### PR TITLE
other(CI): Create reopen_support_issues_without_version_label.yml

### DIFF
--- a/.github/workflows/reopen_support_issues_without_version_label.yml
+++ b/.github/workflows/reopen_support_issues_without_version_label.yml
@@ -1,0 +1,42 @@
+on:
+  issues:
+    types: [closed]
+
+jobs:
+  reopenIfNoVersionLabel:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Reopen issue and add comment if no version label and has support label
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const issue = context.payload.issue;
+            const hasVersionLabel = issue.labels.some(label => label.name.startsWith('version:'));
+            const hasSupportLabel = issue.labels.some(label => label.name === 'support');
+
+            if (!hasVersionLabel && hasSupportLabel) {
+              const comment = "This issue was closed without a 'version:' label and has been reopened as it has a 'support' label. Please add the version: label and close the issue after.";
+              const issue_number = issue.number;
+              const repository = context.repo.repo;
+              const owner = context.repo.owner;
+
+              // Reopen the issue
+              await github.rest.issues.update({
+                owner,
+                repo: repository,
+                issue_number,
+                state: 'open'
+              });
+
+              // Add a comment to the issue
+              await github.rest.issues.createComment({
+                owner,
+                repo: repository,
+                issue_number,
+                body: comment
+              });
+            }
+          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description

Adding a GHA check on issues that are closed that if it includes a "support" label. If it does, this script will check that if it has the version: -label included. If it does not, then the script will reopen the issue and comment on it that this label needs to be added before closure.

## Related issues

Support has had problems that some of the closed support related issues are not included in the support notification message, because the "version:" label is missing from the issues.

closes #

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.

