### PR TITLE
refactor(test performance): modify test to be able to run them in parallel

### DIFF
--- a/connectors/http/rest/src/test/java/io/camunda/connector/http/rest/HttpJsonFunctionTest.java
+++ b/connectors/http/rest/src/test/java/io/camunda/connector/http/rest/HttpJsonFunctionTest.java
@@ -41,7 +41,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 
-@WireMockTest(httpPort = 8085)
+@WireMockTest(httpPort = 8086)
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
 public class HttpJsonFunctionTest extends BaseTest {
@@ -101,7 +101,7 @@ public class HttpJsonFunctionTest extends BaseTest {
   void execute_shouldReturnNullFieldWhenResponseWithContainNullField() throws Exception {
     // given request, and response body with null field value
     final var request =
-        "{ \"method\": \"get\", \"url\": \"http://localhost:8085/http-endpoint\",\"authentication\": { \"type\": \"noAuth\" } }";
+        "{ \"method\": \"get\", \"url\": \"http://localhost:8086/http-endpoint\",\"authentication\": { \"type\": \"noAuth\" } }";
     final var response =
         "{ \"createdAt\": \"2022-10-10T05:03:14.723Z\", \"name\": \"Marvin Cremin\",\"unknown\": null, \"id\": \"1\" }";
     stubFor(any(urlPathEqualTo("/http-endpoint")).willReturn(aResponse().withBody(response)));

--- a/connectors/http/rest/src/test/resources/requests/fail-test-cases.json
+++ b/connectors/http/rest/src/test/resources/requests/fail-test-cases.json
@@ -1,7 +1,7 @@
 [
   {
     "descriptionOfTest": "No method",
-    "url": "http://localhost:8085/http-endpoint",
+    "url": "http://localhost:8086/http-endpoint",
     "queryParameters": {
       "q": "test",
       "priority": 12

--- a/connectors/http/rest/src/test/resources/requests/success-cases-connection-timeout-validation.json
+++ b/connectors/http/rest/src/test/resources/requests/success-cases-connection-timeout-validation.json
@@ -2,7 +2,7 @@
   {
     "descriptionOfTest": "0 value",
     "method": "get",
-    "url": "http://localhost:8085/http-endpoint",
+    "url": "http://localhost:8086/http-endpoint",
     "connectionTimeoutInSeconds": "0",
     "authentication": {
       "type": "noAuth"
@@ -11,7 +11,7 @@
   {
     "descriptionOfTest": "0 value with bearer auth",
     "method": "get",
-    "url": "http://localhost:8085/http-endpoint",
+    "url": "http://localhost:8086/http-endpoint",
     "connectionTimeoutInSeconds": "0",
     "authentication": {
       "type": "bearer",
@@ -21,7 +21,7 @@
   {
     "descriptionOfTest": "positive value",
     "method": "get",
-    "url": "http://localhost:8085/http-endpoint",
+    "url": "http://localhost:8086/http-endpoint",
     "connectionTimeoutInSeconds": "99",
     "authentication": {
       "type": "bearer",
@@ -31,7 +31,7 @@
   {
     "descriptionOfTest": "secrets value",
     "method": "get",
-    "url": "http://localhost:8085/http-endpoint",
+    "url": "http://localhost:8086/http-endpoint",
     "connectionTimeoutInSeconds": "{{secrets.CONNECT_TIMEOUT_KEY}}",
     "authentication": {
       "type": "bearer",

--- a/connectors/http/rest/src/test/resources/requests/success-test-cases-api-key-headers.json
+++ b/connectors/http/rest/src/test/resources/requests/success-test-cases-api-key-headers.json
@@ -2,7 +2,7 @@
   {
     "descriptionOfTest": "Normal request with apiKey in headers",
     "method": "get",
-    "url": "http://localhost:8085/http-endpoint",
+    "url": "http://localhost:8086/http-endpoint",
     "authentication": {
       "apiKeyLocation": "headers",
       "name": "api-key-auth",
@@ -13,7 +13,7 @@
   {
     "descriptionOfTest": "Normal request with apiKey in headers with secrets",
     "method": "get",
-    "url": "http://localhost:8085/http-endpoint",
+    "url": "http://localhost:8086/http-endpoint",
     "authentication": {
       "apiKeyLocation": "headers",
       "name": "{{secrets.API_KEY_NAME}}",

--- a/connectors/http/rest/src/test/resources/requests/success-test-cases-api-key-query.json
+++ b/connectors/http/rest/src/test/resources/requests/success-test-cases-api-key-query.json
@@ -2,7 +2,7 @@
   {
     "descriptionOfTest": "Normal request with apiKey in headers",
     "method": "get",
-    "url": "http://localhost:8085/http-endpoint",
+    "url": "http://localhost:8086/http-endpoint",
     "authentication": {
       "apiKeyLocation": "query",
       "name": "api-key-auth",
@@ -13,7 +13,7 @@
   {
     "descriptionOfTest": "Normal request with apiKey in headers with secrets",
     "method": "get",
-    "url": "http://localhost:8085/http-endpoint",
+    "url": "http://localhost:8086/http-endpoint",
     "authentication": {
       "apiKeyLocation": "query",
       "name": "{{secrets.API_KEY_NAME}}",

--- a/connectors/http/rest/src/test/resources/requests/success-test-cases-oauth.json
+++ b/connectors/http/rest/src/test/resources/requests/success-test-cases-oauth.json
@@ -2,7 +2,7 @@
   {
     "descriptionOfTest": "Normal request with oauth",
     "method": "post",
-    "url": "http://localhost:8085/http-endpoint",
+    "url": "http://localhost:8086/http-endpoint",
     "connectionTimeoutInSeconds": "30",
     "headers": {
       "X-Camunda-Cluster-ID": "abcdef",
@@ -28,7 +28,7 @@
   {
     "descriptionOfTest": "Normal request with oauth without scopes",
     "method": "post",
-    "url": "http://localhost:8085/http-endpoint",
+    "url": "http://localhost:8086/http-endpoint",
     "connectionTimeoutInSeconds": "30",
     "headers": {
       "X-Camunda-Cluster-ID": "abcdef",

--- a/connectors/http/rest/src/test/resources/requests/success-test-cases.json
+++ b/connectors/http/rest/src/test/resources/requests/success-test-cases.json
@@ -2,7 +2,7 @@
   {
     "descriptionOfTest": "Normal request with no auth",
     "method": "get",
-    "url": "http://localhost:8085/http-endpoint",
+    "url": "http://localhost:8086/http-endpoint",
     "authentication": {
       "type": "noAuth"
     },
@@ -26,7 +26,7 @@
   {
     "descriptionOfTest": "Normal request with basic auth",
     "method": "get",
-    "url": "http://localhost:8085/http-endpoint",
+    "url": "http://localhost:8086/http-endpoint",
     "connectionTimeoutInSeconds": 0,
     "readTimeoutInSeconds": 0,
     "queryParameters": {
@@ -53,7 +53,7 @@
   {
     "descriptionOfTest": "Normal request with bearer auth",
     "method": "get",
-    "url": "http://localhost:8085/http-endpoint",
+    "url": "http://localhost:8086/http-endpoint",
     "connectionTimeoutInSeconds": 60,
     "readTimeoutInSeconds": 70,
     "queryParameters": {
@@ -79,7 +79,7 @@
   {
     "descriptionOfTest": "Normal request with no query params",
     "method": "get",
-    "url": "http://localhost:8085/http-endpoint",
+    "url": "http://localhost:8086/http-endpoint",
     "connectionTimeoutInSeconds": 202,
     "readTimeoutInSeconds": 301,
     "headers": {
@@ -101,7 +101,7 @@
   {
     "descriptionOfTest": "Normal request with no headers",
     "method": "get",
-    "url": "http://localhost:8085/http-endpoint",
+    "url": "http://localhost:8086/http-endpoint",
     "connectionTimeoutInSeconds": 5,
     "readTimeoutInSeconds": 67,
     "queryParameters": {
@@ -126,7 +126,7 @@
     "method": "get",
     "connectionTimeoutInSeconds": 20,
     "readTimeoutInSeconds": 30,
-    "url": "http://localhost:8085/http-endpoint",
+    "url": "http://localhost:8086/http-endpoint",
     "queryParameters": {
       "q": "test",
       "priority": 12
@@ -143,7 +143,7 @@
   {
     "descriptionOfTest": "Normal request with empty body",
     "method": "get",
-    "url": "http://localhost:8085/http-endpoint",
+    "url": "http://localhost:8086/http-endpoint",
     "connectionTimeoutInSeconds": 20,
     "readTimeoutInSeconds": 0,
     "queryParameters": {
@@ -164,7 +164,7 @@
   {
     "descriptionOfTest": "Normal request with connectionTimeoutInSeconds",
     "method": "get",
-    "url": "http://localhost:8085/http-endpoint",
+    "url": "http://localhost:8086/http-endpoint",
     "queryParameters": {
       "q": "test",
       "priority": 12


### PR DESCRIPTION
## Description

Simple modification to be able to run all TU in parallel.

full test can be ran in 1m50 instead of 16m

You can run test using `mvn clean install -T100`

## Related issues

Does not close anything, but allow big performance gains

