### PR TITLE
bugfix(mail-connector): Backport 3796 to release/8.6 smtp body validation

### DIFF
--- a/connectors/email/src/main/java/io/camunda/connector/email/outbound/protocols/actions/SmtpSendEmail.java
+++ b/connectors/email/src/main/java/io/camunda/connector/email/outbound/protocols/actions/SmtpSendEmail.java
@@ -126,7 +126,7 @@ public record SmtpSendEmail(
         @Valid
         String htmlBody)
     implements SmtpAction {
-        @AssertTrue(message = "Please provide a proper message body")
+  @AssertTrue(message = "Please provide a proper message body")
   public boolean isEmailMessageValid() {
     return switch (contentType) {
       case PLAIN -> body != null;
@@ -134,4 +134,4 @@ public record SmtpSendEmail(
       case MULTIPART -> body != null && htmlBody != null;
     };
   }
-    }
+}

--- a/connectors/email/src/main/java/io/camunda/connector/email/outbound/protocols/actions/SmtpSendEmail.java
+++ b/connectors/email/src/main/java/io/camunda/connector/email/outbound/protocols/actions/SmtpSendEmail.java
@@ -10,6 +10,7 @@ import io.camunda.connector.generator.dsl.Property;
 import io.camunda.connector.generator.java.annotation.TemplateProperty;
 import io.camunda.connector.generator.java.annotation.TemplateSubType;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.NotNull;
 import java.util.Map;
 
@@ -124,4 +125,13 @@ public record SmtpSendEmail(
                     oneOf = {"HTML", "MULTIPART"}))
         @Valid
         String htmlBody)
-    implements SmtpAction {}
+    implements SmtpAction {
+        @AssertTrue(message = "Please provide a proper message body")
+  public boolean isEmailMessageValid() {
+    return switch (contentType) {
+      case PLAIN -> body != null;
+      case HTML -> htmlBody != null;
+      case MULTIPART -> body != null && htmlBody != null;
+    };
+  }
+    }

--- a/connectors/email/src/test/java/io/camunda/connector/email/outbound/protocols/actions/SmtpSendEmailTest.java
+++ b/connectors/email/src/test/java/io/camunda/connector/email/outbound/protocols/actions/SmtpSendEmailTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.email.outbound.protocols.actions;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class SmtpSendEmailTest {
+
+  @Test
+  void isEmailMessageValidPlainTextWithBody() {
+    SmtpSendEmail smtpSendEmail = mockSmtpSendEmail(ContentType.PLAIN, "text", null);
+    assertTrue(smtpSendEmail.isEmailMessageValid());
+  }
+
+  @Test
+  void isEmailMessageNotValidPlainTextWithoutBody() {
+    SmtpSendEmail smtpSendEmail = mockSmtpSendEmail(ContentType.PLAIN, null, null);
+    assertFalse(smtpSendEmail.isEmailMessageValid());
+  }
+
+  @Test
+  void isEmailMessageValidHtmlTextWithBody() {
+    SmtpSendEmail smtpSendEmail = mockSmtpSendEmail(ContentType.HTML, null, "text");
+    assertTrue(smtpSendEmail.isEmailMessageValid());
+  }
+
+  @Test
+  void isEmailMessageNotValidHtmlWithoutBody() {
+    SmtpSendEmail smtpSendEmail = mockSmtpSendEmail(ContentType.HTML, null, null);
+    assertFalse(smtpSendEmail.isEmailMessageValid());
+  }
+
+  @Test
+  void isEmailMessageValidMultiWithBody() {
+    SmtpSendEmail smtpSendEmail = mockSmtpSendEmail(ContentType.MULTIPART, "text", "text2");
+    assertTrue(smtpSendEmail.isEmailMessageValid());
+  }
+
+  @Test
+  void isEmailMessageNotValidHtmlTextWithoutBothBodies() {
+    SmtpSendEmail smtpSendEmail = mockSmtpSendEmail(ContentType.MULTIPART, null, null);
+    assertFalse(smtpSendEmail.isEmailMessageValid());
+  }
+
+  @Test
+  void isEmailMessageNotValidMultiWithoutHtmlBody() {
+    SmtpSendEmail smtpSendEmail = mockSmtpSendEmail(ContentType.MULTIPART, "text", null);
+    assertFalse(smtpSendEmail.isEmailMessageValid());
+  }
+
+  @Test
+  void isEmailMessageNotValidMultiWithoutBody() {
+    SmtpSendEmail smtpSendEmail = mockSmtpSendEmail(ContentType.MULTIPART, null, "text");
+    assertFalse(smtpSendEmail.isEmailMessageValid());
+  }
+
+  private SmtpSendEmail mockSmtpSendEmail(ContentType contentType, String body, String htmlBody) {
+    return new SmtpSendEmail("", "", "", "", null, "", contentType, body, htmlBody, null);
+  }
+}

--- a/connectors/email/src/test/java/io/camunda/connector/email/outbound/protocols/actions/SmtpSendEmailTest.java
+++ b/connectors/email/src/test/java/io/camunda/connector/email/outbound/protocols/actions/SmtpSendEmailTest.java
@@ -62,6 +62,6 @@ class SmtpSendEmailTest {
   }
 
   private SmtpSendEmail mockSmtpSendEmail(ContentType contentType, String body, String htmlBody) {
-    return new SmtpSendEmail("", "", "", "", null, "", contentType, body, htmlBody, null);
+    return new SmtpSendEmail("", "", "", "", null, "", contentType, body, htmlBody);
   }
 }


### PR DESCRIPTION
## Description

Cherry Pick the bugfix to validate htmlBody and textBody

## Related issues

closes #https://github.com/camunda/connectors/issues/3795

## Checklist

- [ ] PR has a **milestone** or the `no milestone` label.

