### PR TITLE
feat(textract doc handle): add documentation handling for textract

### DIFF
--- a/connectors/aws/aws-textract/element-templates/aws-textract-outbound-connector.json
+++ b/connectors/aws/aws-textract/element-templates/aws-textract-outbound-connector.json
@@ -7,7 +7,7 @@
     "keywords" : [ "extract text", "extract data", "extract text from image", "extract data from image", "ocr" ]
   },
   "documentationRef" : "https://docs.camunda.io/docs/next/components/connectors/out-of-the-box-connectors/amazon-textract/",
-  "version" : 1,
+  "version" : 2,
   "category" : {
     "id" : "connectors",
     "name" : "Connectors"
@@ -152,6 +152,31 @@
       "value" : "POLLING"
     } ]
   }, {
+    "id" : "input.documentLocationType",
+    "label" : "Document location type",
+    "description" : "Document location",
+    "optional" : false,
+    "value" : "UPLOADED",
+    "group" : "input",
+    "binding" : {
+      "name" : "input.documentLocationType",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "input.executionType",
+      "equals" : "SYNC",
+      "type" : "simple"
+    },
+    "tooltip" : "<a href=\"https://docs.camunda.io/docs/next/apis-tools/camunda-api-rest/specifications/create-document-link/\">Camunda Document</a>",
+    "type" : "Dropdown",
+    "choices" : [ {
+      "name" : "S3",
+      "value" : "S3"
+    }, {
+      "name" : "Camunda Document",
+      "value" : "UPLOADED"
+    } ]
+  }, {
     "id" : "input.documentS3Bucket",
     "label" : "Document bucket",
     "description" : "S3 bucket that contains document that needs to be processed",
@@ -164,6 +189,11 @@
     "binding" : {
       "name" : "input.documentS3Bucket",
       "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "input.documentLocationType",
+      "equals" : "S3",
+      "type" : "simple"
     },
     "type" : "String"
   }, {
@@ -180,6 +210,11 @@
       "name" : "input.documentName",
       "type" : "zeebe:input"
     },
+    "condition" : {
+      "property" : "input.documentLocationType",
+      "equals" : "S3",
+      "type" : "simple"
+    },
     "type" : "String"
   }, {
     "id" : "input.documentVersion",
@@ -191,6 +226,11 @@
     "binding" : {
       "name" : "input.documentVersion",
       "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "input.documentLocationType",
+      "equals" : "S3",
+      "type" : "simple"
     },
     "type" : "String"
   }, {
@@ -369,6 +409,25 @@
     "condition" : {
       "property" : "input.executionType",
       "equals" : "ASYNC",
+      "type" : "simple"
+    },
+    "type" : "String"
+  }, {
+    "id" : "input.document",
+    "label" : "Document",
+    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "required",
+    "group" : "input",
+    "binding" : {
+      "name" : "input.document",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "input.documentLocationType",
+      "equals" : "UPLOADED",
       "type" : "simple"
     },
     "type" : "String"

--- a/connectors/aws/aws-textract/element-templates/hybrid/aws-textract-outbound-connector-hybrid.json
+++ b/connectors/aws/aws-textract/element-templates/hybrid/aws-textract-outbound-connector-hybrid.json
@@ -7,7 +7,7 @@
     "keywords" : [ "extract text", "extract data", "extract text from image", "extract data from image", "ocr" ]
   },
   "documentationRef" : "https://docs.camunda.io/docs/next/components/connectors/out-of-the-box-connectors/amazon-textract/",
-  "version" : 1,
+  "version" : 2,
   "category" : {
     "id" : "connectors",
     "name" : "Connectors"
@@ -157,6 +157,31 @@
       "value" : "POLLING"
     } ]
   }, {
+    "id" : "input.documentLocationType",
+    "label" : "Document location type",
+    "description" : "Document location",
+    "optional" : false,
+    "value" : "UPLOADED",
+    "group" : "input",
+    "binding" : {
+      "name" : "input.documentLocationType",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "input.executionType",
+      "equals" : "SYNC",
+      "type" : "simple"
+    },
+    "tooltip" : "<a href=\"https://docs.camunda.io/docs/next/apis-tools/camunda-api-rest/specifications/create-document-link/\">Camunda Document</a>",
+    "type" : "Dropdown",
+    "choices" : [ {
+      "name" : "S3",
+      "value" : "S3"
+    }, {
+      "name" : "Camunda Document",
+      "value" : "UPLOADED"
+    } ]
+  }, {
     "id" : "input.documentS3Bucket",
     "label" : "Document bucket",
     "description" : "S3 bucket that contains document that needs to be processed",
@@ -169,6 +194,11 @@
     "binding" : {
       "name" : "input.documentS3Bucket",
       "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "input.documentLocationType",
+      "equals" : "S3",
+      "type" : "simple"
     },
     "type" : "String"
   }, {
@@ -185,6 +215,11 @@
       "name" : "input.documentName",
       "type" : "zeebe:input"
     },
