### PR TITLE
feat(bundle): add user-managed folder for mounting

### DIFF
--- a/bundle/camunda-saas-bundle/Dockerfile
+++ b/bundle/camunda-saas-bundle/Dockerfile
@@ -1,6 +1,7 @@
 FROM eclipse-temurin:17.0.8_7-jre
 
 RUN mkdir /opt/app
+
 # Download connectors from maven central
 COPY target/*-with-dependencies.jar /opt/app/
 

--- a/bundle/default-bundle/Dockerfile
+++ b/bundle/default-bundle/Dockerfile
@@ -1,6 +1,9 @@
 FROM eclipse-temurin:17.0.8_7-jre
 
-RUN mkdir /opt/app
+# The /opt/app is used for the Connectors runtime, and out-of-the-box connectors
+# Use the /opt/additionalLibs to mount your own connectors, secret providers, or include other jars into the classpath
+RUN mkdir /opt/app && mkdir /opt/custom
+
 COPY target/*-with-dependencies.jar /opt/app/
 
 # Using the start script from the base connector runtime image

--- a/bundle/default-bundle/Dockerfile-focal
+++ b/bundle/default-bundle/Dockerfile-focal
@@ -1,6 +1,9 @@
 FROM eclipse-temurin:17.0.8_7-jre-focal
 
-RUN mkdir /opt/app
+# The /opt/app is used for the Connectors runtime, and out-of-the-box connectors
+# Use the /opt/additionalLibs to mount your own connectors, secret providers, or include other jars into the classpath
+RUN mkdir /opt/app && mkdir /opt/custom
+
 COPY target/*-with-dependencies.jar /opt/app/
 
 # Using the start script from the base connector runtime image

--- a/bundle/default-bundle/start.sh
+++ b/bundle/default-bundle/start.sh
@@ -16,4 +16,4 @@ if [[ -n ${DEBUG_JVM_PRINT_JAVA_OPTS} ]]; then
   echo "Applied JVM options: $JAVA_OPTS"
 fi
 
-exec java ${JAVA_OPTS} -cp '/opt/app/*' "io.camunda.connector.runtime.app.ConnectorRuntimeApplication"
+exec java ${JAVA_OPTS} -cp "/opt/app/*:/opt/custom/*" "io.camunda.connector.runtime.app.ConnectorRuntimeApplication"


### PR DESCRIPTION
feat(bundle): add user-managed folder for mounting

Related to https://github.com/camunda/team-connectors/issues/496.

### Testing done

#### Connector volume defined

Pay attention at the argument `-v $PWD/connector-template-0.1.0-SNAPSHOT-with-dependencies.jar:/opt/additionalLibs/connector.jar`

```
 ~/W/t/custom-connector $ tree
.
└── connector-template-0.1.0-SNAPSHOT-with-dependencies.jar

1 directory, 1 file
 ~/W/t/custom-connector $ docker run --rm --name=HybridConnector -v $PWD/connector-template-0.1.0-SNAPSHOT-with-dependencies.jar:/opt/additionalLibs/connector.jar -e ZEEBE_CLIENT_SECURITY_PLAINTEXT=false -e ZEEBE_CLIENT_CLOUD_CLUSTER-ID='[REDACTED]' -e ZEEBE_CLIENT_CLOUD_CLIENT-ID='[REDACTED]' -e ZEEBE_CLIENT_CLOUD_CLIENT-SECRET='[REDACTED]' -e ZEEBE_CLIENT_CLOUD_REGION='bru-2' -e CAMUNDA_OPERATE_CLIENT_URL='[REDACTED]' -e CONNECTOR_HTTP_REST_TYPE='io.camunda:http-json:2' camunda/connectors-bundle:999.999.1
```

Provides the following output:

```
...
2023-09-13T13:32:53.309Z  INFO 1 --- [           main] i.c.z.s.c.jobhandling.JobWorkerManager   : . Starting Zeebe worker: ZeebeWorkerValue{type='io.camunda:template:1', name='MYCONNECTOR', timeout=null, maxJobsActive=null, requestTimeout=null, pollInterval=null, autoComplete=true, fetchVariables=[authentication, message], enabled=null, methodInfo=null}
...
```

#### Connector volume NOT defined (regression testing)

Connector starts normally without `-v` flag.

```
docker run --rm --name=HybridConnector -e ZEEBE_CLIENT_SECURITY_PLAINTEXT=false -e ZEEBE_CLIENT_CLOUD_CLUSTER-ID='[REDACTED]' -e ZEEBE_CLIENT_CLOUD_CLIENT-ID='[REDACTED]' -e ZEEBE_CLIENT_CLOUD_CLIENT-SECRET='[REDACTED]' -e ZEEBE_CLIENT_CLOUD_REGION='bru-2' -e CAMUNDA_OPERATE_CLIENT_URL='[REDACTED]' -e CONNECTOR_HTTP_REST_TYPE='io.camunda:http-json:2' camunda/connectors-bundle:999.999.1
```



