### PR TITLE
fix: added back identity autoconfigure

### DIFF
--- a/connector-runtime/spring-boot-starter-camunda-connectors/pom.xml
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/pom.xml
@@ -45,6 +45,10 @@
       <artifactId>spring-boot-starter-actuator</artifactId>
     </dependency>
     <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>identity-spring-boot-autoconfigure</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-configuration-processor</artifactId>
       <optional>true</optional>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -71,7 +71,7 @@ limitations under the License.</license.inlineheader>
     <version.zeebe>8.4.17</version.zeebe>
     <version.spring-zeebe>8.4.17</version.spring-zeebe>
     <version.feel-engine>1.19.3</version.feel-engine>
-
+    <version.identity>8.4.20</version.identity>
     <!-- Third party dependencies -->
 
     <version.jakarta-validation>3.1.1</version.jakarta-validation>
@@ -266,6 +266,11 @@ limitations under the License.</license.inlineheader>
         <groupId>io.camunda</groupId>
         <artifactId>zeebe-client-java</artifactId>
         <version>${version.zeebe}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.camunda</groupId>
+        <artifactId>identity-spring-boot-autoconfigure</artifactId>
+        <version>${version.identity}</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

This release adds back identity autoconfigure that was used transitively before.

## Related issues

<!-- Which issues are closed by this PR or are related -->

Slack thread: https://camunda.slack.com/archives/C05K4TAEPDW/p1745937249457359?thread_ts=1745846035.461319&cid=C05K4TAEPDW

closes #

## Checklist

- [ ] PR has a **milestone** or the `no milestone` label.

