### PR TITLE
feat(ms-teams): expand response for get chat method

### DIFF
--- a/connectors/microsoft-teams/element-templates/microsoft-teams-connector.json
+++ b/connectors/microsoft-teams/element-templates/microsoft-teams-connector.json
@@ -345,6 +345,36 @@
       }
     },
     {
+      "label": "Expand response",
+      "description": "Choose expand type. <a href='https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/microsoft-teams/#expand-response'>Learn more about expanding chat response</a>",
+      "group": "data",
+      "type": "Dropdown",
+      "value": "withoutExpand",
+      "optional": true,
+      "choices": [
+        {
+          "name": "Without expand",
+          "value": "withoutExpand"
+        },
+        {
+          "name": "With the last message preview",
+          "value": "lastMessagePreview"
+        },
+        {
+          "name": "With chat members",
+          "value": "members"
+        }
+      ],
+      "binding": {
+        "type": "zeebe:input",
+        "name": "data.expand"
+      },
+      "condition": {
+        "property": "chatMethod",
+        "equals": "getChat"
+      }
+    },
+    {
       "label": "Content",
       "description": "Enter content",
       "group": "data",

--- a/connectors/microsoft-teams/src/test/java/io/camunda/connector/BaseTest.java
+++ b/connectors/microsoft-teams/src/test/java/io/camunda/connector/BaseTest.java
@@ -140,6 +140,10 @@ public abstract class BaseTest {
     return loadTestCasesFromResourceFile(TestCasesPath.Channel.SEND_MESSAGE_VALIDATION_FAIL);
   }
 
+  protected static Stream<String> getChatValidationFailTestCases() throws IOException {
+    return loadTestCasesFromResourceFile(TestCasesPath.Chat.GET_VALIDATION_FAIL);
+  }
+
   @SuppressWarnings("unchecked")
   protected static Stream<String> loadTestCasesFromResourceFile(final String fileWithTestCasesUri)
       throws IOException {

--- a/connectors/microsoft-teams/src/test/java/io/camunda/connector/TestCasesPath.java
+++ b/connectors/microsoft-teams/src/test/java/io/camunda/connector/TestCasesPath.java
@@ -28,4 +28,9 @@ interface TestCasesPath {
     String SEND_MESSAGE_VALIDATION_FAIL =
         CHANNEL_PATH + "send-message-to-channel-validation-fail-test-cases.json";
   }
+
+  interface Chat {
+    String CHAT_PATH = PATH + "chat/";
+    String GET_VALIDATION_FAIL = CHAT_PATH + "get-chat-validation-fail-test-cases.json";
+  }
 }

--- a/connectors/microsoft-teams/src/test/java/io/camunda/connector/model/request/chat/GetChatTest.java
+++ b/connectors/microsoft-teams/src/test/java/io/camunda/connector/model/request/chat/GetChatTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.model.request.chat;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.microsoft.graph.models.Chat;
+import com.microsoft.graph.requests.ChatRequest;
+import com.microsoft.graph.requests.ChatRequestBuilder;
+import com.microsoft.graph.requests.GraphServiceClient;
+import io.camunda.connector.BaseTest;
+import io.camunda.connector.api.outbound.OutboundConnectorContext;
+import io.camunda.connector.impl.ConnectorInputException;
+import io.camunda.connector.model.MSTeamsRequest;
+import okhttp3.Request;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class GetChatTest extends BaseTest {
+
+  @Mock private GraphServiceClient<Request> graphServiceClient;
+  @Mock private ChatRequestBuilder chatRequestBuilder;
+  @Mock private ChatRequest chatRequest;
+
+  @ParameterizedTest
+  @MethodSource("getChatValidationFailTestCases")
+  public void validate_shouldThrowExceptionWhenAtLeastOneRequiredFieldNotExist(String input) {
+    // Given request without one required field
+    MSTeamsRequest request = gson.fromJson(input, MSTeamsRequest.class);
+    OutboundConnectorContext context = getContextBuilderWithSecrets().variables(input).build();
+    // When context.validate;
+    // Then expect exception that one required field not set
+    assertThat(request.getData()).isInstanceOf(GetChat.class);
+    ConnectorInputException thrown =
+        assertThrows(
+            ConnectorInputException.class,
+            () -> context.validate(request.getData()),
+            "IllegalArgumentException was expected");
+    assertThat(thrown.getMessage()).contains("Found constraints violated while validating input");
+  }
+
+  @Test
+  public void invoke_shouldSetOptionalPropertiesIfTheyExist() {
+    // Given
+    when(graphServiceClient.chats(ActualValue.Chat.CHAT_ID)).thenReturn(chatRequestBuilder);
+    when(chatRequestBuilder.buildRequest()).thenReturn(chatRequest);
+
+    when(chatRequest.get()).thenReturn(new Chat());
+
+    GetChat getChat = new GetChat();
+    getChat.setChatId(ActualValue.Chat.CHAT_ID);
+    getChat.setExpand("members");
+    // When
+    Object invoke = getChat.invoke(graphServiceClient);
+    // Then
+    verify(chatRequest).expand("members");
+    assertThat(invoke).isNotNull();
+  }
+
+  @Test
+  public void invoke_shouldReturnChatWithOutNullFieldsInResponse() {
+    // Given
+    Gson gsonWithNull = new GsonBuilder().serializeNulls().create();
+    String chatStringResponse =
+        "{\"oDataType\":null,\"id\":\"19:e37f90808e7748d7bbbb2029ed17f643@thread.v2\",\"chatType\":\"GROUP\",\"members\":null,\"messages\":null}";
+    Chat response = gsonWithNull.fromJson(chatStringResponse, Chat.class);
+
+    when(graphServiceClient.chats(ActualValue.Chat.CHAT_ID)).thenReturn(chatRequestBuilder);
+    when(chatRequestBuilder.buildRequest()).thenReturn(chatRequest);
+
+    when(chatRequest.get()).thenReturn(response);
+    GetChat getChat = new GetChat();
+    getChat.setChatId(ActualValue.Chat.CHAT_ID);
+    // When
+    Object invoke = getChat.invoke(graphServiceClient);
+    // Then
+    assertThat(invoke).isNotNull();
+    assertThat(gsonWithNull.toJson(invoke))
+        .isEqualTo(
+            "{\"chatType\":\"GROUP\",\"id\":\"19:e37f90808e7748d7bbbb2029ed17f643@thread.v2\"}");
+  }
+}

--- a/connectors/microsoft-teams/src/test/resources/requests/chat/get-chat-validation-fail-test-cases.json
+++ b/connectors/microsoft-teams/src/test/resources/requests/chat/get-chat-validation-fail-test-cases.json
@@ -1,0 +1,16 @@
+[
+  {
+    "description": "chatID is blank",
+    "data": {
+      "method": "getChat",
+      "chatId": "    "
+    }
+  },
+  {
+    "description": "chatID is null",
+    "data": {
+      "method": "getChat",
+      "chatId": null
+    }
+  }
+]


### PR DESCRIPTION
## Description

 expand response for get chat method.

Added ability return response with messages and with members

## Related issues

https://github.com/camunda/camunda-platform-docs/issues/1596

closes #
https://github.com/camunda/connectors-bundle/issues/186
