### PR TITLE
fix(inbound-message-ttl): Set the message TTL to 1 hour by default

### DIFF
--- a/bundle/camunda-saas-bundle/src/main/resources/application.properties
+++ b/bundle/camunda-saas-bundle/src/main/resources/application.properties
@@ -25,5 +25,9 @@ connectors.log.appender=stackdriver
 # For specifying the size of inbound connectors activity log
 camunda.connector.inbound.log.size=10
 
+# For specifying the default time-to-live of inbound connectors messages
+# Default is 1h and can be overridden by the connector configuration
+#camunda.connector.inbound.message.ttl=PT1H
+
 # Disabling the default Operate client, we are configuring our own
 camunda.client.operate.enabled=false

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/correlation/InboundCorrelationHandler.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/correlation/InboundCorrelationHandler.java
@@ -100,16 +100,15 @@ public class InboundCorrelationHandler {
     var correlationPoint = activatedElement.correlationPoint();
 
     return switch (correlationPoint) {
-      case StartEventCorrelationPoint corPoint ->
-          triggerStartEvent(activatedElement, corPoint, variables);
-      case MessageCorrelationPoint corPoint ->
-          triggerMessage(
-              activatedElement,
-              corPoint,
-              variables,
-              resolveMessageId(corPoint.messageIdExpression(), messageId, variables));
-      case MessageStartEventCorrelationPoint corPoint ->
-          triggerMessageStartEvent(activatedElement, corPoint, variables);
+      case StartEventCorrelationPoint corPoint -> triggerStartEvent(
+          activatedElement, corPoint, variables);
+      case MessageCorrelationPoint corPoint -> triggerMessage(
+          activatedElement,
+          corPoint,
+          variables,
+          resolveMessageId(corPoint.messageIdExpression(), messageId, variables));
+      case MessageStartEventCorrelationPoint corPoint -> triggerMessageStartEvent(
+          activatedElement, corPoint, variables);
     };
   }
 

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/InboundConnectorRuntimeConfiguration.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/InboundConnectorRuntimeConfiguration.java
@@ -41,7 +41,9 @@ import io.camunda.connector.runtime.inbound.webhook.WebhookConnectorRegistry;
 import io.camunda.operate.CamundaOperateClient;
 import io.camunda.zeebe.client.ZeebeClient;
 import io.camunda.zeebe.spring.client.metrics.MetricsRecorder;
