### PR TITLE
chore(build): split testing and snapshot image build

### DIFF
--- a/.github/workflows/BUILD_FEATURE_BRANCH.yaml
+++ b/.github/workflows/BUILD_FEATURE_BRANCH.yaml
@@ -1,12 +1,10 @@
-name: Test branch
+name: Build branch for preview env deployment
 
 on:
   push:
     branches:
       - '**'
       - '!main'
-  merge_group:
-    branches: [ main ]
 
 jobs:
   run-tests:
@@ -60,20 +58,28 @@ jobs:
       - name: Install element templates CLI
         run: npm install --global element-templates-cli
 
-      - name: Build Connectors
-        run: mvn --batch-mode clean test -PcheckFormat
+      - name: Package Connectors
+        env:
+          PROJECTS: bundle/default-bundle
+        run: mvn --batch-mode compile generate-sources package -DskipTests --projects "${PROJECTS}" --also-make
 
-      - name: Lint Dockerfile - connector-runtime
-        uses: hadolint/hadolint-action@v3.1.0
-        with:
-          dockerfile: connector-runtime/connector-runtime-application/Dockerfile
+      - name: Set up Docker Build
+        uses: docker/setup-buildx-action@v3
 
-      - name: Lint Dockerfile - SaaS
-        uses: hadolint/hadolint-action@v3.1.0
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
         with:
-          dockerfile: bundle/camunda-saas-bundle/Dockerfile
+          registry: registry.camunda.cloud
+          username: ${{ steps.secrets.outputs.CI_LDAP_USER }}
+          password: ${{ steps.secrets.outputs.CI_LDAP_PASSWORD }}
 
-      - name: Lint Dockerfile - default-bundle
-        uses: hadolint/hadolint-action@v3.1.0
+      # Publish Docker images for Preview environments
+      - name: Build and Push Docker Image tag ${{ env.TAG }} - bundle-default
+        env:
+          TAG: pr-${{ github.sha }}
+        uses: docker/build-push-action@v6
         with:
-          dockerfile: bundle/default-bundle/Dockerfile
+          context: bundle/default-bundle/
+          provenance: false
+          push: true
+          tags: registry.camunda.cloud/team-connectors/connectors-bundle:${{ env.TAG }}


### PR DESCRIPTION
## Description

Split feature branch testing and docker image build workflows. This will allow faster deployment of preview env as we won't have to wait 1h until tests are executed.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #

## Checklist

- [ ] PR has a **milestone** or the `no milestone` label.

