### PR TITLE
other(bpmn-import): log warning when duplicate name is found inside process definition

### DIFF
--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/state/ProcessDefinitionInspector.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/state/ProcessDefinitionInspector.java
@@ -312,7 +312,19 @@ public class ProcessDefinitionInspector {
     }
     return zeebeProperties.getProperties().stream()
         .filter(property -> property.getValue() != null)
-        .collect(Collectors.toMap(ZeebeProperty::getName, ZeebeProperty::getValue));
+        .collect(
+            Collectors.toMap(
+                ZeebeProperty::getName,
+                ZeebeProperty::getValue,
+                (nameDuplicate, valueDuplicate) -> {
+                  LOG.warn(
+                      "A duplicate has been found for property name {} and value {} for element {}",
+                      nameDuplicate,
+                      valueDuplicate,
+                      element.getId());
+                  // returns null means to ignore the mapping when there is a duplicate
+                  return null;
+                }));
   }
 
   private String extractRequiredProperty(BaseElement element, String name) {

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/state/ProcessDefinitionInspector.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/state/ProcessDefinitionInspector.java
@@ -316,14 +316,14 @@ public class ProcessDefinitionInspector {
             Collectors.toMap(
                 ZeebeProperty::getName,
                 ZeebeProperty::getValue,
-                (nameDuplicate, valueDuplicate) -> {
+                (oldValue, newValue) -> {
                   LOG.warn(
-                      "A duplicate has been found for property name {} and value {} for element {}",
-                      nameDuplicate,
-                      valueDuplicate,
+                      "A duplicate has been found, old value {} and new value {} for element {}",
+                      oldValue,
+                      newValue,
                       element.getId());
-                  // returns null means to ignore the mapping when there is a duplicate
-                  return null;
+                  //In case a duplicate is found we take the first value found
+                  return oldValue;
                 }));
   }
 

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/state/ProcessDefinitionInspector.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/state/ProcessDefinitionInspector.java
@@ -322,7 +322,7 @@ public class ProcessDefinitionInspector {
                       oldValue,
                       newValue,
                       element.getId());
-                  //In case a duplicate is found we take the first value found
+                  // In case a duplicate is found we take the first value found
                   return oldValue;
                 }));
   }

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/inbound/importer/ProcessDefinitionInspectorUtilTests.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/inbound/importer/ProcessDefinitionInspectorUtilTests.java
@@ -29,6 +29,8 @@ import io.camunda.operate.CamundaOperateClient;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import java.io.FileInputStream;
 import java.util.List;
+
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.util.ResourceUtils;
 
@@ -106,6 +108,14 @@ public class ProcessDefinitionInspectorUtilTests {
             .filter(ic -> ic.element().elementId().equals("wh-start-msg-2"))
             .findFirst()
             .get());
