### PR TITLE
chore(deps) bump spring zeebe to 8.4.1-rc2

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -69,7 +69,7 @@ limitations under the License.</license.inlineheader>
 
     <!-- Camunda internal libraries -->
     <version.zeebe>8.4.0</version.zeebe>
-    <version.spring-zeebe>8.4.0</version.spring-zeebe>
+    <version.spring-zeebe>8.4.1-rc2</version.spring-zeebe>
     <version.feel-engine>1.17.4</version.feel-engine>
 
     <!-- Third party dependencies -->


### PR DESCRIPTION
## Description

Bump spring-zeebe version to 8.4.1-rc2 (includes OIDC support).

