### PR TITLE
ci(integration): use new args for re-usable Helm integration test

### DIFF
--- a/.github/workflows/INTEGRATION_TEST.yml
+++ b/.github/workflows/INTEGRATION_TEST.yml
@@ -62,12 +62,12 @@ jobs:
         id: helm-dir
         run: |
           if [ -z "${{ inputs.helm-dir }}" ]; then
-            helm_branch=$(jq -r ".[\"${{ inputs.release-branch || github.ref_name }}\"]" .github/workflows/helm-git-refs.json)
-            if [ -z "$helm_branch" ] || [ "$helm_branch" == "null" ]; then
-              echo "::error::Could not determine Helm chart branch to use, please provide helm-dir input or adjust the mappings in .github/workflows/helm-git-refs.json"
+            helm_dir=$(jq -r ".[\"${{ inputs.release-branch || github.ref_name }}\"]" .github/workflows/helm-git-refs.json)
+            if [ -z "$helm_dir" ] || [ "$helm_dir" == "null" ]; then
+              echo "::error::Could not determine Helm chart dir to use, please provide helm-dir input or adjust the mappings in .github/workflows/helm-git-refs.json"
               exit 1
             fi
-            echo "helm-dir=$helm_branch" >> $GITHUB_OUTPUT
+            echo "helm-dir=$helm_dir" >> $GITHUB_OUTPUT
           else
             echo "helm-dir=${{ inputs.helm-dir }}" >> $GITHUB_OUTPUT
           fi

--- a/.github/workflows/INTEGRATION_TEST.yml
+++ b/.github/workflows/INTEGRATION_TEST.yml
@@ -9,7 +9,7 @@ on:
         required: false
         type: string
       release-branch:
-        description: 'Connectors release branch containing code to test. If not provided, the Helm branch is determined based on the ref (see helm-git-refs.json)'
+        description: 'Connectors release branch containing code to test. If not provided, the Helm directory is determined based on the ref this workflow was triggered on (see helm-git-refs.json)'
         required: false
         type: string
   workflow_dispatch:
@@ -18,7 +18,7 @@ on:
         description: 'The version of the Connectors to test. If not provided, the version is determined based on the Maven project version. On main branch, the default is SNAPSHOT'
         required: false
       helm-dir:
-        description: 'The branch of the Helm chart to test against. If not provided, the branch is determined based on the ref (see helm-git-refs.json)'
+        description: 'The camunda-platform-helm/charts directory of the Helm chart to test against. If not provided, the directory is determined based on the ref this workflow was triggered on (see helm-git-refs.json)'
         required: false
 
 defaults:
@@ -75,7 +75,7 @@ jobs:
       - name: Log results
         run: |
           echo "Connectors version: ${{ steps.connectors-version.outputs.connectors-version }}"
-          echo "Helm branch: ${{ steps.helm-dir.outputs.helm-dir }}"
+          echo "Helm dir: ${{ steps.helm-dir.outputs.helm-dir }}"
 
   helm-deploy:
     needs: prepare-inputs

--- a/.github/workflows/INTEGRATION_TEST.yml
+++ b/.github/workflows/INTEGRATION_TEST.yml
@@ -62,12 +62,12 @@ jobs:
         id: determine-helm-dir
         run: |
           if [ -z "${{ inputs.helm-dir }}" ]; then
-            helm_dir=$(jq -r ".[\"${{ inputs.release-branch || github.ref_name }}\"]" .github/workflows/helm-git-refs.json)
-            if [ -z "$helm_dir" ] || [ "$helm_dir" == "null" ]; then
+            helm_dir_from_map=$(jq -r ".[\"${{ inputs.release-branch || github.ref_name }}\"]" .github/workflows/helm-git-refs.json)
+            if [ -z "$helm_dir_from_map" ] || [ "$helm_dir_from_map" == "null" ]; then
               echo "::error::Could not determine Helm chart dir to use, please provide helm-dir input or adjust the mappings in .github/workflows/helm-git-refs.json"
               exit 1
             fi
