### PR TITLE
Helm integration tests for release branches

### DIFF
--- a/.github/workflows/INTEGRATION_TEST.yml
+++ b/.github/workflows/INTEGRATION_TEST.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Determine current Maven project version
         id: maven-version
         run: |
-          echo "version=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)" >> $GITHUB_OUTPUT
+          echo "version=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout -o)" >> $GITHUB_OUTPUT
 
       - name: Determine version of the Connectors image to use
         id: connectors-version

--- a/.github/workflows/INTEGRATION_TEST.yml
+++ b/.github/workflows/INTEGRATION_TEST.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
     inputs:
       connectors-version:
-        description: 'The version of the connectors to test. If not provided, the version is determined based on the Maven project version. On main branch, the default is SNAPSHOT'
+        description: 'The version of the Connectors to test. If not provided, the version is determined based on the Maven project version. On main branch, the default is SNAPSHOT'
         required: false
       helm-branch:
         description: 'The branch of the Helm chart to test against. If not provided, the branch is determined based on the ref (see helm-git-refs.json)'

--- a/.github/workflows/INTEGRATION_TEST.yml
+++ b/.github/workflows/INTEGRATION_TEST.yml
@@ -33,16 +33,10 @@ jobs:
       - name: Install jq
         run: sudo apt-get install jq
 
-      - name: Prepare Java and Maven settings
-        uses: actions/setup-java@v4
-        with:
-          distribution: 'temurin'
-          java-version: '21'
-
       - name: Determine current Maven project version
         id: maven-version
         run: |
-          echo "version=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout -o)" >> $GITHUB_OUTPUT
+          echo "version=$(grep -oPm1 "(?<=<version>)[^<]+" "pom.xml")" >> $GITHUB_OUTPUT
 
       - name: Determine version of the Connectors image to use
         id: connectors-version

--- a/.github/workflows/INTEGRATION_TEST.yml
+++ b/.github/workflows/INTEGRATION_TEST.yml
@@ -33,12 +33,6 @@ jobs:
       - name: Install jq
         run: sudo apt-get install jq
 
-      - name: Prepare Java and Maven settings
-        uses: actions/setup-java@v4
-        with:
-          distribution: 'temurin'
-          java-version: '21'
-
       - name: Determine current Maven project version
         id: maven-version
         run: |
@@ -69,6 +63,11 @@ jobs:
           else
             echo "::set-output name=helm-branch::${{ github.event.inputs.helm-branch }}"
           fi
+
+      - name: Log results
+        run: |
+          echo "Connectors version: ${{ steps.connectors-version.outputs.connectors-version }}"
+          echo "Helm branch: ${{ steps.helm-branch.outputs.helm-branch }}"
 
   helm-deploy:
     needs: prepare-inputs

--- a/.github/workflows/INTEGRATION_TEST.yml
+++ b/.github/workflows/INTEGRATION_TEST.yml
@@ -55,7 +55,7 @@ jobs:
         run: |
           if [ -z "${{ github.event.inputs.helm-branch }}" ]; then
             helm_branch=$(jq -r ".[\"${{ github.ref }}\"]" .github/workflows/helm-git-refs.json)
-            if [ -z "$helm_branch" ]; then
+            if [ -z "$helm_branch" ] || [ "$helm_branch" == "null" ]; then
               echo "::error::Could not determine Helm chart branch to use, please provide helm-branch input or adjust the mappings in .github/workflows/helm-git-refs.json"
               exit 1
             fi

--- a/.github/workflows/INTEGRATION_TEST.yml
+++ b/.github/workflows/INTEGRATION_TEST.yml
@@ -21,8 +21,12 @@ defaults:
     shell: bash
 
 jobs:
-  helm-deploy:
+  prepare-inputs:
     runs-on: ubuntu-latest
+    name: Prepare inputs
+    outputs:
+      connectors-version: ${{ steps.maven-version.outputs.version }}
+      helm-branch: ${{ steps.helm-branch.outputs.helm-branch }}
     steps:
       - uses: actions/checkout@v2
 
@@ -59,14 +63,17 @@ jobs:
           else
             echo "::set-output name=helm-branch::${{ github.event.inputs.helm-branch }}"
           fi
