### PR TITLE
fix: sanitize scala map output

### DIFF
--- a/connector-sdk/jackson-datatype-feel/src/main/java/io/camunda/connector/feel/FeelEngineWrapper.java
+++ b/connector-sdk/jackson-datatype-feel/src/main/java/io/camunda/connector/feel/FeelEngineWrapper.java
@@ -98,6 +98,14 @@ public class FeelEngineWrapper {
     }
   }
 
+  @SuppressWarnings("unchecked")
+  private <T> T sanitizeScalaOutput(T output) {
+    if (output instanceof scala.collection.Map<?,?> scalaMap) {
+      return (T) CollectionConverters.asJava(scalaMap);
+    }
+    else return output;
+  }
+
   /**
    * Evaluates an expression with the FEEL engine with the given variables.
    *
@@ -118,12 +126,12 @@ public class FeelEngineWrapper {
 
   public <T> T evaluate(final String expression, final Object variables, final Class<T> clazz) {
     Object result = evaluate(expression, variables);
-    return objectMapper.convertValue(result, clazz);
+    return sanitizeScalaOutput(objectMapper.convertValue(result, clazz));
   }
 
   public <T> T evaluate(final String expression, final Object variables, final JavaType clazz) {
     Object result = evaluate(expression, variables);
-    return objectMapper.convertValue(result, clazz);
+    return sanitizeScalaOutput(objectMapper.convertValue(result, clazz));
   }
 
   /**

--- a/connector-sdk/jackson-datatype-feel/src/main/java/io/camunda/connector/feel/FeelEngineWrapper.java
+++ b/connector-sdk/jackson-datatype-feel/src/main/java/io/camunda/connector/feel/FeelEngineWrapper.java
@@ -100,10 +100,9 @@ public class FeelEngineWrapper {
 
   @SuppressWarnings("unchecked")
   private <T> T sanitizeScalaOutput(T output) {
-    if (output instanceof scala.collection.Map<?,?> scalaMap) {
+    if (output instanceof scala.collection.Map<?, ?> scalaMap) {
       return (T) CollectionConverters.asJava(scalaMap);
-    }
-    else return output;
+    } else return output;
   }
 
   /**

--- a/connector-sdk/jackson-datatype-feel/src/test/java/io/camunda/connector/feel/FeelEngineWrapperExpressionEvaluationTest.java
+++ b/connector-sdk/jackson-datatype-feel/src/test/java/io/camunda/connector/feel/FeelEngineWrapperExpressionEvaluationTest.java
@@ -185,6 +185,21 @@ class FeelEngineWrapperExpressionEvaluationTest {
         .hasMessageContaining("no function found with name 'camel case'");
   }
 
+  @Test
+  void shouldSanitizeScalaMapOutput() {
+    // given
+    final var expression = "={\"processedOutput\": response.callStatus }";
+    final var variables = Map.of("callStatus", "200 OK");
+
+    // when
+    final var result = objectUnderTest.evaluate(expression, variables, Object.class);
+
+    // then
+    // result is not a scala map
+    assertThat(result).isNotInstanceOf(scala.collection.Map.class);
+    assertThat(result).isEqualTo(Map.of("processedOutput", "200 OK"));
+  }
+
   class TestPojo {
 
     private final String value;


### PR DESCRIPTION
## Description

Avoid exposing scala maps outside of `FeelEngineWrapper`.


