### PR TITLE
fix(aws-auth): Prohibit usage of AWS default credential chain in SaaS…

### DIFF
--- a/bundle/camunda-saas-bundle/Dockerfile
+++ b/bundle/camunda-saas-bundle/Dockerfile
@@ -16,6 +16,8 @@ RUN apt-get update && \
 RUN groupadd --gid 1001 camunda && useradd --no-create-home --gid 1001 --uid 1001 camunda
 USER 1001:1001
 
+ENV CAMUNDA_CONNECTOR_RUNTIME_SAAS=true
 ENV ZEEBE_CLIENT_CONFIG_PATH=/tmp/connectors
+
 # Using entry point to allow downstream images to add JVM arguments using CMD
 ENTRYPOINT ["java", "-cp", "/opt/app/*", "io.camunda.connector.runtime.saas.SaaSConnectorRuntimeApplication"]

--- a/connectors/aws/aws-base/pom.xml
+++ b/connectors/aws/aws-base/pom.xml
@@ -31,6 +31,13 @@
             <artifactId>aws-java-sdk-core</artifactId>
             <version>${version.aws-java-sdk}</version>
         </dependency>
+
+        <dependency>
+            <groupId>uk.org.webcompere</groupId>
+            <artifactId>system-stubs-jupiter</artifactId>
+            <version>2.1.3</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/connectors/aws/aws-base/src/main/java/io/camunda/connector/aws/model/impl/AwsBaseRequest.java
+++ b/connectors/aws/aws-base/src/main/java/io/camunda/connector/aws/model/impl/AwsBaseRequest.java
@@ -8,6 +8,7 @@ package io.camunda.connector.aws.model.impl;
 
 import io.camunda.connector.generator.java.annotation.TemplateProperty;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.AssertFalse;
 import jakarta.validation.constraints.NotNull;
 import java.util.Objects;
 
@@ -35,6 +36,12 @@ public class AwsBaseRequest {
 
   public void setConfiguration(final AwsBaseConfiguration configuration) {
     this.configuration = configuration;
+  }
+
+  @AssertFalse
+  public boolean isDefaultCredentialsChainUsedInSaaS() {
+    return System.getenv().containsKey("CAMUNDA_CONNECTOR_RUNTIME_SAAS")
+        && authentication instanceof AwsAuthentication.AwsDefaultCredentialsChainAuthentication;
   }
 
   @Override

--- a/connectors/aws/aws-base/src/test/java/io/camunda/connector/aws/AwsBaseRequestTest.java
+++ b/connectors/aws/aws-base/src/test/java/io/camunda/connector/aws/AwsBaseRequestTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.aws;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import io.camunda.connector.aws.model.impl.AwsAuthentication;
+import io.camunda.connector.aws.model.impl.AwsBaseConfiguration;
+import io.camunda.connector.aws.model.impl.AwsBaseRequest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import uk.org.webcompere.systemstubs.environment.EnvironmentVariables;
+import uk.org.webcompere.systemstubs.jupiter.SystemStub;
+import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
+
+@ExtendWith(SystemStubsExtension.class)
+class AwsBaseRequestTest {
+
+  @SystemStub private EnvironmentVariables environment;
+
+  @Test
+  void shouldReturnTrue_WhenSaaSAndDefaultCredentialChainUsed() {
+    AwsBaseRequest request = new AwsBaseRequest();
+    request.setAuthentication(new AwsAuthentication.AwsDefaultCredentialsChainAuthentication());
+    request.setConfiguration(new AwsBaseConfiguration("eu-central-1", null));
+    environment.set("CAMUNDA_CONNECTOR_RUNTIME_SAAS", "true");
+    assertTrue(request.isDefaultCredentialsChainUsedInSaaS());
+  }
+
+  @Test
+  void shouldReturnFalse_WhenNotSaaSAndDefaultCredentialChainUsed() {
+    AwsBaseRequest request = new AwsBaseRequest();
+    request.setAuthentication(new AwsAuthentication.AwsDefaultCredentialsChainAuthentication());
+    request.setConfiguration(new AwsBaseConfiguration("eu-central-1", null));
+    environment.set("CAMUNDA_CONNECTOR_RUNTIME_SAAS", null);
+    assertFalse(request.isDefaultCredentialsChainUsedInSaaS());
+  }
+
+  @Test
+  void shouldReturnTrue_WhenSaaSAndDifferentAuthIsUsed() {
+    AwsBaseRequest request = new AwsBaseRequest();
+    request.setAuthentication(
+        new AwsAuthentication.AwsStaticCredentialsAuthentication("key", "secret"));
+    request.setConfiguration(new AwsBaseConfiguration("eu-central-1", null));
+    environment.set("CAMUNDA_CONNECTOR_RUNTIME_SAAS", "true");
+    assertFalse(request.isDefaultCredentialsChainUsedInSaaS());
+  }
+
+  @Test
+  void shouldReturnFalse_WhenNotSaaSOrNotDefaultCredentialChain() {
+    AwsBaseRequest request = new AwsBaseRequest();
+    request.setAuthentication(
+        new AwsAuthentication.AwsStaticCredentialsAuthentication("key", "secret"));
+    request.setConfiguration(new AwsBaseConfiguration("eu-central-1", null));
+    environment.set("CAMUNDA_CONNECTOR_RUNTIME_SAAS", null);
+    assertFalse(request.isDefaultCredentialsChainUsedInSaaS());
+  }
+}


### PR DESCRIPTION
… (#4835)

* fix(aws-auth): Prohibit usage of AWS default credential chain in SaaS

## Description

<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #4835

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.

