### PR TITLE
fix(deps): bump dependencies to fix CVEs

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -89,7 +89,7 @@ limitations under the License.</license.inlineheader>
     <version.failsafe>3.3.2</version.failsafe>
     <version.grpc>1.65.0</version.grpc>
 
-    <version.spring-boot>3.3.5</version.spring-boot>
+    <version.spring-boot>3.3.9</version.spring-boot>
     <version.spring-cloud-gcp-starter-logging>5.1.0</version.spring-cloud-gcp-starter-logging>
     <version.logback>1.5.17</version.logback>
 
@@ -117,7 +117,7 @@ limitations under the License.</license.inlineheader>
     <version.kafka-clients>3.7.0</version.kafka-clients>
 
     <version.microsoft-graph>6.4.0</version.microsoft-graph>
-    <version.azure-identity>1.12.2</version.azure-identity>
+    <version.azure-identity>1.15.3</version.azure-identity>
 
     <version.bouncycastle>1.78.1</version.bouncycastle>
     <version.sendGrid>4.10.3</version.sendGrid>


### PR DESCRIPTION
## Description

We currently have 1 critical and 1 high-severity CVE in release/8.5 and below.

- https://www.cve.org/CVERecord?id=CVE-2024-57699 coming from a JSON parser library transitively via `azure-identity`
- https://www.cve.org/CVERecord?id=CVE-2024-50379 coming from Tomcat transitively via Spring Boot

This PR will fix those vulnerabilities by upgrading to versions of those libraries that are patched.

## Checklist

- [ ] PR has a **milestone** or the `no milestone` label.

