### PR TITLE
fix(sqs inbound): correlate message body as object if it possible

### DIFF
--- a/connectors/sqs/src/main/java/io/camunda/connector/inbound/MessageMapper.java
+++ b/connectors/sqs/src/main/java/io/camunda/connector/inbound/MessageMapper.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.inbound;
+
+import com.amazonaws.services.sqs.model.Message;
+import com.amazonaws.services.sqs.model.MessageAttributeValue;
+import com.google.gson.JsonSyntaxException;
+import io.camunda.connector.common.suppliers.SqsGsonComponentSupplier;
+import io.camunda.connector.inbound.model.message.SqsInboundMessage;
+import java.util.HashMap;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class MessageMapper {
+  private static final Logger LOGGER = LoggerFactory.getLogger(MessageMapper.class);
+
+  public static SqsInboundMessage toSqsInboundMessage(final Message message) {
+    SqsInboundMessage sqsInboundMessage = new SqsInboundMessage();
+    sqsInboundMessage.setMessageId(message.getMessageId());
+    sqsInboundMessage.setReceiptHandle(message.getReceiptHandle());
+    sqsInboundMessage.setMD5OfMessageAttributes(message.getMD5OfMessageAttributes());
+    sqsInboundMessage.setAttributes(message.getAttributes());
+
+    Map<String, io.camunda.connector.inbound.model.message.MessageAttributeValue>
+        sqsInboundMessageAttributes = new HashMap<>();
+    for (Map.Entry<String, MessageAttributeValue> entry :
+        message.getMessageAttributes().entrySet()) {
+      io.camunda.connector.inbound.model.message.MessageAttributeValue sqsInboundMessageAttribute =
+          toSqsInboundMessageAttribute(entry.getValue());
+
+      sqsInboundMessageAttributes.put(entry.getKey(), sqsInboundMessageAttribute);
+    }
+    sqsInboundMessage.setMessageAttributes(sqsInboundMessageAttributes);
+
+    sqsInboundMessage.setBody(toObjectIfPossible(message.getBody()));
+    sqsInboundMessage.setmD5OfBody(message.getMD5OfBody());
+
+    return sqsInboundMessage;
+  }
+
+  private static Object toObjectIfPossible(final String body) {
+    try {
+      return SqsGsonComponentSupplier.gsonInstance().fromJson(body, Object.class);
+    } catch (JsonSyntaxException e) {
+      LOGGER.debug("Cannot parse value to JSON object -> using the raw value");
+    }
+    return body;
+  }
+
+  private static io.camunda.connector.inbound.model.message.MessageAttributeValue
+      toSqsInboundMessageAttribute(final MessageAttributeValue attributeValue) {
+    io.camunda.connector.inbound.model.message.MessageAttributeValue sqsInboundMessageAttribute =
+        new io.camunda.connector.inbound.model.message.MessageAttributeValue();
+
+    sqsInboundMessageAttribute.setBinaryValue(attributeValue.getBinaryValue());
+    sqsInboundMessageAttribute.setDataType(attributeValue.getDataType());
+    sqsInboundMessageAttribute.setStringValue(attributeValue.getStringValue());
+    sqsInboundMessageAttribute.setBinaryListValues(attributeValue.getBinaryListValues());
+    sqsInboundMessageAttribute.setStringListValues(attributeValue.getStringListValues());
+
+    return sqsInboundMessageAttribute;
+  }
+}

