### PR TITLE
fix(jdbc): Fix invalid Javadoc comment

### DIFF
--- a/connectors/jdbc/src/main/java/io/camunda/connector/jdbc/utils/ConnectionParameterHelper.java
+++ b/connectors/jdbc/src/main/java/io/camunda/connector/jdbc/utils/ConnectionParameterHelper.java
@@ -13,7 +13,7 @@ import java.net.URISyntaxException;
  * Helper class to add parameters to a URL. Parameters values can be added to the URL as well, but
  * it is optional.
  *
- * @see ConnectionParameterHelperTest for usage examples.
+ * <p>See ConnectionParameterHelperTest for usage examples.
  */
 public class ConnectionParameterHelper {
 


### PR DESCRIPTION
Test file is not accessible from source code. This causes the RC build to fail.
