### PR TITLE
feat(office-365): send documents via email

### DIFF
--- a/connectors/microsoft/mail/element-templates/microsoft-office365-mail-connector.json
+++ b/connectors/microsoft/mail/element-templates/microsoft-office365-mail-connector.json
@@ -603,8 +603,12 @@
     {
       "id": "users.user.sendMail_attachments",
       "label": "Attachments",
-      "description": "Attachments. Must be an array of document objects",
-      "optional": true,
+      "description": "Attachments. Must be an array of document objects or an empty array",
+      "optional": false,
+      "constraints": {
+        "notEmpty": true
+      },
+      "value": "=[]",
       "feel": "required",
       "group": "requestBody",
       "binding": {
@@ -735,7 +739,7 @@
     },
     {
       "id": "users.user.sendMail_body",
-      "value": "={\"message\":{\"subject\":sendMail_subject,\"body\":{\"contentType\":sendMail_body_content_type,\"content\":sendMail_body_content},\"toRecipients\": for currentEmail in sendMail_to_recipients return {\"emailAddress\":{\"address\":currentEmail}},\"ccRecipients\": if sendMail_cc_recipients != null then for currentEmailCC in sendMail_cc_recipients return {\"emailAddress\":{\"address\":currentEmailCC}} else null,\"attachments\": if sendMail_attachments != null then for document in sendMail_attachments return {\"@odata.type\":\"#microsoft.graph.fileAttachment\",\"name\":document.metadata.fileName,\"contentType\":document.metadata.contentType,\"contentBytes\":{\"camunda.function.type\":\"base64\",\"params\":[document]}} else null},\"saveToSentItems\":\"false\"}",
+      "value": "={\"message\":{\"subject\":sendMail_subject,\"body\":{\"contentType\":sendMail_body_content_type,\"content\":sendMail_body_content},\"toRecipients\": for currentEmail in sendMail_to_recipients return {\"emailAddress\":{\"address\":currentEmail}},\"ccRecipients\": if sendMail_cc_recipients != null then for currentEmailCC in sendMail_cc_recipients return {\"emailAddress\":{\"address\":currentEmailCC}} else null,\"attachments\": if sendMail_attachments != null then for document in sendMail_attachments return {\"@odata.type\":\"#microsoft.graph.fileAttachment\",\"name\":document.metadata.fileName,\"contentType\":document.metadata.contentType,\"contentBytes\":document} else null},\"saveToSentItems\":\"false\"}",
       "group": "requestBody",
       "binding": {
         "name": "body",

--- a/connectors/microsoft/mail/element-templates/microsoft-office365-mail-connector.json
+++ b/connectors/microsoft/mail/element-templates/microsoft-office365-mail-connector.json
@@ -601,6 +601,24 @@
       "type": "Text"
     },
     {
+      "id": "users.user.sendMail_attachments",
+      "label": "Attachments",
+      "description": "Attachments. Must be an array of document objects",
+      "optional": true,
+      "feel": "required",
+      "group": "requestBody",
+      "binding": {
+        "name": "sendMail_attachments",
+        "type": "zeebe:input"
+      },
+      "condition": {
+        "property": "operationId",
+        "equals": "users.user.sendMail",
+        "type": "simple"
+      },
+      "type": "String"
+    },
+    {
       "id": "users.user.sendMail_to_recipients",
       "label": "To recipients",
       "description": "Target recipients. Must be an array of emails",
@@ -717,7 +735,7 @@
     },
     {
       "id": "users.user.sendMail_body",
-      "value": "={\"message\":{\"subject\":sendMail_subject,\"body\":{\"contentType\":sendMail_body_content_type,\"content\":sendMail_body_content},\"toRecipients\": for currentEmail in sendMail_to_recipients return {\"emailAddress\":{\"address\":currentEmail}},\"ccRecipients\": if sendMail_cc_recipients != null then for currentEmailCC in sendMail_cc_recipients return {\"emailAddress\":{\"address\":currentEmailCC}} else null},\"saveToSentItems\":\"false\"}",
+      "value": "={\"message\":{\"subject\":sendMail_subject,\"body\":{\"contentType\":sendMail_body_content_type,\"content\":sendMail_body_content},\"toRecipients\": for currentEmail in sendMail_to_recipients return {\"emailAddress\":{\"address\":currentEmail}},\"ccRecipients\": if sendMail_cc_recipients != null then for currentEmailCC in sendMail_cc_recipients return {\"emailAddress\":{\"address\":currentEmailCC}} else null,\"attachments\": if sendMail_attachments != null then for document in sendMail_attachments return {\"@odata.type\":\"#microsoft.graph.fileAttachment\",\"name\":document.metadata.fileName,\"contentType\":document.metadata.contentType,\"contentBytes\":{\"camunda.function.type\":\"base64\",\"params\":[document]}} else null},\"saveToSentItems\":\"false\"}",
       "group": "requestBody",
       "binding": {
         "name": "body",


### PR DESCRIPTION
## Description

This PR adds a new field to our Office 365 connector that allows to send documents in an email.

Since this is an element-template-only connector, we can do this using an intrinsic function `base64`, but for this case it's actually enough to provide a document directly due to how the REST connector works.

<img width="503" alt="Screenshot 2025-03-21 at 14 14 26" src="https://github.com/user-attachments/assets/b888f448-cfce-4d5e-b168-880331d0237c" />

## Testing

Follow this guide: https://github.com/camunda/team-connectors/issues/1004
And another guide on how to get a user token: https://github.com/camunda/team-connectors/blob/main/how-to/OUTLOOK_APP_FOR_EMAIL_TESTING.md

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes https://github.com/camunda/team-connectors/issues/1004

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.

