### PR TITLE
fix(rest): fix document upload in SaaS, using multipart requests

### DIFF
--- a/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/client/apache/builder/parts/ApacheRequestBodyBuilder.java
+++ b/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/client/apache/builder/parts/ApacheRequestBodyBuilder.java
@@ -22,31 +22,31 @@ import static org.apache.hc.core5.http.HttpHeaders.CONTENT_TYPE;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.camunda.client.api.response.DocumentMetadata;
 import io.camunda.connector.api.error.ConnectorException;
 import io.camunda.connector.api.json.ConnectorsObjectMapperSupplier;
 import io.camunda.connector.http.base.model.HttpCommonRequest;
 import io.camunda.connector.http.base.utils.DocumentHelper;
 import io.camunda.document.Document;
-import java.io.BufferedInputStream;
 import java.nio.charset.StandardCharsets;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
-import org.apache.hc.client5.http.entity.mime.HttpMultipartMode;
-import org.apache.hc.client5.http.entity.mime.MultipartEntityBuilder;
 import org.apache.hc.core5.http.ContentType;
 import org.apache.hc.core5.http.HttpEntity;
 import org.apache.hc.core5.http.io.entity.HttpEntities;
 import org.apache.hc.core5.http.io.entity.StringEntity;
 import org.apache.hc.core5.http.io.support.ClassicRequestBuilder;
 import org.apache.hc.core5.http.message.BasicNameValuePair;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Maps the request body of a {@link HttpCommonRequest} to an Apache {@link ClassicRequestBuilder}.
  */
 public class ApacheRequestBodyBuilder implements ApacheRequestPartBuilder {
+
+  private static final Logger LOG = LoggerFactory.getLogger(ApacheRequestBodyBuilder.class);
+
   public static final String EMPTY_BODY = "";
   public static final ObjectMapper mapperIgnoreNull =
       ConnectorsObjectMapperSupplier.getCopy()
@@ -83,7 +83,7 @@ public class ApacheRequestBodyBuilder implements ApacheRequestPartBuilder {
       ContentType contentType, Map<?, ?> body, HttpCommonRequest request) {
     HttpEntity entity;
     if (contentType.getMimeType().equalsIgnoreCase(MULTIPART_FORM_DATA.getMimeType())) {
-      entity = createMultiPartEntity(body, contentType);
+      entity = new DocumentAwareMultipartEntityBuilder(body, contentType).build();
     } else if (contentType
         .getMimeType()
         .equalsIgnoreCase(ContentType.APPLICATION_FORM_URLENCODED.getMimeType())) {
@@ -128,51 +128,5 @@ public class ApacheRequestBodyBuilder implements ApacheRequestPartBuilder {
                         Optional.ofNullable(e.getValue()).map(String::valueOf).orElse(null)))
             .collect(Collectors.toList()),
         StandardCharsets.UTF_8);
-  }
-
-  private HttpEntity createMultiPartEntity(Map<?, ?> body, ContentType contentType) {
-    final MultipartEntityBuilder builder = MultipartEntityBuilder.create();
-    builder.setMode(HttpMultipartMode.LEGACY);
-    Optional.ofNullable(contentType.getParameter("boundary")).ifPresent(builder::setBoundary);
-    for (Map.Entry<?, ?> entry : body.entrySet()) {
-      switch (entry.getValue()) {
-        case Document document -> streamDocumentContent(entry, document, builder);
-        case List<?> list -> tryStreamDocumentListContent(entry, list, builder);
-        case null -> {}
-        default ->
-            builder.addTextBody(
-                String.valueOf(entry.getKey()),
-                String.valueOf(entry.getValue()),
-                MULTIPART_FORM_DATA);
-      }
-    }
-    return builder.build();
-  }
-
-  private void tryStreamDocumentListContent(
-      Map.Entry<?, ?> entry, List<?> list, MultipartEntityBuilder builder) {
-    for (Object item : list) {
-      if (item instanceof Document document) {
-        streamDocumentContent(entry, document, builder);
-      } else {
-        builder.addTextBody(String.valueOf(entry.getKey()), String.valueOf(item));
-      }
-    }
-  }
-
-  private void streamDocumentContent(
-      Map.Entry<?, ?> entry, Document document, MultipartEntityBuilder builder) {
-    DocumentMetadata metadata = document.metadata();
-    ContentType contentType;
-    try {
-      contentType = ContentType.create(metadata.getContentType());
-    } catch (IllegalArgumentException e) {
-      contentType = ContentType.DEFAULT_BINARY;
-    }
-    builder.addBinaryBody(
-        String.valueOf(entry.getKey()),
-        new BufferedInputStream(document.asInputStream()),
-        contentType,
-        metadata.getFileName());
   }
 }

