### PR TITLE
feat(jackson): enable 'accept single value as array' globally

### DIFF
--- a/connector-sdk/core/src/main/java/io/camunda/connector/api/json/ConnectorsObjectMapperSupplier.java
+++ b/connector-sdk/core/src/main/java/io/camunda/connector/api/json/ConnectorsObjectMapperSupplier.java
@@ -44,6 +44,7 @@ public class ConnectorsObjectMapperSupplier {
           .enable(MapperFeature.ACCEPT_CASE_INSENSITIVE_ENUMS)
           .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
           .disable(SerializationFeature.WRITE_DURATIONS_AS_TIMESTAMPS)
+          .enable(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY)
           .build();
 
   private ConnectorsObjectMapperSupplier() {}

--- a/connector-sdk/core/src/test/java/io/camunda/connector/api/json/ConnectorsObjectMapperSupplierTest.java
+++ b/connector-sdk/core/src/test/java/io/camunda/connector/api/json/ConnectorsObjectMapperSupplierTest.java
@@ -53,10 +53,13 @@ class ConnectorsObjectMapperSupplierTest {
 
   @Test
   void singleDocumentShouldBeAcceptedAsArray() throws JsonProcessingException {
-    final var objectMapper = ConnectorsObjectMapperSupplier.getCopy(
-        new DocumentFactoryImpl(InMemoryDocumentStore.INSTANCE), DocumentModuleSettings.create());
-    final var documentReference = new CamundaDocumentReferenceModel(
-        "default", UUID.randomUUID().toString(), null, Optional.empty());
+    final var objectMapper =
+        ConnectorsObjectMapperSupplier.getCopy(
+            new DocumentFactoryImpl(InMemoryDocumentStore.INSTANCE),
+            DocumentModuleSettings.create());
+    final var documentReference =
+        new CamundaDocumentReferenceModel(
+            "default", UUID.randomUUID().toString(), null, Optional.empty());
     final var json = "{\"documents\":" + objectMapper.writeValueAsString(documentReference) + "}";
     var actual = objectMapper.readValue(json, TestRecordWithDocumentList.class);
     Assertions.assertThat(actual.documents()).hasSize(1);

--- a/connector-sdk/core/src/test/java/io/camunda/connector/api/json/ConnectorsObjectMapperSupplierTest.java
+++ b/connector-sdk/core/src/test/java/io/camunda/connector/api/json/ConnectorsObjectMapperSupplierTest.java
@@ -18,15 +18,23 @@ package io.camunda.connector.api.json;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
+import io.camunda.connector.document.annotation.jackson.DocumentReferenceModel.CamundaDocumentReferenceModel;
+import io.camunda.connector.document.annotation.jackson.JacksonModuleDocumentDeserializer.DocumentModuleSettings;
+import io.camunda.document.Document;
+import io.camunda.document.factory.DocumentFactoryImpl;
+import io.camunda.document.store.InMemoryDocumentStore;
 import java.time.LocalDate;
+import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 class ConnectorsObjectMapperSupplierTest {
 
   @Test
-  void objectMapperConfigTest() throws JsonProcessingException {
+  void java8DatesShouldBeSupported() throws JsonProcessingException {
     final var objectMapper = ConnectorsObjectMapperSupplier.getCopy();
     final var json = "{\"data\":\"2024-01-01\"}";
     final var jsonDeserialized = Map.of("data", LocalDate.of(2024, 1, 1));
@@ -34,4 +42,26 @@ class ConnectorsObjectMapperSupplierTest {
     var actual = objectMapper.readValue(json, new TypeReference<Map<String, LocalDate>>() {});
     Assertions.assertThat(actual).isEqualTo(jsonDeserialized);
   }
+
+  @Test
+  void singlePrimitiveValueShouldBeAcceptedAsArray() throws JsonProcessingException {
+    final var objectMapper = ConnectorsObjectMapperSupplier.getCopy();
+    final var json = "1";
+    var actual = objectMapper.readValue(json, int[].class);
+    Assertions.assertThat(actual).isEqualTo(new int[] {1});
+  }
+
+  @Test
+  void singleDocumentShouldBeAcceptedAsArray() throws JsonProcessingException {
+    final var objectMapper = ConnectorsObjectMapperSupplier.getCopy(
+        new DocumentFactoryImpl(InMemoryDocumentStore.INSTANCE), DocumentModuleSettings.create());
+    final var documentReference = new CamundaDocumentReferenceModel(
+        "default", UUID.randomUUID().toString(), null, Optional.empty());
+    final var json = "{\"documents\":" + objectMapper.writeValueAsString(documentReference) + "}";
+    var actual = objectMapper.readValue(json, TestRecordWithDocumentList.class);
+    Assertions.assertThat(actual.documents()).hasSize(1);
+    Assertions.assertThat(actual.documents().get(0).reference()).isEqualTo(documentReference);
+  }
+
+  private record TestRecordWithDocumentList(List<Document> documents) {}
 }


### PR DESCRIPTION
## Description

This PR will enable the "accept single value as array" feature in Jackon globally.

## Related issues

closes #3849 

## Checklist

- [ ] PR has a **milestone** or the `no milestone` label.

