### PR TITLE
refactor: change dockerfile uid and gid

### DIFF
--- a/bundle/camunda-saas-bundle/Dockerfile
+++ b/bundle/camunda-saas-bundle/Dockerfile
@@ -8,8 +8,8 @@ RUN mkdir /opt/app
 COPY target/*-with-dependencies.jar /opt/app/
 
 # Create an unprivileged user / group and switch to that user
-RUN addgroup --gid 1003 connectors && useradd -g connectors -u 1003 -M connectors
-USER connectors:connectors
+RUN addgroup --gid 1001 camunda && useradd --no-create-home --gid 1001 --uid 1001 camunda
+USER 1001:1001
 
 # Using entry point to allow downstream images to add JVM arguments using CMD
 ENTRYPOINT ["java", "-cp", "/opt/app/*", "io.camunda.connector.runtime.saas.SaaSConnectorRuntimeApplication"]

--- a/bundle/default-bundle/Dockerfile
+++ b/bundle/default-bundle/Dockerfile
@@ -13,7 +13,7 @@ COPY start.sh /start.sh
 RUN chmod +x start.sh
 
 # Create an unprivileged user / group and switch to that user
-RUN addgroup --gid 1003 connectors && useradd -g connectors -u 1003 -M connectors
-USER connectors:connectors
+RUN addgroup --gid 1001 camunda && useradd --no-create-home --gid 1001 --uid 1001 camunda
+USER 1001:1001
 
 ENTRYPOINT ["/start.sh"]

--- a/connector-runtime/connector-runtime-application/Dockerfile
+++ b/connector-runtime/connector-runtime-application/Dockerfile
@@ -11,8 +11,8 @@ COPY target/*-with-dependencies.jar /opt/app/
 # ADD https://s01.oss.sonatype.org/content/repositories/releases/io/camunda/connector/connector-runtime-application/${VERSION}/connector-runtime-application-${VERSION}-with-dependencies.jar /opt/app/runtime.jar
 
 # Create an unprivileged user / group and switch to that user
-RUN addgroup --gid 1003 connectors && useradd -g connectors -u 1003 -M connectors
-USER connectors:connectors
+RUN addgroup --gid 1001 camunda && useradd --no-create-home --gid 1001 --uid 1001 camunda
+USER 1001:1001
 
 # Use entry point to allow downstream images to add JVM arguments using CMD
 ENTRYPOINT ["/start.sh"]


### PR DESCRIPTION
## Description

Using a non-numeric user and group ID in Dockerfile makes it harder to configure in K8s since it's not possible to detect if it's a root or non-root.

So we need to make that change to remove explicit config related to the user and group ID. 

**Please note that:**
- This change should be part of 8.4 and not part of 8.3.x release.
- I've also changed the GID to be the same as the UID (no particular need to have them different).
- This could be marked as a potential breaking change (it doesn't affect the app itself but the operational side like K8s).
## Related issues

Related to: https://github.com/camunda/distribution/issues/122
Fixes the wrong syntax of reverted PR: https://github.com/camunda/connectors/pull/1485