### PR TITLE
refactor(agentic-ai): implement JSON schema de(-serializing) as Jackson de(-serializer)

### DIFF
--- a/connectors/agentic-ai/pom.xml
+++ b/connectors/agentic-ai/pom.xml
@@ -18,7 +18,6 @@
   <packaging>jar</packaging>
 
   <properties>
-    <version.json-schema-validator>1.5.7</version.json-schema-validator>
     <version.record-builder>47</version.record-builder>
   </properties>
 
@@ -67,22 +66,6 @@
     <dependency>
       <groupId>dev.langchain4j</groupId>
       <artifactId>langchain4j-open-ai</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>com.networknt</groupId>
-      <artifactId>json-schema-validator</artifactId>
-      <version>${version.json-schema-validator}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>com.fasterxml.jackson.dataformat</groupId>
-          <artifactId>jackson-dataformat-yaml</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>com.ethlo.time</groupId>
-          <artifactId>itu</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
 
     <dependency>

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/JsonSchemaConstants.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/JsonSchemaConstants.java
@@ -24,4 +24,6 @@ public abstract class JsonSchemaConstants {
   public static final String PROPERTY_ENUM = "enum";
   public static final String PROPERTY_ANYOF = "anyOf";
   public static final String PROPERTY_ITEMS = "items";
+  public static final String PROPERTY_DEFINITIONS = "$defs";
+  public static final String PROPERTY_REF = "$ref";
 }

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/JsonSchemaConstants.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/JsonSchemaConstants.java
@@ -22,5 +22,6 @@ public abstract class JsonSchemaConstants {
   public static final String PROPERTY_ADDITIONAL_PROPERTIES = "additionalProperties";
   public static final String PROPERTY_PROPERTIES = "properties";
   public static final String PROPERTY_ENUM = "enum";
+  public static final String PROPERTY_ANYOF = "anyOf";
   public static final String PROPERTY_ITEMS = "items";
 }

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/Langchain4JAiFrameworkAdapter.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/Langchain4JAiFrameworkAdapter.java
@@ -39,7 +39,8 @@ public class Langchain4JAiFrameworkAdapter
       AgentRequest request, AgentContext agentContext, RuntimeMemory runtimeMemory) {
 
     final var messages = chatMessageConverter.map(runtimeMemory.filteredMessages());
-    final var toolSpecifications = toolSpecificationConverter.map(agentContext.toolDefinitions());
+    final var toolSpecifications =
+        toolSpecificationConverter.asToolSpecifications(agentContext.toolDefinitions());
 
     final var chatRequest =
         ChatRequest.builder().messages(messages).toolSpecifications(toolSpecifications).build();

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/configuration/AgenticAiLangchain4JFrameworkConfiguration.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/configuration/AgenticAiLangchain4JFrameworkConfiguration.java
@@ -51,8 +51,9 @@ public class AgenticAiLangchain4JFrameworkConfiguration {
 
   @Bean
   @ConditionalOnMissingBean
-  public ToolSpecificationConverter langchain4JToolSpecificationConverter() {
-    return new ToolSpecificationConverterImpl();
+  public ToolSpecificationConverter langchain4JToolSpecificationConverter(
+      ObjectMapper objectMapper) {
+    return new ToolSpecificationConverterImpl(objectMapper);
   }
 
   @Bean

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/jsonschema/JsonSchemaElementDeserializer.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/jsonschema/JsonSchemaElementDeserializer.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.agenticai.aiagent.framework.langchain4j.jsonschema;
+
+import static io.camunda.connector.agenticai.JsonSchemaConstants.PROPERTY_ADDITIONAL_PROPERTIES;
+import static io.camunda.connector.agenticai.JsonSchemaConstants.PROPERTY_ANYOF;
+import static io.camunda.connector.agenticai.JsonSchemaConstants.PROPERTY_DESCRIPTION;
+import static io.camunda.connector.agenticai.JsonSchemaConstants.PROPERTY_ENUM;
+import static io.camunda.connector.agenticai.JsonSchemaConstants.PROPERTY_ITEMS;
+import static io.camunda.connector.agenticai.JsonSchemaConstants.PROPERTY_PROPERTIES;
+import static io.camunda.connector.agenticai.JsonSchemaConstants.PROPERTY_REQUIRED;
+import static io.camunda.connector.agenticai.JsonSchemaConstants.PROPERTY_TYPE;
+import static io.camunda.connector.agenticai.JsonSchemaConstants.TYPE_ARRAY;
+import static io.camunda.connector.agenticai.JsonSchemaConstants.TYPE_BOOLEAN;
+import static io.camunda.connector.agenticai.JsonSchemaConstants.TYPE_INTEGER;
+import static io.camunda.connector.agenticai.JsonSchemaConstants.TYPE_NUMBER;
+import static io.camunda.connector.agenticai.JsonSchemaConstants.TYPE_OBJECT;
+import static io.camunda.connector.agenticai.JsonSchemaConstants.TYPE_STRING;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import dev.langchain4j.model.chat.request.json.JsonAnyOfSchema;
+import dev.langchain4j.model.chat.request.json.JsonArraySchema;
+import dev.langchain4j.model.chat.request.json.JsonBooleanSchema;
+import dev.langchain4j.model.chat.request.json.JsonEnumSchema;
+import dev.langchain4j.model.chat.request.json.JsonIntegerSchema;
+import dev.langchain4j.model.chat.request.json.JsonNumberSchema;
+import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
+import dev.langchain4j.model.chat.request.json.JsonSchemaElement;
+import dev.langchain4j.model.chat.request.json.JsonStringSchema;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+public class JsonSchemaElementDeserializer extends JsonDeserializer<JsonSchemaElement> {
+
+  @Override
+  public JsonSchemaElement deserialize(JsonParser jp, DeserializationContext ctxt)
+      throws IOException {
+    ObjectMapper objectMapper = (ObjectMapper) jp.getCodec();
+    JsonNode node = objectMapper.readTree(jp);
+
+    if (node.has(PROPERTY_ENUM)) {
+      return createEnumSchema(node);
+    }
+
+    if (node.has(PROPERTY_ANYOF)) {
+      return createAnyOfSchema(node, objectMapper);
+    }
+
+    String nodeType = node.has(PROPERTY_TYPE) ? node.get(PROPERTY_TYPE).asText() : TYPE_OBJECT;
+
+    return switch (nodeType) {
+      case TYPE_OBJECT -> createObjectSchema(node, objectMapper);
+      case TYPE_STRING -> createStringSchema(node);
+      case TYPE_NUMBER -> createNumberSchema(node);
+      case TYPE_INTEGER -> createIntegerSchema(node);
+      case TYPE_BOOLEAN -> createBooleanSchema(node);
+      case TYPE_ARRAY -> createArraySchema(node, objectMapper);
+      default -> throw new IllegalArgumentException("Unknown element type: " + nodeType);
+    };
+  }
+
+  private JsonObjectSchema createObjectSchema(JsonNode node, ObjectMapper objectMapper)
+      throws JsonProcessingException {
+    JsonObjectSchema.Builder builder = JsonObjectSchema.builder();
+    if (node.has(PROPERTY_DESCRIPTION)) {
+      builder.description(node.get(PROPERTY_DESCRIPTION).asText());
+    }
+
+    if (node.has(PROPERTY_PROPERTIES)) {
+      ObjectNode propertiesNode = (ObjectNode) node.get(PROPERTY_PROPERTIES);
+      for (Map.Entry<String, JsonNode> property : propertiesNode.properties()) {
+        builder.addProperty(
+            property.getKey(),
+            objectMapper.treeToValue(property.getValue(), JsonSchemaElement.class));
+      }
+    }
+
+    if (node.has(PROPERTY_REQUIRED)) {
+      builder.required(toStringArray((ArrayNode) node.get(PROPERTY_REQUIRED)));
+    }
+
+    if (node.has(PROPERTY_ADDITIONAL_PROPERTIES)) {
+      builder.additionalProperties(node.get(PROPERTY_ADDITIONAL_PROPERTIES).asBoolean(false));
+    }
+
+    return builder.build();
+  }
+
+  private JsonEnumSchema createEnumSchema(JsonNode node) {
+    JsonEnumSchema.Builder builder = JsonEnumSchema.builder();
+    if (node.has(PROPERTY_DESCRIPTION)) {
+      builder.description(node.get(PROPERTY_DESCRIPTION).asText());
+    }
+
+    builder.enumValues(toStringArray((ArrayNode) node.get(PROPERTY_ENUM)));
+
+    return builder.build();
+  }
+
+  private JsonStringSchema createStringSchema(JsonNode node) {
+    JsonStringSchema.Builder builder = JsonStringSchema.builder();
+    if (node.has(PROPERTY_DESCRIPTION)) {
+      builder.description(node.get(PROPERTY_DESCRIPTION).asText());
+    }
+
+    return builder.build();
+  }
+
+  private JsonNumberSchema createNumberSchema(JsonNode node) {
+    JsonNumberSchema.Builder builder = JsonNumberSchema.builder();
+    if (node.has(PROPERTY_DESCRIPTION)) {
+      builder.description(node.get(PROPERTY_DESCRIPTION).asText());
+    }
+
+    return builder.build();
+  }
+
+  private JsonIntegerSchema createIntegerSchema(JsonNode node) {
+    JsonIntegerSchema.Builder builder = JsonIntegerSchema.builder();
+    if (node.has(PROPERTY_DESCRIPTION)) {
+      builder.description(node.get(PROPERTY_DESCRIPTION).asText());
+    }
+
+    return builder.build();
+  }
+
+  private JsonBooleanSchema createBooleanSchema(JsonNode node) {
+    JsonBooleanSchema.Builder builder = JsonBooleanSchema.builder();
+    if (node.has(PROPERTY_DESCRIPTION)) {
+      builder.description(node.get(PROPERTY_DESCRIPTION).asText());
+    }
+
+    return builder.build();
+  }
+
+  private JsonArraySchema createArraySchema(JsonNode node, ObjectMapper objectMapper)
+      throws JsonProcessingException {
+    JsonArraySchema.Builder builder = JsonArraySchema.builder();
+    if (node.has(PROPERTY_DESCRIPTION)) {
+      builder.description(node.get(PROPERTY_DESCRIPTION).asText());
+    }
+
+    if (node.has(PROPERTY_ITEMS)) {
+      builder.items(objectMapper.treeToValue(node.get(PROPERTY_ITEMS), JsonSchemaElement.class));
+    }
+
+    return builder.build();
+  }
+
+  private JsonAnyOfSchema createAnyOfSchema(JsonNode node, ObjectMapper objectMapper)
+      throws JsonProcessingException {
+    JsonAnyOfSchema.Builder builder = JsonAnyOfSchema.builder();
+    if (node.has(PROPERTY_DESCRIPTION)) {
+      builder.description(node.get(PROPERTY_DESCRIPTION).asText());
+    }
+
+    if (node.has(PROPERTY_ANYOF)) {
+      ArrayNode itemsArray = (ArrayNode) node.get(PROPERTY_ANYOF);
+
+      List<JsonSchemaElement> items = new ArrayList<>();
+      for (JsonNode item : itemsArray) {
+        items.add(objectMapper.treeToValue(item, JsonSchemaElement.class));
+      }
+
+      builder.anyOf(items);
+    }
+
+    return builder.build();
+  }
+
+  private String[] toStringArray(ArrayNode jsonArray) {
+    String[] result = new String[jsonArray.size()];
+
+    for (int i = 0; i < jsonArray.size(); ++i) {
+      result[i] = jsonArray.get(i).asText();
+    }
+
+    return result;
+  }
+}

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/jsonschema/JsonSchemaElementModule.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/jsonschema/JsonSchemaElementModule.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.agenticai.aiagent.framework.langchain4j.jsonschema;
+
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import dev.langchain4j.model.chat.request.json.JsonSchemaElement;
+
+public class JsonSchemaElementModule extends SimpleModule {
+
+  public JsonSchemaElementModule() {
+    super("JsonSchemaElementModule");
+  }
+
+  @Override
+  public void setupModule(SetupContext context) {
+    addSerializer(JsonSchemaElement.class, new JsonSchemaElementSerializer());
+    addDeserializer(JsonSchemaElement.class, new JsonSchemaElementDeserializer());
+    super.setupModule(context);
+  }
+}

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/jsonschema/JsonSchemaElementSerializer.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/jsonschema/JsonSchemaElementSerializer.java
@@ -8,10 +8,12 @@ package io.camunda.connector.agenticai.aiagent.framework.langchain4j.jsonschema;
 
 import static io.camunda.connector.agenticai.JsonSchemaConstants.PROPERTY_ADDITIONAL_PROPERTIES;
 import static io.camunda.connector.agenticai.JsonSchemaConstants.PROPERTY_ANYOF;
+import static io.camunda.connector.agenticai.JsonSchemaConstants.PROPERTY_DEFINITIONS;
 import static io.camunda.connector.agenticai.JsonSchemaConstants.PROPERTY_DESCRIPTION;
 import static io.camunda.connector.agenticai.JsonSchemaConstants.PROPERTY_ENUM;
 import static io.camunda.connector.agenticai.JsonSchemaConstants.PROPERTY_ITEMS;
 import static io.camunda.connector.agenticai.JsonSchemaConstants.PROPERTY_PROPERTIES;
+import static io.camunda.connector.agenticai.JsonSchemaConstants.PROPERTY_REF;
 import static io.camunda.connector.agenticai.JsonSchemaConstants.PROPERTY_REQUIRED;
 import static io.camunda.connector.agenticai.JsonSchemaConstants.PROPERTY_TYPE;
 import static io.camunda.connector.agenticai.JsonSchemaConstants.TYPE_ARRAY;
@@ -31,6 +33,7 @@ import dev.langchain4j.model.chat.request.json.JsonEnumSchema;
 import dev.langchain4j.model.chat.request.json.JsonIntegerSchema;
 import dev.langchain4j.model.chat.request.json.JsonNumberSchema;
 import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
+import dev.langchain4j.model.chat.request.json.JsonReferenceSchema;
 import dev.langchain4j.model.chat.request.json.JsonSchemaElement;
 import dev.langchain4j.model.chat.request.json.JsonStringSchema;
 import java.io.IOException;
@@ -49,10 +52,12 @@ public class JsonSchemaElementSerializer extends JsonSerializer<JsonSchemaElemen
       case JsonNumberSchema numberSchema -> serializeNumberSchema(numberSchema, gen);
       case JsonIntegerSchema integerSchema -> serializeIntegerSchema(integerSchema, gen);
       case JsonBooleanSchema booleanSchema -> serializeBooleanSchema(booleanSchema, gen);
+      case JsonReferenceSchema referenceSchema -> serializeReferenceSchema(referenceSchema, gen);
       case JsonArraySchema arraySchema -> serializeArraySchema(arraySchema, gen);
       case JsonAnyOfSchema anyOfSchema -> serializeAnyOfSchema(anyOfSchema, gen);
       default ->
-          throw new IllegalArgumentException("Unknown schema type: " + value.getClass().getName());
+          throw new IllegalArgumentException(
+              "Unsupported schema type: " + value.getClass().getName());
     }
   }
 
@@ -67,6 +72,7 @@ public class JsonSchemaElementSerializer extends JsonSerializer<JsonSchemaElemen
     }
 
     serializeMapOfSchemaElements(PROPERTY_PROPERTIES, schema.properties(), gen);
