### PR TITLE
chore(deps): enable minor version upgrades on release branches

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -30,8 +30,7 @@
         "/^release/.*/"
       ],
       "matchUpdateTypes": [
-        "major",
-        "minor"
+        "major"
       ],
       "enabled": false
     },


### PR DESCRIPTION
## Description

During the last CVE review, we discovered that Renovate doesn't automatically apply minor version upgrades on feature branches.

Sometimes libraries release fixes for major issues in minor versions instead of patches, so I think it is beneficial if we get minor version upgrades as well.

On the other hand, this might introduce more instability, so I'm open to suggestions/critic regarding this change.

## Checklist

- [ ] PR has a **milestone** or the `no milestone` label.

