### PR TITLE
fix: set Java version used by CodeQL to 19

### DIFF
--- a/.github/workflows/CODEQL.yml
+++ b/.github/workflows/CODEQL.yml
@@ -28,8 +28,8 @@ jobs:
     #   - https://gh.io/supported-runners-and-hardware-resources
     #   - https://gh.io/using-larger-runners
     # Consider using larger runners for possible analysis time improvements.
-    runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'ubuntu-latest' }}
-    timeout-minutes: ${{ (matrix.language == 'swift' && 120) || 360 }}
+    runs-on: 'ubuntu-latest'
+    timeout-minutes: 360
     permissions:
       actions: read
       contents: read
@@ -49,11 +49,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
       # Set up Java version
-      #- name: Setup Java JDK
-        #uses: actions/setup-java@v3
-        #with:
-          #distribution: temurin
-          #java-version: 19
+      - name: Setup Java JDK
+        uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: 19
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v2


### PR DESCRIPTION
## Description

Unfortunately CodeQL Autobuild phase fails.

Setting the Java version to 19 might solve this problem.

## Related issues

No related isssue

closes #

