### PR TITLE
others(uniquet): modify the uniquet now uses engine from element-template

### DIFF
--- a/element-template-generator/uniquet/src/main/java/io/camunda/connector/uniquet/core/GitCrawler.java
+++ b/element-template-generator/uniquet/src/main/java/io/camunda/connector/uniquet/core/GitCrawler.java
@@ -18,6 +18,7 @@ package io.camunda.connector.uniquet.core;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
+import io.camunda.connector.uniquet.dto.ElementTemplate;
 import io.camunda.connector.uniquet.dto.Engine;
 import io.camunda.connector.uniquet.dto.OutputElementTemplate;
 import io.camunda.connector.uniquet.dto.VersionValue;
@@ -77,6 +78,23 @@ public class GitCrawler {
     new ElementTemplateIterator(repository, commit)
         .forEachRemaining(
             elementTemplateFile -> {
+              VersionValue insertableVersionValue =
+                  Optional.ofNullable(elementTemplateFile.elementTemplate())
+                      .map(ElementTemplate::engines)
+                      .map(Engine::camunda)
+                      .map(
+                          s ->
+                              (VersionValue)
+                                  new VersionValue.ImmutableVersionValue(
+                                      RAW_GITHUB_LINK.formatted(
+                                          commit.getName(), elementTemplateFile.path()),
+                                      s))
+                      .orElse(
+                          new VersionValue.MutableVersionValue(
+                              RAW_GITHUB_LINK.formatted(
+                                  commit.getName(), elementTemplateFile.path()),
+                              elementTemplateFile.connectorRuntime()));
+
               if (result.containsKey(elementTemplateFile.elementTemplate().id())) {
                 result
                     .get(elementTemplateFile.elementTemplate().id())
@@ -84,22 +102,12 @@ public class GitCrawler {
                         elementTemplateFile.elementTemplate().version(),
                         (integer, versionValue) ->
                             Optional.ofNullable(versionValue)
-                                .map(
-                                    vv ->
-                                        new VersionValue(
-                                            vv.link(), elementTemplateFile.connectorRuntime()))
-                                .orElse(
-                                    new VersionValue(
-                                        RAW_GITHUB_LINK.formatted(
-                                            commit.getName(), elementTemplateFile.path()),
-                                        elementTemplateFile.connectorRuntime())));
+                                .map(vv -> vv.changeRuntime(elementTemplateFile.connectorRuntime()))
+                                .orElse(insertableVersionValue));
               } else {
                 Map<Integer, VersionValue> version = new HashMap<>();
                 version.put(
-                    elementTemplateFile.elementTemplate().version(),
-                    new VersionValue(
-                        RAW_GITHUB_LINK.formatted(commit.getName(), elementTemplateFile.path()),
-                        elementTemplateFile.connectorRuntime()));
+                    elementTemplateFile.elementTemplate().version(), insertableVersionValue);
                 result.put(elementTemplateFile.elementTemplate().id(), version);
               }
             });

--- a/element-template-generator/uniquet/src/main/java/io/camunda/connector/uniquet/core/GitCrawler.java
+++ b/element-template-generator/uniquet/src/main/java/io/camunda/connector/uniquet/core/GitCrawler.java
@@ -19,7 +19,6 @@ package io.camunda.connector.uniquet.core;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import io.camunda.connector.uniquet.dto.*;
-
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
@@ -54,22 +53,20 @@ public class GitCrawler {
     }
   }
 
-  private static VersionValue getVersionValue(RevCommit commit, ElementTemplateFile elementTemplateFile) {
-      return Optional.ofNullable(elementTemplateFile.elementTemplate())
-          .map(ElementTemplate::engines)
-          .map(Engine::camunda)
-          .map(
-              s ->
-                  (VersionValue)
-                      new VersionValue.ImmutableVersionValue(
-                          RAW_GITHUB_LINK.formatted(
-                              commit.getName(), elementTemplateFile.path()),
-                          s))
-          .orElse(
-              new VersionValue.MutableVersionValue(
-                  RAW_GITHUB_LINK.formatted(
-                      commit.getName(), elementTemplateFile.path()),
-                  elementTemplateFile.connectorRuntime()));
+  private static VersionValue getVersionValue(
+      RevCommit commit, ElementTemplateFile elementTemplateFile) {
+    return Optional.ofNullable(elementTemplateFile.elementTemplate())
+        .map(ElementTemplate::engines)
+        .map(Engine::camunda)
+        .map(
+            s ->
+                (VersionValue)
+                    new VersionValue.ImmutableVersionValue(
+                        RAW_GITHUB_LINK.formatted(commit.getName(), elementTemplateFile.path()), s))
+        .orElse(
+            new VersionValue.MutableVersionValue(
+                RAW_GITHUB_LINK.formatted(commit.getName(), elementTemplateFile.path()),
+                elementTemplateFile.connectorRuntime()));
   }
 
   public Map<String, Map<Integer, VersionValue>> getResult() {

--- a/element-template-generator/uniquet/src/main/java/io/camunda/connector/uniquet/dto/ElementTemplate.java
+++ b/element-template-generator/uniquet/src/main/java/io/camunda/connector/uniquet/dto/ElementTemplate.java
@@ -21,4 +21,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public record ElementTemplate(
-    @JsonProperty(required = true) String id, @JsonProperty(required = true) Integer version) {}
+    @JsonProperty(required = true) String id,
+    @JsonProperty(required = true) Integer version,
+    Engine engines) {}

--- a/element-template-generator/uniquet/src/main/java/io/camunda/connector/uniquet/dto/VersionValue.java
+++ b/element-template-generator/uniquet/src/main/java/io/camunda/connector/uniquet/dto/VersionValue.java
@@ -16,4 +16,27 @@
  */
 package io.camunda.connector.uniquet.dto;
 
-public record VersionValue(String link, String connectorRuntime) {}
+public sealed interface VersionValue {
+
+  VersionValue changeRuntime(String connectorRuntime);
+
+  String link();
+
+  String connectorRuntime();
+
+  record MutableVersionValue(String link, String connectorRuntime) implements VersionValue {
+
+    @Override
+    public VersionValue changeRuntime(String connectorRuntime) {
+      return new MutableVersionValue(link, connectorRuntime);
+    }
+  }
+
+  record ImmutableVersionValue(String link, String connectorRuntime) implements VersionValue {
+
+    @Override
+    public VersionValue changeRuntime(String connectorRuntime) {
+      return this;
+    }
+  }
+}


### PR DESCRIPTION
## Description

discussed with @sbuettner, uniquet should now use the engine from the element template, otherwise work as before


## Checklist

- [ ] PR has a **milestone** or the `no milestone` label.

