### PR TITLE
other(CI): do not execute maven release job if it is an RC release

### DIFF
--- a/.github/workflows/RELEASE.yaml
+++ b/.github/workflows/RELEASE.yaml
@@ -86,6 +86,7 @@ jobs:
           include-hidden-files: 'true'
 
   maven-release:
+    if: "! contains(github.event.release.tag_name, 'rc')"
     needs: setup
     runs-on: ubuntu-latest
     steps:
@@ -333,6 +334,7 @@ jobs:
           # https://github.com/actions/checkout/issues/13#issuecomment-724415212
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config core.filemode false
 
       - name: Commit and tag
         run: |

--- a/.github/workflows/RELEASE.yaml
+++ b/.github/workflows/RELEASE.yaml
@@ -14,28 +14,8 @@ jobs:
       releaseBranch: ${{ steps.determine_release_branch.outputs.releaseBranch }}
       previousTag: ${{ steps.validate_tag.outputs.previousTag }}
     steps:
-      - name: Import Secrets
-        id: vault-secrets
-        uses: hashicorp/vault-action@v3.0.0
-        with:
-          url: ${{ secrets.VAULT_ADDR }}
-          method: approle
-          roleId: ${{ secrets.VAULT_ROLE_ID }}
-          secretId: ${{ secrets.VAULT_SECRET_ID}}
-          secrets: |
-            secret/data/products/connectors/ci/common GITHUB_APP_ID;
-            secret/data/products/connectors/ci/common GITHUB_APP_PRIVATE_KEY;
-
-      - name: Generate a GitHub token for connectors
-        id: app-token
-        uses: actions/create-github-app-token@v1
-        with:
-          app-id: ${{ steps.vault-secrets.outputs.GITHUB_APP_ID }}
-          private-key: ${{ steps.vault-secrets.outputs.GITHUB_APP_PRIVATE_KEY }}
-
       - uses: actions/checkout@v4
         with:
-          token: ${{ steps.app-token.outputs.token }}
           ref: ${{ github.event.release.target_commitish }}
           fetch-depth: 0
 
@@ -72,11 +52,46 @@ jobs:
           distribution: 'temurin'
           java-version: '21'
 
+      - name: Restore cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+
       - name: Install element templates CLI
         run: npm install --global element-templates-cli
 
+      # Maven build & version bump
+      - name: Set Connectors release version
+        run: mvn -B versions:set -DnewVersion=${RELEASE_VERSION} -DgenerateBackupPoms=false -f parent
+        env:
+          RELEASE_VERSION: ${{ github.event.release.tag_name }}
+
       - name: Compile and Test
-        run: mvn clean install
+        run: mvn -B -q package generate-sources source:jar javadoc:jar -DskipTests
+
+      - name: Generate sbom reports
+        run: |
+          mvn cyclonedx:makeAggregateBom -pl bundle/default-bundle
+
+      - name: Configure git user
+        run: |
+          # https://github.com/actions/checkout/issues/13#issuecomment-724415212
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config core.filemode false
+
+      - name: Commit and tag
+        run: |
+          git commit -am "ci: release version ${RELEASE_VERSION}"
+          git push --force-with-lease origin ${RELEASE_BRANCH}
+          git tag -fa ${RELEASE_VERSION} -m "ci: release version ${RELEASE_VERSION}"
+          git push --force origin ${RELEASE_VERSION}
+        env:
+          RELEASE_VERSION: ${{ github.event.release.tag_name }}
+          RELEASE_BRANCH: ${{ needs.setup.outputs.releaseBranch }}
 
       - name: Upload repository
         uses: actions/upload-artifact@v4
@@ -125,14 +140,6 @@ jobs:
           gpg_private_key: ${{ steps.secrets.outputs.MAVEN_CENTRAL_GPG_SIGNING_KEY_SEC }}
           passphrase: ${{ steps.secrets.outputs.MAVEN_CENTRAL_GPG_SIGNING_KEY_PASSPHRASE }}
 
-      - name: Restore cache
-        uses: actions/cache@v4
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
-
       - name: 'Create settings.xml'
         uses: s4u/maven-settings-action@v3.1.0
         with:
@@ -151,34 +158,22 @@ jobs:
             ]
           mirrors: '[{"url": "https://repository.nexus.camunda.cloud/content/groups/internal/", "id": "camunda-nexus", "mirrorOf": "camunda-nexus", "name": "camunda Nexus"}]'
 
