### PR TITLE
feature(secrets): secrets are now hidden from the error message in operate, making error message more reliable

### DIFF
--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/outbound/ConnectorJobHandler.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/outbound/ConnectorJobHandler.java
@@ -126,13 +126,13 @@ public class ConnectorJobHandler implements JobHandler {
         .newThrowErrorCommand(job)
         .errorCode(error.code())
         .variables(error.variables())
-        .errorMessage(truncateErrorMessage( hideSecretsFromLog(error.message())));
+        .errorMessage(truncateErrorMessage(hideSecretsFromLog(error.message())));
   }
 
   protected FinalCommandStep<FailJobResponse> prepareFailJobCommand(
       JobClient client, ActivatedJob job, ConnectorResult.ErrorResult result) {
     var retries = result.retries();
-    var errorMessage = truncateErrorMessage( hideSecretsFromLog(result.exception().getMessage()));
+    var errorMessage = truncateErrorMessage(hideSecretsFromLog(result.exception().getMessage()));
     Duration backoff = result.retryBackoff();
     var command =
         client.newFailCommand(job).retries(Math.max(retries, 0)).errorMessage(errorMessage);
@@ -274,18 +274,19 @@ public class ConnectorJobHandler implements JobHandler {
 
   private ConnectorResult handleSDKException(
       ActivatedJob job, Exception ex, Integer retries, String errorCode, Duration backoffDuration) {
-    try{
+    try {
       LOGGER.debug(
-              "Failing job with retry config => job: {} for tenant: {} with error code: {}, retries: {} and remaining backoffDuration: {}",
-              job.getKey(),
-              job.getTenantId(),
-              errorCode,
-              retries,
-              backoffDuration);
+          "Failing job with retry config => job: {} for tenant: {} with error code: {}, retries: {} and remaining backoffDuration: {}",
+          job.getKey(),
+          job.getTenantId(),
+          errorCode,
+          retries,
+          backoffDuration);
 
       return new ErrorResult(Map.of("error", exceptionToMap(ex)), ex, retries, backoffDuration);
-    }catch (Exception e){
-      System.out.println("Exception while processing job with retry config => job: " + job.getKey());
+    } catch (Exception e) {
+      System.out.println(
+          "Exception while processing job with retry config => job: " + job.getKey());
     }
     return null;
   }

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/outbound/JobHandlerContext.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/outbound/JobHandlerContext.java
@@ -104,11 +104,8 @@ public class JobHandlerContext extends AbstractConnectorContext
               .orElse("Unexpected Error, Further investigation is needed");
 
       throw new ConnectorException("JSON_FORMAT_ERROR", errorMessage);
-    } catch (MismatchedInputException e) {
-      throw new ConnectorException("JSON_MISMATCH_ERROR", e.getOriginalMessage());
     } catch (JsonProcessingException e) {
-      throw new ConnectorException(
-          "JSON_PROCESSING_ERROR", "Exception: " + e.getClass().getSimpleName() + " was raised", e);
+      throw new ConnectorException("JSON_PROCESSING_ERROR", e.getOriginalMessage(), e);
     }
   }
 

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretProviderAggregator.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretProviderAggregator.java
@@ -17,6 +17,7 @@
 package io.camunda.connector.runtime.core.secret;
 
 import io.camunda.connector.api.secret.SecretProvider;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import org.slf4j.Logger;
@@ -56,6 +57,14 @@ public class SecretProviderAggregator implements SecretProvider {
     }
     LOG.debug("Could not resolve secret '{}'", secretName);
     return null;
