### PR TITLE
feat: define element template generator DSL

### DIFF
--- a/connector-sdk/element-template-generator/pom.xml
+++ b/connector-sdk/element-template-generator/pom.xml
@@ -1,0 +1,34 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>io.camunda.connector</groupId>
+    <artifactId>connector-parent</artifactId>
+    <relativePath>../../parent/pom.xml</relativePath>
+    <version>0.23.0-SNAPSHOT</version>
+  </parent>
+
+  <name>element-template-generator</name>
+  <description>Camunda Connector template generator</description>
+  <artifactId>element-template-generator</artifactId>
+  <packaging>jar</packaging>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.skyscreamer</groupId>
+      <artifactId>jsonassert</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/connector-sdk/element-template-generator/src/main/java/io/camunda/connector/generator/dsl/BooleanProperty.java
+++ b/connector-sdk/element-template-generator/src/main/java/io/camunda/connector/generator/dsl/BooleanProperty.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.generator.dsl;
+
+public final class BooleanProperty extends Property {
+
+  public static final String TYPE = "Boolean";
+
+  public BooleanProperty(
+      String name,
+      String label,
+      String description,
+      Boolean required,
+      String value,
+      PropertyConstraints constraints,
+      FeelMode feel,
+      String group,
+      PropertyBinding binding,
+      PropertyCondition condition) {
+    super(
+        name,
+        label,
+        description,
+        required,
+        value,
+        constraints,
+        feel,
+        group,
+        binding,
+        condition,
+        TYPE);
+  }
+
+  public static BooleanPropertyBuilder builder() {
+    return new BooleanPropertyBuilder();
+  }
+
+  public static final class BooleanPropertyBuilder extends PropertyBuilder {
+
+    private BooleanPropertyBuilder() {}
+
+    public BooleanProperty build() {
+      return new BooleanProperty(
+          name, label, description, required, value, constraints, feel, group, binding, condition);
+    }
+  }
+}

--- a/connector-sdk/element-template-generator/src/main/java/io/camunda/connector/generator/dsl/BpmnType.java
+++ b/connector-sdk/element-template-generator/src/main/java/io/camunda/connector/generator/dsl/BpmnType.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.generator.dsl;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+public enum BpmnType {
+  TASK("bpmn:Task"),
+  SERVICE_TASK("bpmn:ServiceTask"),
+  START_EVENT("bpmn:StartEvent"),
+  INTERMEDIATE_CATCH_EVENT("bpmn:IntermediateCatchEvent"),
+  INTERMEDIATE_THROW_EVENT("bpmn:IntermediateThrowEvent");
+
+  private final String name;
+
+  BpmnType(String name) {
+    this.name = name;
+  }
+
+  @JsonValue
+  public String getName() {
+    return name;
+  }
+}

--- a/connector-sdk/element-template-generator/src/main/java/io/camunda/connector/generator/dsl/DropdownProperty.java
+++ b/connector-sdk/element-template-generator/src/main/java/io/camunda/connector/generator/dsl/DropdownProperty.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.generator.dsl;
+
+import java.util.List;
+
+public final class DropdownProperty extends Property {
+
+  public static final String TYPE = "Dropdown";
+
+  private final List<DropdownChoice> choices;
+
+  public DropdownProperty(
+      String name,
+      String label,
+      String description,
+      Boolean required,
+      String value,
+      PropertyConstraints constraints,
+      FeelMode feel,
+      String group,
+      PropertyBinding binding,
+      PropertyCondition condition,
+      List<DropdownChoice> choices) {
+    super(
+        name,
+        label,
+        description,
+        required,
+        value,
+        constraints,
+        feel,
+        group,
+        binding,
+        condition,
+        TYPE);
+    this.choices = choices;
+  }
+
+  public List<DropdownChoice> getChoices() {
+    return choices;
+  }
+
+  public record DropdownChoice(String name, String value) {}
+
+  public static DropdownPropertyBuilder builder() {
+    return new DropdownPropertyBuilder();
+  }
+
+  public static final class DropdownPropertyBuilder extends PropertyBuilder {
+
+    private List<DropdownChoice> choices;
+
+    private DropdownPropertyBuilder() {}
+
+    public DropdownPropertyBuilder choices(List<DropdownChoice> choices) {
+      this.choices = choices;
+      return this;
+    }
+
+    public DropdownProperty build() {
+      return new DropdownProperty(
+          name,
+          label,
+          description,
+          required,
+          value,
+          constraints,
+          feel,
+          group,
+          binding,
+          condition,
+          choices);
+    }
+  }
+}

