### PR TITLE
653 fr slack connector post message add option to post to an existing thread

### DIFF
--- a/connectors/slack/element-templates/hybrid/slack-outbound-connector-hybrid.json
+++ b/connectors/slack/element-templates/hybrid/slack-outbound-connector-hybrid.json
@@ -185,6 +185,22 @@
     },
     "type" : "String"
   }, {
+    "id" : "data.thread",
+    "label" : "Thread",
+    "optional" : false,
+    "feel" : "optional",
+    "group" : "channel",
+    "binding" : {
+      "name" : "data.thread",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "method",
+      "equals" : "chat.postMessage",
+      "type" : "simple"
+    },
+    "type" : "String"
+  }, {
     "id" : "data.newChannelName",
     "label" : "Channel name",
     "optional" : false,

--- a/connectors/slack/element-templates/hybrid/slack-outbound-connector-hybrid.json
+++ b/connectors/slack/element-templates/hybrid/slack-outbound-connector-hybrid.json
@@ -187,7 +187,7 @@
   }, {
     "id" : "data.thread",
     "label" : "Thread",
-    "optional" : false,
+    "optional" : true,
     "feel" : "optional",
     "group" : "channel",
     "binding" : {

--- a/connectors/slack/element-templates/slack-outbound-connector.json
+++ b/connectors/slack/element-templates/slack-outbound-connector.json
@@ -182,7 +182,7 @@
   }, {
     "id" : "data.thread",
     "label" : "Thread",
-    "optional" : false,
+    "optional" : true,
     "feel" : "optional",
     "group" : "channel",
     "binding" : {

--- a/connectors/slack/element-templates/slack-outbound-connector.json
+++ b/connectors/slack/element-templates/slack-outbound-connector.json
@@ -180,6 +180,22 @@
     },
     "type" : "String"
   }, {
+    "id" : "data.thread",
+    "label" : "Thread",
+    "optional" : false,
+    "feel" : "optional",
+    "group" : "channel",
+    "binding" : {
+      "name" : "data.thread",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "method",
+      "equals" : "chat.postMessage",
+      "type" : "simple"
+    },
+    "type" : "String"
+  }, {
     "id" : "data.newChannelName",
     "label" : "Channel name",
     "optional" : false,

--- a/connectors/slack/src/main/java/io/camunda/connector/slack/outbound/model/ChatPostMessageData.java
+++ b/connectors/slack/src/main/java/io/camunda/connector/slack/outbound/model/ChatPostMessageData.java
@@ -40,6 +40,7 @@ public record ChatPostMessageData(
             label = "Thread",
             id = "data.thread",
             group = "channel",
+            optional = true,
             feel = FeelMode.optional,
             binding = @PropertyBinding(name = "data.thread"))
         String thread,
@@ -126,7 +127,7 @@ public record ChatPostMessageData(
     }
 
     var request = requestBuilder.build();
-
+    
     ChatPostMessageResponse chatPostMessageResponse = methodsClient.chatPostMessage(request);
     if (chatPostMessageResponse.isOk()) {
       return new ChatPostMessageSlackResponse(chatPostMessageResponse);

--- a/connectors/slack/src/main/java/io/camunda/connector/slack/outbound/model/ChatPostMessageData.java
+++ b/connectors/slack/src/main/java/io/camunda/connector/slack/outbound/model/ChatPostMessageData.java
@@ -37,6 +37,13 @@ public record ChatPostMessageData(
         @NotBlank
         String channel,
     @TemplateProperty(
+            label = "Thread",
+            id = "data.thread",
+            group = "channel",
+            feel = FeelMode.optional,
+            binding = @PropertyBinding(name = "data.thread"))
+        String thread,
+    @TemplateProperty(
             label = "Message type",
             id = "data.messageType",
             group = "message",
@@ -108,7 +115,9 @@ public record ChatPostMessageData(
       // Enables plain text message formatting
       requestBuilder.linkNames(true);
     }
-
+    if (StringUtils.isNotBlank(thread)) {
+      requestBuilder.threadTs(thread);
+    }
     if (blockContent != null) {
       if (!blockContent.isArray()) {
         throw new ConnectorException("Block section must be an array");

--- a/connectors/slack/src/main/java/io/camunda/connector/slack/outbound/model/ChatPostMessageData.java
+++ b/connectors/slack/src/main/java/io/camunda/connector/slack/outbound/model/ChatPostMessageData.java
@@ -127,7 +127,7 @@ public record ChatPostMessageData(
     }
 
     var request = requestBuilder.build();
-    
+
     ChatPostMessageResponse chatPostMessageResponse = methodsClient.chatPostMessage(request);
     if (chatPostMessageResponse.isOk()) {
       return new ChatPostMessageSlackResponse(chatPostMessageResponse);

--- a/connectors/slack/src/test/java/io/camunda/connector/slack/BaseTest.java
+++ b/connectors/slack/src/test/java/io/camunda/connector/slack/BaseTest.java
@@ -25,42 +25,6 @@ public abstract class BaseTest {
 
   protected static OutboundConnectorContext context;
 
-  protected interface ActualValue {
-    String USER_ID = "1234567890123";
-    String USER_REAL_NAME = "JohnDou";
-    String TS = "ts";
-    String TOKEN = "xoxb-0123456789456-123467890987-thisIsTestToken";
-    String METHOD = "chat.postMessage";
-
-    interface ChatPostMessageData {
-      String EMAIL = "john.dou@camundamail.com";
-      String USERNAME = "@" + USER_REAL_NAME;
-      String CHANNEL_NAME = "#john.channel";
-      String CHANNEL_ID = "12345678";
-      String TEXT = "_ this is secret test text _";
-    }
-
-    interface ConversationsCreateData {
-      String NEW_CHANNEL_NAME = "_ new channel name _";
-    }
-  }
-
-  protected interface SecretsConstant {
-    String TOKEN = "TOKEN_KEY";
-
-    interface ChatPostMessageData {
-      String EMAIL = "EMAIL_KEY";
-      String USERNAME = "USERNAME_KEY";
-      String CHANNEL_NAME = "CHANNEL_NAME_KEY";
-      String CHANNEL_ID = "CHANNEL_ID_KEY";
-      String TEXT = "TEXT_KEY";
-    }
-
-    interface ConversationsCreateData {
-      String NEW_CHANNEL_NAME = "NEW_CHANNEL_NAME_KEY";
-    }
-  }
-
   protected static OutboundConnectorContextBuilder getContextBuilderWithSecrets() {
     return OutboundConnectorContextBuilder.create()
         .validation(new DefaultValidationProvider())
@@ -71,6 +35,9 @@ public abstract class BaseTest {
         .secret(
             SecretsConstant.ChatPostMessageData.CHANNEL_NAME,
             ActualValue.ChatPostMessageData.CHANNEL_NAME)
+        .secret(
+            SecretsConstant.ChatPostMessageData.THREAD_NAME,
+            ActualValue.ChatPostMessageData.THREAD_NAME)
         .secret(
             SecretsConstant.ChatPostMessageData.CHANNEL_ID,
             ActualValue.ChatPostMessageData.CHANNEL_ID)
@@ -132,5 +99,43 @@ public abstract class BaseTest {
               }
             })
         .map(Arguments::of);
+  }
+
+  protected interface ActualValue {
+    String USER_ID = "1234567890123";
+    String USER_REAL_NAME = "JohnDou";
+    String TS = "ts";
+    String TOKEN = "xoxb-0123456789456-123467890987-thisIsTestToken";
+    String METHOD = "chat.postMessage";
+
+    interface ChatPostMessageData {
+      String EMAIL = "john.dou@camundamail.com";
+      String USERNAME = "@" + USER_REAL_NAME;
+      String CHANNEL_NAME = "#john.channel";
+      String THREAD_NAME = "thread_ts";
+      String CHANNEL_ID = "12345678";
+      String TEXT = "_ this is secret test text _";
+    }
+
+    interface ConversationsCreateData {
+      String NEW_CHANNEL_NAME = "_ new channel name _";
+    }
+  }
+
+  protected interface SecretsConstant {
+    String TOKEN = "TOKEN_KEY";
+
+    interface ChatPostMessageData {
+      String EMAIL = "EMAIL_KEY";
+      String USERNAME = "USERNAME_KEY";
+      String CHANNEL_NAME = "CHANNEL_NAME_KEY";
+      String THREAD_NAME = "THREAD_NAME_KEY";
+      String CHANNEL_ID = "CHANNEL_ID_KEY";
+      String TEXT = "TEXT_KEY";
+    }
+
+    interface ConversationsCreateData {
+      String NEW_CHANNEL_NAME = "NEW_CHANNEL_NAME_KEY";
+    }
   }
 }

--- a/connectors/slack/src/test/java/io/camunda/connector/slack/BaseTest.java
+++ b/connectors/slack/src/test/java/io/camunda/connector/slack/BaseTest.java
@@ -25,6 +25,45 @@ public abstract class BaseTest {
 
   protected static OutboundConnectorContext context;
 
+  protected interface ActualValue {
+    String USER_ID = "1234567890123";
+    String USER_REAL_NAME = "JohnDou";
+    String TS = "ts";
+    String TOKEN = "xoxb-0123456789456-123467890987-thisIsTestToken";
+    String METHOD = "chat.postMessage";
+
+    interface ChatPostMessageData {
+      String EMAIL = "john.dou@camundamail.com";
+      String USERNAME = "@" + USER_REAL_NAME;
+      String CHANNEL_NAME = "#john.channel";
+      String THREAD_NAME = "thread_ts";
+      String CHANNEL_ID = "12345678";
+
+      String TEXT = "_ this is secret test text _";
+    }
+
+    interface ConversationsCreateData {
+      String NEW_CHANNEL_NAME = "_ new channel name _";
+    }
+  }
+
+  protected interface SecretsConstant {
+    String TOKEN = "TOKEN_KEY";
+
+    interface ChatPostMessageData {
+      String EMAIL = "EMAIL_KEY";
+      String USERNAME = "USERNAME_KEY";
+      String CHANNEL_NAME = "CHANNEL_NAME_KEY";
+      String CHANNEL_ID = "CHANNEL_ID_KEY";
+      String THREAD_NAME = "THREAD_NAME_KEY";
+      String TEXT = "TEXT_KEY";
+    }
+
+    interface ConversationsCreateData {
+      String NEW_CHANNEL_NAME = "NEW_CHANNEL_NAME_KEY";
+    }
+  }
+
   protected static OutboundConnectorContextBuilder getContextBuilderWithSecrets() {
     return OutboundConnectorContextBuilder.create()
         .validation(new DefaultValidationProvider())
@@ -99,43 +138,5 @@ public abstract class BaseTest {
               }
             })
         .map(Arguments::of);
-  }
-
-  protected interface ActualValue {
-    String USER_ID = "1234567890123";
-    String USER_REAL_NAME = "JohnDou";
-    String TS = "ts";
-    String TOKEN = "xoxb-0123456789456-123467890987-thisIsTestToken";
-    String METHOD = "chat.postMessage";
-
-    interface ChatPostMessageData {
-      String EMAIL = "john.dou@camundamail.com";
-      String USERNAME = "@" + USER_REAL_NAME;
-      String CHANNEL_NAME = "#john.channel";
-      String THREAD_NAME = "thread_ts";
-      String CHANNEL_ID = "12345678";
-      String TEXT = "_ this is secret test text _";
-    }
-
-    interface ConversationsCreateData {
-      String NEW_CHANNEL_NAME = "_ new channel name _";
-    }
-  }
-
-  protected interface SecretsConstant {
-    String TOKEN = "TOKEN_KEY";
-
-    interface ChatPostMessageData {
-      String EMAIL = "EMAIL_KEY";
-      String USERNAME = "USERNAME_KEY";
-      String CHANNEL_NAME = "CHANNEL_NAME_KEY";
-      String THREAD_NAME = "THREAD_NAME_KEY";
-      String CHANNEL_ID = "CHANNEL_ID_KEY";
-      String TEXT = "TEXT_KEY";
-    }
-
-    interface ConversationsCreateData {
-      String NEW_CHANNEL_NAME = "NEW_CHANNEL_NAME_KEY";
-    }
   }
 }

--- a/connectors/slack/src/test/java/io/camunda/connector/slack/BaseTest.java
+++ b/connectors/slack/src/test/java/io/camunda/connector/slack/BaseTest.java
@@ -38,7 +38,6 @@ public abstract class BaseTest {
       String CHANNEL_NAME = "#john.channel";
       String THREAD_NAME = "thread_ts";
       String CHANNEL_ID = "12345678";
-
       String TEXT = "_ this is secret test text _";
     }
 

--- a/connectors/slack/src/test/java/io/camunda/connector/slack/outbound/model/ChatPostMessageDataTest.java
+++ b/connectors/slack/src/test/java/io/camunda/connector/slack/outbound/model/ChatPostMessageDataTest.java
@@ -36,6 +36,13 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 class ChatPostMessageDataTest {
 
+  @Mock private MethodsClient methodsClient;
+  @Mock private UsersLookupByEmailResponse lookupByEmailResponse;
+  @Mock private User user;
+  @Mock private ChatPostMessageResponse chatPostMessageResponse;
+
+  @Captor private ArgumentCaptor<ChatPostMessageRequest> chatPostMessageRequest;
+
   private static final String USERID = "testUserId";
   private static final JsonNode EMPTY_JSON;
 
@@ -46,12 +53,6 @@ class ChatPostMessageDataTest {
       throw new RuntimeException(e);
     }
   }
-
-  @Mock private MethodsClient methodsClient;
-  @Mock private UsersLookupByEmailResponse lookupByEmailResponse;
-  @Mock private User user;
-  @Mock private ChatPostMessageResponse chatPostMessageResponse;
-  @Captor private ArgumentCaptor<ChatPostMessageRequest> chatPostMessageRequest;
 
   @Test
   void invoke_shouldThrowExceptionWhenUserWithoutEmail() throws SlackApiException, IOException {
@@ -79,7 +80,7 @@ class ChatPostMessageDataTest {
   void invoke_shouldFindUserIdByEmail(String email) throws SlackApiException, IOException {
     // Given
     ChatPostMessageData chatPostMessageData =
-        new ChatPostMessageData(email, "thread_ts", "", "test", null);
+        new ChatPostMessageData(email, "thread_ts", "plainText", "test", null);
 
     when(methodsClient.usersLookupByEmail(any(UsersLookupByEmailRequest.class)))
         .thenReturn(lookupByEmailResponse);
@@ -124,45 +125,45 @@ class ChatPostMessageDataTest {
     // Given
     final var blockContent =
         """
-                        [
-                        	{
-                        		"type": "header",
-                        		"text": {
-                        			"type": "plain_text",
-                        			"text": "New request"
-                        		}
-                        	},
-                        	{
-                        		"type": "section",
-                        		"fields": [
-                        			{
-                        				"type": "mrkdwn",
-                        				"text": "*Type:*\\nPaid Time Off"
-                        			},
-                        			{
-                        				"type": "mrkdwn",
-                        				"text": "*Created by:*\\n<example.com|Fred Enriquez>"
-                        			}
-                        		]
-                        	},
-                        	{
-                        		"type": "section",
-                        		"fields": [
-                        			{
-                        				"type": "mrkdwn",
-                        				"text": "*When:*\\nAug 10 - Aug 13"
-                        			}
-                        		]
-                        	},
-                        	{
-                        		"type": "section",
-                        		"text": {
-                        			"type": "mrkdwn",
-                        			"text": "<https://example.com|View request>"
-                        		}
-                        	}
-                        ]
-                        """;
+        [
+        	{
+        		"type": "header",
+        		"text": {
+        			"type": "plain_text",
+        			"text": "New request"
+        		}
+        	},
+        	{
+        		"type": "section",
+        		"fields": [
+        			{
+        				"type": "mrkdwn",
+        				"text": "*Type:*\\nPaid Time Off"
+        			},
+        			{
+        				"type": "mrkdwn",
+        				"text": "*Created by:*\\n<example.com|Fred Enriquez>"
+        			}
+        		]
+        	},
+        	{
+        		"type": "section",
+        		"fields": [
+        			{
+        				"type": "mrkdwn",
+        				"text": "*When:*\\nAug 10 - Aug 13"
+        			}
+        		]
+        	},
+        	{
+        		"type": "section",
+        		"text": {
+        			"type": "mrkdwn",
+        			"text": "<https://example.com|View request>"
+        		}
+        	}
+        ]
+        """;
 
     var objectMapper = ConnectorsObjectMapperSupplier.getCopy();
 
@@ -195,14 +196,14 @@ class ChatPostMessageDataTest {
     // Given
     final var blockContent =
         """
-                        {
-                           "type": "section",
-                           "text": {
-                             "type": "mrkdwn",
-                             "text": "New Paid Time Off request from <example.com|Fred Enriquez>\\n\\n<https://example.com|View request>"
-                           }
-                         }
-                        """;
+        {
+           "type": "section",
+           "text": {
+             "type": "mrkdwn",
+             "text": "New Paid Time Off request from <example.com|Fred Enriquez>\\n\\n<https://example.com|View request>"
+           }
+         }
+        """;
 
     var objectMapper = ConnectorsObjectMapperSupplier.getCopy();
 

--- a/connectors/slack/src/test/java/io/camunda/connector/slack/outbound/model/ChatPostMessageDataTest.java
+++ b/connectors/slack/src/test/java/io/camunda/connector/slack/outbound/model/ChatPostMessageDataTest.java
@@ -36,13 +36,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 class ChatPostMessageDataTest {
 
-  @Mock private MethodsClient methodsClient;
-  @Mock private UsersLookupByEmailResponse lookupByEmailResponse;
-  @Mock private User user;
-  @Mock private ChatPostMessageResponse chatPostMessageResponse;
-
-  @Captor private ArgumentCaptor<ChatPostMessageRequest> chatPostMessageRequest;
-
   private static final String USERID = "testUserId";
   private static final JsonNode EMPTY_JSON;
 
@@ -54,11 +47,17 @@ class ChatPostMessageDataTest {
     }
   }
 
+  @Mock private MethodsClient methodsClient;
+  @Mock private UsersLookupByEmailResponse lookupByEmailResponse;
+  @Mock private User user;
+  @Mock private ChatPostMessageResponse chatPostMessageResponse;
+  @Captor private ArgumentCaptor<ChatPostMessageRequest> chatPostMessageRequest;
+
   @Test
   void invoke_shouldThrowExceptionWhenUserWithoutEmail() throws SlackApiException, IOException {
     // Given
     ChatPostMessageData chatPostMessageData =
-        new ChatPostMessageData("test@test.com", "plainText", "Test text", EMPTY_JSON);
+        new ChatPostMessageData("test@test.com", "thread_ts", "plainText", "Test text", EMPTY_JSON);
     when(methodsClient.usersLookupByEmail(any(UsersLookupByEmailRequest.class))).thenReturn(null);
     // When and then
     Throwable thrown = catchThrowable(() -> chatPostMessageData.invoke(methodsClient));
@@ -80,7 +79,7 @@ class ChatPostMessageDataTest {
   void invoke_shouldFindUserIdByEmail(String email) throws SlackApiException, IOException {
     // Given
     ChatPostMessageData chatPostMessageData =
-        new ChatPostMessageData(email, "plainText", "test", null);
+        new ChatPostMessageData(email, "thread_ts", "", "test", null);
 
     when(methodsClient.usersLookupByEmail(any(UsersLookupByEmailRequest.class)))
         .thenReturn(lookupByEmailResponse);
@@ -102,7 +101,7 @@ class ChatPostMessageDataTest {
   void invoke_WhenTextIsGiven_ShouldInvoke() throws SlackApiException, IOException {
     // Given
     ChatPostMessageData chatPostMessageData =
-        new ChatPostMessageData("test@test.com", "plainText", "test", null);
+        new ChatPostMessageData("test@test.com", "", "plainText", "test", null);
 
     when(methodsClient.usersLookupByEmail(any(UsersLookupByEmailRequest.class)))
         .thenReturn(lookupByEmailResponse);
@@ -125,51 +124,55 @@ class ChatPostMessageDataTest {
     // Given
     final var blockContent =
         """
-        [
-        	{
-        		"type": "header",
-        		"text": {
-        			"type": "plain_text",
-        			"text": "New request"
-        		}
-        	},
-        	{
-        		"type": "section",
-        		"fields": [
-        			{
-        				"type": "mrkdwn",
-        				"text": "*Type:*\\nPaid Time Off"
-        			},
-        			{
-        				"type": "mrkdwn",
-        				"text": "*Created by:*\\n<example.com|Fred Enriquez>"
-        			}
-        		]
-        	},
-        	{
-        		"type": "section",
-        		"fields": [
-        			{
-        				"type": "mrkdwn",
-        				"text": "*When:*\\nAug 10 - Aug 13"
-        			}
-        		]
-        	},
-        	{
-        		"type": "section",
-        		"text": {
-        			"type": "mrkdwn",
-        			"text": "<https://example.com|View request>"
-        		}
-        	}
-        ]
-        """;
+                        [
+                        	{
+                        		"type": "header",
+                        		"text": {
+                        			"type": "plain_text",
+                        			"text": "New request"
+                        		}
+                        	},
+                        	{
+                        		"type": "section",
+                        		"fields": [
+                        			{
+                        				"type": "mrkdwn",
+                        				"text": "*Type:*\\nPaid Time Off"
+                        			},
+                        			{
+                        				"type": "mrkdwn",
+                        				"text": "*Created by:*\\n<example.com|Fred Enriquez>"
+                        			}
+                        		]
+                        	},
+                        	{
+                        		"type": "section",
+                        		"fields": [
+                        			{
+                        				"type": "mrkdwn",
+                        				"text": "*When:*\\nAug 10 - Aug 13"
+                        			}
+                        		]
+                        	},
+                        	{
+                        		"type": "section",
+                        		"text": {
+                        			"type": "mrkdwn",
+                        			"text": "<https://example.com|View request>"
+                        		}
+                        	}
+                        ]
+                        """;
 
     var objectMapper = ConnectorsObjectMapperSupplier.getCopy();
 
     ChatPostMessageData chatPostMessageData =
         new ChatPostMessageData(
-            "test@test.com", "messageBlock", "test", objectMapper.readTree(blockContent));
+            "test@test.com",
+            "thread_ts",
+            "messageBlock",
+            "test",
+            objectMapper.readTree(blockContent));
 
     when(methodsClient.usersLookupByEmail(any(UsersLookupByEmailRequest.class)))
         .thenReturn(lookupByEmailResponse);
@@ -192,20 +195,20 @@ class ChatPostMessageDataTest {
     // Given
     final var blockContent =
         """
-        {
-           "type": "section",
-           "text": {
-             "type": "mrkdwn",
-             "text": "New Paid Time Off request from <example.com|Fred Enriquez>\\n\\n<https://example.com|View request>"
-           }
-         }
-        """;
+                        {
+                           "type": "section",
+                           "text": {
+                             "type": "mrkdwn",
+                             "text": "New Paid Time Off request from <example.com|Fred Enriquez>\\n\\n<https://example.com|View request>"
+                           }
+                         }
+                        """;
 
     var objectMapper = ConnectorsObjectMapperSupplier.getCopy();
 
     ChatPostMessageData chatPostMessageData =
         new ChatPostMessageData(
-            "test@test.com", "plainText", "test", objectMapper.readTree(blockContent));
+            "test@test.com", "thread_ts", "plainText", "test", objectMapper.readTree(blockContent));
 
     when(methodsClient.usersLookupByEmail(any(UsersLookupByEmailRequest.class)))
         .thenReturn(lookupByEmailResponse);

--- a/connectors/slack/src/test/java/io/camunda/connector/slack/outbound/model/ChatPostMessageDataTest.java
+++ b/connectors/slack/src/test/java/io/camunda/connector/slack/outbound/model/ChatPostMessageDataTest.java
@@ -102,7 +102,7 @@ class ChatPostMessageDataTest {
   void invoke_WhenTextIsGiven_ShouldInvoke() throws SlackApiException, IOException {
     // Given
     ChatPostMessageData chatPostMessageData =
-        new ChatPostMessageData("test@test.com", "", "plainText", "test", null);
+        new ChatPostMessageData("test@test.com", "thread_ts", "plainText", "test", null);
 
     when(methodsClient.usersLookupByEmail(any(UsersLookupByEmailRequest.class)))
         .thenReturn(lookupByEmailResponse);

--- a/connectors/slack/src/test/resources/requests/test-cases/execute-function-with-channel-name.json
+++ b/connectors/slack/src/test/resources/requests/test-cases/execute-function-with-channel-name.json
@@ -5,7 +5,8 @@
     "method": "chat.postMessage",
     "data": {
       "channel": "{{secrets.CHANNEL_NAME_KEY}}",
-      "text": "{{secrets.TEXT_KEY}}"
+      "text": "{{secrets.TEXT_KEY}}",
+      "thread" : "{{secrets.THREAD_NAME_KEY}}"
     }
   },
   {
@@ -14,7 +15,8 @@
     "method": "chat.postMessage",
     "data": {
       "channel": "{{secrets.CHANNEL_NAME_KEY}}",
-      "text": "{{secrets.TEXT_KEY}}"
+      "text": "{{secrets.TEXT_KEY}}",
+      "thread" : "{{secrets.THREAD_NAME_KEY}}"
     }
   },
   {
@@ -23,7 +25,8 @@
     "method": "chat.postMessage",
     "data": {
       "channel": "#john.channel",
-      "text": "some text"
+      "text": "some text",
+      "thread" : "normal_thread"
     }
   }
 ]

--- a/connectors/slack/src/test/resources/requests/test-cases/execute-function-with-email.json
+++ b/connectors/slack/src/test/resources/requests/test-cases/execute-function-with-email.json
@@ -5,7 +5,8 @@
     "method": "chat.postMessage",
     "data": {
       "channel": "{{secrets.EMAIL_KEY}}",
-      "text": "{{secrets.TEXT_KEY}}"
+      "text": "{{secrets.TEXT_KEY}}",
+      "thread" : "{{secrets.THREAD_NAME_KEY}}"
     }
   },
   {
@@ -14,7 +15,8 @@
     "method": "chat.postMessage",
     "data": {
       "channel": "{{secrets.EMAIL_KEY}}",
-      "text": "{{secrets.TEXT_KEY}}"
+      "text": "{{secrets.TEXT_KEY}}",
+      "thread" : "{{secrets.THREAD_NAME_KEY}}"
     }
   },
   {
@@ -23,7 +25,8 @@
     "method": "chat.postMessage",
     "data": {
       "channel": "john.dou@camundamail.com",
-      "text": "some text"
+      "text": "some text",
+      "thread" : "normal_thread"
     }
   }
 ]

--- a/connectors/slack/src/test/resources/requests/test-cases/execute-function-with-username.json
+++ b/connectors/slack/src/test/resources/requests/test-cases/execute-function-with-username.json
@@ -5,7 +5,8 @@
     "method": "chat.postMessage",
     "data": {
       "channel": "{{secrets.USERNAME_KEY}}",
-      "text": "{{secrets.TEXT_KEY}}"
+      "text": "{{secrets.TEXT_KEY}}",
+      "thread" : "{{secrets.THREAD_NAME_KEY}}"
     }
   },
   {
@@ -14,7 +15,8 @@
     "method": "chat.postMessage",
     "data": {
       "channel": "{{secrets.USERNAME_KEY}}",
-      "text": "{{secrets.TEXT_KEY}}"
+      "text": "{{secrets.TEXT_KEY}}",
+      "thread" : "{{secrets.THREAD_NAME_KEY}}"
     }
   },
   {
@@ -23,7 +25,8 @@
     "method": "chat.postMessage",
     "data": {
       "channel": "@JohnDou",
-      "text": "some text"
+      "text": "some text",
+      "thread" : "test thread"
     }
   }
 ]

--- a/connectors/slack/src/test/resources/requests/test-cases/replace-secrets.json
+++ b/connectors/slack/src/test/resources/requests/test-cases/replace-secrets.json
@@ -1,47 +1,52 @@
 [
   {
-    "description": "all secrets keys exist without braces",
-    "token": "{{secrets.TOKEN_KEY}}",
-    "method": "chat.postMessage",
-    "data": {
-      "channel": "{{secrets.EMAIL_KEY}}",
-      "text": "{{secrets.TEXT_KEY}}"
+    "description" : "all secrets keys exist without braces",
+    "token" : "{{secrets.TOKEN_KEY}}",
+    "method" : "chat.postMessage",
+    "data" : {
+      "channel" : "{{secrets.EMAIL_KEY}}",
+      "text" : "{{secrets.TEXT_KEY}}",
+      "thread" : "{{secrets.THREAD_NAME_KEY}}"
     }
   },
   {
-    "description": "all secrets keys exist with braces",
-    "token": "{{secrets.TOKEN_KEY}}",
-    "method": "chat.postMessage",
-    "data": {
-      "channel": "{{secrets.EMAIL_KEY}}",
-      "text": "{{secrets.TEXT_KEY}}"
+    "description" : "all secrets keys exist with braces",
+    "token" : "{{secrets.TOKEN_KEY}}",
+    "method" : "chat.postMessage",
+    "data" : {
+      "channel" : "{{secrets.EMAIL_KEY}}",
+      "text" : "{{secrets.TEXT_KEY}}",
+      "thread" : "{{secrets.THREAD_NAME_KEY}}"
     }
   },
   {
-    "description": "secrets in braces after text",
-    "token": "{{secrets.TOKEN_KEY}}",
-    "method": "chat.postMessage",
-    "data": {
-      "channel": "{{secrets.EMAIL_KEY}}",
-      "text": "some text {{secrets.TEXT_KEY}}"
+    "description" : "secrets in braces after text",
+    "token" : "{{secrets.TOKEN_KEY}}",
+    "method" : "chat.postMessage",
+    "data" : {
+      "channel" : "{{secrets.EMAIL_KEY}}",
+      "text" : "some text {{secrets.TEXT_KEY}}",
+      "thread" : "{{secrets.THREAD_NAME_KEY}}"
     }
   },
   {
-    "description": "secrets in braces in text",
-    "token": "{{secrets.TOKEN_KEY}}",
-    "method": "chat.postMessage",
-    "data": {
-      "channel": "{{secrets.EMAIL_KEY}}",
-      "text": "some  {{ secrets.TEXT_KEY}} text"
+    "description" : "secrets in braces in text",
+    "token" : "{{secrets.TOKEN_KEY}}",
+    "method" : "chat.postMessage",
+    "data" : {
+      "channel" : "{{secrets.EMAIL_KEY}}",
+      "text" : "some  {{ secrets.TEXT_KEY}} text",
+      "thread" : "{{secrets.THREAD_NAME_KEY}}"
     }
   },
   {
-    "description": "secrets before braces in text",
-    "token": "{{secrets.TOKEN_KEY}}",
-    "method": "chat.postMessage",
-    "data": {
-      "channel": "{{secrets.EMAIL_KEY}}",
-      "text": "{{secrets.TEXT_KEY}} some text"
+    "description" : "secrets before braces in text",
+    "token" : "{{secrets.TOKEN_KEY}}",
+    "method" : "chat.postMessage",
+    "data" : {
+      "channel" : "{{secrets.EMAIL_KEY}}",
+      "text" : "{{secrets.TEXT_KEY}} some text",
+      "thread" : "thread {{secrets.THREAD_NAME_KEY}}"
     }
   }
 ]

--- a/connectors/slack/src/test/resources/requests/test-cases/validate-fields-fail.json
+++ b/connectors/slack/src/test/resources/requests/test-cases/validate-fields-fail.json
@@ -4,7 +4,8 @@
     "method": "chat.postMessage",
     "data": {
       "channel": "channel",
-      "text": "_ this is secret test text _"
+      "text": "_ this is secret test text _",
+      "thread": "normal_thread"
     }
   },
   {
@@ -13,7 +14,8 @@
     "method": "chat.postMessage",
     "data": {
       "channel": "channel",
-      "text": "_ this is secret test text _"
+      "text": "_ this is secret test text _",
+      "thread": "normal_thread"
     }
   },
 
@@ -23,7 +25,8 @@
     "method": "chat.postMessage",
     "data": {
       "channel": null,
-      "text": "_ this is secret test text _"
+      "text": "_ this is secret test text _",
+      "thread": "normal_thread"
     }
   },
   {
@@ -32,7 +35,8 @@
     "method": "chat.postMessage",
     "data": {
       "channel": "   ",
-      "text": "_ this is secret test text _"
+      "text": "_ this is secret test text _",
+      "thread": "normal_thread"
     }
   },
   {

--- a/connectors/slack/src/test/resources/requests/test-cases/with-wrong-method.json
+++ b/connectors/slack/src/test/resources/requests/test-cases/with-wrong-method.json
@@ -4,7 +4,8 @@
     "method": "chatpostMessage",
     "data": {
       "channel": "{{secrets.CHANNEL_NAME_KEY}}",
-      "text": "{{secrets.TEXT_KEY}}"
+      "text": "{{secrets.TEXT_KEY}}",
+      "thread" : "{{secrets.THREAD_NAME_KEY}}"
     }
   },
   {
@@ -12,7 +13,8 @@
     "method": null,
     "data": {
       "channel": "{{secrets.CHANNEL_NAME_KEY}}",
-      "text": "{{secrets.TEXT_KEY}}"
+      "text": "{{secrets.TEXT_KEY}}",
+      "thread" : "{{secrets.THREAD_NAME_KEY}}"
     }
   },
   {
@@ -20,7 +22,8 @@
     "method": " ",
     "data": {
       "channel": "channel",
-      "text": "some text"
+      "text": "some text",
+      "thread" : "normal_thread"
     }
   },
   {
@@ -28,7 +31,8 @@
     "method": "chat.getMessage",
     "data": {
       "channel": "channel",
-      "text": "some text"
+      "text": "some text",
+      "thread": "normal_thread"
     }
   }
 ]


### PR DESCRIPTION
## Description

Users were not able to create a new thread from an existing message or add a message to an existing thread. this solves the issues.

I added a new optional field to the slack outbound connector `thread` which takes the id of a message to start a thread from.

This id has to be gotten from the output mapping `message.ts` which contains the id of the posted message

## Related issues

There might be an issue in the future when an user wants to add messages (using camunda) inside a thread that has been create by a normal user (human), as I don't know how to retrieve the id.

<!-- Which issues are closed by this PR or are related -->

closes https://github.com/camunda/team-connectors/issues/653

