### PR TITLE
chore(deps): migrate to the official Zeebe Spring SDK

### DIFF
--- a/bundle/camunda-saas-bundle/pom.xml
+++ b/bundle/camunda-saas-bundle/pom.xml
@@ -50,11 +50,6 @@
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>
     </dependency>
-      <dependency>
-          <groupId>io.camunda.spring</groupId>
-          <artifactId>spring-boot-starter-camunda-test</artifactId>
-          <scope>test</scope>
-      </dependency>
   </dependencies>
 
   <build>

--- a/bundle/camunda-saas-bundle/pom.xml
+++ b/bundle/camunda-saas-bundle/pom.xml
@@ -50,6 +50,10 @@
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>camunda-process-test-spring</artifactId>
+    </dependency>
   </dependencies>
 
   <build>

--- a/bundle/camunda-saas-bundle/src/main/java/io/camunda/connector/runtime/saas/SaaSConfiguration.java
+++ b/bundle/camunda-saas-bundle/src/main/java/io/camunda/connector/runtime/saas/SaaSConfiguration.java
@@ -18,8 +18,6 @@ package io.camunda.connector.runtime.saas;
 
 import io.camunda.connector.api.secret.SecretProvider;
 import io.camunda.connector.runtime.cloud.GcpSecretManagerSecretProvider;
-import io.camunda.zeebe.spring.client.properties.ZeebeClientConfigurationProperties;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -39,21 +37,16 @@ public class SaaSConfiguration {
   @Value("${camunda.saas.secrets.internalPrefix:internal-connector-secrets}")
   private String secretsInternalNamePrefix;
 
-  private final ZeebeClientConfigurationProperties conf;
-
-  @Autowired
-  public SaaSConfiguration(ZeebeClientConfigurationProperties conf) {
-    this.conf = conf;
-  }
+  @Value("${zeebe.client.cloud.cluster-id}")
+  private String clusterId;
 
   @Bean
   public SecretProvider getSecretProvider() {
-    return new GcpSecretManagerSecretProvider(
-        conf.getCloud().getClusterId(), secretsProjectId, secretsNamePrefix);
+    return new GcpSecretManagerSecretProvider(clusterId, secretsProjectId, secretsNamePrefix);
   }
 
   public SecretProvider getInternalSecretProvider() {
     return new GcpSecretManagerSecretProvider(
-        conf.getCloud().getClusterId(), secretsProjectId, secretsInternalNamePrefix);
+        clusterId, secretsProjectId, secretsInternalNamePrefix);
   }
 }

--- a/bundle/camunda-saas-bundle/src/main/java/io/camunda/connector/runtime/saas/SaaSOperateClientFactory.java
+++ b/bundle/camunda-saas-bundle/src/main/java/io/camunda/connector/runtime/saas/SaaSOperateClientFactory.java
@@ -82,7 +82,8 @@ public class SaaSOperateClientFactory {
           internalSecretProvider.getSecret(SECRET_NAME_CLIENT_ID),
           internalSecretProvider.getSecret(SECRET_NAME_SECRET),
           operateBaseUrl,
-          authUrl);
+          authUrl,
+          null);
     } catch (MalformedURLException | URISyntaxException e) {
       throw new RuntimeException(e);
     }

--- a/bundle/camunda-saas-bundle/src/main/java/io/camunda/connector/runtime/saas/security/SecurityConfiguration.java
+++ b/bundle/camunda-saas-bundle/src/main/java/io/camunda/connector/runtime/saas/security/SecurityConfiguration.java
@@ -51,9 +51,7 @@ public class SecurityConfiguration {
    * nothing is matched, then the second one will be applied. Here, alls of the public endpoint are
    * caught first.
    *
-   * @param http
    * @return The first security filter chain
-   * @throws Exception
    */
   @Bean
   @Order(0)
@@ -66,7 +64,7 @@ public class SecurityConfiguration {
                     .requestMatchers(HttpMethod.POST, "/inbound/*")
                     .requestMatchers(HttpMethod.PUT, "/inbound/*")
                     .requestMatchers(HttpMethod.DELETE, "/inbound/*")
-                    .requestMatchers("actuator/**"))
+                    .requestMatchers("/actuator/**"))
         .authorizeHttpRequests(
             auth ->
                 auth.requestMatchers("/inbound/logs")
@@ -82,14 +80,17 @@ public class SecurityConfiguration {
    * this was first and endpoint like `GET /inbound/*` would respond 401 Those endpoint will be
    * caught on the first security chain
    *
-   * @param http
    * @return The second security filter chain
-   * @throws Exception
    */
   @Bean
   @Order(1)
   public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
     http.csrf(csrf -> csrf.ignoringRequestMatchers("/inbound/**"))
+        .securityMatchers(
+            requestMatcherConfigurer ->
+                requestMatcherConfigurer
+                    .requestMatchers("/inbound/**")
+                    .requestMatchers("/tenants/**"))
         .authorizeHttpRequests(
             auth ->
                 auth.requestMatchers(HttpMethod.GET, "/inbound", "/tenants/**")

--- a/bundle/camunda-saas-bundle/src/main/resources/application.properties
+++ b/bundle/camunda-saas-bundle/src/main/resources/application.properties
@@ -1,7 +1,6 @@
 server.port=8080
 
 management.server.port=9080
-management.context-path=/actuator
 management.endpoints.web.exposure.include=metrics,health,prometheus,loggers
 management.endpoint.health.group.readiness.include[]=zeebeClient,operate
 
@@ -39,3 +38,5 @@ camunda.connector.inbound.log.size=10
 
 # Disabling the default Operate client, we are configuring our own
 camunda.client.operate.enabled=false
+
+camunda.connector.secretprovider.discovery.enabled=false

--- a/bundle/camunda-saas-bundle/src/main/resources/application.properties
+++ b/bundle/camunda-saas-bundle/src/main/resources/application.properties
@@ -15,11 +15,18 @@ camunda.connector.secret-provider.console.enabled=false
 
 zeebe.client.worker.threads=10
 zeebe.client.worker.max-jobs-active=32
+camunda.client.zeebe.defaults.stream-enabled=true
 
 # Enforce local connection, even if cluster-id set
 zeebe.client.connection-mode=ADDRESS
-camunda.client.mode=simple
-camunda.client.zeebe.defaults.stream-enabled=true
+camunda.client.zeebe.grpc-address=http://${zeebe.client.broker.gateway-address}
+camunda.client.zeebe.base-url=http://${zeebe.client.broker.gateway-address}
+camunda.client.mode=saas
+camunda.client.region=${zeebe.client.cloud.region}
+camunda.client.cluster-id=${zeebe.client.cloud.cluster-id}
+operate.client.profile=saas
+operate.client.region=${zeebe.client.cloud.region}
+operate.client.cluster-id=${zeebe.client.cloud.cluster-id}
 
 connectors.log.appender=stackdriver
 

--- a/bundle/camunda-saas-bundle/src/test/java/io/camunda/connector/runtime/saas/MockSaaSConfiguration.java
+++ b/bundle/camunda-saas-bundle/src/test/java/io/camunda/connector/runtime/saas/MockSaaSConfiguration.java
@@ -17,7 +17,6 @@
 package io.camunda.connector.runtime.saas;
 
 import io.camunda.connector.api.secret.SecretProvider;
-import io.camunda.zeebe.spring.client.properties.ZeebeClientConfigurationProperties;
 import java.util.Map;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
@@ -39,8 +38,8 @@ public class MockSaaSConfiguration {
           SaaSOperateClientFactory.SECRET_NAME_SECRET, OPERATE_CLIENT_SECRET);
 
   @Bean
-  public SaaSConfiguration saaSConfiguration(ZeebeClientConfigurationProperties conf) {
-    return new SaaSConfiguration(conf) {
+  public SaaSConfiguration saaSConfiguration() {
+    return new SaaSConfiguration() {
       @Override
       public SecretProvider getInternalSecretProvider() {
         return secrets::get;

--- a/bundle/camunda-saas-bundle/src/test/java/io/camunda/connector/runtime/saas/SecurityConfigurationTest.java
+++ b/bundle/camunda-saas-bundle/src/test/java/io/camunda/connector/runtime/saas/SecurityConfigurationTest.java
@@ -51,14 +51,16 @@ import org.springframework.test.web.servlet.MockMvc;
     webEnvironment = WebEnvironment.RANDOM_PORT,
     classes = {SaaSConnectorRuntimeApplication.class, MockSaaSConfiguration.class},
     properties = {
-      "camunda.saas.secrets.projectId=42",
-      "zeebe.client.cloud.cluster-id=42",
-      "zeebe.client.security.plaintext=true",
-      "camunda.connector.auth.audience=connectors.dev.ultrawombat.com",
-      "camunda.connector.auth.issuer=https://weblogin.cloud.dev.ultrawombat.com/",
-      "camunda.operate.client.url=" + MockSaaSConfiguration.OPERATE_CLIENT_URL,
-      "camunda.operate.client.authUrl=" + MockSaaSConfiguration.OPERATE_CLIENT_AUTH_URL,
-      "camunda.operate.client.baseUrl=" + MockSaaSConfiguration.OPERATE_CLIENT_BASEURL
+        "camunda.saas.secrets.projectId=42",
+        "zeebe.client.cloud.cluster-id=42",
+        "zeebe.client.security.plaintext=true",
+        "zeebe.client.broker.gateway-address=zeebe-service:26500",
+        "zeebe.client.cloud.region=bru-1",
+        "camunda.connector.auth.audience=connectors.dev.ultrawombat.com",
+        "camunda.connector.auth.issuer=https://weblogin.cloud.dev.ultrawombat.com/",
+        "camunda.operate.client.url=" + MockSaaSConfiguration.OPERATE_CLIENT_URL,
+        "camunda.operate.client.authUrl=" + MockSaaSConfiguration.OPERATE_CLIENT_AUTH_URL,
+        "camunda.operate.client.baseUrl=" + MockSaaSConfiguration.OPERATE_CLIENT_BASEURL
     })
 @DirtiesContext
 @ActiveProfiles("test")

--- a/bundle/camunda-saas-bundle/src/test/java/io/camunda/connector/runtime/saas/SecurityConfigurationTest.java
+++ b/bundle/camunda-saas-bundle/src/test/java/io/camunda/connector/runtime/saas/SecurityConfigurationTest.java
@@ -52,6 +52,7 @@ import org.springframework.test.web.servlet.MockMvc;
     classes = {SaaSConnectorRuntimeApplication.class, MockSaaSConfiguration.class},
     properties = {
       "camunda.saas.secrets.projectId=42",
+      "camunda.client.zeebe.enabled=true",
       "zeebe.client.cloud.cluster-id=42",
       "zeebe.client.security.plaintext=true",
       "zeebe.client.broker.gateway-address=zeebe-service:26500",
@@ -60,7 +61,9 @@ import org.springframework.test.web.servlet.MockMvc;
       "camunda.connector.auth.issuer=https://weblogin.cloud.dev.ultrawombat.com/",
       "camunda.operate.client.url=" + MockSaaSConfiguration.OPERATE_CLIENT_URL,
       "camunda.operate.client.authUrl=" + MockSaaSConfiguration.OPERATE_CLIENT_AUTH_URL,
-      "camunda.operate.client.baseUrl=" + MockSaaSConfiguration.OPERATE_CLIENT_BASEURL
+      "camunda.operate.client.baseUrl=" + MockSaaSConfiguration.OPERATE_CLIENT_BASEURL,
+      "camunda.connector.secretprovider.discovery.enabled=false",
+      "operate.client.profile=oidc"
     })
 @DirtiesContext
 @ActiveProfiles("test")

--- a/bundle/camunda-saas-bundle/src/test/java/io/camunda/connector/runtime/saas/SecurityConfigurationTest.java
+++ b/bundle/camunda-saas-bundle/src/test/java/io/camunda/connector/runtime/saas/SecurityConfigurationTest.java
@@ -63,7 +63,8 @@ import org.springframework.test.web.servlet.MockMvc;
       "camunda.operate.client.authUrl=" + MockSaaSConfiguration.OPERATE_CLIENT_AUTH_URL,
       "camunda.operate.client.baseUrl=" + MockSaaSConfiguration.OPERATE_CLIENT_BASEURL,
       "camunda.connector.secretprovider.discovery.enabled=false",
-      "operate.client.profile=oidc"
+      "operate.client.profile=oidc",
+      "management.endpoints.web.exposure.include=*"
     })
 @DirtiesContext
 @ActiveProfiles("test")

--- a/bundle/camunda-saas-bundle/src/test/java/io/camunda/connector/runtime/saas/SecurityConfigurationTest.java
+++ b/bundle/camunda-saas-bundle/src/test/java/io/camunda/connector/runtime/saas/SecurityConfigurationTest.java
@@ -27,7 +27,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import io.camunda.operate.CamundaOperateClient;
-import io.camunda.zeebe.spring.test.ZeebeSpringTest;
+import io.camunda.process.test.api.CamundaSpringProcessTest;
 import java.time.Duration;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -65,7 +65,7 @@ import org.springframework.test.web.servlet.MockMvc;
 @DirtiesContext
 @ActiveProfiles("test")
 @AutoConfigureMockMvc
-@ZeebeSpringTest
+@CamundaSpringProcessTest
 public class SecurityConfigurationTest {
 
   // needed to access /actuator endpoints

--- a/bundle/camunda-saas-bundle/src/test/java/io/camunda/connector/runtime/saas/SecurityConfigurationTest.java
+++ b/bundle/camunda-saas-bundle/src/test/java/io/camunda/connector/runtime/saas/SecurityConfigurationTest.java
@@ -51,16 +51,16 @@ import org.springframework.test.web.servlet.MockMvc;
     webEnvironment = WebEnvironment.RANDOM_PORT,
     classes = {SaaSConnectorRuntimeApplication.class, MockSaaSConfiguration.class},
     properties = {
-        "camunda.saas.secrets.projectId=42",
-        "zeebe.client.cloud.cluster-id=42",
-        "zeebe.client.security.plaintext=true",
-        "zeebe.client.broker.gateway-address=zeebe-service:26500",
-        "zeebe.client.cloud.region=bru-1",
-        "camunda.connector.auth.audience=connectors.dev.ultrawombat.com",
-        "camunda.connector.auth.issuer=https://weblogin.cloud.dev.ultrawombat.com/",
-        "camunda.operate.client.url=" + MockSaaSConfiguration.OPERATE_CLIENT_URL,
-        "camunda.operate.client.authUrl=" + MockSaaSConfiguration.OPERATE_CLIENT_AUTH_URL,
-        "camunda.operate.client.baseUrl=" + MockSaaSConfiguration.OPERATE_CLIENT_BASEURL
+      "camunda.saas.secrets.projectId=42",
+      "zeebe.client.cloud.cluster-id=42",
+      "zeebe.client.security.plaintext=true",
+      "zeebe.client.broker.gateway-address=zeebe-service:26500",
+      "zeebe.client.cloud.region=bru-1",
+      "camunda.connector.auth.audience=connectors.dev.ultrawombat.com",
+      "camunda.connector.auth.issuer=https://weblogin.cloud.dev.ultrawombat.com/",
+      "camunda.operate.client.url=" + MockSaaSConfiguration.OPERATE_CLIENT_URL,
+      "camunda.operate.client.authUrl=" + MockSaaSConfiguration.OPERATE_CLIENT_AUTH_URL,
+      "camunda.operate.client.baseUrl=" + MockSaaSConfiguration.OPERATE_CLIENT_BASEURL
     })
 @DirtiesContext
 @ActiveProfiles("test")

--- a/bundle/camunda-saas-bundle/src/test/java/io/camunda/connector/runtime/saas/TestSpringContextStartup.java
+++ b/bundle/camunda-saas-bundle/src/test/java/io/camunda/connector/runtime/saas/TestSpringContextStartup.java
@@ -27,7 +27,8 @@ import org.springframework.test.context.ActiveProfiles;
     classes = {SaaSConnectorRuntimeApplication.class, MockSaaSConfiguration.class},
     properties = {
       "camunda.saas.secrets.projectId=42",
-      "zeebe.client.cloud.cluster-id=42",
+      "zeebe.client.cloud.clusterId=42",
+      "zeebe.client.cloud.region=bru-1",
       "zeebe.client.security.plaintext=true",
       "camunda.connector.auth.audience=connectors.dev.ultrawombat.com",
       "camunda.connector.auth.issuer=https://weblogin.cloud.dev.ultrawombat.com/",
@@ -52,11 +53,10 @@ public class TestSpringContextStartup {
   public void jwtCredentialConfigured() {
     var jwtCredential = operateClientFactory.configureJwtCredential();
     assertThat(jwtCredential).isNotNull();
-    assertThat(jwtCredential.getClientId())
-        .isEqualTo(MockSaaSConfiguration.OPERATE_CLIENT_CLIENT_ID);
-    assertThat(jwtCredential.getClientSecret())
-        .isEqualTo(MockSaaSConfiguration.OPERATE_CLIENT_SECRET);
-    assertThat(jwtCredential.getAudience()).isEqualTo(MockSaaSConfiguration.OPERATE_CLIENT_BASEURL);
-    assertThat(jwtCredential.getAuthUrl()).isEqualTo(MockSaaSConfiguration.OPERATE_CLIENT_AUTH_URL);
+    assertThat(jwtCredential.clientId()).isEqualTo(MockSaaSConfiguration.OPERATE_CLIENT_CLIENT_ID);
+    assertThat(jwtCredential.clientSecret()).isEqualTo(MockSaaSConfiguration.OPERATE_CLIENT_SECRET);
+    assertThat(jwtCredential.audience()).isEqualTo(MockSaaSConfiguration.OPERATE_CLIENT_BASEURL);
+    assertThat(jwtCredential.authUrl().toString())
+        .isEqualTo(MockSaaSConfiguration.OPERATE_CLIENT_AUTH_URL);
   }
 }

--- a/bundle/camunda-saas-bundle/src/test/java/io/camunda/connector/runtime/saas/TestSpringContextStartup.java
+++ b/bundle/camunda-saas-bundle/src/test/java/io/camunda/connector/runtime/saas/TestSpringContextStartup.java
@@ -35,7 +35,9 @@ import org.springframework.test.context.ActiveProfiles;
       "camunda.connector.auth.issuer=https://weblogin.cloud.dev.ultrawombat.com/",
       "camunda.operate.client.url=" + MockSaaSConfiguration.OPERATE_CLIENT_URL,
       "camunda.operate.client.authUrl=" + MockSaaSConfiguration.OPERATE_CLIENT_AUTH_URL,
-      "camunda.operate.client.baseUrl=" + MockSaaSConfiguration.OPERATE_CLIENT_BASEURL
+      "camunda.operate.client.baseUrl=" + MockSaaSConfiguration.OPERATE_CLIENT_BASEURL,
+      "camunda.connector.secretprovider.discovery.enabled=false",
+      "operate.client.profile=oidc",
     })
 @ActiveProfiles("test")
 public class TestSpringContextStartup {

--- a/bundle/camunda-saas-bundle/src/test/java/io/camunda/connector/runtime/saas/TestSpringContextStartup.java
+++ b/bundle/camunda-saas-bundle/src/test/java/io/camunda/connector/runtime/saas/TestSpringContextStartup.java
@@ -29,6 +29,7 @@ import org.springframework.test.context.ActiveProfiles;
       "camunda.saas.secrets.projectId=42",
       "zeebe.client.cloud.clusterId=42",
       "zeebe.client.cloud.region=bru-1",
+      "zeebe.client.broker.gateway-address=zeebe-service:26500",
       "zeebe.client.security.plaintext=true",
       "camunda.connector.auth.audience=connectors.dev.ultrawombat.com",
       "camunda.connector.auth.issuer=https://weblogin.cloud.dev.ultrawombat.com/",

--- a/bundle/camunda-saas-bundle/src/test/resources/application.properties
+++ b/bundle/camunda-saas-bundle/src/test/resources/application.properties
@@ -1,0 +1,7 @@
+logging.level.root: info
+logging.level.io.camunda.process.test: info
+
+logging.level.org.testcontainers: warn
+logging.level.tc: warn
+
+logging.level.io.camunda.connector: debug

--- a/bundle/camunda-saas-bundle/src/test/resources/application.properties
+++ b/bundle/camunda-saas-bundle/src/test/resources/application.properties
@@ -5,4 +5,3 @@ logging.level.org.testcontainers: warn
 logging.level.tc: warn
 
 logging.level.io.camunda.connector: debug
-camunda.connector.secretprovider.discovery.enabled: false

--- a/bundle/camunda-saas-bundle/src/test/resources/application.properties
+++ b/bundle/camunda-saas-bundle/src/test/resources/application.properties
@@ -5,3 +5,4 @@ logging.level.org.testcontainers: warn
 logging.level.tc: warn
 
 logging.level.io.camunda.connector: debug
+camunda.connector.secretprovider.discovery.enabled: false

--- a/bundle/default-bundle/src/test/resources/application-docker-core.properties
+++ b/bundle/default-bundle/src/test/resources/application-docker-core.properties
@@ -4,6 +4,8 @@
 logging.level.io.camunda.connector=DEBUG
 
 # Config for use with docker-compose-core.yml
-camunda.client.mode=simple
+camunda.client.mode=self-managed
 camunda.client.auth.username=demo
 camunda.client.auth.password=demo
+camunda.client.auth.issuer="" # if present, will trigger OIDC mode
+operate.client.profile=simple

--- a/bundle/default-bundle/src/test/resources/application.properties
+++ b/bundle/default-bundle/src/test/resources/application.properties
@@ -6,22 +6,24 @@ management.endpoint.health.group.readiness.include[]=zeebeClient,operate
 management.endpoint.health.show-components=always
 management.endpoint.health.show-details=always
 
-camunda.client.operate.base-url=http://localhost:8081
+operate.client.base-url=http://localhost:8081
 camunda.client.zeebe.gateway-url=http://localhost:26500
 camunda.client.zeebe.defaults.max-jobs-active=32
 camunda.client.zeebe.defaults.worker-threads=10
 camunda.client.zeebe.defaults.stream-enabled=true
 
+camunda.client.mode=self-managed
+
 # Config for use with docker-compose.yml
-camunda.client.mode=oidc
 camunda.client.auth.client-id=connectors
 camunda.client.auth.client-secret=XALaRPl5qwTEItdwCMiPS62nVpKs7dL7
 camunda.client.auth.oidc-type=keycloak
 camunda.client.auth.issuer=http://localhost:18080/auth/realms/camunda-platform
 camunda.client.identity.audience=connectors
 camunda.client.identity.base-url=http://localhost:8084
+operate.client.profile=oidc
 
 # Config for use with docker-compose-core.yml
-#camunda.client.mode=simple
 #camunda.client.auth.username=demo
 #camunda.client.auth.password=demo
+#operate.client.profile=simple

--- a/bundle/default-bundle/src/test/resources/application.properties
+++ b/bundle/default-bundle/src/test/resources/application.properties
@@ -18,10 +18,14 @@ camunda.client.mode=self-managed
 camunda.client.auth.client-id=connectors
 camunda.client.auth.client-secret=XALaRPl5qwTEItdwCMiPS62nVpKs7dL7
 camunda.client.auth.oidc-type=keycloak
-camunda.client.auth.issuer=http://localhost:18080/auth/realms/camunda-platform
+camunda.client.auth.issuer=http://localhost:18080/auth/realms/camunda-platform/protocol/openid-connect/token
 camunda.client.identity.audience=connectors
 camunda.client.identity.base-url=http://localhost:8084
+
 operate.client.profile=oidc
+operate.client.auth-url=http://localhost:18080/auth/realms/camunda-platform/protocol/openid-connect/token
+operate.client.client-id=connectors
+operate.client.client-secret=XALaRPl5qwTEItdwCMiPS62nVpKs7dL7
 
 # Config for use with docker-compose-core.yml
 #camunda.client.auth.username=demo

--- a/connector-runtime/connector-runtime-core/pom.xml
+++ b/connector-runtime/connector-runtime-core/pom.xml
@@ -68,6 +68,11 @@
     </dependency>
 
     <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-collections4</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
       <scope>test</scope>

--- a/connector-runtime/connector-runtime-core/pom.xml
+++ b/connector-runtime/connector-runtime-core/pom.xml
@@ -63,6 +63,11 @@
     </dependency>
 
     <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
       <scope>test</scope>

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/details/InboundConnectorDetailsUtil.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/details/InboundConnectorDetailsUtil.java
@@ -27,13 +27,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
-import org.apache.commons.collections4.CollectionUtils;
 
 public class InboundConnectorDetailsUtil {
 
   static InboundConnectorDetails create(
       String deduplicationId, List<InboundConnectorElement> groupedElements) {
-    if (CollectionUtils.isEmpty(groupedElements)) {
+    if (groupedElements == null || groupedElements.isEmpty()) {
       throw new IllegalArgumentException("At least one element must be provided");
     }
     try {

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/details/InboundConnectorDetailsUtil.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/details/InboundConnectorDetailsUtil.java
@@ -27,12 +27,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+import org.apache.commons.collections4.CollectionUtils;
 
 public class InboundConnectorDetailsUtil {
 
   static InboundConnectorDetails create(
       String deduplicationId, List<InboundConnectorElement> groupedElements) {
-    if (groupedElements == null || groupedElements.isEmpty()) {
+    if (CollectionUtils.isEmpty(groupedElements)) {
       throw new IllegalArgumentException("At least one element must be provided");
     }
     try {

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImplTest.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImplTest.java
@@ -34,7 +34,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
 
 class InboundConnectorContextImplTest {
@@ -108,7 +107,6 @@ class InboundConnectorContextImplTest {
         .isInstanceOf(String.class);
   }
 
-  @NotNull
   private static ValidInboundConnectorDetails getInboundConnectorDefinition(
       Map<String, String> properties) {
     properties = new HashMap<>(properties);

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/testutil/command/CreateCommandDummy.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/testutil/command/CreateCommandDummy.java
@@ -91,4 +91,14 @@ public class CreateCommandDummy
     future.complete(new ProcessInstanceEventDummy());
     return future;
   }
+
+  @Override
+  public CreateProcessInstanceCommandStep1 useRest() {
+    return this;
+  }
+
+  @Override
+  public CreateProcessInstanceCommandStep1 useGrpc() {
+    return this;
+  }
 }

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/testutil/command/PublishMessageCommandDummy.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/testutil/command/PublishMessageCommandDummy.java
@@ -98,4 +98,14 @@ public class PublishMessageCommandDummy
     future.complete(new PublishMessageResponseDummy());
     return future;
   }
+
+  @Override
+  public PublishMessageCommandStep1 useRest() {
+    return this;
+  }
+
+  @Override
+  public PublishMessageCommandStep1 useGrpc() {
+    return this;
+  }
 }

--- a/connector-runtime/connector-runtime-spring/pom.xml
+++ b/connector-runtime/connector-runtime-spring/pom.xml
@@ -44,8 +44,8 @@
 
     <!-- Camunda dependencies -->
     <dependency>
-      <groupId>io.camunda.spring</groupId>
-      <artifactId>spring-client-zeebe</artifactId>
+      <groupId>io.camunda</groupId>
+      <artifactId>spring-boot-starter-camunda-sdk</artifactId>
     </dependency>
     <dependency>
       <groupId>io.camunda.spring</groupId>

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/jobhandling/SpringConnectorJobHandler.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/jobhandling/SpringConnectorJobHandler.java
@@ -105,7 +105,7 @@ public class SpringConnectorJobHandler extends ConnectorJobHandler {
               job,
               commandExceptionHandlingStrategy,
               metricsRecorder,
-          MAX_ZEEBE_COMMAND_RETRIES)
+              MAX_ZEEBE_COMMAND_RETRIES)
           .executeAsync();
     }
   }
@@ -123,7 +123,7 @@ public class SpringConnectorJobHandler extends ConnectorJobHandler {
               job,
               commandExceptionHandlingStrategy,
               metricsRecorder,
-          MAX_ZEEBE_COMMAND_RETRIES)
+              MAX_ZEEBE_COMMAND_RETRIES)
           .executeAsync();
     }
   }
@@ -144,7 +144,7 @@ public class SpringConnectorJobHandler extends ConnectorJobHandler {
               job,
               commandExceptionHandlingStrategy,
               metricsRecorder,
-          MAX_ZEEBE_COMMAND_RETRIES)
+              MAX_ZEEBE_COMMAND_RETRIES)
           .executeAsync();
     }
   }

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/jobhandling/SpringConnectorJobHandler.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/jobhandling/SpringConnectorJobHandler.java
@@ -44,8 +44,7 @@ public class SpringConnectorJobHandler extends ConnectorJobHandler {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(SpringConnectorJobHandler.class);
 
-  // no client side retries, retries are handled by Zeebe
-  private static final int MAX_CLIENT_SIDE_RETRIES = -1;
+  private static final int MAX_ZEEBE_COMMAND_RETRIES = 3;
 
   private final CommandExceptionHandlingStrategy commandExceptionHandlingStrategy;
   private final MetricsRecorder metricsRecorder;
@@ -106,7 +105,7 @@ public class SpringConnectorJobHandler extends ConnectorJobHandler {
               job,
               commandExceptionHandlingStrategy,
               metricsRecorder,
-              MAX_CLIENT_SIDE_RETRIES)
+          MAX_ZEEBE_COMMAND_RETRIES)
           .executeAsync();
     }
   }
