### PR TITLE
chore: bump versions of the auto-generated element templates

### DIFF
--- a/connectors/automation-anywhere/element-templates/automation-anywhere-outbound-connector.json
+++ b/connectors/automation-anywhere/element-templates/automation-anywhere-outbound-connector.json
@@ -4,7 +4,7 @@
   "id" : "io.camunda.connectors.AutomationAnywhere",
   "description" : "Orchestrate your Automation Anywhere bots with Camunda. You can create new queue items and get the result from it",
   "documentationRef" : "https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/automation-anywhere/",
-  "version" : 1,
+  "version" : 2,
   "category" : {
     "id" : "connectors",
     "name" : "Connectors"

--- a/connectors/automation-anywhere/src/main/java/io/camunda/connector/automationanywhere/AutomationAnywhereConnector.java
+++ b/connectors/automation-anywhere/src/main/java/io/camunda/connector/automationanywhere/AutomationAnywhereConnector.java
@@ -30,7 +30,7 @@ import java.util.Map;
     description =
         "Orchestrate your Automation Anywhere bots with Camunda. You can create new queue items and get the result from it",
     inputDataClass = AutomationAnywhereRequest.class,
-    version = 1,
+    version = 2,
     propertyGroups = {
       @ElementTemplate.PropertyGroup(id = "operation", label = "Operation"),
       @ElementTemplate.PropertyGroup(id = "configuration", label = "Configuration"),

--- a/connectors/http/rest/element-templates/http-json-connector-hybrid.json
+++ b/connectors/http/rest/element-templates/http-json-connector-hybrid.json
@@ -4,7 +4,7 @@
   "id" : "io.camunda.connectors.HttpJson.v2",
   "description" : "Invoke REST API",
   "documentationRef" : "https://docs.camunda.io/docs/components/connectors/protocol/rest/",
-  "version" : 5,
+  "version" : 6,
   "category" : {
     "id" : "connectors",
     "name" : "Connectors"

--- a/connectors/http/rest/element-templates/http-json-connector.json
+++ b/connectors/http/rest/element-templates/http-json-connector.json
@@ -4,7 +4,7 @@
   "id" : "io.camunda.connectors.HttpJson.v2",
   "description" : "Invoke REST API",
   "documentationRef" : "https://docs.camunda.io/docs/components/connectors/protocol/rest/",
-  "version" : 5,
+  "version" : 6,
   "category" : {
     "id" : "connectors",
     "name" : "Connectors"

--- a/connectors/http/rest/src/main/java/io/camunda/connector/http/rest/HttpJsonFunction.java
+++ b/connectors/http/rest/src/main/java/io/camunda/connector/http/rest/HttpJsonFunction.java
@@ -46,7 +46,7 @@ import java.io.IOException;
     name = "REST Outbound Connector",
     description = "Invoke REST API",
     inputDataClass = HttpJsonRequest.class,
-    version = 5,
+    version = 6,
     propertyGroups = {
       @PropertyGroup(id = "authentication", label = "Authentication"),
       @PropertyGroup(id = "endpoint", label = "HTTP Endpoint"),


### PR DESCRIPTION
## Description

Version bumps for the generated connector templates due to significant changes:
- Switch to the new `taskDefinition` binding
- Added `retryCount`property


