### PR TITLE
chore(fossa): check PRs for newly introduced license issues

### DIFF
--- a/.github/workflows/CHECK_LICENSES.yml
+++ b/.github/workflows/CHECK_LICENSES.yml
@@ -7,6 +7,10 @@ on:
     - release/*
     tags:
     - '*'
+  pull_request:
+    types:
+    - opened
+    - synchronize
 
 jobs:
   analyze:
@@ -52,7 +56,10 @@ jobs:
           }]
         mirrors: '[{"url": "https://repository.nexus.camunda.cloud/content/groups/internal/", "id": "camunda-nexus", "mirrorOf": "*,!confluent,!shibboleth", "name": "camunda Nexus"}]'
     - name: Setup fossa-cli
-      uses: camunda/infra-global-github-actions/fossa/setup@main
+      uses: camunda/infra-global-github-actions/fossa/setup@0e82486eaa9ef8589e051c556a1b5218efa6d37f
+    - name: Get context info
+      id: info
+      uses: camunda/infra-global-github-actions/fossa/info@0e82486eaa9ef8589e051c556a1b5218efa6d37f
     - name: Adjust pom.xml files for FOSSA
       run: |
         # The parent/pom.xml must be the actual root, otherwise, FOSSA won't detect the hierarchy correctly
@@ -64,8 +71,19 @@ jobs:
           'del(.project.modules.module[] | select(. == "parent"))' \
           pom.xml
     - name: Analyze project
-      uses: camunda/infra-global-github-actions/fossa/analyze@main
+      uses: camunda/infra-global-github-actions/fossa/analyze@0e82486eaa9ef8589e051c556a1b5218efa6d37f
       with:
         api-key: ${{ steps.secrets.outputs.FOSSA_API_KEY }}
-        branch: ${{ github.ref_name }}
-        revision-id: ${{ github.sha }}
+        branch: ${{  steps.info.outputs.head-ref }}
+        revision-id: ${{ steps.info.outputs.head-revision }}
+    # PR-only: Check for newly introduced license issues
+    # This step only fails if the PR introduces new license violations.
+    # It does not fail for pre-existing issues already present in the base branch.
+    - name: Check Pull Request for new License Issues
+      if: steps.info.outputs.is-pull-request == 'true'
+      uses: camunda/infra-global-github-actions/fossa/pr-check@0e82486eaa9ef8589e051c556a1b5218efa6d37f
+      with:
+        api-key: ${{ steps.secrets.outputs.FOSSA_API_KEY }}
+        base-ref: ${{ steps.info.outputs.base-ref }}
+        base-revision: ${{ steps.info.outputs.base-revision }}
+        revision: ${{ steps.info.outputs.head-revision }}


### PR DESCRIPTION
## Description

Related to https://github.com/camunda/team-infrastructure/issues/752.

This PR introduces a new job step in `check-licenses.yml` workflow that runs only on pull requests, and checks for newly introduced license policy violations, such as those from new dependencies or updated versions:
- if license issues are found, they are listed in the logs with actionable links to the FOSSA dashboard and Confluence [page](https://confluence.camunda.com/spaces/HAN/pages/277024795/FOSSA#FOSSA-Handlelicenseissues)
- a job annotation is added for visibility, showing `License Check: X issues found. Please check the logs and resolve before merging`
- the step does not fail for pre-existing license issues in the base branch

The job waits for the FOSSA analysis to complete, which typically takes under a minute. If additional dependency scans (at file-level) are required (if results for a new dependency/version are not already in FOSSA's shared database), it may take an extra 3–4 minutes.

Scans for references like `main`, `self-managed/*`, and `tags` are not affected by this change.

TL;DR; FOSSA License analyses (file-level scan) are currently run only on `main`, `self-managed/*`, and tags. This change adds analysis for pull requests, including a policy violation check. It helps support shift-left license compliance (via FOSSA) by catching issues directly at the PR level.

Test workflow run (introducing a temporary issue): https://github.com/camunda/connectors/actions/runs/14971392933

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #

## Checklist

- [ ] PR has a **milestone** or the `no milestone` label.

