### PR TITLE
chore(rest): Add regex to allow integers only for timeouts

### DIFF
--- a/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/model/HttpCommonRequest.java
+++ b/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/model/HttpCommonRequest.java
@@ -48,7 +48,10 @@ public class HttpCommonRequest {
       group = "timeout",
       label = "Connection timeout in seconds",
       defaultValue = "20",
-      constraints = @TemplateProperty.PropertyConstraints(notEmpty = true),
+      constraints =
+          @TemplateProperty.PropertyConstraints(
+              notEmpty = true,
+              pattern = @TemplateProperty.Pattern(value = "^\\d+$", message = "Must be a number")),
       description = "Defines the connection timeout in seconds, or 0 for an infinite timeout")
   private Integer connectionTimeoutInSeconds = 20;
 
@@ -56,7 +59,10 @@ public class HttpCommonRequest {
       group = "timeout",
       label = "Read timeout in seconds",
       defaultValue = "20",
-      constraints = @TemplateProperty.PropertyConstraints(notEmpty = true),
+      constraints =
+          @TemplateProperty.PropertyConstraints(
+              notEmpty = true,
+              pattern = @TemplateProperty.Pattern(value = "^\\d+$", message = "Must be a number")),
       description =
           "Timeout in seconds to read data from an established connection or 0 for an infinite timeout")
   private Integer readTimeoutInSeconds = 20;

--- a/connectors/http/rest/element-templates/http-json-connector.json
+++ b/connectors/http/rest/element-templates/http-json-connector.json
@@ -394,7 +394,11 @@
     "optional" : false,
     "value" : "20",
     "constraints" : {
-      "notEmpty" : true
+      "notEmpty" : true,
+      "pattern" : {
+        "value" : "^\\d+$",
+        "message" : "Must be a number"
+      }
     },
     "feel" : "optional",
     "group" : "timeout",
@@ -410,7 +414,11 @@
     "optional" : false,
     "value" : "20",
     "constraints" : {
-      "notEmpty" : true
+      "notEmpty" : true,
+      "pattern" : {
+        "value" : "^\\d+$",
+        "message" : "Must be a number"
+      }
     },
     "feel" : "optional",
     "group" : "timeout",

--- a/connectors/http/rest/element-templates/hybrid/http-json-connector-hybrid.json
+++ b/connectors/http/rest/element-templates/hybrid/http-json-connector-hybrid.json
@@ -399,7 +399,11 @@
     "optional" : false,
     "value" : "20",
     "constraints" : {
-      "notEmpty" : true
+      "notEmpty" : true,
+      "pattern" : {
+        "value" : "^\\d+$",
+        "message" : "Must be a number"
+      }
     },
     "feel" : "optional",
     "group" : "timeout",
@@ -415,7 +419,11 @@
     "optional" : false,
     "value" : "20",
     "constraints" : {
-      "notEmpty" : true
+      "notEmpty" : true,
+      "pattern" : {
+        "value" : "^\\d+$",
+        "message" : "Must be a number"
+      }
     },
     "feel" : "optional",
     "group" : "timeout",


### PR DESCRIPTION
## Description

- Add regex to validate timeouts, only numbers are allowed there.

## Related issues

closes https://github.com/camunda/team-connectors/issues/813

