### PR TITLE
feat(kafka,sqs): support inbound connector deduplication

### DIFF
--- a/connectors/aws/aws-sqs/element-templates/aws-sqs-boundary-connector.json
+++ b/connectors/aws/aws-sqs/element-templates/aws-sqs-boundary-connector.json
@@ -36,6 +36,10 @@
     "id" : "correlation",
     "label" : "Correlation"
   }, {
+    "id" : "deduplication",
+    "label" : "Deduplication",
+    "tooltip" : "Deduplication allows you to configure multiple inbound connector elements to reuse the same backend (consumer/thread/endpoint) by sharing the same deduplication ID."
+  }, {
     "id" : "output",
     "label" : "Output mapping"
   } ],
@@ -244,6 +248,66 @@
     "binding" : {
       "name" : "name",
       "type" : "bpmn:Message#property"
+    },
+    "type" : "Hidden"
+  }, {
+    "id" : "deduplicationModeManualFlag",
+    "label" : "Manual mode",
+    "description" : "By default, similar connectors receive the same deduplication ID. Customize by activating manual mode",
+    "value" : false,
+    "group" : "deduplication",
+    "binding" : {
+      "name" : "deduplicationModeManualFlag",
+      "type" : "zeebe:property"
+    },
+    "type" : "Boolean"
+  }, {
+    "id" : "deduplicationId",
+    "label" : "Deduplication ID",
+    "constraints" : {
+      "notEmpty" : true,
+      "pattern" : {
+        "value" : "^[a-zA-Z0-9_-]+$",
+        "message" : "Only alphanumeric characters, dashes, and underscores are allowed"
+      }
+    },
+    "group" : "deduplication",
+    "binding" : {
+      "name" : "deduplicationId",
+      "type" : "zeebe:property"
+    },
+    "condition" : {
+      "property" : "deduplicationModeManualFlag",
+      "equals" : true,
+      "type" : "simple"
+    },
+    "type" : "String"
+  }, {
+    "id" : "deduplicationModeManual",
+    "value" : "MANUAL",
+    "group" : "deduplication",
+    "binding" : {
+      "name" : "deduplicationMode",
+      "type" : "zeebe:property"
+    },
+    "condition" : {
+      "property" : "deduplicationId",
+      "isActive" : true,
+      "type" : "simple"
+    },
+    "type" : "Hidden"
+  }, {
+    "id" : "deduplicationModeAuto",
+    "value" : "AUTO",
+    "group" : "deduplication",
+    "binding" : {
+      "name" : "deduplicationMode",
+      "type" : "zeebe:property"
+    },
+    "condition" : {
+      "property" : "deduplicationId",
+      "isActive" : false,
+      "type" : "simple"
     },
     "type" : "Hidden"
   }, {

--- a/connectors/aws/aws-sqs/element-templates/aws-sqs-inbound-intermediate-connector.json
+++ b/connectors/aws/aws-sqs/element-templates/aws-sqs-inbound-intermediate-connector.json
@@ -36,6 +36,10 @@
     "id" : "correlation",
     "label" : "Correlation"
   }, {
+    "id" : "deduplication",
+    "label" : "Deduplication",
+    "tooltip" : "Deduplication allows you to configure multiple inbound connector elements to reuse the same backend (consumer/thread/endpoint) by sharing the same deduplication ID."
+  }, {
     "id" : "output",
     "label" : "Output mapping"
   } ],
