### PR TITLE
fix(rest-connector): fix document upload in SaaS

### DIFF
--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImpl.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImpl.java
@@ -29,6 +29,7 @@ import io.camunda.connector.runtime.core.inbound.details.InboundConnectorDetails
 import io.camunda.document.Document;
 import io.camunda.document.factory.DocumentFactory;
 import io.camunda.document.factory.DocumentFactoryImpl;
+import io.camunda.document.reference.DocumentReference;
 import io.camunda.document.store.DocumentCreationRequest;
 import io.camunda.document.store.InMemoryDocumentStore;
 import java.util.List;
@@ -179,11 +180,6 @@ public class InboundConnectorContextImpl extends AbstractConnectorContext
   }
 
   @Override
-  public Document createDocument(DocumentCreationRequest request) {
-    return documentFactory.create(request);
-  }
-
-  @Override
   public Long getActivationTimestamp() {
     return activationTimestamp;
   }
@@ -217,5 +213,15 @@ public class InboundConnectorContextImpl extends AbstractConnectorContext
   @Override
   public String toString() {
     return "InboundConnectorContextImpl{" + "connectorDetails=" + connectorDetails + '}';
+  }
+
+  @Override
+  public Document resolve(DocumentReference reference) {
+    return documentFactory.resolve(reference);
+  }
+
+  @Override
+  public Document create(DocumentCreationRequest request) {
+    return documentFactory.create(request);
   }
 }

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/InboundIntermediateConnectorContextImpl.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/InboundIntermediateConnectorContextImpl.java
@@ -23,6 +23,7 @@ import io.camunda.connector.api.validation.ValidationProvider;
 import io.camunda.connector.runtime.core.inbound.correlation.InboundCorrelationHandler;
 import io.camunda.connector.runtime.core.inbound.correlation.MessageCorrelationPoint.BoundaryEventCorrelationPoint;
 import io.camunda.document.Document;
+import io.camunda.document.reference.DocumentReference;
 import io.camunda.document.store.DocumentCreationRequest;
 import java.util.List;
 import java.util.Map;
@@ -136,11 +137,6 @@ public class InboundIntermediateConnectorContextImpl
   }
 
   @Override
-  public Document createDocument(DocumentCreationRequest request) {
-    return inboundContext.createDocument(request);
-  }
-
-  @Override
   public List<InboundConnectorElement> connectorElements() {
     return inboundContext.connectorElements();
   }
@@ -148,5 +144,15 @@ public class InboundIntermediateConnectorContextImpl
   @Override
   public Long getActivationTimestamp() {
     return activationTimestamp;
+  }
+
+  @Override
+  public Document resolve(DocumentReference reference) {
+    return inboundContext.resolve(reference);
+  }
+
+  @Override
+  public Document create(DocumentCreationRequest request) {
+    return inboundContext.create(request);
   }
 }

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/outbound/JobHandlerContext.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/outbound/JobHandlerContext.java
@@ -30,6 +30,7 @@ import io.camunda.connector.api.validation.ValidationProvider;
 import io.camunda.connector.runtime.core.AbstractConnectorContext;
 import io.camunda.document.Document;
 import io.camunda.document.factory.DocumentFactory;
+import io.camunda.document.reference.DocumentReference;
 import io.camunda.document.store.DocumentCreationRequest;
 import java.util.Objects;
 import org.slf4j.Logger;
@@ -117,11 +118,6 @@ public class JobHandlerContext extends AbstractConnectorContext
   }
 
   @Override
