### PR TITLE
chore(renovate): Match all release branches with regex

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -60,13 +60,5 @@
       "enabled": false
     }
   ],
-  "baseBranches": [
-    "main",
-    "release/8.3",
-    "release/8.4",
-    "release/8.5",
-    "release/8.6",
-    "release/8.7",
-    "release/8.8"
-  ]
+  "baseBranches": ["main", "/^release\\/.*/"]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -60,5 +60,11 @@
       "enabled": false
     }
   ],
-  "baseBranches": ["main", "/^release\\/.*/"]
+  "baseBranches": [
+    "main",
+    "release/8.4",
+    "release/8.5",
+    "release/8.6",
+    "release/8.7"
+  ]
 }


### PR DESCRIPTION
## Description
Added regex to match base release branches. Should we do this or should we do back to the list and not include 8.8? Do we want to run renovate on latest not yet released release branch?


## Checklist

- [x] PR has a **milestone** or the `no milestone` label.

