### PR TITLE
fix(sqs): increase polling wait time default to reduce cpu usage

### DIFF
--- a/connectors/aws/aws-sqs/element-templates/aws-sqs-boundary-connector.json
+++ b/connectors/aws/aws-sqs/element-templates/aws-sqs-boundary-connector.json
@@ -158,7 +158,7 @@
       "type": "String",
       "optional":false,
       "feel":"optional",
-      "value": "1",
+      "value": "20",
       "binding": {
         "type": "zeebe:property",
         "name": "queue.pollingWaitTime"

--- a/connectors/aws/aws-sqs/element-templates/aws-sqs-inbound-intermediate-connector.json
+++ b/connectors/aws/aws-sqs/element-templates/aws-sqs-inbound-intermediate-connector.json
@@ -159,7 +159,7 @@
       "type": "String",
       "optional":false,
       "feel":"optional",
-      "value": "1",
+      "value": "20",
       "binding": {
         "type": "zeebe:property",
         "name": "queue.pollingWaitTime"

--- a/connectors/aws/aws-sqs/element-templates/aws-sqs-start-event-connector.json
+++ b/connectors/aws/aws-sqs/element-templates/aws-sqs-start-event-connector.json
@@ -147,7 +147,7 @@
       "type": "String",
       "optional":false,
       "feel":"optional",
-      "value": "1",
+      "value": "20",
       "binding": {
         "type": "zeebe:property",
         "name": "queue.pollingWaitTime"

--- a/connectors/aws/aws-sqs/element-templates/aws-sqs-start-message.json
+++ b/connectors/aws/aws-sqs/element-templates/aws-sqs-start-message.json
@@ -162,7 +162,7 @@
       "type": "String",
       "optional":false,
       "feel":"optional",
-      "value": "1",
+      "value": "20",
       "binding": {
         "type": "zeebe:property",
         "name": "queue.pollingWaitTime"

--- a/connectors/aws/aws-sqs/src/main/java/io/camunda/connector/inbound/model/SqsInboundQueueProperties.java
+++ b/connectors/aws/aws-sqs/src/main/java/io/camunda/connector/inbound/model/SqsInboundQueueProperties.java
@@ -17,6 +17,7 @@ public class SqsInboundQueueProperties {
   private List<String> attributeNames;
   private List<String> messageAttributeNames;
 
+  // TODO: when migrating to template generator, default to 20 (max possible value)
   @Pattern(regexp = "^([0-9]?|1[0-9]|20|secrets\\..+)$")
   private String pollingWaitTime;
 


### PR DESCRIPTION
## Description

Increases the default polling wait time for SQS inbound connector, as we observed high CPU usage with small values of this parameter.


