### PR TITLE
fix(github-connector): use correct name of 'release name' property

### DIFF
--- a/connectors/github/element-templates/github-connector.json
+++ b/connectors/github/element-templates/github-connector.json
@@ -2229,7 +2229,7 @@
     {
       "group": "input",
       "type": "Hidden",
-      "value": "={\"tag_name\": tagName, \"body\":if githubBody = null then null else githubBody,\"name\":if name = null then null else name,\"make_latest\":if makeLatest = null then null else makeLatest}",
+      "value": "={\"tag_name\": tagName, \"body\":if githubBody = null then null else githubBody,\"name\":if releaseName = null then null else releaseName,\"make_latest\":if makeLatest = null then null else makeLatest}",
       "binding": {
         "type": "zeebe:input",
         "name": "body"


### PR DESCRIPTION
## Description
Use the correct name of the "release name" property when creating or updating a release.

## Related issues

closes #3973

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.