+  }
+
+  @Override
+  public List<String> getSecretValues() {
+    return secretProviders.stream()
+        .map(SecretProvider::getSecretValues)
+        .flatMap(Collection::stream)
+        .toList();
   }
 
   public List<SecretProvider> getSecretProviders() {

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/FooBarSecretProvider.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/FooBarSecretProvider.java
@@ -19,6 +19,7 @@ package io.camunda.connector.runtime.core;
 import static java.util.Collections.singletonMap;
 
 import io.camunda.connector.api.secret.SecretProvider;
+import java.util.List;
 import java.util.Map;
 
 public class FooBarSecretProvider implements SecretProvider {
@@ -31,5 +32,10 @@ public class FooBarSecretProvider implements SecretProvider {
   @Override
   public String getSecret(String value) {
     return SECRETS.get(value);
+  }
+
+  @Override
+  public List<String> getSecretValues() {
+    return SECRETS.values().stream().toList();
   }
 }

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/outbound/ConnectorJobHandlerTest.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/outbound/ConnectorJobHandlerTest.java
@@ -485,6 +485,24 @@ class ConnectorJobHandlerTest {
     }
 
     @Test
+    void shouldHideSecretsInJobErrorMessage() {
+      // given
+      var errorMessage = "Something went wrong: bar is not the correct password";
+      var jobHandler =
+              newConnectorJobHandler(
+                      context -> {
+                        throw new IllegalArgumentException(errorMessage);
+                      });
+
+      // when
+      var result = JobBuilder.create().executeAndCaptureResult(jobHandler, false);
+
+      // then
+      assertThat(result.getErrorMessage())
+              .isEqualTo("Something went wrong: *** is not the correct password");
+    }
+
+    @Test
     void shouldTruncateBpmnErrorMessage() {
       // given
       var veryLongMessage = "This is quite a long message".repeat(300); // 8400 chars

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/outbound/ConnectorJobHandlerTest.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/outbound/ConnectorJobHandlerTest.java
@@ -489,17 +489,17 @@ class ConnectorJobHandlerTest {
       // given
       var errorMessage = "Something went wrong: bar is not the correct password";
       var jobHandler =
-              newConnectorJobHandler(
-                      context -> {
-                        throw new IllegalArgumentException(errorMessage);
-                      });
+          newConnectorJobHandler(
+              context -> {
+                throw new IllegalArgumentException(errorMessage);
+              });
 
       // when
       var result = JobBuilder.create().executeAndCaptureResult(jobHandler, false);
 
       // then
       assertThat(result.getErrorMessage())
-              .isEqualTo("Something went wrong: *** is not the correct password");
+          .isEqualTo("Something went wrong: *** is not the correct password");
     }
 
     @Test

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/secret/ConsoleSecretProvider.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/secret/ConsoleSecretProvider.java
@@ -22,6 +22,7 @@ import com.google.common.cache.LoadingCache;
 import io.camunda.connector.api.secret.SecretProvider;
 import io.camunda.connector.runtime.secret.console.ConsoleSecretApiClient;
 import java.time.Duration;
+import java.util.List;
 import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -57,5 +58,10 @@ public class ConsoleSecretProvider implements SecretProvider {
   public String getSecret(String name) {
     LOGGER.debug("Resolving secret for key: " + name);
     return secretsCache.getUnchecked(CACHE_KEY).getOrDefault(name, null);
+  }
+
+  @Override
+  public List<String> getSecretValues() {
+    return secretsCache.getUnchecked(CACHE_KEY).values().stream().toList();
   }
 }

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/secret/ConsoleSecretProviderTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/secret/ConsoleSecretProviderTest.java
@@ -32,6 +32,8 @@ import io.camunda.connector.runtime.secret.console.ConsoleSecretApiClient;
 import java.time.Duration;
 import java.util.Collections;
 import java.util.Map;
+
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -82,9 +84,9 @@ public class ConsoleSecretProviderTest {
     // Mock successful response
     var secretsResponse = Map.of("secretKey", "secretValue", "secretKey2", "secretValue2");
     wm.stubFor(
-            get(urlPathMatching("/secrets"))
-                    .withHeader("Authorization", matching("Bearer XXX"))
-                    .willReturn(ResponseDefinitionBuilder.okForJson(secretsResponse)));
+        get(urlPathMatching("/secrets"))
+            .withHeader("Authorization", matching("Bearer XXX"))
+            .willReturn(ResponseDefinitionBuilder.okForJson(secretsResponse)));
 
     // Test the client
     var secrets = client.getSecrets();
@@ -92,7 +94,7 @@ public class ConsoleSecretProviderTest {
 
     // Test the provider
     var consoleSecretProvider = new ConsoleSecretProvider(client, Duration.ofSeconds(1));
-    assertArrayEquals(new String[] {"secretValue", "secretValue2"}, consoleSecretProvider.getSecretValues().toArray());
+    Assertions.assertArrayEquals(new String[] {"secretValue", "secretValue2"}, consoleSecretProvider.getSecretValues().toArray());
   }
 
   @Test

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/secret/ConsoleSecretProviderTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/secret/ConsoleSecretProviderTest.java
@@ -21,7 +21,6 @@ import static com.github.tomakehurst.wiremock.client.WireMock.matching;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathMatching;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 import static org.assertj.core.api.Assertions.*;
-import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertThrows;
 import static org.mockito.Mockito.when;
 
@@ -32,7 +31,6 @@ import io.camunda.connector.runtime.secret.console.ConsoleSecretApiClient;
 import java.time.Duration;
 import java.util.Collections;
 import java.util.Map;
-
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -94,7 +92,9 @@ public class ConsoleSecretProviderTest {
 
     // Test the provider
     var consoleSecretProvider = new ConsoleSecretProvider(client, Duration.ofSeconds(1));
-    Assertions.assertArrayEquals(new String[] {"secretValue", "secretValue2"}, consoleSecretProvider.getSecretValues().toArray());
+    Assertions.assertArrayEquals(
+        new String[] {"secretValue", "secretValue2"},
+        consoleSecretProvider.getSecretValues().toArray());
   }
 
   @Test

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/secret/EnvironmentSecretProviderTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/secret/EnvironmentSecretProviderTest.java
@@ -19,10 +19,9 @@ package io.camunda.connector.runtime.secret;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.Assert.assertArrayEquals;
 
+import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.mock.env.MockEnvironment;
-
-import java.util.List;
 
 public class EnvironmentSecretProviderTest {
 
@@ -44,5 +43,4 @@ public class EnvironmentSecretProviderTest {
     List<String> myTotalSecret = secretProvider.getSecretValues();
     assertArrayEquals(new String[] {"beebop", "beebop2"}, myTotalSecret.toArray());
   }
-
 }

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/secret/EnvironmentSecretProviderTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/secret/EnvironmentSecretProviderTest.java
@@ -16,10 +16,13 @@
  */
 package io.camunda.connector.runtime.secret;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.Assert.assertArrayEquals;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.mock.env.MockEnvironment;
+
+import java.util.List;
 
 public class EnvironmentSecretProviderTest {
 
@@ -31,4 +34,15 @@ public class EnvironmentSecretProviderTest {
     String myTotalSecret = secretProvider.getSecret("my-total-secret");
     assertThat(myTotalSecret).isEqualTo("beebop");
   }
+
+  @Test
+  void shouldReturnAllSecretsValues() {
+    MockEnvironment env = new MockEnvironment();
+    env.setProperty("secrets.my-total-secret", "beebop");
+    env.setProperty("secrets.my-total-secret2", "beebop2");
+    EnvironmentSecretProvider secretProvider = new EnvironmentSecretProvider(env, "secrets.");
+    List<String> myTotalSecret = secretProvider.getSecretValues();
+    assertArrayEquals(new String[] {"beebop", "beebop2"}, myTotalSecret.toArray());
+  }
+
 }

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/secret/providers/BarSpringSecretProvider.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/secret/providers/BarSpringSecretProvider.java
@@ -17,6 +17,7 @@
 package io.camunda.connector.runtime.secret.providers;
 
 import io.camunda.connector.api.secret.SecretProvider;
+import java.util.List;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -29,5 +30,10 @@ public class BarSpringSecretProvider implements SecretProvider {
     } else {
       return null;
     }
+  }
+
+  @Override
+  public List<String> getSecretValues() {
+    return List.of();
   }
 }

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/secret/providers/FooSpringSecretProvider.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/secret/providers/FooSpringSecretProvider.java
@@ -17,6 +17,7 @@
 package io.camunda.connector.runtime.secret.providers;
 
 import io.camunda.connector.api.secret.SecretProvider;
+import java.util.List;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -29,5 +30,10 @@ public class FooSpringSecretProvider implements SecretProvider {
     } else {
       return null;
     }
+  }
+
+  @Override
+  public List<String> getSecretValues() {
+    return List.of();
   }
 }

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/secret/providers/SpiSecretProvider.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/secret/providers/SpiSecretProvider.java
@@ -17,6 +17,7 @@
 package io.camunda.connector.runtime.secret.providers;
 
 import io.camunda.connector.api.secret.SecretProvider;