-      - name: Configure git user
-        run: |
-          # https://github.com/actions/checkout/issues/13#issuecomment-724415212
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-
-      - name: Install element templates CLI
-        run: npm install --global element-templates-cli
-
-      # Maven build & version bump
-
-      - name: Set Connectors release version
-        run: mvn -B versions:set -DnewVersion=${RELEASE_VERSION} -DgenerateBackupPoms=false -f parent
-        env:
-          RELEASE_VERSION: ${{ github.event.release.tag_name }}
+      - name: Restore cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
 
       - name: Deploy artifacts to Artifactory and Maven Central (Staging)
-        run: mvn -B -q compile generate-sources source:jar javadoc:jar deploy -PcheckFormat -Psonatype-oss-release
+        run: mvn deploy -DskipTests -PcheckFormat -Psonatype-oss-release
         env:
           NEXUS_USR: ${{ steps.secrets.outputs.ARTIFACTORY_USR }}
           NEXUS_PSW: ${{ steps.secrets.outputs.ARTIFACTORY_PSW }}
           MAVEN_USR: ${{ steps.secrets.outputs.MAVEN_CENTRAL_DEPLOYMENT_USR }}
           MAVEN_PSW: ${{ steps.secrets.outputs.MAVEN_CENTRAL_DEPLOYMENT_PSW }}
           MAVEN_GPG_PASSPHRASE: ${{ steps.secrets.outputs.MAVEN_CENTRAL_GPG_SIGNING_KEY_PASSPHRASE }}
-
-      - name: Generate sbom reports
-        run: |
-          mvn cyclonedx:makeAggregateBom -pl bundle/default-bundle
 
   docker-release:
     needs: setup
@@ -303,7 +298,7 @@ jobs:
           short_description: 'Camunda out-of-the-box Connectors Bundle for SaaS'
 
   bundle-and-build-changelog:
-    needs: [ setup, maven-release, docker-release ]
+    needs: setup
     name: Bundle and generate changelogs
     runs-on: ubuntu-latest
     steps:
@@ -328,23 +323,6 @@ jobs:
           writeToFile: false
           excludeTypes: build,docs,other,style,ci
           excludeScopes: deps
-
-      - name: Configure git user
-        run: |
-          # https://github.com/actions/checkout/issues/13#issuecomment-724415212
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git config core.filemode false
-
-      - name: Commit and tag
-        run: |
-          git commit -am "ci: release version ${RELEASE_VERSION}"
-          git push --force-with-lease origin ${RELEASE_BRANCH}
-          git tag -fa ${RELEASE_VERSION} -m "ci: release version ${RELEASE_VERSION}"
-          git push --force origin ${RELEASE_VERSION}
-        env:
-          RELEASE_VERSION: ${{ github.event.release.tag_name }}
-          RELEASE_BRANCH: ${{ needs.setup.outputs.releaseBranch }}
 
       - name: Update GitHub Release
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/RELEASE.yaml
+++ b/.github/workflows/RELEASE.yaml
@@ -6,6 +6,7 @@ on:
     types: [ created ]
 
 jobs:
+
   setup:
     name: Prepare the repository
     runs-on: ubuntu-latest
@@ -70,7 +71,7 @@ jobs:
           RELEASE_VERSION: ${{ github.event.release.tag_name }}
 
       - name: Compile and Test
-        run: mvn -B -q package generate-sources source:jar javadoc:jar -DskipTests
+        run: mvn -B package generate-sources source:jar javadoc:jar
 
       - name: Generate sbom reports
         run: |
@@ -81,7 +82,6 @@ jobs:
           # https://github.com/actions/checkout/issues/13#issuecomment-724415212
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git config core.filemode false
 
       - name: Commit and tag
         run: |
@@ -103,6 +103,7 @@ jobs:
   maven-release:
     if: "! contains(github.event.release.tag_name, 'rc')"
     needs: setup
+    name: Create a maven release
     runs-on: ubuntu-latest
     steps:
       - name: Download repository
@@ -178,6 +179,7 @@ jobs:
   docker-release:
     needs: setup
     runs-on: ubuntu-latest
+    name: Perform the docker release
     steps:
       - name: Download repository
         uses: actions/download-artifact@v4
@@ -335,6 +337,7 @@ jobs:
             bundle/default-bundle/target/connectors-bundle-sbom.xml
             connectors-bundle-templates-${{ github.event.release.tag_name }}.tar.gz
             connectors-bundle-templates-${{ github.event.release.tag_name }}.zip
+
 
   helm-deploy:
     needs: [setup, docker-release]


### PR DESCRIPTION
## Description

There is no need to execute the `maven release` job when releasing an RC, this PR fixes this

I also added `git config core.filemode false` because I had this weird [commit](https://github.com/camunda/connectors/commit/c49cb7421cef5e67034243f95550e78402c046ca) while trying to release

## Related issues

closes #https://github.com/camunda/team-connectors/issues/933

## Checklist

- [ ] PR has a **milestone** or the `no milestone` label.

