### PR TITLE
chore(renovate): Increase pr hourly limit to 10

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,6 +10,7 @@
     "dependencies",
     "no milestone"
   ],
+  "prHourlyLimit": 10,
   "packageRules": [
     {
       "matchManagers": [


### PR DESCRIPTION
## Description

Increase the pr hourly limit to 10, so when renovate is running on Sunday night it can open up to 10 PRs and is not blocking itself until next week

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.