--- a/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/client/apache/builder/parts/DocumentAwareMultipartEntityBuilder.java
+++ b/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/client/apache/builder/parts/DocumentAwareMultipartEntityBuilder.java
@@ -20,7 +20,6 @@ import io.camunda.client.api.response.DocumentMetadata;
 import io.camunda.connector.api.json.ConnectorsObjectMapperSupplier;
 import io.camunda.connector.http.base.cloudfunction.CloudFunctionFilePart;
 import io.camunda.document.Document;
-import java.io.BufferedInputStream;
 import java.io.ByteArrayInputStream;
 import java.util.List;
 import java.util.Map;
@@ -131,7 +130,7 @@ public class DocumentAwareMultipartEntityBuilder {
     DocumentMetadata metadata = document.metadata();
     builder.addBinaryBody(
         String.valueOf(entry.getKey()),
-        new BufferedInputStream(document.asInputStream()),
+        document.asInputStream(),
         getContentType(metadata.getContentType()),
         metadata.getFileName());
   }

--- a/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/client/apache/builder/parts/DocumentAwareMultipartEntityBuilder.java
+++ b/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/client/apache/builder/parts/DocumentAwareMultipartEntityBuilder.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.camunda.connector.http.base.client.apache.builder.parts;
 
 import io.camunda.client.api.response.DocumentMetadata;

--- a/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/client/apache/builder/parts/DocumentAwareMultipartEntityBuilder.java
+++ b/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/client/apache/builder/parts/DocumentAwareMultipartEntityBuilder.java
@@ -107,7 +107,7 @@ public class DocumentAwareMultipartEntityBuilder {
           part.name(),
           new ByteArrayInputStream(part.content()),
           getContentType(part.contentType()),
-          part.submittedFileName());
+          part.fileName());
     } catch (IllegalArgumentException e) {
       LOG.error(
           "Failed to convert the provided map {} to CloudFunctionFilePart. A request with Content-Type: multipart/form-data can only contain maps that are convertible to CloudFunctionFilePart.",

--- a/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/client/apache/builder/parts/DocumentAwareMultipartEntityBuilder.java
+++ b/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/client/apache/builder/parts/DocumentAwareMultipartEntityBuilder.java
@@ -1,0 +1,132 @@
+package io.camunda.connector.http.base.client.apache.builder.parts;
+
+import io.camunda.client.api.response.DocumentMetadata;
+import io.camunda.connector.api.json.ConnectorsObjectMapperSupplier;
+import io.camunda.connector.http.base.cloudfunction.CloudFunctionFilePart;
+import io.camunda.document.Document;
+import java.io.BufferedInputStream;
+import java.io.ByteArrayInputStream;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.apache.hc.client5.http.entity.mime.HttpMultipartMode;
+import org.apache.hc.client5.http.entity.mime.MultipartEntityBuilder;
+import org.apache.hc.core5.http.ContentType;
+import org.apache.hc.core5.http.HttpEntity;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A builder for creating a multipart entity from a map. The map represents the parts of a
+ * multipart/form-data request. The keys are the names of the parts and the values are the content
+ * of the parts.
+ *
+ * <p>See {@link DocumentAwareMultipartEntityBuilder#createMultiPartEntity(Map)} for more details.
+ */
+public class DocumentAwareMultipartEntityBuilder {
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(DocumentAwareMultipartEntityBuilder.class);
+  private final ContentType contentType;
+  private final Map<?, ?> body;
+  private final MultipartEntityBuilder builder;
+
+  public DocumentAwareMultipartEntityBuilder(Map<?, ?> body, ContentType contentType) {
+    this.body = body;
+    this.contentType = contentType;
+    this.builder = MultipartEntityBuilder.create();
+  }
+
+  public HttpEntity build() {
+    builder.setMode(HttpMultipartMode.LEGACY);
+    Optional.ofNullable(contentType.getParameter("boundary")).ifPresent(builder::setBoundary);
+
+    return createMultiPartEntity(body);
+  }
+
+  /**
+   * Creates a multipart entity from the given body. A multipart/form-data request is represented by
+   * a map where the keys are the names of the parts and the values are the content of the parts.
+   * The content (map values) can be:
+   *
+   * <ul>
+   *   <li>Maps that are convertible to {@link CloudFunctionFilePart}. If the map is not
+   *       convertible, an error is logged and the map is ignored.
+   *   <li>Documents
+   *   <li>Lists that contain Documents or Maps that are convertible to {@link
+   *       CloudFunctionFilePart}. If the map is not convertible, an error is logged and the list is
+   *       ignored.
+   *   <li>Null values are ignored
+   *   <li>Any other value is converted to a text body
+   * </ul>
+   *
+   * @param body the multipart body
+   * @return the multipart entity
+   */
+  private HttpEntity createMultiPartEntity(Map<?, ?> body) {
+    for (Map.Entry<?, ?> entry : body.entrySet()) {
+      switch (entry.getValue()) {
+        case Map map -> handleFilePartContent(map);
+        case Document document -> handleDocumentContent(entry, document);
+        case List<?> list -> handleListContent(entry, list);
+        case null -> {}
+        default ->
+            builder.addTextBody(String.valueOf(entry.getKey()), String.valueOf(entry.getValue()));
+      }
+    }
+    return builder.build();
+  }
+
+  /**
+   * Converts a map to a {@link CloudFunctionFilePart} and adds it to the multipart entity builder.
+   * Map values that are Maps are expected to be convertible to CloudFunctionFilePart in the context
+   * of a multipart/form-data request executed in SaaS.
+   *
+   * @see io.camunda.connector.http.base.cloudfunction.CloudFunctionService
+   */
+  private void handleFilePartContent(Map map) {
+    try {
+      var part =
+          ConnectorsObjectMapperSupplier.getCopy().convertValue(map, CloudFunctionFilePart.class);
+      builder.addBinaryBody(
+          part.name(),
+          new ByteArrayInputStream(part.content()),
+          getContentType(part.contentType()),
+          part.submittedFileName());
+    } catch (IllegalArgumentException e) {
+      LOG.error(
+          "Failed to convert the provided map {} to CloudFunctionFilePart. A request with Content-Type: multipart/form-data can only contain maps that are convertible to CloudFunctionFilePart.",
+          map,
+          e);
+    }
+  }
+
+  private void handleListContent(Map.Entry<?, ?> entry, List<?> list) {
+    for (Object item : list) {
+      switch (item) {
+        case Document document -> handleDocumentContent(entry, document);
+        case Map map -> handleFilePartContent(map);
+        default -> builder.addTextBody(String.valueOf(entry.getKey()), String.valueOf(item));
+      }
+    }
+  }
+
+  private void handleDocumentContent(Map.Entry<?, ?> entry, Document document) {
+    DocumentMetadata metadata = document.metadata();
+    builder.addBinaryBody(
+        String.valueOf(entry.getKey()),
+        new BufferedInputStream(document.asInputStream()),
+        getContentType(metadata.getContentType()),
+        metadata.getFileName());
+  }
+
+  private ContentType getContentType(String rawContentType) {
+    ContentType contentType;
+    try {
+      contentType = ContentType.create(rawContentType);
+    } catch (IllegalArgumentException e) {
+      contentType = ContentType.DEFAULT_BINARY;
+    }
+    return contentType;
+  }
+}

--- a/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/cloudfunction/CloudFunctionFilePart.java
+++ b/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/cloudfunction/CloudFunctionFilePart.java
@@ -1,0 +1,16 @@
+package io.camunda.connector.http.base.cloudfunction;
+
+/**
+ * Represents a part of a multipart form submission. Can contain either files or a fields. This
+ * record prevents any dependency on the Servlet API. This part is used only in the {@link
+ * io.camunda.connector.http.base.ExecutionEnvironment.SaaSCloudFunction} environment.
+ *
+ * @param name The name of the field in the multipart form corresponding to this part.
+ * @param submittedFileName If this part represents an uploaded file, gets the file name submitted
+ *     in the upload. Returns {@code null} if no file name is available or if this part is not a
+ *     file upload.
+ * @param content The content of this part.
+ * @param contentType The content type of this part.
+ */
+public record CloudFunctionFilePart(
+    String name, String submittedFileName, byte[] content, String contentType) {}

--- a/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/cloudfunction/CloudFunctionFilePart.java
+++ b/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/cloudfunction/CloudFunctionFilePart.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.camunda.connector.http.base.cloudfunction;
 
 /**

--- a/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/cloudfunction/CloudFunctionFilePart.java
+++ b/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/cloudfunction/CloudFunctionFilePart.java
@@ -22,9 +22,9 @@ package io.camunda.connector.http.base.cloudfunction;
  * io.camunda.connector.http.base.ExecutionEnvironment.SaaSCloudFunction} environment.
  *
  * @param name The name of the field in the multipart form corresponding to this part.
- * @param submittedFileName If this part represents an uploaded file, gets the file name submitted
- *     in the upload. Returns {@code null} if no file name is available or if this part is not a
- *     file upload.
+ * @param fileName If this part represents an uploaded file, gets the file name submitted in the
+ *     upload. Returns {@code null} if no file name is available or if this part is not a file
+ *     upload.
  * @param content The content of this part.
  * @param contentType The content type of this part.
  */

--- a/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/cloudfunction/CloudFunctionFilePart.java
+++ b/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/cloudfunction/CloudFunctionFilePart.java
@@ -29,4 +29,4 @@ package io.camunda.connector.http.base.cloudfunction;
  * @param contentType The content type of this part.
  */
 public record CloudFunctionFilePart(
-    String name, String submittedFileName, byte[] content, String contentType) {}
+    String name, String fileName, byte[] content, String contentType) {}

--- a/connectors/http/http-base/src/test/java/io/camunda/connector/http/base/cloudfunction/CloudFunctionServiceTest.java
+++ b/connectors/http/http-base/src/test/java/io/camunda/connector/http/base/cloudfunction/CloudFunctionServiceTest.java
@@ -54,8 +54,119 @@ public class CloudFunctionServiceTest {
   }
 
   @Test
-  public void shouldConvertToCloudFunctionRequestWithDocumentContent_whenBodyContainsDocuments()
-      throws IOException {
+  public void
+      shouldConvertToCloudFunctionRequestWithDocumentContent_whenBodyContainsDocumentsAndJsonContentType()
+          throws IOException {
+    // given
+    var document =
+        documentFactory.create(
+            DocumentCreationRequest.from("the content".getBytes(StandardCharsets.UTF_8))
+                .fileName("the filename")
+                .contentType("text/plain")
+                .build());
+    HttpCommonRequest request = new HttpCommonRequest();
+    request.setUrl("theUrl");
+    request.setMethod(HttpMethod.POST);
+    request.setHeaders(
+        Map.of("header", "value", "Content-Type", ContentType.APPLICATION_JSON.getMimeType()));
+    request.setBody(Map.of("bodyKey", "bodyValue", "myDocument", document));
+    request.setConnectionTimeoutInSeconds(50);
+    request.setReadTimeoutInSeconds(60);
+    request.setAuthentication(new BearerAuthentication("token"));
+
+    // when
+    HttpCommonRequest cloudFunctionRequest = cloudFunctionService.toCloudFunctionRequest(request);
+
+    // then
+    assertThat(cloudFunctionRequest.getUrl()).isEqualTo("proxyUrl");
+    assertThat(cloudFunctionRequest.getMethod()).isEqualTo(HttpMethod.POST);
+    assertThat(cloudFunctionRequest.getHeaders().orElse(Map.of())).hasSize(1);
+    assertThat(cloudFunctionRequest.getHeaders().orElse(Map.of()))
+        .containsEntry("Content-Type", "application/json");
+    Map<String, Object> body =
+        ConnectorsObjectMapperSupplier.getCopy()
+            .readValue((String) cloudFunctionRequest.getBody(), Map.class);
+    assertThat(body).containsEntry("url", "theUrl");
+    assertThat(body).containsEntry("method", "POST");
+    assertThat(body)
+        .containsEntry("headers", Map.of("header", "value", "Content-Type", "application/json"));
+    assertThat(body)
+        .containsEntry(
+            "body",
+            Map.of(
+                "bodyKey",
+                "bodyValue",
+                "myDocument",
+                Base64.getEncoder()
+                    .encodeToString("the content".getBytes(StandardCharsets.UTF_8))));
+    assertThat(body).containsEntry("connectionTimeoutInSeconds", 50);
+    assertThat(body).containsEntry("readTimeoutInSeconds", 60);
+    assertThat(body).containsEntry("authentication", Map.of("token", "token", "type", "bearer"));
+  }
+
+  @Test
+  public void
+      shouldConvertToCloudFunctionRequestWithDocumentContent_whenBodyContainsDocumentsAndMultipartContentType()
+          throws IOException {
+    // given
+    var document =
+        documentFactory.create(
+            DocumentCreationRequest.from("the content".getBytes(StandardCharsets.UTF_8))
+                .fileName("the filename")
+                .contentType("text/plain")
+                .build());
+    HttpCommonRequest request = new HttpCommonRequest();
+    request.setUrl("theUrl");
+    request.setMethod(HttpMethod.POST);
+    request.setHeaders(
+        Map.of("header", "value", "Content-Type", ContentType.MULTIPART_FORM_DATA.getMimeType()));
+    request.setBody(Map.of("bodyKey", "bodyValue", "myDocument", document));
+    request.setConnectionTimeoutInSeconds(50);
+    request.setReadTimeoutInSeconds(60);
+    request.setAuthentication(new BearerAuthentication("token"));
+
+    // when
+    HttpCommonRequest cloudFunctionRequest = cloudFunctionService.toCloudFunctionRequest(request);
+
+    // then
+    assertThat(cloudFunctionRequest.getUrl()).isEqualTo("proxyUrl");
+    assertThat(cloudFunctionRequest.getMethod()).isEqualTo(HttpMethod.POST);
+    assertThat(cloudFunctionRequest.getHeaders().orElse(Map.of())).hasSize(1);
+    assertThat(cloudFunctionRequest.getHeaders().orElse(Map.of()))
+        .containsEntry("Content-Type", "application/json");
+    Map<String, Object> body =
+        ConnectorsObjectMapperSupplier.getCopy()
+            .readValue((String) cloudFunctionRequest.getBody(), Map.class);
+    assertThat(body).containsEntry("url", "theUrl");
+    assertThat(body).containsEntry("method", "POST");
+    assertThat(body)
+        .containsEntry("headers", Map.of("header", "value", "Content-Type", "multipart/form-data"));
+    assertThat(body)
+        .containsEntry(
+            "body",
+            Map.of(
+                "bodyKey",
+                "bodyValue",
+                "myDocument",
+                Map.of(
+                    "name",
+                    "myDocument",
+                    "submittedFileName",
+                    "the filename",
+                    "contentType",
+                    "text/plain",
+                    "content",
+                    Base64.getEncoder()
+                        .encodeToString("the content".getBytes(StandardCharsets.UTF_8)))));
+    assertThat(body).containsEntry("connectionTimeoutInSeconds", 50);
+    assertThat(body).containsEntry("readTimeoutInSeconds", 60);
+    assertThat(body).containsEntry("authentication", Map.of("token", "token", "type", "bearer"));
+  }
+
+  @Test
+  public void
+      shouldConvertToCloudFunctionRequestWithDocumentContent_whenBodyContainsDocumentsAndFormUrlEncodedContentType()
+          throws IOException {
     // given
     var document =
         documentFactory.create(

--- a/connectors/http/http-base/src/test/java/io/camunda/connector/http/base/cloudfunction/CloudFunctionServiceTest.java
+++ b/connectors/http/http-base/src/test/java/io/camunda/connector/http/base/cloudfunction/CloudFunctionServiceTest.java
@@ -175,7 +175,11 @@ public class CloudFunctionServiceTest {
     request.setUrl("theUrl");
     request.setMethod(HttpMethod.POST);
     request.setHeaders(
-        Map.of("header", "value", "Content-Type", ContentType.MULTIPART_FORM_DATA.getMimeType()));
+        Map.of(
+            "header",
+            "value",
+            "Content-Type",
+            ContentType.APPLICATION_FORM_URLENCODED.getMimeType()));
     request.setBody(Map.of("bodyKey", "bodyValue", "myDocument", document));
     request.setConnectionTimeoutInSeconds(50);
     request.setReadTimeoutInSeconds(60);
@@ -196,7 +200,9 @@ public class CloudFunctionServiceTest {
     assertThat(body).containsEntry("url", "theUrl");
     assertThat(body).containsEntry("method", "POST");
     assertThat(body)
-        .containsEntry("headers", Map.of("header", "value", "Content-Type", "multipart/form-data"));
+        .containsEntry(
+            "headers",
+            Map.of("header", "value", "Content-Type", "application/x-www-form-urlencoded"));
     assertThat(body)
         .containsEntry(
             "body",

--- a/connectors/http/http-base/src/test/java/io/camunda/connector/http/base/cloudfunction/CloudFunctionServiceTest.java
+++ b/connectors/http/http-base/src/test/java/io/camunda/connector/http/base/cloudfunction/CloudFunctionServiceTest.java
@@ -151,7 +151,7 @@ public class CloudFunctionServiceTest {
                 Map.of(
                     "name",
                     "myDocument",
-                    "submittedFileName",
+                    "fileName",
                     "the filename",
                     "contentType",
                     "text/plain",

--- a/connectors/http/http-base/src/test/java/io/camunda/connector/http/base/utils/DocumentHelperTest.java
+++ b/connectors/http/http-base/src/test/java/io/camunda/connector/http/base/utils/DocumentHelperTest.java
@@ -89,7 +89,6 @@ public class DocumentHelperTest {
     Map<String, Object> input =
         Map.of("body", Map.of("content", Arrays.asList(document, document, document)));
 
-    var spiedDocument = spy(document);
     // when
     Object res = documentHelper.parseDocumentsInBody(input, Document::asByteArray);
 

--- a/connectors/http/http-base/src/test/java/io/camunda/connector/http/base/utils/DocumentHelperTest.java
+++ b/connectors/http/http-base/src/test/java/io/camunda/connector/http/base/utils/DocumentHelperTest.java
@@ -17,14 +17,12 @@
 package io.camunda.connector.http.base.utils;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
-import io.camunda.client.api.response.DocumentMetadata;
+import io.camunda.connector.http.base.TestDocumentFactory;
 import io.camunda.document.CamundaDocument;
-import io.camunda.document.reference.CamundaDocumentReferenceImpl;
+import io.camunda.document.Document;
+import io.camunda.document.store.DocumentCreationRequest;
 import io.camunda.document.store.InMemoryDocumentStore;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
@@ -36,6 +34,8 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 public class DocumentHelperTest {
+
+  private final TestDocumentFactory factory = new TestDocumentFactory();
 
   @AfterEach
   public void tearDown() {
@@ -79,23 +79,22 @@ public class DocumentHelperTest {
   public void shouldParseDocuments_InBody_whenMapInput() {
     // given
     DocumentHelper documentHelper = new DocumentHelper();
-    var metadata = mock(DocumentMetadata.class);
-    CamundaDocument document =
-        new CamundaDocument(
-            metadata,
-            new CamundaDocumentReferenceImpl("store", "id1", "hash", metadata),
-            InMemoryDocumentStore.INSTANCE);
+    var document =
+        factory.create(
+            DocumentCreationRequest.from("transformed".getBytes(StandardCharsets.UTF_8))
+                .documentId("theId")
+                .fileName("theFileName")
+                .contentType("text/plain")
+                .build());
     Map<String, Object> input =
         Map.of("body", Map.of("content", Arrays.asList(document, document, document)));
-    Function<CamundaDocument, Object> transformer = mock(Function.class);
-    when(transformer.apply(document)).thenReturn("transformed".getBytes(StandardCharsets.UTF_8));
 
+    var spiedDocument = spy(document);
     // when
-    Object res = documentHelper.parseDocumentsInBody(input, transformer);
+    Object res = documentHelper.parseDocumentsInBody(input, Document::asByteArray);
 
     // then
     assertThat(res).isInstanceOf(Map.class);
-    verify(transformer, times(3)).apply(document);
     assertThat(((Map<?, ?>) res).get("body")).isInstanceOf(Map.class);
     assertThat(((Map<?, ?>) ((Map<?, ?>) res).get("body")).get("content")).isInstanceOf(List.class);
     assertThat((List<byte[]>) ((Map<?, ?>) ((Map<?, ?>) res).get("body")).get("content"))
@@ -110,22 +109,20 @@ public class DocumentHelperTest {
   public void shouldParseDocuments_InBody_whenListInput() {
     // given
     DocumentHelper documentHelper = new DocumentHelper();
-    var metadata = mock(DocumentMetadata.class);
-    CamundaDocument document =
-        new CamundaDocument(
-            metadata,
-            new CamundaDocumentReferenceImpl("store", "id1", "hash", metadata),
-            InMemoryDocumentStore.INSTANCE);
+    var document =
+        factory.create(
+            DocumentCreationRequest.from("transformed".getBytes(StandardCharsets.UTF_8))
+                .documentId("theId")
+                .fileName("theFileName")
+                .contentType("text/plain")
+                .build());
     List<Object> input = Arrays.asList(document, document, document);
-    Function<CamundaDocument, Object> transformer = mock(Function.class);
-    when(transformer.apply(document)).thenReturn("transformed".getBytes(StandardCharsets.UTF_8));
 
     // when
-    Object res = documentHelper.parseDocumentsInBody(input, transformer);
+    Object res = documentHelper.parseDocumentsInBody(input, Document::asByteArray);
 
     // then
     assertThat(res).isInstanceOf(List.class);
-    verify(transformer, times(3)).apply(document);
     assertThat((List<byte[]>) res)
         .containsAll(
             Arrays.asList(


### PR DESCRIPTION
## Description

Uploading documents using the REST Connector and a `multipart/form-data` request is now working correctly in SaaS (it was working in SM).
- The cluster will convert the Documents to a new custom `CloudFunctionFilePart` type. This is required so that all the information (filename, content type) is serialized and sent to the CloudFunction.
- Previously only the Document content was sent, leading to the request payload not being identified as a file.

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.

