### PR TITLE
others(etg): Add connector type an version to etg (add metrics)

### DIFF
--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/MeteredInboundCorrelationHandler.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/MeteredInboundCorrelationHandler.java
@@ -45,9 +45,7 @@ public class MeteredInboundCorrelationHandler extends InboundCorrelationHandler 
   public boolean isActivationConditionMet(InboundConnectorElement def, Object context) {
     boolean isConditionMet = super.isActivationConditionMet(def, context);
     if (!isConditionMet) {
-      String type = def.type();
-      String version = String.valueOf(def.element().version());
-      this.connectorsInboundMetrics.increaseActivationConditionFailure(type, version);
+      this.connectorsInboundMetrics.increaseActivationConditionFailure(def);
     }
     return isConditionMet;
   }
@@ -58,15 +56,13 @@ public class MeteredInboundCorrelationHandler extends InboundCorrelationHandler 
     if (elementList.isEmpty()) {
       throw new IllegalArgumentException("No elements to correlate, potential API misuse");
     }
-    String type = elementList.getFirst().type();
-    String version = elementList.getFirst().element().elementTemplateDetails().version();
-    this.connectorsInboundMetrics.increaseTrigger(type, version);
+    this.connectorsInboundMetrics.increaseTrigger(elementList.getFirst());
     try {
       var result = super.correlate(elementList, correlationRequest);
-      this.connectorsInboundMetrics.increaseCorrelationSuccess(type, version);
+      this.connectorsInboundMetrics.increaseCorrelationSuccess(elementList.getFirst());
       return result;
     } catch (Exception e) {
-      this.connectorsInboundMetrics.increaseCorrelationFailure(type, version);
+      this.connectorsInboundMetrics.increaseCorrelationFailure(elementList.getFirst());
       throw e;
     }
   }

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/MeteredInboundCorrelationHandler.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/MeteredInboundCorrelationHandler.java
@@ -17,55 +17,56 @@
 package io.camunda.connector.runtime.inbound;
 
 import io.camunda.client.CamundaClient;
+import io.camunda.connector.api.inbound.CorrelationRequest;
 import io.camunda.connector.api.inbound.CorrelationResult;
 import io.camunda.connector.feel.FeelEngineWrapper;
 import io.camunda.connector.runtime.core.inbound.InboundConnectorElement;
 import io.camunda.connector.runtime.core.inbound.ProcessElementContextFactory;
 import io.camunda.connector.runtime.core.inbound.correlation.InboundCorrelationHandler;
-import io.camunda.connector.runtime.metrics.ConnectorMetrics.Inbound;
-import io.camunda.spring.client.metrics.MetricsRecorder;
+import io.camunda.connector.runtime.metrics.ConnectorsInboundMetrics;
 import java.time.Duration;
 import java.util.List;
 
 public class MeteredInboundCorrelationHandler extends InboundCorrelationHandler {
 
-  private final MetricsRecorder metricsRecorder;
+  private final ConnectorsInboundMetrics connectorsInboundMetrics;
 
   public MeteredInboundCorrelationHandler(
       CamundaClient camundaClient,
       FeelEngineWrapper feelEngine,
-      MetricsRecorder metricsRecorder,
       ProcessElementContextFactory contextFactory,
-      Duration messageTtl) {
+      Duration messageTtl,
+      ConnectorsInboundMetrics connectorsInboundMetrics) {
     super(camundaClient, feelEngine, contextFactory, messageTtl);
-    this.metricsRecorder = metricsRecorder;
+    this.connectorsInboundMetrics = connectorsInboundMetrics;
   }
 
   @Override
   public boolean isActivationConditionMet(InboundConnectorElement def, Object context) {
     boolean isConditionMet = super.isActivationConditionMet(def, context);
     if (!isConditionMet) {
-      metricsRecorder.increase(
-          Inbound.METRIC_NAME_TRIGGERS, Inbound.ACTION_ACTIVATION_CONDITION_FAILED, def.type());
+      String type = def.type();
+      String version = String.valueOf(def.element().version());
+      this.connectorsInboundMetrics.increaseActivationConditionFailure(type, version);
     }
     return isConditionMet;
   }
 
   @Override
-  public CorrelationResult correlate(List<InboundConnectorElement> elementList, Object variables) {
+  public CorrelationResult correlate(
+      List<InboundConnectorElement> elementList, CorrelationRequest correlationRequest) {
     if (elementList.isEmpty()) {
       throw new IllegalArgumentException("No elements to correlate, potential API misuse");
     }
-    var type = elementList.getFirst().type();
-    metricsRecorder.increase(Inbound.METRIC_NAME_TRIGGERS, Inbound.ACTION_TRIGGERED, type);
-
+    String type = elementList.getFirst().type();
+    String version = elementList.getFirst().element().elementTemplateDetails().version();
+    this.connectorsInboundMetrics.increaseTrigger(type, version);
     try {
-      var result = super.correlate(elementList, variables);
-      metricsRecorder.increase(Inbound.METRIC_NAME_TRIGGERS, Inbound.ACTION_CORRELATED, type);
+      var result = super.correlate(elementList, correlationRequest);
+      this.connectorsInboundMetrics.increaseCorrelationSuccess(type, version);
       return result;
     } catch (Exception e) {
-      metricsRecorder.increase(
-          Inbound.METRIC_NAME_TRIGGERS, Inbound.ACTION_CORRELATION_FAILED, type);
+      this.connectorsInboundMetrics.increaseCorrelationFailure(type, version);
       throw e;
     }
   }

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/executable/BatchExecutableProcessor.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/executable/BatchExecutableProcessor.java
@@ -192,7 +192,6 @@ public class BatchExecutableProcessor {
 
     if (metricsRecorder != null) {
       var type = data.type() + "#" + data.connectorElements().getFirst().element().version();
-      System.out.println("==================================>" + type);
       metricsRecorder.increase(Inbound.METRIC_NAME_ACTIVATIONS, Inbound.ACTION_ACTIVATED, type);
     }
 

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/executable/BatchExecutableProcessor.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/executable/BatchExecutableProcessor.java
@@ -178,6 +178,7 @@ public class BatchExecutableProcessor {
       executable.activate(context);
     } catch (Exception e) {
       LOG.error("Failed to activate connector", e);
+      connectorsInboundMetrics.increaseActivationFailure(data.connectorElements().getFirst());
       return new FailedToActivate(data, e.getMessage());
     }
     LOG.info(

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/executable/BatchExecutableProcessor.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/executable/BatchExecutableProcessor.java
@@ -170,7 +170,6 @@ public class BatchExecutableProcessor {
                   "Webhook connectors are not supported in this environment")));
       return new ConnectorNotRegistered(validData);
     }
-
     try {
       if (executable instanceof WebhookConnectorExecutable) {
         LOG.debug("Registering webhook: {}", data.type());
@@ -181,16 +180,11 @@ public class BatchExecutableProcessor {
       LOG.error("Failed to activate connector", e);
       return new FailedToActivate(data, e.getMessage());
     }
-
     LOG.info(
         "Inbound connector {} activated with deduplication ID '{}'",
         data.type(),
         data.deduplicationId());
-
-    String elementTemplateId = data.connectorElements().getFirst().type();
-    String elementTemplateVersion =
-        data.connectorElements().getFirst().element().elementTemplateDetails().version();
-    connectorsInboundMetrics.increaseActivation(elementTemplateId, elementTemplateVersion);
+    connectorsInboundMetrics.increaseActivation(data.connectorElements().getFirst());
     return new Activated(executable, context);
   }
 
@@ -208,17 +202,8 @@ public class BatchExecutableProcessor {
         } catch (Exception e) {
           LOG.error("Failed to deactivate executable", e);
         }
-        String elementTemplateId = activated.context().connectorElements().getFirst().type();
-        String elementTemplateVersion =
-            activated
-                .context()
-                .connectorElements()
-                .getFirst()
-                .element()
-                .elementTemplateDetails()
-                .version();
         connectorsInboundMetrics.increaseDeactivation(
-            elementTemplateId, String.valueOf(elementTemplateVersion));
+            activated.context().connectorElements().getFirst());
       }
     }
   }

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/executable/BatchExecutableProcessor.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/executable/BatchExecutableProcessor.java
@@ -191,8 +191,9 @@ public class BatchExecutableProcessor {
         data.deduplicationId());
 
     if (metricsRecorder != null) {
-      metricsRecorder.increase(
-          Inbound.METRIC_NAME_ACTIVATIONS, Inbound.ACTION_ACTIVATED, data.type());
+      var type = data.type() + "#" + data.connectorElements().getFirst().element().version();
+      System.out.println("==================================>" + type);
+      metricsRecorder.increase(Inbound.METRIC_NAME_ACTIVATIONS, Inbound.ACTION_ACTIVATED, type);
     }
 
     return new Activated(executable, context);
@@ -213,10 +214,13 @@ public class BatchExecutableProcessor {
           LOG.error("Failed to deactivate executable", e);
         }
         if (metricsRecorder != null) {
+          var type =
+              activated.context().getDefinition().type()
+                  + "#"
+                  + activated.context().connectorElements().getFirst().element().version();
+          System.out.println(type);
           metricsRecorder.increase(
-              Inbound.METRIC_NAME_ACTIVATIONS,
-              Inbound.ACTION_DEACTIVATED,
-              activated.context().getDefinition().type());
+              Inbound.METRIC_NAME_ACTIVATIONS, Inbound.ACTION_DEACTIVATED, type);
         }
       }
     }

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/importer/ProcessDefinitionImportConfiguration.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/importer/ProcessDefinitionImportConfiguration.java
@@ -18,7 +18,7 @@ package io.camunda.connector.runtime.inbound.importer;
 
 import io.camunda.connector.runtime.inbound.search.SearchQueryClient;
 import io.camunda.connector.runtime.inbound.state.ProcessStateStore;
-import io.camunda.spring.client.metrics.MetricsRecorder;
+import io.camunda.connector.runtime.metrics.ConnectorsInboundMetrics;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -34,7 +34,7 @@ public class ProcessDefinitionImportConfiguration {
   public ProcessDefinitionImporter processDefinitionImporter(
       ProcessStateStore stateStore,
       ProcessDefinitionSearch search,
-      MetricsRecorder metricsRecorder) {
-    return new ProcessDefinitionImporter(stateStore, search, metricsRecorder);
+      ConnectorsInboundMetrics connectorsInboundMetrics) {
+    return new ProcessDefinitionImporter(stateStore, search, connectorsInboundMetrics);
   }
 }

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/importer/ProcessDefinitionImporter.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/importer/ProcessDefinitionImporter.java
@@ -21,8 +21,7 @@ import io.camunda.connector.runtime.inbound.state.ProcessImportResult;
 import io.camunda.connector.runtime.inbound.state.ProcessImportResult.ProcessDefinitionIdentifier;
 import io.camunda.connector.runtime.inbound.state.ProcessImportResult.ProcessDefinitionVersion;
 import io.camunda.connector.runtime.inbound.state.ProcessStateStore;
-import io.camunda.connector.runtime.metrics.ConnectorMetrics.Inbound;
-import io.camunda.spring.client.metrics.MetricsRecorder;
+import io.camunda.connector.runtime.metrics.ConnectorsInboundMetrics;
 import java.util.*;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
