### PR TITLE
feature(rest-connector): add a boolean that allows to ignore null values

### DIFF
--- a/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/model/HttpCommonRequest.java
+++ b/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/model/HttpCommonRequest.java
@@ -135,7 +135,7 @@ public class HttpCommonRequest {
       type = PropertyType.Boolean,
       defaultValueType = TemplateProperty.DefaultValueType.Boolean,
       defaultValue = "false",
-      description = "Null values will not be sent")
+      tooltip = "Null values will not be sent")
   private boolean ignoreNullValues;
 
   public Object getBody() {

--- a/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/model/HttpCommonRequest.java
+++ b/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/model/HttpCommonRequest.java
@@ -130,6 +130,14 @@ public class HttpCommonRequest {
       optional = true)
   private String groupSetCookieHeaders;
 
+  @TemplateProperty(
+      group = "payload",
+      type = PropertyType.Boolean,
+      defaultValueType = TemplateProperty.DefaultValueType.Boolean,
+      defaultValue = "false",
+      description = "Null values will not be sent")
+  private boolean ignoreNullValues;
+
   public Object getBody() {
     return body;
   }
@@ -298,5 +306,13 @@ public class HttpCommonRequest {
         + ", storeResponse="
         + storeResponse
         + '}';
+  }
+
+  public boolean isIgnoreNullValues() {
+    return ignoreNullValues;
+  }
+
+  public void setIgnoreNullValues(boolean ignoreNullValues) {
+    this.ignoreNullValues = ignoreNullValues;
   }
 }

