### PR TITLE
fix(idp-extraction-connector): add original keys as output to the structured extraction

### DIFF
--- a/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/model/StructuredExtractionResult.java
+++ b/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/model/StructuredExtractionResult.java
@@ -9,4 +9,4 @@ package io.camunda.connector.idp.extraction.model;
 import java.util.Map;
 
 public record StructuredExtractionResult(
-    Map<String, Object> extractedFields, Map<String, Float> confidenceScore) {}
+    Map<String, Object> extractedFields, Map<String, Float> confidenceScore, Map<String, String> originalKeys) {}

--- a/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/model/StructuredExtractionResult.java
+++ b/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/model/StructuredExtractionResult.java
@@ -9,4 +9,6 @@ package io.camunda.connector.idp.extraction.model;
 import java.util.Map;
 
 public record StructuredExtractionResult(
-    Map<String, Object> extractedFields, Map<String, Float> confidenceScore, Map<String, String> originalKeys) {}
+    Map<String, Object> extractedFields,
+    Map<String, Float> confidenceScore,
+    Map<String, String> originalKeys) {}

--- a/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/service/StructuredService.java
+++ b/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/service/StructuredService.java
@@ -111,6 +111,7 @@ public class StructuredService implements ExtractionService {
       StructuredExtractionResponse response, ExtractionRequestData input) {
     Map<String, Object> parsedResults = new HashMap<>();
     Map<String, Float> processedConfidenceScores = new HashMap<>();
+    Map<String, String> originalKeys = new HashMap<>();
 
     response
         .extractedFields()
@@ -122,15 +123,15 @@ public class StructuredService implements ExtractionService {
               if ((input.excludedFields() == null || !input.excludedFields().contains(variableName))
                   && (value != null && !value.isBlank())) {
                 parsedResults.put(variableName, value);
+                originalKeys.put(variableName, key);
 
-                // Add the confidence score with the same formatted key
                 if (confidenceScore != null) {
                   processedConfidenceScores.put(variableName, confidenceScore);
                 }
               }
             });
 
