### PR TITLE
fix(operate): deal with nulls from process definition search

### DIFF
--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/importer/ProcessDefinitionSearch.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/importer/ProcessDefinitionSearch.java
@@ -77,7 +77,7 @@ public class ProcessDefinitionSearch {
       }
 
     } while (processDefinitionResult.getItems() != null
-        && processDefinitionResult.getItems().size() > 0);
+        && !processDefinitionResult.getItems().isEmpty());
 
     resultHandler.accept(processDefinitions);
   }

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/importer/ProcessDefinitionSearch.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/importer/ProcessDefinitionSearch.java
@@ -71,9 +71,13 @@ public class ProcessDefinitionSearch {
         paginationIndex = newPaginationIdx;
       }
 
-      processDefinitions.addAll(processDefinitionResult.getItems());
+      var items = processDefinitionResult.getItems();
+      if (items != null) {
+        processDefinitions.addAll(items);
+      }
 
-    } while (processDefinitionResult.getItems().size() > 0);
+    } while (processDefinitionResult.getItems() != null
+        && processDefinitionResult.getItems().size() > 0);
 
     resultHandler.accept(processDefinitions);
   }


### PR DESCRIPTION
## Description

Handle null values when there are no processes found (previously it returned an empty list and we didn't have this issue)


