### PR TITLE
build(release): add a step to update version in the release branch

### DIFF
--- a/.github/workflows/RELEASE.yaml
+++ b/.github/workflows/RELEASE.yaml
@@ -31,7 +31,7 @@ jobs:
         id: determine_release_branch
         run: |
           releaseBranch=$( git branch --contains ${RELEASE_VERSION} )
-          git checkout $releaseBranch
+          git checkout origin/$releaseBranch
           echo "releaseBranch=$releaseBranch" >> $GITHUB_OUTPUT
         env:
           RELEASE_VERSION: ${{ github.event.release.tag_name }}

--- a/.github/workflows/RELEASE.yaml
+++ b/.github/workflows/RELEASE.yaml
@@ -26,6 +26,16 @@ jobs:
           echo "type=$( echo $OUTPUT | cut -d ' ' -f1 )" >> $GITHUB_OUTPUT
           echo "previousTag=$( echo $OUTPUT | cut -d ' ' -f2 )" >> $GITHUB_OUTPUT
 
+      # We will update this branch by setting the new version and pushing it
+      - name: Determine release branch name
+        id: determine_release_branch
+        run: |
+          releaseBranch=$( git branch --contains ${RELEASE_VERSION} )
+          git checkout $releaseBranch
+          echo "releaseBranch=$releaseBranch" >> $GITHUB_OUTPUT
+        env:
+          RELEASE_VERSION: ${{ github.event.release.tag_name }}
+
       - name: Import Secrets
         id: secrets
         uses: hashicorp/vault-action@v2.8.0
@@ -113,11 +123,13 @@ jobs:
       - name: Commit and tag
         run: |
           git commit -am "ci: release version ${RELEASE_VERSION}"
+          git push origin ${RELEASE_BRANCH}
           git tag -fa ${RELEASE_VERSION} -m "ci: release version ${RELEASE_VERSION}"
           git push --force origin ${RELEASE_VERSION}
 
         env:
           RELEASE_VERSION: ${{ github.event.release.tag_name }}
+          RELEASE_BRANCH: ${{ steps.determine_release_branch.outputs.releaseBranch }}
 
       - name: Generate sbom reports
         run: |

--- a/.github/workflows/RELEASE.yaml
+++ b/.github/workflows/RELEASE.yaml
@@ -31,7 +31,7 @@ jobs:
         id: determine_release_branch
         run: |
           releaseBranch=$( git branch --contains ${RELEASE_VERSION} )
-          git checkout origin/$releaseBranch
+          git checkout "origin/$releaseBranch"
           echo "releaseBranch=$releaseBranch" >> $GITHUB_OUTPUT
         env:
           RELEASE_VERSION: ${{ github.event.release.tag_name }}

--- a/.github/workflows/RELEASE.yaml
+++ b/.github/workflows/RELEASE.yaml
@@ -30,7 +30,7 @@ jobs:
       - name: Determine release branch name
         id: determine_release_branch
         run: |
-          releaseBranch=$( git branch --contains ${RELEASE_VERSION} )
+          releaseBranch=$( git branch --contains ${RELEASE_VERSION} --format='%(refname:short)' )
           git checkout "origin/$releaseBranch"
           echo "releaseBranch=$releaseBranch" >> $GITHUB_OUTPUT
         env:

--- a/.github/workflows/RELEASE.yaml
+++ b/.github/workflows/RELEASE.yaml
@@ -31,7 +31,7 @@ jobs:
         id: determine_release_branch
         run: |
           releaseBranch=$( git branch --contains ${RELEASE_VERSION} --format='%(refname:short)' )
-          git checkout "origin/$releaseBranch"
+          git checkout "$releaseBranch"
           echo "releaseBranch=$releaseBranch" >> $GITHUB_OUTPUT
         env:
           RELEASE_VERSION: ${{ github.event.release.tag_name }}
@@ -111,15 +111,6 @@ jobs:
         env:
           RELEASE_VERSION: ${{ github.event.release.tag_name }}
 
