### PR TITLE
fix(github-connector): Issue number can now be either a String or an Int

### DIFF
--- a/connectors/github/element-templates/github-connector.json
+++ b/connectors/github/element-templates/github-connector.json
@@ -2781,7 +2781,7 @@
     },
     {
       "type": "Hidden",
-      "value": "=baseUrl + \"/repos/\" + owner + \"/\" + repo + \"/issues/\" + issueNumber",
+      "value": "=baseUrl + \"/repos/\" + owner + \"/\" + repo + \"/issues/\" + string(issueNumber)",
       "binding": {
         "type": "zeebe:input",
         "name": "url"
@@ -2796,7 +2796,7 @@
     },
     {
       "type": "Hidden",
-      "value": "=baseUrl + \"/repos/\" + owner + \"/\" + repo + \"/issues/\" + issueNumber + \"/comments\"",
+      "value": "=baseUrl + \"/repos/\" + owner + \"/\" + repo + \"/issues/\" + string(issueNumber) + \"/comments\"",
       "binding": {
         "type": "zeebe:input",
         "name": "url"


### PR DESCRIPTION
## Description

- Wrap `issueNumber` into a string 

## Related issues

closes https://github.com/camunda/team-connectors/issues/827

