### PR TITLE
ci(integration): use new Helm integration test arguments

### DIFF
--- a/.github/workflows/INTEGRATION_TEST.yml
+++ b/.github/workflows/INTEGRATION_TEST.yml
@@ -2,16 +2,23 @@
 name: Integration test
 
 on:
-  push:
-    branches:
-      - release/*
+  workflow_call:
+    inputs:
+      connectors-version:
+        description: 'The version of the Connectors to test. If not provided, the version is determined based on the Maven project version. On main branch, the default is SNAPSHOT'
+        required: false
+        type: string
+      release-branch:
+        description: 'Connectors release branch containing code to test. If not provided, the Helm directory is determined based on the ref this workflow was triggered on (see helm-git-refs.json)'
+        required: false
+        type: string
   workflow_dispatch:
     inputs:
       connectors-version:
         description: 'The version of the Connectors to test. If not provided, the version is determined based on the Maven project version. On main branch, the default is SNAPSHOT'
         required: false
-      helm-branch:
-        description: 'The branch of the Helm chart to test against. If not provided, the branch is determined based on the ref (see helm-git-refs.json)'
+      helm-dir:
+        description: 'The camunda-platform-helm/charts directory of the Helm chart to test against. If not provided, the directory is determined based on the ref this workflow was triggered on (see helm-git-refs.json)'
         required: false
 
 defaults:
@@ -25,8 +32,8 @@ jobs:
     runs-on: ubuntu-latest
     name: Prepare inputs
     outputs:
-      connectors-version: ${{ steps.connectors-version.outputs.connectors-version }}
-      helm-branch: ${{ steps.helm-branch.outputs.helm-branch }}
+      connectors-version: ${{ steps.determine-connectors-version.outputs.connectors-version }}
+      helm-dir: ${{ steps.determine-helm-dir.outputs.helm-dir }}
     steps:
       - uses: actions/checkout@v2
 
@@ -39,36 +46,36 @@ jobs:
           echo "version=$(grep -oPm1 "(?<=<version>)[^<]+" "pom.xml")" >> $GITHUB_OUTPUT
 
       - name: Determine version of the Connectors image to use
-        id: connectors-version
+        id: determine-connectors-version
         run: |
-          if [ -z "${{ github.event.inputs.connectors-version }}" ]; then
+          if [ -z "${{ inputs.connectors-version }}" ]; then
             if [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
               echo "connectors-version=SNAPSHOT" >> $GITHUB_OUTPUT
             else
               echo "connectors-version=${{ steps.maven-version.outputs.version }}" >> $GITHUB_OUTPUT
             fi
           else
-            echo "connectors-version=${{ github.event.inputs.connectors-version }}" >> $GITHUB_OUTPUT
+            echo "connectors-version=${{ inputs.connectors-version }}" >> $GITHUB_OUTPUT
           fi
 
-      - name: Determine Helm chart ref to use
-        id: helm-branch
+      - name: Determine Helm chart directory to use
+        id: determine-helm-dir
         run: |
-          if [ -z "${{ github.event.inputs.helm-branch }}" ]; then
-            helm_branch=$(jq -r ".[\"${{ github.ref }}\"]" .github/workflows/helm-git-refs.json)
-            if [ -z "$helm_branch" ] || [ "$helm_branch" == "null" ]; then
-              echo "::error::Could not determine Helm chart branch to use, please provide helm-branch input or adjust the mappings in .github/workflows/helm-git-refs.json"
+          if [ -z "${{ inputs.helm-dir }}" ]; then
+            helm_dir_from_map=$(jq -r ".[\"${{ inputs.release-branch || github.ref_name }}\"]" .github/workflows/helm-git-refs.json)
+            if [ -z "$helm_dir_from_map" ] || [ "$helm_dir_from_map" == "null" ]; then
+              echo "::error::Could not determine Helm chart dir to use, please provide helm-dir input or adjust the mappings in .github/workflows/helm-git-refs.json"
               exit 1
             fi
-            echo "helm-branch=$helm_branch" >> $GITHUB_OUTPUT
+            echo "helm-dir=$helm_dir_from_map" >> $GITHUB_OUTPUT
           else
-            echo "helm-branch=${{ github.event.inputs.helm-branch }}" >> $GITHUB_OUTPUT
+            echo "helm-dir=${{ inputs.helm-dir }}" >> $GITHUB_OUTPUT
           fi
 
       - name: Log results
         run: |
-          echo "Connectors version: ${{ steps.connectors-version.outputs.connectors-version }}"
-          echo "Helm branch: ${{ steps.helm-branch.outputs.helm-branch }}"
+          echo "Connectors version: ${{ steps.determine-connectors-version.outputs.connectors-version }}"
+          echo "Helm dir: ${{ steps.determine-helm-dir.outputs.helm-dir }}"
 
   helm-deploy:
     needs: prepare-inputs
@@ -77,7 +84,7 @@ jobs:
     secrets: inherit
     with:
       identifier: connectors-int
-      camunda-helm-git-ref: ${{ needs.prepare-inputs.outputs.helm-branch }}
+      camunda-helm-dir: ${{ needs.prepare-inputs.outputs.helm-dir }}
       test-enabled: true
       extra-values: |
         connectors:

--- a/.github/workflows/helm-git-refs.json
+++ b/.github/workflows/helm-git-refs.json
@@ -1,7 +1,7 @@
 {
-  "refs/heads/main": "main",
-  "refs/heads/release/8.6": "main",
-  "refs/heads/release/8.5": "main",
-  "refs/heads/release/8.4": "camunda-platform-8.4",
-  "refs/heads/release/8.3": "camunda-platform-8.3"
+  "main": "camunda-platform",
+  "release/8.6": "camunda-platform",
+  "release/8.5": "camunda-platform",
+  "release/8.4": "camunda-platform-8.4",
+  "release/8.3": "camunda-platform-8.3"
 }


### PR DESCRIPTION
## Description

Backporting `INTEGRATION_TEST.yml` and `helm-git-refs.json` as they were after merge of https://github.com/camunda/connectors/pull/2728

Old arguments passed into test-integration-template will not work in a few weeks.

## Related issues

https://github.com/camunda/team-connectors/issues/804