### PR TITLE
[Backport release/8.6] ci(helm-git-refs): use new refs after 8.6 release

### DIFF
--- a/.github/workflows/helm-git-refs.json
+++ b/.github/workflows/helm-git-refs.json
@@ -1,7 +1,8 @@
 {
   "main": "camunda-platform-alpha",
-  "release/8.6": "camunda-platform-alpha",
-  "release/8.5": "camunda-platform-latest",
+  "release/8.7": "camunda-platform-alpha",
+  "release/8.6": "camunda-platform-8.6",
+  "release/8.5": "camunda-platform-8.5",
   "release/8.4": "camunda-platform-8.4",
   "release/8.3": "camunda-platform-8.3"
 }


### PR DESCRIPTION
# Description
Backport of #3468 to `release/8.6`.