### PR TITLE
feat(restart-inbound): give the possibility to the developer to plan a restart of the connector in case of failure

### DIFF
--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/error/RestartException.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/error/RestartException.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.runtime.core.error;
+
+import java.time.Duration;
+
+public class RestartException extends RuntimeException {
+
+  private final Duration backoffTime;
+
+  public RestartException(String message, Throwable cause, Duration backoffTime) {
+    super(message, cause);
+    this.backoffTime = backoffTime;
+  }
+
+  public Duration getBackoffTime() {
+    return backoffTime;
+  }
+}

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/DefaultInboundConnectorContextFactory.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/DefaultInboundConnectorContextFactory.java
@@ -18,6 +18,7 @@ package io.camunda.connector.runtime.core.inbound;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.EvictingQueue;
+import io.camunda.connector.api.inbound.Activity;
 import io.camunda.connector.api.inbound.InboundConnectorContext;
 import io.camunda.connector.api.inbound.InboundConnectorExecutable;
 import io.camunda.connector.api.inbound.InboundIntermediateConnectorContext;
@@ -28,6 +29,7 @@ import io.camunda.connector.runtime.core.secret.SecretProviderAggregator;
 import io.camunda.document.factory.DocumentFactory;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
+import java.time.Duration;
 import java.util.function.Consumer;
 
 public class DefaultInboundConnectorContextFactory implements InboundConnectorContextFactory {
@@ -57,8 +59,9 @@ public class DefaultInboundConnectorContextFactory implements InboundConnectorCo
   public <T extends InboundConnectorExecutable<?>> InboundConnectorContext createContext(
       final ValidInboundConnectorDetails connectorDetails,
       final Consumer<Throwable> cancellationCallback,
+      final Consumer<Duration> reactivationCallback,
       final Class<T> executableClass,
-      final EvictingQueue queue) {
+      final EvictingQueue<Activity> queue) {
 
     InboundConnectorReportingContext inboundContext =
         new InboundConnectorContextImpl(
@@ -68,6 +71,7 @@ public class DefaultInboundConnectorContextFactory implements InboundConnectorCo
             connectorDetails,
             correlationHandler,
             cancellationCallback,
+            reactivationCallback,
             objectMapper,
             queue);
 

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextFactory.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextFactory.java
@@ -17,9 +17,11 @@
 package io.camunda.connector.runtime.core.inbound;
 
 import com.google.common.collect.EvictingQueue;
+import io.camunda.connector.api.inbound.Activity;
 import io.camunda.connector.api.inbound.InboundConnectorContext;
 import io.camunda.connector.api.inbound.InboundConnectorExecutable;
 import io.camunda.connector.runtime.core.inbound.details.InboundConnectorDetails.ValidInboundConnectorDetails;
+import java.time.Duration;
 import java.util.function.Consumer;
 
 /**
@@ -50,6 +52,7 @@ public interface InboundConnectorContextFactory {
   <T extends InboundConnectorExecutable<?>> InboundConnectorContext createContext(
       final ValidInboundConnectorDetails connectorDetails,
       final Consumer<Throwable> cancellationCallback,
+      final Consumer<Duration> reactivationCallback,
       final Class<T> executableClass,
-      final EvictingQueue queue);
+      final EvictingQueue<Activity> queue);
 }

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/inbound/DefaultInboundConnectorContextFactoryTest.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/inbound/DefaultInboundConnectorContextFactoryTest.java
@@ -28,6 +28,7 @@ import io.camunda.connector.runtime.core.inbound.correlation.InboundCorrelationH
 import io.camunda.connector.runtime.core.inbound.details.InboundConnectorDetails.ValidInboundConnectorDetails;
 import io.camunda.connector.runtime.core.secret.SecretProviderAggregator;
 import io.camunda.document.factory.DocumentFactory;
+import java.time.Duration;
 import java.util.function.Consumer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -44,6 +45,7 @@ class DefaultInboundConnectorContextFactoryTest {
   @Mock private ValidationProvider validationProvider;
   @Mock private OperateClientAdapter operateClientAdapter;
   @Mock private Consumer<Throwable> cancellationCallback;
+  @Mock private Consumer<Duration> reactivationCallback;
   @Mock private ValidInboundConnectorDetails newConnector;
   @Mock private DocumentFactory documentFactory;
   private DefaultInboundConnectorContextFactory factory;
@@ -66,6 +68,7 @@ class DefaultInboundConnectorContextFactoryTest {
         factory.createContext(
             newConnector,
             cancellationCallback,
+            reactivationCallback,
             ExecutableWithInboundContext.class,
             EvictingQueue.create(10));
 
@@ -78,6 +81,7 @@ class DefaultInboundConnectorContextFactoryTest {
         factory.createContext(
             newConnector,
             cancellationCallback,
+            reactivationCallback,
             ExecutableWithEmptyParameterizedType.class,
             EvictingQueue.create(10));
 
@@ -91,6 +95,7 @@ class DefaultInboundConnectorContextFactoryTest {
         factory.createContext(
             newConnector,
             cancellationCallback,
+            reactivationCallback,
             ExecutableWithIntermediate.class,
             EvictingQueue.create(10));
 

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImplTest.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImplTest.java
@@ -41,6 +41,21 @@ class InboundConnectorContextImplTest {
   private final SecretProvider secretProvider = new FooBarSecretProvider();
   private final ObjectMapper mapper = ConnectorsObjectMapperSupplier.DEFAULT_MAPPER;
 
+  @NotNull
+  private static ValidInboundConnectorDetails getInboundConnectorDefinition(
+      Map<String, String> properties) {
+    properties = new HashMap<>(properties);
+    properties.put("inbound.type", "io.camunda:connector:1");
+    InboundConnectorElement element =
+        new InboundConnectorElement(
+            properties,
+            new StandaloneMessageCorrelationPoint("", "", null, null),
+            new ProcessElement("bool", 0, 0, "id", "<default>"));
+    var details = InboundConnectorDetails.of(element.deduplicationId(List.of()), List.of(element));
+    assertThat(details).isInstanceOf(ValidInboundConnectorDetails.class);
+    return (ValidInboundConnectorDetails) details;
+  }
+
   @Test
   void bindProperties_shouldThrowExceptionWhenWrongFormat() {
     // given
@@ -52,6 +67,7 @@ class InboundConnectorContextImplTest {
             definition,
             null,
             (e) -> {},
+            (d) -> {},
             mapper,
             EvictingQueue.create(10));
     // when and then
@@ -73,6 +89,7 @@ class InboundConnectorContextImplTest {
             definition,
             null,
             (e) -> {},
+            (d) -> {},
             mapper,
             EvictingQueue.create(10));
     // when
@@ -98,6 +115,7 @@ class InboundConnectorContextImplTest {
             definition,
             null,
             (e) -> {},
+            (d) -> {},
             mapper,
             EvictingQueue.create(10));
     // when
@@ -106,21 +124,6 @@ class InboundConnectorContextImplTest {
     // then
     assertThat(propertiesAsType.getMapWithStringListWithNumbers().get("key").getFirst())
         .isInstanceOf(String.class);
-  }
-
-  @NotNull
-  private static ValidInboundConnectorDetails getInboundConnectorDefinition(
-      Map<String, String> properties) {
-    properties = new HashMap<>(properties);
-    properties.put("inbound.type", "io.camunda:connector:1");
-    InboundConnectorElement element =
-        new InboundConnectorElement(
-            properties,
-            new StandaloneMessageCorrelationPoint("", "", null, null),
-            new ProcessElement("bool", 0, 0, "id", "<default>"));
-    var details = InboundConnectorDetails.of(element.deduplicationId(List.of()), List.of(element));
-    assertThat(details).isInstanceOf(ValidInboundConnectorDetails.class);
-    return (ValidInboundConnectorDetails) details;
   }
 
   @Test
@@ -156,6 +159,7 @@ class InboundConnectorContextImplTest {
             definition,
             null,
             (e) -> {},
+            (d) -> {},
             mapper,
             EvictingQueue.create(10));
     // when
@@ -177,6 +181,7 @@ class InboundConnectorContextImplTest {
             definition,
             null,
             (e) -> {},
+            (d) -> {},
             mapper,
             EvictingQueue.create(10));
 
@@ -265,8 +270,6 @@ class InboundConnectorContextImplTest {
       this.bool = bool;
     }
 
-    public record InnerObject(List<String> stringList, boolean bool) {}
-
     @Override
     public boolean equals(final Object o) {
       if (this == o) return true;
@@ -325,5 +328,7 @@ class InboundConnectorContextImplTest {
           + bool
           + "}";
     }
+
+    public record InnerObject(List<String> stringList, boolean bool) {}
   }
 }

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/executable/RegisteredExecutable.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/executable/RegisteredExecutable.java
@@ -16,6 +16,7 @@
  */
 package io.camunda.connector.runtime.inbound.executable;
 
+import io.camunda.connector.api.inbound.InboundConnectorContext;
 import io.camunda.connector.api.inbound.InboundConnectorExecutable;
 import io.camunda.connector.runtime.core.inbound.InboundConnectorReportingContext;
 import io.camunda.connector.runtime.core.inbound.details.InboundConnectorDetails;
@@ -25,7 +26,8 @@ import io.camunda.connector.runtime.core.inbound.details.InboundConnectorDetails
 public sealed interface RegisteredExecutable {
 
   record Activated(
-      InboundConnectorExecutable<?> executable, InboundConnectorReportingContext context)
+      InboundConnectorExecutable<InboundConnectorContext> executable,
+      InboundConnectorReportingContext context)
       implements RegisteredExecutable {}
 
   record ConnectorNotRegistered(ValidInboundConnectorDetails data)

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/inbound/executable/InboundExecutableRegistryTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/inbound/executable/InboundExecutableRegistryTest.java
@@ -123,7 +123,7 @@ public class InboundExecutableRegistryTest {
             new ProcessElement("id", 0, 0, elementId, "tenant"));
     var executable = mock(InboundConnectorExecutable.class);
     var context = mock(InboundConnectorContextImpl.class);
-    when(contextFactory.createContext(any(), any(), any(), any())).thenReturn(context);
+    when(contextFactory.createContext(any(), any(), any(), any(), any())).thenReturn(context);
 
     when(factory.getInstance(any())).thenReturn(executable);
 
@@ -148,7 +148,7 @@ public class InboundExecutableRegistryTest {
     doThrow(new RuntimeException("failed")).when(executable).activate(any());
 
     var mockContext = mock(InboundConnectorContextImpl.class);
-    when(contextFactory.createContext(any(), any(), any(), any())).thenReturn(mockContext);
+    when(contextFactory.createContext(any(), any(), any(), any(), any())).thenReturn(mockContext);
 
     doThrow(new RuntimeException("failed")).when(executable).activate(any());
 
@@ -185,7 +185,7 @@ public class InboundExecutableRegistryTest {
     when(mockContext.getDefinition())
         .thenReturn(new InboundConnectorDefinition("type", "tenant", "id", null));
     when(mockContext.getHealth()).thenReturn(Health.up());
-    when(contextFactory.createContext(any(), any(), any(), any())).thenReturn(mockContext);
+    when(contextFactory.createContext(any(), any(), any(), any(), any())).thenReturn(mockContext);
 
     doThrow(new RuntimeException("failed")).when(executable2).activate(mockContext);
 
@@ -232,7 +232,7 @@ public class InboundExecutableRegistryTest {
     when(mockContext.getDefinition())
         .thenReturn(new InboundConnectorDefinition("type", "tenant", "id", null));
     when(mockContext.getHealth()).thenReturn(Health.up());
-    when(contextFactory.createContext(any(), any(), any(), any())).thenReturn(mockContext);
+    when(contextFactory.createContext(any(), any(), any(), any(), any())).thenReturn(mockContext);
 
     // when
     registry.handleEvent(new Activated("tenant", 0, List.of(element1, element2)));

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/inbound/WebhookControllerTestZeebeTests.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/inbound/WebhookControllerTestZeebeTests.java
@@ -106,6 +106,7 @@ class WebhookControllerTestZeebeTests {
             webhookDef,
             correlationHandler,
             (e) -> {},
+            (d) -> {},
             mapper,
             EvictingQueue.create(10));
 
@@ -147,6 +148,7 @@ class WebhookControllerTestZeebeTests {
             webhookDef,
             correlationHandler,
             (e) -> {},
+            (d) -> {},
             mapper,
             EvictingQueue.create(10));
 
@@ -194,6 +196,7 @@ class WebhookControllerTestZeebeTests {
             webhookDef,
             correlationHandlerMock,
             (e) -> {},
+            (d) -> {},
             mapper,
             EvictingQueue.create(10));
 
@@ -235,6 +238,7 @@ class WebhookControllerTestZeebeTests {
             webhookDef,
             correlationHandlerMock,
             (e) -> {},
+            (d) -> {},
             mapper,
             EvictingQueue.create(10));
 
@@ -284,6 +288,7 @@ class WebhookControllerTestZeebeTests {
             webhookDef,
             correlationHandlerMock,
             (e) -> {},
+            (d) -> {},
             mapper,
             EvictingQueue.create(10));
 
@@ -322,6 +327,7 @@ class WebhookControllerTestZeebeTests {
             webhookDef,
             correlationHandler,
             (e) -> {},
+            (d) -> {},
             mapper,
             EvictingQueue.create(10));
 
@@ -360,6 +366,7 @@ class WebhookControllerTestZeebeTests {
             webhookDefinition,
             correlationHandler,
             (e) -> {},
+            (d) -> {},
             mapper,
             EvictingQueue.create(10));
 
@@ -393,6 +400,7 @@ class WebhookControllerTestZeebeTests {
             webhookDef,
             correlationHandler,
             (e) -> {},
+            (d) -> {},
             mapper,
             EvictingQueue.create(10));
 
@@ -428,6 +436,7 @@ class WebhookControllerTestZeebeTests {
             webhookDef,
             correlationHandler,
             (e) -> {},
+            (d) -> {},
             mapper,
             EvictingQueue.create(10));
 
@@ -451,8 +460,6 @@ class WebhookControllerTestZeebeTests {
     assertEquals("expression", responseEntity.getBody().expression());
   }
 
-  interface MyVerifiableWebhook extends WebhookConnectorExecutable {}
-
   @Test
   @SuppressWarnings("unchecked")
   public void testSuccessfulProcessingWithVerification() throws Exception {
@@ -475,6 +482,7 @@ class WebhookControllerTestZeebeTests {
             webhookDef,
             correlationHandler,
             (e) -> {},
+            (d) -> {},
             mapper,
             EvictingQueue.create(10));
 
@@ -533,6 +541,7 @@ class WebhookControllerTestZeebeTests {
             webhookDef,
             correlationHandlerMock,
             (e) -> {},
+            (d) -> {},
             mapper,
             EvictingQueue.create(10));
 
@@ -565,4 +574,6 @@ class WebhookControllerTestZeebeTests {
         .send()
         .join();
   }
+
+  interface MyVerifiableWebhook extends WebhookConnectorExecutable {}
 }

--- a/connectors/http/polling/src/test/java/io/camunda/connector/http/polling/model/PollingIntervalConfigurationTest.java
+++ b/connectors/http/polling/src/test/java/io/camunda/connector/http/polling/model/PollingIntervalConfigurationTest.java
@@ -46,6 +46,7 @@ public class PollingIntervalConfigurationTest {
             connectorData,
             null,
             (e) -> {},
+            (d) -> {},
             ConnectorsObjectMapperSupplier.getCopy(),
             EvictingQueue.create(10));
   }


### PR DESCRIPTION
## Description

Proposal of solution for the restart of inbound connector, not tested yet

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes https://github.com/camunda/connectors/issues/3319

## Checklist

- [ ] PR has a **milestone** or the `no milestone` label.

