### PR TITLE
chore(workflow): update release run name; backport to 8.4

### DIFF
--- a/.github/workflows/RELEASE.yaml
+++ b/.github/workflows/RELEASE.yaml
@@ -1,5 +1,5 @@
 name: Release a new version
-run-name: Release a new version ${{ inputs.version }}
+run-name: Release a new version ${{ github.event.release.tag_name }}
 
 on:
   release:


### PR DESCRIPTION
## Description

correct release run name;


## Related issues

https://github.com/camunda/connectors/pull/2093

