### PR TITLE
fix(generator): reorder inbound correlation properties

### DIFF
--- a/connectors/webhook/element-templates/webhook-connector-boundary.json
+++ b/connectors/webhook/element-templates/webhook-connector-boundary.json
@@ -397,11 +397,6 @@
       "name" : "correlationKeyExpression",
       "type" : "zeebe:property"
     },
-    "condition" : {
-      "property" : "correlationRequired",
-      "equals" : "required",
-      "type" : "simple"
-    },
     "type" : "String"
   }, {
     "id" : "messageIdExpression",

--- a/connectors/webhook/element-templates/webhook-connector-boundary.json
+++ b/connectors/webhook/element-templates/webhook-connector-boundary.json
@@ -30,6 +30,9 @@
     "id" : "activation",
     "label" : "Activation"
   }, {
+    "id" : "correlation",
+    "label" : "Correlation"
+  }, {
     "id" : "output",
     "label" : "Output mapping"
   } ],
@@ -356,6 +359,18 @@
     },
     "type" : "Text"
   }, {
+    "id" : "activationCondition",
+    "label" : "Activation condition",
+    "description" : "Condition under which the Connector triggers. Leave empty to catch all events",
+    "optional" : true,
+    "feel" : "required",
+    "group" : "activation",
+    "binding" : {
+      "name" : "activationCondition",
+      "type" : "zeebe:property"
+    },
+    "type" : "String"
+  }, {
     "id" : "correlationKeyProcess",
     "label" : "Correlation key (process)",
     "description" : "Sets up the correlation key from process variables",
@@ -363,7 +378,7 @@
       "notEmpty" : true
     },
     "feel" : "required",
-    "group" : "activation",
+    "group" : "correlation",
     "binding" : {
       "name" : "correlationKey",
       "type" : "bpmn:Message#zeebe:subscription#property"
@@ -377,10 +392,15 @@
       "notEmpty" : true
     },
     "feel" : "required",
-    "group" : "activation",
+    "group" : "correlation",
     "binding" : {
       "name" : "correlationKeyExpression",
       "type" : "zeebe:property"
+    },
+    "condition" : {
+      "property" : "correlationRequired",
+      "equals" : "required",
+      "type" : "simple"
     },
     "type" : "String"
   }, {
@@ -389,21 +409,9 @@
     "description" : "Expression to extract unique identifier of a message",
     "optional" : true,
     "feel" : "required",
-    "group" : "activation",
+    "group" : "correlation",
     "binding" : {
       "name" : "messageIdExpression",
-      "type" : "zeebe:property"
-    },
-    "type" : "String"
-  }, {
-    "id" : "activationCondition",
-    "label" : "Activation condition",
-    "description" : "Condition under which the Connector triggers. Leave empty to catch all events",
-    "optional" : true,
-    "feel" : "required",
-    "group" : "activation",
-    "binding" : {
-      "name" : "activationCondition",
       "type" : "zeebe:property"
     },
     "type" : "String"
@@ -412,7 +420,7 @@
     "generatedValue" : {
       "type" : "uuid"
     },
-    "group" : "activation",
+    "group" : "correlation",
     "binding" : {
       "name" : "name",
       "type" : "bpmn:Message#property"

--- a/connectors/webhook/element-templates/webhook-connector-intermediate.json
+++ b/connectors/webhook/element-templates/webhook-connector-intermediate.json
@@ -397,11 +397,6 @@
       "name" : "correlationKeyExpression",
       "type" : "zeebe:property"
     },
-    "condition" : {
-      "property" : "correlationRequired",
-      "equals" : "required",
-      "type" : "simple"
-    },
     "type" : "String"
   }, {
     "id" : "messageIdExpression",

--- a/connectors/webhook/element-templates/webhook-connector-intermediate.json
+++ b/connectors/webhook/element-templates/webhook-connector-intermediate.json
@@ -30,6 +30,9 @@
     "id" : "activation",
     "label" : "Activation"
   }, {
+    "id" : "correlation",
+    "label" : "Correlation"
+  }, {
     "id" : "output",
     "label" : "Output mapping"
   } ],
@@ -356,6 +359,18 @@
     },
     "type" : "Text"
   }, {
+    "id" : "activationCondition",
+    "label" : "Activation condition",
+    "description" : "Condition under which the Connector triggers. Leave empty to catch all events",
+    "optional" : true,
+    "feel" : "required",
+    "group" : "activation",
+    "binding" : {
+      "name" : "activationCondition",
+      "type" : "zeebe:property"
+    },
+    "type" : "String"
+  }, {
     "id" : "correlationKeyProcess",
     "label" : "Correlation key (process)",
     "description" : "Sets up the correlation key from process variables",
@@ -363,7 +378,7 @@
       "notEmpty" : true
     },
     "feel" : "required",
-    "group" : "activation",
+    "group" : "correlation",
     "binding" : {
       "name" : "correlationKey",
       "type" : "bpmn:Message#zeebe:subscription#property"
@@ -377,10 +392,15 @@
       "notEmpty" : true
     },
     "feel" : "required",
