### PR TITLE
test(rabbitmq): add test for unnecessary unescaping in inbound connector

### DIFF
--- a/connectors/rabbitmq/src/test/java/io/camunda/connector/rabbitmq/inbound/RabbitMqConsumerTest.java
+++ b/connectors/rabbitmq/src/test/java/io/camunda/connector/rabbitmq/inbound/RabbitMqConsumerTest.java
@@ -303,4 +303,35 @@ public class RabbitMqConsumerTest extends InboundBaseTest {
     // Then
     verify(spyContext, times(1)).cancel(cause);
   }
+
+  @Test
+  void consumer_shouldBeAbleToParseSpecialCharsInJsonString() throws IOException {
+    // Given JSON payload
+    Envelope envelope = new Envelope(1, false, "exchange", "routingKey");
+    BasicProperties properties = new BasicProperties.Builder().build();
+    String jsonBody =
+        """
+        {"key":"value with \\"quotes\\" special chars: \\" \\n \\t \\r"}
+        """;
+    var context = getContextBuilderWithSecrets().build();
+
+    // When
+    RabbitMqConsumer consumer = new RabbitMqConsumer(mockChannel, context);
+    consumer.handleDelivery("consumerTag", envelope, properties, jsonBody.getBytes());
+
+    // Then
+    var correlatedEvents = context.getCorrelations();
+    assertThat(correlatedEvents).hasSize(1);
+    assertThat(correlatedEvents.get(0)).isInstanceOf(RabbitMqInboundResult.class);
+    RabbitMqInboundMessage message = ((RabbitMqInboundResult) correlatedEvents.get(0)).message();
+
+    assertThat(message.body()).isInstanceOf(Map.class);
+    Map<String, Object> body = (Map<String, Object>) message.body();
+    assertThat(body).containsEntry("key", "value with \"quotes\" special chars: \" \n \t \r");
+
+    assertThat(message.properties()).isEqualTo(AMQPPropertyUtil.toProperties(properties));
+    assertThat(message.consumerTag()).isEqualTo("consumerTag");
+
+    verify(mockChannel, times(1)).basicAck(1, false);
+  }
 }


### PR DESCRIPTION
## Description

This PR adds a test for the unnecessary unescaping scenario with RabbitMQ inbound connector. This test is already provided in #3135 for older release branches, but we also need to add it to main and 8.6.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #2730 

