### PR TITLE
chore(tests): Random port for Wiremock

### DIFF
--- a/connectors/http/http-base/src/test/java/io/camunda/connector/http/base/client/apache/CustomApacheHttpClientTest.java
+++ b/connectors/http/http-base/src/test/java/io/camunda/connector/http/base/client/apache/CustomApacheHttpClientTest.java
@@ -39,6 +39,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.unauthorized;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.verify;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -140,7 +141,7 @@ public class CustomApacheHttpClientTest {
   @Nested
   class ProxyTests {
 
-    private static final WireMockServer proxy = new WireMockServer();
+    private static final WireMockServer proxy = new WireMockServer(options().dynamicPort());
     private static CustomApacheHttpClient proxiedApacheHttpClient;
     private static GenericContainer<?> proxyContainer;
 


### PR DESCRIPTION
## Description

Use a random port for WireMock so that you can have something running on 8080 locally.
