### PR TITLE
Allow configurable prefix for environment secret provider

### DIFF
--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/env/SpringEnvironmentSecretProvider.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/env/SpringEnvironmentSecretProvider.java
@@ -17,10 +17,14 @@
 package io.camunda.connector.runtime.env;
 
 import io.camunda.connector.api.secret.SecretProvider;
+import jakarta.annotation.PostConstruct;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.core.env.Environment;
+import org.springframework.util.StringUtils;
 
 public class SpringEnvironmentSecretProvider implements SecretProvider {
-
+  private static final Logger LOG = LoggerFactory.getLogger(SpringEnvironmentSecretProvider.class);
   private final Environment environment;
   private final String prefix;
 
@@ -29,9 +33,21 @@ public class SpringEnvironmentSecretProvider implements SecretProvider {
     this.prefix = prefix;
   }
 
+  @PostConstruct
+  public void init() {
+    if (!StringUtils.hasText(prefix)) {
+      LOG.warn(
+          "No prefix has been configured, all environment variables are available as connector secrets");
+    } else {
+      LOG.debug(
+          "Prefix '{}' has been configured, only environment variables with this prefix are available as connector secrets",
+          prefix);
+    }
+  }
+
   @Override
   public String getSecret(String name) {
-    String prefixedName = prefix == null ? name : prefix + name;
+    String prefixedName = !StringUtils.hasText(prefix) ? name : prefix + name;
     return environment.getProperty(prefixedName);
   }
 }

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/env/SpringEnvironmentSecretProvider.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/env/SpringEnvironmentSecretProvider.java
@@ -36,7 +36,7 @@ public class SpringEnvironmentSecretProvider implements SecretProvider {
   @PostConstruct
   public void init() {
     if (!StringUtils.hasText(prefix)) {
-      LOG.warn(
+      LOG.info(
           "No prefix has been configured, all environment variables are available as connector secrets");
     } else {
       LOG.debug(

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/env/SpringEnvironmentSecretProviderTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/env/SpringEnvironmentSecretProviderTest.java
@@ -16,22 +16,20 @@
  */
 package io.camunda.connector.runtime.env;
 
-import io.camunda.connector.api.secret.SecretProvider;
-import org.springframework.core.env.Environment;
+import static org.assertj.core.api.Assertions.*;
 
-public class SpringEnvironmentSecretProvider implements SecretProvider {
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.env.MockEnvironment;
 
-  private final Environment environment;
-  private final String prefix;
+public class SpringEnvironmentSecretProviderTest {
 
-  public SpringEnvironmentSecretProvider(Environment environment, String prefix) {
-    this.environment = environment;
-    this.prefix = prefix;
-  }
-
-  @Override
-  public String getSecret(String name) {
-    String prefixedName = prefix == null ? name : prefix + name;
-    return environment.getProperty(prefixedName);
+  @Test
+  void shouldApplyPrefix() {
+    MockEnvironment env = new MockEnvironment();
+    env.setProperty("secrets.MY_TOTAL_SECRET", "beebop");
+    SpringEnvironmentSecretProvider secretProvider =
+        new SpringEnvironmentSecretProvider(env, "secrets.");
+    String myTotalSecret = secretProvider.getSecret("MY_TOTAL_SECRET");
+    assertThat(myTotalSecret).isEqualTo("beebop");
   }
 }

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/env/SpringEnvironmentSecretProviderTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/env/SpringEnvironmentSecretProviderTest.java
@@ -26,10 +26,10 @@ public class SpringEnvironmentSecretProviderTest {
   @Test
   void shouldApplyPrefix() {
     MockEnvironment env = new MockEnvironment();
-    env.setProperty("secrets.MY_TOTAL_SECRET", "beebop");
+    env.setProperty("secrets.my-total-secret", "beebop");
     SpringEnvironmentSecretProvider secretProvider =
         new SpringEnvironmentSecretProvider(env, "secrets.");
-    String myTotalSecret = secretProvider.getSecret("MY_TOTAL_SECRET");
+    String myTotalSecret = secretProvider.getSecret("my-total-secret");
     assertThat(myTotalSecret).isEqualTo("beebop");
   }
 }

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/main/java/io/camunda/connector/runtime/ConnectorProperties.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/main/java/io/camunda/connector/runtime/ConnectorProperties.java
@@ -38,5 +38,5 @@ public record ConnectorProperties(Polling polling, Webhook webhook, SecretProvid
   /**
    * Configuration for the {@link org.springframework.core.env.Environment} based secret provider
    */
-  public record Environment(boolean enabled) {}
+  public record Environment(boolean enabled, String prefix) {}
 }

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/main/java/io/camunda/connector/runtime/OutboundConnectorsAutoConfiguration.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/main/java/io/camunda/connector/runtime/OutboundConnectorsAutoConfiguration.java
@@ -49,6 +49,9 @@ public class OutboundConnectorsAutoConfiguration {
   @Value("${camunda.connector.secretprovider.discovery.enabled:true}")
   Boolean secretProviderLookupEnabled;
 
+  @Value("${camunda.connector.secret-provider.environment.prefix:}")
+  String environmentSecretProviderPrefix;
+
   private static final Logger LOG =
       LoggerFactory.getLogger(OutboundConnectorsAutoConfiguration.class);
 
@@ -79,7 +82,7 @@ public class OutboundConnectorsAutoConfiguration {
       havingValue = "true",
       matchIfMissing = true)
   public SpringEnvironmentSecretProvider defaultSecretProvider(Environment environment) {
-    return new SpringEnvironmentSecretProvider(environment);
+    return new SpringEnvironmentSecretProvider(environment, environmentSecretProviderPrefix);
   }
 
   @Bean

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/main/java/io/camunda/connector/runtime/OutboundConnectorsAutoConfiguration.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/main/java/io/camunda/connector/runtime/OutboundConnectorsAutoConfiguration.java
@@ -49,7 +49,7 @@ public class OutboundConnectorsAutoConfiguration {
   @Value("${camunda.connector.secretprovider.discovery.enabled:true}")
   Boolean secretProviderLookupEnabled;
 
-  @Value("${camunda.connector.secret-provider.environment.prefix:}")
+  @Value("${camunda.connector.secretprovider.environment.prefix:}")
   String environmentSecretProviderPrefix;
 
   private static final Logger LOG =
@@ -78,7 +78,7 @@ public class OutboundConnectorsAutoConfiguration {
 
   @Bean
   @ConditionalOnProperty(
-      name = "camunda.connector.secret-provider.environment.enabled",
+      name = "camunda.connector.secretprovider.environment.enabled",
       havingValue = "true",
       matchIfMissing = true)
   public SpringEnvironmentSecretProvider defaultSecretProvider(Environment environment) {

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/secret/SpringEnvironmentSecretProviderTest.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/secret/SpringEnvironmentSecretProviderTest.java
@@ -29,7 +29,7 @@ import org.springframework.boot.test.context.SpringBootTest;
     classes = {TestConnectorRuntimeApplication.class},
     properties = {
       "camunda.connector.secretprovider.discovery.enabled=false",
-      "camunda.connector.secret-provider.environment.prefix=secrets."
+      "camunda.connector.secretprovider.environment.prefix=secrets."
     })
 public class SpringEnvironmentSecretProviderTest {
 

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/secret/SpringEnvironmentSecretProviderTest.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/secret/SpringEnvironmentSecretProviderTest.java
@@ -27,12 +27,15 @@ import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest(
     classes = {TestConnectorRuntimeApplication.class},
-    properties = {"camunda.connector.secretprovider.discovery.enabled=false"})
+    properties = {
+      "camunda.connector.secretprovider.discovery.enabled=false",
+      "camunda.connector.secret-provider.environment.prefix=secrets."
+    })
 public class SpringEnvironmentSecretProviderTest {
 
   @Autowired SecretProviderAggregator secretProviderAggregator;
 
-  @Value("${test.secret}")
+  @Value("${secrets.test.secret}")
   String expectedSecretValue;
 
   @Test

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/test/resources/application.properties
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/test/resources/application.properties
@@ -1,5 +1,5 @@
 # test secret property
-test.secret=test secret value
+secrets.test.secret=test secret value
 
 camunda.operate.client.url=http://localhost:8081
 camunda.operate.client.username=demo


### PR DESCRIPTION
## Description

The Spring Environment Secret Provider has been adjusted to accept a prefix. This allows for easily narrowing down the environment that is accessible through the secret provider.
## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #1290 

