### PR TITLE
refactor(agentic-ai): update ad-hoc sub-process naming to match the new double-hyphen definition

### DIFF
--- a/connectors/agentic-ai/element-templates/agenticai-adhoctoolsschema-outbound-connector.json
+++ b/connectors/agentic-ai/element-templates/agenticai-adhoctoolsschema-outbound-connector.json
@@ -1,8 +1,8 @@
 {
   "$schema" : "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
-  "name" : "Ad-hoc subprocess tools schema (alpha)",
+  "name" : "Ad-hoc tools schema (alpha)",
   "id" : "io.camunda.connectors.agenticai.adhoctoolsschema.v0",
-  "description" : "Connector to fetch tools schema information from an ad-hoc subprocess",
+  "description" : "Connector to fetch tools schema information from an ad-hoc sub-process",
   "metadata" : {
     "keywords" : [ ]
   },
@@ -40,8 +40,8 @@
     "type" : "Hidden"
   }, {
     "id" : "data.containerElementId",
-    "label" : "Ad-hoc subprocess ID",
-    "description" : "The ID of the subprocess containing the tools to be called",
+    "label" : "Ad-hoc sub-process ID",
+    "description" : "The ID of the sub-process containing the tools to be called",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true

--- a/connectors/agentic-ai/element-templates/agenticai-aiagent-outbound-connector.json
+++ b/connectors/agentic-ai/element-templates/agenticai-aiagent-outbound-connector.json
@@ -432,8 +432,8 @@
     "type" : "String"
   }, {
     "id" : "data.tools.containerElementId",
-    "label" : "Ad-hoc subprocess ID",
-    "description" : "The ID of the subprocess containing the tools to be called",
+    "label" : "Ad-hoc sub-process ID",
+    "description" : "The ID of the sub-process containing the tools to be called",
     "optional" : true,
     "feel" : "optional",
     "group" : "tools",
@@ -445,7 +445,7 @@
   }, {
     "id" : "data.tools.toolCallResults",
     "label" : "Tool Call Results",
-    "description" : "Tool call results as returned by the subprocess",
+    "description" : "Tool call results as returned by the sub-process",
     "optional" : true,
     "feel" : "required",
     "group" : "tools",

--- a/connectors/agentic-ai/element-templates/hybrid/agenticai-adhoctoolsschema-outbound-connector-hybrid.json
+++ b/connectors/agentic-ai/element-templates/hybrid/agenticai-adhoctoolsschema-outbound-connector-hybrid.json
@@ -1,8 +1,8 @@
 {
   "$schema" : "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
-  "name" : "Hybrid Ad-hoc subprocess tools schema (alpha)",
+  "name" : "Hybrid Ad-hoc tools schema (alpha)",
   "id" : "io.camunda.connectors.agenticai.adhoctoolsschema.v0-hybrid",
-  "description" : "Connector to fetch tools schema information from an ad-hoc subprocess",
+  "description" : "Connector to fetch tools schema information from an ad-hoc sub-process",
   "metadata" : {
     "keywords" : [ ]
   },
@@ -45,8 +45,8 @@
     "type" : "String"
   }, {
     "id" : "data.containerElementId",
-    "label" : "Ad-hoc subprocess ID",
-    "description" : "The ID of the subprocess containing the tools to be called",
+    "label" : "Ad-hoc sub-process ID",
+    "description" : "The ID of the sub-process containing the tools to be called",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true

--- a/connectors/agentic-ai/element-templates/hybrid/agenticai-aiagent-outbound-connector-hybrid.json
+++ b/connectors/agentic-ai/element-templates/hybrid/agenticai-aiagent-outbound-connector-hybrid.json
@@ -437,8 +437,8 @@
     "type" : "String"
   }, {
     "id" : "data.tools.containerElementId",
-    "label" : "Ad-hoc subprocess ID",
-    "description" : "The ID of the subprocess containing the tools to be called",
+    "label" : "Ad-hoc sub-process ID",
+    "description" : "The ID of the sub-process containing the tools to be called",
     "optional" : true,
     "feel" : "optional",
     "group" : "tools",
@@ -450,7 +450,7 @@
   }, {
     "id" : "data.tools.toolCallResults",
     "label" : "Tool Call Results",
-    "description" : "Tool call results as returned by the subprocess",
+    "description" : "Tool call results as returned by the sub-process",
     "optional" : true,
     "feel" : "required",
     "group" : "tools",

--- a/connectors/agentic-ai/examples/ai-agent-chat-with-tools/ai-agent-chat-with-tools.bpmn
+++ b/connectors/agentic-ai/examples/ai-agent-chat-with-tools/ai-agent-chat-with-tools.bpmn
@@ -270,7 +270,7 @@
 
 - Loads previous memory from provided variables
 - Checks limits (e.g. maximum LLM model calls)
-- Loads available tool information from ad-hoc subprocess definition
+- Loads available tool information from ad-hoc sub-process definition
 - Merges the current request (either a user message or a tool call response) into the memory
 - Calls the LLM, including previous/edited memory + available tools schema
 - Returns memory trimmed to amount of latest messages

--- a/connectors/agentic-ai/examples/fraud-detection/fraud-detection-process.bpmn
+++ b/connectors/agentic-ai/examples/fraud-detection/fraud-detection-process.bpmn
@@ -140,7 +140,6 @@
       <bpmn:extensionElements>
         <zeebe:formDefinition formId="fraud-detection-process-enter-tax-form" />
         <zeebe:properties>
-          <zeebe:property name="camunda:adHocActivityInputSchema" value="{&#34;taxSubmission&#34;: {&#34;fullName&#34;:&#34;Niall&#34;,&#34;nationalID&#34;:&#34;212133242&#34;,&#34;dob&#34;:&#34;2025-02-17&#34;,&#34;totalIncome&#34;:12,&#34;totalExpenses&#34;:1232143,&#34;largePurches&#34;:[&#34;car&#34;,&#34;stocks&#34;],&#34;charitableDonations&#34;:&#34;I gave 5 euro to a homeless man&#34;}}" />
           <zeebe:property name="camundaModeler:exampleOutputJson" value="{&#34;taxSubmission&#34;: {&#34;fullName&#34;:&#34;John Smith&#34;,&#34;dob&#34;:&#34;1980-04-05&#34;,&#34;emailAddress&#34;:&#34;johnny.s@gmail.com&#34;,&#34;totalIncome&#34;:70000,&#34;totalExpenses&#34;:3500,&#34;largePurchases&#34;:[&#34;stocks&#34;],&#34;charitableDonations&#34;:&#34;I gave 5€ to a homeless man.&#34;}}" />
         </zeebe:properties>
       </bpmn:extensionElements>

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/adhoctoolsschema/AdHocToolsSchemaFunction.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/adhoctoolsschema/AdHocToolsSchemaFunction.java
@@ -16,13 +16,13 @@ import io.camunda.connector.generator.java.annotation.ElementTemplate;
 import io.camunda.connector.generator.java.annotation.ElementTemplate.PropertyGroup;
 
 @OutboundConnector(
-    name = "Ad-hoc subprocess tools schema (alpha)",
+    name = "Ad-hoc tools schema (alpha)",
     inputVariables = {"data"},
     type = "io.camunda.agenticai:adhoctoolsschema:0")
 @ElementTemplate(
     id = "io.camunda.connectors.agenticai.adhoctoolsschema.v0",
-    name = "Ad-hoc subprocess tools schema (alpha)",
-    description = "Connector to fetch tools schema information from an ad-hoc subprocess",
+    name = "Ad-hoc tools schema (alpha)",
+    description = "Connector to fetch tools schema information from an ad-hoc sub-process",
     engineVersion = "^8.8",
     version = 0,
     inputDataClass = AdHocToolsSchemaRequest.class,

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/adhoctoolsschema/model/AdHocToolsSchemaRequest.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/adhoctoolsschema/model/AdHocToolsSchemaRequest.java
@@ -17,8 +17,8 @@ public record AdHocToolsSchemaRequest(@Valid @NotNull AdHocToolsSchemaRequestDat
       @NotBlank
           @TemplateProperty(
               group = "tools",
-              label = "Ad-hoc subprocess ID",
-              description = "The ID of the subprocess containing the tools to be called",
+              label = "Ad-hoc sub-process ID",
+              description = "The ID of the sub-process containing the tools to be called",
               constraints = @PropertyConstraints(notEmpty = true))
           String containerElementId) {}
 }

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/adhoctoolsschema/resolver/AdHocToolsSchemaResolver.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/adhoctoolsschema/resolver/AdHocToolsSchemaResolver.java
@@ -9,5 +9,5 @@ package io.camunda.connector.agenticai.adhoctoolsschema.resolver;
 import io.camunda.connector.agenticai.adhoctoolsschema.model.AdHocToolsSchemaResponse;
 
 public interface AdHocToolsSchemaResolver {
-  AdHocToolsSchemaResponse resolveSchema(Long processDefinitionKey, String adHocSubprocessId);
+  AdHocToolsSchemaResponse resolveSchema(Long processDefinitionKey, String adHocSubProcessId);
 }

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/adhoctoolsschema/resolver/CachingAdHocToolsSchemaResolver.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/adhoctoolsschema/resolver/CachingAdHocToolsSchemaResolver.java
@@ -23,8 +23,8 @@ public class CachingAdHocToolsSchemaResolver implements AdHocToolsSchemaResolver
 
   @Override
   public AdHocToolsSchemaResponse resolveSchema(
-      Long processDefinitionKey, String adHocSubprocessId) {
-    return cache.get(new AdHocToolsIdentifier(processDefinitionKey, adHocSubprocessId));
+      Long processDefinitionKey, String adHocSubProcessId) {
+    return cache.get(new AdHocToolsIdentifier(processDefinitionKey, adHocSubProcessId));
   }
 
   private LoadingCache<AdHocToolsIdentifier, AdHocToolsSchemaResponse> buildCache(
@@ -36,17 +36,17 @@ public class CachingAdHocToolsSchemaResolver implements AdHocToolsSchemaResolver
     Optional.ofNullable(config.expireAfterWrite()).ifPresent(builder::expireAfterWrite);
 
     return builder.build(
-        id -> delegate.resolveSchema(id.processDefinitionKey(), id.adHocSubprocessId()));
+        id -> delegate.resolveSchema(id.processDefinitionKey(), id.adHocSubProcessId()));
   }
 
-  private record AdHocToolsIdentifier(Long processDefinitionKey, String adHocSubprocessId) {
+  private record AdHocToolsIdentifier(Long processDefinitionKey, String adHocSubProcessId) {
     private AdHocToolsIdentifier {
       if (processDefinitionKey == null || processDefinitionKey <= 0) {
         throw new IllegalArgumentException("Process definition key must not be null or negative");
       }
 
-      if (adHocSubprocessId == null || adHocSubprocessId.isBlank()) {
-        throw new IllegalArgumentException("adHocSubprocessId cannot be null or empty");
+      if (adHocSubProcessId == null || adHocSubProcessId.isBlank()) {
+        throw new IllegalArgumentException("adHocSubProcessId cannot be null or empty");
       }
     }
   }

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/adhoctoolsschema/resolver/CamundaClientAdHocToolsSchemaResolver.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/adhoctoolsschema/resolver/CamundaClientAdHocToolsSchemaResolver.java
@@ -42,8 +42,8 @@ public class CamundaClientAdHocToolsSchemaResolver implements AdHocToolsSchemaRe
   private static final Logger LOGGER =
       LoggerFactory.getLogger(CamundaClientAdHocToolsSchemaResolver.class);
 
-  private static final String ERROR_CODE_AD_HOC_SUBPROCESS_NOT_FOUND =
-      "AD_HOC_SUBPROCESS_NOT_FOUND";
+  private static final String ERROR_CODE_AD_HOC_SUB_PROCESS_NOT_FOUND =
+      "AD_HOC_SUB_PROCESS_NOT_FOUND";
   private static final String ERROR_CODE_AD_HOC_TOOL_DEFINITION_INVALID =
       "AD_HOC_TOOL_DEFINITION_INVALID";
   private static final String ERROR_CODE_AD_HOC_TOOL_SCHEMA_INVALID = "AD_HOC_TOOL_SCHEMA_INVALID";
@@ -63,18 +63,18 @@ public class CamundaClientAdHocToolsSchemaResolver implements AdHocToolsSchemaRe
 
   @Override
   public AdHocToolsSchemaResponse resolveSchema(
-      Long processDefinitionKey, String adHocSubprocessId) {
+      Long processDefinitionKey, String adHocSubProcessId) {
     if (processDefinitionKey == null || processDefinitionKey <= 0) {
       throw new IllegalArgumentException("Process definition key must not be null or negative");
     }
 
-    if (adHocSubprocessId == null || adHocSubprocessId.isBlank()) {
-      throw new IllegalArgumentException("adHocSubprocessId cannot be null or empty");
+    if (adHocSubProcessId == null || adHocSubProcessId.isBlank()) {
+      throw new IllegalArgumentException("adHocSubProcessId cannot be null or empty");
     }
 
     LOGGER.info(
-        "Resolving tool schema for ad-hoc subprocess {} in process definition with key {}",
-        adHocSubprocessId,
+        "Resolving tool schema for ad-hoc sub-process {} in process definition with key {}",
+        adHocSubProcessId,
         processDefinitionKey);
 
     final String processDefinitionXml =
@@ -84,12 +84,12 @@ public class CamundaClientAdHocToolsSchemaResolver implements AdHocToolsSchemaRe
         Bpmn.readModelFromStream(
             new ByteArrayInputStream(processDefinitionXml.getBytes(StandardCharsets.UTF_8)));
 
-    final var processElement = modelInstance.getModelElementById(adHocSubprocessId);
+    final var processElement = modelInstance.getModelElementById(adHocSubProcessId);
     if (!(processElement instanceof final AdHocSubProcess adHocSubProcess)) {
       throw new ConnectorException(
-          ERROR_CODE_AD_HOC_SUBPROCESS_NOT_FOUND,
-          "Unable to resolve tools schema. Ad-hoc subprocess with ID '%s' was not found."
-              .formatted(adHocSubprocessId));
+          ERROR_CODE_AD_HOC_SUB_PROCESS_NOT_FOUND,
+          "Unable to resolve tools schema. Ad-hoc sub-process with ID '%s' was not found."
+              .formatted(adHocSubProcessId));
     }
 
     final var toolDefinitions =

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/AgentRequest.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/AgentRequest.java
@@ -124,15 +124,15 @@ Reveal **no** additional private reasoning outside these tags.
     public record ToolsConfiguration(
         @TemplateProperty(
                 group = "tools",
-                label = "Ad-hoc subprocess ID",
-                description = "The ID of the subprocess containing the tools to be called",
+                label = "Ad-hoc sub-process ID",
+                description = "The ID of the sub-process containing the tools to be called",
                 optional = true)
             String containerElementId,
         @FEEL
             @TemplateProperty(
                 group = "tools",
                 label = "Tool Call Results",
-                description = "Tool call results as returned by the subprocess",
+                description = "Tool call results as returned by the sub-process",
                 type = TemplateProperty.PropertyType.Text,
                 feel = Property.FeelMode.required,
                 optional = true)

--- a/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/adhoctoolsschema/resolver/CachingAdHocToolsSchemaResolverTest.java
+++ b/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/adhoctoolsschema/resolver/CachingAdHocToolsSchemaResolverTest.java
@@ -38,8 +38,8 @@ class CachingAdHocToolsSchemaResolverTest {
   private static final Long PROCESS_DEFINITION_KEY_1 = 123456L;
   private static final Long PROCESS_DEFINITION_KEY_2 = 654321L;
 
-  private static final String AD_HOC_SUBPROCESS_ID_1 = "AHSP_1";
-  private static final String AD_HOC_SUBPROCESS_ID_2 = "AHSP_2";
+  private static final String AD_HOC_SUB_PROCESS_ID_1 = "AHSP_1";
+  private static final String AD_HOC_SUB_PROCESS_ID_2 = "AHSP_2";
 
   @Mock private AdHocToolsSchemaResolver delegate;
   private CachingAdHocToolsSchemaResolver resolver;
@@ -55,15 +55,15 @@ class CachingAdHocToolsSchemaResolverTest {
   @Test
   void returnsCachedValue() {
     final var mockedResponse = mock(AdHocToolsSchemaResponse.class);
-    when(delegate.resolveSchema(PROCESS_DEFINITION_KEY_1, AD_HOC_SUBPROCESS_ID_1))
+    when(delegate.resolveSchema(PROCESS_DEFINITION_KEY_1, AD_HOC_SUB_PROCESS_ID_1))
         .thenReturn(mockedResponse);
 
-    final var response1 = resolver.resolveSchema(PROCESS_DEFINITION_KEY_1, AD_HOC_SUBPROCESS_ID_1);
-    final var response2 = resolver.resolveSchema(PROCESS_DEFINITION_KEY_1, AD_HOC_SUBPROCESS_ID_1);
+    final var response1 = resolver.resolveSchema(PROCESS_DEFINITION_KEY_1, AD_HOC_SUB_PROCESS_ID_1);
+    final var response2 = resolver.resolveSchema(PROCESS_DEFINITION_KEY_1, AD_HOC_SUB_PROCESS_ID_1);
 
     assertThat(response1).isSameAs(response2).isSameAs(mockedResponse);
 
-    verify(delegate, times(1)).resolveSchema(PROCESS_DEFINITION_KEY_1, AD_HOC_SUBPROCESS_ID_1);
+    verify(delegate, times(1)).resolveSchema(PROCESS_DEFINITION_KEY_1, AD_HOC_SUB_PROCESS_ID_1);
     verifyNoMoreInteractions(delegate);
   }
 
@@ -94,7 +94,7 @@ class CachingAdHocToolsSchemaResolverTest {
   @NullSource
   @ValueSource(longs = {0, -10})
   void throwsExceptionWhenProcessDefinitionKeyIsInvalid(Long processDefinitionKey) {
-    assertThatThrownBy(() -> resolver.resolveSchema(processDefinitionKey, AD_HOC_SUBPROCESS_ID_1))
+    assertThatThrownBy(() -> resolver.resolveSchema(processDefinitionKey, AD_HOC_SUB_PROCESS_ID_1))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Process definition key must not be null or negative");
 
@@ -104,10 +104,10 @@ class CachingAdHocToolsSchemaResolverTest {
   @ParameterizedTest
   @NullAndEmptySource
   @ValueSource(strings = {"   "})
-  void throwsExceptionWhenAdHocSubprocessIdIsInvalid(String adHocSubprocessId) {
-    assertThatThrownBy(() -> resolver.resolveSchema(PROCESS_DEFINITION_KEY_1, adHocSubprocessId))
+  void throwsExceptionWhenAdHocSubProcessIdIsInvalid(String adHocSubProcessId) {
+    assertThatThrownBy(() -> resolver.resolveSchema(PROCESS_DEFINITION_KEY_1, adHocSubProcessId))
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("adHocSubprocessId cannot be null or empty");
+        .hasMessage("adHocSubProcessId cannot be null or empty");
 
     verifyNoInteractions(delegate);
   }
@@ -115,10 +115,10 @@ class CachingAdHocToolsSchemaResolverTest {
   static Stream<Arguments> differentCacheKeys() {
     return Stream.of(
         arguments(
-            Pair.of(PROCESS_DEFINITION_KEY_1, AD_HOC_SUBPROCESS_ID_1),
-            Pair.of(PROCESS_DEFINITION_KEY_1, AD_HOC_SUBPROCESS_ID_2)),
+            Pair.of(PROCESS_DEFINITION_KEY_1, AD_HOC_SUB_PROCESS_ID_1),
+            Pair.of(PROCESS_DEFINITION_KEY_1, AD_HOC_SUB_PROCESS_ID_2)),
         arguments(
-            Pair.of(PROCESS_DEFINITION_KEY_1, AD_HOC_SUBPROCESS_ID_1),
-            Pair.of(PROCESS_DEFINITION_KEY_2, AD_HOC_SUBPROCESS_ID_1)));
+            Pair.of(PROCESS_DEFINITION_KEY_1, AD_HOC_SUB_PROCESS_ID_1),
+            Pair.of(PROCESS_DEFINITION_KEY_2, AD_HOC_SUB_PROCESS_ID_1)));
   }
 }

--- a/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/adhoctoolsschema/resolver/CamundaClientAdHocToolsSchemaResolverTest.java
+++ b/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/adhoctoolsschema/resolver/CamundaClientAdHocToolsSchemaResolverTest.java
@@ -8,7 +8,6 @@ package io.camunda.connector.agenticai.adhoctoolsschema.resolver;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
@@ -46,7 +45,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class CamundaClientAdHocToolsSchemaResolverTest {
 
   private static final Long PROCESS_DEFINITION_KEY = 123456L;
-  private static final String AD_HOC_SUBPROCESS_ID = "Agent_Tools";
+  private static final String AD_HOC_SUB_PROCESS_ID = "Agent_Tools";
 
   @Mock(answer = Answers.RETURNS_DEEP_STUBS)
   private CamundaClient camundaClient;
@@ -89,7 +88,7 @@ class CamundaClientAdHocToolsSchemaResolverTest {
     when(schemaGenerator.generateToolSchema(any())).thenReturn(expectedEmptySchema);
     doReturn(expectedToolASchema).when(schemaGenerator).generateToolSchema(toolAInputParams);
 
-    final var result = resolver.resolveSchema(PROCESS_DEFINITION_KEY, AD_HOC_SUBPROCESS_ID);
+    final var result = resolver.resolveSchema(PROCESS_DEFINITION_KEY, AD_HOC_SUB_PROCESS_ID);
 
     assertThat(result).isNotNull();
     assertThat(result.toolDefinitions())
@@ -136,10 +135,10 @@ class CamundaClientAdHocToolsSchemaResolverTest {
   @ParameterizedTest
   @NullAndEmptySource
   @ValueSource(strings = {"   "})
-  void throwsExceptionWhenAdHocSubprocessIdIsInvalid(String adHocSubprocessId) {
-    assertThatThrownBy(() -> resolver.resolveSchema(123456L, adHocSubprocessId))
+  void throwsExceptionWhenAdHocSubProcessIdIsInvalid(String adHocSubProcessId) {
+    assertThatThrownBy(() -> resolver.resolveSchema(123456L, adHocSubProcessId))
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("adHocSubprocessId cannot be null or empty");
+        .hasMessage("adHocSubProcessId cannot be null or empty");
 
     verifyNoInteractions(camundaClient, feelInputParamExtractor, schemaGenerator);
   }
@@ -149,12 +148,12 @@ class CamundaClientAdHocToolsSchemaResolverTest {
     when(camundaClient.newProcessDefinitionGetXmlRequest(PROCESS_DEFINITION_KEY).send().join())
         .thenReturn("DUMMY");
 
-    assertThatThrownBy(() -> resolver.resolveSchema(PROCESS_DEFINITION_KEY, AD_HOC_SUBPROCESS_ID))
+    assertThatThrownBy(() -> resolver.resolveSchema(PROCESS_DEFINITION_KEY, AD_HOC_SUB_PROCESS_ID))
         .isInstanceOf(ModelParseException.class);
   }
 
   @Test
-  void throwsExceptionWhenAdHocSubprocessWithRequestedIdDoesNotExist() {
+  void throwsExceptionWhenAdHocSubProcessWithRequestedIdDoesNotExist() {
     when(camundaClient.newProcessDefinitionGetXmlRequest(PROCESS_DEFINITION_KEY).send().join())
         .thenReturn(bpmnXml);
 
@@ -162,10 +161,10 @@ class CamundaClientAdHocToolsSchemaResolverTest {
         .isInstanceOfSatisfying(
             ConnectorException.class,
             e -> {
-              assertThat(e.getErrorCode()).isEqualTo("AD_HOC_SUBPROCESS_NOT_FOUND");
+              assertThat(e.getErrorCode()).isEqualTo("AD_HOC_SUB_PROCESS_NOT_FOUND");
               assertThat(e.getMessage())
                   .isEqualTo(
-                      "Unable to resolve tools schema. Ad-hoc subprocess with ID 'DUMMY' was not found.");
+                      "Unable to resolve tools schema. Ad-hoc sub-process with ID 'DUMMY' was not found.");
             });
   }
 
@@ -178,7 +177,7 @@ class CamundaClientAdHocToolsSchemaResolverTest {
         .when(feelInputParamExtractor)
         .extractInputParams("fromAi(toolCall.inputParameter, \"An input parameter\")");
 
-    assertThatThrownBy(() -> resolver.resolveSchema(PROCESS_DEFINITION_KEY, AD_HOC_SUBPROCESS_ID))
+    assertThatThrownBy(() -> resolver.resolveSchema(PROCESS_DEFINITION_KEY, AD_HOC_SUB_PROCESS_ID))
         .isInstanceOfSatisfying(
             ConnectorException.class,
             e -> {
@@ -199,7 +198,7 @@ class CamundaClientAdHocToolsSchemaResolverTest {
         .when(feelInputParamExtractor)
         .extractInputParams("fromAi(toolCall.outputParameter, \"An output parameter\")");
 
-    assertThatThrownBy(() -> resolver.resolveSchema(PROCESS_DEFINITION_KEY, AD_HOC_SUBPROCESS_ID))
+    assertThatThrownBy(() -> resolver.resolveSchema(PROCESS_DEFINITION_KEY, AD_HOC_SUB_PROCESS_ID))
         .isInstanceOfSatisfying(
             ConnectorException.class,
             e -> {
@@ -217,7 +216,7 @@ class CamundaClientAdHocToolsSchemaResolverTest {
     when(schemaGenerator.generateToolSchema(any()))
         .thenThrow(new SchemaGenerationException("I can't generate this schema"));
 
-    assertThatThrownBy(() -> resolver.resolveSchema(PROCESS_DEFINITION_KEY, AD_HOC_SUBPROCESS_ID))
+    assertThatThrownBy(() -> resolver.resolveSchema(PROCESS_DEFINITION_KEY, AD_HOC_SUB_PROCESS_ID))
         .isInstanceOfSatisfying(
             ConnectorException.class,
             e -> {


### PR DESCRIPTION
## Description

Uses a consistent naming of `ad-hoc sub-process` (text, API specs) and `AdHocSubProcess` (code) throughout the codebase - no behavioral changes, only renames.

Background: https://github.com/camunda/documentation-team/issues/460

## Related issues

Related Camunda issue for ad-hoc sub-process APIs: https://github.com/camunda/camunda/pull/31839

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.