+import java.util.List;
 
 // note this is not defined as a Spring bean
 public class SpiSecretProvider implements SecretProvider {
@@ -28,5 +29,10 @@ public class SpiSecretProvider implements SecretProvider {
     } else {
       return null;
     }
+  }
+
+  @Override
+  public List<String> getSecretValues() {
+    return List.of();
   }
 }

--- a/connector-sdk/core/src/main/java/io/camunda/connector/api/secret/SecretProvider.java
+++ b/connector-sdk/core/src/main/java/io/camunda/connector/api/secret/SecretProvider.java
@@ -34,7 +34,6 @@ public interface SecretProvider {
   String getSecret(String name);
 
   /**
-   *
    * @return
    */
   List<String> getSecretValues();

--- a/connector-sdk/core/src/main/java/io/camunda/connector/api/secret/SecretProvider.java
+++ b/connector-sdk/core/src/main/java/io/camunda/connector/api/secret/SecretProvider.java
@@ -16,6 +16,8 @@
  */
 package io.camunda.connector.api.secret;
 
+import java.util.List;
+
 /**
  * Provider of secrets for an environment. This class will be instantiated from an environment
  * runtime according to the <a
@@ -30,4 +32,10 @@ public interface SecretProvider {
    *     returned.
    */
   String getSecret(String name);
+
+  /**
+   *
+   * @return
+   */
+  List<String> getSecretValues();
 }

