### PR TITLE
fix(generator): restore prefixes for template discriminator properties

### DIFF
--- a/connectors/automation-anywhere/src/main/java/io/camunda/connector/automationanywhere/model/request/auth/Authentication.java
+++ b/connectors/automation-anywhere/src/main/java/io/camunda/connector/automationanywhere/model/request/auth/Authentication.java
@@ -21,7 +21,7 @@ import io.camunda.connector.generator.java.annotation.TemplateDiscriminatorPrope
 @TemplateDiscriminatorProperty(
     label = "Type",
     group = "authentication",
-    name = "authentication.type",
+    name = "type",
     defaultValue = "passwordBasedAuthentication",
     description =
         "Choose the authentication type. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/automation-anywhere/\" target=\"_blank\">documentation</a>")

--- a/connectors/automation-anywhere/src/main/java/io/camunda/connector/automationanywhere/model/request/operation/OperationData.java
+++ b/connectors/automation-anywhere/src/main/java/io/camunda/connector/automationanywhere/model/request/operation/OperationData.java
@@ -15,5 +15,5 @@ import io.camunda.connector.generator.java.annotation.TemplateDiscriminatorPrope
   @JsonSubTypes.Type(value = AddWorkItemOperationData.class, name = "addWorkItemsToTheQueue"),
   @JsonSubTypes.Type(value = GetWorkItemOperationData.class, name = "listWorkItemsInQueue")
 })
-@TemplateDiscriminatorProperty(label = "Type", group = "operation", name = "operation.type")
+@TemplateDiscriminatorProperty(label = "Type", group = "operation", name = "type")
 public sealed interface OperationData permits AddWorkItemOperationData, GetWorkItemOperationData {}

--- a/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/auth/Authentication.java
+++ b/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/auth/Authentication.java
@@ -33,7 +33,7 @@ import io.camunda.connector.generator.java.annotation.TemplateDiscriminatorPrope
 @TemplateDiscriminatorProperty(
     label = "Type",
     group = "authentication",
-    name = "authentication.type",
+    name = "type",
     defaultValue = NoAuthentication.TYPE,
     description = "Choose the authentication type. Select 'None' if no authentication is necessary")
 public sealed interface Authentication

--- a/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/util/DiscriminatorPropertyBuilder.java
+++ b/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/util/DiscriminatorPropertyBuilder.java
@@ -17,8 +17,28 @@
 package io.camunda.connector.generator.java.util;
 
 import io.camunda.connector.generator.dsl.DropdownProperty.DropdownPropertyBuilder;
+import io.camunda.connector.generator.dsl.PropertyBuilder;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Marker class for the template generator to know that this property is a discriminator property.
  */
-public class DiscriminatorPropertyBuilder extends DropdownPropertyBuilder {}
+public class DiscriminatorPropertyBuilder extends DropdownPropertyBuilder {
+
+  private final List<PropertyBuilder> dependantProperties = new ArrayList<>();
+
+  public DiscriminatorPropertyBuilder dependantProperty(PropertyBuilder propertyBuilder) {
+    dependantProperties.add(propertyBuilder);
+    return this;
+  }
+
+  public DiscriminatorPropertyBuilder dependantProperties(List<PropertyBuilder> propertyBuilders) {
+    dependantProperties.addAll(propertyBuilders);
+    return this;
+  }
+
+  public List<PropertyBuilder> getDependantProperties() {
+    return dependantProperties;
+  }
+}

--- a/element-template-generator/core/src/test/java/io/camunda/connector/generator/java/OutboundClassBasedTemplateGeneratorTest.java
+++ b/element-template-generator/core/src/test/java/io/camunda/connector/generator/java/OutboundClassBasedTemplateGeneratorTest.java
@@ -23,7 +23,6 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import io.camunda.connector.generator.BaseTest;
 import io.camunda.connector.generator.api.GeneratorConfiguration;
 import io.camunda.connector.generator.api.GeneratorConfiguration.ConnectorElementType;
@@ -504,7 +503,7 @@ public class OutboundClassBasedTemplateGeneratorTest extends BaseTest {
     }
 
     @Test
-    void annotated_sealedType_followsAnnotations() throws JsonProcessingException {
+    void annotated_sealedType_followsAnnotations() {
       var template = generator.generate(MyConnectorFunction.MinimallyAnnotated.class).get(0);
       var discriminatorProperty =
           template.properties().stream()


### PR DESCRIPTION
## Description

[Recent change](https://github.com/camunda/connectors/pull/1561) removed auto-prefixing of discriminator properties in generated element templates.

After discussing with @jonathanlukas we discovered it makes JSON mapping much less convenient (as connectors devs now need to add the nested path manually), so we agreed this functionality should be restored.

