### PR TITLE
other(http-common-request) add  method and make HttpCommonRequest simpler

### DIFF
--- a/connectors/automation-anywhere/src/test/java/io/camunda/connector/automationanywhere/AutomationAnywhereConnectorTest.java
+++ b/connectors/automation-anywhere/src/test/java/io/camunda/connector/automationanywhere/AutomationAnywhereConnectorTest.java
@@ -22,6 +22,7 @@ import io.camunda.connector.http.base.model.HttpMethod;
 import io.camunda.connector.http.base.model.auth.NoAuthentication;
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -146,7 +147,11 @@ class AutomationAnywhereConnectorTest extends BaseTest {
   }
 
   private void verifyThatHeaderContainsToken(HttpCommonRequest request) {
-    assertThat(request.getHeaders().get(AutomationAnywhereConnector.AUTHORIZATION_KEY))
+    assertThat(
+            request
+                .getHeaders()
+                .orElse(Map.of())
+                .get(AutomationAnywhereConnector.AUTHORIZATION_KEY))
         .isEqualTo("thisIsTestToken.0123344567890qwertyuiopASDFGHJKLxcvbnm-Ug");
   }
 }

--- a/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/client/apache/builder/parts/ApacheRequestBodyBuilder.java
+++ b/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/client/apache/builder/parts/ApacheRequestBodyBuilder.java
@@ -84,14 +84,7 @@ public class ApacheRequestBodyBuilder implements ApacheRequestPartBuilder {
   }
 
   private Optional<ContentType> tryGetContentType(HttpCommonRequest request) {
-    return Optional.ofNullable(request.getHeaders())
-        .flatMap(
-            headers ->
-                headers.entrySet().stream()
-                    .filter(e -> e.getKey().equalsIgnoreCase(CONTENT_TYPE))
-                    .findFirst())
-        .map(Map.Entry::getValue)
-        .map(ContentType::parse);
+    return request.getHeader(CONTENT_TYPE).map(ContentType::parse);
   }
 
   private HttpEntity createStringEntity(HttpCommonRequest request) {

--- a/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/client/apache/builder/parts/ApacheRequestHeadersBuilder.java
+++ b/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/client/apache/builder/parts/ApacheRequestHeadersBuilder.java
@@ -24,7 +24,7 @@ import static org.apache.hc.core5.http.HttpHeaders.CONTENT_TYPE;
 import io.camunda.connector.http.base.model.HttpCommonRequest;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Optional;
+import java.util.Objects;
 import java.util.function.Predicate;
 import org.apache.hc.core5.http.io.support.ClassicRequestBuilder;
 
@@ -61,13 +61,13 @@ public class ApacheRequestHeadersBuilder implements ApacheRequestPartBuilder {
 
   /** Remove the content type header if it is {@code null}. */
   private Map<String, String> sanitizedHeaders(HttpCommonRequest request) {
-    var headers =
-        Optional.ofNullable(request.getHeaders()).map(HashMap::new).orElse(new HashMap<>());
-    var keysToRemove =
-        headers.entrySet().stream()
-            .filter(e -> e.getKey().equalsIgnoreCase(CONTENT_TYPE) && e.getValue() == null)
-            .findFirst();
-    keysToRemove.ifPresent(e -> headers.remove(e.getKey()));
+    var headers = request.getHeaders().map(HashMap::new).orElse(new HashMap<>());
+    headers.entrySet().stream()
+        .filter(
+            entry ->
+                Objects.isNull(entry.getValue()) && Objects.equals(entry.getKey(), CONTENT_TYPE))
+        .findFirst()
+        .ifPresent(entry -> headers.remove(entry.getKey()));
     return headers;
   }
 }

--- a/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/model/HttpCommonRequest.java
+++ b/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/model/HttpCommonRequest.java
@@ -117,14 +117,6 @@ public class HttpCommonRequest {
     return body != null;
   }
 
-  public Map<String, String> getHeaders() {
-    return headers;
-  }
-
-  public void setHeaders(final Map<String, String> headers) {
-    this.headers = headers;
-  }
-
   public boolean hasQueryParameters() {
     return queryParameters != null;
   }
@@ -179,6 +171,21 @@ public class HttpCommonRequest {
 
   public void setReadTimeoutInSeconds(final Integer readTimeoutInSeconds) {
     this.readTimeoutInSeconds = readTimeoutInSeconds;
+  }
+
+  public Optional<String> getHeader(final String key) {
+    if (Objects.nonNull(headers)) {
+      return headers.keySet().stream().filter(key::equalsIgnoreCase).findFirst().map(headers::get);
+    }
+    return Optional.empty();
+  }
+
+  public Optional<Map<String, String>> getHeaders() {
+    return Optional.ofNullable(headers);
+  }
+
+  public void setHeaders(final Map<String, String> headers) {
+    this.headers = headers;
   }
 
   @Override

--- a/connectors/http/http-base/src/test/java/io/camunda/connector/http/base/authentication/OAuthServiceTest.java
+++ b/connectors/http/http-base/src/test/java/io/camunda/connector/http/base/authentication/OAuthServiceTest.java
@@ -50,7 +50,7 @@ public class OAuthServiceTest {
       // Then
       assertThat(request.getUrl()).isEqualTo("www.example.com");
       assertThat(request.getMethod()).isEqualTo(HttpMethod.POST);
-      assertThat(request.getHeaders())
+      assertThat(request.getHeaders().orElse(Map.of()))
           .containsEntry("Content-Type", "application/x-www-form-urlencoded");
       assertThat((Map) request.getBody()).containsEntry("client_id", "clientId");
       assertThat((Map) request.getBody()).containsEntry("client_secret", "clientSecret");
@@ -77,9 +77,9 @@ public class OAuthServiceTest {
       // Then
       assertThat(request.getUrl()).isEqualTo("www.example.com");
       assertThat(request.getMethod()).isEqualTo(HttpMethod.POST);
-      assertThat(request.getHeaders())
+      assertThat(request.getHeaders().orElse(Map.of()))
           .containsEntry("Content-Type", "application/x-www-form-urlencoded");
-      assertThat(request.getHeaders())
+      assertThat(request.getHeaders().orElse(Map.of()))
           .containsEntry(
               "Authorization",
               Base64Helper.buildBasicAuthenticationHeader("clientId", "clientSecret"));

--- a/connectors/http/http-base/src/test/java/io/camunda/connector/http/base/cloudfunction/CloudFunctionServiceTest.java
+++ b/connectors/http/http-base/src/test/java/io/camunda/connector/http/base/cloudfunction/CloudFunctionServiceTest.java
@@ -71,8 +71,9 @@ public class CloudFunctionServiceTest {
     // then
     assertThat(cloudFunctionRequest.getUrl()).isEqualTo("proxyUrl");
     assertThat(cloudFunctionRequest.getMethod()).isEqualTo(HttpMethod.POST);
-    assertThat(cloudFunctionRequest.getHeaders()).hasSize(1);
-    assertThat(cloudFunctionRequest.getHeaders()).containsEntry("Content-Type", "application/json");
+    assertThat(cloudFunctionRequest.getHeaders().orElse(Map.of())).hasSize(1);
+    assertThat(cloudFunctionRequest.getHeaders().orElse(Map.of()))
+        .containsEntry("Content-Type", "application/json");
     Map<String, Object> body =
         ConnectorsObjectMapperSupplier.DEFAULT_MAPPER.readValue(
             (String) cloudFunctionRequest.getBody(), Map.class);


### PR DESCRIPTION
## Description

Add a getHeader method and simplify calling function=

## Related issues

closes https://github.com/camunda/team-connectors/issues/841

