### PR TITLE
Release improvements

### DIFF
--- a/.github/workflows/CREATE_RELEASE_BRANCH.yml
+++ b/.github/workflows/CREATE_RELEASE_BRANCH.yml
@@ -5,13 +5,8 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Semantic version number of release: ^[0-9]+.[0-9]+.[0-9]+(-[a-zA-Z0-9.-]+){0,1}$'
+        description: 'Full semantic version number of the next minor release, e.g. 8.4.0'
         required: true
-      setVersionOnMain:
-        description: 'Set the new snapshot version on main branch?'
-        type: boolean
-        required: true
-        default: true
 
 jobs:
   create-release-branch:
@@ -49,7 +44,6 @@ jobs:
         run: |
           MINOR_VERSION=${RELEASE_VERSION%.*}
           git checkout -b release/${MINOR_VERSION}
-          git push --set-upstream origin release/${MINOR_VERSION}
           echo "branchName=release/${RELEASE_VERSION%.*}" >> $GITHUB_OUTPUT
         env:
           RELEASE_VERSION: ${{ github.event.inputs.version }}
@@ -63,7 +57,6 @@ jobs:
           RELEASE_VERSION: ${{ github.event.inputs.version }}
 
       - name: Create pull request to main branch
-        if: ${{ github.event.inputs.setVersionOnMain == 'true' }}
         uses: peter-evans/create-pull-request@v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -79,5 +72,7 @@ jobs:
             - [ ] the PR should be accepted via the "Rebase and merge" option
             - [ ] the branch must **not** be deleted after merging
             - [ ] the PR contains exactly one commit with the version change
+            
+            If this PR has conflicts, re-run the `Create release branch` workflow. No need to close the PR or delete the branch.
         env:
           RELEASE_VERSION: ${{ github.event.inputs.version }}

--- a/.github/workflows/CREATE_RELEASE_BRANCH.yml
+++ b/.github/workflows/CREATE_RELEASE_BRANCH.yml
@@ -24,12 +24,19 @@ jobs:
           ref: ${{ github.event.inputs.branch }}
           fetch-depth: 0
 
+      - name: Restore cache
+        uses: actions/cache@v3
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+
       - name: Prepare Java and Maven settings
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
           java-version: '17'
-          cache: 'maven'
 
       - name: Configure git user
         run: |

--- a/.github/workflows/CREATE_RELEASE_BRANCH.yml
+++ b/.github/workflows/CREATE_RELEASE_BRANCH.yml
@@ -37,33 +37,40 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-      - name: Set snapshot version on main branch
-        if: ${{ github.event.inputs.setVersionOnMain == 'true' }}
-        run: |
-          git checkout main
-          mvn -B versions:set -DnewVersion=${RELEASE_VERSION}-SNAPSHOT -DgenerateBackupPoms=false -f parent
-          git add parent/pom.xml
-          git commit -am "ci: set next snapshot version"
-          git push
-        env:
-          RELEASE_VERSION: ${{ github.event.inputs.version }}
-
       - name: Create branch and set release version
+        id: create-branch
         run: |
           MINOR_VERSION=${RELEASE_VERSION%.*}
           git checkout -b release/${MINOR_VERSION}
           git push --set-upstream origin release/${MINOR_VERSION}
+          echo "branchName=release/${RELEASE_VERSION%.*}" >> $GITHUB_OUTPUT
         env:
           RELEASE_VERSION: ${{ github.event.inputs.version }}
 
-      - name: Set snapshot version on release branch (if not set on main)
-        if: ${{ github.event.inputs.setVersionOnMain == 'false' }}
+      - name: Set snapshot version on release branch
         run: |
           MINOR_VERSION=${RELEASE_VERSION%.*}
           git checkout release/${MINOR_VERSION}
           mvn -B versions:set -DnewVersion=${RELEASE_VERSION}-SNAPSHOT -DgenerateBackupPoms=false -f parent
-          git add parent/pom.xml
-          git commit -am "ci: set next snapshot version"
-          git push
+        env:
+          RELEASE_VERSION: ${{ github.event.inputs.version }}
+
+      - name: Create pull request to main branch
+        if: ${{ github.event.inputs.setVersionOnMain == 'true' }}
+        uses: peter-evans/create-pull-request@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: ${{ steps.create-branch.outputs.branchName }}
+          commit-message: "ci: set next snapshot version"
+          committer: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
+          base: main
+          title: "ci: set next snapshot version"
+          body: |
+            This PR sets the next snapshot version on the main branch.
+            
+            Checklist:
+            - [ ] the PR should be accepted via the "Rebase and merge" option
+            - [ ] the branch must **not** be deleted after merging
+            - [ ] the PR contains exactly one commit with the version change
         env:
           RELEASE_VERSION: ${{ github.event.inputs.version }}

