### PR TITLE
ci(release): use force-with-lease when pushing

### DIFF
--- a/.github/workflows/RELEASE.yaml
+++ b/.github/workflows/RELEASE.yaml
@@ -248,9 +248,9 @@ jobs:
       - name: Commit and tag
         run: |
           git commit -am "ci: release version ${RELEASE_VERSION}"
-          git push --force origin ${RELEASE_BRANCH}
+          git push --force-with-lease origin ${RELEASE_BRANCH}
           git tag -fa ${RELEASE_VERSION} -m "ci: release version ${RELEASE_VERSION}"
-          git push --force origin ${RELEASE_VERSION}
+          git push --force-with-lease origin ${RELEASE_VERSION}
 
         env:
           RELEASE_VERSION: ${{ github.event.release.tag_name }}


### PR DESCRIPTION
## Description

Prevents commit loss when commits are added to the release branch while an RC is being created.

## Related issues

<!-- Which issues are closed by this PR or are related -->

related https://github.com/camunda/team-connectors/issues/763

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.

