### PR TITLE
test(agentic-ai): fix e2e tests breaking due to renamed CPT variable method

### DIFF
--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/AdHocToolsSchemaTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/AdHocToolsSchemaTests.java
@@ -56,7 +56,7 @@ public class AdHocToolsSchemaTests extends BaseAgenticAiTest {
 
   private Variable getResolvedSchemaVariable(ZeebeTest zeebeTest) {
     return new CamundaDataSource(camundaClient)
-            .findVariablesByProcessInstanceKey(
+            .findGlobalVariablesByProcessInstanceKey(
                 zeebeTest.getProcessInstanceEvent().getProcessInstanceKey())
             .stream()
             .filter(variable -> variable.getName().equals("resolvedSchema"))

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/Langchain4JAiAgentTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/Langchain4JAiAgentTests.java
@@ -824,7 +824,7 @@ public class Langchain4JAiAgentTests extends BaseAgenticAiTest {
   private AgentResponse getAgentResponse(ZeebeTest zeebeTest) throws JsonProcessingException {
     final var agentVariableSearchResult =
         new CamundaDataSource(camundaClient)
-                .findVariablesByProcessInstanceKey(
+                .findGlobalVariablesByProcessInstanceKey(
                     zeebeTest.getProcessInstanceEvent().getProcessInstanceKey())
                 .stream()
                 .filter(variable -> variable.getName().equals("agent"))


### PR DESCRIPTION
Fixes e2e tests breaking du to renamed CPT method.

