### PR TITLE
feat(http-polling): prepare SDK to Polling connector

### DIFF
--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/InboundIntermediateConnectorContextImpl.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/InboundIntermediateConnectorContextImpl.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.runtime.core.inbound;
+
+import io.camunda.connector.api.inbound.Health;
+import io.camunda.connector.api.inbound.InboundConnectorContext;
+import io.camunda.connector.api.inbound.InboundConnectorDefinition;
+import io.camunda.connector.api.inbound.InboundConnectorResult;
+import io.camunda.connector.api.inbound.InboundIntermediateConnectorContext;
+import io.camunda.connector.api.inbound.operate.ProcessInstance;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
+
+public class InboundIntermediateConnectorContextImpl
+    implements InboundIntermediateConnectorContext {
+  private final InboundConnectorContext inboundContext;
+  private final Supplier<List<ProcessInstance>> processInstancesSupplier;
+
+  public InboundIntermediateConnectorContextImpl(
+      final InboundConnectorContext inboundContext,
+      final Supplier<List<ProcessInstance>> processInstancesSupplier) {
+    this.inboundContext = inboundContext;
+    this.processInstancesSupplier = processInstancesSupplier;
+  }
+
+  @Override
+  public List<ProcessInstance> getProcessInstances() {
+    return processInstancesSupplier.get();
+  }
+
+  @Override
+  public InboundConnectorResult<?> correlate(final Object variables) {
+    return inboundContext.correlate(variables);
+  }
+
+  @Override
+  public void cancel(final Throwable exception) {
+    inboundContext.cancel(exception);
+  }
+
+  @Override
+  public Map<String, Object> getProperties() {
+    return inboundContext.getProperties();
+  }
+
+  @Override
+  public <T> T bindProperties(final Class<T> cls) {
+    return inboundContext.bindProperties(cls);
+  }
+
+  @Override
+  public InboundConnectorDefinition getDefinition() {
+    return inboundContext.getDefinition();
+  }
+
+  @Override
+  public void reportHealth(final Health health) {
+    inboundContext.reportHealth(health);
+  }
+}

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/importer/ProcessDefinitionSearch.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/importer/ProcessDefinitionSearch.java
@@ -16,13 +16,22 @@
  */
 package io.camunda.connector.runtime.inbound.importer;
 
+import io.camunda.connector.api.inbound.operate.ProcessInstance;
 import io.camunda.operate.CamundaOperateClient;
 import io.camunda.operate.dto.ProcessDefinition;
+import io.camunda.operate.dto.ProcessInstanceState;
 import io.camunda.operate.dto.SearchResult;
+import io.camunda.operate.dto.Variable;
 import io.camunda.operate.exception.OperateException;
+import io.camunda.operate.search.ProcessInstanceFilter;
 import io.camunda.operate.search.SearchQuery;
+import io.camunda.operate.search.VariableFilter;
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Consumer;
+import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.util.CollectionUtils;
@@ -64,5 +73,95 @@ public class ProcessDefinitionSearch {
       resultHandler.accept(result.getItems());
 
     } while (result.getItems().size() > 0);
