### PR TITLE
fix(rest-connector): Fix url encoding to handle edge cases correctly

### DIFF
--- a/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/client/apache/builder/parts/UrlEncoder.java
+++ b/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/client/apache/builder/parts/UrlEncoder.java
@@ -16,90 +16,25 @@
  */
 package io.camunda.connector.http.base.client.apache.builder.parts;
 
-import io.camunda.connector.api.error.ConnectorInputException;
+import com.google.api.client.http.GenericUrl;
 import java.net.MalformedURLException;
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.net.URL;
-import java.util.Objects;
-import java.util.function.BiFunction;
-import java.util.function.Function;
-import org.apache.hc.core5.net.URIBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class UrlEncoder {
-
   private static final Logger LOG = LoggerFactory.getLogger(ApacheRequestUriBuilder.class);
-
-  private static String chooseEncoded(
-      String input,
-      Function<URL, String> getUrlPart,
-      Function<URI, String> get,
-      Function<URI, String> getRaw,
-      BiFunction<URIBuilder, String, URIBuilder> setPart)
-      throws MalformedURLException {
-    URL url = new URL(input);
-    try {
-      URI uri = url.toURI();
-      String rawPart = getRaw.apply(uri);
-      String part = get.apply(uri);
-
-      String fromDecoded = getRaw.apply(setPart.apply(new URIBuilder(), part).build());
-      String fromRaw = get.apply(setPart.apply(new URIBuilder(), rawPart).build());
-
-      return Objects.equals(fromDecoded, fromRaw) ? part : rawPart;
-    } catch (URISyntaxException e) { // if it is not a valid URI, we need to encode it
-      return getUrlPart.apply(url);
-    }
-  }
 
   public static URI toEncodedUri(String requestUrl, Boolean skipEncoding) {
     try {
-      // We try to decode the URL first, because it might be encoded already
-      // which would lead to double encoding. Decoding is safe here, because it does nothing if
-      // the URL is not encoded.
       if (skipEncoding) {
-        try {
-          return URI.create(requestUrl);
-        } catch (IllegalArgumentException e) {
-          throw new ConnectorInputException(
-              "Provided URL must be valid, when setting skipEncoding to true", e);
-        }
+        return URI.create(requestUrl);
       }
-
       URL url = new URL(requestUrl);
-      return new URIBuilder()
-          .setScheme(url.getProtocol())
-          .setUserInfo(
-              chooseEncoded(
-                  requestUrl,
-                  URL::getUserInfo,
-                  URI::getUserInfo,
-                  URI::getRawUserInfo,
-                  URIBuilder::setUserInfo))
-          .setHost(url.getHost())
-          .setPort(url.getPort())
-          .setPath(
-              chooseEncoded(
-                  requestUrl, URL::getPath, URI::getPath, URI::getRawPath, URIBuilder::setPath))
-          .setCustomQuery(
-              chooseEncoded(
-                  requestUrl,
-                  URL::getQuery,
-                  URI::getQuery,
-                  URI::getRawQuery,
-                  URIBuilder::setCustomQuery))
-          .setFragment(
-              chooseEncoded(
-                  requestUrl,
-                  URL::getRef,
-                  URI::getFragment,
-                  URI::getRawFragment,
-                  URIBuilder::setFragment))
-          .build();
-    } catch (MalformedURLException | URISyntaxException e) {
-      LOG.error("Failed to parse URL, defaulting to requested rul ", e);
+      return new GenericUrl(url).toURI();
+    } catch (MalformedURLException e) {
+      LOG.error("Failed to parse URL {}, defaulting to requestUrl", requestUrl, e);
       return URI.create(requestUrl);
     }
   }

--- a/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/client/apache/builder/parts/UrlEncoder.java
+++ b/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/client/apache/builder/parts/UrlEncoder.java
@@ -99,8 +99,8 @@ public class UrlEncoder {
                   URIBuilder::setFragment))
           .build();
     } catch (MalformedURLException | URISyntaxException e) {
-      LOG.error("Failed to parse URL, ", e);
-      throw new ConnectorInputException("Invalid URL", e);
+      LOG.error("Failed to parse URL, defaulting to requested rul ", e);
+      return URI.create(requestUrl);
     }
   }
 }