+  }
+
+  @Test
+  public void testDuplicatePropertiesAreRemoved() {
+    var inboundConnectors =
+            fromModel("multi-webhook-start-message-duplicate-property.bpmn", "multi-webhook-start-message");
+    Assertions.assertEquals("firstRes", inboundConnectors.getFirst().resultVariable());
+    System.out.println(inboundConnectors);
   }
 
   private List<InboundConnectorElement> fromModel(String fileName, String processId) {

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/inbound/importer/ProcessDefinitionInspectorUtilTests.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/inbound/importer/ProcessDefinitionInspectorUtilTests.java
@@ -29,7 +29,6 @@ import io.camunda.operate.CamundaOperateClient;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import java.io.FileInputStream;
 import java.util.List;
-
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.util.ResourceUtils;
@@ -113,7 +112,8 @@ public class ProcessDefinitionInspectorUtilTests {
   @Test
   public void testDuplicatePropertiesAreRemoved() {
     var inboundConnectors =
-            fromModel("multi-webhook-start-message-duplicate-property.bpmn", "multi-webhook-start-message");
+        fromModel(
+            "multi-webhook-start-message-duplicate-property.bpmn", "multi-webhook-start-message");
     Assertions.assertEquals("firstRes", inboundConnectors.getFirst().resultVariable());
     System.out.println(inboundConnectors);
   }

--- a/connector-runtime/connector-runtime-spring/src/test/resources/bpmn/multi-webhook-start-message-duplicate-property.bpmn
+++ b/connector-runtime/connector-runtime-spring/src/test/resources/bpmn/multi-webhook-start-message-duplicate-property.bpmn
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1htcurf" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.11.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.2.0">
+    <bpmn:process id="multi-webhook-start-message" isExecutable="true">
+        <bpmn:startEvent id="wh-start-msg-1" zeebe:modelerTemplate="io.camunda.connectors.webhook.WebhookConnectorStartMessage.v1" zeebe:modelerTemplateVersion="1" zeebe:modelerTemplateIcon="data:image/svg+xml,%3Csvg id=&#39;icon&#39; xmlns=&#39;http://www.w3.org/2000/svg&#39; width=&#39;18&#39; height=&#39;18&#39; viewBox=&#39;0 0 32 32&#39;%3E%3Cdefs%3E%3Cstyle%3E .cls-1 %7B fill: none; %7D %3C/style%3E%3C/defs%3E%3Cpath d=&#39;M24,26a3,3,0,1,0-2.8164-4H13v1a5,5,0,1,1-5-5V16a7,7,0,1,0,6.9287,8h6.2549A2.9914,2.9914,0,0,0,24,26Z&#39;/%3E%3Cpath d=&#39;M24,16a7.024,7.024,0,0,0-2.57.4873l-3.1656-5.5395a3.0469,3.0469,0,1,0-1.7326.9985l4.1189,7.2085.8686-.4976a5.0006,5.0006,0,1,1-1.851,6.8418L17.937,26.501A7.0005,7.0005,0,1,0,24,16Z&#39;/%3E%3Cpath d=&#39;M8.532,20.0537a3.03,3.03,0,1,0,1.7326.9985C11.74,18.47,13.86,14.7607,13.89,14.708l.4976-.8682-.8677-.497a5,5,0,1,1,6.812-1.8438l1.7315,1.002a7.0008,7.0008,0,1,0-10.3462,2.0356c-.457.7427-1.1021,1.8716-2.0737,3.5728Z&#39;/%3E%3Crect id=&#39;_Transparent_Rectangle_&#39; data-name=&#39;&#38;lt;Transparent Rectangle&#38;gt;&#39; class=&#39;cls-1&#39; width=&#39;32&#39; height=&#39;32&#39;/%3E%3C/svg%3E">
+            <bpmn:extensionElements>
+                <zeebe:properties>
+                    <zeebe:property name="idempotencyKey" value="=request.body.msgId" />
+                    <zeebe:property name="inbound.type" value="io.camunda:webhook:1" />
+                    <zeebe:property name="inbound.subtype" value="ConfigurableInboundWebhook" />
+                    <zeebe:property name="inbound.method" value="any" />
+                    <zeebe:property name="inbound.context" value="wh0" />
+                    <zeebe:property name="inbound.shouldValidateHmac" value="disabled" />
+                    <zeebe:property name="inbound.auth.type" value="NONE" />
+                    <zeebe:property name="messageIdExpression" value="=request.body.msgId" />
+                    <zeebe:property name="resultVariable" value="firstRes" />
+                    <zeebe:property name="resultVariable" value="secondRes" />
+                    <zeebe:property name="inbound.responseBodyExpression" value="=correlation" />
+                </zeebe:properties>
+            </bpmn:extensionElements>
+            <bpmn:outgoing>Flow_0fr5490</bpmn:outgoing>
+            <bpmn:messageEventDefinition id="MessageEventDefinition_1qz1uyq" messageRef="Message_1pvfyd3" />
+        </bpmn:startEvent>
+        <bpmn:intermediateCatchEvent id="Event_1ckdsbr">
+            <bpmn:incoming>Flow_0fr5490</bpmn:incoming>
+            <bpmn:incoming>Flow_1qlm1pp</bpmn:incoming>
+            <bpmn:outgoing>Flow_1corvp6</bpmn:outgoing>
+            <bpmn:timerEventDefinition id="TimerEventDefinition_0p1k1ec">
+                <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">PT10S</bpmn:timeDuration>
+            </bpmn:timerEventDefinition>
+        </bpmn:intermediateCatchEvent>
+        <bpmn:sequenceFlow id="Flow_0fr5490" sourceRef="wh-start-msg-1" targetRef="Event_1ckdsbr" />
+        <bpmn:endEvent id="Event_13wqqnd">
+            <bpmn:incoming>Flow_1corvp6</bpmn:incoming>
+        </bpmn:endEvent>
+        <bpmn:sequenceFlow id="Flow_1corvp6" sourceRef="Event_1ckdsbr" targetRef="Event_13wqqnd" />
+    </bpmn:process>
+    <bpmn:message id="Message_1pvfyd3" name="9614f953-0d97-4429-b594-d1a1a407895a" zeebe:modelerTemplate="io.camunda.connectors.webhook.WebhookConnectorStartMessage.v1" />
+    <bpmn:message id="Message_1juhe32" name="8253d3f1-c44b-4cad-933e-8aed7bc9ec71" zeebe:modelerTemplate="io.camunda.connectors.webhook.WebhookConnectorStartMessage.v1" />
+    <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+        <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="multi-webhook-start-message">
+            <bpmndi:BPMNShape id="Event_1vgyg4c_di" bpmnElement="wh-start-msg-1">
+                <dc:Bounds x="179" y="79" width="36" height="36" />
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="Event_06b80yp_di" bpmnElement="Event_1ckdsbr">
+                <dc:Bounds x="282" y="112" width="36" height="36" />
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="Event_13wqqnd_di" bpmnElement="Event_13wqqnd">
+                <dc:Bounds x="362" y="112" width="36" height="36" />
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNEdge id="Flow_0fr5490_di" bpmnElement="Flow_0fr5490">
+                <di:waypoint x="215" y="97" />
+                <di:waypoint x="249" y="97" />
+                <di:waypoint x="249" y="130" />
+                <di:waypoint x="282" y="130" />
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="Flow_1qlm1pp_di" bpmnElement="Flow_1qlm1pp">
+                <di:waypoint x="215" y="160" />
+                <di:waypoint x="249" y="160" />
+                <di:waypoint x="249" y="130" />
+                <di:waypoint x="282" y="130" />
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="Flow_1corvp6_di" bpmnElement="Flow_1corvp6">
+                <di:waypoint x="318" y="130" />
+                <di:waypoint x="362" y="130" />
+            </bpmndi:BPMNEdge>
+        </bpmndi:BPMNPlane>
+    </bpmndi:BPMNDiagram>
+</bpmn:definitions>


### PR DESCRIPTION
## Description

a log (warning) is printed when a duplicate key is found inside a BPMN process, The duplicate value is ignored

## Related issues

closes https://github.com/camunda/connectors/issues/2939

