### PR TITLE
others(test): add e2e tests for email inbound connector, and verify email is not consumed when activation is not matching

### DIFF
--- a/connectors-e2e-test/connectors-e2e-email/pom.xml
+++ b/connectors-e2e-test/connectors-e2e-email/pom.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.camunda.connector</groupId>
+        <artifactId>connectors-e2e-test-parent</artifactId>
+        <version>8.8.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>connectors-e2e-email</artifactId>
+
+    <properties>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.camunda.connector</groupId>
+            <artifactId>connector-email</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.icegreen</groupId>
+            <artifactId>greenmail</artifactId>
+            <version>2.1.3</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <version>4.3.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.camunda.connector</groupId>
+            <artifactId>connectors-e2e-test-base</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/connectors-e2e-test/connectors-e2e-email/src/test/java/io/camunda/connector/e2e/BaseEmailTest.java
+++ b/connectors-e2e-test/connectors-e2e-email/src/test/java/io/camunda/connector/e2e/BaseEmailTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.e2e;
+
+import com.icegreen.greenmail.store.FolderException;
+import com.icegreen.greenmail.user.GreenMailUser;
+import com.icegreen.greenmail.util.GreenMail;
+import com.icegreen.greenmail.util.GreenMailUtil;
+import jakarta.mail.*;
+import jakarta.mail.internet.MimeMessage;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+
+public class BaseEmailTest {
+
+  protected static final String LOCALHOST = "localhost";
+  private static final GreenMail greenMail = new GreenMail();
+  private static final GreenMailUser greenMailUser =
+      greenMail.setUser("test@camunda.com", "password");
+
+  @BeforeAll
+  public static void setup() {
+    greenMail.start();
+  }
+
+  @AfterAll
+  public static void tearDown() {
+    greenMail.stop();
+  }
+
+  protected Message[] getLastReceivedEmails() {
+    return greenMail.getReceivedMessages();
+  }
+
+  protected String getUnsecureImapPort() {
+    return String.valueOf(greenMail.getImap().getPort());
+  }
+
+  protected String getUnsecureSmtpPort() {
+    return String.valueOf(greenMail.getSmtp().getPort());
+  }
+
+  protected void reset() {
+    try {
+      greenMail.purgeEmailFromAllMailboxes();
+    } catch (FolderException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  protected void replyTo(Message[] lastReceivedEmails) {
+    for (Message message : lastReceivedEmails) {
+      try {
+        MimeMessage mimeMessage =
+            GreenMailUtil.createTextEmail(
+                "test@camunda.com",
+                "test@camunda.com",
+                "any",
+                "test",
+                greenMail.getImap().getServerSetup());
+        mimeMessage.setHeader("In-Reply-To", message.getHeader("Message-ID")[0]);
+        greenMailUser.deliver(mimeMessage);
+      } catch (MessagingException e) {
+        throw new RuntimeException(e);
+      }
+    }
+  }
+}

--- a/connectors-e2e-test/connectors-e2e-email/src/test/java/io/camunda/connector/e2e/InboundEmailTests.java
+++ b/connectors-e2e-test/connectors-e2e-email/src/test/java/io/camunda/connector/e2e/InboundEmailTests.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.e2e;
+
+import static io.camunda.connector.e2e.BpmnFile.replace;
+import static org.awaitility.Awaitility.await;
+import static org.mockito.Mockito.when;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.search.response.ProcessDefinition;
+import io.camunda.connector.e2e.app.TestConnectorRuntimeApplication;
+import io.camunda.connector.runtime.inbound.search.SearchQueryClient;
+import io.camunda.connector.runtime.inbound.state.ProcessImportResult;
+import io.camunda.connector.runtime.inbound.state.ProcessStateStore;
+import io.camunda.connector.test.SlowTest;
+import io.camunda.process.test.api.CamundaSpringProcessTest;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.model.bpmn.instance.Process;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+@SpringBootTest(
+    classes = {TestConnectorRuntimeApplication.class},
+    properties = {
+      "spring.main.allow-bean-definition-overriding=true",
+      "camunda.connector.webhook.enabled=false",
+      "camunda.connector.polling.enabled=true"
+    },
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@CamundaSpringProcessTest
+@SlowTest
+@ExtendWith(MockitoExtension.class)
+public class InboundEmailTests extends BaseEmailTest {
+
+  private static final String EMAIL_INTERMEDIATE_EVENT_BPMN = "email-intermediate-event.bpmn";
+
+  @MockitoBean SearchQueryClient searchQueryClient;
+  @Autowired CamundaClient camundaClient;
+  @Autowired ProcessStateStore processStateStore;
+  @MockitoBean private ProcessDefinition processDef;
+
+  @BeforeEach
+  public void beforeEach() {
+    super.reset();
+  }
+
+  @Test
+  public void testEmailComplexIntermediateConnector() {
+
+    var model =
+        replace(
+            EMAIL_INTERMEDIATE_EVENT_BPMN,
+            BpmnFile.Replace.replace("USERNAME", "test@camunda.com"),
+            BpmnFile.Replace.replace("PASSWORD", "password"),
+            BpmnFile.Replace.replace("IMAP_HOST", "localhost"),
+            BpmnFile.Replace.replace("IMAP_PORT", getUnsecureImapPort()),
+            BpmnFile.Replace.replace("SMTP_HOST", "localhost"),
+            BpmnFile.Replace.replace("SMTP_PORT", getUnsecureSmtpPort()));
+
+    mockProcessDefinition(model);
+    processStateStore.update(
+        new ProcessImportResult(
+            Map.of(
+                new ProcessImportResult.ProcessDefinitionIdentifier(
+                    processDef.getProcessDefinitionId(), processDef.getTenantId()),
+                new ProcessImportResult.ProcessDefinitionVersion(
+                    processDef.getProcessDefinitionKey(), processDef.getVersion()))));
+
+    var bpmnTest = ZeebeTest.with(camundaClient).deploy(model).createInstance();
+
+    await()
+        .atMost(10, TimeUnit.SECONDS)
+        .untilAsserted(() -> Assertions.assertEquals(2, super.getLastReceivedEmails().length));
+
+    super.replyTo(super.getLastReceivedEmails());
+
+    bpmnTest.waitForProcessCompletion();
+  }
+
+  private void mockProcessDefinition(BpmnModelInstance model) {
+    when(searchQueryClient.getProcessModel(1)).thenReturn(model);
+    when(processDef.getProcessDefinitionKey()).thenReturn(1L);
+    when(processDef.getTenantId())
+        .thenReturn(camundaClient.getConfiguration().getDefaultTenantId());
+    when(processDef.getProcessDefinitionId())
+        .thenReturn(model.getModelElementsByType(Process.class).stream().findFirst().get().getId());
+  }
+}

--- a/connectors-e2e-test/connectors-e2e-email/src/test/resources/email-intermediate-event.bpmn
+++ b/connectors-e2e-test/connectors-e2e-email/src/test/resources/email-intermediate-event.bpmn
@@ -1,0 +1,207 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_01tg7vp" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Web Modeler" exporterVersion="3e03cdd" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.7.0">
+  <bpmn:process id="Process_1y88oh5" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_12mdnxw</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_12mdnxw" sourceRef="StartEvent_1" targetRef="Gateway_0co78ly" />
+    <bpmn:serviceTask id="Activity_0zge701" zeebe:modelerTemplate="io.camunda.connectors.email.v1" zeebe:modelerTemplateVersion="2" zeebe:modelerTemplateIcon="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTYiIGhlaWdodD0iMTYiIHZpZXdCb3g9IjAgMCAxNiAxNiIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPGcgY2xpcC1wYXRoPSJ1cmwoI2NsaXAwXzkwXzI0MjApIj4KPHBhdGggZD0iTTguMzM4MzUgOS45NTM2NUwxMC4zODk0IDEyLjAxMDRMOC4zMzI2MiAxNC4wNjcyTDkuMTQ2MTYgMTQuODc1TDEyLjAxMDcgMTIuMDEwNEw5LjE0NjE2IDkuMTQ1ODNMOC4zMzgzNSA5Ljk1MzY1WiIgZmlsbD0iYmxhY2siLz4KPHBhdGggZD0iTTEyLjM0ODggOS45NTM2NUwxNC4zOTk4IDEyLjAxMDRMMTIuMzQzIDE0LjA2NzJMMTMuMTU2NiAxNC44NzVMMTYuMDIxMiAxMi4wMTA0TDEzLjE1NjYgOS4xNDU4M0wxMi4zNDg4IDkuOTUzNjVaIiBmaWxsPSJibGFjayIvPgo8cGF0aCBkPSJNMy45NzIgMTEuNDM3NUgxLjEyNTMzVjIuNzkyMTlMNy42NzM3NiA3LjMyMzk2QzcuNzY5NjcgNy4zOTA0OSA3Ljg4MzYgNy40MjYxNCA4LjAwMDMyIDcuNDI2MTRDOC4xMTcwNSA3LjQyNjE0IDguMjMwOTggNy4zOTA0OSA4LjMyNjg5IDcuMzIzOTZMMTQuODc1MyAyLjc5MjE5VjhIMTYuMDIxMlYyLjI3MDgzQzE2LjAyMTIgMS45NjY5NCAxNS45MDA0IDEuNjc1NDkgMTUuNjg1NiAxLjQ2MDYxQzE1LjQ3MDcgMS4yNDU3MiAxNS4xNzkyIDEuMTI1IDE0Ljg3NTMgMS4xMjVIMS4xMjUzM0MwLjgyMTQzMiAxLjEyNSAwLjUyOTk4NCAxLjI0NTcyIDAuMzE1MDk5IDEuNDYwNjFDMC4xMDAyMTQgMS42NzU0OSAtMC4wMjA1MDc4IDEuOTY2OTQgLTAuMDIwNTA3OCAyLjI3MDgzVjExLjQzNzVDLTAuMDIwNTA3OCAxMS43NDE0IDAuMTAwMjE0IDEyLjAzMjggMC4zMTUwOTkgMTIuMjQ3N0MwLjUyOTk4NCAxMi40NjI2IDAuODIxNDMyIDEyLjU4MzMgMS4xMjUzMyAxMi41ODMzSDMuOTcyVjExLjQzNzVaTTEzLjYxNDkgMi4yNzA4M0w4LjAwMDMyIDYuMTU1MjFMMi4zODU3NCAyLjI3MDgzSDEzLjYxNDlaIiBmaWxsPSIjRkM1RDBEIi8+CjxwYXRoIGQ9Ik00LjI4MjEgOS45NTM2NUw2LjMzMzE0IDEyLjAxMDRMNC4yNzYzNyAxNC4wNjcyTDUuMDg5OTEgMTQuODc1TDcuOTU0NDkgMTIuMDEwNEw1LjA4OTkxIDkuMTQ1ODNMNC4yODIxIDkuOTUzNjVaIiBmaWxsPSJibGFjayIvPgo8L2c+CjxkZWZzPgo8Y2xpcFBhdGggaWQ9ImNsaXAwXzkwXzI0MjAiPgo8cmVjdCB3aWR0aD0iMTYiIGhlaWdodD0iMTYiIGZpbGw9IndoaXRlIi8+CjwvY2xpcFBhdGg+CjwvZGVmcz4KPC9zdmc+Cg==">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="io.camunda:email:1" retries="3" />
+        <zeebe:ioMapping>
+          <zeebe:input source="simple" target="authentication.type" />
+          <zeebe:input source="USERNAME" target="authentication.username" />
+          <zeebe:input source="PASSWORD" target="authentication.password" />
+          <zeebe:input source="smtp" target="protocol" />
+          <zeebe:input source="SMTP_HOST" target="data.smtpConfig.smtpHost" />
+          <zeebe:input source="SMTP_PORT" target="data.smtpConfig.smtpPort" />
+          <zeebe:input source="NONE" target="data.smtpConfig.smtpCryptographicProtocol" />
+          <zeebe:input source="sendEmailSmtp" target="data.smtpActionDiscriminator" />
+          <zeebe:input source="camunda.connectors.team@gmail.com" target="data.smtpAction.from" />
+          <zeebe:input source="camunda.connectors.team@ik.me" target="data.smtpAction.to" />
+          <zeebe:input source="Subject" target="data.smtpAction.subject" />
+          <zeebe:input source="PLAIN" target="data.smtpAction.contentType" />
+          <zeebe:input source="Test from 1" target="data.smtpAction.body" />
+        </zeebe:ioMapping>
+        <zeebe:taskHeaders>
+          <zeebe:header key="resultVariable" value="result1" />
+          <zeebe:header key="retryBackoff" value="PT0S" />
+        </zeebe:taskHeaders>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_0inbe6g</bpmn:incoming>
+      <bpmn:outgoing>Flow_1h109e5</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:endEvent id="Event_1x32f3s">
+      <bpmn:incoming>Flow_0rteooj</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1h109e5" sourceRef="Activity_0zge701" targetRef="Event_1y028po" />
+    <bpmn:intermediateCatchEvent id="Event_1y028po" zeebe:modelerTemplate="io.camunda.connectors.inbound.EmailIntermediate.v1" zeebe:modelerTemplateVersion="1" zeebe:modelerTemplateIcon="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTYiIGhlaWdodD0iMTYiIHZpZXdCb3g9IjAgMCAxNiAxNiIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPGcgY2xpcC1wYXRoPSJ1cmwoI2NsaXAwXzkwXzI0MjApIj4KPHBhdGggZD0iTTguMzM4MzUgOS45NTM2NUwxMC4zODk0IDEyLjAxMDRMOC4zMzI2MiAxNC4wNjcyTDkuMTQ2MTYgMTQuODc1TDEyLjAxMDcgMTIuMDEwNEw5LjE0NjE2IDkuMTQ1ODNMOC4zMzgzNSA5Ljk1MzY1WiIgZmlsbD0iYmxhY2siLz4KPHBhdGggZD0iTTEyLjM0ODggOS45NTM2NUwxNC4zOTk4IDEyLjAxMDRMMTIuMzQzIDE0LjA2NzJMMTMuMTU2NiAxNC44NzVMMTYuMDIxMiAxMi4wMTA0TDEzLjE1NjYgOS4xNDU4M0wxMi4zNDg4IDkuOTUzNjVaIiBmaWxsPSJibGFjayIvPgo8cGF0aCBkPSJNMy45NzIgMTEuNDM3NUgxLjEyNTMzVjIuNzkyMTlMNy42NzM3NiA3LjMyMzk2QzcuNzY5NjcgNy4zOTA0OSA3Ljg4MzYgNy40MjYxNCA4LjAwMDMyIDcuNDI2MTRDOC4xMTcwNSA3LjQyNjE0IDguMjMwOTggNy4zOTA0OSA4LjMyNjg5IDcuMzIzOTZMMTQuODc1MyAyLjc5MjE5VjhIMTYuMDIxMlYyLjI3MDgzQzE2LjAyMTIgMS45NjY5NCAxNS45MDA0IDEuNjc1NDkgMTUuNjg1NiAxLjQ2MDYxQzE1LjQ3MDcgMS4yNDU3MiAxNS4xNzkyIDEuMTI1IDE0Ljg3NTMgMS4xMjVIMS4xMjUzM0MwLjgyMTQzMiAxLjEyNSAwLjUyOTk4NCAxLjI0NTcyIDAuMzE1MDk5IDEuNDYwNjFDMC4xMDAyMTQgMS42NzU0OSAtMC4wMjA1MDc4IDEuOTY2OTQgLTAuMDIwNTA3OCAyLjI3MDgzVjExLjQzNzVDLTAuMDIwNTA3OCAxMS43NDE0IDAuMTAwMjE0IDEyLjAzMjggMC4zMTUwOTkgMTIuMjQ3N0MwLjUyOTk4NCAxMi40NjI2IDAuODIxNDMyIDEyLjU4MzMgMS4xMjUzMyAxMi41ODMzSDMuOTcyVjExLjQzNzVaTTEzLjYxNDkgMi4yNzA4M0w4LjAwMDMyIDYuMTU1MjFMMi4zODU3NCAyLjI3MDgzSDEzLjYxNDlaIiBmaWxsPSIjRkM1RDBEIi8+CjxwYXRoIGQ9Ik00LjI4MjEgOS45NTM2NUw2LjMzMzE0IDEyLjAxMDRMNC4yNzYzNyAxNC4wNjcyTDUuMDg5OTEgMTQuODc1TDcuOTU0NDkgMTIuMDEwNEw1LjA4OTkxIDkuMTQ1ODNMNC4yODIxIDkuOTUzNjVaIiBmaWxsPSJibGFjayIvPgo8L2c+CjxkZWZzPgo8Y2xpcFBhdGggaWQ9ImNsaXAwXzkwXzI0MjAiPgo8cmVjdCB3aWR0aD0iMTYiIGhlaWdodD0iMTYiIGZpbGw9IndoaXRlIi8+CjwvY2xpcFBhdGg+CjwvZGVmcz4KPC9zdmc+Cg==">
+      <bpmn:extensionElements>
+        <zeebe:properties>
+          <zeebe:property name="inbound.type" value="io.camunda:connector-email-inbound:1" />
+          <zeebe:property name="authentication.type" value="simple" />
+          <zeebe:property name="authentication.username" value="USERNAME" />
+          <zeebe:property name="authentication.password" value="PASSWORD" />
+          <zeebe:property name="data.imapConfig.imapHost" value="IMAP_HOST" />
+          <zeebe:property name="data.imapConfig.imapPort" value="IMAP_PORT" />
+          <zeebe:property name="data.imapConfig.imapCryptographicProtocol" value="NONE" />
+          <zeebe:property name="data.pollingWaitTime" value="PT2S" />
+          <zeebe:property name="data.pollingConfigDiscriminator" value="unseenPollingConfig" />
+          <zeebe:property name="data.pollingConfig.handlingStrategy" value="READ" />
+          <zeebe:property name="consumeUnmatchedEvents" value="true" />
+          <zeebe:property name="correlationKeyExpression" value="=headers[key = &#34;In-Reply-To&#34;][1].value" />
+          <zeebe:property name="deduplicationModeManualFlag" value="true" />
+          <zeebe:property name="deduplicationId" value="1" />
+          <zeebe:property name="deduplicationMode" value="MANUAL" />
+          <zeebe:property name="resultVariable" />
+          <zeebe:property name="resultExpression" />
+        </zeebe:properties>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1h109e5</bpmn:incoming>
+      <bpmn:outgoing>Flow_0fggusr</bpmn:outgoing>
+      <bpmn:messageEventDefinition id="MessageEventDefinition_0mugcd1" messageRef="Message_1b0imik" />
+    </bpmn:intermediateCatchEvent>
+    <bpmn:parallelGateway id="Gateway_0co78ly">
+      <bpmn:incoming>Flow_12mdnxw</bpmn:incoming>
+      <bpmn:outgoing>Flow_0inbe6g</bpmn:outgoing>
+      <bpmn:outgoing>Flow_1c6bcf4</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:sequenceFlow id="Flow_0inbe6g" sourceRef="Gateway_0co78ly" targetRef="Activity_0zge701" />
+    <bpmn:serviceTask id="Activity_0cw606g" zeebe:modelerTemplate="io.camunda.connectors.email.v1" zeebe:modelerTemplateVersion="2" zeebe:modelerTemplateIcon="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTYiIGhlaWdodD0iMTYiIHZpZXdCb3g9IjAgMCAxNiAxNiIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPGcgY2xpcC1wYXRoPSJ1cmwoI2NsaXAwXzkwXzI0MjApIj4KPHBhdGggZD0iTTguMzM4MzUgOS45NTM2NUwxMC4zODk0IDEyLjAxMDRMOC4zMzI2MiAxNC4wNjcyTDkuMTQ2MTYgMTQuODc1TDEyLjAxMDcgMTIuMDEwNEw5LjE0NjE2IDkuMTQ1ODNMOC4zMzgzNSA5Ljk1MzY1WiIgZmlsbD0iYmxhY2siLz4KPHBhdGggZD0iTTEyLjM0ODggOS45NTM2NUwxNC4zOTk4IDEyLjAxMDRMMTIuMzQzIDE0LjA2NzJMMTMuMTU2NiAxNC44NzVMMTYuMDIxMiAxMi4wMTA0TDEzLjE1NjYgOS4xNDU4M0wxMi4zNDg4IDkuOTUzNjVaIiBmaWxsPSJibGFjayIvPgo8cGF0aCBkPSJNMy45NzIgMTEuNDM3NUgxLjEyNTMzVjIuNzkyMTlMNy42NzM3NiA3LjMyMzk2QzcuNzY5NjcgNy4zOTA0OSA3Ljg4MzYgNy40MjYxNCA4LjAwMDMyIDcuNDI2MTRDOC4xMTcwNSA3LjQyNjE0IDguMjMwOTggNy4zOTA0OSA4LjMyNjg5IDcuMzIzOTZMMTQuODc1MyAyLjc5MjE5VjhIMTYuMDIxMlYyLjI3MDgzQzE2LjAyMTIgMS45NjY5NCAxNS45MDA0IDEuNjc1NDkgMTUuNjg1NiAxLjQ2MDYxQzE1LjQ3MDcgMS4yNDU3MiAxNS4xNzkyIDEuMTI1IDE0Ljg3NTMgMS4xMjVIMS4xMjUzM0MwLjgyMTQzMiAxLjEyNSAwLjUyOTk4NCAxLjI0NTcyIDAuMzE1MDk5IDEuNDYwNjFDMC4xMDAyMTQgMS42NzU0OSAtMC4wMjA1MDc4IDEuOTY2OTQgLTAuMDIwNTA3OCAyLjI3MDgzVjExLjQzNzVDLTAuMDIwNTA3OCAxMS43NDE0IDAuMTAwMjE0IDEyLjAzMjggMC4zMTUwOTkgMTIuMjQ3N0MwLjUyOTk4NCAxMi40NjI2IDAuODIxNDMyIDEyLjU4MzMgMS4xMjUzMyAxMi41ODMzSDMuOTcyVjExLjQzNzVaTTEzLjYxNDkgMi4yNzA4M0w4LjAwMDMyIDYuMTU1MjFMMi4zODU3NCAyLjI3MDgzSDEzLjYxNDlaIiBmaWxsPSIjRkM1RDBEIi8+CjxwYXRoIGQ9Ik00LjI4MjEgOS45NTM2NUw2LjMzMzE0IDEyLjAxMDRMNC4yNzYzNyAxNC4wNjcyTDUuMDg5OTEgMTQuODc1TDcuOTU0NDkgMTIuMDEwNEw1LjA4OTkxIDkuMTQ1ODNMNC4yODIxIDkuOTUzNjVaIiBmaWxsPSJibGFjayIvPgo8L2c+CjxkZWZzPgo8Y2xpcFBhdGggaWQ9ImNsaXAwXzkwXzI0MjAiPgo8cmVjdCB3aWR0aD0iMTYiIGhlaWdodD0iMTYiIGZpbGw9IndoaXRlIi8+CjwvY2xpcFBhdGg+CjwvZGVmcz4KPC9zdmc+Cg==">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="io.camunda:email:1" retries="3" />
+        <zeebe:ioMapping>
+          <zeebe:input source="simple" target="authentication.type" />
+          <zeebe:input source="USERNAME" target="authentication.username" />
+          <zeebe:input source="PASSWORD" target="authentication.password" />
+          <zeebe:input source="smtp" target="protocol" />
+          <zeebe:input source="SMTP_HOST" target="data.smtpConfig.smtpHost" />
+          <zeebe:input source="SMTP_PORT" target="data.smtpConfig.smtpPort" />
+          <zeebe:input source="NONE" target="data.smtpConfig.smtpCryptographicProtocol" />
+          <zeebe:input source="sendEmailSmtp" target="data.smtpActionDiscriminator" />
+          <zeebe:input source="camunda.connectors.team@gmail.com" target="data.smtpAction.from" />
+          <zeebe:input source="camunda.connectors.team@ik.me" target="data.smtpAction.to" />
+          <zeebe:input source="Subject" target="data.smtpAction.subject" />
+          <zeebe:input source="PLAIN" target="data.smtpAction.contentType" />
+          <zeebe:input source="Test from 2 " target="data.smtpAction.body" />
+        </zeebe:ioMapping>
+        <zeebe:taskHeaders>
+          <zeebe:header key="resultVariable" value="result2" />
+          <zeebe:header key="retryBackoff" value="PT0S" />
+        </zeebe:taskHeaders>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1c6bcf4</bpmn:incoming>
+      <bpmn:outgoing>Flow_1v1teb8</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="Flow_1c6bcf4" sourceRef="Gateway_0co78ly" targetRef="Activity_0cw606g" />
+    <bpmn:intermediateCatchEvent id="Event_1s5ngys" zeebe:modelerTemplate="io.camunda.connectors.inbound.EmailIntermediate.v1" zeebe:modelerTemplateVersion="1" zeebe:modelerTemplateIcon="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTYiIGhlaWdodD0iMTYiIHZpZXdCb3g9IjAgMCAxNiAxNiIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPGcgY2xpcC1wYXRoPSJ1cmwoI2NsaXAwXzkwXzI0MjApIj4KPHBhdGggZD0iTTguMzM4MzUgOS45NTM2NUwxMC4zODk0IDEyLjAxMDRMOC4zMzI2MiAxNC4wNjcyTDkuMTQ2MTYgMTQuODc1TDEyLjAxMDcgMTIuMDEwNEw5LjE0NjE2IDkuMTQ1ODNMOC4zMzgzNSA5Ljk1MzY1WiIgZmlsbD0iYmxhY2siLz4KPHBhdGggZD0iTTEyLjM0ODggOS45NTM2NUwxNC4zOTk4IDEyLjAxMDRMMTIuMzQzIDE0LjA2NzJMMTMuMTU2NiAxNC44NzVMMTYuMDIxMiAxMi4wMTA0TDEzLjE1NjYgOS4xNDU4M0wxMi4zNDg4IDkuOTUzNjVaIiBmaWxsPSJibGFjayIvPgo8cGF0aCBkPSJNMy45NzIgMTEuNDM3NUgxLjEyNTMzVjIuNzkyMTlMNy42NzM3NiA3LjMyMzk2QzcuNzY5NjcgNy4zOTA0OSA3Ljg4MzYgNy40MjYxNCA4LjAwMDMyIDcuNDI2MTRDOC4xMTcwNSA3LjQyNjE0IDguMjMwOTggNy4zOTA0OSA4LjMyNjg5IDcuMzIzOTZMMTQuODc1MyAyLjc5MjE5VjhIMTYuMDIxMlYyLjI3MDgzQzE2LjAyMTIgMS45NjY5NCAxNS45MDA0IDEuNjc1NDkgMTUuNjg1NiAxLjQ2MDYxQzE1LjQ3MDcgMS4yNDU3MiAxNS4xNzkyIDEuMTI1IDE0Ljg3NTMgMS4xMjVIMS4xMjUzM0MwLjgyMTQzMiAxLjEyNSAwLjUyOTk4NCAxLjI0NTcyIDAuMzE1MDk5IDEuNDYwNjFDMC4xMDAyMTQgMS42NzU0OSAtMC4wMjA1MDc4IDEuOTY2OTQgLTAuMDIwNTA3OCAyLjI3MDgzVjExLjQzNzVDLTAuMDIwNTA3OCAxMS43NDE0IDAuMTAwMjE0IDEyLjAzMjggMC4zMTUwOTkgMTIuMjQ3N0MwLjUyOTk4NCAxMi40NjI2IDAuODIxNDMyIDEyLjU4MzMgMS4xMjUzMyAxMi41ODMzSDMuOTcyVjExLjQzNzVaTTEzLjYxNDkgMi4yNzA4M0w4LjAwMDMyIDYuMTU1MjFMMi4zODU3NCAyLjI3MDgzSDEzLjYxNDlaIiBmaWxsPSIjRkM1RDBEIi8+CjxwYXRoIGQ9Ik00LjI4MjEgOS45NTM2NUw2LjMzMzE0IDEyLjAxMDRMNC4yNzYzNyAxNC4wNjcyTDUuMDg5OTEgMTQuODc1TDcuOTU0NDkgMTIuMDEwNEw1LjA4OTkxIDkuMTQ1ODNMNC4yODIxIDkuOTUzNjVaIiBmaWxsPSJibGFjayIvPgo8L2c+CjxkZWZzPgo8Y2xpcFBhdGggaWQ9ImNsaXAwXzkwXzI0MjAiPgo8cmVjdCB3aWR0aD0iMTYiIGhlaWdodD0iMTYiIGZpbGw9IndoaXRlIi8+CjwvY2xpcFBhdGg+CjwvZGVmcz4KPC9zdmc+Cg==">
+      <bpmn:extensionElements>
+        <zeebe:properties>
+          <zeebe:property name="inbound.type" value="io.camunda:connector-email-inbound:1" />
+          <zeebe:property name="authentication.type" value="simple" />
+          <zeebe:property name="authentication.username" value="USERNAME" />
+          <zeebe:property name="authentication.password" value="PASSWORD" />
+          <zeebe:property name="data.imapConfig.imapHost" value="IMAP_HOST" />
+          <zeebe:property name="data.imapConfig.imapPort" value="IMAP_PORT" />
+          <zeebe:property name="data.imapConfig.imapCryptographicProtocol" value="NONE" />
+          <zeebe:property name="data.pollingWaitTime" value="PT2S" />
+          <zeebe:property name="data.pollingConfigDiscriminator" value="unseenPollingConfig" />
+          <zeebe:property name="data.pollingConfig.handlingStrategy" value="READ" />
+          <zeebe:property name="consumeUnmatchedEvents" value="true" />
+          <zeebe:property name="correlationKeyExpression" value="=headers[key = &#34;In-Reply-To&#34;][1].value" />
+          <zeebe:property name="deduplicationModeManualFlag" value="true" />
+          <zeebe:property name="deduplicationId" value="2" />
+          <zeebe:property name="deduplicationMode" value="MANUAL" />
+          <zeebe:property name="resultVariable" />
+          <zeebe:property name="resultExpression" />
+        </zeebe:properties>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1v1teb8</bpmn:incoming>
+      <bpmn:outgoing>Flow_14gf4b9</bpmn:outgoing>
+      <bpmn:messageEventDefinition id="MessageEventDefinition_0uekxy0" messageRef="Message_1yo2zku" />
+    </bpmn:intermediateCatchEvent>
+    <bpmn:sequenceFlow id="Flow_1v1teb8" sourceRef="Activity_0cw606g" targetRef="Event_1s5ngys" />
+    <bpmn:sequenceFlow id="Flow_14gf4b9" sourceRef="Event_1s5ngys" targetRef="Gateway_0xnram1" />
+    <bpmn:parallelGateway id="Gateway_0xnram1">
+      <bpmn:incoming>Flow_14gf4b9</bpmn:incoming>
+      <bpmn:incoming>Flow_0fggusr</bpmn:incoming>
+      <bpmn:outgoing>Flow_0rteooj</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:sequenceFlow id="Flow_0rteooj" sourceRef="Gateway_0xnram1" targetRef="Event_1x32f3s" />
+    <bpmn:sequenceFlow id="Flow_0fggusr" sourceRef="Event_1y028po" targetRef="Gateway_0xnram1" />
+  </bpmn:process>
+  <bpmn:message id="Message_1b0imik" name="cbc8e01d-c026-4157-afc1-d21a3fee4820" zeebe:modelerTemplate="io.camunda.connectors.inbound.EmailIntermediate.v1">
+    <bpmn:extensionElements>
+      <zeebe:subscription correlationKey="=result1.messageId" />
+    </bpmn:extensionElements>
+  </bpmn:message>
+  <bpmn:message id="Message_1yo2zku" name="8965741a-cc13-48b2-abb6-1d338cbf37c9" zeebe:modelerTemplate="io.camunda.connectors.inbound.EmailIntermediate.v1">
+    <bpmn:extensionElements>
+      <zeebe:subscription correlationKey="=result2.messageId" />
+    </bpmn:extensionElements>
+  </bpmn:message>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1y88oh5">
+      <bpmndi:BPMNShape id="StartEvent_1_di" bpmnElement="StartEvent_1">
+        <dc:Bounds x="122" y="172" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1mf4qkt_di" bpmnElement="Activity_0zge701">
+        <dc:Bounds x="320" y="70" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1x32f3s_di" bpmnElement="Event_1x32f3s">
+        <dc:Bounds x="742" y="172" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1xxxpby_di" bpmnElement="Event_1y028po">
+        <dc:Bounds x="482" y="92" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_05qusa9_di" bpmnElement="Gateway_0co78ly">
+        <dc:Bounds x="205" y="165" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0jcp9gn" bpmnElement="Activity_0cw606g">
+        <dc:Bounds x="320" y="240" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0ch4a6k" bpmnElement="Event_1s5ngys">
+        <dc:Bounds x="482" y="262" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0hz2joo_di" bpmnElement="Gateway_0xnram1">
+        <dc:Bounds x="585" y="165" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_12mdnxw_di" bpmnElement="Flow_12mdnxw">
+        <di:waypoint x="158" y="190" />
+        <di:waypoint x="205" y="190" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1h109e5_di" bpmnElement="Flow_1h109e5">
+        <di:waypoint x="420" y="110" />
+        <di:waypoint x="482" y="110" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0inbe6g_di" bpmnElement="Flow_0inbe6g">
+        <di:waypoint x="230" y="165" />
+        <di:waypoint x="230" y="110" />
+        <di:waypoint x="320" y="110" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1c6bcf4_di" bpmnElement="Flow_1c6bcf4">
+        <di:waypoint x="230" y="215" />
+        <di:waypoint x="230" y="280" />
+        <di:waypoint x="320" y="280" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1v1teb8_di" bpmnElement="Flow_1v1teb8">
+        <di:waypoint x="420" y="280" />
+        <di:waypoint x="482" y="280" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_14gf4b9_di" bpmnElement="Flow_14gf4b9">
+        <di:waypoint x="518" y="280" />
+        <di:waypoint x="610" y="280" />
+        <di:waypoint x="610" y="215" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0rteooj_di" bpmnElement="Flow_0rteooj">
+        <di:waypoint x="635" y="190" />
+        <di:waypoint x="742" y="190" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0fggusr_di" bpmnElement="Flow_0fggusr">
+        <di:waypoint x="518" y="110" />
+        <di:waypoint x="610" y="110" />
+        <di:waypoint x="610" y="165" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/connectors-e2e-test/pom.xml
+++ b/connectors-e2e-test/pom.xml
@@ -25,6 +25,7 @@
         <module>connectors-e2e-test-rabbitmq</module>
         <module>connectors-e2e-test-message</module>
         <module>connectors-e2e-test-agentic-ai</module>
+        <module>connectors-e2e-email</module>
     </modules>
 
 </project>

--- a/connectors/email/src/test/java/io/camunda/connector/email/integration/BaseEmailTest.java
+++ b/connectors/email/src/test/java/io/camunda/connector/email/integration/BaseEmailTest.java
@@ -149,16 +149,6 @@ public class BaseEmailTest {
     greenMailUser.deliver(mimeMessage);
   }
 
-  protected String getLastEmailMessageId() {
-    Message message = getLastReceivedEmails()[0];
-    try {
-      String messageId = message.getHeader("Message-ID")[0];
-      return messageId.trim().replaceAll("[<>]", "");
-    } catch (MessagingException e) {
-      throw new RuntimeException(e);
-    }
-  }
-
   protected String getUnsecurePop3Port() {
     return String.valueOf(greenMail.getPop3().getPort());
   }

--- a/connectors/email/src/test/java/io/camunda/connector/email/integration/InboundEmailTest.java
+++ b/connectors/email/src/test/java/io/camunda/connector/email/integration/InboundEmailTest.java
@@ -160,41 +160,41 @@ public class InboundEmailTest extends BaseEmailTest {
     InboundConnectorContext inboundConnectorContext = mock(InboundConnectorContext.class);
 
     EmailInboundConnectorProperties emailInboundConnectorProperties =
-            new EmailInboundConnectorProperties(
-                    new SimpleAuthentication("test@camunda.com", "password"),
-                    new EmailListenerConfig(
-                            new ImapConfig(
-                                    "localhost",
-                                    Integer.valueOf(super.getUnsecureImapPort()),
-                                    CryptographicProtocol.NONE),
-                            "",
-                            Duration.of(2, ChronoUnit.SECONDS),
-                            new PollUnseen(HandlingStrategy.READ, "")));
+        new EmailInboundConnectorProperties(
+            new SimpleAuthentication("test@camunda.com", "password"),
+            new EmailListenerConfig(
+                new ImapConfig(
+                    "localhost",
+                    Integer.valueOf(super.getUnsecureImapPort()),
+                    CryptographicProtocol.NONE),
+                "",
+                Duration.of(2, ChronoUnit.SECONDS),
+                new PollUnseen(HandlingStrategy.READ, "")));
 
     doNothing().when(inboundConnectorContext).log(any());
     when(inboundConnectorContext.bindProperties(EmailInboundConnectorProperties.class))
-            .thenReturn(emailInboundConnectorProperties);
+        .thenReturn(emailInboundConnectorProperties);
     when(inboundConnectorContext.correlate(any()))
-            .thenReturn(new CorrelationResult.Failure.ActivationConditionNotMet(true));
+        .thenReturn(new CorrelationResult.Failure.ActivationConditionNotMet(true));
     when(inboundConnectorContext.canActivate(any()))
-            .thenReturn(new ActivationCheckResult.Success.CanActivate(null));
+        .thenReturn(new ActivationCheckResult.Success.CanActivate(null));
 
     this.jakartaEmailListener.startListener(inboundConnectorContext);
     super.sendEmail("camunda@test.com", "Subject", "Content");
 
     await()
-            .atMost(5, TimeUnit.SECONDS)
-            .untilAsserted(
-                    () ->
-                            Assertions.assertTrue(
-                                    Arrays.stream(
-                                                    Arrays.stream(super.getLastReceivedEmails())
-                                                            .findFirst()
-                                                            .get()
-                                                            .getFlags()
-                                                            .getSystemFlags())
-                                            .toList()
-                                            .contains(Flags.Flag.SEEN)));
+        .atMost(5, TimeUnit.SECONDS)
+        .untilAsserted(
+            () ->
+                Assertions.assertTrue(
+                    Arrays.stream(
+                            Arrays.stream(super.getLastReceivedEmails())
+                                .findFirst()
+                                .get()
+                                .getFlags()
+                                .getSystemFlags())
+                        .toList()
+                        .contains(Flags.Flag.SEEN)));
   }
 
   @Test
@@ -202,41 +202,41 @@ public class InboundEmailTest extends BaseEmailTest {
     InboundConnectorContext inboundConnectorContext = mock(InboundConnectorContext.class);
 
     EmailInboundConnectorProperties emailInboundConnectorProperties =
-            new EmailInboundConnectorProperties(
-                    new SimpleAuthentication("test@camunda.com", "password"),
-                    new EmailListenerConfig(
-                            new ImapConfig(
-                                    "localhost",
-                                    Integer.valueOf(super.getUnsecureImapPort()),
-                                    CryptographicProtocol.NONE),
-                            "",
-                            Duration.of(2, ChronoUnit.SECONDS),
-                            new PollUnseen(HandlingStrategy.READ, "")));
+        new EmailInboundConnectorProperties(
+            new SimpleAuthentication("test@camunda.com", "password"),
+            new EmailListenerConfig(
+                new ImapConfig(
+                    "localhost",
+                    Integer.valueOf(super.getUnsecureImapPort()),
+                    CryptographicProtocol.NONE),
+                "",
+                Duration.of(2, ChronoUnit.SECONDS),
+                new PollUnseen(HandlingStrategy.READ, "")));
 
     doNothing().when(inboundConnectorContext).log(any());
     when(inboundConnectorContext.bindProperties(EmailInboundConnectorProperties.class))
-            .thenReturn(emailInboundConnectorProperties);
+        .thenReturn(emailInboundConnectorProperties);
     when(inboundConnectorContext.correlate(any()))
-            .thenReturn(new CorrelationResult.Failure.ZeebeClientStatus("ZeebeIssue", "Error"));
+        .thenReturn(new CorrelationResult.Failure.ZeebeClientStatus("ZeebeIssue", "Error"));
     when(inboundConnectorContext.canActivate(any()))
-            .thenReturn(new ActivationCheckResult.Success.CanActivate(null));
+        .thenReturn(new ActivationCheckResult.Success.CanActivate(null));
 
     this.jakartaEmailListener.startListener(inboundConnectorContext);
     super.sendEmail("camunda@test.com", "Subject", "Content");
 
     await()
-            .atMost(5, TimeUnit.SECONDS)
-            .untilAsserted(
-                    () ->
-                            Assertions.assertTrue(
-                                    Arrays.stream(
-                                                    Arrays.stream(super.getLastReceivedEmails())
-                                                            .findFirst()
-                                                            .get()
-                                                            .getFlags()
-                                                            .getSystemFlags())
-                                            .toList()
-                                            .isEmpty()));
+        .atMost(5, TimeUnit.SECONDS)
+        .untilAsserted(
+            () ->
+                Assertions.assertTrue(
+                    Arrays.stream(
+                            Arrays.stream(super.getLastReceivedEmails())
+                                .findFirst()
+                                .get()
+                                .getFlags()
+                                .getSystemFlags())
+                        .toList()
+                        .isEmpty()));
   }
 
   private void assertFlagOnLastEmail(HandlingStrategy handlingStrategy) throws MessagingException {


### PR DESCRIPTION
## Description

Add tests for email inbound connector, e2e and unit tests

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes https://github.com/camunda/connectors/issues/4740

## Checklist

- [ ] PR has a **milestone** or the `no milestone` label.