@@ -35,7 +34,7 @@ public class ProcessDefinitionImporter {
   private static final Logger LOG = LoggerFactory.getLogger(ProcessDefinitionImporter.class);
   private final ProcessStateStore stateStore;
   private final ProcessDefinitionSearch search;
-  private final MetricsRecorder metricsRecorder;
+  private final ConnectorsInboundMetrics connectorsInboundMetrics;
 
   private boolean ready = true;
 
@@ -43,10 +42,10 @@ public class ProcessDefinitionImporter {
   public ProcessDefinitionImporter(
       ProcessStateStore stateStore,
       ProcessDefinitionSearch search,
-      @Autowired(required = false) MetricsRecorder metricsRecorder) {
+      ConnectorsInboundMetrics connectorsInboundMetrics) {
     this.stateStore = stateStore;
     this.search = search;
-    this.metricsRecorder = metricsRecorder;
+    this.connectorsInboundMetrics = connectorsInboundMetrics;
   }
 
   @Scheduled(fixedDelayString = "${camunda.connector.polling.interval:5000}")
@@ -87,10 +86,7 @@ public class ProcessDefinitionImporter {
   }
 
   private void meter(int count) {
-    if (metricsRecorder != null) {
-      metricsRecorder.increase(
-          Inbound.METRIC_NAME_INBOUND_PROCESS_DEFINITIONS_CHECKED, null, null, count);
-    }
+    connectorsInboundMetrics.increaseProcessDefinitionsChecked(count);
   }
 
   public boolean isReady() {

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/metrics/ConnectorMetrics.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/metrics/ConnectorMetrics.java
@@ -24,29 +24,16 @@ public class ConnectorMetrics {
 
     public static final String METRIC_NAME_INVOCATIONS = "camunda.connector.outbound.invocations";
     public static final String METRIC_NAME_TIME = "camunda.connector.outbound.execution-time";
-    public static final String METRIC_CONNECTOR_VERSION = "camunda.connector.outbound.activations";
 
     public static final String JOB_RECEIVED = "outbound-connector-job-received";
     // same as job worker metrics from Spring Zeebe
     public static final String ACTION_ACTIVATED = MetricsRecorder.ACTION_ACTIVATED;
     public static final String ACTION_COMPLETED = MetricsRecorder.ACTION_COMPLETED;
     public static final String ACTION_FAILED = MetricsRecorder.ACTION_FAILED;
-    public static final String ACTION_BPMN_ERROR = MetricsRecorder.ACTION_BPMN_ERROR;
   }
 
   public static class Inbound {
-    public static final String METRIC_NAME_ACTIVATIONS = "camunda.connector.inbound.activations";
-    public static final String METRIC_NAME_TRIGGERS = "camunda.connector.inbound.triggers";
     public static final String METRIC_NAME_INBOUND_PROCESS_DEFINITIONS_CHECKED =
         "camunda.connector.inbound.process-definitions-checked";
-
-    public static final String ACTION_ACTIVATED = "activated";
-    public static final String ACTION_DEACTIVATED = "deactivated";
-    public static final String ACTION_ACTIVATION_FAILED = "activation-failed";
-
-    public static final String ACTION_TRIGGERED = "triggered";
-    public static final String ACTION_ACTIVATION_CONDITION_FAILED = "activation-condition-failed";
-    public static final String ACTION_CORRELATED = "correlated";
-    public static final String ACTION_CORRELATION_FAILED = "correlation-failed";
   }
 }

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/metrics/ConnectorMetrics.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/metrics/ConnectorMetrics.java
@@ -24,7 +24,9 @@ public class ConnectorMetrics {
 
     public static final String METRIC_NAME_INVOCATIONS = "camunda.connector.outbound.invocations";
     public static final String METRIC_NAME_TIME = "camunda.connector.outbound.execution-time";
+    public static final String METRIC_CONNECTOR_VERSION = "camunda.connector.outbound.activations";
 
+    public static final String JOB_RECEIVED = "outbound-connector-job-received";
     // same as job worker metrics from Spring Zeebe
     public static final String ACTION_ACTIVATED = MetricsRecorder.ACTION_ACTIVATED;
     public static final String ACTION_COMPLETED = MetricsRecorder.ACTION_COMPLETED;

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/metrics/ConnectorMetrics.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/metrics/ConnectorMetrics.java
@@ -20,6 +20,14 @@ import io.camunda.spring.client.metrics.MetricsRecorder;
 
 public class ConnectorMetrics {
 
+  public static class Tag {
+
+    public static final String ELEMENT_TEMPLATE_ID = "elementTemplateId";
+    public static final String TYPE = "type";
+    public static final String ACTION = "ACTION";
+    public static final String ELEMENT_TEMPLATE_VERSION = "elementTemplateVersion";
+  }
+
   public static class Outbound {
 
     public static final String METRIC_NAME_INVOCATIONS = "camunda.connector.outbound.invocations";

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/metrics/ConnectorMetrics.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/metrics/ConnectorMetrics.java
@@ -16,29 +16,33 @@
  */
 package io.camunda.connector.runtime.metrics;
 
+import io.camunda.spring.client.metrics.MetricsRecorder;
+
 public class ConnectorMetrics {
 
   public static class Outbound {
 
     public static final String METRIC_NAME_INVOCATIONS = "camunda.connector.outbound.invocations";
-    public static final String METRIC_NAME_COMPLETIONS = "camunda.connector.outbound.completions";
-    public static final String METRIC_NAME_FAILURES = "camunda.connector.outbound.failures";
-    public static final String METRIC_NAME_BPMN_ERRORS = "camunda.connector.outbound.bpmn-errors";
     public static final String METRIC_NAME_TIME = "camunda.connector.outbound.execution-time";
+
+    public static final String ACTION_ACTIVATED = MetricsRecorder.ACTION_ACTIVATED;
+    public static final String ACTION_COMPLETED = MetricsRecorder.ACTION_COMPLETED;
+    public static final String ACTION_FAILED = MetricsRecorder.ACTION_FAILED;
+    public static final String ACTION_BPMN_ERROR = MetricsRecorder.ACTION_BPMN_ERROR;
   }
 
   public static class Inbound {
     public static final String METRIC_NAME_ACTIVATIONS = "camunda.connector.inbound.activations";
-    public static final String METRIC_NAME_DEACTIVATIONS =
-        "camunda.connector.inbound.deactivations";
-    public static final String METRIC_NAME_TRIGGERS = "camunda.connector.inbound.triggers";
-    public static final String METRIC_NAME_CORRELATION_SUCCESS =
-        "camunda.connector.inbound.correlations-success";
-    public static final String METRIC_NAME_CORRELATION_FAILURE =
-        "camunda.connector.inbound.correlations-failure";
-    public static final String METRIC_NAME_ACTIVATION_CONDITION_FAILURE =
-        "camunda.connector.inbound.activation-conditions-failure";
     public static final String METRIC_NAME_INBOUND_PROCESS_DEFINITIONS_CHECKED =
         "camunda.connector.inbound.process-definitions-checked";
+
+    public static final String ACTION_ACTIVATED = "activated";
+    public static final String ACTION_DEACTIVATED = "deactivated";
+    public static final String ACTION_ACTIVATION_FAILED = "activation-failed";
+
+    public static final String ACTION_TRIGGERED = "triggered";
+    public static final String ACTION_ACTIVATION_CONDITION_FAILED = "activation-condition-failed";
+    public static final String ACTION_CORRELATED = "correlated";
+    public static final String ACTION_CORRELATION_FAILED = "correlation-failed";
   }
 }

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/metrics/ConnectorMetrics.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/metrics/ConnectorMetrics.java
@@ -24,7 +24,7 @@ public class ConnectorMetrics {
 
     public static final String ELEMENT_TEMPLATE_ID = "elementTemplateId";
     public static final String TYPE = "type";
-    public static final String ACTION = "ACTION";
+    public static final String ACTION = "action";
     public static final String ELEMENT_TEMPLATE_VERSION = "elementTemplateVersion";
   }
 
@@ -41,6 +41,7 @@ public class ConnectorMetrics {
 
   public static class Inbound {
     public static final String METRIC_NAME_ACTIVATIONS = "camunda.connector.inbound.activations";
+    public static final String METRIC_NAME_TRIGGERS = "camunda.connector.inbound.triggers";
     public static final String METRIC_NAME_INBOUND_PROCESS_DEFINITIONS_CHECKED =
         "camunda.connector.inbound.process-definitions-checked";
 

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/metrics/ConnectorMetrics.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/metrics/ConnectorMetrics.java
@@ -16,23 +16,28 @@
  */
 package io.camunda.connector.runtime.metrics;
 
-import io.camunda.spring.client.metrics.MetricsRecorder;
-
 public class ConnectorMetrics {
 
   public static class Outbound {
 
     public static final String METRIC_NAME_INVOCATIONS = "camunda.connector.outbound.invocations";
+    public static final String METRIC_NAME_COMPLETIONS = "camunda.connector.outbound.completions";
+    public static final String METRIC_NAME_FAILURES = "camunda.connector.outbound.failures";
+    public static final String METRIC_NAME_BPMN_ERRORS = "camunda.connector.outbound.bpmn-errors";
     public static final String METRIC_NAME_TIME = "camunda.connector.outbound.execution-time";
-
-    public static final String JOB_RECEIVED = "outbound-connector-job-received";
-    // same as job worker metrics from Spring Zeebe
-    public static final String ACTION_ACTIVATED = MetricsRecorder.ACTION_ACTIVATED;
-    public static final String ACTION_COMPLETED = MetricsRecorder.ACTION_COMPLETED;
-    public static final String ACTION_FAILED = MetricsRecorder.ACTION_FAILED;
   }
 
   public static class Inbound {
+    public static final String METRIC_NAME_ACTIVATIONS = "camunda.connector.inbound.activations";
+    public static final String METRIC_NAME_DEACTIVATIONS =
+        "camunda.connector.inbound.deactivations";
+    public static final String METRIC_NAME_TRIGGERS = "camunda.connector.inbound.triggers";
+    public static final String METRIC_NAME_CORRELATION_SUCCESS =
+        "camunda.connector.inbound.correlations-success";
+    public static final String METRIC_NAME_CORRELATION_FAILURE =
+        "camunda.connector.inbound.correlations-failure";
+    public static final String METRIC_NAME_ACTIVATION_CONDITION_FAILURE =
+        "camunda.connector.inbound.activation-conditions-failure";
     public static final String METRIC_NAME_INBOUND_PROCESS_DEFINITIONS_CHECKED =
         "camunda.connector.inbound.process-definitions-checked";
   }

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/metrics/ConnectorsInboundMetrics.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/metrics/ConnectorsInboundMetrics.java
@@ -16,6 +16,7 @@
  */
 package io.camunda.connector.runtime.metrics;
 
+import io.camunda.connector.runtime.core.inbound.InboundConnectorElement;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.util.Map;
@@ -30,86 +31,104 @@ public class ConnectorsInboundMetrics {
   private final Map<String, Counter> correlationFailureCounter = new ConcurrentHashMap<>();
   private final Map<String, Counter> activationConditionFailureCounter = new ConcurrentHashMap<>();
   private final Map<String, Counter> triggerCounter = new ConcurrentHashMap<>();
+  private final Map<String, Counter> processDefinitionsChecked = new ConcurrentHashMap<>();
 
   public ConnectorsInboundMetrics(MeterRegistry meterRegistry) {
     this.meterRegistry = meterRegistry;
   }
 
-  public void increaseActivation(String connectorType, String version) {
-    String key = connectorType + "_" + version;
+  public void increaseActivation(InboundConnectorElement connectorElement) {
+    Result result = Result.getResult(connectorElement);
     this.activationCounter
         .computeIfAbsent(
-            key,
+            result.key(),
             s ->
-                Counter.builder("connectors_inbound_activation")
-                    .tag("type", connectorType)
-                    .tag("version", version)
+                Counter.builder(ConnectorMetrics.Inbound.METRIC_NAME_ACTIVATIONS)
+                    .tag("type", result.type())
+                    .tag("id", result.id())
+                    .tag("version", result.version())
                     .register(meterRegistry))
         .increment();
   }
 
-  public void increaseDeactivation(String connectorType, String version) {
-    String key = connectorType + "_" + version;
+  public void increaseDeactivation(InboundConnectorElement connectorElement) {
+    Result result = Result.getResult(connectorElement);
     this.deactivationCounter
         .computeIfAbsent(
-            key,
+            result.key(),
             s ->
-                Counter.builder("connectors_inbound_deactivation")
-                    .tag("type", connectorType)
-                    .tag("version", version)
+                Counter.builder(ConnectorMetrics.Inbound.METRIC_NAME_DEACTIVATIONS)
+                    .tag("type", result.type())
+                    .tag("id", result.id())
+                    .tag("version", result.version())
                     .register(meterRegistry))
         .increment();
   }
 
-  public void increaseCorrelationSuccess(String connectorType, String version) {
-    String key = connectorType + "_" + version;
+  public void increaseCorrelationSuccess(InboundConnectorElement connectorElement) {
+    Result result = Result.getResult(connectorElement);
     this.correlationSuccessCounter
         .computeIfAbsent(
-            key,
+            result.key(),
             s ->
-                Counter.builder("connectors_inbound_correlation_success")
-                    .tag("type", connectorType)
-                    .tag("version", version)
+                Counter.builder(ConnectorMetrics.Inbound.METRIC_NAME_CORRELATION_SUCCESS)
+                    .tag("type", result.type())
+                    .tag("id", result.id())
+                    .tag("version", result.version())
                     .register(meterRegistry))
         .increment();
   }
 
-  public void increaseCorrelationFailure(String connectorType, String version) {
-    String key = connectorType + "_" + version;
+  public void increaseCorrelationFailure(InboundConnectorElement connectorElement) {
+    Result result = Result.getResult(connectorElement);
     this.correlationFailureCounter
         .computeIfAbsent(
-            key,
+            result.key(),
             s ->
-                Counter.builder("connectors_inbound_correlation_failure")
-                    .tag("type", connectorType)
-                    .tag("version", version)
+                Counter.builder(ConnectorMetrics.Inbound.METRIC_NAME_CORRELATION_FAILURE)
+                    .tag("type", result.type())
+                    .tag("id", result.id())
+                    .tag("version", result.version())
                     .register(meterRegistry))
         .increment();
   }
 
-  public void increaseTrigger(String connectorType, String version) {
-    String key = connectorType + "_" + version;
+  public void increaseTrigger(InboundConnectorElement connectorElement) {
+    Result result = Result.getResult(connectorElement);
     this.triggerCounter
         .computeIfAbsent(
-            key,
+            result.key(),
             s ->
-                Counter.builder("connectors_inbound_triggered")
-                    .tag("type", connectorType)
-                    .tag("version", version)
+                Counter.builder(ConnectorMetrics.Inbound.METRIC_NAME_TRIGGERS)
+                    .tag("type", result.type())
+                    .tag("id", result.id())
+                    .tag("version", result.version())
                     .register(meterRegistry))
         .increment();
   }
 
-  public void increaseActivationConditionFailure(String connectorType, String version) {
-    String key = connectorType + "_" + version;
+  public void increaseActivationConditionFailure(InboundConnectorElement connectorElement) {
+    Result result = Result.getResult(connectorElement);
     this.activationConditionFailureCounter
         .computeIfAbsent(
-            key,
+            result.key(),
             s ->
-                Counter.builder("connectors_inbound_activation_condition_failure")
-                    .tag("type", connectorType)
-                    .tag("version", version)
+                Counter.builder(ConnectorMetrics.Inbound.METRIC_NAME_ACTIVATION_CONDITION_FAILURE)
+                    .tag("type", result.type())
+                    .tag("id", result.id())
+                    .tag("version", result.version())
                     .register(meterRegistry))
         .increment();
+  }
+
+  public void increaseProcessDefinitionsChecked(int count) {
+    this.processDefinitionsChecked
+        .computeIfAbsent(
+            "PROCESS_DEFINITIONS_CHECKED",
+            s ->
+                Counter.builder(
+                        ConnectorMetrics.Inbound.METRIC_NAME_INBOUND_PROCESS_DEFINITIONS_CHECKED)
+                    .register(meterRegistry))
+        .increment(count);
   }
 }

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/metrics/ConnectorsInboundMetrics.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/metrics/ConnectorsInboundMetrics.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.runtime.metrics;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class ConnectorsInboundMetrics {
+
+  private final MeterRegistry meterRegistry;
+  private final Map<String, Counter> activationCounter = new ConcurrentHashMap<>();
+  private final Map<String, Counter> deactivationCounter = new ConcurrentHashMap<>();
+  private final Map<String, Counter> correlationSuccessCounter = new ConcurrentHashMap<>();
+  private final Map<String, Counter> correlationFailureCounter = new ConcurrentHashMap<>();
+  private final Map<String, Counter> activationConditionFailureCounter = new ConcurrentHashMap<>();
+  private final Map<String, Counter> triggerCounter = new ConcurrentHashMap<>();
+
+  public ConnectorsInboundMetrics(MeterRegistry meterRegistry) {
+    this.meterRegistry = meterRegistry;
+  }
+
+  public void increaseActivation(String connectorType, String version) {
+    String key = connectorType + "_" + version;
+    this.activationCounter
+        .computeIfAbsent(
+            key,
+            s ->
+                Counter.builder("connectors_inbound_activation")
+                    .tag("type", connectorType)
+                    .tag("version", version)
+                    .register(meterRegistry))
+        .increment();
+  }
+
+  public void increaseDeactivation(String connectorType, String version) {
+    String key = connectorType + "_" + version;
+    this.deactivationCounter
+        .computeIfAbsent(
+            key,
+            s ->
+                Counter.builder("connectors_inbound_deactivation")
+                    .tag("type", connectorType)
+                    .tag("version", version)
+                    .register(meterRegistry))
+        .increment();
+  }
+
+  public void increaseCorrelationSuccess(String connectorType, String version) {
+    String key = connectorType + "_" + version;
+    this.correlationSuccessCounter
+        .computeIfAbsent(
+            key,
+            s ->
+                Counter.builder("connectors_inbound_correlation_success")
+                    .tag("type", connectorType)
+                    .tag("version", version)
+                    .register(meterRegistry))
+        .increment();
+  }
+
+  public void increaseCorrelationFailure(String connectorType, String version) {
+    String key = connectorType + "_" + version;
+    this.correlationFailureCounter
+        .computeIfAbsent(
+            key,
+            s ->
+                Counter.builder("connectors_inbound_correlation_failure")
+                    .tag("type", connectorType)
+                    .tag("version", version)
+                    .register(meterRegistry))
+        .increment();
+  }
+
+  public void increaseTrigger(String connectorType, String version) {
+    String key = connectorType + "_" + version;
+    this.triggerCounter
+        .computeIfAbsent(
+            key,
+            s ->
+                Counter.builder("connectors_inbound_triggered")
+                    .tag("type", connectorType)
+                    .tag("version", version)
+                    .register(meterRegistry))
+        .increment();
+  }
+
+  public void increaseActivationConditionFailure(String connectorType, String version) {
+    String key = connectorType + "_" + version;
+    this.activationConditionFailureCounter
+        .computeIfAbsent(
+            key,
+            s ->
+                Counter.builder("connectors_inbound_activation_condition_failure")
+                    .tag("type", connectorType)
+                    .tag("version", version)
+                    .register(meterRegistry))
+        .increment();
+  }
+}

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/metrics/ConnectorsInboundMetrics.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/metrics/ConnectorsInboundMetrics.java
@@ -39,10 +39,10 @@ public class ConnectorsInboundMetrics {
             result.createKey(ConnectorMetrics.Inbound.ACTION_ACTIVATED),
             s ->
                 Counter.builder(ConnectorMetrics.Inbound.METRIC_NAME_ACTIVATIONS)
-                    .tag("action", ConnectorMetrics.Inbound.ACTION_ACTIVATED)
-                    .tag("type", result.type())
-                    .tag("id", result.id())
-                    .tag("version", result.version())
+                    .tag(ConnectorMetrics.Tag.ACTION, ConnectorMetrics.Inbound.ACTION_ACTIVATED)
+                    .tag(ConnectorMetrics.Tag.TYPE, result.type())
+                    .tag(ConnectorMetrics.Tag.ELEMENT_TEMPLATE_ID, result.id())
+                    .tag(ConnectorMetrics.Tag.ELEMENT_TEMPLATE_VERSION, result.version())
                     .register(meterRegistry))
         .increment();
   }
@@ -54,10 +54,10 @@ public class ConnectorsInboundMetrics {
             result.createKey(ConnectorMetrics.Inbound.ACTION_DEACTIVATED),
             s ->
                 Counter.builder(ConnectorMetrics.Inbound.METRIC_NAME_ACTIVATIONS)
-                    .tag("action", ConnectorMetrics.Inbound.ACTION_DEACTIVATED)
-                    .tag("type", result.type())
-                    .tag("id", result.id())
-                    .tag("version", result.version())
+                    .tag(ConnectorMetrics.Tag.ACTION, ConnectorMetrics.Inbound.ACTION_DEACTIVATED)
+                    .tag(ConnectorMetrics.Tag.TYPE, result.type())
+                    .tag(ConnectorMetrics.Tag.ELEMENT_TEMPLATE_ID, result.id())
+                    .tag(ConnectorMetrics.Tag.ELEMENT_TEMPLATE_VERSION, result.version())
                     .register(meterRegistry))
         .increment();
   }
@@ -69,10 +69,10 @@ public class ConnectorsInboundMetrics {
             result.createKey(ConnectorMetrics.Inbound.ACTION_CORRELATED),
             s ->
                 Counter.builder(ConnectorMetrics.Inbound.METRIC_NAME_ACTIVATIONS)
-                    .tag("action", ConnectorMetrics.Inbound.ACTION_CORRELATED)
-                    .tag("type", result.type())
-                    .tag("id", result.id())
-                    .tag("version", result.version())
+                    .tag(ConnectorMetrics.Tag.ACTION, ConnectorMetrics.Inbound.ACTION_CORRELATED)
+                    .tag(ConnectorMetrics.Tag.TYPE, result.type())
+                    .tag(ConnectorMetrics.Tag.ELEMENT_TEMPLATE_ID, result.id())
+                    .tag(ConnectorMetrics.Tag.ELEMENT_TEMPLATE_VERSION, result.version())
                     .register(meterRegistry))
         .increment();
   }
@@ -84,10 +84,12 @@ public class ConnectorsInboundMetrics {
             result.createKey(ConnectorMetrics.Inbound.ACTION_CORRELATION_FAILED),
             s ->
                 Counter.builder(ConnectorMetrics.Inbound.METRIC_NAME_ACTIVATIONS)
-                    .tag("action", ConnectorMetrics.Inbound.ACTION_CORRELATION_FAILED)
-                    .tag("type", result.type())
-                    .tag("id", result.id())
-                    .tag("version", result.version())
+                    .tag(
+                        ConnectorMetrics.Tag.ACTION,
+                        ConnectorMetrics.Inbound.ACTION_CORRELATION_FAILED)
+                    .tag(ConnectorMetrics.Tag.TYPE, result.type())
+                    .tag(ConnectorMetrics.Tag.ELEMENT_TEMPLATE_ID, result.id())
+                    .tag(ConnectorMetrics.Tag.ELEMENT_TEMPLATE_VERSION, result.version())
                     .register(meterRegistry))
         .increment();
   }
@@ -99,10 +101,12 @@ public class ConnectorsInboundMetrics {
             result.createKey(ConnectorMetrics.Inbound.ACTION_ACTIVATION_FAILED),
             s ->
                 Counter.builder(ConnectorMetrics.Inbound.METRIC_NAME_ACTIVATIONS)
-                    .tag("action", ConnectorMetrics.Inbound.ACTION_ACTIVATION_FAILED)
-                    .tag("type", result.type())
-                    .tag("id", result.id())
-                    .tag("version", result.version())
+                    .tag(
+                        ConnectorMetrics.Tag.ACTION,
+                        ConnectorMetrics.Inbound.ACTION_ACTIVATION_FAILED)
+                    .tag(ConnectorMetrics.Tag.TYPE, result.type())
+                    .tag(ConnectorMetrics.Tag.ELEMENT_TEMPLATE_ID, result.id())
+                    .tag(ConnectorMetrics.Tag.ELEMENT_TEMPLATE_VERSION, result.version())
                     .register(meterRegistry))
         .increment();
   }
@@ -114,10 +118,10 @@ public class ConnectorsInboundMetrics {
             result.createKey(ConnectorMetrics.Inbound.ACTION_TRIGGERED),
             s ->
                 Counter.builder(ConnectorMetrics.Inbound.METRIC_NAME_ACTIVATIONS)
-                    .tag("action", ConnectorMetrics.Inbound.ACTION_TRIGGERED)
-                    .tag("type", result.type())
-                    .tag("id", result.id())
-                    .tag("version", result.version())
+                    .tag(ConnectorMetrics.Tag.ACTION, ConnectorMetrics.Inbound.ACTION_TRIGGERED)
+                    .tag(ConnectorMetrics.Tag.TYPE, result.type())
+                    .tag(ConnectorMetrics.Tag.ELEMENT_TEMPLATE_ID, result.id())
+                    .tag(ConnectorMetrics.Tag.ELEMENT_TEMPLATE_VERSION, result.version())
                     .register(meterRegistry))
         .increment();
   }
@@ -129,10 +133,12 @@ public class ConnectorsInboundMetrics {
             result.createKey(ConnectorMetrics.Inbound.ACTION_ACTIVATION_CONDITION_FAILED),
             s ->
                 Counter.builder(ConnectorMetrics.Inbound.METRIC_NAME_ACTIVATIONS)
-                    .tag("action", ConnectorMetrics.Inbound.ACTION_ACTIVATION_CONDITION_FAILED)
-                    .tag("type", result.type())
-                    .tag("id", result.id())
-                    .tag("version", result.version())
+                    .tag(
+                        ConnectorMetrics.Tag.ACTION,
+                        ConnectorMetrics.Inbound.ACTION_ACTIVATION_CONDITION_FAILED)
+                    .tag(ConnectorMetrics.Tag.TYPE, result.type())
+                    .tag(ConnectorMetrics.Tag.ELEMENT_TEMPLATE_ID, result.id())
+                    .tag(ConnectorMetrics.Tag.ELEMENT_TEMPLATE_VERSION, result.version())
                     .register(meterRegistry))
         .increment();
   }

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/metrics/ConnectorsInboundMetrics.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/metrics/ConnectorsInboundMetrics.java
@@ -82,33 +82,33 @@ public class ConnectorsInboundMetrics {
   public void increaseCorrelationSuccess(InboundConnectorElement connectorElement) {
     Result result = Result.getResult(connectorElement);
     this.activationCounter
-            .computeIfAbsent(
-                    result.createKey(ConnectorMetrics.Inbound.ACTION_CORRELATED),
-                    s ->
-                            Counter.builder(ConnectorMetrics.Inbound.METRIC_NAME_TRIGGERS)
-                                    .tag(ConnectorMetrics.Tag.ACTION, ConnectorMetrics.Inbound.ACTION_CORRELATED)
-                                    .tag(ConnectorMetrics.Tag.TYPE, result.type())
-                                    .tag(ConnectorMetrics.Tag.ELEMENT_TEMPLATE_ID, result.id())
-                                    .tag(ConnectorMetrics.Tag.ELEMENT_TEMPLATE_VERSION, result.version())
-                                    .register(meterRegistry))
-            .increment();
+        .computeIfAbsent(
+            result.createKey(ConnectorMetrics.Inbound.ACTION_CORRELATED),
+            s ->
+                Counter.builder(ConnectorMetrics.Inbound.METRIC_NAME_TRIGGERS)
+                    .tag(ConnectorMetrics.Tag.ACTION, ConnectorMetrics.Inbound.ACTION_CORRELATED)
+                    .tag(ConnectorMetrics.Tag.TYPE, result.type())
+                    .tag(ConnectorMetrics.Tag.ELEMENT_TEMPLATE_ID, result.id())
+                    .tag(ConnectorMetrics.Tag.ELEMENT_TEMPLATE_VERSION, result.version())
+                    .register(meterRegistry))
+        .increment();
   }
 
   public void increaseCorrelationFailure(InboundConnectorElement connectorElement) {
     Result result = Result.getResult(connectorElement);
     this.activationCounter
-            .computeIfAbsent(
-                    result.createKey(ConnectorMetrics.Inbound.ACTION_CORRELATION_FAILED),
-                    s ->
-                            Counter.builder(ConnectorMetrics.Inbound.METRIC_NAME_TRIGGERS)
-                                    .tag(
-                                            ConnectorMetrics.Tag.ACTION,
-                                            ConnectorMetrics.Inbound.ACTION_CORRELATION_FAILED)
-                                    .tag(ConnectorMetrics.Tag.TYPE, result.type())
-                                    .tag(ConnectorMetrics.Tag.ELEMENT_TEMPLATE_ID, result.id())
-                                    .tag(ConnectorMetrics.Tag.ELEMENT_TEMPLATE_VERSION, result.version())
-                                    .register(meterRegistry))
-            .increment();
+        .computeIfAbsent(
+            result.createKey(ConnectorMetrics.Inbound.ACTION_CORRELATION_FAILED),
+            s ->
+                Counter.builder(ConnectorMetrics.Inbound.METRIC_NAME_TRIGGERS)
+                    .tag(
+                        ConnectorMetrics.Tag.ACTION,
+                        ConnectorMetrics.Inbound.ACTION_CORRELATION_FAILED)
+                    .tag(ConnectorMetrics.Tag.TYPE, result.type())
+                    .tag(ConnectorMetrics.Tag.ELEMENT_TEMPLATE_ID, result.id())
+                    .tag(ConnectorMetrics.Tag.ELEMENT_TEMPLATE_VERSION, result.version())
+                    .register(meterRegistry))
+        .increment();
   }
 
   public void increaseTrigger(InboundConnectorElement connectorElement) {

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/metrics/ConnectorsInboundMetrics.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/metrics/ConnectorsInboundMetrics.java
@@ -26,11 +26,6 @@ public class ConnectorsInboundMetrics {
 
   private final MeterRegistry meterRegistry;
   private final Map<String, Counter> activationCounter = new ConcurrentHashMap<>();
-  private final Map<String, Counter> deactivationCounter = new ConcurrentHashMap<>();
-  private final Map<String, Counter> correlationSuccessCounter = new ConcurrentHashMap<>();
-  private final Map<String, Counter> correlationFailureCounter = new ConcurrentHashMap<>();
-  private final Map<String, Counter> activationConditionFailureCounter = new ConcurrentHashMap<>();
-  private final Map<String, Counter> triggerCounter = new ConcurrentHashMap<>();
   private final Map<String, Counter> processDefinitionsChecked = new ConcurrentHashMap<>();
 
   public ConnectorsInboundMetrics(MeterRegistry meterRegistry) {
@@ -41,9 +36,10 @@ public class ConnectorsInboundMetrics {
     Result result = Result.getResult(connectorElement);
     this.activationCounter
         .computeIfAbsent(
-            result.key(),
+            result.createKey(ConnectorMetrics.Inbound.ACTION_ACTIVATED),
             s ->
                 Counter.builder(ConnectorMetrics.Inbound.METRIC_NAME_ACTIVATIONS)
+                    .tag("action", ConnectorMetrics.Inbound.ACTION_ACTIVATED)
                     .tag("type", result.type())
                     .tag("id", result.id())
                     .tag("version", result.version())
@@ -53,11 +49,12 @@ public class ConnectorsInboundMetrics {
 
   public void increaseDeactivation(InboundConnectorElement connectorElement) {
     Result result = Result.getResult(connectorElement);
-    this.deactivationCounter
+    this.activationCounter
         .computeIfAbsent(
-            result.key(),
+            result.createKey(ConnectorMetrics.Inbound.ACTION_DEACTIVATED),
             s ->
-                Counter.builder(ConnectorMetrics.Inbound.METRIC_NAME_DEACTIVATIONS)
+                Counter.builder(ConnectorMetrics.Inbound.METRIC_NAME_ACTIVATIONS)
+                    .tag("action", ConnectorMetrics.Inbound.ACTION_DEACTIVATED)
                     .tag("type", result.type())
                     .tag("id", result.id())
                     .tag("version", result.version())
@@ -67,11 +64,12 @@ public class ConnectorsInboundMetrics {
 
   public void increaseCorrelationSuccess(InboundConnectorElement connectorElement) {
     Result result = Result.getResult(connectorElement);
-    this.correlationSuccessCounter
+    this.activationCounter
         .computeIfAbsent(
-            result.key(),
+            result.createKey(ConnectorMetrics.Inbound.ACTION_CORRELATED),
             s ->
-                Counter.builder(ConnectorMetrics.Inbound.METRIC_NAME_CORRELATION_SUCCESS)
+                Counter.builder(ConnectorMetrics.Inbound.METRIC_NAME_ACTIVATIONS)
+                    .tag("action", ConnectorMetrics.Inbound.ACTION_CORRELATED)
                     .tag("type", result.type())
                     .tag("id", result.id())
                     .tag("version", result.version())
@@ -81,11 +79,27 @@ public class ConnectorsInboundMetrics {
 
   public void increaseCorrelationFailure(InboundConnectorElement connectorElement) {
     Result result = Result.getResult(connectorElement);
-    this.correlationFailureCounter
+    this.activationCounter
         .computeIfAbsent(
-            result.key(),
+            result.createKey(ConnectorMetrics.Inbound.ACTION_CORRELATION_FAILED),
             s ->
-                Counter.builder(ConnectorMetrics.Inbound.METRIC_NAME_CORRELATION_FAILURE)
+                Counter.builder(ConnectorMetrics.Inbound.METRIC_NAME_ACTIVATIONS)
+                    .tag("action", ConnectorMetrics.Inbound.ACTION_CORRELATION_FAILED)
+                    .tag("type", result.type())
+                    .tag("id", result.id())
+                    .tag("version", result.version())
+                    .register(meterRegistry))
+        .increment();
+  }
+
+  public void increaseActivationFailure(InboundConnectorElement connectorElement) {
+    Result result = Result.getResult(connectorElement);
+    this.activationCounter
+        .computeIfAbsent(
+            result.createKey(ConnectorMetrics.Inbound.ACTION_ACTIVATION_FAILED),
+            s ->
+                Counter.builder(ConnectorMetrics.Inbound.METRIC_NAME_ACTIVATIONS)
+                    .tag("action", ConnectorMetrics.Inbound.ACTION_ACTIVATION_FAILED)
                     .tag("type", result.type())
                     .tag("id", result.id())
                     .tag("version", result.version())
@@ -95,11 +109,12 @@ public class ConnectorsInboundMetrics {
 
   public void increaseTrigger(InboundConnectorElement connectorElement) {
     Result result = Result.getResult(connectorElement);
-    this.triggerCounter
+    this.activationCounter
         .computeIfAbsent(
-            result.key(),
+            result.createKey(ConnectorMetrics.Inbound.ACTION_TRIGGERED),
             s ->
-                Counter.builder(ConnectorMetrics.Inbound.METRIC_NAME_TRIGGERS)
+                Counter.builder(ConnectorMetrics.Inbound.METRIC_NAME_ACTIVATIONS)
+                    .tag("action", ConnectorMetrics.Inbound.ACTION_TRIGGERED)
                     .tag("type", result.type())
                     .tag("id", result.id())
                     .tag("version", result.version())
@@ -109,11 +124,12 @@ public class ConnectorsInboundMetrics {
 
   public void increaseActivationConditionFailure(InboundConnectorElement connectorElement) {
     Result result = Result.getResult(connectorElement);
-    this.activationConditionFailureCounter
+    this.activationCounter
         .computeIfAbsent(
-            result.key(),
+            result.createKey(ConnectorMetrics.Inbound.ACTION_ACTIVATION_CONDITION_FAILED),
             s ->
-                Counter.builder(ConnectorMetrics.Inbound.METRIC_NAME_ACTIVATION_CONDITION_FAILURE)
+                Counter.builder(ConnectorMetrics.Inbound.METRIC_NAME_ACTIVATIONS)
+                    .tag("action", ConnectorMetrics.Inbound.ACTION_ACTIVATION_CONDITION_FAILED)
                     .tag("type", result.type())
                     .tag("id", result.id())
                     .tag("version", result.version())

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/metrics/ConnectorsInboundMetrics.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/metrics/ConnectorsInboundMetrics.java
@@ -62,38 +62,6 @@ public class ConnectorsInboundMetrics {
         .increment();
   }
 
-  public void increaseCorrelationSuccess(InboundConnectorElement connectorElement) {
-    Result result = Result.getResult(connectorElement);
-    this.activationCounter
-        .computeIfAbsent(
-            result.createKey(ConnectorMetrics.Inbound.ACTION_CORRELATED),
-            s ->
-                Counter.builder(ConnectorMetrics.Inbound.METRIC_NAME_ACTIVATIONS)
-                    .tag(ConnectorMetrics.Tag.ACTION, ConnectorMetrics.Inbound.ACTION_CORRELATED)
-                    .tag(ConnectorMetrics.Tag.TYPE, result.type())
-                    .tag(ConnectorMetrics.Tag.ELEMENT_TEMPLATE_ID, result.id())
-                    .tag(ConnectorMetrics.Tag.ELEMENT_TEMPLATE_VERSION, result.version())
-                    .register(meterRegistry))
-        .increment();
-  }
-
-  public void increaseCorrelationFailure(InboundConnectorElement connectorElement) {
-    Result result = Result.getResult(connectorElement);
-    this.activationCounter
-        .computeIfAbsent(
-            result.createKey(ConnectorMetrics.Inbound.ACTION_CORRELATION_FAILED),
-            s ->
-                Counter.builder(ConnectorMetrics.Inbound.METRIC_NAME_ACTIVATIONS)
-                    .tag(
-                        ConnectorMetrics.Tag.ACTION,
-                        ConnectorMetrics.Inbound.ACTION_CORRELATION_FAILED)
-                    .tag(ConnectorMetrics.Tag.TYPE, result.type())
-                    .tag(ConnectorMetrics.Tag.ELEMENT_TEMPLATE_ID, result.id())
-                    .tag(ConnectorMetrics.Tag.ELEMENT_TEMPLATE_VERSION, result.version())
-                    .register(meterRegistry))
-        .increment();
-  }
-
   public void increaseActivationFailure(InboundConnectorElement connectorElement) {
     Result result = Result.getResult(connectorElement);
     this.activationCounter
@@ -111,13 +79,45 @@ public class ConnectorsInboundMetrics {
         .increment();
   }
 
+  public void increaseCorrelationSuccess(InboundConnectorElement connectorElement) {
+    Result result = Result.getResult(connectorElement);
+    this.activationCounter
+            .computeIfAbsent(
+                    result.createKey(ConnectorMetrics.Inbound.ACTION_CORRELATED),
+                    s ->
+                            Counter.builder(ConnectorMetrics.Inbound.METRIC_NAME_TRIGGERS)
+                                    .tag(ConnectorMetrics.Tag.ACTION, ConnectorMetrics.Inbound.ACTION_CORRELATED)
+                                    .tag(ConnectorMetrics.Tag.TYPE, result.type())
+                                    .tag(ConnectorMetrics.Tag.ELEMENT_TEMPLATE_ID, result.id())
+                                    .tag(ConnectorMetrics.Tag.ELEMENT_TEMPLATE_VERSION, result.version())
+                                    .register(meterRegistry))
+            .increment();
+  }
+
+  public void increaseCorrelationFailure(InboundConnectorElement connectorElement) {
+    Result result = Result.getResult(connectorElement);
+    this.activationCounter
+            .computeIfAbsent(
+                    result.createKey(ConnectorMetrics.Inbound.ACTION_CORRELATION_FAILED),
+                    s ->
+                            Counter.builder(ConnectorMetrics.Inbound.METRIC_NAME_TRIGGERS)
+                                    .tag(
+                                            ConnectorMetrics.Tag.ACTION,
+                                            ConnectorMetrics.Inbound.ACTION_CORRELATION_FAILED)
+                                    .tag(ConnectorMetrics.Tag.TYPE, result.type())
+                                    .tag(ConnectorMetrics.Tag.ELEMENT_TEMPLATE_ID, result.id())
+                                    .tag(ConnectorMetrics.Tag.ELEMENT_TEMPLATE_VERSION, result.version())
+                                    .register(meterRegistry))
+            .increment();
+  }
+
   public void increaseTrigger(InboundConnectorElement connectorElement) {
     Result result = Result.getResult(connectorElement);
     this.activationCounter
         .computeIfAbsent(
             result.createKey(ConnectorMetrics.Inbound.ACTION_TRIGGERED),
             s ->
-                Counter.builder(ConnectorMetrics.Inbound.METRIC_NAME_ACTIVATIONS)
+                Counter.builder(ConnectorMetrics.Inbound.METRIC_NAME_TRIGGERS)
                     .tag(ConnectorMetrics.Tag.ACTION, ConnectorMetrics.Inbound.ACTION_TRIGGERED)
                     .tag(ConnectorMetrics.Tag.TYPE, result.type())
                     .tag(ConnectorMetrics.Tag.ELEMENT_TEMPLATE_ID, result.id())
@@ -132,7 +132,7 @@ public class ConnectorsInboundMetrics {
         .computeIfAbsent(
             result.createKey(ConnectorMetrics.Inbound.ACTION_ACTIVATION_CONDITION_FAILED),
             s ->
-                Counter.builder(ConnectorMetrics.Inbound.METRIC_NAME_ACTIVATIONS)
+                Counter.builder(ConnectorMetrics.Inbound.METRIC_NAME_TRIGGERS)
                     .tag(
                         ConnectorMetrics.Tag.ACTION,
                         ConnectorMetrics.Inbound.ACTION_ACTIVATION_CONDITION_FAILED)

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/metrics/ConnectorsInboundMetrics.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/metrics/ConnectorsInboundMetrics.java
@@ -26,10 +26,13 @@ public class ConnectorsInboundMetrics {
 
   private final MeterRegistry meterRegistry;
   private final Map<String, Counter> activationCounter = new ConcurrentHashMap<>();
-  private final Map<String, Counter> processDefinitionsChecked = new ConcurrentHashMap<>();
+  private final Counter processDefinitionsChecked;
 
   public ConnectorsInboundMetrics(MeterRegistry meterRegistry) {
     this.meterRegistry = meterRegistry;
+    this.processDefinitionsChecked =
+        Counter.builder(ConnectorMetrics.Inbound.METRIC_NAME_INBOUND_PROCESS_DEFINITIONS_CHECKED)
+            .register(meterRegistry);
   }
 
   public void increaseActivation(InboundConnectorElement connectorElement) {
@@ -144,13 +147,6 @@ public class ConnectorsInboundMetrics {
   }
 
   public void increaseProcessDefinitionsChecked(int count) {
-    this.processDefinitionsChecked
-        .computeIfAbsent(
-            "PROCESS_DEFINITIONS_CHECKED",
-            s ->
-                Counter.builder(
-                        ConnectorMetrics.Inbound.METRIC_NAME_INBOUND_PROCESS_DEFINITIONS_CHECKED)
-                    .register(meterRegistry))
-        .increment(count);
+    this.processDefinitionsChecked.increment(count);
   }
 }

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/metrics/ConnectorsOutboundMetrics.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/metrics/ConnectorsOutboundMetrics.java
@@ -38,10 +38,10 @@ public class ConnectorsOutboundMetrics {
             result.createKey(ConnectorMetrics.Outbound.ACTION_ACTIVATED),
             s ->
                 Counter.builder(ConnectorMetrics.Outbound.METRIC_NAME_INVOCATIONS)
-                    .tag("action", ConnectorMetrics.Outbound.ACTION_ACTIVATED)
-                    .tag("type", result.type())
-                    .tag("id", result.id())
-                    .tag("version", result.version())
+                    .tag(ConnectorMetrics.Tag.ACTION, ConnectorMetrics.Outbound.ACTION_ACTIVATED)
+                    .tag(ConnectorMetrics.Tag.TYPE, result.type())
+                    .tag(ConnectorMetrics.Tag.ELEMENT_TEMPLATE_ID, result.id())
+                    .tag(ConnectorMetrics.Tag.ELEMENT_TEMPLATE_VERSION, result.version())
                     .register(meterRegistry))
         .increment();
   }
@@ -53,10 +53,10 @@ public class ConnectorsOutboundMetrics {
             result.createKey(ConnectorMetrics.Outbound.ACTION_FAILED),
             s ->
                 Counter.builder(ConnectorMetrics.Outbound.METRIC_NAME_INVOCATIONS)
-                    .tag("action", ConnectorMetrics.Outbound.ACTION_FAILED)
-                    .tag("type", result.type())
-                    .tag("id", result.id())
-                    .tag("version", result.version())
+                    .tag(ConnectorMetrics.Tag.ACTION, ConnectorMetrics.Outbound.ACTION_FAILED)
+                    .tag(ConnectorMetrics.Tag.TYPE, result.type())
+                    .tag(ConnectorMetrics.Tag.ELEMENT_TEMPLATE_ID, result.id())
+                    .tag(ConnectorMetrics.Tag.ELEMENT_TEMPLATE_VERSION, result.version())
                     .register(meterRegistry))
         .increment();
   }
@@ -68,10 +68,10 @@ public class ConnectorsOutboundMetrics {
             result.createKey(ConnectorMetrics.Outbound.ACTION_COMPLETED),
             s ->
                 Counter.builder(ConnectorMetrics.Outbound.METRIC_NAME_INVOCATIONS)
-                    .tag("action", ConnectorMetrics.Outbound.ACTION_COMPLETED)
-                    .tag("type", result.type())
-                    .tag("id", result.id())
-                    .tag("version", result.version())
+                    .tag(ConnectorMetrics.Tag.ACTION, ConnectorMetrics.Outbound.ACTION_COMPLETED)
+                    .tag(ConnectorMetrics.Tag.TYPE, result.type())
+                    .tag(ConnectorMetrics.Tag.ELEMENT_TEMPLATE_ID, result.id())
+                    .tag(ConnectorMetrics.Tag.ELEMENT_TEMPLATE_VERSION, result.version())
                     .register(meterRegistry))
         .increment();
   }
@@ -83,10 +83,10 @@ public class ConnectorsOutboundMetrics {
             result.createKey(ConnectorMetrics.Outbound.ACTION_BPMN_ERROR),
             s ->
                 Counter.builder(ConnectorMetrics.Outbound.METRIC_NAME_INVOCATIONS)
-                    .tag("action", ConnectorMetrics.Outbound.ACTION_BPMN_ERROR)
-                    .tag("type", result.type())
-                    .tag("id", result.id())
-                    .tag("version", result.version())
+                    .tag(ConnectorMetrics.Tag.ACTION, ConnectorMetrics.Outbound.ACTION_BPMN_ERROR)
+                    .tag(ConnectorMetrics.Tag.TYPE, result.type())
+                    .tag(ConnectorMetrics.Tag.ELEMENT_TEMPLATE_ID, result.id())
+                    .tag(ConnectorMetrics.Tag.ELEMENT_TEMPLATE_VERSION, result.version())
                     .register(meterRegistry))
         .increment();
   }
@@ -96,11 +96,11 @@ public class ConnectorsOutboundMetrics {
     meterRegistry
         .timer(
             ConnectorMetrics.Outbound.METRIC_NAME_TIME,
-            "type",
+            ConnectorMetrics.Tag.TYPE,
             result.type(),
-            "id",
+            ConnectorMetrics.Tag.ELEMENT_TEMPLATE_ID,
             result.id(),
-            "version",
+            ConnectorMetrics.Tag.ELEMENT_TEMPLATE_VERSION,
             result.version())
         .record(runnable);
   }

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/metrics/ConnectorsOutboundMetrics.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/metrics/ConnectorsOutboundMetrics.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.runtime.metrics;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class ConnectorsOutboundMetrics {
+
+  private final MeterRegistry meterRegistry;
+  private final Map<String, Counter> counters = new ConcurrentHashMap<>();
+
+  public ConnectorsOutboundMetrics(MeterRegistry meterRegistry) {
+    this.meterRegistry = meterRegistry;
+  }
+
+  public void increase(String connectorType, String version) {
+    String key = connectorType + "_" + version;
+    this.counters
+        .computeIfAbsent(
+            key,
+            s ->
+                Counter.builder("connectors_outbound")
+                    .tag("type", connectorType)
+                    .tag("version", version)
+                    .register(meterRegistry))
+        .increment();
+  }
+}

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/metrics/Result.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/metrics/Result.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.runtime.metrics;
+
+import io.camunda.client.api.response.ActivatedJob;
+import io.camunda.connector.runtime.core.inbound.InboundConnectorElement;
+
+public record Result(String type, String id, String version, String key) {
+
+  public static Result getResult(ActivatedJob job) {
+    String type = job.getType();
+    String id = job.getCustomHeaders().getOrDefault("elementTemplateId", "unknown");
+    String version = job.getCustomHeaders().getOrDefault("elementTemplateVersion", "unknown");
+    String key = type + "_" + id + "_" + version;
+    return new Result(type, id, version, key);
+  }
+
+  public static Result getResult(InboundConnectorElement connectorElement) {
+    String type = connectorElement.type();
+    String id = connectorElement.element().elementTemplateDetails().id();
+    String version = connectorElement.element().elementTemplateDetails().version();
+    String key = type + "_" + id + "_" + version;
+    return new Result(type, id, version, key);
+  }
+}

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/metrics/Result.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/metrics/Result.java
@@ -17,7 +17,10 @@
 package io.camunda.connector.runtime.metrics;
 
 import io.camunda.client.api.response.ActivatedJob;
+import io.camunda.connector.api.inbound.ElementTemplateDetails;
+import io.camunda.connector.api.inbound.ProcessElement;
 import io.camunda.connector.runtime.core.inbound.InboundConnectorElement;
+import java.util.Optional;
 
 public record Result(String type, String id, String version, String key) {
 
@@ -31,8 +34,18 @@ public record Result(String type, String id, String version, String key) {
 
   public static Result getResult(InboundConnectorElement connectorElement) {
     String type = connectorElement.type();
-    String id = connectorElement.element().elementTemplateDetails().id();
-    String version = connectorElement.element().elementTemplateDetails().version();
+    String id =
+        Optional.of(connectorElement)
+            .map(InboundConnectorElement::element)
+            .map(ProcessElement::elementTemplateDetails)
+            .map(ElementTemplateDetails::id)
+            .orElse("unknown");
+    String version =
+        Optional.of(connectorElement)
+            .map(InboundConnectorElement::element)
+            .map(ProcessElement::elementTemplateDetails)
+            .map(ElementTemplateDetails::version)
+            .orElse("unknown");
     String key = type + "_" + id + "_" + version;
     return new Result(type, id, version, key);
   }

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/metrics/Result.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/metrics/Result.java
@@ -36,4 +36,8 @@ public record Result(String type, String id, String version, String key) {
     String key = type + "_" + id + "_" + version;
     return new Result(type, id, version, key);
   }
+
+  public String createKey(String actionActivated) {
+    return this.key() + "_" + actionActivated;
+  }
 }

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/OutboundConnectorRuntimeConfiguration.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/OutboundConnectorRuntimeConfiguration.java
@@ -32,7 +32,6 @@ import io.camunda.document.store.CamundaDocumentStore;
 import io.camunda.document.store.CamundaDocumentStoreImpl;
 import io.camunda.spring.client.jobhandling.CommandExceptionHandlingStrategy;
 import io.camunda.spring.client.jobhandling.JobWorkerManager;
-import io.camunda.spring.client.metrics.MetricsRecorder;
 import io.micrometer.core.instrument.MeterRegistry;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
@@ -66,8 +65,7 @@ public class OutboundConnectorRuntimeConfiguration {
       @Autowired(required = false) ValidationProvider validationProvider,
       ConnectorsOutboundMetrics outboundMetrics,
       DocumentFactory documentFactory,
-      ObjectMapper objectMapper,
-      MetricsRecorder metricsRecorder) {
+      ObjectMapper objectMapper) {
     return new OutboundConnectorManager(
         jobWorkerManager,
         connectorFactory,
@@ -76,7 +74,6 @@ public class OutboundConnectorRuntimeConfiguration {
         validationProvider,
         documentFactory,
         objectMapper,
-        metricsRecorder,
         outboundMetrics);
   }
 

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/OutboundConnectorRuntimeConfiguration.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/OutboundConnectorRuntimeConfiguration.java
@@ -23,6 +23,7 @@ import io.camunda.connector.runtime.core.outbound.DefaultOutboundConnectorFactor
 import io.camunda.connector.runtime.core.outbound.OutboundConnectorDiscovery;
 import io.camunda.connector.runtime.core.outbound.OutboundConnectorFactory;
 import io.camunda.connector.runtime.core.secret.SecretProviderAggregator;
+import io.camunda.connector.runtime.metrics.ConnectorsOutboundMetrics;
 import io.camunda.connector.runtime.outbound.lifecycle.OutboundConnectorAnnotationProcessor;
 import io.camunda.connector.runtime.outbound.lifecycle.OutboundConnectorManager;
 import io.camunda.document.factory.DocumentFactory;
@@ -32,6 +33,7 @@ import io.camunda.document.store.CamundaDocumentStoreImpl;
 import io.camunda.spring.client.jobhandling.CommandExceptionHandlingStrategy;
 import io.camunda.spring.client.jobhandling.JobWorkerManager;
 import io.camunda.spring.client.metrics.MetricsRecorder;
+import io.micrometer.core.instrument.MeterRegistry;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -62,6 +64,7 @@ public class OutboundConnectorRuntimeConfiguration {
       CommandExceptionHandlingStrategy commandExceptionHandlingStrategy,
       SecretProviderAggregator secretProviderAggregator,
       @Autowired(required = false) ValidationProvider validationProvider,
+      ConnectorsOutboundMetrics outboundMetrics,
       DocumentFactory documentFactory,
       ObjectMapper objectMapper,
       MetricsRecorder metricsRecorder) {
@@ -73,12 +76,18 @@ public class OutboundConnectorRuntimeConfiguration {
         validationProvider,
         documentFactory,
         objectMapper,
-        metricsRecorder);
+        metricsRecorder,
+        outboundMetrics);
   }
 
   @Bean
   public OutboundConnectorAnnotationProcessor annotationProcessor(
       OutboundConnectorManager manager, OutboundConnectorFactory factory) {
     return new OutboundConnectorAnnotationProcessor(manager, factory);
+  }
+
+  @Bean
+  public ConnectorsOutboundMetrics connectorsOutboundMetrics(MeterRegistry meterRegistry) {
+    return new ConnectorsOutboundMetrics(meterRegistry);
   }
 }

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/jobhandling/SpringConnectorJobHandler.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/jobhandling/SpringConnectorJobHandler.java
@@ -71,6 +71,13 @@ public class SpringConnectorJobHandler extends ConnectorJobHandler {
 
   @Override
   public void handle(JobClient client, ActivatedJob job) {
+    String jobTypeAndId =
+        job.getCustomHeaders().getOrDefault("id", "unknown")
+            + "#"
+            + job.getCustomHeaders().getOrDefault("version", "0");
+    System.out.println("==================================>" + jobTypeAndId);
+    metricsRecorder.increase(
+        Outbound.METRIC_CONNECTOR_VERSION, Outbound.JOB_RECEIVED, jobTypeAndId);
     metricsRecorder.executeWithTimer(
         ConnectorMetrics.Outbound.METRIC_NAME_TIME,
         job.getType(),

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/jobhandling/SpringConnectorJobHandler.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/jobhandling/SpringConnectorJobHandler.java
@@ -22,17 +22,15 @@ import io.camunda.client.api.response.ActivatedJob;
 import io.camunda.client.api.worker.JobClient;
 import io.camunda.connector.api.outbound.OutboundConnectorFunction;
 import io.camunda.connector.api.validation.ValidationProvider;
-import io.camunda.connector.runtime.core.config.OutboundConnectorConfiguration;
+import io.camunda.connector.runtime.core.error.BpmnError;
 import io.camunda.connector.runtime.core.outbound.ConnectorJobHandler;
 import io.camunda.connector.runtime.core.outbound.ConnectorResult;
 import io.camunda.connector.runtime.core.secret.SecretProviderAggregator;
-import io.camunda.connector.runtime.metrics.ConnectorMetrics;
-import io.camunda.connector.runtime.metrics.ConnectorMetrics.Outbound;
 import io.camunda.connector.runtime.metrics.ConnectorsOutboundMetrics;
 import io.camunda.document.factory.DocumentFactory;
 import io.camunda.spring.client.jobhandling.CommandExceptionHandlingStrategy;
 import io.camunda.spring.client.jobhandling.CommandWrapper;
-import io.camunda.spring.client.metrics.MetricsRecorder;
+import io.camunda.spring.client.metrics.DefaultNoopMetricsRecorder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -47,12 +45,10 @@ public class SpringConnectorJobHandler extends ConnectorJobHandler {
   private static final int MAX_ZEEBE_COMMAND_RETRIES = 3;
 
   private final CommandExceptionHandlingStrategy commandExceptionHandlingStrategy;
-  private final MetricsRecorder metricsRecorder;
-  private final OutboundConnectorConfiguration connectorConfiguration;
   private final ConnectorsOutboundMetrics connectorsOutboundMetrics;
+  private final DefaultNoopMetricsRecorder defaultNoopMetricsRecorder;
 
   public SpringConnectorJobHandler(
-      MetricsRecorder metricsRecorder,
       ConnectorsOutboundMetrics outboundMetrics,
       CommandExceptionHandlingStrategy commandExceptionHandlingStrategy,
       SecretProviderAggregator secretProviderAggregator,
@@ -60,78 +56,80 @@ public class SpringConnectorJobHandler extends ConnectorJobHandler {
       DocumentFactory documentFactory,
       ObjectMapper objectMapper,
       OutboundConnectorFunction connectorFunction,
-      OutboundConnectorConfiguration connectorConfiguration) {
+      DefaultNoopMetricsRecorder defaultNoopMetricsRecorder) {
     super(
         connectorFunction,
         secretProviderAggregator,
         validationProvider,
         documentFactory,
         objectMapper);
-    this.metricsRecorder = metricsRecorder;
     this.commandExceptionHandlingStrategy = commandExceptionHandlingStrategy;
-    this.connectorConfiguration = connectorConfiguration;
     this.connectorsOutboundMetrics = outboundMetrics;
+    this.defaultNoopMetricsRecorder = defaultNoopMetricsRecorder;
   }
 
   @Override
   public void handle(JobClient client, ActivatedJob job) {
-    String type = job.getCustomHeaders().getOrDefault("elementTemplateId", "unknown");
-    String version = job.getCustomHeaders().getOrDefault("elementTemplateVersion", "unknown");
-    connectorsOutboundMetrics.increase(type, version);
-    metricsRecorder.executeWithTimer(
-        ConnectorMetrics.Outbound.METRIC_NAME_TIME,
-        job.getType(),
-        () -> {
-          metricsRecorder.increase(
-              Outbound.METRIC_NAME_INVOCATIONS,
-              Outbound.ACTION_ACTIVATED,
-              connectorConfiguration.type());
-          try {
-            super.handle(client, job);
-          } catch (Exception e) {
-            metricsRecorder.increase(
-                Outbound.METRIC_NAME_INVOCATIONS,
-                Outbound.ACTION_FAILED,
-                connectorConfiguration.type());
-            LOGGER.warn("Failed to handle job: {}", job);
-          }
-        });
+    connectorsOutboundMetrics.increaseInvocation(job);
+    connectorsOutboundMetrics.executeWithTimer(job, () -> this.executeJob(client, job));
+  }
+
+  private void executeJob(JobClient client, ActivatedJob job) {
+    try {
+      super.handle(client, job);
+    } catch (Exception e) {
+      connectorsOutboundMetrics.increaseFailure(job);
+      LOGGER.warn("Failed to handle job: {}", job);
+    }
   }
 
   @Override
-  @SuppressWarnings({"unchecked", "rawtypes"})
+  @SuppressWarnings("rawtypes")
   protected void failJob(JobClient client, ActivatedJob job, ConnectorResult.ErrorResult result) {
     try {
-      metricsRecorder.increase(
-          Outbound.METRIC_NAME_INVOCATIONS, Outbound.ACTION_FAILED, connectorConfiguration.type());
+      connectorsOutboundMetrics.increaseFailure(job);
     } finally {
       FinalCommandStep commandStep = prepareFailJobCommand(client, job, result);
       new CommandWrapper(
               commandStep,
               job,
               commandExceptionHandlingStrategy,
-              metricsRecorder,
+              defaultNoopMetricsRecorder,
               MAX_ZEEBE_COMMAND_RETRIES)
           .executeAsync();
     }
   }
 
   @Override
-  @SuppressWarnings({"unchecked", "rawtypes"})
+  @SuppressWarnings("rawtypes")
+  protected void throwBpmnError(JobClient client, ActivatedJob job, BpmnError value) {
+    try {
+      connectorsOutboundMetrics.increaseBpmnError(job);
+    } finally {
+      FinalCommandStep commandStep = prepareThrowBpmnErrorCommand(client, job, value);
+      new CommandWrapper(
+              commandStep,
+              job,
+              commandExceptionHandlingStrategy,
+              defaultNoopMetricsRecorder,
+              MAX_ZEEBE_COMMAND_RETRIES)
+          .executeAsync();
+    }
+  }
+
+  @Override
+  @SuppressWarnings("rawtypes")
   protected void completeJob(
       JobClient client, ActivatedJob job, ConnectorResult.SuccessResult result) {
     try {
-      metricsRecorder.increase(
-          Outbound.METRIC_NAME_INVOCATIONS,
-          Outbound.ACTION_COMPLETED,
-          connectorConfiguration.type());
+      connectorsOutboundMetrics.increaseCompletion(job);
     } finally {
       FinalCommandStep commandStep = prepareCompleteJobCommand(client, job, result);
       new CommandWrapper(
               commandStep,
               job,
               commandExceptionHandlingStrategy,
-              metricsRecorder,
+              defaultNoopMetricsRecorder,
               MAX_ZEEBE_COMMAND_RETRIES)
           .executeAsync();
     }

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/jobhandling/SpringConnectorJobHandler.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/jobhandling/SpringConnectorJobHandler.java
@@ -75,7 +75,6 @@ public class SpringConnectorJobHandler extends ConnectorJobHandler {
         job.getCustomHeaders().getOrDefault("id", "unknown")
             + "#"
             + job.getCustomHeaders().getOrDefault("version", "0");
-    System.out.println("==================================>" + jobTypeAndId);
     metricsRecorder.increase(
         Outbound.METRIC_CONNECTOR_VERSION, Outbound.JOB_RECEIVED, jobTypeAndId);
     metricsRecorder.executeWithTimer(

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/lifecycle/OutboundConnectorManager.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/lifecycle/OutboundConnectorManager.java
@@ -24,6 +24,7 @@ import io.camunda.connector.api.validation.ValidationProvider;
 import io.camunda.connector.runtime.core.config.OutboundConnectorConfiguration;
 import io.camunda.connector.runtime.core.outbound.OutboundConnectorFactory;
 import io.camunda.connector.runtime.core.secret.SecretProviderAggregator;
+import io.camunda.connector.runtime.metrics.ConnectorsOutboundMetrics;
 import io.camunda.connector.runtime.outbound.jobhandling.SpringConnectorJobHandler;
 import io.camunda.document.factory.DocumentFactory;
 import io.camunda.spring.client.annotation.value.JobWorkerValue;
@@ -48,6 +49,7 @@ public class OutboundConnectorManager {
   private final ObjectMapper objectMapper;
   private final MetricsRecorder metricsRecorder;
   private final DocumentFactory documentFactory;
+  private final ConnectorsOutboundMetrics outboundMetrics;
 
   public OutboundConnectorManager(
       JobWorkerManager jobWorkerManager,
@@ -57,7 +59,8 @@ public class OutboundConnectorManager {
       ValidationProvider validationProvider,
       DocumentFactory documentFactory,
       ObjectMapper objectMapper,
-      MetricsRecorder metricsRecorder) {
+      MetricsRecorder metricsRecorder,
+      ConnectorsOutboundMetrics outboundMetrics) {
     this.jobWorkerManager = jobWorkerManager;
     this.connectorFactory = connectorFactory;
     this.commandExceptionHandlingStrategy = commandExceptionHandlingStrategy;
@@ -66,6 +69,7 @@ public class OutboundConnectorManager {
     this.documentFactory = documentFactory;
     this.objectMapper = objectMapper;
     this.metricsRecorder = metricsRecorder;
+    this.outboundMetrics = outboundMetrics;
   }
 
   public void start(final CamundaClient client) {
@@ -100,6 +104,7 @@ public class OutboundConnectorManager {
     JobHandler connectorJobHandler =
         new SpringConnectorJobHandler(
             metricsRecorder,
+            outboundMetrics,
             commandExceptionHandlingStrategy,
             secretProviderAggregator,
             validationProvider,

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/lifecycle/OutboundConnectorManager.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/lifecycle/OutboundConnectorManager.java
@@ -30,7 +30,7 @@ import io.camunda.document.factory.DocumentFactory;
 import io.camunda.spring.client.annotation.value.JobWorkerValue;
 import io.camunda.spring.client.jobhandling.CommandExceptionHandlingStrategy;
 import io.camunda.spring.client.jobhandling.JobWorkerManager;
-import io.camunda.spring.client.metrics.MetricsRecorder;
+import io.camunda.spring.client.metrics.DefaultNoopMetricsRecorder;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.Set;
@@ -47,7 +47,6 @@ public class OutboundConnectorManager {
   private final SecretProviderAggregator secretProviderAggregator;
   private final ValidationProvider validationProvider;
   private final ObjectMapper objectMapper;
-  private final MetricsRecorder metricsRecorder;
   private final DocumentFactory documentFactory;
   private final ConnectorsOutboundMetrics outboundMetrics;
 
@@ -59,7 +58,6 @@ public class OutboundConnectorManager {
       ValidationProvider validationProvider,
       DocumentFactory documentFactory,
       ObjectMapper objectMapper,
-      MetricsRecorder metricsRecorder,
       ConnectorsOutboundMetrics outboundMetrics) {
     this.jobWorkerManager = jobWorkerManager;
     this.connectorFactory = connectorFactory;
@@ -68,7 +66,6 @@ public class OutboundConnectorManager {
     this.validationProvider = validationProvider;
     this.documentFactory = documentFactory;
     this.objectMapper = objectMapper;
-    this.metricsRecorder = metricsRecorder;
     this.outboundMetrics = outboundMetrics;
   }
 
@@ -103,7 +100,6 @@ public class OutboundConnectorManager {
 
     JobHandler connectorJobHandler =
         new SpringConnectorJobHandler(
-            metricsRecorder,
             outboundMetrics,
             commandExceptionHandlingStrategy,
             secretProviderAggregator,
@@ -111,7 +107,7 @@ public class OutboundConnectorManager {
             documentFactory,
             objectMapper,
             connectorFunction,
-            connector);
+            new DefaultNoopMetricsRecorder());
 
     jobWorkerManager.openWorker(client, zeebeWorkerValue, connectorJobHandler);
   }

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/inbound/executable/InboundExecutableRegistryTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/inbound/executable/InboundExecutableRegistryTest.java
@@ -32,6 +32,7 @@ import io.camunda.connector.runtime.core.inbound.correlation.StartEventCorrelati
 import io.camunda.connector.runtime.core.inbound.details.InboundConnectorDetails;
 import io.camunda.connector.runtime.inbound.executable.InboundExecutableEvent.Activated;
 import io.camunda.connector.runtime.inbound.executable.RegisteredExecutable.ConnectorNotRegistered;
+import io.camunda.connector.runtime.metrics.ConnectorsInboundMetrics;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
@@ -44,21 +45,21 @@ import org.junit.jupiter.api.Test;
 
 public class InboundExecutableRegistryTest {
 
+  public static final String RANDOM_STRING = "thededuplicationId";
   private static final ScheduledExecutorService scheduledExecutorService =
       Executors.newSingleThreadScheduledExecutor();
+  private static final ExecutableId RANDOM_ID = ExecutableId.fromDeduplicationId(RANDOM_STRING);
   private InboundConnectorFactory factory;
   private InboundConnectorContextFactory contextFactory;
   private BatchExecutableProcessor batchProcessor;
   private InboundExecutableRegistryImpl registry;
 
-  public static final String RANDOM_STRING = "thededuplicationId";
-  private static final ExecutableId RANDOM_ID = ExecutableId.fromDeduplicationId(RANDOM_STRING);
-
   @BeforeEach
   public void prepareMocks() {
     factory = mock(InboundConnectorFactory.class);
     contextFactory = mock(DefaultInboundConnectorContextFactory.class);
-    batchProcessor = new BatchExecutableProcessor(factory, contextFactory, null, null);
+    var inboundMetrics = mock(ConnectorsInboundMetrics.class);
+    batchProcessor = new BatchExecutableProcessor(factory, contextFactory, inboundMetrics, null);
     registry = new InboundExecutableRegistryImpl(factory, batchProcessor);
   }
 

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/inbound/importer/ProcessDefinitionImporterTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/inbound/importer/ProcessDefinitionImporterTest.java
@@ -27,7 +27,8 @@ import io.camunda.client.impl.search.response.ProcessDefinitionImpl;
 import io.camunda.client.protocol.rest.ProcessDefinitionResult;
 import io.camunda.connector.runtime.inbound.state.ProcessImportResult;
 import io.camunda.connector.runtime.inbound.state.ProcessStateStore;
-import io.camunda.spring.client.metrics.DefaultNoopMetricsRecorder;
+import io.camunda.connector.runtime.metrics.ConnectorsInboundMetrics;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -43,7 +44,9 @@ public class ProcessDefinitionImporterTest {
   public void init() {
     stateStore = mock(ProcessStateStore.class);
     search = mock(ProcessDefinitionSearch.class);
-    importer = new ProcessDefinitionImporter(stateStore, search, new DefaultNoopMetricsRecorder());
+    importer =
+        new ProcessDefinitionImporter(
+            stateStore, search, new ConnectorsInboundMetrics(new SimpleMeterRegistry()));
   }
 
   @Test

--- a/connector-sdk/core/src/main/java/io/camunda/connector/api/inbound/ProcessElement.java
+++ b/connector-sdk/core/src/main/java/io/camunda/connector/api/inbound/ProcessElement.java
@@ -44,7 +44,7 @@ public record ProcessElement(
         null,
         null,
         tenantId,
-        null,
+        new ElementTemplateDetails("Test", "1", "icon"),
         Map.of());
   }
 }

--- a/connectors/asana/element-templates/asana-connector.json
+++ b/connectors/asana/element-templates/asana-connector.json
@@ -644,6 +644,29 @@
       }
     },
     {
+      "id" : "version",
+      "label" : "Version",
+      "description" : "Version of the element template",
+      "value" : "2",
+      "group" : "connector",
+      "binding" : {
+        "key" : "elementTemplateVersion",
+        "type" : "zeebe:taskHeader"
+      },
+      "type" : "Hidden"
+    }, {
+      "id" : "id",
+      "label" : "ID",
+      "description" : "ID of the element template",
+      "value" : "io.camunda.connectors.Asana.v1",
+      "group" : "connector",
+      "binding" : {
+        "key" : "elementTemplateId",
+        "type" : "zeebe:taskHeader"
+      },
+      "type" : "Hidden"
+    },
+    {
       "label": "Result variable",
       "description": "Name of variable to store the response in. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-variable\" target=\"_blank\">documentation</a>",
       "group": "output",

--- a/connectors/automation-anywhere/element-templates/automation-anywhere-outbound-connector.json
+++ b/connectors/automation-anywhere/element-templates/automation-anywhere-outbound-connector.json
@@ -32,6 +32,9 @@
     "id" : "timeout",
     "label" : "Timeout"
   }, {
+    "id" : "connector",
+    "label" : "Connector"
+  }, {
     "id" : "output",
     "label" : "Output mapping"
   }, {
@@ -312,6 +315,28 @@
       "type" : "zeebe:input"
     },
     "type" : "Number"
+  }, {
+    "id" : "version",
+    "label" : "Version",
+    "description" : "Version of the element template",
+    "value" : "2",
+    "group" : "connector",
+    "binding" : {
+      "key" : "version",
+      "type" : "zeebe:taskHeader"
+    },
+    "type" : "Hidden"
+  }, {
+    "id" : "id",
+    "label" : "ID",
+    "description" : "ID of the element template",
+    "value" : "io.camunda.connectors.AutomationAnywhere",
+    "group" : "connector",
+    "binding" : {
+      "key" : "id",
+      "type" : "zeebe:taskHeader"
+    },
+    "type" : "Hidden"
   }, {
     "id" : "resultVariable",
     "label" : "Result variable",

--- a/connectors/automation-anywhere/element-templates/automation-anywhere-outbound-connector.json
+++ b/connectors/automation-anywhere/element-templates/automation-anywhere-outbound-connector.json
@@ -322,7 +322,7 @@
     "value" : "2",
     "group" : "connector",
     "binding" : {
-      "key" : "version",
+      "key" : "elementTemplateVersion",
       "type" : "zeebe:taskHeader"
     },
     "type" : "Hidden"
@@ -333,7 +333,7 @@
     "value" : "io.camunda.connectors.AutomationAnywhere",
     "group" : "connector",
     "binding" : {
-      "key" : "id",
+      "key" : "elementTemplateId",
       "type" : "zeebe:taskHeader"
     },
     "type" : "Hidden"

--- a/connectors/automation-anywhere/element-templates/hybrid/automation-anywhere-outbound-connector-hybrid.json
+++ b/connectors/automation-anywhere/element-templates/hybrid/automation-anywhere-outbound-connector-hybrid.json
@@ -327,7 +327,7 @@
     "value" : "2",
     "group" : "connector",
     "binding" : {
-      "key" : "version",
+      "key" : "elementTemplateVersion",
       "type" : "zeebe:taskHeader"
     },
     "type" : "Hidden"
@@ -338,7 +338,7 @@
     "value" : "io.camunda.connectors.AutomationAnywhere",
     "group" : "connector",
     "binding" : {
-      "key" : "id",
+      "key" : "elementTemplateId",
       "type" : "zeebe:taskHeader"
     },
     "type" : "Hidden"

--- a/connectors/automation-anywhere/element-templates/hybrid/automation-anywhere-outbound-connector-hybrid.json
+++ b/connectors/automation-anywhere/element-templates/hybrid/automation-anywhere-outbound-connector-hybrid.json
@@ -35,6 +35,9 @@
     "id" : "timeout",
     "label" : "Timeout"
   }, {
+    "id" : "connector",
+    "label" : "Connector"
+  }, {
     "id" : "output",
     "label" : "Output mapping"
   }, {
@@ -317,6 +320,28 @@
       "type" : "zeebe:input"
     },
     "type" : "Number"
+  }, {
+    "id" : "version",
+    "label" : "Version",
+    "description" : "Version of the element template",
+    "value" : "2",
+    "group" : "connector",
+    "binding" : {
+      "key" : "version",
+      "type" : "zeebe:taskHeader"
+    },
+    "type" : "Hidden"
+  }, {
+    "id" : "id",
+    "label" : "ID",
+    "description" : "ID of the element template",
+    "value" : "io.camunda.connectors.AutomationAnywhere",
+    "group" : "connector",
+    "binding" : {
+      "key" : "id",
+      "type" : "zeebe:taskHeader"
+    },
+    "type" : "Hidden"
   }, {
     "id" : "resultVariable",
     "label" : "Result variable",

--- a/connectors/aws/aws-bedrock/element-templates/aws-bedrock-outbound-connector.json
+++ b/connectors/aws/aws-bedrock/element-templates/aws-bedrock-outbound-connector.json
@@ -32,6 +32,9 @@
     "id" : "converse",
     "label" : "Converse"
   }, {
+    "id" : "connector",
+    "label" : "Connector"
+  }, {
     "id" : "output",
     "label" : "Output mapping"
   }, {
@@ -310,6 +313,28 @@
       "type" : "simple"
     },
     "type" : "String"
+  }, {
+    "id" : "version",
+    "label" : "Version",
+    "description" : "Version of the element template",
+    "value" : "2",
+    "group" : "connector",
+    "binding" : {
+      "key" : "version",
+      "type" : "zeebe:taskHeader"
+    },
+    "type" : "Hidden"
+  }, {
+    "id" : "id",
+    "label" : "ID",
+    "description" : "ID of the element template",
+    "value" : "io.camunda.connectors.aws.bedrock.v1",
+    "group" : "connector",
+    "binding" : {
+      "key" : "id",
+      "type" : "zeebe:taskHeader"
+    },
+    "type" : "Hidden"
   }, {
     "id" : "resultVariable",
     "label" : "Result variable",

--- a/connectors/aws/aws-bedrock/element-templates/aws-bedrock-outbound-connector.json
+++ b/connectors/aws/aws-bedrock/element-templates/aws-bedrock-outbound-connector.json
@@ -320,7 +320,7 @@
     "value" : "2",
     "group" : "connector",
     "binding" : {
-      "key" : "version",
+      "key" : "elementTemplateVersion",
       "type" : "zeebe:taskHeader"
     },
     "type" : "Hidden"
@@ -331,7 +331,7 @@
     "value" : "io.camunda.connectors.aws.bedrock.v1",
     "group" : "connector",
     "binding" : {
-      "key" : "id",
+      "key" : "elementTemplateId",
       "type" : "zeebe:taskHeader"
     },
     "type" : "Hidden"

--- a/connectors/aws/aws-bedrock/element-templates/hybrid/aws-bedrock-outbound-connector-hybrid.json
+++ b/connectors/aws/aws-bedrock/element-templates/hybrid/aws-bedrock-outbound-connector-hybrid.json
@@ -35,6 +35,9 @@
     "id" : "converse",
     "label" : "Converse"
   }, {
+    "id" : "connector",
+    "label" : "Connector"
+  }, {
     "id" : "output",
     "label" : "Output mapping"
   }, {
@@ -315,6 +318,28 @@
       "type" : "simple"
     },
     "type" : "String"
+  }, {
+    "id" : "version",
+    "label" : "Version",
+    "description" : "Version of the element template",
+    "value" : "2",
+    "group" : "connector",
+    "binding" : {
+      "key" : "version",
+      "type" : "zeebe:taskHeader"
+    },
+    "type" : "Hidden"
+  }, {
+    "id" : "id",
+    "label" : "ID",
+    "description" : "ID of the element template",
+    "value" : "io.camunda.connectors.aws.bedrock.v1",
+    "group" : "connector",
+    "binding" : {
+      "key" : "id",
+      "type" : "zeebe:taskHeader"
+    },
+    "type" : "Hidden"
   }, {
     "id" : "resultVariable",
     "label" : "Result variable",

--- a/connectors/aws/aws-bedrock/element-templates/hybrid/aws-bedrock-outbound-connector-hybrid.json
+++ b/connectors/aws/aws-bedrock/element-templates/hybrid/aws-bedrock-outbound-connector-hybrid.json
@@ -325,7 +325,7 @@
     "value" : "2",
     "group" : "connector",
     "binding" : {
-      "key" : "version",
+      "key" : "elementTemplateVersion",
       "type" : "zeebe:taskHeader"
     },
     "type" : "Hidden"
@@ -336,7 +336,7 @@
     "value" : "io.camunda.connectors.aws.bedrock.v1",
     "group" : "connector",
     "binding" : {
-      "key" : "id",
+      "key" : "elementTemplateId",
       "type" : "zeebe:taskHeader"
     },
     "type" : "Hidden"

--- a/connectors/aws/aws-comprehend/element-templates/aws-comprehend-outbound-connector.json
+++ b/connectors/aws/aws-comprehend/element-templates/aws-comprehend-outbound-connector.json
@@ -542,7 +542,7 @@
     "value" : "1",
     "group" : "connector",
     "binding" : {
-      "key" : "version",
+      "key" : "elementTemplateVersion",
       "type" : "zeebe:taskHeader"
     },
     "type" : "Hidden"
@@ -553,7 +553,7 @@
     "value" : "io.camunda.connectors.AWSCOMPREHEND.v1",
     "group" : "connector",
     "binding" : {
-      "key" : "id",
+      "key" : "elementTemplateId",
       "type" : "zeebe:taskHeader"
     },
     "type" : "Hidden"

--- a/connectors/aws/aws-comprehend/element-templates/aws-comprehend-outbound-connector.json
+++ b/connectors/aws/aws-comprehend/element-templates/aws-comprehend-outbound-connector.json
@@ -26,6 +26,9 @@
     "id" : "input",
     "label" : "Data Configuration and Processing"
   }, {
+    "id" : "connector",
+    "label" : "Connector"
+  }, {
     "id" : "output",
     "label" : "Output mapping"
   }, {
@@ -532,6 +535,28 @@
       "type" : "simple"
     },
     "type" : "String"
+  }, {
+    "id" : "version",
+    "label" : "Version",
+    "description" : "Version of the element template",
+    "value" : "1",
+    "group" : "connector",
+    "binding" : {
+      "key" : "version",
+      "type" : "zeebe:taskHeader"
+    },
+    "type" : "Hidden"
+  }, {
+    "id" : "id",
+    "label" : "ID",
+    "description" : "ID of the element template",
+    "value" : "io.camunda.connectors.AWSCOMPREHEND.v1",
+    "group" : "connector",
+    "binding" : {
+      "key" : "id",
+      "type" : "zeebe:taskHeader"
+    },
+    "type" : "Hidden"
   }, {
     "id" : "resultVariable",
     "label" : "Result variable",

--- a/connectors/aws/aws-comprehend/element-templates/hybrid/aws-comprehend-outbound-connector-hybrid.json
+++ b/connectors/aws/aws-comprehend/element-templates/hybrid/aws-comprehend-outbound-connector-hybrid.json
@@ -547,7 +547,7 @@
     "value" : "1",
     "group" : "connector",
     "binding" : {
-      "key" : "version",
+      "key" : "elementTemplateVersion",
       "type" : "zeebe:taskHeader"
     },
     "type" : "Hidden"
@@ -558,7 +558,7 @@
     "value" : "io.camunda.connectors.AWSCOMPREHEND.v1",
     "group" : "connector",
     "binding" : {
-      "key" : "id",
+      "key" : "elementTemplateId",
       "type" : "zeebe:taskHeader"
     },
     "type" : "Hidden"

--- a/connectors/aws/aws-comprehend/element-templates/hybrid/aws-comprehend-outbound-connector-hybrid.json
+++ b/connectors/aws/aws-comprehend/element-templates/hybrid/aws-comprehend-outbound-connector-hybrid.json
@@ -29,6 +29,9 @@
     "id" : "input",
     "label" : "Data Configuration and Processing"
   }, {
+    "id" : "connector",
+    "label" : "Connector"
+  }, {
     "id" : "output",
     "label" : "Output mapping"
   }, {
@@ -537,6 +540,28 @@
       "type" : "simple"
     },
     "type" : "String"
+  }, {
+    "id" : "version",
+    "label" : "Version",
+    "description" : "Version of the element template",
+    "value" : "1",
+    "group" : "connector",
+    "binding" : {
+      "key" : "version",
+      "type" : "zeebe:taskHeader"
+    },
+    "type" : "Hidden"
+  }, {
+    "id" : "id",
+    "label" : "ID",
+    "description" : "ID of the element template",
+    "value" : "io.camunda.connectors.AWSCOMPREHEND.v1",
+    "group" : "connector",
+    "binding" : {
+      "key" : "id",
+      "type" : "zeebe:taskHeader"
+    },
+    "type" : "Hidden"
   }, {
     "id" : "resultVariable",
     "label" : "Result variable",

--- a/connectors/aws/aws-dynamodb/element-templates/aws-dynamodb-outbound-connector.json
+++ b/connectors/aws/aws-dynamodb/element-templates/aws-dynamodb-outbound-connector.json
@@ -29,6 +29,9 @@
     "id" : "input",
     "label" : "Input"
   }, {
+    "id" : "connector",
+    "label" : "Connector"
+  }, {
     "id" : "output",
     "label" : "Output mapping"
   }, {
@@ -955,6 +958,28 @@
       "name" : "DELETE",
       "value" : "delete"
     } ]
+  }, {
+    "id" : "version",
+    "label" : "Version",
+    "description" : "Version of the element template",
+    "value" : "7",
+    "group" : "connector",
+    "binding" : {
+      "key" : "version",
+      "type" : "zeebe:taskHeader"
+    },
+    "type" : "Hidden"
+  }, {
+    "id" : "id",
+    "label" : "ID",
+    "description" : "ID of the element template",
+    "value" : "io.camunda.connectors.AWSDynamoDB.v1",
+    "group" : "connector",
+    "binding" : {
+      "key" : "id",
+      "type" : "zeebe:taskHeader"
+    },
+    "type" : "Hidden"
   }, {
     "id" : "resultVariable",
     "label" : "Result variable",

--- a/connectors/aws/aws-dynamodb/element-templates/aws-dynamodb-outbound-connector.json
+++ b/connectors/aws/aws-dynamodb/element-templates/aws-dynamodb-outbound-connector.json
@@ -965,7 +965,7 @@
     "value" : "7",
     "group" : "connector",
     "binding" : {
-      "key" : "version",
+      "key" : "elementTemplateVersion",
       "type" : "zeebe:taskHeader"
     },
     "type" : "Hidden"
@@ -976,7 +976,7 @@
     "value" : "io.camunda.connectors.AWSDynamoDB.v1",
     "group" : "connector",
     "binding" : {
-      "key" : "id",
+      "key" : "elementTemplateId",
       "type" : "zeebe:taskHeader"
     },
     "type" : "Hidden"

--- a/connectors/aws/aws-dynamodb/element-templates/hybrid/aws-dynamodb-outbound-connector-hybrid.json
+++ b/connectors/aws/aws-dynamodb/element-templates/hybrid/aws-dynamodb-outbound-connector-hybrid.json
@@ -32,6 +32,9 @@
     "id" : "input",
     "label" : "Input"
   }, {
+    "id" : "connector",
+    "label" : "Connector"
+  }, {
     "id" : "output",
     "label" : "Output mapping"
   }, {
@@ -960,6 +963,28 @@
       "name" : "DELETE",
       "value" : "delete"
     } ]
+  }, {
+    "id" : "version",
+    "label" : "Version",
+    "description" : "Version of the element template",
+    "value" : "7",
+    "group" : "connector",
+    "binding" : {
+      "key" : "version",
+      "type" : "zeebe:taskHeader"
+    },
+    "type" : "Hidden"
+  }, {
+    "id" : "id",
+    "label" : "ID",
+    "description" : "ID of the element template",
+    "value" : "io.camunda.connectors.AWSDynamoDB.v1",
+    "group" : "connector",
+    "binding" : {
+      "key" : "id",
+      "type" : "zeebe:taskHeader"
+    },
+    "type" : "Hidden"
   }, {
     "id" : "resultVariable",
     "label" : "Result variable",

--- a/connectors/aws/aws-dynamodb/element-templates/hybrid/aws-dynamodb-outbound-connector-hybrid.json
+++ b/connectors/aws/aws-dynamodb/element-templates/hybrid/aws-dynamodb-outbound-connector-hybrid.json
@@ -970,7 +970,7 @@
     "value" : "7",
     "group" : "connector",
     "binding" : {
-      "key" : "version",
+      "key" : "elementTemplateVersion",
       "type" : "zeebe:taskHeader"
     },
     "type" : "Hidden"
@@ -981,7 +981,7 @@
     "value" : "io.camunda.connectors.AWSDynamoDB.v1",
     "group" : "connector",
     "binding" : {
-      "key" : "id",
+      "key" : "elementTemplateId",
       "type" : "zeebe:taskHeader"
     },
     "type" : "Hidden"

--- a/connectors/aws/aws-eventbridge/element-templates/aws-eventbridge-outbound-connector.json
+++ b/connectors/aws/aws-eventbridge/element-templates/aws-eventbridge-outbound-connector.json
@@ -29,6 +29,9 @@
     "id" : "eventPayload",
     "label" : "Event Payload"
   }, {
+    "id" : "connector",
+    "label" : "Connector"
+  }, {
     "id" : "output",
     "label" : "Output mapping"
   }, {
@@ -189,6 +192,28 @@
       "type" : "zeebe:input"
     },
     "type" : "String"
+  }, {
+    "id" : "version",
+    "label" : "Version",
+    "description" : "Version of the element template",
+    "value" : "5",
+    "group" : "connector",
+    "binding" : {
+      "key" : "version",
+      "type" : "zeebe:taskHeader"
+    },
+    "type" : "Hidden"
+  }, {
+    "id" : "id",
+    "label" : "ID",
+    "description" : "ID of the element template",
+    "value" : "io.camunda.connectors.AWSEventBridge.v1",
+    "group" : "connector",
+    "binding" : {
+      "key" : "id",
+      "type" : "zeebe:taskHeader"
+    },
+    "type" : "Hidden"
   }, {
     "id" : "resultVariable",
     "label" : "Result variable",

--- a/connectors/aws/aws-eventbridge/element-templates/aws-eventbridge-outbound-connector.json
+++ b/connectors/aws/aws-eventbridge/element-templates/aws-eventbridge-outbound-connector.json
@@ -199,7 +199,7 @@
     "value" : "5",
     "group" : "connector",
     "binding" : {
-      "key" : "version",
+      "key" : "elementTemplateVersion",
       "type" : "zeebe:taskHeader"
     },
     "type" : "Hidden"
@@ -210,7 +210,7 @@
     "value" : "io.camunda.connectors.AWSEventBridge.v1",
     "group" : "connector",
     "binding" : {
-      "key" : "id",
+      "key" : "elementTemplateId",
       "type" : "zeebe:taskHeader"
     },
     "type" : "Hidden"

--- a/connectors/aws/aws-eventbridge/element-templates/hybrid/aws-eventbridge-outbound-connector-hybrid.json
+++ b/connectors/aws/aws-eventbridge/element-templates/hybrid/aws-eventbridge-outbound-connector-hybrid.json
@@ -204,7 +204,7 @@
     "value" : "5",
     "group" : "connector",
     "binding" : {
-      "key" : "version",
+      "key" : "elementTemplateVersion",
       "type" : "zeebe:taskHeader"
     },
     "type" : "Hidden"
@@ -215,7 +215,7 @@
     "value" : "io.camunda.connectors.AWSEventBridge.v1",
     "group" : "connector",
     "binding" : {
-      "key" : "id",
+      "key" : "elementTemplateId",
       "type" : "zeebe:taskHeader"
     },
     "type" : "Hidden"

--- a/connectors/aws/aws-eventbridge/element-templates/hybrid/aws-eventbridge-outbound-connector-hybrid.json
+++ b/connectors/aws/aws-eventbridge/element-templates/hybrid/aws-eventbridge-outbound-connector-hybrid.json
@@ -32,6 +32,9 @@
     "id" : "eventPayload",
     "label" : "Event Payload"
   }, {
+    "id" : "connector",
+    "label" : "Connector"
+  }, {
     "id" : "output",
     "label" : "Output mapping"
   }, {
@@ -194,6 +197,28 @@
       "type" : "zeebe:input"
     },
     "type" : "String"
+  }, {
+    "id" : "version",
+    "label" : "Version",
+    "description" : "Version of the element template",
+    "value" : "5",
+    "group" : "connector",
+    "binding" : {
+      "key" : "version",
+      "type" : "zeebe:taskHeader"
+    },
+    "type" : "Hidden"
+  }, {
+    "id" : "id",
+    "label" : "ID",
+    "description" : "ID of the element template",
+    "value" : "io.camunda.connectors.AWSEventBridge.v1",
+    "group" : "connector",
+    "binding" : {
+      "key" : "id",
+      "type" : "zeebe:taskHeader"
+    },
+    "type" : "Hidden"
   }, {
     "id" : "resultVariable",
     "label" : "Result variable",

--- a/connectors/aws/aws-lambda/element-templates/aws-lambda-outbound-connector.json
+++ b/connectors/aws/aws-lambda/element-templates/aws-lambda-outbound-connector.json
@@ -184,7 +184,7 @@
     "value" : "5",
     "group" : "connector",
     "binding" : {
-      "key" : "version",
+      "key" : "elementTemplateVersion",
       "type" : "zeebe:taskHeader"
     },
     "type" : "Hidden"
@@ -195,7 +195,7 @@
     "value" : "io.camunda.connectors.AWSLAMBDA.v2",
     "group" : "connector",
     "binding" : {
-      "key" : "id",
+      "key" : "elementTemplateId",
       "type" : "zeebe:taskHeader"
     },
     "type" : "Hidden"

--- a/connectors/aws/aws-lambda/element-templates/aws-lambda-outbound-connector.json
+++ b/connectors/aws/aws-lambda/element-templates/aws-lambda-outbound-connector.json
@@ -29,6 +29,9 @@
     "id" : "operationDetails",
     "label" : "Operation details"
   }, {
+    "id" : "connector",
+    "label" : "Connector"
+  }, {
     "id" : "output",
     "label" : "Output mapping"
   }, {
@@ -174,6 +177,28 @@
       "type" : "zeebe:input"
     },
     "type" : "Text"
+  }, {
+    "id" : "version",
+    "label" : "Version",
+    "description" : "Version of the element template",
+    "value" : "5",
+    "group" : "connector",
+    "binding" : {
+      "key" : "version",
+      "type" : "zeebe:taskHeader"
+    },
+    "type" : "Hidden"
+  }, {
+    "id" : "id",
+    "label" : "ID",
+    "description" : "ID of the element template",
+    "value" : "io.camunda.connectors.AWSLAMBDA.v2",
+    "group" : "connector",
+    "binding" : {
+      "key" : "id",
+      "type" : "zeebe:taskHeader"
+    },
+    "type" : "Hidden"
   }, {
     "id" : "resultVariable",
     "label" : "Result variable",

--- a/connectors/aws/aws-lambda/element-templates/hybrid/aws-lambda-outbound-connector-hybrid.json
+++ b/connectors/aws/aws-lambda/element-templates/hybrid/aws-lambda-outbound-connector-hybrid.json
@@ -32,6 +32,9 @@
     "id" : "operationDetails",
     "label" : "Operation details"
   }, {
+    "id" : "connector",
+    "label" : "Connector"
+  }, {
     "id" : "output",
     "label" : "Output mapping"
   }, {
@@ -179,6 +182,28 @@
       "type" : "zeebe:input"
     },
     "type" : "Text"
+  }, {
+    "id" : "version",
+    "label" : "Version",
+    "description" : "Version of the element template",
+    "value" : "5",
+    "group" : "connector",
+    "binding" : {
+      "key" : "version",
+      "type" : "zeebe:taskHeader"
+    },
+    "type" : "Hidden"
+  }, {
+    "id" : "id",
+    "label" : "ID",
+    "description" : "ID of the element template",
+    "value" : "io.camunda.connectors.AWSLAMBDA.v2",
+    "group" : "connector",
+    "binding" : {
+      "key" : "id",
+      "type" : "zeebe:taskHeader"
+    },
+    "type" : "Hidden"
   }, {
     "id" : "resultVariable",
     "label" : "Result variable",

--- a/connectors/aws/aws-lambda/element-templates/hybrid/aws-lambda-outbound-connector-hybrid.json
+++ b/connectors/aws/aws-lambda/element-templates/hybrid/aws-lambda-outbound-connector-hybrid.json
@@ -189,7 +189,7 @@
     "value" : "5",
     "group" : "connector",
     "binding" : {
-      "key" : "version",
+      "key" : "elementTemplateVersion",
       "type" : "zeebe:taskHeader"
     },
     "type" : "Hidden"
@@ -200,7 +200,7 @@
     "value" : "io.camunda.connectors.AWSLAMBDA.v2",
     "group" : "connector",
     "binding" : {
-      "key" : "id",
+      "key" : "elementTemplateId",
       "type" : "zeebe:taskHeader"
     },
     "type" : "Hidden"

--- a/connectors/aws/aws-s3/element-templates/aws-s3-outbound-connector.json
+++ b/connectors/aws/aws-s3/element-templates/aws-s3-outbound-connector.json
@@ -320,7 +320,7 @@
     "value" : "1",
     "group" : "connector",
     "binding" : {
-      "key" : "version",
+      "key" : "elementTemplateVersion",
       "type" : "zeebe:taskHeader"
     },
     "type" : "Hidden"
@@ -331,7 +331,7 @@
     "value" : "io.camunda.connectors.aws.s3.v1",
     "group" : "connector",
     "binding" : {
-      "key" : "id",
+      "key" : "elementTemplateId",
       "type" : "zeebe:taskHeader"
     },
     "type" : "Hidden"

--- a/connectors/aws/aws-s3/element-templates/aws-s3-outbound-connector.json
+++ b/connectors/aws/aws-s3/element-templates/aws-s3-outbound-connector.json
@@ -35,6 +35,9 @@
     "id" : "downloadObject",
     "label" : "Download an object"
   }, {
+    "id" : "connector",
+    "label" : "Connector"
+  }, {
     "id" : "output",
     "label" : "Output mapping"
   }, {
@@ -310,6 +313,28 @@
     },
     "tooltip" : "If set to true, a document reference will be created. If set to false, the content will be extracted and provided inside the response.",
     "type" : "Boolean"
+  }, {
+    "id" : "version",
+    "label" : "Version",
+    "description" : "Version of the element template",
+    "value" : "1",
+    "group" : "connector",
+    "binding" : {
+      "key" : "version",
+      "type" : "zeebe:taskHeader"
+    },
+    "type" : "Hidden"
+  }, {
+    "id" : "id",
+    "label" : "ID",
+    "description" : "ID of the element template",
+    "value" : "io.camunda.connectors.aws.s3.v1",
+    "group" : "connector",
+    "binding" : {
+      "key" : "id",
+      "type" : "zeebe:taskHeader"
+    },
+    "type" : "Hidden"
   }, {
     "id" : "resultVariable",
     "label" : "Result variable",

--- a/connectors/aws/aws-s3/element-templates/hybrid/aws-s3-outbound-connector-hybrid.json
+++ b/connectors/aws/aws-s3/element-templates/hybrid/aws-s3-outbound-connector-hybrid.json
@@ -325,7 +325,7 @@
     "value" : "1",
     "group" : "connector",
     "binding" : {
-      "key" : "version",
+      "key" : "elementTemplateVersion",
       "type" : "zeebe:taskHeader"
     },
     "type" : "Hidden"
@@ -336,7 +336,7 @@
     "value" : "io.camunda.connectors.aws.s3.v1",
     "group" : "connector",
     "binding" : {
-      "key" : "id",
+      "key" : "elementTemplateId",
       "type" : "zeebe:taskHeader"
     },
     "type" : "Hidden"

--- a/connectors/aws/aws-s3/element-templates/hybrid/aws-s3-outbound-connector-hybrid.json
+++ b/connectors/aws/aws-s3/element-templates/hybrid/aws-s3-outbound-connector-hybrid.json
@@ -38,6 +38,9 @@
     "id" : "downloadObject",
     "label" : "Download an object"
   }, {
+    "id" : "connector",
+    "label" : "Connector"
+  }, {
     "id" : "output",
     "label" : "Output mapping"
   }, {
@@ -315,6 +318,28 @@
     },
     "tooltip" : "If set to true, a document reference will be created. If set to false, the content will be extracted and provided inside the response.",
     "type" : "Boolean"
+  }, {
+    "id" : "version",
+    "label" : "Version",
+    "description" : "Version of the element template",
+    "value" : "1",
+    "group" : "connector",
+    "binding" : {
+      "key" : "version",
+      "type" : "zeebe:taskHeader"
+    },
+    "type" : "Hidden"
+  }, {
+    "id" : "id",
+    "label" : "ID",
+    "description" : "ID of the element template",
+    "value" : "io.camunda.connectors.aws.s3.v1",
+    "group" : "connector",
+    "binding" : {
+      "key" : "id",
+      "type" : "zeebe:taskHeader"
+    },
+    "type" : "Hidden"
   }, {
     "id" : "resultVariable",
     "label" : "Result variable",

--- a/connectors/aws/aws-sagemaker/element-templates/aws-sagemaker-outbound-connector.json
+++ b/connectors/aws/aws-sagemaker/element-templates/aws-sagemaker-outbound-connector.json
@@ -398,7 +398,7 @@
     "value" : "1",
     "group" : "connector",
     "binding" : {
-      "key" : "version",
+      "key" : "elementTemplateVersion",
       "type" : "zeebe:taskHeader"
     },
     "type" : "Hidden"
@@ -409,7 +409,7 @@
     "value" : "io.camunda.connectors.AWSSAGEMAKER.v1",
     "group" : "connector",
     "binding" : {
-      "key" : "id",
+      "key" : "elementTemplateId",
       "type" : "zeebe:taskHeader"
     },
     "type" : "Hidden"

--- a/connectors/aws/aws-sagemaker/element-templates/aws-sagemaker-outbound-connector.json
+++ b/connectors/aws/aws-sagemaker/element-templates/aws-sagemaker-outbound-connector.json
@@ -26,6 +26,9 @@
     "id" : "input",
     "label" : "Configure input"
   }, {
+    "id" : "connector",
+    "label" : "Connector"
+  }, {
     "id" : "output",
     "label" : "Output mapping"
   }, {
@@ -388,6 +391,28 @@
       "type" : "simple"
     },
     "type" : "String"
+  }, {
+    "id" : "version",
+    "label" : "Version",
+    "description" : "Version of the element template",
+    "value" : "1",
+    "group" : "connector",
+    "binding" : {
+      "key" : "version",
+      "type" : "zeebe:taskHeader"
+    },
+    "type" : "Hidden"
+  }, {
+    "id" : "id",
+    "label" : "ID",
+    "description" : "ID of the element template",
+    "value" : "io.camunda.connectors.AWSSAGEMAKER.v1",
+    "group" : "connector",
+    "binding" : {
+      "key" : "id",
+      "type" : "zeebe:taskHeader"
+    },
+    "type" : "Hidden"
   }, {
     "id" : "resultVariable",
     "label" : "Result variable",

--- a/connectors/aws/aws-sagemaker/element-templates/hybrid/aws-sagemaker-outbound-connector-hybrid.json
+++ b/connectors/aws/aws-sagemaker/element-templates/hybrid/aws-sagemaker-outbound-connector-hybrid.json
@@ -403,7 +403,7 @@
     "value" : "1",
     "group" : "connector",
     "binding" : {
-      "key" : "version",
+      "key" : "elementTemplateVersion",
       "type" : "zeebe:taskHeader"
     },
     "type" : "Hidden"
@@ -414,7 +414,7 @@
     "value" : "io.camunda.connectors.AWSSAGEMAKER.v1",
     "group" : "connector",
     "binding" : {
-      "key" : "id",
+      "key" : "elementTemplateId",
       "type" : "zeebe:taskHeader"
     },
     "type" : "Hidden"

--- a/connectors/aws/aws-sagemaker/element-templates/hybrid/aws-sagemaker-outbound-connector-hybrid.json
+++ b/connectors/aws/aws-sagemaker/element-templates/hybrid/aws-sagemaker-outbound-connector-hybrid.json
@@ -29,6 +29,9 @@
     "id" : "input",
     "label" : "Configure input"
   }, {
+    "id" : "connector",
+    "label" : "Connector"
+  }, {
     "id" : "output",
     "label" : "Output mapping"
   }, {
@@ -393,6 +396,28 @@
       "type" : "simple"
     },
     "type" : "String"
+  }, {
+    "id" : "version",
+    "label" : "Version",
+    "description" : "Version of the element template",
+    "value" : "1",
+    "group" : "connector",
+    "binding" : {
+      "key" : "version",
+      "type" : "zeebe:taskHeader"
+    },
+    "type" : "Hidden"
+  }, {
+    "id" : "id",
+    "label" : "ID",
+    "description" : "ID of the element template",
+    "value" : "io.camunda.connectors.AWSSAGEMAKER.v1",
+    "group" : "connector",
+    "binding" : {
+      "key" : "id",
+      "type" : "zeebe:taskHeader"
+    },
+    "type" : "Hidden"
   }, {
     "id" : "resultVariable",
     "label" : "Result variable",

--- a/connectors/aws/aws-sns/element-templates/aws-sns-outbound-connector.json
+++ b/connectors/aws/aws-sns/element-templates/aws-sns-outbound-connector.json
@@ -246,7 +246,7 @@
     "value" : "7",
     "group" : "connector",
     "binding" : {
-      "key" : "version",
+      "key" : "elementTemplateVersion",
       "type" : "zeebe:taskHeader"
     },
     "type" : "Hidden"
@@ -257,7 +257,7 @@
     "value" : "io.camunda.connectors.AWSSNS.v1",
     "group" : "connector",
     "binding" : {
-      "key" : "id",
+      "key" : "elementTemplateId",
       "type" : "zeebe:taskHeader"
     },
     "type" : "Hidden"

--- a/connectors/aws/aws-sns/element-templates/aws-sns-outbound-connector.json
+++ b/connectors/aws/aws-sns/element-templates/aws-sns-outbound-connector.json
@@ -26,6 +26,9 @@
     "id" : "input",
     "label" : "Input message data"
   }, {
+    "id" : "connector",
+    "label" : "Connector"
+  }, {
     "id" : "output",
     "label" : "Output mapping"
   }, {
@@ -236,6 +239,28 @@
       "type" : "zeebe:input"
     },
     "type" : "String"
+  }, {
+    "id" : "version",
+    "label" : "Version",
+    "description" : "Version of the element template",
+    "value" : "7",
+    "group" : "connector",
+    "binding" : {
+      "key" : "version",
+      "type" : "zeebe:taskHeader"
+    },
+    "type" : "Hidden"
+  }, {
+    "id" : "id",
+    "label" : "ID",
+    "description" : "ID of the element template",
+    "value" : "io.camunda.connectors.AWSSNS.v1",
+    "group" : "connector",
+    "binding" : {
+      "key" : "id",
+      "type" : "zeebe:taskHeader"
+    },
+    "type" : "Hidden"
   }, {
     "id" : "resultVariable",
     "label" : "Result variable",

--- a/connectors/aws/aws-sns/element-templates/hybrid/aws-sns-outbound-connector-hybrid.json
+++ b/connectors/aws/aws-sns/element-templates/hybrid/aws-sns-outbound-connector-hybrid.json
@@ -251,7 +251,7 @@
     "value" : "7",
     "group" : "connector",
     "binding" : {
-      "key" : "version",
+      "key" : "elementTemplateVersion",
       "type" : "zeebe:taskHeader"
     },
     "type" : "Hidden"
@@ -262,7 +262,7 @@
     "value" : "io.camunda.connectors.AWSSNS.v1",
     "group" : "connector",
     "binding" : {
-      "key" : "id",
+      "key" : "elementTemplateId",
       "type" : "zeebe:taskHeader"
     },
     "type" : "Hidden"

--- a/connectors/aws/aws-sns/element-templates/hybrid/aws-sns-outbound-connector-hybrid.json
+++ b/connectors/aws/aws-sns/element-templates/hybrid/aws-sns-outbound-connector-hybrid.json
@@ -29,6 +29,9 @@
     "id" : "input",
     "label" : "Input message data"
   }, {
+    "id" : "connector",
+    "label" : "Connector"
+  }, {
     "id" : "output",
     "label" : "Output mapping"
   }, {
@@ -241,6 +244,28 @@
       "type" : "zeebe:input"
     },
     "type" : "String"
+  }, {
+    "id" : "version",
+    "label" : "Version",
+    "description" : "Version of the element template",
+    "value" : "7",
+    "group" : "connector",
+    "binding" : {
+      "key" : "version",
+      "type" : "zeebe:taskHeader"
+    },
+    "type" : "Hidden"
+  }, {
+    "id" : "id",
+    "label" : "ID",
+    "description" : "ID of the element template",
+    "value" : "io.camunda.connectors.AWSSNS.v1",
+    "group" : "connector",
+    "binding" : {
+      "key" : "id",
+      "type" : "zeebe:taskHeader"
+    },
+    "type" : "Hidden"
   }, {
     "id" : "resultVariable",
     "label" : "Result variable",

--- a/connectors/aws/aws-sqs/element-templates/aws-sqs-outbound-connector.json
+++ b/connectors/aws/aws-sqs/element-templates/aws-sqs-outbound-connector.json
@@ -234,7 +234,7 @@
     "value" : "10",
     "group" : "connector",
     "binding" : {
-      "key" : "version",
+      "key" : "elementTemplateVersion",
       "type" : "zeebe:taskHeader"
     },
     "type" : "Hidden"
@@ -245,7 +245,7 @@
     "value" : "io.camunda.connectors.AWSSQS.v1",
     "group" : "connector",
     "binding" : {
-      "key" : "id",
+      "key" : "elementTemplateId",
       "type" : "zeebe:taskHeader"
     },
     "type" : "Hidden"

--- a/connectors/aws/aws-sqs/element-templates/aws-sqs-outbound-connector.json
+++ b/connectors/aws/aws-sqs/element-templates/aws-sqs-outbound-connector.json
@@ -26,6 +26,9 @@
     "id" : "input",
     "label" : "Input message data"
   }, {
+    "id" : "connector",
+    "label" : "Connector"
+  }, {
     "id" : "output",
     "label" : "Output mapping"
   }, {
@@ -224,6 +227,28 @@
       "type" : "simple"
     },
     "type" : "String"
+  }, {
+    "id" : "version",
+    "label" : "Version",
+    "description" : "Version of the element template",
+    "value" : "10",
+    "group" : "connector",
+    "binding" : {
+      "key" : "version",
+      "type" : "zeebe:taskHeader"
+    },
+    "type" : "Hidden"
+  }, {
+    "id" : "id",
+    "label" : "ID",
+    "description" : "ID of the element template",
+    "value" : "io.camunda.connectors.AWSSQS.v1",
+    "group" : "connector",
+    "binding" : {
+      "key" : "id",
+      "type" : "zeebe:taskHeader"
+    },
+    "type" : "Hidden"
   }, {
     "id" : "resultVariable",
     "label" : "Result variable",

--- a/connectors/aws/aws-sqs/element-templates/hybrid/aws-sqs-outbound-connector-hybrid.json
+++ b/connectors/aws/aws-sqs/element-templates/hybrid/aws-sqs-outbound-connector-hybrid.json
@@ -29,6 +29,9 @@
     "id" : "input",
     "label" : "Input message data"
   }, {
+    "id" : "connector",
+    "label" : "Connector"
+  }, {
     "id" : "output",
     "label" : "Output mapping"
   }, {
@@ -229,6 +232,28 @@
       "type" : "simple"
     },
     "type" : "String"
+  }, {
+    "id" : "version",
+    "label" : "Version",
+    "description" : "Version of the element template",
+    "value" : "10",
+    "group" : "connector",
+    "binding" : {
+      "key" : "version",
+      "type" : "zeebe:taskHeader"
+    },
+    "type" : "Hidden"
+  }, {
+    "id" : "id",
+    "label" : "ID",
+    "description" : "ID of the element template",
+    "value" : "io.camunda.connectors.AWSSQS.v1",
+    "group" : "connector",
+    "binding" : {
+      "key" : "id",
+      "type" : "zeebe:taskHeader"
+    },
+    "type" : "Hidden"
   }, {
     "id" : "resultVariable",
     "label" : "Result variable",

--- a/connectors/aws/aws-sqs/element-templates/hybrid/aws-sqs-outbound-connector-hybrid.json
+++ b/connectors/aws/aws-sqs/element-templates/hybrid/aws-sqs-outbound-connector-hybrid.json
@@ -239,7 +239,7 @@
     "value" : "10",
     "group" : "connector",
     "binding" : {
-      "key" : "version",
+      "key" : "elementTemplateVersion",
       "type" : "zeebe:taskHeader"
     },
     "type" : "Hidden"
@@ -250,7 +250,7 @@
     "value" : "io.camunda.connectors.AWSSQS.v1",
     "group" : "connector",
     "binding" : {
-      "key" : "id",
+      "key" : "elementTemplateId",
       "type" : "zeebe:taskHeader"
     },
     "type" : "Hidden"

--- a/connectors/aws/aws-textract/element-templates/aws-textract-outbound-connector.json
+++ b/connectors/aws/aws-textract/element-templates/aws-textract-outbound-connector.json
@@ -26,6 +26,9 @@
     "id" : "input",
     "label" : "Configure input"
   }, {
+    "id" : "connector",
+    "label" : "Connector"
+  }, {
     "id" : "output",
     "label" : "Output mapping"
   }, {
@@ -431,6 +434,28 @@
       "type" : "simple"
     },
     "type" : "String"
+  }, {
+    "id" : "version",
+    "label" : "Version",
+    "description" : "Version of the element template",
+    "value" : "2",
+    "group" : "connector",
+    "binding" : {
+      "key" : "version",
+      "type" : "zeebe:taskHeader"
+    },
+    "type" : "Hidden"
+  }, {
+    "id" : "id",
+    "label" : "ID",
+    "description" : "ID of the element template",
+    "value" : "io.camunda.connectors.AWSTEXTRACT.v1",
+    "group" : "connector",
+    "binding" : {
+      "key" : "id",
+      "type" : "zeebe:taskHeader"
+    },
+    "type" : "Hidden"
   }, {
     "id" : "resultVariable",
     "label" : "Result variable",

--- a/connectors/aws/aws-textract/element-templates/aws-textract-outbound-connector.json
+++ b/connectors/aws/aws-textract/element-templates/aws-textract-outbound-connector.json
@@ -441,7 +441,7 @@
     "value" : "2",
     "group" : "connector",
     "binding" : {
-      "key" : "version",
+      "key" : "elementTemplateVersion",
       "type" : "zeebe:taskHeader"
     },
     "type" : "Hidden"
@@ -452,7 +452,7 @@
     "value" : "io.camunda.connectors.AWSTEXTRACT.v1",
     "group" : "connector",
     "binding" : {
-      "key" : "id",
+      "key" : "elementTemplateId",
       "type" : "zeebe:taskHeader"
     },
     "type" : "Hidden"

--- a/connectors/aws/aws-textract/element-templates/hybrid/aws-textract-outbound-connector-hybrid.json
+++ b/connectors/aws/aws-textract/element-templates/hybrid/aws-textract-outbound-connector-hybrid.json
@@ -29,6 +29,9 @@
     "id" : "input",
     "label" : "Configure input"
   }, {
+    "id" : "connector",
+    "label" : "Connector"
+  }, {
     "id" : "output",
     "label" : "Output mapping"
   }, {
@@ -436,6 +439,28 @@
       "type" : "simple"
     },
     "type" : "String"
+  }, {
+    "id" : "version",
+    "label" : "Version",
+    "description" : "Version of the element template",
+    "value" : "2",
+    "group" : "connector",
+    "binding" : {
+      "key" : "version",
+      "type" : "zeebe:taskHeader"
+    },
+    "type" : "Hidden"
+  }, {
+    "id" : "id",
+    "label" : "ID",
+    "description" : "ID of the element template",
+    "value" : "io.camunda.connectors.AWSTEXTRACT.v1",
+    "group" : "connector",
+    "binding" : {
+      "key" : "id",
+      "type" : "zeebe:taskHeader"
+    },
+    "type" : "Hidden"
   }, {
     "id" : "resultVariable",
     "label" : "Result variable",

--- a/connectors/aws/aws-textract/element-templates/hybrid/aws-textract-outbound-connector-hybrid.json
+++ b/connectors/aws/aws-textract/element-templates/hybrid/aws-textract-outbound-connector-hybrid.json
@@ -446,7 +446,7 @@
     "value" : "2",
     "group" : "connector",
     "binding" : {
-      "key" : "version",
+      "key" : "elementTemplateVersion",
       "type" : "zeebe:taskHeader"
     },
     "type" : "Hidden"
@@ -457,7 +457,7 @@
     "value" : "io.camunda.connectors.AWSTEXTRACT.v1",
     "group" : "connector",
     "binding" : {
-      "key" : "id",
+      "key" : "elementTemplateId",
       "type" : "zeebe:taskHeader"
     },
     "type" : "Hidden"

--- a/connectors/blue-prism/element-templates/blue-prism-connector.json
+++ b/connectors/blue-prism/element-templates/blue-prism-connector.json
@@ -496,6 +496,29 @@
       }
     },
     {
+      "id" : "version",
+      "label" : "Version",
+      "description" : "Version of the element template",
+      "value" : "3",
+      "group" : "connector",
+      "binding" : {
+        "key" : "elementTemplateVersion",
+        "type" : "zeebe:taskHeader"
+      },
+      "type" : "Hidden"
+    }, {
+      "id" : "id",
+      "label" : "ID",
+      "description" : "ID of the element template",
+      "value" : "io.camunda.connectors.BluePrism.v1",
+      "group" : "connector",
+      "binding" : {
+        "key" : "elementTemplateId",
+        "type" : "zeebe:taskHeader"
+      },
+      "type" : "Hidden"
+    },
+    {
       "label": "Error expression",
       "description": "Expression to handle errors. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#bpmn-errors\" target=\"_blank\">documentation</a>",
       "group": "errors",

--- a/connectors/box/element-templates/box-outbound-connector.json
+++ b/connectors/box/element-templates/box-outbound-connector.json
@@ -23,6 +23,9 @@
     "id" : "operation",
     "label" : "Operation"
   }, {
+    "id" : "connector",
+    "label" : "Connector"
+  }, {
     "id" : "output",
     "label" : "Output mapping"
   }, {
@@ -564,6 +567,28 @@
       "type" : "simple"
     },
     "type" : "Number"
+  }, {
+    "id" : "version",
+    "label" : "Version",
+    "description" : "Version of the element template",
+    "value" : "1",
+    "group" : "connector",
+    "binding" : {
+      "key" : "version",
+      "type" : "zeebe:taskHeader"
+    },
+    "type" : "Hidden"
+  }, {
+    "id" : "id",
+    "label" : "ID",
+    "description" : "ID of the element template",
+    "value" : "io.camunda.connectors.box",
+    "group" : "connector",
+    "binding" : {
+      "key" : "id",
+      "type" : "zeebe:taskHeader"
+    },
+    "type" : "Hidden"
   }, {
     "id" : "resultVariable",
     "label" : "Result variable",

--- a/connectors/box/element-templates/box-outbound-connector.json
+++ b/connectors/box/element-templates/box-outbound-connector.json
@@ -574,7 +574,7 @@
     "value" : "1",
     "group" : "connector",
     "binding" : {
-      "key" : "version",
+      "key" : "elementTemplateVersion",
       "type" : "zeebe:taskHeader"
     },
     "type" : "Hidden"
@@ -585,7 +585,7 @@
     "value" : "io.camunda.connectors.box",
     "group" : "connector",
     "binding" : {
-      "key" : "id",
+      "key" : "elementTemplateId",
       "type" : "zeebe:taskHeader"
     },
     "type" : "Hidden"

--- a/connectors/box/element-templates/hybrid/box-outbound-connector-hybrid.json
+++ b/connectors/box/element-templates/hybrid/box-outbound-connector-hybrid.json
@@ -579,7 +579,7 @@
     "value" : "1",
     "group" : "connector",
     "binding" : {
-      "key" : "version",
+      "key" : "elementTemplateVersion",
       "type" : "zeebe:taskHeader"
     },
     "type" : "Hidden"
@@ -590,7 +590,7 @@
     "value" : "io.camunda.connectors.box",
     "group" : "connector",
     "binding" : {
-      "key" : "id",
+      "key" : "elementTemplateId",
       "type" : "zeebe:taskHeader"
     },
     "type" : "Hidden"

--- a/connectors/box/element-templates/hybrid/box-outbound-connector-hybrid.json
+++ b/connectors/box/element-templates/hybrid/box-outbound-connector-hybrid.json
@@ -26,6 +26,9 @@
     "id" : "operation",
     "label" : "Operation"
   }, {
+    "id" : "connector",
+    "label" : "Connector"
+  }, {
     "id" : "output",
     "label" : "Output mapping"
   }, {
@@ -569,6 +572,28 @@
       "type" : "simple"
     },
     "type" : "Number"
+  }, {
+    "id" : "version",
+    "label" : "Version",
+    "description" : "Version of the element template",
+    "value" : "1",
+    "group" : "connector",
+    "binding" : {
+      "key" : "version",
+      "type" : "zeebe:taskHeader"
+    },
+    "type" : "Hidden"
+  }, {
+    "id" : "id",
+    "label" : "ID",
+    "description" : "ID of the element template",
+    "value" : "io.camunda.connectors.box",
+    "group" : "connector",
+    "binding" : {
+      "key" : "id",
+      "type" : "zeebe:taskHeader"
+    },
+    "type" : "Hidden"
   }, {
     "id" : "resultVariable",
     "label" : "Result variable",

--- a/connectors/easy-post/element-templates/easy-post-connector.json
+++ b/connectors/easy-post/element-templates/easy-post-connector.json
@@ -993,6 +993,29 @@
       "type": "Text"
     },
     {
+      "id" : "version",
+      "label" : "Version",
+      "description" : "Version of the element template",
+      "value" : "4",
+      "group" : "connector",
+      "binding" : {
+        "key" : "elementTemplateVersion",
+        "type" : "zeebe:taskHeader"
+      },
+      "type" : "Hidden"
+    }, {
+      "id" : "id",
+      "label" : "ID",
+      "description" : "ID of the element template",
+      "value" : "io.camunda.connectors.EasyPost.v1",
+      "group" : "connector",
+      "binding" : {
+        "key" : "elementTemplateId",
+        "type" : "zeebe:taskHeader"
+      },
+      "type" : "Hidden"
+    },
+    {
       "id": "retryBackoff",
       "label": "Retry backoff",
       "description": "ISO-8601 duration to wait between retries",

--- a/connectors/email/element-templates/email-outbound-connector.json
+++ b/connectors/email/element-templates/email-outbound-connector.json
@@ -7,7 +7,7 @@
     "keywords" : [ "send emails", "list emails", "search emails", "delete emails", "read emails", "move emails" ]
   },
   "documentationRef" : "https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/email/",
-  "version" : 3,
+  "version" : 2,
   "category" : {
     "id" : "connectors",
     "name" : "Connectors"
@@ -1223,7 +1223,7 @@
     "id" : "version",
     "label" : "Version",
     "description" : "Version of the element template",
-    "value" : "3",
+    "value" : "2",
     "group" : "connector",
     "binding" : {
       "key" : "version",

--- a/connectors/email/element-templates/email-outbound-connector.json
+++ b/connectors/email/element-templates/email-outbound-connector.json
@@ -1226,7 +1226,7 @@
     "value" : "2",
     "group" : "connector",
     "binding" : {
-      "key" : "version",
+      "key" : "elementTemplateVersion",
       "type" : "zeebe:taskHeader"
     },
     "type" : "Hidden"
@@ -1237,7 +1237,7 @@
     "value" : "io.camunda.connectors.email.v1",
     "group" : "connector",
     "binding" : {
-      "key" : "id",
+      "key" : "elementTemplateId",
       "type" : "zeebe:taskHeader"
     },
     "type" : "Hidden"

--- a/connectors/email/element-templates/email-outbound-connector.json
+++ b/connectors/email/element-templates/email-outbound-connector.json
@@ -7,7 +7,7 @@
     "keywords" : [ "send emails", "list emails", "search emails", "delete emails", "read emails", "move emails" ]
   },
   "documentationRef" : "https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/email/",
-  "version" : 2,
+  "version" : 3,
   "category" : {
     "id" : "connectors",
     "name" : "Connectors"
@@ -61,6 +61,9 @@
   }, {
     "id" : "moveEmailImap",
     "label" : "Move Emails"
+  }, {
+    "id" : "connector",
+    "label" : "Connector"
   }, {
     "id" : "output",
     "label" : "Output mapping"
@@ -1216,6 +1219,28 @@
     },
     "tooltip" : "Specify the destination folder to which the emails will be moved. To create a new folder or a hierarchy of folders, use a dot-separated path (e.g., 'Archive' or 'Projects.2023.January'). If any part of the path does not exist, it will be created automatically.",
     "type" : "String"
+  }, {
+    "id" : "version",
+    "label" : "Version",
+    "description" : "Version of the element template",
+    "value" : "3",
+    "group" : "connector",
+    "binding" : {
+      "key" : "version",
+      "type" : "zeebe:taskHeader"
+    },
+    "type" : "Hidden"
+  }, {
+    "id" : "id",
+    "label" : "ID",
+    "description" : "ID of the element template",
+    "value" : "io.camunda.connectors.email.v1",
+    "group" : "connector",
+    "binding" : {
+      "key" : "id",
+      "type" : "zeebe:taskHeader"
+    },
+    "type" : "Hidden"
   }, {
     "id" : "resultVariable",
     "label" : "Result variable",

--- a/connectors/email/element-templates/hybrid/email-outbound-connector-hybrid.json
+++ b/connectors/email/element-templates/hybrid/email-outbound-connector-hybrid.json
@@ -7,7 +7,7 @@
     "keywords" : [ "send emails", "list emails", "search emails", "delete emails", "read emails", "move emails" ]
   },
   "documentationRef" : "https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/email/",
-  "version" : 2,
+  "version" : 3,
   "category" : {
     "id" : "connectors",
     "name" : "Connectors"
@@ -64,6 +64,9 @@
   }, {
     "id" : "moveEmailImap",
     "label" : "Move Emails"
+  }, {
+    "id" : "connector",
+    "label" : "Connector"
   }, {
     "id" : "output",
     "label" : "Output mapping"
@@ -1221,6 +1224,28 @@
     },
     "tooltip" : "Specify the destination folder to which the emails will be moved. To create a new folder or a hierarchy of folders, use a dot-separated path (e.g., 'Archive' or 'Projects.2023.January'). If any part of the path does not exist, it will be created automatically.",
     "type" : "String"
+  }, {
+    "id" : "version",
+    "label" : "Version",
+    "description" : "Version of the element template",
+    "value" : "3",
+    "group" : "connector",
+    "binding" : {
+      "key" : "version",
+      "type" : "zeebe:taskHeader"
+    },
+    "type" : "Hidden"
+  }, {
+    "id" : "id",
+    "label" : "ID",
+    "description" : "ID of the element template",
+    "value" : "io.camunda.connectors.email.v1",
+    "group" : "connector",
+    "binding" : {
+      "key" : "id",
+      "type" : "zeebe:taskHeader"
+    },
+    "type" : "Hidden"
   }, {
     "id" : "resultVariable",
     "label" : "Result variable",

--- a/connectors/email/element-templates/hybrid/email-outbound-connector-hybrid.json
+++ b/connectors/email/element-templates/hybrid/email-outbound-connector-hybrid.json
@@ -1231,7 +1231,7 @@
     "value" : "2",
     "group" : "connector",
     "binding" : {
-      "key" : "version",
+      "key" : "elementTemplateVersion",
       "type" : "zeebe:taskHeader"
     },
     "type" : "Hidden"
@@ -1242,7 +1242,7 @@
     "value" : "io.camunda.connectors.email.v1",
     "group" : "connector",
     "binding" : {
-      "key" : "id",
+      "key" : "elementTemplateId",
       "type" : "zeebe:taskHeader"
     },
     "type" : "Hidden"

--- a/connectors/email/element-templates/hybrid/email-outbound-connector-hybrid.json
+++ b/connectors/email/element-templates/hybrid/email-outbound-connector-hybrid.json
@@ -7,7 +7,7 @@
     "keywords" : [ "send emails", "list emails", "search emails", "delete emails", "read emails", "move emails" ]
   },
   "documentationRef" : "https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/email/",
-  "version" : 3,
+  "version" : 2,
   "category" : {
     "id" : "connectors",
     "name" : "Connectors"
@@ -1228,7 +1228,7 @@
     "id" : "version",
     "label" : "Version",
     "description" : "Version of the element template",
-    "value" : "3",
+    "value" : "2",
     "group" : "connector",
     "binding" : {
       "key" : "version",

--- a/connectors/github/element-templates/github-connector.json
+++ b/connectors/github/element-templates/github-connector.json
@@ -3110,6 +3110,29 @@
         "type": "zeebe:taskHeader",
         "key": "errorExpression"
       }
+    },
+    {
+      "id" : "version",
+      "label" : "Version",
+      "description" : "Version of the element template",
+      "value" : "7",
+      "group" : "connector",
+      "binding" : {
+        "key" : "elementTemplateVersion",
+        "type" : "zeebe:taskHeader"
+      },
+      "type" : "Hidden"
+    }, {
+      "id" : "id",
+      "label" : "ID",
+      "description" : "ID of the element template",
+      "value" : "io.camunda.connectors.GitHub.v1",
+      "group" : "connector",
+      "binding" : {
+        "key" : "elementTemplateId",
+        "type" : "zeebe:taskHeader"
+      },
+      "type" : "Hidden"
     }
   ]
 }

--- a/connectors/gitlab/element-templates/gitlab-connector.json
+++ b/connectors/gitlab/element-templates/gitlab-connector.json
@@ -1762,6 +1762,29 @@
         "type": "zeebe:taskHeader",
         "key": "errorExpression"
       }
+    },
+    {
+      "id" : "version",
+      "label" : "Version",
+      "description" : "Version of the element template",
+      "value" : "6",
+      "group" : "connector",
+      "binding" : {
+        "key" : "elementTemplateVersion",
+        "type" : "zeebe:taskHeader"
+      },
+      "type" : "Hidden"
+    }, {
+      "id" : "id",
+      "label" : "ID",
+      "description" : "ID of the element template",
+      "value" : "io.camunda.connectors.GitLab.v1",
+      "group" : "connector",
+      "binding" : {
+        "key" : "elementTemplateId",
+        "type" : "zeebe:taskHeader"
+      },
+      "type" : "Hidden"
     }
   ]
 }

--- a/connectors/google-maps-platform/element-templates/google-maps-platform-connector.json
+++ b/connectors/google-maps-platform/element-templates/google-maps-platform-connector.json
@@ -529,6 +529,29 @@
         "type": "zeebe:taskHeader",
         "key": "errorExpression"
       }
+    },
+    {
+      "id" : "version",
+      "label" : "Version",
+      "description" : "Version of the element template",
+      "value" : "3",
+      "group" : "connector",
+      "binding" : {
+        "key" : "elementTemplateVersion",
+        "type" : "zeebe:taskHeader"
+      },
+      "type" : "Hidden"
+    }, {
+      "id" : "id",
+      "label" : "ID",
+      "description" : "ID of the element template",
+      "value" : "io.camunda.connectors.GoogleMapsPlatform.v1",
+      "group" : "connector",
+      "binding" : {
+        "key" : "elementTemplateId",
+        "type" : "zeebe:taskHeader"
+      },
+      "type" : "Hidden"
     }
   ],
   "icon": {

--- a/connectors/google/google-drive/element-templates/google-drive-outbound-connector.json
+++ b/connectors/google/google-drive/element-templates/google-drive-outbound-connector.json
@@ -26,6 +26,9 @@
     "id" : "operationDetails",
     "label" : "Operation details"
   }, {
+    "id" : "connector",
+    "label" : "Connector"
+  }, {
     "id" : "output",
     "label" : "Output mapping"
   }, {
@@ -296,6 +299,28 @@
       "type" : "simple"
     },
     "type" : "String"
+  }, {
+    "id" : "version",
+    "label" : "Version",
+    "description" : "Version of the element template",
+    "value" : "4",
+    "group" : "connector",
+    "binding" : {
+      "key" : "version",
+      "type" : "zeebe:taskHeader"
+    },
+    "type" : "Hidden"
+  }, {
+    "id" : "id",
+    "label" : "ID",
+    "description" : "ID of the element template",
+    "value" : "io.camunda.connectors.GoogleDrive.v1",
+    "group" : "connector",
+    "binding" : {
+      "key" : "id",
+      "type" : "zeebe:taskHeader"
+    },
+    "type" : "Hidden"
   }, {
     "id" : "resultVariable",
     "label" : "Result variable",

--- a/connectors/google/google-drive/element-templates/google-drive-outbound-connector.json
+++ b/connectors/google/google-drive/element-templates/google-drive-outbound-connector.json
@@ -306,7 +306,7 @@
     "value" : "4",
     "group" : "connector",
     "binding" : {
-      "key" : "version",
+      "key" : "elementTemplateVersion",
       "type" : "zeebe:taskHeader"
     },
     "type" : "Hidden"
@@ -317,7 +317,7 @@
     "value" : "io.camunda.connectors.GoogleDrive.v1",
     "group" : "connector",
     "binding" : {
-      "key" : "id",
+      "key" : "elementTemplateId",
       "type" : "zeebe:taskHeader"
     },
     "type" : "Hidden"

--- a/connectors/google/google-drive/element-templates/hybrid/google-drive-outbound-connector-hybrid.json
+++ b/connectors/google/google-drive/element-templates/hybrid/google-drive-outbound-connector-hybrid.json
@@ -311,7 +311,7 @@
     "value" : "4",
     "group" : "connector",
     "binding" : {
-      "key" : "version",
+      "key" : "elementTemplateVersion",
       "type" : "zeebe:taskHeader"
     },
     "type" : "Hidden"
@@ -322,7 +322,7 @@
     "value" : "io.camunda.connectors.GoogleDrive.v1",
     "group" : "connector",
     "binding" : {
-      "key" : "id",
+      "key" : "elementTemplateId",
       "type" : "zeebe:taskHeader"
     },
     "type" : "Hidden"

--- a/connectors/google/google-drive/element-templates/hybrid/google-drive-outbound-connector-hybrid.json
+++ b/connectors/google/google-drive/element-templates/hybrid/google-drive-outbound-connector-hybrid.json
@@ -29,6 +29,9 @@
     "id" : "operationDetails",
     "label" : "Operation details"
   }, {
+    "id" : "connector",
+    "label" : "Connector"
+  }, {
     "id" : "output",
     "label" : "Output mapping"
   }, {
@@ -301,6 +304,28 @@
       "type" : "simple"
     },
     "type" : "String"
+  }, {
+    "id" : "version",
+    "label" : "Version",
+    "description" : "Version of the element template",
+    "value" : "4",
+    "group" : "connector",
+    "binding" : {
+      "key" : "version",
+      "type" : "zeebe:taskHeader"
+    },
+    "type" : "Hidden"
+  }, {
+    "id" : "id",
+    "label" : "ID",
+    "description" : "ID of the element template",
+    "value" : "io.camunda.connectors.GoogleDrive.v1",
+    "group" : "connector",
+    "binding" : {
+      "key" : "id",
+      "type" : "zeebe:taskHeader"
+    },
+    "type" : "Hidden"
   }, {
     "id" : "resultVariable",
     "label" : "Result variable",

--- a/connectors/google/google-gemini/element-templates/google-gemini-outbound-connector.json
+++ b/connectors/google/google-gemini/element-templates/google-gemini-outbound-connector.json
@@ -541,7 +541,7 @@
     "value" : "1",
     "group" : "connector",
     "binding" : {
-      "key" : "version",
+      "key" : "elementTemplateVersion",
       "type" : "zeebe:taskHeader"
     },
     "type" : "Hidden"
@@ -552,7 +552,7 @@
     "value" : "io.camunda.connectors.GoogleGemini.v1",
     "group" : "connector",
     "binding" : {
-      "key" : "id",
+      "key" : "elementTemplateId",
       "type" : "zeebe:taskHeader"
     },
     "type" : "Hidden"

--- a/connectors/google/google-gemini/element-templates/google-gemini-outbound-connector.json
+++ b/connectors/google/google-gemini/element-templates/google-gemini-outbound-connector.json
@@ -23,6 +23,9 @@
     "id" : "input",
     "label" : "Configure input"
   }, {
+    "id" : "connector",
+    "label" : "Connector"
+  }, {
     "id" : "output",
     "label" : "Output mapping"
   }, {
@@ -531,6 +534,28 @@
       "type" : "zeebe:input"
     },
     "type" : "String"
+  }, {
+    "id" : "version",
+    "label" : "Version",
+    "description" : "Version of the element template",
+    "value" : "1",
+    "group" : "connector",
+    "binding" : {
+      "key" : "version",
+      "type" : "zeebe:taskHeader"
+    },
+    "type" : "Hidden"
+  }, {
+    "id" : "id",
+    "label" : "ID",
+    "description" : "ID of the element template",
+    "value" : "io.camunda.connectors.GoogleGemini.v1",
+    "group" : "connector",
+    "binding" : {
+      "key" : "id",
+      "type" : "zeebe:taskHeader"
+    },
+    "type" : "Hidden"
   }, {
     "id" : "resultVariable",
     "label" : "Result variable",

--- a/connectors/google/google-gemini/element-templates/hybrid/google-gemini-outbound-connector-hybrid.json
+++ b/connectors/google/google-gemini/element-templates/hybrid/google-gemini-outbound-connector-hybrid.json
@@ -26,6 +26,9 @@
     "id" : "input",
     "label" : "Configure input"
   }, {
+    "id" : "connector",
+    "label" : "Connector"
+  }, {
     "id" : "output",
     "label" : "Output mapping"
   }, {
@@ -536,6 +539,28 @@
       "type" : "zeebe:input"
     },
     "type" : "String"
+  }, {
+    "id" : "version",
+    "label" : "Version",
+    "description" : "Version of the element template",
+    "value" : "1",
+    "group" : "connector",
+    "binding" : {
+      "key" : "version",
+      "type" : "zeebe:taskHeader"
+    },
+    "type" : "Hidden"
+  }, {
+    "id" : "id",
+    "label" : "ID",
+    "description" : "ID of the element template",
+    "value" : "io.camunda.connectors.GoogleGemini.v1",
+    "group" : "connector",
+    "binding" : {
+      "key" : "id",
+      "type" : "zeebe:taskHeader"
+    },
+    "type" : "Hidden"
   }, {
     "id" : "resultVariable",
     "label" : "Result variable",

--- a/connectors/google/google-gemini/element-templates/hybrid/google-gemini-outbound-connector-hybrid.json
+++ b/connectors/google/google-gemini/element-templates/hybrid/google-gemini-outbound-connector-hybrid.json
@@ -546,7 +546,7 @@
     "value" : "1",
     "group" : "connector",
     "binding" : {
-      "key" : "version",
+      "key" : "elementTemplateVersion",
       "type" : "zeebe:taskHeader"
     },
     "type" : "Hidden"
@@ -557,7 +557,7 @@
     "value" : "io.camunda.connectors.GoogleGemini.v1",
     "group" : "connector",
     "binding" : {
-      "key" : "id",
+      "key" : "elementTemplateId",
       "type" : "zeebe:taskHeader"
     },
     "type" : "Hidden"

--- a/connectors/google/google-sheets/element-templates/google-sheets-outbound-connector.json
+++ b/connectors/google/google-sheets/element-templates/google-sheets-outbound-connector.json
@@ -822,7 +822,7 @@
     "value" : "4",
     "group" : "connector",
     "binding" : {
-      "key" : "version",
+      "key" : "elementTemplateVersion",
       "type" : "zeebe:taskHeader"
     },
     "type" : "Hidden"
@@ -833,7 +833,7 @@
     "value" : "io.camunda.connectors.GoogleSheets.v1",
     "group" : "connector",
     "binding" : {
-      "key" : "id",
+      "key" : "elementTemplateId",
       "type" : "zeebe:taskHeader"
     },
     "type" : "Hidden"

--- a/connectors/google/google-sheets/element-templates/google-sheets-outbound-connector.json
+++ b/connectors/google/google-sheets/element-templates/google-sheets-outbound-connector.json
@@ -26,6 +26,9 @@
     "id" : "operationDetails",
     "label" : "Operation details"
   }, {
+    "id" : "connector",
+    "label" : "Connector"
+  }, {
     "id" : "output",
     "label" : "Output mapping"
   }, {
@@ -812,6 +815,28 @@
       "type" : "simple"
     },
     "type" : "String"
+  }, {
+    "id" : "version",
+    "label" : "Version",
+    "description" : "Version of the element template",
+    "value" : "4",
+    "group" : "connector",
+    "binding" : {
+      "key" : "version",
+      "type" : "zeebe:taskHeader"
+    },
+    "type" : "Hidden"
+  }, {
+    "id" : "id",
+    "label" : "ID",
+    "description" : "ID of the element template",
+    "value" : "io.camunda.connectors.GoogleSheets.v1",
+    "group" : "connector",
+    "binding" : {
+      "key" : "id",
+      "type" : "zeebe:taskHeader"
+    },
+    "type" : "Hidden"
   }, {
     "id" : "resultVariable",
     "label" : "Result variable",

--- a/connectors/google/google-sheets/element-templates/hybrid/google-sheets-outbound-connector-hybrid.json
+++ b/connectors/google/google-sheets/element-templates/hybrid/google-sheets-outbound-connector-hybrid.json
@@ -827,7 +827,7 @@
     "value" : "4",
     "group" : "connector",
     "binding" : {
-      "key" : "version",
+      "key" : "elementTemplateVersion",
       "type" : "zeebe:taskHeader"
     },
     "type" : "Hidden"
@@ -838,7 +838,7 @@
     "value" : "io.camunda.connectors.GoogleSheets.v1",
     "group" : "connector",
     "binding" : {
-      "key" : "id",
+      "key" : "elementTemplateId",
       "type" : "zeebe:taskHeader"
     },
     "type" : "Hidden"

--- a/connectors/google/google-sheets/element-templates/hybrid/google-sheets-outbound-connector-hybrid.json
+++ b/connectors/google/google-sheets/element-templates/hybrid/google-sheets-outbound-connector-hybrid.json
@@ -29,6 +29,9 @@
     "id" : "operationDetails",
     "label" : "Operation details"
   }, {
+    "id" : "connector",
+    "label" : "Connector"
+  }, {
     "id" : "output",
     "label" : "Output mapping"
   }, {
@@ -817,6 +820,28 @@
       "type" : "simple"
     },
     "type" : "String"
+  }, {
+    "id" : "version",
+    "label" : "Version",
+    "description" : "Version of the element template",
+    "value" : "4",
+    "group" : "connector",
+    "binding" : {
+      "key" : "version",
+      "type" : "zeebe:taskHeader"
+    },
+    "type" : "Hidden"
+  }, {
+    "id" : "id",
+    "label" : "ID",
+    "description" : "ID of the element template",
+    "value" : "io.camunda.connectors.GoogleSheets.v1",
+    "group" : "connector",
+    "binding" : {
+      "key" : "id",
+      "type" : "zeebe:taskHeader"
+    },
+    "type" : "Hidden"
   }, {
     "id" : "resultVariable",
     "label" : "Result variable",

--- a/connectors/http/graphql/element-templates/graphql-outbound-connector.json
+++ b/connectors/http/graphql/element-templates/graphql-outbound-connector.json
@@ -431,7 +431,7 @@
     "value" : "7",
     "group" : "connector",
     "binding" : {
-      "key" : "version",
+      "key" : "elementTemplateVersion",
       "type" : "zeebe:taskHeader"
     },
     "type" : "Hidden"
@@ -442,7 +442,7 @@
     "value" : "io.camunda.connectors.GraphQL.v1",
     "group" : "connector",
     "binding" : {
-      "key" : "id",
+      "key" : "elementTemplateId",
       "type" : "zeebe:taskHeader"
     },
     "type" : "Hidden"

--- a/connectors/http/graphql/element-templates/graphql-outbound-connector.json
+++ b/connectors/http/graphql/element-templates/graphql-outbound-connector.json
@@ -29,6 +29,9 @@
     "id" : "timeout",
     "label" : "Connection timeout"
   }, {
+    "id" : "connector",
+    "label" : "Connector"
+  }, {
     "id" : "output",
     "label" : "Output mapping"
   }, {
@@ -421,6 +424,28 @@
       "type" : "zeebe:input"
     },
     "type" : "Number"
+  }, {
+    "id" : "version",
+    "label" : "Version",
+    "description" : "Version of the element template",
+    "value" : "7",
+    "group" : "connector",
+    "binding" : {
+      "key" : "version",
+      "type" : "zeebe:taskHeader"
+    },
+    "type" : "Hidden"
+  }, {
+    "id" : "id",
+    "label" : "ID",
+    "description" : "ID of the element template",
+    "value" : "io.camunda.connectors.GraphQL.v1",
+    "group" : "connector",
+    "binding" : {
+      "key" : "id",
+      "type" : "zeebe:taskHeader"
+    },
+    "type" : "Hidden"
   }, {
     "id" : "resultVariable",
     "label" : "Result variable",

--- a/connectors/http/graphql/element-templates/hybrid/graphql-outbound-connector-hybrid.json
+++ b/connectors/http/graphql/element-templates/hybrid/graphql-outbound-connector-hybrid.json
@@ -32,6 +32,9 @@
     "id" : "timeout",
     "label" : "Connection timeout"
   }, {
+    "id" : "connector",
+    "label" : "Connector"
+  }, {
     "id" : "output",
     "label" : "Output mapping"
   }, {
@@ -426,6 +429,28 @@
       "type" : "zeebe:input"
     },
     "type" : "Number"
