### PR TITLE
Add RPC support to the RabbitMQ Connector

### DIFF
--- a/connectors/rabbitmq/element-templates/rabbitmq-connector-rpc.json
+++ b/connectors/rabbitmq/element-templates/rabbitmq-connector-rpc.json
@@ -1,0 +1,263 @@
+{
+  "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+  "name": "RabbitMQ Outbound RPC Connector",
+  "id": "io.camunda.connectors.RabbitMQ.RPC.v1",
+  "description": "Send RPC to RabbitMQ",
+  "documentationRef": "https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound",
+  "version": 3,
+  "category": {
+    "id": "connectors",
+    "name": "Connectors"
+  },
+  "appliesTo": [
+    "bpmn:Task"
+  ],
+  "elementType": {
+    "value": "bpmn:ServiceTask"
+  },
+  "groups": [
+    {
+      "id": "authentication",
+      "label": "Authentication"
+    },
+    {
+      "id": "routing",
+      "label": "Routing"
+    },
+    {
+      "id": "message",
+      "label": "Message"
+    },
+    {
+      "id": "output",
+      "label": "Output mapping"
+    },
+    {
+      "id": "errors",
+      "label": "Error handling"
+    }
+  ],
+  "properties": [
+    {
+      "type": "Hidden",
+      "value": "io.camunda:connector-rabbitmq-rpc:1",
+      "binding": {
+        "type": "zeebe:taskDefinition:type"
+      }
+    },
+    {
+      "id": "connectionType",
+      "label": "Connection type",
+      "group": "authentication",
+      "type": "Dropdown",
+      "value": "uri",
+      "binding": {
+        "type": "zeebe:input",
+        "name": "authentication.authType"
+      },
+      "choices": [
+        {
+          "name": "URI",
+          "value": "uri"
+        },
+        {
+          "name": "Username/Password",
+          "value": "credentials"
+        }
+      ]
+    },
+    {
+      "label": "URI",
+      "description": "URI should contain username, password, host name, port number, and virtual host",
+      "group": "authentication",
+      "type": "String",
+      "binding": {
+        "type": "zeebe:input",
+        "name": "authentication.uri"
+      },
+      "constraints": {
+        "notEmpty": true,
+        "pattern": {
+          "value": "^(=|amqps?://|\\{\\{secrets\\..+\\}\\}).*$",
+          "message": "Must start with amqp(s):// or contain a secret reference"
+        }
+      },
+      "condition": {
+        "property": "connectionType",
+        "equals": "uri"
+      }
+    },
+    {
+      "label": "Username",
+      "group": "authentication",
+      "type": "String",
+      "binding": {
+        "type": "zeebe:input",
+        "name": "authentication.userName"
+      },
+      "constraints": {
+        "notEmpty": true
+      },
+      "condition": {
+        "property": "connectionType",
+        "equals": "credentials"
+      }
+    },
+    {
+      "label": "Password",
+      "group": "authentication",
+      "type": "String",
+      "binding": {
+        "type": "zeebe:input",
+        "name": "authentication.password"
+      },
+      "constraints": {
+        "notEmpty": true
+      },
+      "condition": {
+        "property": "connectionType",
+        "equals": "credentials"
+      }
+    },
+    {
+      "label": "Host name",
+      "description": "Host name: get from RabbitMQ external application configurations. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\"target=\"_blank\">documentation</a>",
+      "feel": "optional",
+      "group": "routing",
+      "type": "String",
+      "binding": {
+        "type": "zeebe:input",
+        "name": "routing.hostName"
+      },
+      "constraints": {
+        "notEmpty": true
+      },
+      "condition": {
+        "property": "connectionType",
+        "equals": "credentials"
+      }
+    },
+    {
+      "label": "Virtual host",
+      "description": "Virtual name: get from RabbitMQ external application configurations. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\"target=\"_blank\">documentation</a>",
+      "feel": "optional",
+      "group": "routing",
+      "type": "String",
+      "binding": {
+        "type": "zeebe:input",
+        "name": "routing.virtualHost"
+      },
+      "constraints": {
+        "notEmpty": true
+      },
+      "condition": {
+        "property": "connectionType",
+        "equals": "credentials"
+      }
+    },
+    {
+      "label": "Exchange",
+      "description": "Topic exchange: get from RabbitMQ external application configurations. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\"target=\"_blank\">documentation</a>",
+      "feel": "optional",
+      "group": "routing",
+      "type": "String",
+      "binding": {
+        "type": "zeebe:input",
+        "name": "routing.exchange"
+      },
+      "constraints": {
+        "notEmpty": true
+      }
+    },
+    {
+      "label": "Routing key",
+      "description": "Routing key: a binding is a \"link\" that was set up to bind a queue to an exchange. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\"target=\"_blank\">documentation</a>",
+      "feel": "optional",
+      "group": "routing",
+      "type": "String",
+      "binding": {
+        "type": "zeebe:input",
+        "name": "routing.routingKey"
+      },
+      "constraints": {
+        "notEmpty": true
+      }
+    },
+    {
+      "label": "Port",
+      "description": "Port: get from RabbitMQ external application configurations. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=outbound#routing-data\"target=\"_blank\">documentation</a>",
+      "feel": "optional",
+      "group": "routing",
+      "type": "String",
+      "binding": {
+        "type": "zeebe:input",
+        "name": "routing.port"
+      },
+      "constraints": {
+        "notEmpty": true
+      },
+      "condition": {
+        "property": "connectionType",
+        "equals": "credentials"
+      }
+    },
+    {
+      "label": "Message",
+      "description": "Data to send to RabbitMQ",
+      "group": "message",
+      "type": "Text",
+      "feel": "optional",
+      "binding": {
+        "type": "zeebe:input",
+        "name": "message.body"
+      }
+    },
+    {
+      "label": "Properties",
+      "description": "Properties for the message, routing headers, etc.",
+      "group": "message",
+      "type": "Text",
+      "feel": "required",
+      "value": "={}",
+      "binding": {
+        "type": "zeebe:input",
+        "name": "message.properties"
+      }
+    },
+    {
+      "label": "Result variable",
+      "description": "Enter name of variable to store the response in. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-variable\" target=\"_blank\">documentation</a>",
+      "group": "output",
+      "type": "String",
+      "binding": {
+        "type": "zeebe:taskHeader",
+        "key": "resultVariable"
+      }
+    },
+    {
+      "label": "Result expression",
+      "description": "Expression to map the response into process variables. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-expression\" target=\"_blank\">documentation</a>",
+      "group": "output",
+      "type": "Text",
+      "feel": "required",
+      "binding": {
+        "type": "zeebe:taskHeader",
+        "key": "resultExpression"
+      }
+    },
+    {
+      "label": "Error expression",
+      "description": "Expression to handle errors. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#bpmn-errors\" target=\"_blank\">documentation</a>",
+      "group": "errors",
+      "type": "Text",
+      "feel": "required",
+      "binding": {
+        "type": "zeebe:taskHeader",
+        "key": "errorExpression"
+      }
+    }
+  ],
+  "icon": {
+    "contents": "data:image/svg+xml;utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='18' height='18' viewBox='-7.5 0 271 271' preserveAspectRatio='xMidYMid'%3E%3Cpath d='M245.44 108.308h-85.09a7.738 7.738 0 0 1-7.735-7.734v-88.68C152.615 5.327 147.29 0 140.726 0h-30.375c-6.568 0-11.89 5.327-11.89 11.894v88.143c0 4.573-3.697 8.29-8.27 8.31l-27.885.133c-4.612.025-8.359-3.717-8.35-8.325l.173-88.241C54.144 5.337 48.817 0 42.24 0H11.89C5.321 0 0 5.327 0 11.894V260.21c0 5.834 4.726 10.56 10.555 10.56H245.44c5.834 0 10.56-4.726 10.56-10.56V118.868c0-5.834-4.726-10.56-10.56-10.56zm-39.902 93.233c0 7.645-6.198 13.844-13.843 13.844H167.69c-7.646 0-13.844-6.199-13.844-13.844v-24.005c0-7.646 6.198-13.844 13.844-13.844h24.005c7.645 0 13.843 6.198 13.843 13.844v24.005z' fill='%23F60'/%3E%3C/svg%3E"
+  }
+}

