### PR TITLE
Fix CWE 770 and CWE 835

### DIFF
--- a/connectors-e2e-test/connectors-e2e-test-kafka/pom.xml
+++ b/connectors-e2e-test/connectors-e2e-test-kafka/pom.xml
@@ -26,6 +26,13 @@
   </build>
 
   <dependencies>
+
+    <dependency>
+      <groupId>commons-codec</groupId>
+      <artifactId>commons-codec</artifactId>
+      <version>${version.commons-codec}</version>
+    </dependency>
+
     <dependency>
       <groupId>io.camunda.connector</groupId>
       <artifactId>connector-kafka</artifactId>

--- a/connectors/soap/src/test/java/io/camunda/connectors/soap/xml/XmlToJsonMapperTest.java
+++ b/connectors/soap/src/test/java/io/camunda/connectors/soap/xml/XmlToJsonMapperTest.java
@@ -84,7 +84,11 @@ public class XmlToJsonMapperTest {
     String xmlString =
         mapper.toXmlString(objectMapper.readValue(jsonString, new TypeReference<>() {})).trim();
     String matcher = getResource(xmlFile).trim();
-    assertThat(xmlString).isEqualTo(matcher);
+    assertThat(removeCRChars(xmlString)).isEqualTo(removeCRChars(matcher));
+  }
+
+  private String removeCRChars(String string) {
+    return string.replace("\r", "");
   }
 
   private String getResource(String filename) {

--- a/connectors/webhook/pom.xml
+++ b/connectors/webhook/pom.xml
@@ -61,11 +61,6 @@
       <version>${version.auth0.jwt}</version>
     </dependency>
     <dependency>
-      <groupId>com.nimbusds</groupId>
-      <artifactId>nimbus-jose-jwt</artifactId>
-      <version>${version.nimbus.jose.jwt}</version>
-    </dependency>
-    <dependency>
       <groupId>com.auth0</groupId>
       <artifactId>jwks-rsa</artifactId>
       <version>${version.auth0.jwks}</version>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -109,6 +109,7 @@ limitations under the License.</license.inlineheader>
     <version.httpcore>4.4.16</version.httpcore>
 
     <version.commons-io>2.15.1</version.commons-io>
+    <version.commons-codec>1.16.1</version.commons-codec>
 
     <version.kafka-clients>3.6.1</version.kafka-clients>
 

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -131,7 +131,6 @@ limitations under the License.</license.inlineheader>
 
     <version.wiremock>3.4.2</version.wiremock>
     <version.auth0.jwt>4.4.0</version.auth0.jwt>
-    <version.nimbus.jose.jwt>9.37.3</version.nimbus.jose.jwt>
     <version.auth0.jwks>0.22.1</version.auth0.jwks>
 
     <!-- maven plugins (not managed by parent) -->
@@ -437,6 +436,20 @@ limitations under the License.</license.inlineheader>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-lang3</artifactId>
         <version>3.14.0</version>
+      </dependency>
+
+      <!-- Fixes CWE-770 -->
+      <dependency>
+        <groupId>com.nimbusds</groupId>
+        <artifactId>nimbus-jose-jwt</artifactId>
+        <version>9.37.3</version>
+      </dependency>
+
+      <!-- Fixes CWE-835 -->
+      <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-compress</artifactId>
+        <version>1.26.0</version>
       </dependency>
 
       <!-- FIXME: maven resolves protobuf to 3.21.x while zeebe-client is compiled for 3.22.2. This is a temporary fix to be reassessed later. -->


### PR DESCRIPTION
## Description

Specified the version of commons-compress and nimbus-jose-jwt dependencies as a fix for CWE-835 and CWE-770. The consequence of this was that I had to specify the commons-codec version for kafka e2e test. 

Also slightly modified soap connector test, because it was failing on my machine. I changed the comparison of xmls to ignore the CR chars. This might be a windows related issue, and has no impact on the test quality and coverage.

