### PR TITLE
Kafka connector loop retry

### DIFF
--- a/connectors/kafka/pom.xml
+++ b/connectors/kafka/pom.xml
@@ -63,9 +63,15 @@ except in compliance with the proprietary license.</license.inlineheader>
     </dependency>
 
     <dependency>
+      <groupId>io.github.resilience4j</groupId>
+      <artifactId>resilience4j-retry</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>kafka</artifactId>
       <version>${version.testcontainers}</version>
+      <scope>test</scope>
     </dependency>
 
     <dependency>

--- a/connectors/kafka/pom.xml
+++ b/connectors/kafka/pom.xml
@@ -63,8 +63,8 @@ except in compliance with the proprietary license.</license.inlineheader>
     </dependency>
 
     <dependency>
-      <groupId>io.github.resilience4j</groupId>
-      <artifactId>resilience4j-retry</artifactId>
+      <groupId>dev.failsafe</groupId>
+      <artifactId>failsafe</artifactId>
     </dependency>
 
     <dependency>

--- a/connectors/kafka/src/main/java/io/camunda/connector/kafka/inbound/KafkaExecutable.java
+++ b/connectors/kafka/src/main/java/io/camunda/connector/kafka/inbound/KafkaExecutable.java
@@ -77,7 +77,11 @@ public class KafkaExecutable implements InboundConnectorExecutable<InboundConnec
   public KafkaExecutable() {
     this(
         KafkaConsumer::new,
-        RetryPolicy.builder().handle(Exception.class).withDelay(Duration.ofSeconds(30)).build());
+        RetryPolicy.builder()
+            .handle(Exception.class)
+            .withDelay(Duration.ofSeconds(30))
+            .withMaxAttempts(-1)
+            .build());
   }
 
   @Override

--- a/connectors/kafka/src/main/java/io/camunda/connector/kafka/inbound/KafkaExecutable.java
+++ b/connectors/kafka/src/main/java/io/camunda/connector/kafka/inbound/KafkaExecutable.java
@@ -74,13 +74,15 @@ public class KafkaExecutable implements InboundConnectorExecutable<InboundConnec
     this.retryPolicy = retryConfig;
   }
 
+  private static final int INFINITE_RETRIES = -1;
+
   public KafkaExecutable() {
     this(
         KafkaConsumer::new,
         RetryPolicy.builder()
             .handle(Exception.class)
             .withDelay(Duration.ofSeconds(30))
-            .withMaxAttempts(-1)
+            .withMaxAttempts(INFINITE_RETRIES)
             .build());
   }
 

--- a/connectors/kafka/src/test/java/io/camunda/connector/kafka/inbound/KafkaExecutableTest.java
+++ b/connectors/kafka/src/test/java/io/camunda/connector/kafka/inbound/KafkaExecutableTest.java
@@ -273,7 +273,7 @@ public class KafkaExecutableTest {
   public KafkaExecutable getConsumerMock() {
     return new KafkaExecutable(
         properties -> mockConsumer,
-        RetryConfig.custom().waitDuration(Duration.ofSeconds(1)).maxAttempts(MAX_ATTEMPTS).build());
+        RetryConfig.custom().waitDuration(Duration.ofMillis(500)).maxAttempts(MAX_ATTEMPTS).build());
   }
 
   @ParameterizedTest

