### PR TITLE
fix(ms-teams): add ability get messages without ordering

### DIFF
--- a/connectors/microsoft-teams/src/main/java/io/camunda/connector/model/OrderBy.java
+++ b/connectors/microsoft-teams/src/main/java/io/camunda/connector/model/OrderBy.java
@@ -7,6 +7,7 @@
 package io.camunda.connector.model;
 
 public enum OrderBy {
+  withoutOrdering("withoutOrdering"),
   lastModifiedDateTime("lastModifiedDateTime desc"),
   createdDateTime("createdDateTime desc");
 

--- a/connectors/microsoft-teams/src/main/java/io/camunda/connector/model/request/chat/ListMessagesInChat.java
+++ b/connectors/microsoft-teams/src/main/java/io/camunda/connector/model/request/chat/ListMessagesInChat.java
@@ -21,7 +21,7 @@ import okhttp3.Request;
 public class ListMessagesInChat extends MSTeamsRequestData {
 
   @NotBlank @Secret private String chatId;
-  @NotBlank @Secret private String filter;
+  @Secret private String filter;
   @NotNull private OrderBy orderBy;
 
   @Pattern(regexp = "^([1-9])|([1-4][0-9])|(50)$")
@@ -31,11 +31,11 @@ public class ListMessagesInChat extends MSTeamsRequestData {
   @Override
   public Object invoke(final GraphServiceClient<Request> graphClient) {
     ChatMessageCollectionRequest request = graphClient.chats(chatId).messages().buildRequest();
+    if (orderBy != OrderBy.withoutOrdering) {
+      request.orderBy(orderBy.getValue());
+    }
     if (filter != null) {
       request.filter(filter);
-    }
-    if (orderBy != null) {
-      request.orderBy(orderBy.getValue());
     }
     if (top != null) {
       request.top(Integer.parseInt(top));


### PR DESCRIPTION
## Description

added  `withoutOrdering` filter for method `messages in chat`

closes #

https://github.com/camunda/connectors-bundle/issues/138