### PR TITLE
ci: add commit message linting job

### DIFF
--- a/.github/workflows/TEST_FEATURE_BRANCH.yml
+++ b/.github/workflows/TEST_FEATURE_BRANCH.yml
@@ -9,7 +9,19 @@ on:
     branches: [ main ]
 
 jobs:
+  commit-message-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Ensures all commits are fetched
+
+      - name: Lint Commit Messages
+        uses: wagoid/commitlint-github-action@v4
+
   run-tests:
+    needs: commit-message-check
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -82,7 +94,7 @@ jobs:
         env:
           PROJECTS: bundle/default-bundle
         run: mvn --batch-mode compile generate-sources package -DskipTests --projects "${PROJECTS}" --also-make
-  
+
       - name: Set up Docker Build
         uses: docker/setup-buildx-action@v3
 
@@ -92,7 +104,7 @@ jobs:
           registry: registry.camunda.cloud
           username: ${{ steps.secrets.outputs.CI_LDAP_USER }}
           password: ${{ steps.secrets.outputs.CI_LDAP_PASSWORD }}
-      
+
       # Publish Docker images for Preview environments
       - name: Build and Push Docker Image tag ${{ env.TAG }} - bundle-default
         env:

--- a/connectors/aws/aws-dynamodb/src/main/java/io/camunda/connector/aws/dynamodb/model/UpdateItem.java
+++ b/connectors/aws/aws-dynamodb/src/main/java/io/camunda/connector/aws/dynamodb/model/UpdateItem.java
@@ -13,6 +13,7 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
 @TemplateSubType(id = OperationTypes.UPDATE_ITEM)
+
 public record UpdateItem(
     @TemplateProperty(
             label = "Table name",


### PR DESCRIPTION
## Description

To improve the consistency of our commit messages and ensure they adhere to the Conventional Commits specification, I've introduced a commit message linting job. This addition will help maintain our project's commit quality by automatically checking the format of commit messages against the established standards.

For more details on the linting process and the rules enforced, refer to the following resources:
- Commitlint GitHub Action: https://github.com/wagoid/commitlint-github-action/tree/master
- Conventional Commits Specification: https://commitlint.js.org/#/
