### PR TITLE
chore(config): Disable multiple Runtime instance as the default

### DIFF
--- a/bundle/default-bundle/src/test/resources/application-docker-core.properties
+++ b/bundle/default-bundle/src/test/resources/application-docker-core.properties
@@ -1,5 +1,5 @@
 # uncomment the following line if you need multiple instance of the Runtime
-#server.port=-1
+#server.port=0
 
 logging.level.io.camunda.connector=DEBUG
 

--- a/bundle/default-bundle/src/test/resources/application-docker-core.properties
+++ b/bundle/default-bundle/src/test/resources/application-docker-core.properties
@@ -1,4 +1,5 @@
-server.port=-1
+# uncomment the following line if you need multiple instance of the Runtime
+#server.port=-1
 
 logging.level.io.camunda.connector=DEBUG
 


### PR DESCRIPTION
## Description

By default, we enabled multiple Runtime instances by setting the server port to a random value determined at Runtime.

This is not practical for different reasons:
- It's not often that we need multiple instances to test some feature
- APIs like /inbound are broken as one doesn't know the port soon enough

We will keep the previous value for this port (8080), and one can still uncomment this line if multiple instances are required.