### PR TITLE
ci: fix integration test GHA

### DIFF
--- a/.github/workflows/DEPLOY_SNAPSHOTS.yaml
+++ b/.github/workflows/DEPLOY_SNAPSHOTS.yaml
@@ -123,11 +123,12 @@ jobs:
           provenance: false
 
   helm-deploy:
+    needs: deploy-snapshots
     name: Helm chart Integration Tests
     uses: camunda/camunda-platform-helm/.github/workflows/test-integration-template.yaml@main
     secrets: inherit
     with:
-      identifier: connectors-int-${{ github.run_id }}
+      identifier: connectors-int
       test-enabled: true
       extra-values: |
         connectors:

--- a/.github/workflows/INTEGRATION_TEST.yml
+++ b/.github/workflows/INTEGRATION_TEST.yml
@@ -21,7 +21,7 @@ jobs:
     uses: camunda/camunda-platform-helm/.github/workflows/test-integration-template.yaml@main
     secrets: inherit
     with:
-      identifier: connectors-int-${{ github.run_id }}
+      identifier: connectors-int
       test-enabled: true
       extra-values: |
         connectors:


### PR DESCRIPTION
## Description

- Removes run ID from the deployment identifier (it is added automatically for non-persistent runs)
- Adds a dependency between two parts of the snapshot workflow


