### PR TITLE
fix(element-template-generato): publish to camunda-nexus for release candidate

### DIFF
--- a/.github/workflows/RELEASE.yaml
+++ b/.github/workflows/RELEASE.yaml
@@ -101,7 +101,6 @@ jobs:
           include-hidden-files: 'true'
 
   maven-release:
-    if: "! contains(github.event.release.tag_name, 'rc')"
     needs: setup
     name: Create a maven release
     runs-on: ubuntu-latest
@@ -168,7 +167,18 @@ jobs:
             ${{ runner.os }}-maven-
 
       - name: Deploy artifacts to Artifactory and Maven Central (Staging)
+        if: "! contains(github.event.release.tag_name, 'rc')"
         run: mvn deploy -DskipTests -PcheckFormat -Psonatype-oss-release
+        env:
+          NEXUS_USR: ${{ steps.secrets.outputs.ARTIFACTORY_USR }}
+          NEXUS_PSW: ${{ steps.secrets.outputs.ARTIFACTORY_PSW }}
+          MAVEN_USR: ${{ steps.secrets.outputs.MAVEN_CENTRAL_DEPLOYMENT_USR }}
+          MAVEN_PSW: ${{ steps.secrets.outputs.MAVEN_CENTRAL_DEPLOYMENT_PSW }}
+          MAVEN_GPG_PASSPHRASE: ${{ steps.secrets.outputs.MAVEN_CENTRAL_GPG_SIGNING_KEY_PASSPHRASE }}
+
+      - name: Deploy artifacts to Artifactory and Maven Central (Staging)
+        if: "contains(github.event.release.tag_name, 'rc')"
+        run: mvn deploy -DskipTests -PcheckFormat -Psonatype-oss-release -Dskip.central.release=true
         env:
           NEXUS_USR: ${{ steps.secrets.outputs.ARTIFACTORY_USR }}
           NEXUS_PSW: ${{ steps.secrets.outputs.ARTIFACTORY_PSW }}

--- a/.github/workflows/RELEASE.yaml
+++ b/.github/workflows/RELEASE.yaml
@@ -176,7 +176,7 @@ jobs:
           MAVEN_PSW: ${{ steps.secrets.outputs.MAVEN_CENTRAL_DEPLOYMENT_PSW }}
           MAVEN_GPG_PASSPHRASE: ${{ steps.secrets.outputs.MAVEN_CENTRAL_GPG_SIGNING_KEY_PASSPHRASE }}
 
-      - name: Deploy artifacts to Artifactory and Maven Central (Staging)
+      - name: Deploy artifacts to Artifactory
         if: "contains(github.event.release.tag_name, 'rc')"
         run: mvn deploy -DskipTests -PcheckFormat -Psonatype-oss-release -Dskip.central.release=true
         env:


### PR DESCRIPTION
## Description

We cannot deploy the cloud function because release candidate were not deployed anymore on camunda-nexus. This fixes it

## Related issues

## Checklist

- [ ] PR has a **milestone** or the `no milestone` label.

