### PR TITLE
refactor(agentic-ai): Update model parameters to be provider specific

### DIFF
--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/resources/agentic-ai-connectors.bpmn
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/resources/agentic-ai-connectors.bpmn
@@ -117,6 +117,8 @@
           <zeebe:input source="Agent_Tools" target="data.containerElementId" />
         </zeebe:ioMapping>
         <zeebe:taskHeaders>
+          <zeebe:header key="elementTemplateVersion" value="0" />
+          <zeebe:header key="elementTemplateId" value="io.camunda.connectors.agenticai.adhoctoolsschema.v0" />
           <zeebe:header key="resultVariable" value="resolvedSchema" />
           <zeebe:header key="retryBackoff" value="PT0S" />
         </zeebe:taskHeaders>
@@ -166,10 +168,6 @@
           <zeebe:input source="=agent.context" target="data.context" />
           <zeebe:input source="=50" target="data.memory.maxMessages" />
           <zeebe:input source="=9" target="data.limits.maxModelCalls" />
-          <zeebe:input source="=8192" target="provider.openai.model.parameters.maxOutputTokens" />
-          <zeebe:input source="=0.8" target="provider.openai.model.parameters.temperature" />
-          <zeebe:input source="=1" target="provider.openai.model.parameters.topP" />
-          <zeebe:input source="=50" target="provider.openai.model.parameters.topK" />
         </zeebe:ioMapping>
         <zeebe:taskHeaders>
           <zeebe:header key="elementTemplateVersion" value="0" />

--- a/connectors/agentic-ai/element-templates/agenticai-aiagent-outbound-connector.json
+++ b/connectors/agentic-ai/element-templates/agenticai-aiagent-outbound-connector.json
@@ -41,7 +41,7 @@
   }, {
     "id" : "parameters",
     "label" : "Model Parameters",
-    "tooltip" : "Configuration of common model parameters to optimize and fine-tune LLM responses. Limits such as maximum output tokens are <strong>per LLM request</strong>.",
+    "tooltip" : "Optional configuration of common model parameters to optimize and fine-tune LLM responses. Limits such as maximum output tokens are <strong>per LLM request</strong>.",
     "openByDefault" : false
   }, {
     "id" : "connector",
@@ -124,7 +124,7 @@
   }, {
     "id" : "provider.bedrock.region",
     "label" : "Region",
-    "description" : "Specify the AWS region",
+    "description" : "Specify the AWS region (example: <code>eu-west-1</code>)",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -504,7 +504,7 @@
   }, {
     "id" : "provider.anthropic.model.parameters.maxTokens",
     "label" : "Maximum Tokens",
-    "description" : "The maximum number of tokens per request to generate before stopping.",
+    "description" : "The maximum number of tokens per request to generate before stopping. Details in the <a href=\"https://docs.anthropic.com/en/api/messages#body-max-tokens\" target=\"_blank\">documentation</a>.",
     "optional" : true,
     "feel" : "required",
     "group" : "parameters",
@@ -533,6 +533,7 @@
       "equals" : "anthropic",
       "type" : "simple"
     },
+    "tooltip" : "Floating point number between <code>0</code> and <code>1</code>. The higher the number, the more randomness will be injected into the response. Details in the <a href=\"https://docs.anthropic.com/en/api/messages#body-temperature\" target=\"_blank\">documentation</a>.",
     "type" : "Number"
   }, {
     "id" : "provider.anthropic.model.parameters.topP",
@@ -549,6 +550,7 @@
       "equals" : "anthropic",
       "type" : "simple"
     },
+    "tooltip" : "Floating point number between <code>0</code> and <code>1</code>. Recommended for advanced use cases only, you usually only need to use <code>temperature</code>. Details in the <a href=\"https://docs.anthropic.com/en/api/messages#body-top-p\" target=\"_blank\">documentation</a>.",
     "type" : "Number"
   }, {
     "id" : "provider.anthropic.model.parameters.topK",
@@ -565,16 +567,16 @@
       "equals" : "anthropic",
       "type" : "simple"
     },
+    "tooltip" : "Integer greater than <code>0</code>. Recommended for advanced use cases only, you usually only need to use <code>temperature</code>. Details in the <a href=\"https://docs.anthropic.com/en/api/messages#body-top-k\" target=\"_blank\">documentation</a>.",
     "type" : "Number"
   }, {
-    "id" : "provider.bedrock.model.parameters.maxOutputTokens",
-    "label" : "Maximum Output Tokens",
-    "description" : "The maximum number of tokens to allow in the generated response.",
+    "id" : "provider.bedrock.model.parameters.maxTokens",
+    "label" : "Maximum Tokens",
     "optional" : true,
     "feel" : "required",
     "group" : "parameters",
     "binding" : {
-      "name" : "provider.bedrock.model.parameters.maxOutputTokens",
+      "name" : "provider.bedrock.model.parameters.maxTokens",
       "type" : "zeebe:input"
     },
     "condition" : {
@@ -582,6 +584,7 @@
       "equals" : "bedrock",
       "type" : "simple"
     },
+    "tooltip" : "The maximum number of tokens to allow in the generated response. Details in the <a href=\"https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_InferenceConfiguration.html\" target=\"_blank\">documentation</a>.",
     "type" : "Number"
   }, {
     "id" : "provider.bedrock.model.parameters.temperature",
@@ -598,6 +601,7 @@
       "equals" : "bedrock",
       "type" : "simple"
     },
+    "tooltip" : "Floating point number between <code>0</code> and <code>1</code>. The higher the number, the more randomness will be injected into the response. Details in the <a href=\"https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_InferenceConfiguration.html\" target=\"_blank\">documentation</a>.",
     "type" : "Number"
   }, {
     "id" : "provider.bedrock.model.parameters.topP",
@@ -614,6 +618,7 @@
       "equals" : "bedrock",
       "type" : "simple"
     },
+    "tooltip" : "Floating point number between <code>0</code> and <code>1</code>. Recommended for advanced use cases only, you usually only need to use <code>temperature</code>. Details in the <a href=\"https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_InferenceConfiguration.html\" target=\"_blank\">documentation</a>.",
     "type" : "Number"
   }, {
     "id" : "provider.openai.model.parameters.maxOutputTokens",
@@ -634,6 +639,7 @@
   }, {
     "id" : "provider.openai.model.parameters.maxCompletionTokens",
     "label" : "Maximum Completion Tokens",
+    "description" : "The maximum number of tokens per request to generate before stopping. Details in the <a href=\"https://platform.openai.com/docs/api-reference/chat/create#chat-create-max_completion_tokens\" target=\"_blank\">documentation</a>.",
     "optional" : true,
     "feel" : "required",
     "group" : "parameters",
@@ -662,6 +668,7 @@
       "equals" : "openai",
       "type" : "simple"
     },
+    "tooltip" : "Floating point number between <code>0</code> and <code>2</code>. The higher the number, the more randomness will be injected into the response. Details in the <a href=\"https://platform.openai.com/docs/api-reference/chat/create#chat-create-temperature\" target=\"_blank\">documentation</a>.",
     "type" : "Number"
   }, {
     "id" : "provider.openai.model.parameters.topP",
@@ -678,6 +685,7 @@
       "equals" : "openai",
       "type" : "simple"
     },
+    "tooltip" : "Recommended for advanced use cases only, you usually only need to use <code>temperature</code>. Details in the <a href=\"https://platform.openai.com/docs/api-reference/chat/create#chat-create-top_p\" target=\"_blank\">documentation</a>.",
     "type" : "Number"
   }, {
     "id" : "provider.openai.model.parameters.topK",

--- a/connectors/agentic-ai/element-templates/agenticai-aiagent-outbound-connector.json
+++ b/connectors/agentic-ai/element-templates/agenticai-aiagent-outbound-connector.json
@@ -621,22 +621,6 @@
     "tooltip" : "Floating point number between <code>0</code> and <code>1</code>. Recommended for advanced use cases only, you usually only need to use <code>temperature</code>. Details in the <a href=\"https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_InferenceConfiguration.html\" target=\"_blank\">documentation</a>.",
     "type" : "Number"
   }, {
-    "id" : "provider.openai.model.parameters.maxOutputTokens",
-    "label" : "Maximum Output Tokens",
-    "optional" : true,
-    "feel" : "required",
-    "group" : "parameters",
-    "binding" : {
-      "name" : "provider.openai.model.parameters.maxOutputTokens",
-      "type" : "zeebe:input"
-    },
-    "condition" : {
-      "property" : "provider.type",
-      "equals" : "openai",
-      "type" : "simple"
-    },
-    "type" : "Number"
-  }, {
     "id" : "provider.openai.model.parameters.maxCompletionTokens",
     "label" : "Maximum Completion Tokens",
     "description" : "The maximum number of tokens per request to generate before stopping. Details in the <a href=\"https://platform.openai.com/docs/api-reference/chat/create#chat-create-max_completion_tokens\" target=\"_blank\">documentation</a>.",
@@ -686,22 +670,6 @@
       "type" : "simple"
     },
     "tooltip" : "Recommended for advanced use cases only, you usually only need to use <code>temperature</code>. Details in the <a href=\"https://platform.openai.com/docs/api-reference/chat/create#chat-create-top_p\" target=\"_blank\">documentation</a>.",
-    "type" : "Number"
-  }, {
-    "id" : "provider.openai.model.parameters.topK",
-    "label" : "top K",
-    "optional" : true,
-    "feel" : "required",
-    "group" : "parameters",
-    "binding" : {
-      "name" : "provider.openai.model.parameters.topK",
-      "type" : "zeebe:input"
-    },
-    "condition" : {
-      "property" : "provider.type",
-      "equals" : "openai",
-      "type" : "simple"
-    },
     "type" : "Number"
   }, {
     "id" : "version",

--- a/connectors/agentic-ai/element-templates/agenticai-aiagent-outbound-connector.json
+++ b/connectors/agentic-ai/element-templates/agenticai-aiagent-outbound-connector.json
@@ -504,7 +504,6 @@
   }, {
     "id" : "provider.anthropic.model.parameters.maxTokens",
     "label" : "Maximum Tokens",
-    "description" : "The maximum number of tokens per request to generate before stopping. Details in the <a href=\"https://docs.anthropic.com/en/api/messages#body-max-tokens\" target=\"_blank\">documentation</a>.",
     "optional" : true,
     "feel" : "required",
     "group" : "parameters",
@@ -517,6 +516,7 @@
       "equals" : "anthropic",
       "type" : "simple"
     },
+    "tooltip" : "The maximum number of tokens per request to generate before stopping. <br><br>Details in the <a href=\"https://docs.anthropic.com/en/api/messages#body-max-tokens\" target=\"_blank\">documentation</a>.",
     "type" : "Number"
   }, {
     "id" : "provider.anthropic.model.parameters.temperature",
@@ -533,7 +533,7 @@
       "equals" : "anthropic",
       "type" : "simple"
     },
-    "tooltip" : "Floating point number between <code>0</code> and <code>1</code>. The higher the number, the more randomness will be injected into the response. Details in the <a href=\"https://docs.anthropic.com/en/api/messages#body-temperature\" target=\"_blank\">documentation</a>.",
+    "tooltip" : "Floating point number between 0 and 1. The higher the number, the more randomness will be injected into the response. <br><br>Details in the <a href=\"https://docs.anthropic.com/en/api/messages#body-temperature\" target=\"_blank\">documentation</a>.",
     "type" : "Number"
   }, {
     "id" : "provider.anthropic.model.parameters.topP",
@@ -550,7 +550,7 @@
       "equals" : "anthropic",
       "type" : "simple"
     },
-    "tooltip" : "Floating point number between <code>0</code> and <code>1</code>. Recommended for advanced use cases only, you usually only need to use <code>temperature</code>. Details in the <a href=\"https://docs.anthropic.com/en/api/messages#body-top-p\" target=\"_blank\">documentation</a>.",
+    "tooltip" : "Floating point number between 0 and 1. Recommended for advanced use cases only (you usually only need to use temperature). <br><br>Details in the <a href=\"https://docs.anthropic.com/en/api/messages#body-top-p\" target=\"_blank\">documentation</a>.",
     "type" : "Number"
   }, {
     "id" : "provider.anthropic.model.parameters.topK",
@@ -567,7 +567,7 @@
       "equals" : "anthropic",
       "type" : "simple"
     },
-    "tooltip" : "Integer greater than <code>0</code>. Recommended for advanced use cases only, you usually only need to use <code>temperature</code>. Details in the <a href=\"https://docs.anthropic.com/en/api/messages#body-top-k\" target=\"_blank\">documentation</a>.",
+    "tooltip" : "Integer greater than 0. Recommended for advanced use cases only (you usually only need to use temperature). <br><br>Details in the <a href=\"https://docs.anthropic.com/en/api/messages#body-top-k\" target=\"_blank\">documentation</a>.",
     "type" : "Number"
   }, {
     "id" : "provider.bedrock.model.parameters.maxTokens",
@@ -584,7 +584,7 @@
       "equals" : "bedrock",
       "type" : "simple"
     },
-    "tooltip" : "The maximum number of tokens to allow in the generated response. Details in the <a href=\"https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_InferenceConfiguration.html\" target=\"_blank\">documentation</a>.",
+    "tooltip" : "The maximum number of tokens to allow in the generated response. <br><br>Details in the <a href=\"https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_InferenceConfiguration.html\" target=\"_blank\">documentation</a>.",
     "type" : "Number"
   }, {
     "id" : "provider.bedrock.model.parameters.temperature",
@@ -601,7 +601,7 @@
       "equals" : "bedrock",
       "type" : "simple"
     },
