### PR TITLE
fix(intrinsic-functions): introduce guardrails for intrinsic functions

### DIFF
--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/ConnectorHelper.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/ConnectorHelper.java
@@ -25,6 +25,7 @@ import io.camunda.connector.api.error.ConnectorInputException;
 import io.camunda.connector.api.inbound.InboundConnectorExecutable;
 import io.camunda.connector.api.json.ConnectorsObjectMapperSupplier;
 import io.camunda.connector.api.outbound.OutboundConnectorFunction;
+import io.camunda.connector.document.jackson.IntrinsicFunctionModel;
 import io.camunda.connector.feel.FeelEngineWrapper;
 import io.camunda.connector.feel.FeelEngineWrapperException;
 import io.camunda.connector.runtime.core.error.BpmnError;
@@ -32,6 +33,7 @@ import io.camunda.connector.runtime.core.error.ConnectorError;
 import io.camunda.connector.runtime.core.outbound.ErrorExpressionJobContext;
 import java.lang.reflect.InvocationTargetException;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -40,6 +42,8 @@ public class ConnectorHelper {
   private static final String ERROR_CANNOT_PARSE_VARIABLES = "Cannot parse '%s' as '%s'.";
   public static FeelEngineWrapper FEEL_ENGINE_WRAPPER = new FeelEngineWrapper();
   public static ObjectMapper OBJECT_MAPPER = ConnectorsObjectMapperSupplier.getCopy();
+
+  public static List<String> FORBIDDEN_LITERALS = List.of(IntrinsicFunctionModel.DISCRIMINATOR_KEY);
 
   /**
    * @return a map with output process variables for a given response from an {@link
@@ -61,6 +65,7 @@ public class ConnectorHelper {
           FEEL_ENGINE_WRAPPER.evaluateToJson(
               resultExpression, responseContent, wrapResponse(responseContent));
       if (mappedResponseJson != null) {
+        verifyNoForbiddenLiterals(mappedResponseJson);
         var mappedResponse =
             parseJsonVarsAsTypeOrThrow(mappedResponseJson, Map.class, resultExpression);
         if (mappedResponse != null) {
@@ -119,5 +124,19 @@ public class ConnectorHelper {
               jsonVars,
               e));
     }
+  }
+
+  private static void verifyNoForbiddenLiterals(String json) {
+    FORBIDDEN_LITERALS.forEach(
+        literal -> {
+          if (json.contains(literal)) {
+            throw new ConnectorInputException(
+                new FeelEngineWrapperException(
+                    String.format(
+                        "The connector result contains a forbidden literal '%s'.", literal),
+                    literal,
+                    json));
+          }
+        });
   }
 }

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/ConnectorHelperTest.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/ConnectorHelperTest.java
@@ -17,9 +17,11 @@
 package io.camunda.connector.runtime.core;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
+import io.camunda.connector.api.error.ConnectorInputException;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
@@ -54,15 +56,15 @@ class ConnectorHelperTest {
         ConnectorHelper.OBJECT_MAPPER.readValue(
             ConnectorHelper.FEEL_ENGINE_WRAPPER.evaluateToJson(
                 """
-				{
-					res1: data[item.attr = "value1"][1].date,
-				                res2: "hallo" + res1,
-				                res3: 1 + 2,
-					res4: data[item.date = "2024-02-01"][1].attr,
-					res5: data[date(item.date) = date("2024-02-01")][1].attr,
-					res6: today()
-				}
-				""",
+                    {
+                    	res1: data[item.attr = "value1"][1].date,
+                                    res2: "hallo" + res1,
+                                    res3: 1 + 2,
+                    	res4: data[item.date = "2024-02-01"][1].attr,
+                    	res5: data[date(item.date) = date("2024-02-01")][1].attr,
+                    	res6: today()
+                    }
+                    """,
                 jsonDeserialized2),
             new TypeReference<Map<String, Object>>() {});
 
@@ -74,5 +76,25 @@ class ConnectorHelperTest {
             Map.entry("res4", "value2"),
             Map.entry("res5", "value2"),
             Map.entry("res6", LocalDate.now().format(DateTimeFormatter.ISO_LOCAL_DATE)));
+  }
+
+  @Test
+  void ensureCanNotProduceIntrinsicFunction() {
+    final String resultExpression =
+        """
+        {
+          "camunda.function.type": myfun,
+          "params": ["test"]
+        }
+        """;
+    final Map<String, String> context = Map.of("myfun", "test");
+    final var exception =
+        assertThrows(
+            ConnectorInputException.class,
+            () -> ConnectorHelper.createOutputVariables(context, null, resultExpression));
+
+    assertThat(exception)
+        .hasMessageContaining(
+            "The connector result contains a forbidden literal 'camunda.function.type'");
   }
 }

--- a/connector-sdk/jackson-datatype-document/src/main/java/io/camunda/connector/document/jackson/JacksonModuleDocumentDeserializer.java
+++ b/connector-sdk/jackson-datatype-document/src/main/java/io/camunda/connector/document/jackson/JacksonModuleDocumentDeserializer.java
@@ -62,18 +62,23 @@ public class JacksonModuleDocumentDeserializer extends SimpleModule {
   @Override
   public void setupModule(SetupContext context) {
     addDeserializer(
-        Document.class, new DocumentDeserializer(documentFactory, intrinsicFunctionExecutor));
+        Document.class,
+        new DocumentDeserializer(documentFactory, intrinsicFunctionExecutor, settings));
     addDeserializer(
-        byte[].class, new ByteArrayDeserializer(documentFactory, intrinsicFunctionExecutor));
+        byte[].class,
+        new ByteArrayDeserializer(documentFactory, intrinsicFunctionExecutor, settings));
     addDeserializer(
-        InputStream.class, new InputStreamDeserializer(documentFactory, intrinsicFunctionExecutor));
-    if (settings.enableObject) {
+        InputStream.class,
+        new InputStreamDeserializer(documentFactory, intrinsicFunctionExecutor, settings));
+    if (settings.isObjectEnabled()) {
       addDeserializer(
-          Object.class, new ObjectDeserializer(documentFactory, intrinsicFunctionExecutor));
+          Object.class,
+          new ObjectDeserializer(documentFactory, intrinsicFunctionExecutor, settings));
     }
-    if (settings.enableString) {
+    if (settings.isStringEnabled()) {
       addDeserializer(
-          String.class, new StringDeserializer(documentFactory, intrinsicFunctionExecutor));
+          String.class,
+          new StringDeserializer(documentFactory, intrinsicFunctionExecutor, settings));
     }
     super.setupModule(context);
   }
@@ -82,6 +87,7 @@ public class JacksonModuleDocumentDeserializer extends SimpleModule {
 
     private boolean enableObject = true;
     private boolean enableString = true;
+    private int maxIntrinsicFunctions = 10; // per deserialization run, including nested
 
     private DocumentModuleSettings() {}
 
@@ -97,6 +103,23 @@ public class JacksonModuleDocumentDeserializer extends SimpleModule {
     /** Enable deserialization of document references into strings. */
     public void enableString(boolean enable) {
       this.enableString = enable;
+    }
+
+    /** Set the maximum number of intrinsic functions per object. */
+    public void setMaxIntrinsicFunctions(int maxIntrinsicFunctions) {
+      this.maxIntrinsicFunctions = maxIntrinsicFunctions;
+    }
+
+    public boolean isObjectEnabled() {
+      return enableObject;
+    }
+
+    public boolean isStringEnabled() {
+      return enableString;
+    }
+
+    public int getMaxIntrinsicFunctions() {
+      return maxIntrinsicFunctions;
     }
   }
 }

