### PR TITLE
feat(aws): add inbound eventbridge connector template

### DIFF
--- a/connectors/aws/aws-eventbridge/element-templates/aws-eventbridge-connector-intermediate.json
+++ b/connectors/aws/aws-eventbridge/element-templates/aws-eventbridge-connector-intermediate.json
@@ -1,0 +1,343 @@
+{
+  "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+  "name": "Amazon EventBridge Connector",
+  "id": "io.camunda.connectors.AWSEventBridge.intermediate.v1",
+  "version": 1,
+  "description": "Receive events from AWS EventBridge",
+  "documentationRef": "https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/aws-eventbridge/",
+  "category": {
+    "id": "connectors",
+    "name": "Connectors"
+  },
+  "appliesTo": [
+    "bpmn:IntermediateCatchEvent",
+    "bpmn:IntermediateThrowEvent"
+  ],
+  "elementType": {
+    "value": "bpmn:IntermediateCatchEvent",
+    "eventDefinition": "bpmn:MessageEventDefinition"
+  },
+  "groups": [
+    {
+      "id": "endpoint",
+      "label": "API destination"
+    },
+    {
+      "id": "authentication",
+      "label": "Authentication"
+    },
+    {
+      "id": "authorization",
+      "label": "Authorization"
+    },
+    {
+      "id": "activation",
+      "label": "Activation"
+    },
+    {
+      "id": "variable-mapping",
+      "label": "Variable mapping"
+    }
+  ],
+  "properties": [
+    {
+      "type": "Hidden",
+      "value": "io.camunda:webhook:1",
+      "binding": {
+        "type": "zeebe:property",
+        "name": "inbound.type"
+      }
+    },
+    {
+      "type": "Hidden",
+      "generatedValue": {
+        "type": "uuid"
+      },
+      "binding": {
+        "type": "bpmn:Message#property",
+        "name": "name"
+      }
+    },
+    {
+      "type": "Hidden",
+      "value": "aws:eventbridge",
+      "binding": {
+        "type": "zeebe:property",
+        "name": "inbound.subtype"
+      }
+    },
+    {
+      "id": "webhookMethod",
+      "label": "Webhook method",
+      "group": "endpoint",
+      "description": "Select HTTP method",
+      "value": "any",
+      "type": "Dropdown",
+      "choices": [
+        {
+          "name": "Any",
+          "value": "any"
+        },
+        {
+          "name": "Get",
+          "value": "get"
+        },
+        {
+          "name": "Post",
+          "value": "post"
+        },
+        {
+          "name": "Put",
+          "value": "put"
+        },
+        {
+          "name": "Delete",
+          "value": "delete"
+        }
+      ],
+      "binding": {
+        "type": "zeebe:property",
+        "name": "inbound.method"
+      }
+    },
+    {
+      "label": "Webhook ID",
+      "type": "String",
+      "group": "endpoint",
+      "binding": {
+        "type": "zeebe:property",
+        "name": "inbound.context"
+      },
+      "description": "The webhook ID is a part of the URL",
+      "constraints": {
+        "notEmpty": true
+      }
+    },
+    {
+      "label": "HMAC authentication",
+      "value": "disabled",
+      "type": "Hidden",
+      "binding": {
+        "type": "zeebe:property",
+        "name": "inbound.shouldValidateHmac"
+      }
+    },
+    {
+      "id": "authorizationType",
+      "label": "Authorization type",
+      "group": "authorization",
+      "description": "Choose the authorization type",
+      "value": "NONE",
+      "type": "Dropdown",
+      "choices": [
+        {
+          "name": "None",
+          "value": "NONE"
+        },
+        {
+          "name": "JWT",
+          "value": "JWT"
+        },
+        {
+          "name": "Basic",
+          "value": "BASIC"
+        },
+        {
+          "name": "API key",
+          "value": "APIKEY"
+        }
+      ],
+      "binding": {
+        "type": "zeebe:property",
+        "name": "inbound.auth.type"
+      }
+    },
+    {
+      "label": "JWK URL",
+      "description": "Well-known URL of JWKs",
+      "type": "String",
+      "group": "authorization",
+      "feel": "optional",
+      "optional": true,
+      "binding": {
+        "type": "zeebe:property",
+        "name": "inbound.auth.jwt.jwkUrl"
+      },
+      "condition": {
+        "property": "authorizationType",
+        "equals": "JWT"
+      }
+    },
+    {
+      "label": "JWT role property expression",
+      "description": "Expression to extract the roles from the JWT token",
+      "type": "String",
+      "group": "authorization",
+      "feel": "required",
+      "optional": true,
+      "binding": {
+        "type": "zeebe:property",
+        "name": "inbound.auth.jwt.permissionsExpression"
+      },
+      "condition": {
+        "property": "authorizationType",
+        "equals": "JWT"
+      }
+    },
+    {
+      "label": "Required roles",
+      "description": "List of roles to test JWT roles against",
+      "type": "String",
+      "group": "authorization",
+      "feel": "required",
+      "optional": true,
+      "binding": {
+        "type": "zeebe:property",
+        "name": "inbound.auth.jwt.requiredPermissions"
+      },
+      "condition": {
+        "property": "authorizationType",
+        "equals": "JWT"
+      }
+    },
+    {
+      "label": "Username",
+      "description": "Username for basic authentication",
+      "type": "String",
+      "group": "authorization",
+      "feel": "optional",
+      "binding": {
+        "type": "zeebe:property",
+        "name": "inbound.auth.username"
+      },
+      "condition": {
+        "property": "authorizationType",
+        "equals": "BASIC"
+      },
+      "constraints": {
+        "notEmpty": true
+      }
+    },
+    {
+      "label": "Password",
+      "description": "Password for basic authentication",
+      "type": "String",
+      "group": "authorization",
+      "feel": "optional",
+      "binding": {
+        "type": "zeebe:property",
+        "name": "inbound.auth.password"
+      },
+      "condition": {
+        "property": "authorizationType",
+        "equals": "BASIC"
+      },
+      "constraints": {
+        "notEmpty": true
+      }
+    },
+    {
+      "label": "API key",
+      "description": "Expected API key",
+      "type": "String",
+      "group": "authorization",
+      "feel": "optional",
+      "binding": {
+        "type": "zeebe:property",
+        "name": "inbound.auth.apiKey"
+      },
+      "condition": {
+        "property": "authorizationType",
+        "equals": "APIKEY"
+      },
+      "constraints": {
+        "notEmpty": true
+      }
+    },
+    {
+      "label": "API key locator",
+      "description": "A FEEL expression that extracts API key from the request",
+      "type": "String",
+      "group": "authorization",
+      "feel": "required",
+      "binding": {
+        "type": "zeebe:property",
+        "name": "inbound.auth.apiKeyLocator"
+      },
+      "condition": {
+        "property": "authorizationType",
+        "equals": "APIKEY"
+      },
+      "constraints": {
+        "notEmpty": true
+      },
+      "value": "=request.headers.apiKey"
+    },
+    {
+      "label": "Correlation key (process)",
+      "type": "String",
+      "group": "activation",
+      "feel": "required",
+      "description": "Sets up the correlation key from process variables",
+      "binding": {
+        "type": "bpmn:Message#zeebe:subscription#property",
+        "name": "correlationKey"
+      },
+      "constraints": {
+        "notEmpty": true
+      }
+    },
+    {
+      "label": "Correlation key (payload)",
+      "type": "String",
+      "group": "activation",
+      "feel": "required",
+      "binding": {
+        "type": "zeebe:property",
+        "name": "correlationKeyExpression"
+      },
+      "description": "Extracts the correlation key from the incoming message payload",
+      "constraints": {
+        "notEmpty": true
+      }
+    },
+    {
+      "label": "Condition",
+      "type": "String",
+      "group": "activation",
+      "feel": "required",
+      "optional": true,
+      "binding": {
+        "type": "zeebe:property",
+        "name": "activationCondition"
+      },
+      "description": "Condition under which the connector triggers. Leave empty to catch all events. <a href='https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/http-webhook/#make-your-http-webhook-connector-for-receiving-messages-executable' target='_blank'>See documentation</a>"
+    },
+    {
+      "label": "Result variable",
+      "type": "String",
+      "group": "variable-mapping",
+      "optional": true,
+      "binding": {
+        "type": "zeebe:property",
+        "name": "resultVariable"
+      },
+      "description": "Name of variable to store the result of the connector in"
+    },
+    {
+      "label": "Result expression",
+      "type": "String",
+      "group": "variable-mapping",
+      "feel": "required",
+      "optional": true,
+      "binding": {
+        "type": "zeebe:property",
+        "name": "resultExpression"
+      },
+      "description": "Expression to map the inbound payload to process variables"
+    }
+  ],
+  "icon": {
+    "contents": "data:image/svg+xml;utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='18' height='18' viewBox='0 0 256 256'%3E%3Cdefs%3E%3ClinearGradient id='logosAwsEventbridge0' x1='0%25' x2='100%25' y1='100%25' y2='0%25'%3E%3Cstop offset='0%25' stop-color='%23B0084D'/%3E%3Cstop offset='100%25' stop-color='%23FF4F8B'/%3E%3C/linearGradient%3E%3C/defs%3E%3Cpath fill='url(%23logosAwsEventbridge0)' d='M0 0h256v256H0z'/%3E%3Cpath fill='%23FFF' d='M171.702 211.2c-6.858 0-12.44-5.61-12.44-12.509s5.582-12.509 12.44-12.509c6.857 0 12.438 5.61 12.438 12.51c0 6.898-5.581 12.508-12.438 12.508Zm-27.278-54.4h-33.071L94.815 128l16.538-28.8h33.071L160.96 128l-16.535 28.8ZM88.387 69.818c-6.857 0-12.438-5.61-12.438-12.51c0-6.898 5.581-12.508 12.438-12.508c6.861 0 12.443 5.61 12.443 12.509s-5.582 12.509-12.443 12.509Zm83.315 109.964c-2.362 0-4.614.458-6.699 1.261l-13.514-22.931l-.713.426L167.39 129.6a3.226 3.226 0 0 0 0-3.2l-18.374-32a3.177 3.177 0 0 0-2.755-1.6h-33.435l.13-.077l-12.39-21.03c4.047-3.469 6.628-8.627 6.628-14.384c0-10.426-8.436-18.909-18.807-18.909c-10.367 0-18.803 8.483-18.803 18.909c0 10.425 8.436 18.909 18.803 18.909c2.365 0 4.618-.458 6.702-1.261l11.567 19.625L88.384 126.4a3.226 3.226 0 0 0 0 3.2l18.377 32c.57.992 1.62 1.6 2.756 1.6h36.744c.264 0 .521-.042.77-.102l12.496 21.21c-4.051 3.468-6.629 8.626-6.629 14.383c0 10.426 8.433 18.909 18.804 18.909c10.37 0 18.803-8.483 18.803-18.909c0-10.425-8.433-18.909-18.803-18.909Zm18.968-77.05c-6.857 0-12.436-5.609-12.436-12.508c0-6.9 5.579-12.509 12.436-12.509c6.858 0 12.44 5.61 12.44 12.509c0 6.9-5.582 12.509-12.44 12.509Zm23.303 23.668l-12.08-21.04c4.592-3.453 7.58-8.944 7.58-15.136c0-10.426-8.432-18.909-18.803-18.909c-2.638 0-5.152.554-7.433 1.549l-9.849-17.155a3.18 3.18 0 0 0-2.756-1.6h-39.448v6.4h37.612l9.11 15.872c-3.703 3.456-6.036 8.374-6.036 13.843c0 10.426 8.433 18.909 18.8 18.909c1.932 0 3.8-.298 5.556-.845L207.545 128l-15.892 27.674l5.512 3.2l16.808-29.274a3.21 3.21 0 0 0 0-3.2Zm-146.04 50.39c-6.86 0-12.442-5.612-12.442-12.508c0-6.9 5.581-12.51 12.442-12.51c6.857 0 12.439 5.61 12.439 12.51c0 6.896-5.582 12.508-12.44 12.508Zm10.393 3.236c5.062-3.392 8.41-9.181 8.41-15.744c0-10.426-8.436-18.91-18.803-18.91c-3.004 0-5.833.73-8.353 1.994L48.458 128l18.428-32.093l-5.515-3.2L42.027 126.4a3.21 3.21 0 0 0 0 3.2l12.388 21.568c-3.268 3.405-5.289 8.022-5.289 13.114c0 10.425 8.436 18.908 18.807 18.908c1.562 0 3.074-.214 4.528-.579l10.15 17.68c.57.989 1.62 1.6 2.757 1.6h39.451v-6.4H87.204l-8.878-15.465Z'/%3E%3C/svg%3E%0A"
+  }
+}

