### PR TITLE
feat(generator): Enhanced nested properties support

### DIFF
--- a/connectors/automation-anywhere/src/main/java/io/camunda/connector/automationanywhere/model/request/auth/Authentication.java
+++ b/connectors/automation-anywhere/src/main/java/io/camunda/connector/automationanywhere/model/request/auth/Authentication.java
@@ -21,7 +21,7 @@ import io.camunda.connector.generator.java.annotation.TemplateDiscriminatorPrope
 @TemplateDiscriminatorProperty(
     label = "Type",
     group = "authentication",
-    name = "type",
+    name = "authentication.type",
     defaultValue = "passwordBasedAuthentication",
     description =
         "Choose the authentication type. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/automation-anywhere/\" target=\"_blank\">documentation</a>")

--- a/connectors/automation-anywhere/src/main/java/io/camunda/connector/automationanywhere/model/request/operation/OperationData.java
+++ b/connectors/automation-anywhere/src/main/java/io/camunda/connector/automationanywhere/model/request/operation/OperationData.java
@@ -15,5 +15,5 @@ import io.camunda.connector.generator.java.annotation.TemplateDiscriminatorPrope
   @JsonSubTypes.Type(value = AddWorkItemOperationData.class, name = "addWorkItemsToTheQueue"),
   @JsonSubTypes.Type(value = GetWorkItemOperationData.class, name = "listWorkItemsInQueue")
 })
-@TemplateDiscriminatorProperty(label = "Type", group = "operation", name = "type")
+@TemplateDiscriminatorProperty(label = "Type", group = "operation", name = "operation.type")
 public sealed interface OperationData permits AddWorkItemOperationData, GetWorkItemOperationData {}

--- a/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/auth/Authentication.java
+++ b/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/auth/Authentication.java
@@ -33,7 +33,7 @@ import io.camunda.connector.generator.java.annotation.TemplateDiscriminatorPrope
 @TemplateDiscriminatorProperty(
     label = "Type",
     group = "authentication",
-    name = "type",
+    name = "authentication.type",
     defaultValue = NoAuthentication.TYPE,
     description = "Choose the authentication type. Select 'None' if no authentication is necessary")
 public sealed interface Authentication

--- a/element-template-generator/core/README.md
+++ b/element-template-generator/core/README.md
@@ -112,12 +112,22 @@ The generated Element Template will contain two properties:
 
 As shown in the example, the property ID is composed of the field names of the nested properties
 separated by a dot.
-This behavior is enabled by default to prevent name clashes. You can disable it by setting
-the `addNestedPath` property
-of the `TemplateProperty` annotation to `false`, like this:
+This behavior is enabled by default to prevent name clashes. You can disable it by annotating
+the field that contains nested properties with `@NestedProperties(addNestedPath = false)`.
 
 ```java
-@TemplateProperty(addNestedPath = false)
+@NestedProperties(addNestedPath = false)
+private MyNestedInput nested;
+```
+
+This annotation also allows to apply the same condition to all nested properties of a class.
+For example, if you want to add a condition for the nested properties of the `MyNestedInput`
+class, you can annotate the field with `@NestedProperties` and define the condition there:
+
+```java
+import io.camunda.connector.generator.java.annotation.TemplateProperty.PropertyCondition;
+
+@NestedProperties(condition = @PropertyCondition(property = "someProperty", equals = "someValue"))
 private MyNestedInput nested;
 ```
 
@@ -152,6 +162,9 @@ operations are different or only partially overlapping. Another example of this 
 The Template Generator supports sealed hierarchies by default. For each sealed hierarchy, it generates
 an additional discriminator property of type `Dropdown` that gets mapped to a `type` variable in the resulting JSON.
 
+Nested sealed hierarchies are supported as well. The discriminator property is implicitly considered
+part of the nested type.
+
 The discriminator property can be configured by using the `@TemplateDiscriminatorProperty`.
 It should be placed on the class level of the sealed hierarchy root class.
 
