### PR TITLE
fix(rest): API key auth - do not set the key in headers when it is included in the query

### DIFF
--- a/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/auth/ApiKeyAuthentication.java
+++ b/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/auth/ApiKeyAuthentication.java
@@ -54,7 +54,9 @@ public record ApiKeyAuthentication(
 
   @Override
   public void setHeaders(final HttpHeaders headers) {
-    headers.set(name, value);
+    if (ApiKeyLocation.HEADERS == apiKeyLocation) {
+      headers.set(name, value);
+    }
   }
 
   public boolean isQueryLocationApiKeyAuthentication() {

--- a/connectors/http/rest/src/test/java/io/camunda/connector/http/rest/auth/ApiKeyAuthenticationTest.java
+++ b/connectors/http/rest/src/test/java/io/camunda/connector/http/rest/auth/ApiKeyAuthenticationTest.java
@@ -90,7 +90,7 @@ public class ApiKeyAuthenticationTest extends BaseTest {
             headersCaptor
                 .getValue()
                 .getFirstHeaderStringValue(ActualValue.Authentication.API_KEY_NAME))
-        .isEqualTo(ActualValue.Authentication.API_KEY_VALUE);
+        .isNull();
   }
 
   @ParameterizedTest(name = "Executing test case: {0}")


### PR DESCRIPTION
….

## Description

API key authentication - do not set the key in headers when it is included in the query

