### PR TITLE
ci: use static sha for preview-env/destroy composite action

### DIFF
--- a/.github/workflows/PREVIEW-ENV-TEARDOWN.yml
+++ b/.github/workflows/PREVIEW-ENV-TEARDOWN.yml
@@ -45,7 +45,7 @@ jobs:
     #########################################################################
     # Tear down preview environment
     - name: Tear down Preview Environment for ${{ matrix.product_context }}
-      uses: camunda/infra-global-github-actions/preview-env/destroy@main
+      uses: camunda/infra-global-github-actions/preview-env/destroy@2475eccdfb5a8d530a0c5d3ed0f7f5397225d205 # main branch
       with:
         revision: ${{ env.BRANCH_NAME }}
         argocd_token: ${{ steps.secrets.outputs.ARGOCD_TOKEN }}


### PR DESCRIPTION
## Description

Due to some changes coming up soon to the `preview-env/destroy` github action, Instead of using the `@main` reference, we are now pointing to the specific sha (main branch anyway) to use for the `preview-env/destroy` composite action

## Related issues

- https://github.com/camunda/team-infrastructure/issues/456

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.

