### PR TITLE
[Backport release/8.3] chore(spotless): remove .md spotless checks

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -674,7 +674,6 @@ limitations under the License.</license.inlineheader>
             <formats>
               <format>
                 <includes>
-                  <include>*.md</include>
                   <include>.gitignore</include>
                 </includes>
                 <trimTrailingWhitespace/>


### PR DESCRIPTION
# Description
Backport of #3384 to `release/8.3`.