### PR TITLE
fix(box-connector): Avoid refetching data of deleted items

### DIFF
--- a/connectors/box/element-templates/box-outbound-connector.json
+++ b/connectors/box/element-templates/box-outbound-connector.json
@@ -468,6 +468,9 @@
     "id" : "operation.searchQuery",
     "label" : "Search query",
     "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
     "feel" : "optional",
     "group" : "operation",
     "binding" : {
@@ -486,6 +489,9 @@
     "description" : "Column for sorting search results",
     "optional" : false,
     "value" : "modified_at",
+    "constraints" : {
+      "notEmpty" : true
+    },
     "feel" : "optional",
     "group" : "operation",
     "binding" : {

--- a/connectors/box/element-templates/hybrid/box-outbound-connector-hybrid.json
+++ b/connectors/box/element-templates/hybrid/box-outbound-connector-hybrid.json
@@ -473,6 +473,9 @@
     "id" : "operation.searchQuery",
     "label" : "Search query",
     "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
     "feel" : "optional",
     "group" : "operation",
     "binding" : {
@@ -491,6 +494,9 @@
     "description" : "Column for sorting search results",
     "optional" : false,
     "value" : "modified_at",
+    "constraints" : {
+      "notEmpty" : true
+    },
     "feel" : "optional",
     "group" : "operation",
     "binding" : {

--- a/connectors/box/src/main/java/io/camunda/connector/box/BoxOperations.java
+++ b/connectors/box/src/main/java/io/camunda/connector/box/BoxOperations.java
@@ -20,8 +20,6 @@ import com.box.sdk.BoxFolder;
 import com.box.sdk.BoxItem;
 import com.box.sdk.BoxSearch;
 import com.box.sdk.BoxSearchParameters;
-import com.box.sdk.IAccessTokenCache;
-import com.box.sdk.InMemoryLRUAccessTokenCache;
 import io.camunda.connector.api.outbound.OutboundConnectorContext;
 import io.camunda.connector.box.model.BoxRequest;
 import io.camunda.connector.box.model.BoxRequest.Operation.Search.SortDirection;
@@ -51,15 +49,17 @@ public class BoxOperations {
     return switch (authentication) {
       case BoxRequest.Authentication.DeveloperToken developerToken ->
           new BoxAPIConnection(developerToken.accessToken());
+
       case BoxRequest.Authentication.ClientCredentialsUser user ->
           BoxCCGAPIConnection.userConnection(user.clientId(), user.clientSecret(), user.userId());
+
       case BoxRequest.Authentication.ClientCredentialsEnterprise enterprise ->
           BoxCCGAPIConnection.applicationServiceAccountConnection(
               enterprise.clientId(), enterprise.clientSecret(), enterprise.enterpriseId());
+
       case BoxRequest.Authentication.JWTJsonConfig jwtJsonConfig -> {
         BoxConfig boxConfig = BoxConfig.readFrom(jwtJsonConfig.jsonConfig());
-        IAccessTokenCache tokenCache = new InMemoryLRUAccessTokenCache(100);
-        yield BoxDeveloperEditionAPIConnection.getAppEnterpriseConnection(boxConfig, tokenCache);
+        yield BoxDeveloperEditionAPIConnection.getAppEnterpriseConnection(boxConfig);
       }
     };
   }

--- a/connectors/box/src/main/java/io/camunda/connector/box/BoxUtil.java
+++ b/connectors/box/src/main/java/io/camunda/connector/box/BoxUtil.java
@@ -74,15 +74,14 @@ public class BoxUtil {
   }
 
   public static BoxResult.Item item(BoxFile file) {
-    return new BoxResult.Item(file.getID(), file.getInfo().getName(), file.getInfo().getType());
+    return new BoxResult.Item(file.getID(), "file");
   }
 
   public static BoxResult.Item item(BoxFolder folder) {
-    return new BoxResult.Item(
-        folder.getID(), folder.getInfo().getName(), folder.getInfo().getType());
+    return new BoxResult.Item(folder.getID(), "folder");
   }
 
   public static BoxResult.Item item(BoxItem.Info info) {
-    return new BoxResult.Item(info.getID(), info.getName(), info.getType());
+    return new BoxResult.Item(info.getID(), info.getType());
   }
 }

--- a/connectors/box/src/main/java/io/camunda/connector/box/model/BoxRequest.java
+++ b/connectors/box/src/main/java/io/camunda/connector/box/model/BoxRequest.java
@@ -220,12 +220,13 @@ public record BoxRequest(
 
     @TemplateSubType(id = "search", label = "Search")
     record Search(
-        @TemplateProperty(id = "searchQuery", group = "operation") String query,
+        @TemplateProperty(id = "searchQuery", group = "operation") @NotBlank String query,
         @TemplateProperty(
                 id = "searchSortColumn",
                 defaultValue = "modified_at",
                 description = "Column for sorting search results",
                 group = "operation")
+            @NotBlank
             String sortColumn,
         @TemplateProperty(
                 id = "searchSortDirection",

--- a/connectors/box/src/main/java/io/camunda/connector/box/model/BoxResult.java
+++ b/connectors/box/src/main/java/io/camunda/connector/box/model/BoxResult.java
@@ -11,7 +11,7 @@ import java.util.List;
 
 public sealed interface BoxResult
     permits BoxResult.Download, BoxResult.Generic, BoxResult.Search, BoxResult.Upload {
-  record Item(String id, String name, String type) {}
+  record Item(String id, String type) {}
 
   record Download(Item item, Document document) implements BoxResult {}
 


### PR DESCRIPTION
## Description

Fixes the exception that happened after deleting a file or a folder when the Box client tried to refetch information from the now deleted object.

## Checklist

- [x ] PR has a **milestone** or the `no milestone` label.

