### PR TITLE
ci(release): force push release tag

### DIFF
--- a/.github/workflows/RELEASE.yaml
+++ b/.github/workflows/RELEASE.yaml
@@ -250,7 +250,7 @@ jobs:
           git commit -am "ci: release version ${RELEASE_VERSION}"
           git push --force-with-lease origin ${RELEASE_BRANCH}
           git tag -fa ${RELEASE_VERSION} -m "ci: release version ${RELEASE_VERSION}"
-          git push --force-with-lease origin ${RELEASE_VERSION}
+          git push --force origin ${RELEASE_VERSION}
 
         env:
           RELEASE_VERSION: ${{ github.event.release.tag_name }}


### PR DESCRIPTION
# Description

Manual backport of #3380 to `release/8.5`.