### PR TITLE
fix(webhook): missing default and constraint for the api key locator field

### DIFF
--- a/connectors/webhook/element-templates/webhook-connector-boundary.json
+++ b/connectors/webhook/element-templates/webhook-connector-boundary.json
@@ -264,6 +264,10 @@
     "label" : "API key locator",
     "description" : "A FEEL expression that extracts API key from the request. <a href='https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/http-webhook/#how-to-configure-api-key-authorization'>See documentation</a>",
     "optional" : false,
+    "value" : "=split(request.headers.authorization, \" \")[2]",
+    "constraints" : {
+      "notEmpty" : true
+    },
     "feel" : "required",
     "group" : "authorization",
     "binding" : {

--- a/connectors/webhook/element-templates/webhook-connector-intermediate.json
+++ b/connectors/webhook/element-templates/webhook-connector-intermediate.json
@@ -264,6 +264,10 @@
     "label" : "API key locator",
     "description" : "A FEEL expression that extracts API key from the request. <a href='https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/http-webhook/#how-to-configure-api-key-authorization'>See documentation</a>",
     "optional" : false,
+    "value" : "=split(request.headers.authorization, \" \")[2]",
+    "constraints" : {
+      "notEmpty" : true
+    },
     "feel" : "required",
     "group" : "authorization",
     "binding" : {

--- a/connectors/webhook/element-templates/webhook-connector-start-event.json
+++ b/connectors/webhook/element-templates/webhook-connector-start-event.json
@@ -263,6 +263,10 @@
     "label" : "API key locator",
     "description" : "A FEEL expression that extracts API key from the request. <a href='https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/http-webhook/#how-to-configure-api-key-authorization'>See documentation</a>",
     "optional" : false,
+    "value" : "=split(request.headers.authorization, \" \")[2]",
+    "constraints" : {
+      "notEmpty" : true
+    },
     "feel" : "required",
     "group" : "authorization",
     "binding" : {

--- a/connectors/webhook/element-templates/webhook-connector-start-message.json
+++ b/connectors/webhook/element-templates/webhook-connector-start-message.json
@@ -264,6 +264,10 @@
     "label" : "API key locator",
     "description" : "A FEEL expression that extracts API key from the request. <a href='https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/http-webhook/#how-to-configure-api-key-authorization'>See documentation</a>",
     "optional" : false,
+    "value" : "=split(request.headers.authorization, \" \")[2]",
+    "constraints" : {
+      "notEmpty" : true
+    },
     "feel" : "required",
     "group" : "authorization",
     "binding" : {

--- a/connectors/webhook/src/main/java/io/camunda/connector/inbound/model/WebhookAuthorization.java
+++ b/connectors/webhook/src/main/java/io/camunda/connector/inbound/model/WebhookAuthorization.java
@@ -17,6 +17,7 @@ import io.camunda.connector.inbound.model.WebhookAuthorization.ApiKeyAuth;
 import io.camunda.connector.inbound.model.WebhookAuthorization.BasicAuth;
 import io.camunda.connector.inbound.model.WebhookAuthorization.JwtAuth;
 import io.camunda.connector.inbound.model.WebhookAuthorization.None;
+import jakarta.validation.constraints.NotEmpty;
 import java.util.function.Function;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
@@ -66,7 +67,9 @@ public sealed interface WebhookAuthorization {
               description =
                   "A FEEL expression that extracts API key from the request. <a href='https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/http-webhook/#how-to-configure-api-key-authorization'>See documentation</a>",
               group = "authorization",
-              feel = FeelMode.required)
+              feel = FeelMode.required,
+              defaultValue = "=split(request.headers.authorization, \" \")[2]")
+          @NotEmpty
           Function<Object, String> apiKeyLocator)
       implements WebhookAuthorization {}
 


### PR DESCRIPTION
## Description

Default value and constraint were missing after migrating to the auto-generated template.

## Related issues

Found during QA: https://github.com/camunda/team-connectors/issues/655

