### PR TITLE
chore(spotless): remove .md spotless checks

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -718,7 +718,6 @@ limitations under the License.</license.inlineheader>
             <formats>
               <format>
                 <includes>
-                  <include>*.md</include>
                   <include>.gitignore</include>
                 </includes>
                 <trimTrailingWhitespace/>


### PR DESCRIPTION
## Description

Our release workflow creates a commit that increments the version in each POM file. This commit also makes changes to README.md files that then cause Spotless checks to fail.

[Example](https://github.com/camunda/connectors/commit/9d97dc8d0a0ec1fcfb4e39fed98476da07571879#diff-e18079e36bc2ab8d1876469f92bab9b92065e0cdc94da9e0b9a91b3ef2c8a7aa)

Since the primary purpose of the Spotless checks is to make our code style more consistent, I think this change is worthwhile.


## Related issues

closes https://github.com/camunda/team-connectors/issues/930

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.