--- a/connectors/sqs/src/main/java/io/camunda/connector/inbound/SqsQueueConsumer.java
+++ b/connectors/sqs/src/main/java/io/camunda/connector/inbound/SqsQueueConsumer.java
@@ -25,7 +25,7 @@ public class SqsQueueConsumer implements Runnable {
   private final AmazonSQS sqsClient;
   private final SqsInboundProperties properties;
   private final InboundConnectorContext context;
-  private AtomicBoolean queueConsumerActive;
+  private final AtomicBoolean queueConsumerActive;
 
   public SqsQueueConsumer(
       AmazonSQS sqsClient, SqsInboundProperties properties, InboundConnectorContext context) {
@@ -44,7 +44,8 @@ public class SqsQueueConsumer implements Runnable {
       receiveMessageResult = sqsClient.receiveMessage(receiveMessageRequest);
       List<Message> messages = receiveMessageResult.getMessages();
       for (Message message : messages) {
-        InboundConnectorResult<?> correlate = context.correlate(message);
+        InboundConnectorResult<?> correlate =
+            context.correlate(MessageMapper.toSqsInboundMessage(message));
         if (correlate.isActivated()) {
           sqsClient.deleteMessage(properties.getQueue().getUrl(), message.getReceiptHandle());
           LOGGER.debug(

--- a/connectors/sqs/src/main/java/io/camunda/connector/inbound/model/message/MessageAttributeValue.java
+++ b/connectors/sqs/src/main/java/io/camunda/connector/inbound/model/message/MessageAttributeValue.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.inbound.model.message;
+
+import java.nio.ByteBuffer;
+import java.util.List;
+import java.util.Objects;
+
+public class MessageAttributeValue {
+  private String stringValue;
+  private ByteBuffer binaryValue;
+  private List<String> stringListValues;
+  private List<ByteBuffer> binaryListValues;
+  private String dataType;
+
+  public String getStringValue() {
+    return stringValue;
+  }
+
+  public void setStringValue(final String stringValue) {
+    this.stringValue = stringValue;
+  }
+
+  public ByteBuffer getBinaryValue() {
+    return binaryValue;
+  }
+
+  public void setBinaryValue(final ByteBuffer binaryValue) {
+    this.binaryValue = binaryValue;
+  }
+
+  public List<String> getStringListValues() {
+    return stringListValues;
+  }
+
+  public void setStringListValues(final List<String> stringListValues) {
+    this.stringListValues = stringListValues;
+  }
+
+  public List<ByteBuffer> getBinaryListValues() {
+    return binaryListValues;
+  }
+
+  public void setBinaryListValues(final List<ByteBuffer> binaryListValues) {
+    this.binaryListValues = binaryListValues;
+  }
+
+  public String getDataType() {
+    return dataType;
+  }
+
+  public void setDataType(final String dataType) {
+    this.dataType = dataType;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final MessageAttributeValue that = (MessageAttributeValue) o;
+    return Objects.equals(stringValue, that.stringValue)
+        && Objects.equals(binaryValue, that.binaryValue)
+        && Objects.equals(stringListValues, that.stringListValues)
+        && Objects.equals(binaryListValues, that.binaryListValues)
+        && Objects.equals(dataType, that.dataType);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(stringValue, binaryValue, stringListValues, binaryListValues, dataType);
+  }
+
+  @Override
+  public String toString() {
+    return "MessageAttributeValue{"
+        + "stringValue='"
+        + stringValue
+        + "'"
+        + ", binaryValue="
+        + binaryValue
+        + ", stringListValues="
+        + stringListValues
+        + ", binaryListValues="
+        + binaryListValues
+        + ", dataType='"
+        + dataType
+        + "'"
+        + "}";
+  }
+}

--- a/connectors/sqs/src/main/java/io/camunda/connector/inbound/model/message/SqsInboundMessage.java
+++ b/connectors/sqs/src/main/java/io/camunda/connector/inbound/model/message/SqsInboundMessage.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.inbound.model.message;
+
+import java.util.Map;
+import java.util.Objects;
+
+public class SqsInboundMessage {
+  private String messageId;
+  private String receiptHandle;
+  private String mD5OfBody;
+  private Object body;
+  private Map<String, String> attributes;
+  private String mD5OfMessageAttributes;
+  private Map<String, MessageAttributeValue> messageAttributes;
+
+  public String getMessageId() {
+    return messageId;
+  }
+
+  public void setMessageId(final String messageId) {
+    this.messageId = messageId;
+  }
+
+  public String getReceiptHandle() {
+    return receiptHandle;
+  }
+
+  public void setReceiptHandle(final String receiptHandle) {
+    this.receiptHandle = receiptHandle;
+  }
+
+  public String getmD5OfBody() {
+    return mD5OfBody;
+  }
+
+  public void setmD5OfBody(final String mD5OfBody) {
+    this.mD5OfBody = mD5OfBody;
+  }
+
+  public Object getBody() {
+    return body;
+  }
+
+  public void setBody(final Object body) {
+    this.body = body;
+  }
+
+  public Map<String, String> getAttributes() {
+    return attributes;
+  }
+
+  public void setAttributes(final Map<String, String> attributes) {
+    this.attributes = attributes;
+  }
+
+  public String getMD5OfMessageAttributes() {
+    return mD5OfMessageAttributes;
+  }
+
+  public void setMD5OfMessageAttributes(final String mD5OfMessageAttributes) {
+    this.mD5OfMessageAttributes = mD5OfMessageAttributes;
+  }
+
+  public Map<String, MessageAttributeValue> getMessageAttributes() {
+    return messageAttributes;
+  }
+
+  public void setMessageAttributes(final Map<String, MessageAttributeValue> messageAttributes) {
+    this.messageAttributes = messageAttributes;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final SqsInboundMessage that = (SqsInboundMessage) o;
+    return Objects.equals(messageId, that.messageId)
+        && Objects.equals(receiptHandle, that.receiptHandle)
+        && Objects.equals(mD5OfBody, that.mD5OfBody)
+        && Objects.equals(body, that.body)
+        && Objects.equals(attributes, that.attributes)
+        && Objects.equals(mD5OfMessageAttributes, that.mD5OfMessageAttributes)
+        && Objects.equals(messageAttributes, that.messageAttributes);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        messageId,
+        receiptHandle,
+        mD5OfBody,
+        body,
+        attributes,
+        mD5OfMessageAttributes,
+        messageAttributes);
+  }
+
+  @Override
+  public String toString() {
+    return "SqsInboundMessage{"
+        + "messageId='"
+        + messageId
+        + "'"
+        + ", receiptHandle='"
+        + receiptHandle
+        + "'"
+        + ", mD5OfBody='"
+        + mD5OfBody
+        + "'"
+        + ", body="
+        + body
+        + ", attributes="
+        + attributes
+        + ", mD5OfMessageAttributes='"
+        + mD5OfMessageAttributes
+        + "'"
+        + ", messageAttributes="
+        + messageAttributes
+        + "}";
+  }
+}

--- a/connectors/sqs/src/test/java/io/camunda/connector/inbound/MessageMapperTest.java
+++ b/connectors/sqs/src/test/java/io/camunda/connector/inbound/MessageMapperTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.inbound;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.amazonaws.services.sqs.model.Message;
+import com.amazonaws.services.sqs.model.MessageAttributeValue;
+import com.google.gson.JsonElement;
+import io.camunda.connector.common.suppliers.SqsGsonComponentSupplier;
+import io.camunda.connector.inbound.model.message.SqsInboundMessage;
+import java.nio.ByteBuffer;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class MessageMapperTest {
+  private final String MESSAGE_ID = "messageID";
+  private final String RECEIPT_HANDLE = "receipt handle";
+  private final String MD5_OF_MESSAGE_ATTRIBUTES = "withMD5OfMessageAttributes";
+  private final String JSON_BODY = "{\"key\":{\"innerKey\":\"value\"}}";
+  private final String STRING_BODY = "just string message";
+  private final String ATTRIBUTE_DATA_TYPE = "data type";
+  private final String ATTRIBUTE_STRING_VALUE = "string value";
+  private final String ATTRIBUTE_KEY = "attributeKey";
+  private final ByteBuffer ATTRIBUTE_BINARY_TYPE = ByteBuffer.wrap("binary value".getBytes());
+
+  private final Map<String, String> ATTRIBUTES = Map.of(ATTRIBUTE_KEY, "attributeValue");
+  private Map<String, MessageAttributeValue> messageAttributes;
+  private Message awsMessage;
+
+  @BeforeEach
+  public void setUp() {
+    messageAttributes = new HashMap<>();
+    MessageAttributeValue attributeValue =
+        new MessageAttributeValue()
+            .withStringValue(ATTRIBUTE_STRING_VALUE)
+            .withBinaryValue(ATTRIBUTE_BINARY_TYPE)
+            .withDataType(ATTRIBUTE_DATA_TYPE)
+            .withBinaryListValues(List.of(ATTRIBUTE_BINARY_TYPE))
+            .withStringListValues(List.of(ATTRIBUTE_STRING_VALUE));
+    messageAttributes.put(ATTRIBUTE_KEY, attributeValue);
+
+    awsMessage =
+        new Message()
+            .withMessageId(MESSAGE_ID)
+            .withReceiptHandle(RECEIPT_HANDLE)
+            .withMD5OfMessageAttributes(MD5_OF_MESSAGE_ATTRIBUTES)
+            .withBody(STRING_BODY)
+            .withMD5OfBody(JSON_BODY)
+            .withAttributes(ATTRIBUTES)
+            .withMessageAttributes(messageAttributes);
+  }
+
+  @Test
+  public void toSqsInboundMessage_shouldMapAllProperties() {
+    // When
+    SqsInboundMessage sqsInboundMessage = MessageMapper.toSqsInboundMessage(awsMessage);
+    // then
+    assertThat(sqsInboundMessage.getMessageId()).isEqualTo(MESSAGE_ID);
+    assertThat(sqsInboundMessage.getReceiptHandle()).isEqualTo(RECEIPT_HANDLE);
+    assertThat(sqsInboundMessage.getMD5OfMessageAttributes()).isEqualTo(MD5_OF_MESSAGE_ATTRIBUTES);
+    assertThat(sqsInboundMessage.getAttributes()).isEqualTo(ATTRIBUTES);
+    assertThat(sqsInboundMessage.getmD5OfBody()).isEqualTo(JSON_BODY);
+    assertThat(sqsInboundMessage.getBody()).isEqualTo(STRING_BODY);
+
+    io.camunda.connector.inbound.model.message.MessageAttributeValue
+        sqsInboundMessageAttributeValue =
+            sqsInboundMessage.getMessageAttributes().get("attributeKey");
+    assertThat(sqsInboundMessageAttributeValue.getStringValue()).isEqualTo(ATTRIBUTE_STRING_VALUE);
+    assertThat(sqsInboundMessageAttributeValue.getDataType()).isEqualTo(ATTRIBUTE_DATA_TYPE);
+    assertThat(sqsInboundMessageAttributeValue.getBinaryValue()).isEqualTo(ATTRIBUTE_BINARY_TYPE);
+    assertThat(sqsInboundMessageAttributeValue.getStringListValues())
+        .isEqualTo(List.of(ATTRIBUTE_STRING_VALUE));
+    assertThat(sqsInboundMessageAttributeValue.getBinaryListValues())
+        .isEqualTo(List.of(ATTRIBUTE_BINARY_TYPE));
+  }
+
+  @Test
+  public void toSqsInboundMessage_shouldMapStringJsonBodyToObject() {
+    // Given
+    awsMessage.setBody(JSON_BODY);
+    // When
+    SqsInboundMessage sqsInboundMessage = MessageMapper.toSqsInboundMessage(awsMessage);
+    // then
+    JsonElement jsonElement =
+        SqsGsonComponentSupplier.gsonInstance().toJsonTree(sqsInboundMessage.getBody());
+    String actualValue =
+        jsonElement.getAsJsonObject().get("key").getAsJsonObject().get("innerKey").getAsString();
+    assertThat(actualValue).isEqualTo("value");
+  }
+
+  @Test
+  public void toSqsInboundMessage_shouldWorkWithEmptyAttributes() {
+    // Given
+    awsMessage.setMessageAttributes(new HashMap<>());
+    awsMessage.setAttributes(new HashMap<>());
+    // When
+    SqsInboundMessage sqsInboundMessage = MessageMapper.toSqsInboundMessage(awsMessage);
+    // then
+    assertThat(sqsInboundMessage.getAttributes()).isEqualTo(new HashMap<>());
+    assertThat(sqsInboundMessage.getMessageAttributes()).isEqualTo(new HashMap<>());
+  }
+}

--- a/connectors/sqs/src/test/java/io/camunda/connector/inbound/SqsExecutableTest.java
+++ b/connectors/sqs/src/test/java/io/camunda/connector/inbound/SqsExecutableTest.java
@@ -98,7 +98,7 @@ class SqsExecutableTest {
     executorService.awaitTermination(1, TimeUnit.SECONDS);
     verify(spyContext).replaceSecrets(properties);
     verify(spyContext).validate(properties);
-    verify(spyContext, atLeast(1)).correlate(message);
+    verify(spyContext, atLeast(1)).correlate(MessageMapper.toSqsInboundMessage(message));
   }
 
   @Test


### PR DESCRIPTION
## Description

Parse received string property to object if is a JSON type.

now we can use activation condition for message body :

<img width="1618" alt="Screenshot 2023-05-23 at 18 16 21" src="https://github.com/camunda/connectors-bundle/assets/108869886/77c4e583-3af9-433b-b173-02c7d6c5e9e2">

## Related issues

closes #

https://github.com/camunda/connectors-bundle/issues/623