### PR TITLE
others(etg): versions history are now managed by the element template generator

### DIFF
--- a/connectors/agentic-ai/pom.xml
+++ b/connectors/agentic-ai/pom.xml
@@ -130,8 +130,8 @@
               <generateHybridTemplates>true</generateHybridTemplates>
               <writeMetaInfFileGeneration>false</writeMetaInfFileGeneration>
             </connector>
-                              </connectors>
-                    <versions>true</versions>
+          </connectors>
+          <versionHistoryEnabled>true</versionHistoryEnabled>
           <includeDependencies>
             <includeDependency>io.camunda.connector:connector-aws-base</includeDependency>
           </includeDependencies>

--- a/connectors/agentic-ai/pom.xml
+++ b/connectors/agentic-ai/pom.xml
@@ -130,7 +130,8 @@
               <generateHybridTemplates>true</generateHybridTemplates>
               <writeMetaInfFileGeneration>false</writeMetaInfFileGeneration>
             </connector>
-          </connectors>
+                              </connectors>
+                    <versions>true</versions>
           <includeDependencies>
             <includeDependency>io.camunda.connector:connector-aws-base</includeDependency>
           </includeDependencies>

--- a/connectors/automation-anywhere/pom.xml
+++ b/connectors/automation-anywhere/pom.xml
@@ -50,8 +50,8 @@
               </files>
               <generateHybridTemplates>true</generateHybridTemplates>
             </connector>
-                              </connectors>
-                    <versions>true</versions>
+          </connectors>
+          <versionHistoryEnabled>true</versionHistoryEnabled>
         </configuration>
       </plugin>
     </plugins>

--- a/connectors/automation-anywhere/pom.xml
+++ b/connectors/automation-anywhere/pom.xml
@@ -50,7 +50,8 @@
               </files>
               <generateHybridTemplates>true</generateHybridTemplates>
             </connector>
-          </connectors>
+                              </connectors>
+                    <versions>true</versions>
         </configuration>
       </plugin>
     </plugins>

--- a/connectors/aws/aws-bedrock/pom.xml
+++ b/connectors/aws/aws-bedrock/pom.xml
@@ -63,8 +63,8 @@
                             </files>
                             <generateHybridTemplates>true</generateHybridTemplates>
                         </connector>
-                                        </connectors>
-                    <versions>true</versions>
+                    </connectors>
+          <versionHistoryEnabled>true</versionHistoryEnabled>
                     <includeDependencies>
                         <includeDependency>io.camunda.connector:connector-aws-base</includeDependency>
                     </includeDependencies>

--- a/connectors/aws/aws-bedrock/pom.xml
+++ b/connectors/aws/aws-bedrock/pom.xml
@@ -63,7 +63,8 @@
                             </files>
                             <generateHybridTemplates>true</generateHybridTemplates>
                         </connector>
-                    </connectors>
+                                        </connectors>
+                    <versions>true</versions>
                     <includeDependencies>
                         <includeDependency>io.camunda.connector:connector-aws-base</includeDependency>
                     </includeDependencies>

--- a/connectors/aws/aws-comprehend/pom.xml
+++ b/connectors/aws/aws-comprehend/pom.xml
@@ -64,7 +64,8 @@
               </files>
               <generateHybridTemplates>true</generateHybridTemplates>
             </connector>
-          </connectors>
+                              </connectors>
+                    <versions>true</versions>
           <includeDependencies>
             <includeDependency>io.camunda.connector:connector-aws-base</includeDependency>
           </includeDependencies>

--- a/connectors/aws/aws-comprehend/pom.xml
+++ b/connectors/aws/aws-comprehend/pom.xml
@@ -64,8 +64,8 @@
               </files>
               <generateHybridTemplates>true</generateHybridTemplates>
             </connector>
-                              </connectors>
-                    <versions>true</versions>
+          </connectors>
+          <versionHistoryEnabled>true</versionHistoryEnabled>
           <includeDependencies>
             <includeDependency>io.camunda.connector:connector-aws-base</includeDependency>
           </includeDependencies>

--- a/connectors/aws/aws-dynamodb/pom.xml
+++ b/connectors/aws/aws-dynamodb/pom.xml
@@ -57,8 +57,8 @@
                             </files>
                             <generateHybridTemplates>true</generateHybridTemplates>
                         </connector>
