### PR TITLE
feat(runtime): fail without retries on ConnectorInputException

### DIFF
--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/outbound/ConnectorJobHandler.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/outbound/ConnectorJobHandler.java
@@ -212,14 +212,16 @@ public class ConnectorJobHandler implements JobHandler {
     } catch (Exception ex) {
       LOGGER.debug(
           "Exception while processing job: {} for tenant: {}", job.getKey(), job.getTenantId(), ex);
+
       String errorCode = null;
       int retries = job.getRetries() - 1;
+
       if (ex instanceof ConnectorException connectorException) {
         errorCode = connectorException.getErrorCode();
-        Throwable cause = connectorException.getCause();
-        if (cause instanceof ConnectorInputException) {
-          retries = 0;
-        }
+      }
+      if (ex instanceof ConnectorInputException
+          || ex.getCause() instanceof ConnectorInputException) {
+        retries = 0;
       }
       result = handleSDKException(job, ex, retries, errorCode, retryBackoff);
     }

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/outbound/ConnectorJobHandlerTest.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/outbound/ConnectorJobHandlerTest.java
@@ -37,6 +37,7 @@ import io.camunda.client.api.command.FailJobCommandStep1;
 import io.camunda.client.api.worker.JobClient;
 import io.camunda.connector.api.error.ConnectorException;
 import io.camunda.connector.api.error.ConnectorExceptionBuilder;
+import io.camunda.connector.api.error.ConnectorInputException;
 import io.camunda.connector.api.error.ConnectorRetryExceptionBuilder;
 import io.camunda.connector.api.outbound.OutboundConnectorFunction;
 import io.camunda.connector.runtime.core.ConnectorHelper;
@@ -506,6 +507,26 @@ class ConnectorJobHandlerTest {
       assertThat(result.getErrorMessage().length())
           .isLessThanOrEqualTo(ConnectorJobHandler.MAX_ERROR_MESSAGE_LENGTH);
     }
+
+    @Test
+    void shouldNotRetry_OnConnectorInputException() {
+      // given
+      var jobHandler =
+          newConnectorJobHandler(
+              context -> {
+                throw new ConnectorExceptionBuilder()
+                    .message("expected Connector Input Exception")
+                    .cause(new ConnectorInputException(new Exception()))
+                    .build();
+              });
+
+      // when
+      var result = JobBuilder.create().withRetries(3).executeAndCaptureResult(jobHandler, false);
+
+      // then
+      assertThat(result.getErrorMessage()).isEqualTo("expected Connector Input Exception");
+      assertThat(result.getRetries()).isEqualTo(0);
+    }
   }
 
   @Nested
@@ -934,7 +955,7 @@ class ConnectorJobHandlerTest {
     }
 
     @Test
-    void shouldCreateJobErrpr_UsingExceptionCodeAsSecondConditionAfterResponseProperty()
+    void shouldCreateJobError_UsingExceptionCodeAsSecondConditionAfterResponseProperty()
         throws JsonProcessingException {
       // given
       var errorExpression =


### PR DESCRIPTION
## Description
Set retries to zero, when ConnectorInputException is thrown.

## Related issues

closes #3806 

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.

