### PR TITLE
feat(aws): Role can now be assumed within an AWS EKS cluster using IRSA

### DIFF
--- a/connectors/aws/aws-base/pom.xml
+++ b/connectors/aws/aws-base/pom.xml
@@ -28,10 +28,17 @@
     </licenses>
 
     <dependencies>
+
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-core</artifactId>
             <version>${version.aws-java-sdk}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk-sts</artifactId>
+            <version>${version.aws-java-sdk-sts}</version>
         </dependency>
 
         <dependency>
@@ -41,16 +48,11 @@
         </dependency>
 
         <dependency>
-            <groupId>com.amazonaws</groupId>
-            <artifactId>aws-java-sdk-sagemakerruntime</artifactId>
-            <version>${version.aws-java-sdk}</version>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>sts</artifactId>
+            <version>${version.software-aws-java-sdk-sts}</version>
         </dependency>
 
-        <dependency>
-            <groupId>com.amazonaws</groupId>
-            <artifactId>aws-java-sdk-sagemaker</artifactId>
-            <version>${version.aws-java-sdk}</version>
-        </dependency>
     </dependencies>
 
 </project>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -92,6 +92,8 @@ limitations under the License.</license.inlineheader>
 
     <version.aws-java-sdk>1.12.780</version.aws-java-sdk>
     <version.software-aws-java-sdk>2.29.34</version.software-aws-java-sdk>
+    <version.aws-java-sdk-sts>1.12.779</version.aws-java-sdk-sts>
+    <version.software-aws-java-sdk-sts>2.29.30</version.software-aws-java-sdk-sts>
     <version.aws-lambda-java-events>3.14.0</version.aws-lambda-java-events>
     <version.aws-lambda-java-core>1.2.3</version.aws-lambda-java-core>
 


### PR DESCRIPTION
## Description

Role can now be assumed within an AWS EKS cluster using IRSA

`DefaultAWSCredentialsProviderChain` is already looking for web identity token 

https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/auth/DefaultAWSCredentialsProviderChain.html

The error message was `WebIdentityTokenCredentialsProvider: To use assume role profiles the aws-java-sdk-sts module must be on the class path.`

This is corrected

## Related issues

closes https://github.com/camunda/connectors/issues/3754

## Checklist

- [ ] PR has a **milestone** or the `no milestone` label.

