### PR TITLE
chore: migrate to spring zeebe 8.5.1

### DIFF
--- a/bundle/default-bundle/src/test/resources/application.properties
+++ b/bundle/default-bundle/src/test/resources/application.properties
@@ -1,11 +1,4 @@
 server.port=8080
-zeebe.client.broker.gateway-address=localhost:26500
-zeebe.client.security.plaintext=true
-
-# Operate config for use with docker-compose.yml
-camunda.operate.client.url=http://localhost:8081
-#camunda.operate.client.username=demo
-#camunda.operate.client.password=demo
 
 management.context-path=/actuator
 management.endpoints.web.exposure.include=metrics,health,prometheus
@@ -13,19 +6,21 @@ management.endpoint.health.group.readiness.include[]=zeebeClient,operate
 management.endpoint.health.show-components=always
 management.endpoint.health.show-details=always
 
-camunda.identity.type=keycloak
-camunda.identity.base-url=http://localhost:8084
-camunda.identity.issuer=http://localhost:18080/auth/realms/camunda-platform
-camunda.identity.issuer-backend-url=http://localhost:18080/auth/realms/camunda-platform
-camunda.identity.audience=connectors
-camunda.identity.client-id=connectors
-camunda.identity.client-secret=XALaRPl5qwTEItdwCMiPS62nVpKs7dL7
+camunda.client.operate.base-url=http://localhost:8081
+camunda.client.zeebe.gateway-url=http://localhost:26500
+camunda.client.zeebe.defaults.max-jobs-active=32
+camunda.client.zeebe.defaults.worker-threads=10
 
-debug=true
+# Config for use with docker-compose.yml
+camunda.client.mode=oidc
+camunda.client.auth.client-id=connectors
+camunda.client.auth.client-secret=XALaRPl5qwTEItdwCMiPS62nVpKs7dL7
+camunda.client.auth.oidc-type=keycloak
+camunda.client.auth.issuer=http://localhost:18080/auth/realms/camunda-platform
+camunda.client.identity.audience=connectors
+camunda.client.identity.base-url=http://localhost:8084
 
-zeebe.client.worker.max-jobs-active=32
-zeebe.client.worker.threads=10
-
-camunda.connector.polling.enabled=true
-camunda.connector.webhook.enabled=true
-camunda.connector.polling.interval=5000
+# Config for use with docker-compose-core.yml
+#camunda.client.mode=simple
+#camunda.client.auth.username=demo
+#camunda.client.auth.password=demo

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/testutil/command/PublishMessageCommandDummy.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/testutil/command/PublishMessageCommandDummy.java
@@ -42,6 +42,11 @@ public class PublishMessageCommandDummy
   }
 
   @Override
+  public PublishMessageCommandStep3 withoutCorrelationKey() {
+    return this;
+  }
+
+  @Override
   public PublishMessageCommandStep3 messageId(String messageId) {
     return this;
   }

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/lifecycle/OutboundConnectorManager.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/lifecycle/OutboundConnectorManager.java
@@ -29,6 +29,8 @@ import io.camunda.zeebe.spring.client.annotation.value.ZeebeWorkerValue;
 import io.camunda.zeebe.spring.client.jobhandling.CommandExceptionHandlingStrategy;
 import io.camunda.zeebe.spring.client.jobhandling.JobWorkerManager;
 import io.camunda.zeebe.spring.client.metrics.MetricsRecorder;
+import java.time.Duration;
+import java.util.Arrays;
 import java.util.Set;
 import java.util.TreeSet;
 import org.slf4j.Logger;
@@ -82,8 +84,10 @@ public class OutboundConnectorManager {
     ZeebeWorkerValue zeebeWorkerValue = new ZeebeWorkerValue();
     zeebeWorkerValue.setName(connector.name());
     zeebeWorkerValue.setType(connector.type());
-    zeebeWorkerValue.setFetchVariables(connector.inputVariables());
-    zeebeWorkerValue.setTimeout(connector.timeout());
+    zeebeWorkerValue.setFetchVariables(Arrays.asList(connector.inputVariables()));
+    if (connector.timeout() != null) {
+      zeebeWorkerValue.setTimeout(Duration.ofMillis(connector.timeout()));
+    }
     zeebeWorkerValue.setAutoComplete(true);
 
     OutboundConnectorFunction connectorFunction = connectorFactory.getInstance(connector.type());

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/main/java/io/camunda/connector/runtime/InboundConnectorsAutoConfiguration.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/main/java/io/camunda/connector/runtime/InboundConnectorsAutoConfiguration.java
@@ -16,10 +16,12 @@
  */
 package io.camunda.connector.runtime;
 
+import io.camunda.common.auth.Authentication;
 import io.camunda.connector.runtime.inbound.InboundConnectorRuntimeConfiguration;
 import io.camunda.operate.CamundaOperateClient;
 import io.camunda.zeebe.spring.client.CamundaAutoConfiguration;
 import io.camunda.zeebe.spring.client.configuration.OperateClientConfiguration;
+import io.camunda.zeebe.spring.client.properties.CamundaClientProperties;
 import io.camunda.zeebe.spring.client.properties.OperateClientConfigurationProperties;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
@@ -44,14 +46,16 @@ public class InboundConnectorsAutoConfiguration {
 
   @Bean
   @ConditionalOnMissingBean
-  public CamundaOperateClient myOperateClient(
-      OperateClientConfiguration configuration, OperateClientConfigurationProperties properties) {
-    return configuration.camundaOperateClient(properties);
+  public CamundaOperateClient myOperateClient(OperateClientConfiguration configuration) {
+    return configuration.camundaOperateClient();
   }
 
   @Bean
   @ConditionalOnMissingBean
-  public OperateClientConfiguration operateClientProdAutoConfiguration() {
-    return new OperateClientConfiguration();
+  public OperateClientConfiguration operateClientProdAutoConfiguration(
+      OperateClientConfigurationProperties legacyProperties,
+      CamundaClientProperties properties,
+      Authentication authentication) {
+    return new OperateClientConfiguration(legacyProperties, properties, authentication);
   }
 }

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -71,9 +71,9 @@ limitations under the License.</license.inlineheader>
     <nexus.sonatype.url>https://s01.oss.sonatype.org</nexus.sonatype.url>
 
     <!-- Camunda internal libraries -->
-    <version.zeebe>8.4.5</version.zeebe>
+    <version.zeebe>8.5.0</version.zeebe>
     <version.feel-engine>1.17.5</version.feel-engine>
-    <version.spring-zeebe>8.5.0-rc1</version.spring-zeebe>
+    <version.spring-zeebe>8.5.1</version.spring-zeebe>
 
     <!-- Third party dependencies -->
 


### PR DESCRIPTION
## Description

Changes to support Spring Zeebe 8.5.x, including the config property format.

Replaces the previous PR: https://github.com/camunda/connectors/pull/2344

## Related issues

closes #2313 #2343 #2346 

