### PR TITLE
feat(jdbc): Don't use URI as it breaks when using the hash char

### DIFF
--- a/connectors/jdbc/src/main/java/io/camunda/connector/jdbc/utils/ConnectionHelper.java
+++ b/connectors/jdbc/src/main/java/io/camunda/connector/jdbc/utils/ConnectionHelper.java
@@ -10,7 +10,6 @@ import io.camunda.connector.api.error.ConnectorException;
 import io.camunda.connector.jdbc.model.request.JdbcRequest;
 import io.camunda.connector.jdbc.model.request.SupportedDatabase;
 import io.camunda.connector.jdbc.model.request.connection.JdbcConnection;
-import java.net.URISyntaxException;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
@@ -37,8 +36,6 @@ public class ConnectionHelper {
       return conn;
     } catch (ClassNotFoundException e) {
       throw new ConnectorException("Cannot find class: " + driverClassName);
-    } catch (URISyntaxException e) {
-      throw new ConnectorException("Cannot parse the Database connection URL: " + e.getMessage());
     } catch (SQLException e) {
       throw new ConnectorException("Cannot create the Database connection: " + e.getMessage());
     }
@@ -52,8 +49,7 @@ public class ConnectionHelper {
    *     href="https://mariadb.com/kb/en/about-mariadb-connector-j/#jdbcmysql-scheme-compatibility">Compatibility
    *     details</a>
    */
-  private static String ensureMySQLCompatibleUrl(String url, SupportedDatabase database)
-      throws URISyntaxException {
+  private static String ensureMySQLCompatibleUrl(String url, SupportedDatabase database) {
     if (database == SupportedDatabase.MYSQL) {
       return ConnectionParameterHelper.addQueryParameterToURL(url, "permitMysqlScheme");
     }

--- a/connectors/jdbc/src/main/java/io/camunda/connector/jdbc/utils/ConnectionParameterHelper.java
+++ b/connectors/jdbc/src/main/java/io/camunda/connector/jdbc/utils/ConnectionParameterHelper.java
@@ -6,7 +6,6 @@
  */
 package io.camunda.connector.jdbc.utils;
 
-import java.net.URISyntaxException;
 
 /**
  * Helper class to add parameters to a URL. Parameters values can be added to the URL as well, but
@@ -16,13 +15,12 @@ import java.net.URISyntaxException;
  */
 public class ConnectionParameterHelper {
 
-  public static String addQueryParameterToURL(String urlString, String paramName)
-      throws URISyntaxException {
+  public static String addQueryParameterToURL(String urlString, String paramName) {
     return addQueryParameterToURL(urlString, paramName, null);
   }
 
-  public static String addQueryParameterToURL(String urlString, String paramName, String paramValue)
-      throws URISyntaxException {
+  public static String addQueryParameterToURL(
+      String urlString, String paramName, String paramValue) {
     // Check if the URL already has query parameters
     int queryParamsIndex = urlString.indexOf('?');
     String query;

--- a/connectors/jdbc/src/main/java/io/camunda/connector/jdbc/utils/ConnectionParameterHelper.java
+++ b/connectors/jdbc/src/main/java/io/camunda/connector/jdbc/utils/ConnectionParameterHelper.java
@@ -6,7 +6,6 @@
  */
 package io.camunda.connector.jdbc.utils;
 
-import java.net.URI;
 import java.net.URISyntaxException;
 
 /**
@@ -24,7 +23,6 @@ public class ConnectionParameterHelper {
 
   public static String addQueryParameterToURL(String urlString, String paramName, String paramValue)
       throws URISyntaxException {
-    URI uri = new URI(urlString);
     // Check if the URL already has query parameters
     int queryParamsIndex = urlString.indexOf('?');
     String query;
@@ -43,6 +41,6 @@ public class ConnectionParameterHelper {
     // jdbc:mysql//localhost:3306?paramName=paramValue for instance is not detected as a regular
     // URI,
     // so we need to reconstruct the URI using the scheme and the scheme specific part
-    return new URI(uri.getScheme() + ":" + uri.getSchemeSpecificPart() + query).toString();
+    return urlString + query;
   }
 }

--- a/connectors/jdbc/src/main/java/io/camunda/connector/jdbc/utils/ConnectionParameterHelper.java
+++ b/connectors/jdbc/src/main/java/io/camunda/connector/jdbc/utils/ConnectionParameterHelper.java
@@ -6,6 +6,9 @@
  */
 package io.camunda.connector.jdbc.utils;
 
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+
 /**
  * Helper class to add parameters to a URL. Parameters values can be added to the URL as well, but
  * it is optional.
@@ -20,20 +23,9 @@ public class ConnectionParameterHelper {
 
   public static String addQueryParameterToURL(
       String urlString, String paramName, String paramValue) {
-    // Check if the URL already has query parameters
-    int queryParamsIndex = urlString.indexOf('?');
-    if (queryParamsIndex == -1) {
-      // No query parameters
-      urlString += "?";
-    } else {
-      // Query parameters already exist let's add the new one
-      urlString += "&";
-    }
-    urlString += paramName;
-    // Value is optional
-    if (paramValue != null) {
-      urlString += "=" + paramValue;
-    }
-    return urlString;
+    String encodedValue =
+        paramValue != null ? URLEncoder.encode(paramValue, StandardCharsets.UTF_8) : null;
+    String separator = urlString.contains("?") ? "&" : "?";
+    return urlString + separator + paramName + (encodedValue != null ? "=" + encodedValue : "");
   }
 }

--- a/connectors/jdbc/src/main/java/io/camunda/connector/jdbc/utils/ConnectionParameterHelper.java
+++ b/connectors/jdbc/src/main/java/io/camunda/connector/jdbc/utils/ConnectionParameterHelper.java
@@ -6,7 +6,6 @@
  */
 package io.camunda.connector.jdbc.utils;
 
-
 /**
  * Helper class to add parameters to a URL. Parameters values can be added to the URL as well, but
  * it is optional.
@@ -23,22 +22,18 @@ public class ConnectionParameterHelper {
       String urlString, String paramName, String paramValue) {
     // Check if the URL already has query parameters
     int queryParamsIndex = urlString.indexOf('?');
-    String query;
     if (queryParamsIndex == -1) {
       // No query parameters
-      query = "?";
+      urlString += "?";
     } else {
       // Query parameters already exist let's add the new one
-      query = "&";
+      urlString += "&";
     }
-    query += paramName;
+    urlString += paramName;
     // Value is optional
     if (paramValue != null) {
-      query += "=" + paramValue;
+      urlString += "=" + paramValue;
     }
-    // jdbc:mysql//localhost:3306?paramName=paramValue for instance is not detected as a regular
-    // URI,
-    // so we need to reconstruct the URI using the scheme and the scheme specific part
-    return urlString + query;
+    return urlString;
   }
 }

--- a/connectors/jdbc/src/main/java/io/camunda/connector/jdbc/utils/ConnectionParameterHelper.java
+++ b/connectors/jdbc/src/main/java/io/camunda/connector/jdbc/utils/ConnectionParameterHelper.java
@@ -6,9 +6,6 @@
  */
 package io.camunda.connector.jdbc.utils;
 
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
-
 /**
  * Helper class to add parameters to a URL. Parameters values can be added to the URL as well, but
  * it is optional.
@@ -23,9 +20,7 @@ public class ConnectionParameterHelper {
 
   public static String addQueryParameterToURL(
       String urlString, String paramName, String paramValue) {
-    String encodedValue =
-        paramValue != null ? URLEncoder.encode(paramValue, StandardCharsets.UTF_8) : null;
     String separator = urlString.contains("?") ? "&" : "?";
-    return urlString + separator + paramName + (encodedValue != null ? "=" + encodedValue : "");
+    return urlString + separator + paramName + (paramValue != null ? "=" + paramValue : "");
   }
 }

--- a/connectors/jdbc/src/test/java/io/camunda/connector/jdbc/utils/ConnectionParameterHelperTest.java
+++ b/connectors/jdbc/src/test/java/io/camunda/connector/jdbc/utils/ConnectionParameterHelperTest.java
@@ -12,7 +12,7 @@ import org.junit.jupiter.api.Test;
 
 public class ConnectionParameterHelperTest {
   @Test
-  void shouldCreateQueryParameters_whenNoExistingQueryParameters() throws Exception {
+  void shouldCreateQueryParameters_whenNoExistingQueryParameters() {
     String urlString = "jdbc:mysql//localhost:3306";
     String paramName = "paramName";
     String paramValue = "paramValue";
@@ -22,7 +22,7 @@ public class ConnectionParameterHelperTest {
   }
 
   @Test
-  void shouldNotCreateQueryParameters_whenExistingQueryParameters() throws Exception {
+  void shouldNotCreateQueryParameters_whenExistingQueryParameters() {
     String urlString = "jdbc:mysql//localhost:3306?existingParam=existingValue";
     String paramName = "paramName";
     String paramValue = "paramValue";
@@ -32,7 +32,7 @@ public class ConnectionParameterHelperTest {
   }
 
   @Test
-  void shouldCreateQueryParameters_whenNoParamValue() throws Exception {
+  void shouldCreateQueryParameters_whenNoParamValue() {
     String urlString = "jdbc:mysql//localhost:3306";
     String paramName = "paramName";
     String result = ConnectionParameterHelper.addQueryParameterToURL(urlString, paramName);
@@ -40,7 +40,7 @@ public class ConnectionParameterHelperTest {
   }
 
   @Test
-  void shouldCreateQueryParameters_whenNoParamValueAndExistingQueryParameters() throws Exception {
+  void shouldCreateQueryParameters_whenNoParamValueAndExistingQueryParameters() {
     String urlString = "jdbc:mysql//localhost:3306?existingParam=existingValue";
     String paramName = "paramName";
     String result = ConnectionParameterHelper.addQueryParameterToURL(urlString, paramName);
@@ -48,7 +48,7 @@ public class ConnectionParameterHelperTest {
   }
 
   @Test
-  void shouldCreateQueryParametersAfterPath_whenQueryPathExistsAndNoParamValue() throws Exception {
+  void shouldCreateQueryParametersAfterPath_whenQueryPathExistsAndNoParamValue() {
     String urlString = "jdbc:mysql//localhost:3306/database";
     String paramName = "paramName";
     String result = ConnectionParameterHelper.addQueryParameterToURL(urlString, paramName);
@@ -56,8 +56,7 @@ public class ConnectionParameterHelperTest {
   }
 
   @Test
-  void shouldCreateQueryParametersAfterPath_whenQueryPathExistsAndQueryParametersExist()
-      throws Exception {
+  void shouldCreateQueryParametersAfterPath_whenQueryPathExistsAndQueryParametersExist() {
     String urlString = "jdbc:mysql//localhost:3306/database?existingParam=existingValue";
     String paramName = "paramName";
     String result = ConnectionParameterHelper.addQueryParameterToURL(urlString, paramName);
@@ -65,7 +64,7 @@ public class ConnectionParameterHelperTest {
   }
 
   @Test
-  void shouldCreateQueryParametersAfterPath_whenEmptyPath() throws Exception {
+  void shouldCreateQueryParametersAfterPath_whenEmptyPath() {
     String urlString = "jdbc:mysql//localhost:3306/";
     String paramName = "paramName";
     String result = ConnectionParameterHelper.addQueryParameterToURL(urlString, paramName);
@@ -74,11 +73,79 @@ public class ConnectionParameterHelperTest {
 
   @Test
   void
-      shouldCreateQueryParametersAfterPath_whenQueryPathExistsAndQueryParametersExistAndPasswordHasWeirdChars()
-          throws Exception {
+      shouldCreateQueryParametersAfterPath_whenQueryPathExistsAndQueryParametersExistAndPasswordHasWeirdChars() {
     String urlString = "jdbc:mysql//localhost:3306/database?user=test&password=ab#!xij:()_s23";
     String paramName = "paramName";
     String result = ConnectionParameterHelper.addQueryParameterToURL(urlString, paramName);
     assertThat(result).isEqualTo(urlString + "&paramName");
+  }
+
+  @Test
+  void shouldCreateQueryParameters_whenMultipleExistingQueryParameters() {
+    String urlString =
+        "jdbc:mysql//localhost:3306?existingParam1=existingValue1&existingParam2=existingValue2";
+    String paramName = "paramName";
+    String paramValue = "paramValue";
+    String result =
+        ConnectionParameterHelper.addQueryParameterToURL(urlString, paramName, paramValue);
+    assertThat(result).isEqualTo(urlString + "&paramName=paramValue");
+  }
+
+  @Test
+  void shouldEncodeSpecialCharactersInParamValue() {
+    String urlString = "jdbc:mysql//localhost:3306";
+    String paramName = "paramName";
+    String paramValue = "special&=value%";
+    String result =
+        ConnectionParameterHelper.addQueryParameterToURL(urlString, paramName, paramValue);
+    assertThat(result).isEqualTo(urlString + "?paramName=special%26%3Dvalue%25");
+  }
+
+  @Test
+  void shouldHandleEmptyParamValue() {
+    String urlString = "jdbc:mysql//localhost:3306";
+    String paramName = "paramName";
+    String paramValue = "";
+    String result =
+        ConnectionParameterHelper.addQueryParameterToURL(urlString, paramName, paramValue);
+    assertThat(result).isEqualTo(urlString + "?paramName=");
+  }
+
+  @Test
+  void shouldHandleNullParamValue() {
+    String urlString = "jdbc:mysql//localhost:3306";
+    String paramName = "paramName";
+    String result = ConnectionParameterHelper.addQueryParameterToURL(urlString, paramName, null);
+    assertThat(result).isEqualTo(urlString + "?paramName");
+  }
+
+  @Test
+  void shouldHandleParameterValueWithAmpersand() {
+    String urlString = "jdbc:mysql//localhost:3306";
+    String paramName = "paramName";
+    String paramValue = "value1&value2";
+    String result =
+        ConnectionParameterHelper.addQueryParameterToURL(urlString, paramName, paramValue);
+    assertThat(result).isEqualTo(urlString + "?paramName=value1%26value2");
+  }
+
+  @Test
+  void shouldHandleParameterValueWithEqualsSign() {
+    String urlString = "jdbc:mysql//localhost:3306";
+    String paramName = "paramName";
+    String paramValue = "value=123";
+    String result =
+        ConnectionParameterHelper.addQueryParameterToURL(urlString, paramName, paramValue);
+    assertThat(result).isEqualTo(urlString + "?paramName=value%3D123");
+  }
+
+  @Test
+  void shouldHandleParameterValueWithPercentSign() {
+    String urlString = "jdbc:mysql//localhost:3306";
+    String paramName = "paramName";
+    String paramValue = "25%discount";
+    String result =
+        ConnectionParameterHelper.addQueryParameterToURL(urlString, paramName, paramValue);
+    assertThat(result).isEqualTo(urlString + "?paramName=25%25discount");
   }
 }

--- a/connectors/jdbc/src/test/java/io/camunda/connector/jdbc/utils/ConnectionParameterHelperTest.java
+++ b/connectors/jdbc/src/test/java/io/camunda/connector/jdbc/utils/ConnectionParameterHelperTest.java
@@ -71,4 +71,14 @@ public class ConnectionParameterHelperTest {
     String result = ConnectionParameterHelper.addQueryParameterToURL(urlString, paramName);
     assertThat(result).isEqualTo(urlString + "?paramName");
   }
+
+  @Test
+  void
+      shouldCreateQueryParametersAfterPath_whenQueryPathExistsAndQueryParametersExistAndPasswordHasWeirdChars()
+          throws Exception {
+    String urlString = "jdbc:mysql//localhost:3306/database?user=test&password=ab#!xij:()_s23";
+    String paramName = "paramName";
+    String result = ConnectionParameterHelper.addQueryParameterToURL(urlString, paramName);
+    assertThat(result).isEqualTo(urlString + "&paramName");
+  }
 }

--- a/connectors/jdbc/src/test/java/io/camunda/connector/jdbc/utils/ConnectionParameterHelperTest.java
+++ b/connectors/jdbc/src/test/java/io/camunda/connector/jdbc/utils/ConnectionParameterHelperTest.java
@@ -92,16 +92,6 @@ public class ConnectionParameterHelperTest {
   }
 
   @Test
-  void shouldEncodeSpecialCharactersInParamValue() {
-    String urlString = "jdbc:mysql//localhost:3306";
-    String paramName = "paramName";
-    String paramValue = "special&=value%";
-    String result =
-        ConnectionParameterHelper.addQueryParameterToURL(urlString, paramName, paramValue);
-    assertThat(result).isEqualTo(urlString + "?paramName=special%26%3Dvalue%25");
-  }
-
-  @Test
   void shouldHandleEmptyParamValue() {
     String urlString = "jdbc:mysql//localhost:3306";
     String paramName = "paramName";
@@ -117,35 +107,5 @@ public class ConnectionParameterHelperTest {
     String paramName = "paramName";
     String result = ConnectionParameterHelper.addQueryParameterToURL(urlString, paramName, null);
     assertThat(result).isEqualTo(urlString + "?paramName");
-  }
-
-  @Test
-  void shouldHandleParameterValueWithAmpersand() {
-    String urlString = "jdbc:mysql//localhost:3306";
-    String paramName = "paramName";
-    String paramValue = "value1&value2";
-    String result =
-        ConnectionParameterHelper.addQueryParameterToURL(urlString, paramName, paramValue);
-    assertThat(result).isEqualTo(urlString + "?paramName=value1%26value2");
-  }
-
-  @Test
-  void shouldHandleParameterValueWithEqualsSign() {
-    String urlString = "jdbc:mysql//localhost:3306";
-    String paramName = "paramName";
-    String paramValue = "value=123";
-    String result =
-        ConnectionParameterHelper.addQueryParameterToURL(urlString, paramName, paramValue);
-    assertThat(result).isEqualTo(urlString + "?paramName=value%3D123");
-  }
-
-  @Test
-  void shouldHandleParameterValueWithPercentSign() {
-    String urlString = "jdbc:mysql//localhost:3306";
-    String paramName = "paramName";
-    String paramValue = "25%discount";
-    String result =
-        ConnectionParameterHelper.addQueryParameterToURL(urlString, paramName, paramValue);
-    assertThat(result).isEqualTo(urlString + "?paramName=25%25discount");
   }
 }


### PR DESCRIPTION
## Description

Previously I used a `URI` to get some specific part of the provided database URL.
But:
- it didn't provide anything as the scheme (jdbc:xxx) is not properly detected, so we can't get the query parameters anyway
- it cause an issue when a URL parameter contains a hash (#) it ignores what is after this hash


