### PR TITLE
other(manage-and-run): fix pods URL using HTTP not HTTPS

### DIFF
--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/http/DefaultInstancesUrlBuilder.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/http/DefaultInstancesUrlBuilder.java
@@ -64,7 +64,7 @@ public class DefaultInstancesUrlBuilder implements InstancesUrlBuilder {
               "No Connectors Runtime addresses found for hostname: " + headlessServiceHost);
         }
         return Stream.of(addresses)
-            .map(ip -> "https://" + ip + ":" + appPort)
+            .map(ip -> "http://" + ip + ":" + appPort)
             .collect(Collectors.toSet());
       } catch (UnknownHostException e) {
         LOGGER.error(
@@ -78,7 +78,7 @@ public class DefaultInstancesUrlBuilder implements InstancesUrlBuilder {
             "An error occurred while resolving hostname: " + headlessServiceHost, e);
       }
     } else {
-      return Set.of("https://localhost" + ":" + appPort);
+      return Set.of("http://localhost" + ":" + appPort);
     }
   }
 

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/http/DefaultInstancesUrlBuilderTest.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/http/DefaultInstancesUrlBuilderTest.java
@@ -46,8 +46,8 @@ public class DefaultInstancesUrlBuilderTest {
 
     // then
     assertThat(urls).hasSize(2);
-    assertThat(urls.get(0)).isEqualTo("https://10.0.0.10:8080/test/path");
-    assertThat(urls.get(1)).isEqualTo("https://10.0.0.11:8080/test/path");
+    assertThat(urls.get(0)).isEqualTo("http://10.0.0.10:8080/test/path");
+    assertThat(urls.get(1)).isEqualTo("http://10.0.0.11:8080/test/path");
   }
 
   @Test

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/http/InstanceForwardingHttpClientTest.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/http/InstanceForwardingHttpClientTest.java
@@ -64,7 +64,7 @@ public class InstanceForwardingHttpClientTest {
                             .uri()
                             .toString()
                             .equals(
-                                "https://"
+                                "http://"
                                     + IP_1
                                     + ":8080/test/path?queryParam1=value1&queryParam2=value2")
                         && request.method().equals("GET")
@@ -84,7 +84,7 @@ public class InstanceForwardingHttpClientTest {
                             .uri()
                             .toString()
                             .equals(
-                                "https://"
+                                "http://"
                                     + IP_2
                                     + ":8080/test/path?queryParam1=value1&queryParam2=value2")
                         && request.method().equals("GET")


### PR DESCRIPTION
## Description

Pods should be contacted using HTTP not HTTPS.
