### PR TITLE
feat(generator): support inbound deduplication; boolean props; enhanced conditions

### DIFF
--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/correlation/InboundCorrelationHandler.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/correlation/InboundCorrelationHandler.java
@@ -121,7 +121,7 @@ public class InboundCorrelationHandler {
               .send()
               .join();
 
-      LOG.info("Created a process instance with key" + result.getProcessInstanceKey());
+      LOG.info("Created a process instance with key {}", result.getProcessInstanceKey());
       return new CorrelationResult.Success.ProcessInstanceCreated(
           getElementContext(activatedElement),
           result.getProcessInstanceKey(),
@@ -205,7 +205,7 @@ public class InboundCorrelationHandler {
               .send()
               .join();
 
-      LOG.info("Published message with key: " + response.getMessageKey());
+      LOG.info("Published message with key: {}", response.getMessageKey());
       result =
           new CorrelationResult.Success.MessagePublished(
               getElementContext(activatedElement),
@@ -233,8 +233,10 @@ public class InboundCorrelationHandler {
       LOG.debug("No activation condition specified for connector");
       return true;
     }
+    LOG.debug("Evaluating activation condition: {}", maybeCondition);
     try {
       Object shouldActivate = feelEngine.evaluate(maybeCondition, context);
+      LOG.debug("Activation condition evaluated to: {}", shouldActivate);
       return Boolean.TRUE.equals(shouldActivate);
     } catch (FeelEngineWrapperException e) {
       throw new ConnectorInputException(e);

--- a/connectors/rabbitmq/element-templates/rabbitmq-inbound-connector-boundary.json
+++ b/connectors/rabbitmq/element-templates/rabbitmq-inbound-connector-boundary.json
@@ -4,7 +4,7 @@
   "id" : "io.camunda.connectors.inbound.RabbitMQ.Boundary.v1",
   "description" : "Receive a message from RabbitMQ",
   "documentationRef" : "https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=inbound",
-  "version" : 6,
+  "version" : 7,
   "category" : {
     "id" : "connectors",
     "name" : "Connectors"
@@ -29,6 +29,10 @@
   }, {
     "id" : "correlation",
     "label" : "Correlation"
+  }, {
+    "id" : "deduplication",
+    "label" : "Deduplication",
+    "tooltip" : "Deduplication allows you to configure multiple inbound connector elements to reuse the same backend (consumer/thread/endpoint) by sharing the same deduplication ID."
   }, {
     "id" : "output",
     "label" : "Output mapping"
@@ -291,6 +295,62 @@
       "type" : "bpmn:Message#property"
     },
     "type" : "Hidden"
+  }, {
+    "id" : "deduplicationModeManualFlag",
+    "label" : "Manual mode",
+    "description" : "By default, similar connectors receive the same deduplication ID. Customize by activating manual mode",
+    "value" : false,
+    "group" : "deduplication",
+    "binding" : {
+      "name" : "deduplicationModeManualFlag",
+      "type" : "zeebe:property"
+    },
+    "type" : "Boolean"
+  }, {
+    "id" : "deduplicationModeManual",
+    "value" : "MANUAL",
+    "group" : "deduplication",
+    "binding" : {
+      "name" : "deduplicationMode",
+      "type" : "zeebe:property"
+    },
+    "condition" : {
+      "property" : "deduplicationModeManualFlag",
+      "equals" : true,
+      "type" : "simple"
+    },
+    "type" : "Hidden"
+  }, {
+    "id" : "deduplicationModeAuto",
+    "value" : "AUTO",
+    "group" : "deduplication",
+    "binding" : {
+      "name" : "deduplicationMode",
+      "type" : "zeebe:property"
+    },
+    "condition" : {
+      "property" : "deduplicationModeManualFlag",
+      "equals" : false,
+      "type" : "simple"
+    },
+    "type" : "Hidden"
+  }, {
+    "id" : "deduplicationId",
+    "label" : "Deduplication ID",
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "group" : "deduplication",
+    "binding" : {
+      "name" : "deduplicationId",
+      "type" : "zeebe:property"
+    },
+    "condition" : {
+      "property" : "deduplicationModeManualFlag",
+      "equals" : true,
+      "type" : "simple"
+    },
+    "type" : "String"
   }, {
     "id" : "resultVariable",
     "label" : "Result variable",

--- a/connectors/rabbitmq/element-templates/rabbitmq-inbound-connector-boundary.json
+++ b/connectors/rabbitmq/element-templates/rabbitmq-inbound-connector-boundary.json
@@ -307,34 +307,6 @@
     },
     "type" : "Boolean"
   }, {
-    "id" : "deduplicationModeManual",
-    "value" : "MANUAL",
-    "group" : "deduplication",
-    "binding" : {
-      "name" : "deduplicationMode",
-      "type" : "zeebe:property"
-    },
-    "condition" : {
-      "property" : "deduplicationModeManualFlag",
-      "equals" : true,
-      "type" : "simple"
-    },
-    "type" : "Hidden"
-  }, {
-    "id" : "deduplicationModeAuto",
-    "value" : "AUTO",
-    "group" : "deduplication",
-    "binding" : {
-      "name" : "deduplicationMode",
-      "type" : "zeebe:property"
-    },
-    "condition" : {
-      "property" : "deduplicationModeManualFlag",
-      "equals" : false,
-      "type" : "simple"
-    },
-    "type" : "Hidden"
-  }, {
     "id" : "deduplicationId",
     "label" : "Deduplication ID",
     "constraints" : {
@@ -351,6 +323,34 @@
       "type" : "simple"
     },
     "type" : "String"
+  }, {
+    "id" : "deduplicationModeManual",
+    "value" : "MANUAL",
+    "group" : "deduplication",
+    "binding" : {
+      "name" : "deduplicationMode",
+      "type" : "zeebe:property"
+    },
+    "condition" : {
+      "property" : "deduplicationId",
+      "isActive" : true,
+      "type" : "simple"
+    },
+    "type" : "Hidden"
+  }, {
+    "id" : "deduplicationModeAuto",
+    "value" : "AUTO",
+    "group" : "deduplication",
+    "binding" : {
+      "name" : "deduplicationMode",
+      "type" : "zeebe:property"
+    },
+    "condition" : {
+      "property" : "deduplicationId",
+      "isActive" : false,
+      "type" : "simple"
+    },
+    "type" : "Hidden"
   }, {
     "id" : "resultVariable",
     "label" : "Result variable",

--- a/connectors/rabbitmq/element-templates/rabbitmq-inbound-connector-boundary.json
+++ b/connectors/rabbitmq/element-templates/rabbitmq-inbound-connector-boundary.json
@@ -310,7 +310,11 @@
     "id" : "deduplicationId",
     "label" : "Deduplication ID",
     "constraints" : {
-      "notEmpty" : true
+      "notEmpty" : true,
+      "pattern" : {
+        "value" : "^[a-zA-Z0-9_-]+$",
+        "message" : "Only alphanumeric characters, dashes, and underscores are allowed"
+      }
     },
     "group" : "deduplication",
     "binding" : {

--- a/connectors/rabbitmq/element-templates/rabbitmq-inbound-connector-intermediate.json
+++ b/connectors/rabbitmq/element-templates/rabbitmq-inbound-connector-intermediate.json
@@ -307,34 +307,6 @@
     },
     "type" : "Boolean"
   }, {
-    "id" : "deduplicationModeManual",
-    "value" : "MANUAL",
-    "group" : "deduplication",
-    "binding" : {
-      "name" : "deduplicationMode",
-      "type" : "zeebe:property"
-    },
-    "condition" : {
-      "property" : "deduplicationModeManualFlag",
-      "equals" : true,
-      "type" : "simple"
-    },
-    "type" : "Hidden"
-  }, {
-    "id" : "deduplicationModeAuto",
-    "value" : "AUTO",
-    "group" : "deduplication",
-    "binding" : {
-      "name" : "deduplicationMode",
-      "type" : "zeebe:property"
-    },
-    "condition" : {
-      "property" : "deduplicationModeManualFlag",
-      "equals" : false,
-      "type" : "simple"
-    },
-    "type" : "Hidden"
-  }, {
     "id" : "deduplicationId",
     "label" : "Deduplication ID",
     "constraints" : {
@@ -351,6 +323,34 @@
       "type" : "simple"
     },
     "type" : "String"
+  }, {
+    "id" : "deduplicationModeManual",
+    "value" : "MANUAL",
+    "group" : "deduplication",
+    "binding" : {
+      "name" : "deduplicationMode",
+      "type" : "zeebe:property"
+    },
+    "condition" : {
+      "property" : "deduplicationId",
+      "isActive" : true,
+      "type" : "simple"
+    },
+    "type" : "Hidden"
+  }, {
+    "id" : "deduplicationModeAuto",
+    "value" : "AUTO",
+    "group" : "deduplication",
+    "binding" : {
+      "name" : "deduplicationMode",
+      "type" : "zeebe:property"
+    },
+    "condition" : {
+      "property" : "deduplicationId",
+      "isActive" : false,
+      "type" : "simple"
+    },
+    "type" : "Hidden"
   }, {
     "id" : "resultVariable",
     "label" : "Result variable",

--- a/connectors/rabbitmq/element-templates/rabbitmq-inbound-connector-intermediate.json
+++ b/connectors/rabbitmq/element-templates/rabbitmq-inbound-connector-intermediate.json
@@ -4,7 +4,7 @@
   "id" : "io.camunda.connectors.inbound.RabbitMQ.Intermediate.v1",
   "description" : "Receive a message from RabbitMQ",
   "documentationRef" : "https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=inbound",
-  "version" : 6,
+  "version" : 7,
   "category" : {
     "id" : "connectors",
     "name" : "Connectors"
@@ -29,6 +29,10 @@
   }, {
     "id" : "correlation",
     "label" : "Correlation"
+  }, {
+    "id" : "deduplication",
+    "label" : "Deduplication",
+    "tooltip" : "Deduplication allows you to configure multiple inbound connector elements to reuse the same backend (consumer/thread/endpoint) by sharing the same deduplication ID."
   }, {
     "id" : "output",
     "label" : "Output mapping"
@@ -291,6 +295,62 @@
       "type" : "bpmn:Message#property"
     },
     "type" : "Hidden"
+  }, {
+    "id" : "deduplicationModeManualFlag",
+    "label" : "Manual mode",
+    "description" : "By default, similar connectors receive the same deduplication ID. Customize by activating manual mode",
+    "value" : false,
+    "group" : "deduplication",
+    "binding" : {
+      "name" : "deduplicationModeManualFlag",
+      "type" : "zeebe:property"
+    },
+    "type" : "Boolean"
+  }, {
+    "id" : "deduplicationModeManual",
+    "value" : "MANUAL",
+    "group" : "deduplication",
+    "binding" : {
+      "name" : "deduplicationMode",
+      "type" : "zeebe:property"
+    },
+    "condition" : {
+      "property" : "deduplicationModeManualFlag",
+      "equals" : true,
+      "type" : "simple"
+    },
+    "type" : "Hidden"
+  }, {
+    "id" : "deduplicationModeAuto",
+    "value" : "AUTO",
+    "group" : "deduplication",
+    "binding" : {
+      "name" : "deduplicationMode",
+      "type" : "zeebe:property"
+    },
+    "condition" : {
+      "property" : "deduplicationModeManualFlag",
+      "equals" : false,
+      "type" : "simple"
+    },
+    "type" : "Hidden"
+  }, {
+    "id" : "deduplicationId",
+    "label" : "Deduplication ID",
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "group" : "deduplication",
+    "binding" : {
+      "name" : "deduplicationId",
+      "type" : "zeebe:property"
+    },
+    "condition" : {
+      "property" : "deduplicationModeManualFlag",
+      "equals" : true,
+      "type" : "simple"
+    },
+    "type" : "String"
   }, {
     "id" : "resultVariable",
     "label" : "Result variable",

--- a/connectors/rabbitmq/element-templates/rabbitmq-inbound-connector-intermediate.json
+++ b/connectors/rabbitmq/element-templates/rabbitmq-inbound-connector-intermediate.json
@@ -310,7 +310,11 @@
     "id" : "deduplicationId",
     "label" : "Deduplication ID",
     "constraints" : {
-      "notEmpty" : true
+      "notEmpty" : true,
+      "pattern" : {
+        "value" : "^[a-zA-Z0-9_-]+$",
+        "message" : "Only alphanumeric characters, dashes, and underscores are allowed"
+      }
     },
     "group" : "deduplication",
     "binding" : {

--- a/connectors/rabbitmq/element-templates/rabbitmq-inbound-connector-message-start.json
+++ b/connectors/rabbitmq/element-templates/rabbitmq-inbound-connector-message-start.json
@@ -335,34 +335,6 @@
     },
     "type" : "Boolean"
   }, {
-    "id" : "deduplicationModeManual",
-    "value" : "MANUAL",
-    "group" : "deduplication",
-    "binding" : {
-      "name" : "deduplicationMode",
-      "type" : "zeebe:property"
-    },
-    "condition" : {
-      "property" : "deduplicationModeManualFlag",
-      "equals" : true,
-      "type" : "simple"
-    },
-    "type" : "Hidden"
-  }, {
-    "id" : "deduplicationModeAuto",
-    "value" : "AUTO",
-    "group" : "deduplication",
-    "binding" : {
-      "name" : "deduplicationMode",
-      "type" : "zeebe:property"
-    },
-    "condition" : {
-      "property" : "deduplicationModeManualFlag",
-      "equals" : false,
-      "type" : "simple"
-    },
-    "type" : "Hidden"
-  }, {
     "id" : "deduplicationId",
     "label" : "Deduplication ID",
     "constraints" : {
@@ -379,6 +351,34 @@
       "type" : "simple"
     },
     "type" : "String"
+  }, {
+    "id" : "deduplicationModeManual",
+    "value" : "MANUAL",
+    "group" : "deduplication",
+    "binding" : {
+      "name" : "deduplicationMode",
+      "type" : "zeebe:property"
+    },
+    "condition" : {
+      "property" : "deduplicationId",
+      "isActive" : true,
+      "type" : "simple"
+    },
+    "type" : "Hidden"
+  }, {
+    "id" : "deduplicationModeAuto",
+    "value" : "AUTO",
+    "group" : "deduplication",
+    "binding" : {
+      "name" : "deduplicationMode",
+      "type" : "zeebe:property"
+    },
+    "condition" : {
+      "property" : "deduplicationId",
+      "isActive" : false,
+      "type" : "simple"
+    },
+    "type" : "Hidden"
   }, {
     "id" : "resultVariable",
     "label" : "Result variable",

--- a/connectors/rabbitmq/element-templates/rabbitmq-inbound-connector-message-start.json
+++ b/connectors/rabbitmq/element-templates/rabbitmq-inbound-connector-message-start.json
@@ -4,7 +4,7 @@
   "id" : "io.camunda.connectors.inbound.RabbitMQ.MessageStart.v1",
   "description" : "Receive a message from RabbitMQ",
   "documentationRef" : "https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=inbound",
-  "version" : 6,
+  "version" : 7,
   "category" : {
     "id" : "connectors",
     "name" : "Connectors"
@@ -29,6 +29,10 @@
   }, {
     "id" : "correlation",
     "label" : "Correlation"
+  }, {
+    "id" : "deduplication",
+    "label" : "Deduplication",
+    "tooltip" : "Deduplication allows you to configure multiple inbound connector elements to reuse the same backend (consumer/thread/endpoint) by sharing the same deduplication ID."
   }, {
     "id" : "output",
     "label" : "Output mapping"
@@ -319,6 +323,62 @@
       "type" : "bpmn:Message#property"
     },
     "type" : "Hidden"
+  }, {
+    "id" : "deduplicationModeManualFlag",
+    "label" : "Manual mode",
+    "description" : "By default, similar connectors receive the same deduplication ID. Customize by activating manual mode",
+    "value" : false,
+    "group" : "deduplication",
+    "binding" : {
+      "name" : "deduplicationModeManualFlag",
+      "type" : "zeebe:property"
+    },
+    "type" : "Boolean"
+  }, {
+    "id" : "deduplicationModeManual",
+    "value" : "MANUAL",
+    "group" : "deduplication",
+    "binding" : {
+      "name" : "deduplicationMode",
+      "type" : "zeebe:property"
+    },
+    "condition" : {
+      "property" : "deduplicationModeManualFlag",
+      "equals" : true,
+      "type" : "simple"
+    },
+    "type" : "Hidden"
+  }, {
+    "id" : "deduplicationModeAuto",
+    "value" : "AUTO",
+    "group" : "deduplication",
+    "binding" : {
+      "name" : "deduplicationMode",
+      "type" : "zeebe:property"
+    },
+    "condition" : {
+      "property" : "deduplicationModeManualFlag",
+      "equals" : false,
+      "type" : "simple"
+    },
+    "type" : "Hidden"
+  }, {
+    "id" : "deduplicationId",
+    "label" : "Deduplication ID",
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "group" : "deduplication",
+    "binding" : {
+      "name" : "deduplicationId",
+      "type" : "zeebe:property"
+    },
+    "condition" : {
+      "property" : "deduplicationModeManualFlag",
+      "equals" : true,
+      "type" : "simple"
+    },
+    "type" : "String"
   }, {
     "id" : "resultVariable",
     "label" : "Result variable",

--- a/connectors/rabbitmq/element-templates/rabbitmq-inbound-connector-message-start.json
+++ b/connectors/rabbitmq/element-templates/rabbitmq-inbound-connector-message-start.json
@@ -338,7 +338,11 @@
     "id" : "deduplicationId",
     "label" : "Deduplication ID",
     "constraints" : {
-      "notEmpty" : true
+      "notEmpty" : true,
+      "pattern" : {
+        "value" : "^[a-zA-Z0-9_-]+$",
+        "message" : "Only alphanumeric characters, dashes, and underscores are allowed"
+      }
     },
     "group" : "deduplication",
     "binding" : {

--- a/connectors/rabbitmq/element-templates/rabbitmq-inbound-connector-start-event.json
+++ b/connectors/rabbitmq/element-templates/rabbitmq-inbound-connector-start-event.json
@@ -4,7 +4,7 @@
   "id" : "io.camunda.connectors.inbound.RabbitMQ.StartEvent.v1",
   "description" : "Receive a message from RabbitMQ",
   "documentationRef" : "https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=inbound",
-  "version" : 6,
+  "version" : 7,
   "category" : {
     "id" : "connectors",
     "name" : "Connectors"
@@ -25,6 +25,10 @@
   }, {
     "id" : "activation",
     "label" : "Activation"
+  }, {
+    "id" : "deduplication",
+    "label" : "Deduplication",
+    "tooltip" : "Deduplication allows you to configure multiple inbound connector elements to reuse the same backend (consumer/thread/endpoint) by sharing the same deduplication ID."
   }, {
     "id" : "output",
     "label" : "Output mapping"
@@ -234,6 +238,62 @@
     "binding" : {
       "name" : "activationCondition",
       "type" : "zeebe:property"
+    },
+    "type" : "String"
+  }, {
+    "id" : "deduplicationModeManualFlag",
+    "label" : "Manual mode",
+    "description" : "By default, similar connectors receive the same deduplication ID. Customize by activating manual mode",
+    "value" : false,
+    "group" : "deduplication",
+    "binding" : {
+      "name" : "deduplicationModeManualFlag",
+      "type" : "zeebe:property"
+    },
+    "type" : "Boolean"
+  }, {
+    "id" : "deduplicationModeManual",
+    "value" : "MANUAL",
+    "group" : "deduplication",
+    "binding" : {
+      "name" : "deduplicationMode",
+      "type" : "zeebe:property"
+    },
+    "condition" : {
+      "property" : "deduplicationModeManualFlag",
+      "equals" : true,
+      "type" : "simple"
+    },
+    "type" : "Hidden"
+  }, {
+    "id" : "deduplicationModeAuto",
+    "value" : "AUTO",
+    "group" : "deduplication",
+    "binding" : {
+      "name" : "deduplicationMode",
+      "type" : "zeebe:property"
+    },
+    "condition" : {
+      "property" : "deduplicationModeManualFlag",
+      "equals" : false,
+      "type" : "simple"
+    },
+    "type" : "Hidden"
+  }, {
+    "id" : "deduplicationId",
+    "label" : "Deduplication ID",
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "group" : "deduplication",
+    "binding" : {
+      "name" : "deduplicationId",
+      "type" : "zeebe:property"
+    },
+    "condition" : {
+      "property" : "deduplicationModeManualFlag",
+      "equals" : true,
+      "type" : "simple"
     },
     "type" : "String"
   }, {

--- a/connectors/rabbitmq/element-templates/rabbitmq-inbound-connector-start-event.json
+++ b/connectors/rabbitmq/element-templates/rabbitmq-inbound-connector-start-event.json
@@ -255,7 +255,11 @@
     "id" : "deduplicationId",
     "label" : "Deduplication ID",
     "constraints" : {
-      "notEmpty" : true
+      "notEmpty" : true,
+      "pattern" : {
+        "value" : "^[a-zA-Z0-9_-]+$",
+        "message" : "Only alphanumeric characters, dashes, and underscores are allowed"
+      }
     },
     "group" : "deduplication",
     "binding" : {

--- a/connectors/rabbitmq/element-templates/rabbitmq-inbound-connector-start-event.json
+++ b/connectors/rabbitmq/element-templates/rabbitmq-inbound-connector-start-event.json
@@ -252,34 +252,6 @@
     },
     "type" : "Boolean"
   }, {
-    "id" : "deduplicationModeManual",
-    "value" : "MANUAL",
-    "group" : "deduplication",
-    "binding" : {
-      "name" : "deduplicationMode",
-      "type" : "zeebe:property"
-    },
-    "condition" : {
-      "property" : "deduplicationModeManualFlag",
-      "equals" : true,
-      "type" : "simple"
-    },
-    "type" : "Hidden"
-  }, {
-    "id" : "deduplicationModeAuto",
-    "value" : "AUTO",
-    "group" : "deduplication",
-    "binding" : {
-      "name" : "deduplicationMode",
-      "type" : "zeebe:property"
-    },
-    "condition" : {
-      "property" : "deduplicationModeManualFlag",
-      "equals" : false,
-      "type" : "simple"
-    },
-    "type" : "Hidden"
-  }, {
     "id" : "deduplicationId",
     "label" : "Deduplication ID",
     "constraints" : {
@@ -296,6 +268,34 @@
       "type" : "simple"
     },
     "type" : "String"
+  }, {
+    "id" : "deduplicationModeManual",
+    "value" : "MANUAL",
+    "group" : "deduplication",
+    "binding" : {
+      "name" : "deduplicationMode",
+      "type" : "zeebe:property"
+    },
+    "condition" : {
+      "property" : "deduplicationId",
+      "isActive" : true,
+      "type" : "simple"
+    },
+    "type" : "Hidden"
+  }, {
+    "id" : "deduplicationModeAuto",
+    "value" : "AUTO",
+    "group" : "deduplication",
+    "binding" : {
+      "name" : "deduplicationMode",
+      "type" : "zeebe:property"
+    },
+    "condition" : {
+      "property" : "deduplicationId",
+      "isActive" : false,
+      "type" : "simple"
+    },
+    "type" : "Hidden"
   }, {
     "id" : "resultVariable",
     "label" : "Result variable",

--- a/connectors/rabbitmq/pom.xml
+++ b/connectors/rabbitmq/pom.xml
@@ -84,6 +84,9 @@
                   <templateFileName>rabbitmq-inbound-connector-boundary.json</templateFileName>
                 </file>
               </files>
+              <features>
+                <INBOUND_DEDUPLICATION>true</INBOUND_DEDUPLICATION>
+              </features>
             </connector>
           </connectors>
         </configuration>

--- a/connectors/rabbitmq/src/main/java/io/camunda/connector/rabbitmq/inbound/RabbitMqExecutable.java
+++ b/connectors/rabbitmq/src/main/java/io/camunda/connector/rabbitmq/inbound/RabbitMqExecutable.java
@@ -29,7 +29,7 @@ import org.slf4j.LoggerFactory;
     id = "io.camunda.connectors.inbound.RabbitMQ",
     name = "RabbitMQ Connector",
     icon = "icon.svg",
-    version = 6,
+    version = 7,
     inputDataClass = RabbitMqInboundProperties.class,
     description = "Receive a message from RabbitMQ",
     documentationRef =

--- a/element-template-generator/congen-cli/src/main/java/io/camunda/connector/generator/cli/command/ConGen.java
+++ b/element-template-generator/congen-cli/src/main/java/io/camunda/connector/generator/cli/command/ConGen.java
@@ -22,6 +22,7 @@ import io.camunda.connector.generator.api.GeneratorConfiguration.ConnectorMode;
 import io.camunda.connector.generator.dsl.BpmnType;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -91,7 +92,8 @@ public class ConGen {
         templateId,
         templateName,
         null,
-        bpmnTypes);
+        bpmnTypes,
+        Map.of()); // todo: do we need to support feature overrides from the CLI?
   }
 
   private BpmnType parseBpmnType(String type) {

--- a/element-template-generator/core/src/main/java/io/camunda/connector/generator/api/GeneratorConfiguration.java
+++ b/element-template-generator/core/src/main/java/io/camunda/connector/generator/api/GeneratorConfiguration.java
@@ -18,6 +18,7 @@ package io.camunda.connector.generator.api;
 
 import io.camunda.connector.generator.dsl.BpmnType;
 import java.util.Collections;
+import java.util.Map;
 import java.util.Set;
 
 /** Configuration for the element template generator */
@@ -26,7 +27,8 @@ public record GeneratorConfiguration(
     String templateId,
     String templateName,
     Integer templateVersion,
-    Set<ConnectorElementType> elementTypes) {
+    Set<ConnectorElementType> elementTypes,
+    Map<GenerationFeature, Boolean> features) {
 
   /**
    * Connectors in hybrid mode have a configurable task definition type (for outbound), or a
@@ -38,8 +40,13 @@ public record GeneratorConfiguration(
     HYBRID
   }
 
+  public enum GenerationFeature {
+    INBOUND_DEDUPLICATION
+  }
+
   public static final GeneratorConfiguration DEFAULT =
-      new GeneratorConfiguration(ConnectorMode.NORMAL, null, null, null, Collections.emptySet());
+      new GeneratorConfiguration(
+          ConnectorMode.NORMAL, null, null, null, Collections.emptySet(), Collections.emptyMap());
 
   public record ConnectorElementType(
       Set<BpmnType> appliesTo,

--- a/element-template-generator/core/src/main/java/io/camunda/connector/generator/dsl/BooleanProperty.java
+++ b/element-template-generator/core/src/main/java/io/camunda/connector/generator/dsl/BooleanProperty.java
@@ -25,13 +25,14 @@ public final class BooleanProperty extends Property {
       String label,
       String description,
       Boolean required,
-      String value,
+      Boolean value,
       GeneratedValue generatedValue,
       PropertyConstraints constraints,
       FeelMode feel,
       String group,
       PropertyBinding binding,
-      PropertyCondition condition) {
+      PropertyCondition condition,
+      String tooltip) {
     super(
         name,
         label,
@@ -44,6 +45,7 @@ public final class BooleanProperty extends Property {
         group,
         binding,
         condition,
+        tooltip,
         TYPE);
   }
 
@@ -56,18 +58,22 @@ public final class BooleanProperty extends Property {
     private BooleanPropertyBuilder() {}
 
     public BooleanProperty build() {
+      if (value != null && !(value instanceof Boolean)) {
+        throw new IllegalStateException("Value of a boolean property must be a boolean");
+      }
       return new BooleanProperty(
           id,
           label,
           description,
           optional,
-          value,
+          (Boolean) value,
           generatedValue,
           constraints,
           feel,
           group,
           binding,
-          condition);
+          condition,
+          tooltip);
     }
   }
 }

--- a/element-template-generator/core/src/main/java/io/camunda/connector/generator/dsl/CommonProperties.java
+++ b/element-template-generator/core/src/main/java/io/camunda/connector/generator/dsl/CommonProperties.java
@@ -20,6 +20,7 @@ import io.camunda.connector.generator.dsl.DropdownProperty.DropdownChoice;
 import io.camunda.connector.generator.dsl.Property.FeelMode;
 import io.camunda.connector.generator.dsl.PropertyBinding.ZeebeProperty;
 import io.camunda.connector.generator.dsl.PropertyBinding.ZeebeSubscriptionProperty;
+import io.camunda.connector.generator.dsl.PropertyCondition.Equals;
 import java.util.List;
 
 public class CommonProperties {
@@ -136,5 +137,45 @@ public class CommonProperties {
         .group("correlation")
         .value("notRequired")
         .binding(new ZeebeProperty("correlationRequired"));
+  }
+
+  public static PropertyBuilder deduplicationModeManualFlag() {
+    return BooleanProperty.builder()
+        .id("deduplicationModeManualFlag")
+        .label("Manual mode")
+        .group("deduplication")
+        .description(
+            "By default, similar connectors receive the same deduplication ID. Customize by activating manual mode")
+        .value(false)
+        .binding(new ZeebeProperty("deduplicationModeManualFlag"));
+  }
+
+  public static PropertyBuilder deduplicationModeManual() {
+    return HiddenProperty.builder()
+        .id("deduplicationModeManual")
+        .group("deduplication")
+        .value("MANUAL")
+        .condition(new Equals("deduplicationModeManualFlag", true))
+        .binding(new ZeebeProperty("deduplicationMode"));
+  }
+
+  public static PropertyBuilder deduplicationModeAuto() {
+    return HiddenProperty.builder()
+        .id("deduplicationModeAuto")
+        .group("deduplication")
+        .value("AUTO")
+        .condition(new Equals("deduplicationModeManualFlag", false))
+        .binding(new ZeebeProperty("deduplicationMode"));
+  }
+
+  public static PropertyBuilder deduplicationId() {
+    return StringProperty.builder()
+        .id("deduplicationId")
+        .label("Deduplication ID")
+        .group("deduplication")
+        .feel(FeelMode.disabled)
+        .binding(new ZeebeProperty("deduplicationId"))
+        .constraints(PropertyConstraints.builder().notEmpty(true).build())
+        .condition(new Equals("deduplicationModeManualFlag", true));
   }
 }

--- a/element-template-generator/core/src/main/java/io/camunda/connector/generator/dsl/CommonProperties.java
+++ b/element-template-generator/core/src/main/java/io/camunda/connector/generator/dsl/CommonProperties.java
@@ -22,6 +22,7 @@ import io.camunda.connector.generator.dsl.PropertyBinding.ZeebeProperty;
 import io.camunda.connector.generator.dsl.PropertyBinding.ZeebeSubscriptionProperty;
 import io.camunda.connector.generator.dsl.PropertyCondition.Equals;
 import io.camunda.connector.generator.dsl.PropertyCondition.IsActive;
+import io.camunda.connector.generator.dsl.PropertyConstraints.Pattern;
 import java.util.List;
 
 public class CommonProperties {
@@ -158,7 +159,14 @@ public class CommonProperties {
         .group("deduplication")
         .feel(FeelMode.disabled)
         .binding(new ZeebeProperty("deduplicationId"))
-        .constraints(PropertyConstraints.builder().notEmpty(true).build())
+        .constraints(
+            PropertyConstraints.builder()
+                .notEmpty(true)
+                .pattern(
+                    new Pattern(
+                        "^[a-zA-Z0-9_-]+$",
+                        "Only alphanumeric characters, dashes, and underscores are allowed"))
+                .build())
         .condition(new Equals("deduplicationModeManualFlag", true));
   }
 

--- a/element-template-generator/core/src/main/java/io/camunda/connector/generator/dsl/CommonProperties.java
+++ b/element-template-generator/core/src/main/java/io/camunda/connector/generator/dsl/CommonProperties.java
@@ -21,6 +21,7 @@ import io.camunda.connector.generator.dsl.Property.FeelMode;
 import io.camunda.connector.generator.dsl.PropertyBinding.ZeebeProperty;
 import io.camunda.connector.generator.dsl.PropertyBinding.ZeebeSubscriptionProperty;
 import io.camunda.connector.generator.dsl.PropertyCondition.Equals;
+import io.camunda.connector.generator.dsl.PropertyCondition.IsActive;
 import java.util.List;
 
 public class CommonProperties {
@@ -150,24 +151,6 @@ public class CommonProperties {
         .binding(new ZeebeProperty("deduplicationModeManualFlag"));
   }
 
-  public static PropertyBuilder deduplicationModeManual() {
-    return HiddenProperty.builder()
-        .id("deduplicationModeManual")
-        .group("deduplication")
-        .value("MANUAL")
-        .condition(new Equals("deduplicationModeManualFlag", true))
-        .binding(new ZeebeProperty("deduplicationMode"));
-  }
-
-  public static PropertyBuilder deduplicationModeAuto() {
-    return HiddenProperty.builder()
-        .id("deduplicationModeAuto")
-        .group("deduplication")
-        .value("AUTO")
-        .condition(new Equals("deduplicationModeManualFlag", false))
-        .binding(new ZeebeProperty("deduplicationMode"));
-  }
-
   public static PropertyBuilder deduplicationId() {
     return StringProperty.builder()
         .id("deduplicationId")
@@ -177,5 +160,23 @@ public class CommonProperties {
         .binding(new ZeebeProperty("deduplicationId"))
         .constraints(PropertyConstraints.builder().notEmpty(true).build())
         .condition(new Equals("deduplicationModeManualFlag", true));
+  }
+
+  public static PropertyBuilder deduplicationModeManual() {
+    return HiddenProperty.builder()
+        .id("deduplicationModeManual")
+        .group("deduplication")
+        .value("MANUAL")
+        .condition(new IsActive("deduplicationId", true))
+        .binding(new ZeebeProperty("deduplicationMode"));
+  }
+
+  public static PropertyBuilder deduplicationModeAuto() {
+    return HiddenProperty.builder()
+        .id("deduplicationModeAuto")
+        .group("deduplication")
+        .value("AUTO")
+        .condition(new IsActive("deduplicationId", false))
+        .binding(new ZeebeProperty("deduplicationMode"));
   }
 }

--- a/element-template-generator/core/src/main/java/io/camunda/connector/generator/dsl/DropdownProperty.java
+++ b/element-template-generator/core/src/main/java/io/camunda/connector/generator/dsl/DropdownProperty.java
@@ -36,6 +36,7 @@ public final class DropdownProperty extends Property {
       String group,
       PropertyBinding binding,
       PropertyCondition condition,
+      String tooltip,
       List<DropdownChoice> choices) {
     super(
         name,
@@ -49,6 +50,7 @@ public final class DropdownProperty extends Property {
         group,
         binding,
         condition,
+        tooltip,
         TYPE);
     this.choices = choices;
   }
@@ -75,18 +77,22 @@ public final class DropdownProperty extends Property {
     }
 
     public DropdownProperty build() {
+      if (value != null && !(value instanceof String)) {
+        throw new IllegalStateException("Value of a dropdown property must be a string");
+      }
       return new DropdownProperty(
           id,
           label,
           description,
           optional,
-          value,
+          (String) value,
           generatedValue,
           constraints,
           feel,
           group,
           binding,
           condition,
+          tooltip,
           choices);
     }
   }

--- a/element-template-generator/core/src/main/java/io/camunda/connector/generator/dsl/HiddenProperty.java
+++ b/element-template-generator/core/src/main/java/io/camunda/connector/generator/dsl/HiddenProperty.java
@@ -44,6 +44,7 @@ public final class HiddenProperty extends Property {
         group,
         binding,
         condition,
+        null,
         TYPE);
   }
 
@@ -56,12 +57,15 @@ public final class HiddenProperty extends Property {
     private HiddenPropertyBuilder() {}
 
     public HiddenProperty build() {
+      if (value != null && !(value instanceof String)) {
+        throw new IllegalStateException("Value of a hidden property must be a string");
+      }
       return new HiddenProperty(
           id,
           label,
           description,
           optional,
-          value,
+          (String) value,
           generatedValue,
           constraints,
           feel,

--- a/element-template-generator/core/src/main/java/io/camunda/connector/generator/dsl/Property.java
+++ b/element-template-generator/core/src/main/java/io/camunda/connector/generator/dsl/Property.java
@@ -29,13 +29,14 @@ public abstract sealed class Property
   protected final String label;
   protected final String description;
   protected final Boolean optional;
-  protected final String value;
+  protected final Object value;
   protected final GeneratedValue generatedValue;
   protected final PropertyConstraints constraints;
   protected final FeelMode feel;
   protected final String group;
   protected final PropertyBinding binding;
   protected final PropertyCondition condition;
+  protected final String tooltip;
 
   protected final String type;
 
@@ -55,13 +56,14 @@ public abstract sealed class Property
       String label,
       String description,
       Boolean optional,
-      String value,
+      Object value,
       GeneratedValue generatedValue,
       PropertyConstraints constraints,
       FeelMode feel,
       String group,
       PropertyBinding binding,
       PropertyCondition condition,
+      String tooltip,
       String type) {
     this.id = id;
     this.label = label;
@@ -74,6 +76,7 @@ public abstract sealed class Property
     this.group = group;
     this.binding = binding;
     this.condition = condition;
+    this.tooltip = tooltip;
     this.type = type;
   }
 
@@ -93,7 +96,7 @@ public abstract sealed class Property
     return optional;
   }
 
-  public String getValue() {
+  public Object getValue() {
     return value;
   }
 
@@ -126,6 +129,10 @@ public abstract sealed class Property
 
   public PropertyCondition getCondition() {
     return condition;
+  }
+
+  public String getTooltip() {
+    return tooltip;
   }
 
   @Override
@@ -163,7 +170,8 @@ public abstract sealed class Property
         feel,
         group,
         binding,
-        type);
+        type,
+        tooltip);
   }
 
   @Override
@@ -197,6 +205,12 @@ public abstract sealed class Property
         + binding
         + ", type='"
         + type
+        + '\''
+        + ", condition='"
+        + condition
+        + '\''
+        + ", tooltip='"
+        + tooltip
         + '\''
         + '}';
   }

--- a/element-template-generator/core/src/main/java/io/camunda/connector/generator/dsl/PropertyBuilder.java
+++ b/element-template-generator/core/src/main/java/io/camunda/connector/generator/dsl/PropertyBuilder.java
@@ -24,7 +24,7 @@ public abstract class PropertyBuilder {
   protected String label;
   protected String description;
   protected Boolean optional;
-  protected String value;
+  protected Object value;
   protected Property.GeneratedValue generatedValue;
   protected PropertyConstraints constraints;
   protected FeelMode feel;
@@ -32,6 +32,7 @@ public abstract class PropertyBuilder {
   protected PropertyBinding binding;
   protected String type;
   protected PropertyCondition condition;
+  protected String tooltip;
 
   protected PropertyBuilder() {}
 
@@ -67,7 +68,7 @@ public abstract class PropertyBuilder {
     return this;
   }
 
-  public PropertyBuilder value(String value) {
+  public PropertyBuilder value(Object value) {
     if (generatedValue != null) {
       throw new IllegalStateException("Generated value is already set");
     }
@@ -105,6 +106,11 @@ public abstract class PropertyBuilder {
 
   public PropertyBuilder group(String group) {
     this.group = group;
+    return this;
+  }
+
+  public PropertyBuilder tooltip(String tooltip) {
+    this.tooltip = tooltip;
     return this;
   }
 

--- a/element-template-generator/core/src/main/java/io/camunda/connector/generator/dsl/PropertyCondition.java
+++ b/element-template-generator/core/src/main/java/io/camunda/connector/generator/dsl/PropertyCondition.java
@@ -28,7 +28,7 @@ public sealed interface PropertyCondition {
     }
   }
 
-  record Equals(String property, String equals) implements PropertyCondition {
+  record Equals(String property, Object equals) implements PropertyCondition {
 
     public String getType() {
       return "simple";

--- a/element-template-generator/core/src/main/java/io/camunda/connector/generator/dsl/PropertyCondition.java
+++ b/element-template-generator/core/src/main/java/io/camunda/connector/generator/dsl/PropertyCondition.java
@@ -41,4 +41,11 @@ public sealed interface PropertyCondition {
       this(List.of(conditions));
     }
   }
+
+  record IsActive(String property, boolean isActive) implements PropertyCondition {
+
+    public String getType() {
+      return "simple";
+    }
+  }
 }

--- a/element-template-generator/core/src/main/java/io/camunda/connector/generator/dsl/PropertyGroup.java
+++ b/element-template-generator/core/src/main/java/io/camunda/connector/generator/dsl/PropertyGroup.java
@@ -17,6 +17,8 @@
 package io.camunda.connector.generator.dsl;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import io.camunda.connector.generator.dsl.PropertyBinding.ZeebeProperty;
 import io.camunda.connector.generator.dsl.PropertyBinding.ZeebeTaskDefinition;
 import io.camunda.connector.generator.dsl.PropertyBinding.ZeebeTaskHeader;
@@ -26,7 +28,13 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.Stream;
 
-public record PropertyGroup(String id, String label, @JsonIgnore List<Property> properties) {
+@JsonInclude(Include.NON_NULL)
+public record PropertyGroup(
+    String id,
+    String label,
+    @JsonIgnore List<Property> properties,
+    String tooltip,
+    Boolean openByDefault) {
 
   public static PropertyGroup OUTPUT_GROUP_OUTBOUND =
       PropertyGroup.builder()
@@ -112,6 +120,19 @@ public record PropertyGroup(String id, String label, @JsonIgnore List<Property> 
               CommonProperties.messageNameUuidHidden().build())
           .build();
 
+  public static PropertyGroup DEDUPLICATION_GROUP =
+      PropertyGroup.builder()
+          .id("deduplication")
+          .label("Deduplication")
+          .tooltip(
+              "Deduplication allows you to configure multiple inbound connector elements to reuse the same backend (consumer/thread/endpoint) by sharing the same deduplication ID.")
+          .properties(
+              CommonProperties.deduplicationModeManualFlag().build(),
+              CommonProperties.deduplicationModeManual().build(),
+              CommonProperties.deduplicationModeAuto().build(),
+              CommonProperties.deduplicationId().build())
+          .build();
+
   public PropertyGroup {
     if (id == null) {
       throw new IllegalArgumentException("id is required");
@@ -132,6 +153,8 @@ public record PropertyGroup(String id, String label, @JsonIgnore List<Property> 
 
     private String id;
     private String label;
+    private String tooltip;
+    private Boolean openByDefault;
     private final List<Property> properties = new ArrayList<>();
 
     private PropertyGroupBuilder() {}
@@ -143,6 +166,16 @@ public record PropertyGroup(String id, String label, @JsonIgnore List<Property> 
 
     public PropertyGroupBuilder label(String label) {
       this.label = label;
+      return this;
+    }
+
+    public PropertyGroupBuilder tooltip(String tooltip) {
+      this.tooltip = tooltip;
+      return this;
+    }
+
+    public PropertyGroupBuilder openByDefault(Boolean openByDefault) {
+      this.openByDefault = openByDefault;
       return this;
     }
 
@@ -180,7 +213,7 @@ public record PropertyGroup(String id, String label, @JsonIgnore List<Property> 
     }
 
     public PropertyGroup build() {
-      return new PropertyGroup(id, label, properties);
+      return new PropertyGroup(id, label, properties, tooltip, openByDefault);
     }
 
     private void requireIdSet() {

--- a/element-template-generator/core/src/main/java/io/camunda/connector/generator/dsl/PropertyGroup.java
+++ b/element-template-generator/core/src/main/java/io/camunda/connector/generator/dsl/PropertyGroup.java
@@ -128,9 +128,9 @@ public record PropertyGroup(
               "Deduplication allows you to configure multiple inbound connector elements to reuse the same backend (consumer/thread/endpoint) by sharing the same deduplication ID.")
           .properties(
               CommonProperties.deduplicationModeManualFlag().build(),
+              CommonProperties.deduplicationId().build(),
               CommonProperties.deduplicationModeManual().build(),
-              CommonProperties.deduplicationModeAuto().build(),
-              CommonProperties.deduplicationId().build())
+              CommonProperties.deduplicationModeAuto().build())
           .build();
 
   public PropertyGroup {

--- a/element-template-generator/core/src/main/java/io/camunda/connector/generator/dsl/StringProperty.java
+++ b/element-template-generator/core/src/main/java/io/camunda/connector/generator/dsl/StringProperty.java
@@ -31,7 +31,8 @@ public final class StringProperty extends Property {
       FeelMode feel,
       String group,
       PropertyBinding binding,
-      PropertyCondition condition) {
+      PropertyCondition condition,
+      String tooltip) {
     super(
         name,
         label,
@@ -44,6 +45,7 @@ public final class StringProperty extends Property {
         group,
         binding,
         condition,
+        tooltip,
         TYPE);
   }
 
@@ -59,18 +61,22 @@ public final class StringProperty extends Property {
       if (feel == null) {
         feel = FeelMode.optional;
       }
+      if (value != null && !(value instanceof String)) {
+        throw new IllegalStateException("Value of a string property must be a string");
+      }
       return new StringProperty(
           id,
           label,
           description,
           optional,
-          value,
+          (String) value,
           generatedValue,
           constraints,
           feel,
           group,
           binding,
-          condition);
+          condition,
+          tooltip);
     }
   }
 }

--- a/element-template-generator/core/src/main/java/io/camunda/connector/generator/dsl/TextProperty.java
+++ b/element-template-generator/core/src/main/java/io/camunda/connector/generator/dsl/TextProperty.java
@@ -31,7 +31,8 @@ public final class TextProperty extends Property {
       FeelMode feel,
       String group,
       PropertyBinding binding,
-      PropertyCondition condition) {
+      PropertyCondition condition,
+      String tooltip) {
     super(
         name,
         label,
@@ -44,6 +45,7 @@ public final class TextProperty extends Property {
         group,
         binding,
         condition,
+        tooltip,
         TYPE);
   }
 
@@ -59,18 +61,22 @@ public final class TextProperty extends Property {
       if (feel == null) {
         feel = FeelMode.optional;
       }
+      if (value != null && !(value instanceof String)) {
+        throw new IllegalStateException("Value of a text property must be a string");
+      }
       return new TextProperty(
           id,
           label,
           description,
           optional,
-          value,
+          (String) value,
           generatedValue,
           constraints,
           feel,
           group,
           binding,
-          condition);
+          condition,
+          tooltip);
     }
   }
 }

--- a/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/annotation/ElementTemplate.java
+++ b/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/annotation/ElementTemplate.java
@@ -96,6 +96,10 @@ public @interface ElementTemplate {
     String id();
 
     String label() default "";
+
+    String tooltip() default "";
+
+    boolean openByDefault() default true;
   }
 
   @interface ConnectorElementType {

--- a/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/annotation/TemplateProperty.java
+++ b/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/annotation/TemplateProperty.java
@@ -135,15 +135,13 @@ public @interface TemplateProperty {
   @interface PropertyCondition {
     String property();
 
-    /** For string properties */
     String equals() default "";
-
-    /** For boolean properties */
-    boolean equalsBoolean() default true;
 
     String[] oneOf() default {};
 
     NestedPropertyCondition[] allMatch() default {};
+
+    boolean isActive() default false;
   }
 
   @interface NestedPropertyCondition {
@@ -152,10 +150,9 @@ public @interface TemplateProperty {
     /** For string properties */
     String equals() default "";
 
-    /** For boolean properties */
-    boolean equalsBoolean() default true;
-
     String[] oneOf() default {};
+
+    boolean isActive() default false;
   }
 
   @interface DropdownPropertyChoice {

--- a/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/annotation/TemplateProperty.java
+++ b/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/annotation/TemplateProperty.java
@@ -78,6 +78,9 @@ public @interface TemplateProperty {
   /** Default value for the property */
   String defaultValue() default "";
 
+  /** Resulting JSON type for the default value */
+  DefaultValueType defaultValueType() default DefaultValueType.String;
+
   /**
    * Group ID for the property.
    *
@@ -108,6 +111,9 @@ public @interface TemplateProperty {
    */
   PropertyConstraints constraints() default @PropertyConstraints;
 
+  /** Tooltip for the property */
+  String tooltip() default "";
+
   enum PropertyType {
     Boolean,
     Dropdown,
@@ -117,6 +123,11 @@ public @interface TemplateProperty {
     Unknown
   }
 
+  enum DefaultValueType {
+    String,
+    Boolean
+  }
+
   @interface PropertyBinding {
     String name();
   }
@@ -124,7 +135,25 @@ public @interface TemplateProperty {
   @interface PropertyCondition {
     String property();
 
+    /** For string properties */
     String equals() default "";
+
+    /** For boolean properties */
+    boolean equalsBoolean() default true;
+
+    String[] oneOf() default {};
+
+    NestedPropertyCondition[] allMatch() default {};
+  }
+
+  @interface NestedPropertyCondition {
+    String property();
+
+    /** For string properties */
+    String equals() default "";
+
+    /** For boolean properties */
+    boolean equalsBoolean() default true;
 
     String[] oneOf() default {};
   }

--- a/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/processor/TemplatePropertyFieldProcessor.java
+++ b/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/processor/TemplatePropertyFieldProcessor.java
@@ -108,8 +108,9 @@ public class TemplatePropertyFieldProcessor implements FieldProcessor {
               .map(TemplatePropertyFieldProcessor::transformToNestedCondition)
               .toList());
     } else {
-      return new PropertyCondition.Equals(
-          conditionAnnotation.property(), conditionAnnotation.equalsBoolean());
+      // isActive always has a value, so we consider it is selected if nothing else is set
+      return new PropertyCondition.IsActive(
+          conditionAnnotation.property(), conditionAnnotation.isActive());
     }
   }
 
@@ -127,8 +128,9 @@ public class TemplatePropertyFieldProcessor implements FieldProcessor {
       return new PropertyCondition.OneOf(
           conditionAnnotation.property(), Arrays.asList(conditionAnnotation.oneOf()));
     } else {
-      return new PropertyCondition.Equals(
-          conditionAnnotation.property(), conditionAnnotation.equalsBoolean());
+      // isActive always has a value, so we consider it is selected if nothing else is set
+      return new PropertyCondition.IsActive(
+          conditionAnnotation.property(), conditionAnnotation.isActive());
     }
   }
 

--- a/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/processor/TemplatePropertyFieldProcessor.java
+++ b/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/processor/TemplatePropertyFieldProcessor.java
@@ -22,6 +22,7 @@ import io.camunda.connector.generator.dsl.PropertyBuilder;
 import io.camunda.connector.generator.dsl.PropertyCondition;
 import io.camunda.connector.generator.dsl.PropertyConstraints;
 import io.camunda.connector.generator.java.annotation.TemplateProperty;
+import io.camunda.connector.generator.java.annotation.TemplateProperty.NestedPropertyCondition;
 import io.camunda.connector.generator.java.util.TemplateGenerationContext;
 import java.lang.reflect.Field;
 import java.util.Arrays;
@@ -53,7 +54,17 @@ public class TemplatePropertyFieldProcessor implements FieldProcessor {
       builder.description(annotation.description());
     }
     if (!annotation.defaultValue().isBlank()) {
-      builder.value(annotation.defaultValue());
+      var value = annotation.defaultValue();
+      switch (annotation.defaultValueType()) {
+        case Boolean:
+          builder.value(Boolean.parseBoolean(value));
+          break;
+        case String:
+          builder.value(value);
+          break;
+        default:
+          throw new IllegalStateException("Unexpected value: " + annotation.defaultValueType());
+      }
     }
     if (!annotation.group().isBlank()) {
       builder.group(annotation.group());
@@ -71,12 +82,14 @@ public class TemplatePropertyFieldProcessor implements FieldProcessor {
 
   private PropertyCondition buildCondition(TemplateProperty propertyAnnotation) {
     var conditionAnnotation = propertyAnnotation.condition();
-    if (conditionAnnotation.property().isBlank()) {
+    if (conditionAnnotation.property().isBlank() && conditionAnnotation.allMatch().length == 0) {
       return null;
     }
-    if (conditionAnnotation.equals().isBlank() && conditionAnnotation.oneOf().length == 0) {
-      throw new IllegalStateException("InvalidCondition must have either 'equals' or 'oneOf' set");
-    }
+    validateCondition(
+        conditionAnnotation.property(),
+        conditionAnnotation.equals(),
+        conditionAnnotation.oneOf(),
+        conditionAnnotation.allMatch());
     return transformToCondition(conditionAnnotation);
   }
 
@@ -86,9 +99,65 @@ public class TemplatePropertyFieldProcessor implements FieldProcessor {
     if (!conditionAnnotation.equals().isBlank()) {
       return new PropertyCondition.Equals(
           conditionAnnotation.property(), conditionAnnotation.equals());
-    } else {
+    } else if (conditionAnnotation.oneOf().length > 0) {
       return new PropertyCondition.OneOf(
           conditionAnnotation.property(), Arrays.asList(conditionAnnotation.oneOf()));
+    } else if (conditionAnnotation.allMatch().length > 0) {
+      return new PropertyCondition.AllMatch(
+          Arrays.stream(conditionAnnotation.allMatch())
+              .map(TemplatePropertyFieldProcessor::transformToNestedCondition)
+              .toList());
+    } else {
+      return new PropertyCondition.Equals(
+          conditionAnnotation.property(), conditionAnnotation.equalsBoolean());
+    }
+  }
+
+  public static PropertyCondition transformToNestedCondition(
+      TemplateProperty.NestedPropertyCondition conditionAnnotation) {
+    validateCondition(
+        conditionAnnotation.property(),
+        conditionAnnotation.equals(),
+        conditionAnnotation.oneOf(),
+        new NestedPropertyCondition[] {});
+    if (!conditionAnnotation.equals().isBlank()) {
+      return new PropertyCondition.Equals(
+          conditionAnnotation.property(), conditionAnnotation.equals());
+    } else if (conditionAnnotation.oneOf().length > 0) {
+      return new PropertyCondition.OneOf(
+          conditionAnnotation.property(), Arrays.asList(conditionAnnotation.oneOf()));
+    } else {
+      return new PropertyCondition.Equals(
+          conditionAnnotation.property(), conditionAnnotation.equalsBoolean());
+    }
+  }
+
+  private static void validateCondition(
+      String property, String equals, String[] oneOf, NestedPropertyCondition[] allMatch) {
+    var equalsSet = !equals.isBlank();
+    var oneOfSet = oneOf != null && oneOf.length > 0;
+    var allMatchSet = allMatch != null && allMatch.length > 0;
+    // equalsBoolean always has a value, so it's not included in the check
+    // if everything else is not set, we consider it an equalsBoolean condition
+
+    if (equalsSet && oneOfSet || equalsSet && allMatchSet || oneOfSet && allMatchSet) {
+      throw new IllegalStateException(
+          "Condition must have only one of 'equals', 'oneOf', 'isActive', or 'allMatch' set");
+    }
+    if (equalsSet && property.isBlank()) {
+      throw new IllegalStateException("Condition 'equals' must have 'property' set");
+    }
+
+    if (oneOfSet && property.isBlank()) {
+      throw new IllegalStateException("Condition 'oneOf' must have 'property' set");
+    }
+
+    if (allMatchSet && !property.isBlank()) {
+      throw new IllegalStateException("Condition 'allMatch' must not have 'property' set");
+    }
+
+    if (!equalsSet && !oneOfSet && !allMatchSet && property.isBlank()) {
+      throw new IllegalStateException("Condition 'isActive' must have 'property' set");
     }
   }
 

--- a/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/util/ConfigurationUtil.java
+++ b/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/util/ConfigurationUtil.java
@@ -20,6 +20,7 @@ import io.camunda.connector.generator.api.GeneratorConfiguration;
 import io.camunda.connector.generator.api.GeneratorConfiguration.ConnectorElementType;
 import io.camunda.connector.generator.java.annotation.ElementTemplate;
 import java.util.Arrays;
+import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -48,7 +49,8 @@ public class ConfigurationUtil {
     if (override.elementTypes() != null && !override.elementTypes().isEmpty()) {
       elementTypes = override.elementTypes();
     }
+    var features = Optional.ofNullable(override.features()).orElseGet(Map::of);
     return new GeneratorConfiguration(
-        connectorMode, templateId, templateName, templateVersion, elementTypes);
+        connectorMode, templateId, templateName, templateVersion, elementTypes, features);
   }
 }

--- a/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/util/TemplatePropertiesUtil.java
+++ b/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/util/TemplatePropertiesUtil.java
@@ -172,7 +172,7 @@ public class TemplatePropertiesUtil {
 
   private static PropertyBuilder buildProperty(Field field, TemplateGenerationContext context) {
     var annotation = field.getAnnotation(TemplateProperty.class);
-    String name, label;
+    String name, label, tooltip = null;
     String bindingName = field.getName();
     if (annotation != null) {
       if (annotation.ignore()) {
@@ -191,6 +191,9 @@ public class TemplatePropertiesUtil {
       if (!annotation.binding().name().isBlank()) {
         bindingName = annotation.binding().name();
       }
+      if (!annotation.tooltip().isBlank()) {
+        tooltip = annotation.tooltip();
+      }
     } else {
       name = field.getName();
       label = transformIdIntoLabel(name);
@@ -200,6 +203,7 @@ public class TemplatePropertiesUtil {
         createPropertyBuilder(field, annotation)
             .id(name)
             .label(label)
+            .tooltip(tooltip)
             .binding(createBinding(bindingName, context));
 
     for (FieldProcessor processor : fieldProcessors) {

--- a/element-template-generator/core/src/test/java/io/camunda/connector/generator/dsl/ElementTemplateSerializationTest.java
+++ b/element-template-generator/core/src/test/java/io/camunda/connector/generator/dsl/ElementTemplateSerializationTest.java
@@ -101,6 +101,7 @@ public class ElementTemplateSerializationTest {
                 PropertyGroup.builder()
                     .id("output")
                     .label("Output Mapping")
+                    .tooltip("Map the response to process variables")
                     .properties(
                         StringProperty.builder()
                             .label("Result Variable")

--- a/element-template-generator/core/src/test/java/io/camunda/connector/generator/java/InboundClassBasedTemplateGeneratorTest.java
+++ b/element-template-generator/core/src/test/java/io/camunda/connector/generator/java/InboundClassBasedTemplateGeneratorTest.java
@@ -34,6 +34,7 @@ import io.camunda.connector.generator.dsl.PropertyBinding.MessageProperty;
 import io.camunda.connector.generator.dsl.PropertyBinding.ZeebeProperty;
 import io.camunda.connector.generator.dsl.PropertyBinding.ZeebeSubscriptionProperty;
 import io.camunda.connector.generator.dsl.PropertyCondition.Equals;
+import io.camunda.connector.generator.dsl.PropertyCondition.IsActive;
 import io.camunda.connector.generator.dsl.StringProperty;
 import io.camunda.connector.generator.java.example.inbound.MyConnectorExecutable;
 import java.util.List;
@@ -374,7 +375,7 @@ public class InboundClassBasedTemplateGeneratorTest extends BaseTest {
           .isEqualTo("deduplicationMode");
       assertThat(manualModeProperty.getValue()).isEqualTo("MANUAL");
       assertThat(manualModeProperty.getCondition())
-          .isEqualTo(new Equals("deduplicationModeManualFlag", true));
+          .isEqualTo(new IsActive("deduplicationId", true));
 
       var autoModeProperty = getPropertyById("deduplicationModeAuto", template);
       assertThat(autoModeProperty).isNotNull();
@@ -383,8 +384,7 @@ public class InboundClassBasedTemplateGeneratorTest extends BaseTest {
       assertThat(((ZeebeProperty) autoModeProperty.getBinding()).name())
           .isEqualTo("deduplicationMode");
       assertThat(autoModeProperty.getValue()).isEqualTo("AUTO");
-      assertThat(autoModeProperty.getCondition())
-          .isEqualTo(new Equals("deduplicationModeManualFlag", false));
+      assertThat(autoModeProperty.getCondition()).isEqualTo(new IsActive("deduplicationId", false));
 
       var deduplicationKeyProperty = getPropertyById("deduplicationId", template);
       assertThat(deduplicationKeyProperty).isNotNull();

--- a/element-template-generator/core/src/test/java/io/camunda/connector/generator/java/InboundClassBasedTemplateGeneratorTest.java
+++ b/element-template-generator/core/src/test/java/io/camunda/connector/generator/java/InboundClassBasedTemplateGeneratorTest.java
@@ -23,9 +23,11 @@ import io.camunda.connector.generator.BaseTest;
 import io.camunda.connector.generator.api.GeneratorConfiguration;
 import io.camunda.connector.generator.api.GeneratorConfiguration.ConnectorElementType;
 import io.camunda.connector.generator.api.GeneratorConfiguration.ConnectorMode;
+import io.camunda.connector.generator.api.GeneratorConfiguration.GenerationFeature;
 import io.camunda.connector.generator.dsl.BpmnType;
 import io.camunda.connector.generator.dsl.DropdownProperty;
 import io.camunda.connector.generator.dsl.DropdownProperty.DropdownChoice;
+import io.camunda.connector.generator.dsl.ElementTemplate;
 import io.camunda.connector.generator.dsl.Property.FeelMode;
 import io.camunda.connector.generator.dsl.PropertyBinding;
 import io.camunda.connector.generator.dsl.PropertyBinding.MessageProperty;
@@ -35,6 +37,7 @@ import io.camunda.connector.generator.dsl.PropertyCondition.Equals;
 import io.camunda.connector.generator.dsl.StringProperty;
 import io.camunda.connector.generator.java.example.inbound.MyConnectorExecutable;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -138,7 +141,9 @@ public class InboundClassBasedTemplateGeneratorTest extends BaseTest {
       var type =
           new ConnectorElementType(
               Set.of(BpmnType.START_EVENT), BpmnType.MESSAGE_START_EVENT, null, null);
-      var config = new GeneratorConfiguration(ConnectorMode.NORMAL, null, null, null, Set.of(type));
+      var config =
+          new GeneratorConfiguration(
+              ConnectorMode.NORMAL, null, null, null, Set.of(type), Map.of());
 
       // when
       var templates = generator.generate(MyConnectorExecutable.class, config);
@@ -159,7 +164,9 @@ public class InboundClassBasedTemplateGeneratorTest extends BaseTest {
       // given
       var type =
           new ConnectorElementType(Set.of(BpmnType.START_EVENT), BpmnType.START_EVENT, null, null);
-      var config = new GeneratorConfiguration(ConnectorMode.NORMAL, null, null, null, Set.of(type));
+      var config =
+          new GeneratorConfiguration(
+              ConnectorMode.NORMAL, null, null, null, Set.of(type), Map.of());
 
       // when
       var templates = generator.generate(MyConnectorExecutable.class, config);
@@ -183,7 +190,8 @@ public class InboundClassBasedTemplateGeneratorTest extends BaseTest {
           new ConnectorElementType(
               Set.of(BpmnType.BOUNDARY_EVENT), BpmnType.BOUNDARY_EVENT, null, null);
       var config =
-          new GeneratorConfiguration(ConnectorMode.NORMAL, null, null, null, Set.of(type1, type2));
+          new GeneratorConfiguration(
+              ConnectorMode.NORMAL, null, null, null, Set.of(type1, type2), Map.of());
 
       // when
       var templates = generator.generate(MyConnectorExecutable.class, config);
@@ -216,7 +224,9 @@ public class InboundClassBasedTemplateGeneratorTest extends BaseTest {
       var type =
           new ConnectorElementType(
               Set.of(BpmnType.START_EVENT), BpmnType.MESSAGE_START_EVENT, null, null);
-      var config = new GeneratorConfiguration(ConnectorMode.NORMAL, null, null, null, Set.of(type));
+      var config =
+          new GeneratorConfiguration(
+              ConnectorMode.NORMAL, null, null, null, Set.of(type), Map.of());
 
       // when
       var templates = generator.generate(MyConnectorExecutable.class, config);
@@ -267,7 +277,8 @@ public class InboundClassBasedTemplateGeneratorTest extends BaseTest {
     var type =
         new ConnectorElementType(
             Set.of(BpmnType.START_EVENT), BpmnType.MESSAGE_START_EVENT, null, null);
-    var config = new GeneratorConfiguration(ConnectorMode.NORMAL, null, null, null, Set.of(type));
+    var config =
+        new GeneratorConfiguration(ConnectorMode.NORMAL, null, null, null, Set.of(type), Map.of());
 
     // when
     var template = generator.generate(MyConnectorExecutable.class, config).getFirst();
@@ -280,5 +291,109 @@ public class InboundClassBasedTemplateGeneratorTest extends BaseTest {
     assertThat(property.getFeel()).isEqualTo(null);
     assertThat(property.getBinding()).isEqualTo(new PropertyBinding.ZeebeProperty("prop1"));
     assertThat(property.getConstraints()).isNull();
+  }
+
+  @Nested
+  class Deduplication {
+
+    @Test
+    void deduplicationFeatureFlagNotSet_shouldNotAddDeduplicationProperties() {
+      // given
+      var type =
+          new ConnectorElementType(
+              Set.of(BpmnType.START_EVENT), BpmnType.MESSAGE_START_EVENT, null, null);
+      var config =
+          new GeneratorConfiguration(
+              ConnectorMode.NORMAL, null, null, null, Set.of(type), Map.of());
+
+      // when
+      var template = generator.generate(MyConnectorExecutable.class, config).getFirst();
+
+      // then
+      assertThrows(Exception.class, () -> assertDeduplicationProperties(template));
+    }
+
+    @Test
+    void deduplicationFeatureFlagTrue_shouldAddDeduplicationProperties() {
+      // given
+      var type =
+          new ConnectorElementType(
+              Set.of(BpmnType.START_EVENT), BpmnType.MESSAGE_START_EVENT, null, null);
+      var config =
+          new GeneratorConfiguration(
+              ConnectorMode.NORMAL,
+              null,
+              null,
+              null,
+              Set.of(type),
+              Map.of(GenerationFeature.INBOUND_DEDUPLICATION, true));
+
+      // when
+      var template = generator.generate(MyConnectorExecutable.class, config).getFirst();
+
+      // then
+      assertDeduplicationProperties(template);
+    }
+
+    @Test
+    void deduplicationFeatureFlagFalse_shouldNotAddDeduplicationProperties() {
+      // given
+      var type =
+          new ConnectorElementType(
+              Set.of(BpmnType.START_EVENT), BpmnType.MESSAGE_START_EVENT, null, null);
+      var config =
+          new GeneratorConfiguration(
+              ConnectorMode.NORMAL,
+              null,
+              null,
+              null,
+              Set.of(type),
+              Map.of(GenerationFeature.INBOUND_DEDUPLICATION, false));
+
+      // when
+      var template = generator.generate(MyConnectorExecutable.class, config).getFirst();
+
+      // then
+      assertThrows(Exception.class, () -> assertDeduplicationProperties(template));
+    }
+
+    private void assertDeduplicationProperties(ElementTemplate template) {
+      var manualModeFlagProperty = getPropertyById("deduplicationModeManualFlag", template);
+      assertThat(manualModeFlagProperty).isNotNull();
+      assertThat(manualModeFlagProperty.getType()).isEqualTo("Boolean");
+      assertThat(manualModeFlagProperty.getBinding().type()).isEqualTo("zeebe:property");
+      assertThat(((ZeebeProperty) manualModeFlagProperty.getBinding()).name())
+          .isEqualTo("deduplicationModeManualFlag");
+      assertThat(manualModeFlagProperty.getValue()).isEqualTo(Boolean.FALSE);
+
+      var manualModeProperty = getPropertyById("deduplicationModeManual", template);
+      assertThat(manualModeProperty).isNotNull();
+      assertThat(manualModeProperty.getType()).isEqualTo("Hidden");
+      assertThat(manualModeProperty.getBinding().type()).isEqualTo("zeebe:property");
+      assertThat(((ZeebeProperty) manualModeProperty.getBinding()).name())
+          .isEqualTo("deduplicationMode");
+      assertThat(manualModeProperty.getValue()).isEqualTo("MANUAL");
+      assertThat(manualModeProperty.getCondition())
+          .isEqualTo(new Equals("deduplicationModeManualFlag", true));
+
+      var autoModeProperty = getPropertyById("deduplicationModeAuto", template);
+      assertThat(autoModeProperty).isNotNull();
+      assertThat(autoModeProperty.getType()).isEqualTo("Hidden");
+      assertThat(autoModeProperty.getBinding().type()).isEqualTo("zeebe:property");
+      assertThat(((ZeebeProperty) autoModeProperty.getBinding()).name())
+          .isEqualTo("deduplicationMode");
+      assertThat(autoModeProperty.getValue()).isEqualTo("AUTO");
+      assertThat(autoModeProperty.getCondition())
+          .isEqualTo(new Equals("deduplicationModeManualFlag", false));
+
+      var deduplicationKeyProperty = getPropertyById("deduplicationId", template);
+      assertThat(deduplicationKeyProperty).isNotNull();
+      assertThat(deduplicationKeyProperty.getType()).isEqualTo("String");
+      assertThat(deduplicationKeyProperty.getBinding().type()).isEqualTo("zeebe:property");
+      assertThat(((ZeebeProperty) deduplicationKeyProperty.getBinding()).name())
+          .isEqualTo("deduplicationId");
+      assertThat(deduplicationKeyProperty.getCondition())
+          .isEqualTo(new Equals("deduplicationModeManualFlag", true));
+    }
   }
 }

--- a/element-template-generator/core/src/test/java/io/camunda/connector/generator/java/OutboundClassBasedTemplateGeneratorTest.java
+++ b/element-template-generator/core/src/test/java/io/camunda/connector/generator/java/OutboundClassBasedTemplateGeneratorTest.java
@@ -554,11 +554,9 @@ public class OutboundClassBasedTemplateGeneratorTest extends BaseTest {
     void booleanProperty_dependants() {
       var template = generator.generate(MyConnectorFunction.MinimallyAnnotated.class).getFirst();
       var dependsOnTrue = getPropertyById("dependsOnBooleanPropertyTrue", template);
-      assertThat(dependsOnTrue.getCondition())
-          .isEqualTo(new Equals("booleanProperty", Boolean.TRUE));
+      assertThat(dependsOnTrue.getCondition()).isEqualTo(new Equals("booleanProperty", "true"));
       var dependsOnFalse = getPropertyById("dependsOnBooleanPropertyFalse", template);
-      assertThat(dependsOnFalse.getCondition())
-          .isEqualTo(new Equals("booleanProperty", Boolean.FALSE));
+      assertThat(dependsOnFalse.getCondition()).isEqualTo(new Equals("booleanProperty", "false"));
     }
   }
 

--- a/element-template-generator/core/src/test/java/io/camunda/connector/generator/java/OutboundClassBasedTemplateGeneratorTest.java
+++ b/element-template-generator/core/src/test/java/io/camunda/connector/generator/java/OutboundClassBasedTemplateGeneratorTest.java
@@ -191,7 +191,8 @@ public class OutboundClassBasedTemplateGeneratorTest extends BaseTest {
           generator
               .generate(
                   MyConnectorFunction.MinimallyAnnotated.class,
-                  new GeneratorConfiguration(ConnectorMode.HYBRID, null, null, null, null))
+                  new GeneratorConfiguration(
+                      ConnectorMode.HYBRID, null, null, null, null, Map.of()))
               .getFirst();
       var property = getPropertyById("taskDefinitionType", template);
       assertThat(property.getType()).isEqualTo("String");
@@ -216,7 +217,8 @@ public class OutboundClassBasedTemplateGeneratorTest extends BaseTest {
 
     @Test
     void multipleElementTypes_definedInAnnotation() {
-      var config = new GeneratorConfiguration(ConnectorMode.HYBRID, null, null, null, null);
+      var config =
+          new GeneratorConfiguration(ConnectorMode.HYBRID, null, null, null, null, Map.of());
       var templates =
           generator.generate(MyConnectorFunction.WithMultipleElementTypes.class, config);
       boolean hasServiceTask = false,
@@ -287,7 +289,8 @@ public class OutboundClassBasedTemplateGeneratorTest extends BaseTest {
                       Set.of(BpmnType.INTERMEDIATE_THROW_EVENT),
                       BpmnType.INTERMEDIATE_THROW_EVENT,
                       null,
-                      null)));
+                      null)),
+              Map.of());
       var templates = generator.generate(MyConnectorFunction.FullyAnnotated.class, config);
       boolean hasServiceTask = false, hasMessageThrowEvent = false;
       for (var template : templates) {
@@ -314,7 +317,8 @@ public class OutboundClassBasedTemplateGeneratorTest extends BaseTest {
               null,
               Set.of(
                   new ConnectorElementType(
-                      Set.of(BpmnType.TASK), BpmnType.SERVICE_TASK, null, null)));
+                      Set.of(BpmnType.TASK), BpmnType.SERVICE_TASK, null, null)),
+              Map.of());
       var templates =
           generator.generate(MyConnectorFunction.WithMultipleElementTypes.class, config);
       boolean hasServiceTask = false,
@@ -358,7 +362,8 @@ public class OutboundClassBasedTemplateGeneratorTest extends BaseTest {
                       Set.of(BpmnType.INTERMEDIATE_CATCH_EVENT),
                       BpmnType.INTERMEDIATE_CATCH_EVENT,
                       null,
-                      null)));
+                      null)),
+              Map.of());
       var exception =
           assertThrows(
               IllegalArgumentException.class,
@@ -527,6 +532,33 @@ public class OutboundClassBasedTemplateGeneratorTest extends BaseTest {
       var template = generator.generate(MyConnectorFunction.MinimallyAnnotated.class).getFirst();
       var property = getPropertyByLabel("Date property", template);
       assertThat(property.getType()).isEqualTo("String");
+    }
+
+    @Test
+    void annotatedProperty_tooltipPresent() {
+      var template = generator.generate(MyConnectorFunction.MinimallyAnnotated.class).getFirst();
+      var property = getPropertyById("annotatedStringProperty", template);
+      assertThat(property.getTooltip()).isEqualTo("tooltip");
+    }
+
+    @Test
+    void booleanProperty() {
+      var template = generator.generate(MyConnectorFunction.MinimallyAnnotated.class).getFirst();
+      var property = getPropertyById("booleanProperty", template);
+      assertThat(property.getType()).isEqualTo("Boolean");
+      assertThat(property.getBinding()).isEqualTo(new ZeebeInput("booleanProperty"));
+      assertThat(property.getValue()).isEqualTo(Boolean.FALSE);
+    }
+
+    @Test
+    void booleanProperty_dependants() {
+      var template = generator.generate(MyConnectorFunction.MinimallyAnnotated.class).getFirst();
+      var dependsOnTrue = getPropertyById("dependsOnBooleanPropertyTrue", template);
+      assertThat(dependsOnTrue.getCondition())
+          .isEqualTo(new Equals("booleanProperty", Boolean.TRUE));
+      var dependsOnFalse = getPropertyById("dependsOnBooleanPropertyFalse", template);
+      assertThat(dependsOnFalse.getCondition())
+          .isEqualTo(new Equals("booleanProperty", Boolean.FALSE));
     }
   }
 
@@ -722,7 +754,8 @@ public class OutboundClassBasedTemplateGeneratorTest extends BaseTest {
           generator
               .generate(
                   MyConnectorFunction.MinimallyAnnotated.class,
-                  new GeneratorConfiguration(ConnectorMode.HYBRID, null, null, null, null))
+                  new GeneratorConfiguration(
+                      ConnectorMode.HYBRID, null, null, null, null, Map.of()))
               .getFirst();
       checkPropertyGroups(
           List.of(
@@ -735,6 +768,30 @@ public class OutboundClassBasedTemplateGeneratorTest extends BaseTest {
               Map.entry("retries", "Retries")),
           template,
           true);
+    }
+
+    @Test
+    void tooltip_definedByPropertyGroupAnnotation() {
+      var template = generator.generate(MyConnectorFunction.FullyAnnotated.class).getFirst();
+      var group1 =
+          template.groups().stream().filter(g -> "group1".equals(g.id())).findFirst().orElseThrow();
+      assertThat(group1.tooltip()).isEqualTo("Group One Tooltip");
+
+      var group2 =
+          template.groups().stream().filter(g -> "group2".equals(g.id())).findFirst().orElseThrow();
+      assertThat(group2.tooltip()).isNull();
+    }
+
+    @Test
+    void openByDefault_definedByPropertyGroupAnnotation() {
+      var template = generator.generate(MyConnectorFunction.FullyAnnotated.class).getFirst();
+      var group1 =
+          template.groups().stream().filter(g -> "group1".equals(g.id())).findFirst().orElseThrow();
+      assertThat(group1.openByDefault()).isFalse();
+
+      var group2 =
+          template.groups().stream().filter(g -> "group2".equals(g.id())).findFirst().orElseThrow();
+      assertThat(group2.openByDefault()).isNull();
     }
   }
 

--- a/element-template-generator/core/src/test/java/io/camunda/connector/generator/java/example/outbound/MyConnectorFunction.java
+++ b/element-template-generator/core/src/test/java/io/camunda/connector/generator/java/example/outbound/MyConnectorFunction.java
@@ -54,7 +54,11 @@ public abstract class MyConnectorFunction implements OutboundConnectorFunction {
       inputDataClass = MyConnectorInput.class,
       propertyGroups = {
         @PropertyGroup(id = "group2", label = "Group Two"),
-        @PropertyGroup(id = "group1", label = "Group One")
+        @PropertyGroup(
+            id = "group1",
+            label = "Group One",
+            openByDefault = false,
+            tooltip = "Group One Tooltip")
       })
   public static class FullyAnnotated extends MyConnectorFunction {}
 

--- a/element-template-generator/core/src/test/java/io/camunda/connector/generator/java/example/outbound/MyConnectorInput.java
+++ b/element-template-generator/core/src/test/java/io/camunda/connector/generator/java/example/outbound/MyConnectorInput.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import io.camunda.connector.generator.java.annotation.NestedProperties;
 import io.camunda.connector.generator.java.annotation.TemplateDiscriminatorProperty;
 import io.camunda.connector.generator.java.annotation.TemplateProperty;
+import io.camunda.connector.generator.java.annotation.TemplateProperty.DefaultValueType;
 import io.camunda.connector.generator.java.annotation.TemplateProperty.PropertyCondition;
 import io.camunda.connector.generator.java.annotation.TemplateProperty.PropertyType;
 import io.camunda.connector.generator.java.annotation.TemplateSubType;
@@ -47,7 +48,8 @@ public record MyConnectorInput(
             type = PropertyType.Text,
             group = "group1",
             description = "description",
-            constraints = @TemplateProperty.PropertyConstraints(notEmpty = true))
+            constraints = @TemplateProperty.PropertyConstraints(notEmpty = true),
+            tooltip = "tooltip")
         String annotatedStringProperty,
     String notAnnotatedStringProperty,
     Object objectProperty,
@@ -84,7 +86,20 @@ public record MyConnectorInput(
     @Size(min = Integer.MIN_VALUE, max = 10) String propertyWithMaxSize,
     @NotEmpty String stringPropertyWithNotEmpty,
     @NotBlank String stringPropertyWithNotBlank,
-    @NotNull Object objectPropertyWithNotNull) {
+    @NotNull Object objectPropertyWithNotNull,
+    @TemplateProperty(
+            id = "booleanProperty",
+            defaultValue = "false",
+            defaultValueType = DefaultValueType.Boolean)
+        Boolean booleanProperty,
+    @TemplateProperty(
+            id = "dependsOnBooleanPropertyFalse",
+            condition = @PropertyCondition(property = "booleanProperty", equalsBoolean = false))
+        String dependsOnBooleanPropertyFalse,
+    @TemplateProperty(
+            id = "dependsOnBooleanPropertyTrue",
+            condition = @PropertyCondition(property = "booleanProperty"))
+        String dependsOnBooleanPropertyTrue) {
 
   sealed interface NonAnnotatedSealedType permits FirstSubType, NestedSealedType, SecondSubType {
 

--- a/element-template-generator/core/src/test/java/io/camunda/connector/generator/java/example/outbound/MyConnectorInput.java
+++ b/element-template-generator/core/src/test/java/io/camunda/connector/generator/java/example/outbound/MyConnectorInput.java
@@ -94,11 +94,11 @@ public record MyConnectorInput(
         Boolean booleanProperty,
     @TemplateProperty(
             id = "dependsOnBooleanPropertyFalse",
-            condition = @PropertyCondition(property = "booleanProperty", equalsBoolean = false))
+            condition = @PropertyCondition(property = "booleanProperty", equals = "false"))
         String dependsOnBooleanPropertyFalse,
     @TemplateProperty(
             id = "dependsOnBooleanPropertyTrue",
-            condition = @PropertyCondition(property = "booleanProperty"))
+            condition = @PropertyCondition(property = "booleanProperty", equals = "true"))
         String dependsOnBooleanPropertyTrue) {
 
   sealed interface NonAnnotatedSealedType permits FirstSubType, NestedSealedType, SecondSubType {

--- a/element-template-generator/core/src/test/resources/test-element-template.json
+++ b/element-template-generator/core/src/test/resources/test-element-template.json
@@ -26,7 +26,8 @@
     },
     {
       "id": "output",
-      "label": "Output Mapping"
+      "label": "Output Mapping",
+      "tooltip": "Map the response to process variables"
     },
     {
       "id": "errors",
@@ -37,8 +38,8 @@
     {
       "value": "io.camunda:template:1",
       "binding": {
-        "type": "zeebe:taskDefinition",
-        "property": "type"
+        "property": "type",
+        "type": "zeebe:taskDefinition"
       },
       "type": "Hidden"
     },

--- a/element-template-generator/maven-plugin/src/main/java/io/camunda/connector/generator/ConnectorConfig.java
+++ b/element-template-generator/maven-plugin/src/main/java/io/camunda/connector/generator/ConnectorConfig.java
@@ -17,6 +17,7 @@
 package io.camunda.connector.generator;
 
 import java.util.List;
+import java.util.Map;
 
 public class ConnectorConfig {
 
@@ -25,6 +26,8 @@ public class ConnectorConfig {
   private boolean generateHybridTemplates = false;
 
   private List<FileNameById> files = List.of();
+
+  private Map<String, Boolean> features = Map.of();
 
   public static class FileNameById {
     private String templateId;
@@ -73,5 +76,13 @@ public class ConnectorConfig {
 
   public void setGenerateHybridTemplates(boolean generateHybridTemplates) {
     this.generateHybridTemplates = generateHybridTemplates;
+  }
+
+  public Map<String, Boolean> getFeatures() {
+    return features;
+  }
+
+  public void setFeatures(Map<String, Boolean> features) {
+    this.features = features;
   }
 }

--- a/element-template-generator/openapi-parser/src/main/java/io/camunda/connector/generator/openapi/OpenApiOutboundTemplateGenerator.java
+++ b/element-template-generator/openapi-parser/src/main/java/io/camunda/connector/generator/openapi/OpenApiOutboundTemplateGenerator.java
@@ -91,11 +91,12 @@ public class OpenApiOutboundTemplateGenerator
         template.id(),
         template.name(),
         template.version(),
-        template.properties().stream()
-            .filter(p -> p.getBinding().equals(ZeebeTaskDefinition.TYPE))
-            .findFirst()
-            .orElseThrow()
-            .getValue(),
+        (String)
+            template.properties().stream()
+                .filter(p -> p.getBinding().equals(ZeebeTaskDefinition.TYPE))
+                .findFirst()
+                .orElseThrow()
+                .getValue(),
         operations);
   }
 

--- a/element-template-generator/postman-collections-parser/src/main/java/io/camunda/connector/generator/postman/PostmanCollectionOutboundTemplateGenerator.java
+++ b/element-template-generator/postman-collections-parser/src/main/java/io/camunda/connector/generator/postman/PostmanCollectionOutboundTemplateGenerator.java
@@ -82,11 +82,12 @@ public class PostmanCollectionOutboundTemplateGenerator
         firstTemplate.id(),
         firstTemplate.name(),
         firstTemplate.version(),
-        firstTemplate.properties().stream()
-            .filter(p -> p.getBinding().equals(ZeebeTaskDefinition.TYPE))
-            .findFirst()
-            .orElseThrow()
-            .getValue(),
+        (String)
+            firstTemplate.properties().stream()
+                .filter(p -> p.getBinding().equals(ZeebeTaskDefinition.TYPE))
+                .findFirst()
+                .orElseThrow()
+                .getValue(),
         supportedOperations);
   }
 

--- a/element-template-generator/postman-collections-parser/src/test/java/io/camunda/connector/generator/postman/PostmanCollectionsGeneratorDryRunExampleTest.java
+++ b/element-template-generator/postman-collections-parser/src/test/java/io/camunda/connector/generator/postman/PostmanCollectionsGeneratorDryRunExampleTest.java
@@ -21,6 +21,7 @@ import io.camunda.connector.generator.api.GeneratorConfiguration;
 import io.camunda.connector.generator.api.GeneratorConfiguration.ConnectorMode;
 import io.camunda.connector.generator.postman.utils.ObjectMapperProvider;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Stream;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -35,7 +36,9 @@ public class PostmanCollectionsGeneratorDryRunExampleTest {
     var source = new PostmanCollectionsGenerationSource(args);
     var gen = new PostmanCollectionOutboundTemplateGenerator();
     var templates =
-        gen.generate(source, new GeneratorConfiguration(ConnectorMode.NORMAL, null, null, 1, null));
+        gen.generate(
+            source,
+            new GeneratorConfiguration(ConnectorMode.NORMAL, null, null, 1, null, Map.of()));
     var resultString =
         ObjectMapperProvider.getInstance()
             .writerWithDefaultPrettyPrinter()


### PR DESCRIPTION
## Description

This PR implements inbound deduplication ID support to the element template generator, along with some auxiliary functionality related to new features of the element template JSON schema.

<img width="668" alt="Screenshot 2024-04-16 at 09 27 51" src="https://github.com/camunda/connectors/assets/38818382/23e02153-2d75-4dbd-b279-6b22350021c1">

<br>
<img width="664" alt="Screenshot 2024-04-16 at 09 16 43" src="https://github.com/camunda/connectors/assets/38818382/4967e314-6dfb-45c4-b74b-8668fe6b2303">
<br>
<img width="662" alt="Screenshot 2024-04-16 at 09 28 21" src="https://github.com/camunda/connectors/assets/38818382/25d240c9-c49f-4c34-ab36-fa1fadf8ec08">




Key features:
- Deduplication properties are added to generated inbound connector templates
- They are hidden behind a feature flag that can be enabled in the `pom.xml`
- Boolean values (chechboxes) are now supported in the template generator
- Tooltips can be added to grop labels and properties
- New condition types are supported, including `allMatch` and `isActive` (the latter one determines whether property is visible and not hidden by other conditions).

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes https://github.com/camunda/connectors/issues/2133

