### PR TITLE
fix(easypost): support v4 and earlier of EasyPost element template

### DIFF
--- a/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/auth/BasicAuthentication.java
+++ b/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/auth/BasicAuthentication.java
@@ -39,7 +39,11 @@ public final class BasicAuthentication implements Authentication {
 
   @Override
   public void setHeaders(final HttpHeaders headers) {
-    String passwordForHeader = password == null ? "" : password;
+    String passwordForHeader = password;
+    // checking against "SPEC_PASSWORD_EMPTY_PATTERN" to prevent breaking change
+    if (password == null || password.equals("SPEC_PASSWORD_EMPTY_PATTERN")) {
+      passwordForHeader = "";
+    }
     headers.setBasicAuthentication(username, passwordForHeader);
   }
 


### PR DESCRIPTION
## Description

This change will support v4 and earlier of the EasyPost element template.

Without this PR's changes, using v4 will result in this error when trying to call EasyPost:
```
{"error":{"code":"APIKEY.INACTIVE","message":"This api key is no longer active. Please use a different api key or reactivate this key.","errors":[]}}
```

This is correcting a bug introduced in https://github.com/camunda/connectors/pull/2061

## Related issues

#1970 (issue will close once this PR and https://github.com/camunda/web-modeler/pull/8422 are closed)

