### PR TITLE
refactor(element-template): None start event are now deprecated

### DIFF
--- a/connectors/aws/aws-sns/element-templates/aws-sns-inbound-start-event.json
+++ b/connectors/aws/aws-sns/element-templates/aws-sns-inbound-start-event.json
@@ -4,7 +4,7 @@
   "id" : "io.camunda.connectors.inbound.AWSSNS.StartEvent.v1",
   "description" : "Receive events from AWS SNS",
   "deprecated": {
-    "message": "None start event are deprecated. Start process using a message start event",
+    "message": "None Start Events are deprecated in favor of Message Start Events for message based Connectors.",
     "documentationRef": "https://docs.camunda.io/docs/components/modeler/bpmn/none-events/"
   },
   "documentationRef" : "https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-sns/?amazonsns=inbound",

--- a/connectors/aws/aws-sns/element-templates/aws-sns-inbound-start-event.json
+++ b/connectors/aws/aws-sns/element-templates/aws-sns-inbound-start-event.json
@@ -4,7 +4,7 @@
   "id" : "io.camunda.connectors.inbound.AWSSNS.StartEvent.v1",
   "description" : "Receive events from AWS SNS",
   "deprecated": {
-    "message": "None start event are deprecated. Start process using a message",
+    "message": "None start event are deprecated. Start process using a message start event",
     "documentationRef": "https://docs.camunda.io/docs/components/modeler/bpmn/none-events/"
   },
   "documentationRef" : "https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-sns/?amazonsns=inbound",

--- a/connectors/aws/aws-sns/element-templates/aws-sns-inbound-start-event.json
+++ b/connectors/aws/aws-sns/element-templates/aws-sns-inbound-start-event.json
@@ -3,6 +3,10 @@
   "name" : "SNS HTTPS Start Event Connector",
   "id" : "io.camunda.connectors.inbound.AWSSNS.StartEvent.v1",
   "description" : "Receive events from AWS SNS",
