### PR TITLE
bugfix(mail-connector): check if smtp body is null

### DIFF
--- a/connectors/email/src/main/java/io/camunda/connector/email/client/jakarta/outbound/JakartaEmailActionExecutor.java
+++ b/connectors/email/src/main/java/io/camunda/connector/email/client/jakarta/outbound/JakartaEmailActionExecutor.java
@@ -289,16 +289,25 @@ public class JakartaEmailActionExecutor implements EmailActionExecutor {
         smtpSendEmail.contentType() == null ? PLAIN : smtpSendEmail.contentType();
     switch (contentType) {
       case PLAIN -> {
+        if (smtpSendEmail.body() == null) {
+          throw new MessagingException("Text Body is null");
+        }
         MimeBodyPart textPart = new MimeBodyPart();
         textPart.setText(smtpSendEmail.body(), StandardCharsets.UTF_8.name());
         multipart.addBodyPart(textPart);
       }
       case HTML -> {
+        if (smtpSendEmail.htmlBody() == null) {
+          throw new MessagingException("HTML Body is null");
+        }
         MimeBodyPart htmlPart = new MimeBodyPart();
         htmlPart.setContent(smtpSendEmail.htmlBody(), JakartaUtils.HTML_CHARSET);
         multipart.addBodyPart(htmlPart);
       }
       case MULTIPART -> {
+        if (smtpSendEmail.htmlBody() == null || smtpSendEmail.body() == null) {
+          throw new MessagingException("Text or HTML Body is null");
+        }
         MimeBodyPart textPart = new MimeBodyPart();
         textPart.setText(smtpSendEmail.body(), StandardCharsets.UTF_8.name());
         MimeBodyPart htmlPart = new MimeBodyPart();


### PR DESCRIPTION
## Description

Check if body is null or not. If body is null throw an error.
If the error is not thrown because of the null object, the mail connector will retry it again until all retries are exhausted.
It seems that the connector runtime will block everything in the thread. 

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #

## Checklist

- [ ] PR has a **milestone** or the `no milestone` label.

