### PR TITLE
chore(mail-connector): password can be set with a feel expression

### DIFF
--- a/connectors/email/element-templates/email-outbound-connector.json
+++ b/connectors/email/element-templates/email-outbound-connector.json
@@ -7,7 +7,7 @@
     "keywords" : [ "send emails", "list emails", "search emails", "delete emails", "read emails", "move emails" ]
   },
   "documentationRef" : "https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/email/",
-  "version" : 2,
+  "version" : 3,
   "category" : {
     "id" : "connectors",
     "name" : "Connectors"
@@ -120,6 +120,7 @@
     "constraints" : {
       "notEmpty" : true
     },
+    "feel" : "optional",
     "group" : "authentication",
     "binding" : {
       "name" : "authentication.password",

--- a/connectors/email/element-templates/email-outbound-connector.json
+++ b/connectors/email/element-templates/email-outbound-connector.json
@@ -7,7 +7,7 @@
     "keywords" : [ "send emails", "list emails", "search emails", "delete emails", "read emails", "move emails" ]
   },
   "documentationRef" : "https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/email/",
-  "version" : 3,
+  "version" : 2,
   "category" : {
     "id" : "connectors",
     "name" : "Connectors"

--- a/connectors/email/element-templates/hybrid/email-outbound-connector-hybrid.json
+++ b/connectors/email/element-templates/hybrid/email-outbound-connector-hybrid.json
@@ -7,7 +7,7 @@
     "keywords" : [ "send emails", "list emails", "search emails", "delete emails", "read emails", "move emails" ]
   },
   "documentationRef" : "https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/email/",
-  "version" : 2,
+  "version" : 3,
   "category" : {
     "id" : "connectors",
     "name" : "Connectors"
@@ -125,6 +125,7 @@
     "constraints" : {
       "notEmpty" : true
     },
+    "feel" : "optional",
     "group" : "authentication",
     "binding" : {
       "name" : "authentication.password",

--- a/connectors/email/element-templates/hybrid/email-outbound-connector-hybrid.json
+++ b/connectors/email/element-templates/hybrid/email-outbound-connector-hybrid.json
@@ -7,7 +7,7 @@
     "keywords" : [ "send emails", "list emails", "search emails", "delete emails", "read emails", "move emails" ]
   },
   "documentationRef" : "https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/email/",
-  "version" : 3,
+  "version" : 2,
   "category" : {
     "id" : "connectors",
     "name" : "Connectors"

--- a/connectors/email/src/main/java/io/camunda/connector/email/authentication/SimpleAuthentication.java
+++ b/connectors/email/src/main/java/io/camunda/connector/email/authentication/SimpleAuthentication.java
@@ -6,7 +6,6 @@
  */
 package io.camunda.connector.email.authentication;
 
-import io.camunda.connector.generator.dsl.Property;
 import io.camunda.connector.generator.java.annotation.TemplateProperty;
 import io.camunda.connector.generator.java.annotation.TemplateSubType;
 import jakarta.validation.constraints.NotBlank;
@@ -24,7 +23,6 @@ public record SimpleAuthentication(
     @TemplateProperty(
             group = "authentication",
             label = "Email password",
-            feel = Property.FeelMode.disabled,
             tooltip =
                 "Enter the password associated with your email account. Keep your password secure and do not share it with others.",
             id = "simpleAuthenticationPassword")

--- a/connectors/email/src/main/java/io/camunda/connector/email/outbound/EmailConnectorFunction.java
+++ b/connectors/email/src/main/java/io/camunda/connector/email/outbound/EmailConnectorFunction.java
@@ -35,7 +35,7 @@ import io.camunda.connector.generator.java.annotation.ElementTemplate;
               "move emails"
             }),
     inputDataClass = EmailRequest.class,
-    version = 2,
+    version = 3,
     propertyGroups = {
       @ElementTemplate.PropertyGroup(id = "authentication", label = "Authentication"),
       @ElementTemplate.PropertyGroup(id = "protocol", label = "Protocol"),

--- a/connectors/email/src/main/java/io/camunda/connector/email/outbound/EmailConnectorFunction.java
+++ b/connectors/email/src/main/java/io/camunda/connector/email/outbound/EmailConnectorFunction.java
@@ -35,7 +35,7 @@ import io.camunda.connector.generator.java.annotation.ElementTemplate;
               "move emails"
             }),
     inputDataClass = EmailRequest.class,
-    version = 3,
+    version = 2,
     propertyGroups = {
       @ElementTemplate.PropertyGroup(id = "authentication", label = "Authentication"),
       @ElementTemplate.PropertyGroup(id = "protocol", label = "Protocol"),


### PR DESCRIPTION
## Description

Password can now be set using a feel expression

## Related issues

closes https://github.com/camunda/connectors/issues/4046


PR on web modeler: https://github.com/camunda/web-modeler/pull/13192

## Checklist

- [ ] PR has a **milestone** or the `no milestone` label.