-                                        </connectors>
-                    <versions>true</versions>
+                    </connectors>
+          <versionHistoryEnabled>true</versionHistoryEnabled>
                     <includeDependencies>
                         <includeDependency>io.camunda.connector:connector-aws-base</includeDependency>
                     </includeDependencies>

--- a/connectors/aws/aws-dynamodb/pom.xml
+++ b/connectors/aws/aws-dynamodb/pom.xml
@@ -57,7 +57,8 @@
                             </files>
                             <generateHybridTemplates>true</generateHybridTemplates>
                         </connector>
-                    </connectors>
+                                        </connectors>
+                    <versions>true</versions>
                     <includeDependencies>
                         <includeDependency>io.camunda.connector:connector-aws-base</includeDependency>
                     </includeDependencies>

--- a/connectors/aws/aws-eventbridge/pom.xml
+++ b/connectors/aws/aws-eventbridge/pom.xml
@@ -60,8 +60,8 @@
               </files>
               <generateHybridTemplates>true</generateHybridTemplates>
             </connector>
-                              </connectors>
-                    <versions>true</versions>
+          </connectors>
+          <versionHistoryEnabled>true</versionHistoryEnabled>
           <includeDependencies>
             <includeDependency>io.camunda.connector:connector-aws-base</includeDependency>
           </includeDependencies>

--- a/connectors/aws/aws-eventbridge/pom.xml
+++ b/connectors/aws/aws-eventbridge/pom.xml
@@ -60,7 +60,8 @@
               </files>
               <generateHybridTemplates>true</generateHybridTemplates>
             </connector>
-          </connectors>
+                              </connectors>
+                    <versions>true</versions>
           <includeDependencies>
             <includeDependency>io.camunda.connector:connector-aws-base</includeDependency>
           </includeDependencies>

--- a/connectors/aws/aws-lambda/pom.xml
+++ b/connectors/aws/aws-lambda/pom.xml
@@ -58,8 +58,8 @@
               </files>
               <generateHybridTemplates>true</generateHybridTemplates>
             </connector>
-                              </connectors>
-                    <versions>true</versions>
+          </connectors>
+          <versionHistoryEnabled>true</versionHistoryEnabled>
           <includeDependencies>
             <includeDependency>io.camunda.connector:connector-aws-base</includeDependency>
           </includeDependencies>

--- a/connectors/aws/aws-lambda/pom.xml
+++ b/connectors/aws/aws-lambda/pom.xml
@@ -58,7 +58,8 @@
               </files>
               <generateHybridTemplates>true</generateHybridTemplates>
             </connector>
-          </connectors>
+                              </connectors>
+                    <versions>true</versions>
           <includeDependencies>
             <includeDependency>io.camunda.connector:connector-aws-base</includeDependency>
           </includeDependencies>

--- a/connectors/aws/aws-s3/pom.xml
+++ b/connectors/aws/aws-s3/pom.xml
@@ -64,8 +64,8 @@
                             </files>
                             <generateHybridTemplates>true</generateHybridTemplates>
                         </connector>
-                                        </connectors>
-                    <versions>true</versions>
+                    </connectors>
+          <versionHistoryEnabled>true</versionHistoryEnabled>
                     <includeDependencies>
                         <includeDependency>io.camunda.connector:connector-aws-base</includeDependency>
                     </includeDependencies>

--- a/connectors/aws/aws-s3/pom.xml
+++ b/connectors/aws/aws-s3/pom.xml
@@ -64,7 +64,8 @@
                             </files>
                             <generateHybridTemplates>true</generateHybridTemplates>
                         </connector>
-                    </connectors>
+                                        </connectors>
+                    <versions>true</versions>
                     <includeDependencies>
                         <includeDependency>io.camunda.connector:connector-aws-base</includeDependency>
                     </includeDependencies>

--- a/connectors/aws/aws-sagemaker/pom.xml
+++ b/connectors/aws/aws-sagemaker/pom.xml
@@ -70,7 +70,8 @@
               </files>
               <generateHybridTemplates>true</generateHybridTemplates>
             </connector>
-          </connectors>
+                              </connectors>
+                    <versions>true</versions>
           <includeDependencies>
             <includeDependency>io.camunda.connector:connector-aws-base</includeDependency>
           </includeDependencies>

--- a/connectors/aws/aws-sagemaker/pom.xml
+++ b/connectors/aws/aws-sagemaker/pom.xml
@@ -70,8 +70,8 @@
               </files>
               <generateHybridTemplates>true</generateHybridTemplates>
             </connector>
