### PR TITLE
feat(connectors): add boundary events support

### DIFF
--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/inbound/importer/ProcessDefinitionInspectorUtilTests.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/inbound/importer/ProcessDefinitionInspectorUtilTests.java
@@ -70,6 +70,13 @@ public class ProcessDefinitionInspectorUtilTests {
     assertEquals("start_2", inboundConnectors.get(0).elementId());
   }
 
+  @Test
+  public void testSingleWebhookBoundaryEvent() throws Exception {
+    var inboundConnectors = fromModel("single-webhook-boundary.bpmn", "BoundaryEventTest");
+    assertEquals(1, inboundConnectors.size());
+    assertEquals("boundary_event", inboundConnectors.get(0).elementId());
+  }
+
   private List<InboundConnectorDefinitionImpl> fromModel(String fileName, String processId) {
     try {
       var operateClientMock = mock(CamundaOperateClient.class);

--- a/connector-runtime/connector-runtime-spring/src/test/resources/bpmn/single-webhook-boundary.bpmn
+++ b/connector-runtime/connector-runtime-spring/src/test/resources/bpmn/single-webhook-boundary.bpmn
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_061u7nq" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.11.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.2.0">
+    <bpmn:process id="BoundaryEventTest" name="BoundaryEventTest" isExecutable="true">
+        <bpmn:startEvent id="StartEvent_1">
+            <bpmn:outgoing>Flow_1e2z2fx</bpmn:outgoing>
+        </bpmn:startEvent>
+        <bpmn:sequenceFlow id="Flow_1e2z2fx" sourceRef="StartEvent_1" targetRef="Activity_0d39mr2" />
+        <bpmn:endEvent id="Event_0bt01e2">
+            <bpmn:incoming>Flow_1p1asga</bpmn:incoming>
+            <bpmn:incoming>Flow_1o5h3c4</bpmn:incoming>
+        </bpmn:endEvent>
+        <bpmn:sequenceFlow id="Flow_1p1asga" sourceRef="Activity_0d39mr2" targetRef="Event_0bt01e2" />
+        <bpmn:sequenceFlow id="Flow_0z0ybyd" sourceRef="boundary_event" targetRef="Activity_0fwzykw" />
+        <bpmn:boundaryEvent id="boundary_event" zeebe:modelerTemplate="io.camunda.connectors.webhook.WebhookConnectorBoundary.v1" zeebe:modelerTemplateVersion="1" zeebe:modelerTemplateIcon="data:image/svg+xml,%3Csvg id=&#39;icon&#39; xmlns=&#39;http://www.w3.org/2000/svg&#39; width=&#39;18&#39; height=&#39;18&#39; viewBox=&#39;0 0 32 32&#39;%3E%3Cdefs%3E%3Cstyle%3E .cls-1 %7B fill: none; %7D %3C/style%3E%3C/defs%3E%3Cpath d=&#39;M24,26a3,3,0,1,0-2.8164-4H13v1a5,5,0,1,1-5-5V16a7,7,0,1,0,6.9287,8h6.2549A2.9914,2.9914,0,0,0,24,26Z&#39;/%3E%3Cpath d=&#39;M24,16a7.024,7.024,0,0,0-2.57.4873l-3.1656-5.5395a3.0469,3.0469,0,1,0-1.7326.9985l4.1189,7.2085.8686-.4976a5.0006,5.0006,0,1,1-1.851,6.8418L17.937,26.501A7.0005,7.0005,0,1,0,24,16Z&#39;/%3E%3Cpath d=&#39;M8.532,20.0537a3.03,3.03,0,1,0,1.7326.9985C11.74,18.47,13.86,14.7607,13.89,14.708l.4976-.8682-.8677-.497a5,5,0,1,1,6.812-1.8438l1.7315,1.002a7.0008,7.0008,0,1,0-10.3462,2.0356c-.457.7427-1.1021,1.8716-2.0737,3.5728Z&#39;/%3E%3Crect id=&#39;_Transparent_Rectangle_&#39; data-name=&#39;&#38;lt;Transparent Rectangle&#38;gt;&#39; class=&#39;cls-1&#39; width=&#39;32&#39; height=&#39;32&#39;/%3E%3C/svg%3E" attachedToRef="Activity_0d39mr2">
+            <bpmn:extensionElements>
+                <zeebe:properties>
+                    <zeebe:property name="inbound.type" value="io.camunda:webhook:1" />
+                    <zeebe:property name="inbound.subtype" value="ConfigurableInboundWebhook" />
+                    <zeebe:property name="inbound.method" value="any" />
+                    <zeebe:property name="inbound.context" value="destroy" />
+                    <zeebe:property name="inbound.shouldValidateHmac" value="disabled" />
+                    <zeebe:property name="inbound.auth.type" value="NONE" />
+                    <zeebe:property name="correlationKeyExpression" value="=request.body.val1" />
+                    <zeebe:property name="resultVariable" value="res1" />
+                </zeebe:properties>
+            </bpmn:extensionElements>
+            <bpmn:outgoing>Flow_0z0ybyd</bpmn:outgoing>
+            <bpmn:messageEventDefinition id="MessageEventDefinition_034wd6j" messageRef="Message_1ev5yye" />
+        </bpmn:boundaryEvent>
+        <bpmn:serviceTask id="Activity_0d39mr2" zeebe:modelerTemplate="io.camunda.connectors.HttpJson.v2" zeebe:modelerTemplateVersion="2" zeebe:modelerTemplateIcon="data:image/svg+xml;utf8,%3Csvg%20width%3D%2218%22%20height%3D%2218%22%20viewBox%3D%220%200%2018%2018%22%20fill%3D%22none%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%0A%3Cpath%20d%3D%22M17.0335%208.99997C17.0335%2013.4475%2013.4281%2017.0529%208.98065%2017.0529C4.53316%2017.0529%200.927765%2013.4475%200.927765%208.99997C0.927765%204.55248%204.53316%200.947083%208.98065%200.947083C13.4281%200.947083%2017.0335%204.55248%2017.0335%208.99997Z%22%20fill%3D%22%23505562%22%2F%3E%0A%3Cpath%20d%3D%22M4.93126%2014.1571L6.78106%203.71471H10.1375C11.1917%203.71471%2011.9824%203.98323%2012.5095%204.52027C13.0465%205.04736%2013.315%205.73358%2013.315%206.57892C13.315%207.44414%2013.0714%208.15522%2012.5841%208.71215C12.1067%209.25913%2011.4553%209.63705%2010.6298%209.8459L12.0619%2014.1571H10.3315L9.03364%2010.0249H7.24351L6.51254%2014.1571H4.93126ZM7.49711%208.59281H9.24248C9.99832%208.59281%2010.5901%208.42374%2011.0177%208.08561C11.4553%207.73753%2011.6741%207.26513%2011.6741%206.66842C11.6741%206.19106%2011.5249%205.81811%2011.2265%205.54959C10.9282%205.27113%2010.4558%205.1319%209.80936%205.1319H8.10874L7.49711%208.59281Z%22%20fill%3D%22white%22%2F%3E%0A%3C%2Fsvg%3E%0A">
+            <bpmn:extensionElements>
+                <zeebe:taskDefinition type="io.camunda:http-json:1" />
+                <zeebe:ioMapping>
+                    <zeebe:input source="noAuth" target="authentication.type" />
+                    <zeebe:input source="get" target="method" />
+                    <zeebe:input source="https://httpbin.org/delay/10" target="url" />
+                    <zeebe:input source="20" target="connectionTimeoutInSeconds" />
+                </zeebe:ioMapping>
+                <zeebe:taskHeaders>
+                    <zeebe:header key="resultVariable" value="res0" />
+                </zeebe:taskHeaders>
+            </bpmn:extensionElements>
+            <bpmn:incoming>Flow_1e2z2fx</bpmn:incoming>
+            <bpmn:outgoing>Flow_1p1asga</bpmn:outgoing>
+        </bpmn:serviceTask>
+        <bpmn:serviceTask id="Activity_0fwzykw" zeebe:modelerTemplate="io.camunda.connectors.HttpJson.v2" zeebe:modelerTemplateVersion="2" zeebe:modelerTemplateIcon="data:image/svg+xml;utf8,%3Csvg%20width%3D%2218%22%20height%3D%2218%22%20viewBox%3D%220%200%2018%2018%22%20fill%3D%22none%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%0A%3Cpath%20d%3D%22M17.0335%208.99997C17.0335%2013.4475%2013.4281%2017.0529%208.98065%2017.0529C4.53316%2017.0529%200.927765%2013.4475%200.927765%208.99997C0.927765%204.55248%204.53316%200.947083%208.98065%200.947083C13.4281%200.947083%2017.0335%204.55248%2017.0335%208.99997Z%22%20fill%3D%22%23505562%22%2F%3E%0A%3Cpath%20d%3D%22M4.93126%2014.1571L6.78106%203.71471H10.1375C11.1917%203.71471%2011.9824%203.98323%2012.5095%204.52027C13.0465%205.04736%2013.315%205.73358%2013.315%206.57892C13.315%207.44414%2013.0714%208.15522%2012.5841%208.71215C12.1067%209.25913%2011.4553%209.63705%2010.6298%209.8459L12.0619%2014.1571H10.3315L9.03364%2010.0249H7.24351L6.51254%2014.1571H4.93126ZM7.49711%208.59281H9.24248C9.99832%208.59281%2010.5901%208.42374%2011.0177%208.08561C11.4553%207.73753%2011.6741%207.26513%2011.6741%206.66842C11.6741%206.19106%2011.5249%205.81811%2011.2265%205.54959C10.9282%205.27113%2010.4558%205.1319%209.80936%205.1319H8.10874L7.49711%208.59281Z%22%20fill%3D%22white%22%2F%3E%0A%3C%2Fsvg%3E%0A">
+            <bpmn:extensionElements>
+                <zeebe:taskDefinition type="io.camunda:http-json:1" />
+                <zeebe:ioMapping>
+                    <zeebe:input source="noAuth" target="authentication.type" />
+                    <zeebe:input source="get" target="method" />
+                    <zeebe:input source="https://httpbin.org/anything/anything" target="url" />
+                    <zeebe:input source="20" target="connectionTimeoutInSeconds" />
+                </zeebe:ioMapping>
+                <zeebe:taskHeaders>
+                    <zeebe:header key="resultVariable" value="res2" />
+                </zeebe:taskHeaders>
+            </bpmn:extensionElements>
+            <bpmn:incoming>Flow_0z0ybyd</bpmn:incoming>
+            <bpmn:outgoing>Flow_1o5h3c4</bpmn:outgoing>
+        </bpmn:serviceTask>
+        <bpmn:sequenceFlow id="Flow_1o5h3c4" sourceRef="Activity_0fwzykw" targetRef="Event_0bt01e2" />
+    </bpmn:process>
+    <bpmn:message id="Message_1ev5yye" name="c97ca438-b051-49db-b007-f897574daceb" zeebe:modelerTemplate="io.camunda.connectors.webhook.WebhookConnectorBoundary.v1">
+        <bpmn:extensionElements>
+            <zeebe:subscription correlationKey="=myCorrKey" />
+        </bpmn:extensionElements>
+    </bpmn:message>
+    <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+        <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="BoundaryEventTest">
+            <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+                <dc:Bounds x="179" y="99" width="36" height="36" />
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="Activity_0v5zd43_di" bpmnElement="Activity_0d39mr2">
+                <dc:Bounds x="270" y="77" width="100" height="80" />
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="Activity_07ao8h5_di" bpmnElement="Activity_0fwzykw">
+                <dc:Bounds x="390" y="200" width="100" height="80" />
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="Event_0bt01e2_di" bpmnElement="Event_0bt01e2">
+                <dc:Bounds x="612" y="99" width="36" height="36" />
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="Event_12t2apk_di" bpmnElement="boundary_event">
+                <dc:Bounds x="302" y="139" width="36" height="36" />
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNEdge id="Flow_1e2z2fx_di" bpmnElement="Flow_1e2z2fx">
+                <di:waypoint x="215" y="117" />
+                <di:waypoint x="270" y="117" />
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="Flow_1p1asga_di" bpmnElement="Flow_1p1asga">
+                <di:waypoint x="370" y="117" />
+                <di:waypoint x="612" y="117" />
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="Flow_0z0ybyd_di" bpmnElement="Flow_0z0ybyd">
+                <di:waypoint x="320" y="175" />
+                <di:waypoint x="320" y="240" />
+                <di:waypoint x="390" y="240" />
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="Flow_1o5h3c4_di" bpmnElement="Flow_1o5h3c4">
+                <di:waypoint x="490" y="240" />
+                <di:waypoint x="630" y="240" />
+                <di:waypoint x="630" y="135" />
+            </bpmndi:BPMNEdge>
+        </bpmndi:BPMNPlane>
+    </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/connectors/aws/aws-sns/element-templates/aws-sns-inbound-boundary.json
+++ b/connectors/aws/aws-sns/element-templates/aws-sns-inbound-boundary.json
@@ -1,0 +1,180 @@
+{
+  "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+  "name": "SNS HTTPS Subscription",
+  "id": "io.camunda.connectors.inbound.AWSSNS.Boundary.v1",
+  "description": "Receive events from AWS SNS",
+  "version": 1,
+  "documentationRef": "https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/aws-sns-inbound/",
+  "category": {
+    "id": "connectors",
+    "name": "Connectors"
+  },
+  "appliesTo": [
+    "bpmn:BoundaryEvent"
+  ],
+  "elementType": {
+    "value": "bpmn:BoundaryEvent",
+    "eventDefinition": "bpmn:MessageEventDefinition"
+  },
+  "groups": [
+    {
+      "id": "subscription",
+      "label": "Subscription Configuration"
+    },
+    {
+      "id": "activation",
+      "label": "Activation"
+    },
+    {
+      "id": "variable-mapping",
+      "label": "Variable Mapping"
+    }
+  ],
+  "properties": [
+    {
+      "type":"Hidden",
+      "value":"io.camunda:aws-sns-webhook:1",
+      "binding":{
+        "type":"zeebe:property",
+        "name":"inbound.type"
+      }
+    },
+    {
+      "type": "Hidden",
+      "generatedValue": {
+        "type": "uuid"
+      },
+      "binding": {
+        "type": "bpmn:Message#property",
+        "name": "name"
+      }
+    },
+    {
+      "type":"Hidden",
+      "value":"SnsHttpsSubscription",
+      "binding":{
+        "type":"zeebe:property",
+        "name":"inbound.subtype"
+      }
+    },
+    {
+      "label":"Subscription ID",
+      "type":"String",
+      "group":"subscription",
+      "binding":{
+        "type":"zeebe:property",
+        "name":"inbound.context"
+      },
+      "description":"The subscription ID is a part of the URL endpoint",
+      "constraints": {
+        "notEmpty": true
+      }
+    },
+    {
+      "id": "securitySubscriptionAllowedFor",
+      "label": "Allow to receive messages from topic(s)",
+      "group": "subscription",
+      "description": "Control which topic(s) is allowed to start a process",
+      "value": "any",
+      "type": "Dropdown",
+      "choices": [
+        {
+          "name": "Any",
+          "value": "any"
+        },
+        {
+          "name": "Specific topic(s)",
+          "value": "specific"
+        }
+      ],
+      "binding": {
+        "type": "zeebe:property",
+        "name": "inbound.securitySubscriptionAllowedFor"
+      }
+    },
+    {
+      "label": "Topic ARN(s)",
+      "description": "Topics that allow to publish messages",
+      "type": "String",
+      "group": "subscription",
+      "feel": "optional",
+      "binding": {
+        "type": "zeebe:property",
+        "name": "inbound.topicsAllowList"
+      },
+      "constraints": {
+        "notEmpty": true
+      },
+      "condition": {
+        "property": "securitySubscriptionAllowedFor",
+        "equals": "specific"
+      }
+    },
+    {
+      "label": "Correlation key (process)",
+      "type": "String",
+      "group": "activation",
+      "feel": "required",
+      "description": "Sets up the correlation key from process variables",
+      "binding": {
+        "type": "bpmn:Message#zeebe:subscription#property",
+        "name": "correlationKey"
+      },
+      "constraints": {
+        "notEmpty": true
+      }
+    },
+    {
+      "label": "Correlation key (payload)",
+      "type": "String",
+      "group": "activation",
+      "feel": "required",
+      "binding": {
+        "type": "zeebe:property",
+        "name": "correlationKeyExpression"
+      },
+      "description": "Extracts the correlation key from the incoming message payload",
+      "constraints": {
+        "notEmpty": true
+      }
+    },
+    {
+      "label": "Condition",
+      "type": "String",
+      "group": "activation",
+      "feel": "required",
+      "optional": true,
+      "binding": {
+        "type": "zeebe:property",
+        "name": "activationCondition"
+      },
+      "description": "Condition under which the connector triggers. Leave empty to catch all events"
+    },
+    {
+      "label": "Result variable",
+      "type": "String",
+      "group": "variable-mapping",
+      "optional": true,
+      "binding": {
+        "type": "zeebe:property",
+        "name": "resultVariable"
+      },
+      "description": "Name of variable to store the result of the Connector in"
+    },
+    {
+      "label":"Result expression",
+      "type": "String",
+      "group": "variable-mapping",
+      "feel": "required",
+      "optional": true,
+      "binding": {
+        "type": "zeebe:property",
+        "name": "resultExpression"
+      },
+      "description": "Expression to map the inbound payload to process variables"
+    }
+  ],
+  "icon": {
+    "contents": "data:image/svg+xml,%3Csvg width='18' height='18' viewBox='0 0 80 80' version='1.1' xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink'%3E%3C!-- Generator: Sketch 64 (93537) - https://sketch.com --%3E%3Ctitle%3EIcon-Architecture/64/Arch_AWS-Simple-Notification-Service_64%3C/title%3E%3Cdesc%3ECreated with Sketch.%3C/desc%3E%3Cdefs%3E%3ClinearGradient x1='0%25' y1='100%25' x2='100%25' y2='0%25' id='linearGradient-1'%3E%3Cstop stop-color='%23B0084D' offset='0%25'%3E%3C/stop%3E%3Cstop stop-color='%23FF4F8B' offset='100%25'%3E%3C/stop%3E%3C/linearGradient%3E%3C/defs%3E%3Cg id='Icon-Architecture/64/Arch_AWS-Simple-Notification-Service_64' stroke='none' stroke-width='1' fill='none' fill-rule='evenodd'%3E%3Cg id='Icon-Architecture-BG/64/Application-Integration' fill='url(%23linearGradient-1)'%3E%3Crect id='Rectangle' x='0' y='0' width='80' height='80'%3E%3C/rect%3E%3C/g%3E%3Cpath d='M17,38 C18.103,38 19,38.897 19,40 C19,41.103 18.103,42 17,42 C15.897,42 15,41.103 15,40 C15,38.897 15.897,38 17,38 L17,38 Z M41,64 C29.314,64 19.289,55.466 17.194,43.98 C18.965,43.894 20.427,42.659 20.857,41 L27,41 L27,39 L20.857,39 C20.427,37.342 18.966,36.107 17.195,36.02 C19.285,24.71 29.511,16 41,16 C45.313,16 49.832,17.622 54.429,20.821 L55.571,19.179 C50.633,15.743 45.73,14 41,14 C28.27,14 16.949,23.865 15.063,36.521 C13.839,37.207 13,38.5 13,40 C13,41.5 13.839,42.793 15.063,43.478 C16.97,56.341 28.056,66 41,66 C46.407,66 51.942,64.157 56.585,60.811 L55.415,59.189 C51.11,62.292 45.991,64 41,64 L41,64 Z M30.101,36.442 C31.955,36.895 34.275,37 36,37 C37.642,37 39.823,36.905 41.629,36.506 L37.105,45.553 C37.036,45.691 37,45.845 37,46 L37,50.453 C36.199,50.964 34.833,51.812 34,51.986 L34,46 C34,45.868 33.974,45.737 33.923,45.615 L30.101,36.442 Z M36,33 C40.025,33 42.174,33.604 42.841,34 C42.174,34.396 40.025,35 36,35 C31.975,35 29.826,34.396 29.159,34 C29.826,33.604 31.975,33 36,33 L36,33 Z M33,54 L34,54 C34.043,54 34.086,53.997 34.128,53.992 C35.352,53.833 36.909,52.887 38.272,52.013 L38.535,51.845 C38.824,51.661 39,51.342 39,51 L39,46.236 L44.559,35.12 C44.833,34.801 45,34.434 45,34 C45,31.39 39.361,31 36,31 C32.639,31 27,31.39 27,34 C27,34.366 27.12,34.684 27.32,34.967 L32,46.2 L32,53 C32,53.552 32.447,54 33,54 L33,54 Z M62,53 C63.103,53 64,53.897 64,55 C64,56.103 63.103,57 62,57 C60.897,57 60,56.103 60,55 C60,53.897 60.897,53 62,53 L62,53 Z M62,23 C63.103,23 64,23.897 64,25 C64,26.103 63.103,27 62,27 C60.897,27 60,26.103 60,25 C60,23.897 60.897,23 62,23 L62,23 Z M64,38 C65.103,38 66,38.897 66,40 C66,41.103 65.103,42 64,42 C62.897,42 62,41.103 62,40 C62,38.897 62.897,38 64,38 L64,38 Z M54,41 L60.143,41 C60.589,42.72 62.142,44 64,44 C66.206,44 68,42.206 68,40 C68,37.794 66.206,36 64,36 C62.142,36 60.589,37.28 60.143,39 L54,39 L54,26 L58.143,26 C58.589,27.72 60.142,29 62,29 C64.206,29 66,27.206 66,25 C66,22.794 64.206,21 62,21 C60.142,21 58.589,22.28 58.143,24 L53,24 C52.447,24 52,24.448 52,25 L52,39 L45,39 L45,41 L52,41 L52,55 C52,55.552 52.447,56 53,56 L58.143,56 C58.589,57.72 60.142,59 62,59 C64.206,59 66,57.206 66,55 C66,52.794 64.206,51 62,51 C60.142,51 58.589,52.28 58.143,54 L54,54 L54,41 Z' id='AWS-Simple-Notification-Service_Icon_64_Squid' fill='%23FFFFFF'%3E%3C/path%3E%3C/g%3E%3C/svg%3E"
+  }
+}

--- a/connectors/aws/aws-sqs/element-templates/aws-sqs-boundary-connector.json
+++ b/connectors/aws/aws-sqs/element-templates/aws-sqs-boundary-connector.json
@@ -1,0 +1,231 @@
+{
+  "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+  "name": "Amazon SQS connector",
+  "id": "io.camunda.connectors.AWSSQS.boundary.v1",
+  "version": 1,
+  "description": "Receive message from a queue",
+  "documentationRef": "https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/aws-sqs-inbound/",
+  "appliesTo": [
+    "bpmn:BoundaryEvent"
+  ],
+  "elementType": {
+    "value": "bpmn:BoundaryEvent",
+    "eventDefinition": "bpmn:MessageEventDefinition"
+  },
+  "category": {
+    "id": "connectors",
+    "name": "Connectors"
+  },
+  "groups": [
+    {
+      "id": "authentication",
+      "label": "Authentication"
+    },
+    {
+      "id": "queueProperties",
+      "label": "Queue properties"
+    },
+    {
+      "id": "messagePollingProperties",
+      "label": "Message polling properties"
+    },
+    {
+      "id": "input",
+      "label": "Use next attribute names for activation condition"
+    },
+    {
+      "id": "activation",
+      "label": "Activation"
+    },
+    {
+      "id": "variable-mapping",
+      "label": "Variable mapping"
+    }
+  ],
+  "properties": [
+    {
+      "type": "Hidden",
+      "value": "io.camunda:aws-sqs-inbound:1",
+      "binding": {
+        "type": "zeebe:property",
+        "name": "inbound.type"
+      }
+    },
+    {
+      "type": "Hidden",
+      "generatedValue": {
+        "type": "uuid"
+      },
+      "binding": {
+        "type": "bpmn:Message#property",
+        "name": "name"
+      }
+    },
+    {
+      "label": "Access key",
+      "description": "Provide AWS IAM access key that has permission to send to desired SQS",
+      "group": "authentication",
+      "type": "String",
+      "binding": {
+        "type": "zeebe:property",
+        "name": "authentication.accessKey"
+      },
+      "constraints": {
+        "notEmpty": true
+      }
+    },
+    {
+      "label": "Secret key",
+      "description": "Provide AWS IAM secret key that has permission to send to desired SQS",
+      "group": "authentication",
+      "type": "String",
+      "binding": {
+        "type": "zeebe:property",
+        "name": "authentication.secretKey"
+      },
+      "constraints": {
+        "notEmpty": true
+      }
+    },
+    {
+      "label": "Queue URL",
+      "description": "Specify the URL of the SQS queue where you would like to send message to",
+      "group": "queueProperties",
+      "type": "String",
+      "binding": {
+        "type": "zeebe:property",
+        "name": "queue.url"
+      },
+      "constraints": {
+        "notEmpty": true,
+        "pattern": {
+          "value": "^(https?://.+|arn:.+|\\{\\{secrets\\..+\\}\\}.*)$",
+          "message": "Must be an queue URL or ARN"
+        }
+      }
+    },
+    {
+      "label": "Region",
+      "description": "Specify the AWS region of your queue",
+      "group": "queueProperties",
+      "type": "String",
+      "binding": {
+        "type": "zeebe:property",
+        "name": "configuration.region"
+      },
+      "constraints": {
+        "notEmpty": true
+      }
+    },
+    {
+      "label": "Polling wait time",
+      "description": "The duration (in seconds) for which the call waits for a message to arrive in the queue before returning. See <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/aws-sqs-inbound/\" target=\"_blank\">documentation</a> for details",
+      "group": "messagePollingProperties",
+      "type": "String",
+      "optional":false,
+      "feel":"optional",
+      "value": "1",
+      "binding": {
+        "type": "zeebe:property",
+        "name": "queue.pollingWaitTime"
+      },
+      "constraints": {
+        "notEmpty": true,
+        "pattern": {
+          "value": "^([0-9]?|1[0-9]|20|\\{\\{secrets\\..+\\}\\}.*)$",
+          "message": "Must be >= 0 and <= 20 or a FEEL expression"
+        }
+      }
+    },
+    {
+      "label": "Attribute names",
+      "description": "Array of queue attribute names. See <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/aws-sqs-inbound/\" target=\"_blank\">documentation</a> for details",
+      "group": "input",
+      "type": "String",
+      "optional": true,
+      "binding": {
+        "type": "zeebe:property",
+        "name": "queue.attributeNames"
+      },
+      "feel": "required"
+    },
+    {
+      "label": "Message attribute names",
+      "description": "Array of message attribute names. See <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/aws-sqs-inbound/\" target=\"_blank\">documentation</a> for details",
+      "group": "input",
+      "type": "String",
+      "optional": true,
+      "binding": {
+        "type": "zeebe:property",
+        "name": "queue.messageAttributeNames"
+      },
+      "feel": "required"
+    },
+    {
+      "label": "Correlation key (process)",
+      "type": "String",
+      "group": "activation",
+      "feel": "required",
+      "description": "Sets up the correlation key from process variables",
+      "binding": {
+        "type": "bpmn:Message#zeebe:subscription#property",
+        "name": "correlationKey"
+      },
+      "constraints": {
+        "notEmpty": true
+      }
+    },
+    {
+      "label": "Correlation key (payload)",
+      "type": "String",
+      "group": "activation",
+      "feel": "required",
+      "binding": {
+        "type": "zeebe:property",
+        "name": "correlationKeyExpression"
+      },
+      "description": "Extracts the correlation key from the incoming message payload",
+      "constraints": {
+        "notEmpty": true
+      }
+    },
+    {
+      "label": "Activation condition",
+      "type": "String",
+      "group": "activation",
+      "feel": "required",
+      "optional": true,
+      "binding": {
+        "type": "zeebe:property",
+        "name": "activationCondition"
+      },
+      "description": "Condition under which the connector triggers. Leave empty to catch all events"
+    },
+    {
+      "label": "Result variable",
+      "type": "String",
+      "group": "variable-mapping",
+      "optional": true,
+      "binding": {
+        "type": "zeebe:property",
+        "name": "resultVariable"
+      },
+      "description": "Name of variable to store the result of the connector in"
+    },
+    {
+      "label": "Result expression",
+      "type": "String",
+      "group": "variable-mapping",
+      "feel": "required",
+      "optional": true,
+      "binding": {
+        "type": "zeebe:property",
+        "name": "resultExpression"
+      },
+      "description": "Expression to map the inbound payload to process variables"
+    }
+  ],
+  "icon": {
+    "contents": "data:image/svg+xml,%3Csvg width='18' height='18' viewBox='0 0 40 40' version='1.1' xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink'%3E%3C!-- Generator: Sketch 64 (93537) - https://sketch.com --%3E%3Ctitle%3EIcon-Architecture/32/Arch_AWS-Simple-Queue-Service_32%3C/title%3E%3Cdesc%3ECreated with Sketch.%3C/desc%3E%3Cdefs%3E%3ClinearGradient x1='0%25' y1='100%25' x2='100%25' y2='0%25' id='linearGradient-1'%3E%3Cstop stop-color='%23B0084D' offset='0%25'%3E%3C/stop%3E%3Cstop stop-color='%23FF4F8B' offset='100%25'%3E%3C/stop%3E%3C/linearGradient%3E%3C/defs%3E%3Cg id='Icon-Architecture/32/Arch_AWS-Simple-Queue-Service_32' stroke='none' stroke-width='1' fill='none' fill-rule='evenodd'%3E%3Cg id='Icon-Architecture-BG/32/Application-Integration' fill='url(%23linearGradient-1)'%3E%3Crect id='Rectangle' x='0' y='0' width='40' height='40'%3E%3C/rect%3E%3C/g%3E%3Cpath d='M14.3422051,22.3493786 L15.8466767,20.9061074 C15.9428347,20.8141539 15.9969235,20.687218 15.9999285,20.5552846 C16.0019317,20.4223517 15.9518495,20.2934168 15.8596981,20.1984648 L14.3552264,18.6432502 L13.6350433,19.3378994 L14.311154,20.037546 L11.9913429,20.037546 L11.9913429,21.0370413 L14.2650783,21.0370413 L13.6480647,21.6287425 L14.3422051,22.3493786 Z M26.3579452,22.3533765 L27.9074909,20.9001104 C28.0066538,20.8081569 28.0627459,20.679222 28.0647492,20.5442901 C28.0667525,20.4093583 28.0136653,20.2784244 27.918509,20.1834724 L26.3689633,18.6372532 L25.6607999,19.3438963 L26.3549403,20.037546 L24.0110896,20.037546 L24.0110896,21.0370413 L26.2988481,21.0370413 L25.671818,21.6247445 L26.3579452,22.3533765 Z M17.5875367,23.3608678 C18.3387708,23.0570212 19.1621235,22.8941035 20.0045074,22.8941035 C20.8468913,22.8941035 21.670244,23.0570212 22.4214781,23.3608678 C21.7523789,21.5897622 21.7523789,19.3898731 22.4214781,17.6187675 C20.9190098,18.2264606 19.090005,18.2264606 17.5875367,17.6187675 C18.2566359,19.3898731 18.2566359,21.5897622 17.5875367,23.3608678 L17.5875367,23.3608678 Z M15.6443443,25.3408679 C15.546183,25.2439168 15.4971024,25.1159814 15.4971024,24.988046 C15.4971024,24.8601106 15.546183,24.7321753 15.6443443,24.6342247 C17.5845317,22.6982024 17.5845317,18.2824324 15.6443443,16.3454106 C15.546183,16.2484595 15.4971024,16.1205241 15.4971024,15.9925912 C15.4971024,15.8646534 15.546183,15.736718 15.6443443,15.6387674 C15.8396652,15.4438659 16.1571868,15.4438659 16.3525077,15.6387674 C17.2740216,16.5583031 18.6052086,17.0860366 20.0045074,17.0860366 C21.4048079,17.0860366 22.7359948,16.5583031 23.6575088,15.6387674 C23.8528296,15.4438659 24.1703513,15.4438659 24.3656722,15.6387674 C24.4628318,15.736718 24.5119124,15.8646534 24.5119124,15.9925912 C24.5119124,16.1205241 24.4628318,16.2484595 24.3656722,16.3454106 C22.4244831,18.2824324 22.4244831,22.6982024 24.3656722,24.6342247 C24.4628318,24.7321753 24.5119124,24.8601106 24.5119124,24.988046 C24.5119124,25.1159814 24.4628318,25.2439168 24.3656722,25.3408679 C24.2675109,25.4388184 24.1393003,25.4877937 24.0110896,25.4877937 C23.882879,25.4877937 23.7546684,25.4388184 23.6575088,25.3408679 C22.7359948,24.4213322 21.4048079,23.8935987 20.0045074,23.8935987 C18.6052086,23.8935987 17.2740216,24.4213322 16.3525077,25.3408679 C16.1571868,25.5357694 15.8396652,25.5357694 15.6443443,25.3408679 L15.6443443,25.3408679 Z M32.5421049,19.4358499 C32.236603,19.1320033 31.8369464,18.9800801 31.4362882,18.9800801 C31.0366316,18.9800801 30.636975,19.1320033 30.3314731,19.4358499 C29.721471,20.0445425 29.721471,21.0340428 30.3314731,21.6417359 C30.9414753,22.2504285 31.9321027,22.2504285 32.5421049,21.6417359 C33.1511054,21.0340428 33.1511054,20.0445425 32.5421049,19.4358499 L32.5421049,19.4358499 Z M33.2502683,22.3493786 C32.7504472,22.8481267 32.0933677,23.0980005 31.4362882,23.0980005 C30.7802103,23.0980005 30.1231309,22.8481267 29.6233097,22.3493786 C28.6236675,21.3508828 28.6236675,19.7277025 29.6233097,18.7292068 C30.622952,17.7317105 32.250626,17.7317105 33.2502683,18.7292068 C34.2499106,19.7277025 34.2499106,21.3508828 33.2502683,22.3493786 L33.2502683,22.3493786 Z M9.66852687,19.4468443 C9.36302497,19.1429978 8.96336839,18.9910745 8.56271017,18.9910745 C8.16305359,18.9910745 7.76339701,19.1429978 7.45789511,19.4468443 C6.84889461,20.055537 6.84889461,21.0450373 7.45789511,21.6527304 C8.06789726,22.261423 9.05852472,22.261423 9.66852687,21.6527304 C10.2775274,21.0450373 10.2775274,20.055537 9.66852687,19.4468443 L9.66852687,19.4468443 Z M10.3766903,22.3593735 C9.87686914,22.8581217 9.21978965,23.1079955 8.56271017,23.1079955 C7.90663232,23.1079955 7.24955284,22.8581217 6.7497317,22.3593735 C5.75008943,21.3618773 5.75008943,19.738697 6.7497317,18.7402012 C7.74937397,17.7427049 9.37704801,17.7427049 10.3766903,18.7402012 C11.3763325,19.738697 11.3763325,21.3618773 10.3766903,22.3593735 L10.3766903,22.3593735 Z M27.4337125,28.9100654 C25.4364313,30.903059 22.7820705,32.0005047 19.9574301,32.0005047 C17.1327896,32.0005047 14.4784288,30.903059 12.4821492,28.9100654 C11.165987,27.5977281 10.4077413,26.469298 9.94498104,25.1359713 L8.99842599,25.4628063 C9.50726193,26.9290658 10.3626672,28.2104187 11.7739858,29.6167086 C13.9585748,31.7986067 16.8663519,33 19.9574301,33 C23.0495099,33 25.9562853,31.7986067 28.1418759,29.6167086 C29.2827502,28.4782835 30.4206196,27.1869356 31.0115905,25.4608073 L30.0640338,25.1379703 C29.5391715,26.6701966 28.4894469,27.8565974 27.4337125,28.9100654 L27.4337125,28.9100654 Z M9.94498104,15.8596559 L8.99842599,15.5318214 C9.51026687,14.0645624 10.3656722,12.7832095 11.7759891,11.3759202 C16.2863991,6.87519304 23.6264578,6.87419354 28.1378694,11.3759202 C29.2186449,12.4533761 30.4035916,13.7897012 31.0115905,15.5318214 L30.0640338,15.8596559 C29.5241468,14.3094387 28.4293482,13.0800596 27.4297059,12.0825633 C25.434428,10.0915688 22.7810689,8.99612197 19.9574301,8.99612197 C17.1337912,8.99612197 14.4804321,10.0915688 12.4851542,12.0825633 C11.1870215,13.3779092 10.4037347,14.5423211 9.94498104,15.8596559 L9.94498104,15.8596559 Z' id='AWS-Simple-Queue-Service_Icon_32_Squid' fill='%23FFFFFF'%3E%3C/path%3E%3C/g%3E%3C/svg%3E"
+  }
+}

--- a/connectors/github/element-templates/github-webhook-connector-boundary.json
+++ b/connectors/github/element-templates/github-webhook-connector-boundary.json
@@ -1,0 +1,175 @@
+{
+  "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+  "name": "GitHub webhook connector",
+  "id": "io.camunda.connectors.webhook.GithubWebhookConnectorBoundary.v1",
+  "version": 1,
+  "description": "Receive events from GitHub",
+  "documentationRef": "https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/github-webhook/",
+  "category": {
+    "id": "connectors",
+    "name": "Connectors"
+  },
+  "appliesTo": [
+    "bpmn:BoundaryEvent"
+  ],
+  "elementType": {
+    "value": "bpmn:BoundaryEvent",
+    "eventDefinition": "bpmn:MessageEventDefinition"
+  },
+  "groups": [
+    {
+      "id": "endpoint",
+      "label": "Webhook configuration"
+    },
+    {
+      "id": "activation",
+      "label": "Activation"
+    },
+    {
+      "id": "variable-mapping",
+      "label": "Variable mapping"
+    }
+  ],
+  "properties": [
+    {
+      "type": "Hidden",
+      "value": "io.camunda:webhook:1",
+      "binding": {
+        "type": "zeebe:property",
+        "name": "inbound.type"
+      }
+    },
+    {
+      "type": "Hidden",
+      "generatedValue": {
+        "type": "uuid"
+      },
+      "binding": {
+        "type": "bpmn:Message#property",
+        "name": "name"
+      }
+    },
+    {
+      "type": "Hidden",
+      "value": "GitHubWebhook",
+      "binding": {
+        "type": "zeebe:property",
+        "name": "inbound.subtype"
+      }
+    },
+    {
+      "label": "Webhook ID",
+      "type": "String",
+      "group": "endpoint",
+      "binding": {
+        "type": "zeebe:property",
+        "name": "inbound.context"
+      },
+      "description": "The webhook ID is a part of the URL",
+      "constraints": {
+        "notEmpty": true
+      }
+    },
+    {
+      "type": "Hidden",
+      "value": "enabled",
+      "binding": {
+        "type": "zeebe:property",
+        "name": "inbound.shouldValidateHmac"
+      }
+    },
+    {
+      "label": "GitHub secret",
+      "description": "Shared secret key. <a href='https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/github-webhook/' target='_blank'>See documentation</a> regarding GitHub secret",
+      "type": "String",
+      "group": "endpoint",
+      "optional": true,
+      "binding": {
+        "type": "zeebe:property",
+        "name": "inbound.hmacSecret"
+      }
+    },
+    {
+      "type": "Hidden",
+      "value": "X-Hub-Signature-256",
+      "binding": {
+        "type": "zeebe:property",
+        "name": "inbound.hmacHeader"
+      }
+    },
+    {
+      "type": "Hidden",
+      "value": "sha_256",
+      "binding": {
+        "type": "zeebe:property",
+        "name": "inbound.hmacAlgorithm"
+      }
+    },
+    {
+      "label": "Correlation key (process)",
+      "type": "String",
+      "group": "activation",
+      "feel": "required",
+      "description": "Sets up the correlation key from process variables",
+      "binding": {
+        "type": "bpmn:Message#zeebe:subscription#property",
+        "name": "correlationKey"
+      },
+      "constraints": {
+        "notEmpty": true
+      }
+    },
+    {
+      "label": "Correlation key (payload)",
+      "type": "String",
+      "group": "activation",
+      "feel": "required",
+      "binding": {
+        "type": "zeebe:property",
+        "name": "correlationKeyExpression"
+      },
+      "description": "Extracts the correlation key from the incoming message payload",
+      "constraints": {
+        "notEmpty": true
+      }
+    },
+    {
+      "label": "Condition",
+      "type": "String",
+      "group": "activation",
+      "feel": "required",
+      "optional": true,
+      "binding": {
+        "type": "zeebe:property",
+        "name": "inbound.activationCondition"
+      },
+      "description": "Condition under which the connector triggers. <a href='https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/github-webhook/' target='_blank'>See documentation</a>"
+    },
+    {
+      "label": "Result variable",
+      "type": "String",
+      "group": "variable-mapping",
+      "optional": true,
+      "binding": {
+        "type": "zeebe:property",
+        "name": "resultVariable"
+      },
+      "description": "Name of variable to store the result of the connector in"
+    },
+    {
+      "label": "Result expression",
+      "type": "String",
+      "group": "variable-mapping",
+      "feel": "required",
+      "optional": true,
+      "binding": {
+        "type": "zeebe:property",
+        "name": "resultExpression"
+      },
+      "description": "Expression to map the inbound payload to process variables"
+    }
+  ],
+  "icon": {
+    "contents": "data:image/svg+xml,%3Csvg width='18' height='18' viewBox='0 0 1024 1024' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath fill-rule='evenodd' clip-rule='evenodd' d='M8 0C3.58 0 0 3.58 0 8C0 11.54 2.29 14.53 5.47 15.59C5.87 15.66 6.02 15.42 6.02 15.21C6.02 15.02 6.01 14.39 6.01 13.72C4 14.09 3.48 13.23 3.32 12.78C3.23 12.55 2.84 11.84 2.5 11.65C2.22 11.5 1.82 11.13 2.49 11.12C3.12 11.11 3.57 11.7 3.72 11.94C4.44 13.15 5.59 12.81 6.05 12.6C6.12 12.08 6.33 11.73 6.56 11.53C4.78 11.33 2.92 10.64 2.92 7.58C2.92 6.71 3.23 5.99 3.74 5.43C3.66 5.23 3.38 4.41 3.82 3.31C3.82 3.31 4.49 3.1 6.02 4.13C6.66 3.95 7.34 3.86 8.02 3.86C8.7 3.86 9.38 3.95 10.02 4.13C11.55 3.09 12.22 3.31 12.22 3.31C12.66 4.41 12.38 5.23 12.3 5.43C12.81 5.99 13.12 6.7 13.12 7.58C13.12 10.65 11.25 11.33 9.47 11.53C9.76 11.78 10.01 12.26 10.01 13.01C10.01 14.08 10 14.94 10 15.21C10 15.42 10.15 15.67 10.55 15.59C13.71 14.53 16 11.53 16 8C16 3.58 12.42 0 8 0Z' transform='scale(64)' fill='%231B1F23'/%3E%3C/svg%3E"
+  }
+}

--- a/connectors/kafka/element-templates/kafka-inbound-connector-boundary.json
+++ b/connectors/kafka/element-templates/kafka-inbound-connector-boundary.json
@@ -1,0 +1,270 @@
+{
+  "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+  "name": "Kafka Consumer Connector",
+  "id": "io.camunda.connectors.inbound.KafkaBoundary.v1",
+  "version": 1,
+  "description": "Consume Kafka messages",
+  "documentationRef": "https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/kafka-inbound/",
+  "category": {
+    "id": "connectors",
+    "name": "Connectors"
+  },
+  "appliesTo": [
+    "bpmn:BoundaryEvent"
+  ],
+  "elementType": {
+    "value": "bpmn:BoundaryEvent",
+    "eventDefinition": "bpmn:MessageEventDefinition"
+  },
+  "groups": [
+    {
+      "id": "authentication",
+      "label": "Authentication"
+    },
+    {
+      "id": "kafka",
+      "label": "Kafka"
+    },
+    {
+      "id": "activation",
+      "label": "Activation"
+    },
+    {
+      "id": "variable-mapping",
+      "label": "Variable mapping"
+    }
+  ],
+  "properties": [
+    {
+      "type": "Hidden",
+      "value": "io.camunda:connector-kafka-inbound:1",
+      "binding": {
+        "type": "zeebe:property",
+        "name": "inbound.type"
+      }
+    },
+    {
+      "type": "Hidden",
+      "generatedValue": {
+        "type": "uuid"
+      },
+      "binding": {
+        "type": "bpmn:Message#property",
+        "name": "name"
+      }
+    },
+    {
+      "label": "Authentication type",
+      "description": "Username/password or custom",
+      "id": "authenticationType",
+      "group": "authentication",
+      "type": "Dropdown",
+      "value": "credentials",
+      "choices": [
+        {
+          "name": "Credentials",
+          "value": "credentials"
+        },
+        {
+          "name": "Custom",
+          "value": "custom"
+        }
+      ],
+      "binding": {
+        "type": "zeebe:property",
+        "name": "authenticationType"
+      }
+    },
+    {
+      "label": "Username",
+      "description": "Provide the username (must have permissions to produce message to the topic)",
+      "group": "authentication",
+      "type": "String",
+      "feel": "optional",
+      "optional": true,
+      "binding": {
+        "type": "zeebe:property",
+        "name": "authentication.username"
+      },
+      "condition": {
+        "property": "authenticationType",
+        "equals": "credentials"
+      }
+    },
+    {
+      "label": "Password",
+      "description": "Provide a password for the user",
+      "group": "authentication",
+      "type": "String",
+      "feel": "optional",
+      "optional": true,
+      "binding": {
+        "type": "zeebe:property",
+        "name": "authentication.password"
+      },
+      "condition": {
+        "property": "authenticationType",
+        "equals": "credentials"
+      }
+    },
+    {
+      "label": "Bootstrap servers",
+      "description": "Provide bootstrap server(s), comma-delimited if there are multiple",
+      "group": "kafka",
+      "type": "String",
+      "feel": "optional",
+      "binding": {
+        "type": "zeebe:property",
+        "name": "topic.bootstrapServers"
+      },
+      "constraints": {
+        "notEmpty": true
+      }
+    },
+    {
+      "label": "Topic",
+      "description": "Provide the topic name",
+      "group": "kafka",
+      "type": "String",
+      "feel": "optional",
+      "binding": {
+        "type": "zeebe:property",
+        "name": "topic.topicName"
+      },
+      "constraints": {
+        "notEmpty": true
+      }
+    },
+    {
+      "label": "Consumer Group ID",
+      "description": "Provide the consumer group ID used by the connector. Leave empty for an automatically generated one",
+      "group": "kafka",
+      "type": "String",
+      "feel": "optional",
+      "optional": true,
+      "binding": {
+        "type": "zeebe:property",
+        "name": "groupId"
+      },
+      "constraints": {
+        "notEmpty": false,
+        "maxLength": 250
+      }
+    },
+    {
+      "label": "Additional properties",
+      "description": "Provide additional Kafka consumer properties in JSON",
+      "group": "kafka",
+      "type": "String",
+      "optional": true,
+      "feel": "required",
+      "binding": {
+        "type": "zeebe:property",
+        "name": "additionalProperties"
+      }
+    },
+    {
+      "label": "Offsets",
+      "description": "List of offsets, e.g. '10' or '=[10, 23]'. If specified, it has to have the same number of values as the number of partitions",
+      "group": "kafka",
+      "type": "String",
+      "feel": "optional",
+      "optional": true,
+      "binding": {
+        "type": "zeebe:property",
+        "name": "offsets"
+      }
+    },
+    {
+      "label": "Auto offset reset",
+      "description": "What to do when there is no initial offset in Kafka or if the current offset does not exist any more on the server. You should only select none if you specified the offsets",
+      "id": "autoOffsetReset",
+      "group": "kafka",
+      "type": "Dropdown",
+      "value": "latest",
+      "choices": [
+        {
+          "name": "Latest",
+          "value": "latest"
+        },
+        {
+          "name": "Earliest",
+          "value": "earliest"
+        },
+        {
+          "name": "None",
+          "value": "none"
+        }
+      ],
+      "binding": {
+        "type": "zeebe:property",
+        "name": "autoOffsetReset"
+      }
+    },
+    {
+      "label": "Correlation key (process)",
+      "type": "String",
+      "group": "activation",
+      "feel": "required",
+      "description": "Sets up the correlation key from process variables",
+      "binding": {
+        "type": "bpmn:Message#zeebe:subscription#property",
+        "name": "correlationKey"
+      },
+      "constraints": {
+        "notEmpty": true
+      }
+    },
+    {
+      "label": "Correlation key (payload)",
+      "type": "String",
+      "group": "activation",
+      "feel": "required",
+      "binding": {
+        "type": "zeebe:property",
+        "name": "correlationKeyExpression"
+      },
+      "description": "Extracts the correlation key from the incoming message payload",
+      "constraints": {
+        "notEmpty": true
+      }
+    },
+    {
+      "label": "Activation condition",
+      "type": "String",
+      "group": "activation",
+      "feel": "required",
+      "optional": true,
+      "binding": {
+        "type": "zeebe:property",
+        "name": "activationCondition"
+      },
+      "description": "Condition under which the Connector triggers. Leave empty to catch all events"
+    },
+    {
+      "label": "Result variable",
+      "type": "String",
+      "group": "variable-mapping",
+      "optional": true,
+      "binding": {
+        "type": "zeebe:property",
+        "name": "resultVariable"
+      },
+      "description": "Name of variable to store the result of the connector in"
+    },
+    {
+      "label": "Result expression",
+      "description": "Expression to map the inbound payload to process variables",
+      "group": "variable-mapping",
+      "type": "Text",
+      "feel": "required",
+      "binding": {
+        "type": "zeebe:property",
+        "name": "resultExpression"
+      }
+    }
+  ],
+  "icon": {
+    "contents": "data:image/svg+xml;utf8,%3Csvg width='18' height='18' viewBox='0 0 256 416' xmlns='http://www.w3.org/2000/svg' preserveAspectRatio='xMidYMid'%3E%3Cpath d='M201.816 230.216c-16.186 0-30.697 7.171-40.634 18.461l-25.463-18.026c2.703-7.442 4.255-15.433 4.255-23.797 0-8.219-1.498-16.076-4.112-23.408l25.406-17.835c9.936 11.233 24.409 18.365 40.548 18.365 29.875 0 54.184-24.305 54.184-54.184 0-29.879-24.309-54.184-54.184-54.184-29.875 0-54.184 24.305-54.184 54.184 0 5.348.808 10.505 2.258 15.389l-25.423 17.844c-10.62-13.175-25.911-22.374-43.333-25.182v-30.64c24.544-5.155 43.037-26.962 43.037-53.019C124.171 24.305 99.862 0 69.987 0 40.112 0 15.803 24.305 15.803 54.184c0 25.708 18.014 47.246 42.067 52.769v31.038C25.044 143.753 0 172.401 0 206.854c0 34.621 25.292 63.374 58.355 68.94v32.774c-24.299 5.341-42.552 27.011-42.552 52.894 0 29.879 24.309 54.184 54.184 54.184 29.875 0 54.184-24.305 54.184-54.184 0-25.883-18.253-47.553-42.552-52.894v-32.775a69.965 69.965 0 0 0 42.6-24.776l25.633 18.143c-1.423 4.84-2.22 9.946-2.22 15.24 0 29.879 24.309 54.184 54.184 54.184 29.875 0 54.184-24.305 54.184-54.184 0-29.879-24.309-54.184-54.184-54.184zm0-126.695c14.487 0 26.27 11.788 26.27 26.271s-11.783 26.27-26.27 26.27-26.27-11.787-26.27-26.27c0-14.483 11.783-26.271 26.27-26.271zm-158.1-49.337c0-14.483 11.784-26.27 26.271-26.27s26.27 11.787 26.27 26.27c0 14.483-11.783 26.27-26.27 26.27s-26.271-11.787-26.271-26.27zm52.541 307.278c0 14.483-11.783 26.27-26.27 26.27s-26.271-11.787-26.271-26.27c0-14.483 11.784-26.27 26.271-26.27s26.27 11.787 26.27 26.27zm-26.272-117.97c-20.205 0-36.642-16.434-36.642-36.638 0-20.205 16.437-36.642 36.642-36.642 20.204 0 36.641 16.437 36.641 36.642 0 20.204-16.437 36.638-36.641 36.638zm131.831 67.179c-14.487 0-26.27-11.788-26.27-26.271s11.783-26.27 26.27-26.27 26.27 11.787 26.27 26.27c0 14.483-11.783 26.271-26.27 26.271z' style='fill:%23231f20'/%3E%3C/svg%3E"
+  }
+}

--- a/connectors/rabbitmq/element-templates/rabbitmq-inbound-connector-boundary.json
+++ b/connectors/rabbitmq/element-templates/rabbitmq-inbound-connector-boundary.json
@@ -1,0 +1,308 @@
+{
+  "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+  "name": "RabbitMQ connector",
+  "id": "io.camunda.connectors.inbound.RabbitMQ.Boundary.v1",
+  "version": 1,
+  "description": "Receive a message from RabbitMQ",
+  "documentationRef": "https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq-inbound",
+  "category": {
+    "id": "connectors",
+    "name": "Connectors"
+  },
+  "appliesTo": [
+    "bpmn:BoundaryEvent"
+  ],
+  "elementType": {
+    "value": "bpmn:BoundaryEvent",
+    "eventDefinition": "bpmn:MessageEventDefinition"
+  },
+  "groups": [
+    {
+      "id": "authentication",
+      "label": "Authentication"
+    },
+    {
+      "id": "routing",
+      "label": "Routing"
+    },
+    {
+      "id": "subscription",
+      "label": "Subscription"
+    },
+    {
+      "id": "activation",
+      "label": "Activation"
+    },
+    {
+      "id": "variable-mapping",
+      "label": "Variable mapping"
+    }
+  ],
+  "properties": [
+    {
+      "type": "Hidden",
+      "value": "io.camunda:connector-rabbitmq-inbound:1",
+      "binding": {
+        "type": "zeebe:property",
+        "name": "inbound.type"
+      }
+    },
+    {
+      "type": "Hidden",
+      "generatedValue": {
+        "type": "uuid"
+      },
+      "binding": {
+        "type": "bpmn:Message#property",
+        "name": "name"
+      }
+    },
+    {
+      "id": "connectionType",
+      "label": "Connection type",
+      "group": "authentication",
+      "type": "Dropdown",
+      "value": "uri",
+      "binding": {
+        "type": "zeebe:property",
+        "name": "authentication.authType"
+      },
+      "choices": [
+        {
+          "name": "URI",
+          "value": "uri"
+        },
+        {
+          "name": "Username/Password",
+          "value": "credentials"
+        }
+      ]
+    },
+    {
+      "label": "URI",
+      "description": "URI should contain username, password, host name, port number, and virtual host",
+      "group": "authentication",
+      "type": "String",
+      "binding": {
+        "type": "zeebe:property",
+        "name": "authentication.uri"
+      },
+      "constraints": {
+        "notEmpty": true,
+        "pattern": {
+          "value": "^(amqps?://)|(\\{\\{secrets\\..+\\}\\}).*$",
+          "message": "Must start with amqp(s):// or contain a secret reference"
+        }
+      },
+      "condition": {
+        "property": "connectionType",
+        "equals": "uri"
+      }
+    },
+    {
+      "label": "Username",
+      "group": "authentication",
+      "type": "String",
+      "binding": {
+        "type": "zeebe:property",
+        "name": "authentication.userName"
+      },
+      "constraints": {
+        "notEmpty": true
+      },
+      "condition": {
+        "property": "connectionType",
+        "equals": "credentials"
+      }
+    },
+    {
+      "label": "Password",
+      "group": "authentication",
+      "type": "String",
+      "binding": {
+        "type": "zeebe:property",
+        "name": "authentication.password"
+      },
+      "constraints": {
+        "notEmpty": true
+      },
+      "condition": {
+        "property": "connectionType",
+        "equals": "credentials"
+      }
+    },
+    {
+      "label": "Host name",
+      "description": "Host name: get from RabbitMQ external applocation configurations. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/#routing-data\"target=\"_blank\">documentation</a>",
+      "group": "routing",
+      "type": "String",
+      "binding": {
+        "type": "zeebe:property",
+        "name": "routing.hostName"
+      },
+      "constraints": {
+        "notEmpty": true
+      },
+      "condition": {
+        "property": "connectionType",
+        "equals": "credentials"
+      }
+    },
+    {
+      "label": "Virtual host",
+      "description": "Virtual name: get from RabbitMQ external application configurations. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/#routing-data\"target=\"_blank\">documentation</a>",
+      "group": "routing",
+      "type": "String",
+      "binding": {
+        "type": "zeebe:property",
+        "name": "routing.virtualHost"
+      },
+      "constraints": {
+        "notEmpty": true
+      },
+      "condition": {
+        "property": "connectionType",
+        "equals": "credentials"
+      }
+    },
+    {
+      "label": "Port",
+      "description": "Port: get from RabbitMQ external application configurations. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/#routing-data\"target=\"_blank\">documentation</a>",
+      "group": "routing",
+      "type": "String",
+      "binding": {
+        "type": "zeebe:property",
+        "name": "routing.port"
+      },
+      "constraints": {
+        "notEmpty": true
+      },
+      "condition": {
+        "property": "connectionType",
+        "equals": "credentials"
+      }
+    },
+    {
+      "label": "Queue name",
+      "description": "Name of the queue to subscribe to",
+      "group": "subscription",
+      "type": "String",
+      "feel": "optional",
+      "binding": {
+        "type": "zeebe:property",
+        "name": "queueName"
+      },
+      "constraints": {
+        "notEmpty": true
+      }
+    },
+    {
+      "label": "Consumer tag",
+      "description": "Consumer tag to use for the subscription",
+      "group": "subscription",
+      "type": "String",
+      "feel": "optional",
+      "binding": {
+        "type": "zeebe:property",
+        "name": "consumerTag"
+      }
+    },
+    {
+      "label": "Arguments",
+      "description": "Arguments to use for the subscription",
+      "group": "subscription",
+      "type": "String",
+      "feel": "required",
+      "binding": {
+        "type": "zeebe:property",
+        "name": "arguments"
+      }
+    },
+    {
+      "label": "Exclusive consumer",
+      "group": "subscription",
+      "type": "Dropdown",
+      "value": "false",
+      "binding": {
+        "type": "zeebe:property",
+        "name": "exclusive"
+      },
+      "choices": [
+        {
+          "name": "Yes",
+          "value": "true"
+        },
+        {
+          "name": "No",
+          "value": "false"
+        }
+      ]
+    },
+    {
+      "label": "Correlation key (process)",
+      "type": "String",
+      "group": "activation",
+      "feel": "required",
+      "description": "Sets up the correlation key from process variables",
+      "binding": {
+        "type": "bpmn:Message#zeebe:subscription#property",
+        "name": "correlationKey"
+      },
+      "constraints": {
+        "notEmpty": true
+      }
+    },
+    {
+      "label": "Correlation key (payload)",
+      "type": "String",
+      "group": "activation",
+      "feel": "required",
+      "binding": {
+        "type": "zeebe:property",
+        "name": "correlationKeyExpression"
+      },
+      "description": "Extracts the correlation key from the incoming message payload",
+      "constraints": {
+        "notEmpty": true
+      }
+    },
+    {
+      "label": "Activation condition",
+      "type": "String",
+      "group": "activation",
+      "feel": "required",
+      "optional": true,
+      "binding": {
+        "type": "zeebe:property",
+        "name": "activationCondition"
+      },
+      "description": "Condition under which the connector triggers. Leave empty to catch all events"
+    },
+    {
+      "label": "Result variable",
+      "type": "String",
+      "group": "variable-mapping",
+      "optional": true,
+      "binding": {
+        "type": "zeebe:property",
+        "name": "resultVariable"
+      },
+      "description": "Name of variable to store the result of the connector in"
+    },
+    {
+      "label": "Result expression",
+      "type": "String",
+      "group": "variable-mapping",
+      "feel": "required",
+      "optional": true,
+      "binding": {
+        "type": "zeebe:property",
+        "name": "resultExpression"
+      },
+      "description": "Expression to map the inbound payload to process variables"
+    }
+  ],
+  "icon": {
+    "contents": "data:image/svg+xml;utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='18' height='18' viewBox='-7.5 0 271 271' preserveAspectRatio='xMidYMid'%3E%3Cpath d='M245.44 108.308h-85.09a7.738 7.738 0 0 1-7.735-7.734v-88.68C152.615 5.327 147.29 0 140.726 0h-30.375c-6.568 0-11.89 5.327-11.89 11.894v88.143c0 4.573-3.697 8.29-8.27 8.31l-27.885.133c-4.612.025-8.359-3.717-8.35-8.325l.173-88.241C54.144 5.337 48.817 0 42.24 0H11.89C5.321 0 0 5.327 0 11.894V260.21c0 5.834 4.726 10.56 10.555 10.56H245.44c5.834 0 10.56-4.726 10.56-10.56V118.868c0-5.834-4.726-10.56-10.56-10.56zm-39.902 93.233c0 7.645-6.198 13.844-13.843 13.844H167.69c-7.646 0-13.844-6.199-13.844-13.844v-24.005c0-7.646 6.198-13.844 13.844-13.844h24.005c7.645 0 13.843 6.198 13.843 13.844v24.005z' fill='%23F60'/%3E%3C/svg%3E"
+  }
+}

--- a/connectors/webhook/element-templates/webhook-connector-boundary.json
+++ b/connectors/webhook/element-templates/webhook-connector-boundary.json
@@ -1,0 +1,446 @@
+{
+  "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+  "name": "Webhook connector",
+  "id": "io.camunda.connectors.webhook.WebhookConnectorBoundary.v1",
+  "version": 1,
+  "description": "Configure webhook to receive callbacks",
+  "documentationRef": "https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/http-webhook/",
+  "category": {
+    "id": "connectors",
+    "name": "Connectors"
+  },
+  "appliesTo": [
+    "bpmn:BoundaryEvent"
+  ],
+  "elementType": {
+    "value": "bpmn:BoundaryEvent",
+    "eventDefinition": "bpmn:MessageEventDefinition"
+  },
+  "groups": [
+    {
+      "id": "endpoint",
+      "label": "Webhook configuration"
+    },
+    {
+      "id": "authentication",
+      "label": "Authentication"
+    },
+    {
+      "id": "authorization",
+      "label": "Authorization"
+    },
+    {
+      "id": "activation",
+      "label": "Activation"
+    },
+    {
+      "id": "variable-mapping",
+      "label": "Variable mapping"
+    },
+    {
+      "id": "webhookResponse",
+      "label": "Webhook response"
+    }
+  ],
+  "properties": [
+    {
+      "type": "Hidden",
+      "value": "io.camunda:webhook:1",
+      "binding": {
+        "type": "zeebe:property",
+        "name": "inbound.type"
+      }
+    },
+    {
+      "type": "Hidden",
+      "generatedValue": {
+        "type": "uuid"
+      },
+      "binding": {
+        "type": "bpmn:Message#property",
+        "name": "name"
+      }
+    },
+    {
+      "type": "Hidden",
+      "value": "ConfigurableInboundWebhook",
+      "binding": {
+        "type": "zeebe:property",
+        "name": "inbound.subtype"
+      }
+    },
+    {
+      "id": "webhookMethod",
+      "label": "Webhook method",
+      "group": "endpoint",
+      "description": "Select HTTP method",
+      "value": "any",
+      "type": "Dropdown",
+      "choices": [
+        {
+          "name": "Any",
+          "value": "any"
+        },
+        {
+          "name": "Get",
+          "value": "get"
+        },
+        {
+          "name": "Post",
+          "value": "post"
+        },
+        {
+          "name": "Put",
+          "value": "put"
+        },
+        {
+          "name": "Delete",
+          "value": "delete"
+        }
+      ],
+      "binding": {
+        "type": "zeebe:property",
+        "name": "inbound.method"
+      }
+    },
+    {
+      "label": "Webhook ID",
+      "type": "String",
+      "group": "endpoint",
+      "binding": {
+        "type": "zeebe:property",
+        "name": "inbound.context"
+      },
+      "description": "The webhook ID is a part of the URL",
+      "constraints": {
+        "notEmpty": true
+      }
+    },
+    {
+      "id": "shouldValidateHmac",
+      "label": "HMAC authentication",
+      "group": "authentication",
+      "description": "Choose whether HMAC verification is enabled. <a href='https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/http-webhook/#make-your-http-webhook-connector-for-receiving-messages-executable' target='_blank'>See documentation</a> and <a href='https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/http-webhook/#example' target='_blank'>example</a> that explains how to use HMAC-related fields",
+      "value": "disabled",
+      "type": "Dropdown",
+      "choices": [
+        {
+          "name": "Enabled",
+          "value": "enabled"
+        },
+        {
+          "name": "Disabled",
+          "value": "disabled"
+        }
+      ],
+      "binding": {
+        "type": "zeebe:property",
+        "name": "inbound.shouldValidateHmac"
+      }
+    },
+    {
+      "label": "HMAC secret key",
+      "description": "Shared secret key",
+      "type": "String",
+      "group": "authentication",
+      "optional": true,
+      "binding": {
+        "type": "zeebe:property",
+        "name": "inbound.hmacSecret"
+      },
+      "condition": {
+        "property": "shouldValidateHmac",
+        "equals": "enabled"
+      }
+    },
+    {
+      "label": "HMAC header",
+      "description": "Name of header attribute that will contain the HMAC value",
+      "type": "String",
+      "group": "authentication",
+      "optional": true,
+      "binding": {
+        "type": "zeebe:property",
+        "name": "inbound.hmacHeader"
+      },
+      "condition": {
+        "property": "shouldValidateHmac",
+        "equals": "enabled"
+      }
+    },
+    {
+      "label": "HMAC algorithm",
+      "group": "authentication",
+      "description": "Choose HMAC algorithm",
+      "value": "sha_256",
+      "type": "Dropdown",
+      "choices": [
+        {
+          "name": "SHA-1",
+          "value": "sha_1"
+        },
+        {
+          "name": "SHA-256",
+          "value": "sha_256"
+        },
+        {
+          "name": "SHA-512",
+          "value": "sha_512"
+        }
+      ],
+      "binding": {
+        "type": "zeebe:property",
+        "name": "inbound.hmacAlgorithm"
+      },
+      "condition": {
+        "property": "shouldValidateHmac",
+        "equals": "enabled"
+      }
+    },
+    {
+      "label": "HMAC scopes",
+      "group": "authentication",
+      "description": "Set HMAC scopes for calculating signature data. See <a href='https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/http-webhook/' target='_blank'>documentation</a>",
+      "feel": "required",
+      "type": "String",
+      "optional": true,
+      "binding": {
+        "type": "zeebe:property",
+        "name": "inbound.hmacScopes"
+      },
+      "condition": {
+        "property": "shouldValidateHmac",
+        "equals": "enabled"
+      }
+    },
+    {
+      "id": "authorizationType",
+      "label": "Authorization type",
+      "group": "authorization",
+      "description": "Choose the authorization type.",
+      "value": "NONE",
+      "type": "Dropdown",
+      "choices": [
+        {
+          "name": "None",
+          "value": "NONE"
+        },
+        {
+          "name": "JWT",
+          "value": "JWT"
+        },
+        {
+          "name": "Basic",
+          "value": "BASIC"
+        },
+        {
+          "name": "API Key",
+          "value": "APIKEY"
+        }
+      ],
+      "binding": {
+        "type": "zeebe:property",
+        "name": "inbound.auth.type"
+      }
+    },
+    {
+      "label": "JWK url",
+      "description": "Well-known url of JWKs",
+      "type": "String",
+      "group": "authorization",
+      "feel": "optional",
+      "optional": true,
+      "binding": {
+        "type": "zeebe:property",
+        "name": "inbound.auth.jwt.jwkUrl"
+      },
+      "condition": {
+        "property": "authorizationType",
+        "equals": "JWT"
+      }
+    },
+    {
+      "label": "JWT role property expression",
+      "description": "Expression to extract the roles from the JWT token. <a href='https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/http-webhook/#how-to-extract-roles-from-jwt-data'>See documentation</a>",
+      "type": "String",
+      "group": "authorization",
+      "feel": "required",
+      "optional": true,
+      "binding": {
+        "type": "zeebe:property",
+        "name": "inbound.auth.jwt.permissionsExpression"
+      },
+      "condition": {
+        "property": "authorizationType",
+        "equals": "JWT"
+      }
+    },
+    {
+      "label": "Required roles",
+      "description": "List of roles to test JWT roles against",
+      "type": "String",
+      "group": "authorization",
+      "feel": "required",
+      "optional": true,
+      "binding": {
+        "type": "zeebe:property",
+        "name": "inbound.auth.jwt.requiredPermissions"
+      },
+      "condition": {
+        "property": "authorizationType",
+        "equals": "JWT"
+      }
+    },
+    {
+      "label": "Username",
+      "description": "Username for basic authentication",
+      "type": "String",
+      "group": "authorization",
+      "feel": "optional",
+      "binding": {
+        "type": "zeebe:property",
+        "name": "inbound.auth.username"
+      },
+      "condition": {
+        "property": "authorizationType",
+        "equals": "BASIC"
+      },
+      "constraints": {
+        "notEmpty": true
+      }
+    },
+    {
+      "label": "Password",
+      "description": "Password for basic authentication",
+      "type": "String",
+      "group": "authorization",
+      "feel": "optional",
+      "binding": {
+        "type": "zeebe:property",
+        "name": "inbound.auth.password"
+      },
+      "condition": {
+        "property": "authorizationType",
+        "equals": "BASIC"
+      },
+      "constraints": {
+        "notEmpty": true
+      }
+    },
+    {
+      "label": "API Key",
+      "description": "Expected API key",
+      "type": "String",
+      "group": "authorization",
+      "feel": "optional",
+      "binding": {
+        "type": "zeebe:property",
+        "name": "inbound.auth.apiKey"
+      },
+      "condition": {
+        "property": "authorizationType",
+        "equals": "APIKEY"
+      },
+      "constraints": {
+        "notEmpty": true
+      }
+    },
+    {
+      "label": "API Key locator",
+      "description": "A FEEL expression that extracts API key from the request. <a href='https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/http-webhook/#how-to-configure-api-key-authorization'>See documentation</a>",
+      "type": "String",
+      "group": "authorization",
+      "feel": "required",
+      "binding": {
+        "type": "zeebe:property",
+        "name": "inbound.auth.apiKeyLocator"
+      },
+      "condition": {
+        "property": "authorizationType",
+        "equals": "APIKEY"
+      },
+      "constraints": {
+        "notEmpty": true
+      },
+      "value": "=split(request.headers.authorization, \" \")[2]"
+    },
+    {
+      "label": "Correlation key (process)",
+      "type": "String",
+      "group": "activation",
+      "feel": "required",
+      "description": "Sets up the correlation key from process variables",
+      "binding": {
+        "type": "bpmn:Message#zeebe:subscription#property",
+        "name": "correlationKey"
+      },
+      "constraints": {
+        "notEmpty": true
+      }
+    },
+    {
+      "label": "Correlation key (payload)",
+      "type": "String",
+      "group": "activation",
+      "feel": "required",
+      "binding": {
+        "type": "zeebe:property",
+        "name": "correlationKeyExpression"
+      },
+      "description": "Extracts the correlation key from the incoming message payload",
+      "constraints": {
+        "notEmpty": true
+      }
+    },
+    {
+      "label": "Condition",
+      "type": "String",
+      "group": "activation",
+      "feel": "required",
+      "optional": true,
+      "binding": {
+        "type": "zeebe:property",
+        "name": "activationCondition"
+      },
+      "description": "Condition under which the connector triggers. Leave empty to catch all events. <a href='https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/http-webhook/#make-your-http-webhook-connector-for-receiving-messages-executable' target='_blank'>See documentation</a>"
+    },
+    {
+      "label": "Result variable",
+      "type": "String",
+      "group": "variable-mapping",
+      "optional": true,
+      "binding": {
+        "type": "zeebe:property",
+        "name": "resultVariable"
+      },
+      "description": "Name of variable to store the result of the connector in"
+    },
+    {
+      "label": "Result expression",
+      "type": "String",
+      "group": "variable-mapping",
+      "feel": "required",
+      "optional": true,
+      "binding": {
+        "type": "zeebe:property",
+        "name": "resultExpression"
+      },
+      "description": "Expression to map the inbound payload to process variables"
+    },
+    {
+      "label": "Response body expression",
+      "type": "Text",
+      "group": "webhookResponse",
+      "feel": "required",
+      "optional": true,
+      "binding": {
+        "type": "zeebe:property",
+        "name": "inbound.responseBodyExpression"
+      },
+      "description": "Specify condition and response"
+    }
+  ],
+  "icon": {
+    "contents": "data:image/svg+xml,%3Csvg id='icon' xmlns='http://www.w3.org/2000/svg' width='18' height='18' viewBox='0 0 32 32'%3E%3Cdefs%3E%3Cstyle%3E .cls-1 %7B fill: none; %7D %3C/style%3E%3C/defs%3E%3Cpath d='M24,26a3,3,0,1,0-2.8164-4H13v1a5,5,0,1,1-5-5V16a7,7,0,1,0,6.9287,8h6.2549A2.9914,2.9914,0,0,0,24,26Z'/%3E%3Cpath d='M24,16a7.024,7.024,0,0,0-2.57.4873l-3.1656-5.5395a3.0469,3.0469,0,1,0-1.7326.9985l4.1189,7.2085.8686-.4976a5.0006,5.0006,0,1,1-1.851,6.8418L17.937,26.501A7.0005,7.0005,0,1,0,24,16Z'/%3E%3Cpath d='M8.532,20.0537a3.03,3.03,0,1,0,1.7326.9985C11.74,18.47,13.86,14.7607,13.89,14.708l.4976-.8682-.8677-.497a5,5,0,1,1,6.812-1.8438l1.7315,1.002a7.0008,7.0008,0,1,0-10.3462,2.0356c-.457.7427-1.1021,1.8716-2.0737,3.5728Z'/%3E%3Crect id='_Transparent_Rectangle_' data-name='&lt;Transparent Rectangle&gt;' class='cls-1' width='32' height='32'/%3E%3C/svg%3E"
+  }
+}


### PR DESCRIPTION
feat(connectors): add boundary events support

Tested the following:
- Kafka
- REST
- SQS

### Kafka example

<img width="550" alt="Screenshot 2023-09-05 at 19 08 31" src="https://github.com/camunda/connectors/assets/108870003/633cef98-02ef-443b-a037-f690cc8976b3">

