### PR TITLE
fix: use more recent spring zeebe version

### DIFF
--- a/connector-runtime/connector-runtime-core/pom.xml
+++ b/connector-runtime/connector-runtime-core/pom.xml
@@ -57,7 +57,7 @@
     </dependency>
     <dependency>
       <groupId>io.camunda.spring</groupId>
-      <artifactId>java-client-operate</artifactId>
+      <artifactId>java-client-operate-legacy</artifactId>
     </dependency>
 
     <dependency>

--- a/connector-runtime/connector-runtime-core/pom.xml
+++ b/connector-runtime/connector-runtime-core/pom.xml
@@ -42,6 +42,14 @@
       <groupId>com.fasterxml.jackson.datatype</groupId>
       <artifactId>jackson-datatype-jdk8</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-collections4</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>io.camunda</groupId>
@@ -92,6 +100,12 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jetbrains</groupId>
+      <artifactId>annotations</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/connector-runtime/connector-runtime-spring/pom.xml
+++ b/connector-runtime/connector-runtime-spring/pom.xml
@@ -53,7 +53,7 @@
     </dependency>
     <dependency>
       <groupId>io.camunda.spring</groupId>
-      <artifactId>java-client-operate</artifactId>
+      <artifactId>java-client-operate-legacy</artifactId>
     </dependency>
 
     <dependency>

--- a/connector-runtime/connector-runtime-spring/pom.xml
+++ b/connector-runtime/connector-runtime-spring/pom.xml
@@ -49,6 +49,10 @@
     </dependency>
     <dependency>
       <groupId>io.camunda.spring</groupId>
+      <artifactId>java-common</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.camunda.spring</groupId>
       <artifactId>java-client-operate</artifactId>
     </dependency>
 

--- a/connectors-e2e-test/connectors-e2e-test-base/pom.xml
+++ b/connectors-e2e-test/connectors-e2e-test-base/pom.xml
@@ -51,6 +51,10 @@
             <artifactId>junit-jupiter</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
         </dependency>

--- a/connectors/webhook/pom.xml
+++ b/connectors/webhook/pom.xml
@@ -70,6 +70,10 @@
       <version>${version.auth0.jwks}</version>
     </dependency>
     <dependency>
+      <groupId>org.jetbrains</groupId>
+      <artifactId>annotations</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.wiremock</groupId>
       <artifactId>wiremock-standalone</artifactId>
       <version>${version.wiremock}</version>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -73,7 +73,7 @@ limitations under the License.</license.inlineheader>
     <!-- Camunda internal libraries -->
     <version.zeebe>8.5.5</version.zeebe>
     <version.feel-engine>1.18.1</version.feel-engine>
-    <version.spring-zeebe>8.5.7</version.spring-zeebe>
+    <version.spring-zeebe>8.5.11</version.spring-zeebe>
 
     <!-- Third party dependencies -->
 

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -292,7 +292,7 @@ limitations under the License.</license.inlineheader>
       </dependency>
       <dependency>
         <groupId>io.camunda.spring</groupId>
-        <artifactId>java-client-operate</artifactId>
+        <artifactId>java-client-operate-legacy</artifactId>
         <version>${version.spring-zeebe}</version>
       </dependency>
       <dependency>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -459,6 +459,17 @@ limitations under the License.</license.inlineheader>
         <artifactId>commons-lang3</artifactId>
         <version>3.17.0</version>
       </dependency>
+      <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-collections4</artifactId>
+        <version>4.4</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jetbrains</groupId>
+        <artifactId>annotations</artifactId>
+        <version>26.0.1</version>
+      </dependency>
+
 
       <!-- Fixes CWE-770 -->
       <dependency>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -282,6 +282,11 @@ limitations under the License.</license.inlineheader>
       </dependency>
       <dependency>
         <groupId>io.camunda.spring</groupId>
+        <artifactId>java-common</artifactId>
+        <version>${version.spring-zeebe}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.camunda.spring</groupId>
         <artifactId>spring-boot-starter-camunda-test</artifactId>
         <version>${version.spring-zeebe}</version>
       </dependency>


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

The spring zeebe version is bumped to 8.5.11

Slack thread: https://camunda.slack.com/archives/C02JLRNQQ05/p1732195841890249?thread_ts=1727872562.192379&cid=C02JLRNQQ05

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #

## Checklist

- [ ] PR has a **milestone** or the `no milestone` label.

