### PR TITLE
chore(identity): switch to new identity config

### DIFF
--- a/bundle/default-bundle/src/test/resources/application.properties
+++ b/bundle/default-bundle/src/test/resources/application.properties
@@ -2,7 +2,7 @@ server.port=8080
 zeebe.client.broker.gateway-address=localhost:26500
 zeebe.client.security.plaintext=true
 
-# Operate config for use with docker-compose-core.yml
+# Operate config for use with docker-compose.yml
 camunda.operate.client.url=http://localhost:8081
 
 management.context-path=/actuator

--- a/bundle/default-bundle/src/test/resources/application.properties
+++ b/bundle/default-bundle/src/test/resources/application.properties
@@ -1,0 +1,17 @@
+server.port=8080
+zeebe.client.broker.gateway-address=localhost:26500
+zeebe.client.security.plaintext=true
+
+# Operate config for use with docker-compose-core.yml
+camunda.operate.client.url=http://localhost:8081
+
+management.context-path=/actuator
+management.endpoints.web.exposure.include=metrics,health,prometheus
+
+camunda.identity.type=keycloak
+camunda.identity.base-url=http://localhost:8084
+camunda.identity.issuer=http://localhost:18080/auth/realms/camunda-platform
+camunda.identity.issuer-backend-url=http://localhost:18080/auth/realms/camunda-platform
+camunda.identity.audience=connectors
+# camunda.identity.client-id=xxx
+# camunda.identity.client-secret=xxx

--- a/connector-runtime/README.md
+++ b/connector-runtime/README.md
@@ -151,13 +151,17 @@ camunda.operate.client.password=demo
 ```
 
 When running against a self-managed environment you might also need to configure the keycloak endpoint to not use Operate username/password authentication.
-For this you either need to use the existing connectors client-id and client-secret (see in Identity) or create a new client in Identity that has permission to access the operate-api (read:*)
+For this you either need to use the existing connectors client-id and client-secret (see in Identity) or create a new client in Identity that has permission to access the operate-api (read:*).
+When you have the client-id and client-secret you can configure the following Identity properties:
 
 ```properties
-camunda.operate.client.keycloak-url=http://localhost:18080
-camunda.operate.client.keycloak-realm=camunda-platform
-camunda.operate.client.client-id=xxx
-camunda.operate.client.client-secret=xxx
+camunda.identity.type=keycloak
+camunda.identity.base-url=http://localhost:8084
+camunda.identity.issuer=http://localhost:18080/auth/realms/camunda-platform
+camunda.identity.client-id=connectors
+camunda.identity.client-secret=xxx
+camunda.identity.issuer-backend-url=http://localhost:18080/auth/realms/camunda-platform
+camunda.identity.audience=connectors
 ```
 
 ### Adding Connectors

--- a/connector-runtime/connector-runtime-application/src/main/resources/application.properties
+++ b/connector-runtime/connector-runtime-application/src/main/resources/application.properties
@@ -8,10 +8,8 @@ zeebe.client.worker.threads=10
 camunda.connector.polling.enabled=true
 camunda.connector.polling.interval=5000
 
-# Operate config for use with docker-compose-core.yml
+# Operate config for use with docker-compose.yml
 camunda.operate.client.url=http://localhost:8081
-camunda.operate.client.username=demo
-camunda.operate.client.password=demo
 camunda.connector.webhook.enabled=true
 
 management.context-path=/actuator


### PR DESCRIPTION
## Description

- Removed operate auth properties from the `connector-runtime-application` module (this affected the docker image)
- Updated README with an example of new Identity config
- Added config for `LocalConnectorRuntime`


