### PR TITLE
fix(eventbridge): change the default value of the API key locator to use lowercase header name

### DIFF
--- a/connectors/aws/aws-eventbridge/element-templates/aws-eventbridge-connector-boundary.json
+++ b/connectors/aws/aws-eventbridge/element-templates/aws-eventbridge-connector-boundary.json
@@ -270,7 +270,7 @@
       "constraints": {
         "notEmpty": true
       },
-      "value": "=request.headers.apiKey"
+      "value": "=request.headers.apikey"
     },
     {
       "label": "Correlation key (process)",

--- a/connectors/aws/aws-eventbridge/element-templates/aws-eventbridge-connector-intermediate.json
+++ b/connectors/aws/aws-eventbridge/element-templates/aws-eventbridge-connector-intermediate.json
@@ -271,7 +271,7 @@
       "constraints": {
         "notEmpty": true
       },
-      "value": "=request.headers.apiKey"
+      "value": "=request.headers.apikey"
     },
     {
       "label": "Correlation key (process)",

--- a/connectors/aws/aws-eventbridge/element-templates/aws-eventbridge-connector-message-start.json
+++ b/connectors/aws/aws-eventbridge/element-templates/aws-eventbridge-connector-message-start.json
@@ -274,7 +274,7 @@
       "constraints": {
         "notEmpty": true
       },
-      "value": "=request.headers.apiKey"
+      "value": "=request.headers.apikey"
     },
     {
       "label": "Message ID expression",

--- a/connectors/aws/aws-eventbridge/element-templates/aws-eventbridge-connector-start-event.json
+++ b/connectors/aws/aws-eventbridge/element-templates/aws-eventbridge-connector-start-event.json
@@ -259,7 +259,7 @@
       "constraints": {
         "notEmpty": true
       },
-      "value": "=request.headers.apiKey"
+      "value": "=request.headers.apikey"
     },
     {
       "label": "Condition",


### PR DESCRIPTION
## Description

I changed the default value of the API key locator expression in the EventBridge inbound connector templates by replacing the `camelCase` header name with a `lowercase` header name, since we currently only support lowercase header names.

## Related issues

related to https://github.com/camunda/connectors/issues/2684
Note that this PR will not fix the issue, but it will mitigate the effects for the EventBridge inbound connector.

