### PR TITLE
fix(config): revert failsafe config for cluster id

### DIFF
--- a/bundle/camunda-saas-bundle/src/main/java/io/camunda/connector/runtime/saas/SaaSConfiguration.java
+++ b/bundle/camunda-saas-bundle/src/main/java/io/camunda/connector/runtime/saas/SaaSConfiguration.java
@@ -37,7 +37,7 @@ public class SaaSConfiguration {
   @Value("${camunda.saas.secrets.internalPrefix:internal-connector-secrets}")
   private String secretsInternalNamePrefix;
 
-  @Value("${camunda.client.cloud.clusterId:${camunda.client.clusterId}}")
+  @Value("${camunda.client.cloud.clusterId}")
   private String clusterId;
 
   @Bean


### PR DESCRIPTION
## Description

Revert the failsafe client id reference and use the new format. This was not a good idea.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #

## Checklist

- [ ] PR has a **milestone** or the `no milestone` label.

