### PR TITLE
fix(agentic-ai): rename Limits back to Guardrails & make request data handling more resilient

### DIFF
--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/AiAgentTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/AiAgentTests.java
@@ -573,7 +573,7 @@ public class AiAgentTests extends BaseAgenticAiTest {
   }
 
   @Nested
-  class Limits {
+  class Guardrails {
 
     @Test
     void raisesIncidentWhenMaximumModelCallsAreReached() throws IOException {

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/resources/agentic-ai-connectors.bpmn
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/resources/agentic-ai-connectors.bpmn
@@ -165,7 +165,7 @@
           <zeebe:input source="Agent_Tools" target="data.tools.containerElementId" />
           <zeebe:input source="=toolCallResults" target="data.tools.toolCallResults" />
           <zeebe:input source="=50" target="data.memory.maxMessages" />
-          <zeebe:input source="=10" target="data.limits.maxModelCalls" />
+          <zeebe:input source="=10" target="data.guardrails.maxModelCalls" />
           <zeebe:input source="=8192" target="provider.openai.model.parameters.maxOutputTokens" />
           <zeebe:input source="=0.8" target="provider.openai.model.parameters.temperature" />
           <zeebe:input source="=1" target="provider.openai.model.parameters.topP" />

--- a/connectors/agentic-ai/element-templates/agenticai-aiagent-outbound-connector.json
+++ b/connectors/agentic-ai/element-templates/agenticai-aiagent-outbound-connector.json
@@ -36,8 +36,8 @@
     "label" : "Memory",
     "tooltip" : "Configuration of the Agent's short-term memory."
   }, {
-    "id" : "limits",
-    "label" : "Limits"
+    "id" : "guardrails",
+    "label" : "Guardrails"
   }, {
     "id" : "parameters",
     "label" : "Model Parameters",
@@ -486,7 +486,7 @@
     },
     "type" : "Number"
   }, {
-    "id" : "data.limits.maxModelCalls",
+    "id" : "data.guardrails.maxModelCalls",
     "label" : "Maximum model calls",
     "description" : "Maximum number of calls to the model as a safety limit to prevent infinite loops.",
     "optional" : false,
@@ -495,9 +495,9 @@
       "notEmpty" : true
     },
     "feel" : "static",
-    "group" : "limits",
+    "group" : "guardrails",
     "binding" : {
-      "name" : "data.limits.maxModelCalls",
+      "name" : "data.guardrails.maxModelCalls",
       "type" : "zeebe:input"
     },
     "type" : "Number"

--- a/connectors/agentic-ai/element-templates/hybrid/agenticai-aiagent-outbound-connector-hybrid.json
+++ b/connectors/agentic-ai/element-templates/hybrid/agenticai-aiagent-outbound-connector-hybrid.json
@@ -39,8 +39,8 @@
     "label" : "Memory",
     "tooltip" : "Configuration of the Agent's short-term memory."
   }, {
-    "id" : "limits",
-    "label" : "Limits"
+    "id" : "guardrails",
+    "label" : "Guardrails"
   }, {
     "id" : "parameters",
     "label" : "Model Parameters",
@@ -491,7 +491,7 @@
     },
     "type" : "Number"
   }, {
-    "id" : "data.limits.maxModelCalls",
+    "id" : "data.guardrails.maxModelCalls",
     "label" : "Maximum model calls",
     "description" : "Maximum number of calls to the model as a safety limit to prevent infinite loops.",
     "optional" : false,
@@ -500,9 +500,9 @@
       "notEmpty" : true
     },
     "feel" : "static",
-    "group" : "limits",
+    "group" : "guardrails",
     "binding" : {
-      "name" : "data.limits.maxModelCalls",
+      "name" : "data.guardrails.maxModelCalls",
       "type" : "zeebe:input"
     },
     "type" : "Number"

--- a/connectors/agentic-ai/examples/ai-agent-chat-with-tools/ai-agent-chat-with-tools.bpmn
+++ b/connectors/agentic-ai/examples/ai-agent-chat-with-tools/ai-agent-chat-with-tools.bpmn
@@ -25,7 +25,7 @@
           <zeebe:input source="Agent_Tools" target="data.tools.containerElementId" />
           <zeebe:input source="=toolCallResults" target="data.tools.toolCallResults" />
           <zeebe:input source="=20" target="data.memory.maxMessages" />
-          <zeebe:input source="=20" target="data.limits.maxModelCalls" />
+          <zeebe:input source="=20" target="data.guardrails.maxModelCalls" />
           <zeebe:input source="=8192" target="provider.bedrock.model.parameters.maxOutputTokens" />
         </zeebe:ioMapping>
         <zeebe:taskHeaders>
@@ -267,7 +267,7 @@
       <bpmn:text>Rough outline of the functionality
 
 - Loads previous memory from provided variables
-- Checks limits (e.g. maximum LLM model calls)
+- Checks guardrails (e.g. maximum LLM model calls)
 - Loads available tool information from ad-hoc subprocess definition
 - Merges the current request (either a user message or a tool call response) into the memory
 - Calls the LLM, including previous/edited memory + available tools schema

