### PR TITLE
fix(rest): Fix Cloud Function credentials initialization

### DIFF
--- a/connectors/http/http-base/src/test/java/io/camunda/connector/http/base/cloudfunction/CloudFunctionCredentialsCacheTest.java
+++ b/connectors/http/http-base/src/test/java/io/camunda/connector/http/base/cloudfunction/CloudFunctionCredentialsCacheTest.java
@@ -50,8 +50,8 @@ public class CloudFunctionCredentialsCacheTest {
 
     // then
     assertThat(credentialsSupplierCalledCnt.get()).isEqualTo(1);
-    assertThat(credentials).isPresent();
-    assertThat(credentials.get().getAccessToken()).isEqualTo(new AccessToken("fakeToken", dateNow));
+    assertThat(credentials).isNotNull();
+    assertThat(credentials.getAccessToken()).isEqualTo(new AccessToken("fakeToken", dateNow));
   }
 
   @Test
@@ -72,8 +72,8 @@ public class CloudFunctionCredentialsCacheTest {
 
     // then
     assertThat(credentialsSupplierCalledCnt.get()).isEqualTo(1);
-    assertThat(credentials).isPresent();
-    assertThat(credentials.get().getAccessToken()).isEqualTo(new AccessToken("fakeToken", dateNow));
+    assertThat(credentials).isNotNull();
+    assertThat(credentials.getAccessToken()).isEqualTo(new AccessToken("fakeToken", dateNow));
   }
 
   @Test
@@ -99,9 +99,8 @@ public class CloudFunctionCredentialsCacheTest {
 
     // then
     assertThat(credentialsSupplierCalledCnt.get()).isEqualTo(1);
-    assertThat(credentials).isPresent();
-    assertThat(credentials.get().getAccessToken())
-        .isEqualTo(new AccessToken("fakeToken", expiredDate));
+    assertThat(credentials).isNotNull();
+    assertThat(credentials.getAccessToken()).isEqualTo(new AccessToken("fakeToken", expiredDate));
     verify(fakeCredentials, times(1)).refreshIfExpired();
   }
 


### PR DESCRIPTION
## Description

We can't get the Credentials for our Google Cloud Function.
This is due to a missing call to `refreshIfExpired`, as the credentials are not initialized by default.

Also added some refactoring, as we don't need these Optionals.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes https://github.com/camunda/team-connectors/issues/816