-      - name: Helm chart Integration Tests
-        uses: camunda/camunda-platform-helm/.github/workflows/test-integration-template.yaml@main
-        secrets: inherit
-        with:
-          identifier: connectors-int
-          camunda-helm-git-ref: ${{ steps.helm-branch.outputs.helm-branch }}
-          test-enabled: true
-          extra-values: |
-            connectors:
-              image:
-                tag: ${{ steps.connectors-version.outputs.connectors-version }}
+
+  helm-deploy:
+    needs: prepare-inputs
+    name: Helm chart Integration Tests
+    uses: camunda/camunda-platform-helm/.github/workflows/test-integration-template.yaml@main
+    secrets: inherit
+    with:
+      identifier: connectors-int
+      camunda-helm-git-ref: ${{ needs.prepare-inputs.outputs.helm-branch }}
+      test-enabled: true
+      extra-values: |
+        connectors:
+          image:
+            tag: ${{ needs.prepare-inputs.outputs.connectors-version }}

--- a/.github/workflows/INTEGRATION_TEST.yml
+++ b/.github/workflows/INTEGRATION_TEST.yml
@@ -42,19 +42,19 @@ jobs:
       - name: Determine current Maven project version
         id: maven-version
         run: |
-          echo "::set-output name=version::$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)"
+          echo "version=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)" >> $GITHUB_OUTPUT
 
       - name: Determine version of the Connectors image to use
         id: connectors-version
         run: |
           if [ -z "${{ github.event.inputs.connectors-version }}" ]; then
             if [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
-              echo "::set-output name=connectors-version::SNAPSHOT"
+              echo "connectors-version=SNAPSHOT" >> $GITHUB_OUTPUT
             else
-              echo "::set-output name=connectors-version::${{ steps.maven-version.outputs.version }}"
+              echo "connectors-version=${{ steps.maven-version.outputs.version }}" >> $GITHUB_OUTPUT
             fi
           else
-            echo "::set-output name=connectors-version::${{ github.event.inputs.connectors-version }}"
+            echo "connectors-version=${{ github.event.inputs.connectors-version }}" >> $GITHUB_OUTPUT
           fi
 
       - name: Determine Helm chart ref to use
@@ -65,9 +65,9 @@ jobs:
               echo "::error::Could not determine Helm chart branch to use, please provide helm-branch input or adjust the mappings in .github/workflows/helm-git-refs.json"
               exit 1
             fi
-            echo "::set-output name=helm-branch::$helm_branch"
+            echo "helm-branch=$helm_branch" >> $GITHUB_OUTPUT
           else
-            echo "::set-output name=helm-branch::${{ github.event.inputs.helm-branch }}"
+            echo "helm-branch=${{ github.event.inputs.helm-branch }}" >> $GITHUB_OUTPUT
           fi
 
       - name: Log results

--- a/.github/workflows/INTEGRATION_TEST.yml
+++ b/.github/workflows/INTEGRATION_TEST.yml
@@ -2,12 +2,17 @@
 name: Integration test
 
 on:
+  push:
+    branches:
+      - release/*
   workflow_dispatch:
     inputs:
-      connectors_version:
-        description: 'The version of the connectors to test'
-        required: true
-        default: 'SNAPSHOT'
+      connectors-version:
+        description: 'The version of the connectors to test. If not provided, the version is determined based on the Maven project version. On main branch, the default is SNAPSHOT'
+        required: false
+      helm-branch:
+        description: 'The branch of the Helm chart to test against. If not provided, the branch is determined based on the ref (see helm-git-refs.json)'
+        required: false
 
 defaults:
   run:
@@ -17,13 +22,51 @@ defaults:
 
 jobs:
   helm-deploy:
-    name: Helm chart Integration Tests
-    uses: camunda/camunda-platform-helm/.github/workflows/test-integration-template.yaml@main
-    secrets: inherit
-    with:
-      identifier: connectors-int
-      test-enabled: true
-      extra-values: |
-        connectors:
-          image:
-            tag: ${{ github.event.inputs.connectors_version }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install jq
+        run: sudo apt-get install jq
+
+      - name: Determine current Maven project version
+        id: maven-version
+        run: |
+          echo "::set-output name=version::$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)"
+
+      - name: Determine version of the Connectors image to use
+        id: connectors-version
+        run: |
+          if [ -z "${{ github.event.inputs.connectors-version }}" ]; then
+            if [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
+              echo "::set-output name=connectors-version::SNAPSHOT"
+            else
+              echo "::set-output name=connectors-version::${{ steps.maven-version.outputs.version }}"
+            fi
+          else
+            echo "::set-output name=connectors-version::${{ github.event.inputs.connectors-version }}"
+          fi
+
+      - name: Determine Helm chart ref to use
+        run: |
+          if [ -z "${{ github.event.inputs.helm-branch }}" ]; then
+            helm_branch=$(jq -r ".[\"${{ github.ref }}\"]" .github/workflows/helm-git-refs.json)
+            if [ -z "$helm_branch" ]; then
+              echo "::error::Could not determine Helm chart branch to use, please provide helm-branch input or adjust the mappings in .github/workflows/helm-git-refs.json"
+              exit 1
+            fi
+            echo "::set-output name=helm-branch::$helm_branch"
+          else
+            echo "::set-output name=helm-branch::${{ github.event.inputs.helm-branch }}"
+          fi
+      - name: Helm chart Integration Tests
+        uses: camunda/camunda-platform-helm/.github/workflows/test-integration-template.yaml@main
+        secrets: inherit
+        with:
+          identifier: connectors-int
+          camunda-helm-git-ref: ${{ steps.helm-branch.outputs.helm-branch }}
+          test-enabled: true
+          extra-values: |
+            connectors:
+              image:
+                tag: ${{ steps.connectors-version.outputs.connectors-version }}

--- a/.github/workflows/INTEGRATION_TEST.yml
+++ b/.github/workflows/INTEGRATION_TEST.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Prepare inputs
     outputs:
-      connectors-version: ${{ steps.maven-version.outputs.version }}
+      connectors-version: ${{ steps.connectors-version.outputs.connectors-version }}
       helm-branch: ${{ steps.helm-branch.outputs.helm-branch }}
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/INTEGRATION_TEST.yml
+++ b/.github/workflows/INTEGRATION_TEST.yml
@@ -58,6 +58,7 @@ jobs:
           fi
 
       - name: Determine Helm chart ref to use
+        id: helm-branch
         run: |
           if [ -z "${{ github.event.inputs.helm-branch }}" ]; then
             helm_branch=$(jq -r ".[\"${{ github.ref }}\"]" .github/workflows/helm-git-refs.json)

--- a/.github/workflows/INTEGRATION_TEST.yml
+++ b/.github/workflows/INTEGRATION_TEST.yml
@@ -33,6 +33,12 @@ jobs:
       - name: Install jq
         run: sudo apt-get install jq
 
+      - name: Prepare Java and Maven settings
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+
       - name: Determine current Maven project version
         id: maven-version
         run: |

--- a/.github/workflows/helm-git-refs.json
+++ b/.github/workflows/helm-git-refs.json
@@ -1,0 +1,7 @@
+{
+  "refs/heads/main": "main",
+  "refs/heads/release/8.6": "main",
+  "refs/heads/release/8.5": "main",
+  "refs/heads/release/8.4": "camunda-platform-8.4",
+  "refs/heads/release/8.3": "camunda-platform-8.3"
+}


### PR DESCRIPTION
## Description

Follow up on https://github.com/camunda/connectors/pull/2530.

Previously, INTEGRATION_TEST.md would always pass in the default values. This works well for SNAPSHOT's.

However, for patches on minor versions (especially 8.3), the Helm integration tests need to be passed in dependencies that correspond to the that minor version.

This PR will:

 - determine the correct connectors version to use based on the maven project version (if not provided)
 - determine the correct Helm chart to use (i.e. Helm chart repository git ref)
 - call the integration-test-template.yml with these inputs

ℹ️ Compared to the PR from @ev-codes (#2530), this approach should be simpler because it assumes that we don't need to provide the whole values file in `extraValues` when calling a custom Helm charts branch.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes https://github.com/camunda/team-connectors/issues/764

