### PR TITLE
chore(inbound): Set the readiness to True when starting

### DIFF
--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/importer/ProcessDefinitionImporter.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/importer/ProcessDefinitionImporter.java
@@ -37,7 +37,7 @@ public class ProcessDefinitionImporter {
   private final ProcessDefinitionSearch search;
   private final MetricsRecorder metricsRecorder;
 
-  private boolean ready = false;
+  private boolean ready = true;
 
   @Autowired
   public ProcessDefinitionImporter(


### PR DESCRIPTION
## Description

Set the `ready` property to true by default, so the health check passes when the container starts. This would avoid issues when loading definitions is super long.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes https://github.com/camunda/team-connectors/issues/912

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.

