### PR TITLE
fix(rest): use contentType from Document metadata when uploading a Document with…

### DIFF
--- a/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/client/apache/builder/parts/ApacheRequestBodyBuilder.java
+++ b/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/client/apache/builder/parts/ApacheRequestBodyBuilder.java
@@ -142,10 +142,16 @@ public class ApacheRequestBodyBuilder implements ApacheRequestPartBuilder {
   private void streamDocumentContent(
       Map.Entry<?, ?> entry, Document document, MultipartEntityBuilder builder) {
     DocumentMetadata metadata = document.metadata();
+    ContentType contentType;
+    try {
+      contentType = ContentType.create(metadata.getContentType());
+    } catch(IllegalArgumentException e){
+      contentType = ContentType.DEFAULT_BINARY;
+    }
     builder.addBinaryBody(
         String.valueOf(entry.getKey()),
         new BufferedInputStream(document.asInputStream()),
-        ContentType.DEFAULT_BINARY,
+        contentType,
         metadata.getFileName());
   }
 }

--- a/connectors/http/http-base/src/test/java/io/camunda/connector/http/base/client/apache/CustomApacheHttpClientTest.java
+++ b/connectors/http/http-base/src/test/java/io/camunda/connector/http/base/client/apache/CustomApacheHttpClientTest.java
@@ -126,6 +126,7 @@ public class CustomApacheHttpClientTest {
           store.createDocument(
               DocumentCreationRequest.from("The content of this file".getBytes())
                   .fileName("file.txt")
+                  .contentType("text/plain")
                   .build());
       HttpCommonRequest request = new HttpCommonRequest();
       request.setMethod(HttpMethod.POST);
@@ -153,6 +154,7 @@ public class CustomApacheHttpClientTest {
                   new MultipartValuePatternBuilder()
                       .withName("document")
                       .withBody(equalTo("The content of this file"))
+                      .withHeader("Content-Type", equalTo("text/plain"))
                       .build()));
     }
   }


### PR DESCRIPTION


## Description

When uploading a document with the REST connector to an endpoint the generated multipart/form-data request body always uses application/octet-stream as mime-type for each and every document which is not supported by all endpoints.

As the Document object in Zeebe already has a contentType in its metadata this contentType should be used instead, only if no valid contentType is provided application/octet-stream can be used as fallback.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #4120 

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.

