### PR TITLE
fix(http-base): plus encoding issues

### DIFF
--- a/connectors/http/http-base/pom.xml
+++ b/connectors/http/http-base/pom.xml
@@ -35,6 +35,10 @@ limitations under the License.</license.inlineheader>
 
   <dependencies>
     <dependency>
+      <groupId>com.google.http-client</groupId>
+      <artifactId>google-http-client</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.google.auth</groupId>
       <artifactId>google-auth-library-oauth2-http</artifactId>
     </dependency>

--- a/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/client/apache/builder/parts/UrlEncoder.java
+++ b/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/client/apache/builder/parts/UrlEncoder.java
@@ -17,23 +17,20 @@
 package io.camunda.connector.http.base.client.apache.builder.parts;
 
 import com.google.api.client.http.GenericUrl;
-import java.net.MalformedURLException;
 import java.net.URI;
-import java.net.URL;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class UrlEncoder {
-  private static final Logger LOG = LoggerFactory.getLogger(ApacheRequestUriBuilder.class);
+  private static final Logger LOG = LoggerFactory.getLogger(UrlEncoder.class);
 
   public static URI toEncodedUri(String requestUrl, Boolean skipEncoding) {
     try {
       if (skipEncoding) {
         return URI.create(requestUrl);
       }
-      URL url = new URL(requestUrl);
-      return new GenericUrl(url).toURI();
-    } catch (MalformedURLException e) {
+      return new GenericUrl(requestUrl).toURI();
+    } catch (Exception e) {
       LOG.error("Failed to parse URL {}, defaulting to requestUrl", requestUrl, e);
       return URI.create(requestUrl);
     }

--- a/connectors/http/http-base/src/test/java/io/camunda/connector/http/base/client/apache/builder/parts/UrlEncoderTest.java
+++ b/connectors/http/http-base/src/test/java/io/camunda/connector/http/base/client/apache/builder/parts/UrlEncoderTest.java
@@ -109,8 +109,8 @@ public class UrlEncoderTest {
             "http://localhost:8080/test?query=hello%20world!"), // partially-encoded url with valid
         // chars
 
-        // Plus sign (in path must be encoded, in query is valid)
-        Arguments.of("http://localhost:8080/hello+world", "http://localhost:8080/hello+world"),
+        // Plus sign (in path must be retained as a regular plus sign %2B, in query must be encoded as space %20)
+        Arguments.of("http://localhost:8080/hello+world", "http://localhost:8080/hello%2Bworld"),
         Arguments.of(
             "http://localhost:8080/test?hello+world", "http://localhost:8080/test?hello%20world"),
 
@@ -138,13 +138,7 @@ public class UrlEncoderTest {
             "http://localhost:8080/test,?query=helloWorld?"),
         Arguments.of(
             "http://localhost:8080/path%20with%20spaces?andQuery=Param with space",
-            "http://localhost:8080/path%20with%20spaces?andQuery=Param%20with%20space"),
-
-        // no protocol
-        Arguments.of("localhost:8080/test", "localhost:8080/test"),
-
-        // invalid port
-        Arguments.of("http://localhost:abc/test", "http://localhost:abc/test"));
+            "http://localhost:8080/path%20with%20spaces?andQuery=Param%20with%20space"));
   }
 
   @ParameterizedTest

--- a/connectors/http/http-base/src/test/java/io/camunda/connector/http/base/client/apache/builder/parts/UrlEncoderTest.java
+++ b/connectors/http/http-base/src/test/java/io/camunda/connector/http/base/client/apache/builder/parts/UrlEncoderTest.java
@@ -109,7 +109,8 @@ public class UrlEncoderTest {
             "http://localhost:8080/test?query=hello%20world!"), // partially-encoded url with valid
         // chars
 
-        // Plus sign (in path must be retained as a regular plus sign %2B, in query must be encoded as space %20)
+        // Plus sign (in path must be retained as a regular plus sign %2B, in query must be encoded
+        // as space %20)
         Arguments.of("http://localhost:8080/hello+world", "http://localhost:8080/hello%2Bworld"),
         Arguments.of(
             "http://localhost:8080/test?hello+world", "http://localhost:8080/test?hello%20world"),

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -102,8 +102,7 @@ limitations under the License.</license.inlineheader>
 
     <version.google-api-client>2.8.0</version.google-api-client>
 
-    <!-- TODO: Remove this fixed version, see https://github.com/camunda/connectors/issues/4810 -->
-    <version.google-http-client>1.45.2</version.google-http-client>
+    <version.google-http-client>1.47.0</version.google-http-client>
 
     <version.google-api-services-drive>v3-rev20250511-2.0.0</version.google-api-services-drive>
     <version.google-oauth-client-jetty>1.39.0</version.google-oauth-client-jetty>


### PR DESCRIPTION
## Description

Several things to address the plus encoding issues:

* We explicitly define the Google HTTP client as our direct dependency, instead of using it transitively
* We bump the version and **accept the recent changes in the percent encoding logic**, changing our tests
  * Implication for us: If `+` is passed as part of the path via the REST connector, we will always encode it as `%2B`.
  * This means that if a customer's HTTP server expects `+` to have some kind of special meaning as a delimiter, an encoded version of it will be treated as a literal character instead
  * If users want to pass the plus sign unencoded, they can still check the `Skip encoding` checkbox.
* We remove a couple of irrelevant test cases (missing protocol and invalid port will yeild a runtime error anyway or will be filtered out by the Modeler's regex).

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #4810 

## Checklist

- [ ] PR has a **milestone** or the `no milestone` label.

