### PR TITLE
chore: support Java 17 for Connector SDK

### DIFF
--- a/connector-sdk/core/pom.xml
+++ b/connector-sdk/core/pom.xml
@@ -4,8 +4,8 @@
 
   <parent>
     <groupId>io.camunda.connector</groupId>
-    <artifactId>connector-parent</artifactId>
-    <relativePath>../../parent/pom.xml</relativePath>
+    <artifactId>connector-sdk-parent</artifactId>
+    <relativePath>../pom.xml</relativePath>
     <version>8.5.0-SNAPSHOT</version>
   </parent>
 

--- a/connector-sdk/feel-wrapper/pom.xml
+++ b/connector-sdk/feel-wrapper/pom.xml
@@ -4,8 +4,8 @@
 
   <parent>
     <groupId>io.camunda.connector</groupId>
-    <artifactId>connector-parent</artifactId>
-    <relativePath>../../parent/pom.xml</relativePath>
+    <artifactId>connector-sdk-parent</artifactId>
+    <relativePath>../pom.xml</relativePath>
     <version>8.5.0-SNAPSHOT</version>
   </parent>
 

--- a/connector-sdk/jackson-datatype-feel/pom.xml
+++ b/connector-sdk/jackson-datatype-feel/pom.xml
@@ -3,8 +3,8 @@
 
   <parent>
     <groupId>io.camunda.connector</groupId>
-    <artifactId>connector-parent</artifactId>
-    <relativePath>../../parent/pom.xml</relativePath>
+    <artifactId>connector-sdk-parent</artifactId>
+    <relativePath>../pom.xml</relativePath>
     <version>8.5.0-SNAPSHOT</version>
   </parent>
 

--- a/connector-sdk/pom.xml
+++ b/connector-sdk/pom.xml
@@ -30,9 +30,9 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>${version.java.sdk}</source>
-          <target>${version.java.sdk}</target>
-          <release>${version.java.sdk}</release>
+          <source>${version.java.connector-sdk}</source>
+          <target>${version.java.connector-sdk}</target>
+          <release>${version.java.connector-sdk}</release>
         </configuration>
       </plugin>
     </plugins>

--- a/connector-sdk/pom.xml
+++ b/connector-sdk/pom.xml
@@ -1,0 +1,40 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>io.camunda.connector</groupId>
+    <artifactId>connectors-bundle-parent</artifactId>
+    <version>8.5.0-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+
+  <artifactId>connector-sdk-parent</artifactId>
+  <packaging>pom</packaging>
+
+  <name>connector-sdk-parent</name>
+  <description>Parent POM for Connector SDK modules</description>
+
+  <modules>
+    <module>core</module>
+    <module>validation</module>
+    <module>test</module>
+    <module>feel-wrapper</module>
+    <module>jackson-datatype-feel</module>
+  </modules>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <source>${version.java.sdk}</source>
+          <target>${version.java.sdk}</target>
+          <release>${version.java.sdk}</release>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/connector-sdk/test/pom.xml
+++ b/connector-sdk/test/pom.xml
@@ -4,8 +4,8 @@
 
   <parent>
     <groupId>io.camunda.connector</groupId>
-    <artifactId>connector-parent</artifactId>
-    <relativePath>../../parent/pom.xml</relativePath>
+    <artifactId>connector-sdk-parent</artifactId>
+    <relativePath>../pom.xml</relativePath>
     <version>8.5.0-SNAPSHOT</version>
   </parent>
 

--- a/connector-sdk/validation/pom.xml
+++ b/connector-sdk/validation/pom.xml
@@ -3,11 +3,11 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  
+
   <parent>
     <groupId>io.camunda.connector</groupId>
-    <artifactId>connector-parent</artifactId>
-    <relativePath>../../parent/pom.xml</relativePath>
+    <artifactId>connector-sdk-parent</artifactId>
+    <relativePath>../pom.xml</relativePath>
     <version>8.5.0-SNAPSHOT</version>
   </parent>
 

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -41,7 +41,10 @@
   </licenses>
 
   <properties>
+    <!-- Java version for everything except Connector SDK -->
     <version.java>21</version.java>
+    <!-- Java version for Connector SDK -->
+    <version.java.sdk>17</version.java.sdk>
     <maven.compiler.target>${version.java}</maven.compiler.target>
     <maven.compiler.source>${version.java}</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -44,7 +44,7 @@
     <!-- Java version for everything except Connector SDK -->
     <version.java>21</version.java>
     <!-- Java version for Connector SDK -->
-    <version.java.sdk>17</version.java.sdk>
+    <version.java.connector-sdk>17</version.java.connector-sdk>
     <maven.compiler.target>${version.java}</maven.compiler.target>
     <maven.compiler.source>${version.java}</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -19,11 +19,7 @@
 
   <modules>
     <module>parent</module>
-    <module>connector-sdk/core</module>
-    <module>connector-sdk/validation</module>
-    <module>connector-sdk/test</module>
-    <module>connector-sdk/feel-wrapper</module>
-    <module>connector-sdk/jackson-datatype-feel</module>
+    <module>connector-sdk</module>
     <module>element-template-generator/core</module>
     <module>element-template-generator/maven-plugin</module>
     <module>element-template-generator/http-dsl</module>


### PR DESCRIPTION
## Description

This PR re-introduces Java 17 support for the Connector SDK modules.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #1936