-                              </connectors>
-                    <versions>true</versions>
+          </connectors>
+          <versionHistoryEnabled>true</versionHistoryEnabled>
           <includeDependencies>
             <includeDependency>io.camunda.connector:connector-aws-base</includeDependency>
           </includeDependencies>

--- a/connectors/aws/aws-sns/pom.xml
+++ b/connectors/aws/aws-sns/pom.xml
@@ -89,8 +89,8 @@ except in compliance with the proprietary license.</license.inlineheader>
               </files>
               <generateHybridTemplates>true</generateHybridTemplates>
             </connector>
-                              </connectors>
-                    <versions>true</versions>
+          </connectors>
+          <versionHistoryEnabled>true</versionHistoryEnabled>
           <includeDependencies>
             <includeDependency>io.camunda.connector:connector-aws-base</includeDependency>
           </includeDependencies>

--- a/connectors/aws/aws-sns/pom.xml
+++ b/connectors/aws/aws-sns/pom.xml
@@ -89,7 +89,8 @@ except in compliance with the proprietary license.</license.inlineheader>
               </files>
               <generateHybridTemplates>true</generateHybridTemplates>
             </connector>
-          </connectors>
+                              </connectors>
+                    <versions>true</versions>
           <includeDependencies>
             <includeDependency>io.camunda.connector:connector-aws-base</includeDependency>
           </includeDependencies>

--- a/connectors/aws/aws-sqs/pom.xml
+++ b/connectors/aws/aws-sqs/pom.xml
@@ -81,7 +81,8 @@
                 <ACKNOWLEDGEMENT_STRATEGY_SELECTION>true</ACKNOWLEDGEMENT_STRATEGY_SELECTION>
               </features>
             </connector>
-          </connectors>
+                              </connectors>
+                    <versions>true</versions>
           <includeDependencies>
             <includeDependency>io.camunda.connector:connector-aws-base</includeDependency>
           </includeDependencies>

--- a/connectors/aws/aws-sqs/pom.xml
+++ b/connectors/aws/aws-sqs/pom.xml
@@ -81,8 +81,8 @@
                 <ACKNOWLEDGEMENT_STRATEGY_SELECTION>true</ACKNOWLEDGEMENT_STRATEGY_SELECTION>
               </features>
             </connector>
-                              </connectors>
-                    <versions>true</versions>
+          </connectors>
+          <versionHistoryEnabled>true</versionHistoryEnabled>
           <includeDependencies>
             <includeDependency>io.camunda.connector:connector-aws-base</includeDependency>
           </includeDependencies>

--- a/connectors/aws/aws-textract/pom.xml
+++ b/connectors/aws/aws-textract/pom.xml
@@ -69,8 +69,8 @@ except in compliance with the proprietary license.</license.inlineheader>
               </files>
               <generateHybridTemplates>true</generateHybridTemplates>
             </connector>
-                              </connectors>
-                    <versions>true</versions>
+          </connectors>
+          <versionHistoryEnabled>true</versionHistoryEnabled>
           <includeDependencies>
             <includeDependency>io.camunda.connector:connector-aws-base</includeDependency>
           </includeDependencies>

--- a/connectors/aws/aws-textract/pom.xml
+++ b/connectors/aws/aws-textract/pom.xml
@@ -69,7 +69,8 @@ except in compliance with the proprietary license.</license.inlineheader>
               </files>
               <generateHybridTemplates>true</generateHybridTemplates>
             </connector>
-          </connectors>
+                              </connectors>
+                    <versions>true</versions>
           <includeDependencies>
             <includeDependency>io.camunda.connector:connector-aws-base</includeDependency>
           </includeDependencies>

--- a/connectors/box/pom.xml
+++ b/connectors/box/pom.xml
@@ -59,7 +59,8 @@ except in compliance with the proprietary license.</license.inlineheader>
               </files>
               <generateHybridTemplates>true</generateHybridTemplates>
             </connector>
-          </connectors>
+                              </connectors>
+                    <versions>true</versions>
         </configuration>
       </plugin>
     </plugins>

--- a/connectors/box/pom.xml
+++ b/connectors/box/pom.xml
@@ -59,8 +59,8 @@ except in compliance with the proprietary license.</license.inlineheader>
               </files>
               <generateHybridTemplates>true</generateHybridTemplates>
             </connector>
