### PR TITLE
fix(generator): ConGen - improve help, fix multi-template bugs

### DIFF
--- a/element-template-generator/congen-cli/src/main/java/io/camunda/connector/generator/cli/command/ConGen.java
+++ b/element-template-generator/congen-cli/src/main/java/io/camunda/connector/generator/cli/command/ConGen.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
+import picocli.CommandLine;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
 
@@ -38,22 +39,37 @@ public class ConGen {
   @Option(
       names = {"-h", "--hybrid"},
       usageHelp = true,
-      description = "generate a hybrid template (with configurable type)")
+      description = {
+        "Generate a hybrid template.",
+        "A hybrid template exposes its task definition type as an editable property.",
+      })
   boolean hybrid;
 
   @Option(
       names = {"-i", "--id"},
-      description = "template id to use for generation")
+      description = {
+        "Template ID to use for generation",
+        "If not specified, a sensible default will be chosen by the selected generator."
+      })
   String templateId;
 
   @Option(
       names = {"-n", "--name"},
-      description = "template name to use for generation")
+      description = {
+        "Template name to use for generation.",
+        "If not specified, a sensible default will be chosen by the selected generator."
+      })
   String templateName;
 
   @Option(
       names = {"-e", "--element-types"},
-      description = "target element types for the resulting connector")
+      description = {
+        "Target element types for the resulting connector.",
+        "Multiple values possible, for example:",
+        "-e bpmn:ServiceTask -e bpmn:IntermediateThrowEvent"
+      },
+      showDefaultValue = CommandLine.Help.Visibility.ALWAYS,
+      defaultValue = "bpmn:ServiceTask")
   List<String> elementTypes;
 
   GeneratorConfiguration generatorConfiguration() {

--- a/element-template-generator/congen-cli/src/main/java/io/camunda/connector/generator/cli/command/Generate.java
+++ b/element-template-generator/congen-cli/src/main/java/io/camunda/connector/generator/cli/command/Generate.java
@@ -72,7 +72,8 @@ public class Generate implements Callable<Integer> {
     try {
       String resultString;
       if (templates.size() == 1) {
-        resultString = mapper.writeValueAsString(templates.getFirst());
+        resultString =
+            mapper.writerWithDefaultPrettyPrinter().writeValueAsString(templates.getFirst());
       } else {
         resultString = mapper.writerWithDefaultPrettyPrinter().writeValueAsString(templates);
       }

--- a/element-template-generator/http-dsl/src/main/java/io/camunda/connector/generator/dsl/http/HttpFeelBuilder.java
+++ b/element-template-generator/http-dsl/src/main/java/io/camunda/connector/generator/dsl/http/HttpFeelBuilder.java
@@ -28,7 +28,7 @@ import java.util.stream.Collectors;
  */
 public abstract class HttpFeelBuilder {
 
-  protected final StringBuilder sb = new StringBuilder();
+  protected StringBuilder sb = new StringBuilder();
   protected final Set<String> propertySet = new HashSet<>();
   private static final FeelEngineWrapper feelEngineWrapper = new FeelEngineWrapper();
 
@@ -114,15 +114,17 @@ public abstract class HttpFeelBuilder {
 
   public static class HttpFeelContextBuilder extends HttpFeelBuilder {
 
+    StringBuilder feelContextSb = new StringBuilder();
+
     public HttpFeelContextBuilder property(String targetName, String propertySourceName) {
-      if (sb.isEmpty()) {
-        sb.append("={");
+      if (feelContextSb.isEmpty()) {
+        feelContextSb.append("={");
       } else {
-        sb.append(",");
+        feelContextSb.append(",");
       }
-      sb.append(targetName);
-      sb.append(":");
-      sb.append(propertySourceName);
+      feelContextSb.append(targetName);
+      feelContextSb.append(":");
+      feelContextSb.append(propertySourceName);
 
       propertySet.add(propertySourceName);
       return this;
@@ -130,6 +132,8 @@ public abstract class HttpFeelBuilder {
 
     @Override
     public String build() {
+      // use a copy to make this function call idempotent (i.e. avoid adding multiple curly braces)
+      sb = new StringBuilder(feelContextSb.toString());
       sb.append("}");
       return super.build();
     }

--- a/element-template-generator/http-dsl/src/main/java/io/camunda/connector/generator/dsl/http/HttpOutboundElementTemplateBuilder.java
+++ b/element-template-generator/http-dsl/src/main/java/io/camunda/connector/generator/dsl/http/HttpOutboundElementTemplateBuilder.java
@@ -17,7 +17,6 @@
 package io.camunda.connector.generator.dsl.http;
 
 import io.camunda.connector.generator.api.GeneratorConfiguration.ConnectorElementType;
-import io.camunda.connector.generator.dsl.BpmnType;
 import io.camunda.connector.generator.dsl.ElementTemplateIcon;
 import io.camunda.connector.generator.dsl.OutboundElementTemplate;
 import io.camunda.connector.generator.dsl.OutboundElementTemplateBuilder;
@@ -130,7 +129,6 @@ public class HttpOutboundElementTemplateBuilder {
       throw new IllegalStateException("Could not find any supported operations");
     }
     return builder
-        .appliesTo(BpmnType.TASK)
         .propertyGroups(
             List.of(
                 // Property order is important, parameters must come before their targets (URL,

--- a/element-template-generator/openapi-parser/src/main/java/io/camunda/connector/generator/openapi/OpenApiOutboundTemplateGenerator.java
+++ b/element-template-generator/openapi-parser/src/main/java/io/camunda/connector/generator/openapi/OpenApiOutboundTemplateGenerator.java
@@ -86,7 +86,7 @@ public class OpenApiOutboundTemplateGenerator
     if (templates.isEmpty()) {
       throw new IllegalArgumentException("No operations found in OpenAPI document");
     }
-    var template = templates.get(0);
+    var template = templates.getFirst();
     return new ScanResult(
         template.id(),
         template.name(),
@@ -207,7 +207,7 @@ public class OpenApiOutboundTemplateGenerator
     // otherwise we transform characters to their ascii value and sum them up
 
     String onlyNumbers = openAPIDocVersion.replaceAll("[^0-9]", "");
-    if (onlyNumbers.length() > 0) {
+    if (!onlyNumbers.isEmpty()) {
       return Integer.parseInt(onlyNumbers);
     } else {
       return openAPIDocVersion.chars().sum();

--- a/element-template-generator/openapi-parser/src/main/java/io/camunda/connector/generator/openapi/OpenApiOutboundTemplateGenerator.java
+++ b/element-template-generator/openapi-parser/src/main/java/io/camunda/connector/generator/openapi/OpenApiOutboundTemplateGenerator.java
@@ -152,7 +152,11 @@ public class OpenApiOutboundTemplateGenerator
         .ifPresent(
             t -> {
               throw new IllegalArgumentException(
-                  String.format("Unsupported element type '%s'", t.elementType().getName()));
+                  String.format("Unsupported element type '%s'", t.elementType().getName())
+                      + " for OpenAPI generator. Supported element types: "
+                      + SUPPORTED_ELEMENT_TYPES.stream()
+                          .map(BpmnType::getName)
+                          .collect(Collectors.joining(", ")));
             });
     if (elementTypes.isEmpty()) {
       elementTypes = Set.of(DEFAULT_ELEMENT_TYPE);

--- a/element-template-generator/openapi-parser/src/main/java/io/camunda/connector/generator/openapi/util/OperationUtil.java
+++ b/element-template-generator/openapi-parser/src/main/java/io/camunda/connector/generator/openapi/util/OperationUtil.java
@@ -116,8 +116,7 @@ public class OperationUtil {
             operation ->
                 includeOperations == null
                     || includeOperations.isEmpty()
-                    || operation.builder() != null
-                        && includeOperations.contains(operation.builder().getId()))
+                    || includeOperations.contains(operation.builder().getId()))
         .collect(Collectors.toList());
   }
 

--- a/element-template-generator/openapi-parser/src/main/java/io/camunda/connector/generator/openapi/util/OperationUtil.java
+++ b/element-template-generator/openapi-parser/src/main/java/io/camunda/connector/generator/openapi/util/OperationUtil.java
@@ -116,7 +116,8 @@ public class OperationUtil {
             operation ->
                 includeOperations == null
                     || includeOperations.isEmpty()
-                    || includeOperations.contains(operation.builder().getId()))
+                    || operation.builder() != null
+                        && includeOperations.contains(operation.builder().getId()))
         .collect(Collectors.toList());
   }
 


### PR DESCRIPTION
## Description

- Improved help command output for configuration parameters
- Fixed a couple newly discovered bugs found while experimenting with generating multiple templates at once for different element types:
  - non-idempotent `FeelContextBuilder.build()`
  - unformatted output when only one element template is returned
  - extra call to `appliesTo()` with the hard-coded value`bpmn:Task`, not needed anymore since we set this value in a different place now.