--- a/connector-sdk/jackson-datatype-document/src/main/java/io/camunda/connector/document/jackson/deserializer/AbstractDeserializer.java
+++ b/connector-sdk/jackson-datatype-document/src/main/java/io/camunda/connector/document/jackson/deserializer/AbstractDeserializer.java
@@ -20,10 +20,17 @@ import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.JsonNode;
+import io.camunda.connector.document.jackson.JacksonModuleDocumentDeserializer.DocumentModuleSettings;
 import java.io.IOException;
 
 /** Base class for deserializers within the document module. */
 public abstract class AbstractDeserializer<T> extends JsonDeserializer<T> {
+
+  protected final DocumentModuleSettings settings;
+
+  public AbstractDeserializer(DocumentModuleSettings settings) {
+    this.settings = settings;
+  }
 
   /**
    * Base method from {@link JsonDeserializer} to deserialize a JSON node. It will delegate to
@@ -33,6 +40,7 @@ public abstract class AbstractDeserializer<T> extends JsonDeserializer<T> {
   @Override
   public T deserialize(JsonParser jsonParser, DeserializationContext deserializationContext)
       throws IOException {
+    DeserializationUtil.ensureIntrinsicFunctionCounterInitialized(deserializationContext, settings);
     final JsonNode node = jsonParser.readValueAsTree();
     if (node == null || node.isNull()) {
       return null;

--- a/connector-sdk/jackson-datatype-document/src/main/java/io/camunda/connector/document/jackson/deserializer/DeserializationUtil.java
+++ b/connector-sdk/jackson-datatype-document/src/main/java/io/camunda/connector/document/jackson/deserializer/DeserializationUtil.java
@@ -16,17 +16,40 @@
  */
 package io.camunda.connector.document.jackson.deserializer;
 
+import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonNode;
 import io.camunda.connector.document.jackson.DocumentReferenceModel;
 import io.camunda.connector.document.jackson.IntrinsicFunctionModel;
+import io.camunda.connector.document.jackson.JacksonModuleDocumentDeserializer.DocumentModuleSettings;
 
 public class DeserializationUtil {
+
+  public static final String INTRINSIC_FUNCTION_LIMIT_REMAINING = "IntrinsicFunctionLimitRemaining";
 
   public static boolean isDocumentReference(JsonNode node) {
     return node.has(DocumentReferenceModel.DISCRIMINATOR_KEY);
   }
 
-  public static boolean isOperation(JsonNode node) {
+  public static boolean isIntrinsicFunction(JsonNode node) {
     return node.has(IntrinsicFunctionModel.DISCRIMINATOR_KEY);
+  }
+
+  public static void ensureIntrinsicFunctionCounterInitialized(
+      DeserializationContext ctxt, DocumentModuleSettings settings) {
+    if (ctxt.getAttribute(INTRINSIC_FUNCTION_LIMIT_REMAINING) == null) {
+      ctxt.setAttribute(INTRINSIC_FUNCTION_LIMIT_REMAINING, settings.getMaxIntrinsicFunctions());
+    }
+  }
+
+  public static void tryDecrementIntrinsicFunctionCounter(DeserializationContext ctxt) {
+    final Integer remaining = (Integer) ctxt.getAttribute(INTRINSIC_FUNCTION_LIMIT_REMAINING);
+    if (remaining == null) {
+      throw new IllegalStateException("Intrinsic function counter not initialized");
+    }
+    if (remaining <= 0) {
+      throw new IllegalStateException("Intrinsic function limit exceeded");
+    }
+    // thread-safe because the context object is not shared
+    ctxt.setAttribute(INTRINSIC_FUNCTION_LIMIT_REMAINING, remaining - 1);
   }
 }

--- a/connector-sdk/jackson-datatype-document/src/main/java/io/camunda/connector/document/jackson/deserializer/IntrinsicFunctionObjectResultDeserializer.java
+++ b/connector-sdk/jackson-datatype-document/src/main/java/io/camunda/connector/document/jackson/deserializer/IntrinsicFunctionObjectResultDeserializer.java
@@ -16,11 +16,12 @@
  */
 package io.camunda.connector.document.jackson.deserializer;
 
-import static io.camunda.connector.document.jackson.deserializer.DeserializationUtil.isOperation;
+import static io.camunda.connector.document.jackson.deserializer.DeserializationUtil.isIntrinsicFunction;
 
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonNode;
 import io.camunda.connector.document.jackson.IntrinsicFunctionModel;
+import io.camunda.connector.document.jackson.JacksonModuleDocumentDeserializer.DocumentModuleSettings;
 import io.camunda.intrinsic.IntrinsicFunctionExecutor;
 import io.camunda.intrinsic.IntrinsicFunctionParams;
 import java.io.IOException;
@@ -29,17 +30,20 @@ public class IntrinsicFunctionObjectResultDeserializer extends AbstractDeseriali
 
   private final IntrinsicFunctionExecutor operationExecutor;
 
-  public IntrinsicFunctionObjectResultDeserializer(IntrinsicFunctionExecutor operationExecutor) {
+  public IntrinsicFunctionObjectResultDeserializer(
+      IntrinsicFunctionExecutor operationExecutor, DocumentModuleSettings settings) {
+    super(settings);
     this.operationExecutor = operationExecutor;
   }
 
   @Override
   protected Object handleJsonNode(JsonNode node, DeserializationContext context)
       throws IOException {
-    if (!isOperation(node)) {
+    if (!isIntrinsicFunction(node)) {
       throw new IllegalArgumentException(
           "Unsupported document format. Expected an operation, got: " + node);
     }
+    DeserializationUtil.tryDecrementIntrinsicFunctionCounter(context);
     final IntrinsicFunctionModel operation =
         context.readTreeAsValue(node, IntrinsicFunctionModel.class);
     final IntrinsicFunctionParams params =


### PR DESCRIPTION
## Description

This PR will introduce basic guardrails for intrinsic functions:
- A limit on how many functions can be executed as part of one deserialization round (configurable via document module settings)
- A check when creating output variables to ensure intrinsic functions are not created dynamically as a result of connector execution (works both for inbound and outbound)

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes https://github.com/camunda/team-connectors/issues/1032

## Checklist

- [ ] PR has a **milestone** or the `no milestone` label.

