### PR TITLE
test: fix test compilation errors on release/8.6

### DIFF
--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/inbound/InboundEndpointTest.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/inbound/InboundEndpointTest.java
@@ -61,7 +61,7 @@ public class InboundEndpointTest {
                         new InboundConnectorElement(
                             Map.of("inbound.context", "myPath", "inbound.type", "webhook"),
                             new StandaloneMessageCorrelationPoint(
-                                "myPath", "=expression", "=myPath", null),
+                                "myPath", "=expression", "=myPath"),
                             new ProcessElement("", 1, 1, "", ""))),
                     Health.up(),
                     Collections.emptyList())));


### PR DESCRIPTION
## Description

Previous constructor signature was only available in main with [configurable TTL](https://github.com/camunda/connectors/pull/2341), which will not be part of release/8.6.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #

