### PR TITLE
feat(sendgrid): attachment support

### DIFF
--- a/connectors/sendgrid/element-templates/hybrid/sendgrid-outbound-connector-hybrid.json
+++ b/connectors/sendgrid/element-templates/hybrid/sendgrid-outbound-connector-hybrid.json
@@ -7,7 +7,7 @@
     "keywords" : [ ]
   },
   "documentationRef" : "https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/sendgrid/",
-  "version" : 3,
+  "version" : 4,
   "category" : {
     "id" : "connectors",
     "name" : "Connectors"
@@ -233,6 +233,18 @@
       "type" : "simple"
     },
     "type" : "Text"
+  }, {
+    "id" : "attachments",
+    "label" : "attachments",
+    "description" : "List of <a href=\"https://docs.camunda.io/docs/apis-tools/camunda-api-rest/specifications/upload-document-alpha/\">Camunda Documents</a>",
+    "optional" : true,
+    "feel" : "required",
+    "group" : "content",
+    "binding" : {
+      "name" : "attachments",
+      "type" : "zeebe:input"
+    },
+    "type" : "String"
   }, {
     "id" : "resultVariable",
     "label" : "Result variable",

--- a/connectors/sendgrid/element-templates/sendgrid-outbound-connector.json
+++ b/connectors/sendgrid/element-templates/sendgrid-outbound-connector.json
@@ -7,7 +7,7 @@
     "keywords" : [ ]
   },
   "documentationRef" : "https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/sendgrid/",
-  "version" : 3,
+  "version" : 4,
   "category" : {
     "id" : "connectors",
     "name" : "Connectors"
@@ -228,6 +228,18 @@
       "type" : "simple"
     },
     "type" : "Text"
