### PR TITLE
fix(preview-environments): Adapt to C8 Helm chart v11

### DIFF
--- a/.ci/preview-environments/charts/c8sm/templates/ingress.yml
+++ b/.ci/preview-environments/charts/c8sm/templates/ingress.yml
@@ -24,14 +24,14 @@ spec:
       paths:
       - backend:
           service:
-            name: {{ include "identity.keycloak.service" $camundaPlatform.Subcharts.identity }}
+            name: {{ include "identity.keycloak.service" $camundaPlatform }}
             port:
-              number: {{ include "identity.keycloak.port" $camundaPlatform.Subcharts.identity }}
-        path: {{ include "identity.keycloak.contextPath" $camundaPlatform.Subcharts.identity }}
+              number: {{ include "identity.keycloak.port" $camundaPlatform }}
+        path: {{ include "identity.keycloak.contextPath" $camundaPlatform }}
         pathType: Prefix
       - backend:
           service:
-            name: {{ template "identity.fullname" $camundaPlatform.Subcharts.identity }}
+            name: {{ template "identity.fullname" $camundaPlatform }}
             port:
               number: {{ .Values.camundaPlatform.identity.service.port }}
         path: {{ .Values.camundaPlatform.identity.contextPath }}

--- a/.ci/preview-environments/charts/c8sm/templates/service.yml
+++ b/.ci/preview-environments/charts/c8sm/templates/service.yml
@@ -14,7 +14,7 @@ spec:
   type: ExternalName
   externalName: {{ include "zeebe.names.gateway" $camundaPlatform }}.{{ .Release.Namespace }}.svc.cluster.local
 ---
-{{- $identityKeyCloak := $camundaPlatform.Subcharts.identity.Subcharts.keycloak -}}
+{{- $identityKeyCloak := $camundaPlatform.Subcharts.identityKeycloak -}}
 apiVersion: v1
 kind: Service
 metadata:

--- a/.ci/preview-environments/charts/c8sm/values.yaml
+++ b/.ci/preview-environments/charts/c8sm/values.yaml
@@ -34,7 +34,8 @@ global:
   # Camunda 8 Self-Managed global configurations
   elasticsearch:
     # necessary due to name override bugs
-    host: elasticsearch
+    url:
+      host: elasticsearch
   identity:
     auth:
       # Enable Camunda Identity-based authentication
@@ -368,7 +369,7 @@ camunda-platform:
         operator: "Exists"
         effect: "NoSchedule"
 
-  zeebe-gateway:
+  zeebeGateway:
     fullnameOverride: zeebe-cluster-gateway
     replicas: 1
     # image:

--- a/.ci/preview-environments/charts/c8sm/values.yaml
+++ b/.ci/preview-environments/charts/c8sm/values.yaml
@@ -164,52 +164,53 @@ camunda-platform:
     - key: "previews"
       operator: "Exists"
       effect: "NoSchedule"
-    keycloak:
-      enabled: true
-      fullnameOverride: identity-keycloak
+
+  identityKeycloak:
+    enabled: true
+    fullnameOverride: identity-keycloak
+    auth:
+      adminUser: admin
+      adminPassword: admin
+    externalDatabase:
+      password: postgresql
+    extraEnvVars:
+    - name: KEYCLOAK_PROXY_ADDRESS_FORWARDING
+      value: "true"
+    resources:
+      limits:
+        cpu: 1
+        memory: 1Gi
+      requests:
+        cpu: 500m
+        memory: 512Mi
+    nodeSelector:
+      cloud.google.com/gke-nodepool: previews
+    tolerations:
+    - key: "previews"
+      operator: "Exists"
+      effect: "NoSchedule"
+    postgresql:
+      fullnameOverride: identity-keycloak-postgresql
       auth:
-        adminUser: admin
-        adminPassword: admin
-      externalDatabase:
+        # fixed secret, to avoid generating a random password each time
         password: postgresql
-      extraEnvVars:
-      - name: KEYCLOAK_PROXY_ADDRESS_FORWARDING
-        value: "true"
-      resources:
-        limits:
-          cpu: 1
-          memory: 1Gi
-        requests:
-          cpu: 500m
-          memory: 512Mi
-      nodeSelector:
-        cloud.google.com/gke-nodepool: previews
-      tolerations:
-      - key: "previews"
-        operator: "Exists"
-        effect: "NoSchedule"
-      postgresql:
-        fullnameOverride: identity-keycloak-postgresql
-        auth:
-          # fixed secret, to avoid generating a random password each time
-          password: postgresql
-        primary:
-          persistence:
-            enabled: true
-            size: 1Gi
-          resources:
-            limits:
-              cpu: 500m
-              memory: 512Mi
-            requests:
-              cpu: 250m
-              memory: 256Mi
-          nodeSelector:
-            cloud.google.com/gke-nodepool: previews
-          tolerations:
-          - key: "previews"
-            operator: "Exists"
-            effect: "NoSchedule"
+      primary:
+        persistence:
+          enabled: true
+          size: 1Gi
+        resources:
+          limits:
+            cpu: 500m
+            memory: 512Mi
+          requests:
+            cpu: 250m
+            memory: 256Mi
+        nodeSelector:
+          cloud.google.com/gke-nodepool: previews
+        tolerations:
+        - key: "previews"
+          operator: "Exists"
+          effect: "NoSchedule"
 
   operate:
     enabled: true


### PR DESCRIPTION
## Description

fix(preview-environments): Adapt to C8 Helm chart v11

The preview environments code has recently been upgraded to use Helm charts v11 (https://github.com/camunda/connectors/pull/3476), but no corresponding follow-up adjustments have been done to the code to conform to it (breaking changes in [v10](https://docs.camunda.io/docs/8.5/self-managed/setup/upgrade/#update-your-configuration), [v11](https://docs.camunda.io/docs/self-managed/setup/upgrade/#helm-chart-1100))

- The separate Camunda-developed Identity subchart is not existent since v10 and has been integrated natively into the chart
- `identity.keycloak` became `identityKeycloak` ([ref](https://docs.camunda.io/docs/8.5/self-managed/setup/upgrade/#update-your-configuration))
- `elasticsearch.host` is now `elasticsearch.url.host`
- `zeebe-gateway` became `zeebeGateway`

## Related issues

Related: https://camunda.slack.com/archives/C5AHF1D8T/p1728980290646239

closes #

## Checklist

- [ ] PR has a **milestone** or the `no milestone` label.

