### PR TITLE
fix(email-connector): send emails will always make the process fail

### DIFF
--- a/connectors/email/src/main/java/io/camunda/connector/email/client/jakarta/JakartaEmailActionExecutor.java
+++ b/connectors/email/src/main/java/io/camunda/connector/email/client/jakarta/JakartaEmailActionExecutor.java
@@ -275,8 +275,6 @@ public class JakartaEmailActionExecutor implements EmailActionExecutor {
         transport.sendMessage(message, message.getAllRecipients());
       }
       return new SendEmailResponse(smtpSendEmail.subject(), true);
-    } catch (SendFailedException e) {
-      return new SendEmailResponse(smtpSendEmail.subject(), false);
     } catch (MessagingException e) {
       throw new RuntimeException(e);
     }


### PR DESCRIPTION
## Description

Quick fix, the send email action will always fails if the mail cannot be sent

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #

## Checklist

- [ ] PR has a **milestone** or the `no milestone` label.

