### PR TITLE
fix(kafka): fix Kafka connector deactivate method

### DIFF
--- a/connectors/kafka/src/main/java/io/camunda/connector/kafka/inbound/KafkaConnectorConsumer.java
+++ b/connectors/kafka/src/main/java/io/camunda/connector/kafka/inbound/KafkaConnectorConsumer.java
@@ -196,9 +196,6 @@ public class KafkaConnectorConsumer {
         LOG.error("Timeout while waiting for retryableFuture to stop", e);
       }
     }
-    if (this.consumer != null) {
-      this.consumer.close();
-    }
     if (this.executorService != null) {
       this.executorService.shutdownNow();
     }

--- a/connectors/kafka/src/main/java/io/camunda/connector/kafka/inbound/KafkaConnectorConsumer.java
+++ b/connectors/kafka/src/main/java/io/camunda/connector/kafka/inbound/KafkaConnectorConsumer.java
@@ -96,19 +96,6 @@ public class KafkaConnectorConsumer {
             return null;
           } catch (Exception ex) {
             LOG.error("Consumer loop failure, retry pending: {}", ex.getMessage(), ex);
-<<<<<<< Updated upstream
-            try {
-              if (consumer != null) {
-                consumer.close();
-              }
-            } catch (Exception e) {
-              LOG.error(
-                  "Failed to close consumer before retrying, reason: {}. "
-                      + "This error will be ignored. If the consumer is still running, it will be disconnected after max.poll.interval.ms.",
-                  e.getMessage());
-            }
-=======
->>>>>>> Stashed changes
             throw ex;
           }
         };


### PR DESCRIPTION
## Description

- Add proper exception logging
- Fix an issue where the `deactivate` could wait infinitely if there's an error in `prepareConsumer`
- Integration will come in a separate PR

https://jira.camunda.com/browse/SUPPORT-25217

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.

