### PR TITLE
fix: openapi generator bugfixes + feel builder refactoring

### DIFF
--- a/element-template-generator/congen-cli/README.md
+++ b/element-template-generator/congen-cli/README.md
@@ -41,7 +41,7 @@ Run `congen -h` to see the usage information and a list of available parameters.
 The following command will invoke the generator named `openapi-outbound` and pass the specified OpenAPI specification.
 
 ```shell
-congen openapi-outbound generate https://petstore3.swagger.io/api/v3/openapi.json
+congen generate openapi-outbound https://petstore3.swagger.io/api/v3/openapi.json
 ```
 
 Note that `congen` will pass all parameters specified after the command name to the generator implementation.
@@ -51,11 +51,14 @@ followed by an optional list of operation IDs to include in the generated templa
 The following command will ask the generator to include only the `findPetsById` and `addPet` operations.
 
 ```shell
-congen openapi-outbound generate https://petstore3.swagger.io/api/v3/openapi.json findPetsById addPet
+congen generate openapi-outbound https://petstore3.swagger.io/api/v3/openapi.json findPetsById addPet
 ```
 
 The command below will generate the template with the custom element template ID.
 
 ```shell
-congen --id my-element-template openapi-outbound generate https://petstore3.swagger.io/api/v3/openapi.json
+congen --id my-element-template generate openapi-outbound https://petstore3.swagger.io/api/v3/openapi.json
 ```
+
+Refer to the [OpenAPI generator documentation](../openapi-parser/README.md) for more information on
+how to use it.

--- a/element-template-generator/congen-cli/src/main/java/io/camunda/connector/generator/cli/Main.java
+++ b/element-template-generator/congen-cli/src/main/java/io/camunda/connector/generator/cli/Main.java
@@ -22,7 +22,8 @@ import picocli.CommandLine;
 public class Main {
 
   public static void main(String... args) {
-    int exitCode = new CommandLine(new ConGen()).execute(args);
+    int exitCode =
+        new CommandLine(new ConGen()).setUnmatchedOptionsArePositionalParams(true).execute(args);
     System.exit(exitCode);
   }
 }

