### PR TITLE
http connector: use tcp socket timeout

### DIFF
--- a/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/components/HttpTransportComponentSupplier.java
+++ b/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/components/HttpTransportComponentSupplier.java
@@ -21,12 +21,18 @@ import com.google.api.client.http.HttpTransport;
 import com.google.api.client.http.apache.v2.ApacheHttpTransport;
 import com.google.api.client.json.JsonObjectParser;
 import com.google.api.client.json.gson.GsonFactory;
+import org.apache.http.config.SocketConfig;
+import org.apache.http.impl.client.HttpClientBuilder;
 
 public class HttpTransportComponentSupplier {
 
   private HttpTransportComponentSupplier() {}
 
-  private static final HttpTransport HTTP_TRANSPORT = new ApacheHttpTransport();
+  private static final HttpTransport HTTP_TRANSPORT =
+      new ApacheHttpTransport(
+          HttpClientBuilder.create()
+              .setDefaultSocketConfig(SocketConfig.custom().setSoKeepAlive(true).build())
+              .build());
   private static final HttpRequestFactory REQUEST_FACTORY =
       HTTP_TRANSPORT.createRequestFactory(
           request -> request.setParser(new JsonObjectParser(new GsonFactory())));


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

The HttpTransport of the HttpBase has been configured to use `SO_KEEPALIVE`.

The desired effect is that a long-running http call will not idle and eventually be closed by a gateway.

Reference: https://aws.amazon.com/blogs/networking-and-content-delivery/implementing-long-running-tcp-connections-within-vpc-networking/

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #2049

>Special wish: I would like this to be backported to 8.4 to unblock progress of a project

