### PR TITLE
feat(slack-connector) we can now use the channel Id for inviting people

### DIFF
--- a/connectors/slack/element-templates/hybrid/slack-outbound-connector-hybrid.json
+++ b/connectors/slack/element-templates/hybrid/slack-outbound-connector-hybrid.json
@@ -250,6 +250,35 @@
       "value" : "PRIVATE"
     } ]
   }, {
+    "id" : "data.channelType",
+    "label" : "Invite By",
+    "optional" : false,
+    "value" : "channelId",
+    "group" : "invite",
+    "binding" : {
+      "name" : "data.channelType",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "allMatch" : [ {
+        "property" : "method",
+        "equals" : "conversations.invite",
+        "type" : "simple"
+      }, {
+        "property" : "method",
+        "equals" : "conversations.invite",
+        "type" : "simple"
+      } ]
+    },
+    "type" : "Dropdown",
+    "choices" : [ {
+      "name" : "Channel ID",
+      "value" : "channelId"
+    }, {
+      "name" : "Channel name",
+      "value" : "channelName"
+    } ]
+  }, {
     "id" : "data.channelName",
     "label" : "Channel name",
     "optional" : false,
@@ -267,9 +296,44 @@
       "type" : "zeebe:input"
     },
     "condition" : {
-      "property" : "method",
-      "equals" : "conversations.invite",
-      "type" : "simple"
+      "allMatch" : [ {
+        "property" : "data.channelType",
+        "equals" : "channelName",
+        "type" : "simple"
+      }, {
+        "property" : "method",
+        "equals" : "conversations.invite",
+        "type" : "simple"
+      } ]
+    },
+    "type" : "String"
+  }, {
+    "id" : "data.channelId",
+    "label" : "Channel ID",
+    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true,
+      "pattern" : {
+        "value" : "^(=|([-_a-z0-9]{1,80}$))",
+        "message" : "May contain up to 80 lowercase letters, digits, underscores, and dashes"
+      }
+    },
+    "feel" : "optional",
+    "group" : "invite",
+    "binding" : {
+      "name" : "data.channelId",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "allMatch" : [ {
+        "property" : "data.channelType",
+        "equals" : "channelId",
+        "type" : "simple"
+      }, {
+        "property" : "method",
+        "equals" : "conversations.invite",
+        "type" : "simple"
+      } ]
     },
     "type" : "String"
   }, {

--- a/connectors/slack/element-templates/slack-outbound-connector.json
+++ b/connectors/slack/element-templates/slack-outbound-connector.json
@@ -245,6 +245,35 @@
       "value" : "PRIVATE"
     } ]
   }, {
+    "id" : "data.channelType",
+    "label" : "Invite By",
+    "optional" : false,
+    "value" : "channelId",
+    "group" : "invite",
+    "binding" : {
+      "name" : "data.channelType",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "allMatch" : [ {
+        "property" : "method",
+        "equals" : "conversations.invite",
+        "type" : "simple"
+      }, {
+        "property" : "method",
+        "equals" : "conversations.invite",
+        "type" : "simple"
+      } ]
+    },
+    "type" : "Dropdown",
+    "choices" : [ {
+      "name" : "Channel ID",
+      "value" : "channelId"
+    }, {
+      "name" : "Channel name",
+      "value" : "channelName"
+    } ]
+  }, {
     "id" : "data.channelName",
     "label" : "Channel name",
     "optional" : false,
@@ -262,9 +291,44 @@
       "type" : "zeebe:input"
     },
     "condition" : {
-      "property" : "method",
-      "equals" : "conversations.invite",
-      "type" : "simple"
+      "allMatch" : [ {
+        "property" : "data.channelType",
+        "equals" : "channelName",
+        "type" : "simple"
+      }, {
+        "property" : "method",
+        "equals" : "conversations.invite",
+        "type" : "simple"
+      } ]
+    },
+    "type" : "String"
+  }, {
+    "id" : "data.channelId",
+    "label" : "Channel ID",
+    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true,
+      "pattern" : {
+        "value" : "^(=|([-_a-z0-9]{1,80}$))",
+        "message" : "May contain up to 80 lowercase letters, digits, underscores, and dashes"
+      }
+    },
+    "feel" : "optional",
+    "group" : "invite",
+    "binding" : {
+      "name" : "data.channelId",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "allMatch" : [ {
+        "property" : "data.channelType",
+        "equals" : "channelId",
+        "type" : "simple"
+      }, {
+        "property" : "method",
+        "equals" : "conversations.invite",
+        "type" : "simple"
+      } ]
     },
     "type" : "String"
   }, {


### PR DESCRIPTION
@sbuettner Should I implement the same choice for `postMessage` feature ?

## Description

add the option to use channel Id for inviting people inside a slack channel

## Related issues

https://github.com/camunda/connectors/issues/2695

