### PR TITLE
fix(health report): add general health report and feel exception logging for webhooks

### DIFF
--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/lifecycle/InboundConnectorManager.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/lifecycle/InboundConnectorManager.java
@@ -22,6 +22,7 @@ import io.camunda.connector.api.inbound.InboundConnectorContext;
 import io.camunda.connector.api.inbound.InboundConnectorExecutable;
 import io.camunda.connector.api.inbound.webhook.WebhookConnectorExecutable;
 import io.camunda.connector.runtime.core.inbound.InboundConnectorContextFactory;
+import io.camunda.connector.runtime.core.inbound.InboundConnectorContextImpl;
 import io.camunda.connector.runtime.core.inbound.InboundConnectorDefinitionImpl;
 import io.camunda.connector.runtime.core.inbound.InboundConnectorFactory;
 import io.camunda.connector.runtime.inbound.importer.ProcessDefinitionInspector;
@@ -153,6 +154,12 @@ public class InboundConnectorManager {
       }
       metricsRecorder.increase(
           Inbound.METRIC_NAME_ACTIVATIONS, Inbound.ACTION_ACTIVATED, newConnector.type());
+
+      if (inboundContext instanceof InboundConnectorContextImpl inboundContextImpl) {
+        if (Health.Status.UNKNOWN.equals(inboundContextImpl.getHealth().getStatus())) {
+          inboundContext.reportHealth(Health.up());
+        }
+      }
     } catch (Exception e) {
       inboundContext.reportHealth(Health.down(e));
       // log and continue with other connectors anyway

--- a/connectors/slack/src/main/java/io/camunda/connector/slack/inbound/SlackInboundWebhookExecutable.java
+++ b/connectors/slack/src/main/java/io/camunda/connector/slack/inbound/SlackInboundWebhookExecutable.java
@@ -81,10 +81,7 @@ public class SlackInboundWebhookExecutable
   }
 
   @Override
-  public void activate(InboundConnectorContext context) throws Exception {
-    if (context == null) {
-      throw new Exception("Inbound connector context cannot be null");
-    }
+  public void activate(InboundConnectorContext context) {
     var wrapperProps = context.bindProperties(SlackConnectorPropertiesWrapper.class);
     props = new SlackWebhookProperties(wrapperProps);
   }

--- a/connectors/webhook/src/main/java/io/camunda/connector/inbound/HttpWebhookExecutable.java
+++ b/connectors/webhook/src/main/java/io/camunda/connector/inbound/HttpWebhookExecutable.java
@@ -11,7 +11,6 @@ import static io.camunda.connector.inbound.signature.HMACSwitchCustomerChoice.en
 
 import io.camunda.connector.api.annotation.InboundConnector;
 import io.camunda.connector.api.inbound.Activity;
-import io.camunda.connector.api.inbound.Health;
 import io.camunda.connector.api.inbound.InboundConnectorContext;
 import io.camunda.connector.api.inbound.Severity;
 import io.camunda.connector.api.inbound.webhook.MappedHttpRequest;
@@ -130,7 +129,6 @@ public class HttpWebhookExecutable implements WebhookConnectorExecutable, Verifi
     this.context = context;
     var wrappedProps = context.bindProperties(WebhookConnectorPropertiesWrapper.class);
     props = new WebhookConnectorProperties(wrappedProps);
-    context.reportHealth(Health.up());
     authChecker = WebhookAuthorizationHandler.getHandlerForAuth(props.auth());
   }
 


### PR DESCRIPTION
## Description

Added a general health report logic, which reports the webhook connector health as UP, if it is still in unknown state. This happens after the activate method call, so we can be sure that at this point the connector must be up unless the status is set to DOWN.

Also added an error logging for Feel exceptions to show those on the FE. This way users have a feedback about the error happened.

## Related issues

closes #
https://github.com/camunda/connectors/issues/1799

