### PR TITLE
fix(dynamodb): update attribute with saving type

### DIFF
--- a/connectors/aws/aws-dynamodb/src/main/java/io/camunda/connector/aws/dynamodb/model/UpdateItem.java
+++ b/connectors/aws/aws-dynamodb/src/main/java/io/camunda/connector/aws/dynamodb/model/UpdateItem.java
@@ -11,6 +11,7 @@ import io.camunda.connector.generator.java.annotation.TemplateProperty;
 import io.camunda.connector.generator.java.annotation.TemplateSubType;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import java.util.Map;
 
 @TemplateSubType(id = OperationTypes.UPDATE_ITEM)
 public record UpdateItem(
@@ -28,7 +29,7 @@ public record UpdateItem(
             feel = Property.FeelMode.required,
             description = "Simple or composite primary key")
         @NotNull
-        Object primaryKeyComponents,
+        Map<String, Object> primaryKeyComponents,
     @TemplateProperty(
             label = "Key attributes",
             group = "input",
@@ -36,7 +37,7 @@ public record UpdateItem(
             description =
                 "DynamoDB key attributes. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/aws-dynamodb/\" target=\"_blank\">documentation</a>")
         @NotNull
-        Object keyAttributes,
+        Map<String, Object> keyAttributes,
     @TemplateProperty(
             label = "Attribute action",
             group = "input",

--- a/connectors/aws/aws-dynamodb/src/main/java/io/camunda/connector/aws/dynamodb/operation/item/UpdateItemOperation.java
+++ b/connectors/aws/aws-dynamodb/src/main/java/io/camunda/connector/aws/dynamodb/operation/item/UpdateItemOperation.java
@@ -6,116 +6,53 @@
  */
 package io.camunda.connector.aws.dynamodb.operation.item;
 
+import com.amazonaws.services.dynamodbv2.document.AttributeUpdate;
 import com.amazonaws.services.dynamodbv2.document.DynamoDB;
 import com.amazonaws.services.dynamodbv2.document.PrimaryKey;
-import com.amazonaws.services.dynamodbv2.document.Table;
-import com.amazonaws.services.dynamodbv2.document.UpdateItemOutcome;
-import com.amazonaws.services.dynamodbv2.document.spec.UpdateItemSpec;
-import com.amazonaws.services.dynamodbv2.document.utils.ValueMap;
-import com.amazonaws.services.dynamodbv2.model.ReturnValue;
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import io.camunda.connector.api.error.ConnectorException;
-import io.camunda.connector.aws.ObjectMapperSupplier;
 import io.camunda.connector.aws.dynamodb.model.UpdateItem;
 import io.camunda.connector.aws.dynamodb.operation.AwsDynamoDbOperation;
+import java.util.List;
 import java.util.Map;
 
 public class UpdateItemOperation implements AwsDynamoDbOperation {
-  private static final String ACTION_PUT = "put";
-  private static final String ACTION_DELETE = "delete";
-  private static final String UPDATE_EXPRESSION_SET = "set ";
-  private static final String UPDATE_EXPRESSION_REMOVE = "remove ";
 
   private final UpdateItem updateItemModel;
-  private final ObjectMapper objectMapper;
 
   public UpdateItemOperation(final UpdateItem updateItemModel) {
     this.updateItemModel = updateItemModel;
-    this.objectMapper = ObjectMapperSupplier.getMapperInstance();
   }
 
   @Override
   public Object invoke(final DynamoDB dynamoDB) {
-    Map<String, Object> primaryKeyMap =
-        objectMapper.convertValue(updateItemModel.primaryKeyComponents(), new TypeReference<>() {});
-    Map<String, Object> attributesMap =
-        objectMapper.convertValue(updateItemModel.keyAttributes(), new TypeReference<>() {});
 
-    String tableName = updateItemModel.tableName();
-    String action = updateItemModel.attributeAction();
+    List<AttributeUpdate> attributeUpdates =
+        updateItemModel.keyAttributes().entrySet().stream()
+            .map(
+                entry ->
+                    createAttributeUpdate(
+                        entry.getKey(), entry.getValue(), updateItemModel.attributeAction()))
+            .toList();
 
-    return updateItem(dynamoDB, primaryKeyMap, attributesMap, action, tableName);
+    return dynamoDB
+        .getTable(updateItemModel.tableName())
+        .updateItem(
+            buildPrimaryKey(updateItemModel.primaryKeyComponents()),
+            attributeUpdates.toArray(AttributeUpdate[]::new));
   }
 
-  private UpdateItemOutcome updateItem(
-      DynamoDB dynamoDB,
-      Map<String, Object> primaryKeyMap,
-      Map<String, Object> attributesMap,
-      String action,
-      String tableName) {
-    try {
-      Table table = dynamoDB.getTable(tableName);
-      PrimaryKey primaryKey = buildPrimaryKey(primaryKeyMap);
-
-      UpdateItemSpec updateItemSpec = buildUpdateItemSpec(primaryKey, attributesMap, action);
-      return table.updateItem(updateItemSpec);
-    } catch (Exception e) {
-      throw new ConnectorException("Error in updateItem operation: " + e.getMessage(), e);
-    }
+  private AttributeUpdate createAttributeUpdate(
+      final String key, final Object value, final String action) {
+    AttributeUpdate update = new AttributeUpdate(key);
+    return switch (action.toLowerCase()) {
+      case "put" -> update.put(value);
+      case "delete" -> update.delete();
+      default -> throw new IllegalArgumentException("Unsupported attribute action: " + action);
+    };
   }
 
   private PrimaryKey buildPrimaryKey(Map<String, Object> primaryKeyMap) {
     PrimaryKey primaryKey = new PrimaryKey();
     primaryKeyMap.forEach(primaryKey::addComponent);
     return primaryKey;
-  }
-
-  private UpdateItemSpec buildUpdateItemSpec(
-      PrimaryKey primaryKey, Map<String, Object> attributesMap, String action) {
-    UpdateItemSpec updateItemSpec = new UpdateItemSpec().withPrimaryKey(primaryKey);
-    ValueMap valueMap = new ValueMap();
-    StringBuilder updateExpression = new StringBuilder();
-
-    if (ACTION_PUT.equalsIgnoreCase(action)) {
-      buildPutUpdateExpression(attributesMap, updateExpression, valueMap);
-    } else if (ACTION_DELETE.equalsIgnoreCase(action)) {
-      buildDeleteUpdateExpression(attributesMap, updateExpression);
-    } else {
-      throw new ConnectorException("Invalid action: " + action);
-    }
-
-    updateItemSpec
-        .withUpdateExpression(updateExpression.toString())
-        .withReturnValues(ReturnValue.ALL_NEW);
-    if (!valueMap.isEmpty()) {
-      updateItemSpec.withValueMap(valueMap);
-    }
-    return updateItemSpec;
-  }
-
-  private void buildPutUpdateExpression(
-      Map<String, Object> attributesMap, StringBuilder updateExpression, ValueMap valueMap) {
-    updateExpression.append(UPDATE_EXPRESSION_SET);
-    attributesMap.forEach(
-        (k, v) -> {
-          String attrKey = ":" + k;
-          updateExpression.append(k).append(" = ").append(attrKey).append(", ");
-          valueMap.withString(attrKey, String.valueOf(v));
-        });
-    trimTrailingComma(updateExpression);
-  }
-
-  private void buildDeleteUpdateExpression(
-      Map<String, Object> attributesMap, StringBuilder updateExpression) {
-    updateExpression.append(UPDATE_EXPRESSION_REMOVE);
-    attributesMap.keySet().forEach(k -> updateExpression.append(k).append(", "));
-    trimTrailingComma(updateExpression);
-  }
-
-  private void trimTrailingComma(StringBuilder updateExpression) {
-    if (!updateExpression.isEmpty()) {
-      updateExpression.setLength(updateExpression.length() - 2); // Remove last comma and space
-    }
   }
 }

--- a/connectors/aws/aws-dynamodb/src/test/java/io/camunda/connector/aws/dynamodb/operation/item/UpdateItemOperationTest.java
+++ b/connectors/aws/aws-dynamodb/src/test/java/io/camunda/connector/aws/dynamodb/operation/item/UpdateItemOperationTest.java
@@ -11,54 +11,159 @@ import static org.mockito.Mockito.when;
 
 import com.amazonaws.services.dynamodbv2.document.AttributeUpdate;
 import com.amazonaws.services.dynamodbv2.document.KeyAttribute;
+import com.amazonaws.services.dynamodbv2.document.PrimaryKey;
 import com.amazonaws.services.dynamodbv2.document.UpdateItemOutcome;
-import com.amazonaws.services.dynamodbv2.document.spec.UpdateItemSpec;
+import com.amazonaws.services.dynamodbv2.model.AttributeAction;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import io.camunda.connector.api.outbound.OutboundConnectorContext;
 import io.camunda.connector.aws.dynamodb.BaseDynamoDbOperationTest;
 import io.camunda.connector.aws.dynamodb.TestDynamoDBData;
 import io.camunda.connector.aws.dynamodb.model.AwsInput;
 import io.camunda.connector.aws.dynamodb.model.UpdateItem;
+import java.math.BigDecimal;
+import java.util.List;
 import java.util.Map;
-import org.junit.jupiter.api.BeforeEach;
+import java.util.Set;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
 
 class UpdateItemOperationTest extends BaseDynamoDbOperationTest {
-  private UpdateItemOperation updateItemOperation;
   @Mock private UpdateItemOutcome updateItemOutcome;
-  @Captor private ArgumentCaptor<UpdateItemSpec> updateItemSpecArgumentCaptor;
-  private KeyAttribute keyAttribute;
+  @Captor private ArgumentCaptor<PrimaryKey> primaryKeyArgumentCaptor;
+  @Captor private ArgumentCaptor<AttributeUpdate[]> attributeUpdateArgumentCaptor;
 
-  @BeforeEach
-  public void setUp() {
-
-    keyAttribute = new KeyAttribute("id", "123");
-    AttributeUpdate attributeUpdate = new AttributeUpdate("name").addElements("John Doe");
-
-    Map<String, Object> primaryKey = Map.of(keyAttribute.getName(), keyAttribute.getValue());
-    Map<String, Object> attributeUpdates = Map.of(attributeUpdate.getAttributeName(), "John Doe");
-
+  @ParameterizedTest
+  @MethodSource("updateItemCases")
+  void testUpdateItemOperation(String attributeName, Object newValue) {
+    // Setup
+    AttributeUpdate attributeUpdate = new AttributeUpdate(attributeName).put(newValue);
+    Map<String, Object> attributeUpdates = Map.of(attributeUpdate.getAttributeName(), newValue);
     UpdateItem updateItem =
         new UpdateItem(
-            TestDynamoDBData.ActualValue.TABLE_NAME, primaryKey, attributeUpdates, "PUT");
-    updateItemOperation = new UpdateItemOperation(updateItem);
-  }
+            TestDynamoDBData.ActualValue.TABLE_NAME, Map.of("id", "123"), attributeUpdates, "PUT");
+    UpdateItemOperation operation = new UpdateItemOperation(updateItem);
 
-  @Test
-  public void testInvoke() {
     // Given
-    when(table.updateItem(updateItemSpecArgumentCaptor.capture())).thenReturn(updateItemOutcome);
+    when(table.updateItem(
+            primaryKeyArgumentCaptor.capture(), attributeUpdateArgumentCaptor.capture()))
+        .thenReturn(updateItemOutcome);
     // When
-    Object result = updateItemOperation.invoke(dynamoDB);
+    Object result = operation.invoke(dynamoDB);
     // Then
     assertThat(result).isInstanceOf(UpdateItemOutcome.class);
-    assertThat(((UpdateItemOutcome) result).getItem()).isEqualTo(updateItemOutcome.getItem());
-    UpdateItemSpec value = updateItemSpecArgumentCaptor.getValue();
-    assertThat(value.getKeyComponents()).contains(keyAttribute);
-    assertThat(value.getValueMap()).isEqualTo(Map.of(":name", "John Doe"));
+
+    PrimaryKey value = primaryKeyArgumentCaptor.getValue();
+
+    assertThat(value.getComponents().contains(new KeyAttribute("id", "123"))).isTrue();
+
+    AttributeUpdate expectedAttributeUpdate = attributeUpdateArgumentCaptor.getValue()[0];
+    assertThat(expectedAttributeUpdate.getAttributeName()).isEqualTo(attributeName);
+    assertThat(expectedAttributeUpdate.getValue()).isEqualTo(newValue);
+    assertThat(expectedAttributeUpdate.getAction()).isEqualTo(AttributeAction.PUT);
+  }
+
+  @ParameterizedTest
+  @MethodSource("updateItemCases")
+  void testDeleteItemOperation(String attributeName, Object newValue) {
+    // Setup
+    AttributeUpdate attributeUpdate = new AttributeUpdate(attributeName).put(newValue);
+    Map<String, Object> attributeUpdates = Map.of(attributeUpdate.getAttributeName(), newValue);
+    UpdateItem updateItem =
+        new UpdateItem(
+            TestDynamoDBData.ActualValue.TABLE_NAME,
+            Map.of("id", "123"),
+            attributeUpdates,
+            "DELETE");
+    UpdateItemOperation operation = new UpdateItemOperation(updateItem);
+
+    // Given
+    when(table.updateItem(
+            primaryKeyArgumentCaptor.capture(), attributeUpdateArgumentCaptor.capture()))
+        .thenReturn(updateItemOutcome);
+    // When
+    Object result = operation.invoke(dynamoDB);
+    // Then
+    assertThat(result).isInstanceOf(UpdateItemOutcome.class);
+
+    PrimaryKey value = primaryKeyArgumentCaptor.getValue();
+
+    assertThat(value.getComponents().contains(new KeyAttribute("id", "123"))).isTrue();
+
+    AttributeUpdate expectedAttributeUpdate = attributeUpdateArgumentCaptor.getValue()[0];
+    assertThat(expectedAttributeUpdate.getAttributeName()).isEqualTo(attributeName);
+    assertThat(expectedAttributeUpdate.getValue()).isNull();
+    assertThat(expectedAttributeUpdate.getAction()).isEqualTo(AttributeAction.DELETE);
+  }
+
+  static Stream<Arguments> updateItemCases() {
+    return Stream.of(
+        // String attribute
+        Arguments.of("status", "Active"),
+
+        // Number attribute
+        Arguments.of("age", 45),
+
+        // Set attribute - String Set
+        Arguments.of("stringSet", Set.of("c", "d")),
+
+        // Set attribute - Number Set
+        Arguments.of("numberSet", Set.of(new BigDecimal(3), new BigDecimal(4))),
+        // List attribute
+        Arguments.of("listAttr", List.of("b", 2)),
+        // Map attribute
+        Arguments.of("mapAttr", Map.of("key2", "value2")),
+
+        // Complex Map attribute with nested structures
+        Arguments.of(
+            "complexMap",
+            Map.of(
+                "nestedKey2",
+                Map.of("nestedMapKey2", "nestedValue2"),
+                "nestedList",
+                List.of("item3", "item4"))),
+        // Map attribute with nested Map
+        Arguments.of("nestedMap", Map.of("key", Map.of("innerKey2", "innerValue2"))),
+
+        // Map attribute with a Set of Numbers
+        Arguments.of(
+            "mapWithNumberSet", Map.of("key", Set.of(new BigDecimal(3), new BigDecimal(4)))),
+
+        // Complex Map with nested Map and List
+        Arguments.of(
+            "complexMapWithNestedMapAndList",
+            Map.of(
+                "mapKey",
+                Map.of(
+                    "nestedMapKey",
+                    "newNestedMapValue",
+                    "nestedListKey",
+                    List.of("item3", "item4")),
+                "simpleKey",
+                "updatedSimpleValue")),
+
+        // Map with nested Set of Numbers
+        Arguments.of(
+            "mapWithNestedNumberSet",
+            Map.of("numberSetKey", Set.of(new BigDecimal(3), new BigDecimal(4))),
+            Map.of(
+                ":mapWithNestedNumberSet",
+                Map.of("numberSetKey", Set.of(new BigDecimal(3), new BigDecimal(4))))),
+
+        // Map with nested Set of Strings
+        Arguments.of("mapWithNestedStringSet", Map.of("stringSetKey", Set.of("C", "D"))),
+
+        // Map with nested complex types (Map and Set)
+        Arguments.of(
+            "mapWithComplexNestedTypes",
+            Map.of(
+                "nestedMap", Map.of("key2", "value2"),
+                "nestedSet", Set.of(new BigDecimal(3), new BigDecimal(4)))));
   }
 
   @Test


### PR DESCRIPTION
## Description

No changes to the template in this PR. Current handling of binary types as strings and sets as lists remains. Future updates may address these based on user feedback.

result of execution : 
<img width="1158" alt="Screenshot 2024-02-14 at 14 21 52" src="https://github.com/camunda/connectors/assets/108869886/12b5b3de-9905-493c-aff5-c3c7f9cdeb4f">


closes #

https://github.com/camunda/team-connectors/issues/611