### PR TITLE
fix(email-connector): fix for inbound email connector when an email cant be moved

### DIFF
--- a/connectors/email/pom.xml
+++ b/connectors/email/pom.xml
@@ -37,6 +37,12 @@
             <version>2.1.3</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <version>4.3.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/connectors/email/src/main/java/io/camunda/connector/email/client/jakarta/inbound/PollingManager.java
+++ b/connectors/email/src/main/java/io/camunda/connector/email/client/jakarta/inbound/PollingManager.java
@@ -146,8 +146,6 @@ public class PollingManager {
     }
   }
 
-  private void manageException(Exception e) {}
-
   private void processMail(IMAPMessage message, PollingConfig pollingConfig) {
     // Setting `peek` to true prevents the library to trigger any side effects when reading the
     // message, such as marking it as read

--- a/connectors/email/src/main/java/io/camunda/connector/email/client/jakarta/inbound/PollingManager.java
+++ b/connectors/email/src/main/java/io/camunda/connector/email/client/jakarta/inbound/PollingManager.java
@@ -122,7 +122,7 @@ public class PollingManager {
       Arrays.stream(messages).forEach(message -> this.processMail((IMAPMessage) message, pollAll));
     } catch (Exception e) {
       this.connectorContext.log(
-              Activity.level(Severity.ERROR).tag("mail-polling").message(e.getMessage()));
+          Activity.level(Severity.ERROR).tag("mail-polling").message(e.getMessage()));
       this.connectorContext.cancel(new ConnectorException(e.getMessage(), e));
     }
   }
@@ -135,20 +135,18 @@ public class PollingManager {
           .forEach(message -> this.processMail((IMAPMessage) message, pollUnseen));
     } catch (Exception e) {
       this.connectorContext.log(
-              Activity.level(Severity.ERROR).tag("mail-polling").message(e.getMessage()));
+          Activity.level(Severity.ERROR).tag("mail-polling").message(e.getMessage()));
       this.connectorContext.cancel(
-              ConnectorRetryException.builder()
-                      .cause(e)
-                      .message(e.getMessage())
-                      .retries(2)
-                      .backoffDuration(Duration.of(3, ChronoUnit.SECONDS))
-                      .build());
+          ConnectorRetryException.builder()
+              .cause(e)
+              .message(e.getMessage())
+              .retries(2)
+              .backoffDuration(Duration.of(3, ChronoUnit.SECONDS))
+              .build());
     }
   }
 
