### PR TITLE
fix(importer): upgraded process definitions are not removed

### DIFF
--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/importer/ProcessDefinitionImporter.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/importer/ProcessDefinitionImporter.java
@@ -94,6 +94,7 @@ public class ProcessDefinitionImporter {
     registeredProcessDefinitionKeys.addAll(
         notYetRegistered.stream().map(ProcessDefinition::getKey).toList());
     registeredProcessDefinitionKeys.removeAll(deleted);
+    registeredProcessDefinitionKeys.removeAll(oldProcessDefinitionKeys);
 
     notYetRegistered.forEach(
         definition -> versionByBpmnProcessId.put(definition.getBpmnProcessId(), definition));

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/inbound/importer/ProcessDefinitionImporterTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/inbound/importer/ProcessDefinitionImporterTest.java
@@ -76,6 +76,10 @@ public class ProcessDefinitionImporterTest {
     verify(manager, times(1)).handleNewProcessDefinitions(new HashSet<>(first));
     verify(manager, times(1)).handleDeletedProcessDefinitions(Set.of(first.get(0).getVersion()));
     verify(manager, times(1)).handleNewProcessDefinitions(Set.of(second.get(1)));
+
+    // verify old version was deregistered and no action is taken on the next polling iteration
+    importer.handleImportedDefinitions(second);
+    verifyNoMoreInteractions(manager);
   }
 
   @Test


### PR DESCRIPTION
## Description

Due to this error, process definition upgrades were handled incorrectly: old version was not removed from the local storage and deletion handling was duplicated.