--- a/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/client/apache/builder/parts/UrlEncoder.java
+++ b/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/client/apache/builder/parts/UrlEncoder.java
@@ -99,8 +99,8 @@ public class UrlEncoder {
                   URIBuilder::setFragment))
           .build();
     } catch (MalformedURLException | URISyntaxException e) {
-      LOG.error("Failed to parse URL {}, ", requestUrl, e);
-      throw new ConnectorInputException("Invalid URL: " + requestUrl, e);
+      LOG.error("Failed to parse URL, ", e);
+      throw new ConnectorInputException("Invalid URL", e);
     }
   }
 }

--- a/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/client/apache/builder/parts/UrlEncoder.java
+++ b/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/client/apache/builder/parts/UrlEncoder.java
@@ -16,17 +16,43 @@
  */
 package io.camunda.connector.http.base.client.apache.builder.parts;
 
+import io.camunda.connector.api.error.ConnectorInputException;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
-import java.net.URLDecoder;
-import java.nio.charset.StandardCharsets;
+import java.util.Objects;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import org.apache.hc.core5.net.URIBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class UrlEncoder {
+
   private static final Logger LOG = LoggerFactory.getLogger(ApacheRequestUriBuilder.class);
+
+  private static String chooseEncoded(
+      String input,
+      Function<URL, String> getUrlPart,
+      Function<URI, String> get,
+      Function<URI, String> getRaw,
+      BiFunction<URIBuilder, String, URIBuilder> setPart)
+      throws MalformedURLException {
+    URL url = new URL(input);
+    try {
+      URI uri = url.toURI();
+      String rawPart = getRaw.apply(uri);
+      String part = get.apply(uri);
+
+      String fromDecoded = getRaw.apply(setPart.apply(new URIBuilder(), part).build());
+      String fromRaw = get.apply(setPart.apply(new URIBuilder(), rawPart).build());
+
+      return Objects.equals(fromDecoded, fromRaw) ? part : rawPart;
+    } catch (URISyntaxException e) { // if it is not a valid URI, we need to encode it
+      return getUrlPart.apply(url);
+    }
+  }
 
   public static URI toEncodedUri(String requestUrl, Boolean skipEncoding) {
     try {
@@ -34,22 +60,47 @@ public class UrlEncoder {
       // which would lead to double encoding. Decoding is safe here, because it does nothing if
       // the URL is not encoded.
       if (skipEncoding) {
-        return URI.create(requestUrl);
+        try {
+          return URI.create(requestUrl);
+        } catch (IllegalArgumentException e) {
+          throw new ConnectorInputException(
+              "Provided URL must be valid, when setting skipEncoding to true", e);
+        }
       }
-      var decodedUrl = URLDecoder.decode(requestUrl, StandardCharsets.UTF_8);
-      var url = new URL(decodedUrl);
-      // Only this URI constructor escapes the URL properly
-      return new URI(
-          url.getProtocol(),
-          url.getUserInfo(),
-          url.getHost(),
-          url.getPort(),
-          url.getPath(),
-          url.getQuery(),
-          null);
+
+      URL url = new URL(requestUrl);
+      return new URIBuilder()
+          .setScheme(url.getProtocol())
+          .setUserInfo(
+              chooseEncoded(
+                  requestUrl,
+                  URL::getUserInfo,
+                  URI::getUserInfo,
+                  URI::getRawUserInfo,
+                  URIBuilder::setUserInfo))
+          .setHost(url.getHost())
+          .setPort(url.getPort())
+          .setPath(
+              chooseEncoded(
+                  requestUrl, URL::getPath, URI::getPath, URI::getRawPath, URIBuilder::setPath))
+          .setCustomQuery(
+              chooseEncoded(
+                  requestUrl,
+                  URL::getQuery,
+                  URI::getQuery,
+                  URI::getRawQuery,
+                  URIBuilder::setCustomQuery))
+          .setFragment(
+              chooseEncoded(
+                  requestUrl,
+                  URL::getRef,
+                  URI::getFragment,
+                  URI::getRawFragment,
+                  URIBuilder::setFragment))
+          .build();
     } catch (MalformedURLException | URISyntaxException e) {
-      LOG.error("Failed to parse URL {}, defaulting to requestUrl", requestUrl, e);
-      return URI.create(requestUrl);
+      LOG.error("Failed to parse URL {}, ", requestUrl, e);
+      throw new ConnectorInputException("Invalid URL: " + requestUrl, e);
     }
   }
 }

--- a/connectors/http/http-base/src/test/java/io/camunda/connector/http/base/client/apache/builder/parts/UrlEncoderTest.java
+++ b/connectors/http/http-base/src/test/java/io/camunda/connector/http/base/client/apache/builder/parts/UrlEncoderTest.java
@@ -19,7 +19,6 @@ package io.camunda.connector.http.base.client.apache.builder.parts;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import io.camunda.connector.api.error.ConnectorInputException;
 import java.util.stream.Stream;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -34,23 +33,23 @@ public class UrlEncoderTest {
         // Path
         Arguments.of(
             "http://localhost:8080/hello, world!",
-            "http://localhost:8080/hello%2C%20world%21"), // not-encoded url with invalid char
+            "http://localhost:8080/hello,%20world!"), // not-encoded url with invalid char
         Arguments.of(
-            "http://localhost:8080/hello, %20world!",
-            "http://localhost:8080/hello%2C%20%2520world%21"), // partially-encoded url with invalid
+            "http://localhost:8080/hello, %2Cworld!",
+            "http://localhost:8080/hello,%20,world!"), // partially-encoded url with invalid
         // char
         Arguments.of(
             "http://localhost:8080/hello%2C%20world%21",
-            "http://localhost:8080/hello%2C%20world%21"), // fully-encoded url with invalid char
+            "http://localhost:8080/hello,%20world!"), // fully-encoded url with invalid char
         Arguments.of(
             "http://localhost:8080/hello,world!",
-            "http://localhost:8080/hello%2Cworld%21"), // not-encoded url with valid chars
+            "http://localhost:8080/hello,world!"), // not-encoded url with valid chars
         Arguments.of(
             "http://localhost:8080/hello%2Cworld!",
-            "http://localhost:8080/hello%252Cworld%21"), // partially-encoded url with valid chars
+            "http://localhost:8080/hello,world!"), // partially-encoded url with valid chars
         Arguments.of(
             "http://localhost:8080/hello%2Cworld%21",
-            "http://localhost:8080/hello%2Cworld%21"), // fully-encoded url with invalid char
+            "http://localhost:8080/hello,world!"), // fully-encoded url with invalid char
         Arguments.of(
             "http://localhost:8080/über uns",
             "http://localhost:8080/%C3%BCber%20uns"), // not-encoded with UTF-8
