### PR TITLE
[Backport release/8.4] fix(core) rest connector inbound was not working with query params (#…

### DIFF
--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/webhook/InboundWebhookRestController.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/webhook/InboundWebhookRestController.java
@@ -74,7 +74,7 @@ public class InboundWebhookRestController {
       @PathVariable(value = "context") String context,
       @RequestHeader Map<String, String> headers,
       @RequestBody(required = false) byte[] bodyAsByteArray,
-      @RequestParam(required = false, value = "params") Map<String, String> params,
+      @RequestParam(required = false) Map<String, String> params,
       HttpServletRequest httpServletRequest)
       throws IOException {
     LOG.trace("Received inbound hook on {}", context);

--- a/connectors-e2e-test/connectors-e2e-test-http/src/test/resources/webhook_connector.bpmn
+++ b/connectors-e2e-test/connectors-e2e-test-http/src/test/resources/webhook_connector.bpmn
@@ -20,7 +20,7 @@
           <zeebe:property name="inbound.auth.apiKey" value="123" />
           <zeebe:property name="inbound.auth.apiKeyLocator" value="=split(request.headers.authorization, &#34; &#34;)[2]" />
           <zeebe:property name="correlationKeyExpression" value="=request.body.correlationKey" />
-          <zeebe:property name="resultExpression" value="={correlationKey: request.body.correlationKey, webhookExecuted: request.body.webhookExecuted}" />
+          <zeebe:property name="resultExpression" value="={correlationKey: request.body.correlationKey, webhookExecuted: request.body.webhookExecuted, queryParam: request.params.value}" />
           <zeebe:property name="inbound.responseBodyExpression" value="={correlationKey: request.body.correlationKey}" />
         </zeebe:properties>
       </bpmn:extensionElements>


### PR DESCRIPTION
…3080)

* fix(core) rest connector inbound was not working with query params

* fix(webhook): add integration test to verify query param are being processed correctly

* fix(integration-tests): fix formatting

(cherry picked from commit b00bca31c27de9eebfe4081668bab66a1e068f38)

## Description

<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #

