### PR TITLE
fix(document): handle SDK document reference correctly in the serializer

### DIFF
--- a/connector-sdk/jackson-datatype-document/src/main/java/io/camunda/connector/document/annotation/jackson/serializer/DocumentSerializer.java
+++ b/connector-sdk/jackson-datatype-document/src/main/java/io/camunda/connector/document/annotation/jackson/serializer/DocumentSerializer.java
@@ -19,9 +19,12 @@ package io.camunda.connector.document.annotation.jackson.serializer;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.SerializerProvider;
+import io.camunda.connector.document.annotation.jackson.DocumentReferenceModel.CamundaDocumentReferenceModel;
 import io.camunda.document.Document;
 import io.camunda.document.operation.DocumentOperationExecutor;
+import io.camunda.document.reference.DocumentReference.CamundaDocumentReference;
 import java.io.IOException;
+import java.util.Optional;
 
 public class DocumentSerializer extends JsonSerializer<Document> {
 
@@ -37,6 +40,20 @@ public class DocumentSerializer extends JsonSerializer<Document> {
       throws IOException {
 
     var reference = document.reference();
-    jsonGenerator.writeObject(reference);
+    if (!(reference instanceof CamundaDocumentReference camundaReference)) {
+      throw new IllegalArgumentException("Unsupported document reference type: " + reference);
+    }
+    final CamundaDocumentReferenceModel model;
+    if (camundaReference instanceof CamundaDocumentReferenceModel camundaModel) {
+      model = camundaModel;
+    } else {
+      model =
+          new CamundaDocumentReferenceModel(
+              camundaReference.storeId(),
+              camundaReference.documentId(),
+              camundaReference.metadata().getKeys(),
+              Optional.empty());
+    }
+    jsonGenerator.writeObject(model);
   }
 }

--- a/connector-sdk/jackson-datatype-document/src/test/java/io/camunda/connector/document/jackson/DocumentSerializationTest.java
+++ b/connector-sdk/jackson-datatype-document/src/test/java/io/camunda/connector/document/jackson/DocumentSerializationTest.java
@@ -25,8 +25,10 @@ import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import io.camunda.connector.document.annotation.jackson.DocumentReferenceModel.CamundaDocumentReferenceModel;
 import io.camunda.connector.document.annotation.jackson.JacksonModuleDocument;
 import io.camunda.document.Document;
+import io.camunda.document.DocumentMetadata;
 import io.camunda.document.factory.DocumentFactory;
 import io.camunda.document.operation.DocumentOperationExecutor;
+import io.camunda.document.reference.CamundaDocumentReferenceImpl;
 import java.util.Map;
 import java.util.Optional;
 import org.json.JSONException;
@@ -45,8 +47,29 @@ public class DocumentSerializationTest {
           .registerModule(new Jdk8Module());
 
   @Test
-  void sourceTypeDocument() throws JsonProcessingException, JSONException {
+  void sourceTypeDocument_jacksonInternalModel() throws JsonProcessingException, JSONException {
     var ref = new CamundaDocumentReferenceModel("test", "test", Map.of(), Optional.empty());
+    var document = mock(Document.class);
+    when(document.reference()).thenReturn(ref);
+    var source = new SourceTypeDocument(document);
+    var result = objectMapper.writeValueAsString(source);
+    var expectedResult =
+        """
+        {
+          "document": {
+            "documentType": "camunda",
+            "storeId": "test",
+            "documentId": "test",
+            "metadata": {}
+          }
+        }
+        """;
+    JSONAssert.assertEquals(expectedResult, result, true);
+  }
+
+  @Test
+  void sourceTypeDocument_connectorSdkModel() throws JsonProcessingException, JSONException {
+    var ref = new CamundaDocumentReferenceImpl("test", "test", new DocumentMetadata(Map.of()));
     var document = mock(Document.class);
     when(document.reference()).thenReturn(ref);
     var source = new SourceTypeDocument(document);


### PR DESCRIPTION
## Description

This PR fixes a bug because of which document references from the connector context were not serialized correctly.

