### PR TITLE
feat(rest): allow empty password in basic auth

### DIFF
--- a/connectors/connectors-common-library/src/main/java/io/camunda/connector/common/auth/BasicAuthentication.java
+++ b/connectors/connectors-common-library/src/main/java/io/camunda/connector/common/auth/BasicAuthentication.java
@@ -19,16 +19,20 @@ package io.camunda.connector.common.auth;
 import com.google.api.client.http.HttpHeaders;
 import com.google.common.base.Objects;
 import io.camunda.connector.api.annotation.Secret;
+import java.util.function.Function;
 import javax.validation.constraints.NotEmpty;
 
 public class BasicAuthentication extends Authentication {
+  private static final String SPEC_PASSWORD_EMPTY_PATTERN = "SPEC_PASSWORD_EMPTY_PATTERN";
+  private static final Function<String, String> SPEC_PASSWORD =
+      (psw) -> psw.equals(SPEC_PASSWORD_EMPTY_PATTERN) ? "" : psw;
 
   @NotEmpty @Secret private String username;
   @NotEmpty @Secret private String password;
 
   @Override
   public void setHeaders(final HttpHeaders headers) {
-    headers.setBasicAuthentication(username, password);
+    headers.setBasicAuthentication(username, SPEC_PASSWORD.apply(password));
   }
 
   public String getUsername() {


### PR DESCRIPTION
## Description

What should we do?

need to allow empty password for Basic authentication type for REST connector

Why should we do it?

It is needed for EasyPost Connector. EasyPost Connector for authentication uses [API key](https://www.easypost.com/docs/api/curl#authentication) and Basic type authentication. This API key put in username in basic auth and the password must be empty. For now in Rest connector we have annotation :  @NotEmpty @Secret private String password;

Solving : 
I can't just delete annotation `@NotEmpty`, because if I send an empty String from a template in the password field zeebe trown a NullPointerException.
So I decided to add special String Pattern, if I send this string, this string will replace to empty string in code.

## Related issues

https://github.com/camunda/team-connectors/issues/363
https://github.com/camunda/connectors-bundle/pull/385

closes #

https://github.com/camunda/connectors-bundle/issues/384