### PR TITLE
chore(renovate): Add ignore of replacement updates and migrate outdated rule

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -31,7 +31,7 @@
     },
     {
       "matchBaseBranches": [
-        "/^release/.*/"
+        "release/*"
       ],
       "matchUpdateTypes": [
         "major"
@@ -40,20 +40,21 @@
     },
     {
       "matchBaseBranches": [
-        "/^release/.*/"
+        "release/*"
       ],
       "matchPackageNames": [
-        "io.camunda**"
+        "io.camunda*"
       ],
       "matchUpdateTypes": [
         "major",
-        "minor"
+        "minor",
+        "replacement"
       ],
       "enabled": false
     },
     {
-      "matchPackagePrefixes": [
-        "io.camunda.connector"
+      "matchPackageNames": [
+        "io.camunda.connector{/,}**"
       ],
       "enabled": false
     }


### PR DESCRIPTION
## Description

- add replacement to ignore patterns, needed because zeebe-client dependency was moved
- migrated `matchPackagePrefixes` matcher, that no longer exists
- improved readability of matchings


## Checklist

- [x] PR has a **milestone** or the `no milestone` label.

