### PR TITLE
feat(element-template-generator): accept json content as parameter in template generator

### DIFF
--- a/element-template-generator/openapi-parser/src/test/java/io/camunda/connector/generator/openapi/ExampleTest.java
+++ b/element-template-generator/openapi-parser/src/test/java/io/camunda/connector/generator/openapi/ExampleTest.java
@@ -17,9 +17,13 @@
 package io.camunda.connector.generator.openapi;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.connector.generator.openapi.OpenApiGenerationSource.Options;
 import io.swagger.v3.parser.OpenAPIV3Parser;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.util.List;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
 
@@ -45,6 +49,24 @@ public class ExampleTest {
   }
 
   @Test
+  void generateFromRawJsonContent() throws IOException {
+    // given
+    String openApiCollectionsJsonContent =
+        mapper
+            .readValue(
+                new FileInputStream("src/test/resources/web-modeler-rest-api.json"), JsonNode.class)
+            .toString();
+    var source = new OpenApiGenerationSource(List.of(openApiCollectionsJsonContent));
+    var generator = new OpenApiOutboundTemplateGenerator();
+
+    // when
+    var templates = generator.generate(source);
+
+    // then
+    System.out.println(mapper.writeValueAsString(templates));
+  }
+
+  @Test
   void scan() {
     var parser = new OpenAPIV3Parser();
     var openApi = parser.read("web-modeler-rest-api.json");
@@ -52,6 +74,22 @@ public class ExampleTest {
 
     var scanResult =
         generator.scan(new OpenApiGenerationSource(openApi, Set.of(), new Options(false)));
+
+    System.out.println(scanResult);
+  }
+
+  @Test
+  void scanFromRawJsonContent() throws IOException {
+    String openApiCollectionsJsonContent =
+        mapper
+            .readValue(
+                new FileInputStream("src/test/resources/web-modeler-rest-api.json"), JsonNode.class)
+            .toString();
+    var source = new OpenApiGenerationSource(List.of(openApiCollectionsJsonContent));
+    var generator = new OpenApiOutboundTemplateGenerator();
+
+    var scanResult = generator.scan(source);
+
     System.out.println(scanResult);
   }
 }

