### PR TITLE
fix(workflows) fix prev_tag script

### DIFF
--- a/.github/workflows/scripts/prev_tag-test.sh
+++ b/.github/workflows/scripts/prev_tag-test.sh
@@ -1,0 +1,177 @@
+#!/bin/bash
+# tests only for local running, to verify that prev_tag.sh works as expected
+# Function to create a mock git repository
+setup_mock_repo() {
+  mkdir temp_repo
+  cd temp_repo
+  git init
+  # Create a dummy commit to enable tagging
+  touch dummy.txt
+  git add dummy.txt
+  git commit -m "Initial commit"
+
+  # Add mock tags to simulate different scenarios
+  git tag 0.5.1
+  git tag 0.7.3
+  git tag 0.11.0
+  git tag 0.23.2
+  git tag 7.4.0
+  git tag 8.2.0
+  git tag 8.2.1
+  git tag 8.3.0-alpha1
+  git tag 8.3.0-rc1
+  git tag 8.3.0
+  git tag 8.3.1-rc1
+  git tag 8.3.1
+  git tag 8.3.2-rc1
+  git tag 8.3.2-rc2
+  git tag 8.3.2-rc5
+  git tag 8.3.2-rc11
+  git tag 8.3.2
+  git tag 8.3.3
+  git tag 8.4.0-alpha1
+  git tag 8.4.0-alpha2
+  git tag 8.4.0-alpha2-rc1
+  git tag 8.4.0-alpha2-rc2
+  git tag 8.4.0-alpha2-rc3
+  git tag 8.4.0-rc1
+  git tag 8.4.0-rc2
+  git tag 8.4.0-rc3
+  git tag 8.4.0-rc23
+  git tag 8.4.0
+  git tag 8.4.1-alpha1
+  git tag 8.4.2
+  git tag 8.4.2-alpha1
+  git tag 9.0.0-alpha1
+  git tag 9.0.0-alpha2-rc1
+  git tag 9.0.0-alpha2
+  git tag 9.0.0-alpha3-rc1
+  git tag 9.0.0-rc1
+  git tag 9.0.0
+  git tag 9.1.0
+  git tag 9.2.0-alpha2
+  git tag 9.2.0-rc2
+  git tag 11.2.0
+  git tag 12.0.0
+  git tag 12.2.0
+  git tag 15.0.0-rc1
+  git tag 15.0.0
+  git tag 16.0.0-rc2
+  git tag 16.0.0-alpha2
+  git tag 19.0.0-alpha3
+  git tag 19.0.3-alpha3
+  git tag 19.0.3-rc3
+  git tag 19.0.3
+  git tag 19.0.4-alpha2
+  git tag 19.0.4-alpha6
+  git tag 20.3.0
+  git tag 20.3.1-alpha2
+  git tag 20.3.1-alpha5
+  git tag 20.3.1-alpha11
+  git tag 20.3.1-alpha23
+  git tag 20.4.1-alpha1-rc11
+  git tag 20.4.1-alpha1-rc3
+  git tag 20.4.1-alpha1-rc20
+  git tag 20.4.1-alpha11
+  git tag 20.4.1-alpha30-rc1
+  git tag 20.4.1-alpha2-rc1
+}
+
+# Function to clean up the mock repository
+cleanup() {
+  cd ..
+  rm -rf temp_repo
+}
+
+# Initialize a variable to store test results
+passed_tests_results=""
+fail_test_results=""
+test_passed_count=0
+test_fail_count=0
+
+# Function to run a single test case
+run_test() {
+  input_tag=$1
+  expected_output=$2
+
+  output=$(bash ../prev_tag.sh $input_tag)
+  if [[ $output == *"$expected_output"* ]]; then
+    passed_tests_results+="Test passed for input $input_tag: Expected and got $expected_output\n"
+    ((test_passed_count++))
+  else
+    fail_test_results+="Test failed for input $input_tag: Expected $expected_output, got $output\n"
+    ((test_fail_count++))
+  fi
+}
+
+# Main test logic
+setup_mock_repo
+# input : arg 1 -> input tag, arg 2-> expected output
+run_test "8.4.0" "8.3.0" # Normal release, next lower tag in the same minor series
+run_test "8.3.0" "8.2.0"
+run_test "8.3.3" "8.3.2" # Normal release, next lower tag
+run_test "8.3.1" "8.3.0" # Normal release, next lower tag
+
+run_test "8.4.0-alpha2" "8.4.0-alpha1" # Alpha version, next lower alpha tag
+run_test "8.3.0-alpha1" "8.2.0" # First alpha of a new minor version
+
+run_test "8.4.0-alpha2-rc3" "8.4.0-alpha2-rc2" # Alpha RC, next lower alpha RC tag
+run_test "8.4.0-alpha2-rc2" "8.4.0-alpha2-rc1" # Alpha RC, next lower alpha RC tag
+run_test "8.4.0-alpha2-rc1" "8.4.0-alpha1" # First alpha RC of a new alpha version
+run_test "9.0.0-alpha2-rc1" "9.0.0-alpha1" # First alpha RC of a new alpha version
+run_test "9.0.0-alpha3-rc1" "9.0.0-alpha2" # First alpha RC of a new alpha version
+run_test "8.4.0-alpha1" "8.3.0" # First alpha of a new alpha version
+
+run_test "8.4.1-alpha1" "8.4.0" # First alpha of a new alpha version
+run_test "8.4.2-alpha1" "8.4.1" # First alpha of a new alpha version
+
+run_test "8.3.2-rc1" "8.3.1" # RC for normal release, next lower normal tag
+run_test "8.3.2-rc2" "8.3.2-rc1" # Next RC in series
+run_test "8.3.2-rc5" "8.3.2-rc2" # Next RC in series
+
+run_test "8.4.0-rc1" "8.3.0" # RC for normal release, next lower normal tag
+run_test "8.4.0-rc2" "8.4.0-rc1" # Next RC in series
+run_test "8.4.0-rc3" "8.4.0-rc2" # Next RC in series
+
+run_test "8.4.0-alpha2" "8.4.0-alpha1" # Next alpha in series
+
+run_test "9.0.0" "8.4.0" # First release in a new major version
+run_test "9.1.0" "9.0.0" # First release in a new minor version after a major version
+
+#additional test cases
+run_test "9.2.0-alpha2" "9.1.0" # Missed alpha1
+run_test "9.2.0-rc2" "9.1.0" # Missed rc1
+run_test "8.2.0" "7.4.0"
+run_test "7.4.0" "0.23.2"
+run_test "0.23.2" "0.11.0"
+run_test "0.11.0" "0.7.3"
+run_test "0.7.3" "0.5.1"
+run_test "12.0.0" "11.2.0"
+run_test "15.0.0" "12.2.0"
+run_test "15.0.0-rc1" "12.2.0"
+run_test "15.0.3-rc2" "5.0.0"
+run_test "16.0.0-rc2" "15.0.0"
+run_test "19.0.0-alpha3" "15.0.0"
+run_test "19.0.3-alpha3" "15.0.0"
+run_test "19.0.3-rc3" "15.0.0"
+run_test "19.0.4-alpha11" "19.0.4-alpha6"
+run_test "20.3.1-alpha5" "20.3.1-alpha2"
+run_test "20.3.1-alpha23" "20.3.1-alpha11"
+run_test "20.4.1-alpha1-rc20" "20.4.1-alpha1-rc11"
+run_test "20.4.1-alpha1-rc11" "20.4.1-alpha1-rc3"
+run_test "20.4.1-alpha1-rc3" "20.3.0"
+run_test "20.4.1-alpha30-rc1" "20.4.1-alpha11"
+run_test "20.4.1-alpha2-rc1" "20.3.0"
+
+# Invalid Tag Format
+run_test "invalid-tag" "Release tag is invalid" # Invalid tag format
+run_test "8.4" "Release tag is invalid" # Incomplete tag
+
+# Clean up after tests
+cleanup
+
+# Output all test results at the end
+echo -e "$passed_tests_results"
+echo -e "$fail_test_results"
+echo "Total tests passed: $test_passed_count"
+echo "Total tests fail: $test_fail_count"

