### PR TITLE
feat: openapi generator improvements

### DIFF
--- a/element-template-generator/congen-cli/README.md
+++ b/element-template-generator/congen-cli/README.md
@@ -34,6 +34,7 @@ Run `congen -h` to see the usage information and a list of available parameters.
 `congen` supports the following commands:
 - `generate` invokes the selected generator implementation and prints the generated template to the standard output.
 - `scan` invokes the generator in a dry-run mode and prints the information
+- `list` prints the list of available generators and usage information for each generator
 
 ### Examples
 

--- a/element-template-generator/congen-cli/src/main/java/io/camunda/connector/generator/cli/ReturnCodes.java
+++ b/element-template-generator/congen-cli/src/main/java/io/camunda/connector/generator/cli/ReturnCodes.java
@@ -14,16 +14,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.camunda.connector.generator.openapi;
+package io.camunda.connector.generator.cli;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonInclude.Include;
-import io.camunda.connector.generator.dsl.http.HttpOperationBuilder;
+public enum ReturnCodes {
+  SUCCESS(0),
+  GENERATION_FAILED(1),
+  INPUT_PREPARATION_FAILED(2);
 
-public record OperationParseResult(
-    String id,
-    String path,
-    boolean supported,
-    @JsonInclude(Include.NON_EMPTY) String info,
-    @JsonIgnore HttpOperationBuilder builder) {}
+  private final int code;
+
+  ReturnCodes(int code) {
+    this.code = code;
+  }
+
+  public int getCode() {
+    return code;
+  }
+}

--- a/element-template-generator/congen-cli/src/main/java/io/camunda/connector/generator/cli/command/ConGen.java
+++ b/element-template-generator/congen-cli/src/main/java/io/camunda/connector/generator/cli/command/ConGen.java
@@ -30,7 +30,7 @@ import picocli.CommandLine.Parameters;
 
 @Command(
     name = "congen",
-    subcommands = {Generate.class, Scan.class},
+    subcommands = {Generate.class, Scan.class, ListGenerators.class},
     mixinStandardHelpOptions = true,
     version = "congen 0.1",
     description = "Generate element templates for connectors")
@@ -56,9 +56,6 @@ public class ConGen {
       names = {"-e", "--element-types"},
       description = "target element types for the resulting connector")
   List<String> elementTypes;
