### PR TITLE
chore(ms-teams): Change the description of "List replies"

### DIFF
--- a/connectors/microsoft-teams/element-templates/microsoft-teams-connector.json
+++ b/connectors/microsoft-teams/element-templates/microsoft-teams-connector.json
@@ -714,7 +714,7 @@
     },
     {
       "label": "With replies",
-      "description": "Return messages with replies",
+      "description": "Return message replies",
       "group": "data",
       "type": "Dropdown",
       "choices": [


### PR DESCRIPTION
## Description

changed description of "List replies"  to  `Return message replies`

closes #

https://github.com/camunda/connectors-bundle/issues/234