### PR TITLE
feat(slack): add block content message support

### DIFF
--- a/connectors/slack/element-templates/slack-connector.json
+++ b/connectors/slack/element-templates/slack-connector.json
@@ -2,7 +2,7 @@
   "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
   "name": "Slack Outbound Connector",
   "id": "io.camunda.connectors.Slack.v1",
-  "version": 2,
+  "version": 3,
   "description": "Create a channel or send a message to a channel or user",
   "documentationRef": "https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/slack/?slack=outbound",
   "icon": {
@@ -162,6 +162,28 @@
       }
     },
     {
+      "id": "message.type",
+      "label": "Message type",
+      "group": "message",
+      "type": "Dropdown",
+      "value": "plainText",
+      "optional": false,
+      "choices": [
+        {
+          "name": "Plain text",
+          "value": "plainText"
+        },
+        {
+          "name": "Message block",
+          "value": "messageBlock"
+        }
+      ],
+      "binding": {
+        "type": "zeebe:input",
+        "name": "message.type"
+      }
+    },
+    {
       "label": "Message",
       "group": "message",
       "type": "Text",
@@ -174,8 +196,27 @@
         "notEmpty": true
       },
       "condition": {
-        "property": "method",
-        "equals": "chat.postMessage"
+        "property": "message.type",
+        "equals": "plainText"
+      }
+    },
+    {
+      "label": "Message block",
+      "group": "message",
+      "description": "An array of rich message content blocks. Learn more at the <a href=\"https://api.slack.com/reference/surfaces/formatting#stack_of_blocks\" target=\"_blank\">official Slack documentation page</a>",
+      "type": "Text",
+      "value": "=[\n\t{\n\t\t\"type\": \"header\",\n\t\t\"text\": {\n\t\t\t\"type\": \"plain_text\",\n\t\t\t\"text\": \"New request\"\n\t\t}\n\t},\n\t{\n\t\t\"type\": \"section\",\n\t\t\"fields\": [\n\t\t\t{\n\t\t\t\t\"type\": \"mrkdwn\",\n\t\t\t\t\"text\": \"*Type:*\\nPaid Time Off\"\n\t\t\t},\n\t\t\t{\n\t\t\t\t\"type\": \"mrkdwn\",\n\t\t\t\t\"text\": \"*Created by:*\\n<example.com|John Dow>\"\n\t\t\t}\n\t\t]\n\t},\n\t{\n\t\t\"type\": \"section\",\n\t\t\"fields\": [\n\t\t\t{\n\t\t\t\t\"type\": \"mrkdwn\",\n\t\t\t\t\"text\": \"*When:*\\nAug 10 - Aug 13\"\n\t\t\t}\n\t\t]\n\t},\n\t{\n\t\t\"type\": \"section\",\n\t\t\"text\": {\n\t\t\t\"type\": \"mrkdwn\",\n\t\t\t\"text\": \"<https://example.com|View request>\"\n\t\t}\n\t}\n]",
+      "feel": "required",
+      "binding": {
+        "type": "zeebe:input",
+        "name": "data.blockContent"
+      },
+      "constraints": {
+        "notEmpty": true
+      },
+      "condition": {
+        "property": "message.type",
+        "equals": "messageBlock"
       }
     },
     {

--- a/connectors/slack/src/test/java/io/camunda/connector/slack/outbound/model/ChatPostMessageDataTest.java
+++ b/connectors/slack/src/test/java/io/camunda/connector/slack/outbound/model/ChatPostMessageDataTest.java
@@ -19,6 +19,8 @@ import com.slack.api.methods.response.chat.ChatPostMessageResponse;
 import com.slack.api.methods.response.users.UsersLookupByEmailResponse;
 import com.slack.api.model.Message;
 import com.slack.api.model.User;
+import io.camunda.connector.api.error.ConnectorException;
+import io.camunda.connector.api.json.ConnectorsObjectMapperSupplier;
 import java.io.IOException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -45,6 +47,7 @@ class ChatPostMessageDataTest {
   void invoke_shouldThrowExceptionWhenUserWithoutEmail() throws SlackApiException, IOException {
     // Given
     ChatPostMessageData chatPostMessageData = new ChatPostMessageData();
+    chatPostMessageData.setText("Test text");
     chatPostMessageData.setChannel("test@test.com");
     when(methodsClient.usersLookupByEmail(any(UsersLookupByEmailRequest.class))).thenReturn(null);
     // When and then
@@ -84,5 +87,128 @@ class ChatPostMessageDataTest {
     // Then
     ChatPostMessageRequest value = chatPostMessageRequest.getValue();
     assertThat(value.getChannel()).isEqualTo(USERID);
+  }
+
+  @Test
+  void invoke_WhenTextIsGiven_ShouldInvoke() throws SlackApiException, IOException {
+    // Given
+    ChatPostMessageData chatPostMessageData = new ChatPostMessageData();
+    chatPostMessageData.setChannel("test@test.com");
+    chatPostMessageData.setText("test");
+
+    when(methodsClient.usersLookupByEmail(any(UsersLookupByEmailRequest.class)))
+        .thenReturn(lookupByEmailResponse);
+    when(lookupByEmailResponse.isOk()).thenReturn(Boolean.TRUE);
+    when(lookupByEmailResponse.getUser()).thenReturn(user);
+    when(user.getId()).thenReturn(USERID);
+    when(methodsClient.chatPostMessage(chatPostMessageRequest.capture()))
+        .thenReturn(chatPostMessageResponse);
+    when(chatPostMessageResponse.isOk()).thenReturn(true);
+    when(chatPostMessageResponse.getMessage()).thenReturn(new Message());
+    // When
+    chatPostMessageData.invoke(methodsClient);
+    // Then
+    ChatPostMessageRequest value = chatPostMessageRequest.getValue();
+    assertThat(value.getChannel()).isEqualTo(USERID);
+  }
+
+  @Test
+  void invoke_WhenContentBlockIsGiven_ShouldInvoke() throws SlackApiException, IOException {
+    // Given
+    ChatPostMessageData chatPostMessageData = new ChatPostMessageData();
+    chatPostMessageData.setChannel("test@test.com");
+
+    final var blockContent =
+        """
+        [
+        	{
+        		"type": "header",
+        		"text": {
+        			"type": "plain_text",
+        			"text": "New request"
+        		}
+        	},
+        	{
+        		"type": "section",
+        		"fields": [
+        			{
+        				"type": "mrkdwn",
+        				"text": "*Type:*\\nPaid Time Off"
+        			},
+        			{
+        				"type": "mrkdwn",
+        				"text": "*Created by:*\\n<example.com|Fred Enriquez>"
+        			}
+        		]
+        	},
+        	{
+        		"type": "section",
+        		"fields": [
+        			{
+        				"type": "mrkdwn",
+        				"text": "*When:*\\nAug 10 - Aug 13"
+        			}
+        		]
+        	},
+        	{
+        		"type": "section",
+        		"text": {
+        			"type": "mrkdwn",
+        			"text": "<https://example.com|View request>"
+        		}
+        	}
+        ]
+        """;
+
+    var objectMapper = ConnectorsObjectMapperSupplier.getCopy();
+    chatPostMessageData.setBlockContent(objectMapper.readTree(blockContent));
+
+    when(methodsClient.usersLookupByEmail(any(UsersLookupByEmailRequest.class)))
+        .thenReturn(lookupByEmailResponse);
+    when(lookupByEmailResponse.isOk()).thenReturn(Boolean.TRUE);
+    when(lookupByEmailResponse.getUser()).thenReturn(user);
+    when(user.getId()).thenReturn(USERID);
+    when(methodsClient.chatPostMessage(chatPostMessageRequest.capture()))
+        .thenReturn(chatPostMessageResponse);
+    when(chatPostMessageResponse.isOk()).thenReturn(true);
+    when(chatPostMessageResponse.getMessage()).thenReturn(new Message());
+    // When
+    chatPostMessageData.invoke(methodsClient);
+    // Then
+    ChatPostMessageRequest value = chatPostMessageRequest.getValue();
+    assertThat(value.getChannel()).isEqualTo(USERID);
+  }
+
+  @Test
+  void invoke_WhenContentBlockIsNotArray_ShouldThrow() throws SlackApiException, IOException {
+    // Given
+    ChatPostMessageData chatPostMessageData = new ChatPostMessageData();
+    chatPostMessageData.setChannel("test@test.com");
+
+    final var blockContent =
+        """
+        {
+           "type": "section",
+           "text": {
+             "type": "mrkdwn",
+             "text": "New Paid Time Off request from <example.com|Fred Enriquez>\\n\\n<https://example.com|View request>"
+           }
+         }
+        """;
+
+    var objectMapper = ConnectorsObjectMapperSupplier.getCopy();
+    chatPostMessageData.setBlockContent(objectMapper.readTree(blockContent));
+
+    when(methodsClient.usersLookupByEmail(any(UsersLookupByEmailRequest.class)))
+        .thenReturn(lookupByEmailResponse);
+    when(lookupByEmailResponse.isOk()).thenReturn(Boolean.TRUE);
+    when(lookupByEmailResponse.getUser()).thenReturn(user);
+    when(user.getId()).thenReturn(USERID);
+    // When
+    Throwable thrown = catchThrowable(() -> chatPostMessageData.invoke(methodsClient));
+    // Then
+
+    assertThat(thrown).hasMessageContaining("Block section must be an array");
+    assertThat(thrown).isInstanceOf(ConnectorException.class);
   }
 }

--- a/connectors/slack/src/test/resources/requests/test-cases/validate-fields-fail.json
+++ b/connectors/slack/src/test/resources/requests/test-cases/validate-fields-fail.json
@@ -36,24 +36,6 @@
     }
   },
   {
-    "description": "without text",
-    "token": "xoxb-0123456789456-123467890987-thisIsTestToken",
-    "method": "chat.postMessage",
-    "data": {
-      "channel": "channel",
-      "text": null
-    }
-  },
-  {
-    "description": "without blank text",
-    "token": "xoxb-0123456789456-123467890987-thisIsTestToken",
-    "method": "chat.postMessage",
-    "data": {
-      "channel":"channel",
-      "text": "    "
-    }
-  },
-  {
     "description": "create channel; without visibility",
     "token": "xoxb-0123456789456-123467890987-thisIsTestToken",
     "method": "conversations.create",


### PR DESCRIPTION
feat(slack): add block content message support

closes https://github.com/camunda/team-connectors/issues/584

## CX

<img width="662" alt="Screenshot 2024-01-29 at 16 54 33" src="https://github.com/camunda/connectors/assets/108870003/787f8286-7070-47ae-bb2b-ef7b54681360">

<img width="551" alt="Screenshot 2024-01-29 at 16 55 25" src="https://github.com/camunda/connectors/assets/108870003/7f38c031-a031-40a9-83be-9d77e51f88b4">


