### PR TITLE
feat(GitHub): add file create/update to Repo Operations

### DIFF
--- a/connectors/github/element-templates/github-connector.json
+++ b/connectors/github/element-templates/github-connector.json
@@ -2169,7 +2169,7 @@
     },
     {
       "label": "Path",
-      "description": "The path of the content within the repository",
+      "description": "The path of the file within the repository",
       "group": "input",
       "type": "String",
       "feel": "optional",
@@ -2252,7 +2252,6 @@
       "label": "SHA",
       "description": "Required if you are updating a file. The blob SHA of the file being replaced.",
       "group": "input",
-      
       "type": "String",
       "feel": "optional",
       "value": "",


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

This feature adds the ability to create or update files in a repository using [this endpoint](https://docs.github.com/en/rest/repos/contents?apiVersion=2022-11-28#create-or-update-file-contents).

Features that I've covered:
- Full coverage of API including optional author 
- User provided content can either be base64 encoded or not

## Related issues

<!-- Which issues are closed by this PR or are related -->

Closes #2023

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.
- [x] Docs PR [is open](https://github.com/camunda/camunda-docs/pull/5979)

