### PR TITLE
fix(sendgrid): missing notEmpty constraints for name and email

### DIFF
--- a/connectors/sendgrid/element-templates/hybrid/sendgrid-outbound-connector-hybrid.json
+++ b/connectors/sendgrid/element-templates/hybrid/sendgrid-outbound-connector-hybrid.json
@@ -65,6 +65,9 @@
     "id" : "from.name",
     "label" : "Name",
     "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
     "feel" : "optional",
     "group" : "sender",
     "binding" : {
@@ -76,6 +79,9 @@
     "id" : "from.email",
     "label" : "Email address",
     "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
     "feel" : "optional",
     "group" : "sender",
     "binding" : {
@@ -87,6 +93,9 @@
     "id" : "to.name",
     "label" : "Name",
     "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
     "feel" : "optional",
     "group" : "receiver",
     "binding" : {
@@ -98,6 +107,9 @@
     "id" : "to.email",
     "label" : "Email address",
     "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
     "feel" : "optional",
     "group" : "receiver",
     "binding" : {

--- a/connectors/sendgrid/element-templates/sendgrid-outbound-connector.json
+++ b/connectors/sendgrid/element-templates/sendgrid-outbound-connector.json
@@ -60,6 +60,9 @@
     "id" : "from.name",
     "label" : "Name",
     "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
     "feel" : "optional",
     "group" : "sender",
     "binding" : {
@@ -71,6 +74,9 @@
     "id" : "from.email",
     "label" : "Email address",
     "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
     "feel" : "optional",
     "group" : "sender",
     "binding" : {
@@ -82,6 +88,9 @@
     "id" : "to.name",
     "label" : "Name",
     "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
     "feel" : "optional",
     "group" : "receiver",
     "binding" : {
@@ -93,6 +102,9 @@
     "id" : "to.email",
     "label" : "Email address",
     "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
     "feel" : "optional",
     "group" : "receiver",
     "binding" : {

--- a/connectors/sendgrid/src/main/java/io/camunda/connector/sendgrid/model/SendGridRequest.java
+++ b/connectors/sendgrid/src/main/java/io/camunda/connector/sendgrid/model/SendGridRequest.java
@@ -29,14 +29,30 @@ public class SendGridRequest {
   private String apiKey;
 
   public record Sender(
-      @TemplateProperty(group = "sender", label = "Name") String name,
-      @TemplateProperty(group = "sender", label = "Email address") String email) {}
+      @TemplateProperty(
+              group = "sender",
+              label = "Name",
+              constraints = @TemplateProperty.PropertyConstraints(notEmpty = true))
+          String name,
+      @TemplateProperty(
+              group = "sender",
+              label = "Email address",
+              constraints = @TemplateProperty.PropertyConstraints(notEmpty = true))
+          String email) {}
 
   @Valid @NotNull private Sender from;
 
   public record Recipient(
-      @TemplateProperty(group = "receiver", label = "Name") String name,
-      @TemplateProperty(group = "receiver", label = "Email address") String email) {}
+      @TemplateProperty(
+              group = "receiver",
+              label = "Name",
+              constraints = @TemplateProperty.PropertyConstraints(notEmpty = true))
+          String name,
+      @TemplateProperty(
+              group = "receiver",
+              label = "Email address",
+              constraints = @TemplateProperty.PropertyConstraints(notEmpty = true))
+          String email) {}
 
   @Valid @NotNull private Recipient to;
 


### PR DESCRIPTION
## Description

Fix Missing notEmpty constraints on the template fields (name and email)
## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #
https://github.com/camunda/connectors/issues/2257
