### PR TITLE
chore: Add Preview Environments to Connectors

### DIFF
--- a/.ci/preview-environments/argo/c8sm.yml
+++ b/.ci/preview-environments/argo/c8sm.yml
@@ -1,0 +1,29 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  labels:
+    product-context: "c8sm"
+spec:
+  destination:
+    name: camunda-ci
+  ignoreDifferences:
+  - jsonPointers:
+    - /data/tls.crt
+    - /data/tls.key
+    - /metadata/annotations/replicator.v1.mittwald.de~1replicated-from-version
+    kind: Secret
+    name: "*-wildcard-certificate-tls"
+  project: connectors-previews
+  source:
+    helm:
+      parameters: []
+    path: .ci/preview-environments/charts/c8sm
+    repoURL: https://github.com/camunda/connectors.git
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+    - CreateNamespace=true
+    - RespectIgnoreDifferences=true

--- a/.ci/preview-environments/charts/c8sm/Chart.yaml
+++ b/.ci/preview-environments/charts/c8sm/Chart.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: v2
+name: preview-environments
+appVersion: dev
+description: A Helm chart to deploy a C8 Connectors preview environment to the Camunda-CI cluster managed by the Infrastructure team.
+icon: https://console.cloud.camunda.io/favicon.ico
+type: application
+# Chart version; expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+dependencies:
+- name: infra-preview-environments-ingress
+  repository: oci://registry.camunda.cloud/library
+  version: 1.3.0
+- name: camunda-platform
+  # @camunda-cloud references https://helm.camunda.io repository configured as camunda-cloud in Argo CD
+  repository: https://helm.camunda.io
+  version: 8.3.4

--- a/.ci/preview-environments/charts/c8sm/templates/_helpers.tpl
+++ b/.ci/preview-environments/charts/c8sm/templates/_helpers.tpl
@@ -1,0 +1,15 @@
+
+{{ define "commonLabels" -}}
+{{- toYaml .Values.global.labels -}}
+{{ end }}
+
+{{- define "commonAnnotations" -}}
+camunda.cloud/created-by: "{{ .Values.global.preview.git.repoUrl }}/blob/{{ .Values.global.preview.git.branch }}/.ci/{{ .Template.Name }}"
+{{- if .Values.global.annotations }}
+{{ toYaml .Values.global.annotations -}}
+{{- end }}
+{{- end }}
+
+{{- define "ingress.domain" -}}
+{{- printf "%s.%s" .Release.Name .Values.global.preview.ingress.domain | trimPrefix "connectors-" -}}
+{{- end -}}

--- a/.ci/preview-environments/charts/c8sm/templates/certificate.yml
+++ b/.ci/preview-environments/charts/c8sm/templates/certificate.yml
@@ -1,0 +1,24 @@
+# Replicate the wildcard certificate from the main connectors namespace
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "camundaPlatform.fullname" (index .Subcharts "camunda-platform") }}-wildcard-certificate-tls
+  labels:
+    {{- include "commonLabels" $ | nindent 4 }}
+  annotations:
+    {{- include "commonAnnotations" $ | nindent 4 }}
+    replicator.v1.mittwald.de/replicate-from: connectors/connectors-wildcard-certificate-tls
+    # The following overwrites an "internal" annotation (one that the user
+    # should not interfere with as it is not documented in the README at
+    # https://github.com/mittwald/kubernetes-replicator/). We do this anyways to
+    # force replicator-tool to replicate the contents of this secret again.
+    # This is necessary as we have to set empty default data fields to create a
+    # valid `type: kubernetes.io/tls` secret but this will purge the previously
+    # replicated contents.
+    replicator.v1.mittwald.de/replicated-from-version: "0"
+    argocd.argoproj.io/sync-wave: "-3"
+type: kubernetes.io/tls
+data:
+  tls.key: ""
+  tls.crt: ""

