### PR TITLE
ci(integration): use unique id to allow parallel Helm test runs, accept more commit types

### DIFF
--- a/.github/workflows/INTEGRATION_TEST.yml
+++ b/.github/workflows/INTEGRATION_TEST.yml
@@ -83,7 +83,7 @@ jobs:
     uses: camunda/camunda-platform-helm/.github/workflows/test-integration-template.yaml@main
     secrets: inherit
     with:
-      identifier: connectors-int
+      identifier: connectors-int-${{ github.run_id }}
       camunda-helm-dir: ${{ needs.prepare-inputs.outputs.helm-dir }}
       test-enabled: true
       extra-values: |

--- a/.github/workflows/PULL_REQUEST_NAME_CHECK_ON_PR.yml
+++ b/.github/workflows/PULL_REQUEST_NAME_CHECK_ON_PR.yml
@@ -13,7 +13,7 @@ jobs:
         run: echo "${{ github.event.pull_request.title }}"
       - name: Check if pull request name follows conventional commit regex
         run: |
-          PR_REGEX='^(feat|fix|docs|style|refactor|perf|test|chore)\(?.+\)?: .+$'
+          PR_REGEX='^(feat|fix|docs|style|refactor|perf|test|chore|build|other|ci)\(?.+\)?: .+$'
           if [[ "${{ github.event.pull_request.title }}" =~ $PR_REGEX ]]; then
             echo "Pull request name follows the conventional commit format."
           else


### PR DESCRIPTION
## Description

Before this change, only the last-run Helm integration test would be allowed to finish.

The new commit types I added to [PULL_REQUEST_NAME_CHECK_ON_PR.yml](https://github.com/camunda/connectors/pull/3189/files#diff-92c7a74338bece2a9437a03beecb6a9cf913f4aa45e008aca0503a95237818fe) are currently recognized by our [release workflow](https://github.com/camunda/connectors/blob/main/.github/workflows/RELEASE.yaml#L244). So I think they should be allowed in our PR's.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes https://github.com/camunda/connectors/issues/3188

