### PR TITLE
fix(connector-runtime): delete processes before adding them

### DIFF
--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/state/ProcessStateStoreImpl.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/state/ProcessStateStoreImpl.java
@@ -74,9 +74,9 @@ public class ProcessStateStoreImpl implements ProcessStateStore {
 
     logResult(newlyDeployed, replacedWithDifferentVersion, deletedProcessIds);
 
-    newlyDeployed.forEach(this::newlyDeployed);
-    replacedWithDifferentVersion.forEach(this::replacedWithDifferentVersion);
     deletedProcessIds.forEach(this::deleted);
+    replacedWithDifferentVersion.forEach(this::replacedWithDifferentVersion);
+    newlyDeployed.forEach(this::newlyDeployed);
   }
 
   private void newlyDeployed(


### PR DESCRIPTION
## Description

[Our camunda CPT tests fail when triggering inbount connectors as is discussed here.}(https://github.com/camunda/camunda/issues/31542) The reason for this is that we reuse the same connector id across processes which, in turn, causes the WebhookConnectorRegistry to fail because the same context is already in use:
```
Failed to activate connector of type "io.camunda:webhook:1" with deduplication ID "default-2251799813685268-Event_1fvu473", reason: Context: 941c5492-ab2b-4305-aa18-ac86991ff4ca already in use by: process connector-process(Event_1fvu473). All previously activated executables from this batch will be discarded.
```
After discussing the issue with Philipp, we've reached the conclusion that the error can be solved if we delete existing processes before adding them. Since the event queue operates on a FIFO basis, we're guaranteed that the process deletions are handled before any activations.

## Related issues

closes #31542