### PR TITLE
chore(error-variables): Rename field from errorVariables to variables

### DIFF
--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/outbound/ConnectorJobHandler.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/outbound/ConnectorJobHandler.java
@@ -97,14 +97,14 @@ public class ConnectorJobHandler implements JobHandler {
     }
     if (exception instanceof ConnectorException connectorException) {
       var code = connectorException.getErrorCode();
-      var errorVariables = connectorException.getErrorVariables();
+      var variables = connectorException.getErrorVariables();
 
       if (code != null) {
         result.put("code", code);
       }
 
-      if (errorVariables != null) {
-        result.put("errorVariables", errorVariables);
+      if (variables != null) {
+        result.put("variables", variables);
       }
     }
     return Map.copyOf(result);


### PR DESCRIPTION
## Description

Renaming the ConnectorException field from  `errorVariables` to `variables` to avoid redundancy. 
