### PR TITLE
chore(fix-main): Quick fix for failing LocalConnectorsRuntime on main

### DIFF
--- a/bundle/default-bundle/src/test/resources/application.properties
+++ b/bundle/default-bundle/src/test/resources/application.properties
@@ -14,11 +14,11 @@ camunda.client.zeebe.defaults.stream-enabled=true
 camunda.client.rest-address=http://localhost:8088
 camunda.client.mode=self-managed
 # Config for use with docker-compose.yml
-camunda.client.auth.client-id=connectors
-camunda.client.auth.client-secret=XALaRPl5qwTEItdwCMiPS62nVpKs7dL7
-camunda.client.auth.token-url=http://localhost:18080/auth/realms/camunda-platform/protocol/openid-connect/token
-camunda.client.auth.audience=connectors
-camunda.client.identity.base-url=http://localhost:8084
+#camunda.client.auth.client-id=connectors
+#camunda.client.auth.client-secret=XALaRPl5qwTEItdwCMiPS62nVpKs7dL7
+#camunda.client.auth.token-url=http://localhost:18080/auth/realms/camunda-platform/protocol/openid-connect/token
+#camunda.client.auth.audience=connectors
+#camunda.client.identity.base-url=http://localhost:8084
 # Config for use with docker-compose-core.yml
 #camunda.client.auth.username=demo
 #camunda.client.auth.password=demo


### PR DESCRIPTION
## Description
As discussed in the meeting.
I just tested, this seems not to be necessary for 8.7 release branch.


## Checklist

- [x] PR has a **milestone** or the `no milestone` label.

