### PR TITLE
other(codeowners): exclude files Renovate often updates

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,4 @@
 # These owners will be the default owners for everything in the repo.
 * @camunda/connectors 
-* app/renovate-approve
+
+.github/renovate.json5

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,4 @@
 # These owners will be the default owners for everything in the repo.
 * @camunda/connectors 
 
-.github/renovate.json5
+renovate.json5

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,3 +2,5 @@
 * @camunda/connectors 
 
 renovate.json5
+.ci/preview-environments/charts/c8sm/Chart.yaml
+**/pom.xml

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,3 @@
 # These owners will be the default owners for everything in the repo.
-* @camunda/connectors app/renovate-approve
+* @camunda/connectors 
+* app/renovate-approve

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,6 +1,7 @@
 # These owners will be the default owners for everything in the repo.
 * @camunda/connectors 
 
+# These files are excluded so that Renovate can automatically merge dependency upgrades
 renovate.json5
 .ci/preview-environments/charts/c8sm/Chart.yaml
 **/pom.xml

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
 # These owners will be the default owners for everything in the repo.
-* @camunda/connectors
+* @camunda/connectors app/renovate-approve


### PR DESCRIPTION
## Description

This allows Renovate to automatically merge upgrades that pass status checks.

As discussed in PR comments, it is not currently possible to add the `renovate-approve` bot (or any GitHub App) as a codeowner.

## Related issues

<!-- Which issues are closed by this PR or are related -->

related https://github.com/camunda/team-connectors/issues/763

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.