-                              </connectors>
-                    <versions>true</versions>
+          </connectors>
+          <versionHistoryEnabled>true</versionHistoryEnabled>
         </configuration>
       </plugin>
     </plugins>

--- a/connectors/camunda-message/pom.xml
+++ b/connectors/camunda-message/pom.xml
@@ -43,8 +43,8 @@
                 io.camunda.connector.message.SendMessageConnectorFunction</connectorClass>
               <generateHybridTemplates>true</generateHybridTemplates>
             </connector>
-                              </connectors>
-                    <versions>true</versions>
+          </connectors>
+          <versionHistoryEnabled>true</versionHistoryEnabled>
         </configuration>
       </plugin>
     </plugins>

--- a/connectors/camunda-message/pom.xml
+++ b/connectors/camunda-message/pom.xml
@@ -43,7 +43,8 @@
                 io.camunda.connector.message.SendMessageConnectorFunction</connectorClass>
               <generateHybridTemplates>true</generateHybridTemplates>
             </connector>
-          </connectors>
+                              </connectors>
+                    <versions>true</versions>
         </configuration>
       </plugin>
     </plugins>

--- a/connectors/email/pom.xml
+++ b/connectors/email/pom.xml
@@ -86,7 +86,7 @@
                             </features>
                         </connector>
                     </connectors>
-                    <versions>true</versions>
+                    <versionHistoryEnabled>true</versionHistoryEnabled>
                 </configuration>
             </plugin>
         </plugins>

--- a/connectors/email/pom.xml
+++ b/connectors/email/pom.xml
@@ -86,6 +86,7 @@
                             </features>
                         </connector>
                     </connectors>
+                    <versions>true</versions>
                 </configuration>
             </plugin>
         </plugins>

--- a/connectors/embeddings-vector-database/pom.xml
+++ b/connectors/embeddings-vector-database/pom.xml
@@ -81,7 +81,8 @@
             </files>
             <generateHybridTemplates>true</generateHybridTemplates>
           </connector>
-        </connectors>
+                            </connectors>
+                    <versions>true</versions>
       </configuration>
       </plugin>
     </plugins>

--- a/connectors/embeddings-vector-database/pom.xml
+++ b/connectors/embeddings-vector-database/pom.xml
@@ -82,7 +82,7 @@
             <generateHybridTemplates>true</generateHybridTemplates>
           </connector>
                             </connectors>
-                    <versions>true</versions>
+                    <versionHistoryEnabled>true</versionHistoryEnabled>
       </configuration>
       </plugin>
     </plugins>

--- a/connectors/google/google-drive/pom.xml
+++ b/connectors/google/google-drive/pom.xml
@@ -60,8 +60,8 @@
               </files>
               <generateHybridTemplates>true</generateHybridTemplates>
             </connector>
-                              </connectors>
-                    <versions>true</versions>
+          </connectors>
+          <versionHistoryEnabled>true</versionHistoryEnabled>
           <includeDependencies>io.camunda.connector:connector-google-base</includeDependencies>
         </configuration>
       </plugin>

--- a/connectors/google/google-drive/pom.xml
+++ b/connectors/google/google-drive/pom.xml
@@ -60,7 +60,8 @@
               </files>
               <generateHybridTemplates>true</generateHybridTemplates>
             </connector>
-          </connectors>
+                              </connectors>
+                    <versions>true</versions>
           <includeDependencies>io.camunda.connector:connector-google-base</includeDependencies>
         </configuration>
       </plugin>

--- a/connectors/google/google-gemini/pom.xml
+++ b/connectors/google/google-gemini/pom.xml
@@ -63,7 +63,8 @@ except in compliance with the proprietary license.</license.inlineheader>
                             </files>
                             <generateHybridTemplates>true</generateHybridTemplates>
                         </connector>
-                    </connectors>
+                                        </connectors>
+                    <versions>true</versions>
                     <includeDependencies>
                         <includeDependency>io.camunda.connector:connector-google-base</includeDependency>
                     </includeDependencies>

--- a/connectors/google/google-gemini/pom.xml
+++ b/connectors/google/google-gemini/pom.xml
@@ -63,8 +63,8 @@ except in compliance with the proprietary license.</license.inlineheader>
                             </files>
                             <generateHybridTemplates>true</generateHybridTemplates>
                         </connector>
-                                        </connectors>
-                    <versions>true</versions>
+                    </connectors>
+          <versionHistoryEnabled>true</versionHistoryEnabled>
                     <includeDependencies>
                         <includeDependency>io.camunda.connector:connector-google-base</includeDependency>
                     </includeDependencies>

