### PR TITLE
fix(rest): Fix NPE with readTimeoutInSeconds + Duplicate headers

### DIFF
--- a/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/client/apache/CustomApacheHttpClient.java
+++ b/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/client/apache/CustomApacheHttpClient.java
@@ -26,7 +26,6 @@ import io.camunda.connector.http.base.model.HttpCommonRequest;
 import io.camunda.connector.http.base.model.HttpCommonResult;
 import java.io.IOException;
 import java.net.URISyntaxException;
-import java.util.Optional;
 import org.apache.hc.client5.http.ClientProtocolException;
 import org.apache.hc.client5.http.config.RequestConfig;
 import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
@@ -144,15 +143,9 @@ public class CustomApacheHttpClient implements HttpClient {
   }
 
   private RequestConfig getRequestConfig(HttpCommonRequest request) {
-    var connectionTimeout =
-        Optional.ofNullable(request.getConnectionTimeoutInSeconds())
-            .map(Timeout::ofSeconds)
-            .orElse(null);
-    var readTimeout =
-        Optional.ofNullable(request.getReadTimeoutInSeconds()).map(Timeout::ofSeconds).orElse(null);
     return RequestConfig.custom()
-        .setConnectionRequestTimeout(connectionTimeout)
-        .setResponseTimeout(readTimeout)
+        .setConnectionRequestTimeout(Timeout.ofSeconds(request.getConnectionTimeoutInSeconds()))
+        .setResponseTimeout(Timeout.ofSeconds(request.getReadTimeoutInSeconds()))
         .build();
   }
 }

--- a/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/client/apache/CustomApacheHttpClient.java
+++ b/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/client/apache/CustomApacheHttpClient.java
@@ -26,6 +26,7 @@ import io.camunda.connector.http.base.model.HttpCommonRequest;
 import io.camunda.connector.http.base.model.HttpCommonResult;
 import java.io.IOException;
 import java.net.URISyntaxException;
+import java.util.Optional;
 import org.apache.hc.client5.http.ClientProtocolException;
 import org.apache.hc.client5.http.config.RequestConfig;
 import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
@@ -143,9 +144,15 @@ public class CustomApacheHttpClient implements HttpClient {
   }
 
   private RequestConfig getRequestConfig(HttpCommonRequest request) {
+    var connectionTimeout =
+        Optional.ofNullable(request.getConnectionTimeoutInSeconds())
+            .map(Timeout::ofSeconds)
+            .orElse(null);
+    var readTimeout =
+        Optional.ofNullable(request.getReadTimeoutInSeconds()).map(Timeout::ofSeconds).orElse(null);
     return RequestConfig.custom()
-        .setConnectionRequestTimeout(Timeout.ofSeconds(request.getConnectionTimeoutInSeconds()))
-        .setResponseTimeout(Timeout.ofSeconds(request.getReadTimeoutInSeconds()))
+        .setConnectionRequestTimeout(connectionTimeout)
+        .setResponseTimeout(readTimeout)
         .build();
   }
 }

--- a/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/client/apache/HttpCommonResultResponseHandler.java
+++ b/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/client/apache/HttpCommonResultResponseHandler.java
@@ -52,7 +52,9 @@ public class HttpCommonResultResponseHandler
     String reason = response.getReasonPhrase();
     Map<String, Object> headers =
         Arrays.stream(response.getHeaders())
