### PR TITLE
chore(preview-env): update the preview-env teardown workflow

### DIFF
--- a/.github/workflows/PREVIEW-ENV-TEARDOWN.yml
+++ b/.github/workflows/PREVIEW-ENV-TEARDOWN.yml
@@ -59,7 +59,7 @@ jobs:
     #########################################################################
     # Tear down preview environment
     - name: Tear down Preview Environment for ${{ matrix.product_context }}
-      uses: camunda/infra-global-github-actions/preview-env/destroy@e7a5cf24d2edab2b478197f14b2b03eba7842cbf
+      uses: camunda/infra-global-github-actions/preview-env/destroy@c44dd4b7a6600f91bdd6653901123d4edc8853eb #infra-456-feature-branch
       with:
         revision: ${{ env.BRANCH_NAME }}
         argocd_token: ${{ steps.secrets.outputs.ARGOCD_TOKEN }}

--- a/.github/workflows/PREVIEW-ENV-TEARDOWN.yml
+++ b/.github/workflows/PREVIEW-ENV-TEARDOWN.yml
@@ -59,7 +59,7 @@ jobs:
     #########################################################################
     # Tear down preview environment
     - name: Tear down Preview Environment for ${{ matrix.product_context }}
-      uses: camunda/infra-global-github-actions/preview-env/destroy@c4e343de4774a238350755181203b116ea2b6761 #infra-456-feature-branch
+      uses: camunda/infra-global-github-actions/preview-env/destroy@fa822a648f554e455637bc2f0842b32042fdf06b #infra-456-feature-branch
       with:
         revision: ${{ env.BRANCH_NAME }}
         argocd_token: ${{ steps.secrets.outputs.ARGOCD_TOKEN }}

--- a/.github/workflows/PREVIEW-ENV-TEARDOWN.yml
+++ b/.github/workflows/PREVIEW-ENV-TEARDOWN.yml
@@ -59,7 +59,7 @@ jobs:
     #########################################################################
     # Tear down preview environment
     - name: Tear down Preview Environment for ${{ matrix.product_context }}
-      uses: camunda/infra-global-github-actions/preview-env/destroy@4d371d80474495ee187df50b76dadb8810dedbd7 #infra-456-feature-branch
+      uses: camunda/infra-global-github-actions/preview-env/destroy@main
       with:
         revision: ${{ env.BRANCH_NAME }}
         argocd_token: ${{ steps.secrets.outputs.ARGOCD_TOKEN }}

--- a/.github/workflows/PREVIEW-ENV-TEARDOWN.yml
+++ b/.github/workflows/PREVIEW-ENV-TEARDOWN.yml
@@ -64,7 +64,7 @@ jobs:
         revision: ${{ env.BRANCH_NAME }}
         argocd_token: ${{ steps.secrets.outputs.ARGOCD_TOKEN }}
         app_name: connectors-${{ steps.sanitize.outputs.branch_name }}-${{ matrix.product_context }}
-        github_token: ${{ steps.github-token.outputs.token }}
+        # github_token: ${{ steps.github-token.outputs.token }}
   clean:
     if: always() && needs.teardown-preview.result != 'skipped'
     uses: camunda/connectors/.github/workflows/PREVIEW-ENV-CLEAN.yml@main

--- a/.github/workflows/PREVIEW-ENV-TEARDOWN.yml
+++ b/.github/workflows/PREVIEW-ENV-TEARDOWN.yml
@@ -59,7 +59,7 @@ jobs:
     #########################################################################
     # Tear down preview environment
     - name: Tear down Preview Environment for ${{ matrix.product_context }}
-      uses: camunda/infra-global-github-actions/preview-env/destroy@cead67015c47920f9ba1554256885190b1f08635a #infra-456-feature-branch
+      uses: camunda/infra-global-github-actions/preview-env/destroy@ead67015c47920f9ba1554256885190b1f08635a #infra-456-feature-branch
       with:
         revision: ${{ env.BRANCH_NAME }}
         argocd_token: ${{ steps.secrets.outputs.ARGOCD_TOKEN }}

--- a/.github/workflows/PREVIEW-ENV-TEARDOWN.yml
+++ b/.github/workflows/PREVIEW-ENV-TEARDOWN.yml
@@ -38,6 +38,20 @@ jobs:
         secrets: |
           secret/data/products/connectors/ci/common ARGOCD_TOKEN;
     #########################################################################
+    # Setup: generate github app token
+    - name: Generate a GitHub token
+      id: github-token
+      uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@main
+      with:
+        github-app-id-vault-key: GITHUB_PREVIEW_ENVIRONMENTS_APP_ID
+        github-app-id-vault-path: secret/data/products/connectors/ci/common
+        github-app-private-key-vault-key: GITHUB_PREVIEW_ENVIRONMENTS_APP_PRIVATE_KEY
+        github-app-private-key-vault-path: secret/data/products/connectors/ci/common
+        vault-auth-method: approle
+        vault-auth-role-id: ${{ secrets.VAULT_ROLE_ID }}
+        vault-auth-secret-id: ${{ secrets.VAULT_SECRET_ID}}
+        vault-url: ${{ secrets.VAULT_ADDR }}
+    #########################################################################
     # Setup: checkout code. This is required because we are using
     # composite actions and deployment manifests.
     - name: Checkout
@@ -45,11 +59,12 @@ jobs:
     #########################################################################
     # Tear down preview environment
     - name: Tear down Preview Environment for ${{ matrix.product_context }}
-      uses: camunda/infra-global-github-actions/preview-env/destroy@main
+      uses: camunda/infra-global-github-actions/preview-env/destroy@e7a5cf24d2edab2b478197f14b2b03eba7842cbf
       with:
         revision: ${{ env.BRANCH_NAME }}
         argocd_token: ${{ steps.secrets.outputs.ARGOCD_TOKEN }}
         app_name: connectors-${{ steps.sanitize.outputs.branch_name }}-${{ matrix.product_context }}
+        github_token: ${{ steps.github-token.outputs.token }}
   clean:
     if: always() && needs.teardown-preview.result != 'skipped'
     uses: camunda/connectors/.github/workflows/PREVIEW-ENV-CLEAN.yml@main

--- a/.github/workflows/PREVIEW-ENV-TEARDOWN.yml
+++ b/.github/workflows/PREVIEW-ENV-TEARDOWN.yml
@@ -59,7 +59,7 @@ jobs:
     #########################################################################
     # Tear down preview environment
     - name: Tear down Preview Environment for ${{ matrix.product_context }}
-      uses: camunda/infra-global-github-actions/preview-env/destroy@dbb7c2e1d7e6856f08fd736535e186b9ded5e470 #infra-456-feature-branch
+      uses: camunda/infra-global-github-actions/preview-env/destroy@4d371d80474495ee187df50b76dadb8810dedbd7 #infra-456-feature-branch
       with:
         revision: ${{ env.BRANCH_NAME }}
         argocd_token: ${{ steps.secrets.outputs.ARGOCD_TOKEN }}

--- a/.github/workflows/PREVIEW-ENV-TEARDOWN.yml
+++ b/.github/workflows/PREVIEW-ENV-TEARDOWN.yml
@@ -59,7 +59,7 @@ jobs:
     #########################################################################
     # Tear down preview environment
     - name: Tear down Preview Environment for ${{ matrix.product_context }}
-      uses: camunda/infra-global-github-actions/preview-env/destroy@fa822a648f554e455637bc2f0842b32042fdf06b #infra-456-feature-branch
+      uses: camunda/infra-global-github-actions/preview-env/destroy@dbb7c2e1d7e6856f08fd736535e186b9ded5e470 #infra-456-feature-branch
       with:
         revision: ${{ env.BRANCH_NAME }}
         argocd_token: ${{ steps.secrets.outputs.ARGOCD_TOKEN }}

--- a/.github/workflows/PREVIEW-ENV-TEARDOWN.yml
+++ b/.github/workflows/PREVIEW-ENV-TEARDOWN.yml
@@ -59,7 +59,7 @@ jobs:
     #########################################################################
     # Tear down preview environment
     - name: Tear down Preview Environment for ${{ matrix.product_context }}
-      uses: camunda/infra-global-github-actions/preview-env/destroy@ead67015c47920f9ba1554256885190b1f08635a #infra-456-feature-branch
+      uses: camunda/infra-global-github-actions/preview-env/destroy@c4e343de4774a238350755181203b116ea2b6761 #infra-456-feature-branch
       with:
         revision: ${{ env.BRANCH_NAME }}
         argocd_token: ${{ steps.secrets.outputs.ARGOCD_TOKEN }}

--- a/.github/workflows/PREVIEW-ENV-TEARDOWN.yml
+++ b/.github/workflows/PREVIEW-ENV-TEARDOWN.yml
@@ -59,7 +59,7 @@ jobs:
     #########################################################################
     # Tear down preview environment
     - name: Tear down Preview Environment for ${{ matrix.product_context }}
-      uses: camunda/infra-global-github-actions/preview-env/destroy@c44dd4b7a6600f91bdd6653901123d4edc8853eb #infra-456-feature-branch
+      uses: camunda/infra-global-github-actions/preview-env/destroy@cead67015c47920f9ba1554256885190b1f08635a #infra-456-feature-branch
       with:
         revision: ${{ env.BRANCH_NAME }}
         argocd_token: ${{ steps.secrets.outputs.ARGOCD_TOKEN }}

--- a/.github/workflows/PREVIEW-ENV-TEARDOWN.yml
+++ b/.github/workflows/PREVIEW-ENV-TEARDOWN.yml
@@ -64,7 +64,7 @@ jobs:
         revision: ${{ env.BRANCH_NAME }}
         argocd_token: ${{ steps.secrets.outputs.ARGOCD_TOKEN }}
         app_name: connectors-${{ steps.sanitize.outputs.branch_name }}-${{ matrix.product_context }}
-        # github_token: ${{ steps.github-token.outputs.token }}
+        github_token: ${{ steps.github-token.outputs.token }}
   clean:
     if: always() && needs.teardown-preview.result != 'skipped'
     uses: camunda/connectors/.github/workflows/PREVIEW-ENV-CLEAN.yml@main


### PR DESCRIPTION
## Description

We are updating the `preview-env/destroy` composite action to not only deactivate a deployment during teardown but also to delete the deployment and the relative environment. 
This is to limit the proliferation of inactive deployments, making it very hard to understand what's active and what is not active.

## Related issues
- camunda/team-infrastructure#456

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.

