### PR TITLE
fix(ms-teams): add chat type value and link to members format docs

### DIFF
--- a/connectors/microsoft-teams/element-templates/microsoft-teams-connector.json
+++ b/connectors/microsoft-teams/element-templates/microsoft-teams-connector.json
@@ -265,6 +265,7 @@
       "description": "The type of a new chat",
       "group": "data",
       "type": "Dropdown",
+      "value": "one_on_one",
       "choices": [
         {
           "name": "One on one",
@@ -304,7 +305,7 @@
     },
     {
       "label": "Members",
-      "description": "Set array members of chat",
+      "description": "Set array members of chat. <a href='https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/microsoft-teams/#members-property'>Learn more about the required format</a>",
       "group": "data",
       "type": "Text",
       "feel": "required",


### PR DESCRIPTION
## Description

Add chat type value and link to `members` format docs

## Related issues
https://github.com/camunda/camunda-platform-docs/issues/1596

closes #

https://github.com/camunda/connectors-bundle/issues/181
