### PR TITLE
chore(soap): Send response body when a Fault is received

### DIFF
--- a/connectors-e2e-test/connectors-e2e-test-soap/src/test/java/io/camunda/connector/e2e/soap/SoapConnectorTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-soap/src/test/java/io/camunda/connector/e2e/soap/SoapConnectorTests.java
@@ -20,6 +20,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathMatching;
 import static io.camunda.zeebe.process.test.assertions.BpmnAssert.assertThat;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder;
 import com.github.tomakehurst.wiremock.client.WireMock;
 import io.camunda.connector.e2e.ElementTemplate;
@@ -46,6 +47,53 @@ import org.springframework.boot.test.context.SpringBootTest;
 public class SoapConnectorTests extends SoapConnectorBaseTest {
 
   @Test
+  public void faultResponse() throws JsonProcessingException {
+    wm.stubFor(
+        post(urlPathMatching("/soapservice/service"))
+            .withRequestBody(WireMock.equalToXml(NUMBER_OF_WORDS_REQUEST))
+            .willReturn(
+                new ResponseDefinitionBuilder()
+                    .withStatus(500)
+                    .withHeader("Content-Type", "text/xml")
+                    .withBody(NUMBER_OF_WORDS_ERROR_RESPONSE)));
+
+    var elementTemplate =
+        ElementTemplate.from(ELEMENT_TEMPLATE_PATH)
+            .property("serviceUrl", "http://localhost:" + wm.getPort() + "/soapservice/service")
+            .property("authentication.authentication", "none")
+            .property("soapVersion.version", "1.1")
+            .property("header.type", "none")
+            .property("body.type", "json")
+            .property("body.json", "={\"ns:NumberToWords\":{\"ns:ubiNum\": 500}}")
+            .property("namespaces", "={\"ns\":\"http://www.dataaccess.com/webservicesserver/\"}")
+            .property(
+                "errorExpression",
+                "if error.code=\"SOAP_FAULT_RECEIVED\" then bpmnError(\"Code\", \"The code\", error.variables) else null")
+            .writeTo(new File(tempDir, "template.json"));
+
+    ZeebeTest bpmnTest = setupTestWithBpmnModel("soapSimpleRequest", elementTemplate);
+
+    assertThat(bpmnTest.getProcessInstanceEvent())
+        .hasVariableWithValue("soapVersion", Map.of("version", "1.1"));
+    Map<String, Object> expectedResult =
+        Map.of(
+            "Envelope",
+            Map.of(
+                "Body",
+                Map.of(
+                    "Fault",
+                    Map.of(
+                        "faultcode",
+                        "soap:Server",
+                        "faultstring",
+                        "Server was unable to process request. Object reference not set to an instance of an object.",
+                        "detail",
+                        Map.of(
+                            "error", "Object reference not set to an instance of an object.")))));
+    assertThat(bpmnTest.getProcessInstanceEvent()).hasVariableWithValue("response", expectedResult);
+  }
+
+  @Test
   void noAuthSimpleRequest() {
     wm.stubFor(
         post(urlPathMatching("/soapservice/service"))
@@ -61,12 +109,20 @@ public class SoapConnectorTests extends SoapConnectorBaseTest {
             .property("body.type", "json")
             .property("body.json", "={\"ns:NumberToWords\":{\"ns:ubiNum\": 500}}")
             .property("namespaces", "={\"ns\":\"http://www.dataaccess.com/webservicesserver/\"}")
+            .property("resultVariable", "res")
             .writeTo(new File(tempDir, "template.json"));
 
     ZeebeTest bpmnTest = setupTestWithBpmnModel("soapSimpleRequest", elementTemplate);
 
     assertThat(bpmnTest.getProcessInstanceEvent())
         .hasVariableWithValue("soapVersion", Map.of("version", "1.1"));
+    Map<String, Object> expectedResult =
+        Map.of(
+            "Envelope",
+            Map.of(
+                "Body",
+                Map.of("NumberToWordsResponse", Map.of("NumberToWordsResult", "five hundred "))));
+    assertThat(bpmnTest.getProcessInstanceEvent()).hasVariableWithValue("res", expectedResult);
   }
 
   @Test
@@ -88,11 +144,19 @@ public class SoapConnectorTests extends SoapConnectorBaseTest {
                 "<ns:NumberToWords><ns:ubiNum>{{number}}</ns:ubiNum></ns:NumberToWords>")
             .property("body.context", "={number: 500}")
             .property("namespaces", "={\"ns\":\"http://www.dataaccess.com/webservicesserver/\"}")
+            .property("resultVariable", "res")
             .writeTo(new File(tempDir, "template.json"));
 
     ZeebeTest bpmnTest = setupTestWithBpmnModel("soapSimpleRequest", elementTemplate);
 
     assertThat(bpmnTest.getProcessInstanceEvent())
         .hasVariableWithValue("soapVersion", Map.of("version", "1.1"));
+    Map<String, Object> expectedResult =
+        Map.of(
+            "Envelope",
+            Map.of(
+                "Body",
+                Map.of("NumberToWordsResponse", Map.of("NumberToWordsResult", "five hundred "))));
+    assertThat(bpmnTest.getProcessInstanceEvent()).hasVariableWithValue("res", expectedResult);
   }
 }

--- a/connectors/soap/src/main/java/io/camunda/connectors/soap/SoapConnector.java
+++ b/connectors/soap/src/main/java/io/camunda/connectors/soap/SoapConnector.java
@@ -8,6 +8,7 @@ package io.camunda.connectors.soap;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import io.camunda.connector.api.annotation.OutboundConnector;
+import io.camunda.connector.api.error.ConnectorExceptionBuilder;
 import io.camunda.connector.api.outbound.OutboundConnectorContext;
 import io.camunda.connector.api.outbound.OutboundConnectorFunction;
 import io.camunda.connector.generator.java.annotation.ElementTemplate;
@@ -17,6 +18,7 @@ import io.camunda.connectors.soap.client.SpringSoapClient;
 import io.camunda.connectors.soap.message.SoapMessageHandler;
 import io.camunda.connectors.soap.xml.Mapper;
 import io.camunda.connectors.soap.xml.XmlUtilities;
+import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.ws.FaultAwareWebServiceMessage;
@@ -69,14 +71,6 @@ public class SoapConnector implements OutboundConnectorFunction {
     return context.bindVariables(SoapConnectorInput.class);
   }
 
-  protected Object handleResult(JsonNode response) {
-    return response;
-  }
-
-  protected Exception handleException(SoapConnectorException e) {
-    return e;
-  }
-
   @Override
   public Object execute(OutboundConnectorContext context) throws Exception {
     SoapConnectorInput input = getInput(context);
@@ -98,19 +92,23 @@ public class SoapConnector implements OutboundConnectorFunction {
               .build()
               .toJson(XmlUtilities.xmlStringToDocument(soapResponseMessage));
       LOG.debug("Response to connector runtime: \n{}", response.toPrettyString());
-      return handleResult(response);
+      return response;
     } catch (WebServiceException e) {
       if (e instanceof SoapFaultClientException soapFaultClientException) {
         FaultAwareWebServiceMessage webServiceMessage =
             soapFaultClientException.getWebServiceMessage();
         if (webServiceMessage instanceof SoapMessage soapMessage) {
-          throw handleException(
-              new SoapConnectorException(
-                  e,
-                  Mapper.toJson()
-                      .withPreserveNamespaces(false)
-                      .build()
-                      .toJson(soapMessage.getDocument())));
+          throw new ConnectorExceptionBuilder()
+              .message("SOAP Fault received")
+              .errorCode("SOAP_FAULT_RECEIVED")
+              .errorVariables(
+                  Map.of(
+                      "response",
+                      Mapper.toJson()
+                          .withPreserveNamespaces(false)
+                          .build()
+                          .toJson(soapMessage.getDocument())))
+              .build();
         }
       }
       throw e;


### PR DESCRIPTION
## Description
- Send the response body in case of a Fault 
- Some tests improvements

The body is accessible using this kind of `errorExpression`:
`if error.code="SOAP_FAULT_RECEIVED" then bpmnError("Code", "The code", error.variables) else null`

## Related issues

closes #2743 

