### PR TITLE
chore(idp-extraction-connector): rename results map

### DIFF
--- a/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/caller/VertexCaller.java
+++ b/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/caller/VertexCaller.java
@@ -58,6 +58,7 @@ public class VertexCaller {
       var content =
           ContentMaker.fromMultiModalData(
               llmModel.getMessage(input.taxonomyItems()),
+              // TODO: we need to always expose the content type and not assume its a PDF
               PartMaker.fromMimeTypeAndData(
                   input.document().metadata().getContentType() != null
                       ? input.document().metadata().getContentType()

--- a/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/caller/VertexCaller.java
+++ b/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/caller/VertexCaller.java
@@ -35,7 +35,7 @@ public class VertexCaller {
     String fileUri;
     final String fileName =
         input.document().metadata().getFileName() == null
-            ? "temporaryDocument"
+            ? "temporaryDocument.pdf"
             : input.document().metadata().getFileName();
     try {
       fileUri =
@@ -58,7 +58,11 @@ public class VertexCaller {
       var content =
           ContentMaker.fromMultiModalData(
               llmModel.getMessage(input.taxonomyItems()),
-              PartMaker.fromMimeTypeAndData(input.document().metadata().getContentType(), fileUri));
+              PartMaker.fromMimeTypeAndData(
+                  input.document().metadata().getContentType() != null
+                      ? input.document().metadata().getContentType()
+                      : "application/pdf",
+                  fileUri));
       GenerateContentResponse response = model.generateContent(content);
       String output = ResponseHandler.getText(response);
       LOGGER.debug("Gemini generate content response: {}", output);

--- a/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/model/ExtractionResult.java
+++ b/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/model/ExtractionResult.java
@@ -8,4 +8,4 @@ package io.camunda.connector.idp.extraction.model;
 
 import java.util.Map;
 
-public record ExtractionResult(Map<String, Object> response) {}
+public record ExtractionResult(Map<String, Object> extractedFields) {}

--- a/connectors/idp-extraction/src/test/java/io/camunda/connector/idp/extraction/ExtractionConnectorFunctionTest.java
+++ b/connectors/idp-extraction/src/test/java/io/camunda/connector/idp/extraction/ExtractionConnectorFunctionTest.java
@@ -304,7 +304,7 @@ class ExtractionConnectorFunctionTest {
         .asInstanceOf(InstanceOfAssertFactories.type(ExtractionResult.class))
         .satisfies(
             extractionResult ->
-                assertThat(extractionResult.response())
+                assertThat(extractionResult.extractedFields())
                     .containsExactlyInAnyOrderEntriesOf(expected));
   }
 

--- a/connectors/idp-extraction/src/test/java/io/camunda/connector/idp/extraction/caller/VertexCallerTest.java
+++ b/connectors/idp-extraction/src/test/java/io/camunda/connector/idp/extraction/caller/VertexCallerTest.java
@@ -23,7 +23,6 @@ import io.camunda.connector.idp.extraction.model.providers.VertexProvider;
 import io.camunda.connector.idp.extraction.model.providers.VertexRequestConfiguration;
 import io.camunda.connector.idp.extraction.util.ExtractionTestUtils;
 import io.camunda.connector.idp.extraction.utils.GcsUtil;
-
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.MockedStatic;
@@ -51,7 +50,7 @@ class VertexCallerTest {
       return ResponseHandler.getText(response);
     }
   }
-  
+
   private VertexProvider createBaseRequest() {
     VertexRequestConfiguration configuration =
         new VertexRequestConfiguration("region", "project-id", "bucket-name");

--- a/connectors/idp-extraction/src/test/java/io/camunda/connector/idp/extraction/caller/VertexCallerTest.java
+++ b/connectors/idp-extraction/src/test/java/io/camunda/connector/idp/extraction/caller/VertexCallerTest.java
@@ -23,17 +23,46 @@ import io.camunda.connector.idp.extraction.model.providers.VertexProvider;
 import io.camunda.connector.idp.extraction.model.providers.VertexRequestConfiguration;
 import io.camunda.connector.idp.extraction.util.ExtractionTestUtils;
 import io.camunda.connector.idp.extraction.utils.GcsUtil;
+
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
-class GeminiCallerTest {
+class VertexCallerTest {
+
+  private static class TestVertexCaller extends VertexCaller {
+    private final GenerativeModel mockModel;
+
+    public TestVertexCaller(GenerativeModel mockModel) {
+      this.mockModel = mockModel;
+    }
+
+    @Override
+    public String generateContent(ExtractionRequestData input, VertexProvider baseRequest)
+        throws Exception {
+      GenerateContentResponse response =
+          mockModel.generateContent(
+              Content.newBuilder()
+                  .addParts(Part.newBuilder().setText("just a text").build())
+                  .build());
+
+      return ResponseHandler.getText(response);
+    }
+  }
+  
+  private VertexProvider createBaseRequest() {
+    VertexRequestConfiguration configuration =
+        new VertexRequestConfiguration("region", "project-id", "bucket-name");
+
+    VertexProvider baseRequest = new VertexProvider();
+    baseRequest.setConfiguration(configuration);
+    return baseRequest;
+  }
 
   @Test
   void executeSuccessfulExtraction() throws Exception {
-    // Expected response
     String expectedResponse =
         """
         {
@@ -42,27 +71,6 @@ class GeminiCallerTest {
         }
         """;
 
-    class TestVertexCaller extends VertexCaller {
-      private final GenerativeModel mockModel;
-
-      public TestVertexCaller(GenerativeModel mockModel) {
-        this.mockModel = mockModel;
-      }
-
-      @Override
-      public String generateContent(ExtractionRequestData input, VertexProvider baseRequest)
-          throws Exception {
-        GenerateContentResponse response =
-            mockModel.generateContent(
-                Content.newBuilder()
-                    .addParts(Part.newBuilder().setText("just a text").build())
-                    .build());
-
-        return ResponseHandler.getText(response);
-      }
-    }
-
-    // Mock the GCS upload utility
     String mockedFileUri = "gs://bucket-name/file-name";
     try (MockedStatic<GcsUtil> gcsUtilMockedStatic = mockStatic(GcsUtil.class)) {
       gcsUtilMockedStatic
@@ -73,7 +81,6 @@ class GeminiCallerTest {
           .thenReturn(mockedFileUri);
 
       GenerativeModel mockGenerativeModel = mock(GenerativeModel.class);
-
       GenerateContentResponse mockResponse = mock(GenerateContentResponse.class);
       when(mockGenerativeModel.generateContent(any(Content.class))).thenReturn(mockResponse);
 
@@ -83,17 +90,54 @@ class GeminiCallerTest {
             .when(() -> ResponseHandler.getText(any()))
             .thenReturn(expectedResponse);
 
-        VertexRequestConfiguration configuration =
-            new VertexRequestConfiguration("region", "project-id", "bucket-name");
-
-        VertexProvider baseRequest = new VertexProvider();
-        baseRequest.setConfiguration(configuration);
-
+        VertexProvider baseRequest = createBaseRequest();
         TestVertexCaller testCaller = new TestVertexCaller(mockGenerativeModel);
 
         String result =
             testCaller.generateContent(
                 ExtractionTestUtils.TEXTRACT_EXTRACTION_REQUEST_DATA, baseRequest);
+
+        assertEquals(expectedResponse, result);
+      }
+    }
+  }
+
+  @Test
+  void executeWithMissingDocumentMetadata() throws Exception {
+    // Expected response
+    String expectedResponse =
+        """
+        {
+          "name": "Unknown",
+          "age": 0
+        }
+        """;
+
+    // Mock the GCS upload utility
+    String mockedFileUri = "gs://bucket-name/unknown-file";
+    try (MockedStatic<GcsUtil> gcsUtilMockedStatic = mockStatic(GcsUtil.class)) {
+      gcsUtilMockedStatic
+          .when(
+              () ->
+                  GcsUtil.uploadNewFileFromDocument(
+                      any(), anyString(), anyString(), anyString(), any()))
+          .thenReturn(mockedFileUri);
+
+      GenerativeModel mockGenerativeModel = mock(GenerativeModel.class);
+      GenerateContentResponse mockResponse = mock(GenerateContentResponse.class);
+      when(mockGenerativeModel.generateContent(any(Content.class))).thenReturn(mockResponse);
+
+      try (MockedStatic<ResponseHandler> responseHandlerMockedStatic =
+          mockStatic(ResponseHandler.class)) {
+        responseHandlerMockedStatic
+            .when(() -> ResponseHandler.getText(any()))
+            .thenReturn(expectedResponse);
+
+        ExtractionRequestData requestData = ExtractionTestUtils.TEXTRACT_EXTRACTION_REQUEST_DATA;
+        VertexProvider baseRequest = createBaseRequest();
+        TestVertexCaller testCaller = new TestVertexCaller(mockGenerativeModel);
+
+        String result = testCaller.generateContent(requestData, baseRequest);
 
         assertEquals(expectedResponse, result);
       }


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
I added a rename of the `ExtractionResult` results map. I also added a small fix for gcp


## Related issues

<!-- Which issues are closed by this PR or are related -->

closes https://github.com/camunda/connectors/issues/4355

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.
- [x] ExtractionResult returns extractedFields map.
- [x] If document metadata is missing for gcp, it is treaded as a pdf.

