### PR TITLE
build: enforce no snapshots on release

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -841,6 +841,17 @@ limitations under the License.</license.inlineheader>
             </plugin>
           </plugins>
         </pluginManagement>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-enforcer-plugin</artifactId>
+            <configuration>
+              <rules>
+                <requireReleaseDeps/>
+              </rules>
+            </configuration>
+          </plugin>
+        </plugins>
       </build>
     </profile>
   </profiles>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -546,6 +546,18 @@ limitations under the License.</license.inlineheader>
       <name>Zeebe Snapshot Repository</name>
       <url>https://artifacts.camunda.com/artifactory/zeebe-io-snapshots/</url>
     </repository>
+
+    <repository>
+      <releases>
+        <enabled>true</enabled>
+      </releases>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+      <id>identity</id>
+      <name>Identity Repository</name>
+      <url>https://artifacts.camunda.com/artifactory/camunda-identity/</url>
+    </repository>
   </repositories>
 
   <build>


### PR DESCRIPTION
## Description

Configures maven-enforcer-plugin to check for snapshot dependencies during release builds (only when `sonatype-oss-release` profile is active)

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #1968 

