### PR TITLE
ci(backport-pr): prevent loop on backport fail

### DIFF
--- a/.github/workflows/BACKPORT_PR.yml
+++ b/.github/workflows/BACKPORT_PR.yml
@@ -25,7 +25,7 @@ jobs:
         github.event_name == 'issue_comment' &&
         github.event.issue.pull_request &&
         github.event.comment.user.id != 97796249 &&
-        contains(github.event.comment.body, '/backport')
+        startsWith(github.event.comment.body, '/backport')
       )
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Description

Backport fail comments often contain the text "/backport" as part of the branch name in suggested Git commands

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes https://github.com/camunda/team-connectors/issues/939

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.

