### PR TITLE
fix(agentic-ai): do not resolve boundary events in ad-hoc subprocess as tools

### DIFF
--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/resources/agentic-ai-connectors.bpmn
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/resources/agentic-ai-connectors.bpmn
@@ -92,6 +92,15 @@
           </zeebe:taskHeaders>
         </bpmn:extensionElements>
       </bpmn:serviceTask>
+      <bpmn:boundaryEvent id="Complex_Tool_Error" attachedToRef="A_Complex_Tool">
+        <bpmn:documentation>Handles errors from complex tool</bpmn:documentation>
+        <bpmn:outgoing>Flow_1p7oy92</bpmn:outgoing>
+        <bpmn:errorEventDefinition id="ErrorEventDefinition_1c6dxc2" />
+      </bpmn:boundaryEvent>
+      <bpmn:sequenceFlow id="Flow_1p7oy92" sourceRef="Complex_Tool_Error" targetRef="Activity_12hs7ng" />
+      <bpmn:manualTask id="Activity_12hs7ng" name="Handle complex tool error">
+        <bpmn:incoming>Flow_1p7oy92</bpmn:incoming>
+      </bpmn:manualTask>
     </bpmn:adHocSubProcess>
     <bpmn:exclusiveGateway id="Gateway_0d7bxjf" name="What to do?">
       <bpmn:incoming>Flow_1lbh2cw</bpmn:incoming>
@@ -252,7 +261,7 @@
         <dc:Bounds x="162" y="262" width="36" height="36" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_005wn4n_di" bpmnElement="Agent_Tools" isExpanded="true">
-        <dc:Bounds x="870" y="570" width="350" height="470" />
+        <dc:Bounds x="870" y="570" width="350" height="670" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_02hr6cv_di" bpmnElement="An_Event">
@@ -279,11 +288,18 @@
       <bpmndi:BPMNShape id="Activity_1kglsdx_di" bpmnElement="Search_The_Web">
         <dc:Bounds x="920" y="720" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_0wd2ku5_di" bpmnElement="A_Complex_Tool">
-        <dc:Bounds x="920" y="920" width="100" height="80" />
-      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_0zm24e8_di" bpmnElement="Download_A_File">
         <dc:Bounds x="1060" y="920" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0wd2ku5_di" bpmnElement="A_Complex_Tool">
+        <dc:Bounds x="920" y="1030" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1xv565y_di" bpmnElement="Activity_12hs7ng">
+        <dc:Bounds x="1050" y="1110" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1p1n58n_di" bpmnElement="Complex_Tool_Error">
+        <dc:Bounds x="972" y="1092" width="36" height="36" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNEdge id="Flow_095717l_di" bpmnElement="Flow_095717l">
         <di:waypoint x="1020" y="760" />
@@ -292,6 +308,11 @@
       <bpmndi:BPMNEdge id="Flow_0v33lmt_di" bpmnElement="Flow_0v33lmt">
         <di:waypoint x="988" y="860" />
         <di:waypoint x="1060" y="860" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1p7oy92_di" bpmnElement="Flow_1p7oy92">
+        <di:waypoint x="990" y="1128" />
+        <di:waypoint x="990" y="1150" />
+        <di:waypoint x="1050" y="1150" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="Gateway_0d7bxjf_di" bpmnElement="Gateway_0d7bxjf" isMarkerVisible="true">
         <dc:Bounds x="265" y="255" width="50" height="50" />

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/adhoctoolsschema/resolver/CamundaClientAdHocToolsSchemaResolver.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/adhoctoolsschema/resolver/CamundaClientAdHocToolsSchemaResolver.java
@@ -18,6 +18,7 @@ import io.camunda.connector.api.error.ConnectorException;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.model.bpmn.instance.AdHocSubProcess;
+import io.camunda.zeebe.model.bpmn.instance.BoundaryEvent;
 import io.camunda.zeebe.model.bpmn.instance.FlowNode;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeInput;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeIoMapping;
@@ -93,11 +94,15 @@ public class CamundaClientAdHocToolsSchemaResolver implements AdHocToolsSchemaRe
 
     final var toolDefinitions =
         adHocSubProcess.getChildElementsByType(FlowNode.class).stream()
-            .filter(element -> element.getIncoming().isEmpty())
+            .filter(this::isToolElement)
             .map(this::mapActivityToToolDefinition)
             .toList();
 
     return new AdHocToolsSchemaResponse(toolDefinitions);
