### PR TITLE
fix(webhook): specify permitted auth subclasses explicitly to stabilize template generation

### DIFF
--- a/connectors/webhook/src/main/java/io/camunda/connector/inbound/model/WebhookAuthorization.java
+++ b/connectors/webhook/src/main/java/io/camunda/connector/inbound/model/WebhookAuthorization.java
@@ -33,7 +33,7 @@ import java.util.function.Function;
     group = "authorization",
     description = "Choose the authorization type",
     defaultValue = "NONE")
-public sealed interface WebhookAuthorization {
+public sealed interface WebhookAuthorization permits None, BasicAuth, ApiKeyAuth, JwtAuth {
 
   @TemplateSubType(id = "NONE", label = "None")
   final class None implements WebhookAuthorization {}


### PR DESCRIPTION
## Description

This PR defines the list of permitted subclasses of the webhook authentication interface explicitly. Previously it has been derived implicitly because subclasses were in the same file, but in the byte code the order was not fixed, which lead to flaky template generation results and auth option reordering in the element templates.


