### PR TITLE
chore: configure operate client to be always enabled

### DIFF
--- a/bundle/camunda-saas-bundle/src/main/resources/application.properties
+++ b/bundle/camunda-saas-bundle/src/main/resources/application.properties
@@ -17,6 +17,3 @@ camunda.connector.auth.issuer=https://weblogin.cloud.dev.ultrawombat.com/
 
 # Enforce local connection, even if cluster-id set (for Operate Auth)
 zeebe.client.connection-mode=ADDRESS
-
-# Enable operate client and secret provider initialization. Must be disabled (set to false) to avoid creating the default operate client bean.
-operate.client.enabled=false

--- a/connector-runtime/connector-runtime-application/src/main/resources/application.properties
+++ b/connector-runtime/connector-runtime-application/src/main/resources/application.properties
@@ -8,7 +8,6 @@ zeebe.client.worker.threads=10
 camunda.connector.polling.enabled=true
 camunda.connector.polling.interval=5000
 
-operate.client.enabled=true
 # Operate config for use with docker-compose-core.yml
 camunda.operate.client.url=http://localhost:8081
 camunda.operate.client.username=demo

--- a/connector-runtime/spring-boot-starter-camunda-connectors/README.md
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/README.md
@@ -17,4 +17,3 @@ The Connector runtime used with this starter can be configured via the following
 | `camunda.connector.polling.enabled`  | Whether Operate polling is enabled. This is required for inbound Connectors.        | `true`  |
 | `camunda.connector.polling.interval` | The interval in which Operate polls for new process deployments.                    | `5000`  |
 | `camunda.connector.webhook.enabled`  | Whether webhook connector support is enabled.                                       | `true`  |
-| `operate.client.enabled`             | Whether default Operate client is enabled. This is required for inbound Connectors. | `true`  |

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/main/java/io/camunda/connector/runtime/InboundConnectorsAutoConfiguration.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/main/java/io/camunda/connector/runtime/InboundConnectorsAutoConfiguration.java
@@ -17,14 +17,22 @@
 package io.camunda.connector.runtime;
 
 import io.camunda.connector.runtime.inbound.InboundConnectorRuntimeConfiguration;
+import io.camunda.operate.CamundaOperateClient;
+import io.camunda.zeebe.spring.client.configuration.OperateClientProdAutoConfiguration;
+import io.camunda.zeebe.spring.client.properties.OperateClientConfigurationProperties;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @AutoConfiguration
 @AutoConfigureBefore(OutboundConnectorsAutoConfiguration.class)
+@AutoConfigureAfter(OperateClientProdAutoConfiguration.class)
 @ConditionalOnProperty(
     prefix = "camunda.connector.polling",
     name = "enabled",
@@ -32,4 +40,20 @@ import org.springframework.scheduling.annotation.EnableScheduling;
     matchIfMissing = true)
 @Import(InboundConnectorRuntimeConfiguration.class)
 @EnableScheduling
-public class InboundConnectorsAutoConfiguration {}
+@EnableConfigurationProperties(OperateClientConfigurationProperties.class)
+public class InboundConnectorsAutoConfiguration {
+
+  @Bean
+  @ConditionalOnMissingBean
+  public CamundaOperateClient myOperateClient(
+      OperateClientProdAutoConfiguration configuration,
+      OperateClientConfigurationProperties properties) {
+    return configuration.camundaOperateClient(properties);
+  }
+
+  @Bean
+  @ConditionalOnMissingBean
+  public OperateClientProdAutoConfiguration operateClientProdAutoConfiguration() {
+    return new OperateClientProdAutoConfiguration();
+  }
+}

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/main/resources/application.properties
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/main/resources/application.properties
@@ -1,8 +1,5 @@
 #server.port=9898
 
-# Use this property to enable Operate client (required for inbound connectors)
-#operate.client.enabled=true
-
 # Use these properties to disable inbound connectors (then Operate client won't be required)
 #camunda.connector.polling.enabled=false
 #camunda.connector.webhook.enabled=false

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/inbound/OperateClientAvailabilityTest.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/inbound/OperateClientAvailabilityTest.java
@@ -1,0 +1,25 @@
+package io.camunda.connector.runtime.inbound;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.connector.runtime.app.TestConnectorRuntimeApplication;
+import io.camunda.operate.CamundaOperateClient;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ApplicationContext;
+import org.springframework.test.context.TestPropertySource;
+
+@SpringBootTest(classes = TestConnectorRuntimeApplication.class)
+@TestPropertySource(properties = {"camunda.connector.polling.enabled=true"})
+public class OperateClientAvailabilityTest {
+
+  @Autowired
+  private ApplicationContext applicationContext;
+
+  @Test
+  void noExtraProperties_operateClientAvailable() {
+    // Operate client is available
+    assertThat(applicationContext.getBeansOfType(CamundaOperateClient.class)).hasSize(1);
+  }
+}

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/inbound/OperateClientAvailabilityTest.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/inbound/OperateClientAvailabilityTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.camunda.connector.runtime.inbound;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -14,8 +30,7 @@ import org.springframework.test.context.TestPropertySource;
 @TestPropertySource(properties = {"camunda.connector.polling.enabled=true"})
 public class OperateClientAvailabilityTest {
 
-  @Autowired
-  private ApplicationContext applicationContext;
+  @Autowired private ApplicationContext applicationContext;
 
   @Test
   void noExtraProperties_operateClientAvailable() {

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/test/resources/application.properties
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/test/resources/application.properties
@@ -1,5 +1,6 @@
-# replaced with mock in test scope
-operate.client.enabled=false
-
 # test secret property
 test.secret=test secret value
+
+camunda.operate.client.url=http://localhost:8081
+camunda.operate.client.username=demo
+camunda.operate.client.password=demo


### PR DESCRIPTION
## Description

This is somewhat messy, but does the job.

[`OperateClientAutoConfiguration`](https://github.com/camunda-community-hub/spring-zeebe/blob/main/spring-boot-starter-camunda/src/main/java/io/camunda/zeebe/spring/client/configuration/OperateClientProdAutoConfiguration.java) defined in Spring Zeebe is actually not an auto configuration, it's just a regular configuration, despite its name. It has a `@ConditionalOnProperty` on `operate.client.enabled`. We can't just change this behavior in spring-boot-starter-camunda (I expect that many people rely on it), so we have to override it manually.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #918 

