### PR TITLE
chore(fix-main): fix main after deployment of new snapshot

### DIFF
--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/DefaultProcessInstanceContext.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/DefaultProcessInstanceContext.java
@@ -18,7 +18,7 @@ package io.camunda.connector.runtime.core.inbound;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.camunda.client.api.search.response.FlowNodeInstance;
+import io.camunda.client.api.search.response.ElementInstance;
 import io.camunda.connector.api.inbound.CorrelationRequest;
 import io.camunda.connector.api.inbound.ProcessInstanceContext;
 import io.camunda.connector.api.validation.ValidationProvider;
@@ -31,7 +31,7 @@ import java.util.function.Supplier;
 public final class DefaultProcessInstanceContext implements ProcessInstanceContext {
 
   private final InboundIntermediateConnectorContextImpl context;
-  private final FlowNodeInstance flowNodeInstance;
+  private final ElementInstance elementInstance;
   private final ValidationProvider validationProvider;
   private final ObjectMapper objectMapper;
   private final Supplier<Map<String, Object>> operatePropertiesSupplier;
@@ -41,13 +41,13 @@ public final class DefaultProcessInstanceContext implements ProcessInstanceConte
 
   public DefaultProcessInstanceContext(
       final InboundIntermediateConnectorContextImpl context,
-      final FlowNodeInstance flowNodeInstance,
+      final ElementInstance elementInstance,
       final ValidationProvider validationProvider,
       final InboundCorrelationHandler correlationHandler,
       final ObjectMapper objectMapper,
       final Supplier<Map<String, Object>> operateVariables) {
     this.context = context;
-    this.flowNodeInstance = flowNodeInstance;
+    this.elementInstance = elementInstance;
     this.validationProvider =
         validationProvider == null
             ? ValidationUtil.discoverDefaultValidationProviderImplementation()
@@ -61,7 +61,7 @@ public final class DefaultProcessInstanceContext implements ProcessInstanceConte
 
   @Override
   public Long getKey() {
-    return flowNodeInstance.getProcessInstanceKey();
+    return elementInstance.getProcessInstanceKey();
   }
 
   @Override
@@ -80,7 +80,7 @@ public final class DefaultProcessInstanceContext implements ProcessInstanceConte
 
   @Override
   public void correlate(final Object variables) {
-    String messageId = flowNodeInstance.getFlowNodeId() + flowNodeInstance.getFlowNodeInstanceKey();
+    String messageId = elementInstance.getElementId() + elementInstance.getElementInstanceKey();
     correlationHandler.correlate(
         context.connectorElements(),
         CorrelationRequest.builder().variables(variables).messageId(messageId).build());
@@ -88,6 +88,6 @@ public final class DefaultProcessInstanceContext implements ProcessInstanceConte
 
   @Override
   public String toString() {
-    return "DefaultProcessInstanceContext{" + "flowNodeInstance=" + flowNodeInstance + "}";
+    return "DefaultProcessInstanceContext{" + "flowNodeInstance=" + elementInstance + "}";
   }
 }

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/InboundIntermediateConnectorContextImpl.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/InboundIntermediateConnectorContextImpl.java
@@ -17,7 +17,7 @@
 package io.camunda.connector.runtime.core.inbound;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.camunda.client.api.search.response.FlowNodeInstance;
+import io.camunda.client.api.search.response.ElementInstance;
 import io.camunda.connector.api.inbound.*;
 import io.camunda.connector.api.validation.ValidationProvider;
 import io.camunda.connector.runtime.core.inbound.correlation.InboundCorrelationHandler;
@@ -77,13 +77,19 @@ public class InboundIntermediateConnectorContextImpl
         .collect(Collectors.toList());
   }
 
-  private ProcessInstanceContext createProcessInstanceContext(FlowNodeInstance node) {
+  private ProcessInstanceContext createProcessInstanceContext(ElementInstance elementInstance) {
     Supplier<Map<String, Object>> variableSupplier =
         () ->
-            processInstanceClient.fetchVariablesByProcessInstanceKey(node.getProcessInstanceKey());
+            processInstanceClient.fetchVariablesByProcessInstanceKey(
+                elementInstance.getProcessInstanceKey());
 
     return new DefaultProcessInstanceContext(
-        this, node, validationProvider, correlationHandler, objectMapper, variableSupplier);
+        this,
+        elementInstance,
+        validationProvider,
+        correlationHandler,
+        objectMapper,
+        variableSupplier);
   }
 
   @Override

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/ProcessInstanceClient.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/ProcessInstanceClient.java
@@ -16,7 +16,7 @@
  */
 package io.camunda.connector.runtime.core.inbound;
 
-import io.camunda.client.api.search.response.FlowNodeInstance;
+import io.camunda.client.api.search.response.ElementInstance;
 import java.util.List;
 import java.util.Map;
 
@@ -37,11 +37,11 @@ public interface ProcessInstanceClient {
    * @param processDefinitionKey The unique identifier for the process definition.
    * @param elementId The identifier of the specific flow node element within the process
    *     definition.
-   * @return A list of {@link FlowNodeInstance} objects representing active process instances
+   * @return A list of {@link ElementInstance} objects representing active process instances
    *     associated with the given process definition key and element ID. Returns an empty list if
    *     none are found.
    */
-  List<FlowNodeInstance> fetchActiveProcessInstanceKeyByDefinitionKeyAndElementId(
+  List<ElementInstance> fetchActiveProcessInstanceKeyByDefinitionKeyAndElementId(
       final Long processDefinitionKey, final String elementId);
 
   /**

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/search/ProcessInstanceClientImpl.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/search/ProcessInstanceClientImpl.java
@@ -18,7 +18,7 @@ package io.camunda.connector.runtime.inbound.search;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.camunda.client.api.search.response.FlowNodeInstance;
+import io.camunda.client.api.search.response.ElementInstance;
 import io.camunda.client.api.search.response.SearchResponse;
 import io.camunda.client.api.search.response.Variable;
 import io.camunda.connector.runtime.core.inbound.ProcessInstanceClient;
@@ -54,16 +54,16 @@ public class ProcessInstanceClientImpl implements ProcessInstanceClient {
    *     node instances from.
    * @param elementId The identifier of the specific flow node element within the process
    *     definition.
-   * @return A list of active {@link FlowNodeInstance} objects.
+   * @return A list of active {@link io.camunda.client.api.search.response.ElementInstance} objects.
    * @throws RuntimeException If an error occurs during the fetch operation.
    */
-  public List<FlowNodeInstance> fetchActiveProcessInstanceKeyByDefinitionKeyAndElementId(
+  public List<ElementInstance> fetchActiveProcessInstanceKeyByDefinitionKeyAndElementId(
       final Long processDefinitionKey, final String elementId) {
     fetchActiveProcessLock.lock();
     try {
       List<Object> processPaginationIndex = null;
-      SearchResponse<FlowNodeInstance> searchResult;
-      List<FlowNodeInstance> result = new ArrayList<>();
+      SearchResponse<ElementInstance> searchResult;
+      List<ElementInstance> result = new ArrayList<>();
       do {
         searchResult =
             searchQueryClient.queryActiveFlowNodes(

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/search/SearchQueryClient.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/search/SearchQueryClient.java
@@ -16,7 +16,7 @@
  */
 package io.camunda.connector.runtime.inbound.search;
 
-import io.camunda.client.api.search.response.FlowNodeInstance;
+import io.camunda.client.api.search.response.ElementInstance;
 import io.camunda.client.api.search.response.ProcessDefinition;
 import io.camunda.client.api.search.response.SearchResponse;
 import io.camunda.client.api.search.response.Variable;
@@ -28,7 +28,7 @@ public interface SearchQueryClient {
 
   SearchResponse<ProcessDefinition> queryProcessDefinitions(List<Object> paginationIndex);
 
-  SearchResponse<FlowNodeInstance> queryActiveFlowNodes(
+  SearchResponse<ElementInstance> queryActiveFlowNodes(
       long processDefinitionKey, String elementId, List<Object> paginationIndex);
 
   SearchResponse<Variable> queryVariables(

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/search/SearchQueryClientImpl.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/search/SearchQueryClientImpl.java
@@ -17,7 +17,7 @@
 package io.camunda.connector.runtime.inbound.search;
 
 import io.camunda.client.CamundaClient;
-import io.camunda.client.api.search.enums.FlowNodeInstanceState;
+import io.camunda.client.api.search.enums.ElementInstanceState;
 import io.camunda.client.api.search.response.*;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
@@ -49,16 +49,16 @@ public class SearchQueryClientImpl implements SearchQueryClient {
   }
 
   @Override
-  public SearchResponse<FlowNodeInstance> queryActiveFlowNodes(
+  public SearchResponse<ElementInstance> queryActiveFlowNodes(
       long processDefinitionKey, String elementId, List<Object> paginationIndex) {
     final var query =
         camundaClient
-            .newFlownodeInstanceSearchRequest()
+            .newElementInstanceSearchRequest()
             .filter(
                 i ->
                     i.processDefinitionKey(processDefinitionKey)
-                        .flowNodeId(elementId)
-                        .state(FlowNodeInstanceState.ACTIVE));
+                        .elementId(elementId)
+                        .state(ElementInstanceState.ACTIVE));
     if (paginationIndex != null) {
       query.page(p -> p.limit(PAGE_SIZE).searchAfter(paginationIndex));
     } else {

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/inbound/search/ProcessInstanceClientImplTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/inbound/search/ProcessInstanceClientImplTest.java
@@ -22,14 +22,14 @@ import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.camunda.client.api.search.response.FlowNodeInstance;
+import io.camunda.client.api.search.response.ElementInstance;
 import io.camunda.client.api.search.response.SearchResponse;
 import io.camunda.client.api.search.response.Variable;
-import io.camunda.client.impl.search.response.FlowNodeInstanceImpl;
+import io.camunda.client.impl.search.response.ElementInstanceImpl;
 import io.camunda.client.impl.search.response.SearchResponseImpl;
 import io.camunda.client.impl.search.response.SearchResponsePageImpl;
 import io.camunda.client.impl.search.response.VariableImpl;
-import io.camunda.client.protocol.rest.FlowNodeInstanceResult;
+import io.camunda.client.protocol.rest.ElementInstanceResult;
 import io.camunda.client.protocol.rest.VariableResult;
 import io.camunda.connector.runtime.core.inbound.ProcessInstanceClient;
 import java.util.Arrays;
@@ -61,51 +61,50 @@ class ProcessInstanceClientImplTest {
     // Given
     Long processDefinitionKey = 123L;
     String elementId = "task1";
-    FlowNodeInstance flownodeInstance1 =
+    ElementInstance flownodeInstance1 =
         createFlownodeInstance("456", "123456", "187", "flowNodeName1", "tenantId1");
-    FlowNodeInstance flownodeInstance2 =
+    ElementInstance flownodeInstance2 =
         createFlownodeInstance("789", "234567", "203", "flowNodeName2", "tenantId2");
 
-    SearchResponse<FlowNodeInstance> flownodeInstanceSearchResult =
+    SearchResponse<ElementInstance> flownodeInstanceSearchResult =
         createSearchResult(flownodeInstance1, flownodeInstance2);
-    SearchResponse<FlowNodeInstance> flownodeInstanceEmptySearchResult = createEmptySearchResult();
+    SearchResponse<ElementInstance> flownodeInstanceEmptySearchResult = createEmptySearchResult();
 
     when(searchQueryClient.queryActiveFlowNodes(anyLong(), any(), any()))
         .thenReturn(flownodeInstanceSearchResult)
         .thenReturn(flownodeInstanceEmptySearchResult);
 
     // When
-    List<FlowNodeInstance> result =
+    List<ElementInstance> result =
         processInstanceClient.fetchActiveProcessInstanceKeyByDefinitionKeyAndElementId(
             processDefinitionKey, elementId);
 
     // Then
     assertThat(result.size()).isEqualTo(2);
-    FlowNodeInstance actualFlowNodeInstance1 = result.getFirst();
-    assertThat(actualFlowNodeInstance1.getFlowNodeId())
-        .isEqualTo(flownodeInstance1.getFlowNodeId());
+    ElementInstance actualFlowNodeInstance1 = result.getFirst();
+    assertThat(actualFlowNodeInstance1.getElementId()).isEqualTo(flownodeInstance1.getElementId());
     assertThat(actualFlowNodeInstance1.getProcessDefinitionKey())
         .isEqualTo(flownodeInstance1.getProcessDefinitionKey());
-    assertThat(actualFlowNodeInstance1.getFlowNodeInstanceKey())
-        .isEqualTo(flownodeInstance1.getFlowNodeInstanceKey());
+    assertThat(actualFlowNodeInstance1.getElementInstanceKey())
+        .isEqualTo(flownodeInstance1.getElementInstanceKey());
     assertThat(actualFlowNodeInstance1.getProcessInstanceKey())
         .isEqualTo(flownodeInstance1.getProcessInstanceKey());
     assertThat(actualFlowNodeInstance1.getTenantId()).isEqualTo(flownodeInstance1.getTenantId());
   }
 
-  private FlowNodeInstance createFlownodeInstance(
+  private ElementInstance createFlownodeInstance(
       final String key,
       final String processInstanceKey,
       final String definitionKey,
       final String flowNodeId,
       final String tenantId) {
-    final var item = new FlowNodeInstanceResult();
-    item.setFlowNodeInstanceKey(key);
+    final var item = new ElementInstanceResult();
+    item.setElementInstanceKey(key);
     item.setProcessInstanceKey(processInstanceKey);
     item.setProcessDefinitionKey(definitionKey);
-    item.setFlowNodeId(flowNodeId);
+    item.setElementId(flowNodeId);
     item.setTenantId(tenantId);
-    return new FlowNodeInstanceImpl(item);
+    return new ElementInstanceImpl(item);
   }
 
   @Test

--- a/connectors-e2e-test/connectors-e2e-test-base/src/main/java/io/camunda/connector/e2e/app/TestConnectorRuntimeApplication.java
+++ b/connectors-e2e-test/connectors-e2e-test-base/src/main/java/io/camunda/connector/e2e/app/TestConnectorRuntimeApplication.java
@@ -16,16 +16,15 @@
  */
 package io.camunda.connector.e2e.app;
 
-import io.camunda.connector.runtime.inbound.search.SearchQueryClient;
 import io.camunda.document.factory.DocumentFactory;
 import io.camunda.document.factory.DocumentFactoryImpl;
 import io.camunda.document.store.InMemoryDocumentStore;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Primary;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @SpringBootApplication
 @ImportAutoConfiguration({
@@ -33,7 +32,7 @@ import org.springframework.context.annotation.Primary;
   io.camunda.connector.runtime.OutboundConnectorsAutoConfiguration.class,
   io.camunda.connector.runtime.WebhookConnectorAutoConfiguration.class
 })
-@MockBean(SearchQueryClient.class)
+@MockitoBean("SearchQueryClient")
 public class TestConnectorRuntimeApplication {
 
   public static void main(String[] args) {

--- a/connectors-e2e-test/connectors-e2e-test-base/src/main/resources/application.properties
+++ b/connectors-e2e-test/connectors-e2e-test-base/src/main/resources/application.properties
@@ -3,5 +3,4 @@ logging.level.io.camunda.process.test=info
 logging.level.org.testcontainers=warn
 logging.level.tc=warn
 logging.level.io.camunda.connector=debug
-camunda.rest.query.enabled=true
-io.camunda.process.test.camundaVersion=SNAPSHOT
+io.camunda.process.test.camundaDockerImageName=camunda/zeebe:SNAPSHOT

--- a/connectors-e2e-test/connectors-e2e-test-http/src/test/java/io/camunda/connector/e2e/HttpTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-http/src/test/java/io/camunda/connector/e2e/HttpTests.java
@@ -60,8 +60,8 @@ import org.junit.jupiter.api.io.TempDir;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import wiremock.com.fasterxml.jackson.databind.node.JsonNodeFactory;
 
 @SpringBootTest(
@@ -83,11 +83,11 @@ public class HttpTests {
   @TempDir File tempDir;
   @Autowired CamundaClient camundaClient;
 
-  @MockBean ProcessDefinitionSearch processDefinitionSearch;
+  @MockitoBean ProcessDefinitionSearch processDefinitionSearch;
 
   @Autowired ProcessStateStore stateStore;
 
-  @MockBean SearchQueryClient searchQueryClient;
+  @MockitoBean SearchQueryClient searchQueryClient;
 
   @LocalServerPort int serverPort;
 


### PR DESCRIPTION
## Description

Fix main after this [PR](https://github.com/camunda/camunda/pull/30738) from Camunda. 

I just don't understand why the latest is now `camunda/zeebe:SNAPSHOT` and not `camunda/camunda:SNAPSHOT` That is why I had to add `io.camunda.process.test.camundaDockerImageName=camunda/zeebe:SNAPSHOT`

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #

## Checklist

- [ ] PR has a **milestone** or the `no milestone` label.

