### PR TITLE
feat(zeebe): enable job push by default in bundle

### DIFF
--- a/bundle/camunda-saas-bundle/pom.xml
+++ b/bundle/camunda-saas-bundle/pom.xml
@@ -50,6 +50,11 @@
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>
     </dependency>
+      <dependency>
+          <groupId>io.camunda.spring</groupId>
+          <artifactId>spring-boot-starter-camunda-test</artifactId>
+          <scope>test</scope>
+      </dependency>
   </dependencies>
 
   <build>

--- a/bundle/camunda-saas-bundle/src/main/resources/application.properties
+++ b/bundle/camunda-saas-bundle/src/main/resources/application.properties
@@ -19,6 +19,7 @@ zeebe.client.worker.max-jobs-active=32
 # Enforce local connection, even if cluster-id set
 zeebe.client.connection-mode=ADDRESS
 camunda.client.mode=simple
+camunda.client.zeebe.defaults.stream-enabled=true
 
 connectors.log.appender=stackdriver
 

--- a/bundle/camunda-saas-bundle/src/test/java/io/camunda/connector/runtime/saas/SecurityConfigurationTest.java
+++ b/bundle/camunda-saas-bundle/src/test/java/io/camunda/connector/runtime/saas/SecurityConfigurationTest.java
@@ -52,6 +52,7 @@ import org.springframework.test.web.servlet.MockMvc;
       "zeebe.client.security.plaintext=true",
       "camunda.connector.auth.audience=connectors.dev.ultrawombat.com",
       "camunda.connector.auth.issuer=https://weblogin.cloud.dev.ultrawombat.com/",
+      "camunda.client.zeebe.defaults.stream-enabled=false",
       "camunda.operate.client.url=" + MockSaaSConfiguration.OPERATE_CLIENT_URL,
       "camunda.operate.client.authUrl=" + MockSaaSConfiguration.OPERATE_CLIENT_AUTH_URL,
       "camunda.operate.client.baseUrl=" + MockSaaSConfiguration.OPERATE_CLIENT_BASEURL

--- a/bundle/camunda-saas-bundle/src/test/java/io/camunda/connector/runtime/saas/SecurityConfigurationTest.java
+++ b/bundle/camunda-saas-bundle/src/test/java/io/camunda/connector/runtime/saas/SecurityConfigurationTest.java
@@ -28,6 +28,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import io.camunda.operate.CamundaOperateClient;
 import java.time.Duration;
+
+import io.camunda.zeebe.spring.test.ZeebeSpringTest;
+import org.junit.Ignore;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -60,6 +63,7 @@ import org.springframework.test.web.servlet.MockMvc;
 @DirtiesContext
 @ActiveProfiles("test")
 @AutoConfigureMockMvc
+@ZeebeSpringTest
 public class SecurityConfigurationTest {
 
   @Autowired private MockMvc mvc;

--- a/bundle/camunda-saas-bundle/src/test/java/io/camunda/connector/runtime/saas/SecurityConfigurationTest.java
+++ b/bundle/camunda-saas-bundle/src/test/java/io/camunda/connector/runtime/saas/SecurityConfigurationTest.java
@@ -27,6 +27,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import io.camunda.operate.CamundaOperateClient;
+import org.junit.Ignore;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -52,7 +53,6 @@ import org.springframework.test.web.servlet.MockMvc;
       "zeebe.client.security.plaintext=true",
       "camunda.connector.auth.audience=connectors.dev.ultrawombat.com",
       "camunda.connector.auth.issuer=https://weblogin.cloud.dev.ultrawombat.com/",
-      "camunda.client.zeebe.defaults.stream-enabled=false",
       "camunda.operate.client.url=" + MockSaaSConfiguration.OPERATE_CLIENT_URL,
       "camunda.operate.client.authUrl=" + MockSaaSConfiguration.OPERATE_CLIENT_AUTH_URL,
       "camunda.operate.client.baseUrl=" + MockSaaSConfiguration.OPERATE_CLIENT_BASEURL
@@ -138,7 +138,7 @@ public class SecurityConfigurationTest {
         .andExpect(status().isUnauthorized());
   }
 
-  @Test
+  @Ignore
   public void actuatorEndpoint_isAccessible() {
     ResponseEntity<String> response =
         restTemplateBuilder

--- a/bundle/camunda-saas-bundle/src/test/java/io/camunda/connector/runtime/saas/SecurityConfigurationTest.java
+++ b/bundle/camunda-saas-bundle/src/test/java/io/camunda/connector/runtime/saas/SecurityConfigurationTest.java
@@ -44,6 +44,8 @@ import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
+import java.time.Duration;
+
 @SpringBootTest(
     webEnvironment = WebEnvironment.RANDOM_PORT,
     classes = {SaaSConnectorRuntimeApplication.class, MockSaaSConfiguration.class},
@@ -138,11 +140,12 @@ public class SecurityConfigurationTest {
         .andExpect(status().isUnauthorized());
   }
 
-  @Ignore
+  @Test
   public void actuatorEndpoint_isAccessible() {
     ResponseEntity<String> response =
         restTemplateBuilder
             .rootUri("http://localhost:" + managementPort + "/actuator")
+            .setConnectTimeout(Duration.ofSeconds(60))
             .build()
             .exchange("/metrics", HttpMethod.GET, new HttpEntity<>(null), String.class);
 

--- a/bundle/camunda-saas-bundle/src/test/java/io/camunda/connector/runtime/saas/SecurityConfigurationTest.java
+++ b/bundle/camunda-saas-bundle/src/test/java/io/camunda/connector/runtime/saas/SecurityConfigurationTest.java
@@ -27,7 +27,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import io.camunda.operate.CamundaOperateClient;
-import org.junit.Ignore;
+import java.time.Duration;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -43,8 +43,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
-
-import java.time.Duration;
 
 @SpringBootTest(
     webEnvironment = WebEnvironment.RANDOM_PORT,

--- a/bundle/camunda-saas-bundle/src/test/java/io/camunda/connector/runtime/saas/SecurityConfigurationTest.java
+++ b/bundle/camunda-saas-bundle/src/test/java/io/camunda/connector/runtime/saas/SecurityConfigurationTest.java
@@ -27,10 +27,8 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import io.camunda.operate.CamundaOperateClient;
-import java.time.Duration;
-
 import io.camunda.zeebe.spring.test.ZeebeSpringTest;
-import org.junit.Ignore;
+import java.time.Duration;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;

--- a/bundle/camunda-saas-bundle/src/test/java/io/camunda/connector/runtime/saas/SecurityConfigurationTest.java
+++ b/bundle/camunda-saas-bundle/src/test/java/io/camunda/connector/runtime/saas/SecurityConfigurationTest.java
@@ -144,6 +144,7 @@ public class SecurityConfigurationTest {
         restTemplateBuilder
             .rootUri("http://localhost:" + managementPort + "/actuator")
             .setConnectTimeout(Duration.ofSeconds(60))
+            .setReadTimeout(Duration.ofSeconds(60))
             .build()
             .exchange("/metrics", HttpMethod.GET, new HttpEntity<>(null), String.class);
 

--- a/bundle/default-bundle/src/test/resources/application.properties
+++ b/bundle/default-bundle/src/test/resources/application.properties
@@ -10,6 +10,7 @@ camunda.client.operate.base-url=http://localhost:8081
 camunda.client.zeebe.gateway-url=http://localhost:26500
 camunda.client.zeebe.defaults.max-jobs-active=32
 camunda.client.zeebe.defaults.worker-threads=10
+camunda.client.zeebe.defaults.stream-enabled=true
 
 # Config for use with docker-compose.yml
 camunda.client.mode=oidc


### PR DESCRIPTION
## Description

Modify our provided `application.properties` files in the bundle.

## Notes for Reviewers

Test changes:
- @ZeebeSpringTest and its dependency are needed for the `SecurityConfigurationTest` to consistently finish in CI. 
- I added 60s timeouts because if connection or read takes longer than this, the test should fail instead of waiting indefinitely.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes https://github.com/camunda/connectors/issues/2844

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.

