### PR TITLE
fix(kafka): offsets should be optional; ignore offsets when is empty

### DIFF
--- a/connectors/kafka/element-templates/hybrid/kafka-inbound-connector-boundary-hybrid.json
+++ b/connectors/kafka/element-templates/hybrid/kafka-inbound-connector-boundary-hybrid.json
@@ -167,7 +167,7 @@
     "id" : "offsets",
     "label" : "Offsets",
     "description" : "List of offsets, e.g. '10' or '=[10, 23]'. If specified, it has to have the same number of values as the number of partitions",
-    "optional" : false,
+    "optional" : true,
     "feel" : "optional",
     "group" : "kafka",
     "binding" : {

--- a/connectors/kafka/element-templates/hybrid/kafka-inbound-connector-intermediate-hybrid.json
+++ b/connectors/kafka/element-templates/hybrid/kafka-inbound-connector-intermediate-hybrid.json
@@ -167,7 +167,7 @@
     "id" : "offsets",
     "label" : "Offsets",
     "description" : "List of offsets, e.g. '10' or '=[10, 23]'. If specified, it has to have the same number of values as the number of partitions",
-    "optional" : false,
+    "optional" : true,
     "feel" : "optional",
     "group" : "kafka",
     "binding" : {

--- a/connectors/kafka/element-templates/hybrid/kafka-inbound-connector-start-event-hybrid.json
+++ b/connectors/kafka/element-templates/hybrid/kafka-inbound-connector-start-event-hybrid.json
@@ -163,7 +163,7 @@
     "id" : "offsets",
     "label" : "Offsets",
     "description" : "List of offsets, e.g. '10' or '=[10, 23]'. If specified, it has to have the same number of values as the number of partitions",
-    "optional" : false,
+    "optional" : true,
     "feel" : "optional",
     "group" : "kafka",
     "binding" : {

--- a/connectors/kafka/element-templates/hybrid/kafka-inbound-connector-start-message-hybrid.json
+++ b/connectors/kafka/element-templates/hybrid/kafka-inbound-connector-start-message-hybrid.json
@@ -167,7 +167,7 @@
     "id" : "offsets",
     "label" : "Offsets",
     "description" : "List of offsets, e.g. '10' or '=[10, 23]'. If specified, it has to have the same number of values as the number of partitions",
-    "optional" : false,
+    "optional" : true,
     "feel" : "optional",
     "group" : "kafka",
     "binding" : {

--- a/connectors/kafka/element-templates/kafka-inbound-connector-boundary.json
+++ b/connectors/kafka/element-templates/kafka-inbound-connector-boundary.json
@@ -162,7 +162,7 @@
     "id" : "offsets",
     "label" : "Offsets",
     "description" : "List of offsets, e.g. '10' or '=[10, 23]'. If specified, it has to have the same number of values as the number of partitions",
-    "optional" : false,
+    "optional" : true,
     "feel" : "optional",
     "group" : "kafka",
     "binding" : {

--- a/connectors/kafka/element-templates/kafka-inbound-connector-intermediate.json
+++ b/connectors/kafka/element-templates/kafka-inbound-connector-intermediate.json
@@ -162,7 +162,7 @@
     "id" : "offsets",
     "label" : "Offsets",
     "description" : "List of offsets, e.g. '10' or '=[10, 23]'. If specified, it has to have the same number of values as the number of partitions",
-    "optional" : false,
+    "optional" : true,
     "feel" : "optional",
     "group" : "kafka",
     "binding" : {

--- a/connectors/kafka/element-templates/kafka-inbound-connector-start-event.json
+++ b/connectors/kafka/element-templates/kafka-inbound-connector-start-event.json
@@ -158,7 +158,7 @@
     "id" : "offsets",
     "label" : "Offsets",
     "description" : "List of offsets, e.g. '10' or '=[10, 23]'. If specified, it has to have the same number of values as the number of partitions",
-    "optional" : false,
+    "optional" : true,
     "feel" : "optional",
     "group" : "kafka",
     "binding" : {

--- a/connectors/kafka/element-templates/kafka-inbound-connector-start-message.json
+++ b/connectors/kafka/element-templates/kafka-inbound-connector-start-message.json
@@ -162,7 +162,7 @@
     "id" : "offsets",
     "label" : "Offsets",
     "description" : "List of offsets, e.g. '10' or '=[10, 23]'. If specified, it has to have the same number of values as the number of partitions",
-    "optional" : false,
+    "optional" : true,
     "feel" : "optional",
     "group" : "kafka",
     "binding" : {

--- a/connectors/kafka/src/main/java/io/camunda/connector/kafka/inbound/KafkaConnectorConsumer.java
+++ b/connectors/kafka/src/main/java/io/camunda/connector/kafka/inbound/KafkaConnectorConsumer.java
@@ -109,6 +109,7 @@ public class KafkaConnectorConsumer {
       this.consumer = consumerCreatorFunction.apply(getKafkaProperties(elementProps, context));
       var partitions = assignTopicPartitions(consumer, elementProps.topic().topicName());
       Optional.ofNullable(elementProps.offsets())
+          .filter(listOffsets -> !listOffsets.isEmpty())
           .ifPresent(offsets -> seekOffsets(consumer, partitions, offsets));
       reportUp();
     } catch (Exception ex) {

--- a/connectors/kafka/src/main/java/io/camunda/connector/kafka/inbound/KafkaConnectorProperties.java
+++ b/connectors/kafka/src/main/java/io/camunda/connector/kafka/inbound/KafkaConnectorProperties.java
@@ -70,6 +70,7 @@ public record KafkaConnectorProperties(
             group = "kafka",
             label = "Offsets",
             feel = Property.FeelMode.optional,
+            optional = true,
             description =
                 "List of offsets, e.g. '10' or '=[10, 23]'. If specified, it has to have the same number of values as the number of partitions")
         List<Long> offsets,


### PR DESCRIPTION
## Description

in the 8.6.0-SNAPSHOT was error : 
`org.apache.kafka.clients.consumer.NoOffsetForPartitionException: Undefined offset with no reset policy for partitions: [topic_0-2, topic_0-1, topic_0-0]`

this happens because in the new template offsets property was not optional and the modeler sent empty offsets list;

So, it was fixed : 

- added `optional : true` for  property offsets in the template
- added logic with ignoring list offsets when this list is empty
<!-- Please explain the changes you made here. -->

note : 
for now don't need to add a backport label for 8.5, 8.4, and 8.3, looks like this bug is not reproducible with previous template versions


next steps : 
 - update template in the related PRs : 
   - https://github.com/camunda/web-modeler/pull/9127