### PR TITLE
fix(CustomApacheHttpClientTest): Set max file descriptors in squid

### DIFF
--- a/connectors/http/http-base/src/test/java/io/camunda/connector/http/base/client/apache/CustomApacheHttpClientTest.java
+++ b/connectors/http/http-base/src/test/java/io/camunda/connector/http/base/client/apache/CustomApacheHttpClientTest.java
@@ -262,8 +262,8 @@ public class CustomApacheHttpClientTest {
     @AfterAll
     public static void tearDown() {
       unsetAllSystemProperties();
-      proxyContainer.stop();
       proxy.stop();
+      proxyContainer.stop();
     }
 
     @BeforeEach

--- a/connectors/http/http-base/src/test/resources/squid.conf
+++ b/connectors/http/http-base/src/test/resources/squid.conf
@@ -19,3 +19,5 @@ http_access allow authenticated_user
 
 # Deny everything else (optional, for safety)
 http_access deny all
+
+max_filedescriptors 65536


### PR DESCRIPTION
## Description

On systems that report a very large number of maximum file handles (such as Fedora), squid will try to preallocate an array for all of them.

By setting a fixed number, the container is able to start without running out of memory

See also: <https://bugs.launchpad.net/ubuntu-docker-images/+bug/1978272/comments/1\>

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.

