### PR TITLE
other(google-sheets): add a constraint on row index

### DIFF
--- a/connectors/google/google-sheets/element-templates/google-sheets-outbound-connector.json
+++ b/connectors/google/google-sheets/element-templates/google-sheets-outbound-connector.json
@@ -447,7 +447,7 @@
       "notEmpty" : false,
       "pattern" : {
         "value" : "^(=.*|[0-9]+|)$",
-        "message" : ""
+        "message" : "Must be a number"
       }
     },
     "feel" : "optional",

--- a/connectors/google/google-sheets/element-templates/google-sheets-outbound-connector.json
+++ b/connectors/google/google-sheets/element-templates/google-sheets-outbound-connector.json
@@ -446,7 +446,7 @@
     "constraints" : {
       "notEmpty" : false,
       "pattern" : {
-        "value" : "^(=.*|[0-9].*|)$"
+        "value" : "^(=.*|[0-9]+|)$"
       }
     },
     "feel" : "optional",

--- a/connectors/google/google-sheets/element-templates/google-sheets-outbound-connector.json
+++ b/connectors/google/google-sheets/element-templates/google-sheets-outbound-connector.json
@@ -446,7 +446,8 @@
     "constraints" : {
       "notEmpty" : false,
       "pattern" : {
-        "value" : "^(=.*|[0-9]+|)$"
+        "value" : "^(=.*|[0-9]+|)$",
+        "message" : ""
       }
     },
     "feel" : "optional",

--- a/connectors/google/google-sheets/element-templates/google-sheets-outbound-connector.json
+++ b/connectors/google/google-sheets/element-templates/google-sheets-outbound-connector.json
@@ -443,6 +443,12 @@
     "label" : "Row index",
     "description" : "Enter row index. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#what-is-a-row-index\" target=\"_blank\">documentation</a>",
     "optional" : true,
