### PR TITLE
chore(element-templates): Replace deprecated Zeebe binding by the new version

### DIFF
--- a/connectors/asana/element-templates/asana-connector.json
+++ b/connectors/asana/element-templates/asana-connector.json
@@ -41,7 +41,8 @@
       "type": "Hidden",
       "value": "io.camunda:http-json:1",
       "binding": {
-        "type": "zeebe:taskDefinition:type"
+        "type": "zeebe:taskDefinition",
+        "property": "type"
       }
     },
     {

--- a/connectors/aws/aws-base/README.md
+++ b/connectors/aws/aws-base/README.md
@@ -1,9 +1,14 @@
-#  Camunda Amazon Web Services (AWS) Connector
-This is a base connector that provides common functionality for working with AWS services. It provides an abstract implementation of `io.camunda.connector.io.camunda.connector.aws.model.AwsService` that can be extended to implement AWS-specific services.
+# Camunda Amazon Web Services (AWS) Connector
+
+This is a base connector that provides common functionality for working with AWS services. It provides an abstract
+implementation of `io.camunda.connector.io.camunda.connector.aws.model.AwsService` that can be extended to implement
+AWS-specific services.
 
 ## Service implementation
 
- - For implementing AWS service connector template, you need to use the following task definition type: io.camunda:aws:1. Here's an example of an AWS service connector template that uses AWS Base Connector as the entry point:
+- For implementing AWS service connector template, you need to use the following task definition type: io.camunda:aws:1.
+  Here's an example of an AWS service connector template that uses AWS Base Connector as the entry point:
+
 ```json
 {
   "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
@@ -27,7 +32,8 @@ This is a base connector that provides common functionality for working with AWS
       "type": "Hidden",
       "value": "io.camunda:aws:1",
       "binding": {
-        "type": "zeebe:taskDefinition:type"
+        "type": "zeebe:taskDefinition",
+        "property": "type"
       }
     },
     {
@@ -45,9 +51,16 @@ This is a base connector that provides common functionality for working with AWS
 }
 ```
 
-
 ## Implemented services :
+
 ### AWS DynamoDB Connector
-The [AWS DynamoDB Connector](https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/aws-dynamodb/) allows you to connect your BPMN service with [Amazon Web Service's DynamoDB Service](https://aws.amazon.com/dynamodb/). This can be useful for performing CRUD operations on AWS DynamoDB tables from within a BPMN process.
+
+The [AWS DynamoDB Connector](https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/aws-dynamodb/)
+allows you to connect your BPMN service with [Amazon Web Service's DynamoDB Service](https://aws.amazon.com/dynamodb/).
+This can be useful for performing CRUD operations on AWS DynamoDB tables from within a BPMN process.
+
 ### AWS EventBridge Connector
-The [AWS EventBridge Connector](https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/aws-eventbridge/) allows you to send events from your BPMN service to [Amazon Web Service's EventBridge Service](https://aws.amazon.com/eventbridge/).
+
+The [AWS EventBridge Connector](https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/aws-eventbridge/)
+allows you to send events from your BPMN service
+to [Amazon Web Service's EventBridge Service](https://aws.amazon.com/eventbridge/).

--- a/connectors/blue-prism/element-templates/blue-prism-connector.json
+++ b/connectors/blue-prism/element-templates/blue-prism-connector.json
@@ -46,7 +46,8 @@
       "type": "Hidden",
       "value": "io.camunda:http-json:1",
       "binding": {
-        "type": "zeebe:taskDefinition:type"
+        "type": "zeebe:taskDefinition",
+        "property": "type"
       }
     },
     {

--- a/connectors/github/element-templates/github-connector.json
+++ b/connectors/github/element-templates/github-connector.json
@@ -49,7 +49,8 @@
       "type": "Hidden",
       "value": "io.camunda:http-json:1",
       "binding": {
-        "type": "zeebe:taskDefinition:type"
+        "type": "zeebe:taskDefinition",
+        "property": "type"
       }
     },
     {

--- a/connectors/gitlab/element-templates/gitlab-connector.json
+++ b/connectors/gitlab/element-templates/gitlab-connector.json
@@ -40,7 +40,8 @@
       "type": "Hidden",
       "value": "io.camunda:http-json:1",
       "binding": {
-        "type": "zeebe:taskDefinition:type"
+        "type": "zeebe:taskDefinition",
+        "property": "type"
       }
     },
     {

--- a/connectors/google-maps-platform/element-templates/google-maps-platform-connector.json
+++ b/connectors/google-maps-platform/element-templates/google-maps-platform-connector.json
@@ -46,7 +46,8 @@
       "type": "Hidden",
       "value": "io.camunda:http-json:1",
       "binding": {
-        "type": "zeebe:taskDefinition:type"
+        "type": "zeebe:taskDefinition",
+        "property": "type"
       }
     },
     {

--- a/connectors/hugging-face/element-templates/hugging-face-connector.json
+++ b/connectors/hugging-face/element-templates/hugging-face-connector.json
@@ -4,7 +4,7 @@
   "id": "io.camunda.connectors.HuggingFace.v1",
   "version": 1,
   "description": "Interact with Hugging Face inference API",
-  "documentationRef" : "https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/hugging-face/",
+  "documentationRef": "https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/hugging-face/",
   "category": {
     "id": "connectors",
     "name": "Connectors"
@@ -38,7 +38,8 @@
       "type": "Hidden",
       "value": "io.camunda:http-json:1",
       "binding": {
-        "type": "zeebe:taskDefinition:type"
+        "type": "zeebe:taskDefinition",
+        "property": "type"
       }
     },
     {

--- a/connectors/openai/element-templates/openai-connector.json
+++ b/connectors/openai/element-templates/openai-connector.json
@@ -41,7 +41,8 @@
       "type": "Hidden",
       "value": "io.camunda:http-json:1",
       "binding": {
-        "type": "zeebe:taskDefinition:type"
+        "type": "zeebe:taskDefinition",
+        "property": "type"
       }
     },
     {

--- a/connectors/operate/element-templates/operate-connector.json
+++ b/connectors/operate/element-templates/operate-connector.json
@@ -46,7 +46,8 @@
       "type": "Hidden",
       "value": "io.camunda:http-json:1",
       "binding": {
-        "type": "zeebe:taskDefinition:type"
+        "type": "zeebe:taskDefinition",
+        "property": "type"
       }
     },
     {

--- a/connectors/salesforce/element-templates/salesforce-connector.json
+++ b/connectors/salesforce/element-templates/salesforce-connector.json
@@ -49,7 +49,8 @@
       "type": "Hidden",
       "value": "io.camunda:http-json:1",
       "binding": {
-        "type": "zeebe:taskDefinition:type"
+        "type": "zeebe:taskDefinition",
+        "property": "type"
       }
     },
     {
@@ -281,7 +282,7 @@
       "description": "Map of query parameters to add to the request URL",
       "group": "input",
       "type": "String",
-      "feel":"required",
+      "feel": "required",
       "binding": {
         "type": "zeebe:input",
         "name": "queryParameters"


### PR DESCRIPTION
## Description

Replace old deprecated binding by the new version of it.

## Related issues

Related to:  https://github.com/camunda/team-connectors/issues/927

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.