@@ -124,7 +123,7 @@ public class SpringConnectorJobHandler extends ConnectorJobHandler {
               job,
               commandExceptionHandlingStrategy,
               metricsRecorder,
-              MAX_CLIENT_SIDE_RETRIES)
+          MAX_ZEEBE_COMMAND_RETRIES)
           .executeAsync();
     }
   }
@@ -145,7 +144,7 @@ public class SpringConnectorJobHandler extends ConnectorJobHandler {
               job,
               commandExceptionHandlingStrategy,
               metricsRecorder,
-              MAX_CLIENT_SIDE_RETRIES)
+          MAX_ZEEBE_COMMAND_RETRIES)
           .executeAsync();
     }
   }

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/secret/ConsoleSecretProviderTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/secret/ConsoleSecretProviderTest.java
@@ -26,8 +26,7 @@ import static org.mockito.Mockito.when;
 
 import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder;
 import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
-import io.camunda.common.auth.Authentication;
-import io.camunda.common.auth.Product;
+import io.camunda.operate.auth.Authentication;
 import java.time.Duration;
 import java.util.Collections;
 import java.util.Map;
@@ -53,7 +52,7 @@ public class ConsoleSecretProviderTest {
     // Mock authentication
     auth = Mockito.mock(Authentication.class);
     authToken = Map.of("Authorization", "Bearer XXX");
-    when(auth.getTokenHeader(Product.CONSOLE)).thenReturn(authToken);
+    when(auth.getTokenHeader()).thenReturn(authToken);
 
     client = new ConsoleSecretApiClient(wm.baseUrl() + "/secrets", auth);
   }

--- a/connector-runtime/spring-boot-starter-camunda-connectors/pom.xml
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/pom.xml
@@ -26,14 +26,24 @@
       <artifactId>connector-validation</artifactId>
     </dependency>
     <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>spring-boot-starter-camunda-sdk</artifactId>
+      <version>${version.zeebe}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-client-java</artifactId>
+      <version>${version.zeebe}</version>
+    </dependency>
+    <dependency>
       <groupId>io.camunda.spring</groupId>
-      <artifactId>spring-boot-starter-camunda</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>org.springframework.boot</groupId>
-          <artifactId>spring-boot-starter</artifactId>
-        </exclusion>
-      </exclusions>
+      <artifactId>spring-boot-starter-camunda-operate</artifactId>
+      <version>${version.operate-client}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.camunda.spring</groupId>
+      <artifactId>java-client-operate</artifactId>
+      <version>${version.operate-client}</version>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
@@ -56,8 +66,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>io.camunda.spring</groupId>
-      <artifactId>spring-boot-starter-camunda-test</artifactId>
+      <groupId>io.camunda</groupId>
+      <artifactId>camunda-process-test-spring</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/main/java/io/camunda/connector/runtime/InboundConnectorsAutoConfiguration.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/main/java/io/camunda/connector/runtime/InboundConnectorsAutoConfiguration.java
@@ -16,24 +16,21 @@
  */
 package io.camunda.connector.runtime;
 
-import io.camunda.common.auth.Authentication;
 import io.camunda.connector.runtime.inbound.InboundConnectorRuntimeConfiguration;
