### PR TITLE
feat(idp-extraction-connector): added compatibility with llms lacking system message support

### DIFF
--- a/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/caller/BedrockCaller.java
+++ b/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/caller/BedrockCaller.java
@@ -8,6 +8,7 @@ package io.camunda.connector.idp.extraction.caller;
 
 import io.camunda.connector.idp.extraction.model.ConverseData;
 import io.camunda.connector.idp.extraction.model.ExtractionRequest;
+import io.camunda.connector.idp.extraction.model.LlmModel;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -16,34 +17,11 @@ import software.amazon.awssdk.services.bedrockruntime.model.ContentBlock;
 import software.amazon.awssdk.services.bedrockruntime.model.ConversationRole;
 import software.amazon.awssdk.services.bedrockruntime.model.ConverseResponse;
 import software.amazon.awssdk.services.bedrockruntime.model.Message;
+import software.amazon.awssdk.services.bedrockruntime.model.SystemContentBlock;
 
 public class BedrockCaller {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(BedrockCaller.class);
-
-  private static final String EXTRACTED_TEXT_PLACEHOLDER_FOR_PROMPT = "{{extractedText}}";
-
-  private static final String TAXONOMY_PLACEHOLDER_FOR_PROMPT = "{{taxonomy}}";
-
-  private static final String SYSTEM_PROMPT_TEMPLATE =
-      """
-            You will receive extracted text from a PDF document. This text will be between the <DOCUMENT_TEXT> tags.
-            Your task is to extract certain variables from the text. The description how to extract the variables is
-            between the <EXTRACTION> tags. Every variable is represented by a <VAR> tag. Every variable has a name,
-            which is represented by the <NAME> tag, as well as instructions which data to extract, which is represented
-            by the <PROMPT> tag.
-
-            Respond in JSON format, without any preamble. Example response:
-            {
-              "name": "John Smith",
-              "age": 32
-            }
-
-            Here is the document text as well as your instructions on which variables to extract:
-            <DOCUMENT_TEXT>%s</DOCUMENT_TEXT>
-            <EXTRACTION>%s</EXTRACTION>
-            """
-          .formatted(EXTRACTED_TEXT_PLACEHOLDER_FOR_PROMPT, TAXONOMY_PLACEHOLDER_FOR_PROMPT);
 
   private static final String SYSTEM_PROMPT_VARIABLE_TEMPLATE =
       """
@@ -52,6 +30,10 @@ public class BedrockCaller {
                 <PROMPT>%s</PROMPT>
             </VAR>
             """;
+
+  public static final String EXTRACTED_TEXT_PLACEHOLDER_FOR_MESSAGE = "{{extractedText}}";
+
+  public static final String TAXONOMY_PLACEHOLDER_FOR_MESSAGE = "{{taxonomy}}";
 
   public String call(
       ExtractionRequest extractionRequest,
@@ -64,30 +46,38 @@ public class BedrockCaller {
             .map(item -> String.format(SYSTEM_PROMPT_VARIABLE_TEMPLATE, item.name(), item.prompt()))
             .collect(Collectors.joining());
 
-    String prompt =
-        SYSTEM_PROMPT_TEMPLATE
-            .replace(EXTRACTED_TEXT_PLACEHOLDER_FOR_PROMPT, extractedText)
-            .replace(TAXONOMY_PLACEHOLDER_FOR_PROMPT, taxonomyItems);
-
-    Message message =
-        Message.builder()
-            .content(ContentBlock.fromText(prompt))
-            .role(ConversationRole.USER)
-            .build();
-
     ConverseData converseData = extractionRequest.input().converseData();
+    LlmModel llmModel = LlmModel.fromId(converseData.modelId());
+
     ConverseResponse response =
         bedrockRuntimeClient.converse(
-            request ->
-                request
-                    .modelId(converseData.modelId())
-                    .messages(message)
-                    .inferenceConfig(
-                        config ->
-                            config
-                                .maxTokens(converseData.maxTokens())
-                                .temperature(converseData.temperature())
-                                .topP(converseData.topP())));
+            request -> {
+              String userMessage = llmModel.getMessage(extractedText, taxonomyItems);
+
+              if (llmModel.isSystemPromptAllowed()) {
+                SystemContentBlock prompt =
+                    SystemContentBlock.builder().text(llmModel.getSystemPrompt()).build();
+                request.system(prompt);
+              } else {
+                userMessage = String.format("%s%n%s", llmModel.getSystemPrompt(), userMessage);
+              }
+
+              Message message =
+                  Message.builder()
+                      .content(ContentBlock.fromText(userMessage))
+                      .role(ConversationRole.USER)
+                      .build();
+
+              request
+                  .modelId(converseData.modelId())
+                  .messages(message)
+                  .inferenceConfig(
+                      config ->
+                          config
+                              .maxTokens(converseData.maxTokens())
+                              .temperature(converseData.temperature())
+                              .topP(converseData.topP()));
+            });
 
     return response.output().message().content().getFirst().text();
   }

--- a/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/model/LlmModel.java
+++ b/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/model/LlmModel.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.idp.extraction.model;
+
+import static io.camunda.connector.idp.extraction.caller.BedrockCaller.EXTRACTED_TEXT_PLACEHOLDER_FOR_MESSAGE;
+import static io.camunda.connector.idp.extraction.caller.BedrockCaller.TAXONOMY_PLACEHOLDER_FOR_MESSAGE;
+
+public enum LlmModel {
+  ANTHROPIC(getCommonSystemPrompt(), getCommonMessageTemplate()),
+  LLAMA(
+      """
+            <|begin_of_text|><|start_header_id|>system<|end_header_id|>
+            %s
+
+            You are a helpful assistant with tool calling capabilities.
+      """
+          .formatted(getCommonSystemInstruction()),
+      """
+            <|eot_id|><|start_header_id|>user<|end_header_id|>
+            Given the following functions, please respond with a JSON for a function call with its proper arguments
+            that best answers the given prompts.
+
+            Respond in JSON format, without any preamble. Example response:
+            {
+              "name": "John Smith",
+              "age": 32
+            }
+
+            {
+                "type": "function",
+                "function": {
+                "name": "extract text variables",
+                "description": "extract every variable based on the given prompt in the question",
+                "parameters": {
+                    "type": "object"
+                    }
+                }
+            }
+
+            Question: Given the following functions, please respond with a JSON for a function call with its proper arguments
+            that best answers the given prompt.
+            %s
+      """
+          .formatted(getCommonMessageTemplate())),
+  TITAN(getCommonSystemPrompt(), getCommonMessageTemplate());
+
+  private final String systemPrompt;
+  private final String messageTemplate;
+
+  private static final String ANTHROPIC_PREFIX = "anthropic";
+  private static final String LLAMA_PREFIX = "meta";
+  private static final String TITAN_PREFIX = "amazon";
+
+  LlmModel(String systemPrompt, String messageTemplate) {
+    this.systemPrompt = systemPrompt;
+    this.messageTemplate = messageTemplate;
+  }
+
+  public String getSystemPrompt() {
+    return systemPrompt;
+  }
+
+  public String getMessage(String extractedText, String taxonomyItems) {
+    return messageTemplate
+        .replace(EXTRACTED_TEXT_PLACEHOLDER_FOR_MESSAGE, extractedText)
+        .replace(TAXONOMY_PLACEHOLDER_FOR_MESSAGE, taxonomyItems);
+  }
+
+  public boolean isSystemPromptAllowed() {
+    return this != TITAN;
+  }
+
+  public static LlmModel fromId(String id) {
+    String lowerCaseId = id.toLowerCase();
+    if (lowerCaseId.startsWith(ANTHROPIC_PREFIX)) {
+      return ANTHROPIC;
+    } else if (lowerCaseId.startsWith(LLAMA_PREFIX)) {
+      return LLAMA;
+    } else if (lowerCaseId.startsWith(TITAN_PREFIX)) {
+      return TITAN;
+    } else {
+      return ANTHROPIC;
+    }
+  }
+
+  private static String getCommonSystemInstruction() {
+    return """
+            You will receive extracted text from a PDF document. This text will be between the <DOCUMENT_TEXT> tags.
+            Your task is to extract certain variables from the text. The description how to extract the variables is
+            between the <EXTRACTION> tags. Every variable is represented by a <VAR> tag. Every variable has a name,
+            which is represented by the <NAME> tag, as well as instructions which data to extract, which is represented
+            by the <PROMPT> tag.
+      """;
+  }
+
+  private static String getCommonSystemPrompt() {
+    return """
+            %s
+
+            Respond in JSON format, without any preamble. Example response:
+            {
+              "name": "John Smith",
+              "age": 32
+            }
+      """
+        .formatted(getCommonSystemInstruction());
+  }
+
+  private static String getCommonMessageTemplate() {
+    return """
+            Here is the document text as well as your instructions on which variables to extract:
+            <DOCUMENT_TEXT>%s</DOCUMENT_TEXT>
+            <EXTRACTION>%s</EXTRACTION>
+      """
+        .formatted(EXTRACTED_TEXT_PLACEHOLDER_FOR_MESSAGE, TAXONOMY_PLACEHOLDER_FOR_MESSAGE);
+  }
+}

--- a/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/model/LlmModel.java
+++ b/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/model/LlmModel.java
@@ -10,8 +10,9 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 public enum LlmModel {
-  ANTHROPIC(getCommonSystemPrompt(), getCommonMessageTemplate()),
+  CLAUDE("anthropic", getCommonSystemPrompt(), getCommonMessageTemplate()),
   LLAMA(
+      "meta",
       """
             <|begin_of_text|><|start_header_id|>system<|end_header_id|>
             %s
@@ -46,14 +47,12 @@ public enum LlmModel {
             %s
       """
           .formatted(getCommonMessageTemplate())),
-  TITAN(getCommonSystemPrompt(), getCommonMessageTemplate());
+  TITAN("amazon", getCommonSystemPrompt(), getCommonMessageTemplate());
 
+  private final String vendor;
   private final String systemPrompt;
   private final String messageTemplate;
 
-  private static final String ANTHROPIC_PREFIX = "anthropic";
-  private static final String LLAMA_PREFIX = "meta";
-  private static final String TITAN_PREFIX = "amazon";
   private static final String EXTRACTED_TEXT_PLACEHOLDER_FOR_MESSAGE = "{{extractedText}}";
   private static final String TAXONOMY_PLACEHOLDER_FOR_MESSAGE = "{{taxonomy}}";
   private static final String SYSTEM_PROMPT_VARIABLE_TEMPLATE =
@@ -64,13 +63,18 @@ public enum LlmModel {
             </VAR>
       """;
 
-  LlmModel(String systemPrompt, String messageTemplate) {
+  LlmModel(String vendor, String systemPrompt, String messageTemplate) {
+    this.vendor = vendor;
     this.systemPrompt = systemPrompt;
     this.messageTemplate = messageTemplate;
   }
 
   public String getSystemPrompt() {
     return systemPrompt;
+  }
+
+  public String getVendor() {
+    return vendor;
   }
 
   public String getMessage(String extractedText, List<TaxonomyItem> taxonomyItems) {
@@ -89,15 +93,15 @@ public enum LlmModel {
   }
 
   public static LlmModel fromId(String id) {
-    String lowerCaseId = id.toLowerCase();
-    if (lowerCaseId.startsWith(ANTHROPIC_PREFIX)) {
-      return ANTHROPIC;
-    } else if (lowerCaseId.startsWith(LLAMA_PREFIX)) {
+    String modelId = id.toLowerCase();
+    if (modelId.contains(CLAUDE.getVendor())) {
+      return CLAUDE;
+    } else if (modelId.contains(LLAMA.getVendor())) {
       return LLAMA;
-    } else if (lowerCaseId.startsWith(TITAN_PREFIX)) {
+    } else if (modelId.contains(TITAN.getVendor())) {
       return TITAN;
     } else {
-      return ANTHROPIC;
+      return CLAUDE;
     }
   }
 


### PR DESCRIPTION
## Description

- Added ability to have different system prompts based on `modelId` input.
- Refactored the call to AWS Bedrock to include a `system` message conditionally only for LLMs that support it.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes https://github.com/camunda/connectors/issues/3572

## Checklist

- [ ] PR has a **milestone** or the `no milestone` label.