-            .collect(Collectors.toMap(Header::getName, Header::getValue));
+            .collect(
+                // Collect the headers into a map ignoring duplicates (Set Cookies for instance)
+                Collectors.toMap(Header::getName, Header::getValue, (first, second) -> first));
     if (response.getEntity() != null) {
       try (InputStream content = response.getEntity().getContent()) {
         if (cloudFunctionEnabled) {

--- a/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/model/HttpCommonRequest.java
+++ b/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/model/HttpCommonRequest.java
@@ -28,8 +28,10 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 
 public class HttpCommonRequest {
+  private static final int DEFAULT_TIMEOUT = 20;
 
   @FEEL
   @NotNull
@@ -162,7 +164,7 @@ public class HttpCommonRequest {
   }
 
   public Integer getConnectionTimeoutInSeconds() {
-    return connectionTimeoutInSeconds;
+    return Optional.ofNullable(connectionTimeoutInSeconds).orElse(DEFAULT_TIMEOUT);
   }
 
   public void setConnectionTimeoutInSeconds(Integer connectionTimeoutInSeconds) {
@@ -170,7 +172,7 @@ public class HttpCommonRequest {
   }
 
   public Integer getReadTimeoutInSeconds() {
-    return readTimeoutInSeconds;
+    return Optional.ofNullable(readTimeoutInSeconds).orElse(DEFAULT_TIMEOUT);
   }
 
   public void setReadTimeoutInSeconds(final Integer readTimeoutInSeconds) {

--- a/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/model/HttpCommonRequest.java
+++ b/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/model/HttpCommonRequest.java
@@ -31,6 +31,8 @@ import java.util.Objects;
 import java.util.Optional;
 
 public class HttpCommonRequest {
+
+  @TemplateProperty(ignore = true)
   private static final int DEFAULT_TIMEOUT = 20;
 
   @FEEL

--- a/connectors/http/http-base/src/test/java/io/camunda/connector/http/base/HttpServiceTest.java
+++ b/connectors/http/http-base/src/test/java/io/camunda/connector/http/base/HttpServiceTest.java
@@ -100,7 +100,9 @@ public class HttpServiceTest {
     stubFor(
         post("/path")
             .willReturn(
-                ok().withJsonBody(
+                ok().withHeader("Set-Cookie", "key=value")
+                    .withHeader("Set-Cookie", "key2=value2")
+                    .withJsonBody(
                         JsonNodeFactory.instance
                             .objectNode()
                             .put("responseKey1", "value1")
@@ -120,6 +122,8 @@ public class HttpServiceTest {
     // then
     assertThat(result).isNotNull();
     assertThat(result.status()).isEqualTo(200);
+    assertThat(result.headers()).contains(Map.entry("Set-Cookie", "key=value"));
+    assertThat(result.headers()).doesNotContain(Map.entry("Set-Cookie", "key2=value2"));
     JSONAssert.assertEquals(
         "{\"responseKey1\":\"value1\",\"responseKey2\":40,\"responseKey3\":null}",
         objectMapper.writeValueAsString(result.body()),

--- a/connectors/http/http-base/src/test/java/io/camunda/connector/http/base/client/apache/CustomApacheHttpClientTest.java
+++ b/connectors/http/http-base/src/test/java/io/camunda/connector/http/base/client/apache/CustomApacheHttpClientTest.java
@@ -201,6 +201,19 @@ public class CustomApacheHttpClientTest {
   class GetTests {
 
     @Test
+    public void shouldReturn200_whenNoTimeouts(WireMockRuntimeInfo wmRuntimeInfo) {
+      stubFor(get("/path").willReturn(ok()));
+      HttpCommonRequest request = new HttpCommonRequest();
+      request.setMethod(HttpMethod.GET);
+      request.setConnectionTimeoutInSeconds(null);
+      request.setReadTimeoutInSeconds(null);
+      request.setUrl(getHostAndPort(wmRuntimeInfo) + "/path");
+      HttpCommonResult result = customApacheHttpClient.execute(request);
+      assertThat(result).isNotNull();
+      assertThat(result.status()).isEqualTo(200);
+    }
+
+    @Test
     public void shouldReturn200WithoutBody_whenEmptyGet(WireMockRuntimeInfo wmRuntimeInfo)
         throws Exception {
       stubFor(get("/path").willReturn(ok()));


### PR DESCRIPTION
## Description

- Fix NPE with `readTimeoutInSeconds`
- Fix issue when we have multiple headers with the same name (Set Cookie for instance) => we'll keep only the first occurence.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes https://github.com/camunda/team-connectors/issues/820

