### PR TITLE
other(inbound): fix broken health check

### DIFF
--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/controller/InboundConnectorRestController.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/controller/InboundConnectorRestController.java
@@ -36,7 +36,7 @@ public class InboundConnectorRestController {
     this.executableRegistry = executableRegistry;
   }
 
-  @GetMapping("/inbound")
+  @GetMapping({"/inbound", "/inbound/"})
   public List<ActiveInboundConnectorResponse> getActiveInboundConnectors(
       @RequestParam(required = false, value = "bpmnProcessId") String bpmnProcessId,
       @RequestParam(required = false, value = "elementId") String elementId,


### PR DESCRIPTION
## Description

SRE inbound health check calls /inbound/ with a trailing slash. Since 8.7 we return a 500 in this case.

This PR adds a new mapping to the existing endpoint to limit the possible impact of changing the security config now. Thus we can ship it for this current release.