### PR TITLE
fix: remove length constraints on Google Sheets element template fields

### DIFF
--- a/connectors/google/google-sheets/element-templates/google-sheets-connector.json
+++ b/connectors/google/google-sheets/element-templates/google-sheets-connector.json
@@ -316,8 +316,7 @@
         "name": "operation.worksheetName"
       },
       "constraints": {
-        "notEmpty": false,
-        "maxLength": 100
+        "notEmpty": false
       },
       "condition": {
         "property": "operationType",

--- a/connectors/google/google-sheets/element-templates/google-sheets-connector.json
+++ b/connectors/google/google-sheets/element-templates/google-sheets-connector.json
@@ -516,7 +516,6 @@
       },
       "constraints": {
         "notEmpty": false,
-        "maxLength": 100,
         "pattern": {
           "value": "^([0-9]*$)",
           "message": "Must be a number."
@@ -540,7 +539,6 @@
       },
       "constraints": {
         "notEmpty": false,
-        "maxLength": 100,
         "pattern": {
           "value": "^([0-9]*$)",
           "message": "Must be a number."

--- a/connectors/google/google-sheets/element-templates/google-sheets-connector.json
+++ b/connectors/google/google-sheets/element-templates/google-sheets-connector.json
@@ -245,8 +245,7 @@
         "name": "operation.spreadsheetName"
       },
       "constraints": {
-        "notEmpty": true,
-        "maxLength": 255
+        "notEmpty": true
       },
       "condition": {
         "property": "operationType",

--- a/connectors/google/google-sheets/element-templates/google-sheets-connector.json
+++ b/connectors/google/google-sheets/element-templates/google-sheets-connector.json
@@ -561,8 +561,7 @@
         "name": "operation.cellId"
       },
       "constraints": {
-        "notEmpty": true,
-        "maxLength": 100
+        "notEmpty": true
       },
       "condition": {
         "property": "operationType",

--- a/connectors/google/google-sheets/element-templates/google-sheets-connector.json
+++ b/connectors/google/google-sheets/element-templates/google-sheets-connector.json
@@ -341,7 +341,6 @@
       },
       "constraints": {
         "notEmpty": false,
-        "maxLength": 5,
         "pattern": {
           "value": "^([0-9]*$)",
           "message": "Must be a number."

--- a/connectors/google/google-sheets/element-templates/google-sheets-connector.json
+++ b/connectors/google/google-sheets/element-templates/google-sheets-connector.json
@@ -293,8 +293,7 @@
         "name": "operation.worksheetName"
       },
       "constraints": {
-        "notEmpty": true,
-        "maxLength": 100
+        "notEmpty": true
       },
       "condition": {
         "property": "operationType",

--- a/connectors/google/google-sheets/element-templates/google-sheets-connector.json
+++ b/connectors/google/google-sheets/element-templates/google-sheets-connector.json
@@ -586,7 +586,7 @@
       },
       "constraints": {
         "notEmpty": true,
-        "maxLength": 100
+        "maxLength": 50000
       },
       "condition": {
         "property": "operationType",

--- a/connectors/google/google-sheets/element-templates/google-sheets-connector.json
+++ b/connectors/google/google-sheets/element-templates/google-sheets-connector.json
@@ -266,7 +266,6 @@
       },
       "constraints": {
         "notEmpty": true,
-        "maxLength": 100,
         "pattern": {
           "value": "^([0-9]*$)",
           "message": "Must be a number."

--- a/connectors/google/google-sheets/element-templates/google-sheets-connector.json
+++ b/connectors/google/google-sheets/element-templates/google-sheets-connector.json
@@ -393,7 +393,6 @@
       },
       "constraints": {
         "notEmpty": true,
-        "maxLength": 100,
         "pattern": {
           "value": "^([0-9]*$)",
           "message": "Must be a number."

--- a/connectors/google/google-sheets/element-templates/google-sheets-connector.json
+++ b/connectors/google/google-sheets/element-templates/google-sheets-connector.json
@@ -417,7 +417,6 @@
       },
       "constraints": {
         "notEmpty": false,
-        "maxLength": 100,
         "pattern": {
           "value": "^([0-9]*$)",
           "message": "Must contains only numbers."

--- a/connectors/google/google-sheets/element-templates/google-sheets-connector.json
+++ b/connectors/google/google-sheets/element-templates/google-sheets-connector.json
@@ -606,7 +606,7 @@
       },
       "constraints": {
         "notEmpty": true,
-        "maxLength": 200
+        "maxLength": 50000
       },
       "condition": {
         "property": "operationType",

--- a/connectors/google/google-sheets/element-templates/google-sheets-connector.json
+++ b/connectors/google/google-sheets/element-templates/google-sheets-connector.json
@@ -470,7 +470,6 @@
       },
       "constraints": {
         "notEmpty": true,
-        "maxLength": 100,
         "pattern": {
           "value": "[A-Z]+",
           "message": "Must contains only capital letters."
@@ -494,7 +493,6 @@
       },
       "constraints": {
         "notEmpty": true,
-        "maxLength": 100,
         "pattern": {
           "value": "^([0-9]*$)",
           "message": "Must contains only numbers."

--- a/connectors/google/google-sheets/element-templates/google-sheets-connector.json
+++ b/connectors/google/google-sheets/element-templates/google-sheets-connector.json
@@ -585,8 +585,7 @@
         "name": "operation.values"
       },
       "constraints": {
-        "notEmpty": true,
-        "maxLength": 50000
+        "notEmpty": true
       },
       "condition": {
         "property": "operationType",
@@ -605,8 +604,7 @@
         "name": "operation.value"
       },
       "constraints": {
-        "notEmpty": true,
-        "maxLength": 50000
+        "notEmpty": true
       },
       "condition": {
         "property": "operationType",


### PR DESCRIPTION
## Description

Remove all length constraints on Google Sheets connector template fields.

The previous limits of 200 and 100 characters on `Value` and `Enter values` fields were preventing some otherwise valid FEEL queries from being used with this template.

The initial length constraints were added early in the Element Templates development process. Now, the team feels that (in general) templates should only apply length constraints when the API itself requires it. This is because:
- We can't always determine limits imposed by 3rd party systems
- 3rd party systems could change limits at any time
- We don't want to unnecessarily limit our customers where those limits aren't strictly needed

Although Camunda has a [4MB process instance payload size limit](https://docs.camunda.io/docs/components/concepts/variables/#variable-size-limitation), we can't easily determine how much each field "should" be allowed to take up. 

I quickly checked whether the [Google Sheets API](https://developers.google.com/sheets/api/reference/rest) has any documented length constraints for the fields this PR edits, but I couldn't find any.

### Testing

- [x] Validation in Desktop Modeler works as expected
    - For each field, check if we can input a value longer than the previous length requirement
 - [x] Search for "maxValues" inside `element-templates/google-sheets-connector.json` to ensure no length constraint left behind


## Related issues

closes #1049 

## Links

- [Camunda process instance payload size limit](https://docs.camunda.io/docs/components/concepts/variables/#variable-size-limitation)
- [Google Sheets REST API](https://developers.google.com/sheets/api/reference/rest)

