### PR TITLE
ci(release): support existing tag, clarify Maven staging

### DIFF
--- a/.github/workflows/INTEGRATION_TEST.yml
+++ b/.github/workflows/INTEGRATION_TEST.yml
@@ -21,6 +21,7 @@ jobs:
     uses: camunda/camunda-platform-helm/.github/workflows/test-integration-template.yaml@main
     secrets: inherit
     with:
+      flows: 'upgrade'
       identifier: connectors-int
       test-enabled: true
       extra-values: |

--- a/.github/workflows/INTEGRATION_TEST.yml
+++ b/.github/workflows/INTEGRATION_TEST.yml
@@ -24,9 +24,34 @@ jobs:
       identifier: connectors-int
       test-enabled: true
       extra-values: |
-        global:
+        identity:
+          keycloak:
+            # https://hub.docker.com/r/bitnami/keycloak/tags
+            image:
+              repository: bitnami/keycloak
+              tag: 22.0.5
+            postgresql:
+              # https://hub.docker.com/r/bitnami/postgresql/tags
+              image:
+                repository: bitnami/postgresql
+                tag: 15.5.0
+        optimize:
+          # https://hub.docker.com/r/camunda/optimize/tags
           image:
-            tag: 8.3.10
+            repository: camunda/optimize
+            # renovate: datasource=docker depName=camunda/optimize
+            tag: 8.3.8
+        webModeler:
+          # Camunda Enterprise repository.
+          # registry.camunda.cloud/web-modeler-ee
+          image:
+            # renovate: datasource=docker depName=camunda/web-modeler lookupName=registry.camunda.cloud/web-modeler-ee/modeler-restapi
+            tag: 8.3.6
+        elasticsearch:
+          # https://hub.docker.com/r/bitnami/elasticsearch/tags
+          image:
+            repository: bitnami/elasticsearch
+            tag: 8.8.2
         connectors:
           image:
             tag: ${{ github.event.inputs.connectors_version }}

--- a/.github/workflows/INTEGRATION_TEST.yml
+++ b/.github/workflows/INTEGRATION_TEST.yml
@@ -25,6 +25,9 @@ jobs:
       identifier: connectors-int
       test-enabled: true
       extra-values: |
+        global:
+          image:
+            tag: 8.3.10
         identity:
           keycloak:
             # https://hub.docker.com/r/bitnami/keycloak/tags

--- a/.github/workflows/INTEGRATION_TEST.yml
+++ b/.github/workflows/INTEGRATION_TEST.yml
@@ -24,6 +24,9 @@ jobs:
       identifier: connectors-int
       test-enabled: true
       extra-values: |
+        global:
+          image:
+            tag: 8.3.10
         connectors:
           image:
             tag: ${{ github.event.inputs.connectors_version }}

--- a/.github/workflows/INTEGRATION_TEST.yml
+++ b/.github/workflows/INTEGRATION_TEST.yml
@@ -21,7 +21,6 @@ jobs:
     uses: camunda/camunda-platform-helm/.github/workflows/test-integration-template.yaml@main
     secrets: inherit
     with:
-      flows: 'upgrade'
       identifier: connectors-int
       test-enabled: true
       extra-values: |

--- a/.github/workflows/INTEGRATION_TEST.yml
+++ b/.github/workflows/INTEGRATION_TEST.yml
@@ -21,41 +21,9 @@ jobs:
     uses: camunda/camunda-platform-helm/.github/workflows/test-integration-template.yaml@main
     secrets: inherit
     with:
-      camunda-helm-git-ref: camunda-platform-8.3
       identifier: connectors-int
       test-enabled: true
       extra-values: |
-        global:
-          image:
-            tag: 8.3.10
-        identity:
-          keycloak:
-            # https://hub.docker.com/r/bitnami/keycloak/tags
-            image:
-              repository: bitnami/keycloak
-              tag: 22.0.5
-            postgresql:
-              # https://hub.docker.com/r/bitnami/postgresql/tags
-              image:
-                repository: bitnami/postgresql
-                tag: 15.5.0
-        optimize:
-          # https://hub.docker.com/r/camunda/optimize/tags
-          image:
-            repository: camunda/optimize
-            # renovate: datasource=docker depName=camunda/optimize
-            tag: 8.3.8
-        webModeler:
-          # Camunda Enterprise repository.
-          # registry.camunda.cloud/web-modeler-ee
-          image:
-            # renovate: datasource=docker depName=camunda/web-modeler lookupName=registry.camunda.cloud/web-modeler-ee/modeler-restapi
-            tag: 8.3.6
-        elasticsearch:
-          # https://hub.docker.com/r/bitnami/elasticsearch/tags
-          image:
-            repository: bitnami/elasticsearch
-            tag: 8.8.2
         connectors:
           image:
             tag: ${{ github.event.inputs.connectors_version }}

