### PR TITLE
fix(metric): proc def metric has incorrect name

### DIFF
--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/metrics/ConnectorMetrics.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/metrics/ConnectorMetrics.java
@@ -36,7 +36,7 @@ public class ConnectorMetrics {
     public static final String METRIC_NAME_ACTIVATIONS = "camunda.connector.inbound.activations";
     public static final String METRIC_NAME_TRIGGERS = "camunda.connector.inbound.triggers";
     public static final String METRIC_NAME_INBOUND_PROCESS_DEFINITIONS_CHECKED =
-        "camunda.connector.inbound.process-elements-checked";
+        "camunda.connector.inbound.process-definitions-checked";
 
     public static final String ACTION_ACTIVATED = "activated";
     public static final String ACTION_DEACTIVATED = "deactivated";


### PR DESCRIPTION
## Description

The metric has been renamed by mistake.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #

## Checklist

- [ ] PR has a **milestone** or the `no milestone` label.