@@ -244,6 +248,66 @@
     "binding" : {
       "name" : "name",
       "type" : "bpmn:Message#property"
+    },
+    "type" : "Hidden"
+  }, {
+    "id" : "deduplicationModeManualFlag",
+    "label" : "Manual mode",
+    "description" : "By default, similar connectors receive the same deduplication ID. Customize by activating manual mode",
+    "value" : false,
+    "group" : "deduplication",
+    "binding" : {
+      "name" : "deduplicationModeManualFlag",
+      "type" : "zeebe:property"
+    },
+    "type" : "Boolean"
+  }, {
+    "id" : "deduplicationId",
+    "label" : "Deduplication ID",
+    "constraints" : {
+      "notEmpty" : true,
+      "pattern" : {
+        "value" : "^[a-zA-Z0-9_-]+$",
+        "message" : "Only alphanumeric characters, dashes, and underscores are allowed"
+      }
+    },
+    "group" : "deduplication",
+    "binding" : {
+      "name" : "deduplicationId",
+      "type" : "zeebe:property"
+    },
+    "condition" : {
+      "property" : "deduplicationModeManualFlag",
+      "equals" : true,
+      "type" : "simple"
+    },
+    "type" : "String"
+  }, {
+    "id" : "deduplicationModeManual",
+    "value" : "MANUAL",
+    "group" : "deduplication",
+    "binding" : {
+      "name" : "deduplicationMode",
+      "type" : "zeebe:property"
+    },
+    "condition" : {
+      "property" : "deduplicationId",
+      "isActive" : true,
+      "type" : "simple"
+    },
+    "type" : "Hidden"
+  }, {
+    "id" : "deduplicationModeAuto",
+    "value" : "AUTO",
+    "group" : "deduplication",
+    "binding" : {
+      "name" : "deduplicationMode",
+      "type" : "zeebe:property"
+    },
+    "condition" : {
+      "property" : "deduplicationId",
+      "isActive" : false,
+      "type" : "simple"
     },
     "type" : "Hidden"
   }, {

--- a/connectors/aws/aws-sqs/element-templates/aws-sqs-start-event-connector.json
+++ b/connectors/aws/aws-sqs/element-templates/aws-sqs-start-event-connector.json
@@ -32,6 +32,10 @@
     "id" : "activation",
     "label" : "Activation"
   }, {
+    "id" : "deduplication",
+    "label" : "Deduplication",
+    "tooltip" : "Deduplication allows you to configure multiple inbound connector elements to reuse the same backend (consumer/thread/endpoint) by sharing the same deduplication ID."
+  }, {
     "id" : "output",
     "label" : "Output mapping"
   } ],
@@ -191,6 +195,66 @@
       "type" : "zeebe:property"
     },
     "type" : "String"
+  }, {
+    "id" : "deduplicationModeManualFlag",
+    "label" : "Manual mode",
+    "description" : "By default, similar connectors receive the same deduplication ID. Customize by activating manual mode",
+    "value" : false,
+    "group" : "deduplication",
+    "binding" : {
+      "name" : "deduplicationModeManualFlag",
+      "type" : "zeebe:property"
+    },
+    "type" : "Boolean"
+  }, {
+    "id" : "deduplicationId",
+    "label" : "Deduplication ID",
+    "constraints" : {
+      "notEmpty" : true,
+      "pattern" : {
+        "value" : "^[a-zA-Z0-9_-]+$",
+        "message" : "Only alphanumeric characters, dashes, and underscores are allowed"
+      }
+    },
+    "group" : "deduplication",
+    "binding" : {
+      "name" : "deduplicationId",
+      "type" : "zeebe:property"
+    },
+    "condition" : {
+      "property" : "deduplicationModeManualFlag",
+      "equals" : true,
+      "type" : "simple"
+    },
+    "type" : "String"
+  }, {
+    "id" : "deduplicationModeManual",
+    "value" : "MANUAL",
+    "group" : "deduplication",
+    "binding" : {
+      "name" : "deduplicationMode",
+      "type" : "zeebe:property"
+    },
+    "condition" : {
+      "property" : "deduplicationId",
+      "isActive" : true,
+      "type" : "simple"
+    },
+    "type" : "Hidden"
+  }, {
+    "id" : "deduplicationModeAuto",
+    "value" : "AUTO",
+    "group" : "deduplication",
+    "binding" : {
+      "name" : "deduplicationMode",
+      "type" : "zeebe:property"
+    },
+    "condition" : {
+      "property" : "deduplicationId",
+      "isActive" : false,
+      "type" : "simple"
+    },
+    "type" : "Hidden"
   }, {
     "id" : "resultVariable",
     "label" : "Result variable",

--- a/connectors/aws/aws-sqs/element-templates/aws-sqs-start-message.json
+++ b/connectors/aws/aws-sqs/element-templates/aws-sqs-start-message.json
@@ -36,6 +36,10 @@
     "id" : "correlation",
     "label" : "Correlation"
   }, {
+    "id" : "deduplication",
+    "label" : "Deduplication",
+    "tooltip" : "Deduplication allows you to configure multiple inbound connector elements to reuse the same backend (consumer/thread/endpoint) by sharing the same deduplication ID."
+  }, {
     "id" : "output",
     "label" : "Output mapping"
   } ],
