### PR TITLE
Exclude version updates of own artifacts

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,8 +9,7 @@
       "automerge": true
     },
     {
-      "matchPackagePatterns": ["^io.camunda.connector"],
-      "matchManagers": ["maven"],
+      "matchPackagePrefixes": ["io.camunda.connector"],
       "enabled": false
     }
   ],

--- a/renovate.json
+++ b/renovate.json
@@ -7,6 +7,11 @@
     {
       "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
       "automerge": true
+    },
+    {
+      "matchPackagePatterns": ["io.camunda.connector"],
+      "matchManagers": ["maven"],
+      "enabled": false
     }
   ],
   "baseBranches": ["main", "release/8.3", "release/8.4"]

--- a/renovate.json
+++ b/renovate.json
@@ -9,7 +9,7 @@
       "automerge": true
     },
     {
-      "matchPackagePatterns": ["io.camunda.connector"],
+      "matchPackagePatterns": ["^io.camunda.connector"],
       "matchManagers": ["maven"],
       "enabled": false
     }


### PR DESCRIPTION
## Description

We should exclude our own (same repository) artifacts from renovate:
https://github.com/camunda/connectors/pull/1941
https://github.com/camunda/connectors/pull/1940

