### PR TITLE
feature-1047 create new feature: make the row index optional, if not …

### DIFF
--- a/bundle/default-bundle/src/test/resources/application.properties
+++ b/bundle/default-bundle/src/test/resources/application.properties
@@ -12,15 +12,15 @@ camunda.client.zeebe.defaults.max-jobs-active=32
 camunda.client.zeebe.defaults.worker-threads=10
 
 # Config for use with docker-compose.yml
-camunda.client.mode=oidc
-camunda.client.auth.client-id=connectors
-camunda.client.auth.client-secret=XALaRPl5qwTEItdwCMiPS62nVpKs7dL7
-camunda.client.auth.oidc-type=keycloak
-camunda.client.auth.issuer=http://localhost:18080/auth/realms/camunda-platform
-camunda.client.identity.audience=connectors
-camunda.client.identity.base-url=http://localhost:8084
+#camunda.client.mode=oidc
+#camunda.client.auth.client-id=connectors
+#camunda.client.auth.client-secret=XALaRPl5qwTEItdwCMiPS62nVpKs7dL7
+#camunda.client.auth.oidc-type=keycloak
+#camunda.client.auth.issuer=http://localhost:18080/auth/realms/camunda-platform
+#camunda.client.identity.audience=connectors
+#camunda.client.identity.base-url=http://localhost:8084
 
 # Config for use with docker-compose-core.yml
-#camunda.client.mode=simple
-#camunda.client.auth.username=demo
-#camunda.client.auth.password=demo
+camunda.client.mode=simple
+camunda.client.auth.username=demo
+camunda.client.auth.password=demo

--- a/bundle/default-bundle/src/test/resources/application.properties
+++ b/bundle/default-bundle/src/test/resources/application.properties
@@ -12,15 +12,15 @@ camunda.client.zeebe.defaults.max-jobs-active=32
 camunda.client.zeebe.defaults.worker-threads=10
 
 # Config for use with docker-compose.yml
-#camunda.client.mode=oidc
-#camunda.client.auth.client-id=connectors
-#camunda.client.auth.client-secret=XALaRPl5qwTEItdwCMiPS62nVpKs7dL7
-#camunda.client.auth.oidc-type=keycloak
-#camunda.client.auth.issuer=http://localhost:18080/auth/realms/camunda-platform
-#camunda.client.identity.audience=connectors
-#camunda.client.identity.base-url=http://localhost:8084
+camunda.client.mode=oidc
+camunda.client.auth.client-id=connectors
+camunda.client.auth.client-secret=XALaRPl5qwTEItdwCMiPS62nVpKs7dL7
+camunda.client.auth.oidc-type=keycloak
+camunda.client.auth.issuer=http://localhost:18080/auth/realms/camunda-platform
+camunda.client.identity.audience=connectors
+camunda.client.identity.base-url=http://localhost:8084
 
 # Config for use with docker-compose-core.yml
-camunda.client.mode=simple
-camunda.client.auth.username=demo
-camunda.client.auth.password=demo
+#camunda.client.mode=simple
+#camunda.client.auth.username=demo
+#camunda.client.auth.password=demo

--- a/connectors/google/google-sheets/element-templates/google-sheets-outbound-connector.json
+++ b/connectors/google/google-sheets/element-templates/google-sheets-outbound-connector.json
@@ -442,10 +442,7 @@
     "id" : "createRow.rowIndex",
     "label" : "Row index",
     "description" : "Enter row index. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#what-is-a-row-index\" target=\"_blank\">documentation</a>",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
