### PR TITLE
fix: collect all process definitions before extracting inbound connectors

### DIFF
--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/importer/ProcessDefinitionSearch.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/importer/ProcessDefinitionSearch.java
@@ -53,26 +53,30 @@ public class ProcessDefinitionSearch {
 
   public void query(Consumer<List<ProcessDefinition>> resultHandler) {
     LOG.trace("Query process deployments...");
-    SearchResult<ProcessDefinition> result;
+    List<ProcessDefinition> processDefinitions = new ArrayList<>();
+    SearchResult<ProcessDefinition> processDefinitionResult;
     LOG.trace("Running paginated query");
     do {
       try {
         // automatically sorted by process definition key, i.e. in chronological order of deployment
         SearchQuery processDefinitionQuery =
             new SearchQuery.Builder().searchAfter(paginationIndex).size(20).build();
-        result = camundaOperateClient.search(processDefinitionQuery, ProcessDefinition.class);
+        processDefinitionResult =
+            camundaOperateClient.search(processDefinitionQuery, ProcessDefinition.class);
       } catch (OperateException e) {
         throw new RuntimeException(e);
       }
-      List<Object> newPaginationIdx = result.getSortValues();
+      List<Object> newPaginationIdx = processDefinitionResult.getSortValues();
 
       if (!CollectionUtils.isEmpty(newPaginationIdx)) {
         paginationIndex = newPaginationIdx;
       }
 
-      resultHandler.accept(result.getItems());
+      processDefinitions.addAll(processDefinitionResult.getItems());
 
-    } while (result.getItems().size() > 0);
+    } while (processDefinitionResult.getItems().size() > 0);
+
+    resultHandler.accept(processDefinitions);
   }
 
   /**


### PR DESCRIPTION
## Description

Issue:
We query operate in the chunks of 20, and only process these 20 process definitions. Processing means activating any inbound connector in it. If you have more then 20 versions of a certain process definition, the application might activate an inbound connector which is not part of the latest version but a previous one. Even if we will override this (deactivate the old one and activate the new one) later, there is still a brief moment when we have the old version as an activated inbound connector, which may lead to unexpected behavior.

## Solution

We first collect all the process definitions (not just 20), and only start extracting inbound connectors afterwards. This will result in only processing the latest process definitions as expected.

## Related issues

There is no related issue.

closes #

