### PR TITLE
chore(build): improve release notes generation

### DIFF
--- a/.github/workflows/RELEASE.yaml
+++ b/.github/workflows/RELEASE.yaml
@@ -22,6 +22,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.inputs.branch }}
+          fetch-depth: 0
 
       - name: Import Secrets
         id: secrets
@@ -90,6 +91,17 @@ jobs:
             PRE_RELEASE=true
           fi
           echo "isPreRelease=${PRE_RELEASE}" >> $GITHUB_OUTPUT
+
+      - name: Get previous tag for changelog
+        id: get_previous_tag
+        run: |
+          if [[ ${{steps.check_prerelease.outputs.isPreRelease}} == "true" ]]; then
+            TAG_NAME=$(git --no-pager tag --sort=-creatordate | head -1)
+          else
+            TAG_NAME=$(git --no-pager tag --sort=-creatordate | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | head -1)
+          fi
+          echo "previousTag: $TAG_NAME"
+          echo "previousTag=${TAG_NAME}" >> $GITHUB_OUTPUT
 
     # Maven build & version bump
 
@@ -248,7 +260,8 @@ jobs:
         uses: Requarks/changelog-action@v1
         with:
           token: ${{ github.token }}
-          tag: ${{ github.event.inputs.version }}
+          fromTag: ${{ github.event.inputs.version }}
+          toTag: ${{ steps.get_previous_tag.outputs.previousTag }}
           writeToFile: false
           excludeTypes: build,docs,other,style,ci
 


### PR DESCRIPTION
## Description

Adjusts the release notes generation step:
- If pre-release, release notes should contain the difference between the current state and the previous tag, including other pre-releases. While releasing e.g. 0.23.0-alpha3, the diff will contain commits between 0.23.0-alpha2 and 0.23.0-alpha3.
- It not a pre-release, only the difference between the current state and the latest "normal" version is taken into account. For example, while releasing 0.23.0, the difference will contain the whole changelog between 0.22.1 and 0.23.0, no matter how many alpha/rc releases are in the middle.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #568

