### PR TITLE
chore(ci-release): Backport release changes from `release/8.8` to `main`

### DIFF
--- a/.github/workflows/RELEASE.yaml
+++ b/.github/workflows/RELEASE.yaml
@@ -86,6 +86,7 @@ jobs:
           include-hidden-files: 'true'
 
   maven-release:
+    if: "! contains(github.event.release.tag_name, 'rc')"
     needs: setup
     runs-on: ubuntu-latest
     steps:
@@ -333,6 +334,7 @@ jobs:
           # https://github.com/actions/checkout/issues/13#issuecomment-724415212
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config core.filemode false
 
       - name: Commit and tag
         run: |

--- a/.github/workflows/RELEASE.yaml
+++ b/.github/workflows/RELEASE.yaml
@@ -72,6 +72,9 @@ jobs:
           distribution: 'temurin'
           java-version: '21'
 
+      - name: Install element templates CLI
+        run: npm install --global element-templates-cli
+
       - name: Compile and Test
         run: mvn clean install
 

--- a/.github/workflows/RELEASE.yaml
+++ b/.github/workflows/RELEASE.yaml
@@ -14,28 +14,8 @@ jobs:
       releaseBranch: ${{ steps.determine_release_branch.outputs.releaseBranch }}
       previousTag: ${{ steps.validate_tag.outputs.previousTag }}
     steps:
-      - name: Import Secrets
-        id: vault-secrets
-        uses: hashicorp/vault-action@v3.0.0
-        with:
-          url: ${{ secrets.VAULT_ADDR }}
-          method: approle
-          roleId: ${{ secrets.VAULT_ROLE_ID }}
-          secretId: ${{ secrets.VAULT_SECRET_ID}}
-          secrets: |
-            secret/data/products/connectors/ci/common GITHUB_APP_ID;
-            secret/data/products/connectors/ci/common GITHUB_APP_PRIVATE_KEY;
-
-      - name: Generate a GitHub token for connectors
-        id: app-token
-        uses: actions/create-github-app-token@v1
-        with:
-          app-id: ${{ steps.vault-secrets.outputs.GITHUB_APP_ID }}
-          private-key: ${{ steps.vault-secrets.outputs.GITHUB_APP_PRIVATE_KEY }}
-
       - uses: actions/checkout@v4
         with:
-          token: ${{ steps.app-token.outputs.token }}
           ref: ${{ github.event.release.target_commitish }}
           fetch-depth: 0
 
@@ -72,11 +52,46 @@ jobs:
           distribution: 'temurin'
           java-version: '21'
 
+      - name: Restore cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+
       - name: Install element templates CLI
         run: npm install --global element-templates-cli
 
+      # Maven build & version bump
+      - name: Set Connectors release version
+        run: mvn -B versions:set -DnewVersion=${RELEASE_VERSION} -DgenerateBackupPoms=false -f parent
+        env:
+          RELEASE_VERSION: ${{ github.event.release.tag_name }}
+
       - name: Compile and Test
-        run: mvn clean install
+        run: mvn -B -q package generate-sources source:jar javadoc:jar -DskipTests
+
+      - name: Generate sbom reports
+        run: |
+          mvn cyclonedx:makeAggregateBom -pl bundle/default-bundle
+
+      - name: Configure git user
+        run: |
+          # https://github.com/actions/checkout/issues/13#issuecomment-724415212
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config core.filemode false
+
+      - name: Commit and tag
+        run: |
+          git commit -am "ci: release version ${RELEASE_VERSION}"
+          git push --force-with-lease origin ${RELEASE_BRANCH}
+          git tag -fa ${RELEASE_VERSION} -m "ci: release version ${RELEASE_VERSION}"
+          git push --force origin ${RELEASE_VERSION}
+        env:
+          RELEASE_VERSION: ${{ github.event.release.tag_name }}
+          RELEASE_BRANCH: ${{ needs.setup.outputs.releaseBranch }}
 
       - name: Upload repository
         uses: actions/upload-artifact@v4
@@ -125,14 +140,6 @@ jobs:
           gpg_private_key: ${{ steps.secrets.outputs.MAVEN_CENTRAL_GPG_SIGNING_KEY_SEC }}
           passphrase: ${{ steps.secrets.outputs.MAVEN_CENTRAL_GPG_SIGNING_KEY_PASSPHRASE }}
 
-      - name: Restore cache
-        uses: actions/cache@v4
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
-
       - name: 'Create settings.xml'
         uses: s4u/maven-settings-action@v3.1.0
         with:
