### PR TITLE
fix(dockerfile): replace addgroup with groupadd in Dockerfile

### DIFF
--- a/bundle/camunda-saas-bundle/Dockerfile
+++ b/bundle/camunda-saas-bundle/Dockerfile
@@ -8,7 +8,7 @@ RUN mkdir /opt/app
 COPY target/*-with-dependencies.jar /opt/app/
 
 # Create an unprivileged user / group and switch to that user
-RUN addgroup --gid 1001 camunda && useradd --no-create-home --gid 1001 --uid 1001 camunda
+RUN groupadd --gid 1001 camunda && useradd --no-create-home --gid 1001 --uid 1001 camunda
 USER 1001:1001
 
 ENV ZEEBE_CLIENT_CONFIG_PATH=/tmp/connectors

--- a/bundle/default-bundle/Dockerfile
+++ b/bundle/default-bundle/Dockerfile
@@ -13,7 +13,7 @@ COPY start.sh /start.sh
 RUN chmod +x start.sh
 
 # Create an unprivileged user / group and switch to that user
-RUN addgroup --gid 1001 camunda && useradd --no-create-home --gid 1001 --uid 1001 camunda
+RUN groupadd --gid 1001 camunda && useradd --no-create-home --gid 1001 --uid 1001 camunda
 USER 1001:1001
 
 ENV ZEEBE_CLIENT_CONFIG_PATH=/tmp/connectors

--- a/connector-runtime/connector-runtime-application/Dockerfile
+++ b/connector-runtime/connector-runtime-application/Dockerfile
@@ -15,7 +15,7 @@ COPY target/*-with-dependencies.jar /opt/app/
 # ADD https://s01.oss.sonatype.org/content/repositories/releases/io/camunda/connector/connector-runtime-application/${VERSION}/connector-runtime-application-${VERSION}-with-dependencies.jar /opt/app/runtime.jar
 
 # Create an unprivileged user / group and switch to that user
-RUN addgroup --gid 1001 camunda && useradd --no-create-home --gid 1001 --uid 1001 camunda
+RUN groupadd --gid 1001 camunda && useradd --no-create-home --gid 1001 --uid 1001 camunda
 USER 1001:1001
 
 # Use entry point to allow downstream images to add JVM arguments using CMD


### PR DESCRIPTION
## Description 

Replace addgroup with groupadd to be compatible with the the noble variant of eclipse temurin base docker image.

