### PR TITLE
ci(backport-pr): use protected branch PAT

### DIFF
--- a/.github/workflows/BACKPORT_PR.yml
+++ b/.github/workflows/BACKPORT_PR.yml
@@ -29,9 +29,13 @@ jobs:
       )
     steps:
       - uses: actions/checkout@v4
+        with:
+          # PR created by GitHub Action bot will not trigger CI checks
+          token: ${{ secrets.PROTECTED_BRANCH_PAT }}
       - name: Create backport pull requests
         uses: korthout/backport-action@v3
         with:
+          github_token: ${{ secrets.PROTECTED_BRANCH_PAT }}
           experimental: >
             {
               "detect_merge_method": true


### PR DESCRIPTION
## Description

PR's created with the GitHub Actions bot do not automatically trigger required status checks.

It's possible to trigger the checks manually, but this workflow should prevent the need to do that.

[More details on why this works](https://stackoverflow.com/a/69169858)

## Related issues

related https://github.com/camunda/team-connectors/issues/763

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.