--- a/connectors/aws/aws-eventbridge/element-templates/aws-eventbridge-connector-start-event.json
+++ b/connectors/aws/aws-eventbridge/element-templates/aws-eventbridge-connector-start-event.json
@@ -1,0 +1,303 @@
+{
+  "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+  "name": "Amazon EventBridge Connector",
+  "id": "io.camunda.connectors.AWSEventBridge.startEvent.v1",
+  "version": 1,
+  "description": "Receive events from AWS EventBridge",
+  "documentationRef": "https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/aws-eventbridge/",
+  "category": {
+    "id": "connectors",
+    "name": "Connectors"
+  },
+  "appliesTo": [
+    "bpmn:StartEvent"
+  ],
+  "elementType": {
+    "value": "bpmn:StartEvent"
+  },
+  "groups": [
+    {
+      "id": "endpoint",
+      "label": "API destination"
+    },
+    {
+      "id": "authentication",
+      "label": "Authentication"
+    },
+    {
+      "id": "authorization",
+      "label": "Authorization"
+    },
+    {
+      "id": "activation",
+      "label": "Activation"
+    },
+    {
+      "id": "variable-mapping",
+      "label": "Variable mapping"
+    }
+  ],
+  "properties": [
+    {
+      "type": "Hidden",
+      "value": "io.camunda:webhook:1",
+      "binding": {
+        "type": "zeebe:property",
+        "name": "inbound.type"
+      }
+    },
+    {
+      "type": "Hidden",
+      "value": "aws:eventbridge",
+      "binding": {
+        "type": "zeebe:property",
+        "name": "inbound.subtype"
+      }
+    },
+    {
+      "id": "webhookMethod",
+      "label": "Webhook method",
+      "group": "endpoint",
+      "description": "Select HTTP method",
+      "value": "any",
+      "type": "Dropdown",
+      "choices": [
+        {
+          "name": "Any",
+          "value": "any"
+        },
+        {
+          "name": "Get",
+          "value": "get"
+        },
+        {
+          "name": "Post",
+          "value": "post"
+        },
+        {
+          "name": "Put",
+          "value": "put"
+        },
+        {
+          "name": "Delete",
+          "value": "delete"
+        }
+      ],
+      "binding": {
+        "type": "zeebe:property",
+        "name": "inbound.method"
+      }
+    },
+    {
+      "label": "Webhook ID",
+      "type": "String",
+      "group": "endpoint",
+      "binding": {
+        "type": "zeebe:property",
+        "name": "inbound.context"
+      },
+      "description": "The webhook ID is a part of the URL",
+      "constraints": {
+        "notEmpty": true
+      }
+    },
+    {
+      "label": "HMAC authentication",
+      "value": "disabled",
+      "type": "Hidden",
+      "binding": {
+        "type": "zeebe:property",
+        "name": "inbound.shouldValidateHmac"
+      }
+    },
+    {
+      "id": "authorizationType",
+      "label": "Authorization type",
+      "group": "authorization",
+      "description": "Choose the authorization type",
+      "value": "NONE",
+      "type": "Dropdown",
+      "choices": [
+        {
+          "name": "None",
+          "value": "NONE"
+        },
+        {
+          "name": "JWT",
+          "value": "JWT"
+        },
+        {
+          "name": "Basic",
+          "value": "BASIC"
+        },
+        {
+          "name": "API key",
+          "value": "APIKEY"
+        }
+      ],
+      "binding": {
+        "type": "zeebe:property",
+        "name": "inbound.auth.type"
+      }
+    },
+    {
+      "label": "JWK URL",
+      "description": "Well-known URL of JWKs",
+      "type": "String",
+      "group": "authorization",
+      "feel": "optional",
+      "optional": true,
+      "binding": {
+        "type": "zeebe:property",
+        "name": "inbound.auth.jwt.jwkUrl"
+      },
+      "condition": {
+        "property": "authorizationType",
+        "equals": "JWT"
+      }
+    },
+    {
+      "label": "JWT role property expression",
+      "description": "Expression to extract the roles from the JWT token",
+      "type": "String",
+      "group": "authorization",
+      "feel": "required",
+      "optional": true,
+      "binding": {
+        "type": "zeebe:property",
+        "name": "inbound.auth.jwt.permissionsExpression"
+      },
+      "condition": {
+        "property": "authorizationType",
+        "equals": "JWT"
+      }
+    },
+    {
+      "label": "Required roles",
+      "description": "List of roles to test JWT roles against",
+      "type": "String",
+      "group": "authorization",
+      "feel": "required",
+      "optional": true,
+      "binding": {
+        "type": "zeebe:property",
+        "name": "inbound.auth.jwt.requiredPermissions"
+      },
+      "condition": {
+        "property": "authorizationType",
+        "equals": "JWT"
+      }
+    },
+    {
+      "label": "Username",
+      "description": "Username for basic authentication",
+      "type": "String",
+      "group": "authorization",
+      "feel": "optional",
+      "binding": {
+        "type": "zeebe:property",
+        "name": "inbound.auth.username"
+      },
+      "condition": {
+        "property": "authorizationType",
+        "equals": "BASIC"
+      },
+      "constraints": {
+        "notEmpty": true
+      }
+    },
+    {
+      "label": "Password",
+      "description": "Password for basic authentication",
+      "type": "String",
+      "group": "authorization",
+      "feel": "optional",
+      "binding": {
+        "type": "zeebe:property",
+        "name": "inbound.auth.password"
+      },
+      "condition": {
+        "property": "authorizationType",
+        "equals": "BASIC"
+      },
+      "constraints": {
+        "notEmpty": true
+      }
+    },
+    {
+      "label": "API key",
+      "description": "Expected API key",
+      "type": "String",
+      "group": "authorization",
+      "feel": "optional",
+      "binding": {
+        "type": "zeebe:property",
+        "name": "inbound.auth.apiKey"
+      },
+      "condition": {
+        "property": "authorizationType",
+        "equals": "APIKEY"
+      },
+      "constraints": {
+        "notEmpty": true
+      }
+    },
+    {
+      "label": "API key locator",
+      "description": "A FEEL expression that extracts API key from the request",
+      "type": "String",
+      "group": "authorization",
+      "feel": "required",
+      "binding": {
+        "type": "zeebe:property",
+        "name": "inbound.auth.apiKeyLocator"
+      },
+      "condition": {
+        "property": "authorizationType",
+        "equals": "APIKEY"
+      },
+      "constraints": {
+        "notEmpty": true
+      },
+      "value": "=request.headers.apiKey"
+    },
+    {
+      "label": "Condition",
+      "type": "String",
+      "group": "activation",
+      "feel": "required",
+      "optional": true,
+      "binding": {
+        "type": "zeebe:property",
+        "name": "activationCondition"
+      },
+      "description": "Condition under which the connector triggers. Leave empty to catch all events. <a href='https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/http-webhook/#make-your-http-webhook-connector-for-receiving-messages-executable' target='_blank'>See documentation</a>"
+    },
+    {
+      "label": "Result variable",
+      "type": "String",
+      "group": "variable-mapping",
+      "optional": true,
+      "binding": {
+        "type": "zeebe:property",
+        "name": "resultVariable"
+      },
+      "description": "Name of variable to store the result of the connector in"
+    },
+    {
+      "label": "Result expression",
+      "type": "String",
+      "group": "variable-mapping",
+      "feel": "required",
+      "optional": true,
+      "binding": {
+        "type": "zeebe:property",
+        "name": "resultExpression"
+      },
+      "description": "Expression to map the inbound payload to process variables"
+    }
+  ],
+  "icon": {
+    "contents": "data:image/svg+xml;utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='18' height='18' viewBox='0 0 256 256'%3E%3Cdefs%3E%3ClinearGradient id='logosAwsEventbridge0' x1='0%25' x2='100%25' y1='100%25' y2='0%25'%3E%3Cstop offset='0%25' stop-color='%23B0084D'/%3E%3Cstop offset='100%25' stop-color='%23FF4F8B'/%3E%3C/linearGradient%3E%3C/defs%3E%3Cpath fill='url(%23logosAwsEventbridge0)' d='M0 0h256v256H0z'/%3E%3Cpath fill='%23FFF' d='M171.702 211.2c-6.858 0-12.44-5.61-12.44-12.509s5.582-12.509 12.44-12.509c6.857 0 12.438 5.61 12.438 12.51c0 6.898-5.581 12.508-12.438 12.508Zm-27.278-54.4h-33.071L94.815 128l16.538-28.8h33.071L160.96 128l-16.535 28.8ZM88.387 69.818c-6.857 0-12.438-5.61-12.438-12.51c0-6.898 5.581-12.508 12.438-12.508c6.861 0 12.443 5.61 12.443 12.509s-5.582 12.509-12.443 12.509Zm83.315 109.964c-2.362 0-4.614.458-6.699 1.261l-13.514-22.931l-.713.426L167.39 129.6a3.226 3.226 0 0 0 0-3.2l-18.374-32a3.177 3.177 0 0 0-2.755-1.6h-33.435l.13-.077l-12.39-21.03c4.047-3.469 6.628-8.627 6.628-14.384c0-10.426-8.436-18.909-18.807-18.909c-10.367 0-18.803 8.483-18.803 18.909c0 10.425 8.436 18.909 18.803 18.909c2.365 0 4.618-.458 6.702-1.261l11.567 19.625L88.384 126.4a3.226 3.226 0 0 0 0 3.2l18.377 32c.57.992 1.62 1.6 2.756 1.6h36.744c.264 0 .521-.042.77-.102l12.496 21.21c-4.051 3.468-6.629 8.626-6.629 14.383c0 10.426 8.433 18.909 18.804 18.909c10.37 0 18.803-8.483 18.803-18.909c0-10.425-8.433-18.909-18.803-18.909Zm18.968-77.05c-6.857 0-12.436-5.609-12.436-12.508c0-6.9 5.579-12.509 12.436-12.509c6.858 0 12.44 5.61 12.44 12.509c0 6.9-5.582 12.509-12.44 12.509Zm23.303 23.668l-12.08-21.04c4.592-3.453 7.58-8.944 7.58-15.136c0-10.426-8.432-18.909-18.803-18.909c-2.638 0-5.152.554-7.433 1.549l-9.849-17.155a3.18 3.18 0 0 0-2.756-1.6h-39.448v6.4h37.612l9.11 15.872c-3.703 3.456-6.036 8.374-6.036 13.843c0 10.426 8.433 18.909 18.8 18.909c1.932 0 3.8-.298 5.556-.845L207.545 128l-15.892 27.674l5.512 3.2l16.808-29.274a3.21 3.21 0 0 0 0-3.2Zm-146.04 50.39c-6.86 0-12.442-5.612-12.442-12.508c0-6.9 5.581-12.51 12.442-12.51c6.857 0 12.439 5.61 12.439 12.51c0 6.896-5.582 12.508-12.44 12.508Zm10.393 3.236c5.062-3.392 8.41-9.181 8.41-15.744c0-10.426-8.436-18.91-18.803-18.91c-3.004 0-5.833.73-8.353 1.994L48.458 128l18.428-32.093l-5.515-3.2L42.027 126.4a3.21 3.21 0 0 0 0 3.2l12.388 21.568c-3.268 3.405-5.289 8.022-5.289 13.114c0 10.425 8.436 18.908 18.807 18.908c1.562 0 3.074-.214 4.528-.579l10.15 17.68c.57.989 1.62 1.6 2.757 1.6h39.451v-6.4H87.204l-8.878-15.465Z'/%3E%3C/svg%3E%0A"
+  }
+}


