### PR TITLE
chore(): Support double parentheses in all connectors

### DIFF
--- a/connectors/aws/aws-dynamodb/README.md
+++ b/connectors/aws/aws-dynamodb/README.md
@@ -17,14 +17,14 @@ mvn clean package
 ```json
 {
   "authentication": {
-    "accessKey": "secrets.SNS_ACCESS_KEY",
-    "secretKey": "secrets.SNS_SECRET_KEY"
+    "accessKey": "{{secrets.SNS_ACCESS_KEY}}",
+    "secretKey": "{{secrets.SNS_SECRET_KEY}}"
   },
   "input": {
     "type": "getItem",
-    "tableName": "secrets.TABLE_NAME_KEY",
+    "tableName": "{{secrets.TABLE_NAME_KEY}}",
     "primaryKeyComponents": {
-      "id": "secrets.KEY_ATTRIBUTE_VALUE"
+      "id": "{{secrets.KEY_ATTRIBUTE_VALUE}}"
     }
   }
 }

--- a/connectors/aws/aws-dynamodb/src/test/java/io/camunda/connector/aws/dynamodb/operation/item/DeleteItemOperationTest.java
+++ b/connectors/aws/aws-dynamodb/src/test/java/io/camunda/connector/aws/dynamodb/operation/item/DeleteItemOperationTest.java
@@ -61,8 +61,8 @@ class DeleteItemOperationTest extends BaseDynamoDbOperationTest {
         """
                      {
                      "type": "deleteItem",
-                     "tableName": "secrets.TABLE_NAME_KEY",
-                     "primaryKeyComponents":{"id":"secrets.KEY_ATTRIBUTE_VALUE"}
+                     "tableName": "{{secrets.TABLE_NAME_KEY}}",
+                     "primaryKeyComponents":{"id":"{{secrets.KEY_ATTRIBUTE_VALUE}}"}
                      }""";
     OutboundConnectorContext context = getContextWithSecrets(input);
     var request = context.bindVariables(AwsInput.class);

--- a/connectors/aws/aws-dynamodb/src/test/java/io/camunda/connector/aws/dynamodb/operation/item/GetItemOperationTest.java
+++ b/connectors/aws/aws-dynamodb/src/test/java/io/camunda/connector/aws/dynamodb/operation/item/GetItemOperationTest.java
@@ -85,8 +85,8 @@ class GetItemOperationTest extends BaseDynamoDbOperationTest {
         """
                      {
                      "type": "getItem",
-                     "tableName": "secrets.TABLE_NAME_KEY",
-                     "primaryKeyComponents":{"id":"secrets.KEY_ATTRIBUTE_VALUE"}
+                     "tableName": "{{secrets.TABLE_NAME_KEY}}",
+                     "primaryKeyComponents":{"id":"{{secrets.KEY_ATTRIBUTE_VALUE}}"}
                      }""";
     OutboundConnectorContext context = getContextWithSecrets(input);
     AwsInput request = context.bindVariables(AwsInput.class);

--- a/connectors/aws/aws-dynamodb/src/test/java/io/camunda/connector/aws/dynamodb/operation/table/CreateTableOperationTest.java
+++ b/connectors/aws/aws-dynamodb/src/test/java/io/camunda/connector/aws/dynamodb/operation/table/CreateTableOperationTest.java
@@ -14,7 +14,6 @@ import static org.mockito.Mockito.when;
 import com.amazonaws.services.dynamodbv2.model.BillingMode;
 import com.amazonaws.services.dynamodbv2.model.CreateTableRequest;
 import com.amazonaws.services.dynamodbv2.model.TableDescription;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import io.camunda.connector.api.outbound.OutboundConnectorContext;
 import io.camunda.connector.aws.dynamodb.BaseDynamoDbOperationTest;
 import io.camunda.connector.aws.dynamodb.TestDynamoDBData;
@@ -114,17 +113,17 @@ class CreateTableOperationTest extends BaseDynamoDbOperationTest {
   }
 
   @Test
-  public void replaceSecrets_shouldReplaceSecrets() throws JsonProcessingException {
+  public void replaceSecrets_shouldReplaceSecrets() {
     // Given
     String input =
         """
                 {
                   "type": "createTable",
-                  "partitionKey": "secrets.PARTITION_KEY",
-                  "partitionKeyRole": "secrets.PARTITION_KEY",
-                  "partitionKeyType": "secrets.PARTITION_KEY",
-                  "sortKey": "secrets.SORT_KEY",
-                  "tableName": "secrets.TABLE_NAME_KEY"
+                  "partitionKey": "{{secrets.PARTITION_KEY}}",
+                  "partitionKeyRole": "{{secrets.PARTITION_KEY}}",
+                  "partitionKeyType": "{{secrets.PARTITION_KEY",
+                  "sortKey": "{{secrets.SORT_KEY}}",
+                  "tableName": "{{secrets.TABLE_NAME_KEY}}"
                 }
                 """;
     OutboundConnectorContext context = getContextWithSecrets(input);

--- a/connectors/aws/aws-dynamodb/src/test/java/io/camunda/connector/aws/dynamodb/operation/table/DeleteTableOperationTest.java
+++ b/connectors/aws/aws-dynamodb/src/test/java/io/camunda/connector/aws/dynamodb/operation/table/DeleteTableOperationTest.java
@@ -10,7 +10,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import io.camunda.connector.api.outbound.OutboundConnectorContext;
 import io.camunda.connector.aws.dynamodb.BaseDynamoDbOperationTest;
 import io.camunda.connector.aws.dynamodb.TestDynamoDBData;
@@ -41,13 +40,13 @@ class DeleteTableOperationTest extends BaseDynamoDbOperationTest {
   }
 
   @Test
-  public void replaceSecrets_shouldReplaceSecrets() throws JsonProcessingException {
+  public void replaceSecrets_shouldReplaceSecrets() {
     // Given
     String input =
         """
                 {
                   "type": "deleteTable",
-                  "tableName": "secrets.TABLE_NAME_KEY"
+                  "tableName": "{{secrets.TABLE_NAME_KEY}}"
                 }
                 """;
     OutboundConnectorContext context = getContextWithSecrets(input);

--- a/connectors/aws/aws-dynamodb/src/test/java/io/camunda/connector/aws/dynamodb/operation/table/DescribeTableOperationTest.java
+++ b/connectors/aws/aws-dynamodb/src/test/java/io/camunda/connector/aws/dynamodb/operation/table/DescribeTableOperationTest.java
@@ -9,7 +9,6 @@ package io.camunda.connector.aws.dynamodb.operation.table;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.amazonaws.services.dynamodbv2.model.TableDescription;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import io.camunda.connector.api.outbound.OutboundConnectorContext;
 import io.camunda.connector.aws.dynamodb.BaseDynamoDbOperationTest;
 import io.camunda.connector.aws.dynamodb.TestDynamoDBData;
@@ -34,13 +33,13 @@ class DescribeTableOperationTest extends BaseDynamoDbOperationTest {
   }
 
   @Test
-  public void replaceSecrets_shouldReplaceSecrets() throws JsonProcessingException {
+  public void replaceSecrets_shouldReplaceSecrets() {
     // Given
     String input =
         """
                 {
                   "type": "describeTable",
-                  "tableName": "secrets.TABLE_NAME_KEY"
+                  "tableName": "{{secrets.TABLE_NAME_KEY}}"
                 }
                 """;
     OutboundConnectorContext context = getContextWithSecrets(input);

--- a/connectors/aws/aws-eventbridge/src/test/resources/request/success-cases-eventbridge.json
+++ b/connectors/aws/aws-eventbridge/src/test/resources/request/success-cases-eventbridge.json
@@ -16,17 +16,17 @@
   },
   {
     "authentication": {
-      "secretKey": "secrets.SECRET_KEY",
-      "accessKey": "secrets.ACCESS_KEY"
+      "secretKey": "{{secrets.SECRET_KEY}}",
+      "accessKey": "{{secrets.ACCESS_KEY}}"
     },
     "configuration": {
-      "region": "secrets.REGION"
+      "region": "{{secrets.REGION}}"
     },
     "input": {
-      "detailType": "secrets.DETAIL_TYPE",
-      "eventBusName": "secrets.EVENT_BUS_NAME",
-      "source": "secrets.SOURCE",
-      "detail": {"key1": {"innerKey": "secrets.INNER_DETAIL_VALUE"}}
+      "detailType": "{{secrets.DETAIL_TYPE}}",
+      "eventBusName": "{{secrets.EVENT_BUS_NAME}}",
+      "source": "{{secrets.SOURCE}}",
+      "detail": {"key1": {"innerKey": "{{secrets.INNER_DETAIL_VALUE}}"}}
     }
   }
 ]

--- a/connectors/aws/aws-lambda/README.md
+++ b/connectors/aws/aws-lambda/README.md
@@ -15,13 +15,13 @@ mvn clean package
 ```json
 {
   "authentication": {
-    "secretKey": "secrets.SECRET_KEY",
-    "accessKey": "secrets.ACCESS_KEY",
-    "region": "secrets.REGION_KEY"
+    "secretKey": "{{secrets.SECRET_KEY}}",
+    "accessKey": "{{secrets.ACCESS_KEY}}",
+    "region": "{{secrets.REGION_KEY}}"
   },
   "function": {
-    "functionName": "secrets.FUNCTION_NAME",
-    "operationType": "secrets.OPERATION_TYPE",
+    "functionName": "{{secrets.FUNCTION_NAME}}",
+    "operationType": "{{secrets.OPERATION_TYPE}}",
     "payload": {
       "event": {
         "data": "value"

--- a/connectors/aws/aws-lambda/src/test/resources/requests/lambda-connector-fail-test-case.json
+++ b/connectors/aws/aws-lambda/src/test/resources/requests/lambda-connector-fail-test-case.json
@@ -1,50 +1,50 @@
 [
   {
     "authentication": {
-      "accessKey": "secrets.ACCESS_KEY"
+      "accessKey": "{{secrets.ACCESS_KEY}}"
     },
     "configuration": {
       "region": "test-region"
     },
     "awsFunction": {
-      "payload": "secrets.PAYLOAD_KEY",
-      "functionName": "secrets.FUNCTION_NAME"
+      "payload": "{{secrets.PAYLOAD_KEY}}",
+      "functionName": "{{secrets.FUNCTION_NAME}}"
     }
   },
   {
     "authentication": {
-      "secretKey": "secrets.SECRET_KEY"
+      "secretKey": "{{secrets.SECRET_KEY}}"
     },
     "configuration": {
       "region": "test-region"
     },
     "awsFunction": {
-      "payload": "secrets.PAYLOAD_KEY",
-      "functionName": "secrets.FUNCTION_NAME"
+      "payload": "{{secrets.PAYLOAD_KEY}}",
+      "functionName": "{{secrets.FUNCTION_NAME}}"
     }
   },
   {
     "authentication": {
-      "secretKey": "secrets.SECRET_KEY",
-      "accessKey": "secrets.ACCESS_KEY"
+      "secretKey": "{{secrets.SECRET_KEY}}",
+      "accessKey": "{{secrets.ACCESS_KEY}}"
     },
     "configuration": {
-      "region": "secrets.REGION_KEY"
+      "region": "{{secrets.REGION_KEY}}"
     },
     "awsFunction": {
-      "functionName": "secrets.FUNCTION_NAME"
+      "functionName": "{{secrets.FUNCTION_NAME}}"
     }
   },
   {
     "authentication": {
-      "secretKey": "secrets.SECRET_KEY",
-      "accessKey": "secrets.ACCESS_KEY"
+      "secretKey": "{{secrets.SECRET_KEY}}",
+      "accessKey": "{{secrets.ACCESS_KEY}}"
     },
     "configuration": {
-      "region": "secrets.REGION_KEY"
+      "region": "{{secrets.REGION_KEY}}"
     },
     "awsFunction": {
-      "payload": "secrets.PAYLOAD_KEY"
+      "payload": "{{secrets.PAYLOAD_KEY}}"
     }
   }
 ]

--- a/connectors/aws/aws-lambda/src/test/resources/requests/lambda-connector-success-request-with-secrets-test-case.json
+++ b/connectors/aws/aws-lambda/src/test/resources/requests/lambda-connector-success-request-with-secrets-test-case.json
@@ -1,15 +1,15 @@
 [
   {
     "authentication": {
-      "secretKey": "secrets.SECRET_KEY",
-      "accessKey": "secrets.ACCESS_KEY"
+      "secretKey": "{{secrets.SECRET_KEY}}",
+      "accessKey": "{{secrets.ACCESS_KEY}}"
     },
     "configuration": {
-      "region": "secrets.REGION_KEY"
+      "region": "{{secrets.REGION_KEY}}"
     },
     "awsFunction": {
-      "payload": "secrets.PAYLOAD_KEY",
-      "functionName": "secrets.FUNCTION_NAME"
+      "payload": "{{secrets.PAYLOAD_KEY}}",
+      "functionName": "{{secrets.FUNCTION_NAME}}"
     }
   }
 ]

--- a/connectors/aws/aws-lambda/src/test/resources/requests/lambda-connector-success-test-case.json
+++ b/connectors/aws/aws-lambda/src/test/resources/requests/lambda-connector-success-test-case.json
@@ -1,25 +1,25 @@
 [
   {
     "authentication": {
-      "secretKey": "secrets.SECRET_KEY",
-      "accessKey": "secrets.ACCESS_KEY"
+      "secretKey": "{{secrets.SECRET_KEY}}",
+      "accessKey": "{{secrets.ACCESS_KEY}}"
     },
     "awsFunction": {
       "payload": {"key":{"key1":{"key2":"value"}}},
-      "functionName": "secrets.FUNCTION_NAME",
-      "region": "secrets.REGION_KEY"
+      "functionName": "{{secrets.FUNCTION_NAME}}",
+      "region": "{{secrets.REGION_KEY}}"
     }
   },{
     "authentication": {
-      "secretKey": "secrets.SECRET_KEY",
-      "accessKey": "secrets.ACCESS_KEY"
+      "secretKey": "{{secrets.SECRET_KEY}}",
+      "accessKey": "{{secrets.ACCESS_KEY}}"
     },
     "configuration": {
-      "region": "secrets.REGION_KEY"
+      "region": "{{secrets.REGION_KEY}}"
     },
     "awsFunction": {
       "payload": {"key":{"key1":{"key2":"value"}}},
-      "functionName": "secrets.FUNCTION_NAME"
+      "functionName": "{{secrets.FUNCTION_NAME}}"
     }
   },
   {

--- a/connectors/aws/aws-sns/README.md
+++ b/connectors/aws/aws-sns/README.md
@@ -15,8 +15,8 @@ mvn clean package
 ```json
 {
   "authentication":{
-    "accessKey":"secrets.SNS_ACCESS_KEY",
-    "secretKey":"secrets.SNS_SECRET_KEY"
+    "accessKey":"{{secrets.SNS_ACCESS_KEY}}",
+    "secretKey":"{{secrets.SNS_SECRET_KEY}}"
   },
   "topic":{
     "message":"MyMessage",

--- a/connectors/aws/aws-sns/src/test/java/io/camunda/connector/sns/outbound/BaseTest.java
+++ b/connectors/aws/aws-sns/src/test/java/io/camunda/connector/sns/outbound/BaseTest.java
@@ -13,7 +13,6 @@ public abstract class BaseTest {
 
   protected static final String AWS_TOPIC_REGION = "AWS_TOPIC_REGION";
   protected static final String ACTUAL_TOPIC_REGION = "us-east-1";
-  protected static final String SECRETS = "secrets.";
   protected static final String AWS_ACCESS_KEY = "AWS_ACCESS_KEY";
   protected static final String AWS_SECRET_KEY = "AWS_SECRET_KEY";
   protected static final String ACTUAL_ACCESS_KEY = "4W553CR3TK3Y";
@@ -25,52 +24,54 @@ public abstract class BaseTest {
   protected static final String MSG_ID = "f3f7ac8f-2ff8-48a0-bb30-f220654f6a5f";
 
   protected static final String DEFAULT_REQUEST_BODY =
-      "{\n"
-          + "  \"authentication\":{\n"
-          + "    \"secretKey\":\"abc\",\n"
-          + "    \"accessKey\":\"def\"\n"
-          + "  },\n"
-          + "  \"topic\":{\n"
-          + "    \"message\":\"MyMessage\",\n"
-          + "    \"messageAttributes\":{\n"
-          + "      \"attribute2\":{\n"
-          + "        \"StringValue\":\"attribute 2 value\",\n"
-          + "        \"DataType\":\"String\"\n"
-          + "      },\n"
-          + "      \"attribute1\":{\n"
-          + "        \"StringValue\":\"attribute 1 value\",\n"
-          + "        \"DataType\":\"String\"\n"
-          + "      }\n"
-          + "    },\n"
-          + "    \"subject\":\"MySubject\",\n"
-          + "    \"region\":\"us-east-1\",\n"
-          + "    \"topicArn\":\"arn:aws:sns:us-east-1:000000000000:test\"\n"
-          + "  }\n"
-          + "}";
+      """
+                  {
+                    "authentication":{
+                      "secretKey":"abc",
+                      "accessKey":"def"
+                    },
+                    "topic":{
+                      "message":"MyMessage",
+                      "messageAttributes":{
+                        "attribute2":{
+                          "StringValue":"attribute 2 value",
+                          "DataType":"String"
+                        },
+                        "attribute1":{
+                          "StringValue":"attribute 1 value",
+                          "DataType":"String"
+                        }
+                      },
+                      "subject":"MySubject",
+                      "region":"us-east-1",
+                      "topicArn":"arn:aws:sns:us-east-1:000000000000:test"
+                    }
+                  }""";
 
   protected static final String REQUEST_WITH_JSON_MSG_BODY =
-      "{\n"
-          + "  \"authentication\":{\n"
-          + "    \"secretKey\":\"abc\",\n"
-          + "    \"accessKey\":\"def\"\n"
-          + "  },\n"
-          + "  \"topic\":{\n"
-          + "    \"message\":{\"key\":\"value\"},\n"
-          + "    \"messageAttributes\":{\n"
-          + "      \"attribute2\":{\n"
-          + "        \"StringValue\":\"attribute 2 value\",\n"
-          + "        \"DataType\":\"String\"\n"
-          + "      },\n"
-          + "      \"attribute1\":{\n"
-          + "        \"StringValue\":\"attribute 1 value\",\n"
-          + "        \"DataType\":\"String\"\n"
-          + "      }\n"
-          + "    },\n"
-          + "    \"subject\":\"MySubject\",\n"
-          + "    \"region\":\"us-east-1\",\n"
-          + "    \"topicArn\":\"arn:aws:sns:us-east-1:000000000000:test\"\n"
-          + "  }\n"
-          + "}";
+      """
+                  {
+                    "authentication":{
+                      "secretKey":"abc",
+                      "accessKey":"def"
+                    },
+                    "topic":{
+                      "message":{"key":"value"},
+                      "messageAttributes":{
+                        "attribute2":{
+                          "StringValue":"attribute 2 value",
+                          "DataType":"String"
+                        },
+                        "attribute1":{
+                          "StringValue":"attribute 1 value",
+                          "DataType":"String"
+                        }
+                      },
+                      "subject":"MySubject",
+                      "region":"us-east-1",
+                      "topicArn":"arn:aws:sns:us-east-1:000000000000:test"
+                    }
+                  }""";
 
   protected static final ObjectMapper objectMapper = ObjectMapperSupplier.getMapperInstance();
 }

--- a/connectors/aws/aws-sns/src/test/resources/requests/fail-test-cases.json
+++ b/connectors/aws/aws-sns/src/test/resources/requests/fail-test-cases.json
@@ -14,7 +14,7 @@
   {
     "testDescription": "No access key",
     "authentication":{
-      "secretKey":"secrets.AWS_SECRET_KEY"
+      "secretKey":"{{secrets.AWS_SECRET_KEY}}"
     },
     "configuration": {
       "region":"us-east-1"
@@ -29,7 +29,7 @@
   {
     "testDescription": "No secret key",
     "authentication":{
-      "accessKey":"secrets.AWS_ACCESS_KEY"
+      "accessKey":"{{secrets.AWS_ACCESS_KEY}}"
     },
     "configuration": {
       "region":"us-east-1"
@@ -44,8 +44,8 @@
   {
     "testDescription": "No topic ARN",
     "authentication":{
-      "secretKey":"secrets.AWS_SECRET_KEY",
-      "accessKey":"secrets.AWS_ACCESS_KEY"
+      "secretKey":"{{secrets.AWS_SECRET_KEY}}",
+      "accessKey":"{{secrets.AWS_ACCESS_KEY}}"
     },
     "configuration": {
       "region":"us-east-1"
@@ -59,8 +59,8 @@
   {
     "testDescription": "No region",
     "authentication":{
-      "secretKey":"secrets.AWS_SECRET_KEY",
-      "accessKey":"secrets.AWS_ACCESS_KEY"
+      "secretKey":"{{secrets.AWS_SECRET_KEY}}",
+      "accessKey":"{{secrets.AWS_ACCESS_KEY}}"
     },
     "topic":{
       "message":"Hello",
@@ -72,8 +72,8 @@
   {
     "testDescription": "No message body",
     "authentication":{
-      "secretKey":"secrets.AWS_SECRET_KEY",
-      "accessKey":"secrets.AWS_ACCESS_KEY"
+      "secretKey":"{{secrets.AWS_SECRET_KEY}}",
+      "accessKey":"{{secrets.AWS_ACCESS_KEY}}"
     },
     "configuration": {
       "region":"us-east-1"
@@ -87,15 +87,15 @@
   {
     "testDescription": "No topic",
     "authentication":{
-      "secretKey":"secrets.AWS_SECRET_KEY",
-      "accessKey":"secrets.AWS_ACCESS_KEY"
+      "secretKey":"{{secrets.AWS_SECRET_KEY}}",
+      "accessKey":"{{secrets.AWS_ACCESS_KEY}}"
     }
   },
   {
     "testDescription": "Request with empty region",
     "authentication":{
-      "secretKey":"secrets.AWS_SECRET_KEY",
-      "accessKey":"secrets.AWS_ACCESS_KEY"
+      "secretKey":"{{secrets.AWS_SECRET_KEY}}",
+      "accessKey":"{{secrets.AWS_ACCESS_KEY}}"
     },
     "configuration": {
       "region":""
@@ -110,8 +110,8 @@
   {
     "testDescription": "Request with blank region",
     "authentication":{
-      "secretKey":"secrets.AWS_SECRET_KEY",
-      "accessKey":"secrets.AWS_ACCESS_KEY"
+      "secretKey":"{{secrets.AWS_SECRET_KEY}}",
+      "accessKey":"{{secrets.AWS_ACCESS_KEY}}"
     },
     "configuration": {
       "region":"   "
@@ -127,8 +127,8 @@
   {
     "testDescription": "Request without topic ARN",
     "authentication":{
-      "secretKey":"secrets.AWS_SECRET_KEY",
-      "accessKey":"secrets.AWS_ACCESS_KEY"
+      "secretKey":"{{secrets.AWS_SECRET_KEY}}",
+      "accessKey":"{{secrets.AWS_ACCESS_KEY}}"
     },
     "configuration": {
       "region":"us-east-1"
@@ -142,8 +142,8 @@
   {
     "testDescription": "Request with subject length greater than 99",
     "authentication":{
-      "secretKey":"secrets.AWS_SECRET_KEY",
-      "accessKey":"secrets.AWS_ACCESS_KEY"
+      "secretKey":"{{secrets.AWS_SECRET_KEY}}",
+      "accessKey":"{{secrets.AWS_ACCESS_KEY}}"
     },
     "configuration": {
       "region":"us-east-1"

--- a/connectors/aws/aws-sns/src/test/resources/requests/success-test-cases.json
+++ b/connectors/aws/aws-sns/src/test/resources/requests/success-test-cases.json
@@ -2,8 +2,8 @@
   {
     "testDescription": "Deprecated case where region in topic, but must be supported",
     "authentication":{
-      "secretKey":"secrets.AWS_SECRET_KEY",
-      "accessKey":"secrets.AWS_ACCESS_KEY"
+      "secretKey":"{{secrets.AWS_SECRET_KEY}}",
+      "accessKey":"{{secrets.AWS_ACCESS_KEY}}"
     },
     "topic":{
       "message":"Hello",
@@ -16,8 +16,8 @@
   {
     "testDescription": "Request with secrets",
     "authentication":{
-      "secretKey":"secrets.AWS_SECRET_KEY",
-      "accessKey":"secrets.AWS_ACCESS_KEY"
+      "secretKey":"{{secrets.AWS_SECRET_KEY}}",
+      "accessKey":"{{secrets.AWS_ACCESS_KEY}}"
     },
     "configuration": {
       "region":"us-east-1"
@@ -32,8 +32,8 @@
   {
     "testDescription": "Request with attributes",
     "authentication":{
-      "secretKey":"secrets.AWS_SECRET_KEY",
-      "accessKey":"secrets.AWS_ACCESS_KEY"
+      "secretKey":"{{secrets.AWS_SECRET_KEY}}",
+      "accessKey":"{{secrets.AWS_ACCESS_KEY}}"
     },
     "configuration": {
       "region":"us-east-1"
@@ -51,14 +51,14 @@
         }
       },
       "subject":"MySubject",
-      "topicArn":"secrets.AWS_TOPIC_ARN"
+      "topicArn":"{{secrets.AWS_TOPIC_ARN}}"
     }
   },
   {
     "testDescription": "Request without attributes",
     "authentication":{
-      "secretKey":"secrets.AWS_SECRET_KEY",
-      "accessKey":"secrets.AWS_ACCESS_KEY"
+      "secretKey":"{{secrets.AWS_SECRET_KEY}}",
+      "accessKey":"{{secrets.AWS_ACCESS_KEY}}"
     },
     "configuration": {
       "region":"us-east-1"
@@ -66,7 +66,7 @@
     "topic":{
       "message":"Hello",
       "subject":"MySubject",
-      "topicArn":"secrets.AWS_TOPIC_ARN"
+      "topicArn":"{{secrets.AWS_TOPIC_ARN}}"
     }
   },
   {
@@ -88,8 +88,8 @@
   {
     "testDescription": "Request with secrets for ARN",
     "authentication":{
-      "secretKey":"secrets.AWS_SECRET_KEY",
-      "accessKey":"secrets.AWS_ACCESS_KEY"
+      "secretKey":"{{secrets.AWS_SECRET_KEY}}",
+      "accessKey":"{{secrets.AWS_ACCESS_KEY}}"
     },
     "configuration": {
       "region":"us-east-1"
@@ -98,17 +98,17 @@
       "message":"Hello",
       "messageAttributes":{},
       "subject":"MySubject",
-      "topicArn":"secrets.AWS_TOPIC_ARN"
+      "topicArn":"{{secrets.AWS_TOPIC_ARN}}"
     }
   },
   {
     "testDescription": "Request with secrets for region",
     "authentication":{
-      "secretKey":"secrets.AWS_SECRET_KEY",
-      "accessKey":"secrets.AWS_ACCESS_KEY"
+      "secretKey":"{{secrets.AWS_SECRET_KEY}}",
+      "accessKey":"{{secrets.AWS_ACCESS_KEY}}"
     },
     "configuration": {
-      "region":"secrets.AWS_TOPIC_REGION"
+      "region":"{{secrets.AWS_TOPIC_REGION}}"
     },
     "topic":{
       "message":"Hello",
@@ -120,8 +120,8 @@
   {
     "testDescription": "Request without subject",
     "authentication":{
-      "secretKey":"secrets.AWS_SECRET_KEY",
-      "accessKey":"secrets.AWS_ACCESS_KEY"
+      "secretKey":"{{secrets.AWS_SECRET_KEY}}",
+      "accessKey":"{{secrets.AWS_ACCESS_KEY}}"
     },
     "configuration": {
       "region":"us-east-1"

--- a/connectors/aws/aws-sqs/README.md
+++ b/connectors/aws/aws-sqs/README.md
@@ -15,8 +15,8 @@ mvn clean package
 ```json
 {
   "authentication":{
-    "secretKey":"secrets.AWS_SECRET_KEY",
-    "accessKey":"secrets.AWS_ACCESS_KEY"
+    "secretKey":"{{secrets.AWS_SECRET_KEY}}",
+    "accessKey":"{{secrets.AWS_ACCESS_KEY}}"
   },
   "queue":{
     "messageAttributes":{

--- a/connectors/aws/aws-sqs/src/test/java/io/camunda/connector/outbound/BaseTest.java
+++ b/connectors/aws/aws-sqs/src/test/java/io/camunda/connector/outbound/BaseTest.java
@@ -14,15 +14,12 @@ public abstract class BaseTest {
 
   protected static final String ACTUAL_QUEUE_URL = "https://sqs.region.amazonaws.com/camunda-test";
   protected static final String ACTUAL_QUEUE_REGION = "us-east-1";
-  protected static final String SECRETS = "secrets.";
   protected static final String AWS_ACCESS_KEY = "AWS_ACCESS_KEY";
   protected static final String AWS_SECRET_KEY = "AWS_SECRET_KEY";
   protected static final String SQS_QUEUE_URL = "SQS_QUEUE_URL";
   protected static final String SQS_QUEUE_REGION = "SQS_QUEUE_REGION";
   protected static final String ACTUAL_ACCESS_KEY = "4W553CR3TK3Y";
   protected static final String ACTUAL_SECRET_KEY = "AAAABBBBCCCDDD";
-  protected static final String SQS_MESSAGE_BODY = "{\"myKey\":\"myVal\"}";
-  protected static final String WRONG_MESSAGE_BODY = "its wrong msg";
   protected static final String MSG_ID = "f3f7ac8f-2ff8-48a0-bb30-f220654f6a5f";
 
   protected static final String DEFAULT_REQUEST_BODY_WITH_JSON_PAYLOAD =

--- a/connectors/aws/aws-sqs/src/test/resources/requests/inbound/success-test-cases.json
+++ b/connectors/aws/aws-sqs/src/test/resources/requests/inbound/success-test-cases.json
@@ -17,8 +17,8 @@
   {
     "testDescription": "Request with secrets",
     "authentication":{
-      "secretKey":"secrets.AWS_SECRET_KEY",
-      "accessKey":"secrets.AWS_ACCESS_KEY"
+      "secretKey":"{{secrets.AWS_SECRET_KEY}}",
+      "accessKey":"{{secrets.AWS_ACCESS_KEY}}"
     },
     "configuration": {
       "region":"us-east-1"
@@ -26,7 +26,7 @@
     "queue":{
       "attributeNames":["{{secrets.ATTRIBUTE_NAME_KEY}}"],
       "messageAttributeNames": ["{{secrets.MESSAGE_ATTRIBUTE_NAME_KEY}"],
-      "url":"secrets.SQS_QUEUE_URL",
+      "url":"{{secrets.SQS_QUEUE_URL}}",
       "pollingWaitTime": "1"
     }
   },
@@ -50,14 +50,14 @@
   {
     "testDescription": "Request with secrets, without attributes",
     "authentication":{
-      "secretKey":"secrets.AWS_SECRET_KEY",
-      "accessKey":"secrets.AWS_ACCESS_KEY"
+      "secretKey":"{{secrets.AWS_SECRET_KEY}}",
+      "accessKey":"{{secrets.AWS_ACCESS_KEY}}"
     },
     "configuration": {
       "region":"us-east-1"
     },
     "queue":{
-      "url":"secrets.SQS_QUEUE_URL",
+      "url":"{{secrets.SQS_QUEUE_URL}}",
       "pollingWaitTime": "1"
     }
   },

--- a/connectors/aws/aws-sqs/src/test/resources/requests/outbound/fail-test-cases.json
+++ b/connectors/aws/aws-sqs/src/test/resources/requests/outbound/fail-test-cases.json
@@ -10,13 +10,13 @@
         "data":"ok"
       },
       "region":"us-east-1",
-      "url":"secrets.SQS_QUEUE_URL"
+      "url":"{{secrets.SQS_QUEUE_URL}}"
     }
   },
   {
     "testDescription": "No access key",
     "authentication":{
-      "secretKey":"secrets.AWS_SECRET_KEY"
+      "secretKey":"{{secrets.AWS_SECRET_KEY}}"
     },
     "configuration": {
       "region":"us-east-1"
@@ -27,13 +27,13 @@
         "data":"ok"
       },
       "region":"us-east-1",
-      "url":"secrets.SQS_QUEUE_URL"
+      "url":"{{secrets.SQS_QUEUE_URL}}"
     }
   },
   {
     "testDescription": "No secret key",
     "authentication":{
-      "accessKey":"secrets.AWS_ACCESS_KEY"
+      "accessKey":"{{secrets.AWS_ACCESS_KEY}}"
     },
     "configuration": {
       "region":"us-east-1"
@@ -44,14 +44,14 @@
         "data":"ok"
       },
       "region":"us-east-1",
-      "url":"secrets.SQS_QUEUE_URL"
+      "url":"{{secrets.SQS_QUEUE_URL}}"
     }
   },
   {
     "testDescription": "No queue URL",
     "authentication":{
-      "secretKey":"secrets.AWS_SECRET_KEY",
-      "accessKey":"secrets.AWS_ACCESS_KEY"
+      "secretKey":"{{secrets.AWS_SECRET_KEY}}",
+      "accessKey":"{{secrets.AWS_ACCESS_KEY}}"
     },
     "configuration": {
       "region":"us-east-1"
@@ -67,22 +67,22 @@
   {
     "testDescription": "No region",
     "authentication":{
-      "secretKey":"secrets.AWS_SECRET_KEY",
-      "accessKey":"secrets.AWS_ACCESS_KEY"
+      "secretKey":"{{secrets.AWS_SECRET_KEY}}",
+      "accessKey":"{{secrets.AWS_ACCESS_KEY}}"
     },
     "queue":{
       "messageAttributes":{},
       "messageBody":{
         "data":"ok"
       },
-      "url":"secrets.SQS_QUEUE_URL"
+      "url":"{{secrets.SQS_QUEUE_URL}}"
     }
   },
   {
     "testDescription": "No message body",
     "authentication":{
-      "secretKey":"secrets.AWS_SECRET_KEY",
-      "accessKey":"secrets.AWS_ACCESS_KEY"
+      "secretKey":"{{secrets.AWS_SECRET_KEY}}",
+      "accessKey":"{{secrets.AWS_ACCESS_KEY}}"
     },
     "configuration": {
       "region":"us-east-1"
@@ -90,21 +90,21 @@
     "queue":{
       "messageAttributes":{},
       "region":"us-east-1",
-      "url":"secrets.SQS_QUEUE_URL"
+      "url":"{{secrets.SQS_QUEUE_URL}}"
     }
   },
   {
     "testDescription": "No queue",
     "authentication":{
-      "secretKey":"secrets.AWS_SECRET_KEY",
-      "accessKey":"secrets.AWS_ACCESS_KEY"
+      "secretKey":"{{secrets.AWS_SECRET_KEY}}",
+      "accessKey":"{{secrets.AWS_ACCESS_KEY}}"
     }
   },
   {
     "testDescription": "No messageGroupId for FIFO queue",
     "authentication": {
-      "secretKey": "secrets.AWS_SECRET_KEY",
-      "accessKey": "secrets.AWS_ACCESS_KEY"
+      "secretKey": "{{secrets.AWS_SECRET_KEY}}",
+      "accessKey": "{{secrets.AWS_ACCESS_KEY}}"
     },
     "configuration": {
       "region":"us-east-1"
@@ -117,14 +117,14 @@
         "data": "ok"
       },
       "region": "us-east-1",
-      "url": "secrets.SQS_QUEUE_URL"
+      "url": "{{secrets.SQS_QUEUE_URL}}"
     }
   },
   {
     "testDescription": "Invalid queue type",
     "authentication": {
-      "secretKey": "secrets.AWS_SECRET_KEY",
-      "accessKey": "secrets.AWS_ACCESS_KEY"
+      "secretKey": "{{secrets.AWS_SECRET_KEY}}",
+      "accessKey": "{{secrets.AWS_ACCESS_KEY}}"
     },
     "configuration": {
       "region":"us-east-1"
@@ -138,14 +138,14 @@
         "data": "ok"
       },
       "region": "us-east-1",
-      "url": "secrets.SQS_QUEUE_URL"
+      "url": "{{secrets.SQS_QUEUE_URL}}"
     }
   },
   {
     "testDescription": "messageGroupId not supported for standard queues",
     "authentication": {
-      "secretKey": "secrets.AWS_SECRET_KEY",
-      "accessKey": "secrets.AWS_ACCESS_KEY"
+      "secretKey": "{{secrets.AWS_SECRET_KEY}}",
+      "accessKey": "{{secrets.AWS_ACCESS_KEY}}"
     },
     "configuration": {
       "region":"us-east-1"
@@ -158,7 +158,7 @@
         "data": "ok"
       },
       "region": "us-east-1",
-      "url": "secrets.SQS_QUEUE_URL"
+      "url": "{{secrets.SQS_QUEUE_URL}}"
     }
   }
 ]

--- a/connectors/aws/aws-sqs/src/test/resources/requests/outbound/success-test-cases.json
+++ b/connectors/aws/aws-sqs/src/test/resources/requests/outbound/success-test-cases.json
@@ -2,8 +2,8 @@
   {
     "testDescription": "deprecated case, but region must support in queue too",
     "authentication":{
-      "secretKey":"secrets.AWS_SECRET_KEY",
-      "accessKey":"secrets.AWS_ACCESS_KEY"
+      "secretKey":"{{secrets.AWS_SECRET_KEY}}",
+      "accessKey":"{{secrets.AWS_ACCESS_KEY}}"
     },
     "queue":{
       "messageAttributes":{},
@@ -11,14 +11,14 @@
         "data":"ok"
       },
       "region":"us-east-1",
-      "url":"secrets.SQS_QUEUE_URL"
+      "url":"{{secrets.SQS_QUEUE_URL}}"
     }
   },
   {
     "testDescription": "Request with secrets",
     "authentication":{
-      "secretKey":"secrets.AWS_SECRET_KEY",
-      "accessKey":"secrets.AWS_ACCESS_KEY"
+      "secretKey":"{{secrets.AWS_SECRET_KEY}}",
+      "accessKey":"{{secrets.AWS_ACCESS_KEY}}"
     },
     "configuration": {
       "region":"us-east-1"
@@ -28,7 +28,7 @@
       "messageBody":{
         "data":"ok"
       },
-      "url":"secrets.SQS_QUEUE_URL"
+      "url":"{{secrets.SQS_QUEUE_URL}}"
     }
   },
   {
@@ -51,8 +51,8 @@
   {
     "testDescription":"Request with attributes",
     "authentication":{
-      "secretKey":"secrets.AWS_SECRET_KEY",
-      "accessKey":"secrets.AWS_ACCESS_KEY"
+      "secretKey":"{{secrets.AWS_SECRET_KEY}}",
+      "accessKey":"{{secrets.AWS_ACCESS_KEY}}"
     },
     "configuration": {
       "region":"us-east-1"
@@ -71,14 +71,14 @@
       "messageBody":{
         "data":"ok"
       },
-      "url":"secrets.SQS_QUEUE_URL"
+      "url":"{{secrets.SQS_QUEUE_URL}}"
     }
   },
   {
     "testDescription":"Request for FIFO queue",
     "authentication":{
-      "secretKey":"secrets.AWS_SECRET_KEY",
-      "accessKey":"secrets.AWS_ACCESS_KEY"
+      "secretKey":"{{secrets.AWS_SECRET_KEY}}",
+      "accessKey":"{{secrets.AWS_ACCESS_KEY}}"
     },
     "configuration": {
       "region":"us-east-1"
@@ -91,7 +91,7 @@
       "messageBody":{
         "data":"ok"
       },
-      "url":"secrets.SQS_QUEUE_URL"
+      "url":"{{secrets.SQS_QUEUE_URL}}"
     }
   }
 ]

--- a/connectors/google/google-drive/README.md
+++ b/connectors/google/google-drive/README.md
@@ -18,12 +18,12 @@ mvn clean package
   {
   "authentication":{
     "authType":"bearer",
-    "bearerToken": "secrets.GDRIVE_BEARER"
+    "bearerToken": "{{secrets.GDRIVE_BEARER}}"
   },
   "resource": {
     "type": "folder",
     "name": "MyNewFolderName",
-    "parent": "secrets.PARENT_ID",
+    "parent": "{{secrets.PARENT_ID}}",
     "additionalGoogleDriveProperties": {
       "description": "description"
     }
@@ -37,16 +37,16 @@ mvn clean package
 {
   "authentication":{
     "authType":"refresh",
-    "oauthClientId":"secrets.GDRIVE_OAUTH_CLIENT_ID",
-    "oauthClientSecret":"secrets.GDRIVE_OAUTH_CLIENT_SECRET",
-    "oauthRefreshToken":"secrets.GDRIVE_OAUTH_REFRESH_TOKEN"
+    "oauthClientId":"{{secrets.GDRIVE_OAUTH_CLIENT_ID}}",
+    "oauthClientSecret":"{{secrets.GDRIVE_OAUTH_CLIENT_SECRET}}",
+    "oauthRefreshToken":"{{secrets.GDRIVE_OAUTH_REFRESH_TOKEN}}"
   },
   "resource":{
     "type":"folder",
     "additionalGoogleDriveProperties":{
       "description": "description"
     },
-    "parent":"secrets.PARENT_ID",
+    "parent":"{{secrets.PARENT_ID}}",
     "name":"MyNewFolderName"
   }
 }
@@ -60,12 +60,12 @@ mvn clean package
   {
   "authentication":{
     "authType":"bearer",
-    "bearerToken": "secrets.GDRIVE_BEARER"
+    "bearerToken": "{{secrets.GDRIVE_BEARER}}"
   },
   "resource": {
     "type": "folder",
     "name": "MyNewFolder",
-    "parent": "secrets.PARENT_ID",
+    "parent": "{{secrets.PARENT_ID}}",
     "additionalGoogleDriveProperties": {
       "description": " description"
     },
@@ -95,14 +95,14 @@ mvn clean package
   {
   "authentication":{
     "authType":"refresh",
-    "oauthClientId":"secrets.GDRIVE_OAUTH_CLIENT_ID",
-    "oauthClientSecret":"secrets.GDRIVE_OAUTH_CLIENT_SECRET",
-    "oauthRefreshToken":"secrets.GDRIVE_OAUTH_REFRESH_TOKEN"
+    "oauthClientId":"{{secrets.GDRIVE_OAUTH_CLIENT_ID}}",
+    "oauthClientSecret":"{{secrets.GDRIVE_OAUTH_CLIENT_SECRET}}",
+    "oauthRefreshToken":"{{secrets.GDRIVE_OAUTH_REFRESH_TOKEN}}"
   },
   "resource": {
     "type": "folder",
     "name": "MyNewFolder",
-    "parent": "secrets.PARENT_ID",
+    "parent": "{{secrets.PARENT_ID}}",
     "additionalGoogleDriveProperties": {
       "description": " description"
     },

--- a/connectors/google/google-drive/src/test/resources/requests/file-success-test-cases.json
+++ b/connectors/google/google-drive/src/test/resources/requests/file-success-test-cases.json
@@ -2,7 +2,7 @@
   {
     "authentication": {
       "authType": "bearer",
-      "bearerToken": "secrets.MyToken"
+      "bearerToken": "{{secrets.MyToken}}"
     },
     "resource": {
       "type":"file",
@@ -32,9 +32,9 @@
   {
     "authentication": {
       "authType": "refresh",
-      "oauthClientId": "secrets.MyOauthClient",
-      "oauthClientSecret": "secrets.MyOauthSecret",
-      "oauthRefreshToken": "secrets.MyOauthRefresh"
+      "oauthClientId": "{{secrets.MyOauthClient}}",
+      "oauthClientSecret": "{{secrets.MyOauthSecret}}",
+      "oauthRefreshToken": "{{secrets.MyOauthRefresh}}"
     },
     "resource": {
       "type":"file",
@@ -64,9 +64,9 @@
   {
     "authentication": {
       "authType": "refresh",
-      "oauthClientId": "secrets.MyOauthClient",
-      "oauthClientSecret": "secrets.MyOauthSecret",
-      "oauthRefreshToken": "secrets.MyOauthRefresh"
+      "oauthClientId": "{{secrets.MyOauthClient}}",
+      "oauthClientSecret": "{{secrets.MyOauthSecret}}",
+      "oauthRefreshToken": "{{secrets.MyOauthRefresh}}"
     },
     "resource": {
       "type":"file",

--- a/connectors/google/google-drive/src/test/resources/requests/folder-success-test-cases.json
+++ b/connectors/google/google-drive/src/test/resources/requests/folder-success-test-cases.json
@@ -2,7 +2,7 @@
   {
     "authentication": {
       "authType": "bearer",
-      "bearerToken": "secrets.MyToken"
+      "bearerToken": "{{secrets.MyToken}}"
     },
     "resource": {
       "type":"folder",
@@ -16,9 +16,9 @@
   {
     "authentication": {
       "authType": "refresh",
-      "oauthClientId": "secrets.MyOauthClient",
-      "oauthClientSecret": "secrets.MyOauthSecret",
-      "oauthRefreshToken": "secrets.MyOauthRefresh"
+      "oauthClientId": "{{secrets.MyOauthClient}}",
+      "oauthClientSecret": "{{secrets.MyOauthSecret}}",
+      "oauthRefreshToken": "{{secrets.MyOauthRefresh}}"
     },
     "resource": {
       "type":"folder",

--- a/connectors/google/google-drive/src/test/resources/requests/request-fail-test-cases.json
+++ b/connectors/google/google-drive/src/test/resources/requests/request-fail-test-cases.json
@@ -84,8 +84,8 @@
     "testDescription": "File with refresh token without client id",
     "authentication": {
       "authType": "refresh",
-      "oauthClientSecret": "secrets.MyOauthSecret",
-      "oauthRefreshToken": "secrets.MyOauthRefresh"
+      "oauthClientSecret": "{{secrets.MyOauthSecret}}",
+      "oauthRefreshToken": "{{secrets.MyOauthRefresh}}"
     },
     "resource": {
       "type": "file",
@@ -115,8 +115,8 @@
     "testDescription": "File with refresh token without secret",
     "authentication": {
       "authType": "refresh",
-      "oauthClientId": "secrets.MyOauthClient",
-      "oauthRefreshToken": "secrets.MyOauthRefresh"
+      "oauthClientId": "{{secrets.MyOauthClient}}",
+      "oauthRefreshToken": "{{secrets.MyOauthRefresh}}"
     },
     "resource": {
       "type": "file",
@@ -146,8 +146,8 @@
     "testDescription": "File with refresh token without refresh token",
     "authentication": {
       "authType": "refresh",
-      "oauthClientId": "secrets.MyOauthClient",
-      "oauthClientSecret": "secrets.MyOauthSecret"
+      "oauthClientId": "{{secrets.MyOauthClient}}",
+      "oauthClientSecret": "{{secrets.MyOauthSecret}}"
     },
     "resource": {
       "type": "file",

--- a/connectors/google/google-drive/src/test/resources/requests/request-success-test-cases.json
+++ b/connectors/google/google-drive/src/test/resources/requests/request-success-test-cases.json
@@ -67,7 +67,7 @@
     "testDescription": "Bearer token given as secret",
     "authentication": {
       "authType": "bearer",
-      "bearerToken": "secrets.MyToken"
+      "bearerToken": "{{secrets.MyToken}}"
     },
     "resource": {
       "type":"file",
@@ -98,9 +98,9 @@
     "testDescription": "Refresh token given as secret",
     "authentication": {
       "authType": "refresh",
-      "oauthClientId": "secrets.MyOauthClient",
-      "oauthClientSecret": "secrets.MyOauthSecret",
-      "oauthRefreshToken": "secrets.MyOauthRefresh"
+      "oauthClientId": "{{secrets.MyOauthClient}}",
+      "oauthClientSecret": "{{secrets.MyOauthSecret}}",
+      "oauthRefreshToken": "{{secrets.MyOauthRefresh}}"
     },
     "resource": {
       "type":"file",

--- a/connectors/google/google-sheets/README.md
+++ b/connectors/google/google-sheets/README.md
@@ -18,11 +18,11 @@ mvn clean package
 {
   "authentication": {
     "authType": "bearer",
-    "bearerToken": "secrets.GDRIVE_BEARER"
+    "bearerToken": "{{secrets.GDRIVE_BEARER}}"
   },
   "operation": {
-    "spreadsheetName": "secrets.SPREADSHEET_NAME",
-    "parent": "secrets.PARENT_ID",
+    "spreadsheetName": "{{secrets.SPREADSHEET_NAME}}",
+    "parent": "{{secrets.PARENT_ID}}",
     "type": "createSpreadsheet"
   }
 }
@@ -34,13 +34,13 @@ mvn clean package
 {
   "authentication": {
     "authType": "refresh",
-    "oauthClientId": "secrets.GDRIVE_OAUTH_CLIENT_ID",
-    "oauthClientSecret": "secrets.GDRIVE_OAUTH_CLIENT_SECRET",
-    "oauthRefreshToken": "secrets.GDRIVE_OAUTH_REFRESH_TOKEN"
+    "oauthClientId": "{{secrets.GDRIVE_OAUTH_CLIENT_ID}}",
+    "oauthClientSecret": "{{secrets.GDRIVE_OAUTH_CLIENT_SECRET}}",
+    "oauthRefreshToken": "{{secrets.GDRIVE_OAUTH_REFRESH_TOKEN}}"
   },
   "operation": {
-    "spreadsheetName": "secrets.SPREADSHEET_NAME",
-    "parent": "secrets.PARENT_ID",
+    "spreadsheetName": "{{secrets.SPREADSHEET_NAME}}",
+    "parent": "{{secrets.PARENT_ID}}",
     "type": "createSpreadsheet"
   }
 }
@@ -63,11 +63,11 @@ mvn clean package
 {
   "authentication": {
     "authType": "bearer",
-    "bearerToken": "secrets.GDRIVE_BEARER"
+    "bearerToken": "{{secrets.GDRIVE_BEARER}}"
   },
   "operation": {
-    "worksheetName": "secrets.WORKSHEET_NAME",
-    "spreadsheetId": "secrets.SPREADSHEET_ID",
+    "worksheetName": "{{secrets.WORKSHEET_NAME}}",
+    "spreadsheetId": "{{secrets.SPREADSHEET_ID}}",
     "index": "0",
     "type": "createWorksheet"
   }
@@ -80,13 +80,13 @@ mvn clean package
 {
   "authentication": {
     "authType": "refresh",
-    "oauthClientId": "secrets.GDRIVE_OAUTH_CLIENT_ID",
-    "oauthClientSecret": "secrets.GDRIVE_OAUTH_CLIENT_SECRET",
-    "oauthRefreshToken": "secrets.GDRIVE_OAUTH_REFRESH_TOKEN"
+    "oauthClientId": "{{secrets.GDRIVE_OAUTH_CLIENT_ID}}",
+    "oauthClientSecret": "{{secrets.GDRIVE_OAUTH_CLIENT_SECRET}}",
+    "oauthRefreshToken": "{{secrets.GDRIVE_OAUTH_REFRESH_TOKEN}}"
   },
   "operation": {
-    "worksheetName": "secrets.WORKSHEET_NAME",
-    "spreadsheetId": "secrets.SPREADSHEET_ID",
+    "worksheetName": "{{secrets.WORKSHEET_NAME}}",
+    "spreadsheetId": "{{secrets.SPREADSHEET_ID}}",
     "index": "0",
     "type": "createWorksheet"
   }
@@ -111,10 +111,10 @@ mvn clean package
 {
   "authentication": {
     "authType": "bearer",
-    "bearerToken": "secrets.GDRIVE_BEARER"
+    "bearerToken": "{{secrets.GDRIVE_BEARER}}"
   },
   "operation": {
-    "spreadsheetId": "secrets.SPREADSHEET_ID",
+    "spreadsheetId": "{{secrets.SPREADSHEET_ID}}",
     "type": "spreadsheetsDetails"
   }
 }
@@ -126,12 +126,12 @@ mvn clean package
 {
   "authentication": {
     "authType": "refresh",
-    "oauthClientId": "secrets.GDRIVE_OAUTH_CLIENT_ID",
-    "oauthClientSecret": "secrets.GDRIVE_OAUTH_CLIENT_SECRET",
-    "oauthRefreshToken": "secrets.GDRIVE_OAUTH_REFRESH_TOKEN"
+    "oauthClientId": "{{secrets.GDRIVE_OAUTH_CLIENT_ID}}",
+    "oauthClientSecret": "{{secrets.GDRIVE_OAUTH_CLIENT_SECRET}}",
+    "oauthRefreshToken": "{{secrets.GDRIVE_OAUTH_REFRESH_TOKEN}}"
   },
   "operation": {
-    "spreadsheetId": "secrets.SPREADSHEET_ID",
+    "spreadsheetId": "{{secrets.SPREADSHEET_ID}}",
     "type": "spreadsheetsDetails"
   }
 }
@@ -281,11 +281,11 @@ mvn clean package
 {
   "authentication": {
     "authType": "bearer",
-    "bearerToken": "secrets.GDRIVE_BEARER"
+    "bearerToken": "{{secrets.GDRIVE_BEARER}}"
   },
   "operation": {
     "worksheetId": "0",
-    "spreadsheetId": "secrets.SPREADSHEET_ID",
+    "spreadsheetId": "{{secrets.SPREADSHEET_ID}}",
     "type": "deleteWorksheet"
   }
 }
@@ -297,13 +297,13 @@ mvn clean package
 {
   "authentication": {
     "authType": "refresh",
-    "oauthClientId": "secrets.GDRIVE_OAUTH_CLIENT_ID",
-    "oauthClientSecret": "secrets.GDRIVE_OAUTH_CLIENT_SECRET",
-    "oauthRefreshToken": "secrets.GDRIVE_OAUTH_REFRESH_TOKEN"
+    "oauthClientId": "{{secrets.GDRIVE_OAUTH_CLIENT_ID}}",
+    "oauthClientSecret": "{{secrets.GDRIVE_OAUTH_CLIENT_SECRET}}",
+    "oauthRefreshToken": "{{secrets.GDRIVE_OAUTH_REFRESH_TOKEN}}"
   },
   "operation": {
     "worksheetId": "0",
-    "spreadsheetId": "secrets.SPREADSHEET_ID",
+    "spreadsheetId": "{{secrets.SPREADSHEET_ID}}",
     "type": "deleteWorksheet"
   }
 }
@@ -327,14 +327,14 @@ mvn clean package
 {
   "authentication": {
     "authType": "bearer",
-    "bearerToken": "secrets.GDRIVE_BEARER"
+    "bearerToken": "{{secrets.GDRIVE_BEARER}}"
   },
   "operation": {
-    "worksheetName": "secrets.WORKSHEET_NAME",
-    "spreadsheetId": "secrets.SPREADSHEET_ID",
-    "cellId": "secrets.CELL_ID",
+    "worksheetName": "{{secrets.WORKSHEET_NAME}}",
+    "spreadsheetId": "{{secrets.SPREADSHEET_ID}}",
+    "cellId": "{{secrets.CELL_ID}}",
     "type": "addValues",
-    "value": " secrets.VALUE"
+    "value": "{{secrets.VALUE}}"
   }
 }
 ```
@@ -345,16 +345,16 @@ mvn clean package
 {
   "authentication": {
     "authType": "refresh",
-    "oauthClientId": "secrets.GDRIVE_OAUTH_CLIENT_ID",
-    "oauthClientSecret": "secrets.GDRIVE_OAUTH_CLIENT_SECRET",
-    "oauthRefreshToken": "secrets.GDRIVE_OAUTH_REFRESH_TOKEN"
+    "oauthClientId": "{{secrets.GDRIVE_OAUTH_CLIENT_ID}}",
+    "oauthClientSecret": "{{secrets.GDRIVE_OAUTH_CLIENT_SECRET}}",
+    "oauthRefreshToken": "{{secrets.GDRIVE_OAUTH_REFRESH_TOKEN}}"
   },
   "operation": {
-    "worksheetName": "secrets.WORKSHEET_NAME",
-    "spreadsheetId": "secrets.SPREADSHEET_ID",
-    "cellId": "secrets.WORKSHEET_ID",
+    "worksheetName": "{{secrets.WORKSHEET_NAME}}",
+    "spreadsheetId": "{{secrets.SPREADSHEET_ID}}",
+    "cellId": "{{secrets.WORKSHEET_ID}}",
     "type": "addValues",
-    "value": " secrets.VALUE"
+    "value": "{{secrets.VALUE}}"
   }
 }
 ```
@@ -377,10 +377,10 @@ mvn clean package
 {
   "authentication": {
     "authType": "bearer",
-    "bearerToken": "secrets.GDRIVE_BEARER"
+    "bearerToken": "{{secrets.GDRIVE_BEARER}}"
   },
   "operation": {
-    "spreadsheetId": "secrets.SPREADSHEET_ID",
+    "spreadsheetId": "{{secrets.SPREADSHEET_ID}}",
     "startIndex": null,
     "endIndex": null,
     "worksheetId": "0",
@@ -396,12 +396,12 @@ mvn clean package
 {
   "authentication": {
     "authType": "refresh",
-    "oauthClientId": "secrets.GDRIVE_OAUTH_CLIENT_ID",
-    "oauthClientSecret": "secrets.GDRIVE_OAUTH_CLIENT_SECRET",
-    "oauthRefreshToken": "secrets.GDRIVE_OAUTH_REFRESH_TOKEN"
+    "oauthClientId": "{{secrets.GDRIVE_OAUTH_CLIENT_ID}}",
+    "oauthClientSecret": "{{secrets.GDRIVE_OAUTH_CLIENT_SECRET}}",
+    "oauthRefreshToken": "{{secrets.GDRIVE_OAUTH_REFRESH_TOKEN}}"
   },
   "operation": {
-    "spreadsheetId": "secrets.SPREADSHEET_ID",
+    "spreadsheetId": "{{secrets.SPREADSHEET_ID}}",
     "startIndex": "",
     "endIndex": "",
     "worksheetId": "0",
@@ -430,13 +430,13 @@ mvn clean package
 {
   "authentication": {
     "authType": "bearer",
-    "bearerToken": "secrets.GDRIVE_BEARER"
+    "bearerToken": "{{secrets.GDRIVE_BEARER}}"
   },
   "operation": {
-    "values": ["secrets.ROW"],
+    "values": ["{{secrets.ROW"],
     "rowIndex": "1",
-    "spreadsheetId": "secrets.SPREADSHEET_ID",
-    "worksheetName": "secrets.WORKSHEET_NAME",
+    "spreadsheetId": "{{secrets.SPREADSHEET_ID}}",
+    "worksheetName": "{{secrets.WORKSHEET_NAME}}",
     "type": "createRow"
   }
 }
@@ -448,15 +448,15 @@ mvn clean package
 {
   "authentication": {
     "authType": "refresh",
-    "oauthClientId": "secrets.GDRIVE_OAUTH_CLIENT_ID",
-    "oauthClientSecret": "secrets.GDRIVE_OAUTH_CLIENT_SECRET",
-    "oauthRefreshToken": "secrets.GDRIVE_OAUTH_REFRESH_TOKEN"
+    "oauthClientId": "{{secrets.GDRIVE_OAUTH_CLIENT_ID}}",
+    "oauthClientSecret": "{{secrets.GDRIVE_OAUTH_CLIENT_SECRET}}",
+    "oauthRefreshToken": "{{secrets.GDRIVE_OAUTH_REFRESH_TOKEN}}"
   },
   "operation": {
-    "values": ["secrets.ROW"],
+    "values": ["{{secrets.ROW"],
     "rowIndex": "1",
-    "spreadsheetId": "secrets.SPREADSHEET_ID",
-    "worksheetName": "secrets.WORKSHEET_NAME",
+    "spreadsheetId": "{{secrets.SPREADSHEET_ID}}",
+    "worksheetName": "{{secrets.WORKSHEET_NAME}}",
     "type": "createRow"
   }
 }
@@ -481,10 +481,10 @@ mvn clean package
 {
   "authentication": {
     "authType": "bearer",
-    "bearerToken": "secrets.GDRIVE_BEARER"
+    "bearerToken": "{{secrets.GDRIVE_BEARER}}"
   },
   "operation": {
-    "spreadsheetId": "secrets.SPREADSHEET_ID",
+    "spreadsheetId": "{{secrets.SPREADSHEET_ID}}",
     "columnIndexType": "NUMBERS",
     "worksheetId": "0",
     "type": "deleteColumn",
@@ -499,12 +499,12 @@ mvn clean package
 {
   "authentication": {
     "authType": "refresh",
-    "oauthClientId": "secrets.GDRIVE_OAUTH_CLIENT_ID",
-    "oauthClientSecret": "secrets.GDRIVE_OAUTH_CLIENT_SECRET",
-    "oauthRefreshToken": "secrets.GDRIVE_OAUTH_REFRESH_TOKEN"
+    "oauthClientId": "{{secrets.GDRIVE_OAUTH_CLIENT_ID}}",
+    "oauthClientSecret": "{{secrets.GDRIVE_OAUTH_CLIENT_SECRET}}",
+    "oauthRefreshToken": "{{secrets.GDRIVE_OAUTH_REFRESH_TOKEN}}"
   },
   "operation": {
-    "spreadsheetId": "secrets.SPREADSHEET_ID",
+    "spreadsheetId": "{{secrets.SPREADSHEET_ID}}",
     "columnIndexType": "NUMBERS",
     "worksheetId": "0",
     "type": "deleteColumn",
@@ -519,11 +519,11 @@ mvn clean package
 {
   "authentication": {
     "authType": "bearer",
-    "bearerToken": "secrets.GDRIVE_BEARER"
+    "bearerToken": "{{secrets.GDRIVE_BEARER}}"
   },
   "operation": {
     "columnLetterIndex": "A",
-    "spreadsheetId": "secrets.SPREADSHEET_ID",
+    "spreadsheetId": "{{secrets.SPREADSHEET_ID}}",
     "columnIndexType": "LETTERS",
     "worksheetId": "0",
     "type": "deleteColumn"
@@ -537,13 +537,13 @@ mvn clean package
 {
   "authentication": {
     "authType": "refresh",
-    "oauthClientId": "secrets.GDRIVE_OAUTH_CLIENT_ID",
-    "oauthClientSecret": "secrets.GDRIVE_OAUTH_CLIENT_SECRET",
-    "oauthRefreshToken": "secrets.GDRIVE_OAUTH_REFRESH_TOKEN"
+    "oauthClientId": "{{secrets.GDRIVE_OAUTH_CLIENT_ID}}",
+    "oauthClientSecret": "{{secrets.GDRIVE_OAUTH_CLIENT_SECRET}}",
+    "oauthRefreshToken": "{{secrets.GDRIVE_OAUTH_REFRESH_TOKEN}}"
   },
   "operation": {
     "columnLetterIndex": "A",
-    "spreadsheetId": "secrets.SPREADSHEET_ID",
+    "spreadsheetId": "{{secrets.SPREADSHEET_ID}}",
     "columnIndexType": "LETTERS",
     "worksheetId": "0",
     "type": "deleteColumn"
@@ -568,12 +568,12 @@ mvn clean package
 {
   "authentication": {
     "authType": "bearer",
-    "bearerToken": "secrets.GDRIVE_BEARER"
+    "bearerToken": "{{secrets.GDRIVE_BEARER}}"
   },
   "operation": {
     "rowIndex": "1",
-    "spreadsheetId": "secrets.SPREADSHEET_ID",
-    "worksheetName": "secrets.WORKSHEET_NAME",
+    "spreadsheetId": "{{secrets.SPREADSHEET_ID}}",
+    "worksheetName": "{{secrets.WORKSHEET_NAME}}",
     "type": "getRowByIndex"
   }
 }
@@ -585,14 +585,14 @@ mvn clean package
 {
   "authentication": {
     "authType": "refresh",
-    "oauthClientId": "secrets.GDRIVE_OAUTH_CLIENT_ID",
-    "oauthClientSecret": "secrets.GDRIVE_OAUTH_CLIENT_SECRET",
-    "oauthRefreshToken": "secrets.GDRIVE_OAUTH_REFRESH_TOKEN"
+    "oauthClientId": "{{secrets.GDRIVE_OAUTH_CLIENT_ID}}",
+    "oauthClientSecret": "{{secrets.GDRIVE_OAUTH_CLIENT_SECRET}}",
+    "oauthRefreshToken": "{{secrets.GDRIVE_OAUTH_REFRESH_TOKEN}}"
   },
   "operation":  {
     "rowIndex": "1",
-    "spreadsheetId": "secrets.SPREADSHEET_ID",
-    "worksheetName": "secrets.WORKSHEET_NAME",
+    "spreadsheetId": "{{secrets.SPREADSHEET_ID}}",
+    "worksheetName": "{{secrets.WORKSHEET_NAME}}",
     "type": "getRowByIndex"
   }
 }
@@ -616,11 +616,11 @@ mvn clean package
 {
   "authentication": {
     "authType": "bearer",
-    "bearerToken": "secrets.GDRIVE_BEARER"
+    "bearerToken": "{{secrets.GDRIVE_BEARER}}"
   },
   "operation":  {
-    "worksheetName": "secrets.WORKSHEET_NAME",
-    "spreadsheetId": "secrets.SPREADSHEET_ID",
+    "worksheetName": "{{secrets.WORKSHEET_NAME}}",
+    "spreadsheetId": "{{secrets.SPREADSHEET_ID}}",
     "type": "getWorksheetData"
   }
 }
@@ -632,13 +632,13 @@ mvn clean package
 {
   "authentication": {
     "authType": "refresh",
-    "oauthClientId": "secrets.GDRIVE_OAUTH_CLIENT_ID",
-    "oauthClientSecret": "secrets.GDRIVE_OAUTH_CLIENT_SECRET",
-    "oauthRefreshToken": "secrets.GDRIVE_OAUTH_REFRESH_TOKEN"
+    "oauthClientId": "{{secrets.GDRIVE_OAUTH_CLIENT_ID}}",
+    "oauthClientSecret": "{{secrets.GDRIVE_OAUTH_CLIENT_SECRET}}",
+    "oauthRefreshToken": "{{secrets.GDRIVE_OAUTH_REFRESH_TOKEN}}"
   },
   "operation":  {
-    "worksheetName": "secrets.WORKSHEET_ID",
-    "spreadsheetId": "secrets.SPREADSHEET_ID",
+    "worksheetName": "{{secrets.WORKSHEET_ID}}",
+    "spreadsheetId": "{{secrets.SPREADSHEET_ID}}",
     "type": "getWorksheetData"
   }
 }

--- a/connectors/google/google-sheets/src/test/resources/requests/request-fail-test-cases.json
+++ b/connectors/google/google-sheets/src/test/resources/requests/request-fail-test-cases.json
@@ -3,7 +3,7 @@
     "testDescription": "Request without a token",
     "operation":{
       "spreadsheetName":"newSpreadsheet",
-      "parent":"secrets.PARENT_ID",
+      "parent":"{{secrets.PARENT_ID}}",
       "type":"createSpreadsheet"
     }
   },
@@ -11,12 +11,12 @@
     "testDescription": "Request with refresh token without client id",
     "authentication": {
       "authType": "refresh",
-      "oauthClientSecret": "secrets.MyOauthSecret",
-      "oauthRefreshToken": "secrets.MyOauthRefresh"
+      "oauthClientSecret": "{{secrets.MyOauthSecret}}",
+      "oauthRefreshToken": "{{secrets.MyOauthRefresh}}"
     },
     "operation":{
       "spreadsheetName":"newSpreadsheet",
-      "parent":"secrets.PARENT_ID",
+      "parent":"{{secrets.PARENT_ID}}",
       "type":"createSpreadsheet"
     }
   },
@@ -24,12 +24,12 @@
     "testDescription": "Request with refresh token without secret",
     "authentication": {
       "authType": "refresh",
-      "oauthClientId": "secrets.MyOauthClient",
-      "oauthRefreshToken": "secrets.MyOauthRefresh"
+      "oauthClientId": "{{secrets.MyOauthClient}}",
+      "oauthRefreshToken": "{{secrets.MyOauthRefresh}}"
     },
     "operation":{
       "spreadsheetName":"newSpreadsheet",
-      "parent":"secrets.PARENT_ID",
+      "parent":"{{secrets.PARENT_ID}}",
       "type":"createSpreadsheet"
     }
   },
@@ -37,12 +37,12 @@
     "testDescription": "Request with refresh token without refresh token",
     "authentication": {
       "authType": "refresh",
-      "oauthClientId": "secrets.MyOauthClient",
-      "oauthClientSecret": "secrets.MyOauthSecret"
+      "oauthClientId": "{{secrets.MyOauthClient}}",
+      "oauthClientSecret": "{{secrets.MyOauthSecret}}"
     },
     "operation":{
       "spreadsheetName":"newSpreadsheet",
-      "parent":"secrets.PARENT_ID",
+      "parent":"{{secrets.PARENT_ID}}",
       "type":"createSpreadsheet"
     }
   },
@@ -53,7 +53,7 @@
       "bearerToken": "MyRealToken"
     },
     "operation":{
-      "parent":"secrets.PARENT_ID",
+      "parent":"{{secrets.PARENT_ID}}",
       "type":"createSpreadsheet"
     }
   },

--- a/connectors/google/google-sheets/src/test/resources/requests/request-success-test-cases.json
+++ b/connectors/google/google-sheets/src/test/resources/requests/request-success-test-cases.json
@@ -6,8 +6,8 @@
       "bearerToken": "MyRealToken"
     },
     "operation":{
-      "spreadsheetName":"secrets.SPREADSHEET_NAME",
-      "parent":"secrets.PARENT_ID",
+      "spreadsheetName":"{{secrets.SPREADSHEET_NAME}}",
+      "parent":"{{secrets.PARENT_ID}}",
       "type":"createSpreadsheet"
     }
   },
@@ -20,8 +20,8 @@
       "oauthRefreshToken": "MyRealRefreshTokenValue"
     },
     "operation":{
-      "spreadsheetName":"secrets.SPREADSHEET_NAME",
-      "parent":"secrets.PARENT_ID",
+      "spreadsheetName":"{{secrets.SPREADSHEET_NAME}}",
+      "parent":"{{secrets.PARENT_ID}}",
       "type":"createSpreadsheet"
     }
   },
@@ -29,11 +29,11 @@
     "testDescription": "Bearer token given as secret",
     "authentication": {
       "authType": "bearer",
-      "bearerToken": "secrets.MyToken"
+      "bearerToken": "{{secrets.MyToken}}"
     },
     "operation":{
-      "spreadsheetName":"secrets.SPREADSHEET_NAME",
-      "parent":"secrets.PARENT_ID",
+      "spreadsheetName":"{{secrets.SPREADSHEET_NAME}}",
+      "parent":"{{secrets.PARENT_ID}}",
       "type":"createSpreadsheet"
     }
   },
@@ -41,13 +41,13 @@
     "testDescription": "Refresh token given as secret",
     "authentication": {
       "authType": "refresh",
-      "oauthClientId": "secrets.MyOauthClient",
-      "oauthClientSecret": "secrets.MyOauthSecret",
-      "oauthRefreshToken": "secrets.MyOauthRefresh"
+      "oauthClientId": "{{secrets.MyOauthClient}}",
+      "oauthClientSecret": "{{secrets.MyOauthSecret}}",
+      "oauthRefreshToken": "{{secrets.MyOauthRefresh}}"
     },
     "operation":{
-      "spreadsheetName":"secrets.SPREADSHEET_NAME",
-      "parent":"secrets.PARENT_ID",
+      "spreadsheetName":"{{secrets.SPREADSHEET_NAME}}",
+      "parent":"{{secrets.PARENT_ID}}",
       "type":"createSpreadsheet"
     }
   },
@@ -55,11 +55,11 @@
     "testDescription": "Create spreadsheet with a parent folder",
     "authentication": {
       "authType": "bearer",
-      "bearerToken": "secrets.MyToken"
+      "bearerToken": "{{secrets.MyToken}}"
     },
     "operation":{
-      "spreadsheetName":"secrets.SPREADSHEET_NAME",
-      "parent":"secrets.PARENT_ID",
+      "spreadsheetName":"{{secrets.SPREADSHEET_NAME}}",
+      "parent":"{{secrets.PARENT_ID}}",
       "type":"createSpreadsheet"
     }
   },
@@ -67,11 +67,11 @@
     "testDescription": "Create worksheet",
     "authentication": {
       "authType": "bearer",
-      "bearerToken": "secrets.MyToken"
+      "bearerToken": "{{secrets.MyToken}}"
     },
     "operation": {
-      "worksheetName": "secrets.WORKSHEET_NAME",
-      "spreadsheetId": "secrets.SPREADSHEET_ID",
+      "worksheetName": "{{secrets.WORKSHEET_NAME}}",
+      "spreadsheetId": "{{secrets.SPREADSHEET_ID}}",
       "index": "0",
       "type": "createWorksheet"
     }
@@ -80,10 +80,10 @@
     "testDescription": "Get spreadsheet details",
     "authentication": {
       "authType": "bearer",
-      "bearerToken": "secrets.MyToken"
+      "bearerToken": "{{secrets.MyToken}}"
     },
     "operation": {
-      "spreadsheetId": "secrets.SPREADSHEET_ID",
+      "spreadsheetId": "{{secrets.SPREADSHEET_ID}}",
       "type": "spreadsheetsDetails"
     }
   },
@@ -91,11 +91,11 @@
     "testDescription": "Delete worksheet",
     "authentication": {
       "authType": "bearer",
-      "bearerToken": "secrets.MyToken"
+      "bearerToken": "{{secrets.MyToken}}"
     },
     "operation": {
       "worksheetId": "0",
-      "spreadsheetId": "secrets.SPREADSHEET_ID",
+      "spreadsheetId": "{{secrets.SPREADSHEET_ID}}",
       "type": "deleteWorksheet"
     }
   },
@@ -103,24 +103,24 @@
     "testDescription": "Add values to Spreadsheet",
     "authentication": {
       "authType": "bearer",
-      "bearerToken": "secrets.MyToken"
+      "bearerToken": "{{secrets.MyToken}}"
     },
     "operation": {
-      "worksheetName": "secrets.WORKSHEET_NAME",
-      "spreadsheetId": "secrets.SPREADSHEET_ID",
-      "cellId": "secrets.CELL_ID",
+      "worksheetName": "{{secrets.WORKSHEET_NAME}}",
+      "spreadsheetId": "{{secrets.SPREADSHEET_ID}}",
+      "cellId": "{{secrets.CELL_ID}}",
       "type": "addValues",
-      "value": "secrets.VALUE"
+      "value": "{{secrets.VALUE}}"
     }
   },
   {
     "testDescription": "Create empty column or row",
     "authentication": {
       "authType": "bearer",
-      "bearerToken": "secrets.MyToken"
+      "bearerToken": "{{secrets.MyToken}}"
     },
     "operation": {
-      "spreadsheetId": "secrets.SPREADSHEET_ID",
+      "spreadsheetId": "{{secrets.SPREADSHEET_ID}}",
       "startIndex": null,
       "endIndex": null,
       "worksheetId": "0",
@@ -132,13 +132,13 @@
     "testDescription": "Create row",
     "authentication": {
       "authType": "bearer",
-      "bearerToken": "secrets.MyToken"
+      "bearerToken": "{{secrets.MyToken}}"
     },
     "operation": {
-      "values": ["secrets.ROW"],
+      "values": ["{{secrets.ROW}}"],
       "rowIndex": "1",
-      "spreadsheetId": "secrets.SPREADSHEET_ID",
-      "worksheetName": "secrets.WORKSHEET_NAME",
+      "spreadsheetId": "{{secrets.SPREADSHEET_ID}}",
+      "worksheetName": "{{secrets.WORKSHEET_NAME}}",
       "type": "createRow"
     }
   },
@@ -146,10 +146,10 @@
     "testDescription": "Delete column by index as number",
     "authentication": {
       "authType": "bearer",
-      "bearerToken": "secrets.MyToken"
+      "bearerToken": "{{secrets.MyToken}}"
     },
     "operation": {
-      "spreadsheetId": "secrets.SPREADSHEET_ID",
+      "spreadsheetId": "{{secrets.SPREADSHEET_ID}}",
       "columnIndexType": "NUMBERS",
       "worksheetId": "0",
       "type": "deleteColumn",
@@ -160,11 +160,11 @@
     "testDescription": "Delete column by index as letters",
     "authentication": {
       "authType": "bearer",
-      "bearerToken": "secrets.MyToken"
+      "bearerToken": "{{secrets.MyToken}}"
     },
     "operation": {
       "columnLetterIndex": "A",
-      "spreadsheetId": "secrets.SPREADSHEET_ID",
+      "spreadsheetId": "{{secrets.SPREADSHEET_ID}}",
       "columnIndexType": "LETTERS",
       "worksheetId": "0",
       "type": "deleteColumn"
@@ -174,12 +174,12 @@
     "testDescription": "Get row by index",
     "authentication": {
       "authType": "bearer",
-      "bearerToken": "secrets.MyToken"
+      "bearerToken": "{{secrets.MyToken}}"
     },
     "operation": {
       "rowIndex": "1",
-      "spreadsheetId": "secrets.SPREADSHEET_ID",
-      "worksheetName": "secrets.WORKSHEET_NAME",
+      "spreadsheetId": "{{secrets.SPREADSHEET_ID}}",
+      "worksheetName": "{{secrets.WORKSHEET_NAME}}",
       "type": "getRowByIndex"
     }
   },
@@ -187,11 +187,11 @@
     "testDescription": "Get worksheet data",
     "authentication": {
       "authType": "bearer",
-      "bearerToken": "secrets.MyToken"
+      "bearerToken": "{{secrets.MyToken}}"
     },
     "operation":  {
-      "worksheetName": "secrets.WORKSHEET_NAME",
-      "spreadsheetId": "secrets.SPREADSHEET_ID",
+      "worksheetName": "{{secrets.WORKSHEET_NAME}}",
+      "spreadsheetId": "{{secrets.SPREADSHEET_ID}}",
       "type": "getWorksheetData"
     }
   }

--- a/connectors/graphql/README.md
+++ b/connectors/graphql/README.md
@@ -56,8 +56,8 @@ The response will contain the status code, the headers and the body of the respo
   "url": "https://httpbin.org/basic-auth/user/password",
   "authentication": {
     "type": "basic",
-    "username": "secrets.USERNAME",
-    "password": "secrets.PASSWORD"
+    "username": "{{secrets.USERNAME}}",
+    "password": "{{secrets.PASSWORD}}"
   }
 }
 ```
@@ -70,7 +70,7 @@ The response will contain the status code, the headers and the body of the respo
   "url": "https://httpbin.org/bearer",
   "authentication": {
     "type": "bearer",
-    "token": "secrets.TOKEN"
+    "token": "{{secrets.TOKEN}}"
   }
 }
 ```
@@ -82,13 +82,13 @@ The response will contain the status code, the headers and the body of the respo
   "method": "post",
   "url": "https://youroauthclientdomainname.eu.auth0.com/oauth/token",
   "authentication": {
-    "oauthTokenEndpoint":"secrets.OAUTH_TOKEN_ENDPOINT_KEY",
+    "oauthTokenEndpoint":"{{secrets.OAUTH_TOKEN_ENDPOINT_KEY}}",
     "scopes": "read:clients read:users",
-    "audience":"secrets.AUDIENCE_KEY",
-    "clientId":"secrets.CLIENT_ID_KEY",
-    "clientSecret":"secrets.CLIENT_SECRET_KEY",
+    "audience":"{{secrets.AUDIENCE_KEY}}",
+    "clientId":"{{secrets.CLIENT_ID_KEY}}",
+    "clientSecret":"{{secrets.CLIENT_SECRET_KEY}}",
     "type": "oauth-client-credentials-flow",
-    "clientAuthentication":"secrets.CLIENT_AUTHENTICATION_KEY"
+    "clientAuthentication":"{{secrets.CLIENT_AUTHENTICATION_KEY}}"
   }
 }
 ```

--- a/connectors/graphql/src/test/resources/requests/fail-cases-connection-timeout-validation.json
+++ b/connectors/graphql/src/test/resources/requests/fail-cases-connection-timeout-validation.json
@@ -51,7 +51,7 @@
       "connectionTimeoutInSeconds": "1.56",
       "authentication": {
         "type": "bearer",
-        "token": "secrets.TOKEN_KEY"
+        "token": "{{secrets.TOKEN_KEY}}"
       }
     }
   },
@@ -85,7 +85,7 @@
       "connectionTimeoutInSeconds": "0b0011",
       "authentication": {
         "type": "bearer",
-        "token": "secrets.TOKEN_KEY"
+        "token": "{{secrets.TOKEN_KEY}}"
       }
     }
   },
@@ -94,7 +94,7 @@
     "graphql": {
       "method": "get",
       "url": "https://camunda.io/http-endpoint",
-      "connectionTimeoutInSeconds": "bad secrets.TOKEN_KEY value"
+      "connectionTimeoutInSeconds": "bad secrets.TOKEN_KEY value}}"
     },
     "authentication": {
       "type": "noAuth"

--- a/connectors/graphql/src/test/resources/requests/fail-cases-request-without-one-required-field.json
+++ b/connectors/graphql/src/test/resources/requests/fail-cases-request-without-one-required-field.json
@@ -101,7 +101,7 @@
       "oauthTokenEndpoint":"https://abc.eu.auth0.com/api/v2/",
       "scopes": "read:clients",
       "audience":"https://abc.eu.auth0.com/api/v2/",
-      "clientSecret":"secrets.CLIENT_SECRET_KEY",
+      "clientSecret":"{{secrets.CLIENT_SECRET_KEY}}",
       "type":"oauth-client-credentials-flow",
       "clientAuthentication":"basicAuthHeader"
     },
@@ -121,7 +121,7 @@
       "oauthTokenEndpoint":"https://abc.eu.auth0.com/api/v2/",
       "scopes": "read:clients",
       "audience":"https://abc.eu.auth0.com/api/v2/",
-      "clientId":"secrets.CLIENT_ID_KEY",
+      "clientId":"{{secrets.CLIENT_ID_KEY}}",
       "type":"oauth-client-credentials-flow",
       "clientAuthentication":"basicAuthHeader"
     },
@@ -140,8 +140,8 @@
     "authentication":{
       "scopes": "read:clients",
       "audience":"https://abc.eu.auth0.com/api/v2/",
-      "clientId":"secrets.CLIENT_ID_KEY",
-      "clientSecret":"secrets.CLIENT_SECRET_KEY",
+      "clientId":"{{secrets.CLIENT_ID_KEY}}",
+      "clientSecret":"{{secrets.CLIENT_SECRET_KEY}}",
       "type":"oauth-client-credentials-flow",
       "clientAuthentication":"basicAuthHeader"
     },
@@ -161,8 +161,8 @@
       "oauthTokenEndpoint":"https://abc.eu.auth0.com/api/v2/",
       "scopes": "read:clients",
       "audience":"https://abc.eu.auth0.com/api/v2/",
-      "clientId":"secrets.CLIENT_ID_KEY",
-      "clientSecret":"secrets.CLIENT_SECRET_KEY",
+      "clientId":"{{secrets.CLIENT_ID_KEY}}",
+      "clientSecret":"{{secrets.CLIENT_SECRET_KEY}}",
       "type":"oauth-client-credentials-flow"
     },
     "graphql": {

--- a/connectors/graphql/src/test/resources/requests/success-cases-connection-timeout-validation.json
+++ b/connectors/graphql/src/test/resources/requests/success-cases-connection-timeout-validation.json
@@ -21,7 +21,7 @@
     },
     "authentication": {
       "type": "bearer",
-      "token": "secrets.TOKEN_KEY"
+      "token": "{{secrets.TOKEN_KEY}}"
     }
   },
   {
@@ -34,7 +34,7 @@
     },
     "authentication": {
       "type": "bearer",
-      "token": "secrets.TOKEN_KEY"
+      "token": "{{secrets.TOKEN_KEY}}"
     }
   },
   {
@@ -43,11 +43,11 @@
       "method": "get",
       "url": "https://camunda.io/http-endpoint",
       "query": "query Root($id: ID) {\n  person (id: $id) {\n    id\n    name\n  }\n}",
-      "connectionTimeoutInSeconds": "secrets.CONNECT_TIMEOUT_KEY"
+      "connectionTimeoutInSeconds": "{{secrets.CONNECT_TIMEOUT_KEY}}"
     },
     "authentication": {
       "type": "bearer",
-      "token": "secrets.TOKEN_KEY"
+      "token": "{{secrets.TOKEN_KEY}}"
     }
   }
 ]

--- a/connectors/graphql/src/test/resources/requests/success-cases-replace-secrets.json
+++ b/connectors/graphql/src/test/resources/requests/success-cases-replace-secrets.json
@@ -1,9 +1,9 @@
 [
   {
     "graphql": {
-      "url": "secrets.URL_KEY",
-      "method": "secrets.METHOD_KEY",
-      "connectionTimeoutInSeconds":"secrets.CONNECT_TIMEOUT_KEY",
+      "url": "{{secrets.URL_KEY}}",
+      "method": "{{secrets.METHOD_KEY}}",
+      "connectionTimeoutInSeconds":"{{secrets.CONNECT_TIMEOUT_KEY}}",
       "query": "query Root($id: {{secrets.QUERY_ID}}) {\n  person (id: $id) {\n    id\n    name\n  }\n}",
       "variables": {
         "id": "{{secrets.VARIABLE_ID}}"
@@ -15,9 +15,9 @@
   },
   {
     "graphql": {
-      "url": "secrets.URL_KEY",
-      "method": "secrets.METHOD_KEY",
-      "connectionTimeoutInSeconds":"secrets.CONNECT_TIMEOUT_KEY",
+      "url": "{{secrets.URL_KEY}}",
+      "method": "{{secrets.METHOD_KEY}}",
+      "connectionTimeoutInSeconds":"{{secrets.CONNECT_TIMEOUT_KEY}}",
       "query": "query Root($id: {{secrets.QUERY_ID}}) {\n  person (id: $id) {\n    id\n    name\n  }\n}",
       "variables": {
         "id": "{{secrets.VARIABLE_ID}}"
@@ -25,14 +25,14 @@
     },
     "authentication": {
       "type": "bearer",
-      "token": "secrets.TOKEN_KEY"
+      "token": "{{secrets.TOKEN_KEY}}"
     }
   },
   {
     "graphql": {
-      "url": "secrets.URL_KEY",
-      "method": "secrets.METHOD_KEY",
-      "connectionTimeoutInSeconds":"secrets.CONNECT_TIMEOUT_KEY",
+      "url": "{{secrets.URL_KEY}}",
+      "method": "{{secrets.METHOD_KEY}}",
+      "connectionTimeoutInSeconds":"{{secrets.CONNECT_TIMEOUT_KEY}}",
       "query": "query Root($id: {{secrets.QUERY_ID}}) {\n  person (id: $id) {\n    id\n    name\n  }\n}",
       "variables": {
         "id": "{{secrets.VARIABLE_ID}}"
@@ -40,28 +40,28 @@
     },
     "authentication": {
       "type": "basic",
-      "password": "secrets.PASSWORD_KEY",
-      "username": "secrets.USERNAME_KEY"
+      "password": "{{secrets.PASSWORD_KEY}}",
+      "username": "{{secrets.USERNAME_KEY}}"
     }
   },
   {
     "graphql": {
-      "url": "secrets.URL_KEY",
-      "method": "secrets.METHOD_KEY",
-      "connectionTimeoutInSeconds":"secrets.CONNECT_TIMEOUT_KEY",
+      "url": "{{secrets.URL_KEY}}",
+      "method": "{{secrets.METHOD_KEY}}",
+      "connectionTimeoutInSeconds":"{{secrets.CONNECT_TIMEOUT_KEY}}",
       "query": "query Root($id: {{secrets.QUERY_ID}}) {\n  person (id: $id) {\n    id\n    name\n  }\n}",
       "variables": {
         "id": "{{secrets.VARIABLE_ID}}"
       }
     },
     "authentication": {
-      "oauthTokenEndpoint":"secrets.OAUTH_TOKEN_ENDPOINT_KEY",
+      "oauthTokenEndpoint":"{{secrets.OAUTH_TOKEN_ENDPOINT_KEY}}",
       "scopes": "test",
-      "audience":"secrets.AUDIENCE_KEY",
-      "clientId":"secrets.CLIENT_ID_KEY",
-      "clientSecret":"secrets.CLIENT_SECRET_KEY",
+      "audience":"{{secrets.AUDIENCE_KEY}}",
+      "clientId":"{{secrets.CLIENT_ID_KEY}}",
+      "clientSecret":"{{secrets.CLIENT_SECRET_KEY}}",
       "type": "oauth-client-credentials-flow",
-      "clientAuthentication":"secrets.CLIENT_AUTHENTICATION_KEY"
+      "clientAuthentication":"{{secrets.CLIENT_AUTHENTICATION_KEY}}"
     }
   }
 ]

--- a/connectors/graphql/src/test/resources/requests/success-test-cases-oauth.json
+++ b/connectors/graphql/src/test/resources/requests/success-test-cases-oauth.json
@@ -4,8 +4,8 @@
     "oauthTokenEndpoint":"https://dev-test.eu.auth0.com/api/v2/",
     "scopes": "read:clients",
     "audience":"https://dev-test.eu.auth0.com/api/v2/",
-    "clientId":"secrets.CLIENT_ID_KEY",
-    "clientSecret":"secrets.CLIENT_SECRET_KEY",
+    "clientId":"{{secrets.CLIENT_ID_KEY}}",
+    "clientSecret":"{{secrets.CLIENT_SECRET_KEY}}",
     "type":"oauth-client-credentials-flow",
     "clientAuthentication":"basicAuthHeader"
   },

--- a/connectors/graphql/src/test/resources/requests/success-test-cases.json
+++ b/connectors/graphql/src/test/resources/requests/success-test-cases.json
@@ -30,7 +30,7 @@
     "descriptionOfTest": "Normal request with bearer auth",
     "authentication": {
       "type": "bearer",
-      "token": "secrets.MY_TOKEN"
+      "token": "{{secrets.MY_TOKEN}}"
     },
     "graphql": {
       "method": "get",
@@ -46,7 +46,7 @@
     "descriptionOfTest": "Normal request with no variables",
     "authentication": {
       "type": "bearer",
-      "token": "secrets.MY_TOKEN"
+      "token": "{{secrets.MY_TOKEN}}"
     },
     "graphql": {
       "method": "get",
@@ -59,7 +59,7 @@
     "descriptionOfTest": "Normal request with empty variables",
     "authentication": {
       "type": "bearer",
-      "token": "secrets.MY_TOKEN"
+      "token": "{{secrets.MY_TOKEN}}"
     },
     "graphql": {
       "method": "get",
@@ -73,7 +73,7 @@
     "descriptionOfTest": "Normal request with connectionTimeoutInSeconds",
     "authentication": {
       "type": "bearer",
-      "token": "secrets.MY_TOKEN"
+      "token": "{{secrets.MY_TOKEN}}"
     },
     "graphql": {
       "method": "get",

--- a/connectors/http-json/README.md
+++ b/connectors/http-json/README.md
@@ -87,8 +87,8 @@ The response will contain the status code, the headers and the body of the respo
   "url": "https://httpbin.org/basic-auth/user/password",
   "authentication": {
     "type": "basic",
-    "username": "secrets.USERNAME",
-    "password": "secrets.PASSWORD"
+    "username": "{{secrets.USERNAME}}",
+    "password": "{{secrets.PASSWORD}}"
   }
 }
 ```
@@ -101,7 +101,7 @@ The response will contain the status code, the headers and the body of the respo
   "url": "https://httpbin.org/bearer",
   "authentication": {
     "type": "bearer",
-    "token": "secrets.TOKEN"
+    "token": "{{secrets.TOKEN}}"
   }
 }
 ```
@@ -113,13 +113,13 @@ The response will contain the status code, the headers and the body of the respo
   "method": "post",
   "url": "https://youroauthclientdomainname.eu.auth0.com/oauth/token",
   "authentication": {
-    "oauthTokenEndpoint":"secrets.OAUTH_TOKEN_ENDPOINT_KEY",
+    "oauthTokenEndpoint":"{{secrets.OAUTH_TOKEN_ENDPOINT_KEY}}",
     "scopes": "read:clients read:users",
-    "audience":"secrets.AUDIENCE_KEY",
-    "clientId":"secrets.CLIENT_ID_KEY",
-    "clientSecret":"secrets.CLIENT_SECRET_KEY",
+    "audience":"{{secrets.AUDIENCE_KEY}}",
+    "clientId":"{{secrets.CLIENT_ID_KEY}}",
+    "clientSecret":"{{secrets.CLIENT_SECRET_KEY}}",
     "type": "oauth-client-credentials-flow",
-    "clientAuthentication":"secrets.CLIENT_AUTHENTICATION_KEY"
+    "clientAuthentication":"{{secrets.CLIENT_AUTHENTICATION_KEY}}"
   }
 }
 ```

--- a/connectors/http-json/src/test/resources/requests/fail-cases-connection-timeout-validation.json
+++ b/connectors/http-json/src/test/resources/requests/fail-cases-connection-timeout-validation.json
@@ -42,7 +42,7 @@
     "connectionTimeoutInSeconds": "1.56",
     "authentication": {
       "type": "bearer",
-      "token": "secrets.TOKEN_KEY"
+      "token": "{{secrets.TOKEN_KEY}}"
     }
   },
   {
@@ -70,7 +70,7 @@
     "connectionTimeoutInSeconds": "0b0011",
     "authentication": {
       "type": "bearer",
-      "token": "secrets.TOKEN_KEY"
+      "token": "{{secrets.TOKEN_KEY}}"
     }
   },
   {

--- a/connectors/http-json/src/test/resources/requests/fail-cases-request-witout-one-requered-field.json
+++ b/connectors/http-json/src/test/resources/requests/fail-cases-request-witout-one-requered-field.json
@@ -160,7 +160,7 @@
       "oauthTokenEndpoint":"https://abc.eu.auth0.com/api/v2/",
       "scopes": "read:clients",
       "audience":"https://abc.eu.auth0.com/api/v2/",
-      "clientSecret":"secrets.CLIENT_SECRET_KEY",
+      "clientSecret":"{{secrets.CLIENT_SECRET_KEY}}",
       "type":"oauth-client-credentials-flow",
       "clientAuthentication":"basicAuthHeader"
     },
@@ -185,7 +185,7 @@
       "oauthTokenEndpoint":"https://abc.eu.auth0.com/api/v2/",
       "scopes": "read:clients",
       "audience":"https://abc.eu.auth0.com/api/v2/",
-      "clientId":"secrets.CLIENT_ID_KEY",
+      "clientId":"{{secrets.CLIENT_ID_KEY}}",
       "type":"oauth-client-credentials-flow",
       "clientAuthentication":"basicAuthHeader"
     },
@@ -209,8 +209,8 @@
     "authentication":{
       "scopes": "read:clients",
       "audience":"https://abc.eu.auth0.com/api/v2/",
-      "clientId":"secrets.CLIENT_ID_KEY",
-      "clientSecret":"secrets.CLIENT_SECRET_KEY",
+      "clientId":"{{secrets.CLIENT_ID_KEY}}",
+      "clientSecret":"{{secrets.CLIENT_SECRET_KEY}}",
       "type":"oauth-client-credentials-flow",
       "clientAuthentication":"basicAuthHeader"
     },
@@ -235,8 +235,8 @@
       "oauthTokenEndpoint":"https://abc.eu.auth0.com/api/v2/",
       "scopes": "read:clients",
       "audience":"https://abc.eu.auth0.com/api/v2/",
-      "clientId":"secrets.CLIENT_ID_KEY",
-      "clientSecret":"secrets.CLIENT_SECRET_KEY",
+      "clientId":"{{secrets.CLIENT_ID_KEY}}",
+      "clientSecret":"{{secrets.CLIENT_SECRET_KEY}}",
       "type":"oauth-client-credentials-flow"
     },
     "body": {

--- a/connectors/http-json/src/test/resources/requests/success-cases-connection-timeout-validation.json
+++ b/connectors/http-json/src/test/resources/requests/success-cases-connection-timeout-validation.json
@@ -15,7 +15,7 @@
     "connectionTimeoutInSeconds": "0",
     "authentication": {
       "type": "bearer",
-      "token": "secrets.TOKEN_KEY"
+      "token": "{{secrets.TOKEN_KEY}}"
     }
   },
   {
@@ -25,17 +25,17 @@
     "connectionTimeoutInSeconds": "99",
     "authentication": {
       "type": "bearer",
-      "token": "secrets.TOKEN_KEY"
+      "token": "{{secrets.TOKEN_KEY}}"
     }
   },
   {
     "descriptionOfTest": "secrets value",
     "method": "get",
     "url": "https://camunda.io/http-endpoint",
-    "connectionTimeoutInSeconds": "secrets.CONNECT_TIMEOUT_KEY",
+    "connectionTimeoutInSeconds": "{{secrets.CONNECT_TIMEOUT_KEY}}",
     "authentication": {
       "type": "bearer",
-      "token": "secrets.TOKEN_KEY"
+      "token": "{{secrets.TOKEN_KEY}}"
     }
   }
 ]

--- a/connectors/http-json/src/test/resources/requests/success-cases-replace-secrets.json
+++ b/connectors/http-json/src/test/resources/requests/success-cases-replace-secrets.json
@@ -1,44 +1,19 @@
 [
   {
-    "url": "secrets.URL_KEY",
-    "method": "secrets.METHOD_KEY",
+    "url": "{{secrets.URL_KEY}}",
+    "method": "{{secrets.METHOD_KEY}}",
     "authentication": {
       "type": "noAuth"
     },
     "queryParameters": {
-      "q": "secrets.QUERY_PARAMETER_KEY",
-      "priority": "secrets.PRIORITY_KEY"
+      "q": "{{secrets.QUERY_PARAMETER_KEY}}",
+      "priority": "{{secrets.PRIORITY_KEY}}"
     },
     "headers": {
-      "X-Camunda-Cluster-ID": "secrets.CLUSTER_ID_KEY",
-      "User-Agent": "secrets.USER_AGENT_KEY"
+      "X-Camunda-Cluster-ID": "{{secrets.CLUSTER_ID_KEY}}",
+      "User-Agent": "{{secrets.USER_AGENT_KEY}}"
     },
-    "connectionTimeoutInSeconds":"secrets.CONNECT_TIMEOUT_KEY",
-    "body": {
-      "customer": {
-        "id": "startId plus {{secrets.CUSTOMER_ID_KEY}}",
-        "name": "{{secrets.NAME_KEY}} plus some text",
-        "email": "start email plus {{secrets.EMAIL_KEY}} plus end email"
-      },
-      "text": "secrets.TEXT_KEY"
-    }
-  },
-  {
-    "url": "secrets.URL_KEY",
-    "method": "secrets.METHOD_KEY",
-    "authentication": {
-      "type": "bearer",
-      "token": "secrets.TOKEN_KEY"
-    },
-    "queryParameters": {
-      "q": "secrets.QUERY_PARAMETER_KEY",
-      "priority": "secrets.PRIORITY_KEY"
-    },
-    "headers": {
-      "X-Camunda-Cluster-ID": "secrets.CLUSTER_ID_KEY",
-      "User-Agent": "secrets.USER_AGENT_KEY"
-    },
-    "connectionTimeoutInSeconds":"secrets.CONNECT_TIMEOUT_KEY",
+    "connectionTimeoutInSeconds":"{{secrets.CONNECT_TIMEOUT_KEY}}",
     "body": {
       "customer": {
         "id": "startId plus {{secrets.CUSTOMER_ID_KEY}}",
@@ -49,22 +24,47 @@
     }
   },
   {
-    "url": "secrets.URL_KEY",
-    "method": "secrets.METHOD_KEY",
+    "url": "{{secrets.URL_KEY}}",
+    "method": "{{secrets.METHOD_KEY}}",
     "authentication": {
-      "type": "basic",
-      "password": "secrets.PASSWORD_KEY",
-      "username": "secrets.USERNAME_KEY"
+      "type": "bearer",
+      "token": "{{secrets.TOKEN_KEY}}"
     },
     "queryParameters": {
-      "q": "secrets.QUERY_PARAMETER_KEY",
-      "priority": "secrets.PRIORITY_KEY"
+      "q": "{{secrets.QUERY_PARAMETER_KEY}}",
+      "priority": "{{secrets.PRIORITY_KEY}}"
     },
     "headers": {
-      "X-Camunda-Cluster-ID": "secrets.CLUSTER_ID_KEY",
-      "User-Agent": "secrets.USER_AGENT_KEY"
+      "X-Camunda-Cluster-ID": "{{secrets.CLUSTER_ID_KEY}}",
+      "User-Agent": "{{secrets.USER_AGENT_KEY}}"
     },
-    "connectionTimeoutInSeconds":"secrets.CONNECT_TIMEOUT_KEY",
+    "connectionTimeoutInSeconds":"{{secrets.CONNECT_TIMEOUT_KEY}}",
+    "body": {
+      "customer": {
+        "id": "startId plus {{secrets.CUSTOMER_ID_KEY}}",
+        "name": "{{secrets.NAME_KEY}} plus some text",
+        "email": "start email plus {{secrets.EMAIL_KEY}} plus end email"
+      },
+      "text": "{{secrets.TEXT_KEY}}"
+    }
+  },
+  {
+    "url": "{{secrets.URL_KEY}}",
+    "method": "{{secrets.METHOD_KEY}}",
+    "authentication": {
+      "type": "basic",
+      "password": "{{secrets.PASSWORD_KEY}}",
+      "username": "{{secrets.USERNAME_KEY}}"
+    },
+    "queryParameters": {
+      "q": "{{secrets.QUERY_PARAMETER_KEY}}",
+      "priority": "{{secrets.PRIORITY_KEY}}"
+    },
+    "headers": {
+      "X-Camunda-Cluster-ID": "{{secrets.CLUSTER_ID_KEY}}",
+      "User-Agent": "{{secrets.USER_AGENT_KEY}}"
+    },
+    "connectionTimeoutInSeconds":"{{secrets.CONNECT_TIMEOUT_KEY}}",
     "body": {
       "customer": {
         "id": "startId plus {{secrets.CUSTOMER_ID_KEY}}",
@@ -75,26 +75,26 @@
     }
   },
   {
-    "url": "secrets.URL_KEY",
-    "method": "secrets.METHOD_KEY",
+    "url": "{{secrets.URL_KEY}}",
+    "method": "{{secrets.METHOD_KEY}}",
     "authentication": {
-      "oauthTokenEndpoint":"secrets.OAUTH_TOKEN_ENDPOINT_KEY",
+      "oauthTokenEndpoint":"{{secrets.OAUTH_TOKEN_ENDPOINT_KEY}}",
       "scopes": "test",
-      "audience":"secrets.AUDIENCE_KEY",
-      "clientId":"secrets.CLIENT_ID_KEY",
-      "clientSecret":"secrets.CLIENT_SECRET_KEY",
+      "audience":"{{secrets.AUDIENCE_KEY}}",
+      "clientId":"{{secrets.CLIENT_ID_KEY}}",
+      "clientSecret":"{{secrets.CLIENT_SECRET_KEY}}",
       "type": "oauth-client-credentials-flow",
-      "clientAuthentication":"secrets.CLIENT_AUTHENTICATION_KEY"
+      "clientAuthentication":"{{secrets.CLIENT_AUTHENTICATION_KEY}}"
     },
     "queryParameters": {
-      "q": "secrets.QUERY_PARAMETER_KEY",
-      "priority": "secrets.PRIORITY_KEY"
+      "q": "{{secrets.QUERY_PARAMETER_KEY}}",
+      "priority": "{{secrets.PRIORITY_KEY}}"
     },
     "headers": {
-      "X-Camunda-Cluster-ID": "secrets.CLUSTER_ID_KEY",
-      "User-Agent": "secrets.USER_AGENT_KEY"
+      "X-Camunda-Cluster-ID": "{{secrets.CLUSTER_ID_KEY}}",
+      "User-Agent": "{{secrets.USER_AGENT_KEY}}"
     },
-    "connectionTimeoutInSeconds":"secrets.CONNECT_TIMEOUT_KEY",
+    "connectionTimeoutInSeconds":"{{secrets.CONNECT_TIMEOUT_KEY}}",
     "body": {
       "customer": {
         "id": "startId plus {{secrets.CUSTOMER_ID_KEY}}",
@@ -106,50 +106,50 @@
   },
   {
     "url": "{{secrets.URL_KEY}}",
-    "method": "secrets.METHOD_KEY",
+    "method": "{{secrets.METHOD_KEY}}",
     "authentication": {
       "type": "noAuth"
     },
     "queryParameters": {
-      "q": "secrets.QUERY_PARAMETER_KEY",
-      "priority": "secrets.PRIORITY_KEY"
+      "q": "{{secrets.QUERY_PARAMETER_KEY}}",
+      "priority": "{{secrets.PRIORITY_KEY}}"
     },
     "headers": {
-      "X-Camunda-Cluster-ID": "secrets.CLUSTER_ID_KEY",
-      "User-Agent": "secrets.USER_AGENT_KEY"
+      "X-Camunda-Cluster-ID": "{{secrets.CLUSTER_ID_KEY}}",
+      "User-Agent": "{{secrets.USER_AGENT_KEY}}"
     },
-    "connectionTimeoutInSeconds":"secrets.CONNECT_TIMEOUT_KEY",
+    "connectionTimeoutInSeconds":"{{secrets.CONNECT_TIMEOUT_KEY}}",
     "body": {
       "customer": {
         "id": "startId plus {{secrets.CUSTOMER_ID_KEY}}",
         "name": "{{secrets.NAME_KEY}} plus some text",
         "email": "start email plus {{secrets.EMAIL_KEY}} plus end email"
       },
-      "text": "secrets.TEXT_KEY"
+      "text": "{{secrets.TEXT_KEY}}"
     }
   },
   {
     "url": "{{secrets.URL_KEY}}/path",
-    "method": "secrets.METHOD_KEY",
+    "method": "{{secrets.METHOD_KEY}}",
     "authentication": {
       "type": "noAuth"
     },
     "queryParameters": {
-      "q": "secrets.QUERY_PARAMETER_KEY",
-      "priority": "secrets.PRIORITY_KEY"
+      "q": "{{secrets.QUERY_PARAMETER_KEY}}",
+      "priority": "{{secrets.PRIORITY_KEY}}"
     },
     "headers": {
-      "X-Camunda-Cluster-ID": "secrets.CLUSTER_ID_KEY",
-      "User-Agent": "secrets.USER_AGENT_KEY"
+      "X-Camunda-Cluster-ID": "{{secrets.CLUSTER_ID_KEY}}",
+      "User-Agent": "{{secrets.USER_AGENT_KEY}}"
     },
-    "connectionTimeoutInSeconds":"secrets.CONNECT_TIMEOUT_KEY",
+    "connectionTimeoutInSeconds":"{{secrets.CONNECT_TIMEOUT_KEY}}",
     "body": {
       "customer": {
         "id": "startId plus {{secrets.CUSTOMER_ID_KEY}}",
         "name": "{{secrets.NAME_KEY}} plus some text",
         "email": "start email plus {{secrets.EMAIL_KEY}} plus end email"
       },
-      "text": "secrets.TEXT_KEY"
+      "text": "{{secrets.TEXT_KEY}}"
     }
   }
 ]

--- a/connectors/http-json/src/test/resources/requests/success-test-cases-oauth.json
+++ b/connectors/http-json/src/test/resources/requests/success-test-cases-oauth.json
@@ -11,8 +11,8 @@
     "oauthTokenEndpoint":"https://dev-test.eu.auth0.com/api/v2/",
     "scopes": "read:clients",
     "audience":"https://dev-test.eu.auth0.com/api/v2/",
-    "clientId":"secrets.CLIENT_ID_KEY",
-    "clientSecret":"secrets.CLIENT_SECRET_KEY",
+    "clientId":"{{secrets.CLIENT_ID_KEY}}",
+    "clientSecret":"{{secrets.CLIENT_SECRET_KEY}}",
     "type":"oauth-client-credentials-flow",
     "clientAuthentication":"basicAuthHeader"
   },

--- a/connectors/http-json/src/test/resources/requests/success-test-cases.json
+++ b/connectors/http-json/src/test/resources/requests/success-test-cases.json
@@ -37,8 +37,8 @@
     },
     "authentication": {
       "type": "basic",
-      "username": "secrets.MY_USERNAME",
-      "password": "secrets.MY_PASSWORD"
+      "username": "{{secrets.MY_USERNAME}}",
+      "password": "{{secrets.MY_PASSWORD}}"
     },
     "body": {
       "customer": {
@@ -63,7 +63,7 @@
     },
     "authentication": {
       "type": "bearer",
-      "token": "secrets.MY_TOKEN"
+      "token": "{{secrets.MY_TOKEN}}"
     },
     "body": {
       "customer": {
@@ -84,7 +84,7 @@
     },
     "authentication": {
       "type": "bearer",
-      "token": "secrets.MY_TOKEN"
+      "token": "{{secrets.MY_TOKEN}}"
     },
     "body": {
       "customer": {
@@ -106,7 +106,7 @@
     "authentication": {
       "X-Camunda-Cluster-ID": "abcdef",
       "type": "bearer",
-      "token": "secrets.MY_TOKEN"
+      "token": "{{secrets.MY_TOKEN}}"
     },
     "body": {
       "customer": {
@@ -131,7 +131,7 @@
     },
     "authentication": {
       "type": "bearer",
-      "token": "secrets.MY_TOKEN"
+      "token": "{{secrets.MY_TOKEN}}"
     }
   },
   {
@@ -149,7 +149,7 @@
     },
     "authentication": {
       "type": "bearer",
-      "token": "secrets.MY_TOKEN"
+      "token": "{{secrets.MY_TOKEN}}"
     },
     "body": {
     }
@@ -168,7 +168,7 @@
     },
     "authentication": {
       "type": "bearer",
-      "token": "secrets.MY_TOKEN"
+      "token": "{{secrets.MY_TOKEN}}"
     },
     "connectionTimeoutInSeconds": "50",
     "body": {

--- a/connectors/kafka/README.md
+++ b/connectors/kafka/README.md
@@ -15,12 +15,12 @@ mvn clean package
 ```json
 {
   "authentication":{
-    "username":"secrets.KAFKA_USER_NAME",
-    "password":"secrets.KAFKA_PASSWORD"
+    "username":"{{secrets.KAFKA_USER_NAME}}",
+    "password":"{{secrets.KAFKA_PASSWORD}}"
   },
   "topic":{
-    "bootstrapServers":"secrets.KAFKA_BOOTSTRAP_SERVERS",
-    "topicName":"secrets.KAFKA_TOPIC_NAME"
+    "bootstrapServers":"{{secrets.KAFKA_BOOTSTRAP_SERVERS}}",
+    "topicName":"{{secrets.KAFKA_TOPIC_NAME}}"
   },
   "message":{
     "key":"document-id-1234567890",

--- a/connectors/kafka/src/test/resources/requests/success-test-cases.json
+++ b/connectors/kafka/src/test/resources/requests/success-test-cases.json
@@ -91,7 +91,7 @@
   {
     "testDescription": "Username as secret",
     "authentication":{
-      "username":"secrets.USER_NAME",
+      "username":"{{secrets.USER_NAME}}",
       "password":"mySecretPassword"
     },
     "topic":{
@@ -107,7 +107,7 @@
     "testDescription": "Password as secret",
     "authentication":{
       "username":"myLogin",
-      "password":"secrets.PASSWORD"
+      "password":"{{secrets.PASSWORD}}"
     },
     "topic":{
       "bootstrapServers":"kafka-stub.kafka.cloud:1234",
@@ -125,7 +125,7 @@
       "password":"mySecretPassword"
     },
     "topic":{
-      "bootstrapServers":"secrets.BOOTSTRAP_SERVER",
+      "bootstrapServers":"{{secrets.BOOTSTRAP_SERVER}}",
       "topicName":"some-awesome-topic"
     },
     "message":{
@@ -141,7 +141,7 @@
     },
     "topic":{
       "bootstrapServers":"kafka-stub.kafka.cloud:1234",
-      "topicName":"secrets.TOPIC_NAME"
+      "topicName":"{{secrets.TOPIC_NAME}}"
     },
     "message":{
       "key":"Happy",

--- a/connectors/microsoft-teams/src/test/resources/requests/success-chat-request-test-cases.json
+++ b/connectors/microsoft-teams/src/test/resources/requests/success-chat-request-test-cases.json
@@ -76,7 +76,7 @@
     },
     "data": {
       "method": "getChat",
-      "chatId": "secrets.CHAT_ID_KEY",
+      "chatId": "{{secrets.CHAT_ID_KEY}}",
       "expand": "members"
     }
   },
@@ -128,8 +128,8 @@
     },
     "data": {
       "method": "getMessageFromChat",
-      "chatId": "secrets.CHAT_ID_KEY",
-      "messageId": "secrets.MESSAGE_ID_KEY"
+      "chatId": "{{secrets.CHAT_ID_KEY}}",
+      "messageId": "{{secrets.MESSAGE_ID_KEY}}"
     }
   },
   {
@@ -155,7 +155,7 @@
     },
     "data": {
       "method": "listMembersOfChat",
-      "chatId": "secrets.CHAT_ID_KEY"
+      "chatId": "{{secrets.CHAT_ID_KEY}}"
     }
   },
   {
@@ -183,9 +183,9 @@
     },
     "data": {
       "method": "listMessagesInChat",
-      "chatId": "secrets.CHAT_ID_KEY",
+      "chatId": "{{secrets.CHAT_ID_KEY}}",
       "orderBy": "withoutOrdering",
-      "filter": "secrets.FILTER_KEY"
+      "filter": "{{secrets.FILTER_KEY}}"
     }
   },
   {
@@ -213,7 +213,7 @@
     },
     "data": {
       "method": "sendMessageToChat",
-      "chatId": "secrets.CHAT_ID_KEY",
+      "chatId": "{{secrets.CHAT_ID_KEY}}",
       "content": "{{secrets.CONTENT_PART_1_KEY}}{{secrets.CONTENT_PART_2_KEY}}"
     }
   },
@@ -246,7 +246,7 @@
     "description": "create chat with secrets / bearer token auth type",
     "authentication": {
       "type": "token",
-      "token": "secrets.BEARER_TOKEN_KEY"
+      "token": "{{secrets.BEARER_TOKEN_KEY}}"
     },
     "data": {
       "method": "createChat",
@@ -282,11 +282,11 @@
     "description": "get chat with secrets / bearer token auth type",
     "authentication": {
       "type": "token",
-      "token": "secrets.BEARER_TOKEN_KEY"
+      "token": "{{secrets.BEARER_TOKEN_KEY}}"
     },
     "data": {
       "method": "getChat",
-      "chatId": "secrets.CHAT_ID_KEY",
+      "chatId": "{{secrets.CHAT_ID_KEY}}",
       "expand": "members"
     }
   },
@@ -304,7 +304,7 @@
     "description": "list chats with secrets / bearer token auth type",
     "authentication": {
       "type": "token",
-      "token": "secrets.BEARER_TOKEN_KEY"
+      "token": "{{secrets.BEARER_TOKEN_KEY}}"
     },
     "data": {
       "method": "listChats"
@@ -326,12 +326,12 @@
     "description": "Get message in chat with secrets / bearer token auth type",
     "authentication": {
       "type": "token",
-      "token": "secrets.BEARER_TOKEN_KEY"
+      "token": "{{secrets.BEARER_TOKEN_KEY}}"
     },
     "data": {
       "method": "getMessageFromChat",
-      "chatId": "secrets.CHAT_ID_KEY",
-      "messageId": "secrets.MESSAGE_ID_KEY"
+      "chatId": "{{secrets.CHAT_ID_KEY}}",
+      "messageId": "{{secrets.MESSAGE_ID_KEY}}"
     }
   },
   {
@@ -349,11 +349,11 @@
     "description": "List members of chat with secrets / bearer token auth type",
     "authentication": {
       "type": "token",
-      "token": "secrets.BEARER_TOKEN_KEY"
+      "token": "{{secrets.BEARER_TOKEN_KEY}}"
     },
     "data": {
       "method": "listMembersOfChat",
-      "chatId": "secrets.CHAT_ID_KEY"
+      "chatId": "{{secrets.CHAT_ID_KEY}}"
     }
   },
   {
@@ -373,13 +373,13 @@
     "description": "List messages in chat with secrets / bearer token auth type",
     "authentication": {
       "type": "token",
-      "token": "secrets.BEARER_TOKEN_KEY"
+      "token": "{{secrets.BEARER_TOKEN_KEY}}"
     },
     "data": {
       "method": "listMessagesInChat",
-      "chatId": "secrets.CHAT_ID_KEY",
+      "chatId": "{{secrets.CHAT_ID_KEY}}",
       "orderBy": "withoutOrdering",
-      "filter": "secrets.FILTER_KEY"
+      "filter": "{{secrets.FILTER_KEY}}"
     }
   },
   {
@@ -399,11 +399,11 @@
     "description": "Send messages in chat with secrets / bearer token auth type",
     "authentication": {
       "type": "token",
-      "token": "secrets.BEARER_TOKEN_KEY"
+      "token": "{{secrets.BEARER_TOKEN_KEY}}"
     },
     "data": {
       "method": "sendMessageToChat",
-      "chatId": "secrets.CHAT_ID_KEY",
+      "chatId": "{{secrets.CHAT_ID_KEY}}",
       "content": "{{secrets.CONTENT_PART_1_KEY}}{{secrets.CONTENT_PART_2_KEY}}"
     }
   },
@@ -439,7 +439,7 @@
     "description": "create chat with secrets / refresh token auth type",
     "authentication": {
       "type": "refresh",
-      "token": "secrets.REFRESH_TOKEN_KEY",
+      "token": "{{secrets.REFRESH_TOKEN_KEY}}",
       "clientId": "{{secrets.CLIENT_ID_KEY}}",
       "tenantId": "{{secrets.TENANT_ID_KEY}}",
       "clientSecret": "{{secrets.CLIENT_SECRET_KEY}}"
@@ -481,14 +481,14 @@
     "description": "get chat with secrets / refresh token auth type",
     "authentication": {
       "type": "refresh",
-      "token": "secrets.REFRESH_TOKEN_KEY",
+      "token": "{{secrets.REFRESH_TOKEN_KEY}}",
       "clientId": "{{secrets.CLIENT_ID_KEY}}",
       "tenantId": "{{secrets.TENANT_ID_KEY}}",
       "clientSecret": "{{secrets.CLIENT_SECRET_KEY}}"
     },
     "data": {
       "method": "getChat",
-      "chatId": "secrets.CHAT_ID_KEY",
+      "chatId": "{{secrets.CHAT_ID_KEY}}",
       "expand": "members"
     }
   },
@@ -509,7 +509,7 @@
     "description": "list chats with secrets / refresh token auth type",
     "authentication": {
       "type": "refresh",
-      "token": "secrets.REFRESH_TOKEN_KEY",
+      "token": "{{secrets.REFRESH_TOKEN_KEY}}",
       "clientId": "{{secrets.CLIENT_ID_KEY}}",
       "tenantId": "{{secrets.TENANT_ID_KEY}}",
       "clientSecret": "{{secrets.CLIENT_SECRET_KEY}}"
@@ -537,15 +537,15 @@
     "description": "Get message in chat with secrets / refresh token auth type",
     "authentication": {
       "type": "refresh",
-      "token": "secrets.REFRESH_TOKEN_KEY",
+      "token": "{{secrets.REFRESH_TOKEN_KEY}}",
       "clientId": "{{secrets.CLIENT_ID_KEY}}",
       "tenantId": "{{secrets.TENANT_ID_KEY}}",
       "clientSecret": "{{secrets.CLIENT_SECRET_KEY}}"
     },
     "data": {
       "method": "getMessageFromChat",
-      "chatId": "secrets.CHAT_ID_KEY",
-      "messageId": "secrets.MESSAGE_ID_KEY"
+      "chatId": "{{secrets.CHAT_ID_KEY}}",
+      "messageId": "{{secrets.MESSAGE_ID_KEY}}"
     }
   },
   {
@@ -566,14 +566,14 @@
     "description": "List members of chat with secrets / refresh token auth type",
     "authentication": {
       "type": "refresh",
-      "token": "secrets.REFRESH_TOKEN_KEY",
+      "token": "{{secrets.REFRESH_TOKEN_KEY}}",
       "clientId": "{{secrets.CLIENT_ID_KEY}}",
       "tenantId": "{{secrets.TENANT_ID_KEY}}",
       "clientSecret": "{{secrets.CLIENT_SECRET_KEY}}"
     },
     "data": {
       "method": "listMembersOfChat",
-      "chatId": "secrets.CHAT_ID_KEY"
+      "chatId": "{{secrets.CHAT_ID_KEY}}"
     }
   },
   {
@@ -596,16 +596,16 @@
     "description": "List messages in chat with secrets / refresh token auth type",
     "authentication": {
       "type": "refresh",
-      "token": "secrets.REFRESH_TOKEN_KEY",
+      "token": "{{secrets.REFRESH_TOKEN_KEY}}",
       "clientId": "{{secrets.CLIENT_ID_KEY}}",
       "tenantId": "{{secrets.TENANT_ID_KEY}}",
       "clientSecret": "{{secrets.CLIENT_SECRET_KEY}}"
     },
     "data": {
       "method": "listMessagesInChat",
-      "chatId": "secrets.CHAT_ID_KEY",
+      "chatId": "{{secrets.CHAT_ID_KEY}}",
       "orderBy": "withoutOrdering",
-      "filter": "secrets.FILTER_KEY"
+      "filter": "{{secrets.FILTER_KEY}}"
     }
   },
   {
@@ -627,14 +627,14 @@
     "description": "Send messages in chat with secrets / refresh token auth type",
     "authentication": {
       "type": "refresh",
-      "token": "secrets.REFRESH_TOKEN_KEY",
+      "token": "{{secrets.REFRESH_TOKEN_KEY}}",
       "clientId": "{{secrets.CLIENT_ID_KEY}}",
       "tenantId": "{{secrets.TENANT_ID_KEY}}",
       "clientSecret": "{{secrets.CLIENT_SECRET_KEY}}"
     },
     "data": {
       "method": "sendMessageToChat",
-      "chatId": "secrets.CHAT_ID_KEY",
+      "chatId": "{{secrets.CHAT_ID_KEY}}",
       "content": "{{secrets.CONTENT_PART_1_KEY}}{{secrets.CONTENT_PART_2_KEY}}"
     }
   }

--- a/connectors/rabbitmq/README.md
+++ b/connectors/rabbitmq/README.md
@@ -18,8 +18,8 @@ mvn clean package
 {
   "authentication": {
     "authType": "credentials",
-    "userName": "secrets.USERNAME",
-    "password": "secrets.PASSWORD"
+    "userName": "{{secrets.USERNAME}}",
+    "password": "{{secrets.PASSWORD}}"
   },
   "routing": {
     "exchange": "exchangeName",
@@ -83,8 +83,8 @@ mvn clean package
 {
   "authentication": {
     "authType": "credentials",
-    "userName": "secrets.USERNAME",
-    "password": "secrets.PASSWORD"
+    "userName": "{{secrets.USERNAME}}",
+    "password": "{{secrets.PASSWORD}}"
   },
   "routing": {
     "virtualHost": "virtualHostName",

--- a/connectors/rabbitmq/src/test/resources/requests/inbound/success-test-cases-replace-secrets.json
+++ b/connectors/rabbitmq/src/test/resources/requests/inbound/success-test-cases-replace-secrets.json
@@ -3,18 +3,18 @@
     "testDescription": "success request with credentials auth type",
     "authentication": {
       "authType": "credentials",
-      "password": "secrets.PASSWORD_KEY",
-      "userName": "secrets.USERNAME_KEY"
+      "password": "{{secrets.PASSWORD_KEY}}",
+      "userName": "{{secrets.USERNAME_KEY}}"
     },
     "routing": {
-      "virtualHost": "secrets.VIRTUAL_HOST_KEY",
-      "hostName": "secrets.HOST_NAME_KEY",
-      "port": "secrets.PORT_KEY"
+      "virtualHost": "{{secrets.VIRTUAL_HOST_KEY}}",
+      "hostName": "{{secrets.HOST_NAME_KEY}}",
+      "port": "{{secrets.PORT_KEY}}"
     },
-    "queueName": "secrets.QUEUE_NAME",
-    "consumerTag": "secrets.CONSUMER_TAG",
+    "queueName": "{{secrets.QUEUE_NAME}}",
+    "consumerTag": "{{secrets.CONSUMER_TAG}}",
     "arguments": {
-      "x-queue-type": "secrets.QUEUE_TYPE"
+      "x-queue-type": "{{secrets.QUEUE_TYPE}}"
     },
     "exclusive": "true"
   },
@@ -22,12 +22,12 @@
     "testDescription": "success request with uri auth type",
     "authentication": {
       "authType": "uri",
-      "uri": "secrets.URI_KEY"
+      "uri": "{{secrets.URI_KEY}}"
     },
-    "queueName": "secrets.QUEUE_NAME",
-    "consumerTag": "secrets.CONSUMER_TAG",
+    "queueName": "{{secrets.QUEUE_NAME}}",
+    "consumerTag": "{{secrets.CONSUMER_TAG}}",
     "arguments": {
-      "x-queue-type": "secrets.QUEUE_TYPE"
+      "x-queue-type": "{{secrets.QUEUE_TYPE}}"
     },
     "exclusive": "true"
   }

--- a/connectors/rabbitmq/src/test/resources/requests/outbound/fail-test-cases-bad-message-properties.json
+++ b/connectors/rabbitmq/src/test/resources/requests/outbound/fail-test-cases-bad-message-properties.json
@@ -57,25 +57,25 @@
     "testDescription": "wrong properties with 'credentials' auth type and secrets",
     "authentication": {
       "authType": "credentials",
-      "password": "secrets.PASSWORD_KEY",
-      "userName": "secrets.USERNAME_KEY"
+      "password": "{{secrets.PASSWORD_KEY}}",
+      "userName": "{{secrets.USERNAME_KEY}}"
     },
     "routing": {
-      "virtualHost": "secrets.VIRTUAL_HOST_KEY",
-      "hostName": "secrets.HOST_NAME_KEY",
-      "exchange": "secrets.EXCHANGE_NAME_KEY",
-      "routingKey": "secrets.ROUTING_SECRET_KEY",
-      "port": "secrets.PORT_KEY"
+      "virtualHost": "{{secrets.VIRTUAL_HOST_KEY}}",
+      "hostName": "{{secrets.HOST_NAME_KEY}}",
+      "exchange": "{{secrets.EXCHANGE_NAME_KEY}}",
+      "routingKey": "{{secrets.ROUTING_SECRET_KEY}}",
+      "port": "{{secrets.PORT_KEY}}"
     },
     "message": {
       "body": {
-        "msg_key": "secrets.TEXT_KEY"
+        "msg_key": "{{secrets.TEXT_KEY}}"
       },
       "properties": {
-        "contentType": "secrets.CONTENT_TYPE_KEY",
-        "Encoding": "secrets.CONTENT_ENCODING_KEY",
+        "contentType": "{{secrets.CONTENT_TYPE_KEY}}",
+        "Encoding": "{{secrets.CONTENT_ENCODING_KEY}}",
         "headers": {
-          "header1": "secrets.HEADER_VALUE_KEY"
+          "header1": "{{secrets.HEADER_VALUE_KEY}}"
         }
       }
     }
@@ -84,25 +84,25 @@
     "testDescription": "wrong properties field with 'uri' auth type and secrets",
     "authentication": {
       "authType": "uri",
-      "uri": "secrets.URI_KEY"
+      "uri": "{{secrets.URI_KEY}}"
     },
     "routing": {
-      "virtualHost": "secrets.VIRTUAL_HOST_KEY",
-      "hostName": "secrets.HOST_NAME_KEY",
-      "exchange": "secrets.EXCHANGE_NAME_KEY",
-      "routingKey": "secrets.ROUTING_SECRET_KEY",
-      "port": "secrets.PORT_KEY"
+      "virtualHost": "{{secrets.VIRTUAL_HOST_KEY}}",
+      "hostName": "{{secrets.HOST_NAME_KEY}}",
+      "exchange": "{{secrets.EXCHANGE_NAME_KEY}}",
+      "routingKey": "{{secrets.ROUTING_SECRET_KEY}}",
+      "port": "{{secrets.PORT_KEY}}"
     },
     "message": {
       "body": {
-        "msg_key": "secrets.TEXT_KEY"
+        "msg_key": "{{secrets.TEXT_KEY}}"
       },
       "properties": {
-        "contentType": "secrets.CONTENT_TYPE_KEY",
-        "content": "secrets.CONTENT_ENCODING_KEY",
+        "contentType": "{{secrets.CONTENT_TYPE_KEY}}",
+        "content": "{{secrets.CONTENT_ENCODING_KEY}}",
         "myNewField": "field value",
         "headers": {
-          "header1": "secrets.HEADER_VALUE_KEY"
+          "header1": "{{secrets.HEADER_VALUE_KEY}}"
         }
       }
     }
@@ -111,22 +111,22 @@
     "testDescription": "wrong properties with 'uri' auth type and secrets with string in body",
     "authentication": {
       "authType": "uri",
-      "uri": "secrets.URI_KEY"
+      "uri": "{{secrets.URI_KEY}}"
     },
     "routing": {
-      "virtualHost": "secrets.VIRTUAL_HOST_KEY",
-      "hostName": "secrets.HOST_NAME_KEY",
-      "exchange": "secrets.EXCHANGE_NAME_KEY",
-      "routingKey": "secrets.ROUTING_SECRET_KEY",
-      "port": "secrets.PORT_KEY"
+      "virtualHost": "{{secrets.VIRTUAL_HOST_KEY}}",
+      "hostName": "{{secrets.HOST_NAME_KEY}}",
+      "exchange": "{{secrets.EXCHANGE_NAME_KEY}}",
+      "routingKey": "{{secrets.ROUTING_SECRET_KEY}}",
+      "port": "{{secrets.PORT_KEY}}"
     },
     "message": {
       "body": "string text",
       "properties": {
-        "contentType": "secrets.CONTENT_TYPE_KEY",
-        "contentEncoding": "secrets.CONTENT_ENCODING_KEY",
+        "contentType": "{{secrets.CONTENT_TYPE_KEY}}",
+        "contentEncoding": "{{secrets.CONTENT_ENCODING_KEY}}",
         "headers12": {
-          "header1": "secrets.HEADER_VALUE_KEY"
+          "header1": "{{secrets.HEADER_VALUE_KEY}}"
         }
       }
     }

--- a/connectors/rabbitmq/src/test/resources/requests/outbound/success-test-cases-execute-function.json
+++ b/connectors/rabbitmq/src/test/resources/requests/outbound/success-test-cases-execute-function.json
@@ -81,25 +81,25 @@
     "testDescription": "success request with 'credentials' auth type and secrets",
     "authentication": {
       "authType": "credentials",
-      "password": "secrets.PASSWORD_KEY",
-      "userName": "secrets.USERNAME_KEY"
+      "password": "{{secrets.PASSWORD_KEY}}",
+      "userName": "{{secrets.USERNAME_KEY}}"
     },
     "routing": {
-      "virtualHost": "secrets.VIRTUAL_HOST_KEY",
-      "hostName": "secrets.HOST_NAME_KEY",
-      "exchange": "secrets.EXCHANGE_NAME_KEY",
-      "routingKey": "secrets.ROUTING_SECRET_KEY",
-      "port": "secrets.PORT_KEY"
+      "virtualHost": "{{secrets.VIRTUAL_HOST_KEY}}",
+      "hostName": "{{secrets.HOST_NAME_KEY}}",
+      "exchange": "{{secrets.EXCHANGE_NAME_KEY}}",
+      "routingKey": "{{secrets.ROUTING_SECRET_KEY}}",
+      "port": "{{secrets.PORT_KEY}}"
     },
     "message": {
       "body": {
-        "msg_key": "secrets.TEXT_KEY"
+        "msg_key": "{{secrets.TEXT_KEY}}"
       },
       "properties": {
-        "contentType": "secrets.CONTENT_TYPE_KEY",
-        "contentEncoding": "secrets.CONTENT_ENCODING_KEY",
+        "contentType": "{{secrets.CONTENT_TYPE_KEY}}",
+        "contentEncoding": "{{secrets.CONTENT_ENCODING_KEY}}",
         "headers": {
-          "header1": "secrets.HEADER_VALUE_KEY"
+          "header1": "{{secrets.HEADER_VALUE_KEY}}"
         }
       }
     }
@@ -108,24 +108,24 @@
     "testDescription": "success request with 'uri' auth type and secrets",
     "authentication": {
       "authType": "uri",
-      "uri": "secrets.URI_KEY"
+      "uri": "{{secrets.URI_KEY}}"
     },
     "routing": {
-      "virtualHost": "secrets.VIRTUAL_HOST_KEY",
-      "hostName": "secrets.HOST_NAME_KEY",
-      "exchange": "secrets.EXCHANGE_NAME_KEY",
-      "routingKey": "secrets.ROUTING_SECRET_KEY",
-      "port": "secrets.PORT_KEY"
+      "virtualHost": "{{secrets.VIRTUAL_HOST_KEY}}",
+      "hostName": "{{secrets.HOST_NAME_KEY}}",
+      "exchange": "{{secrets.EXCHANGE_NAME_KEY}}",
+      "routingKey": "{{secrets.ROUTING_SECRET_KEY}}",
+      "port": "{{secrets.PORT_KEY}}"
     },
     "message": {
       "body": {
-        "msg_key": "secrets.TEXT_KEY"
+        "msg_key": "{{secrets.TEXT_KEY}}"
       },
       "properties": {
-        "contentType": "secrets.CONTENT_TYPE_KEY",
-        "contentEncoding": "secrets.CONTENT_ENCODING_KEY",
+        "contentType": "{{secrets.CONTENT_TYPE_KEY}}",
+        "contentEncoding": "{{secrets.CONTENT_ENCODING_KEY}}",
         "headers": {
-          "header1": "secrets.HEADER_VALUE_KEY"
+          "header1": "{{secrets.HEADER_VALUE_KEY}}"
         }
       }
     }
@@ -134,22 +134,22 @@
     "testDescription": "success request with 'uri' auth type and secrets with numbers in body",
     "authentication": {
       "authType": "uri",
-      "uri": "secrets.URI_KEY"
+      "uri": "{{secrets.URI_KEY}}"
     },
     "routing": {
-      "virtualHost": "secrets.VIRTUAL_HOST_KEY",
-      "hostName": "secrets.HOST_NAME_KEY",
-      "exchange": "secrets.EXCHANGE_NAME_KEY",
-      "routingKey": "secrets.ROUTING_SECRET_KEY",
-      "port": "secrets.PORT_KEY"
+      "virtualHost": "{{secrets.VIRTUAL_HOST_KEY}}",
+      "hostName": "{{secrets.HOST_NAME_KEY}}",
+      "exchange": "{{secrets.EXCHANGE_NAME_KEY}}",
+      "routingKey": "{{secrets.ROUTING_SECRET_KEY}}",
+      "port": "{{secrets.PORT_KEY}}"
     },
     "message": {
       "body": "{14:-23}",
       "properties": {
-        "contentType": "secrets.CONTENT_TYPE_KEY",
-        "contentEncoding": "secrets.CONTENT_ENCODING_KEY",
+        "contentType": "{{secrets.CONTENT_TYPE_KEY}}",
+        "contentEncoding": "{{secrets.CONTENT_ENCODING_KEY}}",
         "headers": {
-          "header1": "secrets.HEADER_VALUE_KEY"
+          "header1": "{{secrets.HEADER_VALUE_KEY}}"
         }
       }
     }
@@ -158,22 +158,22 @@
     "testDescription": "success request with 'uri' auth type and secrets with array in body",
     "authentication": {
       "authType": "uri",
-      "uri": "secrets.URI_KEY"
+      "uri": "{{secrets.URI_KEY}}"
     },
     "routing": {
-      "virtualHost": "secrets.VIRTUAL_HOST_KEY",
-      "hostName": "secrets.HOST_NAME_KEY",
-      "exchange": "secrets.EXCHANGE_NAME_KEY",
-      "routingKey": "secrets.ROUTING_SECRET_KEY",
-      "port": "secrets.PORT_KEY"
+      "virtualHost": "{{secrets.VIRTUAL_HOST_KEY}}",
+      "hostName": "{{secrets.HOST_NAME_KEY}}",
+      "exchange": "{{secrets.EXCHANGE_NAME_KEY}}",
+      "routingKey": "{{secrets.ROUTING_SECRET_KEY}}",
+      "port": "{{secrets.PORT_KEY}}"
     },
     "message": {
       "body": "[1,3,4,]",
       "properties": {
-        "contentType": "secrets.CONTENT_TYPE_KEY",
-        "contentEncoding": "secrets.CONTENT_ENCODING_KEY",
+        "contentType": "{{secrets.CONTENT_TYPE_KEY}}",
+        "contentEncoding": "{{secrets.CONTENT_ENCODING_KEY}}",
         "headers": {
-          "header1": "secrets.HEADER_VALUE_KEY"
+          "header1": "{{secrets.HEADER_VALUE_KEY}}"
         }
       }
     }

--- a/connectors/rabbitmq/src/test/resources/requests/outbound/success-test-cases-with-plain-text-execute-function.json
+++ b/connectors/rabbitmq/src/test/resources/requests/outbound/success-test-cases-with-plain-text-execute-function.json
@@ -52,23 +52,23 @@
     "testDescription": "success request with 'credentials' auth type and secrets",
     "authentication": {
       "authType": "credentials",
-      "password": "secrets.PASSWORD_KEY",
-      "userName": "secrets.USERNAME_KEY"
+      "password": "{{secrets.PASSWORD_KEY}}",
+      "userName": "{{secrets.USERNAME_KEY}}"
     },
     "routing": {
-      "virtualHost": "secrets.VIRTUAL_HOST_KEY",
-      "hostName": "secrets.HOST_NAME_KEY",
-      "exchange": "secrets.EXCHANGE_NAME_KEY",
-      "routingKey": "secrets.ROUTING_SECRET_KEY",
-      "port": "secrets.PORT_KEY"
+      "virtualHost": "{{secrets.VIRTUAL_HOST_KEY}}",
+      "hostName": "{{secrets.HOST_NAME_KEY}}",
+      "exchange": "{{secrets.EXCHANGE_NAME_KEY}}",
+      "routingKey": "{{secrets.ROUTING_SECRET_KEY}}",
+      "port": "{{secrets.PORT_KEY}}"
     },
     "message": {
-      "body": "secrets.TEXT_KEY",
+      "body": "{{secrets.TEXT_KEY}}",
       "properties": {
-        "contentType": "secrets.CONTENT_TYPE_KEY",
-        "contentEncoding": "secrets.CONTENT_ENCODING_KEY",
+        "contentType": "{{secrets.CONTENT_TYPE_KEY}}",
+        "contentEncoding": "{{secrets.CONTENT_ENCODING_KEY}}",
         "headers": {
-          "header1": "secrets.HEADER_VALUE_KEY"
+          "header1": "{{secrets.HEADER_VALUE_KEY}}"
         }
       }
     }
@@ -77,22 +77,22 @@
     "testDescription": "success request with 'uri' auth type and secrets",
     "authentication": {
       "authType": "uri",
-      "uri": "secrets.URI_KEY"
+      "uri": "{{secrets.URI_KEY}}"
     },
     "routing": {
-      "virtualHost": "secrets.VIRTUAL_HOST_KEY",
-      "hostName": "secrets.HOST_NAME_KEY",
-      "exchange": "secrets.EXCHANGE_NAME_KEY",
-      "routingKey": "secrets.ROUTING_SECRET_KEY",
-      "port": "secrets.PORT_KEY"
+      "virtualHost": "{{secrets.VIRTUAL_HOST_KEY}}",
+      "hostName": "{{secrets.HOST_NAME_KEY}}",
+      "exchange": "{{secrets.EXCHANGE_NAME_KEY}}",
+      "routingKey": "{{secrets.ROUTING_SECRET_KEY}}",
+      "port": "{{secrets.PORT_KEY}}"
     },
     "message": {
       "body": "false",
       "properties": {
-        "contentType": "secrets.CONTENT_TYPE_KEY",
-        "contentEncoding": "secrets.CONTENT_ENCODING_KEY",
+        "contentType": "{{secrets.CONTENT_TYPE_KEY}}",
+        "contentEncoding": "{{secrets.CONTENT_ENCODING_KEY}}",
         "headers": {
-          "header1": "secrets.HEADER_VALUE_KEY"
+          "header1": "{{secrets.HEADER_VALUE_KEY}}"
         }
       }
     }
@@ -101,22 +101,22 @@
     "testDescription": "success request with 'uri' auth type and secrets with string in body",
     "authentication": {
       "authType": "uri",
-      "uri": "secrets.URI_KEY"
+      "uri": "{{secrets.URI_KEY}}"
     },
     "routing": {
-      "virtualHost": "secrets.VIRTUAL_HOST_KEY",
-      "hostName": "secrets.HOST_NAME_KEY",
-      "exchange": "secrets.EXCHANGE_NAME_KEY",
-      "routingKey": "secrets.ROUTING_SECRET_KEY",
-      "port": "secrets.PORT_KEY"
+      "virtualHost": "{{secrets.VIRTUAL_HOST_KEY}}",
+      "hostName": "{{secrets.HOST_NAME_KEY}}",
+      "exchange": "{{secrets.EXCHANGE_NAME_KEY}}",
+      "routingKey": "{{secrets.ROUTING_SECRET_KEY}}",
+      "port": "{{secrets.PORT_KEY}}"
     },
     "message": {
       "body": "string text",
       "properties": {
-        "contentType": "secrets.CONTENT_TYPE_KEY",
-        "contentEncoding": "secrets.CONTENT_ENCODING_KEY",
+        "contentType": "{{secrets.CONTENT_TYPE_KEY}}",
+        "contentEncoding": "{{secrets.CONTENT_ENCODING_KEY}}",
         "headers": {
-          "header1": "secrets.HEADER_VALUE_KEY"
+          "header1": "{{secrets.HEADER_VALUE_KEY}}"
         }
       }
     }

--- a/connectors/sendgrid/README.md
+++ b/connectors/sendgrid/README.md
@@ -14,7 +14,7 @@ mvn clean package
 
 ```json
 {
-  "apiKey": "secrets.SENDGRID_API_KEY",
+  "apiKey": "{{secrets.SENDGRID_API_KEY}}",
   "from": {
     "name": "John Doe",
     "email": "john.doe@example.com"
@@ -50,7 +50,7 @@ If the email should be sent with a template the request has to contain a `templa
 
 ```json
 {
-  "apiKey": "secrets.SENDGRID_API_KEY",
+  "apiKey": "{{secrets.SENDGRID_API_KEY}}",
   "from": {
     "name": "John Doe",
     "email": "john.doe@example.com"
@@ -76,7 +76,7 @@ If the email should be sent with a template the request has to contain a `templa
 
 ```json
 {
-  "apiKey": "secrets.SENDGRID_API_KEY",
+  "apiKey": "{{secrets.SENDGRID_API_KEY}}",
   "from": {
     "name": "John Doe",
     "email": "john.doe@example.com"

--- a/connectors/sendgrid/src/test/resources/requests/replace-secrets-content-success-test-cases.json
+++ b/connectors/sendgrid/src/test/resources/requests/replace-secrets-content-success-test-cases.json
@@ -1,6 +1,6 @@
 [
   {
-    "apiKey": "secrets.SENDGRID_API_KEY",
+    "apiKey": "{{secrets.SENDGRID_API_KEY}}",
     "from": {
       "name": "John Doe",
       "email": "john.doe@example.com"
@@ -10,9 +10,9 @@
       "email": "jane.doe@example.com"
     },
     "content": {
-      "subject": "secrets.CONTENT_SUBJECT",
-      "type": "secrets.CONTENT_TYPE",
-      "value": "secrets.CONTENT_VALUE"
+      "subject": "{{secrets.CONTENT_SUBJECT}}",
+      "type": "{{secrets.CONTENT_TYPE}}",
+      "value": "{{secrets.CONTENT_VALUE}}"
     }
   }
 ]

--- a/connectors/sendgrid/src/test/resources/requests/replace-secrets-success-test-cases.json
+++ b/connectors/sendgrid/src/test/resources/requests/replace-secrets-success-test-cases.json
@@ -1,13 +1,13 @@
 [
   {
-    "apiKey": "secrets.SENDGRID_API_KEY",
+    "apiKey": "{{secrets.SENDGRID_API_KEY}}",
     "from": {
-      "name": "secrets.SENDER_NAME",
-      "email": "secrets.SENDER_EMAIL"
+      "name": "{{secrets.SENDER_NAME}}",
+      "email": "{{secrets.SENDER_EMAIL}}"
     },
     "to": {
-      "name": "secrets.RECEIVER_NAME",
-      "email": "secrets.RECEIVER_EMAIL"
+      "name": "{{secrets.RECEIVER_NAME}}",
+      "email": "{{secrets.RECEIVER_EMAIL}}"
     },
     "template": {
       "id": "d-0b51e8f77bf8450fae379e0639ca0d11",

--- a/connectors/sendgrid/src/test/resources/requests/replace-secrets-template-success-test-cases.json
+++ b/connectors/sendgrid/src/test/resources/requests/replace-secrets-template-success-test-cases.json
@@ -1,6 +1,6 @@
 [
   {
-    "apiKey": "secrets.SENDGRID_API_KEY",
+    "apiKey": "{{secrets.SENDGRID_API_KEY}}",
     "from": {
       "name": "John Doe",
       "email": "john.doe@example.com"
@@ -10,11 +10,11 @@
       "email": "jane.doe@example.com"
     },
     "template": {
-      "id": "secrets.TEMPLATE_ID",
+      "id": "{{secrets.TEMPLATE_ID}}",
       "data": {
-        "accountName": "secrets.TEMPLATE_DATA_ACCOUNT_NAME",
-        "shipAddress": "secrets.TEMPLATE_DATA_SHIP_ADDRESS",
-        "shipZip": "secrets.TEMPLATE_DATA_SHIP_ZIP"
+        "accountName": "{{secrets.TEMPLATE_DATA_ACCOUNT_NAME}}",
+        "shipAddress": "{{secrets.TEMPLATE_DATA_SHIP_ADDRESS}}",
+        "shipZip": "{{secrets.TEMPLATE_DATA_SHIP_ZIP}}"
       }
     }
   }

--- a/connectors/sendgrid/src/test/resources/requests/send-mail-by-template-success-cases.json
+++ b/connectors/sendgrid/src/test/resources/requests/send-mail-by-template-success-cases.json
@@ -1,6 +1,6 @@
 [
   {
-    "apiKey": "secrets.SENDGRID_API_KEY",
+    "apiKey": "{{secrets.SENDGRID_API_KEY}}",
     "from": {
       "name": "John Doe",
       "email": "john.doe@example.com"
@@ -10,11 +10,11 @@
       "email": "jane.doe@example.com"
     },
     "template": {
-      "id": "secrets.TEMPLATE_ID",
+      "id": "{{secrets.TEMPLATE_ID}}",
       "data": {
-        "accountName": "secrets.TEMPLATE_DATA_ACCOUNT_NAME",
-        "shipAddress": "secrets.TEMPLATE_DATA_SHIP_ADDRESS",
-        "shipZip": "secrets.TEMPLATE_DATA_SHIP_ZIP"
+        "accountName": "{{secrets.TEMPLATE_DATA_ACCOUNT_NAME}}",
+        "shipAddress": "{{secrets.TEMPLATE_DATA_SHIP_ADDRESS}}",
+        "shipZip": "{{secrets.TEMPLATE_DATA_SHIP_ZIP}}"
       }
     }
   },
@@ -46,7 +46,7 @@
       "email":"jane.doe@wxample.com",
       "name":"Jane Doe"
     },
-    "apiKey":"secrets.SENDGRID_API_KEY",
+    "apiKey":"{{secrets.SENDGRID_API_KEY}}",
     "template":{
       "data":{
         "records":47336,

--- a/connectors/sendgrid/src/test/resources/requests/send-mail-with-content-success-cases.json
+++ b/connectors/sendgrid/src/test/resources/requests/send-mail-with-content-success-cases.json
@@ -1,6 +1,6 @@
 [
   {
-    "apiKey": "secrets.SENDGRID_API_KEY",
+    "apiKey": "{{secrets.SENDGRID_API_KEY}}",
     "from": {
       "name": "John Doe",
       "email": "john.doe@example.com"
@@ -10,9 +10,9 @@
       "email": "jane.doe@example.com"
     },
     "content": {
-      "subject": "secrets.CONTENT_SUBJECT",
-      "type": "secrets.CONTENT_TYPE",
-      "value": "secrets.CONTENT_VALUE"
+      "subject": "{{secrets.CONTENT_SUBJECT}}",
+      "type": "{{secrets.CONTENT_TYPE}}",
+      "value": "{{secrets.CONTENT_VALUE}}"
     }
   },
   {

--- a/connectors/sendgrid/src/test/resources/requests/validation/request-without-one-field-fail-test-cases.json
+++ b/connectors/sendgrid/src/test/resources/requests/validation/request-without-one-field-fail-test-cases.json
@@ -20,7 +20,7 @@
     }
   },
   {
-    "apiKey": "secrets.SENDGRID_API_KEY",
+    "apiKey": "{{secrets.SENDGRID_API_KEY}}",
     "to": {
       "name": "Jane Doe",
       "email": "jane.doe@example.com"
@@ -37,7 +37,7 @@
     }
   },
   {
-    "apiKey": "secrets.SENDGRID_API_KEY",
+    "apiKey": "{{secrets.SENDGRID_API_KEY}}",
     "from": {
       "email": "john.doe@example.com"
     },
@@ -57,7 +57,7 @@
     }
   },
   {
-    "apiKey": "secrets.SENDGRID_API_KEY",
+    "apiKey": "{{secrets.SENDGRID_API_KEY}}",
     "from": {
       "name": "John Doe"
     },
@@ -77,7 +77,7 @@
     }
   },
   {
-    "apiKey": "secrets.SENDGRID_API_KEY",
+    "apiKey": "{{secrets.SENDGRID_API_KEY}}",
     "from": {
       "name": "John Doe",
       "email": "john.doe@example.com"
@@ -94,7 +94,7 @@
     }
   },
   {
-    "apiKey": "secrets.SENDGRID_API_KEY",
+    "apiKey": "{{secrets.SENDGRID_API_KEY}}",
     "from": {
       "name": "John Doe",
       "email": "john.doe@example.com"
@@ -114,7 +114,7 @@
     }
   },
   {
-    "apiKey": "secrets.SENDGRID_API_KEY",
+    "apiKey": "{{secrets.SENDGRID_API_KEY}}",
     "from": {
       "name": "John Doe",
       "email": "john.doe@example.com"
@@ -134,7 +134,7 @@
     }
   },
   {
-    "apiKey": "secrets.SENDGRID_API_KEY",
+    "apiKey": "{{secrets.SENDGRID_API_KEY}}",
     "from": {
       "name": "John Doe",
       "email": "john.doe@example.com"
@@ -145,7 +145,7 @@
     }
   },
   {
-    "apiKey": "secrets.SENDGRID_API_KEY",
+    "apiKey": "{{secrets.SENDGRID_API_KEY}}",
     "from": {
       "name": "John Doe",
       "email": "john.doe@example.com"
@@ -165,7 +165,7 @@
     }
   },
   {
-    "apiKey": "secrets.SENDGRID_API_KEY",
+    "apiKey": "{{secrets.SENDGRID_API_KEY}}",
     "from": {
       "name": "John Doe",
       "email": "john.doe@example.com"
@@ -179,7 +179,7 @@
     }
   },
   {
-    "apiKey": "secrets.SENDGRID_API_KEY",
+    "apiKey": "{{secrets.SENDGRID_API_KEY}}",
     "from": {
       "name": "John Doe",
       "email": "john.doe@example.com"
@@ -194,7 +194,7 @@
     }
   },
   {
-    "apiKey": "secrets.SENDGRID_API_KEY",
+    "apiKey": "{{secrets.SENDGRID_API_KEY}}",
     "from": {
       "name": "John Doe",
       "email": "john.doe@example.com"
@@ -209,7 +209,7 @@
     }
   },
   {
-    "apiKey": "secrets.SENDGRID_API_KEY",
+    "apiKey": "{{secrets.SENDGRID_API_KEY}}",
     "from": {
       "name": "John Doe",
       "email": "john.doe@example.com"

--- a/connectors/sendgrid/src/test/resources/requests/validation/validate-receiver-email-tests-cases.json
+++ b/connectors/sendgrid/src/test/resources/requests/validation/validate-receiver-email-tests-cases.json
@@ -1,7 +1,7 @@
 [
   {
     "description": "receiver email is empty",
-    "apiKey": "secrets.SENDGRID_API_KEY",
+    "apiKey": "{{secrets.SENDGRID_API_KEY}}",
     "from": {
       "name": "John Doe",
       "email": "john.doe@example.com"
@@ -11,9 +11,9 @@
       "email": "       "
     },
     "content": {
-      "subject": "secrets.CONTENT_SUBJECT",
-      "type": "secrets.CONTENT_TYPE",
-      "value": "secrets.CONTENT_VALUE"
+      "subject": "{{secrets.CONTENT_SUBJECT}}",
+      "type": "{{secrets.CONTENT_TYPE}}",
+      "value": "{{secrets.CONTENT_VALUE}}"
     }
   },
   {

--- a/connectors/sendgrid/src/test/resources/requests/validation/validate-receiver-name-tests-cases.json
+++ b/connectors/sendgrid/src/test/resources/requests/validation/validate-receiver-name-tests-cases.json
@@ -1,7 +1,7 @@
 [
   {
     "description": "receiver name is empty",
-    "apiKey": "secrets.SENDGRID_API_KEY",
+    "apiKey": "{{secrets.SENDGRID_API_KEY}}",
     "from": {
       "name": "John Doe",
       "email": "john.doe@example.com"
@@ -11,9 +11,9 @@
       "email": "jane.doe@example.com"
     },
     "content": {
-      "subject": "secrets.CONTENT_SUBJECT",
-      "type": "secrets.CONTENT_TYPE",
-      "value": "secrets.CONTENT_VALUE"
+      "subject": "{{secrets.CONTENT_SUBJECT}}",
+      "type": "{{secrets.CONTENT_TYPE}}",
+      "value": "{{secrets.CONTENT_VALUE}}"
     }
   },
   {

--- a/connectors/sendgrid/src/test/resources/requests/validation/validate-sender-email-tests-cases.json
+++ b/connectors/sendgrid/src/test/resources/requests/validation/validate-sender-email-tests-cases.json
@@ -1,7 +1,7 @@
 [
   {
     "description": "sender email is empty",
-    "apiKey": "secrets.SENDGRID_API_KEY",
+    "apiKey": "{{secrets.SENDGRID_API_KEY}}",
     "from": {
       "name": "John Doe",
       "email": "  "
@@ -11,9 +11,9 @@
       "email": "jane.doe@example.com"
     },
     "content": {
-      "subject": "secrets.CONTENT_SUBJECT",
-      "type": "secrets.CONTENT_TYPE",
-      "value": "secrets.CONTENT_VALUE"
+      "subject": "{{secrets.CONTENT_SUBJECT}}",
+      "type": "{{secrets.CONTENT_TYPE}}",
+      "value": "{{secrets.CONTENT_VALUE}}"
     }
   },
   {

--- a/connectors/sendgrid/src/test/resources/requests/validation/validate-sender-name-tests-cases.json
+++ b/connectors/sendgrid/src/test/resources/requests/validation/validate-sender-name-tests-cases.json
@@ -1,7 +1,7 @@
 [
   {
     "description": "sender name is null",
-    "apiKey": "secrets.SENDGRID_API_KEY",
+    "apiKey": "{{secrets.SENDGRID_API_KEY}}",
     "from": {
       "name": null,
       "email": "john.doe@example.com"
@@ -11,9 +11,9 @@
       "email": "jane.doe@example.com"
     },
     "content": {
-      "subject": "secrets.CONTENT_SUBJECT",
-      "type": "secrets.CONTENT_TYPE",
-      "value": "secrets.CONTENT_VALUE"
+      "subject": "{{secrets.CONTENT_SUBJECT}}",
+      "type": "{{secrets.CONTENT_TYPE}}",
+      "value": "{{secrets.CONTENT_VALUE}}"
     }
   },
   {

--- a/connectors/slack/src/test/resources/requests/test-cases/execute-create-channel.json
+++ b/connectors/slack/src/test/resources/requests/test-cases/execute-create-channel.json
@@ -1,10 +1,10 @@
 [
   {
     "description": "with secrets keys without braces",
-    "token": "secrets.TOKEN_KEY",
+    "token": "{{secrets.TOKEN_KEY}}",
     "method": "conversations.create",
     "data": {
-      "newChannelName": "secrets.NEW_CHANNEL_NAME_KEY",
+      "newChannelName": "{{secrets.NEW_CHANNEL_NAME_KEY}}",
       "visibility": "PUBLIC"
     }
   },

--- a/connectors/slack/src/test/resources/requests/test-cases/execute-function-with-channel-name.json
+++ b/connectors/slack/src/test/resources/requests/test-cases/execute-function-with-channel-name.json
@@ -1,11 +1,11 @@
 [
   {
     "description": "with secrets keys without braces",
-    "token": "secrets.TOKEN_KEY",
+    "token": "{{secrets.TOKEN_KEY}}",
     "method": "chat.postMessage",
     "data": {
-      "channel": "secrets.CHANNEL_NAME_KEY",
-      "text": "secrets.TEXT_KEY"
+      "channel": "{{secrets.CHANNEL_NAME_KEY}}",
+      "text": "{{secrets.TEXT_KEY}}"
     }
   },
   {

--- a/connectors/slack/src/test/resources/requests/test-cases/execute-function-with-email.json
+++ b/connectors/slack/src/test/resources/requests/test-cases/execute-function-with-email.json
@@ -1,11 +1,11 @@
 [
   {
     "description": "with secrets keys without braces",
-    "token": "secrets.TOKEN_KEY",
+    "token": "{{secrets.TOKEN_KEY}}",
     "method": "chat.postMessage",
     "data": {
-      "channel": "secrets.EMAIL_KEY",
-      "text": "secrets.TEXT_KEY"
+      "channel": "{{secrets.EMAIL_KEY}}",
+      "text": "{{secrets.TEXT_KEY}}"
     }
   },
   {

--- a/connectors/slack/src/test/resources/requests/test-cases/execute-function-with-username.json
+++ b/connectors/slack/src/test/resources/requests/test-cases/execute-function-with-username.json
@@ -1,11 +1,11 @@
 [
   {
     "description": "with secrets keys without braces",
-    "token": "secrets.TOKEN_KEY",
+    "token": "{{secrets.TOKEN_KEY}}",
     "method": "chat.postMessage",
     "data": {
-      "channel": "secrets.USERNAME_KEY",
-      "text": "secrets.TEXT_KEY"
+      "channel": "{{secrets.USERNAME_KEY}}",
+      "text": "{{secrets.TEXT_KEY}}"
     }
   },
   {

--- a/connectors/slack/src/test/resources/requests/test-cases/execute-invite-to-channel-wrong-input.json
+++ b/connectors/slack/src/test/resources/requests/test-cases/execute-invite-to-channel-wrong-input.json
@@ -1,10 +1,10 @@
 [
   {
     "description": "with null for users input",
-    "token": "secrets.TOKEN_KEY",
+    "token": "{{secrets.TOKEN_KEY}}",
     "method": "conversations.invite",
     "data": {
-      "channelName": "secrets.NEW_CHANNEL_NAME_KEY",
+      "channelName": "{{secrets.NEW_CHANNEL_NAME_KEY}}",
       "users": null
     }
   }

--- a/connectors/slack/src/test/resources/requests/test-cases/execute-invite-to-channel.json
+++ b/connectors/slack/src/test/resources/requests/test-cases/execute-invite-to-channel.json
@@ -1,10 +1,10 @@
 [
   {
     "description": "with secrets keys without braces",
-    "token": "secrets.TOKEN_KEY",
+    "token": "{{secrets.TOKEN_KEY}}",
     "method": "conversations.invite",
     "data": {
-      "channelName": "secrets.NEW_CHANNEL_NAME_KEY",
+      "channelName": "{{secrets.NEW_CHANNEL_NAME_KEY}}",
       "users": "@JohnDou"
     }
   },

--- a/connectors/slack/src/test/resources/requests/test-cases/replace-secrets.json
+++ b/connectors/slack/src/test/resources/requests/test-cases/replace-secrets.json
@@ -1,11 +1,11 @@
 [
   {
     "description": "all secrets keys exist without braces",
-    "token": "secrets.TOKEN_KEY",
+    "token": "{{secrets.TOKEN_KEY}}",
     "method": "chat.postMessage",
     "data": {
-      "channel": "secrets.EMAIL_KEY",
-      "text": "secrets.TEXT_KEY"
+      "channel": "{{secrets.EMAIL_KEY}}",
+      "text": "{{secrets.TEXT_KEY}}"
     }
   },
   {
@@ -19,28 +19,28 @@
   },
   {
     "description": "secrets in braces after text",
-    "token": "secrets.TOKEN_KEY",
+    "token": "{{secrets.TOKEN_KEY}}",
     "method": "chat.postMessage",
     "data": {
-      "channel": "secrets.EMAIL_KEY",
+      "channel": "{{secrets.EMAIL_KEY}}",
       "text": "some text {{secrets.TEXT_KEY}}"
     }
   },
   {
     "description": "secrets in braces in text",
-    "token": "secrets.TOKEN_KEY",
+    "token": "{{secrets.TOKEN_KEY}}",
     "method": "chat.postMessage",
     "data": {
-      "channel": "secrets.EMAIL_KEY",
+      "channel": "{{secrets.EMAIL_KEY}}",
       "text": "some  {{ secrets.TEXT_KEY}} text"
     }
   },
   {
     "description": "secrets before braces in text",
-    "token": "secrets.TOKEN_KEY",
+    "token": "{{secrets.TOKEN_KEY}}",
     "method": "chat.postMessage",
     "data": {
-      "channel": "secrets.EMAIL_KEY",
+      "channel": "{{secrets.EMAIL_KEY}}",
       "text": "{{secrets.TEXT_KEY}} some text"
     }
   }

--- a/connectors/slack/src/test/resources/requests/test-cases/with-wrong-method.json
+++ b/connectors/slack/src/test/resources/requests/test-cases/with-wrong-method.json
@@ -3,8 +3,8 @@
     "token": "xoxb-0123456789456-123467890987-thisIsTestToken",
     "method": "chatpostMessage",
     "data": {
-      "channel": "secrets.CHANNEL_NAME_KEY",
-      "text": "secrets.TEXT_KEY"
+      "channel": "{{secrets.CHANNEL_NAME_KEY}}",
+      "text": "{{secrets.TEXT_KEY}}"
     }
   },
   {


### PR DESCRIPTION
## Description

support double parentheses in all connectors

## Related issues
https://github.com/camunda/team-connectors/issues/448

The next step update docs and correct templates and raise the version.  this pattern can help find all needed templates : `value".+[^\{\{].+secrets\.?.+",`