--- a/connector-sdk/test/src/main/java/io/camunda/connector/test/inbound/InboundConnectorContextBuilder.java
+++ b/connector-sdk/test/src/main/java/io/camunda/connector/test/inbound/InboundConnectorContextBuilder.java
@@ -29,6 +29,7 @@ import io.camunda.connector.runtime.core.AbstractConnectorContext;
 import io.camunda.connector.runtime.core.inbound.InboundConnectorElement;
 import io.camunda.connector.runtime.core.inbound.InboundConnectorReportingContext;
 import io.camunda.connector.test.ConnectorContextTestUtil;
+import io.camunda.connector.test.secretsprovider.SecretProviderConnectorContextBuilder;
 import io.camunda.document.Document;
 import io.camunda.document.factory.DocumentFactory;
 import io.camunda.document.factory.DocumentFactoryImpl;
@@ -48,7 +49,7 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 public class InboundConnectorContextBuilder {
 
   protected final Map<String, String> secrets = new HashMap<>();
-  protected SecretProvider secretProvider = secrets::get;
+  protected SecretProvider secretProvider = new SecretProviderConnectorContextBuilder(secrets);
   protected Map<String, Object> properties;
   protected InboundConnectorDefinition definition;
   protected ValidationProvider validationProvider;

--- a/connector-sdk/test/src/main/java/io/camunda/connector/test/outbound/OutboundConnectorContextBuilder.java
+++ b/connector-sdk/test/src/main/java/io/camunda/connector/test/outbound/OutboundConnectorContextBuilder.java
@@ -27,6 +27,7 @@ import io.camunda.connector.api.validation.ValidationProvider;
 import io.camunda.connector.document.annotation.jackson.JacksonModuleDocumentDeserializer;
 import io.camunda.connector.runtime.core.AbstractConnectorContext;
 import io.camunda.connector.test.ConnectorContextTestUtil;
+import io.camunda.connector.test.secretsprovider.SecretProviderConnectorContextBuilder;
 import io.camunda.document.Document;
 import io.camunda.document.factory.DocumentFactory;
 import io.camunda.document.factory.DocumentFactoryImpl;
@@ -41,7 +42,7 @@ public class OutboundConnectorContextBuilder {
 
   protected final Map<String, String> secrets = new HashMap<>();
   protected final Map<String, String> headers = new HashMap<>();
-  protected SecretProvider secretProvider = secrets::get;
+  protected SecretProvider secretProvider = new SecretProviderConnectorContextBuilder(secrets);
   protected ValidationProvider validationProvider;
   protected Map<String, Object> variables;
   protected DocumentFactory documentFactory =

--- a/connector-sdk/test/src/main/java/io/camunda/connector/test/secretsprovider/SecretProviderConnectorContextBuilder.java
+++ b/connector-sdk/test/src/main/java/io/camunda/connector/test/secretsprovider/SecretProviderConnectorContextBuilder.java
@@ -14,16 +14,23 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.camunda.connector.runtime.core;
+package io.camunda.connector.test.secretsprovider;
 
 import io.camunda.connector.api.secret.SecretProvider;
 import java.util.List;
+import java.util.Map;
 
-public class NoOpSecretProvider implements SecretProvider {
+public class SecretProviderConnectorContextBuilder implements SecretProvider {
+
+  private final Map<String, String> secrets;
+
+  public SecretProviderConnectorContextBuilder(Map<String, String> secrets) {
+    this.secrets = secrets;
+  }
 
   @Override
-  public String getSecret(String value) {
-    return null;
+  public String getSecret(String name) {
+    return secrets.get(name);
   }
 
   @Override

--- a/connector-sdk/validation/src/main/java/io/camunda/connector/validation/impl/DefaultValidationProvider.java
+++ b/connector-sdk/validation/src/main/java/io/camunda/connector/validation/impl/DefaultValidationProvider.java
@@ -75,6 +75,9 @@ public class DefaultValidationProvider implements ValidationProvider {
    * property values.
    */
   protected String buildValidationMessage(ConstraintViolation<Object> violation) {
-    return " - Property: " + violation.getPropertyPath().toString() + ": Validation failed.";
+    return " - Property: "
+        + violation.getPropertyPath().toString()
+        + ": Validation failed. Original message: "
+        + violation.getMessage();
   }
 }

--- a/connectors/aws/aws-textract/src/test/java/io/camunda/connector/textract/TextractConnectorFunctionTest.java
+++ b/connectors/aws/aws-textract/src/test/java/io/camunda/connector/textract/TextractConnectorFunctionTest.java
@@ -6,6 +6,7 @@
  */
 package io.camunda.connector.textract;
 
+import static io.camunda.connector.textract.model.TextractRequestData.WRONG_OUTPUT_VALUES_MSG;
 import static io.camunda.connector.textract.util.TextractTestUtils.ASYNC_EXECUTION_JSON_WITH_ROLE_ARN_AND_WITHOUT_SNS_TOPIC;
 import static io.camunda.connector.textract.util.TextractTestUtils.ASYNC_EXECUTION_JSON_WITH_SNS_TOPIC_AND_WITHOUT_ROLE_ARN;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -85,6 +86,7 @@ class TextractConnectorFunctionTest {
             ConnectorInputException.class,
             () -> textractConnectorFunction.execute(outBounderContext));
 
+    assertThat(exception).hasMessageContaining(WRONG_OUTPUT_VALUES_MSG);
     assertThat(exception).isInstanceOf(ConnectorInputException.class);
   }
 

--- a/connectors/http/graphql/src/test/java/io/camunda/connector/http/graphql/GraphQLFunctionTest.java
+++ b/connectors/http/graphql/src/test/java/io/camunda/connector/http/graphql/GraphQLFunctionTest.java
@@ -18,12 +18,14 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.github.tomakehurst.wiremock.junit5.WireMockTest;
 import io.camunda.connector.api.error.ConnectorInputException;
 import io.camunda.connector.api.json.ConnectorsObjectMapperSupplier;
+import io.camunda.connector.api.secret.SecretProvider;
 import io.camunda.connector.http.base.model.HttpCommonResult;
 import io.camunda.connector.http.graphql.model.GraphQLRequest;
 import io.camunda.connector.http.graphql.utils.GraphQLRequestMapper;
 import io.camunda.connector.test.outbound.OutboundConnectorContextBuilder;
 import io.camunda.connector.validation.impl.DefaultValidationProvider;
 import java.io.IOException;
+import java.util.List;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -76,7 +78,7 @@ public class GraphQLFunctionTest extends BaseTest {
         OutboundConnectorContextBuilder.create()
             .variables(input)
             .validation(new DefaultValidationProvider())
-            .secrets(name -> "foo")
+            .secrets(secretProvider())
             .build();
 
     // when
@@ -93,7 +95,7 @@ public class GraphQLFunctionTest extends BaseTest {
   void execute_shouldSetConnectTime(final String input) throws Exception {
     // given - minimal required entity
     final var context =
-        OutboundConnectorContextBuilder.create().variables(input).secrets(name -> "foo").build();
+        OutboundConnectorContextBuilder.create().variables(input).secrets(secretProvider()).build();
     final var expectedTimeInSeconds =
         objectMapper
             .readValue(
@@ -111,7 +113,21 @@ public class GraphQLFunctionTest extends BaseTest {
 
   private HttpCommonResult arrange(String input) throws Exception {
     final var context =
-        OutboundConnectorContextBuilder.create().variables(input).secrets(name -> "foo").build();
+        OutboundConnectorContextBuilder.create().variables(input).secrets(secretProvider()).build();
     return (HttpCommonResult) functionUnderTest.execute(context);
+  }
+
+  private SecretProvider secretProvider() {
+    return new SecretProvider() {
+      @Override
+      public String getSecret(String name) {
+        return "foo";
+      }
+
+      @Override
+      public List<String> getSecretValues() {
+        return List.of();
+      }
+    };
   }
 }

--- a/connectors/http/rest/src/test/java/io/camunda/connector/http/rest/HttpJsonFunctionTest.java
+++ b/connectors/http/rest/src/test/java/io/camunda/connector/http/rest/HttpJsonFunctionTest.java
@@ -27,10 +27,12 @@ import static org.assertj.core.api.Assertions.catchException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.github.tomakehurst.wiremock.junit5.WireMockTest;
 import io.camunda.connector.api.error.ConnectorInputException;
+import io.camunda.connector.api.secret.SecretProvider;
 import io.camunda.connector.http.base.model.HttpCommonResult;
 import io.camunda.connector.test.outbound.OutboundConnectorContextBuilder;
 import io.camunda.connector.validation.impl.DefaultValidationProvider;
 import java.io.IOException;
+import java.util.List;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -85,7 +87,7 @@ public class HttpJsonFunctionTest extends BaseTest {
         OutboundConnectorContextBuilder.create()
             .variables(input)
             .validation(new DefaultValidationProvider())
-            .secrets(name -> "foo")
+            .secrets(secretProvider())
             .build();
 
     // when
@@ -119,7 +121,21 @@ public class HttpJsonFunctionTest extends BaseTest {
 
   private HttpCommonResult arrange(String input) throws Exception {
     final var context =
-        OutboundConnectorContextBuilder.create().variables(input).secrets(name -> "foo").build();
+        OutboundConnectorContextBuilder.create().variables(input).secrets(secretProvider()).build();
     return (HttpCommonResult) functionUnderTest.execute(context);
+  }
+
+  private SecretProvider secretProvider() {
+    return new SecretProvider() {
+      @Override
+      public String getSecret(String name) {
+        return "foo";
+      }
+
+      @Override
+      public List<String> getSecretValues() {
+        return List.of();
+      }
+    };
   }
 }

--- a/secret-providers/gcp-secret-provider/src/main/java/io/camunda/connector/runtime/cloud/GcpSecretManagerSecretProvider.java
+++ b/secret-providers/gcp-secret-provider/src/main/java/io/camunda/connector/runtime/cloud/GcpSecretManagerSecretProvider.java
@@ -30,6 +30,7 @@ import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import io.camunda.connector.api.error.ConnectorException;
 import io.camunda.connector.api.secret.SecretProvider;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -133,6 +134,15 @@ public class GcpSecretManagerSecretProvider implements SecretProvider {
       return secretsCache.get(CACHE_KEY).get(name);
     } catch (ExecutionException e) {
       throw new ConnectorException("Could not resolve secrets: " + e.getMessage(), e);
+    }
+  }
+
+  @Override
+  public List<String> getSecretValues() {
+    try {
+      return secretsCache.get(CACHE_KEY).values().stream().toList();
+    } catch (ExecutionException e) {
+      throw new RuntimeException(e);
     }
   }
 }


### PR DESCRIPTION
## Description

PR to hide secret from error  message sent to zeebe

- Secrets are being hidden from error message sent to zeebe
- a prefix SECRET_ is automatically added if none has been set
- The object mapper exception is way more precise
- Error from validation are more concise

## Related issues

closes https://github.com/camunda/connectors/issues/3221

## Checklist

- [ ] PR has a **milestone** or the `no milestone` label.

