### PR TITLE
fix(rest api): provide more specific mapping info for rest endpoints

### DIFF
--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/lifecycle/InboundConnectorRestController.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/lifecycle/InboundConnectorRestController.java
@@ -43,26 +43,26 @@ public class InboundConnectorRestController {
 
   @GetMapping("/inbound")
   public List<ActiveInboundConnectorResponse> getActiveInboundConnectors(
-      @RequestParam(required = false) String bpmnProcessId,
-      @RequestParam(required = false) String elementId,
-      @RequestParam(required = false) String type) {
+      @RequestParam(required = false, value = "bpmnProcessId") String bpmnProcessId,
+      @RequestParam(required = false, value = "elementId") String elementId,
+      @RequestParam(required = false, value = "type") String type) {
     return getActiveInboundConnectors(bpmnProcessId, elementId, type, null);
   }
 
   @GetMapping("/tenants/{tenantId}/inbound")
   public List<ActiveInboundConnectorResponse> getActiveInboundConnectorsForTenantId(
-      @PathVariable String tenantId,
-      @RequestParam(required = false) String bpmnProcessId,
-      @RequestParam(required = false) String elementId,
-      @RequestParam(required = false) String type) {
+      @PathVariable(value = "tenantId") String tenantId,
+      @RequestParam(required = false, value = "bpmnProcessId") String bpmnProcessId,
+      @RequestParam(required = false, value = "elementId") String elementId,
+      @RequestParam(required = false, value = "type") String type) {
     return getActiveInboundConnectors(bpmnProcessId, elementId, type, tenantId);
   }
 
   @GetMapping("/tenants/{tenantId}/inbound/{bpmnProcessId}/{elementId}/logs")
   public List<Queue<Activity>> getActiveInboundConnectorLogs(
-      @PathVariable String tenantId,
-      @PathVariable String bpmnProcessId,
-      @PathVariable String elementId) {
+      @PathVariable(value = "tenantId") String tenantId,
+      @PathVariable(value = "bpmnProcessId") String bpmnProcessId,
+      @PathVariable(value = "elementId") String elementId) {
     var result =
         inboundManager.query(
             new ActiveInboundConnectorQuery(bpmnProcessId, elementId, null, tenantId));

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/webhook/InboundWebhookRestController.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/webhook/InboundWebhookRestController.java
@@ -74,7 +74,7 @@ public class InboundWebhookRestController {
       @PathVariable(value = "context") String context,
       @RequestHeader Map<String, String> headers,
       @RequestBody(required = false) byte[] bodyAsByteArray,
-      @RequestParam Map<String, String> params,
+      @RequestParam(value = "params") Map<String, String> params,
       HttpServletRequest httpServletRequest)
       throws IOException {
     LOG.trace("Received inbound hook on {}", context);


### PR DESCRIPTION
## Description

Had to specify explicit mappings for the path and request variables in the rest api endpoint definitions, otherwise they throw an exception.

## Related issues

https://github.com/camunda/connectors/issues/1869

closes #

