### PR TITLE
feat(ms-teams): Add document handling for sending message to channel

### DIFF
--- a/connectors/microsoft-teams/element-templates/hybrid/microsoft-teams-outbound-connector-hybrid.json
+++ b/connectors/microsoft-teams/element-templates/hybrid/microsoft-teams-outbound-connector-hybrid.json
@@ -7,7 +7,7 @@
     "keywords" : [ ]
   },
   "documentationRef" : "https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/microsoft-teams/",
-  "version" : 3,
+  "version" : 4,
   "category" : {
     "id" : "connectors",
     "name" : "Connectors"
@@ -1111,6 +1111,28 @@
       "name" : "HTML",
       "value" : "HTML"
     } ]
+  }, {
+    "id" : "data.sendMessageToChannel.documents",
+    "label" : "documents",
+    "optional" : true,
+    "feel" : "required",
+    "group" : "data",
+    "binding" : {
+      "name" : "data.documents",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "allMatch" : [ {
+        "property" : "data.channelMethod",
+        "equals" : "sendMessageToChannel",
+        "type" : "simple"
+      }, {
+        "property" : "data.type",
+        "equals" : "channel",
+        "type" : "simple"
+      } ]
+    },
+    "type" : "String"
   }, {
     "id" : "data.getChannelMessage.groupId",
     "label" : "Group ID",

--- a/connectors/microsoft-teams/element-templates/microsoft-teams-outbound-connector.json
+++ b/connectors/microsoft-teams/element-templates/microsoft-teams-outbound-connector.json
@@ -7,7 +7,7 @@
     "keywords" : [ ]
   },
   "documentationRef" : "https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/microsoft-teams/",
-  "version" : 3,
+  "version" : 4,
   "category" : {
     "id" : "connectors",
     "name" : "Connectors"
@@ -1106,6 +1106,28 @@
       "name" : "HTML",
       "value" : "HTML"
     } ]
+  }, {
+    "id" : "data.sendMessageToChannel.documents",
+    "label" : "documents",
+    "optional" : true,
+    "feel" : "required",
+    "group" : "data",
+    "binding" : {
+      "name" : "data.documents",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "allMatch" : [ {
+        "property" : "data.channelMethod",
+        "equals" : "sendMessageToChannel",
+        "type" : "simple"
+      }, {
+        "property" : "data.type",
+        "equals" : "channel",
+        "type" : "simple"
+      } ]
+    },
+    "type" : "String"
   }, {
     "id" : "data.getChannelMessage.groupId",
     "label" : "Group ID",

--- a/connectors/microsoft-teams/src/main/java/io/camunda/connector/MSTeamsFunction.java
+++ b/connectors/microsoft-teams/src/main/java/io/camunda/connector/MSTeamsFunction.java
@@ -24,7 +24,7 @@ import io.camunda.connector.suppliers.GraphServiceClientSupplier;
     name = "Microsoft Teams Outbound Connector",
     description = "Create, update, and send a message to your Microsoft Teams",
     inputDataClass = MSTeamsRequest.class,
-    version = 3,
+    version = 4,
     propertyGroups = {
       @ElementTemplate.PropertyGroup(id = "authentication", label = "Authentication"),
       @ElementTemplate.PropertyGroup(id = "operation", label = "Operation"),

--- a/connectors/microsoft-teams/src/main/java/io/camunda/connector/model/request/data/SendMessageToChannel.java
+++ b/connectors/microsoft-teams/src/main/java/io/camunda/connector/model/request/data/SendMessageToChannel.java
@@ -6,10 +6,13 @@
  */
 package io.camunda.connector.model.request.data;
 
+import io.camunda.connector.generator.dsl.Property;
 import io.camunda.connector.generator.java.annotation.TemplateProperty;
 import io.camunda.connector.generator.java.annotation.TemplateSubType;
 import io.camunda.connector.model.MSTeamsMethodTypes;
+import io.camunda.document.Document;
 import jakarta.validation.constraints.NotBlank;
+import java.util.List;
 
 @TemplateSubType(label = "Send message to channel", id = MSTeamsMethodTypes.SEND_MESSAGE_TO_CHANNEL)
 public record SendMessageToChannel(
@@ -47,5 +50,12 @@ public record SendMessageToChannel(
             },
             constraints = @TemplateProperty.PropertyConstraints(notEmpty = true),
             description = "The type of the content. Possible values are text and html")
-        String bodyType)
+        String bodyType,
+    @TemplateProperty(
+            label = "documents",
+            group = "data",
+            id = "sendMessageToChannel.documents",
+            feel = Property.FeelMode.required,
+            optional = true)
+        List<Document> documents)
     implements ChannelData {}