+    "condition" : {
+      "property" : "input.documentLocationType",
+      "equals" : "S3",
+      "type" : "simple"
+    },
     "type" : "String"
   }, {
     "id" : "input.documentVersion",
@@ -196,6 +231,11 @@
     "binding" : {
       "name" : "input.documentVersion",
       "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "input.documentLocationType",
+      "equals" : "S3",
+      "type" : "simple"
     },
     "type" : "String"
   }, {
@@ -374,6 +414,25 @@
     "condition" : {
       "property" : "input.executionType",
       "equals" : "ASYNC",
+      "type" : "simple"
+    },
+    "type" : "String"
+  }, {
+    "id" : "input.document",
+    "label" : "Document",
+    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "required",
+    "group" : "input",
+    "binding" : {
+      "name" : "input.document",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "input.documentLocationType",
+      "equals" : "UPLOADED",
       "type" : "simple"
     },
     "type" : "String"

--- a/connectors/aws/aws-textract/src/main/java/io/camunda/connector/textract/TextractConnectorFunction.java
+++ b/connectors/aws/aws-textract/src/main/java/io/camunda/connector/textract/TextractConnectorFunction.java
@@ -34,7 +34,7 @@ import io.camunda.connector.textract.suppliers.AmazonTextractClientSupplier;
               "ocr"
             }),
     inputDataClass = TextractRequest.class,
-    version = 1,
+    version = 2,
     propertyGroups = {
       @ElementTemplate.PropertyGroup(id = "authentication", label = "Authentication"),
       @ElementTemplate.PropertyGroup(id = "configuration", label = "Configuration"),

--- a/connectors/aws/aws-textract/src/main/java/io/camunda/connector/textract/caller/SyncTextractCaller.java
+++ b/connectors/aws/aws-textract/src/main/java/io/camunda/connector/textract/caller/SyncTextractCaller.java
@@ -11,6 +11,8 @@ import com.amazonaws.services.textract.model.AnalyzeDocumentRequest;
 import com.amazonaws.services.textract.model.AnalyzeDocumentResult;
 import com.amazonaws.services.textract.model.Document;
 import io.camunda.connector.textract.model.TextractRequestData;
+import java.nio.ByteBuffer;
+import java.util.Objects;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -22,7 +24,8 @@ public class SyncTextractCaller implements TextractCaller<AnalyzeDocumentResult>
   public AnalyzeDocumentResult call(
       TextractRequestData requestData, AmazonTextract textractClient) {
     LOGGER.debug("Starting sync task for document analysis with request data: {}", requestData);
-    final Document document = new Document().withS3Object(prepareS3Obj(requestData));
+
+    final Document document = createDocument(requestData);
 
     final AnalyzeDocumentRequest analyzeDocumentRequest =
         new AnalyzeDocumentRequest()
@@ -30,5 +33,17 @@ public class SyncTextractCaller implements TextractCaller<AnalyzeDocumentResult>
             .withDocument(document);
 
     return textractClient.analyzeDocument(analyzeDocumentRequest);
+  }
+
+  private Document createDocument(TextractRequestData requestData) {
+    final Document document = new Document();
+
+    if (Objects.isNull(requestData.document())) {
+      return document.withS3Object(prepareS3Obj(requestData));
+    }
+
+    byte[] docBytes = requestData.document().asByteArray();
+    document.withBytes(ByteBuffer.wrap(docBytes));
+    return document;
   }
 }

--- a/connectors/aws/aws-textract/src/main/java/io/camunda/connector/textract/model/DocumentLocationType.java
+++ b/connectors/aws/aws-textract/src/main/java/io/camunda/connector/textract/model/DocumentLocationType.java
@@ -1,0 +1,12 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.textract.model;
+
+public enum DocumentLocationType {
+  S3,
+  UPLOADED;
+}

--- a/connectors/aws/aws-textract/src/test/java/io/camunda/connector/textract/caller/AsyncTextractCallerTest.java
+++ b/connectors/aws/aws-textract/src/test/java/io/camunda/connector/textract/caller/AsyncTextractCallerTest.java
@@ -14,6 +14,7 @@ import static org.mockito.Mockito.when;
 import com.amazonaws.services.textract.AmazonTextractAsyncClient;
 import com.amazonaws.services.textract.model.StartDocumentAnalysisRequest;
 import com.amazonaws.services.textract.model.StartDocumentAnalysisResult;
