### PR TITLE
feat(kafka): revert to correlate without result

### DIFF
--- a/connectors/kafka/src/main/java/io/camunda/connector/kafka/inbound/KafkaConnectorConsumer.java
+++ b/connectors/kafka/src/main/java/io/camunda/connector/kafka/inbound/KafkaConnectorConsumer.java
@@ -171,7 +171,7 @@ public class KafkaConnectorConsumer {
     LOG.trace("Kafka message received: key = {}, value = {}", record.key(), record.value());
     var reader = avroObjectReader != null ? avroObjectReader : objectMapper.reader();
     var mappedMessage = convertConsumerRecordToKafkaInboundMessage(record, reader);
-    this.context.correlateWithResult(mappedMessage);
+    this.context.correlate(mappedMessage);
   }
 
   public void stopConsumer() throws ExecutionException, InterruptedException {


### PR DESCRIPTION
## Description

Previous commits introduced correlation with the result in the Kafka consumer. In the weekly meeting, it was decided to revert to the previous implementation for now; 
thus, we will correlate without the result

