### PR TITLE
fix(security) any html content response from a webhook is now escaped…

### DIFF
--- a/connectors/webhook/pom.xml
+++ b/connectors/webhook/pom.xml
@@ -55,6 +55,11 @@
       <version>${version.jackson-bom}</version>
     </dependency>
     <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-text</artifactId>
+      <version>1.12.0</version>
+    </dependency>
+    <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
       <version>${version.guava}</version>

--- a/connectors/webhook/pom.xml
+++ b/connectors/webhook/pom.xml
@@ -55,11 +55,6 @@
       <version>${version.jackson-bom}</version>
     </dependency>
     <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-text</artifactId>
-      <version>1.12.0</version>
-    </dependency>
-    <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
       <version>${version.guava}</version>

--- a/connectors/webhook/src/main/java/io/camunda/connector/inbound/HttpWebhookExecutable.java
+++ b/connectors/webhook/src/main/java/io/camunda/connector/inbound/HttpWebhookExecutable.java
@@ -46,7 +46,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
 import java.util.regex.Pattern;
-
 import org.apache.commons.text.StringEscapeUtils;
 import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;

--- a/connectors/webhook/src/main/java/io/camunda/connector/inbound/HttpWebhookExecutable.java
+++ b/connectors/webhook/src/main/java/io/camunda/connector/inbound/HttpWebhookExecutable.java
@@ -45,8 +45,6 @@ import java.security.NoSuchAlgorithmException;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
-import java.util.regex.Pattern;
-import org.apache.commons.text.StringEscapeUtils;
 import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -150,7 +148,7 @@ public class HttpWebhookExecutable implements WebhookConnectorExecutable {
   private Function<WebhookResultContext, WebhookHttpResponse> mapResponseExpression() {
     Function<WebhookResultContext, WebhookHttpResponse> responseExpression = null;
     if (props.responseExpression() != null) {
-      responseExpression = props.responseExpression().andThen(this::sanitizeBody);
+      responseExpression = props.responseExpression();
     } else if (props.responseBodyExpression() != null) {
       // To be backwards compatible we need to wrap the responseBodyExpression into a
       // responseExpression
@@ -162,20 +160,6 @@ public class HttpWebhookExecutable implements WebhookConnectorExecutable {
           };
     }
     return responseExpression;
-  }
-
-  private WebhookHttpResponse sanitizeBody(WebhookHttpResponse webhookHttpResponse) {
-    if (webhookHttpResponse.body() instanceof String bodyStr
-        && Pattern.compile("<//?[a-z][\\s\\S]*>").matcher(bodyStr).find()) {
-      return new WebhookHttpResponse(
-          StringEscapeUtils.escapeHtml4(bodyStr),
-          webhookHttpResponse.headers(),
-          webhookHttpResponse.statusCode());
-    }
-    return new WebhookHttpResponse(
-        webhookHttpResponse.body(),
-        webhookHttpResponse.headers(),
-        webhookHttpResponse.statusCode());
   }
 
   private void verifySignature(WebhookProcessingPayload payload) {

--- a/connectors/webhook/src/test/java/io/camunda/connector/inbound/HttpWebhookExecutableTest.java
+++ b/connectors/webhook/src/test/java/io/camunda/connector/inbound/HttpWebhookExecutableTest.java
@@ -525,36 +525,4 @@ class HttpWebhookExecutableTest {
     assertThat(result.headers()).containsEntry("Content-Type", "application/camunda-bin");
     assertThat(result.headers()).hasSize(1);
   }
-
-  @Test
-  void triggerWebhook_JsonBodyWithHtmlResponseExpression() {
-    InboundConnectorContext ctx =
-        InboundConnectorContextBuilder.create()
-            .properties(
-                Map.of(
-                    "inbound",
-                    Map.of(
-                        "context",
-                        "webhookContext",
-                        "method",
-                        "any",
-                        "auth",
-                        Map.of("type", "NONE"),
-                        "responseExpression",
-                        "={\"body\" : \"<html></html>\" }")))
-            .build();
-
-    WebhookProcessingPayload payload = Mockito.mock(WebhookProcessingPayload.class);
-    Mockito.when(payload.method()).thenReturn(HttpMethods.any.name());
-    Mockito.when(payload.headers())
-        .thenReturn(Map.of(HttpHeaders.CONTENT_TYPE, MediaType.JSON_UTF_8.toString()));
-    Mockito.when(payload.rawBody()).thenReturn("{}".getBytes(StandardCharsets.UTF_8));
-
-    testObject.activate(ctx);
-    var result = testObject.triggerWebhook(payload);
-    WebhookHttpResponse webhookHttpResponse = result.response().apply(null);
-
-    assertNotNull(webhookHttpResponse);
-    assertEquals(webhookHttpResponse.body(), "&lt;html&gt;&lt;/html&gt;");
-  }
 }

--- a/connectors/webhook/src/test/java/io/camunda/connector/inbound/HttpWebhookExecutableTest.java
+++ b/connectors/webhook/src/test/java/io/camunda/connector/inbound/HttpWebhookExecutableTest.java
@@ -529,24 +529,26 @@ class HttpWebhookExecutableTest {
   @Test
   void triggerWebhook_JsonBodyWithHtmlResponseExpression() {
     InboundConnectorContext ctx =
-            InboundConnectorContextBuilder.create()
-                    .properties(
-                            Map.of(
-                                    "inbound",
-                                    Map.of(
-                                            "context", "webhookContext",
-                                            "method", "any",
-                                            "auth", Map.of("type", "NONE"),
-                                            "responseExpression",
-                                            "={\"body\" : \"<html></html>\" }")))
-                    .build();
+        InboundConnectorContextBuilder.create()
+            .properties(
+                Map.of(
+                    "inbound",
+                    Map.of(
+                        "context",
+                        "webhookContext",
+                        "method",
+                        "any",
+                        "auth",
+                        Map.of("type", "NONE"),
+                        "responseExpression",
+                        "={\"body\" : \"<html></html>\" }")))
+            .build();
 
     WebhookProcessingPayload payload = Mockito.mock(WebhookProcessingPayload.class);
     Mockito.when(payload.method()).thenReturn(HttpMethods.any.name());
     Mockito.when(payload.headers())
-            .thenReturn(Map.of(HttpHeaders.CONTENT_TYPE, MediaType.JSON_UTF_8.toString()));
-    Mockito.when(payload.rawBody())
-            .thenReturn("{}".getBytes(StandardCharsets.UTF_8));
+        .thenReturn(Map.of(HttpHeaders.CONTENT_TYPE, MediaType.JSON_UTF_8.toString()));
+    Mockito.when(payload.rawBody()).thenReturn("{}".getBytes(StandardCharsets.UTF_8));
 
     testObject.activate(ctx);
     var result = testObject.triggerWebhook(payload);


### PR DESCRIPTION
Any html content response from a webhook is now escaped and will not be interpreted by the browser

## Description

Another function is executed right after the execution of the FEEL function>

This function will check the response type and sanitize it if necessary.

## Related issues

closes https://github.com/camunda/team-connectors/issues/814