--- a/connectors/rabbitmq/src/main/java/io/camunda/connector/rabbitmq/rpc/RabbitMqRpcFunction.java
+++ b/connectors/rabbitmq/src/main/java/io/camunda/connector/rabbitmq/rpc/RabbitMqRpcFunction.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.rabbitmq.rpc;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ValueNode;
+import com.rabbitmq.client.AMQP;
+import com.rabbitmq.client.Connection;
+import com.rabbitmq.client.RpcClient;
+import com.rabbitmq.client.RpcClientParams;
+import io.camunda.connector.api.annotation.OutboundConnector;
+import io.camunda.connector.api.error.ConnectorException;
+import io.camunda.connector.api.error.ConnectorInputException;
+import io.camunda.connector.api.outbound.OutboundConnectorContext;
+import io.camunda.connector.api.outbound.OutboundConnectorFunction;
+import io.camunda.connector.rabbitmq.inbound.AMQPPropertyUtil;
+import io.camunda.connector.rabbitmq.outbound.model.RabbitMqRequest;
+import io.camunda.connector.rabbitmq.rpc.model.RabbitMqRpcResult;
+import io.camunda.connector.rabbitmq.supplier.ConnectionFactorySupplier;
+import io.camunda.connector.rabbitmq.supplier.ObjectMapperSupplier;
+import java.nio.charset.StandardCharsets;
+import java.util.UUID;
+import org.apache.commons.text.StringEscapeUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@OutboundConnector(
+    name = "RabbitMQ RPC Producer",
+    inputVariables = {"authentication", "routing", "message"},
+    type = "io.camunda:connector-rabbitmq-rpc:1")
+public class RabbitMqRpcFunction implements OutboundConnectorFunction {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(RabbitMqRpcFunction.class);
+
+  private final ConnectionFactorySupplier connectionFactorySupplier;
+
+  public RabbitMqRpcFunction() {
+    this.connectionFactorySupplier = new ConnectionFactorySupplier();
+  }
+
+  public RabbitMqRpcFunction(final ConnectionFactorySupplier connectionFactorySupplier) {
+    this.connectionFactorySupplier = connectionFactorySupplier;
+  }
+
+  @Override
+  public Object execute(final OutboundConnectorContext context) throws Exception {
+    var request = context.bindVariables(RabbitMqRequest.class);
+    return executeConnector(request);
+  }
+
+  private RabbitMqRpcResult executeConnector(final RabbitMqRequest request) throws Exception {
+
+    // Getting properties and body before open new connection, because methods can throw exception
+    final var messageProperties = request.getMessage().getPropertiesAsAmqpBasicProperties();
+    final var messageInByteArray = request.getMessage().getBodyAsByteArray();
+    final var routingKey = request.getRouting().getRoutingKey();
+
+    try (Connection connection = openConnection(request)) {
+      final var channel = connection.createChannel();
+
+      String replyQueueName = channel.queueDeclare().getQueue();
+
+      RpcClientParams rpcClientParams =
+          new RpcClientParams()
+              .channel(channel)
+              .exchange(request.getRouting().getExchange())
+              .routingKey(routingKey)
+              .replyTo(replyQueueName)
+              .correlationIdSupplier(() -> UUID.randomUUID().toString())
+              .timeout(10000); // TODO: 10 seconds
+
+      RpcClient rpcClient = new RpcClient(rpcClientParams);
+
+      try {
+        LOGGER.debug(
+            "Sending RPC message to {} with replyQueueName {}", routingKey, replyQueueName);
+        RpcClient.Response response = rpcClient.doCall(messageProperties, messageInByteArray);
+
+        LOGGER.debug(
+            "Got response for RPC message to {} with replyQueueName {}",
+            routingKey,
+            replyQueueName);
+        return prepareVariables(
+            response.getConsumerTag(), response.getProperties(), response.getBody());
+      } catch (java.util.concurrent.TimeoutException e) {
+        throw new ConnectorException("Timeout while waiting for RPC response");
+      }
+    }
+  }
+
+  private Connection openConnection(RabbitMqRequest request) throws Exception {
+    return connectionFactorySupplier
+        .createFactory(request.getAuthentication(), request.getRouting())
+        .newConnection();
+  }
+
+  private RabbitMqRpcResult prepareVariables(
+      String consumerTag, AMQP.BasicProperties rawProperties, byte[] body) {
+
+    try {
+      String bodyAsString = new String(body, StandardCharsets.UTF_8);
+      Object bodyAsObject;
+      if (isPayloadJson(bodyAsString)) {
+        JsonNode bodyAsJsonElement =
+            ObjectMapperSupplier.instance()
+                .readValue(StringEscapeUtils.unescapeJson(bodyAsString), JsonNode.class);
+        if (bodyAsJsonElement instanceof ValueNode bodyAsPrimitive) {
+          if (bodyAsPrimitive.isBoolean()) {
+            bodyAsObject = bodyAsPrimitive.asBoolean();
+          } else if (bodyAsPrimitive.isNumber()) {
+            bodyAsObject = bodyAsPrimitive.asDouble();
+          } else {
+            bodyAsObject = bodyAsPrimitive.asText();
+          }
+        } else {
+          bodyAsObject =
+              ObjectMapperSupplier.instance().convertValue(bodyAsJsonElement, Object.class);
+        }
+      } else {
+        bodyAsObject = bodyAsString;
+      }
+      RabbitMqRpcResult.RabbitMqRpcMessage message =
+          new RabbitMqRpcResult.RabbitMqRpcMessage(
+              consumerTag, bodyAsObject, AMQPPropertyUtil.toProperties(rawProperties));
+      return new RabbitMqRpcResult(message);
+
+    } catch (Exception e) {
+      LOGGER.error("Failed to parse AMQP message body: {}", e.getMessage());
+      throw new ConnectorInputException(e);
+    }
+  }
+
+  private boolean isPayloadJson(final String bodyAsString) {
+    try {
+      ObjectMapperSupplier.instance()
+          .readValue(StringEscapeUtils.unescapeJson(bodyAsString), JsonNode.class);
+    } catch (JsonProcessingException e) {
+      return false;
+    }
+    return true;
+  }
+}

--- a/connectors/rabbitmq/src/main/java/io/camunda/connector/rabbitmq/rpc/model/RabbitMqRpcResult.java
+++ b/connectors/rabbitmq/src/main/java/io/camunda/connector/rabbitmq/rpc/model/RabbitMqRpcResult.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.rabbitmq.rpc.model;
+
+import io.camunda.connector.rabbitmq.inbound.model.RabbitMqMessageProperties;
+
+/** Model of the Connector output */
+public record RabbitMqRpcResult(RabbitMqRpcMessage message) {
+
+  public record RabbitMqRpcMessage(
+      String consumerTag, Object body, RabbitMqMessageProperties properties) {}
+}

--- a/connectors/rabbitmq/src/main/resources/META-INF/services/io.camunda.connector.api.outbound.OutboundConnectorFunction
+++ b/connectors/rabbitmq/src/main/resources/META-INF/services/io.camunda.connector.api.outbound.OutboundConnectorFunction
@@ -1,1 +1,2 @@
 io.camunda.connector.rabbitmq.outbound.RabbitMqFunction
+io.camunda.connector.rabbitmq.rpc.RabbitMqRpcFunction


### PR DESCRIPTION
## Description

I've extended the RabbitMQ Connector to add RPC support based on the example here: https://www.rabbitmq.com/tutorials/tutorial-six-java.html

This is still a draft to get feedback about this. I'll also need to rebase this to `main` later.

Some code should probably be moved to a common model, but I'll keep it seperate for now to minimize code changes in unrelated files.

## Related issues

closes #1735

