### PR TITLE
fix(rest connector): add skip decoding field for rest outbound connector

### DIFF
--- a/connectors/gitlab/element-templates/gitlab-connector.json
+++ b/connectors/gitlab/element-templates/gitlab-connector.json
@@ -2,7 +2,7 @@
   "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
   "name": "GitLab Outbound Connector",
   "id": "io.camunda.connectors.GitLab.v1",
-  "version": 5,
+  "version": 6,
   "description": "Manage GitLab issues, branches, releases, and more",
   "metadata": {
     "keywords": [
@@ -653,6 +653,19 @@
           "createAnIssue"
         ]
       }
+    },
+    {
+      "id": "skipEncoding",
+      "label": "Skip URL encoding",
+      "description": "Skip the default URL decoding and encoding behavior",
+      "optional": true,
+      "group": "endpoint",
+      "binding": {
+        "name": "skipEncoding",
+        "type": "zeebe:input"
+      },
+      "value": "true",
+      "type": "Hidden"
     },
     {
       "label": "Issue ID",

--- a/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/client/apache/builder/parts/ApacheRequestUriBuilder.java
+++ b/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/client/apache/builder/parts/ApacheRequestUriBuilder.java
@@ -23,6 +23,6 @@ public class ApacheRequestUriBuilder implements ApacheRequestPartBuilder {
 
   @Override
   public void build(ClassicRequestBuilder builder, HttpCommonRequest request) {
-    builder.setUri(UrlEncoder.toEncodedUri(request.getUrl()));
+    builder.setUri(UrlEncoder.toEncodedUri(request.getUrl(), request.getSkipEncoding()));
   }
 }

--- a/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/client/apache/builder/parts/UrlEncoder.java
+++ b/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/client/apache/builder/parts/UrlEncoder.java
@@ -28,11 +28,14 @@ import org.slf4j.LoggerFactory;
 public class UrlEncoder {
   private static final Logger LOG = LoggerFactory.getLogger(ApacheRequestUriBuilder.class);
 
-  public static URI toEncodedUri(String requestUrl) {
+  public static URI toEncodedUri(String requestUrl, Boolean skipEncoding) {
     try {
       // We try to decode the URL first, because it might be encoded already
       // which would lead to double encoding. Decoding is safe here, because it does nothing if
       // the URL is not encoded.
+      if (skipEncoding) {
+        return URI.create(requestUrl);
+      }
       var decodedUrl = URLDecoder.decode(requestUrl, StandardCharsets.UTF_8);
       var url = new URL(decodedUrl);
       // Only this URI constructor escapes the URL properly

--- a/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/model/HttpCommonRequest.java
+++ b/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/model/HttpCommonRequest.java
@@ -111,6 +111,15 @@ public class HttpCommonRequest {
       description = "Store the response as a document in the document store")
   private boolean storeResponse;
 
+  @TemplateProperty(
+      label = "Skip URL encoding",
+      description = "Skip the default URL decoding and encoding behavior",
+      type = TemplateProperty.PropertyType.Hidden,
+      feel = Property.FeelMode.disabled,
+      group = "endpoint",
+      optional = true)
+  private String skipEncoding;
+
   public Object getBody() {
     return body;
   }
@@ -137,6 +146,14 @@ public class HttpCommonRequest {
 
   public void setQueryParameters(Map<String, String> queryParameters) {
     this.queryParameters = queryParameters;
+  }
+
+  public boolean getSkipEncoding() {
+    return Objects.equals(skipEncoding, "true");
+  }
+
+  public void setSkipEncoding(final String skipEncoding) {
+    this.skipEncoding = skipEncoding;
   }
 
   public boolean hasAuthentication() {

--- a/connectors/http/http-base/src/test/java/io/camunda/connector/http/base/client/apache/CustomApacheHttpClientTest.java
+++ b/connectors/http/http-base/src/test/java/io/camunda/connector/http/base/client/apache/CustomApacheHttpClientTest.java
@@ -320,6 +320,23 @@ public class CustomApacheHttpClientTest {
       assertThat(result).isNotNull();
       assertThat(result.status()).isEqualTo(200);
     }
+
+    @ParameterizedTest
+    @EnumSource(HttpMethod.class)
+    public void shouldKeepOriginalEscaping_whenSkipEscapingIsSet(
+        HttpMethod method, WireMockRuntimeInfo wmRuntimeInfo) {
+      stubFor(any(urlEqualTo("/path%2Fwith%2Fencoding")).willReturn(ok()));
+      stubFor(any(urlEqualTo("/path/with/encoding")).willReturn(badRequest()));
+      HttpCommonRequest request = new HttpCommonRequest();
+      request.setMethod(method);
+      request.setUrl(wmRuntimeInfo.getHttpBaseUrl() + "/path%2Fwith%2Fencoding");
+      request.setSkipEncoding("true");
+
+      HttpCommonResult result = customApacheHttpClient.execute(request);
+
+      assertThat(result).isNotNull();
+      assertThat(result.status()).isEqualTo(200);
+    }
   }
 
   @Nested

--- a/connectors/http/rest/README.md
+++ b/connectors/http/rest/README.md
@@ -249,6 +249,6 @@ leading to the following result
 | Connector Info            |                                                                       |
 | ---                       | ---                                                                   |
 | Type                      | io.camunda:http-json:1                                                            |
-| Version                   | 9                                                         |
+| Version                   | 10                                                         |
 | Supported element types   |     |
 

--- a/connectors/http/rest/element-templates/http-json-connector.json
+++ b/connectors/http/rest/element-templates/http-json-connector.json
@@ -7,7 +7,7 @@
     "keywords" : [ ]
   },
   "documentationRef" : "https://docs.camunda.io/docs/components/connectors/protocol/rest/",
-  "version" : 9,
+  "version" : 10,
   "category" : {
     "id" : "connectors",
     "name" : "Connectors"
@@ -402,6 +402,17 @@
       "type" : "zeebe:input"
     },
     "type" : "Boolean"
+  }, {
+    "id" : "skipEncoding",
+    "label" : "Skip URL encoding",
+    "description" : "Skip the default URL decoding and encoding behavior",
+    "optional" : true,
+    "group" : "endpoint",
+    "binding" : {
+      "name" : "skipEncoding",
+      "type" : "zeebe:input"
+    },
+    "type" : "Hidden"
   }, {
     "id" : "connectionTimeoutInSeconds",
     "label" : "Connection timeout in seconds",

--- a/connectors/http/rest/element-templates/hybrid/http-json-connector-hybrid.json
+++ b/connectors/http/rest/element-templates/hybrid/http-json-connector-hybrid.json
@@ -7,7 +7,7 @@
     "keywords" : [ ]
   },
   "documentationRef" : "https://docs.camunda.io/docs/components/connectors/protocol/rest/",
-  "version" : 9,
+  "version" : 10,
   "category" : {
     "id" : "connectors",
     "name" : "Connectors"
@@ -407,6 +407,17 @@
       "type" : "zeebe:input"
     },
     "type" : "Boolean"
+  }, {
+    "id" : "skipEncoding",
+    "label" : "Skip URL encoding",
+    "description" : "Skip the default URL decoding and encoding behavior",
+    "optional" : true,
+    "group" : "endpoint",
+    "binding" : {
+      "name" : "skipEncoding",
+      "type" : "zeebe:input"
+    },
+    "type" : "Hidden"
   }, {
     "id" : "connectionTimeoutInSeconds",
     "label" : "Connection timeout in seconds",

--- a/connectors/http/rest/src/main/java/io/camunda/connector/http/rest/HttpJsonFunction.java
+++ b/connectors/http/rest/src/main/java/io/camunda/connector/http/rest/HttpJsonFunction.java
@@ -33,6 +33,7 @@ import io.camunda.connector.http.rest.model.HttpJsonRequest;
       "authentication",
       "headers",
       "queryParameters",
+      "skipEncoding",
       "connectionTimeoutInSeconds",
       "readTimeoutInSeconds",
       "writeTimeoutInSeconds",
@@ -46,7 +47,7 @@ import io.camunda.connector.http.rest.model.HttpJsonRequest;
     description = "Invoke REST API",
     inputDataClass = HttpJsonRequest.class,
     outputDataClass = HttpCommonResult.class,
-    version = 9,
+    version = 10,
     propertyGroups = {
       @PropertyGroup(id = "authentication", label = "Authentication"),
       @PropertyGroup(id = "endpoint", label = "HTTP endpoint"),


### PR DESCRIPTION
## Description
- Added a skipEnding field to HttpCommonRequest
- Adjusted gitlab connector json to always set skipEncoding to true
- All github connectors now skip encoding
- in XML skip encoding can be set for rest connectors, defaults to false if not set

## Info
- Added a hint to the docs about this option, see PR here: https://github.com/camunda/camunda-docs/pull/4837
- not tested with the web modeller
- I adjusted the gitlab connector by editing the JSON directly

## Questions
- should I add tests for the UrlEncoder?
- is it possible to add a test for the gitlab connector?


## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #3694 

## Checklist

- [x] PR has a **milestone** or the `no milestone` label. (not sure which milestone i should set it too :thinking: )

