### PR TITLE
feat(schema-registry): Fix template variables names

### DIFF
--- a/connectors/kafka/element-templates/hybrid/kafka-inbound-connector-boundary-hybrid.json
+++ b/connectors/kafka/element-templates/hybrid/kafka-inbound-connector-boundary-hybrid.json
@@ -183,12 +183,12 @@
       "value" : "earliest"
     } ]
   }, {
-    "id" : "type",
+    "id" : "schemaStrategy.type",
     "label" : "Schema strategy",
     "value" : "noSchema",
     "group" : "kafka",
     "binding" : {
-      "name" : "type",
+      "name" : "schemaStrategy.type",
       "type" : "zeebe:property"
     },
     "type" : "Dropdown",
@@ -203,18 +203,18 @@
       "value" : "schemaRegistry"
     } ]
   }, {
-    "id" : "schemaType",
+    "id" : "schemaStrategy.schemaType",
     "label" : "Schema type",
     "description" : "Select the schema type. For details, visit the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/kafka/?kafka=inbound\" target=\"_blank\">documentation</a>",
     "optional" : false,
     "value" : "avro",
     "group" : "kafka",
     "binding" : {
-      "name" : "schemaType",
+      "name" : "schemaStrategy.schemaType",
       "type" : "zeebe:property"
     },
     "condition" : {
-      "property" : "type",
+      "property" : "schemaStrategy.type",
       "equals" : "schemaRegistry",
       "type" : "simple"
     },
@@ -227,25 +227,28 @@
       "value" : "avro"
     } ]
   }, {
-    "id" : "schemaRegistryUrl",
+    "id" : "schemaStrategy.schemaRegistryUrl",
     "label" : "Schema registry URL",
     "description" : "Provide the schema registry URL",
     "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
     "group" : "kafka",
     "binding" : {
-      "name" : "schemaRegistryUrl",
+      "name" : "schemaStrategy.schemaRegistryUrl",
       "type" : "zeebe:property"
     },
     "condition" : {
-      "property" : "type",
+      "property" : "schemaStrategy.type",
       "equals" : "schemaRegistry",
       "type" : "simple"
     },
     "type" : "String"
   }, {
-    "id" : "avro.schema",
+    "id" : "schemaStrategy.avro.schema",
     "label" : "Schema",
-    "description" : "Inline schema (JSON or AVRO) for the message value",
+    "description" : "Inline schema (Avro) for the message value",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -253,11 +256,11 @@
     "feel" : "required",
     "group" : "message",
     "binding" : {
-      "name" : "avro.schema",
+      "name" : "schemaStrategy.avro.schema",
       "type" : "zeebe:property"
     },
     "condition" : {
-      "property" : "type",
+      "property" : "schemaStrategy.type",
       "equals" : "inlineSchema",
       "type" : "simple"
     },

--- a/connectors/kafka/element-templates/hybrid/kafka-inbound-connector-intermediate-hybrid.json
+++ b/connectors/kafka/element-templates/hybrid/kafka-inbound-connector-intermediate-hybrid.json
@@ -183,12 +183,12 @@
       "value" : "earliest"
     } ]
   }, {
-    "id" : "type",
+    "id" : "schemaStrategy.type",
     "label" : "Schema strategy",
     "value" : "noSchema",
     "group" : "kafka",
     "binding" : {
-      "name" : "type",
+      "name" : "schemaStrategy.type",
       "type" : "zeebe:property"
     },
     "type" : "Dropdown",
@@ -203,18 +203,18 @@
       "value" : "schemaRegistry"
     } ]
   }, {
-    "id" : "schemaType",
+    "id" : "schemaStrategy.schemaType",
     "label" : "Schema type",
     "description" : "Select the schema type. For details, visit the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/kafka/?kafka=inbound\" target=\"_blank\">documentation</a>",
     "optional" : false,
     "value" : "avro",
     "group" : "kafka",
     "binding" : {
-      "name" : "schemaType",
+      "name" : "schemaStrategy.schemaType",
       "type" : "zeebe:property"
     },
     "condition" : {
-      "property" : "type",
+      "property" : "schemaStrategy.type",
       "equals" : "schemaRegistry",
       "type" : "simple"
     },
@@ -227,25 +227,28 @@
       "value" : "avro"
     } ]
   }, {
-    "id" : "schemaRegistryUrl",
+    "id" : "schemaStrategy.schemaRegistryUrl",
     "label" : "Schema registry URL",
     "description" : "Provide the schema registry URL",
     "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
     "group" : "kafka",
     "binding" : {
-      "name" : "schemaRegistryUrl",
+      "name" : "schemaStrategy.schemaRegistryUrl",
       "type" : "zeebe:property"
     },
     "condition" : {
-      "property" : "type",
+      "property" : "schemaStrategy.type",
       "equals" : "schemaRegistry",
       "type" : "simple"
     },
     "type" : "String"
   }, {
-    "id" : "avro.schema",
+    "id" : "schemaStrategy.avro.schema",
     "label" : "Schema",
-    "description" : "Inline schema (JSON or AVRO) for the message value",
+    "description" : "Inline schema (Avro) for the message value",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -253,11 +256,11 @@
     "feel" : "required",
     "group" : "message",
     "binding" : {
-      "name" : "avro.schema",
+      "name" : "schemaStrategy.avro.schema",
       "type" : "zeebe:property"
     },
     "condition" : {
-      "property" : "type",
+      "property" : "schemaStrategy.type",
       "equals" : "inlineSchema",
       "type" : "simple"
     },

--- a/connectors/kafka/element-templates/hybrid/kafka-inbound-connector-start-message-hybrid.json
+++ b/connectors/kafka/element-templates/hybrid/kafka-inbound-connector-start-message-hybrid.json
@@ -183,12 +183,12 @@
       "value" : "earliest"
     } ]
   }, {
-    "id" : "type",
+    "id" : "schemaStrategy.type",
     "label" : "Schema strategy",
     "value" : "noSchema",
     "group" : "kafka",
     "binding" : {
-      "name" : "type",
+      "name" : "schemaStrategy.type",
       "type" : "zeebe:property"
     },
     "type" : "Dropdown",
@@ -203,18 +203,18 @@
       "value" : "schemaRegistry"
     } ]
   }, {
-    "id" : "schemaType",
+    "id" : "schemaStrategy.schemaType",
     "label" : "Schema type",
     "description" : "Select the schema type. For details, visit the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/kafka/?kafka=inbound\" target=\"_blank\">documentation</a>",
     "optional" : false,
     "value" : "avro",
     "group" : "kafka",
     "binding" : {
-      "name" : "schemaType",
+      "name" : "schemaStrategy.schemaType",
       "type" : "zeebe:property"
     },
     "condition" : {
-      "property" : "type",
+      "property" : "schemaStrategy.type",
       "equals" : "schemaRegistry",
       "type" : "simple"
     },
@@ -227,25 +227,28 @@
       "value" : "avro"
     } ]
   }, {
-    "id" : "schemaRegistryUrl",
+    "id" : "schemaStrategy.schemaRegistryUrl",
     "label" : "Schema registry URL",
     "description" : "Provide the schema registry URL",
     "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
     "group" : "kafka",
     "binding" : {
-      "name" : "schemaRegistryUrl",
+      "name" : "schemaStrategy.schemaRegistryUrl",
       "type" : "zeebe:property"
     },
     "condition" : {
-      "property" : "type",
+      "property" : "schemaStrategy.type",
       "equals" : "schemaRegistry",
       "type" : "simple"
     },
     "type" : "String"
   }, {
-    "id" : "avro.schema",
+    "id" : "schemaStrategy.avro.schema",
     "label" : "Schema",
-    "description" : "Inline schema (JSON or AVRO) for the message value",
+    "description" : "Inline schema (Avro) for the message value",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -253,11 +256,11 @@
     "feel" : "required",
     "group" : "message",
     "binding" : {
-      "name" : "avro.schema",
+      "name" : "schemaStrategy.avro.schema",
       "type" : "zeebe:property"
     },
     "condition" : {
-      "property" : "type",
+      "property" : "schemaStrategy.type",
       "equals" : "inlineSchema",
       "type" : "simple"
     },

--- a/connectors/kafka/element-templates/hybrid/kafka-outbound-connector-hybrid.json
+++ b/connectors/kafka/element-templates/hybrid/kafka-outbound-connector-hybrid.json
@@ -99,12 +99,12 @@
     },
     "type" : "String"
   }, {
-    "id" : "type",
+    "id" : "schemaStrategy.type",
     "label" : "Schema strategy",
     "value" : "noSchema",
     "group" : "kafka",
     "binding" : {
-      "name" : "type",
+      "name" : "schemaStrategy.type",
       "type" : "zeebe:input"
     },
     "type" : "Dropdown",
@@ -119,18 +119,18 @@
       "value" : "schemaRegistry"
     } ]
   }, {
-    "id" : "schemaType",
+    "id" : "schemaStrategy.schemaType",
     "label" : "Schema type",
     "description" : "Select the schema type. For details, visit the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/kafka/?kafka=inbound\" target=\"_blank\">documentation</a>",
     "optional" : false,
     "value" : "avro",
     "group" : "kafka",
     "binding" : {
-      "name" : "schemaType",
+      "name" : "schemaStrategy.schemaType",
       "type" : "zeebe:input"
     },
     "condition" : {
-      "property" : "type",
+      "property" : "schemaStrategy.type",
       "equals" : "schemaRegistry",
       "type" : "simple"
     },
@@ -143,18 +143,21 @@
       "value" : "avro"
     } ]
   }, {
-    "id" : "schemaRegistryUrl",
+    "id" : "schemaStrategy.schemaRegistryUrl",
     "label" : "Schema registry URL",
     "description" : "Provide the schema registry URL",
     "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
     "feel" : "optional",
     "group" : "kafka",
     "binding" : {
-      "name" : "schemaRegistryUrl",
+      "name" : "schemaStrategy.schemaRegistryUrl",
       "type" : "zeebe:input"
     },
     "condition" : {
-      "property" : "type",
+      "property" : "schemaStrategy.type",
       "equals" : "schemaRegistry",
       "type" : "simple"
     },
@@ -211,9 +214,9 @@
     },
     "type" : "String"
   }, {
-    "id" : "avro.schema",
+    "id" : "schemaStrategy.avro.schema",
     "label" : "Schema",
-    "description" : "Inline schema (JSON or AVRO) for the message value",
+    "description" : "Inline schema (Avro) for the message value",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -221,17 +224,17 @@
     "feel" : "required",
     "group" : "message",
     "binding" : {
-      "name" : "avro.schema",
+      "name" : "schemaStrategy.avro.schema",
       "type" : "zeebe:input"
     },
     "condition" : {
-      "property" : "type",
+      "property" : "schemaStrategy.type",
       "equals" : "inlineSchema",
       "type" : "simple"
     },
     "type" : "Text"
   }, {
-    "id" : "schema",
+    "id" : "schemaStrategy.schema",
     "label" : "Schema",
     "description" : "Schema (JSON or AVRO) for the message value",
     "optional" : false,
@@ -241,11 +244,11 @@
     "feel" : "required",
     "group" : "message",
     "binding" : {
-      "name" : "schema",
+      "name" : "schemaStrategy.schema",
       "type" : "zeebe:input"
     },
     "condition" : {
-      "property" : "type",
+      "property" : "schemaStrategy.type",
       "equals" : "schemaRegistry",
       "type" : "simple"
     },

--- a/connectors/kafka/element-templates/kafka-inbound-connector-boundary.json
+++ b/connectors/kafka/element-templates/kafka-inbound-connector-boundary.json
@@ -178,12 +178,12 @@
       "value" : "earliest"
     } ]
   }, {
-    "id" : "type",
+    "id" : "schemaStrategy.type",
     "label" : "Schema strategy",
     "value" : "noSchema",
     "group" : "kafka",
     "binding" : {
-      "name" : "type",
+      "name" : "schemaStrategy.type",
       "type" : "zeebe:property"
     },
     "type" : "Dropdown",
@@ -198,18 +198,18 @@
       "value" : "schemaRegistry"
     } ]
   }, {
-    "id" : "schemaType",
+    "id" : "schemaStrategy.schemaType",
     "label" : "Schema type",
     "description" : "Select the schema type. For details, visit the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/kafka/?kafka=inbound\" target=\"_blank\">documentation</a>",
     "optional" : false,
     "value" : "avro",
     "group" : "kafka",
     "binding" : {
-      "name" : "schemaType",
+      "name" : "schemaStrategy.schemaType",
       "type" : "zeebe:property"
     },
     "condition" : {
-      "property" : "type",
+      "property" : "schemaStrategy.type",
       "equals" : "schemaRegistry",
       "type" : "simple"
     },
@@ -222,25 +222,28 @@
       "value" : "avro"
     } ]
   }, {
-    "id" : "schemaRegistryUrl",
+    "id" : "schemaStrategy.schemaRegistryUrl",
     "label" : "Schema registry URL",
     "description" : "Provide the schema registry URL",
     "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
     "group" : "kafka",
     "binding" : {
-      "name" : "schemaRegistryUrl",
+      "name" : "schemaStrategy.schemaRegistryUrl",
       "type" : "zeebe:property"
     },
     "condition" : {
-      "property" : "type",
+      "property" : "schemaStrategy.type",
       "equals" : "schemaRegistry",
       "type" : "simple"
     },
     "type" : "String"
   }, {
-    "id" : "avro.schema",
+    "id" : "schemaStrategy.avro.schema",
     "label" : "Schema",
-    "description" : "Inline schema (JSON or AVRO) for the message value",
+    "description" : "Inline schema (Avro) for the message value",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -248,11 +251,11 @@
     "feel" : "required",
     "group" : "message",
     "binding" : {
-      "name" : "avro.schema",
+      "name" : "schemaStrategy.avro.schema",
       "type" : "zeebe:property"
     },
     "condition" : {
-      "property" : "type",
+      "property" : "schemaStrategy.type",
       "equals" : "inlineSchema",
       "type" : "simple"
     },

--- a/connectors/kafka/element-templates/kafka-inbound-connector-intermediate.json
+++ b/connectors/kafka/element-templates/kafka-inbound-connector-intermediate.json
@@ -178,12 +178,12 @@
       "value" : "earliest"
     } ]
   }, {
-    "id" : "type",
+    "id" : "schemaStrategy.type",
     "label" : "Schema strategy",
     "value" : "noSchema",
     "group" : "kafka",
     "binding" : {
-      "name" : "type",
+      "name" : "schemaStrategy.type",
       "type" : "zeebe:property"
     },
     "type" : "Dropdown",
@@ -198,18 +198,18 @@
       "value" : "schemaRegistry"
     } ]
   }, {
-    "id" : "schemaType",
+    "id" : "schemaStrategy.schemaType",
     "label" : "Schema type",
     "description" : "Select the schema type. For details, visit the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/kafka/?kafka=inbound\" target=\"_blank\">documentation</a>",
     "optional" : false,
     "value" : "avro",
     "group" : "kafka",
     "binding" : {
-      "name" : "schemaType",
+      "name" : "schemaStrategy.schemaType",
       "type" : "zeebe:property"
     },
     "condition" : {
-      "property" : "type",
+      "property" : "schemaStrategy.type",
       "equals" : "schemaRegistry",
       "type" : "simple"
     },
@@ -222,25 +222,28 @@
       "value" : "avro"
     } ]
   }, {
-    "id" : "schemaRegistryUrl",
+    "id" : "schemaStrategy.schemaRegistryUrl",
     "label" : "Schema registry URL",
     "description" : "Provide the schema registry URL",
     "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
     "group" : "kafka",
     "binding" : {
-      "name" : "schemaRegistryUrl",
+      "name" : "schemaStrategy.schemaRegistryUrl",
       "type" : "zeebe:property"
     },
     "condition" : {
-      "property" : "type",
+      "property" : "schemaStrategy.type",
       "equals" : "schemaRegistry",
       "type" : "simple"
     },
     "type" : "String"
   }, {
-    "id" : "avro.schema",
+    "id" : "schemaStrategy.avro.schema",
     "label" : "Schema",
-    "description" : "Inline schema (JSON or AVRO) for the message value",
+    "description" : "Inline schema (Avro) for the message value",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -248,11 +251,11 @@
     "feel" : "required",
     "group" : "message",
     "binding" : {
-      "name" : "avro.schema",
+      "name" : "schemaStrategy.avro.schema",
       "type" : "zeebe:property"
     },
     "condition" : {
-      "property" : "type",
+      "property" : "schemaStrategy.type",
       "equals" : "inlineSchema",
       "type" : "simple"
     },

--- a/connectors/kafka/element-templates/kafka-inbound-connector-start-message.json
+++ b/connectors/kafka/element-templates/kafka-inbound-connector-start-message.json
@@ -178,12 +178,12 @@
       "value" : "earliest"
     } ]
   }, {
-    "id" : "type",
+    "id" : "schemaStrategy.type",
     "label" : "Schema strategy",
     "value" : "noSchema",
     "group" : "kafka",
     "binding" : {
-      "name" : "type",
+      "name" : "schemaStrategy.type",
       "type" : "zeebe:property"
     },
     "type" : "Dropdown",
@@ -198,18 +198,18 @@
       "value" : "schemaRegistry"
     } ]
   }, {
-    "id" : "schemaType",
+    "id" : "schemaStrategy.schemaType",
     "label" : "Schema type",
     "description" : "Select the schema type. For details, visit the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/kafka/?kafka=inbound\" target=\"_blank\">documentation</a>",
     "optional" : false,
     "value" : "avro",
     "group" : "kafka",
     "binding" : {
-      "name" : "schemaType",
+      "name" : "schemaStrategy.schemaType",
       "type" : "zeebe:property"
     },
     "condition" : {
-      "property" : "type",
+      "property" : "schemaStrategy.type",
       "equals" : "schemaRegistry",
       "type" : "simple"
     },
@@ -222,25 +222,28 @@
       "value" : "avro"
     } ]
   }, {
-    "id" : "schemaRegistryUrl",
+    "id" : "schemaStrategy.schemaRegistryUrl",
     "label" : "Schema registry URL",
     "description" : "Provide the schema registry URL",
     "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
     "group" : "kafka",
     "binding" : {
-      "name" : "schemaRegistryUrl",
+      "name" : "schemaStrategy.schemaRegistryUrl",
       "type" : "zeebe:property"
     },
     "condition" : {
-      "property" : "type",
+      "property" : "schemaStrategy.type",
       "equals" : "schemaRegistry",
       "type" : "simple"
     },
     "type" : "String"
   }, {
-    "id" : "avro.schema",
+    "id" : "schemaStrategy.avro.schema",
     "label" : "Schema",
-    "description" : "Inline schema (JSON or AVRO) for the message value",
+    "description" : "Inline schema (Avro) for the message value",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -248,11 +251,11 @@
     "feel" : "required",
     "group" : "message",
     "binding" : {
-      "name" : "avro.schema",
+      "name" : "schemaStrategy.avro.schema",
       "type" : "zeebe:property"
     },
     "condition" : {
-      "property" : "type",
+      "property" : "schemaStrategy.type",
       "equals" : "inlineSchema",
       "type" : "simple"
     },

--- a/connectors/kafka/element-templates/kafka-outbound-connector.json
+++ b/connectors/kafka/element-templates/kafka-outbound-connector.json
@@ -94,12 +94,12 @@
     },
     "type" : "String"
   }, {
-    "id" : "type",
+    "id" : "schemaStrategy.type",
     "label" : "Schema strategy",
     "value" : "noSchema",
     "group" : "kafka",
     "binding" : {
-      "name" : "type",
+      "name" : "schemaStrategy.type",
       "type" : "zeebe:input"
     },
     "type" : "Dropdown",
@@ -114,18 +114,18 @@
       "value" : "schemaRegistry"
     } ]
   }, {
-    "id" : "schemaType",
+    "id" : "schemaStrategy.schemaType",
     "label" : "Schema type",
     "description" : "Select the schema type. For details, visit the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/kafka/?kafka=inbound\" target=\"_blank\">documentation</a>",
     "optional" : false,
     "value" : "avro",
     "group" : "kafka",
     "binding" : {
-      "name" : "schemaType",
+      "name" : "schemaStrategy.schemaType",
       "type" : "zeebe:input"
     },
     "condition" : {
-      "property" : "type",
+      "property" : "schemaStrategy.type",
       "equals" : "schemaRegistry",
       "type" : "simple"
     },
@@ -138,18 +138,21 @@
       "value" : "avro"
     } ]
   }, {
-    "id" : "schemaRegistryUrl",
+    "id" : "schemaStrategy.schemaRegistryUrl",
     "label" : "Schema registry URL",
     "description" : "Provide the schema registry URL",
     "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
     "feel" : "optional",
     "group" : "kafka",
     "binding" : {
-      "name" : "schemaRegistryUrl",
+      "name" : "schemaStrategy.schemaRegistryUrl",
       "type" : "zeebe:input"
     },
     "condition" : {
-      "property" : "type",
+      "property" : "schemaStrategy.type",
       "equals" : "schemaRegistry",
       "type" : "simple"
     },
@@ -206,9 +209,9 @@
     },
     "type" : "String"
   }, {
-    "id" : "avro.schema",
+    "id" : "schemaStrategy.avro.schema",
     "label" : "Schema",
-    "description" : "Inline schema (JSON or AVRO) for the message value",
+    "description" : "Inline schema (Avro) for the message value",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -216,17 +219,17 @@
     "feel" : "required",
     "group" : "message",
     "binding" : {
-      "name" : "avro.schema",
+      "name" : "schemaStrategy.avro.schema",
       "type" : "zeebe:input"
     },
     "condition" : {
-      "property" : "type",
+      "property" : "schemaStrategy.type",
       "equals" : "inlineSchema",
       "type" : "simple"
     },
     "type" : "Text"
   }, {
-    "id" : "schema",
+    "id" : "schemaStrategy.schema",
     "label" : "Schema",
     "description" : "Schema (JSON or AVRO) for the message value",
     "optional" : false,
@@ -236,11 +239,11 @@
     "feel" : "required",
     "group" : "message",
     "binding" : {
-      "name" : "schema",
+      "name" : "schemaStrategy.schema",
       "type" : "zeebe:input"
     },
     "condition" : {
-      "property" : "type",
+      "property" : "schemaStrategy.type",
       "equals" : "schemaRegistry",
       "type" : "simple"
     },

--- a/connectors/kafka/src/main/java/io/camunda/connector/kafka/inbound/KafkaConnectorProperties.java
+++ b/connectors/kafka/src/main/java/io/camunda/connector/kafka/inbound/KafkaConnectorProperties.java
@@ -9,7 +9,6 @@ package io.camunda.connector.kafka.inbound;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.camunda.connector.feel.annotation.FEEL;
 import io.camunda.connector.generator.dsl.Property;
-import io.camunda.connector.generator.java.annotation.NestedProperties;
 import io.camunda.connector.generator.java.annotation.TemplateProperty;
 import io.camunda.connector.kafka.model.KafkaAuthentication;
 import io.camunda.connector.kafka.model.KafkaTopic;
@@ -75,7 +74,7 @@ public record KafkaConnectorProperties(
             description =
                 "What to do when there is no initial offset in Kafka or if the current offset does not exist any more on the server. You should only select none if you specified the offsets")
         AutoOffsetReset autoOffsetReset, // = AutoOffsetReset.NONE;
-    @Valid @NestedProperties(addNestedPath = false) InboundSchemaStrategy schemaStrategy) {
+    @Valid InboundSchemaStrategy schemaStrategy) {
 
   @Override
   public @Valid InboundSchemaStrategy schemaStrategy() {

--- a/connectors/kafka/src/main/java/io/camunda/connector/kafka/model/schema/AbstractSchemaRegistryStrategy.java
+++ b/connectors/kafka/src/main/java/io/camunda/connector/kafka/model/schema/AbstractSchemaRegistryStrategy.java
@@ -9,6 +9,7 @@ package io.camunda.connector.kafka.model.schema;
 
 import io.camunda.connector.generator.java.annotation.TemplateProperty;
 import io.camunda.connector.kafka.model.SchemaType;
+import jakarta.validation.constraints.NotBlank;
 
 public abstract class AbstractSchemaRegistryStrategy {
   @TemplateProperty(
@@ -25,10 +26,12 @@ public abstract class AbstractSchemaRegistryStrategy {
           "Select the schema type. For details, visit the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/kafka/?kafka=inbound\" target=\"_blank\">documentation</a>")
   SchemaType schemaType;
 
+  @NotBlank
   @TemplateProperty(
       group = "kafka",
       label = "Schema registry URL",
-      description = "Provide the schema registry URL")
+      description = "Provide the schema registry URL",
+      constraints = @TemplateProperty.PropertyConstraints(notEmpty = true))
   private String schemaRegistryUrl;
 
   AbstractSchemaRegistryStrategy(String schemaRegistryUrl, SchemaType schemaType) {

--- a/connectors/kafka/src/main/java/io/camunda/connector/kafka/outbound/KafkaConnectorFunction.java
+++ b/connectors/kafka/src/main/java/io/camunda/connector/kafka/outbound/KafkaConnectorFunction.java
@@ -30,9 +30,9 @@ import org.apache.kafka.clients.producer.RecordMetadata;
       "authentication",
       "topic",
       "message",
+      "schemaStrategy",
       "additionalProperties",
-      "headers",
-      "avro"
+      "headers"
     },
     type = "io.camunda:connector-kafka:1")
 @ElementTemplate(

--- a/connectors/kafka/src/main/java/io/camunda/connector/kafka/outbound/model/KafkaConnectorRequest.java
+++ b/connectors/kafka/src/main/java/io/camunda/connector/kafka/outbound/model/KafkaConnectorRequest.java
@@ -7,7 +7,6 @@
 package io.camunda.connector.kafka.outbound.model;
 
 import io.camunda.connector.generator.dsl.Property;
-import io.camunda.connector.generator.java.annotation.NestedProperties;
 import io.camunda.connector.generator.java.annotation.TemplateProperty;
 import io.camunda.connector.kafka.model.KafkaAuthentication;
 import io.camunda.connector.kafka.model.KafkaTopic;
@@ -22,7 +21,7 @@ public record KafkaConnectorRequest(
     @Valid KafkaAuthentication authentication,
     @Valid @NotNull KafkaTopic topic,
     @Valid @NotNull KafkaMessage message,
-    @Valid @NestedProperties(addNestedPath = false) OutboundSchemaStrategy schemaStrategy,
+    @Valid OutboundSchemaStrategy schemaStrategy,
     @TemplateProperty(
             group = "kafka",
             label = "Headers",


### PR DESCRIPTION
## Description

Some variables were not mapped because of the naming.

## Related issues

Related to:  https://github.com/camunda/team-connectors/issues/646

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.

