### PR TITLE
642 fix spring security config

### DIFF
--- a/bundle/camunda-saas-bundle/src/main/java/io/camunda/connector/runtime/saas/security/SecurityConfiguration.java
+++ b/bundle/camunda-saas-bundle/src/main/java/io/camunda/connector/runtime/saas/security/SecurityConfiguration.java
@@ -19,10 +19,11 @@ package io.camunda.connector.runtime.saas.security;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpMethod;
+import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
 import org.springframework.security.oauth2.core.DelegatingOAuth2TokenValidator;
 import org.springframework.security.oauth2.core.OAuth2TokenValidator;
 import org.springframework.security.oauth2.jwt.Jwt;
@@ -31,6 +32,10 @@ import org.springframework.security.oauth2.jwt.JwtDecoders;
 import org.springframework.security.oauth2.jwt.JwtValidators;
 import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+import org.springframework.security.web.util.matcher.AnyRequestMatcher;
+import org.springframework.security.web.util.matcher.RequestMatcher;
+import org.springframework.util.AntPathMatcher;
 
 @EnableWebSecurity
 @Configuration
@@ -43,25 +48,30 @@ public class SecurityConfiguration {
   private String issuer;
 
   @Bean
-  public WebSecurityCustomizer webSecurityCustomizer() {
-    return (web) ->
-        web.ignoring()
-            .requestMatchers(HttpMethod.POST, "/inbound/*")
-            .requestMatchers(HttpMethod.GET, "/inbound/*")
-            .requestMatchers(HttpMethod.PUT, "/inbound/*")
-            .requestMatchers(HttpMethod.DELETE, "/inbound/*")
-            .requestMatchers("/actuator/**");
-  }
-
-  @Bean
+  @Order(1)
   public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
     http.csrf(csrf -> csrf.ignoringRequestMatchers("/inbound/**"))
         .authorizeHttpRequests(
-            auth -> {
-              auth.requestMatchers("/inbound", "/tenants/**").hasAuthority("SCOPE_inbound:read");
-            })
+            auth ->
+                auth.requestMatchers("/inbound", "/tenants/**").hasAuthority("SCOPE_inbound:read"))
         .oauth2ResourceServer(oauth2 -> oauth2.jwt(jwt -> jwt.decoder(jwtDecoder())));
     return http.build();
+  }
+
+  @Bean
+  @Order(0)
+  public SecurityFilterChain filterChain2(HttpSecurity http) throws Exception {
+    return http.csrf(csrf -> csrf.ignoringRequestMatchers("/inbound/**"))
+        .securityMatchers(
+            requestMatcherConfigurer ->
+                requestMatcherConfigurer
+                    .requestMatchers(HttpMethod.GET, "/inbound/*")
+                    .requestMatchers(HttpMethod.POST, "/inbound/*")
+                    .requestMatchers(HttpMethod.PUT, "/inbound/*")
+                    .requestMatchers(HttpMethod.DELETE, "/inbound/*")
+                    .requestMatchers("actuator/**"))
+        .authorizeHttpRequests(auth -> auth.anyRequest().permitAll())
+        .build();
   }
 
   @Bean

--- a/bundle/camunda-saas-bundle/src/main/java/io/camunda/connector/runtime/saas/security/SecurityConfiguration.java
+++ b/bundle/camunda-saas-bundle/src/main/java/io/camunda/connector/runtime/saas/security/SecurityConfiguration.java
@@ -42,17 +42,14 @@ public class SecurityConfiguration {
   @Value("${camunda.connector.auth.issuer}")
   private String issuer;
 
-  @Bean
-  @Order(1)
-  public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-    http.csrf(csrf -> csrf.ignoringRequestMatchers("/inbound/**"))
-        .authorizeHttpRequests(
-            auth ->
-                auth.requestMatchers("/inbound", "/tenants/**").hasAuthority("SCOPE_inbound:read"))
-        .oauth2ResourceServer(oauth2 -> oauth2.jwt(jwt -> jwt.decoder(jwtDecoder())));
-    return http.build();
-  }
-
+  /**
+   * This is the first (spring priority order) filter chain.
+   * This is going to be applied first, if nothing is matched, then the second one will be applied.
+   * Here, alls of the public endpoint are caught first.
+   * @param http
+   * @return The first security filter chain
+   * @throws Exception
+   */
   @Bean
   @Order(0)
   public SecurityFilterChain filterChain2(HttpSecurity http) throws Exception {
@@ -67,6 +64,27 @@ public class SecurityConfiguration {
                     .requestMatchers("actuator/**"))
         .authorizeHttpRequests(auth -> auth.anyRequest().permitAll())
         .build();
+  }
+
+  /**
+   * This is the second (spring priority order) filter chain.
+   * This has to be applied in second cause spring-security is secure by default
+   * and therefore will protect every endpoint with Oauth2
+   * If this was first and endpoint like `GET /inbound/*` would respond 401
+   * Those endpoint will be caught on the first security chain
+   * @param http
+   * @return The second security filter chain
+   * @throws Exception
+   */
+  @Bean
+  @Order(1)
+  public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+    http.csrf(csrf -> csrf.ignoringRequestMatchers("/inbound/**"))
+        .authorizeHttpRequests(
+            auth ->
+                auth.requestMatchers(HttpMethod.GET, "/inbound", "/tenants/**").hasAuthority("SCOPE_inbound:read"))
+        .oauth2ResourceServer(oauth2 -> oauth2.jwt(jwt -> jwt.decoder(jwtDecoder())));
+    return http.build();
   }
 
   @Bean

