### PR TITLE
chore(element-template-generator): Automate meta-inf service generation

### DIFF
--- a/element-template-generator/maven-plugin/src/main/java/io/camunda/connector/generator/ConnectorConfig.java
+++ b/element-template-generator/maven-plugin/src/main/java/io/camunda/connector/generator/ConnectorConfig.java
@@ -25,6 +25,8 @@ public class ConnectorConfig {
 
   private boolean generateHybridTemplates = false;
 
+  private boolean writeMetaInfFileGeneration = true;
+
   private List<FileNameById> files = List.of();
 
   private Map<String, Boolean> features = Map.of();
@@ -78,6 +80,14 @@ public class ConnectorConfig {
 
   public void setConnectorClass(String connectorClass) {
     this.connectorClass = connectorClass;
+  }
+
+  public boolean isWriteMetaInfFileGeneration() {
+    return writeMetaInfFileGeneration;
+  }
+
+  public void setWriteMetaInfFileGeneration(boolean writeMetaInfFileGeneration) {
+    this.writeMetaInfFileGeneration = writeMetaInfFileGeneration;
   }
 
   public boolean isGenerateHybridTemplates() {

--- a/element-template-generator/maven-plugin/src/main/java/io/camunda/connector/generator/ElementTemplateGeneratorMojo.java
+++ b/element-template-generator/maven-plugin/src/main/java/io/camunda/connector/generator/ElementTemplateGeneratorMojo.java
@@ -157,6 +157,11 @@ public class ElementTemplateGeneratorMojo extends AbstractMojo {
 
   private void writeMetaInfFiles() throws MojoFailureException {
     try {
+      List<ConnectorConfig> filteredConnectors =
+          Arrays.stream(connectors).filter(ConnectorConfig::isWriteMetaInfFileGeneration).toList();
+      if (filteredConnectors.isEmpty()) {
+        return;
+      }
       String uriString = getResourcesDirectory().toString().replaceFirst("^file:", "");
       Path path = Paths.get(uriString + File.separator + "META-INF" + File.separator + "services");
       Files.createDirectories(path);
@@ -169,7 +174,7 @@ public class ElementTemplateGeneratorMojo extends AbstractMojo {
                   "io.camunda.connector.api.outbound.OutboundConnectorFunction");
 
       ClassLoader projectClassLoader = getProjectClassLoader();
-      for (ConnectorConfig connector : connectors) {
+      for (ConnectorConfig connector : filteredConnectors) {
         Class<?> connectorClass =
             Class.forName(connector.getConnectorClass(), false, projectClassLoader);
 


### PR DESCRIPTION
## Description
Add a function to element template generation to create the meta-inf/service files automatically. I tested this with the email, graphql and other connectors and it created the same files as the existing ones. Some connectors do not have the plugin in the pom, so I suppose it is expected, these are not working.
Let me know if there are other use-cases than our connectors in `/connectors/` that need to be tested / keep working.

## Related issues
closes: https://github.com/camunda/team-connectors/issues/620

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.

