### PR TITLE
fix(message-connector): correct unit of buffer time

### DIFF
--- a/connectors/camunda-message/element-templates/hybrid/hybrid-send-message-connector-intermediate-throw-event-hybrid.json
+++ b/connectors/camunda-message/element-templates/hybrid/hybrid-send-message-connector-intermediate-throw-event-hybrid.json
@@ -98,7 +98,7 @@
     } ]
   }, {
     "id" : "correlationType.timeToLive",
-    "label" : "Time to live (in ms)",
+    "label" : "Time to live (as ISO 8601)",
     "description" : "Duration for which the message remains buffered",
     "optional" : true,
     "feel" : "optional",

--- a/connectors/camunda-message/element-templates/hybrid/hybrid-send-message-connector-message-end-event-hybrid.json
+++ b/connectors/camunda-message/element-templates/hybrid/hybrid-send-message-connector-message-end-event-hybrid.json
@@ -98,7 +98,7 @@
     } ]
   }, {
     "id" : "correlationType.timeToLive",
-    "label" : "Time to live (in ms)",
+    "label" : "Time to live (as ISO 8601)",
     "description" : "Duration for which the message remains buffered",
     "optional" : true,
     "feel" : "optional",

--- a/connectors/camunda-message/element-templates/hybrid/hybrid-send-message-connector-send-task-hybrid.json
+++ b/connectors/camunda-message/element-templates/hybrid/hybrid-send-message-connector-send-task-hybrid.json
@@ -97,7 +97,7 @@
     } ]
   }, {
     "id" : "correlationType.timeToLive",
-    "label" : "Time to live (in ms)",
+    "label" : "Time to live (as ISO 8601)",
     "description" : "Duration for which the message remains buffered",
     "optional" : true,
     "feel" : "optional",

--- a/connectors/camunda-message/element-templates/send-message-connector-intermediate-throw-event.json
+++ b/connectors/camunda-message/element-templates/send-message-connector-intermediate-throw-event.json
@@ -93,7 +93,7 @@
     } ]
   }, {
     "id" : "correlationType.timeToLive",
-    "label" : "Time to live (in ms)",
+    "label" : "Time to live (as ISO 8601)",
     "description" : "Duration for which the message remains buffered",
     "optional" : true,
     "feel" : "optional",

--- a/connectors/camunda-message/element-templates/send-message-connector-message-end-event.json
+++ b/connectors/camunda-message/element-templates/send-message-connector-message-end-event.json
@@ -93,7 +93,7 @@
     } ]
   }, {
     "id" : "correlationType.timeToLive",
-    "label" : "Time to live (in ms)",
+    "label" : "Time to live (as ISO 8601)",
     "description" : "Duration for which the message remains buffered",
     "optional" : true,
     "feel" : "optional",

--- a/connectors/camunda-message/element-templates/send-message-connector-send-task.json
+++ b/connectors/camunda-message/element-templates/send-message-connector-send-task.json
@@ -92,7 +92,7 @@
     } ]
   }, {
     "id" : "correlationType.timeToLive",
-    "label" : "Time to live (in ms)",
+    "label" : "Time to live (as ISO 8601)",
     "description" : "Duration for which the message remains buffered",
     "optional" : true,
     "feel" : "optional",

--- a/connectors/camunda-message/src/main/java/io/camunda/connector/message/SendMessageRequest.java
+++ b/connectors/camunda-message/src/main/java/io/camunda/connector/message/SendMessageRequest.java
@@ -41,7 +41,7 @@ public record SendMessageRequest(
     record Publish(
         @TemplateProperty(
                 optional = true,
-                label = "Time to live (in ms)",
+                label = "Time to live (as ISO 8601)",
                 description = "Duration for which the message remains buffered")
             Duration timeToLive,
         @TemplateProperty(optional = true, label = "Message id (optional)") String messageId)


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
The label for the buffer time in the element template had the wrong unit.

This change corrects it to ISO 8601

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #

## Checklist

- [ ] PR has a **milestone** or the `no milestone` label.

