### PR TITLE
ci(release): call Helm integration test

### DIFF
--- a/.github/workflows/RELEASE.yaml
+++ b/.github/workflows/RELEASE.yaml
@@ -9,6 +9,8 @@ jobs:
   build-and-push:
     name: Build and push Docker images
     runs-on: ubuntu-latest
+    outputs:
+      releaseBranch: ${{ steps.determine_release_branch.outputs.releaseBranch }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -264,3 +266,12 @@ jobs:
             bundle/default-bundle/target/connectors-bundle-sbom.xml
             connectors-bundle-templates-${{ github.event.release.tag_name }}.tar.gz
             connectors-bundle-templates-${{ github.event.release.tag_name }}.zip
+
+  helm-deploy:
+    needs: build-and-push
+    name: Run Helm Integration Tests
+    uses: ./.github/workflows/INTEGRATION_TEST.yml
+    secrets: inherit
+    with:
+      connectors-version: ${{ github.event.release.tag_name }}
+      release-branch: ${{ needs.build-and-push.outputs.releaseBranch }}


### PR DESCRIPTION
## Description

Backport release workflow changes

Previously, I thought the release workflow was always run from the release workflow on `main`.

However, it's now clear after the first July 2024 patches that we need to backport this call into each release branch.

## Related issues

https://github.com/camunda/team-connectors/issues/764