### PR TITLE
ci(integration): use unique id for parallel runs

### DIFF
--- a/.github/workflows/INTEGRATION_TEST.yml
+++ b/.github/workflows/INTEGRATION_TEST.yml
@@ -83,7 +83,7 @@ jobs:
     uses: camunda/camunda-platform-helm/.github/workflows/test-integration-template.yaml@main
     secrets: inherit
     with:
-      identifier: connectors-int
+      identifier: connectors-int-${{ github.run_id }}
       camunda-helm-dir: ${{ needs.prepare-inputs.outputs.helm-dir }}
       test-enabled: true
       extra-values: |


### PR DESCRIPTION
## Description

Before this change, only the last-run Helm integration test would be allowed to finish.

## Related issues

<!-- Which issues are closed by this PR or are related -->

related https://github.com/camunda/connectors/issues/3188