--- a/bundle/camunda-saas-bundle/src/main/java/io/camunda/connector/runtime/saas/security/SecurityConfiguration.java
+++ b/bundle/camunda-saas-bundle/src/main/java/io/camunda/connector/runtime/saas/security/SecurityConfiguration.java
@@ -43,9 +43,10 @@ public class SecurityConfiguration {
   private String issuer;
 
   /**
-   * This is the first (spring priority order) filter chain.
-   * This is going to be applied first, if nothing is matched, then the second one will be applied.
-   * Here, alls of the public endpoint are caught first.
+   * This is the first (spring priority order) filter chain. This is going to be applied first, if
+   * nothing is matched, then the second one will be applied. Here, alls of the public endpoint are
+   * caught first.
+   *
    * @param http
    * @return The first security filter chain
    * @throws Exception
@@ -67,11 +68,11 @@ public class SecurityConfiguration {
   }
 
   /**
-   * This is the second (spring priority order) filter chain.
-   * This has to be applied in second cause spring-security is secure by default
-   * and therefore will protect every endpoint with Oauth2
-   * If this was first and endpoint like `GET /inbound/*` would respond 401
-   * Those endpoint will be caught on the first security chain
+   * This is the second (spring priority order) filter chain. This has to be applied in second cause
+   * spring-security is secure by default and therefore will protect every endpoint with Oauth2 If
+   * this was first and endpoint like `GET /inbound/*` would respond 401 Those endpoint will be
+   * caught on the first security chain
+   *
    * @param http
    * @return The second security filter chain
    * @throws Exception
@@ -82,7 +83,8 @@ public class SecurityConfiguration {
     http.csrf(csrf -> csrf.ignoringRequestMatchers("/inbound/**"))
         .authorizeHttpRequests(
             auth ->
-                auth.requestMatchers(HttpMethod.GET, "/inbound", "/tenants/**").hasAuthority("SCOPE_inbound:read"))
+                auth.requestMatchers(HttpMethod.GET, "/inbound", "/tenants/**")
+                    .hasAuthority("SCOPE_inbound:read"))
         .oauth2ResourceServer(oauth2 -> oauth2.jwt(jwt -> jwt.decoder(jwtDecoder())));
     return http.build();
   }

--- a/bundle/camunda-saas-bundle/src/main/java/io/camunda/connector/runtime/saas/security/SecurityConfiguration.java
+++ b/bundle/camunda-saas-bundle/src/main/java/io/camunda/connector/runtime/saas/security/SecurityConfiguration.java
@@ -21,7 +21,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpMethod;
-import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.oauth2.core.DelegatingOAuth2TokenValidator;
@@ -32,10 +31,6 @@ import org.springframework.security.oauth2.jwt.JwtDecoders;
 import org.springframework.security.oauth2.jwt.JwtValidators;
 import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
 import org.springframework.security.web.SecurityFilterChain;
-import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
-import org.springframework.security.web.util.matcher.AnyRequestMatcher;
-import org.springframework.security.web.util.matcher.RequestMatcher;
-import org.springframework.util.AntPathMatcher;
 
 @EnableWebSecurity
 @Configuration


### PR DESCRIPTION
## Description

This ticket was pretty tricky cause those particular behavior are needed:

- `/inbound/*` `GET` `POST` `PUT` `DELETE` must not have any authentication system, and should not even read the authorization header
- `/inbound/*` `OPTIONS` `PATCH` `HEAD` must have an authentication system, and return 401 if the bearer is incorrect.

A new SecurityWebFilter had to be added as explained in this issue on spring-security repository https://github.com/spring-projects/spring-security/issues/14120

## Related issues

closes https://github.com/camunda/team-connectors/issues/642

