### PR TITLE
Support POSTing application-x-www-form-urlencoded Content-Type

### DIFF
--- a/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/services/HttpRequestMapper.java
+++ b/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/services/HttpRequestMapper.java
@@ -21,7 +21,6 @@ import static io.camunda.connector.http.base.constants.Constants.APPLICATION_X_W
 import static org.apache.http.entity.ContentType.APPLICATION_FORM_URLENCODED;
 import static org.apache.http.entity.ContentType.APPLICATION_JSON;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.api.client.http.GenericUrl;
 import com.google.api.client.http.HttpContent;
 import com.google.api.client.http.HttpHeaders;
@@ -37,8 +36,6 @@ import io.camunda.connector.http.base.model.HttpCommonRequest;
 import io.camunda.connector.http.base.model.HttpMethod;
 import io.camunda.connector.http.base.model.HttpRequestBuilder;
 import java.io.IOException;
-import java.util.HashMap;
-import java.util.LinkedHashMap;
 import java.util.Map;
 import org.apache.commons.text.StringEscapeUtils;
 
@@ -100,7 +97,7 @@ public class HttpRequestMapper {
     HttpContent content = null;
     if (request.getMethod().supportsBody && request.hasBody()) {
       if (APPLICATION_FORM_URLENCODED.getMimeType().equalsIgnoreCase(headers.getContentType())
-          && request.getBody() instanceof LinkedHashMap) {
+          && request.getBody() instanceof Map) {
         content = new UrlEncodedContent(request.getBody());
       } else {
         content = new JsonHttpContent(new GsonFactory(), request.getBody());


### PR DESCRIPTION
## Description

Its currently not possible make a POST request and send data in the body with `Content-Type` of `application/x-www-form-urlencoded`. 

The unqork api requires this and I think other folks can benefit from the ability as well. 

The way I implemented this is that if there's a header set like this: 

```
{
  "Content-Type": "application/x-www-form-urlencoded"
}
```

Then a body like this will be interpreted correctly: 

```
{
  "grant_type":"password",
  "username":unqorkUsername,
  "password":unqorkPassword
}
```

![Screen Shot 2024-04-02 at 5 57 55 PM](https://github.com/camunda/connectors/assets/939229/66974bd3-6493-4297-afd0-2d249fe9ca8f)


## Related issues

[camunda-8-rest-connector-for-body-other-than-json](https://forum.camunda.io/t/camunda-8-rest-connector-for-body-other-than-json/43166)

