### PR TITLE
ci: configure renovate to update release branches too

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,5 +8,6 @@
       "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
       "automerge": true
     }
-  ]
+  ],
+  "baseBranches": ["main", "/^release\\/.*/"]
 }


### PR DESCRIPTION
## Description

To avoid backporting version bumps, we can configure renovate to maintain all release branches by default.