--- a/.github/workflows/INTEGRATION_TEST.yml
+++ b/.github/workflows/INTEGRATION_TEST.yml
@@ -21,6 +21,7 @@ jobs:
     uses: camunda/camunda-platform-helm/.github/workflows/test-integration-template.yaml@main
     secrets: inherit
     with:
+      camunda-helm-git-ref: camunda-platform-8.3
       identifier: connectors-int
       test-enabled: true
       extra-values: |

--- a/.github/workflows/RELEASE.yaml
+++ b/.github/workflows/RELEASE.yaml
@@ -5,12 +5,6 @@ on:
   release:
     types: [ created ]
 
-defaults:
-  run:
-    # use bash shell by default to ensure pipefail behavior is the default
-    # see https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#exit-codes-and-error-action-preference
-    shell: bash
-
 jobs:
   build-and-push:
     name: Build and push Docker images
@@ -270,13 +264,3 @@ jobs:
             bundle/default-bundle/target/connectors-bundle-sbom.xml
             connectors-bundle-templates-${{ github.event.release.tag_name }}.tar.gz
             connectors-bundle-templates-${{ github.event.release.tag_name }}.zip
-
-  helm-deploy:
-    name: Helm chart Integration Tests
-    uses: camunda/connectors/.github/workflows/INTEGRATION_TEST.yml@main
-    secrets: inherit
-    with:
-      extra-values: |
-        connectors:
-          image:
-            tag: ${{ github.event.release.tag_name }}

--- a/.github/workflows/RELEASE.yaml
+++ b/.github/workflows/RELEASE.yaml
@@ -273,11 +273,9 @@ jobs:
 
   helm-deploy:
     name: Helm chart Integration Tests
-    uses: camunda/camunda-platform-helm/.github/workflows/test-integration-template.yaml@main
+    uses: camunda/connectors/.github/workflows/INTEGRATION_TEST.yml@main
     secrets: inherit
     with:
-      identifier: connectors-int-${{ github.run_id }}
-      test-enabled: true
       extra-values: |
         connectors:
           image:

--- a/.github/workflows/RELEASE.yaml
+++ b/.github/workflows/RELEASE.yaml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.release.target_commitish || github.event.release.tag_name }}
+          ref: ${{ github.event.release.tag_name || github.event.release.target_commitish }}
           fetch-depth: 0
 
       - name: Validate release tag and determine previous tag

--- a/.github/workflows/RELEASE.yaml
+++ b/.github/workflows/RELEASE.yaml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.release.target_commitish }}
+          ref: ${{ github.event.release.target_commitish || github.event.release.tag_name }}
           fetch-depth: 0
 
       - name: Validate release tag and determine previous tag

--- a/.github/workflows/RELEASE.yaml
+++ b/.github/workflows/RELEASE.yaml
@@ -111,7 +111,7 @@ jobs:
         env:
           RELEASE_VERSION: ${{ github.event.release.tag_name }}
 
-      - name: Deploy artifacts to Artifactory and Maven Central
+      - name: Deploy artifacts to Artifactory and Maven Central (Staging)
         run: mvn -B compile generate-sources source:jar javadoc:jar deploy -PcheckFormat -Psonatype-oss-release
         env:
           NEXUS_USR: ${{ steps.secrets.outputs.ARTIFACTORY_USR }}

--- a/.github/workflows/RELEASE.yaml
+++ b/.github/workflows/RELEASE.yaml
@@ -264,3 +264,15 @@ jobs:
             bundle/default-bundle/target/connectors-bundle-sbom.xml
             connectors-bundle-templates-${{ github.event.release.tag_name }}.tar.gz
             connectors-bundle-templates-${{ github.event.release.tag_name }}.zip
+
+  helm-deploy:
+    name: Helm chart Integration Tests
+    uses: camunda/camunda-platform-helm/.github/workflows/test-integration-template.yaml@main
+    secrets: inherit
+    with:
+      identifier: connectors-int-${{ github.run_id }}
+      test-enabled: true
+      extra-values: |
+        connectors:
+          image:
+            tag: ${{ github.event.release.tag_name }}

--- a/.github/workflows/RELEASE.yaml
+++ b/.github/workflows/RELEASE.yaml
@@ -5,6 +5,12 @@ on:
   release:
     types: [ created ]
 
+defaults:
+  run:
+    # use bash shell by default to ensure pipefail behavior is the default
+    # see https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#exit-codes-and-error-action-preference
+    shell: bash
+
 jobs:
   build-and-push:
     name: Build and push Docker images


### PR DESCRIPTION
## Description

### Checkout existing tag

target_commitish only exists when tag doesn't exist already when the release is created.

While this is often useful, there are times when the tag already exists.

For example, if someone edits an existing release instead of creates a new one. Or if the GitHub release needs to be re-created for some reason.

### Clarify Maven Central (Staging)

To help clarify that this will not publish the artifact directly to the public - an additional step is needed as documented internally.

### ~Run Helm Integration tests~

This is more complicated than expected. We will address this in a separate issue and PR.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #

