### PR TITLE
chore(fossa): extend integration to stable branches and tags

### DIFF
--- a/.fossa.yml
+++ b/.fossa.yml
@@ -3,6 +3,7 @@ version: 3
 project:
   id: camunda/connectors
   labels:
+  - camunda8
   - connectors
   policy: Camunda8 Distribution
   url: https://github.com/camunda/connectors

--- a/.github/workflows/CHECK_LICENSES.yml
+++ b/.github/workflows/CHECK_LICENSES.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
     - main
+    - release/*
+    tags:
+    - '*'
 
 jobs:
   analyze:


### PR DESCRIPTION
## Description

Related to https://github.com/camunda/team-infrastructure/issues/751 and previous PR https://github.com/camunda/connectors/pull/4416.

This PR extends the FOSSA integration to include stable branches and tags in addition to the `main` branch. Like the previous PR, it only pushes data (dependency graph) to FOSSA and does not introduce any blocking checks.

Internally, if the commit has already been scanned by FOSSA (e.g., in the main branch), it will just refer to the existing scan (using the revision ID). If no scan exists (it might happen), a new scan will be triggered and performed by FOSSA (internally).

`${{ github.ref_name }}` retrieves the tag name, as for the branch. Tests with tags have been performed on a separate test repository.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #

## Checklist

- [ ] PR has a **milestone** or the `no milestone` label.