-    "tooltip" : "Floating point number between <code>0</code> and <code>1</code>. The higher the number, the more randomness will be injected into the response. Details in the <a href=\"https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_InferenceConfiguration.html\" target=\"_blank\">documentation</a>.",
+    "tooltip" : "Floating point number between 0 and 1. The higher the number, the more randomness will be injected into the response. <br><br>Details in the <a href=\"https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_InferenceConfiguration.html\" target=\"_blank\">documentation</a>.",
     "type" : "Number"
   }, {
     "id" : "provider.bedrock.model.parameters.topP",
@@ -618,12 +618,11 @@
       "equals" : "bedrock",
       "type" : "simple"
     },
-    "tooltip" : "Floating point number between <code>0</code> and <code>1</code>. Recommended for advanced use cases only, you usually only need to use <code>temperature</code>. Details in the <a href=\"https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_InferenceConfiguration.html\" target=\"_blank\">documentation</a>.",
+    "tooltip" : "Floating point number between 0 and 1. Recommended for advanced use cases only (you usually only need to use temperature). <br><br>Details in the <a href=\"https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_InferenceConfiguration.html\" target=\"_blank\">documentation</a>.",
     "type" : "Number"
   }, {
     "id" : "provider.openai.model.parameters.maxCompletionTokens",
     "label" : "Maximum Completion Tokens",
-    "description" : "The maximum number of tokens per request to generate before stopping. Details in the <a href=\"https://platform.openai.com/docs/api-reference/chat/create#chat-create-max_completion_tokens\" target=\"_blank\">documentation</a>.",
     "optional" : true,
     "feel" : "required",
     "group" : "parameters",
@@ -636,6 +635,7 @@
       "equals" : "openai",
       "type" : "simple"
     },
+    "tooltip" : "The maximum number of tokens per request to generate before stopping. <br><br>Details in the <a href=\"https://platform.openai.com/docs/api-reference/chat/create#chat-create-max_completion_tokens\" target=\"_blank\">documentation</a>.",
     "type" : "Number"
   }, {
     "id" : "provider.openai.model.parameters.temperature",
@@ -652,7 +652,7 @@
       "equals" : "openai",
       "type" : "simple"
     },
-    "tooltip" : "Floating point number between <code>0</code> and <code>2</code>. The higher the number, the more randomness will be injected into the response. Details in the <a href=\"https://platform.openai.com/docs/api-reference/chat/create#chat-create-temperature\" target=\"_blank\">documentation</a>.",
+    "tooltip" : "Floating point number between 0 and 2. The higher the number, the more randomness will be injected into the response. <br><br>Details in the <a href=\"https://platform.openai.com/docs/api-reference/chat/create#chat-create-temperature\" target=\"_blank\">documentation</a>.",
     "type" : "Number"
   }, {
     "id" : "provider.openai.model.parameters.topP",
@@ -669,7 +669,7 @@
       "equals" : "openai",
       "type" : "simple"
     },
-    "tooltip" : "Recommended for advanced use cases only, you usually only need to use <code>temperature</code>. Details in the <a href=\"https://platform.openai.com/docs/api-reference/chat/create#chat-create-top_p\" target=\"_blank\">documentation</a>.",
+    "tooltip" : "Recommended for advanced use cases only (you usually only need to use temperature). <br><br>Details in the <a href=\"https://platform.openai.com/docs/api-reference/chat/create#chat-create-top_p\" target=\"_blank\">documentation</a>.",
     "type" : "Number"
   }, {
     "id" : "version",

--- a/connectors/agentic-ai/element-templates/agenticai-aiagent-outbound-connector.json
+++ b/connectors/agentic-ai/element-templates/agenticai-aiagent-outbound-connector.json
@@ -41,7 +41,7 @@
   }, {
     "id" : "parameters",
     "label" : "Model Parameters",
-    "tooltip" : "Configuration of common model parameters to optimize and fine-tune LLM responses.",
+    "tooltip" : "Configuration of common model parameters to optimize and fine-tune LLM responses. Limits such as maximum output tokens are <strong>per LLM request</strong>.",
     "openByDefault" : false
   }, {
     "id" : "connector",
@@ -502,13 +502,14 @@
     },
     "type" : "Number"
   }, {
-    "id" : "provider.anthropic.model.parameters.maxOutputTokens",
-    "label" : "Maximum Output Tokens",
+    "id" : "provider.anthropic.model.parameters.maxTokens",
+    "label" : "Maximum Tokens",
+    "description" : "The maximum number of tokens per request to generate before stopping.",
     "optional" : true,
     "feel" : "required",
     "group" : "parameters",
     "binding" : {
-      "name" : "provider.anthropic.model.parameters.maxOutputTokens",
+      "name" : "provider.anthropic.model.parameters.maxTokens",
       "type" : "zeebe:input"
     },
     "condition" : {
@@ -568,6 +569,7 @@
   }, {
     "id" : "provider.bedrock.model.parameters.maxOutputTokens",
     "label" : "Maximum Output Tokens",
+    "description" : "The maximum number of tokens to allow in the generated response.",
     "optional" : true,
     "feel" : "required",
     "group" : "parameters",
@@ -614,22 +616,6 @@
     },
     "type" : "Number"
   }, {
-    "id" : "provider.bedrock.model.parameters.topK",
-    "label" : "top K",
-    "optional" : true,
-    "feel" : "required",
-    "group" : "parameters",
-    "binding" : {
-      "name" : "provider.bedrock.model.parameters.topK",
-      "type" : "zeebe:input"
-    },
-    "condition" : {
-      "property" : "provider.type",
-      "equals" : "bedrock",
-      "type" : "simple"
-    },
-    "type" : "Number"
-  }, {
     "id" : "provider.openai.model.parameters.maxOutputTokens",
     "label" : "Maximum Output Tokens",
     "optional" : true,
@@ -637,6 +623,22 @@
     "group" : "parameters",
     "binding" : {
       "name" : "provider.openai.model.parameters.maxOutputTokens",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "provider.type",
+      "equals" : "openai",
+      "type" : "simple"
+    },
+    "type" : "Number"
+  }, {
+    "id" : "provider.openai.model.parameters.maxCompletionTokens",
+    "label" : "Maximum Completion Tokens",
+    "optional" : true,
+    "feel" : "required",
+    "group" : "parameters",
+    "binding" : {
+      "name" : "provider.openai.model.parameters.maxCompletionTokens",
       "type" : "zeebe:input"
     },
     "condition" : {

--- a/connectors/agentic-ai/element-templates/hybrid/agenticai-aiagent-outbound-connector-hybrid.json
+++ b/connectors/agentic-ai/element-templates/hybrid/agenticai-aiagent-outbound-connector-hybrid.json
@@ -626,22 +626,6 @@
     "tooltip" : "Floating point number between <code>0</code> and <code>1</code>. Recommended for advanced use cases only, you usually only need to use <code>temperature</code>. Details in the <a href=\"https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_InferenceConfiguration.html\" target=\"_blank\">documentation</a>.",
     "type" : "Number"
   }, {
-    "id" : "provider.openai.model.parameters.maxOutputTokens",
-    "label" : "Maximum Output Tokens",
-    "optional" : true,
-    "feel" : "required",
-    "group" : "parameters",
-    "binding" : {
-      "name" : "provider.openai.model.parameters.maxOutputTokens",
-      "type" : "zeebe:input"
-    },
-    "condition" : {
-      "property" : "provider.type",
-      "equals" : "openai",
-      "type" : "simple"
-    },
-    "type" : "Number"
-  }, {
     "id" : "provider.openai.model.parameters.maxCompletionTokens",
     "label" : "Maximum Completion Tokens",
     "description" : "The maximum number of tokens per request to generate before stopping. Details in the <a href=\"https://platform.openai.com/docs/api-reference/chat/create#chat-create-max_completion_tokens\" target=\"_blank\">documentation</a>.",
@@ -691,22 +675,6 @@
       "type" : "simple"
     },
     "tooltip" : "Recommended for advanced use cases only, you usually only need to use <code>temperature</code>. Details in the <a href=\"https://platform.openai.com/docs/api-reference/chat/create#chat-create-top_p\" target=\"_blank\">documentation</a>.",
-    "type" : "Number"
-  }, {
-    "id" : "provider.openai.model.parameters.topK",
-    "label" : "top K",
-    "optional" : true,
-    "feel" : "required",
-    "group" : "parameters",
-    "binding" : {
-      "name" : "provider.openai.model.parameters.topK",
-      "type" : "zeebe:input"
-    },
-    "condition" : {
-      "property" : "provider.type",
-      "equals" : "openai",
-      "type" : "simple"
-    },
     "type" : "Number"
   }, {
     "id" : "version",

--- a/connectors/agentic-ai/element-templates/hybrid/agenticai-aiagent-outbound-connector-hybrid.json
+++ b/connectors/agentic-ai/element-templates/hybrid/agenticai-aiagent-outbound-connector-hybrid.json
@@ -509,7 +509,6 @@
   }, {
     "id" : "provider.anthropic.model.parameters.maxTokens",
     "label" : "Maximum Tokens",
-    "description" : "The maximum number of tokens per request to generate before stopping. Details in the <a href=\"https://docs.anthropic.com/en/api/messages#body-max-tokens\" target=\"_blank\">documentation</a>.",
     "optional" : true,
     "feel" : "required",
     "group" : "parameters",
@@ -522,6 +521,7 @@
       "equals" : "anthropic",
       "type" : "simple"
     },
+    "tooltip" : "The maximum number of tokens per request to generate before stopping. <br><br>Details in the <a href=\"https://docs.anthropic.com/en/api/messages#body-max-tokens\" target=\"_blank\">documentation</a>.",
     "type" : "Number"
   }, {
     "id" : "provider.anthropic.model.parameters.temperature",
@@ -538,7 +538,7 @@
       "equals" : "anthropic",
       "type" : "simple"
     },
-    "tooltip" : "Floating point number between <code>0</code> and <code>1</code>. The higher the number, the more randomness will be injected into the response. Details in the <a href=\"https://docs.anthropic.com/en/api/messages#body-temperature\" target=\"_blank\">documentation</a>.",
+    "tooltip" : "Floating point number between 0 and 1. The higher the number, the more randomness will be injected into the response. <br><br>Details in the <a href=\"https://docs.anthropic.com/en/api/messages#body-temperature\" target=\"_blank\">documentation</a>.",
     "type" : "Number"
   }, {
     "id" : "provider.anthropic.model.parameters.topP",
@@ -555,7 +555,7 @@
       "equals" : "anthropic",
       "type" : "simple"
     },
-    "tooltip" : "Floating point number between <code>0</code> and <code>1</code>. Recommended for advanced use cases only, you usually only need to use <code>temperature</code>. Details in the <a href=\"https://docs.anthropic.com/en/api/messages#body-top-p\" target=\"_blank\">documentation</a>.",
+    "tooltip" : "Floating point number between 0 and 1. Recommended for advanced use cases only (you usually only need to use temperature). <br><br>Details in the <a href=\"https://docs.anthropic.com/en/api/messages#body-top-p\" target=\"_blank\">documentation</a>.",
     "type" : "Number"
   }, {
     "id" : "provider.anthropic.model.parameters.topK",
@@ -572,7 +572,7 @@
       "equals" : "anthropic",
       "type" : "simple"
     },
-    "tooltip" : "Integer greater than <code>0</code>. Recommended for advanced use cases only, you usually only need to use <code>temperature</code>. Details in the <a href=\"https://docs.anthropic.com/en/api/messages#body-top-k\" target=\"_blank\">documentation</a>.",
+    "tooltip" : "Integer greater than 0. Recommended for advanced use cases only (you usually only need to use temperature). <br><br>Details in the <a href=\"https://docs.anthropic.com/en/api/messages#body-top-k\" target=\"_blank\">documentation</a>.",
     "type" : "Number"
   }, {
     "id" : "provider.bedrock.model.parameters.maxTokens",
@@ -589,7 +589,7 @@
       "equals" : "bedrock",
       "type" : "simple"
     },
-    "tooltip" : "The maximum number of tokens to allow in the generated response. Details in the <a href=\"https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_InferenceConfiguration.html\" target=\"_blank\">documentation</a>.",
+    "tooltip" : "The maximum number of tokens to allow in the generated response. <br><br>Details in the <a href=\"https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_InferenceConfiguration.html\" target=\"_blank\">documentation</a>.",
     "type" : "Number"
   }, {
     "id" : "provider.bedrock.model.parameters.temperature",
@@ -606,7 +606,7 @@
       "equals" : "bedrock",
       "type" : "simple"
     },
-    "tooltip" : "Floating point number between <code>0</code> and <code>1</code>. The higher the number, the more randomness will be injected into the response. Details in the <a href=\"https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_InferenceConfiguration.html\" target=\"_blank\">documentation</a>.",
+    "tooltip" : "Floating point number between 0 and 1. The higher the number, the more randomness will be injected into the response. <br><br>Details in the <a href=\"https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_InferenceConfiguration.html\" target=\"_blank\">documentation</a>.",
     "type" : "Number"
   }, {
     "id" : "provider.bedrock.model.parameters.topP",
@@ -623,12 +623,11 @@
       "equals" : "bedrock",
       "type" : "simple"
     },