--- a/connectors/google/google-sheets/pom.xml
+++ b/connectors/google/google-sheets/pom.xml
@@ -59,7 +59,8 @@
                             </files>
                             <generateHybridTemplates>true</generateHybridTemplates>
                         </connector>
-                    </connectors>
+                                        </connectors>
+                    <versions>true</versions>
                     <includeDependencies>io.camunda.connector:connector-google-base</includeDependencies>
                 </configuration>
             </plugin>

--- a/connectors/google/google-sheets/pom.xml
+++ b/connectors/google/google-sheets/pom.xml
@@ -59,8 +59,8 @@
                             </files>
                             <generateHybridTemplates>true</generateHybridTemplates>
                         </connector>
-                                        </connectors>
-                    <versions>true</versions>
+                    </connectors>
+          <versionHistoryEnabled>true</versionHistoryEnabled>
                     <includeDependencies>io.camunda.connector:connector-google-base</includeDependencies>
                 </configuration>
             </plugin>

--- a/connectors/http/graphql/pom.xml
+++ b/connectors/http/graphql/pom.xml
@@ -74,8 +74,8 @@
               </files>
               <generateHybridTemplates>true</generateHybridTemplates>
             </connector>
-                              </connectors>
-                    <versions>true</versions>
+          </connectors>
+          <versionHistoryEnabled>true</versionHistoryEnabled>
           <includeDependencies>
             <includeDependency>io.camunda.connector:connector-http-base</includeDependency>
           </includeDependencies>

--- a/connectors/http/graphql/pom.xml
+++ b/connectors/http/graphql/pom.xml
@@ -74,7 +74,8 @@
               </files>
               <generateHybridTemplates>true</generateHybridTemplates>
             </connector>
-          </connectors>
+                              </connectors>
+                    <versions>true</versions>
           <includeDependencies>
             <includeDependency>io.camunda.connector:connector-http-base</includeDependency>
           </includeDependencies>

--- a/connectors/http/rest/pom.xml
+++ b/connectors/http/rest/pom.xml
@@ -80,8 +80,8 @@ limitations under the License.</license.inlineheader>
               </files>
               <generateHybridTemplates>true</generateHybridTemplates>
             </connector>
-                              </connectors>
-                    <versions>true</versions>
+          </connectors>
+          <versionHistoryEnabled>true</versionHistoryEnabled>
           <includeDependencies>
             <includeDependency>io.camunda.connector:connector-http-base</includeDependency>
           </includeDependencies>

--- a/connectors/http/rest/pom.xml
+++ b/connectors/http/rest/pom.xml
@@ -80,7 +80,8 @@ limitations under the License.</license.inlineheader>
               </files>
               <generateHybridTemplates>true</generateHybridTemplates>
             </connector>
-          </connectors>
+                              </connectors>
+                    <versions>true</versions>
           <includeDependencies>
             <includeDependency>io.camunda.connector:connector-http-base</includeDependency>
           </includeDependencies>

--- a/connectors/idp-extraction/pom.xml
+++ b/connectors/idp-extraction/pom.xml
@@ -84,7 +84,8 @@
               </files>
               <generateHybridTemplates>true</generateHybridTemplates>
             </connector>
-          </connectors>
+                              </connectors>
+                    <versions>true</versions>
           <includeDependencies>
             <includeDependency>io.camunda.connector:connector-aws-base</includeDependency>
           </includeDependencies>

--- a/connectors/idp-extraction/pom.xml
+++ b/connectors/idp-extraction/pom.xml
@@ -84,8 +84,8 @@
               </files>
               <generateHybridTemplates>true</generateHybridTemplates>
             </connector>
-                              </connectors>
-                    <versions>true</versions>
+          </connectors>
+          <versionHistoryEnabled>true</versionHistoryEnabled>
           <includeDependencies>
             <includeDependency>io.camunda.connector:connector-aws-base</includeDependency>
           </includeDependencies>

--- a/connectors/jdbc/pom.xml
+++ b/connectors/jdbc/pom.xml
@@ -122,7 +122,8 @@
               </files>
               <generateHybridTemplates>true</generateHybridTemplates>
             </connector>
-          </connectors>
+                              </connectors>
+                    <versions>true</versions>
         </configuration>
       </plugin>
     </plugins>

