### PR TITLE
fix(rest): support lowercase http method names in element template

### DIFF
--- a/connectors/http/rest/element-templates/http-json-connector-hybrid.json
+++ b/connectors/http/rest/element-templates/http-json-connector-hybrid.json
@@ -413,7 +413,7 @@
     },
     "condition" : {
       "property" : "method",
-      "oneOf" : [ "POST", "PUT", "PATCH" ],
+      "oneOf" : [ "POST", "PUT", "PATCH", "post", "put", "patch" ],
       "type" : "simple"
     },
     "type" : "Text"

--- a/connectors/http/rest/element-templates/http-json-connector.json
+++ b/connectors/http/rest/element-templates/http-json-connector.json
@@ -408,7 +408,7 @@
     },
     "condition" : {
       "property" : "method",
-      "oneOf" : [ "POST", "PUT", "PATCH" ],
+      "oneOf" : [ "POST", "PUT", "PATCH", "post", "put", "patch" ],
       "type" : "simple"
     },
     "type" : "Text"


### PR DESCRIPTION
## Description

After replacing the REST connector template with an auto generated one, the backwards compatibility was broken by changing the method name case. This lead to condition issues for users upgrading their already applied old versions of the template.

## Related issues

<!-- Which issues are closed by this PR or are related -->

related to https://github.com/camunda/team-connectors/issues/552

