### PR TITLE
chore(tool-versions):set java temurin version 17.0.7+7

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,4 +1,4 @@
-java temurin-11.0.15+10
+java temurin-17.0.7+7
 maven 3.8.4
 gcloud 367.0.0
 python 3.11.3


### PR DESCRIPTION
## Description

set java temurin version 17.0.7+7 after set java version 17 and temurin - 17.0.7+7 in SDK

## Related issues
https://github.com/camunda/connector-sdk/pull/477
