### PR TITLE
ci(helm): rename chart dir from alpha to 8.8

### DIFF
--- a/.github/workflows/helm-git-refs.json
+++ b/.github/workflows/helm-git-refs.json
@@ -1,6 +1,6 @@
 {
-  "main": "camunda-platform-alpha",
-  "release/8.8": "camunda-platform-alpha",
+  "main": "camunda-platform-8.8",
+  "release/8.8": "camunda-platform-8.8",
   "release/8.7": "camunda-platform-8.7",
   "release/8.6": "camunda-platform-8.6",
   "release/8.5": "camunda-platform-8.5",


### PR DESCRIPTION
## Description

In the Helm repo, we now release all charts, even alpha, so there is no need for a special alpha dir.

Hence, I renamed the chart dir from alpha to 8.8.

## Related issues

Related to: https://github.com/camunda/team-distribution/issues/499

## Checklist

- [ ] PR has a **milestone** or the `no milestone` label.

