### PR TITLE
fix(docs): Fix broken links in element templates

### DIFF
--- a/connectors/aws/aws-base/README.md
+++ b/connectors/aws/aws-base/README.md
@@ -55,7 +55,7 @@ AWS-specific services.
 
 ### AWS DynamoDB Connector
 
-The [AWS DynamoDB Connector](https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/aws-dynamodb/)
+The [AWS DynamoDB Connector](https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-dynamodb/)
 allows you to connect your BPMN service with [Amazon Web Service's DynamoDB Service](https://aws.amazon.com/dynamodb/).
 This can be useful for performing CRUD operations on AWS DynamoDB tables from within a BPMN process.
 

--- a/connectors/aws/aws-bedrock/element-templates/aws-bedrock-outbound-connector.json
+++ b/connectors/aws/aws-bedrock/element-templates/aws-bedrock-outbound-connector.json
@@ -6,7 +6,7 @@
   "metadata" : {
     "keywords" : [ "invoke model", "run inference", "invokemodel API", "converse API" ]
   },
-  "documentationRef" : "https://docs.camunda.io/docs/",
+  "documentationRef" : "https://docs.camunda.io/",
   "version" : 2,
   "category" : {
     "id" : "connectors",

--- a/connectors/aws/aws-bedrock/element-templates/hybrid/aws-bedrock-outbound-connector-hybrid.json
+++ b/connectors/aws/aws-bedrock/element-templates/hybrid/aws-bedrock-outbound-connector-hybrid.json
@@ -6,7 +6,7 @@
   "metadata" : {
     "keywords" : [ "invoke model", "run inference", "invokemodel API", "converse API" ]
   },
-  "documentationRef" : "https://docs.camunda.io/docs/",
+  "documentationRef" : "https://docs.camunda.io/",
   "version" : 2,
   "category" : {
     "id" : "connectors",

--- a/connectors/aws/aws-dynamodb/README.md
+++ b/connectors/aws/aws-dynamodb/README.md
@@ -1,7 +1,7 @@
 # Camunda AWS SNS Connector
 
 Find the user documentation in
-our [Camunda Docs](https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/aws-dynamodb/)
+our [Camunda Docs](https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-dynamodb/)
 .
 
 ## Build

--- a/connectors/aws/aws-dynamodb/element-templates/aws-dynamodb-outbound-connector.json
+++ b/connectors/aws/aws-dynamodb/element-templates/aws-dynamodb-outbound-connector.json
@@ -6,7 +6,7 @@
   "metadata" : {
     "keywords" : [ "create table", "delete table", "update table", "describe table", "scan table", "add item", "delete item", "get item", "update item" ]
   },
-  "documentationRef" : "https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/aws-dynamodb/",
+  "documentationRef" : "https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-dynamodb/",
   "version" : 7,
   "category" : {
     "id" : "connectors",
@@ -228,7 +228,7 @@
   }, {
     "id" : "input.partitionKey",
     "label" : "Partition key",
-    "description" : "Partition key role. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/aws-dynamodb/\" target=\"_blank\">documentation</a>",
+    "description" : "Partition key role. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-dynamodb/\" target=\"_blank\">documentation</a>",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -254,7 +254,7 @@
   }, {
     "id" : "input.partitionKeyRole",
     "label" : "Partition key role",
-    "description" : "The role that this key attribute will assume. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/aws-dynamodb/\" target=\"_blank\">documentation</a>",
+    "description" : "The role that this key attribute will assume. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-dynamodb/\" target=\"_blank\">documentation</a>",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -321,7 +321,7 @@
   }, {
     "id" : "input.sortKey",
     "label" : "Sort key",
-    "description" : "Sort key. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/aws-dynamodb/\" target=\"_blank\">documentation</a>",
+    "description" : "Sort key. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-dynamodb/\" target=\"_blank\">documentation</a>",
     "optional" : true,
     "feel" : "optional",
     "group" : "input",
@@ -405,7 +405,7 @@
   }, {
     "id" : "input.readCapacityUnits",
     "label" : "Read capacity units",
-    "description" : "Total number of read capacity units. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/aws-dynamodb/\" target=\"_blank\">documentation</a>",
+    "description" : "Total number of read capacity units. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-dynamodb/\" target=\"_blank\">documentation</a>",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -431,7 +431,7 @@
   }, {
     "id" : "input.writeCapacityUnits",
     "label" : "Write capacity units",
-    "description" : "Total number of write capacity units. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/aws-dynamodb/\" target=\"_blank\">documentation</a>",
+    "description" : "Total number of write capacity units. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-dynamodb/\" target=\"_blank\">documentation</a>",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -457,7 +457,7 @@
   }, {
     "id" : "input.billingModeStr",
     "label" : "Billing mode",
-    "description" : "Controls how you are charged for read and write throughput. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/aws-dynamodb/\" target=\"_blank\">documentation</a>",
+    "description" : "Controls how you are charged for read and write throughput. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-dynamodb/\" target=\"_blank\">documentation</a>",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -600,7 +600,7 @@
   }, {
     "id" : "input.filterExpression",
     "label" : "Filter expression",
-    "description" : "Filter expressions for scan. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/aws-dynamodb/\" target=\"_blank\">documentation</a>",
+    "description" : "Filter expressions for scan. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-dynamodb/\" target=\"_blank\">documentation</a>",
     "optional" : true,
     "feel" : "optional",
     "group" : "input",
@@ -646,7 +646,7 @@
   }, {
     "id" : "input.expressionAttributeNames",
     "label" : "Expression attribute names",
-    "description" : "Is a placeholder that you use as an alternative to an actual attribute name. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/aws-dynamodb/\" target=\"_blank\">documentation</a>",
+    "description" : "Is a placeholder that you use as an alternative to an actual attribute name. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-dynamodb/\" target=\"_blank\">documentation</a>",
     "optional" : true,
     "feel" : "required",
     "group" : "input",
@@ -669,7 +669,7 @@
   }, {
     "id" : "input.expressionAttributeValues",
     "label" : "Expression attribute values",
-    "description" : "Expression attribute values. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/aws-dynamodb/\" target=\"_blank\">documentation</a>",
+    "description" : "Expression attribute values. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-dynamodb/\" target=\"_blank\">documentation</a>",
     "optional" : true,
     "feel" : "required",
     "group" : "input",
@@ -900,7 +900,7 @@
   }, {
     "id" : "input.keyAttributes",
     "label" : "Key attributes",
-    "description" : "DynamoDB key attributes. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/aws-dynamodb/\" target=\"_blank\">documentation</a>",
+    "description" : "DynamoDB key attributes. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-dynamodb/\" target=\"_blank\">documentation</a>",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true

--- a/connectors/aws/aws-dynamodb/element-templates/hybrid/aws-dynamodb-outbound-connector-hybrid.json
+++ b/connectors/aws/aws-dynamodb/element-templates/hybrid/aws-dynamodb-outbound-connector-hybrid.json
@@ -6,7 +6,7 @@
   "metadata" : {
     "keywords" : [ "create table", "delete table", "update table", "describe table", "scan table", "add item", "delete item", "get item", "update item" ]
   },
-  "documentationRef" : "https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/aws-dynamodb/",
+  "documentationRef" : "https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-dynamodb/",
   "version" : 7,
   "category" : {
     "id" : "connectors",
@@ -233,7 +233,7 @@
   }, {
     "id" : "input.partitionKey",
     "label" : "Partition key",
-    "description" : "Partition key role. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/aws-dynamodb/\" target=\"_blank\">documentation</a>",
+    "description" : "Partition key role. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-dynamodb/\" target=\"_blank\">documentation</a>",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -259,7 +259,7 @@
   }, {
     "id" : "input.partitionKeyRole",
     "label" : "Partition key role",
-    "description" : "The role that this key attribute will assume. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/aws-dynamodb/\" target=\"_blank\">documentation</a>",
+    "description" : "The role that this key attribute will assume. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-dynamodb/\" target=\"_blank\">documentation</a>",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -326,7 +326,7 @@
   }, {
     "id" : "input.sortKey",
     "label" : "Sort key",
-    "description" : "Sort key. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/aws-dynamodb/\" target=\"_blank\">documentation</a>",
+    "description" : "Sort key. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-dynamodb/\" target=\"_blank\">documentation</a>",
     "optional" : true,
     "feel" : "optional",
     "group" : "input",
@@ -410,7 +410,7 @@
   }, {
     "id" : "input.readCapacityUnits",
     "label" : "Read capacity units",
-    "description" : "Total number of read capacity units. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/aws-dynamodb/\" target=\"_blank\">documentation</a>",
+    "description" : "Total number of read capacity units. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-dynamodb/\" target=\"_blank\">documentation</a>",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -436,7 +436,7 @@
   }, {
     "id" : "input.writeCapacityUnits",
     "label" : "Write capacity units",
-    "description" : "Total number of write capacity units. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/aws-dynamodb/\" target=\"_blank\">documentation</a>",
+    "description" : "Total number of write capacity units. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-dynamodb/\" target=\"_blank\">documentation</a>",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -462,7 +462,7 @@
   }, {
     "id" : "input.billingModeStr",
     "label" : "Billing mode",
-    "description" : "Controls how you are charged for read and write throughput. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/aws-dynamodb/\" target=\"_blank\">documentation</a>",
+    "description" : "Controls how you are charged for read and write throughput. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-dynamodb/\" target=\"_blank\">documentation</a>",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -605,7 +605,7 @@
   }, {
     "id" : "input.filterExpression",
     "label" : "Filter expression",
-    "description" : "Filter expressions for scan. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/aws-dynamodb/\" target=\"_blank\">documentation</a>",
+    "description" : "Filter expressions for scan. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-dynamodb/\" target=\"_blank\">documentation</a>",
     "optional" : true,
     "feel" : "optional",
     "group" : "input",
@@ -651,7 +651,7 @@
   }, {
     "id" : "input.expressionAttributeNames",
     "label" : "Expression attribute names",
-    "description" : "Is a placeholder that you use as an alternative to an actual attribute name. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/aws-dynamodb/\" target=\"_blank\">documentation</a>",
+    "description" : "Is a placeholder that you use as an alternative to an actual attribute name. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-dynamodb/\" target=\"_blank\">documentation</a>",
     "optional" : true,
     "feel" : "required",
     "group" : "input",
@@ -674,7 +674,7 @@
   }, {
     "id" : "input.expressionAttributeValues",
     "label" : "Expression attribute values",
-    "description" : "Expression attribute values. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/aws-dynamodb/\" target=\"_blank\">documentation</a>",
+    "description" : "Expression attribute values. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-dynamodb/\" target=\"_blank\">documentation</a>",
     "optional" : true,
     "feel" : "required",
     "group" : "input",
@@ -905,7 +905,7 @@
   }, {
     "id" : "input.keyAttributes",
     "label" : "Key attributes",
-    "description" : "DynamoDB key attributes. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/aws-dynamodb/\" target=\"_blank\">documentation</a>",
+    "description" : "DynamoDB key attributes. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-dynamodb/\" target=\"_blank\">documentation</a>",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true

--- a/connectors/aws/aws-dynamodb/src/main/java/io/camunda/connector/aws/dynamodb/AwsDynamoDbServiceConnectorFunction.java
+++ b/connectors/aws/aws-dynamodb/src/main/java/io/camunda/connector/aws/dynamodb/AwsDynamoDbServiceConnectorFunction.java
@@ -35,7 +35,7 @@ import io.camunda.connector.generator.java.annotation.ElementTemplate;
               "update item"
             }),
     documentationRef =
-        "https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/aws-dynamodb/",
+        "https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-dynamodb/",
     propertyGroups = {
       @ElementTemplate.PropertyGroup(id = "operation", label = "Operation"),
       @ElementTemplate.PropertyGroup(id = "authentication", label = "Authentication"),

--- a/connectors/aws/aws-dynamodb/src/main/java/io/camunda/connector/aws/dynamodb/model/CreateTable.java
+++ b/connectors/aws/aws-dynamodb/src/main/java/io/camunda/connector/aws/dynamodb/model/CreateTable.java
@@ -25,7 +25,7 @@ public record CreateTable(
     @TemplateProperty(
             group = "input",
             description =
-                "Partition key role. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/aws-dynamodb/\" target=\"_blank\">documentation</a>")
+                "Partition key role. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-dynamodb/\" target=\"_blank\">documentation</a>")
         @NotBlank
         String partitionKey,
     @TemplateProperty(
@@ -36,7 +36,7 @@ public record CreateTable(
               @TemplateProperty.DropdownPropertyChoice(value = "RANGE", label = "RANGE")
             },
             description =
-                "The role that this key attribute will assume. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/aws-dynamodb/\" target=\"_blank\">documentation</a>")
+                "The role that this key attribute will assume. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-dynamodb/\" target=\"_blank\">documentation</a>")
         @NotBlank
         String partitionKeyRole,
     @TemplateProperty(
@@ -56,7 +56,7 @@ public record CreateTable(
             group = "input",
             optional = true,
             description =
-                "Sort key. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/aws-dynamodb/\" target=\"_blank\">documentation</a>")
+                "Sort key. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-dynamodb/\" target=\"_blank\">documentation</a>")
         String sortKey,
     @TemplateProperty(
             label = "Sort key role",
@@ -85,14 +85,14 @@ public record CreateTable(
             label = "Read capacity units",
             group = "input",
             description =
-                "Total number of read capacity units. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/aws-dynamodb/\" target=\"_blank\">documentation</a>")
+                "Total number of read capacity units. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-dynamodb/\" target=\"_blank\">documentation</a>")
         @NotNull
         Long readCapacityUnits,
     @TemplateProperty(
             label = "Write capacity units",
             group = "input",
             description =
-                "Total number of write capacity units. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/aws-dynamodb/\" target=\"_blank\">documentation</a>")
+                "Total number of write capacity units. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-dynamodb/\" target=\"_blank\">documentation</a>")
         @NotNull
         Long writeCapacityUnits,
     @TemplateProperty(
@@ -108,7 +108,7 @@ public record CreateTable(
                   label = "PAY_PER_REQUEST")
             },
             description =
-                "Controls how you are charged for read and write throughput. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/aws-dynamodb/\" target=\"_blank\">documentation</a>")
+                "Controls how you are charged for read and write throughput. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-dynamodb/\" target=\"_blank\">documentation</a>")
         @NotBlank
         String billingModeStr,
     @TemplateProperty(

--- a/connectors/aws/aws-dynamodb/src/main/java/io/camunda/connector/aws/dynamodb/model/ScanTable.java
+++ b/connectors/aws/aws-dynamodb/src/main/java/io/camunda/connector/aws/dynamodb/model/ScanTable.java
@@ -26,7 +26,7 @@ public record ScanTable(
             group = "input",
             optional = true,
             description =
-                "Filter expressions for scan. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/aws-dynamodb/\" target=\"_blank\">documentation</a>")
+                "Filter expressions for scan. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-dynamodb/\" target=\"_blank\">documentation</a>")
         String filterExpression,
     @TemplateProperty(
             label = "Projection expression",
@@ -41,7 +41,7 @@ public record ScanTable(
             feel = Property.FeelMode.required,
             optional = true,
             description =
-                "Is a placeholder that you use as an alternative to an actual attribute name. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/aws-dynamodb/\" target=\"_blank\">documentation</a>")
+                "Is a placeholder that you use as an alternative to an actual attribute name. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-dynamodb/\" target=\"_blank\">documentation</a>")
         Map<String, String> expressionAttributeNames,
     @TemplateProperty(
             label = "Expression attribute values",
@@ -49,6 +49,6 @@ public record ScanTable(
             feel = Property.FeelMode.required,
             optional = true,
             description =
-                "Expression attribute values. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/aws-dynamodb/\" target=\"_blank\">documentation</a>")
+                "Expression attribute values. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-dynamodb/\" target=\"_blank\">documentation</a>")
         Map<String, Object> expressionAttributeValues)
     implements TableInput {}

