### PR TITLE
feat(agentic-ai): make the OpenAI endpoint + custom headers configurable through properties panel

### DIFF
--- a/connectors/agentic-ai/element-templates/agenticai-aiagent-outbound-connector.json
+++ b/connectors/agentic-ai/element-templates/agenticai-aiagent-outbound-connector.json
@@ -240,22 +240,6 @@
     },
     "type" : "String"
   }, {
-    "id" : "provider.openai.endpoint",
-    "label" : "Endpoint",
-    "description" : "Specify endpoint if need to use a custom API endpoint",
-    "optional" : true,
-    "group" : "provider",
-    "binding" : {
-      "name" : "provider.openai.endpoint",
-      "type" : "zeebe:input"
-    },
-    "condition" : {
-      "property" : "provider.type",
-      "equals" : "openai",
-      "type" : "simple"
-    },
-    "type" : "Hidden"
-  }, {
     "id" : "provider.openai.authentication.apiKey",
     "label" : "OpenAI API Key",
     "optional" : false,
@@ -300,6 +284,41 @@
     "group" : "provider",
     "binding" : {
       "name" : "provider.openai.authentication.projectId",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "provider.type",
+      "equals" : "openai",
+      "type" : "simple"
+    },
+    "type" : "String"
+  }, {
+    "id" : "provider.openai.endpoint",
+    "label" : "Custom API endpoint",
+    "description" : "Optional custom API endpoint.",
+    "optional" : true,
+    "feel" : "optional",
+    "group" : "provider",
+    "binding" : {
+      "name" : "provider.openai.endpoint",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "provider.type",
+      "equals" : "openai",
+      "type" : "simple"
+    },
+    "tooltip" : "Configure a custom OpenAI compatible API endpoint to use the connector with an OpenAI compatible API. Typically ends in <code>/v1</code>.",
+    "type" : "String"
+  }, {
+    "id" : "provider.openai.headers",
+    "label" : "Custom headers",
+    "description" : "Map of custom HTTP headers to add to the request.",
+    "optional" : true,
+    "feel" : "required",
+    "group" : "provider",
+    "binding" : {
+      "name" : "provider.openai.headers",
       "type" : "zeebe:input"
     },
     "condition" : {

--- a/connectors/agentic-ai/element-templates/hybrid/agenticai-aiagent-outbound-connector-hybrid.json
+++ b/connectors/agentic-ai/element-templates/hybrid/agenticai-aiagent-outbound-connector-hybrid.json
@@ -245,22 +245,6 @@
     },
     "type" : "String"
   }, {
-    "id" : "provider.openai.endpoint",
-    "label" : "Endpoint",
-    "description" : "Specify endpoint if need to use a custom API endpoint",
-    "optional" : true,
-    "group" : "provider",
-    "binding" : {
-      "name" : "provider.openai.endpoint",
-      "type" : "zeebe:input"
-    },
-    "condition" : {
-      "property" : "provider.type",
-      "equals" : "openai",
-      "type" : "simple"
-    },
-    "type" : "Hidden"
-  }, {
     "id" : "provider.openai.authentication.apiKey",
     "label" : "OpenAI API Key",
     "optional" : false,
@@ -305,6 +289,41 @@
     "group" : "provider",
     "binding" : {
       "name" : "provider.openai.authentication.projectId",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "provider.type",
+      "equals" : "openai",
+      "type" : "simple"
+    },
+    "type" : "String"
+  }, {
+    "id" : "provider.openai.endpoint",
+    "label" : "Custom API endpoint",
+    "description" : "Optional custom API endpoint.",
+    "optional" : true,
+    "feel" : "optional",
+    "group" : "provider",
+    "binding" : {
+      "name" : "provider.openai.endpoint",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "provider.type",
+      "equals" : "openai",
+      "type" : "simple"
+    },
+    "tooltip" : "Configure a custom OpenAI compatible API endpoint to use the connector with an OpenAI compatible API. Typically ends in <code>/v1</code>.",
+    "type" : "String"
+  }, {
+    "id" : "provider.openai.headers",
+    "label" : "Custom headers",
+    "description" : "Map of custom HTTP headers to add to the request.",
+    "optional" : true,
+    "feel" : "required",
+    "group" : "provider",
+    "binding" : {
+      "name" : "provider.openai.headers",
       "type" : "zeebe:input"
     },
     "condition" : {

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/ChatModelFactoryImpl.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/ChatModelFactoryImpl.java
@@ -115,6 +115,7 @@ public class ChatModelFactoryImpl implements ChatModelFactory {
         .ifPresent(builder::organizationId);
     Optional.ofNullable(connection.authentication().projectId()).ifPresent(builder::projectId);
     Optional.ofNullable(connection.endpoint()).ifPresent(builder::baseUrl);
+    Optional.ofNullable(connection.headers()).ifPresent(builder::customHeaders);
 
     final var modelParameters = connection.model().parameters();
     if (modelParameters != null) {

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/ProviderConfiguration.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/ProviderConfiguration.java
@@ -22,6 +22,7 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import java.util.Map;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
 @JsonSubTypes({
@@ -263,14 +264,26 @@ public sealed interface ProviderConfiguration
     public static final String OPENAI_ID = "openai";
 
     public record OpenAiConnection(
+        @Valid @NotNull OpenAiAuthentication authentication,
         @TemplateProperty(
                 group = "provider",
-                description = "Specify endpoint if need to use a custom API endpoint",
-                type = TemplateProperty.PropertyType.Hidden,
-                feel = Property.FeelMode.disabled,
+                label = "Custom API endpoint",
+                description = "Optional custom API endpoint.",
+                tooltip =
+                    "Configure a custom OpenAI compatible API endpoint to use the connector with an OpenAI compatible API. "
+                        + "Typically ends in <code>/v1</code>.",
+                type = TemplateProperty.PropertyType.String,
+                feel = Property.FeelMode.optional,
                 optional = true)
             String endpoint,
-        @Valid @NotNull OpenAiAuthentication authentication,
+        @FEEL
+            @TemplateProperty(
+                group = "provider",
+                label = "Custom headers",
+                description = "Map of custom HTTP headers to add to the request.",
+                feel = Property.FeelMode.required,
+                optional = true)
+            Map<String, String> headers,
         @Valid @NotNull OpenAiModel model) {}
 
     public record OpenAiAuthentication(

--- a/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/ChatModelFactoryTest.java
+++ b/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/ChatModelFactoryTest.java
@@ -35,6 +35,7 @@ import io.camunda.connector.agenticai.aiagent.model.request.ProviderConfiguratio
 import io.camunda.connector.agenticai.aiagent.model.request.ProviderConfiguration.OpenAiProviderConfiguration.OpenAiConnection;
 import io.camunda.connector.agenticai.aiagent.model.request.ProviderConfiguration.OpenAiProviderConfiguration.OpenAiModel.OpenAiModelParameters;
 import java.net.URI;
+import java.util.Map;
 import java.util.stream.Stream;
 import org.assertj.core.api.ThrowingConsumer;
 import org.junit.jupiter.api.Nested;
@@ -344,8 +345,9 @@ class ChatModelFactoryTest {
       final var providerConfig =
           new OpenAiProviderConfiguration(
               new OpenAiConnection(
-                  null,
                   new OpenAiProviderConfiguration.OpenAiAuthentication(OPEN_AI_API_KEY, null, null),
+                  null,
+                  Map.of(),
                   new OpenAiProviderConfiguration.OpenAiModel(
                       OPEN_AI_MODEL, DEFAULT_MODEL_PARAMETERS)));
 
@@ -374,9 +376,10 @@ class ChatModelFactoryTest {
       final var providerConfig =
           new OpenAiProviderConfiguration(
               new OpenAiConnection(
-                  null,
                   new OpenAiProviderConfiguration.OpenAiAuthentication(
                       OPEN_AI_API_KEY, "MY_ORG_ID", "MY_PROJECT_ID"),
+                  null,
+                  Map.of(),
                   new OpenAiProviderConfiguration.OpenAiModel(
                       OPEN_AI_MODEL, DEFAULT_MODEL_PARAMETERS)));
 
@@ -389,19 +392,21 @@ class ChatModelFactoryTest {
     }
 
     @Test
-    void createsOpenAiChatModelWithCustomEndpoint() {
+    void createsOpenAiChatModelWithCustomEndpointAndHeaders() {
       final var providerConfig =
           new OpenAiProviderConfiguration(
               new OpenAiConnection(
-                  "https://my-custom-endpoint.local",
                   new OpenAiProviderConfiguration.OpenAiAuthentication(OPEN_AI_API_KEY, null, null),
+                  "https://my-custom-endpoint.local/openai/v1",
+                  Map.of("my-header", "my-value"),
                   new OpenAiProviderConfiguration.OpenAiModel(
                       OPEN_AI_MODEL, DEFAULT_MODEL_PARAMETERS)));
 
       testOpenAiChatModelBuilder(
           providerConfig,
           (builder) -> {
-            verify(builder).baseUrl("https://my-custom-endpoint.local");
+            verify(builder).baseUrl("https://my-custom-endpoint.local/openai/v1");
+            verify(builder).customHeaders(Map.of("my-header", "my-value"));
           });
     }
 
@@ -412,8 +417,9 @@ class ChatModelFactoryTest {
       final var providerConfig =
           new OpenAiProviderConfiguration(
               new OpenAiConnection(
-                  null,
                   new OpenAiProviderConfiguration.OpenAiAuthentication(OPEN_AI_API_KEY, null, null),
+                  null,
+                  Map.of(),
                   new OpenAiProviderConfiguration.OpenAiModel(OPEN_AI_MODEL, modelParameters)));
 
       testOpenAiChatModelBuilder(


### PR DESCRIPTION
## Description

The OpenAI endpoint was already present as hidden property, but as this is a common use case we should officially support configuring a custom API endpoint. This makes testing with OpenAI compatible APIs such as Ollama possible without needing to adapt the template.

## Related issues

closes #4776 

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.

