### PR TITLE
fix(json-mapping): Json mapping now gives a reliable error message

### DIFF
--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/outbound/JobHandlerContext.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/outbound/JobHandlerContext.java
@@ -16,6 +16,7 @@
  */
 package io.camunda.connector.runtime.core.outbound;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.connector.api.error.ConnectorException;
 import io.camunda.connector.api.outbound.JobContext;
@@ -25,6 +26,8 @@ import io.camunda.connector.api.validation.ValidationProvider;
 import io.camunda.connector.runtime.core.AbstractConnectorContext;
 import io.camunda.zeebe.client.api.response.ActivatedJob;
 import java.util.Objects;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Implementation of {@link io.camunda.connector.api.outbound.OutboundConnectorContext} passed on to
@@ -34,13 +37,12 @@ import java.util.Objects;
 public class JobHandlerContext extends AbstractConnectorContext
     implements OutboundConnectorContext {
 
+  private static final Logger log = LoggerFactory.getLogger(JobHandlerContext.class);
   private final ActivatedJob job;
 
   private final ObjectMapper objectMapper;
-
-  private String jsonWithSecrets = null;
-
   private final JobContext jobContext;
+  private String jsonWithSecrets = null;
 
   public JobHandlerContext(
       final ActivatedJob job,
@@ -71,8 +73,9 @@ public class JobHandlerContext extends AbstractConnectorContext
     var jsonWithSecrets = getJsonReplacedWithSecrets();
     try {
       return objectMapper.readValue(jsonWithSecrets, cls);
-    } catch (Exception e) {
-      throw new ConnectorException("JSON_MAPPING", "Error during json mapping.");
+    } catch (JsonProcessingException e) {
+      log.error(e.getOriginalMessage());
+      throw new ConnectorException("JSON_PROCESSING", e.getOriginalMessage());
     }
   }
 

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/outbound/JobHandlerContextTest.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/outbound/JobHandlerContextTest.java
@@ -16,18 +16,23 @@
  */
 package io.camunda.connector.runtime.core.outbound;
 
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.connector.api.error.ConnectorException;
 import io.camunda.connector.api.secret.SecretProvider;
 import io.camunda.connector.api.validation.ValidationProvider;
+import io.camunda.connector.runtime.core.testutil.classexample.TestClass;
 import io.camunda.zeebe.client.api.response.ActivatedJob;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
@@ -35,8 +40,7 @@ class JobHandlerContextTest {
 
   @Mock private ActivatedJob activatedJob;
   @Mock private SecretProvider secretProvider;
-  @Mock private ObjectMapper objectMapper;
-
+  @Spy private ObjectMapper objectMapper = new ObjectMapper();
   @Mock private ValidationProvider validationProvider;
 
   @InjectMocks private JobHandlerContext jobHandlerContext;
@@ -54,5 +58,102 @@ class JobHandlerContextTest {
     when(activatedJob.getVariables()).thenReturn("{}");
     jobHandlerContext.getJobContext().getVariables();
     verify(activatedJob).getVariables();
+  }
+
+  @Test
+  void bindVariables_success() {
+    String json = "{ \"integer\": 3}";
+    when(activatedJob.getVariables()).thenReturn(json);
+    assertThat(jobHandlerContext.bindVariables(TestClass.class).integer).isEqualTo(3);
+  }
+
+  @Test
+  void bindVariables_nullValue() {
+    String json = "{ \"integer\": null}";
+    when(activatedJob.getVariables()).thenReturn(json);
+    assertThat(jobHandlerContext.bindVariables(TestClass.class).integer).isEqualTo(null);
+  }
+
+  @Test
+  void bindVariables_invalidFormat() {
+    String json = "{ \"integer\": \"hello\"}";
+    when(activatedJob.getVariables()).thenReturn(json);
+    Exception thrown =
+        assertThrows(
+            ConnectorException.class, () -> jobHandlerContext.bindVariables(TestClass.class));
+
+    assertThat(thrown.getMessage())
+        .isEqualTo("Json object contains an invalid field: integer. It Must be `Integer`");
+  }
+
+  @Test
+  void bindVariables_invalidFormatNull() {
+    String json = "{ \"invalid\": null }";
+    when(activatedJob.getVariables()).thenReturn(json);
+    Exception thrown =
+        assertThrows(
+            ConnectorException.class, () -> jobHandlerContext.bindVariables(TestClass.class));
+
+    assertThat(thrown.getMessage()).isEqualTo("Json object contains an invalid field: invalid");
+  }
+
+  @Test
+  void bindVariables_invalidParsing() {
+    String json = "{ \"integer\" hello\"}";
+    when(activatedJob.getVariables()).thenReturn(json);
+    Exception thrown =
+        assertThrows(
+            ConnectorException.class, () -> jobHandlerContext.bindVariables(TestClass.class));
+
+    assertThat(thrown.getMessage()).isEqualTo("This is not a JSON object");
+  }
+
+  @Test
+  void bindVariables_invalidFormatObject() {
+    String json = "{ \"integer\": \"{ \"hello\" : 3\"}";
+    when(activatedJob.getVariables()).thenReturn(json);
+    Exception thrown =
+        assertThrows(
+            ConnectorException.class, () -> jobHandlerContext.bindVariables(TestClass.class));
+
+    assertThat(thrown.getMessage())
+        .isEqualTo("Json object contains an invalid field: integer. It Must be `Integer`");
+  }
+
+  @Test
+  void bindVariables_emptyString() {
+    String json = "";
+    when(activatedJob.getVariables()).thenReturn(json);
+    Exception thrown =
+        assertThrows(
+            ConnectorException.class, () -> jobHandlerContext.bindVariables(TestClass.class));
+
+    assertThat(thrown.getMessage()).isEqualTo("No content to map due to end-of-input");
+  }
+
+  @Test
+  void bindVariables_emptyArray() {
+    String json = "[]";
+    when(activatedJob.getVariables()).thenReturn(json);
+    Exception thrown =
+        assertThrows(
+            ConnectorException.class, () -> jobHandlerContext.bindVariables(TestClass.class));
+
+    assertThat(thrown.getMessage())
+        .isEqualTo(
+            "Cannot deserialize value of type `io.camunda.connector.runtime.core.testutil.classexample.TestClass` from Array value (token `JsonToken.START_ARRAY`)");
+  }
+
+  @Test
+  void bindVariables_invalidFormatArray() {
+    String json = "{ \"integer\": [\"hello\"] }";
+    when(activatedJob.getVariables()).thenReturn(json);
+    Exception thrown =
+        assertThrows(
+            ConnectorException.class, () -> jobHandlerContext.bindVariables(TestClass.class));
+
+    assertThat(thrown.getMessage())
+        .isEqualTo(
+            "Cannot deserialize value of type `java.lang.Integer` from Array value (token `JsonToken.START_ARRAY`)");
   }
 }

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/outbound/JobHandlerContextTest.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/outbound/JobHandlerContextTest.java
@@ -18,11 +18,9 @@ package io.camunda.connector.runtime.core.outbound;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.connector.api.error.ConnectorException;
 import io.camunda.connector.api.secret.SecretProvider;

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/outbound/JobHandlerContextTest.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/outbound/JobHandlerContextTest.java
@@ -18,6 +18,7 @@ package io.camunda.connector.runtime.core.outbound;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -44,14 +45,6 @@ class JobHandlerContextTest {
   @Mock private ValidationProvider validationProvider;
 
   @InjectMocks private JobHandlerContext jobHandlerContext;
-
-  @Test
-  void getVariablesAsType() throws JsonProcessingException {
-    Class<Integer> integerClass = Integer.class;
-    when(activatedJob.getVariables()).thenReturn("");
-    jobHandlerContext.bindVariables(integerClass);
-    verify(objectMapper).readValue("", Integer.class);
-  }
 
   @Test
   void getVariables() {

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/testutil/classexample/TestClass.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/testutil/classexample/TestClass.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.camunda.connector.runtime.core.testutil.classexample;
 
 public class TestClass {

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/testutil/classexample/TestClass.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/testutil/classexample/TestClass.java
@@ -1,0 +1,11 @@
+package io.camunda.connector.runtime.core.testutil.classexample;
+
+public class TestClass {
+  public Integer integer;
+
+  public TestClass(Integer integer) {
+    this.integer = integer;
+  }
+
+  public TestClass() {}
+}


### PR DESCRIPTION
## Description

Give a reliable error message to the user in case a json mapping throws an error

before was:

```
2024-06-24T01:51:43.958Z ERROR 1 --- [pool-2-thread-1] i.c.c.r.c.outbound.ConnectorJobHandler : Exception while processing job: 4503599627704641 for tenant:
io.camunda.connector.api.error.ConnectorException: Error during json mapping.
```

now it looks like

```
2024-07-05T16:38:09.648+02:00 ERROR 56519 --- [pool-1-thread-1] i.c.c.r.core.outbound.JobHandlerContext  : Could not resolve type id 'chat' as a subtype of `io.camunda.connector.slack.outbound.model.SlackRequestData`: known type ids = [chat.postMessage, conversations.create, conversations.invite] (for POJO property 'data')
```

## Related issues

closes https://github.com/camunda/connectors/issues/2805

