### PR TITLE
feature-2730 fix the escaping feature for rabbitMQ outbound connector

### DIFF
--- a/connectors/aws/aws-sns/src/main/java/io/camunda/connector/sns/outbound/SnsConnectorFunction.java
+++ b/connectors/aws/aws-sns/src/main/java/io/camunda/connector/sns/outbound/SnsConnectorFunction.java
@@ -24,7 +24,6 @@ import io.camunda.connector.sns.outbound.model.SnsConnectorRequest;
 import io.camunda.connector.sns.outbound.model.SnsConnectorResult;
 import io.camunda.connector.sns.suppliers.SnsClientSupplier;
 import java.util.Optional;
-import org.apache.commons.text.StringEscapeUtils;
 
 @OutboundConnector(
     name = "AWS SNS Outbound",
@@ -81,7 +80,7 @@ public class SnsConnectorFunction implements OutboundConnectorFunction {
     try {
       String topicMessage =
           request.getTopic().getMessage() instanceof String
-              ? StringEscapeUtils.unescapeJson(request.getTopic().getMessage().toString())
+              ? request.getTopic().getMessage().toString()
               : objectMapper.writeValueAsString(request.getTopic().getMessage());
       PublishRequest message =
           new PublishRequest()

--- a/connectors/aws/aws-sns/src/test/java/io/camunda/connector/sns/outbound/BaseTest.java
+++ b/connectors/aws/aws-sns/src/test/java/io/camunda/connector/sns/outbound/BaseTest.java
@@ -73,5 +73,30 @@ public abstract class BaseTest {
                     }
                   }""";
 
+  protected static final String REQUEST_WITH_JSON_MSG_BODY_SPECIAL_CHAR =
+          """
+                      {
+                        "authentication":{
+                          "secretKey":"abc",
+                          "accessKey":"def"
+                        },
+                        "topic":{
+                          "message":{"key":"\\"normal\\" value"},
+                          "messageAttributes":{
+                            "attribute2":{
+                              "StringValue":"attribute 2 value",
+                              "DataType":"String"
+                            },
+                            "attribute1":{
+                              "StringValue":"attribute 1 value",
+                              "DataType":"String"
+                            }
+                          },
+                          "subject":"MySubject",
+                          "region":"us-east-1",
+                          "topicArn":"arn:aws:sns:us-east-1:000000000000:test"
+                        }
+                      }""";
+
   protected static final ObjectMapper objectMapper = ObjectMapperSupplier.getMapperInstance();
 }

--- a/connectors/aws/aws-sns/src/test/java/io/camunda/connector/sns/outbound/BaseTest.java
+++ b/connectors/aws/aws-sns/src/test/java/io/camunda/connector/sns/outbound/BaseTest.java
@@ -74,7 +74,7 @@ public abstract class BaseTest {
                   }""";
 
   protected static final String REQUEST_WITH_JSON_MSG_BODY_SPECIAL_CHAR =
-          """
+      """
                       {
                         "authentication":{
                           "secretKey":"abc",

--- a/connectors/aws/aws-sns/src/test/java/io/camunda/connector/sns/outbound/SnsConnectorFunctionTest.java
+++ b/connectors/aws/aws-sns/src/test/java/io/camunda/connector/sns/outbound/SnsConnectorFunctionTest.java
@@ -112,4 +112,30 @@ public class SnsConnectorFunctionTest extends BaseTest {
     String message = requestArgumentCaptor.getValue().getMessage();
     Assertions.assertThat(message).isEqualTo("{\"key\":\"value\"}");
   }
+
+  @Test
+  public void execute_shouldExecuteRequestWithJsonTypeMsgShouldNotEscape() {
+    // Given
+    Mockito.when(snsClient.publish(requestArgumentCaptor.capture())).thenReturn(publishResult);
+    SnsClientSupplier snsClientSupplier = Mockito.mock(SnsClientSupplier.class);
+    Mockito.when(
+                    snsClientSupplier.getSnsClient(
+                            any(AWSCredentialsProvider.class), ArgumentMatchers.anyString()))
+            .thenReturn(snsClient);
+    connector = new SnsConnectorFunction(snsClientSupplier, objectMapper);
+    context =
+            OutboundConnectorContextBuilder.create()
+                    .secret(AWS_ACCESS_KEY, ACTUAL_ACCESS_KEY)
+                    .secret(AWS_SECRET_KEY, ACTUAL_SECRET_KEY)
+                    .variables(REQUEST_WITH_JSON_MSG_BODY_SPECIAL_CHAR)
+                    .build();
+
+    // When
+    connector.execute(context);
+
+    // Then
+    Mockito.verify(snsClient, Mockito.times(1)).shutdown();
+    String message = requestArgumentCaptor.getValue().getMessage();
+    Assertions.assertThat(message).isEqualTo("{\"key\":\"\\\"normal\\\" value\"}");
+  }
 }

--- a/connectors/aws/aws-sns/src/test/java/io/camunda/connector/sns/outbound/SnsConnectorFunctionTest.java
+++ b/connectors/aws/aws-sns/src/test/java/io/camunda/connector/sns/outbound/SnsConnectorFunctionTest.java
@@ -119,16 +119,16 @@ public class SnsConnectorFunctionTest extends BaseTest {
     Mockito.when(snsClient.publish(requestArgumentCaptor.capture())).thenReturn(publishResult);
     SnsClientSupplier snsClientSupplier = Mockito.mock(SnsClientSupplier.class);
     Mockito.when(
-                    snsClientSupplier.getSnsClient(
-                            any(AWSCredentialsProvider.class), ArgumentMatchers.anyString()))
-            .thenReturn(snsClient);
+            snsClientSupplier.getSnsClient(
+                any(AWSCredentialsProvider.class), ArgumentMatchers.anyString()))
+        .thenReturn(snsClient);
     connector = new SnsConnectorFunction(snsClientSupplier, objectMapper);
     context =
-            OutboundConnectorContextBuilder.create()
-                    .secret(AWS_ACCESS_KEY, ACTUAL_ACCESS_KEY)
-                    .secret(AWS_SECRET_KEY, ACTUAL_SECRET_KEY)
-                    .variables(REQUEST_WITH_JSON_MSG_BODY_SPECIAL_CHAR)
-                    .build();
+        OutboundConnectorContextBuilder.create()
+            .secret(AWS_ACCESS_KEY, ACTUAL_ACCESS_KEY)
+            .secret(AWS_SECRET_KEY, ACTUAL_SECRET_KEY)
+            .variables(REQUEST_WITH_JSON_MSG_BODY_SPECIAL_CHAR)
+            .build();
 
     // When
     connector.execute(context);

--- a/connectors/kafka/src/main/java/io/camunda/connector/kafka/inbound/KafkaConnectorConsumer.java
+++ b/connectors/kafka/src/main/java/io/camunda/connector/kafka/inbound/KafkaConnectorConsumer.java
@@ -42,7 +42,6 @@ import java.util.concurrent.Executors;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.apache.avro.Schema;
-import org.apache.commons.text.StringEscapeUtils;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
@@ -96,8 +95,7 @@ public class KafkaConnectorConsumer {
 
   public void startConsumer() {
     if (elementProps.avro() != null) {
-      var schemaString = StringEscapeUtils.unescapeJson(elementProps.avro().schema());
-      Schema schema = new Schema.Parser().setValidate(true).parse(schemaString);
+      Schema schema = new Schema.Parser().setValidate(true).parse(elementProps.avro().schema());
       AvroSchema avroSchema = new AvroSchema(schema);
       AvroMapper avroMapper = new AvroMapper();
       avroObjectReader = avroMapper.reader(avroSchema);

--- a/connectors/kafka/src/main/java/io/camunda/connector/kafka/inbound/KafkaPropertyTransformer.java
+++ b/connectors/kafka/src/main/java/io/camunda/connector/kafka/inbound/KafkaPropertyTransformer.java
@@ -14,7 +14,6 @@ import io.camunda.connector.kafka.outbound.model.KafkaConnectorRequest;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Properties;
-import org.apache.commons.text.StringEscapeUtils;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.config.TopicConfig;
@@ -24,15 +23,12 @@ import org.slf4j.LoggerFactory;
 
 public class KafkaPropertyTransformer {
 
-  private static final Logger LOG = LoggerFactory.getLogger(KafkaPropertyTransformer.class);
-
-  static final String DEFAULT_GROUP_ID_PREFIX = "kafka-inbound-connector";
-
   protected static final String DEFAULT_KEY_DESERIALIZER =
       "org.apache.kafka.common.serialization.StringDeserializer";
-
   protected static final String BYTE_ARRAY_DESERIALIZER =
       "org.apache.kafka.common.serialization.ByteArrayDeserializer";
+  static final String DEFAULT_GROUP_ID_PREFIX = "kafka-inbound-connector";
+  private static final Logger LOG = LoggerFactory.getLogger(KafkaPropertyTransformer.class);
 
   public static Properties getKafkaProperties(
       KafkaConnectorProperties props, InboundConnectorContext context) {
@@ -109,7 +105,7 @@ public class KafkaPropertyTransformer {
       return objectReader.readTree((String) consumerRecord.key());
     } catch (Exception e) {
       LOG.debug("Cannot parse key to json object -> use as string");
-      return StringEscapeUtils.unescapeJson((String) consumerRecord.key());
+      return consumerRecord.key();
     }
   }
 

--- a/connectors/kafka/src/main/java/io/camunda/connector/kafka/outbound/KafkaConnectorFunction.java
+++ b/connectors/kafka/src/main/java/io/camunda/connector/kafka/outbound/KafkaConnectorFunction.java
@@ -28,7 +28,6 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import org.apache.avro.Schema;
-import org.apache.commons.text.StringEscapeUtils;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.clients.producer.ProducerRecord;
@@ -82,13 +81,13 @@ public class KafkaConnectorFunction implements OutboundConnectorFunction {
   }
 
   public static byte[] produceAvroMessage(final KafkaConnectorRequest request) throws Exception {
-    var schemaString = StringEscapeUtils.unescapeJson(request.avro().schema());
+    var schemaString = request.avro().schema();
     Schema raw = new Schema.Parser().setValidate(true).parse(schemaString);
     AvroSchema schema = new AvroSchema(raw);
     AvroMapper avroMapper = new AvroMapper();
     Object messageValue = request.message().value();
     if (messageValue instanceof String messageValueAsString) {
-      messageValue = objectMapper.readTree(StringEscapeUtils.unescapeJson(messageValueAsString));
+      messageValue = objectMapper.readTree(messageValueAsString);
     }
     return avroMapper.writer(schema).writeValueAsBytes(messageValue);
   }

--- a/connectors/kafka/src/test/resources/requests/success-test-cases.json
+++ b/connectors/kafka/src/test/resources/requests/success-test-cases.json
@@ -1,191 +1,191 @@
 [
   {
-    "testDescription": "Regular happy case",
-    "authentication": {
-      "username": "myLogin",
-      "password": "mySecretPassword"
+    "testDescription":"Regular happy case",
+    "authentication":{
+      "username":"myLogin",
+      "password":"mySecretPassword"
     },
-    "topic": {
-      "bootstrapServers": "kafka-stub.kafka.cloud:1234",
-      "topicName": "some-awesome-topic"
+    "topic":{
+      "bootstrapServers":"kafka-stub.kafka.cloud:1234",
+      "topicName":"some-awesome-topic"
     },
-    "message": {
-      "key": "Happy",
-      "value": "Case"
+    "message":{
+      "key":"Happy",
+      "value":"Case"
     }
   },
   {
-    "testDescription": "Regular happy case with headers",
-    "authentication": {
-      "username": "myLogin",
-      "password": "mySecretPassword"
+    "testDescription":"Regular happy case with headers",
+    "authentication":{
+      "username":"myLogin",
+      "password":"mySecretPassword"
     },
-    "topic": {
-      "bootstrapServers": "kafka-stub.kafka.cloud:1234",
-      "topicName": "some-awesome-topic"
+    "topic":{
+      "bootstrapServers":"kafka-stub.kafka.cloud:1234",
+      "topicName":"some-awesome-topic"
     },
-    "message": {
-      "key": "Happy",
-      "value": "Case"
+    "message":{
+      "key":"Happy",
+      "value":"Case"
     },
-    "headers": {
-      "headerKey1": "headerValue",
-      "headerKey2": "headerValue2"
+    "headers":{
+      "headerKey1":"headerValue",
+      "headerKey2":"headerValue2"
     }
   },
   {
-    "testDescription": "Regular happy case with Avro Schema",
-    "authentication": {
-      "username": "myLogin",
-      "password": "mySecretPassword"
+    "testDescription":"Regular happy case with Avro Schema",
+    "authentication":{
+      "username":"myLogin",
+      "password":"mySecretPassword"
     },
-    "topic": {
-      "bootstrapServers": "kafka-stub.kafka.cloud:1234",
-      "topicName": "some-awesome-topic"
+    "topic":{
+      "bootstrapServers":"kafka-stub.kafka.cloud:1234",
+      "topicName":"some-awesome-topic"
     },
-    "message": {
-      "key": "Happy",
-      "value": {
-        "name": "Testname", "age": 40,
-        "emails": ["test@camunda.com"]
+    "message":{
+      "key":"Happy",
+      "value":{
+        "name":"Testname", "age":40,
+        "emails":["test@camunda.com"]
       }
     },
-    "avro": {
-      "schema": "{\"type\": \"record\",\"name\": \"Employee\",\"fields\": [{\"name\": \"name\", \"type\": \"string\"},{\"name\": \"age\", \"type\": \"int\"},{\"name\": \"emails\", \"type\": {\"type\": \"array\", \"items\": \"string\"}},{\"name\": \"boss\", \"type\": [\"Employee\",\"null\"]}]}"
+    "avro":{
+      "schema":"{\"type\": \"record\",\"name\": \"Employee\",\"fields\": [{\"name\": \"name\", \"type\": \"string\"},{\"name\": \"age\", \"type\": \"int\"},{\"name\": \"emails\", \"type\": {\"type\": \"array\", \"items\": \"string\"}},{\"name\": \"boss\", \"type\": [\"Employee\",\"null\"]}]}"
     }
   },
   {
-    "testDescription": "With additional properties",
-    "authentication": {
-      "username": "myLogin",
-      "password": "mySecretPassword"
+    "testDescription":"With additional properties",
+    "authentication":{
+      "username":"myLogin",
+      "password":"mySecretPassword"
     },
-    "topic": {
-      "bootstrapServers": "kafka-stub.kafka.cloud:1234",
-      "topicName": "some-awesome-topic"
+    "topic":{
+      "bootstrapServers":"kafka-stub.kafka.cloud:1234",
+      "topicName":"some-awesome-topic"
     },
-    "message": {
-      "key": "Happy",
-      "value": "Case"
+    "message":{
+      "key":"Happy",
+      "value":"Case"
     },
-    "additionalProperties": {
-      "transaction.timeout.ms": "20000"
+    "additionalProperties":{
+      "transaction.timeout.ms":"20000"
     }
   },
   {
-    "testDescription": "With overridden properties",
-    "authentication": {
-      "username": "myLogin",
-      "password": "mySecretPassword"
+    "testDescription":"With overridden properties",
+    "authentication":{
+      "username":"myLogin",
+      "password":"mySecretPassword"
     },
-    "topic": {
-      "bootstrapServers": "kafka-stub.kafka.cloud:1234",
-      "topicName": "some-awesome-topic"
+    "topic":{
+      "bootstrapServers":"kafka-stub.kafka.cloud:1234",
+      "topicName":"some-awesome-topic"
     },
-    "groupId": "test-group-id",
-    "message": {
-      "key": "Happy",
-      "value": "Case"
+    "groupId":"test-group-id",
+    "message":{
+      "key":"Happy",
+      "value":"Case"
     },
-    "additionalProperties": {
-      "delivery.timeout.ms": "20000",
-      "value.serializer": "org.apache.kafka.common.serialization.StringSerializer"
+    "additionalProperties":{
+      "delivery.timeout.ms":"20000",
+      "value.serializer":"org.apache.kafka.common.serialization.StringSerializer"
     }
   },
   {
-    "testDescription": "With value as JSON",
-    "authentication": {
-      "username": "myLogin",
-      "password": "mySecretPassword"
+    "testDescription":"With value as JSON",
+    "authentication":{
+      "username":"myLogin",
+      "password":"mySecretPassword"
     },
-    "topic": {
-      "bootstrapServers": "kafka-stub.kafka.cloud:1234",
-      "topicName": "some-awesome-topic"
+    "topic":{
+      "bootstrapServers":"kafka-stub.kafka.cloud:1234",
+      "topicName":"some-awesome-topic"
     },
-    "message": {
-      "key": "Happy",
-      "value": {
-        "documentId": "1234567890", "signee": "User Testerson",
-        "contentBase64": "QXQgbGVhc3Qgc29tZWJvZHkgcmVhZHMgdGhlIHRlc3RzLiBHcmVhdCBqb2Ih"
+    "message":{
+      "key":"Happy",
+      "value":{
+        "documentId":"1234567890", "signee":"User Testerson",
+        "contentBase64":"QXQgbGVhc3Qgc29tZWJvZHkgcmVhZHMgdGhlIHRlc3RzLiBHcmVhdCBqb2Ih"
       }
     },
-    "additionalProperties": {
-      "delivery.timeout.ms": "20000"
+    "additionalProperties":{
+      "delivery.timeout.ms":"20000"
     }
   },
   {
-    "testDescription": "Username as secret",
-    "authentication": {
-      "username": "{{secrets.USER_NAME}}",
-      "password": "mySecretPassword"
+    "testDescription":"Username as secret",
+    "authentication":{
+      "username":"{{secrets.USER_NAME}}",
+      "password":"mySecretPassword"
     },
-    "topic": {
-      "bootstrapServers": "kafka-stub.kafka.cloud:1234",
-      "topicName": "some-awesome-topic"
+    "topic":{
+      "bootstrapServers":"kafka-stub.kafka.cloud:1234",
+      "topicName":"some-awesome-topic"
     },
-    "message": {
-      "key": "Happy",
-      "value": "Case"
+    "message":{
+      "key":"Happy",
+      "value":"Case"
     }
   },
   {
-    "testDescription": "Password as secret",
-    "authentication": {
-      "username": "myLogin",
-      "password": "{{secrets.PASSWORD}}"
+    "testDescription":"Password as secret",
+    "authentication":{
+      "username":"myLogin",
+      "password":"{{secrets.PASSWORD}}"
     },
-    "topic": {
-      "bootstrapServers": "kafka-stub.kafka.cloud:1234",
-      "topicName": "some-awesome-topic"
+    "topic":{
+      "bootstrapServers":"kafka-stub.kafka.cloud:1234",
+      "topicName":"some-awesome-topic"
     },
-    "message": {
-      "key": "Happy",
-      "value": "Case"
+    "message":{
+      "key":"Happy",
+      "value":"Case"
     }
   },
   {
-    "testDescription": "Bootstrap server as secret",
-    "authentication": {
-      "username": "myLogin",
-      "password": "mySecretPassword"
+    "testDescription":"Bootstrap server as secret",
+    "authentication":{
+      "username":"myLogin",
+      "password":"mySecretPassword"
     },
-    "topic": {
-      "bootstrapServers": "{{secrets.BOOTSTRAP_SERVER}}",
-      "topicName": "some-awesome-topic"
+    "topic":{
+      "bootstrapServers":"{{secrets.BOOTSTRAP_SERVER}}",
+      "topicName":"some-awesome-topic"
     },
-    "message": {
-      "key": "Happy",
-      "value": "Case"
+    "message":{
+      "key":"Happy",
+      "value":"Case"
     }
   },
   {
-    "testDescription": "Topic name as secret",
-    "authentication": {
-      "username": "myLogin",
-      "password": "mySecretPassword"
+    "testDescription":"Topic name as secret",
+    "authentication":{
+      "username":"myLogin",
+      "password":"mySecretPassword"
     },
-    "topic": {
-      "bootstrapServers": "kafka-stub.kafka.cloud:1234",
-      "topicName": "{{secrets.TOPIC_NAME}}"
+    "topic":{
+      "bootstrapServers":"kafka-stub.kafka.cloud:1234",
+      "topicName":"{{secrets.TOPIC_NAME}}"
     },
-    "message": {
-      "key": "Happy",
-      "value": "Case"
+    "message":{
+      "key":"Happy",
+      "value":"Case"
     }
   },
   {
-    "testDescription": "Topic name as secret",
-    "authentication": {
-      "username": "myLogin",
-      "password": "mySecretPassword"
+    "testDescription":"Topic name as secret",
+    "authentication":{
+      "username":"myLogin",
+      "password":"mySecretPassword"
     },
-    "topic": {
-      "bootstrapServers": "kafka-stub.kafka.cloud:1234",
-      "topicName": "{{secrets.TOPIC_NAME}}"
+    "topic":{
+      "bootstrapServers":"kafka-stub.kafka.cloud:1234",
+      "topicName":"{{secrets.TOPIC_NAME}}"
     },
-    "message": {
-      "key": "Happy \"birthday\"",
-      "value": "Case"
+    "message":{
+      "key":"Happy \"birthday\"",
+      "value":"Case"
     }
   }
 ]

--- a/connectors/kafka/src/test/resources/requests/success-test-cases.json
+++ b/connectors/kafka/src/test/resources/requests/success-test-cases.json
@@ -1,172 +1,191 @@
 [
   {
-    "testDescription": "Regular happy case",
-    "authentication":{
-      "username":"myLogin",
-      "password":"mySecretPassword"
+    "testDescription" : "Regular happy case",
+    "authentication" : {
+      "username" : "myLogin",
+      "password" : "mySecretPassword"
     },
-    "topic":{
-      "bootstrapServers":"kafka-stub.kafka.cloud:1234",
-      "topicName":"some-awesome-topic"
+    "topic" : {
+      "bootstrapServers" : "kafka-stub.kafka.cloud:1234",
+      "topicName" : "some-awesome-topic"
     },
-    "message":{
-      "key":"Happy",
-      "value":"Case"
+    "message" : {
+      "key" : "Happy",
+      "value" : "Case"
     }
   },
   {
-    "testDescription": "Regular happy case with headers",
-    "authentication":{
-      "username":"myLogin",
-      "password":"mySecretPassword"
+    "testDescription" : "Regular happy case with headers",
+    "authentication" : {
+      "username" : "myLogin",
+      "password" : "mySecretPassword"
     },
-    "topic":{
-      "bootstrapServers":"kafka-stub.kafka.cloud:1234",
-      "topicName":"some-awesome-topic"
+    "topic" : {
+      "bootstrapServers" : "kafka-stub.kafka.cloud:1234",
+      "topicName" : "some-awesome-topic"
     },
-    "message":{
-      "key":"Happy",
-      "value":"Case"
+    "message" : {
+      "key" : "Happy",
+      "value" : "Case"
     },
-    "headers": {
-      "headerKey1":"headerValue",
-      "headerKey2":"headerValue2"
+    "headers" : {
+      "headerKey1" : "headerValue",
+      "headerKey2" : "headerValue2"
     }
   },
   {
-    "testDescription": "Regular happy case with Avro Schema",
-    "authentication":{
-      "username":"myLogin",
-      "password":"mySecretPassword"
+    "testDescription" : "Regular happy case with Avro Schema",
+    "authentication" : {
+      "username" : "myLogin",
+      "password" : "mySecretPassword"
     },
-    "topic":{
-      "bootstrapServers":"kafka-stub.kafka.cloud:1234",
-      "topicName":"some-awesome-topic"
+    "topic" : {
+      "bootstrapServers" : "kafka-stub.kafka.cloud:1234",
+      "topicName" : "some-awesome-topic"
     },
-    "message":{
-      "key":"Happy",
-      "value":{"name":  "Testname", "age": 40,
-        "emails": ["test@camunda.com"]
+    "message" : {
+      "key" : "Happy",
+      "value" : {
+        "name" : "Testname", "age" : 40,
+        "emails" : ["test@camunda.com"]
       }
     },
-    "avro": {
-      "schema": "{\"type\": \"record\",\"name\": \"Employee\",\"fields\": [{\"name\": \"name\", \"type\": \"string\"},{\"name\": \"age\", \"type\": \"int\"},{\"name\": \"emails\", \"type\": {\"type\": \"array\", \"items\": \"string\"}},{\"name\": \"boss\", \"type\": [\"Employee\",\"null\"]}]}"
+    "avro" : {
+      "schema" : "{\"type\": \"record\",\"name\": \"Employee\",\"fields\": [{\"name\": \"name\", \"type\": \"string\"},{\"name\": \"age\", \"type\": \"int\"},{\"name\": \"emails\", \"type\": {\"type\": \"array\", \"items\": \"string\"}},{\"name\": \"boss\", \"type\": [\"Employee\",\"null\"]}]}"
     }
   },
   {
-    "testDescription": "With additional properties",
-    "authentication":{
-      "username":"myLogin",
-      "password":"mySecretPassword"
+    "testDescription" : "With additional properties",
+    "authentication" : {
+      "username" : "myLogin",
+      "password" : "mySecretPassword"
     },
-    "topic":{
-      "bootstrapServers":"kafka-stub.kafka.cloud:1234",
-      "topicName":"some-awesome-topic"
+    "topic" : {
+      "bootstrapServers" : "kafka-stub.kafka.cloud:1234",
+      "topicName" : "some-awesome-topic"
     },
-    "message":{
-      "key":"Happy",
-      "value":"Case"
+    "message" : {
+      "key" : "Happy",
+      "value" : "Case"
     },
     "additionalProperties" : {
-      "transaction.timeout.ms": "20000"
+      "transaction.timeout.ms" : "20000"
     }
   },
   {
-    "testDescription": "With overridden properties",
-    "authentication":{
-      "username":"myLogin",
-      "password":"mySecretPassword"
+    "testDescription" : "With overridden properties",
+    "authentication" : {
+      "username" : "myLogin",
+      "password" : "mySecretPassword"
     },
-    "topic":{
-      "bootstrapServers":"kafka-stub.kafka.cloud:1234",
-      "topicName":"some-awesome-topic"
+    "topic" : {
+      "bootstrapServers" : "kafka-stub.kafka.cloud:1234",
+      "topicName" : "some-awesome-topic"
     },
-    "groupId":  "test-group-id",
-    "message":{
-      "key":"Happy",
-      "value":"Case"
+    "groupId" : "test-group-id",
+    "message" : {
+      "key" : "Happy",
+      "value" : "Case"
     },
     "additionalProperties" : {
-      "delivery.timeout.ms": "20000",
-      "value.serializer":"org.apache.kafka.common.serialization.StringSerializer"
+      "delivery.timeout.ms" : "20000",
+      "value.serializer" : "org.apache.kafka.common.serialization.StringSerializer"
     }
   },
   {
-    "testDescription": "With value as JSON",
-    "authentication":{
-      "username":"myLogin",
-      "password":"mySecretPassword"
+    "testDescription" : "With value as JSON",
+    "authentication" : {
+      "username" : "myLogin",
+      "password" : "mySecretPassword"
     },
-    "topic":{
-      "bootstrapServers":"kafka-stub.kafka.cloud:1234",
-      "topicName":"some-awesome-topic"
+    "topic" : {
+      "bootstrapServers" : "kafka-stub.kafka.cloud:1234",
+      "topicName" : "some-awesome-topic"
     },
-    "message":{
-      "key":"Happy",
-      "value": {"documentId": "1234567890", "signee": "User Testerson", "contentBase64": "QXQgbGVhc3Qgc29tZWJvZHkgcmVhZHMgdGhlIHRlc3RzLiBHcmVhdCBqb2Ih"}
+    "message" : {
+      "key" : "Happy",
+      "value" : {
+        "documentId" : "1234567890", "signee" : "User Testerson",
+        "contentBase64" : "QXQgbGVhc3Qgc29tZWJvZHkgcmVhZHMgdGhlIHRlc3RzLiBHcmVhdCBqb2Ih"
+      }
     },
     "additionalProperties" : {
-      "delivery.timeout.ms": "20000"
+      "delivery.timeout.ms" : "20000"
     }
   },
   {
-    "testDescription": "Username as secret",
-    "authentication":{
-      "username":"{{secrets.USER_NAME}}",
-      "password":"mySecretPassword"
+    "testDescription" : "Username as secret",
+    "authentication" : {
+      "username" : "{{secrets.USER_NAME}}",
+      "password" : "mySecretPassword"
     },
-    "topic":{
-      "bootstrapServers":"kafka-stub.kafka.cloud:1234",
-      "topicName":"some-awesome-topic"
+    "topic" : {
+      "bootstrapServers" : "kafka-stub.kafka.cloud:1234",
+      "topicName" : "some-awesome-topic"
     },
-    "message":{
-      "key":"Happy",
-      "value":"Case"
+    "message" : {
+      "key" : "Happy",
+      "value" : "Case"
     }
   },
   {
-    "testDescription": "Password as secret",
-    "authentication":{
-      "username":"myLogin",
-      "password":"{{secrets.PASSWORD}}"
+    "testDescription" : "Password as secret",
+    "authentication" : {
+      "username" : "myLogin",
+      "password" : "{{secrets.PASSWORD}}"
     },
-    "topic":{
-      "bootstrapServers":"kafka-stub.kafka.cloud:1234",
-      "topicName":"some-awesome-topic"
+    "topic" : {
+      "bootstrapServers" : "kafka-stub.kafka.cloud:1234",
+      "topicName" : "some-awesome-topic"
     },
-    "message":{
-      "key":"Happy",
-      "value":"Case"
+    "message" : {
+      "key" : "Happy",
+      "value" : "Case"
     }
   },
   {
-    "testDescription": "Bootstrap server as secret",
-    "authentication":{
-      "username":"myLogin",
-      "password":"mySecretPassword"
+    "testDescription" : "Bootstrap server as secret",
+    "authentication" : {
+      "username" : "myLogin",
+      "password" : "mySecretPassword"
     },
-    "topic":{
-      "bootstrapServers":"{{secrets.BOOTSTRAP_SERVER}}",
-      "topicName":"some-awesome-topic"
+    "topic" : {
+      "bootstrapServers" : "{{secrets.BOOTSTRAP_SERVER}}",
+      "topicName" : "some-awesome-topic"
     },
-    "message":{
-      "key":"Happy",
-      "value":"Case"
+    "message" : {
+      "key" : "Happy",
+      "value" : "Case"
     }
   },
   {
-    "testDescription": "Topic name as secret",
-    "authentication":{
-      "username":"myLogin",
-      "password":"mySecretPassword"
+    "testDescription" : "Topic name as secret",
+    "authentication" : {
+      "username" : "myLogin",
+      "password" : "mySecretPassword"
     },
-    "topic":{
-      "bootstrapServers":"kafka-stub.kafka.cloud:1234",
-      "topicName":"{{secrets.TOPIC_NAME}}"
+    "topic" : {
+      "bootstrapServers" : "kafka-stub.kafka.cloud:1234",
+      "topicName" : "{{secrets.TOPIC_NAME}}"
     },
-    "message":{
-      "key":"Happy",
-      "value":"Case"
+    "message" : {
+      "key" : "Happy",
+      "value" : "Case"
+    }
+  },
+  {
+    "testDescription" : "Topic name as secret",
+    "authentication" : {
+      "username" : "myLogin",
+      "password" : "mySecretPassword"
+    },
+    "topic" : {
+      "bootstrapServers" : "kafka-stub.kafka.cloud:1234",
+      "topicName" : "{{secrets.TOPIC_NAME}}"
+    },
+    "message" : {
+      "key" : "Happy \"birthday\"",
+      "value" : "Case"
     }
   }
 ]

--- a/connectors/kafka/src/test/resources/requests/success-test-cases.json
+++ b/connectors/kafka/src/test/resources/requests/success-test-cases.json
@@ -1,191 +1,191 @@
 [
   {
-    "testDescription" : "Regular happy case",
-    "authentication" : {
-      "username" : "myLogin",
-      "password" : "mySecretPassword"
+    "testDescription": "Regular happy case",
+    "authentication": {
+      "username": "myLogin",
+      "password": "mySecretPassword"
     },
-    "topic" : {
-      "bootstrapServers" : "kafka-stub.kafka.cloud:1234",
-      "topicName" : "some-awesome-topic"
+    "topic": {
+      "bootstrapServers": "kafka-stub.kafka.cloud:1234",
+      "topicName": "some-awesome-topic"
     },
-    "message" : {
-      "key" : "Happy",
-      "value" : "Case"
+    "message": {
+      "key": "Happy",
+      "value": "Case"
     }
   },
   {
-    "testDescription" : "Regular happy case with headers",
-    "authentication" : {
-      "username" : "myLogin",
-      "password" : "mySecretPassword"
+    "testDescription": "Regular happy case with headers",
+    "authentication": {
+      "username": "myLogin",
+      "password": "mySecretPassword"
     },
-    "topic" : {
-      "bootstrapServers" : "kafka-stub.kafka.cloud:1234",
-      "topicName" : "some-awesome-topic"
+    "topic": {
+      "bootstrapServers": "kafka-stub.kafka.cloud:1234",
+      "topicName": "some-awesome-topic"
     },
-    "message" : {
-      "key" : "Happy",
-      "value" : "Case"
+    "message": {
+      "key": "Happy",
+      "value": "Case"
     },
-    "headers" : {
-      "headerKey1" : "headerValue",
-      "headerKey2" : "headerValue2"
+    "headers": {
+      "headerKey1": "headerValue",
+      "headerKey2": "headerValue2"
     }
   },
   {
-    "testDescription" : "Regular happy case with Avro Schema",
-    "authentication" : {
-      "username" : "myLogin",
-      "password" : "mySecretPassword"
+    "testDescription": "Regular happy case with Avro Schema",
+    "authentication": {
+      "username": "myLogin",
+      "password": "mySecretPassword"
     },
-    "topic" : {
-      "bootstrapServers" : "kafka-stub.kafka.cloud:1234",
-      "topicName" : "some-awesome-topic"
+    "topic": {
+      "bootstrapServers": "kafka-stub.kafka.cloud:1234",
+      "topicName": "some-awesome-topic"
     },
-    "message" : {
-      "key" : "Happy",
-      "value" : {
-        "name" : "Testname", "age" : 40,
-        "emails" : ["test@camunda.com"]
+    "message": {
+      "key": "Happy",
+      "value": {
+        "name": "Testname", "age": 40,
+        "emails": ["test@camunda.com"]
       }
     },
-    "avro" : {
-      "schema" : "{\"type\": \"record\",\"name\": \"Employee\",\"fields\": [{\"name\": \"name\", \"type\": \"string\"},{\"name\": \"age\", \"type\": \"int\"},{\"name\": \"emails\", \"type\": {\"type\": \"array\", \"items\": \"string\"}},{\"name\": \"boss\", \"type\": [\"Employee\",\"null\"]}]}"
+    "avro": {
+      "schema": "{\"type\": \"record\",\"name\": \"Employee\",\"fields\": [{\"name\": \"name\", \"type\": \"string\"},{\"name\": \"age\", \"type\": \"int\"},{\"name\": \"emails\", \"type\": {\"type\": \"array\", \"items\": \"string\"}},{\"name\": \"boss\", \"type\": [\"Employee\",\"null\"]}]}"
     }
   },
   {
-    "testDescription" : "With additional properties",
-    "authentication" : {
-      "username" : "myLogin",
-      "password" : "mySecretPassword"
+    "testDescription": "With additional properties",
+    "authentication": {
+      "username": "myLogin",
+      "password": "mySecretPassword"
     },
-    "topic" : {
-      "bootstrapServers" : "kafka-stub.kafka.cloud:1234",
-      "topicName" : "some-awesome-topic"
+    "topic": {
+      "bootstrapServers": "kafka-stub.kafka.cloud:1234",
+      "topicName": "some-awesome-topic"
     },
-    "message" : {
-      "key" : "Happy",
-      "value" : "Case"
+    "message": {
+      "key": "Happy",
+      "value": "Case"
     },
-    "additionalProperties" : {
-      "transaction.timeout.ms" : "20000"
+    "additionalProperties": {
+      "transaction.timeout.ms": "20000"
     }
   },
   {
-    "testDescription" : "With overridden properties",
-    "authentication" : {
-      "username" : "myLogin",
-      "password" : "mySecretPassword"
+    "testDescription": "With overridden properties",
+    "authentication": {
+      "username": "myLogin",
+      "password": "mySecretPassword"
     },
-    "topic" : {
-      "bootstrapServers" : "kafka-stub.kafka.cloud:1234",
-      "topicName" : "some-awesome-topic"
+    "topic": {
+      "bootstrapServers": "kafka-stub.kafka.cloud:1234",
+      "topicName": "some-awesome-topic"
     },
-    "groupId" : "test-group-id",
-    "message" : {
-      "key" : "Happy",
-      "value" : "Case"
+    "groupId": "test-group-id",
+    "message": {
+      "key": "Happy",
+      "value": "Case"
     },
-    "additionalProperties" : {
-      "delivery.timeout.ms" : "20000",
-      "value.serializer" : "org.apache.kafka.common.serialization.StringSerializer"
+    "additionalProperties": {
+      "delivery.timeout.ms": "20000",
+      "value.serializer": "org.apache.kafka.common.serialization.StringSerializer"
     }
   },
   {
-    "testDescription" : "With value as JSON",
-    "authentication" : {
-      "username" : "myLogin",
-      "password" : "mySecretPassword"
+    "testDescription": "With value as JSON",
+    "authentication": {
+      "username": "myLogin",
+      "password": "mySecretPassword"
     },
-    "topic" : {
-      "bootstrapServers" : "kafka-stub.kafka.cloud:1234",
-      "topicName" : "some-awesome-topic"
+    "topic": {
+      "bootstrapServers": "kafka-stub.kafka.cloud:1234",
+      "topicName": "some-awesome-topic"
     },
-    "message" : {
-      "key" : "Happy",
-      "value" : {
-        "documentId" : "1234567890", "signee" : "User Testerson",
-        "contentBase64" : "QXQgbGVhc3Qgc29tZWJvZHkgcmVhZHMgdGhlIHRlc3RzLiBHcmVhdCBqb2Ih"
+    "message": {
+      "key": "Happy",
+      "value": {
+        "documentId": "1234567890", "signee": "User Testerson",
+        "contentBase64": "QXQgbGVhc3Qgc29tZWJvZHkgcmVhZHMgdGhlIHRlc3RzLiBHcmVhdCBqb2Ih"
       }
     },
-    "additionalProperties" : {
-      "delivery.timeout.ms" : "20000"
+    "additionalProperties": {
+      "delivery.timeout.ms": "20000"
     }
   },
   {
-    "testDescription" : "Username as secret",
-    "authentication" : {
-      "username" : "{{secrets.USER_NAME}}",
-      "password" : "mySecretPassword"
+    "testDescription": "Username as secret",
+    "authentication": {
+      "username": "{{secrets.USER_NAME}}",
+      "password": "mySecretPassword"
     },
-    "topic" : {
-      "bootstrapServers" : "kafka-stub.kafka.cloud:1234",
-      "topicName" : "some-awesome-topic"
+    "topic": {
+      "bootstrapServers": "kafka-stub.kafka.cloud:1234",
+      "topicName": "some-awesome-topic"
     },
-    "message" : {
-      "key" : "Happy",
-      "value" : "Case"
+    "message": {
+      "key": "Happy",
+      "value": "Case"
     }
   },
   {
-    "testDescription" : "Password as secret",
-    "authentication" : {
-      "username" : "myLogin",
-      "password" : "{{secrets.PASSWORD}}"
+    "testDescription": "Password as secret",
+    "authentication": {
+      "username": "myLogin",
+      "password": "{{secrets.PASSWORD}}"
     },
-    "topic" : {
-      "bootstrapServers" : "kafka-stub.kafka.cloud:1234",
-      "topicName" : "some-awesome-topic"
+    "topic": {
+      "bootstrapServers": "kafka-stub.kafka.cloud:1234",
+      "topicName": "some-awesome-topic"
     },
-    "message" : {
-      "key" : "Happy",
-      "value" : "Case"
+    "message": {
+      "key": "Happy",
+      "value": "Case"
     }
   },
   {
-    "testDescription" : "Bootstrap server as secret",
-    "authentication" : {
-      "username" : "myLogin",
-      "password" : "mySecretPassword"
+    "testDescription": "Bootstrap server as secret",
+    "authentication": {
+      "username": "myLogin",
+      "password": "mySecretPassword"
     },
-    "topic" : {
-      "bootstrapServers" : "{{secrets.BOOTSTRAP_SERVER}}",
-      "topicName" : "some-awesome-topic"
+    "topic": {
+      "bootstrapServers": "{{secrets.BOOTSTRAP_SERVER}}",
+      "topicName": "some-awesome-topic"
     },
-    "message" : {
-      "key" : "Happy",
-      "value" : "Case"
+    "message": {
+      "key": "Happy",
+      "value": "Case"
     }
   },
   {
-    "testDescription" : "Topic name as secret",
-    "authentication" : {
-      "username" : "myLogin",
-      "password" : "mySecretPassword"
+    "testDescription": "Topic name as secret",
+    "authentication": {
+      "username": "myLogin",
+      "password": "mySecretPassword"
     },
-    "topic" : {
-      "bootstrapServers" : "kafka-stub.kafka.cloud:1234",
-      "topicName" : "{{secrets.TOPIC_NAME}}"
+    "topic": {
+      "bootstrapServers": "kafka-stub.kafka.cloud:1234",
+      "topicName": "{{secrets.TOPIC_NAME}}"
     },
-    "message" : {
-      "key" : "Happy",
-      "value" : "Case"
+    "message": {
+      "key": "Happy",
+      "value": "Case"
     }
   },
   {
-    "testDescription" : "Topic name as secret",
-    "authentication" : {
-      "username" : "myLogin",
-      "password" : "mySecretPassword"
+    "testDescription": "Topic name as secret",
+    "authentication": {
+      "username": "myLogin",
+      "password": "mySecretPassword"
     },
-    "topic" : {
-      "bootstrapServers" : "kafka-stub.kafka.cloud:1234",
-      "topicName" : "{{secrets.TOPIC_NAME}}"
+    "topic": {
+      "bootstrapServers": "kafka-stub.kafka.cloud:1234",
+      "topicName": "{{secrets.TOPIC_NAME}}"
     },
-    "message" : {
-      "key" : "Happy \"birthday\"",
-      "value" : "Case"
+    "message": {
+      "key": "Happy \"birthday\"",
+      "value": "Case"
     }
   }
 ]

--- a/connectors/microsoft-teams/src/main/java/io/camunda/connector/operation/channel/SendMessageToChannelOperation.java
+++ b/connectors/microsoft-teams/src/main/java/io/camunda/connector/operation/channel/SendMessageToChannelOperation.java
@@ -13,7 +13,6 @@ import com.microsoft.graph.serviceclient.GraphServiceClient;
 import io.camunda.connector.model.request.data.SendMessageToChannel;
 import java.util.Locale;
 import java.util.Optional;
-import org.apache.commons.text.StringEscapeUtils;
 
 public record SendMessageToChannelOperation(SendMessageToChannel model)
     implements ChannelOperation {
@@ -25,7 +24,7 @@ public record SendMessageToChannelOperation(SendMessageToChannel model)
         Optional.ofNullable(model.bodyType())
             .map(type -> BodyType.forValue(type.toLowerCase(Locale.ROOT)))
             .orElse(BodyType.Text));
-    body.setContent(StringEscapeUtils.unescapeJson(model.content()));
+    body.setContent(model.content());
     chatMessage.setBody(body);
     return graphClient
         .teams()

--- a/connectors/microsoft-teams/src/main/java/io/camunda/connector/operation/chat/SendMessageInChatChatOperation.java
+++ b/connectors/microsoft-teams/src/main/java/io/camunda/connector/operation/chat/SendMessageInChatChatOperation.java
@@ -13,7 +13,6 @@ import com.microsoft.graph.serviceclient.GraphServiceClient;
 import io.camunda.connector.model.request.data.SendMessageInChat;
 import java.util.Locale;
 import java.util.Optional;
-import org.apache.commons.text.StringEscapeUtils;
 
 public record SendMessageInChatChatOperation(SendMessageInChat model) implements ChatOperation {
   @Override
@@ -24,7 +23,7 @@ public record SendMessageInChatChatOperation(SendMessageInChat model) implements
         Optional.ofNullable(model.bodyType())
             .map(type -> BodyType.forValue(type.toLowerCase(Locale.ROOT)))
             .orElse(BodyType.Text));
-    body.setContent(StringEscapeUtils.unescapeJson(model.content()));
+    body.setContent(model.content());
     chatMessage.setBody(body);
     return graphClient.chats().byChatId(model.chatId()).messages().post(chatMessage);
   }

--- a/connectors/microsoft-teams/src/test/java/io/camunda/connector/model/request/chat/SendMessageInChatTest.java
+++ b/connectors/microsoft-teams/src/test/java/io/camunda/connector/model/request/chat/SendMessageInChatTest.java
@@ -68,6 +68,18 @@ class SendMessageInChatTest extends BaseTest {
     assertThat(chatMessage.getBody().getContent()).isEqualTo("content");
   }
 
+  @Test
+  public void invoke_shouldSetTextBodyTypeContentIsNotEscaped() {
+    // Given SendMessageInChat without bodyType
+    // When
+    sendMessageInChat = new SendMessageInChat(ActualValue.Chat.CHAT_ID, "\"normal\" content", null);
+    operationFactory.getService(sendMessageInChat).invoke(graphServiceClient);
+    // Then
+    ChatMessage chatMessage = chatMessageCaptor.getValue();
+    assertThat(chatMessage.getBody().getContentType()).isEqualTo(BodyType.Text);
+    assertThat(chatMessage.getBody().getContent()).isEqualTo("\"normal\" content");
+  }
+
   @ParameterizedTest
   @ValueSource(strings = {"html", "HTML", "text", "TexT"})
   public void invoke_shouldSetTextBodyType(String input) {

--- a/connectors/rabbitmq/src/main/java/io/camunda/connector/rabbitmq/inbound/RabbitMqConsumer.java
+++ b/connectors/rabbitmq/src/main/java/io/camunda/connector/rabbitmq/inbound/RabbitMqConsumer.java
@@ -29,7 +29,6 @@ import io.camunda.connector.rabbitmq.inbound.model.RabbitMqInboundResult.RabbitM
 import io.camunda.connector.rabbitmq.supplier.ObjectMapperSupplier;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import org.apache.commons.text.StringEscapeUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -143,8 +142,7 @@ public class RabbitMqConsumer extends DefaultConsumer {
       Object bodyAsObject;
       if (isPayloadJson(bodyAsString)) {
         JsonNode bodyAsJsonElement =
-            ObjectMapperSupplier.instance()
-                .readValue(StringEscapeUtils.unescapeJson(bodyAsString), JsonNode.class);
+            ObjectMapperSupplier.instance().readValue(bodyAsString, JsonNode.class);
         if (bodyAsJsonElement instanceof ValueNode bodyAsPrimitive) {
           if (bodyAsPrimitive.isBoolean()) {
             bodyAsObject = bodyAsPrimitive.asBoolean();
@@ -173,8 +171,7 @@ public class RabbitMqConsumer extends DefaultConsumer {
 
   private boolean isPayloadJson(final String bodyAsString) {
     try {
-      ObjectMapperSupplier.instance()
-          .readValue(StringEscapeUtils.unescapeJson(bodyAsString), JsonNode.class);
+      ObjectMapperSupplier.instance().readValue(bodyAsString, JsonNode.class);
     } catch (JsonProcessingException e) {
       return false;
     }

--- a/connectors/rabbitmq/src/main/java/io/camunda/connector/rabbitmq/outbound/MessageUtil.java
+++ b/connectors/rabbitmq/src/main/java/io/camunda/connector/rabbitmq/outbound/MessageUtil.java
@@ -13,7 +13,6 @@ import com.rabbitmq.client.AMQP;
 import io.camunda.connector.rabbitmq.outbound.model.RabbitMqMessage;
 import io.camunda.connector.rabbitmq.supplier.ObjectMapperSupplier;
 import java.util.Optional;
-import org.apache.commons.text.StringEscapeUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -38,8 +37,7 @@ public final class MessageUtil {
     Object resBody = body;
     if (body instanceof String) {
       try {
-        JsonNode jsonElement =
-            OBJECT_MAPPER.readTree(StringEscapeUtils.unescapeJson(body.toString()));
+        JsonNode jsonElement = OBJECT_MAPPER.readTree(body.toString());
 
         if (jsonElement.isValueNode()) {
           return ((String) body).getBytes();

--- a/connectors/rabbitmq/src/main/java/io/camunda/connector/rabbitmq/outbound/MessageUtil.java
+++ b/connectors/rabbitmq/src/main/java/io/camunda/connector/rabbitmq/outbound/MessageUtil.java
@@ -62,7 +62,6 @@ public final class MessageUtil {
                 throw new RuntimeException(e);
               }
             })
-        .map(StringEscapeUtils::unescapeJson)
         .map(String::getBytes)
         .orElseThrow(() -> new RuntimeException("Parse error to byte array"));
   }

--- a/connectors/rabbitmq/src/test/java/io/camunda/connector/rabbitmq/outbound/RabbitMqMessageTest.java
+++ b/connectors/rabbitmq/src/test/java/io/camunda/connector/rabbitmq/outbound/RabbitMqMessageTest.java
@@ -17,7 +17,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 class RabbitMqMessageTest {
 
   @ParameterizedTest
-  @ValueSource(strings = {"{\\\"key\\\": \\\"value\\\"}", "{\n \\\"key\\\":\n \\\"value\\\"} \n "})
+  @ValueSource(strings = {"{\"key\": \"value\"}", "{\n \"key\":\n \"value\"} \n "})
   public void getBodyAsByteArray_shouldRemoveBackslashesFormJson(String input) {
     // Given
     final RabbitMqMessage rabbitMqMessage = new RabbitMqMessage(null, input);
@@ -30,7 +30,7 @@ class RabbitMqMessageTest {
   @Test
   public void getBodyAsByteArray_shouldParseJsonWithInt() {
     // Given
-    final String msgWithDigital = "{\\\"key\\\": -1}";
+    final String msgWithDigital = "{\"key\": -1}";
     final RabbitMqMessage rabbitMqMessage = new RabbitMqMessage(null, msgWithDigital);
     // when
     final byte[] bodyAsByteArray = MessageUtil.getBodyAsByteArray(rabbitMqMessage.body());

--- a/connectors/rabbitmq/src/test/java/io/camunda/connector/rabbitmq/outbound/RabbitMqMessageTest.java
+++ b/connectors/rabbitmq/src/test/java/io/camunda/connector/rabbitmq/outbound/RabbitMqMessageTest.java
@@ -9,6 +9,7 @@ package io.camunda.connector.rabbitmq.outbound;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.connector.rabbitmq.outbound.model.RabbitMqMessage;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -57,5 +58,16 @@ class RabbitMqMessageTest {
     final byte[] bodyAsByteArray = MessageUtil.getBodyAsByteArray(rabbitMqMessage.body());
     // then
     assertThat(new String(bodyAsByteArray)).isEqualTo(msgWithDigital);
+  }
+
+  @Test
+  public void getBodyAsByteArray_shouldNotEscapeCharWhenObject() {
+    // Given
+    final Map<String, String> msgWithDigital = Map.of("key", "\"simple\" value");
+    final RabbitMqMessage rabbitMqMessage = new RabbitMqMessage(null, msgWithDigital);
+    // when
+    final byte[] bodyAsByteArray = MessageUtil.getBodyAsByteArray(rabbitMqMessage.body());
+    // then
+    assertThat(new String(bodyAsByteArray)).contains("\\\"");
   }
 }

--- a/connectors/slack/src/main/java/io/camunda/connector/slack/outbound/model/ChatPostMessageData.java
+++ b/connectors/slack/src/main/java/io/camunda/connector/slack/outbound/model/ChatPostMessageData.java
@@ -24,7 +24,6 @@ import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.NotBlank;
 import java.io.IOException;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.text.StringEscapeUtils;
 
 @TemplateSubType(id = "chat.postMessage", label = "Post message")
 public record ChatPostMessageData(
@@ -103,8 +102,7 @@ public record ChatPostMessageData(
 
     // Note: both text and block content can co-exist
     if (StringUtils.isNotBlank(text)) {
-      // Temporary workaround related to camunda/zeebe#9859
-      requestBuilder.text(StringEscapeUtils.unescapeJson(text));
+      requestBuilder.text(text);
       // Enables plain text message formatting
       requestBuilder.linkNames(true);
     }


### PR DESCRIPTION
## Description

When passing a JSON object as body for the rabbitMQ outbound connector, it is converted either to a `Map` or a `String`. 

When a `Map` was wrote as a Json, it was then unescaped.
This PR removes this feature.

We have to be sure it does not cause any weird side effect to remove this feature

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes https://github.com/camunda/connectors/issues/2730

