### PR TITLE
fix(generator): property type override via annotation

### DIFF
--- a/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/util/TemplatePropertiesUtil.java
+++ b/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/util/TemplatePropertiesUtil.java
@@ -61,9 +61,7 @@ import java.util.stream.Collectors;
 import org.apache.commons.lang3.ClassUtils;
 import org.apache.commons.lang3.StringUtils;
 
-/**
- * Utility class for transforming data classes into {@link PropertyBuilder} instances.
- */
+/** Utility class for transforming data classes into {@link PropertyBuilder} instances. */
 public class TemplatePropertiesUtil {
 
   private static final List<FieldProcessor> fieldProcessors =
@@ -131,7 +129,9 @@ public class TemplatePropertiesUtil {
         } catch (StackOverflowError e) {
           throw new RuntimeException(
               "Failed to analyze container field "
-                  + field.getName() + " of class " + field.getDeclaringClass()
+                  + field.getName()
+                  + " of class "
+                  + field.getDeclaringClass()
                   + " due to a stack overflow error. This is likely caused by a "
                   + "circular reference in the data class.\nCheck if the type is meant to be handled as "
                   + "a container type and consider applying a type override using @TemplateProperty or breaking the circular reference.");
@@ -396,11 +396,11 @@ public class TemplatePropertiesUtil {
   }
 
   private static <T extends Annotation>
-  Map.Entry<String, String> extractIdAndLabelFromAnnotationOrDeriveFromType(
-      Class<?> type,
-      Class<T> annotationClass,
-      Function<T, String> idExtractor,
-      Function<T, String> labelExtractor) {
+      Map.Entry<String, String> extractIdAndLabelFromAnnotationOrDeriveFromType(
+          Class<?> type,
+          Class<T> annotationClass,
+          Function<T, String> idExtractor,
+          Function<T, String> labelExtractor) {
 
     var annotation = type.getAnnotation(annotationClass);
     if (annotation != null) {

--- a/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/util/TemplatePropertiesUtil.java
+++ b/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/util/TemplatePropertiesUtil.java
@@ -50,7 +50,6 @@ import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -447,8 +446,8 @@ public class TemplatePropertiesUtil {
     // or if the type has a manual type override
     return !ClassUtils.isPrimitiveOrWrapper(type)
         && !hasManualTypeOverride
-        && !type.isAssignableFrom(String.class)
-        && !type.isAssignableFrom(Date.class)
+        && !"java.time".equals(type.getPackageName())
+        && type != String.class
         && type != Object.class
         && type != JsonNode.class
         && !type.isEnum()

--- a/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/util/TemplatePropertiesUtil.java
+++ b/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/util/TemplatePropertiesUtil.java
@@ -50,6 +50,7 @@ import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -58,8 +59,11 @@ import java.util.Objects;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.ClassUtils;
+import org.apache.commons.lang3.StringUtils;
 
-/** Utility class for transforming data classes into {@link PropertyBuilder} instances. */
+/**
+ * Utility class for transforming data classes into {@link PropertyBuilder} instances.
+ */
 public class TemplatePropertiesUtil {
 
   private static final List<FieldProcessor> fieldProcessors =
@@ -93,37 +97,45 @@ public class TemplatePropertiesUtil {
     var properties = new ArrayList<PropertyBuilder>();
 
     for (Field field : fields) {
-      if (isContainerType(field.getType())) {
+      if (isContainerType(field)) {
         var nestedPropertiesAnnotation = field.getAnnotation(NestedProperties.class);
+        boolean hasPathPrefix =
+            nestedPropertiesAnnotation == null || nestedPropertiesAnnotation.addNestedPath();
+        boolean hasConditionOverride =
+            nestedPropertiesAnnotation != null
+                && StringUtils.isNotBlank(nestedPropertiesAnnotation.condition().property());
+        boolean hasGroupOverride =
+            nestedPropertiesAnnotation != null
+                && StringUtils.isNotBlank(nestedPropertiesAnnotation.group());
 
-        // analyze recursively
-        var nestedProperties =
-            extractTemplatePropertiesFromType(field.getType()).stream()
-                .peek(
-                    builder -> {
-                      if (nestedPropertiesAnnotation == null
-                          || nestedPropertiesAnnotation.addNestedPath()) {
-                        addPathPrefix(builder, field.getName());
-                      }
-                    })
-                .peek(
-                    builder -> {
-                      if (nestedPropertiesAnnotation != null
-                          && nestedPropertiesAnnotation.condition() != null) {
-                        builder.condition(
-                            TemplatePropertyFieldProcessor.transformToCondition(
-                                nestedPropertiesAnnotation.condition()));
-                      }
-                    })
-                .peek(
-                    builder -> {
-                      if (nestedPropertiesAnnotation != null
-                          && !nestedPropertiesAnnotation.group().isBlank()) {
-                        builder.group(nestedPropertiesAnnotation.group());
-                      }
-                    })
-                .toList();
-        properties.addAll(nestedProperties);
+        try {
+          // analyze recursively
+          var nestedProperties =
+              extractTemplatePropertiesFromType(field.getType()).stream()
+                  .peek(
+                      builder -> {
+                        if (hasPathPrefix) {
+                          addPathPrefixToBuilder(builder, field.getName());
+                        }
+                        if (hasConditionOverride) {
+                          builder.condition(
+                              TemplatePropertyFieldProcessor.transformToCondition(
+                                  nestedPropertiesAnnotation.condition()));
+                        }
+                        if (hasGroupOverride) {
+                          builder.group(nestedPropertiesAnnotation.group());
+                        }
+                      })
+                  .toList();
+          properties.addAll(nestedProperties);
+        } catch (StackOverflowError e) {
+          throw new RuntimeException(
+              "Failed to analyze container field "
+                  + field.getName() + " of class " + field.getDeclaringClass()
+                  + " due to a stack overflow error. This is likely caused by a "
+                  + "circular reference in the data class.\nCheck if the type is meant to be handled as "
+                  + "a container type and consider applying a type override using @TemplateProperty or breaking the circular reference.");
+        }
       } else {
         properties.add(buildProperty(field));
       }
@@ -158,8 +170,7 @@ public class TemplatePropertiesUtil {
   private static PropertyBuilder buildProperty(Field field) {
     var annotation = field.getAnnotation(TemplateProperty.class);
     String name, label;
-    String fieldName = field.getName();
-    String bindingName = fieldName;
+    String bindingName = field.getName();
     if (annotation != null) {
       if (annotation.ignore()) {
         return null;
@@ -194,7 +205,7 @@ public class TemplatePropertiesUtil {
     return propertyBuilder;
   }
 
-  private static PropertyBuilder addPathPrefix(PropertyBuilder builder, String path) {
+  private static void addPathPrefixToBuilder(PropertyBuilder builder, String path) {
     var originalId = builder.getId();
     builder.id(path + "." + originalId);
     var binding = builder.getBinding();
@@ -212,28 +223,31 @@ public class TemplatePropertiesUtil {
                   dependant.condition(
                       addConditionPrefix(dependant.getCondition(), path, originalId)));
     }
-    return builder;
   }
 
   private static PropertyCondition addConditionPrefix(
       PropertyCondition condition, String path, String discriminatorPropertyId) {
-    if (condition instanceof AllMatch allMatchCondition) {
-      return new AllMatch(
-          allMatchCondition.allMatch().stream()
-              .map(subCondition -> addConditionPrefix(subCondition, path, discriminatorPropertyId))
-              .toList());
-    } else if (condition instanceof Equals equalsCondition) {
-      if (!equalsCondition.property().equals(discriminatorPropertyId)) {
-        return equalsCondition;
+    switch (condition) {
+      case AllMatch allMatchCondition -> {
+        return new AllMatch(
+            allMatchCondition.allMatch().stream()
+                .map(
+                    subCondition -> addConditionPrefix(subCondition, path, discriminatorPropertyId))
+                .toList());
       }
-      return new Equals(path + "." + equalsCondition.property(), equalsCondition.equals());
-    } else if (condition instanceof OneOf oneOfCondition) {
-      if (!oneOfCondition.property().equals(discriminatorPropertyId)) {
-        return oneOfCondition;
+      case Equals equalsCondition -> {
+        if (!equalsCondition.property().equals(discriminatorPropertyId)) {
+          return equalsCondition;
+        }
+        return new Equals(path + "." + equalsCondition.property(), equalsCondition.equals());
       }
-      return new OneOf(path + "." + oneOfCondition.property(), oneOfCondition.oneOf());
-    } else {
-      throw new IllegalStateException("Unknown condition type: " + condition.getClass());
+      case OneOf oneOfCondition -> {
+        if (!oneOfCondition.property().equals(discriminatorPropertyId)) {
+          return oneOfCondition;
+        }
+        return new OneOf(path + "." + oneOfCondition.property(), oneOfCondition.oneOf());
+      }
+      default -> throw new IllegalStateException("Unknown condition type: " + condition.getClass());
     }
   }
 
@@ -382,11 +396,11 @@ public class TemplatePropertiesUtil {
   }
 
   private static <T extends Annotation>
-      Map.Entry<String, String> extractIdAndLabelFromAnnotationOrDeriveFromType(
-          Class<?> type,
-          Class<T> annotationClass,
-          Function<T, String> idExtractor,
-          Function<T, String> labelExtractor) {
+  Map.Entry<String, String> extractIdAndLabelFromAnnotationOrDeriveFromType(
+      Class<?> type,
+      Class<T> annotationClass,
+      Function<T, String> idExtractor,
+      Function<T, String> labelExtractor) {
 
     var annotation = type.getAnnotation(annotationClass);
     if (annotation != null) {
@@ -424,10 +438,17 @@ public class TemplatePropertiesUtil {
     return label.toString();
   }
 
-  private static boolean isContainerType(Class<?> type) {
+  private static boolean isContainerType(Field field) {
+    var type = field.getType();
+    var propertyAnnotation = field.getAnnotation(TemplateProperty.class);
+    boolean hasManualTypeOverride =
+        propertyAnnotation != null && propertyAnnotation.type() != PropertyType.Unknown;
     // true if object with fields, false if primitive or collection or map or array
+    // or if the type has a manual type override
     return !ClassUtils.isPrimitiveOrWrapper(type)
+        && !hasManualTypeOverride
         && !type.isAssignableFrom(String.class)
+        && !type.isAssignableFrom(Date.class)
         && type != Object.class
         && type != JsonNode.class
         && !type.isEnum()

--- a/element-template-generator/core/src/test/java/io/camunda/connector/generator/java/OutboundClassBasedTemplateGeneratorTest.java
+++ b/element-template-generator/core/src/test/java/io/camunda/connector/generator/java/OutboundClassBasedTemplateGeneratorTest.java
@@ -464,6 +464,20 @@ public class OutboundClassBasedTemplateGeneratorTest extends BaseTest {
       assertThat(((AllMatch) property.getCondition()).allMatch())
           .contains(new PropertyCondition.Equals("annotatedStringProperty", "value"));
     }
+
+    @Test
+    void containerType_withManualTypeOverride() {
+      var template = generator.generate(MyConnectorFunction.MinimallyAnnotated.class).getFirst();
+      var property = getPropertyByLabel("Property with type override", template);
+      assertThat(property.getType()).isEqualTo("String");
+    }
+
+    @Test
+    void dateProperty_defaultsToStringType() {
+      var template = generator.generate(MyConnectorFunction.MinimallyAnnotated.class).getFirst();
+      var property = getPropertyByLabel("Date property", template);
+      assertThat(property.getType()).isEqualTo("String");
+    }
   }
 
   @Nested

--- a/element-template-generator/core/src/test/java/io/camunda/connector/generator/java/example/MyConnectorInput.java
+++ b/element-template-generator/core/src/test/java/io/camunda/connector/generator/java/example/MyConnectorInput.java
@@ -37,6 +37,7 @@ import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
+import java.time.LocalDate;
 
 public record MyConnectorInput(
     @TemplateProperty(
@@ -51,6 +52,8 @@ public record MyConnectorInput(
     Object objectProperty,
     JsonNode jsonNodeProperty,
     MyEnum enumProperty,
+    LocalDate dateProperty,
+    @TemplateProperty(type = PropertyType.String) NestedWithDefinedGroup propertyWithTypeOverride,
     NestedWithoutDefinedGroup nestedProperty,
     @NestedProperties(group = "customGroup") NestedWithoutDefinedGroup nestedPropertyWithGroup,
     @NestedProperties(addNestedPath = false) NestedWithDefinedGroup customPathNestedProperty,


### PR DESCRIPTION
## Description

Property type override was not applied to composite/container types. This lead to classes such as `Date` being always interpreted as container types no matter which property type is specified by the user in `@TemplateProperty(type=...)`.

Also:
- `LocalDate` and other Java 8 date/time types are implicitly mapped to `String` properties
- Improved handling of StackOverflowError for misconfigured container types
- Format changes for better readability

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #1948 

