### PR TITLE
feat(correlation): Webhooks now have access to the correlation result…

### DIFF
--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/correlation/InboundCorrelationHandler.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/correlation/InboundCorrelationHandler.java
@@ -21,8 +21,8 @@ import io.camunda.connector.api.error.ConnectorInputException;
 import io.camunda.connector.api.inbound.CorrelationResult;
 import io.camunda.connector.api.inbound.CorrelationResult.Failure;
 import io.camunda.connector.api.inbound.CorrelationResult.Failure.ActivationConditionNotMet;
-import io.camunda.connector.api.inbound.CorrelationResult.Failure.MessageAlreadyCorrelated;
 import io.camunda.connector.api.inbound.CorrelationResult.Failure.Other;
+import io.camunda.connector.api.inbound.CorrelationResult.Success.MessageAlreadyCorrelated;
 import io.camunda.connector.feel.FeelEngineWrapper;
 import io.camunda.connector.feel.FeelEngineWrapperException;
 import io.camunda.connector.runtime.core.ConnectorHelper;
@@ -214,10 +214,10 @@ public class InboundCorrelationHandler {
           new CorrelationResult.Success.MessagePublished(
               response.getMessageKey(), response.getTenantId());
     } catch (ClientStatusException ex) {
-      LOG.info("Failed to publish message: ", ex);
       if (Status.ALREADY_EXISTS.equals(ex.getStatus())) {
         result = MessageAlreadyCorrelated.INSTANCE;
       } else {
+        LOG.info("Failed to publish message: ", ex);
         result =
             new CorrelationResult.Failure.ZeebeClientStatus(
                 ex.getStatus().getCode().name(), ex.getMessage());

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/inbound/correlation/InboundCorrelationHandlerTest.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/inbound/correlation/InboundCorrelationHandlerTest.java
@@ -175,7 +175,7 @@ public class InboundCorrelationHandlerTest {
       verify(zeebeClient).newPublishMessageCommand();
       verifyNoMoreInteractions(zeebeClient);
 
-      assertThat(result).isInstanceOf(Failure.MessageAlreadyCorrelated.class);
+      assertThat(result).isInstanceOf(Success.MessageAlreadyCorrelated.class);
     }
   }
 

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/inbound/correlation/InboundCorrelationHandlerTest.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/inbound/correlation/InboundCorrelationHandlerTest.java
@@ -265,7 +265,7 @@ public class InboundCorrelationHandlerTest {
 
       // then
       verify(zeebeClient).newCreateInstanceCommand();
-      assertThat(result).isEqualTo(Success.INSTANCE);
+      assertThat(result).isInstanceOf(Success.ProcessInstanceCreated.class);
     }
 
     @Test
@@ -286,7 +286,7 @@ public class InboundCorrelationHandlerTest {
 
       // then
       verify(zeebeClient).newCreateInstanceCommand();
-      assertThat(result).isEqualTo(Success.INSTANCE);
+      assertThat(result).isInstanceOf(Success.ProcessInstanceCreated.class);
     }
 
     @Test
@@ -307,7 +307,7 @@ public class InboundCorrelationHandlerTest {
 
       // then
       verify(zeebeClient).newCreateInstanceCommand();
-      assertThat(result).isEqualTo(Success.INSTANCE);
+      assertThat(result).isInstanceOf(Success.ProcessInstanceCreated.class);
     }
 
     @Test
@@ -345,7 +345,7 @@ public class InboundCorrelationHandlerTest {
 
       // then
       verify(zeebeClient).newPublishMessageCommand();
-      assertThat(result).isEqualTo(Success.INSTANCE);
+      assertThat(result).isInstanceOf(Success.MessagePublished.class);
     }
 
     @Test
@@ -367,7 +367,7 @@ public class InboundCorrelationHandlerTest {
 
       // then
       verify(zeebeClient).newPublishMessageCommand();
-      assertThat(result).isEqualTo(Success.INSTANCE);
+      assertThat(result).isInstanceOf(Success.MessagePublished.class);
     }
 
     @Test
@@ -389,7 +389,7 @@ public class InboundCorrelationHandlerTest {
 
       // then
       verify(zeebeClient).newPublishMessageCommand();
-      assertThat(result).isEqualTo(Success.INSTANCE);
+      assertThat(result).isInstanceOf(Success.MessagePublished.class);
     }
   }
 

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/webhook/InboundWebhookRestController.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/webhook/InboundWebhookRestController.java
@@ -142,16 +142,23 @@ public class InboundWebhookRestController {
       response = buildSuccessfulResponse(webhookResult, success);
     } else {
       if (correlationResult instanceof CorrelationResult.Failure failure) {
-        if (failure instanceof CorrelationResult.Failure.MessageAlreadyCorrelated) {
-          response = buildSuccessfulResponse(webhookResult, null);
-        } else if (failure instanceof CorrelationResult.Failure.ActivationConditionNotMet) {
-          response = buildSuccessfulResponse(webhookResult, null);
-        } else {
-          response = buildErrorResponse(failure);
-        }
+        response = buildResponse(webhookResult, failure);
       } else {
         throw new IllegalStateException("Illegal correlation result : " + correlationResult);
       }
+    }
+    return response;
+  }
+
+  private ResponseEntity<?> buildResponse(
+      WebhookResult webhookResult, CorrelationResult.Failure failure) {
+    ResponseEntity<?> response;
+    if (failure instanceof CorrelationResult.Failure.MessageAlreadyCorrelated) {
+      response = buildSuccessfulResponse(webhookResult, null);
+    } else if (failure instanceof CorrelationResult.Failure.ActivationConditionNotMet) {
+      response = buildSuccessfulResponse(webhookResult, null);
+    } else {
+      response = buildErrorResponse(failure);
     }
     return response;
   }

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/inbound/WebhookControllerTestZeebeTests.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/inbound/WebhookControllerTestZeebeTests.java
@@ -221,7 +221,7 @@ class WebhookControllerTestZeebeTests {
 
     var correlationHandlerMock = mock(InboundCorrelationHandler.class);
     when(correlationHandlerMock.correlate(any(), any()))
-        .thenReturn(new CorrelationResult.Failure.MessageAlreadyCorrelated());
+        .thenReturn(new CorrelationResult.Success.MessageAlreadyCorrelated());
 
     var webhookDef = webhookDefinition("nonExistingProcess", 1, "myPath");
     var webhookContext =

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/inbound/WebhookControllerTestZeebeTests.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/inbound/WebhookControllerTestZeebeTests.java
@@ -34,6 +34,7 @@ import io.camunda.connector.api.inbound.webhook.WebhookConnectorExecutable;
 import io.camunda.connector.api.inbound.webhook.WebhookHttpResponse;
 import io.camunda.connector.api.inbound.webhook.WebhookProcessingPayload;
 import io.camunda.connector.api.inbound.webhook.WebhookResult;
+import io.camunda.connector.api.inbound.webhook.WebhookResultContext;
 import io.camunda.connector.feel.FeelEngineWrapperException;
 import io.camunda.connector.runtime.app.TestConnectorRuntimeApplication;
 import io.camunda.connector.runtime.core.inbound.InboundConnectorContextImpl;
@@ -89,7 +90,6 @@ class WebhookControllerTestZeebeTests {
   }
 
   @Test
-  @SuppressWarnings("unchecked")
   public void testSuccessfulProcessingWithActivation() throws Exception {
     WebhookConnectorExecutable webhookConnectorExecutable = mock(WebhookConnectorExecutable.class);
     WebhookResult webhookResult = mock(WebhookResult.class);
@@ -171,7 +171,6 @@ class WebhookControllerTestZeebeTests {
   }
 
   @Test
-  @SuppressWarnings("unchecked")
   public void testSuccessfulProcessingWithFailedActivation() throws Exception {
     WebhookConnectorExecutable webhookConnectorExecutable = mock(WebhookConnectorExecutable.class);
     WebhookResult webhookResult = mock(WebhookResult.class);
@@ -183,6 +182,46 @@ class WebhookControllerTestZeebeTests {
     var correlationHandlerMock = mock(InboundCorrelationHandler.class);
     when(correlationHandlerMock.correlate(any(), any()))
         .thenReturn(new CorrelationResult.Failure.ActivationConditionNotMet());
+
+    var webhookDef = webhookDefinition("nonExistingProcess", 1, "myPath");
+    var webhookContext =
+        new InboundConnectorContextImpl(
+            secretProvider,
+            v -> {},
+            webhookDef,
+            correlationHandlerMock,
+            (e) -> {},
+            mapper,
+            EvictingQueue.create(10));
+
+    // Register webhook function 'implementation'
+    webhookConnectorRegistry.register(
+        new ActiveInboundConnector(webhookConnectorExecutable, webhookContext));
+
+    ResponseEntity<?> responseEntity =
+        controller.inbound(
+            "myPath",
+            new HashMap<>(),
+            "{}".getBytes(),
+            new HashMap<>(),
+            new MockHttpServletRequest());
+
+    assertEquals(200, responseEntity.getStatusCode().value());
+    assertNotNull(responseEntity.getBody());
+  }
+
+  @Test
+  public void testSuccessfulProcessingWithDuplicateMessage() throws Exception {
+    WebhookConnectorExecutable webhookConnectorExecutable = mock(WebhookConnectorExecutable.class);
+    WebhookResult webhookResult = mock(WebhookResult.class);
+    when(webhookResult.request()).thenReturn(new MappedHttpRequest(Map.of(), Map.of(), Map.of()));
+    when(webhookResult.responseBodyExpression()).thenReturn((WebhookResultContext) -> Map.of());
+    when(webhookConnectorExecutable.triggerWebhook(any(WebhookProcessingPayload.class)))
+        .thenReturn(webhookResult);
+
+    var correlationHandlerMock = mock(InboundCorrelationHandler.class);
+    when(correlationHandlerMock.correlate(any(), any()))
+        .thenReturn(new CorrelationResult.Failure.MessageAlreadyCorrelated());
 
     var webhookDef = webhookDefinition("nonExistingProcess", 1, "myPath");
     var webhookContext =
@@ -404,11 +443,57 @@ class WebhookControllerTestZeebeTests {
                 new MockHttpServletRequest());
 
     assertEquals(201, responseEntity.getStatusCode().value());
-    assertEquals(null, responseEntity.getBody().get("keyResponse"));
+    assertNull(responseEntity.getBody().get("keyResponse"));
     assertEquals("GOOD", responseEntity.getBody().get("result"));
 
     var result = responseEntity.getBody();
     assertInstanceOf(Map.class, result);
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void testSuccessfulProcessingWithResponseBodyExpression() throws Exception {
+    var webhookConnectorExecutable = mock(WebhookConnectorExecutable.class);
+
+    var correlationHandlerMock = mock(InboundCorrelationHandler.class);
+    when(correlationHandlerMock.correlate(any(), any()))
+        .thenReturn(new CorrelationResult.Success.ProcessInstanceCreated(1L, "test"));
+
+    WebhookResult webhookResult = mock(WebhookResult.class);
+    when(webhookResult.request()).thenReturn(new MappedHttpRequest(Map.of(), Map.of(), Map.of()));
+    when(webhookResult.responseBodyExpression()).thenReturn((WebhookResultContext::correlation));
+    when(webhookConnectorExecutable.triggerWebhook(any(WebhookProcessingPayload.class)))
+        .thenReturn(webhookResult);
+
+    var webhookDef = webhookDefinition("processA", 1, "myPath");
+    var webhookContext =
+        new InboundConnectorContextImpl(
+            secretProvider,
+            v -> {},
+            webhookDef,
+            correlationHandlerMock,
+            (e) -> {},
+            mapper,
+            EvictingQueue.create(10));
+
+    // Register webhook function 'implementation'
+    webhookConnectorRegistry.register(
+        new ActiveInboundConnector(webhookConnectorExecutable, webhookContext));
+
+    deployProcess("processA");
+
+    ResponseEntity<CorrelationResult.Success.ProcessInstanceCreated> responseEntity =
+        (ResponseEntity<CorrelationResult.Success.ProcessInstanceCreated>)
+            controller.inbound(
+                "myPath",
+                new HashMap<>(),
+                "{}".getBytes(),
+                new HashMap<>(),
+                new MockHttpServletRequest());
+
+    assertEquals(200, responseEntity.getStatusCode().value());
+    assertEquals(1L, responseEntity.getBody().processInstanceKey());
+    assertEquals("test", responseEntity.getBody().tenantId());
   }
 
   public void deployProcess(String bpmnProcessId) {

--- a/connector-sdk/core/src/main/java/io/camunda/connector/api/inbound/CorrelationResult.java
+++ b/connector-sdk/core/src/main/java/io/camunda/connector/api/inbound/CorrelationResult.java
@@ -22,6 +22,10 @@ public sealed interface CorrelationResult {
     record ProcessInstanceCreated(Long processInstanceKey, String tenantId) implements Success {}
 
     record MessagePublished(Long messageKey, String tenantId) implements Success {}
+
+    record MessageAlreadyCorrelated() implements Success {
+      public static final MessageAlreadyCorrelated INSTANCE = new MessageAlreadyCorrelated();
+    }
   }
 
   sealed interface Failure extends CorrelationResult {
@@ -41,10 +45,6 @@ public sealed interface CorrelationResult {
       public boolean isRetryable() {
         return true;
       }
-    }
-
-    record MessageAlreadyCorrelated() implements Failure {
-      public static final MessageAlreadyCorrelated INSTANCE = new MessageAlreadyCorrelated();
     }
 
     record Other(Throwable error) implements Failure {

--- a/connector-sdk/core/src/main/java/io/camunda/connector/api/inbound/CorrelationResult.java
+++ b/connector-sdk/core/src/main/java/io/camunda/connector/api/inbound/CorrelationResult.java
@@ -18,9 +18,10 @@ package io.camunda.connector.api.inbound;
 
 public sealed interface CorrelationResult {
 
-  final class Success implements CorrelationResult {
+  sealed interface Success extends CorrelationResult {
+    record ProcessInstanceCreated(Long processInstanceKey, String tenantId) implements Success {}
 
-    public static final Success INSTANCE = new Success();
+    record MessagePublished(Long messageKey, String tenantId) implements Success {}
   }
 
   sealed interface Failure extends CorrelationResult {

--- a/connector-sdk/core/src/main/java/io/camunda/connector/api/inbound/webhook/WebhookResultContext.java
+++ b/connector-sdk/core/src/main/java/io/camunda/connector/api/inbound/webhook/WebhookResultContext.java
@@ -19,4 +19,4 @@ package io.camunda.connector.api.inbound.webhook;
 import java.util.Map;
 
 public record WebhookResultContext(
-    MappedHttpRequest request, Map<String, Object> connectorData, @Deprecated Object correlation) {}
+    MappedHttpRequest request, Map<String, Object> connectorData, Object correlation) {}

--- a/connector-sdk/test/src/main/java/io/camunda/connector/test/inbound/InboundConnectorContextBuilder.java
+++ b/connector-sdk/test/src/main/java/io/camunda/connector/test/inbound/InboundConnectorContextBuilder.java
@@ -222,7 +222,7 @@ public class InboundConnectorContextBuilder {
     @Override
     public CorrelationResult correlateWithResult(Object variables) {
       correlate(variables);
-      return Objects.requireNonNullElse(result, Success.INSTANCE);
+      return Objects.requireNonNullElse(result, new Success.ProcessInstanceCreated(1L, "test"));
     }
 
     @Override


### PR DESCRIPTION
… in the response body expression

## Description

Provide access to the correlation result in the response body expression of the webhook connector.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #1578

