### PR TITLE
chore(api): increase allowed headers size to 1MB

### DIFF
--- a/bundle/camunda-saas-bundle/src/main/resources/application.properties
+++ b/bundle/camunda-saas-bundle/src/main/resources/application.properties
@@ -28,3 +28,5 @@ camunda.connector.secretprovider.discovery.enabled=false
 camunda.connector.auth.allowed.roles=owner,admin
 camunda.endpoints.cors.mappings=/inbound-instances/**
 camunda.endpoints.cors.allow.credentials=true
+
+server.max-http-request-header-size=1MB

--- a/bundle/default-bundle/src/main/resources/application.properties
+++ b/bundle/default-bundle/src/main/resources/application.properties
@@ -12,3 +12,5 @@ camunda.client.zeebe.defaults.max-jobs-active=32
 camunda.client.zeebe.defaults.stream-enabled=true
 camunda.client.rest-address=http://localhost:8088
 camunda.client.mode=self-managed
+
+server.max-http-request-header-size=1MB

--- a/connector-runtime/connector-runtime-application/src/main/resources/application.properties
+++ b/connector-runtime/connector-runtime-application/src/main/resources/application.properties
@@ -12,3 +12,5 @@ camunda.client.zeebe.defaults.max-jobs-active=32
 camunda.client.zeebe.defaults.stream-enabled=true
 camunda.client.rest-address=http://localhost:8088
 camunda.client.mode=self-managed
+
+server.max-http-request-header-size=1MB


### PR DESCRIPTION
## Description

- Increase headers size to 1MB, this is useful when Console calls our API with a huge JWT which might happen


## Checklist

- [ ] PR has a **milestone** or the `no milestone` label.

