### PR TITLE
chore(deps): pin httpcore5-h2 due to an incompatibility in camunda client

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -406,6 +406,12 @@ limitations under the License.</license.inlineheader>
 
       <dependency>
         <groupId>org.apache.httpcomponents.core5</groupId>
+        <artifactId>httpcore5-h2</artifactId>
+        <version>${version.httpcore5}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.apache.httpcomponents.core5</groupId>
         <artifactId>httpcore5</artifactId>
         <version>${version.httpcore5}</version>
       </dependency>


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
Pin httpcore5-h2 dependency, as the Camunda client imports a different version that causes issues on our side when starting the Runtime. The runtime starts, but the httpclient thread dies, which means nothing can be done.

## Checklist

- [ ] PR has a **milestone** or the `no milestone` label.

