### PR TITLE
other(CI): create different deployment profile if rc or not

### DIFF
--- a/.github/workflows/RELEASE.yaml
+++ b/.github/workflows/RELEASE.yaml
@@ -115,6 +115,7 @@ jobs:
           RELEASE_VERSION: ${{ github.event.release.tag_name }}
 
       - name: Deploy artifacts to Artifactory and Maven Central (Staging)
+        if: "! contains(github.event.release.tag_name, 'rc')"
         run: mvn -B -q compile generate-sources source:jar javadoc:jar deploy -PcheckFormat -Psonatype-oss-release
         env:
           NEXUS_USR: ${{ steps.secrets.outputs.ARTIFACTORY_USR }}


### PR DESCRIPTION
## Description

Add a deployment profile for releases

## Related issues

closes #https://github.com/camunda/team-connectors/issues/933

## Checklist

- [ ] PR has a **milestone** or the `no milestone` label.