--- a/connector-sdk/element-template-generator/src/main/java/io/camunda/connector/generator/dsl/ElementTemplateCategory.java
+++ b/connector-sdk/element-template-generator/src/main/java/io/camunda/connector/generator/dsl/ElementTemplateCategory.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.generator.dsl;
+
+public record ElementTemplateCategory(String id, String name) {
+
+  public static final ElementTemplateCategory CONNECTORS =
+      new ElementTemplateCategory("connectors", "Connectors");
+}

--- a/connector-sdk/element-template-generator/src/main/java/io/camunda/connector/generator/dsl/ElementTemplateSchema.java
+++ b/connector-sdk/element-template-generator/src/main/java/io/camunda/connector/generator/dsl/ElementTemplateSchema.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.generator.dsl;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+interface ElementTemplateSchema {
+
+  String SCHEMA_FIELD_NAME = "$schema";
+  String SCHEMA_URL =
+      "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json";
+
+  @JsonProperty(SCHEMA_FIELD_NAME)
+  default String schema() {
+    return SCHEMA_URL;
+  }
+}

--- a/connector-sdk/element-template-generator/src/main/java/io/camunda/connector/generator/dsl/HiddenProperty.java
+++ b/connector-sdk/element-template-generator/src/main/java/io/camunda/connector/generator/dsl/HiddenProperty.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.generator.dsl;
+
+public final class HiddenProperty extends Property {
+
+  public static final String TYPE = "Hidden";
+
+  public HiddenProperty(
+      String name,
+      String label,
+      String description,
+      Boolean required,
+      String value,
+      PropertyConstraints constraints,
+      FeelMode feel,
+      String group,
+      PropertyBinding binding,
+      PropertyCondition condition) {
+    super(
+        name,
+        label,
+        description,
+        required,
+        value,
+        constraints,
+        feel,
+        group,
+        binding,
+        condition,
+        TYPE);
+  }
+
+  public static HiddenPropertyBuilder builder() {
+    return new HiddenPropertyBuilder();
+  }
+
+  public static final class HiddenPropertyBuilder extends PropertyBuilder {
+
+    private HiddenPropertyBuilder() {}
+
+    public HiddenProperty build() {
+      return new HiddenProperty(
+          name, label, description, required, value, constraints, feel, group, binding, condition);
+    }
+  }
+}

