### PR TITLE
refactor(agentic-ai): error handling & UX improvements

### DIFF
--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/AiAgentTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/AiAgentTests.java
@@ -605,7 +605,7 @@ public class AiAgentTests extends BaseAgenticAiTest {
           incident -> {
             assertThat(incident.getElementId()).isEqualTo("AI_Agent");
             assertThat(incident.getErrorMessage())
-                .isEqualTo("Maximum number of model calls reached");
+                .isEqualTo("Maximum number of model calls reached (modelCalls: 10, limit: 10)");
           });
 
       final var agentResponse = getAgentResponse(zeebeTest);

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/AiAgentTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/AiAgentTests.java
@@ -573,7 +573,7 @@ public class AiAgentTests extends BaseAgenticAiTest {
   }
 
   @Nested
-  class Guardrails {
+  class Limits {
 
     @Test
     void raisesIncidentWhenMaximumModelCallsAreReached() throws IOException {

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/resources/agentic-ai-connectors.bpmn
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/resources/agentic-ai-connectors.bpmn
@@ -165,7 +165,7 @@
           <zeebe:input source="Agent_Tools" target="data.tools.containerElementId" />
           <zeebe:input source="=toolCallResults" target="data.tools.toolCallResults" />
           <zeebe:input source="=50" target="data.memory.maxMessages" />
-          <zeebe:input source="=10" target="data.guardrails.maxModelCalls" />
+          <zeebe:input source="=10" target="data.limits.maxModelCalls" />
           <zeebe:input source="=8192" target="provider.openai.model.parameters.maxOutputTokens" />
           <zeebe:input source="=0.8" target="provider.openai.model.parameters.temperature" />
           <zeebe:input source="=1" target="provider.openai.model.parameters.topP" />

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/resources/agentic-ai-connectors.bpmn
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/resources/agentic-ai-connectors.bpmn
@@ -92,6 +92,15 @@
           </zeebe:taskHeaders>
         </bpmn:extensionElements>
       </bpmn:serviceTask>
+      <bpmn:boundaryEvent id="Complex_Tool_Error" attachedToRef="A_Complex_Tool">
+        <bpmn:documentation>Handles errors from complex tool</bpmn:documentation>
+        <bpmn:outgoing>Flow_1p7oy92</bpmn:outgoing>
+        <bpmn:errorEventDefinition id="ErrorEventDefinition_1c6dxc2" />
+      </bpmn:boundaryEvent>
+      <bpmn:sequenceFlow id="Flow_1p7oy92" sourceRef="Complex_Tool_Error" targetRef="Activity_12hs7ng" />
+      <bpmn:manualTask id="Activity_12hs7ng" name="Handle complex tool error">
+        <bpmn:incoming>Flow_1p7oy92</bpmn:incoming>
+      </bpmn:manualTask>
     </bpmn:adHocSubProcess>
     <bpmn:exclusiveGateway id="Gateway_0d7bxjf" name="What to do?">
       <bpmn:incoming>Flow_1lbh2cw</bpmn:incoming>
@@ -252,7 +261,7 @@
         <dc:Bounds x="162" y="262" width="36" height="36" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_005wn4n_di" bpmnElement="Agent_Tools" isExpanded="true">
-        <dc:Bounds x="870" y="570" width="350" height="470" />
+        <dc:Bounds x="870" y="570" width="350" height="670" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_02hr6cv_di" bpmnElement="An_Event">
@@ -279,11 +288,18 @@
       <bpmndi:BPMNShape id="Activity_1kglsdx_di" bpmnElement="Search_The_Web">
         <dc:Bounds x="920" y="720" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_0wd2ku5_di" bpmnElement="A_Complex_Tool">
-        <dc:Bounds x="920" y="920" width="100" height="80" />
-      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_0zm24e8_di" bpmnElement="Download_A_File">
         <dc:Bounds x="1060" y="920" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0wd2ku5_di" bpmnElement="A_Complex_Tool">
+        <dc:Bounds x="920" y="1030" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1xv565y_di" bpmnElement="Activity_12hs7ng">
+        <dc:Bounds x="1050" y="1110" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1p1n58n_di" bpmnElement="Complex_Tool_Error">
+        <dc:Bounds x="972" y="1092" width="36" height="36" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNEdge id="Flow_095717l_di" bpmnElement="Flow_095717l">
         <di:waypoint x="1020" y="760" />
@@ -292,6 +308,11 @@
       <bpmndi:BPMNEdge id="Flow_0v33lmt_di" bpmnElement="Flow_0v33lmt">
         <di:waypoint x="988" y="860" />
         <di:waypoint x="1060" y="860" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1p7oy92_di" bpmnElement="Flow_1p7oy92">
+        <di:waypoint x="990" y="1128" />
+        <di:waypoint x="990" y="1150" />
+        <di:waypoint x="1050" y="1150" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="Gateway_0d7bxjf_di" bpmnElement="Gateway_0d7bxjf" isMarkerVisible="true">
         <dc:Bounds x="265" y="255" width="50" height="50" />

--- a/connectors/agentic-ai/element-templates/agenticai-adhoctoolsschema-outbound-connector.json
+++ b/connectors/agentic-ai/element-templates/agenticai-adhoctoolsschema-outbound-connector.json
@@ -40,9 +40,12 @@
     "type" : "Hidden"
   }, {
     "id" : "data.containerElementId",
-    "label" : "Ad-hoc subprocess ID containing tools",
+    "label" : "Ad-hoc subprocess ID",
     "description" : "The ID of the subprocess containing the tools to be called",
     "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
     "feel" : "optional",
     "group" : "tools",
     "binding" : {

--- a/connectors/agentic-ai/element-templates/agenticai-aiagent-outbound-connector.json
+++ b/connectors/agentic-ai/element-templates/agenticai-aiagent-outbound-connector.json
@@ -37,8 +37,8 @@
     "id" : "memory",
     "label" : "Memory"
   }, {
-    "id" : "guardrails",
-    "label" : "Guardrails"
+    "id" : "limits",
+    "label" : "Limits"
   }, {
     "id" : "parameters",
     "label" : "Parameters"
@@ -478,7 +478,7 @@
     },
     "type" : "Number"
   }, {
-    "id" : "data.guardrails.maxModelCalls",
+    "id" : "data.limits.maxModelCalls",
     "label" : "Maximum number of calls to the model",
     "optional" : false,
     "value" : 10,
@@ -486,9 +486,9 @@
       "notEmpty" : true
     },
     "feel" : "static",
-    "group" : "guardrails",
+    "group" : "limits",
     "binding" : {
-      "name" : "data.guardrails.maxModelCalls",
+      "name" : "data.limits.maxModelCalls",
       "type" : "zeebe:input"
     },
     "type" : "Number"

--- a/connectors/agentic-ai/element-templates/agenticai-aiagent-outbound-connector.json
+++ b/connectors/agentic-ai/element-templates/agenticai-aiagent-outbound-connector.json
@@ -459,7 +459,6 @@
     "label" : "Agent Context",
     "description" : "The agent context variable containing all relevant data for the agent to support the feedback loop between user requests, tool calls and LLM responses. Make sure this variable points to the <code>context</code> variable which is returned from the agent response.",
     "optional" : false,
-    "value" : "=agent.context",
     "constraints" : {
       "notEmpty" : true
     },
@@ -725,8 +724,7 @@
       "key" : "resultVariable",
       "type" : "zeebe:taskHeader"
     },
-    "type" : "String",
-    "value" : "agent"
+    "type" : "String"
   }, {
     "id" : "resultExpression",
     "label" : "Result expression",

--- a/connectors/agentic-ai/element-templates/agenticai-aiagent-outbound-connector.json
+++ b/connectors/agentic-ai/element-templates/agenticai-aiagent-outbound-connector.json
@@ -2,7 +2,7 @@
   "$schema" : "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
   "name" : "AI Agent (alpha)",
   "id" : "io.camunda.connectors.agenticai.aiagent.v0",
-  "description" : "AI Agent connector",
+  "description" : "Provides a default AI Agent implementation handling the feedback loop between user requests, tool calls and LLM responses.",
   "metadata" : {
     "keywords" : [ ]
   },
@@ -22,9 +22,6 @@
     "id" : "authentication",
     "label" : "Authentication"
   }, {
-    "id" : "context",
-    "label" : "Context"
-  }, {
     "id" : "systemPrompt",
     "label" : "System Prompt"
   }, {
@@ -32,16 +29,20 @@
     "label" : "User Prompt"
   }, {
     "id" : "tools",
-    "label" : "Tools"
+    "label" : "Tools",
+    "tooltip" : "Configuration of tools which should be made available to the agent."
   }, {
     "id" : "memory",
-    "label" : "Memory"
+    "label" : "Memory",
+    "tooltip" : "Configuration of the Agent's short-term memory."
   }, {
     "id" : "limits",
     "label" : "Limits"
   }, {
     "id" : "parameters",
-    "label" : "Parameters"
+    "label" : "Model Parameters",
+    "tooltip" : "Configuration of common model parameters to optimize and fine-tune LLM responses.",
+    "openByDefault" : false
   }, {
     "id" : "connector",
     "label" : "Connector"
@@ -64,8 +65,8 @@
     "type" : "Hidden"
   }, {
     "id" : "provider.type",
-    "label" : "Provider",
-    "description" : "Specify the model provider to use",
+    "label" : "Model Provider",
+    "description" : "Specify the LLM provider to use.",
     "value" : "anthropic",
     "group" : "model",
     "binding" : {
@@ -102,6 +103,7 @@
   }, {
     "id" : "provider.anthropic.model.model",
     "label" : "Model",
+    "description" : "Specify the model ID. Details in the <a href=\"https://docs.anthropic.com/en/docs/about-claude/models/all-models\" target=\"_blank\">documentation</a>.",
     "optional" : false,
     "value" : "claude-3-5-sonnet-20240620",
     "constraints" : {
@@ -158,6 +160,7 @@
   }, {
     "id" : "provider.bedrock.model.model",
     "label" : "Model",
+    "description" : "Specify the model ID. Details in the <a href=\"https://docs.aws.amazon.com/bedrock/latest/userguide/model-ids.html\" target=\"_blank\">documentation</a>.",
     "optional" : false,
     "value" : "anthropic.claude-3-5-sonnet-20240620-v1:0",
     "constraints" : {
@@ -194,6 +197,7 @@
   }, {
     "id" : "provider.openai.model.model",
     "label" : "Model",
+    "description" : "Specify the model ID. Details in the <a href=\"https://platform.openai.com/docs/models\" target=\"_blank\">documentation</a>.",
     "optional" : false,
     "value" : "gpt-4o",
     "constraints" : {
@@ -327,7 +331,7 @@
   }, {
     "id" : "provider.openai.authentication.organization",
     "label" : "Organization",
-    "description" : "For members of multiple organizations. Details in the <a href=\"https://platform.openai.com/docs/api-reference/requesting-organization\" target=\"_blank\">OpenAI documentation</a>.",
+    "description" : "For members of multiple organizations. Details in the <a href=\"https://platform.openai.com/docs/api-reference/requesting-organization\" target=\"_blank\">documentation</a>.",
     "optional" : true,
     "feel" : "optional",
     "group" : "authentication",
@@ -359,22 +363,6 @@
     },
     "type" : "String"
   }, {
-    "id" : "data.agentContext",
-    "label" : "Agent Context",
-    "description" : "The agent context variable containing the conversation memory",
-    "optional" : false,
-    "value" : "=agent.context",
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "feel" : "required",
-    "group" : "context",
-    "binding" : {
-      "name" : "data.context",
-      "type" : "zeebe:input"
-    },
-    "type" : "Text"
-  }, {
     "id" : "data.systemPrompt.prompt",
     "label" : "System Prompt",
     "optional" : false,
@@ -392,6 +380,7 @@
   }, {
     "id" : "data.systemPrompt.parameters",
     "label" : "System Prompt Parameters",
+    "description" : "Map of parameters which can be used in <code>{{parameter}}</code> format in the prompt text.",
     "optional" : true,
     "feel" : "required",
     "group" : "systemPrompt",
@@ -399,6 +388,7 @@
       "name" : "data.systemPrompt.parameters",
       "type" : "zeebe:input"
     },
+    "tooltip" : "Default parameters provided by the integration: <code>current_date</code>, <code>current_time</code>, <code>current_date_time</code>",
     "type" : "String"
   }, {
     "id" : "data.userPrompt.prompt",
@@ -417,6 +407,7 @@
   }, {
     "id" : "data.userPrompt.parameters",
     "label" : "User Prompt Parameters",
+    "description" : "Map of parameters which can be used in <code>{{parameter}}</code> format in the prompt text.",
     "optional" : true,
     "feel" : "required",
     "group" : "userPrompt",
@@ -424,6 +415,7 @@
       "name" : "data.userPrompt.parameters",
       "type" : "zeebe:input"
     },
+    "tooltip" : "Default parameters provided by the integration: <code>current_date</code>, <code>current_time</code>, <code>current_date_time</code>",
     "type" : "String"
   }, {
     "id" : "data.userPrompt.documents",
@@ -463,8 +455,25 @@
     },
     "type" : "Text"
   }, {
+    "id" : "data.agentContext",
+    "label" : "Agent Context",
+    "description" : "The agent context variable containing all relevant data for the agent to support the feedback loop between user requests, tool calls and LLM responses. Make sure this variable points to the <code>context</code> variable which is returned from the agent response.",
+    "optional" : false,
+    "value" : "=agent.context",
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "required",
+    "group" : "memory",
+    "binding" : {
+      "name" : "data.context",
+      "type" : "zeebe:input"
+    },
+    "type" : "Text"
+  }, {
     "id" : "data.memory.maxMessages",
-    "label" : "Maximum amount of messages to keep in memory",
+    "label" : "Maximum messages",
+    "description" : "Maximum amount of messages to keep in short-term/conversation memory.",
     "optional" : false,
     "value" : 20,
     "constraints" : {
@@ -479,7 +488,8 @@
     "type" : "Number"
   }, {
     "id" : "data.limits.maxModelCalls",
-    "label" : "Maximum number of calls to the model",
+    "label" : "Maximum model calls",
+    "description" : "Maximum number of calls to the model as a safety limit to prevent infinite loops.",
     "optional" : false,
     "value" : 10,
     "constraints" : {

--- a/connectors/agentic-ai/element-templates/agenticai-aiagent-outbound-connector.json
+++ b/connectors/agentic-ai/element-templates/agenticai-aiagent-outbound-connector.json
@@ -66,6 +66,7 @@
     "id" : "provider.type",
     "label" : "Provider",
     "description" : "Specify the model provider to use",
+    "value" : "anthropic",
     "group" : "model",
     "binding" : {
       "name" : "provider.type",
@@ -362,6 +363,7 @@
     "label" : "Agent Context",
     "description" : "The agent context variable containing the conversation memory",
     "optional" : false,
+    "value" : "=agent.context",
     "constraints" : {
       "notEmpty" : true
     },
@@ -376,6 +378,7 @@
     "id" : "data.systemPrompt.prompt",
     "label" : "System Prompt",
     "optional" : false,
+    "value" : "You are **TaskAgent**, a helpful, generic chat agent that can handle a wide variety of customer requests using your own domain knowledge **and** any tools explicitly provided to you at runtime.\n\nIf tools are provided, you should prefer them instead of guessing an answer. You can call the same tool multiple times by providing different input values. Don't guess any tools which were not explicitely configured. If no tool matches the request, try to generate an answer. If you're not able to find a good answer, return with a message stating why you're not able to.\n\nWrap minimal, inspectable reasoning in *exactly* this XML template:\n\n<thinking>\n  <context>…briefly state the customer’s need and current state…</context>\n  <reflection>…list candidate tools, justify which you will call next and why…</reflection>\n</thinking>\n\nReveal **no** additional private reasoning outside these tags.\n",
     "constraints" : {
       "notEmpty" : true
     },
@@ -437,7 +440,7 @@
     "type" : "String"
   }, {
     "id" : "data.tools.containerElementId",
-    "label" : "Ad-hoc subprocess ID containing tools",
+    "label" : "Ad-hoc subprocess ID",
     "description" : "The ID of the subprocess containing the tools to be called",
     "optional" : true,
     "feel" : "optional",

--- a/connectors/agentic-ai/element-templates/agenticai-aiagent-outbound-connector.json
+++ b/connectors/agentic-ai/element-templates/agenticai-aiagent-outbound-connector.json
@@ -725,7 +725,8 @@
       "key" : "resultVariable",
       "type" : "zeebe:taskHeader"
     },
-    "type" : "String"
+    "type" : "String",
+    "value" : "agent"
   }, {
     "id" : "resultExpression",
     "label" : "Result expression",

--- a/connectors/agentic-ai/element-templates/hybrid/agenticai-adhoctoolsschema-outbound-connector-hybrid.json
+++ b/connectors/agentic-ai/element-templates/hybrid/agenticai-adhoctoolsschema-outbound-connector-hybrid.json
@@ -45,9 +45,12 @@
     "type" : "String"
   }, {
     "id" : "data.containerElementId",
-    "label" : "Ad-hoc subprocess ID containing tools",
+    "label" : "Ad-hoc subprocess ID",
     "description" : "The ID of the subprocess containing the tools to be called",
     "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
     "feel" : "optional",
     "group" : "tools",
     "binding" : {

--- a/connectors/agentic-ai/element-templates/hybrid/agenticai-aiagent-outbound-connector-hybrid.json
+++ b/connectors/agentic-ai/element-templates/hybrid/agenticai-aiagent-outbound-connector-hybrid.json
@@ -40,8 +40,8 @@
     "id" : "memory",
     "label" : "Memory"
   }, {
-    "id" : "guardrails",
-    "label" : "Guardrails"
+    "id" : "limits",
+    "label" : "Limits"
   }, {
     "id" : "parameters",
     "label" : "Parameters"
@@ -483,7 +483,7 @@
     },
     "type" : "Number"
   }, {
-    "id" : "data.guardrails.maxModelCalls",
+    "id" : "data.limits.maxModelCalls",
     "label" : "Maximum number of calls to the model",
     "optional" : false,
     "value" : 10,
@@ -491,9 +491,9 @@
       "notEmpty" : true
     },
     "feel" : "static",
-    "group" : "guardrails",
+    "group" : "limits",
     "binding" : {
-      "name" : "data.guardrails.maxModelCalls",
+      "name" : "data.limits.maxModelCalls",
       "type" : "zeebe:input"
     },
     "type" : "Number"

--- a/connectors/agentic-ai/element-templates/hybrid/agenticai-aiagent-outbound-connector-hybrid.json
+++ b/connectors/agentic-ai/element-templates/hybrid/agenticai-aiagent-outbound-connector-hybrid.json
@@ -71,6 +71,7 @@
     "id" : "provider.type",
     "label" : "Provider",
     "description" : "Specify the model provider to use",
+    "value" : "anthropic",
     "group" : "model",
     "binding" : {
       "name" : "provider.type",
@@ -367,6 +368,7 @@
     "label" : "Agent Context",
     "description" : "The agent context variable containing the conversation memory",
     "optional" : false,
+    "value" : "=agent.context",
     "constraints" : {
       "notEmpty" : true
     },
@@ -381,6 +383,7 @@
     "id" : "data.systemPrompt.prompt",
     "label" : "System Prompt",
     "optional" : false,
+    "value" : "You are **TaskAgent**, a helpful, generic chat agent that can handle a wide variety of customer requests using your own domain knowledge **and** any tools explicitly provided to you at runtime.\n\nIf tools are provided, you should prefer them instead of guessing an answer. You can call the same tool multiple times by providing different input values. Don't guess any tools which were not explicitely configured. If no tool matches the request, try to generate an answer. If you're not able to find a good answer, return with a message stating why you're not able to.\n\nWrap minimal, inspectable reasoning in *exactly* this XML template:\n\n<thinking>\n  <context>…briefly state the customer’s need and current state…</context>\n  <reflection>…list candidate tools, justify which you will call next and why…</reflection>\n</thinking>\n\nReveal **no** additional private reasoning outside these tags.\n",
     "constraints" : {
       "notEmpty" : true
     },
@@ -442,7 +445,7 @@
     "type" : "String"
   }, {
     "id" : "data.tools.containerElementId",
-    "label" : "Ad-hoc subprocess ID containing tools",
+    "label" : "Ad-hoc subprocess ID",
     "description" : "The ID of the subprocess containing the tools to be called",
     "optional" : true,
     "feel" : "optional",

--- a/connectors/agentic-ai/element-templates/hybrid/agenticai-aiagent-outbound-connector-hybrid.json
+++ b/connectors/agentic-ai/element-templates/hybrid/agenticai-aiagent-outbound-connector-hybrid.json
@@ -730,7 +730,8 @@
       "key" : "resultVariable",
       "type" : "zeebe:taskHeader"
     },
-    "type" : "String"
+    "type" : "String",
+    "value" : "agent"
   }, {
     "id" : "resultExpression",
     "label" : "Result expression",

--- a/connectors/agentic-ai/element-templates/hybrid/agenticai-aiagent-outbound-connector-hybrid.json
+++ b/connectors/agentic-ai/element-templates/hybrid/agenticai-aiagent-outbound-connector-hybrid.json
@@ -2,7 +2,7 @@
   "$schema" : "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
   "name" : "Hybrid AI Agent (alpha)",
   "id" : "io.camunda.connectors.agenticai.aiagent.v0-hybrid",
-  "description" : "AI Agent connector",
+  "description" : "Provides a default AI Agent implementation handling the feedback loop between user requests, tool calls and LLM responses.",
   "metadata" : {
     "keywords" : [ ]
   },
@@ -25,9 +25,6 @@
     "id" : "authentication",
     "label" : "Authentication"
   }, {
-    "id" : "context",
-    "label" : "Context"
-  }, {
     "id" : "systemPrompt",
     "label" : "System Prompt"
   }, {
@@ -35,16 +32,20 @@
     "label" : "User Prompt"
   }, {
     "id" : "tools",
-    "label" : "Tools"
+    "label" : "Tools",
+    "tooltip" : "Configuration of tools which should be made available to the agent."
   }, {
     "id" : "memory",
-    "label" : "Memory"
+    "label" : "Memory",
+    "tooltip" : "Configuration of the Agent's short-term memory."
   }, {
     "id" : "limits",
     "label" : "Limits"
   }, {
     "id" : "parameters",
-    "label" : "Parameters"
+    "label" : "Model Parameters",
+    "tooltip" : "Configuration of common model parameters to optimize and fine-tune LLM responses.",
+    "openByDefault" : false
   }, {
     "id" : "connector",
     "label" : "Connector"
@@ -69,8 +70,8 @@
     "type" : "String"
   }, {
     "id" : "provider.type",
-    "label" : "Provider",
-    "description" : "Specify the model provider to use",
+    "label" : "Model Provider",
+    "description" : "Specify the LLM provider to use.",
     "value" : "anthropic",
     "group" : "model",
     "binding" : {
@@ -107,6 +108,7 @@
   }, {
     "id" : "provider.anthropic.model.model",
     "label" : "Model",
+    "description" : "Specify the model ID. Details in the <a href=\"https://docs.anthropic.com/en/docs/about-claude/models/all-models\" target=\"_blank\">documentation</a>.",
     "optional" : false,
     "value" : "claude-3-5-sonnet-20240620",
     "constraints" : {
@@ -163,6 +165,7 @@
   }, {
     "id" : "provider.bedrock.model.model",
     "label" : "Model",
+    "description" : "Specify the model ID. Details in the <a href=\"https://docs.aws.amazon.com/bedrock/latest/userguide/model-ids.html\" target=\"_blank\">documentation</a>.",
     "optional" : false,
     "value" : "anthropic.claude-3-5-sonnet-20240620-v1:0",
     "constraints" : {
@@ -199,6 +202,7 @@
   }, {
     "id" : "provider.openai.model.model",
     "label" : "Model",
+    "description" : "Specify the model ID. Details in the <a href=\"https://platform.openai.com/docs/models\" target=\"_blank\">documentation</a>.",
     "optional" : false,
     "value" : "gpt-4o",
     "constraints" : {
@@ -332,7 +336,7 @@
   }, {
     "id" : "provider.openai.authentication.organization",
     "label" : "Organization",
-    "description" : "For members of multiple organizations. Details in the <a href=\"https://platform.openai.com/docs/api-reference/requesting-organization\" target=\"_blank\">OpenAI documentation</a>.",
+    "description" : "For members of multiple organizations. Details in the <a href=\"https://platform.openai.com/docs/api-reference/requesting-organization\" target=\"_blank\">documentation</a>.",
     "optional" : true,
     "feel" : "optional",
     "group" : "authentication",
@@ -364,22 +368,6 @@
     },
     "type" : "String"
   }, {
-    "id" : "data.agentContext",
-    "label" : "Agent Context",
-    "description" : "The agent context variable containing the conversation memory",
-    "optional" : false,
-    "value" : "=agent.context",
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "feel" : "required",
-    "group" : "context",
-    "binding" : {
-      "name" : "data.context",
-      "type" : "zeebe:input"
-    },
-    "type" : "Text"
-  }, {
     "id" : "data.systemPrompt.prompt",
     "label" : "System Prompt",
     "optional" : false,
@@ -397,6 +385,7 @@
   }, {
     "id" : "data.systemPrompt.parameters",
     "label" : "System Prompt Parameters",
+    "description" : "Map of parameters which can be used in <code>{{parameter}}</code> format in the prompt text.",
     "optional" : true,
     "feel" : "required",
     "group" : "systemPrompt",
@@ -404,6 +393,7 @@
       "name" : "data.systemPrompt.parameters",
       "type" : "zeebe:input"
     },
+    "tooltip" : "Default parameters provided by the integration: <code>current_date</code>, <code>current_time</code>, <code>current_date_time</code>",
     "type" : "String"
   }, {
     "id" : "data.userPrompt.prompt",
@@ -422,6 +412,7 @@
   }, {
     "id" : "data.userPrompt.parameters",
     "label" : "User Prompt Parameters",
+    "description" : "Map of parameters which can be used in <code>{{parameter}}</code> format in the prompt text.",
     "optional" : true,
     "feel" : "required",
     "group" : "userPrompt",
@@ -429,6 +420,7 @@
       "name" : "data.userPrompt.parameters",
       "type" : "zeebe:input"
     },
+    "tooltip" : "Default parameters provided by the integration: <code>current_date</code>, <code>current_time</code>, <code>current_date_time</code>",
     "type" : "String"
   }, {
     "id" : "data.userPrompt.documents",
@@ -468,8 +460,25 @@
     },
     "type" : "Text"
   }, {
+    "id" : "data.agentContext",
+    "label" : "Agent Context",
+    "description" : "The agent context variable containing all relevant data for the agent to support the feedback loop between user requests, tool calls and LLM responses. Make sure this variable points to the <code>context</code> variable which is returned from the agent response.",
+    "optional" : false,
+    "value" : "=agent.context",
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "required",
+    "group" : "memory",
+    "binding" : {
+      "name" : "data.context",
+      "type" : "zeebe:input"
+    },
+    "type" : "Text"
+  }, {
     "id" : "data.memory.maxMessages",
-    "label" : "Maximum amount of messages to keep in memory",
+    "label" : "Maximum messages",
+    "description" : "Maximum amount of messages to keep in short-term/conversation memory.",
     "optional" : false,
     "value" : 20,
     "constraints" : {
@@ -484,7 +493,8 @@
     "type" : "Number"
   }, {
     "id" : "data.limits.maxModelCalls",
-    "label" : "Maximum number of calls to the model",
+    "label" : "Maximum model calls",
+    "description" : "Maximum number of calls to the model as a safety limit to prevent infinite loops.",
     "optional" : false,
     "value" : 10,
     "constraints" : {

--- a/connectors/agentic-ai/element-templates/hybrid/agenticai-aiagent-outbound-connector-hybrid.json
+++ b/connectors/agentic-ai/element-templates/hybrid/agenticai-aiagent-outbound-connector-hybrid.json
@@ -464,7 +464,6 @@
     "label" : "Agent Context",
     "description" : "The agent context variable containing all relevant data for the agent to support the feedback loop between user requests, tool calls and LLM responses. Make sure this variable points to the <code>context</code> variable which is returned from the agent response.",
     "optional" : false,
-    "value" : "=agent.context",
     "constraints" : {
       "notEmpty" : true
     },
@@ -730,8 +729,7 @@
       "key" : "resultVariable",
       "type" : "zeebe:taskHeader"
     },
-    "type" : "String",
-    "value" : "agent"
+    "type" : "String"
   }, {
     "id" : "resultExpression",
     "label" : "Result expression",

--- a/connectors/agentic-ai/examples/ai-agent-chat-with-tools/ai-agent-chat-initial-request.form
+++ b/connectors/agentic-ai/examples/ai-agent-chat-with-tools/ai-agent-chat-initial-request.form
@@ -11,7 +11,7 @@
       "key": "inputText"
     },
     {
-      "label": "Documents",
+      "label": "Add Documents",
       "type": "filepicker",
       "layout": {
         "row": "Row_03u75o8",

--- a/connectors/agentic-ai/examples/ai-agent-chat-with-tools/ai-agent-chat-user-feedback.form
+++ b/connectors/agentic-ai/examples/ai-agent-chat-with-tools/ai-agent-chat-user-feedback.form
@@ -19,13 +19,16 @@
         "row": "Row_02uha0c",
         "columns": null
       },
-      "id": "Field_0rned2j"
+      "id": "Field_0rned2j",
+      "conditional": {
+        "hide": "=true"
+      }
     },
     {
       "label": "Latest Message",
       "components": [
         {
-          "text": "=agent.chatResponse",
+          "text": "=agent.chatResponse.text",
           "type": "text",
           "layout": {
             "row": "Row_0bbt4ob",
@@ -61,14 +64,36 @@
       "key": "userSatisfied"
     },
     {
-      "label": "Follow up input",
-      "type": "textarea",
+      "label": "Follow Up",
+      "components": [
+        {
+          "label": "",
+          "type": "textarea",
+          "layout": {
+            "row": "Row_0o7jpzk",
+            "columns": null
+          },
+          "id": "Field_0378jfk",
+          "key": "followUpInput"
+        },
+        {
+          "label": "Additional documents",
+          "type": "filepicker",
+          "layout": {
+            "row": "Row_06i75kk",
+            "columns": null
+          },
+          "id": "Field_0vzezpk",
+          "key": "followUpDocuments"
+        }
+      ],
+      "showOutline": true,
+      "type": "group",
       "layout": {
-        "row": "Row_09aikdc",
+        "row": "Row_1nitkoj",
         "columns": null
       },
-      "id": "Field_0378jfk",
-      "key": "followUpInput",
+      "id": "Field_1c8s8ll",
       "conditional": {
         "hide": "=userSatisfied"
       }

--- a/connectors/agentic-ai/examples/ai-agent-chat-with-tools/ai-agent-chat-with-tools.bpmn
+++ b/connectors/agentic-ai/examples/ai-agent-chat-with-tools/ai-agent-chat-with-tools.bpmn
@@ -21,7 +21,7 @@
           <zeebe:input source="=agent.context" target="data.context" />
           <zeebe:input source="You are a helpful, generic chat agent which can answer a wide amount of questions based on your knowledge and an optional set of available tools.&#10;&#10;If tools are provided, you should prefer them instead of guessing an answer. You can call the same tool multiple times by providing different input values. Don&#39;t guess any tools which were not explicitely configured. If no tool matches the request, try to generate an answer. If you&#39;re not able to find a good answer, return with a message stating why you&#39;re not able to.&#10;&#10;If you are prompted to interact with a person, never guess contact details, but use available user/person lookup tools instead and return with an error if you&#39;re not able to look up appropriate data.&#10;&#10;Thinking, step by step, before you execute your tools, you think using the template `&#60;thinking&#62;&#60;context&#62;&#60;/context&#62;&#60;reflection&#62;&#60;/reflection&#62;&#60;/thinking&#62;`" target="data.systemPrompt.prompt" />
           <zeebe:input source="=if (is defined(followUpInput)) then followUpInput else inputText" target="data.userPrompt.prompt" />
-          <zeebe:input source="=if (is defined(followUpInput)) then [] else inputDocuments" target="data.userPrompt.documents" />
+          <zeebe:input source="=if (is defined(followUpDocuments)) then followUpDocuments else inputDocuments" target="data.userPrompt.documents" />
           <zeebe:input source="Agent_Tools" target="data.tools.containerElementId" />
           <zeebe:input source="=toolCallResults" target="data.tools.toolCallResults" />
           <zeebe:input source="=20" target="data.memory.maxMessages" />
@@ -229,6 +229,27 @@
           </zeebe:taskHeaders>
         </bpmn:extensionElements>
       </bpmn:serviceTask>
+      <bpmn:serviceTask id="Fetch_URL" name="Fetch URL" zeebe:modelerTemplate="io.camunda.connectors.HttpJson.v2" zeebe:modelerTemplateVersion="11" zeebe:modelerTemplateIcon="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTgiIGhlaWdodD0iMTgiIHZpZXdCb3g9IjAgMCAxOCAxOCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZD0iTTE3LjAzMzUgOC45OTk5N0MxNy4wMzM1IDEzLjQ0NzUgMTMuNDI4MSAxNy4wNTI5IDguOTgwNjUgMTcuMDUyOUM0LjUzMzE2IDE3LjA1MjkgMC45Mjc3NjUgMTMuNDQ3NSAwLjkyNzc2NSA4Ljk5OTk3QzAuOTI3NzY1IDQuNTUyNDggNC41MzMxNiAwLjk0NzA4MyA4Ljk4MDY1IDAuOTQ3MDgzQzEzLjQyODEgMC45NDcwODMgMTcuMDMzNSA0LjU1MjQ4IDE3LjAzMzUgOC45OTk5N1oiIGZpbGw9IiM1MDU1NjIiLz4KPHBhdGggZD0iTTQuOTMxMjYgMTQuMTU3MUw2Ljc4MTA2IDMuNzE0NzFIMTAuMTM3NUMxMS4xOTE3IDMuNzE0NzEgMTEuOTgyNCAzLjk4MzIzIDEyLjUwOTUgNC41MjAyN0MxMy4wNDY1IDUuMDQ3MzYgMTMuMzE1IDUuNzMzNTggMTMuMzE1IDYuNTc4OTJDMTMuMzE1IDcuNDQ0MTQgMTMuMDcxNCA4LjE1NTIyIDEyLjU4NDEgOC43MTIxNUMxMi4xMDY3IDkuMjU5MTMgMTEuNDU1MyA5LjYzNzA1IDEwLjYyOTggOS44NDU5TDEyLjA2MTkgMTQuMTU3MUgxMC4zMzE1TDkuMDMzNjQgMTAuMDI0OUg3LjI0MzUxTDYuNTEyNTQgMTQuMTU3MUg0LjkzMTI2Wk03LjQ5NzExIDguNTkyODFIOS4yNDI0OEM5Ljk5ODMyIDguNTkyODEgMTAuNTkwMSA4LjQyMzc0IDExLjAxNzcgOC4wODU2MUMxMS40NTUzIDcuNzM3NTMgMTEuNjc0MSA3LjI2NTEzIDExLjY3NDEgNi42Njg0MkMxMS42NzQxIDYuMTkxMDYgMTEuNTI0OSA1LjgxODExIDExLjIyNjUgNS41NDk1OUMxMC45MjgyIDUuMjcxMTMgMTAuNDU1OCA1LjEzMTkgOS44MDkzNiA1LjEzMTlIOC4xMDg3NEw3LjQ5NzExIDguNTkyODFaIiBmaWxsPSJ3aGl0ZSIvPgo8L3N2Zz4K">
+        <bpmn:documentation>Fetches the contents of a given URL. Only accepts valid RFC 3986/RFC 7230 HTTP(s) URLs.</bpmn:documentation>
+        <bpmn:extensionElements>
+          <zeebe:taskDefinition type="io.camunda:http-json:1" retries="3" />
+          <zeebe:ioMapping>
+            <zeebe:input source="noAuth" target="authentication.type" />
+            <zeebe:input source="GET" target="method" />
+            <zeebe:input source="=fromAi(toolCall.url, &#34;The URL to fetch&#34;)" target="url" />
+            <zeebe:input source="=true" target="storeResponse" />
+            <zeebe:input source="=20" target="connectionTimeoutInSeconds" />
+            <zeebe:input source="=20" target="readTimeoutInSeconds" />
+            <zeebe:input source="=false" target="ignoreNullValues" />
+          </zeebe:ioMapping>
+          <zeebe:taskHeaders>
+            <zeebe:header key="elementTemplateVersion" value="11" />
+            <zeebe:header key="elementTemplateId" value="io.camunda.connectors.HttpJson.v2" />
+            <zeebe:header key="resultExpression" value="={&#10;  toolCallResult: response.document&#10;}" />
+            <zeebe:header key="retryBackoff" value="PT0S" />
+          </zeebe:taskHeaders>
+        </bpmn:extensionElements>
+      </bpmn:serviceTask>
     </bpmn:adHocSubProcess>
     <bpmn:intermediateThrowEvent id="Event_1hi12xn" name="Tools follow up">
       <bpmn:incoming>Flow_01k9dy1</bpmn:incoming>
@@ -306,7 +327,7 @@
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_03yngb7_di" bpmnElement="Agent_Tools" isExpanded="true">
-        <dc:Bounds x="480" y="560" width="405" height="580" />
+        <dc:Bounds x="480" y="560" width="400" height="580" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_1sbkoqq_di" bpmnElement="GetDateAndTime">
         <dc:Bounds x="510" y="600" width="100" height="80" />
@@ -343,11 +364,14 @@
           <dc:Bounds x="645" y="1075" width="70" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_1sddc2g_di" bpmnElement="SendEmail">
-        <dc:Bounds x="765" y="930" width="100" height="80" />
-      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_1l8tp85_di" bpmnElement="Jokes_API">
         <dc:Bounds x="630" y="800" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1sddc2g_di" bpmnElement="SendEmail">
+        <dc:Bounds x="750" y="930" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1knqabi_di" bpmnElement="Fetch_URL">
+        <dc:Bounds x="750" y="600" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNEdge id="Flow_0demz1g_di" bpmnElement="Flow_0demz1g">
         <di:waypoint x="610" y="970" />
@@ -355,9 +379,9 @@
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0uqjclh_di" bpmnElement="Flow_0uqjclh">
         <di:waypoint x="705" y="970" />
-        <di:waypoint x="765" y="970" />
+        <di:waypoint x="750" y="970" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="726" y="952" width="18" height="14" />
+          <dc:Bounds x="719" y="952" width="18" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1l2ws6w_di" bpmnElement="Flow_1l2ws6w">

--- a/connectors/agentic-ai/examples/ai-agent-chat-with-tools/ai-agent-chat-with-tools.bpmn
+++ b/connectors/agentic-ai/examples/ai-agent-chat-with-tools/ai-agent-chat-with-tools.bpmn
@@ -25,7 +25,7 @@
           <zeebe:input source="Agent_Tools" target="data.tools.containerElementId" />
           <zeebe:input source="=toolCallResults" target="data.tools.toolCallResults" />
           <zeebe:input source="=20" target="data.memory.maxMessages" />
-          <zeebe:input source="=20" target="data.guardrails.maxModelCalls" />
+          <zeebe:input source="=20" target="data.limits.maxModelCalls" />
           <zeebe:input source="=8192" target="provider.bedrock.model.parameters.maxOutputTokens" />
         </zeebe:ioMapping>
         <zeebe:taskHeaders>
@@ -267,7 +267,7 @@
       <bpmn:text>Rough outline of the functionality
 
 - Loads previous memory from provided variables
-- Checks guardrails (e.g. maximum LLM model calls)
+- Checks limits (e.g. maximum LLM model calls)
 - Loads available tool information from ad-hoc subprocess definition
 - Merges the current request (either a user message or a tool call response) into the memory
 - Calls the LLM, including previous/edited memory + available tools schema

--- a/connectors/agentic-ai/examples/fraud-detection/fraud-detection-process.bpmn
+++ b/connectors/agentic-ai/examples/fraud-detection/fraud-detection-process.bpmn
@@ -186,7 +186,7 @@
           <zeebe:input source="Fraud_Tools" target="data.tools.containerElementId" />
           <zeebe:input source="=toolCallResults" target="data.tools.toolCallResults" />
           <zeebe:input source="=20" target="data.memory.maxMessages" />
-          <zeebe:input source="=20" target="data.guardrails.maxModelCalls" />
+          <zeebe:input source="=20" target="data.limits.maxModelCalls" />
           <zeebe:input source="=8192" target="provider.bedrock.model.parameters.maxOutputTokens" />
         </zeebe:ioMapping>
         <zeebe:taskHeaders>

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/adhoctoolsschema/feel/FeelFunctionInvocationExtractor.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/adhoctoolsschema/feel/FeelFunctionInvocationExtractor.java
@@ -24,7 +24,7 @@ class FeelFunctionInvocationExtractor {
 
   public static FeelFunctionInvocationExtractor forFunctionName(String functionName) {
     return new FeelFunctionInvocationExtractor(
-        functionInvocation -> functionInvocation.function().equals(functionName));
+        functionInvocation -> functionInvocation.function().equalsIgnoreCase(functionName));
   }
 
   public Set<FunctionInvocation> findMatchingFunctionInvocations(

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/adhoctoolsschema/feel/FeelInputParamExtractionException.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/adhoctoolsschema/feel/FeelInputParamExtractionException.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.agenticai.adhoctoolsschema.feel;
+
+public class FeelInputParamExtractionException extends RuntimeException {
+
+  public FeelInputParamExtractionException(String message) {
+    super(message);
+  }
+}

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/adhoctoolsschema/model/AdHocToolsSchemaRequest.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/adhoctoolsschema/model/AdHocToolsSchemaRequest.java
@@ -7,12 +7,18 @@
 package io.camunda.connector.agenticai.adhoctoolsschema.model;
 
 import io.camunda.connector.generator.java.annotation.TemplateProperty;
+import io.camunda.connector.generator.java.annotation.TemplateProperty.PropertyConstraints;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 
-public record AdHocToolsSchemaRequest(AdHocToolsSchemaRequestData data) {
+public record AdHocToolsSchemaRequest(@Valid @NotNull AdHocToolsSchemaRequestData data) {
   public record AdHocToolsSchemaRequestData(
-      @TemplateProperty(
+      @NotBlank
+          @TemplateProperty(
               group = "tools",
-              label = "Ad-hoc subprocess ID containing tools",
-              description = "The ID of the subprocess containing the tools to be called")
+              label = "Ad-hoc subprocess ID",
+              description = "The ID of the subprocess containing the tools to be called",
+              constraints = @PropertyConstraints(notEmpty = true))
           String containerElementId) {}
 }

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/adhoctoolsschema/resolver/CachingAdHocToolsSchemaResolver.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/adhoctoolsschema/resolver/CachingAdHocToolsSchemaResolver.java
@@ -39,7 +39,17 @@ public class CachingAdHocToolsSchemaResolver implements AdHocToolsSchemaResolver
         id -> delegate.resolveSchema(id.processDefinitionKey(), id.adHocSubprocessId()));
   }
 
-  private record AdHocToolsIdentifier(Long processDefinitionKey, String adHocSubprocessId) {}
+  private record AdHocToolsIdentifier(Long processDefinitionKey, String adHocSubprocessId) {
+    private AdHocToolsIdentifier {
+      if (processDefinitionKey == null || processDefinitionKey <= 0) {
+        throw new IllegalArgumentException("Process definition key must not be null or negative");
+      }
+
+      if (adHocSubprocessId == null || adHocSubprocessId.isBlank()) {
+        throw new IllegalArgumentException("adHocSubprocessId cannot be null or empty");
+      }
+    }
+  }
 
   public record CacheConfiguration(Long maximumSize, Duration expireAfterWrite) {}
 }

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/adhoctoolsschema/resolver/CamundaClientAdHocToolsSchemaResolver.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/adhoctoolsschema/resolver/CamundaClientAdHocToolsSchemaResolver.java
@@ -18,6 +18,7 @@ import io.camunda.connector.api.error.ConnectorException;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.model.bpmn.instance.AdHocSubProcess;
+import io.camunda.zeebe.model.bpmn.instance.BoundaryEvent;
 import io.camunda.zeebe.model.bpmn.instance.FlowNode;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeInput;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeIoMapping;
@@ -93,11 +94,15 @@ public class CamundaClientAdHocToolsSchemaResolver implements AdHocToolsSchemaRe
 
     final var toolDefinitions =
         adHocSubProcess.getChildElementsByType(FlowNode.class).stream()
-            .filter(element -> element.getIncoming().isEmpty())
+            .filter(this::isToolElement)
             .map(this::mapActivityToToolDefinition)
             .toList();
 
     return new AdHocToolsSchemaResponse(toolDefinitions);
+  }
+
+  private boolean isToolElement(FlowNode element) {
+    return element.getIncoming().isEmpty() && !(element instanceof BoundaryEvent);
   }
 
   private AdHocToolDefinition mapActivityToToolDefinition(FlowNode element) {

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/adhoctoolsschema/resolver/CamundaClientAdHocToolsSchemaResolver.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/adhoctoolsschema/resolver/CamundaClientAdHocToolsSchemaResolver.java
@@ -63,6 +63,14 @@ public class CamundaClientAdHocToolsSchemaResolver implements AdHocToolsSchemaRe
   @Override
   public AdHocToolsSchemaResponse resolveSchema(
       Long processDefinitionKey, String adHocSubprocessId) {
+    if (processDefinitionKey == null || processDefinitionKey <= 0) {
+      throw new IllegalArgumentException("Process definition key must not be null or negative");
+    }
+
+    if (adHocSubprocessId == null || adHocSubprocessId.isBlank()) {
+      throw new IllegalArgumentException("adHocSubprocessId cannot be null or empty");
+    }
+
     LOGGER.info(
         "Resolving tool schema for ad-hoc subprocess {} in process definition with key {}",
         adHocSubprocessId,

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/adhoctoolsschema/resolver/schema/DefaultAdHocToolSchemaGenerator.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/adhoctoolsschema/resolver/schema/DefaultAdHocToolSchemaGenerator.java
@@ -43,14 +43,14 @@ public class DefaultAdHocToolSchemaGenerator implements AdHocToolSchemaGenerator
     inputParams.forEach(
         inputParam -> {
           if (restrictedParamNames.contains(inputParam.name())) {
-            throw new IllegalArgumentException(
+            throw new SchemaGenerationException(
                 "Input parameter name '%s' is restricted and cannot be used."
                     .formatted(inputParam.name()));
           }
 
           if (properties.containsKey(inputParam.name())) {
-            throw new IllegalArgumentException(
-                "Duplicate input parameter name: %s".formatted(inputParam.name()));
+            throw new SchemaGenerationException(
+                "Duplicate input parameter name '%s'.".formatted(inputParam.name()));
           }
 
           final var propertySchema =

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/adhoctoolsschema/resolver/schema/SchemaGenerationException.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/adhoctoolsschema/resolver/schema/SchemaGenerationException.java
@@ -1,0 +1,13 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.agenticai.adhoctoolsschema.resolver.schema;
+
+public class SchemaGenerationException extends RuntimeException {
+  public SchemaGenerationException(String message) {
+    super(message);
+  }
+}

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/AiAgentFunction.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/AiAgentFunction.java
@@ -33,7 +33,7 @@ import io.camunda.connector.generator.java.annotation.ElementTemplate.PropertyGr
       @PropertyGroup(id = "userPrompt", label = "User Prompt"),
       @PropertyGroup(id = "tools", label = "Tools"),
       @PropertyGroup(id = "memory", label = "Memory"),
-      @PropertyGroup(id = "guardrails", label = "Guardrails"),
+      @PropertyGroup(id = "limits", label = "Limits"),
       @PropertyGroup(id = "parameters", label = "Parameters"),
     },
     icon = "aiagent.svg")

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/AiAgentFunction.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/AiAgentFunction.java
@@ -21,20 +21,31 @@ import io.camunda.connector.generator.java.annotation.ElementTemplate.PropertyGr
 @ElementTemplate(
     id = "io.camunda.connectors.agenticai.aiagent.v0",
     name = "AI Agent (alpha)",
-    description = "AI Agent connector",
+    description =
+        "Provides a default AI Agent implementation handling the feedback loop between user requests, tool calls and LLM responses.",
     engineVersion = "^8.8",
     version = 0,
     inputDataClass = AgentRequest.class,
     propertyGroups = {
       @PropertyGroup(id = "model", label = "Model"),
       @PropertyGroup(id = "authentication", label = "Authentication"),
-      @PropertyGroup(id = "context", label = "Context"),
       @PropertyGroup(id = "systemPrompt", label = "System Prompt"),
       @PropertyGroup(id = "userPrompt", label = "User Prompt"),
-      @PropertyGroup(id = "tools", label = "Tools"),
-      @PropertyGroup(id = "memory", label = "Memory"),
+      @PropertyGroup(
+          id = "tools",
+          label = "Tools",
+          tooltip = "Configuration of tools which should be made available to the agent."),
+      @PropertyGroup(
+          id = "memory",
+          label = "Memory",
+          tooltip = "Configuration of the Agent's short-term memory."),
       @PropertyGroup(id = "limits", label = "Limits"),
-      @PropertyGroup(id = "parameters", label = "Parameters"),
+      @PropertyGroup(
+          id = "parameters",
+          label = "Model Parameters",
+          tooltip =
+              "Configuration of common model parameters to optimize and fine-tune LLM responses.",
+          openByDefault = false)
     },
     icon = "aiagent.svg")
 public class AiAgentFunction implements OutboundConnectorFunction {

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/agent/DefaultAiAgentRequestHandler.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/agent/DefaultAiAgentRequestHandler.java
@@ -89,8 +89,8 @@ public class DefaultAiAgentRequestHandler implements AiAgentRequestHandler {
             .chatMemoryStore(chatMemoryStore)
             .build();
 
-    // check configured guardrails
-    checkGuardrails(requestData, agentContext);
+    // check configured limits
+    checkLimits(requestData, agentContext);
 
     // update memory with system + new user messages/tool call responses
     addSystemPromptIfNecessary(chatMemory, requestData);
@@ -127,12 +127,9 @@ public class DefaultAiAgentRequestHandler implements AiAgentRequestHandler {
     return new AgentResponse(updatedContext, updatedContext.memory().getLast(), toolCalls);
   }
 
-  private void checkGuardrails(
-      AgentRequest.AgentRequestData requestData, AgentContext agentContext) {
-    // naive guardrail implementation
+  private void checkLimits(AgentRequest.AgentRequestData requestData, AgentContext agentContext) {
     final int maxModelCalls =
-        Optional.ofNullable(requestData.guardrails().maxModelCalls())
-            .orElse(DEFAULT_MAX_MODEL_CALLS);
+        Optional.ofNullable(requestData.limits().maxModelCalls()).orElse(DEFAULT_MAX_MODEL_CALLS);
     if (agentContext.metrics().modelCalls() >= maxModelCalls) {
       throw new ConnectorException(
           ERROR_CODE_MAXIMUM_NUMBER_OF_MODEL_CALLS_REACHED,

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/agent/DefaultAiAgentRequestHandler.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/agent/DefaultAiAgentRequestHandler.java
@@ -45,6 +45,8 @@ public class DefaultAiAgentRequestHandler implements AiAgentRequestHandler {
       "WAITING_FOR_TOOL_INPUT_EMPTY_RESULTS";
   private static final String ERROR_CODE_TOOL_CALL_RESULTS_ON_EMPTY_CONTEXT =
       "TOOL_CALL_RESULTS_ON_EMPTY_CONTEXT";
+  private static final String ERROR_CODE_MAXIMUM_NUMBER_OF_MODEL_CALLS_REACHED =
+      "MAXIMUM_NUMBER_OF_MODEL_CALLS_REACHED";
 
   private final ObjectMapper objectMapper;
   private final ChatModelFactory chatModelFactory;
@@ -132,7 +134,10 @@ public class DefaultAiAgentRequestHandler implements AiAgentRequestHandler {
         Optional.ofNullable(requestData.guardrails().maxModelCalls())
             .orElse(DEFAULT_MAX_MODEL_CALLS);
     if (agentContext.metrics().modelCalls() >= maxModelCalls) {
-      throw new ConnectorException("Maximum number of model calls reached");
+      throw new ConnectorException(
+          ERROR_CODE_MAXIMUM_NUMBER_OF_MODEL_CALLS_REACHED,
+          "Maximum number of model calls reached (modelCalls: %d, limit: %d)"
+              .formatted(agentContext.metrics().modelCalls(), maxModelCalls));
     }
   }
 

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/AgentContext.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/AgentContext.java
@@ -9,9 +9,19 @@ package io.camunda.connector.agenticai.aiagent.model;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 public record AgentContext(
     AgentState state, AgentMetrics metrics, List<Map<String, Object>> memory) {
+  public static AgentContext EMPTY =
+      new AgentContext(AgentState.READY, AgentMetrics.EMPTY, Collections.emptyList());
+
+  public AgentContext {
+    Objects.requireNonNull(state, "Agent state must not be null");
+    Objects.requireNonNull(metrics, "Agent metrics must not be null");
+    Objects.requireNonNull(memory, "Agent memory must not be null");
+  }
+
   public AgentContext withState(AgentState state) {
     return new AgentContext(state, metrics, memory);
   }
@@ -20,15 +30,19 @@ public record AgentContext(
     return this.state == state;
   }
 
+  public boolean isEmpty() {
+    return this.equals(EMPTY);
+  }
+
+  public static AgentContext empty() {
+    return EMPTY;
+  }
+
   public AgentContext withMetrics(AgentMetrics metrics) {
     return new AgentContext(state, metrics, memory);
   }
 
   public AgentContext withMemory(List<Map<String, Object>> memory) {
     return new AgentContext(state, metrics, memory);
-  }
-
-  public static AgentContext empty() {
-    return new AgentContext(AgentState.READY, AgentMetrics.empty(), Collections.emptyList());
   }
 }

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/AgentMetrics.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/AgentMetrics.java
@@ -6,9 +6,20 @@
  */
 package io.camunda.connector.agenticai.aiagent.model;
 
+import java.util.Objects;
 import java.util.Optional;
 
 public record AgentMetrics(int modelCalls, TokenUsage tokenUsage) {
+  public static final AgentMetrics EMPTY = new AgentMetrics(0, TokenUsage.empty());
+
+  public AgentMetrics {
+    if (modelCalls < 0) {
+      throw new IllegalArgumentException("Model calls must be non-negative");
+    }
+
+    Objects.requireNonNull(tokenUsage, "Token usage must not be null");
+  }
+
   public AgentMetrics withModelCalls(int modelCalls) {
     return new AgentMetrics(modelCalls, tokenUsage);
   }
@@ -25,11 +36,16 @@ public record AgentMetrics(int modelCalls, TokenUsage tokenUsage) {
     return withTokenUsage(tokenUsage.add(additionalTokenUsage));
   }
 
+  public boolean isEmpty() {
+    return this.equals(EMPTY);
+  }
+
   public static AgentMetrics empty() {
-    return new AgentMetrics(0, TokenUsage.empty());
+    return EMPTY;
   }
 
   public record TokenUsage(int inputTokenCount, int outputTokenCount) {
+    public static TokenUsage EMPTY = new TokenUsage(0, 0);
 
     public int totalTokenCount() {
       return inputTokenCount + outputTokenCount;
@@ -41,8 +57,12 @@ public record AgentMetrics(int modelCalls, TokenUsage tokenUsage) {
           outputTokenCount() + tokenUsage.outputTokenCount());
     }
 
+    public boolean isEmpty() {
+      return this.equals(EMPTY);
+    }
+
     public static TokenUsage empty() {
-      return new TokenUsage(0, 0);
+      return EMPTY;
     }
 
     public static TokenUsage from(dev.langchain4j.model.output.TokenUsage tokenUsage) {

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/AgentRequest.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/AgentRequest.java
@@ -25,9 +25,10 @@ public record AgentRequest(
       @FEEL
           @TemplateProperty(
               label = "Agent Context",
-              group = "context",
+              group = "memory",
               id = "agentContext",
-              description = "The agent context variable containing the conversation memory",
+              description =
+                  "The agent context variable containing all relevant data for the agent to support the feedback loop between user requests, tool calls and LLM responses. Make sure this variable points to the <code>context</code> variable which is returned from the agent response.",
               constraints = @PropertyConstraints(notEmpty = true),
               defaultValue = "=agent.context",
               type = TemplateProperty.PropertyType.Text,
@@ -41,6 +42,11 @@ public record AgentRequest(
       @Valid @NotNull LimitsConfiguration limits) {
 
     public interface PromptConfiguration {
+      String PROMPT_PARAMETERS_DESCRIPTION =
+          "Map of parameters which can be used in <code>{{parameter}}</code> format in the prompt text.";
+      String PROMPT_PARAMETERS_TOOLTIP =
+          "Default parameters provided by the integration: <code>current_date</code>, <code>current_time</code>, <code>current_date_time</code>";
+
       String prompt();
 
       Map<String, Object> parameters();
@@ -61,6 +67,8 @@ public record AgentRequest(
             @TemplateProperty(
                 group = "systemPrompt",
                 label = "System Prompt Parameters",
+                description = PROMPT_PARAMETERS_DESCRIPTION,
+                tooltip = PROMPT_PARAMETERS_TOOLTIP,
                 feel = Property.FeelMode.required,
                 optional = true)
             Map<String, Object> parameters)
@@ -98,6 +106,8 @@ Reveal **no** additional private reasoning outside these tags.
             @TemplateProperty(
                 group = "userPrompt",
                 label = "User Prompt Parameters",
+                description = PROMPT_PARAMETERS_DESCRIPTION,
+                tooltip = PROMPT_PARAMETERS_TOOLTIP,
                 feel = Property.FeelMode.required,
                 optional = true)
             Map<String, Object> parameters,
@@ -130,9 +140,12 @@ Reveal **no** additional private reasoning outside these tags.
             List<Map<String, Object>> toolCallResults) {}
 
     public record MemoryConfiguration(
+        // TODO support more advanced eviction policies (token window)
         @TemplateProperty(
                 group = "memory",
-                label = "Maximum amount of messages to keep in memory",
+                label = "Maximum messages",
+                description =
+                    "Maximum amount of messages to keep in short-term/conversation memory.",
                 type = TemplateProperty.PropertyType.Number,
                 defaultValue = "20",
                 defaultValueType = TemplateProperty.DefaultValueType.Number,
@@ -145,7 +158,9 @@ Reveal **no** additional private reasoning outside these tags.
         // TODO think of other limits (max tool calls, max tokens, ...)
         @TemplateProperty(
                 group = "limits",
-                label = "Maximum number of calls to the model",
+                label = "Maximum model calls",
+                description =
+                    "Maximum number of calls to the model as a safety limit to prevent infinite loops.",
                 type = TemplateProperty.PropertyType.Number,
                 defaultValue = "10",
                 defaultValueType = TemplateProperty.DefaultValueType.Number)

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/AgentRequest.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/AgentRequest.java
@@ -38,7 +38,7 @@ public record AgentRequest(
       @Valid @NotNull UserPromptConfiguration userPrompt,
       @Valid @NotNull ToolsConfiguration tools,
       @Valid @NotNull MemoryConfiguration memory,
-      @Valid @NotNull GuardrailsConfiguration guardrails) {
+      @Valid @NotNull LimitsConfiguration limits) {
 
     public interface PromptConfiguration {
       String prompt();
@@ -141,10 +141,10 @@ Reveal **no** additional private reasoning outside these tags.
             @Min(3)
             Integer maxMessages) {}
 
-    public record GuardrailsConfiguration(
-        // TODO think of other guardrails (max tool calls, max tokens, ...)
+    public record LimitsConfiguration(
+        // TODO think of other limits (max tool calls, max tokens, ...)
         @TemplateProperty(
-                group = "guardrails",
+                group = "limits",
                 label = "Maximum number of calls to the model",
                 type = TemplateProperty.PropertyType.Number,
                 defaultValue = "10",

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/AgentRequest.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/AgentRequest.java
@@ -30,7 +30,6 @@ public record AgentRequest(
               description =
                   "The agent context variable containing all relevant data for the agent to support the feedback loop between user requests, tool calls and LLM responses. Make sure this variable points to the <code>context</code> variable which is returned from the agent response.",
               constraints = @PropertyConstraints(notEmpty = true),
-              defaultValue = "=agent.context",
               type = TemplateProperty.PropertyType.Text,
               feel = Property.FeelMode.required)
           @Valid

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/AgentRequest.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/AgentRequest.java
@@ -10,6 +10,7 @@ import io.camunda.connector.agenticai.aiagent.model.AgentContext;
 import io.camunda.connector.feel.annotation.FEEL;
 import io.camunda.connector.generator.dsl.Property;
 import io.camunda.connector.generator.java.annotation.TemplateProperty;
+import io.camunda.connector.generator.java.annotation.TemplateProperty.PropertyConstraints;
 import io.camunda.document.Document;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
@@ -18,7 +19,8 @@ import jakarta.validation.constraints.NotNull;
 import java.util.List;
 import java.util.Map;
 
-public record AgentRequest(ProviderConfiguration provider, AgentRequestData data) {
+public record AgentRequest(
+    @Valid @NotNull ProviderConfiguration provider, @Valid @NotNull AgentRequestData data) {
   public record AgentRequestData(
       @FEEL
           @TemplateProperty(
@@ -26,10 +28,11 @@ public record AgentRequest(ProviderConfiguration provider, AgentRequestData data
               group = "context",
               id = "agentContext",
               description = "The agent context variable containing the conversation memory",
+              constraints = @PropertyConstraints(notEmpty = true),
+              defaultValue = "=agent.context",
               type = TemplateProperty.PropertyType.Text,
               feel = Property.FeelMode.required)
           @Valid
-          @NotNull
           AgentContext context,
       @Valid @NotNull SystemPromptConfiguration systemPrompt,
       @Valid @NotNull UserPromptConfiguration userPrompt,
@@ -49,7 +52,9 @@ public record AgentRequest(ProviderConfiguration provider, AgentRequestData data
                 group = "systemPrompt",
                 label = "System Prompt",
                 type = TemplateProperty.PropertyType.Text,
-                feel = Property.FeelMode.optional)
+                feel = Property.FeelMode.optional,
+                constraints = @PropertyConstraints(notEmpty = true),
+                defaultValue = DEFAULT_SYSTEM_PROMPT)
             @NotBlank
             String prompt,
         @FEEL
@@ -59,7 +64,25 @@ public record AgentRequest(ProviderConfiguration provider, AgentRequestData data
                 feel = Property.FeelMode.required,
                 optional = true)
             Map<String, Object> parameters)
-        implements PromptConfiguration {}
+        implements PromptConfiguration {
+
+      @TemplateProperty(ignore = true)
+      public static final String DEFAULT_SYSTEM_PROMPT =
+          """
+You are **TaskAgent**, a helpful, generic chat agent that can handle a wide variety of customer requests using your own domain knowledge **and** any tools explicitly provided to you at runtime.
+
+If tools are provided, you should prefer them instead of guessing an answer. You can call the same tool multiple times by providing different input values. Don't guess any tools which were not explicitely configured. If no tool matches the request, try to generate an answer. If you're not able to find a good answer, return with a message stating why you're not able to.
+
+Wrap minimal, inspectable reasoning in *exactly* this XML template:
+
+<thinking>
+  <context>…briefly state the customer’s need and current state…</context>
+  <reflection>…list candidate tools, justify which you will call next and why…</reflection>
+</thinking>
+
+Reveal **no** additional private reasoning outside these tags.
+""";
+    }
 
     public record UserPromptConfiguration(
         @FEEL
@@ -67,7 +90,8 @@ public record AgentRequest(ProviderConfiguration provider, AgentRequestData data
                 group = "userPrompt",
                 label = "User Prompt",
                 type = TemplateProperty.PropertyType.Text,
-                feel = Property.FeelMode.optional)
+                feel = Property.FeelMode.optional,
+                constraints = @PropertyConstraints(notEmpty = true))
             @NotBlank
             String prompt,
         @FEEL
@@ -91,7 +115,7 @@ public record AgentRequest(ProviderConfiguration provider, AgentRequestData data
     public record ToolsConfiguration(
         @TemplateProperty(
                 group = "tools",
-                label = "Ad-hoc subprocess ID containing tools",
+                label = "Ad-hoc subprocess ID",
                 description = "The ID of the subprocess containing the tools to be called",
                 optional = true)
             String containerElementId,
@@ -111,7 +135,8 @@ public record AgentRequest(ProviderConfiguration provider, AgentRequestData data
                 label = "Maximum amount of messages to keep in memory",
                 type = TemplateProperty.PropertyType.Number,
                 defaultValue = "20",
-                defaultValueType = TemplateProperty.DefaultValueType.Number)
+                defaultValueType = TemplateProperty.DefaultValueType.Number,
+                constraints = @PropertyConstraints(notEmpty = true))
             @NotNull
             @Min(3)
             Integer maxMessages) {}

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/ProviderConfiguration.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/ProviderConfiguration.java
@@ -6,6 +6,10 @@
  */
 package io.camunda.connector.agenticai.aiagent.model.request;
 
+import static io.camunda.connector.agenticai.aiagent.model.request.ProviderConfiguration.AnthropicProviderConfiguration.ANTHROPIC_ID;
+import static io.camunda.connector.agenticai.aiagent.model.request.ProviderConfiguration.BedrockProviderConfiguration.BEDROCK_ID;
+import static io.camunda.connector.agenticai.aiagent.model.request.ProviderConfiguration.OpenAiProviderConfiguration.OPENAI_ID;
+
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import io.camunda.connector.aws.model.impl.AwsAuthentication;
@@ -13,36 +17,42 @@ import io.camunda.connector.feel.annotation.FEEL;
 import io.camunda.connector.generator.dsl.Property;
 import io.camunda.connector.generator.java.annotation.TemplateDiscriminatorProperty;
 import io.camunda.connector.generator.java.annotation.TemplateProperty;
+import io.camunda.connector.generator.java.annotation.TemplateProperty.PropertyConstraints;
 import io.camunda.connector.generator.java.annotation.TemplateSubType;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
 @JsonSubTypes({
   @JsonSubTypes.Type(
       value = ProviderConfiguration.AnthropicProviderConfiguration.class,
-      name = "anthropic"),
+      name = ANTHROPIC_ID),
   @JsonSubTypes.Type(
       value = ProviderConfiguration.BedrockProviderConfiguration.class,
-      name = "bedrock"),
+      name = BEDROCK_ID),
   @JsonSubTypes.Type(
       value = ProviderConfiguration.OpenAiProviderConfiguration.class,
-      name = "openai")
+      name = OPENAI_ID)
 })
 @TemplateDiscriminatorProperty(
     label = "Provider",
     group = "model",
     name = "type",
-    description = "Specify the model provider to use")
+    description = "Specify the model provider to use",
+    defaultValue = ANTHROPIC_ID)
 public sealed interface ProviderConfiguration
     permits ProviderConfiguration.AnthropicProviderConfiguration,
         ProviderConfiguration.BedrockProviderConfiguration,
         ProviderConfiguration.OpenAiProviderConfiguration {
 
-  @TemplateSubType(id = "anthropic", label = "Anthropic")
+  @TemplateSubType(id = ANTHROPIC_ID, label = "Anthropic")
   record AnthropicProviderConfiguration(AnthropicConnection anthropic)
       implements ProviderConfiguration {
+
+    @TemplateProperty(ignore = true)
+    public static final String ANTHROPIC_ID = "anthropic";
 
     public record AnthropicConnection(
         @TemplateProperty(
@@ -52,7 +62,7 @@ public sealed interface ProviderConfiguration
                 feel = Property.FeelMode.disabled,
                 optional = true)
             String endpoint,
-        AnthropicAuthentication authentication,
+        @NotNull @Valid AnthropicAuthentication authentication,
         AnthropicModel model) {}
 
     public record AnthropicAuthentication(
@@ -61,7 +71,8 @@ public sealed interface ProviderConfiguration
                 group = "authentication",
                 label = "Anthropic API Key",
                 type = TemplateProperty.PropertyType.String,
-                feel = Property.FeelMode.optional)
+                feel = Property.FeelMode.optional,
+                constraints = @PropertyConstraints(notEmpty = true))
             String apiKey) {}
 
     public record AnthropicModel(
@@ -72,18 +83,23 @@ public sealed interface ProviderConfiguration
                 type = TemplateProperty.PropertyType.String,
                 feel = Property.FeelMode.optional,
                 defaultValue = "claude-3-5-sonnet-20240620",
-                defaultValueType = TemplateProperty.DefaultValueType.String)
+                defaultValueType = TemplateProperty.DefaultValueType.String,
+                constraints = @PropertyConstraints(notEmpty = true))
             String model,
         @Valid ModelParameters parameters) {}
   }
 
-  @TemplateSubType(id = "bedrock", label = "AWS Bedrock")
+  @TemplateSubType(id = BEDROCK_ID, label = "AWS Bedrock")
   record BedrockProviderConfiguration(BedrockConnection bedrock) implements ProviderConfiguration {
+
+    @TemplateProperty(ignore = true)
+    public static final String BEDROCK_ID = "bedrock";
+
     public record BedrockConnection(
         @TemplateProperty(
                 group = "model",
                 description = "Specify the AWS region",
-                constraints = @TemplateProperty.PropertyConstraints(notEmpty = true))
+                constraints = @PropertyConstraints(notEmpty = true))
             String region,
         @FEEL
             @TemplateProperty(
@@ -104,13 +120,17 @@ public sealed interface ProviderConfiguration
                 type = TemplateProperty.PropertyType.String,
                 feel = Property.FeelMode.optional,
                 defaultValue = "anthropic.claude-3-5-sonnet-20240620-v1:0",
-                defaultValueType = TemplateProperty.DefaultValueType.String)
+                defaultValueType = TemplateProperty.DefaultValueType.String,
+                constraints = @PropertyConstraints(notEmpty = true))
             String model,
         @Valid ModelParameters parameters) {}
   }
 
-  @TemplateSubType(id = "openai", label = "OpenAI")
+  @TemplateSubType(id = OPENAI_ID, label = "OpenAI")
   record OpenAiProviderConfiguration(OpenAiConnection openai) implements ProviderConfiguration {
+
+    @TemplateProperty(ignore = true)
+    public static final String OPENAI_ID = "openai";
 
     public record OpenAiConnection(
         @TemplateProperty(
@@ -129,7 +149,8 @@ public sealed interface ProviderConfiguration
                 group = "authentication",
                 label = "OpenAI API Key",
                 type = TemplateProperty.PropertyType.String,
-                feel = Property.FeelMode.optional)
+                feel = Property.FeelMode.optional,
+                constraints = @PropertyConstraints(notEmpty = true))
             String apiKey,
         @TemplateProperty(
                 group = "authentication",
@@ -157,7 +178,8 @@ public sealed interface ProviderConfiguration
                 type = TemplateProperty.PropertyType.String,
                 feel = Property.FeelMode.optional,
                 defaultValue = "gpt-4o",
-                defaultValueType = TemplateProperty.DefaultValueType.String)
+                defaultValueType = TemplateProperty.DefaultValueType.String,
+                constraints = @PropertyConstraints(notEmpty = true))
             String model,
         @Valid ModelParameters parameters) {}
   }

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/ProviderConfiguration.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/ProviderConfiguration.java
@@ -37,10 +37,10 @@ import jakarta.validation.constraints.NotNull;
       name = OPENAI_ID)
 })
 @TemplateDiscriminatorProperty(
-    label = "Provider",
+    label = "Model Provider",
     group = "model",
     name = "type",
-    description = "Specify the model provider to use",
+    description = "Specify the LLM provider to use.",
     defaultValue = ANTHROPIC_ID)
 public sealed interface ProviderConfiguration
     permits ProviderConfiguration.AnthropicProviderConfiguration,
@@ -80,6 +80,8 @@ public sealed interface ProviderConfiguration
             @TemplateProperty(
                 group = "model",
                 label = "Model",
+                description =
+                    "Specify the model ID. Details in the <a href=\"https://docs.anthropic.com/en/docs/about-claude/models/all-models\" target=\"_blank\">documentation</a>.",
                 type = TemplateProperty.PropertyType.String,
                 feel = Property.FeelMode.optional,
                 defaultValue = "claude-3-5-sonnet-20240620",
@@ -117,6 +119,8 @@ public sealed interface ProviderConfiguration
             @TemplateProperty(
                 group = "model",
                 label = "Model",
+                description =
+                    "Specify the model ID. Details in the <a href=\"https://docs.aws.amazon.com/bedrock/latest/userguide/model-ids.html\" target=\"_blank\">documentation</a>.",
                 type = TemplateProperty.PropertyType.String,
                 feel = Property.FeelMode.optional,
                 defaultValue = "anthropic.claude-3-5-sonnet-20240620-v1:0",
@@ -156,7 +160,7 @@ public sealed interface ProviderConfiguration
                 group = "authentication",
                 label = "Organization",
                 description =
-                    "For members of multiple organizations. Details in the <a href=\"https://platform.openai.com/docs/api-reference/requesting-organization\" target=\"_blank\">OpenAI documentation</a>.",
+                    "For members of multiple organizations. Details in the <a href=\"https://platform.openai.com/docs/api-reference/requesting-organization\" target=\"_blank\">documentation</a>.",
                 type = TemplateProperty.PropertyType.String,
                 feel = Property.FeelMode.optional,
                 optional = true)
@@ -175,6 +179,8 @@ public sealed interface ProviderConfiguration
             @TemplateProperty(
                 group = "model",
                 label = "Model",
+                description =
+                    "Specify the model ID. Details in the <a href=\"https://platform.openai.com/docs/models\" target=\"_blank\">documentation</a>.",
                 type = TemplateProperty.PropertyType.String,
                 feel = Property.FeelMode.optional,
                 defaultValue = "gpt-4o",

--- a/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/adhoctoolsschema/feel/FeelInputParamExtractorTest.java
+++ b/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/adhoctoolsschema/feel/FeelInputParamExtractorTest.java
@@ -312,7 +312,22 @@ class FeelInputParamExtractorTest {
                 "fourthValue",
                 "The fourth value to add",
                 "array",
-                Map.of("items", Map.of("type", "string", "enum", List.of("foo", "bar", "baz"))))));
+                Map.of("items", Map.of("type", "string", "enum", List.of("foo", "bar", "baz"))))),
+        new FeelInputParamTestCase(
+            "Multiple parameters, part of a context and list (different casing)",
+            """
+            {
+              foo: [fromAI(toolCall.firstValue, "The first value", "string"), FROMAI(toolCall.secondValue, "The second value", "integer")],
+              bar: {
+                baz: fromai(toolCall.thirdValue, "The third value to add"),
+                qux: fRoMAi(toolCall.fourthValue, "The fourth value to add")
+              }
+            }
+            """,
+            new FeelInputParam("firstValue", "The first value", "string"),
+            new FeelInputParam("secondValue", "The second value", "integer"),
+            new FeelInputParam("thirdValue", "The third value to add"),
+            new FeelInputParam("fourthValue", "The fourth value to add")));
   }
 
   record FeelInputParamTestCase(

--- a/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/adhoctoolsschema/resolver/CachingAdHocToolsSchemaResolverTest.java
+++ b/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/adhoctoolsschema/resolver/CachingAdHocToolsSchemaResolverTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.agenticai.adhoctoolsschema.resolver;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import io.camunda.connector.agenticai.adhoctoolsschema.model.AdHocToolsSchemaResponse;
+import java.time.Duration;
+import java.util.stream.Stream;
+import org.apache.commons.lang3.tuple.Pair;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class CachingAdHocToolsSchemaResolverTest {
+
+  private static final Long PROCESS_DEFINITION_KEY_1 = 123456L;
+  private static final Long PROCESS_DEFINITION_KEY_2 = 654321L;
+
+  private static final String AD_HOC_SUBPROCESS_ID_1 = "AHSP_1";
+  private static final String AD_HOC_SUBPROCESS_ID_2 = "AHSP_2";
+
+  @Mock private AdHocToolsSchemaResolver delegate;
+  private CachingAdHocToolsSchemaResolver resolver;
+
+  @BeforeEach
+  void setUp() {
+    resolver =
+        new CachingAdHocToolsSchemaResolver(
+            delegate,
+            new CachingAdHocToolsSchemaResolver.CacheConfiguration(10L, Duration.ofHours(1)));
+  }
+
+  @Test
+  void returnsCachedValue() {
+    final var mockedResponse = mock(AdHocToolsSchemaResponse.class);
+    when(delegate.resolveSchema(PROCESS_DEFINITION_KEY_1, AD_HOC_SUBPROCESS_ID_1))
+        .thenReturn(mockedResponse);
+
+    final var response1 = resolver.resolveSchema(PROCESS_DEFINITION_KEY_1, AD_HOC_SUBPROCESS_ID_1);
+    final var response2 = resolver.resolveSchema(PROCESS_DEFINITION_KEY_1, AD_HOC_SUBPROCESS_ID_1);
+
+    assertThat(response1).isSameAs(response2).isSameAs(mockedResponse);
+
+    verify(delegate, times(1)).resolveSchema(PROCESS_DEFINITION_KEY_1, AD_HOC_SUBPROCESS_ID_1);
+    verifyNoMoreInteractions(delegate);
+  }
+
+  @ParameterizedTest
+  @MethodSource("differentCacheKeys")
+  void returnsDifferentValueForDifferentCacheKey(
+      Pair<Long, String> cacheKey1, Pair<Long, String> cacheKey2) {
+    final var mockedResponse1 = mock(AdHocToolsSchemaResponse.class);
+    final var mockedResponse2 = mock(AdHocToolsSchemaResponse.class);
+
+    when(delegate.resolveSchema(cacheKey1.getLeft(), cacheKey1.getRight()))
+        .thenReturn(mockedResponse1);
+    when(delegate.resolveSchema(cacheKey2.getLeft(), cacheKey2.getRight()))
+        .thenReturn(mockedResponse2);
+
+    final var response1 = resolver.resolveSchema(cacheKey1.getLeft(), cacheKey1.getRight());
+    final var response2 = resolver.resolveSchema(cacheKey2.getLeft(), cacheKey2.getRight());
+
+    assertThat(response1).isNotSameAs(response2).isSameAs(mockedResponse1);
+    assertThat(response2).isNotSameAs(response1).isSameAs(mockedResponse2);
+
+    verify(delegate, times(1)).resolveSchema(cacheKey1.getLeft(), cacheKey1.getRight());
+    verify(delegate, times(1)).resolveSchema(cacheKey2.getLeft(), cacheKey2.getRight());
+    verifyNoMoreInteractions(delegate);
+  }
+
+  @ParameterizedTest
+  @NullSource
+  @ValueSource(longs = {0, -10})
+  void throwsExceptionWhenProcessDefinitionKeyIsInvalid(Long processDefinitionKey) {
+    assertThatThrownBy(() -> resolver.resolveSchema(processDefinitionKey, AD_HOC_SUBPROCESS_ID_1))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Process definition key must not be null or negative");
+
+    verifyNoInteractions(delegate);
+  }
+
+  @ParameterizedTest
+  @NullAndEmptySource
+  @ValueSource(strings = {"   "})
+  void throwsExceptionWhenAdHocSubprocessIdIsInvalid(String adHocSubprocessId) {
+    assertThatThrownBy(() -> resolver.resolveSchema(PROCESS_DEFINITION_KEY_1, adHocSubprocessId))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("adHocSubprocessId cannot be null or empty");
+
+    verifyNoInteractions(delegate);
+  }
+
+  static Stream<Arguments> differentCacheKeys() {
+    return Stream.of(
+        arguments(
+            Pair.of(PROCESS_DEFINITION_KEY_1, AD_HOC_SUBPROCESS_ID_1),
+            Pair.of(PROCESS_DEFINITION_KEY_1, AD_HOC_SUBPROCESS_ID_2)),
+        arguments(
+            Pair.of(PROCESS_DEFINITION_KEY_1, AD_HOC_SUBPROCESS_ID_1),
+            Pair.of(PROCESS_DEFINITION_KEY_2, AD_HOC_SUBPROCESS_ID_1)));
+  }
+}

--- a/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/adhoctoolsschema/resolver/CamundaClientAdHocToolsSchemaResolverTest.java
+++ b/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/adhoctoolsschema/resolver/CamundaClientAdHocToolsSchemaResolverTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.agenticai.adhoctoolsschema.resolver;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.connector.agenticai.adhoctoolsschema.feel.FeelInputParamExtractor;
+import io.camunda.connector.agenticai.adhoctoolsschema.resolver.schema.AdHocToolSchemaGenerator;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class CamundaClientAdHocToolsSchemaResolverTest {
+
+  @Mock private CamundaClient camundaClient;
+  @Mock private FeelInputParamExtractor feelInputParamExtractor;
+  @Mock private AdHocToolSchemaGenerator schemaGenerator;
+  @InjectMocks private CamundaClientAdHocToolsSchemaResolver resolver;
+
+  @ParameterizedTest
+  @NullSource
+  @ValueSource(longs = {0, -10})
+  void throwsExceptionWhenProcessDefinitionKeyIsInvalid(Long processDefinitionKey) {
+    assertThatThrownBy(() -> resolver.resolveSchema(processDefinitionKey, "AHSP"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Process definition key must not be null or negative");
+
+    verifyNoInteractions(camundaClient, feelInputParamExtractor, schemaGenerator);
+  }
+
+  @ParameterizedTest
+  @NullAndEmptySource
+  @ValueSource(strings = {"   "})
+  void throwsExceptionWhenAdHocSubprocessIdIsInvalid(String adHocSubprocessId) {
+    assertThatThrownBy(() -> resolver.resolveSchema(123456L, adHocSubprocessId))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("adHocSubprocessId cannot be null or empty");
+
+    verifyNoInteractions(camundaClient, feelInputParamExtractor, schemaGenerator);
+  }
+}

--- a/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/adhoctoolsschema/resolver/CamundaClientAdHocToolsSchemaResolverTest.java
+++ b/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/adhoctoolsschema/resolver/CamundaClientAdHocToolsSchemaResolverTest.java
@@ -6,18 +6,38 @@
  */
 package io.camunda.connector.agenticai.adhoctoolsschema.resolver;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
 
 import io.camunda.client.CamundaClient;
+import io.camunda.connector.agenticai.adhoctoolsschema.feel.FeelInputParam;
+import io.camunda.connector.agenticai.adhoctoolsschema.feel.FeelInputParamExtractionException;
 import io.camunda.connector.agenticai.adhoctoolsschema.feel.FeelInputParamExtractor;
+import io.camunda.connector.agenticai.adhoctoolsschema.model.AdHocToolsSchemaResponse.AdHocToolDefinition;
 import io.camunda.connector.agenticai.adhoctoolsschema.resolver.schema.AdHocToolSchemaGenerator;
+import io.camunda.connector.agenticai.adhoctoolsschema.resolver.schema.SchemaGenerationException;
+import io.camunda.connector.api.error.ConnectorException;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import org.camunda.bpm.model.xml.ModelParseException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.junit.jupiter.params.provider.NullSource;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.Answers;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -25,10 +45,82 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 class CamundaClientAdHocToolsSchemaResolverTest {
 
-  @Mock private CamundaClient camundaClient;
+  private static final Long PROCESS_DEFINITION_KEY = 123456L;
+  private static final String AD_HOC_SUBPROCESS_ID = "Agent_Tools";
+
+  @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+  private CamundaClient camundaClient;
+
   @Mock private FeelInputParamExtractor feelInputParamExtractor;
   @Mock private AdHocToolSchemaGenerator schemaGenerator;
   @InjectMocks private CamundaClientAdHocToolsSchemaResolver resolver;
+
+  private String bpmnXml;
+
+  @BeforeEach
+  void setUp() throws IOException {
+    bpmnXml =
+        Files.readString(
+            Path.of(getClass().getClassLoader().getResource("ad-hoc-tools.bpmn").getFile()));
+  }
+
+  @Test
+  void loadsAdHocToolSchema() {
+    when(camundaClient.newProcessDefinitionGetXmlRequest(PROCESS_DEFINITION_KEY).send().join())
+        .thenReturn(bpmnXml);
+
+    final Map<String, Object> expectedToolASchema =
+        Map.of("type", "object", "comment", "toolASchema", "dummy", true);
+    final Map<String, Object> expectedEmptySchema =
+        Map.of("type", "object", "comment", "emptySchema", "dummy", true);
+
+    final var toolAInputParams =
+        List.of(
+            new FeelInputParam("inputParameter", "An input parameter"),
+            new FeelInputParam("outputParameter", "An output parameter"));
+
+    doReturn(List.of(toolAInputParams.get(0)))
+        .when(feelInputParamExtractor)
+        .extractInputParams("fromAi(toolCall.inputParameter, \"An input parameter\")");
+    doReturn(List.of(toolAInputParams.get(1)))
+        .when(feelInputParamExtractor)
+        .extractInputParams("fromAi(toolCall.outputParameter, \"An output parameter\")");
+
+    when(schemaGenerator.generateToolSchema(any())).thenReturn(expectedEmptySchema);
+    doReturn(expectedToolASchema).when(schemaGenerator).generateToolSchema(toolAInputParams);
+
+    final var result = resolver.resolveSchema(PROCESS_DEFINITION_KEY, AD_HOC_SUBPROCESS_ID);
+
+    assertThat(result).isNotNull();
+    assertThat(result.toolDefinitions())
+        .isNotEmpty()
+        .satisfiesExactlyInAnyOrder(
+            td -> {
+              assertThat(td.name()).isEqualTo("A_Complex_Tool");
+              assertThat(td.description()).isEqualTo("A very complex tool");
+              assertThat(td.inputSchema()).isEqualTo(expectedEmptySchema);
+            },
+            td -> {
+              assertThat(td.name()).isEqualTo("Tool_A");
+              assertThat(td.description()).isEqualTo("The A tool");
+              assertThat(td.inputSchema()).isEqualTo(expectedToolASchema);
+            },
+            td -> {
+              assertThat(td.name()).isEqualTo("Simple_Tool");
+              assertThat(td.description()).isEqualTo("A simple tool");
+              assertThat(td.inputSchema()).isEqualTo(expectedEmptySchema);
+            },
+            td -> {
+              assertThat(td.name()).isEqualTo("An_Event");
+              assertThat(td.description()).isEqualTo("An event!");
+              assertThat(td.inputSchema()).isEqualTo(expectedEmptySchema);
+            });
+
+    assertThat(result.toolDefinitions())
+        .extracting(AdHocToolDefinition::name)
+        .doesNotContain(
+            "Tool_B", "Event_Follow_Up_Task", "Complex_Tool_Error", "Handle_Complex_Tool_Error");
+  }
 
   @ParameterizedTest
   @NullSource
@@ -50,5 +142,89 @@ class CamundaClientAdHocToolsSchemaResolverTest {
         .hasMessage("adHocSubprocessId cannot be null or empty");
 
     verifyNoInteractions(camundaClient, feelInputParamExtractor, schemaGenerator);
+  }
+
+  @Test
+  void throwsExceptionWhenBpmnXmlIsInvalid() {
+    when(camundaClient.newProcessDefinitionGetXmlRequest(PROCESS_DEFINITION_KEY).send().join())
+        .thenReturn("DUMMY");
+
+    assertThatThrownBy(() -> resolver.resolveSchema(PROCESS_DEFINITION_KEY, AD_HOC_SUBPROCESS_ID))
+        .isInstanceOf(ModelParseException.class);
+  }
+
+  @Test
+  void throwsExceptionWhenAdHocSubprocessIdIsInvalid() {
+    when(camundaClient.newProcessDefinitionGetXmlRequest(PROCESS_DEFINITION_KEY).send().join())
+        .thenReturn(bpmnXml);
+
+    assertThatThrownBy(() -> resolver.resolveSchema(PROCESS_DEFINITION_KEY, "DUMMY"))
+        .isInstanceOfSatisfying(
+            ConnectorException.class,
+            e -> {
+              assertThat(e.getErrorCode()).isEqualTo("AD_HOC_SUBPROCESS_NOT_FOUND");
+              assertThat(e.getMessage())
+                  .isEqualTo(
+                      "Unable to resolve tools schema. Ad-hoc subprocess with ID 'DUMMY' was not found.");
+            });
+  }
+
+  @Test
+  void throwsExceptionWhenInputParamExtractionFails() {
+    when(camundaClient.newProcessDefinitionGetXmlRequest(PROCESS_DEFINITION_KEY).send().join())
+        .thenReturn(bpmnXml);
+
+    doThrow(new FeelInputParamExtractionException("I can't handle the fromAi function."))
+        .when(feelInputParamExtractor)
+        .extractInputParams("fromAi(toolCall.inputParameter, \"An input parameter\")");
+
+    assertThatThrownBy(() -> resolver.resolveSchema(PROCESS_DEFINITION_KEY, AD_HOC_SUBPROCESS_ID))
+        .isInstanceOfSatisfying(
+            ConnectorException.class,
+            e -> {
+              assertThat(e.getErrorCode()).isEqualTo("AD_HOC_TOOL_DEFINITION_INVALID");
+              assertThat(e.getMessage())
+                  .isEqualTo(
+                      "Invalid ad-hoc tool definition for element 'Tool_A' on input mapping 'inputParameter': I can't handle the fromAi function.");
+            });
+  }
+
+  @Test
+  void throwsExceptionWhenOutputParamExtractionFails() {
+    when(camundaClient.newProcessDefinitionGetXmlRequest(PROCESS_DEFINITION_KEY).send().join())
+        .thenReturn(bpmnXml);
+
+    when(feelInputParamExtractor.extractInputParams(any())).thenReturn(Collections.emptyList());
+    doThrow(new FeelInputParamExtractionException("I can't handle the fromAi function."))
+        .when(feelInputParamExtractor)
+        .extractInputParams("fromAi(toolCall.outputParameter, \"An output parameter\")");
+
+    assertThatThrownBy(() -> resolver.resolveSchema(PROCESS_DEFINITION_KEY, AD_HOC_SUBPROCESS_ID))
+        .isInstanceOfSatisfying(
+            ConnectorException.class,
+            e -> {
+              assertThat(e.getErrorCode()).isEqualTo("AD_HOC_TOOL_DEFINITION_INVALID");
+              assertThat(e.getMessage())
+                  .isEqualTo(
+                      "Invalid ad-hoc tool definition for element 'Tool_A' on output mapping 'outputParameter': I can't handle the fromAi function.");
+            });
+  }
+
+  @Test
+  void throwsExceptionWhenSchemaGenerationFails() {
+    when(camundaClient.newProcessDefinitionGetXmlRequest(PROCESS_DEFINITION_KEY).send().join())
+        .thenReturn(bpmnXml);
+    when(schemaGenerator.generateToolSchema(any()))
+        .thenThrow(new SchemaGenerationException("I can't generate this schema"));
+
+    assertThatThrownBy(() -> resolver.resolveSchema(PROCESS_DEFINITION_KEY, AD_HOC_SUBPROCESS_ID))
+        .isInstanceOfSatisfying(
+            ConnectorException.class,
+            e -> {
+              assertThat(e.getErrorCode()).isEqualTo("AD_HOC_TOOL_SCHEMA_INVALID");
+              assertThat(e.getMessage())
+                  .isEqualTo(
+                      "Failed to generate ad-hoc tool schema for element 'A_Complex_Tool': I can't generate this schema");
+            });
   }
 }

--- a/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/adhoctoolsschema/resolver/schema/DefaultAdHocToolSchemaGeneratorTest.java
+++ b/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/adhoctoolsschema/resolver/schema/DefaultAdHocToolSchemaGeneratorTest.java
@@ -155,7 +155,7 @@ class DefaultAdHocToolSchemaGeneratorTest {
     List<FeelInputParam> inputParams = List.of(new FeelInputParam("_meta", "string"));
 
     assertThatThrownBy(() -> generator.generateToolSchema(inputParams))
-        .isInstanceOf(IllegalArgumentException.class)
+        .isInstanceOf(SchemaGenerationException.class)
         .hasMessage("Input parameter name '_meta' is restricted and cannot be used.");
   }
 
@@ -165,8 +165,8 @@ class DefaultAdHocToolSchemaGeneratorTest {
         List.of(new FeelInputParam("param1", "string"), new FeelInputParam("param1", "string"));
 
     assertThatThrownBy(() -> generator.generateToolSchema(inputParams))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("Duplicate input parameter name: param1");
+        .isInstanceOf(SchemaGenerationException.class)
+        .hasMessage("Duplicate input parameter name 'param1'.");
   }
 
   private void assertJsonSchema(List<FeelInputParam> inputParams, String expectedJsonSchema)

--- a/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/model/AgentContextTest.java
+++ b/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/model/AgentContextTest.java
@@ -7,13 +7,21 @@
 package io.camunda.connector.agenticai.aiagent.model;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 class AgentContextTest {
-  private static final AgentContext EMPTY_CONTEXT = AgentContext.empty();
+  private static final AgentContext EMPTY_CONTEXT =
+      new AgentContext(AgentState.READY, AgentMetrics.empty(), List.of());
 
   @Test
   void emptyContext() {
@@ -67,5 +75,28 @@ class AgentContextTest {
         .isEqualTo(updatedMemory)
         .isNotEqualTo(initialContext.memory())
         .containsExactly(newMessage);
+  }
+
+  @ParameterizedTest
+  @MethodSource("invalidConstructorParameters")
+  void throwsExceptionOnInvalidConstructorParameters(
+      AgentState state,
+      AgentMetrics metrics,
+      List<Map<String, Object>> memory,
+      String exceptionMessage) {
+    assertThatThrownBy(() -> new AgentContext(state, metrics, memory))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage(exceptionMessage);
+  }
+
+  static Stream<Arguments> invalidConstructorParameters() {
+    final var state = AgentState.READY;
+    final var metrics = AgentMetrics.empty();
+    final var memory = Collections.emptyList();
+
+    return Stream.of(
+        arguments(null, metrics, memory, "Agent state must not be null"),
+        arguments(state, null, memory, "Agent metrics must not be null"),
+        arguments(state, metrics, null, "Agent memory must not be null"));
   }
 }

--- a/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/model/AgentMetricsTest.java
+++ b/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/model/AgentMetricsTest.java
@@ -7,6 +7,7 @@
 package io.camunda.connector.agenticai.aiagent.model;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
@@ -19,7 +20,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 class AgentMetricsTest {
-  private static final AgentMetrics EMPTY_METRICS = AgentMetrics.empty();
+  private static final AgentMetrics EMPTY_METRICS = new AgentMetrics(0, new TokenUsage(0, 0));
 
   @Test
   void emptyMetrics() {
@@ -108,5 +109,27 @@ class AgentMetricsTest {
           arguments(new dev.langchain4j.model.output.TokenUsage(10), new TokenUsage(10, 0)),
           arguments(new dev.langchain4j.model.output.TokenUsage(10, 20), new TokenUsage(10, 20)));
     }
+  }
+
+  @ParameterizedTest
+  @MethodSource("invalidConstructorParameters")
+  void throwsExceptionOnInvalidConstructorParameters(
+      int modelCalls,
+      TokenUsage tokenUsage,
+      Class<? extends Throwable> exceptionClass,
+      String exceptionMessage) {
+    assertThatThrownBy(() -> new AgentMetrics(modelCalls, tokenUsage))
+        .isInstanceOf(exceptionClass)
+        .hasMessage(exceptionMessage);
+  }
+
+  static Stream<Arguments> invalidConstructorParameters() {
+    return Stream.of(
+        arguments(
+            -10,
+            TokenUsage.empty(),
+            IllegalArgumentException.class,
+            "Model calls must be non-negative"),
+        arguments(10, null, NullPointerException.class, "Token usage must not be null"));
   }
 }

--- a/connectors/agentic-ai/src/test/resources/ad-hoc-tools.bpmn
+++ b/connectors/agentic-ai/src/test/resources/ad-hoc-tools.bpmn
@@ -1,0 +1,135 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1gx9y68" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.34.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.8.0">
+  <bpmn:process id="Agentic_AI_Connectors" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_0yrziwn</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:adHocSubProcess id="Agent_Tools" name="Agent Tools">
+      <bpmn:extensionElements>
+        <zeebe:adHoc />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_0yrziwn</bpmn:incoming>
+      <bpmn:outgoing>Flow_1e5yz0x</bpmn:outgoing>
+      <bpmn:manualTask id="Handle_Complex_Tool_Error" name="Handle complex tool error">
+        <bpmn:incoming>Flow_1p7oy92</bpmn:incoming>
+      </bpmn:manualTask>
+      <bpmn:scriptTask id="A_Complex_Tool" name="A complex tool">
+        <bpmn:documentation>A very complex tool</bpmn:documentation>
+        <bpmn:extensionElements>
+          <zeebe:script expression="=1 + 1" resultVariable="toolCallResult" />
+        </bpmn:extensionElements>
+      </bpmn:scriptTask>
+      <bpmn:boundaryEvent id="Complex_Tool_Error" attachedToRef="A_Complex_Tool">
+        <bpmn:documentation>Handles errors from complex tool</bpmn:documentation>
+        <bpmn:outgoing>Flow_1p7oy92</bpmn:outgoing>
+        <bpmn:errorEventDefinition id="ErrorEventDefinition_1c6dxc2" />
+      </bpmn:boundaryEvent>
+      <bpmn:sequenceFlow id="Flow_1p7oy92" sourceRef="Complex_Tool_Error" targetRef="Handle_Complex_Tool_Error" />
+      <bpmn:scriptTask id="Tool_A" name="Tool A">
+        <bpmn:documentation>The A tool</bpmn:documentation>
+        <bpmn:extensionElements>
+          <zeebe:script expression="=now()" resultVariable="toolCallResult" />
+          <zeebe:ioMapping>
+            <zeebe:input source="=fromAi(toolCall.inputParameter, &#34;An input parameter&#34;)" target="inputParameter" />
+            <zeebe:output source="=fromAi(toolCall.outputParameter, &#34;An output parameter&#34;)" target="outputParameter" />
+          </zeebe:ioMapping>
+        </bpmn:extensionElements>
+        <bpmn:outgoing>Flow_095717l</bpmn:outgoing>
+      </bpmn:scriptTask>
+      <bpmn:scriptTask id="Tool_B" name="Tool B">
+        <bpmn:documentation>The B tool</bpmn:documentation>
+        <bpmn:extensionElements>
+          <zeebe:script expression="=1 * 1" resultVariable="someThingElse" />
+        </bpmn:extensionElements>
+        <bpmn:incoming>Flow_095717l</bpmn:incoming>
+      </bpmn:scriptTask>
+      <bpmn:sequenceFlow id="Flow_095717l" sourceRef="Tool_A" targetRef="Tool_B" />
+      <bpmn:scriptTask id="Simple_Tool" name="Simple Tool">
+        <bpmn:documentation>A simple tool</bpmn:documentation>
+        <bpmn:extensionElements>
+          <zeebe:script expression="=now()" resultVariable="toolCallResult" />
+        </bpmn:extensionElements>
+      </bpmn:scriptTask>
+      <bpmn:task id="Event_Follow_Up_Task" name="Event follow-up task">
+        <bpmn:incoming>Flow_0v33lmt</bpmn:incoming>
+      </bpmn:task>
+      <bpmn:intermediateThrowEvent id="An_Event" name="An event!">
+        <bpmn:extensionElements />
+        <bpmn:outgoing>Flow_0v33lmt</bpmn:outgoing>
+      </bpmn:intermediateThrowEvent>
+      <bpmn:sequenceFlow id="Flow_0v33lmt" sourceRef="An_Event" targetRef="Event_Follow_Up_Task" />
+    </bpmn:adHocSubProcess>
+    <bpmn:sequenceFlow id="Flow_0yrziwn" sourceRef="StartEvent_1" targetRef="Agent_Tools" />
+    <bpmn:endEvent id="Event_0w61ti7">
+      <bpmn:incoming>Flow_1e5yz0x</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1e5yz0x" sourceRef="Agent_Tools" targetRef="Event_0w61ti7" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Agentic_AI_Connectors">
+      <bpmndi:BPMNShape id="StartEvent_1_di" bpmnElement="StartEvent_1">
+        <dc:Bounds x="152" y="172" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_005wn4n_di" bpmnElement="Agent_Tools" isExpanded="true">
+        <dc:Bounds x="290" y="80" width="350" height="580" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1xv565y_di" bpmnElement="Handle_Complex_Tool_Error">
+        <dc:Bounds x="470" y="530" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0wd2ku5_di" bpmnElement="A_Complex_Tool">
+        <dc:Bounds x="340" y="450" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1kglsdx_di" bpmnElement="Tool_A">
+        <dc:Bounds x="340" y="230" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_02cecmv_di" bpmnElement="Tool_B">
+        <dc:Bounds x="480" y="230" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1sbkoqq_di" bpmnElement="Simple_Tool">
+        <dc:Bounds x="340" y="130" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_17rjl26_di" bpmnElement="Event_Follow_Up_Task">
+        <dc:Bounds x="480" y="330" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_02hr6cv_di" bpmnElement="An_Event">
+        <dc:Bounds x="372" y="352" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="368" y="395" width="47" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1p1n58n_di" bpmnElement="Complex_Tool_Error">
+        <dc:Bounds x="392" y="512" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1p7oy92_di" bpmnElement="Flow_1p7oy92">
+        <di:waypoint x="410" y="548" />
+        <di:waypoint x="410" y="570" />
+        <di:waypoint x="470" y="570" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_095717l_di" bpmnElement="Flow_095717l">
+        <di:waypoint x="440" y="270" />
+        <di:waypoint x="480" y="270" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0v33lmt_di" bpmnElement="Flow_0v33lmt">
+        <di:waypoint x="408" y="370" />
+        <di:waypoint x="480" y="370" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Event_0w61ti7_di" bpmnElement="Event_0w61ti7">
+        <dc:Bounds x="722" y="172" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0yrziwn_di" bpmnElement="Flow_0yrziwn">
+        <di:waypoint x="188" y="190" />
+        <di:waypoint x="290" y="190" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1e5yz0x_di" bpmnElement="Flow_1e5yz0x">
+        <di:waypoint x="640" y="190" />
+        <di:waypoint x="722" y="190" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>


### PR DESCRIPTION
General improvements on error handling and on UX of the properties panel (property order, descriptions/labels, ...).

Note: while this is a mix of different improvements, I opted to put them all on the same PR. The individual commits should be mostly self-contained.

## Description

- Updated properties panel labels/descriptions/tooltips, not empty constraints
- Improves error handling and exception messages when the tools schema configuration is wrong or `fromAi` is used in a wrong way
- Better error handling when the agent context is not set up properly (e.g. an agent receives tool results, but according to its context never requested tool calls)
- Bugfix for #4713 (detecting boundary events as tools)
- Added missing tests for the changed parts
- Updated examples in `examples` to include document support 

### Breaking Changes

- Renamed `guardrails` to `limits` as this better describes this block. Guardrails can be something more advanced in the future.

## Related issues

#4683 
fixes #4713

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.

