### PR TITLE
fix(feel-wrapper): Handle primitive types in FEEL expressions

### DIFF
--- a/connector-sdk/feel-wrapper/src/test/java/io/camunda/connector/feel/FeelEngineWrapperExpressionEvaluationTest.java
+++ b/connector-sdk/feel-wrapper/src/test/java/io/camunda/connector/feel/FeelEngineWrapperExpressionEvaluationTest.java
@@ -179,19 +179,17 @@ class FeelEngineWrapperExpressionEvaluationTest {
   }
 
   @Test
-  void evaluateToJson_ShouldFail_WhenVariablesAreNotMap() {
+  void evaluateToJson_ShouldNotFail_WhenVariablesAreNotMap() throws JSONException {
     // given
     // FEEL expression -> {"processedOutput":response.callStatus}
     final var resultExpression = "{\"processedOutput\": response.callStatus }";
 
     // when & then
-    final var exception =
-        Assertions.catchThrowable(
-            () -> objectUnderTest.evaluateToJson(resultExpression, "I am not a map"));
+    final var evaluatedResultAsJson =
+        objectUnderTest.evaluateToJson(resultExpression, "I am not a map");
 
-    Assertions.assertThat(exception)
-        .isInstanceOf(FeelEngineWrapperException.class)
-        .hasMessageContaining("Unable to parse 'I am not a map' as context");
+    JSONAssert.assertEquals(
+        "{\"processedOutput\": null}", evaluatedResultAsJson, JSONCompareMode.STRICT);
   }
 
   @Test

--- a/connector-sdk/jackson-datatype-feel/src/test/java/io/camunda/connector/feel/jackson/FeelFunctionDeserializerTest.java
+++ b/connector-sdk/jackson-datatype-feel/src/test/java/io/camunda/connector/feel/jackson/FeelFunctionDeserializerTest.java
@@ -201,7 +201,7 @@ public class FeelFunctionDeserializerTest {
   }
 
   @Test
-  void feelFunctionDeserlization_contextAware_knowsJava8Time() throws IOException {
+  void feelFunctionDeserialization_contextAware_knowsJava8Time() throws IOException {
     // given
     var json = """
         { "function": "= string(date(2021, 1, 1))" }


### PR DESCRIPTION
## Description

Previously we [failed](https://github.com/camunda/connectors/blob/main/connector-sdk/feel-wrapper/src/main/java/io/camunda/connector/feel/FeelEngineWrapper.java#L102) when a variable was not convertible to a Map.

Instead of failing, we will now silently ignore variables that are not convertible. 
This will allow the connectors to return primitives, and the result is added to the [response](https://github.com/camunda/connectors/blob/5c1577352bf5c043dade881ecadae4d20e0e783c/connector-sdk/feel-wrapper/src/main/java/io/camunda/connector/feel/FeelEngineWrapperUtil.java#L23) object.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #2098 

