### PR TITLE
chore(aws): force region as mandatory field in templates

### DIFF
--- a/connectors/aws/aws-base/src/main/java/io/camunda/connector/aws/model/impl/AwsBaseConfiguration.java
+++ b/connectors/aws/aws-base/src/main/java/io/camunda/connector/aws/model/impl/AwsBaseConfiguration.java
@@ -9,12 +9,13 @@ package io.camunda.connector.aws.model.impl;
 import io.camunda.connector.aws.model.AwsConfiguration;
 import io.camunda.connector.generator.dsl.Property;
 import io.camunda.connector.generator.java.annotation.TemplateProperty;
+import io.camunda.connector.generator.java.annotation.TemplateProperty.PropertyConstraints;
 
 public record AwsBaseConfiguration(
     @TemplateProperty(
             group = "configuration",
             description = "Specify the AWS region",
-            optional = true)
+            constraints = @PropertyConstraints(notEmpty = true))
         String region,
     @TemplateProperty(
             group = "configuration",

--- a/connectors/aws/aws-dynamodb/element-templates/aws-dynamodb-outbound-connector.json
+++ b/connectors/aws/aws-dynamodb/element-templates/aws-dynamodb-outbound-connector.json
@@ -174,7 +174,10 @@
     "id" : "configuration.region",
     "label" : "Region",
     "description" : "Specify the AWS region",
-    "optional" : true,
+    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
     "feel" : "optional",
     "group" : "configuration",
     "binding" : {

--- a/connectors/aws/aws-eventbridge/element-templates/aws-eventbridge-outbound-connector.json
+++ b/connectors/aws/aws-eventbridge/element-templates/aws-eventbridge-outbound-connector.json
@@ -104,7 +104,10 @@
     "id" : "configuration.region",
     "label" : "Region",
     "description" : "Specify the AWS region",
-    "optional" : true,
+    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
     "feel" : "optional",
     "group" : "configuration",
     "binding" : {

--- a/connectors/aws/aws-lambda/element-templates/aws-lambda-outbound-connector.json
+++ b/connectors/aws/aws-lambda/element-templates/aws-lambda-outbound-connector.json
@@ -104,7 +104,10 @@
     "id" : "configuration.region",
     "label" : "Region",
     "description" : "Specify the AWS region",
-    "optional" : true,
+    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
     "feel" : "optional",
     "group" : "configuration",
     "binding" : {

--- a/connectors/aws/aws-sns/element-templates/aws-sns-outbound-connector.json
+++ b/connectors/aws/aws-sns/element-templates/aws-sns-outbound-connector.json
@@ -138,7 +138,10 @@
     "id" : "configuration.region",
     "label" : "Region",
     "description" : "Specify the AWS region",
-    "optional" : true,
+    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
     "feel" : "optional",
     "group" : "configuration",
     "binding" : {

--- a/connectors/aws/aws-sqs/element-templates/aws-sqs-outbound-connector.json
+++ b/connectors/aws/aws-sqs/element-templates/aws-sqs-outbound-connector.json
@@ -138,7 +138,10 @@
     "id" : "configuration.region",
     "label" : "Region",
     "description" : "Specify the AWS region",
-    "optional" : true,
+    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
     "feel" : "optional",
     "group" : "configuration",
     "binding" : {


### PR DESCRIPTION
chore(aws): force region as mandatory field in templates