+  }, {
+    "id" : "version",
+    "label" : "Version",
+    "description" : "Version of the element template",
+    "value" : "7",
+    "group" : "connector",
+    "binding" : {
+      "key" : "version",
+      "type" : "zeebe:taskHeader"
+    },
+    "type" : "Hidden"
+  }, {
+    "id" : "id",
+    "label" : "ID",
+    "description" : "ID of the element template",
+    "value" : "io.camunda.connectors.GraphQL.v1",
+    "group" : "connector",
+    "binding" : {
+      "key" : "id",
+      "type" : "zeebe:taskHeader"
+    },
+    "type" : "Hidden"
   }, {
     "id" : "resultVariable",
     "label" : "Result variable",

--- a/connectors/http/graphql/element-templates/hybrid/graphql-outbound-connector-hybrid.json
+++ b/connectors/http/graphql/element-templates/hybrid/graphql-outbound-connector-hybrid.json
@@ -436,7 +436,7 @@
     "value" : "7",
     "group" : "connector",
     "binding" : {
-      "key" : "version",
+      "key" : "elementTemplateVersion",
       "type" : "zeebe:taskHeader"
     },
     "type" : "Hidden"
@@ -447,7 +447,7 @@
     "value" : "io.camunda.connectors.GraphQL.v1",
     "group" : "connector",
     "binding" : {
-      "key" : "id",
+      "key" : "elementTemplateId",
       "type" : "zeebe:taskHeader"
     },
     "type" : "Hidden"

--- a/connectors/http/rest/element-templates/http-json-connector.json
+++ b/connectors/http/rest/element-templates/http-json-connector.json
@@ -494,7 +494,7 @@
     "value" : "10",
     "group" : "connector",
     "binding" : {
-      "key" : "version",
+      "key" : "elementTemplateVersion",
       "type" : "zeebe:taskHeader"
     },
     "type" : "Hidden"
@@ -505,7 +505,7 @@
     "value" : "io.camunda.connectors.HttpJson.v2",
     "group" : "connector",
     "binding" : {
-      "key" : "id",
+      "key" : "elementTemplateId",
       "type" : "zeebe:taskHeader"
     },
     "type" : "Hidden"

--- a/connectors/http/rest/element-templates/http-json-connector.json
+++ b/connectors/http/rest/element-templates/http-json-connector.json
@@ -29,6 +29,9 @@
     "id" : "payload",
     "label" : "Payload"
   }, {
+    "id" : "connector",
+    "label" : "Connector"
+  }, {
     "id" : "output",
     "label" : "Output mapping"
   }, {
@@ -484,6 +487,28 @@
     },
     "tooltip" : "Null values will not be sent",
     "type" : "Boolean"
