### PR TITLE
fix(inbound): fix health report on /inbound endpoint

### DIFF
--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImpl.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImpl.java
@@ -97,6 +97,7 @@ public class InboundConnectorContextImpl extends AbstractConnectorContext
     this.health = health;
   }
 
+  @Override
   public Health getHealth() {
     return health;
   }

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/InboundIntermediateConnectorContextImpl.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/InboundIntermediateConnectorContextImpl.java
@@ -109,4 +109,9 @@ public class InboundIntermediateConnectorContextImpl
   public void reportHealth(final Health health) {
     inboundContext.reportHealth(health);
   }
+
+  @Override
+  public Health getHealth() {
+    return inboundContext.getHealth();
+  }
 }

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/lifecycle/InboundConnectorRestController.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/lifecycle/InboundConnectorRestController.java
@@ -17,7 +17,6 @@
 package io.camunda.connector.runtime.inbound.lifecycle;
 
 import io.camunda.connector.api.inbound.webhook.WebhookConnectorExecutable;
-import io.camunda.connector.runtime.core.inbound.InboundConnectorContextImpl;
 import io.camunda.connector.runtime.inbound.webhook.model.CommonWebhookProperties;
 import java.util.Collections;
 import java.util.HashMap;
@@ -53,7 +52,7 @@ public class InboundConnectorRestController {
 
   private ActiveInboundConnectorResponse mapToResponse(ActiveInboundConnector connector) {
     var definition = connector.context().getDefinition();
-    var health = ((InboundConnectorContextImpl) connector.context()).getHealth();
+    var health = connector.context().getHealth();
     Map<String, Object> details;
     if (connector.executable() instanceof WebhookConnectorExecutable) {
       details =

--- a/connector-sdk/core/src/main/java/io/camunda/connector/api/inbound/InboundConnectorContext.java
+++ b/connector-sdk/core/src/main/java/io/camunda/connector/api/inbound/InboundConnectorContext.java
@@ -100,5 +100,13 @@ public interface InboundConnectorContext {
    */
   void reportHealth(Health health);
 
+  /**
+   * Provides a Health object to get information about the current status of the Connector with
+   * optional details.
+   *
+   * <p>Use the {@link #reportHealth(Health)} method to set this information
+   *
+   * @return Health object
+   */
   Health getHealth();
 }

--- a/connector-sdk/core/src/main/java/io/camunda/connector/api/inbound/InboundConnectorContext.java
+++ b/connector-sdk/core/src/main/java/io/camunda/connector/api/inbound/InboundConnectorContext.java
@@ -99,4 +99,6 @@ public interface InboundConnectorContext {
    * implementation requires it.
    */
   void reportHealth(Health health);
+
+  Health getHealth();
 }

--- a/connector-sdk/test/src/main/java/io/camunda/connector/test/inbound/InboundConnectorContextBuilder.java
+++ b/connector-sdk/test/src/main/java/io/camunda/connector/test/inbound/InboundConnectorContextBuilder.java
@@ -259,6 +259,7 @@ public class InboundConnectorContextBuilder {
       return correlatedEvents;
     }
 
+    @Override
     public Health getHealth() {
       return health;
     }


### PR DESCRIPTION
## Description

The /inbound returned 500 error, because of class cast exception. This fix eliminates this error by using the more generic InboundConnectorExecutable instead of the InboundConnectorContextImpl.

## Related issues

closes #
https://github.com/camunda/connectors/issues/1364