--- a/.ci/preview-environments/charts/c8sm/templates/ingress.yml
+++ b/.ci/preview-environments/charts/c8sm/templates/ingress.yml
@@ -1,0 +1,70 @@
+# We connot use .Values.global.ingress.annotations to include "infrapreviewenvironmentsingress.annotations" due
+# to the "toYaml" function used before "tpl". A similar custom ingress must be used instead.
+# https://github.com/camunda/camunda-platform-helm/blob/1814ba5e3ad4c012288dcaf7b0f8a3ceff860b4e/charts/camunda-platform/templates/camunda/ingress.yaml#L9
+---
+{{- $camundaPlatform := deepCopy (index .Subcharts "camunda-platform") -}}
+{{- $_ := set .Values "camundaPlatform" (deepCopy (index .Values "camunda-platform")) -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "camundaPlatform.fullname" $camundaPlatform }}
+  labels:
+    {{- include "commonLabels" $ | nindent 4 }}
+  annotations: 
+    {{- include "commonAnnotations" $ | nindent 4 }}
+    {{- include "infrapreviewenvironmentsingress.annotations" $ | nindent 4 -}}
+    ingress.kubernetes.io/rewrite-target: "/"
+    nginx.ingress.kubernetes.io/app-root: {{ .Values.camundaPlatform.webModeler.contextPath }}
+    nginx.ingress.kubernetes.io/proxy-buffer-size: 16k
+spec:
+  ingressClassName: nginx
+  rules:
+  - host: {{ include "ingress.domain" $ | quote }}
+    http:
+      paths:
+      - backend:
+          service:
+            name: {{ include "identity.keycloak.service" $camundaPlatform.Subcharts.identity }}
+            port:
+              number: {{ include "identity.keycloak.port" $camundaPlatform.Subcharts.identity }}
+        path: {{ include "identity.keycloak.contextPath" $camundaPlatform.Subcharts.identity }}
+        pathType: Prefix
+      - backend:
+          service:
+            name: {{ template "identity.fullname" $camundaPlatform.Subcharts.identity }}
+            port:
+              number: {{ .Values.camundaPlatform.identity.service.port }}
+        path: {{ .Values.camundaPlatform.identity.contextPath }}
+        pathType: Prefix
+      - backend:
+          service:
+            name: {{ template "operate.fullname" $camundaPlatform }}
+            port:
+              number: {{ .Values.camundaPlatform.operate.service.port }}
+        path: {{ .Values.camundaPlatform.operate.contextPath }}
+        pathType: Prefix
+      - backend:
+          service:
+            name: {{ template "webModeler.webapp.fullname" $camundaPlatform }}
+            port:
+              number: {{ .Values.camundaPlatform.webModeler.webapp.service.port }}
+        path: {{ .Values.camundaPlatform.webModeler.contextPath }}
+        pathType: Prefix
+      - backend:
+          service:
+            name: {{ template "webModeler.websockets.fullname" $camundaPlatform }}
+            port:
+              number:  {{ .Values.camundaPlatform.webModeler.websockets.service.port }}
+        path: {{ template "webModeler.websocketContextPath" $camundaPlatform }}
+        pathType: Prefix
+      - backend:
+          service:
+            name: {{ template "connectors.fullname" $camundaPlatform }}
+            port:
+              number: {{ .Values.camundaPlatform.connectors.service.serverPort }}
+        path: {{ .Values.camundaPlatform.connectors.contextPath }}
+        pathType: Prefix
+  tls:
+  - hosts:
+    - {{ include "ingress.domain" $ | quote }}
+    secretName: {{ include "camundaPlatform.fullname" $camundaPlatform }}-wildcard-certificate-tls

--- a/.ci/preview-environments/charts/c8sm/templates/ns.yml
+++ b/.ci/preview-environments/charts/c8sm/templates/ns.yml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ .Release.Name }}
+  annotations: {{ include "commonAnnotations" $ | nindent 4 }}
+    argocd.argoproj.io/sync-wave: "-5"
+  labels: {{ include "commonLabels" $ | nindent 4 }}

--- a/.ci/preview-environments/charts/c8sm/templates/secrets.yml
+++ b/.ci/preview-environments/charts/c8sm/templates/secrets.yml
@@ -1,0 +1,26 @@
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: registry-camunda-cloud
+  labels: {{ include "commonLabels" $ | nindent 4 }}
+  annotations: {{ include "commonAnnotations" $ | nindent 4 }}
+spec:
+  refreshInterval: "5m"
+
+  secretStoreRef:
+    name: connectors-vault-backend
+    kind: ClusterSecretStore
+
+  target:
+    template:
+      type: kubernetes.io/dockerconfigjson
+      metadata:
+        annotations:
+          managed-by: external-secrets
+
+  data:
+  - secretKey: .dockerconfigjson
+    remoteRef:
+      key: secret/data/products/connectors/ci/common
+      property: REGISTRY_CAMUNDA_CLOUD_DOCKERCONFIGJSON

