### PR TITLE
feat(kafka inbound): topic and consumer group not support FEEL

### DIFF
--- a/connectors/kafka/element-templates/avro/kafka-inbound-connector-intermediate.json
+++ b/connectors/kafka/element-templates/avro/kafka-inbound-connector-intermediate.json
@@ -2,7 +2,7 @@
   "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
   "name": "Kafka Intermediate Catch Event Connector",
   "id": "io.camunda.connectors.inbound.KafkaIntermediate.avro-v1",
-  "version": 1,
+  "version": 2,
   "description": "Consume Kafka messages",
   "documentationRef": "https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/kafka/?kafka=inbound",
   "category": {
@@ -127,7 +127,6 @@
       "description": "Provide the topic name",
       "group": "kafka",
       "type": "String",
-      "feel": "optional",
       "binding": {
         "type": "zeebe:property",
         "name": "topic.topicName"
@@ -141,7 +140,6 @@
       "description": "Provide the consumer group ID used by the connector. Leave empty for an automatically generated one",
       "group": "kafka",
       "type": "String",
-      "feel": "optional",
       "optional": true,
       "binding": {
         "type": "zeebe:property",

--- a/connectors/kafka/element-templates/avro/kafka-inbound-connector.json
+++ b/connectors/kafka/element-templates/avro/kafka-inbound-connector.json
@@ -2,7 +2,7 @@
   "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
   "name": "Kafka Start Event Connector",
   "id": "io.camunda.connectors.inbound.KAFKA.avro-v1",
-  "version": 1,
+  "version": 2,
   "description": "Consume Kafka messages",
   "documentationRef": "https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/kafka/?kafka=inbound",
   "category": {
@@ -115,7 +115,6 @@
       "description": "Provide the topic name",
       "group": "kafka",
       "type": "String",
-      "feel": "optional",
       "binding": {
         "type": "zeebe:property",
         "name": "topic.topicName"
@@ -129,7 +128,6 @@
       "description": "Provide the consumer group ID used by the connector. Leave empty for an automatically generated one",
       "group": "kafka",
       "type": "String",
-      "feel": "optional",
       "optional": true,
       "binding": {
         "type": "zeebe:property",

--- a/connectors/kafka/element-templates/kafka-connector-message-start.json
+++ b/connectors/kafka/element-templates/kafka-connector-message-start.json
@@ -2,7 +2,7 @@
   "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
   "name": "Kafka Message Start Event Connector",
   "id": "io.camunda.connectors.inbound.KafkaMessageStart.v1",
-  "version": 1,
+  "version": 2,
   "description": "Consume Kafka messages",
   "documentationRef": "https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/kafka/?kafka=inbound",
   "category": {
@@ -130,7 +130,6 @@
       "description": "Provide the topic name",
       "group": "kafka",
       "type": "String",
-      "feel": "optional",
       "binding": {
         "type": "zeebe:property",
         "name": "topic.topicName"
@@ -144,7 +143,6 @@
       "description": "Provide the consumer group ID used by the connector. Leave empty for an automatically generated one",
       "group": "kafka",
       "type": "String",
-      "feel": "optional",
       "optional": true,
       "binding": {
         "type": "zeebe:property",

--- a/connectors/kafka/element-templates/kafka-inbound-connector-boundary.json
+++ b/connectors/kafka/element-templates/kafka-inbound-connector-boundary.json
@@ -2,7 +2,7 @@
   "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
   "name": "Kafka Boundary Event Connector",
   "id": "io.camunda.connectors.inbound.KafkaBoundary.v1",
-  "version": 2,
+  "version": 3,
   "description": "Consume Kafka messages",
   "documentationRef": "https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/kafka/?kafka=inbound",
   "category": {
@@ -126,7 +126,6 @@
       "description": "Provide the topic name",
       "group": "kafka",
       "type": "String",
-      "feel": "optional",
       "binding": {
         "type": "zeebe:property",
         "name": "topic.topicName"
@@ -140,7 +139,6 @@
       "description": "Provide the consumer group ID used by the connector. Leave empty for an automatically generated one",
       "group": "kafka",
       "type": "String",
-      "feel": "optional",
       "optional": true,
       "binding": {
         "type": "zeebe:property",

--- a/connectors/kafka/element-templates/kafka-inbound-connector-hybrid.json
+++ b/connectors/kafka/element-templates/kafka-inbound-connector-hybrid.json
@@ -2,7 +2,7 @@
   "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
   "name": "Kafka Start Event Connector",
   "id": "io.camunda.connectors.inbound.KAFKA.v1",
-  "version": 2,
+  "version": 3,
   "description": "Consume Kafka messages in hybrid mode",
   "documentationRef": "https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/kafka/?kafka=inbound",
   "category": {
@@ -123,7 +123,6 @@
       "description": "Provide the topic name",
       "group": "kafka",
       "type": "String",
-      "feel": "optional",
       "binding": {
         "type": "zeebe:property",
         "name": "topic.topicName"
@@ -137,7 +136,6 @@
       "description": "Provide the consumer group ID used by the connector. Leave empty for an automatically generated one",
       "group": "kafka",
       "type": "String",
-      "feel": "optional",
       "optional": true,
       "binding": {
         "type": "zeebe:property",

--- a/connectors/kafka/element-templates/kafka-inbound-connector-intermediate.json
+++ b/connectors/kafka/element-templates/kafka-inbound-connector-intermediate.json
@@ -2,7 +2,7 @@
   "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
   "name": "Kafka Intermediate Catch Event Connector",
   "id": "io.camunda.connectors.inbound.KafkaIntermediate.v1",
-  "version": 3,
+  "version": 4,
   "description": "Consume Kafka messages",
   "documentationRef": "https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/kafka/?kafka=inbound",
   "category": {
@@ -127,7 +127,6 @@
       "description": "Provide the topic name",
       "group": "kafka",
       "type": "String",
-      "feel": "optional",
       "binding": {
         "type": "zeebe:property",
         "name": "topic.topicName"
@@ -141,7 +140,6 @@
       "description": "Provide the consumer group ID used by the connector. Leave empty for an automatically generated one",
       "group": "kafka",
       "type": "String",
-      "feel": "optional",
       "optional": true,
       "binding": {
         "type": "zeebe:property",

--- a/connectors/kafka/element-templates/kafka-inbound-connector.json
+++ b/connectors/kafka/element-templates/kafka-inbound-connector.json
@@ -2,7 +2,7 @@
   "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
   "name": "Kafka Start Event Connector",
   "id": "io.camunda.connectors.inbound.KAFKA.v1",
-  "version": 2,
+  "version": 3,
   "description": "Consume Kafka messages",
   "documentationRef": "https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/kafka/?kafka=inbound",
   "category": {
@@ -119,7 +119,6 @@
       "description": "Provide the topic name",
       "group": "kafka",
       "type": "String",
-      "feel": "optional",
       "binding": {
         "type": "zeebe:property",
         "name": "topic.topicName"
@@ -134,7 +133,6 @@
       "description": "Provide the consumer group ID used by the connector. Leave empty for an automatically generated one",
       "group": "kafka",
       "type": "String",
-      "feel": "optional",
       "optional": true,
       "binding": {
         "type": "zeebe:property",

--- a/connectors/kafka/src/main/java/io/camunda/connector/kafka/inbound/KafkaConnectorProperties.java
+++ b/connectors/kafka/src/main/java/io/camunda/connector/kafka/inbound/KafkaConnectorProperties.java
@@ -33,7 +33,7 @@ public final class KafkaConnectorProperties {
 
   @NotNull private AutoOffsetReset autoOffsetReset = AutoOffsetReset.NONE;
 
-  @FEEL private String groupId;
+  private String groupId;
 
   @Valid private Avro avro;
 

--- a/connectors/kafka/src/main/java/io/camunda/connector/kafka/model/KafkaTopic.java
+++ b/connectors/kafka/src/main/java/io/camunda/connector/kafka/model/KafkaTopic.java
@@ -18,7 +18,6 @@ public record KafkaTopic(
             label = "Bootstrap servers",
             description = "Provide bootstrap server(s), comma-delimited if there are multiple")
         String bootstrapServers,
-    @FEEL
-        @NotEmpty
+    @NotEmpty
         @TemplateProperty(label = "Topic", group = "kafka", description = "Provide topic name")
         String topicName) {}


### PR DESCRIPTION
## Description

As discussed with the team, the topic and consumer group ID will not support FEEL expressions. Templates have been updated; template versions have been incremented.

next step : 
- https://github.com/camunda/web-modeler/pull/8355