### PR TITLE
feat(template generator): set default value feel = false for all inbound connectors

### DIFF
--- a/connectors/webhook/src/main/java/io/camunda/connector/inbound/model/JWTProperties.java
+++ b/connectors/webhook/src/main/java/io/camunda/connector/inbound/model/JWTProperties.java
@@ -17,6 +17,7 @@ public record JWTProperties(
     @TemplateProperty(
             label = "JWK URL",
             description = "Well-known URL of JWKs",
+            feel = FeelMode.optional,
             group = "authorization")
         @FEEL
         String jwkUrl,

--- a/connectors/webhook/src/main/java/io/camunda/connector/inbound/model/WebhookAuthorization.java
+++ b/connectors/webhook/src/main/java/io/camunda/connector/inbound/model/WebhookAuthorization.java
@@ -43,12 +43,14 @@ public sealed interface WebhookAuthorization {
       @TemplateProperty(
               label = "Username",
               description = "Username for basic authentication",
+              feel = FeelMode.optional,
               group = "authorization")
           @FEEL
           String username,
       @TemplateProperty(
               label = "Password",
               description = "Password for basic authentication",
+              feel = FeelMode.optional,
               group = "authorization")
           @FEEL
           String password)
@@ -59,6 +61,7 @@ public sealed interface WebhookAuthorization {
       @TemplateProperty(
               label = "API key",
               description = "Expected API key",
+              feel = FeelMode.optional,
               group = "authorization")
           @FEEL
           String apiKey,

--- a/connectors/webhook/src/main/java/io/camunda/connector/inbound/model/WebhookConnectorProperties.java
+++ b/connectors/webhook/src/main/java/io/camunda/connector/inbound/model/WebhookConnectorProperties.java
@@ -68,6 +68,7 @@ public record WebhookConnectorProperties(
             description = "Shared secret key",
             group = "authentication",
             optional = true,
+            feel = FeelMode.optional,
             condition =
                 @PropertyCondition(property = "inbound.shouldValidateHmac", equals = "enabled"))
         String hmacSecret,
@@ -76,6 +77,7 @@ public record WebhookConnectorProperties(
             label = "HMAC header",
             description = "Name of header attribute that will contain the HMAC value",
             group = "authentication",
+            feel = FeelMode.optional,
             optional = true,
             condition =
                 @PropertyCondition(property = "inbound.shouldValidateHmac", equals = "enabled"))

--- a/element-template-generator/core/src/main/java/io/camunda/connector/generator/dsl/Property.java
+++ b/element-template-generator/core/src/main/java/io/camunda/connector/generator/dsl/Property.java
@@ -43,7 +43,9 @@ public abstract sealed class Property
     optional,
     required,
     @JsonIgnore
-    disabled
+    disabled,
+    @JsonIgnore
+    system_default,
   }
 
   public record GeneratedValue(String type) {}

--- a/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/annotation/TemplateProperty.java
+++ b/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/annotation/TemplateProperty.java
@@ -69,8 +69,11 @@ public @interface TemplateProperty {
    */
   DropdownPropertyChoice[] choices() default {};
 
-  /** Whether the property should support FEEL expressions */
-  FeelMode feel() default FeelMode.optional;
+  /**
+   * Defines the support for FEEL expressions in the property. By default, for inbound connectors,
+   * FEEL is disabled; for outbound connectors, FEEL is optional.
+   */
+  FeelMode feel() default FeelMode.system_default;
 
   /** Default value for the property */
   String defaultValue() default "";

--- a/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/processor/FieldProcessor.java
+++ b/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/processor/FieldProcessor.java
@@ -17,9 +17,11 @@
 package io.camunda.connector.generator.java.processor;
 
 import io.camunda.connector.generator.dsl.PropertyBuilder;
+import io.camunda.connector.generator.java.util.TemplateGenerationContext;
 import java.lang.reflect.Field;
 
 public interface FieldProcessor {
 
-  void process(Field field, PropertyBuilder propertyBuilder);
+  void process(
+      Field field, PropertyBuilder propertyBuilder, final TemplateGenerationContext context);
 }

--- a/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/processor/JakartaValidationFieldProcessor.java
+++ b/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/processor/JakartaValidationFieldProcessor.java
@@ -19,6 +19,7 @@ package io.camunda.connector.generator.java.processor;
 import io.camunda.connector.generator.dsl.PropertyBuilder;
 import io.camunda.connector.generator.dsl.PropertyConstraints;
 import io.camunda.connector.generator.dsl.PropertyConstraints.PropertyConstraintsBuilder;
+import io.camunda.connector.generator.java.util.TemplateGenerationContext;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
@@ -31,7 +32,8 @@ import org.apache.commons.lang3.tuple.Pair;
 public class JakartaValidationFieldProcessor implements FieldProcessor {
 
   @Override
-  public void process(Field field, PropertyBuilder propertyBuilder) {
+  public void process(
+      Field field, PropertyBuilder propertyBuilder, final TemplateGenerationContext context) {
     PropertyConstraintsBuilder constraintsBuilder = PropertyConstraints.builder();
 
     if (hasNotEmptyConstraint(field)) {

--- a/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/util/TemplatePropertiesUtil.java
+++ b/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/util/TemplatePropertiesUtil.java
@@ -203,7 +203,7 @@ public class TemplatePropertiesUtil {
             .binding(createBinding(bindingName, context));
 
     for (FieldProcessor processor : fieldProcessors) {
-      processor.process(field, propertyBuilder);
+      processor.process(field, propertyBuilder, context);
     }
     return propertyBuilder;
   }

--- a/element-template-generator/core/src/test/java/io/camunda/connector/generator/java/InboundClassBasedTemplateGeneratorTest.java
+++ b/element-template-generator/core/src/test/java/io/camunda/connector/generator/java/InboundClassBasedTemplateGeneratorTest.java
@@ -27,10 +27,12 @@ import io.camunda.connector.generator.dsl.BpmnType;
 import io.camunda.connector.generator.dsl.DropdownProperty;
 import io.camunda.connector.generator.dsl.DropdownProperty.DropdownChoice;
 import io.camunda.connector.generator.dsl.Property.FeelMode;
+import io.camunda.connector.generator.dsl.PropertyBinding;
 import io.camunda.connector.generator.dsl.PropertyBinding.MessageProperty;
 import io.camunda.connector.generator.dsl.PropertyBinding.ZeebeProperty;
 import io.camunda.connector.generator.dsl.PropertyBinding.ZeebeSubscriptionProperty;
 import io.camunda.connector.generator.dsl.PropertyCondition.Equals;
+import io.camunda.connector.generator.dsl.StringProperty;
 import io.camunda.connector.generator.java.example.inbound.MyConnectorExecutable;
 import java.util.List;
 import java.util.Set;
@@ -257,5 +259,26 @@ public class InboundClassBasedTemplateGeneratorTest extends BaseTest {
       assertThat(((ZeebeProperty) messageIdExpressionProperty.getBinding()).name())
           .isEqualTo("messageIdExpression");
     }
+  }
+
+  @Test
+  void stringProperty_hasCorrectDefaults() {
+    // given
+    var type =
+        new ConnectorElementType(
+            Set.of(BpmnType.START_EVENT), BpmnType.MESSAGE_START_EVENT, null, null);
+    var config = new GeneratorConfiguration(ConnectorMode.NORMAL, null, null, null, Set.of(type));
+
+    // when
+    var template = generator.generate(MyConnectorExecutable.class, config).getFirst();
+
+    var property = getPropertyByLabel("Prop 1", template);
+
+    assertThat(property).isInstanceOf(StringProperty.class);
+    assertThat(property.getType()).isEqualTo("String");
+    assertThat(property.isOptional()).isFalse();
+    assertThat(property.getFeel()).isEqualTo(null);
+    assertThat(property.getBinding()).isEqualTo(new PropertyBinding.ZeebeProperty("prop1"));
+    assertThat(property.getConstraints()).isNull();
   }
 }

--- a/element-template-generator/core/src/test/java/io/camunda/connector/generator/java/example/inbound/MyConnectorProperties.java
+++ b/element-template-generator/core/src/test/java/io/camunda/connector/generator/java/example/inbound/MyConnectorProperties.java
@@ -16,4 +16,6 @@
  */
 package io.camunda.connector.generator.java.example.inbound;
 
-public record MyConnectorProperties(String prop1) {}
+import io.camunda.connector.generator.java.annotation.TemplateProperty;
+
+public record MyConnectorProperties(@TemplateProperty() String prop1) {}


### PR DESCRIPTION
## Description

In the template generator, the default value for all inbound connectors should be 'false', while remaining optional for all outbound connectors;

In the template generator, the default value for all inbound connectors is set to 'false', with this setting remaining optional for all outbound connectors. 

Additionally, a system_default value for FeelMode has been introduced: if it's inbound, the default value is 'disabled'; otherwise, it's 'optional'. 

Furthermore, feel = FeelMode.optional has been added to all webhook templates to ensure this setting remains unchanged.



## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #
 - https://github.com/camunda/connectors/issues/2251
