### PR TITLE
feature(secrets): secrets are now hidden from the error message in operate, making error message more reliable

### DIFF
--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/error/InvalidBackOffDuration.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/error/InvalidBackOffDuration.java
@@ -14,26 +14,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.camunda.connector.api.secret;
+package io.camunda.connector.runtime.core.error;
 
-import java.util.List;
-
-/**
- * Provider of secrets for an environment. This class will be instantiated from an environment
- * runtime according to the <a
- * href="https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/ServiceLoader.html">Service
- * Provider Interface (SPI)</a> documentation.
- */
-public interface SecretProvider {
-
-  /**
-   * @param name - the secret's name to find a value for
-   * @return the secret's value for the given name, if it exists. Otherwise, <code>null</code> is
-   *     returned.
-   */
-  String getSecret(String name);
-
-  default List<String> fetchAll(List<String> keys) {
-    return keys.stream().map(this::getSecret).toList();
+public class InvalidBackOffDuration extends RuntimeException {
+  public InvalidBackOffDuration(String message, Throwable cause) {
+    super(message, cause);
   }
 }

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/error/InvalidBackOffDurationException.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/error/InvalidBackOffDurationException.java
@@ -16,8 +16,8 @@
  */
 package io.camunda.connector.runtime.core.error;
 
-public class InvalidBackOffDuration extends RuntimeException {
-  public InvalidBackOffDuration(String message, Throwable cause) {
+public class InvalidBackOffDurationException extends RuntimeException {
+  public InvalidBackOffDurationException(String message, Throwable cause) {
     super(message, cause);
   }
 }

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/outbound/JobHandlerContext.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/outbound/JobHandlerContext.java
@@ -22,7 +22,7 @@ import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.exc.*;
 import io.camunda.client.api.response.ActivatedJob;
-import io.camunda.connector.api.error.ConnectorException;
+import io.camunda.connector.api.error.ConnectorInputException;
 import io.camunda.connector.api.outbound.JobContext;
 import io.camunda.connector.api.outbound.OutboundConnectorContext;
 import io.camunda.connector.api.secret.SecretProvider;
@@ -84,7 +84,7 @@ public class JobHandlerContext extends AbstractConnectorContext
     try {
       return objectMapper.readValue(jsonWithSecrets, cls);
     } catch (JsonParseException e) {
-      throw new ConnectorException("JSON_PARSE_ERROR", "This is not a JSON object");
+      throw new ConnectorInputException("This is not a JSON object", e);
     } catch (InvalidFormatException
         | InvalidNullException
         | InvalidTypeIdException
@@ -103,9 +103,9 @@ public class JobHandlerContext extends AbstractConnectorContext
                               .concat("`"))
               .orElse("Unexpected Error, Further investigation is needed");
 
-      throw new ConnectorException("JSON_FORMAT_ERROR", errorMessage);
+      throw new ConnectorInputException(errorMessage, e);
     } catch (JsonProcessingException e) {
-      throw new ConnectorException("JSON_PROCESSING_ERROR", e.getOriginalMessage(), e);
+      throw new ConnectorInputException(e.getOriginalMessage(), e);
     }
   }
 

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/outbound/JobHandlerContext.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/outbound/JobHandlerContext.java
@@ -104,11 +104,8 @@ public class JobHandlerContext extends AbstractConnectorContext
               .orElse("Unexpected Error, Further investigation is needed");
 
       throw new ConnectorException("JSON_FORMAT_ERROR", errorMessage);
-    } catch (MismatchedInputException e) {
-      throw new ConnectorException("JSON_MISMATCH_ERROR", e.getOriginalMessage());
     } catch (JsonProcessingException e) {
-      throw new ConnectorException(
-          "JSON_PROCESSING_ERROR", "Exception: " + e.getClass().getSimpleName() + " was raised", e);
+      throw new ConnectorException("JSON_PROCESSING_ERROR", e.getOriginalMessage(), e);
     }
   }
 

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/outbound/OutboundConnectorExceptionHandler.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/outbound/OutboundConnectorExceptionHandler.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.runtime.core.outbound;
+
+import static io.camunda.connector.runtime.core.outbound.ConnectorJobHandler.MAX_ERROR_MESSAGE_LENGTH;
+
+import io.camunda.client.api.response.ActivatedJob;
+import io.camunda.connector.api.error.ConnectorException;
+import io.camunda.connector.api.error.ConnectorInputException;
+import io.camunda.connector.api.error.ConnectorRetryException;
+import io.camunda.connector.api.secret.SecretProvider;
+import io.camunda.connector.runtime.core.error.InvalidBackOffDurationException;
+import io.camunda.connector.runtime.core.secret.SecretUtil;
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class OutboundConnectorExceptionHandler {
+
+  private static final Logger LOGGER =
+      LoggerFactory.getLogger(OutboundConnectorExceptionHandler.class);
+  private final SecretProvider secretProvider;
+
+  public OutboundConnectorExceptionHandler(SecretProvider secretProvider) {
+    this.secretProvider = secretProvider;
+  }
+
+  private static Map<String, Object> exceptionToMap(Exception wrappedException) {
+    Map<String, Object> result = new HashMap<>();
+    Throwable originalCause = wrappedException.getCause();
+    result.put("type", originalCause.getClass().getName());
+    var message = wrappedException.getMessage();
+    if (message != null) {
+      result.put(
+          "message", message.substring(0, Math.min(message.length(), MAX_ERROR_MESSAGE_LENGTH)));
+    }
+    if (originalCause instanceof ConnectorException connectorException) {
+      var code = connectorException.getErrorCode();
+      var variables = connectorException.getErrorVariables();
+
+      if (code != null) {
+        result.put("code", code);
+      }
+
+      if (variables != null) {
+        result.put("variables", variables);
+      }
+    }
+    return Map.copyOf(result);
+  }
+
+  public ConnectorResult.ErrorResult manageConnectorJobHandlerException(
+      Exception e, ActivatedJob job, Duration retryBackoffDuration) {
+    List<String> secrets =
+        this.secretProvider.fetchAll(SecretUtil.retrieveSecretKeysInInput(job.getVariables()));
+    return switch (e) {
+      case InvalidBackOffDurationException invalidBackOffDurationException ->
+          handleBackOffException(invalidBackOffDurationException, secrets);
+      case ConnectorRetryException connectorRetryException ->
+          handleConnectorRetryException(
+              job, connectorRetryException, secrets, retryBackoffDuration);
+      case Exception exception ->
+          handleGenericException(job, exception, secrets, retryBackoffDuration);
+    };
+  }
+
+  private String hideSecretsFromMessage(String message, List<String> secrets) {
+    return secrets.stream().reduce(message, (s, s2) -> s.replace(s2, "***"));
+  }
+
+  private ConnectorResult.ErrorResult handleBackOffException(Exception e, List<String> secrets) {
+    Exception newException = new Exception(hideSecretsFromMessage(e.getMessage(), secrets), e);
+    return new ConnectorResult.ErrorResult(
+        Map.of("error", exceptionToMap(newException)), newException, 0);
+  }
+
+  private ConnectorResult.ErrorResult handleConnectorRetryException(
+      ActivatedJob job, ConnectorRetryException ex, List<String> secrets, Duration retryBackoff) {
+    Exception newException = new Exception(hideSecretsFromMessage(ex.getMessage(), secrets), ex);
+    LOGGER.debug(
+        "ConnectorRetryException while processing job: {} for tenant: {}, error message: {}",
+        job.getKey(),
+        job.getTenantId(),
+        newException.getMessage());
+    String errorCode = ex.getErrorCode();
+    return handleSDKException(
+        job,
+        newException,
+        Optional.ofNullable(ex.getRetries()).orElse(job.getRetries() - 1),
+        errorCode,
+        Optional.ofNullable(ex.getBackoffDuration()).orElse(retryBackoff));
+  }
+
+  private ConnectorResult.ErrorResult handleSDKException(
+      ActivatedJob job, Exception ex, Integer retries, String errorCode, Duration backoffDuration) {
+    LOGGER.debug(
+        "Failing job with retry config => job: {} for tenant: {} with error code: {}, retries: {} and remaining backoffDuration: {}",
+        job.getKey(),
+        job.getTenantId(),
+        errorCode,
+        retries,
+        backoffDuration);
+
+    return new ConnectorResult.ErrorResult(
+        Map.of("error", exceptionToMap(ex)), ex, retries, backoffDuration);
+  }
+
+  private ConnectorResult.ErrorResult handleGenericException(
+      ActivatedJob job, Exception ex, List<String> secrets, Duration retryBackoff) {
+    Exception newException = new Exception(hideSecretsFromMessage(ex.getMessage(), secrets), ex);
+    LOGGER.debug(
+        "Exception while processing job: {} for tenant: {}, message: {}",
+        job.getKey(),
+        job.getTenantId(),
+        newException.getMessage());
+
+    String errorCode = null;
+    int retries = job.getRetries() - 1;
+
+    if (ex instanceof ConnectorException connectorException) {
+      errorCode = connectorException.getErrorCode();
+    }
+    if (ex instanceof ConnectorInputException || ex.getCause() instanceof ConnectorInputException) {
+      retries = 0;
+    }
+    return handleSDKException(job, newException, retries, errorCode, retryBackoff);
+  }
+
+  public ConnectorResult.ErrorResult handleFinalResultException(Exception ex, ActivatedJob job) {
+    List<String> secrets =
+        this.secretProvider.fetchAll(SecretUtil.retrieveSecretKeysInInput(job.getVariables()));
+    Exception newException = new Exception(hideSecretsFromMessage(ex.getMessage(), secrets), ex);
+    LOGGER.error(
+        "Exception while processing job: {} for tenant: {}, message: {}",
+        job.getKey(),
+        job.getTenantId(),
+        ex.getMessage());
+    return new ConnectorResult.ErrorResult(
+        Map.of("error", exceptionToMap(newException)), newException, 0);
+  }
+}

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretUtil.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretUtil.java
@@ -16,9 +16,13 @@
  */
 package io.camunda.connector.runtime.core.secret;
 
