### PR TITLE
fix(webhook): update tag from Warn to Warning

### DIFF
--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/webhook/WebhookConnectorValidationUtil.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/webhook/WebhookConnectorValidationUtil.java
@@ -22,7 +22,7 @@ import io.camunda.connector.runtime.inbound.lifecycle.ActiveInboundConnector;
 import java.util.regex.Pattern;
 
 final class WebhookConnectorValidationUtil {
-  private static final String WARN_TAG = "Warn";
+  private static final String WARNING_TAG = "Warning";
   // Reflect changes to this pattern in webhook element templates
   private static final Pattern CURRENT_WEBHOOK_PATH_PATTERN =
       Pattern.compile("^[a-zA-Z0-9]+([-_][a-zA-Z0-9]+)*$");
@@ -36,7 +36,7 @@ final class WebhookConnectorValidationUtil {
     if (!CURRENT_WEBHOOK_PATH_PATTERN.matcher(webhook).matches()) {
       String message =
           DEPRECATED_WEBHOOK_MESSAGE_PREFIX + webhook + DEPRECATED_WEBHOOK_MESSAGE_SUFFIX;
-      Activity activity = Activity.level(Severity.WARNING).tag(WARN_TAG).message(message);
+      Activity activity = Activity.level(Severity.WARNING).tag(WARNING_TAG).message(message);
 
       connector.context().log(activity);
     }

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/inbound/WebhookControllerLogTest.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/inbound/WebhookControllerLogTest.java
@@ -72,7 +72,7 @@ public class WebhookControllerLogTest {
     verify(processA1.context(), times(1)).log(activityCaptor.capture());
     Activity passedActivity = activityCaptor.getValue();
     assertEquals(Severity.WARNING, passedActivity.severity());
-    assertEquals("Warn", passedActivity.tag());
+    assertEquals("Warning", passedActivity.tag());
     assertTrue(passedActivity.message().contains(webhookPath));
 
     assertWebhookRegistered(webhookPath, webhook, processA1);


### PR DESCRIPTION
## Description

Update webhook deprecated path warning tag to "Warning" instead of "Warn".

After discussion with @YanaSegal , we felt this would be the better tag name. Further UX suggestions we discussed would require `web-modeler` changes and a separate issue.

## Related issues

[[Bug](https://github.com/camunda/connectors/issues/1238)