+import java.time.Duration;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.beans.factory.config.ConfigurableBeanFactory;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -54,6 +56,8 @@ import org.springframework.context.annotation.Import;
   InboundConnectorRestController.class
 })
 public class InboundConnectorRuntimeConfiguration {
+  @Value("${camunda.connector.inbound.message.ttl:PT1H}")
+  private Duration messageTtl;
 
   @Bean
   public ProcessElementContextFactory processElementContextFactory(
@@ -71,7 +75,7 @@ public class InboundConnectorRuntimeConfiguration {
       final MetricsRecorder metricsRecorder,
       final ProcessElementContextFactory elementContextFactory) {
     return new MeteredInboundCorrelationHandler(
-        zeebeClient, feelEngine, metricsRecorder, elementContextFactory);
+        zeebeClient, feelEngine, metricsRecorder, elementContextFactory, messageTtl);
   }
 
   @Bean

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/MeteredInboundCorrelationHandler.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/MeteredInboundCorrelationHandler.java
@@ -24,6 +24,7 @@ import io.camunda.connector.runtime.core.inbound.correlation.InboundCorrelationH
 import io.camunda.connector.runtime.metrics.ConnectorMetrics.Inbound;
 import io.camunda.zeebe.client.ZeebeClient;
 import io.camunda.zeebe.spring.client.metrics.MetricsRecorder;
+import java.time.Duration;
 import java.util.List;
 
 public class MeteredInboundCorrelationHandler extends InboundCorrelationHandler {
@@ -34,8 +35,9 @@ public class MeteredInboundCorrelationHandler extends InboundCorrelationHandler 
       ZeebeClient zeebeClient,
       FeelEngineWrapper feelEngine,
       MetricsRecorder metricsRecorder,
-      ProcessElementContextFactory contextFactory) {
-    super(zeebeClient, feelEngine, contextFactory);
+      ProcessElementContextFactory contextFactory,
+      Duration messageTtl) {
+    super(zeebeClient, feelEngine, contextFactory, messageTtl);
     this.metricsRecorder = metricsRecorder;
   }
 

--- a/connectors/aws/aws-sns/element-templates/aws-sns-inbound-boundary.json
+++ b/connectors/aws/aws-sns/element-templates/aws-sns-inbound-boundary.json
@@ -141,12 +141,11 @@
     "id" : "messageTtl",
     "label" : "Message TTL",
     "description" : "Time-to-live for the message in the broker (ISO-8601 duration)",
-    "optional" : false,
-    "value" : "PT0S",
+    "optional" : true,
     "constraints" : {
-      "notEmpty" : true,
+      "notEmpty" : false,
       "pattern" : {
-        "value" : "P.*",
+        "value" : "^(PT.*|)$",
         "message" : "must be an ISO-8601 duration"
       }
     },

--- a/connectors/aws/aws-sns/element-templates/aws-sns-inbound-intermediate.json
+++ b/connectors/aws/aws-sns/element-templates/aws-sns-inbound-intermediate.json
@@ -141,12 +141,11 @@
     "id" : "messageTtl",
     "label" : "Message TTL",
     "description" : "Time-to-live for the message in the broker (ISO-8601 duration)",
-    "optional" : false,
-    "value" : "PT0S",
+    "optional" : true,
     "constraints" : {
-      "notEmpty" : true,
+      "notEmpty" : false,
       "pattern" : {
-        "value" : "P.*",
+        "value" : "^(PT.*|)$",
         "message" : "must be an ISO-8601 duration"
       }
     },

--- a/connectors/aws/aws-sns/element-templates/aws-sns-inbound-message-start.json
+++ b/connectors/aws/aws-sns/element-templates/aws-sns-inbound-message-start.json
@@ -157,12 +157,11 @@
     "id" : "messageTtl",
     "label" : "Message TTL",
     "description" : "Time-to-live for the message in the broker (ISO-8601 duration)",
-    "optional" : false,
-    "value" : "PT0S",
+    "optional" : true,
     "constraints" : {
-      "notEmpty" : true,
+      "notEmpty" : false,
       "pattern" : {
-        "value" : "P.*",
+        "value" : "^(PT.*|)$",
         "message" : "must be an ISO-8601 duration"
       }
     },

--- a/connectors/aws/aws-sns/element-templates/hybrid/aws-sns-inbound-boundary-hybrid.json
+++ b/connectors/aws/aws-sns/element-templates/hybrid/aws-sns-inbound-boundary-hybrid.json
@@ -146,12 +146,11 @@
     "id" : "messageTtl",
     "label" : "Message TTL",
     "description" : "Time-to-live for the message in the broker (ISO-8601 duration)",
-    "optional" : false,
-    "value" : "PT0S",
+    "optional" : true,
     "constraints" : {
-      "notEmpty" : true,
+      "notEmpty" : false,
       "pattern" : {
-        "value" : "P.*",
+        "value" : "^(PT.*|)$",
         "message" : "must be an ISO-8601 duration"
       }
     },

--- a/connectors/aws/aws-sns/element-templates/hybrid/aws-sns-inbound-intermediate-hybrid.json
+++ b/connectors/aws/aws-sns/element-templates/hybrid/aws-sns-inbound-intermediate-hybrid.json
@@ -146,12 +146,11 @@
     "id" : "messageTtl",
     "label" : "Message TTL",
     "description" : "Time-to-live for the message in the broker (ISO-8601 duration)",
-    "optional" : false,
-    "value" : "PT0S",
+    "optional" : true,
     "constraints" : {
-      "notEmpty" : true,
+      "notEmpty" : false,
       "pattern" : {
-        "value" : "P.*",
+        "value" : "^(PT.*|)$",
         "message" : "must be an ISO-8601 duration"
       }
     },

--- a/connectors/aws/aws-sns/element-templates/hybrid/aws-sns-inbound-message-start-hybrid.json
+++ b/connectors/aws/aws-sns/element-templates/hybrid/aws-sns-inbound-message-start-hybrid.json
@@ -162,12 +162,11 @@
     "id" : "messageTtl",
     "label" : "Message TTL",
     "description" : "Time-to-live for the message in the broker (ISO-8601 duration)",
-    "optional" : false,
-    "value" : "PT0S",
+    "optional" : true,
     "constraints" : {
-      "notEmpty" : true,
+      "notEmpty" : false,
       "pattern" : {
-        "value" : "P.*",
+        "value" : "^(PT.*|)$",
         "message" : "must be an ISO-8601 duration"
       }
     },

--- a/connectors/aws/aws-sqs/element-templates/aws-sqs-boundary-connector.json
+++ b/connectors/aws/aws-sqs/element-templates/aws-sqs-boundary-connector.json
@@ -255,12 +255,11 @@
     "id" : "messageTtl",
     "label" : "Message TTL",
     "description" : "Time-to-live for the message in the broker (ISO-8601 duration)",
-    "optional" : false,
-    "value" : "PT0S",
+    "optional" : true,
     "constraints" : {
-      "notEmpty" : true,
+      "notEmpty" : false,
       "pattern" : {
-        "value" : "P.*",
+        "value" : "^(PT.*|)$",
         "message" : "must be an ISO-8601 duration"
       }
     },

--- a/connectors/aws/aws-sqs/element-templates/aws-sqs-inbound-intermediate-connector.json
+++ b/connectors/aws/aws-sqs/element-templates/aws-sqs-inbound-intermediate-connector.json
@@ -255,12 +255,11 @@
     "id" : "messageTtl",
     "label" : "Message TTL",
     "description" : "Time-to-live for the message in the broker (ISO-8601 duration)",
-    "optional" : false,
-    "value" : "PT0S",
+    "optional" : true,
     "constraints" : {
-      "notEmpty" : true,
+      "notEmpty" : false,
       "pattern" : {
-        "value" : "P.*",
+        "value" : "^(PT.*|)$",
         "message" : "must be an ISO-8601 duration"
       }
     },

--- a/connectors/aws/aws-sqs/element-templates/aws-sqs-start-message.json
+++ b/connectors/aws/aws-sqs/element-templates/aws-sqs-start-message.json
@@ -271,12 +271,11 @@
     "id" : "messageTtl",
     "label" : "Message TTL",
     "description" : "Time-to-live for the message in the broker (ISO-8601 duration)",
-    "optional" : false,
-    "value" : "PT0S",
+    "optional" : true,
     "constraints" : {
-      "notEmpty" : true,
+      "notEmpty" : false,
       "pattern" : {
-        "value" : "P.*",
+        "value" : "^(PT.*|)$",
         "message" : "must be an ISO-8601 duration"
       }
     },

--- a/connectors/create-element-templates-symlinks.sh
+++ b/connectors/create-element-templates-symlinks.sh
@@ -20,7 +20,7 @@ echo -e "${BLUE}Starting to copy element templates to ~/Library/Application\ Sup
 # Find all .json files in element-templates directories and copy them to /tmp/json
 find . -type d -name "element-templates" | while read -r dir; do
   echo -e "${YELLOW}Creating symlink for [$dir]${NC}"
-  find "$dir" -type f -name "*.json" | while read -r file; do
+  find "$dir" -type f -name "*.json" | grep -v "hybrid" | while read -r file; do
     dest_dir=~/Library/Application\ Support/camunda-modeler/resources/element-templates/
     dest_file="$dest_dir$(basename "$file")"
     # Remove the existing symlink if it exists

--- a/connectors/kafka/element-templates/hybrid/kafka-inbound-connector-boundary-hybrid.json
+++ b/connectors/kafka/element-templates/hybrid/kafka-inbound-connector-boundary-hybrid.json
@@ -288,12 +288,11 @@
     "id" : "messageTtl",
     "label" : "Message TTL",
     "description" : "Time-to-live for the message in the broker (ISO-8601 duration)",
-    "optional" : false,
-    "value" : "PT0S",
+    "optional" : true,
     "constraints" : {
-      "notEmpty" : true,
+      "notEmpty" : false,
       "pattern" : {
-        "value" : "P.*",
+        "value" : "^(PT.*|)$",
         "message" : "must be an ISO-8601 duration"
       }
     },

--- a/connectors/kafka/element-templates/hybrid/kafka-inbound-connector-intermediate-hybrid.json
+++ b/connectors/kafka/element-templates/hybrid/kafka-inbound-connector-intermediate-hybrid.json
@@ -288,12 +288,11 @@
     "id" : "messageTtl",
     "label" : "Message TTL",
     "description" : "Time-to-live for the message in the broker (ISO-8601 duration)",
-    "optional" : false,
-    "value" : "PT0S",
+    "optional" : true,
     "constraints" : {
-      "notEmpty" : true,
+      "notEmpty" : false,
       "pattern" : {
-        "value" : "P.*",
+        "value" : "^(PT.*|)$",
         "message" : "must be an ISO-8601 duration"
       }
     },

--- a/connectors/kafka/element-templates/hybrid/kafka-inbound-connector-start-message-hybrid.json
+++ b/connectors/kafka/element-templates/hybrid/kafka-inbound-connector-start-message-hybrid.json
@@ -304,12 +304,11 @@
     "id" : "messageTtl",
     "label" : "Message TTL",
     "description" : "Time-to-live for the message in the broker (ISO-8601 duration)",
-    "optional" : false,
-    "value" : "PT0S",
+    "optional" : true,
     "constraints" : {
-      "notEmpty" : true,
+      "notEmpty" : false,
       "pattern" : {
-        "value" : "P.*",
+        "value" : "^(PT.*|)$",
         "message" : "must be an ISO-8601 duration"
       }
     },

--- a/connectors/kafka/element-templates/kafka-inbound-connector-boundary.json
+++ b/connectors/kafka/element-templates/kafka-inbound-connector-boundary.json
@@ -283,12 +283,11 @@
     "id" : "messageTtl",
     "label" : "Message TTL",
     "description" : "Time-to-live for the message in the broker (ISO-8601 duration)",
-    "optional" : false,
-    "value" : "PT0S",
+    "optional" : true,
     "constraints" : {
-      "notEmpty" : true,
+      "notEmpty" : false,
       "pattern" : {
-        "value" : "P.*",
+        "value" : "^(PT.*|)$",
         "message" : "must be an ISO-8601 duration"
       }
     },

--- a/connectors/kafka/element-templates/kafka-inbound-connector-intermediate.json
+++ b/connectors/kafka/element-templates/kafka-inbound-connector-intermediate.json
@@ -283,12 +283,11 @@
     "id" : "messageTtl",
     "label" : "Message TTL",
     "description" : "Time-to-live for the message in the broker (ISO-8601 duration)",
-    "optional" : false,
-    "value" : "PT0S",
+    "optional" : true,
     "constraints" : {
-      "notEmpty" : true,
+      "notEmpty" : false,
       "pattern" : {
-        "value" : "P.*",
+        "value" : "^(PT.*|)$",
         "message" : "must be an ISO-8601 duration"
       }
     },

--- a/connectors/kafka/element-templates/kafka-inbound-connector-start-message.json
+++ b/connectors/kafka/element-templates/kafka-inbound-connector-start-message.json
@@ -299,12 +299,11 @@
     "id" : "messageTtl",
     "label" : "Message TTL",
     "description" : "Time-to-live for the message in the broker (ISO-8601 duration)",
-    "optional" : false,
-    "value" : "PT0S",
+    "optional" : true,
     "constraints" : {
-      "notEmpty" : true,
+      "notEmpty" : false,
       "pattern" : {
-        "value" : "P.*",
+        "value" : "^(PT.*|)$",
         "message" : "must be an ISO-8601 duration"
       }
     },

--- a/connectors/rabbitmq/element-templates/hybrid/rabbitmq-inbound-connector-boundary-hybrid.json
+++ b/connectors/rabbitmq/element-templates/hybrid/rabbitmq-inbound-connector-boundary-hybrid.json
@@ -305,12 +305,11 @@
     "id" : "messageTtl",
     "label" : "Message TTL",
     "description" : "Time-to-live for the message in the broker (ISO-8601 duration)",
-    "optional" : false,
-    "value" : "PT0S",
+    "optional" : true,
     "constraints" : {
-      "notEmpty" : true,
+      "notEmpty" : false,
       "pattern" : {
-        "value" : "P.*",
+        "value" : "^(PT.*|)$",
         "message" : "must be an ISO-8601 duration"
       }
     },

--- a/connectors/rabbitmq/element-templates/hybrid/rabbitmq-inbound-connector-intermediate-hybrid.json
+++ b/connectors/rabbitmq/element-templates/hybrid/rabbitmq-inbound-connector-intermediate-hybrid.json
@@ -305,12 +305,11 @@
     "id" : "messageTtl",
     "label" : "Message TTL",
     "description" : "Time-to-live for the message in the broker (ISO-8601 duration)",
-    "optional" : false,
-    "value" : "PT0S",
+    "optional" : true,
     "constraints" : {
-      "notEmpty" : true,
+      "notEmpty" : false,
       "pattern" : {
-        "value" : "P.*",
+        "value" : "^(PT.*|)$",
         "message" : "must be an ISO-8601 duration"
       }
     },

--- a/connectors/rabbitmq/element-templates/hybrid/rabbitmq-inbound-connector-message-start-hybrid.json
+++ b/connectors/rabbitmq/element-templates/hybrid/rabbitmq-inbound-connector-message-start-hybrid.json
@@ -321,12 +321,11 @@
     "id" : "messageTtl",
     "label" : "Message TTL",
     "description" : "Time-to-live for the message in the broker (ISO-8601 duration)",
-    "optional" : false,
-    "value" : "PT0S",
+    "optional" : true,
     "constraints" : {
-      "notEmpty" : true,
+      "notEmpty" : false,
       "pattern" : {
-        "value" : "P.*",
+        "value" : "^(PT.*|)$",
         "message" : "must be an ISO-8601 duration"
       }
     },

--- a/connectors/rabbitmq/element-templates/rabbitmq-inbound-connector-boundary.json
+++ b/connectors/rabbitmq/element-templates/rabbitmq-inbound-connector-boundary.json
@@ -300,12 +300,11 @@
     "id" : "messageTtl",
     "label" : "Message TTL",
     "description" : "Time-to-live for the message in the broker (ISO-8601 duration)",
-    "optional" : false,
-    "value" : "PT0S",
+    "optional" : true,
     "constraints" : {
-      "notEmpty" : true,
+      "notEmpty" : false,
       "pattern" : {
-        "value" : "P.*",
+        "value" : "^(PT.*|)$",
         "message" : "must be an ISO-8601 duration"
       }
     },

--- a/connectors/rabbitmq/element-templates/rabbitmq-inbound-connector-intermediate.json
+++ b/connectors/rabbitmq/element-templates/rabbitmq-inbound-connector-intermediate.json
@@ -300,12 +300,11 @@
     "id" : "messageTtl",
     "label" : "Message TTL",
     "description" : "Time-to-live for the message in the broker (ISO-8601 duration)",
-    "optional" : false,
-    "value" : "PT0S",
+    "optional" : true,
     "constraints" : {
-      "notEmpty" : true,
+      "notEmpty" : false,
       "pattern" : {
-        "value" : "P.*",
+        "value" : "^(PT.*|)$",
         "message" : "must be an ISO-8601 duration"
       }
     },

--- a/connectors/rabbitmq/element-templates/rabbitmq-inbound-connector-message-start.json
+++ b/connectors/rabbitmq/element-templates/rabbitmq-inbound-connector-message-start.json
@@ -316,12 +316,11 @@
     "id" : "messageTtl",
     "label" : "Message TTL",
     "description" : "Time-to-live for the message in the broker (ISO-8601 duration)",
-    "optional" : false,
-    "value" : "PT0S",
+    "optional" : true,
     "constraints" : {
-      "notEmpty" : true,
+      "notEmpty" : false,
       "pattern" : {
-        "value" : "P.*",
+        "value" : "^(PT.*|)$",
         "message" : "must be an ISO-8601 duration"
       }
     },

--- a/connectors/slack/element-templates/hybrid/slack-inbound-boundary-hybrid.json
+++ b/connectors/slack/element-templates/hybrid/slack-inbound-boundary-hybrid.json
@@ -135,12 +135,11 @@
     "id" : "messageTtl",
     "label" : "Message TTL",
     "description" : "Time-to-live for the message in the broker (ISO-8601 duration)",
-    "optional" : false,
-    "value" : "PT0S",
+    "optional" : true,
     "constraints" : {
-      "notEmpty" : true,
+      "notEmpty" : false,
       "pattern" : {
-        "value" : "P.*",
+        "value" : "^(PT.*|)$",
         "message" : "must be an ISO-8601 duration"
       }
     },

--- a/connectors/slack/element-templates/hybrid/slack-inbound-intermediate-hybrid.json
+++ b/connectors/slack/element-templates/hybrid/slack-inbound-intermediate-hybrid.json
@@ -135,12 +135,11 @@
     "id" : "messageTtl",
     "label" : "Message TTL",
     "description" : "Time-to-live for the message in the broker (ISO-8601 duration)",
-    "optional" : false,
-    "value" : "PT0S",
+    "optional" : true,
     "constraints" : {
-      "notEmpty" : true,
+      "notEmpty" : false,
       "pattern" : {
-        "value" : "P.*",
+        "value" : "^(PT.*|)$",
         "message" : "must be an ISO-8601 duration"
       }
     },

--- a/connectors/slack/element-templates/hybrid/slack-inbound-message-start-hybrid.json
+++ b/connectors/slack/element-templates/hybrid/slack-inbound-message-start-hybrid.json
@@ -151,12 +151,11 @@
     "id" : "messageTtl",
     "label" : "Message TTL",
     "description" : "Time-to-live for the message in the broker (ISO-8601 duration)",
-    "optional" : false,
-    "value" : "PT0S",
+    "optional" : true,
     "constraints" : {
-      "notEmpty" : true,
+      "notEmpty" : false,
       "pattern" : {
-        "value" : "P.*",
+        "value" : "^(PT.*|)$",
         "message" : "must be an ISO-8601 duration"
       }
     },

--- a/connectors/slack/element-templates/slack-inbound-boundary.json
+++ b/connectors/slack/element-templates/slack-inbound-boundary.json
@@ -130,12 +130,11 @@
     "id" : "messageTtl",
     "label" : "Message TTL",
     "description" : "Time-to-live for the message in the broker (ISO-8601 duration)",
-    "optional" : false,
-    "value" : "PT0S",
+    "optional" : true,
     "constraints" : {
-      "notEmpty" : true,
+      "notEmpty" : false,
       "pattern" : {
-        "value" : "P.*",
+        "value" : "^(PT.*|)$",
         "message" : "must be an ISO-8601 duration"
       }
     },

--- a/connectors/slack/element-templates/slack-inbound-intermediate.json
+++ b/connectors/slack/element-templates/slack-inbound-intermediate.json
@@ -130,12 +130,11 @@
     "id" : "messageTtl",
     "label" : "Message TTL",
     "description" : "Time-to-live for the message in the broker (ISO-8601 duration)",
-    "optional" : false,
-    "value" : "PT0S",
+    "optional" : true,
     "constraints" : {
-      "notEmpty" : true,
+      "notEmpty" : false,
       "pattern" : {
-        "value" : "P.*",
+        "value" : "^(PT.*|)$",
         "message" : "must be an ISO-8601 duration"
       }
     },

--- a/connectors/slack/element-templates/slack-inbound-message-start.json
+++ b/connectors/slack/element-templates/slack-inbound-message-start.json
@@ -146,12 +146,11 @@
     "id" : "messageTtl",
     "label" : "Message TTL",
     "description" : "Time-to-live for the message in the broker (ISO-8601 duration)",
-    "optional" : false,
-    "value" : "PT0S",
+    "optional" : true,
     "constraints" : {
-      "notEmpty" : true,
+      "notEmpty" : false,
       "pattern" : {
-        "value" : "P.*",
+        "value" : "^(PT.*|)$",
         "message" : "must be an ISO-8601 duration"
       }
     },

--- a/connectors/webhook/element-templates/hybrid/webhook-connector-boundary-hybrid.json
+++ b/connectors/webhook/element-templates/hybrid/webhook-connector-boundary-hybrid.json
@@ -430,12 +430,11 @@
     "id" : "messageTtl",
     "label" : "Message TTL",
     "description" : "Time-to-live for the message in the broker (ISO-8601 duration)",
-    "optional" : false,
-    "value" : "PT0S",
+    "optional" : true,
     "constraints" : {
-      "notEmpty" : true,
+      "notEmpty" : false,
       "pattern" : {
-        "value" : "P.*",
+        "value" : "^(PT.*|)$",
         "message" : "must be an ISO-8601 duration"
       }
     },

--- a/connectors/webhook/element-templates/hybrid/webhook-connector-intermediate-hybrid.json
+++ b/connectors/webhook/element-templates/hybrid/webhook-connector-intermediate-hybrid.json
@@ -430,12 +430,11 @@
     "id" : "messageTtl",
     "label" : "Message TTL",
     "description" : "Time-to-live for the message in the broker (ISO-8601 duration)",
-    "optional" : false,
-    "value" : "PT0S",
+    "optional" : true,
     "constraints" : {
-      "notEmpty" : true,
+      "notEmpty" : false,
       "pattern" : {
-        "value" : "P.*",
+        "value" : "^(PT.*|)$",
         "message" : "must be an ISO-8601 duration"
       }
     },

--- a/connectors/webhook/element-templates/hybrid/webhook-connector-start-message-hybrid.json
+++ b/connectors/webhook/element-templates/hybrid/webhook-connector-start-message-hybrid.json
@@ -446,12 +446,11 @@
     "id" : "messageTtl",
     "label" : "Message TTL",
     "description" : "Time-to-live for the message in the broker (ISO-8601 duration)",
-    "optional" : false,
-    "value" : "PT0S",
+    "optional" : true,
     "constraints" : {
-      "notEmpty" : true,
+      "notEmpty" : false,
       "pattern" : {
-        "value" : "P.*",
+        "value" : "^(PT.*|)$",
         "message" : "must be an ISO-8601 duration"
       }
     },

--- a/connectors/webhook/element-templates/webhook-connector-boundary.json
+++ b/connectors/webhook/element-templates/webhook-connector-boundary.json
@@ -425,12 +425,11 @@
     "id" : "messageTtl",
     "label" : "Message TTL",
     "description" : "Time-to-live for the message in the broker (ISO-8601 duration)",
-    "optional" : false,
-    "value" : "PT0S",
+    "optional" : true,
     "constraints" : {
-      "notEmpty" : true,
+      "notEmpty" : false,
       "pattern" : {
-        "value" : "P.*",
+        "value" : "^(PT.*|)$",
         "message" : "must be an ISO-8601 duration"
       }
     },

--- a/connectors/webhook/element-templates/webhook-connector-intermediate.json
+++ b/connectors/webhook/element-templates/webhook-connector-intermediate.json
@@ -425,12 +425,11 @@
     "id" : "messageTtl",
     "label" : "Message TTL",
     "description" : "Time-to-live for the message in the broker (ISO-8601 duration)",
-    "optional" : false,
-    "value" : "PT0S",
+    "optional" : true,
     "constraints" : {
-      "notEmpty" : true,
+      "notEmpty" : false,
       "pattern" : {
-        "value" : "P.*",
+        "value" : "^(PT.*|)$",
         "message" : "must be an ISO-8601 duration"
       }
     },

--- a/connectors/webhook/element-templates/webhook-connector-start-message.json
+++ b/connectors/webhook/element-templates/webhook-connector-start-message.json
@@ -441,12 +441,11 @@
     "id" : "messageTtl",
     "label" : "Message TTL",
     "description" : "Time-to-live for the message in the broker (ISO-8601 duration)",
-    "optional" : false,
-    "value" : "PT0S",
+    "optional" : true,
     "constraints" : {
-      "notEmpty" : true,
+      "notEmpty" : false,
       "pattern" : {
-        "value" : "P.*",
+        "value" : "^(PT.*|)$",
         "message" : "must be an ISO-8601 duration"
       }
     },

--- a/element-template-generator/core/src/main/java/io/camunda/connector/generator/dsl/CommonProperties.java
+++ b/element-template-generator/core/src/main/java/io/camunda/connector/generator/dsl/CommonProperties.java
@@ -135,12 +135,11 @@ public class CommonProperties {
         .label("Message TTL")
         .description("Time-to-live for the message in the broker (ISO-8601 duration)")
         .group("correlation")
-        .optional(false)
-        .value("PT0S")
+        .optional(true)
         .constraints(
             PropertyConstraints.builder()
-                .notEmpty(true)
-                .pattern(new Pattern("P.*", "must be an ISO-8601 duration"))
+                .notEmpty(false)
+                .pattern(new Pattern("^(PT.*|)$", "must be an ISO-8601 duration"))
                 .build())
         .binding(new PropertyBinding.ZeebeProperty("messageTtl"));
   }


### PR DESCRIPTION
## Description

Message Start Event TTL can now be defined as follows, with this order of precedence (low priority to high priority):
- If no env var is provided, default will be 1H.
- If `camunda.connector.inbound.message.ttl` is provided, it will be used as the Runtime default
- `messageTtl` from the connector's configuration will be used if provided

## Related issues

closes #2736


