### PR TITLE
fix(importer): handle missing required properties as invalid connector definition exception

### DIFF
--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/importer/ProcessDefinitionInspector.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/importer/ProcessDefinitionInspector.java
@@ -312,8 +312,10 @@ public class ProcessDefinitionInspector {
 
   private String extractRequiredProperty(BaseElement element, String name) {
     return extractProperty(element, name)
-        .orElseThrow(() ->
-            new InvalidInboundConnectorDefinitionException("Missing required property " + name));
+        .orElseThrow(
+            () ->
+                new InvalidInboundConnectorDefinitionException(
+                    "Missing required property " + name));
   }
 
   private Optional<String> extractProperty(BaseElement element, String name) {

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/importer/ProcessDefinitionInspector.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/importer/ProcessDefinitionInspector.java
@@ -312,7 +312,8 @@ public class ProcessDefinitionInspector {
 
   private String extractRequiredProperty(BaseElement element, String name) {
     return extractProperty(element, name)
-        .orElseThrow(() -> new IllegalStateException("Missing required property " + name));
+        .orElseThrow(() ->
+            new InvalidInboundConnectorDefinitionException("Missing required property " + name));
   }
 
   private Optional<String> extractProperty(BaseElement element, String name) {


### PR DESCRIPTION
## Description

An addition to #1956, one more exception should be handled as invalid connector definition

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #1955

