### PR TITLE
chore(ms-teams): Remove netty-resolver-dns-native-macos

### DIFF
--- a/connectors/microsoft-teams/pom.xml
+++ b/connectors/microsoft-teams/pom.xml
@@ -32,6 +32,12 @@
       <groupId>com.azure</groupId>
       <artifactId>azure-identity</artifactId>
       <scope>compile</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-resolver-dns-native-macos</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -433,6 +433,12 @@ limitations under the License.</license.inlineheader>
         <artifactId>azure-identity</artifactId>
         <version>${version.azure-identity}</version>
         <scope>compile</scope>
+        <exclusions>
+          <exclusion>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-resolver-dns-native-macos</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
## Description
Removed the dependency. Feel free if the connector still works on mac locally.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes https://github.com/camunda/team-connectors/issues/1013

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.

