### PR TITLE
perf:(rest): Add cache for the Cloud Function proxy credentials

### DIFF
--- a/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/cloudfunction/CloudFunctionCredentialsCache.java
+++ b/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/cloudfunction/CloudFunctionCredentialsCache.java
@@ -43,7 +43,7 @@ public class CloudFunctionCredentialsCache {
 
     try {
       refreshAccessTokenIfExpired();
-    } catch (Exception e) {
+    } catch (IOException e) {
       LOG.warn("Failed to refresh access token", e);
       this.credentials = credentialsSupplier.get();
     }

--- a/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/cloudfunction/CloudFunctionCredentialsCache.java
+++ b/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/cloudfunction/CloudFunctionCredentialsCache.java
@@ -43,7 +43,7 @@ public class CloudFunctionCredentialsCache {
 
     try {
       refreshAccessTokenIfExpired();
-    } catch (IOException e) {
+    } catch (Exception e) {
       LOG.warn("Failed to refresh access token", e);
       this.credentials = credentialsSupplier.get();
     }

--- a/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/cloudfunction/CloudFunctionCredentialsCache.java
+++ b/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/cloudfunction/CloudFunctionCredentialsCache.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.http.base.cloudfunction;
+
+import com.google.auth.oauth2.OAuth2Credentials;
+import java.io.IOException;
+import java.util.Date;
+import java.util.Optional;
+import java.util.function.Supplier;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class CloudFunctionCredentialsCache {
+
+  private static final Logger LOG = LoggerFactory.getLogger(CloudFunctionCredentialsCache.class);
+  private OAuth2Credentials credentials;
+
+  /**
+   * Get credentials from cache or fetch new credentials if cache is empty or expired.
+   *
+   * @param credentialsSupplier Supplier to fetch new credentials
+   * @return Optional of credentials
+   */
+  public Optional<OAuth2Credentials> get(Supplier<OAuth2Credentials> credentialsSupplier) {
+    if (credentials == null) {
+      LOG.debug("Credentials cache is empty, fetching new credentials");
+      credentials = credentialsSupplier.get();
+    }
+
+    try {
+      refreshAccessTokenIfExpired();
+    } catch (IOException e) {
+      LOG.warn("Failed to refresh access token", e);
+      this.credentials = credentialsSupplier.get();
+    }
+    return Optional.ofNullable(credentials);
+  }
+
+  private void refreshAccessTokenIfExpired() throws IOException {
+    Date expirationTime = credentials.getAccessToken().getExpirationTime();
+    if (expirationTime != null && expirationTime.before(new Date())) {
+      LOG.debug("Access token expired, refreshing");
+      credentials.refreshIfExpired();
+    }
+  }
+}

--- a/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/cloudfunction/CloudFunctionService.java
+++ b/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/cloudfunction/CloudFunctionService.java
@@ -34,6 +34,15 @@ public class CloudFunctionService {
   private static final Logger LOG = LoggerFactory.getLogger(CloudFunctionService.class);
   private static final String PROXY_FUNCTION_URL_ENV_NAME = "CAMUNDA_CONNECTOR_HTTP_PROXY_URL";
   private final String proxyFunctionUrl = System.getenv(PROXY_FUNCTION_URL_ENV_NAME);
+  private final CloudFunctionCredentials credentials;
+
+  public CloudFunctionService() {
+    this(new CloudFunctionCredentials());
+  }
+
+  CloudFunctionService(CloudFunctionCredentials credentials) {
+    this.credentials = credentials;
+  }
 
   /**
    * Wraps the given request into a new request that is targeted at the Google function to execute
@@ -48,7 +57,7 @@ public class CloudFunctionService {
       // hence write it ourselves:
       String contentAsJson =
           ConnectorsObjectMapperSupplier.DEFAULT_MAPPER.writeValueAsString(request);
-      String token = CloudFunctionHelper.getOAuthToken(getProxyFunctionUrl());
+      String token = credentials.getOAuthToken(getProxyFunctionUrl());
       return createCloudFunctionRequest(contentAsJson, token);
     } catch (IOException e) {
       LOG.error("Failed to serialize the request to JSON: {}", request, e);

--- a/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/cloudfunction/CloudFunctionService.java
+++ b/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/cloudfunction/CloudFunctionService.java
@@ -40,7 +40,7 @@ public class CloudFunctionService {
     this(new CloudFunctionCredentials());
   }
 
-  CloudFunctionService(CloudFunctionCredentials credentials) {
+  public CloudFunctionService(CloudFunctionCredentials credentials) {
     this.credentials = credentials;
   }
 

--- a/connectors/http/http-base/src/test/java/io/camunda/connector/http/base/HttpServiceTest.java
+++ b/connectors/http/http-base/src/test/java/io/camunda/connector/http/base/HttpServiceTest.java
@@ -29,6 +29,8 @@ import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.verify;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
@@ -37,6 +39,7 @@ import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
 import com.github.tomakehurst.wiremock.junit5.WireMockTest;
 import io.camunda.connector.api.error.ConnectorException;
 import io.camunda.connector.api.json.ConnectorsObjectMapperSupplier;
+import io.camunda.connector.http.base.cloudfunction.CloudFunctionCredentials;
 import io.camunda.connector.http.base.cloudfunction.CloudFunctionResponseTransformer;
 import io.camunda.connector.http.base.cloudfunction.CloudFunctionService;
 import io.camunda.connector.http.base.model.HttpCommonRequest;
@@ -53,7 +56,10 @@ import wiremock.com.fasterxml.jackson.databind.node.JsonNodeFactory;
 @WireMockTest(extensionScanningEnabled = true)
 public class HttpServiceTest {
 
-  private static final CloudFunctionService cloudFunctionService = spy(new CloudFunctionService());
+  private static final CloudFunctionCredentials cloudFunctionCredentials =
+      mock(CloudFunctionCredentials.class);
+  private static final CloudFunctionService cloudFunctionService =
+      spy(new CloudFunctionService(cloudFunctionCredentials));
   private static final CloudFunctionService disabledCloudFunctionService =
       spy(new CloudFunctionService());
   private final HttpService httpService = new HttpService(cloudFunctionService);
@@ -64,6 +70,7 @@ public class HttpServiceTest {
   @BeforeAll
   public static void setUp() {
     when(cloudFunctionService.isCloudFunctionEnabled()).thenReturn(true);
+    when(cloudFunctionCredentials.getOAuthToken(anyString())).thenReturn("token");
     when(disabledCloudFunctionService.isCloudFunctionEnabled()).thenReturn(false);
   }
 

--- a/connectors/http/http-base/src/test/java/io/camunda/connector/http/base/cloudfunction/CloudFunctionCredentialsCacheTest.java
+++ b/connectors/http/http-base/src/test/java/io/camunda/connector/http/base/cloudfunction/CloudFunctionCredentialsCacheTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+
+package io.camunda.connector.http.base.cloudfunction;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.auth.oauth2.AccessToken;
+import com.google.auth.oauth2.OAuth2Credentials;
+import java.io.IOException;
+import java.util.Date;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+public class CloudFunctionCredentialsCacheTest {
+
+  @Test
+  public void shouldCallCredentialsSupplier_whenEmptyCache() {
+    // given
+    CloudFunctionCredentialsCache cloudFunctionCredentialsCache =
+        new CloudFunctionCredentialsCache();
+    AtomicInteger credentialsSupplierCalledCnt = new AtomicInteger(0);
+    var fakeCredentials = mock(OAuth2Credentials.class);
+    var dateNow = new Date();
+    when(fakeCredentials.getAccessToken()).thenReturn(new AccessToken("fakeToken", dateNow));
+
+    // when
+    var credentials =
+        cloudFunctionCredentialsCache.get(
+            getOAuth2CredentialsSupplier(fakeCredentials, credentialsSupplierCalledCnt));
+
+    // then
+    assertThat(credentialsSupplierCalledCnt.get()).isEqualTo(1);
+    assertThat(credentials).isPresent();
+    assertThat(credentials.get().getAccessToken()).isEqualTo(new AccessToken("fakeToken", dateNow));
+  }
+
+  @Test
+  public void shouldNotCallCredentialsSupplier_whenCacheFilled() {
+    // given
+    CloudFunctionCredentialsCache cloudFunctionCredentialsCache =
+        new CloudFunctionCredentialsCache();
+    AtomicInteger credentialsSupplierCalledCnt = new AtomicInteger(0);
+    var fakeCredentials = mock(OAuth2Credentials.class);
+    var dateNow = new Date();
+    when(fakeCredentials.getAccessToken()).thenReturn(new AccessToken("fakeToken", dateNow));
+
+    // when
+    Supplier<OAuth2Credentials> oAuth2CredentialsSupplier =
+        getOAuth2CredentialsSupplier(fakeCredentials, credentialsSupplierCalledCnt);
+    cloudFunctionCredentialsCache.get(oAuth2CredentialsSupplier);
+    var credentials = cloudFunctionCredentialsCache.get(oAuth2CredentialsSupplier);
+
+    // then
+    assertThat(credentialsSupplierCalledCnt.get()).isEqualTo(1);
+    assertThat(credentials).isPresent();
+    assertThat(credentials.get().getAccessToken()).isEqualTo(new AccessToken("fakeToken", dateNow));
+  }
+
+  @Test
+  public void shouldCallCredentialsSupplier_whenTokenExpired() throws IOException {
+    // given
+    CloudFunctionCredentialsCache cloudFunctionCredentialsCache =
+        new CloudFunctionCredentialsCache();
+    AtomicInteger credentialsSupplierCalledCnt = new AtomicInteger(0);
+    var fakeCredentials = mock(OAuth2Credentials.class, Mockito.RETURNS_DEEP_STUBS);
+    Date expiredDate = new Date(System.currentTimeMillis() - 3600 * 1000); // 1 hour in the past
+    Date validDate = new Date(System.currentTimeMillis() + 3600 * 1000); // 1 hour in the future
+    when(fakeCredentials.getAccessToken())
+        .thenReturn(new AccessToken("fakeToken", validDate))
+        .thenReturn(new AccessToken("fakeToken", expiredDate));
+
+    // when
+    Supplier<OAuth2Credentials> oAuth2CredentialsSupplier =
+        getOAuth2CredentialsSupplier(fakeCredentials, credentialsSupplierCalledCnt);
+    // first call to fill the cache
+    var credentials = cloudFunctionCredentialsCache.get(oAuth2CredentialsSupplier);
+    // second call to get the cached credentials with expired token
+    credentials = cloudFunctionCredentialsCache.get(oAuth2CredentialsSupplier);
+
+    // then
+    assertThat(credentialsSupplierCalledCnt.get()).isEqualTo(1);
+    assertThat(credentials).isPresent();
+    assertThat(credentials.get().getAccessToken())
+        .isEqualTo(new AccessToken("fakeToken", expiredDate));
+    verify(fakeCredentials, times(1)).refreshIfExpired();
+  }
+
+  private Supplier<OAuth2Credentials> getOAuth2CredentialsSupplier(
+      OAuth2Credentials fakeCredentials, AtomicInteger credentialsSupplierCalled) {
+    credentialsSupplierCalled.incrementAndGet();
+    return () -> fakeCredentials;
+  }
+}

--- a/connectors/http/http-base/src/test/java/io/camunda/connector/http/base/cloudfunction/CloudFunctionCredentialsCacheTest.java
+++ b/connectors/http/http-base/src/test/java/io/camunda/connector/http/base/cloudfunction/CloudFunctionCredentialsCacheTest.java
@@ -1,10 +1,19 @@
 /*
  * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
- * under one or more contributor license agreements. Licensed under a proprietary license.
- * See the License.txt file for more information. You may not use this file
- * except in compliance with the proprietary license.
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package io.camunda.connector.http.base.cloudfunction;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/connectors/http/http-base/src/test/java/io/camunda/connector/http/base/cloudfunction/CloudFunctionServiceTest.java
+++ b/connectors/http/http-base/src/test/java/io/camunda/connector/http/base/cloudfunction/CloudFunctionServiceTest.java
@@ -17,6 +17,8 @@
 package io.camunda.connector.http.base.cloudfunction;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
@@ -34,11 +36,15 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 public class CloudFunctionServiceTest {
-  private static final CloudFunctionService cloudFunctionService = spy(new CloudFunctionService());
+  private static final CloudFunctionCredentials cloudFunctionCredentials =
+      mock(CloudFunctionCredentials.class);
+  private static final CloudFunctionService cloudFunctionService =
+      spy(new CloudFunctionService(cloudFunctionCredentials));
 
   @BeforeAll
   public static void setUp() {
     when(cloudFunctionService.getProxyFunctionUrl()).thenReturn("proxyUrl");
+    when(cloudFunctionCredentials.getOAuthToken(anyString())).thenReturn("token");
   }
 
   @Test


### PR DESCRIPTION
## Description

Adds a cache for the Cloud Function proxy credentials.

The current implementation allows for one cache per HttpService instance. The following connectors use this service:
- REST Connector
- GraphQL Connector
- Automation Anywhere Connector
- Polling Connector

## Related issues

closes https://github.com/camunda/connectors/issues/645