@@ -272,6 +276,66 @@
     "binding" : {
       "name" : "name",
       "type" : "bpmn:Message#property"
+    },
+    "type" : "Hidden"
+  }, {
+    "id" : "deduplicationModeManualFlag",
+    "label" : "Manual mode",
+    "description" : "By default, similar connectors receive the same deduplication ID. Customize by activating manual mode",
+    "value" : false,
+    "group" : "deduplication",
+    "binding" : {
+      "name" : "deduplicationModeManualFlag",
+      "type" : "zeebe:property"
+    },
+    "type" : "Boolean"
+  }, {
+    "id" : "deduplicationId",
+    "label" : "Deduplication ID",
+    "constraints" : {
+      "notEmpty" : true,
+      "pattern" : {
+        "value" : "^[a-zA-Z0-9_-]+$",
+        "message" : "Only alphanumeric characters, dashes, and underscores are allowed"
+      }
+    },
+    "group" : "deduplication",
+    "binding" : {
+      "name" : "deduplicationId",
+      "type" : "zeebe:property"
+    },
+    "condition" : {
+      "property" : "deduplicationModeManualFlag",
+      "equals" : true,
+      "type" : "simple"
+    },
+    "type" : "String"
+  }, {
+    "id" : "deduplicationModeManual",
+    "value" : "MANUAL",
+    "group" : "deduplication",
+    "binding" : {
+      "name" : "deduplicationMode",
+      "type" : "zeebe:property"
+    },
+    "condition" : {
+      "property" : "deduplicationId",
+      "isActive" : true,
+      "type" : "simple"
+    },
+    "type" : "Hidden"
+  }, {
+    "id" : "deduplicationModeAuto",
+    "value" : "AUTO",
+    "group" : "deduplication",
+    "binding" : {
+      "name" : "deduplicationMode",
+      "type" : "zeebe:property"
+    },
+    "condition" : {
+      "property" : "deduplicationId",
+      "isActive" : false,
+      "type" : "simple"
     },
     "type" : "Hidden"
   }, {

--- a/connectors/aws/aws-sqs/pom.xml
+++ b/connectors/aws/aws-sqs/pom.xml
@@ -75,6 +75,9 @@
                   <templateFileName>aws-sqs-boundary-connector.json</templateFileName>
                 </file>
               </files>
+              <features>
+                <INBOUND_DEDUPLICATION>true</INBOUND_DEDUPLICATION>
+              </features>
             </connector>
           </connectors>
           <includeDependencies>

--- a/connectors/kafka/element-templates/hybrid/kafka-inbound-connector-boundary-hybrid.json
+++ b/connectors/kafka/element-templates/hybrid/kafka-inbound-connector-boundary-hybrid.json
@@ -33,6 +33,10 @@
     "id" : "correlation",
     "label" : "Correlation"
   }, {
+    "id" : "deduplication",
+    "label" : "Deduplication",
+    "tooltip" : "Deduplication allows you to configure multiple inbound connector elements to reuse the same backend (consumer/thread/endpoint) by sharing the same deduplication ID."
+  }, {
     "id" : "output",
     "label" : "Output mapping"
   } ],
