### PR TITLE
fix(rest): Fix readTimeout for old runtimes before 8.5

### DIFF
--- a/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/model/HttpCommonRequest.java
+++ b/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/model/HttpCommonRequest.java
@@ -166,7 +166,8 @@ public class HttpCommonRequest {
   }
 
   public Integer getReadTimeoutInSeconds() {
-    return Optional.ofNullable(readTimeoutInSeconds).orElse(DEFAULT_TIMEOUT);
+    return Optional.ofNullable(readTimeoutInSeconds)
+        .orElse(connectionTimeoutInSeconds != null ? connectionTimeoutInSeconds : DEFAULT_TIMEOUT);
   }
 
   public void setReadTimeoutInSeconds(final Integer readTimeoutInSeconds) {

--- a/connectors/http/http-base/src/test/java/io/camunda/connector/http/base/model/HttpCommonRequestTest.java
+++ b/connectors/http/http-base/src/test/java/io/camunda/connector/http/base/model/HttpCommonRequestTest.java
@@ -1,10 +1,19 @@
 /*
  * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
- * under one or more contributor license agreements. Licensed under a proprietary license.
- * See the License.txt file for more information. You may not use this file
- * except in compliance with the proprietary license.
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package io.camunda.connector.http.base.model;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/connectors/http/http-base/src/test/java/io/camunda/connector/http/base/model/HttpCommonRequestTest.java
+++ b/connectors/http/http-base/src/test/java/io/camunda/connector/http/base/model/HttpCommonRequestTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+
+package io.camunda.connector.http.base.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+public class HttpCommonRequestTest {
+
+  @Test
+  public void shouldCopyReadTimeoutFromConnection_whenNoReadTimeoutIsSet() {
+    // given
+    HttpCommonRequest request = new HttpCommonRequest();
+    request.setConnectionTimeoutInSeconds(10);
+
+    // when
+    int readTimeout = request.getReadTimeoutInSeconds();
+
+    // then
+    assertThat(readTimeout).isEqualTo(10);
+  }
+
+  @Test
+  public void shouldNotCopyReadTimeoutFromConnection_whenReadTimeoutIsSet() {
+    // given
+    HttpCommonRequest request = new HttpCommonRequest();
+    request.setConnectionTimeoutInSeconds(10);
+    request.setReadTimeoutInSeconds(20);
+
+    // when
+    int readTimeout = request.getReadTimeoutInSeconds();
+
+    // then
+    assertThat(readTimeout).isEqualTo(20);
+  }
+
+  @Test
+  public void shouldUseDefaultReadTimeout_whenNoReadTimeoutIsSetAndNoConnectionTimeoutIsSet() {
+    // given
+    HttpCommonRequest request = new HttpCommonRequest();
+
+    // when
+    int readTimeout = request.getReadTimeoutInSeconds();
+
+    // then
+    assertThat(readTimeout).isEqualTo(20);
+  }
+}


### PR DESCRIPTION
## Description

- ReadTimeout doesn't exist in HttpCommonRequest before 8.5
- this causes issues with older REST Connectors in Saas, as the Cloud Function will try deserialize `readTimeoutInSeconds`, find nothing, and default to 20s.
- Before the REST connector rework, this value was copied from `connectionTimeout`

=> We are adding this behavior back, by default to:
- First: the `connectionTimeoutInSeconds` if provided 
- Second: 20s otherwise