+  }
+
+  /**
+   * Fetches a list of process instances associated with a given process definition key, including
+   * the variables for each instance. The variables represent the current state of each process
+   * instance and may be updated over the lifetime of the instance.
+   *
+   * @param processDefinitionKey The unique identifier for the process definition to retrieve
+   *     instances of.
+   * @return A list of {@link ProcessInstance} objects, each representing a process instance and its
+   *     associated variables.
+   * @throws RuntimeException If an error occurs during the fetch operation.
+   */
+  public List<ProcessInstance> fetchProcessInstancesWithVariables(final Long processDefinitionKey) {
+    List<Object> processPaginationIndex = null;
+    SearchResult<io.camunda.operate.dto.ProcessInstance> searchResult;
+    List<ProcessInstance> result = new ArrayList<>();
+
+    do {
+      try {
+        ProcessInstanceFilter processInstanceFilter =
+            new ProcessInstanceFilter.Builder()
+                .processDefinitionKey(processDefinitionKey)
+                .state(ProcessInstanceState.ACTIVE)
+                .build();
+        SearchQuery processInstanceQuery =
+            new SearchQuery.Builder()
+                .filter(processInstanceFilter)
+                .searchAfter(processPaginationIndex)
+                .size(20)
+                .build();
+        searchResult =
+            camundaOperateClient.search(
+                processInstanceQuery, io.camunda.operate.dto.ProcessInstance.class);
+      } catch (OperateException e) {
+        throw new RuntimeException(e);
+      }
+      processPaginationIndex = searchResult.getSortValues();
+      searchResult
+          .getItems()
+          .forEach(
+              processInstance -> {
+                Map<String, String> variables =
+                    fetchProcessInstanceVariables(processInstance.getKey());
+                result.add(new ProcessInstance(processInstance.getKey(), variables));
+              });
+
+    } while (searchResult.getItems().size() > 0);
+    return result;
+  }
+
+  /**
+   * Fetches the variables associated with a given process instance key. The variables represent the
+   * dynamic state of the process instance.
+   *
+   * @param processInstanceKey The unique identifier for the process instance to retrieve variables
+   *     of.
+   * @return A map containing the variables associated with the process instance. The keys represent
+   *     variable names, and the values are the variable values.
+   * @throws RuntimeException If an error occurs during the fetch operation.
+   */
+  private Map<String, String> fetchProcessInstanceVariables(final Long processInstanceKey) {
+    List<Object> variablePaginationIndex = null;
+    SearchResult<io.camunda.operate.dto.Variable> searchResult;
+    Map<String, String> processVariables = new HashMap<>();
+    do {
+      try {
+        VariableFilter variableFilter =
+            new VariableFilter.Builder().processInstanceKey(processInstanceKey).build();
+        SearchQuery variableQuery =
+            new SearchQuery.Builder()
+                .filter(variableFilter)
+                .searchAfter(variablePaginationIndex)
+                .size(20)
+                .build();
+        searchResult =
+            camundaOperateClient.search(variableQuery, io.camunda.operate.dto.Variable.class);
+      } catch (OperateException e) {
+        throw new RuntimeException(e);
+      }
+      List<Object> newPaginationIdx = searchResult.getSortValues();
+      processVariables.putAll(
+          searchResult.getItems().stream()
+              .collect(Collectors.toMap(Variable::getName, Variable::getValue)));
+      if (!CollectionUtils.isEmpty(newPaginationIdx)) {
+        variablePaginationIndex = newPaginationIdx;
+      }
+
+    } while (searchResult.getItems().size() > 0);
+    return processVariables;
   }
 }

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/lifecycle/InboundConnectorLifecycleConfiguration.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/lifecycle/InboundConnectorLifecycleConfiguration.java
@@ -23,6 +23,7 @@ import io.camunda.connector.runtime.core.inbound.InboundConnectorFactory;
 import io.camunda.connector.runtime.core.inbound.correlation.InboundCorrelationHandler;
 import io.camunda.connector.runtime.core.secret.SecretProviderAggregator;
 import io.camunda.connector.runtime.inbound.importer.ProcessDefinitionInspector;