+  "deprecated": {
+    "message": "None start event are deprecated. Start process using a message",
+    "documentationRef": "https://docs.camunda.io/docs/components/modeler/bpmn/none-events/"
+  },
   "documentationRef" : "https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-sns/?amazonsns=inbound",
   "version" : 4,
   "category" : {

--- a/connectors/aws/aws-sns/src/main/java/io/camunda/connector/sns/inbound/SnsWebhookExecutable.java
+++ b/connectors/aws/aws-sns/src/main/java/io/camunda/connector/sns/inbound/SnsWebhookExecutable.java
@@ -51,11 +51,6 @@ import org.slf4j.LoggerFactory;
     elementTypes = {
       @ConnectorElementType(
           appliesTo = BpmnType.START_EVENT,
-          elementType = BpmnType.START_EVENT,
-          templateIdOverride = "io.camunda.connectors.inbound.AWSSNS.StartEvent.v1",
-          templateNameOverride = "SNS HTTPS Start Event Connector"),
-      @ConnectorElementType(
-          appliesTo = BpmnType.START_EVENT,
           elementType = BpmnType.MESSAGE_START_EVENT,
           templateIdOverride = "io.camunda.connectors.inbound.AWSSNS.MessageStartEvent.v1",
           templateNameOverride = "SNS HTTPS Message Start Event Connector Subscription"),

--- a/connectors/aws/aws-sqs/element-templates/aws-sqs-start-event-connector.json
+++ b/connectors/aws/aws-sqs/element-templates/aws-sqs-start-event-connector.json
@@ -3,7 +3,7 @@
   "name" : "Amazon SQS Start Event Connector",
   "id" : "io.camunda.connectors.AWSSQS.StartEvent.v1",
   "deprecated": {
-    "message": "None start event are deprecated. Start process using a message",
+    "message": "None start event are deprecated. Start process using a message start event",
     "documentationRef": "https://docs.camunda.io/docs/components/modeler/bpmn/none-events/"
   },
   "description" : "Receive message from a queue",

--- a/connectors/aws/aws-sqs/element-templates/aws-sqs-start-event-connector.json
+++ b/connectors/aws/aws-sqs/element-templates/aws-sqs-start-event-connector.json
@@ -3,7 +3,7 @@
   "name" : "Amazon SQS Start Event Connector",
   "id" : "io.camunda.connectors.AWSSQS.StartEvent.v1",
   "deprecated": {
-    "message": "None start event are deprecated. Start process using a message start event",
+    "message": "None Start Events are deprecated in favor of Message Start Events for message based Connectors.",
     "documentationRef": "https://docs.camunda.io/docs/components/modeler/bpmn/none-events/"
   },
   "description" : "Receive message from a queue",

--- a/connectors/aws/aws-sqs/element-templates/aws-sqs-start-event-connector.json
+++ b/connectors/aws/aws-sqs/element-templates/aws-sqs-start-event-connector.json
@@ -2,6 +2,10 @@
   "$schema" : "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
   "name" : "Amazon SQS Start Event Connector",
   "id" : "io.camunda.connectors.AWSSQS.StartEvent.v1",
+  "deprecated": {
+    "message": "None start event are deprecated. Start process using a message",
+    "documentationRef": "https://docs.camunda.io/docs/components/modeler/bpmn/none-events/"
+  },
   "description" : "Receive message from a queue",
   "documentationRef" : "https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-sqs/?amazonsqs=inbound",
   "version" : 9,

--- a/connectors/aws/aws-sqs/src/main/java/io/camunda/connector/inbound/SqsExecutable.java
+++ b/connectors/aws/aws-sqs/src/main/java/io/camunda/connector/inbound/SqsExecutable.java
@@ -48,11 +48,6 @@ import org.slf4j.LoggerFactory;
     elementTypes = {
       @ConnectorElementType(
           appliesTo = BpmnType.START_EVENT,
-          elementType = BpmnType.START_EVENT,
-          templateIdOverride = "io.camunda.connectors.AWSSQS.StartEvent.v1",
-          templateNameOverride = "Amazon SQS Start Event Connector"),
-      @ConnectorElementType(
-          appliesTo = BpmnType.START_EVENT,
           elementType = BpmnType.MESSAGE_START_EVENT,
           templateIdOverride = "io.camunda.connectors.AWSSQS.startmessage.v1",
           templateNameOverride = "Amazon SQS Message Start Event Connector"),

--- a/connectors/kafka/element-templates/kafka-inbound-connector-start-event.json
+++ b/connectors/kafka/element-templates/kafka-inbound-connector-start-event.json
@@ -4,7 +4,7 @@
   "id" : "io.camunda.connectors.inbound.KAFKA.v1",
   "description" : "Consume Kafka messages",
   "deprecated": {
-    "message": "None start event are deprecated. Start process using a message start event",
+    "message": "None Start Events are deprecated in favor of Message Start Events for message based Connectors.",
     "documentationRef": "https://docs.camunda.io/docs/components/modeler/bpmn/none-events/"
   },
   "documentationRef" : "https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/kafka/?kafka=inbound",

--- a/connectors/kafka/element-templates/kafka-inbound-connector-start-event.json
+++ b/connectors/kafka/element-templates/kafka-inbound-connector-start-event.json
@@ -4,7 +4,7 @@
   "id" : "io.camunda.connectors.inbound.KAFKA.v1",
   "description" : "Consume Kafka messages",
   "deprecated": {
-    "message": "None start event are deprecated. Start process using a message",
+    "message": "None start event are deprecated. Start process using a message start event",
     "documentationRef": "https://docs.camunda.io/docs/components/modeler/bpmn/none-events/"
   },
   "documentationRef" : "https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/kafka/?kafka=inbound",

--- a/connectors/kafka/element-templates/kafka-inbound-connector-start-event.json
+++ b/connectors/kafka/element-templates/kafka-inbound-connector-start-event.json
@@ -3,6 +3,10 @@
   "name" : "Kafka Start Event Connector",
   "id" : "io.camunda.connectors.inbound.KAFKA.v1",
   "description" : "Consume Kafka messages",
+  "deprecated": {
+    "message": "None start event are deprecated. Start process using a message",
+    "documentationRef": "https://docs.camunda.io/docs/components/modeler/bpmn/none-events/"
+  },
   "documentationRef" : "https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/kafka/?kafka=inbound",
   "version" : 5,
   "category" : {

--- a/connectors/kafka/src/main/java/io/camunda/connector/kafka/inbound/KafkaExecutable.java
+++ b/connectors/kafka/src/main/java/io/camunda/connector/kafka/inbound/KafkaExecutable.java
@@ -41,11 +41,6 @@ import org.slf4j.LoggerFactory;
     elementTypes = {
       @ElementTemplate.ConnectorElementType(
           appliesTo = BpmnType.START_EVENT,
-          elementType = BpmnType.START_EVENT,
-          templateIdOverride = "io.camunda.connectors.inbound.KAFKA.v1",
-          templateNameOverride = "Kafka Start Event Connector"),
-      @ElementTemplate.ConnectorElementType(
-          appliesTo = BpmnType.START_EVENT,
           elementType = BpmnType.MESSAGE_START_EVENT,
           templateIdOverride = "io.camunda.connectors.inbound.KafkaMessageStart.v1",
           templateNameOverride = "Kafka Message Start Event Connector"),

--- a/connectors/rabbitmq/element-templates/rabbitmq-inbound-connector-start-event.json
+++ b/connectors/rabbitmq/element-templates/rabbitmq-inbound-connector-start-event.json
@@ -4,7 +4,7 @@
   "id" : "io.camunda.connectors.inbound.RabbitMQ.StartEvent.v1",
   "description" : "Receive a message from RabbitMQ",
   "deprecated": {
-    "message": "None start event are deprecated. Start process using a message",
+    "message": "None start event are deprecated. Start process using a message start event",
     "documentationRef": "https://docs.camunda.io/docs/components/modeler/bpmn/none-events/"
   },
   "documentationRef" : "https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=inbound",

--- a/connectors/rabbitmq/element-templates/rabbitmq-inbound-connector-start-event.json
+++ b/connectors/rabbitmq/element-templates/rabbitmq-inbound-connector-start-event.json
@@ -3,6 +3,10 @@
   "name" : "RabbitMQ Start Event Connector",
   "id" : "io.camunda.connectors.inbound.RabbitMQ.StartEvent.v1",
   "description" : "Receive a message from RabbitMQ",
+  "deprecated": {
+    "message": "None start event are deprecated. Start process using a message",
+    "documentationRef": "https://docs.camunda.io/docs/components/modeler/bpmn/none-events/"
+  },
   "documentationRef" : "https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=inbound",
   "version" : 7,
   "category" : {

--- a/connectors/rabbitmq/element-templates/rabbitmq-inbound-connector-start-event.json
+++ b/connectors/rabbitmq/element-templates/rabbitmq-inbound-connector-start-event.json
@@ -4,7 +4,7 @@
   "id" : "io.camunda.connectors.inbound.RabbitMQ.StartEvent.v1",
   "description" : "Receive a message from RabbitMQ",
   "deprecated": {
-    "message": "None start event are deprecated. Start process using a message start event",
+    "message": "None Start Events are deprecated in favor of Message Start Events for message based Connectors.",
     "documentationRef": "https://docs.camunda.io/docs/components/modeler/bpmn/none-events/"
   },
   "documentationRef" : "https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/rabbitmq/?rabbitmq=inbound",

--- a/connectors/rabbitmq/src/main/java/io/camunda/connector/rabbitmq/inbound/RabbitMqExecutable.java
+++ b/connectors/rabbitmq/src/main/java/io/camunda/connector/rabbitmq/inbound/RabbitMqExecutable.java
@@ -44,11 +44,6 @@ import org.slf4j.LoggerFactory;
     elementTypes = {
       @ElementTemplate.ConnectorElementType(
           appliesTo = BpmnType.START_EVENT,
-          elementType = BpmnType.START_EVENT,
-          templateIdOverride = "io.camunda.connectors.inbound.RabbitMQ.StartEvent.v1",
-          templateNameOverride = "RabbitMQ Start Event Connector"),
-      @ElementTemplate.ConnectorElementType(
-          appliesTo = BpmnType.START_EVENT,
           elementType = BpmnType.MESSAGE_START_EVENT,
           templateIdOverride = "io.camunda.connectors.inbound.RabbitMQ.MessageStart.v1",
           templateNameOverride = "RabbitMQ Message Start Event Connector"),


### PR DESCRIPTION
## Description

We don't have a way to signal the et-generator plugin we want to deprecate a specific type of connector.
None start event will not be generated anymore for connectors:

- AWS SQS
- AWS SNS
- Kafka
- RabbitMQ

They will also be deleted from the web modeler.

I might need help from @sbuettner to remove them from the marketplace.

I noticed that AWS SNS implement `webhookconnectorExecutable`.  Should we still delete it as well?

## Related issues

closes https://github.com/camunda/team-connectors/issues/857

