### PR TITLE
refactor(deduplicationId): change the executableIds from UUID to a hashed deduplicationId for stability across runtimes

### DIFF
--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/ExecutableId.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/ExecutableId.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.HexFormat;
+import java.util.Objects;
 
 /**
  * This class represents the hashed deduplication id of an executable. The deduplication id is
@@ -54,5 +55,17 @@ public class ExecutableId {
   @JsonValue
   public String getId() {
     return id;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (o == null || getClass() != o.getClass()) return false;
+    ExecutableId that = (ExecutableId) o;
+    return Objects.equals(id, that.id);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(id);
   }
 }

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/ExecutableId.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/ExecutableId.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.camunda.connector.runtime.core.inbound;
 
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/ExecutableId.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/ExecutableId.java
@@ -1,0 +1,42 @@
+package io.camunda.connector.runtime.core.inbound;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HexFormat;
+
+/**
+ * This class represents the hashed deduplication id of an executable. The deduplication id is
+ * hashed using SHA-256 algorithm.
+ *
+ * <p>The goal of this class is to provide a unique identifier for an executable that can be used
+ * across different Connectors Runtime and remain stable.
+ */
+public class ExecutableId {
+  private String id;
+
+  ExecutableId() {}
+
+  public ExecutableId(String deduplicationId) {
+    try {
+      var digest = MessageDigest.getInstance("SHA-256");
+      byte[] hash = digest.digest(deduplicationId.getBytes());
+      id = HexFormat.of().formatHex(hash);
+    } catch (NoSuchAlgorithmException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @JsonCreator
+  public static ExecutableId fromString(String hashedValue) {
+    var hashed = new ExecutableId();
+    hashed.id = hashedValue;
+    return hashed;
+  }
+
+  @JsonValue
+  public String getId() {
+    return id;
+  }
+}

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/ExecutableId.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/ExecutableId.java
@@ -31,25 +31,26 @@ import java.util.Objects;
  * across different Connectors Runtime and remain stable.
  */
 public class ExecutableId {
-  private String id;
+  private final String id;
 
-  ExecutableId() {}
+  private ExecutableId(String id) {
+    this.id = id;
+  }
 
-  public ExecutableId(String deduplicationId) {
+  /** Only used for deserialization, in the InboundInstancesRestController for instance. */
+  @JsonCreator
+  private static ExecutableId fromHashedId(String id) {
+    return new ExecutableId(id);
+  }
+
+  public static ExecutableId fromDeduplicationId(String deduplicationId) {
     try {
       var digest = MessageDigest.getInstance("SHA-256");
       byte[] hash = digest.digest(deduplicationId.getBytes());
-      id = HexFormat.of().formatHex(hash);
+      return ExecutableId.fromHashedId(HexFormat.of().formatHex(hash));
     } catch (NoSuchAlgorithmException e) {
       throw new RuntimeException(e);
     }
-  }
-
-  @JsonCreator
-  public static ExecutableId fromString(String hashedValue) {
-    var hashed = new ExecutableId();
-    hashed.id = hashedValue;
-    return hashed;
   }
 
   @JsonValue

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/InboundConnectorElement.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/InboundConnectorElement.java
@@ -83,11 +83,13 @@ public record InboundConnectorElement(
     } else if (DeduplicationMode.MANUAL.name().equals(deduplicationMode)) {
       // manual mode, expect deduplicationId property
       LOG.debug("Using deduplicationMode=MANUAL, expecting deduplicationId property");
-      return Optional.ofNullable(rawProperties.get(Keywords.DEDUPLICATION_ID_KEYWORD))
-          .orElseThrow(
-              () ->
-                  new InvalidInboundConnectorDefinitionException(
-                      "Missing deduplicationId property, expected a value due to deduplicationMode=MANUAL"));
+      return tenantIdAndBpmnProcessId()
+          + "-"
+          + Optional.ofNullable(rawProperties.get(Keywords.DEDUPLICATION_ID_KEYWORD))
+              .orElseThrow(
+                  () ->
+                      new InvalidInboundConnectorDefinitionException(
+                          "Missing deduplicationId property, expected a value due to deduplicationMode=MANUAL"));
     } else {
       throw new InvalidInboundConnectorDefinitionException(
           "Invalid deduplicationMode property, expected AUTO or MANUAL, but was "
@@ -110,7 +112,11 @@ public record InboundConnectorElement(
       throw new InvalidInboundConnectorDefinitionException(
           "Missing deduplication properties, expected at least one property to compute deduplicationId");
     }
-    return tenantId() + "-" + element.bpmnProcessId() + "-" + Objects.hash(propsToHash);
+    return tenantIdAndBpmnProcessId() + "-" + Objects.hash(propsToHash);
+  }
+
+  private String tenantIdAndBpmnProcessId() {
+    return tenantId() + "-" + element.bpmnProcessId();
   }
 
   public Map<String, String> connectorLevelProperties() {

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/InboundConnectorElement.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/InboundConnectorElement.java
@@ -116,7 +116,7 @@ public record InboundConnectorElement(
   }
 
   private String tenantIdAndBpmnProcessId() {
-    return tenantId() + "-" + element.bpmnProcessId();
+    return tenantId() + "-" + element.processDefinitionKey();
   }
 
   public Map<String, String> connectorLevelProperties() {

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/details/InboundConnectorDetails.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/details/InboundConnectorDetails.java
@@ -37,7 +37,7 @@ public sealed interface InboundConnectorDetails {
   String deduplicationId();
 
   default ExecutableId id() {
-    return new ExecutableId(deduplicationId());
+    return ExecutableId.fromDeduplicationId(deduplicationId());
   }
 
   String tenantId();

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/details/InboundConnectorDetails.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/details/InboundConnectorDetails.java
@@ -17,6 +17,7 @@
 package io.camunda.connector.runtime.core.inbound.details;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import io.camunda.connector.runtime.core.inbound.ExecutableId;
 import io.camunda.connector.runtime.core.inbound.InboundConnectorElement;
 import java.util.List;
 import java.util.Map;
@@ -34,6 +35,10 @@ public sealed interface InboundConnectorDetails {
   String type();
 
   String deduplicationId();
+
+  default ExecutableId id() {
+    return new ExecutableId(deduplicationId());
+  }
 
   String tenantId();
 

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/inbound/InboundConnectorElementTest.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/inbound/InboundConnectorElementTest.java
@@ -177,13 +177,13 @@ public class InboundConnectorElementTest {
         new InboundConnectorElement(
             Map.of("inbound.type", "test", "deduplicationMode", "MANUAL", "deduplicationId", "id"),
             new StandaloneMessageCorrelationPoint("", "", null, null),
-            new ProcessElement("myProcess", 0, 0, "element1", "<default>"));
+            new ProcessElement("myProcess", 0, 12345, "element1", "<default>"));
 
     // when
     var result = testObj.deduplicationId(List.of());
 
     // then
-    assertThat(result).isEqualTo("<default>-myProcess-id");
+    assertThat(result).isEqualTo("<default>-12345-id");
   }
 
   @Test

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/inbound/InboundConnectorElementTest.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/inbound/InboundConnectorElementTest.java
@@ -183,7 +183,7 @@ public class InboundConnectorElementTest {
     var result = testObj.deduplicationId(List.of());
 
     // then
-    assertThat(result).isEqualTo("id");
+    assertThat(result).isEqualTo("<default>-myProcess-id");
   }
 
   @Test

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/controller/ActiveInboundConnectorResponse.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/controller/ActiveInboundConnectorResponse.java
@@ -18,12 +18,12 @@ package io.camunda.connector.runtime.inbound.controller;
 
 import io.camunda.connector.api.inbound.Health;
 import io.camunda.connector.api.inbound.ProcessElement;
+import io.camunda.connector.runtime.core.inbound.ExecutableId;
 import java.util.List;
 import java.util.Map;
-import java.util.UUID;
 
 public record ActiveInboundConnectorResponse(
-    UUID executableId, // consider
+    ExecutableId executableId,
     String type,
     String tenantId,
     List<ProcessElement> elements,

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/controller/InboundInstancesRestController.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/controller/InboundInstancesRestController.java
@@ -71,7 +71,7 @@ public class InboundInstancesRestController {
         instance.instances().stream()
             .filter(
                 activeInboundConnectorResponse ->
-                    activeInboundConnectorResponse.executableId().toString().equals(executableId))
+                    activeInboundConnectorResponse.executableId().getId().equals(executableId))
             .toList();
     if (executables.isEmpty()) {
       throw new DataNotFoundException(ActiveInboundConnectorResponse.class, executableId);
@@ -88,7 +88,7 @@ public class InboundInstancesRestController {
         executable.elements().stream().map(ProcessElement::bpmnProcessId).distinct().toList();
     if (processIds.size() > 1) {
       throw new RuntimeException(
-          "Multiple process ids found for the executable id: "
+          "Multiple process ids found for the id: "
               + executableId
               + ". This is not supported yet.");
     }
@@ -99,7 +99,7 @@ public class InboundInstancesRestController {
             .stream()
             .filter(
                 activeExecutableResponse ->
-                    activeExecutableResponse.executableId().toString().equals(executableId))
+                    activeExecutableResponse.executableId().getId().equals(executableId))
             .findFirst();
     if (result.isEmpty()) {
       throw new DataNotFoundException(Activity.class, executableId);

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/executable/ActiveExecutableResponse.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/executable/ActiveExecutableResponse.java
@@ -19,11 +19,12 @@ package io.camunda.connector.runtime.inbound.executable;
 import io.camunda.connector.api.inbound.Activity;
 import io.camunda.connector.api.inbound.Health;
 import io.camunda.connector.api.inbound.InboundConnectorExecutable;
+import io.camunda.connector.runtime.core.inbound.ExecutableId;
 import io.camunda.connector.runtime.core.inbound.InboundConnectorElement;
 import java.util.*;
 
 public record ActiveExecutableResponse(
-    UUID executableId,
+    ExecutableId executableId,
     Class<? extends InboundConnectorExecutable> executableClass,
     List<InboundConnectorElement> elements,
     Health health,

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/executable/InboundExecutableEvent.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/executable/InboundExecutableEvent.java
@@ -16,9 +16,9 @@
  */
 package io.camunda.connector.runtime.inbound.executable;
 
+import io.camunda.connector.runtime.core.inbound.ExecutableId;
 import io.camunda.connector.runtime.core.inbound.InboundConnectorElement;
 import java.util.List;
-import java.util.UUID;
 
 public sealed interface InboundExecutableEvent {
 
@@ -29,5 +29,5 @@ public sealed interface InboundExecutableEvent {
   record Deactivated(String tenantId, long processDefinitionKey)
       implements InboundExecutableEvent {}
 
-  record Cancelled(UUID uuid, Throwable throwable) implements InboundExecutableEvent {}
+  record Cancelled(ExecutableId id, Throwable throwable) implements InboundExecutableEvent {}
 }

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/inbound/executable/InboundExecutableRegistryTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/inbound/executable/InboundExecutableRegistryTest.java
@@ -52,7 +52,7 @@ public class InboundExecutableRegistryTest {
   private InboundExecutableRegistryImpl registry;
 
   public static final String RANDOM_STRING = "thededuplicationId";
-  private static final ExecutableId RANDOM_ID = new ExecutableId(RANDOM_STRING);
+  private static final ExecutableId RANDOM_ID = ExecutableId.fromDeduplicationId(RANDOM_STRING);
 
   @BeforeEach
   public void prepareMocks() {

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/inbound/executable/InboundExecutableRegistryTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/inbound/executable/InboundExecutableRegistryTest.java
@@ -39,7 +39,6 @@ import java.util.NoSuchElementException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
-import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -52,7 +51,7 @@ public class InboundExecutableRegistryTest {
   private BatchExecutableProcessor batchProcessor;
   private InboundExecutableRegistryImpl registry;
 
-  public static final String RANDOM_STRING = RandomStringUtils.insecure().next(10);
+  public static final String RANDOM_STRING = "thededuplicationId";
   private static final ExecutableId RANDOM_ID = new ExecutableId(RANDOM_STRING);
 
   @BeforeEach

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/inbound/InboundEndpointTest.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/inbound/InboundEndpointTest.java
@@ -43,7 +43,7 @@ import org.junit.jupiter.api.Test;
 public class InboundEndpointTest {
 
   private static final ExecutableId RANDOM_ID =
-      new ExecutableId(RandomStringUtils.insecure().next(10));
+      ExecutableId.fromDeduplicationId(RandomStringUtils.insecure().next(10));
 
   static class AnotherExecutable implements InboundConnectorExecutable<InboundConnectorContext> {
 

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/inbound/InboundEndpointTest.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/inbound/InboundEndpointTest.java
@@ -28,6 +28,7 @@ import io.camunda.connector.api.inbound.ProcessElement;
 import io.camunda.connector.api.inbound.webhook.WebhookConnectorExecutable;
 import io.camunda.connector.api.inbound.webhook.WebhookProcessingPayload;
 import io.camunda.connector.api.inbound.webhook.WebhookResult;
+import io.camunda.connector.runtime.core.inbound.ExecutableId;
 import io.camunda.connector.runtime.core.inbound.InboundConnectorElement;
 import io.camunda.connector.runtime.core.inbound.correlation.MessageCorrelationPoint.StandaloneMessageCorrelationPoint;
 import io.camunda.connector.runtime.inbound.controller.InboundConnectorRestController;
@@ -36,10 +37,13 @@ import io.camunda.connector.runtime.inbound.executable.InboundExecutableRegistry
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.UUID;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.jupiter.api.Test;
 
 public class InboundEndpointTest {
+
+  private static final ExecutableId RANDOM_ID =
+      new ExecutableId(RandomStringUtils.insecure().next(10));
 
   static class AnotherExecutable implements InboundConnectorExecutable<InboundConnectorContext> {
 
@@ -66,7 +70,7 @@ public class InboundEndpointTest {
         .thenReturn(
             List.of(
                 new ActiveExecutableResponse(
-                    UUID.randomUUID(),
+                    RANDOM_ID,
                     TestWebhookExecutable.class,
                     List.of(
                         new InboundConnectorElement(
@@ -93,7 +97,7 @@ public class InboundEndpointTest {
         .thenReturn(
             List.of(
                 new ActiveExecutableResponse(
-                    UUID.randomUUID(),
+                    RANDOM_ID,
                     null, // executable class is null
                     List.of(
                         new InboundConnectorElement(

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/inbound/InboundInstancesRestControllerTest.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/inbound/InboundInstancesRestControllerTest.java
@@ -64,9 +64,9 @@ class InboundInstancesRestControllerTest {
 
   private static final String TYPE_1 = "webhook";
 
-  private static final ExecutableId RANDOM_ID_1 = new ExecutableId("theid1");
-  private static final ExecutableId RANDOM_ID_2 = new ExecutableId("theid2");
-  private static final ExecutableId RANDOM_ID_3 = new ExecutableId("theid3");
+  private static final ExecutableId RANDOM_ID_1 = ExecutableId.fromDeduplicationId("theid1");
+  private static final ExecutableId RANDOM_ID_2 = ExecutableId.fromDeduplicationId("theid2");
+  private static final ExecutableId RANDOM_ID_3 = ExecutableId.fromDeduplicationId("theid3");
   private static final String TYPE_2 = "anotherType";
 
   static class AnotherExecutable implements InboundConnectorExecutable<InboundConnectorContext> {

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/inbound/InboundInstancesRestControllerTest.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/inbound/InboundInstancesRestControllerTest.java
@@ -32,6 +32,7 @@ import io.camunda.connector.api.inbound.webhook.WebhookProcessingPayload;
 import io.camunda.connector.api.inbound.webhook.WebhookResult;
 import io.camunda.connector.api.json.ConnectorsObjectMapperSupplier;
 import io.camunda.connector.runtime.app.TestConnectorRuntimeApplication;
+import io.camunda.connector.runtime.core.inbound.ExecutableId;
 import io.camunda.connector.runtime.core.inbound.InboundConnectorElement;
 import io.camunda.connector.runtime.core.inbound.correlation.MessageCorrelationPoint.StandaloneMessageCorrelationPoint;
 import io.camunda.connector.runtime.inbound.controller.ActiveInboundConnectorResponse;
@@ -62,10 +63,11 @@ class InboundInstancesRestControllerTest {
   @InjectMocks private InboundInstancesRestController controller;
 
   private static final String TYPE_1 = "webhook";
-  private static final UUID UUID_1 = UUID.randomUUID();
+
+  private static final ExecutableId RANDOM_ID_1 = new ExecutableId("theid1");
+  private static final ExecutableId RANDOM_ID_2 = new ExecutableId("theid2");
+  private static final ExecutableId RANDOM_ID_3 = new ExecutableId("theid3");
   private static final String TYPE_2 = "anotherType";
-  private static final UUID UUID_2 = UUID.randomUUID();
-  private static final UUID UUID_3 = UUID.randomUUID();
 
   static class AnotherExecutable implements InboundConnectorExecutable<InboundConnectorContext> {
 
@@ -96,7 +98,7 @@ class InboundInstancesRestControllerTest {
                     ? Collections.emptyList()
                     : Stream.of(
                             new ActiveExecutableResponse(
-                                UUID_1,
+                                RANDOM_ID_1,
                                 TestWebhookExecutable.class,
                                 List.of(
                                     new InboundConnectorElement(
@@ -108,7 +110,7 @@ class InboundInstancesRestControllerTest {
                                 Collections.emptyList(),
                                 System.currentTimeMillis()),
                             new ActiveExecutableResponse(
-                                UUID_2,
+                                RANDOM_ID_2,
                                 AnotherExecutable.class,
                                 List.of(
                                     new InboundConnectorElement(
@@ -124,7 +126,7 @@ class InboundInstancesRestControllerTest {
                                 Collections.emptyList(),
                                 System.currentTimeMillis()),
                             new ActiveExecutableResponse(
-                                UUID_3,
+                                RANDOM_ID_3,
                                 AnotherExecutable.class,
                                 List.of(
                                     new InboundConnectorElement(
@@ -160,10 +162,10 @@ class InboundInstancesRestControllerTest {
                                       .type();
                               return switch (providedType) {
                                 case null -> true;
-                                case TYPE_1 -> response.executableId().equals(UUID_1);
+                                case TYPE_1 -> response.executableId().equals(RANDOM_ID_1);
                                 case TYPE_2 ->
-                                    response.executableId().equals(UUID_2)
-                                        || response.executableId().equals(UUID_3);
+                                    response.executableId().equals(RANDOM_ID_2)
+                                        || response.executableId().equals(RANDOM_ID_3);
                                 default -> false;
                               };
                             })
@@ -187,16 +189,16 @@ class InboundInstancesRestControllerTest {
     assertEquals(TYPE_1, instance1.connectorId());
     assertEquals("Webhook", instance1.connectorName());
     assertEquals(1, instance1.instances().size());
-    assertEquals(UUID_1, instance1.instances().get(0).executableId());
+    assertEquals(RANDOM_ID_1, instance1.instances().get(0).executableId());
     assertEquals("ProcessA", instance1.instances().get(0).elements().getFirst().bpmnProcessId());
 
     var instance2 = instance.get(1);
     assertEquals(TYPE_2, instance2.connectorId());
     assertEquals("AnotherType", instance2.connectorName());
     assertEquals(2, instance2.instances().size());
-    assertEquals(UUID_2, instance2.instances().get(0).executableId());
+    assertEquals(RANDOM_ID_2, instance2.instances().get(0).executableId());
     assertEquals("ProcessB", instance2.instances().get(0).elements().getFirst().bpmnProcessId());
-    assertEquals(UUID_3, instance2.instances().get(1).executableId());
+    assertEquals(RANDOM_ID_3, instance2.instances().get(1).executableId());
     assertEquals("ProcessC", instance2.instances().get(1).elements().getFirst().bpmnProcessId());
   }
 
@@ -227,7 +229,7 @@ class InboundInstancesRestControllerTest {
     assertEquals(TYPE_1, instance.connectorId());
     assertEquals("Webhook", instance.connectorName());
     assertEquals(1, instance.instances().size());
-    assertEquals(UUID_1, instance.instances().get(0).executableId());
+    assertEquals(RANDOM_ID_1, instance.instances().get(0).executableId());
     assertEquals("ProcessA", instance.instances().get(0).elements().getFirst().bpmnProcessId());
   }
 
@@ -246,7 +248,7 @@ class InboundInstancesRestControllerTest {
   @Test
   public void shouldReturn404_whenUnknownConnectorTypeAndValidExecutableId() throws Exception {
     mockMvc
-        .perform(get("/inbound-instances/UNKNOWN-ID/executables/" + UUID_1))
+        .perform(get("/inbound-instances/UNKNOWN-ID/executables/" + RANDOM_ID_1.getId()))
         .andExpect(status().isNotFound())
         .andExpect(
             content()
@@ -259,7 +261,7 @@ class InboundInstancesRestControllerTest {
   public void shouldReturnSingleExecutable() throws Exception {
     var response =
         mockMvc
-            .perform(get("/inbound-instances/" + TYPE_1 + "/executables/" + UUID_1))
+            .perform(get("/inbound-instances/" + TYPE_1 + "/executables/" + RANDOM_ID_1.getId()))
             .andExpect(status().isOk())
             .andReturn()
             .getResponse()
@@ -268,7 +270,7 @@ class InboundInstancesRestControllerTest {
     ActiveInboundConnectorResponse executable =
         ConnectorsObjectMapperSupplier.getCopy()
             .readValue(response, ActiveInboundConnectorResponse.class);
-    assertEquals(UUID_1, executable.executableId());
+    assertEquals(RANDOM_ID_1, executable.executableId());
     assertEquals("ProcessA", executable.elements().getFirst().bpmnProcessId());
   }
 
@@ -276,7 +278,13 @@ class InboundInstancesRestControllerTest {
   public void shouldReturnEmptyActivityLogs_whenNoLogs() throws Exception {
     var response =
         mockMvc
-            .perform(get("/inbound-instances/" + TYPE_1 + "/executables/" + UUID_1 + "/logs"))
+            .perform(
+                get(
+                    "/inbound-instances/"
+                        + TYPE_1
+                        + "/executables/"
+                        + RANDOM_ID_1.getId()
+                        + "/logs"))
             .andExpect(status().isOk())
             .andReturn()
             .getResponse()
@@ -291,7 +299,13 @@ class InboundInstancesRestControllerTest {
   public void shouldReturnActivityLogs_whenTypeProvided() throws Exception {
     var response =
         mockMvc
-            .perform(get("/inbound-instances/" + TYPE_2 + "/executables/" + UUID_3 + "/logs"))
+            .perform(
+                get(
+                    "/inbound-instances/"
+                        + TYPE_2
+                        + "/executables/"
+                        + RANDOM_ID_3.getId()
+                        + "/logs"))
             .andExpect(status().isOk())
             .andReturn()
             .getResponse()

--- a/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/model/HttpCommonRequest.java
+++ b/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/model/HttpCommonRequest.java
@@ -122,16 +122,6 @@ public class HttpCommonRequest {
   private String skipEncoding;
 
   @TemplateProperty(
-      label = "Group set-cookie headers to a list",
-      description =
-          "Group incoming headers with same name into a List to support <a href=\"https://datatracker.ietf.org/doc/html/rfc6265\">multiple Set-Cookie headers</a>.",
-      type = TemplateProperty.PropertyType.Hidden,
-      feel = Property.FeelMode.disabled,
-      group = "endpoint",
-      optional = true)
-  private String groupSetCookieHeaders;
-
-  @TemplateProperty(
       group = "payload",
       type = PropertyType.Boolean,
       defaultValueType = TemplateProperty.DefaultValueType.Boolean,
@@ -173,14 +163,6 @@ public class HttpCommonRequest {
 
   public void setSkipEncoding(final String skipEncoding) {
     this.skipEncoding = skipEncoding;
-  }
-
-  public boolean getGroupSetCookieHeaders() {
-    return Objects.equals(groupSetCookieHeaders, "true");
-  }
-
-  public void setGroupSetCookieHeaders(final String groupSetCookieHeaders) {
-    this.groupSetCookieHeaders = groupSetCookieHeaders;
   }
 
   public boolean hasAuthentication() {

--- a/connectors/http/rest/element-templates/http-json-connector.json
+++ b/connectors/http/rest/element-templates/http-json-connector.json
@@ -476,7 +476,7 @@
     "label" : "Ignore null values",
     "optional" : false,
     "value" : false,
-    "feel" : "optional",
+    "feel" : "static",
     "group" : "payload",
     "binding" : {
       "name" : "ignoreNullValues",

--- a/connectors/http/rest/element-templates/hybrid/http-json-connector-hybrid.json
+++ b/connectors/http/rest/element-templates/hybrid/http-json-connector-hybrid.json
@@ -481,7 +481,7 @@
     "label" : "Ignore null values",
     "optional" : false,
     "value" : false,
-    "feel" : "optional",
+    "feel" : "static",
     "group" : "payload",
     "binding" : {
       "name" : "ignoreNullValues",


### PR DESCRIPTION
## Description

- Executable IDs aren't UUIDs anymore. They're now built this way: `executableId = sha256(deduplicationId)` 
- This will ensure stable IDs across runtimes
- I changed the `deduplicationId` generation, and I am now using `processDefinitionKey` instead of `bpmnProcessId`. The idea is that we might have different executables for different process versions (when we fetch latest+active processes). 

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.