-    "tooltip" : "Floating point number between <code>0</code> and <code>1</code>. Recommended for advanced use cases only, you usually only need to use <code>temperature</code>. Details in the <a href=\"https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_InferenceConfiguration.html\" target=\"_blank\">documentation</a>.",
+    "tooltip" : "Floating point number between 0 and 1. Recommended for advanced use cases only (you usually only need to use temperature). <br><br>Details in the <a href=\"https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_InferenceConfiguration.html\" target=\"_blank\">documentation</a>.",
     "type" : "Number"
   }, {
     "id" : "provider.openai.model.parameters.maxCompletionTokens",
     "label" : "Maximum Completion Tokens",
-    "description" : "The maximum number of tokens per request to generate before stopping. Details in the <a href=\"https://platform.openai.com/docs/api-reference/chat/create#chat-create-max_completion_tokens\" target=\"_blank\">documentation</a>.",
     "optional" : true,
     "feel" : "required",
     "group" : "parameters",
@@ -641,6 +640,7 @@
       "equals" : "openai",
       "type" : "simple"
     },
+    "tooltip" : "The maximum number of tokens per request to generate before stopping. <br><br>Details in the <a href=\"https://platform.openai.com/docs/api-reference/chat/create#chat-create-max_completion_tokens\" target=\"_blank\">documentation</a>.",
     "type" : "Number"
   }, {
     "id" : "provider.openai.model.parameters.temperature",
@@ -657,7 +657,7 @@
       "equals" : "openai",
       "type" : "simple"
     },
-    "tooltip" : "Floating point number between <code>0</code> and <code>2</code>. The higher the number, the more randomness will be injected into the response. Details in the <a href=\"https://platform.openai.com/docs/api-reference/chat/create#chat-create-temperature\" target=\"_blank\">documentation</a>.",
+    "tooltip" : "Floating point number between 0 and 2. The higher the number, the more randomness will be injected into the response. <br><br>Details in the <a href=\"https://platform.openai.com/docs/api-reference/chat/create#chat-create-temperature\" target=\"_blank\">documentation</a>.",
     "type" : "Number"
   }, {
     "id" : "provider.openai.model.parameters.topP",
@@ -674,7 +674,7 @@
       "equals" : "openai",
       "type" : "simple"
     },
-    "tooltip" : "Recommended for advanced use cases only, you usually only need to use <code>temperature</code>. Details in the <a href=\"https://platform.openai.com/docs/api-reference/chat/create#chat-create-top_p\" target=\"_blank\">documentation</a>.",
+    "tooltip" : "Recommended for advanced use cases only (you usually only need to use temperature). <br><br>Details in the <a href=\"https://platform.openai.com/docs/api-reference/chat/create#chat-create-top_p\" target=\"_blank\">documentation</a>.",
     "type" : "Number"
   }, {
     "id" : "version",

--- a/connectors/agentic-ai/element-templates/hybrid/agenticai-aiagent-outbound-connector-hybrid.json
+++ b/connectors/agentic-ai/element-templates/hybrid/agenticai-aiagent-outbound-connector-hybrid.json
@@ -44,7 +44,7 @@
   }, {
     "id" : "parameters",
     "label" : "Model Parameters",
-    "tooltip" : "Configuration of common model parameters to optimize and fine-tune LLM responses. Limits such as maximum output tokens are <strong>per LLM request</strong>.",
+    "tooltip" : "Optional configuration of common model parameters to optimize and fine-tune LLM responses. Limits such as maximum output tokens are <strong>per LLM request</strong>.",
     "openByDefault" : false
   }, {
     "id" : "connector",
@@ -129,7 +129,7 @@
   }, {
     "id" : "provider.bedrock.region",
     "label" : "Region",
-    "description" : "Specify the AWS region",
+    "description" : "Specify the AWS region (example: <code>eu-west-1</code>)",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -509,7 +509,7 @@
   }, {
     "id" : "provider.anthropic.model.parameters.maxTokens",
     "label" : "Maximum Tokens",
-    "description" : "The maximum number of tokens per request to generate before stopping.",
+    "description" : "The maximum number of tokens per request to generate before stopping. Details in the <a href=\"https://docs.anthropic.com/en/api/messages#body-max-tokens\" target=\"_blank\">documentation</a>.",
     "optional" : true,
     "feel" : "required",
     "group" : "parameters",
@@ -538,6 +538,7 @@
       "equals" : "anthropic",
       "type" : "simple"
     },
+    "tooltip" : "Floating point number between <code>0</code> and <code>1</code>. The higher the number, the more randomness will be injected into the response. Details in the <a href=\"https://docs.anthropic.com/en/api/messages#body-temperature\" target=\"_blank\">documentation</a>.",
     "type" : "Number"
   }, {
     "id" : "provider.anthropic.model.parameters.topP",
@@ -554,6 +555,7 @@
       "equals" : "anthropic",
       "type" : "simple"
     },
+    "tooltip" : "Floating point number between <code>0</code> and <code>1</code>. Recommended for advanced use cases only, you usually only need to use <code>temperature</code>. Details in the <a href=\"https://docs.anthropic.com/en/api/messages#body-top-p\" target=\"_blank\">documentation</a>.",
     "type" : "Number"
   }, {
     "id" : "provider.anthropic.model.parameters.topK",
@@ -570,16 +572,16 @@
       "equals" : "anthropic",
       "type" : "simple"
     },
+    "tooltip" : "Integer greater than <code>0</code>. Recommended for advanced use cases only, you usually only need to use <code>temperature</code>. Details in the <a href=\"https://docs.anthropic.com/en/api/messages#body-top-k\" target=\"_blank\">documentation</a>.",
     "type" : "Number"
   }, {
-    "id" : "provider.bedrock.model.parameters.maxOutputTokens",
-    "label" : "Maximum Output Tokens",
-    "description" : "The maximum number of tokens to allow in the generated response.",
+    "id" : "provider.bedrock.model.parameters.maxTokens",
+    "label" : "Maximum Tokens",
     "optional" : true,
     "feel" : "required",
     "group" : "parameters",
     "binding" : {
-      "name" : "provider.bedrock.model.parameters.maxOutputTokens",
+      "name" : "provider.bedrock.model.parameters.maxTokens",
       "type" : "zeebe:input"
     },
     "condition" : {
@@ -587,6 +589,7 @@
       "equals" : "bedrock",
       "type" : "simple"
     },
+    "tooltip" : "The maximum number of tokens to allow in the generated response. Details in the <a href=\"https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_InferenceConfiguration.html\" target=\"_blank\">documentation</a>.",
     "type" : "Number"
   }, {
     "id" : "provider.bedrock.model.parameters.temperature",
@@ -603,6 +606,7 @@
       "equals" : "bedrock",
       "type" : "simple"
     },
+    "tooltip" : "Floating point number between <code>0</code> and <code>1</code>. The higher the number, the more randomness will be injected into the response. Details in the <a href=\"https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_InferenceConfiguration.html\" target=\"_blank\">documentation</a>.",
     "type" : "Number"
   }, {
     "id" : "provider.bedrock.model.parameters.topP",
@@ -619,6 +623,7 @@
       "equals" : "bedrock",
       "type" : "simple"
     },
+    "tooltip" : "Floating point number between <code>0</code> and <code>1</code>. Recommended for advanced use cases only, you usually only need to use <code>temperature</code>. Details in the <a href=\"https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_InferenceConfiguration.html\" target=\"_blank\">documentation</a>.",
     "type" : "Number"
   }, {
     "id" : "provider.openai.model.parameters.maxOutputTokens",
@@ -639,6 +644,7 @@
   }, {
     "id" : "provider.openai.model.parameters.maxCompletionTokens",
     "label" : "Maximum Completion Tokens",
+    "description" : "The maximum number of tokens per request to generate before stopping. Details in the <a href=\"https://platform.openai.com/docs/api-reference/chat/create#chat-create-max_completion_tokens\" target=\"_blank\">documentation</a>.",
     "optional" : true,
     "feel" : "required",
     "group" : "parameters",
@@ -667,6 +673,7 @@
       "equals" : "openai",
       "type" : "simple"
     },
+    "tooltip" : "Floating point number between <code>0</code> and <code>2</code>. The higher the number, the more randomness will be injected into the response. Details in the <a href=\"https://platform.openai.com/docs/api-reference/chat/create#chat-create-temperature\" target=\"_blank\">documentation</a>.",
     "type" : "Number"
   }, {
     "id" : "provider.openai.model.parameters.topP",
@@ -683,6 +690,7 @@
       "equals" : "openai",
       "type" : "simple"
     },
+    "tooltip" : "Recommended for advanced use cases only, you usually only need to use <code>temperature</code>. Details in the <a href=\"https://platform.openai.com/docs/api-reference/chat/create#chat-create-top_p\" target=\"_blank\">documentation</a>.",
     "type" : "Number"
   }, {
     "id" : "provider.openai.model.parameters.topK",

--- a/connectors/agentic-ai/element-templates/hybrid/agenticai-aiagent-outbound-connector-hybrid.json
+++ b/connectors/agentic-ai/element-templates/hybrid/agenticai-aiagent-outbound-connector-hybrid.json
@@ -44,7 +44,7 @@
   }, {
     "id" : "parameters",
     "label" : "Model Parameters",
-    "tooltip" : "Configuration of common model parameters to optimize and fine-tune LLM responses.",
+    "tooltip" : "Configuration of common model parameters to optimize and fine-tune LLM responses. Limits such as maximum output tokens are <strong>per LLM request</strong>.",
     "openByDefault" : false
   }, {
     "id" : "connector",
@@ -507,13 +507,14 @@
     },
     "type" : "Number"
   }, {
-    "id" : "provider.anthropic.model.parameters.maxOutputTokens",
-    "label" : "Maximum Output Tokens",
+    "id" : "provider.anthropic.model.parameters.maxTokens",
+    "label" : "Maximum Tokens",
+    "description" : "The maximum number of tokens per request to generate before stopping.",
     "optional" : true,
     "feel" : "required",
     "group" : "parameters",
     "binding" : {
-      "name" : "provider.anthropic.model.parameters.maxOutputTokens",
+      "name" : "provider.anthropic.model.parameters.maxTokens",
       "type" : "zeebe:input"
     },
     "condition" : {
@@ -573,6 +574,7 @@
   }, {
     "id" : "provider.bedrock.model.parameters.maxOutputTokens",
     "label" : "Maximum Output Tokens",
+    "description" : "The maximum number of tokens to allow in the generated response.",
     "optional" : true,
     "feel" : "required",
     "group" : "parameters",
@@ -619,22 +621,6 @@
     },
     "type" : "Number"
   }, {
-    "id" : "provider.bedrock.model.parameters.topK",
-    "label" : "top K",
-    "optional" : true,
-    "feel" : "required",
-    "group" : "parameters",
-    "binding" : {
-      "name" : "provider.bedrock.model.parameters.topK",
-      "type" : "zeebe:input"
-    },
-    "condition" : {
-      "property" : "provider.type",
-      "equals" : "bedrock",
-      "type" : "simple"
-    },
-    "type" : "Number"
-  }, {
     "id" : "provider.openai.model.parameters.maxOutputTokens",
     "label" : "Maximum Output Tokens",
     "optional" : true,
@@ -642,6 +628,22 @@
     "group" : "parameters",
     "binding" : {
       "name" : "provider.openai.model.parameters.maxOutputTokens",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "provider.type",
+      "equals" : "openai",
+      "type" : "simple"
+    },
+    "type" : "Number"
+  }, {
+    "id" : "provider.openai.model.parameters.maxCompletionTokens",
+    "label" : "Maximum Completion Tokens",
+    "optional" : true,
+    "feel" : "required",
+    "group" : "parameters",
+    "binding" : {
+      "name" : "provider.openai.model.parameters.maxCompletionTokens",
       "type" : "zeebe:input"
     },
     "condition" : {

--- a/connectors/agentic-ai/examples/ad-hoc-tools-schema/ad-hoc-tools-schema-resolver.bpmn
+++ b/connectors/agentic-ai/examples/ad-hoc-tools-schema/ad-hoc-tools-schema-resolver.bpmn
@@ -44,6 +44,8 @@
           <zeebe:input source="Dummy_Tools" target="data.containerElementId" />
         </zeebe:ioMapping>
         <zeebe:taskHeaders>
+          <zeebe:header key="elementTemplateVersion" value="0" />
+          <zeebe:header key="elementTemplateId" value="io.camunda.connectors.agenticai.adhoctoolsschema.v0" />
           <zeebe:header key="resultVariable" value="toolsResult" />
           <zeebe:header key="retryBackoff" value="PT0S" />
         </zeebe:taskHeaders>

--- a/connectors/agentic-ai/examples/ai-agent-chat-with-tools/ai-agent-chat-human-send-email-request.form
+++ b/connectors/agentic-ai/examples/ai-agent-chat-with-tools/ai-agent-chat-human-send-email-request.form
@@ -44,7 +44,7 @@
   "type": "default",
   "id": "ai-agent-chat-human-send-email-request",
   "executionPlatform": "Camunda Cloud",
-  "executionPlatformVersion": "8.6.0",
+  "executionPlatformVersion": "8.8.0",
   "exporter": {
     "name": "Camunda Modeler",
     "version": "5.34.0"

--- a/connectors/agentic-ai/examples/ai-agent-chat-with-tools/ai-agent-chat-initial-request.form
+++ b/connectors/agentic-ai/examples/ai-agent-chat-with-tools/ai-agent-chat-initial-request.form
@@ -26,7 +26,7 @@
   "type": "default",
   "id": "ai-agent-chat-initial-request",
   "executionPlatform": "Camunda Cloud",
-  "executionPlatformVersion": "8.6.0",
+  "executionPlatformVersion": "8.8.0",
   "exporter": {
     "name": "Camunda Modeler",
     "version": "5.34.0"

--- a/connectors/agentic-ai/examples/ai-agent-chat-with-tools/ai-agent-chat-user-feedback.form
+++ b/connectors/agentic-ai/examples/ai-agent-chat-with-tools/ai-agent-chat-user-feedback.form
@@ -102,7 +102,7 @@
   "type": "default",
   "id": "ai-agent-chat-user-feedback",
   "executionPlatform": "Camunda Cloud",
-  "executionPlatformVersion": "8.6.0",
+  "executionPlatformVersion": "8.8.0",
   "exporter": {
     "name": "Camunda Modeler",
     "version": "5.34.0"

--- a/connectors/agentic-ai/examples/ai-agent-chat-with-tools/ai-agent-chat-with-tools.bpmn
+++ b/connectors/agentic-ai/examples/ai-agent-chat-with-tools/ai-agent-chat-with-tools.bpmn
@@ -26,7 +26,6 @@
           <zeebe:input source="=agent.context" target="data.context" />
           <zeebe:input source="=20" target="data.memory.maxMessages" />
           <zeebe:input source="=20" target="data.limits.maxModelCalls" />
-          <zeebe:input source="=8192" target="provider.bedrock.model.parameters.maxOutputTokens" />
         </zeebe:ioMapping>
         <zeebe:taskHeaders>
           <zeebe:header key="elementTemplateVersion" value="0" />

--- a/connectors/agentic-ai/examples/fraud-detection/fraud-detection-process-enter-tax-form.form
+++ b/connectors/agentic-ai/examples/fraud-detection/fraud-detection-process-enter-tax-form.form
@@ -180,7 +180,7 @@
     }
   ],
   "executionPlatform": "Camunda Cloud",
-  "executionPlatformVersion": "8.6.0",
+  "executionPlatformVersion": "8.8.0",
   "exporter": {
     "name": "Camunda Modeler",
     "version": "5.34.0"

--- a/connectors/agentic-ai/examples/fraud-detection/fraud-detection-process-send-email.form
+++ b/connectors/agentic-ai/examples/fraud-detection/fraud-detection-process-send-email.form
@@ -38,10 +38,10 @@
     }
   ],
   "executionPlatform": "Camunda Cloud",
-  "executionPlatformVersion": "8.6.0",
+  "executionPlatformVersion": "8.8.0",
   "exporter": {
     "name": "Camunda Modeler",
-    "version": "5.32.0"
+    "version": "5.34.0"
   },
   "schemaVersion": 18,
   "id": "fraud-detection-process-send-email",

--- a/connectors/agentic-ai/examples/fraud-detection/fraud-detection-process-view-tax-details.form
+++ b/connectors/agentic-ai/examples/fraud-detection/fraud-detection-process-view-tax-details.form
@@ -79,7 +79,7 @@
     }
   ],
   "executionPlatform": "Camunda Cloud",
