### PR TITLE
feat(metrics): add logger-aware logback metrics

### DIFF
--- a/connector-runtime/connector-runtime-spring/pom.xml
+++ b/connector-runtime/connector-runtime-spring/pom.xml
@@ -29,6 +29,18 @@
       <artifactId>tomcat-embed-core</artifactId>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-core</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <!-- The runtime provides enhanced metrics for logback if it is present -->
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <optional>true</optional>
+    </dependency>
 
     <!-- Camunda dependencies -->
     <dependency>

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/metrics/ContextAwareLogbackMetrics.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/metrics/ContextAwareLogbackMetrics.java
@@ -33,6 +33,7 @@ import io.micrometer.core.instrument.binder.BaseUnits;
 import io.micrometer.core.instrument.binder.logging.LogbackMetrics;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import org.slf4j.LoggerFactory;
 import org.slf4j.Marker;
 
@@ -148,7 +149,7 @@ public class ContextAwareLogbackMetrics extends LogbackMetrics {
         Counter debugCounter,
         Counter traceCounter) {}
 
-    private final Map<String, Counters> countersByLoggerName = new HashMap<>();
+    private final Map<String, Counters> countersByLoggerName = new ConcurrentHashMap<>();
 
     MetricsTurboFilter(MeterRegistry registry, Iterable<Tag> tags) {
       this.registry = registry;

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/metrics/ContextAwareLogbackMetrics.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/metrics/ContextAwareLogbackMetrics.java
@@ -1,0 +1,245 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.runtime.metrics;
+
+import static java.util.Collections.emptyList;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.spi.LoggerContextListener;
+import ch.qos.logback.classic.turbo.TurboFilter;
+import ch.qos.logback.core.spi.FilterReply;
+import io.micrometer.common.lang.NonNullApi;
+import io.micrometer.common.lang.NonNullFields;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.binder.BaseUnits;
+import io.micrometer.core.instrument.binder.logging.LogbackMetrics;
+import java.util.HashMap;
+import java.util.Map;
+import org.slf4j.LoggerFactory;
+import org.slf4j.Marker;
+
+/** Copy of LogbackMetrics with the addition of logger name as a tag. */
+@NonNullApi
+public class ContextAwareLogbackMetrics extends LogbackMetrics {
+
+  static ThreadLocal<Boolean> ignoreMetrics = new ThreadLocal<>();
+  private final Iterable<Tag> tags;
+  private final LoggerContext loggerContext;
+  private final Map<MeterRegistry, MetricsTurboFilter> metricsTurboFilters = new HashMap<>();
+
+  static {
+    // see gh-2868. Without this called statically, the same call in the constructor
+    // may return SubstituteLoggerFactory and fail to cast.
+    LoggerFactory.getILoggerFactory();
+  }
+
+  public ContextAwareLogbackMetrics() {
+    this(emptyList());
+  }
+
+  public ContextAwareLogbackMetrics(Iterable<Tag> tags) {
+    this(tags, (LoggerContext) LoggerFactory.getILoggerFactory());
+  }
+
+  public ContextAwareLogbackMetrics(Iterable<Tag> tags, LoggerContext context) {
+    this.tags = tags;
+    this.loggerContext = context;
+
+    loggerContext.addListener(
+        new LoggerContextListener() {
+          @Override
+          public boolean isResetResistant() {
+            return true;
+          }
+
+          @Override
+          public void onReset(LoggerContext context) {
+            // re-add turbo filter because reset clears the turbo filter list
+            synchronized (metricsTurboFilters) {
+              for (MetricsTurboFilter metricsTurboFilter : metricsTurboFilters.values()) {
+                loggerContext.addTurboFilter(metricsTurboFilter);
+              }
+            }
+          }
+
+          @Override
+          public void onStart(LoggerContext context) {
+            // no-op
+          }
+
+          @Override
+          public void onStop(LoggerContext context) {
+            // no-op
+          }
+
+          @Override
+          public void onLevelChange(Logger logger, Level level) {
+            // no-op
+          }
+        });
+  }
+
+  @Override
+  public void bindTo(MeterRegistry registry) {
+    MetricsTurboFilter filter = new MetricsTurboFilter(registry, tags);
+    synchronized (metricsTurboFilters) {
+      metricsTurboFilters.put(registry, filter);
+      loggerContext.addTurboFilter(filter);
+    }
+  }
+
+  public static void ignoreMetrics(Runnable runnable) {
+    ignoreMetrics.set(true);
+    try {
+      runnable.run();
+    } finally {
+      ignoreMetrics.remove();
+    }
+  }
+
+  @Override
+  public void close() {
+    synchronized (metricsTurboFilters) {
+      for (MetricsTurboFilter metricsTurboFilter : metricsTurboFilters.values()) {
+        loggerContext.getTurboFilterList().remove(metricsTurboFilter);
+      }
+    }
+  }
+
+  /** Copy of LogbackMetrics.MetricsTurboFilter with the addition of logger name as a tag. */
+  @NonNullApi
+  @NonNullFields
+  static class MetricsTurboFilter extends TurboFilter {
+
+    private static final String METER_NAME = "logback.events";
+    private static final String METER_DESCRIPTION =
+        "Number of log events that were enabled by the effective log level";
+
+    private final Counter.Builder errorCounterTemplate;
+    private final Counter.Builder warnCounterTemplate;
+    private final Counter.Builder infoCounterTemplate;
+    private final Counter.Builder debugCounterTemplate;
+    private final Counter.Builder traceCounterTemplate;
+
+    private final MeterRegistry registry;
+
+    private record Counters(
+        Counter errorCounter,
+        Counter warnCounter,
+        Counter infoCounter,
+        Counter debugCounter,
+        Counter traceCounter) {}
+
+    private final Map<String, Counters> countersByLoggerName = new HashMap<>();
+
+    MetricsTurboFilter(MeterRegistry registry, Iterable<Tag> tags) {
+      this.registry = registry;
+
+      errorCounterTemplate =
+          Counter.builder(METER_NAME)
+              .tags(tags)
+              .tags("level", "error")
+              .description(METER_DESCRIPTION)
+              .baseUnit(BaseUnits.EVENTS);
+      warnCounterTemplate =
+          Counter.builder(METER_NAME)
+              .tags(tags)
+              .tags("level", "warn")
+              .description(METER_DESCRIPTION)
+              .baseUnit(BaseUnits.EVENTS);
+      infoCounterTemplate =
+          Counter.builder(METER_NAME)
+              .tags(tags)
+              .tags("level", "info")
+              .description(METER_DESCRIPTION)
+              .baseUnit(BaseUnits.EVENTS);
+      debugCounterTemplate =
+          Counter.builder(METER_NAME)
+              .tags(tags)
+              .tags("level", "debug")
+              .description(METER_DESCRIPTION)
+              .baseUnit(BaseUnits.EVENTS);
+
+      traceCounterTemplate =
+          Counter.builder(METER_NAME)
+              .tags(tags)
+              .tags("level", "trace")
+              .description(METER_DESCRIPTION)
+              .baseUnit(BaseUnits.EVENTS);
+    }
+
+    @Override
+    public FilterReply decide(
+        Marker marker, Logger logger, Level level, String format, Object[] params, Throwable t) {
+      // When filter is asked for decision for an isDebugEnabled call or similar test,
+      // there is no message (ie format)
+      // and no intention to log anything with this call. We will not increment counters
+      // and can return immediately and
+      // avoid the relatively expensive ThreadLocal access below. See also logbacks
+      // Logger.callTurboFilters().
+      // Calling logger.isEnabledFor(level) might be sub-optimal since it calls this
+      // filter again. This behavior caused a StackOverflowError in the past.
+      if (format == null || !level.isGreaterOrEqual(logger.getEffectiveLevel())) {
+        return FilterReply.NEUTRAL;
+      }
+
+      Boolean ignored = ContextAwareLogbackMetrics.ignoreMetrics.get();
+      if (ignored != null && ignored) {
+        return FilterReply.NEUTRAL;
+      }
+
+      ContextAwareLogbackMetrics.ignoreMetrics(() -> recordMetrics(level, logger));
+
+      return FilterReply.NEUTRAL;
+    }
+
+    private void recordMetrics(Level level, Logger logger) {
+      var loggerName = logger.getName();
+      var counters = countersByLoggerName.computeIfAbsent(loggerName, this::createCounters);
+      switch (level.toInt()) {
+        case Level.ERROR_INT:
+          counters.errorCounter.increment();
+          break;
+        case Level.WARN_INT:
+          counters.warnCounter.increment();
+          break;
+        case Level.INFO_INT:
+          counters.infoCounter.increment();
+          break;
+        case Level.DEBUG_INT:
+          counters.debugCounter.increment();
+          break;
+        case Level.TRACE_INT:
+          counters.traceCounter.increment();
+          break;
+      }
+    }
+
+    private Counters createCounters(String loggerName) {
+      return new Counters(
+          errorCounterTemplate.tags("logger", loggerName).register(registry),
+          warnCounterTemplate.tags("logger", loggerName).register(registry),
+          infoCounterTemplate.tags("logger", loggerName).register(registry),
+          debugCounterTemplate.tags("logger", loggerName).register(registry),
+          traceCounterTemplate.tags("logger", loggerName).register(registry));
+    }
+  }
+}

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/main/java/io/camunda/connector/runtime/ContextAwareLogbackMetricsAutoConfiguration.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/main/java/io/camunda/connector/runtime/ContextAwareLogbackMetricsAutoConfiguration.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.runtime;
+
+import io.camunda.connector.runtime.metrics.ContextAwareLogbackMetrics;
+import io.micrometer.core.instrument.binder.logging.LogbackMetrics;
+import org.springframework.boot.actuate.autoconfigure.metrics.LogbackMetricsAutoConfiguration;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.AutoConfigureBefore;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.context.annotation.Bean;
+
+@ConditionalOnClass(name = "ch.qos.logback.classic.LoggerContext")
+@AutoConfiguration
+@AutoConfigureBefore(LogbackMetricsAutoConfiguration.class)
+public class ContextAwareLogbackMetricsAutoConfiguration {
+
+  @Bean
+  public LogbackMetrics logbackMetrics() {
+    return new ContextAwareLogbackMetrics();
+  }
+}

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/main/resources/META-INF/spring.factories
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/main/resources/META-INF/spring.factories
@@ -1,4 +1,5 @@
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
 io.camunda.connector.runtime.InboundConnectorsAutoConfiguration,\
 io.camunda.connector.runtime.OutboundConnectorsAutoConfiguration,\
-io.camunda.connector.runtime.WebhookConnectorAutoConfiguration
+io.camunda.connector.runtime.WebhookConnectorAutoConfiguration,\
+io.camunda.connector.runtime.ContextAwareLogbackMetricsAutoConfiguration

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,3 +1,4 @@
 io.camunda.connector.runtime.OutboundConnectorsAutoConfiguration
 io.camunda.connector.runtime.InboundConnectorsAutoConfiguration
 io.camunda.connector.runtime.WebhookConnectorAutoConfiguration
+io.camunda.connector.runtime.ContextAwareLogbackMetricsAutoConfiguration


### PR DESCRIPTION
## Description

Replaces the default `LogbackMetrics` that come from `micrometer-core` with our custom copy. The only difference is that our custom implementation also provides logger name as a tag.

<img width="1121" alt="Screenshot 2024-01-12 at 18 09 41" src="https://github.com/camunda/connectors/assets/38818382/bd6b9469-5354-4591-8764-32f77740cd50">

This will make the log counters filterable by logger name (which is almost always the class name).

Unfortunately most of the internal implementation of `LogbackMetrics` is package-private, so it turned out to be impossible to make use of the inheritance in a proper way. The only purpose of the inheritance in this case is to replace a bean in the spring context.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes https://github.com/camunda/team-connectors/issues/589

