### PR TITLE
fix(webhook): user shorter webhook ID validation message

### DIFF
--- a/connectors/webhook/element-templates/webhook-connector-boundary.json
+++ b/connectors/webhook/element-templates/webhook-connector-boundary.json
@@ -116,7 +116,7 @@
         "notEmpty": true,
         "pattern": {
           "value": "^[a-zA-Z0-9]+([-_][a-zA-Z0-9]+)*$",
-          "message": "must contain only hyphens, underscores, letters, or numbers. Must start and end with a letter or a number. A hyphen or an underscore must be immediately followed by a letter or a number."
+          "message": "can only contain letters, numbers, or single underscores/hyphens and cannot begin or end with an underscore/hyphen"
         }
       }
     },

--- a/connectors/webhook/element-templates/webhook-connector-intermediate.json
+++ b/connectors/webhook/element-templates/webhook-connector-intermediate.json
@@ -117,7 +117,7 @@
         "notEmpty": true,
         "pattern": {
           "value": "^[a-zA-Z0-9]+([-_][a-zA-Z0-9]+)*$",
-          "message": "must contain only hyphens, underscores, letters, or numbers. Must start and end with a letter or a number. A hyphen or an underscore must be immediately followed by a letter or a number."
+          "message": "can only contain letters, numbers, or single underscores/hyphens and cannot begin or end with an underscore/hyphen"
         }
       }
     },

--- a/connectors/webhook/element-templates/webhook-connector-start-event.json
+++ b/connectors/webhook/element-templates/webhook-connector-start-event.json
@@ -105,7 +105,7 @@
         "notEmpty": true,
         "pattern": {
           "value": "^[a-zA-Z0-9]+([-_][a-zA-Z0-9]+)*$",
-          "message": "must contain only hyphens, underscores, letters, or numbers. Must start and end with a letter or a number. A hyphen or an underscore must be immediately followed by a letter or a number."
+          "message": "can only contain letters, numbers, or single underscores/hyphens and cannot begin or end with an underscore/hyphen"
         }
       }
     },

--- a/connectors/webhook/element-templates/webhook-connector-start-message.json
+++ b/connectors/webhook/element-templates/webhook-connector-start-message.json
@@ -120,7 +120,7 @@
         "notEmpty": true,
         "pattern": {
           "value": "^[a-zA-Z0-9]+([-_][a-zA-Z0-9]+)*$",
-          "message": "must contain only hyphens, underscores, letters, or numbers. Must start and end with a letter or a number. A hyphen or an underscore must be immediately followed by a letter or a number."
+          "message": "can only contain letters, numbers, or single underscores/hyphens and cannot begin or end with an underscore/hyphen"
         }
       }
     },


### PR DESCRIPTION
## Description

Use more concise error message in webhook element templates.

Previous message was much longer than other template error messages.

## Related issues

Follow up from https://github.com/camunda/team-connectors/issues/599

