### PR TITLE
chore(ingress-chart): Update ingress chart version

### DIFF
--- a/.ci/preview-environments/charts/c8sm/Chart.yaml
+++ b/.ci/preview-environments/charts/c8sm/Chart.yaml
@@ -11,7 +11,7 @@ version: 0.1.0
 dependencies:
 - name: infra-preview-environments-ingress
   repository: oci://registry.camunda.cloud/library
-  version: 1.3.0
+  version: 1.4.0
 - name: camunda-platform
   # @camunda-cloud references https://helm.camunda.io repository configured as camunda-cloud in Argo CD
   repository: https://helm.camunda.io


### PR DESCRIPTION
## Description

As of 10.01.2023 there has been a new release for the [preview-environments-ingress](https://github.com/camunda/infra-preview-environments-ingress?tab=readme-ov-file) helmchart. The version release is 1.4.0 and it is adding some changes which will allow displaying linking the argo cd preview environment and the specific harbor project url


## Related issues
https://github.com/camunda/team-infrastructure/issues/532


