### PR TITLE
build(template-generator): change the strategy order so template properties overrides Jakarta

### DIFF
--- a/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/util/TemplatePropertiesUtil.java
+++ b/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/util/TemplatePropertiesUtil.java
@@ -67,7 +67,7 @@ import org.apache.commons.lang3.StringUtils;
 public class TemplatePropertiesUtil {
 
   private static final List<FieldProcessor> fieldProcessors =
-      List.of(new TemplatePropertyFieldProcessor(), new JakartaValidationFieldProcessor());
+      List.of(new JakartaValidationFieldProcessor(), new TemplatePropertyFieldProcessor());
 
   /**
    * Analyze the type and return a list of {@link PropertyBuilder} instances.


### PR DESCRIPTION
Instead over using a merge strategy, we decided with @sbuettner to change the order properties are applied, so now template property properties will always overrides Jakarta validation properties

## Description

Change the order of the Fields Processor

## Related issues

closes https://github.com/camunda/team-connectors/issues/714