### PR TITLE
chore(idp-extraction-connector): backport rename results map

### DIFF
--- a/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/caller/VertexCaller.java
+++ b/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/caller/VertexCaller.java
@@ -35,7 +35,7 @@ public class VertexCaller {
     String fileUri;
     final String fileName =
         input.document().metadata().getFileName() == null
-            ? "temporaryDocument"
+            ? "temporaryDocument.pdf"
             : input.document().metadata().getFileName();
     try {
       fileUri =
@@ -58,7 +58,12 @@ public class VertexCaller {
       var content =
           ContentMaker.fromMultiModalData(
               llmModel.getMessage(input.taxonomyItems()),
-              PartMaker.fromMimeTypeAndData(input.document().metadata().getContentType(), fileUri));
+              // TODO: we need to always expose the content type and not assume its a PDF
+              PartMaker.fromMimeTypeAndData(
+                  input.document().metadata().getContentType() != null
+                      ? input.document().metadata().getContentType()
+                      : "application/pdf",
+                  fileUri));
       GenerateContentResponse response = model.generateContent(content);
       String output = ResponseHandler.getText(response);
       LOGGER.debug("Gemini generate content response: {}", output);

--- a/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/model/ExtractionResult.java
+++ b/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/model/ExtractionResult.java
@@ -6,4 +6,6 @@
  */
 package io.camunda.connector.idp.extraction.model;
 
-public record ExtractionResult(Object response) {}
+import java.util.Map;
+
+public record ExtractionResult(Map<String, Object> extractedFields) {}

--- a/connectors/idp-extraction/src/test/java/io/camunda/connector/idp/extraction/ExtractionConnectorFunctionTest.java
+++ b/connectors/idp-extraction/src/test/java/io/camunda/connector/idp/extraction/ExtractionConnectorFunctionTest.java
@@ -7,14 +7,22 @@
 package io.camunda.connector.idp.extraction;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.connector.api.error.ConnectorException;
 import io.camunda.connector.idp.extraction.caller.BedrockCaller;
 import io.camunda.connector.idp.extraction.caller.PollingTextractCaller;
 import io.camunda.connector.idp.extraction.model.ExtractionResult;
 import io.camunda.connector.idp.extraction.util.ExtractionTestUtils;
 import io.camunda.connector.test.outbound.OutboundConnectorContextBuilder;
+import java.util.Map;
+import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -23,6 +31,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class ExtractionConnectorFunctionTest {
+
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
   @Mock private PollingTextractCaller pollingTextractCaller;
 
@@ -33,6 +43,180 @@ class ExtractionConnectorFunctionTest {
   @Test
   void executeExtractionReturnsCorrectResult() throws Exception {
     var outBounderContext = prepareConnectorContext();
+    var expectedResponseJson =
+        """
+            {
+            	"sum": "$12.25",
+            	"supplier": "Camunda Inc."
+            }
+        """;
+
+    when(pollingTextractCaller.call(any(), any(), any(), any()))
+        .thenReturn("Test extracted text from test document.pdf");
+    when(bedrockCaller.call(any(), any(), any())).thenReturn(expectedResponseJson);
+
+    var result = extractionConnectorFunction.execute(outBounderContext);
+    assertExtractionResult(result, expectedResponseJson);
+  }
+
+  @Test
+  void
+      executeExtractionReturnsPartiallyCorrectResult_whenLlmResponseIsMissingValueForSomeTaxonomyItems()
+          throws Exception {
+    var outBounderContext = prepareConnectorContext();
+    var expectedResponseJson =
+        """
+            {
+            	"sum": "$12.25"
+            }
+        """;
+
+    when(pollingTextractCaller.call(any(), any(), any(), any()))
+        .thenReturn("Test extracted text from test document.pdf");
+    when(bedrockCaller.call(any(), any(), any())).thenReturn(expectedResponseJson);
+
+    var result = extractionConnectorFunction.execute(outBounderContext);
+    assertExtractionResult(result, expectedResponseJson);
+  }
+
+  @Test
+  void executeExtractionReturnsCorrectResult_whenLlmResponseContainsNestedResponseObject()
+      throws Exception {
+    var outBounderContext = prepareConnectorContext();
+
+    when(pollingTextractCaller.call(any(), any(), any(), any()))
+        .thenReturn("Test extracted text from test document.pdf");
+    when(bedrockCaller.call(any(), any(), any()))
+        .thenReturn(
+            """
+                   {
+                     "response": {
+                                   "sum": "$12.25",
+                                   "supplier": "Camunda Inc."
+                                 }
+                   }
+               """);
+
+    var result = extractionConnectorFunction.execute(outBounderContext);
+    var expectedResponseJson =
+        """
+            {
+              "sum": "$12.25",
+              "supplier": "Camunda Inc."
+            }
+        """;
+    assertExtractionResult(result, expectedResponseJson);
+  }
+
+  @Test
+  void executeExtractionReturnsCorrectResult_whenLlmResponseContainsObjectAsValueForTaxonomyItem()
+      throws Exception {
+    var outBounderContext = prepareConnectorContext();
+
+    when(pollingTextractCaller.call(any(), any(), any(), any()))
+        .thenReturn("Test extracted text from test document.pdf");
+    when(bedrockCaller.call(any(), any(), any()))
+        .thenReturn(
+            """
+                   {
+                     "sum": "$12.25",
+                     "supplier": {
+                                   "id": 12345,
+                                   "name": "Camunda Inc.",
+                                   "city": "Berlin",
+                                   "country": "Germany"
+                                 }
+                   }
+               """);
+
+    var result = extractionConnectorFunction.execute(outBounderContext);
+    var expectedResponseJson =
+        """
+            {
+              "sum": "$12.25",
+              "supplier": {
+                            "id": 12345,
+                            "name": "Camunda Inc.",
+                            "city": "Berlin",
+                            "country": "Germany"
+                          }
+            }
+        """;
+    assertExtractionResult(result, expectedResponseJson);
+  }
+
+  @Test
+  void
+      executeExtractionReturnsCorrectResult_whenLlmResponseContainsNestedObjectAsValueForTaxonomyItem()
+          throws Exception {
+    var outBounderContext = prepareConnectorContext();
+
+    when(pollingTextractCaller.call(any(), any(), any(), any()))
+        .thenReturn("Test extracted text from test document.pdf");
+    when(bedrockCaller.call(any(), any(), any()))
+        .thenReturn(
+            """
+                   {
+                     "response": {
+                                   "sum": "$12.25",
+                                   "supplier": {
+                                                 "id": 12345,
+                                                 "name": "Camunda Inc.",
+                                                 "city": "Berlin",
+                                                 "country": "Germany"
+                                               }
+                                 }
+                   }
+               """);
+
+    var result = extractionConnectorFunction.execute(outBounderContext);
+    var expectedResponseJson =
+        """
+            {
+              "sum": "$12.25",
+              "supplier": {
+                            "id": 12345,
+                            "name": "Camunda Inc.",
+                            "city": "Berlin",
+                            "country": "Germany"
+                          }
+            }
+        """;
+    assertExtractionResult(result, expectedResponseJson);
+  }
+
+  @Test
+  void
+      executeExtractionReturnsCorrectResult_whenLlmResponseContainsNestedResponseWithValidStringifiedObject()
+          throws Exception {
+    var outBounderContext = prepareConnectorContext();
+
+    when(pollingTextractCaller.call(any(), any(), any(), any()))
+        .thenReturn("Test extracted text from test document.pdf");
+    when(bedrockCaller.call(any(), any(), any()))
+        .thenReturn(
+            """
+                   {
+                     "response": "\\n\\n{\\"sum\\":\\"$12.25\\",\\"supplier\\":\\"Camunda Inc.\\"}"
+                   }
+               """);
+
+    var result = extractionConnectorFunction.execute(outBounderContext);
+    var expectedResponseJson =
+        """
+            {
+            	"sum": "$12.25",
+            	"supplier": "Camunda Inc."
+            }
+        """;
+    assertExtractionResult(result, expectedResponseJson);
+  }
+
+  @Test
+  void
+      executeExtractionShouldThrowConnectorException_whenLlmResponseContainsInvalidStringifiedObject()
+          throws Exception {
+    var outBounderContext = prepareConnectorContext();
 
     when(pollingTextractCaller.call(any(), any(), any(), any()))
         .thenReturn("Test extracted text from test document.pdf");
@@ -40,13 +224,88 @@ class ExtractionConnectorFunctionTest {
         .thenReturn(
             """
                         {
-                        	"name": "John Smith",
-                        	"age": 32
+                        """);
+
+    assertThatThrownBy(() -> extractionConnectorFunction.execute(outBounderContext))
+        .isInstanceOf(ConnectorException.class)
+        .hasMessageContaining("Failed to parse the JSON response");
+  }
+
+  @Test
+  void executeExtractionShouldThrowConnectorException_whenLlmResponseIsNotJsonObject()
+      throws Exception {
+    var outBounderContext = prepareConnectorContext();
+
+    when(pollingTextractCaller.call(any(), any(), any(), any()))
+        .thenReturn("Test extracted text from test document.pdf");
+    when(bedrockCaller.call(any(), any(), any()))
+        .thenReturn(
+            """
+                        []
+                        """);
+
+    assertThatThrownBy(() -> extractionConnectorFunction.execute(outBounderContext))
+        .isInstanceOf(ConnectorException.class)
+        .hasMessageContaining("LLM response is not a JSON object");
+  }
+
+  @Test
+  void
+      executeExtractionShouldThrowConnectorException_whenLlmResponseContainsNestedResponseWithInvalidStringifiedObject()
+          throws Exception {
+    var outBounderContext = prepareConnectorContext();
+
+    when(pollingTextractCaller.call(any(), any(), any(), any()))
+        .thenReturn("Test extracted text from test document.pdf");
+    when(bedrockCaller.call(any(), any(), any()))
+        .thenReturn(
+            """
+                        {
+                          "response": "{"
                         }
                         """);
 
-    var result = extractionConnectorFunction.execute(outBounderContext);
-    assertThat(result).isInstanceOf(ExtractionResult.class);
+    assertThatThrownBy(() -> extractionConnectorFunction.execute(outBounderContext))
+        .isInstanceOf(ConnectorException.class)
+        .hasMessageContaining("Failed to parse the JSON response");
+  }
+
+  @Test
+  void
+      executeExtractionShouldThrowConnectorException_whenLlmResponseContainsNestedResponseWithJsonArray()
+          throws Exception {
+    var outBounderContext = prepareConnectorContext();
+
+    when(pollingTextractCaller.call(any(), any(), any(), any()))
+        .thenReturn("Test extracted text from test document.pdf");
+    when(bedrockCaller.call(any(), any(), any()))
+        .thenReturn(
+            """
+                        {
+                          "response": []
+                        }
+                        """);
+
+    assertThatThrownBy(() -> extractionConnectorFunction.execute(outBounderContext))
+        .isInstanceOf(ConnectorException.class)
+        .hasMessageContaining("LLM response is neither a JSON object nor a string");
+  }
+
+  private void assertExtractionResult(Object result, String expectedResponse)
+      throws JsonProcessingException {
+    var expected =
+        OBJECT_MAPPER.convertValue(
+            OBJECT_MAPPER.readTree(expectedResponse),
+            new TypeReference<Map<String, JsonNode>>() {});
+
+    assertThat(result)
+        .isNotNull()
+        .isInstanceOf(ExtractionResult.class)
+        .asInstanceOf(InstanceOfAssertFactories.type(ExtractionResult.class))
+        .satisfies(
+            extractionResult ->
+                assertThat(extractionResult.extractedFields())
+                    .containsExactlyInAnyOrderEntriesOf(expected));
   }
 
   private OutboundConnectorContextBuilder.TestConnectorContext prepareConnectorContext() {


### PR DESCRIPTION
This PR is a cherry-pick to backport this pr https://github.com/camunda/connectors/pull/4356

## Description

<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

Doesn't close any issue. It is just a back port.

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.

