### PR TITLE
fix(generator): various OpenAPI generator bugfixes

### DIFF
--- a/element-template-generator/http-dsl/src/main/java/io/camunda/connector/generator/dsl/http/HttpOperation.java
+++ b/element-template-generator/http-dsl/src/main/java/io/camunda/connector/generator/dsl/http/HttpOperation.java
@@ -16,7 +16,6 @@
  */
 package io.camunda.connector.generator.dsl.http;
 
-import io.camunda.connector.generator.dsl.Property;
 import io.camunda.connector.http.base.model.HttpMethod;
 import java.util.Collection;
 import java.util.List;
@@ -29,9 +28,6 @@ import java.util.List;
  * @param method The HTTP method for this operation.
  * @param bodyFeelExpression A FEEL expression for the request bodyFeelExpression that may include
  *     variable values from properties.
- * @param headersFeelExpression Headers defined for this operation (FEEL context expression).
- * @param queryParamsFeelExpression Query parameters defined for this operation (FEEL context
- *     expression).
  * @param properties Custom properties defined for this operation. This should not include technical
  *     properties like the path or the method, i.e. only properties that are relevant for the
  *     business logic.
@@ -39,12 +35,10 @@ import java.util.List;
 public record HttpOperation(
     String id,
     String label,
-    String pathFeelExpression,
+    HttpPathFeelBuilder pathFeelExpression,
     HttpMethod method,
     String bodyFeelExpression,
-    String headersFeelExpression,
-    String queryParamsFeelExpression,
-    Collection<Property> properties,
+    Collection<HttpOperationProperty> properties,
     List<HttpAuthentication> authenticationOverride) {
 
   public static HttpOperationBuilder builder() {

--- a/element-template-generator/http-dsl/src/main/java/io/camunda/connector/generator/dsl/http/HttpPathFeelBuilder.java
+++ b/element-template-generator/http-dsl/src/main/java/io/camunda/connector/generator/dsl/http/HttpPathFeelBuilder.java
@@ -31,6 +31,8 @@ public class HttpPathFeelBuilder {
   private final Set<String> propertySet = new HashSet<>();
   private static final FeelEngineWrapper feelEngineWrapper = new FeelEngineWrapper();
 
+  public static final String FEEL_OPERATOR_CHARACTERS = "!=<>+-*/[]{}@ ";
+
   private HttpPathFeelBuilder() {}
 
   public static HttpPathFeelBuilder create() {
@@ -52,6 +54,15 @@ public class HttpPathFeelBuilder {
 
   /** Add a variable property to the path */
   public HttpPathFeelBuilder property(String property) {
+    if (property == null || property.isEmpty()) {
+      throw new IllegalArgumentException("Property must not be null or empty");
+    }
+    for (char c : FEEL_OPERATOR_CHARACTERS.toCharArray()) {
+      if (property.contains(String.valueOf(c))) {
+        throw new IllegalArgumentException(
+            "Property must not contain FEEL operator characters: " + FEEL_OPERATOR_CHARACTERS);
+      }
+    }
     if (sb.isEmpty()) {
       sb.append("=");
     } else {
@@ -74,7 +85,7 @@ public class HttpPathFeelBuilder {
   }
 
   /** Transform the constructed path into a FEEL expression string */
-  public String build() {
+  String build() {
     String result = sb.toString();
     evaluateFeel(result, propertySet);
     return result;

--- a/element-template-generator/http-dsl/src/test/java/io/camunda/connector/generator/dsl/http/HttpOutboundElementTemplateBuilderTest.java
+++ b/element-template-generator/http-dsl/src/test/java/io/camunda/connector/generator/dsl/http/HttpOutboundElementTemplateBuilderTest.java
@@ -48,7 +48,7 @@ public class HttpOutboundElementTemplateBuilderTest {
             .label("Some GET request")
             .method(HttpMethod.GET)
             .pathFeelExpression(
-                HttpPathFeelBuilder.create().part("/examples/").property("exampleId").build())
+                HttpPathFeelBuilder.create().part("/examples/").property("exampleId"))
             .properties(
                 HttpOperationProperty.createStringProperty(
                     "exampleId", Target.PATH, "Example ID", true, "42"),
@@ -213,8 +213,7 @@ public class HttpOutboundElementTemplateBuilderTest {
           .id("someGetRequest")
           .label("Some GET request")
           .method(HttpMethod.GET)
-          .pathFeelExpression(
-              HttpPathFeelBuilder.create().part("/examples/").property("exampleId").build())
+          .pathFeelExpression(HttpPathFeelBuilder.create().part("/examples/").property("exampleId"))
           .properties(
               HttpOperationProperty.createStringProperty(
                   "exampleId", Target.PATH, "Example ID", true, "42"),
@@ -230,8 +229,7 @@ public class HttpOutboundElementTemplateBuilderTest {
           .id("somePostRequest")
           .label("Some POST request")
           .method(HttpMethod.POST)
-          .pathFeelExpression(
-              HttpPathFeelBuilder.create().part("/examples/").property("exampleId").build())
+          .pathFeelExpression(HttpPathFeelBuilder.create().part("/examples/").property("exampleId"))
           .properties(
               HttpOperationProperty.createStringProperty(
                   "exampleId", Target.PATH, "Example ID", true, "42"),
@@ -374,7 +372,7 @@ public class HttpOutboundElementTemplateBuilderTest {
                   .label("Some GET request")
                   .method(HttpMethod.GET)
                   .pathFeelExpression(
-                      HttpPathFeelBuilder.create().part("/examples/").property("exampleId").build())
+                      HttpPathFeelBuilder.create().part("/examples/").property("exampleId"))
                   .properties(
                       HttpOperationProperty.createStringProperty(
                           "exampleId", Target.PATH, "Example ID", true, "42"),

--- a/element-template-generator/http-dsl/src/test/java/io/camunda/connector/generator/dsl/http/HttpPathFeelBuilderTest.java
+++ b/element-template-generator/http-dsl/src/test/java/io/camunda/connector/generator/dsl/http/HttpPathFeelBuilderTest.java
@@ -61,4 +61,14 @@ public class HttpPathFeelBuilderTest {
     var builder = HttpPathFeelBuilder.create().part("doesNotStartWithASlash");
     assertThrows(IllegalArgumentException.class, builder::build);
   }
+
+  @Test
+  void feelOperatorCharacters() {
+    var builder = HttpPathFeelBuilder.create();
+    var ex =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> builder.part("/documents/").property("document-id"));
+    assertThat(ex.getMessage()).contains(HttpPathFeelBuilder.FEEL_OPERATOR_CHARACTERS);
+  }
 }

--- a/element-template-generator/openapi-parser/src/main/java/io/camunda/connector/generator/openapi/OpenApiOutboundTemplateGenerator.java
+++ b/element-template-generator/openapi-parser/src/main/java/io/camunda/connector/generator/openapi/OpenApiOutboundTemplateGenerator.java
@@ -37,6 +37,12 @@ import org.slf4j.LoggerFactory;
 public class OpenApiOutboundTemplateGenerator
     implements CliCompatibleTemplateGenerator<OpenApiGenerationSource, OutboundElementTemplate> {
 
+  public OpenApiOutboundTemplateGenerator() {
+    super();
+    // workaround for https://github.com/swagger-api/swagger-parser/issues/1857 (large yaml files)
+    System.setProperty("maxYamlCodePoints", String.valueOf(Integer.MAX_VALUE));
+  }
+
   private static final Logger LOG = LoggerFactory.getLogger(OpenApiOutboundTemplateGenerator.class);
 
   @Override

--- a/element-template-generator/openapi-parser/src/main/java/io/camunda/connector/generator/openapi/ParameterUtil.java
+++ b/element-template-generator/openapi-parser/src/main/java/io/camunda/connector/generator/openapi/ParameterUtil.java
@@ -27,13 +27,9 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /** Utility functions related to converting OpenAPI parameters to {@link HttpOperationProperty}s. */
 public class ParameterUtil {
-
-  private static final Logger LOG = LoggerFactory.getLogger(ParameterUtil.class);
 
   private static final Map<String, Target> targetMapping =
       Map.of(
@@ -54,6 +50,15 @@ public class ParameterUtil {
 
   private static HttpOperationProperty fromSchema(Parameter parameter, Components components) {
 
+    // Path parameter names may contain dashes, which are not allowed by the DSL, as this would be
+    // interpreted as a subtraction by the FEEL engine. It is safe to replace path parameter names
+    // with underscores (this doesn't apply to other parameter targets!)
+
+    var name = parameter.getName();
+    if ("path".equals(parameter.getIn())) {
+      name = name.replace("-", "_");
+    }
+
     String example;
     if (parameter.getExample() != null) {
       example = parameter.getExample().toString();
@@ -64,33 +69,33 @@ public class ParameterUtil {
 
     if (schema.getEnum() != null) {
       return HttpOperationProperty.createEnumProperty(
-          parameter.getName(),
+          name,
           targetMapping.get(parameter.getIn()),
           parameter.getDescription(),
-          parameter.getRequired(),
+          parameter.getRequired() != null && parameter.getRequired(),
           (List<String>) schema.getEnum());
     } else if (schema.getType().equals("boolean")) {
       return HttpOperationProperty.createEnumProperty(
-          parameter.getName(),
+          name,
           targetMapping.get(parameter.getIn()),
           parameter.getDescription(),
-          parameter.getRequired(),
+          parameter.getRequired() != null && parameter.getRequired(),
           Arrays.asList("true", "false"));
     } else if (schema.getType().equals("string")
         || schema.getType().equals("integer")
         || schema.getType().equals("number")) {
       return HttpOperationProperty.createStringProperty(
-          parameter.getName(),
+          name,
           targetMapping.get(parameter.getIn()),
           parameter.getDescription(),
-          parameter.getRequired(),
+          parameter.getRequired() != null && parameter.getRequired(),
           example);
     } else if (schema.getType().equals("object") || schema.getType().equals("array")) {
       return HttpOperationProperty.createFeelProperty(
-          parameter.getName(),
+          name,
           targetMapping.get(parameter.getIn()),
           parameter.getDescription(),
-          parameter.getRequired(),
+          parameter.getRequired() != null && parameter.getRequired(),
           example);
     }
     throw new IllegalArgumentException("Unsupported parameter type: " + schema.getType());
@@ -124,6 +129,11 @@ public class ParameterUtil {
     } catch (Exception e) {
       return null;
     }
+    if (data instanceof String) {
+      return (String) data;
+    } else if (data instanceof Boolean || data instanceof Number) {
+      return data.toString();
+    }
     try {
       return ConnectorsObjectMapperSupplier.DEFAULT_MAPPER
           .writerWithDefaultPrettyPrinter()
@@ -147,6 +157,9 @@ public class ParameterUtil {
       }
       case "array" -> {
         var items = schema.getItems();
+        if (items.getEnum() != null && !items.getEnum().isEmpty()) {
+          return items.getEnum();
+        }
         return new Object[] {generateFakeDataFromSchema(items)};
       }
       case "integer", "number" -> {

--- a/element-template-generator/openapi-parser/src/test/java/io/camunda/connector/generator/openapi/ParameterUtilTest.java
+++ b/element-template-generator/openapi-parser/src/test/java/io/camunda/connector/generator/openapi/ParameterUtilTest.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.generator.openapi;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.swagger.v3.oas.models.media.Schema;
+import io.swagger.v3.oas.models.parameters.Parameter;
+import java.util.List;
+import org.json.JSONException;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
+
+public class ParameterUtilTest {
+
+  @Nested
+  class ParameterEscaping {
+
+    @Test
+    void pathParameter_containsDash_replacedWithUnderscore() {
+      // given
+      var schema = new Schema<>();
+      schema.setType("string");
+
+      var parameter = new Parameter();
+      parameter.setName("my-path-parameter");
+      parameter.setIn("path");
+      parameter.setSchema(schema);
+
+      // when
+      var property = ParameterUtil.transformToProperty(parameter, null);
+
+      // then
+      assertThat(property.id()).isEqualTo("my_path_parameter");
+    }
+
+    @Test
+    void queryParameter_containsDash_notReplacedWithUnderscore() {
+      // given
+      var schema = new Schema<>();
+      schema.setType("string");
+
+      var parameter = new Parameter();
+      parameter.setName("my-query-parameter");
+      parameter.setIn("query");
+      parameter.setSchema(schema);
+
+      // when
+      var property = ParameterUtil.transformToProperty(parameter, null);
+
+      // then
+      assertThat(property.id()).isEqualTo("my-query-parameter");
+    }
+
+    @Test
+    void headerParameter_containsDash_notReplacedWithUnderscore() {
+      // given
+      var schema = new Schema<>();
+      schema.setType("string");
+
+      var parameter = new Parameter();
+      parameter.setName("my-query-parameter");
+      parameter.setIn("header");
+      parameter.setSchema(schema);
+
+      // when
+      var property = ParameterUtil.transformToProperty(parameter, null);
+
+      // then
+      assertThat(property.id()).isEqualTo("my-query-parameter");
+    }
+  }
+
+  @Nested
+  class PropertyExamples {
+
+    @Test
+    void enumArrayExample_shouldContainAllValues() throws JSONException {
+      // given
+      var itemsSchema = new Schema<>();
+      itemsSchema.setType("string");
+      itemsSchema.setEnum(List.of("foo", "bar"));
+      var schema = new Schema<>();
+      schema.setType("array");
+      schema.setItems(itemsSchema);
+
+      var parameter = new Parameter();
+      parameter.setSchema(schema);
+      parameter.setName("myParameter");
+      parameter.setIn("query");
+
+      // when
+      var property = ParameterUtil.transformToProperty(parameter, null);
+
+      // then
+      JSONAssert.assertEquals("[\"foo\", \"bar\"]", property.example(), true);
+    }
+
+    @Test
+    void stringExample_shouldNotBeQuoted() {
+      // given
+      var schema = new Schema<>();
+      schema.setType("string");
+      schema.setExample("foo");
+
+      var parameter = new Parameter();
+      parameter.setSchema(schema);
+      parameter.setName("myParameter");
+      parameter.setIn("query");
+
+      // when
+      var property = ParameterUtil.transformToProperty(parameter, null);
+
+      // then
+      assertThat(property.example()).isEqualTo("foo");
+    }
+  }
+}


### PR DESCRIPTION
## Description

This PR fixes several issues discovered while testing the OpenAPI generator.


| Issue description | Fix description |
|---|---|
| Request body could not be parsed when it was provided as a reference to the `Components` object  | Fetch body from components if ref is provided, see `OperationUtil::extractBodyExample`  |
| Inconsistent operation naming (sometimes method + path, sometimes description) | Use only method + path naming schema, as descriptions are inconsistent among different API providers |
| Examples for string parameters are falsely enclosed in quotes  | Fixed in `OperationUtil::extractBodyExample` |
| If path param contains a dash, it is treated by the FEEL engine as a minus sign  | Replace all dashes in path parameters with underscores, see `OperationUtil::extractPath` |
| Enum param values are not displayed in the property example value | If property is an enum array, we include all enum values as examples. If it is a single enum value, it is included as a dropdown (`generateFakeDataStringFromSchema`) |
| Parameters named like this: `operationId_path` conflict with our internal properties that have the same name  | Replaced the internal property name `operationId_path` with `operationId_$path` to make the chance of such conflicts lower |
| Huge YAML files can't be deserialized | Added a system prop override, see https://github.com/swagger-api/swagger-parser/issues/1857 | 

Additionally, with these changes I moved most of properties shading / processing logic one level up, to the `PropertyUtil` in HTTP DSL. This makes the HTTP DSL cleaner and avoid some data redundancies.

## Related issues

related to https://github.com/camunda/team-connectors/issues/524