+import io.camunda.connector.api.secret.SecretProvider;
+import java.util.List;
+import java.util.Objects;
 import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Stream;
 
 /** Utility class to replace secrets in strings. */
 public class SecretUtil {
@@ -92,5 +96,17 @@ public class SecretUtil {
       output.append(original, lastIndex, original.length());
     }
     return output.toString();
+  }
+
+  public static List<String> retrieveSecretValues(String input, SecretProvider secretProvider) {
+    return Objects.isNull(input)
+        ? List.of()
+        : Stream.of(SECRET_PATTERN_PARENTHESES, SECRET_PATTERN_SECRETS)
+            .map(pattern -> pattern.matcher(input))
+            .flatMap(Matcher::results)
+            .map(matchResult -> matchResult.group("secret"))
+            .map(secretProvider::getSecret)
+            .distinct()
+            .toList();
   }
 }

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretUtil.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretUtil.java
@@ -16,7 +16,6 @@
  */
 package io.camunda.connector.runtime.core.secret;
 
-import io.camunda.connector.api.secret.SecretProvider;
 import java.util.List;
 import java.util.Objects;
 import java.util.function.Function;
@@ -98,14 +97,13 @@ public class SecretUtil {
     return output.toString();
   }
 
-  public static List<String> retrieveSecretValues(String input, SecretProvider secretProvider) {
+  public static List<String> retrieveSecretKeysInInput(String input) {
     return Objects.isNull(input)
         ? List.of()
         : Stream.of(SECRET_PATTERN_PARENTHESES, SECRET_PATTERN_SECRETS)
             .map(pattern -> pattern.matcher(input))
             .flatMap(Matcher::results)
             .map(matchResult -> matchResult.group("secret"))
-            .map(secretProvider::getSecret)
             .distinct()
             .toList();
   }

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/outbound/ConnectorJobHandlerTest.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/outbound/ConnectorJobHandlerTest.java
@@ -863,6 +863,27 @@ class ConnectorJobHandlerTest {
     }
 
     @Test
+    void shouldHideSecretsInJobErrorMessage() {
+      // given
+      var errorMessage = "Something went wrong: bar is not the correct password";
+      var jobHandler =
+          newConnectorJobHandler(
+              context -> {
+                throw new IllegalArgumentException(errorMessage);
+              });
+
+      // when
+      var result =
+          JobBuilder.create()
+              .withVariables("{{secrets.FOO}}")
+              .executeAndCaptureResult(jobHandler, false);
+
+      // then
+      assertThat(result.getErrorMessage())
+          .isEqualTo("Something went wrong: *** is not the correct password");
+    }
+
+    @Test
     void shouldCreateBpmnErro2r_UsingExceptionCodeAndErrorVariables() {
       // given
       var jobHandler =

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/outbound/ConnectorJobHandlerTest.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/outbound/ConnectorJobHandlerTest.java
@@ -41,6 +41,7 @@ import io.camunda.connector.api.error.ConnectorInputException;
 import io.camunda.connector.api.error.ConnectorRetryExceptionBuilder;
 import io.camunda.connector.api.outbound.OutboundConnectorFunction;
 import io.camunda.connector.runtime.core.ConnectorHelper;
+import io.camunda.connector.runtime.core.FooBarSecretProvider;
 import io.camunda.connector.runtime.core.Keywords;
 import java.time.Duration;
 import java.util.HashMap;
@@ -60,7 +61,6 @@ class ConnectorJobHandlerTest {
   private record TestConnectorResponsePojo(String value) {}
 
   private static class NonSerializable {
-
     private final UUID field = UUID.randomUUID();
   }
 
@@ -71,7 +71,8 @@ class ConnectorJobHandlerTest {
     class ResultVariableTests {
 
       protected static ConnectorJobHandler newConnectorJobHandler(OutboundConnectorFunction call) {
-        return new ConnectorJobHandler(call, e -> {});
+        return new ConnectorJobHandler(
+            call, e -> {}, new OutboundConnectorExceptionHandler(new FooBarSecretProvider()));
       }
 
       @ParameterizedTest
@@ -410,7 +411,11 @@ class ConnectorJobHandlerTest {
       @Test
       void shouldNotSetWithoutResultVariableAndExpression() {
         // given
-        var jobHandler = new ConnectorJobHandler((context) -> Map.of("hello", "world"), e -> {});
+        var jobHandler =
+            new ConnectorJobHandler(
+                (context) -> Map.of("hello", "world"),
+                e -> {},
+                new OutboundConnectorExceptionHandler(new FooBarSecretProvider()));
 
         // when
         var result = JobBuilder.create().executeAndCaptureResult(jobHandler);
@@ -424,7 +429,9 @@ class ConnectorJobHandlerTest {
         // given
         var jobHandler =
             new ConnectorJobHandler(
-                (context) -> Map.of("callStatus", Map.of("statusCode", "200 OK")), e -> {});
+                (context) -> Map.of("callStatus", Map.of("statusCode", "200 OK")),
+                e -> {},
+                new OutboundConnectorExceptionHandler(new FooBarSecretProvider()));
         var resultExpression = "{\"processedOutput\": response.callStatus, \"nullVar\": null}";
         var resultVariable = "result";
 

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/outbound/JobHandlerContextTest.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/outbound/JobHandlerContextTest.java
@@ -23,7 +23,7 @@ import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.client.api.response.ActivatedJob;
-import io.camunda.connector.api.error.ConnectorException;
+import io.camunda.connector.api.error.ConnectorInputException;
 import io.camunda.connector.api.secret.SecretProvider;
 import io.camunda.connector.api.validation.ValidationProvider;
 import io.camunda.connector.runtime.core.testutil.classexample.TestClass;
@@ -65,7 +65,7 @@ class JobHandlerContextTest {
     when(secretProvider.getSecret("FOO")).thenReturn("secret");
     Exception thrown =
         assertThrows(
-            ConnectorException.class, () -> jobHandlerContext.bindVariables(TestClass.class));
+            ConnectorInputException.class, () -> jobHandlerContext.bindVariables(TestClass.class));
     assertThat(thrown.getMessage())
         .isEqualTo("Json object contains an invalid field: integer. It Must be `Integer`");
   }
@@ -91,7 +91,7 @@ class JobHandlerContextTest {
     when(activatedJob.getVariables()).thenReturn(json);
     Exception thrown =
         assertThrows(
-            ConnectorException.class, () -> jobHandlerContext.bindVariables(TestClass.class));
+            ConnectorInputException.class, () -> jobHandlerContext.bindVariables(TestClass.class));
 
     assertThat(thrown.getMessage())
         .isEqualTo("Json object contains an invalid field: integer. It Must be `Integer`");
@@ -103,7 +103,7 @@ class JobHandlerContextTest {
     when(activatedJob.getVariables()).thenReturn(json);
     Exception thrown =
         assertThrows(
-            ConnectorException.class, () -> jobHandlerContext.bindVariables(TestClass.class));
+            ConnectorInputException.class, () -> jobHandlerContext.bindVariables(TestClass.class));
 
     assertThat(thrown.getMessage()).isEqualTo("Json object contains an invalid field: invalid");
   }
@@ -114,7 +114,7 @@ class JobHandlerContextTest {
     when(activatedJob.getVariables()).thenReturn(json);
     Exception thrown =
         assertThrows(
-            ConnectorException.class, () -> jobHandlerContext.bindVariables(TestClass.class));
+            ConnectorInputException.class, () -> jobHandlerContext.bindVariables(TestClass.class));
 
     assertThat(thrown.getMessage()).isEqualTo("This is not a JSON object");
   }
@@ -125,7 +125,7 @@ class JobHandlerContextTest {
     when(activatedJob.getVariables()).thenReturn(json);
     Exception thrown =
         assertThrows(
-            ConnectorException.class, () -> jobHandlerContext.bindVariables(TestClass.class));
+            ConnectorInputException.class, () -> jobHandlerContext.bindVariables(TestClass.class));
 
     assertThat(thrown.getMessage())
         .isEqualTo("Json object contains an invalid field: integer. It Must be `Integer`");
@@ -137,7 +137,7 @@ class JobHandlerContextTest {
     when(activatedJob.getVariables()).thenReturn(json);
     Exception thrown =
         assertThrows(
-            ConnectorException.class, () -> jobHandlerContext.bindVariables(TestClass.class));
+            ConnectorInputException.class, () -> jobHandlerContext.bindVariables(TestClass.class));
 
     assertThat(thrown.getMessage()).isEqualTo("No content to map due to end-of-input");
   }
@@ -148,7 +148,7 @@ class JobHandlerContextTest {
     when(activatedJob.getVariables()).thenReturn(json);
     Exception thrown =
         assertThrows(
-            ConnectorException.class, () -> jobHandlerContext.bindVariables(TestClass.class));
+            ConnectorInputException.class, () -> jobHandlerContext.bindVariables(TestClass.class));
 
     assertThat(thrown.getMessage())
         .isEqualTo(
@@ -161,7 +161,7 @@ class JobHandlerContextTest {
     when(activatedJob.getVariables()).thenReturn(json);
     Exception thrown =
         assertThrows(
-            ConnectorException.class, () -> jobHandlerContext.bindVariables(TestClass.class));
+            ConnectorInputException.class, () -> jobHandlerContext.bindVariables(TestClass.class));
 
     assertThat(thrown.getMessage())
         .isEqualTo(

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/outbound/JobHandlerContextTest.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/outbound/JobHandlerContextTest.java
@@ -59,6 +59,27 @@ class JobHandlerContextTest {
   }
 
   @Test
+  void bindVariables_failedSecretAreBounded() {
+    String json = "{ \"integer\": \"{{secrets.FOO}}\"";
+    when(activatedJob.getVariables()).thenReturn(json);
+    when(secretProvider.getSecret("FOO")).thenReturn("secret");
+    Exception thrown =
+            assertThrows(
+                    ConnectorException.class, () -> jobHandlerContext.bindVariables(TestClass.class));
+    assertThat(thrown.getMessage())
+            .isEqualTo("Json object contains an invalid field: integer. It Must be `Integer`");
+
+  }
+
+  @Test
+  void bindVariables_successSecretAreBounded() {
+    String json = "{ \"integer\": {{secrets.FOO}} }";
+    when(activatedJob.getVariables()).thenReturn(json);
+    when(secretProvider.getSecret("FOO")).thenReturn("1");
+    assertThat(jobHandlerContext.bindVariables(TestClass.class).integer).isEqualTo(1);
+  }
+
+  @Test
   void bindVariables_nullValue() {
     String json = "{ \"integer\": null}";
     when(activatedJob.getVariables()).thenReturn(json);

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/outbound/JobHandlerContextTest.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/outbound/JobHandlerContextTest.java
@@ -64,11 +64,10 @@ class JobHandlerContextTest {
     when(activatedJob.getVariables()).thenReturn(json);
     when(secretProvider.getSecret("FOO")).thenReturn("secret");
     Exception thrown =
-            assertThrows(
-                    ConnectorException.class, () -> jobHandlerContext.bindVariables(TestClass.class));
+        assertThrows(
+            ConnectorException.class, () -> jobHandlerContext.bindVariables(TestClass.class));
     assertThat(thrown.getMessage())
-            .isEqualTo("Json object contains an invalid field: integer. It Must be `Integer`");
-
+        .isEqualTo("Json object contains an invalid field: integer. It Must be `Integer`");
   }
 
   @Test

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/jobhandling/SpringConnectorJobHandler.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/jobhandling/SpringConnectorJobHandler.java
@@ -23,7 +23,6 @@ import io.camunda.client.api.worker.JobClient;
 import io.camunda.connector.api.outbound.OutboundConnectorFunction;
 import io.camunda.connector.api.validation.ValidationProvider;
 import io.camunda.connector.runtime.core.config.OutboundConnectorConfiguration;
-import io.camunda.connector.runtime.core.error.BpmnError;
 import io.camunda.connector.runtime.core.outbound.ConnectorJobHandler;
 import io.camunda.connector.runtime.core.outbound.ConnectorResult;
 import io.camunda.connector.runtime.core.secret.SecretProviderAggregator;
@@ -102,24 +101,6 @@ public class SpringConnectorJobHandler extends ConnectorJobHandler {
       FinalCommandStep commandStep = prepareFailJobCommand(client, job, result);
       new CommandWrapper(
               commandStep,
-              job,
-              commandExceptionHandlingStrategy,
-              metricsRecorder,
-              MAX_ZEEBE_COMMAND_RETRIES)
-          .executeAsync();
-    }
-  }
-
-  @Override
-  protected void throwBpmnError(JobClient client, ActivatedJob job, BpmnError value) {
-    try {
-      metricsRecorder.increase(
-          Outbound.METRIC_NAME_INVOCATIONS,
-          Outbound.ACTION_BPMN_ERROR,
-          connectorConfiguration.type());
-    } finally {
-      new CommandWrapper(
-              prepareThrowBpmnErrorCommand(client, job, value),
               job,
               commandExceptionHandlingStrategy,
               metricsRecorder,

--- a/connector-sdk/validation/src/main/java/io/camunda/connector/validation/impl/DefaultValidationProvider.java
+++ b/connector-sdk/validation/src/main/java/io/camunda/connector/validation/impl/DefaultValidationProvider.java
@@ -75,6 +75,9 @@ public class DefaultValidationProvider implements ValidationProvider {
    * property values.
    */
   protected String buildValidationMessage(ConstraintViolation<Object> violation) {
-    return " - Property: " + violation.getPropertyPath().toString() + ": Validation failed.";
+    return " - Property: "
+        + violation.getPropertyPath().toString()
+        + ": Validation failed. Original message: "
+        + violation.getMessage();
   }
 }

--- a/connectors/aws/aws-textract/src/test/java/io/camunda/connector/textract/TextractConnectorFunctionTest.java
+++ b/connectors/aws/aws-textract/src/test/java/io/camunda/connector/textract/TextractConnectorFunctionTest.java
@@ -6,6 +6,7 @@
  */
 package io.camunda.connector.textract;
 
+import static io.camunda.connector.textract.model.TextractRequestData.WRONG_OUTPUT_VALUES_MSG;
 import static io.camunda.connector.textract.util.TextractTestUtils.ASYNC_EXECUTION_JSON_WITH_ROLE_ARN_AND_WITHOUT_SNS_TOPIC;
 import static io.camunda.connector.textract.util.TextractTestUtils.ASYNC_EXECUTION_JSON_WITH_SNS_TOPIC_AND_WITHOUT_ROLE_ARN;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -85,6 +86,7 @@ class TextractConnectorFunctionTest {
             ConnectorInputException.class,
             () -> textractConnectorFunction.execute(outBounderContext));
 
+    assertThat(exception).hasMessageContaining(WRONG_OUTPUT_VALUES_MSG);
     assertThat(exception).isInstanceOf(ConnectorInputException.class);
   }
 

--- a/connectors/soap/element-templates/hybrid/soap-outbound-connector-hybrid.json
+++ b/connectors/soap/element-templates/hybrid/soap-outbound-connector-hybrid.json
@@ -77,77 +77,14 @@
     },
     "type" : "Dropdown",
     "choices" : [ {
+      "name" : "WSS signature",
+      "value" : "signature"
+    }, {
       "name" : "None",
       "value" : "none"
     }, {
       "name" : "WSS username token",
       "value" : "usernameToken"
-    }, {
-      "name" : "WSS signature",
-      "value" : "signature"
-    } ]
-  }, {
-    "id" : "authentication.username",
-    "label" : "Username",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "feel" : "optional",
-    "group" : "authentication",
-    "binding" : {
-      "name" : "authentication.username",
-      "type" : "zeebe:input"
-    },
-    "condition" : {
-      "property" : "authentication.authentication",
-      "equals" : "usernameToken",
-      "type" : "simple"
-    },
-    "type" : "String"
-  }, {
-    "id" : "authentication.password",
-    "label" : "Password",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "feel" : "optional",
-    "group" : "authentication",
-    "binding" : {
-      "name" : "authentication.password",
-      "type" : "zeebe:input"
-    },
-    "condition" : {
-      "property" : "authentication.authentication",
-      "equals" : "usernameToken",
-      "type" : "simple"
-    },
-    "type" : "String"
-  }, {
-    "id" : "authentication.encoded",
-    "label" : "Encoded",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "group" : "authentication",
-    "binding" : {
-      "name" : "authentication.encoded",
-      "type" : "zeebe:input"
-    },
-    "condition" : {
-      "property" : "authentication.authentication",
-      "equals" : "usernameToken",
-      "type" : "simple"
-    },
-    "type" : "Dropdown",
-    "choices" : [ {
-      "name" : "Yes",
-      "value" : "Yes"
-    }, {
-      "name" : "No",
-      "value" : "No"
     } ]
   }, {
     "id" : "authentication.certificate.certificateType",
@@ -426,6 +363,69 @@
       "type" : "simple"
     },
     "type" : "String"
+  }, {
+    "id" : "authentication.username",
+    "label" : "Username",
+    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "authentication",
+    "binding" : {
+      "name" : "authentication.username",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "authentication.authentication",
+      "equals" : "usernameToken",
+      "type" : "simple"
+    },
+    "type" : "String"
+  }, {
+    "id" : "authentication.password",
+    "label" : "Password",
+    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "authentication",
+    "binding" : {
+      "name" : "authentication.password",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "authentication.authentication",
+      "equals" : "usernameToken",
+      "type" : "simple"
+    },
+    "type" : "String"
+  }, {
+    "id" : "authentication.encoded",
+    "label" : "Encoded",
+    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "group" : "authentication",
+    "binding" : {
+      "name" : "authentication.encoded",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "authentication.authentication",
+      "equals" : "usernameToken",
+      "type" : "simple"
+    },
+    "type" : "Dropdown",
+    "choices" : [ {
+      "name" : "Yes",
+      "value" : "Yes"
+    }, {
+      "name" : "No",
+      "value" : "No"
+    } ]
   }, {
     "id" : "soapVersion.version",
     "label" : "SOAP version",

--- a/connectors/soap/element-templates/soap-outbound-connector.json
+++ b/connectors/soap/element-templates/soap-outbound-connector.json
@@ -72,77 +72,14 @@
     },
     "type" : "Dropdown",
     "choices" : [ {
+      "name" : "WSS signature",
+      "value" : "signature"
+    }, {
       "name" : "None",
       "value" : "none"
     }, {
       "name" : "WSS username token",
       "value" : "usernameToken"
-    }, {
-      "name" : "WSS signature",
-      "value" : "signature"
-    } ]
-  }, {
-    "id" : "authentication.username",
-    "label" : "Username",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "feel" : "optional",
-    "group" : "authentication",
-    "binding" : {
-      "name" : "authentication.username",
-      "type" : "zeebe:input"
-    },
-    "condition" : {
-      "property" : "authentication.authentication",
-      "equals" : "usernameToken",
-      "type" : "simple"
-    },
-    "type" : "String"
-  }, {
-    "id" : "authentication.password",
-    "label" : "Password",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "feel" : "optional",
-    "group" : "authentication",
-    "binding" : {
-      "name" : "authentication.password",
-      "type" : "zeebe:input"
-    },
-    "condition" : {
-      "property" : "authentication.authentication",
-      "equals" : "usernameToken",
-      "type" : "simple"
-    },
-    "type" : "String"
-  }, {
-    "id" : "authentication.encoded",
-    "label" : "Encoded",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "group" : "authentication",
-    "binding" : {
-      "name" : "authentication.encoded",
-      "type" : "zeebe:input"
-    },
-    "condition" : {
-      "property" : "authentication.authentication",
-      "equals" : "usernameToken",
-      "type" : "simple"
-    },
-    "type" : "Dropdown",
-    "choices" : [ {
-      "name" : "Yes",
-      "value" : "Yes"
-    }, {
-      "name" : "No",
-      "value" : "No"
     } ]
   }, {
     "id" : "authentication.certificate.certificateType",
@@ -421,6 +358,69 @@
       "type" : "simple"
     },
     "type" : "String"
+  }, {
+    "id" : "authentication.username",
+    "label" : "Username",
+    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "authentication",
+    "binding" : {
+      "name" : "authentication.username",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "authentication.authentication",
+      "equals" : "usernameToken",
+      "type" : "simple"
+    },
+    "type" : "String"
+  }, {
+    "id" : "authentication.password",
+    "label" : "Password",
+    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "authentication",
+    "binding" : {
+      "name" : "authentication.password",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "authentication.authentication",
+      "equals" : "usernameToken",
+      "type" : "simple"
+    },
+    "type" : "String"
+  }, {
+    "id" : "authentication.encoded",
+    "label" : "Encoded",
+    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "group" : "authentication",
+    "binding" : {
+      "name" : "authentication.encoded",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "authentication.authentication",
+      "equals" : "usernameToken",
+      "type" : "simple"
+    },
+    "type" : "Dropdown",
+    "choices" : [ {
+      "name" : "Yes",
+      "value" : "Yes"
+    }, {
+      "name" : "No",
+      "value" : "No"
+    } ]
   }, {
     "id" : "soapVersion.version",
     "label" : "SOAP version",


### PR DESCRIPTION
## Description


PR to hide secret from error  message sent to zeebe

- Secrets are being hidden from error message sent to zeebe
- The object mapper exception is way more precise
- Error from validation are more concise


## Related issues

closes https://github.com/camunda/connectors/issues/3221

## Checklist

- [ ] PR has a **milestone** or the `no milestone` label.

