### PR TITLE
chore(idp-extraction-connector): added a failsafe for filenames

### DIFF
--- a/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/caller/VertexCaller.java
+++ b/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/caller/VertexCaller.java
@@ -33,10 +33,15 @@ public class VertexCaller {
       throws Exception {
     LlmModel llmModel = LlmModel.fromId(input.converseData().modelId());
     String fileUri;
+    final String fileName =
+        input.document().metadata().getFileName() == null
+            ? "temporaryDocument"
+            : input.document().metadata().getFileName();
     try {
       fileUri =
           GcsUtil.uploadNewFileFromDocument(
               input.document(),
+              fileName,
               baseRequest.getConfiguration().bucketName(),
               baseRequest.getConfiguration().projectId(),
               baseRequest.getAuthentication());
@@ -64,7 +69,7 @@ public class VertexCaller {
             try {
               GcsUtil.deleteObjectFromBucket(
                   baseRequest.getConfiguration().bucketName(),
-                  input.document().metadata().getFileName(),
+                  fileName,
                   baseRequest.getConfiguration().projectId(),
                   baseRequest.getAuthentication());
               LOGGER.debug("File deleted from GCS");

--- a/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/utils/GcsUtil.java
+++ b/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/utils/GcsUtil.java
@@ -27,6 +27,7 @@ public class GcsUtil {
 
   public static String uploadNewFileFromDocument(
       final Document document,
+      final String fileName,
       final String bucketName,
       final String projectId,
       GcpAuthentication authentication)
@@ -39,9 +40,9 @@ public class GcsUtil {
             .build()
             .getService();
 
-    BlobInfo blobInfo = BlobInfo.newBuilder(bucketName, document.metadata().getFileName()).build();
+    BlobInfo blobInfo = BlobInfo.newBuilder(bucketName, fileName).build();
     storage.createFrom(blobInfo, document.asInputStream());
-    return String.format("gs://%s/%s", bucketName, document.metadata().getFileName());
+    return String.format("gs://%s/%s", bucketName, fileName);
   }
 
   public static void deleteObjectFromBucket(

--- a/connectors/idp-extraction/src/test/java/io/camunda/connector/idp/extraction/caller/GeminiCallerTest.java
+++ b/connectors/idp-extraction/src/test/java/io/camunda/connector/idp/extraction/caller/GeminiCallerTest.java
@@ -66,7 +66,10 @@ class GeminiCallerTest {
     String mockedFileUri = "gs://bucket-name/file-name";
     try (MockedStatic<GcsUtil> gcsUtilMockedStatic = mockStatic(GcsUtil.class)) {
       gcsUtilMockedStatic
-          .when(() -> GcsUtil.uploadNewFileFromDocument(any(), anyString(), anyString(), any()))
+          .when(
+              () ->
+                  GcsUtil.uploadNewFileFromDocument(
+                      any(), anyString(), anyString(), anyString(), any()))
           .thenReturn(mockedFileUri);
 
       GenerativeModel mockGenerativeModel = mock(GenerativeModel.class);


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
I added a simple null check for filenames when uploading to gcp. 

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes https://github.com/camunda/connectors/issues/4289

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.

