### PR TITLE
chore(fossa): compare PR scan against most recent base commit with available FOSSA scan

### DIFF
--- a/.github/workflows/CHECK_LICENSES.yml
+++ b/.github/workflows/CHECK_LICENSES.yml
@@ -56,10 +56,10 @@ jobs:
           }]
         mirrors: '[{"url": "https://repository.nexus.camunda.cloud/content/groups/internal/", "id": "camunda-nexus", "mirrorOf": "*,!confluent,!shibboleth", "name": "camunda Nexus"}]'
     - name: Setup fossa-cli
-      uses: camunda/infra-global-github-actions/fossa/setup@0e82486eaa9ef8589e051c556a1b5218efa6d37f
+      uses: camunda/infra-global-github-actions/fossa/setup@4a964d63a105aac18a6b1c2fb03144cf8136151f
     - name: Get context info
       id: info
-      uses: camunda/infra-global-github-actions/fossa/info@0e82486eaa9ef8589e051c556a1b5218efa6d37f
+      uses: camunda/infra-global-github-actions/fossa/info@4a964d63a105aac18a6b1c2fb03144cf8136151f
     - name: Adjust pom.xml files for FOSSA
       run: |
         # The parent/pom.xml must be the actual root, otherwise, FOSSA won't detect the hierarchy correctly
@@ -71,7 +71,7 @@ jobs:
           'del(.project.modules.module[] | select(. == "parent"))' \
           pom.xml
     - name: Analyze project
-      uses: camunda/infra-global-github-actions/fossa/analyze@0e82486eaa9ef8589e051c556a1b5218efa6d37f
+      uses: camunda/infra-global-github-actions/fossa/analyze@4a964d63a105aac18a6b1c2fb03144cf8136151f
       with:
         api-key: ${{ steps.secrets.outputs.FOSSA_API_KEY }}
         branch: ${{  steps.info.outputs.head-ref }}
@@ -81,9 +81,15 @@ jobs:
     # It does not fail for pre-existing issues already present in the base branch.
     - name: Check Pull Request for new License Issues
       if: steps.info.outputs.is-pull-request == 'true'
-      uses: camunda/infra-global-github-actions/fossa/pr-check@0e82486eaa9ef8589e051c556a1b5218efa6d37f
+      uses: camunda/infra-global-github-actions/fossa/pr-check@4a964d63a105aac18a6b1c2fb03144cf8136151f
       with:
         api-key: ${{ steps.secrets.outputs.FOSSA_API_KEY }}
         base-ref: ${{ steps.info.outputs.base-ref }}
-        base-revision: ${{ steps.info.outputs.base-revision }}
+        # Use the most recent base commit with a FOSSA scan for comparison.
+        # If none is found, fall back to the original base commit — this will cause the check to fail.
+        base-revision: >-
+          ${{
+            steps.info.outputs.base-revision-most-recent-with-scanning-results || 
+            steps.info.outputs.base-revision
+          }}
         revision: ${{ steps.info.outputs.head-revision }}


### PR DESCRIPTION
## Description

Related to https://github.com/camunda/infra-global-github-actions/pull/417 and https://github.com/camunda/team-infrastructure/issues/752.

This PR enhances the robustness of FOSSA license violation checks on PRs.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #

## Checklist

- [ ] PR has a **milestone** or the `no milestone` label.

