### PR TITLE
Upgrade commons-text including transitive dependency

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -403,7 +403,12 @@ limitations under the License.</license.inlineheader>
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-text</artifactId>
-        <version>1.10.0</version>
+        <version>1.11.0</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-lang3</artifactId>
+        <version>3.13.0</version>
       </dependency>
 
       <!-- FIXME: maven resolves protobuf to 3.21.x while zeebe-client is compiled for 3.22.2. This is a temporary fix to be reassessed later. -->


### PR DESCRIPTION
## Description

Upgrade `commons-text` dependency which require a new additional dependency as classes were relocated.

## Related issues

<!-- Which issues are closed by this PR or are related -->

Relates to https://github.com/camunda/connectors/pull/1339

