### PR TITLE
ci(helm-integration-test): test patches for older minor versions with correct dependencies

### DIFF
--- a/.github/workflows/INTEGRATION_TEST.yml
+++ b/.github/workflows/INTEGRATION_TEST.yml
@@ -46,47 +46,50 @@ jobs:
           VARS_8_4: '{"camunda-helm-git-ref": "camunda-platform-8.4", "extra-values-url": "https://raw.githubusercontent.com/camunda/camunda-platform-helm/main/charts/camunda-platform/values/values-v8.4.yaml"}'
           VARS_8_5: '{"camunda-helm-git-ref": "main", "extra-values-url": "https://raw.githubusercontent.com/camunda/camunda-platform-helm/main/charts/camunda-platform/values/values-latest.yaml"}'
 
-  get-extra-values:
-      needs: determine-inputs
-      if: ${{ needs.determine-inputs.outputs.extra-values-url != 'null' }}
-      runs-on: ubuntu-latest
-      steps:
-        - name: HTTP Request Action
-          id: extra-values-content
-          uses: fjogeleit/http-request-action@v1.15.5
-          with:
-            url: ${{ needs.process_version.outputs.extra-values-url }}
-        - name: WIP Take HTTP response and convert into a .yaml file
-          run: |
-            echo ${{ steps.extra-values-content.outputs.response }}
-            echo ${{ steps.extra-values-content.outputs.headers }}
-            echo ${{ steps.extra-values-content.outputs.status }}
-        - name: WIP Take YAML file from last step and delete the connectors value
-          uses: mikefarah/yq@v4.44.1
-          # hint: https://github.com/marketplace/actions/yq-portable-yaml-processor#github-action
-          # output to something like "non-connectors-extra-values"
-
-  use-input-connectors-version-in-extra-values:
-    needs: get-extra-values
-    runs-on: ubuntu-latest
-    steps:
-      - name: WIP Only Set Extra Values as Connectors By Default
-      - name: WIP Append input connectors version to non-connectors-extra-values from previous
-        uses: mikefarah/yq@v4.44.1
-        # hint: https://github.com/marketplace/actions/yq-portable-yaml-processor#github-action
-        # append this yaml for the connectors version:
-        #   connectors:
-        #      image:
-        #        tag: ${{ github.event.inputs.connectors_version }}
+#  get-extra-values:
+#      needs: determine-inputs
+#      if: ${{ needs.determine-inputs.outputs.extra-values-url != 'null' }}
+#      runs-on: ubuntu-latest
+#      steps:
+#        - name: HTTP Request Action
+#          id: extra-values-content
+#          uses: fjogeleit/http-request-action@v1.15.5
+#          with:
+#            url: ${{ needs.process_version.outputs.extra-values-url }}
+#        - name: WIP Take HTTP response and convert into a .yaml file
+#          run: |
+#            echo ${{ steps.extra-values-content.outputs.response }}
+#            echo ${{ steps.extra-values-content.outputs.headers }}
+#            echo ${{ steps.extra-values-content.outputs.status }}
+#        - name: WIP Take YAML file from last step and delete the connectors value
+#          uses: mikefarah/yq@v4.44.1
+#          # hint: https://github.com/marketplace/actions/yq-portable-yaml-processor#github-action
+#          # output to something like "non-connectors-extra-values"
+#
+#  use-input-connectors-version-in-extra-values:
+#    needs: get-extra-values
+#    runs-on: ubuntu-latest
+#    steps:
+#      - name: WIP Only Set Extra Values as Connectors By Default
+#      - name: WIP Append input connectors version to non-connectors-extra-values from previous
+#        uses: mikefarah/yq@v4.44.1
+#        # hint: https://github.com/marketplace/actions/yq-portable-yaml-processor#github-action
+#        # append this yaml for the connectors version:
+#        #   connectors:
+#        #      image:
+#        #        tag: ${{ github.event.inputs.connectors_version }}
 
 
   helm-deploy:
-    needs: [determine-inputs, use-input-connectors-version-in-extra-values]
+    needs: determine-inputs
     name: Helm chart Integration Tests
     uses: camunda/camunda-platform-helm/.github/workflows/test-integration-template.yaml@main
     secrets: inherit
     with:
       identifier: connectors-int
       test-enabled: true
-      camunda-helm-git-ref: ${{ TO_DEFINE_FROM_LAST_STEP || 'main' }}
-      extra-values: ${{ TO_DEFINE_FROM_LAST_STEP }}
+      camunda-helm-git-ref: ${{ needs.determine-inputs.outputs.camunda-help-git-ref || 'main' }}
+      extra-values: |
+        connectors:
+          image:
+            tag: ${{ github.event.inputs.connectors_version }}

--- a/.github/workflows/INTEGRATION_TEST.yml
+++ b/.github/workflows/INTEGRATION_TEST.yml
@@ -22,6 +22,8 @@ jobs:
       camunda-helm-git-ref: ${{ steps.set_vars.outputs.camunda-helm-git-ref }}
       extra-values-url: ${{ steps.set_vars.outputs.extra-values-url }}
     steps:
+      - name: Install jq
+        uses: dcarbone/install-jq-action@v2.1.0
       - name: Define version map
         run: |
           if [[ "${{ inputs.connectors_version }}" == 8.3* ]]; then

--- a/.github/workflows/INTEGRATION_TEST.yml
+++ b/.github/workflows/INTEGRATION_TEST.yml
@@ -16,6 +16,58 @@ defaults:
     shell: bash
 
 jobs:
