### PR TITLE
fix(kafka): kafka connector loop retry (#2792)

### DIFF
--- a/connectors/kafka/pom.xml
+++ b/connectors/kafka/pom.xml
@@ -63,9 +63,15 @@ except in compliance with the proprietary license.</license.inlineheader>
     </dependency>
 
     <dependency>
+      <groupId>dev.failsafe</groupId>
+      <artifactId>failsafe</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>kafka</artifactId>
       <version>${version.testcontainers}</version>
+      <scope>test</scope>
     </dependency>
 
     <dependency>

--- a/connectors/kafka/src/test/java/io/camunda/connector/kafka/inbound/KafkaExecutableTest.java
+++ b/connectors/kafka/src/test/java/io/camunda/connector/kafka/inbound/KafkaExecutableTest.java
@@ -19,14 +19,17 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.testcontainers.shaded.org.awaitility.Awaitility.await;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import dev.failsafe.RetryPolicy;
 import io.camunda.connector.kafka.outbound.model.KafkaTopic;
 import io.camunda.connector.test.inbound.InboundConnectorContextBuilder;
 import io.camunda.connector.test.inbound.InboundConnectorDefinitionBuilder;
 import io.camunda.connector.validation.impl.DefaultValidationProvider;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
@@ -49,7 +52,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.ArgumentCaptor;
-import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
@@ -59,8 +61,6 @@ public class KafkaExecutableTest {
   private InboundConnectorContextBuilder.TestInboundConnectorContext originalContext;
   private List<PartitionInfo> topicPartitions;
   private KafkaConnectorProperties kafkaConnectorProperties;
-  @Mock private KafkaConsumer<Object, Object> mockConsumer;
-  private String topic;
 
   private static Stream<Arguments> provideStringsForGetOffsets() {
     return Stream.of(
@@ -73,7 +73,15 @@ public class KafkaExecutableTest {
         Arguments.of(Arrays.asList(10L, 12L), Arrays.asList(10L, 12L)));
   }
 
+  private KafkaTopic kafkaTopic;
+  private KafkaConsumer<Object, Object> mockConsumer;
+
+  private String topic;
+
+  private static final int MAX_ATTEMPTS = 3;
+
   @BeforeEach
+  @SuppressWarnings("unchecked")
   public void setUp() {
     topic = "my-topic";
     topicPartitions =
@@ -97,6 +105,7 @@ public class KafkaExecutableTest {
             .validation(new DefaultValidationProvider())
             .build();
     originalContext = context;
+    mockConsumer = mock(KafkaConsumer.class);
   }
 
   @Test
@@ -146,6 +155,29 @@ public class KafkaExecutableTest {
     assertEquals(originalContext, context);
     assertNotNull(kafkaExecutable.kafkaConnectorConsumer.consumer);
     assertFalse(kafkaExecutable.kafkaConnectorConsumer.shouldLoop);
+  }
+
+  @Test
+  void testActivateAndDeactivate_consumerThrows() {
+    // Given
+    KafkaExecutable kafkaExecutable = getConsumerMock();
+    var groupMetadataMock = mock(ConsumerGroupMetadata.class);
+    when(groupMetadataMock.groupId()).thenReturn("groupId");
+    when(groupMetadataMock.groupInstanceId()).thenReturn(Optional.of("groupInstanceId"));
+    when(groupMetadataMock.generationId()).thenReturn(1);
+    when(mockConsumer.groupMetadata()).thenReturn(groupMetadataMock);
+
+    // When
+    when(mockConsumer.poll(any())).thenThrow(new RuntimeException("Test exception"));
+    kafkaExecutable.activate(context);
+    await()
+        .atMost(Duration.ofSeconds(5))
+        .pollInterval(Duration.ofMillis(500))
+        .untilAsserted(() -> assertFalse(kafkaExecutable.kafkaConnectorConsumer.shouldLoop));
+    kafkaExecutable.deactivate();
+
+    // Then
+    verify(mockConsumer, times(MAX_ATTEMPTS)).poll(any(Duration.class));
   }
 
   @Test
@@ -236,7 +268,13 @@ public class KafkaExecutableTest {
   }
 
   public KafkaExecutable getConsumerMock() {
-    return new KafkaExecutable(properties -> mockConsumer);
+    return new KafkaExecutable(
+        properties -> mockConsumer,
+        RetryPolicy.builder()
+            .handle(Exception.class)
+            .withDelay(Duration.ofMillis(50))
+            .withMaxAttempts(MAX_ATTEMPTS)
+            .build());
   }
 
   @ParameterizedTest

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -82,6 +82,7 @@ limitations under the License.</license.inlineheader>
     <version.jackson-datatype-jsr310>2.17.2</version.jackson-datatype-jsr310>
     <version.hibernate-validator>8.0.1.Final</version.hibernate-validator>
     <version.jsonassert>1.5.3</version.jsonassert>
+    <version.failsafe>3.3.2</version.failsafe>
 
     <version.spring-boot>3.3.0</version.spring-boot>
     <version.spring-cloud-gcp-starter-logging>5.3.0</version.spring-cloud-gcp-starter-logging>
@@ -450,6 +451,12 @@ limitations under the License.</license.inlineheader>
         <groupId>org.bouncycastle</groupId>
         <artifactId>bcprov-jdk18on</artifactId>
         <version>${version.bouncycastle}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>dev.failsafe</groupId>
+        <artifactId>failsafe</artifactId>
+        <version>${version.failsafe}</version>
       </dependency>
 
       <!-- test dependencies -->


### PR DESCRIPTION
* fix(kafka): retry the main consumer loop with 30 seconds backoff

* reduce test wait duration

* lint

* switch to failsafe

* set number of retries to -1 (unlimited)

* use constant for retry number

* try fixing the integration test

* try fixing the integration test

* try fixing the integration test

* try fixing the integration test

* try fixing the integration test

* formatting

(cherry picked from commit 807071e2ae74a81e73d2689505a131e1cdd8bb7e)

## Description

<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #

