### PR TITLE
fix(document-handling): Get document by reference including hash

### DIFF
--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/outbound/JobHandlerContext.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/outbound/JobHandlerContext.java
@@ -30,9 +30,7 @@ import io.camunda.connector.api.validation.ValidationProvider;
 import io.camunda.connector.runtime.core.AbstractConnectorContext;
 import io.camunda.document.Document;
 import io.camunda.document.factory.DocumentFactory;
-import io.camunda.document.factory.DocumentFactoryImpl;
 import io.camunda.document.store.DocumentCreationRequest;
-import io.camunda.document.store.InMemoryDocumentStore;
 import java.util.Objects;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -64,19 +62,6 @@ public class JobHandlerContext extends AbstractConnectorContext
     this.job = job;
     this.objectMapper = objectMapper;
     this.jobContext = new ActivatedJobContext(job, this::getJsonReplacedWithSecrets);
-  }
-
-  public JobHandlerContext(
-      final ActivatedJob job,
-      final SecretProvider secretProvider,
-      final ValidationProvider validationProvider,
-      final ObjectMapper objectMapper) {
-    this(
-        job,
-        secretProvider,
-        validationProvider,
-        new DocumentFactoryImpl(InMemoryDocumentStore.INSTANCE),
-        objectMapper);
   }
 
   @Override

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretUtil.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretUtil.java
@@ -67,7 +67,7 @@ public class SecretUtil {
   private static String resolveSecretValue(
       Function<String, String> secretReplacer, Matcher matcher) {
     var secretName = matcher.group("secret").trim();
-    if (!secretName.isBlank() && !secretName.isEmpty()) {
+    if (!secretName.isBlank()) {
       var result = secretReplacer.apply(secretName);
       if (result != null) {
         return result;

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/inbound/InboundConnectorDiscoveryTest.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/inbound/InboundConnectorDiscoveryTest.java
@@ -16,7 +16,7 @@
  */
 package io.camunda.connector.runtime.core.inbound;
 
-import static io.camunda.connector.runtime.core.util.TestUtil.withEnvVars;
+import static io.camunda.connector.runtime.core.testutil.TestUtil.withEnvVars;
 
 import io.camunda.connector.runtime.core.config.InboundConnectorConfiguration;
 import java.util.List;

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/outbound/JobBuilder.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/outbound/JobBuilder.java
@@ -166,7 +166,7 @@ class JobBuilder {
 
   public static class JobResult {
 
-    private Map<String, Object> variables;
+    private final Map<String, Object> variables;
     private String errorCode;
     private String errorMessage;
     private int retries;

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/outbound/OutboundConnectorDiscoveryTest.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/outbound/OutboundConnectorDiscoveryTest.java
@@ -16,7 +16,7 @@
  */
 package io.camunda.connector.runtime.core.outbound;
 
-import static io.camunda.connector.runtime.core.util.TestUtil.withEnvVars;
+import static io.camunda.connector.runtime.core.testutil.TestUtil.withEnvVars;
 
 import io.camunda.connector.runtime.core.config.OutboundConnectorConfiguration;
 import java.util.Arrays;

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/testutil/TestUtil.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/testutil/TestUtil.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.camunda.connector.runtime.core.util;
+package io.camunda.connector.runtime.core.testutil;
 
 import java.util.concurrent.Callable;
 import uk.org.webcompere.systemstubs.environment.EnvironmentVariables;

--- a/connector-sdk/document/src/main/java/io/camunda/document/reference/CamundaDocumentReferenceImpl.java
+++ b/connector-sdk/document/src/main/java/io/camunda/document/reference/CamundaDocumentReferenceImpl.java
@@ -26,4 +26,19 @@ public record CamundaDocumentReferenceImpl(
   public CamundaDocumentReferenceImpl(DocumentReferenceResponse response) {
     this(response.getStoreId(), response.getDocumentId(), response.getMetadata());
   }
+
+  @Override
+  public String getDocumentId() {
+    return documentId;
+  }
+
+  @Override
+  public String getStoreId() {
+    return storeId;
+  }
+
+  @Override
+  public DocumentMetadata getMetadata() {
+    return metadata;
+  }
 }

--- a/connector-sdk/document/src/main/java/io/camunda/document/reference/DocumentReference.java
+++ b/connector-sdk/document/src/main/java/io/camunda/document/reference/DocumentReference.java
@@ -17,10 +17,11 @@
 package io.camunda.document.reference;
 
 import io.camunda.client.api.response.DocumentMetadata;
+import io.camunda.client.api.response.DocumentReferenceResponse;
 
 public interface DocumentReference {
 
-  interface CamundaDocumentReference extends DocumentReference {
+  interface CamundaDocumentReference extends DocumentReference, DocumentReferenceResponse {
     String storeId();
 
     String documentId();

--- a/connector-sdk/document/src/main/java/io/camunda/document/store/CamundaDocumentStoreImpl.java
+++ b/connector-sdk/document/src/main/java/io/camunda/document/store/CamundaDocumentStoreImpl.java
@@ -52,7 +52,7 @@ public class CamundaDocumentStoreImpl implements CamundaDocumentStore {
   @Override
   public InputStream getDocumentContent(CamundaDocumentReference reference) {
     return camundaClient
-        .newDocumentContentGetRequest(reference.documentId())
+        .newDocumentContentGetRequest(reference)
         .storeId(reference.storeId())
         .send()
         .join();

--- a/connector-sdk/jackson-datatype-document/src/main/java/io/camunda/connector/document/annotation/jackson/DocumentReferenceModel.java
+++ b/connector-sdk/jackson-datatype-document/src/main/java/io/camunda/connector/document/annotation/jackson/DocumentReferenceModel.java
@@ -123,6 +123,21 @@ public sealed interface DocumentReferenceModel extends DocumentReference {
     private String documentType() {
       return "camunda";
     }
+
+    @Override
+    public String getDocumentId() {
+      return documentId;
+    }
+
+    @Override
+    public String getStoreId() {
+      return storeId;
+    }
+
+    @Override
+    public DocumentMetadata getMetadata() {
+      return metadata;
+    }
   }
 
   record ExternalDocumentReferenceModel(String url, Optional<DocumentOperation> operation)


### PR DESCRIPTION
## Description

Use the new client request that includes the content hash when retrieving a document 

- [x] PR has a **milestone** or the `no milestone` label.

