### PR TITLE
fix(openai): Add a NotEmpty constraint when using OpenAI Custom model

### DIFF
--- a/connectors/openai/element-templates/openai-connector.json
+++ b/connectors/openai/element-templates/openai-connector.json
@@ -210,6 +210,9 @@
       "condition": {
         "property": "model",
         "equals": "custom"
+      },
+      "constraints": {
+        "notEmpty": true
       }
     },
     {


### PR DESCRIPTION
## Description

Fixes a bug where using an OpenAI Custom model would allow empty model values.

**Solution**
Added a new **notEmpty** constraint when this textfield is displayed.

## Related issues

Initial ticket is #1959 
Initial PR [here](https://github.com/camunda/connectors/pull/2053)

