### PR TITLE
ignore major and minor on release branches

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,6 +9,12 @@
       "automerge": true
     },
     {
+      "matchManagers": ["maven"],
+      "matchBaseBranches": ["/^release/.*/"],
+      "matchUpdateTypes": ["major", "minor"],
+      "enabled": false
+    },
+    {
       "matchPackagePrefixes": ["io.camunda.connector"],
       "enabled": false
     },


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

This PR adds a rule to renovate to ignore major and minor releases on release branches as they should only contain patches by nature.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #

