### PR TITLE
chore(tool-versions): use current Java, Maven versions

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-java temurin-17.0.12+7
-maven 3.8.4
+java temurin-21.0.1+12.0.LTS
+maven 3.9.9

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ For more information on Connectors, refer to the
 ## Contents
 
 * [License](#license)
+* [Setup](#setup)
 * [Create a Connector](#create-a-connector)
     * [Outbound Connector](#outbound-connector)
     * [Inbound Connector](#inbound-connector)
@@ -40,6 +41,15 @@ This is a multi-module project with different licenses applied to different modu
 * [Docker images](bundle) of the out-of-the-box Connectors for Camunda, bundled with a runtime
 
 When in doubt, refer to the `LICENSE` file in the respective module.
+
+## Setup
+
+Download these utilities:
+
+* [`make`](https://www.gnu.org/software/make/) for building
+* [`asdf`](https://asdf-vm.com/) for managing Java and Maven versions
+
+The [Connector SDK](connector-sdk) uses Java 17, unlike the rest of this repository.
 
 ## Create a Connector
 


### PR DESCRIPTION
## Description

Updating these manually because Renovate will not do this automatically.

Java 17 is still used in the Connector SDK. I edited the README to reflect this since nested `asdf` tool-version files are not supported.

## Related issues

follow-up from https://github.com/camunda/team-connectors/issues/921

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.

