### PR TITLE
fix(config): remove default address property values on 8.7

### DIFF
--- a/bundle/default-bundle/src/main/resources/application.properties
+++ b/bundle/default-bundle/src/main/resources/application.properties
@@ -9,5 +9,4 @@ camunda.client.zeebe.execution-threads=10
 camunda.client.zeebe.defaults.max-jobs-active=32
 camunda.client.zeebe.defaults.stream-enabled=true
 
-operate.client.base-url=http://localhost:8081
 server.max-http-request-header-size=1MB

--- a/bundle/default-bundle/src/main/resources/application.properties
+++ b/bundle/default-bundle/src/main/resources/application.properties
@@ -6,11 +6,8 @@ management.endpoint.health.show-components=always
 management.endpoint.health.show-details=always
 camunda.client.zeebe.execution-threads=10
 
-camunda.client.zeebe.grpc-address=http://localhost:26500
 camunda.client.zeebe.defaults.max-jobs-active=32
 camunda.client.zeebe.defaults.stream-enabled=true
-camunda.client.zeebe.rest-address=http://localhost:8088
-camunda.client.mode=self-managed
 
 operate.client.base-url=http://localhost:8081
 server.max-http-request-header-size=1MB

--- a/connector-runtime/connector-runtime-application/src/main/resources/application.properties
+++ b/connector-runtime/connector-runtime-application/src/main/resources/application.properties
@@ -7,10 +7,7 @@ management.endpoint.health.show-components=always
 management.endpoint.health.show-details=always
 camunda.client.zeebe.execution-threads=10
 
-camunda.client.zeebe.grpc-address=http://localhost:26500
 camunda.client.zeebe.defaults.max-jobs-active=32
 camunda.client.zeebe.defaults.stream-enabled=true
-camunda.client.zeebe.rest-address=http://localhost:8088
-camunda.client.mode=self-managed
 
 server.max-http-request-header-size=1MB

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/secret/ConsoleSecretProvider.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/secret/ConsoleSecretProvider.java
@@ -54,7 +54,7 @@ public class ConsoleSecretProvider implements SecretProvider {
 
   @Override
   public String getSecret(String name) {
-    LOGGER.debug("Resolving secret for key: " + name);
+    LOGGER.debug("Resolving secret for key: {}", name);
     return secretsCache.getUnchecked(CACHE_KEY).getOrDefault(name, null);
   }
 }

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/main/java/io/camunda/connector/runtime/OutboundConnectorsAutoConfiguration.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/main/java/io/camunda/connector/runtime/OutboundConnectorsAutoConfiguration.java
@@ -34,7 +34,6 @@ import io.camunda.zeebe.client.impl.ZeebeObjectMapper;
 import io.camunda.zeebe.spring.client.properties.CamundaClientProperties;
 import io.camunda.zeebe.spring.client.properties.CamundaClientProperties.ClientMode;
 import io.camunda.zeebe.spring.common.json.SdkObjectMapper;
-import java.net.URI;
 import java.net.URL;
 import java.time.Duration;
 import java.util.LinkedList;
@@ -145,9 +144,9 @@ public class OutboundConnectorsAutoConfiguration {
     var authProperties = clientProperties.getAuth();
     URL issuerUrl;
     try {
-      issuerUrl = new URI(authProperties.getIssuer()).toURL();
+      issuerUrl = authProperties.getTokenUrl().toURL();
     } catch (Exception e) {
-      throw new RuntimeException("Invalid issuer URL: " + authProperties.getIssuer(), e);
+      throw new RuntimeException("Invalid issuer URL: " + authProperties.getTokenUrl(), e);
     }
 
     var jwtCredential =


### PR DESCRIPTION
## Description

Remove default address properties because they break the bundle when Camunda is not running locally (e.g. in hybrid mode).

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #

## Checklist

- [ ] PR has a **milestone** or the `no milestone` label.