--- a/connectors/jdbc/pom.xml
+++ b/connectors/jdbc/pom.xml
@@ -122,8 +122,8 @@
               </files>
               <generateHybridTemplates>true</generateHybridTemplates>
             </connector>
-                              </connectors>
-                    <versions>true</versions>
+          </connectors>
+          <versionHistoryEnabled>true</versionHistoryEnabled>
         </configuration>
       </plugin>
     </plugins>

--- a/connectors/kafka/pom.xml
+++ b/connectors/kafka/pom.xml
@@ -171,7 +171,8 @@ except in compliance with the proprietary license.</license.inlineheader>
                 <ACKNOWLEDGEMENT_STRATEGY_SELECTION>true</ACKNOWLEDGEMENT_STRATEGY_SELECTION>
               </features>
             </connector>
-          </connectors>
+                              </connectors>
+                    <versions>true</versions>
         </configuration>
       </plugin>
     </plugins>

--- a/connectors/kafka/pom.xml
+++ b/connectors/kafka/pom.xml
@@ -171,8 +171,8 @@ except in compliance with the proprietary license.</license.inlineheader>
                 <ACKNOWLEDGEMENT_STRATEGY_SELECTION>true</ACKNOWLEDGEMENT_STRATEGY_SELECTION>
               </features>
             </connector>
-                              </connectors>
-                    <versions>true</versions>
+          </connectors>
+          <versionHistoryEnabled>true</versionHistoryEnabled>
         </configuration>
       </plugin>
     </plugins>

--- a/connectors/microsoft-teams/pom.xml
+++ b/connectors/microsoft-teams/pom.xml
@@ -69,7 +69,8 @@
             </files>
             <generateHybridTemplates>true</generateHybridTemplates>
           </connector>
-        </connectors>
+                            </connectors>
+                    <versions>true</versions>
       </configuration>
       </plugin>
     </plugins>

--- a/connectors/microsoft-teams/pom.xml
+++ b/connectors/microsoft-teams/pom.xml
@@ -70,7 +70,7 @@
             <generateHybridTemplates>true</generateHybridTemplates>
           </connector>
                             </connectors>
-                    <versions>true</versions>
+                    <versionHistoryEnabled>true</versionHistoryEnabled>
       </configuration>
       </plugin>
     </plugins>

--- a/connectors/rabbitmq/pom.xml
+++ b/connectors/rabbitmq/pom.xml
@@ -90,8 +90,8 @@
                 <ACKNOWLEDGEMENT_STRATEGY_SELECTION>true</ACKNOWLEDGEMENT_STRATEGY_SELECTION>
               </features>
             </connector>
-                              </connectors>
-                    <versions>true</versions>
+          </connectors>
+          <versionHistoryEnabled>true</versionHistoryEnabled>
         </configuration>
       </plugin>
     </plugins>

--- a/connectors/rabbitmq/pom.xml
+++ b/connectors/rabbitmq/pom.xml
@@ -90,7 +90,8 @@
                 <ACKNOWLEDGEMENT_STRATEGY_SELECTION>true</ACKNOWLEDGEMENT_STRATEGY_SELECTION>
               </features>
             </connector>
-          </connectors>
+                              </connectors>
+                    <versions>true</versions>
         </configuration>
       </plugin>
     </plugins>

--- a/connectors/sendgrid/pom.xml
+++ b/connectors/sendgrid/pom.xml
@@ -67,7 +67,8 @@ except in compliance with the proprietary license.</license.inlineheader>
               </files>
               <generateHybridTemplates>true</generateHybridTemplates>
             </connector>
-          </connectors>
+                              </connectors>
+                    <versions>true</versions>
         </configuration>
       </plugin>
     </plugins>

--- a/connectors/sendgrid/pom.xml
+++ b/connectors/sendgrid/pom.xml
@@ -67,8 +67,8 @@ except in compliance with the proprietary license.</license.inlineheader>
               </files>
               <generateHybridTemplates>true</generateHybridTemplates>
             </connector>
-                              </connectors>
-                    <versions>true</versions>
+          </connectors>
+          <versionHistoryEnabled>true</versionHistoryEnabled>
         </configuration>
       </plugin>
     </plugins>

--- a/connectors/slack/pom.xml
+++ b/connectors/slack/pom.xml
@@ -98,8 +98,8 @@
               </files>
               <generateHybridTemplates>true</generateHybridTemplates>
             </connector>
