### PR TITLE
fix: use camunda-platform-VERSION for git-refs and not alpha

### DIFF
--- a/.github/workflows/helm-git-refs.json
+++ b/.github/workflows/helm-git-refs.json
@@ -1,6 +1,6 @@
 {
-  "main": "camunda-platform-alpha",
-  "release/8.7": "camunda-platform-alpha",
+  "main": "camunda-platform-8.8",
+  "release/8.7": "camunda-platform-8.7",
   "release/8.6": "camunda-platform-8.6",
   "release/8.5": "camunda-platform-8.5",
   "release/8.4": "camunda-platform-8.4",


### PR DESCRIPTION
## Description

we recently switched from using camunda-platform-alpha and camunda-platform-alpha-8.8  to using camunda-platform-8.7 and camunda-platform-8.8 . we have symlinks for compatibility but they seemed to not work well with the `helm dependency update` command.

<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #

## Checklist

- [ ] PR has a **milestone** or the `no milestone` label.

