### PR TITLE
fix(cve): Critical modify avro version 8.4

### DIFF
--- a/connectors/kafka/pom.xml
+++ b/connectors/kafka/pom.xml
@@ -25,7 +25,7 @@
 
   <properties>
     <!-- Pins avro version, as jackson-dataformat-avro transitively imports the outdated one -->
-    <version.avro>1.11.3</version.avro>
+    <version.avro>1.12.0</version.avro>
     <license.inlineheader>Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
 under one or more contributor license agreements. Licensed under a proprietary license.
 See the License.txt file for more information. You may not use this file

--- a/connectors/kafka/pom.xml
+++ b/connectors/kafka/pom.xml
@@ -25,7 +25,7 @@
 
   <properties>
     <!-- Pins avro version, as jackson-dataformat-avro transitively imports the outdated one -->
-    <version.avro>1.12.0</version.avro>
+    <version.avro>1.11.4</version.avro>
     <license.inlineheader>Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
 under one or more contributor license agreements. Licensed under a proprietary license.
 See the License.txt file for more information. You may not use this file


### PR DESCRIPTION
Schema parsing in the Java SDK of Apache Avro 1.11.3 and previous versions allows bad actors to execute arbitrary code. Users are recommended to upgrade to version 1.11.4, which fix this issue.
