### PR TITLE
ci(release): revert to force pushing release tag

### DIFF
--- a/.github/workflows/RELEASE.yaml
+++ b/.github/workflows/RELEASE.yaml
@@ -250,7 +250,7 @@ jobs:
           git commit -am "ci: release version ${RELEASE_VERSION}"
           git push --force-with-lease origin ${RELEASE_BRANCH}
           git tag -fa ${RELEASE_VERSION} -m "ci: release version ${RELEASE_VERSION}"
-          git push --force-with-lease origin ${RELEASE_VERSION}
+          git push --force origin ${RELEASE_VERSION}
 
         env:
           RELEASE_VERSION: ${{ github.event.release.tag_name }}


### PR DESCRIPTION
## Description

Since we're only pushing a tag, this shouldn't delete commits

Even if someone adds commits in the meantime, we still want to move the release tag to the commit we have just pushed.

Without this change, we'll see a "rejected stale info" error in CI

## Related issues

related https://github.com/camunda/team-connectors/issues/763

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.

