### PR TITLE
fix(security): Disallow include in pebble engine

### DIFF
--- a/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/ClassBasedDocsGenerator.java
+++ b/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/ClassBasedDocsGenerator.java
@@ -43,6 +43,7 @@ import io.camunda.connector.generator.java.util.TemplateGenerationContext;
 import io.camunda.connector.generator.java.util.TemplateGenerationContextUtil;
 import io.camunda.connector.generator.java.util.TemplatePropertiesUtil;
 import io.pebbletemplates.pebble.PebbleEngine;
+import io.pebbletemplates.pebble.extension.core.DisallowExtensionCustomizerBuilder;
 import io.pebbletemplates.pebble.loader.FileLoader;
 import io.pebbletemplates.pebble.template.PebbleTemplate;
 import java.io.File;
@@ -145,6 +146,10 @@ public class ClassBasedDocsGenerator implements DocsGenerator<Class<?>> {
 
     PebbleEngine engine =
         new PebbleEngine.Builder()
+            .registerExtensionCustomizer(
+                new DisallowExtensionCustomizerBuilder()
+                    .disallowedTokenParserTags(List.of("include"))
+                    .build()) // Security fix for https://www.cve.org/CVERecord?id=CVE-2025-1686
             .loader(new FileLoader())
             .autoEscaping(false)
             .extension(new DocsPebbleExtension())


### PR DESCRIPTION
Disallow include in pebble engine in element template builder core. See [here](https://www.cve.org/CVERecord?id=CVE-2025-1686) and [here](https://camunda.slack.com/archives/C02JLRNQQ05/p1741089936227569)

## Description
Applied the suggested fix. Tested element template generation for email connector and openAPI specs. Works as expected. Pebble engine is not used in [8.5.](https://github.com/camunda/connectors/blob/release/8.5/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/ClassBasedTemplateGenerator.java) so only needs backport to 8.7 and 8.6

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.

