### PR TITLE
chore(tests): fix tests on main after camunda client changes

### DIFF
--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/main/java/io/camunda/connector/runtime/OutboundConnectorsAutoConfiguration.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/main/java/io/camunda/connector/runtime/OutboundConnectorsAutoConfiguration.java
@@ -17,7 +17,6 @@
 package io.camunda.connector.runtime;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.camunda.client.api.JsonMapper;
 import io.camunda.client.impl.CamundaObjectMapper;
 import io.camunda.connector.api.json.ConnectorsObjectMapperSupplier;
 import io.camunda.connector.api.secret.SecretProvider;
@@ -94,19 +93,10 @@ public class OutboundConnectorsAutoConfiguration {
     return new SecretProviderAggregator(secretProviders);
   }
 
-  @Bean(name = "zeebeJsonMapper")
+  @Bean(name = "camundaJsonMapper")
   @ConditionalOnMissingBean
   public CamundaObjectMapper jsonMapper() {
     return new CamundaObjectMapper(ConnectorsObjectMapperSupplier.getCopy());
-  }
-
-  @Bean(name = "commonJsonMapper")
-  @ConditionalOnMissingBean
-  public JsonMapper commonJsonMapper(ObjectMapper objectMapper) {
-    if (objectMapper == null) {
-      return new CamundaObjectMapper();
-    }
-    return new CamundaObjectMapper(objectMapper.copy());
   }
 
   @Bean

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/ObjectMapperSerializationTest.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/ObjectMapperSerializationTest.java
@@ -60,8 +60,8 @@ public class ObjectMapperSerializationTest {
     assertNotEquals(objectMapper, objectMapperOfJsonMapper);
 
     assertThat(jsonMapperBeans.size()).isEqualTo(1);
-    assertThat(jsonMapperBeans.containsKey("zeebeJsonMapper")).isTrue();
-    assertThat(jsonMapperBeans.get("zeebeJsonMapper")).isSameAs(jsonMapper);
+    assertThat(jsonMapperBeans.containsKey("camundaJsonMapper")).isTrue();
+    assertThat(jsonMapperBeans.get("camundaJsonMapper")).isSameAs(jsonMapper);
 
     assertThat(objectMapper).isNotNull();
     assertThat(objectMapper).isInstanceOf(ObjectMapper.class);


### PR DESCRIPTION
## Description

The latest camunda-java-client snapshot has changed the name of the bean to `zeebeJsonMapper` to `camundaJsonMapper`

Additionally, I removed the `commonJsonMapper` which is useless since we separated the serializer and deserializer

- To create `CamundaDocumentStore` we use the `CamundaClient` containing the `JsonMapper` containing only the Serializer (The Basic one), the client does not need the deserializer anyways
- To create the  `DocumentFactory` we use the `CamundaDocumentStore` : no problems here
- To create OUR objectMapper for connectors, we use this `DocumentFactory` : no issues again

This simplifies everything and fixes the current issue

## Related issues

<!-- Which issues are closed by this PR or are related -->

Fixing main tests

## Checklist

- [ ] PR has a **milestone** or the `no milestone` label.

