### PR TITLE
chore(ci): Fix Helm chart version

### DIFF
--- a/.github/workflows/helm-git-refs.json
+++ b/.github/workflows/helm-git-refs.json
@@ -1,7 +1,6 @@
 {
   "main": "camunda-platform-alpha",
-  "release/8.6": "camunda-platform-alpha",
-  "release/8.5": "camunda-platform-latest",
+  "release/8.5": "camunda-platform-8.5",
   "release/8.4": "camunda-platform-8.4",
   "release/8.3": "camunda-platform-8.3"
 }


### PR DESCRIPTION
## Description

“Latest" version no longer exists, it has to be 8.5 now.
