### PR TITLE
fix(deps): declare google http client dependency directly

### DIFF
--- a/connectors/http/http-base/pom.xml
+++ b/connectors/http/http-base/pom.xml
@@ -35,6 +35,10 @@ limitations under the License.</license.inlineheader>
 
   <dependencies>
     <dependency>
+      <groupId>com.google.http-client</groupId>
+      <artifactId>google-http-client</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.google.auth</groupId>
       <artifactId>google-auth-library-oauth2-http</artifactId>
     </dependency>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -103,7 +103,6 @@ limitations under the License.</license.inlineheader>
 
     <version.google-api-client>2.8.0</version.google-api-client>
 
-    <!-- TODO: Remove this fixed version, see https://github.com/camunda/connectors/issues/4810 -->
     <version.google-http-client>1.45.2</version.google-http-client>
 
     <version.google-api-services-drive>v3-rev20250511-2.0.0</version.google-api-services-drive>


### PR DESCRIPTION
## Description

We use Google's HTTP client for URL encoding. This PR declares it as a direct dependency instead of using it transitively.

This is a backported subset of changes introduced in #4877 

## Related issues

<!-- Which issues are closed by this PR or are related -->

related #4810 

## Checklist

- [ ] PR has a **milestone** or the `no milestone` label.

