### PR TITLE
chore(rest): Bump element template version

### DIFF
--- a/connectors/http/rest/element-templates/http-json-connector.json
+++ b/connectors/http/rest/element-templates/http-json-connector.json
@@ -4,7 +4,7 @@
   "id" : "io.camunda.connectors.HttpJson.v2",
   "description" : "Invoke REST API",
   "documentationRef" : "https://docs.camunda.io/docs/components/connectors/protocol/rest/",
-  "version" : 7,
+  "version" : 8,
   "category" : {
     "id" : "connectors",
     "name" : "Connectors"

--- a/connectors/http/rest/element-templates/hybrid/http-json-connector-hybrid.json
+++ b/connectors/http/rest/element-templates/hybrid/http-json-connector-hybrid.json
@@ -4,7 +4,7 @@
   "id" : "io.camunda.connectors.HttpJson.v2-hybrid",
   "description" : "Invoke REST API",
   "documentationRef" : "https://docs.camunda.io/docs/components/connectors/protocol/rest/",
-  "version" : 7,
+  "version" : 8,
   "category" : {
     "id" : "connectors",
     "name" : "Connectors"

--- a/connectors/http/rest/src/main/java/io/camunda/connector/http/rest/HttpJsonFunction.java
+++ b/connectors/http/rest/src/main/java/io/camunda/connector/http/rest/HttpJsonFunction.java
@@ -43,7 +43,7 @@ import io.camunda.connector.http.rest.model.HttpJsonRequest;
     name = "REST Outbound Connector",
     description = "Invoke REST API",
     inputDataClass = HttpJsonRequest.class,
-    version = 7,
+    version = 8,
     propertyGroups = {
       @PropertyGroup(id = "authentication", label = "Authentication"),
       @PropertyGroup(id = "endpoint", label = "HTTP endpoint"),

--- a/connectors/http/rest/src/test/resources/requests/fail-cases-connection-timeout-validation.json
+++ b/connectors/http/rest/src/test/resources/requests/fail-cases-connection-timeout-validation.json
@@ -3,9 +3,8 @@
     "descriptionOfTest": "String value",
     "method": "get",
     "url": "https://camunda.io/http-endpoint",
-    "connectionTimeoutInSeconds" : "bad value",
-    "readTimeoutInSeconds" : "bad value",
-    "writeTimeoutInSeconds" : "bad value",
+    "connectionTimeoutInSeconds": "bad value",
+    "readTimeoutInSeconds": "bad value",
     "authentication": {
       "type": "noAuth"
     }
@@ -14,9 +13,8 @@
     "descriptionOfTest": "Float value",
     "method": "get",
     "url": "https://camunda.io/http-endpoint",
-    "connectionTimeoutInSeconds" : "0.1",
-    "readTimeoutInSeconds" : "0.2",
-    "writeTimeoutInSeconds" : "0.4",
+    "connectionTimeoutInSeconds": "0.1",
+    "readTimeoutInSeconds": "0.2",
     "authentication": {
       "type": "noAuth"
     }
@@ -26,8 +24,7 @@
     "method": "get",
     "url": "https://camunda.io/http-endpoint",
     "connectionTimeoutInSeconds": "0xFF",
-    "readTimeoutInSeconds" : "0xFF",
-    "writeTimeoutInSeconds" : "0xFF",
+    "readTimeoutInSeconds": "0xFF",
     "authentication": {
       "type": "noAuth"
     }
@@ -37,8 +34,7 @@
     "method": "get",
     "url": "https://camunda.io/http-endpoint",
     "connectionTimeoutInSeconds": "0b0011",
-    "readTimeoutInSeconds" : "0b0011",
-    "writeTimeoutInSeconds" : "0b0011",
+    "readTimeoutInSeconds": "0b0011",
     "authentication": {
       "type": "bearer",
       "token": "{{secrets.TOKEN_KEY}}"
@@ -49,8 +45,7 @@
     "method": "get",
     "url": "https://camunda.io/http-endpoint",
     "connectionTimeoutInSeconds": "bad secrets.TOKEN_KEY value",
-    "readTimeoutInSeconds" : "bad secrets.TOKEN_KEY value",
-    "writeTimeoutInSeconds" : "bad secrets.TOKEN_KEY value",
+    "readTimeoutInSeconds": "bad secrets.TOKEN_KEY value",
     "authentication": {
       "type": "noAuth"
     }
@@ -60,8 +55,7 @@
     "method": "get",
     "url": "https://camunda.io/http-endpoint",
     "connectionTimeoutInSeconds": "bad 123 value",
-    "readTimeoutInSeconds" : "bad 123 value",
-    "writeTimeoutInSeconds" : "bad 123 value",
+    "readTimeoutInSeconds": "bad 123 value",
     "authentication": {
       "type": "noAuth"
     }

--- a/connectors/http/rest/src/test/resources/requests/success-test-cases.json
+++ b/connectors/http/rest/src/test/resources/requests/success-test-cases.json
@@ -8,7 +8,6 @@
     },
     "connectionTimeoutInSeconds": 20,
     "readTimeoutInSeconds": 30,
-    "writeTimeoutInSeconds": 40,
     "queryParameters": {
       "q": "test",
       "priority": 12
@@ -30,7 +29,6 @@
     "url": "http://localhost:8085/http-endpoint",
     "connectionTimeoutInSeconds": 0,
     "readTimeoutInSeconds": 0,
-    "writeTimeoutInSeconds": 0,
     "queryParameters": {
       "q": "test",
       "priority": 12
@@ -58,7 +56,6 @@
     "url": "http://localhost:8085/http-endpoint",
     "connectionTimeoutInSeconds": 60,
     "readTimeoutInSeconds": 70,
-    "writeTimeoutInSeconds": 200,
     "queryParameters": {
       "q": "test",
       "priority": 12
@@ -85,7 +82,6 @@
     "url": "http://localhost:8085/http-endpoint",
     "connectionTimeoutInSeconds": 202,
     "readTimeoutInSeconds": 301,
-    "writeTimeoutInSeconds": 402,
     "headers": {
       "X-Camunda-Cluster-ID": "abcdef",
       "User-Agent": "http-connector-demo"
@@ -108,7 +104,6 @@
     "url": "http://localhost:8085/http-endpoint",
     "connectionTimeoutInSeconds": 5,
     "readTimeoutInSeconds": 67,
-    "writeTimeoutInSeconds": 34,
     "queryParameters": {
       "q": "test",
       "priority": 12
@@ -131,7 +126,6 @@
     "method": "get",
     "connectionTimeoutInSeconds": 20,
     "readTimeoutInSeconds": 30,
-    "writeTimeoutInSeconds": 40,
     "url": "http://localhost:8085/http-endpoint",
     "queryParameters": {
       "q": "test",
@@ -152,7 +146,6 @@
     "url": "http://localhost:8085/http-endpoint",
     "connectionTimeoutInSeconds": 20,
     "readTimeoutInSeconds": 0,
-    "writeTimeoutInSeconds": 10,
     "queryParameters": {
       "q": "test",
       "priority": 12
@@ -186,7 +179,6 @@
     },
     "connectionTimeoutInSeconds": 50,
     "readTimeoutInSeconds": 30,
-    "writeTimeoutInSeconds": 40,
     "body": {
       "customer": {
         "id": 1231231,


### PR DESCRIPTION
## Description

Bump the REST Connector element template version.
Removes `writeTimeoutInSeconds` as it's not supported anymore by the connector.

## Related issues

https://github.com/camunda/connectors/issues/1069

