### PR TITLE
fix(rest): Ensure proper URL encoding + fix case issues with content type headers

### DIFF
--- a/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/client/apache/builder/parts/ApacheRequestBodyBuilder.java
+++ b/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/client/apache/builder/parts/ApacheRequestBodyBuilder.java
@@ -71,11 +71,11 @@ public class ApacheRequestBodyBuilder implements ApacheRequestPartBuilder {
   private HttpEntity createEntityForContentType(
       ContentType contentType, Map<?, ?> body, HttpCommonRequest request) {
     HttpEntity entity;
-    if (contentType.getMimeType().equals(MULTIPART_FORM_DATA.getMimeType())) {
+    if (contentType.getMimeType().equalsIgnoreCase(MULTIPART_FORM_DATA.getMimeType())) {
       entity = createMultiPartEntity(body, contentType);
     } else if (contentType
         .getMimeType()
-        .equals(ContentType.APPLICATION_FORM_URLENCODED.getMimeType())) {
+        .equalsIgnoreCase(ContentType.APPLICATION_FORM_URLENCODED.getMimeType())) {
       entity = createUrlEncodedFormEntity(body);
     } else {
       entity = createStringEntity(request);

--- a/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/client/apache/builder/parts/ApacheRequestUriBuilder.java
+++ b/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/client/apache/builder/parts/ApacheRequestUriBuilder.java
@@ -25,8 +25,11 @@ import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.util.Optional;
 import org.apache.hc.core5.http.io.support.ClassicRequestBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class ApacheRequestUriBuilder implements ApacheRequestPartBuilder {
+  private static final Logger LOG = LoggerFactory.getLogger(ApacheRequestUriBuilder.class);
 
   @Override
   public void build(ClassicRequestBuilder builder, HttpCommonRequest request) {
@@ -49,6 +52,7 @@ public class ApacheRequestUriBuilder implements ApacheRequestPartBuilder {
               url.getQuery(),
               null));
     } catch (MalformedURLException | URISyntaxException e) {
+      LOG.error("Failed to parse URL {}", request.getUrl(), e);
       builder.setUri(request.getUrl());
     }
   }

--- a/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/client/apache/builder/parts/ApacheRequestUriBuilder.java
+++ b/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/client/apache/builder/parts/ApacheRequestUriBuilder.java
@@ -20,18 +20,9 @@ import io.camunda.connector.http.base.model.HttpCommonRequest;
 import org.apache.hc.core5.http.io.support.ClassicRequestBuilder;
 
 public class ApacheRequestUriBuilder implements ApacheRequestPartBuilder {
-  private final UrlEncoder urlEncoder;
-
-  ApacheRequestUriBuilder(UrlEncoder urlEncoder) {
-    this.urlEncoder = urlEncoder;
-  }
-
-  public ApacheRequestUriBuilder() {
-    this(new UrlEncoder());
-  }
 
   @Override
   public void build(ClassicRequestBuilder builder, HttpCommonRequest request) {
-    builder.setUri(urlEncoder.toEncodedUri(request.getUrl()));
+    builder.setUri(UrlEncoder.toEncodedUri(request.getUrl()));
   }
 }

--- a/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/client/apache/builder/parts/ApacheRequestUriBuilder.java
+++ b/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/client/apache/builder/parts/ApacheRequestUriBuilder.java
@@ -21,6 +21,9 @@ import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Optional;
 import org.apache.hc.core5.http.io.support.ClassicRequestBuilder;
 
 public class ApacheRequestUriBuilder implements ApacheRequestPartBuilder {
@@ -28,7 +31,13 @@ public class ApacheRequestUriBuilder implements ApacheRequestPartBuilder {
   @Override
   public void build(ClassicRequestBuilder builder, HttpCommonRequest request) {
     try {
-      var url = new URL(request.getUrl());
+      // We try to decode the URL first, because it might be encoded already
+      // which would lead to double encoding. Decoding is safe here, because it does nothing if
+      // the URL is not encoded.
+      var decodedUrl =
+          URLDecoder.decode(
+              Optional.ofNullable(request.getUrl()).orElse(""), StandardCharsets.UTF_8);
+      var url = new URL(decodedUrl);
       builder.setUri(
           // Only this URI constructor escapes the URL properly
           new URI(

--- a/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/client/apache/builder/parts/UrlEncoder.java
+++ b/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/client/apache/builder/parts/UrlEncoder.java
@@ -7,20 +7,19 @@
 
 package io.camunda.connector.http.base.client.apache.builder.parts;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class UrlEncoder {
   private static final Logger LOG = LoggerFactory.getLogger(ApacheRequestUriBuilder.class);
 
-  public URI toEncodedUri(String requestUrl) {
+  public static URI toEncodedUri(String requestUrl) {
     try {
       // We try to decode the URL first, because it might be encoded already
       // which would lead to double encoding. Decoding is safe here, because it does nothing if

--- a/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/client/apache/builder/parts/UrlEncoder.java
+++ b/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/client/apache/builder/parts/UrlEncoder.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+
+package io.camunda.connector.http.base.client.apache.builder.parts;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+
+public class UrlEncoder {
+  private static final Logger LOG = LoggerFactory.getLogger(ApacheRequestUriBuilder.class);
+
+  public URI toEncodedUri(String requestUrl) {
+    try {
+      // We try to decode the URL first, because it might be encoded already
+      // which would lead to double encoding. Decoding is safe here, because it does nothing if
+      // the URL is not encoded.
+      var decodedUrl = URLDecoder.decode(requestUrl, StandardCharsets.UTF_8);
+      var url = new URL(decodedUrl);
+      // Only this URI constructor escapes the URL properly
+      return new URI(
+          url.getProtocol(),
+          url.getUserInfo(),
+          url.getHost(),
+          url.getPort(),
+          url.getPath(),
+          url.getQuery(),
+          null);
+    } catch (MalformedURLException | URISyntaxException e) {
+      LOG.error("Failed to parse URL {}, defaulting to requestUrl", requestUrl, e);
+      return URI.create(requestUrl);
+    }
+  }
+}

--- a/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/client/apache/builder/parts/UrlEncoder.java
+++ b/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/client/apache/builder/parts/UrlEncoder.java
@@ -1,10 +1,19 @@
 /*
  * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
- * under one or more contributor license agreements. Licensed under a proprietary license.
- * See the License.txt file for more information. You may not use this file
- * except in compliance with the proprietary license.
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package io.camunda.connector.http.base.client.apache.builder.parts;
 
 import java.net.MalformedURLException;

--- a/connectors/http/http-base/src/test/java/io/camunda/connector/http/base/client/apache/ApacheRequestFactoryTest.java
+++ b/connectors/http/http-base/src/test/java/io/camunda/connector/http/base/client/apache/ApacheRequestFactoryTest.java
@@ -65,6 +65,7 @@ public class ApacheRequestFactoryTest {
       // given request without authentication
       HttpCommonRequest request = new HttpCommonRequest();
       request.setMethod(HttpMethod.GET);
+      request.setUrl("theurl");
 
       // when
       ClassicHttpRequest httpRequest = ApacheRequestFactory.get().createHttpRequest(request);
@@ -79,6 +80,7 @@ public class ApacheRequestFactoryTest {
       HttpCommonRequest request = new HttpCommonRequest();
       request.setMethod(HttpMethod.GET);
       request.setAuthentication(new BasicAuthentication("user", "password"));
+      request.setUrl("theurl");
 
       // when
       ClassicHttpRequest httpRequest = ApacheRequestFactory.get().createHttpRequest(request);
@@ -94,6 +96,7 @@ public class ApacheRequestFactoryTest {
       HttpCommonRequest request = new HttpCommonRequest();
       request.setMethod(HttpMethod.GET);
       request.setAuthentication(new BearerAuthentication("token"));
+      request.setUrl("theurl");
 
       // when
       ClassicHttpRequest httpRequest = ApacheRequestFactory.get().createHttpRequest(request);
@@ -109,6 +112,7 @@ public class ApacheRequestFactoryTest {
       HttpCommonResult result = new HttpCommonResult(200, null, "{\"access_token\":\"token\"}");
       HttpCommonRequest request = new HttpCommonRequest();
       request.setMethod(HttpMethod.GET);
+      request.setUrl("theurl");
       request.setAuthentication(
           new OAuthAuthentication(
               "url", "clientId", "secret", "audience", OAuthConstants.CREDENTIALS_BODY, "scopes"));
@@ -133,6 +137,7 @@ public class ApacheRequestFactoryTest {
       HttpCommonRequest request = new HttpCommonRequest();
       request.setMethod(HttpMethod.GET);
       request.setAuthentication(new ApiKeyAuthentication(ApiKeyLocation.HEADERS, "name", "value"));
+      request.setUrl("theurl");
 
       // when
       ClassicHttpRequest httpRequest = ApacheRequestFactory.get().createHttpRequest(request);
@@ -147,6 +152,7 @@ public class ApacheRequestFactoryTest {
       HttpCommonRequest request = new HttpCommonRequest();
       request.setMethod(HttpMethod.GET);
       request.setAuthentication(new ApiKeyAuthentication(ApiKeyLocation.QUERY, "name", "value"));
+      request.setUrl("theurl");
 
       // when
       ClassicHttpRequest httpRequest = ApacheRequestFactory.get().createHttpRequest(request);
@@ -165,6 +171,7 @@ public class ApacheRequestFactoryTest {
       // given request without query parameters
       HttpCommonRequest request = new HttpCommonRequest();
       request.setMethod(HttpMethod.GET);
+      request.setUrl("theurl");
 
       // when
       ClassicHttpRequest httpRequest = ApacheRequestFactory.get().createHttpRequest(request);
@@ -179,6 +186,7 @@ public class ApacheRequestFactoryTest {
       HttpCommonRequest request = new HttpCommonRequest();
       request.setMethod(HttpMethod.GET);
       request.setQueryParameters(Map.of("key", "value"));
+      request.setUrl("theurl");
 
       // when
       ClassicHttpRequest httpRequest = ApacheRequestFactory.get().createHttpRequest(request);
@@ -193,6 +201,7 @@ public class ApacheRequestFactoryTest {
       HttpCommonRequest request = new HttpCommonRequest();
       request.setMethod(HttpMethod.GET);
       request.setQueryParameters(Map.of("key", "value", "key2", "value2"));
+      request.setUrl("theurl");
 
       // when
       ClassicHttpRequest httpRequest = ApacheRequestFactory.get().createHttpRequest(request);
@@ -313,6 +322,7 @@ public class ApacheRequestFactoryTest {
       // given request with body
       HttpCommonRequest request = new HttpCommonRequest();
       request.setMethod(HttpMethod.GET);
+      request.setUrl("theurl");
 
       // when
       ClassicHttpRequest httpRequest = ApacheRequestFactory.get().createHttpRequest(request);
@@ -327,6 +337,7 @@ public class ApacheRequestFactoryTest {
       HttpCommonRequest request = new HttpCommonRequest();
       request.setMethod(HttpMethod.POST);
       request.setBody(Map.of("key", "value"));
+      request.setUrl("theurl");
 
       // when
       ClassicHttpRequest httpRequest = ApacheRequestFactory.get().createHttpRequest(request);
@@ -352,6 +363,7 @@ public class ApacheRequestFactoryTest {
           Map.of(
               HttpHeaders.CONTENT_TYPE,
               ContentType.TEXT_PLAIN.withCharset(StandardCharsets.UTF_8).toString()));
+      request.setUrl("theurl");
 
       // when
       ClassicHttpRequest httpRequest = ApacheRequestFactory.get().createHttpRequest(request);
@@ -377,6 +389,7 @@ public class ApacheRequestFactoryTest {
           Map.of(
               HttpHeaders.CONTENT_TYPE,
               ContentType.APPLICATION_JSON.withCharset(StandardCharsets.UTF_8).toString()));
+      request.setUrl("theurl");
 
       // when
       ClassicHttpRequest httpRequest = ApacheRequestFactory.get().createHttpRequest(request);
@@ -403,6 +416,7 @@ public class ApacheRequestFactoryTest {
           Map.of(
               HttpHeaders.CONTENT_TYPE,
               ContentType.APPLICATION_JSON.withCharset(StandardCharsets.UTF_8).toString()));
+      request.setUrl("theurl");
 
       // when
       ClassicHttpRequest httpRequest = ApacheRequestFactory.get().createHttpRequest(request);
@@ -433,6 +447,7 @@ public class ApacheRequestFactoryTest {
               ContentType.APPLICATION_FORM_URLENCODED
                   .withCharset(StandardCharsets.UTF_8)
                   .toString()));
+      request.setUrl("theurl");
 
       // when
       ClassicHttpRequest httpRequest = ApacheRequestFactory.get().createHttpRequest(request);
@@ -467,6 +482,7 @@ public class ApacheRequestFactoryTest {
               ContentType.APPLICATION_FORM_URLENCODED
                   .withCharset(StandardCharsets.UTF_8)
                   .toString()));
+      request.setUrl("theurl");
 
       // when
       ClassicHttpRequest httpRequest = ApacheRequestFactory.get().createHttpRequest(request);
@@ -495,6 +511,7 @@ public class ApacheRequestFactoryTest {
       request.setMethod(HttpMethod.POST);
       request.setBody(Map.of("key", "value", "key2", "value2"));
       request.setHeaders(Map.of(contentType, formUrlEncodedValue));
+      request.setUrl("theurl");
 
       // when
       ClassicHttpRequest httpRequest = ApacheRequestFactory.get().createHttpRequest(request);
@@ -522,6 +539,7 @@ public class ApacheRequestFactoryTest {
       request.setMethod(HttpMethod.POST);
       request.setBody(Map.of("key", "value", "key2", "value2"));
       request.setHeaders(Map.of(contentType, multipartValue));
+      request.setUrl("theurl");
 
       // when
       ClassicHttpRequest httpRequest = ApacheRequestFactory.get().createHttpRequest(request);
@@ -549,6 +567,7 @@ public class ApacheRequestFactoryTest {
       headers.put(HttpHeaders.CONTENT_TYPE, null);
       headers.put(HttpHeaders.ACCEPT, null);
       headers.put("Other", null);
+      request.setUrl("theurl");
       request.setHeaders(headers);
 
       // when
@@ -568,6 +587,7 @@ public class ApacheRequestFactoryTest {
       // given request without headers
       HttpCommonRequest request = new HttpCommonRequest();
       request.setMethod(HttpMethod.POST);
+      request.setUrl("theurl");
 
       // when
       ClassicHttpRequest httpRequest = ApacheRequestFactory.get().createHttpRequest(request);
@@ -585,6 +605,7 @@ public class ApacheRequestFactoryTest {
       HttpCommonRequest request = new HttpCommonRequest();
       request.setHeaders(Map.of("Authorization", "Bearer token"));
       request.setMethod(HttpMethod.POST);
+      request.setUrl("theurl");
 
       // when
       ClassicHttpRequest httpRequest = ApacheRequestFactory.get().createHttpRequest(request);
@@ -602,6 +623,7 @@ public class ApacheRequestFactoryTest {
       // given request without headers
       HttpCommonRequest request = new HttpCommonRequest();
       request.setMethod(HttpMethod.GET);
+      request.setUrl("theurl");
 
       // when
       ClassicHttpRequest httpRequest = ApacheRequestFactory.get().createHttpRequest(request);
@@ -617,6 +639,7 @@ public class ApacheRequestFactoryTest {
       HttpCommonRequest request = new HttpCommonRequest();
       request.setHeaders(Map.of(HttpHeaders.CONTENT_TYPE, "text/plain"));
       request.setMethod(HttpMethod.POST);
+      request.setUrl("theurl");
 
       // when
       ClassicHttpRequest httpRequest = ApacheRequestFactory.get().createHttpRequest(request);

--- a/connectors/http/http-base/src/test/java/io/camunda/connector/http/base/client/apache/CustomApacheHttpClientTest.java
+++ b/connectors/http/http-base/src/test/java/io/camunda/connector/http/base/client/apache/CustomApacheHttpClientTest.java
@@ -232,6 +232,24 @@ public class CustomApacheHttpClientTest {
       assertThat(result).isNotNull();
       assertThat(result.status()).isEqualTo(200);
     }
+
+    @ParameterizedTest
+    @EnumSource(HttpMethod.class)
+    public void shouldReturn200_whenEscapedSpaceInPathAndQueryParametersInPath(
+        HttpMethod method, WireMockRuntimeInfo wmRuntimeInfo) {
+      stubFor(
+          any(urlEqualTo("/path%20with%20spaces?andQuery=Param%20with%20space"))
+              .withQueryParams(Map.of("andQuery", equalTo("Param with space")))
+              .willReturn(ok()));
+
+      HttpCommonRequest request = new HttpCommonRequest();
+      request.setMethod(method);
+      request.setUrl(
+          getHostAndPort(wmRuntimeInfo) + "/path%20with%20spaces?andQuery=Param with space");
+      HttpCommonResult result = customApacheHttpClient.execute(request);
+      assertThat(result).isNotNull();
+      assertThat(result.status()).isEqualTo(200);
+    }
   }
 
   @Nested


### PR DESCRIPTION
## Description

- Decode the URL before encoding it, to avoid double encoding if the provided URL was already encoded (that's a lot of encoding/decoding)
- Fix some potential issues with contentType headers cases (multipart, and formencoded).

## Related issues

closes https://github.com/camunda/team-connectors/issues/840

