### PR TITLE
feat(rest): Add proxy support

### DIFF
--- a/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/client/ProxyConfiguration.java
+++ b/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/client/ProxyConfiguration.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+
+package io.camunda.connector.http.base.client;
+
+import java.util.Optional;
+
+public class ProxyConfiguration {
+  private static final String HTTP_PROXY_URL = "HTTP_PROXY_URL";
+  private final String httpProxyUrl = System.getenv(HTTP_PROXY_URL);
+
+  public Optional<String> getHttpProxyUrl() {
+    return Optional.ofNullable(httpProxyUrl);
+  }
+}

--- a/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/client/ProxyConfiguration.java
+++ b/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/client/ProxyConfiguration.java
@@ -1,10 +1,19 @@
 /*
  * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
- * under one or more contributor license agreements. Licensed under a proprietary license.
- * See the License.txt file for more information. You may not use this file
- * except in compliance with the proprietary license.
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package io.camunda.connector.http.base.client;
 
 import java.util.Optional;


### PR DESCRIPTION
## Description

- Add support for proxy using an env var containing the proxy URL (host+port).

We might add authentication later.

## Related issues

closes https://github.com/camunda/team-connectors/issues/699

