### PR TITLE
build: add backport action

### DIFF
--- a/.github/workflows/BACKPORT_PR.yml
+++ b/.github/workflows/BACKPORT_PR.yml
@@ -1,0 +1,33 @@
+name: Backport merged pull request
+on:
+  pull_request_target:
+    types: [ closed ]
+  issue_comment:
+    types: [ created ]
+
+permissions:
+  contents: write # so it can comment
+  pull-requests: write # so it can create pull requests
+
+jobs:
+  backport:
+    name: Backport pull request
+    runs-on: ubuntu-latest
+
+    # Only run when pull request is merged
+    # or when a comment containing `/backport` is created by someone other than the
+    # https://github.com/backport-action bot user (user id: 97796249)
+    if: >
+      (
+        github.event_name == 'pull_request' &&
+        github.event.pull_request.merged
+      ) || (
+        github.event_name == 'issue_comment' &&
+        github.event.issue.pull_request &&
+        github.event.comment.user.id != 97796249 &&
+        contains(github.event.comment.body, '/backport')
+      )
+    steps:
+      - uses: actions/checkout@v4
+      - name: Create backport pull requests
+        uses: korthout/backport-action@v2

--- a/README.md
+++ b/README.md
@@ -148,3 +148,10 @@ mvn clean package
 
 1. For minor releases (x.y.0), create a new branch `release/x.y` from `main` in advance and rebase it onto `main` from time to time. This can be done using the `CREATE_RELEASE_BRANCH` workflow.
 2. To trigger the release, publish a new GitHub release and name the tag according to the version you want to release (e.g. `1.0.0`). This will trigger a GitHub workflow that builds and publishes the release artifacts, generates a changelog and bundles the element templates into an archive.
+
+### Backport a PR to an older release
+
+We use `[backport-action](https://github.com/korthout/backport-action)` to backport PRs to older releases.
+For example, add a label `backport release/8.3` to backport a PR to the `release/8.3` branch. This will take effect when the PR is meged.
+
+You can also trigger this for already merged PRs by posting a comment on the PR containing `/backport`.


### PR DESCRIPTION
## Description

This PR adds [backport-action](https://github.com/korthout/backport-action) to the repo. This should work as is, I'll give it a try after merging!

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes https://github.com/camunda/team-connectors/issues/540

