### PR TITLE
fix: Dont send body for GET requests

### DIFF
--- a/connectors/http/graphql/src/main/java/io/camunda/connector/http/graphql/GraphQLFunction.java
+++ b/connectors/http/graphql/src/main/java/io/camunda/connector/http/graphql/GraphQLFunction.java
@@ -26,9 +26,10 @@ import io.camunda.connector.http.base.auth.OAuthAuthentication;
 import io.camunda.connector.http.base.constants.Constants;
 import io.camunda.connector.http.base.model.HttpCommonRequest;
 import io.camunda.connector.http.base.model.HttpCommonResult;
+import io.camunda.connector.http.base.model.HttpMethod;
 import io.camunda.connector.http.base.services.AuthenticationService;
-import io.camunda.connector.http.base.services.HTTPProxyService;
 import io.camunda.connector.http.base.services.HttpInteractionService;
+import io.camunda.connector.http.base.services.HttpProxyService;
 import io.camunda.connector.http.graphql.components.HttpTransportComponentSupplier;
 import io.camunda.connector.http.graphql.model.GraphQLRequest;
 import io.camunda.connector.http.graphql.model.GraphQLRequestWrapper;
@@ -119,7 +120,7 @@ public class GraphQLFunction implements OutboundConnectorFunction {
     HttpInteractionService httpInteractionService = new HttpInteractionService(objectMapper);
 
     com.google.api.client.http.HttpRequest httpRequest =
-        HTTPProxyService.toRequestViaProxy(requestFactory, commonRequest, proxyFunctionUrl);
+        HttpProxyService.toRequestViaProxy(requestFactory, commonRequest, proxyFunctionUrl);
 
     HttpResponse httpResponse = httpInteractionService.executeHttpRequest(httpRequest, true);
 
@@ -139,19 +140,19 @@ public class GraphQLFunction implements OutboundConnectorFunction {
       final GraphQLRequest request,
       String bearerToken)
       throws IOException {
-    final String method = request.getMethod().toUpperCase();
     final GenericUrl genericUrl = new GenericUrl(request.getUrl());
     HttpContent content = null;
     final HttpHeaders headers = httpInteractionService.createHeaders(request, bearerToken);
     final Map<String, Object> queryAndVariablesMap =
         JsonSerializeHelper.queryAndVariablesToMap(request);
-    if (Constants.POST.equalsIgnoreCase(method)) {
+    if (HttpMethod.post.equals(request.getMethod())) {
       content = new JsonHttpContent(gsonFactory, queryAndVariablesMap);
     } else {
       genericUrl.putAll(queryAndVariablesMap);
     }
 
-    final var httpRequest = requestFactory.buildRequest(method, genericUrl, content);
+    final var httpRequest =
+        requestFactory.buildRequest(request.getMethod().name().toUpperCase(), genericUrl, content);
     httpRequest.setFollowRedirects(false);
     setTimeout(request, httpRequest);
     httpRequest.setHeaders(headers);

--- a/connectors/http/graphql/src/main/java/io/camunda/connector/http/graphql/utils/GraphQLRequestMapper.java
+++ b/connectors/http/graphql/src/main/java/io/camunda/connector/http/graphql/utils/GraphQLRequestMapper.java
@@ -6,7 +6,6 @@
  */
 package io.camunda.connector.http.graphql.utils;
 
-import io.camunda.connector.http.base.constants.Constants;
 import io.camunda.connector.http.base.model.HttpCommonRequest;
 import io.camunda.connector.http.graphql.model.GraphQLRequest;
 import java.util.Map;
@@ -18,7 +17,7 @@ public final class GraphQLRequestMapper {
     HttpCommonRequest httpCommonRequest = new HttpCommonRequest();
     final Map<String, Object> queryAndVariablesMap =
         JsonSerializeHelper.queryAndVariablesToMap(graphQLRequest);
-    if (Constants.POST.equalsIgnoreCase(graphQLRequest.getMethod())) {
+    if (graphQLRequest.getMethod().supportsBody) {
       httpCommonRequest.setBody(queryAndVariablesMap);
     } else {
       final Map<String, String> queryAndVariablesStringMap =

--- a/connectors/http/graphql/src/test/java/io/camunda/connector/http/graphql/BaseTest.java
+++ b/connectors/http/graphql/src/test/java/io/camunda/connector/http/graphql/BaseTest.java
@@ -54,7 +54,7 @@ public class BaseTest {
 
   protected interface ActualValue {
     String URL = "https://camunda.io/http-endpoint";
-    String METHOD = "GET";
+    String METHOD = "get";
     String CONNECT_TIMEOUT = "50";
 
     interface Authentication {

--- a/connectors/http/graphql/src/test/java/io/camunda/connector/http/graphql/GraphQLFunctionInputValidationTest.java
+++ b/connectors/http/graphql/src/test/java/io/camunda/connector/http/graphql/GraphQLFunctionInputValidationTest.java
@@ -59,11 +59,10 @@ public class GraphQLFunctionInputValidationTest extends BaseTest {
 
     // When
     Throwable exception =
-        assertThrows(ConnectorInputException.class, () -> functionUnderTest.execute(ctx));
+        assertThrows(RuntimeException.class, () -> functionUnderTest.execute(ctx));
 
     // Then
-    assertThat(exception.getMessage())
-        .contains("Found constraints violated while validating input", "method");
+    assertThat(exception.getMessage()).contains("HttpMethod");
   }
 
   @ParameterizedTest

--- a/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/constants/Constants.java
+++ b/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/constants/Constants.java
@@ -26,7 +26,7 @@ public class Constants {
   public static final String BASIC_AUTH_HEADER = "basicAuthHeader";
   public static final String CREDENTIALS_BODY = "credentialsBody";
   public static final String PROXY_FUNCTION_URL_ENV_NAME = "CAMUNDA_CONNECTOR_HTTP_PROXY_URL";
-  public static final String POST = "POST";
+
   public static final String APPLICATION_JSON_CHARSET_UTF_8 = "application/json; charset=UTF-8";
   public static final String APPLICATION_X_WWW_FORM_URLENCODED =
       "application/x-www-form-urlencoded";

--- a/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/model/HttpCommonRequest.java
+++ b/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/model/HttpCommonRequest.java
@@ -20,6 +20,7 @@ import io.camunda.connector.api.annotation.FEEL;
 import io.camunda.connector.http.base.auth.Authentication;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import java.util.Map;
 import java.util.Objects;
@@ -31,7 +32,7 @@ public class HttpCommonRequest {
   @Pattern(regexp = "^(=|http://|https://|secrets|\\{\\{).*$")
   private String url;
 
-  @FEEL @NotBlank private String method;
+  @FEEL @NotNull private HttpMethod method;
 
   @Valid private Authentication authentication;
 
@@ -99,11 +100,11 @@ public class HttpCommonRequest {
     this.authentication = authentication;
   }
 
-  public String getMethod() {
+  public HttpMethod getMethod() {
     return method;
   }
 
-  public void setMethod(String method) {
+  public void setMethod(HttpMethod method) {
     this.method = method;
   }
 

--- a/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/model/HttpMethod.java
+++ b/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/model/HttpMethod.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.http.base.model;
+
+public enum HttpMethod {
+  post(true),
+  get(false),
+  delete(false),
+  patch(true),
+  put(true);
+
+  public final boolean supportsBody;
+
+  private HttpMethod(boolean supportsBody) {
+    this.supportsBody = supportsBody;
+  }
+}

--- a/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/model/HttpRequestBuilder.java
+++ b/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/model/HttpRequestBuilder.java
@@ -26,14 +26,14 @@ import java.util.concurrent.TimeUnit;
 
 public final class HttpRequestBuilder {
 
-  private String method;
+  private HttpMethod method;
   private GenericUrl genericUrl;
   private HttpHeaders headers;
   private HttpContent content;
   private Integer connectionTimeoutInSeconds;
   private boolean followRedirects;
 
-  public HttpRequestBuilder method(String method) {
+  public HttpRequestBuilder method(HttpMethod method) {
     this.method = method;
     return this;
   }
@@ -64,8 +64,8 @@ public final class HttpRequestBuilder {
   }
 
   public HttpRequest build(final HttpRequestFactory requestFactory) throws IOException {
-
-    final var httpRequest = requestFactory.buildRequest(method, genericUrl, content);
+    final var httpRequest =
+        requestFactory.buildRequest(method.name().toUpperCase(), genericUrl, content);
     httpRequest.setFollowRedirects(this.followRedirects);
     if (headers != null) {
       httpRequest.setHeaders(headers);

--- a/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/services/AuthenticationService.java
+++ b/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/services/AuthenticationService.java
@@ -31,6 +31,7 @@ import io.camunda.connector.http.base.auth.CustomAuthentication;
 import io.camunda.connector.http.base.auth.OAuthAuthentication;
 import io.camunda.connector.http.base.constants.Constants;
 import io.camunda.connector.http.base.model.HttpCommonRequest;
+import io.camunda.connector.http.base.model.HttpMethod;
 import io.camunda.connector.http.base.utils.JsonHelper;
 import io.camunda.connector.http.base.utils.ResponseParser;
 import java.io.IOException;
@@ -105,8 +106,8 @@ public class AuthenticationService {
     final GenericUrl genericUrl = new GenericUrl(authentication.getOauthTokenEndpoint());
     Map<String, String> data = authentication.getDataForAuthRequestBody();
     HttpContent content = new UrlEncodedContent(data);
-    final String method = Constants.POST;
-    final var httpRequest = requestFactory.buildRequest(method, genericUrl, content);
+    final var httpRequest =
+        requestFactory.buildRequest(HttpMethod.post.name().toUpperCase(), genericUrl, content);
     httpRequest.setFollowRedirects(false);
     setTimeout(request, httpRequest);
     HttpHeaders headers = new HttpHeaders();

--- a/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/services/HttpInteractionService.java
+++ b/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/services/HttpInteractionService.java
@@ -27,7 +27,6 @@ import com.google.gson.JsonParseException;
 import com.google.gson.JsonParser;
 import com.google.gson.stream.JsonReader;
 import io.camunda.connector.api.error.ConnectorException;
-import io.camunda.connector.http.base.constants.Constants;
 import io.camunda.connector.http.base.model.ErrorResponse;
 import io.camunda.connector.http.base.model.HttpCommonRequest;
 import io.camunda.connector.http.base.model.HttpCommonResult;
@@ -53,7 +52,7 @@ public class HttpInteractionService {
 
   public HttpHeaders createHeaders(final HttpCommonRequest request, String bearerToken) {
     final HttpHeaders httpHeaders = new HttpHeaders();
-    if (Constants.POST.equalsIgnoreCase(request.getMethod())) {
+    if (request.getMethod().supportsBody) {
       httpHeaders.setContentType(APPLICATION_JSON.getMimeType());
     }
     if (request.hasAuthentication()) {

--- a/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/services/HttpProxyService.java
+++ b/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/services/HttpProxyService.java
@@ -25,6 +25,7 @@ import io.camunda.connector.api.error.ConnectorException;
 import io.camunda.connector.feel.ConnectorsObjectMapperSupplier;
 import io.camunda.connector.http.base.constants.Constants;
 import io.camunda.connector.http.base.model.HttpCommonRequest;
+import io.camunda.connector.http.base.model.HttpMethod;
 import io.camunda.connector.http.base.model.HttpRequestBuilder;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -32,9 +33,9 @@ import java.nio.charset.StandardCharsets;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public final class HTTPProxyService {
+public final class HttpProxyService {
 
-  private static final Logger LOG = LoggerFactory.getLogger(HTTPProxyService.class);
+  private static final Logger LOG = LoggerFactory.getLogger(HttpProxyService.class);
 
   private static final ObjectMapper objectMapper = ConnectorsObjectMapperSupplier.getCopy();
 
@@ -55,7 +56,7 @@ public final class HTTPProxyService {
 
     com.google.api.client.http.HttpRequest httpRequest =
         new HttpRequestBuilder()
-            .method(Constants.POST)
+            .method(HttpMethod.post)
             .genericUrl(new GenericUrl(proxyFunctionUrl))
             .content(content)
             .connectionTimeoutInSeconds(request.getConnectionTimeoutInSeconds())

--- a/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/services/HttpService.java
+++ b/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/services/HttpService.java
@@ -98,7 +98,7 @@ public class HttpService {
 
   private HttpCommonResult executeRequestViaProxy(HttpCommonRequest request) throws IOException {
     HttpRequest httpRequest =
-        HTTPProxyService.toRequestViaProxy(requestFactory, request, proxyFunctionUrl);
+        HttpProxyService.toRequestViaProxy(requestFactory, request, proxyFunctionUrl);
 
     HttpInteractionService httpInteractionService = new HttpInteractionService(objectMapper);
 

--- a/connectors/http/rest/src/test/java/io/camunda/connector/http/rest/BaseTest.java
+++ b/connectors/http/rest/src/test/java/io/camunda/connector/http/rest/BaseTest.java
@@ -73,7 +73,7 @@ public class BaseTest {
   protected interface ActualValue {
     String URL = "https://camunda.io/http-endpoint";
     String URL_WITH_PATH = "https://camunda.io/http-endpoint/path";
-    String METHOD = "GET";
+    String METHOD = "get";
     Integer CONNECT_TIMEOUT = 50;
 
     interface Authentication {

--- a/connectors/http/rest/src/test/java/io/camunda/connector/http/rest/HttpJsonFunctionInputValidationTest.java
+++ b/connectors/http/rest/src/test/java/io/camunda/connector/http/rest/HttpJsonFunctionInputValidationTest.java
@@ -70,11 +70,10 @@ public class HttpJsonFunctionInputValidationTest extends BaseTest {
 
     // When
     Throwable exception =
-        assertThrows(ConnectorInputException.class, () -> functionUnderTest.execute(ctx));
+        assertThrows(RuntimeException.class, () -> functionUnderTest.execute(ctx));
 
     // Then
-    assertThat(exception.getMessage())
-        .contains("Found constraints violated while validating input", "method");
+    assertThat(exception.getMessage()).contains("HttpMethod");
   }
 
   @ParameterizedTest

--- a/connectors/http/rest/src/test/java/io/camunda/connector/http/rest/HttpJsonFunctionProxyTest.java
+++ b/connectors/http/rest/src/test/java/io/camunda/connector/http/rest/HttpJsonFunctionProxyTest.java
@@ -33,8 +33,8 @@ import com.google.api.client.http.HttpRequestFactory;
 import com.google.api.client.http.HttpResponse;
 import com.google.api.client.http.HttpResponseException;
 import io.camunda.connector.api.error.ConnectorException;
-import io.camunda.connector.http.base.constants.Constants;
 import io.camunda.connector.http.base.model.HttpCommonResult;
+import io.camunda.connector.http.base.model.HttpMethod;
 import io.camunda.connector.test.outbound.OutboundConnectorContextBuilder;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -80,7 +80,7 @@ public class HttpJsonFunctionProxyTest extends BaseTest {
         OutboundConnectorContextBuilder.create().variables(input).secrets(name -> "foo").build();
 
     when(requestFactory.buildRequest(
-            eq(Constants.POST),
+            eq(HttpMethod.post.name().toUpperCase()),
             eq(new GenericUrl(PROXY_FUNCTION_URL)),
             nullable(HttpContent.class)))
         .thenReturn(httpRequest);
@@ -111,7 +111,7 @@ public class HttpJsonFunctionProxyTest extends BaseTest {
     when(httpException.getStatusCode()).thenReturn(500);
     when(httpException.getMessage()).thenReturn("my error message");
     when(requestFactory.buildRequest(
-            eq(Constants.POST),
+            eq(HttpMethod.post.name().toUpperCase()),
             eq(new GenericUrl(PROXY_FUNCTION_URL)),
             nullable(HttpContent.class)))
         .thenReturn(httpRequest);
@@ -140,7 +140,7 @@ public class HttpJsonFunctionProxyTest extends BaseTest {
     when(httpException.getStatusCode()).thenReturn(500);
     when(httpException.getMessage()).thenReturn("my error message");
     when(requestFactory.buildRequest(
-            eq(Constants.POST),
+            eq(HttpMethod.post.name().toUpperCase()),
             eq(new GenericUrl(PROXY_FUNCTION_URL)),
             nullable(HttpContent.class)))
         .thenReturn(httpRequest);
@@ -167,7 +167,7 @@ public class HttpJsonFunctionProxyTest extends BaseTest {
     when(httpException.getStatusCode()).thenReturn(500);
     when(httpException.getMessage()).thenReturn("my error message");
     when(requestFactory.buildRequest(
-            eq(Constants.POST),
+            eq(HttpMethod.post.name().toUpperCase()),
             eq(new GenericUrl(PROXY_FUNCTION_URL)),
             nullable(HttpContent.class)))
         .thenReturn(httpRequest);

--- a/connectors/http/rest/src/test/java/io/camunda/connector/http/rest/HttpJsonFunctionSecretsTest.java
+++ b/connectors/http/rest/src/test/java/io/camunda/connector/http/rest/HttpJsonFunctionSecretsTest.java
@@ -50,7 +50,7 @@ public class HttpJsonFunctionSecretsTest extends BaseTest {
     HttpJsonRequest httpJsonRequest = context.bindVariables(HttpJsonRequest.class);
     // Then should replace secrets
     assertThat(httpJsonRequest.getUrl()).isIn(ActualValue.URL, ActualValue.URL_WITH_PATH);
-    assertThat(httpJsonRequest.getMethod()).isEqualTo(ActualValue.METHOD);
+    assertThat(httpJsonRequest.getMethod().name()).isEqualTo(ActualValue.METHOD);
     assertThat(httpJsonRequest.getConnectionTimeoutInSeconds())
         .isEqualTo(ActualValue.CONNECT_TIMEOUT);
   }

--- a/connectors/http/rest/src/test/java/io/camunda/connector/http/rest/HttpRequestMapperTest.java
+++ b/connectors/http/rest/src/test/java/io/camunda/connector/http/rest/HttpRequestMapperTest.java
@@ -24,6 +24,7 @@ import com.google.api.client.http.HttpHeaders;
 import com.google.api.client.http.HttpRequestFactory;
 import io.camunda.connector.http.base.components.HttpTransportComponentSupplier;
 import io.camunda.connector.http.base.model.HttpCommonRequest;
+import io.camunda.connector.http.base.model.HttpMethod;
 import io.camunda.connector.http.base.services.HttpRequestMapper;
 import java.io.IOException;
 import java.util.Map;
@@ -39,7 +40,7 @@ class HttpRequestMapperTest {
   public void setUp() {
     httpRequestFactory = HttpTransportComponentSupplier.httpRequestFactoryInstance();
     request = new HttpCommonRequest();
-    request.setMethod("POST");
+    request.setMethod(HttpMethod.post);
     request.setUrl("http://example.com");
     request.setBody("{ \"key\": \"value\" }");
   }

--- a/connectors/http/rest/src/test/java/io/camunda/connector/http/rest/HttpServiceTest.java
+++ b/connectors/http/rest/src/test/java/io/camunda/connector/http/rest/HttpServiceTest.java
@@ -36,6 +36,7 @@ import com.google.api.client.testing.http.MockLowLevelHttpResponse;
 import io.camunda.connector.api.config.ConnectorConfigurationUtil;
 import io.camunda.connector.http.base.constants.Constants;
 import io.camunda.connector.http.base.model.HttpCommonResult;
+import io.camunda.connector.http.base.model.HttpMethod;
 import io.camunda.connector.http.base.services.AuthenticationService;
 import io.camunda.connector.http.base.services.HttpRequestMapper;
 import io.camunda.connector.http.base.services.HttpService;
@@ -76,7 +77,8 @@ class HttpServiceTest extends BaseTest {
 
     HttpRequestFactory factory = new MockHttpTransport().createRequestFactory();
     HttpRequest httpRequest =
-        factory.buildRequest(Constants.POST, new GenericUrl("http://test.bearer.com"), null);
+        factory.buildRequest(
+            HttpMethod.post.name().toUpperCase(), new GenericUrl("http://test.bearer.com"), null);
     when(requestFactory.buildRequest(any(), any(), any())).thenReturn(httpRequest);
     when(httpResponse.parseAsString()).thenReturn(ACCESS_TOKEN);
 

--- a/connectors/http/rest/src/test/java/io/camunda/connector/http/rest/auth/OAuthAuthenticationTest.java
+++ b/connectors/http/rest/src/test/java/io/camunda/connector/http/rest/auth/OAuthAuthenticationTest.java
@@ -28,6 +28,7 @@ import com.google.api.client.http.HttpRequestFactory;
 import com.google.api.client.http.HttpResponse;
 import com.google.api.client.testing.http.MockHttpTransport;
 import io.camunda.connector.http.base.constants.Constants;
+import io.camunda.connector.http.base.model.HttpMethod;
 import io.camunda.connector.http.base.services.AuthenticationService;
 import io.camunda.connector.http.base.services.HttpRequestMapper;
 import io.camunda.connector.http.rest.BaseTest;
@@ -61,7 +62,8 @@ class OAuthAuthenticationTest extends BaseTest {
 
     HttpRequestFactory factory = new MockHttpTransport().createRequestFactory();
     HttpRequest httpRequest =
-        factory.buildRequest(Constants.POST, new GenericUrl("http://abc3241.com"), null);
+        factory.buildRequest(
+            HttpMethod.post.name().toUpperCase(), new GenericUrl("http://abc3241.com"), null);
     when(requestFactory.buildRequest(any(), any(), any())).thenReturn(httpRequest);
     when(httpResponse.parseAsString()).thenReturn(ACCESS_TOKEN);
 


### PR DESCRIPTION
## Description

Dont sent body for HTTP methods that dont support it (or are not supported by the underlying clients).

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #1087 

