### PR TITLE
Template Generator CLI tool

### DIFF
--- a/element-template-generator/connectorgen-cli/pom.xml
+++ b/element-template-generator/connectorgen-cli/pom.xml
@@ -1,0 +1,71 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>io.camunda.connector</groupId>
+    <artifactId>connector-parent</artifactId>
+    <relativePath>../../parent/pom.xml</relativePath>
+    <version>8.4.0-SNAPSHOT</version>
+  </parent>
+
+  <name>connectorgen-cli</name>
+  <description>connectorgen CLI application</description>
+  <artifactId>connectorgen-cli</artifactId>
+  <packaging>jar</packaging>
+
+  <properties>
+    <version.picocli>4.7.5</version.picocli>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>info.picocli</groupId>
+      <artifactId>picocli</artifactId>
+      <version>${version.picocli}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.camunda.connector</groupId>
+      <artifactId>element-template-generator-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.camunda.connector</groupId>
+      <artifactId>openapi-parser</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.camunda.connector</groupId>
+      <artifactId>jackson-datatype-feel</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.dataformat</groupId>
+      <artifactId>jackson-dataformat-yaml</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-nop</artifactId>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <!-- annotationProcessorPaths requires maven-compiler-plugin version 3.5 or higher -->
+        <configuration>
+          <annotationProcessorPaths>
+            <path>
+              <groupId>info.picocli</groupId>
+              <artifactId>picocli-codegen</artifactId>
+              <version>4.7.5</version>
+            </path>
+          </annotationProcessorPaths>
+          <compilerArgs>
+            <arg>-Aproject=${project.groupId}/${project.artifactId}</arg>
+          </compilerArgs>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/element-template-generator/connectorgen-cli/src/main/java/io/camunda/connector/generator/cli/GeneratorServiceLoader.java
+++ b/element-template-generator/connectorgen-cli/src/main/java/io/camunda/connector/generator/cli/GeneratorServiceLoader.java
@@ -14,10 +14,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.camunda.connector.generator.api;
+package io.camunda.connector.generator.cli;
 
-import io.camunda.connector.generator.dsl.OutboundElementTemplate;
+import io.camunda.connector.generator.api.CliCompatibleTemplateGenerator;
+import java.util.Map;
+import java.util.ServiceLoader;
+import java.util.stream.Collectors;
 
-/** Shortcut interface for outbound template generators. */
-public interface OutboundTemplateGenerator<IN>
-    extends ElementTemplateGenerator<IN, OutboundElementTemplate> {}
+public class GeneratorServiceLoader {
+
+  public static Map<String, CliCompatibleTemplateGenerator<?, ?>> loadGenerators() {
+    return ServiceLoader.load(CliCompatibleTemplateGenerator.class).stream()
+        .map(ServiceLoader.Provider::get)
+        .collect(
+            Collectors.toMap(
+                CliCompatibleTemplateGenerator::getGeneratorId,
+                g -> (CliCompatibleTemplateGenerator<?, ?>) g));
+  }
+}

--- a/element-template-generator/connectorgen-cli/src/main/java/io/camunda/connector/generator/cli/command/ConnectorGen.java
+++ b/element-template-generator/connectorgen-cli/src/main/java/io/camunda/connector/generator/cli/command/ConnectorGen.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.generator.cli.command;
+
+import io.camunda.connector.generator.api.GeneratorConfiguration;
+import io.camunda.connector.generator.api.GeneratorConfiguration.ConnectorMode;
+import picocli.CommandLine;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+
+@Command(
+    name = "connectorgen",
+    subcommands = {Generate.class, Scan.class},
+    mixinStandardHelpOptions = true,
+    version = "connectorgen 1.0",
+    description = "Generate element templates for connectors")
+public class ConnectorGen {
+
+  @Option(
+      names = {"-h", "--hybrid"},
+      usageHelp = true,
+      description = "generate a hybrid template (with configurable type)")
+  boolean hybrid;
+
+  @Option(
+      names = {"-i", "--id"},
+      description = "template id to use for generation")
+  String templateId;
+
+  @Option(
+      names = {"-n", "--name"},
+      description = "template name to use for generation")
+  String templateName;
+
+  GeneratorConfiguration generatorConfiguration() {
+    return new GeneratorConfiguration(
+        hybrid ? ConnectorMode.HYBRID : ConnectorMode.NORMAL, templateId, templateName, null);
+  }
+
+  public static void main(String... args) {
+    int exitCode = new CommandLine(new ConnectorGen()).execute(args);
+    System.exit(exitCode);
+  }
+}

