### PR TITLE
fix(rest): Fix missing path encoding in URLs

### DIFF
--- a/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/client/apache/builder/parts/ApacheRequestBodyBuilder.java
+++ b/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/client/apache/builder/parts/ApacheRequestBodyBuilder.java
@@ -115,7 +115,8 @@ public class ApacheRequestBodyBuilder implements ApacheRequestPartBuilder {
             .map(
                 e ->
                     new BasicNameValuePair(
-                        String.valueOf(e.getKey()), String.valueOf(e.getValue())))
+                        String.valueOf(e.getKey()),
+                        Optional.ofNullable(e.getValue()).map(String::valueOf).orElse(null)))
             .collect(Collectors.toList()),
         StandardCharsets.UTF_8);
   }

--- a/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/client/apache/builder/parts/ApacheRequestUriBuilder.java
+++ b/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/client/apache/builder/parts/ApacheRequestUriBuilder.java
@@ -30,6 +30,7 @@ public class ApacheRequestUriBuilder implements ApacheRequestPartBuilder {
     try {
       var url = new URL(request.getUrl());
       builder.setUri(
+          // Only this URI constructor escapes the URL properly
           new URI(
               url.getProtocol(),
               url.getUserInfo(),

--- a/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/client/apache/builder/parts/ApacheRequestUriBuilder.java
+++ b/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/client/apache/builder/parts/ApacheRequestUriBuilder.java
@@ -17,12 +17,29 @@
 package io.camunda.connector.http.base.client.apache.builder.parts;
 
 import io.camunda.connector.http.base.model.HttpCommonRequest;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
 import org.apache.hc.core5.http.io.support.ClassicRequestBuilder;
 
 public class ApacheRequestUriBuilder implements ApacheRequestPartBuilder {
 
   @Override
   public void build(ClassicRequestBuilder builder, HttpCommonRequest request) {
-    builder.setUri(request.getUrl());
+    try {
+      var url = new URL(request.getUrl());
+      builder.setUri(
+          new URI(
+              url.getProtocol(),
+              url.getUserInfo(),
+              url.getHost(),
+              url.getPort(),
+              url.getPath(),
+              url.getQuery(),
+              null));
+    } catch (MalformedURLException | URISyntaxException e) {
+      builder.setUri(request.getUrl());
+    }
   }
 }

--- a/connectors/http/http-base/src/test/java/io/camunda/connector/http/base/client/apache/ApacheRequestFactoryTest.java
+++ b/connectors/http/http-base/src/test/java/io/camunda/connector/http/base/client/apache/ApacheRequestFactoryTest.java
@@ -393,6 +393,41 @@ public class ApacheRequestFactoryTest {
     }
 
     @Test
+    public void shouldSetFormUrlEncodedBody_whenBodySupportedAndBodyIsMapAndHasNullValues()
+        throws Exception {
+      // given request with body
+      HttpCommonRequest request = new HttpCommonRequest();
+      request.setMethod(HttpMethod.POST);
+      var body = new HashMap<String, String>();
+      body.put("key", null);
+      body.put("key2", "value2");
+      request.setBody(body);
+      request.setHeaders(
+          Map.of(
+              HttpHeaders.CONTENT_TYPE,
+              ContentType.APPLICATION_FORM_URLENCODED
+                  .withCharset(StandardCharsets.UTF_8)
+                  .toString()));
+
+      // when
+      ClassicHttpRequest httpRequest = ApacheRequestFactory.get().createHttpRequest(request);
+
+      // then
+      assertThat(httpRequest.getEntity()).isNotNull();
+      assertThat(httpRequest.getEntity().getContentLength()).isGreaterThan(0);
+      assertThat(httpRequest.getEntity().getContentType())
+          .isEqualTo(
+              ContentType.APPLICATION_FORM_URLENCODED
+                  .withCharset(StandardCharsets.UTF_8)
+                  .toString());
+      String content = new String(httpRequest.getEntity().getContent().readAllBytes());
+      assertThat(content).contains("key");
+      assertThat(content).doesNotContain("null");
+      assertThat(content).contains("key2=value2");
+      assertThat(content).contains("&");
+    }
+
+    @Test
     public void shouldSetFormUrlEncodedBody_whenBodySupportedAndContentTypeProvidedAndBodyIsMap()
         throws Exception {
       // given request with body

--- a/connectors/http/http-base/src/test/java/io/camunda/connector/http/base/client/apache/CustomApacheHttpClientTest.java
+++ b/connectors/http/http-base/src/test/java/io/camunda/connector/http/base/client/apache/CustomApacheHttpClientTest.java
@@ -199,6 +199,42 @@ public class CustomApacheHttpClientTest {
   }
 
   @Nested
+  class EscapeTests {
+
+    @ParameterizedTest
+    @EnumSource(HttpMethod.class)
+    public void shouldReturn200_whenSpaceInPathAndQueryParameters(
+        HttpMethod method, WireMockRuntimeInfo wmRuntimeInfo) {
+      stubFor(any(urlEqualTo("/path%20with%20spaces?andQuery=S%C3%A3o%20Paulo")).willReturn(ok()));
+
+      HttpCommonRequest request = new HttpCommonRequest();
+      request.setMethod(method);
+      request.setUrl(getHostAndPort(wmRuntimeInfo) + "/path with spaces");
+      request.setQueryParameters(Map.of("andQuery", "São Paulo"));
+      HttpCommonResult result = customApacheHttpClient.execute(request);
+      assertThat(result).isNotNull();
+      assertThat(result.status()).isEqualTo(200);
+    }
+
+    @ParameterizedTest
+    @EnumSource(HttpMethod.class)
+    public void shouldReturn200_whenSpaceInPathAndQueryParametersInPath(
+        HttpMethod method, WireMockRuntimeInfo wmRuntimeInfo) {
+      stubFor(
+          any(urlEqualTo("/path%20with%20spaces?andQuery=Param%20with%20space"))
+              .withQueryParams(Map.of("andQuery", equalTo("Param with space")))
+              .willReturn(ok()));
+
+      HttpCommonRequest request = new HttpCommonRequest();
+      request.setMethod(method);
+      request.setUrl(getHostAndPort(wmRuntimeInfo) + "/path with spaces?andQuery=Param with space");
+      HttpCommonResult result = customApacheHttpClient.execute(request);
+      assertThat(result).isNotNull();
+      assertThat(result.status()).isEqualTo(200);
+    }
+  }
+
+  @Nested
   class GetTests {
 
     @Test


### PR DESCRIPTION
## Description

- Use the URI constructor that escapes the necessary parts
- Check for null values in form-encoded body before calling `String.valueOf`

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes https://github.com/camunda/team-connectors/issues/840