-      - name: Deploy artifacts to Artifactory and Maven Central
-        run: mvn -B compile generate-sources source:jar javadoc:jar deploy -PcheckFormat -Psonatype-oss-release
-        env:
-          NEXUS_USR: ${{ steps.secrets.outputs.ARTIFACTORY_USR }}
-          NEXUS_PSW: ${{ steps.secrets.outputs.ARTIFACTORY_PSW }}
-          MAVEN_USR: ${{ steps.secrets.outputs.MAVEN_CENTRAL_DEPLOYMENT_USR }}
-          MAVEN_PSW: ${{ steps.secrets.outputs.MAVEN_CENTRAL_DEPLOYMENT_PSW }}
-          MAVEN_GPG_PASSPHRASE: ${{ steps.secrets.outputs.MAVEN_CENTRAL_GPG_SIGNING_KEY_PASSPHRASE }}
-
       - name: Commit and tag
         run: |
           git commit -am "ci: release version ${RELEASE_VERSION}"
@@ -130,6 +121,15 @@ jobs:
         env:
           RELEASE_VERSION: ${{ github.event.release.tag_name }}
           RELEASE_BRANCH: ${{ steps.determine_release_branch.outputs.releaseBranch }}
+
+      - name: Deploy artifacts to Artifactory and Maven Central
+        run: mvn -B compile generate-sources source:jar javadoc:jar deploy -PcheckFormat -Psonatype-oss-release
+        env:
+          NEXUS_USR: ${{ steps.secrets.outputs.ARTIFACTORY_USR }}
+          NEXUS_PSW: ${{ steps.secrets.outputs.ARTIFACTORY_PSW }}
+          MAVEN_USR: ${{ steps.secrets.outputs.MAVEN_CENTRAL_DEPLOYMENT_USR }}
+          MAVEN_PSW: ${{ steps.secrets.outputs.MAVEN_CENTRAL_DEPLOYMENT_PSW }}
+          MAVEN_GPG_PASSPHRASE: ${{ steps.secrets.outputs.MAVEN_CENTRAL_GPG_SIGNING_KEY_PASSPHRASE }}
 
       - name: Generate sbom reports
         run: |

--- a/.github/workflows/RELEASE.yaml
+++ b/.github/workflows/RELEASE.yaml
@@ -111,17 +111,6 @@ jobs:
         env:
           RELEASE_VERSION: ${{ github.event.release.tag_name }}
 
-      - name: Commit and tag
-        run: |
-          git commit -am "ci: release version ${RELEASE_VERSION}"
-          git push origin ${RELEASE_BRANCH}
-          git tag -fa ${RELEASE_VERSION} -m "ci: release version ${RELEASE_VERSION}"
-          git push --force origin ${RELEASE_VERSION}
-
-        env:
-          RELEASE_VERSION: ${{ github.event.release.tag_name }}
-          RELEASE_BRANCH: ${{ steps.determine_release_branch.outputs.releaseBranch }}
-
       - name: Deploy artifacts to Artifactory and Maven Central
         run: mvn -B compile generate-sources source:jar javadoc:jar deploy -PcheckFormat -Psonatype-oss-release
         env:
@@ -253,7 +242,18 @@ jobs:
           excludeTypes: build,docs,other,style,ci
           excludeScopes: deps
 
-      - name: Create GitHub Release
+      - name: Commit and tag
+        run: |
+          git commit -am "ci: release version ${RELEASE_VERSION}"
+          git push origin ${RELEASE_BRANCH}
+          git tag -fa ${RELEASE_VERSION} -m "ci: release version ${RELEASE_VERSION}"
+          git push --force origin ${RELEASE_VERSION}
+
+        env:
+          RELEASE_VERSION: ${{ github.event.release.tag_name }}
+          RELEASE_BRANCH: ${{ steps.determine_release_branch.outputs.releaseBranch }}
+
+      - name: Update GitHub Release
         uses: softprops/action-gh-release@v1
         with:
           prerelease: ${{ steps.validate_tag.outputs.type != 'NORMAL' }}


### PR DESCRIPTION
## Description

- We have recently discovered that CI tests on release branches sometimes show inconsistent results compared to main / other feature branches
- It is likely that the issues were caused by version mismatches, when different pom files in the project have different versions, which can be caused by backporting (i.e. cherry-picking commits from the main branch where the version already differs from the release branch).
  - Such mismatches can be hard to detect because they don't affect the following releases (release workflow sets the version on its own), but tend to complicate things for the release manager.
- This PR adds a step to our release workflow to update the release branch and set the new version. This should help prevent such mismatches in the future, as the version in the release branch will now be updated with every patch.
- I also moved the "Commit and tag" deeper into the pipeline execution to prevent inconsistencies
  - We're now updating the branch => we may result in an inconsistent state when Maven build failed but the branch is already updated


