### PR TITLE
chore: added banners and /tmp volume

### DIFF
--- a/bundle/README.md
+++ b/bundle/README.md
@@ -25,7 +25,7 @@ docker run --rm --name=connectors -d \
            -e MY_SECRET=secret \              # Set a secret with value
            -e SECRET_FROM_SHELL \             # Set a secret from the environment
            --env-file secrets.txt \           # Set secrets from a file
-           camunda/connectors-bundle:0.20.3
+           camunda/connectors-bundle:8.3.0
 ```
 
 The secret `MY_SECRET` value is specified directly in the `docker run` call,

--- a/bundle/camunda-saas-bundle/Dockerfile
+++ b/bundle/camunda-saas-bundle/Dockerfile
@@ -1,5 +1,7 @@
 FROM eclipse-temurin:17.0.8.1_1-jre
 
+VOLUME /tmp
+
 RUN mkdir /opt/app
 
 # Download connectors from maven central

--- a/bundle/camunda-saas-bundle/src/main/resources/banner.txt
+++ b/bundle/camunda-saas-bundle/src/main/resources/banner.txt
@@ -1,0 +1,11 @@
+ _____                             _                 
+/  __ \                           | |                
+| /  \/ ___  _ __  _ __   ___  ___| |_ ___  _ __ ___ 
+| |    / _ \| '_ \| '_ \ / _ \/ __| __/ _ \| '__/ __|
+| \__/\ (_) | | | | | | |  __/ (__| || (_) | |  \__ \
+ \____/\___/|_| |_|_| |_|\___|\___|\__\___/|_|  |___/
+ 
+Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH.
+${application.title} ${application.version}
+Powered by Spring Boot ${spring-boot.version}
+                                                    

--- a/bundle/default-bundle/Dockerfile
+++ b/bundle/default-bundle/Dockerfile
@@ -1,5 +1,7 @@
 FROM eclipse-temurin:17.0.8.1_1-jre
 
+VOLUME /tmp
+
 # The /opt/app is used for the Connectors runtime, and out-of-the-box connectors
 # Use the /opt/additionalLibs to mount your own connectors, secret providers, or include other jars into the classpath
 RUN mkdir /opt/app && mkdir /opt/custom

--- a/bundle/default-bundle/src/main/resources/banner.txt
+++ b/bundle/default-bundle/src/main/resources/banner.txt
@@ -1,0 +1,11 @@
+ _____                             _                 
+/  __ \                           | |                
+| /  \/ ___  _ __  _ __   ___  ___| |_ ___  _ __ ___ 
+| |    / _ \| '_ \| '_ \ / _ \/ __| __/ _ \| '__/ __|
+| \__/\ (_) | | | | | | |  __/ (__| || (_) | |  \__ \
+ \____/\___/|_| |_|_| |_|\___|\___|\__\___/|_|  |___/
+ 
+Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH.
+${application.title} ${application.version}
+Powered by Spring Boot ${spring-boot.version}
+                                                    


### PR DESCRIPTION
## Description

- Added banner: addresses an issue to show current running version of connectors
- Added a volume, which is related to https://github.com/camunda/team-connectors/issues/525

## Banner

![Screenshot 2023-11-01 at 14 46 24](https://github.com/camunda/connectors/assets/108870003/ac068fa2-e3d8-489b-ac73-b508a91ae152)

## Related issues

- https://github.com/camunda/team-connectors/issues/525

