### PR TITLE
fix(idp-extraction-connector): reversed logic of excluded fields, using inclusion.

### DIFF
--- a/connectors/idp-extraction/element-templates/hybrid/hybrid-idp-extraction-outbound-connector-hybrid.json
+++ b/connectors/idp-extraction/element-templates/hybrid/hybrid-idp-extraction-outbound-connector-hybrid.json
@@ -96,14 +96,14 @@
     },
     "type" : "Hidden"
   }, {
-    "id" : "input.excludedFields",
-    "label" : "Excluded Fields",
-    "description" : "List of fields that should not be returned from the extraction",
+    "id" : "input.includedFields",
+    "label" : "Included Fields",
+    "description" : "List of fields that should be returned from the extraction",
     "optional" : false,
-    "value" : "= input.excludedFields",
+    "value" : "= input.includedFields",
     "group" : "input",
     "binding" : {
-      "name" : "input.excludedFields",
+      "name" : "input.includedFields",
       "type" : "zeebe:input"
     },
     "type" : "Hidden"

--- a/connectors/idp-extraction/element-templates/idp-extraction-outbound-connector.json
+++ b/connectors/idp-extraction/element-templates/idp-extraction-outbound-connector.json
@@ -91,14 +91,14 @@
     },
     "type" : "Hidden"
   }, {
-    "id" : "input.excludedFields",
-    "label" : "Excluded Fields",
-    "description" : "List of fields that should not be returned from the extraction",
+    "id" : "input.includedFields",
+    "label" : "Included Fields",
+    "description" : "List of fields that should be returned from the extraction",
     "optional" : false,
-    "value" : "= input.excludedFields",
+    "value" : "= input.includedFields",
     "group" : "input",
     "binding" : {
-      "name" : "input.excludedFields",
+      "name" : "input.includedFields",
       "type" : "zeebe:input"
     },
     "type" : "Hidden"

--- a/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/model/ExtractionRequestData.java
+++ b/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/model/ExtractionRequestData.java
@@ -51,15 +51,15 @@ public record ExtractionRequestData(
             feel = Property.FeelMode.disabled)
         List<TaxonomyItem> taxonomyItems,
     @TemplateProperty(
-            id = "excludedFields",
-            label = "Excluded Fields",
+            id = "includedFields",
+            label = "Included Fields",
             group = "input",
             type = TemplateProperty.PropertyType.Hidden,
-            description = "List of fields that should not be returned from the extraction",
-            defaultValue = "= input.excludedFields",
-            binding = @PropertyBinding(name = "excludedFields"),
+            description = "List of fields that should be returned from the extraction",
+            defaultValue = "= input.includedFields",
+            binding = @PropertyBinding(name = "includedFields"),
             feel = Property.FeelMode.disabled)
-        List<String> excludedFields,
+        List<String> includedFields,
     @TemplateProperty(
             id = "renameMappings",
             label = "Rename mappings",

--- a/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/service/StructuredService.java
+++ b/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/service/StructuredService.java
@@ -126,7 +126,10 @@ public class StructuredService implements ExtractionService {
               }
               Float confidenceScore = response.confidenceScore().get(key);
 
-              if ((input.excludedFields() == null || !input.excludedFields().contains(key))
+              // if the list is empty will not filter any fields.
+              if ((input.includedFields() == null
+                      || input.includedFields().isEmpty()
+                      || input.includedFields().contains(key))
                   && (value != null && !value.isBlank())) {
                 parsedResults.put(variableName, value);
                 originalKeys.put(variableName, key);

--- a/connectors/idp-extraction/src/test/java/io/camunda/connector/idp/extraction/service/StructuredServiceTest.java
+++ b/connectors/idp-extraction/src/test/java/io/camunda/connector/idp/extraction/service/StructuredServiceTest.java
@@ -89,22 +89,21 @@ public class StructuredServiceTest {
   }
 
   @Test
-  void extractUsingTextract_WithExcludedFields_ReturnsCorrectResultWithoutExcludedFields()
-      throws Exception {
+  void extractUsingTextract_WithIncludedFields_ReturnsOnlyIncludedFields() throws Exception {
     // given
     AwsProvider baseRequest = ExtractionTestUtils.createDefaultAwsProvider();
 
-    ExtractionRequestData requestDataWithExclusions =
+    ExtractionRequestData requestDataWithInclusions =
         new ExtractionRequestData(
             ExtractionTestUtils.TEXTRACT_EXTRACTION_REQUEST_DATA.document(),
             ExtractionType.STRUCTURED,
             ExtractionTestUtils.TEXTRACT_EXTRACTION_REQUEST_DATA.taxonomyItems(),
-            List.of("Total Amount"), // Use original field name instead of formatted name
+            List.of("Invoice Number", "Supplier Name"), // Only include these fields
             null, // No rename mappings
             "_", // Set a delimiter
             ExtractionTestUtils.TEXTRACT_EXTRACTION_REQUEST_DATA.converseData());
 
-    ExtractionRequest request = new ExtractionRequest(requestDataWithExclusions, baseRequest);
+    ExtractionRequest request = new ExtractionRequest(requestDataWithInclusions, baseRequest);
 
     StructuredExtractionResponse extractionResponse = getStructuredExtractionResponse();
 
@@ -129,7 +128,7 @@ public class StructuredServiceTest {
         .containsEntry("supplier_name", 0.92f)
         .doesNotContainKey("total_amount");
 
-    // Verify original keys were properly mapped (excluding the excluded field)
+    // Verify original keys were properly mapped (excluding non-included fields)
     assertThat(structuredResult.originalKeys())
         .containsEntry("invoice_number", "Invoice Number")
         .containsEntry("supplier_name", "Supplier Name")
@@ -218,7 +217,7 @@ public class StructuredServiceTest {
   }
 
   @Test
-  void extractUsingGcp_WithExcludedFields_ReturnsCorrectResultWithoutExcludedFields() {
+  void extractUsingGcp_WithIncludedFields_ReturnsOnlyIncludedFields() {
     GcpProvider gcpProvider = new GcpProvider();
     DocumentAiRequestConfiguration configuration =
         new DocumentAiRequestConfiguration("us-central1", "test-project", "test-processor-id");
@@ -228,20 +227,20 @@ public class StructuredServiceTest {
         new GcpAuthentication(GcpAuthenticationType.BEARER, "test-token", null, null, null, null);
     gcpProvider.setAuthentication(authentication);
 
-    // Create a custom extraction request with excluded fields
-    ExtractionRequestData requestDataWithExclusions =
+    // Create a custom extraction request with included fields
+    ExtractionRequestData requestDataWithInclusions =
         new ExtractionRequestData(
             ExtractionTestUtils.TEXTRACT_EXTRACTION_REQUEST_DATA.document(),
             ExtractionType.STRUCTURED,
             ExtractionTestUtils.TEXTRACT_EXTRACTION_REQUEST_DATA.taxonomyItems(),
-            List.of("Total Amount"), // Use original field name instead of formatted name
+            List.of("Invoice Number", "Supplier Name"), // Only include these fields
             null, // No rename mappings
             "_", // Set a delimiter
             ExtractionTestUtils.TEXTRACT_EXTRACTION_REQUEST_DATA.converseData());
 
-    ExtractionRequest request = new ExtractionRequest(requestDataWithExclusions, gcpProvider);
+    ExtractionRequest request = new ExtractionRequest(requestDataWithInclusions, gcpProvider);
 
-    // Create the extraction response with all fields (including the one to be excluded)
+    // Create the extraction response with all fields (but only included ones will be processed)
     StructuredExtractionResponse extractionResponse = getStructuredExtractionResponse();
 
     // Mock the Document AI caller to return our sample response
@@ -268,7 +267,7 @@ public class StructuredServiceTest {
         .containsEntry("supplier_name", 0.92f)
         .doesNotContainKey("total_amount");
 
-    // Verify original keys were properly mapped (excluding the excluded field)
+    // Verify original keys were properly mapped (excluding non-included fields)
     assertThat(structuredResult.originalKeys())
         .containsEntry("invoice_number", "Invoice Number")
         .containsEntry("supplier_name", "Supplier Name")
@@ -315,7 +314,7 @@ public class StructuredServiceTest {
             ExtractionTestUtils.TEXTRACT_EXTRACTION_REQUEST_DATA.document(),
             ExtractionType.STRUCTURED,
             ExtractionTestUtils.TEXTRACT_EXTRACTION_REQUEST_DATA.taxonomyItems(),
-            null, // No excluded fields
+            null,
             renameMappings, // Apply our custom rename mappings
             "_", // Set a delimiter
             ExtractionTestUtils.TEXTRACT_EXTRACTION_REQUEST_DATA.converseData());


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

I flipped one of the inputs to use inclusion for allowed fields instead of exclusion.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes https://github.com/camunda/connectors/issues/4738

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.

