### PR TITLE
feat(mail-connector): Adding Dropdown for Outbound Connector to switch content type between plain text and html

### DIFF
--- a/connector-sdk/validation/src/main/java/io/camunda/connector/validation/impl/DefaultValidationProvider.java
+++ b/connector-sdk/validation/src/main/java/io/camunda/connector/validation/impl/DefaultValidationProvider.java
@@ -44,7 +44,7 @@ public class DefaultValidationProvider implements ValidationProvider {
         validatorFactory.getValidator().validate(objectToValidate);
     if (!violations.isEmpty()) {
       String errorMessage = composeMessage(violations);
-      throw new ConnectorInputException(errorMessage, new ValidationException(errorMessage));
+      throw new ConnectorInputException(new ValidationException(errorMessage));
     }
   }
 

--- a/connector-sdk/validation/src/main/java/io/camunda/connector/validation/impl/DefaultValidationProvider.java
+++ b/connector-sdk/validation/src/main/java/io/camunda/connector/validation/impl/DefaultValidationProvider.java
@@ -44,7 +44,7 @@ public class DefaultValidationProvider implements ValidationProvider {
         validatorFactory.getValidator().validate(objectToValidate);
     if (!violations.isEmpty()) {
       String errorMessage = composeMessage(violations);
-      throw new ConnectorInputException(new ValidationException(errorMessage));
+      throw new ConnectorInputException(errorMessage, new ValidationException(errorMessage));
     }
   }
 

--- a/connectors-e2e-test/connectors-e2e-test-mail/src/test/java/io/camunda/connector/e2e/BaseEmailTest.java
+++ b/connectors-e2e-test/connectors-e2e-test-mail/src/test/java/io/camunda/connector/e2e/BaseEmailTest.java
@@ -24,6 +24,7 @@ import jakarta.mail.Address;
 import jakarta.mail.Message;
 import jakarta.mail.MessagingException;
 import jakarta.mail.Multipart;
+import jakarta.mail.internet.MimeBodyPart;
 import jakarta.mail.internet.MimeMessage;
 import java.io.File;
 import java.io.IOException;
