### PR TITLE
Element Template generation: set notEmpty: false explicitly

### DIFF
--- a/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/annotation/TemplateProperty.java
+++ b/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/annotation/TemplateProperty.java
@@ -38,6 +38,7 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.FIELD, ElementType.RECORD_COMPONENT})
 public @interface TemplateProperty {
+  public static boolean OPTIONAL_DEFAULT = false;
 
   /** Custom property ID that can be referenced in conditions */
   String id() default "";
@@ -52,7 +53,7 @@ public @interface TemplateProperty {
   String description() default "";
 
   /** Whether the property should be marked as optional in the element template */
-  boolean optional() default false;
+  boolean optional() default OPTIONAL_DEFAULT;
 
   /**
    * Overrides the property type. By default, the generator will use the field type to determine the

--- a/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/processor/FieldProcessor.java
+++ b/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/processor/FieldProcessor.java
@@ -17,6 +17,7 @@
 package io.camunda.connector.generator.java.processor;
 
 import io.camunda.connector.generator.dsl.PropertyBuilder;
+import io.camunda.connector.generator.java.annotation.TemplateProperty;
 import io.camunda.connector.generator.java.util.TemplateGenerationContext;
 import java.lang.reflect.Field;
 
@@ -24,4 +25,12 @@ public interface FieldProcessor {
 
   void process(
       Field field, PropertyBuilder propertyBuilder, final TemplateGenerationContext context);
+
+  static boolean isOptional(Field field) {
+    var annotation = field.getAnnotation(TemplateProperty.class);
+    if (annotation == null) {
+      return TemplateProperty.OPTIONAL_DEFAULT;
+    }
+    return annotation.optional();
+  }
 }

--- a/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/processor/JakartaValidationFieldProcessor.java
+++ b/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/processor/JakartaValidationFieldProcessor.java
@@ -54,12 +54,11 @@ public class JakartaValidationFieldProcessor implements FieldProcessor {
       constraintsBuilder.pattern(
           new PropertyConstraints.Pattern(pattern.getLeft(), pattern.getRight()));
     }
-
+    if (pattern != null && !hasNotEmptyConstraint(field) && FieldProcessor.isOptional(field)) {
+      constraintsBuilder.notEmpty(false);
+    }
     var constraints = constraintsBuilder.build();
     if (!isConstraintEmpty(constraints)) {
-      if (pattern != null && !hasNotEmptyConstraint(field)) {
-        constraintsBuilder.notEmpty(false);
-      }
       propertyBuilder.constraints(constraints);
     }
   }

--- a/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/processor/JakartaValidationFieldProcessor.java
+++ b/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/processor/JakartaValidationFieldProcessor.java
@@ -57,6 +57,9 @@ public class JakartaValidationFieldProcessor implements FieldProcessor {
 
     var constraints = constraintsBuilder.build();
     if (!isConstraintEmpty(constraints)) {
+      if (pattern != null && !hasNotEmptyConstraint(field)) {
+        constraintsBuilder.notEmpty(false);
+      }
       propertyBuilder.constraints(constraints);
     }
   }

--- a/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/processor/TemplatePropertyFieldProcessor.java
+++ b/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/processor/TemplatePropertyFieldProcessor.java
@@ -37,7 +37,7 @@ public class TemplatePropertyFieldProcessor implements FieldProcessor {
     if (annotation == null) {
       return;
     }
-    builder.optional(annotation.optional());
+    builder.optional(FieldProcessor.isOptional(field));
 
     if (!(builder instanceof DropdownPropertyBuilder)) {
       if (annotation.feel() == Property.FeelMode.system_default) {
@@ -182,6 +182,9 @@ public class TemplatePropertyFieldProcessor implements FieldProcessor {
       builder.minLength(constraintsAnnotation.minLength());
     }
     if (!constraintsAnnotation.pattern().value().isBlank()) {
+      if (!constraintsAnnotation.notEmpty() && propertyAnnotation.optional()) {
+        builder.notEmpty(false);
+      }
       builder.pattern(
           new PropertyConstraints.Pattern(
               constraintsAnnotation.pattern().value(), constraintsAnnotation.pattern().message()));

--- a/element-template-generator/core/src/test/java/io/camunda/connector/generator/java/OutboundClassBasedTemplateGeneratorTest.java
+++ b/element-template-generator/core/src/test/java/io/camunda/connector/generator/java/OutboundClassBasedTemplateGeneratorTest.java
@@ -858,6 +858,27 @@ public class OutboundClassBasedTemplateGeneratorTest extends BaseTest {
       assertThat(notEmptyProperty.getConstraints().minLength()).isNull();
       assertThat(notEmptyProperty.getConstraints().maxLength()).isNull();
     }
+
+    @Test
+    void validationPresent_Pattern_optional() {
+      var template = generator.generate(MyConnectorFunction.MinimallyAnnotated.class).getFirst();
+      var mayBeEmptyOrRegexValidated = getPropertyById("mayBeEmptyOrRegexValidated", template);
+      assertThat(mayBeEmptyOrRegexValidated.getConstraints()).isNotNull();
+      assertThat(mayBeEmptyOrRegexValidated.getConstraints().notEmpty()).isFalse();
+      assertThat(mayBeEmptyOrRegexValidated.getConstraints().minLength()).isNull();
+      assertThat(mayBeEmptyOrRegexValidated.getConstraints().maxLength()).isNull();
+    }
+
+    @Test
+    void validationPresent_Pattern_optional_jakarta() {
+      var template = generator.generate(MyConnectorFunction.MinimallyAnnotated.class).getFirst();
+      var mayBeEmptyOrRegexValidated =
+          getPropertyById("mayBeEmptyOrRegexValidatedJakartaStyle", template);
+      assertThat(mayBeEmptyOrRegexValidated.getConstraints()).isNotNull();
+      assertThat(mayBeEmptyOrRegexValidated.getConstraints().notEmpty()).isFalse();
+      assertThat(mayBeEmptyOrRegexValidated.getConstraints().minLength()).isNull();
+      assertThat(mayBeEmptyOrRegexValidated.getConstraints().maxLength()).isNull();
+    }
   }
 
   @Nested

--- a/element-template-generator/core/src/test/java/io/camunda/connector/generator/java/example/outbound/MyConnectorInput.java
+++ b/element-template-generator/core/src/test/java/io/camunda/connector/generator/java/example/outbound/MyConnectorInput.java
@@ -22,6 +22,7 @@ import io.camunda.connector.generator.java.annotation.TemplateDiscriminatorPrope
 import io.camunda.connector.generator.java.annotation.TemplateProperty;
 import io.camunda.connector.generator.java.annotation.TemplateProperty.DefaultValueType;
 import io.camunda.connector.generator.java.annotation.TemplateProperty.PropertyCondition;
+import io.camunda.connector.generator.java.annotation.TemplateProperty.PropertyConstraints;
 import io.camunda.connector.generator.java.annotation.TemplateProperty.PropertyType;
 import io.camunda.connector.generator.java.annotation.TemplateSubType;
 import io.camunda.connector.generator.java.example.outbound.MyConnectorInput.AnnotatedSealedType.FirstAnnotatedSubType;
@@ -99,7 +100,17 @@ public record MyConnectorInput(
     @TemplateProperty(
             id = "dependsOnBooleanPropertyTrue",
             condition = @PropertyCondition(property = "booleanProperty", equals = "true"))
-        String dependsOnBooleanPropertyTrue) {
+        String dependsOnBooleanPropertyTrue,
+    @TemplateProperty(
+            id = "mayBeEmptyOrRegexValidated",
+            optional = true,
+            constraints =
+                @PropertyConstraints(
+                    pattern = @TemplateProperty.Pattern(value = "xxx", message = "Oh no!")))
+        String mayBeEmptyOrRegexValidated,
+    @TemplateProperty(id = "mayBeEmptyOrRegexValidatedJakartaStyle", optional = true)
+        @Pattern(regexp = "xxx", message = "Oh no!")
+        String mayBeEmptyOrRegexValidatedJakartaStyle) {
 
   sealed interface NonAnnotatedSealedType permits FirstSubType, NestedSealedType, SecondSubType {
 


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

On template generation, there seems to be no way to have `constraints.notEmpty` being set to true.

However, this is currently required to achieve a field that has a regex for validation but may remain empty.

This PR enables this behaviour for template property fields and jakarta validation annotations on processing.

## Related issues

<!-- Which issues are closed by this PR or are related -->

https://github.com/camunda/camunda-modeler/issues/4314#issuecomment-2134494119

closes #

