### PR TITLE
[Backport release/8.6] fix(CustomApacheHttpClientTest): Set max file descriptors in squid

### DIFF
--- a/connectors/http/http-base/src/test/java/io/camunda/connector/http/base/client/apache/CustomApacheHttpClientTest.java
+++ b/connectors/http/http-base/src/test/java/io/camunda/connector/http/base/client/apache/CustomApacheHttpClientTest.java
@@ -124,7 +124,6 @@ public class CustomApacheHttpClientTest {
 
     @AfterAll
     public static void tearDown() {
-      proxyContainer.stop();
       System.setProperty("http.proxyHost", "");
       System.setProperty("http.proxyPort", "");
       System.setProperty("http.nonProxyHosts", "");
@@ -132,6 +131,7 @@ public class CustomApacheHttpClientTest {
       System.setProperty("https.proxyPort", "");
       System.setProperty("https.nonProxyHosts", "");
       proxy.stop();
+      proxyContainer.stop();
     }
 
     @AfterEach

--- a/connectors/http/http-base/src/test/resources/squid.conf
+++ b/connectors/http/http-base/src/test/resources/squid.conf
@@ -9,3 +9,4 @@ acl CONNECT method CONNECT
 # Allow all outgoing HTTP/HTTPS traffic
 http_access allow all
 
+max_filedescriptors 65536


### PR DESCRIPTION
# Description

Backport of https://github.com/camunda/connectors/pull/4872 to release/8.6.