### PR TITLE
refactor(rest): refactor the proxy support for the REST Connector

### DIFF
--- a/.ci/preview-environments/charts/c8sm/values.yaml
+++ b/.ci/preview-environments/charts/c8sm/values.yaml
@@ -95,9 +95,9 @@ camunda-platform:
         value: ${ZEEBE_AUTHORIZATION_SERVER_URL}
       - name: CAMUNDA_CONNECTOR_POLLING_ENABLED
         value: "false"
-      - name: CAMUNDA_CLIENT_ZEEBE_REST-ADDRESS
+      - name: CAMUNDA_CLIENT_REST-ADDRESS
         value: http://zeebe-cluster-gateway:9600
-      - name: CAMUNDA_CLIENT_ZEEBE_GRPC-ADDRESS
+      - name: CAMUNDA_CLIENT_GRPC-ADDRESS
         value: http://zeebe-cluster-gateway:26500
     resources:
       limits:

--- a/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/HttpService.java
+++ b/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/HttpService.java
@@ -21,7 +21,6 @@ import io.camunda.connector.http.base.blocklist.DefaultHttpBlocklistManager;
 import io.camunda.connector.http.base.blocklist.HttpBlockListManager;
 import io.camunda.connector.http.base.client.HttpClient;
 import io.camunda.connector.http.base.client.apache.CustomApacheHttpClient;
-import io.camunda.connector.http.base.client.apache.ProxyHandler;
 import io.camunda.connector.http.base.cloudfunction.CloudFunctionService;
 import io.camunda.connector.http.base.model.HttpCommonRequest;
 import io.camunda.connector.http.base.model.HttpCommonResult;
