### PR TITLE
chore(idp-extraction-connector): backport idp connector should return response as key/value pair of extracted fields

### DIFF
--- a/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/ExtractionConnectorFunction.java
+++ b/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/ExtractionConnectorFunction.java
@@ -6,6 +6,9 @@
  */
 package io.camunda.connector.idp.extraction;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.connector.api.annotation.OutboundConnector;
 import io.camunda.connector.api.error.ConnectorException;
 import io.camunda.connector.api.outbound.OutboundConnectorContext;
@@ -15,9 +18,14 @@ import io.camunda.connector.idp.extraction.caller.BedrockCaller;
 import io.camunda.connector.idp.extraction.caller.PollingTextractCaller;
 import io.camunda.connector.idp.extraction.model.ExtractionRequest;
 import io.camunda.connector.idp.extraction.model.ExtractionResult;
+import io.camunda.connector.idp.extraction.model.TaxonomyItem;
 import io.camunda.connector.idp.extraction.supplier.BedrockRuntimeClientSupplier;
 import io.camunda.connector.idp.extraction.supplier.S3ClientSupplier;
 import io.camunda.connector.idp.extraction.supplier.TextractClientSupplier;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.apache.hc.core5.http.HttpStatus;
 import org.apache.pdfbox.Loader;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.text.PDFTextStripper;
@@ -51,12 +59,15 @@ public class ExtractionConnectorFunction implements OutboundConnectorFunction {
 
   private final BedrockCaller bedrockCaller;
 
+  private final ObjectMapper objectMapper;
+
   public ExtractionConnectorFunction() {
     this.textractClientSupplier = new TextractClientSupplier();
     this.s3ClientSupplier = new S3ClientSupplier();
     this.bedrockRuntimeClientSupplier = new BedrockRuntimeClientSupplier();
     this.pollingTextractCaller = new PollingTextractCaller();
     this.bedrockCaller = new BedrockCaller();
+    this.objectMapper = new ObjectMapper();
   }
 
   public ExtractionConnectorFunction(
@@ -64,6 +75,7 @@ public class ExtractionConnectorFunction implements OutboundConnectorFunction {
     this.textractClientSupplier = new TextractClientSupplier();
     this.s3ClientSupplier = new S3ClientSupplier();
     this.bedrockRuntimeClientSupplier = new BedrockRuntimeClientSupplier();
+    this.objectMapper = new ObjectMapper();
     this.pollingTextractCaller = pollingTextractCaller;
     this.bedrockCaller = bedrockCaller;
   }
@@ -85,10 +97,62 @@ public class ExtractionConnectorFunction implements OutboundConnectorFunction {
               extractedText,
               bedrockRuntimeClientSupplier.getBedrockRuntimeClient(extractionRequest));
 
-      return new ExtractionResult(bedrockResponse);
+      return new ExtractionResult(
+          buildResponseJsonIfPossible(bedrockResponse, extractionRequest.input().taxonomyItems()));
     } catch (Exception e) {
       LOGGER.error("Document extraction failed: {}", e.getMessage());
       throw new ConnectorException(e);
+    }
+  }
+
+  private Map<String, Object> buildResponseJsonIfPossible(
+      String llmResponse, List<TaxonomyItem> taxonomyItems) {
+    try {
+      var llmResponseJson = objectMapper.readValue(llmResponse, JsonNode.class);
+      var taxonomyItemsNames = taxonomyItems.stream().map(TaxonomyItem::name).toList();
+
+      if (llmResponseJson.isObject()) {
+        if (llmResponseJson.has("response")
+            && llmResponseJson.size() == 1
+            && !taxonomyItemsNames.contains("response")) {
+          var nestedResponse = llmResponseJson.get("response");
+          if (nestedResponse.isObject()) {
+            llmResponseJson = nestedResponse;
+          } else if (nestedResponse.isTextual()) {
+            llmResponseJson = objectMapper.readValue(nestedResponse.asText(), JsonNode.class);
+          } else {
+            throw new ConnectorException(
+                String.valueOf(HttpStatus.SC_SERVER_ERROR),
+                String.format(
+                    "LLM response is neither a JSON object nor a string: %s", llmResponse));
+          }
+        }
+
+        Map<String, Object> result =
+            taxonomyItemsNames.stream()
+                .filter(llmResponseJson::has)
+                .collect(Collectors.toMap(name -> name, llmResponseJson::get));
+
+        var missingKeys =
+            taxonomyItemsNames.stream().filter(name -> !result.containsKey(name)).toList();
+        if (!missingKeys.isEmpty()) {
+          LOGGER.warn(
+              "LLM model response is missing the following keys: ({})",
+              String.join(", ", missingKeys));
+        }
+
+        return result;
+
+      } else {
+        throw new ConnectorException(
+            String.valueOf(HttpStatus.SC_SERVER_ERROR),
+            String.format("LLM response is not a JSON object: %s", llmResponse));
+      }
+    } catch (JsonProcessingException e) {
+      throw new ConnectorException(
+          String.valueOf(HttpStatus.SC_SERVER_ERROR),
+          String.format("Failed to parse the JSON response from LLM: %s", llmResponse),
+          e);
     }
   }
 

