### PR TITLE
fix(docs): Fix wrong documentation link

### DIFF
--- a/connectors/aws/aws-sagemaker/element-templates/aws-sagemaker-outbound-connector.json
+++ b/connectors/aws/aws-sagemaker/element-templates/aws-sagemaker-outbound-connector.json
@@ -3,7 +3,7 @@
   "name" : "AWS SageMaker Outbound Connector",
   "id" : "io.camunda.connectors.AWSSAGEMAKER.v1",
   "description" : "Execute SageMaker models",
-  "documentationRef" : "https://docs.camunda.io/docs/next/components/connectors/out-of-the-box-connectors/aws-sagemaker/",
+  "documentationRef" : "https://docs.camunda.io/docs/next/components/connectors/out-of-the-box-connectors/amazon-sagemaker/",
   "version" : 1,
   "category" : {
     "id" : "connectors",

--- a/connectors/aws/aws-sagemaker/element-templates/hybrid/aws-sagemaker-outbound-connector-hybrid.json
+++ b/connectors/aws/aws-sagemaker/element-templates/hybrid/aws-sagemaker-outbound-connector-hybrid.json
@@ -3,7 +3,7 @@
   "name" : "Hybrid AWS SageMaker Outbound Connector",
   "id" : "io.camunda.connectors.AWSSAGEMAKER.v1-hybrid",
   "description" : "Execute SageMaker models",
-  "documentationRef" : "https://docs.camunda.io/docs/next/components/connectors/out-of-the-box-connectors/aws-sagemaker/",
+  "documentationRef" : "https://docs.camunda.io/docs/next/components/connectors/out-of-the-box-connectors/amazon-sagemaker/",
   "version" : 1,
   "category" : {
     "id" : "connectors",

--- a/connectors/aws/aws-sagemaker/src/main/java/io/camunda/connector/sagemaker/SagemakerConnectorFunction.java
+++ b/connectors/aws/aws-sagemaker/src/main/java/io/camunda/connector/sagemaker/SagemakerConnectorFunction.java
@@ -38,7 +38,7 @@ import java.util.function.BiFunction;
       @ElementTemplate.PropertyGroup(id = "input", label = "Configure input")
     },
     documentationRef =
-        "https://docs.camunda.io/docs/next/components/connectors/out-of-the-box-connectors/aws-sagemaker/",
+        "https://docs.camunda.io/docs/next/components/connectors/out-of-the-box-connectors/amazon-sagemaker/",
     icon = "icon.svg")
 public class SagemakerConnectorFunction implements OutboundConnectorFunction {
 


### PR DESCRIPTION
## Description
The documentation link is broken in the element template.

It's: https://docs.camunda.io/docs/next/components/connectors/out-of-the-box-connectors/aws-sagemaker/

It should be: https://docs.camunda.io/docs/next/components/connectors/out-of-the-box-connectors/amazon-sagemaker/


## Related issues

closes https://github.com/camunda/team-connectors/issues/800

