### PR TITLE
fix: incorrect context binding in wh element template

### DIFF
--- a/connectors/webhook/element-templates/webhook-connector-boundary.json
+++ b/connectors/webhook/element-templates/webhook-connector-boundary.json
@@ -83,7 +83,7 @@
     "feel" : "optional",
     "group" : "endpoint",
     "binding" : {
-      "name" : "inbound.inbound.context",
+      "name" : "inbound.context",
       "type" : "zeebe:property"
     },
     "type" : "String"

--- a/connectors/webhook/element-templates/webhook-connector-intermediate.json
+++ b/connectors/webhook/element-templates/webhook-connector-intermediate.json
@@ -83,7 +83,7 @@
     "feel" : "optional",
     "group" : "endpoint",
     "binding" : {
-      "name" : "inbound.inbound.context",
+      "name" : "inbound.context",
       "type" : "zeebe:property"
     },
     "type" : "String"

--- a/connectors/webhook/element-templates/webhook-connector-start-event.json
+++ b/connectors/webhook/element-templates/webhook-connector-start-event.json
@@ -82,7 +82,7 @@
     "feel" : "optional",
     "group" : "endpoint",
     "binding" : {
-      "name" : "inbound.inbound.context",
+      "name" : "inbound.context",
       "type" : "zeebe:property"
     },
     "type" : "String"

--- a/connectors/webhook/element-templates/webhook-connector-start-message.json
+++ b/connectors/webhook/element-templates/webhook-connector-start-message.json
@@ -83,7 +83,7 @@
     "feel" : "optional",
     "group" : "endpoint",
     "binding" : {
-      "name" : "inbound.inbound.context",
+      "name" : "inbound.context",
       "type" : "zeebe:property"
     },
     "type" : "String"

--- a/connectors/webhook/src/main/java/io/camunda/connector/inbound/model/WebhookConnectorProperties.java
+++ b/connectors/webhook/src/main/java/io/camunda/connector/inbound/model/WebhookConnectorProperties.java
@@ -43,7 +43,7 @@ public record WebhookConnectorProperties(
             label = "Webhook ID",
             group = "endpoint",
             description = "The webhook ID is a part of the URL",
-            binding = @PropertyBinding(name = "inbound.context"))
+            binding = @PropertyBinding(name = "context"))
         @NotBlank
         @Pattern(
             regexp = "^[a-zA-Z0-9]+([-_][a-zA-Z0-9]+)*$",


### PR DESCRIPTION
## Description

Fixes an error with the incorrect binding name (was `inbound.inbound.context` due to nested path resolution).