### PR TITLE
feat(polling): add activity log in case of binding exception in polling connector

### DIFF
--- a/connectors/http/polling/src/main/java/io/camunda/connector/http/polling/task/HttpRequestTask.java
+++ b/connectors/http/polling/src/main/java/io/camunda/connector/http/polling/task/HttpRequestTask.java
@@ -61,6 +61,10 @@ public class HttpRequestTask implements Runnable {
           "Error occurred while binding properties for processInstanceKey {}: {}",
           processInstanceContext.getKey(),
           e.getMessage());
+      context.log(
+          Activity.level(Severity.ERROR)
+              .tag("error")
+              .message("Error occurred while binding properties"));
     }
   }
 }


### PR DESCRIPTION
## Description

Added an activity log with error severity when property binding fails.

## Related issues

https://github.com/camunda/team-connectors/issues/587

closes https://github.com/camunda/team-connectors/issues/587