+  }, {
+    "id" : "version",
+    "label" : "Version",
+    "description" : "Version of the element template",
+    "value" : "10",
+    "group" : "connector",
+    "binding" : {
+      "key" : "version",
+      "type" : "zeebe:taskHeader"
+    },
+    "type" : "Hidden"
+  }, {
+    "id" : "id",
+    "label" : "ID",
+    "description" : "ID of the element template",
+    "value" : "io.camunda.connectors.HttpJson.v2",
+    "group" : "connector",
+    "binding" : {
+      "key" : "id",
+      "type" : "zeebe:taskHeader"
+    },
+    "type" : "Hidden"
   }, {
     "id" : "resultVariable",
     "label" : "Result variable",

--- a/connectors/http/rest/element-templates/hybrid/http-json-connector-hybrid.json
+++ b/connectors/http/rest/element-templates/hybrid/http-json-connector-hybrid.json
@@ -32,6 +32,9 @@
     "id" : "payload",
     "label" : "Payload"
   }, {
+    "id" : "connector",
+    "label" : "Connector"
+  }, {
     "id" : "output",
     "label" : "Output mapping"
   }, {
@@ -489,6 +492,28 @@
     },
     "tooltip" : "Null values will not be sent",
     "type" : "Boolean"
+  }, {
+    "id" : "version",
+    "label" : "Version",
+    "description" : "Version of the element template",
+    "value" : "10",
+    "group" : "connector",
+    "binding" : {
+      "key" : "version",
+      "type" : "zeebe:taskHeader"
+    },
+    "type" : "Hidden"
+  }, {
+    "id" : "id",
+    "label" : "ID",
+    "description" : "ID of the element template",
+    "value" : "io.camunda.connectors.HttpJson.v2",
+    "group" : "connector",
+    "binding" : {
+      "key" : "id",
+      "type" : "zeebe:taskHeader"
+    },
+    "type" : "Hidden"
   }, {
     "id" : "resultVariable",
     "label" : "Result variable",

--- a/connectors/http/rest/element-templates/hybrid/http-json-connector-hybrid.json
+++ b/connectors/http/rest/element-templates/hybrid/http-json-connector-hybrid.json
@@ -499,7 +499,7 @@
     "value" : "10",
     "group" : "connector",
     "binding" : {
-      "key" : "version",
+      "key" : "elementTemplateVersion",
       "type" : "zeebe:taskHeader"
     },
     "type" : "Hidden"
@@ -510,7 +510,7 @@
     "value" : "io.camunda.connectors.HttpJson.v2",
     "group" : "connector",
     "binding" : {
-      "key" : "id",
+      "key" : "elementTemplateId",
       "type" : "zeebe:taskHeader"
     },
     "type" : "Hidden"

--- a/connectors/hugging-face/element-templates/hugging-face-connector.json
+++ b/connectors/hugging-face/element-templates/hugging-face-connector.json
@@ -166,6 +166,29 @@
         "type": "zeebe:taskHeader",
         "key": "errorExpression"
       }
