### PR TITLE
fix(config): remove default address property values

### DIFF
--- a/bundle/default-bundle/src/main/resources/application.properties
+++ b/bundle/default-bundle/src/main/resources/application.properties
@@ -7,10 +7,7 @@ management.endpoint.health.show-components=always
 management.endpoint.health.show-details=always
 camunda.client.execution-threads=10
 
-camunda.client.grpc-address=http://localhost:26500
 camunda.client.zeebe.defaults.max-jobs-active=32
 camunda.client.zeebe.defaults.stream-enabled=true
-camunda.client.rest-address=http://localhost:8088
-camunda.client.mode=self-managed
 
 server.max-http-request-header-size=1MB

--- a/connector-runtime/connector-runtime-application/src/main/resources/application.properties
+++ b/connector-runtime/connector-runtime-application/src/main/resources/application.properties
@@ -7,10 +7,7 @@ management.endpoint.health.show-components=always
 management.endpoint.health.show-details=always
 camunda.client.execution-threads=10
 
-camunda.client.grpc-address=http://localhost:26500
 camunda.client.zeebe.defaults.max-jobs-active=32
 camunda.client.zeebe.defaults.stream-enabled=true
-camunda.client.rest-address=http://localhost:8088
-camunda.client.mode=self-managed
 
 server.max-http-request-header-size=1MB

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/secret/ConsoleSecretProvider.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/secret/ConsoleSecretProvider.java
@@ -55,7 +55,7 @@ public class ConsoleSecretProvider implements SecretProvider {
 
   @Override
   public String getSecret(String name) {
-    LOGGER.debug("Resolving secret for key: " + name);
+    LOGGER.debug("Resolving secret for key: {}", name);
     return secretsCache.getUnchecked(CACHE_KEY).getOrDefault(name, null);
   }
 }

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/main/java/io/camunda/connector/runtime/OutboundConnectorsAutoConfiguration.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/main/java/io/camunda/connector/runtime/OutboundConnectorsAutoConfiguration.java
@@ -132,9 +132,9 @@ public class OutboundConnectorsAutoConfiguration {
     var authProperties = clientProperties.getAuth();
     URL issuerUrl;
     try {
-      issuerUrl = authProperties.getIssuer().toURL();
+      issuerUrl = authProperties.getTokenUrl().toURL();
     } catch (Exception e) {
-      throw new RuntimeException("Invalid issuer URL: " + authProperties.getIssuer(), e);
+      throw new RuntimeException("Invalid token URL: " + authProperties.getTokenUrl(), e);
     }
 
     var jwtCredential =


### PR DESCRIPTION
## Description

Remove default address properties because they break the bundle when Camunda is not running locally (e.g. in hybrid mode).

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #

## Checklist

- [ ] PR has a **milestone** or the `no milestone` label.

