### PR TITLE
fix(email-connector): add correlation result management and and stop removing the brackets from messageID

### DIFF
--- a/connectors/email/src/main/java/io/camunda/connector/email/client/jakarta/inbound/PollingManager.java
+++ b/connectors/email/src/main/java/io/camunda/connector/email/client/jakarta/inbound/PollingManager.java
@@ -52,6 +52,19 @@ public class PollingManager {
     this.store = store;
   }
 
+  private static ReadEmailResponse createResponse(Email email, List<Document> documents) {
+    return new ReadEmailResponse(
+        email.messageId(),
+        email.from(),
+        email.headers(),
+        email.subject(),
+        email.size(),
+        email.body().bodyAsPlainText(),
+        email.body().bodyAsHtml(),
+        documents,
+        email.receivedAt());
+  }
+
   public static PollingManager create(
       InboundConnectorContext connectorContext, JakartaUtils jakartaUtils) {
     Store store = null;
@@ -87,6 +100,57 @@ public class PollingManager {
       }
       throw new RuntimeException(e);
     }
+  }
+
+  private List<Document> createDocumentList(Email email) {
+    return email.body().attachments().stream()
+        .map(
+            document ->
+                this.connectorContext.create(
+                    DocumentCreationRequest.from(document.inputStream())
+                        .contentType(document.contentType())
+                        .fileName(document.name())
+                        .build()))
+        .toList();
+  }
+
+  private boolean correlate(Email email) {
+    List<Document> documents = createDocumentList(email);
+    CorrelationRequest correlationRequest =
+        CorrelationRequest.builder()
+            .variables(createResponse(email, documents))
+            .messageId(email.messageId())
+            .build();
+    return switch (this.connectorContext.correlate(correlationRequest)) {
+      case CorrelationResult.Failure failure ->
+          switch (failure.handlingStrategy()) {
+            case CorrelationFailureHandlingStrategy.ForwardErrorToUpstream ignored -> {
+              this.connectorContext.log(
+                  Activity.level(Severity.ERROR)
+                      .tag("ForwardErrorToUpstream")
+                      .message(
+                          "Error processing mail: %s, message %s"
+                              .formatted(email.messageId(), failure.message())));
+              yield false;
+            }
+            case CorrelationFailureHandlingStrategy.Ignore ignored -> {
+              this.connectorContext.log(
+                  Activity.level(Severity.INFO)
+                      .tag("Ignore")
+                      .message(
+                          "No activation condition was met for email: %s. `Consume unmatched event` was selected. Continuing.."
+                              .formatted(email.messageId())));
+              yield true;
+            }
+          };
+      case CorrelationResult.Success ignored -> {
+        this.connectorContext.log(
+            Activity.level(Severity.INFO)
+                .tag("Success")
+                .message("Correlated email: %s".formatted(email.messageId())));
+        yield true;
+      }
+    };
   }
 
   public void poll() {
@@ -150,62 +214,62 @@ public class PollingManager {
     // Setting `peek` to true prevents the library to trigger any side effects when reading the
     // message, such as marking it as read
     message.setPeek(true);
-    this.correlateEmail(message, connectorContext);
+    Email email = this.jakartaUtils.createEmail(message);
+    boolean markAsProcessed = process(email);
     message.setPeek(false);
-    switch (pollingConfig.handlingStrategy()) {
-      case READ -> this.jakartaUtils.markAsSeen(message);
-      case DELETE -> this.jakartaUtils.markAsDeleted(message);
-      case MOVE -> {
-        this.jakartaUtils.markAsSeen(message);
-        this.jakartaUtils.moveMessage(this.store, message, pollingConfig.targetFolder());
+    if (markAsProcessed) {
+      switch (pollingConfig.handlingStrategy()) {
+        case READ -> this.jakartaUtils.markAsSeen(message);
+        case DELETE -> this.jakartaUtils.markAsDeleted(message);
+        case MOVE -> {
+          this.jakartaUtils.markAsSeen(message);
+          this.jakartaUtils.moveMessage(this.store, message, pollingConfig.targetFolder());
+        }
       }
     }
   }
 
-  private void correlateEmail(Message message, InboundConnectorContext connectorContext) {
-    Email email = this.jakartaUtils.createEmail(message);
-    List<Document> documents = this.createDocumentList(email, connectorContext);
-    connectorContext.correlate(
-        CorrelationRequest.builder()
-            .variables(
-                new ReadEmailResponse(
-                    email.messageId(),
-                    email.from(),
-                    email.headers(),
-                    email.subject(),
-                    email.size(),
-                    email.body().bodyAsPlainText(),
-                    email.body().bodyAsHtml(),
-                    documents,
-                    email.receivedAt()))
-            .messageId(email.messageId())
-            .build());
-  }
-
-  private List<Document> createDocumentList(Email email, InboundConnectorContext connectorContext) {
-    if (!(connectorContext.canActivate(
-            new ReadEmailResponse(
-                email.messageId(),
-                email.from(),
-                email.headers(),
-                email.subject(),
-                email.size(),
-                email.body().bodyAsPlainText(),
-                email.body().bodyAsHtml(),
-                List.of(),
-                email.receivedAt()))
-        instanceof ActivationCheckResult.Success)) {
-      return List.of();
-    } else
-      return email.body().attachments().stream()
-          .map(
-              document ->
-                  connectorContext.create(
-                      DocumentCreationRequest.from(document.inputStream())
-                          .contentType(document.contentType())
-                          .fileName(document.name())
-                          .build()))
-          .toList();
+  private boolean process(Email email) {
+    this.connectorContext.log(
+        Activity.level(Severity.INFO)
+            .tag("new-email")
+            .message("Processing email: %s".formatted(email.messageId())));
+    ActivationCheckResult activationCheckResult =
+        this.connectorContext.canActivate(createResponse(email, List.of()));
+    return switch (activationCheckResult) {
+      case ActivationCheckResult.Failure failure ->
+          switch (failure) {
+            case ActivationCheckResult.Failure.NoMatchingElement noMatchingElement -> {
+              if (noMatchingElement.discardUnmatchedEvents()) {
+                this.connectorContext.log(
+                    Activity.level(Severity.INFO)
+                        .tag("NoMatchingElement")
+                        .message(
+                            "No matching activation condition. Discarding unmatched email: %s"
+                                .formatted(email.messageId())));
+                yield true;
+              } else {
+                this.connectorContext.log(
+                    Activity.level(Severity.INFO)
+                        .tag("NoMatchingElement")
+                        .message(
+                            "No matching activation condition. Not discarding unmatched email: %s"
+                                .formatted(email.messageId())));
+                yield false;
+              }
+            }
+            case ActivationCheckResult.Failure.TooManyMatchingElements ignored -> {
+              this.connectorContext.log(
+                  Activity.level(Severity.ERROR)
+                      .tag("TooManyMatchingElements")
+                      .message(
+                          "Too many matching activation conditions. Email: %s"
+                              .formatted(email.messageId())));
+              yield false;
+            }
+          };
+      case ActivationCheckResult.Success ignored -> correlate(email);
+    };
   }
 
   public long delay() {

--- a/connectors/email/src/main/java/io/camunda/connector/email/client/jakarta/utils/JakartaUtils.java
+++ b/connectors/email/src/main/java/io/camunda/connector/email/client/jakarta/utils/JakartaUtils.java
@@ -284,8 +284,8 @@ public class JakartaUtils {
       throws MessagingException, IOException {
     BodyPart bodyPart = multipart.getBodyPart(i);
     switch (bodyPart.getContent()) {
-      case InputStream attachment when Part.ATTACHMENT.equalsIgnoreCase(
-              bodyPart.getDisposition()) ->
+      case InputStream attachment
+          when Part.ATTACHMENT.equalsIgnoreCase(bodyPart.getDisposition()) ->
           emailBodyBuilder.addAttachment(
               new EmailAttachment(
                   attachment,
@@ -313,13 +313,10 @@ public class JakartaUtils {
   private String getMessageId(Message message) {
     try {
       String[] messageIds = message.getHeader("Message-ID");
-      if (messageIds.length != 0) {
-        return messageIds[0];
-      }
+      return (messageIds != null && messageIds.length > 0) ? messageIds[0] : null;
     } catch (MessagingException e) {
       throw new RuntimeException(e);
     }
-    return null;
   }
 
   public void moveMessage(Store store, Message message, String targetFolder) {

--- a/connectors/email/src/main/java/io/camunda/connector/email/client/jakarta/utils/JakartaUtils.java
+++ b/connectors/email/src/main/java/io/camunda/connector/email/client/jakarta/utils/JakartaUtils.java
@@ -220,7 +220,7 @@ public class JakartaUtils {
           Collections.list(message.getAllHeaders()).stream()
               .map(header -> new Header(header.getName(), header.getValue()))
               .toList();
-      String messageId = stripMessageId(message.getHeader("Message-ID")[0]);
+      String messageId = getMessageId(message);
       return new Email(
           null,
           messageId,
@@ -310,9 +310,16 @@ public class JakartaUtils {
     }
   }
 
-  private String stripMessageId(String messageId) {
-    if (messageId == null) return null;
-    return messageId.trim().replaceAll("[<>]", "");
+  private String getMessageId(Message message) {
+    try {
+      String[] messageIds = message.getHeader("Message-ID");
+      if (messageIds.length != 0) {
+        return messageIds[0];
+      }
+    } catch (MessagingException e) {
+      throw new RuntimeException(e);
+    }
+    return null;
   }
 
   public void moveMessage(Store store, Message message, String targetFolder) {

--- a/connectors/email/src/test/java/io/camunda/connector/email/client/jakarta/PollingManagerTest.java
+++ b/connectors/email/src/test/java/io/camunda/connector/email/client/jakarta/PollingManagerTest.java
@@ -9,6 +9,8 @@ package io.camunda.connector.email.client.jakarta;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
+import io.camunda.connector.api.inbound.ActivationCheckResult;
+import io.camunda.connector.api.inbound.CorrelationResult;
 import io.camunda.connector.api.inbound.InboundConnectorContext;
 import io.camunda.connector.email.authentication.Authentication;
 import io.camunda.connector.email.authentication.SimpleAuthentication;
@@ -69,6 +71,10 @@ class PollingManagerTest {
             .createTestMessage();
 
     when(connectorContext.bindProperties(any())).thenReturn(emailInboundConnectorProperties);
+    when(connectorContext.canActivate(any()))
+        .thenReturn(new ActivationCheckResult.Success.CanActivate(null));
+    when(connectorContext.correlate(any()))
+        .thenReturn(new CorrelationResult.Success.ProcessInstanceCreated(null, null, null));
     when(emailInboundConnectorProperties.authentication()).thenReturn(authentication);
     when(emailInboundConnectorProperties.data()).thenReturn(emailListenerConfig);
     when(jakartaUtils.createSession(any())).thenReturn(session);

--- a/connectors/email/src/test/java/io/camunda/connector/email/integration/BaseEmailTest.java
+++ b/connectors/email/src/test/java/io/camunda/connector/email/integration/BaseEmailTest.java
@@ -214,8 +214,7 @@ public class BaseEmailTest {
   protected String getLastMessageId() {
     Message message = getLastReceivedEmails()[0];
     try {
-      String messageId = message.getHeader("Message-ID")[0];
-      return messageId.trim().replaceAll("[<>]", "");
+      return message.getHeader("Message-ID")[0];
     } catch (MessagingException e) {
       throw new RuntimeException(e);
     }

--- a/connectors/email/src/test/java/io/camunda/connector/email/integration/InboundEmailTest.java
+++ b/connectors/email/src/test/java/io/camunda/connector/email/integration/InboundEmailTest.java
@@ -12,6 +12,8 @@ import static org.mockito.Mockito.*;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.connector.api.inbound.ActivationCheckResult;
+import io.camunda.connector.api.inbound.CorrelationResult;
 import io.camunda.connector.api.inbound.InboundConnectorContext;
 import io.camunda.connector.email.client.jakarta.inbound.JakartaEmailListener;
 import io.camunda.connector.email.config.CryptographicProtocol;
@@ -87,8 +89,13 @@ public class InboundEmailTest extends BaseEmailTest {
                 emailInboundConnectorProperties.data().pollingWaitTime(),
                 emailInboundConnectorProperties.data().pollingConfig()));
 
+    doNothing().when(inboundConnectorContext).log(any());
     when(inboundConnectorContext.bindProperties(EmailInboundConnectorProperties.class))
         .thenReturn(emailInboundConnectorProperties1);
+    when(inboundConnectorContext.correlate(any()))
+        .thenReturn(new CorrelationResult.Success.ProcessInstanceCreated(null, null, null));
+    when(inboundConnectorContext.canActivate(any()))
+        .thenReturn(new ActivationCheckResult.Success.CanActivate(null));
 
     this.jakartaEmailListener.startListener(inboundConnectorContext);
 


### PR DESCRIPTION
## Description

Fix:

- CorrelationResult is now properly managed.
- MessageId is not stripped from its brackets

## Related issues

closes https://github.com/camunda/connectors/issues/4740

## Checklist

- [ ] PR has a **milestone** or the `no milestone` label.

