### PR TITLE
fix(core) rest connector inbound was not working with query params

### DIFF
--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/webhook/InboundWebhookRestController.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/webhook/InboundWebhookRestController.java
@@ -98,7 +98,7 @@ public class InboundWebhookRestController {
       @PathVariable(value = "context") String context,
       @RequestHeader Map<String, String> headers,
       @RequestBody(required = false) byte[] bodyAsByteArray,
-      @RequestParam(required = false, value = "params") Map<String, String> params,
+      @RequestParam(required = false) Map<String, String> params,
       HttpServletRequest httpServletRequest)
       throws IOException {
     LOG.trace("Received inbound hook on {}", context);

--- a/connectors-e2e-test/connectors-e2e-test-http/src/test/java/io/camunda/connector/e2e/HttpTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-http/src/test/java/io/camunda/connector/e2e/HttpTests.java
@@ -366,6 +366,36 @@ public class HttpTests {
   }
 
   @Test
+  void successfulWebhookModelWithQueryParamsRun() throws Exception {
+    var mockUrl = "http://localhost:" + serverPort + "/inbound/test-webhook?value=test";
+
+    var model = replace("webhook_connector.bpmn", replace("http://webhook", mockUrl));
+
+    // Prepare a mocked process connectorData backed by our test model
+    when(camundaOperateClient.getProcessDefinitionModel(1L)).thenReturn(model);
+    var processDef = mock(ProcessDefinition.class);
+    when(processDef.getKey()).thenReturn(1L);
+    when(processDef.getTenantId()).thenReturn(zeebeClient.getConfiguration().getDefaultTenantId());
+    when(processDef.getBpmnProcessId())
+            .thenReturn(model.getModelElementsByType(Process.class).stream().findFirst().get().getId());
+
+    // Deploy the webhook
+    stateStore.update(
+            new ProcessImportResult(
+                    Map.of(
+                            new ProcessDefinitionIdentifier(
+                                    processDef.getBpmnProcessId(), processDef.getTenantId()),
+                            new ProcessDefinitionVersion(
+                                    processDef.getKey(), processDef.getVersion().intValue()))));
+
+    var bpmnTest =
+            ZeebeTest.with(zeebeClient).deploy(model).createInstance().waitForProcessCompletion();
+
+    assertThat(bpmnTest.getProcessInstanceEvent()).hasVariableWithValue("webhookExecuted", true);
+    assertThat(bpmnTest.getProcessInstanceEvent()).hasVariableWithValue("queryParam", "test");
+  }
+
+  @Test
   void graphQL() {
     // Prepare an HTTP mock server
     wm.stubFor(

--- a/connectors-e2e-test/connectors-e2e-test-http/src/test/java/io/camunda/connector/e2e/HttpTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-http/src/test/java/io/camunda/connector/e2e/HttpTests.java
@@ -377,19 +377,19 @@ public class HttpTests {
     when(processDef.getKey()).thenReturn(1L);
     when(processDef.getTenantId()).thenReturn(zeebeClient.getConfiguration().getDefaultTenantId());
     when(processDef.getBpmnProcessId())
-            .thenReturn(model.getModelElementsByType(Process.class).stream().findFirst().get().getId());
+        .thenReturn(model.getModelElementsByType(Process.class).stream().findFirst().get().getId());
 
     // Deploy the webhook
     stateStore.update(
-            new ProcessImportResult(
-                    Map.of(
-                            new ProcessDefinitionIdentifier(
-                                    processDef.getBpmnProcessId(), processDef.getTenantId()),
-                            new ProcessDefinitionVersion(
-                                    processDef.getKey(), processDef.getVersion().intValue()))));
+        new ProcessImportResult(
+            Map.of(
+                new ProcessDefinitionIdentifier(
+                    processDef.getBpmnProcessId(), processDef.getTenantId()),
+                new ProcessDefinitionVersion(
+                    processDef.getKey(), processDef.getVersion().intValue()))));
 
     var bpmnTest =
-            ZeebeTest.with(zeebeClient).deploy(model).createInstance().waitForProcessCompletion();
+        ZeebeTest.with(zeebeClient).deploy(model).createInstance().waitForProcessCompletion();
 
     assertThat(bpmnTest.getProcessInstanceEvent()).hasVariableWithValue("webhookExecuted", true);
     assertThat(bpmnTest.getProcessInstanceEvent()).hasVariableWithValue("queryParam", "test");

--- a/connectors-e2e-test/connectors-e2e-test-http/src/test/resources/webhook_connector.bpmn
+++ b/connectors-e2e-test/connectors-e2e-test-http/src/test/resources/webhook_connector.bpmn
@@ -20,7 +20,7 @@
           <zeebe:property name="inbound.auth.apiKey" value="123" />
           <zeebe:property name="inbound.auth.apiKeyLocator" value="=split(request.headers.authorization, &#34; &#34;)[2]" />
           <zeebe:property name="correlationKeyExpression" value="=request.body.correlationKey" />
-          <zeebe:property name="resultExpression" value="={correlationKey: request.body.correlationKey, webhookExecuted: request.body.webhookExecuted}" />
+          <zeebe:property name="resultExpression" value="={correlationKey: request.body.correlationKey, webhookExecuted: request.body.webhookExecuted, queryParam: request.params.value}" />
           <zeebe:property name="inbound.responseBodyExpression" value="={correlationKey: request.body.correlationKey}" />
         </zeebe:properties>
       </bpmn:extensionElements>


### PR DESCRIPTION
## Description

removing the value parameter in annotation.

Tested for message start and intermediate catch event successfully.

## Related issues

closes https://github.com/camunda/team-connectors/issues/876
