### PR TITLE
Use upper case enums for http method consistency.

### DIFF
--- a/connector-sdk/jackson-datatype-feel/src/main/java/io/camunda/connector/feel/ConnectorsObjectMapperSupplier.java
+++ b/connector-sdk/jackson-datatype-feel/src/main/java/io/camunda/connector/feel/ConnectorsObjectMapperSupplier.java
@@ -17,8 +17,10 @@
 package io.camunda.connector.feel;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import io.camunda.connector.feel.jackson.FeelAnnotationIntrospector;
@@ -30,13 +32,13 @@ public class ConnectorsObjectMapperSupplier {
   private ConnectorsObjectMapperSupplier() {}
 
   public static ObjectMapper DEFAULT_MAPPER =
-      new ObjectMapper()
-          .setAnnotationIntrospector(new FeelAnnotationIntrospector())
-          .registerModule(new JacksonModuleFeelFunction())
-          .registerModule(new Jdk8Module())
-          .registerModule(new JavaTimeModule())
+      JsonMapper.builder()
+          .annotationIntrospector(new FeelAnnotationIntrospector())
+          .addModules(new JacksonModuleFeelFunction(), new Jdk8Module(), new JavaTimeModule())
           .disable(SerializationFeature.FAIL_ON_EMPTY_BEANS)
-          .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+          .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+          .enable(MapperFeature.ACCEPT_CASE_INSENSITIVE_ENUMS)
+          .build();
 
   public static ObjectMapper getCopy() {
     return DEFAULT_MAPPER.copy();

--- a/connectors/http/graphql/src/main/java/io/camunda/connector/http/graphql/GraphQLFunction.java
+++ b/connectors/http/graphql/src/main/java/io/camunda/connector/http/graphql/GraphQLFunction.java
@@ -145,14 +145,14 @@ public class GraphQLFunction implements OutboundConnectorFunction {
     final HttpHeaders headers = httpInteractionService.createHeaders(request, bearerToken);
     final Map<String, Object> queryAndVariablesMap =
         JsonSerializeHelper.queryAndVariablesToMap(request);
-    if (HttpMethod.post.equals(request.getMethod())) {
+    if (HttpMethod.POST.equals(request.getMethod())) {
       content = new JsonHttpContent(gsonFactory, queryAndVariablesMap);
     } else {
       genericUrl.putAll(queryAndVariablesMap);
     }
 
     final var httpRequest =
-        requestFactory.buildRequest(request.getMethod().name().toUpperCase(), genericUrl, content);
+        requestFactory.buildRequest(request.getMethod().name(), genericUrl, content);
     httpRequest.setFollowRedirects(false);
     setTimeout(request, httpRequest);
     httpRequest.setHeaders(headers);

--- a/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/model/HttpMethod.java
+++ b/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/model/HttpMethod.java
@@ -17,11 +17,11 @@
 package io.camunda.connector.http.base.model;
 
 public enum HttpMethod {
-  post(true),
-  get(false),
-  delete(false),
-  patch(true),
-  put(true);
+  POST(true),
+  GET(false),
+  DELETE(false),
+  PATCH(true),
+  PUT(true);
 
   public final boolean supportsBody;
 

--- a/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/model/HttpRequestBuilder.java
+++ b/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/model/HttpRequestBuilder.java
@@ -64,8 +64,7 @@ public final class HttpRequestBuilder {
   }
 
   public HttpRequest build(final HttpRequestFactory requestFactory) throws IOException {
-    final var httpRequest =
-        requestFactory.buildRequest(method.name().toUpperCase(), genericUrl, content);
+    final var httpRequest = requestFactory.buildRequest(method.name(), genericUrl, content);
     httpRequest.setFollowRedirects(this.followRedirects);
     if (headers != null) {
       httpRequest.setHeaders(headers);

--- a/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/services/AuthenticationService.java
+++ b/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/services/AuthenticationService.java
@@ -107,7 +107,7 @@ public class AuthenticationService {
     Map<String, String> data = authentication.getDataForAuthRequestBody();
     HttpContent content = new UrlEncodedContent(data);
     final var httpRequest =
-        requestFactory.buildRequest(HttpMethod.post.name().toUpperCase(), genericUrl, content);
+        requestFactory.buildRequest(HttpMethod.POST.name(), genericUrl, content);
     httpRequest.setFollowRedirects(false);
     setTimeout(request, httpRequest);
     HttpHeaders headers = new HttpHeaders();

--- a/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/services/HttpProxyService.java
+++ b/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/services/HttpProxyService.java
@@ -56,7 +56,7 @@ public final class HttpProxyService {
 
     com.google.api.client.http.HttpRequest httpRequest =
         new HttpRequestBuilder()
-            .method(HttpMethod.post)
+            .method(HttpMethod.POST)
             .genericUrl(new GenericUrl(proxyFunctionUrl))
             .content(content)
             .connectionTimeoutInSeconds(request.getConnectionTimeoutInSeconds())

--- a/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/services/HttpRequestMapper.java
+++ b/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/services/HttpRequestMapper.java
@@ -55,7 +55,7 @@ public class HttpRequestMapper {
     headers.setContentType(Constants.APPLICATION_X_WWW_FORM_URLENCODED);
 
     return new HttpRequestBuilder()
-        .method(HttpMethod.post)
+        .method(HttpMethod.POST)
         .genericUrl(new GenericUrl(authentication.getOauthTokenEndpoint()))
         .content(new UrlEncodedContent(authentication.getDataForAuthRequestBody()))
         .headers(headers)

--- a/connectors/http/rest/src/test/java/io/camunda/connector/http/rest/BaseTest.java
+++ b/connectors/http/rest/src/test/java/io/camunda/connector/http/rest/BaseTest.java
@@ -73,7 +73,7 @@ public class BaseTest {
   protected interface ActualValue {
     String URL = "https://camunda.io/http-endpoint";
     String URL_WITH_PATH = "https://camunda.io/http-endpoint/path";
-    String METHOD = "get";
+    String METHOD = "GET";
     Integer CONNECT_TIMEOUT = 50;
 
     interface Authentication {

--- a/connectors/http/rest/src/test/java/io/camunda/connector/http/rest/HttpJsonFunctionProxyTest.java
+++ b/connectors/http/rest/src/test/java/io/camunda/connector/http/rest/HttpJsonFunctionProxyTest.java
@@ -80,7 +80,7 @@ public class HttpJsonFunctionProxyTest extends BaseTest {
         OutboundConnectorContextBuilder.create().variables(input).secrets(name -> "foo").build();
 
     when(requestFactory.buildRequest(
-            eq(HttpMethod.post.name().toUpperCase()),
+            eq(HttpMethod.POST.name().toUpperCase()),
             eq(new GenericUrl(PROXY_FUNCTION_URL)),
             nullable(HttpContent.class)))
         .thenReturn(httpRequest);
@@ -111,7 +111,7 @@ public class HttpJsonFunctionProxyTest extends BaseTest {
     when(httpException.getStatusCode()).thenReturn(500);
     when(httpException.getMessage()).thenReturn("my error message");
     when(requestFactory.buildRequest(
-            eq(HttpMethod.post.name().toUpperCase()),
+            eq(HttpMethod.POST.name().toUpperCase()),
             eq(new GenericUrl(PROXY_FUNCTION_URL)),
             nullable(HttpContent.class)))
         .thenReturn(httpRequest);
@@ -140,7 +140,7 @@ public class HttpJsonFunctionProxyTest extends BaseTest {
     when(httpException.getStatusCode()).thenReturn(500);
     when(httpException.getMessage()).thenReturn("my error message");
     when(requestFactory.buildRequest(
-            eq(HttpMethod.post.name().toUpperCase()),
+            eq(HttpMethod.POST.name().toUpperCase()),
             eq(new GenericUrl(PROXY_FUNCTION_URL)),
             nullable(HttpContent.class)))
         .thenReturn(httpRequest);
@@ -167,7 +167,7 @@ public class HttpJsonFunctionProxyTest extends BaseTest {
     when(httpException.getStatusCode()).thenReturn(500);
     when(httpException.getMessage()).thenReturn("my error message");
     when(requestFactory.buildRequest(
-            eq(HttpMethod.post.name().toUpperCase()),
+            eq(HttpMethod.POST.name().toUpperCase()),
             eq(new GenericUrl(PROXY_FUNCTION_URL)),
             nullable(HttpContent.class)))
         .thenReturn(httpRequest);

--- a/connectors/http/rest/src/test/java/io/camunda/connector/http/rest/HttpRequestMapperTest.java
+++ b/connectors/http/rest/src/test/java/io/camunda/connector/http/rest/HttpRequestMapperTest.java
@@ -40,7 +40,7 @@ class HttpRequestMapperTest {
   public void setUp() {
     httpRequestFactory = HttpTransportComponentSupplier.httpRequestFactoryInstance();
     request = new HttpCommonRequest();
-    request.setMethod(HttpMethod.post);
+    request.setMethod(HttpMethod.POST);
     request.setUrl("http://example.com");
     request.setBody("{ \"key\": \"value\" }");
   }

--- a/connectors/http/rest/src/test/java/io/camunda/connector/http/rest/HttpServiceTest.java
+++ b/connectors/http/rest/src/test/java/io/camunda/connector/http/rest/HttpServiceTest.java
@@ -78,7 +78,7 @@ class HttpServiceTest extends BaseTest {
     HttpRequestFactory factory = new MockHttpTransport().createRequestFactory();
     HttpRequest httpRequest =
         factory.buildRequest(
-            HttpMethod.post.name().toUpperCase(), new GenericUrl("http://test.bearer.com"), null);
+            HttpMethod.POST.name().toUpperCase(), new GenericUrl("http://test.bearer.com"), null);
     when(requestFactory.buildRequest(any(), any(), any())).thenReturn(httpRequest);
     when(httpResponse.parseAsString()).thenReturn(ACCESS_TOKEN);
 

--- a/connectors/http/rest/src/test/java/io/camunda/connector/http/rest/auth/OAuthAuthenticationTest.java
+++ b/connectors/http/rest/src/test/java/io/camunda/connector/http/rest/auth/OAuthAuthenticationTest.java
@@ -62,8 +62,7 @@ class OAuthAuthenticationTest extends BaseTest {
 
     HttpRequestFactory factory = new MockHttpTransport().createRequestFactory();
     HttpRequest httpRequest =
-        factory.buildRequest(
-            HttpMethod.post.name().toUpperCase(), new GenericUrl("http://abc3241.com"), null);
+        factory.buildRequest(HttpMethod.POST.name(), new GenericUrl("http://abc3241.com"), null);
     when(requestFactory.buildRequest(any(), any(), any())).thenReturn(httpRequest);
     when(httpResponse.parseAsString()).thenReturn(ACCESS_TOKEN);
 


### PR DESCRIPTION
## Related issues

<!-- Which issues are closed by this PR or are related -->

relates to #1087