--- a/connectors/aws/aws-dynamodb/src/main/java/io/camunda/connector/aws/dynamodb/model/UpdateItem.java
+++ b/connectors/aws/aws-dynamodb/src/main/java/io/camunda/connector/aws/dynamodb/model/UpdateItem.java
@@ -35,7 +35,7 @@ public record UpdateItem(
             group = "input",
             feel = Property.FeelMode.required,
             description =
-                "DynamoDB key attributes. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/aws-dynamodb/\" target=\"_blank\">documentation</a>")
+                "DynamoDB key attributes. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-dynamodb/\" target=\"_blank\">documentation</a>")
         @NotNull
         Map<String, Object> keyAttributes,
     @TemplateProperty(

--- a/connectors/aws/aws-eventbridge/element-templates/aws-eventbridge-connector-boundary.json
+++ b/connectors/aws/aws-eventbridge/element-templates/aws-eventbridge-connector-boundary.json
@@ -322,7 +322,7 @@
         "type": "zeebe:property",
         "name": "activationCondition"
       },
-      "description": "Condition under which the connector triggers. Leave empty to catch all events. <a href='https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/http-webhook/#make-your-http-webhook-connector-for-receiving-messages-executable' target='_blank'>See documentation</a>"
+      "description": "Condition under which the connector triggers. Leave empty to catch all events. <a href='https://docs.camunda.io/docs/components/connectors/protocol/http-webhook/#make-your-http-webhook-connector-for-receiving-messages-executable' target='_blank'>See documentation</a>"
     },
     {
       "label": "Result variable",

--- a/connectors/aws/aws-eventbridge/element-templates/aws-eventbridge-connector-intermediate.json
+++ b/connectors/aws/aws-eventbridge/element-templates/aws-eventbridge-connector-intermediate.json
@@ -323,7 +323,7 @@
         "type": "zeebe:property",
         "name": "activationCondition"
       },
