### PR TITLE
fix(postman): for 3322_NPE_when_empty_path_in_postman_collection

### DIFF
--- a/element-template-generator/postman-collections-parser/src/main/java/io/camunda/connector/generator/postman/utils/PostmanPathUtil.java
+++ b/element-template-generator/postman-collections-parser/src/main/java/io/camunda/connector/generator/postman/utils/PostmanPathUtil.java
@@ -59,7 +59,10 @@ public class PostmanPathUtil {
     var host = String.join(".", endpoint.request().url().host());
     pathSegments.add(host);
 
-    pathSegments.addAll(endpoint.request().url().path());
+    // fixes https://github.com/camunda/connectors/issues/3322
+    List<String> path =
+        endpoint.request().url().path() == null ? List.of() : endpoint.request().url().path();
+    pathSegments.addAll(path);
     return pathSegments.stream()
         .map(s -> s.replace("+", "_"))
         .map(


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
Introduced a check on a null path, in that case return an empty collection so that the extractPathFromUrl method can succeed.

## Related issues

<!-- Which issues are closed by this PR or are related -->
https://github.com/camunda/connectors/issues/3322

closes #3322

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.

