### PR TITLE
fix(aws eventbridge): standardize template type

### DIFF
--- a/connectors/aws/aws-eventbridge/element-templates/aws-eventbridge-connector.json
+++ b/connectors/aws/aws-eventbridge/element-templates/aws-eventbridge-connector.json
@@ -44,7 +44,7 @@
   "properties": [
     {
       "type": "Hidden",
-      "value": "io.camunda:aws:eventbridge:1",
+      "value": "io.camunda:aws-eventbridge:1",
       "binding": {
         "type": "zeebe:taskDefinition:type"
       }

--- a/connectors/aws/aws-eventbridge/src/main/java/io/camunda/connector/aws/eventbridge/EventBridgeFunction.java
+++ b/connectors/aws/aws-eventbridge/src/main/java/io/camunda/connector/aws/eventbridge/EventBridgeFunction.java
@@ -21,7 +21,7 @@ import io.camunda.connector.aws.ObjectMapperSupplier;
 @OutboundConnector(
     name = "AWSEventBridge",
     inputVariables = {"authentication", "configuration", "input"},
-    type = "io.camunda:aws:eventbridge:1")
+    type = "io.camunda:aws-eventbridge:1")
 public class EventBridgeFunction implements OutboundConnectorFunction {
 
   private final AwsEventBridgeClientSupplier awsEventBridgeClientSupplier;


### PR DESCRIPTION
## Description

standardize template type

<img width="430" alt="Screenshot 2023-06-27 at 16 14 58" src="https://github.com/camunda/connectors-bundle/assets/108869886/9384b731-2843-4add-8305-1f9977074b9f">


also added this fix to modeler PR : https://github.com/camunda/web-modeler/pull/5166
