### PR TITLE
fix(generator): boolean conditions in template generator annotations

### DIFF
--- a/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/annotation/TemplateProperty.java
+++ b/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/annotation/TemplateProperty.java
@@ -135,10 +135,36 @@ public @interface TemplateProperty {
     String name();
   }
 
+  enum EqualsBoolean {
+    TRUE,
+    FALSE,
+    NULL;
+
+    public static EqualsBoolean fromBoolean(Boolean value) {
+      if (value == null) {
+        return NULL;
+      } else if (value) {
+        return TRUE;
+      } else {
+        return FALSE;
+      }
+    }
+
+    public Boolean toBoolean() {
+      if (this == NULL) {
+        return null;
+      } else {
+        return this == TRUE;
+      }
+    }
+  }
+
   @interface PropertyCondition {
     String property();
 
     String equals() default "";
+
+    EqualsBoolean equalsBoolean() default EqualsBoolean.NULL;
 
     String[] oneOf() default {};
 
@@ -152,6 +178,8 @@ public @interface TemplateProperty {
 
     /** For string properties */
     String equals() default "";
+
+    EqualsBoolean equalsBoolean() default EqualsBoolean.NULL;
 
     String[] oneOf() default {};
 

--- a/element-template-generator/core/src/test/java/io/camunda/connector/generator/java/OutboundClassBasedTemplateGeneratorTest.java
+++ b/element-template-generator/core/src/test/java/io/camunda/connector/generator/java/OutboundClassBasedTemplateGeneratorTest.java
@@ -554,9 +554,9 @@ public class OutboundClassBasedTemplateGeneratorTest extends BaseTest {
     void booleanProperty_dependants() {
       var template = generator.generate(MyConnectorFunction.MinimallyAnnotated.class).getFirst();
       var dependsOnTrue = getPropertyById("dependsOnBooleanPropertyTrue", template);
-      assertThat(dependsOnTrue.getCondition()).isEqualTo(new Equals("booleanProperty", "true"));
+      assertThat(dependsOnTrue.getCondition()).isEqualTo(new Equals("booleanProperty", true));
       var dependsOnFalse = getPropertyById("dependsOnBooleanPropertyFalse", template);
-      assertThat(dependsOnFalse.getCondition()).isEqualTo(new Equals("booleanProperty", "false"));
+      assertThat(dependsOnFalse.getCondition()).isEqualTo(new Equals("booleanProperty", false));
     }
   }
 

--- a/element-template-generator/core/src/test/java/io/camunda/connector/generator/java/example/outbound/MyConnectorInput.java
+++ b/element-template-generator/core/src/test/java/io/camunda/connector/generator/java/example/outbound/MyConnectorInput.java
@@ -21,6 +21,7 @@ import io.camunda.connector.generator.java.annotation.NestedProperties;
 import io.camunda.connector.generator.java.annotation.TemplateDiscriminatorProperty;
 import io.camunda.connector.generator.java.annotation.TemplateProperty;
 import io.camunda.connector.generator.java.annotation.TemplateProperty.DefaultValueType;
+import io.camunda.connector.generator.java.annotation.TemplateProperty.EqualsBoolean;
 import io.camunda.connector.generator.java.annotation.TemplateProperty.PropertyCondition;
 import io.camunda.connector.generator.java.annotation.TemplateProperty.PropertyConstraints;
 import io.camunda.connector.generator.java.annotation.TemplateProperty.PropertyType;
@@ -96,11 +97,17 @@ public record MyConnectorInput(
         Boolean booleanProperty,
     @TemplateProperty(
             id = "dependsOnBooleanPropertyFalse",
-            condition = @PropertyCondition(property = "booleanProperty", equals = "false"))
+            condition =
+                @PropertyCondition(
+                    property = "booleanProperty",
+                    equalsBoolean = EqualsBoolean.FALSE))
         String dependsOnBooleanPropertyFalse,
     @TemplateProperty(
             id = "dependsOnBooleanPropertyTrue",
-            condition = @PropertyCondition(property = "booleanProperty", equals = "true"))
+            condition =
+                @PropertyCondition(
+                    property = "booleanProperty",
+                    equalsBoolean = EqualsBoolean.TRUE))
         String dependsOnBooleanPropertyTrue,
     @TemplateProperty(
             id = "mayBeEmptyOrRegexValidated",


### PR DESCRIPTION
## Description

This PR will add the missing property in the template generator annotations to create a condition that references a boolean property.

This possibility already exists on the lower level in the classes that are mapped to element template JSON, but it has been missing in the annotation.

An enum is used because we need to have a null/missing value, as the annotation can lead to different behavior of the generator based on which property is set.

## Checklist

- [ ] PR has a **milestone** or the `no milestone` label.