--- a/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/model/ExtractionResult.java
+++ b/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/model/ExtractionResult.java
@@ -6,4 +6,6 @@
  */
 package io.camunda.connector.idp.extraction.model;
 
-public record ExtractionResult(Object response) {}
+import java.util.Map;
+
+public record ExtractionResult(Map<String, Object> response) {}

--- a/connectors/idp-extraction/src/test/java/io/camunda/connector/idp/extraction/ExtractionConnectorFunctionTest.java
+++ b/connectors/idp-extraction/src/test/java/io/camunda/connector/idp/extraction/ExtractionConnectorFunctionTest.java
@@ -221,8 +221,7 @@ class ExtractionConnectorFunctionTest {
     when(pollingTextractCaller.call(any(), any(), any(), any()))
         .thenReturn("Test extracted text from test document.pdf");
     when(bedrockCaller.call(any(), any(), any()))
-        .thenReturn(
-            """
+        .thenReturn("""
                         {
                         """);
 
@@ -239,8 +238,7 @@ class ExtractionConnectorFunctionTest {
     when(pollingTextractCaller.call(any(), any(), any(), any()))
         .thenReturn("Test extracted text from test document.pdf");
     when(bedrockCaller.call(any(), any(), any()))
-        .thenReturn(
-            """
+        .thenReturn("""
                         []
                         """);
 

--- a/connectors/idp-extraction/src/test/java/io/camunda/connector/idp/extraction/ExtractionConnectorFunctionTest.java
+++ b/connectors/idp-extraction/src/test/java/io/camunda/connector/idp/extraction/ExtractionConnectorFunctionTest.java
@@ -7,14 +7,22 @@
 package io.camunda.connector.idp.extraction;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.connector.api.error.ConnectorException;
 import io.camunda.connector.idp.extraction.caller.BedrockCaller;
 import io.camunda.connector.idp.extraction.caller.PollingTextractCaller;
 import io.camunda.connector.idp.extraction.model.ExtractionResult;
 import io.camunda.connector.idp.extraction.util.ExtractionTestUtils;
 import io.camunda.connector.test.outbound.OutboundConnectorContextBuilder;
+import java.util.Map;
+import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -23,6 +31,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class ExtractionConnectorFunctionTest {
+
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
   @Mock private PollingTextractCaller pollingTextractCaller;
 
@@ -33,6 +43,180 @@ class ExtractionConnectorFunctionTest {
   @Test
   void executeExtractionReturnsCorrectResult() throws Exception {
     var outBounderContext = prepareConnectorContext();
+    var expectedResponseJson =
+        """
+            {
+            	"sum": "$12.25",
+            	"supplier": "Camunda Inc."
+            }
+        """;
+
+    when(pollingTextractCaller.call(any(), any(), any(), any()))
+        .thenReturn("Test extracted text from test document.pdf");
+    when(bedrockCaller.call(any(), any(), any())).thenReturn(expectedResponseJson);
+
+    var result = extractionConnectorFunction.execute(outBounderContext);
+    assertExtractionResult(result, expectedResponseJson);
+  }
+
+  @Test
+  void
+      executeExtractionReturnsPartiallyCorrectResult_whenLlmResponseIsMissingValueForSomeTaxonomyItems()
+          throws Exception {
+    var outBounderContext = prepareConnectorContext();
+    var expectedResponseJson =
+        """
+            {
+            	"sum": "$12.25"
+            }
+        """;
+
+    when(pollingTextractCaller.call(any(), any(), any(), any()))
+        .thenReturn("Test extracted text from test document.pdf");
+    when(bedrockCaller.call(any(), any(), any())).thenReturn(expectedResponseJson);
+
+    var result = extractionConnectorFunction.execute(outBounderContext);
+    assertExtractionResult(result, expectedResponseJson);
+  }
+
+  @Test
+  void executeExtractionReturnsCorrectResult_whenLlmResponseContainsNestedResponseObject()
+      throws Exception {
+    var outBounderContext = prepareConnectorContext();
+
+    when(pollingTextractCaller.call(any(), any(), any(), any()))
+        .thenReturn("Test extracted text from test document.pdf");
+    when(bedrockCaller.call(any(), any(), any()))
+        .thenReturn(
+            """
+                   {
+                     "response": {
+                                   "sum": "$12.25",
+                                   "supplier": "Camunda Inc."
+                                 }
+                   }
+               """);
+
+    var result = extractionConnectorFunction.execute(outBounderContext);
+    var expectedResponseJson =
+        """
+            {
+              "sum": "$12.25",
+              "supplier": "Camunda Inc."
+            }
+        """;
+    assertExtractionResult(result, expectedResponseJson);
+  }
+
+  @Test
+  void executeExtractionReturnsCorrectResult_whenLlmResponseContainsObjectAsValueForTaxonomyItem()
+      throws Exception {
+    var outBounderContext = prepareConnectorContext();
+
+    when(pollingTextractCaller.call(any(), any(), any(), any()))
+        .thenReturn("Test extracted text from test document.pdf");
+    when(bedrockCaller.call(any(), any(), any()))
+        .thenReturn(
+            """
+                   {
+                     "sum": "$12.25",
+                     "supplier": {
+                                   "id": 12345,
+                                   "name": "Camunda Inc.",
+                                   "city": "Berlin",
+                                   "country": "Germany"
+                                 }
+                   }
+               """);
+
+    var result = extractionConnectorFunction.execute(outBounderContext);
+    var expectedResponseJson =
+        """
+            {
+              "sum": "$12.25",
+              "supplier": {
+                            "id": 12345,
+                            "name": "Camunda Inc.",
+                            "city": "Berlin",
+                            "country": "Germany"
+                          }
+            }
+        """;
+    assertExtractionResult(result, expectedResponseJson);
+  }
+
+  @Test
+  void
+      executeExtractionReturnsCorrectResult_whenLlmResponseContainsNestedObjectAsValueForTaxonomyItem()
+          throws Exception {
+    var outBounderContext = prepareConnectorContext();
+
+    when(pollingTextractCaller.call(any(), any(), any(), any()))
+        .thenReturn("Test extracted text from test document.pdf");
+    when(bedrockCaller.call(any(), any(), any()))
+        .thenReturn(
+            """
+                   {
+                     "response": {
+                                   "sum": "$12.25",
+                                   "supplier": {
+                                                 "id": 12345,
+                                                 "name": "Camunda Inc.",
+                                                 "city": "Berlin",
+                                                 "country": "Germany"
+                                               }
+                                 }
+                   }
+               """);
+
+    var result = extractionConnectorFunction.execute(outBounderContext);
+    var expectedResponseJson =
+        """
+            {
+              "sum": "$12.25",
+              "supplier": {
+                            "id": 12345,
+                            "name": "Camunda Inc.",
+                            "city": "Berlin",
+                            "country": "Germany"
+                          }
+            }
+        """;
+    assertExtractionResult(result, expectedResponseJson);
+  }
+
+  @Test
+  void
+      executeExtractionReturnsCorrectResult_whenLlmResponseContainsNestedResponseWithValidStringifiedObject()
+          throws Exception {
+    var outBounderContext = prepareConnectorContext();
+
+    when(pollingTextractCaller.call(any(), any(), any(), any()))
+        .thenReturn("Test extracted text from test document.pdf");
+    when(bedrockCaller.call(any(), any(), any()))
+        .thenReturn(
+            """
+                   {
+                     "response": "\\n\\n{\\"sum\\":\\"$12.25\\",\\"supplier\\":\\"Camunda Inc.\\"}"
+                   }
+               """);
+
+    var result = extractionConnectorFunction.execute(outBounderContext);
+    var expectedResponseJson =
+        """
+            {
+            	"sum": "$12.25",
+            	"supplier": "Camunda Inc."
+            }
+        """;
+    assertExtractionResult(result, expectedResponseJson);
+  }
+
+  @Test
+  void
+      executeExtractionShouldThrowConnectorException_whenLlmResponseContainsInvalidStringifiedObject()
+          throws Exception {
+    var outBounderContext = prepareConnectorContext();
 
     when(pollingTextractCaller.call(any(), any(), any(), any()))
         .thenReturn("Test extracted text from test document.pdf");
@@ -40,13 +224,88 @@ class ExtractionConnectorFunctionTest {
         .thenReturn(
             """
                         {
-                        	"name": "John Smith",
-                        	"age": 32
+                        """);
+
+    assertThatThrownBy(() -> extractionConnectorFunction.execute(outBounderContext))
+        .isInstanceOf(ConnectorException.class)
+        .hasMessageContaining("Failed to parse the JSON response");
+  }
+
+  @Test
+  void executeExtractionShouldThrowConnectorException_whenLlmResponseIsNotJsonObject()
+      throws Exception {
+    var outBounderContext = prepareConnectorContext();
+
+    when(pollingTextractCaller.call(any(), any(), any(), any()))
+        .thenReturn("Test extracted text from test document.pdf");
+    when(bedrockCaller.call(any(), any(), any()))
+        .thenReturn(
+            """
+                        []
+                        """);
+
+    assertThatThrownBy(() -> extractionConnectorFunction.execute(outBounderContext))
+        .isInstanceOf(ConnectorException.class)
+        .hasMessageContaining("LLM response is not a JSON object");
+  }
+
+  @Test
+  void
+      executeExtractionShouldThrowConnectorException_whenLlmResponseContainsNestedResponseWithInvalidStringifiedObject()
+          throws Exception {
+    var outBounderContext = prepareConnectorContext();
+
+    when(pollingTextractCaller.call(any(), any(), any(), any()))
+        .thenReturn("Test extracted text from test document.pdf");
+    when(bedrockCaller.call(any(), any(), any()))
+        .thenReturn(
+            """
+                        {
+                          "response": "{"
                         }
                         """);
 
-    var result = extractionConnectorFunction.execute(outBounderContext);
-    assertThat(result).isInstanceOf(ExtractionResult.class);
+    assertThatThrownBy(() -> extractionConnectorFunction.execute(outBounderContext))
+        .isInstanceOf(ConnectorException.class)
+        .hasMessageContaining("Failed to parse the JSON response");
+  }
+
+  @Test
+  void
+      executeExtractionShouldThrowConnectorException_whenLlmResponseContainsNestedResponseWithJsonArray()
+          throws Exception {
+    var outBounderContext = prepareConnectorContext();
+
+    when(pollingTextractCaller.call(any(), any(), any(), any()))
+        .thenReturn("Test extracted text from test document.pdf");
+    when(bedrockCaller.call(any(), any(), any()))
+        .thenReturn(
+            """
+                        {
+                          "response": []
+                        }
+                        """);
+
+    assertThatThrownBy(() -> extractionConnectorFunction.execute(outBounderContext))
+        .isInstanceOf(ConnectorException.class)
+        .hasMessageContaining("LLM response is neither a JSON object nor a string");
+  }
+
+  private void assertExtractionResult(Object result, String expectedResponse)
+      throws JsonProcessingException {
+    var expected =
+        OBJECT_MAPPER.convertValue(
+            OBJECT_MAPPER.readTree(expectedResponse),
+            new TypeReference<Map<String, JsonNode>>() {});
+
+    assertThat(result)
+        .isNotNull()
+        .isInstanceOf(ExtractionResult.class)
+        .asInstanceOf(InstanceOfAssertFactories.type(ExtractionResult.class))
+        .satisfies(
+            extractionResult ->
+                assertThat(extractionResult.response())
+                    .containsExactlyInAnyOrderEntriesOf(expected));
   }
 
   private OutboundConnectorContextBuilder.TestConnectorContext prepareConnectorContext() {


### PR DESCRIPTION
## Description

This PR is a cherry-pick to backport the changes [merged](https://github.com/camunda/connectors/commit/bca3459b7ae8b40097485fdf310ecb9fad21a094) to main to `release/8.7`

## Related issues

<!-- Which issues are closed by this PR or are related -->

Doesn't close any issue. It is just a back port.

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.