@@ -277,6 +281,66 @@
     "binding" : {
       "name" : "name",
       "type" : "bpmn:Message#property"
+    },
+    "type" : "Hidden"
+  }, {
+    "id" : "deduplicationModeManualFlag",
+    "label" : "Manual mode",
+    "description" : "By default, similar connectors receive the same deduplication ID. Customize by activating manual mode",
+    "value" : false,
+    "group" : "deduplication",
+    "binding" : {
+      "name" : "deduplicationModeManualFlag",
+      "type" : "zeebe:property"
+    },
+    "type" : "Boolean"
+  }, {
+    "id" : "deduplicationId",
+    "label" : "Deduplication ID",
+    "constraints" : {
+      "notEmpty" : true,
+      "pattern" : {
+        "value" : "^[a-zA-Z0-9_-]+$",
+        "message" : "Only alphanumeric characters, dashes, and underscores are allowed"
+      }
+    },
+    "group" : "deduplication",
+    "binding" : {
+      "name" : "deduplicationId",
+      "type" : "zeebe:property"
+    },
+    "condition" : {
+      "property" : "deduplicationModeManualFlag",
+      "equals" : true,
+      "type" : "simple"
+    },
+    "type" : "String"
+  }, {
+    "id" : "deduplicationModeManual",
+    "value" : "MANUAL",
+    "group" : "deduplication",
+    "binding" : {
+      "name" : "deduplicationMode",
+      "type" : "zeebe:property"
+    },
+    "condition" : {
+      "property" : "deduplicationId",
+      "isActive" : true,
+      "type" : "simple"
+    },
+    "type" : "Hidden"
+  }, {
+    "id" : "deduplicationModeAuto",
+    "value" : "AUTO",
+    "group" : "deduplication",
+    "binding" : {
+      "name" : "deduplicationMode",
+      "type" : "zeebe:property"
+    },
+    "condition" : {
+      "property" : "deduplicationId",
+      "isActive" : false,
+      "type" : "simple"
     },
     "type" : "Hidden"
   }, {

--- a/connectors/kafka/element-templates/hybrid/kafka-inbound-connector-intermediate-hybrid.json
+++ b/connectors/kafka/element-templates/hybrid/kafka-inbound-connector-intermediate-hybrid.json
@@ -33,6 +33,10 @@
     "id" : "correlation",
     "label" : "Correlation"
   }, {
+    "id" : "deduplication",
+    "label" : "Deduplication",
+    "tooltip" : "Deduplication allows you to configure multiple inbound connector elements to reuse the same backend (consumer/thread/endpoint) by sharing the same deduplication ID."
+  }, {
     "id" : "output",
     "label" : "Output mapping"
   } ],
@@ -277,6 +281,66 @@
     "binding" : {
       "name" : "name",
       "type" : "bpmn:Message#property"
+    },
+    "type" : "Hidden"
+  }, {
+    "id" : "deduplicationModeManualFlag",
+    "label" : "Manual mode",
+    "description" : "By default, similar connectors receive the same deduplication ID. Customize by activating manual mode",
+    "value" : false,
+    "group" : "deduplication",
+    "binding" : {
+      "name" : "deduplicationModeManualFlag",
+      "type" : "zeebe:property"
+    },
+    "type" : "Boolean"
+  }, {
+    "id" : "deduplicationId",
+    "label" : "Deduplication ID",
+    "constraints" : {
+      "notEmpty" : true,
+      "pattern" : {
+        "value" : "^[a-zA-Z0-9_-]+$",
+        "message" : "Only alphanumeric characters, dashes, and underscores are allowed"
+      }
+    },
+    "group" : "deduplication",
+    "binding" : {
+      "name" : "deduplicationId",
+      "type" : "zeebe:property"
+    },
+    "condition" : {
+      "property" : "deduplicationModeManualFlag",
+      "equals" : true,
+      "type" : "simple"
+    },
+    "type" : "String"
+  }, {
+    "id" : "deduplicationModeManual",
+    "value" : "MANUAL",
+    "group" : "deduplication",
+    "binding" : {
+      "name" : "deduplicationMode",
+      "type" : "zeebe:property"
+    },
+    "condition" : {
+      "property" : "deduplicationId",
+      "isActive" : true,
+      "type" : "simple"
+    },
+    "type" : "Hidden"
+  }, {
+    "id" : "deduplicationModeAuto",
+    "value" : "AUTO",
+    "group" : "deduplication",
+    "binding" : {
+      "name" : "deduplicationMode",
+      "type" : "zeebe:property"
+    },
+    "condition" : {
+      "property" : "deduplicationId",
+      "isActive" : false,
+      "type" : "simple"
     },
     "type" : "Hidden"
   }, {

--- a/connectors/kafka/element-templates/hybrid/kafka-inbound-connector-start-event-hybrid.json
+++ b/connectors/kafka/element-templates/hybrid/kafka-inbound-connector-start-event-hybrid.json
@@ -29,6 +29,10 @@
     "id" : "activation",
     "label" : "Activation"
   }, {
+    "id" : "deduplication",
+    "label" : "Deduplication",
+    "tooltip" : "Deduplication allows you to configure multiple inbound connector elements to reuse the same backend (consumer/thread/endpoint) by sharing the same deduplication ID."
+  }, {
     "id" : "output",
     "label" : "Output mapping"
   } ],