+    "optional" : true,
     "feel" : "optional",
     "group" : "operationDetails",
     "binding" : {

--- a/connectors/google/google-sheets/element-templates/hybrid/google-sheets-outbound-connector-hybrid.json
+++ b/connectors/google/google-sheets/element-templates/hybrid/google-sheets-outbound-connector-hybrid.json
@@ -447,10 +447,7 @@
     "id" : "createRow.rowIndex",
     "label" : "Row index",
     "description" : "Enter row index. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#what-is-a-row-index\" target=\"_blank\">documentation</a>",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
+    "optional" : true,
     "feel" : "optional",
     "group" : "operationDetails",
     "binding" : {

--- a/connectors/google/google-sheets/src/main/java/io/camunda/connector/gsheets/model/request/input/CreateRow.java
+++ b/connectors/google/google-sheets/src/main/java/io/camunda/connector/gsheets/model/request/input/CreateRow.java
@@ -13,7 +13,6 @@ import io.camunda.connector.generator.java.annotation.TemplateProperty.PropertyC
 import io.camunda.connector.generator.java.annotation.TemplateSubType;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
-import jakarta.validation.constraints.NotNull;
 import java.util.List;
 
 @TemplateSubType(id = "createRow", label = "Create row")
@@ -43,9 +42,8 @@ public record CreateRow(
                 "Enter row index. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#what-is-a-row-index\" target=\"_blank\">documentation</a>",
             group = "operationDetails",
             feel = FeelMode.optional,
-            constraints = @PropertyConstraints(notEmpty = true),
+            optional = true,
             binding = @PropertyBinding(name = "operation.rowIndex"))
-        @NotNull
         Integer rowIndex,
     @TemplateProperty(
             label = "Enter values",

--- a/connectors/google/google-sheets/src/main/java/io/camunda/connector/gsheets/operation/GoogleSheetOperation.java
+++ b/connectors/google/google-sheets/src/main/java/io/camunda/connector/gsheets/operation/GoogleSheetOperation.java
@@ -50,6 +50,22 @@ public abstract class GoogleSheetOperation {
         .execute();
   }
 
+  protected final void append(
+      final Authentication auth,
+      final String spreadsheetId,
+      final String range,
+      final ValueRange valueRange)
+      throws IOException {
+    Sheets service = GoogleSheetsServiceSupplier.getGoogleSheetsService(auth);
+
+    service
+        .spreadsheets()
+        .values()
+        .append(spreadsheetId, range, valueRange)
+        .setValueInputOption(VALUE_INPUT_OPTION)
+        .execute();
+  }
+
   protected final List<List<Object>> get(
       final Authentication auth, final String spreadsheetId, final String range)
       throws IOException {

--- a/connectors/google/google-sheets/src/main/java/io/camunda/connector/gsheets/operation/impl/CreateRowOperation.java
+++ b/connectors/google/google-sheets/src/main/java/io/camunda/connector/gsheets/operation/impl/CreateRowOperation.java
@@ -13,6 +13,7 @@ import io.camunda.connector.gsheets.operation.GoogleSheetOperation;
 import io.camunda.google.model.Authentication;
 import java.io.IOException;
 import java.util.List;
+import java.util.Objects;
 
 public class CreateRowOperation extends GoogleSheetOperation {
 
@@ -25,11 +26,15 @@ public class CreateRowOperation extends GoogleSheetOperation {
   @Override
   public Object execute(Authentication auth) {
     ValueRange valueRange = new ValueRange().setValues(List.of(model.values()));
-    String range = buildRange(model.worksheetName(), buildRowRange(model.rowIndex()));
 
     try {
-      this.update(auth, model.spreadsheetId(), range, valueRange);
-
+      if (Objects.isNull(model.rowIndex())) {
+        String range = buildRange(model.worksheetName(), "1:" + Integer.MAX_VALUE);
+        this.append(auth, model.spreadsheetId(), model.worksheetName(), valueRange);
+      } else {
+        String range = buildRange(model.worksheetName(), buildRowRange(model.rowIndex()));
+        this.update(auth, model.spreadsheetId(), range, valueRange);
+      }
       return new GoogleSheetsResult("Create row", "OK");
     } catch (IOException e) {
       throw new RuntimeException(e);

--- a/connectors/google/google-sheets/src/main/java/io/camunda/connector/gsheets/operation/impl/CreateRowOperation.java
+++ b/connectors/google/google-sheets/src/main/java/io/camunda/connector/gsheets/operation/impl/CreateRowOperation.java
@@ -29,7 +29,6 @@ public class CreateRowOperation extends GoogleSheetOperation {
 
     try {
       if (Objects.isNull(model.rowIndex())) {
-        String range = buildRange(model.worksheetName(), "1:" + Integer.MAX_VALUE);
         this.append(auth, model.spreadsheetId(), model.worksheetName(), valueRange);
       } else {
         String range = buildRange(model.worksheetName(), buildRowRange(model.rowIndex()));

--- a/connectors/google/google-sheets/src/test/resources/requests/request-fail-test-cases.json
+++ b/connectors/google/google-sheets/src/test/resources/requests/request-fail-test-cases.json
@@ -202,19 +202,6 @@
     }
   },
   {
-    "testDescription": "Create row without row index",
-    "authentication": {
-      "authType": "bearer",
-      "bearerToken": "MyRealToken"
-    },
-    "operation": {
-      "values": [1],
-      "spreadsheetId": "id",
-      "worksheetName": "name",
-      "type": "createRow"
-    }
-  },
-  {
     "testDescription": "Create row without row values",
     "authentication": {
       "authType": "bearer",

--- a/connectors/google/google-sheets/src/test/resources/requests/request-success-test-cases.json
+++ b/connectors/google/google-sheets/src/test/resources/requests/request-success-test-cases.json
@@ -143,6 +143,19 @@
     }
   },
   {
+    "testDescription": "Create row without row index",
+    "authentication": {
+      "authType": "bearer",
+      "bearerToken": "MyRealToken"
+    },
+    "operation": {
+      "values": ["{{secrets.ROW}}"],
+      "spreadsheetId": "id",
+      "worksheetName": "worksheet",
+      "type": "createRow"
+    }
+  },
+  {
     "testDescription": "Delete column by index as number",
     "authentication": {
       "authType": "bearer",


### PR DESCRIPTION
…specified will just append to the next row

## Description

<!-- Please explain the changes you made here. -->

Add a feature:

The row index field is now optional
  - if defined, it will add the row to the specified row index
  - if not defined, it will append to the last row

<!-- Which issues are closed by this PR or are related -->

closes https://github.com/camunda/connectors/issues/1047

