### PR TITLE
others(operate-importer): add more logs during the import of process definitions

### DIFF
--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/importer/ProcessDefinitionImporter.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/importer/ProcessDefinitionImporter.java
@@ -65,6 +65,7 @@ public class ProcessDefinitionImporter {
     if (definitions.isEmpty()) {
       return;
     }
+    LOG.debug("Handle of the imported process definitions starts...");
     try {
       meter(definitions.size());
       var result =
@@ -78,6 +79,7 @@ public class ProcessDefinitionImporter {
                           definition ->
                               new ProcessDefinitionVersion(
                                   definition.getKey(), definition.getVersion().intValue()))));
+      LOG.info("Updating the store with retrieved process definitions");
       stateStore.update(result);
     } catch (Exception e) {
       LOG.error("Failed to handle imported definitions", e);

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/importer/ProcessDefinitionSearch.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/importer/ProcessDefinitionSearch.java
@@ -75,7 +75,7 @@ public class ProcessDefinitionSearch {
       }
       List<Object> newPaginationIdx = processDefinitionResult.getSortValues();
 
-      LOG.trace("A page of process definitions has been fetched, continuing...");
+      LOG.debug("A page of process definitions has been fetched, continuing...");
 
       if (!CollectionUtils.isEmpty(newPaginationIdx)) {
         paginationIndex = newPaginationIdx;
@@ -84,7 +84,7 @@ public class ProcessDefinitionSearch {
       // result is sorted by key in descending order, so we will always encounter the latest
       // version first
 
-      LOG.trace("Sorting process definition results by descending order");
+      LOG.debug("Sorting process definition results by descending order");
       var items =
           Optional.ofNullable(processDefinitionResult.getItems()).orElse(List.of()).stream()
               .filter(

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/importer/ProcessDefinitionSearch.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/importer/ProcessDefinitionSearch.java
@@ -75,6 +75,8 @@ public class ProcessDefinitionSearch {
       }
       List<Object> newPaginationIdx = processDefinitionResult.getSortValues();
 
+      LOG.trace("A page of process definitions has been fetched, continuing...");
+
       if (!CollectionUtils.isEmpty(newPaginationIdx)) {
         paginationIndex = newPaginationIdx;
       }
@@ -82,6 +84,7 @@ public class ProcessDefinitionSearch {
       // result is sorted by key in descending order, so we will always encounter the latest
       // version first
 
+      LOG.trace("Sorting process definition results by descending order");
       var items =
           Optional.ofNullable(processDefinitionResult.getItems()).orElse(List.of()).stream()
               .filter(
@@ -93,7 +96,7 @@ public class ProcessDefinitionSearch {
 
     } while (processDefinitionResult.getItems() != null
         && !processDefinitionResult.getItems().isEmpty());
-
+    LOG.debug("Fetching from Operate has been correctly executed.");
     return processDefinitions;
   }
 }

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/state/ProcessStateStoreImpl.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/state/ProcessStateStoreImpl.java
@@ -37,12 +37,6 @@ public class ProcessStateStoreImpl implements ProcessStateStore {
   private final ProcessDefinitionInspector processDefinitionInspector;
   private final InboundExecutableRegistry executableRegistry;
 
-  private record ProcessState(
-      int version,
-      long processDefinitionKey,
-      String tenantId,
-      List<InboundConnectorElement> connectorElements) {}
-
   public ProcessStateStoreImpl(
       ProcessDefinitionInspector processDefinitionInspector,
       InboundExecutableRegistry executableRegistry) {
@@ -54,11 +48,13 @@ public class ProcessStateStoreImpl implements ProcessStateStore {
   public void update(ProcessImportResult processDefinitions) {
     var entries = processDefinitions.processDefinitionVersions().entrySet();
 
+    LOG.debug("Filtering only new process definitions...");
     var newlyDeployed =
         entries.stream()
             .filter(entry -> !processStates.containsKey(entry.getKey().bpmnProcessId()))
             .toList();
 
+    LOG.debug("Filtering only updated process definitions...");
     var replacedWithDifferentVersion =
         entries.stream()
             .filter(
@@ -68,6 +64,7 @@ public class ProcessStateStoreImpl implements ProcessStateStore {
                 })
             .toList();
 
+    LOG.debug("Filtering only old process definitions)");
     var deletedProcessIds =
         processStates.keySet().stream()
             .filter(
@@ -85,6 +82,7 @@ public class ProcessStateStoreImpl implements ProcessStateStore {
 
   private void newlyDeployed(
       Map.Entry<ProcessDefinitionIdentifier, ProcessDefinitionVersion> entry) {
+    LOG.info("Activating newly deployed process definition: {}", entry.getKey().bpmnProcessId());
     try {
       processStates.compute(
           entry.getKey().bpmnProcessId(),
@@ -110,6 +108,7 @@ public class ProcessStateStoreImpl implements ProcessStateStore {
   private void replacedWithDifferentVersion(
       Map.Entry<ProcessDefinitionIdentifier, ProcessDefinitionVersion> entry) {
     try {
+      LOG.info("Activating newest deployed version process definition: {}", entry.getKey().bpmnProcessId());
       processStates.computeIfPresent(
           entry.getKey().bpmnProcessId(),
           (key, state) -> {
@@ -133,6 +132,7 @@ public class ProcessStateStoreImpl implements ProcessStateStore {
 
   private void deleted(String processId) {
     try {
+      LOG.info("Deactivating newly deployed process definition: {}", processId);
       processStates.computeIfPresent(
           processId,
           (key1, state) -> {
@@ -204,4 +204,10 @@ public class ProcessStateStoreImpl implements ProcessStateStore {
       LOG.info(". . Process {}", key);
     }
   }
+
+  private record ProcessState(
+      int version,
+      long processDefinitionKey,
+      String tenantId,
+      List<InboundConnectorElement> connectorElements) {}
 }

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/state/ProcessStateStoreImpl.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/state/ProcessStateStoreImpl.java
@@ -108,7 +108,9 @@ public class ProcessStateStoreImpl implements ProcessStateStore {
   private void replacedWithDifferentVersion(
       Map.Entry<ProcessDefinitionIdentifier, ProcessDefinitionVersion> entry) {
     try {
-      LOG.info("Activating newest deployed version process definition: {}", entry.getKey().bpmnProcessId());
+      LOG.info(
+          "Activating newest deployed version process definition: {}",
+          entry.getKey().bpmnProcessId());
       processStates.computeIfPresent(
           entry.getKey().bpmnProcessId(),
           (key, state) -> {


### PR DESCRIPTION
Adding logs during the importation of process definitions

## Description

This PR add logs tracing what is happening during the importation of the process definition from Operate.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes https://github.com/camunda/connectors/issues/3190

## Checklist

- [ ] PR has a **milestone** or the `no milestone` label.

