### PR TITLE
ci(preview-env): add deployment summary

### DIFF
--- a/.github/workflows/PREVIEW-ENV-DEPLOY.yml
+++ b/.github/workflows/PREVIEW-ENV-DEPLOY.yml
@@ -78,7 +78,6 @@ jobs:
         app_url: https://${{ steps.sanitize.outputs.branch_name }}-${{ matrix.product_context }}.connectors.camunda.cloud
         argocd_arguments: ${{ env.argocd_arguments }}
         argocd_server: argocd.int.camunda.com
-
   clean:
     if: always() && github.event_name == 'pull_request' && needs.deploy-preview.result != 'skipped'
     uses: camunda/connectors/.github/workflows/PREVIEW-ENV-CLEAN.yml@main
@@ -86,3 +85,10 @@ jobs:
     secrets: inherit
     with:
       pull-request: ${{ github.event.pull_request.number }}
+  comment:
+    if: always() && github.event_name == 'pull_request' && needs.deploy-preview.result != 'skipped'
+    name: create-deployment-result-summary
+    runs-on: ubuntu-22.04
+    needs: [deploy-preview]
+    steps:
+      - uses: camunda/infra-global-github-actions/preview-env/comment@main

--- a/.github/workflows/PREVIEW-ENV-TEARDOWN.yml
+++ b/.github/workflows/PREVIEW-ENV-TEARDOWN.yml
@@ -50,7 +50,6 @@ jobs:
         revision: ${{ env.BRANCH_NAME }}
         argocd_token: ${{ steps.secrets.outputs.ARGOCD_TOKEN }}
         app_name: connectors-${{ steps.sanitize.outputs.branch_name }}-${{ matrix.product_context }}
-
   clean:
     if: always() && needs.teardown-preview.result != 'skipped'
     uses: camunda/connectors/.github/workflows/PREVIEW-ENV-CLEAN.yml@main
@@ -58,3 +57,10 @@ jobs:
     secrets: inherit
     with:
       pull-request: ${{ github.event.pull_request.number }}
+  comment:
+    if: always() && needs.teardown-preview.result != 'skipped'
+    name: delete-deployment-result-summary
+    runs-on: ubuntu-22.04
+    needs: [teardown-preview]
+    steps:
+      - uses: camunda/infra-global-github-actions/preview-env/comment@main


### PR DESCRIPTION
## Description

We integrated the "Deployment Summary" functionality into the preview-env deployments/teardowns.
Read more about it [here](https://github.com/camunda/infra-global-github-actions/tree/main/preview-env/comment)

## Related issues

* https://github.com/camunda/team-infrastructure/issues/459
* https://github.com/camunda/infra-global-github-actions/pull/228

closes https://github.com/camunda/team-infrastructure/issues/459

