### PR TITLE
chore(preview-env): Use a static name for the TLS secret

### DIFF
--- a/.ci/preview-environments/argo/c8sm.yml
+++ b/.ci/preview-environments/argo/c8sm.yml
@@ -13,7 +13,7 @@ spec:
     - /data/tls.key
     - /metadata/annotations/replicator.v1.mittwald.de~1replicated-from-version
     kind: Secret
-    name: "*-wildcard-certificate-tls"
+    name: connectors-wildcard-certificate-tls
   project: connectors-previews
   source:
     helm:
@@ -26,4 +26,3 @@ spec:
       selfHeal: true
     syncOptions:
     - CreateNamespace=true
-    - RespectIgnoreDifferences=true

--- a/.ci/preview-environments/charts/c8sm/templates/certificate.yml
+++ b/.ci/preview-environments/charts/c8sm/templates/certificate.yml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "camundaPlatform.fullname" (index .Subcharts "camunda-platform") }}-wildcard-certificate-tls
+  name: connectors-wildcard-certificate-tls
   labels:
     {{- include "commonLabels" $ | nindent 4 }}
   annotations:

--- a/.ci/preview-environments/charts/c8sm/templates/ingress.yml
+++ b/.ci/preview-environments/charts/c8sm/templates/ingress.yml
@@ -67,4 +67,4 @@ spec:
   tls:
   - hosts:
     - {{ include "ingress.domain" $ | quote }}
-    secretName: {{ include "camundaPlatform.fullname" $camundaPlatform }}-wildcard-certificate-tls
+    secretName: connectors-wildcard-certificate-tls


### PR DESCRIPTION
## Description

Related to https://github.com/camunda/team-infrastructure/issues/510

This PR introduces the use of a static name for the secret containing the TLS certificate of the preview environment.

Reasons:
- Using a dynamic name implies using a`*` in the ArgoCD `ignoreDifferences` configuration, which does not seem to be well supported as ArgoCD sometimes synchronizes the TLS secret (`tls.crt`, `tls.key`), whereas differences should be ignored
- When this happens, the TLS certificate of the preview environment is (removed) no longer exposed. Instead, a self-signed certifcat is temporarily used.


