### PR TITLE
FeelEngineWrapper: only wrap the actual response to the response context

### DIFF
--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/ConnectorHelper.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/ConnectorHelper.java
@@ -16,6 +16,8 @@
  */
 package io.camunda.connector.runtime.core;
 
+import static io.camunda.connector.feel.FeelEngineWrapperUtil.*;
+
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
@@ -58,7 +60,10 @@ public class ConnectorHelper {
 
     Optional.ofNullable(resultExpression)
         .filter(s -> !s.isBlank())
-        .map(expression -> FEEL_ENGINE_WRAPPER.evaluateToJson(expression, responseContent))
+        .map(
+            expression ->
+                FEEL_ENGINE_WRAPPER.evaluateToJson(
+                    expression, responseContent, wrapResponse(responseContent)))
         .map(json -> parseJsonVarsAsTypeOrThrow(json, Map.class, resultExpression))
         .ifPresent(outputVariables::putAll);
 
@@ -74,7 +79,8 @@ public class ConnectorHelper {
         .filter(s -> !s.isBlank())
         .map(
             expression ->
-                FEEL_ENGINE_WRAPPER.evaluateToJson(expression, responseContent, jobContext))
+                FEEL_ENGINE_WRAPPER.evaluateToJson(
+                    expression, responseContent, wrapResponse(responseContent), jobContext))
         .filter(json -> !json.equals("null"))
         .filter(json -> !parseJsonVarsAsTypeOrThrow(json, Map.class, errorExpression).isEmpty())
         .map(json -> parseJsonVarsAsTypeOrThrow(json, ConnectorError.class, errorExpression))

--- a/connector-sdk/feel-wrapper/src/main/java/io/camunda/connector/feel/FeelEngineWrapper.java
+++ b/connector-sdk/feel-wrapper/src/main/java/io/camunda/connector/feel/FeelEngineWrapper.java
@@ -41,7 +41,6 @@ import scala.jdk.javaapi.CollectionConverters;
 /** Wrapper for the FEEL engine, handling type conversions and expression evaluations. */
 public class FeelEngineWrapper {
 
-  static final String RESPONSE_MAP_KEY = "response";
   static final String ERROR_CONTEXT_IS_NULL = "Context is null";
 
   static final TypeReference<Map<String, Object>> MAP_TYPE_REFERENCE = new TypeReference<>() {};
@@ -100,10 +99,6 @@ public class FeelEngineWrapper {
       for (Object o : variables) {
         Objects.requireNonNull(o, ERROR_CONTEXT_IS_NULL);
         variablesMap.putAll(objectMapper.convertValue(o, MAP_TYPE_REFERENCE));
-      }
-      if (variables.length >= 1) {
-        variablesMap.put(
-            RESPONSE_MAP_KEY, objectMapper.convertValue(variables[0], MAP_TYPE_REFERENCE));
       }
       return variablesMap;
     } catch (IllegalArgumentException ex) {

--- a/connector-sdk/feel-wrapper/src/main/java/io/camunda/connector/feel/FeelEngineWrapper.java
+++ b/connector-sdk/feel-wrapper/src/main/java/io/camunda/connector/feel/FeelEngineWrapper.java
@@ -53,17 +53,16 @@ public class FeelEngineWrapper {
    * configuration.
    */
   public FeelEngineWrapper() {
-    this.feelEngine =
+    this(
         new FeelEngine.Builder()
             .customValueMapper(new JavaValueMapper())
             .functionProvider(SpiServiceLoader.loadFunctionProvider())
-            .build();
-    this.objectMapper =
+            .build(),
         new ObjectMapper()
             .registerModule(DefaultScalaModule$.MODULE$)
             .registerModule(new JavaTimeModule())
             // deserialize unknown types as empty objects
-            .disable(SerializationFeature.FAIL_ON_EMPTY_BEANS);
+            .disable(SerializationFeature.FAIL_ON_EMPTY_BEANS));
   }
 
   /**
@@ -130,8 +129,7 @@ public class FeelEngineWrapper {
    * Evaluates an expression with the FEEL engine with the given variables.
    *
    * @param expression the expression to evaluate
-   * @param variables the variables to use in evaluation, the first context provided will be
-   *     available wrapped as "response"
+   * @param variables the variables to use in evaluation
    * @param <T> the type to cast the evaluation result to
    * @return the evaluation result
    * @throws FeelEngineWrapperException when there is an exception message as a result of the
@@ -150,8 +148,7 @@ public class FeelEngineWrapper {
    *
    * @param expression the expression to evaluate
    * @param clazz the class the result should be converted to
-   * @param variables the variables to use in evaluation, the first context provided will be
-   *     available wrapped as "response"
+   * @param variables the variables to use in evaluation
    * @param <T> the type to cast the evaluation result to
    * @return the evaluation result
    * @throws FeelEngineWrapperException when there is an exception message as a result of the
@@ -175,8 +172,7 @@ public class FeelEngineWrapper {
    *
    * @param expression the expression to evaluate
    * @param clazz the class the result should be converted to
-   * @param variables the variables to use in evaluation, the first context provided will be
-   *     available wrapped as "response"
+   * @param variables the variables to use in evaluation
    * @param <T> the type to cast the evaluation result to
    * @return the evaluation result
    * @throws FeelEngineWrapperException when there is an exception message as a result of the
@@ -203,8 +199,7 @@ public class FeelEngineWrapper {
    * @param ctx the deserialization context to apply
    * @param expression the expression to evaluate
    * @param clazz the class the result should be converted to
-   * @param variables the variables to use in evaluation, the first context provided will be
-   *     available wrapped as "response"
+   * @param variables the variables to use in evaluation
    * @param <T> the type to cast the evaluation result to
    * @return the evaluation result
    * @throws FeelEngineWrapperException when there is an exception message as a result of the
@@ -255,8 +250,7 @@ public class FeelEngineWrapper {
    * Evaluates an expression to a JSON String.
    *
    * @param expression the expression to evaluate
-   * @param variables the variables to use in evaluation, the first context provided will be
-   *     available wrapped as "response"
+   * @param variables the variables to use in evaluation
    * @return the JSON String representing the evaluation result
    * @throws FeelEngineWrapperException when there is an exception message as a result of the
    *     evaluation or the result cannot be parsed as JSON

--- a/connector-sdk/feel-wrapper/src/main/java/io/camunda/connector/feel/FeelEngineWrapperUtil.java
+++ b/connector-sdk/feel-wrapper/src/main/java/io/camunda/connector/feel/FeelEngineWrapperUtil.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.feel;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class FeelEngineWrapperUtil {
+  public static Map<String, Object> wrapResponse(Object response) {
+    Map<String, Object> responseContext = new HashMap<>();
+    responseContext.put("response", response);
+    return responseContext;
+  }
+}

--- a/connector-sdk/feel-wrapper/src/test/java/io/camunda/connector/feel/FeelEngineWrapperExpressionEvaluationTest.java
+++ b/connector-sdk/feel-wrapper/src/test/java/io/camunda/connector/feel/FeelEngineWrapperExpressionEvaluationTest.java
@@ -16,6 +16,7 @@
  */
 package io.camunda.connector.feel;
 
+import static io.camunda.connector.feel.FeelEngineWrapperUtil.*;
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -47,7 +48,8 @@ class FeelEngineWrapperExpressionEvaluationTest {
     final var variables = Map.of("callStatus", Map.of("statusCode", "200 OK"));
 
     // when
-    final var evaluatedResultAsJson = objectUnderTest.evaluateToJson(resultExpression, variables);
+    final var evaluatedResultAsJson =
+        objectUnderTest.evaluateToJson(resultExpression, variables, wrapResponse(variables));
 
     // then
     JSONAssert.assertEquals(
@@ -65,7 +67,8 @@ class FeelEngineWrapperExpressionEvaluationTest {
     final var variables = Map.of("callStatus", Map.of("statusCode", "200 OK"));
 
     // when
-    final var evaluatedResultAsMap = objectUnderTest.evaluate(resultExpression, variables);
+    final var evaluatedResultAsMap =
+        objectUnderTest.evaluate(resultExpression, variables, wrapResponse(variables));
 
     // then
     final var expectedResult = Map.of("processedOutput", Map.of("statusCode", "200 OK"));
@@ -79,7 +82,8 @@ class FeelEngineWrapperExpressionEvaluationTest {
     final var variables = new TestPojo("FOO");
 
     // when
-    final var evaluatedResultAsJson = objectUnderTest.evaluateToJson(resultExpression, variables);
+    final var evaluatedResultAsJson =
+        objectUnderTest.evaluateToJson(resultExpression, variables, wrapResponse(variables));
 
     // then
     JSONAssert.assertEquals(
@@ -97,7 +101,8 @@ class FeelEngineWrapperExpressionEvaluationTest {
     final var variables = Map.of("callStatus", Map.of("statusCode", "200 OK"));
 
     // when
-    final var evaluatedResultAsJson = objectUnderTest.evaluateToJson(resultExpression, variables);
+    final var evaluatedResultAsJson =
+        objectUnderTest.evaluateToJson(resultExpression, variables, wrapResponse(variables));
 
     // then
     JSONAssert.assertEquals(
@@ -117,7 +122,8 @@ class FeelEngineWrapperExpressionEvaluationTest {
     final var variables = Map.of("status", 204, "body", "", "headers", Map.of());
     final var jobContent = Map.of("job", Map.of("retries", 3));
     final var evaluatedResultAsJson =
-        objectUnderTest.evaluateToJson(errorExpression, variables, jobContent);
+        objectUnderTest.evaluateToJson(
+            errorExpression, variables, Map.of("response", variables), jobContent);
     // then
     JSONAssert.assertEquals(
         "{\"retries\":3,\"responseRetries\":null}", evaluatedResultAsJson, JSONCompareMode.STRICT);
@@ -148,7 +154,8 @@ class FeelEngineWrapperExpressionEvaluationTest {
     final var variables = Map.of("callStatus", "done");
 
     // when
-    final var evaluatedResultAsJson = objectUnderTest.evaluateToJson(resultExpression, variables);
+    final var evaluatedResultAsJson =
+        objectUnderTest.evaluateToJson(resultExpression, variables, wrapResponse(variables));
 
     // then
     JSONAssert.assertEquals(
@@ -214,7 +221,8 @@ class FeelEngineWrapperExpressionEvaluationTest {
     final var variables = Map.of("callStatus", "200 OK");
 
     // when
-    final var result = objectUnderTest.evaluate(expression, Object.class, variables);
+    final var result =
+        objectUnderTest.evaluate(expression, Object.class, variables, wrapResponse(variables));
 
     // then
     // result is not a scala map

--- a/connector-sdk/feel-wrapper/src/test/java/io/camunda/connector/feel/FeelEngineWrapperExpressionEvaluationTest.java
+++ b/connector-sdk/feel-wrapper/src/test/java/io/camunda/connector/feel/FeelEngineWrapperExpressionEvaluationTest.java
@@ -107,6 +107,23 @@ class FeelEngineWrapperExpressionEvaluationTest {
   }
 
   @Test
+  void evaluateToJson_ShouldSucceed_WhenContextWithContextFromHttpResponse() throws JSONException {
+    // given
+    // FEEL expression which is a bit useless, but it proves 2 things
+    // 1. status is wrapped to response
+    // 2. job is not
+    final var errorExpression =
+        "if response.status = 204 then {retries: job.retries, responseRetries: response.job.retries} else null";
+    final var variables = Map.of("status", 204, "body", "", "headers", Map.of());
+    final var jobContent = Map.of("job", Map.of("retries", 3));
+    final var evaluatedResultAsJson =
+        objectUnderTest.evaluateToJson(errorExpression, variables, jobContent);
+    // then
+    JSONAssert.assertEquals(
+        "{\"retries\":3,\"responseRetries\":null}", evaluatedResultAsJson, JSONCompareMode.STRICT);
+  }
+
+  @Test
   void evaluateToJson_ShouldSucceed_WhenVariableNotFound() throws JSONException {
     // given
     // FEEL expression -> ={"processedOutput":response.doesnt-exist}

--- a/connector-sdk/feel-wrapper/src/test/java/io/camunda/connector/feel/FeelEngineWrapperUtilTest.java
+++ b/connector-sdk/feel-wrapper/src/test/java/io/camunda/connector/feel/FeelEngineWrapperUtilTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.feel;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+public class FeelEngineWrapperUtilTest {
+
+  @Test
+  void shouldWrapObject() {
+    Object o = new Object();
+    Map<String, Object> responseWrapper = FeelEngineWrapperUtil.wrapResponse(o);
+    assertThat(responseWrapper.get("response")).isEqualTo(o);
+  }
+
+  @Test
+  void shouldWrapNull() {
+    Map<String, Object> responseWrapper = FeelEngineWrapperUtil.wrapResponse(null);
+    assertThat(responseWrapper.get("response")).isNull();
+  }
+}


### PR DESCRIPTION
## Description

Right now, the job context is wrapped to the response context, leading to the jobs' retries being available as `response.job.retries` which is not valid.

This PR fixes this (documented and tested) so that only the FIRST element of the varArgs for an evaluation is considered to be the response and wrapped into a response context.

## Related issues

<!-- Which issues are closed by this PR or are related -->

nothing to close
