### PR TITLE
other(renovate): add no milestone label, include release 8.6

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -31,5 +31,5 @@
       "allowedVersions": "!/-SNAPSHOT$/"
     }
   ],
-  "baseBranches": ["main", "release/8.3", "release/8.4", "release/8.5"]
+  "baseBranches": ["main", "release/8.3", "release/8.4", "release/8.5", "release/8.6"]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -2,7 +2,7 @@
   "extends": [
     "config:base"
   ],
-  "labels": ["dependencies"],
+  "labels": ["dependencies", "no milestone"],
   "packageRules": [
     {
       "matchManagers": ["maven"],


### PR DESCRIPTION
## Description

Without this label, all Renovate PR's will fail PR check.

Dependency upgrades (especially ones handled by Renovate) clutter the release milestones more than clarifying them.

## Related issues

<!-- Which issues are closed by this PR or are related -->

None

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.