@@ -69,7 +70,28 @@ public class BaseEmailTest {
   protected static String getPlainTextBody(Message message) {
     try {
       if (message.getContent() instanceof Multipart multipart) {
-        return multipart.getBodyPart(0).getContent().toString();
+        for (int i = 0; i < multipart.getCount(); i++) {
+          MimeBodyPart bodyPart = (MimeBodyPart) multipart.getBodyPart(i);
+          if (bodyPart.isMimeType("text/plain")) {
+            return (String) bodyPart.getContent();
+          }
+        }
+      }
+      return null;
+    } catch (MessagingException | IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  protected static String getHtmlBody(Message message) {
+    try {
+      if (message.getContent() instanceof Multipart multipart) {
+        for (int i = 0; i < multipart.getCount(); i++) {
+          MimeBodyPart bodyPart = (MimeBodyPart) multipart.getBodyPart(i);
+          if (bodyPart.isMimeType("text/html")) {
+            return (String) bodyPart.getContent();
+          }
+        }
       }
       return null;
     } catch (MessagingException | IOException e) {

--- a/connectors-e2e-test/connectors-e2e-test-mail/src/test/java/io/camunda/connector/e2e/BaseEmailTest.java
+++ b/connectors-e2e-test/connectors-e2e-test-mail/src/test/java/io/camunda/connector/e2e/BaseEmailTest.java
@@ -23,6 +23,7 @@ import com.icegreen.greenmail.util.GreenMailUtil;
 import jakarta.mail.Address;
 import jakarta.mail.Message;
 import jakarta.mail.MessagingException;
+import jakarta.mail.Multipart;
 import jakarta.mail.internet.MimeMessage;
 import java.io.File;
 import java.io.IOException;
@@ -67,7 +68,10 @@ public class BaseEmailTest {
 
   protected static String getPlainTextBody(Message message) {
     try {
-      return message.getContent().toString().trim();
+      if (message.getContent() instanceof Multipart multipart) {
+        return multipart.getBodyPart(0).getContent().toString();
+      }
+      return null;
     } catch (MessagingException | IOException e) {
       throw new RuntimeException(e);
     }

--- a/connectors-e2e-test/connectors-e2e-test-mail/src/test/java/io/camunda/connector/e2e/InboundEmailTest.java
+++ b/connectors-e2e-test/connectors-e2e-test-mail/src/test/java/io/camunda/connector/e2e/InboundEmailTest.java
@@ -27,12 +27,14 @@ import io.camunda.connector.runtime.inbound.state.ProcessStateStore;
 import io.camunda.operate.CamundaOperateClient;
 import io.camunda.operate.exception.OperateException;
 import io.camunda.operate.model.ProcessDefinition;
+import io.camunda.process.test.api.CamundaAssert;
 import io.camunda.process.test.api.CamundaSpringProcessTest;
 import io.camunda.zeebe.client.ZeebeClient;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.model.bpmn.instance.Process;
 import jakarta.mail.Flags;
 import jakarta.mail.MessagingException;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.concurrent.Executors;
@@ -70,6 +72,7 @@ public class InboundEmailTest extends BaseEmailTest {
   @BeforeEach
   public void beforeEach() {
     super.reset();
+    CamundaAssert.setAssertionTimeout(Duration.ofSeconds(20));
   }
 
   @Test

--- a/connectors-e2e-test/connectors-e2e-test-mail/src/test/java/io/camunda/connector/e2e/OutboundEmailTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-mail/src/test/java/io/camunda/connector/e2e/OutboundEmailTests.java
@@ -44,6 +44,7 @@ import org.springframework.boot.test.context.SpringBootTest;
     classes = {TestConnectorRuntimeApplication.class},
     properties = {
       "spring.main.allow-bean-definition-overriding=true",
+      "camunda.connector.polling.enabled=false",
     },
     webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @CamundaSpringProcessTest
@@ -120,29 +121,29 @@ public class OutboundEmailTests extends BaseEmailTest {
   @Test
   public void shouldSendSMTPHtmlEmail() {
     File elementTemplate =
-            ElementTemplate.from(ELEMENT_TEMPLATE_PATH)
-                    .property("authentication.type", "simple")
-                    .property("authentication.simpleAuthenticationUsername", "test@camunda.com")
-                    .property("authentication.simpleAuthenticationPassword", "password")
-                    .property("protocol", "smtp")
-                    .property("data.smtpPort", getUnsecureSmtpPort())
-                    .property("data.smtpHost", LOCALHOST)
-                    .property("smtpCryptographicProtocol", "NONE")
-                    .property("data.smtpActionDiscriminator", "sendEmailSmtp")
-                    .property("smtpFrom", "test@camunda.com")
-                    .property("smtpTo", "receiver@test.com")
-                    .property("smtpSubject", "subject")
-                    .property("contentType", "HTML")
-                    .property("smtpHtmlBody", "<h1>content</h1>")
-                    .property("resultExpression", RESULT_EXPRESSION_SEND_EMAIL)
-                    .writeTo(new File(tempDir, "template.json"));
+        ElementTemplate.from(ELEMENT_TEMPLATE_PATH)
+            .property("authentication.type", "simple")
+            .property("authentication.simpleAuthenticationUsername", "test@camunda.com")
+            .property("authentication.simpleAuthenticationPassword", "password")
+            .property("protocol", "smtp")
+            .property("data.smtpPort", getUnsecureSmtpPort())
+            .property("data.smtpHost", LOCALHOST)
+            .property("smtpCryptographicProtocol", "NONE")
+            .property("data.smtpActionDiscriminator", "sendEmailSmtp")
+            .property("smtpFrom", "test@camunda.com")
+            .property("smtpTo", "receiver@test.com")
+            .property("smtpSubject", "subject")
+            .property("contentType", "HTML")
+            .property("smtpHtmlBody", "<h1>content</h1>")
+            .property("resultExpression", RESULT_EXPRESSION_SEND_EMAIL)
+            .writeTo(new File(tempDir, "template.json"));
 
     BpmnModelInstance model = getBpmnModelInstance("sendEmailTask");
     BpmnModelInstance updatedModel = getBpmnModelInstance(model, elementTemplate, "sendEmailTask");
     var result = getZeebeTest(updatedModel);
 
     assertThat(result).isNotNull();
-    assertThat(result.getProcessInstanceEvent()).hasVariableWithValue("sent", true);
+    assertThat(result.getProcessInstanceEvent()).hasVariable("sent", true);
 
     assertTrue(super.waitForNewEmails(5000, 1));
     List<Message> message = List.of(super.getLastReceivedEmails());

--- a/connectors-e2e-test/connectors-e2e-test-mail/src/test/java/io/camunda/connector/e2e/OutboundEmailTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-mail/src/test/java/io/camunda/connector/e2e/OutboundEmailTests.java
@@ -96,6 +96,7 @@ public class OutboundEmailTests extends BaseEmailTest {
             .property("smtpFrom", "test@camunda.com")
             .property("smtpTo", "receiver@test.com")
             .property("smtpSubject", "subject")
+            .property("contentType", "PLAIN")
             .property("smtpBody", "content")
             .property("resultExpression", RESULT_EXPRESSION_SEND_EMAIL)
             .writeTo(new File(tempDir, "template.json"));

--- a/connectors/email/element-templates/email-outbound-connector.json
+++ b/connectors/email/element-templates/email-outbound-connector.json
@@ -588,25 +588,35 @@
     "tooltip" : "Email's subject",
     "type" : "String"
   }, {
-    "id": "content_type",
-    "label": "Content Type",
-    "value": "plain",
-    "group": "sendEmailSmtp",
-    "binding": {
-      "name": "data.smtpAction.contentType",
-      "type": "zeebe:input"
+    "id" : "contentType",
+    "label" : "ContentType",
+    "optional" : false,
+    "value" : "plain",
+    "group" : "sendEmailSmtp",
+    "binding" : {
+      "name" : "data.smtpAction.contentType",
+      "type" : "zeebe:input"
     },
-    "type": "Dropdown",
-    "choices": [
-      {
-        "name": "Plain",
-        "value": "plain"
-      },
-      {
-        "name": "Html",
-        "value": "html"
-      }
-    ]
+    "condition" : {
+      "allMatch" : [ {
+        "property" : "data.smtpActionDiscriminator",
+        "equals" : "sendEmailSmtp",
+        "type" : "simple"
+      }, {
+        "property" : "protocol",
+        "equals" : "smtp",
+        "type" : "simple"
+      } ]
+    },
+    "tooltip" : "Email's contentType",
+    "type" : "Dropdown",
+    "choices" : [ {
+      "name" : "Plain",
+      "value" : "plain"
+    }, {
+      "name" : "Html",
+      "value" : "html"
+    } ]
   }, {
     "id" : "smtpBody",
     "label" : "Email Content",

--- a/connectors/email/element-templates/email-outbound-connector.json
+++ b/connectors/email/element-templates/email-outbound-connector.json
@@ -614,22 +614,19 @@
     "tooltip" : "Email's contentType",
     "type" : "Dropdown",
     "choices" : [ {
-      "name" : "Plain",
+      "name" : "PLAIN",
       "value" : "PLAIN"
     }, {
-      "name" : "Html",
+      "name" : "HTML",
       "value" : "HTML"
     }, {
-      "name" : "Html+Plain",
+      "name" : "HTML & Plaintext",
       "value" : "MULTIPART"
     } ]
   }, {
     "id" : "smtpBody",
-    "label" : "Email Content",
+    "label" : "Email Text Content",
     "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
     "feel" : "optional",
     "group" : "sendEmailSmtp",
     "binding" : {
@@ -638,6 +635,10 @@
     },
     "condition" : {
       "allMatch" : [ {
+        "property" : "contentType",
+        "oneOf" : [ "PLAIN", "MULTIPART" ],
+        "type" : "simple"
+      }, {
         "property" : "data.smtpActionDiscriminator",
         "equals" : "sendEmailSmtp",
         "type" : "simple"
@@ -648,6 +649,33 @@
       } ]
     },
     "tooltip" : "Email's content",
+    "type" : "Text"
+  }, {
+    "id" : "smtpHtmlBody",
+    "label" : "Email Html Content",
+    "optional" : false,
+    "feel" : "optional",
+    "group" : "sendEmailSmtp",
+    "binding" : {
+      "name" : "data.smtpAction.htmlBody",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "allMatch" : [ {
+        "property" : "contentType",
+        "oneOf" : [ "HTML", "MULTIPART" ],
+        "type" : "simple"
+      }, {
+        "property" : "data.smtpActionDiscriminator",
+        "equals" : "sendEmailSmtp",
+        "type" : "simple"
+      }, {
+        "property" : "protocol",
+        "equals" : "smtp",
+        "type" : "simple"
+      } ]
+    },
+    "tooltip" : "Email's Html content",
     "type" : "Text"
   }, {
     "id" : "pop3maxToBeRead",

--- a/connectors/email/element-templates/email-outbound-connector.json
+++ b/connectors/email/element-templates/email-outbound-connector.json
@@ -616,6 +616,9 @@
     }, {
       "name" : "Html",
       "value" : "html"
+    }, {
+      "name" : "Html+Plain",
+      "value" : "multipart"
     } ]
   }, {
     "id" : "smtpBody",

--- a/connectors/email/element-templates/email-outbound-connector.json
+++ b/connectors/email/element-templates/email-outbound-connector.json
@@ -588,6 +588,26 @@
     "tooltip" : "Email's subject",
     "type" : "String"
   }, {
+    "id": "content_type",
+    "label": "Content Type",
+    "value": "plain",
+    "group": "sendEmailSmtp",
+    "binding": {
+      "name": "data.smtpAction.contentType",
+      "type": "zeebe:input"
+    },
+    "type": "Dropdown",
+    "choices": [
+      {
+        "name": "Plain",
+        "value": "plain"
+      },
+      {
+        "name": "Html",
+        "value": "html"
+      }
+    ]
+  }, {
     "id" : "smtpBody",
     "label" : "Email Content",
     "optional" : false,

--- a/connectors/email/element-templates/email-outbound-connector.json
+++ b/connectors/email/element-templates/email-outbound-connector.json
@@ -591,7 +591,10 @@
     "id" : "contentType",
     "label" : "ContentType",
     "optional" : false,
-    "value" : "plain",
+    "value" : "PLAIN",
+    "constraints" : {
+      "notEmpty" : true
+    },
     "group" : "sendEmailSmtp",
     "binding" : {
       "name" : "data.smtpAction.contentType",
@@ -612,13 +615,13 @@
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "Plain",
-      "value" : "plain"
+      "value" : "PLAIN"
     }, {
       "name" : "Html",
-      "value" : "html"
+      "value" : "HTML"
     }, {
       "name" : "Html+Plain",
-      "value" : "multipart"
+      "value" : "MULTIPART"
     } ]
   }, {
     "id" : "smtpBody",

--- a/connectors/email/element-templates/hybrid/email-outbound-connector-hybrid.json
+++ b/connectors/email/element-templates/hybrid/email-outbound-connector-hybrid.json
@@ -619,22 +619,19 @@
     "tooltip" : "Email's contentType",
     "type" : "Dropdown",
     "choices" : [ {
-      "name" : "Plain",
+      "name" : "PLAIN",
       "value" : "PLAIN"
     }, {
-      "name" : "Html",
+      "name" : "HTML",
       "value" : "HTML"
     }, {
-      "name" : "Html+Plain",
+      "name" : "HTML & Plaintext",
       "value" : "MULTIPART"
     } ]
   }, {
     "id" : "smtpBody",
-    "label" : "Email Content",
+    "label" : "Email Text Content",
     "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
     "feel" : "optional",
     "group" : "sendEmailSmtp",
     "binding" : {
@@ -643,6 +640,10 @@
     },
     "condition" : {
       "allMatch" : [ {
+        "property" : "contentType",
+        "oneOf" : [ "PLAIN", "MULTIPART" ],
+        "type" : "simple"
+      }, {
         "property" : "data.smtpActionDiscriminator",
         "equals" : "sendEmailSmtp",
         "type" : "simple"
@@ -653,6 +654,33 @@
       } ]
     },
     "tooltip" : "Email's content",
+    "type" : "Text"
+  }, {
+    "id" : "smtpHtmlBody",
+    "label" : "Email Html Content",
+    "optional" : false,
+    "feel" : "optional",
+    "group" : "sendEmailSmtp",
+    "binding" : {
+      "name" : "data.smtpAction.htmlBody",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "allMatch" : [ {
+        "property" : "contentType",
+        "oneOf" : [ "HTML", "MULTIPART" ],
+        "type" : "simple"
+      }, {
+        "property" : "data.smtpActionDiscriminator",
+        "equals" : "sendEmailSmtp",
+        "type" : "simple"
+      }, {
+        "property" : "protocol",
+        "equals" : "smtp",
+        "type" : "simple"
+      } ]
+    },
+    "tooltip" : "Email's Html content",
     "type" : "Text"
   }, {
     "id" : "pop3maxToBeRead",

--- a/connectors/email/element-templates/hybrid/email-outbound-connector-hybrid.json
+++ b/connectors/email/element-templates/hybrid/email-outbound-connector-hybrid.json
@@ -593,25 +593,35 @@
     "tooltip" : "Email's subject",
     "type" : "String"
   }, {
-    "id": "content_type",
-    "label": "Content Type",
-    "value": "plain",
-    "group": "sendEmailSmtp",
-    "binding": {
-      "name": "data.smtpAction.contentType",
-      "type": "zeebe:input"
+    "id" : "contentType",
+    "label" : "ContentType",
+    "optional" : false,
+    "value" : "plain",
+    "group" : "sendEmailSmtp",
+    "binding" : {
+      "name" : "data.smtpAction.contentType",
+      "type" : "zeebe:input"
     },
-    "type": "Dropdown",
-    "choices": [
-      {
-        "name": "Plain",
-        "value": "plain"
-      },
-      {
-        "name": "Html",
-        "value": "html"
-      }
-    ]
+    "condition" : {
+      "allMatch" : [ {
+        "property" : "data.smtpActionDiscriminator",
+        "equals" : "sendEmailSmtp",
+        "type" : "simple"
+      }, {
+        "property" : "protocol",
+        "equals" : "smtp",
+        "type" : "simple"
+      } ]
+    },
+    "tooltip" : "Email's contentType",
+    "type" : "Dropdown",
+    "choices" : [ {
+      "name" : "Plain",
+      "value" : "plain"
+    }, {
+      "name" : "Html",
+      "value" : "html"
+    } ]
   }, {
     "id" : "smtpBody",
     "label" : "Email Content",

--- a/connectors/email/element-templates/hybrid/email-outbound-connector-hybrid.json
+++ b/connectors/email/element-templates/hybrid/email-outbound-connector-hybrid.json
@@ -621,6 +621,9 @@
     }, {
       "name" : "Html",
       "value" : "html"
+    }, {
+      "name" : "Html+Plain",
+      "value" : "multipart"
     } ]
   }, {
     "id" : "smtpBody",

--- a/connectors/email/element-templates/hybrid/email-outbound-connector-hybrid.json
+++ b/connectors/email/element-templates/hybrid/email-outbound-connector-hybrid.json
@@ -593,6 +593,26 @@
     "tooltip" : "Email's subject",
     "type" : "String"
   }, {
+    "id": "content_type",
+    "label": "Content Type",
+    "value": "plain",
+    "group": "sendEmailSmtp",
+    "binding": {
+      "name": "data.smtpAction.contentType",
+      "type": "zeebe:input"
+    },
+    "type": "Dropdown",
+    "choices": [
+      {
+        "name": "Plain",
+        "value": "plain"
+      },
+      {
+        "name": "Html",
+        "value": "html"
+      }
+    ]
+  }, {
     "id" : "smtpBody",
     "label" : "Email Content",
     "optional" : false,

--- a/connectors/email/element-templates/hybrid/email-outbound-connector-hybrid.json
+++ b/connectors/email/element-templates/hybrid/email-outbound-connector-hybrid.json
@@ -596,7 +596,10 @@
     "id" : "contentType",
     "label" : "ContentType",
     "optional" : false,
-    "value" : "plain",
+    "value" : "PLAIN",
+    "constraints" : {
+      "notEmpty" : true
+    },
     "group" : "sendEmailSmtp",
     "binding" : {
       "name" : "data.smtpAction.contentType",
@@ -617,13 +620,13 @@
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "Plain",
-      "value" : "plain"
+      "value" : "PLAIN"
     }, {
       "name" : "Html",
-      "value" : "html"
+      "value" : "HTML"
     }, {
       "name" : "Html+Plain",
-      "value" : "multipart"
+      "value" : "MULTIPART"
     } ]
   }, {
     "id" : "smtpBody",

--- a/connectors/email/src/main/java/io/camunda/connector/email/client/jakarta/outbound/JakartaEmailActionExecutor.java
+++ b/connectors/email/src/main/java/io/camunda/connector/email/client/jakarta/outbound/JakartaEmailActionExecutor.java
@@ -257,7 +257,11 @@ public class JakartaEmailActionExecutor implements EmailActionExecutor {
       if (bcc.isPresent()) message.setRecipients(Message.RecipientType.BCC, bcc.get());
       headers.ifPresent(stringObjectMap -> setMessageHeaders(stringObjectMap, message));
       message.setSubject(smtpSendEmail.subject());
-      message.setText(smtpSendEmail.body());
+      if (smtpSendEmail.contentType().equals("html")) {
+        message.setContent(smtpSendEmail.body(), "text/html; charset=utf-8");
+      } else {
+        message.setText(smtpSendEmail.body());
+      }
       try (Transport transport = session.getTransport()) {
         this.jakartaUtils.connectTransport(transport, authentication);
         transport.sendMessage(message, message.getAllRecipients());

--- a/connectors/email/src/main/java/io/camunda/connector/email/client/jakarta/outbound/JakartaEmailActionExecutor.java
+++ b/connectors/email/src/main/java/io/camunda/connector/email/client/jakarta/outbound/JakartaEmailActionExecutor.java
@@ -257,7 +257,8 @@ public class JakartaEmailActionExecutor implements EmailActionExecutor {
       if (bcc.isPresent()) message.setRecipients(Message.RecipientType.BCC, bcc.get());
       headers.ifPresent(stringObjectMap -> setMessageHeaders(stringObjectMap, message));
       message.setSubject(smtpSendEmail.subject());
-      if (smtpSendEmail.contentType().equals("html")) {
+      if (smtpSendEmail.contentType() != null
+          && smtpSendEmail.contentType().equals(ContentType.HTML)) {
         message.setContent(smtpSendEmail.body(), "text/html; charset=utf-8");
       } else {
         message.setText(smtpSendEmail.body());

--- a/connectors/email/src/main/java/io/camunda/connector/email/client/jakarta/outbound/JakartaEmailActionExecutor.java
+++ b/connectors/email/src/main/java/io/camunda/connector/email/client/jakarta/outbound/JakartaEmailActionExecutor.java
@@ -257,16 +257,7 @@ public class JakartaEmailActionExecutor implements EmailActionExecutor {
       if (bcc.isPresent()) message.setRecipients(Message.RecipientType.BCC, bcc.get());
       headers.ifPresent(stringObjectMap -> setMessageHeaders(stringObjectMap, message));
       message.setSubject(smtpSendEmail.subject());
-      if (smtpSendEmail.contentType() != null) {
-        switch (smtpSendEmail.contentType()) {
-          case ContentType.HTML ->
-              message.setContent(smtpSendEmail.body(), "text/html; charset=utf-8");
-          case ContentType.MULTIPART ->
-              message.setContent(smtpSendEmail, "multipart/mixed; charset=utf-8");
-        }
-      } else {
-        message.setText(smtpSendEmail.body());
-      }
+      message.setContent(smtpSendEmail.body(), smtpSendEmail.contentType().value());
       try (Transport transport = session.getTransport()) {
         this.jakartaUtils.connectTransport(transport, authentication);
         transport.sendMessage(message, message.getAllRecipients());

--- a/connectors/email/src/main/java/io/camunda/connector/email/client/jakarta/outbound/JakartaEmailActionExecutor.java
+++ b/connectors/email/src/main/java/io/camunda/connector/email/client/jakarta/outbound/JakartaEmailActionExecutor.java
@@ -257,9 +257,13 @@ public class JakartaEmailActionExecutor implements EmailActionExecutor {
       if (bcc.isPresent()) message.setRecipients(Message.RecipientType.BCC, bcc.get());
       headers.ifPresent(stringObjectMap -> setMessageHeaders(stringObjectMap, message));
       message.setSubject(smtpSendEmail.subject());
-      if (smtpSendEmail.contentType() != null
-          && smtpSendEmail.contentType().equals(ContentType.HTML)) {
-        message.setContent(smtpSendEmail.body(), "text/html; charset=utf-8");
+      if (smtpSendEmail.contentType() != null) {
+        switch (smtpSendEmail.contentType()) {
+          case ContentType.HTML ->
+              message.setContent(smtpSendEmail.body(), "text/html; charset=utf-8");
+          case ContentType.MULTIPART ->
+              message.setContent(smtpSendEmail, "multipart/mixed; charset=utf-8");
+        }
       } else {
         message.setText(smtpSendEmail.body());
       }

--- a/connectors/email/src/main/java/io/camunda/connector/email/client/jakarta/outbound/JakartaEmailActionExecutor.java
+++ b/connectors/email/src/main/java/io/camunda/connector/email/client/jakarta/outbound/JakartaEmailActionExecutor.java
@@ -16,10 +16,9 @@ import io.camunda.connector.email.outbound.protocols.Protocol;
 import io.camunda.connector.email.outbound.protocols.actions.*;
 import io.camunda.connector.email.response.*;
 import jakarta.mail.*;
-import jakarta.mail.internet.AddressException;
-import jakarta.mail.internet.InternetAddress;
-import jakarta.mail.internet.MimeMessage;
+import jakarta.mail.internet.*;
 import jakarta.mail.search.*;
+import java.nio.charset.StandardCharsets;
 import java.util.*;
 
 public class JakartaEmailActionExecutor implements EmailActionExecutor {
@@ -257,7 +256,8 @@ public class JakartaEmailActionExecutor implements EmailActionExecutor {
       if (bcc.isPresent()) message.setRecipients(Message.RecipientType.BCC, bcc.get());
       headers.ifPresent(stringObjectMap -> setMessageHeaders(stringObjectMap, message));
       message.setSubject(smtpSendEmail.subject());
-      message.setContent(smtpSendEmail.body(), smtpSendEmail.contentType().value());
+      Multipart multipart = getMultipart(smtpSendEmail);
+      message.setContent(multipart);
       try (Transport transport = session.getTransport()) {
         this.jakartaUtils.connectTransport(transport, authentication);
         transport.sendMessage(message, message.getAllRecipients());
@@ -277,6 +277,31 @@ public class JakartaEmailActionExecutor implements EmailActionExecutor {
             throw new RuntimeException(e);
           }
         });
+  }
+
+  private Multipart getMultipart(SmtpSendEmail smtpSendEmail) throws MessagingException {
+    Multipart multipart = new MimeMultipart();
+    switch (smtpSendEmail.contentType()) {
+      case PLAIN -> {
+        MimeBodyPart textPart = new MimeBodyPart();
+        textPart.setText(smtpSendEmail.body(), StandardCharsets.UTF_8.name());
+        multipart.addBodyPart(textPart);
+      }
+      case HTML -> {
+        MimeBodyPart htmlPart = new MimeBodyPart();
+        htmlPart.setContent(smtpSendEmail.htmlBody(), JakartaUtils.HTML_CHARSET);
+        multipart.addBodyPart(htmlPart);
+      }
+      case MULTIPART -> {
+        MimeBodyPart textPart = new MimeBodyPart();
+        textPart.setText(smtpSendEmail.body(), StandardCharsets.UTF_8.name());
+        MimeBodyPart htmlPart = new MimeBodyPart();
+        htmlPart.setContent(smtpSendEmail.htmlBody(), JakartaUtils.HTML_CHARSET);
+        multipart.addBodyPart(textPart);
+        multipart.addBodyPart(htmlPart);
+      }
+    }
+    return multipart;
   }
 
   private SearchTerm createSearchTerms(JsonNode jsonNode) throws AddressException {

--- a/connectors/email/src/main/java/io/camunda/connector/email/client/jakarta/utils/JakartaUtils.java
+++ b/connectors/email/src/main/java/io/camunda/connector/email/client/jakarta/utils/JakartaUtils.java
@@ -34,6 +34,7 @@ public class JakartaUtils {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(JakartaUtils.class);
   private static final String REGEX_PATH_SPLITTER = "[./]";
+  public static final String HTML_CHARSET = "text/html; charset=utf-8";
 
   public Session createSession(Configuration configuration) {
     return Session.getInstance(

--- a/connectors/email/src/main/java/io/camunda/connector/email/outbound/protocols/actions/ContentType.java
+++ b/connectors/email/src/main/java/io/camunda/connector/email/outbound/protocols/actions/ContentType.java
@@ -7,14 +7,17 @@
 package io.camunda.connector.email.outbound.protocols.actions;
 
 public enum ContentType {
-  PLAIN,
-  HTML,
-  MULTIPART;
+  PLAIN("text/plain; charset=utf-8"),
+  HTML("text/html; charset=utf-8"),
+  MULTIPART("multipart/mixed; charset=utf-8");
 
-  public static class Constants {
-    public static final String PLAIN_VALUE = "plain";
-    public static final String HTML_VALUE = "html";
+  private final String value;
 
-    public static final String MULTIPART_VALUE = "multipart";
+  ContentType(String value) {
+    this.value = value;
+  }
+
+  public String value() {
+    return value;
   }
 }

--- a/connectors/email/src/main/java/io/camunda/connector/email/outbound/protocols/actions/ContentType.java
+++ b/connectors/email/src/main/java/io/camunda/connector/email/outbound/protocols/actions/ContentType.java
@@ -8,10 +8,13 @@ package io.camunda.connector.email.outbound.protocols.actions;
 
 public enum ContentType {
   PLAIN,
-  HTML;
+  HTML,
+  MULTIPART;
 
   public static class Constants {
     public static final String PLAIN_VALUE = "plain";
     public static final String HTML_VALUE = "html";
+
+    public static final String MULTIPART_VALUE = "multipart";
   }
 }

--- a/connectors/email/src/main/java/io/camunda/connector/email/outbound/protocols/actions/ContentType.java
+++ b/connectors/email/src/main/java/io/camunda/connector/email/outbound/protocols/actions/ContentType.java
@@ -17,7 +17,7 @@ public enum ContentType {
     this.value = value;
   }
 
-  public String value() {
+  public String type() {
     return value;
   }
 }

--- a/connectors/email/src/main/java/io/camunda/connector/email/outbound/protocols/actions/ContentType.java
+++ b/connectors/email/src/main/java/io/camunda/connector/email/outbound/protocols/actions/ContentType.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.email.outbound.protocols.actions;
+
+public enum ContentType {
+  PLAIN,
+  HTML;
+
+  public static class Constants {
+    public static final String PLAIN_VALUE = "plain";
+    public static final String HTML_VALUE = "html";
+  }
+}

--- a/connectors/email/src/main/java/io/camunda/connector/email/outbound/protocols/actions/SmtpSendEmail.java
+++ b/connectors/email/src/main/java/io/camunda/connector/email/outbound/protocols/actions/SmtpSendEmail.java
@@ -86,11 +86,10 @@ public record SmtpSendEmail(
             defaultValue = "plain",
             type = TemplateProperty.PropertyType.String,
             tooltip = "Email's contentType",
-            binding = @TemplateProperty.PropertyBinding(name = "data.smtpAction.contentType")
-    )
-    @Valid
-    @NotNull
-    String contentType,
+            binding = @TemplateProperty.PropertyBinding(name = "data.smtpAction.contentType"))
+        @Valid
+        @NotNull
+        String contentType,
     @TemplateProperty(
             label = "Email Content",
             group = "sendEmailSmtp",
@@ -102,5 +101,4 @@ public record SmtpSendEmail(
         @Valid
         @NotNull
         String body)
-
     implements SmtpAction {}

--- a/connectors/email/src/main/java/io/camunda/connector/email/outbound/protocols/actions/SmtpSendEmail.java
+++ b/connectors/email/src/main/java/io/camunda/connector/email/outbound/protocols/actions/SmtpSendEmail.java
@@ -86,9 +86,9 @@ public record SmtpSendEmail(
             defaultValue = "PLAIN",
             type = TemplateProperty.PropertyType.Dropdown,
             choices = {
-              @TemplateProperty.DropdownPropertyChoice(label = "Plain", value = "PLAIN"),
-              @TemplateProperty.DropdownPropertyChoice(label = "Html", value = "HTML"),
-              @TemplateProperty.DropdownPropertyChoice(label = "Html+Plain", value = "MULTIPART")
+              @TemplateProperty.DropdownPropertyChoice(label = "PLAIN", value = "PLAIN"),
+              @TemplateProperty.DropdownPropertyChoice(label = "HTML", value = "HTML"),
+              @TemplateProperty.DropdownPropertyChoice(label = "HTML & Plaintext", value = "MULTIPART")
             },
             tooltip = "Email's contentType",
             binding = @TemplateProperty.PropertyBinding(name = "data.smtpAction.contentType"))

--- a/connectors/email/src/main/java/io/camunda/connector/email/outbound/protocols/actions/SmtpSendEmail.java
+++ b/connectors/email/src/main/java/io/camunda/connector/email/outbound/protocols/actions/SmtpSendEmail.java
@@ -83,13 +83,20 @@ public record SmtpSendEmail(
             label = "ContentType",
             group = "sendEmailSmtp",
             id = "contentType",
-            defaultValue = "plain",
-            type = TemplateProperty.PropertyType.String,
+            defaultValue = ContentType.Constants.PLAIN_VALUE,
+            type = TemplateProperty.PropertyType.Dropdown,
+            choices = {
+              @TemplateProperty.DropdownPropertyChoice(
+                  label = "Plain",
+                  value = ContentType.Constants.PLAIN_VALUE),
+              @TemplateProperty.DropdownPropertyChoice(
+                  label = "Html",
+                  value = ContentType.Constants.HTML_VALUE)
+            },
             tooltip = "Email's contentType",
             binding = @TemplateProperty.PropertyBinding(name = "data.smtpAction.contentType"))
         @Valid
-        @NotNull
-        String contentType,
+        ContentType contentType,
     @TemplateProperty(
             label = "Email Content",
             group = "sendEmailSmtp",

--- a/connectors/email/src/main/java/io/camunda/connector/email/outbound/protocols/actions/SmtpSendEmail.java
+++ b/connectors/email/src/main/java/io/camunda/connector/email/outbound/protocols/actions/SmtpSendEmail.java
@@ -91,7 +91,10 @@ public record SmtpSendEmail(
                   value = ContentType.Constants.PLAIN_VALUE),
               @TemplateProperty.DropdownPropertyChoice(
                   label = "Html",
-                  value = ContentType.Constants.HTML_VALUE)
+                  value = ContentType.Constants.HTML_VALUE),
+              @TemplateProperty.DropdownPropertyChoice(
+                  label = "Html+Plain",
+                  value = ContentType.Constants.MULTIPART_VALUE)
             },
             tooltip = "Email's contentType",
             binding = @TemplateProperty.PropertyBinding(name = "data.smtpAction.contentType"))

--- a/connectors/email/src/main/java/io/camunda/connector/email/outbound/protocols/actions/SmtpSendEmail.java
+++ b/connectors/email/src/main/java/io/camunda/connector/email/outbound/protocols/actions/SmtpSendEmail.java
@@ -83,22 +83,17 @@ public record SmtpSendEmail(
             label = "ContentType",
             group = "sendEmailSmtp",
             id = "contentType",
-            defaultValue = ContentType.Constants.PLAIN_VALUE,
+            defaultValue = "PLAIN",
             type = TemplateProperty.PropertyType.Dropdown,
             choices = {
-              @TemplateProperty.DropdownPropertyChoice(
-                  label = "Plain",
-                  value = ContentType.Constants.PLAIN_VALUE),
-              @TemplateProperty.DropdownPropertyChoice(
-                  label = "Html",
-                  value = ContentType.Constants.HTML_VALUE),
-              @TemplateProperty.DropdownPropertyChoice(
-                  label = "Html+Plain",
-                  value = ContentType.Constants.MULTIPART_VALUE)
+              @TemplateProperty.DropdownPropertyChoice(label = "Plain", value = "PLAIN"),
+              @TemplateProperty.DropdownPropertyChoice(label = "Html", value = "HTML"),
+              @TemplateProperty.DropdownPropertyChoice(label = "Html+Plain", value = "MULTIPART")
             },
             tooltip = "Email's contentType",
             binding = @TemplateProperty.PropertyBinding(name = "data.smtpAction.contentType"))
         @Valid
+        @NotNull
         ContentType contentType,
     @TemplateProperty(
             label = "Email Content",

--- a/connectors/email/src/main/java/io/camunda/connector/email/outbound/protocols/actions/SmtpSendEmail.java
+++ b/connectors/email/src/main/java/io/camunda/connector/email/outbound/protocols/actions/SmtpSendEmail.java
@@ -80,6 +80,18 @@ public record SmtpSendEmail(
         @NotNull
         String subject,
     @TemplateProperty(
+            label = "ContentType",
+            group = "sendEmailSmtp",
+            id = "contentType",
+            defaultValue = "plain",
+            type = TemplateProperty.PropertyType.String,
+            tooltip = "Email's contentType",
+            binding = @TemplateProperty.PropertyBinding(name = "data.smtpAction.contentType")
+    )
+    @Valid
+    @NotNull
+    String contentType,
+    @TemplateProperty(
             label = "Email Content",
             group = "sendEmailSmtp",
             id = "smtpBody",
@@ -90,4 +102,5 @@ public record SmtpSendEmail(
         @Valid
         @NotNull
         String body)
+
     implements SmtpAction {}

--- a/connectors/email/src/main/java/io/camunda/connector/email/outbound/protocols/actions/SmtpSendEmail.java
+++ b/connectors/email/src/main/java/io/camunda/connector/email/outbound/protocols/actions/SmtpSendEmail.java
@@ -88,7 +88,9 @@ public record SmtpSendEmail(
             choices = {
               @TemplateProperty.DropdownPropertyChoice(label = "PLAIN", value = "PLAIN"),
               @TemplateProperty.DropdownPropertyChoice(label = "HTML", value = "HTML"),
-              @TemplateProperty.DropdownPropertyChoice(label = "HTML & Plaintext", value = "MULTIPART")
+              @TemplateProperty.DropdownPropertyChoice(
+                  label = "HTML & Plaintext",
+                  value = "MULTIPART")
             },
             tooltip = "Email's contentType",
             binding = @TemplateProperty.PropertyBinding(name = "data.smtpAction.contentType"))
@@ -96,14 +98,31 @@ public record SmtpSendEmail(
         @NotNull
         ContentType contentType,
     @TemplateProperty(
-            label = "Email Content",
+            label = "Email Text Content",
             group = "sendEmailSmtp",
             id = "smtpBody",
             type = TemplateProperty.PropertyType.Text,
             tooltip = "Email's content",
             binding = @TemplateProperty.PropertyBinding(name = "data.smtpAction.body"),
-            feel = Property.FeelMode.optional)
+            feel = Property.FeelMode.optional,
+            condition =
+                @TemplateProperty.PropertyCondition(
+                    property = "contentType",
+                    oneOf = {"PLAIN", "MULTIPART"}))
         @Valid
-        @NotNull
-        String body)
+        String body,
+    @TemplateProperty(
+            label = "Email Html Content",
+            group = "sendEmailSmtp",
+            id = "smtpHtmlBody",
+            type = TemplateProperty.PropertyType.Text,
+            tooltip = "Email's Html content",
+            binding = @TemplateProperty.PropertyBinding(name = "data.smtpAction.htmlBody"),
+            feel = Property.FeelMode.optional,
+            condition =
+                @TemplateProperty.PropertyCondition(
+                    property = "contentType",
+                    oneOf = {"HTML", "MULTIPART"}))
+        @Valid
+        String htmlBody)
     implements SmtpAction {}

--- a/connectors/email/src/test/java/io/camunda/connector/email/client/jakarta/JakartaExecutorTest.java
+++ b/connectors/email/src/test/java/io/camunda/connector/email/client/jakarta/JakartaExecutorTest.java
@@ -76,8 +76,8 @@ class JakartaExecutorTest {
                   try {
                     return Arrays.stream(argument.getFrom())
                             .allMatch(address -> address.toString().contains("myself"))
-                            && argument.getContent().toString().contains("body")
-                            && argument.getContentType().contains("text/plain");
+                        && argument.getContent().toString().contains("body")
+                        && argument.getContentType().contains("text/plain");
                   } catch (MessagingException | IOException e) {
                     throw new RuntimeException(e);
                   }
@@ -95,7 +95,7 @@ class JakartaExecutorTest {
     JakartaUtils sessionFactory = mock(JakartaUtils.class);
     ObjectMapper objectMapper = mock(ObjectMapper.class);
     JakartaEmailActionExecutor actionExecutor =
-            JakartaEmailActionExecutor.create(sessionFactory, objectMapper);
+        JakartaEmailActionExecutor.create(sessionFactory, objectMapper);
 
     EmailRequest emailRequest = mock(EmailRequest.class);
     SmtpSendEmail smtpSendEmail = mock(SmtpSendEmail.class);
@@ -125,23 +125,23 @@ class JakartaExecutorTest {
     actionExecutor.execute(emailRequest);
 
     verify(transport, times(1))
-            .sendMessage(
-                    argThat(
-                            argument -> {
-                              try {
-                                return Arrays.stream(argument.getFrom())
-                                        .allMatch(address -> address.toString().contains("myself"))
-                                        && argument.getContent().toString().contains("<!DOCTYPE html>")
-                                        && argument.getDataHandler().getContentType().contains("text/html");
-                              } catch (MessagingException | IOException e) {
-                                throw new RuntimeException(e);
-                              }
-                            }),
-                    argThat(
-                            argument ->
-                                    Arrays.toString(argument).contains("to")
-                                            && Arrays.toString(argument).contains("cc")
-                                            && Arrays.toString(argument).contains("bcc")));
+        .sendMessage(
+            argThat(
+                argument -> {
+                  try {
+                    return Arrays.stream(argument.getFrom())
+                            .allMatch(address -> address.toString().contains("myself"))
+                        && argument.getContent().toString().contains("<!DOCTYPE html>")
+                        && argument.getDataHandler().getContentType().contains("text/html");
+                  } catch (MessagingException | IOException e) {
+                    throw new RuntimeException(e);
+                  }
+                }),
+            argThat(
+                argument ->
+                    Arrays.toString(argument).contains("to")
+                        && Arrays.toString(argument).contains("cc")
+                        && Arrays.toString(argument).contains("bcc")));
   }
 
   @Test

--- a/connectors/email/src/test/java/io/camunda/connector/email/client/jakarta/JakartaExecutorTest.java
+++ b/connectors/email/src/test/java/io/camunda/connector/email/client/jakarta/JakartaExecutorTest.java
@@ -35,60 +35,6 @@ import org.junit.jupiter.api.Test;
 class JakartaExecutorTest {
 
   @Test
-  void executeSmtpSendEmailContentTypeNotSet() throws MessagingException {
-
-    JakartaUtils sessionFactory = mock(JakartaUtils.class);
-    ObjectMapper objectMapper = mock(ObjectMapper.class);
-    JakartaEmailActionExecutor actionExecutor =
-        JakartaEmailActionExecutor.create(sessionFactory, objectMapper);
-
-    EmailRequest emailRequest = mock(EmailRequest.class);
-    SmtpSendEmail smtpSendEmail = mock(SmtpSendEmail.class);
-    SimpleAuthentication simpleAuthentication = mock(SimpleAuthentication.class);
-    Protocol protocol = mock(Smtp.class);
-    Session session = mock(Session.class);
-    Transport transport = mock(Transport.class);
-
-    // Authentication
-    when(simpleAuthentication.username()).thenReturn("user");
-    when(simpleAuthentication.password()).thenReturn("secret");
-    doNothing().when(transport).connect(any(), any());
-
-    when(emailRequest.authentication()).thenReturn(simpleAuthentication);
-    when(session.getProperties()).thenReturn(new Properties());
-    when(emailRequest.data()).thenReturn(protocol);
-    when(protocol.getProtocolAction()).thenReturn(smtpSendEmail);
-    when(sessionFactory.createSession(any())).thenReturn(session);
-    when(smtpSendEmail.to()).thenReturn(List.of("to"));
-    when(smtpSendEmail.cc()).thenReturn(List.of("cc"));
-    when(smtpSendEmail.bcc()).thenReturn(List.of("bcc"));
-    when(smtpSendEmail.from()).thenReturn("myself");
-    when(smtpSendEmail.body()).thenReturn("body");
-    when(session.getTransport()).thenReturn(transport);
-
-    actionExecutor.execute(emailRequest);
-
-    verify(transport, times(1))
-        .sendMessage(
-            argThat(
-                argument -> {
-                  try {
-                    return Arrays.stream(argument.getFrom())
-                            .allMatch(address -> address.toString().contains("myself"))
-                        && argument.getContent().toString().contains("body")
-                        && argument.getContentType().contains("text/plain");
-                  } catch (MessagingException | IOException e) {
-                    throw new RuntimeException(e);
-                  }
-                }),
-            argThat(
-                argument ->
-                    Arrays.toString(argument).contains("to")
-                        && Arrays.toString(argument).contains("cc")
-                        && Arrays.toString(argument).contains("bcc")));
-  }
-
-  @Test
   void executeSmtpSendEmail() throws MessagingException {
     buildSmtpTest(ContentType.PLAIN, "body", "text/plain");
   }

--- a/connectors/email/src/test/java/io/camunda/connector/email/client/jakarta/JakartaExecutorTest.java
+++ b/connectors/email/src/test/java/io/camunda/connector/email/client/jakarta/JakartaExecutorTest.java
@@ -64,7 +64,61 @@ class JakartaExecutorTest {
     when(smtpSendEmail.bcc()).thenReturn(List.of("bcc"));
     when(smtpSendEmail.from()).thenReturn("myself");
     when(smtpSendEmail.body()).thenReturn("body");
-    when(smtpSendEmail.contentType()).thenReturn("plain");
+    when(smtpSendEmail.contentType()).thenReturn(ContentType.PLAIN);
+    when(session.getTransport()).thenReturn(transport);
+
+    actionExecutor.execute(emailRequest);
+
+    verify(transport, times(1))
+        .sendMessage(
+            argThat(
+                argument -> {
+                  try {
+                    return Arrays.stream(argument.getFrom())
+                            .allMatch(address -> address.toString().contains("myself"))
+                        && argument.getContent().toString().contains("body")
+                        && argument.getContentType().contains("text/plain");
+                  } catch (MessagingException | IOException e) {
+                    throw new RuntimeException(e);
+                  }
+                }),
+            argThat(
+                argument ->
+                    Arrays.toString(argument).contains("to")
+                        && Arrays.toString(argument).contains("cc")
+                        && Arrays.toString(argument).contains("bcc")));
+  }
+
+  @Test
+  void executeSmtpSendEmailContentTypeNotSet() throws MessagingException {
+
+    JakartaUtils sessionFactory = mock(JakartaUtils.class);
+    ObjectMapper objectMapper = mock(ObjectMapper.class);
+    JakartaEmailActionExecutor actionExecutor =
+        JakartaEmailActionExecutor.create(sessionFactory, objectMapper);
+
+    EmailRequest emailRequest = mock(EmailRequest.class);
+    SmtpSendEmail smtpSendEmail = mock(SmtpSendEmail.class);
+    SimpleAuthentication simpleAuthentication = mock(SimpleAuthentication.class);
+    Protocol protocol = mock(Smtp.class);
+    Session session = mock(Session.class);
+    Transport transport = mock(Transport.class);
+
+    // Authentication
+    when(simpleAuthentication.username()).thenReturn("user");
+    when(simpleAuthentication.password()).thenReturn("secret");
+    doNothing().when(transport).connect(any(), any());
+
+    when(emailRequest.authentication()).thenReturn(simpleAuthentication);
+    when(session.getProperties()).thenReturn(new Properties());
+    when(emailRequest.data()).thenReturn(protocol);
+    when(protocol.getProtocolAction()).thenReturn(smtpSendEmail);
+    when(sessionFactory.createSession(any())).thenReturn(session);
+    when(smtpSendEmail.to()).thenReturn(List.of("to"));
+    when(smtpSendEmail.cc()).thenReturn(List.of("cc"));
+    when(smtpSendEmail.bcc()).thenReturn(List.of("bcc"));
+    when(smtpSendEmail.from()).thenReturn("myself");
+    when(smtpSendEmail.body()).thenReturn("body");
     when(session.getTransport()).thenReturn(transport);
 
     actionExecutor.execute(emailRequest);
@@ -118,7 +172,7 @@ class JakartaExecutorTest {
     when(smtpSendEmail.cc()).thenReturn(List.of("cc"));
     when(smtpSendEmail.bcc()).thenReturn(List.of("bcc"));
     when(smtpSendEmail.from()).thenReturn("myself");
-    when(smtpSendEmail.contentType()).thenReturn("html");
+    when(smtpSendEmail.contentType()).thenReturn(ContentType.HTML);
     when(smtpSendEmail.body()).thenReturn("<!DOCTYPE html>");
     when(session.getTransport()).thenReturn(transport);
 

--- a/connectors/email/src/test/java/io/camunda/connector/email/client/jakarta/JakartaExecutorTest.java
+++ b/connectors/email/src/test/java/io/camunda/connector/email/client/jakarta/JakartaExecutorTest.java
@@ -172,6 +172,7 @@ class JakartaExecutorTest {
     when(smtpSendEmail.headers()).thenReturn(Map.of("test", "header1"));
     when(smtpSendEmail.from()).thenReturn("myself");
     when(smtpSendEmail.body()).thenReturn("body");
+    when(smtpSendEmail.contentType()).thenReturn(ContentType.PLAIN);
     when(session.getTransport()).thenReturn(transport);
 
     actionExecutor.execute(emailRequest);
@@ -183,9 +184,9 @@ class JakartaExecutorTest {
                   try {
                     return Arrays.stream(argument.getFrom())
                             .allMatch(address -> address.toString().contains("myself"))
-                        && argument.getContent().toString().contains("body")
+                        && messageContains(argument, "body")
                         && Arrays.stream(argument.getHeader("test")).toList().contains("header1");
-                  } catch (MessagingException | IOException e) {
+                  } catch (MessagingException e) {
                     throw new RuntimeException(e);
                   }
                 }),


### PR DESCRIPTION
## Description
<img width="1527" alt="image" src="https://github.com/user-attachments/assets/74203b7c-ea0f-448d-af44-ef145051ce40">

Adding a Dropdown to set the content type of an email so that html templates can be used in this email outbound connector.

Also set the right content type in the smtp send mail 

## Checklist

- [ ] PR has a **milestone** or the `no milestone` label.

