### PR TITLE
fix(email-connector): removing cancellation event when a exception is raised during email consumption

### DIFF
--- a/connectors/email/src/main/java/io/camunda/connector/email/client/jakarta/inbound/PollingManager.java
+++ b/connectors/email/src/main/java/io/camunda/connector/email/client/jakarta/inbound/PollingManager.java
@@ -114,7 +114,6 @@ public class PollingManager {
       Message[] messages = this.folder.getMessages();
       Arrays.stream(messages).forEach(message -> this.processMail((IMAPMessage) message, pollAll));
     } catch (MessagingException e) {
-      this.connectorContext.cancel(e);
       throw new RuntimeException(e);
     }
   }
@@ -126,7 +125,6 @@ public class PollingManager {
       Arrays.stream(unseenMessages)
           .forEach(message -> this.processMail((IMAPMessage) message, pollUnseen));
     } catch (MessagingException e) {
-      this.connectorContext.cancel(e);
       throw new RuntimeException(e);
     }
   }


### PR DESCRIPTION
## Description

When a exception was raised at consumption, a cancel event was sent

## Related issues

closes https://github.com/camunda/connectors/issues/3656

## Checklist

- [ ] PR has a **milestone** or the `no milestone` label.

