### PR TITLE
feat(element-template-generator): Add all auth sections if no security scheme provided by openapi scheme

### DIFF
--- a/element-template-generator/http-dsl/src/main/java/io/camunda/connector/generator/dsl/http/PropertyUtil.java
+++ b/element-template-generator/http-dsl/src/main/java/io/camunda/connector/generator/dsl/http/PropertyUtil.java
@@ -61,10 +61,11 @@ public class PropertyUtil {
             .map(
                 type -> {
                   String label = type.label();
-                  if (type instanceof HttpAuthentication.ApiKey apiKey) {
+                  if (type instanceof HttpAuthentication.ApiKey apiKey && !apiKey.key().isEmpty()) {
                     label += " (" + apiKey.key() + ")";
                   }
-                  if (type instanceof HttpAuthentication.BasicAuth basicAuth) {
+                  if (type instanceof HttpAuthentication.BasicAuth basicAuth
+                      && !basicAuth.key.isEmpty()) {
                     label += " (" + basicAuth.key + ")";
                   }
                   return new DropdownProperty.DropdownChoice(label, type.id());
@@ -164,7 +165,6 @@ public class PropertyUtil {
 
     List<Property> properties = new ArrayList<>();
     if (authentications.size() > 1) {
-
       var discriminator =
           authDiscriminatorPropertyPrefab(authentications)
               .condition(
@@ -200,7 +200,7 @@ public class PropertyUtil {
                           .build())
               .toList();
 
-      properties.addAll(authProperties); // second added has id = null
+      properties.addAll(authProperties);
     }
 
     // handle operation-specific auth types

--- a/element-template-generator/openapi-parser/src/main/java/io/camunda/connector/generator/openapi/util/SecurityUtil.java
+++ b/element-template-generator/openapi-parser/src/main/java/io/camunda/connector/generator/openapi/util/SecurityUtil.java
@@ -23,6 +23,7 @@ import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
 import io.swagger.v3.oas.models.security.SecurityScheme.Type;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
@@ -37,7 +38,15 @@ public class SecurityUtil {
 
   public static List<HttpAuthentication> parseAuthentication(
       List<SecurityRequirement> security, Components components) {
-    if (security == null) {
+
+    boolean operationSecuritySchemeOverwritesGlobalWithNoAuth =
+        (security != null && security.isEmpty());
+    boolean operationSecuritySchemeAndGlobalSchemeIsEmtpy =
+        (security == null && components == null)
+            || (security == null && components.getSecuritySchemes() == null);
+
+    if (operationSecuritySchemeOverwritesGlobalWithNoAuth
+        || operationSecuritySchemeAndGlobalSchemeIsEmtpy) {
       LOG.info("No security schemes found, providing default security section");
       return List.of(
           new HttpAuthentication.NoAuth(),
@@ -45,6 +54,10 @@ public class SecurityUtil {
           new HttpAuthentication.BearerAuth(),
           new HttpAuthentication.OAuth2("", Set.of("")),
           new HttpAuthentication.ApiKey("", "", ""));
+    }
+    boolean operationSecuritySchemeIsEmptyFallbackToGlobal = (security == null);
+    if (operationSecuritySchemeIsEmptyFallbackToGlobal) {
+      return Collections.emptyList();
     }
 
     List<HttpAuthentication> result = new ArrayList<>();

--- a/element-template-generator/openapi-parser/src/main/java/io/camunda/connector/generator/openapi/util/SecurityUtil.java
+++ b/element-template-generator/openapi-parser/src/main/java/io/camunda/connector/generator/openapi/util/SecurityUtil.java
@@ -23,7 +23,6 @@ import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
 import io.swagger.v3.oas.models.security.SecurityScheme.Type;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
@@ -39,7 +38,13 @@ public class SecurityUtil {
   public static List<HttpAuthentication> parseAuthentication(
       List<SecurityRequirement> security, Components components) {
     if (security == null) {
-      return Collections.emptyList();
+      LOG.info("No security schemes found, providing default security section");
+      return List.of(
+          new HttpAuthentication.NoAuth(),
+          new HttpAuthentication.BasicAuth(""),
+          new HttpAuthentication.BearerAuth(),
+          new HttpAuthentication.OAuth2("", Set.of("")),
+          new HttpAuthentication.ApiKey("", "", ""));
     }
 
     List<HttpAuthentication> result = new ArrayList<>();

--- a/element-template-generator/openapi-parser/src/test/java/io/camunda/connector/generator/openapi/SecurityUtilTest.java
+++ b/element-template-generator/openapi-parser/src/test/java/io/camunda/connector/generator/openapi/SecurityUtilTest.java
@@ -1,0 +1,191 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.generator.openapi;
+
+import static io.camunda.connector.generator.openapi.util.SecurityUtil.parseAuthentication;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.connector.generator.dsl.http.HttpAuthentication;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.parser.OpenAPIV3Parser;
+import io.swagger.v3.parser.core.models.SwaggerParseResult;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+public class SecurityUtilTest {
+
+  void assertThatDefaultAuthSectionIsUsed(List<HttpAuthentication> auth) {
+    assertThat(auth).hasSize(5);
+  }
+
+  @Test
+  void shouldHandleNoAuthCorrectly() {
+    // language=yaml
+    String yaml =
+        """
+      openapi: 3.0.0
+      info:
+        title: test
+        version: 1.0.0
+      servers:
+        - url: https://example.com
+      paths:
+        /health:
+          get:
+            summary: Health check, no auth
+            responses:
+              '200': { description: OK }
+      """;
+
+    SwaggerParseResult result = new OpenAPIV3Parser().readContents(yaml, null, null);
+    OpenAPI openAPI = result.getOpenAPI();
+
+    var authHealthPath =
+        parseAuthentication(
+            openAPI.getPaths().get("/health").getGet().getSecurity(), openAPI.getComponents());
+    var authGlobal = parseAuthentication(openAPI.getSecurity(), openAPI.getComponents());
+
+    assertThatDefaultAuthSectionIsUsed(authHealthPath);
+    assertThatDefaultAuthSectionIsUsed(authGlobal);
+  }
+
+  @Test
+  void shouldHandleOperationAuthCorrectly() {
+    // language=yaml
+    String yaml =
+        """
+      openapi: 3.0.0
+      info:
+        title: test
+        version: 1.0.0
+      servers:
+        - url: https://example.com
+      paths:
+        /secure:
+          get:
+            summary: Returns a greeting
+            security:
+              - bearerAuth: []
+            responses:
+              '200': { description: OK }
+      components:
+        securitySchemes:
+          bearerAuth:
+            type: http
+            scheme: bearer
+            bearerFormat: JWT
+      """;
+
+    SwaggerParseResult result = new OpenAPIV3Parser().readContents(yaml, null, null);
+    OpenAPI openAPI = result.getOpenAPI();
+
+    var authSecurePath =
+        parseAuthentication(
+            openAPI.getPaths().get("/secure").getGet().getSecurity(), openAPI.getComponents());
+    var authGlobal = parseAuthentication(openAPI.getSecurity(), openAPI.getComponents());
+
+    assertThat(authSecurePath).hasSize(1);
+    assertThat(authGlobal).hasSize(0);
+  }
+
+  @Test
+  void shouldHandleGlobalAuthCorrectly() {
+    // language=yaml
+    String yaml =
+        """
+      openapi: 3.0.0
+      info:
+        title: test
+        version: 1.0.0
+      servers:
+        - url: https://example.com
+      paths:
+        /secure:
+          get:
+            summary: Returns a greeting
+            responses:
+              '200': { description: OK }
+      security:
+        - bearerAuth: []
+      components:
+        securitySchemes:
+          bearerAuth:
+            type: http
+            scheme: bearer
+            bearerFormat: JWT
+      """;
+
+    SwaggerParseResult result = new OpenAPIV3Parser().readContents(yaml, null, null);
+    OpenAPI openAPI = result.getOpenAPI();
+
+    var authSecurePath =
+        parseAuthentication(
+            openAPI.getPaths().get("/secure").getGet().getSecurity(), openAPI.getComponents());
+    var authGlobal = parseAuthentication(openAPI.getSecurity(), openAPI.getComponents());
+
+    assertThat(authSecurePath).hasSize(0);
+    assertThat(authGlobal).hasSize(1);
+  }
+
+  @Test
+  void shouldHandleAuthAndNoAuthMixedCorrectly() {
+    // language=yaml
+    String yaml =
+        """
+      openapi: 3.0.0
+      info:
+        title: test
+        version: 1.0.0
+      servers:
+        - url: https://example.com
+      components:
+        securitySchemes:
+          bearerAuth:
+            type: http
+            scheme: bearer
+      security:
+        - bearerAuth: []
+      paths:
+        /secure:
+          get:
+            summary: Needs token
+            responses:
+              '200': { description: OK }
+        /health:
+          get:
+            summary: Health check, no auth
+            security: []
+            responses:
+              '200': { description: OK }
+      """;
+
+    SwaggerParseResult result = new OpenAPIV3Parser().readContents(yaml, null, null);
+    OpenAPI openAPI = result.getOpenAPI();
+
+    var authSecurePath =
+        parseAuthentication(
+            openAPI.getPaths().get("/secure").getGet().getSecurity(), openAPI.getComponents());
+    var authHealthPath =
+        parseAuthentication(
+            openAPI.getPaths().get("/health").getGet().getSecurity(), openAPI.getComponents());
+    var authGlobal = parseAuthentication(openAPI.getSecurity(), openAPI.getComponents());
+
+    assertThat(authSecurePath).hasSize(0); // empty value will be overwritten by global
+    assertThatDefaultAuthSectionIsUsed(authHealthPath);
+    assertThat(authGlobal).hasSize(1);
+  }
+}


### PR DESCRIPTION
## Description
- Added the default auth section with all options if providing a openAPI spec with no security section.
- added some missing ids to avoid duplicated keys


## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #4296 

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.

## Testing

Here are some test files I used for testing:
[test.zip](https://github.com/user-attachments/files/19547782/test.zip)

I used nginx to verify the api keys worked properly with this endpoint config:
```
    location /test-api-key {
        default_type application/json;
        add_header sendApiKeyHeader $http_keynameabc;
        add_header sendApiKeyQuery $arg_keynameABC;
        return 201;
    }
```
