### PR TITLE
fix(process-import): handle exceptions in imported process definitions explicitly

### DIFF
--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/importer/ProcessDefinitionImporter.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/importer/ProcessDefinitionImporter.java
@@ -56,7 +56,7 @@ public class ProcessDefinitionImporter {
       try {
         handleImportedDefinitions(result);
       } catch (Exception e) {
-        LOG.error("Failed to handle imported process definitions", e);
+        LOG.warn("Failed to handle imported process definitions", e);
       }
       ready = true;
     } catch (Exception e) {

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/importer/ProcessDefinitionImporter.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/importer/ProcessDefinitionImporter.java
@@ -53,7 +53,11 @@ public class ProcessDefinitionImporter {
   public synchronized void scheduleImport() {
     try {
       var result = search.query();
-      handleImportedDefinitions(result);
+      try {
+        handleImportedDefinitions(result);
+      } catch (Exception e) {
+        LOG.error("Failed to handle imported process definitions", e);
+      }
       ready = true;
     } catch (Exception e) {
       LOG.error("Failed to import process definitions", e);


### PR DESCRIPTION
## Description

Handle exceptions in imported process definitions explicitly to avoid setting the variable `ready` to false (in case of an exception in the handleImportedDefinitions), which indicates that connectors component is unhealthy. 

