### PR TITLE
other(CI): Add skipAfterFailure flag to tests

### DIFF
--- a/.github/workflows/TEST_FEATURE_BRANCH.yml
+++ b/.github/workflows/TEST_FEATURE_BRANCH.yml
@@ -62,7 +62,7 @@ jobs:
         run: npm install --global element-templates-cli
 
       - name: Build Connectors
-        run: mvn --batch-mode clean test -PcheckFormat
+        run: mvn --batch-mode clean test -PcheckFormat -Dsurefire.skipAfterFailureCount=1
 
       - name: Lint Dockerfile - connector-runtime
         uses: hadolint/hadolint-action@v3.1.0


### PR DESCRIPTION
## Description
Add -Dsurefire.skipAfterFailureCount=1 to TEST_FEATURE_BRANCH action.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes https://github.com/camunda/team-connectors/issues/983

## Checklist

- [ ] PR has a **milestone** or the `no milestone` label.