-            echo "helm-dir=$helm_dir" >> $GITHUB_OUTPUT
+            echo "helm-dir=$helm_dir_from_map" >> $GITHUB_OUTPUT
           else
             echo "helm-dir=${{ inputs.helm-dir }}" >> $GITHUB_OUTPUT
           fi

--- a/.github/workflows/INTEGRATION_TEST.yml
+++ b/.github/workflows/INTEGRATION_TEST.yml
@@ -17,7 +17,7 @@ on:
       connectors-version:
         description: 'The version of the Connectors to test. If not provided, the version is determined based on the Maven project version. On main branch, the default is SNAPSHOT'
         required: false
-      helm-branch:
+      helm-dir:
         description: 'The branch of the Helm chart to test against. If not provided, the branch is determined based on the ref (see helm-git-refs.json)'
         required: false
 
@@ -33,7 +33,7 @@ jobs:
     name: Prepare inputs
     outputs:
       connectors-version: ${{ steps.connectors-version.outputs.connectors-version }}
-      helm-branch: ${{ steps.helm-branch.outputs.helm-branch }}
+      helm-dir: ${{ steps.helm-dir.outputs.helm-dir }}
     steps:
       - uses: actions/checkout@v2
 
@@ -59,23 +59,23 @@ jobs:
           fi
 
       - name: Determine Helm chart ref to use
-        id: helm-branch
+        id: helm-dir
         run: |
-          if [ -z "${{ inputs.helm-branch }}" ]; then
+          if [ -z "${{ inputs.helm-dir }}" ]; then
             helm_branch=$(jq -r ".[\"${{ inputs.release-branch || github.ref_name }}\"]" .github/workflows/helm-git-refs.json)
             if [ -z "$helm_branch" ] || [ "$helm_branch" == "null" ]; then
-              echo "::error::Could not determine Helm chart branch to use, please provide helm-branch input or adjust the mappings in .github/workflows/helm-git-refs.json"
+              echo "::error::Could not determine Helm chart branch to use, please provide helm-dir input or adjust the mappings in .github/workflows/helm-git-refs.json"
               exit 1
             fi
-            echo "helm-branch=$helm_branch" >> $GITHUB_OUTPUT
+            echo "helm-dir=$helm_branch" >> $GITHUB_OUTPUT
           else
-            echo "helm-branch=${{ inputs.helm-branch }}" >> $GITHUB_OUTPUT
+            echo "helm-dir=${{ inputs.helm-dir }}" >> $GITHUB_OUTPUT
           fi
 
       - name: Log results
         run: |
           echo "Connectors version: ${{ steps.connectors-version.outputs.connectors-version }}"
-          echo "Helm branch: ${{ steps.helm-branch.outputs.helm-branch }}"
+          echo "Helm branch: ${{ steps.helm-dir.outputs.helm-dir }}"
 
   helm-deploy:
     needs: prepare-inputs
@@ -84,7 +84,7 @@ jobs:
     secrets: inherit
     with:
       identifier: connectors-int
-      camunda-helm-dir: ${{ needs.prepare-inputs.outputs.helm-branch }}
+      camunda-helm-dir: ${{ needs.prepare-inputs.outputs.helm-dir }}
       test-enabled: true
       extra-values: |
         connectors:

--- a/.github/workflows/INTEGRATION_TEST.yml
+++ b/.github/workflows/INTEGRATION_TEST.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Prepare inputs
     outputs:
-      connectors-version: ${{ steps.connectors-version.outputs.connectors-version }}
+      connectors-version: ${{ steps.determine-connectors-version.outputs.connectors-version }}
       helm-dir: ${{ steps.helm-dir.outputs.helm-dir }}
     steps:
       - uses: actions/checkout@v2
@@ -46,7 +46,7 @@ jobs:
           echo "version=$(grep -oPm1 "(?<=<version>)[^<]+" "pom.xml")" >> $GITHUB_OUTPUT
 
       - name: Determine version of the Connectors image to use
