### PR TITLE
fix(rest-connector): Return always an array for set cookie headers

### DIFF
--- a/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/client/apache/CustomApacheHttpClient.java
+++ b/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/client/apache/CustomApacheHttpClient.java
@@ -112,9 +112,7 @@ public class CustomApacheHttpClient implements HttpClient {
               .execute(
                   apacheRequest,
                   new HttpCommonResultResponseHandler(
-                      executionEnvironment,
-                      request.isStoreResponse(),
-                      request.getGroupSetCookieHeaders()));
+                      executionEnvironment, request.isStoreResponse()));
       if (HttpStatusHelper.isError(result.status())) {
         throw ConnectorExceptionMapper.from(result);
       }

--- a/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/client/apache/HttpCommonResultResponseHandler.java
+++ b/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/client/apache/HttpCommonResultResponseHandler.java
@@ -49,17 +49,12 @@ public class HttpCommonResultResponseHandler
 
   private final boolean isStoreResponseSelected;
 
-  private final boolean groupSetCookieHeaders;
-
   public HttpCommonResultResponseHandler(
-      @Nullable ExecutionEnvironment executionEnvironment,
-      boolean isStoreResponseSelected,
-      boolean groupSetCookieHeaders) {
+      @Nullable ExecutionEnvironment executionEnvironment, boolean isStoreResponseSelected) {
     this.executionEnvironment = executionEnvironment;
     this.isStoreResponseSelected = isStoreResponseSelected;
     this.fileResponseHandler =
         new FileResponseHandler(executionEnvironment, isStoreResponseSelected);
-    this.groupSetCookieHeaders = groupSetCookieHeaders;
   }
 
   @Override
@@ -67,8 +62,7 @@ public class HttpCommonResultResponseHandler
     int code = response.getCode();
     String reason = response.getReasonPhrase();
     Map<String, Object> headers =