--- a/connectors/microsoft-teams/src/main/java/io/camunda/connector/operation/channel/DocumentHandler.java
+++ b/connectors/microsoft-teams/src/main/java/io/camunda/connector/operation/channel/DocumentHandler.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.operation.channel;
+
+import com.microsoft.graph.core.models.UploadResult;
+import com.microsoft.graph.core.tasks.LargeFileUploadTask;
+import com.microsoft.graph.drives.item.items.item.createuploadsession.CreateUploadSessionPostRequestBody;
+import com.microsoft.graph.models.ChatMessage;
+import com.microsoft.graph.models.ChatMessageAttachment;
+import com.microsoft.graph.models.DriveItem;
+import com.microsoft.graph.models.DriveItemUploadableProperties;
+import com.microsoft.graph.models.ItemReference;
+import com.microsoft.graph.models.UploadSession;
+import com.microsoft.graph.serviceclient.GraphServiceClient;
+import io.camunda.connector.api.error.ConnectorException;
+import io.camunda.connector.api.error.ConnectorInputException;
+import io.camunda.connector.model.request.data.SendMessageToChannel;
+import io.camunda.document.Document;
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.CancellationException;
+
+public class DocumentHandler {
+
+  SendMessageToChannel model;
+
+  public DocumentHandler(SendMessageToChannel model) {
+    this.model = model;
+  }
+
+  public void handleDocuments(GraphServiceClient graphClient, ChatMessage chatMessage) {
+    List<String> fileUrls =
+        model.documents().stream()
+            .filter(Objects::nonNull)
+            .map(
+                document -> {
+                  try {
+                    return uploadDocument(
+                        graphClient, model.groupId(), document, document.metadata().getFileName());
+                  } catch (IOException
+                      | InvocationTargetException
+                      | IllegalAccessException
+                      | NoSuchMethodException e) {
+                    throw new ConnectorException("Error uploading document: " + e.getMessage(), e);
+                  }
+                })
+            .filter(Objects::nonNull)
+            .toList();
+
+    List<ChatMessageAttachment> attachments = new ArrayList<>();
+    fileUrls.forEach(
+        fileUrl -> {
+          ChatMessageAttachment attachment = new ChatMessageAttachment();
+          attachment.setContentUrl(fileUrl);
+          attachment.setContentType("reference");
+          attachments.add(attachment);
+        });
+    chatMessage.setAttachments(attachments);
+  }
+
+  private String uploadDocument(
+      GraphServiceClient graphClient, String teamID, Document document, String filename)
+      throws IOException, InvocationTargetException, IllegalAccessException, NoSuchMethodException {
+
+    DriveItem driveItem = getDriveItem(graphClient, teamID);
+    String driveItemId = getDriveItemId(driveItem, filename);
+    String driveId = getMyDriveId(driveItem);
+
+    CreateUploadSessionPostRequestBody uploadSessionRequest =
+        new CreateUploadSessionPostRequestBody();
+    DriveItemUploadableProperties properties = new DriveItemUploadableProperties();
+    properties.getAdditionalData().put("@microsoft.graph.conflictBehavior", "rename");
+    uploadSessionRequest.setItem(properties);
+
+    UploadSession uploadSession =
+        Optional.ofNullable(
+                graphClient
+                    .drives()
+                    .byDriveId(driveId)
+                    .items()
+                    .byDriveItemId(driveItemId)
+                    .createUploadSession()
+                    .post(uploadSessionRequest))
+            .orElseThrow(
+                () -> new IllegalStateException("Upload session is null, cannot proceed."));
+
+    LargeFileUploadTask<DriveItem> largeFileUploadTask =
+        new LargeFileUploadTask<>(
+            graphClient.getRequestAdapter(),
+            uploadSession,
+            document.asInputStream(),
+            document.metadata().getSize(),
+            DriveItem::createFromDiscriminatorValue);
+
+    try {
+      UploadResult<DriveItem> uploadResult =
+          largeFileUploadTask.upload(); // This will retry 3 times
+      if (uploadResult.isUploadSuccessful() && uploadResult.itemResponse != null) {
+        return uploadResult.itemResponse.getWebUrl();
+      } else {
+        throw new ConnectorInputException(
+            "Failed to upload document " + document.metadata().getFileName() + " with retries",
+            new RuntimeException());
+      }
+    } catch (CancellationException | InterruptedException e) {
+      throw new ConnectorException("Error uploading document: " + e.getMessage(), e);
+    }
+  }
+
+  private DriveItem getDriveItem(GraphServiceClient graphClient, String teamID) {
+    return Optional.ofNullable(
+            graphClient
+                .teams()
+                .byTeamId(teamID)
+                .channels()
+                .byChannelId(model.channelId())
+                .filesFolder()
+                .get())
+        .orElseThrow(() -> new IllegalStateException("Drive ID is null, cannot proceed."));
+  }
+
+  private String getMyDriveId(DriveItem channelFolder) {
+    return Optional.ofNullable(channelFolder.getParentReference())
+        .map(ItemReference::getDriveId)
+        .orElseThrow(() -> new IllegalStateException("Drive ID is null, cannot proceed."));
+  }
+
+  private String getDriveItemId(DriveItem driveItem, String filename) {
+    String channelName =
+        Optional.ofNullable(driveItem.getName())
+            .orElseThrow(() -> new IllegalStateException("Channel name is null, cannot proceed."));
+    return "root:/" + channelName + "/" + filename + ":";
+  }
+}

