### PR TITLE
fix(prometheus): Re-add prometheus default config

### DIFF
--- a/connector-runtime/connector-runtime-application/src/main/resources/application.properties
+++ b/connector-runtime/connector-runtime-application/src/main/resources/application.properties
@@ -1,2 +1,3 @@
-# These application properties intentionally left blank
-# The application.properties values are defined per bundle.
+management.context-path=/actuator
+management.endpoints.web.exposure.include=metrics,health,prometheus,loggers
+management.endpoint.health.group.readiness.include[]=zeebeClient,operate


### PR DESCRIPTION
Re-add prometheus default config to Connector runtime application config

## Related issues

closes #3514

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.