-        HttpCommonResultResponseHandler.formatHeaders(
-            response.getHeaders(), this.groupSetCookieHeaders);
+        HttpCommonResultResponseHandler.formatHeaders(response.getHeaders());
 
     if (response.getEntity() != null) {
       try (InputStream content = response.getEntity().getContent()) {
@@ -90,23 +84,20 @@ public class HttpCommonResultResponseHandler
     return new HttpCommonResult(code, headers, null, reason);
   }
 
-  private static Map<String, Object> formatHeaders(
-      Header[] headersArray, Boolean groupSetCookieHeaders) {
+  private static Map<String, Object> formatHeaders(Header[] headersArray) {
     return Arrays.stream(headersArray)
         .collect(
             Collectors.toMap(
                 Header::getName,
                 header -> {
-                  if (groupSetCookieHeaders && header.getName().equalsIgnoreCase("Set-Cookie")) {
+                  if (header.getName().equalsIgnoreCase("Set-Cookie")) {
                     return new ArrayList<String>(List.of(header.getValue()));
                   } else {
                     return header.getValue();
                   }
                 },
                 (existingValue, newValue) -> {
-                  if (groupSetCookieHeaders
-                      && existingValue instanceof List
-                      && newValue instanceof List) {
+                  if (existingValue instanceof List && newValue instanceof List) {
                     ((List<String>) existingValue).add(((List<String>) newValue).getFirst());
                   }
                   return existingValue;

--- a/connectors/http/http-base/src/test/java/io/camunda/connector/http/base/HttpServiceTest.java
+++ b/connectors/http/http-base/src/test/java/io/camunda/connector/http/base/HttpServiceTest.java
@@ -38,6 +38,7 @@ import io.camunda.connector.http.base.model.HttpMethod;
 import io.camunda.document.store.DocumentCreationRequest;
 import java.util.Base64;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import org.apache.hc.core5.http.ContentType;
@@ -200,8 +201,7 @@ public class HttpServiceTest {
     // then
     assertThat(result).isNotNull();
     assertThat(result.status()).isEqualTo(200);
-    assertThat(result.headers()).contains(Map.entry("Set-Cookie", "key=value"));
-    assertThat(result.headers()).doesNotContain(Map.entry("Set-Cookie", "key2=value2"));
+    assertThat(result.headers()).containsEntry("Set-Cookie", List.of("key=value", "key2=value2"));
     JSONAssert.assertEquals(
         "{\"responseKey1\":\"value1\",\"responseKey2\":40,\"responseKey3\":null}",
         objectMapper.writeValueAsString(result.body()),

--- a/connectors/http/http-base/src/test/java/io/camunda/connector/http/base/client/apache/CustomApacheHttpClientTest.java
+++ b/connectors/http/http-base/src/test/java/io/camunda/connector/http/base/client/apache/CustomApacheHttpClientTest.java
@@ -602,17 +602,14 @@ public class CustomApacheHttpClientTest {
 
     private static Stream<Arguments> provideTestDataForHeaderTest() {
       return Stream.of(
-          Arguments.of("Set-Cookie", "false", false, "Test-Value-1"),
-          Arguments.of("Set-Cookie", "true", true, List.of("Test-Value-1", "Test-Value-2")),
-          Arguments.of("other-than-set-cookie", "false", false, "Test-Value-1"),
-          Arguments.of("other-than-set-cookie", "true", false, "Test-Value-1"));
+          Arguments.of("Set-Cookie", true, List.of("Test-Value-1", "Test-Value-2")),
+          Arguments.of("other-than-set-cookie", false, "Test-Value-1"));
     }
 
     @ParameterizedTest
     @MethodSource("provideTestDataForHeaderTest")
     public void shouldReturn200_whenDuplicatedHeadersAsListDisabled(
         String headerKey,
-        String groupSetCookieHeaders,
         Boolean expectedDoesReturnList,
         Object expectedValue,
         WireMockRuntimeInfo wmRuntimeInfo) {
@@ -620,7 +617,6 @@ public class CustomApacheHttpClientTest {
       HttpCommonRequest request = new HttpCommonRequest();
       request.setMethod(HttpMethod.GET);
       request.setUrl(wmRuntimeInfo.getHttpBaseUrl() + "/path");
-      request.setGroupSetCookieHeaders(groupSetCookieHeaders);
       HttpCommonResult result = customApacheHttpClient.execute(request);
       assertThat(result).isNotNull();
       assertThat(result.status()).isEqualTo(200);

--- a/connectors/http/http-base/src/test/java/io/camunda/connector/http/base/client/apache/HttpCommonResultResponseHandlerTest.java
+++ b/connectors/http/http-base/src/test/java/io/camunda/connector/http/base/client/apache/HttpCommonResultResponseHandlerTest.java
@@ -35,8 +35,7 @@ public class HttpCommonResultResponseHandlerTest {
   @Test
   public void shouldHandleJsonResponse_whenCloudFunctionDisabled() throws Exception {
     // given
-    HttpCommonResultResponseHandler handler =
-        new HttpCommonResultResponseHandler(null, false, false);
+    HttpCommonResultResponseHandler handler = new HttpCommonResultResponseHandler(null, false);
     ClassicHttpResponse response = new BasicClassicHttpResponse(200);
     Header[] headers = new Header[] {new BasicHeader("Content-Type", "application/json")};
     response.setHeaders(headers);
@@ -56,8 +55,7 @@ public class HttpCommonResultResponseHandlerTest {
   @Test
   public void shouldHandleTextResponse_whenCloudFunctionDisabled() throws Exception {
     // given
-    HttpCommonResultResponseHandler handler =
-        new HttpCommonResultResponseHandler(null, false, false);
+    HttpCommonResultResponseHandler handler = new HttpCommonResultResponseHandler(null, false);
     ClassicHttpResponse response = new BasicClassicHttpResponse(200);
     Header[] headers = new Header[] {new BasicHeader("Content-Type", "text/plain")};
     response.setHeaders(headers);
@@ -78,8 +76,7 @@ public class HttpCommonResultResponseHandlerTest {
   public void shouldHandleJsonResponse_whenCloudFunctionEnabled() throws Exception {
     // given
     HttpCommonResultResponseHandler handler =
-        new HttpCommonResultResponseHandler(
-            new ExecutionEnvironment.SaaSCluster(null), false, false);
+        new HttpCommonResultResponseHandler(new ExecutionEnvironment.SaaSCluster(null), false);
     ClassicHttpResponse response = new BasicClassicHttpResponse(201);
     Header[] headers = new Header[] {new BasicHeader("Content-Type", "application/json")};
     response.setHeaders(headers);
@@ -104,8 +101,7 @@ public class HttpCommonResultResponseHandlerTest {
   public void shouldHandleError_whenCloudFunctionEnabled() throws Exception {
     // given
     HttpCommonResultResponseHandler handler =
-        new HttpCommonResultResponseHandler(
-            new ExecutionEnvironment.SaaSCluster(null), false, false);
+        new HttpCommonResultResponseHandler(new ExecutionEnvironment.SaaSCluster(null), false);
     ClassicHttpResponse response = new BasicClassicHttpResponse(500);
     Header[] headers =
         new Header[] {
@@ -134,8 +130,7 @@ public class HttpCommonResultResponseHandlerTest {
   public void shouldHandleJsonAsTextResponse_whenCloudFunctionEnabled() throws Exception {
     // given
     HttpCommonResultResponseHandler handler =
-        new HttpCommonResultResponseHandler(
-            new ExecutionEnvironment.SaaSCluster(null), false, false);
+        new HttpCommonResultResponseHandler(new ExecutionEnvironment.SaaSCluster(null), false);
     ClassicHttpResponse response = new BasicClassicHttpResponse(201);
     Header[] headers = new Header[] {new BasicHeader("Content-Type", "application/json")};
     response.setHeaders(headers);

--- a/connectors/http/rest/element-templates/http-json-connector.json
+++ b/connectors/http/rest/element-templates/http-json-connector.json
@@ -333,14 +333,14 @@
     },
     "type" : "Dropdown",
     "choices" : [ {
-      "name" : "DELETE",
-      "value" : "DELETE"
-    }, {
       "name" : "POST",
       "value" : "POST"
     }, {
       "name" : "GET",
       "value" : "GET"
+    }, {
+      "name" : "DELETE",
+      "value" : "DELETE"
     }, {
       "name" : "PATCH",
       "value" : "PATCH"

--- a/connectors/http/rest/element-templates/http-json-connector.json
+++ b/connectors/http/rest/element-templates/http-json-connector.json
@@ -333,14 +333,14 @@
     },
     "type" : "Dropdown",
     "choices" : [ {
+      "name" : "DELETE",
+      "value" : "DELETE"
+    }, {
       "name" : "POST",
       "value" : "POST"
     }, {
       "name" : "GET",
       "value" : "GET"
-    }, {
-      "name" : "DELETE",
-      "value" : "DELETE"
     }, {
       "name" : "PATCH",
       "value" : "PATCH"
@@ -410,17 +410,6 @@
     "group" : "endpoint",
     "binding" : {
       "name" : "skipEncoding",
-      "type" : "zeebe:input"
-    },
-    "type" : "Hidden"
-  }, {
-    "id" : "groupSetCookieHeaders",
-    "label" : "Group set-cookie headers to a list",
-    "description" : "Group incoming headers with same name into a List to support <a href=\"https://datatracker.ietf.org/doc/html/rfc6265\">multiple Set-Cookie headers</a>.",
-    "optional" : true,
-    "group" : "endpoint",
-    "binding" : {
-      "name" : "groupSetCookieHeaders",
       "type" : "zeebe:input"
     },
     "type" : "Hidden"

--- a/connectors/http/rest/element-templates/hybrid/http-json-connector-hybrid.json
+++ b/connectors/http/rest/element-templates/hybrid/http-json-connector-hybrid.json
@@ -338,14 +338,14 @@
     },
     "type" : "Dropdown",
     "choices" : [ {
+      "name" : "DELETE",
+      "value" : "DELETE"
+    }, {
       "name" : "POST",
       "value" : "POST"
     }, {
       "name" : "GET",
       "value" : "GET"
-    }, {
-      "name" : "DELETE",
-      "value" : "DELETE"
     }, {
       "name" : "PATCH",
       "value" : "PATCH"
@@ -415,17 +415,6 @@
     "group" : "endpoint",
     "binding" : {
       "name" : "skipEncoding",
-      "type" : "zeebe:input"
-    },
-    "type" : "Hidden"
-  }, {
-    "id" : "groupSetCookieHeaders",
-    "label" : "Group set-cookie headers to a list",
-    "description" : "Group incoming headers with same name into a List to support <a href=\"https://datatracker.ietf.org/doc/html/rfc6265\">multiple Set-Cookie headers</a>.",
-    "optional" : true,
-    "group" : "endpoint",
-    "binding" : {
-      "name" : "groupSetCookieHeaders",
       "type" : "zeebe:input"
     },
     "type" : "Hidden"

--- a/connectors/http/rest/element-templates/hybrid/http-json-connector-hybrid.json
+++ b/connectors/http/rest/element-templates/hybrid/http-json-connector-hybrid.json
@@ -338,14 +338,14 @@
     },
     "type" : "Dropdown",
     "choices" : [ {
-      "name" : "DELETE",
-      "value" : "DELETE"
-    }, {
       "name" : "POST",
       "value" : "POST"
     }, {
       "name" : "GET",
       "value" : "GET"
+    }, {
+      "name" : "DELETE",
+      "value" : "DELETE"
     }, {
       "name" : "PATCH",
       "value" : "PATCH"


### PR DESCRIPTION
## Description
Restore the default behavior of 8.5. Set cookie headers a always merged into an array. The flag for grouping is removed. This also means, if someone sets the group flag to false, this will be ignored after an update, but I think that is ok, as this is not really a helpful feature and I guess noone will do this. 

This will be documented [here](https://github.com/camunda/camunda-docs/pull/5137)

I did not document the "breaking change" in the last two lines of the table, because i consider this a bug fix and not a breaking change. Let me know if you disagree, then I will add it to the docs. (We could adjust the behavior so that if there is only one Set-Cookie header, it returns a simple string instead of an array. However, this approach is not ideal. For example, if an endpoint sometimes returns one cookie (e.g., when login fails) and sometimes two (e.g., when login succeeds), it would make handling cookies in FEEL more complex.)

| Behavior | Expected result |
| -- | -- |
| Users are on 8.5 and update to 8.6.11 |nothing should break |
| Users are on 8.5 and update to 8.6.7 | will break but should be fixed with manually editing the template |
| Users are on 8.6.7 and did edit their template and update to 8.6.11 | should work fine |
| Users are on 8.6.7 and did not edit their template and update to 8.6.11 | breaking change: if using a set cookie header in a feel result, this will fail, as now an array is returned |
| Users are on 8.6.7 or higher and update to 8.7 | breaking change: if using a set cookie header in a feel result, this will fail, as now an array is returned |

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #4201 

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.