@@ -224,6 +228,66 @@
       "type" : "zeebe:property"
     },
     "type" : "String"
+  }, {
+    "id" : "deduplicationModeManualFlag",
+    "label" : "Manual mode",
+    "description" : "By default, similar connectors receive the same deduplication ID. Customize by activating manual mode",
+    "value" : false,
+    "group" : "deduplication",
+    "binding" : {
+      "name" : "deduplicationModeManualFlag",
+      "type" : "zeebe:property"
+    },
+    "type" : "Boolean"
+  }, {
+    "id" : "deduplicationId",
+    "label" : "Deduplication ID",
+    "constraints" : {
+      "notEmpty" : true,
+      "pattern" : {
+        "value" : "^[a-zA-Z0-9_-]+$",
+        "message" : "Only alphanumeric characters, dashes, and underscores are allowed"
+      }
+    },
+    "group" : "deduplication",
+    "binding" : {
+      "name" : "deduplicationId",
+      "type" : "zeebe:property"
+    },
+    "condition" : {
+      "property" : "deduplicationModeManualFlag",
+      "equals" : true,
+      "type" : "simple"
+    },
+    "type" : "String"
+  }, {
+    "id" : "deduplicationModeManual",
+    "value" : "MANUAL",
+    "group" : "deduplication",
+    "binding" : {
+      "name" : "deduplicationMode",
+      "type" : "zeebe:property"
+    },
+    "condition" : {
+      "property" : "deduplicationId",
+      "isActive" : true,
+      "type" : "simple"
+    },
+    "type" : "Hidden"
+  }, {
+    "id" : "deduplicationModeAuto",
+    "value" : "AUTO",
+    "group" : "deduplication",
+    "binding" : {
+      "name" : "deduplicationMode",
+      "type" : "zeebe:property"
+    },
+    "condition" : {
+      "property" : "deduplicationId",
+      "isActive" : false,
+      "type" : "simple"
+    },
+    "type" : "Hidden"
   }, {
     "id" : "resultVariable",
     "label" : "Result variable",

--- a/connectors/kafka/element-templates/hybrid/kafka-inbound-connector-start-message-hybrid.json
+++ b/connectors/kafka/element-templates/hybrid/kafka-inbound-connector-start-message-hybrid.json
@@ -33,6 +33,10 @@
     "id" : "correlation",
     "label" : "Correlation"
   }, {
+    "id" : "deduplication",
+    "label" : "Deduplication",
+    "tooltip" : "Deduplication allows you to configure multiple inbound connector elements to reuse the same backend (consumer/thread/endpoint) by sharing the same deduplication ID."
+  }, {
     "id" : "output",
     "label" : "Output mapping"
   } ],