-  "executionPlatformVersion": "8.6.0",
+  "executionPlatformVersion": "8.8.0",
   "exporter": {
     "name": "Camunda Modeler",
     "version": "5.34.0"

--- a/connectors/agentic-ai/examples/fraud-detection/fraud-detection-process.bpmn
+++ b/connectors/agentic-ai/examples/fraud-detection/fraud-detection-process.bpmn
@@ -186,7 +186,6 @@
           <zeebe:input source="=agent.context" target="data.context" />
           <zeebe:input source="=20" target="data.memory.maxMessages" />
           <zeebe:input source="=20" target="data.limits.maxModelCalls" />
-          <zeebe:input source="=8192" target="provider.bedrock.model.parameters.maxOutputTokens" />
         </zeebe:ioMapping>
         <zeebe:taskHeaders>
           <zeebe:header key="elementTemplateVersion" value="0" />

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/AiAgentFunction.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/AiAgentFunction.java
@@ -44,7 +44,7 @@ import io.camunda.connector.generator.java.annotation.ElementTemplate.PropertyGr
           id = "parameters",
           label = "Model Parameters",
           tooltip =
-              "Configuration of common model parameters to optimize and fine-tune LLM responses. Limits such as maximum output tokens are <strong>per LLM request</strong>.",
+              "Optional configuration of common model parameters to optimize and fine-tune LLM responses. Limits such as maximum output tokens are <strong>per LLM request</strong>.",
           openByDefault = false)
     },
     icon = "aiagent.svg")

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/AiAgentFunction.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/AiAgentFunction.java
@@ -44,7 +44,7 @@ import io.camunda.connector.generator.java.annotation.ElementTemplate.PropertyGr
           id = "parameters",
           label = "Model Parameters",
           tooltip =
-              "Configuration of common model parameters to optimize and fine-tune LLM responses.",
+              "Configuration of common model parameters to optimize and fine-tune LLM responses. Limits such as maximum output tokens are <strong>per LLM request</strong>.",
           openByDefault = false)
     },
     icon = "aiagent.svg")

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/agent/DefaultAiAgentRequestHandler.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/agent/DefaultAiAgentRequestHandler.java
@@ -76,7 +76,7 @@ public class DefaultAiAgentRequestHandler implements AiAgentRequestHandler {
         Optional.ofNullable(requestData.context()).orElseGet(AgentContext::empty);
 
     // initialize configured model
-    final ChatModel chatModel = chatModelFactory.createChatModel(request);
+    final ChatModel chatModel = chatModelFactory.createChatModel(request.provider());
 
     // set up memory and load from context if available
     final AgentContextChatMemoryStore chatMemoryStore =

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/ProviderConfiguration.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/ProviderConfiguration.java
@@ -88,7 +88,44 @@ public sealed interface ProviderConfiguration
                 defaultValueType = TemplateProperty.DefaultValueType.String,
                 constraints = @PropertyConstraints(notEmpty = true))
             String model,
-        @Valid ModelParameters parameters) {}
+        @Valid AnthropicModelParameters parameters) {
+
+      public record AnthropicModelParameters(
+          @Min(0)
+              @TemplateProperty(
+                  group = "parameters",
+                  label = "Maximum Tokens",
+                  description =
+                      "The maximum number of tokens per request to generate before stopping.",
+                  type = TemplateProperty.PropertyType.Number,
+                  feel = Property.FeelMode.required,
+                  optional = true)
+              Integer maxTokens,
+          @Min(0)
+              @TemplateProperty(
+                  group = "parameters",
+                  label = "Temperature",
+                  type = TemplateProperty.PropertyType.Number,
+                  feel = Property.FeelMode.required,
+                  optional = true)
+              Double temperature,
+          @Min(0)
+              @TemplateProperty(
+                  group = "parameters",
+                  label = "top P",
+                  type = TemplateProperty.PropertyType.Number,
+                  feel = Property.FeelMode.required,
+                  optional = true)
+              Double topP,
+          @Min(0)
+              @TemplateProperty(
+                  group = "parameters",
+                  label = "top K",
+                  type = TemplateProperty.PropertyType.Number,
+                  feel = Property.FeelMode.required,
+                  optional = true)
+              Integer topK) {}
+    }
   }
 
   @TemplateSubType(id = BEDROCK_ID, label = "AWS Bedrock")
@@ -129,7 +166,35 @@ public sealed interface ProviderConfiguration
                 defaultValueType = TemplateProperty.DefaultValueType.String,
                 constraints = @PropertyConstraints(notEmpty = true))
             String model,
-        @Valid ModelParameters parameters) {}
+        @Valid BedrockModelParameters parameters) {
+
+      public record BedrockModelParameters(
+          @Min(0)
+              @TemplateProperty(
+                  group = "parameters",
+                  label = "Maximum Output Tokens",
+                  description = "The maximum number of tokens to allow in the generated response.",
+                  type = TemplateProperty.PropertyType.Number,
+                  feel = Property.FeelMode.required,
+                  optional = true)
+              Integer maxOutputTokens,
+          @Min(0)
+              @TemplateProperty(
+                  group = "parameters",
+                  label = "Temperature",
+                  type = TemplateProperty.PropertyType.Number,
+                  feel = Property.FeelMode.required,
+                  optional = true)
+              Double temperature,
+          @Min(0)
+              @TemplateProperty(
+                  group = "parameters",
+                  label = "top P",
+                  type = TemplateProperty.PropertyType.Number,
+                  feel = Property.FeelMode.required,
+                  optional = true)
+              Double topP) {}
+    }
   }
 
   @TemplateSubType(id = OPENAI_ID, label = "OpenAI")
@@ -190,40 +255,49 @@ public sealed interface ProviderConfiguration
                 defaultValueType = TemplateProperty.DefaultValueType.String,
                 constraints = @PropertyConstraints(notEmpty = true))
             String model,
-        @Valid ModelParameters parameters) {}
-  }
+        @Valid OpenAiModelParameters parameters) {
 
-  record ModelParameters(
-      @Min(0)
-          @TemplateProperty(
-              group = "parameters",
-              label = "Maximum Output Tokens",
-              type = TemplateProperty.PropertyType.Number,
-              feel = Property.FeelMode.required,
-              optional = true)
-          Integer maxOutputTokens,
-      @Min(0)
-          @TemplateProperty(
-              group = "parameters",
-              label = "Temperature",
-              type = TemplateProperty.PropertyType.Number,
-              feel = Property.FeelMode.required,
-              optional = true)
-          Double temperature,
-      @Min(0)
-          @TemplateProperty(
-              group = "parameters",
-              label = "top P",
-              type = TemplateProperty.PropertyType.Number,
-              feel = Property.FeelMode.required,
-              optional = true)
-          Double topP,
-      @Min(0)
-          @TemplateProperty(
-              group = "parameters",
-              label = "top K",
-              type = TemplateProperty.PropertyType.Number,
-              feel = Property.FeelMode.required,
-              optional = true)
-          Integer topK) {}
+      public record OpenAiModelParameters(
+          @Min(0)
+              @TemplateProperty(
+                  group = "parameters",
+                  label = "Maximum Output Tokens",
+                  type = TemplateProperty.PropertyType.Number,
+                  feel = Property.FeelMode.required,
+                  optional = true)
+              Integer maxOutputTokens,
+          @Min(0)
+              @TemplateProperty(
+                  group = "parameters",
+                  label = "Maximum Completion Tokens",
+                  type = TemplateProperty.PropertyType.Number,
+                  feel = Property.FeelMode.required,
+                  optional = true)
+              Integer maxCompletionTokens,
+          @Min(0)
+              @TemplateProperty(
+                  group = "parameters",
+                  label = "Temperature",
+                  type = TemplateProperty.PropertyType.Number,
+                  feel = Property.FeelMode.required,
+                  optional = true)
+              Double temperature,
+          @Min(0)
+              @TemplateProperty(
+                  group = "parameters",
+                  label = "top P",
+                  type = TemplateProperty.PropertyType.Number,
+                  feel = Property.FeelMode.required,
+                  optional = true)
+              Double topP,
+          @Min(0)
+              @TemplateProperty(
+                  group = "parameters",
+                  label = "top K",
+                  type = TemplateProperty.PropertyType.Number,
+                  feel = Property.FeelMode.required,
+                  optional = true)
+              Integer topK) {}
+    }
+  }
 }

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/ProviderConfiguration.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/ProviderConfiguration.java
@@ -48,7 +48,7 @@ public sealed interface ProviderConfiguration
         ProviderConfiguration.OpenAiProviderConfiguration {
 
   @TemplateSubType(id = ANTHROPIC_ID, label = "Anthropic")
-  record AnthropicProviderConfiguration(AnthropicConnection anthropic)
+  record AnthropicProviderConfiguration(@Valid @NotNull AnthropicConnection anthropic)
       implements ProviderConfiguration {
 
     @TemplateProperty(ignore = true)
@@ -62,8 +62,8 @@ public sealed interface ProviderConfiguration
                 feel = Property.FeelMode.disabled,
                 optional = true)
             String endpoint,
-        @NotNull @Valid AnthropicAuthentication authentication,
-        AnthropicModel model) {}
+        @Valid @NotNull AnthropicAuthentication authentication,
+        @Valid @NotNull AnthropicModel model) {}
 
     public record AnthropicAuthentication(
         @NotBlank
@@ -92,13 +92,15 @@ public sealed interface ProviderConfiguration
   }
 
   @TemplateSubType(id = BEDROCK_ID, label = "AWS Bedrock")
