### PR TITLE
chore(java-version): update java version in dockerfile

### DIFF
--- a/bundle/camunda-saas-bundle/Dockerfile
+++ b/bundle/camunda-saas-bundle/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:17.0.8.1_1-jre
+FROM eclipse-temurin:17.0.10_7-jre
 
 VOLUME /tmp
 


### PR DESCRIPTION
## Description

We had to update because of security concerns. 
https://jira.camunda.com/browse/SEC-983

