### PR TITLE
fix(kafka-inbound): log the exception when kafka throw on start

### DIFF
--- a/connectors/kafka/src/main/java/io/camunda/connector/kafka/inbound/KafkaConnectorConsumer.java
+++ b/connectors/kafka/src/main/java/io/camunda/connector/kafka/inbound/KafkaConnectorConsumer.java
@@ -100,7 +100,7 @@ public class KafkaConnectorConsumer {
             consume();
             return null;
           } catch (Exception ex) {
-            LOG.error("Consumer loop failure, retry pending: {}", ex.getMessage());
+            LOG.error("Consumer loop failure, retry pending: {}", ex.getMessage(), ex);
             try {
               consumer.close();
             } catch (Exception e) {


### PR DESCRIPTION
## Description

Log the exception when Kafka consumer cannot be started 

## Related issues

closes #https://github.com/camunda/team-connectors/issues/953

## Checklist

- [ ] PR has a **milestone** or the `no milestone` label.

