### PR TITLE
deps(jdbc): Bump connector snapshot version

### DIFF
--- a/connectors/jdbc/pom.xml
+++ b/connectors/jdbc/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.camunda.connector</groupId>
     <artifactId>connectors-parent</artifactId>
-    <version>8.5.0-SNAPSHOT</version>
+    <version>8.6.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 


### PR DESCRIPTION
## Description

Version was bumped globally in #2304 but there was a time gap between PR creation and merging where the JDBC connector merge has happened, so it was not included in that PR.



