### PR TITLE
chore(embedding-vector-db): Fix docs link

### DIFF
--- a/connectors/embeddings-vector-database/element-templates/embeddings-vector-database-outbound-connector.json
+++ b/connectors/embeddings-vector-database/element-templates/embeddings-vector-database-outbound-connector.json
@@ -6,7 +6,7 @@
   "metadata" : {
     "keywords" : [ ]
   },
-  "documentationRef" : "https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/embeddings-vector-db/",
+  "documentationRef" : "https://docs.camunda.io/docs/8.8/components/connectors/out-of-the-box-connectors/embeddings-vector-db/",
   "version" : 1,
   "category" : {
     "id" : "connectors",

--- a/connectors/embeddings-vector-database/element-templates/hybrid/embeddings-vector-database-outbound-connector-hybrid.json
+++ b/connectors/embeddings-vector-database/element-templates/hybrid/embeddings-vector-database-outbound-connector-hybrid.json
@@ -6,7 +6,7 @@
   "metadata" : {
     "keywords" : [ ]
   },
-  "documentationRef" : "https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/embeddings-vector-db/",
+  "documentationRef" : "https://docs.camunda.io/docs/8.8/components/connectors/out-of-the-box-connectors/embeddings-vector-db/",
   "version" : 1,
   "category" : {
     "id" : "connectors",

--- a/connectors/embeddings-vector-database/src/main/java/io/camunda/connector/EmbeddingsVectorDBFunction.java
+++ b/connectors/embeddings-vector-database/src/main/java/io/camunda/connector/EmbeddingsVectorDBFunction.java
@@ -31,7 +31,7 @@ import io.camunda.connector.model.EmbeddingsVectorDBRequest;
       @ElementTemplate.PropertyGroup(id = "document", label = "Document")
     },
     documentationRef =
-        "https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/embeddings-vector-db/",
+        "https://docs.camunda.io/docs/8.8/components/connectors/out-of-the-box-connectors/embeddings-vector-db/",
     icon = "icon.svg")
 public class EmbeddingsVectorDBFunction implements OutboundConnectorFunction {
 


### PR DESCRIPTION
## Description
is only available on 8.8 but linking to 8.7

Was raised here: https://github.com/camunda/camunda-docs/pull/5728

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.

