### PR TITLE
fix(email-inbound-connector): implement a reconnect and reopen mechan…

### DIFF
--- a/connectors-e2e-test/connectors-e2e-test-mail/src/test/java/io/camunda/connector/e2e/BaseEmailTest.java
+++ b/connectors-e2e-test/connectors-e2e-test-mail/src/test/java/io/camunda/connector/e2e/BaseEmailTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.e2e;
+
+import com.icegreen.greenmail.store.FolderException;
+import com.icegreen.greenmail.user.GreenMailUser;
+import com.icegreen.greenmail.util.GreenMail;
+import com.icegreen.greenmail.util.GreenMailUtil;
+import jakarta.mail.Address;
+import jakarta.mail.Message;
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.io.TempDir;
+
+public class BaseEmailTest {
+
+  protected static final String LOCALHOST = "localhost";
+  private static final GreenMail greenMail = new GreenMail();
+  @TempDir File tempDir;
+  private GreenMailUser greenMailUser = greenMail.setUser("test@camunda.com", "password");
+
+  @BeforeAll
+  static void setup() {
+    greenMail.start();
+  }
+
+  @AfterAll
+  static void tearDown() {
+    greenMail.stop();
+  }
+
+  protected static List<String> getSenders(Message message) {
+    try {
+      return Arrays.stream(message.getFrom()).map(Address::toString).toList();
+    } catch (MessagingException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  protected static List<String> getReceivers(Message message) {
+    try {
+      return Arrays.stream(message.getAllRecipients()).map(Address::toString).toList();
+    } catch (MessagingException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  protected static String getPlainTextBody(Message message) {
+    try {
+      return message.getContent().toString().trim();
+    } catch (MessagingException | IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  protected static String getSubject(Message message) {
+    try {
+      return message.getSubject();
+    } catch (MessagingException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  protected Message[] getLastReceivedEmails() {
+    return greenMail.getReceivedMessages();
+  }
+
+  protected boolean waitForNewEmails(long timeout, int numberOfEmails) {
+    return greenMail.waitForIncomingEmail(timeout, numberOfEmails);
+  }
+
+  protected void sendEmail(String to, String subject, String body) {
+    MimeMessage mimeMessage =
+        GreenMailUtil.createTextEmail(
+            to, "test@camunda.com", subject, body, greenMail.getImap().getServerSetup());
+    greenMailUser.deliver(mimeMessage);
+  }
+
+  protected String getLastEmailMessageId() {
+    Message message = getLastReceivedEmails()[0];
+    try {
+      String messageId = message.getHeader("Message-ID")[0];
+      return messageId.trim().replaceAll("[<>]", "");
+    } catch (MessagingException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  protected String getUnsecurePop3Port() {
+    return String.valueOf(greenMail.getPop3().getPort());
+  }
+
+  protected String getUnsecureImapPort() {
+    return String.valueOf(greenMail.getImap().getPort());
+  }
+
+  protected String getUnsecureSmtpPort() {
+    return String.valueOf(greenMail.getSmtp().getPort());
+  }
+
+  protected void reset() {
+    try {
+      greenMail.purgeEmailFromAllMailboxes();
+    } catch (FolderException e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/connectors-e2e-test/connectors-e2e-test-mail/src/test/java/io/camunda/connector/e2e/InboundEmailTest.java
+++ b/connectors-e2e-test/connectors-e2e-test-mail/src/test/java/io/camunda/connector/e2e/InboundEmailTest.java
@@ -1,0 +1,252 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.e2e;
+
+import static io.camunda.connector.e2e.BpmnFile.replace;
+import static org.mockito.Mockito.when;
+
+import io.camunda.connector.e2e.app.TestConnectorRuntimeApplication;
+import io.camunda.connector.runtime.inbound.state.ProcessImportResult;
+import io.camunda.connector.runtime.inbound.state.ProcessStateStore;
+import io.camunda.operate.CamundaOperateClient;
+import io.camunda.operate.exception.OperateException;
+import io.camunda.operate.model.ProcessDefinition;
+import io.camunda.zeebe.client.ZeebeClient;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.model.bpmn.instance.Process;
+import io.camunda.zeebe.process.test.assertions.BpmnAssert;
+import io.camunda.zeebe.spring.test.ZeebeSpringTest;
+import jakarta.mail.Flags;
+import jakarta.mail.MessagingException;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import org.awaitility.core.ConditionTimeoutException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest(
+    classes = {TestConnectorRuntimeApplication.class},
+    properties = {
+      "spring.main.allow-bean-definition-overriding=true",
+    },
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ZeebeSpringTest
+@ExtendWith(MockitoExtension.class)
+public class InboundEmailTest extends BaseEmailTest {
+
+  private static final ScheduledExecutorService scheduler =
+      Executors.newSingleThreadScheduledExecutor();
+  private static AtomicLong counter = new AtomicLong(1);
+  @Autowired ProcessStateStore processStateStore;
+  @Autowired CamundaOperateClient camundaOperateClient;
+  @Mock private ProcessDefinition processDef;
+  @Autowired private ZeebeClient zeebeClient;
+
+  @BeforeEach
+  public void beforeEach() {
+    super.reset();
+  }
+
+  @Test
+  public void shouldReceiveEmailAndSetAsSeen() throws OperateException, MessagingException {
+    var model =
+        replace(
+            "email-inbound-connector-intermediate_unseen_read.bpmn",
+            BpmnFile.Replace.replace("55555", super.getUnsecureImapPort()));
+
+    mockProcessDefinition(model);
+
+    scheduler.schedule(
+        () -> super.sendEmail("test@camunda.com", "test", "hey"), 2, TimeUnit.SECONDS);
+
+    processStateStore.update(
+        new ProcessImportResult(
+            Map.of(
+                new ProcessImportResult.ProcessDefinitionIdentifier(
+                    processDef.getBpmnProcessId(), processDef.getTenantId()),
+                new ProcessImportResult.ProcessDefinitionVersion(
+                    processDef.getKey(), processDef.getVersion().intValue()))));
+    var bpmnTest = ZeebeTest.with(zeebeClient).deploy(model).createInstance();
+
+    bpmnTest = bpmnTest.waitForProcessCompletion();
+
+    Assertions.assertTrue(
+        Arrays.stream(super.getLastReceivedEmails())
+            .findFirst()
+            .get()
+            .getFlags()
+            .contains(Flags.Flag.SEEN));
+    BpmnAssert.assertThat(bpmnTest.getProcessInstanceEvent())
+        .hasVariableWithValue("subject", "test");
+    BpmnAssert.assertThat(bpmnTest.getProcessInstanceEvent())
+        .hasVariableWithValue("plainTextBody", "hey");
+  }
+
+  @Test
+  public void shouldThrowWhenAllMessageAreSeen() throws OperateException, MessagingException {
+    var model =
+        replace(
+            "email-inbound-connector-intermediate_unseen_read.bpmn",
+            BpmnFile.Replace.replace("55555", super.getUnsecureImapPort()));
+
+    mockProcessDefinition(model);
+
+    super.sendEmail("test@camunda.com", "test", "hey");
+
+    Arrays.stream(getLastReceivedEmails()).findFirst().get().setFlag(Flags.Flag.SEEN, true);
+
+    processStateStore.update(
+        new ProcessImportResult(
+            Map.of(
+                new ProcessImportResult.ProcessDefinitionIdentifier(
+                    processDef.getBpmnProcessId(), processDef.getTenantId()),
+                new ProcessImportResult.ProcessDefinitionVersion(
+                    processDef.getKey(), processDef.getVersion().intValue()))));
+    var bpmnTest = ZeebeTest.with(zeebeClient).deploy(model).createInstance();
+
+    Assertions.assertThrows(ConditionTimeoutException.class, bpmnTest::waitForProcessCompletion);
+  }
+
+  @Test
+  public void shouldReceiveEmailAndDelete() throws OperateException, MessagingException {
+    var model =
+        replace(
+            "email-inbound-connector-intermediate_unseen_delete.bpmn",
+            BpmnFile.Replace.replace("55555", super.getUnsecureImapPort()));
+
+    mockProcessDefinition(model);
+
+    scheduler.schedule(
+        () -> super.sendEmail("test@camunda.com", "test", "hey"), 2, TimeUnit.SECONDS);
+
+    processStateStore.update(
+        new ProcessImportResult(
+            Map.of(
+                new ProcessImportResult.ProcessDefinitionIdentifier(
+                    processDef.getBpmnProcessId(), processDef.getTenantId()),
+                new ProcessImportResult.ProcessDefinitionVersion(
+                    processDef.getKey(), processDef.getVersion().intValue()))));
+
+    var bpmnTest = ZeebeTest.with(zeebeClient).deploy(model).createInstance();
+
+    bpmnTest = bpmnTest.waitForProcessCompletion();
+
+    Assertions.assertTrue(
+        Arrays.stream(super.getLastReceivedEmails())
+            .findFirst()
+            .get()
+            .getFlags()
+            .contains(Flags.Flag.DELETED));
+    BpmnAssert.assertThat(bpmnTest.getProcessInstanceEvent())
+        .hasVariableWithValue("subject", "test");
+    BpmnAssert.assertThat(bpmnTest.getProcessInstanceEvent())
+        .hasVariableWithValue("plainTextBody", "hey");
+  }
+
+  @Test
+  public void shouldReceiveEmailAndMove() throws OperateException, MessagingException {
+    var model =
+        replace(
+            "email-inbound-connector-intermediate_unseen_move.bpmn",
+            BpmnFile.Replace.replace("55555", super.getUnsecureImapPort()));
+
+    mockProcessDefinition(model);
+
+    scheduler.schedule(
+        () -> super.sendEmail("test@camunda.com", "test", "hey"), 2, TimeUnit.SECONDS);
+
+    processStateStore.update(
+        new ProcessImportResult(
+            Map.of(
+                new ProcessImportResult.ProcessDefinitionIdentifier(
+                    processDef.getBpmnProcessId(), processDef.getTenantId()),
+                new ProcessImportResult.ProcessDefinitionVersion(
+                    processDef.getKey(), processDef.getVersion().intValue()))));
+
+    var bpmnTest = ZeebeTest.with(zeebeClient).deploy(model).createInstance();
+
+    bpmnTest = bpmnTest.waitForProcessCompletion();
+
+    Assertions.assertEquals(2, getLastReceivedEmails().length);
+    Assertions.assertTrue(
+        Arrays.stream(getLastReceivedEmails())
+            .findFirst()
+            .get()
+            .getFlags()
+            .contains(Flags.Flag.DELETED));
+    BpmnAssert.assertThat(bpmnTest.getProcessInstanceEvent())
+        .hasVariableWithValue("subject", "test");
+    BpmnAssert.assertThat(bpmnTest.getProcessInstanceEvent())
+        .hasVariableWithValue("plainTextBody", "hey");
+  }
+
+  private void mockProcessDefinition(BpmnModelInstance model) throws OperateException {
+    when(camundaOperateClient.getProcessDefinitionModel(1L)).thenReturn(model);
+    when(processDef.getKey()).thenReturn(1L);
+    when(processDef.getTenantId()).thenReturn(zeebeClient.getConfiguration().getDefaultTenantId());
+    when(processDef.getBpmnProcessId())
+        .thenReturn(model.getModelElementsByType(Process.class).stream().findFirst().get().getId());
+    when(processDef.getVersion()).thenReturn(counter.getAndIncrement());
+  }
+
+  @Test
+  public void shouldPollEmailAndMove() throws OperateException, MessagingException {
+    var model =
+        replace(
+            "email-inbound-connector-intermediate_all_delete.bpmn",
+            BpmnFile.Replace.replace("55555", super.getUnsecureImapPort()));
+
+    mockProcessDefinition(model);
+
+    super.sendEmail("test@camunda.com", "test", "hey");
+
+    Arrays.stream(super.getLastReceivedEmails()).findFirst().get().setFlag(Flags.Flag.SEEN, true);
+
+    processStateStore.update(
+        new ProcessImportResult(
+            Map.of(
+                new ProcessImportResult.ProcessDefinitionIdentifier(
+                    processDef.getBpmnProcessId(), processDef.getTenantId()),
+                new ProcessImportResult.ProcessDefinitionVersion(
+                    processDef.getKey(), processDef.getVersion().intValue()))));
+
+    var bpmnTest = ZeebeTest.with(zeebeClient).deploy(model).createInstance();
+
+    bpmnTest = bpmnTest.waitForProcessCompletion();
+
+    Assertions.assertTrue(
+        Arrays.stream(super.getLastReceivedEmails())
+            .findFirst()
+            .get()
+            .getFlags()
+            .contains(Flags.Flag.DELETED));
+    BpmnAssert.assertThat(bpmnTest.getProcessInstanceEvent())
+        .hasVariableWithValue("subject", "test");
+    BpmnAssert.assertThat(bpmnTest.getProcessInstanceEvent())
+        .hasVariableWithValue("plainTextBody", "hey");
+  }
+}

--- a/connectors-e2e-test/connectors-e2e-test-mail/src/test/java/io/camunda/connector/e2e/OutboundEmailTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-mail/src/test/java/io/camunda/connector/e2e/OutboundEmailTests.java
@@ -1,0 +1,356 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.e2e;
+
+import static io.camunda.zeebe.process.test.assertions.BpmnAssert.assertThat;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.camunda.connector.e2e.app.TestConnectorRuntimeApplication;
+import io.camunda.zeebe.client.ZeebeClient;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.process.test.api.ZeebeTestEngine;
+import io.camunda.zeebe.spring.test.ZeebeSpringTest;
+import io.camunda.zeebe.spring.test.ZeebeTestThreadSupport;
+import jakarta.mail.Message;
+import java.io.File;
+import java.util.List;
+import java.util.concurrent.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest(
+    classes = {TestConnectorRuntimeApplication.class},
+    properties = {
+      "spring.main.allow-bean-definition-overriding=true",
+    },
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ZeebeSpringTest
+@ExtendWith(MockitoExtension.class)
+public class OutboundEmailTests extends BaseEmailTest {
+
+  private static final ScheduledExecutorService scheduler =
+      Executors.newSingleThreadScheduledExecutor();
+
+  private static final String ELEMENT_TEMPLATE_PATH =
+      "../../connectors/email/element-templates/email-outbound-connector.json";
+  private static final String RESULT_EXPRESSION_SEND_EMAIL = "={sent: sent}";
+  private static final String RESULT_EXPRESSION_LIST_EMAIL =
+      "={subject1: response[1].subject, subject2 : response[2].subject }";
+  private static final String RESULT_EXPRESSION_DELETE_EMAIL =
+      "={deleted : deleted, messageId : messageId }";
+  private static final String RESULT_EXPRESSION_READ_EMAIL =
+      "={fromAddress : fromAddress, messageId : messageId, subject: subject, size: size, plainTextBody : plainTextBody }";
+  private static final String RESULT_EXPRESSION_MOVE_EMAIL =
+      "={messageId : messageId, from: from, to: to }";
+  @Autowired private ZeebeClient zeebeClient;
+  @Autowired private ZeebeTestEngine proxiedZeebeTestEngine;
+
+  private static BpmnModelInstance getBpmnModelInstance(final String serviceTaskName) {
+    return Bpmn.createProcess()
+        .executable()
+        .startEvent()
+        .serviceTask(serviceTaskName)
+        .endEvent()
+        .done();
+  }
+
+  @BeforeEach
+  public void beforeEach() {
+    super.reset();
+  }
+
+  @Test
+  public void shouldSendSMTPEmail() {
+    File elementTemplate =
+        ElementTemplate.from(ELEMENT_TEMPLATE_PATH)
+            .property("authentication.type", "simple")
+            .property("authentication.simpleAuthenticationUsername", "test@camunda.com")
+            .property("authentication.simpleAuthenticationPassword", "password")
+            .property("protocol", "smtp")
+            .property("data.smtpPort", getUnsecureSmtpPort())
+            .property("data.smtpHost", LOCALHOST)
+            .property("smtpCryptographicProtocol", "NONE")
+            .property("data.smtpActionDiscriminator", "sendEmailSmtp")
+            .property("smtpFrom", "test@camunda.com")
+            .property("smtpTo", "receiver@test.com")
+            .property("smtpSubject", "subject")
+            .property("smtpBody", "content")
+            .property("resultExpression", RESULT_EXPRESSION_SEND_EMAIL)
+            .writeTo(new File(tempDir, "template.json"));
+
+    BpmnModelInstance model = getBpmnModelInstance("sendEmailTask");
+    BpmnModelInstance updatedModel = getBpmnModelInstance(model, elementTemplate, "sendEmailTask");
+    var result = getZeebeTest(updatedModel);
+
+    assertThat(result).isNotNull();
+    assertThat(result.getProcessInstanceEvent()).hasVariableWithValue("sent", true);
+
+    assertTrue(super.waitForNewEmails(5000, 1));
+    List<Message> message = List.of(super.getLastReceivedEmails());
+    assertThat(message).isNotNull();
+    assertThat(getSenders(message.getFirst())).hasSize(1).first().isEqualTo("test@camunda.com");
+    assertThat(getReceivers(message.getFirst())).hasSize(1).first().isEqualTo("receiver@test.com");
+    assertThat(getSubject(message.getFirst())).isEqualTo("subject");
+    assertThat(getPlainTextBody(message.getFirst())).isEqualTo("content");
+  }
+
+  @Test
+  public void shouldListPop3Email() throws ExecutionException, InterruptedException {
+
+    File elementTemplate =
+        ElementTemplate.from(ELEMENT_TEMPLATE_PATH)
+            .property("authentication.type", "simple")
+            .property("authentication.simpleAuthenticationUsername", "test@camunda.com")
+            .property("authentication.simpleAuthenticationPassword", "password")
+            .property("protocol", "pop3")
+            .property("data.pop3Port", getUnsecurePop3Port())
+            .property("data.pop3Host", LOCALHOST)
+            .property("pop3CryptographicProtocol", "NONE")
+            .property("data.pop3ActionDiscriminator", "listEmailsPop3")
+            .property("pop3maxToBeRead", "100")
+            .property("pop3SortField", "SENT_DATE")
+            .property("pop3SortOrder", "DESC")
+            .property("resultExpression", RESULT_EXPRESSION_LIST_EMAIL)
+            .writeTo(new File(tempDir, "template.json"));
+
+    scheduler.schedule(
+        () -> super.sendEmail("receiver@test.com", "subject1", "content1"), 1, SECONDS);
+    scheduler.schedule(
+        () -> super.sendEmail("receiver@test.com", "subject2", "content2"), 2, SECONDS);
+
+    BpmnModelInstance model = getBpmnModelInstance("listEmailsTask");
+    BpmnModelInstance updatedModel = getBpmnModelInstance(model, elementTemplate, "listEmailsTask");
+    var result =
+        scheduler.schedule(() -> getZeebeTestMultiThreadSupport(updatedModel), 3, SECONDS).get();
+    assertThat(result.getProcessInstanceEvent()).hasVariableWithValue("subject1", "subject2");
+    assertThat(result.getProcessInstanceEvent()).hasVariableWithValue("subject2", "subject1");
+  }
+
+  @Test
+  public void shouldListImapEmail() throws InterruptedException, ExecutionException {
+
+    File elementTemplate =
+        ElementTemplate.from(ELEMENT_TEMPLATE_PATH)
+            .property("authentication.type", "simple")
+            .property("authentication.simpleAuthenticationUsername", "test@camunda.com")
+            .property("authentication.simpleAuthenticationPassword", "password")
+            .property("protocol", "imap")
+            .property("data.imapPort", getUnsecureImapPort())
+            .property("data.imapHost", LOCALHOST)
+            .property("imapCryptographicProtocol", "NONE")
+            .property("data.imapActionDiscriminator", "listEmailsImap")
+            .property("imapMaxToBeRead", "100")
+            .property("imapSortField", "RECEIVED_DATE")
+            .property("imapSortOrder", "DESC")
+            .property("resultExpression", RESULT_EXPRESSION_LIST_EMAIL)
+            .writeTo(new File(tempDir, "template.json"));
+
+    scheduler.schedule(
+        () -> super.sendEmail("receiver@test.com", "subject1", "content1"), 1, SECONDS);
+    scheduler.schedule(
+        () -> super.sendEmail("receiver@test.com", "subject2", "content2"), 2, SECONDS);
+
+    BpmnModelInstance model = getBpmnModelInstance("listEmailsTask");
+    BpmnModelInstance updatedModel = getBpmnModelInstance(model, elementTemplate, "listEmailsTask");
+    var result =
+        scheduler.schedule(() -> getZeebeTestMultiThreadSupport(updatedModel), 3, SECONDS).get();
+
+    assertThat(result.getProcessInstanceEvent()).hasVariableWithValue("subject1", "subject2");
+    assertThat(result.getProcessInstanceEvent()).hasVariableWithValue("subject2", "subject1");
+  }
+
+  @Test
+  public void shouldDeletePop3Email() throws ExecutionException, InterruptedException {
+
+    super.sendEmail("test@camunda.com", "subject1", "content1");
+    String messageId = getLastEmailMessageId();
+    File elementTemplate =
+        ElementTemplate.from(ELEMENT_TEMPLATE_PATH)
+            .property("authentication.type", "simple")
+            .property("authentication.simpleAuthenticationUsername", "test@camunda.com")
+            .property("authentication.simpleAuthenticationPassword", "password")
+            .property("protocol", "pop3")
+            .property("data.pop3Port", getUnsecurePop3Port())
+            .property("data.pop3Host", LOCALHOST)
+            .property("pop3CryptographicProtocol", "NONE")
+            .property("data.pop3ActionDiscriminator", "deleteEmailPop3")
+            .property("pop3MessageIdDelete", messageId)
+            .property("resultExpression", RESULT_EXPRESSION_DELETE_EMAIL)
+            .writeTo(new File(tempDir, "template.json"));
+
+    BpmnModelInstance model = getBpmnModelInstance("deleteEmailTask");
+    BpmnModelInstance updatedModel =
+        getBpmnModelInstance(model, elementTemplate, "deleteEmailTask");
+    var result =
+        scheduler.schedule(() -> getZeebeTestMultiThreadSupport(updatedModel), 3, SECONDS).get();
+    assertThat(result.getProcessInstanceEvent()).hasVariableWithValue("messageId", messageId);
+    assertThat(result.getProcessInstanceEvent()).hasVariableWithValue("deleted", true);
+  }
+
+  @Test
+  public void shouldDeleteImapEmail() throws ExecutionException, InterruptedException {
+
+    super.sendEmail("test@camunda.com", "subject1", "content1");
+    String messageId = getLastEmailMessageId();
+    File elementTemplate =
+        ElementTemplate.from(ELEMENT_TEMPLATE_PATH)
+            .property("authentication.type", "simple")
+            .property("authentication.simpleAuthenticationUsername", "test@camunda.com")
+            .property("authentication.simpleAuthenticationPassword", "password")
+            .property("protocol", "imap")
+            .property("data.imapPort", getUnsecureImapPort())
+            .property("data.imapHost", LOCALHOST)
+            .property("imapCryptographicProtocol", "NONE")
+            .property("data.imapActionDiscriminator", "deleteEmailImap")
+            .property("imapMessageIdDelete", messageId)
+            .property("deleteEmailFolder", "INBOX")
+            .property("resultExpression", RESULT_EXPRESSION_DELETE_EMAIL)
+            .writeTo(new File(tempDir, "template.json"));
+
+    BpmnModelInstance model = getBpmnModelInstance("deleteEmailTask");
+    BpmnModelInstance updatedModel =
+        getBpmnModelInstance(model, elementTemplate, "deleteEmailTask");
+    var result =
+        scheduler.schedule(() -> getZeebeTestMultiThreadSupport(updatedModel), 3, SECONDS).get();
+    assertThat(result.getProcessInstanceEvent()).hasVariableWithValue("messageId", messageId);
+    assertThat(result.getProcessInstanceEvent()).hasVariableWithValue("deleted", true);
+  }
+
+  @Test
+  public void shouldReadPop3Email() throws ExecutionException, InterruptedException {
+
+    super.sendEmail("test@camunda.com", "subject", "content");
+    String messageId = getLastEmailMessageId();
+    File elementTemplate =
+        ElementTemplate.from(ELEMENT_TEMPLATE_PATH)
+            .property("authentication.type", "simple")
+            .property("authentication.simpleAuthenticationUsername", "test@camunda.com")
+            .property("authentication.simpleAuthenticationPassword", "password")
+            .property("protocol", "pop3")
+            .property("data.pop3Port", getUnsecurePop3Port())
+            .property("data.pop3Host", LOCALHOST)
+            .property("pop3CryptographicProtocol", "NONE")
+            .property("data.pop3ActionDiscriminator", "readEmailPop3")
+            .property("pop3MessageIdRead", messageId)
+            .property("resultExpression", RESULT_EXPRESSION_READ_EMAIL)
+            .writeTo(new File(tempDir, "template.json"));
+
+    BpmnModelInstance model = getBpmnModelInstance("readEmailTask");
+    BpmnModelInstance updatedModel = getBpmnModelInstance(model, elementTemplate, "readEmailTask");
+    var result =
+        scheduler.schedule(() -> getZeebeTestMultiThreadSupport(updatedModel), 3, SECONDS).get();
+    assertThat(result.getProcessInstanceEvent()).hasVariableWithValue("messageId", messageId);
+    assertThat(result.getProcessInstanceEvent())
+        .hasVariableWithValue("fromAddress", "test@camunda.com");
+    assertThat(result.getProcessInstanceEvent()).hasVariableWithValue("subject", "subject");
+    assertThat(result.getProcessInstanceEvent()).hasVariableWithValue("size", 9);
+    assertThat(result.getProcessInstanceEvent())
+        .hasVariableWithValue("plainTextBody", "content\r\n");
+  }
+
+  @Test
+  public void shouldReadImapEmail() throws ExecutionException, InterruptedException {
+
+    super.sendEmail("test@camunda.com", "subject", "content");
+    String messageId = getLastEmailMessageId();
+    File elementTemplate =
+        ElementTemplate.from(ELEMENT_TEMPLATE_PATH)
+            .property("authentication.type", "simple")
+            .property("authentication.simpleAuthenticationUsername", "test@camunda.com")
+            .property("authentication.simpleAuthenticationPassword", "password")
+            .property("protocol", "imap")
+            .property("data.imapPort", getUnsecureImapPort())
+            .property("data.imapHost", LOCALHOST)
+            .property("imapCryptographicProtocol", "NONE")
+            .property("data.imapActionDiscriminator", "readEmailImap")
+            .property("imapMessageIdRead", messageId)
+            .property("readEmailFolder", "INBOX")
+            .property("resultExpression", RESULT_EXPRESSION_READ_EMAIL)
+            .writeTo(new File(tempDir, "template.json"));
+
+    BpmnModelInstance model = getBpmnModelInstance("readEmailTask");
+    BpmnModelInstance updatedModel = getBpmnModelInstance(model, elementTemplate, "readEmailTask");
+    var result =
+        scheduler.schedule(() -> getZeebeTestMultiThreadSupport(updatedModel), 3, SECONDS).get();
+    assertThat(result.getProcessInstanceEvent()).hasVariableWithValue("messageId", messageId);
+    assertThat(result.getProcessInstanceEvent())
+        .hasVariableWithValue("fromAddress", "test@camunda.com");
+    assertThat(result.getProcessInstanceEvent()).hasVariableWithValue("subject", "subject");
+    assertThat(result.getProcessInstanceEvent()).hasVariableWithValue("size", 7);
+    assertThat(result.getProcessInstanceEvent()).hasVariableWithValue("plainTextBody", "content");
+  }
+
+  @Test
+  public void shouldMoveImapEmail() throws ExecutionException, InterruptedException {
+
+    super.sendEmail("test@camunda.com", "subject", "content");
+    String messageId = getLastEmailMessageId();
+    File elementTemplate =
+        ElementTemplate.from(ELEMENT_TEMPLATE_PATH)
+            .property("authentication.type", "simple")
+            .property("authentication.simpleAuthenticationUsername", "test@camunda.com")
+            .property("authentication.simpleAuthenticationPassword", "password")
+            .property("protocol", "imap")
+            .property("data.imapPort", getUnsecureImapPort())
+            .property("data.imapHost", LOCALHOST)
+            .property("imapCryptographicProtocol", "NONE")
+            .property("data.imapActionDiscriminator", "moveEmailImap")
+            .property("imapMessageIdMove", messageId)
+            .property("data.fromFolder", "INBOX")
+            .property("data.toFolder", "TEST")
+            .property("resultExpression", RESULT_EXPRESSION_MOVE_EMAIL)
+            .writeTo(new File(tempDir, "template.json"));
+
+    BpmnModelInstance model = getBpmnModelInstance("readEmailTask");
+    BpmnModelInstance updatedModel = getBpmnModelInstance(model, elementTemplate, "readEmailTask");
+    var result =
+        scheduler.schedule(() -> getZeebeTestMultiThreadSupport(updatedModel), 3, SECONDS).get();
+
+    assertThat(result.getProcessInstanceEvent()).hasVariableWithValue("messageId", messageId);
+    assertThat(result.getProcessInstanceEvent()).hasVariableWithValue("from", "INBOX");
+    assertThat(result.getProcessInstanceEvent()).hasVariableWithValue("to", "TEST");
+  }
+
+  private BpmnModelInstance getBpmnModelInstance(
+      final BpmnModelInstance model, final File elementTemplate, final String taskName) {
+    return new BpmnFile(model)
+        .writeToFile(new File(tempDir, "test.bpmn"))
+        .apply(elementTemplate, taskName, new File(tempDir, "result.bpmn"));
+  }
+
+  protected ZeebeTest getZeebeTest(final BpmnModelInstance updatedModel) {
+    return ZeebeTest.with(zeebeClient)
+        .deploy(updatedModel)
+        .createInstance()
+        .waitForProcessCompletion();
+  }
+
+  protected ZeebeTest getZeebeTestMultiThreadSupport(final BpmnModelInstance updatedModel) {
+    ZeebeTestThreadSupport.setEngineForCurrentThread(this.proxiedZeebeTestEngine);
+    return ZeebeTest.with(zeebeClient)
+        .deploy(updatedModel)
+        .createInstance()
+        .waitForProcessCompletion();
+  }
+}

--- a/connectors-e2e-test/connectors-e2e-test-mail/src/test/resources/email-inbound-connector-intermediate_all_delete.bpmn
+++ b/connectors-e2e-test/connectors-e2e-test-mail/src/test/resources/email-inbound-connector-intermediate_all_delete.bpmn
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1ry9nn1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.24.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.5.0">
+  <bpmn:process id="Process_1crecrd" isExecutable="true">
+    <bpmn:endEvent id="Event_1aq97te">
+      <bpmn:incoming>Flow_1vp6srd</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:startEvent id="Event_0xs76az">
+      <bpmn:outgoing>Flow_0lofu08</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_0lofu08" sourceRef="Event_0xs76az" targetRef="Event_1y1ygyn" />
+    <bpmn:intermediateCatchEvent id="Event_1y1ygyn" zeebe:modelerTemplate="io.camunda.connectors.inbound.EmailIntermediate.v1" zeebe:modelerTemplateVersion="1" zeebe:modelerTemplateIcon="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTYiIGhlaWdodD0iMTYiIHZpZXdCb3g9IjAgMCAxNiAxNiIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPGcgY2xpcC1wYXRoPSJ1cmwoI2NsaXAwXzkwXzI0MjApIj4KPHBhdGggZD0iTTguMzM4MzUgOS45NTM2NUwxMC4zODk0IDEyLjAxMDRMOC4zMzI2MiAxNC4wNjcyTDkuMTQ2MTYgMTQuODc1TDEyLjAxMDcgMTIuMDEwNEw5LjE0NjE2IDkuMTQ1ODNMOC4zMzgzNSA5Ljk1MzY1WiIgZmlsbD0iYmxhY2siLz4KPHBhdGggZD0iTTEyLjM0ODggOS45NTM2NUwxNC4zOTk4IDEyLjAxMDRMMTIuMzQzIDE0LjA2NzJMMTMuMTU2NiAxNC44NzVMMTYuMDIxMiAxMi4wMTA0TDEzLjE1NjYgOS4xNDU4M0wxMi4zNDg4IDkuOTUzNjVaIiBmaWxsPSJibGFjayIvPgo8cGF0aCBkPSJNMy45NzIgMTEuNDM3NUgxLjEyNTMzVjIuNzkyMTlMNy42NzM3NiA3LjMyMzk2QzcuNzY5NjcgNy4zOTA0OSA3Ljg4MzYgNy40MjYxNCA4LjAwMDMyIDcuNDI2MTRDOC4xMTcwNSA3LjQyNjE0IDguMjMwOTggNy4zOTA0OSA4LjMyNjg5IDcuMzIzOTZMMTQuODc1MyAyLjc5MjE5VjhIMTYuMDIxMlYyLjI3MDgzQzE2LjAyMTIgMS45NjY5NCAxNS45MDA0IDEuNjc1NDkgMTUuNjg1NiAxLjQ2MDYxQzE1LjQ3MDcgMS4yNDU3MiAxNS4xNzkyIDEuMTI1IDE0Ljg3NTMgMS4xMjVIMS4xMjUzM0MwLjgyMTQzMiAxLjEyNSAwLjUyOTk4NCAxLjI0NTcyIDAuMzE1MDk5IDEuNDYwNjFDMC4xMDAyMTQgMS42NzU0OSAtMC4wMjA1MDc4IDEuOTY2OTQgLTAuMDIwNTA3OCAyLjI3MDgzVjExLjQzNzVDLTAuMDIwNTA3OCAxMS43NDE0IDAuMTAwMjE0IDEyLjAzMjggMC4zMTUwOTkgMTIuMjQ3N0MwLjUyOTk4NCAxMi40NjI2IDAuODIxNDMyIDEyLjU4MzMgMS4xMjUzMyAxMi41ODMzSDMuOTcyVjExLjQzNzVaTTEzLjYxNDkgMi4yNzA4M0w4LjAwMDMyIDYuMTU1MjFMMi4zODU3NCAyLjI3MDgzSDEzLjYxNDlaIiBmaWxsPSIjRkM1RDBEIi8+CjxwYXRoIGQ9Ik00LjI4MjEgOS45NTM2NUw2LjMzMzE0IDEyLjAxMDRMNC4yNzYzNyAxNC4wNjcyTDUuMDg5OTEgMTQuODc1TDcuOTU0NDkgMTIuMDEwNEw1LjA4OTkxIDkuMTQ1ODNMNC4yODIxIDkuOTUzNjVaIiBmaWxsPSJibGFjayIvPgo8L2c+CjxkZWZzPgo8Y2xpcFBhdGggaWQ9ImNsaXAwXzkwXzI0MjAiPgo8cmVjdCB3aWR0aD0iMTYiIGhlaWdodD0iMTYiIGZpbGw9IndoaXRlIi8+CjwvY2xpcFBhdGg+CjwvZGVmcz4KPC9zdmc+Cg==">
+      <bpmn:extensionElements>
+        <zeebe:properties>
+          <zeebe:property name="inbound.type" value="io.camunda:connector-email-inbound:1" />
+          <zeebe:property name="authentication.type" value="simple" />
+          <zeebe:property name="authentication.username" value="test@camunda.com" />
+          <zeebe:property name="authentication.password" value="password" />
+          <zeebe:property name="data.imapConfig.imapHost" value="localhost" />
+          <zeebe:property name="data.imapConfig.imapPort" value="55555" />
+          <zeebe:property name="data.imapConfig.imapCryptographicProtocol" value="NONE" />
+          <zeebe:property name="data.pollingWaitTime" value="PT2S" />
+          <zeebe:property name="data.pollingConfigDiscriminator" value="allPollingConfig" />
+          <zeebe:property name="data.pollingConfig.handlingStrategy" value="DELETE" />
+          <zeebe:property name="consumeUnmatchedEvents" value="true" />
+          <zeebe:property name="correlationKeyExpression" value="=&#34;ok&#34;" />
+          <zeebe:property name="deduplicationModeManualFlag" value="false" />
+          <zeebe:property name="deduplicationMode" value="AUTO" />
+          <zeebe:property name="resultVariable" />
+          <zeebe:property name="resultExpression" value="={fromAddress : fromAddress, messageId : messageId, subject: subject, size: size, plainTextBody : plainTextBody }" />
+        </zeebe:properties>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_0lofu08</bpmn:incoming>
+      <bpmn:outgoing>Flow_1vp6srd</bpmn:outgoing>
+      <bpmn:messageEventDefinition id="MessageEventDefinition_1om0jbh" messageRef="Message_1rm9467" />
+    </bpmn:intermediateCatchEvent>
+    <bpmn:sequenceFlow id="Flow_1vp6srd" sourceRef="Event_1y1ygyn" targetRef="Event_1aq97te" />
+  </bpmn:process>
+  <bpmn:message id="Message_1rm9467" name="0514aee7-2eab-4cf7-9f6c-acae87549711" zeebe:modelerTemplate="io.camunda.connectors.inbound.EmailIntermediate.v1">
+    <bpmn:extensionElements>
+      <zeebe:subscription correlationKey="=&#34;ok&#34;" />
+    </bpmn:extensionElements>
+  </bpmn:message>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1crecrd">
+      <bpmndi:BPMNShape id="Event_1aq97te_di" bpmnElement="Event_1aq97te">
+        <dc:Bounds x="782" y="72" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0xs76az_di" bpmnElement="Event_0xs76az">
+        <dc:Bounds x="192" y="72" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1hvfzo1_di" bpmnElement="Event_1y1ygyn">
+        <dc:Bounds x="432" y="72" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0lofu08_di" bpmnElement="Flow_0lofu08">
+        <di:waypoint x="228" y="90" />
+        <di:waypoint x="432" y="90" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1vp6srd_di" bpmnElement="Flow_1vp6srd">
+        <di:waypoint x="468" y="90" />
+        <di:waypoint x="782" y="90" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/connectors-e2e-test/connectors-e2e-test-mail/src/test/resources/email-inbound-connector-intermediate_all_move.bpmn
+++ b/connectors-e2e-test/connectors-e2e-test-mail/src/test/resources/email-inbound-connector-intermediate_all_move.bpmn
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1ry9nn1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.24.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.5.0">
+  <bpmn:process id="Process_1crecrd" isExecutable="true">
+    <bpmn:endEvent id="Event_1aq97te">
+      <bpmn:incoming>Flow_1vp6srd</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:startEvent id="Event_0xs76az">
+      <bpmn:outgoing>Flow_0lofu08</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_0lofu08" sourceRef="Event_0xs76az" targetRef="Event_1y1ygyn" />
+    <bpmn:intermediateCatchEvent id="Event_1y1ygyn" zeebe:modelerTemplate="io.camunda.connectors.inbound.EmailIntermediate.v1" zeebe:modelerTemplateVersion="1" zeebe:modelerTemplateIcon="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTYiIGhlaWdodD0iMTYiIHZpZXdCb3g9IjAgMCAxNiAxNiIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPGcgY2xpcC1wYXRoPSJ1cmwoI2NsaXAwXzkwXzI0MjApIj4KPHBhdGggZD0iTTguMzM4MzUgOS45NTM2NUwxMC4zODk0IDEyLjAxMDRMOC4zMzI2MiAxNC4wNjcyTDkuMTQ2MTYgMTQuODc1TDEyLjAxMDcgMTIuMDEwNEw5LjE0NjE2IDkuMTQ1ODNMOC4zMzgzNSA5Ljk1MzY1WiIgZmlsbD0iYmxhY2siLz4KPHBhdGggZD0iTTEyLjM0ODggOS45NTM2NUwxNC4zOTk4IDEyLjAxMDRMMTIuMzQzIDE0LjA2NzJMMTMuMTU2NiAxNC44NzVMMTYuMDIxMiAxMi4wMTA0TDEzLjE1NjYgOS4xNDU4M0wxMi4zNDg4IDkuOTUzNjVaIiBmaWxsPSJibGFjayIvPgo8cGF0aCBkPSJNMy45NzIgMTEuNDM3NUgxLjEyNTMzVjIuNzkyMTlMNy42NzM3NiA3LjMyMzk2QzcuNzY5NjcgNy4zOTA0OSA3Ljg4MzYgNy40MjYxNCA4LjAwMDMyIDcuNDI2MTRDOC4xMTcwNSA3LjQyNjE0IDguMjMwOTggNy4zOTA0OSA4LjMyNjg5IDcuMzIzOTZMMTQuODc1MyAyLjc5MjE5VjhIMTYuMDIxMlYyLjI3MDgzQzE2LjAyMTIgMS45NjY5NCAxNS45MDA0IDEuNjc1NDkgMTUuNjg1NiAxLjQ2MDYxQzE1LjQ3MDcgMS4yNDU3MiAxNS4xNzkyIDEuMTI1IDE0Ljg3NTMgMS4xMjVIMS4xMjUzM0MwLjgyMTQzMiAxLjEyNSAwLjUyOTk4NCAxLjI0NTcyIDAuMzE1MDk5IDEuNDYwNjFDMC4xMDAyMTQgMS42NzU0OSAtMC4wMjA1MDc4IDEuOTY2OTQgLTAuMDIwNTA3OCAyLjI3MDgzVjExLjQzNzVDLTAuMDIwNTA3OCAxMS43NDE0IDAuMTAwMjE0IDEyLjAzMjggMC4zMTUwOTkgMTIuMjQ3N0MwLjUyOTk4NCAxMi40NjI2IDAuODIxNDMyIDEyLjU4MzMgMS4xMjUzMyAxMi41ODMzSDMuOTcyVjExLjQzNzVaTTEzLjYxNDkgMi4yNzA4M0w4LjAwMDMyIDYuMTU1MjFMMi4zODU3NCAyLjI3MDgzSDEzLjYxNDlaIiBmaWxsPSIjRkM1RDBEIi8+CjxwYXRoIGQ9Ik00LjI4MjEgOS45NTM2NUw2LjMzMzE0IDEyLjAxMDRMNC4yNzYzNyAxNC4wNjcyTDUuMDg5OTEgMTQuODc1TDcuOTU0NDkgMTIuMDEwNEw1LjA4OTkxIDkuMTQ1ODNMNC4yODIxIDkuOTUzNjVaIiBmaWxsPSJibGFjayIvPgo8L2c+CjxkZWZzPgo8Y2xpcFBhdGggaWQ9ImNsaXAwXzkwXzI0MjAiPgo8cmVjdCB3aWR0aD0iMTYiIGhlaWdodD0iMTYiIGZpbGw9IndoaXRlIi8+CjwvY2xpcFBhdGg+CjwvZGVmcz4KPC9zdmc+Cg==">
+      <bpmn:extensionElements>
+        <zeebe:properties>
+          <zeebe:property name="inbound.type" value="io.camunda:connector-email-inbound:1" />
+          <zeebe:property name="authentication.type" value="simple" />
+          <zeebe:property name="authentication.username" value="test@camunda.com" />
+          <zeebe:property name="authentication.password" value="password" />
+          <zeebe:property name="data.imapConfig.imapHost" value="localhost" />
+          <zeebe:property name="data.imapConfig.imapPort" value="55555" />
+          <zeebe:property name="data.imapConfig.imapCryptographicProtocol" value="NONE" />
+          <zeebe:property name="data.pollingWaitTime" value="PT2S" />
+          <zeebe:property name="data.pollingConfigDiscriminator" value="allPollingConfig" />
+          <zeebe:property name="data.pollingConfig.handlingStrategy" value="MOVE" />
+          <zeebe:property name="data.pollingConfig.targetFolder" value="Test" />
+          <zeebe:property name="consumeUnmatchedEvents" value="true" />
+          <zeebe:property name="correlationKeyExpression" value="=&#34;ok&#34;" />
+          <zeebe:property name="deduplicationModeManualFlag" value="false" />
+          <zeebe:property name="deduplicationMode" value="AUTO" />
+          <zeebe:property name="resultVariable" />
+          <zeebe:property name="resultExpression" value="={fromAddress : fromAddress, messageId : messageId, subject: subject, size: size, plainTextBody : plainTextBody }" />
+        </zeebe:properties>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_0lofu08</bpmn:incoming>
+      <bpmn:outgoing>Flow_1vp6srd</bpmn:outgoing>
+      <bpmn:messageEventDefinition id="MessageEventDefinition_1om0jbh" messageRef="Message_1rm9467" />
+    </bpmn:intermediateCatchEvent>
+    <bpmn:sequenceFlow id="Flow_1vp6srd" sourceRef="Event_1y1ygyn" targetRef="Event_1aq97te" />
+  </bpmn:process>
+  <bpmn:message id="Message_1rm9467" name="7b5efd1a-405f-4f67-b43a-59b66499778f" zeebe:modelerTemplate="io.camunda.connectors.inbound.EmailIntermediate.v1">
+    <bpmn:extensionElements>
+      <zeebe:subscription correlationKey="=&#34;ok&#34;" />
+    </bpmn:extensionElements>
+  </bpmn:message>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1crecrd">
+      <bpmndi:BPMNShape id="Event_1aq97te_di" bpmnElement="Event_1aq97te">
+        <dc:Bounds x="782" y="72" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0xs76az_di" bpmnElement="Event_0xs76az">
+        <dc:Bounds x="192" y="72" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1hvfzo1_di" bpmnElement="Event_1y1ygyn">
+        <dc:Bounds x="432" y="72" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0lofu08_di" bpmnElement="Flow_0lofu08">
+        <di:waypoint x="228" y="90" />
+        <di:waypoint x="432" y="90" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1vp6srd_di" bpmnElement="Flow_1vp6srd">
+        <di:waypoint x="468" y="90" />
+        <di:waypoint x="782" y="90" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/connectors-e2e-test/connectors-e2e-test-mail/src/test/resources/email-inbound-connector-intermediate_unseen_delete.bpmn
+++ b/connectors-e2e-test/connectors-e2e-test-mail/src/test/resources/email-inbound-connector-intermediate_unseen_delete.bpmn
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1ry9nn1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.24.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.5.0">
+  <bpmn:process id="Process_1crecrd" isExecutable="true">
+    <bpmn:endEvent id="Event_1aq97te">
+      <bpmn:incoming>Flow_1vp6srd</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:startEvent id="Event_0xs76az">
+      <bpmn:outgoing>Flow_0lofu08</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_0lofu08" sourceRef="Event_0xs76az" targetRef="Event_1y1ygyn" />
+    <bpmn:intermediateCatchEvent id="Event_1y1ygyn" zeebe:modelerTemplate="io.camunda.connectors.inbound.EmailIntermediate.v1" zeebe:modelerTemplateVersion="1" zeebe:modelerTemplateIcon="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTYiIGhlaWdodD0iMTYiIHZpZXdCb3g9IjAgMCAxNiAxNiIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPGcgY2xpcC1wYXRoPSJ1cmwoI2NsaXAwXzkwXzI0MjApIj4KPHBhdGggZD0iTTguMzM4MzUgOS45NTM2NUwxMC4zODk0IDEyLjAxMDRMOC4zMzI2MiAxNC4wNjcyTDkuMTQ2MTYgMTQuODc1TDEyLjAxMDcgMTIuMDEwNEw5LjE0NjE2IDkuMTQ1ODNMOC4zMzgzNSA5Ljk1MzY1WiIgZmlsbD0iYmxhY2siLz4KPHBhdGggZD0iTTEyLjM0ODggOS45NTM2NUwxNC4zOTk4IDEyLjAxMDRMMTIuMzQzIDE0LjA2NzJMMTMuMTU2NiAxNC44NzVMMTYuMDIxMiAxMi4wMTA0TDEzLjE1NjYgOS4xNDU4M0wxMi4zNDg4IDkuOTUzNjVaIiBmaWxsPSJibGFjayIvPgo8cGF0aCBkPSJNMy45NzIgMTEuNDM3NUgxLjEyNTMzVjIuNzkyMTlMNy42NzM3NiA3LjMyMzk2QzcuNzY5NjcgNy4zOTA0OSA3Ljg4MzYgNy40MjYxNCA4LjAwMDMyIDcuNDI2MTRDOC4xMTcwNSA3LjQyNjE0IDguMjMwOTggNy4zOTA0OSA4LjMyNjg5IDcuMzIzOTZMMTQuODc1MyAyLjc5MjE5VjhIMTYuMDIxMlYyLjI3MDgzQzE2LjAyMTIgMS45NjY5NCAxNS45MDA0IDEuNjc1NDkgMTUuNjg1NiAxLjQ2MDYxQzE1LjQ3MDcgMS4yNDU3MiAxNS4xNzkyIDEuMTI1IDE0Ljg3NTMgMS4xMjVIMS4xMjUzM0MwLjgyMTQzMiAxLjEyNSAwLjUyOTk4NCAxLjI0NTcyIDAuMzE1MDk5IDEuNDYwNjFDMC4xMDAyMTQgMS42NzU0OSAtMC4wMjA1MDc4IDEuOTY2OTQgLTAuMDIwNTA3OCAyLjI3MDgzVjExLjQzNzVDLTAuMDIwNTA3OCAxMS43NDE0IDAuMTAwMjE0IDEyLjAzMjggMC4zMTUwOTkgMTIuMjQ3N0MwLjUyOTk4NCAxMi40NjI2IDAuODIxNDMyIDEyLjU4MzMgMS4xMjUzMyAxMi41ODMzSDMuOTcyVjExLjQzNzVaTTEzLjYxNDkgMi4yNzA4M0w4LjAwMDMyIDYuMTU1MjFMMi4zODU3NCAyLjI3MDgzSDEzLjYxNDlaIiBmaWxsPSIjRkM1RDBEIi8+CjxwYXRoIGQ9Ik00LjI4MjEgOS45NTM2NUw2LjMzMzE0IDEyLjAxMDRMNC4yNzYzNyAxNC4wNjcyTDUuMDg5OTEgMTQuODc1TDcuOTU0NDkgMTIuMDEwNEw1LjA4OTkxIDkuMTQ1ODNMNC4yODIxIDkuOTUzNjVaIiBmaWxsPSJibGFjayIvPgo8L2c+CjxkZWZzPgo8Y2xpcFBhdGggaWQ9ImNsaXAwXzkwXzI0MjAiPgo8cmVjdCB3aWR0aD0iMTYiIGhlaWdodD0iMTYiIGZpbGw9IndoaXRlIi8+CjwvY2xpcFBhdGg+CjwvZGVmcz4KPC9zdmc+Cg==">
+      <bpmn:extensionElements>
+        <zeebe:properties>
+          <zeebe:property name="inbound.type" value="io.camunda:connector-email-inbound:1" />
+          <zeebe:property name="authentication.type" value="simple" />
+          <zeebe:property name="authentication.username" value="test@camunda.com" />
+          <zeebe:property name="authentication.password" value="password" />
+          <zeebe:property name="data.imapConfig.imapHost" value="localhost" />
+          <zeebe:property name="data.imapConfig.imapPort" value="55555" />
+          <zeebe:property name="data.imapConfig.imapCryptographicProtocol" value="NONE" />
+          <zeebe:property name="data.pollingWaitTime" value="PT2S" />
+          <zeebe:property name="data.pollingConfigDiscriminator" value="unseenPollingConfig" />
+          <zeebe:property name="data.pollingConfig.handlingStrategy" value="DELETE" />
+          <zeebe:property name="consumeUnmatchedEvents" value="true" />
+          <zeebe:property name="correlationKeyExpression" value="=&#34;ok&#34;" />
+          <zeebe:property name="deduplicationModeManualFlag" value="false" />
+          <zeebe:property name="deduplicationMode" value="AUTO" />
+          <zeebe:property name="resultVariable" />
+          <zeebe:property name="resultExpression" value="={fromAddress : fromAddress, messageId : messageId, subject: subject, size: size, plainTextBody : plainTextBody }" />
+        </zeebe:properties>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_0lofu08</bpmn:incoming>
+      <bpmn:outgoing>Flow_1vp6srd</bpmn:outgoing>
+      <bpmn:messageEventDefinition id="MessageEventDefinition_1om0jbh" messageRef="Message_1rm9467" />
+    </bpmn:intermediateCatchEvent>
+    <bpmn:sequenceFlow id="Flow_1vp6srd" sourceRef="Event_1y1ygyn" targetRef="Event_1aq97te" />
+  </bpmn:process>
+  <bpmn:message id="Message_1rm9467" name="b0610e39-41ff-4bd2-8b01-43288823fbf2" zeebe:modelerTemplate="io.camunda.connectors.inbound.EmailIntermediate.v1">
+    <bpmn:extensionElements>
+      <zeebe:subscription correlationKey="=&#34;ok&#34;" />
+    </bpmn:extensionElements>
+  </bpmn:message>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1crecrd">
+      <bpmndi:BPMNShape id="Event_1aq97te_di" bpmnElement="Event_1aq97te">
+        <dc:Bounds x="782" y="72" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0xs76az_di" bpmnElement="Event_0xs76az">
+        <dc:Bounds x="192" y="72" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1hvfzo1_di" bpmnElement="Event_1y1ygyn">
+        <dc:Bounds x="432" y="72" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0lofu08_di" bpmnElement="Flow_0lofu08">
+        <di:waypoint x="228" y="90" />
+        <di:waypoint x="432" y="90" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1vp6srd_di" bpmnElement="Flow_1vp6srd">
+        <di:waypoint x="468" y="90" />
+        <di:waypoint x="782" y="90" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/connectors-e2e-test/connectors-e2e-test-mail/src/test/resources/email-inbound-connector-intermediate_unseen_move.bpmn
+++ b/connectors-e2e-test/connectors-e2e-test-mail/src/test/resources/email-inbound-connector-intermediate_unseen_move.bpmn
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1ry9nn1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.24.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.5.0">
+  <bpmn:process id="Process_1crecrd" isExecutable="true">
+    <bpmn:endEvent id="Event_1aq97te">
+      <bpmn:incoming>Flow_1vp6srd</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:startEvent id="Event_0xs76az">
+      <bpmn:outgoing>Flow_0lofu08</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_0lofu08" sourceRef="Event_0xs76az" targetRef="Event_1y1ygyn" />
+    <bpmn:intermediateCatchEvent id="Event_1y1ygyn" zeebe:modelerTemplate="io.camunda.connectors.inbound.EmailIntermediate.v1" zeebe:modelerTemplateVersion="1" zeebe:modelerTemplateIcon="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTYiIGhlaWdodD0iMTYiIHZpZXdCb3g9IjAgMCAxNiAxNiIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPGcgY2xpcC1wYXRoPSJ1cmwoI2NsaXAwXzkwXzI0MjApIj4KPHBhdGggZD0iTTguMzM4MzUgOS45NTM2NUwxMC4zODk0IDEyLjAxMDRMOC4zMzI2MiAxNC4wNjcyTDkuMTQ2MTYgMTQuODc1TDEyLjAxMDcgMTIuMDEwNEw5LjE0NjE2IDkuMTQ1ODNMOC4zMzgzNSA5Ljk1MzY1WiIgZmlsbD0iYmxhY2siLz4KPHBhdGggZD0iTTEyLjM0ODggOS45NTM2NUwxNC4zOTk4IDEyLjAxMDRMMTIuMzQzIDE0LjA2NzJMMTMuMTU2NiAxNC44NzVMMTYuMDIxMiAxMi4wMTA0TDEzLjE1NjYgOS4xNDU4M0wxMi4zNDg4IDkuOTUzNjVaIiBmaWxsPSJibGFjayIvPgo8cGF0aCBkPSJNMy45NzIgMTEuNDM3NUgxLjEyNTMzVjIuNzkyMTlMNy42NzM3NiA3LjMyMzk2QzcuNzY5NjcgNy4zOTA0OSA3Ljg4MzYgNy40MjYxNCA4LjAwMDMyIDcuNDI2MTRDOC4xMTcwNSA3LjQyNjE0IDguMjMwOTggNy4zOTA0OSA4LjMyNjg5IDcuMzIzOTZMMTQuODc1MyAyLjc5MjE5VjhIMTYuMDIxMlYyLjI3MDgzQzE2LjAyMTIgMS45NjY5NCAxNS45MDA0IDEuNjc1NDkgMTUuNjg1NiAxLjQ2MDYxQzE1LjQ3MDcgMS4yNDU3MiAxNS4xNzkyIDEuMTI1IDE0Ljg3NTMgMS4xMjVIMS4xMjUzM0MwLjgyMTQzMiAxLjEyNSAwLjUyOTk4NCAxLjI0NTcyIDAuMzE1MDk5IDEuNDYwNjFDMC4xMDAyMTQgMS42NzU0OSAtMC4wMjA1MDc4IDEuOTY2OTQgLTAuMDIwNTA3OCAyLjI3MDgzVjExLjQzNzVDLTAuMDIwNTA3OCAxMS43NDE0IDAuMTAwMjE0IDEyLjAzMjggMC4zMTUwOTkgMTIuMjQ3N0MwLjUyOTk4NCAxMi40NjI2IDAuODIxNDMyIDEyLjU4MzMgMS4xMjUzMyAxMi41ODMzSDMuOTcyVjExLjQzNzVaTTEzLjYxNDkgMi4yNzA4M0w4LjAwMDMyIDYuMTU1MjFMMi4zODU3NCAyLjI3MDgzSDEzLjYxNDlaIiBmaWxsPSIjRkM1RDBEIi8+CjxwYXRoIGQ9Ik00LjI4MjEgOS45NTM2NUw2LjMzMzE0IDEyLjAxMDRMNC4yNzYzNyAxNC4wNjcyTDUuMDg5OTEgMTQuODc1TDcuOTU0NDkgMTIuMDEwNEw1LjA4OTkxIDkuMTQ1ODNMNC4yODIxIDkuOTUzNjVaIiBmaWxsPSJibGFjayIvPgo8L2c+CjxkZWZzPgo8Y2xpcFBhdGggaWQ9ImNsaXAwXzkwXzI0MjAiPgo8cmVjdCB3aWR0aD0iMTYiIGhlaWdodD0iMTYiIGZpbGw9IndoaXRlIi8+CjwvY2xpcFBhdGg+CjwvZGVmcz4KPC9zdmc+Cg==">
+      <bpmn:extensionElements>
+        <zeebe:properties>
+          <zeebe:property name="inbound.type" value="io.camunda:connector-email-inbound:1" />
+          <zeebe:property name="authentication.type" value="simple" />
+          <zeebe:property name="authentication.username" value="test@camunda.com" />
+          <zeebe:property name="authentication.password" value="password" />
+          <zeebe:property name="data.imapConfig.imapHost" value="localhost" />
+          <zeebe:property name="data.imapConfig.imapPort" value="55555" />
+          <zeebe:property name="data.imapConfig.imapCryptographicProtocol" value="NONE" />
+          <zeebe:property name="data.pollingWaitTime" value="PT2S" />
+          <zeebe:property name="data.pollingConfigDiscriminator" value="unseenPollingConfig" />
+          <zeebe:property name="data.pollingConfig.handlingStrategy" value="MOVE" />
+          <zeebe:property name="data.pollingConfig.targetFolder" value="Test" />
+          <zeebe:property name="consumeUnmatchedEvents" value="true" />
+          <zeebe:property name="correlationKeyExpression" value="=&#34;ok&#34;" />
+          <zeebe:property name="deduplicationModeManualFlag" value="false" />
+          <zeebe:property name="deduplicationMode" value="AUTO" />
+          <zeebe:property name="resultVariable" />
+          <zeebe:property name="resultExpression" value="={fromAddress : fromAddress, messageId : messageId, subject: subject, size: size, plainTextBody : plainTextBody }" />
+        </zeebe:properties>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_0lofu08</bpmn:incoming>
+      <bpmn:outgoing>Flow_1vp6srd</bpmn:outgoing>
+      <bpmn:messageEventDefinition id="MessageEventDefinition_1om0jbh" messageRef="Message_1rm9467" />
+    </bpmn:intermediateCatchEvent>
+    <bpmn:sequenceFlow id="Flow_1vp6srd" sourceRef="Event_1y1ygyn" targetRef="Event_1aq97te" />
+  </bpmn:process>
+  <bpmn:message id="Message_1rm9467" name="7316a676-ddde-4c42-8c1e-9609113ef154" zeebe:modelerTemplate="io.camunda.connectors.inbound.EmailIntermediate.v1">
+    <bpmn:extensionElements>
+      <zeebe:subscription correlationKey="=&#34;ok&#34;" />
+    </bpmn:extensionElements>
+  </bpmn:message>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1crecrd">
+      <bpmndi:BPMNShape id="Event_1aq97te_di" bpmnElement="Event_1aq97te">
+        <dc:Bounds x="782" y="72" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0xs76az_di" bpmnElement="Event_0xs76az">
+        <dc:Bounds x="192" y="72" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1hvfzo1_di" bpmnElement="Event_1y1ygyn">
+        <dc:Bounds x="432" y="72" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0lofu08_di" bpmnElement="Flow_0lofu08">
+        <di:waypoint x="228" y="90" />
+        <di:waypoint x="432" y="90" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1vp6srd_di" bpmnElement="Flow_1vp6srd">
+        <di:waypoint x="468" y="90" />
+        <di:waypoint x="782" y="90" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/connectors-e2e-test/connectors-e2e-test-mail/src/test/resources/email-inbound-connector-intermediate_unseen_read.bpmn
+++ b/connectors-e2e-test/connectors-e2e-test-mail/src/test/resources/email-inbound-connector-intermediate_unseen_read.bpmn
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1ry9nn1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.24.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.5.0">
+  <bpmn:process id="Process_1crecrd" isExecutable="true">
+    <bpmn:endEvent id="Event_1aq97te">
+      <bpmn:incoming>Flow_1vp6srd</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:startEvent id="Event_0xs76az">
+      <bpmn:outgoing>Flow_0lofu08</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_0lofu08" sourceRef="Event_0xs76az" targetRef="Event_1y1ygyn" />
+    <bpmn:intermediateCatchEvent id="Event_1y1ygyn" zeebe:modelerTemplate="io.camunda.connectors.inbound.EmailIntermediate.v1" zeebe:modelerTemplateVersion="1" zeebe:modelerTemplateIcon="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTYiIGhlaWdodD0iMTYiIHZpZXdCb3g9IjAgMCAxNiAxNiIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPGcgY2xpcC1wYXRoPSJ1cmwoI2NsaXAwXzkwXzI0MjApIj4KPHBhdGggZD0iTTguMzM4MzUgOS45NTM2NUwxMC4zODk0IDEyLjAxMDRMOC4zMzI2MiAxNC4wNjcyTDkuMTQ2MTYgMTQuODc1TDEyLjAxMDcgMTIuMDEwNEw5LjE0NjE2IDkuMTQ1ODNMOC4zMzgzNSA5Ljk1MzY1WiIgZmlsbD0iYmxhY2siLz4KPHBhdGggZD0iTTEyLjM0ODggOS45NTM2NUwxNC4zOTk4IDEyLjAxMDRMMTIuMzQzIDE0LjA2NzJMMTMuMTU2NiAxNC44NzVMMTYuMDIxMiAxMi4wMTA0TDEzLjE1NjYgOS4xNDU4M0wxMi4zNDg4IDkuOTUzNjVaIiBmaWxsPSJibGFjayIvPgo8cGF0aCBkPSJNMy45NzIgMTEuNDM3NUgxLjEyNTMzVjIuNzkyMTlMNy42NzM3NiA3LjMyMzk2QzcuNzY5NjcgNy4zOTA0OSA3Ljg4MzYgNy40MjYxNCA4LjAwMDMyIDcuNDI2MTRDOC4xMTcwNSA3LjQyNjE0IDguMjMwOTggNy4zOTA0OSA4LjMyNjg5IDcuMzIzOTZMMTQuODc1MyAyLjc5MjE5VjhIMTYuMDIxMlYyLjI3MDgzQzE2LjAyMTIgMS45NjY5NCAxNS45MDA0IDEuNjc1NDkgMTUuNjg1NiAxLjQ2MDYxQzE1LjQ3MDcgMS4yNDU3MiAxNS4xNzkyIDEuMTI1IDE0Ljg3NTMgMS4xMjVIMS4xMjUzM0MwLjgyMTQzMiAxLjEyNSAwLjUyOTk4NCAxLjI0NTcyIDAuMzE1MDk5IDEuNDYwNjFDMC4xMDAyMTQgMS42NzU0OSAtMC4wMjA1MDc4IDEuOTY2OTQgLTAuMDIwNTA3OCAyLjI3MDgzVjExLjQzNzVDLTAuMDIwNTA3OCAxMS43NDE0IDAuMTAwMjE0IDEyLjAzMjggMC4zMTUwOTkgMTIuMjQ3N0MwLjUyOTk4NCAxMi40NjI2IDAuODIxNDMyIDEyLjU4MzMgMS4xMjUzMyAxMi41ODMzSDMuOTcyVjExLjQzNzVaTTEzLjYxNDkgMi4yNzA4M0w4LjAwMDMyIDYuMTU1MjFMMi4zODU3NCAyLjI3MDgzSDEzLjYxNDlaIiBmaWxsPSIjRkM1RDBEIi8+CjxwYXRoIGQ9Ik00LjI4MjEgOS45NTM2NUw2LjMzMzE0IDEyLjAxMDRMNC4yNzYzNyAxNC4wNjcyTDUuMDg5OTEgMTQuODc1TDcuOTU0NDkgMTIuMDEwNEw1LjA4OTkxIDkuMTQ1ODNMNC4yODIxIDkuOTUzNjVaIiBmaWxsPSJibGFjayIvPgo8L2c+CjxkZWZzPgo8Y2xpcFBhdGggaWQ9ImNsaXAwXzkwXzI0MjAiPgo8cmVjdCB3aWR0aD0iMTYiIGhlaWdodD0iMTYiIGZpbGw9IndoaXRlIi8+CjwvY2xpcFBhdGg+CjwvZGVmcz4KPC9zdmc+Cg==">
+      <bpmn:extensionElements>
+        <zeebe:properties>
+          <zeebe:property name="inbound.type" value="io.camunda:connector-email-inbound:1" />
+          <zeebe:property name="authentication.type" value="simple" />
+          <zeebe:property name="authentication.username" value="test@camunda.com" />
+          <zeebe:property name="authentication.password" value="password" />
+          <zeebe:property name="data.imapConfig.imapHost" value="localhost" />
+          <zeebe:property name="data.imapConfig.imapPort" value="55555" />
+          <zeebe:property name="data.imapConfig.imapCryptographicProtocol" value="NONE" />
+          <zeebe:property name="data.pollingWaitTime" value="PT2S" />
+          <zeebe:property name="data.pollingConfigDiscriminator" value="unseenPollingConfig" />
+          <zeebe:property name="data.pollingConfig.handlingStrategy" value="READ" />
+          <zeebe:property name="consumeUnmatchedEvents" value="true" />
+          <zeebe:property name="correlationKeyExpression" value="=&#34;ok&#34;" />
+          <zeebe:property name="deduplicationModeManualFlag" value="false" />
+          <zeebe:property name="deduplicationMode" value="AUTO" />
+          <zeebe:property name="resultVariable" />
+          <zeebe:property name="resultExpression" value="={fromAddress : fromAddress, messageId : messageId, subject: subject, size: size, plainTextBody : plainTextBody }" />
+        </zeebe:properties>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_0lofu08</bpmn:incoming>
+      <bpmn:outgoing>Flow_1vp6srd</bpmn:outgoing>
+      <bpmn:messageEventDefinition id="MessageEventDefinition_1om0jbh" messageRef="Message_1rm9467" />
+    </bpmn:intermediateCatchEvent>
+    <bpmn:sequenceFlow id="Flow_1vp6srd" sourceRef="Event_1y1ygyn" targetRef="Event_1aq97te" />
+  </bpmn:process>
+  <bpmn:message id="Message_1rm9467" name="b0610e39-41ff-4bd2-8b01-43288823fbf2" zeebe:modelerTemplate="io.camunda.connectors.inbound.EmailIntermediate.v1">
+    <bpmn:extensionElements>
+      <zeebe:subscription correlationKey="=&#34;ok&#34;" />
+    </bpmn:extensionElements>
+  </bpmn:message>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1crecrd">
+      <bpmndi:BPMNShape id="Event_1aq97te_di" bpmnElement="Event_1aq97te">
+        <dc:Bounds x="782" y="72" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0xs76az_di" bpmnElement="Event_0xs76az">
+        <dc:Bounds x="192" y="72" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1hvfzo1_di" bpmnElement="Event_1y1ygyn">
+        <dc:Bounds x="432" y="72" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0lofu08_di" bpmnElement="Flow_0lofu08">
+        <di:waypoint x="228" y="90" />
+        <di:waypoint x="432" y="90" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1vp6srd_di" bpmnElement="Flow_1vp6srd">
+        <di:waypoint x="468" y="90" />
+        <di:waypoint x="782" y="90" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/connectors/email/src/main/java/io/camunda/connector/email/client/jakarta/inbound/JakartaEmailListener.java
+++ b/connectors/email/src/main/java/io/camunda/connector/email/client/jakarta/inbound/JakartaEmailListener.java
@@ -11,12 +11,9 @@ import io.camunda.connector.email.client.EmailListener;
 import io.camunda.connector.email.client.jakarta.utils.JakartaUtils;
 import java.util.Objects;
 import java.util.concurrent.*;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class JakartaEmailListener implements EmailListener {
 
-  private static final Logger log = LoggerFactory.getLogger(JakartaEmailListener.class);
   private ScheduledExecutorService scheduledExecutorService;
   private PollingManager pollingManager;
 

--- a/connectors/email/src/main/java/io/camunda/connector/email/client/jakarta/outbound/JakartaEmailActionExecutor.java
+++ b/connectors/email/src/main/java/io/camunda/connector/email/client/jakarta/outbound/JakartaEmailActionExecutor.java
@@ -64,9 +64,8 @@ public class JakartaEmailActionExecutor implements EmailActionExecutor {
       ImapSearchEmails imapSearchEmails, Authentication authentication, Session session) {
     try (Store store = session.getStore()) {
       this.jakartaUtils.connectStore(store, authentication);
-      Folder defaultFolder = store.getDefaultFolder();
       String targetFolder = imapSearchEmails.searchEmailFolder();
-      try (Folder imapFolder = this.jakartaUtils.findImapFolder(defaultFolder, targetFolder)) {
+      try (Folder imapFolder = this.jakartaUtils.findImapFolder(store, targetFolder)) {
         return searchEmails(imapFolder, imapSearchEmails.criteria());
       }
     } catch (MessagingException e) {
@@ -78,9 +77,8 @@ public class JakartaEmailActionExecutor implements EmailActionExecutor {
       ImapReadEmail imapReadEmail, Authentication authentication, Session session) {
     try (Store store = session.getStore()) {
       this.jakartaUtils.connectStore(store, authentication);
-      Folder defaultFolder = store.getDefaultFolder();
       String targetFolder = imapReadEmail.readEmailFolder();
-      try (Folder imapFolder = this.jakartaUtils.findImapFolder(defaultFolder, targetFolder)) {
+      try (Folder imapFolder = this.jakartaUtils.findImapFolder(store, targetFolder)) {
         imapFolder.open(Folder.READ_ONLY);
         Message[] messages = imapFolder.search(new MessageIDTerm(imapReadEmail.messageId()));
         return Arrays.stream(messages)
@@ -108,9 +106,8 @@ public class JakartaEmailActionExecutor implements EmailActionExecutor {
       ImapDeleteEmail imapDeleteEmail, Authentication authentication, Session session) {
     try (Store store = session.getStore()) {
       this.jakartaUtils.connectStore(store, authentication);
-      Folder defaultFolder = store.getDefaultFolder();
       String targetFolder = imapDeleteEmail.deleteEmailFolder();
-      try (Folder folder = this.jakartaUtils.findImapFolder(defaultFolder, targetFolder)) {
+      try (Folder folder = this.jakartaUtils.findImapFolder(store, targetFolder)) {
         return deleteEmail(folder, imapDeleteEmail.messageId());
       }
     } catch (MessagingException e) {
@@ -122,18 +119,9 @@ public class JakartaEmailActionExecutor implements EmailActionExecutor {
       ImapMoveEmail imapMoveEmail, Authentication authentication, Session session) {
     try (Store store = session.getStore()) {
       this.jakartaUtils.connectStore(store, authentication);
-      Folder rootFolder = store.getDefaultFolder();
       String fromFolder = imapMoveEmail.fromFolder();
-      String toFolder = imapMoveEmail.toFolder();
-      Folder sourceImapFolder = this.jakartaUtils.findImapFolder(rootFolder, fromFolder);
-      if (!sourceImapFolder.exists()) throw new MessagingException("Source folder does not exist");
+      Folder sourceImapFolder = this.jakartaUtils.findImapFolder(store, fromFolder);
       sourceImapFolder.open(Folder.READ_WRITE);
-      Folder targetImapFolder =
-          store.getFolder(
-              String.join(String.valueOf(rootFolder.getSeparator()), toFolder.split("\\.")));
-      if (!targetImapFolder.exists()) targetImapFolder.create(Folder.HOLDS_MESSAGES);
-      targetImapFolder.open(Folder.READ_WRITE);
-
       Message[] messages = sourceImapFolder.search(new MessageIDTerm(imapMoveEmail.messageId()));
       Message message =
           Arrays.stream(messages)
@@ -143,10 +131,8 @@ public class JakartaEmailActionExecutor implements EmailActionExecutor {
                       new MessagingException(
                           "Email with messageId %s does not exist"
                               .formatted(imapMoveEmail.messageId())));
-      sourceImapFolder.copyMessages(new Message[] {message}, targetImapFolder);
-      this.jakartaUtils.markAsDeleted(message);
+      this.jakartaUtils.moveMessage(store, message, imapMoveEmail.toFolder());
       sourceImapFolder.close();
-      targetImapFolder.close();
       return new MoveEmailResponse(
           imapMoveEmail.messageId(), imapMoveEmail.fromFolder(), imapMoveEmail.toFolder());
     } catch (MessagingException e) {
@@ -158,9 +144,8 @@ public class JakartaEmailActionExecutor implements EmailActionExecutor {
       ImapListEmails imapListEmails, Authentication authentication, Session session) {
     try (Store store = session.getStore()) {
       this.jakartaUtils.connectStore(store, authentication);
-      Folder rootFolder = store.getDefaultFolder();
       String targetFolder = imapListEmails.listEmailsFolder();
-      try (Folder imapFolder = this.jakartaUtils.findImapFolder(rootFolder, targetFolder)) {
+      try (Folder imapFolder = this.jakartaUtils.findImapFolder(store, targetFolder)) {
         imapFolder.open(Folder.READ_ONLY);
         return Arrays.stream(imapFolder.getMessages())
             .map(this.jakartaUtils::createBodylessEmail)

--- a/connectors/email/src/main/java/io/camunda/connector/email/client/jakarta/utils/JakartaUtils.java
+++ b/connectors/email/src/main/java/io/camunda/connector/email/client/jakarta/utils/JakartaUtils.java
@@ -33,6 +33,7 @@ import org.slf4j.LoggerFactory;
 public class JakartaUtils {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(JakartaUtils.class);
+  private static final String REGEX_PATH_SPLITTER = "[./]";
 
   public Session createSession(Configuration configuration) {
     return Session.getInstance(
@@ -165,31 +166,19 @@ public class JakartaUtils {
         };
   }
 
-  private Folder findFolderRecursively(Folder rootFolder, String targetFolder)
-      throws MessagingException {
-    if (targetFolder == null || targetFolder.isEmpty() || "INBOX".equals(targetFolder)) {
-      return rootFolder.getFolder("INBOX");
+  public Folder findImapFolder(Store store, String folderPath) throws MessagingException {
+    if (folderPath == null || folderPath.isEmpty() || "INBOX".equalsIgnoreCase(folderPath)) {
+      return store.getFolder("INBOX");
     }
-    Folder[] folders = rootFolder.list();
-    for (Folder folder : folders) {
-      if (folder.getName().equals(targetFolder)) {
-        return folder;
-      } else {
-        Folder folderReturned = findFolderRecursively(folder, targetFolder);
-        if (folderReturned != null) {
-          return folderReturned;
-        }
-      }
-    }
-    return null;
-  }
-
-  public Folder findImapFolder(Folder rootFolder, String targetFolder) throws MessagingException {
-    Folder folder = findFolderRecursively(rootFolder, targetFolder);
-    if (folder != null) {
-      return folder;
-    }
-    throw new MessagingException("Unable to find IMAP folder");
+    char separator = store.getDefaultFolder().getSeparator();
+    String formattedPath =
+        Optional.of(folderPath)
+            .map(string -> string.split(REGEX_PATH_SPLITTER))
+            .map(strings -> String.join(String.valueOf(separator), strings))
+            .orElseThrow(() -> new RuntimeException("No folder has been set"));
+    Folder folder = store.getFolder(formattedPath);
+    if (!folder.exists()) throw new RuntimeException("Folder " + formattedPath + " does not exist");
+    return folder;
   }
 
   public Email createBodylessEmail(Message message) {
@@ -321,9 +310,9 @@ public class JakartaUtils {
       char separator = imapFolder.getSeparator();
       String targetFolderFormatted =
           Optional.ofNullable(targetFolder)
-              .map(string -> string.split("\\."))
+              .map(string -> string.split(REGEX_PATH_SPLITTER))
               .map(strings -> String.join(String.valueOf(separator), strings))
-              .orElse("temp");
+              .orElseThrow(() -> new RuntimeException("No folder has been set"));
       Folder targetImapFolder = store.getFolder(targetFolderFormatted);
       if (!targetImapFolder.exists()) targetImapFolder.create(Folder.HOLDS_MESSAGES);
       targetImapFolder.open(Folder.READ_WRITE);

--- a/connectors/idp-extraction/element-templates/hybrid/hybrid-idp-extraction-outbound-connector-hybrid.json
+++ b/connectors/idp-extraction/element-templates/hybrid/hybrid-idp-extraction-outbound-connector-hybrid.json
@@ -1,0 +1,176 @@
+{
+  "$schema" : "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+  "name" : "Hybrid IDP extraction outbound Connector",
+  "id" : "io.camunda.connector.IdpExtractionOutBoundTemplate.v1-hybrid",
+  "description" : "Execute IDP extraction requests",
+  "documentationRef" : "https://docs.camunda.io/docs/guides/",
+  "version" : 1,
+  "category" : {
+    "id" : "connectors",
+    "name" : "Connectors"
+  },
+  "appliesTo" : [ "bpmn:Task" ],
+  "elementType" : {
+    "value" : "bpmn:ServiceTask"
+  },
+  "groups" : [ {
+    "id" : "taskDefinitionType",
+    "label" : "Task definition type"
+  }, {
+    "id" : "input",
+    "label" : "Input message data"
+  }, {
+    "id" : "output",
+    "label" : "Output mapping"
+  }, {
+    "id" : "error",
+    "label" : "Error handling"
+  }, {
+    "id" : "retries",
+    "label" : "Retries"
+  } ],
+  "properties" : [ {
+    "id" : "taskDefinitionType",
+    "value" : "io.camunda:idp-extraction-connector-template:1",
+    "group" : "taskDefinitionType",
+    "binding" : {
+      "property" : "type",
+      "type" : "zeebe:taskDefinition"
+    },
+    "type" : "String"
+  }, {
+    "id" : "input.extractionEngineType",
+    "label" : "Extraction engine type",
+    "description" : "Specify extraction engine to be used",
+    "optional" : false,
+    "value" : "= input.extractionEngineType",
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "group" : "input",
+    "binding" : {
+      "name" : "input.extractionEngineType",
+      "type" : "zeebe:input"
+    },
+    "type" : "Hidden"
+  }, {
+    "id" : "input.documentUrl",
+    "label" : "Document URL",
+    "description" : "Specify the URL where the document is hosted",
+    "optional" : false,
+    "value" : "= input.documentUrl",
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "group" : "input",
+    "binding" : {
+      "name" : "input.documentUrl",
+      "type" : "zeebe:input"
+    },
+    "type" : "Hidden"
+  }, {
+    "id" : "input.s3BucketName",
+    "label" : "AWS S3 Bucket name",
+    "description" : "Specify the name of the AWS S3 bucket where document will be stored temporarily during Textract analysis",
+    "optional" : false,
+    "value" : "idp-extraction-connector",
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "group" : "input",
+    "binding" : {
+      "name" : "input.s3BucketName",
+      "type" : "zeebe:input"
+    },
+    "type" : "Text"
+  }, {
+    "id" : "input.taxonomyItems",
+    "label" : "Taxonomy Items",
+    "description" : "Array of taxonomy items",
+    "optional" : false,
+    "value" : "= input.taxonomyItems",
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "group" : "input",
+    "binding" : {
+      "name" : "input.taxonomyItems",
+      "type" : "zeebe:input"
+    },
+    "type" : "Hidden"
+  }, {
+    "id" : "input.converseData",
+    "label" : "AWS Bedrock Converse Parameters",
+    "description" : "Specify the parameters for AWS Bedrock",
+    "optional" : false,
+    "value" : "= input.converseData",
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "group" : "input",
+    "binding" : {
+      "name" : "input.converseData",
+      "type" : "zeebe:input"
+    },
+    "type" : "Hidden"
+  }, {
+    "id" : "resultVariable",
+    "label" : "Result variable",
+    "description" : "Name of variable to store the response in",
+    "group" : "output",
+    "binding" : {
+      "key" : "resultVariable",
+      "type" : "zeebe:taskHeader"
+    },
+    "type" : "String"
+  }, {
+    "id" : "resultExpression",
+    "label" : "Result expression",
+    "description" : "Expression to map the response into process variables",
+    "feel" : "required",
+    "group" : "output",
+    "binding" : {
+      "key" : "resultExpression",
+      "type" : "zeebe:taskHeader"
+    },
+    "type" : "Text"
+  }, {
+    "id" : "errorExpression",
+    "label" : "Error expression",
+    "description" : "Expression to handle errors. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/\" target=\"_blank\">documentation</a>.",
+    "feel" : "required",
+    "group" : "error",
+    "binding" : {
+      "key" : "errorExpression",
+      "type" : "zeebe:taskHeader"
+    },
+    "type" : "Text"
+  }, {
+    "id" : "retryCount",
+    "label" : "Retries",
+    "description" : "Number of retries",
+    "value" : "3",
+    "feel" : "optional",
+    "group" : "retries",
+    "binding" : {
+      "property" : "retries",
+      "type" : "zeebe:taskDefinition"
+    },
+    "type" : "String"
+  }, {
+    "id" : "retryBackoff",
+    "label" : "Retry backoff",
+    "description" : "ISO-8601 duration to wait between retries",
+    "value" : "PT0S",
+    "feel" : "optional",
+    "group" : "retries",
+    "binding" : {
+      "key" : "retryBackoff",
+      "type" : "zeebe:taskHeader"
+    },
+    "type" : "String"
+  } ],
+  "icon" : {
+    "contents" : "data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjAiIGhlaWdodD0iMjAiIHZpZXdCb3g9IjAgMCAyMCAyMCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHJlY3Qgd2lkdGg9IjE5LjE3ODkiIGhlaWdodD0iMTkuMTc4OSIgZmlsbD0id2hpdGUiIGZpbGwtb3BhY2l0eT0iMC4wMSIgc3R5bGU9Im1peC1ibGVuZC1tb2RlOm11bHRpcGx5Ii8+CjxwYXRoIGQ9Ik0xNi43ODA2IDcuMTkyMDhIMTEuOTg1OVYyLjM5NzM3SDE2Ljc4MDZWNy4xOTIwOFpNMTMuMTg0NiA1Ljk5MzRIMTUuNTgxOVYzLjU5NjA1SDEzLjE4NDZWNS45OTM0WiIgZmlsbD0iI0ZDNUQwRCIvPgo8cGF0aCBkPSJNMTAuMTg3OSA4Ljk5MDFWNS4zOTQwN0g1LjM5MzE4VjEzLjc4NDhIMTMuNzgzOVY4Ljk5MDFIMTAuMTg3OVpNNi41OTE4NiA2LjU5Mjc0SDguOTg5MjFWOC45OTAxSDYuNTkxODZWNi41OTI3NFpNOC45ODkyMSAxMi41ODYxSDYuNTkxODZWMTAuMTg4OEg4Ljk4OTIxVjEyLjU4NjFaTTEyLjU4NTIgMTIuNTg2MUgxMC4xODc5VjEwLjE4ODhIMTIuNTg1MlYxMi41ODYxWiIgZmlsbD0iI0ZDNUQwRCIvPgo8cGF0aCBkPSJNMTUuNTgxOSAxNi43ODE1SDMuNTk1MTZDMy4yNzczNyAxNi43ODExIDIuOTcyNjkgMTYuNjU0NyAyLjc0Nzk3IDE2LjQzQzIuNTIzMjYgMTYuMjA1MyAyLjM5Njg1IDE1LjkwMDYgMi4zOTY0OCAxNS41ODI4VjMuNTk2MDVDMi4zOTY4NSAzLjI3ODI1IDIuNTIzMjYgMi45NzM1NyAyLjc0Nzk3IDIuNzQ4ODZDMi45NzI2OSAyLjUyNDE0IDMuMjc3MzcgMi4zOTc3MyAzLjU5NTE2IDIuMzk3MzdIOS41ODg1NVYzLjU5NjA1SDMuNTk1MTZWMTUuNTgyOEgxNS41ODE5VjkuNTg5NDRIMTYuNzgwNlYxNS41ODI4QzE2Ljc4MDMgMTUuOTAwNiAxNi42NTM5IDE2LjIwNTMgMTYuNDI5MSAxNi40M0MxNi4yMDQ0IDE2LjY1NDcgMTUuODk5NyAxNi43ODExIDE1LjU4MTkgMTYuNzgxNVoiIGZpbGw9IiMxNjE2MTYiLz4KPC9zdmc+Cg=="
+  }
+}

--- a/connectors/idp-extraction/element-templates/idp-extraction-outbound-connector.json
+++ b/connectors/idp-extraction/element-templates/idp-extraction-outbound-connector.json
@@ -1,0 +1,172 @@
+
+{
+  "$schema" : "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+  "name" : "IDP extraction outbound Connector",
+  "id" : "io.camunda.connector.IdpExtractionOutBoundTemplate.v1",
+  "description" : "Execute IDP extraction requests",
+  "documentationRef" : "https://docs.camunda.io/docs/guides/",
+  "version" : 1,
+  "category" : {
+    "id" : "connectors",
+    "name" : "Connectors"
+  },
+  "appliesTo" : [ "bpmn:Task" ],
+  "elementType" : {
+    "value" : "bpmn:ServiceTask"
+  },
+  "groups" : [ {
+    "id" : "input",
+    "label" : "Input message data"
+  }, {
+    "id" : "output",
+    "label" : "Output mapping"
+  }, {
+    "id" : "error",
+    "label" : "Error handling"
+  }, {
+    "id" : "retries",
+    "label" : "Retries"
+  } ],
+  "properties" : [ {
+    "value" : "io.camunda:idp-extraction-connector-template:1",
+    "binding" : {
+      "property" : "type",
+      "type" : "zeebe:taskDefinition"
+    },
+    "type" : "Hidden"
+  }, {
+    "id" : "input.extractionEngineType",
+    "label" : "Extraction engine type",
+    "description" : "Specify extraction engine to be used",
+    "optional" : false,
+    "value" : "= input.extractionEngineType",
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "group" : "input",
+    "binding" : {
+      "name" : "input.extractionEngineType",
+      "type" : "zeebe:input"
+    },
+    "type" : "Hidden"
+  }, {
+    "id" : "input.documentUrl",
+    "label" : "Document URL",
+    "description" : "Specify the URL where the document is hosted",
+    "optional" : false,
+    "value" : "= input.documentUrl",
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "group" : "input",
+    "binding" : {
+      "name" : "input.documentUrl",
+      "type" : "zeebe:input"
+    },
+    "type" : "Hidden"
+  }, {
+    "id" : "input.s3BucketName",
+    "label" : "AWS S3 Bucket name",
+    "description" : "Specify the name of the AWS S3 bucket where document will be stored temporarily during Textract analysis",
+    "optional" : false,
+    "value" : "idp-extraction-connector",
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "group" : "input",
+    "binding" : {
+      "name" : "input.s3BucketName",
+      "type" : "zeebe:input"
+    },
+    "type" : "Text"
+  }, {
+    "id" : "input.taxonomyItems",
+    "label" : "Taxonomy Items",
+    "description" : "Array of taxonomy items",
+    "optional" : false,
+    "value" : "= input.taxonomyItems",
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "group" : "input",
+    "binding" : {
+      "name" : "input.taxonomyItems",
+      "type" : "zeebe:input"
+    },
+    "type" : "Hidden"
+  }, {
+    "id" : "input.converseData",
+    "label" : "AWS Bedrock Converse Parameters",
+    "description" : "Specify the parameters for AWS Bedrock",
+    "optional" : false,
+    "value" : "= input.converseData",
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "group" : "input",
+    "binding" : {
+      "name" : "input.converseData",
+      "type" : "zeebe:input"
+    },
+    "type" : "Hidden"
+  }, {
+    "id" : "resultVariable",
+    "label" : "Result variable",
+    "description" : "Name of variable to store the response in",
+    "group" : "output",
+    "binding" : {
+      "key" : "resultVariable",
+      "type" : "zeebe:taskHeader"
+    },
+    "type" : "String"
+  }, {
+    "id" : "resultExpression",
+    "label" : "Result expression",
+    "description" : "Expression to map the response into process variables",
+    "feel" : "required",
+    "group" : "output",
+    "binding" : {
+      "key" : "resultExpression",
+      "type" : "zeebe:taskHeader"
+    },
+    "type" : "Text"
+  }, {
+    "id" : "errorExpression",
+    "label" : "Error expression",
+    "description" : "Expression to handle errors. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/\" target=\"_blank\">documentation</a>.",
+    "feel" : "required",
+    "group" : "error",
+    "binding" : {
+      "key" : "errorExpression",
+      "type" : "zeebe:taskHeader"
+    },
+    "type" : "Text"
+  }, {
+    "id" : "retryCount",
+    "label" : "Retries",
+    "description" : "Number of retries",
+    "value" : "3",
+    "feel" : "optional",
+    "group" : "retries",
+    "binding" : {
+      "property" : "retries",
+      "type" : "zeebe:taskDefinition"
+    },
+    "type" : "String"
+  }, {
+    "id" : "retryBackoff",
+    "label" : "Retry backoff",
+    "description" : "ISO-8601 duration to wait between retries",
+    "value" : "PT0S",
+    "feel" : "optional",
+    "group" : "retries",
+    "binding" : {
+      "key" : "retryBackoff",
+      "type" : "zeebe:taskHeader"
+    },
+    "type" : "String"
+  } ],
+  "icon" : {
+    "contents" : "data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjAiIGhlaWdodD0iMjAiIHZpZXdCb3g9IjAgMCAyMCAyMCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHJlY3Qgd2lkdGg9IjE5LjE3ODkiIGhlaWdodD0iMTkuMTc4OSIgZmlsbD0id2hpdGUiIGZpbGwtb3BhY2l0eT0iMC4wMSIgc3R5bGU9Im1peC1ibGVuZC1tb2RlOm11bHRpcGx5Ii8+CjxwYXRoIGQ9Ik0xNi43ODA2IDcuMTkyMDhIMTEuOTg1OVYyLjM5NzM3SDE2Ljc4MDZWNy4xOTIwOFpNMTMuMTg0NiA1Ljk5MzRIMTUuNTgxOVYzLjU5NjA1SDEzLjE4NDZWNS45OTM0WiIgZmlsbD0iI0ZDNUQwRCIvPgo8cGF0aCBkPSJNMTAuMTg3OSA4Ljk5MDFWNS4zOTQwN0g1LjM5MzE4VjEzLjc4NDhIMTMuNzgzOVY4Ljk5MDFIMTAuMTg3OVpNNi41OTE4NiA2LjU5Mjc0SDguOTg5MjFWOC45OTAxSDYuNTkxODZWNi41OTI3NFpNOC45ODkyMSAxMi41ODYxSDYuNTkxODZWMTAuMTg4OEg4Ljk4OTIxVjEyLjU4NjFaTTEyLjU4NTIgMTIuNTg2MUgxMC4xODc5VjEwLjE4ODhIMTIuNTg1MlYxMi41ODYxWiIgZmlsbD0iI0ZDNUQwRCIvPgo8cGF0aCBkPSJNMTUuNTgxOSAxNi43ODE1SDMuNTk1MTZDMy4yNzczNyAxNi43ODExIDIuOTcyNjkgMTYuNjU0NyAyLjc0Nzk3IDE2LjQzQzIuNTIzMjYgMTYuMjA1MyAyLjM5Njg1IDE1LjkwMDYgMi4zOTY0OCAxNS41ODI4VjMuNTk2MDVDMi4zOTY4NSAzLjI3ODI1IDIuNTIzMjYgMi45NzM1NyAyLjc0Nzk3IDIuNzQ4ODZDMi45NzI2OSAyLjUyNDE0IDMuMjc3MzcgMi4zOTc3MyAzLjU5NTE2IDIuMzk3MzdIOS41ODg1NVYzLjU5NjA1SDMuNTk1MTZWMTUuNTgyOEgxNS41ODE5VjkuNTg5NDRIMTYuNzgwNlYxNS41ODI4QzE2Ljc4MDMgMTUuOTAwNiAxNi42NTM5IDE2LjIwNTMgMTYuNDI5MSAxNi40M0MxNi4yMDQ0IDE2LjY1NDcgMTUuODk5NyAxNi43ODExIDE1LjU4MTkgMTYuNzgxNVoiIGZpbGw9IiMxNjE2MTYiLz4KPC9zdmc+Cg=="
+  }
+}


### PR DESCRIPTION
…ism (#3506)

* fix(email-inbound-connector): implement a reconnect and reopen mechanism

* fix(email-connectors): add equalsIgnoreCase for INBOX

* fix(email-inbound-connector): add integration tests, modify the split for folder creation, and add unit tests

* fix(email-inbound-connector): add integration tests, modify the split for folder creation, and add unit tests 2

(cherry picked from commit be06a0ee548f5049437bf24b54b2e730cdf1c582)

## Description

<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #

## Checklist

- [ ] PR has a **milestone** or the `no milestone` label.

