### PR TITLE
feat(sqs, kafka): enable acknowledgment config

### DIFF
--- a/connectors/aws/aws-sqs/element-templates/aws-sqs-boundary-connector.json
+++ b/connectors/aws/aws-sqs/element-templates/aws-sqs-boundary-connector.json
@@ -201,6 +201,17 @@
     },
     "type" : "String"
   }, {
+    "id" : "consumeUnmatchedEvents",
+    "label" : "Consume unmatched events",
+    "value" : false,
+    "group" : "activation",
+    "binding" : {
+      "name" : "consumeUnmatchedEvents",
+      "type" : "zeebe:property"
+    },
+    "tooltip" : "Unmatched events are rejected by default, allowing the upstream service to handle the error. Check this box to consume unmatched events and return a success response",
+    "type" : "Boolean"
+  }, {
     "id" : "correlationKeyProcess",
     "label" : "Correlation key (process)",
     "description" : "Sets up the correlation key from process variables",

--- a/connectors/aws/aws-sqs/element-templates/aws-sqs-inbound-intermediate-connector.json
+++ b/connectors/aws/aws-sqs/element-templates/aws-sqs-inbound-intermediate-connector.json
@@ -201,6 +201,17 @@
     },
     "type" : "String"
   }, {
+    "id" : "consumeUnmatchedEvents",
+    "label" : "Consume unmatched events",
+    "value" : false,
+    "group" : "activation",
+    "binding" : {
+      "name" : "consumeUnmatchedEvents",
+      "type" : "zeebe:property"
+    },
+    "tooltip" : "Unmatched events are rejected by default, allowing the upstream service to handle the error. Check this box to consume unmatched events and return a success response",
+    "type" : "Boolean"
+  }, {
     "id" : "correlationKeyProcess",
     "label" : "Correlation key (process)",
     "description" : "Sets up the correlation key from process variables",

--- a/connectors/aws/aws-sqs/element-templates/aws-sqs-start-event-connector.json
+++ b/connectors/aws/aws-sqs/element-templates/aws-sqs-start-event-connector.json
@@ -196,6 +196,17 @@
     },
     "type" : "String"
   }, {
+    "id" : "consumeUnmatchedEvents",
+    "label" : "Consume unmatched events",
+    "value" : false,
+    "group" : "activation",
+    "binding" : {
+      "name" : "consumeUnmatchedEvents",
+      "type" : "zeebe:property"
+    },
+    "tooltip" : "Unmatched events are rejected by default, allowing the upstream service to handle the error. Check this box to consume unmatched events and return a success response",
+    "type" : "Boolean"
+  }, {
     "id" : "deduplicationModeManualFlag",
     "label" : "Manual mode",
     "description" : "By default, similar connectors receive the same deduplication ID. Customize by activating manual mode",

--- a/connectors/aws/aws-sqs/element-templates/aws-sqs-start-message.json
+++ b/connectors/aws/aws-sqs/element-templates/aws-sqs-start-message.json
@@ -201,6 +201,17 @@
     },
     "type" : "String"
   }, {
+    "id" : "consumeUnmatchedEvents",
+    "label" : "Consume unmatched events",
+    "value" : false,
+    "group" : "activation",
+    "binding" : {
+      "name" : "consumeUnmatchedEvents",
+      "type" : "zeebe:property"
+    },
+    "tooltip" : "Unmatched events are rejected by default, allowing the upstream service to handle the error. Check this box to consume unmatched events and return a success response",
+    "type" : "Boolean"
+  }, {
     "id" : "correlationRequired",
     "label" : "Subprocess correlation required",
     "description" : "Indicates whether correlation is required. This is needed for event-based subprocess message start events",

--- a/connectors/aws/aws-sqs/pom.xml
+++ b/connectors/aws/aws-sqs/pom.xml
@@ -78,6 +78,7 @@
               </files>
               <features>
                 <INBOUND_DEDUPLICATION>true</INBOUND_DEDUPLICATION>
+                <ACKNOWLEDGEMENT_STRATEGY_SELECTION>true</ACKNOWLEDGEMENT_STRATEGY_SELECTION>
               </features>
             </connector>
           </connectors>

--- a/connectors/kafka/element-templates/hybrid/kafka-inbound-connector-boundary-hybrid.json
+++ b/connectors/kafka/element-templates/hybrid/kafka-inbound-connector-boundary-hybrid.json
@@ -234,6 +234,17 @@
     },
     "type" : "String"
   }, {
+    "id" : "consumeUnmatchedEvents",
+    "label" : "Consume unmatched events",
+    "value" : false,
+    "group" : "activation",
+    "binding" : {
+      "name" : "consumeUnmatchedEvents",
+      "type" : "zeebe:property"
+    },
+    "tooltip" : "Unmatched events are rejected by default, allowing the upstream service to handle the error. Check this box to consume unmatched events and return a success response",
+    "type" : "Boolean"
+  }, {
     "id" : "correlationKeyProcess",
     "label" : "Correlation key (process)",
     "description" : "Sets up the correlation key from process variables",

--- a/connectors/kafka/element-templates/hybrid/kafka-inbound-connector-intermediate-hybrid.json
+++ b/connectors/kafka/element-templates/hybrid/kafka-inbound-connector-intermediate-hybrid.json
@@ -234,6 +234,17 @@
     },
     "type" : "String"
   }, {
+    "id" : "consumeUnmatchedEvents",
+    "label" : "Consume unmatched events",
+    "value" : false,
+    "group" : "activation",
+    "binding" : {
+      "name" : "consumeUnmatchedEvents",
+      "type" : "zeebe:property"
+    },
+    "tooltip" : "Unmatched events are rejected by default, allowing the upstream service to handle the error. Check this box to consume unmatched events and return a success response",
+    "type" : "Boolean"
+  }, {
     "id" : "correlationKeyProcess",
     "label" : "Correlation key (process)",
     "description" : "Sets up the correlation key from process variables",

--- a/connectors/kafka/element-templates/hybrid/kafka-inbound-connector-start-event-hybrid.json
+++ b/connectors/kafka/element-templates/hybrid/kafka-inbound-connector-start-event-hybrid.json
@@ -229,6 +229,17 @@
     },
     "type" : "String"
   }, {
+    "id" : "consumeUnmatchedEvents",
+    "label" : "Consume unmatched events",
+    "value" : false,
+    "group" : "activation",
+    "binding" : {
+      "name" : "consumeUnmatchedEvents",
+      "type" : "zeebe:property"
+    },
+    "tooltip" : "Unmatched events are rejected by default, allowing the upstream service to handle the error. Check this box to consume unmatched events and return a success response",
+    "type" : "Boolean"
+  }, {
     "id" : "deduplicationModeManualFlag",
     "label" : "Manual mode",
     "description" : "By default, similar connectors receive the same deduplication ID. Customize by activating manual mode",

--- a/connectors/kafka/element-templates/hybrid/kafka-inbound-connector-start-message-hybrid.json
+++ b/connectors/kafka/element-templates/hybrid/kafka-inbound-connector-start-message-hybrid.json
@@ -234,6 +234,17 @@
     },
     "type" : "String"
   }, {
+    "id" : "consumeUnmatchedEvents",
+    "label" : "Consume unmatched events",
+    "value" : false,
+    "group" : "activation",
+    "binding" : {
+      "name" : "consumeUnmatchedEvents",
+      "type" : "zeebe:property"
+    },
+    "tooltip" : "Unmatched events are rejected by default, allowing the upstream service to handle the error. Check this box to consume unmatched events and return a success response",
+    "type" : "Boolean"
+  }, {
     "id" : "correlationRequired",
     "label" : "Subprocess correlation required",
     "description" : "Indicates whether correlation is required. This is needed for event-based subprocess message start events",

--- a/connectors/kafka/element-templates/kafka-inbound-connector-boundary.json
+++ b/connectors/kafka/element-templates/kafka-inbound-connector-boundary.json
@@ -229,6 +229,17 @@
     },
     "type" : "String"
   }, {
+    "id" : "consumeUnmatchedEvents",
+    "label" : "Consume unmatched events",
+    "value" : false,
+    "group" : "activation",
+    "binding" : {
+      "name" : "consumeUnmatchedEvents",
+      "type" : "zeebe:property"
+    },
+    "tooltip" : "Unmatched events are rejected by default, allowing the upstream service to handle the error. Check this box to consume unmatched events and return a success response",
+    "type" : "Boolean"
+  }, {
     "id" : "correlationKeyProcess",
     "label" : "Correlation key (process)",
     "description" : "Sets up the correlation key from process variables",

--- a/connectors/kafka/element-templates/kafka-inbound-connector-intermediate.json
+++ b/connectors/kafka/element-templates/kafka-inbound-connector-intermediate.json
@@ -229,6 +229,17 @@
     },
     "type" : "String"
   }, {
+    "id" : "consumeUnmatchedEvents",
+    "label" : "Consume unmatched events",
+    "value" : false,
+    "group" : "activation",
+    "binding" : {
+      "name" : "consumeUnmatchedEvents",
+      "type" : "zeebe:property"
+    },
+    "tooltip" : "Unmatched events are rejected by default, allowing the upstream service to handle the error. Check this box to consume unmatched events and return a success response",
+    "type" : "Boolean"
+  }, {
     "id" : "correlationKeyProcess",
     "label" : "Correlation key (process)",
     "description" : "Sets up the correlation key from process variables",

--- a/connectors/kafka/element-templates/kafka-inbound-connector-start-event.json
+++ b/connectors/kafka/element-templates/kafka-inbound-connector-start-event.json
@@ -224,6 +224,17 @@
     },
     "type" : "String"
   }, {
+    "id" : "consumeUnmatchedEvents",
+    "label" : "Consume unmatched events",
+    "value" : false,
+    "group" : "activation",
+    "binding" : {
+      "name" : "consumeUnmatchedEvents",
+      "type" : "zeebe:property"
+    },
+    "tooltip" : "Unmatched events are rejected by default, allowing the upstream service to handle the error. Check this box to consume unmatched events and return a success response",
+    "type" : "Boolean"
+  }, {
     "id" : "deduplicationModeManualFlag",
     "label" : "Manual mode",
     "description" : "By default, similar connectors receive the same deduplication ID. Customize by activating manual mode",

--- a/connectors/kafka/element-templates/kafka-inbound-connector-start-message.json
+++ b/connectors/kafka/element-templates/kafka-inbound-connector-start-message.json
@@ -229,6 +229,17 @@
     },
     "type" : "String"
   }, {
+    "id" : "consumeUnmatchedEvents",
+    "label" : "Consume unmatched events",
+    "value" : false,
+    "group" : "activation",
+    "binding" : {
+      "name" : "consumeUnmatchedEvents",
+      "type" : "zeebe:property"
+    },
+    "tooltip" : "Unmatched events are rejected by default, allowing the upstream service to handle the error. Check this box to consume unmatched events and return a success response",
+    "type" : "Boolean"
+  }, {
     "id" : "correlationRequired",
     "label" : "Subprocess correlation required",
     "description" : "Indicates whether correlation is required. This is needed for event-based subprocess message start events",

--- a/connectors/kafka/pom.xml
+++ b/connectors/kafka/pom.xml
@@ -120,6 +120,7 @@ except in compliance with the proprietary license.</license.inlineheader>
               <generateHybridTemplates>true</generateHybridTemplates>
               <features>
                 <INBOUND_DEDUPLICATION>true</INBOUND_DEDUPLICATION>
+                <ACKNOWLEDGEMENT_STRATEGY_SELECTION>true</ACKNOWLEDGEMENT_STRATEGY_SELECTION>
               </features>
             </connector>
           </connectors>


### PR DESCRIPTION
## Description

This PR will enable acknowledgment config feature for SQS and Kafka connectors (already supported by the BE implementation of both connectors as part of #2333)

## Related issues

<!-- Which issues are closed by this PR or are related -->

related to #2134 

