### PR TITLE
chore(element-templates): Adjust doc links

### DIFF
--- a/connectors/aws/aws-s3/element-templates/aws-s3-outbound-connector.json
+++ b/connectors/aws/aws-s3/element-templates/aws-s3-outbound-connector.json
@@ -6,7 +6,7 @@
   "metadata" : {
     "keywords" : [ ]
   },
-  "documentationRef" : "https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-s3/",
+  "documentationRef" : "https://docs.camunda.io/docs/8.7/components/connectors/out-of-the-box-connectors/amazon-s3/",
   "version" : 1,
   "category" : {
     "id" : "connectors",

--- a/connectors/aws/aws-s3/element-templates/hybrid/aws-s3-outbound-connector-hybrid.json
+++ b/connectors/aws/aws-s3/element-templates/hybrid/aws-s3-outbound-connector-hybrid.json
@@ -6,7 +6,7 @@
   "metadata" : {
     "keywords" : [ ]
   },
-  "documentationRef" : "https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-s3/",
+  "documentationRef" : "https://docs.camunda.io/docs/8.7/components/connectors/out-of-the-box-connectors/amazon-s3/",
   "version" : 1,
   "category" : {
     "id" : "connectors",

--- a/connectors/aws/aws-s3/src/main/java/io/camunda/connector/aws/s3/S3ConnectorFunction.java
+++ b/connectors/aws/aws-s3/src/main/java/io/camunda/connector/aws/s3/S3ConnectorFunction.java
@@ -35,7 +35,7 @@ import java.util.function.Function;
       @ElementTemplate.PropertyGroup(id = "downloadObject", label = "Download an object"),
     },
     documentationRef =
-        "https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-s3/",
+        "https://docs.camunda.io/docs/8.7/components/connectors/out-of-the-box-connectors/amazon-s3/",
     icon = "icon.svg")
 public class S3ConnectorFunction implements OutboundConnectorFunction {
 

--- a/connectors/box/element-templates/box-outbound-connector.json
+++ b/connectors/box/element-templates/box-outbound-connector.json
@@ -6,7 +6,7 @@
   "metadata" : {
     "keywords" : [ ]
   },
-  "documentationRef" : "https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/box/",
+  "documentationRef" : "https://docs.camunda.io/docs/8.7/components/connectors/out-of-the-box-connectors/box/",
   "version" : 1,
   "category" : {
     "id" : "connectors",

--- a/connectors/box/element-templates/hybrid/box-outbound-connector-hybrid.json
+++ b/connectors/box/element-templates/hybrid/box-outbound-connector-hybrid.json
@@ -6,7 +6,7 @@
   "metadata" : {
     "keywords" : [ ]
   },
-  "documentationRef" : "https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/box/",
+  "documentationRef" : "https://docs.camunda.io/docs/8.7/components/connectors/out-of-the-box-connectors/box/",
   "version" : 1,
   "category" : {
     "id" : "connectors",

--- a/connectors/box/src/main/java/io/camunda/connector/box/BoxFunction.java
+++ b/connectors/box/src/main/java/io/camunda/connector/box/BoxFunction.java
@@ -27,7 +27,7 @@ import io.camunda.connector.generator.java.annotation.ElementTemplate;
       @ElementTemplate.PropertyGroup(id = "operation", label = "Operation"),
     },
     documentationRef =
-        "https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/box/",
+        "https://docs.camunda.io/docs/8.7/components/connectors/out-of-the-box-connectors/box/",
     icon = "icon.svg")
 public class BoxFunction implements OutboundConnectorFunction {
 

--- a/connectors/google/google-gemini/element-templates/google-gemini-outbound-connector.json
+++ b/connectors/google/google-gemini/element-templates/google-gemini-outbound-connector.json
@@ -6,7 +6,7 @@
   "metadata" : {
     "keywords" : [ ]
   },
-  "documentationRef" : "https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-gemini/",
+  "documentationRef" : "https://docs.camunda.io/docs/8.7/components/connectors/out-of-the-box-connectors/google-gemini/",
   "version" : 1,
   "category" : {
     "id" : "connectors",

--- a/connectors/google/google-gemini/element-templates/hybrid/google-gemini-outbound-connector-hybrid.json
+++ b/connectors/google/google-gemini/element-templates/hybrid/google-gemini-outbound-connector-hybrid.json
@@ -6,7 +6,7 @@
   "metadata" : {
     "keywords" : [ ]
   },
-  "documentationRef" : "https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-gemini/",
+  "documentationRef" : "https://docs.camunda.io/docs/8.7/components/connectors/out-of-the-box-connectors/google-gemini/",
   "version" : 1,
   "category" : {
     "id" : "connectors",

--- a/connectors/google/google-gemini/src/main/java/io/camunda/connector/gemini/GeminiConnectorFunction.java
+++ b/connectors/google/google-gemini/src/main/java/io/camunda/connector/gemini/GeminiConnectorFunction.java
@@ -35,7 +35,7 @@ import java.util.HashMap;
       @ElementTemplate.PropertyGroup(id = "input", label = "Configure input")
     },
     documentationRef =
-        "https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-gemini/",
+        "https://docs.camunda.io/docs/8.7/components/connectors/out-of-the-box-connectors/google-gemini/",
     icon = "icon.svg")
 public class GeminiConnectorFunction implements OutboundConnectorFunction {
 


### PR DESCRIPTION
## Description
Added version to connectors links that are not available in 8.6.
Similar changes I did to web-modeler project here:  https://github.com/camunda/web-modeler/pull/13654

## Related issues
See related docs PR here: https://github.com/camunda/camunda-docs/pull/5090

Can I backport this or is backporting to 8.7 "closed"?


- [x] PR has a **milestone** or the `no milestone` label.

