### PR TITLE
fix(saas): credentials cache path not applied

### DIFF
--- a/bundle/camunda-saas-bundle/src/main/java/io/camunda/connector/runtime/saas/CamundaClientSaaSConfiguration.java
+++ b/bundle/camunda-saas-bundle/src/main/java/io/camunda/connector/runtime/saas/CamundaClientSaaSConfiguration.java
@@ -53,6 +53,9 @@ public class CamundaClientSaaSConfiguration {
   @Value("${camunda.client.auth.audience}")
   private String camundaClientAudience;
 
+  @Value("${camunda.client.auth.credentials-cache-path:/tmp/connectors}")
+  private String credentialsCachePath;
+
   public CamundaClientSaaSConfiguration(@Autowired SaaSSecretConfiguration saaSConfiguration) {
     this.internalSecretProvider = saaSConfiguration.getInternalSecretProvider();
   }
@@ -81,6 +84,7 @@ public class CamundaClientSaaSConfiguration {
     builder.clientSecret(internalSecretProvider.getSecret(SECRET_NAME_SECRET));
     builder.authorizationServerUrl(camundaClientTokenUrl);
     builder.audience(camundaClientAudience);
+    builder.credentialsCachePath(credentialsCachePath);
     return builder.build();
   }
 }


### PR DESCRIPTION
## Description

In https://github.com/camunda/connectors/pull/4836 we switched to the new config cache path variable.

This caused our SNAPSHOT to break on SaaS because we are constructing a custom instance of Camunda client in the SaaS environment, and we didn't explicitly apply the new credentials cache path when building it.

Before that change, it worked because we provided the lower-level env var defined in the Zeebe client which took effect even though the new property was not provided.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #

## Checklist

- [ ] PR has a **milestone** or the `no milestone` label.

