### PR TITLE
fix(jackson): replace ObjectMapper with lower-level APIs in FEEL deserializers

### DIFF
--- a/connector-sdk/jackson-datatype-feel/src/main/java/io/camunda/connector/feel/jackson/FeelSupplierDeserializer.java
+++ b/connector-sdk/jackson-datatype-feel/src/main/java/io/camunda/connector/feel/jackson/FeelSupplierDeserializer.java
@@ -20,7 +20,6 @@ import com.fasterxml.jackson.databind.BeanProperty;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.type.TypeFactory;
 import io.camunda.connector.feel.FeelEngineWrapper;
 import java.util.function.Supplier;
@@ -35,8 +34,11 @@ class FeelSupplierDeserializer<OUT> extends AbstractFeelDeserializer<Supplier<OU
   }
 
   @Override
-  protected Supplier<OUT> doDeserialize(JsonNode node, ObjectMapper mapper, JsonNode context) {
-    return () -> feelEngineWrapper.evaluate(node.textValue(), outputType, context);
+  protected Supplier<OUT> doDeserialize(
+      JsonNode node, JsonNode feelContext, DeserializationContext deserializationContext) {
+    return () ->
+        feelEngineWrapper.evaluate(
+            deserializationContext, node.textValue(), outputType, feelContext);
   }
 
   @Override

--- a/connector-sdk/jackson-datatype-feel/src/test/java/io/camunda/connector/feel/jackson/FeelSupplierDeserializerTest.java
+++ b/connector-sdk/jackson-datatype-feel/src/test/java/io/camunda/connector/feel/jackson/FeelSupplierDeserializerTest.java
@@ -20,7 +20,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import java.io.IOException;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
@@ -29,7 +31,9 @@ import org.junit.jupiter.api.Test;
 public class FeelSupplierDeserializerTest {
 
   private final ObjectMapper mapper =
-      new ObjectMapper().registerModule(new JacksonModuleFeelFunction());
+      new ObjectMapper()
+          .registerModule(new JacksonModuleFeelFunction())
+          .registerModule(new JavaTimeModule());
 
   @Test
   void feelSupplierDeserialization_objectResult() throws JsonProcessingException {
@@ -170,6 +174,21 @@ public class FeelSupplierDeserializerTest {
     assertThat(result).isEqualTo("foobar");
   }
 
+  @Test
+  void feelSupplierDeserialization_java8Time() throws IOException {
+    // given
+    var json = """
+        { "supplier": "= string(date(2021,1,1))" }
+        """;
+
+    // when
+    TargetTypeJava8Time targetType = mapper.readValue(json, TargetTypeJava8Time.class);
+
+    // then
+    LocalDate result = targetType.supplier().get();
+    assertThat(result).isEqualTo(LocalDate.of(2021, 1, 1));
+  }
+
   private record OutputContext(String result) {}
 
   private record TargetTypeObject(Supplier<OutputContext> supplier) {}
@@ -183,4 +202,6 @@ public class FeelSupplierDeserializerTest {
   private record TargetTypeList(Supplier<List<Long>> supplier) {}
 
   private record TargetTypeMap(Supplier<Map<String, String>> supplier) {}
+
+  private record TargetTypeJava8Time(Supplier<LocalDate> supplier) {}
 }


### PR DESCRIPTION
## Description

This PR replaces the temporary hotfix we had in place to fix the broken FEEL context aware deserialization.

To recap, the issue was that we are calling Jackson deserialization not only on `ObjectMapper`, but also on `ObjectReader` in case of the polling connector where we need to inject process variables into FEEL expression evaluation. We previously fetched the `ObjectMapper` instance from the deserialization context, but it turned out that Jackson doesn't necessarily return an `ObjectMapper`, but actually whatever was used to call the deserialization initially.

The proposed solution is to partially switch to lower-level APIs (such as `deserializationContext.readValue(...)`.

- The important part was to make sure that custom modules registered with the original object reader / mapper and any custom configs will also be used in the FEEL deserializer. To check that, I added a test that requires Jackson's `Java time module` to be preserved in the deserializer.
- The fix also includes some refactoring of the `FeelEngineWrapper` for improved type cast support (moved from the deserializer) and readability.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes https://github.com/camunda/connectors/issues/1552