-import io.camunda.operate.CamundaOperateClient;
-import io.camunda.zeebe.spring.client.CamundaAutoConfiguration;
-import io.camunda.zeebe.spring.client.configuration.OperateClientConfiguration;
-import io.camunda.zeebe.spring.client.properties.CamundaClientProperties;
-import io.camunda.zeebe.spring.client.properties.OperateClientConfigurationProperties;
+import io.camunda.operate.spring.OperateClientConfiguration;
+import io.camunda.zeebe.spring.client.configuration.CamundaAutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @AutoConfiguration
-@AutoConfigureAfter({CamundaAutoConfiguration.class, OutboundConnectorsAutoConfiguration.class})
+@AutoConfigureAfter({
+  CamundaAutoConfiguration.class,
+  OutboundConnectorsAutoConfiguration.class,
+  OperateClientConfiguration.class
+})
 @ConditionalOnProperty(
     prefix = "camunda.connector.polling",
     name = "enabled",
@@ -41,21 +38,4 @@ import org.springframework.scheduling.annotation.EnableScheduling;
     matchIfMissing = true)
 @Import(InboundConnectorRuntimeConfiguration.class)
 @EnableScheduling
-@EnableConfigurationProperties(OperateClientConfigurationProperties.class)
-public class InboundConnectorsAutoConfiguration {
-
-  @Bean
-  @ConditionalOnMissingBean
-  public CamundaOperateClient myOperateClient(OperateClientConfiguration configuration) {
-    return configuration.camundaOperateClient();
-  }
-
-  @Bean
-  @ConditionalOnMissingBean
-  public OperateClientConfiguration operateClientProdAutoConfiguration(
-      OperateClientConfigurationProperties legacyProperties,
-      CamundaClientProperties properties,
-      Authentication authentication) {
-    return new OperateClientConfiguration(legacyProperties, properties, authentication);
-  }
-}
+public class InboundConnectorsAutoConfiguration {}

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/main/java/io/camunda/connector/runtime/OutboundConnectorsAutoConfiguration.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/main/java/io/camunda/connector/runtime/OutboundConnectorsAutoConfiguration.java
@@ -156,7 +156,8 @@ public class OutboundConnectorsAutoConfiguration {
             authProperties.getClientId(),
             authProperties.getClientSecret(),
             consoleSecretsApiAudience,
-            issuerUrl);
+            issuerUrl,
+            null);
     return new ConsoleSecretApiClient(consoleSecretsApiEndpoint, jwtCredential);
   }
 

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/main/java/io/camunda/connector/runtime/OutboundConnectorsAutoConfiguration.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/main/java/io/camunda/connector/runtime/OutboundConnectorsAutoConfiguration.java
@@ -17,10 +17,6 @@
 package io.camunda.connector.runtime;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.camunda.common.auth.Authentication;
-import io.camunda.common.auth.JwtCredential;
-import io.camunda.common.auth.Product;
-import io.camunda.common.auth.SaaSAuthentication;
 import io.camunda.connector.api.json.ConnectorsObjectMapperSupplier;
 import io.camunda.connector.api.secret.SecretProvider;
 import io.camunda.connector.feel.FeelEngineWrapper;
@@ -30,6 +26,11 @@ import io.camunda.connector.runtime.outbound.OutboundConnectorRuntimeConfigurati
 import io.camunda.connector.runtime.secret.ConsoleSecretApiClient;
 import io.camunda.connector.runtime.secret.ConsoleSecretProvider;
 import io.camunda.connector.runtime.secret.EnvironmentSecretProvider;
+import io.camunda.operate.auth.JwtCredential;
+import io.camunda.zeebe.spring.client.properties.CamundaClientProperties;
+import io.camunda.zeebe.spring.client.properties.CamundaClientProperties.ClientMode;
+import java.net.URI;
+import java.net.URL;
 import java.time.Duration;
 import java.util.LinkedList;
 import java.util.List;
@@ -112,24 +113,29 @@ public class OutboundConnectorsAutoConfiguration {
   @ConditionalOnProperty(
       name = "camunda.connector.secretprovider.console.enabled",
       havingValue = "true")
-  public ConsoleSecretApiClient consoleSecretApiClient(Authentication authentication) {
-    if (authentication instanceof SaaSAuthentication saaSAuthentication) {
-      // We reuse the Zeebe SaaS authentication here as
-      // Connectors will always rely on being connected to a zeebe instance
-      JwtCredential zeebeJwtCredential =
-          saaSAuthentication.getJwtConfig().getProduct(Product.ZEEBE);
-      JwtCredential jwtCredential =
-          new JwtCredential(
-              zeebeJwtCredential.getClientId(),
-              zeebeJwtCredential.getClientSecret(),
-              consoleSecretsApiAudience,
-              zeebeJwtCredential.getAuthUrl());
-      return new ConsoleSecretApiClient(consoleSecretsApiEndpoint, jwtCredential);
-    } else {
+  public ConsoleSecretApiClient consoleSecretApiClient(CamundaClientProperties clientProperties) {
+
+    if (!clientProperties.getMode().equals(ClientMode.saas)) {
       throw new RuntimeException(
-          "Console Secrets require an authentication against the SaaS environment:"
-              + authentication.getClass());
+          "Console Secrets require a SaaS environment, but the client is configured for "
+              + clientProperties.getMode());
     }
+
+    var authProperties = clientProperties.getAuth();
+    URL issuerUrl;
+    try {
+      issuerUrl = new URI(authProperties.getIssuer()).toURL();
+    } catch (Exception e) {
+      throw new RuntimeException("Invalid issuer URL: " + authProperties.getIssuer(), e);
+    }
+
+    var jwtCredential =
+        new JwtCredential(
+            authProperties.getClientId(),
+            authProperties.getClientSecret(),
+            consoleSecretsApiAudience,
+            issuerUrl);
+    return new ConsoleSecretApiClient(consoleSecretsApiEndpoint, jwtCredential);
   }
 
   @Bean

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/main/java/io/camunda/connector/runtime/OutboundConnectorsAutoConfiguration.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/main/java/io/camunda/connector/runtime/OutboundConnectorsAutoConfiguration.java
@@ -27,8 +27,11 @@ import io.camunda.connector.runtime.secret.ConsoleSecretApiClient;
 import io.camunda.connector.runtime.secret.ConsoleSecretProvider;
 import io.camunda.connector.runtime.secret.EnvironmentSecretProvider;
 import io.camunda.operate.auth.JwtCredential;
+import io.camunda.zeebe.client.api.JsonMapper;
+import io.camunda.zeebe.client.impl.ZeebeObjectMapper;
 import io.camunda.zeebe.spring.client.properties.CamundaClientProperties;
 import io.camunda.zeebe.spring.client.properties.CamundaClientProperties.ClientMode;
+import io.camunda.zeebe.spring.common.json.SdkObjectMapper;
 import java.net.URI;
 import java.net.URL;
 import java.time.Duration;
@@ -89,6 +92,25 @@ public class OutboundConnectorsAutoConfiguration {
       secretProviders.addAll(discoveredSecretProviders);
     }
     return new SecretProviderAggregator(secretProviders);
+  }
+
+  @Bean(name = "zeebeJsonMapper")
+  @ConditionalOnMissingBean
+  public JsonMapper jsonMapper(ObjectMapper objectMapper) {
+    if (objectMapper == null) {
+      return new ZeebeObjectMapper();
+    }
+    return new ZeebeObjectMapper(objectMapper.copy());
+  }
+
+  @Bean(name = "commonJsonMapper")
+  @ConditionalOnMissingBean
+  public io.camunda.zeebe.spring.common.json.JsonMapper commonJsonMapper(
+      ObjectMapper objectMapper) {
+    if (objectMapper == null) {
+      return new SdkObjectMapper();
+    }
+    return new SdkObjectMapper(objectMapper.copy());
   }
 
   @Bean

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/ObjectMapperSerializationTest.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/ObjectMapperSerializationTest.java
@@ -17,14 +17,13 @@
 package io.camunda.connector.runtime;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.connector.feel.annotation.FEEL;
 import io.camunda.connector.runtime.app.TestConnectorRuntimeApplication;
-import io.camunda.process.test.api.CamundaSpringProcessTest;
 import io.camunda.zeebe.client.api.JsonMapper;
 import java.time.ZoneOffset;
 import java.util.Date;
@@ -42,7 +41,6 @@ import org.springframework.test.util.ReflectionTestUtils;
       "camunda.connector.polling.enabled=false"
     },
     classes = {TestConnectorRuntimeApplication.class})
-@CamundaSpringProcessTest
 public class ObjectMapperSerializationTest {
 
   @Autowired private JsonMapper jsonMapper;
@@ -59,8 +57,7 @@ public class ObjectMapperSerializationTest {
     Map<String, JsonMapper> jsonMapperBeans = applicationContext.getBeansOfType(JsonMapper.class);
     Object objectMapperOfJsonMapper = ReflectionTestUtils.getField(jsonMapper, "objectMapper");
 
-    // TODO: why are these not equal?
-    assertEquals(objectMapper, objectMapperOfJsonMapper);
+    assertNotEquals(objectMapper, objectMapperOfJsonMapper);
 
     assertThat(jsonMapperBeans.size()).isEqualTo(1);
     assertThat(jsonMapperBeans.containsKey("zeebeJsonMapper")).isTrue();

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/ObjectMapperSerializationTest.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/ObjectMapperSerializationTest.java
@@ -17,15 +17,15 @@
 package io.camunda.connector.runtime;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.connector.feel.annotation.FEEL;
 import io.camunda.connector.runtime.app.TestConnectorRuntimeApplication;
+import io.camunda.process.test.api.CamundaSpringProcessTest;
 import io.camunda.zeebe.client.api.JsonMapper;
-import io.camunda.zeebe.spring.test.ZeebeSpringTest;
 import java.time.ZoneOffset;
 import java.util.Date;
 import java.util.Map;
@@ -42,7 +42,7 @@ import org.springframework.test.util.ReflectionTestUtils;
       "camunda.connector.polling.enabled=false"
     },
     classes = {TestConnectorRuntimeApplication.class})
-@ZeebeSpringTest
+@CamundaSpringProcessTest
 public class ObjectMapperSerializationTest {
 
   @Autowired private JsonMapper jsonMapper;
@@ -58,7 +58,9 @@ public class ObjectMapperSerializationTest {
     assertThat(jsonMapper).isNotNull();
     Map<String, JsonMapper> jsonMapperBeans = applicationContext.getBeansOfType(JsonMapper.class);
     Object objectMapperOfJsonMapper = ReflectionTestUtils.getField(jsonMapper, "objectMapper");
-    assertNotEquals(objectMapper, objectMapperOfJsonMapper);
+
+    // TODO: why are these not equal?
+    assertEquals(objectMapper, objectMapperOfJsonMapper);
 
     assertThat(jsonMapperBeans.size()).isEqualTo(1);
     assertThat(jsonMapperBeans.containsKey("zeebeJsonMapper")).isTrue();

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/inbound/WebhookControllerPlainJavaTests.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/inbound/WebhookControllerPlainJavaTests.java
@@ -182,6 +182,6 @@ public class WebhookControllerPlainJavaTests {
         Map.of("inbound.type", "io.camunda:webhook:1", "inbound.context", path),
         new StartEventCorrelationPoint(bpmnProcessId, version, processDefinitionKey),
         new ProcessElement(
-            bpmnProcessId, version, processDefinitionKey, "testElement", "testTenantId"));
+            bpmnProcessId, version, processDefinitionKey, "testElement", "<default>"));
   }
 }

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/inbound/WebhookControllerTestZeebeTests.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/inbound/WebhookControllerTestZeebeTests.java
@@ -45,9 +45,9 @@ import io.camunda.connector.runtime.inbound.executable.RegisteredExecutable;
 import io.camunda.connector.runtime.inbound.webhook.FeelExpressionErrorResponse;
 import io.camunda.connector.runtime.inbound.webhook.InboundWebhookRestController;
 import io.camunda.connector.runtime.inbound.webhook.WebhookConnectorRegistry;
+import io.camunda.process.test.api.CamundaSpringProcessTest;
 import io.camunda.zeebe.client.ZeebeClient;
 import io.camunda.zeebe.model.bpmn.Bpmn;
-import io.camunda.zeebe.spring.test.ZeebeSpringTest;
 import java.util.HashMap;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
@@ -68,7 +68,7 @@ import org.springframework.mock.web.MockHttpServletRequest;
       "spring.main.allow-bean-definition-overriding=true",
       "camunda.connector.webhook.enabled=true"
     })
-@ZeebeSpringTest
+@CamundaSpringProcessTest
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
 class WebhookControllerTestZeebeTests {

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/outbound/RuntimeStartupWithConnectorsFromEnvVarsTests.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/outbound/RuntimeStartupWithConnectorsFromEnvVarsTests.java
@@ -22,9 +22,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.camunda.connector.runtime.app.TestConnectorRuntimeApplication;
 import io.camunda.connector.runtime.core.discovery.EnvVarsConnectorDiscovery;
+import io.camunda.process.test.api.CamundaSpringProcessTest;
 import io.camunda.zeebe.spring.client.annotation.value.ZeebeWorkerValue;
 import io.camunda.zeebe.spring.client.jobhandling.JobWorkerManager;
-import io.camunda.zeebe.spring.test.ZeebeSpringTest;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -38,7 +38,7 @@ import org.springframework.test.context.event.annotation.BeforeTestClass;
       "camunda.connector.polling.enabled=false"
     },
     classes = {TestConnectorRuntimeApplication.class})
