### PR TITLE
fix(generator): allow configuring template in/out types, support different property id and binding

### DIFF
--- a/element-template-generator/core/src/main/java/io/camunda/connector/generator/dsl/OutboundElementTemplate.java
+++ b/element-template-generator/core/src/main/java/io/camunda/connector/generator/dsl/OutboundElementTemplate.java
@@ -45,6 +45,8 @@ public record OutboundElementTemplate(
     @JsonProperty int version,
     @JsonProperty String documentationRef,
     @JsonProperty String description,
+    @JsonProperty Set<String> appliesTo,
+    @JsonProperty ElementType elementType,
     @JsonProperty List<PropertyGroup> groups,
     @JsonProperty List<Property> properties,
     @JsonProperty ElementTemplateIcon icon)
@@ -60,6 +62,12 @@ public record OutboundElementTemplate(
     }
     if (version < 0) {
       errors.add("version cannot be negative");
+    }
+    if (appliesTo == null || appliesTo.isEmpty() || appliesTo.stream().allMatch(String::isBlank)) {
+      errors.add("appliesTo must be defined");
+    }
+    if (elementType == null || elementType.value == null || elementType.value.isBlank()) {
+      errors.add("elementType must be defined");
     }
     if (groups == null) {
       errors.add("groups is required");
@@ -86,16 +94,6 @@ public record OutboundElementTemplate(
   }
 
   @JsonProperty
-  public Set<BpmnType> appliesTo() {
-    return Set.of(BpmnType.TASK);
-  }
-
-  @JsonProperty
-  public ElementType elementType() {
-    return new ElementType(BpmnType.SERVICE_TASK);
-  }
-
-  @JsonProperty
   public ElementTemplateCategory category() {
     return ElementTemplateCategory.CONNECTORS;
   }
@@ -104,5 +102,5 @@ public record OutboundElementTemplate(
     return OutboundElementTemplateBuilder.create();
   }
 
-  public record ElementType(@JsonProperty BpmnType value) {}
+  public record ElementType(@JsonProperty String value) {}
 }

--- a/element-template-generator/core/src/main/java/io/camunda/connector/generator/dsl/OutboundElementTemplateBuilder.java
+++ b/element-template-generator/core/src/main/java/io/camunda/connector/generator/dsl/OutboundElementTemplateBuilder.java
@@ -16,12 +16,14 @@
  */
 package io.camunda.connector.generator.dsl;
 
+import io.camunda.connector.generator.dsl.OutboundElementTemplate.ElementType;
 import io.camunda.connector.generator.dsl.Property.FeelMode;
 import io.camunda.connector.generator.dsl.PropertyBinding.ZeebeTaskDefinitionType;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
