### PR TITLE
chore(workflow): update release run name

### DIFF
--- a/.github/workflows/RELEASE.yaml
+++ b/.github/workflows/RELEASE.yaml
@@ -1,5 +1,5 @@
 name: Release a new version
-run-name: Release a new version ${{ inputs.version }}
+run-name: Release a new version ${{ github.event.release.tag_name }}
 
 on:
   release:


### PR DESCRIPTION
## Description

correct release run name;

#### Not urgent changes, can be merged after release

should looks like before : 
![Screenshot 2024-03-05 at 16 57 31](https://github.com/camunda/connectors/assets/108869886/24c945a4-0b86-45f5-a7a6-4eb324088c98)