+import io.camunda.connector.textract.model.DocumentLocationType;
 import io.camunda.connector.textract.model.TextractExecutionType;
 import io.camunda.connector.textract.model.TextractRequestData;
 import org.junit.jupiter.api.Test;
@@ -100,6 +101,7 @@ class AsyncTextractCallerTest {
   private TextractRequestData prepareReqData(String roleArn, String topicArn) {
     return new TextractRequestData(
         TextractExecutionType.ASYNC,
+        DocumentLocationType.S3,
         "test-bucket",
         "test-object",
         "1",
@@ -113,12 +115,14 @@ class AsyncTextractCallerTest {
         roleArn,
         topicArn,
         "outputBucket",
-        "prefix");
+        "prefix",
+        null);
   }
 
   private TextractRequestData prepareReqDataWithoutOutputS3Bucket() {
     return new TextractRequestData(
         TextractExecutionType.ASYNC,
+        DocumentLocationType.S3,
         "test-bucket",
         "test-object",
         "1",
@@ -132,6 +136,7 @@ class AsyncTextractCallerTest {
         "roleArn",
         "topicArn",
         "",
-        "prefix");
+        "prefix",
+        null);
   }
 }

--- a/connectors/aws/aws-textract/src/test/java/io/camunda/connector/textract/caller/SyncTextractCallerTest.java
+++ b/connectors/aws/aws-textract/src/test/java/io/camunda/connector/textract/caller/SyncTextractCallerTest.java
@@ -6,24 +6,30 @@
  */
 package io.camunda.connector.textract.caller;
 
+import static com.amazonaws.services.textract.model.FeatureType.*;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 import com.amazonaws.services.textract.AmazonTextractClient;
 import com.amazonaws.services.textract.model.AnalyzeDocumentRequest;
 import com.amazonaws.services.textract.model.AnalyzeDocumentResult;
+import io.camunda.connector.textract.model.DocumentLocationType;
 import io.camunda.connector.textract.model.TextractExecutionType;
 import io.camunda.connector.textract.model.TextractRequestData;
