### PR TITLE
fix(rabbitmq): unnecessary unescaping in inbound connector

### DIFF
--- a/connectors/rabbitmq/src/main/java/io/camunda/connector/rabbitmq/inbound/RabbitMqConsumer.java
+++ b/connectors/rabbitmq/src/main/java/io/camunda/connector/rabbitmq/inbound/RabbitMqConsumer.java
@@ -22,7 +22,6 @@ import io.camunda.connector.rabbitmq.inbound.model.RabbitMqInboundResult.RabbitM
 import io.camunda.connector.rabbitmq.supplier.ObjectMapperSupplier;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import org.apache.commons.text.StringEscapeUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -85,8 +84,7 @@ public class RabbitMqConsumer extends DefaultConsumer {
       Object bodyAsObject;
       if (isPayloadJson(bodyAsString)) {
         JsonNode bodyAsJsonElement =
-            ObjectMapperSupplier.instance()
-                .readValue(StringEscapeUtils.unescapeJson(bodyAsString), JsonNode.class);
+            ObjectMapperSupplier.instance().readValue(bodyAsString, JsonNode.class);
         if (bodyAsJsonElement instanceof ValueNode bodyAsPrimitive) {
           if (bodyAsPrimitive.isBoolean()) {
             bodyAsObject = bodyAsPrimitive.asBoolean();
@@ -115,8 +113,7 @@ public class RabbitMqConsumer extends DefaultConsumer {
 
   private boolean isPayloadJson(final String bodyAsString) {
     try {
-      ObjectMapperSupplier.instance()
-          .readValue(StringEscapeUtils.unescapeJson(bodyAsString), JsonNode.class);
+      ObjectMapperSupplier.instance().readValue(bodyAsString, JsonNode.class);
     } catch (JsonProcessingException e) {
       return false;
     }


### PR DESCRIPTION
## Description

This PR removes unnecessary unescaping from the RabbitMQ inbound connector.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #2730 

related PR: https://github.com/camunda/connectors/pull/2778
(fixed in 8.6 but not backported)