-
-  @Parameters(index = "0", description = "name of the generator to invoke")
-  String generatorName;
 
   GeneratorConfiguration generatorConfiguration() {
     var bpmnTypes =

--- a/element-template-generator/congen-cli/src/main/java/io/camunda/connector/generator/cli/command/ConGen.java
+++ b/element-template-generator/congen-cli/src/main/java/io/camunda/connector/generator/cli/command/ConGen.java
@@ -26,7 +26,6 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
-import picocli.CommandLine.Parameters;
 
 @Command(
     name = "congen",

--- a/element-template-generator/congen-cli/src/main/java/io/camunda/connector/generator/cli/command/ListGenerators.java
+++ b/element-template-generator/congen-cli/src/main/java/io/camunda/connector/generator/cli/command/ListGenerators.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.generator.cli.command;
+
+import static io.camunda.connector.generator.cli.ReturnCodes.GENERATION_FAILED;
+import static io.camunda.connector.generator.cli.ReturnCodes.SUCCESS;
+
+import io.camunda.connector.generator.cli.GeneratorServiceLoader;
+import java.util.concurrent.Callable;
+import picocli.CommandLine.Command;
+
+@Command(name = "list")
+public class ListGenerators implements Callable<Integer> {
+
+  public Integer call() {
+    System.out.println("Available generators:");
+    try {
+      GeneratorServiceLoader.loadGenerators()
+          .forEach(
+              (key, generator) -> System.out.println(" - " + key + ", usage: " + generator.getUsage()));
+    } catch (Exception e) {
+      System.err.println("Failed to list generators: " + e.getMessage());
+      return GENERATION_FAILED.getCode();
+    }
+    return SUCCESS.getCode();
+  }
+}

--- a/element-template-generator/congen-cli/src/main/java/io/camunda/connector/generator/cli/command/ListGenerators.java
+++ b/element-template-generator/congen-cli/src/main/java/io/camunda/connector/generator/cli/command/ListGenerators.java
@@ -31,7 +31,8 @@ public class ListGenerators implements Callable<Integer> {
     try {
       GeneratorServiceLoader.loadGenerators()
           .forEach(
-              (key, generator) -> System.out.println(" - " + key + ", usage: " + generator.getUsage()));
+              (key, generator) ->
+                  System.out.println(" - " + key + ", usage: " + generator.getUsage()));
     } catch (Exception e) {
       System.err.println("Failed to list generators: " + e.getMessage());
       return GENERATION_FAILED.getCode();

--- a/element-template-generator/congen-cli/src/main/java/io/camunda/connector/generator/cli/command/Scan.java
+++ b/element-template-generator/congen-cli/src/main/java/io/camunda/connector/generator/cli/command/Scan.java
@@ -52,8 +52,7 @@ public class Scan implements Callable<Integer> {
   @Override
   public Integer call() {
     CliCompatibleTemplateGenerator<Object, ?> generator =
-        (CliCompatibleTemplateGenerator<Object, ?>)
-            Generate.loadGenerator(generatorName);
+        (CliCompatibleTemplateGenerator<Object, ?>) Generate.loadGenerator(generatorName);
     Object input;
     try {
       input = generator.prepareInput(params);

--- a/element-template-generator/core/src/main/java/io/camunda/connector/generator/api/CliCompatibleTemplateGenerator.java
+++ b/element-template-generator/core/src/main/java/io/camunda/connector/generator/api/CliCompatibleTemplateGenerator.java
@@ -31,6 +31,9 @@ public interface CliCompatibleTemplateGenerator<IN, OUT extends ElementTemplateB
    */
   IN prepareInput(List<String> parameters);
 
+  /** Provides a usage description for the generator. This description is used in the CLI help. */
+  String getUsage();
+
   /** Scan the source and do a dry run of the generation process. */
   ScanResult scan(IN input);
 

--- a/element-template-generator/core/src/main/java/io/camunda/connector/generator/dsl/OutboundElementTemplateBuilder.java
+++ b/element-template-generator/core/src/main/java/io/camunda/connector/generator/dsl/OutboundElementTemplateBuilder.java
@@ -146,7 +146,6 @@ public class OutboundElementTemplateBuilder {
     if (!isTypeAssigned()) {
       throw new IllegalStateException("type is not assigned");
     }
-    verifyUniquePropertyIds();
     return new OutboundElementTemplate(
         id,
         name,
@@ -164,6 +163,4 @@ public class OutboundElementTemplateBuilder {
     return this.properties.stream()
         .anyMatch(property -> property.binding.equals(ZeebeTaskDefinition.TYPE));
   }
-
-  private void verifyUniquePropertyIds() {}
 }

--- a/element-template-generator/http-dsl/src/main/java/io/camunda/connector/generator/dsl/http/HttpFeelBuilder.java
+++ b/element-template-generator/http-dsl/src/main/java/io/camunda/connector/generator/dsl/http/HttpFeelBuilder.java
@@ -86,7 +86,7 @@ public class HttpFeelBuilder {
   }
 
   /** Transform into a FEEL expression string */
-  String build() {
+  public String build() {
     String result = sb.toString();
     evaluateFeel(result, propertySet);
     return result;

--- a/element-template-generator/http-dsl/src/main/java/io/camunda/connector/generator/dsl/http/HttpFeelBuilder.java
+++ b/element-template-generator/http-dsl/src/main/java/io/camunda/connector/generator/dsl/http/HttpFeelBuilder.java
@@ -23,9 +23,10 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
- * Fluent API to avoid the complex string transformations when creating HTTP path FEEL expressions.
+ * Fluent API to avoid the complex string transformations when creating HTTP path or body FEEL
+ * expressions.
  */
-public class HttpPathFeelBuilder {
+public class HttpFeelBuilder {
 
   private final StringBuilder sb = new StringBuilder();
   private final Set<String> propertySet = new HashSet<>();
@@ -33,14 +34,14 @@ public class HttpPathFeelBuilder {
 
   public static final String FEEL_OPERATOR_CHARACTERS = "!=<>+-*/[]{}@ ";
 
-  private HttpPathFeelBuilder() {}
+  private HttpFeelBuilder() {}
 
-  public static HttpPathFeelBuilder create() {
-    return new HttpPathFeelBuilder();
+  public static HttpFeelBuilder create() {
+    return new HttpFeelBuilder();
   }
 
-  /** Add a constant part to the path */
-  public HttpPathFeelBuilder part(String part) {
+  /** Add a constant part to the FEEL expression */
+  public HttpFeelBuilder part(String part) {
     if (sb.isEmpty()) {
       sb.append("=");
     } else {
@@ -52,8 +53,8 @@ public class HttpPathFeelBuilder {
     return this;
   }
 
-  /** Add a variable property to the path */
-  public HttpPathFeelBuilder property(String property) {
+  /** Add a variable property to the FEEL expression */
+  public HttpFeelBuilder property(String property) {
     if (property == null || property.isEmpty()) {
       throw new IllegalArgumentException("Property must not be null or empty");
     }
@@ -73,8 +74,8 @@ public class HttpPathFeelBuilder {
     return this;
   }
 
-  /** Append a '/' slash symbol to the URL */
-  public HttpPathFeelBuilder slash() {
+  /** Append a '/' slash symbol, useful for URLs */
+  public HttpFeelBuilder slash() {
     if (sb.isEmpty()) {
       sb.append("=");
     } else {
@@ -84,7 +85,7 @@ public class HttpPathFeelBuilder {
     return this;
   }
 
-  /** Transform the constructed path into a FEEL expression string */
+  /** Transform into a FEEL expression string */
   String build() {
     String result = sb.toString();
     evaluateFeel(result, propertySet);
@@ -94,9 +95,6 @@ public class HttpPathFeelBuilder {
   static void evaluateFeel(String expression, Set<String> propertyList) {
     Map<String, String> mockPropertyContext =
         propertyList.stream().collect(Collectors.toMap(property -> property, property -> "mock"));
-    String resultingPath = feelEngineWrapper.evaluate(expression, mockPropertyContext);
-    if (!resultingPath.startsWith("/")) {
-      throw new IllegalArgumentException("Operation path must start with '/'");
-    }
+    feelEngineWrapper.evaluate(expression, mockPropertyContext);
   }
 }

--- a/element-template-generator/http-dsl/src/main/java/io/camunda/connector/generator/dsl/http/HttpOperation.java
+++ b/element-template-generator/http-dsl/src/main/java/io/camunda/connector/generator/dsl/http/HttpOperation.java
@@ -35,9 +35,9 @@ import java.util.List;
 public record HttpOperation(
     String id,
     String label,
-    HttpPathFeelBuilder pathFeelExpression,
+    HttpFeelBuilder pathFeelExpression,
     HttpMethod method,
-    String bodyFeelExpression,
+    HttpFeelBuilder bodyFeelExpression,
     Collection<HttpOperationProperty> properties,
     List<HttpAuthentication> authenticationOverride) {
 

--- a/element-template-generator/http-dsl/src/main/java/io/camunda/connector/generator/dsl/http/HttpOperationBuilder.java
+++ b/element-template-generator/http-dsl/src/main/java/io/camunda/connector/generator/dsl/http/HttpOperationBuilder.java
@@ -32,8 +32,8 @@ public class HttpOperationBuilder {
   private String id;
   private String label;
   private HttpMethod method;
-  private HttpPathFeelBuilder pathFeelExpression;
-  private String bodyExample = "";
+  private HttpFeelBuilder pathFeelExpression;
+  private HttpFeelBuilder bodyFeelExpression;
   private List<HttpAuthentication> authenticationOverride = null;
   private List<HttpOperationProperty> properties = Collections.emptyList();
 
@@ -47,7 +47,7 @@ public class HttpOperationBuilder {
         .label(operation.label())
         .method(operation.method())
         .pathFeelExpression(operation.pathFeelExpression())
-        .bodyExample(operation.bodyFeelExpression())
+        .bodyFeelExpression(operation.bodyFeelExpression())
         .authenticationOverride(operation.authenticationOverride())
         .properties(operation.properties());
   }
@@ -81,16 +81,16 @@ public class HttpOperationBuilder {
    * <p>Example: {@code = "/foo/" + bar} <br>
    * The variable {@code bar} should be present in {@link #properties(Collection)}.
    *
-   * <p>Usage of {@link HttpPathFeelBuilder} is enforced to avoid complex string transformations and
-   * to avoid errors.
+   * <p>Usage of {@link HttpFeelBuilder} is enforced to avoid complex string transformations and to
+   * avoid errors.
    */
-  public HttpOperationBuilder pathFeelExpression(HttpPathFeelBuilder builder) {
+  public HttpOperationBuilder pathFeelExpression(HttpFeelBuilder builder) {
     this.pathFeelExpression = builder;
     return this;
   }
 
-  public HttpOperationBuilder bodyExample(String bodyExample) {
-    this.bodyExample = bodyExample;
+  public HttpOperationBuilder bodyFeelExpression(HttpFeelBuilder bodyFeelExpression) {
+    this.bodyFeelExpression = bodyFeelExpression;
     return this;
   }
 
@@ -143,7 +143,13 @@ public class HttpOperationBuilder {
     }
 
     return new HttpOperation(
-        id, label, pathFeelExpression, method, bodyExample, properties, authenticationOverride);
+        id,
+        label,
+        pathFeelExpression,
+        method,
+        bodyFeelExpression,
+        properties,
+        authenticationOverride);
   }
 
   private void validate() {

--- a/element-template-generator/http-dsl/src/main/java/io/camunda/connector/generator/dsl/http/HttpOperationProperty.java
+++ b/element-template-generator/http-dsl/src/main/java/io/camunda/connector/generator/dsl/http/HttpOperationProperty.java
@@ -45,7 +45,8 @@ public record HttpOperationProperty(
   public enum Target {
     PATH,
     QUERY,
-    HEADER
+    HEADER,
+    BODY
   }
 
   public enum Type {

--- a/element-template-generator/http-dsl/src/main/java/io/camunda/connector/generator/dsl/http/PropertyUtil.java
+++ b/element-template-generator/http-dsl/src/main/java/io/camunda/connector/generator/dsl/http/PropertyUtil.java
@@ -35,6 +35,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -245,7 +246,11 @@ public class PropertyUtil {
       List<Property> transformedProperties = new ArrayList<>();
 
       for (var property : operation.properties()) {
-        var transformed = transformProperty(operation.id(), property);
+        if (property.target() == Target.BODY) {
+          // body properties are handled separately
+          continue;
+        }
+        var transformed = transformProperty(operation.id(), property, "parameters");
         if (!(transformed.getBinding() instanceof ZeebeInput binding)) {
           throw new RuntimeException(
               "Unexpected binding type: " + transformed.getBinding().getClass());
@@ -306,7 +311,7 @@ public class PropertyUtil {
         .build();
   }
 
-  private static Property transformProperty(String operationId, HttpOperationProperty property) {
+  private static Property transformProperty(String operationId, HttpOperationProperty property, String group) {
     PropertyBuilder builder =
         switch (property.type()) {
           case STRING -> StringProperty.builder().value(property.example()).feel(FeelMode.optional);
@@ -326,7 +331,7 @@ public class PropertyUtil {
         .optional(!property.required())
         .binding(new ZeebeInput(property.id()))
         .condition(new Equals(OPERATION_DISCRIMINATOR_PROPERTY_ID, operationId))
-        .group("parameters");
+        .group(group);
 
     if (property.required()) {
       builder.constraints(PropertyConstraints.builder().notEmpty(true).build());
@@ -342,15 +347,40 @@ public class PropertyUtil {
       if (!operation.method().supportsBody) {
         continue;
       }
-      properties.add(
-          StringProperty.builder()
-              .id(operation.id() + "_body")
-              .feel(FeelMode.required)
-              .group("requestBody")
-              .value(operation.bodyFeelExpression())
-              .condition(new Equals(OPERATION_DISCRIMINATOR_PROPERTY_ID, operation.id()))
-              .binding(new ZeebeInput("body"))
-              .build());
+
+      var bodyProperties = operation.properties().stream()
+          .filter(p -> p.target() == Target.BODY)
+          .map(p -> transformProperty(operation.id(), p, "requestBody"))
+          .toList();
+
+      Property bodyAggregationProperty = null;
+      if (bodyProperties.isEmpty()) {
+        bodyAggregationProperty = StringProperty.builder()
+            .id(operation.id() + "_body")
+            .feel(FeelMode.required)
+            .group("requestBody")
+            .value(
+                Optional.ofNullable(operation.bodyFeelExpression())
+                    .map(HttpFeelBuilder::build)
+                    .orElse(""))
+            .condition(new Equals(OPERATION_DISCRIMINATOR_PROPERTY_ID, operation.id()))
+            .binding(new ZeebeInput("body"))
+            .build();
+      } else {
+        bodyAggregationProperty = HiddenProperty.builder()
+            .id(operation.id() + "_$body")
+            .group("requestBody")
+            .value(
+                Optional.ofNullable(operation.bodyFeelExpression())
+                    .map(HttpFeelBuilder::build)
+                    .orElse(""))
+            .condition(new Equals(OPERATION_DISCRIMINATOR_PROPERTY_ID, operation.id()))
+            .binding(new ZeebeInput("body"))
+            .build();
+      }
+
+      properties.addAll(bodyProperties);
+      properties.add(bodyAggregationProperty);
     }
     return PropertyGroup.builder()
         .id("requestBody")

--- a/element-template-generator/http-dsl/src/main/java/io/camunda/connector/generator/dsl/http/PropertyUtil.java
+++ b/element-template-generator/http-dsl/src/main/java/io/camunda/connector/generator/dsl/http/PropertyUtil.java
@@ -311,7 +311,8 @@ public class PropertyUtil {
         .build();
   }
 
-  private static Property transformProperty(String operationId, HttpOperationProperty property, String group) {
+  private static Property transformProperty(
+      String operationId, HttpOperationProperty property, String group) {
     PropertyBuilder builder =
         switch (property.type()) {
           case STRING -> StringProperty.builder().value(property.example()).feel(FeelMode.optional);
@@ -348,35 +349,38 @@ public class PropertyUtil {
         continue;
       }
 
-      var bodyProperties = operation.properties().stream()
-          .filter(p -> p.target() == Target.BODY)
-          .map(p -> transformProperty(operation.id(), p, "requestBody"))
-          .toList();
+      var bodyProperties =
+          operation.properties().stream()
+              .filter(p -> p.target() == Target.BODY)
+              .map(p -> transformProperty(operation.id(), p, "requestBody"))
+              .toList();
 
       Property bodyAggregationProperty = null;
       if (bodyProperties.isEmpty()) {
-        bodyAggregationProperty = StringProperty.builder()
-            .id(operation.id() + "_body")
-            .feel(FeelMode.required)
-            .group("requestBody")
-            .value(
-                Optional.ofNullable(operation.bodyFeelExpression())
-                    .map(HttpFeelBuilder::build)
-                    .orElse(""))
-            .condition(new Equals(OPERATION_DISCRIMINATOR_PROPERTY_ID, operation.id()))
-            .binding(new ZeebeInput("body"))
-            .build();
+        bodyAggregationProperty =
+            StringProperty.builder()
+                .id(operation.id() + "_body")
+                .feel(FeelMode.required)
+                .group("requestBody")
+                .value(
+                    Optional.ofNullable(operation.bodyFeelExpression())
+                        .map(HttpFeelBuilder::build)
+                        .orElse(""))
+                .condition(new Equals(OPERATION_DISCRIMINATOR_PROPERTY_ID, operation.id()))
+                .binding(new ZeebeInput("body"))
+                .build();
       } else {
-        bodyAggregationProperty = HiddenProperty.builder()
-            .id(operation.id() + "_$body")
-            .group("requestBody")
-            .value(
-                Optional.ofNullable(operation.bodyFeelExpression())
-                    .map(HttpFeelBuilder::build)
-                    .orElse(""))
-            .condition(new Equals(OPERATION_DISCRIMINATOR_PROPERTY_ID, operation.id()))
-            .binding(new ZeebeInput("body"))
-            .build();
+        bodyAggregationProperty =
+            HiddenProperty.builder()
+                .id(operation.id() + "_$body")
+                .group("requestBody")
+                .value(
+                    Optional.ofNullable(operation.bodyFeelExpression())
+                        .map(HttpFeelBuilder::build)
+                        .orElse(""))
+                .condition(new Equals(OPERATION_DISCRIMINATOR_PROPERTY_ID, operation.id()))
+                .binding(new ZeebeInput("body"))
+                .build();
       }
 
       properties.addAll(bodyProperties);

--- a/element-template-generator/http-dsl/src/test/java/io/camunda/connector/generator/dsl/http/HttpFeelBuilderTest.java
+++ b/element-template-generator/http-dsl/src/test/java/io/camunda/connector/generator/dsl/http/HttpFeelBuilderTest.java
@@ -21,12 +21,12 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.junit.jupiter.api.Test;
 
-public class HttpPathFeelBuilderTest {
+public class HttpFeelBuilderTest {
 
   @Test
   void severalConstantPartsPath() {
     // when
-    String s = HttpPathFeelBuilder.create().part("/hello").part("/world").build();
+    String s = HttpFeelBuilder.create().part("/hello").part("/world").build();
 
     // then
     assertThat(s).isEqualTo("=\"/hello\"+\"/world\"");
@@ -35,7 +35,7 @@ public class HttpPathFeelBuilderTest {
   @Test
   void mixedPath() {
     // when
-    String s = HttpPathFeelBuilder.create().part("/example/").property("myProp").build();
+    String s = HttpFeelBuilder.create().part("/example/").property("myProp").build();
 
     // then
     assertThat(s).isEqualTo("=\"/example/\"+myProp");
@@ -45,7 +45,7 @@ public class HttpPathFeelBuilderTest {
   void duplicatePropertyName() {
     // when
     String s =
-        HttpPathFeelBuilder.create()
+        HttpFeelBuilder.create()
             .part("/example/")
             .property("myProp")
             .slash()
@@ -57,18 +57,12 @@ public class HttpPathFeelBuilderTest {
   }
 
   @Test
-  void invalidPath() {
-    var builder = HttpPathFeelBuilder.create().part("doesNotStartWithASlash");
-    assertThrows(IllegalArgumentException.class, builder::build);
-  }
-
-  @Test
   void feelOperatorCharacters() {
-    var builder = HttpPathFeelBuilder.create();
+    var builder = HttpFeelBuilder.create();
     var ex =
         assertThrows(
             IllegalArgumentException.class,
             () -> builder.part("/documents/").property("document-id"));
-    assertThat(ex.getMessage()).contains(HttpPathFeelBuilder.FEEL_OPERATOR_CHARACTERS);
+    assertThat(ex.getMessage()).contains(HttpFeelBuilder.FEEL_OPERATOR_CHARACTERS);
   }
 }

--- a/element-template-generator/http-dsl/src/test/java/io/camunda/connector/generator/dsl/http/HttpOutboundElementTemplateBuilderTest.java
+++ b/element-template-generator/http-dsl/src/test/java/io/camunda/connector/generator/dsl/http/HttpOutboundElementTemplateBuilderTest.java
@@ -49,8 +49,7 @@ public class HttpOutboundElementTemplateBuilderTest {
             .id("someGetRequest")
             .label("Some GET request")
             .method(HttpMethod.GET)
-            .pathFeelExpression(
-                HttpPathFeelBuilder.create().part("/examples/").property("exampleId"))
+            .pathFeelExpression(HttpFeelBuilder.create().part("/examples/").property("exampleId"))
             .properties(
                 HttpOperationProperty.createStringProperty(
                     "exampleId", Target.PATH, "Example ID", true, "42"),
@@ -215,7 +214,7 @@ public class HttpOutboundElementTemplateBuilderTest {
           .id("someGetRequest")
           .label("Some GET request")
           .method(HttpMethod.GET)
-          .pathFeelExpression(HttpPathFeelBuilder.create().part("/examples/").property("exampleId"))
+          .pathFeelExpression(HttpFeelBuilder.create().part("/examples/").property("exampleId"))
           .properties(
               HttpOperationProperty.createStringProperty(
                   "exampleId", Target.PATH, "Example ID", true, "42"),
@@ -231,7 +230,7 @@ public class HttpOutboundElementTemplateBuilderTest {
           .id("somePostRequest")
           .label("Some POST request")
           .method(HttpMethod.POST)
-          .pathFeelExpression(HttpPathFeelBuilder.create().part("/examples/").property("exampleId"))
+          .pathFeelExpression(HttpFeelBuilder.create().part("/examples/").property("exampleId"))
           .properties(
               HttpOperationProperty.createStringProperty(
                   "exampleId", Target.PATH, "Example ID", true, "42"),
@@ -374,7 +373,7 @@ public class HttpOutboundElementTemplateBuilderTest {
                   .label("Some GET request")
                   .method(HttpMethod.GET)
                   .pathFeelExpression(
-                      HttpPathFeelBuilder.create().part("/examples/").property("exampleId"))
+                      HttpFeelBuilder.create().part("/examples/").property("exampleId"))
                   .properties(
                       HttpOperationProperty.createStringProperty(
                           "exampleId", Target.PATH, "Example ID", true, "42"),

--- a/element-template-generator/openapi-parser/src/main/java/io/camunda/connector/generator/openapi/OpenApiGenerationSource.java
+++ b/element-template-generator/openapi-parser/src/main/java/io/camunda/connector/generator/openapi/OpenApiGenerationSource.java
@@ -32,8 +32,7 @@ public record OpenApiGenerationSource(
 
   public record Options(boolean rawBody) {}
 
-  static final String USAGE =
-      "openapi-outbound [openapi-file] [operation-id]... [--raw-body]";
+  static final String USAGE = "openapi-outbound [openapi-file] [operation-id]... [--raw-body]";
 
   public OpenApiGenerationSource(List<String> cliParams) {
     this(fetchOpenApi(cliParams), extractOperationIds(cliParams), extractOptions(cliParams));

--- a/element-template-generator/openapi-parser/src/main/java/io/camunda/connector/generator/openapi/util/BodyUtil.java
+++ b/element-template-generator/openapi-parser/src/main/java/io/camunda/connector/generator/openapi/util/BodyUtil.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.generator.openapi.util;
+
+import io.camunda.connector.generator.dsl.http.HttpFeelBuilder;
+import io.camunda.connector.generator.dsl.http.HttpOperationProperty;
+import io.camunda.connector.generator.dsl.http.HttpOperationProperty.Target;
+import io.camunda.connector.generator.openapi.OpenApiGenerationSource;
+import io.camunda.connector.generator.openapi.util.BodyUtil.BodyParseResult.Detailed;
+import io.camunda.connector.generator.openapi.util.BodyUtil.BodyParseResult.Raw;
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.media.Schema;
+import io.swagger.v3.oas.models.parameters.RequestBody;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+public class BodyUtil {
+
+  // ordered by priority if endpoint allows multiple
+  private static final List<String> SUPPORTED_BODY_MEDIA_TYPES =
+      List.of("application/json", "text/plain");
+
+  sealed interface BodyParseResult permits BodyParseResult.Detailed, BodyParseResult.Raw {
+
+    record Detailed(HttpFeelBuilder feelBuilder, List<HttpOperationProperty> properties)
+        implements BodyParseResult {}
+
+    record Raw(String rawBody) implements BodyParseResult {}
+  }
+
+  public static BodyParseResult parseBody(
+      RequestBody requestBody, Components components, OpenApiGenerationSource.Options options) {
+
+    if (requestBody == null) {
+      return new Raw("");
+    }
+    if (requestBody.get$ref() != null) {
+      requestBody =
+          components
+              .getRequestBodies()
+              .get(requestBody.get$ref().replace("#/components/requestBodies/", ""));
+    }
+    Schema<?> schema = null;
+    var content = requestBody.getContent();
+    for (String mediaType : SUPPORTED_BODY_MEDIA_TYPES) {
+      if (content.containsKey(mediaType)) {
+        var mt = content.get(mediaType);
+        schema = ParameterUtil.getSchemaOrFromComponents(mt.getSchema(), components);
+        break;
+      }
+    }
+    if (schema == null) {
+      throw new IllegalArgumentException(
+          "Request body must have a schema of one of the following media types: "
+              + SUPPORTED_BODY_MEDIA_TYPES);
+    }
+
+    if (options.rawBody() || isComplexSchema(schema, components)) {
+      return new Raw(buildRawBodyExample(schema, components));
+    }
+
+    try {
+      return buildDetailedBody(schema, components);
+    } catch (Exception e) {
+      return new Raw(buildRawBodyExample(schema, components));
+    }
+  }
+
+  private static Detailed buildDetailedBody(Schema<?> schema, Components components) {
+
+    var feelBuilder = HttpFeelBuilder.create();
+
+    List<HttpOperationProperty> properties = new ArrayList<>();
+
+    if (schema.getProperties() != null) {
+
+      feelBuilder.part("{");
+      var entries = schema.getProperties().entrySet().stream().toList();
+
+      for (int i = 0; i < entries.size(); i++) {
+        var entry = entries.get(i);
+        var propertySchema = ParameterUtil.getSchemaOrFromComponents(entry.getValue(), components);
+        var name = entry.getKey();
+        if ("object".equals(propertySchema.getType()) || "array".equals(propertySchema.getType())) {
+          throw new IllegalArgumentException(
+              "Complex objects are not supported in detailed request bodies");
+        }
+        var property = fromSchema(name, propertySchema, components);
+        properties.add(property);
+        feelBuilder.part(name).part(":").property(name);
+        if (i < entries.size() - 1) {
+          feelBuilder.part(",");
+        }
+      }
+      feelBuilder.part("}");
+    } else {
+      properties.add(fromSchema("body", schema, components));
+      feelBuilder.property("body");
+    }
+    return new Detailed(feelBuilder, properties);
+  }
+
+  static HttpOperationProperty fromSchema(String name, Schema<?> schema, Components components) {
+    schema = ParameterUtil.getSchemaOrFromComponents(schema, components);
+
+    if (schema.getEnum() != null) {
+      return HttpOperationProperty.createEnumProperty(
+          name, Target.BODY, schema.getDescription(), true, (List<String>) schema.getEnum());
+    } else if (schema.getType().equals("boolean")) {
+      return HttpOperationProperty.createEnumProperty(
+          name, Target.BODY, schema.getDescription(), true, Arrays.asList("true", "false"));
+    } else if (schema.getType().equals("string")
+        || schema.getType().equals("integer")
+        || schema.getType().equals("number")) {
+      return HttpOperationProperty.createStringProperty(
+          name,
+          Target.BODY,
+          schema.getDescription(),
+          true,
+          ParameterUtil.getExampleFromSchema(schema, components));
+    }
+    throw new IllegalArgumentException("Unsupported parameter type: " + schema.getType());
+  }
+
+  private static String buildRawBodyExample(Schema<?> schema, Components components) {
+    var schemaExample = ParameterUtil.getExampleFromSchema(schema, components);
+    return Optional.ofNullable(schemaExample).orElse("");
+  }
+
+  // complex objects are difficult to visually break down into fields
+  // this includes objects with nested objects, arrays, or a combination of both
+  private static boolean isComplexSchema(Schema<?> schema, Components components) {
+    schema = ParameterUtil.getSchemaOrFromComponents(schema, components);
+    if (schema == null) {
+      return false;
+    }
+    if (schema.getType().equals("array")) {
+      return isComplexSchema(schema.getItems(), components);
+    }
+    if (schema.getType().equals("object")) {
+      return schema.getProperties().values().stream()
+          .map(s -> ParameterUtil.getSchemaOrFromComponents(s, components))
+          .anyMatch(s -> "object".equals(s.getType()) || "array".equals(s.getType()));
+    }
+    return false;
+  }
+}

--- a/element-template-generator/openapi-parser/src/main/java/io/camunda/connector/generator/openapi/util/BodyUtil.java
+++ b/element-template-generator/openapi-parser/src/main/java/io/camunda/connector/generator/openapi/util/BodyUtil.java
@@ -36,7 +36,7 @@ public class BodyUtil {
   private static final List<String> SUPPORTED_BODY_MEDIA_TYPES =
       List.of("application/json", "text/plain");
 
-  sealed interface BodyParseResult permits BodyParseResult.Detailed, BodyParseResult.Raw {
+  public sealed interface BodyParseResult permits BodyParseResult.Detailed, BodyParseResult.Raw {
 
     record Detailed(HttpFeelBuilder feelBuilder, List<HttpOperationProperty> properties)
         implements BodyParseResult {}

--- a/element-template-generator/openapi-parser/src/main/java/io/camunda/connector/generator/openapi/util/SecurityUtil.java
+++ b/element-template-generator/openapi-parser/src/main/java/io/camunda/connector/generator/openapi/util/SecurityUtil.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.camunda.connector.generator.openapi;
+package io.camunda.connector.generator.openapi.util;
 
 import io.camunda.connector.generator.dsl.http.HttpAuthentication;
 import io.camunda.connector.generator.dsl.http.HttpAuthentication.NoAuth;

--- a/element-template-generator/openapi-parser/src/test/java/io/camunda/connector/generator/openapi/BodyUtilTest.java
+++ b/element-template-generator/openapi-parser/src/test/java/io/camunda/connector/generator/openapi/BodyUtilTest.java
@@ -16,14 +16,4 @@
  */
 package io.camunda.connector.generator.openapi;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonInclude.Include;
-import io.camunda.connector.generator.dsl.http.HttpOperationBuilder;
-
-public record OperationParseResult(
-    String id,
-    String path,
-    boolean supported,
-    @JsonInclude(Include.NON_EMPTY) String info,
-    @JsonIgnore HttpOperationBuilder builder) {}
+public class BodyUtilTest {}

--- a/element-template-generator/openapi-parser/src/test/java/io/camunda/connector/generator/openapi/ExampleTest.java
+++ b/element-template-generator/openapi-parser/src/test/java/io/camunda/connector/generator/openapi/ExampleTest.java
@@ -18,6 +18,7 @@ package io.camunda.connector.generator.openapi;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.connector.generator.openapi.OpenApiGenerationSource.Options;
 import io.swagger.v3.parser.OpenAPIV3Parser;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
@@ -35,7 +36,9 @@ public class ExampleTest {
     var generator = new OpenApiOutboundTemplateGenerator();
 
     // when
-    var template = generator.generate(new OpenApiGenerationSource(openApi, Set.of()), null);
+    var template =
+        generator.generate(
+            new OpenApiGenerationSource(openApi, Set.of(), new Options(false)), null);
 
     // then
     System.out.println(mapper.writeValueAsString(template));
@@ -47,7 +50,8 @@ public class ExampleTest {
     var openApi = parser.read("web-modeler-rest-api.json");
     var generator = new OpenApiOutboundTemplateGenerator();
 
-    var scanResult = generator.scan(new OpenApiGenerationSource(openApi, Set.of()));
+    var scanResult =
+        generator.scan(new OpenApiGenerationSource(openApi, Set.of(), new Options(false)));
     System.out.println(scanResult);
   }
 }

--- a/element-template-generator/openapi-parser/src/test/java/io/camunda/connector/generator/openapi/ParameterUtilTest.java
+++ b/element-template-generator/openapi-parser/src/test/java/io/camunda/connector/generator/openapi/ParameterUtilTest.java
@@ -18,6 +18,7 @@ package io.camunda.connector.generator.openapi;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.camunda.connector.generator.openapi.util.ParameterUtil;
 import io.swagger.v3.oas.models.media.Schema;
 import io.swagger.v3.oas.models.parameters.Parameter;
 import java.util.List;


### PR DESCRIPTION
## Description

- Adds `list` CLI command to output the available generators and their usage information (because it is not visible in the help page)
- Fix body example corner cases that caused the body example to remain undetected
- New body parsing mode that breaks down the body into individual fields (enabled by default for simple body objects or primitives, can be disabled with a CLI option)
- Support schemas without operation IDs (we generate our own ID in that case)

## Related issues

closes https://github.com/camunda/team-connectors/issues/549