@@ -59,31 +58,31 @@ public class UrlEncoderTest {
             "http://localhost:8080/%C3%BCberuns"), // not-encoded with UTF-8
         Arguments.of(
             "http://localhost:8080/hello,&world!",
-            "http://localhost:8080/hello%2C%26world%21"), // not-encoded url with reserved char
+            "http://localhost:8080/hello,&world!"), // not-encoded url with reserved char
         Arguments.of(
             "http://localhost:8080/hello,%26world!",
-            "http://localhost:8080/hello%2C%2526world%21"), // partially-encoded url with reserved
+            "http://localhost:8080/hello,&world!"), // partially-encoded url with reserved
         // char
         Arguments.of(
             "http://localhost:8080/hello%2C%26world%21",
-            "http://localhost:8080/hello%2C%26world%21"), // fully-encoded url with reserved char
+            "http://localhost:8080/hello,&world!"), // fully-encoded url with reserved char
 
         // Query = *( pchar / "/" / "?" )
         Arguments.of(
             "http://localhost:8080/test?query=hello:world?",
-            "http://localhost:8080/test?query=hello%3Aworld%3F"), // not-encoded url with invalid
+            "http://localhost:8080/test?query=hello:world?"), // not-encoded url with invalid
         // char
         Arguments.of(
             "http://localhost:8080/test?query=hello%3Fworld?",
-            "http://localhost:8080/test?query=hello%253Fworld%3F"), // partially-encoded url with
+            "http://localhost:8080/test?query=hello?world?"), // partially-encoded url with
         // invalid char
         Arguments.of(
             "http://localhost:8080/test?query=hello%3Aworld%3F",
-            "http://localhost:8080/test?query=hello%3Aworld%3F"), // fully-encoded url with invalid
+            "http://localhost:8080/test?query=hello:world?"), // fully-encoded url with invalid
         // char
         Arguments.of(
             "http://localhost:8080/test?query=hello world?",
-            "http://localhost:8080/test?query=hello%20world%3F"), // not-encoded url with invalid
+            "http://localhost:8080/test?query=hello%20world?"), // not-encoded url with invalid
         // char
         Arguments.of(
             "http://localhost:8080/test?param1=value1&param2=value 2",
@@ -91,15 +90,15 @@ public class UrlEncoderTest {
         // invalid char
         Arguments.of(
             "http://localhost:8080/test?query=hello world%3F",
-            "http://localhost:8080/test?query=hello%20world%253F"), // partially-encoded url with
+            "http://localhost:8080/test?query=hello%20world?"), // partially-encoded url with
         // invalid char
         Arguments.of(
             "http://localhost:8080/test?mark?value%3F",
-            "http://localhost:8080/test?mark%3Fvalue%253F"), // partially-encoded url with invalid
+            "http://localhost:8080/test?mark?value?"), // partially-encoded url with invalid
         // char
         Arguments.of(
             "http://localhost:8080/test?query=hello%20world%3F",
-            "http://localhost:8080/test?query=hello%20world%3F"), // fully-encoded url with invalid
+            "http://localhost:8080/test?query=hello%20world?"), // fully-encoded url with invalid
         // char
         Arguments.of(
             "http://localhost:8080/test?query=hello,world!",
@@ -111,19 +110,18 @@ public class UrlEncoderTest {
         // chars
 
         // Plus sign (in path must be encoded, in query is valid)
+        Arguments.of("http://localhost:8080/hello+world", "http://localhost:8080/hello+world"),
         Arguments.of(
-            "http://localhost:8080/hello + world", "http://localhost:8080/hello%20%2B%20world"),
-        Arguments.of(
-            "http://localhost:8080/test?hello+world", "http://localhost:8080/test?hello+world"),
+            "http://localhost:8080/test?hello+world", "http://localhost:8080/test?hello%20world"),
 
         // Fragment
         Arguments.of(
             "http://localhost:8080/foo/bar#section 2", "http://localhost:8080/foo/bar#section%202"),
         Arguments.of(
-            "http://localhost:8080/foo/bar#section:2", "http://localhost:8080/foo/bar#section%3A2"),
+            "http://localhost:8080/foo/bar#section:2", "http://localhost:8080/foo/bar#section:2"),
         Arguments.of(
             "http://localhost:8080/foo/bar#section:%202",
-            "http://localhost:8080/foo/bar#section%3A%25202"),
+            "http://localhost:8080/foo/bar#section:%202"),
         Arguments.of(
             "http://localhost:8080/foo/bar#section%202",
             "http://localhost:8080/foo/bar#section%202"),
