### PR TITLE
fix(build): adjust project version bump step in the release pipeline

### DIFF
--- a/.github/workflows/RELEASE.yaml
+++ b/.github/workflows/RELEASE.yaml
@@ -94,7 +94,7 @@ jobs:
     # Maven build & version bump
 
       - name: Set Connectors release version
-        run:  mvn -B versions:set -DnewVersion=${RELEASE_VERSION} -DgenerateBackupPoms=false
+        run:  mvn -B versions:set -DnewVersion=${RELEASE_VERSION} -DgenerateBackupPoms=false -f parent
         env:
           RELEASE_VERSION: ${{ github.event.inputs.version }}
 


### PR DESCRIPTION
## Description

Adjust the version bump step to take the new project structure into account (parent is now not in the root dir)


