### PR TITLE
feat(jdbc): Remove MySQL ConnectorJ and use MariaDb instead

### DIFF
--- a/connectors/jdbc/pom.xml
+++ b/connectors/jdbc/pom.xml
@@ -51,17 +51,24 @@
     </dependency>
 
     <dependency>
-      <groupId>com.mysql</groupId>
-      <artifactId>mysql-connector-j</artifactId>
-      <version>8.4.0</version>
-    </dependency>
-
-    <dependency>
       <groupId>org.postgresql</groupId>
       <artifactId>postgresql</artifactId>
       <version>42.7.3</version>
     </dependency>
 
+    <!-- Mariadb is used because of an issue with the MySQL ConnectorJ licence (GPL). We're not mentioning Mariadb in our docs -->
+    <dependency>
+      <groupId>org.mariadb.jdbc</groupId>
+      <artifactId>mariadb-java-client</artifactId>
+      <version>3.3.3</version>
+    </dependency>
+
+    <dependency>
+      <groupId>com.mysql</groupId>
+      <artifactId>mysql-connector-j</artifactId>
+      <version>8.4.0</version>
+      <scope>test</scope>
+    </dependency>
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>postgresql</artifactId>

--- a/connectors/jdbc/src/main/java/io/camunda/connector/jdbc/model/request/SupportedDatabase.java
+++ b/connectors/jdbc/src/main/java/io/camunda/connector/jdbc/model/request/SupportedDatabase.java
@@ -8,7 +8,7 @@ package io.camunda.connector.jdbc.model.request;
 
 public enum SupportedDatabase {
   MSSQL("com.microsoft.sqlserver.jdbc.SQLServerDriver", "jdbc:sqlserver://"),
-  MYSQL("com.mysql.cj.jdbc.Driver", "jdbc:mysql://"),
+  MYSQL("org.mariadb.jdbc.Driver", "jdbc:mysql://"),
   POSTGRESQL("org.postgresql.Driver", "jdbc:postgresql://");
 
   private final String driverClassName;

--- a/connectors/jdbc/src/main/java/io/camunda/connector/jdbc/utils/ConnectionHelper.java
+++ b/connectors/jdbc/src/main/java/io/camunda/connector/jdbc/utils/ConnectionHelper.java
@@ -22,20 +22,21 @@ public class ConnectionHelper {
   private static final Logger LOG = LoggerFactory.getLogger(ConnectionHelper.class);
 
   public static Connection openConnection(JdbcRequest request) {
+    SupportedDatabase database = request.database();
+    String driverClassName = database.getDriverClassName();
     try {
       LOG.debug("Executing JDBC request: {}", request);
-      LOG.debug("Loading JDBC driver: {}", request.database().getDriverClassName());
-      Class.forName(request.database().getDriverClassName());
+      LOG.debug("Loading JDBC driver: {}", driverClassName);
+      Class.forName(driverClassName);
       JdbcConnection connection = request.connection();
       Connection conn =
           DriverManager.getConnection(
-              ensureMySQLCompatibleUrl(
-                  connection.getConnectionString(request.database()), request.database()),
+              ensureMySQLCompatibleUrl(connection.getConnectionString(database), database),
               connection.getProperties());
-      LOG.debug("Connection established for Database {}: {}", request.database(), conn);
+      LOG.debug("Connection established for Database {}: {}", database, conn);
       return conn;
     } catch (ClassNotFoundException e) {
-      throw new ConnectorException("Cannot find class: " + request.database().getDriverClassName());
+      throw new ConnectorException("Cannot find class: " + driverClassName);
     } catch (URISyntaxException e) {
       throw new ConnectorException("Cannot parse the Database connection URL: " + e.getMessage());
     } catch (SQLException e) {

--- a/connectors/jdbc/src/main/java/io/camunda/connector/jdbc/utils/ConnectionParameterHelper.java
+++ b/connectors/jdbc/src/main/java/io/camunda/connector/jdbc/utils/ConnectionParameterHelper.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.camunda.connector.jdbc.utils;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+/**
+ * Helper class to add parameters to a URL. Parameters values can be added to the URL as well, but
+ * it is optional.
+ *
+ * @see ConnectionParameterHelperTest for usage examples.
+ */
+public class ConnectionParameterHelper {
+
+  public static String addQueryParameterToURL(String urlString, String paramName)
+      throws URISyntaxException {
+    return addQueryParameterToURL(urlString, paramName, null);
+  }
+
+  public static String addQueryParameterToURL(String urlString, String paramName, String paramValue)
+      throws URISyntaxException {
+    URI uri = new URI(urlString);
+    // Check if the URL already has query parameters
+    int queryParamsIndex = urlString.indexOf('?');
+    String query;
+    if (queryParamsIndex == -1) {
+      // No query parameters
+      query = "?";
+    } else {
+      // Query parameters already exist let's add the new one
+      query = "&";
+    }
+    query += paramName;
+    // Value is optional
+    if (paramValue != null) {
+      query += "=" + paramValue;
+    }
+    // jdbc:mysql//localhost:3306?paramName=paramValue for instance is not detected as a regular
+    // URI,
+    // so we need to reconstruct the URI using the scheme and the scheme specific part
+    return new URI(uri.getScheme() + ":" + uri.getSchemeSpecificPart() + query).toString();
+  }
+}

--- a/connectors/jdbc/src/main/java/io/camunda/connector/jdbc/utils/ConnectionParameterHelper.java
+++ b/connectors/jdbc/src/main/java/io/camunda/connector/jdbc/utils/ConnectionParameterHelper.java
@@ -1,20 +1,9 @@
 /*
  * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
- * under one or more contributor license agreements. See the NOTICE file
- * distributed with this work for additional information regarding copyright
- * ownership. Camunda licenses this file to you under the Apache License,
- * Version 2.0; you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
  */
-
 package io.camunda.connector.jdbc.utils;
 
 import java.net.URI;

--- a/connectors/jdbc/src/main/java/io/camunda/connector/jdbc/utils/ConnectionStringHelper.java
+++ b/connectors/jdbc/src/main/java/io/camunda/connector/jdbc/utils/ConnectionStringHelper.java
@@ -15,35 +15,13 @@ public class ConnectionStringHelper {
   public static String buildConnectionString(
       SupportedDatabase database, DetailedConnection connection) {
     return switch (database) {
-      case MYSQL -> buildMySqlConnectionString(database, connection);
-      case POSTGRESQL -> buildPostgresConnectionString(database, connection);
+      case MYSQL, POSTGRESQL -> buildCommonConnectionString(database, connection);
       case MSSQL -> buildMssqlConnectionString(database, connection);
       default -> throw new ConnectorException("Unsupported database: " + database);
     };
   }
 
-  private static String buildMySqlConnectionString(
-      SupportedDatabase database, DetailedConnection connection) {
-    String host = connection.host();
-    String port = connection.port();
-    String username = connection.username();
-    String password = connection.password();
-    String databaseName = connection.databaseName();
-    String authentication = "";
-    if (username != null && !username.isEmpty()) {
-      authentication += username;
-      if (password != null && !password.isEmpty()) {
-        authentication += ":" + password + "@";
-      }
-    }
-    String connectionString = database.getUrlSchema() + authentication + host + ":" + port;
-    if (databaseName != null && !databaseName.isEmpty()) {
-      connectionString += "/" + databaseName;
-    }
-    return connectionString;
-  }
-
-  private static String buildPostgresConnectionString(
+  private static String buildCommonConnectionString(
       SupportedDatabase database, DetailedConnection connection) {
     String host = connection.host();
     String port = connection.port();

--- a/connectors/jdbc/src/test/java/io/camunda/connector/jdbc/utils/ConnectionParameterHelperTest.java
+++ b/connectors/jdbc/src/test/java/io/camunda/connector/jdbc/utils/ConnectionParameterHelperTest.java
@@ -1,20 +1,9 @@
 /*
  * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
- * under one or more contributor license agreements. See the NOTICE file
- * distributed with this work for additional information regarding copyright
- * ownership. Camunda licenses this file to you under the Apache License,
- * Version 2.0; you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
  */
-
 package io.camunda.connector.jdbc.utils;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/connectors/jdbc/src/test/java/io/camunda/connector/jdbc/utils/ConnectionParameterHelperTest.java
+++ b/connectors/jdbc/src/test/java/io/camunda/connector/jdbc/utils/ConnectionParameterHelperTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.camunda.connector.jdbc.utils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+public class ConnectionParameterHelperTest {
+  @Test
+  void shouldCreateQueryParameters_whenNoExistingQueryParameters() throws Exception {
+    String urlString = "jdbc:mysql//localhost:3306";
+    String paramName = "paramName";
+    String paramValue = "paramValue";
+    String result =
+        ConnectionParameterHelper.addQueryParameterToURL(urlString, paramName, paramValue);
+    assertThat(result).isEqualTo(urlString + "?paramName=paramValue");
+  }
+
+  @Test
+  void shouldNotCreateQueryParameters_whenExistingQueryParameters() throws Exception {
+    String urlString = "jdbc:mysql//localhost:3306?existingParam=existingValue";
+    String paramName = "paramName";
+    String paramValue = "paramValue";
+    String result =
+        ConnectionParameterHelper.addQueryParameterToURL(urlString, paramName, paramValue);
+    assertThat(result).isEqualTo(urlString + "&paramName=paramValue");
+  }
+
+  @Test
+  void shouldCreateQueryParameters_whenNoParamValue() throws Exception {
+    String urlString = "jdbc:mysql//localhost:3306";
+    String paramName = "paramName";
+    String result = ConnectionParameterHelper.addQueryParameterToURL(urlString, paramName);
+    assertThat(result).isEqualTo(urlString + "?paramName");
+  }
+
+  @Test
+  void shouldCreateQueryParameters_whenNoParamValueAndExistingQueryParameters() throws Exception {
+    String urlString = "jdbc:mysql//localhost:3306?existingParam=existingValue";
+    String paramName = "paramName";
+    String result = ConnectionParameterHelper.addQueryParameterToURL(urlString, paramName);
+    assertThat(result).isEqualTo(urlString + "&paramName");
+  }
+
+  @Test
+  void shouldCreateQueryParametersAfterPath_whenQueryPathExistsAndNoParamValue() throws Exception {
+    String urlString = "jdbc:mysql//localhost:3306/database";
+    String paramName = "paramName";
+    String result = ConnectionParameterHelper.addQueryParameterToURL(urlString, paramName);
+    assertThat(result).isEqualTo(urlString + "?paramName");
+  }
+
+  @Test
+  void shouldCreateQueryParametersAfterPath_whenQueryPathExistsAndQueryParametersExist()
+      throws Exception {
+    String urlString = "jdbc:mysql//localhost:3306/database?existingParam=existingValue";
+    String paramName = "paramName";
+    String result = ConnectionParameterHelper.addQueryParameterToURL(urlString, paramName);
+    assertThat(result).isEqualTo(urlString + "&paramName");
+  }
+
+  @Test
+  void shouldCreateQueryParametersAfterPath_whenEmptyPath() throws Exception {
+    String urlString = "jdbc:mysql//localhost:3306/";
+    String paramName = "paramName";
+    String result = ConnectionParameterHelper.addQueryParameterToURL(urlString, paramName);
+    assertThat(result).isEqualTo(urlString + "?paramName");
+  }
+}


### PR DESCRIPTION
## Description

We can't use GPL license, so we needed to replace the MySQL connector with the compatible MariaDb connector.

This won't change anything for our end users, and to accomplish that we needed to handle the compatibility part for them.
Thus we are adding the `permitMysqlScheme` at the end of the connection string.

Note that we still need the MySQL connector for our tests, as _testcontainers_ is looking for this driver to start a MySQL server.


