### PR TITLE
chore(config): add slim application.properties file to default-bundle

### DIFF
--- a/bundle/default-bundle/src/test/resources/application.properties
+++ b/bundle/default-bundle/src/test/resources/application.properties
@@ -1,0 +1,18 @@
+server.port=8080
+
+management.context-path=/actuator
+management.endpoints.web.exposure.include=metrics,health,prometheus
+management.endpoint.health.group.readiness.include[]=zeebeClient,operate
+management.endpoint.health.show-components=always
+management.endpoint.health.show-details=always
+
+zeebe.client.security.plaintext=true
+
+# Config for use with docker-compose-core.yml
+camunda.operate.client.url=http://localhost:8081
+camunda.operate.client.username=demo
+camunda.operate.client.password=demo
+
+camunda.connector.webhook.enabled=true
+
+debug=true


### PR DESCRIPTION
## Description

add application.properties to be able to run connectors locally with docker compose (using docker-compose.core.yaml). 

