### PR TITLE
fix: support FEEL for Kafka additional properties

### DIFF
--- a/connectors/kafka/src/main/java/io/camunda/connector/kafka/inbound/KafkaConnectorProperties.java
+++ b/connectors/kafka/src/main/java/io/camunda/connector/kafka/inbound/KafkaConnectorProperties.java
@@ -24,7 +24,7 @@ public class KafkaConnectorProperties {
 
   @Valid @NotNull private KafkaTopic topic;
 
-  private Map<String, Object> additionalProperties = new HashMap<>();
+  @FEEL private Map<String, Object> additionalProperties = new HashMap<>();
 
   private String activationCondition;
 


### PR DESCRIPTION
## Description

Add the `@FEEL` annotation to Kafka additional properties to handle JSON and FEEL mappings.

## Related issues

<!-- Which issues are closed by this PR or are related -->

related to #983

