### PR TITLE
fix(operate): handle nulls in process instance importing

### DIFF
--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/operate/OperateClientAdapterImpl.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/operate/OperateClientAdapterImpl.java
@@ -91,9 +91,11 @@ public class OperateClientAdapterImpl implements OperateClientAdapter {
           throw new RuntimeException(e);
         }
         processPaginationIndex = searchResult.getSortValues();
-        result.addAll(searchResult.getItems());
+        if (searchResult.getItems() != null) {
+          result.addAll(searchResult.getItems());
+        }
 
-      } while (searchResult.getItems().size() > 0);
+      } while (!CollectionUtils.isEmpty(searchResult.getItems()));
       return result;
     } finally {
       fetchActiveProcessLock.unlock();
@@ -133,16 +135,18 @@ public class OperateClientAdapterImpl implements OperateClientAdapter {
           throw new RuntimeException(e);
         }
         List<Object> newPaginationIdx = searchResult.getSortValues();
-        processVariables.putAll(
-            searchResult.getItems().stream()
-                .collect(
-                    Collectors.toMap(
-                        Variable::getName, variable -> unwrapValue(variable.getValue()))));
+        if (searchResult.getItems() != null) {
+          processVariables.putAll(
+              searchResult.getItems().stream()
+                  .collect(
+                      Collectors.toMap(
+                          Variable::getName, variable -> unwrapValue(variable.getValue()))));
+        }
         if (!CollectionUtils.isEmpty(newPaginationIdx)) {
           variablePaginationIndex = newPaginationIdx;
         }
 
-      } while (searchResult.getItems().size() > 0);
+      } while (!CollectionUtils.isEmpty(searchResult.getItems()));
       return processVariables;
     } finally {
       fetchVariablesLock.unlock();


### PR DESCRIPTION
## Description

After the Operate client upgrade, the calls can return nulls and we need to handle those explicitly.


