### PR TITLE
chore(ci): nightly e2e test slack notifications

### DIFF
--- a/.github/workflows/NIGHTLY_E2E.yml
+++ b/.github/workflows/NIGHTLY_E2E.yml
@@ -24,7 +24,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   run-tests:
-    name: Nightly E2E test (${{ matrix.branch }})
+    name: [${{ matrix.branch }}] Nightly E2E test run
     needs: get-branches
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/NIGHTLY_E2E.yml
+++ b/.github/workflows/NIGHTLY_E2E.yml
@@ -1,4 +1,4 @@
-name: nightly_e2e_tests
+name: Nightly E2E test run
 
 on:
   workflow_dispatch:
@@ -61,3 +61,15 @@ jobs:
 
       - name: Build Connectors
         run: mvn --batch-mode clean test -PcheckFormat
+
+      - name: Send Slack notification on failure
+        if: failure()
+        uses: slackapi/slack-github-action@v2.0.0
+        with:
+          payload: |
+            {
+              "channel": ${{ secrets.CONNECTORS_SUPPORT_SLACK_CHANNEL_ID }},
+              "text": "🚨 Nightly E2E test run failed on branch `${{ github.ref_name }}`.\nCheck details: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            }
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.CONNECTORS_SLACK_BOT_TOKEN }}

--- a/.github/workflows/NIGHTLY_E2E.yml
+++ b/.github/workflows/NIGHTLY_E2E.yml
@@ -26,6 +26,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   run-tests:
+    name: Nightly E2E test ${{ matrix.branch }}
     needs: get-branches
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/NIGHTLY_E2E.yml
+++ b/.github/workflows/NIGHTLY_E2E.yml
@@ -28,6 +28,7 @@ jobs:
     needs: get-branches
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         branch: ${{ fromJson(needs.get-branches.outputs.branches) }}
     steps:

--- a/.github/workflows/NIGHTLY_E2E.yml
+++ b/.github/workflows/NIGHTLY_E2E.yml
@@ -94,5 +94,5 @@ jobs:
           payload: |
             {
               "channel": ${{ secrets.CONNECTORS_SUPPORT_SLACK_CHANNEL_ID }},
-              "text": ":alarm: Nightly E2E test run failed on branch `${{ github.ref_name }}`.\nCheck details: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+              "text": ":alarm: Nightly E2E test run failed on branch `${{ matrix.branch}}`.\nCheck details: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
             }

--- a/.github/workflows/NIGHTLY_E2E.yml
+++ b/.github/workflows/NIGHTLY_E2E.yml
@@ -66,10 +66,9 @@ jobs:
         if: failure()
         uses: slackapi/slack-github-action@v2.0.0
         with:
+          token: ${{ secrets.CONNECTORS_SLACK_BOT_TOKEN }}
           payload: |
             {
               "channel": ${{ secrets.CONNECTORS_SUPPORT_SLACK_CHANNEL_ID }},
               "text": "🚨 Nightly E2E test run failed on branch `${{ github.ref_name }}`.\nCheck details: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
             }
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.CONNECTORS_SLACK_BOT_TOKEN }}

--- a/.github/workflows/NIGHTLY_E2E.yml
+++ b/.github/workflows/NIGHTLY_E2E.yml
@@ -16,17 +16,15 @@ jobs:
         id: set-matrix
         run: |
           # Get all release/* branches
-          release_branches=$(gh api repos/${{ github.repository }}/branches --paginate -q '[].[.name]' | grep '^release/' || true)
-          
-          # Add 'main' manually and convert to JSON array
-          all_branches=$( (echo "main"; echo "$release_branches") | jq -R -s -c 'split("\n")[:-1]')
-          
+          git ls-remote --heads https://github.com/${{ github.repository }}.git | \
+          awk '{print $2}' | sed 's|refs/heads/||' | grep '^release/' > releases.txt || true
+          all_branches=$( (echo "main"; cat releases.txt) | grep -v '^$' | jq -R -s -c 'split("\n")[:-1]' )
           echo "branches=$all_branches" >> $GITHUB_OUTPUT
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   run-tests:
-    name: Nightly E2E test ${{ matrix.branch }}
+    name: Nightly E2E test (${{ matrix.branch }})
     needs: get-branches
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/NIGHTLY_E2E.yml
+++ b/.github/workflows/NIGHTLY_E2E.yml
@@ -67,6 +67,7 @@ jobs:
         uses: slackapi/slack-github-action@v2.0.0
         with:
           token: ${{ secrets.CONNECTORS_SLACK_BOT_TOKEN }}
+          method: chat.postMessage
           payload: |
             {
               "channel": ${{ secrets.CONNECTORS_SUPPORT_SLACK_CHANNEL_ID }},

--- a/.github/workflows/NIGHTLY_E2E.yml
+++ b/.github/workflows/NIGHTLY_E2E.yml
@@ -6,11 +6,35 @@ on:
     - cron: "0 3 * * *"  # Runs daily at 03:00 UTC
 
 jobs:
-  run-tests:
 
+  get-branches:
     runs-on: ubuntu-latest
+    outputs:
+      branches: ${{ steps.set-matrix.outputs.branches }}
+    steps:
+      - name: Fetch release branches
+        id: set-matrix
+        run: |
+          # Get all release/* branches
+          release_branches=$(gh api repos/${{ github.repository }}/branches --paginate -q '[].[.name]' | grep '^release/' || true)
+          
+          # Add 'main' manually and convert to JSON array
+          all_branches=$( (echo "main"; echo "$release_branches") | jq -R -s -c 'split("\n")[:-1]')
+          
+          echo "branches=$all_branches" >> $GITHUB_OUTPUT
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  run-tests:
+    needs: get-branches
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        branch: ${{ fromJson(needs.get-branches.outputs.branches) }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ matrix.branch }}
 
       - name: Import Secrets
         id: secrets

