### PR TITLE
fix: add URI validation to webhook connectors

### DIFF
--- a/connectors/webhook/element-templates/webhook-connector-intermediate.json
+++ b/connectors/webhook/element-templates/webhook-connector-intermediate.json
@@ -2,7 +2,7 @@
   "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
   "name": "Webhook Intermediate Catch Event Connector",
   "id": "io.camunda.connectors.webhook.WebhookConnectorIntermediate.v1",
-  "version": 5,
+  "version": 6,
   "description": "Configure webhook to receive callbacks",
   "documentationRef": "https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/http-webhook/",
   "category": {

--- a/connectors/webhook/element-templates/webhook-connector-intermediate.json
+++ b/connectors/webhook/element-templates/webhook-connector-intermediate.json
@@ -114,7 +114,11 @@
       },
       "description": "The webhook ID is a part of the URL",
       "constraints": {
-        "notEmpty": true
+        "notEmpty": true,
+        "pattern": {
+          "value": "^[-\\]_.~!*'();:@&=+$,\/?%#[A-z0-9]+$",
+          "message": "must only contain valid URI characters"
+        }
       }
     },
     {

--- a/connectors/webhook/element-templates/webhook-connector-start-event.json
+++ b/connectors/webhook/element-templates/webhook-connector-start-event.json
@@ -2,7 +2,7 @@
   "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
   "name": "Webhook Start Event Connector",
   "id": "io.camunda.connectors.webhook.WebhookConnector.v1",
-  "version": 8,
+  "version": 9,
   "description": "Configure webhook to receive callbacks",
   "documentationRef": "https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/http-webhook/",
   "category": {

--- a/connectors/webhook/element-templates/webhook-connector-start-event.json
+++ b/connectors/webhook/element-templates/webhook-connector-start-event.json
@@ -104,7 +104,7 @@
       "constraints": {
         "notEmpty": true,
         "pattern": {
-          "value": "^[^-\\]_.~!*'();:@&=+$,/?%#[A-z0-9]+$",
+          "value": "^[-\\]_.~!*'();:@&=+$,\/?%#[A-z0-9]+$",
           "message": "must only contain valid URI characters"
         }
       }

--- a/connectors/webhook/element-templates/webhook-connector-start-event.json
+++ b/connectors/webhook/element-templates/webhook-connector-start-event.json
@@ -102,7 +102,11 @@
       },
       "description": "The webhook ID is a part of the URL",
       "constraints": {
-        "notEmpty": true
+        "notEmpty": true,
+        "pattern": {
+          "value": "^[^-\\]_.~!*'();:@&=+$,/?%#[A-z0-9]+$",
+          "message": "Must only contain valid URI characters"
+        }
       }
     },
     {

--- a/connectors/webhook/element-templates/webhook-connector-start-event.json
+++ b/connectors/webhook/element-templates/webhook-connector-start-event.json
@@ -105,7 +105,7 @@
         "notEmpty": true,
         "pattern": {
           "value": "^[^-\\]_.~!*'();:@&=+$,/?%#[A-z0-9]+$",
-          "message": "Must only contain valid URI characters"
+          "message": "must only contain valid URI characters"
         }
       }
     },


### PR DESCRIPTION
## Description

Check that webhook ID contains only valid URI characters as outlined in [RFC 3986](https://datatracker.ietf.org/doc/html/rfc3986) for the following:
- Webhook Start Event Connector
- Webhook Intermediate Event Connector

Before:
<img width="602" alt="Screenshot 2024-01-03 at 16 04 44" src="https://github.com/camunda/connectors/assets/7648845/60477942-38e9-40ba-bc45-62a0fc64b8d4">

After:
<img width="610" alt="Screenshot 2024-01-03 at 16 05 56" src="https://github.com/camunda/connectors/assets/7648845/3633e03f-49ef-4088-b970-817e8fb5d630">

Webhook ID's form part of a URL. As such, the ID needs to be a valid URI in order to prevent obviously malformed URL's. See #1238 for more details.

## More Details

### Allowing "/"

There was discussion in #1238 to disallow the forward slash "/" as this could be misconstrued as a path delimiter.

I personally feel we should still allow "/" because it is still syntactically correct. I don't want to enforce semantics, as it's possible there are some use cases where a Webhook ID could have a "/".

### Test Cases

Checked the following for all connectors in Desktop Modeller:

Should show error message:
- "Start event"
- "Start event€"
- " Start event "

Should not show error message:
- "12345"
- "abcde"
- "\_start_event\_"
- "%20start%20event%20"

### Next Steps

- Other generic webhook connectors (e.g., `webhook-connector-boundary`)
- 3rd party service webhook connectors (e.g., Twilio)

I wanted to wait to get feedback on my first implementation before expanding this approach to many other connectors.

## Related issues

https://github.com/camunda/connectors/issues/1238