@@ -151,34 +158,22 @@ jobs:
             ]
           mirrors: '[{"url": "https://repository.nexus.camunda.cloud/content/groups/internal/", "id": "camunda-nexus", "mirrorOf": "camunda-nexus", "name": "camunda Nexus"}]'
 
-      - name: Configure git user
-        run: |
-          # https://github.com/actions/checkout/issues/13#issuecomment-724415212
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-
-      - name: Install element templates CLI
-        run: npm install --global element-templates-cli
-
-      # Maven build & version bump
-
-      - name: Set Connectors release version
-        run: mvn -B versions:set -DnewVersion=${RELEASE_VERSION} -DgenerateBackupPoms=false -f parent
-        env:
-          RELEASE_VERSION: ${{ github.event.release.tag_name }}
+      - name: Restore cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
 
       - name: Deploy artifacts to Artifactory and Maven Central (Staging)
-        run: mvn -B -q compile generate-sources source:jar javadoc:jar deploy -PcheckFormat -Psonatype-oss-release
+        run: mvn deploy -DskipTests -PcheckFormat -Psonatype-oss-release
         env:
           NEXUS_USR: ${{ steps.secrets.outputs.ARTIFACTORY_USR }}
           NEXUS_PSW: ${{ steps.secrets.outputs.ARTIFACTORY_PSW }}
           MAVEN_USR: ${{ steps.secrets.outputs.MAVEN_CENTRAL_DEPLOYMENT_USR }}
           MAVEN_PSW: ${{ steps.secrets.outputs.MAVEN_CENTRAL_DEPLOYMENT_PSW }}
           MAVEN_GPG_PASSPHRASE: ${{ steps.secrets.outputs.MAVEN_CENTRAL_GPG_SIGNING_KEY_PASSPHRASE }}
-
-      - name: Generate sbom reports
-        run: |
-          mvn cyclonedx:makeAggregateBom -pl bundle/default-bundle
 
   docker-release:
     needs: setup
@@ -303,7 +298,7 @@ jobs:
           short_description: 'Camunda out-of-the-box Connectors Bundle for SaaS'
 
   bundle-and-build-changelog:
-    needs: [ setup, maven-release, docker-release ]
+    needs: setup
     name: Bundle and generate changelogs
     runs-on: ubuntu-latest
     steps:
@@ -328,23 +323,6 @@ jobs:
           writeToFile: false
           excludeTypes: build,docs,other,style,ci
           excludeScopes: deps
-
-      - name: Configure git user
-        run: |
-          # https://github.com/actions/checkout/issues/13#issuecomment-724415212
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git config core.filemode false
-
-      - name: Commit and tag
-        run: |
-          git commit -am "ci: release version ${RELEASE_VERSION}"
-          git push --force-with-lease origin ${RELEASE_BRANCH}
-          git tag -fa ${RELEASE_VERSION} -m "ci: release version ${RELEASE_VERSION}"
-          git push --force origin ${RELEASE_VERSION}
-        env:
-          RELEASE_VERSION: ${{ github.event.release.tag_name }}
-          RELEASE_BRANCH: ${{ needs.setup.outputs.releaseBranch }}
 
       - name: Update GitHub Release
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/RELEASE.yaml
+++ b/.github/workflows/RELEASE.yaml
@@ -6,6 +6,7 @@ on:
     types: [ created ]
 
 jobs:
+
   setup:
     name: Prepare the repository
     runs-on: ubuntu-latest
@@ -70,7 +71,7 @@ jobs:
           RELEASE_VERSION: ${{ github.event.release.tag_name }}
 
       - name: Compile and Test
-        run: mvn -B -q package generate-sources source:jar javadoc:jar -DskipTests
+        run: mvn -B package generate-sources source:jar javadoc:jar
 
       - name: Generate sbom reports
         run: |
@@ -81,7 +82,6 @@ jobs:
           # https://github.com/actions/checkout/issues/13#issuecomment-724415212
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git config core.filemode false
 
       - name: Commit and tag
         run: |
@@ -103,6 +103,7 @@ jobs:
   maven-release:
     if: "! contains(github.event.release.tag_name, 'rc')"
     needs: setup
+    name: Create a maven release
     runs-on: ubuntu-latest
     steps:
       - name: Download repository
@@ -178,6 +179,7 @@ jobs:
   docker-release:
     needs: setup
     runs-on: ubuntu-latest
+    name: Perform the docker release
     steps:
       - name: Download repository
         uses: actions/download-artifact@v4
