### PR TITLE
fix(deploy-preview): upgrade 8.7. helm chart to make deploy preview work

### DIFF
--- a/.ci/preview-environments/charts/c8sm/Chart.yaml
+++ b/.ci/preview-environments/charts/c8sm/Chart.yaml
@@ -14,5 +14,5 @@ dependencies:
   version: 1.4.8
 - name: camunda-platform
   # @camunda-cloud references https://helm.camunda.io repository configured as camunda-cloud in Argo CD
-  repository: https://helm.camunda.io
-  version: 11.1.0
+  repository: oci://ghcr.io/camunda/helm
+  version: 0.0.0-8.7.0-alpha4

--- a/.ci/preview-environments/charts/c8sm/Chart.yaml
+++ b/.ci/preview-environments/charts/c8sm/Chart.yaml
@@ -14,5 +14,5 @@ dependencies:
   version: 1.4.8
 - name: camunda-platform
   # @camunda-cloud references https://helm.camunda.io repository configured as camunda-cloud in Argo CD
-  repository: oci://ghcr.io/camunda/helm
-  version: 0.0.0-8.7.0-alpha4
+  repository: https://helm.camunda.io
+  version: 12.0.0-alpha4

--- a/.github/workflows/RELEASE.yaml
+++ b/.github/workflows/RELEASE.yaml
@@ -123,6 +123,7 @@ jobs:
           MAVEN_PSW: ${{ steps.secrets.outputs.MAVEN_CENTRAL_DEPLOYMENT_PSW }}
           MAVEN_GPG_PASSPHRASE: ${{ steps.secrets.outputs.MAVEN_CENTRAL_GPG_SIGNING_KEY_PASSPHRASE }}
 
+
       - name: Generate sbom reports
         run: |
           mvn cyclonedx:makeAggregateBom -pl bundle/default-bundle


### PR DESCRIPTION
## Description

This PR will fix the preview env deployment for 8.7 by upgrading to the latest alpha version of the Helm chart.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #

## Checklist

- [ ] PR has a **milestone** or the `no milestone` label.