--- a/.github/workflows/scripts/prev_tag.sh
+++ b/.github/workflows/scripts/prev_tag.sh
@@ -1,61 +1,215 @@
-if [[ $1 =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-  echo "Release tag is valid" >&2
-  TYPE=NORMAL
-elif [[ $1 =~ ^[0-9]+\.[0-9]+\.[0-9]+.*-rc[0-9]+$ ]]; then
-  echo "Release tag is valid (release candidate)" >&2
-  TYPE=RC
-elif [[ $1 =~ [0-9]+\.[0-9]+\.[0-9]+-alpha[0-9]+$ ]]; then
-  echo "Release tag is valid (alpha)" >&2
-  TYPE=ALPHA
-else
+#!/bin/bash
+# This Bash script is designed to determine the previous version tag of a software release in a Git repository.
+# It handles various tag formats, including normal versions, release candidates (RC), and alpha versions.
+# The script defines rules for each tag type and calculates the previous tag based on the current tag.
+#
+# Rules for Determining Previous Tags
+#
+# Normal Versions:
+# - For a regular release within a minor version (e.g., 8.3.3), the previous tag is the next lower tag in the same minor series (e.g., 8.3.2).
+# - When it's the first release of a new minor version (e.g., 8.4.0), the previous tag is the base (x.0) tag of the preceding minor version (e.g., 8.3.0).
+#
+# Release Candidates (RC) for Normal Versions:
+# - For the first RC of a new minor version (e.g., 8.4.0-rc1), the previous tag is the base (x.0) tag of the preceding minor version (e.g., 8.3.0).
+# - For subsequent RC releases within the same minor version, the previous tag is the same as the previous RC release (e.g., 8.4.0-rc2).
+#
+# Alpha Versions:
+# - When it's the first alpha release of a new minor version (e.g., 8.4.0-alpha1), the previous tag is the base (x.0) tag of the preceding minor version (e.g., 8.3.0).
+# - For subsequent alpha releases within the same minor version, the previous tag is the same as the previous alpha release (e.g., 8.4.2-alpha2).
+#
+# Release Candidates (RC) for Alpha Versions:
+# - For RC releases of alpha versions (e.g., 8.4.0-alpha2-rc1), the previous tag is the corresponding alpha tag (e.g., 8.4.0-alpha1).
+#
+# Major Version Releases:
+# - For the first release of a new major version (e.g., 9.0.0), the previous tag is the base (x.0) tag of the highest minor version from the last major series (e.g., 8.9.0).
+#
+# Release Candidates (RC) for Major Versions:
+# - For RC releases of a major version (e.g., 9.0.0-rc1), the previous tag is the base (x.0) tag of the highest minor version from the last major series (e.g., 8.9.0).
+
+# Function to determine the previous tag using 'NORMAL' logic
+  determine_normal_prev_tag() {
+    local candidate=""
+    local candidateWithPatch0=""
+    # Loop through all previous tags to find the appropriate previous tag
+    for tag in "${prev_tags[@]}"; do
+      echo "$tag"
+      # Split the tag into major, minor, and patch numbers
+      IFS='.' read -r tag_major tag_minor tag_patch <<< "$tag"
+      # Split the current tag into major, minor, and patch numbers
+      IFS='.' read -r curr_major curr_minor curr_patch <<< "$current_tag"
+      # Compare each previous tag with the current tag to find the closest preceding version
+      if ((tag_major < curr_major)); then
+        candidate="$tag"
+      elif ((tag_major == curr_major)); then
+        if ((tag_minor < curr_minor)); then
+          candidate="$tag"
+        elif ((tag_minor == curr_minor)); then
+          if ((tag_patch <= curr_patch)); then
+            candidate="$tag"
+          fi
+        fi
+      fi
+      # Special handling for tags with a patch version of 0
+      if ((tag_patch == 0)) && ((tag_major <= curr_major)) && ((tag_minor <= curr_minor)); then
+        if [[ -n "$candidateWithPatch0" ]]; then
+          # Compare and update the candidate with patch 0 if it's a closer match
+          IFS='.' read -r candidate_major candidate_minor _ <<< "$candidateWithPatch0"
+          if ((candidate_major < tag_major)) || ((candidate_minor < tag_minor)); then
+            candidateWithPatch0="$tag"
+          fi
+        else
+          candidateWithPatch0="$tag"
+        fi
+      fi
+    done
+    # Decide the previous tag based on whether the current patch number is 0
+    if [[ "$curr_patch" == "0" ]]; then
+      # If the current patch is 0, prefer the candidate with patch 0 if available
+      if [[ -n "$candidateWithPatch0" ]]; then
+        prev_tag="$candidateWithPatch0"
+      else
+        prev_tag="$candidate"
+      fi
+    else
+      # Otherwise, use the candidate determined above
+      prev_tag="$candidate"
+    fi
+  }
+
+# Function to determine the previous tag based on the type and version
+determine_prev_tag() {
+  local current_tag=$1
+   local type=$2
+   local major_minor
+   local rc_number
+   local prev_tags
+   local prev_tag=""
+   local prev_rc_tag
+
+   prev_tags=$(git --no-pager tag --sort=-v:refname)
+   major_minor=$(echo "$current_tag" | cut -d '.' -f 1,2)
+   rc_number=${current_tag//*-rc/}
+
+   case $type in
+   NORMAL)
+     determine_normal_prev_tag
+     ;;
+   RC)
+  # Check if there's a previous RC within the same minor version and with a lower RC number
+  prev_rc_tag=$(get_previous_rc_tag "$major_minor" "$current_tag" "$rc_number" "$prev_tags")
+  if [[ -n $prev_rc_tag ]]; then
+    prev_tag="$prev_rc_tag"
+    fi
+   # Fallback to 'NORMAL' logic if no previous tag found
+       if [[ -z $prev_tag ]]; then
+         determine_normal_prev_tag
+        fi
+  echo "$prev_tag"
+  ;;
+ALPHA)
+  local alpha_base
+  local alpha_version
+  local alpha_number
+alpha_base=${current_tag##*-alpha[0-9]*}
+
+ if [[ $current_tag =~ -alpha[0-9]+-rc[0-9]+$ ]]; then
+   alpha_version=${current_tag%-rc[0-9]*}
+
+   # Check if there's a previous RC within the same alpha version and with a lower RC number
+   prev_rc_tag=$(get_previous_rc_tag_for_alpha "$alpha_version" "$current_tag" "$rc_number" "$prev_tags")
+   if [[ -z $prev_rc_tag ]]; then
+     # If no previous RC found for the same alpha version, find the highest alpha version before the current alpha
+     prev_tag=$(get_previous_alpha_tag "$alpha_base" "$alpha_version" "$prev_tags")
+     else
+     prev_tag=$prev_rc_tag
+   fi
+  elif [[ $current_tag =~ -alpha[0-9]+$ ]]; then
+    alpha_number=$(echo "$current_tag" | grep -oE "alpha[0-9]+$" | sed 's/alpha//')
+    prev_tag=$(get_previous_alpha_tag "$alpha_base" "$alpha_number" "$prev_tags")
+  fi
+
+  # Fallback to 'NORMAL' logic if no previous tag found
+  if [[ -z $prev_tag ]]; then
+    determine_normal_prev_tag
+  fi
+;;
+
+  esac
+  echo "$prev_tag"
+}
+
+# Function to get the previous RC tag
+get_previous_rc_tag() {
+  local major_minor=$1
+  local current_tag=$2
+  local rc_number=$3
+  local prev_tags=$4
+  local prev_rc_tag
+  local awk_script="{split(\$0, a, \"-rc\"); if (\$0 < curTag && \$0 ~ \"-rc[0-9]+$\" && (a[2] + 0 < curRc + 0)) print}"
+
+  prev_rc_tag=$(echo "$prev_tags" | grep -E "^$major_minor\.[0-9]+-rc[0-9]+$" | awk -v curTag="$current_tag" -v curRc="$rc_number" "$awk_script" | sort -n | tail -1)
+
+  echo "$prev_rc_tag"
+}
+
+# Function to get the previous RC tag for a given alpha version
+get_previous_rc_tag_for_alpha() {
+  local alpha_version=$1
+  local current_tag=$2
+  local rc_number=$3
+  local prev_tags=$4
+  local prev_rc_tag
+  local awk_script="{split(\$0, a, \"-rc\"); if (\$0 < curTag && \$0 ~ \"-rc[0-9]+$\" && (a[2] + 0 < curRc + 0)) print}"
+
+  prev_rc_tag=$(echo "$prev_tags" | grep -E "^$alpha_version-rc[0-9]+$" | awk -v curTag="$current_tag" -v curRc="$rc_number" "$awk_script" | sort -n | tail -1)
+
+  echo "$prev_rc_tag"
+}
+
+# Function to get the previous alpha tag
+get_previous_alpha_tag() {
+  local alpha_base=$1
+  local alpha_number=$2
+  local prev_tags=$3
+  local prev_tag
+  local awk_script="BEGIN{FS=\"-alpha\"} \$2+0 < curAlpha+0"
+
+  prev_tag=$(echo "$prev_tags" | grep -E "^$alpha_base-alpha[0-9]+$" | awk -v curAlpha="$alpha_number" "$awk_script" | sort -rV | head -1)
+
+  echo "$prev_tag"
+}
+
+
+# validation for tag format
+if [[ ! $1 =~ ^[0-9]+\.[0-9]+\.[0-9]+(-alpha[0-9]+)?(-rc[0-9]+)?$ ]]; then
   echo "Release tag is invalid"
   exit 1
 fi
-CUR_MINOR=$(echo "$1" | cut -d '.' -f 1,2)
-PREV_MINOR=$(echo "$1" | cut -d '.' -f 1,2 | awk -F. '{$NF = $NF - 1;} 1' | sed 's/ /./g')
 
-git fetch --tags -f 1>/dev/null
-git pull --tags -f 1>/dev/null
-PREV_TAGS=$(git --no-pager tag --sort=-creatordate)
-NORMAL_PATTERN='^[0-9]+\.[0-9]+\.[0-9]+$'
-RC_PATTERN='^[0-9]+\.[0-9]+\.[0-9]+.*-rc[0-9]+$'
-ALPHA_PATTERN='^[0-9]+\.[0-9]+\.[0-9]+-alpha[0-9]+$'
+# Determine the tag type
+TYPE=""
+if [[ $1 =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  TYPE="NORMAL"
+elif [[ $1 =~ -alpha[0-9]+(-rc[0-9]+)?$ ]]; then
+  TYPE="ALPHA"
+elif [[ $1 =~ -rc[0-9]+$ ]]; then
+  TYPE="RC"
+fi
 
-# sanity check: the new tag must already exist
-if [[ -z $(echo "$PREV_TAGS" | grep "$1") ]]; then
-  echo "Tag $1 does not exist" >&2
+if [[ -z $TYPE ]]; then
+  echo "Invalid tag format"
   exit 1
 fi
 
+# Fetch and pull the tags from the repository
+git fetch --tags -f 1>/dev/null
+git pull --tags -f 1>/dev/null
 
-echo "Current minor: $CUR_MINOR" >&2
-echo "Previous minor: $PREV_MINOR" >&2
-echo "Type: $TYPE" >&2
-
-if [[ $TYPE == "NORMAL" ]]; then
-  # take last normal tag from current minor, if present - otherwise take last normal tag from previous minor
-  PREV_TAG=$(echo "$PREV_TAGS" | grep -E "$NORMAL_PATTERN" | grep "$CUR_MINOR" | head -2 | tail -1)
-  if [[ -z $PREV_TAG ]]; then
-    PREV_TAG=$(echo "$PREV_TAGS" | grep -E "$NORMAL_PATTERN" | grep "$PREV_MINOR" | head -1)
-  fi
-elif [[ $TYPE == "RC" ]]; then
-  # take rc from current minor, if present - otherwise take last normal from previous minor
-  PREV_TAG=$(echo "$PREV_TAGS" | grep -E "$RC_PATTERN" | grep "$CUR_MINOR" | head -2 | tail -1)
-  if [[ -z $PREV_TAG ]]; then
-    PREV_TAG=$(echo "$PREV_TAGS" | grep -E "$NORMAL_PATTERN" | grep "$PREV_MINOR" | head -1)
-  fi
-elif [[ $TYPE == "ALPHA" ]]; then
-  # take alpha from current minor, if present - otherwise take last normal tag from previous minor
-  PREV_TAG=$(echo "$PREV_TAGS" | grep -E "$ALPHA_PATTERN" | grep "$CUR_MINOR" | head -2 | tail -1)
-  if [[ -z $PREV_TAG ]]; then
-    PREV_TAG=$(echo "$PREV_TAGS" | grep -E "$NORMAL_PATTERN" | grep "$PREV_MINOR" | head -1)
-  fi
+# Determine the previous tag
+prev_tag=$(determine_prev_tag "$1" "$TYPE")
+if [[ -z $prev_tag ]]; then
+  echo "No previous tag found for the given rules"
+  exit 1
 fi
 
-if [[ -z $PREV_TAG ]]; then
-  echo "WARNING: No previous tag found for the given rules, taking the previous tag" >&2
-  PREV_TAG=$(echo "$PREV_TAGS" | head -2 | tail -1)
-fi
-
-echo "Previous tag: $PREV_TAG" >&2
-echo $TYPE "$PREV_TAG"
+echo "Previous tag: $prev_tag"


### PR DESCRIPTION
## Overview
This PR introduces significant enhancements to the existing script used for determining previous version tags in a Git repository. The script efficiently handles various tag formats, including normal versions, release candidates (RC), and alpha versions. It is utilized in our release workflow, as detailed in [RELEASE.yaml](https://github.com/camunda/connectors/blob/main/.github/workflows/RELEASE.yaml#L21).

The script's primary purpose is to identify the previous tag for generating a changelog after each release. The previous version of this script was not functioning correctly, leading to inaccuracies in the changelog generation process. This update addresses those issues, ensuring more reliable and accurate output.
## Rules for Determining Previous Tags

### Normal Versions:
- For a regular release within a minor version (e.g., 8.3.3), the previous tag is the next lower tag in the same minor series (e.g., 8.3.2).
- When it's the first release of a new minor version (e.g., 8.4.0), the previous tag is the base (x.0) tag of the preceding minor version (e.g., 8.3.0).

### Release Candidates (RC) for Normal Versions:
- For the first RC of a new minor version (e.g., 8.4.0-rc1), the previous tag is the base (x.0) tag of the preceding minor version (e.g., 8.3.0).
- For subsequent RC releases within the same minor version, the previous tag is the same as the previous RC release (e.g., 8.4.0-rc2).

### Alpha Versions:
- When it's the first alpha release of a new minor version (e.g., 8.4.0-alpha1), the previous tag is the base (x.0) tag of the preceding minor version (e.g., 8.3.0).
- For subsequent alpha releases within the same minor version, the previous tag is the same as the previous alpha release (e.g., 8.4.2-alpha2).

### Release Candidates (RC) for Alpha Versions:
- For RC releases of alpha versions (e.g., 8.4.0-alpha2-rc1), the previous tag is the corresponding alpha tag (e.g., 8.4.0-alpha1).

### Major Version Releases:
- For the first release of a new major version (e.g., 9.0.0), the previous tag is the base (x.0) tag of the highest minor version from the last major series (e.g., 8.9.0).

### Release Candidates (RC) for Major Versions:
- For RC releases of a major version (e.g., 9.0.0-rc1), the previous tag is the base (x.0) tag of the highest minor version from the last major series (e.g., 8.9.0).

## Examples:

### Normal Versions:
- For `8.4.0`, the previous tag is `8.3.0`.
- For `8.3.3`, the previous tag is `8.3.2`.
- For `8.3.1`, the previous tag is `8.3.0`.

### Release Candidates (RC) for Normal Versions:
- For `8.4.0-rc1`, the previous tag is `8.3.0`.
- For `8.4.0-rc2`, the previous tag is `8.4.0-rc1`.

### Alpha Versions:
- For `8.4.0-alpha1`, the previous tag is `8.3.0`.
- For `8.4.2-alpha2`, the previous tag is `8.4.2-alpha1`.

### Release Candidates (RC) for Alpha Versions:
- For `8.4.0-alpha2-rc1`, the previous tag is `8.4.0-alpha1`.
- For `8.4.0-alpha1-rc1`, the previous tag is `8.3.0`.
- 
### Major Version Releases:
- For `9.0.0`, the previous tag is `8.9.0`.
- For `9.1.0`, the previous tag is `9.0.0`.

### Release Candidates (RC) for Major Versions:
- For `9.0.0-rc1`, the previous tag is `8.9.0`.

### Invalid Tag Format:
- For an invalid tag format (e.g., "invalid-tag"), the script outputs "Release tag is invalid."

### Incomplete Tag:
- For an incomplete tag (e.g., "8.4"), the script outputs "Release tag is invalid."


### Test Results : 
```
Test passed for input 8.4.0: Expected and got 8.3.0
Test passed for input 8.3.0: Expected and got 8.2.0
Test passed for input 8.3.3: Expected and got 8.3.2
Test passed for input 8.3.1: Expected and got 8.3.0
Test passed for input 8.4.0-alpha2: Expected and got 8.4.0-alpha1
Test passed for input 8.3.0-alpha1: Expected and got 8.2.0
Test passed for input 8.4.0-alpha2-rc3: Expected and got 8.4.0-alpha2-rc2
Test passed for input 8.4.0-alpha2-rc2: Expected and got 8.4.0-alpha2-rc1
Test passed for input 8.4.0-alpha2-rc1: Expected and got 8.4.0-alpha1
Test passed for input 9.0.0-alpha2-rc1: Expected and got 9.0.0-alpha1
Test passed for input 9.0.0-alpha3-rc1: Expected and got 9.0.0-alpha2
Test passed for input 8.4.0-alpha1: Expected and got 8.3.0
Test passed for input 8.4.1-alpha1: Expected and got 8.4.0
Test passed for input 8.4.2-alpha1: Expected and got 8.4.1
Test passed for input 8.3.2-rc1: Expected and got 8.3.1
Test passed for input 8.3.2-rc2: Expected and got 8.3.2-rc1
Test passed for input 8.3.2-rc5: Expected and got 8.3.2-rc2
Test passed for input 8.4.0-rc1: Expected and got 8.3.0
Test passed for input 8.4.0-rc2: Expected and got 8.4.0-rc1
Test passed for input 8.4.0-rc3: Expected and got 8.4.0-rc2
Test passed for input 8.4.0-alpha2: Expected and got 8.4.0-alpha1
Test passed for input 9.0.0: Expected and got 8.4.0
Test passed for input 9.1.0: Expected and got 9.0.0
Test passed for input 9.2.0-alpha2: Expected and got 9.1.0
Test passed for input 9.2.0-rc2: Expected and got 9.1.0
Test passed for input 8.2.0: Expected and got 7.4.0
Test passed for input 7.4.0: Expected and got 0.23.2
Test passed for input 0.23.2: Expected and got 0.11.0
Test passed for input 0.11.0: Expected and got 0.7.3
Test passed for input 0.7.3: Expected and got 0.5.1
Test passed for input 12.0.0: Expected and got 11.2.0
Test passed for input 15.0.0: Expected and got 12.2.0
Test passed for input 15.0.0-rc1: Expected and got 12.2.0
Test passed for input 15.0.3-rc2: Expected and got 5.0.0
Test passed for input 16.0.0-rc2: Expected and got 15.0.0
Test passed for input 19.0.0-alpha3: Expected and got 15.0.0
Test passed for input 19.0.3-alpha3: Expected and got 15.0.0
Test passed for input 19.0.3-rc3: Expected and got 15.0.0
Test passed for input 19.0.4-alpha11: Expected and got 19.0.4-alpha6
Test passed for input 20.3.1-alpha5: Expected and got 20.3.1-alpha2
Test passed for input 20.3.1-alpha23: Expected and got 20.3.1-alpha11
Test passed for input 20.4.1-alpha1-rc20: Expected and got 20.4.1-alpha1-rc11
Test passed for input 20.4.1-alpha1-rc11: Expected and got 20.4.1-alpha1-rc3
Test passed for input 20.4.1-alpha1-rc3: Expected and got 20.3.0
Test passed for input 20.4.1-alpha30-rc1: Expected and got 20.4.1-alpha11
Test passed for input 20.4.1-alpha2-rc1: Expected and got 20.3.0
Test passed for input invalid-tag: Expected and got Release tag is invalid
Test passed for input 8.4: Expected and got Release tag is invalid


Total tests passed: 48
Total tests fail: 0
```