-        id: connectors-version
+        id: determine-connectors-version
         run: |
           if [ -z "${{ inputs.connectors-version }}" ]; then
             if [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
@@ -74,7 +74,7 @@ jobs:
 
       - name: Log results
         run: |
-          echo "Connectors version: ${{ steps.connectors-version.outputs.connectors-version }}"
+          echo "Connectors version: ${{ steps.determine-connectors-version.outputs.connectors-version }}"
           echo "Helm dir: ${{ steps.helm-dir.outputs.helm-dir }}"
 
   helm-deploy:

--- a/.github/workflows/INTEGRATION_TEST.yml
+++ b/.github/workflows/INTEGRATION_TEST.yml
@@ -84,7 +84,7 @@ jobs:
     secrets: inherit
     with:
       identifier: connectors-int
-      camunda-helm-git-ref: ${{ needs.prepare-inputs.outputs.helm-branch }}
+      camunda-helm-dir: ${{ needs.prepare-inputs.outputs.helm-branch }}
       test-enabled: true
       extra-values: |
         connectors:

--- a/.github/workflows/INTEGRATION_TEST.yml
+++ b/.github/workflows/INTEGRATION_TEST.yml
@@ -33,7 +33,7 @@ jobs:
     name: Prepare inputs
     outputs:
       connectors-version: ${{ steps.determine-connectors-version.outputs.connectors-version }}
-      helm-dir: ${{ steps.helm-dir.outputs.helm-dir }}
+      helm-dir: ${{ steps.determine-helm-dir.outputs.helm-dir }}
     steps:
       - uses: actions/checkout@v2
 
@@ -58,8 +58,8 @@ jobs:
             echo "connectors-version=${{ inputs.connectors-version }}" >> $GITHUB_OUTPUT
           fi
 
-      - name: Determine Helm chart ref to use
-        id: helm-dir
+      - name: Determine Helm chart directory to use
+        id: determine-helm-dir
         run: |
           if [ -z "${{ inputs.helm-dir }}" ]; then
             helm_dir=$(jq -r ".[\"${{ inputs.release-branch || github.ref_name }}\"]" .github/workflows/helm-git-refs.json)
@@ -75,7 +75,7 @@ jobs:
       - name: Log results
         run: |
           echo "Connectors version: ${{ steps.determine-connectors-version.outputs.connectors-version }}"
-          echo "Helm dir: ${{ steps.helm-dir.outputs.helm-dir }}"
+          echo "Helm dir: ${{ steps.determine-helm-dir.outputs.helm-dir }}"
 
   helm-deploy:
     needs: prepare-inputs

--- a/.github/workflows/helm-git-refs.json
+++ b/.github/workflows/helm-git-refs.json
@@ -1,7 +1,7 @@
 {
-  "main": "main",
-  "release/8.6": "main",
-  "release/8.5": "main",
+  "main": "camunda-platform",
+  "release/8.6": "camunda-platform",
+  "release/8.5": "camunda-platform",
   "release/8.4": "camunda-platform-8.4",
   "release/8.3": "camunda-platform-8.3"
 }


### PR DESCRIPTION
## Description

The Helm integration test workflow we rely on ([`test-integration-template.yaml`](https://github.com/camunda/camunda-platform-helm/blob/main/.github/workflows/test-integration-template.yaml)) and camunda-platform-helm as a whole was recently refactored to rely on directories instead of branches for chart versions. [See issue for more context](https://github.com/camunda/team-connectors/issues/804)

This PR passes in the new required arguments. It also updates variable names and documentation to reflect the new directory system.


## Test Runs

To help reviewers understand the changes, here's a [test run of this workflow that @ev-codes ran against Connectors v8.3.11](https://github.com/camunda/connectors/actions/runs/9416057521/job/25938368512)

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes https://github.com/camunda/team-connectors/issues/804

