### PR TITLE
feat(agentic-ai): support fromAi() FEEL function to define ad-hoc tools schema

### DIFF
--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/AiAgentTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/AiAgentTests.java
@@ -362,7 +362,7 @@ public class AiAgentTests extends BaseAgenticAiTest {
       AgentResponse agentResponse, AgentMetrics expectedMetrics, List<ChatMessage> expectedMessages)
       throws JsonProcessingException {
     assertThat(agentResponse).isNotNull();
-    assertThat(agentResponse.toolsToCall()).isEmpty();
+    assertThat(agentResponse.toolCalls()).isEmpty();
     assertTrue(agentResponse.context().isInState(AgentState.READY));
     assertThat(agentResponse.context().metrics()).isEqualTo(expectedMetrics);
 

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/AiAgentTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/AiAgentTests.java
@@ -388,9 +388,9 @@ public class AiAgentTests extends BaseAgenticAiTest {
 
   private void assertToolSpecifications(ChatRequest chatRequest) {
     assertThat(chatRequest.toolSpecifications())
-        .hasSize(4)
         .extracting(ToolSpecification::name)
-        .containsExactly("GetDateAndTime", "SuperfluxProduct", "Search_The_Web", "An_Event");
+        .containsExactly(
+            "GetDateAndTime", "SuperfluxProduct", "Search_The_Web", "A_Complex_Tool", "An_Event");
   }
 
   private void assertIncident(ZeebeTest zeebeTest, ThrowingConsumer<Incident> assertion) {

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/resources/agentic-ai-connectors.bpmn
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/resources/agentic-ai-connectors.bpmn
@@ -7,13 +7,13 @@
     <bpmn:sequenceFlow id="Flow_1lbh2cw" sourceRef="StartEvent_1" targetRef="Gateway_0d7bxjf" />
     <bpmn:adHocSubProcess id="Agent_Tools" name="Agent Tools">
       <bpmn:extensionElements>
-        <zeebe:adHoc activeElementsCollection="=[toolCall.name]" />
+        <zeebe:adHoc activeElementsCollection="=[toolCall._meta.name]" />
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_Agent_ToolCalls</bpmn:incoming>
       <bpmn:outgoing>Flow_0ytgkit</bpmn:outgoing>
       <bpmn:multiInstanceLoopCharacteristics>
         <bpmn:extensionElements>
-          <zeebe:loopCharacteristics inputCollection="=agent.toolCalls" inputElement="toolCall" outputCollection="toolCallResults" outputElement="={&#10;  id: toolCall.id,&#10;  name: toolCall.name,&#10;  content: toolCallResult&#10;}" />
+          <zeebe:loopCharacteristics inputCollection="=agent.toolCalls" inputElement="toolCall" outputCollection="toolCallResults" outputElement="={&#10;  id: toolCall._meta.id,&#10;  name: toolCall._meta.name,&#10;  content: toolCallResult&#10;}" />
         </bpmn:extensionElements>
       </bpmn:multiInstanceLoopCharacteristics>
       <bpmn:sequenceFlow id="Flow_095717l" sourceRef="Search_The_Web" targetRef="Follow_Up_Task" />
@@ -36,8 +36,8 @@
         <bpmn:extensionElements>
           <zeebe:script expression="=3 * (inputA + inputB)" resultVariable="toolCallResult" />
           <zeebe:ioMapping>
-            <zeebe:input source="=fromAi(toolCall.input.a, &#34;The first number to be superflux calculated.&#34;, &#34;number&#34;)" target="inputA" />
-            <zeebe:input source="=fromAi(toolCall.input.b, &#34;The second number to be superflux calculated.&#34;, &#34;number&#34;)" target="inputB" />
+            <zeebe:input source="=fromAi(toolCall.a, &#34;The first number to be superflux calculated.&#34;, &#34;number&#34;)" target="inputA" />
+            <zeebe:input source="=fromAi(toolCall.b, &#34;The second number to be superflux calculated.&#34;, &#34;number&#34;)" target="inputB" />
           </zeebe:ioMapping>
         </bpmn:extensionElements>
       </bpmn:scriptTask>
@@ -52,7 +52,7 @@
         <bpmn:extensionElements>
           <zeebe:script expression="={&#10;  searchQuery: searchQuery,&#10;  items: []&#10;}" resultVariable="searchResults" />
           <zeebe:ioMapping>
-            <zeebe:input source="=fromAi(toolCall.input.searchQuery, &#34;The search query to use&#34;)" target="searchQuery" />
+            <zeebe:input source="=fromAi(toolCall.searchQuery, &#34;The search query to use&#34;)" target="searchQuery" />
           </zeebe:ioMapping>
         </bpmn:extensionElements>
         <bpmn:outgoing>Flow_095717l</bpmn:outgoing>

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/resources/agentic-ai-connectors.bpmn
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/resources/agentic-ai-connectors.bpmn
@@ -36,8 +36,8 @@
         <bpmn:extensionElements>
           <zeebe:script expression="=3 * (inputA + inputB)" resultVariable="toolCallResult" />
           <zeebe:ioMapping>
-            <zeebe:input source="=fromAi(toolToCall.input, &#34;a&#34;, &#34;The first number to be superflux calculated.&#34;, &#34;number&#34;)" target="inputA" />
-            <zeebe:input source="=fromAi(toolToCall.input, &#34;b&#34;, &#34;The second number to be superflux calculated.&#34;, &#34;number&#34;)" target="inputB" />
+            <zeebe:input source="=fromAi(toolToCall.input.a, &#34;The first number to be superflux calculated.&#34;, &#34;number&#34;)" target="inputA" />
+            <zeebe:input source="=fromAi(toolToCall.input.b, &#34;The second number to be superflux calculated.&#34;, &#34;number&#34;)" target="inputB" />
           </zeebe:ioMapping>
         </bpmn:extensionElements>
       </bpmn:scriptTask>
@@ -52,7 +52,7 @@
         <bpmn:extensionElements>
           <zeebe:script expression="={&#10;  searchQuery: searchQuery,&#10;  items: []&#10;}" resultVariable="searchResults" />
           <zeebe:ioMapping>
-            <zeebe:input source="=fromAi(toolToCall.input, &#34;searchQuery&#34;, &#34;The search query to use&#34;)" target="searchQuery" />
+            <zeebe:input source="=fromAi(toolToCall.input.searchQuery, &#34;The search query to use&#34;)" target="searchQuery" />
           </zeebe:ioMapping>
         </bpmn:extensionElements>
         <bpmn:outgoing>Flow_095717l</bpmn:outgoing>

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/resources/agentic-ai-connectors.bpmn
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/resources/agentic-ai-connectors.bpmn
@@ -57,6 +57,20 @@
         </bpmn:extensionElements>
         <bpmn:outgoing>Flow_095717l</bpmn:outgoing>
       </bpmn:scriptTask>
+      <bpmn:scriptTask id="A_Complex_Tool" name="A complex tool">
+        <bpmn:documentation>A very complex tool</bpmn:documentation>
+        <bpmn:extensionElements>
+          <zeebe:script expression="=toolCall" resultVariable="complexToolResult" />
+          <zeebe:ioMapping>
+            <zeebe:input source="=fromAi(toolCall.aSimpleValue, &#34;A simple value&#34;)" target="aSimpleValue" />
+            <zeebe:input source="=fromAi(toolCall.anEnumValue, &#34;An enum value&#34;, &#34;string&#34;, { enum: [&#34;A&#34;, &#34;B&#34;, &#34;C&#34;] })" target="anEnumValue" />
+            <zeebe:input source="=fromAi(toolCall.anArrayValue, &#34;An array value&#34;, &#34;array&#34;, {&#10;  items: {&#10;    type: &#34;string&#34;,&#10;    enum: [&#34;foo&#34;, &#34;bar&#34;, &#34;baz&#34;]&#10;  }&#10;})" target="anArrayValue" />
+            <zeebe:input source="=&#34;https://example.com/&#34; + fromAi(toolCall.urlPath, &#34;The URL path to use&#34;, &#34;string&#34;)" target="aCombinedValue" />
+            <zeebe:input source="={&#10;  comment: &#34;Multiple params, positional &#38; named, simple &#38; complex&#34;,&#10;  foo: [fromAi(toolCall.firstValue), fromAi(toolCall.secondValue, &#34;The second value&#34;,  &#34;integer&#34;)],&#10;  bar: {&#10;    baz: fromAi(description: &#34;The third value to add&#34;, value: toolCall.thirdValue),&#10;    qux: fromAi(toolCall.fourthValue, &#34;The fourth value to add&#34;, &#34;array&#34;, {&#10;      &#34;items&#34;: {&#10;        &#34;type&#34;: &#34;string&#34;,&#10;        &#34;enum&#34;: [&#34;foo&#34;, &#34;bar&#34;, &#34;baz&#34;]&#10;      }&#10;    })&#10;  }&#10;}" target="multipleParametersInDifferentFormats" />
+            <zeebe:output source="=fromAi(toolCall.outputValue, &#34;An output value&#34;)" target="anOutputVariable" />
+          </zeebe:ioMapping>
+        </bpmn:extensionElements>
+      </bpmn:scriptTask>
     </bpmn:adHocSubProcess>
     <bpmn:exclusiveGateway id="Gateway_0d7bxjf" name="What to do?">
       <bpmn:incoming>Flow_1lbh2cw</bpmn:incoming>
@@ -173,7 +187,7 @@
         <dc:Bounds x="162" y="262" width="36" height="36" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_005wn4n_di" bpmnElement="Agent_Tools" isExpanded="true">
-        <dc:Bounds x="480" y="570" width="350" height="390" />
+        <dc:Bounds x="480" y="570" width="350" height="480" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_02hr6cv_di" bpmnElement="An_Event">
@@ -199,6 +213,9 @@
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_1kglsdx_di" bpmnElement="Search_The_Web">
         <dc:Bounds x="530" y="720" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0wd2ku5_di" bpmnElement="A_Complex_Tool">
+        <dc:Bounds x="530" y="930" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNEdge id="Flow_095717l_di" bpmnElement="Flow_095717l">
         <di:waypoint x="630" y="760" />

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/resources/agentic-ai-connectors.bpmn
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/resources/agentic-ai-connectors.bpmn
@@ -34,25 +34,25 @@
       <bpmn:scriptTask id="SuperfluxProduct" name="Superflux Product Calculation">
         <bpmn:documentation>Calculates the superflux product (a very complicated method only this tool can do) given two input numbers</bpmn:documentation>
         <bpmn:extensionElements>
-          <zeebe:script expression="=3 * (toolToCall.input.a + toolToCall.input.b)" resultVariable="toolCallResult" />
+          <zeebe:script expression="=3 * (inputA + inputB)" resultVariable="toolCallResult" />
           <zeebe:ioMapping>
-            <zeebe:input source="=fromAi(&#34;a&#34;, &#34;The first number to be superflux calculated.&#34;, &#34;number&#34;)" target="inputA" />
-            <zeebe:input source="=fromAi(&#34;b&#34;, &#34;The second number to be superflux calculated.&#34;, &#34;number&#34;)" target="inputB" />
+            <zeebe:input source="=fromAi(toolToCall.input, &#34;a&#34;, &#34;The first number to be superflux calculated.&#34;, &#34;number&#34;)" target="inputA" />
+            <zeebe:input source="=fromAi(toolToCall.input, &#34;b&#34;, &#34;The second number to be superflux calculated.&#34;, &#34;number&#34;)" target="inputB" />
           </zeebe:ioMapping>
         </bpmn:extensionElements>
       </bpmn:scriptTask>
       <bpmn:scriptTask id="Follow_Up_Task" name="Follow-up task">
         <bpmn:extensionElements>
-          <zeebe:script expression="=&#34;No results for &#39;&#34; + toolToCall.input.searchQuery + &#34;&#39;&#34;" resultVariable="toolCallResult" />
+          <zeebe:script expression="=&#34;No results for &#39;&#34; + searchResults.searchQuery + &#34;&#39;&#34;" resultVariable="toolCallResult" />
         </bpmn:extensionElements>
         <bpmn:incoming>Flow_095717l</bpmn:incoming>
       </bpmn:scriptTask>
       <bpmn:scriptTask id="Search_The_Web" name="Search The Web">
         <bpmn:documentation>Do a web search to find the needed information.</bpmn:documentation>
         <bpmn:extensionElements>
-          <zeebe:script expression="={}" resultVariable="tmp" />
+          <zeebe:script expression="={&#10;  searchQuery: searchQuery,&#10;  items: []&#10;}" resultVariable="searchResults" />
           <zeebe:ioMapping>
-            <zeebe:input source="=fromAi(&#34;searchQuery&#34;, &#34;The search query to use&#34;)" target="searchQuery" />
+            <zeebe:input source="=fromAi(toolToCall.input, &#34;searchQuery&#34;, &#34;The search query to use&#34;)" target="searchQuery" />
           </zeebe:ioMapping>
         </bpmn:extensionElements>
         <bpmn:outgoing>Flow_095717l</bpmn:outgoing>

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/resources/agentic-ai-connectors.bpmn
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/resources/agentic-ai-connectors.bpmn
@@ -7,13 +7,13 @@
     <bpmn:sequenceFlow id="Flow_1lbh2cw" sourceRef="StartEvent_1" targetRef="Gateway_0d7bxjf" />
     <bpmn:adHocSubProcess id="Agent_Tools" name="Agent Tools">
       <bpmn:extensionElements>
-        <zeebe:adHoc activeElementsCollection="=[toolToCall.name]" />
+        <zeebe:adHoc activeElementsCollection="=[toolCall.name]" />
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_Agent_ToolCalls</bpmn:incoming>
       <bpmn:outgoing>Flow_0ytgkit</bpmn:outgoing>
       <bpmn:multiInstanceLoopCharacteristics>
         <bpmn:extensionElements>
-          <zeebe:loopCharacteristics inputCollection="=agent.toolsToCall" inputElement="toolToCall" outputCollection="toolCallResults" outputElement="={&#10;  id: toolToCall.id,&#10;  name: toolToCall.name,&#10;  content: toolCallResult&#10;}" />
+          <zeebe:loopCharacteristics inputCollection="=agent.toolCalls" inputElement="toolCall" outputCollection="toolCallResults" outputElement="={&#10;  id: toolCall.id,&#10;  name: toolCall.name,&#10;  content: toolCallResult&#10;}" />
         </bpmn:extensionElements>
       </bpmn:multiInstanceLoopCharacteristics>
       <bpmn:sequenceFlow id="Flow_095717l" sourceRef="Search_The_Web" targetRef="Follow_Up_Task" />
@@ -36,8 +36,8 @@
         <bpmn:extensionElements>
           <zeebe:script expression="=3 * (inputA + inputB)" resultVariable="toolCallResult" />
           <zeebe:ioMapping>
-            <zeebe:input source="=fromAi(toolToCall.input.a, &#34;The first number to be superflux calculated.&#34;, &#34;number&#34;)" target="inputA" />
-            <zeebe:input source="=fromAi(toolToCall.input.b, &#34;The second number to be superflux calculated.&#34;, &#34;number&#34;)" target="inputB" />
+            <zeebe:input source="=fromAi(toolCall.input.a, &#34;The first number to be superflux calculated.&#34;, &#34;number&#34;)" target="inputA" />
+            <zeebe:input source="=fromAi(toolCall.input.b, &#34;The second number to be superflux calculated.&#34;, &#34;number&#34;)" target="inputB" />
           </zeebe:ioMapping>
         </bpmn:extensionElements>
       </bpmn:scriptTask>
@@ -52,7 +52,7 @@
         <bpmn:extensionElements>
           <zeebe:script expression="={&#10;  searchQuery: searchQuery,&#10;  items: []&#10;}" resultVariable="searchResults" />
           <zeebe:ioMapping>
-            <zeebe:input source="=fromAi(toolToCall.input.searchQuery, &#34;The search query to use&#34;)" target="searchQuery" />
+            <zeebe:input source="=fromAi(toolCall.input.searchQuery, &#34;The search query to use&#34;)" target="searchQuery" />
           </zeebe:ioMapping>
         </bpmn:extensionElements>
         <bpmn:outgoing>Flow_095717l</bpmn:outgoing>
@@ -103,7 +103,7 @@
       <bpmn:outgoing>Flow_Agent_ToolCalls</bpmn:outgoing>
     </bpmn:exclusiveGateway>
     <bpmn:sequenceFlow id="Flow_Agent_NoToolCalls" name="no" sourceRef="Gateway_0bukj01" targetRef="User_Feedback">
-      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=is empty(agent.toolsToCall)</bpmn:conditionExpression>
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=is empty(agent.toolCalls)</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
     <bpmn:sequenceFlow id="Flow_04hfzs8" sourceRef="AI_Agent" targetRef="Gateway_0bukj01" />
     <bpmn:serviceTask id="AI_Agent" name="AI Agent" zeebe:modelerTemplate="io.camunda.connectors.agenticai.aiagent.v0" zeebe:modelerTemplateVersion="0" zeebe:modelerTemplateIcon="data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPHN2ZyBpZD0iaWNvbiIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB3aWR0aD0iMzIiIGhlaWdodD0iMzIiIHZpZXdCb3g9IjAgMCAzMiAzMiI+CiAgPGRlZnM+CiAgICA8c3R5bGU+CiAgICAgIC5jbHMtMSB7CiAgICAgICAgZmlsbDogbm9uZTsKICAgICAgfQoKICAgICAgLmNscy0xLCAuY2xzLTIgewogICAgICAgIHN0cm9rZS13aWR0aDogMHB4OwogICAgICB9CiAgICA8L3N0eWxlPgogIDwvZGVmcz4KICA8cGF0aCBjbGFzcz0iY2xzLTIiIGQ9Im0yNywxOWMxLjY1NDMsMCwzLTEuMzQ1NywzLTNzLTEuMzQ1Ny0zLTMtM2MtMS4zMDIsMC0yLjQwMTYuODM4NC0yLjgxNTcsMmgtNS43NzAzbDcuMzAwOC03LjMwMDhjLjM5MTEuMTg3NS44MjM1LjMwMDgsMS4yODUyLjMwMDgsMS42NTQzLDAsMy0xLjM0NTcsMy0zcy0xLjM0NTctMy0zLTMtMywxLjM0NTctMywzYzAsLjQ2MTkuMTEzNS44OTQuMzAwNSwxLjI4NTJsLTguMzAwNSw4LjMwMDh2LTYuNTg1OWMwLTEuMTAyNS44OTctMiwyLTJoMnYtMmgtMmMtMS4yMDAyLDAtMi4yNjYxLjU0MjUtMywxLjM4MjMtLjczMzktLjgzOTgtMS43OTk4LTEuMzgyMy0zLTEuMzgyM2gtMWMtNC45NjI0LDAtOSw0LjAzNzEtOSw5djZjMCw0Ljk2MjksNC4wMzc2LDksOSw5aDFjMS4yMDAyLDAsMi4yNjYxLS41NDI1LDMtMS4zODIzLjczMzkuODM5OCwxLjc5OTgsMS4zODIzLDMsMS4zODIzaDJ2LTJoLTJjLTEuMTAzLDAtMi0uODk3NS0yLTJ2LTYuNTg1OWw4LjMwMDUsOC4zMDA4Yy0uMTg3LjM5MTEtLjMwMDUuODIzMi0uMzAwNSwxLjI4NTIsMCwxLjY1NDMsMS4zNDU3LDMsMywzczMtMS4zNDU3LDMtMy0xLjM0NTctMy0zLTNjLS40NjE3LDAtLjg5NC4xMTMzLTEuMjg1Mi4zMDA4bC03LjMwMDgtNy4zMDA4aDUuNzcwM2MuNDE0MSwxLjE2MTYsMS41MTM3LDIsMi44MTU3LDJabTAtNGMuNTUxMywwLDEsLjQ0ODIsMSwxcy0uNDQ4NywxLTEsMS0xLS40NDgyLTEtMSwuNDQ4Ny0xLDEtMVptMC0xMWMuNTUxNSwwLDEsLjQ0ODcsMSwxcy0uNDQ4NSwxLTEsMS0xLS40NDg3LTEtMSwuNDQ4NS0xLDEtMVptLTEzLDhoLTJ2MmgydjRoLTJjLTEuNjU0MywwLTMsMS4zNDU3LTMsM3YyaDJ2LTJjMC0uNTUxOC40NDg3LTEsMS0xaDJ2NGMwLDEuMTAyNS0uODk3LDItMiwyaC0xYy0zLjUxOTUsMC02LjQzMjQtMi42MTMzLTYuOTIwMi02aDEuOTIwMnYtMmgtMnYtNGgzYzEuNjU0MywwLDMtMS4zNDU3LDMtM3YtMmgtMnYyYzAsLjU1MTgtLjQ0ODcsMS0xLDFoLTIuOTIwMmMuNDg3OC0zLjM4NjcsMy40MDA2LTYsNi45MjAyLTZoMWMxLjEwMywwLDIsLjg5NzUsMiwydjRabTE0LDE1YzAsLjU1MTMtLjQ0ODUsMS0xLDFzLTEtLjQ0ODctMS0xLC40NDg1LTEsMS0xLDEsLjQ0ODcsMSwxWiIvPgogIDxyZWN0IGlkPSJfVHJhbnNwYXJlbnRfUmVjdGFuZ2xlXyIgZGF0YS1uYW1lPSImYW1wO2x0O1RyYW5zcGFyZW50IFJlY3RhbmdsZSZhbXA7Z3Q7IiBjbGFzcz0iY2xzLTEiIHdpZHRoPSIzMiIgaGVpZ2h0PSIzMiIvPgo8L3N2Zz4=">
@@ -135,7 +135,7 @@
       <bpmn:outgoing>Flow_04hfzs8</bpmn:outgoing>
     </bpmn:serviceTask>
     <bpmn:sequenceFlow id="Flow_Agent_ToolCalls" name="yes" sourceRef="Gateway_0bukj01" targetRef="Agent_Tools">
-      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=not(is empty(agent.toolsToCall))</bpmn:conditionExpression>
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=not(is empty(agent.toolCalls))</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
     <bpmn:sequenceFlow id="Flow_0ytgkit" name="Tool results" sourceRef="Agent_Tools" targetRef="Gateway_1onk6us" />
     <bpmn:sequenceFlow id="Flow_0c131w3" sourceRef="User_Feedback" targetRef="Gateway_17hr3ni" />

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/resources/agentic-ai-connectors.bpmn
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/resources/agentic-ai-connectors.bpmn
@@ -16,25 +16,6 @@
           <zeebe:loopCharacteristics inputCollection="=agent.toolsToCall" inputElement="toolToCall" outputCollection="toolCallResults" outputElement="={&#10;  id: toolToCall.id,&#10;  name: toolToCall.name,&#10;  content: toolCallResult&#10;}" />
         </bpmn:extensionElements>
       </bpmn:multiInstanceLoopCharacteristics>
-      <bpmn:task id="Search_The_Web" name="Search The Web">
-        <bpmn:documentation>{
-  "description": "Do a web search to find the needed information.",
-  "inputSchema": {
-    "type": "object",
-    "properties": {
-      "searchQuery": {
-        "type": "string",
-        "description": "The search query to use"
-      }
-    },
-    "required": [
-      "searchQuery"
-    ]
-  }
-}</bpmn:documentation>
-        <bpmn:extensionElements />
-        <bpmn:outgoing>Flow_095717l</bpmn:outgoing>
-      </bpmn:task>
       <bpmn:sequenceFlow id="Flow_095717l" sourceRef="Search_The_Web" targetRef="Follow_Up_Task" />
       <bpmn:intermediateThrowEvent id="An_Event" name="An event!">
         <bpmn:extensionElements />
@@ -51,28 +32,13 @@
         </bpmn:extensionElements>
       </bpmn:scriptTask>
       <bpmn:scriptTask id="SuperfluxProduct" name="Superflux Product Calculation">
-        <bpmn:documentation>{
-  "description": "Calculates the superflux product (a very complicated method only this tool can do) given two input numbers",
-  "inputSchema": {
-    "type": "object",
-    "properties": {
-      "a": {
-        "type": "number",
-        "description": "The first number to be superflux calculated."
-      },
-      "b": {
-        "type": "number",
-        "description": "The second number to be superflux calculated."
-      }
-    },
-    "required": [
-      "a",
-      "b"
-    ]
-  }
-}</bpmn:documentation>
+        <bpmn:documentation>Calculates the superflux product (a very complicated method only this tool can do) given two input numbers</bpmn:documentation>
         <bpmn:extensionElements>
           <zeebe:script expression="=3 * (toolToCall.input.a + toolToCall.input.b)" resultVariable="toolCallResult" />
+          <zeebe:ioMapping>
+            <zeebe:input source="=fromAi(&#34;a&#34;, &#34;The first number to be superflux calculated.&#34;, &#34;number&#34;)" target="inputA" />
+            <zeebe:input source="=fromAi(&#34;b&#34;, &#34;The second number to be superflux calculated.&#34;, &#34;number&#34;)" target="inputB" />
+          </zeebe:ioMapping>
         </bpmn:extensionElements>
       </bpmn:scriptTask>
       <bpmn:scriptTask id="Follow_Up_Task" name="Follow-up task">
@@ -80,6 +46,16 @@
           <zeebe:script expression="=&#34;No results for &#39;&#34; + toolToCall.input.searchQuery + &#34;&#39;&#34;" resultVariable="toolCallResult" />
         </bpmn:extensionElements>
         <bpmn:incoming>Flow_095717l</bpmn:incoming>
+      </bpmn:scriptTask>
+      <bpmn:scriptTask id="Search_The_Web" name="Search The Web">
+        <bpmn:documentation>Do a web search to find the needed information.</bpmn:documentation>
+        <bpmn:extensionElements>
+          <zeebe:script expression="={}" resultVariable="tmp" />
+          <zeebe:ioMapping>
+            <zeebe:input source="=fromAi(&#34;searchQuery&#34;, &#34;The search query to use&#34;)" target="searchQuery" />
+          </zeebe:ioMapping>
+        </bpmn:extensionElements>
+        <bpmn:outgoing>Flow_095717l</bpmn:outgoing>
       </bpmn:scriptTask>
     </bpmn:adHocSubProcess>
     <bpmn:exclusiveGateway id="Gateway_0d7bxjf" name="What to do?">
@@ -200,10 +176,6 @@
         <dc:Bounds x="480" y="570" width="350" height="390" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_0bb8bvc_di" bpmnElement="Search_The_Web">
-        <dc:Bounds x="530" y="720" width="100" height="80" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_02hr6cv_di" bpmnElement="An_Event">
         <dc:Bounds x="562" y="842" width="36" height="36" />
         <bpmndi:BPMNLabel>
@@ -224,6 +196,9 @@
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_02cecmv_di" bpmnElement="Follow_Up_Task">
         <dc:Bounds x="670" y="720" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1kglsdx_di" bpmnElement="Search_The_Web">
+        <dc:Bounds x="530" y="720" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNEdge id="Flow_095717l_di" bpmnElement="Flow_095717l">
         <di:waypoint x="630" y="760" />

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/resources/expected-schema-result.json
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/resources/expected-schema-result.json
@@ -47,6 +47,82 @@
       }
     },
     {
+      "name": "A_Complex_Tool",
+      "description": "A very complex tool",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "aSimpleValue": {
+            "type": "string",
+            "description": "A simple value"
+          },
+          "anEnumValue": {
+            "type": "string",
+            "description": "An enum value",
+            "enum": [
+              "A",
+              "B",
+              "C"
+            ]
+          },
+          "anArrayValue": {
+            "type": "array",
+            "description": "An array value",
+            "items": {
+              "type": "string",
+              "enum": [
+                "foo",
+                "bar",
+                "baz"
+              ]
+            }
+          },
+          "urlPath": {
+            "type": "string",
+            "description": "The URL path to use"
+          },
+          "firstValue": {
+            "type": "string"
+          },
+          "secondValue": {
+            "type": "integer",
+            "description": "The second value"
+          },
+          "thirdValue": {
+            "type": "string",
+            "description": "The third value to add"
+          },
+          "fourthValue": {
+            "type": "array",
+            "description": "The fourth value to add",
+            "items": {
+              "type": "string",
+              "enum": [
+                "foo",
+                "bar",
+                "baz"
+              ]
+            }
+          },
+          "outputValue": {
+            "type": "string",
+            "description": "An output value"
+          }
+        },
+        "required": [
+          "aSimpleValue",
+          "anEnumValue",
+          "anArrayValue",
+          "urlPath",
+          "firstValue",
+          "secondValue",
+          "thirdValue",
+          "fourthValue",
+          "outputValue"
+        ]
+      }
+    },
+    {
       "name": "An_Event",
       "description": "An event!",
       "inputSchema": {

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/resources/expected-schema-result.json
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/resources/expected-schema-result.json
@@ -48,7 +48,7 @@
     },
     {
       "name": "An_Event",
-      "description": "",
+      "description": "An event!",
       "inputSchema": {
         "type": "object",
         "properties": {},

--- a/connectors/agentic-ai/element-templates/agenticai-adhoctoolsschema-outbound-connector.json
+++ b/connectors/agentic-ai/element-templates/agenticai-adhoctoolsschema-outbound-connector.json
@@ -19,6 +19,9 @@
     "id" : "tools",
     "label" : "Available Tools"
   }, {
+    "id" : "connector",
+    "label" : "Connector"
+  }, {
     "id" : "output",
     "label" : "Output mapping"
   }, {
@@ -47,6 +50,28 @@
       "type" : "zeebe:input"
     },
     "type" : "String"
+  }, {
+    "id" : "version",
+    "label" : "Version",
+    "description" : "Version of the element template",
+    "value" : "0",
+    "group" : "connector",
+    "binding" : {
+      "key" : "elementTemplateVersion",
+      "type" : "zeebe:taskHeader"
+    },
+    "type" : "Hidden"
+  }, {
+    "id" : "id",
+    "label" : "ID",
+    "description" : "ID of the element template",
+    "value" : "io.camunda.connectors.agenticai.adhoctoolsschema.v0",
+    "group" : "connector",
+    "binding" : {
+      "key" : "elementTemplateId",
+      "type" : "zeebe:taskHeader"
+    },
+    "type" : "Hidden"
   }, {
     "id" : "resultVariable",
     "label" : "Result variable",

--- a/connectors/agentic-ai/element-templates/agenticai-aiagent-outbound-connector.json
+++ b/connectors/agentic-ai/element-templates/agenticai-aiagent-outbound-connector.json
@@ -43,6 +43,9 @@
     "id" : "parameters",
     "label" : "Parameters"
   }, {
+    "id" : "connector",
+    "label" : "Connector"
+  }, {
     "id" : "output",
     "label" : "Output mapping"
   }, {
@@ -665,6 +668,28 @@
       "type" : "simple"
     },
     "type" : "Number"
+  }, {
+    "id" : "version",
+    "label" : "Version",
+    "description" : "Version of the element template",
+    "value" : "0",
+    "group" : "connector",
+    "binding" : {
+      "key" : "elementTemplateVersion",
+      "type" : "zeebe:taskHeader"
+    },
+    "type" : "Hidden"
+  }, {
+    "id" : "id",
+    "label" : "ID",
+    "description" : "ID of the element template",
+    "value" : "io.camunda.connectors.agenticai.aiagent.v0",
+    "group" : "connector",
+    "binding" : {
+      "key" : "elementTemplateId",
+      "type" : "zeebe:taskHeader"
+    },
+    "type" : "Hidden"
   }, {
     "id" : "resultVariable",
     "label" : "Result variable",

--- a/connectors/agentic-ai/element-templates/hybrid/agenticai-adhoctoolsschema-outbound-connector-hybrid.json
+++ b/connectors/agentic-ai/element-templates/hybrid/agenticai-adhoctoolsschema-outbound-connector-hybrid.json
@@ -22,6 +22,9 @@
     "id" : "tools",
     "label" : "Available Tools"
   }, {
+    "id" : "connector",
+    "label" : "Connector"
+  }, {
     "id" : "output",
     "label" : "Output mapping"
   }, {
@@ -52,6 +55,28 @@
       "type" : "zeebe:input"
     },
     "type" : "String"
