### PR TITLE
fix(docs): remove the mention of make on readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,6 @@ When in doubt, refer to the `LICENSE` file in the respective module.
 
 Download these utilities:
 
-* [`make`](https://www.gnu.org/software/make/) for building
 * [`asdf`](https://asdf-vm.com/) for managing Java and Maven versions
 
 The [Connector SDK](connector-sdk) uses Java 17, unlike the rest of this repository.


### PR DESCRIPTION
## Description

We don't use make in this repo.

closes #

## Checklist

- [ ] PR has a **milestone** or the `no milestone` label.

