### PR TITLE
chore(sqs inbound): fix doc links

### DIFF
--- a/connectors/sqs/element-templates/aws-sqs-inbound-intermediate-connector.json
+++ b/connectors/sqs/element-templates/aws-sqs-inbound-intermediate-connector.json
@@ -4,7 +4,7 @@
   "id": "io.camunda.connectors.AWSSQS.intermediate.v1",
   "version": 1,
   "description": "Receive message from a queue",
-  "documentationRef": "https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/aws-sqs-start-event/",
+  "documentationRef": "https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/aws-sqs-inbound/",
   "appliesTo": [
     "bpmn:IntermediateCatchEvent",
     "bpmn:IntermediateThrowEvent"
@@ -120,7 +120,7 @@
     },
     {
       "label": "Polling wait time",
-      "description": "The duration (in seconds) for which the call waits for a message to arrive in the queue before returning. See <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/aws-sqs-start-event/\" target=\"_blank\">documentation</a> for details",
+      "description": "The duration (in seconds) for which the call waits for a message to arrive in the queue before returning. See <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/aws-sqs-inbound/\" target=\"_blank\">documentation</a> for details",
       "group": "messagePollingProperties",
       "type": "String",
       "optional":false,
@@ -140,7 +140,7 @@
     },
     {
       "label": "Attribute names",
-      "description": "Queue attribute names. See <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/aws-sqs-start-event/\" target=\"_blank\">documentation</a> for details",
+      "description": "Queue attribute names. See <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/aws-sqs-inbound/\" target=\"_blank\">documentation</a> for details",
       "group": "input",
       "type": "String",
       "optional": true,
@@ -152,7 +152,7 @@
     },
     {
       "label": "Message attribute names",
-      "description": "Message attribute names. See <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/aws-sqs-start-event/\" target=\"_blank\">documentation</a> for details",
+      "description": "Message attribute names. See <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/aws-sqs-inbound/\" target=\"_blank\">documentation</a> for details",
       "group": "input",
       "type": "String",
       "optional": true,

--- a/connectors/sqs/element-templates/aws-sqs-start-event-connector.json
+++ b/connectors/sqs/element-templates/aws-sqs-start-event-connector.json
@@ -4,7 +4,7 @@
   "id": "io.camunda.connectors.AWSSQS.StartEvent.v1",
   "version": 1,
   "description": "Receive message from a queue",
-  "documentationRef": "https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/aws-sqs-start-event/",
+  "documentationRef": "https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/aws-sqs-inbound/",
   "appliesTo": [
     "bpmn:StartEvent"
   ],
@@ -108,7 +108,7 @@
     },
     {
       "label": "Polling wait time",
-      "description": "The duration (in seconds) for which the call waits for a message to arrive in the queue before returning. See <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/aws-sqs-start-event/\" target=\"_blank\">documentation</a> for details",
+      "description": "The duration (in seconds) for which the call waits for a message to arrive in the queue before returning. See <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/aws-sqs-inbound/\" target=\"_blank\">documentation</a> for details",
       "group": "messagePollingProperties",
       "type": "String",
       "optional":false,
@@ -128,7 +128,7 @@
     },
     {
       "label": "Attribute names",
-      "description": "Queue attribute names. See <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/aws-sqs-start-event/\" target=\"_blank\">documentation</a> for details",
+      "description": "Queue attribute names. See <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/aws-sqs-inbound/\" target=\"_blank\">documentation</a> for details",
       "group": "input",
       "type": "String",
       "optional": true,
@@ -140,7 +140,7 @@
     },
     {
       "label": "Message attribute names",
-      "description": "Message attribute names. See <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/aws-sqs-start-event/\" target=\"_blank\">documentation</a> for details",
+      "description": "Message attribute names. See <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/aws-sqs-inbound/\" target=\"_blank\">documentation</a> for details",
       "group": "input",
       "type": "String",
       "optional": true,


### PR DESCRIPTION
## Description

fix doc links for sqs inbound connector (documentation for start event and for intermediate connectors in one file /docs/components/connectors/out-of-the-box-connectors/aws-sqs-inbound/)

