### PR TITLE
fix(agentic-ai,aws-auth): Prohibit usage of AWS default credential chain in SaaS in AI Agent connector

### DIFF
--- a/connectors/agentic-ai/pom.xml
+++ b/connectors/agentic-ai/pom.xml
@@ -83,6 +83,11 @@
       <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>uk.org.webcompere</groupId>
+      <artifactId>system-stubs-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/ProviderConfiguration.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/ProviderConfiguration.java
@@ -19,6 +19,7 @@ import io.camunda.connector.generator.java.annotation.TemplateProperty;
 import io.camunda.connector.generator.java.annotation.TemplateProperty.PropertyConstraints;
 import io.camunda.connector.generator.java.annotation.TemplateSubType;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.AssertFalse;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -157,7 +158,14 @@ public sealed interface ProviderConfiguration
                 optional = true)
             String endpoint,
         @Valid @NotNull AwsAuthentication authentication,
-        @Valid @NotNull BedrockModel model) {}
+        @Valid @NotNull BedrockModel model) {
+
+      @AssertFalse(message = "AWS default credentials chain is not supported on SaaS")
+      public boolean isDefaultCredentialsChainUsedInSaaS() {
+        return System.getenv().containsKey("CAMUNDA_CONNECTOR_RUNTIME_SAAS")
+            && authentication instanceof AwsAuthentication.AwsDefaultCredentialsChainAuthentication;
+      }
+    }
 
     @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
     @JsonSubTypes({

--- a/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/model/request/ProviderConfigurationTest.java
+++ b/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/model/request/ProviderConfigurationTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.agenticai.aiagent.model.request;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.connector.agenticai.aiagent.model.request.ProviderConfiguration.BedrockProviderConfiguration.AwsAuthentication;
+import io.camunda.connector.agenticai.aiagent.model.request.ProviderConfiguration.BedrockProviderConfiguration.BedrockConnection;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validator;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.validation.ValidationAutoConfiguration;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import uk.org.webcompere.systemstubs.environment.EnvironmentVariables;
+import uk.org.webcompere.systemstubs.jupiter.SystemStub;
+import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
+
+@ExtendWith({SpringExtension.class, SystemStubsExtension.class})
+@Import(ValidationAutoConfiguration.class)
+class ProviderConfigurationTest {
+
+  @Autowired private Validator validator;
+  @SystemStub private EnvironmentVariables environment;
+
+  @Nested
+  class BedrockConnectionTest {
+
+    @BeforeEach
+    void setUp() {
+      environment.set("CAMUNDA_CONNECTOR_RUNTIME_SAAS", null);
+    }
+
+    @Test
+    void validationShouldFail_WhenSaaSAndDefaultCredentialChainUsed() {
+      environment.set("CAMUNDA_CONNECTOR_RUNTIME_SAAS", "true");
+
+      final var connection =
+          createConnection(new AwsAuthentication.AwsDefaultCredentialsChainAuthentication());
+      assertThat(validator.validate(connection))
+          .hasSize(1)
+          .extracting(ConstraintViolation::getMessage)
+          .containsExactly("AWS default credentials chain is not supported on SaaS");
+    }
+
+    @Test
+    void validationShouldSucceed_WhenNotSaaSAndDefaultCredentialChainUsed() {
+      final var connection =
+          createConnection(new AwsAuthentication.AwsDefaultCredentialsChainAuthentication());
+      assertThat(validator.validate(connection)).isEmpty();
+    }
+
+    @Test
+    void validationShouldSucceed_WhenSaaSAndNotDefaultCredentialChainUsed() {
+      environment.set("CAMUNDA_CONNECTOR_RUNTIME_SAAS", "true");
+
+      final var connection =
+          createConnection(
+              new AwsAuthentication.AwsStaticCredentialsAuthentication("key", "secret"));
+      assertThat(validator.validate(connection)).isEmpty();
+    }
+
+    @Test
+    void validationShouldSucceed_WhenNotSaaSAndNotDefaultCredentialChainUsed() {
+      final var connection =
+          createConnection(
+              new AwsAuthentication.AwsStaticCredentialsAuthentication("key", "secret"));
+      assertThat(validator.validate(connection)).isEmpty();
+    }
+
+    private BedrockConnection createConnection(AwsAuthentication authentication) {
+      return new BedrockConnection(
+          "eu-central-1",
+          null,
+          authentication,
+          new ProviderConfiguration.BedrockProviderConfiguration.BedrockModel(
+              "test",
+              new ProviderConfiguration.BedrockProviderConfiguration.BedrockModel
+                  .BedrockModelParameters(null, null, null)));
+    }
+  }
+}

--- a/connectors/aws/aws-base/pom.xml
+++ b/connectors/aws/aws-base/pom.xml
@@ -56,12 +56,9 @@
         <dependency>
             <groupId>uk.org.webcompere</groupId>
             <artifactId>system-stubs-jupiter</artifactId>
-            <version>2.1.3</version>
             <scope>test</scope>
         </dependency>
 
     </dependencies>
 
 </project>
-
-

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -145,6 +145,8 @@ limitations under the License.</license.inlineheader>
     <version.javax.xml.bind>2.4.0-b180830.0359</version.javax.xml.bind>
 
     <version.wiremock>3.13.0</version.wiremock>
+    <version.system-stubs-jupiter>2.1.3</version.system-stubs-jupiter>
+
     <version.auth0.jwt>4.5.0</version.auth0.jwt>
     <version.auth0.jwks>0.22.1</version.auth0.jwks>
     
@@ -612,6 +614,13 @@ limitations under the License.</license.inlineheader>
         <groupId>org.wiremock</groupId>
         <artifactId>wiremock-standalone</artifactId>
         <version>${version.wiremock}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>uk.org.webcompere</groupId>
+        <artifactId>system-stubs-jupiter</artifactId>
+        <version>${version.system-stubs-jupiter}</version>
+        <scope>test</scope>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
## Description

Add the same validation as done in https://github.com/camunda/connectors/pull/4835 to the AI Agent connector configuration.

## Related issues

relates to #4835 

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.

