### PR TITLE
ci: add `ADD_TO_PROJECT` action

### DIFF
--- a/.github/workflows/ADD_TO_PROJECT.yml
+++ b/.github/workflows/ADD_TO_PROJECT.yml
@@ -1,0 +1,22 @@
+name: ADD_TO_PROJECT
+
+on:
+  issues:
+    types:
+      - opened
+      - transferred
+      - labeled
+  pull_request:
+    types:
+      - opened
+      - labeled
+
+jobs:
+  Exec:
+    name: Add issue to project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@82f0eaddf3c8f781ece8cc1164d06d24d5f28ad0
+        with:
+          project-url: https://github.com/orgs/camunda/projects/23/views/1
+          github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}


### PR DESCRIPTION
Ensures issues land on our [project board](https://github.com/orgs/camunda/projects/23/views/1).