+import java.util.Set;
 
 public class OutboundElementTemplateBuilder {
 
@@ -31,6 +33,8 @@ public class OutboundElementTemplateBuilder {
   private ElementTemplateIcon icon;
   private String documentationRef;
   private String description;
+  private Set<String> appliesTo;
+  private String elementType;
   private final List<PropertyGroup> groups = new ArrayList<>();
   private final List<Property> properties = new ArrayList<>();
 
@@ -99,6 +103,16 @@ public class OutboundElementTemplateBuilder {
     return this;
   }
 
+  public OutboundElementTemplateBuilder appliesTo(Set<String> appliesTo) {
+    this.appliesTo = appliesTo;
+    return this;
+  }
+
+  public OutboundElementTemplateBuilder elementType(String elementType) {
+    this.elementType = elementType;
+    return this;
+  }
+
   public OutboundElementTemplateBuilder propertyGroups(PropertyGroup... groups) {
     this.groups.addAll(Arrays.asList(groups));
     this.properties.addAll(
@@ -129,7 +143,16 @@ public class OutboundElementTemplateBuilder {
     }
     verifyUniquePropertyIds();
     return new OutboundElementTemplate(
-        id, name, version, documentationRef, description, groups, properties, icon);
+        id,
+        name,
+        version,
+        documentationRef,
+        description,
+        appliesTo,
+        new ElementType(elementType),
+        groups,
+        properties,
+        icon);
   }
 
   private boolean isTypeAssigned() {

--- a/element-template-generator/core/src/main/java/io/camunda/connector/generator/dsl/PropertyBuilder.java
+++ b/element-template-generator/core/src/main/java/io/camunda/connector/generator/dsl/PropertyBuilder.java
@@ -48,6 +48,10 @@ public abstract sealed class PropertyBuilder
     return id;
   }
 
+  public PropertyBinding getBinding() {
+    return binding;
+  }
+
   public PropertyBuilder id(String name) {
     this.id = name;
     return this;

--- a/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/annotation/ElementTemplate.java
+++ b/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/annotation/ElementTemplate.java
@@ -88,7 +88,27 @@ public @interface ElementTemplate {
    */
   String icon() default "";
 
+  /**
+   * BPMN element types the template is applicable to, e.g. "bpmn:Task".
+   *
+   * <p>If not specified, the default value is chosen by the underlying generator implementation.
+   *
+   * @see #elementType() allows to configure the resulting element type.
+   */
+  String[] appliesTo() default {};
+
+  /**
+   * The target element type of the template, e.g. "bpmn:ServiceTask". When template is applied, the
+   * element is transformed to this type.
+   *
+   * <p>If not specified, the default value is chosen by the underlying generator implementation.
+   *
+   * @see #appliesTo() allows to configure the types the template can be applied to.
+   */
+  String elementType() default "";
+
   @interface PropertyGroup {
+
     String id();
 
     String label() default "";

--- a/element-template-generator/core/src/test/java/io/camunda/connector/generator/dsl/OutboundElementTemplateSerializationTest.java
+++ b/element-template-generator/core/src/test/java/io/camunda/connector/generator/dsl/OutboundElementTemplateSerializationTest.java
@@ -23,6 +23,7 @@ import io.camunda.connector.generator.dsl.PropertyBinding.ZeebeTaskHeader;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Set;
 import org.junit.jupiter.api.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
 
@@ -38,6 +39,8 @@ public class OutboundElementTemplateSerializationTest {
             .id("io.camunda.connector.Template.v1")
             .type("io.camunda:template:1")
             .name("Template: Some Function")
+            .appliesTo(Set.of("bpmn:Task"))
+            .elementType("bpmn:ServiceTask")
             .version(1)
             .documentationRef(
                 "https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/available-connectors-overview/")

--- a/element-template-generator/core/src/test/java/io/camunda/connector/generator/java/example/MyConnectorFunction.java
+++ b/element-template-generator/core/src/test/java/io/camunda/connector/generator/java/example/MyConnectorFunction.java
@@ -42,6 +42,8 @@ public abstract class MyConnectorFunction implements OutboundConnectorFunction {
       inputVariables = {})
   @ElementTemplate(
       id = MyConnectorFunction.ID,
+      appliesTo = "bpmn:ServiceTask",
+      elementType = "bpmn:ScriptTask",
       name = MyConnectorFunction.NAME,
       version = MyConnectorFunction.VERSION,
       description = MyConnectorFunction.DESCRIPTION,

--- a/element-template-generator/core/src/test/java/io/camunda/connector/generator/java/example/MyConnectorInput.java
+++ b/element-template-generator/core/src/test/java/io/camunda/connector/generator/java/example/MyConnectorInput.java
@@ -64,6 +64,7 @@ public record MyConnectorInput(
     @TemplateProperty(type = PropertyType.Text)
         @Pattern(regexp = "^(=.*|[0-9]+|\\{\\{secrets\\..+}})$", message = "Pattern violated")
         String propertyWithPattern,
+    @TemplateProperty(id = "idNotEqualToBinding") String propertyWithDifferentIdAndBinding,
     @Size(min = 1, max = 10) String propertyWithMinMax,
     @Size(min = Integer.MIN_VALUE, max = 10) String propertyWithMaxSize,
     @NotEmpty String stringPropertyWithNotEmpty,

--- a/element-template-generator/http/src/main/java/io/camunda/connector/generator/http/HttpOutboundElementTemplateBuilder.java
+++ b/element-template-generator/http/src/main/java/io/camunda/connector/generator/http/HttpOutboundElementTemplateBuilder.java
@@ -32,6 +32,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 public class HttpOutboundElementTemplateBuilder {
@@ -128,6 +129,7 @@ public class HttpOutboundElementTemplateBuilder {
     }
     builder.propertyGroups(List.of(serverPropertyGroup(), operationPropertyGroup()));
     builder.properties(businessLogicPropertyGroups());
+    builder.elementType("bpmn:ServiceTask").appliesTo(Set.of("bpmn:Task"));
     return builder.build();
   }
 


### PR DESCRIPTION
## Description

1 bug fix and 1 improvement for the element template generator API.

- Allow custom `elementType` and `appliesTo` for element templates on the DSL level and in the `@ElementTemplate` annotation.
- Support defining properties whose input binding name is not equal to property id. This is particularly useful for sealed hierarchies where there might be properties with the same name in different subtypes.

## Related issues

related to https://github.com/camunda/connectors/issues/1342