-  record BedrockProviderConfiguration(BedrockConnection bedrock) implements ProviderConfiguration {
+  record BedrockProviderConfiguration(@Valid @NotNull BedrockConnection bedrock)
+      implements ProviderConfiguration {
 
     @TemplateProperty(ignore = true)
     public static final String BEDROCK_ID = "bedrock";
 
     public record BedrockConnection(
-        @TemplateProperty(
+        @NotBlank
+            @TemplateProperty(
                 group = "model",
                 description = "Specify the AWS region",
                 constraints = @PropertyConstraints(notEmpty = true))
@@ -111,8 +113,8 @@ public sealed interface ProviderConfiguration
                 feel = Property.FeelMode.disabled,
                 optional = true)
             String endpoint,
-        AwsAuthentication authentication,
-        BedrockModel model) {}
+        @Valid @NotNull AwsAuthentication authentication,
+        @Valid @NotNull BedrockModel model) {}
 
     public record BedrockModel(
         @NotBlank
@@ -131,7 +133,8 @@ public sealed interface ProviderConfiguration
   }
 
   @TemplateSubType(id = OPENAI_ID, label = "OpenAI")
-  record OpenAiProviderConfiguration(OpenAiConnection openai) implements ProviderConfiguration {
+  record OpenAiProviderConfiguration(@Valid @NotNull OpenAiConnection openai)
+      implements ProviderConfiguration {
 
     @TemplateProperty(ignore = true)
     public static final String OPENAI_ID = "openai";
@@ -144,8 +147,8 @@ public sealed interface ProviderConfiguration
                 feel = Property.FeelMode.disabled,
                 optional = true)
             String endpoint,
-        OpenAiAuthentication authentication,
-        OpenAiModel model) {}
+        @Valid @NotNull OpenAiAuthentication authentication,
+        @Valid @NotNull OpenAiModel model) {}
 
     public record OpenAiAuthentication(
         @NotBlank

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/ProviderConfiguration.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/ProviderConfiguration.java
@@ -95,8 +95,8 @@ public sealed interface ProviderConfiguration
               @TemplateProperty(
                   group = "parameters",
                   label = "Maximum Tokens",
-                  description =
-                      "The maximum number of tokens per request to generate before stopping. Details in the <a href=\"https://docs.anthropic.com/en/api/messages#body-max-tokens\" target=\"_blank\">documentation</a>.",
+                  tooltip =
+                      "The maximum number of tokens per request to generate before stopping. <br><br>Details in the <a href=\"https://docs.anthropic.com/en/api/messages#body-max-tokens\" target=\"_blank\">documentation</a>.",
                   type = TemplateProperty.PropertyType.Number,
                   feel = Property.FeelMode.required,
                   optional = true)
@@ -106,7 +106,7 @@ public sealed interface ProviderConfiguration
                   group = "parameters",
                   label = "Temperature",
                   tooltip =
-                      "Floating point number between <code>0</code> and <code>1</code>. The higher the number, the more randomness will be injected into the response. Details in the <a href=\"https://docs.anthropic.com/en/api/messages#body-temperature\" target=\"_blank\">documentation</a>.",
+                      "Floating point number between 0 and 1. The higher the number, the more randomness will be injected into the response. <br><br>Details in the <a href=\"https://docs.anthropic.com/en/api/messages#body-temperature\" target=\"_blank\">documentation</a>.",
                   type = TemplateProperty.PropertyType.Number,
                   feel = Property.FeelMode.required,
                   optional = true)
@@ -116,7 +116,7 @@ public sealed interface ProviderConfiguration
                   group = "parameters",
                   label = "top P",
                   tooltip =
-                      "Floating point number between <code>0</code> and <code>1</code>. Recommended for advanced use cases only, you usually only need to use <code>temperature</code>. Details in the <a href=\"https://docs.anthropic.com/en/api/messages#body-top-p\" target=\"_blank\">documentation</a>.",
+                      "Floating point number between 0 and 1. Recommended for advanced use cases only (you usually only need to use temperature). <br><br>Details in the <a href=\"https://docs.anthropic.com/en/api/messages#body-top-p\" target=\"_blank\">documentation</a>.",
                   type = TemplateProperty.PropertyType.Number,
                   feel = Property.FeelMode.required,
                   optional = true)
@@ -126,7 +126,7 @@ public sealed interface ProviderConfiguration
                   group = "parameters",
                   label = "top K",
                   tooltip =
-                      "Integer greater than <code>0</code>. Recommended for advanced use cases only, you usually only need to use <code>temperature</code>. Details in the <a href=\"https://docs.anthropic.com/en/api/messages#body-top-k\" target=\"_blank\">documentation</a>.",
+                      "Integer greater than 0. Recommended for advanced use cases only (you usually only need to use temperature). <br><br>Details in the <a href=\"https://docs.anthropic.com/en/api/messages#body-top-k\" target=\"_blank\">documentation</a>.",
                   type = TemplateProperty.PropertyType.Number,
                   feel = Property.FeelMode.required,
                   optional = true)
@@ -180,7 +180,7 @@ public sealed interface ProviderConfiguration
                   group = "parameters",
                   label = "Maximum Tokens",
                   tooltip =
-                      "The maximum number of tokens to allow in the generated response. Details in the <a href=\"https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_InferenceConfiguration.html\" target=\"_blank\">documentation</a>.",
+                      "The maximum number of tokens to allow in the generated response. <br><br>Details in the <a href=\"https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_InferenceConfiguration.html\" target=\"_blank\">documentation</a>.",
                   type = TemplateProperty.PropertyType.Number,
                   feel = Property.FeelMode.required,
                   optional = true)
@@ -190,7 +190,7 @@ public sealed interface ProviderConfiguration
                   group = "parameters",
                   label = "Temperature",
                   tooltip =
-                      "Floating point number between <code>0</code> and <code>1</code>. The higher the number, the more randomness will be injected into the response. Details in the <a href=\"https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_InferenceConfiguration.html\" target=\"_blank\">documentation</a>.",
+                      "Floating point number between 0 and 1. The higher the number, the more randomness will be injected into the response. <br><br>Details in the <a href=\"https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_InferenceConfiguration.html\" target=\"_blank\">documentation</a>.",
                   type = TemplateProperty.PropertyType.Number,
                   feel = Property.FeelMode.required,
                   optional = true)
@@ -200,7 +200,7 @@ public sealed interface ProviderConfiguration
                   group = "parameters",
                   label = "top P",
                   tooltip =
-                      "Floating point number between <code>0</code> and <code>1</code>. Recommended for advanced use cases only, you usually only need to use <code>temperature</code>. Details in the <a href=\"https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_InferenceConfiguration.html\" target=\"_blank\">documentation</a>.",
+                      "Floating point number between 0 and 1. Recommended for advanced use cases only (you usually only need to use temperature). <br><br>Details in the <a href=\"https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_InferenceConfiguration.html\" target=\"_blank\">documentation</a>.",
                   type = TemplateProperty.PropertyType.Number,
                   feel = Property.FeelMode.required,
                   optional = true)
@@ -273,8 +273,8 @@ public sealed interface ProviderConfiguration
               @TemplateProperty(
                   group = "parameters",
                   label = "Maximum Completion Tokens",
-                  description =
-                      "The maximum number of tokens per request to generate before stopping. Details in the <a href=\"https://platform.openai.com/docs/api-reference/chat/create#chat-create-max_completion_tokens\" target=\"_blank\">documentation</a>.",
+                  tooltip =
+                      "The maximum number of tokens per request to generate before stopping. <br><br>Details in the <a href=\"https://platform.openai.com/docs/api-reference/chat/create#chat-create-max_completion_tokens\" target=\"_blank\">documentation</a>.",
                   type = TemplateProperty.PropertyType.Number,
                   feel = Property.FeelMode.required,
                   optional = true)
@@ -284,7 +284,7 @@ public sealed interface ProviderConfiguration
                   group = "parameters",
                   label = "Temperature",
                   tooltip =
-                      "Floating point number between <code>0</code> and <code>2</code>. The higher the number, the more randomness will be injected into the response. Details in the <a href=\"https://platform.openai.com/docs/api-reference/chat/create#chat-create-temperature\" target=\"_blank\">documentation</a>.",
+                      "Floating point number between 0 and 2. The higher the number, the more randomness will be injected into the response. <br><br>Details in the <a href=\"https://platform.openai.com/docs/api-reference/chat/create#chat-create-temperature\" target=\"_blank\">documentation</a>.",
                   type = TemplateProperty.PropertyType.Number,
                   feel = Property.FeelMode.required,
                   optional = true)
@@ -294,7 +294,7 @@ public sealed interface ProviderConfiguration
                   group = "parameters",
                   label = "top P",
                   tooltip =
-                      "Recommended for advanced use cases only, you usually only need to use <code>temperature</code>. Details in the <a href=\"https://platform.openai.com/docs/api-reference/chat/create#chat-create-top_p\" target=\"_blank\">documentation</a>.",
+                      "Recommended for advanced use cases only (you usually only need to use temperature). <br><br>Details in the <a href=\"https://platform.openai.com/docs/api-reference/chat/create#chat-create-top_p\" target=\"_blank\">documentation</a>.",
                   type = TemplateProperty.PropertyType.Number,
                   feel = Property.FeelMode.required,
                   optional = true)

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/ProviderConfiguration.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/ProviderConfiguration.java
@@ -96,7 +96,7 @@ public sealed interface ProviderConfiguration
                   group = "parameters",
                   label = "Maximum Tokens",
                   description =
-                      "The maximum number of tokens per request to generate before stopping.",
+                      "The maximum number of tokens per request to generate before stopping. Details in the <a href=\"https://docs.anthropic.com/en/api/messages#body-max-tokens\" target=\"_blank\">documentation</a>.",
                   type = TemplateProperty.PropertyType.Number,
                   feel = Property.FeelMode.required,
                   optional = true)
@@ -105,6 +105,8 @@ public sealed interface ProviderConfiguration
               @TemplateProperty(
                   group = "parameters",
                   label = "Temperature",
+                  tooltip =
+                      "Floating point number between <code>0</code> and <code>1</code>. The higher the number, the more randomness will be injected into the response. Details in the <a href=\"https://docs.anthropic.com/en/api/messages#body-temperature\" target=\"_blank\">documentation</a>.",
                   type = TemplateProperty.PropertyType.Number,
                   feel = Property.FeelMode.required,
                   optional = true)
@@ -113,6 +115,8 @@ public sealed interface ProviderConfiguration
               @TemplateProperty(
                   group = "parameters",
                   label = "top P",
+                  tooltip =
+                      "Floating point number between <code>0</code> and <code>1</code>. Recommended for advanced use cases only, you usually only need to use <code>temperature</code>. Details in the <a href=\"https://docs.anthropic.com/en/api/messages#body-top-p\" target=\"_blank\">documentation</a>.",
                   type = TemplateProperty.PropertyType.Number,
                   feel = Property.FeelMode.required,
                   optional = true)
@@ -121,6 +125,8 @@ public sealed interface ProviderConfiguration
               @TemplateProperty(
                   group = "parameters",
                   label = "top K",
+                  tooltip =
+                      "Integer greater than <code>0</code>. Recommended for advanced use cases only, you usually only need to use <code>temperature</code>. Details in the <a href=\"https://docs.anthropic.com/en/api/messages#body-top-k\" target=\"_blank\">documentation</a>.",
                   type = TemplateProperty.PropertyType.Number,
                   feel = Property.FeelMode.required,
                   optional = true)
@@ -139,7 +145,7 @@ public sealed interface ProviderConfiguration
         @NotBlank
             @TemplateProperty(
                 group = "model",
-                description = "Specify the AWS region",
+                description = "Specify the AWS region (example: <code>eu-west-1</code>)",
                 constraints = @PropertyConstraints(notEmpty = true))
             String region,
         @FEEL
@@ -172,16 +178,19 @@ public sealed interface ProviderConfiguration
           @Min(0)
               @TemplateProperty(
                   group = "parameters",
-                  label = "Maximum Output Tokens",
-                  description = "The maximum number of tokens to allow in the generated response.",
+                  label = "Maximum Tokens",
+                  tooltip =
+                      "The maximum number of tokens to allow in the generated response. Details in the <a href=\"https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_InferenceConfiguration.html\" target=\"_blank\">documentation</a>.",
                   type = TemplateProperty.PropertyType.Number,
                   feel = Property.FeelMode.required,
                   optional = true)
-              Integer maxOutputTokens,
+              Integer maxTokens,
           @Min(0)
               @TemplateProperty(
                   group = "parameters",
                   label = "Temperature",
+                  tooltip =
+                      "Floating point number between <code>0</code> and <code>1</code>. The higher the number, the more randomness will be injected into the response. Details in the <a href=\"https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_InferenceConfiguration.html\" target=\"_blank\">documentation</a>.",
                   type = TemplateProperty.PropertyType.Number,
                   feel = Property.FeelMode.required,
                   optional = true)
@@ -190,6 +199,8 @@ public sealed interface ProviderConfiguration
               @TemplateProperty(
                   group = "parameters",
                   label = "top P",
+                  tooltip =
+                      "Floating point number between <code>0</code> and <code>1</code>. Recommended for advanced use cases only, you usually only need to use <code>temperature</code>. Details in the <a href=\"https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_InferenceConfiguration.html\" target=\"_blank\">documentation</a>.",
                   type = TemplateProperty.PropertyType.Number,
                   feel = Property.FeelMode.required,
                   optional = true)
@@ -270,6 +281,8 @@ public sealed interface ProviderConfiguration
               @TemplateProperty(
                   group = "parameters",
                   label = "Maximum Completion Tokens",
+                  description =
+                      "The maximum number of tokens per request to generate before stopping. Details in the <a href=\"https://platform.openai.com/docs/api-reference/chat/create#chat-create-max_completion_tokens\" target=\"_blank\">documentation</a>.",
                   type = TemplateProperty.PropertyType.Number,
                   feel = Property.FeelMode.required,
                   optional = true)
@@ -278,6 +291,8 @@ public sealed interface ProviderConfiguration
               @TemplateProperty(
                   group = "parameters",
                   label = "Temperature",
+                  tooltip =
+                      "Floating point number between <code>0</code> and <code>2</code>. The higher the number, the more randomness will be injected into the response. Details in the <a href=\"https://platform.openai.com/docs/api-reference/chat/create#chat-create-temperature\" target=\"_blank\">documentation</a>.",
                   type = TemplateProperty.PropertyType.Number,
                   feel = Property.FeelMode.required,
                   optional = true)
