### PR TITLE
fix(sqs): Minor fix to prevent user from entering a 0 polling time which would result to CPU throtling.

### DIFF
--- a/connectors/aws/aws-sqs/element-templates/aws-sqs-boundary-connector.json
+++ b/connectors/aws/aws-sqs/element-templates/aws-sqs-boundary-connector.json
@@ -155,7 +155,7 @@
     "constraints" : {
       "notEmpty" : true,
       "pattern" : {
-        "value" : "^([0-9]?|1[0-9]|20|secrets\\..+)$"
+        "value" : "^([1-9]?|1[0-9]|20|secrets\\..+)$"
       }
     },
     "group" : "messagePollingProperties",

--- a/connectors/aws/aws-sqs/element-templates/aws-sqs-inbound-intermediate-connector.json
+++ b/connectors/aws/aws-sqs/element-templates/aws-sqs-inbound-intermediate-connector.json
@@ -155,7 +155,7 @@
     "constraints" : {
       "notEmpty" : true,
       "pattern" : {
-        "value" : "^([0-9]?|1[0-9]|20|secrets\\..+)$"
+        "value" : "^([1-9]?|1[0-9]|20|secrets\\..+)$"
       }
     },
     "group" : "messagePollingProperties",

--- a/connectors/aws/aws-sqs/element-templates/aws-sqs-start-message.json
+++ b/connectors/aws/aws-sqs/element-templates/aws-sqs-start-message.json
@@ -155,7 +155,7 @@
     "constraints" : {
       "notEmpty" : true,
       "pattern" : {
-        "value" : "^([0-9]?|1[0-9]|20|secrets\\..+)$"
+        "value" : "^([1-9]?|1[0-9]|20|secrets\\..+)$"
       }
     },
     "group" : "messagePollingProperties",

--- a/connectors/aws/aws-sqs/src/main/java/io/camunda/connector/inbound/SqsQueueConsumer.java
+++ b/connectors/aws/aws-sqs/src/main/java/io/camunda/connector/inbound/SqsQueueConsumer.java
@@ -99,7 +99,7 @@ public class SqsQueueConsumer implements Runnable {
 
   private ReceiveMessageRequest createReceiveMessageRequest() {
     return new ReceiveMessageRequest()
-        .withWaitTimeSeconds(Integer.valueOf(properties.getQueue().pollingWaitTime()))
+        .withWaitTimeSeconds(Math.max(Integer.parseInt(properties.getQueue().pollingWaitTime()), 1))
         .withQueueUrl(properties.getQueue().url())
         .withMessageAttributeNames(
             Optional.ofNullable(properties.getQueue().messageAttributeNames())

--- a/connectors/aws/aws-sqs/src/main/java/io/camunda/connector/inbound/model/SqsInboundQueueProperties.java
+++ b/connectors/aws/aws-sqs/src/main/java/io/camunda/connector/inbound/model/SqsInboundQueueProperties.java
@@ -46,6 +46,6 @@ public record SqsInboundQueueProperties(
             description =
                 "The duration (in seconds) for which the call waits for a message to arrive in the queue before returning. See <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-sqs/?amazonsqs=inbound\" target=\"_blank\">documentation</a> for details",
             feel = FeelMode.disabled)
-        @Pattern(regexp = "^([0-9]?|1[0-9]|20|secrets\\..+)$")
+        @Pattern(regexp = "^([1-9]?|1[0-9]|20|secrets\\..+)$")
         @NotBlank
         String pollingWaitTime) {}


### PR DESCRIPTION
## Description

It prevents the user to enter a 0 polling time value.

That's a solution I can propose to resolve this issue https://github.com/camunda/team-connectors/issues/831

@sbuettner @chillleader What do you think?

## Related issues

closes https://github.com/camunda/team-connectors/issues/831 potentially 

