### PR TITLE
other(codeowners): exclude files Renovate often updates (#3325)

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,7 @@
 # These owners will be the default owners for everything in the repo.
-* @camunda/connectors
+* @camunda/connectors 
+
+# These files are excluded so that Renovate can automatically merge dependency upgrades
+renovate.json5
+.ci/preview-environments/charts/c8sm/Chart.yaml
+**/pom.xml


### PR DESCRIPTION
## Description

2nd backport of https://github.com/camunda/connectors/pull/3325

Original backport was overwritten by retrying releasing 8.6.0-rc3.

## Related issues

<!-- Which issues are closed by this PR or are related -->

related https://github.com/camunda/team-connectors/issues/763

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.

