### PR TITLE
fix: sanitize toString and json for inbound connector def impl

### DIFF
--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/InboundConnectorDefinitionImpl.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/InboundConnectorDefinitionImpl.java
@@ -16,6 +16,7 @@
  */
 package io.camunda.connector.runtime.core.inbound;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.connector.api.inbound.InboundConnectorDefinition;
 import io.camunda.connector.api.inbound.correlation.ProcessCorrelationPoint;
 import io.camunda.connector.runtime.core.Keywords;
@@ -24,7 +25,7 @@ import java.util.Optional;
 
 /** Inbound connector definition implementation that also contains connector properties */
 public record InboundConnectorDefinitionImpl(
-    Map<String, String> rawProperties,
+    @JsonIgnore Map<String, String> rawProperties,
     ProcessCorrelationPoint correlationPoint,
     String bpmnProcessId,
     Integer version,
@@ -51,5 +52,24 @@ public record InboundConnectorDefinitionImpl(
 
   public String activationCondition() {
     return rawProperties.get(Keywords.ACTIVATION_CONDITION_KEYWORD);
+  }
+
+  // override to exclude rawProperties
+  @Override
+  public String toString() {
+    return "InboundConnectorDefinitionImpl{"
+        + "correlationPoint="
+        + correlationPoint
+        + ", bpmnProcessId='"
+        + bpmnProcessId
+        + '\''
+        + ", version="
+        + version
+        + ", processDefinitionKey="
+        + processDefinitionKey
+        + ", elementId='"
+        + elementId
+        + '\''
+        + '}';
   }
 }

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/inbound/InboundConnectorDefinitionImplTest.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/inbound/InboundConnectorDefinitionImplTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.runtime.core.inbound;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import io.camunda.connector.api.inbound.correlation.MessageCorrelationPoint;
+import io.camunda.connector.feel.ConnectorsObjectMapperSupplier;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+public class InboundConnectorDefinitionImplTest {
+
+  @Test
+  void rawProperties_notSerializedAsJson() throws JsonProcessingException {
+    // given
+    var testObj =
+        new InboundConnectorDefinitionImpl(
+            Map.of("auth", "abc"), new MessageCorrelationPoint("", ""), "", 0, 0L, "");
+
+    // when
+    var result = ConnectorsObjectMapperSupplier.DEFAULT_MAPPER.writeValueAsString(testObj);
+
+    // then
+    assertThat(result).doesNotContain("auth", "abc");
+  }
+
+  @Test
+  void rawProperties_notPartOfToString() {
+    // given
+    var testObj =
+        new InboundConnectorDefinitionImpl(
+            Map.of("auth", "abc"), new MessageCorrelationPoint("", ""), "", 0, 0L, "");
+
+    // when
+    var result = testObj.toString();
+
+    // then
+    assertThat(result).doesNotContain("auth", "abc");
+  }
+}


### PR DESCRIPTION
## Description

Because `rawProperties` were included into `toString`, sensitive data is potentially leaked (for example, when connector properties contains credentials).