-  private void manageException(Exception e) {
-
-  }
+  private void manageException(Exception e) {}
 
   private void processMail(IMAPMessage message, PollingConfig pollingConfig) {
     // Setting `peek` to true prevents the library to trigger any side effects when reading the

--- a/connectors/email/src/main/java/io/camunda/connector/email/client/jakarta/inbound/PollingManager.java
+++ b/connectors/email/src/main/java/io/camunda/connector/email/client/jakarta/inbound/PollingManager.java
@@ -143,7 +143,10 @@ public class PollingManager {
     switch (pollingConfig.handlingStrategy()) {
       case READ -> this.jakartaUtils.markAsSeen(message);
       case DELETE -> this.jakartaUtils.markAsDeleted(message);
-      case MOVE -> this.jakartaUtils.moveMessage(this.store, message, pollingConfig.targetFolder());
+      case MOVE -> {
+        this.jakartaUtils.markAsSeen(message);
+        this.jakartaUtils.moveMessage(this.store, message, pollingConfig.targetFolder());
+      }
     }
   }
 

--- a/connectors/email/src/main/java/io/camunda/connector/email/client/jakarta/utils/JakartaUtils.java
+++ b/connectors/email/src/main/java/io/camunda/connector/email/client/jakarta/utils/JakartaUtils.java
@@ -284,8 +284,8 @@ public class JakartaUtils {
       throws MessagingException, IOException {
     BodyPart bodyPart = multipart.getBodyPart(i);
     switch (bodyPart.getContent()) {
-      case InputStream attachment when Part.ATTACHMENT.equalsIgnoreCase(
-              bodyPart.getDisposition()) ->
+      case InputStream attachment
+          when Part.ATTACHMENT.equalsIgnoreCase(bodyPart.getDisposition()) ->
           emailBodyBuilder.addAttachment(
               new EmailAttachment(
                   attachment,
@@ -326,12 +326,10 @@ public class JakartaUtils {
               .orElseThrow(() -> new RuntimeException("No folder has been set"));
       Folder targetImapFolder = store.getFolder(targetFolderFormatted);
       if (!targetImapFolder.exists()) targetImapFolder.create(Folder.HOLDS_MESSAGES);
-      if (targetImapFolder.exists()) {
-        targetImapFolder.open(Folder.READ_WRITE);
-        imapFolder.copyMessages(new Message[] {message}, targetImapFolder);
-        this.markAsDeleted(message);
-        targetImapFolder.close();
-      }
+      targetImapFolder.open(Folder.READ_WRITE);
+      imapFolder.copyMessages(new Message[] {message}, targetImapFolder);
+      this.markAsDeleted(message);
+      targetImapFolder.close();
     } catch (MessagingException e) {
       throw new RuntimeException(e);
     }

--- a/connectors/email/src/main/java/io/camunda/connector/email/client/jakarta/utils/JakartaUtils.java
+++ b/connectors/email/src/main/java/io/camunda/connector/email/client/jakarta/utils/JakartaUtils.java
@@ -326,10 +326,12 @@ public class JakartaUtils {
               .orElseThrow(() -> new RuntimeException("No folder has been set"));
       Folder targetImapFolder = store.getFolder(targetFolderFormatted);
       if (!targetImapFolder.exists()) targetImapFolder.create(Folder.HOLDS_MESSAGES);
-      targetImapFolder.open(Folder.READ_WRITE);
-      imapFolder.copyMessages(new Message[] {message}, targetImapFolder);
-      this.markAsDeleted(message);
-      targetImapFolder.close();
+      if (targetImapFolder.exists()) {
+        targetImapFolder.open(Folder.READ_WRITE);
+        imapFolder.copyMessages(new Message[] {message}, targetImapFolder);
+        this.markAsDeleted(message);
+        targetImapFolder.close();
+      }
     } catch (MessagingException e) {
       throw new RuntimeException(e);
     }

--- a/connectors/email/src/main/java/io/camunda/connector/email/client/jakarta/utils/JakartaUtils.java
+++ b/connectors/email/src/main/java/io/camunda/connector/email/client/jakarta/utils/JakartaUtils.java
@@ -284,8 +284,8 @@ public class JakartaUtils {
       throws MessagingException, IOException {
     BodyPart bodyPart = multipart.getBodyPart(i);
     switch (bodyPart.getContent()) {
-      case InputStream attachment
-          when Part.ATTACHMENT.equalsIgnoreCase(bodyPart.getDisposition()) ->
+      case InputStream attachment when Part.ATTACHMENT.equalsIgnoreCase(
+              bodyPart.getDisposition()) ->
           emailBodyBuilder.addAttachment(
               new EmailAttachment(
                   attachment,


### PR DESCRIPTION
## Description

Some IMAP servers do not permit folder creation:

- Infomaniak allows it.
- Gmail does not.

When the folder did not exist on Gmail, the scheduler malfunctioned due to an exception being thrown. To prevent this issue, we now mark the email as 'read' before attempting to move it, ensuring that it is not processed again, thereby improving the system's efficiency.

If an exception occurs because the folder could not be created, and we are reading only unseen emails, the connector is canceled with a RetryException. If we are reading all emails, the connector is canceled with a ConnectorException.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes https://github.com/camunda/connectors/issues/4367

## Checklist

- [ ] PR has a **milestone** or the `no milestone` label.

