### PR TITLE
deps(spring-zeebe): Bump spring zeebe to 8.5.5

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -73,7 +73,7 @@ limitations under the License.</license.inlineheader>
     <!-- Camunda internal libraries -->
     <version.zeebe>8.5.2</version.zeebe>
     <version.feel-engine>1.17.7</version.feel-engine>
-    <version.spring-zeebe>8.5.4</version.spring-zeebe>
+    <version.spring-zeebe>8.5.5</version.spring-zeebe>
 
     <!-- Third party dependencies -->
 


### PR DESCRIPTION
## Description

To fix this issue: https://github.com/camunda-community-hub/spring-zeebe/issues/835