+  }, {
+    "id" : "attachments",
+    "label" : "attachments",
+    "description" : "List of <a href=\"https://docs.camunda.io/docs/apis-tools/camunda-api-rest/specifications/upload-document-alpha/\">Camunda Documents</a>",
+    "optional" : true,
+    "feel" : "required",
+    "group" : "content",
+    "binding" : {
+      "name" : "attachments",
+      "type" : "zeebe:input"
+    },
+    "type" : "String"
   }, {
     "id" : "resultVariable",
     "label" : "Result variable",

--- a/connectors/sendgrid/src/test/java/io/camunda/connector/sendgrid/BaseTest.java
+++ b/connectors/sendgrid/src/test/java/io/camunda/connector/sendgrid/BaseTest.java
@@ -30,6 +30,8 @@ public class BaseTest {
       "src/test/resources/requests/validation/validate-receiver-email-tests-cases.json";
   private static final String FAIL_REQUEST_WITH_WRONG_RECEIVER_NAME =
       "src/test/resources/requests/validation/validate-receiver-name-tests-cases.json";
+  private static final String FAIL_REQUEST_WITH_ATTACHMENTS_WITHOUT_FILE_NAME =
+      "src/test/resources/requests/validation/request-with-attachments-without-file-name.json";
 
   private static final String SUCCESS_REPLACE_SECRETS_REQUEST_CASES_PATH =
       "src/test/resources/requests/replace-secrets-success-test-cases.json";
@@ -48,6 +50,7 @@ public class BaseTest {
     String RECEIVER_NAME = "Jane Doe";
     String SENDER_EMAIL = "john.doe@example.com";
     String SENDER_NAME = "John Doe";
+    String ATTACHED_FILE_NAME = "google-my-business-logo-png-transparent.png";
 
     interface Content {
       String SUBJECT = "subject_test";
@@ -128,6 +131,10 @@ public class BaseTest {
 
   protected static Stream<String> failTestWithWrongReceiverEmail() throws IOException {
     return loadTestCasesFromResourceFile(FAIL_REQUEST_WITH_WRONG_RECEIVER_EMAIL);
+  }
+
+  protected static Stream<String> failTestWithEmptyFileName() throws IOException {
+    return loadTestCasesFromResourceFile(FAIL_REQUEST_WITH_ATTACHMENTS_WITHOUT_FILE_NAME);
   }
 
   protected static Stream<String> failTestWithWrongReceiverName() throws IOException {

--- a/connectors/sendgrid/src/test/java/io/camunda/connector/sendgrid/SendGridFunctionTest.java
+++ b/connectors/sendgrid/src/test/java/io/camunda/connector/sendgrid/SendGridFunctionTest.java
@@ -8,19 +8,20 @@ package io.camunda.connector.sendgrid;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 import com.fasterxml.jackson.core.JsonPointer;
+import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.sendgrid.Method;
 import com.sendgrid.Request;
 import com.sendgrid.Response;
 import com.sendgrid.SendGrid;
+import io.camunda.client.api.response.DocumentMetadata;
 import io.camunda.connector.api.outbound.OutboundConnectorContext;
 import io.camunda.connector.sendgrid.model.SendGridRequest;
 import io.camunda.connector.test.outbound.OutboundConnectorContextBuilder;
+import io.camunda.document.Document;
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.List;
 import org.junit.jupiter.api.Assertions;
@@ -42,6 +43,8 @@ public class SendGridFunctionTest extends BaseTest {
   private static final String PERSONALIZATION_JSON_NAME = "personalizations";
   private static final String NAME_JSON_NAME = "name";
   private static final String EMAIL_JSON_NAME = "email";
+  private static final String ATTACHMENTS_JSON_NAME = "attachments";
+  private static final String ATTACHMENTS_FILE_NAME_JSON_NAME = "filename";
 
   private OutboundConnectorContext context;
   private SendGridFunction function;
@@ -107,9 +110,15 @@ public class SendGridFunctionTest extends BaseTest {
   public void execute_shouldCreateRequestWithMailAndExpectedData(String input) throws Exception {
     // Given
     context = contextBuilder.variables(input).build();
-    ArgumentCaptor<Request> requestArgumentCaptor = ArgumentCaptor.forClass(Request.class);
+
+    var contextWithMocketDocument = mock(OutboundConnectorContext.class);
+
+    var requestWithMockedDocument = prepareRequestWithDocumentMock(context);
+
+    when(contextWithMocketDocument.bindVariables(any())).thenReturn(requestWithMockedDocument);
+
     // When
-    function.execute(context);
+    function.execute(contextWithMocketDocument);
     verify(sendGridMock).api(requestArgumentCaptor.capture());
     // Then we have POST request with mail participants,
     Request requestValue = requestArgumentCaptor.getValue();
@@ -122,10 +131,14 @@ public class SendGridFunctionTest extends BaseTest {
         requestJsonObject.withObject(
             JsonPointer.valueOf("/" + PERSONALIZATION_JSON_NAME + "/0/" + TO_JSON_NAME + "/0"));
 
+    var array = (ArrayNode) requestJsonObject.get(ATTACHMENTS_JSON_NAME);
+    String attachmentName = array.get(0).get(ATTACHMENTS_FILE_NAME_JSON_NAME).textValue();
+
     assertThat(from.get(NAME_JSON_NAME).textValue()).isEqualTo(ActualValue.SENDER_NAME);
     assertThat(from.get(EMAIL_JSON_NAME).textValue()).isEqualTo(ActualValue.SENDER_EMAIL);
     assertThat(to.get(NAME_JSON_NAME).textValue()).isEqualTo(ActualValue.RECEIVER_NAME);
     assertThat(to.get(EMAIL_JSON_NAME).textValue()).isEqualTo(ActualValue.RECEIVER_EMAIL);
+    assertThat(attachmentName).isEqualTo(ActualValue.ATTACHED_FILE_NAME);
   }
 
   @ParameterizedTest(name = "Should send mail with template. Test case # {index}")
@@ -133,16 +146,27 @@ public class SendGridFunctionTest extends BaseTest {
   public void execute_shouldSendMailByTemplateIfTemplateExist(String input) throws Exception {
     // Given
     context = contextBuilder.variables(input).build();
-    ArgumentCaptor<Request> requestArgumentCaptor = ArgumentCaptor.forClass(Request.class);
+
+    var contextWithMocketDocument = mock(OutboundConnectorContext.class);
+
+    var requestWithMockedDocument = prepareRequestWithDocumentMock(context);
+
+    when(contextWithMocketDocument.bindVariables(any())).thenReturn(requestWithMockedDocument);
+
     // When
-    function.execute(context);
+    function.execute(contextWithMocketDocument);
     verify(sendGridMock).api(requestArgumentCaptor.capture());
     // Then we have 'template_id' in sendGridRequest with expected ID and 'content' is not exist
     Request requestValue = requestArgumentCaptor.getValue();
+
     var requestJsonObject = objectMapper.readTree(requestValue.getBody());
+
+    var array = (ArrayNode) requestJsonObject.get(ATTACHMENTS_JSON_NAME);
+    String attachmentName = array.get(0).get(ATTACHMENTS_FILE_NAME_JSON_NAME).textValue();
     assertThat(requestJsonObject.get(TEMPLATE_ID_JSON_NAME).textValue())
         .isEqualTo(ActualValue.Template.ID);
     assertThat(requestJsonObject.has(CONTENT_JSON_NAME)).isFalse();
+    assertThat(attachmentName).isEqualTo(ActualValue.ATTACHED_FILE_NAME);
   }
 
   @ParameterizedTest(name = "Should send mail with content. Test case # {index}")
@@ -150,8 +174,16 @@ public class SendGridFunctionTest extends BaseTest {
   public void execute_shouldSendMailIfContentExist(String input) throws Exception {
     // Given
     context = contextBuilder.variables(input).build();
+
+    var contextWithMocketDocument = mock(OutboundConnectorContext.class);
+
+    var requestWithMockedDocument = prepareRequestWithDocumentMock(context);
+
+    when(contextWithMocketDocument.bindVariables(any())).thenReturn(requestWithMockedDocument);
+
     // When
-    function.execute(context);
+    function.execute(contextWithMocketDocument);
+
     verify(sendGridMock).api(requestArgumentCaptor.capture());
     // Then we have 'content' in sendGridRequest with expected data and template ID is not exist
     var requestJsonObject = objectMapper.readTree(requestArgumentCaptor.getValue().getBody());
@@ -165,5 +197,20 @@ public class SendGridFunctionTest extends BaseTest {
         .isEqualTo(ActualValue.Content.VALUE);
 
     assertThat(requestJsonObject.has(TEMPLATE_ID_JSON_NAME)).isFalse();
+  }
+
+  private SendGridRequest prepareRequestWithDocumentMock(OutboundConnectorContext context) {
+    var request = context.bindVariables(SendGridRequest.class);
+
+    var document = mock(Document.class);
+    var documentMetadata = mock(DocumentMetadata.class);
+    when(document.metadata()).thenReturn(documentMetadata);
+
+    String fileName = request.getAttachments().getFirst().metadata().getFileName();
+    when(documentMetadata.getFileName()).thenReturn(fileName);
+    when(document.asInputStream()).thenReturn(new ByteArrayInputStream(new byte[0]));
+
+    request.setAttachments(List.of(document));
+    return request;
   }
 }

--- a/connectors/sendgrid/src/test/java/io/camunda/connector/sendgrid/SendGridRequestTest.java
+++ b/connectors/sendgrid/src/test/java/io/camunda/connector/sendgrid/SendGridRequestTest.java
@@ -91,6 +91,19 @@ public class SendGridRequestTest extends BaseTest {
     assertThat(thrown.getMessage()).contains("receiverName");
   }
 
+  @ParameterizedTest
+  @MethodSource("failTestWithEmptyFileName")
+  public void validate_shouldThrowExceptionWhenDocumentsNamesAreEmpty(String input) {
+    var context = getContextBuilderWithSecrets().variables(input).build();
+
+    Exception exception =
+        assertThrows(
+            ConnectorInputException.class,
+            () -> context.bindVariables(SendGridRequest.class));
+
+    assertThat(exception.getMessage()).contains("attachmentsShouldContainsFileName");
+  }
+
   @ParameterizedTest(name = "Should replace secrets in template")
   @MethodSource("successReplaceSecretsTemplateRequestCases")
   void replaceSecrets_shouldReplaceSecretsWhenExistTemplateRequest(String input) {

--- a/connectors/sendgrid/src/test/resources/requests/send-mail-by-template-success-cases.json
+++ b/connectors/sendgrid/src/test/resources/requests/send-mail-by-template-success-cases.json
@@ -16,7 +16,18 @@
         "shipAddress": "{{secrets.TEMPLATE_DATA_SHIP_ADDRESS}}",
         "shipZip": "{{secrets.TEMPLATE_DATA_SHIP_ZIP}}"
       }
-    }
+    },
+    "attachments" : [ {
+      "camunda.document.type" : "camunda",
+      "storeId" : "in-memory",
+      "documentId" : "2ea3bfcc-7683-4cb6-b0ce-8052ca1d6da0",
+      "metadata" : {
+        "contentType" : "image/png",
+        "fileName" : "google-my-business-logo-png-transparent.png",
+        "size" : 66497,
+        "customProperties" : { }
+      }
+    }]
   },
   {
     "apiKey": "send_grid_key",
@@ -35,7 +46,18 @@
         "shipAddress": "Krossener Str. 24",
         "shipZip": "10245"
       }
-    }
+    },
+    "attachments" : [ {
+      "camunda.document.type" : "camunda",
+      "storeId" : "in-memory",
+      "documentId" : "2ea3bfcc-7683-4cb6-b0ce-8052ca1d6da0",
+      "metadata" : {
+        "contentType" : "image/png",
+        "fileName" : "google-my-business-logo-png-transparent.png",
+        "size" : 66497,
+        "customProperties" : { }
+      }
+    }]
   },
   {
     "to":{
@@ -78,6 +100,17 @@
         ]
       },
       "id":"d-0b51e8f77bf8450fae379e0639ca0d11"
-    }
+    },
+    "attachments" : [ {
+      "camunda.document.type" : "camunda",
+      "storeId" : "in-memory",
+      "documentId" : "2ea3bfcc-7683-4cb6-b0ce-8052ca1d6da0",
+      "metadata" : {
+        "contentType" : "image/png",
+        "fileName" : "google-my-business-logo-png-transparent.png",
+        "size" : 66497,
+        "customProperties" : { }
+      }
+    }]
   }
 ]

--- a/connectors/sendgrid/src/test/resources/requests/validation/request-with-attachments-without-file-name.json
+++ b/connectors/sendgrid/src/test/resources/requests/validation/request-with-attachments-without-file-name.json
@@ -1,6 +1,6 @@
 [
   {
-    "apiKey": "{{secrets.SENDGRID_API_KEY}}",
+    "apiKey": "send_grid_key",
     "from": {
       "name": "John Doe",
       "email": "john.doe@example.com"
@@ -9,10 +9,13 @@
       "name": "Jane Doe",
       "email": "jane.doe@example.com"
     },
-    "content": {
-      "subject": "{{secrets.CONTENT_SUBJECT}}",
-      "type": "{{secrets.CONTENT_TYPE}}",
-      "value": "{{secrets.CONTENT_VALUE}}"
+    "template": {
+      "id": "d-0b51e8f77bf8450fae379e0639ca0d11",
+      "data": {
+        "accountName": "Feuerwehrmann Sam",
+        "shipAddress": "Krossener Str. 24",
+        "shipZip": "10245"
+      }
     },
     "attachments" : [ {
       "camunda.document.type" : "camunda",
@@ -20,7 +23,7 @@
       "documentId" : "2ea3bfcc-7683-4cb6-b0ce-8052ca1d6da0",
       "metadata" : {
         "contentType" : "image/png",
-        "fileName" : "google-my-business-logo-png-transparent.png",
+        "fileName" : "",
         "size" : 66497,
         "customProperties" : { }
       }
@@ -36,10 +39,13 @@
       "name": "Jane Doe",
       "email": "jane.doe@example.com"
     },
-    "content": {
-      "subject": "subject_test",
-      "type": "text/json",
-      "value": "Hello world"
+    "template": {
+      "id": "d-0b51e8f77bf8450fae379e0639ca0d11",
+      "data": {
+        "accountName": "Feuerwehrmann Sam",
+        "shipAddress": "Krossener Str. 24",
+        "shipZip": "10245"
+      }
     },
     "attachments" : [ {
       "camunda.document.type" : "camunda",
@@ -47,10 +53,22 @@
       "documentId" : "2ea3bfcc-7683-4cb6-b0ce-8052ca1d6da0",
       "metadata" : {
         "contentType" : "image/png",
-        "fileName" : "google-my-business-logo-png-transparent.png",
+        "fileName" : "file.png",
         "size" : 66497,
         "customProperties" : { }
       }
-    }]
+    },
+      {
+        "camunda.document.type" : "camunda",
+        "storeId" : "in-memory",
+        "documentId" : "2ea3bfcc-7683-4cb6-b0ce-8052ca1d6da1",
+        "metadata" : {
+          "contentType" : "image/png",
+          "fileName" : " ",
+          "size" : 66497,
+          "customProperties" : { }
+        }
+      }
+    ]
   }
 ]


### PR DESCRIPTION
## Description

attachments support for sendgrid connector

## Related [issues](https://github.com/camunda/team-connectors/issues/998)
<img width="1384" alt="image" src="https://github.com/user-attachments/assets/652fe084-339c-4dea-a41a-7fbc187520cc" />

element template [pr](https://github.com/camunda/web-modeler/pull/12776)
documentation [pr](https://github.com/camunda/camunda-docs/pull/4916)



https://github.com/user-attachments/assets/fc36eefc-3242-49fc-8d5b-b9ad457e323b

