### PR TITLE
fix(idp-extraction-connector): added cross-region inference support

### DIFF
--- a/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/service/UnstructuredService.java
+++ b/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/service/UnstructuredService.java
@@ -114,6 +114,7 @@ public class UnstructuredService implements ExtractionService {
       String bedrockResponse =
           bedrockCaller.call(
               input,
+              baseRequest.getConfiguration().region(),
               extractedText,
               bedrockRuntimeClientSupplier.getBedrockRuntimeClient(baseRequest));
       long endTime = System.currentTimeMillis();

--- a/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/utils/AwsLlmModelUtil.java
+++ b/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/utils/AwsLlmModelUtil.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.idp.extraction.utils;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+public class AwsLlmModelUtil {
+
+  // Models that require cross-region inference (marked with asterisks in AWS docs)
+  private static final Set<String> CROSS_REGION_ONLY_MODELS =
+      Set.of(
+          // Amazon Nova models
+          "amazon.nova-lite-v1:0",
+          "amazon.nova-micro-v1:0",
+          "amazon.nova-premier-v1:0",
+          "amazon.nova-pro-v1:0",
+
+          // Anthropic Claude models
+          "anthropic.claude-3-5-haiku-20241022-v1:0",
+          "anthropic.claude-3-5-sonnet-20241022-v2:0",
+          "anthropic.claude-3-7-sonnet-20250219-v1:0",
+          "anthropic.claude-opus-4-20250514-v1:0",
+          "anthropic.claude-sonnet-4-20250514-v1:0",
+
+          // Meta Llama models
+          "meta.llama3-1-405b-instruct-v1:0",
+          "meta.llama4-maverick-17b-instruct-v1:0",
+          "meta.llama4-scout-17b-instruct-v1:0",
+
+          // Mistral models
+          "mistral.pixtral-large-2502-v1:0",
+
+          // Writer models
+          "writer.palmyra-x4-v1:0",
+          "writer.palmyra-x5-v1:0",
+
+          // DeepSeek models
+          "deepseek.r1-v1:0");
+
+  // Regional groupings for cross-region inference
+  private static final Map<String, String> REGION_TO_PREFIX;
+
+  static {
+    Map<String, String> regionMap = new HashMap<>();
+
+    // US regions
+    regionMap.put("us-east-1", "us");
+    regionMap.put("us-east-2", "us");
+    regionMap.put("us-west-1", "us");
+    regionMap.put("us-west-2", "us");
+    regionMap.put("us-gov-east-1", "us-gov");
+    regionMap.put("us-gov-west-1", "us-gov");
+
+    // EU regions
+    regionMap.put("eu-central-1", "eu");
+    regionMap.put("eu-north-1", "eu");
+    regionMap.put("eu-south-1", "eu");
+    regionMap.put("eu-south-2", "eu");
+    regionMap.put("eu-west-1", "eu");
+    regionMap.put("eu-west-2", "eu");
+    regionMap.put("eu-west-3", "eu");
+
+    // APAC regions
+    regionMap.put("ap-northeast-1", "apac");
+    regionMap.put("ap-northeast-2", "apac");
+    regionMap.put("ap-northeast-3", "apac");
+    regionMap.put("ap-south-1", "apac");
+    regionMap.put("ap-south-2", "apac");
+    regionMap.put("ap-southeast-1", "apac");
+    regionMap.put("ap-southeast-2", "apac");
+    regionMap.put("ap-southeast-4", "apac");
+
+    REGION_TO_PREFIX = Map.copyOf(regionMap);
+  }
+
+  /**
+   * Processes the model ID to add proper region prefix for cross-region inference if needed.
+   *
+   * @param modelId The original model ID (e.g., "anthropic.claude-3-5-sonnet-20241022-v2:0")
+   * @param userRegion The AWS region the user is operating in (e.g., "us-east-1")
+   * @return The processed model ID with regional prefix if needed for cross-region inference
+   */
+  public static String processModelIdForCrossRegion(String modelId, String userRegion) {
+    if (modelId == null || modelId.trim().isEmpty()) {
+      throw new IllegalArgumentException("Model ID cannot be null or empty");
+    }
+
+    if (userRegion == null || userRegion.trim().isEmpty()) {
+      throw new IllegalArgumentException("User region cannot be null or empty");
+    }
+
+    // Normalize inputs
+    String normalizedModelId = modelId.trim();
+    String normalizedRegion = userRegion.trim().toLowerCase();
+
+    // If model ID already has a regional prefix, return as-is
+    if (hasRegionalPrefix(normalizedModelId)) {
+      return normalizedModelId;
+    }
+
+    // Check if this model requires cross-region inference
+    if (!requiresCrossRegionInference(normalizedModelId)) {
+      return normalizedModelId;
+    }
+
+    // Get the appropriate regional prefix
+    String regionPrefix = REGION_TO_PREFIX.get(normalizedRegion);
+    if (regionPrefix == null) {
+      // If region is not in our mapping, return original model ID
+      // This handles cases like regions not supported for cross-region inference
+      return normalizedModelId;
+    }
+
+    // Add the regional prefix
+    return regionPrefix + "." + normalizedModelId;
+  }
+
+  /**
+   * Checks if the model ID already has a regional prefix.
+   *
+   * @param modelId The model ID to check
+   * @return true if the model ID starts with a regional prefix (us., eu., apac., us-gov.)
+   */
+  private static boolean hasRegionalPrefix(String modelId) {
+    return modelId.startsWith("us.")
+        || modelId.startsWith("eu.")
+        || modelId.startsWith("apac.")
+        || modelId.startsWith("us-gov.");
+  }
+
+  /**
+   * Determines if a model requires cross-region inference based on AWS documentation. Models marked
+   * with asterisks in the AWS Bedrock supported models table require cross-region inference.
+   *
+   * @param modelId The model ID to check (without regional prefix)
+   * @return true if the model requires cross-region inference
+   */
+  private static boolean requiresCrossRegionInference(String modelId) {
+    return CROSS_REGION_ONLY_MODELS.contains(modelId);
+  }
+
+  /**
+   * Gets the regional prefix for a given AWS region.
+   *
+   * @param region The AWS region (e.g., "us-east-1")
+   * @return The regional prefix (e.g., "us") or null if region is not supported
+   */
+  public static String getRegionalPrefix(String region) {
+    if (region == null) {
+      return null;
+    }
+    return REGION_TO_PREFIX.get(region.trim().toLowerCase());
+  }
+
+  /**
+   * Checks if a region supports cross-region inference.
+   *
+   * @param region The AWS region to check
+   * @return true if the region supports cross-region inference
+   */
+  public static boolean supportsCrossRegionInference(String region) {
+    return getRegionalPrefix(region) != null;
+  }
+}

--- a/connectors/idp-extraction/src/test/java/io/camunda/connector/idp/extraction/caller/BedrockCallerTest.java
+++ b/connectors/idp-extraction/src/test/java/io/camunda/connector/idp/extraction/caller/BedrockCallerTest.java
@@ -9,17 +9,22 @@ package io.camunda.connector.idp.extraction.caller;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import io.camunda.connector.idp.extraction.model.ConverseData;
 import io.camunda.connector.idp.extraction.model.ExtractionRequest;
+import io.camunda.connector.idp.extraction.model.ExtractionRequestData;
 import io.camunda.connector.idp.extraction.model.providers.AwsProvider;
 import io.camunda.connector.idp.extraction.util.ExtractionTestUtils;
 import java.util.function.Consumer;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import software.amazon.awssdk.services.bedrockruntime.BedrockRuntimeClient;
+import software.amazon.awssdk.services.bedrockruntime.model.ConverseRequest;
 import software.amazon.awssdk.services.bedrockruntime.model.ConverseResponse;
 
 @ExtendWith(MockitoExtension.class)
@@ -48,8 +53,202 @@ class BedrockCallerTest {
         new ExtractionRequest(ExtractionTestUtils.TEXTRACT_EXTRACTION_REQUEST_DATA, baseRequest);
 
     String bedrockResponse =
-        bedrockCaller.call(extractionRequest.input(), "", bedrockRuntimeClient);
+        bedrockCaller.call(
+            extractionRequest.input(), "us-east-1", "extracted text", bedrockRuntimeClient);
 
     assertEquals(expectedResponse, bedrockResponse);
+  }
+
+  @Test
+  void shouldAddCrossRegionPrefixForNovaModel() {
+    // Given
+    String originalModelId = "amazon.nova-lite-v1:0";
+    String awsRegion = "us-east-1";
+    String expectedPrefixedModelId = "us.amazon.nova-lite-v1:0";
+
+    ExtractionRequestData requestData = createTestRequestData(originalModelId);
+
+    setupMockResponse();
+
+    // When
+    bedrockCaller.call(requestData, awsRegion, "extracted text", bedrockRuntimeClient);
+
+    // Then
+    ArgumentCaptor<Consumer<ConverseRequest.Builder>> captor =
+        ArgumentCaptor.forClass(Consumer.class);
+    verify(bedrockRuntimeClient).converse(captor.capture());
+
+    ConverseRequest.Builder builder = ConverseRequest.builder();
+    captor.getValue().accept(builder);
+
+    assertEquals(expectedPrefixedModelId, builder.build().modelId());
+  }
+
+  @Test
+  void shouldAddCrossRegionPrefixForClaudeModel() {
+    // Given
+    String originalModelId = "anthropic.claude-3-5-sonnet-20241022-v2:0";
+    String awsRegion = "eu-west-1";
+    String expectedPrefixedModelId = "eu.anthropic.claude-3-5-sonnet-20241022-v2:0";
+
+    ExtractionRequestData requestData = createTestRequestData(originalModelId);
+
+    setupMockResponse();
+
+    // When
+    bedrockCaller.call(requestData, awsRegion, "extracted text", bedrockRuntimeClient);
+
+    // Then
+    ArgumentCaptor<Consumer<ConverseRequest.Builder>> captor =
+        ArgumentCaptor.forClass(Consumer.class);
+    verify(bedrockRuntimeClient).converse(captor.capture());
+
+    ConverseRequest.Builder builder = ConverseRequest.builder();
+    captor.getValue().accept(builder);
+
+    assertEquals(expectedPrefixedModelId, builder.build().modelId());
+  }
+
+  @Test
+  void shouldNotModifyRegularModels() {
+    // Given
+    String originalModelId = "anthropic.claude-3-sonnet-20240229-v1:0";
+    String awsRegion = "us-east-1";
+
+    ExtractionRequestData requestData = createTestRequestData(originalModelId);
+
+    setupMockResponse();
+
+    // When
+    bedrockCaller.call(requestData, awsRegion, "extracted text", bedrockRuntimeClient);
+
+    // Then
+    ArgumentCaptor<Consumer<ConverseRequest.Builder>> captor =
+        ArgumentCaptor.forClass(Consumer.class);
+    verify(bedrockRuntimeClient).converse(captor.capture());
+
+    ConverseRequest.Builder builder = ConverseRequest.builder();
+    captor.getValue().accept(builder);
+
+    assertEquals(originalModelId, builder.build().modelId());
+  }
+
+  @Test
+  void shouldNotModifyAlreadyPrefixedModels() {
+    // Given
+    String prefixedModelId = "us.amazon.nova-lite-v1:0";
+    String awsRegion = "eu-west-1"; // Different region, but model already has prefix
+
+    ExtractionRequestData requestData = createTestRequestData(prefixedModelId);
+
+    setupMockResponse();
+
+    // When
+    bedrockCaller.call(requestData, awsRegion, "extracted text", bedrockRuntimeClient);
+
+    // Then
+    ArgumentCaptor<Consumer<ConverseRequest.Builder>> captor =
+        ArgumentCaptor.forClass(Consumer.class);
+    verify(bedrockRuntimeClient).converse(captor.capture());
+
+    ConverseRequest.Builder builder = ConverseRequest.builder();
+    captor.getValue().accept(builder);
+
+    assertEquals(prefixedModelId, builder.build().modelId());
+  }
+
+  @Test
+  void shouldHandleUnsupportedRegion() {
+    // Given
+    String originalModelId = "amazon.nova-lite-v1:0";
+    String unsupportedRegion = "af-south-1"; // Region not in our mapping
+
+    ExtractionRequestData requestData = createTestRequestData(originalModelId);
+
+    setupMockResponse();
+
+    // When
+    bedrockCaller.call(requestData, unsupportedRegion, "extracted text", bedrockRuntimeClient);
+
+    // Then
+    ArgumentCaptor<Consumer<ConverseRequest.Builder>> captor =
+        ArgumentCaptor.forClass(Consumer.class);
+    verify(bedrockRuntimeClient).converse(captor.capture());
+
+    ConverseRequest.Builder builder = ConverseRequest.builder();
+    captor.getValue().accept(builder);
+
+    // Should return original model ID since region doesn't support cross-region inference
+    assertEquals(originalModelId, builder.build().modelId());
+  }
+
+  @Test
+  void shouldHandleApacRegion() {
+    // Given
+    String originalModelId = "amazon.nova-lite-v1:0";
+    String awsRegion = "ap-southeast-2";
+    String expectedPrefixedModelId = "apac.amazon.nova-lite-v1:0";
+
+    ExtractionRequestData requestData = createTestRequestData(originalModelId);
+
+    setupMockResponse();
+
+    // When
+    bedrockCaller.call(requestData, awsRegion, "extracted text", bedrockRuntimeClient);
+
+    // Then
+    ArgumentCaptor<Consumer<ConverseRequest.Builder>> captor =
+        ArgumentCaptor.forClass(Consumer.class);
+    verify(bedrockRuntimeClient).converse(captor.capture());
+
+    ConverseRequest.Builder builder = ConverseRequest.builder();
+    captor.getValue().accept(builder);
+
+    assertEquals(expectedPrefixedModelId, builder.build().modelId());
+  }
+
+  @Test
+  void shouldHandleGovCloudRegion() {
+    // Given
+    String originalModelId =
+        "anthropic.claude-3-haiku-20240307-v1:0"; // This would be cross-region if it was in the
+    // list
+    String awsRegion = "us-gov-west-1";
+
+    ExtractionRequestData requestData = createTestRequestData(originalModelId);
+
+    setupMockResponse();
+
+    // When
+    bedrockCaller.call(requestData, awsRegion, "extracted text", bedrockRuntimeClient);
+
+    // Then
+    ArgumentCaptor<Consumer<ConverseRequest.Builder>> captor =
+        ArgumentCaptor.forClass(Consumer.class);
+    verify(bedrockRuntimeClient).converse(captor.capture());
+
+    ConverseRequest.Builder builder = ConverseRequest.builder();
+    captor.getValue().accept(builder);
+
+    // This model is not in our cross-region list, so should remain unchanged
+    assertEquals(originalModelId, builder.build().modelId());
+  }
+
+  private ExtractionRequestData createTestRequestData(String modelId) {
+    ConverseData converseData = new ConverseData(modelId, 512, 0.5f, 0.9f);
+    return new ExtractionRequestData(
+        ExtractionTestUtils.TEXTRACT_EXTRACTION_REQUEST_DATA.document(),
+        ExtractionTestUtils.TEXTRACT_EXTRACTION_REQUEST_DATA.extractionType(),
+        ExtractionTestUtils.TEXTRACT_EXTRACTION_REQUEST_DATA.taxonomyItems(),
+        ExtractionTestUtils.TEXTRACT_EXTRACTION_REQUEST_DATA.includedFields(),
+        ExtractionTestUtils.TEXTRACT_EXTRACTION_REQUEST_DATA.renameMappings(),
+        ExtractionTestUtils.TEXTRACT_EXTRACTION_REQUEST_DATA.delimiter(),
+        converseData);
+  }
+
+  private void setupMockResponse() {
+    when(bedrockRuntimeClient.converse(any(Consumer.class))).thenReturn(converseResponse);
+    when(converseResponse.output().message().content().getFirst().text())
+        .thenReturn("test response");
   }
 }