-    "group" : "activation",
+    "group" : "correlation",
     "binding" : {
       "name" : "correlationKeyExpression",
       "type" : "zeebe:property"
+    },
+    "condition" : {
+      "property" : "correlationRequired",
+      "equals" : "required",
+      "type" : "simple"
     },
     "type" : "String"
   }, {
@@ -389,21 +409,9 @@
     "description" : "Expression to extract unique identifier of a message",
     "optional" : true,
     "feel" : "required",
-    "group" : "activation",
+    "group" : "correlation",
     "binding" : {
       "name" : "messageIdExpression",
-      "type" : "zeebe:property"
-    },
-    "type" : "String"
-  }, {
-    "id" : "activationCondition",
-    "label" : "Activation condition",
-    "description" : "Condition under which the Connector triggers. Leave empty to catch all events",
-    "optional" : true,
-    "feel" : "required",
-    "group" : "activation",
-    "binding" : {
-      "name" : "activationCondition",
       "type" : "zeebe:property"
     },
     "type" : "String"
@@ -412,7 +420,7 @@
     "generatedValue" : {
       "type" : "uuid"
     },
-    "group" : "activation",
+    "group" : "correlation",
     "binding" : {
       "name" : "name",
       "type" : "bpmn:Message#property"

--- a/connectors/webhook/element-templates/webhook-connector-start-message.json
+++ b/connectors/webhook/element-templates/webhook-connector-start-message.json
@@ -408,6 +408,25 @@
     },
     "type" : "String"
   }, {
+    "id" : "correlationKeyPayload",
+    "label" : "Correlation key (payload)",
+    "description" : "Extracts the correlation key from the incoming message payload",
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "required",
+    "group" : "correlation",
+    "binding" : {
+      "name" : "correlationKeyExpression",
+      "type" : "zeebe:property"
+    },
+    "condition" : {
+      "property" : "correlationRequired",
+      "equals" : "required",
+      "type" : "simple"
+    },
+    "type" : "String"
+  }, {
     "id" : "messageIdExpression",
     "label" : "Message ID expression",
     "description" : "Expression to extract unique identifier of a message",

--- a/connectors/webhook/element-templates/webhook-connector-start-message.json
+++ b/connectors/webhook/element-templates/webhook-connector-start-message.json
@@ -30,6 +30,9 @@
     "id" : "activation",
     "label" : "Activation"
   }, {
+    "id" : "correlation",
+    "label" : "Correlation"
+  }, {
     "id" : "output",
     "label" : "Output mapping"
   } ],
