### PR TITLE
fix: support multiple security schemas in openapi security requirements

### DIFF
--- a/element-template-generator/http-dsl/src/main/java/io/camunda/connector/generator/dsl/http/PropertyUtil.java
+++ b/element-template-generator/http-dsl/src/main/java/io/camunda/connector/generator/dsl/http/PropertyUtil.java
@@ -146,7 +146,8 @@ public class PropertyUtil {
 
     var operationsWithoutCustomAuth =
         operations.stream()
-            .filter(op -> op.authenticationOverride() == null)
+            .filter(
+                op -> op.authenticationOverride() == null || op.authenticationOverride().isEmpty())
             .map(HttpOperation::id)
             .toList();
 

--- a/element-template-generator/openapi-parser/src/main/java/io/camunda/connector/generator/openapi/util/ParameterUtil.java
+++ b/element-template-generator/openapi-parser/src/main/java/io/camunda/connector/generator/openapi/util/ParameterUtil.java
@@ -162,7 +162,7 @@ public class ParameterUtil {
         return nested;
       }
       case "array" -> {
-        var items = schema.getItems();
+        var items = getSchemaOrFromComponents(schema.getItems(), components);
         if (items.getEnum() != null && !items.getEnum().isEmpty()) {
           return items.getEnum();
         }

--- a/element-template-generator/openapi-parser/src/main/java/io/camunda/connector/generator/openapi/util/SecurityUtil.java
+++ b/element-template-generator/openapi-parser/src/main/java/io/camunda/connector/generator/openapi/util/SecurityUtil.java
@@ -54,13 +54,6 @@ public class SecurityUtil {
               }
               return true;
             })
-        .peek(
-            s -> {
-              if (s.size() > 1) {
-                throw new IllegalArgumentException(
-                    "Only one SecurityScheme per SecurityRequirement object is supported");
-              }
-            })
         .flatMap(s -> s.entrySet().stream())
         .map(
             schemeRef -> {


### PR DESCRIPTION
## Description

This came up while checking our OpenAPI generator against Tasklist API.

- Multiple security schemes per security requirements were considered invalid (for no reason)
- Array json schemas were ignored if provided in `components` rather than directly inside parent schema.
- Authentication condition was invalid for parent authentication applied to the whole API