+  }
+
+  private boolean isToolElement(FlowNode element) {
+    return element.getIncoming().isEmpty() && !(element instanceof BoundaryEvent);
   }
 
   private AdHocToolDefinition mapActivityToToolDefinition(FlowNode element) {

--- a/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/adhoctoolsschema/resolver/CamundaClientAdHocToolsSchemaResolverTest.java
+++ b/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/adhoctoolsschema/resolver/CamundaClientAdHocToolsSchemaResolverTest.java
@@ -6,18 +6,38 @@
  */
 package io.camunda.connector.agenticai.adhoctoolsschema.resolver;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
 
 import io.camunda.client.CamundaClient;
+import io.camunda.connector.agenticai.adhoctoolsschema.feel.FeelInputParam;
+import io.camunda.connector.agenticai.adhoctoolsschema.feel.FeelInputParamExtractionException;
 import io.camunda.connector.agenticai.adhoctoolsschema.feel.FeelInputParamExtractor;
+import io.camunda.connector.agenticai.adhoctoolsschema.model.AdHocToolsSchemaResponse.AdHocToolDefinition;
 import io.camunda.connector.agenticai.adhoctoolsschema.resolver.schema.AdHocToolSchemaGenerator;
+import io.camunda.connector.agenticai.adhoctoolsschema.resolver.schema.SchemaGenerationException;
+import io.camunda.connector.api.error.ConnectorException;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import org.camunda.bpm.model.xml.ModelParseException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.junit.jupiter.params.provider.NullSource;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.Answers;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -25,10 +45,82 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 class CamundaClientAdHocToolsSchemaResolverTest {
 
-  @Mock private CamundaClient camundaClient;
+  private static final Long PROCESS_DEFINITION_KEY = 123456L;
+  private static final String AD_HOC_SUBPROCESS_ID = "Agent_Tools";
+
+  @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+  private CamundaClient camundaClient;
+
   @Mock private FeelInputParamExtractor feelInputParamExtractor;
   @Mock private AdHocToolSchemaGenerator schemaGenerator;
   @InjectMocks private CamundaClientAdHocToolsSchemaResolver resolver;
+
+  private String bpmnXml;
+
+  @BeforeEach
+  void setUp() throws IOException {
+    bpmnXml =
+        Files.readString(
+            Path.of(getClass().getClassLoader().getResource("ad-hoc-tools.bpmn").getFile()));
+  }
+
+  @Test
+  void loadsAdHocToolSchema() {
+    when(camundaClient.newProcessDefinitionGetXmlRequest(PROCESS_DEFINITION_KEY).send().join())
+        .thenReturn(bpmnXml);
+
+    final Map<String, Object> expectedToolASchema =
+        Map.of("type", "object", "comment", "toolASchema", "dummy", true);
+    final Map<String, Object> expectedEmptySchema =
+        Map.of("type", "object", "comment", "emptySchema", "dummy", true);
+
+    final var toolAInputParams =
+        List.of(
+            new FeelInputParam("inputParameter", "An input parameter"),
+            new FeelInputParam("outputParameter", "An output parameter"));
+
+    doReturn(List.of(toolAInputParams.get(0)))
+        .when(feelInputParamExtractor)
+        .extractInputParams("fromAi(toolCall.inputParameter, \"An input parameter\")");
+    doReturn(List.of(toolAInputParams.get(1)))
+        .when(feelInputParamExtractor)
+        .extractInputParams("fromAi(toolCall.outputParameter, \"An output parameter\")");
+
+    when(schemaGenerator.generateToolSchema(any())).thenReturn(expectedEmptySchema);
+    doReturn(expectedToolASchema).when(schemaGenerator).generateToolSchema(toolAInputParams);
+
+    final var result = resolver.resolveSchema(PROCESS_DEFINITION_KEY, AD_HOC_SUBPROCESS_ID);
+
+    assertThat(result).isNotNull();
+    assertThat(result.toolDefinitions())
+        .isNotEmpty()
+        .satisfiesExactlyInAnyOrder(
+            td -> {
+              assertThat(td.name()).isEqualTo("A_Complex_Tool");
+              assertThat(td.description()).isEqualTo("A very complex tool");
+              assertThat(td.inputSchema()).isEqualTo(expectedEmptySchema);
+            },
+            td -> {
+              assertThat(td.name()).isEqualTo("Tool_A");
+              assertThat(td.description()).isEqualTo("The A tool");
+              assertThat(td.inputSchema()).isEqualTo(expectedToolASchema);
+            },
+            td -> {
+              assertThat(td.name()).isEqualTo("Simple_Tool");
+              assertThat(td.description()).isEqualTo("A simple tool");
+              assertThat(td.inputSchema()).isEqualTo(expectedEmptySchema);
+            },
+            td -> {
+              assertThat(td.name()).isEqualTo("An_Event");
+              assertThat(td.description()).isEqualTo("An event!");
+              assertThat(td.inputSchema()).isEqualTo(expectedEmptySchema);
+            });
+
+    assertThat(result.toolDefinitions())
+        .extracting(AdHocToolDefinition::name)
+        .doesNotContain(
+            "Tool_B", "Event_Follow_Up_Task", "Complex_Tool_Error", "Handle_Complex_Tool_Error");
+  }
 
   @ParameterizedTest
   @NullSource
@@ -50,5 +142,89 @@ class CamundaClientAdHocToolsSchemaResolverTest {
         .hasMessage("adHocSubprocessId cannot be null or empty");
 
     verifyNoInteractions(camundaClient, feelInputParamExtractor, schemaGenerator);
+  }
+
+  @Test
+  void throwsExceptionWhenBpmnXmlIsInvalid() {
+    when(camundaClient.newProcessDefinitionGetXmlRequest(PROCESS_DEFINITION_KEY).send().join())
+        .thenReturn("DUMMY");
+
+    assertThatThrownBy(() -> resolver.resolveSchema(PROCESS_DEFINITION_KEY, AD_HOC_SUBPROCESS_ID))
+        .isInstanceOf(ModelParseException.class);
+  }
+
+  @Test
+  void throwsExceptionWhenAdHocSubprocessWithRequestedIdDoesNotExist() {
+    when(camundaClient.newProcessDefinitionGetXmlRequest(PROCESS_DEFINITION_KEY).send().join())
+        .thenReturn(bpmnXml);
+
+    assertThatThrownBy(() -> resolver.resolveSchema(PROCESS_DEFINITION_KEY, "DUMMY"))
+        .isInstanceOfSatisfying(
+            ConnectorException.class,
+            e -> {
+              assertThat(e.getErrorCode()).isEqualTo("AD_HOC_SUBPROCESS_NOT_FOUND");
+              assertThat(e.getMessage())
+                  .isEqualTo(
+                      "Unable to resolve tools schema. Ad-hoc subprocess with ID 'DUMMY' was not found.");
+            });
+  }
+
+  @Test
+  void throwsExceptionWhenInputParamExtractionFails() {
+    when(camundaClient.newProcessDefinitionGetXmlRequest(PROCESS_DEFINITION_KEY).send().join())
+        .thenReturn(bpmnXml);
+
+    doThrow(new FeelInputParamExtractionException("I can't handle the fromAi function."))
+        .when(feelInputParamExtractor)
+        .extractInputParams("fromAi(toolCall.inputParameter, \"An input parameter\")");
+
+    assertThatThrownBy(() -> resolver.resolveSchema(PROCESS_DEFINITION_KEY, AD_HOC_SUBPROCESS_ID))
+        .isInstanceOfSatisfying(
+            ConnectorException.class,
+            e -> {
+              assertThat(e.getErrorCode()).isEqualTo("AD_HOC_TOOL_DEFINITION_INVALID");
+              assertThat(e.getMessage())
+                  .isEqualTo(
+                      "Invalid ad-hoc tool definition for element 'Tool_A' on input mapping 'inputParameter': I can't handle the fromAi function.");
+            });
+  }
+
+  @Test
+  void throwsExceptionWhenOutputParamExtractionFails() {
+    when(camundaClient.newProcessDefinitionGetXmlRequest(PROCESS_DEFINITION_KEY).send().join())
+        .thenReturn(bpmnXml);
+
+    when(feelInputParamExtractor.extractInputParams(any())).thenReturn(Collections.emptyList());
+    doThrow(new FeelInputParamExtractionException("I can't handle the fromAi function."))
+        .when(feelInputParamExtractor)
+        .extractInputParams("fromAi(toolCall.outputParameter, \"An output parameter\")");
+
+    assertThatThrownBy(() -> resolver.resolveSchema(PROCESS_DEFINITION_KEY, AD_HOC_SUBPROCESS_ID))
+        .isInstanceOfSatisfying(
+            ConnectorException.class,
+            e -> {
+              assertThat(e.getErrorCode()).isEqualTo("AD_HOC_TOOL_DEFINITION_INVALID");
+              assertThat(e.getMessage())
+                  .isEqualTo(
+                      "Invalid ad-hoc tool definition for element 'Tool_A' on output mapping 'outputParameter': I can't handle the fromAi function.");
+            });
+  }
+
+  @Test
+  void throwsExceptionWhenSchemaGenerationFails() {
+    when(camundaClient.newProcessDefinitionGetXmlRequest(PROCESS_DEFINITION_KEY).send().join())
+        .thenReturn(bpmnXml);
+    when(schemaGenerator.generateToolSchema(any()))
+        .thenThrow(new SchemaGenerationException("I can't generate this schema"));
+
+    assertThatThrownBy(() -> resolver.resolveSchema(PROCESS_DEFINITION_KEY, AD_HOC_SUBPROCESS_ID))
+        .isInstanceOfSatisfying(
+            ConnectorException.class,
+            e -> {
+              assertThat(e.getErrorCode()).isEqualTo("AD_HOC_TOOL_SCHEMA_INVALID");
+              assertThat(e.getMessage())
+                  .isEqualTo(
+                      "Failed to generate ad-hoc tool schema for element 'A_Complex_Tool': I can't generate this schema");
+            });
   }
 }

--- a/connectors/agentic-ai/src/test/resources/ad-hoc-tools.bpmn
+++ b/connectors/agentic-ai/src/test/resources/ad-hoc-tools.bpmn
@@ -1,0 +1,135 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1gx9y68" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.34.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.8.0">
+  <bpmn:process id="Agentic_AI_Connectors" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_0yrziwn</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:adHocSubProcess id="Agent_Tools" name="Agent Tools">
+      <bpmn:extensionElements>
+        <zeebe:adHoc />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_0yrziwn</bpmn:incoming>
+      <bpmn:outgoing>Flow_1e5yz0x</bpmn:outgoing>
+      <bpmn:manualTask id="Handle_Complex_Tool_Error" name="Handle complex tool error">
+        <bpmn:incoming>Flow_1p7oy92</bpmn:incoming>
+      </bpmn:manualTask>
+      <bpmn:scriptTask id="A_Complex_Tool" name="A complex tool">
+        <bpmn:documentation>A very complex tool</bpmn:documentation>
+        <bpmn:extensionElements>
+          <zeebe:script expression="=1 + 1" resultVariable="toolCallResult" />
+        </bpmn:extensionElements>
+      </bpmn:scriptTask>
+      <bpmn:boundaryEvent id="Complex_Tool_Error" attachedToRef="A_Complex_Tool">
+        <bpmn:documentation>Handles errors from complex tool</bpmn:documentation>
+        <bpmn:outgoing>Flow_1p7oy92</bpmn:outgoing>
+        <bpmn:errorEventDefinition id="ErrorEventDefinition_1c6dxc2" />
+      </bpmn:boundaryEvent>
+      <bpmn:sequenceFlow id="Flow_1p7oy92" sourceRef="Complex_Tool_Error" targetRef="Handle_Complex_Tool_Error" />
+      <bpmn:scriptTask id="Tool_A" name="Tool A">
+        <bpmn:documentation>The A tool</bpmn:documentation>
+        <bpmn:extensionElements>
+          <zeebe:script expression="=now()" resultVariable="toolCallResult" />
+          <zeebe:ioMapping>
+            <zeebe:input source="=fromAi(toolCall.inputParameter, &#34;An input parameter&#34;)" target="inputParameter" />
+            <zeebe:output source="=fromAi(toolCall.outputParameter, &#34;An output parameter&#34;)" target="outputParameter" />
+          </zeebe:ioMapping>
+        </bpmn:extensionElements>
+        <bpmn:outgoing>Flow_095717l</bpmn:outgoing>
+      </bpmn:scriptTask>
+      <bpmn:scriptTask id="Tool_B" name="Tool B">
+        <bpmn:documentation>The B tool</bpmn:documentation>
+        <bpmn:extensionElements>
+          <zeebe:script expression="=1 * 1" resultVariable="someThingElse" />
+        </bpmn:extensionElements>
+        <bpmn:incoming>Flow_095717l</bpmn:incoming>
+      </bpmn:scriptTask>
+      <bpmn:sequenceFlow id="Flow_095717l" sourceRef="Tool_A" targetRef="Tool_B" />
+      <bpmn:scriptTask id="Simple_Tool" name="Simple Tool">
+        <bpmn:documentation>A simple tool</bpmn:documentation>
+        <bpmn:extensionElements>
+          <zeebe:script expression="=now()" resultVariable="toolCallResult" />
+        </bpmn:extensionElements>
+      </bpmn:scriptTask>
+      <bpmn:task id="Event_Follow_Up_Task" name="Event follow-up task">
+        <bpmn:incoming>Flow_0v33lmt</bpmn:incoming>
+      </bpmn:task>
+      <bpmn:intermediateThrowEvent id="An_Event" name="An event!">
+        <bpmn:extensionElements />
+        <bpmn:outgoing>Flow_0v33lmt</bpmn:outgoing>
+      </bpmn:intermediateThrowEvent>
+      <bpmn:sequenceFlow id="Flow_0v33lmt" sourceRef="An_Event" targetRef="Event_Follow_Up_Task" />
+    </bpmn:adHocSubProcess>
+    <bpmn:sequenceFlow id="Flow_0yrziwn" sourceRef="StartEvent_1" targetRef="Agent_Tools" />
+    <bpmn:endEvent id="Event_0w61ti7">
+      <bpmn:incoming>Flow_1e5yz0x</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1e5yz0x" sourceRef="Agent_Tools" targetRef="Event_0w61ti7" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Agentic_AI_Connectors">
+      <bpmndi:BPMNShape id="StartEvent_1_di" bpmnElement="StartEvent_1">
+        <dc:Bounds x="152" y="172" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_005wn4n_di" bpmnElement="Agent_Tools" isExpanded="true">
+        <dc:Bounds x="290" y="80" width="350" height="580" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1xv565y_di" bpmnElement="Handle_Complex_Tool_Error">
+        <dc:Bounds x="470" y="530" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0wd2ku5_di" bpmnElement="A_Complex_Tool">
+        <dc:Bounds x="340" y="450" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1kglsdx_di" bpmnElement="Tool_A">
+        <dc:Bounds x="340" y="230" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_02cecmv_di" bpmnElement="Tool_B">
+        <dc:Bounds x="480" y="230" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1sbkoqq_di" bpmnElement="Simple_Tool">
+        <dc:Bounds x="340" y="130" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_17rjl26_di" bpmnElement="Event_Follow_Up_Task">
+        <dc:Bounds x="480" y="330" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_02hr6cv_di" bpmnElement="An_Event">
+        <dc:Bounds x="372" y="352" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="368" y="395" width="47" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1p1n58n_di" bpmnElement="Complex_Tool_Error">
+        <dc:Bounds x="392" y="512" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1p7oy92_di" bpmnElement="Flow_1p7oy92">
+        <di:waypoint x="410" y="548" />
+        <di:waypoint x="410" y="570" />
+        <di:waypoint x="470" y="570" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_095717l_di" bpmnElement="Flow_095717l">
+        <di:waypoint x="440" y="270" />
+        <di:waypoint x="480" y="270" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0v33lmt_di" bpmnElement="Flow_0v33lmt">
+        <di:waypoint x="408" y="370" />
+        <di:waypoint x="480" y="370" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Event_0w61ti7_di" bpmnElement="Event_0w61ti7">
+        <dc:Bounds x="722" y="172" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0yrziwn_di" bpmnElement="Flow_0yrziwn">
+        <di:waypoint x="188" y="190" />
+        <di:waypoint x="290" y="190" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1e5yz0x_di" bpmnElement="Flow_1e5yz0x">
+        <di:waypoint x="640" y="190" />
+        <di:waypoint x="722" y="190" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>


### PR DESCRIPTION
## Description

The current agentic AI tool resolving logic resolves all "root" elements (no incoming flows) within an ad-hoc subprocess as tools, which also applies to boundary events. With this change, boundary events are explicitly excluded from being resolved as tools.

## Related issues

based on #4721 

closes #4713

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.

