### PR TITLE
chore(kafka): fix broken kafka test after backport

### DIFF
--- a/connectors/kafka/src/test/java/io/camunda/connector/kafka/inbound/KafkaExecutableTest.java
+++ b/connectors/kafka/src/test/java/io/camunda/connector/kafka/inbound/KafkaExecutableTest.java
@@ -200,7 +200,7 @@ public class KafkaExecutableTest {
   @Test
   public void testConvertSpecialCharactersRecordToKafkaInboundMessage() {
     // When
-    ConsumerRecord<Object, Object> consumerRecord =
+    ConsumerRecord<String, Object> consumerRecord =
         new ConsumerRecord<>("my-topic", 0, 0, "my-key", "{\"foo\": \"\nb\ta\\r\"}");
     KafkaInboundMessage kafkaInboundMessage =
         KafkaPropertyTransformer.convertConsumerRecordToKafkaInboundMessage(


### PR DESCRIPTION
## Description

After backporting https://github.com/camunda/connectors/pull/2091 a test was failing. This commit fixes that test.

