### PR TITLE
feat(rest-connector): Add flag to get multiple set cookie headers as list

### DIFF
--- a/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/client/apache/CustomApacheHttpClient.java
+++ b/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/client/apache/CustomApacheHttpClient.java
@@ -109,7 +109,9 @@ public class CustomApacheHttpClient implements HttpClient {
               .execute(
                   apacheRequest,
                   new HttpCommonResultResponseHandler(
-                      executionEnvironment, request.isStoreResponse()));
+                      executionEnvironment,
+                      request.isStoreResponse(),
+                      request.isHeaderGroupingEnabled()));
       if (HttpStatusHelper.isError(result.status())) {
         throw ConnectorExceptionMapper.from(result);
       }

--- a/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/client/apache/CustomApacheHttpClient.java
+++ b/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/client/apache/CustomApacheHttpClient.java
@@ -111,7 +111,7 @@ public class CustomApacheHttpClient implements HttpClient {
                   new HttpCommonResultResponseHandler(
                       executionEnvironment,
                       request.isStoreResponse(),
-                      request.isHeaderGroupingEnabled()));
+                      request.getGroupSetCookieHeaders()));
       if (HttpStatusHelper.isError(result.status())) {
         throw ConnectorExceptionMapper.from(result);
       }

--- a/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/client/apache/HttpCommonResultResponseHandler.java
+++ b/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/client/apache/HttpCommonResultResponseHandler.java
@@ -28,9 +28,7 @@ import io.camunda.document.Document;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
-import java.util.Base64;
-import java.util.Map;
+import java.util.*;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import org.apache.commons.lang3.StringUtils;
@@ -51,23 +49,25 @@ public class HttpCommonResultResponseHandler
 
   private final boolean isStoreResponseSelected;
 
