### PR TITLE
fix(textract): polling exec should assembly block array

### DIFF
--- a/connectors/aws/aws-textract/src/main/java/io/camunda/connector/textract/caller/PollingTextractCalller.java
+++ b/connectors/aws/aws-textract/src/main/java/io/camunda/connector/textract/caller/PollingTextractCalller.java
@@ -10,20 +10,22 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 
 import com.amazonaws.services.textract.AmazonTextract;
 import com.amazonaws.services.textract.AmazonTextractAsync;
-import com.amazonaws.services.textract.model.GetDocumentAnalysisRequest;
-import com.amazonaws.services.textract.model.GetDocumentAnalysisResult;
-import com.amazonaws.services.textract.model.StartDocumentAnalysisRequest;
-import com.amazonaws.services.textract.model.StartDocumentAnalysisResult;
+import com.amazonaws.services.textract.model.*;
 import io.camunda.connector.textract.model.TextractRequestData;
 import io.camunda.connector.textract.model.TextractTask;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class PollingTextractCalller implements TextractCaller<GetDocumentAnalysisResult> {
   public static final long DELAY_BETWEEN_POLLING = 5;
+
+  public static final int MAX_RESULT = 1000;
 
   private static final Logger LOGGER = LoggerFactory.getLogger(PollingTextractCalller.class);
 
@@ -37,23 +39,49 @@ public class PollingTextractCalller implements TextractCaller<GetDocumentAnalysi
             .withDocumentLocation(this.prepareDocumentLocation(requestData));
 
     final StartDocumentAnalysisResult result = textractClient.startDocumentAnalysis(startDocReq);
-    final var documentAnalysisReq = new GetDocumentAnalysisRequest().withJobId(result.getJobId());
-    final var textractTask =
-        new TextractTask(documentAnalysisReq, (AmazonTextractAsync) textractClient);
 
-    ScheduledFuture<GetDocumentAnalysisResult> future;
+    GetDocumentAnalysisResult lastDocumentResult;
+    List<Block> allBlocks;
     try (ScheduledExecutorService executorService = Executors.newSingleThreadScheduledExecutor()) {
-      future = executorService.schedule(textractTask, 0, SECONDS);
+      final String jobId = result.getJobId();
+      final TextractTask firstTextractTask = prepareTextractTask(jobId, null, textractClient);
+      final GetDocumentAnalysisResult firstDocumentResult =
+          executeTask(firstTextractTask, 0, executorService);
 
-      while (continuePolling(future.get().getJobStatus())) {
-        future = executorService.schedule(textractTask, DELAY_BETWEEN_POLLING, SECONDS);
+      allBlocks = new ArrayList<>(firstDocumentResult.getBlocks());
+      lastDocumentResult = firstDocumentResult;
+      String nextToken = firstDocumentResult.getNextToken();
+
+      while (StringUtils.isNoneEmpty(nextToken)) {
+        final TextractTask nextTextractTask = prepareTextractTask(jobId, nextToken, textractClient);
+        GetDocumentAnalysisResult nextDocumentResult =
+            executeTask(nextTextractTask, DELAY_BETWEEN_POLLING, executorService);
+        nextToken = nextDocumentResult.getNextToken();
+        allBlocks.addAll(nextDocumentResult.getBlocks());
+        lastDocumentResult = nextDocumentResult;
       }
     }
 
-    return future.get();
+    lastDocumentResult.setBlocks(allBlocks);
+    return lastDocumentResult;
   }
 
-  private boolean continuePolling(String status) {
-    return "IN_PROGRESS".equals(status);
+  private TextractTask prepareTextractTask(
+      String jobId, String nextToken, AmazonTextract textractClient) {
+    GetDocumentAnalysisRequest documentAnalysisReq =
+        new GetDocumentAnalysisRequest().withJobId(jobId).withMaxResults(MAX_RESULT);
+
+    if (StringUtils.isNoneEmpty(nextToken)) {
+      documentAnalysisReq.withNextToken(nextToken);
+    }
+
+    return new TextractTask(documentAnalysisReq, (AmazonTextractAsync) textractClient);
+  }
+
+  private GetDocumentAnalysisResult executeTask(
+      TextractTask task, long delay, ScheduledExecutorService executorService) throws Exception {
+    ScheduledFuture<GetDocumentAnalysisResult> nextDocumentResultFuture =
+        executorService.schedule(task, delay, SECONDS);
+    return nextDocumentResultFuture.get();
   }
 }

--- a/connectors/aws/aws-textract/src/main/java/io/camunda/connector/textract/model/TextractTask.java
+++ b/connectors/aws/aws-textract/src/main/java/io/camunda/connector/textract/model/TextractTask.java
@@ -24,7 +24,7 @@ public class TextractTask implements Callable<GetDocumentAnalysisResult> {
   }
 
   @Override
-  public GetDocumentAnalysisResult call() {
-    return this.amazonTextract.getDocumentAnalysis(docAnalysisReq);
+  public GetDocumentAnalysisResult call() throws Exception {
+    return amazonTextract.getDocumentAnalysis(docAnalysisReq);
   }
 }


### PR DESCRIPTION
## Description

polling exec should assembly array of blocks 

## Related issues

[issue](https://github.com/camunda/connectors/issues/3200)


