### PR TITLE
fix(dockerfile): force bad username for connectors images

### DIFF
--- a/bundle/camunda-saas-bundle/Dockerfile
+++ b/bundle/camunda-saas-bundle/Dockerfile
@@ -8,8 +8,8 @@ RUN mkdir /opt/app
 COPY target/*-with-dependencies.jar /opt/app/
 
 # Create an unprivileged user / group and switch to that user
-RUN addgroup --gid 1001 1001 && useradd -g 1001 -u 1001 -M 1001
-USER 1001:1001
+RUN addgroup --gid 1003 connectors && useradd --force-badname -g connectors -u 1003 -M connectors
+USER connectors:connectors
 
 # Using entry point to allow downstream images to add JVM arguments using CMD
 ENTRYPOINT ["java", "-cp", "/opt/app/*", "io.camunda.connector.runtime.saas.SaaSConnectorRuntimeApplication"]

--- a/bundle/default-bundle/Dockerfile
+++ b/bundle/default-bundle/Dockerfile
@@ -13,7 +13,7 @@ COPY start.sh /start.sh
 RUN chmod +x start.sh
 
 # Create an unprivileged user / group and switch to that user
-RUN addgroup --gid 1001 1001 && useradd -g 1001 -u 1003 -M 1001
-USER 1001:1001
+RUN addgroup --gid 1003 connectors && useradd --force-badname -g connectors -u 1003 -M connectors
+USER connectors:connectors
 
 ENTRYPOINT ["/start.sh"]

--- a/connector-runtime/connector-runtime-application/Dockerfile
+++ b/connector-runtime/connector-runtime-application/Dockerfile
@@ -11,8 +11,8 @@ COPY target/*-with-dependencies.jar /opt/app/
 # ADD https://s01.oss.sonatype.org/content/repositories/releases/io/camunda/connector/connector-runtime-application/${VERSION}/connector-runtime-application-${VERSION}-with-dependencies.jar /opt/app/runtime.jar
 
 # Create an unprivileged user / group and switch to that user
-RUN addgroup --gid 1001 1001 && useradd -g 1001 -u 1001 -M 1001
-USER 1001:1001
+RUN addgroup --gid 1003 connectors && useradd --force-badname -g connectors -u 1003 -M connectors
+USER connectors:connectors
 
 # Use entry point to allow downstream images to add JVM arguments using CMD
 ENTRYPOINT ["/start.sh"]


### PR DESCRIPTION
## Description

Add a flag to force the required bad username in our docker images.

Dry run of the failing workflow: https://github.com/camunda/connectors/actions/runs/7103286141