+  private final boolean isHeaderGroupingEnabled;
+
   public HttpCommonResultResponseHandler(
-      @Nullable ExecutionEnvironment executionEnvironment, boolean isStoreResponseSelected) {
+      @Nullable ExecutionEnvironment executionEnvironment,
+      boolean isStoreResponseSelected,
+      boolean isHeaderGroupingEnabled) {
     this.executionEnvironment = executionEnvironment;
     this.isStoreResponseSelected = isStoreResponseSelected;
     this.fileResponseHandler =
         new FileResponseHandler(executionEnvironment, isStoreResponseSelected);
+    this.isHeaderGroupingEnabled = isHeaderGroupingEnabled;
   }
 
   @Override
   public HttpCommonResult handleResponse(ClassicHttpResponse response) {
     int code = response.getCode();
     String reason = response.getReasonPhrase();
-    Map<String, String> headers =
-        Arrays.stream(response.getHeaders())
-            .collect(
-                // Collect the headers into a map ignoring duplicates (Set Cookies for instance)
-                Collectors.toMap(Header::getName, Header::getValue, (first, second) -> first));
+    Map<String, Object> headers = this.formatHeaders(response.getHeaders());
+
     if (response.getEntity() != null) {
       try (InputStream content = response.getEntity().getContent()) {
         if (executionEnvironment instanceof ExecutionEnvironment.SaaSCluster) {
@@ -88,7 +88,30 @@ public class HttpCommonResultResponseHandler
     return new HttpCommonResult(code, headers, null, reason);
   }
 
-  private Document handleFileResponse(Map<String, String> headers, byte[] content) {
+  private Map<String, Object> formatHeaders(Header[] headersArray) {
+    return Arrays.stream(headersArray)
+        .collect(
+            Collectors.toMap(
+                Header::getName,
+                header -> {
+                  if (isHeaderGroupingEnabled && header.getName().equalsIgnoreCase("Set-Cookie")) {
+                    return new ArrayList<String>(List.of(header.getValue()));
+                  }
+                  return header.getValue();
+                },
+                (existingValue, newValue) -> {
+                  if (isHeaderGroupingEnabled
+                      && existingValue instanceof List
+                      && ((List<?>) existingValue).getFirst() instanceof String
+                      && newValue instanceof List
+                      && ((List<?>) newValue).getFirst() instanceof String) {
+                    ((List<String>) existingValue).add(((List<String>) newValue).getFirst());
+                  }
+                  return existingValue;
+                }));
+  }
+
+  private Document handleFileResponse(Map<String, Object> headers, byte[] content) {
     var document = fileResponseHandler.handle(headers, content);
     LOGGER.debug("Stored response as document. Document reference: {}", document);
     return document;
@@ -99,7 +122,7 @@ public class HttpCommonResultResponseHandler
    * unwrapped as an ErrorResponse. Otherwise, it will be unwrapped as a HttpCommonResult.
    */
   private HttpCommonResult getResultForCloudFunction(
-      int code, InputStream content, Map<String, String> headers, String reason)
+      int code, InputStream content, Map<String, Object> headers, String reason)
       throws IOException {
     if (HttpStatusHelper.isError(code)) {
       // unwrap as ErrorResponse

--- a/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/document/FileResponseHandler.java
+++ b/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/document/FileResponseHandler.java
@@ -55,7 +55,7 @@ public class FileResponseHandler {
     return null;
   }
 
-  public Document handle(Map<String, String> headers, byte[] content) {
+  public Document handle(Map<String, Object> headers, byte[] content) {
     if (storeResponseSelected()
         && executionEnvironment instanceof ExecutionEnvironment.StoresDocument env) {
       try (var byteArrayInputStream = new ByteArrayInputStream(content)) {
@@ -72,10 +72,11 @@ public class FileResponseHandler {
     return null;
   }
 
-  private String getContentType(Map<String, String> headers) {
+  private String getContentType(Map<String, Object> headers) {
     return headers.entrySet().stream()
         .filter(e -> e.getKey().equalsIgnoreCase(CONTENT_TYPE))
         .map(Map.Entry::getValue)
+        .map(Object::toString)
         .findFirst()
         .orElse(null);
   }

--- a/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/exception/ConnectorExceptionMapper.java
+++ b/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/exception/ConnectorExceptionMapper.java
@@ -28,7 +28,7 @@ public class ConnectorExceptionMapper {
   public static ConnectorException from(HttpCommonResult result) {
     String status = String.valueOf(result.status());
     String reason = Optional.ofNullable(result.reason()).orElse("[no reason]");
-    Map<String, String> headers = result.headers();
+    Map<String, Object> headers = result.headers();
     Object body = result.body();
     Map<String, Object> response = new HashMap<>();
     response.put("headers", headers);

--- a/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/model/HttpCommonRequest.java
+++ b/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/model/HttpCommonRequest.java
@@ -120,6 +120,15 @@ public class HttpCommonRequest {
       optional = true)
   private String skipEncoding;
 
+  @TemplateProperty(
+      label = "isHeaderGroupingEnabled",
+      description = "Group incoming headers with same name into a List",
+      type = TemplateProperty.PropertyType.Hidden,
+      feel = Property.FeelMode.disabled,
+      group = "endpoint",
+      optional = true)
+  private String isHeaderGroupingEnabled;
+
   public Object getBody() {
     return body;
   }
@@ -154,6 +163,14 @@ public class HttpCommonRequest {
 
   public void setSkipEncoding(final String skipEncoding) {
     this.skipEncoding = skipEncoding;
+  }
+
+  public boolean isHeaderGroupingEnabled() {
+    return Objects.equals(isHeaderGroupingEnabled, "true");
+  }
+
+  public void setHeaderGroupingEnabled(final String isHeaderGroupingEnabled) {
+    this.isHeaderGroupingEnabled = isHeaderGroupingEnabled;
   }
 
   public boolean hasAuthentication() {

--- a/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/model/HttpCommonRequest.java
+++ b/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/model/HttpCommonRequest.java
@@ -121,13 +121,14 @@ public class HttpCommonRequest {
   private String skipEncoding;
 
   @TemplateProperty(
-      label = "isHeaderGroupingEnabled",
-      description = "Group incoming headers with same name into a List",
+      label = "Group set-cookie headers to a list",
+      description =
+          "Group incoming headers with same name into a List to support <a href=\"https://datatracker.ietf.org/doc/html/rfc6265\">multiple Set-Cookie headers</a>.",
       type = TemplateProperty.PropertyType.Hidden,
       feel = Property.FeelMode.disabled,
       group = "endpoint",
       optional = true)
-  private String isHeaderGroupingEnabled;
+  private String groupSetCookieHeaders;
 
   public Object getBody() {
     return body;
@@ -165,12 +166,12 @@ public class HttpCommonRequest {
     this.skipEncoding = skipEncoding;
   }
 
-  public boolean isHeaderGroupingEnabled() {
-    return Objects.equals(isHeaderGroupingEnabled, "true");
+  public boolean getGroupSetCookieHeaders() {
+    return Objects.equals(groupSetCookieHeaders, "true");
   }
 
-  public void setHeaderGroupingEnabled(final String isHeaderGroupingEnabled) {
-    this.isHeaderGroupingEnabled = isHeaderGroupingEnabled;
+  public void setGroupSetCookieHeaders(final String groupSetCookieHeaders) {
+    this.groupSetCookieHeaders = groupSetCookieHeaders;
   }
 
   public boolean hasAuthentication() {

--- a/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/model/HttpCommonResult.java
+++ b/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/model/HttpCommonResult.java
@@ -27,24 +27,24 @@ import java.time.OffsetDateTime;
 import java.util.Map;
 
 public record HttpCommonResult(
-    int status, Map<String, String> headers, Object body, String reason, Document document) {
+    int status, Map<String, Object> headers, Object body, String reason, Document document) {
 
-  public HttpCommonResult(int status, Map<String, String> headers, Object body, String reason) {
+  public HttpCommonResult(int status, Map<String, Object> headers, Object body, String reason) {
     this(status, headers, body, reason, null);
   }
 
   public HttpCommonResult(
-      int status, Map<String, String> headers, Object body, Document documentReference) {
+      int status, Map<String, Object> headers, Object body, Document documentReference) {
     this(status, headers, body, null, documentReference);
   }
 
-  public HttpCommonResult(int status, Map<String, String> headers, Object body) {
+  public HttpCommonResult(int status, Map<String, Object> headers, Object body) {
     this(status, headers, body, null, null);
   }
 
   @DataExample(id = "basic", feel = "= body.order.id")
   public static HttpCommonResult exampleResult() {
-    Map<String, String> headers = Map.of("Content-Type", "application/json");
+    Map<String, Object> headers = Map.of("Content-Type", "application/json");
     DocumentReference.CamundaDocumentReference documentReference =
         new CamundaDocumentReferenceImpl(
             "theStoreId",

--- a/connectors/http/http-base/src/test/java/io/camunda/connector/http/base/client/apache/CustomApacheHttpClientTest.java
+++ b/connectors/http/http-base/src/test/java/io/camunda/connector/http/base/client/apache/CustomApacheHttpClientTest.java
@@ -395,7 +395,7 @@ public class CustomApacheHttpClientTest {
     @MethodSource("provideTestDataForHeaderTest")
     public void shouldReturn200_whenDuplicatedHeadersAsListDisabled(
         String headerKey,
-        String isHeaderGroupingEnabled,
+        String groupSetCookieHeaders,
         Boolean expectedDoesReturnList,
         Object expectedValue,
         WireMockRuntimeInfo wmRuntimeInfo) {
@@ -403,7 +403,7 @@ public class CustomApacheHttpClientTest {
       HttpCommonRequest request = new HttpCommonRequest();
       request.setMethod(HttpMethod.GET);
       request.setUrl(wmRuntimeInfo.getHttpBaseUrl() + "/path");
-      request.setHeaderGroupingEnabled(isHeaderGroupingEnabled);
+      request.setGroupSetCookieHeaders(groupSetCookieHeaders);
       HttpCommonResult result = customApacheHttpClient.execute(request);
       assertThat(result).isNotNull();
       assertThat(result.status()).isEqualTo(200);

--- a/connectors/http/http-base/src/test/java/io/camunda/connector/http/base/client/apache/CustomApacheHttpClientTest.java
+++ b/connectors/http/http-base/src/test/java/io/camunda/connector/http/base/client/apache/CustomApacheHttpClientTest.java
@@ -45,7 +45,9 @@ import io.camunda.document.store.DocumentCreationRequest;
 import io.camunda.document.store.InMemoryDocumentStore;
 import java.io.IOException;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
 import org.apache.commons.text.StringEscapeUtils;
 import org.apache.hc.client5.http.impl.classic.HttpClients;
 import org.apache.hc.core5.http.ContentType;
@@ -53,8 +55,7 @@ import org.apache.hc.core5.http.HttpHeaders;
 import org.apache.hc.core5.http.HttpStatus;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.EnumSource;
-import org.junit.jupiter.params.provider.ValueSource;
+import org.junit.jupiter.params.provider.*;
 import org.skyscreamer.jsonassert.JSONAssert;
 import org.skyscreamer.jsonassert.JSONCompareMode;
 import org.testcontainers.Testcontainers;
@@ -380,6 +381,34 @@ public class CustomApacheHttpClientTest {
       HttpCommonResult result = customApacheHttpClient.execute(request);
       assertThat(result).isNotNull();
       assertThat(result.status()).isEqualTo(200);
+    }
+
+    private static Stream<Arguments> provideTestDataForHeaderTest() {
+      return Stream.of(
+          Arguments.of("Set-Cookie", "false", false, "Test-Value-1"),
+          Arguments.of("Set-Cookie", "true", true, List.of("Test-Value-1", "Test-Value-2")),
+          Arguments.of("other-than-set-cookie", "false", false, "Test-Value-1"),
+          Arguments.of("other-than-set-cookie", "true", false, "Test-Value-1"));
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideTestDataForHeaderTest")
+    public void shouldReturn200_whenDuplicatedHeadersAsListDisabled(
+        String headerKey,
+        String isHeaderGroupingEnabled,
+        Boolean expectedDoesReturnList,
+        Object expectedValue,
+        WireMockRuntimeInfo wmRuntimeInfo) {
+      stubFor(get("/path").willReturn(ok().withHeader(headerKey, "Test-Value-1", "Test-Value-2")));
+      HttpCommonRequest request = new HttpCommonRequest();
+      request.setMethod(HttpMethod.GET);
+      request.setUrl(wmRuntimeInfo.getHttpBaseUrl() + "/path");
+      request.setHeaderGroupingEnabled(isHeaderGroupingEnabled);
+      HttpCommonResult result = customApacheHttpClient.execute(request);
+      assertThat(result).isNotNull();
+      assertThat(result.status()).isEqualTo(200);
+      assertThat(result.headers().get(headerKey) instanceof List).isEqualTo(expectedDoesReturnList);
+      assertThat(result.headers().get(headerKey)).isEqualTo(expectedValue);
     }
 
     @Test

--- a/connectors/http/http-base/src/test/java/io/camunda/connector/http/base/client/apache/HttpCommonResultResponseHandlerTest.java
+++ b/connectors/http/http-base/src/test/java/io/camunda/connector/http/base/client/apache/HttpCommonResultResponseHandlerTest.java
@@ -35,7 +35,8 @@ public class HttpCommonResultResponseHandlerTest {
   @Test
   public void shouldHandleJsonResponse_whenCloudFunctionDisabled() throws Exception {
     // given
-    HttpCommonResultResponseHandler handler = new HttpCommonResultResponseHandler(null, false);
+    HttpCommonResultResponseHandler handler =
+        new HttpCommonResultResponseHandler(null, false, false);
     ClassicHttpResponse response = new BasicClassicHttpResponse(200);
     Header[] headers = new Header[] {new BasicHeader("Content-Type", "application/json")};
     response.setHeaders(headers);
@@ -55,7 +56,8 @@ public class HttpCommonResultResponseHandlerTest {
   @Test
   public void shouldHandleTextResponse_whenCloudFunctionDisabled() throws Exception {
     // given
-    HttpCommonResultResponseHandler handler = new HttpCommonResultResponseHandler(null, false);
+    HttpCommonResultResponseHandler handler =
+        new HttpCommonResultResponseHandler(null, false, false);
     ClassicHttpResponse response = new BasicClassicHttpResponse(200);
     Header[] headers = new Header[] {new BasicHeader("Content-Type", "text/plain")};
     response.setHeaders(headers);
@@ -76,7 +78,8 @@ public class HttpCommonResultResponseHandlerTest {
   public void shouldHandleJsonResponse_whenCloudFunctionEnabled() throws Exception {
     // given
     HttpCommonResultResponseHandler handler =
-        new HttpCommonResultResponseHandler(new ExecutionEnvironment.SaaSCluster(null), false);
+        new HttpCommonResultResponseHandler(
+            new ExecutionEnvironment.SaaSCluster(null), false, false);
     ClassicHttpResponse response = new BasicClassicHttpResponse(201);
     Header[] headers = new Header[] {new BasicHeader("Content-Type", "application/json")};
     response.setHeaders(headers);
@@ -101,7 +104,8 @@ public class HttpCommonResultResponseHandlerTest {
   public void shouldHandleError_whenCloudFunctionEnabled() throws Exception {
     // given
     HttpCommonResultResponseHandler handler =
-        new HttpCommonResultResponseHandler(new ExecutionEnvironment.SaaSCluster(null), false);
+        new HttpCommonResultResponseHandler(
+            new ExecutionEnvironment.SaaSCluster(null), false, false);
     ClassicHttpResponse response = new BasicClassicHttpResponse(500);
     Header[] headers =
         new Header[] {
@@ -130,7 +134,8 @@ public class HttpCommonResultResponseHandlerTest {
   public void shouldHandleJsonAsTextResponse_whenCloudFunctionEnabled() throws Exception {
     // given
     HttpCommonResultResponseHandler handler =
-        new HttpCommonResultResponseHandler(new ExecutionEnvironment.SaaSCluster(null), false);
+        new HttpCommonResultResponseHandler(
+            new ExecutionEnvironment.SaaSCluster(null), false, false);
     ClassicHttpResponse response = new BasicClassicHttpResponse(201);
     Header[] headers = new Header[] {new BasicHeader("Content-Type", "application/json")};
     response.setHeaders(headers);

--- a/connectors/http/rest/element-templates/http-json-connector.json
+++ b/connectors/http/rest/element-templates/http-json-connector.json
@@ -414,13 +414,13 @@
     },
     "type" : "Hidden"
   }, {
-    "id" : "isHeaderGroupingEnabled",
-    "label" : "isHeaderGroupingEnabled",
-    "description" : "Group incoming headers with same name into a List",
+    "id" : "groupSetCookieHeaders",
+    "label" : "Group set-cookie headers to a list",
+    "description" : "Group incoming headers with same name into a List to support <a href=\"https://datatracker.ietf.org/doc/html/rfc6265\">multiple Set-Cookie headers</a>.",
     "optional" : true,
     "group" : "endpoint",
     "binding" : {
-      "name" : "isHeaderGroupingEnabled",
+      "name" : "groupSetCookieHeaders",
       "type" : "zeebe:input"
     },
     "type" : "Hidden"

--- a/connectors/http/rest/element-templates/http-json-connector.json
+++ b/connectors/http/rest/element-templates/http-json-connector.json
@@ -414,6 +414,17 @@
     },
     "type" : "Hidden"
   }, {
+    "id" : "isHeaderGroupingEnabled",
+    "label" : "isHeaderGroupingEnabled",
+    "description" : "Group incoming headers with same name into a List",
+    "optional" : true,
+    "group" : "endpoint",
+    "binding" : {
+      "name" : "isHeaderGroupingEnabled",
+      "type" : "zeebe:input"
+    },
+    "type" : "Hidden"
+  }, {
     "id" : "connectionTimeoutInSeconds",
     "label" : "Connection timeout in seconds",
     "description" : "Defines the connection timeout in seconds, or 0 for an infinite timeout",

--- a/connectors/http/rest/element-templates/hybrid/http-json-connector-hybrid.json
+++ b/connectors/http/rest/element-templates/hybrid/http-json-connector-hybrid.json
@@ -419,13 +419,13 @@
     },
     "type" : "Hidden"
   }, {
-    "id" : "isHeaderGroupingEnabled",
-    "label" : "isHeaderGroupingEnabled",
-    "description" : "Group incoming headers with same name into a List",
+    "id" : "groupSetCookieHeaders",
+    "label" : "Group set-cookie headers to a list",
+    "description" : "Group incoming headers with same name into a List to support <a href=\"https://datatracker.ietf.org/doc/html/rfc6265\">multiple Set-Cookie headers</a>.",
     "optional" : true,
     "group" : "endpoint",
     "binding" : {
-      "name" : "isHeaderGroupingEnabled",
+      "name" : "groupSetCookieHeaders",
       "type" : "zeebe:input"
     },
     "type" : "Hidden"

--- a/connectors/http/rest/element-templates/hybrid/http-json-connector-hybrid.json
+++ b/connectors/http/rest/element-templates/hybrid/http-json-connector-hybrid.json
@@ -419,6 +419,17 @@
     },
     "type" : "Hidden"
   }, {
+    "id" : "isHeaderGroupingEnabled",
+    "label" : "isHeaderGroupingEnabled",
+    "description" : "Group incoming headers with same name into a List",
+    "optional" : true,
+    "group" : "endpoint",
+    "binding" : {
+      "name" : "isHeaderGroupingEnabled",
+      "type" : "zeebe:input"
+    },
+    "type" : "Hidden"
+  }, {
     "id" : "connectionTimeoutInSeconds",
     "label" : "Connection timeout in seconds",
     "description" : "Defines the connection timeout in seconds, or 0 for an infinite timeout",

--- a/connectors/http/rest/src/main/java/io/camunda/connector/http/rest/HttpJsonFunction.java
+++ b/connectors/http/rest/src/main/java/io/camunda/connector/http/rest/HttpJsonFunction.java
@@ -38,7 +38,8 @@ import io.camunda.connector.http.rest.model.HttpJsonRequest;
       "readTimeoutInSeconds",
       "writeTimeoutInSeconds",
       "body",
-      "storeResponse"
+      "storeResponse",
+      "isHeaderGroupingEnabled"
     },
     type = HttpJsonFunction.TYPE)
 @ElementTemplate(

--- a/connectors/http/rest/src/main/java/io/camunda/connector/http/rest/HttpJsonFunction.java
+++ b/connectors/http/rest/src/main/java/io/camunda/connector/http/rest/HttpJsonFunction.java
@@ -39,7 +39,7 @@ import io.camunda.connector.http.rest.model.HttpJsonRequest;
       "writeTimeoutInSeconds",
       "body",
       "storeResponse",
-      "isHeaderGroupingEnabled"
+      "groupSetCookieHeaders"
     },
     type = HttpJsonFunction.TYPE)
 @ElementTemplate(


### PR DESCRIPTION
## Description
- Added a feature flag to enable getting multiple set cookie headers as a list
- if flag is not set to true behavior is not changed
- if flag is set to true set cookie headers are merged into a list
- other headers are not merged, as set cookie is the only header that is allowed to occure multiple times

- PR for documenting this feature is here: https://github.com/camunda/camunda-docs/pull/4875

## Related issues

closes #3812 

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.

