### PR TITLE
fix(sqs): remove pattern validation in runtime, add override description to template

### DIFF
--- a/connectors/aws/aws-sqs/element-templates/aws-sqs-boundary-connector.json
+++ b/connectors/aws/aws-sqs/element-templates/aws-sqs-boundary-connector.json
@@ -149,13 +149,13 @@
   }, {
     "id" : "queue.queue.pollingWaitTime",
     "label" : "Polling wait time",
-    "description" : "The duration (in seconds) for which the call waits for a message to arrive in the queue before returning. See <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-sqs/?amazonsqs=inbound\" target=\"_blank\">documentation</a> for details",
+    "description" : "The duration (in seconds) for which the call waits for a message to arrive in the queue before returning. See <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-sqs/?amazonsqs=inbound\" target=\"_blank\">documentation</a> for details. A value of 0 will automatically be overridden to 1",
     "optional" : false,
     "value" : "20",
     "constraints" : {
       "notEmpty" : true,
       "pattern" : {
-        "value" : "^([1-9]?|1[0-9]|20|secrets\\..+)$"
+        "value" : "^([0-9]?|1[0-9]|20|secrets\\..+)$"
       }
     },
     "group" : "messagePollingProperties",

--- a/connectors/aws/aws-sqs/element-templates/aws-sqs-inbound-intermediate-connector.json
+++ b/connectors/aws/aws-sqs/element-templates/aws-sqs-inbound-intermediate-connector.json
@@ -149,13 +149,13 @@
   }, {
     "id" : "queue.queue.pollingWaitTime",
     "label" : "Polling wait time",
-    "description" : "The duration (in seconds) for which the call waits for a message to arrive in the queue before returning. See <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-sqs/?amazonsqs=inbound\" target=\"_blank\">documentation</a> for details",
+    "description" : "The duration (in seconds) for which the call waits for a message to arrive in the queue before returning. See <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-sqs/?amazonsqs=inbound\" target=\"_blank\">documentation</a> for details. A value of 0 will automatically be overridden to 1",
     "optional" : false,
     "value" : "20",
     "constraints" : {
       "notEmpty" : true,
       "pattern" : {
-        "value" : "^([1-9]?|1[0-9]|20|secrets\\..+)$"
+        "value" : "^([0-9]?|1[0-9]|20|secrets\\..+)$"
       }
     },
     "group" : "messagePollingProperties",

--- a/connectors/aws/aws-sqs/element-templates/aws-sqs-start-message.json
+++ b/connectors/aws/aws-sqs/element-templates/aws-sqs-start-message.json
@@ -149,13 +149,13 @@
   }, {
     "id" : "queue.queue.pollingWaitTime",
     "label" : "Polling wait time",
-    "description" : "The duration (in seconds) for which the call waits for a message to arrive in the queue before returning. See <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-sqs/?amazonsqs=inbound\" target=\"_blank\">documentation</a> for details",
+    "description" : "The duration (in seconds) for which the call waits for a message to arrive in the queue before returning. See <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-sqs/?amazonsqs=inbound\" target=\"_blank\">documentation</a> for details. A value of 0 will automatically be overridden to 1",
     "optional" : false,
     "value" : "20",
     "constraints" : {
       "notEmpty" : true,
       "pattern" : {
-        "value" : "^([1-9]?|1[0-9]|20|secrets\\..+)$"
+        "value" : "^([0-9]?|1[0-9]|20|secrets\\..+)$"
       }
     },
     "group" : "messagePollingProperties",

--- a/connectors/aws/aws-sqs/src/main/java/io/camunda/connector/inbound/model/SqsInboundQueueProperties.java
+++ b/connectors/aws/aws-sqs/src/main/java/io/camunda/connector/inbound/model/SqsInboundQueueProperties.java
@@ -44,8 +44,8 @@ public record SqsInboundQueueProperties(
             group = "messagePollingProperties",
             defaultValue = "20",
             description =
-                "The duration (in seconds) for which the call waits for a message to arrive in the queue before returning. See <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-sqs/?amazonsqs=inbound\" target=\"_blank\">documentation</a> for details",
+                "The duration (in seconds) for which the call waits for a message to arrive in the queue before returning. See <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-sqs/?amazonsqs=inbound\" target=\"_blank\">documentation</a> for details. A value of 0 will automatically be overridden to 1",
             feel = FeelMode.disabled)
-        @Pattern(regexp = "^([1-9]?|1[0-9]|20|secrets\\..+)$")
+        @Pattern(regexp = "^([0-9]?|1[0-9]|20|secrets\\..+)$")
         @NotBlank
         String pollingWaitTime) {}

--- a/connectors/http/rest/README.md
+++ b/connectors/http/rest/README.md
@@ -229,8 +229,9 @@ leading to the following result
 ```
 
 
-| Connector Info          |                        |
-|-------------------------|------------------------|
-| Type                    | io.camunda:http-json:1 |
-| Version                 | 8                      |
-| Supported element types |                        |
+| Connector Info            |                                                                       |
+| ---                       | ---                                                                   |
+| Type                      | io.camunda:http-json:1                                                            |
+| Version                   | 8                                                         |
+| Supported element types   |     |
+

--- a/connectors/http/rest/README.md
+++ b/connectors/http/rest/README.md
@@ -229,9 +229,8 @@ leading to the following result
 ```
 
 
-| Connector Info            |                                                                       |
-| ---                       | ---                                                                   |
-| Type                      | io.camunda:http-json:1                                                            |
-| Version                   | 8                                                         |
-| Supported element types   |     |
-
+| Connector Info          |                        |
+|-------------------------|------------------------|
+| Type                    | io.camunda:http-json:1 |
+| Version                 | 8                      |
+| Supported element types |                        |


### PR DESCRIPTION
## Description

These changes allow old SQS element templates to be used with the latest Connectors runtime

## Related issues

related https://github.com/camunda/team-connectors/issues/922

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.

