### PR TITLE
feat: add /connector-test endpoint to test outbound connector

### DIFF
--- a/bundle/camunda-saas-bundle/src/main/java/io/camunda/connector/runtime/saas/security/SecurityConfiguration.java
+++ b/bundle/camunda-saas-bundle/src/main/java/io/camunda/connector/runtime/saas/security/SecurityConfiguration.java
@@ -58,6 +58,7 @@ public class SecurityConfiguration {
         .securityMatchers(
             requestMatcherConfigurer ->
                 requestMatcherConfigurer
+                    .requestMatchers(HttpMethod.POST, "/connector-test")
                     .requestMatchers(HttpMethod.GET, "/inbound/*")
                     .requestMatchers(HttpMethod.POST, "/inbound/*")
                     .requestMatchers(HttpMethod.PUT, "/inbound/*")

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/OutboundConnectorRuntimeConfiguration.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/OutboundConnectorRuntimeConfiguration.java
@@ -24,14 +24,19 @@ import io.camunda.connector.runtime.core.outbound.OutboundConnectorFactory;
 import io.camunda.connector.runtime.core.secret.SecretProviderAggregator;
 import io.camunda.connector.runtime.outbound.lifecycle.OutboundConnectorAnnotationProcessor;
 import io.camunda.connector.runtime.outbound.lifecycle.OutboundConnectorManager;
+import io.camunda.connector.runtime.test.ConnectorTestImpl;
+import io.camunda.connector.runtime.test.ConnectorTestRestController;
+import io.camunda.zeebe.client.ZeebeClient;
 import io.camunda.zeebe.spring.client.jobhandling.CommandExceptionHandlingStrategy;
 import io.camunda.zeebe.spring.client.jobhandling.JobWorkerManager;
 import io.camunda.zeebe.spring.client.metrics.MetricsRecorder;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
 
 @Configuration
+@Import({ConnectorTestRestController.class})
 public class OutboundConnectorRuntimeConfiguration {
 
   @Bean
@@ -63,5 +68,13 @@ public class OutboundConnectorRuntimeConfiguration {
   public OutboundConnectorAnnotationProcessor annotationProcessor(
       OutboundConnectorManager manager, OutboundConnectorFactory factory) {
     return new OutboundConnectorAnnotationProcessor(manager, factory);
+  }
+
+  @Bean
+  public ConnectorTestImpl connectorTest(
+      ZeebeClient zeebeClient,
+      ObjectMapper objectMapper,
+      SecretProviderAggregator secretProviderAggregator) {
+    return new ConnectorTestImpl(zeebeClient, objectMapper, secretProviderAggregator);
   }
 }

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/test/ConnectorTest.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/test/ConnectorTest.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.runtime.test;
+
+public interface ConnectorTest {
+
+  void test(ConnectorTestRq req) throws Exception;
+}

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/test/ConnectorTestActivatedJobImpl.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/test/ConnectorTestActivatedJobImpl.java
@@ -1,0 +1,204 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.runtime.test;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import io.camunda.connector.feel.FeelEngineWrapper;
+import io.camunda.zeebe.client.api.JsonMapper;
+import io.camunda.zeebe.client.api.command.ClientException;
+import io.camunda.zeebe.client.api.response.ActivatedJob;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+public class ConnectorTestActivatedJobImpl implements ActivatedJob {
+
+  public static FeelEngineWrapper FEEL_ENGINE_WRAPPER = new FeelEngineWrapper();
+
+  @JsonIgnore private final JsonMapper jsonMapper;
+
+  private final long key;
+  private final String type;
+  private final Map<String, String> customHeaders;
+  private final long processInstanceKey;
+  private final String bpmnProcessId;
+  private final int processDefinitionVersion;
+  private final long processDefinitionKey;
+  private final String elementId;
+  private final long elementInstanceKey;
+  private final String tenantId;
+  private final String worker;
+  private final int retries;
+  private final long deadline;
+  private final String variables;
+
+  private Map<String, Object> variablesAsMap;
+
+  public ConnectorTestActivatedJobImpl(
+      final JsonMapper jsonMapper, final ConnectorTestRq connectorTestRq) {
+    this.jsonMapper = jsonMapper;
+
+    var variables = resolveVariables(connectorTestRq, this.jsonMapper);
+
+    key = 123l;
+    type = connectorTestRq.type(); // "io.camunda:http-json:1";
+
+    final String customHeaders = connectorTestRq.customHeaders(); // "{\"retryBackoff\":\"PT0S\"}";
+    this.customHeaders =
+        customHeaders.isEmpty() ? new HashMap<>() : jsonMapper.fromJsonAsStringMap(customHeaders);
+    worker = "HTTP REST";
+    retries = 3;
+    deadline = 123l;
+    this.variables =
+        variables; // "{\"url\":\"https://abc.com/def\",\"method\":\"GET\",\"authentication\":{\"type\":\"noAuth\"},\"readTimeoutInSeconds\":\"20\",\"connectionTimeoutInSeconds\":\"20\"}";
+    processInstanceKey = 123l;
+    bpmnProcessId = "job.getBpmnProcessId()";
+    processDefinitionVersion = 1;
+    processDefinitionKey = 123l;
+    elementId = "job.getElementId()";
+    elementInstanceKey = 123l;
+    tenantId = "job.getTenantId()";
+  }
+
+  private String resolveVariables(
+      final ConnectorTestRq connectorTestRq, final JsonMapper jsonMapper) {
+    var contextAsMap =
+        Optional.ofNullable(connectorTestRq.context())
+            .filter(context -> !connectorTestRq.context().isBlank())
+            .map(context -> jsonMapper.fromJsonAsMap(context))
+            .orElse(Collections.emptyMap());
+    var variablesMap = jsonMapper.fromJsonAsMap(connectorTestRq.variables());
+    evaluateAllFeelStringsInMap(variablesMap, contextAsMap);
+    return jsonMapper.toJson(variablesMap);
+  }
+
+  public void evaluateAllFeelStringsInMap(
+      Map<String, Object> variablesMap, Map<String, Object> contextAsMap) {
+    for (Map.Entry<String, Object> entry : variablesMap.entrySet()) {
+      Object value = entry.getValue();
+      if (value instanceof String && ((String) entry.getValue()).startsWith("=")) {
+        var newValue = FEEL_ENGINE_WRAPPER.evaluateToJson((String) entry.getValue(), contextAsMap);
+        entry.setValue(newValue);
+      } else if (value instanceof Map) {
+        evaluateAllFeelStringsInMap((Map<String, Object>) value, contextAsMap);
+      }
+    }
+  }
+
+  @Override
+  public long getKey() {
+    return key;
+  }
+
+  @Override
+  public String getType() {
+    return type;
+  }
+
+  @Override
+  public long getProcessInstanceKey() {
+    return processInstanceKey;
+  }
+
+  @Override
+  public String getBpmnProcessId() {
+    return bpmnProcessId;
+  }
+
+  @Override
+  public int getProcessDefinitionVersion() {
+    return processDefinitionVersion;
+  }
+
+  @Override
+  public long getProcessDefinitionKey() {
+    return processDefinitionKey;
+  }
+
+  @Override
+  public String getElementId() {
+    return elementId;
+  }
+
+  @Override
+  public long getElementInstanceKey() {
+    return elementInstanceKey;
+  }
+
+  @Override
+  public Map<String, String> getCustomHeaders() {
+    return customHeaders;
+  }
+
+  @Override
+  public String getWorker() {
+    return worker;
+  }
+
+  @Override
+  public int getRetries() {
+    return retries;
+  }
+
+  @Override
+  public long getDeadline() {
+    return deadline;
+  }
+
+  @Override
+  public String getVariables() {
+    return variables;
+  }
+
+  @Override
+  public Map<String, Object> getVariablesAsMap() {
+    if (variablesAsMap == null) {
+      variablesAsMap = jsonMapper.fromJsonAsMap(variables);
+    }
+    return variablesAsMap;
+  }
+
+  @Override
+  public <T> T getVariablesAsType(final Class<T> variableType) {
+    return jsonMapper.fromJson(variables, variableType);
+  }
+
+  @Override
+  public Object getVariable(final String name) {
+    final Map<String, Object> variables = getVariablesAsMap();
+    if (!variables.containsKey(name)) {
+      throw new ClientException(String.format("The variable %s is not available", name));
+    }
+    return getVariablesAsMap().get(name);
+  }
+
+  @Override
+  public String toJson() {
+    return jsonMapper.toJson(this);
+  }
+
+  @Override
+  public String getTenantId() {
+    return tenantId;
+  }
+
+  @Override
+  public String toString() {
+    return ""; // return toJson();
+  }
+}

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/test/ConnectorTestCompleteJobCommandImpl.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/test/ConnectorTestCompleteJobCommandImpl.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.runtime.test;
+
+import io.camunda.zeebe.client.api.ZeebeFuture;
+import io.camunda.zeebe.client.api.command.CompleteJobCommandStep1;
+import io.camunda.zeebe.client.api.command.FinalCommandStep;
+import io.camunda.zeebe.client.api.response.CompleteJobResponse;
+import java.io.InputStream;
+import java.time.Duration;
+import java.util.Map;
+
+class ConnectorTestCompleteJobCommandImpl implements CompleteJobCommandStep1 {
+
+  long jobKey;
+
+  ConnectorTestCompleteJobCommandImpl(long jobKey) {
+    this.jobKey = jobKey;
+  }
+
+  @Override
+  public CompleteJobCommandStep1 variables(InputStream variables) {
+    return this;
+  }
+
+  @Override
+  public CompleteJobCommandStep1 variables(String variables) {
+    return this;
+  }
+
+  @Override
+  public CompleteJobCommandStep1 variables(Map<String, Object> variables) {
+    return this;
+  }
+
+  @Override
+  public CompleteJobCommandStep1 variables(Object variables) {
+    return this;
+  }
+
+  @Override
+  public CompleteJobCommandStep1 variable(String key, Object value) {
+    return this;
+  }
+
+  @Override
+  public FinalCommandStep<CompleteJobResponse> requestTimeout(Duration requestTimeout) {
+    return null;
+  }
+
+  @Override
+  public ZeebeFuture<CompleteJobResponse> send() {
+    return new ConnectorTestZeebeFutureImpl();
+  }
+}

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/test/ConnectorTestImpl.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/test/ConnectorTestImpl.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.runtime.test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.connector.api.outbound.OutboundConnectorFunction;
+import io.camunda.connector.runtime.core.outbound.ConnectorJobHandler;
+import io.camunda.connector.runtime.core.outbound.DefaultOutboundConnectorFactory;
+import io.camunda.connector.runtime.core.outbound.OutboundConnectorDiscovery;
+import io.camunda.connector.runtime.core.outbound.OutboundConnectorFactory;
+import io.camunda.connector.runtime.core.secret.SecretProviderAggregator;
+import io.camunda.zeebe.client.ZeebeClient;
+import io.camunda.zeebe.client.api.worker.JobClient;
+import io.camunda.zeebe.client.impl.ZeebeObjectMapper;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ConnectorTestImpl implements ConnectorTest {
+  ZeebeClient zeebeClient;
+
+  private final JobClient jobClient = new ConnectorTestJobClientImpl();
+
+  ObjectMapper objectMapper;
+
+  SecretProviderAggregator secretProviderAggregator;
+
+  OutboundConnectorFactory connectorFactory =
+      new DefaultOutboundConnectorFactory(OutboundConnectorDiscovery.loadConnectorConfigurations());
+
+  public ConnectorTestImpl(
+      ZeebeClient zeebeClient,
+      ObjectMapper objectMapper,
+      SecretProviderAggregator secretProviderAggregator) {
+    this.secretProviderAggregator = secretProviderAggregator;
+    this.zeebeClient = zeebeClient;
+    this.objectMapper = objectMapper;
+  }
+
+  public void test(ConnectorTestRq req) throws Exception {
+    var job = new ConnectorTestActivatedJobImpl(new ZeebeObjectMapper(), req);
+    OutboundConnectorFunction connectorFunction = connectorFactory.getInstance(job.getType());
+    var jobHandler =
+        new ConnectorJobHandler(connectorFunction, secretProviderAggregator, e -> {}, objectMapper);
+    jobHandler.handle(jobClient, job);
+  }
+}

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/test/ConnectorTestJobClientImpl.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/test/ConnectorTestJobClientImpl.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.runtime.test;
+
+import io.camunda.zeebe.client.api.command.ActivateJobsCommandStep1;
+import io.camunda.zeebe.client.api.command.CompleteJobCommandStep1;
+import io.camunda.zeebe.client.api.command.FailJobCommandStep1;
+import io.camunda.zeebe.client.api.command.StreamJobsCommandStep1;
+import io.camunda.zeebe.client.api.command.ThrowErrorCommandStep1;
+import io.camunda.zeebe.client.api.response.ActivatedJob;
+import io.camunda.zeebe.client.api.worker.JobClient;
+
+public class ConnectorTestJobClientImpl implements JobClient {
+
+  @Override
+  public CompleteJobCommandStep1 newCompleteCommand(long jobKey) {
+    return new ConnectorTestCompleteJobCommandImpl(jobKey);
+  }
+
+  @Override
+  public CompleteJobCommandStep1 newCompleteCommand(ActivatedJob job) {
+    return newCompleteCommand(job.getKey());
+  }
+
+  @Override
+  public FailJobCommandStep1 newFailCommand(long jobKey) {
+    return null;
+  }
+
+  @Override
+  public FailJobCommandStep1 newFailCommand(ActivatedJob job) {
+    return newFailCommand(job.getKey());
+  }
+
+  @Override
+  public ThrowErrorCommandStep1 newThrowErrorCommand(long jobKey) {
+    return null;
+  }
+
+  @Override
+  public ThrowErrorCommandStep1 newThrowErrorCommand(ActivatedJob job) {
+    return null;
+  }
+
+  @Override
+  public ActivateJobsCommandStep1 newActivateJobsCommand() {
+    return null;
+  }
+
+  @Override
+  public StreamJobsCommandStep1 newStreamJobsCommand() {
+    return null;
+  }
+}

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/test/ConnectorTestRestController.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/test/ConnectorTestRestController.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.runtime.test;
+
+import io.camunda.connector.runtime.inbound.controller.InboundConnectorRestController;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class ConnectorTestRestController {
+
+  private static final Logger LOG = LoggerFactory.getLogger(InboundConnectorRestController.class);
+
+  ConnectorTest connectorTest;
+
+  public ConnectorTestRestController(ConnectorTest connectorTest) {
+    this.connectorTest = connectorTest;
+  }
+
+  @PostMapping("/connector-test")
+  public Boolean execute(@RequestBody ConnectorTestRq connectorData) throws Exception {
+    LOG.trace("'/connector-test' endpoint has been called");
+    connectorTest.test(connectorData);
+    return true;
+  }
+}

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/test/ConnectorTestRq.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/test/ConnectorTestRq.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.runtime.test;
+
+public record ConnectorTestRq(
+    String type, String variables, String customHeaders, String context) {}

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/test/ConnectorTestZeebeFutureImpl.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/test/ConnectorTestZeebeFutureImpl.java
@@ -1,0 +1,266 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.runtime.test;
+
+import io.camunda.zeebe.client.api.ZeebeFuture;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.function.BiConsumer;
+import java.util.function.BiFunction;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ConnectorTestZeebeFutureImpl implements ZeebeFuture {
+  private static final Logger LOG = LoggerFactory.getLogger(ConnectorTestZeebeFutureImpl.class);
+
+  @Override
+  public Object join() {
+    LOG.debug("FakeZeebeFuture join called");
+    return null;
+  }
+
+  @Override
+  public Object join(long timeout, TimeUnit unit) {
+    return null;
+  }
+
+  @Override
+  public CompletionStage thenApply(Function fn) {
+    return null;
+  }
+
+  @Override
+  public CompletionStage thenApplyAsync(Function fn) {
+    return null;
+  }
+
+  @Override
+  public CompletionStage thenApplyAsync(Function fn, Executor executor) {
+    return null;
+  }
+
+  @Override
+  public CompletionStage<Void> thenAccept(Consumer action) {
+    return null;
+  }
+
+  @Override
+  public CompletionStage<Void> thenAcceptAsync(Consumer action) {
+    return null;
+  }
+
+  @Override
+  public CompletionStage<Void> thenAcceptAsync(Consumer action, Executor executor) {
+    return null;
+  }
+
+  @Override
+  public CompletionStage<Void> thenRun(Runnable action) {
+    return null;
+  }
+
+  @Override
+  public CompletionStage<Void> thenRunAsync(Runnable action) {
+    return null;
+  }
+
+  @Override
+  public CompletionStage<Void> thenRunAsync(Runnable action, Executor executor) {
+    return null;
+  }
+
+  @Override
+  public CompletionStage<Void> acceptEither(CompletionStage other, Consumer action) {
+    return null;
+  }
+
+  @Override
+  public CompletionStage<Void> acceptEitherAsync(CompletionStage other, Consumer action) {
+    return null;
+  }
+
+  @Override
+  public CompletionStage<Void> acceptEitherAsync(
+      CompletionStage other, Consumer action, Executor executor) {
+    return null;
+  }
+
+  @Override
+  public CompletableFuture toCompletableFuture() {
+    return null;
+  }
+
+  @Override
+  public CompletionStage exceptionally(Function fn) {
+    return null;
+  }
+
+  @Override
+  public CompletionStage whenCompleteAsync(BiConsumer action, Executor executor) {
+    return null;
+  }
+
+  @Override
+  public CompletionStage whenCompleteAsync(BiConsumer action) {
+    return null;
+  }
+
+  @Override
+  public CompletionStage whenComplete(BiConsumer action) {
+    return null;
+  }
+
+  @Override
+  public CompletionStage handleAsync(BiFunction fn, Executor executor) {
+    return null;
+  }
+
+  @Override
+  public CompletionStage handleAsync(BiFunction fn) {
+    return null;
+  }
+
+  @Override
+  public CompletionStage handle(BiFunction fn) {
+    return null;
+  }
+
+  @Override
+  public CompletionStage thenComposeAsync(Function fn, Executor executor) {
+    return null;
+  }
+
+  @Override
+  public CompletionStage thenComposeAsync(Function fn) {
+    return null;
+  }
+
+  @Override
+  public CompletionStage thenCompose(Function fn) {
+    return null;
+  }
+
+  @Override
+  public CompletionStage<Void> runAfterEitherAsync(
+      CompletionStage other, Runnable action, Executor executor) {
+    return null;
+  }
+
+  @Override
+  public CompletionStage<Void> runAfterEitherAsync(CompletionStage other, Runnable action) {
+    return null;
+  }
+
+  @Override
+  public CompletionStage<Void> runAfterEither(CompletionStage other, Runnable action) {
+    return null;
+  }
+
+  @Override
+  public CompletionStage applyToEitherAsync(CompletionStage other, Function fn, Executor executor) {
+    return null;
+  }
+
+  @Override
+  public CompletionStage applyToEitherAsync(CompletionStage other, Function fn) {
+    return null;
+  }
+
+  @Override
+  public CompletionStage applyToEither(CompletionStage other, Function fn) {
+    return null;
+  }
+
+  @Override
+  public CompletionStage<Void> runAfterBothAsync(
+      CompletionStage other, Runnable action, Executor executor) {
+    return null;
+  }
+
+  @Override
+  public CompletionStage<Void> runAfterBothAsync(CompletionStage other, Runnable action) {
+    return null;
+  }
+
+  @Override
+  public CompletionStage<Void> runAfterBoth(CompletionStage other, Runnable action) {
+    return null;
+  }
+
+  @Override
+  public CompletionStage<Void> thenAcceptBothAsync(
+      CompletionStage other, BiConsumer action, Executor executor) {
+    return null;
+  }
+
+  @Override
+  public CompletionStage<Void> thenAcceptBothAsync(CompletionStage other, BiConsumer action) {
+    return null;
+  }
+
+  @Override
+  public CompletionStage<Void> thenAcceptBoth(CompletionStage other, BiConsumer action) {
+    return null;
+  }
+
+  @Override
+  public CompletionStage thenCombineAsync(CompletionStage other, BiFunction fn, Executor executor) {
+    return null;
+  }
+
+  @Override
+  public CompletionStage thenCombineAsync(CompletionStage other, BiFunction fn) {
+    return null;
+  }
+
+  @Override
+  public CompletionStage thenCombine(CompletionStage other, BiFunction fn) {
+    return null;
+  }
+
+  @Override
+  public boolean cancel(boolean mayInterruptIfRunning) {
+    return false;
+  }
+
+  @Override
+  public boolean isCancelled() {
+    return false;
+  }
+
+  @Override
+  public boolean isDone() {
+    return false;
+  }
+
+  @Override
+  public Object get() throws InterruptedException, ExecutionException {
+    return null;
+  }
+
+  @Override
+  public Object get(long timeout, TimeUnit unit)
+      throws InterruptedException, ExecutionException, TimeoutException {
+    return null;
+  }
+}


### PR DESCRIPTION
## Description

Hackdays project to test Outbound Connectors from web-modeler. A new `/connector-test` was added to trigger the execution of a connector. 