--- a/element-template-generator/http-dsl/src/test/java/io/camunda/connector/generator/dsl/http/HttpFeelBuilderTest.java
+++ b/element-template-generator/http-dsl/src/test/java/io/camunda/connector/generator/dsl/http/HttpFeelBuilderTest.java
@@ -26,7 +26,7 @@ public class HttpFeelBuilderTest {
   @Test
   void severalConstantPartsPath() {
     // when
-    String s = HttpFeelBuilder.create().part("/hello").part("/world").build();
+    String s = HttpFeelBuilder.string().part("/hello").part("/world").build();
 
     // then
     assertThat(s).isEqualTo("=\"/hello\"+\"/world\"");
@@ -35,7 +35,7 @@ public class HttpFeelBuilderTest {
   @Test
   void mixedPath() {
     // when
-    String s = HttpFeelBuilder.create().part("/example/").property("myProp").build();
+    String s = HttpFeelBuilder.string().part("/example/").property("myProp").build();
 
     // then
     assertThat(s).isEqualTo("=\"/example/\"+myProp");
@@ -45,7 +45,7 @@ public class HttpFeelBuilderTest {
   void duplicatePropertyName() {
     // when
     String s =
-        HttpFeelBuilder.create()
+        HttpFeelBuilder.string()
             .part("/example/")
             .property("myProp")
             .slash()
@@ -58,7 +58,7 @@ public class HttpFeelBuilderTest {
 
   @Test
   void feelOperatorCharacters() {
-    var builder = HttpFeelBuilder.create();
+    var builder = HttpFeelBuilder.string();
     var ex =
         assertThrows(
             IllegalArgumentException.class,

--- a/element-template-generator/http-dsl/src/test/java/io/camunda/connector/generator/dsl/http/HttpOutboundElementTemplateBuilderTest.java
+++ b/element-template-generator/http-dsl/src/test/java/io/camunda/connector/generator/dsl/http/HttpOutboundElementTemplateBuilderTest.java
@@ -49,7 +49,7 @@ public class HttpOutboundElementTemplateBuilderTest {
             .id("someGetRequest")
             .label("Some GET request")
             .method(HttpMethod.GET)
-            .pathFeelExpression(HttpFeelBuilder.create().part("/examples/").property("exampleId"))
+            .pathFeelExpression(HttpFeelBuilder.string().part("/examples/").property("exampleId"))
             .properties(
                 HttpOperationProperty.createStringProperty(
                     "exampleId", Target.PATH, "Example ID", true, "42"),
@@ -214,7 +214,7 @@ public class HttpOutboundElementTemplateBuilderTest {
           .id("someGetRequest")
           .label("Some GET request")
           .method(HttpMethod.GET)
-          .pathFeelExpression(HttpFeelBuilder.create().part("/examples/").property("exampleId"))
+          .pathFeelExpression(HttpFeelBuilder.string().part("/examples/").property("exampleId"))
           .properties(
               HttpOperationProperty.createStringProperty(
                   "exampleId", Target.PATH, "Example ID", true, "42"),
@@ -230,7 +230,7 @@ public class HttpOutboundElementTemplateBuilderTest {
           .id("somePostRequest")
           .label("Some POST request")
           .method(HttpMethod.POST)
-          .pathFeelExpression(HttpFeelBuilder.create().part("/examples/").property("exampleId"))
+          .pathFeelExpression(HttpFeelBuilder.string().part("/examples/").property("exampleId"))
           .properties(
               HttpOperationProperty.createStringProperty(
                   "exampleId", Target.PATH, "Example ID", true, "42"),
@@ -373,7 +373,7 @@ public class HttpOutboundElementTemplateBuilderTest {
                   .label("Some GET request")
                   .method(HttpMethod.GET)
                   .pathFeelExpression(
-                      HttpFeelBuilder.create().part("/examples/").property("exampleId"))
+                      HttpFeelBuilder.string().part("/examples/").property("exampleId"))
                   .properties(
                       HttpOperationProperty.createStringProperty(
                           "exampleId", Target.PATH, "Example ID", true, "42"),

--- a/element-template-generator/openapi-parser/README.md
+++ b/element-template-generator/openapi-parser/README.md
@@ -1,0 +1,56 @@
+# OpenAPI parser for [`congen`](../congen-cli/README.md)
+
+The OpenAPI parser is a generator implementation for [`congen`](../congen-cli/README.md) that generates
+connector templates from OpenAPI specifications.
+
+## Usage
+
+The generator accepts the path or URL of the OpenAPI specification as the first parameter,
+followed by an optional list of operation IDs to include in the generated template.
+
+The following command will ask the generator to include only the `listPets` operation.
+
+```shell
+congen generate openapi-outbound https://raw.githubusercontent.com/OAI/OpenAPI-Specification/main/examples/v3.0/petstore.json listPets
+```
+
+Use the options provided by `congen` to customize the generated template.
+For example, the following command will generate the template with the custom element template ID.
+
+```shell
+congen --id my-element-template generate openapi-outbound https://raw.githubusercontent.com/OAI/OpenAPI-Specification/main/examples/v3.0/petstore.json
+```
+
+Refer to the [congen documentation](../congen-cli/README.md) for more information on the available options.
+
+### Body example generation
+
+By default, the generator will try to break down the request payload into individual fields.
+This makes it easier to work with the payload in the BPMN modeler. For complex payloads,
+the generator will generate a single field for the whole request payload and prefill it with an example value.
+
+You can force the generator to generate a single field for the whole request payload by using the `--raw-body` option.
+Note that this is not a standard option of `congen` and is only supported by the OpenAPI generator.
+Add it after all other inputs.
+
+```shell
+congen generate openapi-outbound https://raw.githubusercontent.com/OAI/OpenAPI-Specification/main/examples/v3.0/petstore.json --raw-body
+```
+
+## Known limitations
+
+The OpenAPI parser currently supports only OpenAPI 3.0 specifications.
+
+Only the following authentication methods from the OpenAPI specification are supported:
+
+- HTTP Basic authentication
+- HTTP Bearer authentication
+- OAuth 2.0 with the `client_credentials` grant type
+- No authentication
+
+Only the following content types are supported for request and response payloads:
+
+- `application/json`
+- `text/plain`
+
+The generator will ignore operations that have unsupported content types or authentication methods.

--- a/element-template-generator/openapi-parser/src/main/java/io/camunda/connector/generator/openapi/util/BodyUtil.java
+++ b/element-template-generator/openapi-parser/src/main/java/io/camunda/connector/generator/openapi/util/BodyUtil.java
@@ -84,17 +84,16 @@ public class BodyUtil {
 
   private static Detailed buildDetailedBody(Schema<?> schema, Components components) {
 
-    var feelBuilder = HttpFeelBuilder.create();
+    HttpFeelBuilder feelBuilder = null;
 
     List<HttpOperationProperty> properties = new ArrayList<>();
 
     if (schema.getProperties() != null) {
+      var contextBuilder = HttpFeelBuilder.context();
 
-      feelBuilder.part("{");
       var entries = schema.getProperties().entrySet().stream().toList();
 
-      for (int i = 0; i < entries.size(); i++) {
-        var entry = entries.get(i);
+      for (java.util.Map.Entry<String, Schema> entry : entries) {
         var propertySchema = ParameterUtil.getSchemaOrFromComponents(entry.getValue(), components);
         var name = entry.getKey();
         if ("object".equals(propertySchema.getType()) || "array".equals(propertySchema.getType())) {
@@ -103,15 +102,12 @@ public class BodyUtil {
         }
         var property = fromSchema(name, propertySchema, components);
         properties.add(property);
-        feelBuilder.part(name).part(":").property(name);
-        if (i < entries.size() - 1) {
-          feelBuilder.part(",");
-        }
+        contextBuilder.property(name, property.id());
+        feelBuilder = contextBuilder;
       }
-      feelBuilder.part("}");
     } else {
       properties.add(fromSchema("body", schema, components));
-      feelBuilder.property("body");
+      feelBuilder = HttpFeelBuilder.string().property("body");
     }
     return new Detailed(feelBuilder, properties);
   }

--- a/element-template-generator/openapi-parser/src/main/java/io/camunda/connector/generator/openapi/util/OperationUtil.java
+++ b/element-template-generator/openapi-parser/src/main/java/io/camunda/connector/generator/openapi/util/OperationUtil.java
@@ -141,7 +141,7 @@ public class OperationUtil {
       HttpFeelBuilder bodyFeelExpression = null;
 
       if (body instanceof BodyParseResult.Raw raw) {
-        bodyFeelExpression = HttpFeelBuilder.create().part(raw.rawBody());
+        bodyFeelExpression = HttpFeelBuilder.preFormatted("=" + raw.rawBody());
       } else {
         bodyFeelExpression = ((BodyParseResult.Detailed) body).feelBuilder();
         properties.addAll(((BodyParseResult.Detailed) body).properties());
@@ -165,7 +165,7 @@ public class OperationUtil {
   private static HttpFeelBuilder extractPath(String rawPath) {
     // split path into parts, each part is either a variable or a constant
     String[] pathParts = rawPath.split("\\{");
-    var builder = HttpFeelBuilder.create();
+    var builder = HttpFeelBuilder.string();
     if (pathParts.length == 1) {
       // no variables
       builder.part(rawPath);

--- a/element-template-generator/openapi-parser/src/test/java/io/camunda/connector/generator/openapi/BodyUtilTest.java
+++ b/element-template-generator/openapi-parser/src/test/java/io/camunda/connector/generator/openapi/BodyUtilTest.java
@@ -94,7 +94,7 @@ public class BodyUtilTest {
     // then
     assertThat(result).isInstanceOf(BodyUtil.BodyParseResult.Detailed.class);
     var detailedResult = (BodyUtil.BodyParseResult.Detailed) result;
-    assertThat(detailedResult.feelBuilder().build()).isEqualTo("=\"{\"+\"foo\"+\":\"+foo+\"}\"");
+    assertThat(detailedResult.feelBuilder().build()).isEqualTo("={foo:foo}");
     assertThat(detailedResult.properties()).hasSize(1);
     assertThat(detailedResult.properties().get(0).id()).isEqualTo("foo");
     assertThat(detailedResult.properties().get(0).target())


### PR DESCRIPTION
## Description

- `congen` was not configured to pass the unmatched properties to the generator
- `HttpFeelBuilder` did not support FEEL context expressions properly (only strings, which didn't work for complex body examples)


