### PR TITLE
other(tests): fix proxy tests, clear properties properly

### DIFF
--- a/connectors/http/http-base/src/test/java/io/camunda/connector/http/base/client/apache/CustomApacheHttpClientTest.java
+++ b/connectors/http/http-base/src/test/java/io/camunda/connector/http/base/client/apache/CustomApacheHttpClientTest.java
@@ -251,14 +251,14 @@ public class CustomApacheHttpClientTest {
     }
 
     private static void unsetAllSystemProperties() {
-      System.setProperty("http.proxyHost", "");
-      System.setProperty("http.proxyPort", "");
-      System.setProperty("http.nonProxyHosts", "");
-      System.setProperty("https.proxyHost", "");
-      System.setProperty("https.proxyPort", "");
-      System.setProperty("https.nonProxyHosts", "");
-      System.setProperty("http.proxyUser", "");
-      System.setProperty("http.proxyPassword", "");
+      System.clearProperty("http.proxyHost");
+      System.clearProperty("http.proxyPort");
+      System.clearProperty("http.nonProxyHosts");
+      System.clearProperty("https.proxyHost");
+      System.clearProperty("https.proxyPort");
+      System.clearProperty("https.nonProxyHosts");
+      System.clearProperty("http.proxyUser");
+      System.clearProperty("http.proxyPassword");
     }
 
     @AfterAll

--- a/connectors/http/http-base/src/test/java/io/camunda/connector/http/base/client/apache/ProxyHandlerTest.java
+++ b/connectors/http/http-base/src/test/java/io/camunda/connector/http/base/client/apache/ProxyHandlerTest.java
@@ -44,15 +44,15 @@ public class ProxyHandlerTest {
   }
 
   public static void unsetAllSystemProperties() {
-    System.setProperty("http.proxyHost", "");
-    System.setProperty("http.proxyPort", "");
-    System.setProperty("http.nonProxyHosts", "");
+    System.clearProperty("http.proxyHost");
+    System.clearProperty("http.proxyPort");
+    System.clearProperty("http.nonProxyHosts");
     // user and password kept to null to make tests easier. You can still test https value if needed
 
-    System.setProperty("https.proxyHost", "");
-    System.setProperty("https.proxyPort", "");
-    System.setProperty("https.proxyUser", "");
-    System.setProperty("https.proxyPassword", "");
+    System.clearProperty("https.proxyHost");
+    System.clearProperty("https.proxyPort");
+    System.clearProperty("https.proxyUser");
+    System.clearProperty("https.proxyPassword");
   }
 
   @Test
@@ -113,11 +113,11 @@ public class ProxyHandlerTest {
                   "www.test.de")
               .execute(
                   () -> {
-                    assertThat(System.getProperty("https.proxyHost")).isEmpty();
-                    assertThat(System.getProperty("https.proxyPort")).isEmpty();
-                    assertThat(System.getProperty("https.proxyUser")).isEmpty();
-                    assertThat(System.getProperty("https.proxyPassword")).isEmpty();
-                    assertThat(System.getProperty("http.nonProxyHosts")).isEmpty();
+                    assertThat(System.getProperty("https.proxyHost")).isNull();
+                    assertThat(System.getProperty("https.proxyPort")).isNull();
+                    assertThat(System.getProperty("https.proxyUser")).isNull();
+                    assertThat(System.getProperty("https.proxyPassword")).isNull();
+                    assertThat(System.getProperty("http.nonProxyHosts")).isNull();
 
                     new ProxyHandler();
 
@@ -143,11 +143,11 @@ public class ProxyHandlerTest {
                   "www.test.de")
               .execute(
                   () -> {
-                    assertThat(System.getProperty("http.proxyHost")).isEmpty();
-                    assertThat(System.getProperty("http.proxyPort")).isEmpty();
+                    assertThat(System.getProperty("http.proxyHost")).isNull();
+                    assertThat(System.getProperty("http.proxyPort")).isNull();
                     assertThat(System.getProperty("http.proxyUser")).isNull();
                     assertThat(System.getProperty("http.proxyPassword")).isNull();
-                    assertThat(System.getProperty("http.nonProxyHosts")).isEmpty();
+                    assertThat(System.getProperty("http.nonProxyHosts")).isNull();
 
                     new ProxyHandler();
 


### PR DESCRIPTION
## Description

- We need to clear system properties properly, not setting them to empty string as we now handle unset properties.


## Checklist

- [x] PR has a **milestone** or the `no milestone` label.

