### PR TITLE
fix(rest): Add retries and synchronize OAuth credentials init for the Cloud Function

### DIFF
--- a/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/cloudfunction/CloudFunctionCredentialsCache.java
+++ b/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/cloudfunction/CloudFunctionCredentialsCache.java
@@ -26,6 +26,7 @@ import org.slf4j.LoggerFactory;
 
 public class CloudFunctionCredentialsCache {
 
+  public static final int MAX_ATTEMPTS = 3;
   private static final Logger LOG = LoggerFactory.getLogger(CloudFunctionCredentialsCache.class);
   private OAuth2Credentials credentials;
 
@@ -36,7 +37,7 @@ public class CloudFunctionCredentialsCache {
    * @return Optional of credentials
    */
   public synchronized OAuth2Credentials get(Supplier<OAuth2Credentials> credentialsSupplier) {
-    return getWithRetries(credentialsSupplier, 3);
+    return getWithRetries(credentialsSupplier, MAX_ATTEMPTS);
   }
 
   private OAuth2Credentials getWithRetries(


### PR DESCRIPTION
## Description

- Catch exception when refreshing the OAuth token for the Cloud Function
- Add retry
- Log exception

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes [#932](https://github.com/camunda/team-connectors/issues/932)

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.

