### PR TITLE
feat(generator): support constraints in @TemplateProperty

### DIFF
--- a/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/annotation/TemplateProperty.java
+++ b/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/annotation/TemplateProperty.java
@@ -16,6 +16,9 @@
  */
 package io.camunda.connector.generator.java.annotation;
 
+import static java.lang.Integer.MAX_VALUE;
+import static java.lang.Integer.MIN_VALUE;
+
 import io.camunda.connector.generator.dsl.Property.FeelMode;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -95,6 +98,13 @@ public @interface TemplateProperty {
    */
   boolean ignore() default false;
 
+  /**
+   * Constraints for the property that are used by the Modeler to validate the input.
+   * Constraints can also be set using the Java Bean Validation API annotations, which takes
+   * precedence over the constraints defined in this annotation.
+   */
+  PropertyConstraints constraints() default @PropertyConstraints;
+
   enum PropertyType {
     Boolean,
     Dropdown,
@@ -120,5 +130,17 @@ public @interface TemplateProperty {
     String value();
 
     String label();
+  }
+
+  @interface PropertyConstraints {
+    boolean notEmpty() default false;
+    int minLength() default MIN_VALUE;
+    int maxLength() default MAX_VALUE;
+    Pattern pattern() default @Pattern(value = "", message = "");
+  }
+
+  @interface Pattern {
+    String value();
+    String message();
   }
 }

--- a/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/annotation/TemplateProperty.java
+++ b/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/annotation/TemplateProperty.java
@@ -99,9 +99,9 @@ public @interface TemplateProperty {
   boolean ignore() default false;
 
   /**
-   * Constraints for the property that are used by the Modeler to validate the input.
-   * Constraints can also be set using the Java Bean Validation API annotations, which takes
-   * precedence over the constraints defined in this annotation.
+   * Constraints for the property that are used by the Modeler to validate the input. Constraints
+   * can also be set using the Java Bean Validation API annotations, which takes precedence over the
+   * constraints defined in this annotation.
    */
   PropertyConstraints constraints() default @PropertyConstraints;
 
@@ -134,13 +134,17 @@ public @interface TemplateProperty {
 
   @interface PropertyConstraints {
     boolean notEmpty() default false;
+
     int minLength() default MIN_VALUE;
+
     int maxLength() default MAX_VALUE;
+
     Pattern pattern() default @Pattern(value = "", message = "");
   }
 
   @interface Pattern {
     String value();
+
     String message();
   }
 }

--- a/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/processor/TemplatePropertyFieldProcessor.java
+++ b/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/processor/TemplatePropertyFieldProcessor.java
@@ -79,11 +79,10 @@ public class TemplatePropertyFieldProcessor implements FieldProcessor {
 
   private PropertyConstraints buildConstraints(TemplateProperty propertyAnnotation) {
     var constraintsAnnotation = propertyAnnotation.constraints();
-    if (
-        !constraintsAnnotation.notEmpty()
-            && constraintsAnnotation.maxLength() == Integer.MAX_VALUE
-            && constraintsAnnotation.minLength() == Integer.MIN_VALUE
-            && constraintsAnnotation.pattern().value().isBlank()) {
+    if (!constraintsAnnotation.notEmpty()
+        && constraintsAnnotation.maxLength() == Integer.MAX_VALUE
+        && constraintsAnnotation.minLength() == Integer.MIN_VALUE
+        && constraintsAnnotation.pattern().value().isBlank()) {
       return null;
     }
     var builder = PropertyConstraints.builder();

--- a/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/processor/TemplatePropertyFieldProcessor.java
+++ b/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/processor/TemplatePropertyFieldProcessor.java
@@ -20,6 +20,7 @@ import io.camunda.connector.generator.dsl.DropdownProperty.DropdownPropertyBuild
 import io.camunda.connector.generator.dsl.Property.FeelMode;
 import io.camunda.connector.generator.dsl.PropertyBuilder;
 import io.camunda.connector.generator.dsl.PropertyCondition;
+import io.camunda.connector.generator.dsl.PropertyConstraints;
 import io.camunda.connector.generator.java.annotation.TemplateProperty;
 import java.lang.reflect.Field;
 import java.util.Arrays;
@@ -50,6 +51,7 @@ public class TemplatePropertyFieldProcessor implements FieldProcessor {
       builder.group(annotation.group());
     }
     builder.condition(buildCondition(annotation));
+    builder.constraints(buildConstraints(annotation));
   }
 
   private PropertyCondition buildCondition(TemplateProperty propertyAnnotation) {
@@ -73,5 +75,32 @@ public class TemplatePropertyFieldProcessor implements FieldProcessor {
       return new PropertyCondition.OneOf(
           conditionAnnotation.property(), Arrays.asList(conditionAnnotation.oneOf()));
     }
+  }
+
+  private PropertyConstraints buildConstraints(TemplateProperty propertyAnnotation) {
+    var constraintsAnnotation = propertyAnnotation.constraints();
+    if (
+        !constraintsAnnotation.notEmpty()
+            && constraintsAnnotation.maxLength() == Integer.MAX_VALUE
+            && constraintsAnnotation.minLength() == Integer.MIN_VALUE
+            && constraintsAnnotation.pattern().value().isBlank()) {
+      return null;
+    }
+    var builder = PropertyConstraints.builder();
+    if (constraintsAnnotation.notEmpty()) {
+      builder.notEmpty(true);
+    }
+    if (constraintsAnnotation.maxLength() != Integer.MAX_VALUE) {
+      builder.maxLength(constraintsAnnotation.maxLength());
+    }
+    if (constraintsAnnotation.minLength() != Integer.MIN_VALUE) {
+      builder.minLength(constraintsAnnotation.minLength());
+    }
+    if (!constraintsAnnotation.pattern().value().isBlank()) {
+      builder.pattern(
+          new PropertyConstraints.Pattern(
+              constraintsAnnotation.pattern().value(), constraintsAnnotation.pattern().message()));
+    }
+    return builder.build();
   }
 }

--- a/element-template-generator/core/src/test/java/io/camunda/connector/generator/java/OutboundClassBasedTemplateGeneratorTest.java
+++ b/element-template-generator/core/src/test/java/io/camunda/connector/generator/java/OutboundClassBasedTemplateGeneratorTest.java
@@ -353,6 +353,7 @@ public class OutboundClassBasedTemplateGeneratorTest extends BaseTest {
       assertThat(property.getDescription()).isEqualTo("description");
       assertThat(property.getFeel()).isEqualTo(FeelMode.optional);
       assertThat(property.getBinding()).isEqualTo(new PropertyBinding.ZeebeInput("customBinding"));
+      assertThat(property.getConstraints().notEmpty()).isTrue();
     }
 
     @Test

--- a/element-template-generator/core/src/test/java/io/camunda/connector/generator/java/OutboundClassBasedTemplateGeneratorTest.java
+++ b/element-template-generator/core/src/test/java/io/camunda/connector/generator/java/OutboundClassBasedTemplateGeneratorTest.java
@@ -338,6 +338,7 @@ public class OutboundClassBasedTemplateGeneratorTest extends BaseTest {
       assertThat(property.getFeel()).isEqualTo(FeelMode.optional);
       assertThat(property.getBinding())
           .isEqualTo(new PropertyBinding.ZeebeInput("notAnnotatedStringProperty"));
+      assertThat(property.getConstraints()).isNull();
     }
 
     @Test
@@ -354,6 +355,9 @@ public class OutboundClassBasedTemplateGeneratorTest extends BaseTest {
       assertThat(property.getFeel()).isEqualTo(FeelMode.optional);
       assertThat(property.getBinding()).isEqualTo(new PropertyBinding.ZeebeInput("customBinding"));
       assertThat(property.getConstraints().notEmpty()).isTrue();
+      assertThat(property.getConstraints().minLength()).isNull();
+      assertThat(property.getConstraints().maxLength()).isNull();
+      assertThat(property.getConstraints().pattern()).isNull();
     }
 
     @Test

--- a/element-template-generator/core/src/test/java/io/camunda/connector/generator/java/example/MyConnectorInput.java
+++ b/element-template-generator/core/src/test/java/io/camunda/connector/generator/java/example/MyConnectorInput.java
@@ -46,7 +46,8 @@ public record MyConnectorInput(
             label = "Annotated and renamed string property",
             type = PropertyType.Text,
             group = "group1",
-            description = "description")
+            description = "description",
+            constraints = @TemplateProperty.PropertyConstraints(notEmpty = true))
         String annotatedStringProperty,
     String notAnnotatedStringProperty,
     Object objectProperty,


### PR DESCRIPTION
## Description

Adds a way to define property constraints in `@TemplateProperty` instead of using Java bean validation API annotations.

Context: https://camunda.slack.com/archives/C0350959WG1/p1708515841961049


