### PR TITLE
fix(webhook): inconsistent webhook de-registration

### DIFF
--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/webhook/WebhookConnectorRegistry.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/webhook/WebhookConnectorRegistry.java
@@ -34,6 +34,12 @@ public class WebhookConnectorRegistry {
     return Optional.ofNullable(activeEndpointsByContext.get(context));
   }
 
+  public boolean isRegistered(ActiveInboundConnector connector) {
+    var context = connector.context().bindProperties(CommonWebhookProperties.class).getContext();
+    return activeEndpointsByContext.containsKey(context)
+        && activeEndpointsByContext.get(context) == connector;
+  }
+
   public void register(ActiveInboundConnector connector) {
     var properties = connector.context().bindProperties(CommonWebhookProperties.class);
     var context = properties.getContext();
@@ -50,6 +56,26 @@ public class WebhookConnectorRegistry {
 
   public void deregister(ActiveInboundConnector connector) {
     var context = connector.context().bindProperties(CommonWebhookProperties.class).getContext();
+    var registeredConnector = activeEndpointsByContext.get(context);
+    if (registeredConnector == null) {
+      var logMessage = "Context: " + context + " is not registered. Cannot deregister.";
+      LOG.debug(logMessage);
+      throw new RuntimeException(logMessage);
+    }
+    if (registeredConnector != connector) {
+      var bpmnProcessId = registeredConnector.context().getDefinition().bpmnProcessId();
+      var elementId = registeredConnector.context().getDefinition().elementId();
+      var logMessage =
+          "Context: "
+              + context
+              + " is not registered by "
+              + bpmnProcessId
+              + "/"
+              + elementId
+              + ". Cannot deregister.";
+      LOG.debug(logMessage);
+      throw new RuntimeException(logMessage);
+    }
     activeEndpointsByContext.remove(context);
   }
 

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/inbound/WebhookControllerPlainJavaTests.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/inbound/WebhookControllerPlainJavaTests.java
@@ -60,6 +60,7 @@ public class WebhookControllerPlainJavaTests {
     var connectorB = buildConnector(webhookDefinition("processA", 1, "myPath"));
     assertThrowsExactly(
         RuntimeException.class, () -> webhookConnectorRegistry.register(connectorB));
+    assertFalse(webhookConnectorRegistry.isRegistered(connectorB));
   }
 
   @Test
@@ -80,7 +81,10 @@ public class WebhookControllerPlainJavaTests {
 
     var connectorForPath1 = webhook.getWebhookConnectorByContextPath("myPath");
 
-    assertTrue(connectorForPath1.isPresent(), "Connector is present");
+    assertTrue(connectorForPath1.isPresent(), "A2 context is present");
+    assertTrue(webhook.isRegistered(processA2), "A2 is registered");
+    assertFalse(webhook.isRegistered(processA1), "A1 is not registered");
+    assertFalse(webhook.isRegistered(processB1), "B1 is not registered");
     assertEquals(2, connectorForPath1.get().context().getDefinition().version(), "The newest one");
 
     var connectorForPath2 = webhook.getWebhookConnectorByContextPath("myPath2");
@@ -100,6 +104,24 @@ public class WebhookControllerPlainJavaTests {
 
     // then
     assertFalse(webhook.getWebhookConnectorByContextPath("myPath").isPresent());
+    assertFalse(webhook.isRegistered(processA1));
+  }
+
+  @Test
+  public void webhookDeactivation_samePathButDifferentConnector_shouldFail() {
+    WebhookConnectorRegistry webhook = new WebhookConnectorRegistry();
+
+    // given
+    var processA1 = buildConnector(webhookDefinition("processA", 1, "myPath"));
+    var processA2 = buildConnector(webhookDefinition("processA", 2, "myPath"));
+
+    // when
+    webhook.register(processA1);
+
+    // then
+    assertThrowsExactly(RuntimeException.class, () -> webhook.deregister(processA2));
+    assertFalse(webhook.isRegistered(processA2));
+    assertTrue(webhook.isRegistered(processA1));
   }
 
   private static long nextProcessDefinitionKey = 0L;


### PR DESCRIPTION
## Description

There was a bug in the webhook connector registration code: we attempted to deregister a webhook connector that was not registered due to a conflicting webhook endpoint path.

Consider the scenario:
- A process (`P1`) is deployed containing a webhook connector with path `myPath`. It is successfully registered with `WebhookConnectorRegistry`.
- We attempt to deploy another process (`P2`) that contains a webhook connector with the same path, `myPath`.
- This results in an error during registration, because this path is already used. This is checked in `webhookConnectorRegistry::register`.
- We make a change to `P2` and try to deploy a newer version
  - Process definition for the previous version of `P2` is registered
  - We know it contained a webhook connector, so we try to deactivate it
  - In `WebhookConnectorRegistry::deactivate`, the code doesn't check whether we are actually trying to deactivate the same connector that we tried to activate before. It only checks if paths are the same - which can also happen for different processes, like in our case.
  - The code removes `P1`'s webhook instead of the `P2`'s webhook, as only path is checked.

**Proposed solution**

1. Check the connector during the deregistration attempt and throw an exception if it is not the original connector (to be fail-safe)
2. In `InboundConnectorManager`, make a preliminary call to check whether the connector we are trying to deactivate, had actually been activated before (to avoid bumping into an exception)

## Related issues

<!-- Which issues are closed by this PR or are related -->
closes https://github.com/camunda/team-connectors/issues/586