@@ -137,7 +135,16 @@ public class UrlEncoderTest {
         // path is encoded, query is not encoded
         Arguments.of(
             "http://localhost:8080/test%2C?query=helloWorld?",
-            "http://localhost:8080/test%2C?query=helloWorld%3F"));
+            "http://localhost:8080/test,?query=helloWorld?"),
+        Arguments.of(
+            "http://localhost:8080/path%20with%20spaces?andQuery=Param with space",
+            "http://localhost:8080/path%20with%20spaces?andQuery=Param%20with%20space"),
+
+        // no protocol
+        Arguments.of("localhost:8080/test", "localhost:8080/test"),
+
+        // invalid port
+        Arguments.of("http://localhost:abc/test", "http://localhost:abc/test"));
   }
 
   @ParameterizedTest
@@ -146,19 +153,6 @@ public class UrlEncoderTest {
     Boolean skipEncoding = false;
     var result = UrlEncoder.toEncodedUri(requestUrl, skipEncoding);
     assertThat(result.toString()).isEqualTo(expectedEncodedUrl);
-  }
-
-  private static Stream<Arguments> urlEncodingInvalidTestCases() {
-    return Stream.of(
-        Arguments.of("localhost:8080/test"), Arguments.of("http://localhost:abc/test"));
-  }
-
-  @ParameterizedTest
-  @MethodSource("urlEncodingInvalidTestCases")
-  public void shouldThrowException(String requestUrl) {
-    Boolean skipEncoding = false;
-    assertThrows(
-        ConnectorInputException.class, () -> UrlEncoder.toEncodedUri(requestUrl, skipEncoding));
   }
 
   private static Stream<Arguments> urlEncodingValidTestCasesWithSkipEncoding() {
@@ -189,6 +183,6 @@ public class UrlEncoderTest {
   public void shouldThrowException_whenSkipEncodingWithInvalidURL(String requestUrl) {
     Boolean skipEncoding = true;
     assertThrows(
-        ConnectorInputException.class, () -> UrlEncoder.toEncodedUri(requestUrl, skipEncoding));
+        IllegalArgumentException.class, () -> UrlEncoder.toEncodedUri(requestUrl, skipEncoding));
   }
 }

