### PR TITLE
chore(renovate): Add grouping and schedule to renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,11 @@
 {
   "extends": [
-    "config:recommended"
+    "config:recommended",
+    "group:allNonMajor",
+    "schedule:earlyMondays",
+    "schedule:automergeNonOfficeHours"
   ],
+  "timezone": "Europe/Berlin",
   "labels": [
     "dependencies",
     "no milestone"


### PR DESCRIPTION
## Description
Added some improvements to the renovate config.

`group:allNonMajor`
- one PR for all minor and patch updates instead of a separate PR for every one of them.
- Because of grouping i expect all the dependency updates blocked by rate limiting ([see dashboard](https://github.com/camunda/connectors/issues/72)), will now come now.

`schedule:earlyMondays` at monday 4am the PRs are created

`schedule:automergeNonOfficeHours` at non office hours the PRs are merged, so we do not get blocked because renovate fills our merge queue during working hours.

Timezone: Europe/Berlin


## Related issues
closes #4558

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.

