### PR TITLE
chore(http-polling): add pattern to default interval

### DIFF
--- a/connectors/http/polling/element-templates/http-polling-connector.json
+++ b/connectors/http/polling/element-templates/http-polling-connector.json
@@ -145,7 +145,7 @@
         "notEmpty": true,
         "pattern": {
           "value": "^(=|https?://|secrets\\..+|\\{\\{secrets\\..+\\}\\}).*$",
-          "message": "Must be a http(s) URL"
+          "message": "must be a http(s) URL"
         }
       }
     },
@@ -179,11 +179,19 @@
       "group": "endpoint",
       "type": "String",
       "feel": "optional",
+      "value": "PT50S",
       "binding": {
         "type": "zeebe:property",
         "name": "httpRequestInterval"
       },
-      "optional": true
+      "constraints": {
+        "notEmpty": true,
+        "pattern": {
+          "value": "^P(?=\\d|T\\d)(?:\\d+Y)?(?:\\d+M)?(?:\\d+W)?(?:\\d+D)?(?:T(?:\\d+H)?(?:\\d+M)?(?:\\d+(?:\\.\\d{1,3})?S)?)$",
+          "message": "value must be defined"
+        }
+      },
+      "optional": false
     },
     {
       "group": "endpoint",
@@ -434,7 +442,7 @@
         "notEmpty": false,
         "pattern": {
           "value": "^(=.+|[0-9]+|secrets\\..+|\\{\\{secrets\\..+\\}\\})$",
-          "message": "Must be a timeout in seconds (default value is 20 seconds) or a FEEL expression"
+          "message": "must be a timeout in seconds (default value is 20 seconds) or a FEEL expression"
         }
       }
     },


### PR DESCRIPTION
## Description

Added a default value to the interval and introduced a pattern; all pattern messages start with a lowercase letter.

![Screenshot 2023-10-04 at 12 35 26](https://github.com/camunda/connectors/assets/108869886/fc8ea0cb-c7b2-4521-87b9-d72bb8ea907e)
![Screenshot 2023-10-04 at 12 35 34](https://github.com/camunda/connectors/assets/108869886/bfde0cc7-ee81-42fa-8123-b41c28263749)
![Screenshot 2023-10-04 at 12 35 52](https://github.com/camunda/connectors/assets/108869886/0dcf77e6-5b9e-4967-b89b-581ce046b208)
![Screenshot 2023-10-04 at 12 36 04](https://github.com/camunda/connectors/assets/108869886/25d902c5-554d-425b-8e05-698e95b472d6)



Related : https://github.com/camunda/team-connectors/issues/504