--- a/connectors/http/http-base/src/test/java/io/camunda/connector/http/base/client/apache/builder/parts/UrlEncoderTest.java
+++ b/connectors/http/http-base/src/test/java/io/camunda/connector/http/base/client/apache/builder/parts/UrlEncoderTest.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.http.base.client.apache.builder.parts;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import io.camunda.connector.api.error.ConnectorInputException;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public class UrlEncoderTest {
+  private static Stream<Arguments> urlEncodingTestCases() {
+    return Stream.of(
+        // RFC3986: https://datatracker.ietf.org/doc/html/rfc3986
+        // pchar  = unreserved / pct-encoded / sub-delims (e.g. , and !) / ":" / "@"
+
+        // Path
+        Arguments.of(
+            "http://localhost:8080/hello, world!",
+            "http://localhost:8080/hello%2C%20world%21"), // not-encoded url with invalid char
+        Arguments.of(
+            "http://localhost:8080/hello, %20world!",
+            "http://localhost:8080/hello%2C%20%2520world%21"), // partially-encoded url with invalid
+        // char
+        Arguments.of(
+            "http://localhost:8080/hello%2C%20world%21",
+            "http://localhost:8080/hello%2C%20world%21"), // fully-encoded url with invalid char
+        Arguments.of(
+            "http://localhost:8080/hello,world!",
+            "http://localhost:8080/hello%2Cworld%21"), // not-encoded url with valid chars
+        Arguments.of(
+            "http://localhost:8080/hello%2Cworld!",
+            "http://localhost:8080/hello%252Cworld%21"), // partially-encoded url with valid chars
+        Arguments.of(
+            "http://localhost:8080/hello%2Cworld%21",
+            "http://localhost:8080/hello%2Cworld%21"), // fully-encoded url with invalid char
+        Arguments.of(
+            "http://localhost:8080/über uns",
+            "http://localhost:8080/%C3%BCber%20uns"), // not-encoded with UTF-8
+        Arguments.of(
+            "http://localhost:8080/überuns",
+            "http://localhost:8080/%C3%BCberuns"), // not-encoded with UTF-8
+        Arguments.of(
+            "http://localhost:8080/hello,&world!",
+            "http://localhost:8080/hello%2C%26world%21"), // not-encoded url with reserved char
+        Arguments.of(
+            "http://localhost:8080/hello,%26world!",
+            "http://localhost:8080/hello%2C%2526world%21"), // partially-encoded url with reserved
+        // char
+        Arguments.of(
+            "http://localhost:8080/hello%2C%26world%21",
+            "http://localhost:8080/hello%2C%26world%21"), // fully-encoded url with reserved char
+
+        // Query = *( pchar / "/" / "?" )
+        Arguments.of(
+            "http://localhost:8080/test?query=hello:world?",
+            "http://localhost:8080/test?query=hello%3Aworld%3F"), // not-encoded url with invalid
+        // char
+        Arguments.of(
+            "http://localhost:8080/test?query=hello%3Fworld?",
+            "http://localhost:8080/test?query=hello%253Fworld%3F"), // partially-encoded url with
+        // invalid char
+        Arguments.of(
+            "http://localhost:8080/test?query=hello%3Aworld%3F",
+            "http://localhost:8080/test?query=hello%3Aworld%3F"), // fully-encoded url with invalid
+        // char
+        Arguments.of(
+            "http://localhost:8080/test?query=hello world?",
+            "http://localhost:8080/test?query=hello%20world%3F"), // not-encoded url with invalid
+        // char
+        Arguments.of(
+            "http://localhost:8080/test?param1=value1&param2=value 2",
+            "http://localhost:8080/test?param1=value1&param2=value%202"), // not-encoded url with
+        // invalid char
+        Arguments.of(
+            "http://localhost:8080/test?query=hello world%3F",
+            "http://localhost:8080/test?query=hello%20world%253F"), // partially-encoded url with
+        // invalid char
+        Arguments.of(
+            "http://localhost:8080/test?mark?value%3F",
+            "http://localhost:8080/test?mark%3Fvalue%253F"), // partially-encoded url with invalid
+        // char
+        Arguments.of(
+            "http://localhost:8080/test?query=hello%20world%3F",
+            "http://localhost:8080/test?query=hello%20world%3F"), // fully-encoded url with invalid
+        // char
+        Arguments.of(
+            "http://localhost:8080/test?query=hello,world!",
+            "http://localhost:8080/test?query=hello,world!"), // not-encoded/fully-encoded url with
+        // valid chars
+        Arguments.of(
+            "http://localhost:8080/test?query=hello%20world!",
+            "http://localhost:8080/test?query=hello%20world!"), // partially-encoded url with valid
+        // chars
+
+        // Plus sign (in path must be encoded, in query is valid)
+        Arguments.of(
+            "http://localhost:8080/hello + world", "http://localhost:8080/hello%20%2B%20world"),
+        Arguments.of(
+            "http://localhost:8080/test?hello+world", "http://localhost:8080/test?hello+world"),
+
+        // Fragment
+        Arguments.of(
+            "http://localhost:8080/foo/bar#section 2", "http://localhost:8080/foo/bar#section%202"),
+        Arguments.of(
+            "http://localhost:8080/foo/bar#section:2", "http://localhost:8080/foo/bar#section%3A2"),
+        Arguments.of(
+            "http://localhost:8080/foo/bar#section:%202",
+            "http://localhost:8080/foo/bar#section%3A%25202"),
+        Arguments.of(
+            "http://localhost:8080/foo/bar#section%202",
+            "http://localhost:8080/foo/bar#section%202"),
+
+        // user info, port, empty path
+        Arguments.of(
+            "http://user:pass@localhost:8080/secret", "http://user:pass@localhost:8080/secret"),
+        Arguments.of("http://localhost:1234/port/test", "http://localhost:1234/port/test"),
+        Arguments.of("http://localhost:8080", "http://localhost:8080"));
+  }
+
+  @ParameterizedTest
+  @MethodSource("urlEncodingTestCases")
+  public void shouldHandleEncoding(String requestUrl, String expectedEncodedUrl) {
+    Boolean skipEncoding = false;
+    var result = UrlEncoder.toEncodedUri(requestUrl, skipEncoding);
+    assertThat(result.toString()).isEqualTo(expectedEncodedUrl);
+  }
+
+  private static Stream<Arguments> urlEncodingInvalidTestCases() {
+    return Stream.of(
+        Arguments.of("localhost:8080/test"), Arguments.of("http://localhost:abc/test"));
+  }
+
+  @ParameterizedTest
+  @MethodSource("urlEncodingInvalidTestCases")
+  public void shouldThrowException(String requestUrl) {
+    Boolean skipEncoding = false;
+    assertThrows(
+        ConnectorInputException.class, () -> UrlEncoder.toEncodedUri(requestUrl, skipEncoding));
+  }
+
+  private static Stream<Arguments> urlEncodingValidTestCasesWithSkipEncoding() {
+    return Stream.of(
+        Arguments.of("http://localhost:8080/hello,world!"),
+        Arguments.of("http://localhost:8080/hello%2Cworld%21"),
+        Arguments.of("http://localhost:8080/hello,%20world!"),
+        Arguments.of("http://localhost:8080/test?hello+world"));
+  }
+
+  @ParameterizedTest
+  @MethodSource("urlEncodingValidTestCasesWithSkipEncoding")
+  public void shouldHandleSkipEncoding(String requestUrl) {
+    Boolean skipEncoding = true;
+    var result = UrlEncoder.toEncodedUri(requestUrl, skipEncoding);
+    assertThat(result.toString()).isEqualTo(requestUrl);
+  }
+
+  private static Stream<Arguments> urlEncodingInvalidTestCasesWithSkipEncoding() {
+    return Stream.of(
+        Arguments.of("http://localhost:8080/hello world"),
+        Arguments.of("http://localhost:8080/hello%20world?invalid query"),
+        Arguments.of("http://localhost:8080/hello%20world#invalid fragment"));
+  }
+
+  @ParameterizedTest
+  @MethodSource("urlEncodingInvalidTestCasesWithSkipEncoding")
+  public void shouldThrowException_whenSkipEncodingWithInvalidURL(String requestUrl) {
+    Boolean skipEncoding = true;
+    assertThrows(
+        ConnectorInputException.class, () -> UrlEncoder.toEncodedUri(requestUrl, skipEncoding));
+  }
+}

