### PR TITLE
fix(ci): Remove helm manager from renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -14,11 +14,6 @@
       "automerge": true
     },
     {
-      "matchManagers": ["helm"],
-      "automerge": true,
-      "matchUpdateTypes": ["minor", "patch", "pin", "digest"]
-    },
-    {
       "matchBaseBranches": ["/^release/.*/"],
       "matchUpdateTypes": ["major", "minor"],
       "enabled": false


### PR DESCRIPTION
## Description

It seems like the manager value for `helm` might not be correct. Hence reverting it.

## Checklist

- [ ] PR has a **milestone** or the `no milestone` label.

