### PR TITLE
fix(rest): Properly handle null Content-Type header

### DIFF
--- a/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/client/apache/builder/parts/ApacheRequestHeadersBuilder.java
+++ b/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/client/apache/builder/parts/ApacheRequestHeadersBuilder.java
@@ -31,6 +31,8 @@ public class ApacheRequestHeadersBuilder implements ApacheRequestPartBuilder {
 
   @Override
   public void build(ClassicRequestBuilder builder, HttpCommonRequest request) {
+    sanitizeContentType(request);
+
     var hasContentTypeHeader =
         Optional.ofNullable(request.getHeaders())
             .map(headers -> headers.containsKey(CONTENT_TYPE))
@@ -59,5 +61,12 @@ public class ApacheRequestHeadersBuilder implements ApacheRequestPartBuilder {
         e.getKey().equals(CONTENT_TYPE)
             && e.getValue().contains(MULTIPART_FORM_DATA.getMimeType())
             && !e.getValue().contains("boundary");
+  }
+
+  /** Remove the content type header if it is {@code null}. */
+  private void sanitizeContentType(HttpCommonRequest request) {
+    if (request.getHeaders() != null && request.getHeaders().get(CONTENT_TYPE) == null) {
+      request.getHeaders().remove(CONTENT_TYPE);
+    }
   }
 }

--- a/connectors/http/http-base/src/test/java/io/camunda/connector/http/base/HttpServiceTest.java
+++ b/connectors/http/http-base/src/test/java/io/camunda/connector/http/base/HttpServiceTest.java
@@ -234,6 +234,7 @@ public class HttpServiceTest {
     request.setBody(Map.of("name", "John", "age", 30, "message", "{\"key\":\"value\"}"));
     Map<String, String> headers = new HashMap<>();
     headers.put("Content-Type", null);
+    headers.put("Other", null);
     request.setHeaders(headers);
     request.setUrl(getHostAndPort(wmRuntimeInfo) + "/path");
 
@@ -250,6 +251,7 @@ public class HttpServiceTest {
     verify(
         postRequestedFor(urlEqualTo("/path"))
             .withHeader("Content-Type", equalTo("application/json"))
+            .withHeader("Other", equalTo(""))
             .withRequestBody(
                 matchingJsonPath("$.name", equalTo("John"))
                     .and(matchingJsonPath("$.message", equalTo("{\"key\":\"value\"}")))

--- a/connectors/http/http-base/src/test/java/io/camunda/connector/http/base/HttpServiceTest.java
+++ b/connectors/http/http-base/src/test/java/io/camunda/connector/http/base/HttpServiceTest.java
@@ -45,6 +45,7 @@ import io.camunda.connector.http.base.cloudfunction.CloudFunctionService;
 import io.camunda.connector.http.base.model.HttpCommonRequest;
 import io.camunda.connector.http.base.model.HttpCommonResult;
 import io.camunda.connector.http.base.model.HttpMethod;
+import java.util.HashMap;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -202,6 +203,57 @@ public class HttpServiceTest {
     assertThat(e).isNotNull();
     assertThat(e.getErrorCode()).isEqualTo("401");
     assertThat(e.getMessage()).isEqualTo("Unauthorized sorry!");
+    if (cloudFunctionEnabled) {
+      verify(
+          postRequestedFor(urlEqualTo("/proxy"))
+              .withRequestBody(equalTo(objectMapper.writeValueAsString(request))));
+    }
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  public void shouldReturn200WithBody_whenPostRequestWithNullContentType(
+      boolean cloudFunctionEnabled, WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
+    stubCloudFunction(wmRuntimeInfo);
+    HttpService httpService =
+        cloudFunctionEnabled ? HttpServiceTest.this.httpService : httpServiceWithoutCloudFunction;
+
+    stubFor(
+        post("/path")
+            .willReturn(
+                ok().withJsonBody(
+                        JsonNodeFactory.instance
+                            .objectNode()
+                            .put("responseKey1", "value1")
+                            .put("responseKey2", 40)
+                            .putNull("responseKey3"))));
+
+    // given
+    HttpCommonRequest request = new HttpCommonRequest();
+    request.setMethod(HttpMethod.POST);
+    request.setBody(Map.of("name", "John", "age", 30, "message", "{\"key\":\"value\"}"));
+    Map<String, String> headers = new HashMap<>();
+    headers.put("Content-Type", null);
+    request.setHeaders(headers);
+    request.setUrl(getHostAndPort(wmRuntimeInfo) + "/path");
+
+    // when
+    HttpCommonResult result = httpService.executeConnectorRequest(request);
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.status()).isEqualTo(200);
+    JSONAssert.assertEquals(
+        "{\"responseKey1\":\"value1\",\"responseKey2\":40,\"responseKey3\":null}",
+        objectMapper.writeValueAsString(result.body()),
+        JSONCompareMode.STRICT);
+    verify(
+        postRequestedFor(urlEqualTo("/path"))
+            .withHeader("Content-Type", equalTo("application/json"))
+            .withRequestBody(
+                matchingJsonPath("$.name", equalTo("John"))
+                    .and(matchingJsonPath("$.message", equalTo("{\"key\":\"value\"}")))
+                    .and(matchingJsonPath("$.age", equalTo("30")))));
     if (cloudFunctionEnabled) {
       verify(
           postRequestedFor(urlEqualTo("/proxy"))

--- a/connectors/http/http-base/src/test/java/io/camunda/connector/http/base/client/apache/CustomApacheHttpClientTest.java
+++ b/connectors/http/http-base/src/test/java/io/camunda/connector/http/base/client/apache/CustomApacheHttpClientTest.java
@@ -63,6 +63,7 @@ import io.camunda.connector.http.base.model.auth.BasicAuthentication;
 import io.camunda.connector.http.base.model.auth.BearerAuthentication;
 import io.camunda.connector.http.base.model.auth.OAuthAuthentication;
 import java.net.URISyntaxException;
+import java.util.HashMap;
 import java.util.Map;
 import org.apache.commons.text.StringEscapeUtils;
 import org.apache.hc.core5.http.ContentType;
@@ -199,6 +200,20 @@ public class CustomApacheHttpClientTest {
 
   @Nested
   class GetTests {
+
+    @Test
+    public void shouldReturn200_whenNullHeaders(WireMockRuntimeInfo wmRuntimeInfo) {
+      stubFor(get("/path").willReturn(ok()));
+      HttpCommonRequest request = new HttpCommonRequest();
+      request.setMethod(HttpMethod.GET);
+      var headers = new HashMap<String, String>();
+      headers.put("Content-Type", null);
+      request.setHeaders(headers);
+      request.setUrl(getHostAndPort(wmRuntimeInfo) + "/path");
+      HttpCommonResult result = customApacheHttpClient.execute(request);
+      assertThat(result).isNotNull();
+      assertThat(result.status()).isEqualTo(200);
+    }
 
     @Test
     public void shouldReturn200_whenNoTimeouts(WireMockRuntimeInfo wmRuntimeInfo) {


### PR DESCRIPTION
## Description

- Add support for `null` Content-Type.

## Related issues

closes #2813 

