### PR TITLE
fix(sendgrid): fix sendgrid error expression handling

### DIFF
--- a/connectors/sendgrid/src/main/java/io/camunda/connector/sendgrid/SendGridFunction.java
+++ b/connectors/sendgrid/src/main/java/io/camunda/connector/sendgrid/SendGridFunction.java
@@ -75,7 +75,7 @@ public class SendGridFunction implements OutboundConnectorFunction {
       LOGGER.info(exceptionMessage);
       throw new IllegalArgumentException(exceptionMessage);
     }
-    return null;
+    return result;
   }
 
   private Mail createEmail(final SendGridRequest request) {

--- a/connectors/sendgrid/src/test/java/io/camunda/connector/sendgrid/SendGridFunctionTest.java
+++ b/connectors/sendgrid/src/test/java/io/camunda/connector/sendgrid/SendGridFunctionTest.java
@@ -98,7 +98,7 @@ public class SendGridFunctionTest extends BaseTest {
     // When
     Object execute = function.execute(context);
     // Then no exception and result is null
-    assertThat(execute).isNull();
+    assertThat(execute).isNotNull();
   }
 
   @ParameterizedTest(


### PR DESCRIPTION
fix(sendgrid): fix sendgrid error expression handling

## Description

if sendgrid return null response, and we use boundary error event, then it throw exception

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #
https://github.com/camunda/connectors/issues/2188
