### PR TITLE
fix(kafka): Handle consumerGroup properly + update the offset override part

### DIFF
--- a/bundle/default-bundle/src/test/java/io/camunda/connector/runtime/app/LocalConnectorRuntime.java
+++ b/bundle/default-bundle/src/test/java/io/camunda/connector/runtime/app/LocalConnectorRuntime.java
@@ -17,10 +17,14 @@
 package io.camunda.connector.runtime.app;
 
 import org.springframework.boot.SpringApplication;
+import org.springframework.core.env.AbstractEnvironment;
 
 public class LocalConnectorRuntime {
 
   public static void main(String[] args) {
+    // Comment this line if you are using the docker-compose.yml file instead of the
+    // docker-compose-core.yml file
+    System.setProperty(AbstractEnvironment.ACTIVE_PROFILES_PROPERTY_NAME, "docker-core");
     SpringApplication.run(ConnectorRuntimeApplication.class, args);
   }
 }

--- a/bundle/default-bundle/src/test/resources/application-docker-core.properties
+++ b/bundle/default-bundle/src/test/resources/application-docker-core.properties
@@ -1,0 +1,8 @@
+server.port=-1
+
+logging.level.io.camunda.connector=DEBUG
+
+# Config for use with docker-compose-core.yml
+camunda.client.mode=simple
+camunda.client.auth.username=demo
+camunda.client.auth.password=demo

--- a/connectors/kafka/src/main/java/io/camunda/connector/kafka/inbound/KafkaConnectorConsumer.java
+++ b/connectors/kafka/src/main/java/io/camunda/connector/kafka/inbound/KafkaConnectorConsumer.java
@@ -224,9 +224,8 @@ public class KafkaConnectorConsumer {
             throw new RuntimeException(
                 "Message cannot be processed: " + failure.getClass().getSimpleName());
           }
-          case Ignore ignored ->
-              LOG.debug(
-                  "Message not correlated, but the error is ignored. Offset will be committed");
+          case Ignore ignored -> LOG.debug(
+              "Message not correlated, but the error is ignored. Offset will be committed");
         }
       }
     }

--- a/connectors/kafka/src/main/java/io/camunda/connector/kafka/inbound/OffsetUpdateRequiredListener.java
+++ b/connectors/kafka/src/main/java/io/camunda/connector/kafka/inbound/OffsetUpdateRequiredListener.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+
+package io.camunda.connector.kafka.inbound;
+
+import io.camunda.connector.api.error.ConnectorInputException;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
+import org.apache.kafka.common.TopicPartition;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Listener that is invoked when partitions are assigned to a consumer. It is used to update the
+ * offsets of the partitions. Only used when the connector is configured with a list of offsets to
+ * start from.
+ *
+ * @param topicName The topic name
+ * @param consumer The consumer
+ * @param offsets The offsets to start from, one for each partition
+ */
+public record OffsetUpdateRequiredListener(
+    String topicName, Consumer<Object, Object> consumer, List<Long> offsets)
+    implements ConsumerRebalanceListener {
+
+  private static final Logger LOG = LoggerFactory.getLogger(OffsetUpdateRequiredListener.class);
+
+  @Override
+  public void onPartitionsRevoked(Collection<TopicPartition> partitions) {}
+
+  @Override
+  public void onPartitionsAssigned(Collection<TopicPartition> partitions) {
+    LOG.debug(
+        "Partitions assigned: {} for topic: {} and consumer: {}",
+        partitions,
+        topicName,
+        consumer.groupMetadata().memberId());
+    Optional.ofNullable(offsets)
+        .filter(listOffsets -> !listOffsets.isEmpty())
+        .ifPresent(offsets -> seekOffsets(consumer, partitions, offsets, topicName));
+  }
+
+  private void seekOffsets(
+      Consumer<Object, Object> consumer,
+      Collection<TopicPartition> partitions,
+      List<Long> offsets,
+      String topicName) {
+    if (consumer.partitionsFor(topicName).size() != offsets.size()) {
+      throw new ConnectorInputException(
+          new IllegalArgumentException(
+              "Number of offsets provided is not equal the number of partitions!"));
+    }
+    partitions.forEach(partition -> setPartitionOffset(partition, consumer, offsets));
+  }
+
+  private void setPartitionOffset(
+      TopicPartition partition, Consumer<Object, Object> consumer, List<Long> offsets) {
+    Long offset = offsets.get(partition.partition());
+    if (offset != null) {
+      LOG.debug(
+          "Overriding partition {} to offset: {} for consumer: {}",
+          partition,
+          offset,
+          consumer.groupMetadata().memberId());
+      consumer.seek(partition, offset);
+    }
+  }
+}

