### PR TITLE
fix(inbound): flip the acknowledgment config checkbox, enable it for webhook

### DIFF
--- a/connectors/aws/aws-sqs/element-templates/aws-sqs-boundary-connector.json
+++ b/connectors/aws/aws-sqs/element-templates/aws-sqs-boundary-connector.json
@@ -203,7 +203,7 @@
   }, {
     "id" : "consumeUnmatchedEvents",
     "label" : "Consume unmatched events",
-    "value" : false,
+    "value" : true,
     "group" : "activation",
     "binding" : {
       "name" : "consumeUnmatchedEvents",

--- a/connectors/aws/aws-sqs/element-templates/aws-sqs-inbound-intermediate-connector.json
+++ b/connectors/aws/aws-sqs/element-templates/aws-sqs-inbound-intermediate-connector.json
@@ -203,7 +203,7 @@
   }, {
     "id" : "consumeUnmatchedEvents",
     "label" : "Consume unmatched events",
-    "value" : false,
+    "value" : true,
     "group" : "activation",
     "binding" : {
       "name" : "consumeUnmatchedEvents",

--- a/connectors/aws/aws-sqs/element-templates/aws-sqs-start-event-connector.json
+++ b/connectors/aws/aws-sqs/element-templates/aws-sqs-start-event-connector.json
@@ -198,7 +198,7 @@
   }, {
     "id" : "consumeUnmatchedEvents",
     "label" : "Consume unmatched events",
-    "value" : false,
+    "value" : true,
     "group" : "activation",
     "binding" : {
       "name" : "consumeUnmatchedEvents",

--- a/connectors/aws/aws-sqs/element-templates/aws-sqs-start-message.json
+++ b/connectors/aws/aws-sqs/element-templates/aws-sqs-start-message.json
@@ -203,7 +203,7 @@
   }, {
     "id" : "consumeUnmatchedEvents",
     "label" : "Consume unmatched events",
-    "value" : false,
+    "value" : true,
     "group" : "activation",
     "binding" : {
       "name" : "consumeUnmatchedEvents",

--- a/connectors/kafka/element-templates/hybrid/kafka-inbound-connector-boundary-hybrid.json
+++ b/connectors/kafka/element-templates/hybrid/kafka-inbound-connector-boundary-hybrid.json
@@ -236,7 +236,7 @@
   }, {
     "id" : "consumeUnmatchedEvents",
     "label" : "Consume unmatched events",
-    "value" : false,
+    "value" : true,
     "group" : "activation",
     "binding" : {
       "name" : "consumeUnmatchedEvents",

--- a/connectors/kafka/element-templates/hybrid/kafka-inbound-connector-intermediate-hybrid.json
+++ b/connectors/kafka/element-templates/hybrid/kafka-inbound-connector-intermediate-hybrid.json
@@ -236,7 +236,7 @@
   }, {
     "id" : "consumeUnmatchedEvents",
     "label" : "Consume unmatched events",
-    "value" : false,
+    "value" : true,
     "group" : "activation",
     "binding" : {
       "name" : "consumeUnmatchedEvents",

--- a/connectors/kafka/element-templates/hybrid/kafka-inbound-connector-start-event-hybrid.json
+++ b/connectors/kafka/element-templates/hybrid/kafka-inbound-connector-start-event-hybrid.json
@@ -231,7 +231,7 @@
   }, {
     "id" : "consumeUnmatchedEvents",
     "label" : "Consume unmatched events",
-    "value" : false,
+    "value" : true,
     "group" : "activation",
     "binding" : {
       "name" : "consumeUnmatchedEvents",

--- a/connectors/kafka/element-templates/hybrid/kafka-inbound-connector-start-message-hybrid.json
+++ b/connectors/kafka/element-templates/hybrid/kafka-inbound-connector-start-message-hybrid.json
@@ -236,7 +236,7 @@
   }, {
     "id" : "consumeUnmatchedEvents",
     "label" : "Consume unmatched events",
-    "value" : false,
+    "value" : true,
     "group" : "activation",
     "binding" : {
       "name" : "consumeUnmatchedEvents",

--- a/connectors/kafka/element-templates/kafka-inbound-connector-boundary.json
+++ b/connectors/kafka/element-templates/kafka-inbound-connector-boundary.json
@@ -231,7 +231,7 @@
   }, {
     "id" : "consumeUnmatchedEvents",
     "label" : "Consume unmatched events",
-    "value" : false,
+    "value" : true,
     "group" : "activation",
     "binding" : {
       "name" : "consumeUnmatchedEvents",

--- a/connectors/kafka/element-templates/kafka-inbound-connector-intermediate.json
+++ b/connectors/kafka/element-templates/kafka-inbound-connector-intermediate.json
@@ -231,7 +231,7 @@
   }, {
     "id" : "consumeUnmatchedEvents",
     "label" : "Consume unmatched events",
-    "value" : false,
+    "value" : true,
     "group" : "activation",
     "binding" : {
       "name" : "consumeUnmatchedEvents",

--- a/connectors/kafka/element-templates/kafka-inbound-connector-start-event.json
+++ b/connectors/kafka/element-templates/kafka-inbound-connector-start-event.json
@@ -226,7 +226,7 @@
   }, {
     "id" : "consumeUnmatchedEvents",
     "label" : "Consume unmatched events",
-    "value" : false,
+    "value" : true,
     "group" : "activation",
     "binding" : {
       "name" : "consumeUnmatchedEvents",

--- a/connectors/kafka/element-templates/kafka-inbound-connector-start-message.json
+++ b/connectors/kafka/element-templates/kafka-inbound-connector-start-message.json
@@ -231,7 +231,7 @@
   }, {
     "id" : "consumeUnmatchedEvents",
     "label" : "Consume unmatched events",
-    "value" : false,
+    "value" : true,
     "group" : "activation",
     "binding" : {
       "name" : "consumeUnmatchedEvents",

--- a/connectors/rabbitmq/element-templates/hybrid/rabbitmq-inbound-connector-boundary-hybrid.json
+++ b/connectors/rabbitmq/element-templates/hybrid/rabbitmq-inbound-connector-boundary-hybrid.json
@@ -253,7 +253,7 @@
   }, {
     "id" : "consumeUnmatchedEvents",
     "label" : "Consume unmatched events",
-    "value" : false,
+    "value" : true,
     "group" : "activation",
     "binding" : {
       "name" : "consumeUnmatchedEvents",

--- a/connectors/rabbitmq/element-templates/hybrid/rabbitmq-inbound-connector-intermediate-hybrid.json
+++ b/connectors/rabbitmq/element-templates/hybrid/rabbitmq-inbound-connector-intermediate-hybrid.json
@@ -253,7 +253,7 @@
   }, {
     "id" : "consumeUnmatchedEvents",
     "label" : "Consume unmatched events",
-    "value" : false,
+    "value" : true,
     "group" : "activation",
     "binding" : {
       "name" : "consumeUnmatchedEvents",

--- a/connectors/rabbitmq/element-templates/hybrid/rabbitmq-inbound-connector-message-start-hybrid.json
+++ b/connectors/rabbitmq/element-templates/hybrid/rabbitmq-inbound-connector-message-start-hybrid.json
@@ -253,7 +253,7 @@
   }, {
     "id" : "consumeUnmatchedEvents",
     "label" : "Consume unmatched events",
-    "value" : false,
+    "value" : true,
     "group" : "activation",
     "binding" : {
       "name" : "consumeUnmatchedEvents",

--- a/connectors/rabbitmq/element-templates/hybrid/rabbitmq-inbound-connector-start-event-hybrid.json
+++ b/connectors/rabbitmq/element-templates/hybrid/rabbitmq-inbound-connector-start-event-hybrid.json
@@ -248,7 +248,7 @@
   }, {
     "id" : "consumeUnmatchedEvents",
     "label" : "Consume unmatched events",
-    "value" : false,
+    "value" : true,
     "group" : "activation",
     "binding" : {
       "name" : "consumeUnmatchedEvents",

--- a/connectors/rabbitmq/element-templates/rabbitmq-inbound-connector-boundary.json
+++ b/connectors/rabbitmq/element-templates/rabbitmq-inbound-connector-boundary.json
@@ -248,7 +248,7 @@
   }, {
     "id" : "consumeUnmatchedEvents",
     "label" : "Consume unmatched events",
-    "value" : false,
+    "value" : true,
     "group" : "activation",
     "binding" : {
       "name" : "consumeUnmatchedEvents",

--- a/connectors/rabbitmq/element-templates/rabbitmq-inbound-connector-intermediate.json
+++ b/connectors/rabbitmq/element-templates/rabbitmq-inbound-connector-intermediate.json
@@ -248,7 +248,7 @@
   }, {
     "id" : "consumeUnmatchedEvents",
     "label" : "Consume unmatched events",
-    "value" : false,
+    "value" : true,
     "group" : "activation",
     "binding" : {
       "name" : "consumeUnmatchedEvents",

--- a/connectors/rabbitmq/element-templates/rabbitmq-inbound-connector-message-start.json
+++ b/connectors/rabbitmq/element-templates/rabbitmq-inbound-connector-message-start.json
@@ -248,7 +248,7 @@
   }, {
     "id" : "consumeUnmatchedEvents",
     "label" : "Consume unmatched events",
-    "value" : false,
+    "value" : true,
     "group" : "activation",
     "binding" : {
       "name" : "consumeUnmatchedEvents",

--- a/connectors/rabbitmq/element-templates/rabbitmq-inbound-connector-start-event.json
+++ b/connectors/rabbitmq/element-templates/rabbitmq-inbound-connector-start-event.json
@@ -243,7 +243,7 @@
   }, {
     "id" : "consumeUnmatchedEvents",
     "label" : "Consume unmatched events",
-    "value" : false,
+    "value" : true,
     "group" : "activation",
     "binding" : {
       "name" : "consumeUnmatchedEvents",

--- a/connectors/webhook/element-templates/hybrid/webhook-connector-boundary-hybrid.json
+++ b/connectors/webhook/element-templates/hybrid/webhook-connector-boundary-hybrid.json
@@ -376,6 +376,17 @@
     },
     "type" : "String"
   }, {
+    "id" : "consumeUnmatchedEvents",
+    "label" : "Consume unmatched events",
+    "value" : true,
+    "group" : "activation",
+    "binding" : {
+      "name" : "consumeUnmatchedEvents",
+      "type" : "zeebe:property"
+    },
+    "tooltip" : "Unmatched events are rejected by default, allowing the upstream service to handle the error. Check this box to consume unmatched events and return a success response",
+    "type" : "Boolean"
+  }, {
     "id" : "correlationKeyProcess",
     "label" : "Correlation key (process)",
     "description" : "Sets up the correlation key from process variables",

--- a/connectors/webhook/element-templates/hybrid/webhook-connector-intermediate-hybrid.json
+++ b/connectors/webhook/element-templates/hybrid/webhook-connector-intermediate-hybrid.json
@@ -376,6 +376,17 @@
     },
     "type" : "String"
   }, {
+    "id" : "consumeUnmatchedEvents",
+    "label" : "Consume unmatched events",
+    "value" : true,
+    "group" : "activation",
+    "binding" : {
+      "name" : "consumeUnmatchedEvents",
+      "type" : "zeebe:property"
+    },
+    "tooltip" : "Unmatched events are rejected by default, allowing the upstream service to handle the error. Check this box to consume unmatched events and return a success response",
+    "type" : "Boolean"
+  }, {
     "id" : "correlationKeyProcess",
     "label" : "Correlation key (process)",
     "description" : "Sets up the correlation key from process variables",

--- a/connectors/webhook/element-templates/hybrid/webhook-connector-start-event-hybrid.json
+++ b/connectors/webhook/element-templates/hybrid/webhook-connector-start-event-hybrid.json
@@ -371,6 +371,17 @@
     },
     "type" : "String"
   }, {
+    "id" : "consumeUnmatchedEvents",
+    "label" : "Consume unmatched events",
+    "value" : true,
+    "group" : "activation",
+    "binding" : {
+      "name" : "consumeUnmatchedEvents",
+      "type" : "zeebe:property"
+    },
+    "tooltip" : "Unmatched events are rejected by default, allowing the upstream service to handle the error. Check this box to consume unmatched events and return a success response",
+    "type" : "Boolean"
+  }, {
     "id" : "resultVariable",
     "label" : "Result variable",
     "description" : "Name of variable to store the response in",

--- a/connectors/webhook/element-templates/hybrid/webhook-connector-start-message-hybrid.json
+++ b/connectors/webhook/element-templates/hybrid/webhook-connector-start-message-hybrid.json
@@ -376,6 +376,17 @@
     },
     "type" : "String"
   }, {
+    "id" : "consumeUnmatchedEvents",
+    "label" : "Consume unmatched events",
+    "value" : true,
+    "group" : "activation",
+    "binding" : {
+      "name" : "consumeUnmatchedEvents",
+      "type" : "zeebe:property"
+    },
+    "tooltip" : "Unmatched events are rejected by default, allowing the upstream service to handle the error. Check this box to consume unmatched events and return a success response",
+    "type" : "Boolean"
+  }, {
     "id" : "correlationRequired",
     "label" : "Subprocess correlation required",
     "description" : "Indicates whether correlation is required. This is needed for event-based subprocess message start events",

--- a/connectors/webhook/element-templates/webhook-connector-boundary.json
+++ b/connectors/webhook/element-templates/webhook-connector-boundary.json
@@ -371,6 +371,17 @@
     },
     "type" : "String"
   }, {
+    "id" : "consumeUnmatchedEvents",
+    "label" : "Consume unmatched events",
+    "value" : true,
+    "group" : "activation",
+    "binding" : {
+      "name" : "consumeUnmatchedEvents",
+      "type" : "zeebe:property"
+    },
+    "tooltip" : "Unmatched events are rejected by default, allowing the upstream service to handle the error. Check this box to consume unmatched events and return a success response",
+    "type" : "Boolean"
+  }, {
     "id" : "correlationKeyProcess",
     "label" : "Correlation key (process)",
     "description" : "Sets up the correlation key from process variables",

--- a/connectors/webhook/element-templates/webhook-connector-intermediate.json
+++ b/connectors/webhook/element-templates/webhook-connector-intermediate.json
@@ -371,6 +371,17 @@
     },
     "type" : "String"
   }, {
+    "id" : "consumeUnmatchedEvents",
+    "label" : "Consume unmatched events",
+    "value" : true,
+    "group" : "activation",
+    "binding" : {
+      "name" : "consumeUnmatchedEvents",
+      "type" : "zeebe:property"
+    },
+    "tooltip" : "Unmatched events are rejected by default, allowing the upstream service to handle the error. Check this box to consume unmatched events and return a success response",
+    "type" : "Boolean"
+  }, {
     "id" : "correlationKeyProcess",
     "label" : "Correlation key (process)",
     "description" : "Sets up the correlation key from process variables",

--- a/connectors/webhook/element-templates/webhook-connector-start-event.json
+++ b/connectors/webhook/element-templates/webhook-connector-start-event.json
@@ -366,6 +366,17 @@
     },
     "type" : "String"
   }, {
+    "id" : "consumeUnmatchedEvents",
+    "label" : "Consume unmatched events",
+    "value" : true,
+    "group" : "activation",
+    "binding" : {
+      "name" : "consumeUnmatchedEvents",
+      "type" : "zeebe:property"
+    },
+    "tooltip" : "Unmatched events are rejected by default, allowing the upstream service to handle the error. Check this box to consume unmatched events and return a success response",
+    "type" : "Boolean"
+  }, {
     "id" : "resultVariable",
     "label" : "Result variable",
     "description" : "Name of variable to store the response in",

--- a/connectors/webhook/element-templates/webhook-connector-start-message.json
+++ b/connectors/webhook/element-templates/webhook-connector-start-message.json
@@ -371,6 +371,17 @@
     },
     "type" : "String"
   }, {
+    "id" : "consumeUnmatchedEvents",
+    "label" : "Consume unmatched events",
+    "value" : true,
+    "group" : "activation",
+    "binding" : {
+      "name" : "consumeUnmatchedEvents",
+      "type" : "zeebe:property"
+    },
+    "tooltip" : "Unmatched events are rejected by default, allowing the upstream service to handle the error. Check this box to consume unmatched events and return a success response",
+    "type" : "Boolean"
+  }, {
     "id" : "correlationRequired",
     "label" : "Subprocess correlation required",
     "description" : "Indicates whether correlation is required. This is needed for event-based subprocess message start events",

--- a/connectors/webhook/pom.xml
+++ b/connectors/webhook/pom.xml
@@ -105,6 +105,9 @@
                 </file>
               </files>
               <generateHybridTemplates>true</generateHybridTemplates>
+              <features>
+                <ACKNOWLEDGEMENT_STRATEGY_SELECTION>true</ACKNOWLEDGEMENT_STRATEGY_SELECTION>
+              </features>
             </connector>
           </connectors>
         </configuration>

--- a/element-template-generator/core/src/main/java/io/camunda/connector/generator/dsl/CommonProperties.java
+++ b/element-template-generator/core/src/main/java/io/camunda/connector/generator/dsl/CommonProperties.java
@@ -92,7 +92,7 @@ public class CommonProperties {
         .tooltip(
             "Unmatched events are rejected by default, allowing the upstream service to handle the error. Check this box to consume unmatched events and return a success response")
         .group("activation")
-        .value(false)
+        .value(true)
         .binding(new ZeebeProperty("consumeUnmatchedEvents"));
   }
 


### PR DESCRIPTION
## Description

This PR changes the default setting of the acknowledgment configuration to "Acknowledge unmatched events by default" to restore the previous default behavior.

Also this feature is now enabled for the webhook connector.

## Related issues

closes https://github.com/camunda/connectors/issues/2596

