### PR TITLE
fix(config): remove default address property values

### DIFF
--- a/bundle/default-bundle/src/main/resources/application.properties
+++ b/bundle/default-bundle/src/main/resources/application.properties
@@ -7,10 +7,7 @@ management.endpoint.health.show-components=always
 management.endpoint.health.show-details=always
 camunda.client.execution-threads=10
 
-camunda.client.grpc-address=http://localhost:26500
 camunda.client.zeebe.defaults.max-jobs-active=32
 camunda.client.zeebe.defaults.stream-enabled=true
-camunda.client.rest-address=http://localhost:8088
-camunda.client.mode=self-managed
 
 server.max-http-request-header-size=1MB

--- a/connector-runtime/connector-runtime-application/src/main/resources/application.properties
+++ b/connector-runtime/connector-runtime-application/src/main/resources/application.properties
@@ -7,10 +7,7 @@ management.endpoint.health.show-components=always
 management.endpoint.health.show-details=always
 camunda.client.execution-threads=10
 
-camunda.client.grpc-address=http://localhost:26500
 camunda.client.zeebe.defaults.max-jobs-active=32
 camunda.client.zeebe.defaults.stream-enabled=true
-camunda.client.rest-address=http://localhost:8088
-camunda.client.mode=self-managed
 
 server.max-http-request-header-size=1MB


### PR DESCRIPTION
## Description

Remove default address properties because they break the bundle installations when Camunda is not running locally (e.g. hybrid mode)

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #

## Checklist

- [ ] PR has a **milestone** or the `no milestone` label.