### PR DESCRIPTION
## Description

Added inbound aws eventbridge connector template

## Related issues
tested with next fix : https://github.com/camunda/connectors-bundle/pull/913

depend on https://github.com/camunda/connectors-bundle/pull/920


<img width="611" alt="Screenshot 2023-07-20 at 20 52 11" src="https://github.com/camunda/connectors-bundle/assets/108869886/03a33bea-c6ca-4884-a96f-0196ff15edd9">
<img width="361" alt="Screenshot 2023-07-20 at 20 52 24" src="https://github.com/camunda/connectors-bundle/assets/108869886/b6510463-132e-4a88-ae91-30b16b07ad01">
<img width="359" alt="Screenshot 2023-07-20 at 20 52 32" src="https://github.com/camunda/connectors-bundle/assets/108869886/87707198-d2c4-464a-a0cf-4c1543e4f185">
<img width="355" alt="Screenshot 2023-07-20 at 20 52 38" src="https://github.com/camunda/connectors-bundle/assets/108869886/aae57853-52c1-43fd-950d-4a51de3da583">
<img width="346" alt="Screenshot 2023-07-20 at 20 52 47" src="https://github.com/camunda/connectors-bundle/assets/108869886/705e8f8a-e9b1-4a03-9f53-9b742aebeae1">