+    "constraints" : {
+      "notEmpty" : false,
+      "pattern" : {
+        "value" : "^(=.*|[0-9].*|)$"
+      }
+    },
     "feel" : "optional",
     "group" : "operationDetails",
     "binding" : {

--- a/connectors/google/google-sheets/element-templates/hybrid/google-sheets-outbound-connector-hybrid.json
+++ b/connectors/google/google-sheets/element-templates/hybrid/google-sheets-outbound-connector-hybrid.json
@@ -451,7 +451,8 @@
     "constraints" : {
       "notEmpty" : false,
       "pattern" : {
-        "value" : "^(=.*|[0-9]+|)$"
+        "value" : "^(=.*|[0-9]+|)$",
+        "message" : ""
       }
     },
     "feel" : "optional",

--- a/connectors/google/google-sheets/element-templates/hybrid/google-sheets-outbound-connector-hybrid.json
+++ b/connectors/google/google-sheets/element-templates/hybrid/google-sheets-outbound-connector-hybrid.json
@@ -448,6 +448,12 @@
     "label" : "Row index",
     "description" : "Enter row index. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#what-is-a-row-index\" target=\"_blank\">documentation</a>",
     "optional" : true,
+    "constraints" : {
+      "notEmpty" : false,
+      "pattern" : {
+        "value" : "^(=.*|[0-9].*|)$"
+      }
+    },
     "feel" : "optional",
     "group" : "operationDetails",
     "binding" : {

--- a/connectors/google/google-sheets/element-templates/hybrid/google-sheets-outbound-connector-hybrid.json
+++ b/connectors/google/google-sheets/element-templates/hybrid/google-sheets-outbound-connector-hybrid.json
@@ -451,7 +451,7 @@
     "constraints" : {
       "notEmpty" : false,
       "pattern" : {
-        "value" : "^(=.*|[0-9].*|)$"
+        "value" : "^(=.*|[0-9]+|)$"
       }
     },
     "feel" : "optional",

--- a/connectors/google/google-sheets/element-templates/hybrid/google-sheets-outbound-connector-hybrid.json
+++ b/connectors/google/google-sheets/element-templates/hybrid/google-sheets-outbound-connector-hybrid.json
@@ -452,7 +452,7 @@
       "notEmpty" : false,
       "pattern" : {
         "value" : "^(=.*|[0-9]+|)$",
-        "message" : ""
+        "message" : "Must be a number"
       }
     },
     "feel" : "optional",

--- a/connectors/google/google-sheets/src/main/java/io/camunda/connector/gsheets/model/request/input/CreateRow.java
+++ b/connectors/google/google-sheets/src/main/java/io/camunda/connector/gsheets/model/request/input/CreateRow.java
@@ -13,7 +13,6 @@ import io.camunda.connector.generator.java.annotation.TemplateProperty.PropertyC
 import io.camunda.connector.generator.java.annotation.TemplateSubType;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
-import jakarta.validation.constraints.Pattern;
 import java.util.List;
 
 @TemplateSubType(id = "createRow", label = "Create row")
@@ -43,9 +42,11 @@ public record CreateRow(
                 "Enter row index. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#what-is-a-row-index\" target=\"_blank\">documentation</a>",
             group = "operationDetails",
             feel = FeelMode.optional,
+            constraints =
+                @PropertyConstraints(
+                    pattern = @TemplateProperty.Pattern(value = "^(=.*|[0-9]+|)$", message = "")),
             optional = true,
             binding = @PropertyBinding(name = "operation.rowIndex"))
-        @Pattern(regexp = "^(=.*|[0-9]+|)$")
         Integer rowIndex,
     @TemplateProperty(
             label = "Enter values",

--- a/connectors/google/google-sheets/src/main/java/io/camunda/connector/gsheets/model/request/input/CreateRow.java
+++ b/connectors/google/google-sheets/src/main/java/io/camunda/connector/gsheets/model/request/input/CreateRow.java
@@ -45,7 +45,7 @@ public record CreateRow(
             feel = FeelMode.optional,
             optional = true,
             binding = @PropertyBinding(name = "operation.rowIndex"))
-        @Pattern(regexp = "^(=.*|[0-9].*|)$")
+        @Pattern(regexp = "^(=.*|[0-9]+|)$")
         Integer rowIndex,
     @TemplateProperty(
             label = "Enter values",

--- a/connectors/google/google-sheets/src/main/java/io/camunda/connector/gsheets/model/request/input/CreateRow.java
+++ b/connectors/google/google-sheets/src/main/java/io/camunda/connector/gsheets/model/request/input/CreateRow.java
@@ -13,6 +13,7 @@ import io.camunda.connector.generator.java.annotation.TemplateProperty.PropertyC
 import io.camunda.connector.generator.java.annotation.TemplateSubType;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Pattern;
 import java.util.List;
 
 @TemplateSubType(id = "createRow", label = "Create row")
@@ -44,6 +45,7 @@ public record CreateRow(
             feel = FeelMode.optional,
             optional = true,
             binding = @PropertyBinding(name = "operation.rowIndex"))
+        @Pattern(regexp = "^(=.*|[0-9].*|)$")
         Integer rowIndex,
     @TemplateProperty(
             label = "Enter values",

--- a/connectors/google/google-sheets/src/main/java/io/camunda/connector/gsheets/model/request/input/CreateRow.java
+++ b/connectors/google/google-sheets/src/main/java/io/camunda/connector/gsheets/model/request/input/CreateRow.java
@@ -44,7 +44,10 @@ public record CreateRow(
             feel = FeelMode.optional,
             constraints =
                 @PropertyConstraints(
-                    pattern = @TemplateProperty.Pattern(value = "^(=.*|[0-9]+|)$", message = "")),
+                    pattern =
+                        @TemplateProperty.Pattern(
+                            value = "^(=.*|[0-9]+|)$",
+                            message = "Must be a number")),
             optional = true,
             binding = @PropertyBinding(name = "operation.rowIndex"))
         Integer rowIndex,


### PR DESCRIPTION
## Description

Fix a small issue found by @slolatte 

Now the row index field is restricted to either a FEEL expression, a number or empty String