-      "description": "Condition under which the connector triggers. Leave empty to catch all events. <a href='https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/http-webhook/#make-your-http-webhook-connector-for-receiving-messages-executable' target='_blank'>See documentation</a>"
+      "description": "Condition under which the connector triggers. Leave empty to catch all events. <a href='https://docs.camunda.io/docs/components/connectors/protocol/http-webhook/#make-your-http-webhook-connector-for-receiving-messages-executable' target='_blank'>See documentation</a>"
     },
     {
       "label": "Result variable",

--- a/connectors/aws/aws-eventbridge/element-templates/aws-eventbridge-connector-message-start.json
+++ b/connectors/aws/aws-eventbridge/element-templates/aws-eventbridge-connector-message-start.json
@@ -298,7 +298,7 @@
         "type": "zeebe:property",
         "name": "activationCondition"
       },
-      "description": "Condition under which the connector triggers. Leave empty to catch all events. <a href='https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/http-webhook/#make-your-http-webhook-connector-for-receiving-messages-executable' target='_blank'>See documentation</a>"
+      "description": "Condition under which the connector triggers. Leave empty to catch all events. <a href='https://docs.camunda.io/docs/components/connectors/protocol/http-webhook/#make-your-http-webhook-connector-for-receiving-messages-executable' target='_blank'>See documentation</a>"
     },
     {
       "label": "Correlation required",

--- a/connectors/aws/aws-eventbridge/element-templates/aws-eventbridge-connector-start-event.json
+++ b/connectors/aws/aws-eventbridge/element-templates/aws-eventbridge-connector-start-event.json
@@ -271,7 +271,7 @@
         "type": "zeebe:property",
         "name": "activationCondition"
       },