-                              </connectors>
-                    <versions>true</versions>
+          </connectors>
+          <versionHistoryEnabled>true</versionHistoryEnabled>
         </configuration>
       </plugin>
     </plugins>

--- a/connectors/slack/pom.xml
+++ b/connectors/slack/pom.xml
@@ -98,7 +98,8 @@
               </files>
               <generateHybridTemplates>true</generateHybridTemplates>
             </connector>
-          </connectors>
+                              </connectors>
+                    <versions>true</versions>
         </configuration>
       </plugin>
     </plugins>

--- a/connectors/soap/pom.xml
+++ b/connectors/soap/pom.xml
@@ -180,8 +180,8 @@
               </files>
               <generateHybridTemplates>true</generateHybridTemplates>
             </connector>
-                              </connectors>
-                    <versions>true</versions>
+          </connectors>
+          <versionHistoryEnabled>true</versionHistoryEnabled>
         </configuration>
       </plugin>
     </plugins>

--- a/connectors/soap/pom.xml
+++ b/connectors/soap/pom.xml
@@ -180,7 +180,8 @@
               </files>
               <generateHybridTemplates>true</generateHybridTemplates>
             </connector>
-          </connectors>
+                              </connectors>
+                    <versions>true</versions>
         </configuration>
       </plugin>
     </plugins>

--- a/connectors/webhook/pom.xml
+++ b/connectors/webhook/pom.xml
@@ -110,8 +110,8 @@
                 <ACKNOWLEDGEMENT_STRATEGY_SELECTION>true</ACKNOWLEDGEMENT_STRATEGY_SELECTION>
               </features>
             </connector>
-                              </connectors>
-                    <versions>true</versions>
+          </connectors>
+          <versionHistoryEnabled>true</versionHistoryEnabled>
         </configuration>
       </plugin>
     </plugins>

--- a/connectors/webhook/pom.xml
+++ b/connectors/webhook/pom.xml
@@ -110,7 +110,8 @@
                 <ACKNOWLEDGEMENT_STRATEGY_SELECTION>true</ACKNOWLEDGEMENT_STRATEGY_SELECTION>
               </features>
             </connector>
-          </connectors>
+                              </connectors>
+                    <versions>true</versions>
         </configuration>
       </plugin>
     </plugins>

--- a/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/util/BasicElementTemplate.java
+++ b/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/util/BasicElementTemplate.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.generator.java.util;
+
+public record BasicElementTemplate(String id, Integer version) {}

--- a/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/util/VersionedElementTemplate.java
+++ b/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/util/VersionedElementTemplate.java
@@ -16,4 +16,4 @@
  */
 package io.camunda.connector.generator.java.util;
 
-public record BasicElementTemplate(String id, Integer version) {}
+public record VersionedElementTemplate(String id, Integer version) {}

--- a/element-template-generator/maven-plugin/src/main/java/io/camunda/connector/generator/ElementTemplateGeneratorMojo.java
+++ b/element-template-generator/maven-plugin/src/main/java/io/camunda/connector/generator/ElementTemplateGeneratorMojo.java
@@ -18,6 +18,7 @@ package io.camunda.connector.generator;
 
 import com.fasterxml.jackson.core.util.DefaultIndenter;
 import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
 import io.camunda.connector.api.inbound.InboundConnectorExecutable;
@@ -31,6 +32,7 @@ import io.camunda.connector.generator.api.GeneratorConfiguration.GenerationFeatu
 import io.camunda.connector.generator.dsl.ElementTemplate;
 import io.camunda.connector.generator.java.ClassBasedDocsGenerator;
 import io.camunda.connector.generator.java.ClassBasedTemplateGenerator;