+  }, {
+    "id" : "version",
+    "label" : "Version",
+    "description" : "Version of the element template",
+    "value" : "0",
+    "group" : "connector",
+    "binding" : {
+      "key" : "elementTemplateVersion",
+      "type" : "zeebe:taskHeader"
+    },
+    "type" : "Hidden"
+  }, {
+    "id" : "id",
+    "label" : "ID",
+    "description" : "ID of the element template",
+    "value" : "io.camunda.connectors.agenticai.adhoctoolsschema.v0",
+    "group" : "connector",
+    "binding" : {
+      "key" : "elementTemplateId",
+      "type" : "zeebe:taskHeader"
+    },
+    "type" : "Hidden"
   }, {
     "id" : "resultVariable",
     "label" : "Result variable",

--- a/connectors/agentic-ai/element-templates/hybrid/agenticai-aiagent-outbound-connector-hybrid.json
+++ b/connectors/agentic-ai/element-templates/hybrid/agenticai-aiagent-outbound-connector-hybrid.json
@@ -46,6 +46,9 @@
     "id" : "parameters",
     "label" : "Parameters"
   }, {
+    "id" : "connector",
+    "label" : "Connector"
+  }, {
     "id" : "output",
     "label" : "Output mapping"
   }, {
@@ -670,6 +673,28 @@
       "type" : "simple"
     },
     "type" : "Number"