+    },
+    {
+      "id" : "version",
+      "label" : "Version",
+      "description" : "Version of the element template",
+      "value" : "1",
+      "group" : "connector",
+      "binding" : {
+        "key" : "elementTemplateVersion",
+        "type" : "zeebe:taskHeader"
+      },
+      "type" : "Hidden"
+    }, {
+      "id" : "id",
+      "label" : "ID",
+      "description" : "ID of the element template",
+      "value" : "io.camunda.connectors.HuggingFace.v1",
+      "group" : "connector",
+      "binding" : {
+        "key" : "elementTemplateId",
+        "type" : "zeebe:taskHeader"
+      },
+      "type" : "Hidden"
     }
   ],
   "icon": {

--- a/connectors/idp-extraction/element-templates/hybrid/hybrid-idp-extraction-outbound-connector-hybrid.json
+++ b/connectors/idp-extraction/element-templates/hybrid/hybrid-idp-extraction-outbound-connector-hybrid.json
@@ -23,6 +23,9 @@
     "id" : "input",
     "label" : "Input message data"
   }, {
+    "id" : "connector",
+    "label" : "Connector"
+  }, {
     "id" : "output",
     "label" : "Output mapping"
   }, {
@@ -84,6 +87,28 @@
     "binding" : {
       "name" : "input.converseData",
       "type" : "zeebe:input"
+    },
+    "type" : "Hidden"
+  }, {
+    "id" : "version",
+    "label" : "Version",
+    "description" : "Version of the element template",
+    "value" : "1",
+    "group" : "connector",
+    "binding" : {
+      "key" : "version",
+      "type" : "zeebe:taskHeader"
+    },
+    "type" : "Hidden"
+  }, {
+    "id" : "id",
+    "label" : "ID",
+    "description" : "ID of the element template",
+    "value" : "io.camunda.connector.IdpExtractionOutBoundTemplate.v1",
+    "group" : "connector",
+    "binding" : {
+      "key" : "id",
+      "type" : "zeebe:taskHeader"
     },
     "type" : "Hidden"
   }, {

--- a/connectors/idp-extraction/element-templates/hybrid/hybrid-idp-extraction-outbound-connector-hybrid.json
+++ b/connectors/idp-extraction/element-templates/hybrid/hybrid-idp-extraction-outbound-connector-hybrid.json
@@ -96,7 +96,7 @@
     "value" : "1",
     "group" : "connector",
     "binding" : {
-      "key" : "version",
+      "key" : "elementTemplateVersion",
       "type" : "zeebe:taskHeader"
     },
     "type" : "Hidden"
@@ -107,7 +107,7 @@
     "value" : "io.camunda.connector.IdpExtractionOutBoundTemplate.v1",
     "group" : "connector",
     "binding" : {
-      "key" : "id",
+      "key" : "elementTemplateId",
       "type" : "zeebe:taskHeader"
     },
     "type" : "Hidden"

--- a/connectors/idp-extraction/element-templates/idp-extraction-outbound-connector.json
+++ b/connectors/idp-extraction/element-templates/idp-extraction-outbound-connector.json
@@ -20,6 +20,9 @@
     "id" : "input",
     "label" : "Input message data"
   }, {
+    "id" : "connector",
+    "label" : "Connector"
+  }, {
     "id" : "output",
     "label" : "Output mapping"
   }, {
@@ -79,6 +82,28 @@
     "binding" : {
       "name" : "input.converseData",
       "type" : "zeebe:input"
+    },
+    "type" : "Hidden"
+  }, {
+    "id" : "version",
+    "label" : "Version",
+    "description" : "Version of the element template",
+    "value" : "1",
+    "group" : "connector",
+    "binding" : {
+      "key" : "version",
+      "type" : "zeebe:taskHeader"
+    },
+    "type" : "Hidden"
+  }, {
+    "id" : "id",
+    "label" : "ID",
+    "description" : "ID of the element template",
+    "value" : "io.camunda.connector.IdpExtractionOutBoundTemplate.v1",
+    "group" : "connector",
+    "binding" : {
+      "key" : "id",
+      "type" : "zeebe:taskHeader"
     },
     "type" : "Hidden"
   }, {

--- a/connectors/idp-extraction/element-templates/idp-extraction-outbound-connector.json
+++ b/connectors/idp-extraction/element-templates/idp-extraction-outbound-connector.json
@@ -91,7 +91,7 @@
     "value" : "1",
     "group" : "connector",
     "binding" : {
-      "key" : "version",
+      "key" : "elementTemplateVersion",
       "type" : "zeebe:taskHeader"
     },
     "type" : "Hidden"
@@ -102,7 +102,7 @@
     "value" : "io.camunda.connector.IdpExtractionOutBoundTemplate.v1",
     "group" : "connector",
     "binding" : {
-      "key" : "id",
+      "key" : "elementTemplateId",
       "type" : "zeebe:taskHeader"
     },
     "type" : "Hidden"

--- a/connectors/jdbc/element-templates/hybrid/jdbc-outbound-connector-hybrid.json
+++ b/connectors/jdbc/element-templates/hybrid/jdbc-outbound-connector-hybrid.json
@@ -29,6 +29,9 @@
     "id" : "query",
     "label" : "Query"
   }, {
+    "id" : "connector",
+    "label" : "Connector"
+  }, {
     "id" : "output",
     "label" : "Output mapping"
   }, {
@@ -274,6 +277,28 @@
       "type" : "zeebe:input"
     },
     "type" : "String"
