### PR TITLE
fix(inbound-connector): do not apply number and boolean to inbound connector

### DIFF
--- a/connectors/email/element-templates/email-inbound-connector-boundary.json
+++ b/connectors/email/element-templates/email-inbound-connector-boundary.json
@@ -126,7 +126,7 @@
     "id" : "data.imapPort",
     "label" : "IMAP Port",
     "optional" : false,
-    "value" : 993,
+    "value" : "993",
     "constraints" : {
       "notEmpty" : true
     },
@@ -137,7 +137,7 @@
       "type" : "zeebe:property"
     },
     "tooltip" : "Enter the port number for connecting to the IMAP server. Common ports are 993 for secure connections using SSL/TLS, or 143 for non-secure connections.",
-    "type" : "Number"
+    "type" : "String"
   }, {
     "id" : "imapCryptographicProtocol",
     "label" : "Encryption protocol",

--- a/connectors/email/element-templates/email-inbound-connector-intermediate.json
+++ b/connectors/email/element-templates/email-inbound-connector-intermediate.json
@@ -126,7 +126,7 @@
     "id" : "data.imapPort",
     "label" : "IMAP Port",
     "optional" : false,
-    "value" : 993,
+    "value" : "993",
     "constraints" : {
       "notEmpty" : true
     },
@@ -137,7 +137,7 @@
       "type" : "zeebe:property"
     },
     "tooltip" : "Enter the port number for connecting to the IMAP server. Common ports are 993 for secure connections using SSL/TLS, or 143 for non-secure connections.",
-    "type" : "Number"
+    "type" : "String"
   }, {
     "id" : "imapCryptographicProtocol",
     "label" : "Encryption protocol",

--- a/connectors/email/element-templates/email-message-start-event-connector.json
+++ b/connectors/email/element-templates/email-message-start-event-connector.json
@@ -126,7 +126,7 @@
     "id" : "data.imapPort",
     "label" : "IMAP Port",
     "optional" : false,
-    "value" : 993,
+    "value" : "993",
     "constraints" : {
       "notEmpty" : true
     },
@@ -137,7 +137,7 @@
       "type" : "zeebe:property"
     },
     "tooltip" : "Enter the port number for connecting to the IMAP server. Common ports are 993 for secure connections using SSL/TLS, or 143 for non-secure connections.",
-    "type" : "Number"
+    "type" : "String"
   }, {
     "id" : "imapCryptographicProtocol",
     "label" : "Encryption protocol",

--- a/connectors/email/element-templates/hybrid/email-inbound-connector-boundary-hybrid.json
+++ b/connectors/email/element-templates/hybrid/email-inbound-connector-boundary-hybrid.json
@@ -131,7 +131,7 @@
     "id" : "data.imapPort",
     "label" : "IMAP Port",
     "optional" : false,
-    "value" : 993,
+    "value" : "993",
     "constraints" : {
       "notEmpty" : true
     },
@@ -142,7 +142,7 @@
       "type" : "zeebe:property"
     },
     "tooltip" : "Enter the port number for connecting to the IMAP server. Common ports are 993 for secure connections using SSL/TLS, or 143 for non-secure connections.",
-    "type" : "Number"
+    "type" : "String"
   }, {
     "id" : "imapCryptographicProtocol",
     "label" : "Encryption protocol",

--- a/connectors/email/element-templates/hybrid/email-inbound-connector-intermediate-hybrid.json
+++ b/connectors/email/element-templates/hybrid/email-inbound-connector-intermediate-hybrid.json
@@ -131,7 +131,7 @@
     "id" : "data.imapPort",
     "label" : "IMAP Port",
     "optional" : false,
-    "value" : 993,
+    "value" : "993",
     "constraints" : {
       "notEmpty" : true
     },
@@ -142,7 +142,7 @@
       "type" : "zeebe:property"
     },
     "tooltip" : "Enter the port number for connecting to the IMAP server. Common ports are 993 for secure connections using SSL/TLS, or 143 for non-secure connections.",
-    "type" : "Number"
+    "type" : "String"
   }, {
     "id" : "imapCryptographicProtocol",
     "label" : "Encryption protocol",

--- a/connectors/email/element-templates/hybrid/hybrid-email-message-start-event-connector-hybrid.json
+++ b/connectors/email/element-templates/hybrid/hybrid-email-message-start-event-connector-hybrid.json
@@ -131,7 +131,7 @@
     "id" : "data.imapPort",
     "label" : "IMAP Port",
     "optional" : false,
-    "value" : 993,
+    "value" : "993",
     "constraints" : {
       "notEmpty" : true
     },
@@ -142,7 +142,7 @@
       "type" : "zeebe:property"
     },
     "tooltip" : "Enter the port number for connecting to the IMAP server. Common ports are 993 for secure connections using SSL/TLS, or 143 for non-secure connections.",
