### PR TITLE
fix(runtime): error messages are now delivered correctly to operate when input validation fails

### DIFF
--- a/connector-sdk/validation/src/main/java/io/camunda/connector/validation/impl/DefaultValidationProvider.java
+++ b/connector-sdk/validation/src/main/java/io/camunda/connector/validation/impl/DefaultValidationProvider.java
@@ -75,6 +75,9 @@ public class DefaultValidationProvider implements ValidationProvider {
    * property values.
    */
   protected String buildValidationMessage(ConstraintViolation<Object> violation) {
-    return " - Property: " + violation.getPropertyPath().toString() + ": Validation failed. Original message: " + violation.getMessage();
+    return " - Property: "
+        + violation.getPropertyPath().toString()
+        + ": Validation failed. Original message: "
+        + violation.getMessage();
   }
 }

--- a/connector-sdk/validation/src/main/java/io/camunda/connector/validation/impl/DefaultValidationProvider.java
+++ b/connector-sdk/validation/src/main/java/io/camunda/connector/validation/impl/DefaultValidationProvider.java
@@ -75,6 +75,6 @@ public class DefaultValidationProvider implements ValidationProvider {
    * property values.
    */
   protected String buildValidationMessage(ConstraintViolation<Object> violation) {
-    return " - Property: " + violation.getPropertyPath().toString() + ": Validation failed.";
+    return " - Property: " + violation.getPropertyPath().toString() + ": Validation failed. Original message: " + violation.getMessage();
   }
 }

--- a/connectors/aws/aws-textract/src/test/java/io/camunda/connector/textract/TextractConnectorFunctionTest.java
+++ b/connectors/aws/aws-textract/src/test/java/io/camunda/connector/textract/TextractConnectorFunctionTest.java
@@ -6,6 +6,7 @@
  */
 package io.camunda.connector.textract;
 
+import static io.camunda.connector.textract.model.TextractRequestData.WRONG_OUTPUT_VALUES_MSG;
 import static io.camunda.connector.textract.util.TextractTestUtils.ASYNC_EXECUTION_JSON_WITH_ROLE_ARN_AND_WITHOUT_SNS_TOPIC;
 import static io.camunda.connector.textract.util.TextractTestUtils.ASYNC_EXECUTION_JSON_WITH_SNS_TOPIC_AND_WITHOUT_ROLE_ARN;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -85,6 +86,7 @@ class TextractConnectorFunctionTest {
             ConnectorInputException.class,
             () -> textractConnectorFunction.execute(outBounderContext));
 
+    assertThat(exception).hasMessageContaining(WRONG_OUTPUT_VALUES_MSG);
     assertThat(exception).isInstanceOf(ConnectorInputException.class);
   }
 


### PR DESCRIPTION
## Description

Add wrapped error message to the overall input validation error

## Related issues

https://github.com/camunda/connectors/issues/3221


