### PR TITLE
chore(api): increase allowed headers size to 1MB (#4223)

### DIFF
--- a/bundle/camunda-saas-bundle/src/main/resources/application.properties
+++ b/bundle/camunda-saas-bundle/src/main/resources/application.properties
@@ -36,3 +36,5 @@ camunda.connector.secretprovider.discovery.enabled=false
 camunda.connector.auth.allowed.roles=owner,admin
 camunda.endpoints.cors.mappings=/inbound-instances/**
 camunda.endpoints.cors.allow.credentials=true
+
+server.max-http-request-header-size=1MB

--- a/bundle/default-bundle/src/main/resources/application.properties
+++ b/bundle/default-bundle/src/main/resources/application.properties
@@ -12,4 +12,4 @@ camunda.client.zeebe.defaults.stream-enabled=true
 camunda.client.zeebe.rest-address=http://localhost:8088
 camunda.client.mode=self-managed
 
-operate.client.base-url=http://localhost:8081
+server.max-http-request-header-size=1MB

--- a/bundle/default-bundle/src/main/resources/application.properties
+++ b/bundle/default-bundle/src/main/resources/application.properties
@@ -12,4 +12,5 @@ camunda.client.zeebe.defaults.stream-enabled=true
 camunda.client.zeebe.rest-address=http://localhost:8088
 camunda.client.mode=self-managed
 
+operate.client.base-url=http://localhost:8081
 server.max-http-request-header-size=1MB

--- a/connector-runtime/connector-runtime-application/src/main/resources/application.properties
+++ b/connector-runtime/connector-runtime-application/src/main/resources/application.properties
@@ -12,3 +12,5 @@ camunda.client.zeebe.defaults.max-jobs-active=32
 camunda.client.zeebe.defaults.stream-enabled=true
 camunda.client.zeebe.rest-address=http://localhost:8088
 camunda.client.mode=self-managed
+
+server.max-http-request-header-size=1MB


### PR DESCRIPTION
(cherry picked from commit 83a708b22d401e3e170d7d40e3e78bdad055df73)

## Description
 Backport of https://github.com/camunda/connectors/pull/4223

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.

