### PR TITLE
fix(kafka): close consumer before retrying on failures

### DIFF
--- a/connectors/kafka/src/main/java/io/camunda/connector/kafka/inbound/KafkaConnectorConsumer.java
+++ b/connectors/kafka/src/main/java/io/camunda/connector/kafka/inbound/KafkaConnectorConsumer.java
@@ -49,6 +49,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class KafkaConnectorConsumer {
+
   private static final Logger LOG = LoggerFactory.getLogger(KafkaConnectorConsumer.class);
   public static ObjectMapper objectMapper =
       new ObjectMapper()
@@ -99,6 +100,14 @@ public class KafkaConnectorConsumer {
             return null;
           } catch (Exception ex) {
             LOG.error("Consumer loop failure, retry pending: {}", ex.getMessage());
+            try {
+              consumer.close();
+            } catch (Exception e) {
+              LOG.error(
+                  "Failed to close consumer before retrying, reason: {}. "
+                      + "This error will be ignored. If the consumer is still running, it will be disconnected after max.poll.interval.ms.",
+                  e.getMessage());
+            }
             throw ex;
           }
         };

--- a/connectors/kafka/src/test/java/io/camunda/connector/kafka/inbound/KafkaExecutableTest.java
+++ b/connectors/kafka/src/test/java/io/camunda/connector/kafka/inbound/KafkaExecutableTest.java
@@ -172,7 +172,6 @@ public class KafkaExecutableTest {
         .atMost(Duration.ofSeconds(5))
         .pollInterval(Duration.ofMillis(500))
         .untilAsserted(() -> assertFalse(kafkaExecutable.kafkaConnectorConsumer.shouldLoop));
-    kafkaExecutable.deactivate();
 
     // Then
     verify(mockConsumer, times(MAX_ATTEMPTS)).subscribe(anyCollection(), any());

--- a/connectors/kafka/src/test/java/io/camunda/connector/kafka/inbound/KafkaExecutableTest.java
+++ b/connectors/kafka/src/test/java/io/camunda/connector/kafka/inbound/KafkaExecutableTest.java
@@ -177,6 +177,7 @@ public class KafkaExecutableTest {
     // Then
     verify(mockConsumer, times(MAX_ATTEMPTS)).subscribe(anyCollection(), any());
     verify(mockConsumer, times(MAX_ATTEMPTS)).poll(any(Duration.class));
+    verify(mockConsumer, times(MAX_ATTEMPTS)).close();
   }
 
   @Test


### PR DESCRIPTION
## Description

This PR will fix the issue with the Kafka connector retry loop. Previously, we didn't close the consumer properly before retrying, which resulted in longer waiting time before the new consumer could connect to the topic (it had to wait until the old consumer is killed by timeout).

## Related issues

related: #2750, #2792 