+    serializeMapOfSchemaElements(PROPERTY_DEFINITIONS, schema.definitions(), gen);
 
     List<String> required = schema.required();
     if (required != null && !required.isEmpty()) {
@@ -156,6 +162,19 @@ public class JsonSchemaElementSerializer extends JsonSerializer<JsonSchemaElemen
     gen.writeStartObject();
 
     gen.writeStringField(PROPERTY_TYPE, TYPE_BOOLEAN);
+
+    if (schema.description() != null) {
+      gen.writeStringField(PROPERTY_DESCRIPTION, schema.description());
+    }
+
+    gen.writeEndObject();
+  }
+
+  private void serializeReferenceSchema(JsonReferenceSchema schema, JsonGenerator gen)
+      throws IOException {
+    gen.writeStartObject();
+
+    gen.writeStringField(PROPERTY_REF, schema.reference());
 
     if (schema.description() != null) {
       gen.writeStringField(PROPERTY_DESCRIPTION, schema.description());

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/jsonschema/JsonSchemaElementSerializer.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/jsonschema/JsonSchemaElementSerializer.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.agenticai.aiagent.framework.langchain4j.jsonschema;
+
+import static io.camunda.connector.agenticai.JsonSchemaConstants.PROPERTY_ADDITIONAL_PROPERTIES;
+import static io.camunda.connector.agenticai.JsonSchemaConstants.PROPERTY_ANYOF;
+import static io.camunda.connector.agenticai.JsonSchemaConstants.PROPERTY_DESCRIPTION;
+import static io.camunda.connector.agenticai.JsonSchemaConstants.PROPERTY_ENUM;
+import static io.camunda.connector.agenticai.JsonSchemaConstants.PROPERTY_ITEMS;
+import static io.camunda.connector.agenticai.JsonSchemaConstants.PROPERTY_PROPERTIES;
+import static io.camunda.connector.agenticai.JsonSchemaConstants.PROPERTY_REQUIRED;
+import static io.camunda.connector.agenticai.JsonSchemaConstants.PROPERTY_TYPE;
+import static io.camunda.connector.agenticai.JsonSchemaConstants.TYPE_ARRAY;
+import static io.camunda.connector.agenticai.JsonSchemaConstants.TYPE_BOOLEAN;
+import static io.camunda.connector.agenticai.JsonSchemaConstants.TYPE_INTEGER;
+import static io.camunda.connector.agenticai.JsonSchemaConstants.TYPE_NUMBER;
+import static io.camunda.connector.agenticai.JsonSchemaConstants.TYPE_OBJECT;
+import static io.camunda.connector.agenticai.JsonSchemaConstants.TYPE_STRING;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import dev.langchain4j.model.chat.request.json.JsonAnyOfSchema;
+import dev.langchain4j.model.chat.request.json.JsonArraySchema;
+import dev.langchain4j.model.chat.request.json.JsonBooleanSchema;
+import dev.langchain4j.model.chat.request.json.JsonEnumSchema;
+import dev.langchain4j.model.chat.request.json.JsonIntegerSchema;
+import dev.langchain4j.model.chat.request.json.JsonNumberSchema;
+import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
+import dev.langchain4j.model.chat.request.json.JsonSchemaElement;
+import dev.langchain4j.model.chat.request.json.JsonStringSchema;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+public class JsonSchemaElementSerializer extends JsonSerializer<JsonSchemaElement> {
+
+  @Override
+  public void serialize(JsonSchemaElement value, JsonGenerator gen, SerializerProvider serializers)
+      throws IOException {
+    switch (value) {
+      case JsonObjectSchema objectSchema -> serializeObjectSchema(objectSchema, gen);
+      case JsonEnumSchema enumSchema -> serializeEnumSchema(enumSchema, gen);
+      case JsonStringSchema stringSchema -> serializeStringSchema(stringSchema, gen);
+      case JsonNumberSchema numberSchema -> serializeNumberSchema(numberSchema, gen);
+      case JsonIntegerSchema integerSchema -> serializeIntegerSchema(integerSchema, gen);
+      case JsonBooleanSchema booleanSchema -> serializeBooleanSchema(booleanSchema, gen);
+      case JsonArraySchema arraySchema -> serializeArraySchema(arraySchema, gen);
+      case JsonAnyOfSchema anyOfSchema -> serializeAnyOfSchema(anyOfSchema, gen);
+      default ->
+          throw new IllegalArgumentException("Unknown schema type: " + value.getClass().getName());
+    }
+  }
+
+  private void serializeObjectSchema(JsonObjectSchema schema, JsonGenerator gen)
+      throws IOException {
+    gen.writeStartObject();
+
+    gen.writeStringField(PROPERTY_TYPE, TYPE_OBJECT);
+
+    if (schema.description() != null) {
+      gen.writeStringField(PROPERTY_DESCRIPTION, schema.description());
+    }
+
+    serializeMapOfSchemaElements(PROPERTY_PROPERTIES, schema.properties(), gen);
+
+    List<String> required = schema.required();
+    if (required != null && !required.isEmpty()) {
+      gen.writeArrayFieldStart(PROPERTY_REQUIRED);
+      for (String req : required) {
+        gen.writeString(req);
+      }
+      gen.writeEndArray();
+    }
+
+    if (schema.additionalProperties() != null) {
+      gen.writeBooleanField(PROPERTY_ADDITIONAL_PROPERTIES, schema.additionalProperties());
+    }
+
+    gen.writeEndObject();
+  }
+
+  private void serializeMapOfSchemaElements(
+      String fieldName, Map<String, JsonSchemaElement> elements, JsonGenerator gen)
+      throws IOException {
+    if (elements != null && !elements.isEmpty()) {
+      gen.writeObjectFieldStart(fieldName);
+      for (Map.Entry<String, JsonSchemaElement> entry : elements.entrySet()) {
+        gen.writeObjectField(entry.getKey(), entry.getValue());
+      }
+      gen.writeEndObject();
+    }
+  }
+
+  private void serializeEnumSchema(JsonEnumSchema schema, JsonGenerator gen) throws IOException {
+    gen.writeStartObject();
+
+    if (schema.description() != null) {
+      gen.writeStringField(PROPERTY_DESCRIPTION, schema.description());
+    }
+
+    gen.writeArrayFieldStart(PROPERTY_ENUM);
+    for (String value : schema.enumValues()) {
+      gen.writeString(value);
+    }
+    gen.writeEndArray();
+
+    gen.writeEndObject();
+  }
+
+  private void serializeStringSchema(JsonStringSchema schema, JsonGenerator gen)
+      throws IOException {
+    gen.writeStartObject();
+
+    gen.writeStringField(PROPERTY_TYPE, TYPE_STRING);
+
+    if (schema.description() != null) {
+      gen.writeStringField(PROPERTY_DESCRIPTION, schema.description());
+    }
+
+    gen.writeEndObject();
+  }
+
+  private void serializeNumberSchema(JsonNumberSchema schema, JsonGenerator gen)
+      throws IOException {
+    gen.writeStartObject();
+
+    gen.writeStringField(PROPERTY_TYPE, TYPE_NUMBER);
+
+    if (schema.description() != null) {
+      gen.writeStringField(PROPERTY_DESCRIPTION, schema.description());
+    }
+
+    gen.writeEndObject();
+  }
+
+  private void serializeIntegerSchema(JsonIntegerSchema schema, JsonGenerator gen)
+      throws IOException {
+    gen.writeStartObject();
+
+    gen.writeStringField(PROPERTY_TYPE, TYPE_INTEGER);
+
+    if (schema.description() != null) {
+      gen.writeStringField(PROPERTY_DESCRIPTION, schema.description());
+    }
+
+    gen.writeEndObject();
+  }
+
+  private void serializeBooleanSchema(JsonBooleanSchema schema, JsonGenerator gen)
+      throws IOException {
+    gen.writeStartObject();
+
+    gen.writeStringField(PROPERTY_TYPE, TYPE_BOOLEAN);
+
+    if (schema.description() != null) {
+      gen.writeStringField(PROPERTY_DESCRIPTION, schema.description());
+    }
+
+    gen.writeEndObject();
+  }
+
+  private void serializeArraySchema(JsonArraySchema schema, JsonGenerator gen) throws IOException {
+    gen.writeStartObject();
+
+    gen.writeStringField(PROPERTY_TYPE, TYPE_ARRAY);
+
+    if (schema.description() != null) {
+      gen.writeStringField(PROPERTY_DESCRIPTION, schema.description());
+    }
+
+    if (schema.items() != null) {
+      gen.writeObjectField(PROPERTY_ITEMS, schema.items());
+    }
+
+    gen.writeEndObject();
+  }
+
+  private void serializeAnyOfSchema(JsonAnyOfSchema schema, JsonGenerator gen) throws IOException {
+    gen.writeStartObject();
+
+    if (schema.description() != null) {
+      gen.writeStringField(PROPERTY_DESCRIPTION, schema.description());
+    }
+
+    gen.writeArrayFieldStart(PROPERTY_ANYOF);
+    for (JsonSchemaElement item : schema.anyOf()) {
+      gen.writeObject(item);
+    }
+    gen.writeEndArray();
+
+    gen.writeEndObject();
+  }
+}

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/tool/ToolSpecificationConverter.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/tool/ToolSpecificationConverter.java
@@ -11,9 +11,15 @@ import io.camunda.connector.agenticai.model.tool.ToolDefinition;
 import java.util.List;
 
 public interface ToolSpecificationConverter {
-  default List<ToolSpecification> map(List<ToolDefinition> toolDefinitions) {
+  default List<ToolSpecification> asToolSpecifications(List<ToolDefinition> toolDefinitions) {
     return toolDefinitions.stream().map(this::asToolSpecification).toList();
   }
 
   ToolSpecification asToolSpecification(ToolDefinition toolDefinition);
+
+  default List<ToolDefinition> asToolDefinitions(List<ToolSpecification> toolSpecifications) {
+    return toolSpecifications.stream().map(this::asToolDefinition).toList();
+  }
+
+  ToolDefinition asToolDefinition(ToolSpecification toolSpecification);
 }

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/tool/ToolSpecificationConverterImpl.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/tool/ToolSpecificationConverterImpl.java
@@ -6,185 +6,51 @@
  */
 package io.camunda.connector.agenticai.aiagent.framework.langchain4j.tool;
 
-import static io.camunda.connector.agenticai.JsonSchemaConstants.PROPERTY_ADDITIONAL_PROPERTIES;
-import static io.camunda.connector.agenticai.JsonSchemaConstants.PROPERTY_DESCRIPTION;
-import static io.camunda.connector.agenticai.JsonSchemaConstants.PROPERTY_ENUM;
-import static io.camunda.connector.agenticai.JsonSchemaConstants.PROPERTY_ITEMS;
-import static io.camunda.connector.agenticai.JsonSchemaConstants.PROPERTY_PROPERTIES;
-import static io.camunda.connector.agenticai.JsonSchemaConstants.PROPERTY_REQUIRED;
-import static io.camunda.connector.agenticai.JsonSchemaConstants.PROPERTY_TYPE;
-import static io.camunda.connector.agenticai.JsonSchemaConstants.TYPE_ARRAY;
-import static io.camunda.connector.agenticai.JsonSchemaConstants.TYPE_BOOLEAN;
-import static io.camunda.connector.agenticai.JsonSchemaConstants.TYPE_INTEGER;
-import static io.camunda.connector.agenticai.JsonSchemaConstants.TYPE_NUMBER;
-import static io.camunda.connector.agenticai.JsonSchemaConstants.TYPE_OBJECT;
-import static io.camunda.connector.agenticai.JsonSchemaConstants.TYPE_STRING;
-import static io.camunda.connector.agenticai.util.JacksonExceptionMessageExtractor.humanReadableJsonProcessingExceptionMessage;
-
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.networknt.schema.JsonSchema;
-import com.networknt.schema.JsonSchemaFactory;
-import com.networknt.schema.SpecVersion.VersionFlag;
-import com.networknt.schema.serialization.JsonMapperFactory;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import dev.langchain4j.agent.tool.ToolSpecification;
-import dev.langchain4j.model.chat.request.json.JsonArraySchema;
-import dev.langchain4j.model.chat.request.json.JsonBooleanSchema;
-import dev.langchain4j.model.chat.request.json.JsonEnumSchema;
-import dev.langchain4j.model.chat.request.json.JsonIntegerSchema;
-import dev.langchain4j.model.chat.request.json.JsonNumberSchema;
 import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
 import dev.langchain4j.model.chat.request.json.JsonSchemaElement;
-import dev.langchain4j.model.chat.request.json.JsonStringSchema;
+import io.camunda.connector.agenticai.aiagent.framework.langchain4j.jsonschema.JsonSchemaElementModule;
 import io.camunda.connector.agenticai.model.tool.ToolDefinition;
-import java.util.Map;
 
 /**
- * Validates and converts a json schema to a tool specification. Conversion logic is based on
+ * Validates and converts a JSON schema to a tool specification. Conversion logic is based on
  * dev.langchain4j.mcp.client.ToolSpecificationHelper.
  */
 public class ToolSpecificationConverterImpl implements ToolSpecificationConverter {
 
-  private final JsonSchemaFactory jsonSchemaFactory;
+  private final ObjectMapper objectMapper;
 
-  public ToolSpecificationConverterImpl() {
-    this(JsonSchemaFactory.getInstance(VersionFlag.V202012));
+  public ToolSpecificationConverterImpl(ObjectMapper objectMapper) {
+    this.objectMapper = configuredObjectMapperCopy(objectMapper);
   }
 
-  public ToolSpecificationConverterImpl(JsonSchemaFactory jsonSchemaFactory) {
-    this.jsonSchemaFactory = jsonSchemaFactory;
+  private ObjectMapper configuredObjectMapperCopy(ObjectMapper objectMapper) {
+    return objectMapper.copy().registerModule(new JsonSchemaElementModule());
   }
 
   @Override
   public ToolSpecification asToolSpecification(ToolDefinition toolDefinition) {
-    JsonNode schemaNode = JsonMapperFactory.getInstance().valueToTree(toolDefinition.inputSchema());
-    final var inputSchema = convertToJsonObjectSchema(schemaNode);
+    final var jsonSchema = parseSchema(toolDefinition);
+    if (!(jsonSchema instanceof JsonObjectSchema jsonObjectSchema)) {
+      throw new ParseSchemaException(
+          "Failed to parse input schema for tool '%s'. Input schema must be of type object."
+              .formatted(toolDefinition.name()));
+    }
 
     return ToolSpecification.builder()
         .name(toolDefinition.name())
         .description(toolDefinition.description())
-        .parameters(inputSchema)
+        .parameters(jsonObjectSchema)
         .build();
   }
 
-  private JsonObjectSchema convertToJsonObjectSchema(JsonNode schemaNode) {
-    if (!schemaNode.has(PROPERTY_TYPE)
-        || !TYPE_OBJECT.equals(schemaNode.get(PROPERTY_TYPE).textValue())) {
-      throw new ParseSchemaException(
-          "Failed to read input schema. Root input schema must be type object.");
-    }
-
-    return (JsonObjectSchema) jsonNodeToJsonSchemaElement(schemaNode);
-  }
-
-  private JsonSchemaElement jsonNodeToJsonSchemaElement(JsonNode node) {
-    String nodeType = node.get(PROPERTY_TYPE).asText();
-    switch (nodeType) {
-      case TYPE_OBJECT -> {
-        JsonObjectSchema.Builder builder = JsonObjectSchema.builder();
-        JsonNode required = node.get(PROPERTY_REQUIRED);
-        if (required != null) {
-          builder.required(toStringArray((ArrayNode) required));
-        }
-
-        if (node.has(PROPERTY_ADDITIONAL_PROPERTIES)) {
-          builder.additionalProperties(node.get(PROPERTY_ADDITIONAL_PROPERTIES).asBoolean(false));
-        }
-
-        JsonNode description = node.get(PROPERTY_DESCRIPTION);
-        if (description != null) {
-          builder.description(description.asText());
-        }
-
-        JsonNode properties = node.get(PROPERTY_PROPERTIES);
-        if (properties != null) {
-          ObjectNode propertiesObject = (ObjectNode) properties;
-
-          for (Map.Entry<String, JsonNode> property : propertiesObject.properties()) {
-            builder.addProperty(
-                property.getKey(), jsonNodeToJsonSchemaElement(property.getValue()));
-          }
-        }
-
-        return builder.build();
-      }
-      case TYPE_STRING -> {
-        if (node.has(PROPERTY_ENUM)) {
-          JsonEnumSchema.Builder builder = JsonEnumSchema.builder();
-          if (node.has(PROPERTY_DESCRIPTION)) {
-            builder.description(node.get(PROPERTY_DESCRIPTION).asText());
-          }
-
-          builder.enumValues(toStringArray((ArrayNode) node.get(PROPERTY_ENUM)));
-          return builder.build();
-        } else {
-          JsonStringSchema.Builder builder = JsonStringSchema.builder();
-          if (node.has(PROPERTY_DESCRIPTION)) {
-            builder.description(node.get(PROPERTY_DESCRIPTION).asText());
-          }
-
-          return builder.build();
-        }
-      }
-      case TYPE_NUMBER -> {
-        JsonNumberSchema.Builder builder = JsonNumberSchema.builder();
-        if (node.has(PROPERTY_DESCRIPTION)) {
-          builder.description(node.get(PROPERTY_DESCRIPTION).asText());
-        }
-
-        return builder.build();
-      }
-      case TYPE_INTEGER -> {
-        JsonIntegerSchema.Builder builder = JsonIntegerSchema.builder();
-        if (node.has(PROPERTY_DESCRIPTION)) {
-          builder.description(node.get(PROPERTY_DESCRIPTION).asText());
-        }
-
-        return builder.build();
-      }
-      case TYPE_BOOLEAN -> {
-        JsonBooleanSchema.Builder builder = JsonBooleanSchema.builder();
-        if (node.has(PROPERTY_DESCRIPTION)) {
-          builder.description(node.get(PROPERTY_DESCRIPTION).asText());
-        }
-
-        return builder.build();
-      }
-      case TYPE_ARRAY -> {
-        JsonArraySchema.Builder builder = JsonArraySchema.builder();
-        if (node.has(PROPERTY_DESCRIPTION)) {
-          builder.description(node.get(PROPERTY_DESCRIPTION).asText());
-        }
-
-        builder.items(jsonNodeToJsonSchemaElement(node.get(PROPERTY_ITEMS)));
-        return builder.build();
-      }
-      default -> throw new IllegalArgumentException("Unknown element type: " + nodeType);
-    }
-  }
-
-  private static String[] toStringArray(ArrayNode jsonArray) {
-    String[] result = new String[jsonArray.size()];
-
-    for (int i = 0; i < jsonArray.size(); ++i) {
-      result[i] = jsonArray.get(i).asText();
-    }
-
-    return result;
-  }
-
-  private JsonSchema loadSchema(String inputSchemaJson) {
+  private JsonSchemaElement parseSchema(ToolDefinition toolDefinition) {
     try {
-      return jsonSchemaFactory.getSchema(inputSchemaJson);
+      return objectMapper.convertValue(toolDefinition.inputSchema(), JsonSchemaElement.class);
     } catch (Exception e) {
-      if (e.getCause() instanceof com.fasterxml.jackson.core.JsonParseException jpe) {
-        String sb =
-            "Failed to read input schema. " + humanReadableJsonProcessingExceptionMessage(jpe);
-        throw new ParseSchemaException(sb, e);
-      }
-
-      throw new ParseSchemaException("Failed to read input schema.", e);
+      throw new ParseSchemaException(
+          "Failed to parse input schema for tool '%s'".formatted(toolDefinition.name()), e);
     }
   }
 

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/tool/ToolSpecificationConverterImpl.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/tool/ToolSpecificationConverterImpl.java
@@ -12,6 +12,8 @@ import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
 import dev.langchain4j.model.chat.request.json.JsonSchemaElement;
 import io.camunda.connector.agenticai.aiagent.framework.langchain4j.jsonschema.JsonSchemaElementModule;
 import io.camunda.connector.agenticai.model.tool.ToolDefinition;
+import io.camunda.connector.agenticai.util.ObjectMapperConstants;
+import java.util.Map;
 
 /**
  * Validates and converts a JSON schema to a tool specification. Conversion logic is based on
@@ -51,6 +53,27 @@ public class ToolSpecificationConverterImpl implements ToolSpecificationConverte
     } catch (Exception e) {
       throw new ParseSchemaException(
           "Failed to parse input schema for tool '%s'".formatted(toolDefinition.name()), e);
+    }
+  }
+
+  @Override
+  public ToolDefinition asToolDefinition(ToolSpecification toolSpecification) {
+    return ToolDefinition.builder()
+        .name(toolSpecification.name())
+        .description(toolSpecification.description())
+        .inputSchema(schemaToMap(toolSpecification))
+        .build();
+  }
+
+  private Map<String, Object> schemaToMap(ToolSpecification toolSpecification) {
+    try {
+      return objectMapper.convertValue(
+          toolSpecification.parameters(), ObjectMapperConstants.STRING_OBJECT_MAP_TYPE_REFERENCE);
+    } catch (Exception e) {
+      throw new ParseSchemaException(
+          "Failed to convert JSON schema for tool specification '%s'"
+              .formatted(toolSpecification.name()),
+          e);
     }
   }
 

--- a/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/jsonschema/JsonSchemaElementModuleTest.java
+++ b/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/jsonschema/JsonSchemaElementModuleTest.java
@@ -551,7 +551,7 @@ class JsonSchemaElementModuleTest {
         .satisfies(schemaAssertions);
   }
 
-  private class JsonTestSchema implements JsonSchemaElement {
+  private static class JsonTestSchema implements JsonSchemaElement {
     @Override
     public String description() {
       return "test";

--- a/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/jsonschema/JsonSchemaElementModuleTest.java
+++ b/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/jsonschema/JsonSchemaElementModuleTest.java
@@ -1,0 +1,434 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.agenticai.aiagent.framework.langchain4j.jsonschema;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.langchain4j.model.chat.request.json.JsonAnyOfSchema;
+import dev.langchain4j.model.chat.request.json.JsonArraySchema;
+import dev.langchain4j.model.chat.request.json.JsonBooleanSchema;
+import dev.langchain4j.model.chat.request.json.JsonEnumSchema;
+import dev.langchain4j.model.chat.request.json.JsonIntegerSchema;
+import dev.langchain4j.model.chat.request.json.JsonNumberSchema;
+import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
+import dev.langchain4j.model.chat.request.json.JsonSchemaElement;
+import dev.langchain4j.model.chat.request.json.JsonStringSchema;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import org.assertj.core.api.InstanceOfAssertFactories;
+import org.assertj.core.api.ThrowingConsumer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.skyscreamer.jsonassert.JSONAssert;
+
+class JsonSchemaElementModuleTest {
+
+  private ObjectMapper objectMapper;
+
+  @BeforeEach
+  void setUp() {
+    objectMapper = new ObjectMapper();
+    objectMapper.registerModule(new JsonSchemaElementModule());
+  }
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "jsonschema/mcp-server-everything-tools-list.json",
+        "jsonschema/mcp-server-filesystem-tools-list.json"
+      })
+  void deserializesAndSerializesMcpToolSchemas(String path) throws Exception {
+    final var inputJson =
+        Files.readString(Path.of(getClass().getClassLoader().getResource(path).getFile()));
+
+    final var tools = objectMapper.readValue(inputJson, TestMcpListToolsResponse.class);
+    assertThat(tools).isNotNull();
+
+    final var serialized = objectMapper.writeValueAsString(tools);
+    assertThat(serialized).isNotNull();
+  }
+
+  private record TestMcpListToolsResponse(List<TestMcpToolDefinition> tools) {
+    private record TestMcpToolDefinition(
+        String name, String description, JsonSchemaElement inputSchema) {}
+  }
+
+  @Test
+  void shouldSerializeAndDeserializeSimpleObjectSchema() throws Exception {
+    String json =
+        """
+        {
+          "type": "object",
+          "properties": {
+            "message": {
+              "type": "string",
+              "description": "Message to echo"
+            }
+          },
+          "required": [
+            "message"
+          ],
+          "additionalProperties": false
+        }
+        """;
+
+    assertSchemaSerializationAndDeserialization(
+        json,
+        schema -> {
+          assertThat(schema.properties()).containsOnlyKeys("message");
+          assertThat(schema.properties().get("message"))
+              .asInstanceOf(InstanceOfAssertFactories.type(JsonStringSchema.class))
+              .satisfies(
+                  stringSchema -> {
+                    assertThat(stringSchema.description()).isEqualTo("Message to echo");
+                  });
+          assertThat(schema.required()).containsExactly("message");
+          assertThat(schema.additionalProperties()).isFalse();
+        });
+  }
+
+  @Test
+  void shouldSerializeAndDeserializeComplexObjectSchema() throws Exception {
+    String json =
+        """
+        {
+          "type": "object",
+          "properties": {
+            "type": {
+              "enum": [
+                "edit",
+                "overwrite"
+              ],
+              "description": "Type of edit"
+            },
+            "path": {
+              "type": "string"
+            },
+            "edits": {
+              "type": "array",
+              "description": "The edits to apply",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "oldText": {
+                    "type": "string",
+                    "description": "Text to search for - must match exactly"
+                  },
+                  "newText": {
+                    "type": "string",
+                    "description": "Text to replace with"
+                  }
+                },
+                "required": [
+                  "oldText",
+                  "newText"
+                ],
+                "additionalProperties": true
+              }
+            },
+            "maxLines": {
+              "type": "number",
+              "description": "The maximum number of lines to edit"
+            },
+            "startLine": {
+              "type": "integer",
+              "description": "Do not edit lines before this line number"
+            },
+            "dryRun": {
+              "type": "boolean",
+              "description": "Preview changes using git-style diff format"
+            },
+            "encoding": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "description": "Encoding string, e.g. 'utf-8', 'ascii', etc."
+                },
+                {
+                  "type": "number",
+                  "description": "Encoding codepage, e.g. 65001 for UTF-8"
+                }
+              ]
+            }
+          },
+          "required": [
+            "path",
+            "edits"
+          ],
+          "additionalProperties": false
+        }
+        """;
+
+    assertSchemaSerializationAndDeserialization(
+        json,
+        schema -> {
+          assertThat(schema.properties())
+              .containsOnlyKeys(
+                  "type", "path", "edits", "maxLines", "startLine", "dryRun", "encoding");
+
+          assertThat(schema.properties().get("type"))
+              .asInstanceOf(InstanceOfAssertFactories.type(JsonEnumSchema.class))
+              .satisfies(
+                  enumSchema -> {
+                    assertThat(enumSchema.enumValues()).contains("edit", "overwrite");
+                    assertThat(enumSchema.description()).isEqualTo("Type of edit");
+                  });
+
+          assertThat(schema.properties().get("path"))
+              .asInstanceOf(InstanceOfAssertFactories.type(JsonStringSchema.class))
+              .satisfies(
+                  stringSchema -> {
+                    assertThat(stringSchema.description()).isNull();
+                  });
+
+          assertThat(schema.properties().get("edits"))
+              .asInstanceOf(InstanceOfAssertFactories.type(JsonArraySchema.class))
+              .satisfies(
+                  arraySchema -> {
+                    assertThat(arraySchema.description()).isEqualTo("The edits to apply");
+                    assertThat(arraySchema.items())
+                        .asInstanceOf(InstanceOfAssertFactories.type(JsonObjectSchema.class))
+                        .satisfies(
+                            objectSchema -> {
+                              assertThat(objectSchema.properties())
+                                  .containsOnlyKeys("oldText", "newText");
+                              assertThat(objectSchema.properties().get("oldText"))
+                                  .asInstanceOf(
+                                      InstanceOfAssertFactories.type(JsonStringSchema.class))
+                                  .satisfies(
+                                      stringSchema -> {
+                                        assertThat(stringSchema.description())
+                                            .isEqualTo("Text to search for - must match exactly");
+                                      });
+                              assertThat(objectSchema.properties().get("newText"))
+                                  .asInstanceOf(
+                                      InstanceOfAssertFactories.type(JsonStringSchema.class))
+                                  .satisfies(
+                                      stringSchema -> {
+                                        assertThat(stringSchema.description())
+                                            .isEqualTo("Text to replace with");
+                                      });
+                              assertThat(objectSchema.required())
+                                  .containsExactly("oldText", "newText");
+                              assertThat(objectSchema.additionalProperties()).isTrue();
+                            });
+                  });
+
+          assertThat(schema.properties().get("maxLines"))
+              .asInstanceOf(InstanceOfAssertFactories.type(JsonNumberSchema.class))
+              .satisfies(
+                  numberSchema -> {
+                    assertThat(numberSchema.description())
+                        .isEqualTo("The maximum number of lines to edit");
+                  });
+
+          assertThat(schema.properties().get("startLine"))
+              .asInstanceOf(InstanceOfAssertFactories.type(JsonIntegerSchema.class))
+              .satisfies(
+                  integerSchema -> {
+                    assertThat(integerSchema.description())
+                        .isEqualTo("Do not edit lines before this line number");
+                  });
+
+          assertThat(schema.properties().get("dryRun"))
+              .asInstanceOf(InstanceOfAssertFactories.type(JsonBooleanSchema.class))
+              .satisfies(
+                  booleanSchema -> {
+                    assertThat(booleanSchema.description())
+                        .isEqualTo("Preview changes using git-style diff format");
+                  });
+
+          assertThat(schema.properties().get("encoding"))
+              .asInstanceOf(InstanceOfAssertFactories.type(JsonAnyOfSchema.class))
+              .satisfies(
+                  anyOfSchema -> {
+                    assertThat(anyOfSchema.anyOf()).hasSize(2);
+
+                    assertThat(anyOfSchema.anyOf().get(0))
+                        .asInstanceOf(InstanceOfAssertFactories.type(JsonStringSchema.class))
+                        .satisfies(
+                            stringSchema -> {
+                              assertThat(stringSchema.description())
+                                  .isEqualTo("Encoding string, e.g. 'utf-8', 'ascii', etc.");
+                            });
+
+                    assertThat(anyOfSchema.anyOf().get(1))
+                        .asInstanceOf(InstanceOfAssertFactories.type(JsonNumberSchema.class))
+                        .satisfies(
+                            numberSchema -> {
+                              assertThat(numberSchema.description())
+                                  .isEqualTo("Encoding codepage, e.g. 65001 for UTF-8");
+                            });
+                  });
+
+          assertThat(schema.required()).containsExactly("path", "edits");
+          assertThat(schema.additionalProperties()).isFalse();
+        });
+  }
+
+  @Test
+  void shouldHandleSchemaIncludingEnum() throws Exception {
+    String json =
+        """
+        {
+          "type": "object",
+          "properties": {
+            "messageType": {
+              "enum": [
+                "error",
+                "success",
+                "debug"
+              ],
+              "description": "Type of message to demonstrate different annotation patterns"
+            },
+            "includeImage": {
+              "type": "boolean",
+              "description": "Whether to include an example image"
+            }
+          },
+          "required": [
+            "messageType"
+          ],
+          "additionalProperties": false
+        }
+        """;
+
+    assertSchemaSerializationAndDeserialization(
+        json,
+        schema -> {
+          assertThat(schema.properties()).containsKeys("messageType", "includeImage");
+          assertThat(schema.properties().get("messageType"))
+              .asInstanceOf(InstanceOfAssertFactories.type(JsonEnumSchema.class))
+              .satisfies(
+                  enumSchema -> {
+                    assertThat(enumSchema.enumValues()).contains("error", "success", "debug");
+                    assertThat(enumSchema.description())
+                        .isEqualTo("Type of message to demonstrate different annotation patterns");
+                  });
+          assertThat(schema.properties().get("includeImage"))
+              .asInstanceOf(InstanceOfAssertFactories.type(JsonBooleanSchema.class))
+              .satisfies(
+                  booleanSchema -> {
+                    assertThat(booleanSchema.description())
+                        .isEqualTo("Whether to include an example image");
+                  });
+          assertThat(schema.required()).containsExactly("messageType");
+          assertThat(schema.additionalProperties()).isFalse();
+        });
+  }
+
+  @Test
+  void shouldHandleSchemaIncludingArray() throws Exception {
+    String json =
+        """
+        {
+          "type": "object",
+          "properties": {
+            "myItems": {
+              "type": "array",
+              "description": "Array description",
+              "items": {
+                "type": "string",
+                "description": "Item description"
+              }
+            }
+          },
+          "required": [
+            "myItems"
+          ]
+        }
+        """;
+
+    assertSchemaSerializationAndDeserialization(
+        json,
+        schema -> {
+          assertThat(schema.properties()).containsKey("myItems");
+          assertThat(schema.properties().get("myItems"))
+              .asInstanceOf(InstanceOfAssertFactories.type(JsonArraySchema.class))
+              .satisfies(
+                  arraySchema -> {
+                    assertThat(arraySchema.description()).isEqualTo("Array description");
+                    assertThat(arraySchema.items())
+                        .asInstanceOf(InstanceOfAssertFactories.type(JsonStringSchema.class))
+                        .satisfies(
+                            stringSchema -> {
+                              assertThat(stringSchema.description()).isEqualTo("Item description");
+                            });
+                  });
+          assertThat(schema.required()).containsExactly("myItems");
+          assertThat(schema.additionalProperties()).isNull();
+        });
+  }
+
+  @Test
+  void shouldIgnoreUnknownProperties() throws Exception {
+    String json =
+        """
+        {
+          "type": "object",
+          "properties": {
+            "message": {
+              "type": "string",
+              "description": "Message to echo",
+              "unknownProperty": "value"
+            }
+          },
+          "required": [
+            "message"
+          ],
+          "additionalProperties": false,
+          "anotherUnknownProperty": 123
+        }
+        """;
+
+    assertSchemaSerializationAndDeserialization(
+        json,
+        schema -> {
+          assertThat(schema.properties()).containsKey("message");
+          assertThat(schema.properties().get("message"))
+              .asInstanceOf(InstanceOfAssertFactories.type(JsonStringSchema.class))
+              .satisfies(
+                  stringSchema -> {
+                    assertThat(stringSchema.description()).isEqualTo("Message to echo");
+                  });
+          assertThat(schema.required()).contains("message");
+          assertThat(schema.additionalProperties()).isFalse();
+        },
+        false);
+  }
+
+  private void assertSchemaSerializationAndDeserialization(
+      String inputJson, ThrowingConsumer<JsonObjectSchema> schemaAssertions) throws Exception {
+    assertSchemaSerializationAndDeserialization(inputJson, schemaAssertions, true);
+  }
+
+  private void assertSchemaSerializationAndDeserialization(
+      String inputJson, ThrowingConsumer<JsonObjectSchema> schemaAssertions, boolean compareJson)
+      throws Exception {
+    // deserialize JSON
+    JsonSchemaElement element = objectMapper.readValue(inputJson, JsonSchemaElement.class);
+    assertThat(element)
+        .asInstanceOf(InstanceOfAssertFactories.type(JsonObjectSchema.class))
+        .satisfies(schemaAssertions);
+
+    // compare serialized JSON with original input
+    String serialized = objectMapper.writeValueAsString(element);
+    if (compareJson) {
+      JSONAssert.assertEquals(inputJson, serialized, true);
+    }
+
+    // deserialize back from serialized JSON
+    JsonSchemaElement deserialized = objectMapper.readValue(serialized, JsonSchemaElement.class);
+    assertThat(deserialized)
+        .asInstanceOf(InstanceOfAssertFactories.type(JsonObjectSchema.class))
+        .satisfies(schemaAssertions);
+  }
+}

--- a/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/tool/ToolSpecificationConverterTest.java
+++ b/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/tool/ToolSpecificationConverterTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.agenticai.aiagent.framework.langchain4j.tool;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.langchain4j.model.chat.request.json.JsonArraySchema;
+import dev.langchain4j.model.chat.request.json.JsonBooleanSchema;
+import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
+import dev.langchain4j.model.chat.request.json.JsonStringSchema;
+import io.camunda.connector.agenticai.model.tool.ToolDefinition;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import org.assertj.core.api.InstanceOfAssertFactories;
+import org.junit.jupiter.api.Test;
+
+class ToolSpecificationConverterTest {
+
+  private final ObjectMapper objectMapper = new ObjectMapper();
+  private final ToolSpecificationConverter toolSpecificationConverter =
+      new ToolSpecificationConverterImpl(objectMapper);
+
+  @Test
+  void convertsToolDefinitionToToolSpecification() throws Exception {
+    final var toolsDefinitions =
+        loadToolDefinitions("jsonschema/mcp-server-filesystem-tools-list.json");
+    final var toolDefinition =
+        toolsDefinitions.tools().stream()
+            .filter(td -> td.name().equals("edit_file"))
+            .findFirst()
+            .get();
+
+    final var toolSpecification = toolSpecificationConverter.asToolSpecification(toolDefinition);
+
+    assertThat(toolSpecification.name()).isEqualTo("edit_file");
+    assertThat(toolSpecification.description())
+        .isEqualTo(
+            "Make line-based edits to a text file. Each edit replaces exact line sequences with new content. Returns a git-style diff showing the changes made. Only works within allowed directories.");
+    assertThat(toolSpecification.parameters())
+        .satisfies(
+            schema -> {
+              assertThat(schema.properties()).containsOnlyKeys("path", "edits", "dryRun");
+
+              assertThat(schema.properties().get("path"))
+                  .asInstanceOf(InstanceOfAssertFactories.type(JsonStringSchema.class))
+                  .satisfies(
+                      stringSchema -> {
+                        assertThat(stringSchema.description()).isNull();
+                      });
+
+              assertThat(schema.properties().get("edits"))
+                  .asInstanceOf(InstanceOfAssertFactories.type(JsonArraySchema.class))
+                  .satisfies(
+                      arraySchema -> {
+                        assertThat(arraySchema.items())
+                            .asInstanceOf(InstanceOfAssertFactories.type(JsonObjectSchema.class))
+                            .satisfies(
+                                objectSchema -> {
+                                  assertThat(objectSchema.properties())
+                                      .containsOnlyKeys("oldText", "newText");
+                                  assertThat(objectSchema.properties().get("oldText"))
+                                      .asInstanceOf(
+                                          InstanceOfAssertFactories.type(JsonStringSchema.class))
+                                      .satisfies(
+                                          stringSchema -> {
+                                            assertThat(stringSchema.description())
+                                                .isEqualTo(
+                                                    "Text to search for - must match exactly");
+                                          });
+                                  assertThat(objectSchema.properties().get("newText"))
+                                      .asInstanceOf(
+                                          InstanceOfAssertFactories.type(JsonStringSchema.class))
+                                      .satisfies(
+                                          stringSchema -> {
+                                            assertThat(stringSchema.description())
+                                                .isEqualTo("Text to replace with");
+                                          });
+                                  assertThat(objectSchema.required())
+                                      .containsExactly("oldText", "newText");
+                                  assertThat(objectSchema.additionalProperties()).isFalse();
+                                });
+                      });
+
+              assertThat(schema.properties().get("dryRun"))
+                  .asInstanceOf(InstanceOfAssertFactories.type(JsonBooleanSchema.class))
+                  .satisfies(
+                      booleanSchema -> {
+                        assertThat(booleanSchema.description())
+                            .isEqualTo("Preview changes using git-style diff format");
+                      });
+
+              assertThat(schema.required()).containsExactly("path", "edits");
+              assertThat(schema.additionalProperties()).isFalse();
+            });
+  }
+
+  private TestToolDefinitions loadToolDefinitions(String path) throws IOException {
+    final var inputJson =
+        Files.readString(Path.of(getClass().getClassLoader().getResource(path).getFile()));
+
+    return objectMapper.readValue(inputJson, TestToolDefinitions.class);
+  }
+
+  private record TestToolDefinitions(List<ToolDefinition> tools) {}
+}

--- a/connectors/agentic-ai/src/test/resources/jsonschema/mcp-server-everything-tools-list.json
+++ b/connectors/agentic-ai/src/test/resources/jsonschema/mcp-server-everything-tools-list.json
@@ -1,0 +1,157 @@
+{
+  "tools": [
+    {
+      "name": "echo",
+      "description": "Echoes back the input",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string",
+            "description": "Message to echo"
+          }
+        },
+        "required": [
+          "message"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      }
+    },
+    {
+      "name": "add",
+      "description": "Adds two numbers",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "a": {
+            "type": "number",
+            "description": "First number"
+          },
+          "b": {
+            "type": "number",
+            "description": "Second number"
+          }
+        },
+        "required": [
+          "a",
+          "b"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      }
+    },
+    {
+      "name": "printEnv",
+      "description": "Prints all environment variables, helpful for debugging MCP server configuration",
+      "inputSchema": {
+        "type": "object",
+        "properties": {},
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      }
+    },
+    {
+      "name": "longRunningOperation",
+      "description": "Demonstrates a long running operation with progress updates",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "duration": {
+            "type": "number",
+            "default": 10,
+            "description": "Duration of the operation in seconds"
+          },
+          "steps": {
+            "type": "number",
+            "default": 5,
+            "description": "Number of steps in the operation"
+          }
+        },
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      }
+    },
+    {
+      "name": "sampleLLM",
+      "description": "Samples from an LLM using MCP's sampling feature",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "prompt": {
+            "type": "string",
+            "description": "The prompt to send to the LLM"
+          },
+          "maxTokens": {
+            "type": "number",
+            "default": 100,
+            "description": "Maximum number of tokens to generate"
+          }
+        },
+        "required": [
+          "prompt"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      }
+    },
+    {
+      "name": "getTinyImage",
+      "description": "Returns the MCP_TINY_IMAGE",
+      "inputSchema": {
+        "type": "object",
+        "properties": {},
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      }
+    },
+    {
+      "name": "annotatedMessage",
+      "description": "Demonstrates how annotations can be used to provide metadata about content",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "messageType": {
+            "type": "string",
+            "enum": [
+              "error",
+              "success",
+              "debug"
+            ],
+            "description": "Type of message to demonstrate different annotation patterns"
+          },
+          "includeImage": {
+            "type": "boolean",
+            "default": false,
+            "description": "Whether to include an example image"
+          }
+        },
+        "required": [
+          "messageType"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      }
+    },
+    {
+      "name": "getResourceReference",
+      "description": "Returns a resource reference that can be used by MCP clients",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "resourceId": {
+            "type": "number",
+            "minimum": 1,
+            "maximum": 100,
+            "description": "ID of the resource to reference (1-100)"
+          }
+        },
+        "required": [
+          "resourceId"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      }
+    }
+  ]
+}

--- a/connectors/agentic-ai/src/test/resources/jsonschema/mcp-server-filesystem-tools-list.json
+++ b/connectors/agentic-ai/src/test/resources/jsonschema/mcp-server-filesystem-tools-list.json
@@ -1,0 +1,232 @@
+{
+  "tools": [
+    {
+      "name": "read_file",
+      "description": "Read the complete contents of a file from the file system. Handles various text encodings and provides detailed error messages if the file cannot be read. Use this tool when you need to examine the contents of a single file. Only works within allowed directories.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "path": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "path"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      }
+    },
+    {
+      "name": "read_multiple_files",
+      "description": "Read the contents of multiple files simultaneously. This is more efficient than reading files one by one when you need to analyze or compare multiple files. Each file's content is returned with its path as a reference. Failed reads for individual files won't stop the entire operation. Only works within allowed directories.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "paths": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "required": [
+          "paths"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      }
+    },
+    {
+      "name": "write_file",
+      "description": "Create a new file or completely overwrite an existing file with new content. Use with caution as it will overwrite existing files without warning. Handles text content with proper encoding. Only works within allowed directories.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "path": {
+            "type": "string"
+          },
+          "content": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "path",
+          "content"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      }
+    },
+    {
+      "name": "edit_file",
+      "description": "Make line-based edits to a text file. Each edit replaces exact line sequences with new content. Returns a git-style diff showing the changes made. Only works within allowed directories.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "path": {
+            "type": "string"
+          },
+          "edits": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "oldText": {
+                  "type": "string",
+                  "description": "Text to search for - must match exactly"
+                },
+                "newText": {
+                  "type": "string",
+                  "description": "Text to replace with"
+                }
+              },
+              "required": [
+                "oldText",
+                "newText"
+              ],
+              "additionalProperties": false
+            }
+          },
+          "dryRun": {
+            "type": "boolean",
+            "default": false,
+            "description": "Preview changes using git-style diff format"
+          }
+        },
+        "required": [
+          "path",
+          "edits"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      }
+    },
+    {
+      "name": "create_directory",
+      "description": "Create a new directory or ensure a directory exists. Can create multiple nested directories in one operation. If the directory already exists, this operation will succeed silently. Perfect for setting up directory structures for projects or ensuring required paths exist. Only works within allowed directories.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "path": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "path"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      }
+    },
+    {
+      "name": "list_directory",
+      "description": "Get a detailed listing of all files and directories in a specified path. Results clearly distinguish between files and directories with [FILE] and [DIR] prefixes. This tool is essential for understanding directory structure and finding specific files within a directory. Only works within allowed directories.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "path": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "path"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      }
+    },
+    {
+      "name": "directory_tree",
+      "description": "Get a recursive tree view of files and directories as a JSON structure. Each entry includes 'name', 'type' (file/directory), and 'children' for directories. Files have no children array, while directories always have a children array (which may be empty). The output is formatted with 2-space indentation for readability. Only works within allowed directories.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "path": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "path"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      }
+    },
+    {
+      "name": "move_file",
+      "description": "Move or rename files and directories. Can move files between directories and rename them in a single operation. If the destination exists, the operation will fail. Works across different directories and can be used for simple renaming within the same directory. Both source and destination must be within allowed directories.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "source": {
+            "type": "string"
+          },
+          "destination": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "source",
+          "destination"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      }
+    },
+    {
+      "name": "search_files",
+      "description": "Recursively search for files and directories matching a pattern. Searches through all subdirectories from the starting path. The search is case-insensitive and matches partial names. Returns full paths to all matching items. Great for finding files when you don't know their exact location. Only searches within allowed directories.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "path": {
+            "type": "string"
+          },
+          "pattern": {
+            "type": "string"
+          },
+          "excludePatterns": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "default": []
+          }
+        },
+        "required": [
+          "path",
+          "pattern"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      }
+    },
+    {
+      "name": "get_file_info",
+      "description": "Retrieve detailed metadata about a file or directory. Returns comprehensive information including size, creation time, last modified time, permissions, and type. This tool is perfect for understanding file characteristics without reading the actual content. Only works within allowed directories.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "path": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "path"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      }
+    },
+    {
+      "name": "list_allowed_directories",
+      "description": "Returns the list of directories that this server is allowed to access. Use this to understand which directories are available before trying to access files.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {},
+        "required": []
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Description

Moves custom parsing code to create a `JsonSchemaElement` from a JSON string and vice-versa to a Jackson de(serializer). This is not provided by L4J, so we need to do this manually for multiple use cases:

- MCP tool definitions to L4J tool definitions
- Structured output format definitions to L4J output format definitions

In addition to moving the logic to a Jackson (de-)serializer this PR:

- adds support for reusable schema blocks via `$defs` + adds tests to deserialize JSON schemas from sample MCP server definitions
- adds support to convert from a Langchain4J `ToolSpecification` to a `ToolDefinition` (our model)

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.