--- a/connector-sdk/element-template-generator/src/main/java/io/camunda/connector/generator/dsl/OutboundElementTemplate.java
+++ b/connector-sdk/element-template-generator/src/main/java/io/camunda/connector/generator/dsl/OutboundElementTemplate.java
@@ -22,7 +22,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
 @JsonPropertyOrder({
@@ -46,7 +45,8 @@ public record OutboundElementTemplate(
     String documentationRef,
     String description,
     List<PropertyGroup> groups,
-    List<Property> properties) {
+    List<Property> properties)
+    implements ElementTemplateSchema {
 
   public OutboundElementTemplate {
     List<String> errors = new ArrayList<>();
@@ -76,27 +76,24 @@ public record OutboundElementTemplate(
     }
   }
 
-  @JsonProperty("$schema")
-  public String schema() {
-    return "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json";
+  @JsonProperty
+  public Set<BpmnType> appliesTo() {
+    return Set.of(BpmnType.TASK);
   }
 
   @JsonProperty
-  public Set<String> appliesTo() {
-    return Set.of("bpmn:Task");
+  public ElementType elementType() {
+    return new ElementType(BpmnType.SERVICE_TASK);
   }
 
   @JsonProperty
-  public Map<String, String> elementType() {
-    return Map.of("value", "bpmn:ServiceTask");
-  }
-
-  @JsonProperty
-  public Map<String, String> category() {
-    return Map.of("id", "connectors", "name", "Connectors");
+  public ElementTemplateCategory category() {
+    return ElementTemplateCategory.CONNECTORS;
   }
 
   public static OutboundElementTemplateBuilder builder() {
     return OutboundElementTemplateBuilder.create();
   }
+
+  public record ElementType(BpmnType value) {}
 }

--- a/connector-sdk/element-template-generator/src/main/java/io/camunda/connector/generator/dsl/OutboundElementTemplate.java
+++ b/connector-sdk/element-template-generator/src/main/java/io/camunda/connector/generator/dsl/OutboundElementTemplate.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.generator.dsl;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+@JsonPropertyOrder({
+  "$schema",
+  "name",
+  "id",
+  "description",
+  "documentationRef",
+  "version",
+  "category",
+  "appliesTo",
+  "elementType",
+  "groups",
+  "properties"
+})
+@JsonInclude(Include.NON_NULL)
+public record OutboundElementTemplate(
+    String id,
+    String name,
+    int version,
+    String documentationRef,
+    String description,
+    List<PropertyGroup> groups,
+    List<Property> properties) {
+
+  public OutboundElementTemplate {
+    List<String> errors = new ArrayList<>();
+    if (id == null) {
+      errors.add("id is required");
+    }
+    if (name == null) {
+      errors.add("name is required");
+    }
+    if (version < 0) {
+      errors.add("version cannot be negative");
+    }
+    if (documentationRef == null) {
+      errors.add("documentationRef is required");
+    }
+    if (description == null) {
+      errors.add("description is required");
+    }
+    if (groups == null) {
+      errors.add("groups is required");
+    }
+    if (properties == null) {
+      errors.add("properties is required");
+    }
+    if (!errors.isEmpty()) {
+      throw new IllegalArgumentException(String.join(", ", errors));
+    }
+  }
+
+  @JsonProperty("$schema")
+  public String schema() {
+    return "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json";
+  }
+
+  @JsonProperty
+  public Set<String> appliesTo() {
+    return Set.of("bpmn:Task");
+  }
+
+  @JsonProperty
+  public Map<String, String> elementType() {
+    return Map.of("value", "bpmn:ServiceTask");
+  }
+
+  @JsonProperty
+  public Map<String, String> category() {
+    return Map.of("id", "connectors", "name", "Connectors");
+  }
+
+  public static OutboundElementTemplateBuilder builder() {
+    return OutboundElementTemplateBuilder.create();
+  }
+}

--- a/connector-sdk/element-template-generator/src/main/java/io/camunda/connector/generator/dsl/OutboundElementTemplateBuilder.java
+++ b/connector-sdk/element-template-generator/src/main/java/io/camunda/connector/generator/dsl/OutboundElementTemplateBuilder.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.generator.dsl;
+
+import io.camunda.connector.generator.dsl.PropertyBinding.ZeebeTaskDefinitionType;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class OutboundElementTemplateBuilder {
+
+  private String id;
+  private String name;
+  private int version;
+  private String documentationRef;
+  private String description;
+  private final List<PropertyGroup> groups = new ArrayList<>();
+  private final List<Property> properties = new ArrayList<>();
+
+  private OutboundElementTemplateBuilder() {}
+
+  static OutboundElementTemplateBuilder create() {
+    return new OutboundElementTemplateBuilder();
+  }
+
+  public OutboundElementTemplateBuilder id(String id) {
+    this.id = id;
+    return this;
+  }
+
+  public OutboundElementTemplateBuilder type(String type) {
+    if (isTypeAssigned()) {
+      throw new IllegalStateException("type is already assigned");
+    }
+    properties.add(
+        HiddenProperty.builder()
+            .value(type)
+            .binding(PropertyBinding.ZeebeTaskDefinitionType.INSTANCE)
+            .build());
+    return this;
+  }
+
+  public OutboundElementTemplateBuilder name(String name) {
+    this.name = name;
+    return this;
+  }
+
+  public OutboundElementTemplateBuilder version(int version) {
+    this.version = version;
+    return this;
+  }
+
+  public OutboundElementTemplateBuilder documentationRef(String documentationRef) {
+    this.documentationRef = documentationRef;
+    return this;
+  }
+
+  public OutboundElementTemplateBuilder description(String description) {
+    this.description = description;
+    return this;
+  }
+
+  public OutboundElementTemplateBuilder propertyGroups(PropertyGroup... groups) {
+    this.groups.addAll(Arrays.asList(groups));
+    this.properties.addAll(
+        this.groups.stream().flatMap(group -> group.properties().stream()).toList());
+    return this;
+  }
+
+  public OutboundElementTemplateBuilder properties(Property... properties) {
+    this.properties.addAll(Arrays.asList(properties));
+    return this;
+  }
+
+  public OutboundElementTemplate build() {
+    if (!isTypeAssigned()) {
+      throw new IllegalStateException("type is not assigned");
+    }
+    return new OutboundElementTemplate(
+        id, name, version, documentationRef, description, groups, properties);
+  }
+
+  private boolean isTypeAssigned() {
+    return this.properties.stream()
+        .anyMatch(property -> property.binding.type().equals(ZeebeTaskDefinitionType.NAME));
+  }
+}

--- a/connector-sdk/element-template-generator/src/main/java/io/camunda/connector/generator/dsl/Property.java
+++ b/connector-sdk/element-template-generator/src/main/java/io/camunda/connector/generator/dsl/Property.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.generator.dsl;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import java.util.Objects;
+
+@JsonInclude(Include.NON_NULL)
+public abstract sealed class Property
+    permits BooleanProperty, DropdownProperty, HiddenProperty, StringProperty, TextProperty {
+
+  protected final String name;
+  protected final String label;
+  protected final String description;
+  protected final Boolean required;
+  protected final String value;
+  protected final PropertyConstraints constraints;
+  protected final FeelMode feel;
+  protected final String group;
+  protected final PropertyBinding binding;
+  protected final PropertyCondition condition;
+
+  protected final String type;
+
+  enum FeelMode {
+    optional,
+    required
+  }
+
+  public Property(
+      String name,
+      String label,
+      String description,
+      Boolean required,
+      String value,
+      PropertyConstraints constraints,
+      FeelMode feel,
+      String group,
+      PropertyBinding binding,
+      PropertyCondition condition,
+      String type) {
+    this.name = name;
+    this.label = label;
+    this.description = description;
+    this.required = required;
+    this.value = value;
+    this.constraints = constraints;
+    this.feel = feel;
+    this.group = group;
+    this.binding = binding;
+    this.condition = condition;
+    this.type = type;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public String getLabel() {
+    return label;
+  }
+
+  public String getDescription() {
+    return description;
+  }
+
+  public Boolean isRequired() {
+    return required;
+  }
+
+  public String getValue() {
+    return value;
+  }
+
+  public PropertyConstraints getConstraints() {
+    return constraints;
+  }
+
+  public FeelMode getFeel() {
+    return feel;
+  }
+
+  public String getGroup() {
+    return group;
+  }
+
+  public PropertyBinding getBinding() {
+    return binding;
+  }
+
+  public String getType() {
+    return type;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    Property property = (Property) o;
+    return required == property.required
+        && Objects.equals(name, property.name)
+        && Objects.equals(label, property.label)
+        && Objects.equals(description, property.description)
+        && Objects.equals(value, property.value)
+        && Objects.equals(constraints, property.constraints)
+        && feel == property.feel
+        && Objects.equals(group, property.group)
+        && Objects.equals(binding, property.binding)
+        && Objects.equals(type, property.type);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        name, label, description, required, value, constraints, feel, group, binding, type);
+  }
+
+  @Override
+  public String toString() {
+    return "Property{"
+        + "name='"
+        + name
+        + '\''
+        + ", label='"
+        + label
+        + '\''
+        + ", description='"
+        + description
+        + '\''
+        + ", required="
+        + required
+        + ", value='"
+        + value
+        + '\''
+        + ", constraints="
+        + constraints
+        + ", feel="
+        + feel
+        + ", group='"
+        + group
+        + '\''
+        + ", binding="
+        + binding
+        + ", type='"
+        + type
+        + '\''
+        + '}';
+  }
+}

--- a/connector-sdk/element-template-generator/src/main/java/io/camunda/connector/generator/dsl/PropertyBinding.java
+++ b/connector-sdk/element-template-generator/src/main/java/io/camunda/connector/generator/dsl/PropertyBinding.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.generator.dsl;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public sealed interface PropertyBinding {
+
+  @JsonProperty("type")
+  String type();
+
+  record ZeebeInput(String name) implements PropertyBinding {
+
+    @Override
+    public String type() {
+      return "zeebe:input";
+    }
+  }
+
+  record ZeebeTaskHeader(String key) implements PropertyBinding {
+
+    @Override
+    public String type() {
+      return "zeebe:taskHeader";
+    }
+  }
+
+  final class ZeebeTaskDefinitionType implements PropertyBinding {
+
+    public static final String NAME = "zeebe:taskDefinition:type";
+
+    private ZeebeTaskDefinitionType() {}
+
+    public static ZeebeTaskDefinitionType INSTANCE = new ZeebeTaskDefinitionType();
+
+    @Override
+    public String type() {
+      return NAME;
+    }
+  }
+}

--- a/connector-sdk/element-template-generator/src/main/java/io/camunda/connector/generator/dsl/PropertyBuilder.java
+++ b/connector-sdk/element-template-generator/src/main/java/io/camunda/connector/generator/dsl/PropertyBuilder.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.generator.dsl;
+
+import io.camunda.connector.generator.dsl.BooleanProperty.BooleanPropertyBuilder;
+import io.camunda.connector.generator.dsl.DropdownProperty.DropdownPropertyBuilder;
+import io.camunda.connector.generator.dsl.HiddenProperty.HiddenPropertyBuilder;
+import io.camunda.connector.generator.dsl.Property.FeelMode;
+import io.camunda.connector.generator.dsl.StringProperty.StringPropertyBuilder;
+import io.camunda.connector.generator.dsl.TextProperty.TextPropertyBuilder;
+
+public abstract sealed class PropertyBuilder
+    permits BooleanPropertyBuilder,
+        DropdownPropertyBuilder,
+        HiddenPropertyBuilder,
+        StringPropertyBuilder,
+        TextPropertyBuilder {
+
+  protected String name;
+  protected String label;
+  protected String description;
+  protected Boolean required;
+  protected String value;
+  protected PropertyConstraints constraints;
+  protected FeelMode feel;
+  protected String group;
+  protected PropertyBinding binding;
+  protected String type;
+  protected PropertyCondition condition;
+
+  protected PropertyBuilder() {}
+
+  public PropertyBuilder name(String name) {
+    this.name = name;
+    return this;
+  }
+
+  public PropertyBuilder label(String label) {
+    this.label = label;
+    return this;
+  }
+
+  public PropertyBuilder description(String description) {
+    this.description = description;
+    return this;
+  }
+
+  public PropertyBuilder required(boolean required) {
+    this.required = required;
+    return this;
+  }
+
+  public PropertyBuilder value(String value) {
+    this.value = value;
+    return this;
+  }
+
+  public PropertyBuilder constraints(PropertyConstraints constraints) {
+    this.constraints = constraints;
+    return this;
+  }
+
+  public PropertyBuilder feel(FeelMode feel) {
+    this.feel = feel;
+    return this;
+  }
+
+  public PropertyBuilder binding(PropertyBinding binding) {
+    this.binding = binding;
+    return this;
+  }
+
+  public PropertyBuilder type(String type) {
+    this.type = type;
+    return this;
+  }
+
+  public PropertyBuilder condition(PropertyCondition condition) {
+    this.condition = condition;
+    return this;
+  }
+
+  // package-private to enforce usage of group class
+  PropertyBuilder group(String group) {
+    this.group = group;
+    return this;
+  }
+
+  public abstract Property build();
+}

--- a/connector-sdk/element-template-generator/src/main/java/io/camunda/connector/generator/dsl/PropertyCondition.java
+++ b/connector-sdk/element-template-generator/src/main/java/io/camunda/connector/generator/dsl/PropertyCondition.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.generator.dsl;
+
+public sealed interface PropertyCondition {
+
+  record OneOf(String property, String... values) implements PropertyCondition {}
+
+  record Equals(String property, String equals) implements PropertyCondition {}
+}

--- a/connector-sdk/element-template-generator/src/main/java/io/camunda/connector/generator/dsl/PropertyConstraints.java
+++ b/connector-sdk/element-template-generator/src/main/java/io/camunda/connector/generator/dsl/PropertyConstraints.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.generator.dsl;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+
+@JsonInclude(Include.NON_NULL)
+public record PropertyConstraints(
+    Boolean notEmpty, Integer minLength, Integer maxLength, Pattern pattern) {
+  public record Pattern(String value, String message) {}
+
+  public static PropertyConstraintsBuilder builder() {
+    return new PropertyConstraintsBuilder();
+  }
+
+  public static class PropertyConstraintsBuilder {
+    private Boolean notEmpty;
+    private Integer minLength;
+    private Integer maxLength;
+    private Pattern pattern;
+
+    private PropertyConstraintsBuilder() {}
+
+    public static PropertyConstraintsBuilder create() {
+      return new PropertyConstraintsBuilder();
+    }
+
+    public PropertyConstraintsBuilder notEmpty(boolean notEmpty) {
+      this.notEmpty = notEmpty;
+      return this;
+    }
+
+    public PropertyConstraintsBuilder minLength(int minLength) {
+      this.minLength = minLength;
+      return this;
+    }
+
+    public PropertyConstraintsBuilder maxLength(int maxLength) {
+      this.maxLength = maxLength;
+      return this;
+    }
+
+    public PropertyConstraintsBuilder pattern(Pattern pattern) {
+      this.pattern = pattern;
+      return this;
+    }
+
+    public PropertyConstraints build() {
+      return new PropertyConstraints(notEmpty, minLength, maxLength, pattern);
+    }
+  }
+}

--- a/connector-sdk/element-template-generator/src/main/java/io/camunda/connector/generator/dsl/PropertyGroup.java
+++ b/connector-sdk/element-template-generator/src/main/java/io/camunda/connector/generator/dsl/PropertyGroup.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.generator.dsl;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Stream;
+
+public record PropertyGroup(String id, String label, @JsonIgnore List<Property> properties) {
+
+  public PropertyGroup {
+    if (id == null) {
+      throw new IllegalArgumentException("id is required");
+    }
+    if (label == null) {
+      throw new IllegalArgumentException("label is required");
+    }
+    if (properties == null) {
+      properties = Collections.emptyList();
+    }
+  }
+
+  public static PropertyGroupBuilder builder() {
+    return new PropertyGroupBuilder();
+  }
+
+  public static final class PropertyGroupBuilder {
+
+    private String id;
+    private String label;
+    private List<Property> properties = new ArrayList<>();
+
+    private PropertyGroupBuilder() {}
+
+    public PropertyGroupBuilder id(String id) {
+      this.id = id;
+      return this;
+    }
+
+    public PropertyGroupBuilder label(String label) {
+      this.label = label;
+      return this;
+    }
+
+    public PropertyGroupBuilder properties(PropertyBuilder... properties) {
+      requireIdSet();
+      this.properties.addAll(
+          Stream.of(properties)
+              .map(builder -> builder.group(id))
+              .map(PropertyBuilder::build)
+              .toList());
+      return this;
+    }
+
+    public PropertyGroupBuilder properties(List<Property> properties) {
+      requireIdSet();
+      properties.forEach(
+          property -> {
+            if (!id.equals(property.group)) {
+              throw new IllegalArgumentException(
+                  "Property "
+                      + property.name
+                      + " defines a different group "
+                      + property.group
+                      + " than the group "
+                      + id
+                      + " it is added to");
+            }
+          });
+      this.properties.addAll(properties);
+      return this;
+    }
+
+    public PropertyGroupBuilder properties(Property... properties) {
+      return properties(List.of(properties));
+    }
+
+    public PropertyGroup build() {
+      return new PropertyGroup(id, label, properties);
+    }
+
+    private void requireIdSet() {
+      if (id == null) {
+        throw new IllegalStateException("id is required before properties can be set");
+      }
+    }
+  }
+}

--- a/connector-sdk/element-template-generator/src/main/java/io/camunda/connector/generator/dsl/StringProperty.java
+++ b/connector-sdk/element-template-generator/src/main/java/io/camunda/connector/generator/dsl/StringProperty.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.generator.dsl;
+
+public final class StringProperty extends Property {
+
+  public static final String TYPE = "String";
+
+  public StringProperty(
+      String name,
+      String label,
+      String description,
+      Boolean required,
+      String value,
+      PropertyConstraints constraints,
+      FeelMode feel,
+      String group,
+      PropertyBinding binding,
+      PropertyCondition condition) {
+    super(
+        name,
+        label,
+        description,
+        required,
+        value,
+        constraints,
+        feel,
+        group,
+        binding,
+        condition,
+        TYPE);
+  }
+
+  public static StringPropertyBuilder builder() {
+    return new StringPropertyBuilder();
+  }
+
+  public static final class StringPropertyBuilder extends PropertyBuilder {
+
+    private StringPropertyBuilder() {}
+
+    public StringProperty build() {
+      return new StringProperty(
+          name, label, description, required, value, constraints, feel, group, binding, condition);
+    }
+  }
+}

--- a/connector-sdk/element-template-generator/src/main/java/io/camunda/connector/generator/dsl/TargetElementType.java
+++ b/connector-sdk/element-template-generator/src/main/java/io/camunda/connector/generator/dsl/TargetElementType.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.generator.dsl;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public enum TargetElementType {
+  @JsonProperty("bpmn:ServiceTask")
+  SERVICE_TASK,
+  @JsonProperty("bpmn:StartEvent")
+  START_EVENT,
+}

--- a/connector-sdk/element-template-generator/src/main/java/io/camunda/connector/generator/dsl/TextProperty.java
+++ b/connector-sdk/element-template-generator/src/main/java/io/camunda/connector/generator/dsl/TextProperty.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.generator.dsl;
+
+public final class TextProperty extends Property {
+
+  public static final String TYPE = "Text";
+
+  public TextProperty(
+      String name,
+      String label,
+      String description,
+      Boolean required,
+      String value,
+      PropertyConstraints constraints,
+      FeelMode feel,
+      String group,
+      PropertyBinding binding,
+      PropertyCondition condition) {
+    super(
+        name,
+        label,
+        description,
+        required,
+        value,
+        constraints,
+        feel,
+        group,
+        binding,
+        condition,
+        TYPE);
+  }
+
+  public static TextPropertyBuilder builder() {
+    return new TextPropertyBuilder();
+  }
+
+  public static final class TextPropertyBuilder extends PropertyBuilder {
+
+    private TextPropertyBuilder() {}
+
+    public TextProperty build() {
+      return new TextProperty(
+          name, label, description, required, value, constraints, feel, group, binding, condition);
+    }
+  }
+}

--- a/connector-sdk/element-template-generator/src/test/java/io/camunda/connector/generator/dsl/OutboundElementTemplateSerializationTest.java
+++ b/connector-sdk/element-template-generator/src/test/java/io/camunda/connector/generator/dsl/OutboundElementTemplateSerializationTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.generator.dsl;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.connector.generator.dsl.Property.FeelMode;
+import io.camunda.connector.generator.dsl.PropertyBinding.ZeebeInput;
+import io.camunda.connector.generator.dsl.PropertyBinding.ZeebeTaskHeader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
+
+public class OutboundElementTemplateSerializationTest {
+
+  private final ObjectMapper objectMapper = new ObjectMapper();
+
+  @Test
+  void serializationTest() throws Exception {
+    // given
+    var elementTemplate =
+        OutboundElementTemplate.builder()
+            .id("io.camunda.connector.Template.v1")
+            .type("io.camunda:template:1")
+            .name("Template: Some Function")
+            .version(1)
+            .documentationRef(
+                "https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/available-connectors-overview/")
+            .description("Describe this connector")
+            .propertyGroups(
+                PropertyGroup.builder()
+                    .id("authentication")
+                    .label("Authentication")
+                    .properties(
+                        StringProperty.builder()
+                            .label("Username")
+                            .description("The username for authentication.")
+                            .constraints(PropertyConstraints.builder().notEmpty(true).build())
+                            .feel(FeelMode.optional)
+                            .binding(new ZeebeInput("authentication.user")),
+                        StringProperty.builder()
+                            .label("Token")
+                            .description("The token for authentication.")
+                            .constraints(PropertyConstraints.builder().notEmpty(true).build())
+                            .feel(FeelMode.optional)
+                            .binding(new ZeebeInput("authentication.token")))
+                    .build(),
+                PropertyGroup.builder()
+                    .id("compose")
+                    .label("Compose")
+                    .properties(
+                        TextProperty.builder()
+                            .label("Message")
+                            .feel(FeelMode.optional)
+                            .binding(new ZeebeInput("message"))
+                            .constraints(PropertyConstraints.builder().notEmpty(true).build()))
+                    .build(),
+                PropertyGroup.builder()
+                    .id("output")
+                    .label("Output Mapping")
+                    .properties(
+                        StringProperty.builder()
+                            .label("Result Variable")
+                            .description("Name of variable to store the response in")
+                            .binding(new ZeebeTaskHeader("resultVariable")),
+                        TextProperty.builder()
+                            .label("Result Expression")
+                            .description("Expression to map the response into process variables")
+                            .feel(FeelMode.required)
+                            .binding(new ZeebeTaskHeader("resultExpression")))
+                    .build(),
+                PropertyGroup.builder()
+                    .id("errors")
+                    .label("Error Handling")
+                    .properties(
+                        TextProperty.builder()
+                            .label("Error Expression")
+                            .description(
+                                "Expression to handle errors. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/\" target=\"_blank\">documentation</a>.")
+                            .group("errors")
+                            .feel(FeelMode.required)
+                            .binding(new ZeebeTaskHeader("errorExpression")))
+                    .build())
+            .build();
+
+    // when
+    var jsonString = objectMapper.writeValueAsString(elementTemplate);
+
+    // then
+    var path = Path.of(ClassLoader.getSystemResource("test-element-template.json").toURI());
+    var referenceJsonString = Files.readString(path);
+    JSONAssert.assertEquals(referenceJsonString, jsonString, true);
+  }
+}

--- a/connector-sdk/element-template-generator/src/test/java/io/camunda/connector/generator/dsl/OutboundElementTemplateSerializationTest.java
+++ b/connector-sdk/element-template-generator/src/test/java/io/camunda/connector/generator/dsl/OutboundElementTemplateSerializationTest.java
@@ -99,6 +99,7 @@ public class OutboundElementTemplateSerializationTest {
 
     // when
     var jsonString = objectMapper.writeValueAsString(elementTemplate);
+    System.out.println(jsonString);
 
     // then
     var path = Path.of(ClassLoader.getSystemResource("test-element-template.json").toURI());

--- a/connector-sdk/element-template-generator/src/test/resources/test-element-template.json
+++ b/connector-sdk/element-template-generator/src/test/resources/test-element-template.json
@@ -1,0 +1,118 @@
+{
+  "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+  "name": "Template: Some Function",
+  "id": "io.camunda.connector.Template.v1",
+  "description": "Describe this connector",
+  "version": 1,
+  "documentationRef": "https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/available-connectors-overview/",
+  "category": {
+    "id": "connectors",
+    "name": "Connectors"
+  },
+  "appliesTo": [
+    "bpmn:Task"
+  ],
+  "elementType": {
+    "value": "bpmn:ServiceTask"
+  },
+  "groups": [
+    {
+      "id": "authentication",
+      "label": "Authentication"
+    },
+    {
+      "id": "compose",
+      "label": "Compose"
+    },
+    {
+      "id": "output",
+      "label": "Output Mapping"
+    },
+    {
+      "id": "errors",
+      "label": "Error Handling"
+    }
+  ],
+  "properties": [
+    {
+      "type": "Hidden",
+      "value": "io.camunda:template:1",
+      "binding": {
+        "type": "zeebe:taskDefinition:type"
+      }
+    },
+    {
+      "label": "Username",
+      "description": "The username for authentication.",
+      "group": "authentication",
+      "type": "String",
+      "feel": "optional",
+      "binding": {
+        "type": "zeebe:input",
+        "name": "authentication.user"
+      },
+      "constraints": {
+        "notEmpty": true
+      }
+    },
+    {
+      "label": "Token",
+      "description": "The token for authentication.",
+      "group": "authentication",
+      "type": "String",
+      "feel": "optional",
+      "binding": {
+        "type": "zeebe:input",
+        "name": "authentication.token"
+      },
+      "constraints": {
+        "notEmpty": true
+      }
+    },
+    {
+      "label": "Message",
+      "group": "compose",
+      "type": "Text",
+      "feel": "optional",
+      "binding": {
+        "type": "zeebe:input",
+        "name": "message"
+      },
+      "constraints": {
+        "notEmpty": true
+      }
+    },
+    {
+      "label": "Result Variable",
+      "description": "Name of variable to store the response in",
+      "group": "output",
+      "type": "String",
+      "binding": {
+        "type": "zeebe:taskHeader",
+        "key": "resultVariable"
+      }
+    },
+    {
+      "label": "Result Expression",
+      "description": "Expression to map the response into process variables",
+      "group": "output",
+      "type": "Text",
+      "feel": "required",
+      "binding": {
+        "type": "zeebe:taskHeader",
+        "key": "resultExpression"
+      }
+    },
+    {
+      "label": "Error Expression",
+      "description": "Expression to handle errors. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/\" target=\"_blank\">documentation</a>.",
+      "group": "errors",
+      "type": "Text",
+      "feel": "required",
+      "binding": {
+        "type": "zeebe:taskHeader",
+        "key": "errorExpression"
+      }
+    }
+  ]
+}

--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,7 @@
     <module>connector-sdk/validation</module>
     <module>connector-sdk/test</module>
     <module>connector-sdk/jackson-datatype-feel</module>
+    <module>connector-sdk/element-template-generator</module>
     <module>secret-providers/gcp-secret-provider</module>
     <module>connector-runtime/connector-runtime-core</module>
     <module>connector-runtime/connector-runtime-spring</module>


### PR DESCRIPTION
## Description

DSL for element template generation.

This common base code will be used to provide element template generation based on Java annotations and/or OpenAPI definitions.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes https://github.com/camunda/team-connectors/issues/444