@@ -305,6 +309,66 @@
     "binding" : {
       "name" : "name",
       "type" : "bpmn:Message#property"
+    },
+    "type" : "Hidden"
+  }, {
+    "id" : "deduplicationModeManualFlag",
+    "label" : "Manual mode",
+    "description" : "By default, similar connectors receive the same deduplication ID. Customize by activating manual mode",
+    "value" : false,
+    "group" : "deduplication",
+    "binding" : {
+      "name" : "deduplicationModeManualFlag",
+      "type" : "zeebe:property"
+    },
+    "type" : "Boolean"
+  }, {
+    "id" : "deduplicationId",
+    "label" : "Deduplication ID",
+    "constraints" : {
+      "notEmpty" : true,
+      "pattern" : {
+        "value" : "^[a-zA-Z0-9_-]+$",
+        "message" : "Only alphanumeric characters, dashes, and underscores are allowed"
+      }
+    },
+    "group" : "deduplication",
+    "binding" : {
+      "name" : "deduplicationId",
+      "type" : "zeebe:property"
+    },
+    "condition" : {
+      "property" : "deduplicationModeManualFlag",
+      "equals" : true,
+      "type" : "simple"
+    },
+    "type" : "String"
+  }, {
+    "id" : "deduplicationModeManual",
+    "value" : "MANUAL",
+    "group" : "deduplication",
+    "binding" : {
+      "name" : "deduplicationMode",
+      "type" : "zeebe:property"
+    },
+    "condition" : {
+      "property" : "deduplicationId",
+      "isActive" : true,
+      "type" : "simple"
+    },
+    "type" : "Hidden"
+  }, {
+    "id" : "deduplicationModeAuto",
+    "value" : "AUTO",
+    "group" : "deduplication",
+    "binding" : {
+      "name" : "deduplicationMode",
+      "type" : "zeebe:property"
+    },
+    "condition" : {
+      "property" : "deduplicationId",
+      "isActive" : false,
+      "type" : "simple"
     },
     "type" : "Hidden"
   }, {

--- a/connectors/kafka/element-templates/kafka-inbound-connector-boundary.json
+++ b/connectors/kafka/element-templates/kafka-inbound-connector-boundary.json
@@ -30,6 +30,10 @@
     "id" : "correlation",
     "label" : "Correlation"
   }, {
+    "id" : "deduplication",
+    "label" : "Deduplication",
+    "tooltip" : "Deduplication allows you to configure multiple inbound connector elements to reuse the same backend (consumer/thread/endpoint) by sharing the same deduplication ID."
+  }, {
     "id" : "output",
     "label" : "Output mapping"
   } ],
@@ -272,6 +276,66 @@
     "binding" : {
       "name" : "name",
       "type" : "bpmn:Message#property"
+    },
+    "type" : "Hidden"
+  }, {
+    "id" : "deduplicationModeManualFlag",
+    "label" : "Manual mode",
+    "description" : "By default, similar connectors receive the same deduplication ID. Customize by activating manual mode",
+    "value" : false,
+    "group" : "deduplication",
+    "binding" : {
+      "name" : "deduplicationModeManualFlag",
+      "type" : "zeebe:property"
+    },
+    "type" : "Boolean"
+  }, {
+    "id" : "deduplicationId",
+    "label" : "Deduplication ID",
+    "constraints" : {
+      "notEmpty" : true,
+      "pattern" : {
+        "value" : "^[a-zA-Z0-9_-]+$",
+        "message" : "Only alphanumeric characters, dashes, and underscores are allowed"
+      }
+    },
+    "group" : "deduplication",
+    "binding" : {
+      "name" : "deduplicationId",
+      "type" : "zeebe:property"
+    },
+    "condition" : {
+      "property" : "deduplicationModeManualFlag",
+      "equals" : true,
+      "type" : "simple"
+    },
+    "type" : "String"
+  }, {
+    "id" : "deduplicationModeManual",
+    "value" : "MANUAL",
+    "group" : "deduplication",
+    "binding" : {
+      "name" : "deduplicationMode",
+      "type" : "zeebe:property"
+    },
+    "condition" : {
+      "property" : "deduplicationId",
+      "isActive" : true,
+      "type" : "simple"
+    },
+    "type" : "Hidden"
+  }, {
+    "id" : "deduplicationModeAuto",
+    "value" : "AUTO",
+    "group" : "deduplication",
+    "binding" : {
+      "name" : "deduplicationMode",
+      "type" : "zeebe:property"
+    },
+    "condition" : {
+      "property" : "deduplicationId",
+      "isActive" : false,
+      "type" : "simple"
     },
     "type" : "Hidden"
   }, {

--- a/connectors/kafka/element-templates/kafka-inbound-connector-intermediate.json
+++ b/connectors/kafka/element-templates/kafka-inbound-connector-intermediate.json
@@ -30,6 +30,10 @@
     "id" : "correlation",
     "label" : "Correlation"
   }, {
+    "id" : "deduplication",
+    "label" : "Deduplication",
+    "tooltip" : "Deduplication allows you to configure multiple inbound connector elements to reuse the same backend (consumer/thread/endpoint) by sharing the same deduplication ID."
+  }, {
     "id" : "output",
     "label" : "Output mapping"
   } ],