--- a/connectors/http/rest/element-templates/http-json-connector.json
+++ b/connectors/http/rest/element-templates/http-json-connector.json
@@ -482,6 +482,19 @@
     },
     "type" : "Text"
   }, {
+    "id" : "ignoreNullValues",
+    "label" : "Ignore null values",
+    "description" : "Null values will not be sent",
+    "optional" : false,
+    "value" : false,
+    "feel" : "optional",
+    "group" : "payload",
+    "binding" : {
+      "name" : "ignoreNullValues",
+      "type" : "zeebe:input"
+    },
+    "type" : "Boolean"
+  }, {
     "id" : "resultVariable",
     "label" : "Result variable",
     "description" : "Name of variable to store the response in",

--- a/connectors/http/rest/element-templates/hybrid/http-json-connector-hybrid.json
+++ b/connectors/http/rest/element-templates/hybrid/http-json-connector-hybrid.json
@@ -487,6 +487,19 @@
     },
     "type" : "Text"
   }, {
+    "id" : "ignoreNullValues",
+    "label" : "Ignore null values",
+    "description" : "Null values will not be sent",
+    "optional" : false,
+    "value" : false,
+    "feel" : "optional",
+    "group" : "payload",
+    "binding" : {
+      "name" : "ignoreNullValues",
+      "type" : "zeebe:input"
+    },
+    "type" : "Boolean"
+  }, {
     "id" : "resultVariable",
     "label" : "Result variable",
     "description" : "Name of variable to store the response in",

--- a/connectors/http/rest/src/main/java/io/camunda/connector/http/rest/HttpJsonFunction.java
+++ b/connectors/http/rest/src/main/java/io/camunda/connector/http/rest/HttpJsonFunction.java
@@ -39,7 +39,8 @@ import io.camunda.connector.http.rest.model.HttpJsonRequest;
       "writeTimeoutInSeconds",
       "body",
       "storeResponse",
-      "groupSetCookieHeaders"
+      "groupSetCookieHeaders",
+      "ignoreNullValues"
     },
     type = HttpJsonFunction.TYPE)
 @ElementTemplate(

--- a/connectors/http/rest/src/test/java/io/camunda/connector/http/rest/HttpJsonFunctionTest.java
+++ b/connectors/http/rest/src/test/java/io/camunda/connector/http/rest/HttpJsonFunctionTest.java
@@ -16,21 +16,23 @@
  */
 package io.camunda.connector.http.rest;
 
-import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
-import static com.github.tomakehurst.wiremock.client.WireMock.any;
-import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
-import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static org.apache.http.entity.ContentType.APPLICATION_JSON;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchException;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.github.tomakehurst.wiremock.admin.model.ServeEventQuery;
 import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import com.github.tomakehurst.wiremock.stubbing.ServeEvent;
 import io.camunda.connector.api.error.ConnectorInputException;
 import io.camunda.connector.http.base.model.HttpCommonResult;
 import io.camunda.connector.test.outbound.OutboundConnectorContextBuilder;
 import io.camunda.connector.validation.impl.DefaultValidationProvider;
 import java.io.IOException;
+import java.util.List;
+import java.util.UUID;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -115,6 +117,48 @@ public class HttpJsonFunctionTest extends BaseTest {
             ((HttpCommonResult) functionCallResponseAsObject).body(), JsonNode.class);
     assertThat(asJsonObject.has("unknown")).isTrue();
     assertThat(asJsonObject.get("unknown").isNull()).isTrue();
+  }
+
+  @Test
+  void execute_shouldSendNullFieldWhenRequestContainsNullField() throws JsonProcessingException {
+    // given request, and response body with null field value
+    final var request =
+        "{ \"method\": \"put\", \"url\": \"http://localhost:8086/http-endpoint\",\"authentication\": { \"type\": \"noAuth\" }, \"body\" : { \"test\": 2, \"second\" : null}, \"ignoreNullValues\" : false }";
+
+    UUID uuid = UUID.randomUUID();
+    stubFor(
+        put(urlPathEqualTo("/http-endpoint")).willReturn(aResponse().withStatus(200)).withId(uuid));
+
+    final var context = OutboundConnectorContextBuilder.create().variables(request).build();
+    functionUnderTest.execute(context);
+
+    List<ServeEvent> allServeEvents = getAllServeEvents(ServeEventQuery.forStubMapping(uuid));
+    assertThat(allServeEvents).hasSize(1);
+    String body = allServeEvents.getFirst().getRequest().getBodyAsString();
+    JsonNode jsonBody = objectMapper.readValue(body, JsonNode.class);
+    assertThat(jsonBody.has("test")).isTrue();
+    assertThat(jsonBody.has("second")).isTrue();
+  }
+
+  @Test
+  void execute_shouldNotSendNullFieldWhenRequestContainsNullField() throws JsonProcessingException {
+    // given request, and response body with null field value
+    final var request =
+        "{ \"method\": \"put\", \"url\": \"http://localhost:8086/http-endpoint\",\"authentication\": { \"type\": \"noAuth\" }, \"body\" : { \"test\": 2, \"second\" : null}, \"ignoreNullValues\" : true }";
+
+    UUID uuid = UUID.randomUUID();
+    stubFor(
+        put(urlPathEqualTo("/http-endpoint")).willReturn(aResponse().withStatus(200)).withId(uuid));
+
+    final var context = OutboundConnectorContextBuilder.create().variables(request).build();
+    functionUnderTest.execute(context);
+
+    List<ServeEvent> allServeEvents = getAllServeEvents(ServeEventQuery.forStubMapping(uuid));
+    assertThat(allServeEvents).hasSize(1);
+    String body = allServeEvents.getFirst().getRequest().getBodyAsString();
+    JsonNode jsonBody = objectMapper.readValue(body, JsonNode.class);
+    assertThat(jsonBody.has("test")).isTrue();
+    assertThat(jsonBody.has("second")).isFalse();
   }
 
   private HttpCommonResult arrange(String input) throws Exception {


### PR DESCRIPTION
## Description

add a boolean that allows to ignore null values

## Related issues

closes https://github.com/camunda/team-connectors/issues/948

## Checklist

- [ ] PR has a **milestone** or the `no milestone` label.

