### PR TITLE
chore(email-connector-headers): correct typo on ET

### DIFF
--- a/connectors/email/element-templates/email-outbound-connector.json
+++ b/connectors/email/element-templates/email-outbound-connector.json
@@ -559,7 +559,7 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "Additional email's headers",
+    "tooltip" : "Additional email headers",
     "type" : "String"
   }, {
     "id" : "smtpSubject",

--- a/connectors/email/element-templates/hybrid/email-outbound-connector-hybrid.json
+++ b/connectors/email/element-templates/hybrid/email-outbound-connector-hybrid.json
@@ -564,7 +564,7 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "Additional email's headers",
+    "tooltip" : "Additional email headers",
     "type" : "String"
   }, {
     "id" : "smtpSubject",

--- a/connectors/email/src/main/java/io/camunda/connector/email/outbound/protocols/actions/SmtpSendEmail.java
+++ b/connectors/email/src/main/java/io/camunda/connector/email/outbound/protocols/actions/SmtpSendEmail.java
@@ -62,7 +62,7 @@ public record SmtpSendEmail(
             label = "Headers",
             group = "sendEmailSmtp",
             id = "smtpHeaders",
-            tooltip = "Additional email's headers",
+            tooltip = "Additional email headers",
             feel = Property.FeelMode.required,
             binding = @TemplateProperty.PropertyBinding(name = "data.smtpAction.headers"),
             optional = true)


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

## Related issues

closes https://github.com/camunda/connectors/issues/3640

## Checklist

- [ ] PR has a **milestone** or the `no milestone` label.