@@ -356,46 +359,6 @@
     },
     "type" : "Text"
   }, {
-    "id" : "correlationKeyProcess",
-    "label" : "Correlation key (process)",
-    "description" : "Sets up the correlation key from process variables",
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "feel" : "required",
-    "group" : "activation",
-    "binding" : {
-      "name" : "correlationKey",
-      "type" : "bpmn:Message#zeebe:subscription#property"
-    },
-    "type" : "String"
-  }, {
-    "id" : "correlationKeyPayload",
-    "label" : "Correlation key (payload)",
-    "description" : "Extracts the correlation key from the incoming message payload",
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "feel" : "required",
-    "group" : "activation",
-    "binding" : {
-      "name" : "correlationKeyExpression",
-      "type" : "zeebe:property"
-    },
-    "type" : "String"
-  }, {
-    "id" : "messageIdExpression",
-    "label" : "Message ID expression",
-    "description" : "Expression to extract unique identifier of a message",
-    "optional" : true,
-    "feel" : "required",
-    "group" : "activation",
-    "binding" : {
-      "name" : "messageIdExpression",
-      "type" : "zeebe:property"
-    },
-    "type" : "String"
-  }, {
     "id" : "activationCondition",
     "label" : "Activation condition",
     "description" : "Condition under which the Connector triggers. Leave empty to catch all events",
@@ -408,11 +371,48 @@
     },
     "type" : "String"
   }, {
+    "id" : "correlationRequired",
+    "label" : "Subprocess correlation required",
+    "description" : "Indicates whether correlation is required. This is needed for event-based subprocess message start events",
+    "value" : "notRequired",
+    "group" : "correlation",
+    "binding" : {
+      "name" : "correlationRequired",
+      "type" : "zeebe:property"
+    },
+    "type" : "Dropdown",
+    "choices" : [ {
+      "name" : "Correlation not required",
+      "value" : "notRequired"
+    }, {
+      "name" : "Correlation required",
+      "value" : "required"
+    } ]
+  }, {
+    "id" : "correlationKeyPayload",
+    "label" : "Correlation key (payload)",
+    "description" : "Extracts the correlation key from the incoming message payload",
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "required",
+    "group" : "correlation",
+    "binding" : {
+      "name" : "correlationKeyExpression",
+      "type" : "zeebe:property"
+    },
+    "condition" : {
+      "property" : "correlationRequired",
+      "equals" : "required",
+      "type" : "simple"
+    },
+    "type" : "String"
+  }, {
     "id" : "messageNameUuid",
     "generatedValue" : {
       "type" : "uuid"
     },
-    "group" : "activation",
+    "group" : "correlation",
     "binding" : {
       "name" : "name",
       "type" : "bpmn:Message#property"

--- a/connectors/webhook/element-templates/webhook-connector-start-message.json
+++ b/connectors/webhook/element-templates/webhook-connector-start-message.json
@@ -408,6 +408,18 @@
     },
     "type" : "String"
   }, {
+    "id" : "messageIdExpression",
+    "label" : "Message ID expression",
+    "description" : "Expression to extract unique identifier of a message",
+    "optional" : true,
+    "feel" : "required",
+    "group" : "correlation",
+    "binding" : {
+      "name" : "messageIdExpression",
+      "type" : "zeebe:property"
+    },
+    "type" : "String"
+  }, {
     "id" : "messageNameUuid",
     "generatedValue" : {
       "type" : "uuid"

--- a/connectors/webhook/element-templates/webhook-connector-start-message.json
+++ b/connectors/webhook/element-templates/webhook-connector-start-message.json
@@ -389,17 +389,17 @@
       "value" : "required"
     } ]
   }, {
-    "id" : "correlationKeyPayload",
-    "label" : "Correlation key (payload)",
-    "description" : "Extracts the correlation key from the incoming message payload",
+    "id" : "correlationKeyProcess",
+    "label" : "Correlation key (process)",
+    "description" : "Sets up the correlation key from process variables",
     "constraints" : {
       "notEmpty" : true
     },
     "feel" : "required",
     "group" : "correlation",
     "binding" : {
-      "name" : "correlationKeyExpression",
-      "type" : "zeebe:property"
+      "name" : "correlationKey",
+      "type" : "bpmn:Message#zeebe:subscription#property"
     },
     "condition" : {
       "property" : "correlationRequired",

--- a/element-template-generator/core/src/main/java/io/camunda/connector/generator/dsl/CommonProperties.java
+++ b/element-template-generator/core/src/main/java/io/camunda/connector/generator/dsl/CommonProperties.java
@@ -16,9 +16,11 @@
  */
 package io.camunda.connector.generator.dsl;
 
+import io.camunda.connector.generator.dsl.DropdownProperty.DropdownChoice;
 import io.camunda.connector.generator.dsl.Property.FeelMode;
 import io.camunda.connector.generator.dsl.PropertyBinding.ZeebeProperty;
 import io.camunda.connector.generator.dsl.PropertyBinding.ZeebeSubscriptionProperty;
+import java.util.List;
 
 public class CommonProperties {
 
@@ -79,7 +81,7 @@ public class CommonProperties {
           .id("correlationKeyProcess")
           .label("Correlation key (process)")
           .description("Sets up the correlation key from process variables")
-          .group("activation")
+          .group("correlation")
           .feel(FeelMode.required)
           .binding(ZeebeSubscriptionProperty.CORRELATION_KEY)
           .constraints(PropertyConstraints.builder().notEmpty(true).build());
@@ -89,7 +91,7 @@ public class CommonProperties {
           .id("correlationKeyPayload")
           .label("Correlation key (payload)")
           .description("Extracts the correlation key from the incoming message payload")
-          .group("activation")
+          .group("correlation")
           .feel(FeelMode.required)
           .binding(new PropertyBinding.ZeebeProperty("correlationKeyExpression"))
           .constraints(PropertyConstraints.builder().notEmpty(true).build());
@@ -99,15 +101,29 @@ public class CommonProperties {
           .id("messageIdExpression")
           .label("Message ID expression")
           .description("Expression to extract unique identifier of a message")
-          .group("activation")
+          .group("correlation")
           .feel(FeelMode.required)
           .optional(true)
           .binding(new PropertyBinding.ZeebeProperty("messageIdExpression"));
 
-  public static final PropertyBuilder MESSAGE_NAME_UUID =
+  public static final PropertyBuilder MESSAGE_NAME_UUID_HIDDEN =
       HiddenProperty.builder()
           .id("messageNameUuid")
-          .group("activation")
+          .group("correlation")
           .generatedValue()
           .binding(PropertyBinding.MessageProperty.NAME);
+
+  public static final PropertyBuilder CORRELATION_REQUIRED_DROPDOWN =
+      DropdownProperty.builder()
+          .choices(
+              List.of(
+                  new DropdownChoice("Correlation not required", "notRequired"),
+                  new DropdownChoice("Correlation required", "required")))
+          .id("correlationRequired")
+          .label("Subprocess correlation required")
+          .description(
+              "Indicates whether correlation is required. This is needed for event-based subprocess message start events")
+          .group("correlation")
+          .value("notRequired")
+          .binding(new ZeebeProperty("correlationRequired"));
 }

--- a/element-template-generator/core/src/main/java/io/camunda/connector/generator/dsl/CommonProperties.java
+++ b/element-template-generator/core/src/main/java/io/camunda/connector/generator/dsl/CommonProperties.java
@@ -24,106 +24,117 @@ import java.util.List;
 
 public class CommonProperties {
 
-  public static final PropertyBuilder RESULT_EXPRESSION =
-      TextProperty.builder()
-          .id("resultExpression")
-          .group("output")
-          .label("Result expression")
-          .description("Expression to map the response into process variables")
-          .feel(FeelMode.required);
+  public static PropertyBuilder resultExpression() {
+    return TextProperty.builder()
+        .id("resultExpression")
+        .group("output")
+        .label("Result expression")
+        .description("Expression to map the response into process variables")
+        .feel(FeelMode.required);
+  }
 
-  public static final PropertyBuilder RESULT_VARIABLE =
-      StringProperty.builder()
-          .id("resultVariable")
-          .group("output")
-          .label("Result variable")
-          .description("Name of variable to store the response in")
-          .feel(FeelMode.disabled);
+  public static PropertyBuilder resultVariable() {
+    return StringProperty.builder()
+        .id("resultVariable")
+        .group("output")
+        .label("Result variable")
+        .description("Name of variable to store the response in")
+        .feel(FeelMode.disabled);
+  }
 
-  public static final PropertyBuilder ERROR_EXPRESSION =
-      TextProperty.builder()
-          .id("errorExpression")
-          .label("Error expression")
-          .group("error")
-          .description(
-              "Expression to handle errors. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/\" target=\"_blank\">documentation</a>.")
-          .feel(FeelMode.required);
+  public static PropertyBuilder errorExpression() {
+    return TextProperty.builder()
+        .id("errorExpression")
+        .label("Error expression")
+        .group("error")
+        .description(
+            "Expression to handle errors. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/\" target=\"_blank\">documentation</a>.")
+        .feel(FeelMode.required);
+  }
 
-  public static final PropertyBuilder RETRY_COUNT =
-      StringProperty.builder()
-          .id("retryCount")
-          .label("Retries")
-          .description("Number of retries")
-          .group("retries")
-          .value("3");
+  public static PropertyBuilder retryCount() {
+    return StringProperty.builder()
+        .id("retryCount")
+        .label("Retries")
+        .description("Number of retries")
+        .group("retries")
+        .value("3");
+  }
 
-  public static final PropertyBuilder RETRY_BACKOFF =
-      StringProperty.builder()
-          .id("retryBackoff")
-          .label("Retry backoff")
-          .description("ISO-8601 duration to wait between retries")
-          .group("retries")
-          .value("PT0S");
+  public static PropertyBuilder retryBackoff() {
+    return StringProperty.builder()
+        .id("retryBackoff")
+        .label("Retry backoff")
+        .description("ISO-8601 duration to wait between retries")
+        .group("retries")
+        .value("PT0S");
+  }
 
-  public static final PropertyBuilder ACTIVATION_CONDITION =
-      StringProperty.builder()
-          .id("activationCondition")
-          .label("Activation condition")
-          .description(
-              "Condition under which the Connector triggers. Leave empty to catch all events")
-          .group("activation")
-          .feel(FeelMode.required)
-          .optional(true)
-          .binding(new ZeebeProperty("activationCondition"));
+  public static PropertyBuilder activationCondition() {
+    return StringProperty.builder()
+        .id("activationCondition")
+        .label("Activation condition")
+        .description(
+            "Condition under which the Connector triggers. Leave empty to catch all events")
+        .group("activation")
+        .feel(FeelMode.required)
+        .optional(true)
+        .binding(new ZeebeProperty("activationCondition"));
+  }
 
-  public static final PropertyBuilder CORRELATION_KEY_PROCESS =
-      StringProperty.builder()
-          .id("correlationKeyProcess")
-          .label("Correlation key (process)")
-          .description("Sets up the correlation key from process variables")
-          .group("correlation")
-          .feel(FeelMode.required)
-          .binding(ZeebeSubscriptionProperty.CORRELATION_KEY)
-          .constraints(PropertyConstraints.builder().notEmpty(true).build());
+  public static PropertyBuilder correlationKeyProcess() {
+    return StringProperty.builder()
+        .id("correlationKeyProcess")
+        .label("Correlation key (process)")
+        .description("Sets up the correlation key from process variables")
+        .group("correlation")
+        .feel(FeelMode.required)
+        .binding(ZeebeSubscriptionProperty.CORRELATION_KEY)
+        .constraints(PropertyConstraints.builder().notEmpty(true).build());
+  }
 
-  public static final PropertyBuilder CORRELATION_KEY_PAYLOAD =
-      StringProperty.builder()
-          .id("correlationKeyPayload")
-          .label("Correlation key (payload)")
-          .description("Extracts the correlation key from the incoming message payload")
-          .group("correlation")
-          .feel(FeelMode.required)
-          .binding(new PropertyBinding.ZeebeProperty("correlationKeyExpression"))
-          .constraints(PropertyConstraints.builder().notEmpty(true).build());
+  public static PropertyBuilder correlationKeyPayload() {
+    return StringProperty.builder()
+        .id("correlationKeyPayload")
+        .label("Correlation key (payload)")
+        .description("Extracts the correlation key from the incoming message payload")
+        .group("correlation")
+        .feel(FeelMode.required)
+        .binding(new PropertyBinding.ZeebeProperty("correlationKeyExpression"))
+        .constraints(PropertyConstraints.builder().notEmpty(true).build());
+  }
 
-  public static final PropertyBuilder MESSAGE_ID_EXPRESSION =
-      StringProperty.builder()
-          .id("messageIdExpression")
-          .label("Message ID expression")
-          .description("Expression to extract unique identifier of a message")
-          .group("correlation")
-          .feel(FeelMode.required)
-          .optional(true)
-          .binding(new PropertyBinding.ZeebeProperty("messageIdExpression"));
+  public static PropertyBuilder messageIdExpression() {
+    return StringProperty.builder()
+        .id("messageIdExpression")
+        .label("Message ID expression")
+        .description("Expression to extract unique identifier of a message")
+        .group("correlation")
+        .feel(FeelMode.required)
+        .optional(true)
+        .binding(new PropertyBinding.ZeebeProperty("messageIdExpression"));
+  }
 
-  public static final PropertyBuilder MESSAGE_NAME_UUID_HIDDEN =
-      HiddenProperty.builder()
-          .id("messageNameUuid")
-          .group("correlation")
-          .generatedValue()
-          .binding(PropertyBinding.MessageProperty.NAME);
+  public static PropertyBuilder messageNameUuidHidden() {
+    return HiddenProperty.builder()
+        .id("messageNameUuid")
+        .group("correlation")
+        .generatedValue()
+        .binding(PropertyBinding.MessageProperty.NAME);
+  }
 
-  public static final PropertyBuilder CORRELATION_REQUIRED_DROPDOWN =
-      DropdownProperty.builder()
-          .choices(
-              List.of(
-                  new DropdownChoice("Correlation not required", "notRequired"),
-                  new DropdownChoice("Correlation required", "required")))
-          .id("correlationRequired")
-          .label("Subprocess correlation required")
-          .description(
-              "Indicates whether correlation is required. This is needed for event-based subprocess message start events")
-          .group("correlation")
-          .value("notRequired")
-          .binding(new ZeebeProperty("correlationRequired"));
+  public static PropertyBuilder correlationRequiredDropdown() {
+    return DropdownProperty.builder()
+        .choices(
+            List.of(
+                new DropdownChoice("Correlation not required", "notRequired"),
+                new DropdownChoice("Correlation required", "required")))
+        .id("correlationRequired")
+        .label("Subprocess correlation required")
+        .description(
+            "Indicates whether correlation is required. This is needed for event-based subprocess message start events")
+        .group("correlation")
+        .value("notRequired")
+        .binding(new ZeebeProperty("correlationRequired"));
+  }
 }

--- a/element-template-generator/core/src/main/java/io/camunda/connector/generator/dsl/PropertyGroup.java
+++ b/element-template-generator/core/src/main/java/io/camunda/connector/generator/dsl/PropertyGroup.java
@@ -93,6 +93,7 @@ public record PropertyGroup(String id, String label, @JsonIgnore List<Property> 
                   .condition(
                       new Equals(CommonProperties.correlationRequiredDropdown().id, "required"))
                   .build(),
+              CommonProperties.messageIdExpression().build(),
               CommonProperties.messageNameUuidHidden().build())
           .build();
 

--- a/element-template-generator/core/src/main/java/io/camunda/connector/generator/dsl/PropertyGroup.java
+++ b/element-template-generator/core/src/main/java/io/camunda/connector/generator/dsl/PropertyGroup.java
@@ -89,7 +89,7 @@ public record PropertyGroup(String id, String label, @JsonIgnore List<Property> 
           .label("Correlation")
           .properties(
               CommonProperties.correlationRequiredDropdown().build(),
-              CommonProperties.correlationKeyPayload()
+              CommonProperties.correlationKeyProcess()
                   .condition(
                       new Equals(CommonProperties.correlationRequiredDropdown().id, "required"))
                   .build(),

--- a/element-template-generator/core/src/main/java/io/camunda/connector/generator/dsl/PropertyGroup.java
+++ b/element-template-generator/core/src/main/java/io/camunda/connector/generator/dsl/PropertyGroup.java
@@ -33,10 +33,10 @@ public record PropertyGroup(String id, String label, @JsonIgnore List<Property> 
           .id("output")
           .label("Output mapping")
           .properties(
-              CommonProperties.RESULT_VARIABLE
+              CommonProperties.resultVariable()
                   .binding(new ZeebeTaskHeader("resultVariable"))
                   .build(),
-              CommonProperties.RESULT_EXPRESSION
+              CommonProperties.resultExpression()
                   .binding(new ZeebeTaskHeader("resultExpression"))
                   .build())
           .build();
@@ -46,8 +46,10 @@ public record PropertyGroup(String id, String label, @JsonIgnore List<Property> 
           .id("output")
           .label("Output mapping")
           .properties(
-              CommonProperties.RESULT_VARIABLE.binding(new ZeebeProperty("resultVariable")).build(),
-              CommonProperties.RESULT_EXPRESSION
+              CommonProperties.resultVariable()
+                  .binding(new ZeebeProperty("resultVariable"))
+                  .build(),
+              CommonProperties.resultExpression()
                   .binding(new ZeebeProperty("resultExpression"))
                   .build())
           .build();
@@ -57,7 +59,7 @@ public record PropertyGroup(String id, String label, @JsonIgnore List<Property> 
           .id("error")
           .label("Error handling")
           .properties(
-              CommonProperties.ERROR_EXPRESSION
+              CommonProperties.errorExpression()
                   .binding(new ZeebeTaskHeader("errorExpression"))
                   .build())
           .build();
@@ -67,8 +69,8 @@ public record PropertyGroup(String id, String label, @JsonIgnore List<Property> 
           .id("retries")
           .label("Retries")
           .properties(
-              CommonProperties.RETRY_COUNT.binding(ZeebeTaskDefinition.RETRIES).build(),
-              CommonProperties.RETRY_BACKOFF.binding(new ZeebeTaskHeader("retryBackoff")).build())
+              CommonProperties.retryCount().binding(ZeebeTaskDefinition.RETRIES).build(),
+              CommonProperties.retryBackoff().binding(new ZeebeTaskHeader("retryBackoff")).build())
           .build();
 
   public static PropertyGroup ACTIVATION_GROUP =
@@ -76,7 +78,7 @@ public record PropertyGroup(String id, String label, @JsonIgnore List<Property> 
           .id("activation")
           .label("Activation")
           .properties(
-              CommonProperties.ACTIVATION_CONDITION
+              CommonProperties.activationCondition()
                   .binding(new ZeebeProperty("activationCondition"))
                   .build())
           .build();
@@ -86,12 +88,12 @@ public record PropertyGroup(String id, String label, @JsonIgnore List<Property> 
           .id("correlation")
           .label("Correlation")
           .properties(
-              CommonProperties.CORRELATION_REQUIRED_DROPDOWN.build(),
-              CommonProperties.CORRELATION_KEY_PAYLOAD
+              CommonProperties.correlationRequiredDropdown().build(),
+              CommonProperties.correlationKeyPayload()
                   .condition(
-                      new Equals(CommonProperties.CORRELATION_REQUIRED_DROPDOWN.id, "required"))
+                      new Equals(CommonProperties.correlationRequiredDropdown().id, "required"))
                   .build(),
-              CommonProperties.MESSAGE_NAME_UUID_HIDDEN.build())
+              CommonProperties.messageNameUuidHidden().build())
           .build();
 
   public static PropertyGroup CORRELATION_GROUP_INTERMEDIATE_CATCH_EVENT_OR_BOUNDARY =
@@ -99,10 +101,10 @@ public record PropertyGroup(String id, String label, @JsonIgnore List<Property> 
           .id("correlation")
           .label("Correlation")
           .properties(
-              CommonProperties.CORRELATION_KEY_PROCESS.build(),
-              CommonProperties.CORRELATION_KEY_PAYLOAD.build(),
-              CommonProperties.MESSAGE_ID_EXPRESSION.build(),
-              CommonProperties.MESSAGE_NAME_UUID_HIDDEN.build())
+              CommonProperties.correlationKeyProcess().build(),
+              CommonProperties.correlationKeyPayload().build(),
+              CommonProperties.messageIdExpression().build(),
+              CommonProperties.messageNameUuidHidden().build())
           .build();
 
   public PropertyGroup {

--- a/element-template-generator/core/src/main/java/io/camunda/connector/generator/dsl/PropertyGroup.java
+++ b/element-template-generator/core/src/main/java/io/camunda/connector/generator/dsl/PropertyGroup.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.connector.generator.dsl.PropertyBinding.ZeebeProperty;
 import io.camunda.connector.generator.dsl.PropertyBinding.ZeebeTaskDefinition;
 import io.camunda.connector.generator.dsl.PropertyBinding.ZeebeTaskHeader;
+import io.camunda.connector.generator.dsl.PropertyCondition.Equals;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -70,7 +71,7 @@ public record PropertyGroup(String id, String label, @JsonIgnore List<Property> 
               CommonProperties.RETRY_BACKOFF.binding(new ZeebeTaskHeader("retryBackoff")).build())
           .build();
 
-  public static PropertyGroup ACTIVATION_GROUP_WITHOUT_MESSAGE_ID_EXPR =
+  public static PropertyGroup ACTIVATION_GROUP =
       PropertyGroup.builder()
           .id("activation")
           .label("Activation")
@@ -80,16 +81,28 @@ public record PropertyGroup(String id, String label, @JsonIgnore List<Property> 
                   .build())
           .build();
 
-  public static PropertyGroup ACTIVATION_GROUP_WITH_MESSAGE_ID_EXP =
+  public static PropertyGroup CORRELATION_GROUP_MESSAGE_START_EVENT =
       PropertyGroup.builder()
-          .id("activation")
-          .label("Activation")
+          .id("correlation")
+          .label("Correlation")
+          .properties(
+              CommonProperties.CORRELATION_REQUIRED_DROPDOWN.build(),
+              CommonProperties.CORRELATION_KEY_PAYLOAD
+                  .condition(
+                      new Equals(CommonProperties.CORRELATION_REQUIRED_DROPDOWN.id, "required"))
+                  .build(),
+              CommonProperties.MESSAGE_NAME_UUID_HIDDEN.build())
+          .build();
+
+  public static PropertyGroup CORRELATION_GROUP_INTERMEDIATE_CATCH_EVENT_OR_BOUNDARY =
+      PropertyGroup.builder()
+          .id("correlation")
+          .label("Correlation")
           .properties(
               CommonProperties.CORRELATION_KEY_PROCESS.build(),
               CommonProperties.CORRELATION_KEY_PAYLOAD.build(),
               CommonProperties.MESSAGE_ID_EXPRESSION.build(),
-              CommonProperties.ACTIVATION_CONDITION.build(),
-              CommonProperties.MESSAGE_NAME_UUID.build())
+              CommonProperties.MESSAGE_NAME_UUID_HIDDEN.build())
           .build();
 
   public PropertyGroup {

--- a/element-template-generator/core/src/main/java/io/camunda/connector/generator/dsl/PropertyGroup.java
+++ b/element-template-generator/core/src/main/java/io/camunda/connector/generator/dsl/PropertyGroup.java
@@ -93,6 +93,10 @@ public record PropertyGroup(String id, String label, @JsonIgnore List<Property> 
                   .condition(
                       new Equals(CommonProperties.correlationRequiredDropdown().id, "required"))
                   .build(),
+              CommonProperties.correlationKeyPayload()
+                  .condition(
+                      new Equals(CommonProperties.correlationRequiredDropdown().id, "required"))
+                  .build(),
               CommonProperties.messageIdExpression().build(),
               CommonProperties.messageNameUuidHidden().build())
           .build();

--- a/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/ClassBasedTemplateGenerator.java
+++ b/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/ClassBasedTemplateGenerator.java
@@ -22,6 +22,7 @@ import io.camunda.connector.generator.api.ElementTemplateGenerator;
 import io.camunda.connector.generator.api.GeneratorConfiguration;
 import io.camunda.connector.generator.api.GeneratorConfiguration.ConnectorElementType;
 import io.camunda.connector.generator.api.GeneratorConfiguration.ConnectorMode;
+import io.camunda.connector.generator.dsl.BpmnType;
 import io.camunda.connector.generator.dsl.ElementTemplateBuilder;
 import io.camunda.connector.generator.dsl.ElementTemplateIcon;
 import io.camunda.connector.generator.dsl.PropertyBuilder;
@@ -172,10 +173,12 @@ public class ClassBasedTemplateGenerator implements ElementTemplateGenerator<Cla
       newGroups.add(PropertyGroup.ERROR_GROUP);
       newGroups.add(PropertyGroup.RETRIES_GROUP);
     } else {
-      if (elementType.elementType().isMessage()) {
-        newGroups.add(PropertyGroup.ACTIVATION_GROUP_WITH_MESSAGE_ID_EXP);
-      } else {
-        newGroups.add(PropertyGroup.ACTIVATION_GROUP_WITHOUT_MESSAGE_ID_EXPR);
+      newGroups.add(PropertyGroup.ACTIVATION_GROUP);
+      if (elementType.elementType().equals(BpmnType.MESSAGE_START_EVENT)) {
+        newGroups.add(PropertyGroup.CORRELATION_GROUP_MESSAGE_START_EVENT);
+      } else if (elementType.elementType().equals(BpmnType.INTERMEDIATE_CATCH_EVENT)
+          || elementType.elementType().equals(BpmnType.BOUNDARY_EVENT)) {
+        newGroups.add(PropertyGroup.CORRELATION_GROUP_INTERMEDIATE_CATCH_EVENT_OR_BOUNDARY);
       }
       newGroups.add(PropertyGroup.OUTPUT_GROUP_INBOUND);
     }

--- a/element-template-generator/core/src/test/java/io/camunda/connector/generator/java/InboundClassBasedTemplateGeneratorTest.java
+++ b/element-template-generator/core/src/test/java/io/camunda/connector/generator/java/InboundClassBasedTemplateGeneratorTest.java
@@ -203,6 +203,7 @@ public class InboundClassBasedTemplateGeneratorTest extends BaseTest {
             .isEqualTo("zeebe:property");
         assertThat(((ZeebeProperty) correlationKeyExpressionProperty.getBinding()).name())
             .isEqualTo("correlationKeyExpression");
+        assertThat(correlationKeyExpressionProperty.getCondition()).isNull();
       }
     }
 

--- a/element-template-generator/core/src/test/java/io/camunda/connector/generator/java/InboundClassBasedTemplateGeneratorTest.java
+++ b/element-template-generator/core/src/test/java/io/camunda/connector/generator/java/InboundClassBasedTemplateGeneratorTest.java
@@ -235,6 +235,13 @@ public class InboundClassBasedTemplateGeneratorTest extends BaseTest {
       assertThat(correlationKeyExpressionProperty.getBinding().type()).isEqualTo("zeebe:property");
       assertThat(((ZeebeProperty) correlationKeyExpressionProperty.getBinding()).name())
           .isEqualTo("correlationKeyExpression");
+
+      var messageIdExpressionProperty = getPropertyById("messageIdExpression", template);
+      assertThat(messageIdExpressionProperty).isNotNull();
+      assertThat(messageIdExpressionProperty.getType()).isEqualTo("String");
+      assertThat(messageIdExpressionProperty.getBinding().type()).isEqualTo("zeebe:property");
+      assertThat(((ZeebeProperty) messageIdExpressionProperty.getBinding()).name())
+          .isEqualTo("messageIdExpression");
     }
   }
 }

--- a/element-template-generator/core/src/test/java/io/camunda/connector/generator/java/InboundClassBasedTemplateGeneratorTest.java
+++ b/element-template-generator/core/src/test/java/io/camunda/connector/generator/java/InboundClassBasedTemplateGeneratorTest.java
@@ -30,6 +30,7 @@ import io.camunda.connector.generator.dsl.Property.FeelMode;
 import io.camunda.connector.generator.dsl.PropertyBinding.MessageProperty;
 import io.camunda.connector.generator.dsl.PropertyBinding.ZeebeProperty;
 import io.camunda.connector.generator.dsl.PropertyBinding.ZeebeSubscriptionProperty;
+import io.camunda.connector.generator.dsl.PropertyCondition.Equals;
 import io.camunda.connector.generator.java.example.inbound.MyConnectorExecutable;
 import java.util.List;
 import java.util.Set;
@@ -229,13 +230,25 @@ public class InboundClassBasedTemplateGeneratorTest extends BaseTest {
               new DropdownChoice("Correlation not required", "notRequired"),
               new DropdownChoice("Correlation required", "required"));
 
-      var correlationKeyExpressionProperty = getPropertyById("correlationKeyProcess", template);
-      assertThat(correlationKeyExpressionProperty).isNotNull();
-      assertThat(correlationKeyExpressionProperty.getType()).isEqualTo("String");
-      assertThat(correlationKeyExpressionProperty.getBinding().type())
+      var correlationKeyProcessProperty = getPropertyById("correlationKeyProcess", template);
+      assertThat(correlationKeyProcessProperty).isNotNull();
+      assertThat(correlationKeyProcessProperty.getType()).isEqualTo("String");
+      assertThat(correlationKeyProcessProperty.getBinding().type())
           .isEqualTo("bpmn:Message#zeebe:subscription#property");
-      assertThat(((ZeebeSubscriptionProperty) correlationKeyExpressionProperty.getBinding()).name())
+      assertThat(((ZeebeSubscriptionProperty) correlationKeyProcessProperty.getBinding()).name())
           .isEqualTo("correlationKey");
+      assertThat(correlationKeyProcessProperty.getCondition())
+          .isEqualTo(new Equals("correlationRequired", "required"));
+
+      var correlationKeyPayloadProperty = getPropertyById("correlationKeyPayload", template);
+      assertThat(correlationKeyPayloadProperty).isNotNull();
+      assertThat(correlationKeyPayloadProperty.getType()).isEqualTo("String");
+      assertThat(correlationKeyPayloadProperty.getBinding().type()).isEqualTo("zeebe:property");
+      assertThat(((ZeebeProperty) correlationKeyPayloadProperty.getBinding()).name())
+          .isEqualTo("correlationKeyExpression");
+      assertThat(correlationKeyPayloadProperty.getCondition()).isNotNull();
+      assertThat(correlationKeyPayloadProperty.getCondition())
+          .isEqualTo(new Equals("correlationRequired", "required"));
 
       var messageIdExpressionProperty = getPropertyById("messageIdExpression", template);
       assertThat(messageIdExpressionProperty).isNotNull();

--- a/element-template-generator/core/src/test/java/io/camunda/connector/generator/java/InboundClassBasedTemplateGeneratorTest.java
+++ b/element-template-generator/core/src/test/java/io/camunda/connector/generator/java/InboundClassBasedTemplateGeneratorTest.java
@@ -229,12 +229,13 @@ public class InboundClassBasedTemplateGeneratorTest extends BaseTest {
               new DropdownChoice("Correlation not required", "notRequired"),
               new DropdownChoice("Correlation required", "required"));
 
-      var correlationKeyExpressionProperty = getPropertyById("correlationKeyPayload", template);
+      var correlationKeyExpressionProperty = getPropertyById("correlationKeyProcess", template);
       assertThat(correlationKeyExpressionProperty).isNotNull();
       assertThat(correlationKeyExpressionProperty.getType()).isEqualTo("String");
-      assertThat(correlationKeyExpressionProperty.getBinding().type()).isEqualTo("zeebe:property");
-      assertThat(((ZeebeProperty) correlationKeyExpressionProperty.getBinding()).name())
-          .isEqualTo("correlationKeyExpression");
+      assertThat(correlationKeyExpressionProperty.getBinding().type())
+          .isEqualTo("bpmn:Message#zeebe:subscription#property");
+      assertThat(((ZeebeSubscriptionProperty) correlationKeyExpressionProperty.getBinding()).name())
+          .isEqualTo("correlationKey");
 
       var messageIdExpressionProperty = getPropertyById("messageIdExpression", template);
       assertThat(messageIdExpressionProperty).isNotNull();


### PR DESCRIPTION
## Description

Fixes the issues found while testing the generated templates for boundary and message start events.

Also reorders property structure for generated inbound templates.

## Related issues

QA ticket: https://github.com/camunda/team-connectors/issues/655