-    return new StructuredExtractionResult(parsedResults, processedConfidenceScores);
+    return new StructuredExtractionResult(parsedResults, processedConfidenceScores, originalKeys);
   }
 
   /**

--- a/connectors/idp-extraction/src/test/java/io/camunda/connector/idp/extraction/service/StructuredServiceTest.java
+++ b/connectors/idp-extraction/src/test/java/io/camunda/connector/idp/extraction/service/StructuredServiceTest.java
@@ -66,7 +66,6 @@ public class StructuredServiceTest {
     StructuredExtractionResult structuredResult = (StructuredExtractionResult) result;
 
     // Verify the extracted fields were properly processed
-    // Note: The field names should be formatted according to the formatZeebeVariableName method
     assertThat(structuredResult.extractedFields())
         .containsEntry("invoice_number", "INV-12345")
         .containsEntry("total_amount", "$12.25")
@@ -77,6 +76,12 @@ public class StructuredServiceTest {
         .containsEntry("invoice_number", 0.95f)
         .containsEntry("total_amount", 0.98f)
         .containsEntry("supplier_name", 0.92f);
+        
+    // Verify original keys were properly mapped
+    assertThat(structuredResult.originalKeys())
+        .containsEntry("invoice_number", "Invoice Number")
+        .containsEntry("total_amount", "Total Amount")
+        .containsEntry("supplier_name", "Supplier Name");
   }
 
   @Test
@@ -117,6 +122,12 @@ public class StructuredServiceTest {
     assertThat(structuredResult.confidenceScore())
         .containsEntry("invoice_number", 0.95f)
         .containsEntry("supplier_name", 0.92f)
+        .doesNotContainKey("total_amount");
+        
+    // Verify original keys were properly mapped (excluding the excluded field)
+    assertThat(structuredResult.originalKeys())
+        .containsEntry("invoice_number", "Invoice Number")
+        .containsEntry("supplier_name", "Supplier Name")
         .doesNotContainKey("total_amount");
   }
 
@@ -184,7 +195,6 @@ public class StructuredServiceTest {
     StructuredExtractionResult structuredResult = (StructuredExtractionResult) result;
 
     // Verify the extracted fields were properly processed
-    // Note: The field names should be formatted according to the formatZeebeVariableName method
     assertThat(structuredResult.extractedFields())
         .containsEntry("invoice_number", "INV-12345")
         .containsEntry("total_amount", "$12.25")
@@ -195,6 +205,12 @@ public class StructuredServiceTest {
         .containsEntry("invoice_number", 0.95f)
         .containsEntry("total_amount", 0.98f)
         .containsEntry("supplier_name", 0.92f);
+        
+    // Verify original keys were properly mapped
+    assertThat(structuredResult.originalKeys())
+        .containsEntry("invoice_number", "Invoice Number")
+        .containsEntry("total_amount", "Total Amount")
+        .containsEntry("supplier_name", "Supplier Name");
   }
 
   @Test
@@ -237,22 +253,26 @@ public class StructuredServiceTest {
     StructuredExtractionResult structuredResult = (StructuredExtractionResult) result;
 
     // Verify the extracted fields were properly processed
-    // The excluded field (total_amount) should not be present
     assertThat(structuredResult.extractedFields())
         .containsEntry("invoice_number", "INV-12345")
         .containsEntry("supplier_name", "Camunda Inc.")
         .doesNotContainKey("total_amount");
 
     // Verify confidence scores were properly processed
-    // The confidence score for the excluded field should also not be present
     assertThat(structuredResult.confidenceScore())
         .containsEntry("invoice_number", 0.95f)
         .containsEntry("supplier_name", 0.92f)
         .doesNotContainKey("total_amount");
+        
+    // Verify original keys were properly mapped (excluding the excluded field)
+    assertThat(structuredResult.originalKeys())
+        .containsEntry("invoice_number", "Invoice Number")
+        .containsEntry("supplier_name", "Supplier Name")
+        .doesNotContainKey("total_amount");
   }
 
   @Test
-  void extractUsingDocumentAi_ShouldThrowConnectorException_whenExtractionFails() throws Exception {
+  void extractUsingDocumentAi_ShouldThrowConnectorException_whenExtractionFails() {
     // given
     DocumentAIProvider documentAiProvider = new DocumentAIProvider();
     DocumentAiRequestConfiguration configuration =

--- a/connectors/idp-extraction/src/test/java/io/camunda/connector/idp/extraction/service/StructuredServiceTest.java
+++ b/connectors/idp-extraction/src/test/java/io/camunda/connector/idp/extraction/service/StructuredServiceTest.java
@@ -76,7 +76,7 @@ public class StructuredServiceTest {
         .containsEntry("invoice_number", 0.95f)
         .containsEntry("total_amount", 0.98f)
         .containsEntry("supplier_name", 0.92f);
-        
+
     // Verify original keys were properly mapped
     assertThat(structuredResult.originalKeys())
         .containsEntry("invoice_number", "Invoice Number")
@@ -123,7 +123,7 @@ public class StructuredServiceTest {
         .containsEntry("invoice_number", 0.95f)
         .containsEntry("supplier_name", 0.92f)
         .doesNotContainKey("total_amount");
-        
+
     // Verify original keys were properly mapped (excluding the excluded field)
     assertThat(structuredResult.originalKeys())
         .containsEntry("invoice_number", "Invoice Number")
@@ -205,7 +205,7 @@ public class StructuredServiceTest {
         .containsEntry("invoice_number", 0.95f)
         .containsEntry("total_amount", 0.98f)
         .containsEntry("supplier_name", 0.92f);
-        
+
     // Verify original keys were properly mapped
     assertThat(structuredResult.originalKeys())
         .containsEntry("invoice_number", "Invoice Number")
@@ -263,7 +263,7 @@ public class StructuredServiceTest {
         .containsEntry("invoice_number", 0.95f)
         .containsEntry("supplier_name", 0.92f)
         .doesNotContainKey("total_amount");
-        
+
     // Verify original keys were properly mapped (excluding the excluded field)
     assertThat(structuredResult.originalKeys())
         .containsEntry("invoice_number", "Invoice Number")


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
We are adding a new map to the response of the idp structured extraction. We are sending the original extracted keys because they are needed in the WM ui. 

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes https://github.com/camunda/connectors/issues/4628

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.

