### PR TITLE
feat(generator): support custom ID for discriminator properties

### DIFF
--- a/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/annotation/TemplateDiscriminatorProperty.java
+++ b/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/annotation/TemplateDiscriminatorProperty.java
@@ -34,8 +34,22 @@ import java.lang.annotation.RetentionPolicy;
 @Retention(RetentionPolicy.RUNTIME)
 public @interface TemplateDiscriminatorProperty {
 
-  /** Custom ID of the discriminator property */
+  /**
+   * Custom binding name of the discriminator property. If not specified, the name will be derived
+   * from the sealed hierarchy root class name. Also defines the {@link TemplateProperty#id()} if a
+   * different value is not specified.
+   */
   String name();
+
+  /**
+   * Custom property ID of the discriminator property. If not specified, the {@link #name()} will be
+   * used as the ID. If both are not specified, the ID will be derived from the sealed hierarchy
+   * root class name.
+   *
+   * <p>Note that nested property prefixing applies to discriminator property ID as well. This
+   * behavior can be controlled using {@link NestedProperties#addNestedPath()}.
+   */
+  String id() default "";
 
   /**
    * Custom label of the discriminator property. If not specified, the label will be derived from

--- a/element-template-generator/core/src/test/java/io/camunda/connector/generator/java/OutboundClassBasedTemplateGeneratorTest.java
+++ b/element-template-generator/core/src/test/java/io/camunda/connector/generator/java/OutboundClassBasedTemplateGeneratorTest.java
@@ -605,6 +605,11 @@ public class OutboundClassBasedTemplateGeneratorTest extends BaseTest {
               new DropdownChoice(
                   "Nested annotated sealed type override", "nestedAnnotatedSealedType"));
 
+      assertThat(discriminatorProperty.getId())
+          .isEqualTo("annotatedSealedType.annotatedTypeOverrideCustomId");
+      assertThat(((ZeebeInput) discriminatorProperty.getBinding()).name())
+          .isEqualTo("annotatedSealedType.annotatedTypeOverride");
+
       var firstSubTypeValueProperty =
           template.properties().stream()
               .filter(p -> "First annotated override value".equals(p.getLabel()))

--- a/element-template-generator/core/src/test/java/io/camunda/connector/generator/java/example/outbound/MyConnectorInput.java
+++ b/element-template-generator/core/src/test/java/io/camunda/connector/generator/java/example/outbound/MyConnectorInput.java
@@ -98,7 +98,10 @@ public record MyConnectorInput(
     }
   }
 
-  @TemplateDiscriminatorProperty(name = "annotatedTypeOverride", label = "Annotated type override")
+  @TemplateDiscriminatorProperty(
+      name = "annotatedTypeOverride",
+      label = "Annotated type override",
+      id = "annotatedTypeOverrideCustomId")
   sealed interface AnnotatedSealedType
       permits FirstAnnotatedSubType,
           IgnoredSubType,


### PR DESCRIPTION
## Description

Support custom ID different than binding name for template discriminator properties, as discussed with @Oleksiivanov 