+  }, {
+    "id" : "version",
+    "label" : "Version",
+    "description" : "Version of the element template",
+    "value" : "1",
+    "group" : "connector",
+    "binding" : {
+      "key" : "version",
+      "type" : "zeebe:taskHeader"
+    },
+    "type" : "Hidden"
+  }, {
+    "id" : "id",
+    "label" : "ID",
+    "description" : "ID of the element template",
+    "value" : "io.camunda.connectors.Jdbc.v1",
+    "group" : "connector",
+    "binding" : {
+      "key" : "id",
+      "type" : "zeebe:taskHeader"
+    },
+    "type" : "Hidden"
   }, {
     "id" : "resultVariable",
     "label" : "Result variable",

--- a/connectors/jdbc/element-templates/hybrid/jdbc-outbound-connector-hybrid.json
+++ b/connectors/jdbc/element-templates/hybrid/jdbc-outbound-connector-hybrid.json
@@ -284,7 +284,7 @@
     "value" : "1",
     "group" : "connector",
     "binding" : {
-      "key" : "version",
+      "key" : "elementTemplateVersion",
       "type" : "zeebe:taskHeader"
     },
     "type" : "Hidden"
@@ -295,7 +295,7 @@
     "value" : "io.camunda.connectors.Jdbc.v1",
     "group" : "connector",
     "binding" : {
-      "key" : "id",
+      "key" : "elementTemplateId",
       "type" : "zeebe:taskHeader"
     },
     "type" : "Hidden"

--- a/connectors/jdbc/element-templates/jdbc-outbound-connector.json
+++ b/connectors/jdbc/element-templates/jdbc-outbound-connector.json
@@ -26,6 +26,9 @@
     "id" : "query",
     "label" : "Query"
   }, {
+    "id" : "connector",
+    "label" : "Connector"
+  }, {
     "id" : "output",
     "label" : "Output mapping"
   }, {
@@ -269,6 +272,28 @@
       "type" : "zeebe:input"
     },
     "type" : "String"