-      "description": "Condition under which the connector triggers. Leave empty to catch all events. <a href='https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/http-webhook/#make-your-http-webhook-connector-for-receiving-messages-executable' target='_blank'>See documentation</a>"
+      "description": "Condition under which the connector triggers. Leave empty to catch all events. <a href='https://docs.camunda.io/docs/components/connectors/protocol/http-webhook/#make-your-http-webhook-connector-for-receiving-messages-executable' target='_blank'>See documentation</a>"
     },
     {
       "label": "Result variable",

--- a/connectors/aws/aws-s3/element-templates/aws-s3-outbound-connector.json
+++ b/connectors/aws/aws-s3/element-templates/aws-s3-outbound-connector.json
@@ -6,7 +6,7 @@
   "metadata" : {
     "keywords" : [ ]
   },
-  "documentationRef" : "https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/aws-s3/",
+  "documentationRef" : "https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-s3/",
   "version" : 1,
   "category" : {
     "id" : "connectors",

--- a/connectors/aws/aws-s3/element-templates/hybrid/aws-s3-outbound-connector-hybrid.json
+++ b/connectors/aws/aws-s3/element-templates/hybrid/aws-s3-outbound-connector-hybrid.json
@@ -6,7 +6,7 @@
   "metadata" : {
     "keywords" : [ ]
   },
-  "documentationRef" : "https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/aws-s3/",
+  "documentationRef" : "https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-s3/",
   "version" : 1,
   "category" : {
     "id" : "connectors",

--- a/connectors/aws/aws-s3/src/main/java/io/camunda/connector/aws/s3/S3ConnectorFunction.java
+++ b/connectors/aws/aws-s3/src/main/java/io/camunda/connector/aws/s3/S3ConnectorFunction.java
@@ -35,7 +35,7 @@ import java.util.function.Function;
       @ElementTemplate.PropertyGroup(id = "downloadObject", label = "Download an object"),
     },
     documentationRef =
-        "https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/aws-s3/",
+        "https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-s3/",
     icon = "icon.svg")
 public class S3ConnectorFunction implements OutboundConnectorFunction {
 

--- a/connectors/http/graphql/element-templates/graphql-outbound-connector.json
+++ b/connectors/http/graphql/element-templates/graphql-outbound-connector.json
@@ -384,7 +384,7 @@
   }, {
     "id" : "graphql.query",
     "label" : "Query/Mutation",
-    "description" : "See <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/graphql/#querymutation\" target=\"_blank\">documentation</a>",
+    "description" : "See <a href=\"https://docs.camunda.io/docs/components/connectors/protocol/graphql/#querymutation\" target=\"_blank\">documentation</a>",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true

--- a/connectors/http/graphql/element-templates/hybrid/graphql-outbound-connector-hybrid.json
+++ b/connectors/http/graphql/element-templates/hybrid/graphql-outbound-connector-hybrid.json
@@ -389,7 +389,7 @@
   }, {
     "id" : "graphql.query",
     "label" : "Query/Mutation",
-    "description" : "See <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/graphql/#querymutation\" target=\"_blank\">documentation</a>",
+    "description" : "See <a href=\"https://docs.camunda.io/docs/components/connectors/protocol/graphql/#querymutation\" target=\"_blank\">documentation</a>",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true

--- a/connectors/http/graphql/src/main/java/io/camunda/connector/http/graphql/model/GraphQLRequest.java
+++ b/connectors/http/graphql/src/main/java/io/camunda/connector/http/graphql/model/GraphQLRequest.java
@@ -33,7 +33,7 @@ public record GraphQLRequest(@Valid GraphQL graphql, @Valid Authentication authe
               id = "query",
               label = "Query/Mutation",
               description =
-                  "See <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/graphql/#querymutation\" target=\"_blank\">documentation</a>",
+                  "See <a href=\"https://docs.camunda.io/docs/components/connectors/protocol/graphql/#querymutation\" target=\"_blank\">documentation</a>",
               type = TemplateProperty.PropertyType.Text,
               // TODO add support for language property supported by element templates: language:
               // graphql

--- a/connectors/operate/README.md
+++ b/connectors/operate/README.md
@@ -28,4 +28,4 @@ Note: basic authentication (username & password) is not supported.
 
 ## Operate API documentation
 
-Please refer to [Operate API documentation](https://docs.camunda.io/docs/apis-clients/operate-api/) for a complete overview of API entities and endpoints.
+Please refer to [Operate API documentation](https://docs.camunda.io/docs/apis-tools/operate-api/overview/) for a complete overview of API entities and endpoints.

--- a/connectors/operate/element-templates/operate-connector.json
+++ b/connectors/operate/element-templates/operate-connector.json
@@ -374,7 +374,7 @@
     },
     {
       "label": "Filter",
-      "description": "Search filter in <a href=\"https://docs.camunda.io/docs/apis-clients/operate-api/#filter\" target=\"_blank\">Operate format</a>",
+      "description": "Search filter in <a href=\"https://docs.camunda.io/docs/apis-tools/operate-api/specifications/search/\" target=\"_blank\">Operate format</a>",
       "group": "parameters",
       "type": "String",
       "feel": "required",
@@ -390,7 +390,7 @@
     },
     {
       "label": "Sort",
-      "description": "Sorting properties in <a href=\"https://docs.camunda.io/docs/apis-clients/operate-api/#sort\" target=\"_blank\">Operate format</a><br>Please provide a list of sort objects",
+      "description": "Sorting properties in <a href=\"https://docs.camunda.io/docs/apis-tools/operate-api/specifications/search\" target=\"_blank\">Operate format</a><br>Please provide a list of sort objects",
       "group": "parameters",
       "type": "String",
       "feel": "required",

--- a/connectors/twilio/element-templates/twilio-webhook-boundary-connector.json
+++ b/connectors/twilio/element-templates/twilio-webhook-boundary-connector.json
@@ -108,7 +108,7 @@
       "id": "shouldValidateHmac",
       "label": "HMAC authentication",
       "group": "endpoint",
-      "description": "Choose whether HMAC verification is enabled. <a href='https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/http-webhook/#make-your-http-webhook-connector-for-receiving-messages-executable' target='_blank'>See documentation</a> and <a href='https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/http-webhook/#example' target='_blank'>example</a> that explains how to use HMAC-related fields",
+      "description": "Choose whether HMAC verification is enabled. <a href='https://docs.camunda.io/docs/components/connectors/protocol/http-webhook/#make-your-http-webhook-connector-for-receiving-messages-executable' target='_blank'>See documentation</a> and <a href='https://docs.camunda.io/docs/components/connectors/protocol/http-webhook/#example' target='_blank'>example</a> that explains how to use HMAC-related fields",
       "value": "disabled",
       "type": "Dropdown",
       "choices": [

--- a/connectors/twilio/element-templates/twilio-webhook-connector.json
+++ b/connectors/twilio/element-templates/twilio-webhook-connector.json
@@ -101,7 +101,7 @@
       "id": "shouldValidateHmac",
       "label": "HMAC authentication",
       "group": "endpoint",
-      "description": "Choose whether HMAC verification is enabled. <a href='https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/http-webhook/#make-your-http-webhook-connector-for-receiving-messages-executable' target='_blank'>See documentation</a> and <a href='https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/http-webhook/#example' target='_blank'>example</a> that explains how to use HMAC-related fields",
+      "description": "Choose whether HMAC verification is enabled. <a href='https://docs.camunda.io/docs/components/connectors/protocol/http-webhook/#make-your-http-webhook-connector-for-receiving-messages-executable' target='_blank'>See documentation</a> and <a href='https://docs.camunda.io/docs/components/connectors/protocol/http-webhook/#example' target='_blank'>example</a> that explains how to use HMAC-related fields",
       "value": "disabled",
       "type": "Dropdown",
       "choices": [

--- a/connectors/twilio/element-templates/twilio-webhook-intermediate-connector.json
+++ b/connectors/twilio/element-templates/twilio-webhook-intermediate-connector.json
@@ -109,7 +109,7 @@
       "id": "shouldValidateHmac",
       "label": "HMAC authentication",
       "group": "endpoint",
-      "description": "Choose whether HMAC verification is enabled. <a href='https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/http-webhook/#make-your-http-webhook-connector-for-receiving-messages-executable' target='_blank'>See documentation</a> and <a href='https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/http-webhook/#example' target='_blank'>example</a> that explains how to use HMAC-related fields",
+      "description": "Choose whether HMAC verification is enabled. <a href='https://docs.camunda.io/docs/components/connectors/protocol/http-webhook/#make-your-http-webhook-connector-for-receiving-messages-executable' target='_blank'>See documentation</a> and <a href='https://docs.camunda.io/docs/components/connectors/protocol/http-webhook/#example' target='_blank'>example</a> that explains how to use HMAC-related fields",
       "value": "disabled",
       "type": "Dropdown",
       "choices": [

--- a/connectors/twilio/element-templates/twilio-webhook-message-start-connector.json
+++ b/connectors/twilio/element-templates/twilio-webhook-message-start-connector.json
@@ -116,7 +116,7 @@
       "id": "shouldValidateHmac",
       "label": "HMAC authentication",
       "group": "endpoint",
-      "description": "Choose whether HMAC verification is enabled. <a href='https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/http-webhook/#make-your-http-webhook-connector-for-receiving-messages-executable' target='_blank'>See documentation</a> and <a href='https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/http-webhook/#example' target='_blank'>example</a> that explains how to use HMAC-related fields",
+      "description": "Choose whether HMAC verification is enabled. <a href='https://docs.camunda.io/docs/components/connectors/protocol/http-webhook/#make-your-http-webhook-connector-for-receiving-messages-executable' target='_blank'>See documentation</a> and <a href='https://docs.camunda.io/docs/components/connectors/protocol/http-webhook/#example' target='_blank'>example</a> that explains how to use HMAC-related fields",
       "value": "disabled",
       "type": "Dropdown",
       "choices": [

--- a/connectors/webhook/element-templates/hybrid/webhook-connector-boundary-hybrid.json
+++ b/connectors/webhook/element-templates/hybrid/webhook-connector-boundary-hybrid.json
@@ -101,7 +101,7 @@
   }, {
     "id" : "inbound.shouldValidateHmac",
     "label" : "HMAC authentication",
-    "description" : "Choose whether HMAC verification is enabled. <a href='https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/http-webhook/#make-your-http-webhook-connector-for-receiving-messages-executable' target='_blank'>See documentation</a> and <a href='https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/http-webhook/#example' target='_blank'>example</a> that explains how to use HMAC-related fields",
+    "description" : "Choose whether HMAC verification is enabled. <a href='https://docs.camunda.io/docs/components/connectors/protocol/http-webhook/#make-your-http-webhook-connector-for-receiving-messages-executable' target='_blank'>See documentation</a> and <a href='https://docs.camunda.io/docs/components/connectors/protocol/http-webhook/#example' target='_blank'>example</a> that explains how to use HMAC-related fields",
     "optional" : false,
     "value" : "disabled",
     "group" : "authentication",
@@ -181,7 +181,7 @@
   }, {
     "id" : "inbound.hmacScopes",
     "label" : "HMAC scopes",
-    "description" : "Set HMAC scopes for calculating signature data. See <a href='https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/http-webhook/' target='_blank'>documentation</a>",
+    "description" : "Set HMAC scopes for calculating signature data. See <a href='https://docs.camunda.io/docs/components/connectors/protocol/http-webhook/' target='_blank'>documentation</a>",
     "optional" : true,
     "feel" : "required",
     "group" : "authentication",
@@ -273,7 +273,7 @@
   }, {
     "id" : "inbound.auth.apiKeyLocator",
     "label" : "API key locator",
-    "description" : "A FEEL expression that extracts API key from the request. <a href='https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/http-webhook/#how-to-configure-api-key-authorization'>See documentation</a>",
+    "description" : "A FEEL expression that extracts API key from the request. <a href='https://docs.camunda.io/docs/components/connectors/protocol/http-webhook/#how-to-configure-api-key-authorization'>See documentation</a>",
     "optional" : false,
     "value" : "=split(request.headers.authorization, \" \")[2]",
     "constraints" : {
@@ -311,7 +311,7 @@
   }, {
     "id" : "inbound.auth.jwt.permissionsExpression",
     "label" : "JWT role property expression",
-    "description" : "Expression to extract the roles from the JWT token. <a href='https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/http-webhook/#how-to-extract-roles-from-jwt-data'>See documentation</a>",
+    "description" : "Expression to extract the roles from the JWT token. <a href='https://docs.camunda.io/docs/components/connectors/protocol/http-webhook/#how-to-extract-roles-from-jwt-data'>See documentation</a>",
     "optional" : false,
     "feel" : "required",
     "group" : "authorization",

--- a/connectors/webhook/element-templates/hybrid/webhook-connector-intermediate-hybrid.json
+++ b/connectors/webhook/element-templates/hybrid/webhook-connector-intermediate-hybrid.json
@@ -101,7 +101,7 @@
   }, {
     "id" : "inbound.shouldValidateHmac",
     "label" : "HMAC authentication",
-    "description" : "Choose whether HMAC verification is enabled. <a href='https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/http-webhook/#make-your-http-webhook-connector-for-receiving-messages-executable' target='_blank'>See documentation</a> and <a href='https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/http-webhook/#example' target='_blank'>example</a> that explains how to use HMAC-related fields",
+    "description" : "Choose whether HMAC verification is enabled. <a href='https://docs.camunda.io/docs/components/connectors/protocol/http-webhook/#make-your-http-webhook-connector-for-receiving-messages-executable' target='_blank'>See documentation</a> and <a href='https://docs.camunda.io/docs/components/connectors/protocol/http-webhook/#example' target='_blank'>example</a> that explains how to use HMAC-related fields",
     "optional" : false,
     "value" : "disabled",
     "group" : "authentication",
@@ -181,7 +181,7 @@
   }, {
     "id" : "inbound.hmacScopes",
     "label" : "HMAC scopes",
-    "description" : "Set HMAC scopes for calculating signature data. See <a href='https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/http-webhook/' target='_blank'>documentation</a>",
+    "description" : "Set HMAC scopes for calculating signature data. See <a href='https://docs.camunda.io/docs/components/connectors/protocol/http-webhook/' target='_blank'>documentation</a>",
     "optional" : true,
     "feel" : "required",
     "group" : "authentication",
@@ -273,7 +273,7 @@
   }, {
     "id" : "inbound.auth.apiKeyLocator",
     "label" : "API key locator",
-    "description" : "A FEEL expression that extracts API key from the request. <a href='https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/http-webhook/#how-to-configure-api-key-authorization'>See documentation</a>",
+    "description" : "A FEEL expression that extracts API key from the request. <a href='https://docs.camunda.io/docs/components/connectors/protocol/http-webhook/#how-to-configure-api-key-authorization'>See documentation</a>",
     "optional" : false,
     "value" : "=split(request.headers.authorization, \" \")[2]",
     "constraints" : {
@@ -311,7 +311,7 @@
   }, {
     "id" : "inbound.auth.jwt.permissionsExpression",
     "label" : "JWT role property expression",
-    "description" : "Expression to extract the roles from the JWT token. <a href='https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/http-webhook/#how-to-extract-roles-from-jwt-data'>See documentation</a>",
+    "description" : "Expression to extract the roles from the JWT token. <a href='https://docs.camunda.io/docs/components/connectors/protocol/http-webhook/#how-to-extract-roles-from-jwt-data'>See documentation</a>",
     "optional" : false,
     "feel" : "required",
     "group" : "authorization",

--- a/connectors/webhook/element-templates/hybrid/webhook-connector-start-event-hybrid.json
+++ b/connectors/webhook/element-templates/hybrid/webhook-connector-start-event-hybrid.json
@@ -96,7 +96,7 @@
   }, {
     "id" : "inbound.shouldValidateHmac",
     "label" : "HMAC authentication",
-    "description" : "Choose whether HMAC verification is enabled. <a href='https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/http-webhook/#make-your-http-webhook-connector-for-receiving-messages-executable' target='_blank'>See documentation</a> and <a href='https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/http-webhook/#example' target='_blank'>example</a> that explains how to use HMAC-related fields",
+    "description" : "Choose whether HMAC verification is enabled. <a href='https://docs.camunda.io/docs/components/connectors/protocol/http-webhook/#make-your-http-webhook-connector-for-receiving-messages-executable' target='_blank'>See documentation</a> and <a href='https://docs.camunda.io/docs/components/connectors/protocol/http-webhook/#example' target='_blank'>example</a> that explains how to use HMAC-related fields",
     "optional" : false,
     "value" : "disabled",
     "group" : "authentication",
@@ -176,7 +176,7 @@
   }, {
     "id" : "inbound.hmacScopes",
     "label" : "HMAC scopes",
-    "description" : "Set HMAC scopes for calculating signature data. See <a href='https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/http-webhook/' target='_blank'>documentation</a>",
+    "description" : "Set HMAC scopes for calculating signature data. See <a href='https://docs.camunda.io/docs/components/connectors/protocol/http-webhook/' target='_blank'>documentation</a>",
     "optional" : true,
     "feel" : "required",
     "group" : "authentication",
@@ -268,7 +268,7 @@
   }, {
     "id" : "inbound.auth.apiKeyLocator",
     "label" : "API key locator",
-    "description" : "A FEEL expression that extracts API key from the request. <a href='https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/http-webhook/#how-to-configure-api-key-authorization'>See documentation</a>",
+    "description" : "A FEEL expression that extracts API key from the request. <a href='https://docs.camunda.io/docs/components/connectors/protocol/http-webhook/#how-to-configure-api-key-authorization'>See documentation</a>",
     "optional" : false,
     "value" : "=split(request.headers.authorization, \" \")[2]",
     "constraints" : {
@@ -306,7 +306,7 @@
   }, {
     "id" : "inbound.auth.jwt.permissionsExpression",
     "label" : "JWT role property expression",
-    "description" : "Expression to extract the roles from the JWT token. <a href='https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/http-webhook/#how-to-extract-roles-from-jwt-data'>See documentation</a>",
+    "description" : "Expression to extract the roles from the JWT token. <a href='https://docs.camunda.io/docs/components/connectors/protocol/http-webhook/#how-to-extract-roles-from-jwt-data'>See documentation</a>",
     "optional" : false,
     "feel" : "required",
     "group" : "authorization",

--- a/connectors/webhook/element-templates/hybrid/webhook-connector-start-message-hybrid.json
+++ b/connectors/webhook/element-templates/hybrid/webhook-connector-start-message-hybrid.json
@@ -101,7 +101,7 @@
   }, {
     "id" : "inbound.shouldValidateHmac",
     "label" : "HMAC authentication",
-    "description" : "Choose whether HMAC verification is enabled. <a href='https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/http-webhook/#make-your-http-webhook-connector-for-receiving-messages-executable' target='_blank'>See documentation</a> and <a href='https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/http-webhook/#example' target='_blank'>example</a> that explains how to use HMAC-related fields",
+    "description" : "Choose whether HMAC verification is enabled. <a href='https://docs.camunda.io/docs/components/connectors/protocol/http-webhook/#make-your-http-webhook-connector-for-receiving-messages-executable' target='_blank'>See documentation</a> and <a href='https://docs.camunda.io/docs/components/connectors/protocol/http-webhook/#example' target='_blank'>example</a> that explains how to use HMAC-related fields",
     "optional" : false,
     "value" : "disabled",
     "group" : "authentication",
@@ -181,7 +181,7 @@
   }, {
     "id" : "inbound.hmacScopes",
     "label" : "HMAC scopes",
-    "description" : "Set HMAC scopes for calculating signature data. See <a href='https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/http-webhook/' target='_blank'>documentation</a>",
+    "description" : "Set HMAC scopes for calculating signature data. See <a href='https://docs.camunda.io/docs/components/connectors/protocol/http-webhook/' target='_blank'>documentation</a>",
     "optional" : true,
     "feel" : "required",
     "group" : "authentication",
@@ -273,7 +273,7 @@
   }, {
     "id" : "inbound.auth.apiKeyLocator",
     "label" : "API key locator",
-    "description" : "A FEEL expression that extracts API key from the request. <a href='https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/http-webhook/#how-to-configure-api-key-authorization'>See documentation</a>",
+    "description" : "A FEEL expression that extracts API key from the request. <a href='https://docs.camunda.io/docs/components/connectors/protocol/http-webhook/#how-to-configure-api-key-authorization'>See documentation</a>",
     "optional" : false,
     "value" : "=split(request.headers.authorization, \" \")[2]",
     "constraints" : {
@@ -311,7 +311,7 @@
   }, {
     "id" : "inbound.auth.jwt.permissionsExpression",
     "label" : "JWT role property expression",
-    "description" : "Expression to extract the roles from the JWT token. <a href='https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/http-webhook/#how-to-extract-roles-from-jwt-data'>See documentation</a>",
+    "description" : "Expression to extract the roles from the JWT token. <a href='https://docs.camunda.io/docs/components/connectors/protocol/http-webhook/#how-to-extract-roles-from-jwt-data'>See documentation</a>",
     "optional" : false,
     "feel" : "required",
     "group" : "authorization",

--- a/connectors/webhook/element-templates/webhook-connector-boundary.json
+++ b/connectors/webhook/element-templates/webhook-connector-boundary.json
@@ -96,7 +96,7 @@
   }, {
     "id" : "inbound.shouldValidateHmac",
     "label" : "HMAC authentication",
-    "description" : "Choose whether HMAC verification is enabled. <a href='https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/http-webhook/#make-your-http-webhook-connector-for-receiving-messages-executable' target='_blank'>See documentation</a> and <a href='https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/http-webhook/#example' target='_blank'>example</a> that explains how to use HMAC-related fields",
+    "description" : "Choose whether HMAC verification is enabled. <a href='https://docs.camunda.io/docs/components/connectors/protocol/http-webhook/#make-your-http-webhook-connector-for-receiving-messages-executable' target='_blank'>See documentation</a> and <a href='https://docs.camunda.io/docs/components/connectors/protocol/http-webhook/#example' target='_blank'>example</a> that explains how to use HMAC-related fields",
     "optional" : false,
     "value" : "disabled",
     "group" : "authentication",
@@ -176,7 +176,7 @@
   }, {
     "id" : "inbound.hmacScopes",
     "label" : "HMAC scopes",
-    "description" : "Set HMAC scopes for calculating signature data. See <a href='https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/http-webhook/' target='_blank'>documentation</a>",
+    "description" : "Set HMAC scopes for calculating signature data. See <a href='https://docs.camunda.io/docs/components/connectors/protocol/http-webhook/' target='_blank'>documentation</a>",
     "optional" : true,
     "feel" : "required",
     "group" : "authentication",
@@ -268,7 +268,7 @@
   }, {
     "id" : "inbound.auth.apiKeyLocator",
     "label" : "API key locator",
-    "description" : "A FEEL expression that extracts API key from the request. <a href='https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/http-webhook/#how-to-configure-api-key-authorization'>See documentation</a>",
+    "description" : "A FEEL expression that extracts API key from the request. <a href='https://docs.camunda.io/docs/components/connectors/protocol/http-webhook/#how-to-configure-api-key-authorization'>See documentation</a>",
     "optional" : false,
     "value" : "=split(request.headers.authorization, \" \")[2]",
     "constraints" : {
@@ -306,7 +306,7 @@
   }, {
     "id" : "inbound.auth.jwt.permissionsExpression",
     "label" : "JWT role property expression",
-    "description" : "Expression to extract the roles from the JWT token. <a href='https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/http-webhook/#how-to-extract-roles-from-jwt-data'>See documentation</a>",
+    "description" : "Expression to extract the roles from the JWT token. <a href='https://docs.camunda.io/docs/components/connectors/protocol/http-webhook/#how-to-extract-roles-from-jwt-data'>See documentation</a>",
     "optional" : false,
     "feel" : "required",
     "group" : "authorization",

--- a/connectors/webhook/element-templates/webhook-connector-intermediate.json
+++ b/connectors/webhook/element-templates/webhook-connector-intermediate.json
@@ -96,7 +96,7 @@
   }, {
     "id" : "inbound.shouldValidateHmac",
     "label" : "HMAC authentication",
-    "description" : "Choose whether HMAC verification is enabled. <a href='https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/http-webhook/#make-your-http-webhook-connector-for-receiving-messages-executable' target='_blank'>See documentation</a> and <a href='https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/http-webhook/#example' target='_blank'>example</a> that explains how to use HMAC-related fields",
+    "description" : "Choose whether HMAC verification is enabled. <a href='https://docs.camunda.io/docs/components/connectors/protocol/http-webhook/#make-your-http-webhook-connector-for-receiving-messages-executable' target='_blank'>See documentation</a> and <a href='https://docs.camunda.io/docs/components/connectors/protocol/http-webhook/#example' target='_blank'>example</a> that explains how to use HMAC-related fields",
     "optional" : false,
     "value" : "disabled",
     "group" : "authentication",
@@ -176,7 +176,7 @@
   }, {
     "id" : "inbound.hmacScopes",
     "label" : "HMAC scopes",
-    "description" : "Set HMAC scopes for calculating signature data. See <a href='https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/http-webhook/' target='_blank'>documentation</a>",
+    "description" : "Set HMAC scopes for calculating signature data. See <a href='https://docs.camunda.io/docs/components/connectors/protocol/http-webhook/' target='_blank'>documentation</a>",
     "optional" : true,
     "feel" : "required",
     "group" : "authentication",
@@ -268,7 +268,7 @@
   }, {
     "id" : "inbound.auth.apiKeyLocator",
     "label" : "API key locator",
-    "description" : "A FEEL expression that extracts API key from the request. <a href='https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/http-webhook/#how-to-configure-api-key-authorization'>See documentation</a>",
+    "description" : "A FEEL expression that extracts API key from the request. <a href='https://docs.camunda.io/docs/components/connectors/protocol/http-webhook/#how-to-configure-api-key-authorization'>See documentation</a>",
     "optional" : false,
     "value" : "=split(request.headers.authorization, \" \")[2]",
     "constraints" : {
@@ -306,7 +306,7 @@
   }, {
     "id" : "inbound.auth.jwt.permissionsExpression",
     "label" : "JWT role property expression",
-    "description" : "Expression to extract the roles from the JWT token. <a href='https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/http-webhook/#how-to-extract-roles-from-jwt-data'>See documentation</a>",
+    "description" : "Expression to extract the roles from the JWT token. <a href='https://docs.camunda.io/docs/components/connectors/protocol/http-webhook/#how-to-extract-roles-from-jwt-data'>See documentation</a>",
     "optional" : false,
     "feel" : "required",
     "group" : "authorization",

--- a/connectors/webhook/element-templates/webhook-connector-start-event.json
+++ b/connectors/webhook/element-templates/webhook-connector-start-event.json
@@ -91,7 +91,7 @@
   }, {
     "id" : "inbound.shouldValidateHmac",
     "label" : "HMAC authentication",
-    "description" : "Choose whether HMAC verification is enabled. <a href='https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/http-webhook/#make-your-http-webhook-connector-for-receiving-messages-executable' target='_blank'>See documentation</a> and <a href='https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/http-webhook/#example' target='_blank'>example</a> that explains how to use HMAC-related fields",
+    "description" : "Choose whether HMAC verification is enabled. <a href='https://docs.camunda.io/docs/components/connectors/protocol/http-webhook/#make-your-http-webhook-connector-for-receiving-messages-executable' target='_blank'>See documentation</a> and <a href='https://docs.camunda.io/docs/components/connectors/protocol/http-webhook/#example' target='_blank'>example</a> that explains how to use HMAC-related fields",
     "optional" : false,
     "value" : "disabled",
     "group" : "authentication",
@@ -171,7 +171,7 @@
   }, {
     "id" : "inbound.hmacScopes",
     "label" : "HMAC scopes",
-    "description" : "Set HMAC scopes for calculating signature data. See <a href='https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/http-webhook/' target='_blank'>documentation</a>",
+    "description" : "Set HMAC scopes for calculating signature data. See <a href='https://docs.camunda.io/docs/components/connectors/protocol/http-webhook/' target='_blank'>documentation</a>",
     "optional" : true,
     "feel" : "required",
     "group" : "authentication",
@@ -263,7 +263,7 @@
   }, {
     "id" : "inbound.auth.apiKeyLocator",
     "label" : "API key locator",
-    "description" : "A FEEL expression that extracts API key from the request. <a href='https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/http-webhook/#how-to-configure-api-key-authorization'>See documentation</a>",
+    "description" : "A FEEL expression that extracts API key from the request. <a href='https://docs.camunda.io/docs/components/connectors/protocol/http-webhook/#how-to-configure-api-key-authorization'>See documentation</a>",
     "optional" : false,
     "value" : "=split(request.headers.authorization, \" \")[2]",
     "constraints" : {
@@ -301,7 +301,7 @@
   }, {
     "id" : "inbound.auth.jwt.permissionsExpression",
     "label" : "JWT role property expression",
-    "description" : "Expression to extract the roles from the JWT token. <a href='https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/http-webhook/#how-to-extract-roles-from-jwt-data'>See documentation</a>",
+    "description" : "Expression to extract the roles from the JWT token. <a href='https://docs.camunda.io/docs/components/connectors/protocol/http-webhook/#how-to-extract-roles-from-jwt-data'>See documentation</a>",
     "optional" : false,
     "feel" : "required",
     "group" : "authorization",

--- a/connectors/webhook/element-templates/webhook-connector-start-message.json
+++ b/connectors/webhook/element-templates/webhook-connector-start-message.json
@@ -96,7 +96,7 @@
   }, {
     "id" : "inbound.shouldValidateHmac",
     "label" : "HMAC authentication",
-    "description" : "Choose whether HMAC verification is enabled. <a href='https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/http-webhook/#make-your-http-webhook-connector-for-receiving-messages-executable' target='_blank'>See documentation</a> and <a href='https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/http-webhook/#example' target='_blank'>example</a> that explains how to use HMAC-related fields",
+    "description" : "Choose whether HMAC verification is enabled. <a href='https://docs.camunda.io/docs/components/connectors/protocol/http-webhook/#make-your-http-webhook-connector-for-receiving-messages-executable' target='_blank'>See documentation</a> and <a href='https://docs.camunda.io/docs/components/connectors/protocol/http-webhook/#example' target='_blank'>example</a> that explains how to use HMAC-related fields",
     "optional" : false,
     "value" : "disabled",
     "group" : "authentication",
@@ -176,7 +176,7 @@
   }, {
     "id" : "inbound.hmacScopes",
     "label" : "HMAC scopes",
-    "description" : "Set HMAC scopes for calculating signature data. See <a href='https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/http-webhook/' target='_blank'>documentation</a>",
+    "description" : "Set HMAC scopes for calculating signature data. See <a href='https://docs.camunda.io/docs/components/connectors/protocol/http-webhook/' target='_blank'>documentation</a>",
     "optional" : true,
     "feel" : "required",
     "group" : "authentication",
@@ -268,7 +268,7 @@
   }, {
     "id" : "inbound.auth.apiKeyLocator",
     "label" : "API key locator",
-    "description" : "A FEEL expression that extracts API key from the request. <a href='https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/http-webhook/#how-to-configure-api-key-authorization'>See documentation</a>",
+    "description" : "A FEEL expression that extracts API key from the request. <a href='https://docs.camunda.io/docs/components/connectors/protocol/http-webhook/#how-to-configure-api-key-authorization'>See documentation</a>",
     "optional" : false,
     "value" : "=split(request.headers.authorization, \" \")[2]",
     "constraints" : {
@@ -306,7 +306,7 @@
   }, {
     "id" : "inbound.auth.jwt.permissionsExpression",
     "label" : "JWT role property expression",
-    "description" : "Expression to extract the roles from the JWT token. <a href='https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/http-webhook/#how-to-extract-roles-from-jwt-data'>See documentation</a>",
+    "description" : "Expression to extract the roles from the JWT token. <a href='https://docs.camunda.io/docs/components/connectors/protocol/http-webhook/#how-to-extract-roles-from-jwt-data'>See documentation</a>",
     "optional" : false,
     "feel" : "required",
     "group" : "authorization",

--- a/connectors/webhook/src/main/java/io/camunda/connector/inbound/model/JWTProperties.java
+++ b/connectors/webhook/src/main/java/io/camunda/connector/inbound/model/JWTProperties.java
@@ -24,7 +24,7 @@ public record JWTProperties(
     @TemplateProperty(
             label = "JWT role property expression",
             description =
-                "Expression to extract the roles from the JWT token. <a href='https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/http-webhook/#how-to-extract-roles-from-jwt-data'>See documentation</a>",
+                "Expression to extract the roles from the JWT token. <a href='https://docs.camunda.io/docs/components/connectors/protocol/http-webhook/#how-to-extract-roles-from-jwt-data'>See documentation</a>",
             group = "authorization",
             feel = FeelMode.required)
         Function<Object, List<String>> permissionsExpression,

--- a/connectors/webhook/src/main/java/io/camunda/connector/inbound/model/WebhookAuthorization.java
+++ b/connectors/webhook/src/main/java/io/camunda/connector/inbound/model/WebhookAuthorization.java
@@ -73,7 +73,7 @@ public sealed interface WebhookAuthorization permits None, BasicAuth, ApiKeyAuth
       @TemplateProperty(
               label = "API key locator",
               description =
-                  "A FEEL expression that extracts API key from the request. <a href='https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/http-webhook/#how-to-configure-api-key-authorization'>See documentation</a>",
+                  "A FEEL expression that extracts API key from the request. <a href='https://docs.camunda.io/docs/components/connectors/protocol/http-webhook/#how-to-configure-api-key-authorization'>See documentation</a>",
               group = "authorization",
               feel = FeelMode.required,
               defaultValue = "=split(request.headers.authorization, \" \")[2]")

--- a/connectors/webhook/src/main/java/io/camunda/connector/inbound/model/WebhookConnectorProperties.java
+++ b/connectors/webhook/src/main/java/io/camunda/connector/inbound/model/WebhookConnectorProperties.java
@@ -54,7 +54,7 @@ public record WebhookConnectorProperties(
             label = "HMAC authentication",
             group = "authentication",
             description =
-                "Choose whether HMAC verification is enabled. <a href='https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/http-webhook/#make-your-http-webhook-connector-for-receiving-messages-executable' target='_blank'>See documentation</a> and <a href='https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/http-webhook/#example' target='_blank'>example</a> that explains how to use HMAC-related fields",
+                "Choose whether HMAC verification is enabled. <a href='https://docs.camunda.io/docs/components/connectors/protocol/http-webhook/#make-your-http-webhook-connector-for-receiving-messages-executable' target='_blank'>See documentation</a> and <a href='https://docs.camunda.io/docs/components/connectors/protocol/http-webhook/#example' target='_blank'>example</a> that explains how to use HMAC-related fields",
             defaultValue = "disabled",
             type = PropertyType.Dropdown,
             choices = {
@@ -102,7 +102,7 @@ public record WebhookConnectorProperties(
             label = "HMAC scopes",
             group = "authentication",
             description =
-                "Set HMAC scopes for calculating signature data. See <a href='https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/http-webhook/' target='_blank'>documentation</a>",
+                "Set HMAC scopes for calculating signature data. See <a href='https://docs.camunda.io/docs/components/connectors/protocol/http-webhook/' target='_blank'>documentation</a>",
             optional = true,
             type = PropertyType.String,
             feel = FeelMode.required,


### PR DESCRIPTION
## Description
- Fix broken docs links in element templates
- Some links are still broken, because they refer to newer versions of the docs. These are the links for s3, box and gemini connectors, that are not in the docs of version 8.6. They will work as soon as newer versions become the default.
- related issue: https://github.com/camunda/camunda-docs/pull/4992 there I created a new script that checks all element templates for broken links.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes https://github.com/camunda/camunda-docs/issues/4995

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.

