### PR TITLE
feat(element-template,agentic-ai): Add support to configure a default result variable & result expression

### DIFF
--- a/connectors/agentic-ai/element-templates/agenticai-aiagent-outbound-connector.json
+++ b/connectors/agentic-ai/element-templates/agenticai-aiagent-outbound-connector.json
@@ -635,6 +635,7 @@
     "label" : "Agent Context",
     "description" : "The agent context variable containing all relevant data for the agent to support the feedback loop between user requests, tool calls and LLM responses. Make sure this variable points to the <code>context</code> variable which is returned from the agent response.",
     "optional" : false,
+    "value" : "=agent.context",
     "constraints" : {
       "notEmpty" : true
     },
@@ -703,6 +704,7 @@
     "id" : "resultVariable",
     "label" : "Result variable",
     "description" : "Name of variable to store the response in",
+    "value" : "agent",
     "group" : "output",
     "binding" : {
       "key" : "resultVariable",

--- a/connectors/agentic-ai/element-templates/hybrid/agenticai-aiagent-outbound-connector-hybrid.json
+++ b/connectors/agentic-ai/element-templates/hybrid/agenticai-aiagent-outbound-connector-hybrid.json
@@ -640,6 +640,7 @@
     "label" : "Agent Context",
     "description" : "The agent context variable containing all relevant data for the agent to support the feedback loop between user requests, tool calls and LLM responses. Make sure this variable points to the <code>context</code> variable which is returned from the agent response.",
     "optional" : false,
+    "value" : "=agent.context",
     "constraints" : {
       "notEmpty" : true
     },
@@ -708,6 +709,7 @@
     "id" : "resultVariable",
     "label" : "Result variable",
     "description" : "Name of variable to store the response in",
+    "value" : "agent",
     "group" : "output",
     "binding" : {
       "key" : "resultVariable",

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/AiAgentFunction.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/AiAgentFunction.java
@@ -26,6 +26,7 @@ import io.camunda.connector.generator.java.annotation.ElementTemplate.PropertyGr
     engineVersion = "^8.8",
     version = 0,
     inputDataClass = AgentRequest.class,
+    defaultResultVariable = "agent",
     propertyGroups = {
       @PropertyGroup(id = "provider", label = "Model Provider", openByDefault = false),
       @PropertyGroup(id = "model", label = "Model", openByDefault = false),

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/AgentRequest.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/AgentRequest.java
@@ -31,7 +31,8 @@ public record AgentRequest(
                   "The agent context variable containing all relevant data for the agent to support the feedback loop between user requests, tool calls and LLM responses. Make sure this variable points to the <code>context</code> variable which is returned from the agent response.",
               constraints = @PropertyConstraints(notEmpty = true),
               type = TemplateProperty.PropertyType.Text,
-              feel = Property.FeelMode.required)
+              feel = Property.FeelMode.required,
+              defaultValue = "=agent.context")
           @Valid
           AgentContext context,
       @Valid @NotNull SystemPromptConfiguration systemPrompt,

--- a/element-template-generator/core/src/main/java/io/camunda/connector/generator/dsl/CommonProperties.java
+++ b/element-template-generator/core/src/main/java/io/camunda/connector/generator/dsl/CommonProperties.java
@@ -24,25 +24,48 @@ import io.camunda.connector.generator.dsl.PropertyCondition.Equals;
 import io.camunda.connector.generator.dsl.PropertyCondition.IsActive;
 import io.camunda.connector.generator.dsl.PropertyConstraints.Pattern;
 import java.util.List;
+import org.apache.commons.lang3.StringUtils;
 
 public class CommonProperties {
 
   public static PropertyBuilder resultExpression() {
-    return TextProperty.builder()
-        .id("resultExpression")
-        .group("output")
-        .label("Result expression")
-        .description("Expression to map the response into process variables")
-        .feel(FeelMode.required);
+    return resultExpression(null);
+  }
+
+  public static PropertyBuilder resultExpression(String value) {
+    final var builder =
+        TextProperty.builder()
+            .id("resultExpression")
+            .group("output")
+            .label("Result expression")
+            .description("Expression to map the response into process variables")
+            .feel(FeelMode.required);
+
+    if (StringUtils.isNotBlank(value)) {
+      builder.value(value);
+    }
+
+    return builder;
   }
 
   public static PropertyBuilder resultVariable() {
-    return StringProperty.builder()
-        .id("resultVariable")
-        .group("output")
-        .label("Result variable")
-        .description("Name of variable to store the response in")
-        .feel(FeelMode.disabled);
+    return resultVariable(null);
+  }
+
+  public static PropertyBuilder resultVariable(String value) {
+    final var builder =
+        StringProperty.builder()
+            .id("resultVariable")
+            .group("output")
+            .label("Result variable")
+            .description("Name of variable to store the response in")
+            .feel(FeelMode.disabled);
+
+    if (StringUtils.isNotBlank(value)) {
+      builder.value(value);
+    }
+
+    return builder;
   }
 
   public static PropertyBuilder version(Integer version) {

--- a/element-template-generator/core/src/main/java/io/camunda/connector/generator/dsl/PropertyGroup.java
+++ b/element-template-generator/core/src/main/java/io/camunda/connector/generator/dsl/PropertyGroup.java
@@ -37,18 +37,19 @@ public record PropertyGroup(
     String tooltip,
     Boolean openByDefault) {
 
-  public static PropertyGroup OUTPUT_GROUP_OUTBOUND =
-      PropertyGroup.builder()
-          .id("output")
-          .label("Output mapping")
-          .properties(
-              CommonProperties.resultVariable()
-                  .binding(new ZeebeTaskHeader("resultVariable"))
-                  .build(),
-              CommonProperties.resultExpression()
-                  .binding(new ZeebeTaskHeader("resultExpression"))
-                  .build())
-          .build();
+  public static BiFunction<String, String, PropertyGroup> OUTPUT_GROUP_OUTBOUND =
+      (resultVariableValue, resultExpressionValue) ->
+          PropertyGroup.builder()
+              .id("output")
+              .label("Output mapping")
+              .properties(
+                  CommonProperties.resultVariable(resultVariableValue)
+                      .binding(new ZeebeTaskHeader("resultVariable"))
+                      .build(),
+                  CommonProperties.resultExpression(resultExpressionValue)
+                      .binding(new ZeebeTaskHeader("resultExpression"))
+                      .build())
+              .build();
 
   public static BiFunction<String, Integer, PropertyGroup> ADD_CONNECTORS_DETAILS_OUTPUT =
       (id, version) ->
@@ -62,18 +63,19 @@ public record PropertyGroup(
                   CommonProperties.id(id).binding(new ZeebeTaskHeader("elementTemplateId")).build())
               .build();
 
-  public static PropertyGroup OUTPUT_GROUP_INBOUND =
-      PropertyGroup.builder()
-          .id("output")
-          .label("Output mapping")
-          .properties(
-              CommonProperties.resultVariable()
-                  .binding(new ZeebeProperty("resultVariable"))
-                  .build(),
-              CommonProperties.resultExpression()
-                  .binding(new ZeebeProperty("resultExpression"))
-                  .build())
-          .build();
+  public static BiFunction<String, String, PropertyGroup> OUTPUT_GROUP_INBOUND =
+      (resultVariableValue, resultExpressionValue) ->
+          PropertyGroup.builder()
+              .id("output")
+              .label("Output mapping")
+              .properties(
+                  CommonProperties.resultVariable(resultVariableValue)
+                      .binding(new ZeebeProperty("resultVariable"))
+                      .build(),
+                  CommonProperties.resultExpression(resultExpressionValue)
+                      .binding(new ZeebeProperty("resultExpression"))
+                      .build())
+              .build();
 
   public static PropertyGroup ERROR_GROUP =
       PropertyGroup.builder()

--- a/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/ClassBasedTemplateGenerator.java
+++ b/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/ClassBasedTemplateGenerator.java
@@ -204,7 +204,9 @@ public class ClassBasedTemplateGenerator implements ElementTemplateGenerator<Cla
     if (context instanceof Outbound) {
       newGroups.add(
           PropertyGroup.ADD_CONNECTORS_DETAILS_OUTPUT.apply(template.id(), template.version()));
-      newGroups.add(PropertyGroup.OUTPUT_GROUP_OUTBOUND);
+      newGroups.add(
+          PropertyGroup.OUTPUT_GROUP_OUTBOUND.apply(
+              template.defaultResultVariable(), template.defaultResultExpression()));
       newGroups.add(PropertyGroup.ERROR_GROUP);
       newGroups.add(PropertyGroup.RETRIES_GROUP);
     } else {
@@ -225,7 +227,9 @@ public class ClassBasedTemplateGenerator implements ElementTemplateGenerator<Cla
       if (configuration.features().get(GenerationFeature.INBOUND_DEDUPLICATION) == Boolean.TRUE) {
         newGroups.add(PropertyGroup.DEDUPLICATION_GROUP);
       }
-      newGroups.add(PropertyGroup.OUTPUT_GROUP_INBOUND);
+      newGroups.add(
+          PropertyGroup.OUTPUT_GROUP_INBOUND.apply(
+              template.defaultResultVariable(), template.defaultResultExpression()));
     }
     return newGroups;
   }

--- a/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/annotation/ElementTemplate.java
+++ b/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/annotation/ElementTemplate.java
@@ -98,6 +98,20 @@ public @interface ElementTemplate {
 
   ConnectorElementType[] elementTypes() default {};
 
+  /**
+   * Default result variable value.
+   *
+   * <p>If not specified, no default variable value will be set.
+   */
+  String defaultResultVariable() default "";
+
+  /**
+   * Default result expression value.
+   *
+   * <p>If not specified, no default expression value will be set.
+   */
+  String defaultResultExpression() default "";
+
   /** Metadata tags for the connector. Will be used in Camunda Modeler. */
   @interface Metadata {
 

--- a/element-template-generator/core/src/test/java/io/camunda/connector/generator/java/InboundClassBasedTemplateGeneratorTest.java
+++ b/element-template-generator/core/src/test/java/io/camunda/connector/generator/java/InboundClassBasedTemplateGeneratorTest.java
@@ -52,7 +52,7 @@ public class InboundClassBasedTemplateGeneratorTest extends BaseTest {
 
     @Test
     void connectorTypeProperty() {
-      var templates = generator.generate(MyConnectorExecutable.class);
+      var templates = generator.generate(MyConnectorExecutable.MinimallyAnnotated.class);
       for (var template : templates) {
         var property =
             template.properties().stream()
@@ -66,7 +66,7 @@ public class InboundClassBasedTemplateGeneratorTest extends BaseTest {
 
     @Test
     void resultVariableProperty() {
-      var templates = generator.generate(MyConnectorExecutable.class);
+      var templates = generator.generate(MyConnectorExecutable.MinimallyAnnotated.class);
       for (var template : templates) {
         var property = getPropertyByLabel("Result variable", template);
         assertThat(property.getType()).isEqualTo("String");
@@ -76,8 +76,21 @@ public class InboundClassBasedTemplateGeneratorTest extends BaseTest {
     }
 
     @Test
+    void resultVariablePropertyWithValue() {
+      var templates =
+          generator.generate(MyConnectorExecutable.MinimallyAnnotatedWithResultVariable.class);
+      for (var template : templates) {
+        var property = getPropertyByLabel("Result variable", template);
+        assertThat(property.getType()).isEqualTo("String");
+        assertThat(property.getBinding().type()).isEqualTo("zeebe:property");
+        assertThat(property.getFeel()).isNull();
+        assertThat(property.getValue()).isEqualTo("myResultVariable");
+      }
+    }
+
+    @Test
     void resultExpressionProperty() {
-      var templates = generator.generate(MyConnectorExecutable.class);
+      var templates = generator.generate(MyConnectorExecutable.MinimallyAnnotated.class);
       for (var template : templates) {
         var property = getPropertyByLabel("Result expression", template);
         assertThat(property.getType()).isEqualTo("Text");
@@ -87,8 +100,21 @@ public class InboundClassBasedTemplateGeneratorTest extends BaseTest {
     }
 
     @Test
+    void resultExpressionPropertyWithValue() {
+      var templates =
+          generator.generate(MyConnectorExecutable.MinimallyAnnotatedWithResultExpression.class);
+      for (var template : templates) {
+        var property = getPropertyByLabel("Result expression", template);
+        assertThat(property.getType()).isEqualTo("Text");
+        assertThat(property.getBinding().type()).isEqualTo("zeebe:property");
+        assertThat(property.getFeel()).isEqualTo(FeelMode.required);
+        assertThat(property.getValue()).isEqualTo("={ myResponse: request }");
+      }
+    }
+
+    @Test
     void activationConditionProperty() {
-      var templates = generator.generate(MyConnectorExecutable.class);
+      var templates = generator.generate(MyConnectorExecutable.MinimallyAnnotated.class);
       for (var template : templates) {
         var property = getPropertyByLabel("Activation condition", template);
         assertThat(property.getType()).isEqualTo("String");
@@ -120,7 +146,7 @@ public class InboundClassBasedTemplateGeneratorTest extends BaseTest {
                   Set.of(BpmnType.BOUNDARY_EVENT), BpmnType.BOUNDARY_EVENT, null, null));
 
       // when
-      var templates = generator.generate(MyConnectorExecutable.class);
+      var templates = generator.generate(MyConnectorExecutable.MinimallyAnnotated.class);
 
       // then
       assertThat(templates).hasSize(expectedTypes.size());
@@ -147,7 +173,7 @@ public class InboundClassBasedTemplateGeneratorTest extends BaseTest {
               ConnectorMode.NORMAL, null, null, null, Set.of(type), Map.of());
 
       // when
-      var templates = generator.generate(MyConnectorExecutable.class, config);
+      var templates = generator.generate(MyConnectorExecutable.MinimallyAnnotated.class, config);
 
       // then
       assertThat(templates).hasSize(1);
@@ -170,7 +196,7 @@ public class InboundClassBasedTemplateGeneratorTest extends BaseTest {
               ConnectorMode.NORMAL, null, null, null, Set.of(type), Map.of());
 
       // when
-      var templates = generator.generate(MyConnectorExecutable.class, config);
+      var templates = generator.generate(MyConnectorExecutable.MinimallyAnnotated.class, config);
 
       // then
       assertThat(templates).hasSize(1);
@@ -195,7 +221,7 @@ public class InboundClassBasedTemplateGeneratorTest extends BaseTest {
               ConnectorMode.NORMAL, null, null, null, Set.of(type1, type2), Map.of());
 
       // when
-      var templates = generator.generate(MyConnectorExecutable.class, config);
+      var templates = generator.generate(MyConnectorExecutable.MinimallyAnnotated.class, config);
 
       // then
       assertThat(templates).hasSize(2);
@@ -230,7 +256,7 @@ public class InboundClassBasedTemplateGeneratorTest extends BaseTest {
               ConnectorMode.NORMAL, null, null, null, Set.of(type), Map.of());
 
       // when
-      var templates = generator.generate(MyConnectorExecutable.class, config);
+      var templates = generator.generate(MyConnectorExecutable.MinimallyAnnotated.class, config);
 
       // then
       assertThat(templates).hasSize(1);
@@ -282,7 +308,8 @@ public class InboundClassBasedTemplateGeneratorTest extends BaseTest {
         new GeneratorConfiguration(ConnectorMode.NORMAL, null, null, null, Set.of(type), Map.of());
 
     // when
-    var template = generator.generate(MyConnectorExecutable.class, config).getFirst();
+    var template =
+        generator.generate(MyConnectorExecutable.MinimallyAnnotated.class, config).getFirst();
 
     var property = getPropertyByLabel("Prop 1", template);
 
@@ -308,7 +335,8 @@ public class InboundClassBasedTemplateGeneratorTest extends BaseTest {
               ConnectorMode.NORMAL, null, null, null, Set.of(type), Map.of());
 
       // when
-      var template = generator.generate(MyConnectorExecutable.class, config).getFirst();
+      var template =
+          generator.generate(MyConnectorExecutable.MinimallyAnnotated.class, config).getFirst();
 
       // then
       assertThrows(Exception.class, () -> assertDeduplicationProperties(template));
@@ -330,7 +358,8 @@ public class InboundClassBasedTemplateGeneratorTest extends BaseTest {
               Map.of(GenerationFeature.INBOUND_DEDUPLICATION, true));
 
       // when
-      var template = generator.generate(MyConnectorExecutable.class, config).getFirst();
+      var template =
+          generator.generate(MyConnectorExecutable.MinimallyAnnotated.class, config).getFirst();
 
       // then
       assertDeduplicationProperties(template);
@@ -352,7 +381,8 @@ public class InboundClassBasedTemplateGeneratorTest extends BaseTest {
               Map.of(GenerationFeature.INBOUND_DEDUPLICATION, false));
 
       // when
-      var template = generator.generate(MyConnectorExecutable.class, config).getFirst();
+      var template =
+          generator.generate(MyConnectorExecutable.MinimallyAnnotated.class, config).getFirst();
 
       // then
       assertThrows(Exception.class, () -> assertDeduplicationProperties(template));

--- a/element-template-generator/core/src/test/java/io/camunda/connector/generator/java/OutboundClassBasedTemplateGeneratorTest.java
+++ b/element-template-generator/core/src/test/java/io/camunda/connector/generator/java/OutboundClassBasedTemplateGeneratorTest.java
@@ -133,12 +133,38 @@ public class OutboundClassBasedTemplateGeneratorTest extends BaseTest {
     }
 
     @Test
+    void resultVariablePropertyWithValue() {
+      var template =
+          generator
+              .generate(MyConnectorFunction.MinimallyAnnotatedWithResultVariable.class)
+              .getFirst();
+      var property = getPropertyByLabel("Result variable", template);
+      assertThat(property.getType()).isEqualTo("String");
+      assertThat(property.getBinding().type()).isEqualTo("zeebe:taskHeader");
+      assertThat(property.getFeel()).isNull();
+      assertThat(property.getValue()).isEqualTo("myResultVariable");
+    }
+
+    @Test
     void resultExpressionProperty() {
       var template = generator.generate(MyConnectorFunction.MinimallyAnnotated.class).getFirst();
       var property = getPropertyByLabel("Result expression", template);
       assertThat(property.getType()).isEqualTo("Text");
       assertThat(property.getBinding().type()).isEqualTo("zeebe:taskHeader");
       assertThat(property.getFeel()).isEqualTo(FeelMode.required);
+    }
+
+    @Test
+    void resultExpressionPropertyWithValue() {
+      var template =
+          generator
+              .generate(MyConnectorFunction.MinimallyAnnotatedWithResultExpression.class)
+              .getFirst();
+      var property = getPropertyByLabel("Result expression", template);
+      assertThat(property.getType()).isEqualTo("Text");
+      assertThat(property.getBinding().type()).isEqualTo("zeebe:taskHeader");
+      assertThat(property.getFeel()).isEqualTo(FeelMode.required);
+      assertThat(property.getValue()).isEqualTo("={ myResponse: response }");
     }
 
     @Test

--- a/element-template-generator/core/src/test/java/io/camunda/connector/generator/java/example/inbound/MyConnectorExecutable.java
+++ b/element-template-generator/core/src/test/java/io/camunda/connector/generator/java/example/inbound/MyConnectorExecutable.java
@@ -21,13 +21,6 @@ import io.camunda.connector.api.inbound.InboundConnectorContext;
 import io.camunda.connector.api.inbound.InboundConnectorExecutable;
 import io.camunda.connector.generator.java.annotation.ElementTemplate;
 
-@InboundConnector(name = "my-inbound-connector", type = "my-inbound-connector-type")
-@ElementTemplate(
-    engineVersion = "^8.7",
-    id = MyConnectorExecutable.ID,
-    name = MyConnectorExecutable.NAME,
-    inputDataClass = MyConnectorProperties.class,
-    icon = "my-connector-icon.png")
 public class MyConnectorExecutable implements InboundConnectorExecutable<InboundConnectorContext> {
 
   public static final String ID = "my-inbound-connector-template";
@@ -38,4 +31,33 @@ public class MyConnectorExecutable implements InboundConnectorExecutable<Inbound
 
   @Override
   public void deactivate() {}
+
+  @InboundConnector(name = "my-inbound-connector", type = "my-inbound-connector-type")
+  @ElementTemplate(
+      engineVersion = "^8.7",
+      id = MyConnectorExecutable.ID,
+      name = MyConnectorExecutable.NAME,
+      inputDataClass = MyConnectorProperties.class,
+      icon = "my-connector-icon.png")
+  public static class MinimallyAnnotated extends MyConnectorExecutable {}
+
+  @InboundConnector(name = "my-inbound-connector", type = "my-inbound-connector-type")
+  @ElementTemplate(
+      engineVersion = "^8.7",
+      id = MyConnectorExecutable.ID,
+      name = MyConnectorExecutable.NAME,
+      inputDataClass = MyConnectorProperties.class,
+      icon = "my-connector-icon.png",
+      defaultResultVariable = "myResultVariable")
+  public static class MinimallyAnnotatedWithResultVariable extends MyConnectorExecutable {}
+
+  @InboundConnector(name = "my-inbound-connector", type = "my-inbound-connector-type")
+  @ElementTemplate(
+      engineVersion = "^8.7",
+      id = MyConnectorExecutable.ID,
+      name = MyConnectorExecutable.NAME,
+      inputDataClass = MyConnectorProperties.class,
+      icon = "my-connector-icon.png",
+      defaultResultExpression = "={ myResponse: request }")
+  public static class MinimallyAnnotatedWithResultExpression extends MyConnectorExecutable {}
 }

--- a/element-template-generator/core/src/test/java/io/camunda/connector/generator/java/example/outbound/MyConnectorFunction.java
+++ b/element-template-generator/core/src/test/java/io/camunda/connector/generator/java/example/outbound/MyConnectorFunction.java
@@ -85,6 +85,30 @@ public abstract class MyConnectorFunction implements OutboundConnectorFunction {
       id = MyConnectorFunction.ID,
       name = MyConnectorFunction.NAME,
       inputDataClass = MyConnectorInput.class,
+      defaultResultVariable = "myResultVariable")
+  public static class MinimallyAnnotatedWithResultVariable extends MyConnectorFunction {}
+
+  @OutboundConnector(
+      name = "my-connector",
+      type = "my-connector-type",
+      inputVariables = {})
+  @ElementTemplate(
+      engineVersion = "^8.7",
+      id = MyConnectorFunction.ID,
+      name = MyConnectorFunction.NAME,
+      inputDataClass = MyConnectorInput.class,
+      defaultResultExpression = "={ myResponse: response }")
+  public static class MinimallyAnnotatedWithResultExpression extends MyConnectorFunction {}
+
+  @OutboundConnector(
+      name = "my-connector",
+      type = "my-connector-type",
+      inputVariables = {})
+  @ElementTemplate(
+      engineVersion = "^8.7",
+      id = MyConnectorFunction.ID,
+      name = MyConnectorFunction.NAME,
+      inputDataClass = MyConnectorInput.class,
       icon = "my-connector-icon.svg")
   public static class MinimallyAnnotatedWithSvgIcon extends MyConnectorFunction {}
 

--- a/element-template-generator/http-dsl/src/main/java/io/camunda/connector/generator/dsl/http/HttpOutboundElementTemplateBuilder.java
+++ b/element-template-generator/http-dsl/src/main/java/io/camunda/connector/generator/dsl/http/HttpOutboundElementTemplateBuilder.java
@@ -140,7 +140,7 @@ public class HttpOutboundElementTemplateBuilder {
                 PropertyUtil.parametersPropertyGroup(operations),
                 PropertyUtil.requestBodyPropertyGroup(operations),
                 PropertyUtil.urlPropertyGroup(),
-                PropertyGroup.OUTPUT_GROUP_OUTBOUND,
+                PropertyGroup.OUTPUT_GROUP_OUTBOUND.apply(null, null),
                 PropertyGroup.ERROR_GROUP,
                 PropertyGroup.RETRIES_GROUP))
         .build();


### PR DESCRIPTION
## Description

Adds support to configure a default `resultVariable` and/or `resultExpression` via `@ElementTemplate` for both inbound and outbound connectors & configures a default result variable on the Agentic AI connector.

Related discussion: https://camunda.slack.com/archives/C02JLRNQQ05/p1746616997970169

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #4729
related to https://github.com/camunda/team-connectors/issues/1049

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.

