### PR TITLE
chore(preview-env): add dockerhub pull secret

### DIFF
--- a/.ci/preview-environments/charts/c8sm/templates/secrets.yml
+++ b/.ci/preview-environments/charts/c8sm/templates/secrets.yml
@@ -1,4 +1,26 @@
 ---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: dockerhub-registry
+  labels:
+    {{- include "commonLabels" $ | nindent 4 }}
+  annotations:
+    {{- include "commonAnnotations" $ | nindent 4 }}
+    replicator.v1.mittwald.de/replicate-from: connectors/dockerhub-registry
+    # The following overwrites an "internal" annotation (one that the user
+    # should not interfere with as it is not documented in the README at
+    # https://github.com/mittwald/kubernetes-replicator/). We do this anyways to
+    # force replicator-tool to replicate the contents of this secret again.
+    # This is necessary as we have to set empty default data fields to create a
+    # valid `type: kubernetes.io/tls` secret but this will purge the previously
+    # replicated contents.
+    replicator.v1.mittwald.de/replicated-from-version: "0"
+type: kubernetes.io/dockerconfigjson
+data:
+  # Set to an empty JSON to comply with kubernetes.io/dockerconfigjson requirements
+  .dockerconfigjson: "e30="
+---
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:

--- a/.ci/preview-environments/charts/c8sm/values.yaml
+++ b/.ci/preview-environments/charts/c8sm/values.yaml
@@ -11,6 +11,14 @@ global:
     camunda.cloud/managed-by: Helm
     camunda.cloud/source: argocd
     team: connectors
+  
+  image:
+    pullSecrets:
+    - name: dockerhub-registry
+
+  # still required by some subcharts (e.g. elasticsearch)
+  imagePullSecrets:
+  - name: dockerhub-registry
 
   # Preview environment configurations
   preview:
@@ -72,6 +80,7 @@ camunda-platform:
       repository: team-connectors/connectors-bundle
       pullSecrets:
       - name: registry-camunda-cloud
+      - name: dockerhub-registry
     env:
     - name: JAVA_OPTS
       value: "-Xms512m -Xmx512m"
@@ -242,6 +251,7 @@ camunda-platform:
     contextPath: /modeler
     image:
       pullSecrets:
+      - name: dockerhub-registry
       - name: registry-camunda-cloud
       # tag: latest
     restapi:


### PR DESCRIPTION
## Description

Related to https://github.com/camunda/team-infrastructure/issues/575

This PR introduces  pull secrets (`imagePullSecrets`) with a dedicated DockerHub account (credentials from Camunda's paid subscription) to ensure not to be affected by DockerHub rate limit when pulling images from DockerHub for preview environments.