### PR TITLE
chore(logs): Add an endpoint to publish inbound logs

### DIFF
--- a/bundle/camunda-saas-bundle/src/main/java/io/camunda/connector/runtime/saas/security/SecurityConfiguration.java
+++ b/bundle/camunda-saas-bundle/src/main/java/io/camunda/connector/runtime/saas/security/SecurityConfiguration.java
@@ -16,6 +16,8 @@
  */
 package io.camunda.connector.runtime.saas.security;
 
+import static org.springframework.security.web.access.IpAddressAuthorizationManager.hasIpAddress;
+
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -35,6 +37,8 @@ import org.springframework.security.web.SecurityFilterChain;
 @EnableWebSecurity
 @Configuration
 public class SecurityConfiguration {
+
+  public static final String LOCALHOST_IPV4 = "127.0.0.1";
 
   @Value("${camunda.connector.auth.audience}")
   private String audience;
@@ -63,7 +67,12 @@ public class SecurityConfiguration {
                     .requestMatchers(HttpMethod.PUT, "/inbound/*")
                     .requestMatchers(HttpMethod.DELETE, "/inbound/*")
                     .requestMatchers("actuator/**"))
-        .authorizeHttpRequests(auth -> auth.anyRequest().permitAll())
+        .authorizeHttpRequests(
+            auth ->
+                auth.requestMatchers("/inbound/logs")
+                    .access(hasIpAddress(LOCALHOST_IPV4))
+                    .anyRequest()
+                    .permitAll())
         .build();
   }
 

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/controller/InboundConnectorRestController.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/controller/InboundConnectorRestController.java
@@ -22,6 +22,7 @@ import io.camunda.connector.runtime.core.inbound.InboundConnectorElement;
 import io.camunda.connector.runtime.inbound.executable.ActiveExecutableQuery;
 import io.camunda.connector.runtime.inbound.executable.ActiveExecutableResponse;
 import io.camunda.connector.runtime.inbound.executable.InboundExecutableRegistry;
+import io.camunda.connector.runtime.inbound.executable.InboundExecutableRegistryImpl;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -30,6 +31,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -50,6 +52,11 @@ public class InboundConnectorRestController {
       @RequestParam(required = false, value = "elementId") String elementId,
       @RequestParam(required = false, value = "type") String type) {
     return getActiveInboundConnectors(bpmnProcessId, elementId, type, null);
+  }
+
+  @PostMapping("/inbound/logs")
+  public void logActiveInboundConnectors() {
+    ((InboundExecutableRegistryImpl) executableRegistry).logStatusReport();
   }
 
   @GetMapping("/tenants/{tenantId}/inbound")


### PR DESCRIPTION
## Description

- New endpoint: `POST /inbound/logs` that will log the registered Inbound Connectors 
- Only accessible from Localhost even if not critical

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes [#931](https://github.com/camunda/team-connectors/issues/931)

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.

