### PR TITLE
fix(sqs,twilio): fix docs links in templates

### DIFF
--- a/connectors/sqs/element-templates/aws-sqs-inbound-intermediate-connector.json
+++ b/connectors/sqs/element-templates/aws-sqs-inbound-intermediate-connector.json
@@ -4,7 +4,7 @@
   "id": "io.camunda.connectors.AWSSQS.intermediate.v1",
   "version": 1,
   "description": "Receive message from a queue",
-  "documentationRef": "https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/aws-sqs/",
+  "documentationRef": "https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/aws-sqs-start-event/",
   "appliesTo": [
     "bpmn:IntermediateCatchEvent",
     "bpmn:IntermediateThrowEvent"
@@ -120,7 +120,7 @@
     },
     {
       "label": "Polling wait time",
-      "description": "The duration (in seconds) for which the call waits for a message to arrive in the queue before returning. See <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/aws-sqs/\" target=\"_blank\">documentation</a> for details",
+      "description": "The duration (in seconds) for which the call waits for a message to arrive in the queue before returning. See <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/aws-sqs-start-event/\" target=\"_blank\">documentation</a> for details",
       "group": "messagePollingProperties",
       "type": "String",
       "optional":false,
@@ -140,7 +140,7 @@
     },
     {
       "label": "Attribute names",
-      "description": "Queue attribute names. See <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/aws-sqs/\" target=\"_blank\">documentation</a> for details",
+      "description": "Queue attribute names. See <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/aws-sqs-start-event/\" target=\"_blank\">documentation</a> for details",
       "group": "input",
       "type": "String",
       "optional": true,
@@ -152,7 +152,7 @@
     },
     {
       "label": "Message attribute names",
-      "description": "Message attribute names. See <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/aws-sqs/\" target=\"_blank\">documentation</a> for details",
+      "description": "Message attribute names. See <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/aws-sqs-start-event/\" target=\"_blank\">documentation</a> for details",
       "group": "input",
       "type": "String",
       "optional": true,

--- a/connectors/sqs/element-templates/aws-sqs-start-event-connector.json
+++ b/connectors/sqs/element-templates/aws-sqs-start-event-connector.json
@@ -4,7 +4,7 @@
   "id": "io.camunda.connectors.AWSSQS.StartEvent.v1",
   "version": 1,
   "description": "Receive message from a queue",
-  "documentationRef": "https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/aws-sqs/",
+  "documentationRef": "https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/aws-sqs-start-event/",
   "appliesTo": [
     "bpmn:StartEvent"
   ],
@@ -108,7 +108,7 @@
     },
     {
       "label": "Polling wait time",
-      "description": "The duration (in seconds) for which the call waits for a message to arrive in the queue before returning. See <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/aws-sqs/\" target=\"_blank\">documentation</a> for details",
+      "description": "The duration (in seconds) for which the call waits for a message to arrive in the queue before returning. See <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/aws-sqs-start-event/\" target=\"_blank\">documentation</a> for details",
       "group": "messagePollingProperties",
       "type": "String",
       "optional":false,
@@ -128,7 +128,7 @@
     },
     {
       "label": "Attribute names",
-      "description": "Queue attribute names. See <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/aws-sqs/\" target=\"_blank\">documentation</a> for details",
+      "description": "Queue attribute names. See <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/aws-sqs-start-event/\" target=\"_blank\">documentation</a> for details",
       "group": "input",
       "type": "String",
       "optional": true,
@@ -140,7 +140,7 @@
     },
     {
       "label": "Message attribute names",
-      "description": "Message attribute names. See <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/aws-sqs/\" target=\"_blank\">documentation</a> for details",
+      "description": "Message attribute names. See <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/aws-sqs-start-event/\" target=\"_blank\">documentation</a> for details",
       "group": "input",
       "type": "String",
       "optional": true,

--- a/connectors/twilio/element-templates/twilio-webhook-connector.json
+++ b/connectors/twilio/element-templates/twilio-webhook-connector.json
@@ -4,7 +4,7 @@
   "id": "io.camunda.connectors.TwilioWebhook.v1",
   "version": 1,
   "description": "Receive incoming message with Twilio service",
-  "documentationRef": "https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/twilio/",
+  "documentationRef": "https://docs.camunda.io/docs/components/connectors/protocol/twilio-webhook/",
   "category": {
     "id": "connectors",
     "name": "Connectors"
@@ -36,6 +36,19 @@
       "binding": {
         "type": "zeebe:property",
         "name": "inbound.type"
+      }
+    },
+    {
+      "label": "Webhook ID",
+      "type": "String",
+      "group": "endpoint",
+      "binding": {
+        "type": "zeebe:property",
+        "name": "inbound.context"
+      },
+      "description": "The webhook ID is a part of the URL",
+      "constraints": {
+        "notEmpty": true
       }
     },
     {
@@ -72,7 +85,7 @@
         "type": "zeebe:property",
         "name": "inbound.activationCondition"
       },
-      "description": "Condition under which the connector triggers. Leave empty to catch all events. <a href='https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/http-webhook/#make-your-http-webhook-connector-for-receiving-messages-executable' target='_blank'>See documentation</a>"
+      "description": "Condition under which the connector triggers. Leave empty to catch all events. <a href='https://docs.camunda.io/docs/components/connectors/protocol/twilio-webhook/#make-your-twilio-webhook-connector-for-receiving-messages-executable' target='_blank'>See documentation</a>"
     },
     {
       "label": "Variables",
@@ -84,7 +97,7 @@
         "type": "zeebe:property",
         "name": "inbound.variableMapping"
       },
-      "description": "Map variables from the webhook payload (request) to start the process with. <a href='https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/http-webhook/#make-your-http-webhook-connector-for-receiving-messages-executable' target='_blank'>See documentation</a>"
+      "description": "Map variables from the webhook payload (request) to start the process with. <a href='https://docs.camunda.io/docs/components/connectors/protocol/twilio-webhook/#make-your-twilio-webhook-connector-for-receiving-messages-executable' target='_blank'>See documentation</a>"
     }
   ],
   "icon": {


### PR DESCRIPTION
## Description

Corrected documentation links in SQS start event, SQS intermediate and Twilio webhook connector templates 


