### PR TITLE
fix(rest): Handle unsupported multipart/form-data parts gracefully

### DIFF
--- a/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/client/apache/builder/parts/DocumentAwareMultipartEntityBuilder.java
+++ b/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/client/apache/builder/parts/DocumentAwareMultipartEntityBuilder.java
@@ -108,7 +108,7 @@ public class DocumentAwareMultipartEntityBuilder {
           new ByteArrayInputStream(part.content()),
           getContentType(part.contentType()),
           part.fileName());
-    } catch (IllegalArgumentException e) {
+    } catch (IllegalArgumentException | NullPointerException e) {
       LOG.error(
           "Failed to convert the provided map {} to CloudFunctionFilePart. A request with Content-Type: multipart/form-data can only contain maps that are convertible to CloudFunctionFilePart.",
           map,


### PR DESCRIPTION
## Description
Added NullpointerException to catch, as this is thrown for input like this:
```
{
  "address" : {  //this is invalid as only string and file are allowed
    "city" : "Berlin", 
    "street" : "Teststr"
  }
}
```

I decided to not throw a ConnectorInputExcpetion for this, as this would be a breaking change for process that currently have invalid input that leads to an `IllegalArgumentException` and therefore ignoring this part, but succeeding the process. Feel free to disagree, then I can change this.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes https://github.com/camunda/connectors/issues/4772

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.

