### PR TITLE
fix(sqs): fail fast when queue does not exist

### DIFF
--- a/connectors/aws/aws-sqs/src/main/java/io/camunda/connector/inbound/SqsQueueConsumer.java
+++ b/connectors/aws/aws-sqs/src/main/java/io/camunda/connector/inbound/SqsQueueConsumer.java
@@ -54,6 +54,11 @@ public class SqsQueueConsumer implements Runnable {
     do {
       try {
         receiveMessageResult = sqsClient.receiveMessage(receiveMessageRequest);
+      } catch (Exception e) {
+        LOGGER.error("Failed to receive messages from SQS queue", e);
+        continue;
+      }
+      try {
         List<Message> messages = receiveMessageResult.getMessages();
         for (Message message : messages) {
           context.log(

--- a/connectors/aws/aws-sqs/src/test/java/io/camunda/connector/inbound/SqsExecutableTest.java
+++ b/connectors/aws/aws-sqs/src/test/java/io/camunda/connector/inbound/SqsExecutableTest.java
@@ -9,6 +9,7 @@ package io.camunda.connector.inbound;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.nio.file.Files.readString;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.atLeast;
@@ -19,6 +20,7 @@ import static org.mockito.Mockito.when;
 import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.services.sqs.AmazonSQS;
 import com.amazonaws.services.sqs.model.Message;
+import com.amazonaws.services.sqs.model.QueueDoesNotExistException;
 import com.amazonaws.services.sqs.model.ReceiveMessageRequest;
 import com.amazonaws.services.sqs.model.ReceiveMessageResult;
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -110,6 +112,9 @@ class SqsExecutableTest {
   @Test
   public void deactivateTest() {
     // Given
+    when(sqsClient.getQueueAttributes(any(), any())).thenReturn(null);
+    when(supplier.sqsClient(any(AWSCredentialsProvider.class), eq(ACTUAL_QUEUE_REGION)))
+        .thenReturn(sqsClient);
     Map<String, Object> properties =
         Map.of(
             "authentication",
@@ -131,6 +136,30 @@ class SqsExecutableTest {
     assertThat(consumer.isQueueConsumerActive()).isFalse();
     assertThat(context.getHealth()).isEqualTo(Health.down());
     assertThat(executorService.isShutdown()).isTrue();
+  }
+
+  @Test
+  public void nonExistingQueueTest() {
+    // Given
+    when(sqsClient.getQueueAttributes(any(), any())).thenThrow(new QueueDoesNotExistException(""));
+    when(supplier.sqsClient(any(AWSCredentialsProvider.class), eq(ACTUAL_QUEUE_REGION)))
+        .thenReturn(sqsClient);
+    Map<String, Object> properties =
+        Map.of(
+            "authentication",
+            Map.of(
+                "secretKey", ACTUAL_SECRET_KEY,
+                "accessKey", ACTUAL_ACCESS_KEY),
+            "configuration",
+            Map.of("region", "us-east-1"),
+            "queue",
+            Map.of("url", ACTUAL_QUEUE_URL, "pollingWaitTime", "1"));
+    var context = createConnectorContext(properties, createDefinition());
+    consumer = new SqsQueueConsumer(sqsClient, new SqsInboundProperties(), context);
+    consumer.setQueueConsumerActive(true);
+    SqsExecutable sqsExecutable = new SqsExecutable(supplier, executorService, consumer);
+    // When & then
+    assertThrows(RuntimeException.class, () -> sqsExecutable.activate(context));
   }
 
   private InboundConnectorDefinition createDefinition() {


### PR DESCRIPTION
## Description

This PR adds a check on the SQS inbound connector startup to handle cases when the queue doesn't exist.

## Related issues


related #3405 

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.

