### PR TITLE
Add skipEndcoding flag for rest and gitlab connector (#3840)

### DIFF
--- a/connectors/gitlab/element-templates/gitlab-connector.json
+++ b/connectors/gitlab/element-templates/gitlab-connector.json
@@ -2,7 +2,7 @@
   "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
   "name": "GitLab Outbound Connector",
   "id": "io.camunda.connectors.GitLab.v1",
-  "version": 5,
+  "version": 6,
   "description": "Administer and work with issues, releases, and more",
   "icon": {
     "contents": "data:image/svg+xml;utf8,%3Csvg width='18px' height='18px' viewBox='0 -10 256 256' version='1.1' xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' preserveAspectRatio='xMidYMid'%3E%3Cg%3E%3Cpath d='M128.07485,236.074667 L128.07485,236.074667 L175.17885,91.1043048 L80.9708495,91.1043048 L128.07485,236.074667 L128.07485,236.074667 Z' fill='%23E24329'%3E%3C/path%3E%3Cpath d='M128.07485,236.074423 L80.9708495,91.104061 L14.9557638,91.104061 L128.07485,236.074423 L128.07485,236.074423 Z' fill='%23FC6D26'%3E%3C/path%3E%3Cpath d='M14.9558857,91.1044267 L14.9558857,91.1044267 L0.641828571,135.159589 C-0.663771429,139.17757 0.766171429,143.57955 4.18438095,146.06275 L128.074971,236.074789 L14.9558857,91.1044267 L14.9558857,91.1044267 Z' fill='%23FCA326'%3E%3C/path%3E%3Cpath d='M14.9558857,91.1045486 L80.9709714,91.1045486 L52.6000762,3.79026286 C51.1408762,-0.703146667 44.7847619,-0.701927619 43.3255619,3.79026286 L14.9558857,91.1045486 L14.9558857,91.1045486 Z' fill='%23E24329'%3E%3C/path%3E%3Cpath d='M128.07485,236.074423 L175.17885,91.104061 L241.193935,91.104061 L128.07485,236.074423 L128.07485,236.074423 Z' fill='%23FC6D26'%3E%3C/path%3E%3Cpath d='M241.193935,91.1044267 L241.193935,91.1044267 L255.507992,135.159589 C256.813592,139.17757 255.38365,143.57955 251.96544,146.06275 L128.07485,236.074789 L241.193935,91.1044267 L241.193935,91.1044267 Z' fill='%23FCA326'%3E%3C/path%3E%3Cpath d='M241.193935,91.1045486 L175.17885,91.1045486 L203.549745,3.79026286 C205.008945,-0.703146667 211.365059,-0.701927619 212.824259,3.79026286 L241.193935,91.1045486 L241.193935,91.1045486 Z' fill='%23E24329'%3E%3C/path%3E%3C/g%3E%3C/svg%3E"
@@ -635,6 +635,19 @@
           "createAnIssue"
         ]
       }
