### PR TITLE
feat: use identity to authenticate to operate

### DIFF
--- a/connector-runtime/spring-boot-starter-camunda-connectors/pom.xml
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/pom.xml
@@ -47,6 +47,10 @@
       </exclusions>
     </dependency>
     <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>identity-spring-boot-starter</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-web</artifactId>
     </dependency>

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/main/java/io/camunda/connector/runtime/InboundConnectorsAutoConfiguration.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/main/java/io/camunda/connector/runtime/InboundConnectorsAutoConfiguration.java
@@ -69,28 +69,28 @@ public class InboundConnectorsAutoConfiguration {
   }
 
   private OperateClientConfigurationProperties operatePropertiesProxy(
-      OperateClientConfigurationProperties properties,
-      Identity identity) {
-    return (OperateClientConfigurationProperties) Proxy.newProxyInstance(
-        OperateClientConfigurationProperties.class.getClassLoader(),
-        new Class[] {OperateClientConfigurationProperties.class},
-        (proxy, method, args) -> {
-          try {
-            if (method.getReturnType().equals(AuthInterface.class)
-                && identity.authentication().isAvailable()) {
-              return new IdentityAuth(identity, operateAudience);
-            }
+      OperateClientConfigurationProperties properties, Identity identity) {
+    return (OperateClientConfigurationProperties)
+        Proxy.newProxyInstance(
+            OperateClientConfigurationProperties.class.getClassLoader(),
+            new Class[] {OperateClientConfigurationProperties.class},
+            (proxy, method, args) -> {
+              try {
+                if (method.getReturnType().equals(AuthInterface.class)
+                    && identity.authentication().isAvailable()) {
+                  return new IdentityAuth(identity, operateAudience);
+                }
 
-            return method.invoke(properties, args);
-          } catch (final InvocationTargetException e) {
-            throw e.getCause();
-          }
-        });
+                return method.invoke(properties, args);
+              } catch (final InvocationTargetException e) {
+                throw e.getCause();
+              }
+            });
   }
 
   private static class IdentityAuth extends JwtAuthentication {
-    final private Identity identity;
-    final private String audience;
+    private final Identity identity;
+    private final String audience;
 
     public IdentityAuth(Identity identity, String audience) {
       this.identity = identity;

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -525,6 +525,12 @@ limitations under the License.</license.inlineheader>
       <name>Zeebe Snapshot Repository</name>
       <url>https://artifacts.camunda.com/artifactory/zeebe-io-snapshots/</url>
     </repository>
+
+    <repository>
+      <id>camunda-nexus</id>
+      <name>Camunda Nexus</name>
+      <url>https://artifacts.camunda.com/artifactory/internal/</url>
+    </repository>
   </repositories>
 
   <build>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -72,6 +72,7 @@ limitations under the License.</license.inlineheader>
     <version.spring-zeebe>8.3.1</version.spring-zeebe>
     <version.feel-engine>1.17.3</version.feel-engine>
     <version.operate-client>8.3.0.1</version.operate-client>
+    <version.identity>8.4.0-SNAPSHOT</version.identity>
 
     <!-- Third party dependencies -->
 
@@ -262,6 +263,12 @@ limitations under the License.</license.inlineheader>
         <groupId>io.camunda</groupId>
         <artifactId>camunda-operate-client-java</artifactId>
         <version>${version.operate-client}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>io.camunda</groupId>
+        <artifactId>identity-spring-boot-starter</artifactId>
+        <version>${version.identity}</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
## Description

This work is part of the https://github.com/camunda/product-hub/issues/1849 epic.

- Adds `identity-spring-boot-starter` for auto-configuration of `Identity` bean (Identity SDK), that supports generic OpenIDC and Azure authentication
- Injects Identity authorization handling into Operate client with minimal destructivity 💥 (via proxy on operate properties class)
- Only uses Identity authorization if it is configured properly. If run with the same env variables, the current behavior should not change

Please feel free to add tests based on your test strategy
 
## Related issues

<!-- Which issues are closed by this PR or are related -->
Based on https://github.com/camunda-cloud/identity/pull/2379 (the PR in Identity has to be merged first, in order for the new helper method to be available)
Closes https://github.com/camunda-cloud/identity/issues/2341

