### PR TITLE
fix(agentic-ai): resilient optional configuration (tools, memory, limits) handling

### DIFF
--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/BaseAgenticAiTest.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/BaseAgenticAiTest.java
@@ -25,9 +25,15 @@ import io.camunda.connector.e2e.ZeebeTest;
 import io.camunda.connector.e2e.app.TestConnectorRuntimeApplication;
 import io.camunda.process.test.api.CamundaSpringProcessTest;
 import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.model.bpmn.instance.ServiceTask;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeInput;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeIoMapping;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.Map;
+import java.util.function.Function;
+import java.util.function.Predicate;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -45,7 +51,8 @@ import org.springframework.core.io.Resource;
 @CamundaSpringProcessTest
 public abstract class BaseAgenticAiTest {
 
-  public static final String PROCESS_DEFINITION_ID = "Agentic_AI_Connectors";
+  static final String PROCESS_DEFINITION_ID = "Agentic_AI_Connectors";
+  static final String AI_AGENT_TASK_ID = "AI_Agent";
 
   @Autowired CamundaClient camundaClient;
   @Autowired ObjectMapper objectMapper;
@@ -54,13 +61,22 @@ public abstract class BaseAgenticAiTest {
   Resource process;
 
   protected ZeebeTest createProcessInstance(Map<String, Object> variables) throws IOException {
-    return deployModel().createInstance(variables);
+    return createProcessInstance(m -> m, variables);
   }
 
-  protected ZeebeTest deployModel() throws IOException {
-    final var model = Bpmn.readModelFromFile(process.getFile());
+  protected ZeebeTest createProcessInstance(
+      Function<BpmnModelInstance, BpmnModelInstance> modelModifier, Map<String, Object> variables)
+      throws IOException {
+    return deployModel(modelModifier).createInstance(variables);
+  }
 
-    ZeebeTest zeebeTest = ZeebeTest.with(camundaClient).awaitCompleteTopology().deploy(model);
+  protected ZeebeTest deployModel(Function<BpmnModelInstance, BpmnModelInstance> modelModifier)
+      throws IOException {
+    final var originalModel = Bpmn.readModelFromFile(process.getFile());
+    final var modifiedModel = modelModifier.apply(originalModel);
+
+    ZeebeTest zeebeTest =
+        ZeebeTest.with(camundaClient).awaitCompleteTopology().deploy(modifiedModel);
 
     await()
         .pollInSameThread()
@@ -78,5 +94,18 @@ public abstract class BaseAgenticAiTest {
             });
 
     return zeebeTest;
+  }
+
+  protected Function<BpmnModelInstance, BpmnModelInstance> withoutInputsMatching(
+      Predicate<ZeebeInput> filter) {
+    return (model) -> {
+      final ServiceTask aiAgentTask = model.getModelElementById(AI_AGENT_TASK_ID);
+      final var inputs = aiAgentTask.getSingleExtensionElement(ZeebeIoMapping.class).getInputs();
+
+      final var toRemove = inputs.stream().filter(filter).toList();
+      inputs.removeAll(toRemove);
+
+      return model;
+    };
   }
 }

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/resources/agentic-ai-connectors.bpmn
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/resources/agentic-ai-connectors.bpmn
@@ -165,7 +165,7 @@
           <zeebe:input source="Agent_Tools" target="data.tools.containerElementId" />
           <zeebe:input source="=toolCallResults" target="data.tools.toolCallResults" />
           <zeebe:input source="=50" target="data.memory.maxMessages" />
-          <zeebe:input source="=10" target="data.limits.maxModelCalls" />
+          <zeebe:input source="=9" target="data.limits.maxModelCalls" />
           <zeebe:input source="=8192" target="provider.openai.model.parameters.maxOutputTokens" />
           <zeebe:input source="=0.8" target="provider.openai.model.parameters.temperature" />
           <zeebe:input source="=1" target="provider.openai.model.parameters.topP" />

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/agent/DefaultAiAgentRequestHandler.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/agent/DefaultAiAgentRequestHandler.java
@@ -25,6 +25,8 @@ import io.camunda.connector.agenticai.aiagent.model.AgentMetrics;
 import io.camunda.connector.agenticai.aiagent.model.AgentResponse;
 import io.camunda.connector.agenticai.aiagent.model.AgentState;
 import io.camunda.connector.agenticai.aiagent.model.request.AgentRequest;
+import io.camunda.connector.agenticai.aiagent.model.request.AgentRequest.AgentRequestData.LimitsConfiguration;
+import io.camunda.connector.agenticai.aiagent.model.request.AgentRequest.AgentRequestData.MemoryConfiguration;
 import io.camunda.connector.agenticai.aiagent.model.request.AgentRequest.AgentRequestData.PromptConfiguration;
 import io.camunda.connector.agenticai.aiagent.model.request.AgentRequest.AgentRequestData.ToolsConfiguration;
 import io.camunda.connector.agenticai.aiagent.provider.ChatModelFactory;
@@ -84,7 +86,8 @@ public class DefaultAiAgentRequestHandler implements AiAgentRequestHandler {
     final ChatMemory chatMemory =
         MessageWindowChatMemory.builder()
             .maxMessages(
-                Optional.ofNullable(requestData.memory().maxMessages())
+                Optional.ofNullable(requestData.memory())
+                    .map(MemoryConfiguration::maxMessages)
                     .orElse(DEFAULT_MAX_MEMORY_MESSAGES))
             .chatMemoryStore(chatMemoryStore)
             .build();
@@ -129,7 +132,9 @@ public class DefaultAiAgentRequestHandler implements AiAgentRequestHandler {
 
   private void checkLimits(AgentRequest.AgentRequestData requestData, AgentContext agentContext) {
     final int maxModelCalls =
-        Optional.ofNullable(requestData.limits().maxModelCalls()).orElse(DEFAULT_MAX_MODEL_CALLS);
+        Optional.ofNullable(requestData.limits())
+            .map(LimitsConfiguration::maxModelCalls)
+            .orElse(DEFAULT_MAX_MODEL_CALLS);
     if (agentContext.metrics().modelCalls() >= maxModelCalls) {
       throw new ConnectorException(
           ERROR_CODE_MAXIMUM_NUMBER_OF_MODEL_CALLS_REACHED,

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/AgentRequest.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/AgentRequest.java
@@ -36,9 +36,9 @@ public record AgentRequest(
           AgentContext context,
       @Valid @NotNull SystemPromptConfiguration systemPrompt,
       @Valid @NotNull UserPromptConfiguration userPrompt,
-      @Valid @NotNull ToolsConfiguration tools,
-      @Valid @NotNull MemoryConfiguration memory,
-      @Valid @NotNull LimitsConfiguration limits) {
+      @Valid ToolsConfiguration tools,
+      @Valid MemoryConfiguration memory,
+      @Valid LimitsConfiguration limits) {
 
     public interface PromptConfiguration {
       String PROMPT_PARAMETERS_DESCRIPTION =


### PR DESCRIPTION
## Description

- Make configuration of tools, memory settings and limits optional & do not fail if the request object is null
- Add e2e tests verifying that the connector still works when none of these settings is set and that the max model calls limit falls back to a default value of 10

## Related issues

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.