--- a/element-template-generator/postman-collections-parser/src/main/java/io/camunda/connector/generator/postman/PostmanCollectionsGenerationSource.java
+++ b/element-template-generator/postman-collections-parser/src/main/java/io/camunda/connector/generator/postman/PostmanCollectionsGenerationSource.java
@@ -29,6 +29,7 @@ import java.nio.file.StandardCopyOption;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 public record PostmanCollectionsGenerationSource(
@@ -43,35 +44,52 @@ public record PostmanCollectionsGenerationSource(
       throw new IllegalArgumentException("Incorrect usage");
     }
 
-    final var collectionPath = cliParams.getFirst();
+    final var collectionPathOrContent = cliParams.getFirst();
 
-    File postmanCollectionsFileJson;
-    if (collectionPath.startsWith("http")) { // Network
-      try {
-        postmanCollectionsFileJson = File.createTempFile("postman-gen", "tmp");
-        postmanCollectionsFileJson.deleteOnExit();
-        InputStream collectionUrl = new URL(collectionPath).openStream();
-        Files.copy(
-            collectionUrl,
-            postmanCollectionsFileJson.toPath(),
-            StandardCopyOption.REPLACE_EXISTING);
-      } catch (IOException e) {
-        throw new RuntimeException(e);
-      }
-    } else { // Local file system
-      postmanCollectionsFileJson = new File(collectionPath);
-    }
-
-    if (!postmanCollectionsFileJson.exists() || !postmanCollectionsFileJson.isFile()) {
-      throw new IllegalArgumentException(
-          "Incorrect Postman Collections file: " + postmanCollectionsFileJson.getName());
-    }
+    JsonNode collectionNode =
+        Optional.ofNullable(collectionPathOrContent)
+            .map(
+                pathOrContent -> {
+                  try {
+                    if (isValidJSON(pathOrContent)) {
+                      try {
+                        return ObjectMapperProvider.getInstance()
+                            .readValue(pathOrContent, JsonNode.class);
+                      } catch (IOException e) {
+                        throw new IllegalArgumentException(
+                            "Couldn't parse Postman Collection to v.2.1.0 standard", e);
+                      }
+                    }
+                    final File postmanCollectionsFileJson;
+                    if (pathOrContent.startsWith("http")) { // Network
+                      postmanCollectionsFileJson = File.createTempFile("postman-gen", "tmp");
+                      postmanCollectionsFileJson.deleteOnExit();
+                      InputStream collectionUrl = new URL(collectionPathOrContent).openStream();
+                      Files.copy(
+                          collectionUrl,
+                          postmanCollectionsFileJson.toPath(),
+                          StandardCopyOption.REPLACE_EXISTING);
+                    } else { // Local file system
+                      postmanCollectionsFileJson = new File(collectionPathOrContent);
+                    }
+                    if (!postmanCollectionsFileJson.exists()
+                        || !postmanCollectionsFileJson.isFile()) {
+                      throw new IllegalArgumentException(
+                          "Incorrect Postman Collections file: "
+                              + postmanCollectionsFileJson.getName());
+                    }
+                    return ObjectMapperProvider.getInstance()
+                        .readValue(new FileInputStream(postmanCollectionsFileJson), JsonNode.class);
+                  } catch (IOException e) {
+                    throw new RuntimeException(e);
+                  }
+                })
+            .orElseThrow(
+                () ->
+                    new IllegalArgumentException(
+                        "OpenAPI file path or URL must be provided as first parameter"));
 
     try {
-      JsonNode collectionNode =
-          ObjectMapperProvider.getInstance()
-              .readValue(new FileInputStream(postmanCollectionsFileJson), JsonNode.class);
-
       PostmanCollectionV210 collection;
       // When collection shared directly from Postman UI
       if (collectionNode.has("collection")) {
@@ -91,6 +109,15 @@ public record PostmanCollectionsGenerationSource(
     } catch (IOException e) {
       throw new IllegalArgumentException(
           "Couldn't parse Postman Collection to v.2.1.0 standard", e);
+    }
+  }
+
+  public static boolean isValidJSON(String jsonInString) {
+    try {
+      ObjectMapperProvider.getInstance().readTree(jsonInString);
+      return true;
+    } catch (IOException e) {
+      return false;
     }
   }
 

--- a/element-template-generator/postman-collections-parser/src/test/java/io/camunda/connector/generator/postman/PostmanCollectionsGeneratorDryRunExampleTest.java
+++ b/element-template-generator/postman-collections-parser/src/test/java/io/camunda/connector/generator/postman/PostmanCollectionsGeneratorDryRunExampleTest.java
@@ -17,9 +17,12 @@
 package io.camunda.connector.generator.postman;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
 import io.camunda.connector.generator.api.GeneratorConfiguration;
 import io.camunda.connector.generator.api.GeneratorConfiguration.ConnectorMode;
 import io.camunda.connector.generator.postman.utils.ObjectMapperProvider;
+import java.io.FileInputStream;
+import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
@@ -61,7 +64,13 @@ public class PostmanCollectionsGeneratorDryRunExampleTest {
     Assertions.assertThat(scanResult).isNotNull();
   }
 
-  private static Stream<Arguments> commandLineArguments() {
+  private static Stream<Arguments> commandLineArguments() throws IOException {
+    String postmanCollectionsJsonContent =
+        ObjectMapperProvider.getInstance()
+            .readValue(
+                new FileInputStream("src/test/resources/operate-api-saas-bearer.json"),
+                JsonNode.class)
+            .toString();
     return Stream.of(
         // Test case 1: generate all methods
         Arguments.of(List.of("src/test/resources/operate-api-saas-bearer.json")),
@@ -84,6 +93,9 @@ public class PostmanCollectionsGeneratorDryRunExampleTest {
             List.of(
                 "https://raw.githubusercontent.com/camunda-community-hub/camunda-8-api-postman-collection/main/Operate%20Public%20API%20-%20SaaS.postman_collection.json",
                 "/Process instances/Search for process instances",
-                "/Process instances/Get process instance by key")));
+                "/Process instances/Get process instance by key")),
+
+        // Test case 5: from raw content
+        Arguments.of(List.of(postmanCollectionsJsonContent)));
   }
 }


### PR DESCRIPTION
## Description

Modified the postman and openapi element template generator to accept raw json content as input.

## Related issues

closes #3179

