### PR TITLE
fix(inbound-state-management): inbound state management bug fixes

### DIFF
--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/executable/BatchExecutableProcessor.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/executable/BatchExecutableProcessor.java
@@ -33,6 +33,7 @@ import io.camunda.connector.runtime.inbound.executable.RegisteredExecutable.Inva
 import io.camunda.connector.runtime.inbound.webhook.WebhookConnectorRegistry;
 import io.camunda.connector.runtime.metrics.ConnectorMetrics.Inbound;
 import io.camunda.zeebe.spring.client.metrics.MetricsRecorder;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -108,7 +109,7 @@ public class BatchExecutableProcessor {
               failed.reason());
 
           // deactivate all previously activated connectors
-          deactivateBatch(List.of(failed));
+          deactivateBatch(new ArrayList<>(alreadyActivated.values()));
 
           var failureReasonForOthers =
               "Process contains invalid connector(s): "
@@ -199,6 +200,7 @@ public class BatchExecutableProcessor {
     for (var activeExecutable : executables) {
       if (activeExecutable instanceof Activated activated) {
         try {
+          LOG.info("Deactivating executable: {}", activated.context().getDefinition().type());
           if (activated.executable() instanceof WebhookConnectorExecutable) {
             LOG.debug("Unregistering webhook: {}", activated.context().getDefinition().type());
             webhookConnectorRegistry.deregister(activated);

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/executable/InboundExecutableRegistryImpl.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/executable/InboundExecutableRegistryImpl.java
@@ -53,7 +53,7 @@ public class InboundExecutableRegistryImpl implements InboundExecutableRegistry 
   private final BatchExecutableProcessor batchExecutableProcessor;
 
   private final Map<ProcessElement, UUID> executablesByElement = new ConcurrentHashMap<>();
-  private final Map<UUID, RegisteredExecutable> executables = new HashMap<>();
+  final Map<UUID, RegisteredExecutable> executables = new HashMap<>();
 
   private static final Logger LOG = LoggerFactory.getLogger(InboundExecutableRegistryImpl.class);
 

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/state/ProcessStateStoreImpl.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/state/ProcessStateStoreImpl.java
@@ -38,7 +38,10 @@ public class ProcessStateStoreImpl implements ProcessStateStore {
   private final InboundExecutableRegistry executableRegistry;
 
   private record ProcessState(
-      int version, long processDefinitionKey, List<InboundConnectorElement> connectorElements) {}
+      int version,
+      long processDefinitionKey,
+      String tenantId,
+      List<InboundConnectorElement> connectorElements) {}
 
   public ProcessStateStoreImpl(
       ProcessDefinitionInspector processDefinitionInspector,
@@ -95,6 +98,7 @@ public class ProcessStateStoreImpl implements ProcessStateStore {
             return new ProcessState(
                 entry.getValue().version(),
                 entry.getValue().processDefinitionKey(),
+                entry.getKey().tenantId(),
                 connectorElements);
           });
     } catch (Throwable e) {
@@ -118,6 +122,7 @@ public class ProcessStateStoreImpl implements ProcessStateStore {
             return new ProcessState(
                 entry.getValue().version(),
                 entry.getValue().processDefinitionKey(),
+                entry.getKey().tenantId(),
                 newConnectorElements);
           });
     } catch (Throwable e) {
@@ -131,7 +136,7 @@ public class ProcessStateStoreImpl implements ProcessStateStore {
       processStates.computeIfPresent(
           processId,
           (key1, state) -> {
-            var tenantId = state.connectorElements.getFirst().element().tenantId();
+            var tenantId = state.tenantId;
             deactivate(tenantId, state.processDefinitionKey);
             return null;
           });

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/webhook/WebhookConnectorRegistry.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/webhook/WebhookConnectorRegistry.java
@@ -44,6 +44,11 @@ public class WebhookConnectorRegistry {
   public void register(RegisteredExecutable.Activated connector) {
     var properties = connector.context().bindProperties(CommonWebhookProperties.class);
     var context = properties.getContext();
+    if (context == null) {
+      var logMessage = "Webhook path not provided";
+      LOG.debug(logMessage);
+      throw new RuntimeException(logMessage);
+    }
 
     WebhookConnectorValidationUtil.logIfWebhookPathDeprecated(connector, context);
 

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/webhook/WebhookConnectorValidationUtil.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/webhook/WebhookConnectorValidationUtil.java
@@ -32,7 +32,9 @@ final class WebhookConnectorValidationUtil {
   private static final String DEPRECATED_WEBHOOK_MESSAGE_PREFIX = "Deprecated webhook path: ";
 
   static void logIfWebhookPathDeprecated(RegisteredExecutable.Activated connector, String webhook) {
-
+    if (webhook == null) {
+      return;
+    }
     if (!CURRENT_WEBHOOK_PATH_PATTERN.matcher(webhook).matches()) {
       String message =
           DEPRECATED_WEBHOOK_MESSAGE_PREFIX + webhook + DEPRECATED_WEBHOOK_MESSAGE_SUFFIX;


### PR DESCRIPTION
## Description

This PR will fix the following issues from 8.6.0-alpha1:

- Webhook connector not being able to recover from duplicate context path (see linked issue). Root cause was incorrect deactivation in `BatchExecutableProcessor:111`
- Unhandled exception in `WebhookConnectorValidationUtil:36` when webhook path is missing (rare find but still possible with an invalid / old element template)
- Unhandled exception when trying to delete a process that contains no inbound connectors, `ProcessStateStoreImpl:134`. Discovered in one of our alerts.

I also added a couple of tests for batch activation cases that check the correct batch activation / error handling logic.

## Related issues

<!-- Which issues are closed by this PR or are related -->

related to https://github.com/camunda/connectors/issues/2565

