### PR TITLE
Fix read timeout with cloud function

### DIFF
--- a/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/cloudfunction/CloudFunctionService.java
+++ b/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/cloudfunction/CloudFunctionService.java
@@ -33,6 +33,7 @@ public class CloudFunctionService {
 
   private static final Logger LOG = LoggerFactory.getLogger(CloudFunctionService.class);
   private static final String PROXY_FUNCTION_URL_ENV_NAME = "CAMUNDA_CONNECTOR_HTTP_PROXY_URL";
+  private static final int NO_TIMEOUT = 0;
   private final String proxyFunctionUrl = System.getenv(PROXY_FUNCTION_URL_ENV_NAME);
   private final CloudFunctionCredentials credentials;
 
@@ -107,7 +108,7 @@ public class CloudFunctionService {
     cloudFunctionRequest.setMethod(HttpMethod.POST);
     cloudFunctionRequest.setUrl(getProxyFunctionUrl());
     cloudFunctionRequest.setBody(contentAsJson);
-    cloudFunctionRequest.setReadTimeoutInSeconds(0);
+    cloudFunctionRequest.setReadTimeoutInSeconds(NO_TIMEOUT);
     cloudFunctionRequest.setHeaders(
         Map.of(HttpHeaders.CONTENT_TYPE, ContentType.APPLICATION_JSON.getMimeType()));
     cloudFunctionRequest.setAuthentication(new BearerAuthentication(token));

--- a/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/cloudfunction/CloudFunctionService.java
+++ b/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/cloudfunction/CloudFunctionService.java
@@ -58,9 +58,7 @@ public class CloudFunctionService {
       String contentAsJson =
           ConnectorsObjectMapperSupplier.DEFAULT_MAPPER.writeValueAsString(request);
       String token = credentials.getOAuthToken(getProxyFunctionUrl());
-      HttpCommonRequest cloudFunctionRequest = createCloudFunctionRequest(contentAsJson, token);
-      copyTimeouts(request, cloudFunctionRequest);
-      return cloudFunctionRequest;
+      return createCloudFunctionRequest(contentAsJson, token);
     } catch (IOException e) {
       LOG.error("Failed to serialize the request to JSON: {}", request, e);
       throw new ConnectorException("Failed to serialize the request to JSON: " + request, e);
@@ -70,11 +68,6 @@ public class CloudFunctionService {
       throw new ConnectorException(
           "Failure during OAuth authentication attempt for the Google cloud function");
     }
-  }
-
-  private void copyTimeouts(HttpCommonRequest request, HttpCommonRequest cloudFunctionRequest) {
-    cloudFunctionRequest.setConnectionTimeoutInSeconds(request.getConnectionTimeoutInSeconds());
-    cloudFunctionRequest.setReadTimeoutInSeconds(request.getReadTimeoutInSeconds());
   }
 
   /**


### PR DESCRIPTION
## Description

- When creating the Cloud Function request we didn't set any timeout, so we defaulted to HttpCommonRequest#DEFAULT_VALUE (20). We need to have an infinite timeout when calling the Cloud Function, as this is the function that will timeout.
