### PR TITLE
fix(kafka): fix deserialization of escaped characters

### DIFF
--- a/connectors/kafka/src/main/java/io/camunda/connector/kafka/inbound/KafkaConnectorConsumer.java
+++ b/connectors/kafka/src/main/java/io/camunda/connector/kafka/inbound/KafkaConnectorConsumer.java
@@ -10,6 +10,7 @@ import static io.camunda.connector.kafka.inbound.KafkaPropertyTransformer.conver
 import static io.camunda.connector.kafka.inbound.KafkaPropertyTransformer.getKafkaProperties;
 
 import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.json.JsonReadFeature;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
@@ -67,7 +68,8 @@ public class KafkaConnectorConsumer {
           // deserialize unknown types as empty objects
           .disable(SerializationFeature.FAIL_ON_EMPTY_BEANS)
           .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
-          .enable(JsonParser.Feature.ALLOW_SINGLE_QUOTES);
+          .enable(JsonParser.Feature.ALLOW_SINGLE_QUOTES)
+          .enable(JsonReadFeature.ALLOW_UNESCAPED_CONTROL_CHARS.mappedFeature());
 
   private ObjectReader avroObjectReader;
 

--- a/connectors/kafka/src/test/java/io/camunda/connector/kafka/inbound/KafkaExecutableTest.java
+++ b/connectors/kafka/src/test/java/io/camunda/connector/kafka/inbound/KafkaExecutableTest.java
@@ -191,10 +191,10 @@ public class KafkaExecutableTest {
   public void testConvertSpecialCharactersRecordToKafkaInboundMessage() {
     // When
     ConsumerRecord<Object, Object> consumerRecord =
-            new ConsumerRecord<>("my-topic", 0, 0, "my-key", "{\"foo\": \"\nb\ta\\r\"}");
+        new ConsumerRecord<>("my-topic", 0, 0, "my-key", "{\"foo\": \"\nb\ta\\r\"}");
     KafkaInboundMessage kafkaInboundMessage =
-            KafkaPropertyTransformer.convertConsumerRecordToKafkaInboundMessage(
-                    consumerRecord, KafkaConnectorConsumer.objectMapper.reader());
+        KafkaPropertyTransformer.convertConsumerRecordToKafkaInboundMessage(
+            consumerRecord, KafkaConnectorConsumer.objectMapper.reader());
 
     // Then
     assertEquals("my-key", kafkaInboundMessage.getKey());

--- a/connectors/kafka/src/test/java/io/camunda/connector/kafka/inbound/KafkaExecutableTest.java
+++ b/connectors/kafka/src/test/java/io/camunda/connector/kafka/inbound/KafkaExecutableTest.java
@@ -187,6 +187,23 @@ public class KafkaExecutableTest {
     assertEquals("headerValue", kafkaInboundMessage.getHeaders().get("header"));
   }
 
+  @Test
+  public void testConvertSpecialCharactersRecordToKafkaInboundMessage() {
+    // When
+    ConsumerRecord<Object, Object> consumerRecord =
+            new ConsumerRecord<>("my-topic", 0, 0, "my-key", "{\"foo\": \"\nb\ta\\r\"}");
+    KafkaInboundMessage kafkaInboundMessage =
+            KafkaPropertyTransformer.convertConsumerRecordToKafkaInboundMessage(
+                    consumerRecord, KafkaConnectorConsumer.objectMapper.reader());
+
+    // Then
+    assertEquals("my-key", kafkaInboundMessage.getKey());
+    assertEquals("{\"foo\": \"\nb\ta\\r\"}", kafkaInboundMessage.getRawValue());
+    ObjectNode expectedValue = JsonNodeFactory.instance.objectNode();
+    expectedValue.set("foo", JsonNodeFactory.instance.textNode("\nb\ta\r"));
+    assertEquals(expectedValue, kafkaInboundMessage.getValue());
+  }
+
   public KafkaExecutable getConsumerMock() {
     return new KafkaExecutable(properties -> mockConsumer);
   }


### PR DESCRIPTION
## Description

Allow parsing properly unescaped control characters, to prevent parsing failures.

## Related issues

closes https://github.com/camunda/connectors/issues/1236