--- a/connectors/kafka/src/test/java/io/camunda/connector/kafka/inbound/KafkaExecutableTest.java
+++ b/connectors/kafka/src/test/java/io/camunda/connector/kafka/inbound/KafkaExecutableTest.java
@@ -52,7 +52,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
@@ -63,15 +62,14 @@ public class KafkaExecutableTest {
   private List<PartitionInfo> topicPartitions;
   private KafkaConnectorProperties kafkaConnectorProperties;
   private KafkaTopic kafkaTopic;
-  @Mock private KafkaConsumer<Object, Object> mockConsumer;
+  private KafkaConsumer<Object, Object> mockConsumer;
 
   private String topic;
-
-  private final String processId = "Process_id";
 
   private static final int MAX_ATTEMPTS = 3;
 
   @BeforeEach
+  @SuppressWarnings("unchecked")
   public void setUp() {
     topic = "my-topic";
     topicPartitions =
@@ -100,6 +98,7 @@ public class KafkaExecutableTest {
             .validation(new DefaultValidationProvider())
             .build();
     originalContext = context;
+    mockConsumer = mock(KafkaConsumer.class);
   }
 
   @Test

--- a/connectors/kafka/src/test/java/io/camunda/connector/kafka/inbound/KafkaExecutableTest.java
+++ b/connectors/kafka/src/test/java/io/camunda/connector/kafka/inbound/KafkaExecutableTest.java
@@ -273,7 +273,10 @@ public class KafkaExecutableTest {
   public KafkaExecutable getConsumerMock() {
     return new KafkaExecutable(
         properties -> mockConsumer,
-        RetryConfig.custom().waitDuration(Duration.ofMillis(500)).maxAttempts(MAX_ATTEMPTS).build());
+        RetryConfig.custom()
+            .waitDuration(Duration.ofMillis(500))
+            .maxAttempts(MAX_ATTEMPTS)
+            .build());
   }
 
   @ParameterizedTest

--- a/connectors/kafka/src/test/java/io/camunda/connector/kafka/inbound/KafkaExecutableTest.java
+++ b/connectors/kafka/src/test/java/io/camunda/connector/kafka/inbound/KafkaExecutableTest.java
@@ -169,7 +169,8 @@ public class KafkaExecutableTest {
     when(mockConsumer.poll(any())).thenThrow(new RuntimeException("Test exception"));
     await()
         .atMost(Duration.ofSeconds(5))
-        .until(() -> !kafkaExecutable.kafkaConnectorConsumer.shouldLoop);
+        .pollInterval(Duration.ofMillis(500))
+        .untilAsserted(() -> assertFalse(kafkaExecutable.kafkaConnectorConsumer.shouldLoop));
     kafkaExecutable.deactivate();
 
     // Then

--- a/connectors/kafka/src/test/java/io/camunda/connector/kafka/inbound/KafkaExecutableTest.java
+++ b/connectors/kafka/src/test/java/io/camunda/connector/kafka/inbound/KafkaExecutableTest.java
@@ -275,7 +275,7 @@ public class KafkaExecutableTest {
         properties -> mockConsumer,
         RetryPolicy.builder()
             .handle(Exception.class)
-            .withDelay(Duration.ofMillis(500))
+            .withDelay(Duration.ofMillis(50))
             .withMaxAttempts(MAX_ATTEMPTS)
             .build());
   }

--- a/connectors/kafka/src/test/java/io/camunda/connector/kafka/inbound/KafkaExecutableTest.java
+++ b/connectors/kafka/src/test/java/io/camunda/connector/kafka/inbound/KafkaExecutableTest.java
@@ -15,7 +15,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;

--- a/connectors/kafka/src/test/java/io/camunda/connector/kafka/inbound/KafkaExecutableTest.java
+++ b/connectors/kafka/src/test/java/io/camunda/connector/kafka/inbound/KafkaExecutableTest.java
@@ -24,13 +24,13 @@ import static org.testcontainers.shaded.org.awaitility.Awaitility.await;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import dev.failsafe.RetryPolicy;
 import io.camunda.connector.kafka.model.KafkaAuthentication;
 import io.camunda.connector.kafka.model.KafkaTopic;
 import io.camunda.connector.kafka.model.SerializationType;
 import io.camunda.connector.test.inbound.InboundConnectorContextBuilder;
 import io.camunda.connector.test.inbound.InboundConnectorDefinitionBuilder;
 import io.camunda.connector.validation.impl.DefaultValidationProvider;
-import io.github.resilience4j.retry.RetryConfig;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -273,9 +273,10 @@ public class KafkaExecutableTest {
   public KafkaExecutable getConsumerMock() {
     return new KafkaExecutable(
         properties -> mockConsumer,
-        RetryConfig.custom()
-            .waitDuration(Duration.ofMillis(500))
-            .maxAttempts(MAX_ATTEMPTS)
+        RetryPolicy.builder()
+            .handle(Exception.class)
+            .withDelay(Duration.ofMillis(500))
+            .withMaxAttempts(MAX_ATTEMPTS)
             .build());
   }
 

--- a/connectors/kafka/src/test/java/io/camunda/connector/kafka/inbound/KafkaExecutableTest.java
+++ b/connectors/kafka/src/test/java/io/camunda/connector/kafka/inbound/KafkaExecutableTest.java
@@ -15,6 +15,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -166,7 +167,7 @@ public class KafkaExecutableTest {
 
     // When
     kafkaExecutable.activate(context);
-    when(mockConsumer.poll(any())).thenThrow(new RuntimeException("Test exception"));
+    doThrow(new RuntimeException("Test exception")).when(mockConsumer).poll(any());
     await()
         .atMost(Duration.ofSeconds(5))
         .pollInterval(Duration.ofMillis(500))

--- a/connectors/kafka/src/test/java/io/camunda/connector/kafka/inbound/KafkaExecutableTest.java
+++ b/connectors/kafka/src/test/java/io/camunda/connector/kafka/inbound/KafkaExecutableTest.java
@@ -166,8 +166,8 @@ public class KafkaExecutableTest {
     when(mockConsumer.groupMetadata()).thenReturn(groupMetadataMock);
 
     // When
+    when(mockConsumer.poll(any())).thenThrow(new RuntimeException("Test exception"));
     kafkaExecutable.activate(context);
-    doThrow(new RuntimeException("Test exception")).when(mockConsumer).poll(any());
     await()
         .atMost(Duration.ofSeconds(5))
         .pollInterval(Duration.ofMillis(500))
@@ -175,7 +175,7 @@ public class KafkaExecutableTest {
     kafkaExecutable.deactivate();
 
     // Then
-    verify(mockConsumer, times(MAX_ATTEMPTS)).poll(any());
+    verify(mockConsumer, times(MAX_ATTEMPTS)).poll(any(Duration.class));
   }
 
   @Test

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -85,7 +85,7 @@ limitations under the License.</license.inlineheader>
     <version.jackson-datatype-jsr310>2.17.1</version.jackson-datatype-jsr310>
     <version.hibernate-validator>8.0.1.Final</version.hibernate-validator>
     <version.jsonassert>1.5.1</version.jsonassert>
-    <version.resilience4j>2.2.0</version.resilience4j>
+    <version.failsafe>3.3.2</version.failsafe>
 
     <version.spring-boot>3.3.0</version.spring-boot>
     <version.spring-cloud-gcp-starter-logging>5.4.1</version.spring-cloud-gcp-starter-logging>
@@ -492,9 +492,9 @@ limitations under the License.</license.inlineheader>
       </dependency>
 
       <dependency>
-        <groupId>io.github.resilience4j</groupId>
-        <artifactId>resilience4j-retry</artifactId>
-        <version>${version.resilience4j}</version>
+        <groupId>dev.failsafe</groupId>
+        <artifactId>failsafe</artifactId>
+        <version>${version.failsafe}</version>
       </dependency>
 
       <!-- test dependencies -->

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -85,6 +85,7 @@ limitations under the License.</license.inlineheader>
     <version.jackson-datatype-jsr310>2.17.1</version.jackson-datatype-jsr310>
     <version.hibernate-validator>8.0.1.Final</version.hibernate-validator>
     <version.jsonassert>1.5.1</version.jsonassert>
+    <version.resilience4j>2.2.0</version.resilience4j>
 
     <version.spring-boot>3.3.0</version.spring-boot>
     <version.spring-cloud-gcp-starter-logging>5.4.1</version.spring-cloud-gcp-starter-logging>
@@ -488,6 +489,12 @@ limitations under the License.</license.inlineheader>
         <groupId>org.bouncycastle</groupId>
         <artifactId>bcprov-jdk18on</artifactId>
         <version>${version.bouncycastle}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>io.github.resilience4j</groupId>
+        <artifactId>resilience4j-retry</artifactId>
+        <version>${version.resilience4j}</version>
       </dependency>
 
       <!-- test dependencies -->


### PR DESCRIPTION
## Description

Adds retries to the Kafka connector consumer loop.

Previously, when the consumer threw an exception, it just stopped processing until the process is redeployed. The new default is to retry this as long as the connector is active, with a backoff of 30 seconds.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #2750 

