### PR TITLE
chore: update nimbus-jose-jwt version

### DIFF
--- a/connectors/webhook/pom.xml
+++ b/connectors/webhook/pom.xml
@@ -61,6 +61,11 @@
       <version>${version.auth0.jwt}</version>
     </dependency>
     <dependency>
+      <groupId>com.nimbusds</groupId>
+      <artifactId>nimbus-jose-jwt</artifactId>
+      <version>${version.nimbus.jose.jwt}</version>
+    </dependency>
+    <dependency>
       <groupId>com.auth0</groupId>
       <artifactId>jwks-rsa</artifactId>
       <version>${version.auth0.jwks}</version>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -131,6 +131,7 @@ limitations under the License.</license.inlineheader>
 
     <version.wiremock>3.3.1</version.wiremock>
     <version.auth0.jwt>4.4.0</version.auth0.jwt>
+    <version.nimbus.jose.jwt>9.37.3</version.nimbus.jose.jwt>
     <version.auth0.jwks>0.22.1</version.auth0.jwks>
 
     <!-- maven plugins (not managed by parent) -->


### PR DESCRIPTION
## Description

We have to update [nimbus-jose-jwt](https://mvnrepository.com/artifact/com.nimbusds/nimbus-jose-jwt) version because of security reasons.