--- a/connectors/http/http-base/src/test/java/io/camunda/connector/http/base/client/apache/builder/parts/UrlEncoderTest.java
+++ b/connectors/http/http-base/src/test/java/io/camunda/connector/http/base/client/apache/builder/parts/UrlEncoderTest.java
@@ -132,7 +132,12 @@ public class UrlEncoderTest {
         Arguments.of(
             "http://user:pass@localhost:8080/secret", "http://user:pass@localhost:8080/secret"),
         Arguments.of("http://localhost:1234/port/test", "http://localhost:1234/port/test"),
-        Arguments.of("http://localhost:8080", "http://localhost:8080"));
+        Arguments.of("http://localhost:8080", "http://localhost:8080"),
+
+        // path is encoded, query is not encoded
+        Arguments.of(
+            "http://localhost:8080/test%2C?query=helloWorld?",
+            "http://localhost:8080/test%2C?query=helloWorld%3F"));
   }
 
   @ParameterizedTest


### PR DESCRIPTION
## Description
Use the correct functions for en- and decoding.

See from [Java docs](https://docs.oracle.com/javase/8/docs/api/java/net/URL.html): 

> Note, the URI class does perform escaping of its component fields in certain circumstances. The recommended way to manage the encoding and decoding of URLs is to use URI, and to convert between these two classes using toURI() and URI.toURL().
> 
>   The URLEncoder and URLDecoder classes can also be used, but only for HTML form encoding, which is not the same as the encoding scheme defined in RFC2396.

And the [URL Encoder docs:](https://docs.oracle.com/javase/8/docs/api/java/net/URLDecoder.html)

> The plus sign "+" is converted into a space character "   " .

Fr Refernce also see: [RFC 3986](https://datatracker.ietf.org/doc/html/rfc3986)


## Related issues
closes #4676

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.




https://stackoverflow.com/questions/43375916/urldecoder-is-converting-into-space
https://bugs.openjdk.org/browse/JDK-8179507