+import io.camunda.connector.generator.java.util.BasicElementTemplate;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -42,11 +44,9 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoFailureException;
@@ -62,6 +62,16 @@ import org.apache.maven.project.MavenProject;
     requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME)
 public class ElementTemplateGeneratorMojo extends AbstractMojo {
 
+  private static final ObjectMapper objectMapper =
+      new ObjectMapper().disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+  private static final ObjectWriter objectWriter =
+      new ObjectMapper()
+          .writer(
+              new DefaultPrettyPrinter()
+                  .withObjectIndenter(new DefaultIndenter().withLinefeed("\n")));
+  private static final String COMPILED_CLASSES_DIR = "target" + File.separator + "classes";
+  private static final String HYBRID_TEMPLATES_DIR = "hybrid";
+
   @Parameter(defaultValue = "${project}", readonly = true, required = true)
   private MavenProject project;
 
@@ -74,14 +84,21 @@ public class ElementTemplateGeneratorMojo extends AbstractMojo {
   @Parameter(property = "outputDirectory", defaultValue = "${project.basedir}/element-templates")
   private String outputDirectory;
 
-  private static final ObjectWriter objectWriter =
-      new ObjectMapper()
-          .writer(
-              new DefaultPrettyPrinter()
-                  .withObjectIndenter(new DefaultIndenter().withLinefeed("\n")));
+  @Parameter(
+      property = "versionedDirectory",
+      defaultValue = "${project.basedir}/element-templates/versioned")
+  private String versionedDirectory;
 
-  private static final String COMPILED_CLASSES_DIR = "target" + File.separator + "classes";
-  private static final String HYBRID_TEMPLATES_DIR = "hybrid";
+  @Parameter(property = "versions", defaultValue = "false")
+  private Boolean versions;
+
+  private static BasicElementTemplate getBasicElementTemplate(File file) {
+    try {
+      return objectMapper.readValue(file, BasicElementTemplate.class);
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
 
   @Override
   public void execute() throws MojoFailureException {
@@ -263,7 +280,6 @@ public class ElementTemplateGeneratorMojo extends AbstractMojo {
     var generator = new ClassBasedTemplateGenerator(classLoader);
     var templates = generator.generate(clazz, generatorConfig);
     writeElementTemplates(templates, false, config.getFiles());
-
     if (config.isGenerateHybridTemplates()) {
       var hybridGeneratorConfig =
           new GeneratorConfiguration(ConnectorMode.HYBRID, null, null, null, null, features);
@@ -274,10 +290,59 @@ public class ElementTemplateGeneratorMojo extends AbstractMojo {
 
   private void writeElementTemplates(
       List<ElementTemplate> templates, boolean hybrid, List<FileNameById> fileNames) {
+    List<BasicElementTemplate> versionedElementTemplates = retrieveBasicElementTemplates();
     for (var template : templates) {
       var fileName = determineFileName(template, fileNames, hybrid);
+      if (versions && !hybrid) manageVersions(template, versionedElementTemplates, fileName);
       writeElementTemplate(template, hybrid, fileName);
     }
+  }
+
+  private void manageVersions(
+      ElementTemplate template,
+      List<BasicElementTemplate> versionedElementTemplates,
+      String fileName) {
+    BasicElementTemplate latestBasicElementTemplate =
+        new BasicElementTemplate(template.id(), template.version());
+    if (versionedElementTemplates.stream().noneMatch(latestBasicElementTemplate::equals)) {
+      copyLatestBasicElementTemplate(fileName);
+    }
+  }
+
+  private void copyLatestBasicElementTemplate(String fileName) {
+    File latestBasicElementTemplateFile = new File(this.outputDirectory, fileName);
+    try {
+      BasicElementTemplate latestBasicElementTemplate =
+          objectMapper.readValue(latestBasicElementTemplateFile, BasicElementTemplate.class);
+      Files.copy(
+          latestBasicElementTemplateFile.toPath(),
+          Path.of(
+              this.versionedDirectory
+                  + File.separator
+                  + fileName.replaceFirst(".json", "")
+                  + "-"
+                  + latestBasicElementTemplate.version()
+                  + ".json"));
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private List<BasicElementTemplate> retrieveBasicElementTemplates() {
+    File classicFolder = new File(this.outputDirectory);
+    File versionedFolder = new File(this.versionedDirectory);
+    Optional<File[]> listClassicFiles =
+        Optional.ofNullable(
+            classicFolder.listFiles((dir, name) -> name.toLowerCase().endsWith(".json")));
+    Optional<File[]> listVersionedFiles =
+        Optional.ofNullable(
+            versionedFolder.listFiles((dir, name) -> name.toLowerCase().endsWith(".json")));
+    return Stream.concat(
+            Arrays.stream(listClassicFiles.orElse(new File[0])),
+            Arrays.stream(listVersionedFiles.orElse(new File[0])))
+        .filter(File::isFile)
+        .map(ElementTemplateGeneratorMojo::getBasicElementTemplate)
+        .toList();
   }
 
   private String determineFileName(


### PR DESCRIPTION
## Description

versions history are now managed by the element template generator

## Related issues

closes https://github.com/camunda/connectors/issues/4693

## Checklist

- [ ] PR has a **milestone** or the `no milestone` label.