-    "type" : "Number"
+    "type" : "String"
   }, {
     "id" : "imapCryptographicProtocol",
     "label" : "Encryption protocol",

--- a/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/processor/TemplatePropertyFieldProcessor.java
+++ b/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/processor/TemplatePropertyFieldProcessor.java
@@ -148,7 +148,14 @@ public class TemplatePropertyFieldProcessor implements FieldProcessor {
       switch (annotation.defaultValueType()) {
         case Boolean -> builder.value(Boolean.parseBoolean(value));
         case String -> builder.value(value);
-        case Number -> builder.value(parseNumber(value, field.getType()));
+        case Number -> {
+          // To be removed
+          if (context instanceof TemplateGenerationContext.Outbound) {
+            builder.value(parseNumber(value, field.getType()));
+          } else {
+            builder.value(value);
+          }
+        }
         default ->
             throw new IllegalStateException("Unexpected value: " + annotation.defaultValueType());
       }

--- a/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/processor/TemplatePropertyFieldProcessor.java
+++ b/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/processor/TemplatePropertyFieldProcessor.java
@@ -149,7 +149,7 @@ public class TemplatePropertyFieldProcessor implements FieldProcessor {
         case Boolean -> builder.value(Boolean.parseBoolean(value));
         case String -> builder.value(value);
         case Number -> {
-          // To be removed
+          // TODO: To be removed
           if (context instanceof TemplateGenerationContext.Outbound) {
             builder.value(parseNumber(value, field.getType()));
           } else {

--- a/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/util/TemplatePropertiesUtil.java
+++ b/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/util/TemplatePropertiesUtil.java
@@ -183,7 +183,7 @@ public class TemplatePropertiesUtil {
     }
 
     PropertyBuilder propertyBuilder =
-        createPropertyBuilder(field, annotation)
+        createPropertyBuilder(field, annotation, context)
             .id(name)
             .label(label)
             .tooltip(tooltip)
@@ -281,7 +281,8 @@ public class TemplatePropertiesUtil {
     return Number.class.isAssignableFrom(clazz);
   }
 
-  private static PropertyBuilder createPropertyBuilder(Field field, TemplateProperty annotation) {
+  private static PropertyBuilder createPropertyBuilder(
+      Field field, TemplateProperty annotation, TemplateGenerationContext context) {
     PropertyType type;
     List<DropdownModel> dropdownChoices = new ArrayList<>();
 
@@ -291,7 +292,7 @@ public class TemplatePropertiesUtil {
       type = PropertyType.Dropdown;
       Class<?> enumType = field.getType();
       dropdownChoices = createDropdownModelList(enumType);
-    } else if (isNumberClass(field.getType())) {
+    } else if (isNumberClass(field.getType()) && isOutbound(context)) { // To be removed
       type = PropertyType.Number;
     } else {
       type = PropertyType.String;
@@ -336,6 +337,13 @@ public class TemplatePropertiesUtil {
       builder.feel(FeelMode.required);
     }
     return builder;
+  }
+
+  private static boolean isOutbound(TemplateGenerationContext context) {
+    return switch (context) {
+      case TemplateGenerationContext.Inbound unused -> false;
+      case Outbound unused -> true;
+    };
   }
 
   private static List<PropertyBuilder> handleSealedType(

--- a/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/util/TemplatePropertiesUtil.java
+++ b/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/util/TemplatePropertiesUtil.java
@@ -292,7 +292,7 @@ public class TemplatePropertiesUtil {
       type = PropertyType.Dropdown;
       Class<?> enumType = field.getType();
       dropdownChoices = createDropdownModelList(enumType);
-    } else if (isNumberClass(field.getType()) && isOutbound(context)) { // To be removed
+    } else if (isNumberClass(field.getType()) && isOutbound(context)) { // TODO: To be removed
       type = PropertyType.Number;
     } else {
       type = PropertyType.String;


### PR DESCRIPTION
## Description

ETG has a filter now

It will not apply `Number` and `Boolean` to inbound connector template

## Checklist

- [ ] PR has a **milestone** or the `no milestone` label.