-@ZeebeSpringTest
+@CamundaSpringProcessTest
 /*
 @TestPropertySource(properties = {
         "CONNECTOR_TEST2_FUNCTION=io.camunda.connector.http.HttpJsonFunction",

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/outbound/RuntimeStartupWithConnectorsFromSpiTests.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/outbound/RuntimeStartupWithConnectorsFromSpiTests.java
@@ -19,9 +19,9 @@ package io.camunda.connector.runtime.outbound;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.camunda.connector.runtime.app.TestConnectorRuntimeApplication;
+import io.camunda.process.test.api.CamundaSpringProcessTest;
 import io.camunda.zeebe.spring.client.annotation.value.ZeebeWorkerValue;
 import io.camunda.zeebe.spring.client.jobhandling.JobWorkerManager;
-import io.camunda.zeebe.spring.test.ZeebeSpringTest;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -33,7 +33,7 @@ import org.springframework.boot.test.context.SpringBootTest;
       "camunda.connector.polling.enabled=false"
     },
     classes = {TestConnectorRuntimeApplication.class})
-@ZeebeSpringTest
+@CamundaSpringProcessTest
 class RuntimeStartupWithConnectorsFromSpiTests {
 
   @Autowired private JobWorkerManager jobWorkerManager;

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/test/resources/application.properties
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/test/resources/application.properties
@@ -1,6 +1,4 @@
 # test secret property
 secrets.test.secret=test secret value
 
-operate.client.url=http://localhost:8081
-operate.client.username=demo
-operate.client.password=demo
+operate.client.profile=simple

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/test/resources/application.properties
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/test/resources/application.properties
@@ -2,3 +2,12 @@
 secrets.test.secret=test secret value
 
 operate.client.profile=simple
+
+
+logging.level.root: info
+logging.level.io.camunda.process.test: info
+
+logging.level.org.testcontainers: warn
+logging.level.tc: warn
+
+logging.level.io.camunda.connector: debug

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/test/resources/camunda-container-runtime.properties
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/test/resources/camunda-container-runtime.properties
@@ -1,0 +1,1 @@
+camunda.version=8.5.0

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/test/resources/camunda-container-runtime.properties
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/test/resources/camunda-container-runtime.properties
@@ -1,1 +1,0 @@
-camunda.version=8.5.0

--- a/connectors-e2e-test/connectors-e2e-test-automation-anywhere/pom.xml
+++ b/connectors-e2e-test/connectors-e2e-test-automation-anywhere/pom.xml
@@ -31,6 +31,11 @@
       <artifactId>connector-automationanywhere</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>camunda-process-test-spring</artifactId>
+      <version>8.6.0-SNAPSHOT</version>
+    </dependency>
 
     <!-- Test -->
     <dependency>

--- a/connectors-e2e-test/connectors-e2e-test-automation-anywhere/pom.xml
+++ b/connectors-e2e-test/connectors-e2e-test-automation-anywhere/pom.xml
@@ -34,7 +34,7 @@
     <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>camunda-process-test-spring</artifactId>
-      <version>8.6.0-SNAPSHOT</version>
+      <version>8.7.0-SNAPSHOT</version>
     </dependency>
 
     <!-- Test -->

--- a/connectors-e2e-test/connectors-e2e-test-automation-anywhere/src/test/java/io/camunda/connector/e2e/AddWorkItemAutomationAnywhereTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-automation-anywhere/src/test/java/io/camunda/connector/e2e/AddWorkItemAutomationAnywhereTests.java
@@ -19,13 +19,13 @@ package io.camunda.connector.e2e;
 import static com.github.tomakehurst.wiremock.client.WireMock.matching;
 import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathMatching;
-import static io.camunda.zeebe.process.test.assertions.BpmnAssert.assertThat;
+import static io.camunda.process.test.api.CamundaAssert.assertThat;
 
 import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder;
 import com.github.tomakehurst.wiremock.client.WireMock;
 import io.camunda.connector.e2e.app.TestConnectorRuntimeApplication;
+import io.camunda.process.test.api.CamundaSpringProcessTest;
 import io.camunda.zeebe.model.bpmn.Bpmn;
-import io.camunda.zeebe.spring.test.ZeebeSpringTest;
 import java.io.File;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -40,7 +40,7 @@ import org.springframework.boot.test.context.SpringBootTest;
       "camunda.connector.polling.enabled=false"
     },
     webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@ZeebeSpringTest
+@CamundaSpringProcessTest
 @ExtendWith(MockitoExtension.class)
 public class AddWorkItemAutomationAnywhereTests extends BaseAutomationAnywhereTest {
 
@@ -84,7 +84,7 @@ public class AddWorkItemAutomationAnywhereTests extends BaseAutomationAnywhereTe
             .createInstance()
             .waitForProcessCompletion();
 
-    assertThat(bpmnTest.getProcessInstanceEvent()).hasVariableWithValue("itemId", 31250);
+    assertThat(bpmnTest.getProcessInstanceEvent()).hasVariable("itemId", 31250);
   }
 
   @Test
@@ -134,7 +134,7 @@ public class AddWorkItemAutomationAnywhereTests extends BaseAutomationAnywhereTe
             .createInstance()
             .waitForProcessCompletion();
 
-    assertThat(bpmnTest.getProcessInstanceEvent()).hasVariableWithValue("itemId", 31250);
+    assertThat(bpmnTest.getProcessInstanceEvent()).hasVariable("itemId", 31250);
   }
 
   @Test
@@ -181,6 +181,6 @@ public class AddWorkItemAutomationAnywhereTests extends BaseAutomationAnywhereTe
             .createInstance()
             .waitForProcessCompletion();
 
-    assertThat(bpmnTest.getProcessInstanceEvent()).hasVariableWithValue("itemId", 31250);
+    assertThat(bpmnTest.getProcessInstanceEvent()).hasVariable("itemId", 31250);
   }
 }

--- a/connectors-e2e-test/connectors-e2e-test-automation-anywhere/src/test/java/io/camunda/connector/e2e/AddWorkItemAutomationAnywhereTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-automation-anywhere/src/test/java/io/camunda/connector/e2e/AddWorkItemAutomationAnywhereTests.java
@@ -37,7 +37,8 @@ import org.springframework.boot.test.context.SpringBootTest;
     properties = {
       "spring.main.allow-bean-definition-overriding=true",
       "camunda.connector.webhook.enabled=false",
-      "camunda.connector.polling.enabled=false"
+      "camunda.connector.polling.enabled=false",
+      "operate.client.profile=simple"
     },
     webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @CamundaSpringProcessTest

--- a/connectors-e2e-test/connectors-e2e-test-automation-anywhere/src/test/java/io/camunda/connector/e2e/GetWorkItemAutomationAnywhereTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-automation-anywhere/src/test/java/io/camunda/connector/e2e/GetWorkItemAutomationAnywhereTests.java
@@ -37,7 +37,8 @@ import org.springframework.boot.test.context.SpringBootTest;
     properties = {
       "spring.main.allow-bean-definition-overriding=true",
       "camunda.connector.webhook.enabled=false",
-      "camunda.connector.polling.enabled=false"
+      "camunda.connector.polling.enabled=false",
+      "operate.client.profile=simple"
     },
     webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @CamundaSpringProcessTest

--- a/connectors-e2e-test/connectors-e2e-test-automation-anywhere/src/test/java/io/camunda/connector/e2e/GetWorkItemAutomationAnywhereTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-automation-anywhere/src/test/java/io/camunda/connector/e2e/GetWorkItemAutomationAnywhereTests.java
@@ -19,13 +19,13 @@ package io.camunda.connector.e2e;
 import static com.github.tomakehurst.wiremock.client.WireMock.matching;
 import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathMatching;
-import static io.camunda.zeebe.process.test.assertions.BpmnAssert.assertThat;
+import static io.camunda.process.test.api.CamundaAssert.assertThat;
 
 import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder;
 import com.github.tomakehurst.wiremock.client.WireMock;
 import io.camunda.connector.e2e.app.TestConnectorRuntimeApplication;
+import io.camunda.process.test.api.CamundaSpringProcessTest;
 import io.camunda.zeebe.model.bpmn.Bpmn;
-import io.camunda.zeebe.spring.test.ZeebeSpringTest;
 import java.io.File;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -40,7 +40,7 @@ import org.springframework.boot.test.context.SpringBootTest;
       "camunda.connector.polling.enabled=false"
     },
     webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@ZeebeSpringTest
+@CamundaSpringProcessTest
 @ExtendWith(MockitoExtension.class)
 public class GetWorkItemAutomationAnywhereTests extends BaseAutomationAnywhereTest {
 
@@ -82,8 +82,7 @@ public class GetWorkItemAutomationAnywhereTests extends BaseAutomationAnywhereTe
             .createInstance()
             .waitForProcessCompletion();
 
-    assertThat(bpmnTest.getProcessInstanceEvent())
-        .hasVariableWithValue("itemState", "READY_TO_RUN");
+    assertThat(bpmnTest.getProcessInstanceEvent()).hasVariable("itemState", "READY_TO_RUN");
   }
 
   @Test
@@ -131,8 +130,7 @@ public class GetWorkItemAutomationAnywhereTests extends BaseAutomationAnywhereTe
             .createInstance()
             .waitForProcessCompletion();
 
-    assertThat(bpmnTest.getProcessInstanceEvent())
-        .hasVariableWithValue("itemState", "READY_TO_RUN");
+    assertThat(bpmnTest.getProcessInstanceEvent()).hasVariable("itemState", "READY_TO_RUN");
   }
 
   @Test
@@ -179,7 +177,6 @@ public class GetWorkItemAutomationAnywhereTests extends BaseAutomationAnywhereTe
             .createInstance()
             .waitForProcessCompletion();
 
-    assertThat(bpmnTest.getProcessInstanceEvent())
-        .hasVariableWithValue("itemState", "READY_TO_RUN");
+    assertThat(bpmnTest.getProcessInstanceEvent()).hasVariable("itemState", "READY_TO_RUN");
   }
 }

--- a/connectors-e2e-test/connectors-e2e-test-aws/connectors-e2e-test-aws-base/src/test/java/io/camunda/connector/e2e/BaseAwsTest.java
+++ b/connectors-e2e-test/connectors-e2e-test-aws/connectors-e2e-test-aws-base/src/test/java/io/camunda/connector/e2e/BaseAwsTest.java
@@ -25,8 +25,8 @@ import static org.mockito.Mockito.when;
 import io.camunda.connector.e2e.app.TestConnectorRuntimeApplication;
 import io.camunda.connector.runtime.inbound.importer.ProcessDefinitionSearch;
 import io.camunda.operate.CamundaOperateClient;
+import io.camunda.process.test.api.CamundaSpringProcessTest;
 import io.camunda.zeebe.client.ZeebeClient;
-import io.camunda.zeebe.spring.test.ZeebeSpringTest;
 import java.io.File;
 import java.util.Collections;
 import org.junit.jupiter.api.AfterAll;
@@ -49,7 +49,7 @@ import org.testcontainers.utility.DockerImageName;
       "camunda.connector.polling.enabled=true"
     },
     webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@ZeebeSpringTest
+@CamundaSpringProcessTest
 @ExtendWith(MockitoExtension.class)
 public abstract class BaseAwsTest {
   private static final DockerImageName localstackImage =

--- a/connectors-e2e-test/connectors-e2e-test-aws/connectors-e2e-test-aws-base/src/test/java/io/camunda/connector/e2e/BaseAwsTest.java
+++ b/connectors-e2e-test/connectors-e2e-test-aws/connectors-e2e-test-aws-base/src/test/java/io/camunda/connector/e2e/BaseAwsTest.java
@@ -46,7 +46,8 @@ import org.testcontainers.utility.DockerImageName;
     properties = {
       "spring.main.allow-bean-definition-overriding=true",
       "camunda.connector.webhook.enabled=false",
-      "camunda.connector.polling.enabled=true"
+      "camunda.connector.polling.enabled=true",
+      "operate.client.profile=simple"
     },
     webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @CamundaSpringProcessTest

--- a/connectors-e2e-test/connectors-e2e-test-aws/connectors-e2e-test-aws-event-bridge/src/test/java/io/camunda/connector/e2e/AwsEventBridgeTest.java
+++ b/connectors-e2e-test/connectors-e2e-test-aws/connectors-e2e-test-aws-event-bridge/src/test/java/io/camunda/connector/e2e/AwsEventBridgeTest.java
@@ -16,7 +16,7 @@
  */
 package io.camunda.connector.e2e;
 
-import static io.camunda.zeebe.process.test.assertions.BpmnAssert.assertThat;
+import static io.camunda.process.test.api.CamundaAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
@@ -135,7 +135,7 @@ public class AwsEventBridgeTest extends BaseAwsTest {
             .createInstance()
             .waitForProcessCompletion();
 
-    assertThat(bpmnTest.getProcessInstanceEvent()).hasVariable("result");
+    assertThat(bpmnTest.getProcessInstanceEvent()).hasVariableNames("result");
     // Poll the SQS queue to check for the event
     List<Message> messages = AwsTestHelper.receiveMessages(sqsClient, queueUrl);
     // Assert that the queue received the message

--- a/connectors-e2e-test/connectors-e2e-test-aws/connectors-e2e-test-aws-lambda/src/test/java/io/camunda/connector/e2e/AwsLambdaTest.java
+++ b/connectors-e2e-test/connectors-e2e-test-aws/connectors-e2e-test-aws-lambda/src/test/java/io/camunda/connector/e2e/AwsLambdaTest.java
@@ -16,7 +16,7 @@
  */
 package io.camunda.connector.e2e;
 
-import static io.camunda.zeebe.process.test.assertions.BpmnAssert.assertThat;
+import static io.camunda.process.test.api.CamundaAssert.assertThat;
 
 import com.amazonaws.auth.AWSStaticCredentialsProvider;
 import com.amazonaws.auth.BasicAWSCredentials;
@@ -109,6 +109,6 @@ public class AwsLambdaTest extends BaseAwsTest {
             .readValue(
                 "{\"statusCode\":200,\"body\":\"{\\\"message\\\": \\\"Hello from your Python Lambda function!\\\", \\\"receivedEvent\\\": \\\"str\\\"}\"}",
                 Object.class);
-    assertThat(bpmnTest.getProcessInstanceEvent()).hasVariableWithValue("response", expectedResult);
+    assertThat(bpmnTest.getProcessInstanceEvent()).hasVariable("response", expectedResult);
   }
 }

--- a/connectors-e2e-test/connectors-e2e-test-aws/connectors-e2e-test-aws-sns/src/test/java/io/camunda/connector/e2e/AwsSnsTest.java
+++ b/connectors-e2e-test/connectors-e2e-test-aws/connectors-e2e-test-aws-sns/src/test/java/io/camunda/connector/e2e/AwsSnsTest.java
@@ -16,7 +16,7 @@
  */
 package io.camunda.connector.e2e;
 
