### PR TITLE
[Backport release/8.3] chore(deps): update org.bouncycastle dependency to v1.78

### DIFF
--- a/connectors/sendgrid/pom.xml
+++ b/connectors/sendgrid/pom.xml
@@ -35,6 +35,14 @@ except in compliance with the proprietary license.</license.inlineheader>
       <groupId>com.sendgrid</groupId>
       <artifactId>sendgrid-java</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcpkix-jdk18on</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcprov-jdk18on</artifactId>
+    </dependency>
   </dependencies>
 
 </project>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -108,7 +108,7 @@ limitations under the License.</license.inlineheader>
     <version.microsoft-graph>5.80.0</version.microsoft-graph>
     <version.azure-identity>1.11.4</version.azure-identity>
 
-    <version.bcprov-jdk15on>1.70</version.bcprov-jdk15on>
+    <version.bouncycastle>1.78</version.bouncycastle>
     <version.sendGrid>4.10.2</version.sendGrid>
 
     <version.slack>1.38.3</version.slack>
@@ -387,11 +387,6 @@ limitations under the License.</license.inlineheader>
       </dependency>
 
       <dependency>
-        <groupId>org.bouncycastle</groupId>
-        <artifactId>bcprov-jdk15on</artifactId>
-        <version>${version.bcprov-jdk15on}</version>
-      </dependency>
-      <dependency>
         <groupId>com.sendgrid</groupId>
         <artifactId>sendgrid-java</artifactId>
         <version>${version.sendGrid}</version>
@@ -444,6 +439,17 @@ limitations under the License.</license.inlineheader>
         <groupId>com.google.protobuf</groupId>
         <artifactId>protobuf-java</artifactId>
         <version>3.25.3</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.bouncycastle</groupId>
+        <artifactId>bcpkix-jdk18on</artifactId>
+        <version>${version.bouncycastle}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.bouncycastle</groupId>
+        <artifactId>bcprov-jdk18on</artifactId>
+        <version>${version.bouncycastle}</version>
       </dependency>
 
       <!-- test dependencies -->


### PR DESCRIPTION
(cherry picked from commit a69c200bd7300d8efe7f1fc9ceca57f9e7eae2ed)

## Description
Backport of https://github.com/camunda/connectors/pull/2317 to release/8.3.