+  }, {
+    "id" : "version",
+    "label" : "Version",
+    "description" : "Version of the element template",
+    "value" : "0",
+    "group" : "connector",
+    "binding" : {
+      "key" : "elementTemplateVersion",
+      "type" : "zeebe:taskHeader"
+    },
+    "type" : "Hidden"
+  }, {
+    "id" : "id",
+    "label" : "ID",
+    "description" : "ID of the element template",
+    "value" : "io.camunda.connectors.agenticai.aiagent.v0",
+    "group" : "connector",
+    "binding" : {
+      "key" : "elementTemplateId",
+      "type" : "zeebe:taskHeader"
+    },
+    "type" : "Hidden"
   }, {
     "id" : "resultVariable",
     "label" : "Result variable",

--- a/connectors/agentic-ai/examples/ad-hoc-tools-schema/ad-hoc-tools-schema-resolver.bpmn
+++ b/connectors/agentic-ai/examples/ad-hoc-tools-schema/ad-hoc-tools-schema-resolver.bpmn
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1cv9tep" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.34.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.8.0">
+  <bpmn:process id="Ad_Hoc_Tools_Schema_Resolver_Demo" name="Ad-Hoc Tools Schema Resolver Demo" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_05ytxgl</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_05ytxgl" sourceRef="StartEvent_1" targetRef="Activity_09sgm6t" />
+    <bpmn:endEvent id="Event_1vhkswr">
+      <bpmn:incoming>Flow_10i4xfj</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_06qc98j" sourceRef="Activity_09sgm6t" targetRef="Gateway_08wk5pu" />
+    <bpmn:exclusiveGateway id="Gateway_08wk5pu" default="Flow_10i4xfj">
+      <bpmn:incoming>Flow_06qc98j</bpmn:incoming>
+      <bpmn:outgoing>Flow_10i4xfj</bpmn:outgoing>
+      <bpmn:outgoing>Flow_1i22pvs</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="Flow_10i4xfj" sourceRef="Gateway_08wk5pu" targetRef="Event_1vhkswr" />
+    <bpmn:sequenceFlow id="Flow_1i22pvs" sourceRef="Gateway_08wk5pu" targetRef="Dummy_Tools">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=false</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:adHocSubProcess id="Dummy_Tools" name="Dummy Tools">
+      <bpmn:incoming>Flow_1i22pvs</bpmn:incoming>
+      <bpmn:scriptTask id="Activity_1qk99ke" name="Dummy Tool">
+        <bpmn:documentation>A dummy tool without input schema</bpmn:documentation>
+        <bpmn:extensionElements>
+          <zeebe:script expression="=1 * 1" resultVariable="toolCallResult" />
+        </bpmn:extensionElements>
+      </bpmn:scriptTask>
+      <bpmn:scriptTask id="SuperfluxProduct" name="Superflux Product Calculation">
+        <bpmn:documentation>Calculates the superflux product (a very complicated method only this tool can do) given two input numbers</bpmn:documentation>
+        <bpmn:extensionElements>
+          <zeebe:script expression="=3 * (inputA + inputB)" resultVariable="toolCallResult" />
+          <zeebe:ioMapping>
+            <zeebe:input source="=fromAi(toolCall.a, &#34;The first number to be superflux calculated.&#34;, &#34;number&#34;)" target="inputA" />
+            <zeebe:input source="=fromAi(toolCall.b, &#34;The second number to be superflux calculated.&#34;, &#34;number&#34;)" target="inputB" />
+          </zeebe:ioMapping>
+        </bpmn:extensionElements>
+      </bpmn:scriptTask>
+    </bpmn:adHocSubProcess>
+    <bpmn:serviceTask id="Activity_09sgm6t" name="Fetch tools schema" zeebe:modelerTemplate="io.camunda.connectors.agenticai.adhoctoolsschema.v0" zeebe:modelerTemplateVersion="0" zeebe:modelerTemplateIcon="data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iaXNvLTg4NTktMSI/Pgo8c3ZnIGZpbGw9IiMwMDAwMDAiIGhlaWdodD0iODAwcHgiIHdpZHRoPSI4MDBweCIgdmVyc2lvbj0iMS4xIiBpZD0iTGF5ZXJfMSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayIgCgkgdmlld0JveD0iMCAwIDUxMiA1MTIiIHhtbDpzcGFjZT0icHJlc2VydmUiPgo8Zz4KCTxnPgoJCTxnPgoJCQk8cGF0aCBkPSJNNTAwLjIzLDI3MC4wNTFoLTc0LjU0VjIxMi42NmMwLTYuNTAxLTUuMjcxLTExLjc3LTExLjc3LTExLjc3aC00OC4xbDI3LjY4OC00Ny45NThsNjQuMDQ2LDM2Ljk3NwoJCQkJYzEuODA0LDEuMDQzLDMuODM3LDEuNTc3LDUuODg1LDEuNTc3YzEuMDE5LDAsMi4wNDQtMC4xMzMsMy4wNDYtMC40MDFjMy4wMTctMC44MDksNS41ODYtMi43OCw3LjE0Ny01LjQ4NGwyMC41OTgtMzUuNjc4CgkJCQljMi41MzMtNC4zODgsMS45NzUtOS45MDYtMS4zODktMTMuNjk2QzQ0NS45MTMsODMuMzMzLDM5NC43OTMsMjkuMzcxLDMzMS40MjQsMS42NDljLTUuNDkxLTIuNDAyLTExLjkxMy0wLjI5NC0xNC45MSw0Ljg5OQoJCQkJbC0zOC4yNTMsNjYuMjU2Yy0zLjI1MSw1LjYzLTEuMzIyLDEyLjgyOCw0LjMwOCwxNi4wNzhsMzkuNTg2LDIyLjg1NWwtNjkuMzk0LDEyMC4xODlsLTc4Ljg5My0xMTYuOTUzbC0yLjE5NC0xNi44MTgKCQkJCWMtMC4yMzctMS44MTMtMC44OTItMy41NDQtMS45MTQtNS4wNTlsLTI5LjgzNy00NC4yMzJjLTMuNjM2LTUuMzktMTAuOTUyLTYuODEtMTYuMzM5LTMuMTc2bC01My42NiwzNi4xOTMKCQkJCWMtMi41ODgsMS43NDYtNC4zNzcsNC40NDgtNC45NzMsNy41MTJjLTAuNTk2LDMuMDY0LDAuMDUxLDYuMjQsMS43OTYsOC44MjhsMjkuODM3LDQ0LjIzMmMxLjAyLDEuNTEzLDIuMzc5LDIuNzY3LDMuOTY4LDMuNjY1CgkJCQlsMTQuNzY5LDguMzQ1bDc3Ljk3LDExNS41ODdIMTQ3LjY3bC00Ni40NTgtOTUuNDg1Yy0yLjg0NS01Ljg0NS05Ljg5LTguMjc3LTE1LjczMy01LjQzNGMtNS44NDUsMi44NDUtOC4yNzgsOS44ODgtNS40MzQsMTUuNzMzCgkJCQlsNDEuNDQ3LDg1LjE4Nkg5MS43MTJsLTE4LjU1Ni00Mi4yMDVjLTIuNjE4LTUuOTUxLTkuNTY2LTguNjUzLTE1LjUxMi02LjAzN2MtNS45NTEsMi42MTYtOC42NTUsOS41NjEtNi4wMzgsMTUuNTEyCgkJCQlsMTQuMzksMzIuNzMySDExLjc3Yy02LjUsMC0xMS43Nyw1LjI2OS0xMS43NywxMS43N3Y2NC43MzZjMCw2LjUwMSw1LjI3MSwxMS43NywxMS43NywxMS43N2gyMC41OTh2MTQxLjI0MQoJCQkJYzAsNi41MDEsNS4yNzEsMTEuNzcsMTEuNzcsMTEuNzdoNDIzLjcyNGM2LjQ5OSwwLDExLjc3LTUuMjY5LDExLjc3LTExLjc3VjM1OC4zMjhoMjAuNTk4YzYuNSwwLDExLjc3LTUuMjY5LDExLjc3LTExLjc3CgkJCQl2LTY0LjczNkM1MTIsMjc1LjMyLDUwNi43MjksMjcwLjA1MSw1MDAuMjMsMjcwLjA1MXogTTQwMi4xNSwyMjQuNDN2NDUuNjIxaC03Ni4yNTlsMjYuMzM4LTQ1LjYyMUg0MDIuMTV6IE0zMDQuNTMzLDc0LjM4MQoJCQkJbDI2Ljk4Mi00Ni43MzRjNTIuMzg1LDI1LjgyNyw5Ni45MTcsNzEuNzgsMTM4LjA4LDExNy44NjhsLTEwLjQ2NCwxOC4xMjJMMzA0LjUzMyw3NC4zODF6IE0yNjMuNzM0LDI2MC4wMTMKCQkJCWMwLjAwNS0wLjAwOCwwLjAwNy0wLjAxNiwwLjAxMi0wLjAyNWw3OC43OTktMTM2LjQ4MmwzMC41NzgsMTcuNjU0bC03NC40MTIsMTI4Ljg5aC00MC43NzRMMjYzLjczNCwyNjAuMDEzeiBNMTMzLjI4NSwxMzkKCQkJCWMtMS4wMi0xLjUxMi0yLjM3OS0yLjc2Ny0zLjk2OC0zLjY2NWwtMTQuNzY5LTguMzQ1TDkyLjg0Niw5NC44MTVsMzQuMTQ0LTIzLjAyOWwyMS43MDIsMzIuMTcxbDIuMTk0LDE2LjgxOAoJCQkJYzAuMjM3LDEuODEzLDAuODkyLDMuNTQ0LDEuOTE0LDUuMDU5bDg2Ljg2OCwxMjguNzcybC04LjkxNywxNS40NDRoLTkuMDYzTDEzMy4yODUsMTM5eiBNNDU2LjA5Miw0MzguOTUyaC00OC44NDYKCQkJCWMtNi40OTksMC0xMS43Nyw1LjI2OS0xMS43NywxMS43N3M1LjI3MSwxMS43NywxMS43NywxMS43N2g0OC44NDZ2MjUuMzA2SDU1LjkwOHYtMjUuMzA2aDQ4Ljg0NgoJCQkJYzYuNDk5LDAsMTEuNzctNS4yNjksMTEuNzctMTEuNzdzLTUuMjcxLTExLjc3LTExLjc3LTExLjc3SDU1LjkwOHYtODAuNjI1aDEzNS4zNTZ2NDEuMTk1YzAsNi41MDEsNS4yNzEsMTEuNzcsMTEuNzcsMTEuNzcKCQkJCWgxMDUuOTMxYzYuNDk5LDAsMTEuNzctNS4yNjksMTEuNzctMTEuNzd2LTQxLjE5NWgxMzUuMzU2VjQzOC45NTJ6IE0yMTQuODA1LDM4Ny43NTJ2LTI5LjQyNWg4Mi4zOTF2MjkuNDI1SDIxNC44MDV6CgkJCQkgTTQ4OC40NiwzMzQuNzg3SDIzLjU0di00MS4xOTVoNDY0LjkyVjMzNC43ODd6Ii8+CgkJCTxwYXRoIGQ9Ik0xNDkuNjc3LDQzOC45NTJIMTQ4LjVjLTYuNDk5LDAtMTEuNzcsNS4yNjktMTEuNzcsMTEuNzdzNS4yNzEsMTEuNzcsMTEuNzcsMTEuNzdoMS4xNzcKCQkJCWM2LjQ5OSwwLDExLjc3LTUuMjY5LDExLjc3LTExLjc3UzE1Ni4xNzYsNDM4Ljk1MiwxNDkuNjc3LDQzOC45NTJ6Ii8+CgkJCTxwYXRoIGQ9Ik0zNjIuMzIzLDQ2Mi40OTJoMS4xNzdjNi40OTksMCwxMS43Ny01LjI2OSwxMS43Ny0xMS43N3MtNS4yNzEtMTEuNzctMTEuNzctMTEuNzdoLTEuMTc3CgkJCQljLTYuNDk5LDAtMTEuNzcsNS4yNjktMTEuNzcsMTEuNzdTMzU1LjgyNCw0NjIuNDkyLDM2Mi4zMjMsNDYyLjQ5MnoiLz4KCQk8L2c+Cgk8L2c+CjwvZz4KPC9zdmc+Cg==">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="io.camunda.agenticai:adhoctoolsschema:0" retries="3" />
+        <zeebe:ioMapping>
+          <zeebe:input source="Dummy_Tools" target="data.containerElementId" />
+        </zeebe:ioMapping>
+        <zeebe:taskHeaders>
+          <zeebe:header key="resultVariable" value="toolsResult" />
+          <zeebe:header key="retryBackoff" value="PT0S" />
+        </zeebe:taskHeaders>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_05ytxgl</bpmn:incoming>
+      <bpmn:outgoing>Flow_06qc98j</bpmn:outgoing>
+    </bpmn:serviceTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Ad_Hoc_Tools_Schema_Resolver_Demo">
+      <bpmndi:BPMNShape id="StartEvent_1_di" bpmnElement="StartEvent_1">
+        <dc:Bounds x="182" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1vhkswr_di" bpmnElement="Event_1vhkswr">
+        <dc:Bounds x="577" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_08wk5pu_di" bpmnElement="Gateway_08wk5pu" isMarkerVisible="true">
+        <dc:Bounds x="420" y="95" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1cyr941_di" bpmnElement="Dummy_Tools" isExpanded="true">
+        <dc:Bounds x="270" y="230" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_00gt8p3_di" bpmnElement="Activity_1qk99ke">
+        <dc:Bounds x="310" y="290" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0x0a1hy" bpmnElement="SuperfluxProduct">
+        <dc:Bounds x="460" y="290" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1xmtl89_di" bpmnElement="Activity_09sgm6t">
+        <dc:Bounds x="270" y="80" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_05ytxgl_di" bpmnElement="Flow_05ytxgl">
+        <di:waypoint x="218" y="120" />
+        <di:waypoint x="270" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_06qc98j_di" bpmnElement="Flow_06qc98j">
+        <di:waypoint x="370" y="120" />
+        <di:waypoint x="420" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_10i4xfj_di" bpmnElement="Flow_10i4xfj">
+        <di:waypoint x="470" y="120" />
+        <di:waypoint x="577" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1i22pvs_di" bpmnElement="Flow_1i22pvs">
+        <di:waypoint x="445" y="145" />
+        <di:waypoint x="445" y="230" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/connectors/agentic-ai/examples/ai-agent-chat-with-tools/ai-agent-chat-human-send-email-request.form
+++ b/connectors/agentic-ai/examples/ai-agent-chat-with-tools/ai-agent-chat-human-send-email-request.form
@@ -1,0 +1,53 @@
+{
+  "components": [
+    {
+      "text": "{{instructions}}\n\n---\n\n**Recipient**: {{recipient_name}} &lt;{{recipient_email}}&gt;\n**Subject**: {{email_subject}}\n\n{{email_body}}\n",
+      "type": "text",
+      "layout": {
+        "row": "Row_1ko9ud1",
+        "columns": null
+      },
+      "id": "Field_0wn5mar"
+    },
+    {
+      "type": "separator",
+      "layout": {
+        "row": "Row_1loqtfk",
+        "columns": null
+      },
+      "id": "Field_0uhe0yn"
+    },
+    {
+      "label": "Can you send the e-mail?",
+      "type": "checkbox",
+      "layout": {
+        "row": "Row_03aistc",
+        "columns": null
+      },
+      "id": "Field_0weyspd",
+      "key": "emailOk"
+    },
+    {
+      "label": "E-mail sending operator feedback",
+      "type": "textarea",
+      "layout": {
+        "row": "Row_18xl7gf",
+        "columns": null
+      },
+      "id": "Field_001235a",
+      "key": "operatorFeedback",
+      "conditional": {
+        "hide": "=emailOk"
+      }
+    }
+  ],
+  "type": "default",
+  "id": "ai-agent-chat-human-send-email-request",
+  "executionPlatform": "Camunda Cloud",
+  "executionPlatformVersion": "8.6.0",
+  "exporter": {
+    "name": "Camunda Modeler",
+    "version": "5.34.0"
+  },
+  "schemaVersion": 18
+}

--- a/connectors/agentic-ai/examples/ai-agent-chat-with-tools/ai-agent-chat-initial-request.form
+++ b/connectors/agentic-ai/examples/ai-agent-chat-with-tools/ai-agent-chat-initial-request.form
@@ -1,0 +1,23 @@
+{
+  "components": [
+    {
+      "label": "How can I help you today?",
+      "type": "textarea",
+      "layout": {
+        "row": "Row_0aav7jn",
+        "columns": null
+      },
+      "id": "Field_12i4zil",
+      "key": "inputText"
+    }
+  ],
+  "type": "default",
+  "id": "ai-agent-chat-initial-request",
+  "executionPlatform": "Camunda Cloud",
+  "executionPlatformVersion": "8.6.0",
+  "exporter": {
+    "name": "Camunda Modeler",
+    "version": "5.32.0"
+  },
+  "schemaVersion": 18
+}

--- a/connectors/agentic-ai/examples/ai-agent-chat-with-tools/ai-agent-chat-user-feedback.form
+++ b/connectors/agentic-ai/examples/ai-agent-chat-with-tools/ai-agent-chat-user-feedback.form
@@ -1,0 +1,86 @@
+{
+  "components": [
+    {
+      "label": "Conversation",
+      "components": [
+        {
+          "text": "=agent.context.memory",
+          "type": "text",
+          "layout": {
+            "row": "Row_12e5ibq",
+            "columns": null
+          },
+          "id": "Field_1oekhzq"
+        }
+      ],
+      "showOutline": true,
+      "type": "group",
+      "layout": {
+        "row": "Row_02uha0c",
+        "columns": null
+      },
+      "id": "Field_0rned2j"
+    },
+    {
+      "label": "Latest Message",
+      "components": [
+        {
+          "text": "=agent.chatResponse",
+          "type": "text",
+          "layout": {
+            "row": "Row_0bbt4ob",
+            "columns": null
+          },
+          "id": "Field_0e59eom"
+        }
+      ],
+      "showOutline": true,
+      "type": "group",
+      "layout": {
+        "row": "Row_1m365mf",
+        "columns": null
+      },
+      "id": "Field_0cj02xb"
+    },
+    {
+      "type": "separator",
+      "layout": {
+        "row": "Row_06uyv64",
+        "columns": null
+      },
+      "id": "Field_1mue7xa"
+    },
+    {
+      "label": "Are you satisfied with the result?",
+      "type": "checkbox",
+      "layout": {
+        "row": "Row_14oyfjc",
+        "columns": null
+      },
+      "id": "Field_03n8az1",
+      "key": "userSatisfied"
+    },
+    {
+      "label": "Follow up input",
+      "type": "textarea",
+      "layout": {
+        "row": "Row_09aikdc",
+        "columns": null
+      },
+      "id": "Field_0378jfk",
+      "key": "followUpInput",
+      "conditional": {
+        "hide": "=userSatisfied"
+      }
+    }
+  ],
+  "type": "default",
+  "id": "ai-agent-chat-user-feedback",
+  "executionPlatform": "Camunda Cloud",
+  "executionPlatformVersion": "8.6.0",
+  "exporter": {
+    "name": "Camunda Modeler",
+    "version": "5.34.0"
+  },
+  "schemaVersion": 18
+}

--- a/connectors/agentic-ai/examples/ai-agent-chat-with-tools/ai-agent-chat-with-tools.bpmn
+++ b/connectors/agentic-ai/examples/ai-agent-chat-with-tools/ai-agent-chat-with-tools.bpmn
@@ -1,0 +1,441 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bioc="http://bpmn.io/schema/bpmn/biocolor/1.0" xmlns:color="http://www.omg.org/spec/BPMN/non-normative/color/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_18jxukq" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.34.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.8.0">
+  <bpmn:process id="ai-agent-chat-with-tools" name="AI Agent Chat With Tools" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:extensionElements>
+        <zeebe:formDefinition formId="ai-agent-chat-initial-request" />
+      </bpmn:extensionElements>
+      <bpmn:outgoing>Flow_0pbzrme</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_0pbzrme" sourceRef="StartEvent_1" targetRef="Gateway_0z6ctwk" />
+    <bpmn:serviceTask id="AI_Agent" name="AI Agent" zeebe:modelerTemplate="io.camunda.connectors.agenticai.aiagent.v0" zeebe:modelerTemplateVersion="0" zeebe:modelerTemplateIcon="data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPHN2ZyBpZD0iaWNvbiIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB3aWR0aD0iMzIiIGhlaWdodD0iMzIiIHZpZXdCb3g9IjAgMCAzMiAzMiI+CiAgPGRlZnM+CiAgICA8c3R5bGU+CiAgICAgIC5jbHMtMSB7CiAgICAgICAgZmlsbDogbm9uZTsKICAgICAgfQoKICAgICAgLmNscy0xLCAuY2xzLTIgewogICAgICAgIHN0cm9rZS13aWR0aDogMHB4OwogICAgICB9CiAgICA8L3N0eWxlPgogIDwvZGVmcz4KICA8cGF0aCBjbGFzcz0iY2xzLTIiIGQ9Im0yNywxOWMxLjY1NDMsMCwzLTEuMzQ1NywzLTNzLTEuMzQ1Ny0zLTMtM2MtMS4zMDIsMC0yLjQwMTYuODM4NC0yLjgxNTcsMmgtNS43NzAzbDcuMzAwOC03LjMwMDhjLjM5MTEuMTg3NS44MjM1LjMwMDgsMS4yODUyLjMwMDgsMS42NTQzLDAsMy0xLjM0NTcsMy0zcy0xLjM0NTctMy0zLTMtMywxLjM0NTctMywzYzAsLjQ2MTkuMTEzNS44OTQuMzAwNSwxLjI4NTJsLTguMzAwNSw4LjMwMDh2LTYuNTg1OWMwLTEuMTAyNS44OTctMiwyLTJoMnYtMmgtMmMtMS4yMDAyLDAtMi4yNjYxLjU0MjUtMywxLjM4MjMtLjczMzktLjgzOTgtMS43OTk4LTEuMzgyMy0zLTEuMzgyM2gtMWMtNC45NjI0LDAtOSw0LjAzNzEtOSw5djZjMCw0Ljk2MjksNC4wMzc2LDksOSw5aDFjMS4yMDAyLDAsMi4yNjYxLS41NDI1LDMtMS4zODIzLjczMzkuODM5OCwxLjc5OTgsMS4zODIzLDMsMS4zODIzaDJ2LTJoLTJjLTEuMTAzLDAtMi0uODk3NS0yLTJ2LTYuNTg1OWw4LjMwMDUsOC4zMDA4Yy0uMTg3LjM5MTEtLjMwMDUuODIzMi0uMzAwNSwxLjI4NTIsMCwxLjY1NDMsMS4zNDU3LDMsMywzczMtMS4zNDU3LDMtMy0xLjM0NTctMy0zLTNjLS40NjE3LDAtLjg5NC4xMTMzLTEuMjg1Mi4zMDA4bC03LjMwMDgtNy4zMDA4aDUuNzcwM2MuNDE0MSwxLjE2MTYsMS41MTM3LDIsMi44MTU3LDJabTAtNGMuNTUxMywwLDEsLjQ0ODIsMSwxcy0uNDQ4NywxLTEsMS0xLS40NDgyLTEtMSwuNDQ4Ny0xLDEtMVptMC0xMWMuNTUxNSwwLDEsLjQ0ODcsMSwxcy0uNDQ4NSwxLTEsMS0xLS40NDg3LTEtMSwuNDQ4NS0xLDEtMVptLTEzLDhoLTJ2MmgydjRoLTJjLTEuNjU0MywwLTMsMS4zNDU3LTMsM3YyaDJ2LTJjMC0uNTUxOC40NDg3LTEsMS0xaDJ2NGMwLDEuMTAyNS0uODk3LDItMiwyaC0xYy0zLjUxOTUsMC02LjQzMjQtMi42MTMzLTYuOTIwMi02aDEuOTIwMnYtMmgtMnYtNGgzYzEuNjU0MywwLDMtMS4zNDU3LDMtM3YtMmgtMnYyYzAsLjU1MTgtLjQ0ODcsMS0xLDFoLTIuOTIwMmMuNDg3OC0zLjM4NjcsMy40MDA2LTYsNi45MjAyLTZoMWMxLjEwMywwLDIsLjg5NzUsMiwydjRabTE0LDE1YzAsLjU1MTMtLjQ0ODUsMS0xLDFzLTEtLjQ0ODctMS0xLC40NDg1LTEsMS0xLDEsLjQ0ODcsMSwxWiIvPgogIDxyZWN0IGlkPSJfVHJhbnNwYXJlbnRfUmVjdGFuZ2xlXyIgZGF0YS1uYW1lPSImYW1wO2x0O1RyYW5zcGFyZW50IFJlY3RhbmdsZSZhbXA7Z3Q7IiBjbGFzcz0iY2xzLTEiIHdpZHRoPSIzMiIgaGVpZ2h0PSIzMiIvPgo8L3N2Zz4=">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="io.camunda.agenticai:aiagent:0" retries="0" />
+        <zeebe:ioMapping>
+          <zeebe:input source="bedrock" target="provider.type" />
+          <zeebe:input source="eu-central-1" target="provider.bedrock.region" />
+          <zeebe:input source="anthropic.claude-3-5-sonnet-20240620-v1:0" target="provider.bedrock.model.model" />
+          <zeebe:input source="credentials" target="provider.bedrock.authentication.type" />
+          <zeebe:input source="{{secrets.AWS_BEDROCK_ACCESS_KEY}}" target="provider.bedrock.authentication.accessKey" />
+          <zeebe:input source="{{secrets.AWS_BEDROCK_SECRET_KEY}}" target="provider.bedrock.authentication.secretKey" />
+          <zeebe:input source="=agent.context" target="data.context" />
+          <zeebe:input source="You are a helpful, generic chat agent which can answer a wide amount of questions based on your knowledge and an optional set of available tools.&#10;&#10;If tools are provided, you should prefer them instead of guessing an answer. You can call the same tool multiple times by providing different input values. Don&#39;t guess any tools which were not explicitely configured. If no tool matches the request, try to generate an answer. If you&#39;re not able to find a good answer, return with a message stating why you&#39;re not able to.&#10;&#10;If you are prompted to interact with a person, never guess contact details, but use available user/person lookup tools instead and return with an error if you&#39;re not able to look up appropriate data.&#10;&#10;Thinking, step by step, before you execute your tools, you think using the template `&#60;thinking&#62;&#60;context&#62;&#60;/context&#62;&#60;reflection&#62;&#60;/reflection&#62;&#60;/thinking&#62;`" target="data.systemPrompt.prompt" />
+          <zeebe:input source="=if (is defined(followUpInput)) then followUpInput else inputText" target="data.userPrompt.prompt" />
+          <zeebe:input source="Agent_Tools" target="data.tools.containerElementId" />
+          <zeebe:input source="=toolCallResults" target="data.tools.toolCallResults" />
+          <zeebe:input source="=20" target="data.memory.maxMessages" />
+          <zeebe:input source="=20" target="data.guardrails.maxModelCalls" />
+          <zeebe:input source="=8192" target="provider.bedrock.model.parameters.maxOutputTokens" />
+        </zeebe:ioMapping>
+        <zeebe:taskHeaders>
+          <zeebe:header key="resultVariable" value="agent" />
+          <zeebe:header key="retryBackoff" value="PT0S" />
+        </zeebe:taskHeaders>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_050377t</bpmn:incoming>
+      <bpmn:outgoing>Flow_041ffce</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:exclusiveGateway id="Gateway_0z6ctwk">
+      <bpmn:incoming>Flow_0pbzrme</bpmn:incoming>
+      <bpmn:incoming>Flow_10x2etf</bpmn:incoming>
+      <bpmn:incoming>Flow_0ojrvh4</bpmn:incoming>
+      <bpmn:outgoing>Flow_050377t</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:intermediateCatchEvent id="Event_1ynf9aq" name="Handle user follow up">
+      <bpmn:outgoing>Flow_0ojrvh4</bpmn:outgoing>
+      <bpmn:linkEventDefinition id="LinkEventDefinition_1xhmsl2" name="user_follow_up" />
+    </bpmn:intermediateCatchEvent>
+    <bpmn:intermediateCatchEvent id="Event_11zcrdo" name="Handle tools follow up">
+      <bpmn:outgoing>Flow_10x2etf</bpmn:outgoing>
+      <bpmn:linkEventDefinition id="LinkEventDefinition_0iu6pw3" name="tools_follow_up" />
+    </bpmn:intermediateCatchEvent>
+    <bpmn:sequenceFlow id="Flow_10x2etf" sourceRef="Event_11zcrdo" targetRef="Gateway_0z6ctwk" />
+    <bpmn:sequenceFlow id="Flow_0ojrvh4" sourceRef="Event_1ynf9aq" targetRef="Gateway_0z6ctwk" />
+    <bpmn:userTask id="User_Feedback" name="User Feedback">
+      <bpmn:extensionElements>
+        <zeebe:userTask />
+        <zeebe:formDefinition formId="ai-agent-chat-user-feedback" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_11y3kim</bpmn:incoming>
+      <bpmn:outgoing>Flow_09y08ef</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:exclusiveGateway id="Gateway_1dcg4ha" name="User satisfied?">
+      <bpmn:incoming>Flow_09y08ef</bpmn:incoming>
+      <bpmn:outgoing>Flow_19gp461</bpmn:outgoing>
+      <bpmn:outgoing>Flow_16c9bwj</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:intermediateThrowEvent id="Event_User_Follow_Up" name="User follow up">
+      <bpmn:incoming>Flow_19gp461</bpmn:incoming>
+      <bpmn:linkEventDefinition id="LinkEventDefinition_1j5h3eh" name="user_follow_up" />
+    </bpmn:intermediateThrowEvent>
+    <bpmn:sequenceFlow id="Flow_09y08ef" sourceRef="User_Feedback" targetRef="Gateway_1dcg4ha" />
+    <bpmn:sequenceFlow id="Flow_19gp461" name="no" sourceRef="Gateway_1dcg4ha" targetRef="Event_User_Follow_Up">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=userSatisfied = null or userSatisfied = false</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:endEvent id="Event_0i39jej">
+      <bpmn:incoming>Flow_16c9bwj</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_16c9bwj" name="yes" sourceRef="Gateway_1dcg4ha" targetRef="Event_0i39jej">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=userSatisfied</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_041ffce" sourceRef="AI_Agent" targetRef="Gateway_0bukj01" />
+    <bpmn:exclusiveGateway id="Gateway_0bukj01" name="Includes tool calls?">
+      <bpmn:incoming>Flow_041ffce</bpmn:incoming>
+      <bpmn:outgoing>Flow_00lg7l2</bpmn:outgoing>
+      <bpmn:outgoing>Flow_11y3kim</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:adHocSubProcess id="Agent_Tools" name="Agent Tools">
+      <bpmn:extensionElements>
+        <zeebe:adHoc activeElementsCollection="=[toolCall._meta.name]" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_00lg7l2</bpmn:incoming>
+      <bpmn:outgoing>Flow_01k9dy1</bpmn:outgoing>
+      <bpmn:multiInstanceLoopCharacteristics>
+        <bpmn:extensionElements>
+          <zeebe:loopCharacteristics inputCollection="=agent.toolCalls" inputElement="toolCall" outputCollection="toolCallResults" outputElement="={&#10;  id: toolCall._meta.id,&#10;  name: toolCall._meta.name,&#10;  content: toolCallResult&#10;}" />
+        </bpmn:extensionElements>
+      </bpmn:multiInstanceLoopCharacteristics>
+      <bpmn:scriptTask id="GetDateAndTime" name="Get Date and Time">
+        <bpmn:documentation>Returns the current date and time including the timezone.</bpmn:documentation>
+        <bpmn:extensionElements>
+          <zeebe:script expression="=now()" resultVariable="toolCallResult" />
+        </bpmn:extensionElements>
+      </bpmn:scriptTask>
+      <bpmn:serviceTask id="LoadUserByID" name="Load user by ID" zeebe:modelerTemplate="io.camunda.connectors.HttpJson.v2" zeebe:modelerTemplateVersion="10" zeebe:modelerTemplateIcon="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTgiIGhlaWdodD0iMTgiIHZpZXdCb3g9IjAgMCAxOCAxOCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZD0iTTE3LjAzMzUgOC45OTk5N0MxNy4wMzM1IDEzLjQ0NzUgMTMuNDI4MSAxNy4wNTI5IDguOTgwNjUgMTcuMDUyOUM0LjUzMzE2IDE3LjA1MjkgMC45Mjc3NjUgMTMuNDQ3NSAwLjkyNzc2NSA4Ljk5OTk3QzAuOTI3NzY1IDQuNTUyNDggNC41MzMxNiAwLjk0NzA4MyA4Ljk4MDY1IDAuOTQ3MDgzQzEzLjQyODEgMC45NDcwODMgMTcuMDMzNSA0LjU1MjQ4IDE3LjAzMzUgOC45OTk5N1oiIGZpbGw9IiM1MDU1NjIiLz4KPHBhdGggZD0iTTQuOTMxMjYgMTQuMTU3MUw2Ljc4MTA2IDMuNzE0NzFIMTAuMTM3NUMxMS4xOTE3IDMuNzE0NzEgMTEuOTgyNCAzLjk4MzIzIDEyLjUwOTUgNC41MjAyN0MxMy4wNDY1IDUuMDQ3MzYgMTMuMzE1IDUuNzMzNTggMTMuMzE1IDYuNTc4OTJDMTMuMzE1IDcuNDQ0MTQgMTMuMDcxNCA4LjE1NTIyIDEyLjU4NDEgOC43MTIxNUMxMi4xMDY3IDkuMjU5MTMgMTEuNDU1MyA5LjYzNzA1IDEwLjYyOTggOS44NDU5TDEyLjA2MTkgMTQuMTU3MUgxMC4zMzE1TDkuMDMzNjQgMTAuMDI0OUg3LjI0MzUxTDYuNTEyNTQgMTQuMTU3MUg0LjkzMTI2Wk03LjQ5NzExIDguNTkyODFIOS4yNDI0OEM5Ljk5ODMyIDguNTkyODEgMTAuNTkwMSA4LjQyMzc0IDExLjAxNzcgOC4wODU2MUMxMS40NTUzIDcuNzM3NTMgMTEuNjc0MSA3LjI2NTEzIDExLjY3NDEgNi42Njg0MkMxMS42NzQxIDYuMTkxMDYgMTEuNTI0OSA1LjgxODExIDExLjIyNjUgNS41NDk1OUMxMC45MjgyIDUuMjcxMTMgMTAuNDU1OCA1LjEzMTkgOS44MDkzNiA1LjEzMTlIOC4xMDg3NEw3LjQ5NzExIDguNTkyODFaIiBmaWxsPSJ3aGl0ZSIvPgo8L3N2Zz4K">
+        <bpmn:documentation>Loads a user by ID</bpmn:documentation>
+        <bpmn:extensionElements>
+          <zeebe:taskDefinition type="io.camunda:http-json:1" retries="0" />
+          <zeebe:ioMapping>
+            <zeebe:input source="noAuth" target="authentication.type" />
+            <zeebe:input source="GET" target="method" />
+            <zeebe:input source="=&#34;https://jsonplaceholder.typicode.com/users/&#34; + string(fromAi(toolCall.id, &#34;The user ID&#34;, &#34;number&#34;))" target="url" />
+            <zeebe:input source="=false" target="storeResponse" />
+            <zeebe:input source="20" target="connectionTimeoutInSeconds" />
+            <zeebe:input source="20" target="readTimeoutInSeconds" />
+            <zeebe:input source="=false" target="ignoreNullValues" />
+          </zeebe:ioMapping>
+          <zeebe:taskHeaders>
+            <zeebe:header key="resultExpression" value="={&#10;  toolCallResult: if (is defined(response.body.id)) then response.body else &#34;User not found&#34;&#10;}" />
+            <zeebe:header key="retryBackoff" value="PT0S" />
+          </zeebe:taskHeaders>
+        </bpmn:extensionElements>
+      </bpmn:serviceTask>
+      <bpmn:serviceTask id="ListUsers" name="List users" zeebe:modelerTemplate="io.camunda.connectors.HttpJson.v2" zeebe:modelerTemplateVersion="10" zeebe:modelerTemplateIcon="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTgiIGhlaWdodD0iMTgiIHZpZXdCb3g9IjAgMCAxOCAxOCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZD0iTTE3LjAzMzUgOC45OTk5N0MxNy4wMzM1IDEzLjQ0NzUgMTMuNDI4MSAxNy4wNTI5IDguOTgwNjUgMTcuMDUyOUM0LjUzMzE2IDE3LjA1MjkgMC45Mjc3NjUgMTMuNDQ3NSAwLjkyNzc2NSA4Ljk5OTk3QzAuOTI3NzY1IDQuNTUyNDggNC41MzMxNiAwLjk0NzA4MyA4Ljk4MDY1IDAuOTQ3MDgzQzEzLjQyODEgMC45NDcwODMgMTcuMDMzNSA0LjU1MjQ4IDE3LjAzMzUgOC45OTk5N1oiIGZpbGw9IiM1MDU1NjIiLz4KPHBhdGggZD0iTTQuOTMxMjYgMTQuMTU3MUw2Ljc4MTA2IDMuNzE0NzFIMTAuMTM3NUMxMS4xOTE3IDMuNzE0NzEgMTEuOTgyNCAzLjk4MzIzIDEyLjUwOTUgNC41MjAyN0MxMy4wNDY1IDUuMDQ3MzYgMTMuMzE1IDUuNzMzNTggMTMuMzE1IDYuNTc4OTJDMTMuMzE1IDcuNDQ0MTQgMTMuMDcxNCA4LjE1NTIyIDEyLjU4NDEgOC43MTIxNUMxMi4xMDY3IDkuMjU5MTMgMTEuNDU1MyA5LjYzNzA1IDEwLjYyOTggOS44NDU5TDEyLjA2MTkgMTQuMTU3MUgxMC4zMzE1TDkuMDMzNjQgMTAuMDI0OUg3LjI0MzUxTDYuNTEyNTQgMTQuMTU3MUg0LjkzMTI2Wk03LjQ5NzExIDguNTkyODFIOS4yNDI0OEM5Ljk5ODMyIDguNTkyODEgMTAuNTkwMSA4LjQyMzc0IDExLjAxNzcgOC4wODU2MUMxMS40NTUzIDcuNzM3NTMgMTEuNjc0MSA3LjI2NTEzIDExLjY3NDEgNi42Njg0MkMxMS42NzQxIDYuMTkxMDYgMTEuNTI0OSA1LjgxODExIDExLjIyNjUgNS41NDk1OUMxMC45MjgyIDUuMjcxMTMgMTAuNDU1OCA1LjEzMTkgOS44MDkzNiA1LjEzMTlIOC4xMDg3NEw3LjQ5NzExIDguNTkyODFaIiBmaWxsPSJ3aGl0ZSIvPgo8L3N2Zz4K">
+        <bpmn:documentation>Lists all available users. More contact details (such as e-mail addresses) can be loaded up by looking up the individual user by ID.</bpmn:documentation>
+        <bpmn:extensionElements>
+          <zeebe:taskDefinition type="io.camunda:http-json:1" retries="3" />
+          <zeebe:ioMapping>
+            <zeebe:input source="noAuth" target="authentication.type" />
+            <zeebe:input source="GET" target="method" />
+            <zeebe:input source="https://jsonplaceholder.typicode.com/users" target="url" />
+            <zeebe:input source="=false" target="storeResponse" />
+            <zeebe:input source="20" target="connectionTimeoutInSeconds" />
+            <zeebe:input source="20" target="readTimeoutInSeconds" />
+            <zeebe:input source="=false" target="ignoreNullValues" />
+          </zeebe:ioMapping>
+          <zeebe:taskHeaders>
+            <zeebe:header key="resultExpression" value="={&#10;  toolCallResult: for user in response.body return {&#10;    id: user.id,&#10;    name: user.name,&#10;    username: user.username&#10;  }&#10;}" />
+            <zeebe:header key="retryBackoff" value="PT0S" />
+          </zeebe:taskHeaders>
+        </bpmn:extensionElements>
+      </bpmn:serviceTask>
+      <bpmn:serviceTask id="Search_Recipe" name="Search recipe" zeebe:modelerTemplate="io.camunda.connectors.HttpJson.v2" zeebe:modelerTemplateVersion="10" zeebe:modelerTemplateIcon="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTgiIGhlaWdodD0iMTgiIHZpZXdCb3g9IjAgMCAxOCAxOCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZD0iTTE3LjAzMzUgOC45OTk5N0MxNy4wMzM1IDEzLjQ0NzUgMTMuNDI4MSAxNy4wNTI5IDguOTgwNjUgMTcuMDUyOUM0LjUzMzE2IDE3LjA1MjkgMC45Mjc3NjUgMTMuNDQ3NSAwLjkyNzc2NSA4Ljk5OTk3QzAuOTI3NzY1IDQuNTUyNDggNC41MzMxNiAwLjk0NzA4MyA4Ljk4MDY1IDAuOTQ3MDgzQzEzLjQyODEgMC45NDcwODMgMTcuMDMzNSA0LjU1MjQ4IDE3LjAzMzUgOC45OTk5N1oiIGZpbGw9IiM1MDU1NjIiLz4KPHBhdGggZD0iTTQuOTMxMjYgMTQuMTU3MUw2Ljc4MTA2IDMuNzE0NzFIMTAuMTM3NUMxMS4xOTE3IDMuNzE0NzEgMTEuOTgyNCAzLjk4MzIzIDEyLjUwOTUgNC41MjAyN0MxMy4wNDY1IDUuMDQ3MzYgMTMuMzE1IDUuNzMzNTggMTMuMzE1IDYuNTc4OTJDMTMuMzE1IDcuNDQ0MTQgMTMuMDcxNCA4LjE1NTIyIDEyLjU4NDEgOC43MTIxNUMxMi4xMDY3IDkuMjU5MTMgMTEuNDU1MyA5LjYzNzA1IDEwLjYyOTggOS44NDU5TDEyLjA2MTkgMTQuMTU3MUgxMC4zMzE1TDkuMDMzNjQgMTAuMDI0OUg3LjI0MzUxTDYuNTEyNTQgMTQuMTU3MUg0LjkzMTI2Wk03LjQ5NzExIDguNTkyODFIOS4yNDI0OEM5Ljk5ODMyIDguNTkyODEgMTAuNTkwMSA4LjQyMzc0IDExLjAxNzcgOC4wODU2MUMxMS40NTUzIDcuNzM3NTMgMTEuNjc0MSA3LjI2NTEzIDExLjY3NDEgNi42Njg0MkMxMS42NzQxIDYuMTkxMDYgMTEuNTI0OSA1LjgxODExIDExLjIyNjUgNS41NDk1OUMxMC45MjgyIDUuMjcxMTMgMTAuNDU1OCA1LjEzMTkgOS44MDkzNiA1LjEzMTlIOC4xMDg3NEw3LjQ5NzExIDguNTkyODFaIiBmaWxsPSJ3aGl0ZSIvPgo8L3N2Zz4K">
+        <bpmn:documentation>Searches a recipe given a search query</bpmn:documentation>
+        <bpmn:extensionElements>
+          <zeebe:taskDefinition type="io.camunda:http-json:1" retries="3" />
+          <zeebe:ioMapping>
+            <zeebe:input source="noAuth" target="authentication.type" />
+            <zeebe:input source="GET" target="method" />
+            <zeebe:input source="https://dummyjson.com/recipes/search" target="url" />
+            <zeebe:input source="={&#10;  q: fromAi(toolCall.searchQuery, &#34;The query describing which recipe to search (e.g. a specific dish or the cuisine).&#34;)&#10;}" target="queryParameters" />
+            <zeebe:input source="=false" target="storeResponse" />
+            <zeebe:input source="20" target="connectionTimeoutInSeconds" />
+            <zeebe:input source="20" target="readTimeoutInSeconds" />
+            <zeebe:input source="=false" target="ignoreNullValues" />
+          </zeebe:ioMapping>
+          <zeebe:taskHeaders>
+            <zeebe:header key="resultExpression" value="={&#10;  toolCallResult: if (count(response.body.recipes) &#62; 0) then response.body.recipes else &#34;No result found.&#34;&#10;}" />
+            <zeebe:header key="retryBackoff" value="PT0S" />
+          </zeebe:taskHeaders>
+        </bpmn:extensionElements>
+      </bpmn:serviceTask>
+      <bpmn:scriptTask id="SuperfluxProduct" name="Superflux Product Calculation">
+        <bpmn:documentation>Calculates the superflux product (a very complicated method only this tool can do) given two input numbers</bpmn:documentation>
+        <bpmn:extensionElements>
+          <zeebe:script expression="=3 * (inputA + inputB)" resultVariable="toolCallResult" />
+          <zeebe:ioMapping>
+            <zeebe:input source="=fromAi(toolCall.a, &#34;The first number to be superflux calculated.&#34;, &#34;number&#34;)" target="inputA" />
+            <zeebe:input source="=fromAi(toolCall.b, &#34;The second number to be superflux calculated.&#34;, &#34;number&#34;)" target="inputB" />
+          </zeebe:ioMapping>
+        </bpmn:extensionElements>
+      </bpmn:scriptTask>
+      <bpmn:userTask id="AskHumanToSendEmail" name="Ask human to send email">
+        <bpmn:documentation>Ask a human to send an email for you</bpmn:documentation>
+        <bpmn:extensionElements>
+          <zeebe:userTask />
+          <zeebe:formDefinition formId="ai-agent-chat-human-send-email-request" />
+          <zeebe:ioMapping>
+            <zeebe:input source="=fromAi(toolCall.instructions, &#34;Instructions for the human to follow when sending the email, including background of the email.&#34;)" target="instructions" />
+            <zeebe:input source="=fromAi(toolCall.recipient_name, &#34;The recipient&#39;s full name.&#34;)" target="recipient_name" />
+            <zeebe:input source="=fromAi(toolCall.recipient_email, &#34;The the recipient&#39;s email address.&#34;)" target="recipient_email" />
+            <zeebe:input source="=fromAi(toolCall.email_subject, &#34;The subject of the email.&#34;)" target="email_subject" />
+            <zeebe:input source="=fromAi(toolCall.email_body, &#34;The body of the email.&#34;)" target="email_body" />
+            <zeebe:output source="={&#10;  operatorFeedback: operatorFeedback,&#10;  emailOk: emailOk&#10;}" target="toolCallResult" />
+          </zeebe:ioMapping>
+        </bpmn:extensionElements>
+        <bpmn:outgoing>Flow_0demz1g</bpmn:outgoing>
+      </bpmn:userTask>
+      <bpmn:sequenceFlow id="Flow_0demz1g" sourceRef="AskHumanToSendEmail" targetRef="Gateway_1lux75t" />
+      <bpmn:exclusiveGateway id="Gateway_1lux75t" name="OK to send email?">
+        <bpmn:incoming>Flow_0demz1g</bpmn:incoming>
+        <bpmn:outgoing>Flow_0uqjclh</bpmn:outgoing>
+        <bpmn:outgoing>Flow_1l2ws6w</bpmn:outgoing>
+      </bpmn:exclusiveGateway>
+      <bpmn:sequenceFlow id="Flow_0uqjclh" name="yes" sourceRef="Gateway_1lux75t" targetRef="SendEmail">
+        <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=toolCallResult.emailOk</bpmn:conditionExpression>
+      </bpmn:sequenceFlow>
+      <bpmn:sequenceFlow id="Flow_1l2ws6w" name="no" sourceRef="Gateway_1lux75t" targetRef="Event_1wxfv4u">
+        <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=toolCallResult.emailOk != true</bpmn:conditionExpression>
+      </bpmn:sequenceFlow>
+      <bpmn:intermediateThrowEvent id="Event_1wxfv4u" name="loop back with feedback">
+        <bpmn:incoming>Flow_1l2ws6w</bpmn:incoming>
+      </bpmn:intermediateThrowEvent>
+      <bpmn:scriptTask id="SendEmail" name="Send email">
+        <bpmn:extensionElements>
+          <zeebe:script expression="=true" resultVariable="emailSent" />
+          <zeebe:ioMapping>
+            <zeebe:output source="=emailSent" target="toolCallResult.emailSent" />
+          </zeebe:ioMapping>
+        </bpmn:extensionElements>
+        <bpmn:incoming>Flow_0uqjclh</bpmn:incoming>
+      </bpmn:scriptTask>
+      <bpmn:serviceTask id="Jokes_API" name="Jokes API" zeebe:modelerTemplate="io.camunda.connectors.HttpJson.v2" zeebe:modelerTemplateVersion="10" zeebe:modelerTemplateIcon="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTgiIGhlaWdodD0iMTgiIHZpZXdCb3g9IjAgMCAxOCAxOCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZD0iTTE3LjAzMzUgOC45OTk5N0MxNy4wMzM1IDEzLjQ0NzUgMTMuNDI4MSAxNy4wNTI5IDguOTgwNjUgMTcuMDUyOUM0LjUzMzE2IDE3LjA1MjkgMC45Mjc3NjUgMTMuNDQ3NSAwLjkyNzc2NSA4Ljk5OTk3QzAuOTI3NzY1IDQuNTUyNDggNC41MzMxNiAwLjk0NzA4MyA4Ljk4MDY1IDAuOTQ3MDgzQzEzLjQyODEgMC45NDcwODMgMTcuMDMzNSA0LjU1MjQ4IDE3LjAzMzUgOC45OTk5N1oiIGZpbGw9IiM1MDU1NjIiLz4KPHBhdGggZD0iTTQuOTMxMjYgMTQuMTU3MUw2Ljc4MTA2IDMuNzE0NzFIMTAuMTM3NUMxMS4xOTE3IDMuNzE0NzEgMTEuOTgyNCAzLjk4MzIzIDEyLjUwOTUgNC41MjAyN0MxMy4wNDY1IDUuMDQ3MzYgMTMuMzE1IDUuNzMzNTggMTMuMzE1IDYuNTc4OTJDMTMuMzE1IDcuNDQ0MTQgMTMuMDcxNCA4LjE1NTIyIDEyLjU4NDEgOC43MTIxNUMxMi4xMDY3IDkuMjU5MTMgMTEuNDU1MyA5LjYzNzA1IDEwLjYyOTggOS44NDU5TDEyLjA2MTkgMTQuMTU3MUgxMC4zMzE1TDkuMDMzNjQgMTAuMDI0OUg3LjI0MzUxTDYuNTEyNTQgMTQuMTU3MUg0LjkzMTI2Wk03LjQ5NzExIDguNTkyODFIOS4yNDI0OEM5Ljk5ODMyIDguNTkyODEgMTAuNTkwMSA4LjQyMzc0IDExLjAxNzcgOC4wODU2MUMxMS40NTUzIDcuNzM3NTMgMTEuNjc0MSA3LjI2NTEzIDExLjY3NDEgNi42Njg0MkMxMS42NzQxIDYuMTkxMDYgMTEuNTI0OSA1LjgxODExIDExLjIyNjUgNS41NDk1OUMxMC45MjgyIDUuMjcxMTMgMTAuNDU1OCA1LjEzMTkgOS44MDkzNiA1LjEzMTlIOC4xMDg3NEw3LjQ5NzExIDguNTkyODFaIiBmaWxsPSJ3aGl0ZSIvPgo8L3N2Zz4K">
+        <bpmn:documentation>Fetches a random joke from a Jokes REST API</bpmn:documentation>
+        <bpmn:extensionElements>
+          <zeebe:taskDefinition type="io.camunda:http-json:1" retries="3" />
+          <zeebe:ioMapping>
+            <zeebe:input source="noAuth" target="authentication.type" />
+            <zeebe:input source="GET" target="method" />
+            <zeebe:input source="https://v2.jokeapi.dev/joke/Any?format=txt&#38;safe-mode" target="url" />
+            <zeebe:input source="=false" target="storeResponse" />
+            <zeebe:input source="=20" target="connectionTimeoutInSeconds" />
+            <zeebe:input source="=20" target="readTimeoutInSeconds" />
+            <zeebe:input source="=false" target="ignoreNullValues" />
+          </zeebe:ioMapping>
+          <zeebe:taskHeaders>
+            <zeebe:header key="resultExpression" value="={&#10;  toolCallResult: response.body&#10;}" />
+            <zeebe:header key="retryBackoff" value="PT0S" />
+          </zeebe:taskHeaders>
+        </bpmn:extensionElements>
+      </bpmn:serviceTask>
+    </bpmn:adHocSubProcess>
+    <bpmn:intermediateThrowEvent id="Event_1hi12xn" name="Tools follow up">
+      <bpmn:incoming>Flow_01k9dy1</bpmn:incoming>
+      <bpmn:linkEventDefinition id="LinkEventDefinition_05e1y25" name="tools_follow_up" />
+    </bpmn:intermediateThrowEvent>
+    <bpmn:sequenceFlow id="Flow_00lg7l2" name="yes" sourceRef="Gateway_0bukj01" targetRef="Agent_Tools">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=not(is empty(agent.toolCalls))</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_01k9dy1" sourceRef="Agent_Tools" targetRef="Event_1hi12xn" />
+    <bpmn:sequenceFlow id="Flow_11y3kim" name="no" sourceRef="Gateway_0bukj01" targetRef="User_Feedback">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=is empty(agent.toolCalls)</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_050377t" sourceRef="Gateway_0z6ctwk" targetRef="AI_Agent" />
+    <bpmn:textAnnotation id="TextAnnotation_0rg9ar3">
+      <bpmn:text>Rough outline of the functionality
+
+- Loads previous memory from provided variables
+- Checks guardrails (e.g. maximum LLM model calls)
+- Loads available tool information from ad-hoc subprocess definition
+- Merges the current request (either a user message or a tool call response) into the memory
+- Calls the LLM, including previous/edited memory + available tools schema
+- Returns memory trimmed to amount of latest messages
+- Returns last response
+- Returns tools to call, including their parameters</bpmn:text>
+    </bpmn:textAnnotation>
+    <bpmn:association id="Association_0ic98nl" associationDirection="None" sourceRef="AI_Agent" targetRef="TextAnnotation_0rg9ar3" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="ai-agent-chat-with-tools">
+      <bpmndi:BPMNShape id="StartEvent_1_di" bpmnElement="StartEvent_1">
+        <dc:Bounds x="152" y="442" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0xj2598_di" bpmnElement="AI_Agent" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="340" y="420" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0z6ctwk_di" bpmnElement="Gateway_0z6ctwk" isMarkerVisible="true">
+        <dc:Bounds x="245" y="435" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1vly22n" bpmnElement="Event_1ynf9aq" bioc:stroke="#6b3c00" bioc:fill="#ffe0b2" color:background-color="#ffe0b2" color:border-color="#6b3c00">
+        <dc:Bounds x="252" y="352" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="240" y="316" width="60" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1m69yzg" bpmnElement="Event_11zcrdo" bioc:stroke="#0d4372" bioc:fill="#bbdefb" color:background-color="#bbdefb" color:border-color="#0d4372">
+        <dc:Bounds x="252" y="532" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="239" y="575" width="62" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1fam9db_di" bpmnElement="User_Feedback">
+        <dc:Bounds x="640" y="420" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_1dcg4ha_di" bpmnElement="Gateway_1dcg4ha" isMarkerVisible="true">
+        <dc:Bounds x="805" y="435" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="794" y="492" width="73" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_07erbg0_di" bpmnElement="Event_User_Follow_Up" bioc:stroke="#6b3c00" bioc:fill="#ffe0b2" color:background-color="#ffe0b2" color:border-color="#6b3c00">
+        <dc:Bounds x="812" y="352" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="795" y="333" width="70" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0i39jej_di" bpmnElement="Event_0i39jej">
+        <dc:Bounds x="912" y="442" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0bukj01_di" bpmnElement="Gateway_0bukj01" isMarkerVisible="true">
+        <dc:Bounds x="505" y="435" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="499" y="406" width="62" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0gbt4n4_di" bpmnElement="Event_1hi12xn" bioc:stroke="#0d4372" bioc:fill="#bbdefb" color:background-color="#bbdefb" color:border-color="#0d4372">
+        <dc:Bounds x="665" y="1202" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="647" y="1245" width="73" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_03yngb7_di" bpmnElement="Agent_Tools" isExpanded="true">
+        <dc:Bounds x="480" y="560" width="405" height="580" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1sbkoqq_di" bpmnElement="GetDateAndTime">
+        <dc:Bounds x="510" y="600" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1fihe00" bpmnElement="LoadUserByID">
+        <dc:Bounds x="630" y="700" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0kkpyxf_di" bpmnElement="ListUsers">
+        <dc:Bounds x="510" y="700" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0d8luif_di" bpmnElement="Search_Recipe">
+        <dc:Bounds x="510" y="800" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0x0a1hy" bpmnElement="SuperfluxProduct">
+        <dc:Bounds x="630" y="600" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_16uhg8o_di" bpmnElement="AskHumanToSendEmail">
+        <dc:Bounds x="510" y="930" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_1lux75t_di" bpmnElement="Gateway_1lux75t" isMarkerVisible="true">
+        <dc:Bounds x="655" y="945" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="652" y="916" width="56" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1ny5xkz_di" bpmnElement="Event_1wxfv4u">
+        <dc:Bounds x="662" y="1032" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="645" y="1075" width="70" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1sddc2g_di" bpmnElement="SendEmail">
+        <dc:Bounds x="765" y="930" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1l8tp85_di" bpmnElement="Jokes_API">
+        <dc:Bounds x="630" y="800" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0demz1g_di" bpmnElement="Flow_0demz1g">
+        <di:waypoint x="610" y="970" />
+        <di:waypoint x="655" y="970" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0uqjclh_di" bpmnElement="Flow_0uqjclh">
+        <di:waypoint x="705" y="970" />
+        <di:waypoint x="765" y="970" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="726" y="952" width="18" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1l2ws6w_di" bpmnElement="Flow_1l2ws6w">
+        <di:waypoint x="680" y="995" />
+        <di:waypoint x="680" y="1032" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="689" y="1003" width="13" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Association_0ic98nl_di" bpmnElement="Association_0ic98nl">
+        <di:waypoint x="410" y="420" />
+        <di:waypoint x="502" y="236" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="TextAnnotation_0rg9ar3_di" bpmnElement="TextAnnotation_0rg9ar3">
+        <dc:Bounds x="401" y="80" width="578" height="156" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0pbzrme_di" bpmnElement="Flow_0pbzrme">
+        <di:waypoint x="188" y="460" />
+        <di:waypoint x="245" y="460" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_050377t_di" bpmnElement="Flow_050377t">
+        <di:waypoint x="295" y="460" />
+        <di:waypoint x="340" y="460" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_041ffce_di" bpmnElement="Flow_041ffce">
+        <di:waypoint x="440" y="460" />
+        <di:waypoint x="505" y="460" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_10x2etf_di" bpmnElement="Flow_10x2etf">
+        <di:waypoint x="270" y="532" />
+        <di:waypoint x="270" y="485" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0ojrvh4_di" bpmnElement="Flow_0ojrvh4">
+        <di:waypoint x="270" y="388" />
+        <di:waypoint x="270" y="435" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_11y3kim_di" bpmnElement="Flow_11y3kim">
+        <di:waypoint x="555" y="460" />
+        <di:waypoint x="640" y="460" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="591" y="442" width="13" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_09y08ef_di" bpmnElement="Flow_09y08ef">
+        <di:waypoint x="740" y="460" />
+        <di:waypoint x="805" y="460" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_19gp461_di" bpmnElement="Flow_19gp461">
+        <di:waypoint x="830" y="435" />
+        <di:waypoint x="830" y="388" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="839" y="408" width="13" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_16c9bwj_di" bpmnElement="Flow_16c9bwj">
+        <di:waypoint x="855" y="460" />
+        <di:waypoint x="912" y="460" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="875" y="442" width="18" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_00lg7l2_di" bpmnElement="Flow_00lg7l2">
+        <di:waypoint x="530" y="485" />
+        <di:waypoint x="530" y="560" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="507" y="509" width="18" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_01k9dy1_di" bpmnElement="Flow_01k9dy1">
+        <di:waypoint x="683" y="1140" />
+        <di:waypoint x="683" y="1202" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/connectors/agentic-ai/examples/fraud-detection/fraud-detection-process-enter-tax-form.form
+++ b/connectors/agentic-ai/examples/fraud-detection/fraud-detection-process-enter-tax-form.form
@@ -1,0 +1,192 @@
+{
+  "components": [
+    {
+      "text": "### Tax Return Submission Form",
+      "type": "text",
+      "id": "Heading_0",
+      "layout": {
+        "row": "row_0",
+        "columns": null
+      }
+    },
+    {
+      "text": "##### Personal Information",
+      "type": "text",
+      "id": "Subheading_1",
+      "layout": {
+        "row": "row_1",
+        "columns": null
+      }
+    },
+    {
+      "label": "Full Name",
+      "type": "textfield",
+      "id": "Textfield_2",
+      "validate": {
+        "minLength": 5,
+        "maxLength": 50,
+        "required": true
+      },
+      "key": "taxSubmission.fullName",
+      "description": "Enter your full name",
+      "layout": {
+        "row": "row_2",
+        "columns": null
+      },
+      "properties": {}
+    },
+    {
+      "subtype": "date",
+      "type": "datetime",
+      "id": "Date_4",
+      "dateLabel": "Date of Birth",
+      "validate": {
+        "required": true
+      },
+      "key": "taxSubmission.dob",
+      "description": "Select your date of birth",
+      "layout": {
+        "row": "row_2",
+        "columns": null
+      }
+    },
+    {
+      "label": "Email Address",
+      "type": "textfield",
+      "layout": {
+        "row": "row_2",
+        "columns": null
+      },
+      "id": "Field_13hu2ve",
+      "key": "taxSubmission.emailAddress",
+      "validate": {
+        "required": true,
+        "validationType": "email"
+      }
+    },
+    {
+      "text": "##### Financial Information",
+      "type": "text",
+      "id": "Subheading_5",
+      "layout": {
+        "row": "row_3",
+        "columns": null
+      }
+    },
+    {
+      "label": "Total Income",
+      "type": "number",
+      "id": "Number_6",
+      "decimalDigits": 2,
+      "defaultValue": 0,
+      "appearance": {
+        "prefixAdorner": "€"
+      },
+      "validate": {
+        "min": 0,
+        "max": 9999999,
+        "step": 1000.5,
+        "required": true
+      },
+      "key": "taxSubmission.totalIncome",
+      "description": "Enter your total income",
+      "layout": {
+        "row": "row_4",
+        "columns": null
+      }
+    },
+    {
+      "label": "Total Expenses",
+      "type": "number",
+      "id": "Number_7",
+      "decimalDigits": 2,
+      "defaultValue": 0,
+      "appearance": {
+        "prefixAdorner": "€"
+      },
+      "validate": {
+        "min": 0,
+        "max": 9999999,
+        "step": 1000.5,
+        "required": true
+      },
+      "key": "taxSubmission.totalExpenses",
+      "description": "Enter your total expenses",
+      "layout": {
+        "row": "row_4",
+        "columns": null
+      }
+    },
+    {
+      "text": "##### Deductions",
+      "type": "text",
+      "id": "Subheading_8",
+      "layout": {
+        "row": "row_5",
+        "columns": null
+      }
+    },
+    {
+      "label": "Large Purchases ",
+      "values": [
+        {
+          "label": "Car",
+          "value": "car"
+        },
+        {
+          "label": "House",
+          "value": "house"
+        },
+        {
+          "label": "Stocks",
+          "value": "stocks"
+        },
+        {
+          "label": "Holiday",
+          "value": "holiday"
+        },
+        {
+          "label": "Boat",
+          "value": "boat"
+        }
+      ],
+      "type": "taglist",
+      "layout": {
+        "row": "row_6",
+        "columns": null
+      },
+      "id": "Field_04tpvca",
+      "key": "taxSubmission.largePurchases",
+      "description": "Please add any large purchases you've made this year",
+      "validate": {
+        "required": false
+      }
+    },
+    {
+      "label": "Charitable Donations",
+      "type": "textarea",
+      "id": "Textarea_10",
+      "validate": {
+        "minLength": 0,
+        "maxLength": 500,
+        "required": true
+      },
+      "key": "taxSubmission.charitableDonations",
+      "description": "Enter any charitable donations",
+      "layout": {
+        "row": "row_6",
+        "columns": null
+      }
+    }
+  ],
+  "executionPlatform": "Camunda Cloud",
+  "executionPlatformVersion": "8.6.0",
+  "exporter": {
+    "name": "Camunda Modeler",
+    "version": "5.34.0"
+  },
+  "schemaVersion": 18,
+  "id": "fraud-detection-process-enter-tax-form",
+  "generated": true,
+  "type": "default"
+}

--- a/connectors/agentic-ai/examples/fraud-detection/fraud-detection-process-send-email.form
+++ b/connectors/agentic-ai/examples/fraud-detection/fraud-detection-process-send-email.form
@@ -1,0 +1,49 @@
+{
+  "components": [
+    {
+      "text": "# E-Mail Body",
+      "type": "text",
+      "layout": {
+        "row": "Row_18aw07r",
+        "columns": null
+      },
+      "id": "Field_09n3pq9"
+    },
+    {
+      "text": "=emailBody",
+      "type": "text",
+      "layout": {
+        "row": "Row_0wkhavr",
+        "columns": null
+      },
+      "id": "Field_1rx8pjf"
+    },
+    {
+      "type": "separator",
+      "layout": {
+        "row": "Row_0n7xc4d",
+        "columns": null
+      },
+      "id": "Field_04c20dn"
+    },
+    {
+      "label": "User Response",
+      "type": "textarea",
+      "layout": {
+        "row": "Row_04bsh7q",
+        "columns": null
+      },
+      "id": "Field_1qrykkr",
+      "key": "userResponse"
+    }
+  ],
+  "executionPlatform": "Camunda Cloud",
+  "executionPlatformVersion": "8.6.0",
+  "exporter": {
+    "name": "Camunda Modeler",
+    "version": "5.32.0"
+  },
+  "schemaVersion": 18,
+  "id": "fraud-detection-process-send-email",
+  "type": "default"
+}

--- a/connectors/agentic-ai/examples/fraud-detection/fraud-detection-process-view-tax-details.form
+++ b/connectors/agentic-ai/examples/fraud-detection/fraud-detection-process-view-tax-details.form
@@ -1,0 +1,91 @@
+{
+  "components": [
+    {
+      "text": "### Tax Return  Check Form",
+      "type": "text",
+      "id": "Heading_0",
+      "layout": {
+        "row": "row_0",
+        "columns": null
+      }
+    },
+    {
+      "label": "Tax Submission",
+      "type": "textarea",
+      "layout": {
+        "row": "Row_18j8vk9",
+        "columns": null
+      },
+      "id": "Field_0waor45",
+      "key": "taxSubmission",
+      "description": "The initial tax submission.",
+      "readonly": true
+    },
+    {
+      "label": "Suspicious Parts",
+      "type": "textarea",
+      "layout": {
+        "row": "Row_0tjz84s",
+        "columns": null
+      },
+      "id": "Field_1dw6scf",
+      "key": "suspiciousParts",
+      "description": "Parts of the submission the agent think are suspicious.",
+      "readonly": true
+    },
+    {
+      "label": "Agent Tendency",
+      "type": "textarea",
+      "layout": {
+        "row": "Row_0wlpd3v",
+        "columns": null
+      },
+      "id": "Field_0qv58sy",
+      "key": "tendency",
+      "readonly": true
+    },
+    {
+      "type": "separator",
+      "layout": {
+        "row": "Row_13f9qkr",
+        "columns": null
+      },
+      "id": "Field_1t9te94"
+    },
+    {
+      "label": "Fraud",
+      "type": "checkbox",
+      "layout": {
+        "row": "Row_0ghpm8o",
+        "columns": null
+      },
+      "id": "Field_0obtm2e",
+      "key": "fraudDetected",
+      "description": "👆Tick the fraud box"
+    },
+    {
+      "label": "Reason for Decision",
+      "type": "textarea",
+      "layout": {
+        "row": "Row_0wsk0xa",
+        "columns": null
+      },
+      "id": "Field_1p3319m",
+      "key": "expertAnalysis",
+      "validate": {
+        "required": true,
+        "minLength": 10
+      }
+    }
+  ],
+  "executionPlatform": "Camunda Cloud",
+  "executionPlatformVersion": "8.6.0",
+  "exporter": {
+    "name": "Camunda Modeler",
+    "version": "5.34.0"
+  },
+  "schemaVersion": 18,
+  "id": "fraud-detection-process-view-tax-details",
+  "generated": true,
+  "type": "default"
+}

--- a/connectors/agentic-ai/examples/fraud-detection/fraud-detection-process.bpmn
+++ b/connectors/agentic-ai/examples/fraud-detection/fraud-detection-process.bpmn
@@ -1,0 +1,444 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:bioc="http://bpmn.io/schema/bpmn/biocolor/1.0" xmlns:color="http://www.omg.org/spec/BPMN/non-normative/color/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.34.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.8.0">
+  <bpmn:process id="fraud-detection-process" name="Fraud Detection Process" isExecutable="true">
+    <bpmn:adHocSubProcess id="Fraud_Tools" name="Agent Tools/Actions">
+      <bpmn:extensionElements>
+        <zeebe:adHoc activeElementsCollection="=[toolCall._meta.name]" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_06sbwe8</bpmn:incoming>
+      <bpmn:outgoing>Flow_1dc12gc</bpmn:outgoing>
+      <bpmn:multiInstanceLoopCharacteristics>
+        <bpmn:extensionElements>
+          <zeebe:loopCharacteristics inputCollection="=agent.toolCalls" inputElement="toolCall" outputCollection="toolCallResults" outputElement="={&#10;  id: toolCall._meta.id,&#10;  name: toolCall._meta.name,&#10;  content: toolCallResult&#10;}" />
+        </bpmn:extensionElements>
+      </bpmn:multiInstanceLoopCharacteristics>
+      <bpmn:userTask id="CallOnExternalAdvisor" name="Call On External Advisor">
+        <bpmn:documentation>Ask a human expert to assist in the fraud detection.</bpmn:documentation>
+        <bpmn:extensionElements>
+          <zeebe:userTask />
+          <zeebe:formDefinition formId="fraud-detection-process-view-tax-details" />
+          <zeebe:ioMapping>
+            <zeebe:input source="=fromAi(toolCall.taxSubmission, &#34;Summarize the tax submission which was provided by the user&#34;)" target="taxSubmission" />
+            <zeebe:input source="=fromAi(toolCall.tendency, &#34;Share youre thoughts and tendency if this is fraud or not. This should help the expert getting a conclusion.&#34;)" target="tendency" />
+            <zeebe:input source="=fromAi(toolCall.suspiciousParts, &#34;Parts of the tax submission you think are suspicious&#34;)" target="suspiciousParts" />
+            <zeebe:output source="={&#10;  fraudDetected: fraudDetected,&#10;  expertAnalysis: expertAnalysis&#10;}" target="toolCallResult" />
+          </zeebe:ioMapping>
+        </bpmn:extensionElements>
+        <bpmn:outgoing>Flow_02dr109</bpmn:outgoing>
+      </bpmn:userTask>
+      <bpmn:sequenceFlow id="Flow_02dr109" sourceRef="CallOnExternalAdvisor" targetRef="Gateway_04sl072" />
+      <bpmn:sequenceFlow id="Flow_1plqcas" sourceRef="FraudDetected" targetRef="Event_0gnk722" />
+      <bpmn:intermediateThrowEvent id="FraudDetected" name="Fraud! Detected">
+        <bpmn:documentation>Use this tool to mark the submission as definitely being fraud.</bpmn:documentation>
+        <bpmn:extensionElements>
+          <zeebe:ioMapping>
+            <zeebe:output source="=true" target="fraudDetected" />
+            <zeebe:output source="=fromAi(toolCall.agentAnalysis, &#34;Final analysis why the submission is definitely fraud&#34;)" target="agentAnalysis" />
+          </zeebe:ioMapping>
+        </bpmn:extensionElements>
+        <bpmn:outgoing>Flow_1plqcas</bpmn:outgoing>
+      </bpmn:intermediateThrowEvent>
+      <bpmn:serviceTask id="EmailInquiry" name="Generate Email Inquiry" zeebe:modelerTemplate="io.camunda.connectors.OpenAI.v1" zeebe:modelerTemplateVersion="5" zeebe:modelerTemplateIcon="data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPHN2ZyB3aWR0aD0iMjU2cHgiIGhlaWdodD0iMjYwcHgiIHZpZXdCb3g9IjAgMCAyNTYgMjYwIiB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHByZXNlcnZlQXNwZWN0UmF0aW89InhNaWRZTWlkIj4KICAgIDx0aXRsZT5PcGVuQUk8L3RpdGxlPgogICAgPGc+CiAgICAgICAgPHBhdGggZD0iTTIzOS4xODM5MTQsMTA2LjIwMjc4MyBDMjQ1LjA1NDMwNCw4OC41MjQyMDk2IDI0My4wMjIyOCw2OS4xNzMzODA1IDIzMy42MDc1OTksNTMuMDk5ODg2NCBDMjE5LjQ1MTY3OCwyOC40NTg4MDIxIDE5MC45OTk3MDMsMTUuNzgzNjEyOSAxNjMuMjEzMDA3LDIxLjczOTUwNSBDMTQ3LjU1NDA3Nyw0LjMyMTQ1ODgzIDEyMy43OTQ5MDksLTMuNDIzOTg1NTQgMTAwLjg3OTAxLDEuNDE4NzM4OTggQzc3Ljk2MzExMDUsNi4yNjE0NjM0OSA1OS4zNjkwMDkzLDIyLjk1NzI1MzYgNTIuMDk1OTYyMSw0NS4yMjE0MjE5IEMzMy44NDM2NDk0LDQ4Ljk2NDQ4NjcgMTguMDkwMTcyMSw2MC4zOTI3NDkgOC44NjY3MjUxMyw3Ni41ODE4MDMzIEMtNS40NDM0OTEsMTAxLjE4Mjk2MiAtMi4xOTU0NDQzMSwxMzIuMjE1MjU1IDE2Ljg5ODY2NjIsMTUzLjMyMDA5NCBDMTEuMDA2MDg2NSwxNzAuOTkwNjU2IDEzLjAxOTcyODMsMTkwLjM0Mzk5MSAyMi40MjM4MjMxLDIwNi40MjI5OTEgQzM2LjU5NzU1NTMsMjMxLjA3MjM0NCA2NS4wNjgwMzQyLDI0My43NDY1NjYgOTIuODY5NTczOCwyMzcuNzgzMzcyIEMxMDUuMjM1NjM5LDI1MS43MDgyNDkgMTIzLjAwMTExMywyNTkuNjMwOTQyIDE0MS42MjM5NjgsMjU5LjUyNjkyIEMxNzAuMTA1MzU5LDI1OS41NTIxNjkgMTk1LjMzNzYxMSwyNDEuMTY1NzE4IDIwNC4wMzc3NzcsMjE0LjA0NTY2MSBDMjIyLjI4NzM0LDIxMC4yOTYzNTYgMjM4LjAzODQ4OSwxOTguODY5NzgzIDI0Ny4yNjcwMTQsMTgyLjY4NTI4IEMyNjEuNDA0NDUzLDE1OC4xMjc1MTUgMjU4LjE0MjQ5NCwxMjcuMjYyNzc1IDIzOS4xODM5MTQsMTA2LjIwMjc4MyBMMjM5LjE4MzkxNCwxMDYuMjAyNzgzIFogTTE0MS42MjM5NjgsMjQyLjU0MTIwNyBDMTMwLjI1NTY4MiwyNDIuNTU5MTc3IDExOS4yNDM4NzYsMjM4LjU3NDY0MiAxMTAuNTE5MzgxLDIzMS4yODYxOTcgTDExMi4wNTQxNDYsMjMwLjQxNjQ5NiBMMTYzLjcyNDU5NSwyMDAuNTkwODgxIEMxNjYuMzQwNjQ4LDE5OS4wNTY0NDQgMTY3Ljk1NDMyMSwxOTYuMjU2ODE4IDE2Ny45NzA3ODEsMTkzLjIyNDAwNSBMMTY3Ljk3MDc4MSwxMjAuMzczNzg4IEwxODkuODE1NjE0LDEzMy4wMTAwMjYgQzE5MC4wMzQxMzIsMTMzLjEyMTQyMyAxOTAuMTg2MjM1LDEzMy4zMzA1NjQgMTkwLjIyNDg4NSwxMzMuNTcyNzc0IEwxOTAuMjI0ODg1LDE5My45NDAyMjkgQzE5MC4xNjg2MDMsMjIwLjc1ODQyNyAxNjguNDQyMTY2LDI0Mi40ODQ4NjQgMTQxLjYyMzk2OCwyNDIuNTQxMjA3IFogTTM3LjE1NzU3NDksMTk3LjkzMDYyIEMzMS40NTY0OTgsMTg4LjA4NjM1OSAyOS40MDk0ODE4LDE3Ni41NDY5ODQgMzEuMzc2NjIzNywxNjUuMzQyNDI2IEwzMi45MTEzODk1LDE2Ni4yNjMyODUgTDg0LjYzMjk5NzMsMTk2LjA4ODkwMSBDODcuMjM4OTM0OSwxOTcuNjE4MjA3IDkwLjQ2ODI3MTcsMTk3LjYxODIwNyA5My4wNzQyMDkzLDE5Ni4wODg5MDEgTDE1Ni4yNTU0MDIsMTU5LjY2Mzc5MyBMMTU2LjI1NTQwMiwxODQuODg1MTExIEMxNTYuMjQzNTU3LDE4NS4xNDk3NzEgMTU2LjExMTcyNSwxODUuMzk0NjAyIDE1NS44OTcyOSwxODUuNTUwMTc2IEwxMDMuNTYxNzc2LDIxNS43MzM5MDMgQzgwLjMwNTQ5NTMsMjI5LjEzMTYzMiA1MC41OTI0OTU0LDIyMS4xNjU0MzUgMzcuMTU3NTc0OSwxOTcuOTMwNjIgWiBNMjMuNTQ5MzE4MSw4NS4zODExMjczIEMyOS4yODk5ODYxLDc1LjQ3MzMwOTcgMzguMzUxMTkxMSw2Ny45MTYyNjQ4IDQ5LjEyODc0ODIsNjQuMDQ3ODgyNSBMNDkuMTI4NzQ4MiwxMjUuNDM4NTE1IEM0OS4wODkxNDkyLDEyOC40NTk0MjUgNTAuNjk2NTM4NiwxMzEuMjYyNTU2IDUzLjMyMzc3NDgsMTMyLjc1NDIzMiBMMTE2LjE5ODAxNCwxNjkuMDI1ODY0IEw5NC4zNTMxODA4LDE4MS42NjIxMDIgQzk0LjExMzIzMjUsMTgxLjc4OTQzNCA5My44MjU3NDYxLDE4MS43ODk0MzQgOTMuNTg1Nzk3OSwxODEuNjYyMTAyIEw0MS4zNTI2MDE1LDE1MS41Mjk1MzQgQzE4LjE0MTk0MjYsMTM4LjA3NjA5OCAxMC4xODE3NjgxLDEwOC4zODU1NjIgMjMuNTQ5MzE4MSw4NS4xMjUzMzMgTDIzLjU0OTMxODEsODUuMzgxMTI3MyBaIE0yMDMuMDE0NiwxMjcuMDc1NTk4IEwxMzkuOTM1NzI1LDkwLjQ0NTg1NDUgTDE2MS43Mjk0LDc3Ljg2MDc3NDggQzE2MS45NjkzNDgsNzcuNzMzNDQzNCAxNjIuMjU2ODM0LDc3LjczMzQ0MzQgMTYyLjQ5Njc4Myw3Ny44NjA3NzQ4IEwyMTQuNzI5OTc5LDEwOC4wNDQ1MDIgQzIzMS4wMzIzMjksMTE3LjQ1MTc0NyAyNDAuNDM3Mjk0LDEzNS40MjYxMDkgMjM4Ljg3MTUwNCwxNTQuMTgyNzM5IEMyMzcuMzA1NzE0LDE3Mi45MzkzNjggMjI1LjA1MDcxOSwxODkuMTA1NTcyIDIwNy40MTQyNjIsMTk1LjY3OTYzIEwyMDcuNDE0MjYyLDEzNC4yODg5OTggQzIwNy4zMjI1MjEsMTMxLjI3Njg2NyAyMDUuNjUwNjk3LDEyOC41MzU4NTMgMjAzLjAxNDYsMTI3LjA3NTU5OCBaIE0yMjQuNzU3MTE2LDk0LjM4NTA4NjcgTDIyMy4yMjIzNSw5My40NjQyMjcyIEwxNzEuNjAzMDYsNjMuMzgyODE3MyBDMTY4Ljk4MTI5Myw2MS44NDQzNzUxIDE2NS43MzI0NTYsNjEuODQ0Mzc1MSAxNjMuMTEwNjg5LDYzLjM4MjgxNzMgTDk5Ljk4MDY1NTQsOTkuODA3OTI1OSBMOTkuOTgwNjU1NCw3NC41ODY2MDc3IEM5OS45NTMzMDA0LDc0LjMyNTQwODggMTAwLjA3MTA5NSw3NC4wNzAxODY5IDEwMC4yODc2MDksNzMuOTIxNTQyNiBMMTUyLjUyMDgwNSw0My43ODg5NzM4IEMxNjguODYzMDk4LDM0LjM3NDM1MTggMTg5LjE3NDI1NiwzNS4yNTI5MDQzIDIwNC42NDI1NzksNDYuMDQzNDg0MSBDMjIwLjExMDkwMyw1Ni44MzQwNjM4IDIyNy45NDkyNjksNzUuNTkyMzk1OSAyMjQuNzU3MTE2LDk0LjE4MDQ1MTMgTDIyNC43NTcxMTYsOTQuMzg1MDg2NyBaIE04OC4wNjA2NDA5LDEzOS4wOTc5MzEgTDY2LjIxNTgwNzYsMTI2LjUxMjg1MSBDNjUuOTk1MDM5OSwxMjYuMzc5MDkxIDY1Ljg0NTA5NjUsMTI2LjE1NDE3NiA2NS44MDY1MzY3LDEyNS44OTg5NDUgTDY1LjgwNjUzNjcsNjUuNjg0OTY2IEM2NS44MzE0NDk1LDQ2LjgyODUzNjcgNzYuNzUwMDYwNSwyOS42ODQ2MDMyIDkzLjgyNzA4NTIsMjEuNjg4MzA1NSBDMTEwLjkwNDExLDEzLjY5MjAwNzkgMTMxLjA2MzgzMywxNi4yODM1NDYyIDE0NS41NjMyLDI4LjMzODk5OCBMMTQ0LjAyODQzNCwyOS4yMDg2OTg2IEw5Mi4zNTc5ODUyLDU5LjAzNDMxNDIgQzg5Ljc0MTkzMjcsNjAuNTY4NzUxMyA4OC4xMjgyNTk3LDYzLjM2ODM3NjcgODguMTExNzk5OCw2Ni40MDExOTAxIEw4OC4wNjA2NDA5LDEzOS4wOTc5MzEgWiBNOTkuOTI5NDk2NSwxMTMuNTE4NSBMMTI4LjA2Njg3LDk3LjMwMTE0MTcgTDE1Ni4yNTU0MDIsMTEzLjUxODUgTDE1Ni4yNTU0MDIsMTQ1Ljk1MzIxOCBMMTI4LjE2OTE4NywxNjIuMTcwNTc3IEw5OS45ODA2NTU0LDE0NS45NTMyMTggTDk5LjkyOTQ5NjUsMTEzLjUxODUgWiIgZmlsbD0iIzAwMDAwMCI+PC9wYXRoPgogICAgPC9nPgo8L3N2Zz4K">
+        <bpmn:documentation>Let an email expert system generate an email to clarify information from the tax submission. You don't need to focus on the actual email text, but to give all the neexed context to the expert system.</bpmn:documentation>
+        <bpmn:extensionElements>
+          <zeebe:taskDefinition type="io.camunda:http-json:1" />
+          <zeebe:ioMapping>
+            <zeebe:input source="bearer" target="authentication.type" />
+            <zeebe:input source="{{secrets.OPENAI_API_KEY}}" target="authentication.token" />
+            <zeebe:input source="=if is defined(internal_organization) and internal_organization != null then {&#34;Content-Type&#34;:&#34;application/json&#34;, &#34;OpenAI-Organization&#34;:internal_organization} else {&#34;Content-Type&#34;:&#34;application/json&#34;}" target="headers" />
+            <zeebe:input source="chat" target="operation" />
+            <zeebe:input source="post" target="method" />
+            <zeebe:input source="https://api.openai.com/v1/chat/completions" target="url" />
+            <zeebe:input source="gpt-3.5-turbo" target="internal_model" />
+            <zeebe:input source="1" target="internal_temperature" />
+            <zeebe:input source="You are an e-mail generator. If you need to create a signature, call yourself &#34;Tax Verifcation Authority&#34;." target="internal_systemMessage" />
+            <zeebe:input source="=&#34;I&#39;d like you to generate an email inquiry to a user who submitted a tax form and where more clarification is needed. You will receive the initial submission and a rough outline on which points need to be clarified. Generate a polite e-mail text asking for the needed information. Return only the e-mail body, no additional messages.\n\n&#60;taxSubmission&#62;&#34; + fromAi(toolCall.taxSubmission, &#34;Summarize the tax submission which was provided by the user&#34;) + &#34;\n&#60;/taxSubmission&#62;\n&#60;whatToClarify&#62;\n&#34; + fromAi(toolCall.whatToClarify, &#34;Which parts of the tax submission need clarification. Make sure to insist in case the user did not provide the right information.&#34;) + &#34;\n&#60;/whatToClarify&#62;&#34;" target="internal_prompt" />
+            <zeebe:input source="1" target="internal_choices" />
+            <zeebe:input source="=append(concatenate(if is defined(internal_systemMessage) then [{&#34;role&#34;: &#34;system&#34;, &#34;content&#34;: internal_systemMessage}] else [], if is defined(internal_chatHistory) then internal_chatHistory else []), {&#34;role&#34;: &#34;user&#34;, &#34;content&#34;: internal_prompt})" target="internal_messages" />
+            <zeebe:input source="={&#34;model&#34;: if is defined(internal_custom_model) then internal_custom_model else internal_model, &#34;messages&#34;: internal_messages, &#34;n&#34;: number(internal_choices), &#34;temperature&#34;: number(internal_temperature)}" target="body" />
+            <zeebe:input source="30" target="connectionTimeoutInSeconds" />
+          </zeebe:ioMapping>
+          <zeebe:taskHeaders>
+            <zeebe:header key="resultExpression" value="={&#10;  emailBody: response.body.choices[1].message.content&#10;}" />
+          </zeebe:taskHeaders>
+        </bpmn:extensionElements>
+        <bpmn:outgoing>Flow_0uh3nkx</bpmn:outgoing>
+      </bpmn:serviceTask>
+      <bpmn:exclusiveGateway id="Gateway_04sl072" name="Is Fraud Detected?" default="Flow_1y3onm8">
+        <bpmn:incoming>Flow_02dr109</bpmn:incoming>
+        <bpmn:outgoing>Flow_1ex155v</bpmn:outgoing>
+        <bpmn:outgoing>Flow_1y3onm8</bpmn:outgoing>
+      </bpmn:exclusiveGateway>
+      <bpmn:sequenceFlow id="Flow_1y3onm8" name="No" sourceRef="Gateway_04sl072" targetRef="Event_0ut60ps" />
+      <bpmn:intermediateThrowEvent id="Event_0ut60ps" name="No Fraud!">
+        <bpmn:extensionElements />
+        <bpmn:incoming>Flow_1y3onm8</bpmn:incoming>
+      </bpmn:intermediateThrowEvent>
+      <bpmn:intermediateThrowEvent id="Event_0gnk722" name="Throw Fraud">
+        <bpmn:extensionElements>
+          <zeebe:ioMapping>
+            <zeebe:output source="=toolCallResult.expertAnalysis" target="expertAnalysis" />
+            <zeebe:output source="=agentAnalysis" target="agentAnalysis" />
+          </zeebe:ioMapping>
+        </bpmn:extensionElements>
+        <bpmn:incoming>Flow_1plqcas</bpmn:incoming>
+        <bpmn:incoming>Flow_1ex155v</bpmn:incoming>
+        <bpmn:escalationEventDefinition id="EscalationEventDefinition_1a0n3ld" escalationRef="Escalation_3eekq60" />
+      </bpmn:intermediateThrowEvent>
+      <bpmn:sequenceFlow id="Flow_1ex155v" name="Yes" sourceRef="Gateway_04sl072" targetRef="Event_0gnk722">
+        <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=toolCallResult.fraudDetected</bpmn:conditionExpression>
+      </bpmn:sequenceFlow>
+      <bpmn:sequenceFlow id="Flow_0uh3nkx" sourceRef="EmailInquiry" targetRef="Activity_1yge9uw" />
+      <bpmn:userTask id="Activity_087ozlu" name="User response">
+        <bpmn:extensionElements>
+          <zeebe:userTask />
+          <zeebe:formDefinition formId="fraud-detection-process-send-email" />
+          <zeebe:ioMapping>
+            <zeebe:output source="={&#10;  userResponse: userResponse&#10;}" target="toolCallResult" />
+          </zeebe:ioMapping>
+        </bpmn:extensionElements>
+        <bpmn:incoming>Flow_04fnx3s</bpmn:incoming>
+      </bpmn:userTask>
+      <bpmn:sequenceFlow id="Flow_04fnx3s" sourceRef="Activity_1yge9uw" targetRef="Activity_087ozlu" />
+      <bpmn:task id="Activity_1yge9uw" name="Send e-mail">
+        <bpmn:incoming>Flow_0uh3nkx</bpmn:incoming>
+        <bpmn:outgoing>Flow_04fnx3s</bpmn:outgoing>
+      </bpmn:task>
+    </bpmn:adHocSubProcess>
+    <bpmn:serviceTask id="RunFinalCheck" name="Run Final Check on Result" zeebe:modelerTemplate="io.camunda.connectors.OpenAI.v1" zeebe:modelerTemplateVersion="5" zeebe:modelerTemplateIcon="data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPHN2ZyB3aWR0aD0iMjU2cHgiIGhlaWdodD0iMjYwcHgiIHZpZXdCb3g9IjAgMCAyNTYgMjYwIiB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHByZXNlcnZlQXNwZWN0UmF0aW89InhNaWRZTWlkIj4KICAgIDx0aXRsZT5PcGVuQUk8L3RpdGxlPgogICAgPGc+CiAgICAgICAgPHBhdGggZD0iTTIzOS4xODM5MTQsMTA2LjIwMjc4MyBDMjQ1LjA1NDMwNCw4OC41MjQyMDk2IDI0My4wMjIyOCw2OS4xNzMzODA1IDIzMy42MDc1OTksNTMuMDk5ODg2NCBDMjE5LjQ1MTY3OCwyOC40NTg4MDIxIDE5MC45OTk3MDMsMTUuNzgzNjEyOSAxNjMuMjEzMDA3LDIxLjczOTUwNSBDMTQ3LjU1NDA3Nyw0LjMyMTQ1ODgzIDEyMy43OTQ5MDksLTMuNDIzOTg1NTQgMTAwLjg3OTAxLDEuNDE4NzM4OTggQzc3Ljk2MzExMDUsNi4yNjE0NjM0OSA1OS4zNjkwMDkzLDIyLjk1NzI1MzYgNTIuMDk1OTYyMSw0NS4yMjE0MjE5IEMzMy44NDM2NDk0LDQ4Ljk2NDQ4NjcgMTguMDkwMTcyMSw2MC4zOTI3NDkgOC44NjY3MjUxMyw3Ni41ODE4MDMzIEMtNS40NDM0OTEsMTAxLjE4Mjk2MiAtMi4xOTU0NDQzMSwxMzIuMjE1MjU1IDE2Ljg5ODY2NjIsMTUzLjMyMDA5NCBDMTEuMDA2MDg2NSwxNzAuOTkwNjU2IDEzLjAxOTcyODMsMTkwLjM0Mzk5MSAyMi40MjM4MjMxLDIwNi40MjI5OTEgQzM2LjU5NzU1NTMsMjMxLjA3MjM0NCA2NS4wNjgwMzQyLDI0My43NDY1NjYgOTIuODY5NTczOCwyMzcuNzgzMzcyIEMxMDUuMjM1NjM5LDI1MS43MDgyNDkgMTIzLjAwMTExMywyNTkuNjMwOTQyIDE0MS42MjM5NjgsMjU5LjUyNjkyIEMxNzAuMTA1MzU5LDI1OS41NTIxNjkgMTk1LjMzNzYxMSwyNDEuMTY1NzE4IDIwNC4wMzc3NzcsMjE0LjA0NTY2MSBDMjIyLjI4NzM0LDIxMC4yOTYzNTYgMjM4LjAzODQ4OSwxOTguODY5NzgzIDI0Ny4yNjcwMTQsMTgyLjY4NTI4IEMyNjEuNDA0NDUzLDE1OC4xMjc1MTUgMjU4LjE0MjQ5NCwxMjcuMjYyNzc1IDIzOS4xODM5MTQsMTA2LjIwMjc4MyBMMjM5LjE4MzkxNCwxMDYuMjAyNzgzIFogTTE0MS42MjM5NjgsMjQyLjU0MTIwNyBDMTMwLjI1NTY4MiwyNDIuNTU5MTc3IDExOS4yNDM4NzYsMjM4LjU3NDY0MiAxMTAuNTE5MzgxLDIzMS4yODYxOTcgTDExMi4wNTQxNDYsMjMwLjQxNjQ5NiBMMTYzLjcyNDU5NSwyMDAuNTkwODgxIEMxNjYuMzQwNjQ4LDE5OS4wNTY0NDQgMTY3Ljk1NDMyMSwxOTYuMjU2ODE4IDE2Ny45NzA3ODEsMTkzLjIyNDAwNSBMMTY3Ljk3MDc4MSwxMjAuMzczNzg4IEwxODkuODE1NjE0LDEzMy4wMTAwMjYgQzE5MC4wMzQxMzIsMTMzLjEyMTQyMyAxOTAuMTg2MjM1LDEzMy4zMzA1NjQgMTkwLjIyNDg4NSwxMzMuNTcyNzc0IEwxOTAuMjI0ODg1LDE5My45NDAyMjkgQzE5MC4xNjg2MDMsMjIwLjc1ODQyNyAxNjguNDQyMTY2LDI0Mi40ODQ4NjQgMTQxLjYyMzk2OCwyNDIuNTQxMjA3IFogTTM3LjE1NzU3NDksMTk3LjkzMDYyIEMzMS40NTY0OTgsMTg4LjA4NjM1OSAyOS40MDk0ODE4LDE3Ni41NDY5ODQgMzEuMzc2NjIzNywxNjUuMzQyNDI2IEwzMi45MTEzODk1LDE2Ni4yNjMyODUgTDg0LjYzMjk5NzMsMTk2LjA4ODkwMSBDODcuMjM4OTM0OSwxOTcuNjE4MjA3IDkwLjQ2ODI3MTcsMTk3LjYxODIwNyA5My4wNzQyMDkzLDE5Ni4wODg5MDEgTDE1Ni4yNTU0MDIsMTU5LjY2Mzc5MyBMMTU2LjI1NTQwMiwxODQuODg1MTExIEMxNTYuMjQzNTU3LDE4NS4xNDk3NzEgMTU2LjExMTcyNSwxODUuMzk0NjAyIDE1NS44OTcyOSwxODUuNTUwMTc2IEwxMDMuNTYxNzc2LDIxNS43MzM5MDMgQzgwLjMwNTQ5NTMsMjI5LjEzMTYzMiA1MC41OTI0OTU0LDIyMS4xNjU0MzUgMzcuMTU3NTc0OSwxOTcuOTMwNjIgWiBNMjMuNTQ5MzE4MSw4NS4zODExMjczIEMyOS4yODk5ODYxLDc1LjQ3MzMwOTcgMzguMzUxMTkxMSw2Ny45MTYyNjQ4IDQ5LjEyODc0ODIsNjQuMDQ3ODgyNSBMNDkuMTI4NzQ4MiwxMjUuNDM4NTE1IEM0OS4wODkxNDkyLDEyOC40NTk0MjUgNTAuNjk2NTM4NiwxMzEuMjYyNTU2IDUzLjMyMzc3NDgsMTMyLjc1NDIzMiBMMTE2LjE5ODAxNCwxNjkuMDI1ODY0IEw5NC4zNTMxODA4LDE4MS42NjIxMDIgQzk0LjExMzIzMjUsMTgxLjc4OTQzNCA5My44MjU3NDYxLDE4MS43ODk0MzQgOTMuNTg1Nzk3OSwxODEuNjYyMTAyIEw0MS4zNTI2MDE1LDE1MS41Mjk1MzQgQzE4LjE0MTk0MjYsMTM4LjA3NjA5OCAxMC4xODE3NjgxLDEwOC4zODU1NjIgMjMuNTQ5MzE4MSw4NS4xMjUzMzMgTDIzLjU0OTMxODEsODUuMzgxMTI3MyBaIE0yMDMuMDE0NiwxMjcuMDc1NTk4IEwxMzkuOTM1NzI1LDkwLjQ0NTg1NDUgTDE2MS43Mjk0LDc3Ljg2MDc3NDggQzE2MS45NjkzNDgsNzcuNzMzNDQzNCAxNjIuMjU2ODM0LDc3LjczMzQ0MzQgMTYyLjQ5Njc4Myw3Ny44NjA3NzQ4IEwyMTQuNzI5OTc5LDEwOC4wNDQ1MDIgQzIzMS4wMzIzMjksMTE3LjQ1MTc0NyAyNDAuNDM3Mjk0LDEzNS40MjYxMDkgMjM4Ljg3MTUwNCwxNTQuMTgyNzM5IEMyMzcuMzA1NzE0LDE3Mi45MzkzNjggMjI1LjA1MDcxOSwxODkuMTA1NTcyIDIwNy40MTQyNjIsMTk1LjY3OTYzIEwyMDcuNDE0MjYyLDEzNC4yODg5OTggQzIwNy4zMjI1MjEsMTMxLjI3Njg2NyAyMDUuNjUwNjk3LDEyOC41MzU4NTMgMjAzLjAxNDYsMTI3LjA3NTU5OCBaIE0yMjQuNzU3MTE2LDk0LjM4NTA4NjcgTDIyMy4yMjIzNSw5My40NjQyMjcyIEwxNzEuNjAzMDYsNjMuMzgyODE3MyBDMTY4Ljk4MTI5Myw2MS44NDQzNzUxIDE2NS43MzI0NTYsNjEuODQ0Mzc1MSAxNjMuMTEwNjg5LDYzLjM4MjgxNzMgTDk5Ljk4MDY1NTQsOTkuODA3OTI1OSBMOTkuOTgwNjU1NCw3NC41ODY2MDc3IEM5OS45NTMzMDA0LDc0LjMyNTQwODggMTAwLjA3MTA5NSw3NC4wNzAxODY5IDEwMC4yODc2MDksNzMuOTIxNTQyNiBMMTUyLjUyMDgwNSw0My43ODg5NzM4IEMxNjguODYzMDk4LDM0LjM3NDM1MTggMTg5LjE3NDI1NiwzNS4yNTI5MDQzIDIwNC42NDI1NzksNDYuMDQzNDg0MSBDMjIwLjExMDkwMyw1Ni44MzQwNjM4IDIyNy45NDkyNjksNzUuNTkyMzk1OSAyMjQuNzU3MTE2LDk0LjE4MDQ1MTMgTDIyNC43NTcxMTYsOTQuMzg1MDg2NyBaIE04OC4wNjA2NDA5LDEzOS4wOTc5MzEgTDY2LjIxNTgwNzYsMTI2LjUxMjg1MSBDNjUuOTk1MDM5OSwxMjYuMzc5MDkxIDY1Ljg0NTA5NjUsMTI2LjE1NDE3NiA2NS44MDY1MzY3LDEyNS44OTg5NDUgTDY1LjgwNjUzNjcsNjUuNjg0OTY2IEM2NS44MzE0NDk1LDQ2LjgyODUzNjcgNzYuNzUwMDYwNSwyOS42ODQ2MDMyIDkzLjgyNzA4NTIsMjEuNjg4MzA1NSBDMTEwLjkwNDExLDEzLjY5MjAwNzkgMTMxLjA2MzgzMywxNi4yODM1NDYyIDE0NS41NjMyLDI4LjMzODk5OCBMMTQ0LjAyODQzNCwyOS4yMDg2OTg2IEw5Mi4zNTc5ODUyLDU5LjAzNDMxNDIgQzg5Ljc0MTkzMjcsNjAuNTY4NzUxMyA4OC4xMjgyNTk3LDYzLjM2ODM3NjcgODguMTExNzk5OCw2Ni40MDExOTAxIEw4OC4wNjA2NDA5LDEzOS4wOTc5MzEgWiBNOTkuOTI5NDk2NSwxMTMuNTE4NSBMMTI4LjA2Njg3LDk3LjMwMTE0MTcgTDE1Ni4yNTU0MDIsMTEzLjUxODUgTDE1Ni4yNTU0MDIsMTQ1Ljk1MzIxOCBMMTI4LjE2OTE4NywxNjIuMTcwNTc3IEw5OS45ODA2NTU0LDE0NS45NTMyMTggTDk5LjkyOTQ5NjUsMTEzLjUxODUgWiIgZmlsbD0iIzAwMDAwMCI+PC9wYXRoPgogICAgPC9nPgo8L3N2Zz4K">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="io.camunda:http-json:1" />
+        <zeebe:ioMapping>
+          <zeebe:input source="bearer" target="authentication.type" />
+          <zeebe:input source="{{secrets.OPENAI_API_KEY}}" target="authentication.token" />
+          <zeebe:input source="=if is defined(internal_organization) and internal_organization != null then {&#34;Content-Type&#34;:&#34;application/json&#34;, &#34;OpenAI-Organization&#34;:internal_organization} else {&#34;Content-Type&#34;:&#34;application/json&#34;}" target="headers" />
+          <zeebe:input source="chat" target="operation" />
+          <zeebe:input source="post" target="method" />
+          <zeebe:input source="https://api.openai.com/v1/chat/completions" target="url" />
+          <zeebe:input source="gpt-4o" target="internal_model" />
+          <zeebe:input source="1" target="internal_temperature" />
+          <zeebe:input source="You are verifying the decision of a fraud detection process based on a tax submission. You will receive a conversation history with another model as input and need to decide if you agree with this submission being valid. &#10;&#10;If you decide the submission is no fraud, simply answer with &#39;yes&#39; (no quotes, tags or other text).&#10;&#10;If you think it can still be fraud, answer with your suggestion in &#60;fraudVerification&#62;&#60;/fraudVerification&#62; tags." target="internal_systemMessage" />
+          <zeebe:input source="=&#34;&#60;history&#62;&#34; + string(agent.context.memory) + &#34;&#60;/history&#62;&#34;" target="internal_prompt" />
+          <zeebe:input source="1" target="internal_choices" />
+          <zeebe:input source="=append(concatenate(if is defined(internal_systemMessage) then [{&#34;role&#34;: &#34;system&#34;, &#34;content&#34;: internal_systemMessage}] else [], if is defined(internal_chatHistory) then internal_chatHistory else []), {&#34;role&#34;: &#34;user&#34;, &#34;content&#34;: internal_prompt})" target="internal_messages" />
+          <zeebe:input source="={&#34;model&#34;: if is defined(internal_custom_model) then internal_custom_model else internal_model, &#34;messages&#34;: internal_messages, &#34;n&#34;: number(internal_choices), &#34;temperature&#34;: number(internal_temperature)}" target="body" />
+          <zeebe:input source="30" target="connectionTimeoutInSeconds" />
+        </zeebe:ioMapping>
+        <zeebe:taskHeaders>
+          <zeebe:header key="resultExpression" value="={&#10;  finalCheck: response.body.choices[1].message.content&#10;}" />
+        </zeebe:taskHeaders>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_0fo3u1d</bpmn:incoming>
+      <bpmn:outgoing>Flow_0nriff3</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:exclusiveGateway id="Gateway_0y12zon" name="Decision Made?" default="Flow_1yea5o1">
+      <bpmn:incoming>Flow_0nriff3</bpmn:incoming>
+      <bpmn:outgoing>Flow_1dqcrtw</bpmn:outgoing>
+      <bpmn:outgoing>Flow_1yea5o1</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:startEvent id="StartEvent_1" name="Enter Details of Tax">
+      <bpmn:extensionElements>
+        <zeebe:formDefinition formId="fraud-detection-process-enter-tax-form" />
+        <zeebe:properties>
+          <zeebe:property name="camunda:adHocActivityInputSchema" value="{&#34;taxSubmission&#34;: {&#34;fullName&#34;:&#34;Niall&#34;,&#34;nationalID&#34;:&#34;212133242&#34;,&#34;dob&#34;:&#34;2025-02-17&#34;,&#34;totalIncome&#34;:12,&#34;totalExpenses&#34;:1232143,&#34;largePurches&#34;:[&#34;car&#34;,&#34;stocks&#34;],&#34;charitableDonations&#34;:&#34;I gave 5 euro to a homeless man&#34;}}" />
+          <zeebe:property name="camundaModeler:exampleOutputJson" value="{&#34;taxSubmission&#34;: {&#34;fullName&#34;:&#34;John Smith&#34;,&#34;dob&#34;:&#34;1980-04-05&#34;,&#34;emailAddress&#34;:&#34;johnny.s@gmail.com&#34;,&#34;totalIncome&#34;:70000,&#34;totalExpenses&#34;:3500,&#34;largePurchases&#34;:[&#34;stocks&#34;],&#34;charitableDonations&#34;:&#34;I gave 5€ to a homeless man.&#34;}}" />
+        </zeebe:properties>
+      </bpmn:extensionElements>
+      <bpmn:outgoing>Flow_0ifqrnr</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_06y8gt9" sourceRef="Gateway_0cttbk8" targetRef="FraudDetectionAgent" />
+    <bpmn:sequenceFlow id="Flow_0ifqrnr" sourceRef="StartEvent_1" targetRef="Gateway_0cttbk8" />
+    <bpmn:sequenceFlow id="Flow_0nriff3" sourceRef="RunFinalCheck" targetRef="Gateway_0y12zon" />
+    <bpmn:sequenceFlow id="Flow_0udscr6" sourceRef="Event_01me1b4" targetRef="Event_1sxkleb" />
+    <bpmn:endEvent id="Event_1sxkleb" name="Fraud is detected">
+      <bpmn:incoming>Flow_0udscr6</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:exclusiveGateway id="Gateway_0cttbk8">
+      <bpmn:incoming>Flow_1yea5o1</bpmn:incoming>
+      <bpmn:incoming>Flow_1dc12gc</bpmn:incoming>
+      <bpmn:incoming>Flow_0ifqrnr</bpmn:incoming>
+      <bpmn:outgoing>Flow_06y8gt9</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="Flow_1yea5o1" name="No" sourceRef="Gateway_0y12zon" targetRef="Gateway_0cttbk8" />
+    <bpmn:endEvent id="Event_0vgcvn8" name="No Fraud Detected">
+      <bpmn:incoming>Flow_1dqcrtw</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:boundaryEvent id="Event_01me1b4" name="Throw Fraud" attachedToRef="Fraud_Tools">
+      <bpmn:outgoing>Flow_0udscr6</bpmn:outgoing>
+      <bpmn:escalationEventDefinition id="EscalationEventDefinition_12tppbv" escalationRef="Escalation_3eekq60" />
+    </bpmn:boundaryEvent>
+    <bpmn:sequenceFlow id="Flow_1dqcrtw" name="Yes" sourceRef="Gateway_0y12zon" targetRef="Event_0vgcvn8">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=finalCheck = "yes"</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:serviceTask id="FraudDetectionAgent" name="Fraud detection agent" zeebe:modelerTemplate="io.camunda.connectors.agenticai.aiagent.v0" zeebe:modelerTemplateVersion="0" zeebe:modelerTemplateIcon="data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPHN2ZyBpZD0iaWNvbiIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB3aWR0aD0iMzIiIGhlaWdodD0iMzIiIHZpZXdCb3g9IjAgMCAzMiAzMiI+CiAgPGRlZnM+CiAgICA8c3R5bGU+CiAgICAgIC5jbHMtMSB7CiAgICAgICAgZmlsbDogbm9uZTsKICAgICAgfQoKICAgICAgLmNscy0xLCAuY2xzLTIgewogICAgICAgIHN0cm9rZS13aWR0aDogMHB4OwogICAgICB9CiAgICA8L3N0eWxlPgogIDwvZGVmcz4KICA8cGF0aCBjbGFzcz0iY2xzLTIiIGQ9Im0yNywxOWMxLjY1NDMsMCwzLTEuMzQ1NywzLTNzLTEuMzQ1Ny0zLTMtM2MtMS4zMDIsMC0yLjQwMTYuODM4NC0yLjgxNTcsMmgtNS43NzAzbDcuMzAwOC03LjMwMDhjLjM5MTEuMTg3NS44MjM1LjMwMDgsMS4yODUyLjMwMDgsMS42NTQzLDAsMy0xLjM0NTcsMy0zcy0xLjM0NTctMy0zLTMtMywxLjM0NTctMywzYzAsLjQ2MTkuMTEzNS44OTQuMzAwNSwxLjI4NTJsLTguMzAwNSw4LjMwMDh2LTYuNTg1OWMwLTEuMTAyNS44OTctMiwyLTJoMnYtMmgtMmMtMS4yMDAyLDAtMi4yNjYxLjU0MjUtMywxLjM4MjMtLjczMzktLjgzOTgtMS43OTk4LTEuMzgyMy0zLTEuMzgyM2gtMWMtNC45NjI0LDAtOSw0LjAzNzEtOSw5djZjMCw0Ljk2MjksNC4wMzc2LDksOSw5aDFjMS4yMDAyLDAsMi4yNjYxLS41NDI1LDMtMS4zODIzLjczMzkuODM5OCwxLjc5OTgsMS4zODIzLDMsMS4zODIzaDJ2LTJoLTJjLTEuMTAzLDAtMi0uODk3NS0yLTJ2LTYuNTg1OWw4LjMwMDUsOC4zMDA4Yy0uMTg3LjM5MTEtLjMwMDUuODIzMi0uMzAwNSwxLjI4NTIsMCwxLjY1NDMsMS4zNDU3LDMsMywzczMtMS4zNDU3LDMtMy0xLjM0NTctMy0zLTNjLS40NjE3LDAtLjg5NC4xMTMzLTEuMjg1Mi4zMDA4bC03LjMwMDgtNy4zMDA4aDUuNzcwM2MuNDE0MSwxLjE2MTYsMS41MTM3LDIsMi44MTU3LDJabTAtNGMuNTUxMywwLDEsLjQ0ODIsMSwxcy0uNDQ4NywxLTEsMS0xLS40NDgyLTEtMSwuNDQ4Ny0xLDEtMVptMC0xMWMuNTUxNSwwLDEsLjQ0ODcsMSwxcy0uNDQ4NSwxLTEsMS0xLS40NDg3LTEtMSwuNDQ4NS0xLDEtMVptLTEzLDhoLTJ2MmgydjRoLTJjLTEuNjU0MywwLTMsMS4zNDU3LTMsM3YyaDJ2LTJjMC0uNTUxOC40NDg3LTEsMS0xaDJ2NGMwLDEuMTAyNS0uODk3LDItMiwyaC0xYy0zLjUxOTUsMC02LjQzMjQtMi42MTMzLTYuOTIwMi02aDEuOTIwMnYtMmgtMnYtNGgzYzEuNjU0MywwLDMtMS4zNDU3LDMtM3YtMmgtMnYyYzAsLjU1MTgtLjQ0ODcsMS0xLDFoLTIuOTIwMmMuNDg3OC0zLjM4NjcsMy40MDA2LTYsNi45MjAyLTZoMWMxLjEwMywwLDIsLjg5NzUsMiwydjRabTE0LDE1YzAsLjU1MTMtLjQ0ODUsMS0xLDFzLTEtLjQ0ODctMS0xLC40NDg1LTEsMS0xLDEsLjQ0ODcsMSwxWiIvPgogIDxyZWN0IGlkPSJfVHJhbnNwYXJlbnRfUmVjdGFuZ2xlXyIgZGF0YS1uYW1lPSImYW1wO2x0O1RyYW5zcGFyZW50IFJlY3RhbmdsZSZhbXA7Z3Q7IiBjbGFzcz0iY2xzLTEiIHdpZHRoPSIzMiIgaGVpZ2h0PSIzMiIvPgo8L3N2Zz4=">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="io.camunda.agenticai:aiagent:0" retries="0" />
+        <zeebe:ioMapping>
+          <zeebe:input source="bedrock" target="provider.type" />
+          <zeebe:input source="eu-central-1" target="provider.bedrock.region" />
+          <zeebe:input source="anthropic.claude-3-5-sonnet-20240620-v1:0" target="provider.bedrock.model.model" />
+          <zeebe:input source="credentials" target="provider.bedrock.authentication.type" />
+          <zeebe:input source="{{secrets.AWS_BEDROCK_ACCESS_KEY}}" target="provider.bedrock.authentication.accessKey" />
+          <zeebe:input source="{{secrets.AWS_BEDROCK_SECRET_KEY}}" target="provider.bedrock.authentication.secretKey" />
+          <zeebe:input source="=agent.context" target="data.context" />
+          <zeebe:input source="You are a fraud detection agent which needs to decide if a tax submission is fraud or not. You can decide on fraud right away and you can use a set of provided tools to gain more knowledge. &#10;&#10;You will receive the initial tax submission in &#60;taxSubmission&#62; tags and a follow up process might make suggestions on your decision which you should incorporate. If you detect a submission to be wildly wrong or a joke submission, directly flag it as fraud using the provided tool.&#10;&#10;You can call the same tool multiple times by providing different input values. Don&#39;t guess any tools which were not explicitely configured. If no tool matches the request, try to generate an answer. If you&#39;re not able to find a good answer, return with a message stating why you&#39;re not able to.&#10;&#10;Thinking, step by step, before you execute your tools, you think using the template `&#60;thinking&#62;&#60;context&#62;&#60;/context&#62;&#60;reflection&#62;&#60;/reflection&#62;&#60;/thinking&#62;`. When you are able to come to a decision, return it in a `&#60;fraudDecision&#62;&#60;fraud&#62;true|false&#60;/fraud&#62;&#60;verdict&#62;&#60;/verdict&#62;&#60;/fraudDecision&#62;` structure.&#10;&#10;The current date and time is: {{current_date_time}}" target="data.systemPrompt.prompt" />
+          <zeebe:input source="=if (is defined(finalCheck)) then&#10;  finalCheck&#10;else &#34;&#60;taxSubmission&#62;&#34; + string(taxSubmission) + &#34;&#60;/taxSubmission&#62;&#34;" target="data.userPrompt.prompt" />
+          <zeebe:input source="Fraud_Tools" target="data.tools.containerElementId" />
+          <zeebe:input source="=toolCallResults" target="data.tools.toolCallResults" />
+          <zeebe:input source="=20" target="data.memory.maxMessages" />
+          <zeebe:input source="=20" target="data.guardrails.maxModelCalls" />
+          <zeebe:input source="=8192" target="provider.bedrock.model.parameters.maxOutputTokens" />
+        </zeebe:ioMapping>
+        <zeebe:taskHeaders>
+          <zeebe:header key="resultVariable" value="agent" />
+          <zeebe:header key="resultExpression" value="={&#10;  agentResponse: response.chatResponse.text&#10;}" />
+          <zeebe:header key="retryBackoff" value="PT0S" />
+        </zeebe:taskHeaders>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_06y8gt9</bpmn:incoming>
+      <bpmn:outgoing>Flow_09px1dp</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:exclusiveGateway id="Gateway_0bukj01" name="Includes tool calls?" default="Flow_0fo3u1d">
+      <bpmn:incoming>Flow_09px1dp</bpmn:incoming>
+      <bpmn:outgoing>Flow_06sbwe8</bpmn:outgoing>
+      <bpmn:outgoing>Flow_0fo3u1d</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="Flow_06sbwe8" sourceRef="Gateway_0bukj01" targetRef="Fraud_Tools">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=not(is empty(agent.toolCalls))</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_09px1dp" sourceRef="FraudDetectionAgent" targetRef="Gateway_0bukj01" />
+    <bpmn:sequenceFlow id="Flow_1dc12gc" sourceRef="Fraud_Tools" targetRef="Gateway_0cttbk8" />
+    <bpmn:sequenceFlow id="Flow_0fo3u1d" sourceRef="Gateway_0bukj01" targetRef="RunFinalCheck" />
+    <bpmn:scriptTask id="Check_Fraud_Database" name="Check Fraud Database">
+      <bpmn:documentation>Consult the fraud database to check if the person is known as fradulent. If this returns FRAUD, the tax submission can be directly categorized as fraud.</bpmn:documentation>
+      <bpmn:extensionElements>
+        <zeebe:script expression="=if taxSubmission.emailAddress = &#34;johnny.s@gmail.com&#34; then &#34;FRAUD&#34; else &#34;NO FRAUD&#34;" resultVariable="toolCallResult" />
+      </bpmn:extensionElements>
+    </bpmn:scriptTask>
+    <bpmn:group id="Group_0yjli8o" categoryValueRef="CategoryValue_0ympg8h" />
+    <bpmn:textAnnotation id="TextAnnotation_0ch3sx4">
+      <bpmn:text>LLM as a judge</bpmn:text>
+    </bpmn:textAnnotation>
+    <bpmn:association id="Association_0lga9ob" associationDirection="None" sourceRef="TextAnnotation_0ch3sx4" targetRef="RunFinalCheck" />
+    <bpmn:textAnnotation id="TextAnnotation_0yrffgq">
+      <bpmn:text>Tool calling feedback loop</bpmn:text>
+    </bpmn:textAnnotation>
+    <bpmn:association id="Association_11mgikv" associationDirection="None" sourceRef="Flow_1dc12gc" targetRef="TextAnnotation_0yrffgq" />
+    <bpmn:textAnnotation id="TextAnnotation_1umfv2v">
+      <bpmn:text>LLM feedback loop</bpmn:text>
+    </bpmn:textAnnotation>
+    <bpmn:association id="Association_0abk3ku" associationDirection="None" sourceRef="Flow_1yea5o1" targetRef="TextAnnotation_1umfv2v" />
+  </bpmn:process>
+  <bpmn:escalation id="Escalation_3eekq60" name="FraudDetected" escalationCode="FraudDetected" />
+  <bpmn:error id="Error_1vkip6r" name="Fraud Error" errorCode="Fraud_Error" />
+  <bpmn:category id="Category_0wyof6z">
+    <bpmn:categoryValue id="CategoryValue_0ympg8h" value="Parked" />
+  </bpmn:category>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="fraud-detection-process">
+      <bpmndi:BPMNShape id="Activity_158b240_di" bpmnElement="Fraud_Tools" isExpanded="true">
+        <dc:Bounds x="360" y="340" width="480" height="420" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1rk6e27_di" bpmnElement="CallOnExternalAdvisor">
+        <dc:Bounds x="420" y="500" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_02hr6cv_di" bpmnElement="FraudDetected">
+        <dc:Bounds x="452" y="662" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="432" y="705" width="79" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0pk8zb7_di" bpmnElement="EmailInquiry">
+        <dc:Bounds x="420" y="380" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_04sl072_di" bpmnElement="Gateway_04sl072" isMarkerVisible="true">
+        <dc:Bounds x="595" y="515" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="595" y="485" width="51" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0ut60ps_di" bpmnElement="Event_0ut60ps">
+        <dc:Bounds x="722" y="522" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="716" y="565" width="49" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1vf3i1y_di" bpmnElement="Event_0gnk722">
+        <dc:Bounds x="602" y="662" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="589" y="705" width="63" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1oai29b_di" bpmnElement="Activity_087ozlu">
+        <dc:Bounds x="710" y="380" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_18gj1i3_di" bpmnElement="Activity_1yge9uw">
+        <dc:Bounds x="570" y="380" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_02dr109_di" bpmnElement="Flow_02dr109">
+        <di:waypoint x="520" y="540" />
+        <di:waypoint x="595" y="540" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1plqcas_di" bpmnElement="Flow_1plqcas">
+        <di:waypoint x="488" y="680" />
+        <di:waypoint x="602" y="680" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1y3onm8_di" bpmnElement="Flow_1y3onm8">
+        <di:waypoint x="645" y="540" />
+        <di:waypoint x="722" y="540" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="676" y="522" width="15" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1ex155v_di" bpmnElement="Flow_1ex155v">
+        <di:waypoint x="620" y="565" />
+        <di:waypoint x="620" y="662" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="626" y="611" width="18" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0uh3nkx_di" bpmnElement="Flow_0uh3nkx">
+        <di:waypoint x="520" y="420" />
+        <di:waypoint x="570" y="420" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_04fnx3s_di" bpmnElement="Flow_04fnx3s">
+        <di:waypoint x="670" y="420" />
+        <di:waypoint x="710" y="420" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="BPMNShape_1wybe8w" bpmnElement="RunFinalCheck">
+        <dc:Bounds x="740" y="198" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0y12zon_di" bpmnElement="Gateway_0y12zon" isMarkerVisible="true">
+        <dc:Bounds x="895" y="213" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="881" y="270" width="79" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="172" y="220" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="153" y="263" width="76" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1sxkleb_di" bpmnElement="Event_1sxkleb">
+        <dc:Bounds x="852" y="842" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="827" y="818" width="85" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0cttbk8_di" bpmnElement="Gateway_0cttbk8" isMarkerVisible="true">
+        <dc:Bounds x="255" y="213" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0vgcvn8_di" bpmnElement="Event_0vgcvn8">
+        <dc:Bounds x="1022" y="220" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1018" y="263" width="46" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0xj2598_di" bpmnElement="FraudDetectionAgent" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="360" y="198" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0bukj01_di" bpmnElement="Gateway_0bukj01" isMarkerVisible="true">
+        <dc:Bounds x="565" y="213" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="559" y="184" width="62" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1levbiy_di" bpmnElement="Check_Fraud_Database">
+        <dc:Bounds x="1210" y="580" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Group_0yjli8o_di" bpmnElement="Group_0yjli8o">
+        <dc:Bounds x="1190" y="530" width="300" height="300" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1323" y="537" width="35" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="TextAnnotation_0ch3sx4_di" bpmnElement="TextAnnotation_0ch3sx4">
+        <dc:Bounds x="790" y="110" width="100" height="26" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="TextAnnotation_0yrffgq_di" bpmnElement="TextAnnotation_0yrffgq">
+        <dc:Bounds x="130" y="360" width="100" height="41" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="TextAnnotation_1umfv2v_di" bpmnElement="TextAnnotation_1umfv2v">
+        <dc:Bounds x="130" y="102" width="100" height="41" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0gvn82i_di" bpmnElement="Event_01me1b4">
+        <dc:Bounds x="732" y="742" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="768" y="773" width="63" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_06y8gt9_di" bpmnElement="Flow_06y8gt9">
+        <di:waypoint x="305" y="238" />
+        <di:waypoint x="360" y="238" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0ifqrnr_di" bpmnElement="Flow_0ifqrnr">
+        <di:waypoint x="208" y="238" />
+        <di:waypoint x="255" y="238" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0nriff3_di" bpmnElement="Flow_0nriff3">
+        <di:waypoint x="840" y="238" />
+        <di:waypoint x="895" y="238" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0udscr6_di" bpmnElement="Flow_0udscr6">
+        <di:waypoint x="750" y="778" />
+        <di:waypoint x="750" y="860" />
+        <di:waypoint x="852" y="860" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1yea5o1_di" bpmnElement="Flow_1yea5o1">
+        <di:waypoint x="920" y="213" />
+        <di:waypoint x="920" y="80" />
+        <di:waypoint x="280" y="80" />
+        <di:waypoint x="280" y="213" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="952" y="165" width="15" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1dqcrtw_di" bpmnElement="Flow_1dqcrtw">
+        <di:waypoint x="945" y="238" />
+        <di:waypoint x="1022" y="238" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="975" y="220" width="18" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_06sbwe8_di" bpmnElement="Flow_06sbwe8">
+        <di:waypoint x="590" y="263" />
+        <di:waypoint x="590" y="340" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_09px1dp_di" bpmnElement="Flow_09px1dp">
+        <di:waypoint x="460" y="238" />
+        <di:waypoint x="565" y="238" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1dc12gc_di" bpmnElement="Flow_1dc12gc">
+        <di:waypoint x="360" y="410" />
+        <di:waypoint x="280" y="410" />
+        <di:waypoint x="280" y="263" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0fo3u1d_di" bpmnElement="Flow_0fo3u1d">
+        <di:waypoint x="615" y="238" />
+        <di:waypoint x="740" y="238" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Association_0lga9ob_di" bpmnElement="Association_0lga9ob">
+        <di:waypoint x="837" y="136" />
+        <di:waypoint x="798" y="198" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Association_11mgikv_di" bpmnElement="Association_11mgikv">
+        <di:waypoint x="280" y="358" />
+        <di:waypoint x="230" y="377" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Association_0abk3ku_di" bpmnElement="Association_0abk3ku">
+        <di:waypoint x="280" y="160" />
+        <di:waypoint x="230" y="140" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/connectors/agentic-ai/pom.xml
+++ b/connectors/agentic-ai/pom.xml
@@ -18,7 +18,6 @@
   <packaging>jar</packaging>
 
   <properties>
-    <version.langchain4j>1.0.0-beta3</version.langchain4j>
     <version.json-schema-validator>1.5.6</version.json-schema-validator>
   </properties>
 

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/JsonSchemaConstants.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/JsonSchemaConstants.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.agenticai;
+
+public abstract class JsonSchemaConstants {
+  private JsonSchemaConstants() {}
+
+  public static final String TYPE_OBJECT = "object";
+  public static final String TYPE_STRING = "string";
+  public static final String TYPE_NUMBER = "number";
+  public static final String TYPE_INTEGER = "integer";
+  public static final String TYPE_BOOLEAN = "boolean";
+  public static final String TYPE_ARRAY = "array";
+
+  public static final String PROPERTY_TYPE = "type";
+  public static final String PROPERTY_DESCRIPTION = "description";
+  public static final String PROPERTY_REQUIRED = "required";
+  public static final String PROPERTY_ADDITIONAL_PROPERTIES = "additionalProperties";
+  public static final String PROPERTY_PROPERTIES = "properties";
+  public static final String PROPERTY_ENUM = "enum";
+  public static final String PROPERTY_ITEMS = "items";
+}

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/adhoctoolsschema/feel/FeelFunctionInvocationExtractor.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/adhoctoolsschema/feel/FeelFunctionInvocationExtractor.java
@@ -13,7 +13,7 @@ import java.util.function.Predicate;
 import org.camunda.feel.syntaxtree.FunctionInvocation;
 import org.camunda.feel.syntaxtree.ParsedExpression;
 import scala.Product;
-import scala.collection.JavaConverters;
+import scala.jdk.javaapi.CollectionConverters;
 
 class FeelFunctionInvocationExtractor {
   private final Predicate<FunctionInvocation> functionPredicate;
@@ -46,7 +46,7 @@ class FeelFunctionInvocationExtractor {
       return functions;
     }
 
-    JavaConverters.asJava(product.productIterator())
+    CollectionConverters.asJava(product.productIterator())
         .forEachRemaining(
             obj -> {
               if (obj instanceof FunctionInvocation functionInvocation

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/adhoctoolsschema/feel/FeelFunctionInvocationExtractor.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/adhoctoolsschema/feel/FeelFunctionInvocationExtractor.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.agenticai.adhoctoolsschema.feel;
+
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.function.Predicate;
+import org.camunda.feel.syntaxtree.FunctionInvocation;
+import org.camunda.feel.syntaxtree.ParsedExpression;
+import scala.Product;
+import scala.collection.JavaConverters;
+
+class FeelFunctionInvocationExtractor {
+  private final Predicate<FunctionInvocation> functionPredicate;
+
+  public FeelFunctionInvocationExtractor(Predicate<FunctionInvocation> functionPredicate) {
+    this.functionPredicate = functionPredicate;
+  }
+
+  public static FeelFunctionInvocationExtractor forFunctionName(String functionName) {
+    return new FeelFunctionInvocationExtractor(
+        functionInvocation -> functionInvocation.function().equals(functionName));
+  }
+
+  public Set<FunctionInvocation> findMatchingFunctionInvocations(
+      ParsedExpression parsedExpression) {
+    final var results =
+        findMatchingFunctionInvocations(parsedExpression.expression(), new LinkedHashSet<>());
+    return Collections.unmodifiableSet(results);
+  }
+
+  private Set<FunctionInvocation> findMatchingFunctionInvocations(
+      Object object, Set<FunctionInvocation> functions) {
+    if (object instanceof FunctionInvocation functionInvocation
+        && isMatchingFunctionInvocation(functionInvocation)) {
+      functions.add(functionInvocation);
+      return functions;
+    }
+
+    if (!(object instanceof Product product)) {
+      return functions;
+    }
+
+    JavaConverters.asJava(product.productIterator())
+        .forEachRemaining(
+            obj -> {
+              if (obj instanceof FunctionInvocation functionInvocation
+                  && isMatchingFunctionInvocation(functionInvocation)) {
+                functions.add(functionInvocation);
+              } else {
+                findMatchingFunctionInvocations(obj, functions);
+              }
+            });
+
+    return functions;
+  }
+
+  private boolean isMatchingFunctionInvocation(FunctionInvocation functionInvocation) {
+    return functionPredicate.test(functionInvocation);
+  }
+}

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/adhoctoolsschema/feel/FeelFunctionInvocationExtractor.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/adhoctoolsschema/feel/FeelFunctionInvocationExtractor.java
@@ -37,7 +37,7 @@ class FeelFunctionInvocationExtractor {
   private Set<FunctionInvocation> findMatchingFunctionInvocations(
       Object object, Set<FunctionInvocation> functions) {
     if (object instanceof FunctionInvocation functionInvocation
-        && isMatchingFunctionInvocation(functionInvocation)) {
+        && functionPredicate.test(functionInvocation)) {
       functions.add(functionInvocation);
       return functions;
     }
@@ -50,7 +50,7 @@ class FeelFunctionInvocationExtractor {
         .forEachRemaining(
             obj -> {
               if (obj instanceof FunctionInvocation functionInvocation
-                  && isMatchingFunctionInvocation(functionInvocation)) {
+                  && functionPredicate.test(functionInvocation)) {
                 functions.add(functionInvocation);
               } else {
                 findMatchingFunctionInvocations(obj, functions);
@@ -58,9 +58,5 @@ class FeelFunctionInvocationExtractor {
             });
 
     return functions;
-  }
-
-  private boolean isMatchingFunctionInvocation(FunctionInvocation functionInvocation) {
-    return functionPredicate.test(functionInvocation);
   }
 }

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/adhoctoolsschema/feel/FeelInputParam.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/adhoctoolsschema/feel/FeelInputParam.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.agenticai.adhoctoolsschema.feel;
+
+import java.util.Map;
+
+public record FeelInputParam(
+    String name,
+    String description,
+    String type,
+    Map<String, Object> schema,
+    Map<String, Object> options) {
+
+  public FeelInputParam(String name) {
+    this(name, null, null, null, null);
+  }
+
+  public FeelInputParam(String name, String description) {
+    this(name, description, null, null, null);
+  }
+
+  public FeelInputParam(String name, String description, String type) {
+    this(name, description, type, null, null);
+  }
+
+  public FeelInputParam(String name, String description, String type, Map<String, Object> schema) {
+    this(name, description, type, schema, null);
+  }
+}

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/adhoctoolsschema/feel/FeelInputParamExtractor.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/adhoctoolsschema/feel/FeelInputParamExtractor.java
@@ -184,29 +184,4 @@ public class FeelInputParamExtractor {
       super(message);
     }
   }
-
-  public record FeelInputParam(
-      String name,
-      String description,
-      String type,
-      Map<String, Object> schema,
-      Map<String, Object> options) {
-
-    public FeelInputParam(String name) {
-      this(name, null, null, null, null);
-    }
-
-    public FeelInputParam(String name, String description) {
-      this(name, description, null, null, null);
-    }
-
-    public FeelInputParam(String name, String description, String type) {
-      this(name, description, type, null, null);
-    }
-
-    public FeelInputParam(
-        String name, String description, String type, Map<String, Object> schema) {
-      this(name, description, type, schema, null);
-    }
-  }
 }

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/adhoctoolsschema/feel/FeelInputParamExtractor.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/adhoctoolsschema/feel/FeelInputParamExtractor.java
@@ -25,7 +25,7 @@ import org.camunda.feel.syntaxtree.NamedFunctionParameters;
 import org.camunda.feel.syntaxtree.ParsedExpression;
 import org.camunda.feel.syntaxtree.PositionalFunctionParameters;
 import org.camunda.feel.syntaxtree.Ref;
-import scala.collection.JavaConverters;
+import scala.jdk.javaapi.CollectionConverters;
 
 public class FeelInputParamExtractor {
 
@@ -61,21 +61,18 @@ public class FeelInputParamExtractor {
     Set<FunctionInvocation> functionInvocations =
         extractor.findMatchingFunctionInvocations(parseResult.parsedExpression());
 
-    List<FeelInputParam> inputParams =
-        functionInvocations.stream().map(this::mapToInputParameter).toList();
-
-    return inputParams;
+    return functionInvocations.stream().map(this::mapToInputParameter).toList();
   }
 
   private FeelInputParam mapToInputParameter(FunctionInvocation functionInvocation) {
     return switch (functionInvocation.params()) {
       case PositionalFunctionParameters positionalFunctionParameters ->
           fromPositionalFunctionInvocationParams(
-              JavaConverters.asJava(positionalFunctionParameters.params()));
+              CollectionConverters.asJava(positionalFunctionParameters.params()));
 
       case NamedFunctionParameters namedFunctionParameters ->
           fromNamedFunctionInvocationParams(
-              JavaConverters.asJava(namedFunctionParameters.params()));
+              CollectionConverters.asJava(namedFunctionParameters.params()));
 
       default ->
           throw new RuntimeException(

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/adhoctoolsschema/feel/FeelInputParamExtractor.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/adhoctoolsschema/feel/FeelInputParamExtractor.java
@@ -81,14 +81,14 @@ public class FeelInputParamExtractor {
   }
 
   private FeelInputParam fromPositionalFunctionInvocationParams(List<Exp> params) {
-    if (params.isEmpty()) {
-      throw new RuntimeException("Expected parameter name as first parameter");
+    if (params.size() < 2) {
+      throw new RuntimeException("Expected parameter name as second parameter");
     }
 
-    final var name = params.get(0);
-    final var description = params.size() > 1 ? params.get(1) : null;
-    final var type = params.size() > 2 ? params.get(2) : null;
-    final var schema = params.size() > 3 ? params.get(3) : null;
+    final var name = params.get(1);
+    final var description = params.size() > 2 ? params.get(2) : null;
+    final var type = params.size() > 3 ? params.get(3) : null;
+    final var schema = params.size() > 4 ? params.get(4) : null;
 
     return fromFunctionInvocationParams(name, description, type, schema);
   }

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/adhoctoolsschema/feel/FeelInputParamExtractor.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/adhoctoolsschema/feel/FeelInputParamExtractor.java
@@ -117,7 +117,6 @@ public class FeelInputParamExtractor {
   }
 
   private String parameterName(Exp value) {
-    // TODO check for reserved names (e.g. _meta)
     if (!(value instanceof Ref valueRef)) {
       throw new FeelInputParamExtractionException(
           "Expected parameter 'value' to be a reference, but got '%s'"

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/adhoctoolsschema/feel/FeelInputParamExtractor.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/adhoctoolsschema/feel/FeelInputParamExtractor.java
@@ -107,6 +107,7 @@ public class FeelInputParamExtractor {
   }
 
   private String parameterName(Exp value) {
+    // TODO check for reserved names (e.g. _meta)
     if (!(value instanceof Ref valueRef)) {
       throw new FeelInputParamExtractionException(
           "Expected parameter 'value' to be a reference, but got '%s'"

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/adhoctoolsschema/feel/FeelInputParamExtractor.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/adhoctoolsschema/feel/FeelInputParamExtractor.java
@@ -48,7 +48,7 @@ public class FeelInputParamExtractor {
     this.scalaObjectMapper = objectMapper.copy().registerModule(new DefaultScalaModule());
   }
 
-  public List<FeelInputParam> extractInputParams(String expression) throws Exception {
+  public List<FeelInputParam> extractInputParams(String expression) {
     ParseResult parseResult = feelEngineApi.parseExpression(expression);
     if (parseResult.isFailure()) {
       throw new RuntimeException(
@@ -94,6 +94,7 @@ public class FeelInputParamExtractor {
   }
 
   private FeelInputParam fromNamedFunctionInvocationParams(Map<String, Exp> params) {
+    // TODO validate name is valid, not empty, ...
     if (!params.containsKey("name")) {
       throw new RuntimeException("Expected parameter name to be defined");
     }

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/adhoctoolsschema/feel/FeelInputParamExtractor.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/adhoctoolsschema/feel/FeelInputParamExtractor.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.agenticai.adhoctoolsschema.feel;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.module.scala.DefaultScalaModule;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.camunda.feel.api.EvaluationResult;
+import org.camunda.feel.api.FeelEngineApi;
+import org.camunda.feel.api.FeelEngineBuilder;
+import org.camunda.feel.api.ParseResult;
+import org.camunda.feel.syntaxtree.Exp;
+import org.camunda.feel.syntaxtree.FunctionInvocation;
+import org.camunda.feel.syntaxtree.NamedFunctionParameters;
+import org.camunda.feel.syntaxtree.ParsedExpression;
+import org.camunda.feel.syntaxtree.PositionalFunctionParameters;
+import scala.collection.JavaConverters;
+
+public class FeelInputParamExtractor {
+
+  private final FeelEngineApi feelEngineApi;
+
+  private final ObjectMapper objectMapper;
+  private final ObjectMapper scalaObjectMapper;
+
+  private final FeelFunctionInvocationExtractor extractor =
+      FeelFunctionInvocationExtractor.forFunctionName("fromAi");
+
+  public FeelInputParamExtractor() {
+    this(new ObjectMapper());
+  }
+
+  public FeelInputParamExtractor(ObjectMapper objectMapper) {
+    this(FeelEngineBuilder.create().build(), objectMapper);
+  }
+
+  public FeelInputParamExtractor(FeelEngineApi feelEngineApi, ObjectMapper objectMapper) {
+    this.feelEngineApi = feelEngineApi;
+    this.objectMapper = objectMapper;
+    this.scalaObjectMapper = objectMapper.copy().registerModule(new DefaultScalaModule());
+  }
+
+  public List<FeelInputParam> extractInputParams(String expression) throws Exception {
+    ParseResult parseResult = feelEngineApi.parseExpression(expression);
+    if (parseResult.isFailure()) {
+      throw new RuntimeException(
+          "Failed to parse FEEL expression: " + parseResult.failure().message());
+    }
+
+    Set<FunctionInvocation> functionInvocations =
+        extractor.findMatchingFunctionInvocations(parseResult.parsedExpression());
+
+    List<FeelInputParam> inputParams =
+        functionInvocations.stream().map(this::mapToInputParameter).toList();
+
+    return inputParams;
+  }
+
+  private FeelInputParam mapToInputParameter(FunctionInvocation functionInvocation) {
+    return switch (functionInvocation.params()) {
+      case PositionalFunctionParameters positionalFunctionParameters ->
+          fromPositionalFunctionInvocationParams(
+              JavaConverters.asJava(positionalFunctionParameters.params()));
+
+      case NamedFunctionParameters namedFunctionParameters ->
+          fromNamedFunctionInvocationParams(
+              JavaConverters.asJava(namedFunctionParameters.params()));
+
+      default ->
+          throw new RuntimeException(
+              "Unsupported function invocation: " + functionInvocation.params());
+    };
+  }
+
+  private FeelInputParam fromPositionalFunctionInvocationParams(List<Exp> params) {
+    if (params.isEmpty()) {
+      throw new RuntimeException("Expected parameter name as first parameter");
+    }
+
+    final var name = params.get(0);
+    final var description = params.size() > 1 ? params.get(1) : null;
+    final var type = params.size() > 2 ? params.get(2) : null;
+    final var schema = params.size() > 3 ? params.get(3) : null;
+
+    return fromFunctionInvocationParams(name, description, type, schema);
+  }
+
+  private FeelInputParam fromNamedFunctionInvocationParams(Map<String, Exp> params) {
+    if (!params.containsKey("name")) {
+      throw new RuntimeException("Expected parameter name to be defined");
+    }
+
+    return fromFunctionInvocationParams(
+        params.get("name"), params.get("description"), params.get("type"), params.get("schema"));
+  }
+
+  private FeelInputParam fromFunctionInvocationParams(
+      Exp name, Exp description, Exp type, Exp schema) {
+
+    final var nameVal = evaluateToString(name, "name");
+    final var descriptionVal = evaluateToString(description, "description");
+    final var typeVal = evaluateToString(type, "type");
+    final var schemaVal = evaluateToMap(schema, "schema");
+
+    return new FeelInputParam(nameVal, descriptionVal, typeVal, schemaVal);
+  }
+
+  private String evaluateToString(Exp exp, String parameterName) {
+    if (exp == null) {
+      return null;
+    }
+
+    try {
+      Object result = evaluate(exp);
+      if (!(result instanceof String resultString)) {
+        throw new FeelInputParamExtractionException(
+            "Expected parameter %s to be a string, but got: %s"
+                .formatted(parameterName, result.getClass().getName()));
+      }
+
+      return resultString;
+    } catch (Throwable e) {
+      throw new FeelInputParamExtractionException(
+          "Failed to evaluate parameter %s: %s".formatted(parameterName, e.getMessage()));
+    }
+  }
+
+  private Map<String, Object> evaluateToMap(Exp exp, String parameterName) {
+    if (exp == null) {
+      return null;
+    }
+
+    try {
+      Object result = evaluate(exp);
+      if (!(result instanceof scala.collection.Map<?, ?> resultMap)) {
+        throw new FeelInputParamExtractionException(
+            "Expected parameter %s to be a map, but got: %s"
+                .formatted(parameterName, result.getClass().getName()));
+      }
+
+      final var jsonSchemaString = scalaObjectMapper.writeValueAsString(resultMap);
+      return objectMapper.readValue(jsonSchemaString, new TypeReference<>() {});
+    } catch (Throwable e) {
+      throw new FeelInputParamExtractionException(
+          "Failed to evaluate parameter %s: %s".formatted(parameterName, e.getMessage()));
+    }
+  }
+
+  private Object evaluate(Exp exp) {
+    EvaluationResult result =
+        feelEngineApi.evaluate(new ParsedExpression(exp, ""), Collections.emptyMap());
+    if (result.isFailure()) {
+      throw new FeelInputParamExtractionException(
+          "Failed to evaluate expression: " + result.failure().message());
+    }
+
+    return result.result();
+  }
+
+  public static class FeelInputParamExtractionException extends RuntimeException {
+
+    public FeelInputParamExtractionException(String message) {
+      super(message);
+    }
+  }
+
+  public record FeelInputParam(
+      String name, String description, String type, Map<String, Object> schema) {}
+}

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/adhoctoolsschema/model/AdHocToolsSchemaResponse.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/adhoctoolsschema/model/AdHocToolsSchemaResponse.java
@@ -14,18 +14,6 @@ import java.util.Map;
 public record AdHocToolsSchemaResponse(List<AdHocToolDefinition> toolDefinitions) {
   @JsonInclude(JsonInclude.Include.NON_ABSENT)
   @JsonIgnoreProperties(ignoreUnknown = true)
-  public record AdHocToolDefinition(String name, String description, JsonSchema inputSchema) {
-
-    @JsonInclude(JsonInclude.Include.NON_ABSENT)
-    @JsonIgnoreProperties(ignoreUnknown = true)
-    public record JsonSchema(
-        String type,
-        Map<String, Object> properties,
-        List<String> required,
-        Boolean additionalProperties) {
-      public static JsonSchema empty() {
-        return new JsonSchema("object", Map.of(), List.of(), null);
-      }
-    }
-  }
+  public record AdHocToolDefinition(
+      String name, String description, Map<String, Object> inputSchema) {}
 }

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/adhoctoolsschema/resolver/CamundaClientAdHocToolsSchemaResolver.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/adhoctoolsschema/resolver/CamundaClientAdHocToolsSchemaResolver.java
@@ -6,6 +6,13 @@
  */
 package io.camunda.connector.agenticai.adhoctoolsschema.resolver;
 
+import static io.camunda.connector.agenticai.JsonSchemaConstants.PROPERTY_DESCRIPTION;
+import static io.camunda.connector.agenticai.JsonSchemaConstants.PROPERTY_PROPERTIES;
+import static io.camunda.connector.agenticai.JsonSchemaConstants.PROPERTY_REQUIRED;
+import static io.camunda.connector.agenticai.JsonSchemaConstants.PROPERTY_TYPE;
+import static io.camunda.connector.agenticai.JsonSchemaConstants.TYPE_OBJECT;
+import static io.camunda.connector.agenticai.JsonSchemaConstants.TYPE_STRING;
+
 import io.camunda.client.CamundaClient;
 import io.camunda.connector.agenticai.adhoctoolsschema.feel.FeelInputParamExtractor;
 import io.camunda.connector.agenticai.adhoctoolsschema.feel.FeelInputParamExtractor.FeelInputParam;
@@ -108,16 +115,16 @@ public class CamundaClientAdHocToolsSchemaResolver implements AdHocToolsSchemaRe
 
           // apply type from inputParam if it is set
           if (!StringUtils.isBlank(inputParam.type())) {
-            propertySchema.put("type", inputParam.type());
+            propertySchema.put(PROPERTY_TYPE, inputParam.type());
           }
 
           // default to string if no type is set (not on inputParam, not in schema directly)
-          if (!propertySchema.containsKey("type")) {
-            propertySchema.put("type", "string");
+          if (!propertySchema.containsKey(PROPERTY_TYPE)) {
+            propertySchema.put(PROPERTY_TYPE, TYPE_STRING);
           }
 
           if (!StringUtils.isBlank(inputParam.description())) {
-            propertySchema.put("description", inputParam.description());
+            propertySchema.put(PROPERTY_DESCRIPTION, inputParam.description());
           }
 
           properties.put(inputParam.name(), propertySchema);
@@ -125,9 +132,9 @@ public class CamundaClientAdHocToolsSchemaResolver implements AdHocToolsSchemaRe
         });
 
     Map<String, Object> inputSchema = new LinkedHashMap<>();
-    inputSchema.put("type", "object");
-    inputSchema.put("properties", properties);
-    inputSchema.put("required", required);
+    inputSchema.put(PROPERTY_TYPE, TYPE_OBJECT);
+    inputSchema.put(PROPERTY_PROPERTIES, properties);
+    inputSchema.put(PROPERTY_REQUIRED, required);
     return Collections.unmodifiableMap(inputSchema);
   }
 

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/adhoctoolsschema/resolver/CamundaClientAdHocToolsSchemaResolver.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/adhoctoolsschema/resolver/CamundaClientAdHocToolsSchemaResolver.java
@@ -96,6 +96,11 @@ public class CamundaClientAdHocToolsSchemaResolver implements AdHocToolsSchemaRe
     final var inputParams = extractFeelInputParams(element);
     inputParams.forEach(
         inputParam -> {
+          if (properties.containsKey(inputParam.name())) {
+            throw new IllegalArgumentException(
+                "Duplicate input parameter name: %s".formatted(inputParam.name()));
+          }
+
           final var propertySchema =
               Optional.ofNullable(inputParam.schema())
                   .map(LinkedHashMap::new)

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/adhoctoolsschema/resolver/CamundaClientAdHocToolsSchemaResolver.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/adhoctoolsschema/resolver/CamundaClientAdHocToolsSchemaResolver.java
@@ -7,8 +7,8 @@
 package io.camunda.connector.agenticai.adhoctoolsschema.resolver;
 
 import io.camunda.client.CamundaClient;
+import io.camunda.connector.agenticai.adhoctoolsschema.feel.FeelInputParam;
 import io.camunda.connector.agenticai.adhoctoolsschema.feel.FeelInputParamExtractor;
-import io.camunda.connector.agenticai.adhoctoolsschema.feel.FeelInputParamExtractor.FeelInputParam;
 import io.camunda.connector.agenticai.adhoctoolsschema.model.AdHocToolsSchemaResponse;
 import io.camunda.connector.agenticai.adhoctoolsschema.model.AdHocToolsSchemaResponse.AdHocToolDefinition;
 import io.camunda.connector.agenticai.adhoctoolsschema.resolver.schema.AdHocToolSchemaGenerator;

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/adhoctoolsschema/resolver/CamundaClientAdHocToolsSchemaResolver.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/adhoctoolsschema/resolver/CamundaClientAdHocToolsSchemaResolver.java
@@ -6,18 +6,12 @@
  */
 package io.camunda.connector.agenticai.adhoctoolsschema.resolver;
 
-import static io.camunda.connector.agenticai.JsonSchemaConstants.PROPERTY_DESCRIPTION;
-import static io.camunda.connector.agenticai.JsonSchemaConstants.PROPERTY_PROPERTIES;
-import static io.camunda.connector.agenticai.JsonSchemaConstants.PROPERTY_REQUIRED;
-import static io.camunda.connector.agenticai.JsonSchemaConstants.PROPERTY_TYPE;
-import static io.camunda.connector.agenticai.JsonSchemaConstants.TYPE_OBJECT;
-import static io.camunda.connector.agenticai.JsonSchemaConstants.TYPE_STRING;
-
 import io.camunda.client.CamundaClient;
 import io.camunda.connector.agenticai.adhoctoolsschema.feel.FeelInputParamExtractor;
 import io.camunda.connector.agenticai.adhoctoolsschema.feel.FeelInputParamExtractor.FeelInputParam;
 import io.camunda.connector.agenticai.adhoctoolsschema.model.AdHocToolsSchemaResponse;
 import io.camunda.connector.agenticai.adhoctoolsschema.model.AdHocToolsSchemaResponse.AdHocToolDefinition;
+import io.camunda.connector.agenticai.adhoctoolsschema.resolver.schema.AdHocToolSchemaGenerator;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.model.bpmn.instance.AdHocSubProcess;
@@ -29,9 +23,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import org.apache.commons.lang3.StringUtils;
 import org.camunda.bpm.model.xml.instance.ModelElementInstance;
@@ -45,11 +37,15 @@ public class CamundaClientAdHocToolsSchemaResolver implements AdHocToolsSchemaRe
 
   private final CamundaClient camundaClient;
   private final FeelInputParamExtractor feelInputParamExtractor;
+  private final AdHocToolSchemaGenerator schemaGenerator;
 
   public CamundaClientAdHocToolsSchemaResolver(
-      CamundaClient camundaClient, FeelInputParamExtractor feelInputParamExtractor) {
+      CamundaClient camundaClient,
+      FeelInputParamExtractor feelInputParamExtractor,
+      AdHocToolSchemaGenerator schemaGenerator) {
     this.camundaClient = camundaClient;
     this.feelInputParamExtractor = feelInputParamExtractor;
+    this.schemaGenerator = schemaGenerator;
   }
 
   @Override
@@ -83,7 +79,7 @@ public class CamundaClientAdHocToolsSchemaResolver implements AdHocToolsSchemaRe
 
   private AdHocToolDefinition mapActivityToToolDefinition(FlowNode element) {
     final var documentation = getDocumentation(element).orElseGet(element::getName);
-    final var inputSchema = extractInputSchema(element);
+    final var inputSchema = schemaGenerator.generateToolSchema(extractFeelInputParams(element));
 
     return new AdHocToolDefinition(element.getId(), documentation, inputSchema);
   }
@@ -94,48 +90,6 @@ public class CamundaClientAdHocToolsSchemaResolver implements AdHocToolsSchemaRe
         .findFirst()
         .map(ModelElementInstance::getTextContent)
         .filter(StringUtils::isNotBlank);
-  }
-
-  private Map<String, Object> extractInputSchema(FlowNode element) {
-    Map<String, Object> properties = new LinkedHashMap<>();
-    List<String> required = new ArrayList<>();
-
-    final var inputParams = extractFeelInputParams(element);
-    inputParams.forEach(
-        inputParam -> {
-          if (properties.containsKey(inputParam.name())) {
-            throw new IllegalArgumentException(
-                "Duplicate input parameter name: %s".formatted(inputParam.name()));
-          }
-
-          final var propertySchema =
-              Optional.ofNullable(inputParam.schema())
-                  .map(LinkedHashMap::new)
-                  .orElseGet(LinkedHashMap::new);
-
-          // apply type from inputParam if it is set
-          if (!StringUtils.isBlank(inputParam.type())) {
-            propertySchema.put(PROPERTY_TYPE, inputParam.type());
-          }
-
-          // default to string if no type is set (not on inputParam, not in schema directly)
-          if (!propertySchema.containsKey(PROPERTY_TYPE)) {
-            propertySchema.put(PROPERTY_TYPE, TYPE_STRING);
-          }
-
-          if (!StringUtils.isBlank(inputParam.description())) {
-            propertySchema.put(PROPERTY_DESCRIPTION, inputParam.description());
-          }
-
-          properties.put(inputParam.name(), propertySchema);
-          required.add(inputParam.name());
-        });
-
-    Map<String, Object> inputSchema = new LinkedHashMap<>();
-    inputSchema.put(PROPERTY_TYPE, TYPE_OBJECT);
-    inputSchema.put(PROPERTY_PROPERTIES, properties);
-    inputSchema.put(PROPERTY_REQUIRED, required);
-    return Collections.unmodifiableMap(inputSchema);
   }
 
   private List<FeelInputParam> extractFeelInputParams(FlowNode element) {

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/adhoctoolsschema/resolver/schema/AdHocToolSchemaGenerator.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/adhoctoolsschema/resolver/schema/AdHocToolSchemaGenerator.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.agenticai.adhoctoolsschema.resolver.schema;
+
+import io.camunda.connector.agenticai.adhoctoolsschema.feel.FeelInputParamExtractor.FeelInputParam;
+import java.util.List;
+import java.util.Map;
+
+public interface AdHocToolSchemaGenerator {
+  Map<String, Object> generateToolSchema(List<FeelInputParam> inputParams);
+}

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/adhoctoolsschema/resolver/schema/AdHocToolSchemaGenerator.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/adhoctoolsschema/resolver/schema/AdHocToolSchemaGenerator.java
@@ -6,7 +6,7 @@
  */
 package io.camunda.connector.agenticai.adhoctoolsschema.resolver.schema;
 
-import io.camunda.connector.agenticai.adhoctoolsschema.feel.FeelInputParamExtractor.FeelInputParam;
+import io.camunda.connector.agenticai.adhoctoolsschema.feel.FeelInputParam;
 import java.util.List;
 import java.util.Map;
 

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/adhoctoolsschema/resolver/schema/DefaultAdHocToolSchemaGenerator.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/adhoctoolsschema/resolver/schema/DefaultAdHocToolSchemaGenerator.java
@@ -13,7 +13,7 @@ import static io.camunda.connector.agenticai.JsonSchemaConstants.PROPERTY_TYPE;
 import static io.camunda.connector.agenticai.JsonSchemaConstants.TYPE_OBJECT;
 import static io.camunda.connector.agenticai.JsonSchemaConstants.TYPE_STRING;
 
-import io.camunda.connector.agenticai.adhoctoolsschema.feel.FeelInputParamExtractor.FeelInputParam;
+import io.camunda.connector.agenticai.adhoctoolsschema.feel.FeelInputParam;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/adhoctoolsschema/resolver/schema/DefaultAdHocToolSchemaGenerator.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/adhoctoolsschema/resolver/schema/DefaultAdHocToolSchemaGenerator.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.agenticai.adhoctoolsschema.resolver.schema;
+
+import static io.camunda.connector.agenticai.JsonSchemaConstants.PROPERTY_DESCRIPTION;
+import static io.camunda.connector.agenticai.JsonSchemaConstants.PROPERTY_PROPERTIES;
+import static io.camunda.connector.agenticai.JsonSchemaConstants.PROPERTY_REQUIRED;
+import static io.camunda.connector.agenticai.JsonSchemaConstants.PROPERTY_TYPE;
+import static io.camunda.connector.agenticai.JsonSchemaConstants.TYPE_OBJECT;
+import static io.camunda.connector.agenticai.JsonSchemaConstants.TYPE_STRING;
+
+import io.camunda.connector.agenticai.adhoctoolsschema.feel.FeelInputParamExtractor.FeelInputParam;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.apache.commons.lang3.StringUtils;
+
+public class DefaultAdHocToolSchemaGenerator implements AdHocToolSchemaGenerator {
+
+  public static final List<String> DEFAULT_RESTRICTED_PARAM_NAMES = List.of("_meta");
+
+  private final List<String> restrictedParamNames;
+
+  public DefaultAdHocToolSchemaGenerator() {
+    this(DEFAULT_RESTRICTED_PARAM_NAMES);
+  }
+
+  public DefaultAdHocToolSchemaGenerator(List<String> restrictedParamNames) {
+    this.restrictedParamNames = restrictedParamNames;
+  }
+
+  @Override
+  public Map<String, Object> generateToolSchema(List<FeelInputParam> inputParams) {
+    Map<String, Object> properties = new LinkedHashMap<>();
+    List<String> required = new ArrayList<>();
+
+    inputParams.forEach(
+        inputParam -> {
+          if (restrictedParamNames.contains(inputParam.name())) {
+            throw new IllegalArgumentException(
+                "Input parameter name '%s' is restricted and cannot be used."
+                    .formatted(inputParam.name()));
+          }
+
+          if (properties.containsKey(inputParam.name())) {
+            throw new IllegalArgumentException(
+                "Duplicate input parameter name: %s".formatted(inputParam.name()));
+          }
+
+          final var propertySchema =
+              Optional.ofNullable(inputParam.schema())
+                  .map(LinkedHashMap::new)
+                  .orElseGet(LinkedHashMap::new);
+
+          // apply type from inputParam if it is set
+          if (!StringUtils.isBlank(inputParam.type())) {
+            propertySchema.put(PROPERTY_TYPE, inputParam.type());
+          }
+
+          // default to string if no type is set (not on inputParam, not in schema directly)
+          if (!propertySchema.containsKey(PROPERTY_TYPE)) {
+            propertySchema.put(PROPERTY_TYPE, TYPE_STRING);
+          }
+
+          if (!StringUtils.isBlank(inputParam.description())) {
+            propertySchema.put(PROPERTY_DESCRIPTION, inputParam.description());
+          }
+
+          properties.put(inputParam.name(), propertySchema);
+          required.add(inputParam.name());
+        });
+
+    Map<String, Object> inputSchema = new LinkedHashMap<>();
+    inputSchema.put(PROPERTY_TYPE, TYPE_OBJECT);
+    inputSchema.put(PROPERTY_PROPERTIES, properties);
+    inputSchema.put(PROPERTY_REQUIRED, required);
+
+    return inputSchema;
+  }
+}

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/agent/DefaultAiAgentRequestHandler.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/agent/DefaultAiAgentRequestHandler.java
@@ -93,9 +93,9 @@ public class DefaultAiAgentRequestHandler implements AiAgentRequestHandler {
     chatMemory.add(aiMessage);
 
     // extract tool call requests from LLM response
-    final var toolsToCall = toolCallingHandler.extractToolsToCall(toolSpecifications, aiMessage);
+    final var toolCalls = toolCallingHandler.extractToolCalls(toolSpecifications, aiMessage);
     final var nextAgentState =
-        !toolsToCall.isEmpty() ? AgentState.WAITING_FOR_TOOL_INPUT : AgentState.READY;
+        !toolCalls.isEmpty() ? AgentState.WAITING_FOR_TOOL_INPUT : AgentState.READY;
 
     // update context
     final var updatedContext =
@@ -108,7 +108,7 @@ public class DefaultAiAgentRequestHandler implements AiAgentRequestHandler {
                     .incrementModelCalls(1)
                     .incrementTokenUsage(AgentMetrics.TokenUsage.from(chatResponse.tokenUsage())));
 
-    return new AgentResponse(updatedContext, updatedContext.memory().getLast(), toolsToCall);
+    return new AgentResponse(updatedContext, updatedContext.memory().getLast(), toolCalls);
   }
 
   private void checkGuardrails(

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/AgentResponse.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/AgentResponse.java
@@ -10,6 +10,6 @@ import java.util.List;
 import java.util.Map;
 
 public record AgentResponse(
-    AgentContext context, Map<String, Object> chatResponse, List<ToolToCall> toolsToCall) {
-  public record ToolToCall(String id, String name, Map<String, Object> input) {}
+    AgentContext context, Map<String, Object> chatResponse, List<ToolCall> toolCalls) {
+  public record ToolCall(String id, String name, Map<String, Object> input) {}
 }

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/AgentResponse.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/AgentResponse.java
@@ -6,10 +6,22 @@
  */
 package io.camunda.connector.agenticai.aiagent.model;
 
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
 import java.util.Map;
 
 public record AgentResponse(
     AgentContext context, Map<String, Object> chatResponse, List<ToolCall> toolCalls) {
-  public record ToolCall(String id, String name, Map<String, Object> input) {}
+  public record ToolCall(
+      @JsonProperty("_meta") ToolCallMetadata metadata,
+      @JsonAnySetter @JsonAnyGetter Map<String, Object> arguments) {
+
+    public ToolCall(String id, String name, Map<String, Object> arguments) {
+      this(new ToolCallMetadata(id, name), arguments);
+    }
+
+    public record ToolCallMetadata(String id, String name) {}
+  }
 }

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/tools/ToolCallingHandler.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/tools/ToolCallingHandler.java
@@ -17,7 +17,7 @@ import dev.langchain4j.agent.tool.ToolSpecification;
 import dev.langchain4j.data.message.AiMessage;
 import dev.langchain4j.data.message.ToolExecutionResultMessage;
 import io.camunda.connector.agenticai.adhoctoolsschema.resolver.AdHocToolsSchemaResolver;
-import io.camunda.connector.agenticai.aiagent.model.AgentResponse;
+import io.camunda.connector.agenticai.aiagent.model.AgentResponse.ToolCall;
 import io.camunda.connector.api.error.ConnectorException;
 import java.util.Collections;
 import java.util.List;
@@ -52,7 +52,7 @@ public class ToolCallingHandler {
         .toList();
   }
 
-  public List<AgentResponse.ToolCall> extractToolCalls(
+  public List<ToolCall> extractToolCalls(
       List<ToolSpecification> toolSpecifications, AiMessage aiMessage) {
     if (!aiMessage.hasToolExecutionRequests() || toolSpecifications.isEmpty()) {
       return Collections.emptyList();
@@ -61,16 +61,16 @@ public class ToolCallingHandler {
     return aiMessage.toolExecutionRequests().stream().map(this::asToolCall).toList();
   }
 
-  private AgentResponse.ToolCall asToolCall(ToolExecutionRequest toolExecutionRequest) {
+  private ToolCall asToolCall(ToolExecutionRequest toolExecutionRequest) {
     return asToolCall(
         toolExecutionRequest.id(), toolExecutionRequest.name(), toolExecutionRequest.arguments());
   }
 
-  private AgentResponse.ToolCall asToolCall(String id, String name, String inputJson) {
+  private ToolCall asToolCall(String id, String name, String inputJson) {
     try {
       Map<String, Object> arguments =
           objectMapper.readValue(inputJson, STRING_OBJECT_MAP_TYPE_REFERENCE);
-      return new AgentResponse.ToolCall(id, name, arguments);
+      return new ToolCall(id, name, arguments);
     } catch (Exception e) {
       throw new ConnectorException(
           "Failed to parse tool call results for tool %s".formatted(name), e);

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/tools/ToolCallingHandler.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/tools/ToolCallingHandler.java
@@ -52,25 +52,25 @@ public class ToolCallingHandler {
         .toList();
   }
 
-  public List<AgentResponse.ToolToCall> extractToolsToCall(
+  public List<AgentResponse.ToolCall> extractToolCalls(
       List<ToolSpecification> toolSpecifications, AiMessage aiMessage) {
     if (!aiMessage.hasToolExecutionRequests() || toolSpecifications.isEmpty()) {
       return Collections.emptyList();
     }
 
-    return aiMessage.toolExecutionRequests().stream().map(this::toolToCall).toList();
+    return aiMessage.toolExecutionRequests().stream().map(this::asToolCall).toList();
   }
 
-  private AgentResponse.ToolToCall toolToCall(ToolExecutionRequest toolExecutionRequest) {
-    return toolToCall(
+  private AgentResponse.ToolCall asToolCall(ToolExecutionRequest toolExecutionRequest) {
+    return asToolCall(
         toolExecutionRequest.id(), toolExecutionRequest.name(), toolExecutionRequest.arguments());
   }
 
-  private AgentResponse.ToolToCall toolToCall(String id, String name, String inputJson) {
+  private AgentResponse.ToolCall asToolCall(String id, String name, String inputJson) {
     try {
       Map<String, Object> arguments =
           objectMapper.readValue(inputJson, STRING_OBJECT_MAP_TYPE_REFERENCE);
-      return new AgentResponse.ToolToCall(id, name, arguments);
+      return new AgentResponse.ToolCall(id, name, arguments);
     } catch (Exception e) {
       throw new ConnectorException(
           "Failed to parse tool call results for tool %s".formatted(name), e);

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/tools/ToolSpecificationConverter.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/tools/ToolSpecificationConverter.java
@@ -6,6 +6,19 @@
  */
 package io.camunda.connector.agenticai.aiagent.tools;
 
+import static io.camunda.connector.agenticai.JsonSchemaConstants.PROPERTY_ADDITIONAL_PROPERTIES;
+import static io.camunda.connector.agenticai.JsonSchemaConstants.PROPERTY_DESCRIPTION;
+import static io.camunda.connector.agenticai.JsonSchemaConstants.PROPERTY_ENUM;
+import static io.camunda.connector.agenticai.JsonSchemaConstants.PROPERTY_ITEMS;
+import static io.camunda.connector.agenticai.JsonSchemaConstants.PROPERTY_PROPERTIES;
+import static io.camunda.connector.agenticai.JsonSchemaConstants.PROPERTY_REQUIRED;
+import static io.camunda.connector.agenticai.JsonSchemaConstants.PROPERTY_TYPE;
+import static io.camunda.connector.agenticai.JsonSchemaConstants.TYPE_ARRAY;
+import static io.camunda.connector.agenticai.JsonSchemaConstants.TYPE_BOOLEAN;
+import static io.camunda.connector.agenticai.JsonSchemaConstants.TYPE_INTEGER;
+import static io.camunda.connector.agenticai.JsonSchemaConstants.TYPE_NUMBER;
+import static io.camunda.connector.agenticai.JsonSchemaConstants.TYPE_OBJECT;
+import static io.camunda.connector.agenticai.JsonSchemaConstants.TYPE_STRING;
 import static io.camunda.connector.agenticai.util.JacksonExceptionMessageExtractor.humanReadableJsonProcessingExceptionMessage;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -32,21 +45,6 @@ import java.util.Map;
  * dev.langchain4j.mcp.client.ToolSpecificationHelper.
  */
 public class ToolSpecificationConverter {
-
-  private static final String TYPE_OBJECT = "object";
-  private static final String TYPE_STRING = "string";
-  private static final String TYPE_NUMBER = "number";
-  private static final String TYPE_INTEGER = "integer";
-  private static final String TYPE_BOOLEAN = "boolean";
-  private static final String TYPE_ARRAY = "array";
-
-  private static final String PROPERTY_TYPE = "type";
-  private static final String PROPERTY_DESCRIPTION = "description";
-  private static final String PROPERTY_REQUIRED = "required";
-  private static final String PROPERTY_ADDITIONAL_PROPERTIES = "additionalProperties";
-  private static final String PROPERTY_PROPERTIES = "properties";
-  private static final String PROPERTY_ENUM = "enum";
-  private static final String PROPERTY_ITEMS = "items";
 
   private final JsonSchemaFactory jsonSchemaFactory;
 

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/autoconfigure/AgenticAiConnectorsAutoConfiguration.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/autoconfigure/AgenticAiConnectorsAutoConfiguration.java
@@ -9,6 +9,7 @@ package io.camunda.connector.agenticai.autoconfigure;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.client.CamundaClient;
 import io.camunda.connector.agenticai.adhoctoolsschema.AdHocToolsSchemaFunction;
+import io.camunda.connector.agenticai.adhoctoolsschema.feel.FeelInputParamExtractor;
 import io.camunda.connector.agenticai.adhoctoolsschema.resolver.AdHocToolsSchemaResolver;
 import io.camunda.connector.agenticai.adhoctoolsschema.resolver.CachingAdHocToolsSchemaResolver;
 import io.camunda.connector.agenticai.adhoctoolsschema.resolver.CamundaClientAdHocToolsSchemaResolver;
@@ -34,11 +35,18 @@ public class AgenticAiConnectorsAutoConfiguration {
 
   @Bean
   @ConditionalOnMissingBean
+  public FeelInputParamExtractor feelInputParamExtractor(ObjectMapper objectMapper) {
+    return new FeelInputParamExtractor(objectMapper);
+  }
+
+  @Bean
+  @ConditionalOnMissingBean
   public AdHocToolsSchemaResolver adHocToolsSchemaResolver(
       AgenticAiConnectorsConfigurationProperties configuration,
       CamundaClient camundaClient,
-      ObjectMapper objectMapper) {
-    final var resolver = new CamundaClientAdHocToolsSchemaResolver(camundaClient, objectMapper);
+      FeelInputParamExtractor feelInputParamExtractor) {
+    final var resolver =
+        new CamundaClientAdHocToolsSchemaResolver(camundaClient, feelInputParamExtractor);
 
     final var cacheConfiguration = configuration.tools().cache();
     if (cacheConfiguration.enabled()) {

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/autoconfigure/AgenticAiConnectorsAutoConfiguration.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/autoconfigure/AgenticAiConnectorsAutoConfiguration.java
@@ -13,6 +13,8 @@ import io.camunda.connector.agenticai.adhoctoolsschema.feel.FeelInputParamExtrac
 import io.camunda.connector.agenticai.adhoctoolsschema.resolver.AdHocToolsSchemaResolver;
 import io.camunda.connector.agenticai.adhoctoolsschema.resolver.CachingAdHocToolsSchemaResolver;
 import io.camunda.connector.agenticai.adhoctoolsschema.resolver.CamundaClientAdHocToolsSchemaResolver;
+import io.camunda.connector.agenticai.adhoctoolsschema.resolver.schema.AdHocToolSchemaGenerator;
+import io.camunda.connector.agenticai.adhoctoolsschema.resolver.schema.DefaultAdHocToolSchemaGenerator;
 import io.camunda.connector.agenticai.aiagent.AiAgentFunction;
 import io.camunda.connector.agenticai.aiagent.agent.AiAgentRequestHandler;
 import io.camunda.connector.agenticai.aiagent.agent.DefaultAiAgentRequestHandler;
@@ -41,12 +43,21 @@ public class AgenticAiConnectorsAutoConfiguration {
 
   @Bean
   @ConditionalOnMissingBean
+  public AdHocToolSchemaGenerator adHocToolSchemaGenerator() {
+    return new DefaultAdHocToolSchemaGenerator();
+  }
+
+  @Bean
+  @ConditionalOnMissingBean
   public AdHocToolsSchemaResolver adHocToolsSchemaResolver(
       AgenticAiConnectorsConfigurationProperties configuration,
       CamundaClient camundaClient,
-      FeelInputParamExtractor feelInputParamExtractor) {
+      FeelInputParamExtractor feelInputParamExtractor,
+      AdHocToolSchemaGenerator adHocToolSchemaGenerator) {
+
     final var resolver =
-        new CamundaClientAdHocToolsSchemaResolver(camundaClient, feelInputParamExtractor);
+        new CamundaClientAdHocToolsSchemaResolver(
+            camundaClient, feelInputParamExtractor, adHocToolSchemaGenerator);
 
     final var cacheConfiguration = configuration.tools().cache();
     if (cacheConfiguration.enabled()) {

--- a/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/adhoctoolsschema/feel/FeelInputParamExtractorTest.java
+++ b/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/adhoctoolsschema/feel/FeelInputParamExtractorTest.java
@@ -1,0 +1,216 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.agenticai.adhoctoolsschema.feel;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.connector.agenticai.adhoctoolsschema.feel.FeelInputParamExtractor.FeelInputParam;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class FeelInputParamExtractorTest {
+
+  private final FeelInputParamExtractor extractor = new FeelInputParamExtractor();
+
+  @ParameterizedTest
+  @MethodSource("testFeelExpressionsWithExpectedInputParams")
+  void extractsAllInputParametersFromExpression(FeelInputParamTestCase testCase) throws Exception {
+    List<FeelInputParam> inputParams = extractor.extractInputParams(testCase.expression());
+    assertThat(inputParams)
+        .usingRecursiveFieldByFieldElementComparator()
+        .containsExactlyElementsOf(testCase.expectedInputParams());
+  }
+
+  public static List<FeelInputParamTestCase> testFeelExpressionsWithExpectedInputParams() {
+    return List.of(
+        new FeelInputParamTestCase(
+            "Only expression: Name",
+            """
+            fromAi("aSimpleValue")
+            """,
+            new FeelInputParam("aSimpleValue", null, null, null)),
+        new FeelInputParamTestCase(
+            "Only expression: Name + description",
+            """
+            fromAi("aSimpleValue", "A simple value")
+            """,
+            new FeelInputParam("aSimpleValue", "A simple value", null, null)),
+        new FeelInputParamTestCase(
+            "Only expression: Name + description + type",
+            """
+            fromAi("aSimpleValue", "A simple value", "string")
+            """,
+            new FeelInputParam("aSimpleValue", "A simple value", "string", null)),
+        new FeelInputParamTestCase(
+            "Only expression: Name + description + type + schema",
+            """
+            fromAi("aSimpleValue", "A simple value", "string", { enum: ["A", "B", "C"] })
+            """,
+            new FeelInputParam(
+                "aSimpleValue",
+                "A simple value",
+                "string",
+                Map.of("enum", List.of("A", "B", "C")))),
+        new FeelInputParamTestCase(
+            "Only expression: Name + description + type + schema (expressions to generate params)",
+            """
+            fromAi("a" + "Simple" + "Value", string join(["A", "simple", "value"], " "), "str" + "ing", context put({}, "enum", ["A", "B", "C"]))
+            """,
+            new FeelInputParam(
+                "aSimpleValue",
+                "A simple value",
+                "string",
+                Map.of("enum", List.of("A", "B", "C")))),
+        new FeelInputParamTestCase(
+            "Only expression: Name (named params)",
+            """
+            fromAi(name: "aSimpleValue")
+            """,
+            new FeelInputParam("aSimpleValue", null, null, null)),
+        new FeelInputParamTestCase(
+            "Only expression: Name + description (named params)",
+            """
+            fromAi(name: "aSimpleValue", description: "A simple value")
+            """,
+            new FeelInputParam("aSimpleValue", "A simple value", null, null)),
+        new FeelInputParamTestCase(
+            "Only expression: Name + description + type (named params)",
+            """
+            fromAi(name: "aSimpleValue", description: "A simple value", type: "string")
+            """,
+            new FeelInputParam("aSimpleValue", "A simple value", "string", null)),
+        new FeelInputParamTestCase(
+            "Only expression: Name + description + type + schema (named params)",
+            """
+            fromAi(name: "aSimpleValue", description: "A simple value", type: "string", schema: { enum: ["A", "B", "C"] })
+            """,
+            new FeelInputParam(
+                "aSimpleValue",
+                "A simple value",
+                "string",
+                Map.of("enum", List.of("A", "B", "C")))),
+        new FeelInputParamTestCase(
+            "Only expression: Name + description + type + schema (named params, mixed order)",
+            """
+            fromAi(description: "A simple value", schema: { enum: ["A", "B", "C"] }, type: "string", name: "aSimpleValue")
+            """,
+            new FeelInputParam(
+                "aSimpleValue",
+                "A simple value",
+                "string",
+                Map.of("enum", List.of("A", "B", "C")))),
+        new FeelInputParamTestCase(
+            "Only expression: Name + description + type + schema (named params, mixed order, expressions to generate params)",
+            """
+            fromAi(description: string join(["A", "simple", "value"], " "), schema: context put({}, "enum", ["A", "B", "C"]), type: "str" + "ing", name: "a" + "Simple" + "Value")
+            """,
+            new FeelInputParam(
+                "aSimpleValue",
+                "A simple value",
+                "string",
+                Map.of("enum", List.of("A", "B", "C")))),
+        new FeelInputParamTestCase(
+            "Array schema with sub-schema",
+            """
+            fromAi("multiValue", "Select a multi value", "array", {
+              "items": {
+                "type": "string",
+                "enum": ["foo", "bar", "baz"]
+              }
+            })
+            """,
+            new FeelInputParam(
+                "multiValue",
+                "Select a multi value",
+                "array",
+                Map.of("items", Map.of("type", "string", "enum", List.of("foo", "bar", "baz"))))),
+        new FeelInputParamTestCase(
+            "Part of operation (integer)",
+            """
+            1 + 2 + fromAi("thirdValue", "The third value to add", "integer")
+            """,
+            new FeelInputParam("thirdValue", "The third value to add", "integer", null)),
+        new FeelInputParamTestCase(
+            "Part of string concatenation",
+            """
+            "https://example.com/" + fromAi("urlPath", "The URL path to use", "string")
+            """,
+            new FeelInputParam("urlPath", "The URL path to use", "string", null)),
+        new FeelInputParamTestCase(
+            "Multiple parameters, part of a context",
+            """
+            {
+              foo: "bar",
+              bar: fromAi("barValue", "A good bar value", "string"),
+              combined: fromAi("firstOne", "The first value") + fromAi("secondOne", "The second value", "string")
+            }
+            """,
+            new FeelInputParam("barValue", "A good bar value", "string", null),
+            new FeelInputParam("firstOne", "The first value", null, null),
+            new FeelInputParam("secondOne", "The second value", "string", null)),
+        new FeelInputParamTestCase(
+            "Multiple parameters, part of a list",
+            """
+            ["something", fromAi("firstValue", "The first value", "string"), fromAi("secondValue", "The second value", "integer")]
+            """,
+            new FeelInputParam("firstValue", "The first value", "string", null),
+            new FeelInputParam("secondValue", "The second value", "integer", null)),
+        new FeelInputParamTestCase(
+            "Multiple parameters, part of a context and list",
+            """
+            {
+              foo: [fromAi("firstValue", "The first value", "string"), fromAi("secondValue", "The second value", "integer")],
+              bar: {
+                baz: fromAi("thirdValue", "The third value to add")
+              }
+            }
+            """,
+            new FeelInputParam("firstValue", "The first value", "string", null),
+            new FeelInputParam("secondValue", "The second value", "integer", null),
+            new FeelInputParam("thirdValue", "The third value to add", null, null)),
+        new FeelInputParamTestCase(
+            "Multiple parameters, part of a context and list (named params)",
+            """
+            {
+              foo: [fromAi(name: "firstValue", description: "The first value", type: "string"), fromAi(description: "The second value", type: "integer", name: "secondValue")],
+              bar: {
+                baz: fromAi(name: "thirdValue", description: "The third value to add"),
+                qux: fromAi(name: "fourthValue", description: "The fourth value to add", type: "array", schema: {
+                  "items": {
+                    "type": "string",
+                    "enum": ["foo", "bar", "baz"]
+                  }
+                })
+              }
+            }
+            """,
+            new FeelInputParam("firstValue", "The first value", "string", null),
+            new FeelInputParam("secondValue", "The second value", "integer", null),
+            new FeelInputParam("thirdValue", "The third value to add", null, null),
+            new FeelInputParam(
+                "fourthValue",
+                "The fourth value to add",
+                "array",
+                Map.of("items", Map.of("type", "string", "enum", List.of("foo", "bar", "baz"))))));
+  }
+
+  record FeelInputParamTestCase(
+      String description, String expression, List<FeelInputParam> expectedInputParams) {
+
+    FeelInputParamTestCase(
+        String description, String expression, FeelInputParam... expectedInputParams) {
+      this(description, expression, List.of(expectedInputParams));
+    }
+
+    @Override
+    public String toString() {
+      return "%s: %s".formatted(description, expression);
+    }
+  }
+}

--- a/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/adhoctoolsschema/feel/FeelInputParamExtractorTest.java
+++ b/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/adhoctoolsschema/feel/FeelInputParamExtractorTest.java
@@ -34,19 +34,19 @@ class FeelInputParamExtractorTest {
             """
             fromAi(toolCall.aSimpleValue)
             """,
-            new FeelInputParam("aSimpleValue", null, null, null)),
+            new FeelInputParam("aSimpleValue")),
         new FeelInputParamTestCase(
             "Only expression: Name + description",
             """
             fromAi(toolCall.aSimpleValue, "A simple value")
             """,
-            new FeelInputParam("aSimpleValue", "A simple value", null, null)),
+            new FeelInputParam("aSimpleValue", "A simple value")),
         new FeelInputParamTestCase(
             "Only expression: Name + description + type",
             """
             fromAi(toolCall.aSimpleValue, "A simple value", "string")
             """,
-            new FeelInputParam("aSimpleValue", "A simple value", "string", null)),
+            new FeelInputParam("aSimpleValue", "A simple value", "string")),
         new FeelInputParamTestCase(
             "Only expression: Name + description + type + schema",
             """
@@ -58,33 +58,45 @@ class FeelInputParamExtractorTest {
                 "string",
                 Map.of("enum", List.of("A", "B", "C")))),
         new FeelInputParamTestCase(
-            "Only expression: Name + description + type + schema (expressions to generate schema)",
+            "Only expression: Name + description + type + schema + options",
             """
-            fromAi(toolCall.aSimpleValue, "A simple value", "string", context put({}, "enum", ["A", "B", "C"]))
+            fromAi(toolCall.aSimpleValue, "A simple value", "string", { enum: ["A", "B", "C"] }, { optional: true })
             """,
             new FeelInputParam(
                 "aSimpleValue",
                 "A simple value",
                 "string",
-                Map.of("enum", List.of("A", "B", "C")))),
+                Map.of("enum", List.of("A", "B", "C")),
+                Map.of("optional", true))),
+        new FeelInputParamTestCase(
+            "Only expression: Name + description + type + schema + options (expressions to generate schema)",
+            """
+            fromAi(toolCall.aSimpleValue, "A simple value", "string", context put({}, "enum", ["A", "B", "C"]), { optional: not(false) })
+            """,
+            new FeelInputParam(
+                "aSimpleValue",
+                "A simple value",
+                "string",
+                Map.of("enum", List.of("A", "B", "C")),
+                Map.of("optional", true))),
         new FeelInputParamTestCase(
             "Only expression: Name (named params)",
             """
             fromAi(value: toolCall.aSimpleValue)
             """,
-            new FeelInputParam("aSimpleValue", null, null, null)),
+            new FeelInputParam("aSimpleValue")),
         new FeelInputParamTestCase(
             "Only expression: Name + description (named params)",
             """
             fromAi(value: toolCall.aSimpleValue, description: "A simple value")
             """,
-            new FeelInputParam("aSimpleValue", "A simple value", null, null)),
+            new FeelInputParam("aSimpleValue", "A simple value")),
         new FeelInputParamTestCase(
             "Only expression: Name + description + type (named params)",
             """
             fromAi(value: toolCall.aSimpleValue, description: "A simple value", type: "string")
             """,
-            new FeelInputParam("aSimpleValue", "A simple value", "string", null)),
+            new FeelInputParam("aSimpleValue", "A simple value", "string")),
         new FeelInputParamTestCase(
             "Only expression: Name + description + type + schema (named params)",
             """
@@ -96,25 +108,56 @@ class FeelInputParamExtractorTest {
                 "string",
                 Map.of("enum", List.of("A", "B", "C")))),
         new FeelInputParamTestCase(
-            "Only expression: Name + description + type + schema (named params, mixed order)",
+            "Only expression: Name + description + type + schema + options (named params)",
             """
-            fromAi(description: "A simple value", schema: { enum: ["A", "B", "C"] }, type: "string", value: toolCall.aSimpleValue)
+            fromAi(
+              value: toolCall.aSimpleValue,
+              description: "A simple value",
+              type: "string",
+              schema: { enum: ["A", "B", "C"] },
+              options: { optional: true }
+            )
             """,
             new FeelInputParam(
                 "aSimpleValue",
                 "A simple value",
                 "string",
-                Map.of("enum", List.of("A", "B", "C")))),
+                Map.of("enum", List.of("A", "B", "C")),
+                Map.of("optional", true))),
         new FeelInputParamTestCase(
-            "Only expression: Name + description + type + schema (named params, mixed order, expression to generate schema)",
+            "Only expression: Name + description + type + schema + options (named params, mixed order)",
             """
-            fromAi(description: "A simple value", schema: context put({}, "enum", ["A", "B", "C"]), type: "string", value: toolCall.aSimpleValue)
+            fromAi(
+              description: "A simple value",
+              options: { optional: true },
+              schema: { enum: ["A", "B", "C"] },
+              type: "string",
+              value: toolCall.aSimpleValue
+            )
             """,
             new FeelInputParam(
                 "aSimpleValue",
                 "A simple value",
                 "string",
-                Map.of("enum", List.of("A", "B", "C")))),
+                Map.of("enum", List.of("A", "B", "C")),
+                Map.of("optional", true))),
+        new FeelInputParamTestCase(
+            "Only expression: Name + description + type + schema + options (named params, mixed order, expression to generate schema and options)",
+            """
+            fromAi(
+              description: "A simple value",
+              options: { optional: not(false) },
+              schema: context put({}, "enum", ["A", "B", "C"]),
+              type: "string",
+              value: toolCall.aSimpleValue
+            )
+            """,
+            new FeelInputParam(
+                "aSimpleValue",
+                "A simple value",
+                "string",
+                Map.of("enum", List.of("A", "B", "C")),
+                Map.of("optional", true))),
         new FeelInputParamTestCase(
             "Array schema with sub-schema",
             """
@@ -135,13 +178,13 @@ class FeelInputParamExtractorTest {
             """
             1 + 2 + fromAi(toolCall.thirdValue, "The third value to add", "integer")
             """,
-            new FeelInputParam("thirdValue", "The third value to add", "integer", null)),
+            new FeelInputParam("thirdValue", "The third value to add", "integer")),
         new FeelInputParamTestCase(
             "Part of string concatenation",
             """
             "https://example.com/" + fromAi(toolCall.urlPath, "The URL path to use", "string")
             """,
-            new FeelInputParam("urlPath", "The URL path to use", "string", null)),
+            new FeelInputParam("urlPath", "The URL path to use", "string")),
         new FeelInputParamTestCase(
             "Multiple parameters, part of a context",
             """
@@ -151,16 +194,16 @@ class FeelInputParamExtractorTest {
               combined: fromAi(toolCall.firstOne, "The first value") + fromAi(toolCall.secondOne, "The second value", "string")
             }
             """,
-            new FeelInputParam("barValue", "A good bar value", "string", null),
-            new FeelInputParam("firstOne", "The first value", null, null),
-            new FeelInputParam("secondOne", "The second value", "string", null)),
+            new FeelInputParam("barValue", "A good bar value", "string"),
+            new FeelInputParam("firstOne", "The first value"),
+            new FeelInputParam("secondOne", "The second value", "string")),
         new FeelInputParamTestCase(
             "Multiple parameters, part of a list",
             """
             ["something", fromAi(toolCall.firstValue, "The first value", "string"), fromAi(toolCall.secondValue, "The second value", "integer")]
             """,
-            new FeelInputParam("firstValue", "The first value", "string", null),
-            new FeelInputParam("secondValue", "The second value", "integer", null)),
+            new FeelInputParam("firstValue", "The first value", "string"),
+            new FeelInputParam("secondValue", "The second value", "integer")),
         new FeelInputParamTestCase(
             "Multiple parameters, part of a context and list",
             """
@@ -171,9 +214,9 @@ class FeelInputParamExtractorTest {
               }
             }
             """,
-            new FeelInputParam("firstValue", "The first value", "string", null),
-            new FeelInputParam("secondValue", "The second value", "integer", null),
-            new FeelInputParam("thirdValue", "The third value to add", null, null)),
+            new FeelInputParam("firstValue", "The first value", "string"),
+            new FeelInputParam("secondValue", "The second value", "integer"),
+            new FeelInputParam("thirdValue", "The third value to add")),
         new FeelInputParamTestCase(
             "Multiple parameters, part of a context and list (named params)",
             """
@@ -190,9 +233,9 @@ class FeelInputParamExtractorTest {
               }
             }
             """,
-            new FeelInputParam("firstValue", "The first value", "string", null),
-            new FeelInputParam("secondValue", "The second value", "integer", null),
-            new FeelInputParam("thirdValue", "The third value to add", null, null),
+            new FeelInputParam("firstValue", "The first value", "string"),
+            new FeelInputParam("secondValue", "The second value", "integer"),
+            new FeelInputParam("thirdValue", "The third value to add"),
             new FeelInputParam(
                 "fourthValue",
                 "The fourth value to add",

--- a/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/adhoctoolsschema/feel/FeelInputParamExtractorTest.java
+++ b/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/adhoctoolsschema/feel/FeelInputParamExtractorTest.java
@@ -8,7 +8,6 @@ package io.camunda.connector.agenticai.adhoctoolsschema.feel;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.camunda.connector.agenticai.adhoctoolsschema.feel.FeelInputParamExtractor.FeelInputParam;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.params.ParameterizedTest;

--- a/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/adhoctoolsschema/feel/FeelInputParamExtractorTest.java
+++ b/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/adhoctoolsschema/feel/FeelInputParamExtractorTest.java
@@ -32,25 +32,25 @@ class FeelInputParamExtractorTest {
         new FeelInputParamTestCase(
             "Only expression: Name",
             """
-            fromAi("aSimpleValue")
+            fromAi({}, "aSimpleValue")
             """,
             new FeelInputParam("aSimpleValue", null, null, null)),
         new FeelInputParamTestCase(
             "Only expression: Name + description",
             """
-            fromAi("aSimpleValue", "A simple value")
+            fromAi({}, "aSimpleValue", "A simple value")
             """,
             new FeelInputParam("aSimpleValue", "A simple value", null, null)),
         new FeelInputParamTestCase(
             "Only expression: Name + description + type",
             """
-            fromAi("aSimpleValue", "A simple value", "string")
+            fromAi({}, "aSimpleValue", "A simple value", "string")
             """,
             new FeelInputParam("aSimpleValue", "A simple value", "string", null)),
         new FeelInputParamTestCase(
             "Only expression: Name + description + type + schema",
             """
-            fromAi("aSimpleValue", "A simple value", "string", { enum: ["A", "B", "C"] })
+            fromAi({}, "aSimpleValue", "A simple value", "string", { enum: ["A", "B", "C"] })
             """,
             new FeelInputParam(
                 "aSimpleValue",
@@ -60,7 +60,7 @@ class FeelInputParamExtractorTest {
         new FeelInputParamTestCase(
             "Only expression: Name + description + type + schema (expressions to generate params)",
             """
-            fromAi("a" + "Simple" + "Value", string join(["A", "simple", "value"], " "), "str" + "ing", context put({}, "enum", ["A", "B", "C"]))
+            fromAi({}, "a" + "Simple" + "Value", string join(["A", "simple", "value"], " "), "str" + "ing", context put({}, "enum", ["A", "B", "C"]))
             """,
             new FeelInputParam(
                 "aSimpleValue",
@@ -70,25 +70,25 @@ class FeelInputParamExtractorTest {
         new FeelInputParamTestCase(
             "Only expression: Name (named params)",
             """
-            fromAi(name: "aSimpleValue")
+            fromAi(context: {}, name: "aSimpleValue")
             """,
             new FeelInputParam("aSimpleValue", null, null, null)),
         new FeelInputParamTestCase(
             "Only expression: Name + description (named params)",
             """
-            fromAi(name: "aSimpleValue", description: "A simple value")
+            fromAi(context: {}, name: "aSimpleValue", description: "A simple value")
             """,
             new FeelInputParam("aSimpleValue", "A simple value", null, null)),
         new FeelInputParamTestCase(
             "Only expression: Name + description + type (named params)",
             """
-            fromAi(name: "aSimpleValue", description: "A simple value", type: "string")
+            fromAi(context: {}, name: "aSimpleValue", description: "A simple value", type: "string")
             """,
             new FeelInputParam("aSimpleValue", "A simple value", "string", null)),
         new FeelInputParamTestCase(
             "Only expression: Name + description + type + schema (named params)",
             """
-            fromAi(name: "aSimpleValue", description: "A simple value", type: "string", schema: { enum: ["A", "B", "C"] })
+            fromAi(context: {}, name: "aSimpleValue", description: "A simple value", type: "string", schema: { enum: ["A", "B", "C"] })
             """,
             new FeelInputParam(
                 "aSimpleValue",
@@ -98,7 +98,7 @@ class FeelInputParamExtractorTest {
         new FeelInputParamTestCase(
             "Only expression: Name + description + type + schema (named params, mixed order)",
             """
-            fromAi(description: "A simple value", schema: { enum: ["A", "B", "C"] }, type: "string", name: "aSimpleValue")
+            fromAi(description: "A simple value", schema: { enum: ["A", "B", "C"] }, context: {}, type: "string", name: "aSimpleValue")
             """,
             new FeelInputParam(
                 "aSimpleValue",
@@ -108,7 +108,7 @@ class FeelInputParamExtractorTest {
         new FeelInputParamTestCase(
             "Only expression: Name + description + type + schema (named params, mixed order, expressions to generate params)",
             """
-            fromAi(description: string join(["A", "simple", "value"], " "), schema: context put({}, "enum", ["A", "B", "C"]), type: "str" + "ing", name: "a" + "Simple" + "Value")
+            fromAi(description: string join(["A", "simple", "value"], " "), schema: context put({}, "enum", ["A", "B", "C"]), context: {}, type: "str" + "ing", name: "a" + "Simple" + "Value")
             """,
             new FeelInputParam(
                 "aSimpleValue",
@@ -118,7 +118,7 @@ class FeelInputParamExtractorTest {
         new FeelInputParamTestCase(
             "Array schema with sub-schema",
             """
-            fromAi("multiValue", "Select a multi value", "array", {
+            fromAi({}, "multiValue", "Select a multi value", "array", {
               "items": {
                 "type": "string",
                 "enum": ["foo", "bar", "baz"]
@@ -133,13 +133,13 @@ class FeelInputParamExtractorTest {
         new FeelInputParamTestCase(
             "Part of operation (integer)",
             """
-            1 + 2 + fromAi("thirdValue", "The third value to add", "integer")
+            1 + 2 + fromAi({}, "thirdValue", "The third value to add", "integer")
             """,
             new FeelInputParam("thirdValue", "The third value to add", "integer", null)),
         new FeelInputParamTestCase(
             "Part of string concatenation",
             """
-            "https://example.com/" + fromAi("urlPath", "The URL path to use", "string")
+            "https://example.com/" + fromAi({}, "urlPath", "The URL path to use", "string")
             """,
             new FeelInputParam("urlPath", "The URL path to use", "string", null)),
         new FeelInputParamTestCase(
@@ -147,8 +147,8 @@ class FeelInputParamExtractorTest {
             """
             {
               foo: "bar",
-              bar: fromAi("barValue", "A good bar value", "string"),
-              combined: fromAi("firstOne", "The first value") + fromAi("secondOne", "The second value", "string")
+              bar: fromAi({}, "barValue", "A good bar value", "string"),
+              combined: fromAi({}, "firstOne", "The first value") + fromAi({}, "secondOne", "The second value", "string")
             }
             """,
             new FeelInputParam("barValue", "A good bar value", "string", null),
@@ -157,7 +157,7 @@ class FeelInputParamExtractorTest {
         new FeelInputParamTestCase(
             "Multiple parameters, part of a list",
             """
-            ["something", fromAi("firstValue", "The first value", "string"), fromAi("secondValue", "The second value", "integer")]
+            ["something", fromAi({}, "firstValue", "The first value", "string"), fromAi({}, "secondValue", "The second value", "integer")]
             """,
             new FeelInputParam("firstValue", "The first value", "string", null),
             new FeelInputParam("secondValue", "The second value", "integer", null)),
@@ -165,9 +165,9 @@ class FeelInputParamExtractorTest {
             "Multiple parameters, part of a context and list",
             """
             {
-              foo: [fromAi("firstValue", "The first value", "string"), fromAi("secondValue", "The second value", "integer")],
+              foo: [fromAi({}, "firstValue", "The first value", "string"), fromAi({}, "secondValue", "The second value", "integer")],
               bar: {
-                baz: fromAi("thirdValue", "The third value to add")
+                baz: fromAi({}, "thirdValue", "The third value to add")
               }
             }
             """,
@@ -178,10 +178,10 @@ class FeelInputParamExtractorTest {
             "Multiple parameters, part of a context and list (named params)",
             """
             {
-              foo: [fromAi(name: "firstValue", description: "The first value", type: "string"), fromAi(description: "The second value", type: "integer", name: "secondValue")],
+              foo: [fromAi(context: {}, name: "firstValue", description: "The first value", type: "string"), fromAi(context: {}, description: "The second value", type: "integer", name: "secondValue")],
               bar: {
-                baz: fromAi(name: "thirdValue", description: "The third value to add"),
-                qux: fromAi(name: "fourthValue", description: "The fourth value to add", type: "array", schema: {
+                baz: fromAi(context: {}, name: "thirdValue", description: "The third value to add"),
+                qux: fromAi(context: {}, name: "fourthValue", description: "The fourth value to add", type: "array", schema: {
                   "items": {
                     "type": "string",
                     "enum": ["foo", "bar", "baz"]

--- a/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/adhoctoolsschema/feel/FeelInputParamExtractorTest.java
+++ b/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/adhoctoolsschema/feel/FeelInputParamExtractorTest.java
@@ -32,25 +32,25 @@ class FeelInputParamExtractorTest {
         new FeelInputParamTestCase(
             "Only expression: Name",
             """
-            fromAi({}, "aSimpleValue")
+            fromAi(toolCall.aSimpleValue)
             """,
             new FeelInputParam("aSimpleValue", null, null, null)),
         new FeelInputParamTestCase(
             "Only expression: Name + description",
             """
-            fromAi({}, "aSimpleValue", "A simple value")
+            fromAi(toolCall.aSimpleValue, "A simple value")
             """,
             new FeelInputParam("aSimpleValue", "A simple value", null, null)),
         new FeelInputParamTestCase(
             "Only expression: Name + description + type",
             """
-            fromAi({}, "aSimpleValue", "A simple value", "string")
+            fromAi(toolCall.aSimpleValue, "A simple value", "string")
             """,
             new FeelInputParam("aSimpleValue", "A simple value", "string", null)),
         new FeelInputParamTestCase(
             "Only expression: Name + description + type + schema",
             """
-            fromAi({}, "aSimpleValue", "A simple value", "string", { enum: ["A", "B", "C"] })
+            fromAi(toolCall.aSimpleValue, "A simple value", "string", { enum: ["A", "B", "C"] })
             """,
             new FeelInputParam(
                 "aSimpleValue",
@@ -58,9 +58,9 @@ class FeelInputParamExtractorTest {
                 "string",
                 Map.of("enum", List.of("A", "B", "C")))),
         new FeelInputParamTestCase(
-            "Only expression: Name + description + type + schema (expressions to generate params)",
+            "Only expression: Name + description + type + schema (expressions to generate schema)",
             """
-            fromAi({}, "a" + "Simple" + "Value", string join(["A", "simple", "value"], " "), "str" + "ing", context put({}, "enum", ["A", "B", "C"]))
+            fromAi(toolCall.aSimpleValue, "A simple value", "string", context put({}, "enum", ["A", "B", "C"]))
             """,
             new FeelInputParam(
                 "aSimpleValue",
@@ -70,25 +70,25 @@ class FeelInputParamExtractorTest {
         new FeelInputParamTestCase(
             "Only expression: Name (named params)",
             """
-            fromAi(context: {}, name: "aSimpleValue")
+            fromAi(value: toolCall.aSimpleValue)
             """,
             new FeelInputParam("aSimpleValue", null, null, null)),
         new FeelInputParamTestCase(
             "Only expression: Name + description (named params)",
             """
-            fromAi(context: {}, name: "aSimpleValue", description: "A simple value")
+            fromAi(value: toolCall.aSimpleValue, description: "A simple value")
             """,
             new FeelInputParam("aSimpleValue", "A simple value", null, null)),
         new FeelInputParamTestCase(
             "Only expression: Name + description + type (named params)",
             """
-            fromAi(context: {}, name: "aSimpleValue", description: "A simple value", type: "string")
+            fromAi(value: toolCall.aSimpleValue, description: "A simple value", type: "string")
             """,
             new FeelInputParam("aSimpleValue", "A simple value", "string", null)),
         new FeelInputParamTestCase(
             "Only expression: Name + description + type + schema (named params)",
             """
-            fromAi(context: {}, name: "aSimpleValue", description: "A simple value", type: "string", schema: { enum: ["A", "B", "C"] })
+            fromAi(value: toolCall.aSimpleValue, description: "A simple value", type: "string", schema: { enum: ["A", "B", "C"] })
             """,
             new FeelInputParam(
                 "aSimpleValue",
@@ -98,7 +98,7 @@ class FeelInputParamExtractorTest {
         new FeelInputParamTestCase(
             "Only expression: Name + description + type + schema (named params, mixed order)",
             """
-            fromAi(description: "A simple value", schema: { enum: ["A", "B", "C"] }, context: {}, type: "string", name: "aSimpleValue")
+            fromAi(description: "A simple value", schema: { enum: ["A", "B", "C"] }, type: "string", value: toolCall.aSimpleValue)
             """,
             new FeelInputParam(
                 "aSimpleValue",
@@ -106,9 +106,9 @@ class FeelInputParamExtractorTest {
                 "string",
                 Map.of("enum", List.of("A", "B", "C")))),
         new FeelInputParamTestCase(
-            "Only expression: Name + description + type + schema (named params, mixed order, expressions to generate params)",
+            "Only expression: Name + description + type + schema (named params, mixed order, expression to generate schema)",
             """
-            fromAi(description: string join(["A", "simple", "value"], " "), schema: context put({}, "enum", ["A", "B", "C"]), context: {}, type: "str" + "ing", name: "a" + "Simple" + "Value")
+            fromAi(description: "A simple value", schema: context put({}, "enum", ["A", "B", "C"]), type: "string", value: toolCall.aSimpleValue)
             """,
             new FeelInputParam(
                 "aSimpleValue",
@@ -118,7 +118,7 @@ class FeelInputParamExtractorTest {
         new FeelInputParamTestCase(
             "Array schema with sub-schema",
             """
-            fromAi({}, "multiValue", "Select a multi value", "array", {
+            fromAi(toolCall.multiValue, "Select a multi value", "array", {
               "items": {
                 "type": "string",
                 "enum": ["foo", "bar", "baz"]
@@ -133,13 +133,13 @@ class FeelInputParamExtractorTest {
         new FeelInputParamTestCase(
             "Part of operation (integer)",
             """
-            1 + 2 + fromAi({}, "thirdValue", "The third value to add", "integer")
+            1 + 2 + fromAi(toolCall.thirdValue, "The third value to add", "integer")
             """,
             new FeelInputParam("thirdValue", "The third value to add", "integer", null)),
         new FeelInputParamTestCase(
             "Part of string concatenation",
             """
-            "https://example.com/" + fromAi({}, "urlPath", "The URL path to use", "string")
+            "https://example.com/" + fromAi(toolCall.urlPath, "The URL path to use", "string")
             """,
             new FeelInputParam("urlPath", "The URL path to use", "string", null)),
         new FeelInputParamTestCase(
@@ -147,8 +147,8 @@ class FeelInputParamExtractorTest {
             """
             {
               foo: "bar",
-              bar: fromAi({}, "barValue", "A good bar value", "string"),
-              combined: fromAi({}, "firstOne", "The first value") + fromAi({}, "secondOne", "The second value", "string")
+              bar: fromAi(toolCall.barValue, "A good bar value", "string"),
+              combined: fromAi(toolCall.firstOne, "The first value") + fromAi(toolCall.secondOne, "The second value", "string")
             }
             """,
             new FeelInputParam("barValue", "A good bar value", "string", null),
@@ -157,7 +157,7 @@ class FeelInputParamExtractorTest {
         new FeelInputParamTestCase(
             "Multiple parameters, part of a list",
             """
-            ["something", fromAi({}, "firstValue", "The first value", "string"), fromAi({}, "secondValue", "The second value", "integer")]
+            ["something", fromAi(toolCall.firstValue, "The first value", "string"), fromAi(toolCall.secondValue, "The second value", "integer")]
             """,
             new FeelInputParam("firstValue", "The first value", "string", null),
             new FeelInputParam("secondValue", "The second value", "integer", null)),
@@ -165,9 +165,9 @@ class FeelInputParamExtractorTest {
             "Multiple parameters, part of a context and list",
             """
             {
-              foo: [fromAi({}, "firstValue", "The first value", "string"), fromAi({}, "secondValue", "The second value", "integer")],
+              foo: [fromAi(toolCall.firstValue, "The first value", "string"), fromAi(toolCall.secondValue, "The second value", "integer")],
               bar: {
-                baz: fromAi({}, "thirdValue", "The third value to add")
+                baz: fromAi(toolCall.thirdValue, "The third value to add")
               }
             }
             """,
@@ -178,10 +178,10 @@ class FeelInputParamExtractorTest {
             "Multiple parameters, part of a context and list (named params)",
             """
             {
-              foo: [fromAi(context: {}, name: "firstValue", description: "The first value", type: "string"), fromAi(context: {}, description: "The second value", type: "integer", name: "secondValue")],
+              foo: [fromAi(value: toolCall.firstValue, description: "The first value", type: "string"), fromAi(description: "The second value", type: "integer", value: toolCall.secondValue)],
               bar: {
-                baz: fromAi(context: {}, name: "thirdValue", description: "The third value to add"),
-                qux: fromAi(context: {}, name: "fourthValue", description: "The fourth value to add", type: "array", schema: {
+                baz: fromAi(value: toolCall.thirdValue, description: "The third value to add"),
+                qux: fromAi(value: toolCall.fourthValue, description: "The fourth value to add", type: "array", schema: {
                   "items": {
                     "type": "string",
                     "enum": ["foo", "bar", "baz"]

--- a/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/adhoctoolsschema/resolver/schema/DefaultAdHocToolSchemaGeneratorTest.java
+++ b/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/adhoctoolsschema/resolver/schema/DefaultAdHocToolSchemaGeneratorTest.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.agenticai.adhoctoolsschema.resolver.schema;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.connector.agenticai.adhoctoolsschema.feel.FeelInputParam;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
+
+class DefaultAdHocToolSchemaGeneratorTest {
+
+  private final DefaultAdHocToolSchemaGenerator generator = new DefaultAdHocToolSchemaGenerator();
+  private final ObjectMapper objectMapper = new ObjectMapper();
+
+  @Test
+  void usesProvidedSchemaProperty() throws Exception {
+    List<FeelInputParam> inputParams =
+        List.of(
+            new FeelInputParam(
+                "param1",
+                null,
+                null,
+                Map.of("description", "A nice description", "type", "string")));
+
+    assertJsonSchema(
+        inputParams,
+        """
+        {
+          "type": "object",
+          "properties": {
+            "param1": {
+              "type": "string",
+              "description": "A nice description"
+            }
+          },
+          "required": ["param1"]
+        }
+        """);
+  }
+
+  @Test
+  void overwritesTypeAndDescriptionFromDedicatedParams() throws Exception {
+    List<FeelInputParam> inputParams =
+        List.of(
+            new FeelInputParam(
+                "param1",
+                "Overridden description",
+                "number",
+                Map.of("description", "A nice description", "type", "string")));
+
+    assertJsonSchema(
+        inputParams,
+        """
+        {
+          "type": "object",
+          "properties": {
+            "param1": {
+              "type": "number",
+              "description": "Overridden description"
+            }
+          },
+          "required": ["param1"]
+        }
+        """);
+  }
+
+  @Test
+  void defaultsToStringType() throws Exception {
+    List<FeelInputParam> inputParams = List.of(new FeelInputParam("param1", "A nice description"));
+
+    assertJsonSchema(
+        inputParams,
+        """
+        {
+          "type": "object",
+          "properties": {
+            "param1": {
+              "type": "string",
+              "description": "A nice description"
+            }
+          },
+          "required": ["param1"]
+        }
+        """);
+  }
+
+  @Test
+  void defaultsToStringTypeWithSchemaObject() throws Exception {
+    List<FeelInputParam> inputParams =
+        List.of(
+            new FeelInputParam(
+                "param1", "A nice description", null, Map.of("enum", List.of("A", "B", "C"))));
+
+    assertJsonSchema(
+        inputParams,
+        """
+        {
+          "type": "object",
+          "properties": {
+            "param1": {
+              "type": "string",
+              "description": "A nice description",
+              "enum": ["A", "B", "C"]
+            }
+          },
+          "required": ["param1"]
+        }
+        """);
+  }
+
+  @Test
+  void supportsMultipleProperties() throws Exception {
+    List<FeelInputParam> inputParams =
+        List.of(
+            new FeelInputParam("param1", "The first param"),
+            new FeelInputParam("param2", "The second param", "number"),
+            new FeelInputParam(
+                "param3", "The third param", "string", Map.of("enum", List.of("A", "B", "C"))));
+
+    assertJsonSchema(
+        inputParams,
+        """
+        {
+          "type": "object",
+          "properties": {
+            "param1": {
+              "type": "string",
+              "description": "The first param"
+            },
+            "param2": {
+              "type": "number",
+              "description": "The second param"
+            },
+            "param3": {
+              "type": "string",
+              "description": "The third param",
+              "enum": ["A", "B", "C"]
+            }
+          },
+          "required": ["param1", "param2", "param3"]
+        }
+        """);
+  }
+
+  @Test
+  void throwsExceptionWhenRestrictedParamNameIsUsed() {
+    List<FeelInputParam> inputParams = List.of(new FeelInputParam("_meta", "string"));
+
+    assertThatThrownBy(() -> generator.generateToolSchema(inputParams))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Input parameter name '_meta' is restricted and cannot be used.");
+  }
+
+  @Test
+  void throwsExceptionWhenDuplicateParamNameIsUsed() {
+    List<FeelInputParam> inputParams =
+        List.of(new FeelInputParam("param1", "string"), new FeelInputParam("param1", "string"));
+
+    assertThatThrownBy(() -> generator.generateToolSchema(inputParams))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Duplicate input parameter name: param1");
+  }
+
+  private void assertJsonSchema(List<FeelInputParam> inputParams, String expectedJsonSchema)
+      throws Exception {
+    Map<String, Object> schema = generator.generateToolSchema(inputParams);
+    assertJsonSchema(schema, expectedJsonSchema);
+  }
+
+  private void assertJsonSchema(Map<String, Object> schema, String expectedJsonSchema)
+      throws Exception {
+    JSONAssert.assertEquals(expectedJsonSchema, objectMapper.writeValueAsString(schema), true);
+  }
+}

--- a/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/model/AgentResponseTest.java
+++ b/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/model/AgentResponseTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.agenticai.aiagent.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Map;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
+
+class AgentResponseTest {
+
+  private final ObjectMapper objectMapper = new ObjectMapper();
+
+  @Nested
+  class ToolCall {
+
+    private static final AgentResponse.ToolCall TOOL_CALL =
+        new AgentResponse.ToolCall("123456", "toolName", Map.of("foo", "bar", "baz", "qux"));
+    private static final String TOOL_CALL_JSON_VALUE =
+        """
+            {
+              "_meta": {
+                "id": "123456",
+                "name": "toolName"
+              },
+              "foo": "bar",
+              "baz": "qux"
+            }
+            """;
+
+    @Test
+    void canBeSerialized() throws Exception {
+      final var json = objectMapper.writeValueAsString(TOOL_CALL);
+      JSONAssert.assertEquals(TOOL_CALL_JSON_VALUE, json, true);
+    }
+
+    @Test
+    void canBeDeserialized() throws Exception {
+      final var toolCall =
+          objectMapper.readValue(TOOL_CALL_JSON_VALUE, AgentResponse.ToolCall.class);
+      assertThat(toolCall).usingRecursiveComparison().isEqualTo(TOOL_CALL);
+    }
+  }
+}

--- a/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/autoconfigure/AgenticAiConnectorsAutoConfigurationTest.java
+++ b/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/autoconfigure/AgenticAiConnectorsAutoConfigurationTest.java
@@ -17,6 +17,7 @@ import io.camunda.connector.agenticai.adhoctoolsschema.feel.FeelInputParamExtrac
 import io.camunda.connector.agenticai.adhoctoolsschema.resolver.AdHocToolsSchemaResolver;
 import io.camunda.connector.agenticai.adhoctoolsschema.resolver.CachingAdHocToolsSchemaResolver;
 import io.camunda.connector.agenticai.adhoctoolsschema.resolver.CamundaClientAdHocToolsSchemaResolver;
+import io.camunda.connector.agenticai.adhoctoolsschema.resolver.schema.AdHocToolSchemaGenerator;
 import io.camunda.connector.agenticai.aiagent.AiAgentFunction;
 import io.camunda.connector.agenticai.aiagent.agent.AiAgentRequestHandler;
 import io.camunda.connector.agenticai.aiagent.provider.ChatModelFactory;
@@ -36,6 +37,7 @@ class AgenticAiConnectorsAutoConfigurationTest {
   private static final List<Class<?>> AGENTIC_AI_BEANS =
       List.of(
           FeelInputParamExtractor.class,
+          AdHocToolSchemaGenerator.class,
           AdHocToolsSchemaResolver.class,
           AdHocToolsSchemaFunction.class,
           ChatModelFactory.class,

--- a/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/autoconfigure/AgenticAiConnectorsAutoConfigurationTest.java
+++ b/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/autoconfigure/AgenticAiConnectorsAutoConfigurationTest.java
@@ -13,6 +13,7 @@ import static org.mockito.Mockito.mock;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.client.CamundaClient;
 import io.camunda.connector.agenticai.adhoctoolsschema.AdHocToolsSchemaFunction;
+import io.camunda.connector.agenticai.adhoctoolsschema.feel.FeelInputParamExtractor;
 import io.camunda.connector.agenticai.adhoctoolsschema.resolver.AdHocToolsSchemaResolver;
 import io.camunda.connector.agenticai.adhoctoolsschema.resolver.CachingAdHocToolsSchemaResolver;
 import io.camunda.connector.agenticai.adhoctoolsschema.resolver.CamundaClientAdHocToolsSchemaResolver;
@@ -34,6 +35,7 @@ class AgenticAiConnectorsAutoConfigurationTest {
 
   private static final List<Class<?>> AGENTIC_AI_BEANS =
       List.of(
+          FeelInputParamExtractor.class,
           AdHocToolsSchemaResolver.class,
           AdHocToolsSchemaFunction.class,
           ChatModelFactory.class,
@@ -50,7 +52,7 @@ class AgenticAiConnectorsAutoConfigurationTest {
   protected static class TestConfig {
     @Bean
     public ObjectMapper objectMapper() {
-      return mock(ObjectMapper.class);
+      return new ObjectMapper();
     }
 
     @Bean


### PR DESCRIPTION
## Description

See #4634 for background. This PR moves the definition of inputs which need to be provided by an LLM in an agentic context from a JSON schema in the `documentation` block to individual `fromAi()` function calls which define the metadata/schema of the input properties.

Instead of parsing a JSON schema from the `documentation` element, the tools schema resolver now looks for `fromAi` FEEL function calls in input and output mappings and collects them to generate the tool schema. The first argument to the `fromAi()` function needs to reference the injected variable in the `toolCall` object which contains all LLM-generated inputs.

In addition, this PR renames `toolToCall`/`toolsToCall` to `toolCall`/`toolCalls` (reflected in the e2e tests).

**Note:** I added the current working use cases to the `examples` folder so we can develop them in parallel with the implementation. If needed we can also do this on a dedicated PR. In terms of review I think we can ignore them.

### Examples

A task with an input mapping containing `fromAi(toolCall.myVariable, "This is our first variable")` will result in the following JSON schema. If multiple `fromAi` calls are used in the same task, they are all added to the task schema.

```json
{
  "name": "MyTask",
  "description": "Some description.",
  "inputSchema": {
    "type": "object",
    "properties": {
      "myVariable": {
        "type": "string",
        "description": "This is our first variable"
      }
    },
    "required": [
      "myVariable"
    ]
  }
}
```

Mappings can define very simple inputs (defaulting to string):
```
fromAi(toolCall.userId)
```

Or more complex ones, including a schema:
```
fromAi(toolCall.anEnumValue, "An enum value", "string", { enum: ["A", "B", "C"] })
```

An optional last parameter `options` supports passing a map of options which are currently unused, but reserved for future use (e.g. to provide metadata, mark properties as optional, ...).

### Parameter name resolution

The examples above showcase the value being defined as `toolCall.myVariable` which will be a pattern implemented by this connector. The engine implementation of `fromAi` does not restrict the value format, but the parsing implementation requires the value to be an object dereference as doing so allows us to use the field name as variable name. 

In the example above, a variable `myVariable` is derived from the `fromAi` function call.

### Schema extraction logic

As all parameters besides the value are optional, the schema is built in the following way:

- If the `schema` property is defined, its value be used as the initial schema. Otherwise, an empty JSON schema object is initialized to `{}`.
- If the `type` property is set, it will be applied to the schema (`{"type": "number"}`), potentially overwriting a type which was directly defined on the schema object.
- If no type is set after reading `schema` and `type` properties, a default value of `{"type": "string"}` will be set.
- If the `description` property is set, it will be applied to the schema (`{"description": "My property"}`), potentially overwriting a description which was directly defined on the schema object.

This process is repeated for every parameter and combined to a task schema like in the example above. In this implementation, all properties are defined as required, but this can be adapted in a follow-up if needed.

### Repeated usage of the same input value name

A `fromAi()` function for a certain value can only be used once per task to avoid ambiguity, however as the value part accesses an existing value, a value can be directly referenced in case it is needed multiple times:

```
{
  first: fromAi(toolCall.first, "The first parameter", "number"),
  second: fromAi(toolCall.second, "The second parameter", "string", { enum: ["A", "B", "C"] }),
  allParams: [toolCall.first, toolCall.second]
}
```

The following will raise an incident due to the repeated usage of the same value ❌ 
```
{
  first: fromAi(toolCall.first, "The first parameter", "number"),
  first2: fromAi(toolCall.first, "Testme")
}
```

## Related issues

Based on https://github.com/camunda/connectors/pull/4548.
Depends on https://github.com/camunda/camunda/pull/31259 to implement `fromAi()` support in the engine ✅ 

closes #4634

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.

