### PR TITLE
fix(connector-runtime-core): SecretProviderAggregator should respect fetchAll function of each secret provider

### DIFF
--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretProviderAggregator.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretProviderAggregator.java
@@ -19,6 +19,7 @@ package io.camunda.connector.runtime.core.secret;
 import io.camunda.connector.api.secret.SecretProvider;
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -56,6 +57,13 @@ public class SecretProviderAggregator implements SecretProvider {
     }
     LOG.debug("Could not resolve secret '{}'", secretName);
     return null;
+  }
+
+  @Override
+  public List<String> fetchAll(List<String> keys) {
+    return secretProviders.stream()
+        .flatMap(provider -> provider.fetchAll(keys).stream())
+        .collect(Collectors.toList());
   }
 
   public List<SecretProvider> getSecretProviders() {

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/secret/SecretProviderAggregatorTest.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/secret/SecretProviderAggregatorTest.java
@@ -17,6 +17,7 @@
 package io.camunda.connector.runtime.core.secret;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
 
 import io.camunda.connector.api.secret.SecretProvider;
 import io.camunda.connector.runtime.core.FooBarSecretProvider;
@@ -54,5 +55,14 @@ public class SecretProviderAggregatorTest {
     assertThat(aggregator.getSecretProviders().get(1)).isInstanceOf(NoOpSecretProvider.class);
     assertThat(aggregator.getSecretProviders().get(0)).isInstanceOf(FooBarSecretProvider.class);
     assertThat(secret).isEqualTo(FooBarSecretProvider.SECRET_VALUE);
+  }
+
+  @Test
+  public void fetchAllShouldInvokeAllSecretProviders() {
+    SecretProvider mock = mock(SecretProvider.class);
+    List<SecretProvider> secretProviders = List.of(mock);
+    SecretProviderAggregator aggregator = new SecretProviderAggregator(secretProviders);
+    aggregator.fetchAll(List.of("foo", "bar"));
+    verify(mock, times(1)).fetchAll(List.of("foo", "bar"));
   }
 }


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

This PR fixes an issue that the `fetchAll` function of each secret provider is not invoked if the aggregator is used.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.

