### PR TITLE
build: fix kafka connector integration test

### DIFF
--- a/connectors/kafka/src/main/java/io/camunda/connector/kafka/inbound/KafkaConnectorConsumer.java
+++ b/connectors/kafka/src/main/java/io/camunda/connector/kafka/inbound/KafkaConnectorConsumer.java
@@ -126,7 +126,8 @@ public class KafkaConnectorConsumer {
             .exceptionally(
                 (e) -> {
                   shouldLoop = false;
-                  return null;
+                  throw new RuntimeException(
+                      "Consumer loop failed, retries exhausted: " + e.getMessage(), e);
                 });
   }
 


### PR DESCRIPTION
## Description

This PR will fix the Kafka Integration test that has been failing since #2792 was merged.
- The test itself was adjusted to provide a custom retry policy, also a couple small errors were fixed in other test cases
- The consumer code now rethrows the exception when the retry loop fails (this shouldn't affect normal execution in production, as the retry loop is infinite there)

The test itself is marked as disabled, to be discussed whether we want to run it always.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes https://github.com/camunda/team-connectors/issues/858