-  public Document createDocument(DocumentCreationRequest document) {
-    return documentFactory.create(document);
-  }
-
-  @Override
   public boolean equals(Object o) {
     if (this == o) {
       return true;
@@ -136,5 +132,15 @@ public class JobHandlerContext extends AbstractConnectorContext
   @Override
   public int hashCode() {
     return Objects.hash(job);
+  }
+
+  @Override
+  public Document resolve(DocumentReference reference) {
+    return documentFactory.resolve(reference);
+  }
+
+  @Override
+  public Document create(DocumentCreationRequest request) {
+    return documentFactory.create(request);
   }
 }

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/webhook/InboundWebhookRestController.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/webhook/InboundWebhookRestController.java
@@ -161,7 +161,7 @@ public class InboundWebhookRestController {
     return parts.stream()
         .map(
             part ->
-                context.createDocument(
+                context.create(
                     DocumentCreationRequest.from(part.inputStream())
                         .fileName(part.submittedFileName())
                         .contentType(part.contentType())

--- a/connector-sdk/core/src/main/java/io/camunda/connector/api/inbound/InboundConnectorContext.java
+++ b/connector-sdk/core/src/main/java/io/camunda/connector/api/inbound/InboundConnectorContext.java
@@ -16,15 +16,14 @@
  */
 package io.camunda.connector.api.inbound;
 
-import io.camunda.document.Document;
-import io.camunda.document.store.DocumentCreationRequest;
+import io.camunda.document.factory.DocumentFactory;
 import java.util.Map;
 
 /**
  * The context object provided to an inbound connector function. The context allows to fetch
  * information injected by the environment runtime.
  */
-public interface InboundConnectorContext {
+public interface InboundConnectorContext extends DocumentFactory {
 
   /**
    * Checks if the Connector can be activated. The Connector can be activated if the activation
@@ -125,7 +124,4 @@ public interface InboundConnectorContext {
    * implementation requires it.
    */
   void log(Activity activity);
-
-  /** Creates a new document in the Camunda Document Store. */
-  Document createDocument(DocumentCreationRequest request);
 }

--- a/connector-sdk/core/src/main/java/io/camunda/connector/api/outbound/OutboundConnectorContext.java
+++ b/connector-sdk/core/src/main/java/io/camunda/connector/api/outbound/OutboundConnectorContext.java
@@ -16,14 +16,13 @@
  */
 package io.camunda.connector.api.outbound;
 
-import io.camunda.document.Document;
-import io.camunda.document.store.DocumentCreationRequest;
+import io.camunda.document.factory.DocumentFactory;
 
 /**
  * The context object provided to a connector function. The context allows to fetch information
  * injected by the environment runtime.
  */
-public interface OutboundConnectorContext {
+public interface OutboundConnectorContext extends DocumentFactory {
 
   /** Context information about the activated job. */
   JobContext getJobContext();
@@ -46,7 +45,4 @@ public interface OutboundConnectorContext {
    * @return deserialized and validated variables with secrets replaced
    */
   <T> T bindVariables(Class<T> cls);
-
-  /** Creates a new document in the Camunda Document Store. */
-  Document createDocument(DocumentCreationRequest request);
 }

--- a/connector-sdk/test/src/main/java/io/camunda/connector/test/inbound/InboundConnectorContextBuilder.java
+++ b/connector-sdk/test/src/main/java/io/camunda/connector/test/inbound/InboundConnectorContextBuilder.java
@@ -32,6 +32,7 @@ import io.camunda.connector.test.ConnectorContextTestUtil;
 import io.camunda.document.Document;
 import io.camunda.document.factory.DocumentFactory;
 import io.camunda.document.factory.DocumentFactoryImpl;
+import io.camunda.document.reference.DocumentReference;
 import io.camunda.document.store.DocumentCreationRequest;
 import io.camunda.document.store.InMemoryDocumentStore;
 import java.util.ArrayList;
@@ -339,11 +340,6 @@ public class InboundConnectorContextBuilder {
     public void log(Activity activity) {}
 
     @Override
-    public Document createDocument(DocumentCreationRequest request) {
-      return documentFactory.create(request);
-    }
-
-    @Override
     public Queue<Activity> getLogs() {
       return new ConcurrentLinkedQueue<>();
     }
@@ -357,6 +353,16 @@ public class InboundConnectorContextBuilder {
     @Override
     public Long getActivationTimestamp() {
       return activationTimestamp;
+    }
+
+    @Override
+    public Document resolve(DocumentReference reference) {
+      return documentFactory.resolve(reference);
+    }
+
+    @Override
+    public Document create(DocumentCreationRequest request) {
+      return documentFactory.create(request);
     }
   }
 

--- a/connector-sdk/test/src/main/java/io/camunda/connector/test/outbound/OutboundConnectorContextBuilder.java
+++ b/connector-sdk/test/src/main/java/io/camunda/connector/test/outbound/OutboundConnectorContextBuilder.java
@@ -30,6 +30,7 @@ import io.camunda.connector.test.ConnectorContextTestUtil;
 import io.camunda.document.Document;
 import io.camunda.document.factory.DocumentFactory;
 import io.camunda.document.factory.DocumentFactoryImpl;
+import io.camunda.document.reference.DocumentReference;
 import io.camunda.document.store.DocumentCreationRequest;
 import io.camunda.document.store.InMemoryDocumentStore;
 import java.util.HashMap;
@@ -223,7 +224,12 @@ public class OutboundConnectorContextBuilder {
     }
 
     @Override
-    public Document createDocument(DocumentCreationRequest request) {
+    public Document resolve(DocumentReference reference) {
+      return documentFactory.resolve(reference);
+    }
+
+    @Override
+    public Document create(DocumentCreationRequest request) {
       return documentFactory.create(request);
     }
   }

--- a/connectors/aws/aws-bedrock/element-templates/aws-bedrock-outbound-connector.json
+++ b/connectors/aws/aws-bedrock/element-templates/aws-bedrock-outbound-connector.json
@@ -6,7 +6,7 @@
   "metadata" : {
     "keywords" : [ "invoke model", "run inference", "invokemodel API", "converse API" ]
   },
-  "documentationRef" : "https://docs.camunda.io/",
+  "documentationRef" : "https://docs.camunda.io/docs/",
   "version" : 2,
   "category" : {
     "id" : "connectors",

--- a/connectors/aws/aws-bedrock/element-templates/aws-bedrock-outbound-connector.json
+++ b/connectors/aws/aws-bedrock/element-templates/aws-bedrock-outbound-connector.json
@@ -6,7 +6,7 @@
   "metadata" : {
     "keywords" : [ "invoke model", "run inference", "invokemodel API", "converse API" ]
   },
-  "documentationRef" : "https://docs.camunda.io/docs/",
+  "documentationRef" : "https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-bedrock/",
   "version" : 2,
   "category" : {
     "id" : "connectors",

--- a/connectors/aws/aws-bedrock/element-templates/hybrid/aws-bedrock-outbound-connector-hybrid.json
+++ b/connectors/aws/aws-bedrock/element-templates/hybrid/aws-bedrock-outbound-connector-hybrid.json
@@ -6,7 +6,7 @@
   "metadata" : {
     "keywords" : [ "invoke model", "run inference", "invokemodel API", "converse API" ]
   },
-  "documentationRef" : "https://docs.camunda.io/",
+  "documentationRef" : "https://docs.camunda.io/docs/",
   "version" : 2,
   "category" : {
     "id" : "connectors",

--- a/connectors/aws/aws-bedrock/element-templates/hybrid/aws-bedrock-outbound-connector-hybrid.json
+++ b/connectors/aws/aws-bedrock/element-templates/hybrid/aws-bedrock-outbound-connector-hybrid.json
@@ -6,7 +6,7 @@
   "metadata" : {
     "keywords" : [ "invoke model", "run inference", "invokemodel API", "converse API" ]
   },
-  "documentationRef" : "https://docs.camunda.io/docs/",
+  "documentationRef" : "https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-bedrock/",
   "version" : 2,
   "category" : {
     "id" : "connectors",

--- a/connectors/aws/aws-bedrock/src/main/java/io/camunda/connector/aws/bedrock/BedrockConnectorFunction.java
+++ b/connectors/aws/aws-bedrock/src/main/java/io/camunda/connector/aws/bedrock/BedrockConnectorFunction.java
@@ -33,7 +33,8 @@ import io.camunda.connector.generator.java.annotation.ElementTemplate;
       @ElementTemplate.PropertyGroup(id = "invokeModel", label = "Invoke Model"),
       @ElementTemplate.PropertyGroup(id = "converse", label = "Converse"),
     },
-    documentationRef = "https://docs.camunda.io/docs/",
+    documentationRef =
+        "https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-bedrock/",
     icon = "icon.svg")
 public class BedrockConnectorFunction implements OutboundConnectorFunction {
 

--- a/connectors/aws/aws-s3/src/main/java/io/camunda/connector/aws/s3/S3ConnectorFunction.java
+++ b/connectors/aws/aws-s3/src/main/java/io/camunda/connector/aws/s3/S3ConnectorFunction.java
@@ -41,7 +41,7 @@ public class S3ConnectorFunction implements OutboundConnectorFunction {
 
   @Override
   public Object execute(OutboundConnectorContext context) {
-    Function<DocumentCreationRequest, Document> createDocument = context::createDocument;
+    Function<DocumentCreationRequest, Document> createDocument = context::create;
     S3Request s3Request = context.bindVariables(S3Request.class);
     return S3Executor.create(s3Request, createDocument).execute(s3Request.getAction());
   }

--- a/connectors/box/src/main/java/io/camunda/connector/box/BoxOperations.java
+++ b/connectors/box/src/main/java/io/camunda/connector/box/BoxOperations.java
@@ -84,7 +84,7 @@ public class BoxOperations {
     var fileContent = download(file);
     var documentCreationRequest =
         DocumentCreationRequest.from(fileContent).fileName(file.getInfo().getName()).build();
-    return context.createDocument(documentCreationRequest);
+    return context.create(documentCreationRequest);
   }
 
   private static BoxResult deleteFile(

--- a/connectors/email/src/main/java/io/camunda/connector/email/client/jakarta/inbound/PollingManager.java
+++ b/connectors/email/src/main/java/io/camunda/connector/email/client/jakarta/inbound/PollingManager.java
@@ -180,7 +180,7 @@ public class PollingManager {
       return email.body().attachments().stream()
           .map(
               document ->
-                  connectorContext.createDocument(
+                  connectorContext.create(
                       DocumentCreationRequest.from(document.inputStream())
                           .contentType(document.contentType())
                           .fileName(document.name())

--- a/connectors/email/src/main/java/io/camunda/connector/email/client/jakarta/outbound/JakartaEmailActionExecutor.java
+++ b/connectors/email/src/main/java/io/camunda/connector/email/client/jakarta/outbound/JakartaEmailActionExecutor.java
@@ -401,7 +401,7 @@ public class JakartaEmailActionExecutor implements EmailActionExecutor {
     return attachments.stream()
         .map(
             document ->
-                connectorContext.createDocument(
+                connectorContext.create(
                     DocumentCreationRequest.from(document.inputStream())
                         .fileName(document.name())
                         .contentType(document.contentType())

--- a/connectors/google/google-drive/src/main/java/io/camunda/connector/gdrive/mapper/DocumentMapper.java
+++ b/connectors/google/google-drive/src/main/java/io/camunda/connector/gdrive/mapper/DocumentMapper.java
@@ -20,7 +20,7 @@ public class DocumentMapper {
   }
 
   public Document mapToDocument(byte[] bytes, File fileMetaData) {
-    return context.createDocument(
+    return context.create(
         DocumentCreationRequest.from(bytes)
             .contentType(fileMetaData.getMimeType())
             .fileName(fileMetaData.getName())

--- a/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/ExecutionEnvironment.java
+++ b/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/ExecutionEnvironment.java
@@ -16,7 +16,7 @@
  */
 package io.camunda.connector.http.base;
 
-import io.camunda.connector.api.outbound.OutboundConnectorContext;
+import io.camunda.document.factory.DocumentFactory;
 
 public sealed interface ExecutionEnvironment
     permits ExecutionEnvironment.SaaSCluster,
@@ -34,32 +34,33 @@ public sealed interface ExecutionEnvironment
    * here, the initial HttpCommonRequest will be serialized as JSON and passed to the Cloud
    * Function.
    */
-  record SaaSCluster(OutboundConnectorContext context)
+  record SaaSCluster(DocumentFactory documentFactory)
       implements ExecutionEnvironment, StoresDocument {}
 
-  record SelfManaged(OutboundConnectorContext context)
+  record SelfManaged(DocumentFactory documentFactory)
       implements ExecutionEnvironment, StoresDocument {}
 
   /**
    * Factory method to create an ExecutionEnvironment based on the given parameters.
    *
    * @param cloudFunctionEnabled whether the connector is executed in the context of a cloud
+   *     function
    * @param isRunningInCloudFunction whether the connector is executed in the cloud function
    */
   static ExecutionEnvironment from(
       boolean cloudFunctionEnabled,
       boolean isRunningInCloudFunction,
-      OutboundConnectorContext context) {
+      DocumentFactory documentFactory) {
     if (cloudFunctionEnabled) {
-      return new SaaSCluster(context);
+      return new SaaSCluster(documentFactory);
     }
     if (isRunningInCloudFunction) {
       return new SaaSCloudFunction();
     }
-    return new SelfManaged(context);
+    return new SelfManaged(documentFactory);
   }
 
   interface StoresDocument {
-    OutboundConnectorContext context();
+    DocumentFactory documentFactory();
   }
 }

--- a/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/HttpService.java
+++ b/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/HttpService.java
@@ -17,7 +17,6 @@
 package io.camunda.connector.http.base;
 
 import io.camunda.connector.api.error.ConnectorException;
-import io.camunda.connector.api.outbound.OutboundConnectorContext;
 import io.camunda.connector.http.base.blocklist.DefaultHttpBlocklistManager;
 import io.camunda.connector.http.base.blocklist.HttpBlockListManager;
 import io.camunda.connector.http.base.client.HttpClient;
@@ -26,6 +25,7 @@ import io.camunda.connector.http.base.client.apache.ProxyHandler;
 import io.camunda.connector.http.base.cloudfunction.CloudFunctionService;
 import io.camunda.connector.http.base.model.HttpCommonRequest;
 import io.camunda.connector.http.base.model.HttpCommonResult;
+import io.camunda.document.factory.DocumentFactory;
 import javax.annotation.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -54,14 +54,14 @@ public class HttpService {
   }
 
   public HttpCommonResult executeConnectorRequest(
-      HttpCommonRequest request, @Nullable OutboundConnectorContext context) {
+      HttpCommonRequest request, @Nullable DocumentFactory documentFactory) {
     // Will throw ConnectorInputException if URL is blocked
     httpBlocklistManager.validateUrlAgainstBlocklist(request.getUrl());
     ExecutionEnvironment executionEnvironment =
         ExecutionEnvironment.from(
             cloudFunctionService.isCloudFunctionEnabled(),
             cloudFunctionService.isRunningInCloudFunction(),
-            context);
+            documentFactory);
 
     if (executionEnvironment instanceof ExecutionEnvironment.SaaSCluster) {
       // Wrap the request in a proxy request

--- a/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/client/apache/builder/parts/ApacheRequestBodyBuilder.java
+++ b/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/client/apache/builder/parts/ApacheRequestBodyBuilder.java
@@ -92,10 +92,8 @@ public class ApacheRequestBodyBuilder implements ApacheRequestPartBuilder {
   }
 
   private HttpEntity createStringEntity(HttpCommonRequest request) {
-    Object body = request.getBody();
-    if (body instanceof Map map) {
-      body = new DocumentHelper().parseDocumentsInBody(map, Document::asByteArray);
-    }
+    Object body =
+        new DocumentHelper().parseDocumentsInBody(request.getBody(), Document::asByteArray);
     Optional<ContentType> contentType = tryGetContentType(request);
     try {
       return body instanceof String s

--- a/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/client/apache/builder/parts/ApacheRequestBodyBuilder.java
+++ b/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/client/apache/builder/parts/ApacheRequestBodyBuilder.java
@@ -92,8 +92,10 @@ public class ApacheRequestBodyBuilder implements ApacheRequestPartBuilder {
   }
 
   private HttpEntity createStringEntity(HttpCommonRequest request) {
-    Object body =
-        new DocumentHelper().parseDocumentsInBody(request.getBody(), Document::asByteArray);
+    Object body = request.getBody();
+    if (body instanceof Map map) {
+      body = new DocumentHelper().parseDocumentsInBody(map, Document::asByteArray);
+    }
     Optional<ContentType> contentType = tryGetContentType(request);
     try {
       return body instanceof String s

--- a/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/cloudfunction/CloudFunctionService.java
+++ b/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/cloudfunction/CloudFunctionService.java
@@ -24,6 +24,9 @@ import io.camunda.connector.http.base.model.ErrorResponse;
 import io.camunda.connector.http.base.model.HttpCommonRequest;
 import io.camunda.connector.http.base.model.HttpMethod;
 import io.camunda.connector.http.base.model.auth.BearerAuthentication;
+import io.camunda.connector.http.base.utils.DocumentHelper;
+import io.camunda.document.Document;
+import io.camunda.document.factory.DocumentFactory;
 import java.io.IOException;
 import java.util.Map;
 import org.apache.hc.core5.http.ContentType;
@@ -118,6 +121,9 @@ public class CloudFunctionService {
 
   private HttpCommonRequest createCloudFunctionRequest(HttpCommonRequest request, String token)
       throws JsonProcessingException {
+    Object parsedBody =
+        new DocumentHelper().parseDocumentsInBody(request.getBody(), Document::asByteArray);
+    request.setBody(parsedBody);
     String contentAsJson = ConnectorsObjectMapperSupplier.getCopy().writeValueAsString(request);
     HttpCommonRequest cloudFunctionRequest = new HttpCommonRequest();
     cloudFunctionRequest.setMethod(HttpMethod.POST);

--- a/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/cloudfunction/CloudFunctionService.java
+++ b/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/cloudfunction/CloudFunctionService.java
@@ -26,7 +26,6 @@ import io.camunda.connector.http.base.model.HttpMethod;
 import io.camunda.connector.http.base.model.auth.BearerAuthentication;
 import io.camunda.connector.http.base.utils.DocumentHelper;
 import io.camunda.document.Document;
-import io.camunda.document.factory.DocumentFactory;
 import java.io.IOException;
 import java.util.Map;
 import org.apache.hc.core5.http.ContentType;

--- a/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/document/FileResponseHandler.java
+++ b/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/document/FileResponseHandler.java
@@ -59,8 +59,8 @@ public class FileResponseHandler {
     if (storeResponseSelected()
         && executionEnvironment instanceof ExecutionEnvironment.StoresDocument env) {
       try (var byteArrayInputStream = new ByteArrayInputStream(content)) {
-        return env.context()
-            .createDocument(
+        return env.documentFactory()
+            .create(
                 DocumentCreationRequest.from(byteArrayInputStream)
                     .contentType(getContentType(headers))
                     .build());

--- a/connectors/http/http-base/src/test/java/io/camunda/connector/http/base/TestDocumentFactory.java
+++ b/connectors/http/http-base/src/test/java/io/camunda/connector/http/base/TestDocumentFactory.java
@@ -18,29 +18,26 @@ package io.camunda.connector.http.base;
 
 import io.camunda.client.impl.response.DocumentMetadataImpl;
 import io.camunda.client.protocol.rest.DocumentMetadata;
-import io.camunda.connector.api.outbound.JobContext;
-import io.camunda.connector.api.outbound.OutboundConnectorContext;
 import io.camunda.document.CamundaDocument;
 import io.camunda.document.Document;
+import io.camunda.document.factory.DocumentFactory;
+import io.camunda.document.factory.DocumentFactoryImpl;
+import io.camunda.document.reference.DocumentReference;
 import io.camunda.document.store.DocumentCreationRequest;
 import io.camunda.document.store.InMemoryDocumentStore;
 
-public class DocumentOutboundContext implements OutboundConnectorContext {
+public class TestDocumentFactory implements DocumentFactory {
 
   public static final InMemoryDocumentStore store = InMemoryDocumentStore.INSTANCE;
+  private final DocumentFactory factory = new DocumentFactoryImpl(store);
 
   @Override
-  public JobContext getJobContext() {
-    return null;
+  public Document resolve(DocumentReference reference) {
+    return factory.resolve(reference);
   }
 
   @Override
-  public <T> T bindVariables(Class<T> cls) {
-    return null;
-  }
-
-  @Override
-  public Document createDocument(DocumentCreationRequest request) {
+  public Document create(DocumentCreationRequest request) {
     var reference = store.createDocument(request);
     var metadata = new DocumentMetadata();
     metadata.setContentType(reference.metadata().getContentType());

--- a/connectors/http/http-base/src/test/java/io/camunda/connector/http/base/client/apache/CustomApacheHttpClientTest.java
+++ b/connectors/http/http-base/src/test/java/io/camunda/connector/http/base/client/apache/CustomApacheHttpClientTest.java
@@ -30,8 +30,8 @@ import com.github.tomakehurst.wiremock.junit5.WireMockTest;
 import com.github.tomakehurst.wiremock.matching.MultipartValuePatternBuilder;
 import io.camunda.connector.api.error.ConnectorException;
 import io.camunda.connector.api.json.ConnectorsObjectMapperSupplier;
-import io.camunda.connector.http.base.DocumentOutboundContext;
 import io.camunda.connector.http.base.ExecutionEnvironment;
+import io.camunda.connector.http.base.TestDocumentFactory;
 import io.camunda.connector.http.base.authentication.OAuthConstants;
 import io.camunda.connector.http.base.model.HttpCommonRequest;
 import io.camunda.connector.http.base.model.HttpCommonResult;
@@ -98,7 +98,7 @@ public class CustomApacheHttpClientTest {
           customApacheHttpClient.execute(
               request,
               new ProxyHandler(),
-              new ExecutionEnvironment.SelfManaged(new DocumentOutboundContext()));
+              new ExecutionEnvironment.SelfManaged(new TestDocumentFactory()));
       assertThat(result).isNotNull();
       assertThat(result.status()).isEqualTo(200);
       assertThat(result.headers().get(HttpHeaders.CONTENT_TYPE))

--- a/connectors/http/http-base/src/test/java/io/camunda/connector/http/base/cloudfunction/CloudFunctionResponseTransformer.java
+++ b/connectors/http/http-base/src/test/java/io/camunda/connector/http/base/cloudfunction/CloudFunctionResponseTransformer.java
@@ -27,8 +27,8 @@ import com.github.tomakehurst.wiremock.http.Response;
 import com.github.tomakehurst.wiremock.stubbing.ServeEvent;
 import io.camunda.connector.api.error.ConnectorException;
 import io.camunda.connector.api.json.ConnectorsObjectMapperSupplier;
-import io.camunda.connector.http.base.DocumentOutboundContext;
 import io.camunda.connector.http.base.HttpService;
+import io.camunda.connector.http.base.TestDocumentFactory;
 import io.camunda.connector.http.base.model.ErrorResponse;
 import io.camunda.connector.http.base.model.HttpCommonRequest;
 import io.camunda.connector.http.base.model.HttpCommonResult;
@@ -50,7 +50,7 @@ public class CloudFunctionResponseTransformer implements ResponseTransformerV2 {
       HttpCommonRequest request =
           ConnectorsObjectMapperSupplier.getCopy().readValue(body, HttpCommonRequest.class);
       HttpCommonResult value =
-          httpService.executeConnectorRequest(request, new DocumentOutboundContext());
+          httpService.executeConnectorRequest(request, new TestDocumentFactory());
       return Response.Builder.like(response)
           .but()
           .status(200)


### PR DESCRIPTION
## Description

- Fix the REST Connector issue when uploading documents in SaaS
- Make the Outbound/Inbound-ConnectorContexts great again: they now implement `DocumentFactory` as discussed in an architecture session.

## Related issues


closes https://github.com/camunda/team-connectors/issues/1015

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.

