### PR TITLE
feat: template generator improvements

### DIFF
--- a/connector-sdk/element-template-generator/src/main/java/io/camunda/connector/generator/annotation/ElementTemplate.java
+++ b/connector-sdk/element-template-generator/src/main/java/io/camunda/connector/generator/annotation/ElementTemplate.java
@@ -28,11 +28,20 @@ public @interface ElementTemplate {
 
   String name();
 
-  int version();
+  int version() default 0;
 
-  String documentationRef();
+  String documentationRef() default "";
 
-  String description();
+  String description() default "";
+
+  /** Allows to customize group labels */
+  PropertyGroup[] propertyGroups() default {};
 
   Class<?> inputDataClass();
+
+  @interface PropertyGroup {
+    String id();
+
+    String label() default "";
+  }
 }

--- a/connector-sdk/element-template-generator/src/main/java/io/camunda/connector/generator/annotation/TemplateDiscriminatorProperty.java
+++ b/connector-sdk/element-template-generator/src/main/java/io/camunda/connector/generator/annotation/TemplateDiscriminatorProperty.java
@@ -16,17 +16,15 @@
  */
 package io.camunda.connector.generator.annotation;
 
-import java.lang.annotation.ElementType;
+import io.camunda.connector.generator.core.util.TemplatePropertiesUtil;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
 
 @Retention(RetentionPolicy.RUNTIME)
