### PR TITLE
Make README.md point to new Dockerfile example

### DIFF
--- a/connector-runtime/README.md
+++ b/connector-runtime/README.md
@@ -32,7 +32,7 @@ Refer to the [Releases](https://github.com/camunda/connectors-bundle/releases) p
 
 ### Via Docker
 
-Refer to the [Connector Runtime Docker image documentation](https://github.com/camunda/connector-runtime-docker) for further details.
+Refer to the [Connector Runtime Application Docker example](./connector-runtime-application/example) for further details.
 
 To use the Camunda-provided Connectors with the runtime out of the box, refer to the [Connectors Bundle](../bundle).
 


### PR DESCRIPTION

## Description

point to new Dockerfile example instead of archived repository

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes # 
https://github.com/camunda/connectors/issues/1307

