### PR TITLE
fix(inbound): status report not shown for unhealthy connectors

### DIFF
--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/controller/InboundConnectorRestController.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/controller/InboundConnectorRestController.java
@@ -83,7 +83,8 @@ public class InboundConnectorRestController {
 
   private Map<String, Object> getData(ActiveExecutableResponse connector) {
     Map<String, Object> data = Map.of();
-    if (WebhookConnectorExecutable.class.isAssignableFrom(connector.executableClass())) {
+    if (connector.executableClass() != null
+        && WebhookConnectorExecutable.class.isAssignableFrom(connector.executableClass())) {
       try {
         var properties = connector.elements().getFirst().rawPropertiesWithoutKeywords();
         var contextPath = properties.get("inbound.context");

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/inbound/InboundEndpointTest.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/inbound/InboundEndpointTest.java
@@ -73,4 +73,30 @@ public class InboundEndpointTest {
     assertEquals(1, response.size());
     assertEquals("myPath", response.get(0).data().get("path"));
   }
+
+  @Test
+  public void executableClassNullHandledCorrectly() {
+    var executableRegistry = mock(InboundExecutableRegistry.class);
+    when(executableRegistry.query(any()))
+        .thenReturn(
+            List.of(
+                new ActiveExecutableResponse(
+                    UUID.randomUUID(),
+                    null, // executable class is null
+                    List.of(
+                        new InboundConnectorElement(
+                            Map.of("inbound.context", "myPath", "inbound.type", "webhook"),
+                            new StandaloneMessageCorrelationPoint(
+                                "myPath", "=expression", "=myPath", null),
+                            new ProcessElement("", 1, 1, "", ""))),
+                    Health.down(),
+                    Collections.emptyList())));
+
+    InboundConnectorRestController statusController =
+        new InboundConnectorRestController(executableRegistry);
+
+    var response = statusController.getActiveInboundConnectors(null, null, null);
+    assertEquals(1, response.size());
+    assertEquals(Health.down(), response.get(0).health());
+  }
 }


### PR DESCRIPTION
## Description

This edge case was not handled:
- the executable registry cannot return the executable class with the status response because the executable doesn't exist
- the executable doesn't exist because of an activation failure
