### PR TITLE
fix: revert to v4 EasyPost template

### DIFF
--- a/connectors/easy-post/element-templates/easy-post-connector.json
+++ b/connectors/easy-post/element-templates/easy-post-connector.json
@@ -2,7 +2,7 @@
   "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
   "name": "Easy Post Outbound Connector",
   "id": "io.camunda.connectors.EasyPost.v1",
-  "version": 5,
+  "version": 4,
   "description": "Allows you to create addresses, parcels, and shipments, as well as purchase and verify shipments",
   "documentationRef": "https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/easy-post/",
   "category": {
@@ -111,6 +111,21 @@
       },
       "constraints": {
         "notEmpty": true
+      }
+    },
+    {
+      "id": "authentication.password",
+      "description": "This field will replace to empty string. EasyPost API use only username field for put API key",
+      "group": "authentication",
+      "type": "Hidden",
+      "optional": true,
+      "value": "SPEC_PASSWORD_EMPTY_PATTERN",
+      "constraints": {
+        "notEmpty": false
+      },
+      "binding": {
+        "type": "zeebe:input",
+        "name": "authentication.password"
       }
     },
     {


### PR DESCRIPTION
## Description

v5 was never released to customers.

v5 will not work with runtimes before 8.5.0.

We don't yet have a mechanism to inform customers which runtimes a template is supported by.

Because this template was only cleaning up technical debt and not introducing new features, we believe the best option is to not release a new version for now.

[See the discussion here](https://github.com/camunda/connectors/issues/1970#issuecomment-1997022685) for more details.

## Related issues

https://github.com/camunda/connectors/issues/1970