--- a/connectors/agentic-ai/examples/fraud-detection/fraud-detection-process.bpmn
+++ b/connectors/agentic-ai/examples/fraud-detection/fraud-detection-process.bpmn
@@ -186,7 +186,7 @@
           <zeebe:input source="Fraud_Tools" target="data.tools.containerElementId" />
           <zeebe:input source="=toolCallResults" target="data.tools.toolCallResults" />
           <zeebe:input source="=20" target="data.memory.maxMessages" />
-          <zeebe:input source="=20" target="data.limits.maxModelCalls" />
+          <zeebe:input source="=20" target="data.guardrails.maxModelCalls" />
           <zeebe:input source="=8192" target="provider.bedrock.model.parameters.maxOutputTokens" />
         </zeebe:ioMapping>
         <zeebe:taskHeaders>

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/AiAgentFunction.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/AiAgentFunction.java
@@ -39,7 +39,7 @@ import io.camunda.connector.generator.java.annotation.ElementTemplate.PropertyGr
           id = "memory",
           label = "Memory",
           tooltip = "Configuration of the Agent's short-term memory."),
-      @PropertyGroup(id = "limits", label = "Limits"),
+      @PropertyGroup(id = "guardrails", label = "Guardrails"),
       @PropertyGroup(
           id = "parameters",
           label = "Model Parameters",

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/agent/DefaultAiAgentRequestHandler.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/agent/DefaultAiAgentRequestHandler.java
@@ -26,6 +26,7 @@ import io.camunda.connector.agenticai.aiagent.model.AgentResponse;
 import io.camunda.connector.agenticai.aiagent.model.AgentState;
 import io.camunda.connector.agenticai.aiagent.model.request.AgentRequest;
 import io.camunda.connector.agenticai.aiagent.model.request.AgentRequest.AgentRequestData.GuardrailsConfiguration;
+import io.camunda.connector.agenticai.aiagent.model.request.AgentRequest.AgentRequestData.MemoryConfiguration;
 import io.camunda.connector.agenticai.aiagent.model.request.AgentRequest.AgentRequestData.PromptConfiguration;
 import io.camunda.connector.agenticai.aiagent.model.request.AgentRequest.AgentRequestData.ToolsConfiguration;
 import io.camunda.connector.agenticai.aiagent.provider.ChatModelFactory;
@@ -85,7 +86,8 @@ public class DefaultAiAgentRequestHandler implements AiAgentRequestHandler {
     final ChatMemory chatMemory =
         MessageWindowChatMemory.builder()
             .maxMessages(
-                Optional.ofNullable(requestData.memory().maxMessages())
+                Optional.ofNullable(requestData.memory())
+                    .map(MemoryConfiguration::maxMessages)
                     .orElse(DEFAULT_MAX_MEMORY_MESSAGES))
             .chatMemoryStore(chatMemoryStore)
             .build();

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/AgentRequest.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/AgentRequest.java
@@ -38,7 +38,7 @@ public record AgentRequest(
       @Valid @NotNull UserPromptConfiguration userPrompt,
       @Valid @NotNull ToolsConfiguration tools,
       @Valid @NotNull MemoryConfiguration memory,
-      @Valid @NotNull LimitsConfiguration limits) {
+      @Valid GuardrailsConfiguration guardrails) {
 
     public interface PromptConfiguration {
       String PROMPT_PARAMETERS_DESCRIPTION =
@@ -153,10 +153,10 @@ Reveal **no** additional private reasoning outside these tags.
             @Min(3)
             Integer maxMessages) {}
 
-    public record LimitsConfiguration(
-        // TODO think of other limits (max tool calls, max tokens, ...)
+    public record GuardrailsConfiguration(
+        // TODO think of other guardrails (max tool calls, max tokens, ...)
         @TemplateProperty(
-                group = "limits",
+                group = "guardrails",
                 label = "Maximum model calls",
                 description =
                     "Maximum number of calls to the model as a safety limit to prevent infinite loops.",

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/AgentRequest.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/AgentRequest.java
@@ -36,8 +36,8 @@ public record AgentRequest(
           AgentContext context,
       @Valid @NotNull SystemPromptConfiguration systemPrompt,
       @Valid @NotNull UserPromptConfiguration userPrompt,
-      @Valid @NotNull ToolsConfiguration tools,
-      @Valid @NotNull MemoryConfiguration memory,
+      @Valid ToolsConfiguration tools,
+      @Valid MemoryConfiguration memory,
       @Valid GuardrailsConfiguration guardrails) {
 
     public interface PromptConfiguration {


### PR DESCRIPTION
## Description

- Rename `Limits` back to `Guardrails` for now (we'll rename this back in a follow-up issue)
- Make resolving limits, tools, memory settings more resilient (do not fail if the request object is null)

## Related issues

based on https://github.com/camunda/connectors/pull/4722

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.