@@ -335,6 +337,7 @@ jobs:
             bundle/default-bundle/target/connectors-bundle-sbom.xml
             connectors-bundle-templates-${{ github.event.release.tag_name }}.tar.gz
             connectors-bundle-templates-${{ github.event.release.tag_name }}.zip
+
 
   helm-deploy:
     needs: [setup, docker-release]

--- a/.github/workflows/RELEASE.yaml
+++ b/.github/workflows/RELEASE.yaml
@@ -6,15 +6,36 @@ on:
     types: [ created ]
 
 jobs:
-  build-and-push:
-    name: Build and push Docker images
+  setup:
+    name: Prepare the repository
     runs-on: ubuntu-latest
     outputs:
+      tagType: ${{ steps.validate_tag.outputs.type }}
       releaseBranch: ${{ steps.determine_release_branch.outputs.releaseBranch }}
+      previousTag: ${{ steps.validate_tag.outputs.previousTag }}
     steps:
+      - name: Import Secrets
+        id: vault-secrets
+        uses: hashicorp/vault-action@v3.0.0
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID}}
+          secrets: |
+            secret/data/products/connectors/ci/common GITHUB_APP_ID;
+            secret/data/products/connectors/ci/common GITHUB_APP_PRIVATE_KEY;
+
+      - name: Generate a GitHub token for connectors
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ steps.vault-secrets.outputs.GITHUB_APP_ID }}
+          private-key: ${{ steps.vault-secrets.outputs.GITHUB_APP_PRIVATE_KEY }}
+
       - uses: actions/checkout@v4
         with:
-          token: ${{ secrets.PROTECTED_BRANCH_PAT }}
+          token: ${{ steps.app-token.outputs.token }}
           ref: ${{ github.event.release.target_commitish }}
           fetch-depth: 0
 
@@ -39,6 +60,43 @@ jobs:
         env:
           RELEASE_VERSION: ${{ github.event.release.tag_name }}
 
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.PROTECTED_BRANCH_PAT }}
+          ref: ${{ github.event.release.target_commitish }}
+          fetch-depth: 0
+
+      - name: Prepare Java and Maven settings
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+
+      - name: Compile and Test
+        run: mvn clean install
+
+      - name: Upload repository
+        uses: actions/upload-artifact@v4
+        with:
+          name: repository
+          path: .
+          include-hidden-files: 'true'
+
+  maven-release:
+    needs: setup
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download repository
+        uses: actions/download-artifact@v4
+        with:
+          name: repository
+
+      - name: Prepare Java and Maven settings
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+
       - name: Import Secrets
         id: secrets
         uses: hashicorp/vault-action@v3.1.0
@@ -49,8 +107,6 @@ jobs:
           secretId: ${{ secrets.VAULT_SECRET_ID }}
           exportEnv: false # we rely on step outputs, no need for environment variables
           secrets: |
-            secret/data/products/connectors/ci/common DOCKERHUB_USER;
-            secret/data/products/connectors/ci/common DOCKERHUB_PASSWORD;
             secret/data/products/connectors/ci/common ARTIFACTORY_USR;
             secret/data/products/connectors/ci/common ARTIFACTORY_PSW;
             secret/data/github.com/organizations/camunda MAVEN_CENTRAL_DEPLOYMENT_USR;
@@ -73,13 +129,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-
 
-      - name: Prepare Java and Maven settings
-        uses: actions/setup-java@v4
-        with:
-          distribution: 'temurin'
-          java-version: '21'
-
-      # Use CI Nexus as co-located pull-through cache for Maven artifacts via ~/.m2/settings.xml
       - name: 'Create settings.xml'
         uses: s4u/maven-settings-action@v3.1.0
         with:
@@ -126,6 +175,28 @@ jobs:
       - name: Generate sbom reports
         run: |
           mvn cyclonedx:makeAggregateBom -pl bundle/default-bundle
+
+  docker-release:
+    needs: setup
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download repository
+        uses: actions/download-artifact@v4
+        with:
+          name: repository
+
+      - name: Import Secrets
+        id: secrets
+        uses: hashicorp/vault-action@v3.0.0
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          exportEnv: false # we rely on step outputs, no need for environment variables
+          secrets: |
+            secret/data/products/connectors/ci/common DOCKERHUB_USER;
+            secret/data/products/connectors/ci/common DOCKERHUB_PASSWORD;
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -182,7 +253,7 @@ jobs:
           provenance: false
 
       - name: Build and Push Docker Image tag latest - bundle-default
