### PR TITLE
chore(deps): bump identity SDK to 8.5.5

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -74,6 +74,7 @@ limitations under the License.</license.inlineheader>
     <version.zeebe>8.5.5</version.zeebe>
     <version.feel-engine>1.17.7</version.feel-engine>
     <version.spring-zeebe>8.5.5</version.spring-zeebe>
+    <version.identity-sdk>8.5.5</version.identity-sdk>
 
     <!-- Third party dependencies -->
 
@@ -307,6 +308,18 @@ limitations under the License.</license.inlineheader>
         <groupId>org.camunda.feel</groupId>
         <artifactId>feel-engine</artifactId>
         <version>${version.feel-engine}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>io.camunda</groupId>
+        <artifactId>identity-sdk</artifactId>
+        <version>${version.identity-sdk}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>io.camunda</groupId>
+        <artifactId>identity-spring-boot-autoconfigure</artifactId>
+        <version>${version.identity-sdk}</version>
       </dependency>
 
       <!-- Third party dependencies -->


### PR DESCRIPTION
Increase the version of Identity SDK that comes from spring-zeebe transitively.
