### PR TITLE
fix(renovate.json): Fix SNAPSHOT filter

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,6 @@
 {
-  "extends": [
-    "config:base"
-  ],
+  "extends": ["config:recommended"],
+  "configMigration": true,
   "labels": [
     "dependencies",
     "no milestone"

--- a/renovate.json
+++ b/renovate.json
@@ -27,7 +27,7 @@
     },
     {
       "matchBaseBranches": [
-        "/^release/.*/"
+        "^release/.*"
       ],
       "matchUpdateTypes": [
         "major"
@@ -48,7 +48,7 @@
       "matchPackagePatterns": [
         ".*"
       ],
-      "allowedVersions": "!/-SNAPSHOT$/"
+      "allowedVersions": "^(?!.*-SNAPSHOT$).*$"
     }
   ],
   "baseBranches": [


### PR DESCRIPTION
## Description

Fix the renovate.json file regex that filters out suggesting to update to SNAPSHOT dependencies.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #4311

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.