+  }, {
+    "id" : "version",
+    "label" : "Version",
+    "description" : "Version of the element template",
+    "value" : "1",
+    "group" : "connector",
+    "binding" : {
+      "key" : "version",
+      "type" : "zeebe:taskHeader"
+    },
+    "type" : "Hidden"
+  }, {
+    "id" : "id",
+    "label" : "ID",
+    "description" : "ID of the element template",
+    "value" : "io.camunda.connectors.Jdbc.v1",
+    "group" : "connector",
+    "binding" : {
+      "key" : "id",
+      "type" : "zeebe:taskHeader"
+    },
+    "type" : "Hidden"
   }, {
     "id" : "resultVariable",
     "label" : "Result variable",

--- a/connectors/jdbc/element-templates/jdbc-outbound-connector.json
+++ b/connectors/jdbc/element-templates/jdbc-outbound-connector.json
@@ -279,7 +279,7 @@
     "value" : "1",
     "group" : "connector",
     "binding" : {
-      "key" : "version",
+      "key" : "elementTemplateVersion",
       "type" : "zeebe:taskHeader"
     },
     "type" : "Hidden"
@@ -290,7 +290,7 @@
     "value" : "io.camunda.connectors.Jdbc.v1",
     "group" : "connector",
     "binding" : {
-      "key" : "id",
+      "key" : "elementTemplateId",
       "type" : "zeebe:taskHeader"
     },
     "type" : "Hidden"

--- a/connectors/kafka/element-templates/hybrid/kafka-outbound-connector-hybrid.json
+++ b/connectors/kafka/element-templates/hybrid/kafka-outbound-connector-hybrid.json
@@ -29,6 +29,9 @@
     "id" : "message",
     "label" : "Message"
   }, {
+    "id" : "connector",
+    "label" : "Connector"
+  }, {
     "id" : "output",
     "label" : "Output mapping"
   }, {
@@ -256,6 +259,28 @@
       "type" : "simple"
     },
     "type" : "Text"
+  }, {
+    "id" : "version",
+    "label" : "Version",
+    "description" : "Version of the element template",
+    "value" : "5",
+    "group" : "connector",
+    "binding" : {
+      "key" : "version",
+      "type" : "zeebe:taskHeader"
+    },
+    "type" : "Hidden"
+  }, {
+    "id" : "id",
+    "label" : "ID",
+    "description" : "ID of the element template",
+    "value" : "io.camunda.connectors.KAFKA.v1",
+    "group" : "connector",
+    "binding" : {
+      "key" : "id",
+      "type" : "zeebe:taskHeader"
+    },
+    "type" : "Hidden"
   }, {
     "id" : "resultVariable",
     "label" : "Result variable",

--- a/connectors/kafka/element-templates/hybrid/kafka-outbound-connector-hybrid.json
+++ b/connectors/kafka/element-templates/hybrid/kafka-outbound-connector-hybrid.json
@@ -266,7 +266,7 @@
     "value" : "5",
     "group" : "connector",
     "binding" : {
-      "key" : "version",
+      "key" : "elementTemplateVersion",
       "type" : "zeebe:taskHeader"
     },
     "type" : "Hidden"
@@ -277,7 +277,7 @@
     "value" : "io.camunda.connectors.KAFKA.v1",
     "group" : "connector",
     "binding" : {
-      "key" : "id",
+      "key" : "elementTemplateId",
       "type" : "zeebe:taskHeader"
     },
     "type" : "Hidden"

--- a/connectors/kafka/element-templates/kafka-outbound-connector.json
+++ b/connectors/kafka/element-templates/kafka-outbound-connector.json
@@ -26,6 +26,9 @@
     "id" : "message",
     "label" : "Message"
   }, {
+    "id" : "connector",
+    "label" : "Connector"
+  }, {
     "id" : "output",
     "label" : "Output mapping"
   }, {
@@ -251,6 +254,28 @@
       "type" : "simple"
     },
     "type" : "Text"
+  }, {
+    "id" : "version",
+    "label" : "Version",
+    "description" : "Version of the element template",
+    "value" : "5",
+    "group" : "connector",
+    "binding" : {
+      "key" : "version",
+      "type" : "zeebe:taskHeader"
+    },
+    "type" : "Hidden"
+  }, {
+    "id" : "id",
+    "label" : "ID",
+    "description" : "ID of the element template",
+    "value" : "io.camunda.connectors.KAFKA.v1",
+    "group" : "connector",
+    "binding" : {
+      "key" : "id",
+      "type" : "zeebe:taskHeader"
+    },
+    "type" : "Hidden"
   }, {
     "id" : "resultVariable",
     "label" : "Result variable",

--- a/connectors/kafka/element-templates/kafka-outbound-connector.json
+++ b/connectors/kafka/element-templates/kafka-outbound-connector.json
@@ -261,7 +261,7 @@
     "value" : "5",
     "group" : "connector",
     "binding" : {
-      "key" : "version",
+      "key" : "elementTemplateVersion",
       "type" : "zeebe:taskHeader"
     },
     "type" : "Hidden"
@@ -272,7 +272,7 @@
     "value" : "io.camunda.connectors.KAFKA.v1",
     "group" : "connector",
     "binding" : {
-      "key" : "id",
+      "key" : "elementTemplateId",
       "type" : "zeebe:taskHeader"
     },
     "type" : "Hidden"

--- a/connectors/microsoft-teams/element-templates/hybrid/microsoft-teams-outbound-connector-hybrid.json
+++ b/connectors/microsoft-teams/element-templates/hybrid/microsoft-teams-outbound-connector-hybrid.json
@@ -1459,7 +1459,7 @@
     "value" : "4",
     "group" : "connector",
     "binding" : {
-      "key" : "version",
+      "key" : "elementTemplateVersion",
       "type" : "zeebe:taskHeader"
     },
     "type" : "Hidden"
@@ -1470,7 +1470,7 @@
     "value" : "io.camunda.connectors.MSTeams.v1",
     "group" : "connector",
     "binding" : {
-      "key" : "id",
+      "key" : "elementTemplateId",
       "type" : "zeebe:taskHeader"
     },
     "type" : "Hidden"

--- a/connectors/microsoft-teams/element-templates/hybrid/microsoft-teams-outbound-connector-hybrid.json
+++ b/connectors/microsoft-teams/element-templates/hybrid/microsoft-teams-outbound-connector-hybrid.json
@@ -29,6 +29,9 @@
     "id" : "data",
     "label" : "Data"
   }, {
+    "id" : "connector",
+    "label" : "Connector"
+  }, {
     "id" : "output",
     "label" : "Output mapping"
   }, {
@@ -1449,6 +1452,28 @@
       } ]
     },
     "type" : "String"
+  }, {
+    "id" : "version",
+    "label" : "Version",
+    "description" : "Version of the element template",
+    "value" : "4",
+    "group" : "connector",
+    "binding" : {
+      "key" : "version",
+      "type" : "zeebe:taskHeader"
+    },
+    "type" : "Hidden"
+  }, {
+    "id" : "id",
+    "label" : "ID",
+    "description" : "ID of the element template",
+    "value" : "io.camunda.connectors.MSTeams.v1",
+    "group" : "connector",
+    "binding" : {
+      "key" : "id",
+      "type" : "zeebe:taskHeader"
+    },
+    "type" : "Hidden"
   }, {
     "id" : "resultVariable",
     "label" : "Result variable",

--- a/connectors/microsoft-teams/element-templates/microsoft-teams-outbound-connector.json
+++ b/connectors/microsoft-teams/element-templates/microsoft-teams-outbound-connector.json
@@ -26,6 +26,9 @@
     "id" : "data",
     "label" : "Data"
   }, {
+    "id" : "connector",
+    "label" : "Connector"
+  }, {
     "id" : "output",
     "label" : "Output mapping"
   }, {
@@ -1444,6 +1447,28 @@
       } ]
     },
     "type" : "String"
+  }, {
+    "id" : "version",
+    "label" : "Version",
+    "description" : "Version of the element template",
+    "value" : "4",
+    "group" : "connector",
+    "binding" : {
+      "key" : "version",
+      "type" : "zeebe:taskHeader"
+    },
+    "type" : "Hidden"
+  }, {
+    "id" : "id",
+    "label" : "ID",
+    "description" : "ID of the element template",
+    "value" : "io.camunda.connectors.MSTeams.v1",
+    "group" : "connector",
+    "binding" : {
+      "key" : "id",
+      "type" : "zeebe:taskHeader"
+    },
+    "type" : "Hidden"
   }, {
     "id" : "resultVariable",
     "label" : "Result variable",

--- a/connectors/microsoft-teams/element-templates/microsoft-teams-outbound-connector.json
+++ b/connectors/microsoft-teams/element-templates/microsoft-teams-outbound-connector.json
@@ -1454,7 +1454,7 @@
     "value" : "4",
     "group" : "connector",
     "binding" : {
-      "key" : "version",
+      "key" : "elementTemplateVersion",
       "type" : "zeebe:taskHeader"
     },
     "type" : "Hidden"
@@ -1465,7 +1465,7 @@
     "value" : "io.camunda.connectors.MSTeams.v1",
     "group" : "connector",
     "binding" : {
-      "key" : "id",
+      "key" : "elementTemplateId",
       "type" : "zeebe:taskHeader"
     },
     "type" : "Hidden"

--- a/connectors/microsoft/azure-open-ai/element-templates/azure-open-ai-connector.json
+++ b/connectors/microsoft/azure-open-ai/element-templates/azure-open-ai-connector.json
@@ -1184,7 +1184,31 @@
       "type" : "zeebe:taskHeader"
     },
     "type" : "String"
-  } ],
+  },
+    {
+      "id" : "version",
+      "label" : "Version",
+      "description" : "Version of the element template",
+      "value" : "1",
+      "group" : "connector",
+      "binding" : {
+        "key" : "elementTemplateVersion",
+        "type" : "zeebe:taskHeader"
+      },
+      "type" : "Hidden"
+    }, {
+      "id" : "id",
+      "label" : "ID",
+      "description" : "ID of the element template",
+      "value" : "io.camunda.connectors.AzureOpenAI.outbound.v1",
+      "group" : "connector",
+      "binding" : {
+        "key" : "elementTemplateId",
+        "type" : "zeebe:taskHeader"
+      },
+      "type" : "Hidden"
+    }
+  ],
   "icon": {
     "contents": "data:image/svg+xml;utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' fill='none' viewBox='0 0 513 512'%3E%3Cg clip-path='url(%23a)'%3E%3Crect width='512' height='512' x='.25' fill='%23fff' rx='76'/%3E%3Cpath fill='url(%23b)' d='M.25 76.8v358.4c0 42.411 34.39 76.8 76.8 76.8h358.4c42.411 0 76.8-34.389 76.8-76.8V76.8c0-42.41-34.389-76.8-76.8-76.8H77.05C34.64 0 .25 34.39.25 76.8ZM307.45 0v102.4c0 113.095 91.705 204.8 204.8 204.8h-102.4c-113.095 0-204.772 91.648-204.8 204.743V409.6c0-113.095-91.705-204.8-204.8-204.8h102.4c113.095 0 204.8-91.705 204.8-204.8Z'/%3E%3C/g%3E%3Cdefs%3E%3CradialGradient id='b' cx='0' cy='0' r='1' gradientTransform='rotate(45 -176.261 403.94) scale(321.165 437.107)' gradientUnits='userSpaceOnUse'%3E%3Cstop stop-color='%2383B9F9'/%3E%3Cstop offset='1' stop-color='%230078D4'/%3E%3C/radialGradient%3E%3CclipPath id='a'%3E%3Crect width='512' height='512' x='.25' fill='%23fff' rx='76'/%3E%3C/clipPath%3E%3C/defs%3E%3C/svg%3E"
   }

--- a/connectors/microsoft/mail/element-templates/microsoft-office365-mail-connector.json
+++ b/connectors/microsoft/mail/element-templates/microsoft-office365-mail-connector.json
@@ -825,6 +825,29 @@
         "type": "zeebe:taskHeader"
       },
       "type": "String"
+    },
+    {
+      "id" : "version",
+      "label" : "Version",
+      "description" : "Version of the element template",
+      "value" : "2",
+      "group" : "connector",
+      "binding" : {
+        "key" : "elementTemplateVersion",
+        "type" : "zeebe:taskHeader"
+      },
+      "type" : "Hidden"
+    }, {
+      "id" : "id",
+      "label" : "ID",
+      "description" : "ID of the element template",
+      "value" : "io.camunda.connectors.MSFT.O365.Mail.v1",
+      "group" : "connector",
+      "binding" : {
+        "key" : "elementTemplateId",
+        "type" : "zeebe:taskHeader"
+      },
+      "type" : "Hidden"
     }
   ],
   "icon": {

--- a/connectors/openai/element-templates/openai-connector.json
+++ b/connectors/openai/element-templates/openai-connector.json
@@ -407,6 +407,29 @@
         "type": "zeebe:taskHeader",
         "key": "errorExpression"
       }
+    },
+    {
+      "id" : "version",
+      "label" : "Version",
+      "description" : "Version of the element template",
+      "value" : "5",
+      "group" : "connector",
+      "binding" : {
+        "key" : "elementTemplateVersion",
+        "type" : "zeebe:taskHeader"
+      },
+      "type" : "Hidden"
+    }, {
+      "id" : "id",
+      "label" : "ID",
+      "description" : "ID of the element template",
+      "value" : "io.camunda.connectors.OpenAI.v1",
+      "group" : "connector",
+      "binding" : {
+        "key" : "elementTemplateId",
+        "type" : "zeebe:taskHeader"
+      },
+      "type" : "Hidden"
     }
   ]
 }

--- a/connectors/operate/element-templates/operate-connector.json
+++ b/connectors/operate/element-templates/operate-connector.json
@@ -510,6 +510,29 @@
         "type": "zeebe:taskHeader",
         "key": "errorExpression"
       }
+    },
+    {
+      "id" : "version",
+      "label" : "Version",
+      "description" : "Version of the element template",
+      "value" : "4",
+      "group" : "connector",
+      "binding" : {
+        "key" : "elementTemplateVersion",
+        "type" : "zeebe:taskHeader"
+      },
+      "type" : "Hidden"
+    }, {
+      "id" : "id",
+      "label" : "ID",
+      "description" : "ID of the element template",
+      "value" : "io.camunda.connectors.CamundaOperate.v1",
+      "group" : "connector",
+      "binding" : {
+        "key" : "elementTemplateId",
+        "type" : "zeebe:taskHeader"
+      },
+      "type" : "Hidden"
     }
   ],
   "icon": {

--- a/connectors/rabbitmq/element-templates/hybrid/rabbitmq-outbound-connector-hybrid.json
+++ b/connectors/rabbitmq/element-templates/hybrid/rabbitmq-outbound-connector-hybrid.json
@@ -29,6 +29,9 @@
     "id" : "message",
     "label" : "Message"
   }, {
+    "id" : "connector",
+    "label" : "Connector"
+  }, {
     "id" : "output",
     "label" : "Output mapping"
   }, {
@@ -244,6 +247,28 @@
       "type" : "zeebe:input"
     },
     "type" : "Text"
+  }, {
+    "id" : "version",
+    "label" : "Version",
+    "description" : "Version of the element template",
+    "value" : "5",
+    "group" : "connector",
+    "binding" : {
+      "key" : "version",
+      "type" : "zeebe:taskHeader"
+    },
+    "type" : "Hidden"
+  }, {
+    "id" : "id",
+    "label" : "ID",
+    "description" : "ID of the element template",
+    "value" : "io.camunda.connectors.RabbitMQ.v1",
+    "group" : "connector",
+    "binding" : {
+      "key" : "id",
+      "type" : "zeebe:taskHeader"
+    },
+    "type" : "Hidden"
   }, {
     "id" : "resultVariable",
     "label" : "Result variable",

--- a/connectors/rabbitmq/element-templates/hybrid/rabbitmq-outbound-connector-hybrid.json
+++ b/connectors/rabbitmq/element-templates/hybrid/rabbitmq-outbound-connector-hybrid.json
@@ -254,7 +254,7 @@
     "value" : "5",
     "group" : "connector",
     "binding" : {
-      "key" : "version",
+      "key" : "elementTemplateVersion",
       "type" : "zeebe:taskHeader"
     },
     "type" : "Hidden"
@@ -265,7 +265,7 @@
     "value" : "io.camunda.connectors.RabbitMQ.v1",
     "group" : "connector",
     "binding" : {
-      "key" : "id",
+      "key" : "elementTemplateId",
       "type" : "zeebe:taskHeader"
     },
     "type" : "Hidden"

--- a/connectors/rabbitmq/element-templates/rabbitmq-outbound-connector.json
+++ b/connectors/rabbitmq/element-templates/rabbitmq-outbound-connector.json
@@ -249,7 +249,7 @@
     "value" : "5",
     "group" : "connector",
     "binding" : {
-      "key" : "version",
+      "key" : "elementTemplateVersion",
       "type" : "zeebe:taskHeader"
     },
     "type" : "Hidden"
@@ -260,7 +260,7 @@
     "value" : "io.camunda.connectors.RabbitMQ.v1",
     "group" : "connector",
     "binding" : {
-      "key" : "id",
+      "key" : "elementTemplateId",
       "type" : "zeebe:taskHeader"
     },
     "type" : "Hidden"

--- a/connectors/rabbitmq/element-templates/rabbitmq-outbound-connector.json
+++ b/connectors/rabbitmq/element-templates/rabbitmq-outbound-connector.json
@@ -26,6 +26,9 @@
     "id" : "message",
     "label" : "Message"
   }, {
+    "id" : "connector",
+    "label" : "Connector"
+  }, {
     "id" : "output",
     "label" : "Output mapping"
   }, {
@@ -239,6 +242,28 @@
       "type" : "zeebe:input"
     },
     "type" : "Text"
+  }, {
+    "id" : "version",
+    "label" : "Version",
+    "description" : "Version of the element template",
+    "value" : "5",
+    "group" : "connector",
+    "binding" : {
+      "key" : "version",
+      "type" : "zeebe:taskHeader"
+    },
+    "type" : "Hidden"
+  }, {
+    "id" : "id",
+    "label" : "ID",
+    "description" : "ID of the element template",
+    "value" : "io.camunda.connectors.RabbitMQ.v1",
+    "group" : "connector",
+    "binding" : {
+      "key" : "id",
+      "type" : "zeebe:taskHeader"
+    },
+    "type" : "Hidden"
   }, {
     "id" : "resultVariable",
     "label" : "Result variable",

--- a/connectors/salesforce/element-templates/salesforce-connector.json
+++ b/connectors/salesforce/element-templates/salesforce-connector.json
@@ -496,6 +496,29 @@
         "type": "zeebe:taskHeader",
         "key": "errorExpression"
       }
+    },
+    {
+      "id" : "version",
+      "label" : "Version",
+      "description" : "Version of the element template",
+      "value" : "2",
+      "group" : "connector",
+      "binding" : {
+        "key" : "elementTemplateVersion",
+        "type" : "zeebe:taskHeader"
+      },
+      "type" : "Hidden"
+    }, {
+      "id" : "id",
+      "label" : "ID",
+      "description" : "ID of the element template",
+      "value" : "io.camunda.connectors.Salesforce.v1",
+      "group" : "connector",
+      "binding" : {
+        "key" : "elementTemplateId",
+        "type" : "zeebe:taskHeader"
+      },
+      "type" : "Hidden"
     }
   ]
 }

