### PR TITLE
chore(cors): fix cors config for /inbound-instances subpaths

### DIFF
--- a/bundle/camunda-saas-bundle/src/main/java/io/camunda/connector/runtime/saas/security/InboundInstancesSecurityConfiguration.java
+++ b/bundle/camunda-saas-bundle/src/main/java/io/camunda/connector/runtime/saas/security/InboundInstancesSecurityConfiguration.java
@@ -41,7 +41,7 @@ public class InboundInstancesSecurityConfiguration {
   @Value("${camunda.connector.auth.console.audience:}")
   private String consoleAudience;
 
-  @Value("${camunda.connector.auth.allowed-roles:owner,admin}")
+  @Value("${camunda.connector.auth.allowed.roles:owner,admin}")
   private List<String> allowedRoles;
 
   @Value("${camunda.connector.auth.issuer}")
@@ -49,6 +49,9 @@ public class InboundInstancesSecurityConfiguration {
 
   @Value("${camunda.endpoints.cors.allowed.origins:*}")
   private String[] allowedOrigins;
+
+  @Value("${camunda.endpoints.cors.allow.credentials:false}")
+  private boolean allowCredentials;
 
   @Value("${camunda.endpoints.cors.mappings:/**}")
   private List<String> mappings;
@@ -65,7 +68,7 @@ public class InboundInstancesSecurityConfiguration {
             mapping ->
                 registry
                     .addMapping(mapping)
-                    .allowCredentials(true)
+                    .allowCredentials(allowCredentials)
                     .allowedOrigins(allowedOrigins)
                     .allowedMethods("*"));
       }

--- a/bundle/camunda-saas-bundle/src/main/resources/application.properties
+++ b/bundle/camunda-saas-bundle/src/main/resources/application.properties
@@ -25,5 +25,6 @@ camunda.connector.inbound.log.size=10
 # Disabling the default Operate client, we are configuring our own
 camunda.client.operate.enabled=false
 camunda.connector.secretprovider.discovery.enabled=false
-camunda.connector.auth.allowed-roles=owner,admin
+camunda.connector.auth.allowed.roles=owner,admin
 camunda.endpoints.cors.mappings=/inbound-instances/**
+camunda.endpoints.cors.allow.credentials=true


### PR DESCRIPTION
(cherry picked from commit 5533dea48a6f748396f2f9bcf50c49759f258dee)

## Description
- Fix tests by adding the possibility to disable `allowCredentials`. When set to `true` one cannot set the allowed origins to `*` anymore.

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.