@@ -286,6 +301,8 @@ public sealed interface ProviderConfiguration
               @TemplateProperty(
                   group = "parameters",
                   label = "top P",
+                  tooltip =
+                      "Recommended for advanced use cases only, you usually only need to use <code>temperature</code>. Details in the <a href=\"https://platform.openai.com/docs/api-reference/chat/create#chat-create-top_p\" target=\"_blank\">documentation</a>.",
                   type = TemplateProperty.PropertyType.Number,
                   feel = Property.FeelMode.required,
                   optional = true)

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/ProviderConfiguration.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/ProviderConfiguration.java
@@ -272,14 +272,6 @@ public sealed interface ProviderConfiguration
           @Min(0)
               @TemplateProperty(
                   group = "parameters",
-                  label = "Maximum Output Tokens",
-                  type = TemplateProperty.PropertyType.Number,
-                  feel = Property.FeelMode.required,
-                  optional = true)
-              Integer maxOutputTokens,
-          @Min(0)
-              @TemplateProperty(
-                  group = "parameters",
                   label = "Maximum Completion Tokens",
                   description =
                       "The maximum number of tokens per request to generate before stopping. Details in the <a href=\"https://platform.openai.com/docs/api-reference/chat/create#chat-create-max_completion_tokens\" target=\"_blank\">documentation</a>.",
@@ -306,15 +298,7 @@ public sealed interface ProviderConfiguration
                   type = TemplateProperty.PropertyType.Number,
                   feel = Property.FeelMode.required,
                   optional = true)
-              Double topP,
-          @Min(0)
-              @TemplateProperty(
-                  group = "parameters",
-                  label = "top K",
-                  type = TemplateProperty.PropertyType.Number,
-                  feel = Property.FeelMode.required,
-                  optional = true)
-              Integer topK) {}
+              Double topP) {}
     }
   }
 }

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/provider/ChatModelFactory.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/provider/ChatModelFactory.java
@@ -10,7 +10,6 @@ import dev.langchain4j.model.anthropic.AnthropicChatModel;
 import dev.langchain4j.model.bedrock.BedrockChatModel;
 import dev.langchain4j.model.bedrock.BedrockChatRequestParameters;
 import dev.langchain4j.model.chat.ChatModel;
-import dev.langchain4j.model.chat.request.DefaultChatRequestParameters;
 import dev.langchain4j.model.openai.OpenAiChatModel;
 import dev.langchain4j.model.openai.OpenAiChatRequestParameters;
 import io.camunda.connector.agenticai.aiagent.model.request.ProviderConfiguration;
@@ -52,8 +51,8 @@ public class ChatModelFactory {
 
     final var modelParameters = connection.model().parameters();
     if (modelParameters != null) {
+      Optional.ofNullable(modelParameters.maxTokens()).ifPresent(builder::maxTokens);
       Optional.ofNullable(modelParameters.temperature()).ifPresent(builder::temperature);
-      Optional.ofNullable(modelParameters.maxOutputTokens()).ifPresent(builder::maxTokens);
       Optional.ofNullable(modelParameters.topP()).ifPresent(builder::topP);
       Optional.ofNullable(modelParameters.topK()).ifPresent(builder::topK);
     }
@@ -80,47 +79,54 @@ public class ChatModelFactory {
       bedrockClientBuilder.endpointOverride(URI.create(connection.endpoint()));
     }
 
-    return BedrockChatModel.builder()
-        .client(bedrockClientBuilder.build())
-        .modelId(connection.model().model())
-        .defaultRequestParameters(
-            applyModelParameters(
-                    BedrockChatRequestParameters.builder(), connection.model().parameters())
-                .build())
-        .build();
+    final var builder =
+        BedrockChatModel.builder()
+            .client(bedrockClientBuilder.build())
+            .modelId(connection.model().model());
+
+    final var modelParameters = connection.model().parameters();
+    if (modelParameters != null) {
+      final var requestParametersBuilder = BedrockChatRequestParameters.builder();
+      Optional.ofNullable(modelParameters.maxOutputTokens())
+          .ifPresent(requestParametersBuilder::maxOutputTokens);
+      Optional.ofNullable(modelParameters.temperature())
+          .ifPresent(requestParametersBuilder::temperature);
+      Optional.ofNullable(modelParameters.topP()).ifPresent(requestParametersBuilder::topP);
+
+      builder.defaultRequestParameters(requestParametersBuilder.build());
+    }
+
+    return builder.build();
   }
 
   private OpenAiChatModel createOpenaiChatModel(OpenAiProviderConfiguration configuration) {
     final var connection = configuration.openai();
 
-    final var modelBuilder =
+    final var builder =
         OpenAiChatModel.builder()
             .apiKey(connection.authentication().apiKey())
-            .modelName(connection.model().model())
-            .defaultRequestParameters(
-                applyModelParameters(
-                        OpenAiChatRequestParameters.builder(), connection.model().parameters())
-                    .build());
+            .modelName(connection.model().model());
 
     Optional.ofNullable(connection.authentication().organization())
-        .ifPresent(modelBuilder::organizationId);
-    Optional.ofNullable(connection.authentication().project()).ifPresent(modelBuilder::projectId);
-    Optional.ofNullable(connection.endpoint()).ifPresent(modelBuilder::baseUrl);
+        .ifPresent(builder::organizationId);
+    Optional.ofNullable(connection.authentication().project()).ifPresent(builder::projectId);
+    Optional.ofNullable(connection.endpoint()).ifPresent(builder::baseUrl);
 
-    return modelBuilder.build();
-  }
+    final var modelParameters = connection.model().parameters();
+    if (modelParameters != null) {
+      final var requestParametersBuilder = OpenAiChatRequestParameters.builder();
+      Optional.ofNullable(modelParameters.maxOutputTokens())
+          .ifPresent(requestParametersBuilder::maxOutputTokens);
+      Optional.ofNullable(modelParameters.maxCompletionTokens())
+          .ifPresent(requestParametersBuilder::maxCompletionTokens);
+      Optional.ofNullable(modelParameters.temperature())
+          .ifPresent(requestParametersBuilder::temperature);
+      Optional.ofNullable(modelParameters.topP()).ifPresent(requestParametersBuilder::topP);
+      Optional.ofNullable(modelParameters.topK()).ifPresent(requestParametersBuilder::topK);
 
-  private DefaultChatRequestParameters.Builder<?> applyModelParameters(
-      DefaultChatRequestParameters.Builder<?> builder,
-      ProviderConfiguration.ModelParameters modelParameters) {
-    if (modelParameters == null) {
-      return builder;
+      builder.defaultRequestParameters(requestParametersBuilder.build());
     }
 
-    Optional.ofNullable(modelParameters.temperature()).ifPresent(builder::temperature);
-    Optional.ofNullable(modelParameters.maxOutputTokens()).ifPresent(builder::maxOutputTokens);
-    Optional.ofNullable(modelParameters.topP()).ifPresent(builder::topP);
-    Optional.ofNullable(modelParameters.topK()).ifPresent(builder::topK);
-    return builder;
+    return builder.build();
   }
 }

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/provider/ChatModelFactory.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/provider/ChatModelFactory.java
@@ -8,6 +8,7 @@ package io.camunda.connector.agenticai.aiagent.provider;
 
 import dev.langchain4j.model.anthropic.AnthropicChatModel;
 import dev.langchain4j.model.bedrock.BedrockChatModel;
+import dev.langchain4j.model.bedrock.BedrockChatRequestParameters;
 import dev.langchain4j.model.chat.ChatModel;
 import dev.langchain4j.model.chat.request.DefaultChatRequestParameters;
 import dev.langchain4j.model.openai.OpenAiChatModel;
@@ -84,7 +85,7 @@ public class ChatModelFactory {
         .modelId(connection.model().model())
         .defaultRequestParameters(
             applyModelParameters(
-                    DefaultChatRequestParameters.builder(), connection.model().parameters())
+                    BedrockChatRequestParameters.builder(), connection.model().parameters())
                 .build())
         .build();
   }

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/provider/ChatModelFactory.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/provider/ChatModelFactory.java
@@ -12,7 +12,6 @@ import dev.langchain4j.model.chat.ChatModel;
 import dev.langchain4j.model.chat.request.DefaultChatRequestParameters;
 import dev.langchain4j.model.openai.OpenAiChatModel;
 import dev.langchain4j.model.openai.OpenAiChatRequestParameters;
-import io.camunda.connector.agenticai.aiagent.model.request.AgentRequest;
 import io.camunda.connector.agenticai.aiagent.model.request.ProviderConfiguration;
 import io.camunda.connector.agenticai.aiagent.model.request.ProviderConfiguration.AnthropicProviderConfiguration;
 import io.camunda.connector.agenticai.aiagent.model.request.ProviderConfiguration.BedrockProviderConfiguration;
