### PR TITLE
feat(idp-extraction-connector): idp connector should return response as key/value pair of extracted fields

### DIFF
--- a/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/ExtractionConnectorFunction.java
+++ b/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/ExtractionConnectorFunction.java
@@ -129,7 +129,7 @@ public class ExtractionConnectorFunction implements OutboundConnectorFunction {
 
       var missingKeys = taxonomyItemsNames.stream().filter(name -> !result.containsKey(name)).toList();
       if (!missingKeys.isEmpty()) {
-        LOGGER.warn("LLM model response is the following missing keys: ({})", String.join(", ", missingKeys));
+        LOGGER.warn("LLM model response is missing the following keys: ({})", String.join(", ", missingKeys));
       }
 
       return result;

--- a/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/ExtractionConnectorFunction.java
+++ b/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/ExtractionConnectorFunction.java
@@ -105,7 +105,7 @@ public class ExtractionConnectorFunction implements OutboundConnectorFunction {
     }
   }
 
-  private Map<String, JsonNode> buildResponseJsonIfPossible(
+  private Map<String, Object> buildResponseJsonIfPossible(
       String llmResponse, List<TaxonomyItem> taxonomyItems) {
     try {
       var llmResponseJson = objectMapper.readValue(llmResponse, JsonNode.class);
@@ -128,7 +128,7 @@ public class ExtractionConnectorFunction implements OutboundConnectorFunction {
           }
         }
 
-        var result =
+        Map<String, Object> result =
             taxonomyItemsNames.stream()
                 .filter(llmResponseJson::has)
                 .collect(Collectors.toMap(name -> name, llmResponseJson::get));

--- a/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/ExtractionConnectorFunction.java
+++ b/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/ExtractionConnectorFunction.java
@@ -123,13 +123,17 @@ public class ExtractionConnectorFunction implements OutboundConnectorFunction {
         }
       }
 
-      var result = taxonomyItemsNames.stream()
-          .filter(llmResponseJson::has)
-          .collect(Collectors.toMap(name -> name, llmResponseJson::get));
+      var result =
+          taxonomyItemsNames.stream()
+              .filter(llmResponseJson::has)
+              .collect(Collectors.toMap(name -> name, llmResponseJson::get));
 
-      var missingKeys = taxonomyItemsNames.stream().filter(name -> !result.containsKey(name)).toList();
+      var missingKeys =
+          taxonomyItemsNames.stream().filter(name -> !result.containsKey(name)).toList();
       if (!missingKeys.isEmpty()) {
-        LOGGER.warn("LLM model response is missing the following keys: ({})", String.join(", ", missingKeys));
+        LOGGER.warn(
+            "LLM model response is missing the following keys: ({})",
+            String.join(", ", missingKeys));
       }
 
       return result;

--- a/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/model/ExtractionResult.java
+++ b/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/model/ExtractionResult.java
@@ -6,4 +6,6 @@
  */
 package io.camunda.connector.idp.extraction.model;
 
-public record ExtractionResult(Object response) {}
+import java.util.Map;
+
+public record ExtractionResult(Map<String, Object> response) {}

--- a/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/model/ExtractionResult.java
+++ b/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/model/ExtractionResult.java
@@ -6,7 +6,6 @@
  */
 package io.camunda.connector.idp.extraction.model;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import java.util.Map;
 
-public record ExtractionResult(Map<String, JsonNode> response) {}
+public record ExtractionResult(Map<String, Object> response) {}

--- a/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/model/ExtractionResult.java
+++ b/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/model/ExtractionResult.java
@@ -6,6 +6,7 @@
  */
 package io.camunda.connector.idp.extraction.model;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import java.util.Map;
 
-public record ExtractionResult(Map<String, Object> response) {}
+public record ExtractionResult(Map<String, JsonNode> response) {}

--- a/connectors/idp-extraction/src/test/java/io/camunda/connector/idp/extraction/ExtractionConnectorFunctionTest.java
+++ b/connectors/idp-extraction/src/test/java/io/camunda/connector/idp/extraction/ExtractionConnectorFunctionTest.java
@@ -138,7 +138,7 @@ class ExtractionConnectorFunctionTest {
   }
 
   @Test
-  void executeExtractionReturnsEmptyResult_whenLlmResponseContainsInValidStringifiedObject()
+  void executeExtractionReturnsEmptyResult_whenLlmResponseContainsInvalidStringifiedObject()
       throws Exception {
     var outBounderContext = prepareConnectorContext();
 

--- a/connectors/idp-extraction/src/test/java/io/camunda/connector/idp/extraction/ExtractionConnectorFunctionTest.java
+++ b/connectors/idp-extraction/src/test/java/io/camunda/connector/idp/extraction/ExtractionConnectorFunctionTest.java
@@ -10,11 +10,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
+import com.fasterxml.jackson.databind.node.TextNode;
 import io.camunda.connector.idp.extraction.caller.BedrockCaller;
 import io.camunda.connector.idp.extraction.caller.PollingTextractCaller;
 import io.camunda.connector.idp.extraction.model.ExtractionResult;
 import io.camunda.connector.idp.extraction.util.ExtractionTestUtils;
 import io.camunda.connector.test.outbound.OutboundConnectorContextBuilder;
+import java.util.Map;
+import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -40,13 +43,106 @@ class ExtractionConnectorFunctionTest {
         .thenReturn(
             """
                         {
-                        	"name": "John Smith",
-                        	"age": 32
+                        	"sum": "$12.25",
+                        	"supplier": "Camunda Inc."
                         }
                         """);
 
     var result = extractionConnectorFunction.execute(outBounderContext);
-    assertThat(result).isInstanceOf(ExtractionResult.class);
+    assertExtractionResult(
+        result, Map.of("sum", new TextNode("$12.25"), "supplier", new TextNode("Camunda Inc.")));
+  }
+
+  @Test
+  void executeExtractionReturnsCorrectResult_whenLlmResponseContainsNestedResponseObject()
+      throws Exception {
+    var outBounderContext = prepareConnectorContext();
+
+    when(pollingTextractCaller.call(any(), any(), any(), any()))
+        .thenReturn("Test extracted text from test document.pdf");
+    when(bedrockCaller.call(any(), any(), any()))
+        .thenReturn(
+            """
+                        {
+                          "response": {
+                                      "sum": "$12.25",
+                                      "supplier": "Camunda Inc."
+                                      }
+                        }
+                        """);
+
+    var result = extractionConnectorFunction.execute(outBounderContext);
+    assertExtractionResult(
+        result, Map.of("sum", new TextNode("$12.25"), "supplier", new TextNode("Camunda Inc.")));
+  }
+
+  @Test
+  void
+      executeExtractionReturnsCorrectResult_whenLlmResponseContainsNestedResponseWithValidStringifiedObject()
+          throws Exception {
+    var outBounderContext = prepareConnectorContext();
+
+    when(pollingTextractCaller.call(any(), any(), any(), any()))
+        .thenReturn("Test extracted text from test document.pdf");
+    when(bedrockCaller.call(any(), any(), any()))
+        .thenReturn(
+            """
+                        {
+                          "response": "\\n\\n{\\"sum\\":\\"$12.25\\",\\"supplier\\":\\"Camunda Inc.\\"}"
+                        }
+                        """);
+
+    var result = extractionConnectorFunction.execute(outBounderContext);
+    assertExtractionResult(
+        result, Map.of("sum", new TextNode("$12.25"), "supplier", new TextNode("Camunda Inc.")));
+  }
+
+  @Test
+  void
+      executeExtractionReturnsEmptyResult_whenLlmResponseContainsNestedResponseWithInvalidStringifiedObject()
+          throws Exception {
+    var outBounderContext = prepareConnectorContext();
+
+    when(pollingTextractCaller.call(any(), any(), any(), any()))
+        .thenReturn("Test extracted text from test document.pdf");
+    when(bedrockCaller.call(any(), any(), any()))
+        .thenReturn(
+            """
+                        {
+                          "response": "{"
+                        }
+                        """);
+
+    var result = extractionConnectorFunction.execute(outBounderContext);
+    assertExtractionResult(result, Map.of());
+  }
+
+  @Test
+  void executeExtractionReturnsEmptyResult_whenLlmResponseContainsInValidStringifiedObject()
+      throws Exception {
+    var outBounderContext = prepareConnectorContext();
+
+    when(pollingTextractCaller.call(any(), any(), any(), any()))
+        .thenReturn("Test extracted text from test document.pdf");
+    when(bedrockCaller.call(any(), any(), any()))
+        .thenReturn(
+            """
+                        {
+                        """);
+
+    var result = extractionConnectorFunction.execute(outBounderContext);
+    assertExtractionResult(result, Map.of());
+  }
+
+  private void assertExtractionResult(Object result, Map<String, Object> expectedResponse) {
+    assertThat(result)
+        .isNotNull()
+        .isInstanceOf(ExtractionResult.class)
+        .asInstanceOf(InstanceOfAssertFactories.type(ExtractionResult.class))
+        .satisfies(
+            extractionResult ->
+                assertThat(extractionResult.response())
+                    .containsExactlyInAnyOrderEntriesOf(expectedResponse));
   }
 
   private OutboundConnectorContextBuilder.TestConnectorContext prepareConnectorContext() {

--- a/connectors/idp-extraction/src/test/java/io/camunda/connector/idp/extraction/ExtractionConnectorFunctionTest.java
+++ b/connectors/idp-extraction/src/test/java/io/camunda/connector/idp/extraction/ExtractionConnectorFunctionTest.java
@@ -55,7 +55,9 @@ class ExtractionConnectorFunctionTest {
   }
 
   @Test
-  void executeExtractionReturnsPartiallyCorrectResult_whenLlmResponseIsMissingValueForSomeTaxonomyItems() throws Exception {
+  void
+      executeExtractionReturnsPartiallyCorrectResult_whenLlmResponseIsMissingValueForSomeTaxonomyItems()
+          throws Exception {
     var outBounderContext = prepareConnectorContext();
 
     when(pollingTextractCaller.call(any(), any(), any(), any()))
@@ -69,8 +71,7 @@ class ExtractionConnectorFunctionTest {
                         """);
 
     var result = extractionConnectorFunction.execute(outBounderContext);
-    assertExtractionResult(
-        result, Map.of("sum", new TextNode("$12.25")));
+    assertExtractionResult(result, Map.of("sum", new TextNode("$12.25")));
   }
 
   @Test

--- a/connectors/idp-extraction/src/test/java/io/camunda/connector/idp/extraction/ExtractionConnectorFunctionTest.java
+++ b/connectors/idp-extraction/src/test/java/io/camunda/connector/idp/extraction/ExtractionConnectorFunctionTest.java
@@ -43,7 +43,7 @@ class ExtractionConnectorFunctionTest {
   @Test
   void executeExtractionReturnsCorrectResult() throws Exception {
     var outBounderContext = prepareConnectorContext();
-    var responseJson =
+    var expectedResponseJson =
         """
             {
             	"sum": "$12.25",
@@ -53,10 +53,10 @@ class ExtractionConnectorFunctionTest {
 
     when(pollingTextractCaller.call(any(), any(), any(), any()))
         .thenReturn("Test extracted text from test document.pdf");
-    when(bedrockCaller.call(any(), any(), any())).thenReturn(responseJson);
+    when(bedrockCaller.call(any(), any(), any())).thenReturn(expectedResponseJson);
 
     var result = extractionConnectorFunction.execute(outBounderContext);
-    assertExtractionResult(result, responseJson);
+    assertExtractionResult(result, expectedResponseJson);
   }
 
   @Test
@@ -64,7 +64,7 @@ class ExtractionConnectorFunctionTest {
       executeExtractionReturnsPartiallyCorrectResult_whenLlmResponseIsMissingValueForSomeTaxonomyItems()
           throws Exception {
     var outBounderContext = prepareConnectorContext();
-    var responseJson =
+    var expectedResponseJson =
         """
             {
             	"sum": "$12.25"
@@ -73,10 +73,10 @@ class ExtractionConnectorFunctionTest {
 
     when(pollingTextractCaller.call(any(), any(), any(), any()))
         .thenReturn("Test extracted text from test document.pdf");
-    when(bedrockCaller.call(any(), any(), any())).thenReturn(responseJson);
+    when(bedrockCaller.call(any(), any(), any())).thenReturn(expectedResponseJson);
 
     var result = extractionConnectorFunction.execute(outBounderContext);
-    assertExtractionResult(result, responseJson);
+    assertExtractionResult(result, expectedResponseJson);
   }
 
   @Test
@@ -98,14 +98,14 @@ class ExtractionConnectorFunctionTest {
                """);
 
     var result = extractionConnectorFunction.execute(outBounderContext);
-    var responseJson =
+    var expectedResponseJson =
         """
             {
               "sum": "$12.25",
               "supplier": "Camunda Inc."
             }
         """;
-    assertExtractionResult(result, responseJson);
+    assertExtractionResult(result, expectedResponseJson);
   }
 
   @Test
@@ -130,7 +130,7 @@ class ExtractionConnectorFunctionTest {
                """);
 
     var result = extractionConnectorFunction.execute(outBounderContext);
-    var responseJson =
+    var expectedResponseJson =
         """
             {
               "sum": "$12.25",
@@ -142,7 +142,7 @@ class ExtractionConnectorFunctionTest {
                           }
             }
         """;
-    assertExtractionResult(result, responseJson);
+    assertExtractionResult(result, expectedResponseJson);
   }
 
   @Test
@@ -170,7 +170,7 @@ class ExtractionConnectorFunctionTest {
                """);
 
     var result = extractionConnectorFunction.execute(outBounderContext);
-    var responseJson =
+    var expectedResponseJson =
         """
             {
               "sum": "$12.25",
@@ -182,7 +182,7 @@ class ExtractionConnectorFunctionTest {
                           }
             }
         """;
-    assertExtractionResult(result, responseJson);
+    assertExtractionResult(result, expectedResponseJson);
   }
 
   @Test
@@ -202,14 +202,14 @@ class ExtractionConnectorFunctionTest {
                """);
 
     var result = extractionConnectorFunction.execute(outBounderContext);
-    var responseJson =
+    var expectedResponseJson =
         """
             {
             	"sum": "$12.25",
             	"supplier": "Camunda Inc."
             }
         """;
-    assertExtractionResult(result, responseJson);
+    assertExtractionResult(result, expectedResponseJson);
   }
 
   @Test


### PR DESCRIPTION
## Description

Changes were made to the response from `ExtractionConnectorFunction`. The new method `buildResponseJsonIfPossible` ensures a specific structure based on the `taxonomyItems` input.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes https://github.com/camunda/connectors/issues/4145

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.

