### PR TITLE
fix(generator): OpenAPI generator issues with Petstore example

### DIFF
--- a/element-template-generator/congen-cli/README.md
+++ b/element-template-generator/congen-cli/README.md
@@ -48,11 +48,20 @@ Note that `congen` will pass all parameters specified after the command name to 
 For example, the OpenAPI generator accepts the path or URL of the OpenAPI specification as the first parameter,
 followed by an optional list of operation IDs to include in the generated template.
 
-The following command will ask the generator to include only the `findPetsById` and `addPet` operations.
+The following command will ask the generator to include only the `placeOrder` operation.
 
 ```shell
-congen generate openapi-outbound https://petstore3.swagger.io/api/v3/openapi.json findPetsById addPet
+congen generate openapi-outbound https://petstore3.swagger.io/api/v3/openapi.json placeOrder
 ```
+
+Note that not all operations in the OpenAPI specification can be converted to a template. The generator will
+ignore operations that cannot be converted. To see the list of operations that can be converted, use the `scan` command.
+
+```shell
+congen scan openapi-outbound https://petstore3.swagger.io/api/v3/openapi.json
+```
+
+```shell
 
 The command below will generate the template with the custom element template ID.
 

--- a/element-template-generator/congen-cli/src/main/java/io/camunda/connector/generator/cli/command/Generate.java
+++ b/element-template-generator/congen-cli/src/main/java/io/camunda/connector/generator/cli/command/Generate.java
@@ -70,7 +70,12 @@ public class Generate implements Callable<Integer> {
       return GENERATION_FAILED.getCode();
     }
     try {
-      var resultString = mapper.writerWithDefaultPrettyPrinter().writeValueAsString(templates);
+      String resultString;
+      if (templates.size() == 1) {
+        resultString = mapper.writeValueAsString(templates.getFirst());
+      } else {
+        resultString = mapper.writerWithDefaultPrettyPrinter().writeValueAsString(templates);
+      }
       System.out.println(resultString);
       return SUCCESS.getCode();
     } catch (JsonProcessingException e) {

--- a/element-template-generator/http-dsl/src/main/java/io/camunda/connector/generator/dsl/http/PropertyUtil.java
+++ b/element-template-generator/http-dsl/src/main/java/io/camunda/connector/generator/dsl/http/PropertyUtil.java
@@ -67,7 +67,7 @@ public class PropertyUtil {
         .label("Authentication")
         .optional(false)
         .binding(new ZeebeInput("authentication.type"))
-        .value(choices.get(0).value());
+        .value(choices.getFirst().value());
   }
 
   static PropertyGroup operationDiscriminatorPropertyGroup(Collection<HttpOperation> operations) {
@@ -327,7 +327,7 @@ public class PropertyUtil {
 
     // shade property id with operation id as there may be duplicates in different operations
     builder
-        .id(operationId + "_" + property.id())
+        .id(operationId + "_" + property.target().name().toLowerCase() + "_" + property.id())
         .label(TemplatePropertiesUtil.transformIdIntoLabel(property.id()))
         .description(property.description())
         .optional(!property.required())
@@ -356,7 +356,7 @@ public class PropertyUtil {
               .map(p -> transformProperty(operation.id(), p, "requestBody"))
               .toList();
 
-      Property bodyAggregationProperty = null;
+      Property bodyAggregationProperty;
       if (bodyProperties.isEmpty()) {
         bodyAggregationProperty =
             StringProperty.builder()

--- a/element-template-generator/openapi-parser/src/main/java/io/camunda/connector/generator/openapi/util/OperationUtil.java
+++ b/element-template-generator/openapi-parser/src/main/java/io/camunda/connector/generator/openapi/util/OperationUtil.java
@@ -112,7 +112,6 @@ public class OperationUtil {
                   });
               return operations.stream();
             })
-        .filter(OperationParseResult::supported)
         .filter(
             operation ->
                 includeOperations == null
@@ -138,7 +137,7 @@ public class OperationUtil {
       var authenticationOverride = parseAuthentication(operation.getSecurity(), components);
 
       var body = BodyUtil.parseBody(operation.getRequestBody(), components, options);
-      HttpFeelBuilder bodyFeelExpression = null;
+      HttpFeelBuilder bodyFeelExpression;
 
       if (body instanceof BodyParseResult.Raw raw) {
         bodyFeelExpression = HttpFeelBuilder.preFormatted("=" + raw.rawBody());


### PR DESCRIPTION
## Description

1. Added a "target" prefix to all property IDs so they look like `operationId_body_propertyName` or `operationId_headers_propertyName`. Sometimes properties in body (derived from the JSON schema) can have the same name as parameters.
2. Fixed an issue with `scan` command where unsupported operations were never displayed
3. Changed the `generate` command output so it returns a single JSON object when only one template was generated, instead of an array of element template JSON objects.
4. Adjusted the README: removed the invalid example, added a note about unsupported operations.

## Related issues

See https://camunda.slack.com/archives/C0350959WG1/p1705053321728369