+import io.camunda.document.Document;
+import java.nio.ByteBuffer;
+import java.util.HexFormat;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
+import org.mockito.ArgumentCaptor;
 
 class SyncTextractCallerTest {
   @Test
-  void call() {
+  void callWithS3DocumentLocation() {
     TextractRequestData requestData =
         new TextractRequestData(
             TextractExecutionType.SYNC,
+            DocumentLocationType.S3,
             "test-bucket",
             "test-object",
             "1",
@@ -37,9 +43,10 @@ class SyncTextractCallerTest {
             "notification-channel",
             "role-arn",
             "outputBucket",
-            "prefix");
+            "prefix",
+            null);
 
-    AmazonTextractClient textractClient = Mockito.mock(AmazonTextractClient.class);
+    AmazonTextractClient textractClient = mock(AmazonTextractClient.class);
 
     when(textractClient.analyzeDocument(any(AnalyzeDocumentRequest.class)))
         .thenReturn(new AnalyzeDocumentResult());
@@ -47,5 +54,53 @@ class SyncTextractCallerTest {
     new SyncTextractCaller().call(requestData, textractClient);
 
     verify(textractClient).analyzeDocument(any(AnalyzeDocumentRequest.class));
+  }
+
+  @Test
+  void callWithUploadDocumentLocation() {
+    final Document document = mock(Document.class);
+    byte[] bytes = HexFormat.of().parseHex("e04fd020ea3a6910a2d808002b30309d");
+
+    when(document.asByteArray()).thenReturn(bytes);
+
+    TextractRequestData requestData =
+        new TextractRequestData(
+            TextractExecutionType.SYNC,
+            DocumentLocationType.UPLOADED,
+            null,
+            null,
+            null,
+            true,
+            false,
+            false,
+            false,
+            "token",
+            "client-request-token",
+            "job-tag",
+            "notification-channel",
+            "role-arn",
+            "outputBucket",
+            "prefix",
+            document);
+
+    AmazonTextractClient textractClient = mock(AmazonTextractClient.class);
+
+    when(textractClient.analyzeDocument(any(AnalyzeDocumentRequest.class)))
+        .thenReturn(new AnalyzeDocumentResult());
+
+    new SyncTextractCaller().call(requestData, textractClient);
+
+    ArgumentCaptor<AnalyzeDocumentRequest> argumentCaptor =
+        ArgumentCaptor.forClass(AnalyzeDocumentRequest.class);
+
+    verify(textractClient).analyzeDocument(argumentCaptor.capture());
+    AnalyzeDocumentRequest analyzeDocumentRequest = argumentCaptor.getValue();
+    assertThat(analyzeDocumentRequest)
+        .isEqualTo(
+            new AnalyzeDocumentRequest()
+                .withFeatureTypes(TABLES.name())
+                .withDocument(
+                    new com.amazonaws.services.textract.model.Document()
+                        .withBytes(ByteBuffer.wrap(bytes))));
   }
 }

--- a/connectors/aws/aws-textract/src/test/java/io/camunda/connector/textract/caller/TextractCallerTest.java
+++ b/connectors/aws/aws-textract/src/test/java/io/camunda/connector/textract/caller/TextractCallerTest.java
@@ -14,6 +14,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import com.amazonaws.services.textract.model.AnalyzeDocumentResult;
 import com.amazonaws.services.textract.model.DocumentLocation;
 import com.amazonaws.services.textract.model.S3Object;
+import io.camunda.connector.textract.model.DocumentLocationType;
 import io.camunda.connector.textract.model.TextractExecutionType;
 import io.camunda.connector.textract.model.TextractRequestData;
 import java.util.Set;
@@ -37,6 +38,7 @@ class TextractCallerTest {
     TextractRequestData requestData1 =
         new TextractRequestData(
             TextractExecutionType.SYNC,
+            DocumentLocationType.S3,
             "test-bucket",
             "test-object",
             "1",
@@ -50,7 +52,8 @@ class TextractCallerTest {
             "notification-channel",
             "role-arn",
             "outputBucket",
-            "prefix");
+            "prefix",
+            null);
     Set<String> featureTypes = textractCaller.prepareFeatureTypes(requestData1);
     assertThat(featureTypes).containsExactlyInAnyOrder("FORMS", "LAYOUT", "SIGNATURES", "TABLES");
   }
@@ -60,6 +63,7 @@ class TextractCallerTest {
     TextractRequestData requestData =
         new TextractRequestData(
             TextractExecutionType.SYNC,
+            DocumentLocationType.S3,
             "test-bucket",
             "test-object",
             "1",
@@ -73,7 +77,8 @@ class TextractCallerTest {
             "notification-channel",
             "role-arn",
             "outputBucket",
-            "prefix");
+            "prefix",
+            null);
 
     Exception exception =
         assertThrows(
@@ -87,6 +92,7 @@ class TextractCallerTest {
     TextractRequestData requestData =
         new TextractRequestData(
             TextractExecutionType.SYNC,
+            DocumentLocationType.S3,
             "test-bucket",
             "test-object",
             "1",
@@ -100,7 +106,8 @@ class TextractCallerTest {
             "notification-channel",
             "role-arn",
             "outputBucket",
-            "prefix");
+            "prefix",
+            null);
     Set<String> featureTypes = textractCaller.prepareFeatureTypes(requestData);
     assertThat(featureTypes).containsExactlyInAnyOrder("TABLES", "LAYOUT");
   }

--- a/connectors/aws/aws-textract/src/test/java/io/camunda/connector/textract/util/TextractTestUtils.java
+++ b/connectors/aws/aws-textract/src/test/java/io/camunda/connector/textract/util/TextractTestUtils.java
@@ -6,6 +6,7 @@
  */
 package io.camunda.connector.textract.util;
 
+import io.camunda.connector.textract.model.DocumentLocationType;
 import io.camunda.connector.textract.model.TextractExecutionType;
 import io.camunda.connector.textract.model.TextractRequestData;
 
@@ -194,6 +195,7 @@ public class TextractTestUtils {
   public static final TextractRequestData FULL_FILLED_ASYNC_TEXTRACT_DATA =
       new TextractRequestData(
           TextractExecutionType.ASYNC,
+          DocumentLocationType.S3,
           "test-bucket",
           "test-object",
           "1",
@@ -207,5 +209,6 @@ public class TextractTestUtils {
           "notification-channel",
           "sns-arn",
           "outputBucket",
-          "prefix");
+          "prefix",
+          null);
 }


### PR DESCRIPTION
## Description

added documentation handling for textract connector 
![image](https://github.com/user-attachments/assets/66520bae-c1fc-443f-b59f-65489179d860)


## Related issues

[issue](https://github.com/camunda/team-connectors/issues/981)
[element template PR](https://github.com/camunda/web-modeler/pull/12429)
[documentation PR](https://github.com/camunda/camunda-docs/pull/4820)


https://github.com/user-attachments/assets/82738414-916f-48ba-9de8-7ec8a65e80ac





