### PR TITLE
fix(importer): prevent OOM by filtering out older process versions eerly on

### DIFF
--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/inbound/importer/ProcessDefinitionImporterTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/inbound/importer/ProcessDefinitionImporterTest.java
@@ -80,8 +80,8 @@ public class ProcessDefinitionImporterTest {
     // then
     verify(manager, times(1)).handleNewProcessDefinitions(new HashSet<>(first));
     verify(manager, times(1))
-        .handleDeletedProcessDefinitions(Set.of(first.getFirst().getVersion()));
-    verify(manager, times(1)).handleNewProcessDefinitions(Set.of(second.getFirst()));
+        .handleDeletedProcessDefinitions(Set.of(first.get(0).getVersion()));
+    verify(manager, times(1)).handleNewProcessDefinitions(Set.of(second.get(0)));
 
     // verify old version was deregistered and no action is taken on the next polling iteration
     importer.scheduleImport();

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/inbound/importer/ProcessDefinitionImporterTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/inbound/importer/ProcessDefinitionImporterTest.java
@@ -79,8 +79,7 @@ public class ProcessDefinitionImporterTest {
 
     // then
     verify(manager, times(1)).handleNewProcessDefinitions(new HashSet<>(first));
-    verify(manager, times(1))
-        .handleDeletedProcessDefinitions(Set.of(first.get(0).getVersion()));
+    verify(manager, times(1)).handleDeletedProcessDefinitions(Set.of(first.get(0).getVersion()));
     verify(manager, times(1)).handleNewProcessDefinitions(Set.of(second.get(0)));
 
     // verify old version was deregistered and no action is taken on the next polling iteration

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/inbound/importer/ProcessDefinitionImporterTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/inbound/importer/ProcessDefinitionImporterTest.java
@@ -137,9 +137,8 @@ public class ProcessDefinitionImporterTest {
     importer.scheduleImport();
 
     // then
-    verify(manager, times(1)).handleNewProcessDefinitions(Set.of(first.getFirst()));
-    verify(manager, times(1))
-        .handleDeletedProcessDefinitions(Set.of(first.getFirst().getVersion()));
+    verify(manager, times(1)).handleNewProcessDefinitions(Set.of(first.get(0)));
+    verify(manager, times(1)).handleDeletedProcessDefinitions(Set.of(first.get(0).getVersion()));
     verify(manager, times(1)).handleNewProcessDefinitions(new HashSet<>(second));
   }
 

--- a/connectors-e2e-test/connectors-e2e-test-http/src/test/java/io/camunda/connector/e2e/HttpTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-http/src/test/java/io/camunda/connector/e2e/HttpTests.java
@@ -23,8 +23,6 @@ import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMoc
 import static io.camunda.connector.e2e.BpmnFile.Replace.replace;
 import static io.camunda.connector.e2e.BpmnFile.replace;
 import static io.camunda.zeebe.process.test.assertions.BpmnAssert.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -44,6 +42,7 @@ import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.instance.Process;
 import io.camunda.zeebe.spring.test.ZeebeSpringTest;
 import java.io.File;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
@@ -87,7 +86,7 @@ public class HttpTests {
 
   @BeforeEach
   void beforeAll() {
-    doNothing().when(processDefinitionSearch).query(any());
+    when(processDefinitionSearch.query()).thenReturn(Collections.emptyList());
   }
 
   @Test


### PR DESCRIPTION
## Description

Backport #2038 to release/8.3

## Related issues

related: https://github.com/camunda/team-connectors/issues/647
