### PR TITLE
chore(cors): fix authenticated path after API changes

### DIFF
--- a/bundle/camunda-saas-bundle/src/main/java/io/camunda/connector/runtime/saas/security/InboundInstancesSecurityConfiguration.java
+++ b/bundle/camunda-saas-bundle/src/main/java/io/camunda/connector/runtime/saas/security/InboundInstancesSecurityConfiguration.java
@@ -21,6 +21,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.annotation.Order;
+import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.oauth2.core.DelegatingOAuth2TokenValidator;
@@ -78,11 +79,13 @@ public class InboundInstancesSecurityConfiguration {
   @Bean
   @Order(2)
   public SecurityFilterChain inboundInstancesFilterChain(HttpSecurity http) throws Exception {
-    http.csrf(csrf -> csrf.ignoringRequestMatchers("/inbound-instances/**"))
+    http.cors(Customizer.withDefaults())
+        .csrf(csrf -> csrf.ignoringRequestMatchers("/inbound-instances/**"))
         .securityMatchers(
             requestMatcherConfigurer ->
                 requestMatcherConfigurer.requestMatchers("/inbound-instances/**"))
-        .authorizeHttpRequests(auth -> auth.requestMatchers("/inbound-instances").authenticated())
+        .authorizeHttpRequests(
+            auth -> auth.requestMatchers("/inbound-instances/**").authenticated())
         .oauth2ResourceServer(
             oauth2 -> oauth2.jwt(jwt -> jwt.decoder(inboundInstancesJwtDecoder())));
     return http.build();


### PR DESCRIPTION
## Description

- The `/inbound-instances` API changes and has now a sub path. Thus we need to authenticate all the requests for this path and its subpaths.
- Enable default cors to see if it stops the 401 when performing an OPTIONS request


## Checklist

- [x] PR has a **milestone** or the `no milestone` label.

