### PR TITLE
fix(twilio): Fix content-type header issue when the case is inconsistent + fix element template

### DIFF
--- a/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/client/apache/builder/parts/ApacheRequestBodyBuilder.java
+++ b/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/client/apache/builder/parts/ApacheRequestBodyBuilder.java
@@ -85,7 +85,12 @@ public class ApacheRequestBodyBuilder implements ApacheRequestPartBuilder {
 
   private Optional<ContentType> tryGetContentType(HttpCommonRequest request) {
     return Optional.ofNullable(request.getHeaders())
-        .map(headers -> headers.get(CONTENT_TYPE))
+        .flatMap(
+            headers ->
+                headers.entrySet().stream()
+                    .filter(e -> e.getKey().equalsIgnoreCase(CONTENT_TYPE))
+                    .findFirst())
+        .map(Map.Entry::getValue)
         .map(ContentType::parse);
   }
 

--- a/connectors/twilio/element-templates/twilio-connector.json
+++ b/connectors/twilio/element-templates/twilio-connector.json
@@ -2,7 +2,7 @@
   "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
   "name": "Twilio Outbound Connector",
   "id": "io.camunda.connectors.Twilio.v1",
-  "version": 3,
+  "version": 4,
   "description": "Send SMS messages or retrieve message information using the Twilio API",
   "icon": {
     "contents": "data:image/svg+xml;utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='18' height='18' preserveAspectRatio='xMidYMid' viewBox='0 0 256 256' id='twilio'%3E%3Cg fill='%23CF272D'%3E%3Cpath d='M127.86 222.304c-52.005 0-94.164-42.159-94.164-94.163 0-52.005 42.159-94.163 94.164-94.163 52.004 0 94.162 42.158 94.162 94.163 0 52.004-42.158 94.163-94.162 94.163zm0-222.023C57.245.281 0 57.527 0 128.141 0 198.756 57.245 256 127.86 256c70.614 0 127.859-57.244 127.859-127.859 0-70.614-57.245-127.86-127.86-127.86z'%3E%3C/path%3E%3Cpath d='M133.116 96.297c0-14.682 11.903-26.585 26.586-26.585 14.683 0 26.585 11.903 26.585 26.585 0 14.684-11.902 26.586-26.585 26.586-14.683 0-26.586-11.902-26.586-26.586M133.116 159.983c0-14.682 11.903-26.586 26.586-26.586 14.683 0 26.585 11.904 26.585 26.586 0 14.683-11.902 26.586-26.585 26.586-14.683 0-26.586-11.903-26.586-26.586M69.431 159.983c0-14.682 11.904-26.586 26.586-26.586 14.683 0 26.586 11.904 26.586 26.586 0 14.683-11.903 26.586-26.586 26.586-14.682 0-26.586-11.903-26.586-26.586M69.431 96.298c0-14.683 11.904-26.585 26.586-26.585 14.683 0 26.586 11.902 26.586 26.585 0 14.684-11.903 26.586-26.586 26.586-14.682 0-26.586-11.902-26.586-26.586'%3E%3C/path%3E%3C/g%3E%3C/svg%3E"
@@ -156,7 +156,7 @@
     },
     {
       "type": "Hidden",
-      "value": "={\"content-type\":\"application/x-www-form-urlencoded\"}",
+      "value": "={\"Content-Type\":\"application/x-www-form-urlencoded\"}",
       "binding": {
         "type": "zeebe:input",
         "name": "headers"


### PR DESCRIPTION
## Description

We were looking for a `Content-Type` header in different places, but only with this specific case.
We now ignore the case.

## Related issues

closes #2820 

