### PR TITLE
other(ci): bring back the old test configuration

### DIFF
--- a/.github/workflows/TEST_FEATURE_BRANCH.yml
+++ b/.github/workflows/TEST_FEATURE_BRANCH.yml
@@ -1,9 +1,10 @@
 name: Test branch
 
 on:
-  pull_request_target:
+  push:
     branches:
-      - 'main'
+      - '**'
+      - '!main'
   merge_group:
     branches: [ main ]
 


### PR DESCRIPTION
## Description

- Using `pull_request_target` lead to this behavior:

> This event runs in the context of the base of the pull request, rather than in the context of the merge commit, as the pull_request event does. This prevents execution of unsafe code from the head of the pull request that could alter your repository or steal any secrets you use in your workflow. This event allows your workflow to do things like label or comment on pull requests from forks. Avoid using this event if you need to build or run code from the pull request.

Using the `main` branch context is not acceptable, as a failing test in your branch won't be detected.
For now we will use the previous configuration, and we'll deal with PRs from forks manually as it's not happening often.
 
## Checklist

- [x] PR has a **milestone** or the `no milestone` label.