@@ -181,9 +194,11 @@ public final class BasicAuthentication extends Authentication {
 If you are relying on Jackson to deserialize the polymorphic type, make sure to align the
 discriminator property name and subtype IDs with the Jackson configuration.
 
-Note that the [nested properties rules](#nested-properties) also apply to the discriminator property
-and the sealed variants. The discriminator property is implicitly considered part of the nested
-type.
+Note that the [nested properties rules](#nested-properties) also apply to sealed hierarchies.
+The only difference is that the discriminator property is not considered part of the nested type,
+so it will never be prefixed with the nested path.
+Therefore, **the discriminator property ID must always be unique** within the Connector input data
+model.
 
 ## Property groups
 

--- a/element-template-generator/core/src/main/java/io/camunda/connector/generator/dsl/BooleanProperty.java
+++ b/element-template-generator/core/src/main/java/io/camunda/connector/generator/dsl/BooleanProperty.java
@@ -49,7 +49,7 @@ public final class BooleanProperty extends Property {
     return new BooleanPropertyBuilder();
   }
 
-  public static final class BooleanPropertyBuilder extends PropertyBuilder {
+  public static class BooleanPropertyBuilder extends PropertyBuilder {
 
     private BooleanPropertyBuilder() {}
 

--- a/element-template-generator/core/src/main/java/io/camunda/connector/generator/dsl/DropdownProperty.java
+++ b/element-template-generator/core/src/main/java/io/camunda/connector/generator/dsl/DropdownProperty.java
@@ -61,11 +61,11 @@ public final class DropdownProperty extends Property {
     return new DropdownPropertyBuilder();
   }
 
-  public static final class DropdownPropertyBuilder extends PropertyBuilder {
+  public static class DropdownPropertyBuilder extends PropertyBuilder {
 
     private List<DropdownChoice> choices;
 
-    private DropdownPropertyBuilder() {}
+    public DropdownPropertyBuilder() {}
 
     public DropdownPropertyBuilder choices(List<DropdownChoice> choices) {
       this.choices = choices;

--- a/element-template-generator/core/src/main/java/io/camunda/connector/generator/dsl/HiddenProperty.java
+++ b/element-template-generator/core/src/main/java/io/camunda/connector/generator/dsl/HiddenProperty.java
@@ -49,7 +49,7 @@ public final class HiddenProperty extends Property {
     return new HiddenPropertyBuilder();
   }
 
-  public static final class HiddenPropertyBuilder extends PropertyBuilder {
+  public static class HiddenPropertyBuilder extends PropertyBuilder {
 
     private HiddenPropertyBuilder() {}
 

--- a/element-template-generator/core/src/main/java/io/camunda/connector/generator/dsl/PropertyBuilder.java
+++ b/element-template-generator/core/src/main/java/io/camunda/connector/generator/dsl/PropertyBuilder.java
@@ -16,19 +16,9 @@
  */
 package io.camunda.connector.generator.dsl;
 
-import io.camunda.connector.generator.dsl.BooleanProperty.BooleanPropertyBuilder;
-import io.camunda.connector.generator.dsl.DropdownProperty.DropdownPropertyBuilder;
-import io.camunda.connector.generator.dsl.HiddenProperty.HiddenPropertyBuilder;
 import io.camunda.connector.generator.dsl.Property.FeelMode;
-import io.camunda.connector.generator.dsl.StringProperty.StringPropertyBuilder;
-import io.camunda.connector.generator.dsl.TextProperty.TextPropertyBuilder;
 
-public abstract sealed class PropertyBuilder
-    permits BooleanPropertyBuilder,
-        DropdownPropertyBuilder,
-        HiddenPropertyBuilder,
-        StringPropertyBuilder,
-        TextPropertyBuilder {
+public abstract class PropertyBuilder {
 
   protected String id;
   protected String label;
@@ -50,6 +40,10 @@ public abstract sealed class PropertyBuilder
 
   public PropertyBinding getBinding() {
     return binding;
+  }
+
+  public PropertyCondition getCondition() {
+    return condition;
   }
 
   public PropertyBuilder id(String name) {

--- a/element-template-generator/core/src/main/java/io/camunda/connector/generator/dsl/StringProperty.java
+++ b/element-template-generator/core/src/main/java/io/camunda/connector/generator/dsl/StringProperty.java
@@ -49,7 +49,7 @@ public final class StringProperty extends Property {
     return new StringPropertyBuilder();
   }
 
-  public static final class StringPropertyBuilder extends PropertyBuilder {
+  public static class StringPropertyBuilder extends PropertyBuilder {
 
     private StringPropertyBuilder() {}
 

--- a/element-template-generator/core/src/main/java/io/camunda/connector/generator/dsl/TextProperty.java
+++ b/element-template-generator/core/src/main/java/io/camunda/connector/generator/dsl/TextProperty.java
@@ -49,7 +49,7 @@ public final class TextProperty extends Property {
     return new TextPropertyBuilder();
   }
 
-  public static final class TextPropertyBuilder extends PropertyBuilder {
+  public static class TextPropertyBuilder extends PropertyBuilder {
 
     private TextPropertyBuilder() {}
 

--- a/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/annotation/NestedProperties.java
+++ b/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/annotation/NestedProperties.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.generator.java.annotation;
+
+import io.camunda.connector.generator.java.annotation.TemplateProperty.PropertyCondition;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.FIELD, ElementType.RECORD_COMPONENT})
+public @interface NestedProperties {
+
+  /**
+   * Condition that will be applied to all nested properties. If the condition evaluates to false,
+   * the nested properties will not be visible in the element template.
+   */
+  PropertyCondition condition() default @PropertyCondition(property = "");
+
+  /**
+   * Whether to add the nested path to the property name. Consider the example:
+   *
+   * <pre>{@code
+   * MyNestedType foo;
+   *
+   * }</pre>
+   *
+   * where MyNestedType is defined like this:
+   *
+   * <pre>{@code
+   * record MyNestedType(String bar) {}
+   *
+   * }</pre>
+   *
+   * In the example above, if this property is set to true, the property name in the generated
+   * element template will be "foo.bar". If it is set to false, the property name will be "bar".
+   *
+   * <p>Disabling this setting can be used to define custom element template structure, overriding
+   * the default behavior of nesting properties.
+   */
+  boolean addNestedPath() default true;
+}

--- a/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/annotation/TemplateProperty.java
+++ b/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/annotation/TemplateProperty.java
@@ -77,29 +77,6 @@ public @interface TemplateProperty {
   String group() default "";
 
   /**
-   * Whether to add the nested path to the property name. Consider the example:
-   *
-   * <pre>{@code
-   * MyNestedType foo;
-   *
-   * }</pre>
-   *
-   * where MyNestedType is defined like this:
-   *
-   * <pre>{@code
-   * record MyNestedType(String bar) {}
-   *
-   * }</pre>
-   *
-   * In the example above, if this property is set to true, the property name in the generated
-   * element template will be "foo.bar". If it is set to false, the property name will be "bar".
-   *
-   * <p>Disabling this setting can be used to define custom element template structure, overriding
-   * the default behavior of nesting properties.
-   */
-  boolean addNestedPath() default true;
-
-  /**
    * Condition for the property. Conditions can reference other properties to decide whether the
    * property should be rendered by the Modeler. This field can either be an 'Equals' condition or a
    * 'One of' condition.

--- a/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/processor/TemplatePropertyFieldProcessor.java
+++ b/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/processor/TemplatePropertyFieldProcessor.java
@@ -60,6 +60,12 @@ public class TemplatePropertyFieldProcessor implements FieldProcessor {
     if (conditionAnnotation.equals().isBlank() && conditionAnnotation.oneOf().length == 0) {
       throw new IllegalStateException("InvalidCondition must have either 'equals' or 'oneOf' set");
     }
+    return transformToCondition(conditionAnnotation);
+  }
+
+  public static PropertyCondition transformToCondition(
+      TemplateProperty.PropertyCondition conditionAnnotation) {
+
     if (!conditionAnnotation.equals().isBlank()) {
       return new PropertyCondition.Equals(
           conditionAnnotation.property(), conditionAnnotation.equals());

--- a/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/util/DiscriminatorPropertyBuilder.java
+++ b/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/util/DiscriminatorPropertyBuilder.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.generator.java.util;
+
+import io.camunda.connector.generator.dsl.DropdownProperty.DropdownPropertyBuilder;
+
+/**
+ * Marker class for the template generator to know that this property is a discriminator property.
+ */
+public class DiscriminatorPropertyBuilder extends DropdownPropertyBuilder {}


### PR DESCRIPTION
## Description

This PR introduces enhanced nested properties features for the annotation-based element template generator.

### 1. Support nested sealed hierarchies

Previously it was impossible to wrap sealed hierarchies into sealed hierarchy subtypes. The new solution changes the way discriminator property IDs are treated by the generator: 

### 2. `@NestedProperties` annotation with support for bulk condition.

`@TemplateProperty` annotation was previously used to configure the `addNestedPath` feature (deciding whether path would be prefixed for nested properties). This was semantically incorrect: nested property containers are technically not properties, besides it was confusing that all the other fields of `@TemplateProperty`, like `id` or `label`, didn't cause any effects on the generated template.

The new approach utilizes a special annotation called `NestedProperties` that allows to configure only those options that can be applied to nested hierarchies. To accomodate the request from @jonathanlukas, bulk condition support has also been added to this annotation.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #1497 

