### PR TITLE
Operate client fix

### DIFF
--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/main/java/io/camunda/connector/runtime/InboundConnectorsAutoConfiguration.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/main/java/io/camunda/connector/runtime/InboundConnectorsAutoConfiguration.java
@@ -31,10 +31,7 @@ import org.springframework.context.annotation.Import;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @AutoConfiguration
-@AutoConfigureAfter({
-    CamundaAutoConfiguration.class,
-    OutboundConnectorsAutoConfiguration.class
-})
+@AutoConfigureAfter({CamundaAutoConfiguration.class, OutboundConnectorsAutoConfiguration.class})
 @ConditionalOnProperty(
     prefix = "camunda.connector.polling",
     name = "enabled",

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/main/java/io/camunda/connector/runtime/InboundConnectorsAutoConfiguration.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/main/java/io/camunda/connector/runtime/InboundConnectorsAutoConfiguration.java
@@ -18,6 +18,7 @@ package io.camunda.connector.runtime;
 
 import io.camunda.connector.runtime.inbound.InboundConnectorRuntimeConfiguration;
 import io.camunda.operate.CamundaOperateClient;
+import io.camunda.zeebe.spring.client.CamundaAutoConfiguration;
 import io.camunda.zeebe.spring.client.configuration.OperateClientProdAutoConfiguration;
 import io.camunda.zeebe.spring.client.properties.OperateClientConfigurationProperties;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
@@ -31,7 +32,7 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 
 @AutoConfiguration
 @AutoConfigureAfter({
-    OperateClientProdAutoConfiguration.class,
+    CamundaAutoConfiguration.class,
     OutboundConnectorsAutoConfiguration.class
 })
 @ConditionalOnProperty(
@@ -46,7 +47,6 @@ public class InboundConnectorsAutoConfiguration {
 
   @Bean
   @ConditionalOnMissingBean
-  @ConditionalOnProperty(value = "operate.client.enabled", havingValue = "false", matchIfMissing = true)
   public CamundaOperateClient myOperateClient(
       OperateClientProdAutoConfiguration configuration,
       OperateClientConfigurationProperties properties) {
@@ -55,7 +55,6 @@ public class InboundConnectorsAutoConfiguration {
 
   @Bean
   @ConditionalOnMissingBean
-  @ConditionalOnProperty(value = "operate.client.enabled", havingValue = "false", matchIfMissing = true)
   public OperateClientProdAutoConfiguration operateClientProdAutoConfiguration() {
     return new OperateClientProdAutoConfiguration();
   }

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/main/java/io/camunda/connector/runtime/InboundConnectorsAutoConfiguration.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/main/java/io/camunda/connector/runtime/InboundConnectorsAutoConfiguration.java
@@ -22,7 +22,6 @@ import io.camunda.zeebe.spring.client.configuration.OperateClientProdAutoConfigu
 import io.camunda.zeebe.spring.client.properties.OperateClientConfigurationProperties;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
-import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -31,8 +30,10 @@ import org.springframework.context.annotation.Import;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @AutoConfiguration
-@AutoConfigureBefore(OutboundConnectorsAutoConfiguration.class)
-@AutoConfigureAfter(OperateClientProdAutoConfiguration.class)
+@AutoConfigureAfter({
+    OperateClientProdAutoConfiguration.class,
+    OutboundConnectorsAutoConfiguration.class
+})
 @ConditionalOnProperty(
     prefix = "camunda.connector.polling",
     name = "enabled",
@@ -45,6 +46,7 @@ public class InboundConnectorsAutoConfiguration {
 
   @Bean
   @ConditionalOnMissingBean
+  @ConditionalOnProperty(value = "operate.client.enabled", havingValue = "false", matchIfMissing = true)
   public CamundaOperateClient myOperateClient(
       OperateClientProdAutoConfiguration configuration,
       OperateClientConfigurationProperties properties) {
@@ -53,6 +55,7 @@ public class InboundConnectorsAutoConfiguration {
 
   @Bean
   @ConditionalOnMissingBean
+  @ConditionalOnProperty(value = "operate.client.enabled", havingValue = "false", matchIfMissing = true)
   public OperateClientProdAutoConfiguration operateClientProdAutoConfiguration() {
     return new OperateClientProdAutoConfiguration();
   }


### PR DESCRIPTION
## Description

Turns out `OperateClientProdAutoConfiguration` is actually not an auto configuration in Spring Zeebe (despite the name), so the ordering annotations didn't work properly.
