### PR TITLE
fix(deps): bump dependencies to fix CVEs (8.3)

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -85,7 +85,7 @@ limitations under the License.</license.inlineheader>
     <version.failsafe>3.3.2</version.failsafe>
     <version.grpc>1.65.0</version.grpc>
 
-    <version.spring-boot>3.3.5</version.spring-boot>
+    <version.spring-boot>3.3.9</version.spring-boot>
     <version.spring-cloud-gcp-starter-logging>5.3.0</version.spring-cloud-gcp-starter-logging>
     <version.logback>1.5.17</version.logback>
 
@@ -108,7 +108,7 @@ limitations under the License.</license.inlineheader>
     <version.kafka-clients>3.7.1</version.kafka-clients>
 
     <version.microsoft-graph>5.80.0</version.microsoft-graph>
-    <version.azure-identity>1.12.2</version.azure-identity>
+    <version.azure-identity>1.15.3</version.azure-identity>
 
     <version.bouncycastle>1.78.1</version.bouncycastle>
     <version.sendGrid>4.10.3</version.sendGrid>


### PR DESCRIPTION
## Description

Backport of https://github.com/camunda/connectors/pull/4267 to 8.3

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #

## Checklist

- [ ] PR has a **milestone** or the `no milestone` label.

