### PR TITLE
docs: add template generator to the license list

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ This is a multi-module project with different licenses applied to different modu
 * [Connector Secret providers](secret-providers) implementations
 * [Connector Runtime](connector-runtime) and all its submodules
 * [Http Json Outbound Connector](connectors/http/rest)
+* [Element Template Generator](element-template-generator) and its submodules
 
 ### Modules available under [Camunda Self-Managed Free Edition license](https://camunda.com/legal/terms/cloud-terms-and-conditions/camunda-cloud-self-managed-free-edition-terms/)
 


### PR DESCRIPTION
## Description

Adds element template generator to the list of modules licensed under Apache 2.0.