-        if: ${{ steps.validate_tag.outputs.type == 'NORMAL' }}
+        if: ${{ needs.setup.outputs.tagType == 'NORMAL' }}
         uses: docker/build-push-action@v6
         with:
           context: bundle/default-bundle/
@@ -192,7 +263,7 @@ jobs:
           provenance: false
 
       - name: Build and Push Docker Image tag latest - bundle-saas
-        if: ${{ steps.validate_tag.outputs.type == 'NORMAL' }}
+        if: ${{ needs.setup.outputs.tagType == 'NORMAL' }}
         uses: docker/build-push-action@v6
         with:
           context: bundle/camunda-saas-bundle/
@@ -204,7 +275,7 @@ jobs:
       # Update README in Dockerhub
 
       - name: Push README to Dockerhub - bundle-default
-        if: ${{ steps.validate_tag.outputs.type == 'NORMAL' }}
+        if: ${{ needs.setup.outputs.tagType == 'NORMAL' }}
         uses: christian-korneck/update-container-description-action@v1
         env:
           DOCKER_USER: ${{ steps.secrets.outputs.DOCKERHUB_USER }}
@@ -216,7 +287,7 @@ jobs:
           short_description: 'Camunda out-of-the-box Connectors Bundle'
 
       - name: Push README to Dockerhub - bundle-saas
-        if: ${{ steps.validate_tag.outputs.type == 'NORMAL' }}
+        if: ${{ needs.setup.outputs.tagType == 'NORMAL' }}
         uses: christian-korneck/update-container-description-action@v1
         env:
           DOCKER_USER: ${{ steps.secrets.outputs.DOCKERHUB_USER }}
@@ -227,8 +298,17 @@ jobs:
           readme_file: bundle/README.md
           short_description: 'Camunda out-of-the-box Connectors Bundle for SaaS'
 
-      # Update GitHub release
+  bundle-and-build-changelog:
+    needs: [ setup, maven-release, docker-release ]
+    name: Bundle and generate changelogs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download repository
+        uses: actions/download-artifact@v4
+        with:
+          name: repository
 
+      # Update GitHub release
       - name: Bundle element templates
         run: bash bundle/bundle-templates.sh ${RELEASE_VERSION}
         env:
@@ -240,10 +320,16 @@ jobs:
         with:
           token: ${{ github.token }}
           fromTag: ${{ github.event.release.tag_name }}
-          toTag: ${{ steps.validate_tag.outputs.previousTag }}
+          toTag: ${{ needs.setup.outputs.previousTag }}
           writeToFile: false
           excludeTypes: build,docs,other,style,ci
           excludeScopes: deps
+
+      - name: Configure git user
+        run: |
+          # https://github.com/actions/checkout/issues/13#issuecomment-724415212
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
       - name: Commit and tag
         run: |
@@ -251,15 +337,14 @@ jobs:
           git push --force-with-lease origin ${RELEASE_BRANCH}
           git tag -fa ${RELEASE_VERSION} -m "ci: release version ${RELEASE_VERSION}"
           git push --force origin ${RELEASE_VERSION}
-
         env:
           RELEASE_VERSION: ${{ github.event.release.tag_name }}
-          RELEASE_BRANCH: ${{ steps.determine_release_branch.outputs.releaseBranch }}
+          RELEASE_BRANCH: ${{ needs.setup.outputs.releaseBranch }}
 
       - name: Update GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          prerelease: ${{ steps.validate_tag.outputs.type != 'NORMAL' }}
+          prerelease: ${{ needs.setup.outputs.tagType != 'NORMAL' }}
           body: ${{ steps.changelog.outputs.changes }}
           tag_name: ${{ github.event.release.tag_name }}
           files: |
@@ -269,10 +354,10 @@ jobs:
             connectors-bundle-templates-${{ github.event.release.tag_name }}.zip
 
   helm-deploy:
-    needs: build-and-push
+    needs: [setup, docker-release]
     name: Run Helm Integration Tests
     uses: ./.github/workflows/INTEGRATION_TEST.yml
     secrets: inherit
     with:
       connectors-version: ${{ github.event.release.tag_name }}
-      release-branch: ${{ needs.build-and-push.outputs.releaseBranch }}
+      release-branch: ${{ needs.setup.outputs.releaseBranch }}


### PR DESCRIPTION
## Description

Backporting changes from `release/8.8` to `main`

## Related issues

related https://github.com/camunda/team-connectors/issues/933 & https://github.com/camunda/team-connectors/issues/991

## Checklist

- [ ] PR has a **milestone** or the `no milestone` label.