@@ -272,6 +276,66 @@
     "binding" : {
       "name" : "name",
       "type" : "bpmn:Message#property"
+    },
+    "type" : "Hidden"
+  }, {
+    "id" : "deduplicationModeManualFlag",
+    "label" : "Manual mode",
+    "description" : "By default, similar connectors receive the same deduplication ID. Customize by activating manual mode",
+    "value" : false,
+    "group" : "deduplication",
+    "binding" : {
+      "name" : "deduplicationModeManualFlag",
+      "type" : "zeebe:property"
+    },
+    "type" : "Boolean"
+  }, {
+    "id" : "deduplicationId",
+    "label" : "Deduplication ID",
+    "constraints" : {
+      "notEmpty" : true,
+      "pattern" : {
+        "value" : "^[a-zA-Z0-9_-]+$",
+        "message" : "Only alphanumeric characters, dashes, and underscores are allowed"
+      }
+    },
+    "group" : "deduplication",
+    "binding" : {
+      "name" : "deduplicationId",
+      "type" : "zeebe:property"
+    },
+    "condition" : {
+      "property" : "deduplicationModeManualFlag",
+      "equals" : true,
+      "type" : "simple"
+    },
+    "type" : "String"
+  }, {
+    "id" : "deduplicationModeManual",
+    "value" : "MANUAL",
+    "group" : "deduplication",
+    "binding" : {
+      "name" : "deduplicationMode",
+      "type" : "zeebe:property"
+    },
+    "condition" : {
+      "property" : "deduplicationId",
+      "isActive" : true,
+      "type" : "simple"
+    },
+    "type" : "Hidden"
+  }, {
+    "id" : "deduplicationModeAuto",
+    "value" : "AUTO",
+    "group" : "deduplication",
+    "binding" : {
+      "name" : "deduplicationMode",
+      "type" : "zeebe:property"
+    },
+    "condition" : {
+      "property" : "deduplicationId",
+      "isActive" : false,
+      "type" : "simple"
     },
     "type" : "Hidden"
   }, {

--- a/connectors/kafka/element-templates/kafka-inbound-connector-start-event.json
+++ b/connectors/kafka/element-templates/kafka-inbound-connector-start-event.json
@@ -26,6 +26,10 @@
     "id" : "activation",
     "label" : "Activation"
   }, {
+    "id" : "deduplication",
+    "label" : "Deduplication",
+    "tooltip" : "Deduplication allows you to configure multiple inbound connector elements to reuse the same backend (consumer/thread/endpoint) by sharing the same deduplication ID."
+  }, {
     "id" : "output",
     "label" : "Output mapping"
   } ],
@@ -219,6 +223,66 @@
       "type" : "zeebe:property"
     },
     "type" : "String"
