### PR TITLE
ci: adjust branch detection

### DIFF
--- a/.github/workflows/RELEASE.yaml
+++ b/.github/workflows/RELEASE.yaml
@@ -30,7 +30,7 @@ jobs:
       - name: Determine release branch name
         id: determine_release_branch
         run: |
-          releaseBranch=$( git branch --contains ${RELEASE_VERSION} --format='%(refname:short)' )
+          releaseBranch=$( git branch --contains ${RELEASE_VERSION} --format='%(refname:short)' | tail -1 )
           git checkout "$releaseBranch"
           echo "releaseBranch=$releaseBranch" >> $GITHUB_OUTPUT
         env:


### PR DESCRIPTION
## Description

This PR will adjust branch detection script to account for (new?) output format of the git command we're running.

Previously we received only one string as an output of this `git branch` command, e.g. `release/8.6`.
Now the output looks like this:

```
(HEAD detached at 8.6.0-alpha2-rc1)
release/8.6
```

(i.e. head detached message was added)

Not sure where this change comes from but this should fix our release pipeline.