-import static io.camunda.zeebe.process.test.assertions.BpmnAssert.assertThat;
+import static io.camunda.process.test.api.CamundaAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.testcontainers.containers.localstack.LocalStackContainer.Service.SQS;
@@ -135,7 +135,7 @@ public class AwsSnsTest extends BaseAwsTest {
             .createInstance()
             .waitForProcessCompletion();
 
-    assertThat(bpmnTest.getProcessInstanceEvent()).hasVariable("result");
+    assertThat(bpmnTest.getProcessInstanceEvent()).hasVariableNames("result");
 
     // Retrieve and validate messages from the SQS queue
     List<Message> messages = AwsTestHelper.receiveMessages(sqsClient, sqsQueueUrl);
@@ -195,7 +195,7 @@ public class AwsSnsTest extends BaseAwsTest {
             .createInstance()
             .waitForProcessCompletion();
 
-    assertThat(bpmnTest.getProcessInstanceEvent()).hasVariable("result");
+    assertThat(bpmnTest.getProcessInstanceEvent()).hasVariableNames("result");
 
     // Retrieve and validate messages from the SQS queue
     List<Message> messages = AwsTestHelper.receiveMessages(sqsClient, sqsFifoQueueUrl);

--- a/connectors-e2e-test/connectors-e2e-test-aws/connectors-e2e-test-aws-sqs/src/test/java/io/camunda/connector/e2e/AwsSqsTest.java
+++ b/connectors-e2e-test/connectors-e2e-test-aws/connectors-e2e-test-aws-sqs/src/test/java/io/camunda/connector/e2e/AwsSqsTest.java
@@ -17,7 +17,7 @@
 package io.camunda.connector.e2e;
 
 import static io.camunda.connector.e2e.AwsTestHelper.initSqsClient;
-import static io.camunda.zeebe.process.test.assertions.BpmnAssert.assertThat;
+import static io.camunda.process.test.api.CamundaAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
@@ -107,7 +107,7 @@ public class AwsSqsTest extends BaseAwsTest {
             .createInstance()
             .waitForProcessCompletion();
 
-    assertThat(bpmnTest.getProcessInstanceEvent()).hasVariable("result");
+    assertThat(bpmnTest.getProcessInstanceEvent()).hasVariableNames("result");
 
     List<Message> messages = AwsTestHelper.receiveMessages(sqsClient, sqsQueueUrl);
 
@@ -167,7 +167,7 @@ public class AwsSqsTest extends BaseAwsTest {
             .createInstance()
             .waitForProcessCompletion();
 
-    assertThat(bpmnTest.getProcessInstanceEvent()).hasVariable("result");
+    assertThat(bpmnTest.getProcessInstanceEvent()).hasVariableNames("result");
 
     List<Message> messages = AwsTestHelper.receiveMessages(sqsClient, sqsQueueUrl);
 

--- a/connectors-e2e-test/connectors-e2e-test-aws/pom.xml
+++ b/connectors-e2e-test/connectors-e2e-test-aws/pom.xml
@@ -32,7 +32,7 @@
     <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>camunda-process-test-spring</artifactId>
-      <version>8.6.0-SNAPSHOT</version>
+      <version>8.7.0-SNAPSHOT</version>
     </dependency>
 
 </dependencies>

--- a/connectors-e2e-test/connectors-e2e-test-aws/pom.xml
+++ b/connectors-e2e-test/connectors-e2e-test-aws/pom.xml
@@ -29,6 +29,11 @@
       <artifactId>connectors-e2e-test-base</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>camunda-process-test-spring</artifactId>
+      <version>8.6.0-SNAPSHOT</version>
+    </dependency>
 
 </dependencies>
 

--- a/connectors-e2e-test/connectors-e2e-test-base/pom.xml
+++ b/connectors-e2e-test/connectors-e2e-test-base/pom.xml
@@ -35,8 +35,8 @@
             <artifactId>spring-boot-starter-test</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.camunda.spring</groupId>
-            <artifactId>spring-boot-starter-camunda-test</artifactId>
+            <groupId>io.camunda</groupId>
+            <artifactId>spring-boot-starter-camunda-sdk</artifactId>
         </dependency>
         <dependency>
             <groupId>io.camunda.connector</groupId>

--- a/connectors-e2e-test/connectors-e2e-test-base/pom.xml
+++ b/connectors-e2e-test/connectors-e2e-test-base/pom.xml
@@ -39,6 +39,11 @@
             <artifactId>spring-boot-starter-camunda-sdk</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.camunda</groupId>
+            <artifactId>camunda-process-test-spring</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
             <groupId>io.camunda.connector</groupId>
             <artifactId>connector-test</artifactId>
         </dependency>

--- a/connectors-e2e-test/connectors-e2e-test-base/src/main/java/io/camunda/connector/e2e/ZeebeTest.java
+++ b/connectors-e2e-test/connectors-e2e-test-base/src/main/java/io/camunda/connector/e2e/ZeebeTest.java
@@ -16,8 +16,6 @@
  */
 package io.camunda.connector.e2e;
 
-import static org.awaitility.Awaitility.await;
-
 import io.camunda.process.test.api.CamundaAssert;
 import io.camunda.zeebe.client.ZeebeClient;
 import io.camunda.zeebe.client.api.response.DeploymentEvent;
@@ -68,7 +66,9 @@ public class ZeebeTest {
   }
 
   public ZeebeTest waitForProcessCompletion() {
-    Awaitility.with().pollInSameThread().await()
+    Awaitility.with()
+        .pollInSameThread()
+        .await()
         .atMost(10, TimeUnit.SECONDS)
         .untilAsserted(() -> CamundaAssert.assertThat(processInstanceEvent).isCompleted());
     return this;

--- a/connectors-e2e-test/connectors-e2e-test-base/src/main/java/io/camunda/connector/e2e/ZeebeTest.java
+++ b/connectors-e2e-test/connectors-e2e-test-base/src/main/java/io/camunda/connector/e2e/ZeebeTest.java
@@ -16,14 +16,16 @@
  */
 package io.camunda.connector.e2e;
 
+import static org.awaitility.Awaitility.await;
+
+import io.camunda.process.test.api.CamundaAssert;
 import io.camunda.zeebe.client.ZeebeClient;
 import io.camunda.zeebe.client.api.response.DeploymentEvent;
 import io.camunda.zeebe.client.api.response.ProcessInstanceEvent;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.model.bpmn.instance.Process;
-import io.camunda.zeebe.spring.test.ZeebeTestThreadSupport;
-import java.time.Duration;
-import java.time.temporal.ChronoUnit;
+import java.util.concurrent.TimeUnit;
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Assertions;
 
 public class ZeebeTest {
@@ -66,8 +68,9 @@ public class ZeebeTest {
   }
 
   public ZeebeTest waitForProcessCompletion() {
-    ZeebeTestThreadSupport.waitForProcessInstanceCompleted(
-        processInstanceEvent, Duration.of(10, ChronoUnit.SECONDS));
+    Awaitility.with().pollInSameThread().await()
+        .atMost(10, TimeUnit.SECONDS)
+        .untilAsserted(() -> CamundaAssert.assertThat(processInstanceEvent).isCompleted());
     return this;
   }
 

--- a/connectors-e2e-test/connectors-e2e-test-base/src/main/resources/application.properties
+++ b/connectors-e2e-test/connectors-e2e-test-base/src/main/resources/application.properties
@@ -3,3 +3,5 @@ logging.level.io.camunda.process.test: info
 
 logging.level.org.testcontainers: warn
 logging.level.tc: warn
+
+logging.level.io.camunda.connector: debug

--- a/connectors-e2e-test/connectors-e2e-test-base/src/main/resources/application.properties
+++ b/connectors-e2e-test/connectors-e2e-test-base/src/main/resources/application.properties
@@ -1,7 +1,9 @@
-logging.level.root: info
-logging.level.io.camunda.process.test: info
+logging.level.root=info
+logging.level.io.camunda.process.test=info
 
-logging.level.org.testcontainers: warn
-logging.level.tc: warn
+logging.level.org.testcontainers=warn
+logging.level.tc=warn
 
-logging.level.io.camunda.connector: debug
+logging.level.io.camunda.connector=debug
+
+operate.client.profile=simple

--- a/connectors-e2e-test/connectors-e2e-test-base/src/main/resources/application.properties
+++ b/connectors-e2e-test/connectors-e2e-test-base/src/main/resources/application.properties
@@ -1,0 +1,5 @@
+logging.level.root: info
+logging.level.io.camunda.process.test: info
+
+logging.level.org.testcontainers: warn
+logging.level.tc: warn

--- a/connectors-e2e-test/connectors-e2e-test-easy-post/pom.xml
+++ b/connectors-e2e-test/connectors-e2e-test-easy-post/pom.xml
@@ -33,6 +33,12 @@
       <version>${project.version}</version>
     </dependency>
 
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>camunda-process-test-spring</artifactId>
+      <version>8.6.0-SNAPSHOT</version>
+    </dependency>
+
     <!-- Test -->
     <dependency>
       <groupId>io.camunda.connector</groupId>

--- a/connectors-e2e-test/connectors-e2e-test-easy-post/pom.xml
+++ b/connectors-e2e-test/connectors-e2e-test-easy-post/pom.xml
@@ -36,7 +36,7 @@
     <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>camunda-process-test-spring</artifactId>
-      <version>8.6.0-SNAPSHOT</version>
+      <version>8.7.0-SNAPSHOT</version>
     </dependency>
 
     <!-- Test -->

--- a/connectors-e2e-test/connectors-e2e-test-easy-post/src/test/java/io/camunda/connector/e2e/EasyPostTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-easy-post/src/test/java/io/camunda/connector/e2e/EasyPostTests.java
@@ -38,7 +38,7 @@ import org.springframework.boot.test.context.SpringBootTest;
       "spring.main.allow-bean-definition-overriding=true",
       "camunda.connector.webhook.enabled=false",
       "camunda.connector.polling.enabled=false",
-        "operate.client.profile=simple"
+      "operate.client.profile=simple"
     },
     webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @CamundaSpringProcessTest
@@ -71,8 +71,7 @@ public class EasyPostTests extends BaseEasyPostTest {
 
     ZeebeTest bpmnTest = setupTestWithBpmnModel("easyPostCreateAddressTask", elementTemplate);
 
-    assertThat(bpmnTest.getProcessInstanceEvent())
-        .hasVariable("addressId", "expectedAddressId");
+    assertThat(bpmnTest.getProcessInstanceEvent()).hasVariable("addressId", "expectedAddressId");
   }
 
   @Test
@@ -94,8 +93,7 @@ public class EasyPostTests extends BaseEasyPostTest {
 
     ZeebeTest bpmnTest = setupTestWithBpmnModel("easyPostCreateParcelTask", elementTemplate);
 
-    assertThat(bpmnTest.getProcessInstanceEvent())
-        .hasVariable("parcelId", "expectedParcelId");
+    assertThat(bpmnTest.getProcessInstanceEvent()).hasVariable("parcelId", "expectedParcelId");
   }
 
   @Test
@@ -117,8 +115,7 @@ public class EasyPostTests extends BaseEasyPostTest {
 
     ZeebeTest bpmnTest = setupTestWithBpmnModel("easyPostCreateShipmentTask", elementTemplate);
 
-    assertThat(bpmnTest.getProcessInstanceEvent())
-        .hasVariable("shipmentId", "shp_123456789");
+    assertThat(bpmnTest.getProcessInstanceEvent()).hasVariable("shipmentId", "shp_123456789");
   }
 
   @Test
@@ -161,8 +158,7 @@ public class EasyPostTests extends BaseEasyPostTest {
 
     ZeebeTest bpmnTest = setupTestWithBpmnModel("easyPostVerifyAddressTask", elementTemplate);
 
-    assertThat(bpmnTest.getProcessInstanceEvent())
-        .hasVariable("addressDeliverySuccess", true);
+    assertThat(bpmnTest.getProcessInstanceEvent()).hasVariable("addressDeliverySuccess", true);
   }
 
   @Test
@@ -179,8 +175,7 @@ public class EasyPostTests extends BaseEasyPostTest {
 
     ZeebeTest bpmnTest = setupTestWithBpmnModel("easyPostRetrieveTrackerTask", elementTemplate);
 
-    assertThat(bpmnTest.getProcessInstanceEvent())
-        .hasVariable("trackerStatus", "pre_transit");
+    assertThat(bpmnTest.getProcessInstanceEvent()).hasVariable("trackerStatus", "pre_transit");
   }
 
   private ElementTemplate getElementTemplateWithBasicAuthForOperationType(String operationType) {

--- a/connectors-e2e-test/connectors-e2e-test-easy-post/src/test/java/io/camunda/connector/e2e/EasyPostTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-easy-post/src/test/java/io/camunda/connector/e2e/EasyPostTests.java
@@ -20,12 +20,12 @@ import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.matching;
 import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathMatching;
-import static io.camunda.zeebe.process.test.assertions.BpmnAssert.assertThat;
+import static io.camunda.process.test.api.CamundaAssert.assertThat;
 
 import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder;
 import com.github.tomakehurst.wiremock.client.WireMock;
 import io.camunda.connector.e2e.app.TestConnectorRuntimeApplication;
-import io.camunda.zeebe.spring.test.ZeebeSpringTest;
+import io.camunda.process.test.api.CamundaSpringProcessTest;
 import java.io.File;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -37,10 +37,11 @@ import org.springframework.boot.test.context.SpringBootTest;
     properties = {
       "spring.main.allow-bean-definition-overriding=true",
       "camunda.connector.webhook.enabled=false",
-      "camunda.connector.polling.enabled=false"
+      "camunda.connector.polling.enabled=false",
+        "operate.client.profile=simple"
     },
     webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@ZeebeSpringTest
+@CamundaSpringProcessTest
 @ExtendWith(MockitoExtension.class)
 public class EasyPostTests extends BaseEasyPostTest {
 
@@ -71,7 +72,7 @@ public class EasyPostTests extends BaseEasyPostTest {
     ZeebeTest bpmnTest = setupTestWithBpmnModel("easyPostCreateAddressTask", elementTemplate);
 
     assertThat(bpmnTest.getProcessInstanceEvent())
-        .hasVariableWithValue("addressId", "expectedAddressId");
+        .hasVariable("addressId", "expectedAddressId");
   }
 
   @Test
@@ -94,7 +95,7 @@ public class EasyPostTests extends BaseEasyPostTest {
     ZeebeTest bpmnTest = setupTestWithBpmnModel("easyPostCreateParcelTask", elementTemplate);
 
     assertThat(bpmnTest.getProcessInstanceEvent())
-        .hasVariableWithValue("parcelId", "expectedParcelId");
+        .hasVariable("parcelId", "expectedParcelId");
   }
 
   @Test
@@ -117,7 +118,7 @@ public class EasyPostTests extends BaseEasyPostTest {
     ZeebeTest bpmnTest = setupTestWithBpmnModel("easyPostCreateShipmentTask", elementTemplate);
 
     assertThat(bpmnTest.getProcessInstanceEvent())
-        .hasVariableWithValue("shipmentId", "shp_123456789");
+        .hasVariable("shipmentId", "shp_123456789");
   }
 
   @Test
@@ -137,7 +138,7 @@ public class EasyPostTests extends BaseEasyPostTest {
     ZeebeTest bpmnTest = setupTestWithBpmnModel("easyPostBuyShipmentTask", elementTemplate);
 
     assertThat(bpmnTest.getProcessInstanceEvent())
-        .hasVariableWithValue("trackerId", "trk_c1aa7f4bfa71414887e5e87e0138fb98");
+        .hasVariable("trackerId", "trk_c1aa7f4bfa71414887e5e87e0138fb98");
   }
 
   @Test
@@ -161,7 +162,7 @@ public class EasyPostTests extends BaseEasyPostTest {
     ZeebeTest bpmnTest = setupTestWithBpmnModel("easyPostVerifyAddressTask", elementTemplate);
 
     assertThat(bpmnTest.getProcessInstanceEvent())
-        .hasVariableWithValue("addressDeliverySuccess", true);
+        .hasVariable("addressDeliverySuccess", true);
   }
 
   @Test
@@ -179,7 +180,7 @@ public class EasyPostTests extends BaseEasyPostTest {
     ZeebeTest bpmnTest = setupTestWithBpmnModel("easyPostRetrieveTrackerTask", elementTemplate);
 
     assertThat(bpmnTest.getProcessInstanceEvent())
-        .hasVariableWithValue("trackerStatus", "pre_transit");
+        .hasVariable("trackerStatus", "pre_transit");
   }
 
   private ElementTemplate getElementTemplateWithBasicAuthForOperationType(String operationType) {

--- a/connectors-e2e-test/connectors-e2e-test-easy-post/src/test/resources/camunda-container-runtime.properties
+++ b/connectors-e2e-test/connectors-e2e-test-easy-post/src/test/resources/camunda-container-runtime.properties
@@ -1,0 +1,1 @@
+camunda.version=8.5.0

--- a/connectors-e2e-test/connectors-e2e-test-easy-post/src/test/resources/camunda-container-runtime.properties
+++ b/connectors-e2e-test/connectors-e2e-test-easy-post/src/test/resources/camunda-container-runtime.properties
@@ -1,1 +1,0 @@
-camunda.version=8.5.0

--- a/connectors-e2e-test/connectors-e2e-test-http/pom.xml
+++ b/connectors-e2e-test/connectors-e2e-test-http/pom.xml
@@ -47,7 +47,7 @@
     <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>camunda-process-test-spring</artifactId>
-      <version>8.6.0-SNAPSHOT</version>
+      <version>8.7.0-SNAPSHOT</version>
     </dependency>
 
     <!-- Test -->

--- a/connectors-e2e-test/connectors-e2e-test-http/pom.xml
+++ b/connectors-e2e-test/connectors-e2e-test-http/pom.xml
@@ -44,6 +44,12 @@
       <version>${project.version}</version>
     </dependency>
 
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>camunda-process-test-spring</artifactId>
+      <version>8.6.0-SNAPSHOT</version>
+    </dependency>
+
     <!-- Test -->
     <dependency>
       <groupId>io.camunda.connector</groupId>

--- a/connectors-e2e-test/connectors-e2e-test-http/src/test/java/io/camunda/connector/e2e/HttpTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-http/src/test/java/io/camunda/connector/e2e/HttpTests.java
@@ -70,7 +70,7 @@ import wiremock.com.fasterxml.jackson.databind.node.JsonNodeFactory;
       "spring.main.allow-bean-definition-overriding=true",
       "camunda.connector.webhook.enabled=true",
       "camunda.connector.polling.enabled=true",
-        "operate.client.profile=simple"
+      "operate.client.profile=simple"
     },
     webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @CamundaSpringProcessTest

--- a/connectors-e2e-test/connectors-e2e-test-http/src/test/java/io/camunda/connector/e2e/HttpTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-http/src/test/java/io/camunda/connector/e2e/HttpTests.java
@@ -517,6 +517,9 @@ public class HttpTests {
             .serviceTask("restTask")
             .boundaryEvent("errorId")
             .error()
+            .zeebeOutput("=temp", "temp")
+            .zeebeOutput("=message", "message")
+            .zeebeOutput("=booleanField", "booleanField")
             .endEvent()
             .done();
 
@@ -524,10 +527,10 @@ public class HttpTests {
         ElementTemplate.from(
                 "../../connectors/http/rest/element-templates/http-json-connector.json")
             .property("url", mockUrl)
-            .property("method", "post")
+            .property("method", "POST")
             .property(
                 "errorExpression",
-                "if matches(error.code, \"400\") and error.variables.response.body.temp = 36 then bpmnError(\"Too hot\", error.variables.response.body.message, error.variables.response.body) else bpmnError(\"Not too hot\", \"The message default\",{fake: \"fakeValue\"})")
+                "=if matches(error.code, \"400\") and error.variables.response.body.temp = 36 then bpmnError(\"Too hot\", error.variables.response.body.message, error.variables.response.body) else bpmnError(\"Not too hot\", \"The message default\",{fake: \"fakeValue\"})")
             .writeTo(new File(tempDir, "template.json"));
 
     var updatedModel =
@@ -541,13 +544,6 @@ public class HttpTests {
             .createInstance()
             .waitForProcessCompletion();
 
-    var pi =
-        zeebeClient
-            .newProcessInstanceQuery()
-            .filter(
-                (filter) ->
-                    filter.processInstanceKeys(
-                        bpmnTest.getProcessInstanceEvent().getProcessInstanceKey()));
     assertThat(bpmnTest.getProcessInstanceEvent())
         .hasVariable("temp", 36)
         .hasVariable("booleanField", true)

--- a/connectors-e2e-test/connectors-e2e-test-http/src/test/java/io/camunda/connector/e2e/HttpTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-http/src/test/java/io/camunda/connector/e2e/HttpTests.java
@@ -26,7 +26,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.urlPathMatching;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 import static io.camunda.connector.e2e.BpmnFile.Replace.replace;
 import static io.camunda.connector.e2e.BpmnFile.replace;
-import static io.camunda.zeebe.process.test.assertions.BpmnAssert.assertThat;
+import static io.camunda.process.test.api.CamundaAssert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -45,10 +45,10 @@ import io.camunda.connector.runtime.inbound.state.ProcessImportResult.ProcessDef
 import io.camunda.connector.runtime.inbound.state.ProcessStateStore;
 import io.camunda.operate.CamundaOperateClient;
 import io.camunda.operate.model.ProcessDefinition;
+import io.camunda.process.test.api.CamundaSpringProcessTest;
 import io.camunda.zeebe.client.ZeebeClient;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.instance.Process;
-import io.camunda.zeebe.spring.test.ZeebeSpringTest;
 import java.io.File;
 import java.util.Collections;
 import java.util.Map;
@@ -69,10 +69,11 @@ import wiremock.com.fasterxml.jackson.databind.node.JsonNodeFactory;
     properties = {
       "spring.main.allow-bean-definition-overriding=true",
       "camunda.connector.webhook.enabled=true",
-      "camunda.connector.polling.enabled=true"
+      "camunda.connector.polling.enabled=true",
+        "operate.client.profile=simple"
     },
     webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@ZeebeSpringTest
+@CamundaSpringProcessTest
 @ExtendWith(MockitoExtension.class)
 public class HttpTests {
 
@@ -87,7 +88,7 @@ public class HttpTests {
 
   @Autowired ProcessStateStore stateStore;
 
-  @Autowired CamundaOperateClient camundaOperateClient;
+  @MockBean CamundaOperateClient camundaOperateClient;
 
   @LocalServerPort int serverPort;
 
@@ -138,8 +139,7 @@ public class HttpTests {
             .createInstance()
             .waitForProcessCompletion();
 
-    assertThat(bpmnTest.getProcessInstanceEvent())
-        .hasVariableWithValue("orderStatus", "processing");
+    assertThat(bpmnTest.getProcessInstanceEvent()).hasVariable("orderStatus", "processing");
   }
 
   @Test
@@ -178,8 +178,7 @@ public class HttpTests {
             .createInstance()
             .waitForProcessCompletion();
 
-    assertThat(bpmnTest.getProcessInstanceEvent())
-        .hasVariableWithValue("orderStatus", "processing");
+    assertThat(bpmnTest.getProcessInstanceEvent()).hasVariable("orderStatus", "processing");
   }
 
   @Test
@@ -220,8 +219,7 @@ public class HttpTests {
             .createInstance()
             .waitForProcessCompletion();
 
-    assertThat(bpmnTest.getProcessInstanceEvent())
-        .hasVariableWithValue("orderStatus", "processing");
+    assertThat(bpmnTest.getProcessInstanceEvent()).hasVariable("orderStatus", "processing");
   }
 
   @Test
@@ -262,8 +260,7 @@ public class HttpTests {
             .createInstance()
             .waitForProcessCompletion();
 
-    assertThat(bpmnTest.getProcessInstanceEvent())
-        .hasVariableWithValue("orderStatus", "processing");
+    assertThat(bpmnTest.getProcessInstanceEvent()).hasVariable("orderStatus", "processing");
   }
 
   @Test
@@ -312,8 +309,7 @@ public class HttpTests {
             .createInstance()
             .waitForProcessCompletion();
 
-    assertThat(bpmnTest.getProcessInstanceEvent())
-        .hasVariableWithValue("orderStatus", "processing");
+    assertThat(bpmnTest.getProcessInstanceEvent()).hasVariable("orderStatus", "processing");
   }
 
   @Test
@@ -333,8 +329,7 @@ public class HttpTests {
     var bpmnTest =
         ZeebeTest.with(zeebeClient).deploy(model).createInstance().waitForProcessCompletion();
 
-    assertThat(bpmnTest.getProcessInstanceEvent())
-        .hasVariableWithValue("orderStatus", "processing");
+    assertThat(bpmnTest.getProcessInstanceEvent()).hasVariable("orderStatus", "processing");
   }
 
   @Test
@@ -363,7 +358,7 @@ public class HttpTests {
     var bpmnTest =
         ZeebeTest.with(zeebeClient).deploy(model).createInstance().waitForProcessCompletion();
 
-    assertThat(bpmnTest.getProcessInstanceEvent()).hasVariableWithValue("webhookExecuted", true);
+    assertThat(bpmnTest.getProcessInstanceEvent()).hasVariable("webhookExecuted", true);
   }
 
   @Test
@@ -392,8 +387,8 @@ public class HttpTests {
     var bpmnTest =
         ZeebeTest.with(zeebeClient).deploy(model).createInstance().waitForProcessCompletion();
 
-    assertThat(bpmnTest.getProcessInstanceEvent()).hasVariableWithValue("webhookExecuted", true);
-    assertThat(bpmnTest.getProcessInstanceEvent()).hasVariableWithValue("queryParam", "test");
+    assertThat(bpmnTest.getProcessInstanceEvent()).hasVariable("webhookExecuted", true);
+    assertThat(bpmnTest.getProcessInstanceEvent()).hasVariable("queryParam", "test");
   }
 
   @Test
@@ -441,8 +436,7 @@ public class HttpTests {
             .createInstance()
             .waitForProcessCompletion();
 
-    assertThat(bpmnTest.getProcessInstanceEvent())
-        .hasVariableWithValue("orderStatus", "processing");
+    assertThat(bpmnTest.getProcessInstanceEvent()).hasVariable("orderStatus", "processing");
   }
 
   @Test
@@ -494,8 +488,7 @@ public class HttpTests {
             .createInstance()
             .waitForProcessCompletion();
 
-    assertThat(bpmnTest.getProcessInstanceEvent())
-        .hasVariableWithValue("orderStatus", "processing");
+    assertThat(bpmnTest.getProcessInstanceEvent()).hasVariable("orderStatus", "processing");
   }
 
   @Test
@@ -545,10 +538,9 @@ public class HttpTests {
             .createInstance()
             .waitForProcessCompletion();
 
-    assertThat(bpmnTest.getProcessInstanceEvent()).hasNoIncidents();
     assertThat(bpmnTest.getProcessInstanceEvent())
-        .hasVariableWithValue("temp", 36)
-        .hasVariableWithValue("booleanField", true)
-        .hasVariableWithValue("message", "custom message");
+        .hasVariable("temp", 36)
+        .hasVariable("booleanField", true)
+        .hasVariable("message", "custom message");
   }
 }

--- a/connectors-e2e-test/connectors-e2e-test-http/src/test/java/io/camunda/connector/e2e/HttpTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-http/src/test/java/io/camunda/connector/e2e/HttpTests.java
@@ -541,7 +541,13 @@ public class HttpTests {
             .createInstance()
             .waitForProcessCompletion();
 
-    var pi = zeebeClient.newProcessInstanceQuery().filter((filter) -> filter.processInstanceKeys(bpmnTest.getProcessInstanceEvent().getProcessInstanceKey()));
+    var pi =
+        zeebeClient
+            .newProcessInstanceQuery()
+            .filter(
+                (filter) ->
+                    filter.processInstanceKeys(
+                        bpmnTest.getProcessInstanceEvent().getProcessInstanceKey()));
     assertThat(bpmnTest.getProcessInstanceEvent())
         .hasVariable("temp", 36)
         .hasVariable("booleanField", true)

--- a/connectors-e2e-test/connectors-e2e-test-http/src/test/java/io/camunda/connector/e2e/HttpTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-http/src/test/java/io/camunda/connector/e2e/HttpTests.java
@@ -45,6 +45,7 @@ import io.camunda.connector.runtime.inbound.state.ProcessImportResult.ProcessDef
 import io.camunda.connector.runtime.inbound.state.ProcessStateStore;
 import io.camunda.operate.CamundaOperateClient;
 import io.camunda.operate.model.ProcessDefinition;
+import io.camunda.process.test.api.CamundaProcessTestContext;
 import io.camunda.process.test.api.CamundaSpringProcessTest;
 import io.camunda.zeebe.client.ZeebeClient;
 import io.camunda.zeebe.model.bpmn.Bpmn;
@@ -89,6 +90,8 @@ public class HttpTests {
   @Autowired ProcessStateStore stateStore;
 
   @MockBean CamundaOperateClient camundaOperateClient;
+
+  @Autowired CamundaProcessTestContext context;
 
   @LocalServerPort int serverPort;
 
@@ -538,6 +541,7 @@ public class HttpTests {
             .createInstance()
             .waitForProcessCompletion();
 
+    var pi = zeebeClient.newProcessInstanceQuery().filter((filter) -> filter.processInstanceKeys(bpmnTest.getProcessInstanceEvent().getProcessInstanceKey()));
     assertThat(bpmnTest.getProcessInstanceEvent())
         .hasVariable("temp", 36)
         .hasVariable("booleanField", true)

--- a/connectors-e2e-test/connectors-e2e-test-http/src/test/resources/camunda-container-runtime.properties
+++ b/connectors-e2e-test/connectors-e2e-test-http/src/test/resources/camunda-container-runtime.properties
@@ -1,0 +1,1 @@
+camunda.version=8.5.0

--- a/connectors-e2e-test/connectors-e2e-test-http/src/test/resources/camunda-container-runtime.properties
+++ b/connectors-e2e-test/connectors-e2e-test-http/src/test/resources/camunda-container-runtime.properties
@@ -1,1 +1,0 @@
-camunda.version=8.5.0

--- a/connectors-e2e-test/connectors-e2e-test-kafka/pom.xml
+++ b/connectors-e2e-test/connectors-e2e-test-kafka/pom.xml
@@ -48,7 +48,7 @@
     <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>camunda-process-test-spring</artifactId>
-      <version>8.6.0-SNAPSHOT</version>
+      <version>8.7.0-SNAPSHOT</version>
     </dependency>
 
     <dependency>

--- a/connectors-e2e-test/connectors-e2e-test-kafka/pom.xml
+++ b/connectors-e2e-test/connectors-e2e-test-kafka/pom.xml
@@ -45,6 +45,11 @@
       <version>${version.testcontainers}</version>
     </dependency>
 
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>camunda-process-test-spring</artifactId>
+      <version>8.6.0-SNAPSHOT</version>
+    </dependency>
 
     <dependency>
       <groupId>io.camunda.connector</groupId>

--- a/connectors-e2e-test/connectors-e2e-test-kafka/src/test/java/io/camunda/connector/e2e/InboundKafkaTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-kafka/src/test/java/io/camunda/connector/e2e/InboundKafkaTests.java
@@ -27,6 +27,7 @@ import io.camunda.connector.runtime.inbound.state.ProcessImportResult.ProcessDef
 import io.camunda.operate.exception.OperateException;
 import io.camunda.operate.model.ProcessDefinition;
 import io.camunda.process.test.api.CamundaAssert;
+import io.camunda.process.test.api.CamundaSpringProcessTest;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.model.bpmn.instance.Process;
 import java.util.Map;
@@ -47,6 +48,7 @@ import org.springframework.boot.test.context.SpringBootTest;
       "camunda.connector.polling.enabled=true"
     },
     webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@CamundaSpringProcessTest
 @ExtendWith(MockitoExtension.class)
 public class InboundKafkaTests extends BaseKafkaTest {
 

--- a/connectors-e2e-test/connectors-e2e-test-kafka/src/test/java/io/camunda/connector/e2e/InboundKafkaTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-kafka/src/test/java/io/camunda/connector/e2e/InboundKafkaTests.java
@@ -26,6 +26,7 @@ import io.camunda.connector.runtime.inbound.state.ProcessImportResult.ProcessDef
 import io.camunda.connector.runtime.inbound.state.ProcessImportResult.ProcessDefinitionVersion;
 import io.camunda.operate.exception.OperateException;
 import io.camunda.operate.model.ProcessDefinition;
+import io.camunda.process.test.api.CamundaAssert;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.model.bpmn.instance.Process;
 import java.util.Map;
@@ -46,7 +47,6 @@ import org.springframework.boot.test.context.SpringBootTest;
       "camunda.connector.polling.enabled=true"
     },
     webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@ZeebeSpringTest
 @ExtendWith(MockitoExtension.class)
 public class InboundKafkaTests extends BaseKafkaTest {
 
@@ -98,10 +98,10 @@ public class InboundKafkaTests extends BaseKafkaTest {
 
     kafkaProducerThreadRun.set(false);
 
-    BpmnAssert.assertThat(bpmnTest.getProcessInstanceEvent())
-        .hasVariableWithValue("keyResult", "keyJsonValue");
-    BpmnAssert.assertThat(bpmnTest.getProcessInstanceEvent())
-        .hasVariableWithValue("allResult", expectedJsonResponse);
+    CamundaAssert.assertThat(bpmnTest.getProcessInstanceEvent())
+        .hasVariable("keyResult", "keyJsonValue");
+    CamundaAssert.assertThat(bpmnTest.getProcessInstanceEvent())
+        .hasVariable("allResult", expectedJsonResponse);
   }
 
   @Test
@@ -141,8 +141,8 @@ public class InboundKafkaTests extends BaseKafkaTest {
 
     kafkaProducerThreadRun.set(false);
 
-    BpmnAssert.assertThat(bpmnTest.getProcessInstanceEvent())
-        .hasVariableWithValue("allResult", expectedJsonResponse);
+    CamundaAssert.assertThat(bpmnTest.getProcessInstanceEvent())
+        .hasVariable("allResult", expectedJsonResponse);
   }
 
   private void mockProcessDefinition(BpmnModelInstance model) throws OperateException {

--- a/connectors-e2e-test/connectors-e2e-test-kafka/src/test/java/io/camunda/connector/e2e/InboundKafkaTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-kafka/src/test/java/io/camunda/connector/e2e/InboundKafkaTests.java
@@ -28,8 +28,6 @@ import io.camunda.operate.exception.OperateException;
 import io.camunda.operate.model.ProcessDefinition;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.model.bpmn.instance.Process;
-import io.camunda.zeebe.process.test.assertions.BpmnAssert;
-import io.camunda.zeebe.spring.test.ZeebeSpringTest;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.jupiter.api.AfterEach;

--- a/connectors-e2e-test/connectors-e2e-test-kafka/src/test/java/io/camunda/connector/e2e/OutboundKafkaTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-kafka/src/test/java/io/camunda/connector/e2e/OutboundKafkaTests.java
@@ -16,15 +16,15 @@
  */
 package io.camunda.connector.e2e;
 
-import static io.camunda.zeebe.process.test.assertions.BpmnAssert.assertThat;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.connector.e2e.app.TestConnectorRuntimeApplication;
 import io.camunda.connector.e2e.helper.KafkaTestConsumer;
 import io.camunda.connector.kafka.inbound.KafkaInboundMessage;
+import io.camunda.process.test.api.CamundaAssert;
+import io.camunda.process.test.api.CamundaSpringProcessTest;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
-import io.camunda.zeebe.spring.test.ZeebeSpringTest;
 import java.io.File;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -41,7 +41,7 @@ import org.springframework.boot.test.context.SpringBootTest;
       "camunda.connector.polling.enabled=true"
     },
     webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@ZeebeSpringTest
+@CamundaSpringProcessTest
 @ExtendWith(MockitoExtension.class)
 public class OutboundKafkaTests extends BaseKafkaTest {
   private static final String ELEMENT_TEMPLATE_PATH =
@@ -91,8 +91,9 @@ public class OutboundKafkaTests extends BaseKafkaTest {
     assertThat(kafkaMessage.getValue().toString()).isEqualTo(MESSAGE_VALUE);
     assertThat(kafkaMessage.getRawValue()).isEqualTo(MESSAGE_VALUE);
     // validate process variables
-    assertThat(bpmnTest.getProcessInstanceEvent()).hasVariableWithValue("partitionResponse", 0);
-    assertThat(bpmnTest.getProcessInstanceEvent()).hasVariableWithValue("topicResult", TOPIC);
+    CamundaAssert.assertThat(bpmnTest.getProcessInstanceEvent())
+        .hasVariable("partitionResponse", 0);
+    CamundaAssert.assertThat(bpmnTest.getProcessInstanceEvent()).hasVariable("topicResult", TOPIC);
   }
 
   private static BpmnModelInstance getBpmnModelInstance(final String serviceTaskName) {

--- a/connectors-e2e-test/connectors-e2e-test-kafka/src/test/resources/camunda-container-runtime.properties
+++ b/connectors-e2e-test/connectors-e2e-test-kafka/src/test/resources/camunda-container-runtime.properties
@@ -1,0 +1,1 @@
+camunda.version=8.5.0

--- a/connectors-e2e-test/connectors-e2e-test-kafka/src/test/resources/camunda-container-runtime.properties
+++ b/connectors-e2e-test/connectors-e2e-test-kafka/src/test/resources/camunda-container-runtime.properties
@@ -1,1 +1,0 @@
-camunda.version=8.5.0

--- a/connectors-e2e-test/connectors-e2e-test-mail/src/test/java/io/camunda/connector/e2e/InboundEmailTest.java
+++ b/connectors-e2e-test/connectors-e2e-test-mail/src/test/java/io/camunda/connector/e2e/InboundEmailTest.java
@@ -17,6 +17,7 @@
 package io.camunda.connector.e2e;
 
 import static io.camunda.connector.e2e.BpmnFile.replace;
+import static io.camunda.process.test.api.CamundaAssert.assertThat;
 import static org.mockito.Mockito.when;
 
 import io.camunda.connector.e2e.app.TestConnectorRuntimeApplication;
@@ -25,11 +26,10 @@ import io.camunda.connector.runtime.inbound.state.ProcessStateStore;
 import io.camunda.operate.CamundaOperateClient;
 import io.camunda.operate.exception.OperateException;
 import io.camunda.operate.model.ProcessDefinition;
+import io.camunda.process.test.api.CamundaSpringProcessTest;
 import io.camunda.zeebe.client.ZeebeClient;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.model.bpmn.instance.Process;
-import io.camunda.zeebe.process.test.assertions.BpmnAssert;
-import io.camunda.zeebe.spring.test.ZeebeSpringTest;
 import jakarta.mail.Flags;
 import jakarta.mail.MessagingException;
 import java.util.Arrays;
@@ -54,7 +54,7 @@ import org.springframework.boot.test.context.SpringBootTest;
       "spring.main.allow-bean-definition-overriding=true",
     },
     webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@ZeebeSpringTest
+@CamundaSpringProcessTest
 @ExtendWith(MockitoExtension.class)
 public class InboundEmailTest extends BaseEmailTest {
 
@@ -100,10 +100,8 @@ public class InboundEmailTest extends BaseEmailTest {
             .get()
             .getFlags()
             .contains(Flags.Flag.SEEN));
-    BpmnAssert.assertThat(bpmnTest.getProcessInstanceEvent())
-        .hasVariableWithValue("subject", "test");
-    BpmnAssert.assertThat(bpmnTest.getProcessInstanceEvent())
-        .hasVariableWithValue("plainTextBody", "hey");
+    assertThat(bpmnTest.getProcessInstanceEvent()).hasVariable("subject", "test");
+    assertThat(bpmnTest.getProcessInstanceEvent()).hasVariable("plainTextBody", "hey");
   }
 
   @Test
@@ -161,10 +159,8 @@ public class InboundEmailTest extends BaseEmailTest {
             .get()
             .getFlags()
             .contains(Flags.Flag.DELETED));
-    BpmnAssert.assertThat(bpmnTest.getProcessInstanceEvent())
-        .hasVariableWithValue("subject", "test");
-    BpmnAssert.assertThat(bpmnTest.getProcessInstanceEvent())
-        .hasVariableWithValue("plainTextBody", "hey");
+    assertThat(bpmnTest.getProcessInstanceEvent()).hasVariable("subject", "test");
+    assertThat(bpmnTest.getProcessInstanceEvent()).hasVariable("plainTextBody", "hey");
   }
 
   @Test
@@ -198,10 +194,8 @@ public class InboundEmailTest extends BaseEmailTest {
             .get()
             .getFlags()
             .contains(Flags.Flag.DELETED));
-    BpmnAssert.assertThat(bpmnTest.getProcessInstanceEvent())
-        .hasVariableWithValue("subject", "test");
-    BpmnAssert.assertThat(bpmnTest.getProcessInstanceEvent())
-        .hasVariableWithValue("plainTextBody", "hey");
+    assertThat(bpmnTest.getProcessInstanceEvent()).hasVariable("subject", "test");
+    assertThat(bpmnTest.getProcessInstanceEvent()).hasVariable("plainTextBody", "hey");
   }
 
   private void mockProcessDefinition(BpmnModelInstance model) throws OperateException {
@@ -244,9 +238,7 @@ public class InboundEmailTest extends BaseEmailTest {
             .get()
             .getFlags()
             .contains(Flags.Flag.DELETED));
-    BpmnAssert.assertThat(bpmnTest.getProcessInstanceEvent())
-        .hasVariableWithValue("subject", "test");
-    BpmnAssert.assertThat(bpmnTest.getProcessInstanceEvent())
-        .hasVariableWithValue("plainTextBody", "hey");
+    assertThat(bpmnTest.getProcessInstanceEvent()).hasVariable("subject", "test");
+    assertThat(bpmnTest.getProcessInstanceEvent()).hasVariable("plainTextBody", "hey");
   }
 }

--- a/connectors-e2e-test/connectors-e2e-test-mail/src/test/java/io/camunda/connector/e2e/InboundEmailTest.java
+++ b/connectors-e2e-test/connectors-e2e-test-mail/src/test/java/io/camunda/connector/e2e/InboundEmailTest.java
@@ -18,6 +18,7 @@ package io.camunda.connector.e2e;
 
 import static io.camunda.connector.e2e.BpmnFile.replace;
 import static io.camunda.process.test.api.CamundaAssert.assertThat;
+import static org.awaitility.Awaitility.await;
 import static org.mockito.Mockito.when;
 
 import io.camunda.connector.e2e.app.TestConnectorRuntimeApplication;
@@ -83,6 +84,10 @@ public class InboundEmailTest extends BaseEmailTest {
     scheduler.schedule(
         () -> super.sendEmail("test@camunda.com", "test", "hey"), 2, TimeUnit.SECONDS);
 
+    var bpmnTest = ZeebeTest.with(zeebeClient).deploy(model).createInstance();
+
+    await().atMost(3, TimeUnit.SECONDS).until(() -> getLastReceivedEmails().length == 1);
+
     processStateStore.update(
         new ProcessImportResult(
             Map.of(
@@ -90,7 +95,6 @@ public class InboundEmailTest extends BaseEmailTest {
                     processDef.getBpmnProcessId(), processDef.getTenantId()),
                 new ProcessImportResult.ProcessDefinitionVersion(
                     processDef.getKey(), processDef.getVersion().intValue()))));
-    var bpmnTest = ZeebeTest.with(zeebeClient).deploy(model).createInstance();
 
     bpmnTest = bpmnTest.waitForProcessCompletion();
 
@@ -113,9 +117,21 @@ public class InboundEmailTest extends BaseEmailTest {
 
     mockProcessDefinition(model);
 
-    super.sendEmail("test@camunda.com", "test", "hey");
+    scheduler.schedule(
+        () -> {
+          super.sendEmail("test@camunda.com", "test", "hey");
+          try {
+            Arrays.stream(getLastReceivedEmails()).findFirst().get().setFlag(Flags.Flag.SEEN, true);
+          } catch (MessagingException e) {
+            throw new RuntimeException(e);
+          }
+        },
+        2,
+        TimeUnit.SECONDS);
 
-    Arrays.stream(getLastReceivedEmails()).findFirst().get().setFlag(Flags.Flag.SEEN, true);
+    var bpmnTest = ZeebeTest.with(zeebeClient).deploy(model).createInstance();
+
+    await().atMost(3, TimeUnit.SECONDS).until(() -> getLastReceivedEmails().length == 1);
 
     processStateStore.update(
         new ProcessImportResult(
@@ -124,7 +140,6 @@ public class InboundEmailTest extends BaseEmailTest {
                     processDef.getBpmnProcessId(), processDef.getTenantId()),
                 new ProcessImportResult.ProcessDefinitionVersion(
                     processDef.getKey(), processDef.getVersion().intValue()))));
-    var bpmnTest = ZeebeTest.with(zeebeClient).deploy(model).createInstance();
 
     Assertions.assertThrows(ConditionTimeoutException.class, bpmnTest::waitForProcessCompletion);
   }
@@ -141,6 +156,10 @@ public class InboundEmailTest extends BaseEmailTest {
     scheduler.schedule(
         () -> super.sendEmail("test@camunda.com", "test", "hey"), 2, TimeUnit.SECONDS);
 
+    var bpmnTest = ZeebeTest.with(zeebeClient).deploy(model).createInstance();
+
+    await().atMost(3, TimeUnit.SECONDS).until(() -> getLastReceivedEmails().length == 1);
+
     processStateStore.update(
         new ProcessImportResult(
             Map.of(
@@ -148,8 +167,6 @@ public class InboundEmailTest extends BaseEmailTest {
                     processDef.getBpmnProcessId(), processDef.getTenantId()),
                 new ProcessImportResult.ProcessDefinitionVersion(
                     processDef.getKey(), processDef.getVersion().intValue()))));
-
-    var bpmnTest = ZeebeTest.with(zeebeClient).deploy(model).createInstance();
 
     bpmnTest = bpmnTest.waitForProcessCompletion();
 
@@ -175,6 +192,10 @@ public class InboundEmailTest extends BaseEmailTest {
     scheduler.schedule(
         () -> super.sendEmail("test@camunda.com", "test", "hey"), 2, TimeUnit.SECONDS);
 
+    var bpmnTest = ZeebeTest.with(zeebeClient).deploy(model).createInstance();
+
+    await().atMost(3, TimeUnit.SECONDS).until(() -> getLastReceivedEmails().length == 1);
+
     processStateStore.update(
         new ProcessImportResult(
             Map.of(
@@ -182,8 +203,6 @@ public class InboundEmailTest extends BaseEmailTest {
                     processDef.getBpmnProcessId(), processDef.getTenantId()),
                 new ProcessImportResult.ProcessDefinitionVersion(
                     processDef.getKey(), processDef.getVersion().intValue()))));
-
-    var bpmnTest = ZeebeTest.with(zeebeClient).deploy(model).createInstance();
 
     bpmnTest = bpmnTest.waitForProcessCompletion();
 
@@ -216,9 +235,24 @@ public class InboundEmailTest extends BaseEmailTest {
 
     mockProcessDefinition(model);
 
-    super.sendEmail("test@camunda.com", "test", "hey");
+    scheduler.schedule(
+        () -> {
+          super.sendEmail("test@camunda.com", "test", "hey");
+          try {
+            Arrays.stream(super.getLastReceivedEmails())
+                .findFirst()
+                .get()
+                .setFlag(Flags.Flag.SEEN, true);
+          } catch (MessagingException e) {
+            throw new RuntimeException(e);
+          }
+        },
+        2,
+        TimeUnit.SECONDS);
 
-    Arrays.stream(super.getLastReceivedEmails()).findFirst().get().setFlag(Flags.Flag.SEEN, true);
+    var bpmnTest = ZeebeTest.with(zeebeClient).deploy(model).createInstance();
+
+    await().atMost(3, TimeUnit.SECONDS).until(() -> getLastReceivedEmails().length == 1);
 
     processStateStore.update(
         new ProcessImportResult(
@@ -227,8 +261,6 @@ public class InboundEmailTest extends BaseEmailTest {
                     processDef.getBpmnProcessId(), processDef.getTenantId()),
                 new ProcessImportResult.ProcessDefinitionVersion(
                     processDef.getKey(), processDef.getVersion().intValue()))));
-
-    var bpmnTest = ZeebeTest.with(zeebeClient).deploy(model).createInstance();
 
     bpmnTest = bpmnTest.waitForProcessCompletion();
 

--- a/connectors-e2e-test/connectors-e2e-test-rabbitmq/pom.xml
+++ b/connectors-e2e-test/connectors-e2e-test-rabbitmq/pom.xml
@@ -33,6 +33,12 @@
       <version>${project.version}</version>
     </dependency>
 
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>camunda-process-test-spring</artifactId>
+      <version>8.6.0-SNAPSHOT</version>
+    </dependency>
+
     <!-- Test -->
     <dependency>
       <groupId>io.camunda.connector</groupId>

--- a/connectors-e2e-test/connectors-e2e-test-rabbitmq/pom.xml
+++ b/connectors-e2e-test/connectors-e2e-test-rabbitmq/pom.xml
@@ -36,7 +36,7 @@
     <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>camunda-process-test-spring</artifactId>
-      <version>8.6.0-SNAPSHOT</version>
+      <version>8.7.0-SNAPSHOT</version>
     </dependency>
 
     <!-- Test -->

--- a/connectors-e2e-test/connectors-e2e-test-rabbitmq/src/test/java/io/camunda/connector/e2e/RabbitMqInboundStartEventTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-rabbitmq/src/test/java/io/camunda/connector/e2e/RabbitMqInboundStartEventTests.java
@@ -29,10 +29,10 @@ import io.camunda.connector.runtime.inbound.state.ProcessImportResult.ProcessDef
 import io.camunda.connector.runtime.inbound.state.ProcessImportResult.ProcessDefinitionVersion;
 import io.camunda.connector.runtime.inbound.state.ProcessStateStore;
 import io.camunda.operate.exception.OperateException;
+import io.camunda.process.test.api.CamundaAssert;
+import io.camunda.process.test.api.CamundaSpringProcessTest;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.model.bpmn.instance.Process;
-import io.camunda.zeebe.process.test.assertions.BpmnAssert;
-import io.camunda.zeebe.spring.test.ZeebeSpringTest;
 import java.io.IOException;
 import java.util.Map;
 import java.util.concurrent.TimeoutException;
@@ -55,7 +55,7 @@ import org.testcontainers.utility.DockerImageName;
       "camunda.connector.polling.enabled=true"
     },
     webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@ZeebeSpringTest
+@CamundaSpringProcessTest
 @ExtendWith(MockitoExtension.class)
 public class RabbitMqInboundStartEventTests extends BaseRabbitMqTest {
 
@@ -142,11 +142,11 @@ public class RabbitMqInboundStartEventTests extends BaseRabbitMqTest {
     postMessage();
     bpmnTest = bpmnTest.waitForProcessCompletion();
 
-    BpmnAssert.assertThat(bpmnTest.getProcessInstanceEvent())
-        .hasVariableWithValue("allResult", expectedJsonResponse);
+    CamundaAssert.assertThat(bpmnTest.getProcessInstanceEvent())
+        .hasVariable("allResult", expectedJsonResponse);
 
-    BpmnAssert.assertThat(bpmnTest.getProcessInstanceEvent())
-        .hasVariableWithValue("partialResult", "barValue");
+    CamundaAssert.assertThat(bpmnTest.getProcessInstanceEvent())
+        .hasVariable("partialResult", "barValue");
   }
 
   private void postMessage() throws Exception {

--- a/connectors-e2e-test/connectors-e2e-test-rabbitmq/src/test/java/io/camunda/connector/e2e/RabbitMqOutboundTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-rabbitmq/src/test/java/io/camunda/connector/e2e/RabbitMqOutboundTests.java
@@ -16,7 +16,7 @@
  */
 package io.camunda.connector.e2e;
 
-import static io.camunda.zeebe.process.test.assertions.BpmnAssert.assertThat;
+import static io.camunda.process.test.api.CamundaAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -26,9 +26,9 @@ import com.rabbitmq.client.ConnectionFactory;
 import com.rabbitmq.client.GetResponse;
 import io.camunda.connector.e2e.app.TestConnectorRuntimeApplication;
 import io.camunda.connector.rabbitmq.outbound.RabbitMqResult;
+import io.camunda.process.test.api.CamundaSpringProcessTest;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
-import io.camunda.zeebe.spring.test.ZeebeSpringTest;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -51,7 +51,7 @@ import org.testcontainers.utility.DockerImageName;
       "camunda.connector.polling.enabled=false"
     },
     webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@ZeebeSpringTest
+@CamundaSpringProcessTest
 @ExtendWith(MockitoExtension.class)
 public class RabbitMqOutboundTests extends BaseRabbitMqTest {
   private static final String QUEUE_NAME = "testQueue";
@@ -117,7 +117,7 @@ public class RabbitMqOutboundTests extends BaseRabbitMqTest {
     ZeebeTest bpmnTest = setupTestWithBpmnModel(elementTemplate);
 
     RabbitMqResult result = RabbitMqResult.success();
-    assertThat(bpmnTest.getProcessInstanceEvent()).hasVariableWithValue("result", result);
+    assertThat(bpmnTest.getProcessInstanceEvent()).hasVariable("result", result);
 
     String receivedMessage = consumeMessage();
 
@@ -152,7 +152,7 @@ public class RabbitMqOutboundTests extends BaseRabbitMqTest {
     ZeebeTest bpmnTest = setupTestWithBpmnModel(elementTemplate);
 
     RabbitMqResult result = RabbitMqResult.success();
-    assertThat(bpmnTest.getProcessInstanceEvent()).hasVariableWithValue("result", result);
+    assertThat(bpmnTest.getProcessInstanceEvent()).hasVariable("result", result);
 
     String receivedMessage = consumeMessage();
     if (receivedMessage == null) {

--- a/connectors-e2e-test/connectors-e2e-test-soap/pom.xml
+++ b/connectors-e2e-test/connectors-e2e-test-soap/pom.xml
@@ -33,6 +33,12 @@
       <version>${project.version}</version>
     </dependency>
 
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>camunda-process-test-spring</artifactId>
+      <version>8.6.0-SNAPSHOT</version>
+    </dependency>
+
     <!-- Test -->
     <dependency>
       <groupId>io.camunda.connector</groupId>

--- a/connectors-e2e-test/connectors-e2e-test-soap/pom.xml
+++ b/connectors-e2e-test/connectors-e2e-test-soap/pom.xml
@@ -36,7 +36,7 @@
     <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>camunda-process-test-spring</artifactId>
-      <version>8.6.0-SNAPSHOT</version>
+      <version>8.7.0-SNAPSHOT</version>
     </dependency>
 
     <!-- Test -->

--- a/connectors-e2e-test/connectors-e2e-test-soap/src/test/java/io/camunda/connector/e2e/soap/SoapConnectorTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-soap/src/test/java/io/camunda/connector/e2e/soap/SoapConnectorTests.java
@@ -47,7 +47,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 public class SoapConnectorTests extends SoapConnectorBaseTest {
 
   @Test
-  public void faultResponse() throws JsonProcessingException {
+  public void faultResponse() {
     wm.stubFor(
         post(urlPathMatching("/soapservice/service"))
             .withRequestBody(WireMock.equalToXml(NUMBER_OF_WORDS_REQUEST))
@@ -73,8 +73,6 @@ public class SoapConnectorTests extends SoapConnectorBaseTest {
 
     ZeebeTest bpmnTest = setupTestWithBpmnModel("soapSimpleRequest", elementTemplate);
 
-    assertThat(bpmnTest.getProcessInstanceEvent())
-        .hasVariable("soapVersion", Map.of("version", "1.1"));
     Map<String, Object> expectedResult =
         Map.of(
             "Envelope",
@@ -114,8 +112,6 @@ public class SoapConnectorTests extends SoapConnectorBaseTest {
 
     ZeebeTest bpmnTest = setupTestWithBpmnModel("soapSimpleRequest", elementTemplate);
 
-    assertThat(bpmnTest.getProcessInstanceEvent())
-        .hasVariable("soapVersion", Map.of("version", "1.1"));
     Map<String, Object> expectedResult =
         Map.of(
             "Envelope",
@@ -149,8 +145,6 @@ public class SoapConnectorTests extends SoapConnectorBaseTest {
 
     ZeebeTest bpmnTest = setupTestWithBpmnModel("soapSimpleRequest", elementTemplate);
 
-    assertThat(bpmnTest.getProcessInstanceEvent())
-        .hasVariable("soapVersion", Map.of("version", "1.1"));
     Map<String, Object> expectedResult =
         Map.of(
             "Envelope",

--- a/connectors-e2e-test/connectors-e2e-test-soap/src/test/java/io/camunda/connector/e2e/soap/SoapConnectorTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-soap/src/test/java/io/camunda/connector/e2e/soap/SoapConnectorTests.java
@@ -18,7 +18,7 @@ package io.camunda.connector.e2e.soap;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathMatching;
-import static io.camunda.zeebe.process.test.assertions.BpmnAssert.assertThat;
+import static io.camunda.process.test.api.CamundaAssert.assertThat;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder;
@@ -26,7 +26,7 @@ import com.github.tomakehurst.wiremock.client.WireMock;
 import io.camunda.connector.e2e.ElementTemplate;
 import io.camunda.connector.e2e.ZeebeTest;
 import io.camunda.connector.e2e.app.TestConnectorRuntimeApplication;
-import io.camunda.zeebe.spring.test.ZeebeSpringTest;
+import io.camunda.process.test.api.CamundaSpringProcessTest;
 import java.io.File;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
@@ -42,7 +42,7 @@ import org.springframework.boot.test.context.SpringBootTest;
       "camunda.connector.polling.enabled=false"
     },
     webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@ZeebeSpringTest
+@CamundaSpringProcessTest
 @ExtendWith(MockitoExtension.class)
 public class SoapConnectorTests extends SoapConnectorBaseTest {
 
@@ -74,7 +74,7 @@ public class SoapConnectorTests extends SoapConnectorBaseTest {
     ZeebeTest bpmnTest = setupTestWithBpmnModel("soapSimpleRequest", elementTemplate);
 
     assertThat(bpmnTest.getProcessInstanceEvent())
-        .hasVariableWithValue("soapVersion", Map.of("version", "1.1"));
+        .hasVariable("soapVersion", Map.of("version", "1.1"));
     Map<String, Object> expectedResult =
         Map.of(
             "Envelope",
@@ -90,7 +90,7 @@ public class SoapConnectorTests extends SoapConnectorBaseTest {
                         "detail",
                         Map.of(
                             "error", "Object reference not set to an instance of an object.")))));
-    assertThat(bpmnTest.getProcessInstanceEvent()).hasVariableWithValue("response", expectedResult);
+    assertThat(bpmnTest.getProcessInstanceEvent()).hasVariable("response", expectedResult);
   }
 
   @Test
@@ -115,14 +115,14 @@ public class SoapConnectorTests extends SoapConnectorBaseTest {
     ZeebeTest bpmnTest = setupTestWithBpmnModel("soapSimpleRequest", elementTemplate);
 
     assertThat(bpmnTest.getProcessInstanceEvent())
-        .hasVariableWithValue("soapVersion", Map.of("version", "1.1"));
+        .hasVariable("soapVersion", Map.of("version", "1.1"));
     Map<String, Object> expectedResult =
         Map.of(
             "Envelope",
             Map.of(
                 "Body",
                 Map.of("NumberToWordsResponse", Map.of("NumberToWordsResult", "five hundred "))));
-    assertThat(bpmnTest.getProcessInstanceEvent()).hasVariableWithValue("res", expectedResult);
+    assertThat(bpmnTest.getProcessInstanceEvent()).hasVariable("res", expectedResult);
   }
 
   @Test
@@ -150,13 +150,13 @@ public class SoapConnectorTests extends SoapConnectorBaseTest {
     ZeebeTest bpmnTest = setupTestWithBpmnModel("soapSimpleRequest", elementTemplate);
 
     assertThat(bpmnTest.getProcessInstanceEvent())
-        .hasVariableWithValue("soapVersion", Map.of("version", "1.1"));
+        .hasVariable("soapVersion", Map.of("version", "1.1"));
     Map<String, Object> expectedResult =
         Map.of(
             "Envelope",
             Map.of(
                 "Body",
                 Map.of("NumberToWordsResponse", Map.of("NumberToWordsResult", "five hundred "))));
-    assertThat(bpmnTest.getProcessInstanceEvent()).hasVariableWithValue("res", expectedResult);
+    assertThat(bpmnTest.getProcessInstanceEvent()).hasVariable("res", expectedResult);
   }
 }

--- a/connectors-e2e-test/connectors-e2e-test-soap/src/test/java/io/camunda/connector/e2e/soap/SoapConnectorTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-soap/src/test/java/io/camunda/connector/e2e/soap/SoapConnectorTests.java
@@ -20,7 +20,6 @@ import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathMatching;
 import static io.camunda.process.test.api.CamundaAssert.assertThat;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder;
 import com.github.tomakehurst.wiremock.client.WireMock;
 import io.camunda.connector.e2e.ElementTemplate;

--- a/connectors/aws/aws-textract/pom.xml
+++ b/connectors/aws/aws-textract/pom.xml
@@ -44,6 +44,11 @@ except in compliance with the proprietary license.</license.inlineheader>
       <version>${version.aws-java-sdk}</version>
     </dependency>
 
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-collections4</artifactId>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/connectors/soap/pom.xml
+++ b/connectors/soap/pom.xml
@@ -26,7 +26,6 @@
   <properties>
     <version.wss4j>3.0.3</version.wss4j>
     <version.xmlsec>4.0.3</version.xmlsec>
-    <version.zeebe-process-test>8.3.0</version.zeebe-process-test>
     <version.commons-text>1.11.0</version.commons-text>
     <version.commons-lang3>3.17.0</version.commons-lang3>
     <version.spring-boot>3.3.5</version.spring-boot>

--- a/connectors/webhook/src/main/java/io/camunda/connector/inbound/HttpWebhookExecutable.java
+++ b/connectors/webhook/src/main/java/io/camunda/connector/inbound/HttpWebhookExecutable.java
@@ -45,7 +45,7 @@ import java.security.NoSuchAlgorithmException;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
-import org.jetbrains.annotations.Nullable;
+import javax.annotation.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -71,7 +71,7 @@ limitations under the License.</license.inlineheader>
     <nexus.sonatype.url>https://s01.oss.sonatype.org</nexus.sonatype.url>
 
     <!-- Camunda internal libraries -->
-    <version.zeebe>8.6.0-alpha5</version.zeebe>
+    <version.zeebe>8.6.0-SNAPSHOT</version.zeebe>
     <version.operate-client>8.5.12</version.operate-client>
     <version.feel-engine>1.18.1</version.feel-engine>
 

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -289,6 +289,17 @@ limitations under the License.</license.inlineheader>
       </dependency>
 
       <dependency>
+        <groupId>io.camunda</groupId>
+        <artifactId>zeebe-client-java</artifactId>
+        <version>${version.zeebe}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.camunda.spring</groupId>
+        <artifactId>java-client-operate</artifactId>
+        <version>${version.operate-client}</version>
+      </dependency>
+
+      <dependency>
         <groupId>org.camunda.feel</groupId>
         <artifactId>feel-engine</artifactId>
         <version>${version.feel-engine}</version>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -71,8 +71,8 @@ limitations under the License.</license.inlineheader>
     <nexus.sonatype.url>https://s01.oss.sonatype.org</nexus.sonatype.url>
 
     <!-- Camunda internal libraries -->
-    <version.zeebe>8.6.0-SNAPSHOT</version.zeebe>
-    <version.operate-client>8.5.12</version.operate-client>
+    <version.zeebe>8.7.0-SNAPSHOT</version.zeebe>
+    <version.operate-client>8.6.2</version.operate-client>
     <version.feel-engine>1.18.1</version.feel-engine>
 
     <!-- Third party dependencies -->

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -71,9 +71,8 @@ limitations under the License.</license.inlineheader>
     <nexus.sonatype.url>https://s01.oss.sonatype.org</nexus.sonatype.url>
 
     <!-- Camunda internal libraries -->
-    <version.zeebe>8.6.0-alpha4</version.zeebe>
-    <version.zeebe-process-test>8.6.0-SNAPSHOT</version.zeebe-process-test>
-    <version.operate-client>8.5.10</version.operate-client>
+    <version.zeebe>8.6.0-alpha5</version.zeebe>
+    <version.operate-client>8.5.12</version.operate-client>
     <version.feel-engine>1.18.1</version.feel-engine>
 
     <!-- Third party dependencies -->
@@ -512,7 +511,7 @@ limitations under the License.</license.inlineheader>
       <dependency>
         <groupId>io.camunda</groupId>
         <artifactId>camunda-process-test-spring</artifactId>
-        <version>${version.zeebe-process-test}</version>
+        <version>${version.zeebe}</version>
         <scope>test</scope>
       </dependency>
       <dependency>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -72,6 +72,7 @@ limitations under the License.</license.inlineheader>
 
     <!-- Camunda internal libraries -->
     <version.zeebe>8.6.0-alpha4</version.zeebe>
+    <version.zeebe-process-test>8.6.0-SNAPSHOT</version.zeebe-process-test>
     <version.operate-client>8.5.10</version.operate-client>
     <version.feel-engine>1.18.1</version.feel-engine>
 
@@ -511,7 +512,8 @@ limitations under the License.</license.inlineheader>
       <dependency>
         <groupId>io.camunda</groupId>
         <artifactId>camunda-process-test-spring</artifactId>
-        <version>${version.zeebe}</version>
+        <version>${version.zeebe-process-test}</version>
+        <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.junit.jupiter</groupId>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -71,9 +71,9 @@ limitations under the License.</license.inlineheader>
     <nexus.sonatype.url>https://s01.oss.sonatype.org</nexus.sonatype.url>
 
     <!-- Camunda internal libraries -->
-    <version.zeebe>8.5.5</version.zeebe>
+    <version.zeebe>8.6.0-alpha4</version.zeebe>
+    <version.operate-client>8.5.10</version.operate-client>
     <version.feel-engine>1.18.1</version.feel-engine>
-    <version.spring-zeebe>8.5.7</version.spring-zeebe>
 
     <!-- Third party dependencies -->
 
@@ -278,29 +278,14 @@ limitations under the License.</license.inlineheader>
 
       <dependency>
         <groupId>io.camunda</groupId>
-        <artifactId>zeebe-client-java</artifactId>
+        <artifactId>spring-boot-starter-camunda-sdk</artifactId>
         <version>${version.zeebe}</version>
       </dependency>
 
       <dependency>
         <groupId>io.camunda.spring</groupId>
-        <artifactId>spring-boot-starter-camunda</artifactId>
-        <version>${version.spring-zeebe}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.camunda.spring</groupId>
-        <artifactId>spring-boot-starter-camunda-test</artifactId>
-        <version>${version.spring-zeebe}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.camunda.spring</groupId>
-        <artifactId>java-client-operate</artifactId>
-        <version>${version.spring-zeebe}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.camunda.spring</groupId>
-        <artifactId>spring-client-zeebe</artifactId>
-        <version>${version.spring-zeebe}</version>
+        <artifactId>spring-boot-starter-camunda-operate</artifactId>
+        <version>${version.operate-client}</version>
       </dependency>
 
       <dependency>
@@ -512,6 +497,11 @@ limitations under the License.</license.inlineheader>
       </dependency>
 
       <!-- test dependencies -->
+      <dependency>
+        <groupId>io.camunda</groupId>
+        <artifactId>camunda-process-test-spring</artifactId>
+        <version>${version.zeebe}</version>
+      </dependency>
       <dependency>
         <groupId>org.junit.jupiter</groupId>
         <artifactId>junit-jupiter</artifactId>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -112,6 +112,7 @@ limitations under the License.</license.inlineheader>
     <version.httpcore5>5.3.1</version.httpcore5>
     <version.httpclient5>5.4.1</version.httpclient5>
     <version.pdfbox>3.0.3</version.pdfbox>
+    <version.collections4>4.5.0-M2</version.collections4>
 
     <version.commons-io>2.17.0</version.commons-io>
     <version.commons-codec>1.16.1</version.commons-codec>
@@ -409,6 +410,12 @@ limitations under the License.</license.inlineheader>
         <groupId>org.apache.httpcomponents.core5</groupId>
         <artifactId>httpcore5</artifactId>
         <version>${version.httpcore5}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-collections4</artifactId>
+        <version>${version.collections4}</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
## Description

This PR will migrate the Connectors project to the official Camunda Spring SDK. Until now, we have been using the community-supported library [Spring Zeebe](https://github.com/camunda-community-hub/spring-zeebe) which is now on a deprecation path.

Key changes:
- All Spring Boot apps are not using the new property structure for authentication-related config
- A community-supported [Operate client](https://github.com/camunda-community-hub/camunda-operate-client-java) is now used. The official Camunda Spring SDK doesn't offer an Operate client yet.
- All integration tests that had previously used the testing library from Spring Zeebe now use the official [Camunda Process Test](https://docs.camunda.io/docs/next/apis-tools/testing/getting-started/) (CPT) library.
  - ⚠️ This will lead to significant increase in build time - each integration test case now takes 30+ seconds.
  - We can consider build optimizations due to this in a follow-up PR if this impacts our productivity
- Console Secret API client has been changed: it uses the authentication classes from the Operate client library. The check whether or not it should be enabled is done via the standard Zeebe client properties to cover the use cases where Operate is disabled and no properties are provided.
  - This is subject to change when Operate client becomes part of the Spring SDK.


## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #2896 

