### PR TITLE
fix(GraphQL): GraphQL Connector bearer token does not work

### DIFF
--- a/connectors/http/graphql/element-templates/graphql-connector.json
+++ b/connectors/http/graphql/element-templates/graphql-connector.json
@@ -166,7 +166,7 @@
       "feel": "optional",
       "binding": {
         "type": "zeebe:input",
-        "name": "graphql.authentication.token"
+        "name": "authentication.token"
       },
       "constraints": {
         "notEmpty": true


### PR DESCRIPTION
## Description

- Mapping for bearer token in element template was incorrect
- Removed wrong prefix `graphql.`

<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #1482 

