### PR TITLE
fix(docker): set a custom location for zeebe credentials cache

### DIFF
--- a/bundle/camunda-saas-bundle/Dockerfile
+++ b/bundle/camunda-saas-bundle/Dockerfile
@@ -11,5 +11,6 @@ COPY target/*-with-dependencies.jar /opt/app/
 RUN addgroup --gid 1001 camunda && useradd --no-create-home --gid 1001 --uid 1001 camunda
 USER 1001:1001
 
+ENV ZEEBE_CLIENT_CONFIG_PATH=/tmp/connectors
 # Using entry point to allow downstream images to add JVM arguments using CMD
 ENTRYPOINT ["java", "-cp", "/opt/app/*", "io.camunda.connector.runtime.saas.SaaSConnectorRuntimeApplication"]

--- a/bundle/default-bundle/Dockerfile
+++ b/bundle/default-bundle/Dockerfile
@@ -16,4 +16,5 @@ RUN chmod +x start.sh
 RUN addgroup --gid 1001 camunda && useradd --no-create-home --gid 1001 --uid 1001 camunda
 USER 1001:1001
 
+ENV ZEEBE_CLIENT_CONFIG_PATH=/tmp/connectors
 ENTRYPOINT ["/start.sh"]

--- a/connector-runtime/connector-runtime-application/Dockerfile
+++ b/connector-runtime/connector-runtime-application/Dockerfile
@@ -19,4 +19,5 @@ RUN addgroup --gid 1001 camunda && useradd --no-create-home --gid 1001 --uid 100
 USER 1001:1001
 
 # Use entry point to allow downstream images to add JVM arguments using CMD
+ENV ZEEBE_CLIENT_CONFIG_PATH=/tmp/connectors
 ENTRYPOINT ["/start.sh"]


### PR DESCRIPTION
## Description

Zeebe client occasionally tries to write the credentials cache file and fails resulting in errors in the logs. This started failing after we switched to running our containers as non-root.

More context in #1613 

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #1613

