### PR TITLE
feat(webhook): Replace DocumentReference by Document

### DIFF
--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/webhook/InboundWebhookRestController.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/webhook/InboundWebhookRestController.java
@@ -296,7 +296,7 @@ public class InboundWebhookRestController {
                   Optional.ofNullable(processedResult.request().headers()).orElse(emptyMap()),
                   Optional.ofNullable(processedResult.request().params()).orElse(emptyMap())),
               Optional.ofNullable(processedResult.connectorData()).orElse(emptyMap()),
-                  documents);
+              documents);
     }
     return ctx;
   }

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/webhook/InboundWebhookRestController.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/webhook/InboundWebhookRestController.java
@@ -42,7 +42,7 @@ import io.camunda.connector.api.inbound.webhook.WebhookTriggerResultContext;
 import io.camunda.connector.feel.FeelEngineWrapperException;
 import io.camunda.connector.runtime.inbound.executable.RegisteredExecutable;
 import io.camunda.connector.runtime.inbound.webhook.model.HttpServletRequestWebhookProcessingPayload;
-import io.camunda.document.reference.DocumentReference;
+import io.camunda.document.Document;
 import io.camunda.document.store.DocumentCreationRequest;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -137,12 +137,11 @@ public class InboundWebhookRestController {
         // Step 2: trigger and correlate
         var webhookResult = connectorHook.triggerWebhook(payload);
         // create documents if the connector is activable
-        var documentReferences =
-            createDocuments(connector.context(), webhookResult, payload.parts());
-        var ctxData = toWebhookTriggerResultContext(webhookResult, documentReferences);
+        var documents = createDocuments(connector.context(), webhookResult, payload.parts());
+        var ctxData = toWebhookTriggerResultContext(webhookResult, documents);
         // correlate
         var correlationResult = connector.context().correlateWithResult(ctxData);
-        response = buildResponse(webhookResult, documentReferences, correlationResult);
+        response = buildResponse(webhookResult, documents, correlationResult);
       }
     } catch (Exception e) {
       LOG.info("Webhook: {} failed with exception", connector.context().getDefinition(), e);
@@ -151,7 +150,7 @@ public class InboundWebhookRestController {
     return response;
   }
 
-  private List<DocumentReference> createDocuments(
+  private List<Document> createDocuments(
       InboundConnectorContext context,
       WebhookResult webhookResult,
       Collection<io.camunda.connector.api.inbound.webhook.Part> parts) {
@@ -162,13 +161,11 @@ public class InboundWebhookRestController {
     return parts.stream()
         .map(
             part ->
-                context
-                    .createDocument(
-                        DocumentCreationRequest.from(part.inputStream())
-                            .fileName(part.submittedFileName())
-                            .contentType(part.contentType())
-                            .build())
-                    .reference())
+                context.createDocument(
+                    DocumentCreationRequest.from(part.inputStream())
+                        .fileName(part.submittedFileName())
+                        .contentType(part.contentType())
+                        .build()))
         .toList();
   }
 
@@ -183,18 +180,15 @@ public class InboundWebhookRestController {
   }
 
   private ResponseEntity<?> buildResponse(
-      WebhookResult webhookResult,
-      List<DocumentReference> documentReferences,
-      CorrelationResult correlationResult) {
+      WebhookResult webhookResult, List<Document> documents, CorrelationResult correlationResult) {
     ResponseEntity<?> response;
     if (correlationResult instanceof CorrelationResult.Success success) {
-      response = buildSuccessfulResponse(webhookResult, documentReferences, success);
+      response = buildSuccessfulResponse(webhookResult, documents, success);
     } else {
       if (correlationResult instanceof CorrelationResult.Failure failure) {
         switch (failure.handlingStrategy()) {
           case ForwardErrorToUpstream ignored -> response = buildErrorResponse(failure);
-          case Ignore ignored ->
-              response = buildSuccessfulResponse(webhookResult, documentReferences, null);
+          case Ignore ignored -> response = buildSuccessfulResponse(webhookResult, documents, null);
         }
       } else {
         throw new IllegalStateException("Illegal correlation result : " + correlationResult);
@@ -215,12 +209,12 @@ public class InboundWebhookRestController {
 
   private ResponseEntity<?> buildSuccessfulResponse(
       WebhookResult webhookResult,
-      List<DocumentReference> documentReferences,
+      List<Document> documents,
       CorrelationResult.Success correlationResult) {
     ResponseEntity<?> response;
     if (webhookResult.response() != null) {
       var processVariablesContext =
-          toWebhookResultContext(webhookResult, documentReferences, correlationResult);
+          toWebhookResultContext(webhookResult, documents, correlationResult);
       var httpResponseData = webhookResult.response().apply(processVariablesContext);
       if (httpResponseData != null) {
         response = toResponseEntity(httpResponseData);
@@ -292,7 +286,7 @@ public class InboundWebhookRestController {
   // This will be used to correlate data returned from connector.
   // In other words, we pass this data to Zeebe.
   private WebhookTriggerResultContext toWebhookTriggerResultContext(
-      WebhookResult processedResult, List<DocumentReference> documentReferences) {
+      WebhookResult processedResult, List<Document> documents) {
     WebhookTriggerResultContext ctx = new WebhookTriggerResultContext(null, null, List.of());
     if (processedResult != null) {
       ctx =
@@ -302,7 +296,7 @@ public class InboundWebhookRestController {
                   Optional.ofNullable(processedResult.request().headers()).orElse(emptyMap()),
                   Optional.ofNullable(processedResult.request().params()).orElse(emptyMap())),
               Optional.ofNullable(processedResult.connectorData()).orElse(emptyMap()),
-              documentReferences);
+                  documents);
     }
     return ctx;
   }
@@ -312,7 +306,7 @@ public class InboundWebhookRestController {
   // this data may be returned to the webhook caller.
   private WebhookResultContext toWebhookResultContext(
       WebhookResult processedResult,
-      List<DocumentReference> documents,
+      List<Document> documents,
       CorrelationResult.Success correlationResult) {
     WebhookResultContext ctx = new WebhookResultContext(null, null, null);
     if (processedResult != null) {

--- a/connector-sdk/core/src/main/java/io/camunda/connector/api/inbound/webhook/WebhookResultContext.java
+++ b/connector-sdk/core/src/main/java/io/camunda/connector/api/inbound/webhook/WebhookResultContext.java
@@ -16,7 +16,7 @@
  */
 package io.camunda.connector.api.inbound.webhook;
 
-import io.camunda.document.reference.DocumentReference;
+import io.camunda.document.Document;
 import java.util.List;
 import java.util.Map;
 
@@ -24,7 +24,7 @@ public record WebhookResultContext(
     MappedHttpRequest request,
     Map<String, Object> connectorData,
     Object correlation,
-    List<DocumentReference> documents) {
+    List<Document> documents) {
 
   public WebhookResultContext(
       MappedHttpRequest request, Map<String, Object> connectorData, Object correlation) {

--- a/connector-sdk/core/src/main/java/io/camunda/connector/api/inbound/webhook/WebhookTriggerResultContext.java
+++ b/connector-sdk/core/src/main/java/io/camunda/connector/api/inbound/webhook/WebhookTriggerResultContext.java
@@ -17,7 +17,6 @@
 package io.camunda.connector.api.inbound.webhook;
 
 import io.camunda.document.Document;
-import io.camunda.document.reference.DocumentReference;
 import java.util.List;
 import java.util.Map;
 

--- a/connector-sdk/core/src/main/java/io/camunda/connector/api/inbound/webhook/WebhookTriggerResultContext.java
+++ b/connector-sdk/core/src/main/java/io/camunda/connector/api/inbound/webhook/WebhookTriggerResultContext.java
@@ -16,6 +16,7 @@
  */
 package io.camunda.connector.api.inbound.webhook;
 
+import io.camunda.document.Document;
 import io.camunda.document.reference.DocumentReference;
 import java.util.List;
 import java.util.Map;
@@ -25,9 +26,7 @@ import java.util.Map;
  * variables.
  */
 public record WebhookTriggerResultContext(
-    MappedHttpRequest request,
-    Map<String, Object> connectorData,
-    List<DocumentReference> documents) {
+    MappedHttpRequest request, Map<String, Object> connectorData, List<Document> documents) {
   public WebhookTriggerResultContext(MappedHttpRequest request, Map<String, Object> connectorData) {
     this(request, connectorData, List.of());
   }

--- a/connector-sdk/jackson-datatype-feel/src/main/java/io/camunda/connector/feel/jackson/AbstractFeelDeserializer.java
+++ b/connector-sdk/jackson-datatype-feel/src/main/java/io/camunda/connector/feel/jackson/AbstractFeelDeserializer.java
@@ -22,10 +22,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.deser.ContextualDeserializer;
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
-import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
-import io.camunda.connector.document.annotation.jackson.JacksonModuleDocument;
 import io.camunda.connector.feel.FeelEngineWrapper;
-import io.camunda.document.factory.DocumentFactoryImpl;
 import java.io.IOException;
 import java.util.function.Supplier;
 
@@ -49,9 +46,6 @@ public abstract class AbstractFeelDeserializer<T> extends StdDeserializer<T>
     super(String.class);
     this.feelEngineWrapper = feelEngineWrapper;
     this.relaxed = relaxed;
-    BLANK_OBJECT_MAPPER
-        .registerModule(new Jdk8Module())
-        .registerModule(new JacksonModuleDocument(new DocumentFactoryImpl(null), null));
   }
 
   @Override

--- a/connector-sdk/jackson-datatype-feel/src/main/java/io/camunda/connector/feel/jackson/AbstractFeelDeserializer.java
+++ b/connector-sdk/jackson-datatype-feel/src/main/java/io/camunda/connector/feel/jackson/AbstractFeelDeserializer.java
@@ -22,7 +22,10 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.deser.ContextualDeserializer;
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import io.camunda.connector.document.annotation.jackson.JacksonModuleDocument;
 import io.camunda.connector.feel.FeelEngineWrapper;
+import io.camunda.document.factory.DocumentFactoryImpl;
 import java.io.IOException;
 import java.util.function.Supplier;
 
@@ -46,6 +49,8 @@ public abstract class AbstractFeelDeserializer<T> extends StdDeserializer<T>
     super(String.class);
     this.feelEngineWrapper = feelEngineWrapper;
     this.relaxed = relaxed;
+    BLANK_OBJECT_MAPPER.registerModule(new Jdk8Module())
+            .registerModule(new JacksonModuleDocument(new DocumentFactoryImpl(null), null));
   }
 
   @Override

--- a/connector-sdk/jackson-datatype-feel/src/main/java/io/camunda/connector/feel/jackson/AbstractFeelDeserializer.java
+++ b/connector-sdk/jackson-datatype-feel/src/main/java/io/camunda/connector/feel/jackson/AbstractFeelDeserializer.java
@@ -49,8 +49,9 @@ public abstract class AbstractFeelDeserializer<T> extends StdDeserializer<T>
     super(String.class);
     this.feelEngineWrapper = feelEngineWrapper;
     this.relaxed = relaxed;
-    BLANK_OBJECT_MAPPER.registerModule(new Jdk8Module())
-            .registerModule(new JacksonModuleDocument(new DocumentFactoryImpl(null), null));
+    BLANK_OBJECT_MAPPER
+        .registerModule(new Jdk8Module())
+        .registerModule(new JacksonModuleDocument(new DocumentFactoryImpl(null), null));
   }
 
   @Override

--- a/connector-sdk/jackson-datatype-feel/src/main/java/io/camunda/connector/feel/jackson/FeelFunctionDeserializer.java
+++ b/connector-sdk/jackson-datatype-feel/src/main/java/io/camunda/connector/feel/jackson/FeelFunctionDeserializer.java
@@ -52,7 +52,8 @@ class FeelFunctionDeserializer<IN, OUT> extends AbstractFeelDeserializer<Functio
               deserializationContext,
               node.textValue(),
               deserializationContext.getTypeFactory().constructType(JsonNode.class),
-              mergeContexts(input, feelContext));
+              input,
+              feelContext);
       try {
         if (jsonNode == null || jsonNode.isNull()) {
           return null;
@@ -66,23 +67,6 @@ class FeelFunctionDeserializer<IN, OUT> extends AbstractFeelDeserializer<Functio
         throw new RuntimeException(e);
       }
     };
-  }
-
-  private Object mergeContexts(Object inputContext, Object feelContext) {
-    try {
-      var wrappedInput =
-          new MergedContext(BLANK_OBJECT_MAPPER.convertValue(inputContext, MAP_TYPE_REF));
-      var wrappedFeelContext =
-          new MergedContext(BLANK_OBJECT_MAPPER.convertValue(feelContext, MAP_TYPE_REF));
-      var merged =
-          BLANK_OBJECT_MAPPER
-              .readerForUpdating(wrappedInput)
-              .treeToValue(
-                  BLANK_OBJECT_MAPPER.valueToTree(wrappedFeelContext), MergedContext.class);
-      return merged.context;
-    } catch (IOException e) {
-      throw new RuntimeException(e);
-    }
   }
 
   @Override


### PR DESCRIPTION
## Description

- Replace DocumentReference with Document so that we have the right format that can be used by subsequent connectors;
- Add the right Jackson modules to the ObjectMapper used by the AbstractFeelDeserializer

## Related issues

https://github.com/camunda/team-connectors/issues/788

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.