+  determine-inputs:
+    runs-on: ubuntu-latest
+    outputs:
+      camunda-helm-git-ref: ${{ steps.set_vars.outputs.camunda-helm-git-ref }}
+      extra-values-url: ${{ steps.set_vars.outputs.extra-values-url }}
+    steps:
+      - name: Define version map
+        run: |
+          if [[ "${{ inputs.connectors_version }}" == 8.3* ]]; then
+            echo "Setting variables for 8.3"
+            echo "::set-output name=camunda-helm-git-ref::$(echo $VARS_8_3 | jq -r '.camunda-helm-git-ref')"
+            echo "::set-output name=extra-values-url::$(echo $VARS_8_3 | jq -r '.extra-values-url')"
+          elif [[ "${{ inputs.connectors_version }}" == 8.4* ]]; then
+            echo "Setting variables for 8.4"
+            echo "::set-output name=camunda-helm-git-ref::$(echo $VARS_8_4 | jq -r '.camunda-helm-git-ref')"
+            echo "::set-output name=extra-values-url::$(echo $VARS_8_4 | jq -r '.extra-values-url')"
+          elif [[ "${{ inputs.connectors_version }}" == 8.5* ]]; then
+            echo "Setting variables for 8.5"
+            echo "::set-output name=camunda-helm-git-ref::$(echo $VARS_8_5 | jq -r '.camunda-helm-git-ref')"
+            echo "::set-output name=extra-values-url::$(echo $VARS_8_5 | jq -r '.extra-values-url')"
+          else
+            echo "Version does not match a supported minor version, setting outputs to null"
+            echo "::set-output name=camunda-helm-git-ref::null"
+            echo "::set-output name=extra-values-url::null"
+          fi
+        env:
+          VARS_8_3: '{"camunda-helm-git-ref": "camunda-platform-8.3", "extra-values-url": "https://raw.githubusercontent.com/camunda/camunda-platform-helm/main/charts/camunda-platform/values/values-v8.3.yaml"}'
+          VARS_8_4: '{"camunda-helm-git-ref": "camunda-platform-8.4", "extra-values-url": "https://raw.githubusercontent.com/camunda/camunda-platform-helm/main/charts/camunda-platform/values/values-v8.4.yaml"}'
+          VARS_8_5: '{"camunda-helm-git-ref": "main", "extra-values-url": "https://raw.githubusercontent.com/camunda/camunda-platform-helm/main/charts/camunda-platform/values/values-latest.yaml"}'
+
+  get-extra-values:
+      needs: determine-inputs
+      if: ${{ needs.determine-inputs.outputs.extra-values-url != 'null' }}
+      runs-on: ubuntu-latest
+      steps:
+        - name: HTTP Request Action
+          id: extra-values-content
+          uses: fjogeleit/http-request-action@v1.15.5
+          with:
+            url: ${{ needs.process_version.outputs.extra-values-url }}
+        - name: WIP Take HTTP response and convert into a .yaml file
+          run: |
+            echo ${{ steps.extra-values-content.outputs.response }}
+            echo ${{ steps.extra-values-content.outputs.headers }}
+            echo ${{ steps.extra-values-content.outputs.status }}
+        - name: WIP Take YAML file from last step and delete the connectors value
+          uses: mikefarah/yq@v4.44.1
+          # hint: https://github.com/marketplace/actions/yq-portable-yaml-processor#github-action
+        -
+
+
+
   helm-deploy:
     name: Helm chart Integration Tests
     uses: camunda/camunda-platform-helm/.github/workflows/test-integration-template.yaml@main

--- a/.github/workflows/INTEGRATION_TEST.yml
+++ b/.github/workflows/INTEGRATION_TEST.yml
@@ -64,18 +64,29 @@ jobs:
         - name: WIP Take YAML file from last step and delete the connectors value
           uses: mikefarah/yq@v4.44.1
           # hint: https://github.com/marketplace/actions/yq-portable-yaml-processor#github-action
-        -
+          # output to something like "non-connectors-extra-values"
 
+  use-input-connectors-version-in-extra-values:
+    needs: get-extra-values
+    runs-on: ubuntu-latest
+    steps:
+      - name: WIP Only Set Extra Values as Connectors By Default
+      - name: WIP Append input connectors version to non-connectors-extra-values from previous
+        uses: mikefarah/yq@v4.44.1
+        # hint: https://github.com/marketplace/actions/yq-portable-yaml-processor#github-action
+        # append this yaml for the connectors version:
+        #   connectors:
+        #      image:
+        #        tag: ${{ github.event.inputs.connectors_version }}
 
 
   helm-deploy:
+    needs: [determine-inputs, use-input-connectors-version-in-extra-values]
     name: Helm chart Integration Tests
     uses: camunda/camunda-platform-helm/.github/workflows/test-integration-template.yaml@main
     secrets: inherit
     with:
       identifier: connectors-int
       test-enabled: true
-      extra-values: |
-        connectors:
-          image:
-            tag: ${{ github.event.inputs.connectors_version }}
+      camunda-helm-git-ref: ${{ TO_DEFINE_FROM_LAST_STEP || 'main' }}
+      extra-values: ${{ TO_DEFINE_FROM_LAST_STEP }}


### PR DESCRIPTION
## Description

Previously, `INTEGRATION_TEST.md` would always pass in the default values. This works well for SNAPSHOT's.

However, for patches on minor versions (especially 8.3), the Helm integration tests need to be passed in dependencies that correspond to the that minor version.

This PR will:
- determine the correct dependencies to pass in
- determine the correct Helm chart to use
- call the `integration-test-template.yml` with these inputs

## Related issues

https://github.com/camunda/team-connectors/issues/764

