### PR TITLE
fix(webhook): allow multi hmac scopes

### DIFF
--- a/connectors/webhook/src/main/java/io/camunda/connector/inbound/utils/HttpWebhookUtil.java
+++ b/connectors/webhook/src/main/java/io/camunda/connector/inbound/utils/HttpWebhookUtil.java
@@ -75,6 +75,11 @@ public class HttpWebhookUtil {
             return (payload.requestURL() + "?" + extractSignatureDataFromParams(payload.params()))
                 .getBytes();
           }
+        case 3:
+          // case for method 'any' and 'post for hmac scopes 'url' and 'body' or 'parameters'
+          if (hmacScopeHashSet.containsAll(List.of(HMACScope.URL, HMACScope.BODY))) {
+            return (payload.requestURL() + extractSignatureDataFromBody(payload)).getBytes();
+          }
       }
     }
     throw new UnsupportedOperationException(

--- a/connectors/webhook/src/test/java/io/camunda/connector/inbound/signature/HMACTwilioSignatureTest.java
+++ b/connectors/webhook/src/test/java/io/camunda/connector/inbound/signature/HMACTwilioSignatureTest.java
@@ -88,6 +88,20 @@ public class HMACTwilioSignatureTest {
     assertThat(webhookProcessingResult).isNotNull();
   }
 
+  @ParameterizedTest
+  @MethodSource("successCases")
+  public void hmacSignatureVerificationParametrizedTest_shouldPassHMACValidationWithMultiScopes(
+      final WebhookProcessingPayload webhookProcessingPayload) throws Exception {
+    // Given
+    mapOfProperties.put("inbound.hmacScopes", "=[\"url\",\"body\",\"parameters\"]");
+    httpWebhookExecutable.activate(inboundConnectorContext);
+    // When
+    WebhookProcessingResult webhookProcessingResult =
+        httpWebhookExecutable.triggerWebhook(webhookProcessingPayload);
+    // Then assert that result not null, and validation pass done, without exceptions
+    assertThat(webhookProcessingResult).isNotNull();
+  }
+
   private static Stream<WebhookProcessingPayloadTest> successCases() throws IOException {
     return loadTestCasesFromResourceFile(SUCCESS_CASES_RESOURCE_PATH);
   }


### PR DESCRIPTION
## Description

Added ability to set multi hmac scopes, for example, when we set array of ` url, body , parameters` if this GET method we use `url` and `parameters` for calculate signature, another for calculating we use `url` and `body`

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #

