### PR TITLE
feat(element-template-generator): accept yaml content as parameter in template generator

### DIFF
--- a/element-template-generator/openapi-parser/pom.xml
+++ b/element-template-generator/openapi-parser/pom.xml
@@ -29,6 +29,10 @@
       <artifactId>swagger-parser</artifactId>
       <version>${version.swagger-parser}</version>
     </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.dataformat</groupId>
+      <artifactId>jackson-dataformat-yaml</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>org.junit.jupiter</groupId>

--- a/element-template-generator/openapi-parser/src/main/java/io/camunda/connector/generator/openapi/OpenApiGenerationSource.java
+++ b/element-template-generator/openapi-parser/src/main/java/io/camunda/connector/generator/openapi/OpenApiGenerationSource.java
@@ -17,6 +17,7 @@
 package io.camunda.connector.generator.openapi;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.parser.OpenAPIV3Parser;
 import java.io.IOException;
@@ -53,7 +54,7 @@ public record OpenApiGenerationSource(
     var openApiPathOrContent = cliParams.get(0);
     var openApiParser = new OpenAPIV3Parser();
     try {
-      if (isValidJSON(openApiPathOrContent)) {
+      if (isValidJSON(openApiPathOrContent) || isValidYAML(openApiPathOrContent)) {
         return openApiParser.readContents(openApiPathOrContent).getOpenAPI();
       }
       return openApiParser.read(openApiPathOrContent);
@@ -71,6 +72,16 @@ public record OpenApiGenerationSource(
       final ObjectMapper mapper = new ObjectMapper();
       mapper.readTree(jsonInString);
       return true;
+    } catch (IOException e) {
+      return false;
+    }
+  }
+
+  public static boolean isValidYAML(String yamlString) {
+    try {
+      final ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
+      mapper.readTree(yamlString);
+      return yamlString.contains("\n");
     } catch (IOException e) {
       return false;
     }

--- a/element-template-generator/openapi-parser/src/test/java/io/camunda/connector/generator/openapi/ExampleTest.java
+++ b/element-template-generator/openapi-parser/src/test/java/io/camunda/connector/generator/openapi/ExampleTest.java
@@ -68,6 +68,26 @@ public class ExampleTest {
     }
   }
 
+  @SuppressWarnings("ResultOfMethodCallIgnored")
+  @Test
+  void generateFromRawYamlContent() {
+    // given
+    try (var openApiYamlContent = new FileInputStream("src/test/resources/example.yaml")) {
+      byte[] b = new byte[openApiYamlContent.available()];
+      openApiYamlContent.read(b);
+      var source = new OpenApiGenerationSource(List.of(new String(b)));
+      var generator = new OpenApiOutboundTemplateGenerator();
+
+      // when
+      var scanResult = generator.generate(source);
+
+      // then
+      System.out.println(scanResult);
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
   @Test
   void scan() {
     var parser = new OpenAPIV3Parser();
@@ -87,6 +107,23 @@ public class ExampleTest {
       String openApiCollectionsJsonContent =
           mapper.readValue(openApiJsonContent, JsonNode.class).toString();
       var source = new OpenApiGenerationSource(List.of(openApiCollectionsJsonContent));
+      var generator = new OpenApiOutboundTemplateGenerator();
+
+      var scanResult = generator.scan(source);
+
+      System.out.println(scanResult);
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @SuppressWarnings("ResultOfMethodCallIgnored")
+  @Test
+  void scanFromRawYamlContent() {
+    try (var openApiYamlContent = new FileInputStream("src/test/resources/example.yaml")) {
+      byte[] b = new byte[openApiYamlContent.available()];
+      openApiYamlContent.read(b);
+      var source = new OpenApiGenerationSource(List.of(new String(b)));
       var generator = new OpenApiOutboundTemplateGenerator();
 
       var scanResult = generator.scan(source);

--- a/element-template-generator/openapi-parser/src/test/java/io/camunda/connector/generator/openapi/ExampleTest.java
+++ b/element-template-generator/openapi-parser/src/test/java/io/camunda/connector/generator/openapi/ExampleTest.java
@@ -68,21 +68,22 @@ public class ExampleTest {
     }
   }
 
-  @SuppressWarnings("ResultOfMethodCallIgnored")
   @Test
   void generateFromRawYamlContent() {
     // given
     try (var openApiYamlContent = new FileInputStream("src/test/resources/example.yaml")) {
       byte[] b = new byte[openApiYamlContent.available()];
-      openApiYamlContent.read(b);
+      if (openApiYamlContent.read(b) == -1) {
+        throw new RuntimeException("Failed to read yaml file!");
+      }
       var source = new OpenApiGenerationSource(List.of(new String(b)));
       var generator = new OpenApiOutboundTemplateGenerator();
 
       // when
-      var scanResult = generator.generate(source);
+      var templates = generator.generate(source);
 
       // then
-      System.out.println(scanResult);
+      System.out.println(mapper.writeValueAsString(templates));
     } catch (IOException e) {
       throw new RuntimeException(e);
     }
@@ -117,12 +118,13 @@ public class ExampleTest {
     }
   }
 
-  @SuppressWarnings("ResultOfMethodCallIgnored")
   @Test
   void scanFromRawYamlContent() {
     try (var openApiYamlContent = new FileInputStream("src/test/resources/example.yaml")) {
       byte[] b = new byte[openApiYamlContent.available()];
-      openApiYamlContent.read(b);
+      if (openApiYamlContent.read(b) == -1) {
+        throw new RuntimeException("Failed to read yaml file!");
+      }
       var source = new OpenApiGenerationSource(List.of(new String(b)));
       var generator = new OpenApiOutboundTemplateGenerator();
 

--- a/element-template-generator/openapi-parser/src/test/resources/example.yaml
+++ b/element-template-generator/openapi-parser/src/test/resources/example.yaml
@@ -1,0 +1,24 @@
+openapi: 3.0.0
+info:
+  title: Sample API
+  description: Optional multiline or single-line description in [CommonMark](http://commonmark.org/help/) or HTML.
+  version: 0.1.9
+servers:
+  - url: http://api.example.com/v1
+    description: Optional server description, e.g. Main (production) server
+  - url: http://staging-api.example.com
+    description: Optional server description, e.g. Internal staging server for testing
+paths:
+  /users:
+    get:
+      summary: Returns a list of users.
+      description: Optional extended description in CommonMark or HTML.
+      responses:
+        '200':    # status code
+          description: A JSON array of user names
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: string

--- a/element-template-generator/postman-collections-parser/pom.xml
+++ b/element-template-generator/postman-collections-parser/pom.xml
@@ -19,6 +19,10 @@
       <groupId>io.camunda.connector</groupId>
       <artifactId>element-template-generator-http-dsl</artifactId>
     </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.dataformat</groupId>
+      <artifactId>jackson-dataformat-yaml</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>org.junit.jupiter</groupId>

--- a/element-template-generator/postman-collections-parser/src/main/java/io/camunda/connector/generator/postman/PostmanCollectionsGenerationSource.java
+++ b/element-template-generator/postman-collections-parser/src/main/java/io/camunda/connector/generator/postman/PostmanCollectionsGenerationSource.java
@@ -17,6 +17,8 @@
 package io.camunda.connector.generator.postman;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import io.camunda.connector.generator.postman.model.PostmanCollectionV210;
 import io.camunda.connector.generator.postman.utils.ObjectMapperProvider;
 import java.io.File;
@@ -59,6 +61,10 @@ public record PostmanCollectionsGenerationSource(
                         throw new IllegalArgumentException(
                             "Couldn't parse Postman Collection to v.2.1.0 standard", e);
                       }
+                    } else if (isValidYAML(pathOrContent)) {
+                      final ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
+                      mapper.findAndRegisterModules();
+                      return mapper.readValue(pathOrContent, JsonNode.class);
                     }
                     final File postmanCollectionsFileJson;
                     if (pathOrContent.startsWith("http")) { // Network
@@ -116,6 +122,16 @@ public record PostmanCollectionsGenerationSource(
     try {
       ObjectMapperProvider.getInstance().readTree(jsonInString);
       return true;
+    } catch (IOException e) {
+      return false;
+    }
+  }
+
+  public static boolean isValidYAML(String yamlString) {
+    try {
+      final ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
+      mapper.readTree(yamlString);
+      return yamlString.contains("\n");
     } catch (IOException e) {
       return false;
     }

--- a/element-template-generator/postman-collections-parser/src/test/java/io/camunda/connector/generator/postman/PostmanCollectionsGeneratorDryRunExampleTest.java
+++ b/element-template-generator/postman-collections-parser/src/test/java/io/camunda/connector/generator/postman/PostmanCollectionsGeneratorDryRunExampleTest.java
@@ -110,11 +110,12 @@ public class PostmanCollectionsGeneratorDryRunExampleTest {
     }
   }
 
-  @SuppressWarnings("ResultOfMethodCallIgnored")
   private static String getYamlContent() {
     try (var openApiYamlContent = new FileInputStream("src/test/resources/example.yaml")) {
       byte[] b = new byte[openApiYamlContent.available()];
-      openApiYamlContent.read(b);
+      if (openApiYamlContent.read(b) == -1) {
+        throw new RuntimeException("Failed to read yaml file!");
+      }
       return new String(b);
     } catch (IOException e) {
       throw new RuntimeException(e);

--- a/element-template-generator/postman-collections-parser/src/test/java/io/camunda/connector/generator/postman/PostmanCollectionsGeneratorDryRunExampleTest.java
+++ b/element-template-generator/postman-collections-parser/src/test/java/io/camunda/connector/generator/postman/PostmanCollectionsGeneratorDryRunExampleTest.java
@@ -65,38 +65,57 @@ public class PostmanCollectionsGeneratorDryRunExampleTest {
   }
 
   private static Stream<Arguments> commandLineArguments() {
+    String postmanCollectionsJsonContent = getJsonContent();
+    String postmanCollectionsYamlContent = getYamlContent();
+
+    return Stream.of(
+        // Test case 1: generate all methods
+        Arguments.of(List.of("src/test/resources/operate-api-saas-bearer.json")),
+
+        // Test case 2: generate specific methods
+        Arguments.of(
+            List.of(
+                "src/test/resources/postman-books.json",
+                "/1. Sending requests & inspecting responses/books",
+                "/1. Sending requests & inspecting responses/book",
+                "/1. Sending requests & inspecting responses/add book")),
+
+        // Test case 3: fetch from internet
+        Arguments.of(
+            List.of(
+                "https://raw.githubusercontent.com/camunda-community-hub/camunda-8-api-postman-collection/main/Operate%20Public%20API%20-%20SaaS.postman_collection.json")),
+
+        // Test case 4: from internet with operations
+        Arguments.of(
+            List.of(
+                "https://raw.githubusercontent.com/camunda-community-hub/camunda-8-api-postman-collection/main/Operate%20Public%20API%20-%20SaaS.postman_collection.json",
+                "/Process instances/Search for process instances",
+                "/Process instances/Get process instance by key")),
+
+        // Test case 5: from raw json content
+        Arguments.of(List.of(postmanCollectionsJsonContent)),
+
+        // Test case 6: from raw yaml content
+        Arguments.of(List.of(postmanCollectionsYamlContent)));
+  }
+
+  private static String getJsonContent() {
     try (var openApiJsonContent =
         new FileInputStream("src/test/resources/operate-api-saas-bearer.json")) {
-      String postmanCollectionsJsonContent =
-          ObjectMapperProvider.getInstance()
-              .readValue(openApiJsonContent, JsonNode.class)
-              .toString();
-      return Stream.of(
-          // Test case 1: generate all methods
-          Arguments.of(List.of("src/test/resources/operate-api-saas-bearer.json")),
+      return ObjectMapperProvider.getInstance()
+          .readValue(openApiJsonContent, JsonNode.class)
+          .toString();
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
 
-          // Test case 2: generate specific methods
-          Arguments.of(
-              List.of(
-                  "src/test/resources/postman-books.json",
-                  "/1. Sending requests & inspecting responses/books",
-                  "/1. Sending requests & inspecting responses/book",
-                  "/1. Sending requests & inspecting responses/add book")),
-
-          // Test case 3: fetch from internet
-          Arguments.of(
-              List.of(
-                  "https://raw.githubusercontent.com/camunda-community-hub/camunda-8-api-postman-collection/main/Operate%20Public%20API%20-%20SaaS.postman_collection.json")),
-
-          // Test case 4: from internet with operations
-          Arguments.of(
-              List.of(
-                  "https://raw.githubusercontent.com/camunda-community-hub/camunda-8-api-postman-collection/main/Operate%20Public%20API%20-%20SaaS.postman_collection.json",
-                  "/Process instances/Search for process instances",
-                  "/Process instances/Get process instance by key")),
-
-          // Test case 5: from raw content
-          Arguments.of(List.of(postmanCollectionsJsonContent)));
+  @SuppressWarnings("ResultOfMethodCallIgnored")
+  private static String getYamlContent() {
+    try (var openApiYamlContent = new FileInputStream("src/test/resources/example.yaml")) {
+      byte[] b = new byte[openApiYamlContent.available()];
+      openApiYamlContent.read(b);
+      return new String(b);
     } catch (IOException e) {
       throw new RuntimeException(e);
     }

--- a/element-template-generator/postman-collections-parser/src/test/resources/example.yaml
+++ b/element-template-generator/postman-collections-parser/src/test/resources/example.yaml
@@ -1,0 +1,25 @@
+info:
+  _postman_id: 431257b5-df1f-4a84-863a-46d2aa3ae731
+  name: TEST
+  schema: https://schema.getpostman.com/json/collection/v2.1.0/collection.json
+  _exporter_id: '25378986'
+item:
+  - name: v1
+    item:
+      - name: New Request
+        request:
+          method: GET
+          header: []
+        response: []
+  - name: v2
+    item:
+      - name: New Request
+        request:
+          method: GET
+          header: []
+        response: []
+  - name: test
+    request:
+      method: GET
+      header: []
+    response: []


### PR DESCRIPTION
## Description

Added a check if the provided content is a valid yaml, and specific handling for that case. Did it for both openapi, and postman parser.

## Related issues

closes https://github.com/camunda/connectors/issues/3241

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.