--- a/connectors/microsoft-teams/src/main/java/io/camunda/connector/operation/channel/SendMessageToChannelOperation.java
+++ b/connectors/microsoft-teams/src/main/java/io/camunda/connector/operation/channel/SendMessageToChannelOperation.java
@@ -8,9 +8,11 @@ package io.camunda.connector.operation.channel;
 
 import com.microsoft.graph.models.BodyType;
 import com.microsoft.graph.models.ChatMessage;
+import com.microsoft.graph.models.ChatMessageAttachment;
 import com.microsoft.graph.models.ItemBody;
 import com.microsoft.graph.serviceclient.GraphServiceClient;
 import io.camunda.connector.model.request.data.SendMessageToChannel;
+import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
 
@@ -26,8 +28,9 @@ public record SendMessageToChannelOperation(SendMessageToChannel model)
             .orElse(BodyType.Text));
     body.setContent(model.content());
     if (model.documents() != null) {
-      DocumentHandler documentHandler = new DocumentHandler(model);
-      documentHandler.handleDocuments(graphClient, chatMessage);
+      DocumentHandler documentHandler = new DocumentHandler(graphClient, model);
+      List<ChatMessageAttachment> attachments = documentHandler.handleDocuments();
+      chatMessage.setAttachments(attachments);
     }
     chatMessage.setBody(body);
     return graphClient

--- a/connectors/microsoft-teams/src/main/java/io/camunda/connector/operation/channel/SendMessageToChannelOperation.java
+++ b/connectors/microsoft-teams/src/main/java/io/camunda/connector/operation/channel/SendMessageToChannelOperation.java
@@ -25,6 +25,10 @@ public record SendMessageToChannelOperation(SendMessageToChannel model)
             .map(type -> BodyType.forValue(type.toLowerCase(Locale.ROOT)))
             .orElse(BodyType.Text));
     body.setContent(model.content());
+    if (model.documents() != null) {
+      DocumentHandler documentHandler = new DocumentHandler(model);
+      documentHandler.handleDocuments(graphClient, chatMessage);
+    }
     chatMessage.setBody(body);
     return graphClient
         .teams()

--- a/connectors/microsoft-teams/src/test/java/io/camunda/connector/model/request/channel/SendMessageToChannelTest.java
+++ b/connectors/microsoft-teams/src/test/java/io/camunda/connector/model/request/channel/SendMessageToChannelTest.java
@@ -52,7 +52,11 @@ class SendMessageToChannelTest extends BaseTest {
 
     sendMessageToChannel =
         new SendMessageToChannel(
-            ActualValue.Channel.GROUP_ID, ActualValue.Channel.CHANNEL_ID, "channel content", null);
+            ActualValue.Channel.GROUP_ID,
+            ActualValue.Channel.CHANNEL_ID,
+            "channel content",
+            null,
+            null);
 
     when(graphServiceClient.teams()).thenReturn(teamsRequestBuilder);
     when(teamsRequestBuilder.byTeamId(ActualValue.Channel.GROUP_ID))
@@ -88,7 +92,11 @@ class SendMessageToChannelTest extends BaseTest {
     // Given
     sendMessageToChannel =
         new SendMessageToChannel(
-            ActualValue.Channel.GROUP_ID, ActualValue.Channel.CHANNEL_ID, "channel content", input);
+            ActualValue.Channel.GROUP_ID,
+            ActualValue.Channel.CHANNEL_ID,
+            "channel content",
+            input,
+            null);
     // When
     operationFactory.getService(sendMessageToChannel).invoke(graphServiceClient);
     // Then


### PR DESCRIPTION
## Description
Added document support when sending messages to channels

See example bpmn [here](https://modeler.ultrawombat.com/diagrams/fae5f90c-edc9-4c9e-81af-d3120555f1b8--teams?v=579,282,1)
Get your token [here](https://developer.microsoft.com/en-us/graph/graph-explorer) under "Access Token" tab

Documented here: https://github.com/camunda/camunda-docs/pull/5333

## Related issues

<!-- Which issues are closed by this PR or are related -->

partially solves https://github.com/camunda/team-connectors/issues/1002


In a next PR the option to send documents in private messages is added, this is currently not possible, because of access restrictions in our MS Teams setup. We are hoping to get access to a Sandbox environment where we can test this. When sending documents in messages, the documents are uploaded to the SharePoint. When sending documents to a channel, they are uploaded to the teams sharepoint. When sending documents to a private chat, they are uploaded to the private sharepoint. I currently assume, that bots / apps do not have own sharepoints and therefore need to write the documents they want to send, to the receivers SharePoint. As I cannot test this with the current MS teams options / permissions, this is postponed. 

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.

