### PR TITLE
chore: fix duplicated property IDs in templates, part 1

### DIFF
--- a/connectors/asana/element-templates/asana-connector.json
+++ b/connectors/asana/element-templates/asana-connector.json
@@ -28,10 +28,6 @@
       "label": "Authentication"
     },
     {
-      "id": "operation",
-      "label": "Operation"
-    },
-    {
       "id": "output",
       "label": "Output"
     },

--- a/connectors/blue-prism/element-templates/blue-prism-connector.json
+++ b/connectors/blue-prism/element-templates/blue-prism-connector.json
@@ -174,7 +174,7 @@
       }
     },
     {
-      "id": "authenticationType",
+      "id": "authentication.clientAuthentication",
       "group": "authentication",
       "value": "basicAuthHeader",
       "type": "Hidden",
@@ -448,7 +448,7 @@
     },
     {
       "label": "Result expression",
-      "id": "resultExpressionGet",
+      "id": "resultExpressionGetItemState",
       "description": "Expression to map the response into process variables. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-expression\" target=\"_blank\">documentation</a>",
       "group": "output",
       "type": "String",
@@ -467,7 +467,7 @@
     },
     {
       "label": "Result expression",
-      "id": "resultExpressionGet",
+      "id": "resultExpressionGetItemId",
       "description": "Expression to map the response into process variables. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-expression\" target=\"_blank\">documentation</a>",
       "group": "output",
       "type": "String",

--- a/connectors/http/polling/element-templates/http-polling-connector-boundary.json
+++ b/connectors/http/polling/element-templates/http-polling-connector-boundary.json
@@ -307,7 +307,7 @@
     },
     {
       "label": "Client authentication",
-      "id": "authenticationType",
+      "id": "authentication.clientAuthentication",
       "group": "authentication",
       "description": "Send client ID and client secret as Basic Auth request in the header, or as client credentials in the request body",
       "value": "basicAuthHeader",

--- a/connectors/http/polling/element-templates/http-polling-connector.json
+++ b/connectors/http/polling/element-templates/http-polling-connector.json
@@ -308,7 +308,7 @@
     },
     {
       "label": "Client authentication",
-      "id": "authenticationType",
+      "id": "authentication.clientAuthentication",
       "group": "authentication",
       "description": "Send client ID and client secret as Basic Auth request in the header, or as client credentials in the request body",
       "value": "basicAuthHeader",

--- a/connectors/salesforce/element-templates/salesforce-connector.json
+++ b/connectors/salesforce/element-templates/salesforce-connector.json
@@ -415,7 +415,7 @@
     },
     {
       "description": "Client authentication type",
-      "id": "authenticationType",
+      "id": "authentication.clientAuthentication",
       "value": "credentialsBody",
       "type": "Hidden",
       "binding": {

--- a/connectors/uipath/element-templates/uipath-connector.json
+++ b/connectors/uipath/element-templates/uipath-connector.json
@@ -176,7 +176,7 @@
       }
     },
     {
-      "id": "authenticationType",
+      "id": "authentication.clientAuthentication",
       "group": "authentication",
       "value": "basicAuthHeader",
       "type": "Hidden",
@@ -455,7 +455,7 @@
     },
     {
       "label": "Result expression",
-      "id": "resultExpressionGet",
+      "id": "resultExpressionGetBodyId",
       "description": "Expression to map the response into process variables. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-expression\" target=\"_blank\">documentation</a>",
       "group": "output",
       "type": "String",
@@ -474,7 +474,7 @@
     },
     {
       "label": "Result expression",
-      "id": "resultExpressionGet",
+      "id": "resultExpressionGetStatus",
       "description": "Expression to map the response into process variables. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-expression\" target=\"_blank\">documentation</a>",
       "group": "output",
       "type": "String",


### PR DESCRIPTION
## Description

Fix templates;
rename duplicated property IDs;

next step : 
need to fix the next templates : 

 ./github-connector.json 
 ./gitlab-connector.json 
./asana-connector.json



<!-- Please explain the changes you made here. -->

## Related issues

https://github.com/camunda/team-connectors/issues/708
