### PR TITLE
fix(inbound): always return health objects with error set

### DIFF
--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/executable/InboundExecutableRegistryImpl.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/executable/InboundExecutableRegistryImpl.java
@@ -17,6 +17,7 @@
 package io.camunda.connector.runtime.inbound.executable;
 
 import io.camunda.connector.api.inbound.Health;
+import io.camunda.connector.api.inbound.Health.Error;
 import io.camunda.connector.api.inbound.ProcessElement;
 import io.camunda.connector.runtime.core.config.InboundConnectorConfiguration;
 import io.camunda.connector.runtime.core.inbound.InboundConnectorDetails;
@@ -268,13 +269,16 @@ public class InboundExecutableRegistryImpl implements InboundExecutableRegistry 
           id,
           null,
           failed.data().connectorElements(),
-          Health.down("reason", failed.reason()),
+          Health.down(new Error("Activation failure", failed.reason())),
           List.of());
-      case ConnectorNotRegistered ignored -> new ActiveExecutableResponse(
+      case ConnectorNotRegistered notRegistered -> new ActiveExecutableResponse(
           id,
           null,
-          ignored.data().connectorElements(),
-          Health.down("reason", "Connector not registered"),
+          notRegistered.data().connectorElements(),
+          Health.down(
+              new Error(
+                  "Activation failure",
+                  "Connector " + notRegistered.data().type() + " not registered")),
           List.of());
     };
   }

--- a/connector-sdk/core/src/main/java/io/camunda/connector/api/inbound/Health.java
+++ b/connector-sdk/core/src/main/java/io/camunda/connector/api/inbound/Health.java
@@ -106,16 +106,8 @@ public class Health {
     return new Health(Status.DOWN, error, null);
   }
 
-  public static Health down(String key, Object value) {
-    return Health.status(Status.DOWN).detail(key, value);
-  }
-
-  public static Health down(Map<String, Object> details) {
-    return Health.status(Status.DOWN).details(details);
-  }
-
   public static Health down(Error error, Map<String, Object> details) {
-    return Health.status(Status.DOWN).details(details);
+    return new Health(Status.DOWN, error, details);
   }
 
   public static Health down(Throwable ex) {
@@ -131,7 +123,7 @@ public class Health {
   public static class Builder implements DetailsStep {
     private final Health.Status status;
     private Map<String, Object> details;
-    private Error error;
+    private final Error error;
 
     private Builder(Status status, Error error) {
       this.status = status;


### PR DESCRIPTION
## Description

Restores compatibility with web modeler's Problems tab by always returning an error object along with the health response. Additionally, the constructors that allow creating Health objects without an Error were removed.



