### PR TITLE
Fix for not being able to set details on an UNKNOWN/DOWN Health instance

### DIFF
--- a/connector-sdk/core/src/main/java/io/camunda/connector/api/inbound/Health.java
+++ b/connector-sdk/core/src/main/java/io/camunda/connector/api/inbound/Health.java
@@ -124,6 +124,7 @@ public class Health {
 
     @Override
     public Health details(Map<String, Object> details) {
+      this.details = details;
       return new Health(this);
     }
   }


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
Could not previously set details map on a unknown/down instance

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #

