### PR TITLE
refactor(office-365): use an intrinsic function for sending base64 documents

### DIFF
--- a/connectors/microsoft/mail/element-templates/microsoft-office365-mail-connector.json
+++ b/connectors/microsoft/mail/element-templates/microsoft-office365-mail-connector.json
@@ -739,7 +739,8 @@
     },
     {
       "id": "users.user.sendMail_body",
-      "value": "={\"message\":{\"subject\":sendMail_subject,\"body\":{\"contentType\":sendMail_body_content_type,\"content\":sendMail_body_content},\"toRecipients\": for currentEmail in sendMail_to_recipients return {\"emailAddress\":{\"address\":currentEmail}},\"ccRecipients\": if sendMail_cc_recipients != null then for currentEmailCC in sendMail_cc_recipients return {\"emailAddress\":{\"address\":currentEmailCC}} else null,\"attachments\": if sendMail_attachments != null then for document in sendMail_attachments return {\"@odata.type\":\"#microsoft.graph.fileAttachment\",\"name\":document.metadata.fileName,\"contentType\":document.metadata.contentType,\"contentBytes\":{\"camunda.function.type\":\"base64\",\"params\":[document]}} else null},\"saveToSentItems\":\"false\"}",      "group": "requestBody",
+      "value": "={\"message\":{\"subject\":sendMail_subject,\"body\":{\"contentType\":sendMail_body_content_type,\"content\":sendMail_body_content},\"toRecipients\": for currentEmail in sendMail_to_recipients return {\"emailAddress\":{\"address\":currentEmail}},\"ccRecipients\": if sendMail_cc_recipients != null then for currentEmailCC in sendMail_cc_recipients return {\"emailAddress\":{\"address\":currentEmailCC}} else null,\"attachments\": if sendMail_attachments != null then for document in sendMail_attachments return {\"@odata.type\":\"#microsoft.graph.fileAttachment\",\"name\":document.metadata.fileName,\"contentType\":document.metadata.contentType,\"contentBytes\":{\"camunda.function.type\":\"base64\",\"params\":[document]}} else null},\"saveToSentItems\":\"false\"}",
+      "group": "requestBody",
       "binding": {
         "name": "body",
         "type": "zeebe:input"

--- a/connectors/microsoft/mail/element-templates/microsoft-office365-mail-connector.json
+++ b/connectors/microsoft/mail/element-templates/microsoft-office365-mail-connector.json
@@ -739,8 +739,7 @@
     },
     {
       "id": "users.user.sendMail_body",
-      "value": "={\"message\":{\"subject\":sendMail_subject,\"body\":{\"contentType\":sendMail_body_content_type,\"content\":sendMail_body_content},\"toRecipients\": for currentEmail in sendMail_to_recipients return {\"emailAddress\":{\"address\":currentEmail}},\"ccRecipients\": if sendMail_cc_recipients != null then for currentEmailCC in sendMail_cc_recipients return {\"emailAddress\":{\"address\":currentEmailCC}} else null,\"attachments\": if sendMail_attachments != null then for document in sendMail_attachments return {\"@odata.type\":\"#microsoft.graph.fileAttachment\",\"name\":document.metadata.fileName,\"contentType\":document.metadata.contentType,\"contentBytes\":document} else null},\"saveToSentItems\":\"false\"}",
-      "group": "requestBody",
+      "value": "={\"message\":{\"subject\":sendMail_subject,\"body\":{\"contentType\":sendMail_body_content_type,\"content\":sendMail_body_content},\"toRecipients\": for currentEmail in sendMail_to_recipients return {\"emailAddress\":{\"address\":currentEmail}},\"ccRecipients\": if sendMail_cc_recipients != null then for currentEmailCC in sendMail_cc_recipients return {\"emailAddress\":{\"address\":currentEmailCC}} else null,\"attachments\": if sendMail_attachments != null then for document in sendMail_attachments return {\"@odata.type\":\"#microsoft.graph.fileAttachment\",\"name\":document.metadata.fileName,\"contentType\":document.metadata.contentType,\"contentBytes\":{\"camunda.function.type\":\"base64\",\"params\":[document]}} else null},\"saveToSentItems\":\"false\"}",      "group": "requestBody",
       "binding": {
         "name": "body",
         "type": "zeebe:input"


### PR DESCRIPTION
## Description

Follow up for #4393 - use an intrinsic function instead of relying on implicit Jackson + HTTP connector functionality. This might be simpler to maintain.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #

## Checklist

- [ ] PR has a **milestone** or the `no milestone` label.

