### PR TITLE
fix(generator): disable feel for result variable

### DIFF
--- a/connector-sdk/element-template-generator/src/main/java/io/camunda/connector/generator/dsl/CommonProperties.java
+++ b/connector-sdk/element-template-generator/src/main/java/io/camunda/connector/generator/dsl/CommonProperties.java
@@ -33,7 +33,8 @@ public class CommonProperties {
           .id("resultVariable")
           .group("output")
           .label("Result Variable")
-          .description("Name of variable to store the response in");
+          .description("Name of variable to store the response in")
+          .feel(FeelMode.disabled);
 
   public static final PropertyBuilder ERROR_EXPRESSION =
       TextProperty.builder()

--- a/connector-sdk/element-template-generator/src/test/java/io/camunda/connector/generator/core/OutboundTemplateGeneratorTest.java
+++ b/connector-sdk/element-template-generator/src/test/java/io/camunda/connector/generator/core/OutboundTemplateGeneratorTest.java
@@ -88,6 +88,33 @@ public class OutboundTemplateGeneratorTest extends BaseTest {
       assertThat(template.documentationRef()).isNull();
       assertThat(template.description()).isNull();
     }
+
+    @Test
+    void resultVariableProperty() {
+      var template = generator.generate(MyConnectorFunction.MinimallyAnnotated.class);
+      var property = getPropertyByLabel("Result Variable", template);
+      assertThat(property.getType()).isEqualTo("String");
+      assertThat(property.getBinding().type()).isEqualTo("zeebe:taskHeader");
+      assertThat(property.getFeel()).isNull();
+    }
+
+    @Test
+    void resultExpressionProperty() {
+      var template = generator.generate(MyConnectorFunction.MinimallyAnnotated.class);
+      var property = getPropertyByLabel("Result Expression", template);
+      assertThat(property.getType()).isEqualTo("Text");
+      assertThat(property.getBinding().type()).isEqualTo("zeebe:taskHeader");
+      assertThat(property.getFeel()).isEqualTo(FeelMode.required);
+    }
+
+    @Test
+    void errorExpressionProperty() {
+      var template = generator.generate(MyConnectorFunction.MinimallyAnnotated.class);
+      var property = getPropertyByLabel("Error Expression", template);
+      assertThat(property.getType()).isEqualTo("Text");
+      assertThat(property.getBinding().type()).isEqualTo("zeebe:taskHeader");
+      assertThat(property.getFeel()).isEqualTo(FeelMode.required);
+    }
   }
 
   @Nested


### PR DESCRIPTION
## Description

As FEEL is set to "Optional" by default for all generated properties, it was automatically enabled for the result variable property too. But result variable is a Zeebe task header, so FEEL expressions are not evaluated there, and neither would it be evaluated in Connector Runtime. So it will be correct to disable FEEL for result variable.


