### PR TITLE
fix(config): failsafe cluster id prop in saas

### DIFF
--- a/bundle/camunda-saas-bundle/src/main/java/io/camunda/connector/runtime/saas/SaaSConfiguration.java
+++ b/bundle/camunda-saas-bundle/src/main/java/io/camunda/connector/runtime/saas/SaaSConfiguration.java
@@ -37,7 +37,7 @@ public class SaaSConfiguration {
   @Value("${camunda.saas.secrets.internalPrefix:internal-connector-secrets}")
   private String secretsInternalNamePrefix;
 
-  @Value("${camunda.client.clusterId}")
+  @Value("${camunda.client.cloud.clusterId:${camunda.client.clusterId}}")
   private String clusterId;
 
   @Bean


### PR DESCRIPTION
## Description

`camunda.client.clusterId` is now deprecated. We should switch to `camunda.client.cloud.clusterId` in a failsafe way.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #

## Checklist

- [ ] PR has a **milestone** or the `no milestone` label.