--- a/.github/workflows/DEPLOY_SNAPSHOTS.yaml
+++ b/.github/workflows/DEPLOY_SNAPSHOTS.yaml
@@ -29,12 +29,19 @@ jobs:
             secret/data/products/connectors/ci/common ARTIFACTORY_USR;
             secret/data/products/connectors/ci/common ARTIFACTORY_PSW;
 
+      - name: Restore cache
+        uses: actions/cache@v3
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+
       - name: Setup Java Build
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
           java-version: '17'
-          cache: 'maven'
           server-id: camunda-nexus
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD

--- a/.github/workflows/DEPLOY_SNAPSHOTS.yaml
+++ b/.github/workflows/DEPLOY_SNAPSHOTS.yaml
@@ -53,7 +53,7 @@ jobs:
           mirrors: '[{"url": "https://repository.nexus.camunda.cloud/content/groups/internal/", "id": "camunda-nexus", "mirrorOf": "camunda-nexus", "name": "camunda Nexus"}]'
 
       - name: Build Artifacts
-        run: mvn -B compile generate-sources source:jar javadoc:jar deploy
+        run: mvn -B compile generate-sources source:jar javadoc:jar deploy -DskipTests
         env:
           MAVEN_USERNAME: ${{ steps.secrets.outputs.ARTIFACTORY_USR }}
           MAVEN_PASSWORD: ${{ steps.secrets.outputs.ARTIFACTORY_PSW }}

--- a/.github/workflows/RELEASE.yaml
+++ b/.github/workflows/RELEASE.yaml
@@ -41,12 +41,19 @@ jobs:
           gpg_private_key: ${{ steps.secrets.outputs.MAVEN_CENTRAL_GPG_SIGNING_KEY_SEC }}
           passphrase: ${{ steps.secrets.outputs.MAVEN_CENTRAL_GPG_SIGNING_KEY_PASSPHRASE }}
 
+      - name: Restore cache
+        uses: actions/cache@v3
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+
       - name: Prepare Java and Maven settings
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
           java-version: '17'
-          cache: 'maven'
 
       # Use CI Nexus as co-located pull-through cache for Maven artifacts via ~/.m2/settings.xml
       - name: 'Create settings.xml'

--- a/.github/workflows/RELEASE.yaml
+++ b/.github/workflows/RELEASE.yaml
@@ -104,7 +104,7 @@ jobs:
           RELEASE_VERSION: ${{ github.event.release.tag_name }}
 
       - name: Deploy artifacts to Artifactory and Maven Central
-        run: mvn -B compile generate-sources source:jar javadoc:jar deploy -PcheckFormat -Psonatype-oss-release -DskipTests
+        run: mvn -B compile generate-sources source:jar javadoc:jar deploy -PcheckFormat -Psonatype-oss-release
         env:
           NEXUS_USR: ${{ steps.secrets.outputs.ARTIFACTORY_USR }}
           NEXUS_PSW: ${{ steps.secrets.outputs.ARTIFACTORY_PSW }}

--- a/.github/workflows/TEST_FEATURE_BRANCH.yml
+++ b/.github/workflows/TEST_FEATURE_BRANCH.yml
@@ -56,7 +56,7 @@ jobs:
           node-version: '16'
 
       - name: Build Connectors
-        run: mvn --batch-mode clean verify -PcheckFormat
+        run: mvn --batch-mode clean test -PcheckFormat
 
       - name: Lint Dockerfile - connector-runtime
         uses: hadolint/hadolint-action@v3.1.0

--- a/.github/workflows/TEST_FEATURE_BRANCH.yml
+++ b/.github/workflows/TEST_FEATURE_BRANCH.yml
@@ -25,11 +25,18 @@ jobs:
             secret/data/products/connectors/ci/common ARTIFACTORY_USR;
             secret/data/products/connectors/ci/common ARTIFACTORY_PSW;
 
+      - name: Restore cache
+        uses: actions/cache@v3
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+
       - uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
           java-version: '17'
-          cache: 'maven'
 
       # Use CI Nexus as co-located pull-through cache for Maven artifacts via ~/.m2/settings.xml
       - name: 'Create settings.xml'


### PR DESCRIPTION
## Description

1. Disable tests on snapshot build, re-enable during release build
2. Run `mvn test` instead of `mvn verify` to speed up feature branch builds. This should save about 4 minutes on each feature branch build.
3. Adjust the release branch creation workflow to create a PR instead of pushing to main directly. This is needed to enforce proper branch protection for main (allow PRs only). Example PR (next snapshot version): https://github.com/camunda/connectors/pull/1254

4. Experimental: custom cache configuration to speed up workflow runs, using the [`restore-keys`](https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#matching-a-cache-key) feature of the `cache` action. This should try to restore cache from other runs if the exact match is not found. This should save 1-2 min additionally on each build.

Result: feature branch build completed in just 3.5 minutes vs usual 10 minutes 🎉 

## Related issues

<!-- Which issues are closed by this PR or are related -->

related to https://github.com/camunda/team-connectors/issues/453

