### PR TITLE
ci(helm-git-refs): use new refs after 8.6 release

### DIFF
--- a/.github/workflows/helm-git-refs.json
+++ b/.github/workflows/helm-git-refs.json
@@ -1,7 +1,8 @@
 {
   "main": "camunda-platform-alpha",
-  "release/8.6": "camunda-platform-alpha",
-  "release/8.5": "camunda-platform-latest",
+  "release/8.7": "camunda-platform-alpha",
+  "release/8.6": "camunda-platform-8.6",
+  "release/8.5": "camunda-platform-8.5",
   "release/8.4": "camunda-platform-8.4",
   "release/8.3": "camunda-platform-8.3"
 }


### PR DESCRIPTION
## Description

`camunda-platform-latest` is [no longer supported](https://github.com/camunda/camunda-platform-helm/blob/dc8877d419a456b2ff671e448165b5ba3af3ac99/charts/camunda-platform-latest/README.md).

We should use `camunda-platform-8.6` instead.

## Related issues

<!-- Which issues are closed by this PR or are related -->

related https://github.com/camunda/team-connectors/issues/943

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.

