### PR TITLE
fix(rest): fix sending null params in a body map

### DIFF
--- a/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/utils/DocumentHelper.java
+++ b/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/utils/DocumentHelper.java
@@ -19,6 +19,7 @@ package io.camunda.connector.http.base.utils;
 import io.camunda.document.CamundaDocument;
 import java.util.AbstractMap;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -35,16 +36,20 @@ public class DocumentHelper {
     return switch (input) {
       case Map<?, ?> map ->
           map.entrySet().stream()
+              .filter(e -> e.getValue() != null)
               .map(
                   (Map.Entry<?, ?> e) ->
                       new AbstractMap.SimpleEntry<>(
                           e.getKey(), parseDocumentsInBody(e.getValue(), transformer)))
               .collect(
                   Collectors.toMap(
-                      AbstractMap.SimpleEntry::getKey, AbstractMap.SimpleEntry::getValue));
-
+                      AbstractMap.SimpleEntry::getKey,
+                      AbstractMap.SimpleEntry::getValue,
+                      (a, b) -> b,
+                      () -> new HashMap<>(map)));
       case Collection list -> list.stream().map(o -> parseDocumentsInBody(o, transformer)).toList();
       case CamundaDocument doc -> transformer.apply(doc);
+      case null -> null;
       default -> input;
     };
   }

--- a/connectors/http/http-base/src/test/java/io/camunda/connector/http/base/client/apache/CustomApacheHttpClientTest.java
+++ b/connectors/http/http-base/src/test/java/io/camunda/connector/http/base/client/apache/CustomApacheHttpClientTest.java
@@ -124,14 +124,13 @@ public class CustomApacheHttpClientTest {
                   .build());
       HttpCommonRequest request = new HttpCommonRequest();
       request.setMethod(HttpMethod.POST);
+      var bodyMap = new HashMap<>();
+      bodyMap.put("document", new CamundaDocument(ref.metadata(), ref, store));
+      bodyMap.put("otherField", "otherValue");
+      bodyMap.put("nullField", null);
       request.setHeaders(Map.of("Content-Type", ContentType.MULTIPART_FORM_DATA.getMimeType()));
       request.setUrl(wmRuntimeInfo.getHttpBaseUrl() + "/path");
-      request.setBody(
-          Map.of(
-              "otherField",
-              "otherValue",
-              "document",
-              new CamundaDocument(ref.metadata(), ref, store)));
+      request.setBody(bodyMap);
       HttpCommonResult result = customApacheHttpClient.execute(request);
       assertThat(result).isNotNull();
       assertThat(result.status()).isEqualTo(201);
@@ -506,7 +505,10 @@ public class CustomApacheHttpClientTest {
       HttpCommonRequest request = new HttpCommonRequest();
       request.setMethod(HttpMethod.POST);
       request.setHeaders(Map.of("header", "headerValue"));
-      request.setBody(Map.of("key1", "value1"));
+      var bodyMap = new HashMap<>();
+      bodyMap.put("key1", "value1");
+      bodyMap.put("nullKey", null);
+      request.setBody(bodyMap);
       request.setUrl(wmRuntimeInfo.getHttpBaseUrl() + "/path");
       HttpCommonResult result = customApacheHttpClient.execute(request);
       assertThat(result).isNotNull();
@@ -516,7 +518,9 @@ public class CustomApacheHttpClientTest {
           postRequestedFor(urlEqualTo("/path"))
               .withHeader("Content-Type", equalTo("application/json"))
               .withHeader("header", equalTo("headerValue"))
-              .withRequestBody(equalTo(StringEscapeUtils.unescapeJson("{\"key1\":\"value1\"}"))));
+              .withRequestBody(
+                  equalTo(
+                      StringEscapeUtils.unescapeJson("{\"key1\":\"value1\",\"nullKey\":null}"))));
     }
 
     @Test

--- a/connectors/http/http-base/src/test/java/io/camunda/connector/http/base/utils/DocumentHelperTest.java
+++ b/connectors/http/http-base/src/test/java/io/camunda/connector/http/base/utils/DocumentHelperTest.java
@@ -28,6 +28,7 @@ import io.camunda.document.store.InMemoryDocumentStore;
 import io.camunda.zeebe.client.api.response.DocumentMetadata;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
@@ -39,6 +40,39 @@ public class DocumentHelperTest {
   @AfterEach
   public void tearDown() {
     InMemoryDocumentStore.INSTANCE.clear();
+  }
+
+  @Test
+  public void shouldReturnBody_whenMapInputWithoutDocumentAndWithNullValues() {
+    // given
+    DocumentHelper documentHelper = new DocumentHelper();
+    Map<String, Object> input = new HashMap<>();
+    input.put("body", new HashMap<>());
+    ((Map<String, Object>) input.get("body")).put("content", null);
+
+    // when
+    Object res = documentHelper.parseDocumentsInBody(input, mock(Function.class));
+
+    // then
+    assertThat(res).isInstanceOf(Map.class);
+    assertThat(((Map<?, ?>) res).get("body")).isInstanceOf(Map.class);
+    assertThat(((Map<?, ?>) ((Map<?, ?>) res).get("body")).containsKey("content")).isTrue();
+    assertThat(((Map<?, ?>) ((Map<?, ?>) res).get("body")).get("content")).isNull();
+  }
+
+  @Test
+  public void shouldReturnBody_whenMapInputWithoutDocument() {
+    // given
+    DocumentHelper documentHelper = new DocumentHelper();
+    Map<String, Object> input = Map.of("body", Map.of("content", "no document"));
+
+    // when
+    Object res = documentHelper.parseDocumentsInBody(input, mock(Function.class));
+
+    // then
+    assertThat(res).isInstanceOf(Map.class);
+    assertThat(((Map<?, ?>) res).get("body")).isInstanceOf(Map.class);
+    assertThat(((Map<?, ?>) ((Map<?, ?>) res).get("body")).get("content")).isEqualTo("no document");
   }
 
   @Test


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
- Java's  `Collectors.toMap(` does not accept null value, hence producing a NPE when sending this kind of body:

```json
{
"myKey": null
}
```
