### PR TITLE
fix(email-connector): now the runtime is backcompatible with all ET

### DIFF
--- a/connector-sdk/core/src/main/java/io/camunda/connector/api/json/ConnectorsObjectMapperSupplier.java
+++ b/connector-sdk/core/src/main/java/io/camunda/connector/api/json/ConnectorsObjectMapperSupplier.java
@@ -45,6 +45,7 @@ public class ConnectorsObjectMapperSupplier {
           .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
           .disable(SerializationFeature.WRITE_DURATIONS_AS_TIMESTAMPS)
           .enable(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY)
+          .enable(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE)
           .build();
 
   private ConnectorsObjectMapperSupplier() {}

--- a/connectors-e2e-test/connectors-e2e-test-mail/src/test/java/io/camunda/connector/e2e/BaseEmailTest.java
+++ b/connectors-e2e-test/connectors-e2e-test-mail/src/test/java/io/camunda/connector/e2e/BaseEmailTest.java
@@ -88,7 +88,7 @@ public class BaseEmailTest {
       if (message.getContent() instanceof Multipart multipart) {
         for (int i = 0; i < multipart.getCount(); i++) {
           MimeBodyPart bodyPart = (MimeBodyPart) multipart.getBodyPart(i);
-          if (bodyPart.isMimeType("text/html")) {
+          if (bodyPart.isMimeType("text/html") || bodyPart.isMimeType("text/plain")) {
             return (String) bodyPart.getContent();
           }
         }

--- a/connectors-e2e-test/connectors-e2e-test-mail/src/test/java/io/camunda/connector/e2e/OutboundEmailTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-mail/src/test/java/io/camunda/connector/e2e/OutboundEmailTests.java
@@ -367,9 +367,9 @@ public class OutboundEmailTests extends BaseEmailTest {
   @Test
   public void shouldSendEmailVersion1() {
     var model =
-            replace(
-                    "email-outbound-connector-send-email-v1.bpmn",
-                    BpmnFile.Replace.replace("55555", super.getUnsecureSmtpPort()));
+        replace(
+            "email-outbound-connector-send-email-v1.bpmn",
+            BpmnFile.Replace.replace("55555", super.getUnsecureSmtpPort()));
 
     var result = getZeebeTest(model);
 

--- a/connectors-e2e-test/connectors-e2e-test-mail/src/test/resources/email-outbound-connector-send-email-v1.bpmn
+++ b/connectors-e2e-test/connectors-e2e-test-mail/src/test/resources/email-outbound-connector-send-email-v1.bpmn
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                  xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI"
+                  xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI"
+                  xmlns:zeebe="http://camunda.org/schema/zeebe/1.0"
+                  xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_0i0443o"
+                  targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.24.0"
+                  modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.5.0">
+    <bpmn:process id="Process_1rzjwzi" isExecutable="true">
+        <bpmn:startEvent id="StartEvent_1">
+            <bpmn:outgoing>Flow_1krhvnz</bpmn:outgoing>
+        </bpmn:startEvent>
+        <bpmn:sequenceFlow id="Flow_1krhvnz" sourceRef="StartEvent_1" targetRef="Activity_1audidp"/>
+        <bpmn:endEvent id="Event_0zvpod7">
+            <bpmn:incoming>Flow_0g2casz</bpmn:incoming>
+        </bpmn:endEvent>
+        <bpmn:sequenceFlow id="Flow_0g2casz" sourceRef="Activity_1audidp" targetRef="Event_0zvpod7"/>
+        <bpmn:serviceTask id="Activity_1audidp" zeebe:modelerTemplate="e2376fbe-d887-46af-8fff-b79ac081adde"
+                          zeebe:modelerTemplateVersion="1737634177610"
+                          zeebe:modelerTemplateIcon="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTYiIGhlaWdodD0iMTYiIHZpZXdCb3g9IjAgMCAxNiAxNiIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPGcgY2xpcC1wYXRoPSJ1cmwoI2NsaXAwXzkwXzI0MjApIj4KPHBhdGggZD0iTTguMzM4MzUgOS45NTM2NUwxMC4zODk0IDEyLjAxMDRMOC4zMzI2MiAxNC4wNjcyTDkuMTQ2MTYgMTQuODc1TDEyLjAxMDcgMTIuMDEwNEw5LjE0NjE2IDkuMTQ1ODNMOC4zMzgzNSA5Ljk1MzY1WiIgZmlsbD0iYmxhY2siLz4KPHBhdGggZD0iTTEyLjM0ODggOS45NTM2NUwxNC4zOTk4IDEyLjAxMDRMMTIuMzQzIDE0LjA2NzJMMTMuMTU2NiAxNC44NzVMMTYuMDIxMiAxMi4wMTA0TDEzLjE1NjYgOS4xNDU4M0wxMi4zNDg4IDkuOTUzNjVaIiBmaWxsPSJibGFjayIvPgo8cGF0aCBkPSJNMy45NzIgMTEuNDM3NUgxLjEyNTMzVjIuNzkyMTlMNy42NzM3NiA3LjMyMzk2QzcuNzY5NjcgNy4zOTA0OSA3Ljg4MzYgNy40MjYxNCA4LjAwMDMyIDcuNDI2MTRDOC4xMTcwNSA3LjQyNjE0IDguMjMwOTggNy4zOTA0OSA4LjMyNjg5IDcuMzIzOTZMMTQuODc1MyAyLjc5MjE5VjhIMTYuMDIxMlYyLjI3MDgzQzE2LjAyMTIgMS45NjY5NCAxNS45MDA0IDEuNjc1NDkgMTUuNjg1NiAxLjQ2MDYxQzE1LjQ3MDcgMS4yNDU3MiAxNS4xNzkyIDEuMTI1IDE0Ljg3NTMgMS4xMjVIMS4xMjUzM0MwLjgyMTQzMiAxLjEyNSAwLjUyOTk4NCAxLjI0NTcyIDAuMzE1MDk5IDEuNDYwNjFDMC4xMDAyMTQgMS42NzU0OSAtMC4wMjA1MDc4IDEuOTY2OTQgLTAuMDIwNTA3OCAyLjI3MDgzVjExLjQzNzVDLTAuMDIwNTA3OCAxMS43NDE0IDAuMTAwMjE0IDEyLjAzMjggMC4zMTUwOTkgMTIuMjQ3N0MwLjUyOTk4NCAxMi40NjI2IDAuODIxNDMyIDEyLjU4MzMgMS4xMjUzMyAxMi41ODMzSDMuOTcyVjExLjQzNzVaTTEzLjYxNDkgMi4yNzA4M0w4LjAwMDMyIDYuMTU1MjFMMi4zODU3NCAyLjI3MDgzSDEzLjYxNDlaIiBmaWxsPSIjRkM1RDBEIi8+CjxwYXRoIGQ9Ik00LjI4MjEgOS45NTM2NUw2LjMzMzE0IDEyLjAxMDRMNC4yNzYzNyAxNC4wNjcyTDUuMDg5OTEgMTQuODc1TDcuOTU0NDkgMTIuMDEwNEw1LjA4OTkxIDkuMTQ1ODNMNC4yODIxIDkuOTUzNjVaIiBmaWxsPSJibGFjayIvPgo8L2c+CjxkZWZzPgo8Y2xpcFBhdGggaWQ9ImNsaXAwXzkwXzI0MjAiPgo8cmVjdCB3aWR0aD0iMTYiIGhlaWdodD0iMTYiIGZpbGw9IndoaXRlIi8+CjwvY2xpcFBhdGg+CjwvZGVmcz4KPC9zdmc+Cg==">
+            <bpmn:extensionElements>
+                <zeebe:taskDefinition type="io.camunda:email:1" retries="3"/>
+                <zeebe:ioMapping>
+                    <zeebe:input source="simple" target="authentication.type"/>
+                    <zeebe:input source="test@camunda.com" target="authentication.username"/>
+                    <zeebe:input source="password" target="authentication.password"/>
+                    <zeebe:input source="smtp" target="protocol"/>
+                    <zeebe:input source="localhost" target="data.smtpConfig.smtpHost"/>
+                    <zeebe:input source="55555" target="data.smtpConfig.smtpPort"/>
+                    <zeebe:input source="NONE" target="data.smtpConfig.smtpCryptographicProtocol"/>
+                    <zeebe:input source="sendEmailSmtp" target="data.smtpActionDiscriminator"/>
+                    <zeebe:input source="test@camunda.com" target="data.smtpAction.from"/>
+                    <zeebe:input source="receiver@test.com" target="data.smtpAction.to"/>
+                    <zeebe:input source="Hello" target="data.smtpAction.subject"/>
+                    <zeebe:input source="This is a test" target="data.smtpAction.body"/>
+                </zeebe:ioMapping>
+                <zeebe:taskHeaders>
+                    <zeebe:header key="resultExpression" value="={sent: sent}" />
+                    <zeebe:header key="retryBackoff" value="PT0S"/>
+                </zeebe:taskHeaders>
+            </bpmn:extensionElements>
+            <bpmn:incoming>Flow_1krhvnz</bpmn:incoming>
+            <bpmn:outgoing>Flow_0g2casz</bpmn:outgoing>
+        </bpmn:serviceTask>
+    </bpmn:process>
+    <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+        <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1rzjwzi">
+            <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+                <dc:Bounds x="179" y="99" width="36" height="36"/>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="Event_0zvpod7_di" bpmnElement="Event_0zvpod7">
+                <dc:Bounds x="432" y="99" width="36" height="36"/>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="Activity_1f3pk4v_di" bpmnElement="Activity_1audidp">
+                <dc:Bounds x="270" y="77" width="100" height="80"/>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNEdge id="Flow_1krhvnz_di" bpmnElement="Flow_1krhvnz">
+                <di:waypoint x="215" y="117"/>
+                <di:waypoint x="270" y="117"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="Flow_0g2casz_di" bpmnElement="Flow_0g2casz">
+                <di:waypoint x="370" y="117"/>
+                <di:waypoint x="432" y="117"/>
+            </bpmndi:BPMNEdge>
+        </bpmndi:BPMNPlane>
+    </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/connectors/email/src/main/java/io/camunda/connector/email/outbound/protocols/actions/ContentType.java
+++ b/connectors/email/src/main/java/io/camunda/connector/email/outbound/protocols/actions/ContentType.java
@@ -6,7 +6,10 @@
  */
 package io.camunda.connector.email.outbound.protocols.actions;
 
+import com.fasterxml.jackson.annotation.JsonEnumDefaultValue;
+
 public enum ContentType {
+  @JsonEnumDefaultValue
   PLAIN("text/plain; charset=utf-8"),
   HTML("text/html; charset=utf-8"),
   MULTIPART("multipart/mixed; charset=utf-8");

--- a/connectors/email/src/main/java/io/camunda/connector/email/outbound/protocols/actions/SmtpSendEmail.java
+++ b/connectors/email/src/main/java/io/camunda/connector/email/outbound/protocols/actions/SmtpSendEmail.java
@@ -6,6 +6,8 @@
  */
 package io.camunda.connector.email.outbound.protocols.actions;
 
+import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.annotation.Nulls;
 import io.camunda.connector.generator.dsl.Property;
 import io.camunda.connector.generator.java.annotation.TemplateProperty;
 import io.camunda.connector.generator.java.annotation.TemplateSubType;
@@ -99,6 +101,7 @@ public record SmtpSendEmail(
             binding = @TemplateProperty.PropertyBinding(name = "data.smtpAction.contentType"))
         @Valid
         @NotNull
+        @JsonSetter(nulls = Nulls.AS_EMPTY)
         ContentType contentType,
     @TemplateProperty(
             label = "Email Text Content",


### PR DESCRIPTION
## Description

FIx the backcompatibility issue on between email connector runtime and older template version

## Related issues

closes https://github.com/camunda/connectors/issues/3874

## Checklist

- [ ] PR has a **milestone** or the `no milestone` label.