--- a/.github/workflows/NIGHTLY_E2E.yml
+++ b/.github/workflows/NIGHTLY_E2E.yml
@@ -71,5 +71,5 @@ jobs:
           payload: |
             {
               "channel": ${{ secrets.CONNECTORS_SUPPORT_SLACK_CHANNEL_ID }},
-              "text": "🚨 Nightly E2E test run failed on branch `${{ github.ref_name }}`.\nCheck details: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+              "text": ":alarm: Nightly E2E test run failed on branch `${{ github.ref_name }}`.\nCheck details: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
             }

--- a/.github/workflows/NIGHTLY_E2E.yml
+++ b/.github/workflows/NIGHTLY_E2E.yml
@@ -24,7 +24,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   run-tests:
-    name: [${{ matrix.branch }}] Nightly E2E test run
+    name: (${{ matrix.branch }}) Nightly E2E test run
     needs: get-branches
     runs-on: ubuntu-latest
     strategy:

--- a/connector-sdk/core/src/test/java/io/camunda/connector/api/json/ConnectorsObjectMapperSupplierTest.java
+++ b/connector-sdk/core/src/test/java/io/camunda/connector/api/json/ConnectorsObjectMapperSupplierTest.java
@@ -35,12 +35,7 @@ class ConnectorsObjectMapperSupplierTest {
 
   @Test
   void java8DatesShouldBeSupported() throws JsonProcessingException {
-    final var objectMapper = ConnectorsObjectMapperSupplier.getCopy();
-    final var json = "{\"data\":\"2024-01-01\"}";
-    final var jsonDeserialized = Map.of("data", LocalDate.of(2024, 1, 1));
-    Assertions.assertThat(objectMapper.writeValueAsString(jsonDeserialized)).isEqualTo(json);
-    var actual = objectMapper.readValue(json, new TypeReference<Map<String, LocalDate>>() {});
-    Assertions.assertThat(actual).isEqualTo(jsonDeserialized);
+    throw new RuntimeException("Not implemented");
   }
 
   @Test

--- a/connector-sdk/core/src/test/java/io/camunda/connector/api/json/ConnectorsObjectMapperSupplierTest.java
+++ b/connector-sdk/core/src/test/java/io/camunda/connector/api/json/ConnectorsObjectMapperSupplierTest.java
@@ -35,7 +35,12 @@ class ConnectorsObjectMapperSupplierTest {
 
   @Test
   void java8DatesShouldBeSupported() throws JsonProcessingException {
-    throw new RuntimeException("Not implemented");
+    final var objectMapper = ConnectorsObjectMapperSupplier.getCopy();
+    final var json = "{\"data\":\"2024-01-01\"}";
+    final var jsonDeserialized = Map.of("data", LocalDate.of(2024, 1, 1));
+    Assertions.assertThat(objectMapper.writeValueAsString(jsonDeserialized)).isEqualTo(json);
+    var actual = objectMapper.readValue(json, new TypeReference<Map<String, LocalDate>>() {});
+    Assertions.assertThat(actual).isEqualTo(jsonDeserialized);
   }
 
   @Test

--- a/connector-sdk/test/src/main/java/io/camunda/connector/test/SlowTestCondition.java
+++ b/connector-sdk/test/src/main/java/io/camunda/connector/test/SlowTestCondition.java
@@ -16,13 +16,23 @@
  */
 package io.camunda.connector.test;
 
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
-import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.ConditionEvaluationResult;
+import org.junit.jupiter.api.extension.ExecutionCondition;
+import org.junit.jupiter.api.extension.ExtensionContext;
 
-@Target(ElementType.TYPE)
-@Retention(RetentionPolicy.RUNTIME)
-@ExtendWith(SlowTestCondition.class)
-public @interface SlowTest {}
+public class SlowTestCondition implements ExecutionCondition {
+
+  private static final ConditionEvaluationResult ENABLED =
+      ConditionEvaluationResult.enabled("Running slow test");
+  private static final ConditionEvaluationResult DISABLED =
+      ConditionEvaluationResult.disabled("Disabled because 'quickly' system property is present");
+
+  @Override
+  public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext context) {
+    String quickly = System.getProperty("quickly");
+    if (quickly != null) {
+      return DISABLED;
+    }
+    return ENABLED;
+  }
+}


### PR DESCRIPTION
## Description

This PR fixes the `SlowTest` condition - previously it never worked to run the tests if the flag is not present.

Additionally, I configured Slack notifications for test runs, and introduced a matrix to run e2e tests across all release branches too, not only main.

## Checklist

- [ ] PR has a **milestone** or the `no milestone` label.

