### PR TITLE
fix(idp-extraction-connector): added handling of duplicate keys and checkboxes on structured extraction

### DIFF
--- a/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/caller/DocumentAiCaller.java
+++ b/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/caller/DocumentAiCaller.java
@@ -89,15 +89,26 @@ public class DocumentAiCaller {
   private StructuredExtractionResponse extractFormFieldsWithConfidence(Document document) {
     Map<String, String> keyValuePairs = new HashMap<>();
     Map<String, Float> confidenceScores = new HashMap<>();
+    Map<String, Integer> keyOccurrences = new HashMap<>();
 
     // Process form fields from Document AI response
     for (Document.Page page : document.getPagesList()) {
       for (Document.Page.FormField formField : page.getFormFieldsList()) {
         if (formField.hasFieldName() && formField.hasFieldValue()) {
-          String name = getTextFromLayout(document, formField.getFieldName().getTextAnchor());
-          String value = getTextFromLayout(document, formField.getFieldValue().getTextAnchor());
+          String originalKey = getTextFromLayout(formField.getFieldName().getTextAnchor()).trim();
+          String key = originalKey;
+          String value = getValueFromFormField(formField).trim();
 
-          if (name != null && !name.trim().isEmpty()) {
+          // Handle duplicate keys by adding a suffix
+          if (keyValuePairs.containsKey(key)) {
+            int count = keyOccurrences.getOrDefault(originalKey, 1) + 1;
+            keyOccurrences.put(originalKey, count);
+            key = originalKey + " " + count;
+          } else {
+            keyOccurrences.put(originalKey, 1);
+          }
+
+          if (!key.isEmpty()) {
             // Get confidence scores from both name and value fields
             float nameConfidence = formField.getFieldName().getConfidence();
             float valueConfidence = formField.getFieldValue().getConfidence();
@@ -105,37 +116,9 @@ public class DocumentAiCaller {
             // Use the lower of the two confidence scores (conservative approach)
             float combinedConfidence = Math.min(nameConfidence, valueConfidence);
 
-            keyValuePairs.put(name.trim(), value != null ? value.trim() : "");
-            confidenceScores.put(name.trim(), combinedConfidence);
+            keyValuePairs.put(key, value);
+            confidenceScores.put(key, combinedConfidence);
           }
-        }
-      }
-    }
-
-    // If available, also get key-value pairs from entities
-    for (Document.Entity entity : document.getEntitiesList()) {
-      if (entity.getType().equals("key_value_pair") || entity.getType().equals("form_field")) {
-        String key = null;
-        String value = null;
-        float keyConfidence = 0;
-        float valueConfidence = 0;
-
-        for (Document.Entity property : entity.getPropertiesList()) {
-          if (property.getType().equals("key")) {
-            key = property.getMentionText();
-            keyConfidence = property.getConfidence();
-          } else if (property.getType().equals("value")) {
-            value = property.getMentionText();
-            valueConfidence = property.getConfidence();
-          }
-        }
-
-        if (key != null && !key.trim().isEmpty()) {
-          // Use the lower of the two confidence scores
-          float combinedConfidence = Math.min(keyConfidence, valueConfidence);
-
-          keyValuePairs.put(key.trim(), value != null ? value.trim() : "");
-          confidenceScores.put(key.trim(), combinedConfidence);
         }
       }
     }
@@ -143,21 +126,21 @@ public class DocumentAiCaller {
     return new StructuredExtractionResponse(keyValuePairs, confidenceScores);
   }
 
-  private String getTextFromLayout(Document document, Document.TextAnchor textAnchor) {
-    if (textAnchor == null || textAnchor.getTextSegmentsList().isEmpty()) {
+  private String getValueFromFormField(Document.Page.FormField formField) {
+    String valueType = formField.getValueType();
+    if (valueType != null && valueType.equals("unfilled_checkbox")) {
+      return "false";
+    } else if (valueType != null && valueType.equals("filled_checkbox")) {
+      return "true";
+    } else {
+      return getTextFromLayout(formField.getFieldValue().getTextAnchor());
+    }
+  }
+
+  private String getTextFromLayout(Document.TextAnchor textAnchor) {
+    if (textAnchor == null) {
       return "";
     }
-
-    StringBuilder result = new StringBuilder();
-    for (Document.TextAnchor.TextSegment segment : textAnchor.getTextSegmentsList()) {
-      int startIndex = (int) segment.getStartIndex();
-      int endIndex = (int) segment.getEndIndex();
-
-      if (startIndex >= 0 && endIndex > startIndex && endIndex <= document.getText().length()) {
-        result.append(document.getText(), startIndex, endIndex);
-      }
-    }
-
-    return result.toString();
+    return textAnchor.getContent();
   }
 }

--- a/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/caller/DocumentAiCaller.java
+++ b/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/caller/DocumentAiCaller.java
@@ -95,20 +95,19 @@ public class DocumentAiCaller {
     for (Document.Page page : document.getPagesList()) {
       for (Document.Page.FormField formField : page.getFormFieldsList()) {
         if (formField.hasFieldName() && formField.hasFieldValue()) {
-          String originalKey = getTextFromLayout(formField.getFieldName().getTextAnchor()).trim();
+          String originalKey = getTextFromLayout(formField.getFieldName().getTextAnchor());
           String key = originalKey;
-          String value = getValueFromFormField(formField).trim();
-
-          // Handle duplicate keys by adding a suffix
-          if (keyValuePairs.containsKey(key)) {
-            int count = keyOccurrences.getOrDefault(originalKey, 1) + 1;
-            keyOccurrences.put(originalKey, count);
-            key = originalKey + " " + count;
-          } else {
-            keyOccurrences.put(originalKey, 1);
-          }
+          String value = getValueFromFormField(formField);
 
           if (!key.isEmpty()) {
+            // Handle duplicate keys by adding a suffix
+            if (keyValuePairs.containsKey(key)) {
+              int count = keyOccurrences.getOrDefault(originalKey, 1) + 1;
+              keyOccurrences.put(originalKey, count);
+              key = originalKey + " " + count;
+            } else {
+              keyOccurrences.put(originalKey, 1);
+            }
             // Get confidence scores from both name and value fields
             float nameConfidence = formField.getFieldName().getConfidence();
             float valueConfidence = formField.getFieldValue().getConfidence();
@@ -141,6 +140,6 @@ public class DocumentAiCaller {
     if (textAnchor == null) {
       return "";
     }
-    return textAnchor.getContent();
+    return textAnchor.getContent().trim();
   }
 }

--- a/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/caller/PollingTextractCaller.java
+++ b/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/caller/PollingTextractCaller.java
@@ -220,17 +220,6 @@ public class PollingTextractCaller {
         blocks.stream().collect(Collectors.toMap(Block::id, block -> block));
     Map<String, Integer> keyOccurrences = new HashMap<>();
 
-    extractKeyValueSet(blocks, blockMap, keyValuePairs, keyOccurrences, confidenceScores);
-
-    return new StructuredExtractionResponse(keyValuePairs, confidenceScores);
-  }
-
-  private void extractKeyValueSet(
-      List<Block> blocks,
-      Map<String, Block> blockMap,
-      Map<String, String> keyValuePairs,
-      Map<String, Integer> keyOccurrences,
-      Map<String, Float> confidenceScores) {
     blocks.stream()
         .filter(
             block ->
@@ -269,6 +258,8 @@ public class PollingTextractCaller {
               keyValuePairs.put(key, value);
               confidenceScores.put(key, combinedConfidence / 100); // Convert to percentage
             });
+
+    return new StructuredExtractionResponse(keyValuePairs, confidenceScores);
   }
 
   private String getTextFromRelationships(Block block, Map<String, Block> blockMap) {

--- a/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/model/TextractAnalysisTask.java
+++ b/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/model/TextractAnalysisTask.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.idp.extraction.model;
+
+import java.util.concurrent.Callable;
+import software.amazon.awssdk.services.textract.TextractClient;
+import software.amazon.awssdk.services.textract.model.GetDocumentAnalysisRequest;
+import software.amazon.awssdk.services.textract.model.GetDocumentAnalysisResponse;
+
+public class TextractAnalysisTask implements Callable<GetDocumentAnalysisResponse> {
+
+  private final GetDocumentAnalysisRequest docAnalysisReq;
+
+  private final TextractClient textractClient;
+
+  public TextractAnalysisTask(
+      GetDocumentAnalysisRequest documentAnalysisRequest, TextractClient textractClient) {
+    this.docAnalysisReq = documentAnalysisRequest;
+    this.textractClient = textractClient;
+  }
+
+  @Override
+  public GetDocumentAnalysisResponse call() {
+    return textractClient.getDocumentAnalysis(docAnalysisReq);
+  }
+}

--- a/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/model/TextractTextDetectionTask.java
+++ b/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/model/TextractTextDetectionTask.java
@@ -11,13 +11,13 @@ import software.amazon.awssdk.services.textract.TextractClient;
 import software.amazon.awssdk.services.textract.model.GetDocumentTextDetectionRequest;
 import software.amazon.awssdk.services.textract.model.GetDocumentTextDetectionResponse;
 
-public class TextractTask implements Callable<GetDocumentTextDetectionResponse> {
+public class TextractTextDetectionTask implements Callable<GetDocumentTextDetectionResponse> {
 
   private final GetDocumentTextDetectionRequest docAnalysisReq;
 
   private final TextractClient textractClient;
 
-  public TextractTask(
+  public TextractTextDetectionTask(
       GetDocumentTextDetectionRequest documentAnalysisRequest, TextractClient textractClient) {
     this.docAnalysisReq = documentAnalysisRequest;
     this.textractClient = textractClient;

--- a/connectors/idp-extraction/src/test/java/io/camunda/connector/idp/extraction/caller/DocumentAiCallerTest.java
+++ b/connectors/idp-extraction/src/test/java/io/camunda/connector/idp/extraction/caller/DocumentAiCallerTest.java
@@ -59,18 +59,6 @@ class DocumentAiCallerTest {
     Document.TextAnchor mockNameAnchor = mock(Document.TextAnchor.class);
     Document.TextAnchor mockValueAnchor = mock(Document.TextAnchor.class);
 
-    // Set up text segments for the name and value anchors
-    Document.TextAnchor.TextSegment mockNameSegment = mock(Document.TextAnchor.TextSegment.class);
-    Document.TextAnchor.TextSegment mockValueSegment = mock(Document.TextAnchor.TextSegment.class);
-
-    when(mockNameSegment.getStartIndex()).thenReturn(0L);
-    when(mockNameSegment.getEndIndex()).thenReturn(7L);
-    when(mockValueSegment.getStartIndex()).thenReturn(8L);
-    when(mockValueSegment.getEndIndex()).thenReturn(14L);
-
-    when(mockNameAnchor.getTextSegmentsList()).thenReturn(List.of(mockNameSegment));
-    when(mockValueAnchor.getTextSegmentsList()).thenReturn(List.of(mockValueSegment));
-
     // Create mock Layout objects
     Document.Page.Layout mockNameLayout = mock(Document.Page.Layout.class);
     Document.Page.Layout mockValueLayout = mock(Document.Page.Layout.class);
@@ -80,6 +68,7 @@ class DocumentAiCallerTest {
     when(mockFormField.getFieldValue()).thenReturn(mockValueLayout);
     when(mockFormField.hasFieldName()).thenReturn(true);
     when(mockFormField.hasFieldValue()).thenReturn(true);
+    when(mockFormField.getValueType()).thenReturn(null);
 
     // Set up text anchors for the layouts
     when(mockNameLayout.getTextAnchor()).thenReturn(mockNameAnchor);
@@ -94,6 +83,10 @@ class DocumentAiCallerTest {
     when(mockPage.getFormFieldsList()).thenReturn(List.of(mockFormField));
     when(mockDocument.getPagesList()).thenReturn(List.of(mockPage));
 
+    // Set up text content for anchors instead of using text segments
+    when(mockNameAnchor.getContent()).thenReturn("Invoice");
+    when(mockValueAnchor.getContent()).thenReturn("Total:");
+
     // Mock entities for additional key-value pairs
     Document.Entity mockEntity = mock(Document.Entity.class);
     Document.Entity mockKeyProperty = mock(Document.Entity.class);
@@ -101,24 +94,17 @@ class DocumentAiCallerTest {
     Document.TextAnchor mockKeyAnchor = mock(Document.TextAnchor.class);
     Document.TextAnchor mockValAnchor = mock(Document.TextAnchor.class);
 
-    Document.TextAnchor.TextSegment mockKeySegment = mock(Document.TextAnchor.TextSegment.class);
-    Document.TextAnchor.TextSegment mockValSegment = mock(Document.TextAnchor.TextSegment.class);
-
-    lenient().when(mockKeySegment.getStartIndex()).thenReturn(15L);
-    lenient().when(mockKeySegment.getEndIndex()).thenReturn(19L);
-    lenient().when(mockValSegment.getStartIndex()).thenReturn(20L);
-    lenient().when(mockValSegment.getEndIndex()).thenReturn(30L);
-
-    lenient().when(mockKeyAnchor.getTextSegmentsList()).thenReturn(List.of(mockKeySegment));
-    lenient().when(mockValAnchor.getTextSegmentsList()).thenReturn(List.of(mockValSegment));
-
-    lenient().when(mockKeyProperty.getTextAnchor()).thenReturn(mockKeyAnchor);
-    lenient().when(mockValueProperty.getTextAnchor()).thenReturn(mockValAnchor);
-
     when(mockKeyProperty.getType()).thenReturn("key");
     when(mockValueProperty.getType()).thenReturn("value");
     when(mockKeyProperty.getMentionText()).thenReturn("Date");
     when(mockValueProperty.getMentionText()).thenReturn("2023-05-15");
+
+    // Set up text content for key and value anchors
+    when(mockKeyAnchor.getContent()).thenReturn("Date");
+    when(mockValAnchor.getContent()).thenReturn("2023-05-15");
+
+    lenient().when(mockKeyProperty.getTextAnchor()).thenReturn(mockKeyAnchor);
+    lenient().when(mockValueProperty.getTextAnchor()).thenReturn(mockValAnchor);
 
     when(mockKeyProperty.getConfidence()).thenReturn(0.98f);
     when(mockValueProperty.getConfidence()).thenReturn(0.92f);
@@ -168,11 +154,9 @@ class DocumentAiCallerTest {
     // Assert
     Map<String, String> expectedKeyValuePairs = new HashMap<>();
     expectedKeyValuePairs.put("Invoice", "Total:");
-    expectedKeyValuePairs.put("Date", "2023-05-15");
 
     Map<String, Float> expectedConfidenceScores = new HashMap<>();
     expectedConfidenceScores.put("Invoice", 0.85f); // Min of 0.95 and 0.85
-    expectedConfidenceScores.put("Date", 0.92f); // Min of 0.98 and 0.92
 
     assertEquals(expectedKeyValuePairs, response.extractedFields());
     assertEquals(expectedConfidenceScores, response.confidenceScore());

--- a/connectors/idp-extraction/src/test/java/io/camunda/connector/idp/extraction/caller/DocumentAiCallerTest.java
+++ b/connectors/idp-extraction/src/test/java/io/camunda/connector/idp/extraction/caller/DocumentAiCallerTest.java
@@ -161,4 +161,104 @@ class DocumentAiCallerTest {
     assertEquals(expectedKeyValuePairs, response.extractedFields());
     assertEquals(expectedConfidenceScores, response.confidenceScore());
   }
+
+  @Test
+  void extractKeyValuePairs_HandlesMultipleDuplicateKeys() throws Exception {
+    // Arrange
+    DocumentAiClientSupplier mockSupplier = mock(DocumentAiClientSupplier.class);
+    DocumentProcessorServiceClient mockClient = mock(DocumentProcessorServiceClient.class);
+    ProcessResponse mockResponse = mock(ProcessResponse.class);
+    Document mockDocument = mock(Document.class);
+
+    when(mockSupplier.getDocumentAiClient(any(GcpAuthentication.class))).thenReturn(mockClient);
+    when(mockClient.processDocument((ProcessRequest) any())).thenReturn(mockResponse);
+    when(mockResponse.getDocument()).thenReturn(mockDocument);
+
+    DocumentAiCaller caller = new DocumentAiCaller(mockSupplier);
+
+    // Mock document page
+    Document.Page mockPage = mock(Document.Page.class);
+
+    // Create multiple form fields with the same key
+    Document.Page.FormField formField1 = createMockFormField("Invoice", "Total1", 0.95f, 0.90f);
+    Document.Page.FormField formField2 = createMockFormField("Invoice", "Total2", 0.92f, 0.89f);
+    Document.Page.FormField formField3 = createMockFormField("Invoice", "Total3", 0.88f, 0.85f);
+    Document.Page.FormField uniqueFormField =
+        createMockFormField("Date", "2023-05-15", 0.99f, 0.97f);
+
+    when(mockPage.getFormFieldsList())
+        .thenReturn(List.of(formField1, formField2, formField3, uniqueFormField));
+    when(mockDocument.getPagesList()).thenReturn(List.of(mockPage));
+
+    // Setup GcpProvider and request data (same as existing test)
+    GcpProvider baseRequest = new GcpProvider();
+    DocumentAiRequestConfiguration configuration =
+        new DocumentAiRequestConfiguration("us", "test-project", "test-processor");
+    baseRequest.setConfiguration(configuration);
+
+    GcpAuthentication authentication =
+        new GcpAuthentication(GcpAuthenticationType.BEARER, "test-token", null, null, null, null);
+    baseRequest.setAuthentication(authentication);
+
+    ExtractionRequestData requestData = mock(ExtractionRequestData.class);
+    io.camunda.document.Document mockInputDocument = mock(io.camunda.document.Document.class);
+    DocumentMetadata mockMetadata = mock(DocumentMetadata.class);
+    InputStream mockInputStream = new ByteArrayInputStream("test document content".getBytes());
+
+    when(requestData.document()).thenReturn(mockInputDocument);
+    when(mockInputDocument.asInputStream()).thenReturn(mockInputStream);
+    when(mockInputDocument.metadata()).thenReturn(mockMetadata);
+    when(mockMetadata.getContentType()).thenReturn("application/pdf");
+
+    // Act
+    StructuredExtractionResponse response =
+        caller.extractKeyValuePairsWithConfidence(requestData, baseRequest);
+
+    // Assert
+    Map<String, String> expectedKeyValuePairs = new HashMap<>();
+    expectedKeyValuePairs.put("Invoice", "Total1"); // First occurrence keeps original key
+    expectedKeyValuePairs.put("Invoice 2", "Total2"); // Second occurrence gets suffix " 2"
+    expectedKeyValuePairs.put("Invoice 3", "Total3"); // Third occurrence gets suffix " 3"
+    expectedKeyValuePairs.put("Date", "2023-05-15"); // Unique key stays as is
+
+    Map<String, Float> expectedConfidenceScores = new HashMap<>();
+    expectedConfidenceScores.put("Invoice", 0.90f); // Min of 0.95 and 0.90
+    expectedConfidenceScores.put("Invoice 2", 0.89f); // Min of 0.92 and 0.89
+    expectedConfidenceScores.put("Invoice 3", 0.85f); // Min of 0.88 and 0.85
+    expectedConfidenceScores.put("Date", 0.97f); // Min of 0.99 and 0.97
+
+    assertEquals(expectedKeyValuePairs, response.extractedFields());
+    assertEquals(expectedConfidenceScores, response.confidenceScore());
+  }
+
+  // Helper method to create mock form fields
+  private Document.Page.FormField createMockFormField(
+      String key, String value, float keyConfidence, float valueConfidence) {
+    Document.Page.FormField mockFormField = mock(Document.Page.FormField.class);
+    Document.Page.Layout mockNameLayout = mock(Document.Page.Layout.class);
+    Document.Page.Layout mockValueLayout = mock(Document.Page.Layout.class);
+    Document.TextAnchor mockNameAnchor = mock(Document.TextAnchor.class);
+    Document.TextAnchor mockValueAnchor = mock(Document.TextAnchor.class);
+
+    // Set up the form field with field name and value layouts
+    when(mockFormField.getFieldName()).thenReturn(mockNameLayout);
+    when(mockFormField.getFieldValue()).thenReturn(mockValueLayout);
+    when(mockFormField.hasFieldName()).thenReturn(true);
+    when(mockFormField.hasFieldValue()).thenReturn(true);
+    when(mockFormField.getValueType()).thenReturn(null);
+
+    // Set up text anchors for the layouts
+    when(mockNameLayout.getTextAnchor()).thenReturn(mockNameAnchor);
+    when(mockValueLayout.getTextAnchor()).thenReturn(mockValueAnchor);
+
+    // Set up confidence values
+    when(mockNameLayout.getConfidence()).thenReturn(keyConfidence);
+    when(mockValueLayout.getConfidence()).thenReturn(valueConfidence);
+
+    // Set up text content
+    when(mockNameAnchor.getContent()).thenReturn(key);
+    when(mockValueAnchor.getContent()).thenReturn(value);
+
+    return mockFormField;
+  }
 }

--- a/connectors/idp-extraction/src/test/java/io/camunda/connector/idp/extraction/caller/PollingTextractCallerTest.java
+++ b/connectors/idp-extraction/src/test/java/io/camunda/connector/idp/extraction/caller/PollingTextractCallerTest.java
@@ -62,7 +62,7 @@ class PollingTextractCallerTest {
   }
 
   @Test
-  void callTextractDocumentAnalysisWithSuccess() throws Exception {
+  void callTextractTextDetectionWithSuccess() throws Exception {
     String jobId = "1";
     GetDocumentTextDetectionRequest getDocumentTextDetectionRequest =
         GetDocumentTextDetectionRequest.builder().jobId(jobId).maxResults(MAX_RESULT).build();
@@ -94,7 +94,7 @@ class PollingTextractCallerTest {
   }
 
   @Test
-  void callTextractDocumentAnalysisWithEmptyResult() throws Exception {
+  void callTextractTextDetectionWithEmptyResult() throws Exception {
     String jobId = "1";
     GetDocumentTextDetectionRequest getDocumentTextDetectionRequest =
         GetDocumentTextDetectionRequest.builder().jobId(jobId).maxResults(MAX_RESULT).build();
@@ -123,7 +123,7 @@ class PollingTextractCallerTest {
   }
 
   @Test
-  void callTextractDocumentAnalysisWithFailure() {
+  void callTextractTextDetectionWithFailure() {
     String jobId = "1";
     GetDocumentTextDetectionRequest getDocumentTextDetectionRequest =
         GetDocumentTextDetectionRequest.builder().jobId(jobId).maxResults(MAX_RESULT).build();


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

This code does 2 things: 
- Adds logic to save all duplicate keys as a new key with a numerator. So if we have three "name" keys they will be returned as "name" "name 2" and "name 3" then the space will be substituted with whatever the delimiter is.
- Handles checkboxes and maps their values to "true" or "false"
 
Additionally i added this fix:
- Fixes the code to use both text-extraction and document-analysis for textract

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes https://github.com/camunda/connectors/issues/4765

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.

