### PR TITLE
fix: added back identity-autoconfigure

### DIFF
--- a/connector-runtime/spring-boot-starter-camunda-connectors/pom.xml
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/pom.xml
@@ -37,6 +37,10 @@
       </exclusions>
     </dependency>
     <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>identity-spring-boot-autoconfigure</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-web</artifactId>
     </dependency>


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

This PR fixes the helm chart setup for version 8.5

The issue was that during the version upgrade, spring-zeebe removed unused dependencies, among them identity-autoconfigure.

As we rely on the identity-sdk in our helm chart to configure the oidc client, this was breaking the build.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #

## Checklist

- [ ] PR has a **milestone** or the `no milestone` label.