--- a/.ci/preview-environments/charts/c8sm/templates/service.yml
+++ b/.ci/preview-environments/charts/c8sm/templates/service.yml
@@ -1,0 +1,28 @@
+# Fixed service names for Zeebe Gateway and Keycloak to be used in Web Modeler
+# to easily configure the cluster endpoint (with Camunda identity-based authentication)
+---
+{{- $camundaPlatform := index .Subcharts "camunda-platform" -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: zeebe
+  labels:
+    {{- include "commonLabels" $ | nindent 4 }}
+  annotations: 
+    {{- include "commonAnnotations" $ | nindent 4 }}
+spec:
+  type: ExternalName
+  externalName: {{ include "zeebe.names.gateway" $camundaPlatform }}.{{ .Release.Namespace }}.svc.cluster.local
+---
+{{- $identityKeyCloak := $camundaPlatform.Subcharts.identity.Subcharts.keycloak -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: keycloak
+  labels:
+    {{- include "commonLabels" $ | nindent 4 }}
+  annotations: 
+    {{- include "commonAnnotations" $ | nindent 4 }}
+spec:
+  type: ExternalName
+  externalName: {{ template "common.names.fullname" $identityKeyCloak }}.{{ .Release.Namespace }}.svc.cluster.local

--- a/.ci/preview-environments/charts/c8sm/values.yaml
+++ b/.ci/preview-environments/charts/c8sm/values.yaml
@@ -1,0 +1,384 @@
+---
+# Default values for the Connectors preview environment
+
+# Global values accessible from any chart or subchart
+global:
+
+  # Common labels
+  labels:
+    # app label will be dynamically set according to preview envrionment name
+    app: connectors
+    camunda.cloud/managed-by: Helm
+    camunda.cloud/source: argocd
+    team: connectors
+
+  # Preview environment configurations
+  preview:
+    git:
+      # GitHub references for annotating resources
+      # Branch name will be dynamically set with PR branch name
+      branch: master
+      repoUrl: https://github.com/camunda/connectors
+    ingress:
+      # The domain name under which to expose the preview environment
+      domain: connectors.camunda.cloud
+
+  # Camunda 8 Self-Managed global configurations
+  elasticsearch:
+    # necessary due to name override bugs
+    host: elasticsearch
+  identity:
+    auth:
+      # Enable Camunda Identity-based authentication
+      enabled: true
+      # Token issuer (Keycloak) URL
+      publicIssuerUrl: https://{{ include "ingress.domain" . }}/auth/realms/camunda-platform
+      connectors:
+        # fixed secret, to avoid generating a random one each time
+        existingSecret: connectors
+      operate:
+        # fixed secret, to avoid generating a random one each time
+        existingSecret: operate
+        redirectUrl: https://{{ include "ingress.domain" . }}/operate
+      webModeler:
+        redirectUrl: https://{{ include "ingress.domain" . }}/modeler
+      zeebe:
+        # fixed secret, to avoid generating a random one each time
+        existingSecret: zeebe
+    keycloak:
+      auth:
+        # necessary due to name override bugs
+        adminUser: admin
+        existingSecret: identity-keycloak
+        existingSecretKey: admin-password
+  zeebeClusterName: zeebe-cluster
+
+
+# Camunda 8 Self-Managed configurations
+camunda-platform:
+
+  fullnameOverride: connectors
+
+  # Out-of-the-box Connectors
+  connectors:
+    enabled: true
+    fullnameOverride: connectors
+    contextPath: /connectors
+    inbound:
+      ## Use Identity-based authentication
+      mode: oauth
+    image:
+      registry: registry.camunda.cloud
+      repository: team-connectors/connectors-bundle
+      pullSecrets:
+      - name: registry-camunda-cloud
+    env:
+    - name: JAVA_OPTS
+      value: "-Xms512m -Xmx512m"
+    resources:
+      limits:
+        cpu: 1
+        memory: 1Gi
+      requests:
+        cpu: 500m
+        memory: 512Mi
+    nodeSelector:
+      cloud.google.com/gke-nodepool: previews
+    tolerations:
+    - key: "previews"
+      operator: "Exists"
+      effect: "NoSchedule"
+
+  elasticsearch:
+    enabled: true
+    fullnameOverride: elasticsearch
+    # image:
+    #   repository: bitnami/elasticsearch
+    #   tag: latest
+    master:
+      fullnameOverride: elasticsearch-master
+      replicaCount: 1
+      heapSize: 512m
+      persistence:
+        enabled: true
+        size: 1Gi
+      resources:
+        limits:
+          cpu: 1
+          memory: 1Gi
+        requests:
+          cpu: 500m
+          memory: 512Mi
+      nodeSelector:
+        cloud.google.com/gke-nodepool: previews
+      tolerations:
+      - key: "previews"
+        operator: "Exists"
+        effect: "NoSchedule"
+
+  identity:
+    enabled: true
+    fullnameOverride: identity
+    contextPath: /identity
+    fullURL: https://{{ include "ingress.domain" . }}{{ .Values.contextPath }}
+    # image:
+    #     repository: camunda/identity
+    #     tag: latest
+    env:
+    # Pre-create an Identity test application to be used to access the Zeebe cluster endpoint
+    - name: KEYCLOAK_CLIENTS_2_ID
+      value: test
+    - name: KEYCLOAK_CLIENTS_2_NAME
+      value: test
+    - name: KEYCLOAK_CLIENTS_2_SECRET
+      value: test
+    - name: KEYCLOAK_CLIENTS_2_REDIRECT_URIS_0
+      value: /callback
+    - name: KEYCLOAK_CLIENTS_2_ROOT_URL
+      value: http://test
+    - name: KEYCLOAK_CLIENTS_2_TYPE
+      value: CONFIDENTIAL
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_0_RESOURCE_SERVER_ID
+      value: zeebe-api
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_0_DEFINITION
+      value: "write:*"
+    resources:
+      limits:
+        cpu: 1
+        memory: 1Gi
+      requests:
+        cpu: 500m
+        memory: 512Mi
+    nodeSelector:
+      cloud.google.com/gke-nodepool: previews
+    tolerations:
+    - key: "previews"
+      operator: "Exists"
+      effect: "NoSchedule"
+    keycloak:
+      enabled: true
+      fullnameOverride: identity-keycloak
+      auth:
+        adminUser: admin
+        adminPassword: admin
+      externalDatabase:
+        password: postgresql
+      extraEnvVars:
+      - name: KEYCLOAK_PROXY_ADDRESS_FORWARDING
+        value: "true"
+      resources:
+        limits:
+          cpu: 1
+          memory: 1Gi
+        requests:
+          cpu: 500m
+          memory: 512Mi
+      nodeSelector:
+        cloud.google.com/gke-nodepool: previews
+      tolerations:
+      - key: "previews"
+        operator: "Exists"
+        effect: "NoSchedule"
+      postgresql:
+        fullnameOverride: identity-keycloak-postgresql
+        auth:
+          # fixed secret, to avoid generating a random password each time
+          password: postgresql
+        primary:
+          persistence:
+            enabled: true
+            size: 1Gi
+          resources:
+            limits:
+              cpu: 500m
+              memory: 512Mi
+            requests:
+              cpu: 250m
+              memory: 256Mi
+          nodeSelector:
+            cloud.google.com/gke-nodepool: previews
+          tolerations:
+          - key: "previews"
+            operator: "Exists"
+            effect: "NoSchedule"
+
+  operate:
+    enabled: true
+    fullnameOverride: operate
+    contextPath: /operate
+    # image:
+    #   repository: camunda/operate
+    #   tag: 8.3.4
+    env:
+    - name: JAVA_OPTS
+      value: "-Xms512m -Xmx512m"
+    resources:
+      limits:
+        cpu: 1
+        memory: 1Gi
+      requests:
+        cpu: 500m
+        memory: 512Mi
+    livenessProbe:
+      enabled: true
+      # Force restart if not ready
+      probePath: /actuator/health/readiness
+    nodeSelector:
+      cloud.google.com/gke-nodepool: previews
+    tolerations:
+    - key: "previews"
+      operator: "Exists"
+      effect: "NoSchedule"
+
+  optimize:
+    enabled: false
+
+  tasklist:
+    enabled: false
+
+  webModeler:
+    enabled: true
+    fullnameOverride: web-modeler
+    contextPath: /modeler
+    image:
+      pullSecrets:
+      - name: registry-camunda-cloud
+      # tag: latest
+    restapi:
+      # image:
+      #   repository: web-modeler-ee/modeler-restapi
+      mail:
+        # This value is required, otherwise, the restapi pod won't start.
+        fromAddress: noreply@example.com
+      resources:
+        limits:
+          cpu: 1
+          memory: 1Gi
+        requests:
+          cpu: 500m
+          memory: 512Mi
+      nodeSelector:
+        cloud.google.com/gke-nodepool: previews
+      tolerations:
+      - key: "previews"
+        operator: "Exists"
+        effect: "NoSchedule"
+    webapp:
+      # image:
+      #   repository: web-modeler-ee/modeler-webapp
+      image:
+        repository: web-modeler/modeler-webapp-self-managed
+        tag: latest
+      resources:
+        limits:
+          cpu: 100m
+          memory: 256Mi
+        requests:
+          cpu: 40m
+          memory: 256Mi
+      nodeSelector:
+        cloud.google.com/gke-nodepool: previews
+      tolerations:
+      - key: "previews"
+        operator: "Exists"
+        effect: "NoSchedule"
+    websockets:
+      # image:
+      #   repository: web-modeler-ee/modeler-websockets
+      resources:
+        limits:
+          cpu: 20m
+          memory: 64Mi
+        requests:
+          cpu: 20m
+          memory: 64Mi
+      nodeSelector:
+        cloud.google.com/gke-nodepool: previews
+      tolerations:
+      - key: "previews"
+        operator: "Exists"
+        effect: "NoSchedule"
+
+  # WebModeler PostgreSQL
+  postgresql:
+    enabled: true
+    fullnameOverride: web-modeler-postgresql
+    auth:
+      password: postgresql
+    primary:
+      persistence:
+        enabled: true
+        size: 1Gi
+      resources:
+        limits:
+          cpu: 500m
+          memory: 512Mi
+        requests:
+          cpu: 250m
+          memory: 256Mi
+      nodeSelector:
+        cloud.google.com/gke-nodepool: previews
+      tolerations:
+      - key: "previews"
+        operator: "Exists"
+        effect: "NoSchedule"
+
+  zeebe:
+    enabled: true
+    fullnameOverride: zeebe-cluster
+    # image:
+    #   repository: camunda/zeebe
+    #   tag: latest
+    clusterSize: 1
+    partitionCount: 1
+    replicationFactor: 1
+    persistenceType: disk
+    pvcSize: 1Gi
+    env:
+    ## Adjustement required due to PVC size
+    - name: ZEEBE_BROKER_DATA_DISK_FREESPACE_REPLICATION
+      value: "100MB"
+    - name: ZEEBE_BROKER_DATA_DISK_FREESPACE_PROCESSING
+      value: "150MB"
+    javaOpts: >-
+      -Xms512m -Xmx512m
+      -XX:+HeapDumpOnOutOfMemoryError
+      -XX:HeapDumpPath=/usr/local/zeebe/data
+      -XX:ErrorFile=/usr/local/zeebe/data/zeebe_error%p.log
+      -XX:+ExitOnOutOfMemoryError
+    resources:
+      limits:
+        cpu: 1
+        memory: 1Gi
+      requests:
+        cpu: 500m
+        memory: 512Mi
+    nodeSelector:
+      cloud.google.com/gke-nodepool: previews
+    tolerations:
+      - key: "previews"
+        operator: "Exists"
+        effect: "NoSchedule"
+
+  zeebe-gateway:
+    fullnameOverride: zeebe-cluster-gateway
+    replicas: 1
+    # image:
+    #   repository: camunda/zeebe
+    #   tag: latest
+    javaOpts: >-
+      -Xms512m -Xmx512m
+      -XX:+ExitOnOutOfMemoryError
+    resources:
+      limits:
+        cpu: 1
+        memory: 1Gi
+      requests:
+        cpu: 500m
+        memory: 512Mi
+    nodeSelector:
+      cloud.google.com/gke-nodepool: previews
+    tolerations:
+      - key: "previews"
+        operator: "Exists"
+        effect: "NoSchedule"

--- a/.github/workflows/PREVIEW-ENV-CLEAN.yml
+++ b/.github/workflows/PREVIEW-ENV-CLEAN.yml
@@ -1,0 +1,51 @@
+---
+name: preview-env-clean
+
+on:
+  schedule:
+  - cron: 0 6,22 * * *
+  workflow_call:
+    inputs:
+      pull-request:
+        description: |
+          Limit cleanup to a single pull request (number) and a minimal mode.
+          Useful for quickly eliminating inconsistencies while waiting for the full cleanup cycle to run.
+        required: false
+        type: number
+    secrets:
+      VAULT_ADDR:
+        required: true
+      VAULT_ROLE_ID:
+        required: true
+      VAULT_SECRET_ID:
+        required: true
+  workflow_dispatch:
+
+jobs:
+  preview-env-clean:
+    concurrency:
+      group: ${{ github.workflow }}-${{ inputs.pull-request }}
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+    - name: Generate a GitHub token
+      id: github-token
+      uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@main
+      with:
+        github-app-id-vault-key: GITHUB_PREVIEW_ENVIRONMENTS_APP_ID
+        github-app-id-vault-path: secret/data/products/connectors/ci/common
+        github-app-private-key-vault-key: GITHUB_PREVIEW_ENVIRONMENTS_APP_PRIVATE_KEY
+        github-app-private-key-vault-path: secret/data/products/connectors/ci/common
+        vault-auth-method: approle
+        vault-auth-role-id: ${{ secrets.VAULT_ROLE_ID }}
+        vault-auth-secret-id: ${{ secrets.VAULT_SECRET_ID}}
+        vault-url: ${{ secrets.VAULT_ADDR }}
+
+    - uses: camunda/infra-global-github-actions/preview-env/clean@main
+      with:
+        labels: deploy-preview
+        pull-request: ${{ inputs.pull-request }}
+        token: ${{ steps.github-token.outputs.token }}
+        ttl: 21d
+        warning-ttl: 14d

--- a/.github/workflows/PREVIEW-ENV-DEPLOY.yml
+++ b/.github/workflows/PREVIEW-ENV-DEPLOY.yml
@@ -1,0 +1,88 @@
+
+---
+name: preview-env-deploy
+on:
+  pull_request:
+    types: [ labeled,synchronize ]
+
+jobs:
+  deploy-preview:
+    # checks that the PR isn't closed AND check whether the labeled event contains deploy-preview as substring || check whether on new commit of PR the label deploy-preview is part of label array
+    if: github.event.pull_request.state != 'closed' && (contains( github.event.label.name, 'deploy-preview') || contains( github.event.pull_request.labels.*.name, 'deploy-preview'))
+    runs-on: ubuntu-22.04
+    timeout-minutes: 20
+    name: deploy-preview-env-${{ matrix.product_context }}
+    env:
+      BRANCH_NAME: ${{ github.head_ref }} # head_ref = branch on PR
+    concurrency:
+      group: pr-update-${{ github.head_ref }}-${{ matrix.product_context }} # env is not yet available here
+      cancel-in-progress: true
+    strategy: 
+      fail-fast: false # Don't disrupt other deployments because of failure
+      matrix:
+        product_context: [c8sm]
+
+    steps:
+    #########################################################################
+    # Sanitize the branch name to remove dependabot/,renovate/ and transform the name
+    - id: sanitize
+      uses: camunda/infra-global-github-actions/sanitize-branch-name@main
+      with:
+        branch: ${{ env.BRANCH_NAME }}
+        max_length: '15'
+    #########################################################################
+    # Setup: import secrets from vault
+    - name: Import secrets
+      id: secrets
+      uses: hashicorp/vault-action@affa6f04da5c2d55e6e115b7d1b044a6b1af8c74 # v2.7.4
+      with:
+        url: ${{ secrets.VAULT_ADDR }}
+        method: approle
+        roleId: ${{ secrets.VAULT_ROLE_ID }}
+        secretId: ${{ secrets.VAULT_SECRET_ID }}
+        secrets: |
+          secret/data/products/connectors/ci/common ARGOCD_TOKEN;
+    #########################################################################
+    # Setup: checkout code. This is required because we are using
+    # composite actions and deployment manifests.
+    - name: Checkout
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+    #########################################################################
+    # Determine the argocd arguments that need to be passed to the create app command
+    - name: Determine Argocd Arguments for ${{ matrix.product_context }}
+      if: matrix.product_context == 'c8sm'
+      shell: bash
+      run: |
+        echo "argocd_arguments=--dest-namespace ${app_name} \
+          --file .ci/preview-environments/argo/${argocd_app_file_name}.yml \
+          --helm-set camunda-platform.connectors.image.tag=${docker_tag} \
+          --helm-set global.preview.git.branch=${revision} \
+          --helm-set global.labels.app=${app_name} \
+          --helm-set global.preview.ingress.domain=connectors.camunda.cloud \
+          --name ${app_name} \
+          --revision ${revision} \
+          --upsert" >> $GITHUB_ENV
+      env:
+        docker_tag: pr-${{ github.event.pull_request.head.sha }} # SHA of latest commit
+        revision: ${{ env.BRANCH_NAME }}
+        app_name: connectors-${{ steps.sanitize.outputs.branch_name }}-${{ matrix.product_context }}
+        argocd_app_file_name: ${{ matrix.product_context }}
+    #########################################################################
+    # Create a preview environment
+    - name: Deploy Preview Environment for ${{ matrix.product_context }}
+      uses: camunda/infra-global-github-actions/preview-env/create@main
+      with:
+        revision: ${{ env.BRANCH_NAME }}
+        argocd_token: ${{ steps.secrets.outputs.ARGOCD_TOKEN }}
+        app_name: connectors-${{ steps.sanitize.outputs.branch_name }}-${{ matrix.product_context }}
+        app_url: https://${{ steps.sanitize.outputs.branch_name }}-${{ matrix.product_context }}.connectors.camunda.cloud
+        argocd_arguments: ${{ env.argocd_arguments }}
+        argocd_server: argocd.int.camunda.com
+
+  clean:
+    if: always() && github.event_name == 'pull_request' && needs.deploy-preview.result != 'skipped'
+    uses: camunda/connectors/.github/workflows/PREVIEW-ENV-CLEAN.yml@master
+    needs: [deploy-preview]
+    secrets: inherit
+    with:
+      pull-request: ${{ github.event.pull_request.number }}

--- a/.github/workflows/PREVIEW-ENV-TEARDOWN.yml
+++ b/.github/workflows/PREVIEW-ENV-TEARDOWN.yml
@@ -1,0 +1,60 @@
+---
+name: preview-env-teardown
+on:
+  pull_request:
+    types: [ unlabeled,closed ]
+
+jobs:
+  teardown-preview:
+    # check whether the unlabel name was deploy-preview || check whether the PR was closed / merged and whether deploy-preview was part of the array
+    if: github.event.label.name == 'deploy-preview' || (github.event.action == 'closed' && contains( github.event.pull_request.labels.*.name, 'deploy-preview') )
+    runs-on: ubuntu-22.04
+    timeout-minutes: 20
+    env:
+      BRANCH_NAME: ${{ github.head_ref }} # head_ref = branch on PR
+    strategy:
+      fail-fast: false # Don't disrupt other deployments because of failure
+      matrix:
+        product_context: [c8sm]
+
+    steps:
+    #########################################################################
+    # Sanitize the branch name to remove dependabot/,renovate/ and transform the name
+    - id: sanitize
+      uses: camunda/infra-global-github-actions/sanitize-branch-name@main
+      with:
+        branch: ${{ env.BRANCH_NAME }}
+        max_length: '15'
+    #########################################################################
+    # Setup: import secrets from vault
+    - name: Import secrets
+      id: secrets
+      uses: hashicorp/vault-action@affa6f04da5c2d55e6e115b7d1b044a6b1af8c74 # v2.7.4
+      with:
+        url: ${{ secrets.VAULT_ADDR }}
+        method: approle
+        roleId: ${{ secrets.VAULT_ROLE_ID }}
+        secretId: ${{ secrets.VAULT_SECRET_ID }}
+        secrets: |
+          secret/data/products/connectors/ci/common ARGOCD_TOKEN;
+    #########################################################################
+    # Setup: checkout code. This is required because we are using
+    # composite actions and deployment manifests.
+    - name: Checkout
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+    #########################################################################
+    # Tear down preview environment
+    - name: Tear down Preview Environment for ${{ matrix.product_context }}
+      uses: camunda/infra-global-github-actions/preview-env/destroy@main
+      with:
+        revision: ${{ env.BRANCH_NAME }}
+        argocd_token: ${{ steps.secrets.outputs.ARGOCD_TOKEN }}
+        app_name: connectors-${{ steps.sanitize.outputs.branch_name }}-${{ matrix.product_context }}
+
+  clean:
+    if: always() && needs.teardown-preview.result != 'skipped'
+    uses: camunda/connectors/.github/workflows/preview-env-clean.yml@master
+    needs: [teardown-preview]
+    secrets: inherit
+    with:
+      pull-request: ${{ github.event.pull_request.number }}

--- a/.github/workflows/TEST_FEATURE_BRANCH.yml
+++ b/.github/workflows/TEST_FEATURE_BRANCH.yml
@@ -24,8 +24,8 @@ jobs:
           secretId: ${{ secrets.VAULT_SECRET_ID }}
           exportEnv: false # we rely on step outputs, no need for environment variables
           secrets: |
-            secret/data/products/connectors/ci/common ARTIFACTORY_USR;
-            secret/data/products/connectors/ci/common ARTIFACTORY_PSW;
+            secret/data/products/connectors/ci/common ARTIFACTORY_USR | CI_LDAP_USER;
+            secret/data/products/connectors/ci/common ARTIFACTORY_PSW | CI_LDAP_PASSWORD;
 
       - name: Restore cache
         uses: actions/cache@v3
@@ -48,8 +48,8 @@ jobs:
           servers: |
             [{
                "id": "camunda-nexus",
-               "username": "${{ steps.secrets.outputs.ARTIFACTORY_USR }}",
-               "password": "${{ steps.secrets.outputs.ARTIFACTORY_PSW }}"
+               "username": "${{ steps.secrets.outputs.CI_LDAP_USER }}",
+               "password": "${{ steps.secrets.outputs.CI_LDAP_PASSWORD }}"
              }]
           mirrors: '[{"url": "https://repository.nexus.camunda.cloud/content/groups/internal/", "id": "camunda-nexus", "mirrorOf": "camunda-nexus", "name": "camunda Nexus"}]'
 
@@ -77,3 +77,29 @@ jobs:
         uses: hadolint/hadolint-action@v3.1.0
         with:
           dockerfile: bundle/default-bundle/Dockerfile
+
+      - name: Package Connectors
+        env:
+          PROJECTS: bundle/default-bundle
+        run: mvn --batch-mode compile generate-sources package -DskipTests --projects "${PROJECTS}" --also-make
+  
+      - name: Set up Docker Build
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          registry: registry.camunda.cloud
+          username: ${{ steps.secrets.outputs.CI_LDAP_USER }}
+          password: ${{ steps.secrets.outputs.CI_LDAP_PASSWORD }}
+      
+      # Publish Docker images for Preview environments
+      - name: Build and Push Docker Image tag ${{ env.TAG }} - bundle-default
+        env:
+          TAG: pr-${{ github.sha }}
+        uses: docker/build-push-action@v5
+        with:
+          context: bundle/default-bundle/
+          provenance: false
+          push: true
+          tags: registry.camunda.cloud/team-connectors/connectors-bundle:${{ env.TAG }}


### PR DESCRIPTION
## Description

Related to https://github.com/camunda/team-infrastructure/issues/510

This introduces a SelfManaged-like preview environment for Connectors that can be enabled on any PR by adding the `deploy-preview` label, and disabled by removing it.

Deployment manifests for the preview environment are defined in a Helm Chart, fully configurable via the [values.yml](https://github.com/camunda/connectors/blob/infra-gh-510-preview-environments/.ci/preview-environments/charts/c8sm/values.yaml) file. This Helm Chart leverages the [Camunda Platform Helm Chart](https://github.com/camunda/camunda-platform-helm), as well as the [infra-preview-environments-ingress Helm Chart](https://github.com/camunda/infra-preview-environments-ingress), maintained by infra, to enable an Okta-based authentication overlay on top of all exposed endpoints by default.

The following components, required for a minimal functional preview environment, are deployed:
- Identity
- Zeebe (+ Zeebe Gateway)
- Elasticsearch
- Operate
- WebModeler
- Connectors runtime (default-bundle)

The Identity-based authentification is configured by default.

For each component (except Connectors), the version used is the default one defined in the Camunda Platform Helm Chart. These versions can be modified if necessary via the values.yml file (e.g. [Operate](https://github.com/camunda/connectors/blob/infra-gh-510-preview-environments/.ci/preview-environments/charts/c8sm/values.yaml#L213-L215)).

For Connectors, the `connectors-bundle` Docker image is built from the current version of the branch and deployed. For every new commit, a new version of the Docker image is automatically built and deployed accordingly. To achieve this, the [TEST_FEATURE_BRANCH.yml](https://github.com/camunda/connectors/blob/infra-gh-510-preview-environments/.github/workflows/TEST_FEATURE_BRANCH.yml) workflow has been extended to build this Docker image after running the tests, and to push it to a dedicated project in the Camunda Docker Registry ([Harbor](https://registry.camunda.cloud/harbor/projects/33/repositories)), to which all Connectors team members have access.
The complete execution of this workflow (tests + docker image) takes between 5 to 8 minutes, a minimum time for the preview environment to be deployed with the latest version of the Connectors component. This can be optimized quite easily if really necessary.

The URL of the preview environment is provided directly in the PR, as a GitHub deployment is created and managed in parallel.
<img width="941" alt="image" src="https://github.com/camunda/connectors/assets/1970739/6f13c8d5-ea9b-426f-97fa-a5332fd354d5">
This URL is unique, and the various components can be accessed via different URIs. By default, the root path redirects to WebModeler (`/` -> `/modeler`):
- `Identity`: `<branch-short-name>.connectors.camunda.cloud/identity`
- `WebModeler`:  `<branch-short-name>.connectors.camunda.cloud/modeler`
- `Operate`: `<branch-short-name>.connectors.camunda.cloud/operate`
- `Connectors`: `<branch-short-name>.connectors.camunda.cloud/connectors`

By default, a `demo` user and a `test` application are automatically created on Identity. They can be used to connect to the different user interfaces, deploy diagrams and create process instances. For endpoint cluster configuration, internal URLs of Zeebe (Gateway) and Keycloak must be used, as external ones won't work due to the additional Okta authentication layers. Two simple internal aliases are created by default and are to be used:
- http://zeebe:26500
- http://identity-keycloak

To access the Kubernetes namespaces in which preview environments are deployed, for example for port-forwarding (binding a remote service port to a local port), or accessing logs and executing commands directly in containers (debugging), all Connectors team members can use [Teleport](https://confluence.camunda.com/display/HAN/Accessing+Kubernetes+Clusters) to access the `camunda-ci` Kubernetes cluster.
This is especially needed to access the `/inbound` endpoint of the Connectors component deployed, to play with Inbound connectors.

Here are the rest of the configurations implemented:
- Activation of the standard Preview environment clean-up policy, to delete them after [21 days of inactivity](https://confluence.camunda.com/display/HAN/Preview+Environments)
- The names of the various pods deployed have been overwritten in order to simplify them as much as possible for better readability, but also to comply with the length limit for resource names
- Minimum resources have been allocated to each component, which can be increased if necessary (e.g. if tests are resource-intensive)
- Persistence has been activated for some components where necessary, to avoid issues in the event of a component restart

Before merging:
- [x] **Remove the last commit used for test purposes only**
