### PR TITLE
ci(release): enable force push to protected release branches

### DIFF
--- a/.github/workflows/RELEASE.yaml
+++ b/.github/workflows/RELEASE.yaml
@@ -14,6 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          token: ${{ secrets.PROTECTED_BRANCH_PAT }}
           ref: ${{ github.event.release.target_commitish }}
           fetch-depth: 0
 
@@ -247,7 +248,7 @@ jobs:
       - name: Commit and tag
         run: |
           git commit -am "ci: release version ${RELEASE_VERSION}"
-          git push origin ${RELEASE_BRANCH}
+          git push --force origin ${RELEASE_BRANCH}
           git tag -fa ${RELEASE_VERSION} -m "ci: release version ${RELEASE_VERSION}"
           git push --force origin ${RELEASE_VERSION}
 


### PR DESCRIPTION
# Description

Backport of #3309 to `release/8.4`.