### PR TITLE
chore(deps): exclude jcip-annotations from podam dependency

### DIFF
--- a/element-template-generator/core/pom.xml
+++ b/element-template-generator/core/pom.xml
@@ -58,6 +58,12 @@
       <groupId>uk.co.jemos.podam</groupId>
       <artifactId>podam</artifactId>
       <version>8.0.2.RELEASE</version>
+      <exclusions>
+        <exclusion>
+          <groupId>net.jcip</groupId>
+          <artifactId>jcip-annotations</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <!-- Test dependencies -->


### PR DESCRIPTION
## Description

We use the element template generator in web-modeler as a dependency. In web-modeler we do a license check.
[jcip-annotations](https://mvnrepository.com/artifact/net.jcip/jcip-annotations/1.0) doesn't have any valid license which causes issues in web-modeler.

Because we do not actually use this dependency I excluded it.

Added the 8.6.0 milestone because it is a small change without any impact, so we can include it in the next stable version, which would be beneficial for the web-modeler.

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.