+import io.camunda.connector.runtime.inbound.importer.ProcessDefinitionSearch;
 import io.camunda.connector.runtime.inbound.webhook.WebhookConnectorRegistry;
 import io.camunda.zeebe.spring.client.metrics.MetricsRecorder;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -45,6 +46,7 @@ public class InboundConnectorLifecycleConfiguration {
       InboundConnectorFactory connectorFactory,
       InboundCorrelationHandler correlationHandler,
       ProcessDefinitionInspector processDefinitionInspector,
+      ProcessDefinitionSearch processDefinitionSearch,
       SecretProviderAggregator secretProviderAggregator,
       @Autowired(required = false) ValidationProvider validationProvider,
       MetricsRecorder metricsRecorder,
@@ -54,6 +56,7 @@ public class InboundConnectorLifecycleConfiguration {
         connectorFactory,
         correlationHandler,
         processDefinitionInspector,
+        processDefinitionSearch,
         secretProviderAggregator,
         validationProvider,
         metricsRecorder,

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/inbound/importer/ProcessDefinitionSearchTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/inbound/importer/ProcessDefinitionSearchTest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.runtime.inbound.importer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.when;
+
+import io.camunda.operate.CamundaOperateClient;
+import io.camunda.operate.dto.ProcessInstance;
+import io.camunda.operate.dto.SearchResult;
+import io.camunda.operate.dto.Variable;
+import io.camunda.operate.search.SearchQuery;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class ProcessDefinitionSearchTest {
+  @Mock private CamundaOperateClient camundaOperateClient;
+
+  @Test
+  public void testFetchProcessInstancesWithVariables() throws Exception {
+    ProcessDefinitionSearch processDefinitionSearch =
+        new ProcessDefinitionSearch(camundaOperateClient);
+
+    // Given
+    Long processDefinitionKey = 456L;
+    ProcessInstance processInstance1 = createProcessInstance(123L);
+    ProcessInstance processInstance2 = createProcessInstance(789L);
+
+    SearchResult<ProcessInstance> processInstanceSearchResult =
+        createSearchResult(processInstance1, processInstance2);
+    SearchResult<ProcessInstance> processInstanceEmptySearchResult = createEmptySearchResult();
+
+    Variable variable1 = createVariable(12345L, "var1", "value1");
+    Variable variable2 = createVariable(67890L, "var2", "value2");
+
+    SearchResult<Variable> variableSearchResult = createSearchResult(variable1, variable2);
+    SearchResult<Variable> variableEmptySearchResult = createEmptySearchResult();
+
+    when(camundaOperateClient.search(any(SearchQuery.class), eq(ProcessInstance.class)))
+        .thenReturn(processInstanceSearchResult)
+        .thenReturn(processInstanceEmptySearchResult);
+
+    when(camundaOperateClient.search(any(SearchQuery.class), eq(Variable.class)))
+        .thenReturn(variableSearchResult)
+        .thenReturn(variableEmptySearchResult);
+
+    // When
+    List<io.camunda.connector.api.inbound.operate.ProcessInstance> result =
+        processDefinitionSearch.fetchProcessInstancesWithVariables(processDefinitionKey);
+
+    // Then
+    assertThat(result.size()).isEqualTo(2);
+    assertThat(result.get(0).key()).isEqualTo(123L);
+    assertThat(result.get(1).key()).isEqualTo(789L);
+
+    Map<String, String> variables = result.get(0).variables();
+    assertThat(variables).isNotEmpty();
+    assertThat(variables.get("var1")).isEqualTo("value1");
+    assertThat(variables.get("var2")).isEqualTo("value2");
+    assertThat(result.get(1).variables()).isEmpty();
+  }
+
+  private ProcessInstance createProcessInstance(Long key) {
+    ProcessInstance instance = new ProcessInstance();
+    instance.setKey(key);
+    return instance;
+  }
+
+  private Variable createVariable(Long key, String name, String value) {
+    Variable variable = new Variable();
+    variable.setKey(key);
+    variable.setName(name);
+    variable.setValue(value);
+    return variable;
+  }
+
+  @SafeVarargs
+  private <T> SearchResult<T> createSearchResult(T... items) {
+    SearchResult<T> searchResult = new SearchResult<>();
+    searchResult.setItems(Arrays.asList(items));
+    searchResult.setTotal(items.length);
+    return searchResult;
+  }
+
+  private <T> SearchResult<T> createEmptySearchResult() {
+    SearchResult<T> searchResult = new SearchResult<>();
+    searchResult.setItems(Collections.emptyList());
+    searchResult.setTotal(0);
+    return searchResult;
+  }
+}

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/inbound/lifecycle/InboundConnectorManagerTest.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/inbound/lifecycle/InboundConnectorManagerTest.java
@@ -47,6 +47,7 @@ import io.camunda.connector.runtime.core.inbound.correlation.InboundCorrelationH
 import io.camunda.connector.runtime.core.secret.SecretProviderAggregator;
 import io.camunda.connector.runtime.inbound.ProcessDefinitionTestUtil;
 import io.camunda.connector.runtime.inbound.importer.ProcessDefinitionInspector;
+import io.camunda.connector.runtime.inbound.importer.ProcessDefinitionSearch;
 import io.camunda.connector.runtime.inbound.webhook.WebhookConnectorRegistry;
 import io.camunda.operate.dto.ProcessDefinition;
 import io.camunda.zeebe.spring.client.metrics.DefaultNoopMetricsRecorder;
@@ -81,6 +82,7 @@ public class InboundConnectorManagerTest {
     secretProviderAggregator = mock(SecretProviderAggregator.class);
 
     ProcessDefinitionInspector inspector = mock(ProcessDefinitionInspector.class);
+    ProcessDefinitionSearch processDefinitionSearch = mock(ProcessDefinitionSearch.class);
 
     manager =
         new InboundConnectorManager(
@@ -88,6 +90,7 @@ public class InboundConnectorManagerTest {
             factory,
             correlationHandler,
             inspector,
+            processDefinitionSearch,
             secretProviderAggregator,
             v -> {},
             new DefaultNoopMetricsRecorder(),
@@ -235,6 +238,7 @@ public class InboundConnectorManagerTest {
   void shouldNotActivateWebhookWhenDisabled() throws Exception {
     // Given
     ProcessDefinitionInspector inspector = mock(ProcessDefinitionInspector.class);
+    ProcessDefinitionSearch processDefinitionSearch = mock(ProcessDefinitionSearch.class);
     // webhook connector registry is set to null,
     // emulating camunda.connector.webhook.enabled=false
     manager =
@@ -243,6 +247,7 @@ public class InboundConnectorManagerTest {
             factory,
             correlationHandler,
             inspector,
+            processDefinitionSearch,
             secretProviderAggregator,
             v -> {},
             new DefaultNoopMetricsRecorder(),

--- a/connector-sdk/core/src/main/java/io/camunda/connector/api/inbound/InboundIntermediateConnectorContext.java
+++ b/connector-sdk/core/src/main/java/io/camunda/connector/api/inbound/InboundIntermediateConnectorContext.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.api.inbound;
+
+import io.camunda.connector.api.inbound.operate.ProcessInstance;
+import java.util.List;
+
+/**
+ * Extended context object for inbound connectors, providing additional capabilities specific to
+ * intermediate processing stages. This context provides methods to interact with process instances
+ * associated with it, including the ability to fetch the latest state of these instances
+ * dynamically. The method {@link #getProcessInstances()} returns a list of process instances with
+ * their associated variables. Note that the variables associated with each process instance are
+ * updated every time the method is invoked, reflecting the latest state of the process instances at
+ * the time of the call.
+ */
+public interface InboundIntermediateConnectorContext extends InboundConnectorContext {
+  /**
+   * Retrieves a list of process instances associated with this context, including their latest
+   * variables. The variables are dynamically updated every time this method is invoked, allowing
+   * the connector to have access to the most recent state of the process instances.
+   *
+   * @return a list of {@link ProcessInstance} with updated variables
+   */
+  List<ProcessInstance> getProcessInstances();
+}

--- a/connector-sdk/core/src/main/java/io/camunda/connector/api/inbound/PollingConnectorExecutable.java
+++ b/connector-sdk/core/src/main/java/io/camunda/connector/api/inbound/PollingConnectorExecutable.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.api.inbound;
+
+/**
+ * Defines the behavior for a connector that performs polling operations.
+ *
+ * <p>This interface extends {@link InboundConnectorExecutable} to specify functionality for
+ * connectors that periodically query an external system to fetch information or detect changes.
+ */
+public interface PollingConnectorExecutable extends InboundConnectorExecutable {}

--- a/connector-sdk/core/src/main/java/io/camunda/connector/api/inbound/operate/ProcessInstance.java
+++ b/connector-sdk/core/src/main/java/io/camunda/connector/api/inbound/operate/ProcessInstance.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.api.inbound.operate;
+
+import java.util.Map;
+
+/**
+ * Represents a process instance with associated variables.
+ *
+ * <p>A process instance is a single execution of a process definition within a workflow engine. The
+ * associated variables contain the dynamic data of the process instance at a given point in time.
+ * These variables can change during the lifetime of the process instance, reflecting the evolving
+ * state of the instance.
+ *
+ * @param key The unique identifier of the process instance.
+ * @param variables A map containing the variables associated with this process instance. The keys
+ *     represent variable names, and the values are the variable values.
+ */
+public record ProcessInstance(Long key, Map<String, String> variables) {}

--- a/connectors/http/polling/src/main/java/io/camunda/connector/http/polling/PollingConnector.java
+++ b/connectors/http/polling/src/main/java/io/camunda/connector/http/polling/PollingConnector.java
@@ -6,5 +6,21 @@
  */
 package io.camunda.connector.http.polling;
 
-// https://github.com/camunda/product-hub/issues/767#polling-diagram
-public class PollingConnector {}
+import io.camunda.connector.api.annotation.InboundConnector;
+import io.camunda.connector.api.inbound.InboundConnectorContext;
+import io.camunda.connector.api.inbound.InboundIntermediateConnectorContext;
+import io.camunda.connector.api.inbound.PollingConnectorExecutable;
+
+@InboundConnector(name = "HTTP_POLLING", type = "io.camunda:http:polling:1")
+public class PollingConnector implements PollingConnectorExecutable {
+
+  @Override
+  public void activate(final InboundConnectorContext context) {
+    InboundIntermediateConnectorContext pollingContext =
+        (InboundIntermediateConnectorContext) context;
+    throw new UnsupportedOperationException("Connector not implemented yet");
+  }
+
+  @Override
+  public void deactivate() {}
+}


### PR DESCRIPTION
## Description

Added  `InboundIntermediateConnectorContext` that expand  `InboundConnectorContext` and allows to get processVariables;

Added `fetchProcessInstanceVariables` method to `ProcessDefinitionSearch`

Added `PollingConnectorExecutable` interface, that extends `InboundExecutable`
<!-- Please explain the changes you made here. -->

A bit updated scheme : 

```mermaid
sequenceDiagram
    participant c as InboundConnectorManager
    participant o as Operate
    participant ps as Polling Source
    participant z as Zeebe
    c->>o: Fetch all inbound connectors (didn't change the logic that was before)
    Note right of c:  activate inbound connectors, if connector = polling -> use InboundIntermediateConnectorContext
    c->>c: Schedule internal polling request jobs
    Note right of c: Either one request per process or multiple if resource is list based   
    c->>o: if connector context.getProcessInstances() (depend on polling interval)
    Note right of c:  Fetch process instance variables by defenitionKey (update variables)
    c->>ps: Poll resource based on configuration (url query params & body)
    c->>c: Analyze response and map based on config
    Note right of c: List results could lead to multiple correlations
    c->>z: Correlate event(s)
```

## Related issues

https://github.com/camunda/team-connectors/issues/449