--- a/element-template-generator/connectorgen-cli/src/main/java/io/camunda/connector/generator/cli/command/Generate.java
+++ b/element-template-generator/connectorgen-cli/src/main/java/io/camunda/connector/generator/cli/command/Generate.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.generator.cli.command;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import io.camunda.connector.generator.api.CliCompatibleTemplateGenerator;
+import io.camunda.connector.generator.cli.GeneratorServiceLoader;
+import java.util.List;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Parameters;
+import picocli.CommandLine.ParentCommand;
+
+@Command(name = "generate")
+public class Generate implements Runnable {
+
+  @ParentCommand ConnectorGen connectorGen;
+
+  @Parameters(index = "0", description = "name of the generator to invoke")
+  String generatorName;
+
+  @Parameters(
+      index = "1..*",
+      description = "parameters to be passed to the generator (at least the generation source)")
+  List<String> params;
+
+  static final ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public void run() {
+    CliCompatibleTemplateGenerator<Object, ?> generator =
+        (CliCompatibleTemplateGenerator<Object, ?>) loadGenerator(generatorName);
+    var input = generator.prepareInput(params);
+    var template = generator.generate(input, connectorGen.generatorConfiguration());
+    try {
+      var resultString = mapper.writeValueAsString(template);
+      System.out.println(resultString);
+    } catch (JsonProcessingException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  static CliCompatibleTemplateGenerator<?, ?> loadGenerator(String name) {
+    var generators = GeneratorServiceLoader.loadGenerators();
+    if (generators.isEmpty()) {
+      throw new IllegalStateException("No generators available");
+    }
+    var generator = generators.get(name);
+    if (generator == null) {
+      throw new IllegalArgumentException(
+          "No generator found with name "
+              + name
+              + ". Known generators: "
+              + String.join(", ", generators.keySet()));
+    }
+    return generator;
+  }
+}

--- a/element-template-generator/connectorgen-cli/src/main/java/io/camunda/connector/generator/cli/command/Scan.java
+++ b/element-template-generator/connectorgen-cli/src/main/java/io/camunda/connector/generator/cli/command/Scan.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.generator.cli.command;
+
+import static io.camunda.connector.generator.cli.command.Generate.mapper;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import io.camunda.connector.generator.api.CliCompatibleTemplateGenerator;
+import java.util.List;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Parameters;
+import picocli.CommandLine.ParentCommand;
+
+@Command(name = "scan")
+public class Scan implements Runnable {
+
+  @ParentCommand ConnectorGen connectorGen;
+
+  @Parameters(index = "0", description = "name of the generator to invoke")
+  String generatorName;
+
+  @Parameters(
+      index = "1..*",
+      description = "parameters to be passed to the generator (at least the generation source)")
+  List<String> params;
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public void run() {
+    CliCompatibleTemplateGenerator<Object, ?> generator =
+        (CliCompatibleTemplateGenerator<Object, ?>) Generate.loadGenerator(generatorName);
+    var input = generator.prepareInput(params);
+    var result = generator.scan(input);
+    try {
+      var resultString = mapper.writeValueAsString(result);
+      System.out.println(resultString);
+    } catch (JsonProcessingException e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/element-template-generator/core/src/main/java/io/camunda/connector/generator/api/CliCompatibleTemplateGenerator.java
+++ b/element-template-generator/core/src/main/java/io/camunda/connector/generator/api/CliCompatibleTemplateGenerator.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.generator.api;
+
+import io.camunda.connector.generator.dsl.ElementTemplateBase;
+import java.util.List;
+
+public interface CliCompatibleTemplateGenerator<IN, OUT extends ElementTemplateBase>
+    extends ElementTemplateGenerator<IN, OUT> {
+
+  /** ID of the generator. This ID is used to identify the generator in the CLI. */
+  String getGeneratorId();
+
+  /**
+   * Prepare the input for the generation process. This method receives a list of CLI parameters
+   * passed to the generator and should return a data structure consumable by the other methods.
+   */
+  IN prepareInput(List<String> parameters);
+
+  /** Scan the source and do a dry run of the generation process. */
+  ScanResult scan(IN input);
+
+  /**
+   * Preview of the generation result.
+   *
+   * @param templateId ID of the resulting template
+   * @param templateName Name of the resulting template
+   * @param templateVersion Version of the resulting template
+   * @param templateType Type of the resulting template
+   * @param additionalData Any additional information provided by the generator
+   */
+  record ScanResult(
+      String templateId,
+      String templateName,
+      Integer templateVersion,
+      String templateType,
+      Object additionalData) {}
+}

--- a/element-template-generator/core/src/main/java/io/camunda/connector/generator/api/GeneratorConfiguration.java
+++ b/element-template-generator/core/src/main/java/io/camunda/connector/generator/api/GeneratorConfiguration.java
@@ -18,17 +18,18 @@ package io.camunda.connector.generator.api;
 
 /** Configuration for the element template generator */
 public record GeneratorConfiguration(
-    /*
-     * Connectors in hybrid mode have a configurable task definition type (for outbound), or a
-     * configurable connector type (for inbound) property. This allows to run multiple connector
-     * runtimes against the same Camunda cluster and distinguish between them on the BPMN level.
-     */
-    ConnectorMode connectorMode) {
+    ConnectorMode connectorMode, String templateId, String templateName, Integer templateVersion) {
+
+  /**
+   * Connectors in hybrid mode have a configurable task definition type (for outbound), or a
+   * configurable connector type (for inbound) property. This allows to run multiple connector
+   * runtimes against the same Camunda cluster and distinguish between them on the BPMN level.
+   */
   public enum ConnectorMode {
     NORMAL,
     HYBRID
   }
 
   public static final GeneratorConfiguration DEFAULT =
-      new GeneratorConfiguration(ConnectorMode.NORMAL);
+      new GeneratorConfiguration(ConnectorMode.NORMAL, null, null, null);
 }

--- a/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/OutboundClassBasedTemplateGenerator.java
+++ b/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/OutboundClassBasedTemplateGenerator.java
@@ -17,9 +17,9 @@
 package io.camunda.connector.generator.java;
 
 import io.camunda.connector.api.annotation.OutboundConnector;
+import io.camunda.connector.generator.api.ElementTemplateGenerator;
 import io.camunda.connector.generator.api.GeneratorConfiguration;
 import io.camunda.connector.generator.api.GeneratorConfiguration.ConnectorMode;
-import io.camunda.connector.generator.api.OutboundTemplateGenerator;
 import io.camunda.connector.generator.dsl.CommonProperties;
 import io.camunda.connector.generator.dsl.ElementTemplateIcon;
 import io.camunda.connector.generator.dsl.OutboundElementTemplate;
@@ -37,7 +37,8 @@ import java.util.Arrays;
 import java.util.Base64;
 import java.util.List;
 
-public class OutboundClassBasedTemplateGenerator implements OutboundTemplateGenerator<Class<?>> {
+public class OutboundClassBasedTemplateGenerator
+    implements ElementTemplateGenerator<Class<?>, OutboundElementTemplate> {
 
   private final ClassLoader classLoader;
 

--- a/element-template-generator/core/src/test/java/io/camunda/connector/generator/java/OutboundTemplateGeneratorTest.java
+++ b/element-template-generator/core/src/test/java/io/camunda/connector/generator/java/OutboundTemplateGeneratorTest.java
@@ -136,7 +136,7 @@ public class OutboundTemplateGeneratorTest extends BaseTest {
       var template =
           generator.generate(
               MyConnectorFunction.MinimallyAnnotated.class,
-              new GeneratorConfiguration(ConnectorMode.HYBRID));
+              new GeneratorConfiguration(ConnectorMode.HYBRID, null, null, null));
       var property = getPropertyById("taskDefinitionType", template);
       assertThat(property.getType()).isEqualTo("String");
       assertThat(property.getGroup()).isEqualTo("taskDefinitionType");
@@ -375,7 +375,7 @@ public class OutboundTemplateGeneratorTest extends BaseTest {
       var template =
           generator.generate(
               MyConnectorFunction.MinimallyAnnotated.class,
-              new GeneratorConfiguration(ConnectorMode.HYBRID));
+              new GeneratorConfiguration(ConnectorMode.HYBRID, null, null, null));
       checkPropertyGroups(
           List.of(
               Map.entry("taskDefinitionType", "Task definition type"),

--- a/element-template-generator/http-dsl/src/main/java/io/camunda/connector/generator/dsl/http/HttpOutboundElementTemplateBuilder.java
+++ b/element-template-generator/http-dsl/src/main/java/io/camunda/connector/generator/dsl/http/HttpOutboundElementTemplateBuilder.java
@@ -35,12 +35,16 @@ public class HttpOutboundElementTemplateBuilder {
   private Collection<HttpOperation> operations;
   private List<HttpAuthentication> authentication = List.of(NoAuth.INSTANCE);
 
-  private HttpOutboundElementTemplateBuilder() {
-    builder = OutboundElementTemplateBuilder.create().type(CONNECTOR_TYPE);
+  private HttpOutboundElementTemplateBuilder(boolean configurable) {
+    builder = OutboundElementTemplateBuilder.create().type(CONNECTOR_TYPE, configurable);
   }
 
   public static HttpOutboundElementTemplateBuilder create() {
-    return new HttpOutboundElementTemplateBuilder();
+    return new HttpOutboundElementTemplateBuilder(false);
+  }
+
+  public static HttpOutboundElementTemplateBuilder create(boolean configurable) {
+    return new HttpOutboundElementTemplateBuilder(configurable);
   }
 
   public HttpOutboundElementTemplateBuilder id(String id) {

--- a/element-template-generator/maven-plugin/src/main/java/io/camunda/connector/generator/ElementTemplateGeneratorMojo.java
+++ b/element-template-generator/maven-plugin/src/main/java/io/camunda/connector/generator/ElementTemplateGeneratorMojo.java
@@ -124,7 +124,8 @@ public class ElementTemplateGeneratorMojo extends AbstractMojo {
         if (generateHybridTemplates) {
           getLog().info("Generating hybrid element template for " + className);
           OutboundElementTemplate hybridTemplate =
-              generator.generate(clazz, new GeneratorConfiguration(ConnectorMode.HYBRID));
+              generator.generate(
+                  clazz, new GeneratorConfiguration(ConnectorMode.HYBRID, null, null, null));
           var name = basicFileName.replace(".json", "-hybrid.json");
           writeElementTemplate(hybridTemplate, name);
         }

--- a/element-template-generator/openapi-parser/src/main/java/io/camunda/connector/generator/openapi/OpenApiGenerationSource.java
+++ b/element-template-generator/openapi-parser/src/main/java/io/camunda/connector/generator/openapi/OpenApiGenerationSource.java
@@ -17,6 +17,8 @@
 package io.camunda.connector.generator.openapi;
 
 import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.parser.OpenAPIV3Parser;
+import java.util.List;
 import java.util.Set;
 
 /**
@@ -24,4 +26,23 @@ import java.util.Set;
  * @param includeOperations IDs of operations that should be processed. If null/empty, all
  *     operations will be taken into account.
  */
-public record OpenApiGenerationSource(OpenAPI openAPI, Set<String> includeOperations) {}
+public record OpenApiGenerationSource(OpenAPI openAPI, Set<String> includeOperations) {
+
+  public OpenApiGenerationSource(List<String> cliParams) {
+    this(fetchOpenApi(cliParams), extractOperationIds(cliParams));
+  }
+
+  private static OpenAPI fetchOpenApi(List<String> cliParams) {
+    if (cliParams.size() < 1) {
+      throw new IllegalArgumentException(
+          "OpenAPI file path or URL must be provided as first parameter");
+    }
+    var openApiPath = cliParams.get(0);
+    var openApiParser = new OpenAPIV3Parser();
+    return openApiParser.readLocation(openApiPath, null, null).getOpenAPI();
+  }
+
+  private static Set<String> extractOperationIds(List<String> cliParams) {
+    return cliParams.size() > 1 ? Set.copyOf(cliParams.subList(1, cliParams.size())) : Set.of();
+  }
+}

--- a/element-template-generator/openapi-parser/src/main/java/io/camunda/connector/generator/openapi/OperationParseResult.java
+++ b/element-template-generator/openapi-parser/src/main/java/io/camunda/connector/generator/openapi/OperationParseResult.java
@@ -14,6 +14,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.camunda.connector.generator.api;
+package io.camunda.connector.generator.openapi;
 
-public interface GenerationSourceProvider<IN> {}
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import io.camunda.connector.generator.dsl.http.HttpOperationBuilder;
+
+record OperationParseResult(
+    String id,
+    String path,
+    boolean supported,
+    @JsonInclude(Include.NON_EMPTY) String info,
+    @JsonIgnore HttpOperationBuilder builder) {}

--- a/element-template-generator/openapi-parser/src/main/java/io/camunda/connector/generator/openapi/OperationUtil.java
+++ b/element-template-generator/openapi-parser/src/main/java/io/camunda/connector/generator/openapi/OperationUtil.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.generator.openapi;
+
+import static io.camunda.connector.generator.openapi.SecurityUtil.parseAuthentication;
+
+import io.camunda.connector.generator.dsl.http.HttpOperation;
+import io.camunda.connector.generator.dsl.http.HttpOperationProperty;
+import io.camunda.connector.generator.dsl.http.HttpPathFeelBuilder;
+import io.camunda.connector.http.base.model.HttpMethod;
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.oas.models.parameters.RequestBody;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Utility functions related to parsing OpenAPI operations and converting them into {@link
+ * HttpOperation}s.
+ */
+public class OperationUtil {
+
+  // ordered by priority if endpoint allows multiple
+  private static final List<String> SUPPORTED_BODY_MEDIA_TYPES =
+      List.of("application/json", "text/plain");
+
+  static List<OperationParseResult> extractOperations(
+      OpenAPI openAPI, Set<String> includeOperations) {
+    var components = openAPI.getComponents();
+    return openAPI.getPaths().entrySet().stream()
+        .flatMap(
+            pathEntry -> {
+              var pathItem = pathEntry.getValue();
+              if (pathItem.get$ref() != null) {
+                pathItem =
+                    components
+                        .getPathItems()
+                        .get(pathItem.get$ref().replace("#/components/pathItems/", ""));
+              }
+
+              List<OperationParseResult> operations = new ArrayList<>();
+              if (pathItem.getGet() != null) {
+                operations.add(
+                    extractOperation(
+                        pathEntry.getKey(), HttpMethod.GET, pathItem.getGet(), components));
+              }
+              if (pathItem.getPost() != null) {
+                operations.add(
+                    extractOperation(
+                        pathEntry.getKey(), HttpMethod.POST, pathItem.getPost(), components));
+              }
+              if (pathItem.getPut() != null) {
+                operations.add(
+                    extractOperation(
+                        pathEntry.getKey(), HttpMethod.PUT, pathItem.getPut(), components));
+              }
+              if (pathItem.getPatch() != null) {
+                operations.add(
+                    extractOperation(
+                        pathEntry.getKey(), HttpMethod.PATCH, pathItem.getPatch(), components));
+              }
+              if (pathItem.getDelete() != null) {
+                operations.add(
+                    extractOperation(
+                        pathEntry.getKey(), HttpMethod.DELETE, pathItem.getDelete(), components));
+              }
+              var path = extractPath(pathEntry.getKey());
+
+              operations.forEach(
+                  operation -> {
+                    if (operation.supported()) {
+                      operation.builder().pathFeelExpression(path);
+                    }
+                  });
+              return operations.stream();
+            })
+        .filter(
+            operation ->
+                includeOperations == null
+                    || includeOperations.isEmpty()
+                    || includeOperations.contains(operation.builder().getId()))
+        .collect(Collectors.toList());
+  }
+
+  private static OperationParseResult extractOperation(
+      String path, HttpMethod method, Operation operation, Components components) {
+    try {
+      var parameters = operation.getParameters();
+      Set<HttpOperationProperty> properties =
+          parameters == null
+              ? Collections.emptySet()
+              : parameters.stream()
+                  .map(parameter -> ParameterUtil.transformToProperty(parameter, components))
+                  .collect(Collectors.toSet());
+
+      var bodyExample = extractBodyExample(operation.getRequestBody(), components);
+      var label = extractLabel(operation, path, method);
+
+      var authenticationOverride = parseAuthentication(operation.getSecurity(), components);
+      var opBuilder =
+          HttpOperation.builder()
+              .id(operation.getOperationId())
+              .label(label)
+              .bodyExample(bodyExample)
+              .authenticationOverride(authenticationOverride)
+              .method(method)
+              .properties(properties);
+      return new OperationParseResult(operation.getOperationId(), path, true, null, opBuilder);
+    } catch (Exception e) {
+      return new OperationParseResult(
+          operation.getOperationId(), path, false, e.getMessage(), null);
+    }
+  }
+
+  private static HttpPathFeelBuilder extractPath(String rawPath) {
+    // split path into parts, each part is either a variable or a constant
+    String[] pathParts = rawPath.split("\\{");
+    var builder = HttpPathFeelBuilder.create();
+    if (pathParts.length == 1) {
+      // no variables
+      builder.part(rawPath);
+    } else {
+      for (String pathPart : pathParts) {
+        if (pathPart.contains("}")) {
+          String[] variableParts = pathPart.split("}");
+          builder.property(variableParts[0]);
+          if (variableParts.length > 1) {
+            builder.part(variableParts[1]);
+          }
+        } else {
+          builder.part(pathPart);
+        }
+      }
+    }
+    return builder;
+  }
+
+  private static String extractBodyExample(RequestBody body, Components components) {
+    if (body == null) {
+      return "";
+    }
+    var content = body.getContent();
+    for (String mediaType : SUPPORTED_BODY_MEDIA_TYPES) {
+      if (content.containsKey(mediaType)) {
+        var mt = content.get(mediaType);
+        var example = mt.getExample();
+        if (example == null) {
+          example = ParameterUtil.getExampleFromSchema(mt.getSchema(), components);
+        }
+        return example == null ? "" : example.toString();
+      }
+    }
+    throw new IllegalArgumentException(
+        "Request body media types are not supported by the REST Connector");
+  }
+
+  private static String extractLabel(Operation operation, String path, HttpMethod method) {
+    if (operation.getDescription() != null && operation.getDescription().length() < 50) {
+      return operation.getDescription();
+    } else {
+      return method.name() + " " + path;
+    }
+  }
+}

--- a/element-template-generator/openapi-parser/src/main/java/io/camunda/connector/generator/openapi/ParameterUtil.java
+++ b/element-template-generator/openapi-parser/src/main/java/io/camunda/connector/generator/openapi/ParameterUtil.java
@@ -24,6 +24,7 @@ import io.swagger.v3.oas.models.parameters.Parameter;
 import java.util.Arrays;
 import java.util.Map;
 
+/** Utility functions related to converting OpenAPI parameters to {@link HttpOperationProperty}s. */
 public class ParameterUtil {
 
   private static final Map<String, Target> targetMapping =

--- a/element-template-generator/openapi-parser/src/main/java/io/camunda/connector/generator/openapi/SecurityUtil.java
+++ b/element-template-generator/openapi-parser/src/main/java/io/camunda/connector/generator/openapi/SecurityUtil.java
@@ -78,7 +78,8 @@ public class SecurityUtil {
         .forEach(result::add);
 
     if (result.isEmpty() && foundErrors.get()) {
-      throw new IllegalArgumentException("Could not parse any security scheme");
+      throw new IllegalArgumentException(
+          "Security schemes are not supported by the REST Connector");
     }
     return result;
   }

--- a/element-template-generator/openapi-parser/src/main/resources/META-INF/services/io.camunda.connector.generator.api.CliCompatibleTemplateGenerator
+++ b/element-template-generator/openapi-parser/src/main/resources/META-INF/services/io.camunda.connector.generator.api.CliCompatibleTemplateGenerator
@@ -1,0 +1,1 @@
+io.camunda.connector.generator.openapi.OpenApiOutboundTemplateGenerator

--- a/element-template-generator/openapi-parser/src/test/java/io/camunda/connector/generator/openapi/ExampleTest.java
+++ b/element-template-generator/openapi-parser/src/test/java/io/camunda/connector/generator/openapi/ExampleTest.java
@@ -27,7 +27,7 @@ public class ExampleTest {
   private final ObjectMapper mapper = new ObjectMapper();
 
   @Test
-  void swaggerPetstoreTest() throws JsonProcessingException {
+  void generate() throws JsonProcessingException {
     // given
     var parser = new OpenAPIV3Parser();
     var openApi = parser.read("https://modeler.cloud.camunda.io/v3/api-docs/api-v1");
@@ -38,5 +38,15 @@ public class ExampleTest {
 
     // then
     System.out.println(mapper.writeValueAsString(template));
+  }
+
+  @Test
+  void scan() {
+    var parser = new OpenAPIV3Parser();
+    var openApi = parser.read("https://modeler.cloud.camunda.io/v3/api-docs/api-v1");
+    var generator = new OpenApiOutboundTemplateGenerator();
+
+    var scanResult = generator.scan(new OpenApiGenerationSource(openApi, Set.of()));
+    System.out.println(scanResult);
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,7 @@
     <module>element-template-generator/maven-plugin</module>
     <module>element-template-generator/http-dsl</module>
     <module>element-template-generator/openapi-parser</module>
+    <module>element-template-generator/connectorgen-cli</module>
     <module>secret-providers/gcp-secret-provider</module>
     <module>connector-runtime/connector-runtime-core</module>
     <module>connector-runtime/connector-runtime-spring</module>


### PR DESCRIPTION
## Description

Introduces the element template generator CLI tool `connectorgen`

Features:
- Can work with any template generator that implements `CliCompatibleTemplateGenerator` interface (basically an extended version of `Element Template Generator`)
- Generators can be bundled with the tool via Java ServiceLoader
- Able to can the generation source to dry run the generation and list the supported operations, detailed reason is provided for each non-supported operation
- Configurable template name, id, version, hybrid support

Example usage:
1. `connectorgen scan openapi-outbound https://petstore3.swagger.io/api/v3/openapi.json`
  Here, `openapi-outbound` is the generator name, followed by a source link
2. `connectorgen generate openapi-outbound https://petstore3.swagger.io/api/v3/openapi.json createOrder`
  This will generate the actual template and include only the `createOrder` operation
3. `connectorgen -h -i MyTemplate openapi-outbound https://petstore3.swagger.io/api/v3/openapi.json`
  This generates a template with a custom ID `MyTemplate` and a configurable `type` property (hybrid mode).

## Related issues

<!-- Which issues are closed by this PR or are related -->

related to https://github.com/camunda/team-connectors/issues/524