-@Target(ElementType.TYPE)
-public @interface TemplateSubType {
-  String id() default "";
+public @interface TemplateDiscriminatorProperty {
+  String id();
 
   String label() default "";
 
-  boolean ignore() default false;
+  String group() default TemplatePropertiesUtil.DISCRIMINATOR_PROPERTIES_GROUP_ID;
 }

--- a/connector-sdk/element-template-generator/src/main/java/io/camunda/connector/generator/annotation/TemplateProperty.java
+++ b/connector-sdk/element-template-generator/src/main/java/io/camunda/connector/generator/annotation/TemplateProperty.java
@@ -23,7 +23,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 @Retention(RetentionPolicy.RUNTIME)
-@Target(ElementType.FIELD)
+@Target({ElementType.FIELD, ElementType.RECORD_COMPONENT})
 public @interface TemplateProperty {
 
   String name() default "";
@@ -38,11 +38,34 @@ public @interface TemplateProperty {
 
   String[] choices() default {};
 
-  FeelMode feel() default FeelMode.disabled;
+  FeelMode feel() default FeelMode.optional;
 
   String defaultValue() default "";
 
   String group() default "";
+
+  /**
+   * Whether to add the nested path to the property name. Consider the example:
+   *
+   * <pre>{@code
+   * MyNestedType foo;
+   *
+   * }</pre>
+   *
+   * where MyNestedType is defined like this:
+   *
+   * <pre>{@code
+   * record MyNestedType(String bar) {}
+   *
+   * }</pre>
+   *
+   * In the example above, if this property is set to true, the property name in the generated
+   * element template will be "foo.bar". If it is set to false, the property name will be "bar".
+   *
+   * <p>Disabling this setting can be used to define custom element template structure, overriding
+   * the default behavior of nesting properties.
+   */
+  boolean addNestedPath() default true;
 
   enum PropertyType {
     Boolean,

--- a/connector-sdk/element-template-generator/src/main/java/io/camunda/connector/generator/dsl/DropdownProperty.java
+++ b/connector-sdk/element-template-generator/src/main/java/io/camunda/connector/generator/dsl/DropdownProperty.java
@@ -16,6 +16,7 @@
  */
 package io.camunda.connector.generator.dsl;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
 
 public final class DropdownProperty extends Property {
@@ -55,7 +56,7 @@ public final class DropdownProperty extends Property {
     return choices;
   }
 
-  public record DropdownChoice(String name, String value) {}
+  public record DropdownChoice(@JsonProperty String name, @JsonProperty String value) {}
 
   public static DropdownPropertyBuilder builder() {
     return new DropdownPropertyBuilder();

--- a/connector-sdk/element-template-generator/src/main/java/io/camunda/connector/generator/dsl/ElementTemplateCategory.java
+++ b/connector-sdk/element-template-generator/src/main/java/io/camunda/connector/generator/dsl/ElementTemplateCategory.java
@@ -16,7 +16,9 @@
  */
 package io.camunda.connector.generator.dsl;
 
-public record ElementTemplateCategory(String id, String name) {
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record ElementTemplateCategory(@JsonProperty String id, @JsonProperty String name) {
 
   public static final ElementTemplateCategory CONNECTORS =
       new ElementTemplateCategory("connectors", "Connectors");

--- a/connector-sdk/element-template-generator/src/main/java/io/camunda/connector/generator/dsl/OutboundElementTemplate.java
+++ b/connector-sdk/element-template-generator/src/main/java/io/camunda/connector/generator/dsl/OutboundElementTemplate.java
@@ -39,13 +39,13 @@ import java.util.Set;
 })
 @JsonInclude(Include.NON_NULL)
 public record OutboundElementTemplate(
-    String id,
-    String name,
-    int version,
-    String documentationRef,
-    String description,
-    List<PropertyGroup> groups,
-    List<Property> properties)
+    @JsonProperty String id,
+    @JsonProperty String name,
+    @JsonProperty int version,
+    @JsonProperty String documentationRef,
+    @JsonProperty String description,
+    @JsonProperty List<PropertyGroup> groups,
+    @JsonProperty List<Property> properties)
     implements ElementTemplateBase {
 
   public OutboundElementTemplate {
@@ -58,12 +58,6 @@ public record OutboundElementTemplate(
     }
     if (version < 0) {
       errors.add("version cannot be negative");
-    }
-    if (documentationRef == null) {
-      errors.add("documentationRef is required");
-    }
-    if (description == null) {
-      errors.add("description is required");
     }
     if (groups == null) {
       errors.add("groups is required");
@@ -95,5 +89,5 @@ public record OutboundElementTemplate(
     return OutboundElementTemplateBuilder.create();
   }
 
-  public record ElementType(BpmnType value) {}
+  public record ElementType(@JsonProperty BpmnType value) {}
 }

--- a/connector-sdk/element-template-generator/src/main/java/io/camunda/connector/generator/dsl/PropertyBinding.java
+++ b/connector-sdk/element-template-generator/src/main/java/io/camunda/connector/generator/dsl/PropertyBinding.java
@@ -23,7 +23,7 @@ public sealed interface PropertyBinding {
   @JsonProperty("type")
   String type();
 
-  record ZeebeInput(String name) implements PropertyBinding {
+  record ZeebeInput(@JsonProperty String name) implements PropertyBinding {
 
     @Override
     public String type() {
@@ -31,7 +31,7 @@ public sealed interface PropertyBinding {
     }
   }
 
-  record ZeebeTaskHeader(String key) implements PropertyBinding {
+  record ZeebeTaskHeader(@JsonProperty String key) implements PropertyBinding {
 
     @Override
     public String type() {

--- a/connector-sdk/element-template-generator/src/main/java/io/camunda/connector/generator/dsl/PropertyCondition.java
+++ b/connector-sdk/element-template-generator/src/main/java/io/camunda/connector/generator/dsl/PropertyCondition.java
@@ -16,11 +16,14 @@
  */
 package io.camunda.connector.generator.dsl;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
 
 public sealed interface PropertyCondition {
 
-  record OneOf(String property, List<String> oneOf) implements PropertyCondition {}
+  record OneOf(@JsonProperty String property, @JsonProperty List<String> oneOf)
+      implements PropertyCondition {}
 
-  record Equals(String property, String equals) implements PropertyCondition {}
+  record Equals(@JsonProperty String property, @JsonProperty String equals)
+      implements PropertyCondition {}
 }

--- a/connector-sdk/element-template-generator/src/main/java/io/camunda/connector/generator/dsl/PropertyGroup.java
+++ b/connector-sdk/element-template-generator/src/main/java/io/camunda/connector/generator/dsl/PropertyGroup.java
@@ -17,12 +17,14 @@
 package io.camunda.connector.generator.dsl;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Stream;
 
-public record PropertyGroup(String id, String label, @JsonIgnore List<Property> properties) {
+public record PropertyGroup(
+    @JsonProperty String id, @JsonProperty String label, @JsonIgnore List<Property> properties) {
 
   public PropertyGroup {
     if (id == null) {

--- a/connector-sdk/element-template-generator/src/main/java/io/camunda/connector/generator/dsl/StringProperty.java
+++ b/connector-sdk/element-template-generator/src/main/java/io/camunda/connector/generator/dsl/StringProperty.java
@@ -54,6 +54,9 @@ public final class StringProperty extends Property {
     private StringPropertyBuilder() {}
 
     public StringProperty build() {
+      if (feel == null) {
+        feel = FeelMode.optional;
+      }
       return new StringProperty(
           id, label, description, optional, value, constraints, feel, group, binding, condition);
     }

--- a/connector-sdk/element-template-generator/src/main/java/io/camunda/connector/generator/dsl/TextProperty.java
+++ b/connector-sdk/element-template-generator/src/main/java/io/camunda/connector/generator/dsl/TextProperty.java
@@ -54,6 +54,9 @@ public final class TextProperty extends Property {
     private TextPropertyBuilder() {}
 
     public TextProperty build() {
+      if (feel == null) {
+        feel = FeelMode.optional;
+      }
       return new TextProperty(
           id, label, description, optional, value, constraints, feel, group, binding, condition);
     }

--- a/connector-sdk/element-template-generator/src/test/java/io/camunda/connector/generator/core/example/MyConnectorInput.java
+++ b/connector-sdk/element-template-generator/src/test/java/io/camunda/connector/generator/core/example/MyConnectorInput.java
@@ -16,6 +16,7 @@
  */
 package io.camunda.connector.generator.core.example;
 
+import io.camunda.connector.generator.annotation.TemplateDiscriminatorProperty;
 import io.camunda.connector.generator.annotation.TemplateProperty;
 import io.camunda.connector.generator.annotation.TemplateProperty.PropertyType;
 import io.camunda.connector.generator.annotation.TemplateSubType;
@@ -27,9 +28,11 @@ public record MyConnectorInput(
     Authorization authorization,
     @TemplateProperty(type = PropertyType.Text, group = "message") String message,
     String recipient) {
+
+  @TemplateDiscriminatorProperty(id = "authType", label = "Auth type")
   sealed interface Authorization permits BasicAuth, TokenAuth {
 
-    @TemplateSubType(discriminatorProperty = "authType", equals = "basic")
+    @TemplateSubType(id = "basic")
     record BasicAuth(
         @TemplateProperty(label = "Username", group = "auth", feel = FeelMode.optional)
             String username,
@@ -37,7 +40,7 @@ public record MyConnectorInput(
             String password)
         implements Authorization {}
 
-    @TemplateSubType(discriminatorProperty = "authType", equals = "token")
+    @TemplateSubType(id = "token")
     record TokenAuth(@TemplateProperty(label = "Token", group = "auth") String token)
         implements Authorization {}
   }

--- a/connector-sdk/element-template-generator/src/test/resources/test-element-template-simplified.json
+++ b/connector-sdk/element-template-generator/src/test/resources/test-element-template-simplified.json
@@ -48,6 +48,7 @@
     {
       "id": "recipient",
       "label": "Recipient",
+      "feel": "optional",
       "binding": {
         "name": "recipient",
         "type": "zeebe:input"
@@ -66,11 +67,11 @@
       "type": "Dropdown",
       "choices": [
         {
-          "name": "Basic",
+          "name": "Basic auth",
           "value": "basic"
         },
         {
-          "name": "Token",
+          "name": "Token auth",
           "value": "token"
         }
       ]
@@ -111,6 +112,7 @@
       "id": "authorization.token",
       "label": "Token",
       "optional": false,
+      "feel": "optional",
       "group": "auth",
       "binding": {
         "name": "authorization.token",
@@ -126,6 +128,7 @@
       "id": "message",
       "label": "Message",
       "optional": false,
+      "feel": "optional",
       "group": "message",
       "binding": {
         "name": "message",
@@ -137,6 +140,7 @@
       "id": "resultVariable",
       "label": "Result Variable",
       "description": "Name of variable to store the response in",
+      "feel": "optional",
       "group": "output",
       "binding": {
         "key": "resultVariable",

--- a/connector-sdk/element-template-generator/src/test/resources/test-element-template.json
+++ b/connector-sdk/element-template-generator/src/test/resources/test-element-template.json
@@ -3,8 +3,8 @@
   "name": "Template: Some Function",
   "id": "io.camunda.connector.Template.v1",
   "description": "Describe this connector",
-  "version": 1,
   "documentationRef": "https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/available-connectors-overview/",
+  "version": 1,
   "category": {
     "id": "connectors",
     "name": "Connectors"
@@ -35,104 +35,105 @@
   ],
   "properties": [
     {
-      "type": "Hidden",
       "value": "io.camunda:template:1",
       "binding": {
         "type": "zeebe:taskDefinition:type"
-      }
+      },
+      "type": "Hidden"
     },
     {
       "label": "Username",
       "description": "The username for authentication.",
-      "group": "authentication",
-      "type": "String",
-      "feel": "optional",
-      "binding": {
-        "type": "zeebe:input",
-        "name": "authentication.user"
-      },
       "constraints": {
         "notEmpty": true
-      }
+      },
+      "feel": "optional",
+      "group": "authentication",
+      "binding": {
+        "name": "authentication.user",
+        "type": "zeebe:input"
+      },
+      "type": "String"
     },
     {
       "label": "Token",
       "description": "The token for authentication.",
-      "group": "authentication",
-      "type": "String",
-      "feel": "optional",
-      "binding": {
-        "type": "zeebe:input",
-        "name": "authentication.token"
-      },
       "constraints": {
         "notEmpty": true
-      }
+      },
+      "feel": "optional",
+      "group": "authentication",
+      "binding": {
+        "name": "authentication.token",
+        "type": "zeebe:input"
+      },
+      "type": "String"
     },
     {
       "label": "Type",
       "description": "The type of message to compose",
       "group": "compose",
+      "binding": {
+        "name": "compose.type",
+        "type": "zeebe:input"
+      },
       "type": "Dropdown",
       "choices": [
         {
           "name": "message",
           "value": "Compose a message"
         }
-      ],
-      "binding": {
-        "type": "zeebe:input",
-        "name": "compose.type"
-      }
+      ]
     },
     {
       "label": "Message",
-      "group": "compose",
-      "type": "Text",
-      "feel": "optional",
-      "binding": {
-        "type": "zeebe:input",
-        "name": "message"
-      },
       "constraints": {
         "notEmpty": true
+      },
+      "feel": "optional",
+      "group": "compose",
+      "binding": {
+        "name": "message",
+        "type": "zeebe:input"
       },
       "condition": {
         "property": "compose.type",
         "equals": "message"
-      }
+      },
+      "type": "Text"
     },
     {
       "label": "Result Variable",
       "description": "Name of variable to store the response in",
+      "feel": "optional",
       "group": "output",
-      "type": "String",
       "binding": {
-        "type": "zeebe:taskHeader",
-        "key": "resultVariable"
-      }
+        "key": "resultVariable",
+        "type": "zeebe:taskHeader"
+      },
+      "type": "String"
     },
     {
       "label": "Result Expression",
       "description": "Expression to map the response into process variables",
-      "group": "output",
-      "type": "Text",
       "feel": "required",
+      "group": "output",
       "binding": {
-        "type": "zeebe:taskHeader",
-        "key": "resultExpression"
-      }
+        "key": "resultExpression",
+        "type": "zeebe:taskHeader"
+      },
+      "type": "Text"
     },
     {
       "label": "Error Expression",
       "description": "Expression to handle errors. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/\" target=\"_blank\">documentation</a>.",
-      "group": "errors",
-      "type": "Text",
       "feel": "required",
+      "group": "errors",
       "binding": {
-        "type": "zeebe:taskHeader",
-        "key": "errorExpression"
-      }
+        "key": "errorExpression",
+        "type": "zeebe:taskHeader"
+      },
+      "type": "Text"
     }
   ]
 }

--- a/connectors/http/http-base/pom.xml
+++ b/connectors/http/http-base/pom.xml
@@ -68,6 +68,11 @@ limitations under the License.</license.inlineheader>
       <groupId>org.slf4j</groupId>
       <artifactId>jcl-over-slf4j</artifactId>
     </dependency>
+
+    <dependency>
+      <groupId>io.camunda.connector</groupId>
+      <artifactId>element-template-generator</artifactId>
+    </dependency>
   </dependencies>
 
   <profiles>

--- a/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/auth/Authentication.java
+++ b/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/auth/Authentication.java
@@ -28,7 +28,12 @@ import com.google.api.client.http.HttpHeaders;
   @JsonSubTypes.Type(value = OAuthAuthentication.class, name = "oauth-client-credentials-flow"),
   @JsonSubTypes.Type(value = BearerAuthentication.class, name = "bearer")
 })
-public abstract class Authentication {
+public abstract sealed class Authentication
+    permits BasicAuthentication,
+        BearerAuthentication,
+        CustomAuthentication,
+        NoAuthentication,
+        OAuthAuthentication {
 
   public abstract void setHeaders(HttpHeaders headers);
 }

--- a/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/auth/BasicAuthentication.java
+++ b/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/auth/BasicAuthentication.java
@@ -22,7 +22,7 @@ import io.camunda.connector.api.annotation.FEEL;
 import jakarta.validation.constraints.NotEmpty;
 import java.util.function.Function;
 
-public class BasicAuthentication extends Authentication {
+public final class BasicAuthentication extends Authentication {
   private static final String SPEC_PASSWORD_EMPTY_PATTERN = "SPEC_PASSWORD_EMPTY_PATTERN";
   private static final Function<String, String> SPEC_PASSWORD =
       (psw) -> psw.equals(SPEC_PASSWORD_EMPTY_PATTERN) ? "" : psw;

--- a/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/auth/BearerAuthentication.java
+++ b/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/auth/BearerAuthentication.java
@@ -21,7 +21,7 @@ import com.google.common.base.Objects;
 import io.camunda.connector.api.annotation.FEEL;
 import jakarta.validation.constraints.NotEmpty;
 
-public class BearerAuthentication extends Authentication {
+public final class BearerAuthentication extends Authentication {
 
   @FEEL @NotEmpty private String token;
 

--- a/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/auth/CustomAuthentication.java
+++ b/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/auth/CustomAuthentication.java
@@ -18,13 +18,15 @@ package io.camunda.connector.http.base.auth;
 
 import com.google.api.client.http.HttpHeaders;
 import io.camunda.connector.api.annotation.FEEL;
+import io.camunda.connector.generator.annotation.TemplateSubType;
 import io.camunda.connector.http.base.model.HttpCommonRequest;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import java.util.Map;
 import java.util.Objects;
 
-public class CustomAuthentication extends Authentication {
+@TemplateSubType(ignore = true)
+public final class CustomAuthentication extends Authentication {
 
   @FEEL @NotNull @Valid private HttpCommonRequest request;
 

--- a/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/auth/NoAuthentication.java
+++ b/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/auth/NoAuthentication.java
@@ -18,7 +18,7 @@ package io.camunda.connector.http.base.auth;
 
 import com.google.api.client.http.HttpHeaders;
 
-public class NoAuthentication extends Authentication {
+public final class NoAuthentication extends Authentication {
 
   @Override
   public void setHeaders(final HttpHeaders headers) {}

--- a/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/auth/OAuthAuthentication.java
+++ b/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/auth/OAuthAuthentication.java
@@ -24,7 +24,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
-public class OAuthAuthentication extends Authentication {
+public final class OAuthAuthentication extends Authentication {
   private final String grantType = "client_credentials";
   @FEEL @NotEmpty private String oauthTokenEndpoint;
   @FEEL @NotEmpty private String clientId;

--- a/connectors/http/rest/pom.xml
+++ b/connectors/http/rest/pom.xml
@@ -68,7 +68,6 @@ limitations under the License.</license.inlineheader>
       <groupId>org.slf4j</groupId>
       <artifactId>jcl-over-slf4j</artifactId>
     </dependency>
-
   </dependencies>
 
   <profiles>

--- a/connectors/http/rest/src/main/java/io/camunda/connector/http/rest/HttpJsonFunction.java
+++ b/connectors/http/rest/src/main/java/io/camunda/connector/http/rest/HttpJsonFunction.java
@@ -23,6 +23,7 @@ import io.camunda.connector.api.config.ConnectorConfigurationUtil;
 import io.camunda.connector.api.outbound.OutboundConnectorContext;
 import io.camunda.connector.api.outbound.OutboundConnectorFunction;
 import io.camunda.connector.feel.ConnectorsObjectMapperSupplier;
+import io.camunda.connector.generator.annotation.ElementTemplate;
 import io.camunda.connector.http.base.components.HttpTransportComponentSupplier;
 import io.camunda.connector.http.base.constants.Constants;
 import io.camunda.connector.http.base.services.HttpService;
@@ -41,6 +42,12 @@ import java.io.IOException;
       "body"
     },
     type = "io.camunda:http-json:1")
+@ElementTemplate(
+    id = "generated-http-json",
+    name = "Generated REST Connector",
+    description = "Generated REST Connector",
+    inputDataClass = HttpJsonRequest.class,
+    version = 1)
 public class HttpJsonFunction implements OutboundConnectorFunction {
 
   private final HttpService httpService;

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -209,6 +209,12 @@ limitations under the License.</license.inlineheader>
       </dependency>
 
       <dependency>
+        <groupId>io.camunda.connector</groupId>
+        <artifactId>element-template-generator</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+
+      <dependency>
         <groupId>io.camunda</groupId>
         <artifactId>zeebe-client-java</artifactId>
         <version>${version.zeebe}</version>


### PR DESCRIPTION
## Description

Element template generator improvements based on testing with REST Connector.

- Support for custom nested path (using combination of disabling the `addNestedPath` param of `TemplateProperty`
- Improvements to how sealed hierarchies are recognized; now it's not necessary to add the `@TemplateSubType` annotation any more as sealed hierarchies are detected automatically.
- Refactoring of `@TemplateSubType`, a part of it related to discriminator was extracted to `@TemplateDiscriminatorProperty`, an optional annotation that can be placed on the hierarchy root.
- Visual / functional improvements of the generated template
  - Set FEEL to optional by default
  - Reorder property groups, handle a case where no custom groups were defined.

**Outcome**: the generator is able to provide a fully generated & functional template for REST connector (excluding validation constraints for now)

## Related issues

<!-- Which issues are closed by this PR or are related -->

related to https://github.com/camunda/team-connectors/issues/481

