### PR TITLE
build: exclude deps from changelog

### DIFF
--- a/.github/workflows/RELEASE.yaml
+++ b/.github/workflows/RELEASE.yaml
@@ -248,6 +248,7 @@ jobs:
           toTag: ${{ steps.get_previous_tag.outputs.previousTag }}
           writeToFile: false
           excludeTypes: build,docs,other,style,ci
+          excludeScopes: deps
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v1


### PR DESCRIPTION
## Description

Exclude `deps` commits from the changelog generated by our release action.

