### PR TITLE
fix(webhook): adjust property IDs in the element templates

### DIFF
--- a/connectors/webhook/element-templates/webhook-connector-boundary.json
+++ b/connectors/webhook/element-templates/webhook-connector-boundary.json
@@ -44,7 +44,7 @@
     },
     "type" : "Hidden"
   }, {
-    "id" : "inbound.webhookMethod",
+    "id" : "inbound.method",
     "label" : "Webhook method",
     "description" : "Select HTTP method",
     "optional" : false,
@@ -72,7 +72,7 @@
       "value" : "delete"
     } ]
   }, {
-    "id" : "inbound.webhookId",
+    "id" : "inbound.context",
     "label" : "Webhook ID",
     "description" : "The webhook ID is a part of the URL",
     "optional" : false,

--- a/connectors/webhook/element-templates/webhook-connector-intermediate.json
+++ b/connectors/webhook/element-templates/webhook-connector-intermediate.json
@@ -44,7 +44,7 @@
     },
     "type" : "Hidden"
   }, {
-    "id" : "inbound.webhookMethod",
+    "id" : "inbound.method",
     "label" : "Webhook method",
     "description" : "Select HTTP method",
     "optional" : false,
@@ -72,7 +72,7 @@
       "value" : "delete"
     } ]
   }, {
-    "id" : "inbound.webhookId",
+    "id" : "inbound.context",
     "label" : "Webhook ID",
     "description" : "The webhook ID is a part of the URL",
     "optional" : false,

--- a/connectors/webhook/element-templates/webhook-connector-start-event.json
+++ b/connectors/webhook/element-templates/webhook-connector-start-event.json
@@ -40,7 +40,7 @@
     },
     "type" : "Hidden"
   }, {
-    "id" : "inbound.webhookMethod",
+    "id" : "inbound.method",
     "label" : "Webhook method",
     "description" : "Select HTTP method",
     "optional" : false,
@@ -68,7 +68,7 @@
       "value" : "delete"
     } ]
   }, {
-    "id" : "inbound.webhookId",
+    "id" : "inbound.context",
     "label" : "Webhook ID",
     "description" : "The webhook ID is a part of the URL",
     "optional" : false,

--- a/connectors/webhook/element-templates/webhook-connector-start-message.json
+++ b/connectors/webhook/element-templates/webhook-connector-start-message.json
@@ -44,7 +44,7 @@
     },
     "type" : "Hidden"
   }, {
-    "id" : "inbound.webhookMethod",
+    "id" : "inbound.method",
     "label" : "Webhook method",
     "description" : "Select HTTP method",
     "optional" : false,
@@ -72,7 +72,7 @@
       "value" : "delete"
     } ]
   }, {
-    "id" : "inbound.webhookId",
+    "id" : "inbound.context",
     "label" : "Webhook ID",
     "description" : "The webhook ID is a part of the URL",
     "optional" : false,

--- a/connectors/webhook/src/main/java/io/camunda/connector/inbound/model/WebhookConnectorProperties.java
+++ b/connectors/webhook/src/main/java/io/camunda/connector/inbound/model/WebhookConnectorProperties.java
@@ -13,7 +13,6 @@ import io.camunda.connector.feel.annotation.FEEL;
 import io.camunda.connector.generator.dsl.Property.FeelMode;
 import io.camunda.connector.generator.java.annotation.TemplateProperty;
 import io.camunda.connector.generator.java.annotation.TemplateProperty.DropdownPropertyChoice;
-import io.camunda.connector.generator.java.annotation.TemplateProperty.PropertyBinding;
 import io.camunda.connector.generator.java.annotation.TemplateProperty.PropertyCondition;
 import io.camunda.connector.generator.java.annotation.TemplateProperty.PropertyType;
 import io.camunda.connector.inbound.utils.HttpMethods;
@@ -24,7 +23,7 @@ import java.util.function.Function;
 
 public record WebhookConnectorProperties(
     @TemplateProperty(
-            id = "webhookMethod",
+            id = "method",
             label = "Webhook method",
             group = "endpoint",
             description = "Select HTTP method",
@@ -39,11 +38,11 @@ public record WebhookConnectorProperties(
             defaultValue = "any")
         String method,
     @TemplateProperty(
-            id = "webhookId",
+            id = "context",
             label = "Webhook ID",
             group = "endpoint",
             description = "The webhook ID is a part of the URL",
-            binding = @PropertyBinding(name = "context"))
+            feel = FeelMode.disabled)
         @NotBlank
         @Pattern(
             regexp = "^[a-zA-Z0-9]+([-_][a-zA-Z0-9]+)*$",


### PR DESCRIPTION
## Description

Changes the property IDs of the webhook element templates that deviated from the original values after migrating to the template generator. This does not change the runtime behavior since binding names don't change, i.e. IDs are simply brought in accordance with bindings for clarity.


