### PR TITLE
fix(idp-extraction-connector): add renameMappings input

### DIFF
--- a/connectors/idp-extraction/element-templates/hybrid/hybrid-idp-extraction-outbound-connector-hybrid.json
+++ b/connectors/idp-extraction/element-templates/hybrid/hybrid-idp-extraction-outbound-connector-hybrid.json
@@ -96,6 +96,18 @@
     },
     "type" : "Hidden"
   }, {
+    "id" : "input.renameMappings",
+    "label" : "Rename mappings",
+    "description" : "List of keys that should be renamed and not be given the default name",
+    "optional" : false,
+    "value" : "= input.renameMappings",
+    "group" : "input",
+    "binding" : {
+      "name" : "input.renameMappings",
+      "type" : "zeebe:input"
+    },
+    "type" : "Hidden"
+  }, {
     "id" : "input.delimiter",
     "label" : "delimiter",
     "description" : "The delimiter used for the variable name of the extracted field",

--- a/connectors/idp-extraction/element-templates/idp-extraction-outbound-connector.json
+++ b/connectors/idp-extraction/element-templates/idp-extraction-outbound-connector.json
@@ -91,6 +91,18 @@
     },
     "type" : "Hidden"
   }, {
+    "id" : "input.renameMappings",
+    "label" : "Rename mappings",
+    "description" : "List of keys that should be renamed and not be given the default name",
+    "optional" : false,
+    "value" : "= input.renameMappings",
+    "group" : "input",
+    "binding" : {
+      "name" : "input.renameMappings",
+      "type" : "zeebe:input"
+    },
+    "type" : "Hidden"
+  }, {
     "id" : "input.delimiter",
     "label" : "delimiter",
     "description" : "The delimiter used for the variable name of the extracted field",

--- a/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/model/ExtractionRequestData.java
+++ b/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/model/ExtractionRequestData.java
@@ -13,6 +13,7 @@ import io.camunda.connector.generator.java.annotation.TemplateProperty.PropertyC
 import io.camunda.document.Document;
 import jakarta.validation.constraints.NotNull;
 import java.util.List;
+import java.util.Map;
 
 public record ExtractionRequestData(
     @TemplateProperty(
@@ -59,6 +60,16 @@ public record ExtractionRequestData(
             binding = @PropertyBinding(name = "excludedFields"),
             feel = Property.FeelMode.disabled)
         List<String> excludedFields,
+    @TemplateProperty(
+            id = "renameMappings",
+            label = "Rename mappings",
+            group = "input",
+            type = TemplateProperty.PropertyType.Hidden,
+            description = "List of keys that should be renamed and not be given the default name",
+            defaultValue = "= input.renameMappings",
+            binding = @PropertyBinding(name = "renameMappings"),
+            feel = Property.FeelMode.disabled)
+        Map<String, String> renameMappings,
     @TemplateProperty(
             id = "delimiter",
             label = "delimiter",

--- a/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/service/StructuredService.java
+++ b/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/service/StructuredService.java
@@ -116,10 +116,16 @@ public class StructuredService implements ExtractionService {
         .extractedFields()
         .forEach(
             (key, value) -> {
-              String variableName = formatZeebeVariableName(key, input.delimiter());
+              String variableName;
+              // Check if key variable should be overridden by renameMappings value
+              if (input.renameMappings() != null && input.renameMappings().containsKey(key)) {
+                variableName = input.renameMappings().get(key);
+              } else {
+                variableName = formatZeebeVariableName(key, input.delimiter());
+              }
               Float confidenceScore = response.confidenceScore().get(key);
 
-              if ((input.excludedFields() == null || !input.excludedFields().contains(variableName))
+              if ((input.excludedFields() == null || !input.excludedFields().contains(key))
                   && (value != null && !value.isBlank())) {
                 parsedResults.put(variableName, value);
 

--- a/connectors/idp-extraction/src/test/java/io/camunda/connector/idp/extraction/util/ExtractionTestUtils.java
+++ b/connectors/idp-extraction/src/test/java/io/camunda/connector/idp/extraction/util/ExtractionTestUtils.java
@@ -23,6 +23,7 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 
 public class ExtractionTestUtils {
 
@@ -87,6 +88,7 @@ public class ExtractionTestUtils {
               new TaxonomyItem("sum", "the total amount that was paid for this invoice"),
               new TaxonomyItem("supplier", "who provided the goods or services")),
           List.of(),
+          Map.of(),
           null,
           new ConverseData("anthropic.claude-3-5-sonnet-20240620-v1:0", 512, 0.5f, 0.9f));
 


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
This PR adds a new input to the idp structured extraction. The logic goes like this: 
- For every key we genrate a "Zeebe-safe" variable 
- If the user wants to override any of them, he sends them back as input on this new "renameMappings" field.
- When running the extraction again, before we do the variable generation, we check if we have an override available.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes https://github.com/camunda/connectors/issues/4627

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.