@@ -35,11 +34,11 @@ public class HttpService {
 
   private final CloudFunctionService cloudFunctionService;
 
-  private final HttpClient httpClient = CustomApacheHttpClient.getDefault();
+  private final HttpClient httpClient = new CustomApacheHttpClient();
 
   private final HttpBlockListManager httpBlocklistManager = new DefaultHttpBlocklistManager();
 
-  private final ProxyHandler proxyHandler = new ProxyHandler();
+  // private final ProxyHandler proxyHandler = new ProxyHandler();
 
   public HttpService() {
     this(new CloudFunctionService());
@@ -73,7 +72,7 @@ public class HttpService {
   private HttpCommonResult executeRequest(
       HttpCommonRequest request, @Nullable ExecutionEnvironment executionEnvironment) {
     try {
-      HttpCommonResult jsonResult = httpClient.execute(request, proxyHandler, executionEnvironment);
+      HttpCommonResult jsonResult = httpClient.execute(request, null, executionEnvironment);
       LOGGER.debug("Connector returned result: {}", jsonResult);
       return jsonResult;
     } catch (ConnectorException e) {

--- a/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/HttpService.java
+++ b/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/HttpService.java
@@ -38,8 +38,6 @@ public class HttpService {
 
   private final HttpBlockListManager httpBlocklistManager = new DefaultHttpBlocklistManager();
 
-  // private final ProxyHandler proxyHandler = new ProxyHandler();
-
   public HttpService() {
     this(new CloudFunctionService());
   }
@@ -72,7 +70,7 @@ public class HttpService {
   private HttpCommonResult executeRequest(
       HttpCommonRequest request, @Nullable ExecutionEnvironment executionEnvironment) {
     try {
-      HttpCommonResult jsonResult = httpClient.execute(request, null, executionEnvironment);
+      HttpCommonResult jsonResult = httpClient.execute(request, executionEnvironment);
       LOGGER.debug("Connector returned result: {}", jsonResult);
       return jsonResult;
     } catch (ConnectorException e) {

--- a/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/client/HttpClient.java
+++ b/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/client/HttpClient.java
@@ -17,7 +17,7 @@
 package io.camunda.connector.http.base.client;
 
 import io.camunda.connector.http.base.ExecutionEnvironment;
-import io.camunda.connector.http.base.client.apache.ProxyHandler;
+import io.camunda.connector.http.base.client.apache.proxy.ProxyHandler;
 import io.camunda.connector.http.base.model.HttpCommonRequest;
 import io.camunda.connector.http.base.model.HttpCommonResult;
 import javax.annotation.Nullable;

--- a/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/client/HttpClient.java
+++ b/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/client/HttpClient.java
@@ -17,7 +17,6 @@
 package io.camunda.connector.http.base.client;
 
 import io.camunda.connector.http.base.ExecutionEnvironment;
-import io.camunda.connector.http.base.client.apache.proxy.ProxyHandler;
 import io.camunda.connector.http.base.model.HttpCommonRequest;
 import io.camunda.connector.http.base.model.HttpCommonResult;
 import javax.annotation.Nullable;
@@ -33,9 +32,7 @@ public interface HttpClient {
    * @return the result of the request as a {@link HttpCommonResult}
    */
   HttpCommonResult execute(
-      HttpCommonRequest request,
-      ProxyHandler proxyHandler,
-      @Nullable ExecutionEnvironment executionEnvironment);
+      HttpCommonRequest request, @Nullable ExecutionEnvironment executionEnvironment);
 
   /**
    * Executes the given {@link HttpCommonRequest} and returns the result as a {@link
@@ -43,9 +40,9 @@ public interface HttpClient {
    *
    * @param request the {@link HttpCommonRequest} to execute
    * @return the result of the request as a {@link HttpCommonResult}
-   * @see #execute(HttpCommonRequest, ProxyHandler, ExecutionEnvironment)
+   * @see #execute(HttpCommonRequest, ExecutionEnvironment)
    */
   default HttpCommonResult execute(HttpCommonRequest request) {
-    return execute(request, new ProxyHandler(), null);
+    return execute(request, null);
   }
 }

--- a/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/client/apache/CustomApacheHttpClient.java
+++ b/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/client/apache/CustomApacheHttpClient.java
@@ -36,15 +36,15 @@ public class CustomApacheHttpClient implements HttpClient {
    * Converts the given {@link HttpCommonRequest} to an Apache {@link
    * org.apache.hc.core5.http.ClassicHttpRequest} and executes it.
    *
+   * <p>This method is thread-safe.
+   *
    * @param request the request to execute
    * @param executionEnvironment the {@link ExecutionEnvironment} we are in
    * @return the {@link HttpCommonResult}
    */
   @Override
   public HttpCommonResult execute(
-      HttpCommonRequest request,
-      ProxyHandler proxyHandler,
-      @Nullable ExecutionEnvironment executionEnvironment) {
+      HttpCommonRequest request, @Nullable ExecutionEnvironment executionEnvironment) {
     try {
       var apacheRequest = ApacheRequestFactory.get().createHttpRequest(request);
       var host = apacheRequest.getAuthority().getHostName();

--- a/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/client/apache/CustomApacheHttpClient.java
+++ b/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/client/apache/CustomApacheHttpClient.java
@@ -21,7 +21,6 @@ import io.camunda.connector.http.base.ExecutionEnvironment;
 import io.camunda.connector.http.base.client.HttpClient;
 import io.camunda.connector.http.base.client.HttpStatusHelper;
 import io.camunda.connector.http.base.client.apache.proxy.ProxyAwareHttpClient;
-import io.camunda.connector.http.base.client.apache.proxy.ProxyHandler;
 import io.camunda.connector.http.base.exception.ConnectorExceptionMapper;
 import io.camunda.connector.http.base.model.HttpCommonRequest;
 import io.camunda.connector.http.base.model.HttpCommonResult;

--- a/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/client/apache/CustomApacheHttpClient.java
+++ b/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/client/apache/CustomApacheHttpClient.java
@@ -20,71 +20,17 @@ import io.camunda.connector.api.error.ConnectorException;
 import io.camunda.connector.http.base.ExecutionEnvironment;
 import io.camunda.connector.http.base.client.HttpClient;
 import io.camunda.connector.http.base.client.HttpStatusHelper;
+import io.camunda.connector.http.base.client.apache.proxy.ProxyAwareHttpClient;
+import io.camunda.connector.http.base.client.apache.proxy.ProxyHandler;
 import io.camunda.connector.http.base.exception.ConnectorExceptionMapper;
 import io.camunda.connector.http.base.model.HttpCommonRequest;
 import io.camunda.connector.http.base.model.HttpCommonResult;
 import java.io.IOException;
 import javax.annotation.Nullable;
 import org.apache.hc.client5.http.ClientProtocolException;
-import org.apache.hc.client5.http.config.RequestConfig;
-import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
-import org.apache.hc.client5.http.impl.classic.HttpClients;
-import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManager;
 import org.apache.hc.core5.http.HttpStatus;
-import org.apache.hc.core5.http.io.SocketConfig;
-import org.apache.hc.core5.util.Timeout;
 
 public class CustomApacheHttpClient implements HttpClient {
-
-  public static final CustomApacheHttpClient DEFAULT =
-      new CustomApacheHttpClient(createHttpClientBuilder());
-
-  private final HttpClientBuilder httpClientBuilder;
-
-  private CustomApacheHttpClient(HttpClientBuilder httpClientBuilder) {
-    this.httpClientBuilder = httpClientBuilder;
-  }
-
-  /**
-   * Returns the default instance of {@link CustomApacheHttpClient}. The default instance is
-   * configured with a {@link HttpClientBuilder} that has a {@link
-   * PoolingHttpClientConnectionManager} with a maximum of {@link Integer#MAX_VALUE} connections.
-   *
-   * @return the default instance of {@link CustomApacheHttpClient}
-   */
-  public static CustomApacheHttpClient getDefault() {
-    return DEFAULT;
-  }
-
-  /**
-   * Creates a new instance of {@link CustomApacheHttpClient} with the given {@link
-   * HttpClientBuilder}. Use this method if you want to customize the {@link HttpClientBuilder}. See
-   * {@link #getDefault()} for the default instance.
-   *
-   * @param httpClientBuilder the {@link HttpClientBuilder} to use
-   * @return a new instance of {@link CustomApacheHttpClient}
-   * @see HttpClients#custom()
-   */
-  public static CustomApacheHttpClient create(HttpClientBuilder httpClientBuilder) {
-    return new CustomApacheHttpClient(httpClientBuilder);
-  }
-
-  private static HttpClientBuilder createHttpClientBuilder() {
-    return HttpClients.custom()
-        .setConnectionManager(createConnectionManager())
-        .disableRedirectHandling();
-  }
-
-  private static PoolingHttpClientConnectionManager createConnectionManager() {
-    PoolingHttpClientConnectionManager connectionManager = new PoolingHttpClientConnectionManager();
-    connectionManager.setMaxTotal(Integer.MAX_VALUE);
-    connectionManager.setDefaultMaxPerRoute(Integer.MAX_VALUE);
-
-    // Socket config
-    connectionManager.setDefaultSocketConfig(SocketConfig.custom().setSoKeepAlive(true).build());
-
-    return connectionManager;
-  }
 
   /**
    * Converts the given {@link HttpCommonRequest} to an Apache {@link
@@ -101,22 +47,23 @@ public class CustomApacheHttpClient implements HttpClient {
       @Nullable ExecutionEnvironment executionEnvironment) {
     try {
       var apacheRequest = ApacheRequestFactory.get().createHttpRequest(request);
-      var result =
-          httpClientBuilder
-              .setDefaultRequestConfig(getRequestConfig(request))
-              .setDefaultCredentialsProvider(
-                  proxyHandler.getCredentialsProvider(apacheRequest.getScheme()))
-              .useSystemProperties() // Will fallback on system properties for unset values,
-              // e.g. http.keepAlive, http.agent
-              .build()
-              .execute(
-                  apacheRequest,
-                  new HttpCommonResultResponseHandler(
-                      executionEnvironment, request.isStoreResponse()));
-      if (HttpStatusHelper.isError(result.status())) {
-        throw ConnectorExceptionMapper.from(result);
+      var host = apacheRequest.getAuthority().getHostName();
+      var scheme = apacheRequest.getScheme();
+      try (var client =
+          new ProxyAwareHttpClient(
+              new ProxyAwareHttpClient.TimeoutConfiguration(
+                  request.getConnectionTimeoutInSeconds(), request.getReadTimeoutInSeconds()),
+              new ProxyAwareHttpClient.ProxyContext(scheme, host))) {
+        var result =
+            client.execute(
+                apacheRequest,
+                new HttpCommonResultResponseHandler(
+                    executionEnvironment, request.isStoreResponse()));
+        if (HttpStatusHelper.isError(result.status())) {
+          throw ConnectorExceptionMapper.from(result);
+        }
+        return result;
       }
-      return result;
     } catch (ClientProtocolException e) {
       throw new ConnectorException(
           String.valueOf(HttpStatus.SC_SERVER_ERROR),
@@ -128,12 +75,5 @@ public class CustomApacheHttpClient implements HttpClient {
           "An error occurred while executing the request, or the connection was aborted",
           e);
     }
-  }
-
-  private RequestConfig getRequestConfig(HttpCommonRequest request) {
-    return RequestConfig.custom()
-        .setConnectionRequestTimeout(Timeout.ofSeconds(request.getConnectionTimeoutInSeconds()))
-        .setResponseTimeout(Timeout.ofSeconds(request.getReadTimeoutInSeconds()))
-        .build();
   }
 }

--- a/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/client/apache/builder/parts/ApacheRequestAuthenticationBuilder.java
+++ b/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/client/apache/builder/parts/ApacheRequestAuthenticationBuilder.java
@@ -63,7 +63,7 @@ public class ApacheRequestAuthenticationBuilder implements ApacheRequestPartBuil
 
   String fetchOAuthToken(OAuthAuthentication authentication) {
     HttpCommonRequest oAuthRequest = oAuthService.createOAuthRequestFrom(authentication);
-    HttpCommonResult response = CustomApacheHttpClient.getDefault().execute(oAuthRequest);
+    HttpCommonResult response = new CustomApacheHttpClient().execute(oAuthRequest);
     return oAuthService.extractTokenFromResponse(response.body());
   }
 }

--- a/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/client/apache/proxy/ProxyAwareHttpClient.java
+++ b/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/client/apache/proxy/ProxyAwareHttpClient.java
@@ -1,0 +1,106 @@
+package io.camunda.connector.http.base.client.apache.proxy;
+
+import java.io.Closeable;
+import java.io.IOException;
+import org.apache.hc.client5.http.config.RequestConfig;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
+import org.apache.hc.client5.http.impl.classic.HttpClients;
+import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManager;
+import org.apache.hc.core5.http.ClassicHttpRequest;
+import org.apache.hc.core5.http.HttpHost;
+import org.apache.hc.core5.http.io.HttpClientResponseHandler;
+import org.apache.hc.core5.http.io.SocketConfig;
+import org.apache.hc.core5.util.Timeout;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Builder for creating a {@link CloseableHttpClient} with proxy support. This class is thread-safe.
+ */
+public class ProxyAwareHttpClient implements Closeable {
+  private static final Logger LOG = LoggerFactory.getLogger(ProxyAwareHttpClient.class);
+
+  private final ProxyHandler proxyHandler = new ProxyHandler();
+  private final TimeoutConfiguration timeoutConfiguration;
+  private final ProxyContext proxyContext;
+  private final CloseableHttpClient client;
+
+  public record TimeoutConfiguration(int connectionTimeoutInSeconds, int readTimeoutInSeconds) {}
+
+  public record ProxyContext(String scheme, String host) {}
+
+  public ProxyAwareHttpClient(
+      TimeoutConfiguration timeoutConfiguration, ProxyContext proxyContext) {
+    this.timeoutConfiguration = timeoutConfiguration;
+    this.proxyContext = proxyContext;
+    this.client = createClient();
+  }
+
+  @Override
+  public void close() throws IOException {
+    if (client != null) {
+      client.close();
+    }
+  }
+
+  public <T> T execute(ClassicHttpRequest request, HttpClientResponseHandler<T> responseHandler)
+      throws IOException {
+    return client.execute(request, responseHandler);
+  }
+
+  private CloseableHttpClient createClient() {
+    var builder = createHttpClientBuilder();
+
+    setProxyIfConfigured(proxyContext, builder);
+
+    builder
+        .setDefaultRequestConfig(getRequestTimeoutConfig(timeoutConfiguration))
+        .useSystemProperties();
+
+    return builder.build();
+  }
+
+  private void setProxyIfConfigured(ProxyContext proxyContext, HttpClientBuilder builder) {
+    proxyHandler
+        .getProxyDetails(proxyContext.scheme())
+        .ifPresent(
+            proxyDetails -> {
+              HttpHost proxyHttpHost =
+                  new HttpHost(proxyDetails.scheme(), proxyDetails.host(), proxyDetails.port());
+              LOG.debug(
+                  "Using proxy for target scheme [{}] and host [{}] => [{}]",
+                  proxyContext.scheme(),
+                  proxyContext.host(),
+                  proxyHttpHost);
+              builder.setDefaultCredentialsProvider(
+                  proxyHandler.getCredentialsProvider(proxyContext.scheme()));
+              builder.setRoutePlanner(new ProxyRoutePlanner(proxyHttpHost));
+            });
+  }
+
+  private HttpClientBuilder createHttpClientBuilder() {
+    return HttpClients.custom()
+        .setConnectionManager(createConnectionManager())
+        .disableRedirectHandling();
+  }
+
+  private PoolingHttpClientConnectionManager createConnectionManager() {
+    PoolingHttpClientConnectionManager connectionManager = new PoolingHttpClientConnectionManager();
+    connectionManager.setMaxTotal(Integer.MAX_VALUE);
+    connectionManager.setDefaultMaxPerRoute(Integer.MAX_VALUE);
+
+    // Socket config
+    connectionManager.setDefaultSocketConfig(SocketConfig.custom().setSoKeepAlive(true).build());
+
+    return connectionManager;
+  }
+
+  private RequestConfig getRequestTimeoutConfig(TimeoutConfiguration timeoutConfiguration) {
+    return RequestConfig.custom()
+        .setConnectionRequestTimeout(
+            Timeout.ofSeconds(timeoutConfiguration.connectionTimeoutInSeconds()))
+        .setResponseTimeout(Timeout.ofSeconds(timeoutConfiguration.readTimeoutInSeconds()))
+        .build();
+  }
+}

--- a/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/client/apache/proxy/ProxyAwareHttpClient.java
+++ b/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/client/apache/proxy/ProxyAwareHttpClient.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.camunda.connector.http.base.client.apache.proxy;
 
 import java.io.Closeable;

--- a/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/client/apache/proxy/ProxyRoutePlanner.java
+++ b/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/client/apache/proxy/ProxyRoutePlanner.java
@@ -1,0 +1,49 @@
+package io.camunda.connector.http.base.client.apache.proxy;
+
+import static io.camunda.connector.http.base.client.apache.proxy.ProxyHandler.CONNECTOR_HTTP_NON_PROXY_HOSTS_ENV_VAR;
+
+import java.util.Objects;
+import java.util.stream.Stream;
+import org.apache.hc.client5.http.impl.routing.DefaultProxyRoutePlanner;
+import org.apache.hc.core5.http.HttpException;
+import org.apache.hc.core5.http.HttpHost;
+import org.apache.hc.core5.http.protocol.HttpContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ProxyRoutePlanner extends DefaultProxyRoutePlanner {
+  private static final Logger LOG = LoggerFactory.getLogger(ProxyRoutePlanner.class.getName());
+  private static final String NON_PROXY_HOSTS_FROM_SYSTEM_PROPERTIES =
+      System.getProperty("http.nonProxyHosts");
+  private static final String NON_PROXY_HOSTS_FROM_ENV_VAR =
+      System.getenv(CONNECTOR_HTTP_NON_PROXY_HOSTS_ENV_VAR);
+
+  public ProxyRoutePlanner(HttpHost proxy) {
+    super(proxy);
+  }
+
+  @Override
+  protected HttpHost determineProxy(HttpHost target, HttpContext context) throws HttpException {
+    if (Stream.of(NON_PROXY_HOSTS_FROM_SYSTEM_PROPERTIES, NON_PROXY_HOSTS_FROM_ENV_VAR)
+        .filter(Objects::nonNull)
+        .anyMatch(
+            nonProxyHosts ->
+                target.getHostName().matches(sanitizedNonProxyHostsRegex(nonProxyHosts)))) {
+      LOG.debug(
+          "Not using proxy for target host [{}] as it matched either system properties (http.nonProxyHosts) or environment variables ({})",
+          target.getHostName(),
+          CONNECTOR_HTTP_NON_PROXY_HOSTS_ENV_VAR);
+      return null;
+    }
+    var proxy = super.determineProxy(target, context);
+    LOG.debug("Using proxy for target host [{}] => [{}]", target.getHostName(), proxy);
+    return proxy;
+  }
+
+  private String sanitizedNonProxyHostsRegex(String nonProxyHosts) {
+    return nonProxyHosts != null
+        ? nonProxyHosts.replace(
+            "*", ".*") // This is required as the nonProxyHosts property uses * as a wildcard
+        : null;
+  }
+}

--- a/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/client/apache/proxy/ProxyRoutePlanner.java
+++ b/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/client/apache/proxy/ProxyRoutePlanner.java
@@ -29,10 +29,6 @@ import org.slf4j.LoggerFactory;
 
 public class ProxyRoutePlanner extends DefaultProxyRoutePlanner {
   private static final Logger LOG = LoggerFactory.getLogger(ProxyRoutePlanner.class.getName());
-  private static final String NON_PROXY_HOSTS_FROM_SYSTEM_PROPERTIES =
-      System.getProperty("http.nonProxyHosts");
-  private static final String NON_PROXY_HOSTS_FROM_ENV_VAR =
-      System.getenv(CONNECTOR_HTTP_NON_PROXY_HOSTS_ENV_VAR);
 
   public ProxyRoutePlanner(HttpHost proxy) {
     super(proxy);
@@ -40,7 +36,7 @@ public class ProxyRoutePlanner extends DefaultProxyRoutePlanner {
 
   @Override
   protected HttpHost determineProxy(HttpHost target, HttpContext context) throws HttpException {
-    if (Stream.of(NON_PROXY_HOSTS_FROM_SYSTEM_PROPERTIES, NON_PROXY_HOSTS_FROM_ENV_VAR)
+    if (getNonProxyHosts()
         .filter(Objects::nonNull)
         .anyMatch(
             nonProxyHosts ->
@@ -61,5 +57,11 @@ public class ProxyRoutePlanner extends DefaultProxyRoutePlanner {
         ? nonProxyHosts.replace(
             "*", ".*") // This is required as the nonProxyHosts property uses * as a wildcard
         : null;
+  }
+
+  private Stream<String> getNonProxyHosts() {
+    return Stream.of(
+        System.getProperty("http.nonProxyHosts"),
+        System.getenv(CONNECTOR_HTTP_NON_PROXY_HOSTS_ENV_VAR));
   }
 }

--- a/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/client/apache/proxy/ProxyRoutePlanner.java
+++ b/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/client/apache/proxy/ProxyRoutePlanner.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.camunda.connector.http.base.client.apache.proxy;
 
 import static io.camunda.connector.http.base.client.apache.proxy.ProxyHandler.CONNECTOR_HTTP_NON_PROXY_HOSTS_ENV_VAR;

--- a/connectors/http/http-base/src/test/java/io/camunda/connector/http/base/client/apache/ApacheRequestFactoryTest.java
+++ b/connectors/http/http-base/src/test/java/io/camunda/connector/http/base/client/apache/ApacheRequestFactoryTest.java
@@ -20,9 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.mockStatic;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 import io.camunda.connector.api.json.ConnectorsObjectMapperSupplier;
 import io.camunda.connector.http.base.authentication.Base64Helper;
@@ -53,7 +51,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
-import org.mockito.MockedStatic;
+import org.mockito.MockedConstruction;
 
 public class ApacheRequestFactoryTest {
 
@@ -116,12 +114,11 @@ public class ApacheRequestFactoryTest {
       request.setAuthentication(
           new OAuthAuthentication(
               "url", "clientId", "secret", "audience", OAuthConstants.CREDENTIALS_BODY, "scopes"));
-      var mockedClient = mock(CustomApacheHttpClient.class);
-      try (MockedStatic<CustomApacheHttpClient> mockedClientSupplier =
-          mockStatic(CustomApacheHttpClient.class)) {
-        mockedClientSupplier.when(CustomApacheHttpClient::getDefault).thenReturn(mockedClient);
-        when(mockedClient.execute(any(HttpCommonRequest.class))).thenReturn(result);
-
+      try (MockedConstruction<CustomApacheHttpClient> mocked =
+          mockConstruction(
+              CustomApacheHttpClient.class,
+              (mock, context) ->
+                  when(mock.execute(any(HttpCommonRequest.class))).thenReturn(result))) {
         // when
         ClassicHttpRequest httpRequest = ApacheRequestFactory.get().createHttpRequest(request);
 

--- a/connectors/http/http-base/src/test/java/io/camunda/connector/http/base/client/apache/CustomApacheHttpClientTest.java
+++ b/connectors/http/http-base/src/test/java/io/camunda/connector/http/base/client/apache/CustomApacheHttpClientTest.java
@@ -33,7 +33,6 @@ import io.camunda.connector.api.json.ConnectorsObjectMapperSupplier;
 import io.camunda.connector.http.base.ExecutionEnvironment;
 import io.camunda.connector.http.base.TestDocumentFactory;
 import io.camunda.connector.http.base.authentication.OAuthConstants;
-import io.camunda.connector.http.base.client.apache.proxy.ProxyHandler;
 import io.camunda.connector.http.base.model.HttpCommonRequest;
 import io.camunda.connector.http.base.model.HttpCommonResult;
 import io.camunda.connector.http.base.model.HttpMethod;
@@ -97,7 +96,6 @@ public class CustomApacheHttpClientTest {
       HttpCommonResult result =
           customApacheHttpClient.execute(
               request,
-              new ProxyHandler(),
               new ExecutionEnvironment.SelfManaged(new TestDocumentFactory()));
       assertThat(result).isNotNull();
       assertThat(result.status()).isEqualTo(200);

--- a/connectors/http/http-base/src/test/java/io/camunda/connector/http/base/client/apache/CustomApacheHttpClientTest.java
+++ b/connectors/http/http-base/src/test/java/io/camunda/connector/http/base/client/apache/CustomApacheHttpClientTest.java
@@ -33,6 +33,7 @@ import io.camunda.connector.api.json.ConnectorsObjectMapperSupplier;
 import io.camunda.connector.http.base.ExecutionEnvironment;
 import io.camunda.connector.http.base.TestDocumentFactory;
 import io.camunda.connector.http.base.authentication.OAuthConstants;
+import io.camunda.connector.http.base.client.apache.proxy.ProxyHandler;
 import io.camunda.connector.http.base.model.HttpCommonRequest;
 import io.camunda.connector.http.base.model.HttpCommonResult;
 import io.camunda.connector.http.base.model.HttpMethod;
@@ -51,7 +52,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
 import org.apache.commons.text.StringEscapeUtils;
-import org.apache.hc.client5.http.impl.classic.HttpClients;
 import org.apache.hc.core5.http.ContentType;
 import org.apache.hc.core5.http.HttpHeaders;
 import org.apache.hc.core5.http.HttpStatus;
@@ -70,7 +70,7 @@ import wiremock.com.fasterxml.jackson.databind.node.POJONode;
 @WireMockTest
 public class CustomApacheHttpClientTest {
 
-  private final CustomApacheHttpClient customApacheHttpClient = CustomApacheHttpClient.getDefault();
+  private final CustomApacheHttpClient customApacheHttpClient = new CustomApacheHttpClient();
   private final ObjectMapper objectMapper = ConnectorsObjectMapperSupplier.getCopy();
   private final InMemoryDocumentStore store = InMemoryDocumentStore.INSTANCE;
 
@@ -234,7 +234,7 @@ public class CustomApacheHttpClientTest {
       Testcontainers.exposeHostPorts(proxy.port());
       proxyContainer.withAccessToHost(true);
       proxyContainer.start();
-      proxiedApacheHttpClient = CustomApacheHttpClient.create(HttpClients.custom());
+      proxiedApacheHttpClient = new CustomApacheHttpClient();
     }
 
     private static void setAllSystemProperties() {

--- a/connectors/http/http-base/src/test/java/io/camunda/connector/http/base/client/apache/CustomApacheHttpClientTest.java
+++ b/connectors/http/http-base/src/test/java/io/camunda/connector/http/base/client/apache/CustomApacheHttpClientTest.java
@@ -95,8 +95,7 @@ public class CustomApacheHttpClientTest {
       request.setUrl(wmRuntimeInfo.getHttpBaseUrl() + "/download");
       HttpCommonResult result =
           customApacheHttpClient.execute(
-              request,
-              new ExecutionEnvironment.SelfManaged(new TestDocumentFactory()));
+              request, new ExecutionEnvironment.SelfManaged(new TestDocumentFactory()));
       assertThat(result).isNotNull();
       assertThat(result.status()).isEqualTo(200);
       assertThat(result.headers().get(HttpHeaders.CONTENT_TYPE))

--- a/connectors/http/http-base/src/test/java/io/camunda/connector/http/base/client/apache/ProxyHandlerTest.java
+++ b/connectors/http/http-base/src/test/java/io/camunda/connector/http/base/client/apache/ProxyHandlerTest.java
@@ -22,6 +22,7 @@ import static uk.org.webcompere.systemstubs.SystemStubs.restoreSystemProperties;
 import static uk.org.webcompere.systemstubs.SystemStubs.withEnvironmentVariables;
 
 import io.camunda.connector.api.error.ConnectorInputException;
+import io.camunda.connector.http.base.client.apache.proxy.ProxyHandler;
 import org.apache.hc.client5.http.auth.CredentialsProvider;
 import org.apache.hc.client5.http.impl.auth.BasicCredentialsProvider;
 import org.junit.jupiter.api.AfterAll;

--- a/connectors/http/http-base/src/test/java/io/camunda/connector/http/base/client/apache/ProxyHandlerTest.java
+++ b/connectors/http/http-base/src/test/java/io/camunda/connector/http/base/client/apache/ProxyHandlerTest.java
@@ -57,14 +57,6 @@ public class ProxyHandlerTest {
   }
 
   @Test
-  public void shouldThrowException_whenProxyPortInvalidInSystemProperties() {
-    System.setProperty("http.proxyHost", "localhost");
-    System.setProperty("http.proxyPort", "invalid");
-
-    assertThrows(ConnectorInputException.class, () -> new ProxyHandler());
-  }
-
-  @Test
   public void shouldThrowException_whenProxyPortInvalidInEnvVars() throws Exception {
     restoreSystemProperties(
         () -> {
@@ -95,70 +87,6 @@ public class ProxyHandlerTest {
     CredentialsProvider provider = proxyHandler.getCredentialsProvider("http");
 
     assertThat(provider).isInstanceOf(BasicCredentialsProvider.class);
-  }
-
-  @Test
-  public void shouldSetSystemProperties_whenProxySettingsEnvVars() throws Exception {
-    restoreSystemProperties(
-        () -> {
-          withEnvironmentVariables(
-                  "CONNECTOR_HTTPS_PROXY_HOST",
-                  "localhost",
-                  "CONNECTOR_HTTPS_PROXY_PORT",
-                  "3128",
-                  "CONNECTOR_HTTPS_PROXY_USER",
-                  "my-user",
-                  "CONNECTOR_HTTPS_PROXY_PASSWORD",
-                  "demo",
-                  "CONNECTOR_HTTP_PROXY_NON_PROXY_HOSTS",
-                  "www.test.de")
-              .execute(
-                  () -> {
-                    assertThat(System.getProperty("https.proxyHost")).isNull();
-                    assertThat(System.getProperty("https.proxyPort")).isNull();
-                    assertThat(System.getProperty("https.proxyUser")).isNull();
-                    assertThat(System.getProperty("https.proxyPassword")).isNull();
-                    assertThat(System.getProperty("http.nonProxyHosts")).isNull();
-
-                    new ProxyHandler();
-
-                    assertThat(System.getProperty("https.proxyHost")).isEqualTo("localhost");
-                    assertThat(System.getProperty("https.proxyPort")).isEqualTo("3128");
-                    assertThat(System.getProperty("https.proxyUser")).isEqualTo("my-user");
-                    assertThat(System.getProperty("https.proxyPassword")).isEqualTo("demo");
-                    assertThat(System.getProperty("http.nonProxyHosts")).isEqualTo("www.test.de");
-                  });
-        });
-  }
-
-  @Test
-  public void shouldNotSetAuthSystemProperties_whenProxySettingsEnvVarsNoAuth() throws Exception {
-    restoreSystemProperties(
-        () -> {
-          withEnvironmentVariables(
-                  "CONNECTOR_HTTP_PROXY_HOST",
-                  "localhost",
-                  "CONNECTOR_HTTP_PROXY_PORT",
-                  "3128",
-                  "CONNECTOR_HTTP_PROXY_NON_PROXY_HOSTS",
-                  "www.test.de")
-              .execute(
-                  () -> {
-                    assertThat(System.getProperty("http.proxyHost")).isNull();
-                    assertThat(System.getProperty("http.proxyPort")).isNull();
-                    assertThat(System.getProperty("http.proxyUser")).isNull();
-                    assertThat(System.getProperty("http.proxyPassword")).isNull();
-                    assertThat(System.getProperty("http.nonProxyHosts")).isNull();
-
-                    new ProxyHandler();
-
-                    assertThat(System.getProperty("http.proxyHost")).isEqualTo("localhost");
-                    assertThat(System.getProperty("http.proxyPort")).isEqualTo("3128");
-                    assertThat(System.getProperty("http.proxyUser")).isEqualTo(null);
-                    assertThat(System.getProperty("http.proxyPassword")).isEqualTo(null);
-                    assertThat(System.getProperty("http.nonProxyHosts")).isEqualTo("www.test.de");
-                  });
-        });
   }
 
   @Test

--- a/connectors/http/http-base/src/test/java/io/camunda/connector/http/base/client/apache/proxy/ProxyRoutePlannerTest.java
+++ b/connectors/http/http-base/src/test/java/io/camunda/connector/http/base/client/apache/proxy/ProxyRoutePlannerTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.camunda.connector.http.base.client.apache.proxy;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/connectors/http/http-base/src/test/java/io/camunda/connector/http/base/client/apache/proxy/ProxyRoutePlannerTest.java
+++ b/connectors/http/http-base/src/test/java/io/camunda/connector/http/base/client/apache/proxy/ProxyRoutePlannerTest.java
@@ -1,0 +1,79 @@
+package io.camunda.connector.http.base.client.apache.proxy;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.Proxy;
+import java.net.ProxySelector;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.stream.Stream;
+import org.apache.hc.core5.http.HttpException;
+import org.apache.hc.core5.http.HttpHost;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public class ProxyRoutePlannerTest {
+
+  HttpHost proxy = new HttpHost("theproxyhost", 4750);
+
+  private static Stream<Arguments> provideNonProxyHostTestData() {
+    return Stream.of(
+        // nonProxyHosts, requestUrl, skipProxy
+        Arguments.of("example.de", "http://example.de", true),
+        Arguments.of("example.de", "http://www.example.de", false),
+        Arguments.of("www.example.de", "http://www.example.de", true),
+        Arguments.of("example.de|www.camunda.de", "http://www.camunda.io", false),
+        Arguments.of("example.de", "http://www.example.de", false),
+        Arguments.of("example.de", "http://api.example.de", false),
+        Arguments.of("example.de", "http://another.example.de", false),
+        Arguments.of("example.de", "http://example.com", false),
+        Arguments.of("example.de|camunda.de", "http://www.example.de", false),
+        Arguments.of("example.de|camunda.de", "http://www.camunda.de", false),
+        Arguments.of("example.de|camunda.de", "http://www.google.de", false),
+        Arguments.of("*.example.de", "http://api.example.de", true),
+        Arguments.of("*.example.de", "http://www.example.de", true),
+        Arguments.of("*.example.de", "http://example.de", false),
+        Arguments.of("*.example.de", "http://example.com", false),
+        Arguments.of("*.example.de|*.camunda.io", "http://sub.example.de", true),
+        Arguments.of("*.example.de|*.camunda.io", "http://api.camunda.io", true),
+        Arguments.of("*.example.de|*.camunda.io", "http://www.google.com", false));
+  }
+
+  @AfterEach
+  public void clearSystemProperties() {
+    System.clearProperty("http.nonProxyHosts");
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideNonProxyHostTestData")
+  public void shouldUseProxy_whenRequestUrlMatches(
+      String nonProxyHosts, String requestUrl, Boolean skipProxy)
+      throws HttpException, URISyntaxException {
+    // given
+    HttpHost target = HttpHost.create(requestUrl);
+    System.setProperty("http.nonProxyHosts", nonProxyHosts);
+    ProxyRoutePlanner proxyRoutePlanner = new ProxyRoutePlanner(proxy);
+    // Tests with the Java default proxy selector
+    System.setProperty("http.proxyHost", "theproxyhost");
+    System.setProperty("http.proxyPort", "4750");
+    var javaDefaultProxies = ProxySelector.getDefault().select(URI.create(requestUrl));
+
+    // when
+    var route = proxyRoutePlanner.determineProxy(target, null);
+
+    // then
+    assertThat(javaDefaultProxies.size()).isEqualTo(1);
+    var javaProxy = javaDefaultProxies.getFirst();
+
+    if (skipProxy) {
+      assertThat(route).isNull();
+      assertThat(javaProxy.type()).isEqualTo(Proxy.Type.DIRECT);
+    } else {
+      assertThat(route).isNotNull();
+      assertThat(route).isEqualTo(proxy);
+      assertThat(javaProxy.type()).isEqualTo(Proxy.Type.HTTP);
+    }
+  }
+}

--- a/connectors/http/http-base/src/test/java/io/camunda/connector/http/base/cloudfunction/CloudFunctionServiceTest.java
+++ b/connectors/http/http-base/src/test/java/io/camunda/connector/http/base/cloudfunction/CloudFunctionServiceTest.java
@@ -64,11 +64,7 @@ public class CloudFunctionServiceTest {
     request.setUrl("theUrl");
     request.setMethod(HttpMethod.POST);
     request.setHeaders(
-        Map.of(
-            "header",
-            "value",
-            "Content-Type",
-            ContentType.APPLICATION_FORM_URLENCODED.getMimeType()));
+        Map.of("header", "value", "Content-Type", ContentType.MULTIPART_FORM_DATA.getMimeType()));
     request.setBody(Map.of("bodyKey", "bodyValue", "myDocument", document));
     request.setConnectionTimeoutInSeconds(50);
     request.setReadTimeoutInSeconds(60);
@@ -89,9 +85,7 @@ public class CloudFunctionServiceTest {
     assertThat(body).containsEntry("url", "theUrl");
     assertThat(body).containsEntry("method", "POST");
     assertThat(body)
-        .containsEntry(
-            "headers",
-            Map.of("header", "value", "Content-Type", "application/x-www-form-urlencoded"));
+        .containsEntry("headers", Map.of("header", "value", "Content-Type", "multipart/form-data"));
     assertThat(body)
         .containsEntry(
             "body",

--- a/connectors/http/rest/src/test/java/io/camunda/connector/http/rest/HttpServiceTest.java
+++ b/connectors/http/rest/src/test/java/io/camunda/connector/http/rest/HttpServiceTest.java
@@ -37,7 +37,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.MockedConstruction;
-import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)


### PR DESCRIPTION
## Description

This PR changes the previous behavior about how we configure a proxy (and non-proxy hosts).
- We can now set up a proxy for REST-like connectors **only** (REST, Github, etc). This is done using a specific set of **environment variables**: 


| Env. Var | Description | Default |
|--------|--------|--------|
| CONNECTOR_HTTP(S)_PROXY_SCHEME | The proxy **scheme** (`http`, or `https`). This allows the user to use https proxies which is not possible with other clients | `http` |
| CONNECTOR_HTTP(S)_PROXY_HOST | The **host** part of the proxy URL (do not include `http://`)  | |
| CONNECTOR_HTTP(S)_PROXY_PORT | The **port** part of the proxy URL | |
| CONNECTOR_HTTP(S)_PROXY_USER | If you need to authenticate, use this variable to set the **user** | |
| CONNECTOR_HTTP(S)_PROXY_PASSWORD | If you need to authenticate, use this variable to set the **password** | | 
| CONNECTOR_HTTP_NON_PROXY_HOSTS | Similar to the [Java](https://docs.oracle.com/javase/8/docs/technotes/guides/net/proxies.html) `http.nonProxyHosts` system property | 

- Note that these values are **not copied** to the System Properties anymore.
- If you want a global behavior, don't use these variables but use System Properties instead.

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.