@@ -29,8 +28,8 @@ import software.amazon.awssdk.services.bedrockruntime.BedrockRuntimeClient;
 
 public class ChatModelFactory {
 
-  public ChatModel createChatModel(AgentRequest request) {
-    return switch (request.provider()) {
+  public ChatModel createChatModel(ProviderConfiguration providerConfiguration) {
+    return switch (providerConfiguration) {
       case AnthropicProviderConfiguration anthropic -> createAnthropicChatModel(anthropic);
       case BedrockProviderConfiguration bedrock -> createBedrockChatModel(bedrock);
       case OpenAiProviderConfiguration openai -> createOpenaiChatModel(openai);
@@ -51,10 +50,12 @@ public class ChatModelFactory {
     }
 
     final var modelParameters = connection.model().parameters();
-    Optional.ofNullable(modelParameters.temperature()).ifPresent(builder::temperature);
-    Optional.ofNullable(modelParameters.maxOutputTokens()).ifPresent(builder::maxTokens);
-    Optional.ofNullable(modelParameters.topP()).ifPresent(builder::topP);
-    Optional.ofNullable(modelParameters.topK()).ifPresent(builder::topK);
+    if (modelParameters != null) {
+      Optional.ofNullable(modelParameters.temperature()).ifPresent(builder::temperature);
+      Optional.ofNullable(modelParameters.maxOutputTokens()).ifPresent(builder::maxTokens);
+      Optional.ofNullable(modelParameters.topP()).ifPresent(builder::topP);
+      Optional.ofNullable(modelParameters.topK()).ifPresent(builder::topK);
+    }
 
     return builder.build();
   }

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/provider/ChatModelFactory.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/provider/ChatModelFactory.java
@@ -112,6 +112,10 @@ public class ChatModelFactory {
   private DefaultChatRequestParameters.Builder<?> applyModelParameters(
       DefaultChatRequestParameters.Builder<?> builder,
       ProviderConfiguration.ModelParameters modelParameters) {
+    if (modelParameters == null) {
+      return builder;
+    }
+
     Optional.ofNullable(modelParameters.temperature()).ifPresent(builder::temperature);
     Optional.ofNullable(modelParameters.maxOutputTokens()).ifPresent(builder::maxOutputTokens);
     Optional.ofNullable(modelParameters.topP()).ifPresent(builder::topP);

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/provider/ChatModelFactory.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/provider/ChatModelFactory.java
@@ -87,7 +87,7 @@ public class ChatModelFactory {
     final var modelParameters = connection.model().parameters();
     if (modelParameters != null) {
       final var requestParametersBuilder = BedrockChatRequestParameters.builder();
-      Optional.ofNullable(modelParameters.maxOutputTokens())
+      Optional.ofNullable(modelParameters.maxTokens())
           .ifPresent(requestParametersBuilder::maxOutputTokens);
       Optional.ofNullable(modelParameters.temperature())
           .ifPresent(requestParametersBuilder::temperature);

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/provider/ChatModelFactory.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/provider/ChatModelFactory.java
@@ -115,14 +115,11 @@ public class ChatModelFactory {
     final var modelParameters = connection.model().parameters();
     if (modelParameters != null) {
       final var requestParametersBuilder = OpenAiChatRequestParameters.builder();
-      Optional.ofNullable(modelParameters.maxOutputTokens())
-          .ifPresent(requestParametersBuilder::maxOutputTokens);
       Optional.ofNullable(modelParameters.maxCompletionTokens())
           .ifPresent(requestParametersBuilder::maxCompletionTokens);
       Optional.ofNullable(modelParameters.temperature())
           .ifPresent(requestParametersBuilder::temperature);
       Optional.ofNullable(modelParameters.topP()).ifPresent(requestParametersBuilder::topP);
-      Optional.ofNullable(modelParameters.topK()).ifPresent(requestParametersBuilder::topK);
 
       builder.defaultRequestParameters(requestParametersBuilder.build());
     }

--- a/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/provider/ChatModelFactoryTest.java
+++ b/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/provider/ChatModelFactoryTest.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.agenticai.aiagent.provider;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+import dev.langchain4j.model.anthropic.AnthropicChatModel;
+import dev.langchain4j.model.anthropic.AnthropicChatModel.AnthropicChatModelBuilder;
+import io.camunda.connector.agenticai.aiagent.model.request.ProviderConfiguration.AnthropicProviderConfiguration;
+import io.camunda.connector.agenticai.aiagent.model.request.ProviderConfiguration.AnthropicProviderConfiguration.AnthropicAuthentication;
+import io.camunda.connector.agenticai.aiagent.model.request.ProviderConfiguration.AnthropicProviderConfiguration.AnthropicConnection;
+import io.camunda.connector.agenticai.aiagent.model.request.ProviderConfiguration.AnthropicProviderConfiguration.AnthropicModel;
+import io.camunda.connector.agenticai.aiagent.model.request.ProviderConfiguration.ModelParameters;
+import java.util.stream.Stream;
+import org.assertj.core.api.ThrowingConsumer;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+import org.junit.jupiter.params.provider.NullSource;
+import org.mockito.Answers;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ChatModelFactoryTest {
+  private static final ModelParameters DEFAULT_MODEL_PARAMETERS =
+      new ModelParameters(10, 1.0, 0.8, 50);
+  private static final ModelParameters NULL_MODEL_PARAMETERS =
+      new ModelParameters(null, null, null, null);
+
+  private final ChatModelFactory chatModelFactory = new ChatModelFactory();
+
+  @Nested
+  class AnthropicChatModelFactoryTest {
+
+    private static final String ANTHROPIC_API_KEY = "myApiKey";
+    private static final String ANTHROPIC_MODEL = "myModel";
+
+    @Test
+    void createsAnthropicChatModel() {
+      final var providerConfig =
+          new AnthropicProviderConfiguration(
+              new AnthropicConnection(
+                  null,
+                  new AnthropicAuthentication(ANTHROPIC_API_KEY),
+                  new AnthropicModel(ANTHROPIC_MODEL, DEFAULT_MODEL_PARAMETERS)));
+
+      testAnthropicChatModelBuilder(
+          providerConfig,
+          (builder) -> {
+            verify(builder).apiKey(ANTHROPIC_API_KEY);
+            verify(builder).modelName(ANTHROPIC_MODEL);
+            verify(builder, never()).baseUrl(any());
+            verify(builder).maxTokens(DEFAULT_MODEL_PARAMETERS.maxOutputTokens());
+            verify(builder).temperature(DEFAULT_MODEL_PARAMETERS.temperature());
+            verify(builder).topP(DEFAULT_MODEL_PARAMETERS.topP());
+            verify(builder).topK(DEFAULT_MODEL_PARAMETERS.topK());
+          });
+    }
+
+    @Test
+    void createsAnthropicChatModelWithCustomEndpoint() {
+      final var providerConfig =
+          new AnthropicProviderConfiguration(
+              new AnthropicConnection(
+                  "https://my-custom-endpoint.local",
+                  new AnthropicAuthentication(ANTHROPIC_API_KEY),
+                  new AnthropicModel(ANTHROPIC_MODEL, DEFAULT_MODEL_PARAMETERS)));
+
+      testAnthropicChatModelBuilder(
+          providerConfig,
+          (builder) -> {
+            verify(builder).baseUrl("https://my-custom-endpoint.local");
+          });
+    }
+
+    @ParameterizedTest
+    @NullSource
+    @ArgumentsSource(NullModelParametersArgumentsProvider.class)
+    void createsAnthropicChatModelWithNullModelParameters(ModelParameters modelParameters) {
+      final var providerConfig =
+          new AnthropicProviderConfiguration(
+              new AnthropicConnection(
+                  null,
+                  new AnthropicAuthentication(ANTHROPIC_API_KEY),
+                  new AnthropicModel(ANTHROPIC_MODEL, modelParameters)));
+
+      testAnthropicChatModelBuilder(
+          providerConfig,
+          (builder) -> {
+            verify(builder).apiKey(ANTHROPIC_API_KEY);
+            verify(builder).modelName(ANTHROPIC_MODEL);
+            verify(builder, never()).baseUrl(any());
+            verify(builder, never()).maxTokens(DEFAULT_MODEL_PARAMETERS.maxOutputTokens());
+            verify(builder, never()).temperature(DEFAULT_MODEL_PARAMETERS.temperature());
+            verify(builder, never()).topP(DEFAULT_MODEL_PARAMETERS.topP());
+            verify(builder, never()).topK(DEFAULT_MODEL_PARAMETERS.topK());
+          });
+    }
+
+    private void testAnthropicChatModelBuilder(
+        AnthropicProviderConfiguration providerConfig,
+        ThrowingConsumer<AnthropicChatModelBuilder> builderAssertions) {
+      try (MockedStatic<AnthropicChatModel> chatModelMock =
+          Mockito.mockStatic(AnthropicChatModel.class, Answers.CALLS_REAL_METHODS)) {
+        var builder = spy(new AnthropicChatModelBuilder());
+        chatModelMock.when(AnthropicChatModel::builder).thenReturn(builder);
+
+        final var chatModel = chatModelFactory.createChatModel(providerConfig);
+        assertThat(chatModel).isNotNull().isInstanceOf(AnthropicChatModel.class);
+
+        builderAssertions.accept(builder);
+      }
+    }
+  }
+
+  private static class NullModelParametersArgumentsProvider implements ArgumentsProvider {
+    @Override
+    public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
+      return Stream.of(arguments(NULL_MODEL_PARAMETERS));
+    }
+  }
+}

--- a/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/provider/ChatModelFactoryTest.java
+++ b/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/provider/ChatModelFactoryTest.java
@@ -141,13 +141,17 @@ class ChatModelFactoryTest {
     private void testAnthropicChatModelBuilder(
         AnthropicProviderConfiguration providerConfig,
         ThrowingConsumer<AnthropicChatModelBuilder> builderAssertions) {
-      var chatModelBuilder = spy(AnthropicChatModel.builder());
+      final var chatModelBuilder = spy(AnthropicChatModel.builder());
+      final var chatModelResultCaptor = new ResultCaptor<AnthropicChatModel>();
+      doAnswer(chatModelResultCaptor).when(chatModelBuilder).build();
+
       try (MockedStatic<AnthropicChatModel> chatModelMock =
           Mockito.mockStatic(AnthropicChatModel.class, Answers.CALLS_REAL_METHODS)) {
         chatModelMock.when(AnthropicChatModel::builder).thenReturn(chatModelBuilder);
 
         final var chatModel = chatModelFactory.createChatModel(providerConfig);
         assertThat(chatModel).isNotNull().isInstanceOf(AnthropicChatModel.class);
+        assertThat(chatModel).isSameAs(chatModelResultCaptor.getResult());
 
         builderAssertions.accept(chatModelBuilder);
       }
@@ -304,7 +308,12 @@ class ChatModelFactoryTest {
         BedrockProviderConfiguration providerConfig,
         ThrowingConsumer<BedrockBuilderContext> builderAssertions) {
       final var clientBuilder = spy(BedrockRuntimeClient.builder());
+      final var clientResultCaptor = new ResultCaptor<BedrockRuntimeClient>();
+      doAnswer(clientResultCaptor).when(clientBuilder).build();
+
       final var chatModelBuilder = spy(BedrockChatModel.builder());
+      final var chatModelResultCaptor = new ResultCaptor<OpenAiChatModel>();
+      doAnswer(chatModelResultCaptor).when(chatModelBuilder).build();
 
       try (MockedStatic<BedrockRuntimeClient> clientMock =
               Mockito.mockStatic(BedrockRuntimeClient.class, Answers.CALLS_REAL_METHODS);
@@ -313,14 +322,12 @@ class ChatModelFactoryTest {
         clientMock.when(BedrockRuntimeClient::builder).thenReturn(clientBuilder);
         chatModelMock.when(BedrockChatModel::builder).thenReturn(chatModelBuilder);
 
-        final var clientResultCaptor = new ResultCaptor<BedrockRuntimeClient>();
-        doAnswer(clientResultCaptor).when(clientBuilder).build();
-
         final var builders =
             new BedrockBuilderContext(clientBuilder, clientResultCaptor, chatModelBuilder);
 
         final var chatModel = chatModelFactory.createChatModel(providerConfig);
         assertThat(chatModel).isNotNull().isInstanceOf(BedrockChatModel.class);
+        assertThat(chatModel).isSameAs(chatModelResultCaptor.getResult());
 
         builderAssertions.accept(builders);
       }
@@ -436,13 +443,17 @@ class ChatModelFactoryTest {
     private void testOpenAiChatModelBuilder(
         OpenAiProviderConfiguration providerConfig,
         ThrowingConsumer<OpenAiChatModelBuilder> builderAssertions) {
-      var chatModelBuilder = spy(OpenAiChatModel.builder());
+      final var chatModelBuilder = spy(OpenAiChatModel.builder());
+      final var chatModelResultCaptor = new ResultCaptor<OpenAiChatModel>();
+      doAnswer(chatModelResultCaptor).when(chatModelBuilder).build();
+
       try (MockedStatic<OpenAiChatModel> chatModelMock =
           Mockito.mockStatic(OpenAiChatModel.class, Answers.CALLS_REAL_METHODS)) {
         chatModelMock.when(OpenAiChatModel::builder).thenReturn(chatModelBuilder);
 
         final var chatModel = chatModelFactory.createChatModel(providerConfig);
         assertThat(chatModel).isNotNull().isInstanceOf(OpenAiChatModel.class);
+        assertThat(chatModel).isSameAs(chatModelResultCaptor.getResult());
 
         builderAssertions.accept(chatModelBuilder);
       }

--- a/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/provider/ChatModelFactoryTest.java
+++ b/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/provider/ChatModelFactoryTest.java
@@ -335,7 +335,7 @@ class ChatModelFactoryTest {
     private static final String OPEN_AI_MODEL = "openAiModel";
 
     private static final OpenAiModelParameters DEFAULT_MODEL_PARAMETERS =
-        new OpenAiModelParameters(10, 5, 1.0, 0.8, 50);
+        new OpenAiModelParameters(10, 1.0, 0.8);
 
     @Captor private ArgumentCaptor<OpenAiChatRequestParameters> modelParametersArgumentCaptor;
 
@@ -362,11 +362,10 @@ class ChatModelFactoryTest {
 
             final var parameters = modelParametersArgumentCaptor.getValue();
             assertThat(parameters).isNotNull();
-            assertThat(parameters.maxOutputTokens())
-                .isEqualTo(DEFAULT_MODEL_PARAMETERS.maxOutputTokens());
+            assertThat(parameters.maxCompletionTokens())
+                .isEqualTo(DEFAULT_MODEL_PARAMETERS.maxCompletionTokens());
             assertThat(parameters.temperature()).isEqualTo(DEFAULT_MODEL_PARAMETERS.temperature());
             assertThat(parameters.topP()).isEqualTo(DEFAULT_MODEL_PARAMETERS.topP());
-            assertThat(parameters.topK()).isEqualTo(DEFAULT_MODEL_PARAMETERS.topK());
           });
     }
 
@@ -428,11 +427,9 @@ class ChatModelFactoryTest {
               final var parameters = modelParametersArgumentCaptor.getValue();
               assertThat(parameters).isNotNull().isInstanceOf(OpenAiChatRequestParameters.class);
 
-              assertThat(parameters.maxOutputTokens()).isNull();
               assertThat(parameters.maxCompletionTokens()).isNull();
               assertThat(parameters.temperature()).isNull();
               assertThat(parameters.topP()).isNull();
-              assertThat(parameters.topK()).isNull();
             }
           });
     }
@@ -457,7 +454,7 @@ class ChatModelFactoryTest {
     }
 
     static Stream<OpenAiModelParameters> nullModelParameters() {
-      return Stream.of(new OpenAiModelParameters(null, null, null, null, null));
+      return Stream.of(new OpenAiModelParameters(null, null, null));
     }
   }
 

--- a/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/provider/ChatModelFactoryTest.java
+++ b/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/provider/ChatModelFactoryTest.java
@@ -7,14 +7,20 @@
 package io.camunda.connector.agenticai.aiagent.provider;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 
+import dev.langchain4j.exception.UnsupportedFeatureException;
 import dev.langchain4j.model.anthropic.AnthropicChatModel;
 import dev.langchain4j.model.anthropic.AnthropicChatModel.AnthropicChatModelBuilder;
+import dev.langchain4j.model.bedrock.BedrockChatModel;
+import dev.langchain4j.model.bedrock.BedrockChatRequestParameters;
+import dev.langchain4j.model.chat.request.ChatRequestParameters;
 import dev.langchain4j.model.openai.OpenAiChatModel;
 import dev.langchain4j.model.openai.OpenAiChatModel.OpenAiChatModelBuilder;
 import dev.langchain4j.model.openai.OpenAiChatRequestParameters;
@@ -22,9 +28,15 @@ import io.camunda.connector.agenticai.aiagent.model.request.ProviderConfiguratio
 import io.camunda.connector.agenticai.aiagent.model.request.ProviderConfiguration.AnthropicProviderConfiguration.AnthropicAuthentication;
 import io.camunda.connector.agenticai.aiagent.model.request.ProviderConfiguration.AnthropicProviderConfiguration.AnthropicConnection;
 import io.camunda.connector.agenticai.aiagent.model.request.ProviderConfiguration.AnthropicProviderConfiguration.AnthropicModel;
+import io.camunda.connector.agenticai.aiagent.model.request.ProviderConfiguration.BedrockProviderConfiguration;
+import io.camunda.connector.agenticai.aiagent.model.request.ProviderConfiguration.BedrockProviderConfiguration.BedrockConnection;
+import io.camunda.connector.agenticai.aiagent.model.request.ProviderConfiguration.BedrockProviderConfiguration.BedrockModel;
 import io.camunda.connector.agenticai.aiagent.model.request.ProviderConfiguration.ModelParameters;
 import io.camunda.connector.agenticai.aiagent.model.request.ProviderConfiguration.OpenAiProviderConfiguration;
 import io.camunda.connector.agenticai.aiagent.model.request.ProviderConfiguration.OpenAiProviderConfiguration.OpenAiConnection;
+import io.camunda.connector.aws.model.impl.AwsAuthentication;
+import io.camunda.connector.aws.model.impl.AwsAuthentication.AwsStaticCredentialsAuthentication;
+import java.net.URI;
 import java.util.stream.Stream;
 import org.assertj.core.api.ThrowingConsumer;
 import org.junit.jupiter.api.Nested;
@@ -41,7 +53,16 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.stubbing.Answer;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.bedrockruntime.BedrockRuntimeClient;
+import software.amazon.awssdk.services.bedrockruntime.BedrockRuntimeClientBuilder;
 
 @ExtendWith(MockitoExtension.class)
 class ChatModelFactoryTest {
@@ -120,17 +141,195 @@ class ChatModelFactoryTest {
     private void testAnthropicChatModelBuilder(
         AnthropicProviderConfiguration providerConfig,
         ThrowingConsumer<AnthropicChatModelBuilder> builderAssertions) {
+      var chatModelBuilder = spy(AnthropicChatModel.builder());
       try (MockedStatic<AnthropicChatModel> chatModelMock =
           Mockito.mockStatic(AnthropicChatModel.class, Answers.CALLS_REAL_METHODS)) {
-        var builder = spy(new AnthropicChatModelBuilder());
-        chatModelMock.when(AnthropicChatModel::builder).thenReturn(builder);
+        chatModelMock.when(AnthropicChatModel::builder).thenReturn(chatModelBuilder);
 
         final var chatModel = chatModelFactory.createChatModel(providerConfig);
         assertThat(chatModel).isNotNull().isInstanceOf(AnthropicChatModel.class);
 
-        builderAssertions.accept(builder);
+        builderAssertions.accept(chatModelBuilder);
       }
     }
+  }
+
+  @Nested
+  class BedrockChatModelFactoryTest {
+
+    private static final String BEDROCK_REGION = "eu-west-1";
+    private static final String BEDROCK_ACCESS_KEY = "bedrockAccessKey";
+    private static final String BEDROCK_SECRET_KEY = "bedrockSecretKey";
+    private static final String BEDROCK_MODEL = "bedrockModel";
+
+    private static final ModelParameters BEDROCK_DEFAULT_MODEL_PARAMETERS =
+        new ModelParameters(10, 1.0, 0.8, null);
+
+    @Captor private ArgumentCaptor<ChatRequestParameters> modelParametersArgumentCaptor;
+    @Captor private ArgumentCaptor<AwsCredentialsProvider> credentialsProviderArgumentCaptor;
+
+    @Test
+    void createsBedrockChatModelWithDefaultCredentials() {
+      final var providerConfig =
+          new BedrockProviderConfiguration(
+              new BedrockConnection(
+                  BEDROCK_REGION,
+                  null,
+                  new AwsAuthentication.AwsDefaultCredentialsChainAuthentication(),
+                  new BedrockModel(BEDROCK_MODEL, BEDROCK_DEFAULT_MODEL_PARAMETERS)));
+
+      testCreateBedrockChatModelWithCredentials(
+          providerConfig,
+          (credentialsProvider) ->
+              assertThat(credentialsProvider)
+                  .isNotNull()
+                  .isInstanceOf(DefaultCredentialsProvider.class));
+    }
+
+    @Test
+    void createsBedrockChatModelWithBasicCredentials() {
+      final var providerConfig =
+          new BedrockProviderConfiguration(
+              new BedrockConnection(
+                  BEDROCK_REGION,
+                  null,
+                  new AwsStaticCredentialsAuthentication(BEDROCK_ACCESS_KEY, BEDROCK_SECRET_KEY),
+                  new BedrockModel(BEDROCK_MODEL, BEDROCK_DEFAULT_MODEL_PARAMETERS)));
+
+      testCreateBedrockChatModelWithCredentials(
+          providerConfig,
+          (credentialsProvider) -> {
+            assertThat(credentialsProvider)
+                .isNotNull()
+                .isInstanceOf(StaticCredentialsProvider.class);
+
+            final var credentials = credentialsProvider.resolveCredentials();
+            assertThat(credentials).isNotNull().isInstanceOf(AwsBasicCredentials.class);
+            assertThat(credentials.accessKeyId()).isEqualTo(BEDROCK_ACCESS_KEY);
+            assertThat(credentials.secretAccessKey()).isEqualTo(BEDROCK_SECRET_KEY);
+          });
+    }
+
+    private void testCreateBedrockChatModelWithCredentials(
+        BedrockProviderConfiguration providerConfig,
+        ThrowingConsumer<AwsCredentialsProvider> credentialsProviderAssertions) {
+      testBedrockChatModelBuilder(
+          providerConfig,
+          (builders) -> {
+            verify(builders.clientBuilder).region(Region.EU_WEST_1);
+            verify(builders.clientBuilder, never()).endpointOverride(any());
+
+            verify(builders.clientBuilder)
+                .credentialsProvider(credentialsProviderArgumentCaptor.capture());
+            credentialsProviderAssertions.accept(credentialsProviderArgumentCaptor.getValue());
+
+            verify(builders.chatModelBuilder).client(builders.clientResultCaptor.getResult());
+            verify(builders.chatModelBuilder).modelId(BEDROCK_MODEL);
+
+            verify(builders.chatModelBuilder)
+                .defaultRequestParameters(modelParametersArgumentCaptor.capture());
+
+            final var parameters = modelParametersArgumentCaptor.getValue();
+            assertThat(parameters).isNotNull().isInstanceOf(BedrockChatRequestParameters.class);
+            assertThat(parameters.maxOutputTokens())
+                .isEqualTo(BEDROCK_DEFAULT_MODEL_PARAMETERS.maxOutputTokens());
+            assertThat(parameters.temperature())
+                .isEqualTo(BEDROCK_DEFAULT_MODEL_PARAMETERS.temperature());
+            assertThat(parameters.topP()).isEqualTo(BEDROCK_DEFAULT_MODEL_PARAMETERS.topP());
+            assertThat(parameters.topK()).isEqualTo(BEDROCK_DEFAULT_MODEL_PARAMETERS.topK());
+          });
+    }
+
+    @Test
+    void createsBedrockChatModelWithCustomEndpoint() {
+      final var providerConfig =
+          new BedrockProviderConfiguration(
+              new BedrockConnection(
+                  BEDROCK_REGION,
+                  "https://my-custom-endpoint.local",
+                  new AwsAuthentication.AwsDefaultCredentialsChainAuthentication(),
+                  new BedrockModel(BEDROCK_MODEL, BEDROCK_DEFAULT_MODEL_PARAMETERS)));
+
+      testBedrockChatModelBuilder(
+          providerConfig,
+          (builders) -> {
+            verify(builders.clientBuilder)
+                .endpointOverride(URI.create("https://my-custom-endpoint.local"));
+          });
+    }
+
+    @Test
+    void throwsExceptionWhenCreatingAModelWithUnsupportedTopKValue() {
+      final var providerConfig =
+          new BedrockProviderConfiguration(
+              new BedrockConnection(
+                  BEDROCK_REGION,
+                  null,
+                  new AwsAuthentication.AwsDefaultCredentialsChainAuthentication(),
+                  new BedrockModel(BEDROCK_MODEL, DEFAULT_MODEL_PARAMETERS)));
+
+      assertThatThrownBy(() -> testBedrockChatModelBuilder(providerConfig, (builders) -> {}))
+          .isInstanceOf(UnsupportedFeatureException.class)
+          .hasMessageContaining("'topK' parameter is not supported yet by this model provider");
+    }
+
+    @ParameterizedTest
+    @NullSource
+    @ArgumentsSource(NullModelParametersArgumentsProvider.class)
+    void createsBedrockChatModelWithNullModelParameters(ModelParameters modelParameters) {
+      final var providerConfig =
+          new BedrockProviderConfiguration(
+              new BedrockConnection(
+                  BEDROCK_REGION,
+                  null,
+                  new AwsAuthentication.AwsDefaultCredentialsChainAuthentication(),
+                  new BedrockModel(BEDROCK_MODEL, modelParameters)));
+
+      testBedrockChatModelBuilder(
+          providerConfig,
+          (builders) -> {
+            verify(builders.chatModelBuilder)
+                .defaultRequestParameters(modelParametersArgumentCaptor.capture());
+
+            final var parameters = modelParametersArgumentCaptor.getValue();
+            assertThat(parameters).isNotNull().isInstanceOf(BedrockChatRequestParameters.class);
+            assertThat(parameters.maxOutputTokens()).isNull();
+            assertThat(parameters.temperature()).isNull();
+            assertThat(parameters.topP()).isNull();
+            assertThat(parameters.topK()).isNull();
+          });
+    }
+
+    private void testBedrockChatModelBuilder(
+        BedrockProviderConfiguration providerConfig,
+        ThrowingConsumer<BedrockBuilderContext> builderAssertions) {
+      final var clientBuilder = spy(BedrockRuntimeClient.builder());
+      final var chatModelBuilder = spy(BedrockChatModel.builder());
+
+      try (MockedStatic<BedrockRuntimeClient> clientMock =
+              Mockito.mockStatic(BedrockRuntimeClient.class, Answers.CALLS_REAL_METHODS);
+          MockedStatic<BedrockChatModel> chatModelMock =
+              Mockito.mockStatic(BedrockChatModel.class, Answers.CALLS_REAL_METHODS)) {
+        clientMock.when(BedrockRuntimeClient::builder).thenReturn(clientBuilder);
+        chatModelMock.when(BedrockChatModel::builder).thenReturn(chatModelBuilder);
+
+        final var clientResultCaptor = new ResultCaptor<BedrockRuntimeClient>();
+        doAnswer(clientResultCaptor).when(clientBuilder).build();
+
+        final var builders =
+            new BedrockBuilderContext(clientBuilder, clientResultCaptor, chatModelBuilder);
+
+        final var chatModel = chatModelFactory.createChatModel(providerConfig);
+        assertThat(chatModel).isNotNull().isInstanceOf(BedrockChatModel.class);
+
+        builderAssertions.accept(builders);
+      }
+    }
+
+    private record BedrockBuilderContext(
+        BedrockRuntimeClientBuilder clientBuilder,
+        ResultCaptor<BedrockRuntimeClient> clientResultCaptor,
+        BedrockChatModel.Builder chatModelBuilder) {}
   }
 
   @Nested
@@ -225,7 +424,7 @@ class ChatModelFactoryTest {
             verify(builder).defaultRequestParameters(modelParametersArgumentCaptor.capture());
 
             final var parameters = modelParametersArgumentCaptor.getValue();
-            assertThat(parameters).isNotNull();
+            assertThat(parameters).isNotNull().isInstanceOf(OpenAiChatRequestParameters.class);
 
             assertThat(parameters.maxOutputTokens()).isNull();
             assertThat(parameters.temperature()).isNull();
@@ -237,15 +436,15 @@ class ChatModelFactoryTest {
     private void testOpenAiChatModelBuilder(
         OpenAiProviderConfiguration providerConfig,
         ThrowingConsumer<OpenAiChatModelBuilder> builderAssertions) {
+      var chatModelBuilder = spy(OpenAiChatModel.builder());
       try (MockedStatic<OpenAiChatModel> chatModelMock =
           Mockito.mockStatic(OpenAiChatModel.class, Answers.CALLS_REAL_METHODS)) {
-        var builder = spy(new OpenAiChatModelBuilder());
-        chatModelMock.when(OpenAiChatModel::builder).thenReturn(builder);
+        chatModelMock.when(OpenAiChatModel::builder).thenReturn(chatModelBuilder);
 
         final var chatModel = chatModelFactory.createChatModel(providerConfig);
         assertThat(chatModel).isNotNull().isInstanceOf(OpenAiChatModel.class);
 
-        builderAssertions.accept(builder);
+        builderAssertions.accept(chatModelBuilder);
       }
     }
   }
@@ -254,6 +453,21 @@ class ChatModelFactoryTest {
     @Override
     public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
       return Stream.of(arguments(NULL_MODEL_PARAMETERS));
+    }
+  }
+
+  private static class ResultCaptor<T> implements Answer<T> {
+    private T result = null;
+
+    public T getResult() {
+      return result;
+    }
+
+    @Override
+    public T answer(InvocationOnMock invocationOnMock) throws Throwable {
+      //noinspection unchecked
+      result = (T) invocationOnMock.callRealMethod();
+      return result;
     }
   }
 }

--- a/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/provider/ChatModelFactoryTest.java
+++ b/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/provider/ChatModelFactoryTest.java
@@ -235,7 +235,7 @@ class ChatModelFactoryTest {
             final var parameters = modelParametersArgumentCaptor.getValue();
             assertThat(parameters).isNotNull().isInstanceOf(BedrockChatRequestParameters.class);
             assertThat(parameters.maxOutputTokens())
-                .isEqualTo(DEFAULT_MODEL_PARAMETERS.maxOutputTokens());
+                .isEqualTo(DEFAULT_MODEL_PARAMETERS.maxTokens());
             assertThat(parameters.temperature()).isEqualTo(DEFAULT_MODEL_PARAMETERS.temperature());
             assertThat(parameters.topP()).isEqualTo(DEFAULT_MODEL_PARAMETERS.topP());
           });


### PR DESCRIPTION
## Description

Initially we used a common set of model parameters (e.g. max output tokens, topP) for all providers, but the provider APIs differ in which parameters are actually supported. For example OpenAI and Bedrock do not support topK and the maximum tokens configuration varies by provider. 

This PR:

1. Adds a dedicated set of model parameters targeted to the specific provider API
2. Adds tooltips to each parameter referencing the actual provider documentation
3. Refactor the parameter handling in the `ChatModelFactory` to account for null values
4. Adds tests for `ChatModelFactory` verifying that the chat models are built as expected

## Related issues

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.