--- a/connectors/sendgrid/element-templates/hybrid/sendgrid-outbound-connector-hybrid.json
+++ b/connectors/sendgrid/element-templates/hybrid/sendgrid-outbound-connector-hybrid.json
@@ -32,6 +32,9 @@
     "id" : "content",
     "label" : "Compose email"
   }, {
+    "id" : "connector",
+    "label" : "Connector"
+  }, {
     "id" : "output",
     "label" : "Output mapping"
   }, {
@@ -245,6 +248,28 @@
       "type" : "zeebe:input"
     },
     "type" : "String"
+  }, {
+    "id" : "version",
+    "label" : "Version",
+    "description" : "Version of the element template",
+    "value" : "4",
+    "group" : "connector",
+    "binding" : {
+      "key" : "version",
+      "type" : "zeebe:taskHeader"
+    },
+    "type" : "Hidden"
+  }, {
+    "id" : "id",
+    "label" : "ID",
+    "description" : "ID of the element template",
+    "value" : "io.camunda.connectors.SendGrid.v2",
+    "group" : "connector",
+    "binding" : {
+      "key" : "id",
+      "type" : "zeebe:taskHeader"
+    },
+    "type" : "Hidden"
   }, {
     "id" : "resultVariable",
     "label" : "Result variable",

--- a/connectors/sendgrid/element-templates/hybrid/sendgrid-outbound-connector-hybrid.json
+++ b/connectors/sendgrid/element-templates/hybrid/sendgrid-outbound-connector-hybrid.json
@@ -255,7 +255,7 @@
     "value" : "4",
     "group" : "connector",
     "binding" : {
-      "key" : "version",
+      "key" : "elementTemplateVersion",
       "type" : "zeebe:taskHeader"
     },
     "type" : "Hidden"
@@ -266,7 +266,7 @@
     "value" : "io.camunda.connectors.SendGrid.v2",
     "group" : "connector",
     "binding" : {
-      "key" : "id",
+      "key" : "elementTemplateId",
       "type" : "zeebe:taskHeader"
     },
     "type" : "Hidden"

--- a/connectors/sendgrid/element-templates/sendgrid-outbound-connector.json
+++ b/connectors/sendgrid/element-templates/sendgrid-outbound-connector.json
@@ -29,6 +29,9 @@
     "id" : "content",
     "label" : "Compose email"
   }, {
+    "id" : "connector",
+    "label" : "Connector"
+  }, {
     "id" : "output",
     "label" : "Output mapping"
   }, {
@@ -240,6 +243,28 @@
       "type" : "zeebe:input"
     },
     "type" : "String"
+  }, {
+    "id" : "version",
+    "label" : "Version",
+    "description" : "Version of the element template",
+    "value" : "4",
+    "group" : "connector",
+    "binding" : {
+      "key" : "version",
+      "type" : "zeebe:taskHeader"
+    },
+    "type" : "Hidden"
+  }, {
+    "id" : "id",
+    "label" : "ID",
+    "description" : "ID of the element template",
+    "value" : "io.camunda.connectors.SendGrid.v2",
+    "group" : "connector",
+    "binding" : {
+      "key" : "id",
+      "type" : "zeebe:taskHeader"
+    },
+    "type" : "Hidden"
   }, {
     "id" : "resultVariable",
     "label" : "Result variable",

--- a/connectors/sendgrid/element-templates/sendgrid-outbound-connector.json
+++ b/connectors/sendgrid/element-templates/sendgrid-outbound-connector.json
@@ -250,7 +250,7 @@
     "value" : "4",
     "group" : "connector",
     "binding" : {
-      "key" : "version",
+      "key" : "elementTemplateVersion",
       "type" : "zeebe:taskHeader"
     },
     "type" : "Hidden"
@@ -261,7 +261,7 @@
     "value" : "io.camunda.connectors.SendGrid.v2",
     "group" : "connector",
     "binding" : {
-      "key" : "id",
+      "key" : "elementTemplateId",
       "type" : "zeebe:taskHeader"
     },
     "type" : "Hidden"

--- a/connectors/slack/element-templates/hybrid/slack-outbound-connector-hybrid.json
+++ b/connectors/slack/element-templates/hybrid/slack-outbound-connector-hybrid.json
@@ -35,6 +35,9 @@
     "id" : "invite",
     "label" : "Invite"
   }, {
+    "id" : "connector",
+    "label" : "Connector"
+  }, {
     "id" : "output",
     "label" : "Output mapping"
   }, {
@@ -376,6 +379,28 @@
       "type" : "simple"
     },
     "type" : "String"
+  }, {
+    "id" : "version",
+    "label" : "Version",
+    "description" : "Version of the element template",
+    "value" : "6",
+    "group" : "connector",
+    "binding" : {
+      "key" : "version",
+      "type" : "zeebe:taskHeader"
+    },
+    "type" : "Hidden"
+  }, {
+    "id" : "id",
+    "label" : "ID",
+    "description" : "ID of the element template",
+    "value" : "io.camunda.connectors.Slack.v1",
+    "group" : "connector",
+    "binding" : {
+      "key" : "id",
+      "type" : "zeebe:taskHeader"
+    },
+    "type" : "Hidden"
   }, {
     "id" : "resultVariable",
     "label" : "Result variable",

--- a/connectors/slack/element-templates/hybrid/slack-outbound-connector-hybrid.json
+++ b/connectors/slack/element-templates/hybrid/slack-outbound-connector-hybrid.json
@@ -7,7 +7,7 @@
     "keywords" : [ ]
   },
   "documentationRef" : "https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/slack/?slack=outbound",
-  "version" : 7,
+  "version" : 6,
   "category" : {
     "id" : "connectors",
     "name" : "Connectors"
@@ -383,7 +383,7 @@
     "id" : "version",
     "label" : "Version",
     "description" : "Version of the element template",
-    "value" : "7",
+    "value" : "6",
     "group" : "connector",
     "binding" : {
       "key" : "elementTemplateVersion",

--- a/connectors/slack/element-templates/hybrid/slack-outbound-connector-hybrid.json
+++ b/connectors/slack/element-templates/hybrid/slack-outbound-connector-hybrid.json
@@ -7,7 +7,7 @@
     "keywords" : [ ]
   },
   "documentationRef" : "https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/slack/?slack=outbound",
-  "version" : 6,
+  "version" : 7,
   "category" : {
     "id" : "connectors",
     "name" : "Connectors"
@@ -383,10 +383,10 @@
     "id" : "version",
     "label" : "Version",
     "description" : "Version of the element template",
-    "value" : "6",
+    "value" : "7",
     "group" : "connector",
     "binding" : {
-      "key" : "version",
+      "key" : "elementTemplateVersion",
       "type" : "zeebe:taskHeader"
     },
     "type" : "Hidden"
@@ -397,7 +397,7 @@
     "value" : "io.camunda.connectors.Slack.v1",
     "group" : "connector",
     "binding" : {
-      "key" : "id",
+      "key" : "elementTemplateId",
       "type" : "zeebe:taskHeader"
     },
     "type" : "Hidden"

--- a/connectors/slack/element-templates/slack-outbound-connector.json
+++ b/connectors/slack/element-templates/slack-outbound-connector.json
@@ -7,7 +7,7 @@
     "keywords" : [ ]
   },
   "documentationRef" : "https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/slack/?slack=outbound",
-  "version" : 7,
+  "version" : 6,
   "category" : {
     "id" : "connectors",
     "name" : "Connectors"
@@ -378,7 +378,7 @@
     "id" : "version",
     "label" : "Version",
     "description" : "Version of the element template",
-    "value" : "7",
+    "value" : "6",
     "group" : "connector",
     "binding" : {
       "key" : "elementTemplateVersion",

--- a/connectors/slack/element-templates/slack-outbound-connector.json
+++ b/connectors/slack/element-templates/slack-outbound-connector.json
@@ -7,7 +7,7 @@
     "keywords" : [ ]
   },
   "documentationRef" : "https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/slack/?slack=outbound",
-  "version" : 6,
+  "version" : 7,
   "category" : {
     "id" : "connectors",
     "name" : "Connectors"
@@ -378,10 +378,10 @@
     "id" : "version",
     "label" : "Version",
     "description" : "Version of the element template",
-    "value" : "6",
+    "value" : "7",
     "group" : "connector",
     "binding" : {
-      "key" : "version",
+      "key" : "elementTemplateVersion",
       "type" : "zeebe:taskHeader"
     },
     "type" : "Hidden"
@@ -392,7 +392,7 @@
     "value" : "io.camunda.connectors.Slack.v1",
     "group" : "connector",
     "binding" : {
-      "key" : "id",
+      "key" : "elementTemplateId",
       "type" : "zeebe:taskHeader"
     },
     "type" : "Hidden"

--- a/connectors/slack/element-templates/slack-outbound-connector.json
+++ b/connectors/slack/element-templates/slack-outbound-connector.json
@@ -32,6 +32,9 @@
     "id" : "invite",
     "label" : "Invite"
   }, {
+    "id" : "connector",
+    "label" : "Connector"
+  }, {
     "id" : "output",
     "label" : "Output mapping"
   }, {
@@ -371,6 +374,28 @@
       "type" : "simple"
     },
     "type" : "String"
+  }, {
+    "id" : "version",
+    "label" : "Version",
+    "description" : "Version of the element template",
+    "value" : "6",
+    "group" : "connector",
+    "binding" : {
+      "key" : "version",
+      "type" : "zeebe:taskHeader"
+    },
+    "type" : "Hidden"
+  }, {
+    "id" : "id",
+    "label" : "ID",
+    "description" : "ID of the element template",
+    "value" : "io.camunda.connectors.Slack.v1",
+    "group" : "connector",
+    "binding" : {
+      "key" : "id",
+      "type" : "zeebe:taskHeader"
+    },
+    "type" : "Hidden"
   }, {
     "id" : "resultVariable",
     "label" : "Result variable",

--- a/connectors/slack/src/main/java/io/camunda/connector/slack/outbound/SlackFunction.java
+++ b/connectors/slack/src/main/java/io/camunda/connector/slack/outbound/SlackFunction.java
@@ -18,7 +18,7 @@ import io.camunda.connector.generator.java.annotation.ElementTemplate;
     name = "Slack Outbound Connector",
     description = "Create a channel or send a message to a channel or user",
     inputDataClass = SlackRequest.class,
-    version = 6,
+    version = 7,
     propertyGroups = {
       @ElementTemplate.PropertyGroup(id = "authentication", label = "Authentication"),
       @ElementTemplate.PropertyGroup(id = "method", label = "Method"),

--- a/connectors/slack/src/main/java/io/camunda/connector/slack/outbound/SlackFunction.java
+++ b/connectors/slack/src/main/java/io/camunda/connector/slack/outbound/SlackFunction.java
@@ -18,7 +18,7 @@ import io.camunda.connector.generator.java.annotation.ElementTemplate;
     name = "Slack Outbound Connector",
     description = "Create a channel or send a message to a channel or user",
     inputDataClass = SlackRequest.class,
-    version = 7,
+    version = 6,
     propertyGroups = {
       @ElementTemplate.PropertyGroup(id = "authentication", label = "Authentication"),
       @ElementTemplate.PropertyGroup(id = "method", label = "Method"),

--- a/connectors/soap/element-templates/hybrid/soap-outbound-connector-hybrid.json
+++ b/connectors/soap/element-templates/hybrid/soap-outbound-connector-hybrid.json
@@ -32,6 +32,9 @@
     "id" : "timeout",
     "label" : "Timeout"
   }, {
+    "id" : "connector",
+    "label" : "Connector"
+  }, {
     "id" : "output",
     "label" : "Output mapping"
   }, {
@@ -627,6 +630,28 @@
       "type" : "zeebe:input"
     },
     "type" : "Number"
+  }, {
+    "id" : "version",
+    "label" : "Version",
+    "description" : "Version of the element template",
+    "value" : "1",
+    "group" : "connector",
+    "binding" : {
+      "key" : "version",
+      "type" : "zeebe:taskHeader"
+    },
+    "type" : "Hidden"
+  }, {
+    "id" : "id",
+    "label" : "ID",
+    "description" : "ID of the element template",
+    "value" : "io.camunda:soap",
+    "group" : "connector",
+    "binding" : {
+      "key" : "id",
+      "type" : "zeebe:taskHeader"
+    },
+    "type" : "Hidden"
   }, {
     "id" : "resultVariable",
     "label" : "Result variable",

--- a/connectors/soap/element-templates/hybrid/soap-outbound-connector-hybrid.json
+++ b/connectors/soap/element-templates/hybrid/soap-outbound-connector-hybrid.json
@@ -637,7 +637,7 @@
     "value" : "1",
     "group" : "connector",
     "binding" : {
-      "key" : "version",
+      "key" : "elementTemplateVersion",
       "type" : "zeebe:taskHeader"
     },
     "type" : "Hidden"
@@ -648,7 +648,7 @@
     "value" : "io.camunda:soap",
     "group" : "connector",
     "binding" : {
-      "key" : "id",
+      "key" : "elementTemplateId",
       "type" : "zeebe:taskHeader"
     },
     "type" : "Hidden"

--- a/connectors/soap/element-templates/soap-outbound-connector.json
+++ b/connectors/soap/element-templates/soap-outbound-connector.json
@@ -29,6 +29,9 @@
     "id" : "timeout",
     "label" : "Timeout"
   }, {
+    "id" : "connector",
+    "label" : "Connector"
+  }, {
     "id" : "output",
     "label" : "Output mapping"
   }, {
@@ -622,6 +625,28 @@
       "type" : "zeebe:input"
     },
     "type" : "Number"
+  }, {
+    "id" : "version",
+    "label" : "Version",
+    "description" : "Version of the element template",
+    "value" : "1",
+    "group" : "connector",
+    "binding" : {
+      "key" : "version",
+      "type" : "zeebe:taskHeader"
+    },
+    "type" : "Hidden"
+  }, {
+    "id" : "id",
+    "label" : "ID",
+    "description" : "ID of the element template",
+    "value" : "io.camunda:soap",
+    "group" : "connector",
+    "binding" : {
+      "key" : "id",
+      "type" : "zeebe:taskHeader"
+    },
+    "type" : "Hidden"
   }, {
     "id" : "resultVariable",
     "label" : "Result variable",

--- a/connectors/soap/element-templates/soap-outbound-connector.json
+++ b/connectors/soap/element-templates/soap-outbound-connector.json
@@ -632,7 +632,7 @@
     "value" : "1",
     "group" : "connector",
     "binding" : {
-      "key" : "version",
+      "key" : "elementTemplateVersion",
       "type" : "zeebe:taskHeader"
     },
     "type" : "Hidden"
@@ -643,7 +643,7 @@
     "value" : "io.camunda:soap",
     "group" : "connector",
     "binding" : {
-      "key" : "id",
+      "key" : "elementTemplateId",
       "type" : "zeebe:taskHeader"
     },
     "type" : "Hidden"

--- a/connectors/twilio/element-templates/twilio-connector.json
+++ b/connectors/twilio/element-templates/twilio-connector.json
@@ -547,6 +547,29 @@
         "type": "zeebe:taskHeader",
         "key": "errorExpression"
       }
+    },
+    {
+      "id" : "version",
+      "label" : "Version",
+      "description" : "Version of the element template",
+      "value" : "4",
+      "group" : "connector",
+      "binding" : {
+        "key" : "elementTemplateVersion",
+        "type" : "zeebe:taskHeader"
+      },
+      "type" : "Hidden"
+    }, {
+      "id" : "id",
+      "label" : "ID",
+      "description" : "ID of the element template",
+      "value" : "io.camunda.connectors.Twilio.v1",
+      "group" : "connector",
+      "binding" : {
+        "key" : "elementTemplateId",
+        "type" : "zeebe:taskHeader"
+      },
+      "type" : "Hidden"
     }
   ]
 }

--- a/connectors/uipath/element-templates/uipath-connector.json
+++ b/connectors/uipath/element-templates/uipath-connector.json
@@ -570,6 +570,29 @@
         "type": "zeebe:taskHeader",
         "key": "errorExpression"
       }
+    },
+    {
+      "id" : "version",
+      "label" : "Version",
+      "description" : "Version of the element template",
+      "value" : "4",
+      "group" : "connector",
+      "binding" : {
+        "key" : "elementTemplateVersion",
+        "type" : "zeebe:taskHeader"
+      },
+      "type" : "Hidden"
+    }, {
+      "id" : "id",
+      "label" : "ID",
+      "description" : "ID of the element template",
+      "value" : "io.camunda.connectors.UIPath.v1",
+      "group" : "connector",
+      "binding" : {
+        "key" : "elementTemplateId",
+        "type" : "zeebe:taskHeader"
+      },
+      "type" : "Hidden"
     }
   ]
 }

--- a/connectors/whatsapp/element-templates/whatsapp-connector.json
+++ b/connectors/whatsapp/element-templates/whatsapp-connector.json
@@ -292,6 +292,29 @@
         "type": "zeebe:taskHeader",
         "key": "errorExpression"
       }
+    },
+    {
+      "id" : "version",
+      "label" : "Version",
+      "description" : "Version of the element template",
+      "value" : "2",
+      "group" : "connector",
+      "binding" : {
+        "key" : "elementTemplateVersion",
+        "type" : "zeebe:taskHeader"
+      },
+      "type" : "Hidden"
+    }, {
+      "id" : "id",
+      "label" : "ID",
+      "description" : "ID of the element template",
+      "value" : "io.camunda.connectors.WhatsApp.v1",
+      "group" : "connector",
+      "binding" : {
+        "key" : "elementTemplateId",
+        "type" : "zeebe:taskHeader"
+      },
+      "type" : "Hidden"
     }
   ]
 }

--- a/element-template-generator/core/src/main/java/io/camunda/connector/generator/dsl/CommonProperties.java
+++ b/element-template-generator/core/src/main/java/io/camunda/connector/generator/dsl/CommonProperties.java
@@ -45,6 +45,24 @@ public class CommonProperties {
         .feel(FeelMode.disabled);
   }
 
+  public static PropertyBuilder version(Integer version) {
+    return HiddenProperty.builder()
+        .id("version")
+        .group("connector")
+        .label("Version")
+        .value(String.valueOf(version))
+        .description("Version of the element template");
+  }
+
+  public static PropertyBuilder id(String id) {
+    return HiddenProperty.builder()
+        .id("id")
+        .group("connector")
+        .label("ID")
+        .value(id)
+        .description("ID of the element template");
+  }
+
   public static PropertyBuilder errorExpression() {
     return TextProperty.builder()
         .id("errorExpression")

--- a/element-template-generator/core/src/main/java/io/camunda/connector/generator/dsl/PropertyGroup.java
+++ b/element-template-generator/core/src/main/java/io/camunda/connector/generator/dsl/PropertyGroup.java
@@ -56,8 +56,10 @@ public record PropertyGroup(
               .id("connector")
               .label("Connector")
               .properties(
-                  CommonProperties.version(version).binding(new ZeebeTaskHeader("version")).build(),
-                  CommonProperties.id(id).binding(new ZeebeTaskHeader("id")).build())
+                  CommonProperties.version(version)
+                      .binding(new ZeebeTaskHeader("elementTemplateVersion"))
+                      .build(),
+                  CommonProperties.id(id).binding(new ZeebeTaskHeader("elementTemplateId")).build())
               .build();
 
   public static PropertyGroup OUTPUT_GROUP_INBOUND =

--- a/element-template-generator/core/src/main/java/io/camunda/connector/generator/dsl/PropertyGroup.java
+++ b/element-template-generator/core/src/main/java/io/camunda/connector/generator/dsl/PropertyGroup.java
@@ -26,6 +26,7 @@ import io.camunda.connector.generator.dsl.PropertyCondition.Equals;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.function.BiFunction;
 import java.util.stream.Stream;
 
 @JsonInclude(Include.NON_NULL)
@@ -48,6 +49,16 @@ public record PropertyGroup(
                   .binding(new ZeebeTaskHeader("resultExpression"))
                   .build())
           .build();
+
+  public static BiFunction<String, Integer, PropertyGroup> ADD_CONNECTORS_DETAILS_OUTPUT =
+      (id, version) ->
+          PropertyGroup.builder()
+              .id("connector")
+              .label("Connector")
+              .properties(
+                  CommonProperties.version(version).binding(new ZeebeTaskHeader("version")).build(),
+                  CommonProperties.id(id).binding(new ZeebeTaskHeader("id")).build())
+              .build();
 
   public static PropertyGroup OUTPUT_GROUP_INBOUND =
       PropertyGroup.builder()
@@ -170,11 +181,11 @@ public record PropertyGroup(
 
   public static final class PropertyGroupBuilder {
 
+    private final List<Property> properties = new ArrayList<>();
     private String id;
     private String label;
     private String tooltip;
     private Boolean openByDefault;
-    private final List<Property> properties = new ArrayList<>();
 
     private PropertyGroupBuilder() {}
 

--- a/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/ClassBasedTemplateGenerator.java
+++ b/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/ClassBasedTemplateGenerator.java
@@ -187,7 +187,8 @@ public class ClassBasedTemplateGenerator implements ElementTemplateGenerator<Cla
                   .description(template.description().isEmpty() ? null : template.description())
                   .properties(nonGroupedProperties.stream().map(PropertyBuilder::build).toList())
                   .propertyGroups(
-                      addServiceProperties(mergedGroups, context, elementType, configuration))
+                      addServiceProperties(
+                          mergedGroups, context, elementType, configuration, template))
                   .build();
             })
         .toList();
@@ -197,9 +198,12 @@ public class ClassBasedTemplateGenerator implements ElementTemplateGenerator<Cla
       List<PropertyGroup> groups,
       TemplateGenerationContext context,
       ConnectorElementType elementType,
-      GeneratorConfiguration configuration) {
+      GeneratorConfiguration configuration,
+      ElementTemplate template) {
     var newGroups = new ArrayList<>(groups);
     if (context instanceof Outbound) {
+      newGroups.add(
+          PropertyGroup.ADD_CONNECTORS_DETAILS_OUTPUT.apply(template.id(), template.version()));
       newGroups.add(PropertyGroup.OUTPUT_GROUP_OUTBOUND);
       newGroups.add(PropertyGroup.ERROR_GROUP);
       newGroups.add(PropertyGroup.RETRIES_GROUP);

--- a/element-template-generator/core/src/test/java/io/camunda/connector/generator/java/OutboundClassBasedTemplateGeneratorTest.java
+++ b/element-template-generator/core/src/test/java/io/camunda/connector/generator/java/OutboundClassBasedTemplateGeneratorTest.java
@@ -717,7 +717,8 @@ public class OutboundClassBasedTemplateGeneratorTest extends BaseTest {
               Map.entry("group2", "Group 2"),
               Map.entry("output", "Output mapping"),
               Map.entry("error", "Error handling"),
-              Map.entry("retries", "Retries")),
+              Map.entry("retries", "Retries"),
+              Map.entry("connector", "Connector")),
           template,
           false);
     }
@@ -729,6 +730,7 @@ public class OutboundClassBasedTemplateGeneratorTest extends BaseTest {
           List.of(
               Map.entry("group2", "Group Two"),
               Map.entry("group1", "Group One"),
+              Map.entry("connector", "Connector"),
               Map.entry("output", "Output mapping"),
               Map.entry("error", "Error handling"),
               Map.entry("retries", "Retries")),
@@ -765,6 +767,7 @@ public class OutboundClassBasedTemplateGeneratorTest extends BaseTest {
               Map.entry("customGroup", "Custom group"),
               Map.entry("group2", "Group 2"),
               Map.entry("group1", "Group 1"),
+              Map.entry("connector", "Connector"),
               Map.entry("output", "Output mapping"),
               Map.entry("error", "Error handling"),
               Map.entry("retries", "Retries")),


### PR DESCRIPTION
## Description

I have completely removed the usage of MetricsRecorder since we are now utilizing our own metrics system. Our new metrics capture the type, ID, and version of the element template. 

For each state of an outbound or inbound connector, a new metric is created, with tags used to differentiate the type, ID, and version.

I have also modified the static elements template such as github, gitlab, openai etc..

Metrics looks like this

```
# HELP camunda_connector_inbound_activations_total  
# TYPE camunda_connector_inbound_activations_total counter
camunda_connector_inbound_activations_total{id="io.camunda.connectors.inbound.EmailMessageStart.v1",type="io.camunda:connector-email-inbound:1",version="1"} 1.0
# HELP camunda_connector_inbound_correlations_success_total  
# TYPE camunda_connector_inbound_correlations_success_total counter
camunda_connector_inbound_correlations_success_total{id="io.camunda.connectors.inbound.EmailMessageStart.v1",type="io.camunda:connector-email-inbound:1",version="1"} 2.0
# HELP camunda_connector_inbound_process_definitions_checked_total  
# TYPE camunda_connector_inbound_process_definitions_checked_total counter
camunda_connector_inbound_process_definitions_checked_total 13.0
# HELP camunda_connector_inbound_triggers_total  
# TYPE camunda_connector_inbound_triggers_total counter
camunda_connector_inbound_triggers_total{id="io.camunda.connectors.inbound.EmailMessageStart.v1",type="io.camunda:connector-email-inbound:1",version="1"} 2.0
# HELP camunda_connector_outbound_completions_total  
# TYPE camunda_connector_outbound_completions_total counter
camunda_connector_outbound_completions_total{id="io.camunda.connectors.Slack.v1",type="io.camunda:slack:1",version="7"} 2.0
camunda_connector_outbound_completions_total{id="unknown",type="io.camunda:http-json:1",version="unknown"} 2.0
# HELP camunda_connector_outbound_execution_time_seconds  
# TYPE camunda_connector_outbound_execution_time_seconds summary
camunda_connector_outbound_execution_time_seconds_count{id="io.camunda.connectors.Slack.v1",type="io.camunda:slack:1",version="7"} 2
camunda_connector_outbound_execution_time_seconds_sum{id="io.camunda.connectors.Slack.v1",type="io.camunda:slack:1",version="7"} 1.634261667
camunda_connector_outbound_execution_time_seconds_count{id="unknown",type="io.camunda:http-json:1",version="unknown"} 2
camunda_connector_outbound_execution_time_seconds_sum{id="unknown",type="io.camunda:http-json:1",version="unknown"} 2.258928083
# HELP camunda_connector_outbound_execution_time_seconds_max  
# TYPE camunda_connector_outbound_execution_time_seconds_max gauge
camunda_connector_outbound_execution_time_seconds_max{id="io.camunda.connectors.Slack.v1",type="io.camunda:slack:1",version="7"} 1.231433625
camunda_connector_outbound_execution_time_seconds_max{id="unknown",type="io.camunda:http-json:1",version="unknown"} 1.141629542
# HELP camunda_connector_outbound_invocations_total  
# TYPE camunda_connector_outbound_invocations_total counter
camunda_connector_outbound_invocations_total{id="io.camunda.connectors.Slack.v1",type="io.camunda:slack:1",version="7"} 2.0
camunda_connector_outbound_invocations_total{id="unknown",type="io.camunda:http-json:1",version="unknown"} 2.0
```

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes https://github.com/camunda/connectors/issues/4440

## Checklist

- [ ] PR has a **milestone** or the `no milestone` label.