+  }, {
+    "id" : "deduplicationModeManualFlag",
+    "label" : "Manual mode",
+    "description" : "By default, similar connectors receive the same deduplication ID. Customize by activating manual mode",
+    "value" : false,
+    "group" : "deduplication",
+    "binding" : {
+      "name" : "deduplicationModeManualFlag",
+      "type" : "zeebe:property"
+    },
+    "type" : "Boolean"
+  }, {
+    "id" : "deduplicationId",
+    "label" : "Deduplication ID",
+    "constraints" : {
+      "notEmpty" : true,
+      "pattern" : {
+        "value" : "^[a-zA-Z0-9_-]+$",
+        "message" : "Only alphanumeric characters, dashes, and underscores are allowed"
+      }
+    },
+    "group" : "deduplication",
+    "binding" : {
+      "name" : "deduplicationId",
+      "type" : "zeebe:property"
+    },
+    "condition" : {
+      "property" : "deduplicationModeManualFlag",
+      "equals" : true,
+      "type" : "simple"
+    },
+    "type" : "String"
+  }, {
+    "id" : "deduplicationModeManual",
+    "value" : "MANUAL",
+    "group" : "deduplication",
+    "binding" : {
+      "name" : "deduplicationMode",
+      "type" : "zeebe:property"
+    },
+    "condition" : {
+      "property" : "deduplicationId",
+      "isActive" : true,
+      "type" : "simple"
+    },
+    "type" : "Hidden"
+  }, {
+    "id" : "deduplicationModeAuto",
+    "value" : "AUTO",
+    "group" : "deduplication",
+    "binding" : {
+      "name" : "deduplicationMode",
+      "type" : "zeebe:property"
+    },
+    "condition" : {
+      "property" : "deduplicationId",
+      "isActive" : false,
+      "type" : "simple"
+    },
+    "type" : "Hidden"
   }, {
     "id" : "resultVariable",
     "label" : "Result variable",

--- a/connectors/kafka/element-templates/kafka-inbound-connector-start-message.json
+++ b/connectors/kafka/element-templates/kafka-inbound-connector-start-message.json
@@ -30,6 +30,10 @@
     "id" : "correlation",
     "label" : "Correlation"
   }, {
+    "id" : "deduplication",
+    "label" : "Deduplication",
+    "tooltip" : "Deduplication allows you to configure multiple inbound connector elements to reuse the same backend (consumer/thread/endpoint) by sharing the same deduplication ID."
+  }, {
     "id" : "output",
     "label" : "Output mapping"
   } ],
@@ -300,6 +304,66 @@
     "binding" : {
       "name" : "name",
       "type" : "bpmn:Message#property"
+    },
+    "type" : "Hidden"
+  }, {
+    "id" : "deduplicationModeManualFlag",
+    "label" : "Manual mode",
+    "description" : "By default, similar connectors receive the same deduplication ID. Customize by activating manual mode",
+    "value" : false,
+    "group" : "deduplication",
+    "binding" : {
+      "name" : "deduplicationModeManualFlag",
+      "type" : "zeebe:property"
+    },
+    "type" : "Boolean"
+  }, {
+    "id" : "deduplicationId",
+    "label" : "Deduplication ID",
+    "constraints" : {
+      "notEmpty" : true,
+      "pattern" : {
+        "value" : "^[a-zA-Z0-9_-]+$",
+        "message" : "Only alphanumeric characters, dashes, and underscores are allowed"
+      }
+    },
+    "group" : "deduplication",
+    "binding" : {
+      "name" : "deduplicationId",
+      "type" : "zeebe:property"
+    },
+    "condition" : {
+      "property" : "deduplicationModeManualFlag",
+      "equals" : true,
+      "type" : "simple"
+    },
+    "type" : "String"
+  }, {
+    "id" : "deduplicationModeManual",
+    "value" : "MANUAL",
+    "group" : "deduplication",
+    "binding" : {
+      "name" : "deduplicationMode",
+      "type" : "zeebe:property"
+    },
+    "condition" : {
+      "property" : "deduplicationId",
+      "isActive" : true,
+      "type" : "simple"
+    },
+    "type" : "Hidden"
+  }, {
+    "id" : "deduplicationModeAuto",
+    "value" : "AUTO",
+    "group" : "deduplication",
+    "binding" : {
+      "name" : "deduplicationMode",
+      "type" : "zeebe:property"
+    },
+    "condition" : {
+      "property" : "deduplicationId",
+      "isActive" : false,
+      "type" : "simple"
     },
     "type" : "Hidden"
   }, {

--- a/connectors/kafka/pom.xml
+++ b/connectors/kafka/pom.xml
@@ -118,6 +118,9 @@ except in compliance with the proprietary license.</license.inlineheader>
                 </file>
               </files>
               <generateHybridTemplates>true</generateHybridTemplates>
+              <features>
+                <INBOUND_DEDUPLICATION>true</INBOUND_DEDUPLICATION>
+              </features>
             </connector>
           </connectors>
         </configuration>


### PR DESCRIPTION
## Description

Adds deduplication configuration to SQS and Kafka inbound connector templates.

## Related issues

closes https://github.com/camunda/connectors/issues/2133