--- a/connectors/idp-extraction/src/test/java/io/camunda/connector/idp/extraction/service/UnstructuredServiceTest.java
+++ b/connectors/idp-extraction/src/test/java/io/camunda/connector/idp/extraction/service/UnstructuredServiceTest.java
@@ -78,7 +78,7 @@ public class UnstructuredServiceTest {
 
     when(pollingTextractCaller.call(any(), any(), any(), any()))
         .thenReturn("Test extracted text from test document.pdf");
-    when(bedrockCaller.call(any(), any(), any())).thenReturn(expectedResponseJson);
+    when(bedrockCaller.call(any(), any(), any(), any())).thenReturn(expectedResponseJson);
 
     // when
     var result = unstructuredService.extract(request);
@@ -102,7 +102,7 @@ public class UnstructuredServiceTest {
 
     when(pollingTextractCaller.call(any(), any(), any(), any()))
         .thenReturn("Test extracted text from test document.pdf");
-    when(bedrockCaller.call(any(), any(), any())).thenReturn(expectedResponseJson);
+    when(bedrockCaller.call(any(), any(), any(), any())).thenReturn(expectedResponseJson);
 
     // when
     var result = unstructuredService.extract(request);
@@ -119,7 +119,7 @@ public class UnstructuredServiceTest {
 
     when(pollingTextractCaller.call(any(), any(), any(), any()))
         .thenReturn("Test extracted text from test document.pdf");
-    when(bedrockCaller.call(any(), any(), any()))
+    when(bedrockCaller.call(any(), any(), any(), any()))
         .thenReturn(
             """
                    {
@@ -152,7 +152,7 @@ public class UnstructuredServiceTest {
 
     when(pollingTextractCaller.call(any(), any(), any(), any()))
         .thenReturn("Test extracted text from test document.pdf");
-    when(bedrockCaller.call(any(), any(), any()))
+    when(bedrockCaller.call(any(), any(), any(), any()))
         .thenReturn(
             """
                    {
@@ -194,7 +194,7 @@ public class UnstructuredServiceTest {
 
     when(pollingTextractCaller.call(any(), any(), any(), any()))
         .thenReturn("Test extracted text from test document.pdf");
-    when(bedrockCaller.call(any(), any(), any()))
+    when(bedrockCaller.call(any(), any(), any(), any()))
         .thenReturn(
             """
                    {
@@ -238,7 +238,7 @@ public class UnstructuredServiceTest {
 
     when(pollingTextractCaller.call(any(), any(), any(), any()))
         .thenReturn("Test extracted text from test document.pdf");
-    when(bedrockCaller.call(any(), any(), any()))
+    when(bedrockCaller.call(any(), any(), any(), any()))
         .thenReturn(
             """
                    {
@@ -269,7 +269,7 @@ public class UnstructuredServiceTest {
 
     when(pollingTextractCaller.call(any(), any(), any(), any()))
         .thenReturn("Test extracted text from test document.pdf");
-    when(bedrockCaller.call(any(), any(), any()))
+    when(bedrockCaller.call(any(), any(), any(), any()))
         .thenReturn(
             """
                         {
@@ -289,7 +289,7 @@ public class UnstructuredServiceTest {
 
     when(pollingTextractCaller.call(any(), any(), any(), any()))
         .thenReturn("Test extracted text from test document.pdf");
-    when(bedrockCaller.call(any(), any(), any()))
+    when(bedrockCaller.call(any(), any(), any(), any()))
         .thenReturn(
             """
                         []
@@ -310,7 +310,7 @@ public class UnstructuredServiceTest {
 
     when(pollingTextractCaller.call(any(), any(), any(), any()))
         .thenReturn("Test extracted text from test document.pdf");
-    when(bedrockCaller.call(any(), any(), any()))
+    when(bedrockCaller.call(any(), any(), any(), any()))
         .thenReturn(
             """
                         {
@@ -333,7 +333,7 @@ public class UnstructuredServiceTest {
 
     when(pollingTextractCaller.call(any(), any(), any(), any()))
         .thenReturn("Test extracted text from test document.pdf");
-    when(bedrockCaller.call(any(), any(), any()))
+    when(bedrockCaller.call(any(), any(), any(), any()))
         .thenReturn(
             """
                         {


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

This PR implements automatic handling of AWS Bedrock model IDs for cross-region inference, addressing the requirement to add proper regional prefixes for models that are only available through cross-region inference profiles.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes https://github.com/camunda/connectors/issues/4820

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.