--- a/connectors/kafka/src/test/java/io/camunda/connector/kafka/inbound/KafkaExecutableTest.java
+++ b/connectors/kafka/src/test/java/io/camunda/connector/kafka/inbound/KafkaExecutableTest.java
@@ -46,7 +46,6 @@ import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.producer.ProducerConfig;
-import org.apache.kafka.common.PartitionInfo;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -81,10 +80,6 @@ public class KafkaExecutableTest {
   @SuppressWarnings("unchecked")
   public void setUp() {
     String topic = "my-topic";
-    List<PartitionInfo> topicPartitions =
-        Arrays.asList(
-            new PartitionInfo(topic, 0, null, null, null),
-            new PartitionInfo(topic, 1, null, null, null));
     kafkaTopic = new KafkaTopic("localhost:9092", topic);
     KafkaAuthentication kafkaAuthentication = new KafkaAuthentication(null, null);
     kafkaConnectorProperties =

--- a/connectors/kafka/src/test/java/io/camunda/connector/kafka/integration/KafkaIntegrationTest.java
+++ b/connectors/kafka/src/test/java/io/camunda/connector/kafka/integration/KafkaIntegrationTest.java
@@ -66,16 +66,14 @@ public class KafkaIntegrationTest {
   private static final String AVRO_TOPIC = "avro-test-topic-" + UUID.randomUUID();
   private static final Map<String, String> HEADERS =
       Map.of("header1", "value1", "header2", "value2");
-
-  private static String BOOTSTRAP_SERVERS;
-
   private static final String kafkaDockerImage = "confluentinc/cp-kafka:6.2.1";
-
-  private static Avro avro;
 
   @ClassRule
   public static final KafkaContainer kafkaContainer =
       new KafkaContainer(DockerImageName.parse(kafkaDockerImage)).withReuse(true);
+
+  private static String BOOTSTRAP_SERVERS;
+  private static Avro avro;
 
   @BeforeAll
   public static void init() throws Exception {

--- a/connectors/kafka/src/test/java/io/camunda/connector/kafka/integration/KafkaIntegrationTest.java
+++ b/connectors/kafka/src/test/java/io/camunda/connector/kafka/integration/KafkaIntegrationTest.java
@@ -49,7 +49,6 @@ import org.apache.kafka.clients.consumer.OffsetOutOfRangeException;
 import org.junit.ClassRule;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
@@ -58,7 +57,6 @@ import org.skyscreamer.jsonassert.JSONAssert;
 import org.testcontainers.containers.KafkaContainer;
 import org.testcontainers.utility.DockerImageName;
 
-@Disabled // to be run manually
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 public class KafkaIntegrationTest {
 
@@ -221,6 +219,7 @@ public class KafkaIntegrationTest {
     assertThat(thrown.getMessage()).contains("Fetch position FetchPosition");
     assertThat(thrown.getMessage()).contains("is out of range for partition " + TOPIC + "-");
     assertEquals(0, context.getCorrelations().size());
+    executable.deactivate();
   }
 
   @Test
@@ -251,7 +250,7 @@ public class KafkaIntegrationTest {
 
     // When
     executable.activate(context);
-    await().atMost(Duration.ofSeconds(5)).until(() -> !context.getCorrelations().isEmpty());
+    await().atMost(Duration.ofSeconds(55)).until(() -> !context.getCorrelations().isEmpty());
     executable.deactivate();
 
     // Then


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
- Fix the way we handle consumerGroups
  - The `assign` method that we used was overriding Kafka's consumer group mechanism (silently). We now use `subscribe` instead.
- Update the way we handle manual offsets.
- Update UTs.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #2846 

