### PR TITLE
build: fix tag not found on release

### DIFF
--- a/.github/workflows/RELEASE.yaml
+++ b/.github/workflows/RELEASE.yaml
@@ -15,6 +15,30 @@ jobs:
           ref: ${{ github.event.release.target_commitish }}
           fetch-depth: 0
 
+      - name: Check if new version implies pre-release
+        id: check_prerelease
+        run: |
+          if [[ ${{github.event.release.prerelease}} == "true" ]]; then
+            PRE_RELEASE=true
+          elif [[ ${{ github.event.release.tag_name }} =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            PRE_RELEASE=false
+          else
+            PRE_RELEASE=true
+          fi
+          echo "isPreRelease=${PRE_RELEASE}" >> $GITHUB_OUTPUT
+
+      - name: Get previous tag for changelog
+        id: get_previous_tag
+        run: |
+          git pull --tags
+          if [[ ${{steps.check_prerelease.outputs.isPreRelease}} == "true" ]]; then
+            TAG_NAME=$(git --no-pager tag --sort=-creatordate | head -2 | tail -1)
+          else
+            TAG_NAME=$(git --no-pager tag --sort=-creatordate | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | head -2 | tail -1)
+          fi
+          echo "previousTag: $TAG_NAME"
+          echo "previousTag=${TAG_NAME}" >> $GITHUB_OUTPUT
+
       - name: Import Secrets
         id: secrets
         uses: hashicorp/vault-action@v2.7.4
@@ -82,29 +106,6 @@ jobs:
 
       - name: Install element templates CLI
         run: npm install --global element-templates-cli
-
-      - name: Check if new version implies pre-release
-        id: check_prerelease
-        run: |
-          if [[ ${{github.event.release.prerelease}} == "true" ]]; then
-            PRE_RELEASE=true
-          elif [[ ${{ github.event.release.tag_name }} =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            PRE_RELEASE=false
-          else
-            PRE_RELEASE=true
-          fi
-          echo "isPreRelease=${PRE_RELEASE}" >> $GITHUB_OUTPUT
-
-      - name: Get previous tag for changelog
-        id: get_previous_tag
-        run: |
-          if [[ ${{steps.check_prerelease.outputs.isPreRelease}} == "true" ]]; then
-            TAG_NAME=$(git --no-pager tag --sort=-creatordate | head -2 | tail -1)
-          else
-            TAG_NAME=$(git --no-pager tag --sort=-creatordate | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | head -2 | tail -1)
-          fi
-          echo "previousTag: $TAG_NAME"
-          echo "previousTag=${TAG_NAME}" >> $GITHUB_OUTPUT
 
     # Maven build & version bump
 


### PR DESCRIPTION
## Description

This PR fixes a strange error I caught while running the release pipeline. The previous tag history was missing in the local repo although `actions/checkout` is configured with `fetch-depth=0` which should fetch everything.

The bullet-proof solution is to do `git pull --tags` right before using the tag history.

Also moved it further up in the pipeline to simplify debugging.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #

