### PR TITLE
chore(ci): introduce merge conflict comments

### DIFF
--- a/.github/workflows/PREVIEW-ENV-DEPLOY.yml
+++ b/.github/workflows/PREVIEW-ENV-DEPLOY.yml
@@ -78,6 +78,14 @@ jobs:
         app_url: https://${{ steps.sanitize.outputs.branch_name }}-${{ matrix.product_context }}.connectors.camunda.cloud
         argocd_arguments: ${{ env.argocd_arguments }}
         argocd_server: argocd.int.camunda.com
+  conflicts:
+    if: always() && github.event_name == 'pull_request' && (contains( github.event.label.name, 'deploy-preview') || contains( github.event.pull_request.labels.*.name, 'deploy-preview'))
+    runs-on: ubuntu-22.04
+    steps:
+    - name: Check PR for merge conflicts
+      uses: camunda/infra-global-github-actions/preview-env/conflicts@main
+      with:
+        pull-request-id: ${{ github.event.pull_request.number }}
   clean:
     if: always() && github.event_name == 'pull_request' && needs.deploy-preview.result != 'skipped'
     uses: camunda/connectors/.github/workflows/PREVIEW-ENV-CLEAN.yml@main
@@ -91,4 +99,4 @@ jobs:
     runs-on: ubuntu-22.04
     needs: [deploy-preview]
     steps:
-      - uses: camunda/infra-global-github-actions/preview-env/comment@main
+    - uses: camunda/infra-global-github-actions/preview-env/comment@main

--- a/.github/workflows/check-pr-conflicts.yml
+++ b/.github/workflows/check-pr-conflicts.yml
@@ -1,0 +1,15 @@
+---
+name: Check for PR conflicts
+
+on:
+  schedule:
+  - cron: 23 1 * * 1-5
+  workflow_dispatch:
+
+jobs:
+  check-pr-conflicts:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+    - name: Check all PRs for conflict
+      uses: camunda/infra-global-github-actions/preview-env/conflicts@main


### PR DESCRIPTION
## Description

When pipelines/workflows don't run due to merge conflicts with the base branch, it's not always that obvious.
The newly introduced workflow will check for merge conflicts in PRs labeled `deploy-preview`.

Furthermore, we'll introduce a quick-cleanup in the `preview-env-deploy.yml` workflow, which will get rid of the comment as soon as the merge conflict got resolved.

## Related issues

* https://github.com/camunda/team-infrastructure/issues/566