+    },
+    {
+      "id": "skipEncoding",
+      "label": "Skip URL encoding",
+      "description": "Skip the default URL decoding and encoding behavior",
+      "optional": true,
+      "group": "endpoint",
+      "binding": {
+        "name": "skipEncoding",
+        "type": "zeebe:input"
+      },
+      "value": "true",
+      "type": "Hidden"
     },
     {
       "label": "Issue ID",

--- a/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/client/apache/builder/parts/ApacheRequestUriBuilder.java
+++ b/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/client/apache/builder/parts/ApacheRequestUriBuilder.java
@@ -23,6 +23,6 @@ public class ApacheRequestUriBuilder implements ApacheRequestPartBuilder {
 
   @Override
   public void build(ClassicRequestBuilder builder, HttpCommonRequest request) {
-    builder.setUri(UrlEncoder.toEncodedUri(request.getUrl()));
+    builder.setUri(UrlEncoder.toEncodedUri(request.getUrl(), request.getSkipEncoding()));
   }
 }

--- a/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/client/apache/builder/parts/UrlEncoder.java
+++ b/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/client/apache/builder/parts/UrlEncoder.java
@@ -28,11 +28,14 @@ import org.slf4j.LoggerFactory;
 public class UrlEncoder {
   private static final Logger LOG = LoggerFactory.getLogger(ApacheRequestUriBuilder.class);
 
-  public static URI toEncodedUri(String requestUrl) {
+  public static URI toEncodedUri(String requestUrl, Boolean skipEncoding) {
     try {
       // We try to decode the URL first, because it might be encoded already
       // which would lead to double encoding. Decoding is safe here, because it does nothing if
       // the URL is not encoded.
+      if (skipEncoding) {
+        return URI.create(requestUrl);
+      }
       var decodedUrl = URLDecoder.decode(requestUrl, StandardCharsets.UTF_8);
       var url = new URL(decodedUrl);
       // Only this URI constructor escapes the URL properly

--- a/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/model/HttpCommonRequest.java
+++ b/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/model/HttpCommonRequest.java
@@ -111,6 +111,15 @@ public class HttpCommonRequest {
       optional = true)
   private String groupSetCookieHeaders;
 
+  @TemplateProperty(
+      label = "Skip URL encoding",
+      description = "Skip the default URL decoding and encoding behavior",
+      type = TemplateProperty.PropertyType.Hidden,
+      feel = FeelMode.disabled,
+      group = "endpoint",
+      optional = true)
+  private String skipEncoding;
+
   public Object getBody() {
     return body;
   }
@@ -145,6 +154,14 @@ public class HttpCommonRequest {
 
   public void setGroupSetCookieHeaders(final String groupSetCookieHeaders) {
     this.groupSetCookieHeaders = groupSetCookieHeaders;
+  }
+
+  public boolean getSkipEncoding() {
+    return Objects.equals(skipEncoding, "true");
+  }
+
+  public void setSkipEncoding(final String skipEncoding) {
+    this.skipEncoding = skipEncoding;
   }
 
   public boolean hasAuthentication() {

--- a/connectors/http/http-base/src/test/java/io/camunda/connector/http/base/client/apache/CustomApacheHttpClientTest.java
+++ b/connectors/http/http-base/src/test/java/io/camunda/connector/http/base/client/apache/CustomApacheHttpClientTest.java
@@ -19,6 +19,7 @@ package io.camunda.connector.http.base.client.apache;
 import static com.github.tomakehurst.wiremock.client.WireMock.aMultipart;
 import static com.github.tomakehurst.wiremock.client.WireMock.and;
 import static com.github.tomakehurst.wiremock.client.WireMock.any;
+import static com.github.tomakehurst.wiremock.client.WireMock.badRequest;
 import static com.github.tomakehurst.wiremock.client.WireMock.containing;
 import static com.github.tomakehurst.wiremock.client.WireMock.created;
 import static com.github.tomakehurst.wiremock.client.WireMock.delete;
@@ -254,6 +255,23 @@ public class CustomApacheHttpClientTest {
       request.setUrl(
           wmRuntimeInfo.getHttpBaseUrl() + "/path%20with%20spaces?andQuery=Param with space");
       HttpCommonResult result = customApacheHttpClient.execute(request);
+      assertThat(result).isNotNull();
+      assertThat(result.status()).isEqualTo(200);
+    }
+
+    @ParameterizedTest
+    @EnumSource(HttpMethod.class)
+    public void shouldKeepOriginalEscaping_whenSkipEscapingIsSet(
+        HttpMethod method, WireMockRuntimeInfo wmRuntimeInfo) {
+      stubFor(any(urlEqualTo("/path%2Fwith%2Fencoding")).willReturn(ok()));
+      stubFor(any(urlEqualTo("/path/with/encoding")).willReturn(badRequest()));
+      HttpCommonRequest request = new HttpCommonRequest();
+      request.setMethod(method);
+      request.setUrl(wmRuntimeInfo.getHttpBaseUrl() + "/path%2Fwith%2Fencoding");
+      request.setSkipEncoding("true");
+
+      HttpCommonResult result = customApacheHttpClient.execute(request);
+
       assertThat(result).isNotNull();
       assertThat(result.status()).isEqualTo(200);
     }

--- a/connectors/http/rest/README.md
+++ b/connectors/http/rest/README.md
@@ -232,6 +232,6 @@ leading to the following result
 | Connector Info            |                                                                       |
 | ---                       | ---                                                                   |
 | Type                      | io.camunda:http-json:1                                                            |
-| Version                   | 8                                                         |
+| Version                   | 10                                                         |
 | Supported element types   |     |
 

--- a/connectors/http/rest/element-templates/http-json-connector.json
+++ b/connectors/http/rest/element-templates/http-json-connector.json
@@ -4,7 +4,7 @@
   "id" : "io.camunda.connectors.HttpJson.v2",
   "description" : "Invoke REST API",
   "documentationRef" : "https://docs.camunda.io/docs/components/connectors/protocol/rest/",
-  "version" : 8,
+  "version" : 10,
   "category" : {
     "id" : "connectors",
     "name" : "Connectors"
@@ -395,6 +395,17 @@
     "group" : "endpoint",
     "binding" : {
       "name" : "groupSetCookieHeaders",
+      "type" : "zeebe:input"
+    },
+    "type" : "Hidden"
+  }, {
+    "id" : "skipEncoding",
+    "label" : "Skip URL encoding",
+    "description" : "Skip the default URL decoding and encoding behavior",
+    "optional" : true,
+    "group" : "endpoint",
+    "binding" : {
+      "name" : "skipEncoding",
       "type" : "zeebe:input"
     },
     "type" : "Hidden"

--- a/connectors/http/rest/element-templates/hybrid/http-json-connector-hybrid.json
+++ b/connectors/http/rest/element-templates/hybrid/http-json-connector-hybrid.json
@@ -4,7 +4,7 @@
   "id" : "io.camunda.connectors.HttpJson.v2-hybrid",
   "description" : "Invoke REST API",
   "documentationRef" : "https://docs.camunda.io/docs/components/connectors/protocol/rest/",
-  "version" : 8,
+  "version" : 10,
   "category" : {
     "id" : "connectors",
     "name" : "Connectors"
@@ -400,6 +400,17 @@
     "group" : "endpoint",
     "binding" : {
       "name" : "groupSetCookieHeaders",
+      "type" : "zeebe:input"
+    },
+    "type" : "Hidden"
+  }, {
+    "id" : "skipEncoding",
+    "label" : "Skip URL encoding",
+    "description" : "Skip the default URL decoding and encoding behavior",
+    "optional" : true,
+    "group" : "endpoint",
+    "binding" : {
+      "name" : "skipEncoding",
       "type" : "zeebe:input"
     },
     "type" : "Hidden"

--- a/connectors/http/rest/src/main/java/io/camunda/connector/http/rest/HttpJsonFunction.java
+++ b/connectors/http/rest/src/main/java/io/camunda/connector/http/rest/HttpJsonFunction.java
@@ -33,6 +33,7 @@ import io.camunda.connector.http.rest.model.HttpJsonRequest;
       "authentication",
       "headers",
       "queryParameters",
+      "skipEncoding",
       "connectionTimeoutInSeconds",
       "readTimeoutInSeconds",
       "writeTimeoutInSeconds",
@@ -46,7 +47,7 @@ import io.camunda.connector.http.rest.model.HttpJsonRequest;
     description = "Invoke REST API",
     inputDataClass = HttpJsonRequest.class,
     outputDataClass = HttpCommonResult.class,
-    version = 8,
+    version = 10,
     propertyGroups = {
       @PropertyGroup(id = "authentication", label = "Authentication"),
       @PropertyGroup(id = "endpoint", label = "HTTP endpoint"),


### PR DESCRIPTION
(cherry picked from commit 0c341672729da9d4e59fc716ec38d47f1331648d)

## Description
Backport the skip encoding feature to 8.6. Feel free to test this will change nothing, if not explicitly updating the element template.


## Checklist

- [x] PR has a **milestone** or the `no milestone` label.

