### PR TITLE
chore(readme): remove wrong env var hyphen usage

### DIFF
--- a/connector-runtime/README.md
+++ b/connector-runtime/README.md
@@ -108,7 +108,7 @@ See also [Docker: Custom set of connectors](https://docs.camunda.io/docs/self-ma
 
 The following configuration properties can be set via `src/main/application.properties` if you run Java directly.
 
-You can also set those configuration options via environment variables (then named `ZEEBE_CLIENT_CLOUD_CLUSTER-ID` instead of `zeebe.client.cloud.cluster-id`), especially useful if you run via DOCKER.
+You can also set those configuration options via environment variables (then named `ZEEBE_CLIENT_CLOUD_CLUSTERID` instead of `zeebe.client.cloud.cluster-id`), especially useful if you run via DOCKER.
 
 In general, the Connector Runtime will respect all properties known to [Spring Zeebe](https://github.com/camunda-community-hub/spring-zeebe), which allows to specify some more options.
 

--- a/secret-providers/gcp-secret-provider/README.md
+++ b/secret-providers/gcp-secret-provider/README.md
@@ -11,7 +11,7 @@ Requires the following properties being set,e.g. via application.properties:
 or as environment variables:
 
 ```bash
-ZEEBE_CLIENT_CLOUD_CLUSTER-ID
+ZEEBE_CLIENT_CLOUD_CLUSTERID
 CAMUNDA_SECRETS_PROJECT_ID
 CAMUNDA_SECRETS_PREFIX
 ```


### PR DESCRIPTION
## Description

Shells don't support hyphens or dashes in environment variables and will fail to export them. There are ways around this, but I'd not advertise those.
Kubernetes can deal with it but depends on the application within whether it can properly load those.

My origin of the change stems from the [manual setup](https://docs.camunda.io/docs/next/self-managed/setup/deploy/local/manual/) where one is typically running some form of shell and based on that the advertised conversion from `cluster-id` to `CLUSTER-ID` doesn't work.

Additionally, Spring boot has [relaxed binding rules](https://github.com/spring-projects/spring-boot/wiki/Relaxed-Binding-2.0#environment-variables) where hyphens are also ignored. Probably stems from shells typically not supporting those out of the box.

I'm not sure whether you've more occurrences in other docs or so, just as a heads up that you shouldn't advertise it this way.
The Helm chart is also not using the hyphens and drops it when configuring connectors.

Feel free to use the PR as you see fit, even close. I'd just like to avoid advertising something that does not work in where it's originally linked from.

## Related issues

none, just thought I would provide a PR instead of going through slack.

closes #

