### PR TITLE
ci: upgrade camunda-release-parent to 4.0.0 and switch to Central Portal deployment

### DIFF
--- a/.github/workflows/RELEASE.yaml
+++ b/.github/workflows/RELEASE.yaml
@@ -168,7 +168,7 @@ jobs:
 
       - name: Deploy artifacts to Artifactory and Maven Central (Staging)
         if: "! contains(github.event.release.tag_name, 'rc')"
-        run: mvn deploy -DskipTests -PcheckFormat -Psonatype-oss-release
+        run: mvn deploy -DskipTests -PcheckFormat -Pcentral-sonatype-publish
         env:
           NEXUS_USR: ${{ steps.secrets.outputs.ARTIFACTORY_USR }}
           NEXUS_PSW: ${{ steps.secrets.outputs.ARTIFACTORY_PSW }}
@@ -178,7 +178,7 @@ jobs:
 
       - name: Deploy artifacts to Artifactory
         if: "contains(github.event.release.tag_name, 'rc')"
-        run: mvn deploy -DskipTests -PcheckFormat -Psonatype-oss-release -Dskip.central.release=true
+        run: mvn deploy -DskipTests -PcheckFormat -Pcentral-sonatype-publish -Dskip.central.release=true
         env:
           NEXUS_USR: ${{ steps.secrets.outputs.ARTIFACTORY_USR }}
           NEXUS_PSW: ${{ steps.secrets.outputs.ARTIFACTORY_PSW }}

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.camunda</groupId>
     <artifactId>camunda-release-parent</artifactId>
-    <version>3.9.1</version>
+    <version>4.0.0</version>
     <!-- do not remove empty tag - http://jira.codehaus.org/browse/MNG-4687 -->
     <relativePath/>
   </parent>
@@ -68,7 +68,6 @@ limitations under the License.</license.inlineheader>
     <!-- release parent settings -->
     <nexus.snapshot.repository>https://artifacts.camunda.com/artifactory/connectors-snapshots/</nexus.snapshot.repository>
     <nexus.release.repository>https://artifacts.camunda.com/artifactory/connectors/</nexus.release.repository>
-    <nexus.sonatype.url>https://s01.oss.sonatype.org</nexus.sonatype.url>
 
     <!-- Camunda internal libraries -->
     <version.camunda>8.8.0-SNAPSHOT</version.camunda>
@@ -978,7 +977,7 @@ limitations under the License.</license.inlineheader>
     </profile>
 
     <profile>
-      <id>sonatype-oss-release</id>
+      <id>central-sonatype-publish</id>
       <build>
         <pluginManagement>
           <plugins>


### PR DESCRIPTION
## Description

Related to https://github.com/camunda/team-infrastructure/issues/833.

This PR upgrades the `camunda-release-parent `POM to version 4.0.0 and switches to the new `central-sonatype-publish` profile. This is part of our [migration](https://github.com/camunda/camunda-release-parent/blob/infra-833-prepare-migration/README.md) to the new Sonatype Central Portal.

Sonatype is deprecating the legacy OSSRH Staging API, and the migration affects all Camunda namespaces (io.camunda, org.camunda). Publishing via OSSRH will no longer be possible once the namespaces are migrated.

To ensure a smooth transition, I have surfaced changes in terms of plugin execution, and test deployment of an (empty) test submodule to a test namespace.

<details>
  <summary>TEST Submodule POM</summary>

```xml
<?xml version="1.0" encoding="UTF-8"?>
<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

  <modelVersion>4.0.0</modelVersion>

  <parent>
    <groupId>io.camunda.connector</groupId>
    <artifactId>connector-parent</artifactId>
    <relativePath>../parent/pom.xml</relativePath>
    <version>8.8.0-SNAPSHOT</version>
  </parent>

  <groupId>io.github.clementnero.maven-poc-833.camunda.connectors</groupId>
  <artifactId>infra-833-test</artifactId>
  <version>1.0.0-SNAPSHOT</version>
  <packaging>pom</packaging>

  <name>Infra 833 Test</name>

  <properties>
    <!-- Camund Nexus / Artifactory  -->
    <skip.camunda.release>false</skip.camunda.release>
    <nexus.release.repository>https://artifacts.camunda.com/artifactory/camunda-internal</nexus.release.repository>
    <nexus.snapshot.repository>https://artifacts.camunda.com/artifactory/camunda-internal-snapshots</nexus.snapshot.repository>
    <!-- Maven Central -->
    <skip.central.release>false</skip.central.release>
    <deploymentName>https://github.com/camunda/connectors - Infra 833 Test</deploymentName>
  </properties>

</project>
```
</details>


### Plugins

To prevent any unexpected issue with plugin executions, I compared the effective <plugins> and <pluginManagement> sections using versions 3.9.1 and 4.0.0 of the parent POM to quickly surface any odd config changes that might affect behavior.

<details>
  <summary>Effective-plugins when using <strong>camunda-release-parent.3.9.1</strong> POM</summary>

```xml
mvnw help:effective-pom -Psonatype-oss-release

[effective-plugins.camunda-release-parent.3.9.1.xml.gz](https://github.com/user-attachments/files/20751605/effective-plugins.camunda-release-parent.3.9.1.xml.gz)
```
</details> 

<details>
  <summary>Effective-plugins when using <strong>camunda-release-parent.4.0.0</strong> POM</summary>

```xml
mvnw help:effective-pom -Pcentral-sonatype-publish

[effective-plugins.camunda-release-parent.4.0.0.xml.gz](https://github.com/user-attachments/files/20751612/effective-plugins.camunda-release-parent.4.0.0.xml.gz)
```
</details> 

Effective changes:

TL;DR ✅ 
- The `central-sonatype-publish` profile is now the default and is appended to the value of `arguments` property of the `maven-release-plugin`.
- The `nexus-staging-maven-plugin` has been updated to a newer patch version.
- A new `id:central-deploy` execution of the `central-publishing-maven-plugin` is configured, replacing the previous `id:central-deploy` execution from the `nexus-staging-maven-plugin`.
- The `nexusUrl` of the `id:default-deploy` execution from the `nexus-staging-maven-plugin` now points to the correct URL but is skipped because `skipStaging` is set to true.

```diff
@@ -11,10 +11,15 @@
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>
         <version>3.6.1</version>
       </plugin>
       <plugin>
+        <groupId>org.sonatype.central</groupId>
+        <artifactId>central-publishing-maven-plugin</artifactId>
+        <version>0.7.0</version>
+      </plugin>
+      <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>exec-maven-plugin</artifactId>
         <version>3.5.1</version>
         <executions>
           <execution>
@@ -485,11 +490,11 @@
         <artifactId>maven-release-plugin</artifactId>
         <version>2.5.3</version>
         <configuration>
           <mavenExecutorId>forked-path</mavenExecutorId>
           <useReleaseProfile>false</useReleaseProfile>
-          <arguments>${arguments} -Psonatype-oss-release</arguments>
+          <arguments>${arguments} -Pcentral-sonatype-publish</arguments>
         </configuration>
       </plugin>
       <plugin>
         <artifactId>maven-resources-plugin</artifactId>
         <version>3.3.1</version>
@@ -549,11 +554,11 @@
         </configuration>
       </plugin>
       <plugin>
         <groupId>org.sonatype.plugins</groupId>
         <artifactId>nexus-staging-maven-plugin</artifactId>
-        <version>1.6.8</version>
+        <version>1.6.13</version>
       </plugin>
       <plugin>
         <groupId>org.openapitools</groupId>
         <artifactId>openapi-generator-maven-plugin</artifactId>
         <version>7.12.0</version>
@@ -702,10 +707,39 @@
       </plugin>
     </plugins>
   </pluginManagement>
   <plugins>
     <plugin>
+      <groupId>org.sonatype.central</groupId>
+      <artifactId>central-publishing-maven-plugin</artifactId>
+      <version>0.7.0</version>
+      <extensions>true</extensions>
+      <executions>
+        <execution>
+          <id>central-deploy</id>
+          <phase>deploy</phase>
+          <goals>
+            <goal>publish</goal>
+          </goals>
+          <configuration>
+            <autoPublish>false</autoPublish>
+            <deploymentName>https://github.com/camunda/camunda - Infra 833 Test</deploymentName>
+            <failOnBuildFailure>true</failOnBuildFailure>
+            <publishingServerId>central</publishingServerId>
+            <skipPublishing>false</skipPublishing>
+          </configuration>
+        </execution>
+      </executions>
+      <configuration>
+        <autoPublish>false</autoPublish>
+        <deploymentName>https://github.com/camunda/camunda - Infra 833 Test</deploymentName>
+        <failOnBuildFailure>true</failOnBuildFailure>
+        <publishingServerId>central</publishingServerId>
+        <skipPublishing>false</skipPublishing>
+      </configuration>
+    </plugin>
+    <plugin>
       <groupId>org.codehaus.mojo</groupId>
       <artifactId>flatten-maven-plugin</artifactId>
       <version>1.7.0</version>
       <executions>
         <execution>
@@ -1159,11 +1193,11 @@
       </configuration>
     </plugin>
     <plugin>
       <groupId>org.sonatype.plugins</groupId>
       <artifactId>nexus-staging-maven-plugin</artifactId>
-      <version>1.6.8</version>
+      <version>1.6.13</version>
       <extensions>true</extensions>
       <executions>
         <execution>
           <id>default-deploy</id>
           <phase>deploy</phase>
@@ -1171,29 +1205,12 @@
             <goal>deploy</goal>
           </goals>
           <configuration>
             <detectBuildFailures>true</detectBuildFailures>
             <serverId>camunda-nexus</serverId>
-            <nexusUrl>https://app.camunda.com/nexus</nexusUrl>
+            <nexusUrl>https://artifacts.camunda.com/artifactory</nexusUrl>
             <skipStaging>true</skipStaging>
-            <skipNexusStagingDeployMojo>false</skipNexusStagingDeployMojo>
-            <stagingProgressTimeoutMinutes>40</stagingProgressTimeoutMinutes>
-          </configuration>
-        </execution>
-        <execution>
-          <id>central-deploy</id>
-          <phase>deploy</phase>
-          <goals>
-            <goal>deploy</goal>
-          </goals>
-          <configuration>
-            <detectBuildFailures>true</detectBuildFailures>
-            <keepStagingRepositoryOnFailure>true</keepStagingRepositoryOnFailure>
-            <keepStagingRepositoryOnCloseRuleFailure>true</keepStagingRepositoryOnCloseRuleFailure>
-            <serverId>central</serverId>
-            <nexusUrl>https://s01.oss.sonatype.org</nexusUrl>
-            <skipStaging>false</skipStaging>
             <skipNexusStagingDeployMojo>false</skipNexusStagingDeployMojo>
             <stagingProgressTimeoutMinutes>40</stagingProgressTimeoutMinutes>
           </configuration>
         </execution>
       </executions>
```

### Deployment

To ensure artifact deployment continues to work, I performed one locally using `release:prepare` and `release:perform` plugin goals (maven-release-plugin).

For this, I used a minimal empty test submodulemodule inheriting the project’s (parent) POMs but changed the groupId to a test namespace (io.github.clementnero).

<details>
  <summary>Deployment logs</summary>

```log
mvn clean release:prepare release:perform --batch-mode -DreleaseVersion=1.0.0 -DlocalCheckout=true -DpushChanges=false -DremoteTagging=false -Darguments=-Dgpg.passphrase=*** -DignoreSnapshots=true

[INFO] Scanning for projects...
[INFO] Inspecting build with total of 1 modules...
[INFO] Not installing Nexus Staging features:
[INFO]  * Preexisting staging related goal bindings found in 1 modules.
[INFO] 
[INFO] --< io.github.clementnero.maven-poc-833.camunda.connectors:infra-833-test >--
[INFO] Building Infra 833 Test 1.0.0-SNAPSHOT
[INFO]   from pom.xml
[INFO] --------------------------------[ pom ]---------------------------------
[INFO] 
[INFO] --- clean:3.1.0:clean (default-clean) @ infra-833-test ---
[INFO] Deleting /Users/clement.nero/camunda/connectors/infra-833-test/target
[INFO] 
[INFO] --< io.github.clementnero.maven-poc-833.camunda.connectors:infra-833-test >--
[INFO] Building Infra 833 Test 1.0.0-SNAPSHOT
[INFO]   from pom.xml
[INFO] --------------------------------[ pom ]---------------------------------
[INFO] 
[INFO] --- release:2.5.3:prepare (default-cli) @ infra-833-test ---
[INFO] Verifying that there are no local modifications...
[INFO]   ignoring changes on: **/pom.xml.releaseBackup, **/pom.xml.next, **/pom.xml.tag, **/pom.xml.branch, **/release.properties, **/pom.xml.backup
[INFO] Executing: /bin/sh -c cd /Users/clement.nero/camunda/connectors/infra-833-test && git rev-parse --show-toplevel
[INFO] Working directory: /Users/clement.nero/camunda/connectors/infra-833-test
[INFO] Executing: /bin/sh -c cd /Users/clement.nero/camunda/connectors/infra-833-test && git status --porcelain .
[INFO] Working directory: /Users/clement.nero/camunda/connectors/infra-833-test
[WARNING] Ignoring unrecognized line: ?? infra-833-test/release.properties
[INFO] Ignoring SNAPSHOT depenedencies and plugins ...
[INFO] Transforming 'Infra 833 Test'...
[INFO] Not generating release POMs
[INFO] Executing goals 'clean verify'...
[INFO] Executing: /bin/sh -c cd /Users/clement.nero/camunda/connectors/infra-833-test && /opt/homebrew/Cellar/maven/3.9.9/libexec/bin/mvn -s /var/folders/zw/_30vxb_s0_qdhnsndcxf_nf00000gn/T/release-settings599942167876204026.xml clean verify --no-plugin-updates --batch-mode '-Dgpg.passphrase=c9@2WmUDC8GqNj(y9Ogv' -Pcentral-sonatype-publish
    [WARNING] Command line option -npu is deprecated and will be removed in future Maven versions.
    [INFO] Scanning for projects...
    [INFO] Inspecting build with total of 1 modules
    [INFO] Not installing Central Publishing features. Preexisting publish related goal bindings found in 1 modules.
    [INFO] Inspecting build with total of 1 modules...
    [INFO] Not installing Nexus Staging features:
    [INFO]  * Preexisting staging related goal bindings found in 1 modules.
    [INFO] 
    [INFO] --< io.github.clementnero.maven-poc-833.camunda.connectors:infra-833-test >--
    [INFO] Building Infra 833 Test 1.0.0
    [INFO]   from pom.xml
    [INFO] --------------------------------[ pom ]---------------------------------
    [INFO] 
    [INFO] --- clean:3.1.0:clean (default-clean) @ infra-833-test ---
    [INFO] 
    [INFO] --- enforcer:3.5.0:enforce (default) @ infra-833-test ---
    [INFO] Rule 0: org.apache.maven.enforcer.rules.RequirePluginVersions passed
    [INFO] 
    [INFO] --- source:3.2.1:jar-no-fork (attach-sources) @ infra-833-test ---
    [INFO] 
    [INFO] --- source:3.2.1:test-jar-no-fork (attach-test-sources) @ infra-833-test ---
    [INFO] 
    [INFO] --- javadoc:3.3.1:jar (attach-javadocs) @ infra-833-test ---
    [INFO] Not executing Javadoc as the project is not a Java classpath-capable package
    [INFO] 
    [INFO] --- gpg:3.0.1:sign (sign-artifacts) @ infra-833-test ---
    [INFO] ------------------------------------------------------------------------
    [INFO] BUILD SUCCESS
    [INFO] ------------------------------------------------------------------------
    [INFO] Total time:  1.569 s
    [INFO] Finished at: 2025-06-15T10:58:59+02:00
    [INFO] ------------------------------------------------------------------------
[INFO] Checking in modified POMs...
[INFO] Executing: /bin/sh -c cd /Users/clement.nero/camunda/connectors/infra-833-test && git add -- pom.xml
[INFO] Working directory: /Users/clement.nero/camunda/connectors/infra-833-test
[INFO] Executing: /bin/sh -c cd /Users/clement.nero/camunda/connectors/infra-833-test && git rev-parse --show-toplevel
[INFO] Working directory: /Users/clement.nero/camunda/connectors/infra-833-test
[INFO] Executing: /bin/sh -c cd /Users/clement.nero/camunda/connectors/infra-833-test && git status --porcelain .
[INFO] Working directory: /Users/clement.nero/camunda/connectors/infra-833-test
[WARNING] Ignoring unrecognized line: ?? infra-833-test/pom.xml.releaseBackup
[WARNING] Ignoring unrecognized line: ?? infra-833-test/release.properties
[INFO] Executing: /bin/sh -c cd /Users/clement.nero/camunda/connectors/infra-833-test && git commit --verbose -F /var/folders/zw/_30vxb_s0_qdhnsndcxf_nf00000gn/T/maven-scm-1675361198.commit pom.xml
[INFO] Working directory: /Users/clement.nero/camunda/connectors/infra-833-test
[INFO] Tagging release with the label infra-833-test-1.0.0...
[INFO] Executing: /bin/sh -c cd /Users/clement.nero/camunda/connectors/infra-833-test && git tag -F /var/folders/zw/_30vxb_s0_qdhnsndcxf_nf00000gn/T/maven-scm-1438109274.commit infra-833-test-1.0.0
[INFO] Working directory: /Users/clement.nero/camunda/connectors/infra-833-test
[INFO] Executing: /bin/sh -c cd /Users/clement.nero/camunda/connectors/infra-833-test && git ls-files
[INFO] Working directory: /Users/clement.nero/camunda/connectors/infra-833-test
[INFO] Transforming 'Infra 833 Test'...
[INFO] Not removing release POMs
[INFO] Checking in modified POMs...
[INFO] Executing: /bin/sh -c cd /Users/clement.nero/camunda/connectors/infra-833-test && git add -- pom.xml
[INFO] Working directory: /Users/clement.nero/camunda/connectors/infra-833-test
[INFO] Executing: /bin/sh -c cd /Users/clement.nero/camunda/connectors/infra-833-test && git rev-parse --show-toplevel
[INFO] Working directory: /Users/clement.nero/camunda/connectors/infra-833-test
[INFO] Executing: /bin/sh -c cd /Users/clement.nero/camunda/connectors/infra-833-test && git status --porcelain .
[INFO] Working directory: /Users/clement.nero/camunda/connectors/infra-833-test
[WARNING] Ignoring unrecognized line: ?? infra-833-test/pom.xml.releaseBackup
[WARNING] Ignoring unrecognized line: ?? infra-833-test/release.properties
[INFO] Executing: /bin/sh -c cd /Users/clement.nero/camunda/connectors/infra-833-test && git commit --verbose -F /var/folders/zw/_30vxb_s0_qdhnsndcxf_nf00000gn/T/maven-scm-1251693039.commit pom.xml
[INFO] Working directory: /Users/clement.nero/camunda/connectors/infra-833-test
[INFO] Release preparation complete.
[INFO] 
[INFO] --- release:2.5.3:perform (default-cli) @ infra-833-test ---
[INFO] Performing a LOCAL checkout from scm:git:file:///Users/clement.nero/camunda/connectors/infra-833-test
[INFO] Checking out the project to perform the release ...
[INFO] Executing: /bin/sh -c cd /Users/clement.nero/camunda/connectors/infra-833-test/target && git clone --branch infra-833-test-1.0.0 file:///Users/clement.nero/camunda/connectors/infra-833-test /Users/clement.nero/camunda/connectors/infra-833-test/target/checkout
[INFO] Working directory: /Users/clement.nero/camunda/connectors/infra-833-test/target
[INFO] Performing a LOCAL checkout from scm:git:file:///Users/clement.nero/camunda/connectors
[INFO] Checking out the project to perform the release ...
[INFO] Executing: /bin/sh -c cd /Users/clement.nero/camunda/connectors/infra-833-test/target && git clone --branch infra-833-test-1.0.0 file:///Users/clement.nero/camunda/connectors /Users/clement.nero/camunda/connectors/infra-833-test/target/checkout
[INFO] Working directory: /Users/clement.nero/camunda/connectors/infra-833-test/target
[INFO] Executing: /bin/sh -c cd /var/folders/zw/_30vxb_s0_qdhnsndcxf_nf00000gn/T/ && git ls-remote file:///Users/clement.nero/camunda/connectors
[INFO] Working directory: /var/folders/zw/_30vxb_s0_qdhnsndcxf_nf00000gn/T
[INFO] Executing: /bin/sh -c cd /Users/clement.nero/camunda/connectors/infra-833-test/target/checkout && git fetch file:///Users/clement.nero/camunda/connectors
[INFO] Working directory: /Users/clement.nero/camunda/connectors/infra-833-test/target/checkout
[INFO] Executing: /bin/sh -c cd /Users/clement.nero/camunda/connectors/infra-833-test/target/checkout && git checkout infra-833-test-1.0.0
[INFO] Working directory: /Users/clement.nero/camunda/connectors/infra-833-test/target/checkout
[INFO] Executing: /bin/sh -c cd /Users/clement.nero/camunda/connectors/infra-833-test/target/checkout && git ls-files
[INFO] Working directory: /Users/clement.nero/camunda/connectors/infra-833-test/target/checkout
[INFO] Invoking perform goals in directory /Users/clement.nero/camunda/connectors/infra-833-test/target/checkout/infra-833-test
[INFO] Executing goals 'deploy'...
[INFO] Executing: /bin/sh -c cd /Users/clement.nero/camunda/connectors/infra-833-test/target/checkout/infra-833-test && /opt/homebrew/Cellar/maven/3.9.9/libexec/bin/mvn -s /var/folders/zw/_30vxb_s0_qdhnsndcxf_nf00000gn/T/release-settings667642629516173040.xml deploy --no-plugin-updates --batch-mode '-Dgpg.passphrase=c9@2WmUDC8GqNj(y9Ogv' -Pcentral-sonatype-publish -f pom.xml
    [WARNING] Command line option -npu is deprecated and will be removed in future Maven versions.
    [INFO] Scanning for projects...
    [INFO] Inspecting build with total of 1 modules
    [INFO] Not installing Central Publishing features. Preexisting publish related goal bindings found in 1 modules.
    [INFO] Inspecting build with total of 1 modules...
    [INFO] Not installing Nexus Staging features:
    [INFO]  * Preexisting staging related goal bindings found in 1 modules.
    [INFO] 
    [INFO] --< io.github.clementnero.maven-poc-833.camunda.connectors:infra-833-test >--
    [INFO] Building Infra 833 Test 1.0.0
    [INFO]   from pom.xml
    [INFO] --------------------------------[ pom ]---------------------------------
    [INFO] 
    [INFO] --- enforcer:3.5.0:enforce (default) @ infra-833-test ---
    [INFO] Rule 0: org.apache.maven.enforcer.rules.RequirePluginVersions passed
    [INFO] 
    [INFO] --- source:3.2.1:jar-no-fork (attach-sources) @ infra-833-test ---
    [INFO] 
    [INFO] --- source:3.2.1:test-jar-no-fork (attach-test-sources) @ infra-833-test ---
    [INFO] 
    [INFO] --- javadoc:3.3.1:jar (attach-javadocs) @ infra-833-test ---
    [INFO] Not executing Javadoc as the project is not a Java classpath-capable package
    [INFO] 
    [INFO] --- gpg:3.0.1:sign (sign-artifacts) @ infra-833-test ---
    [INFO] 
    [INFO] --- install:3.1.4:install (default-install) @ infra-833-test ---
    [INFO] Installing /Users/clement.nero/camunda/connectors/infra-833-test/target/checkout/infra-833-test/pom.xml to /Users/clement.nero/.m2/repository/io/github/clementnero/maven-poc-833/camunda/connectors/infra-833-test/1.0.0/infra-833-test-1.0.0.pom
    [INFO] Installing /Users/clement.nero/camunda/connectors/infra-833-test/target/checkout/infra-833-test/target/infra-833-test-1.0.0.pom.asc to /Users/clement.nero/.m2/repository/io/github/clementnero/maven-poc-833/camunda/connectors/infra-833-test/1.0.0/infra-833-test-1.0.0.pom.asc
    [INFO] 
    [INFO] --- deploy:2.8.2:deploy (default-deploy) @ infra-833-test ---
    [INFO] Skipping artifact deployment
    [INFO] 
    [INFO] --- nexus-staging:1.6.13:deploy (default-deploy) @ infra-833-test ---
    [INFO] Performing deferred deploys (gathering into "/Users/clement.nero/camunda/connectors/infra-833-test/target/checkout/infra-833-test/target/nexus-staging/deferred")...
    [INFO] Installing /Users/clement.nero/camunda/connectors/infra-833-test/target/checkout/infra-833-test/pom.xml to /Users/clement.nero/camunda/connectors/infra-833-test/target/checkout/infra-833-test/target/nexus-staging/deferred/io/github/clementnero/maven-poc-833/camunda/connectors/infra-833-test/1.0.0/infra-833-test-1.0.0.pom
    [INFO] Installing /Users/clement.nero/camunda/connectors/infra-833-test/target/checkout/infra-833-test/target/infra-833-test-1.0.0.pom.asc to /Users/clement.nero/camunda/connectors/infra-833-test/target/checkout/infra-833-test/target/nexus-staging/deferred/io/github/clementnero/maven-poc-833/camunda/connectors/infra-833-test/1.0.0/infra-833-test-1.0.0.pom.asc
    [INFO] Deploying remotely...
    [INFO] Bulk deploying locally gathered artifacts from directory: 
    [INFO]  * Bulk deploying locally gathered snapshot artifacts
    [INFO] Uploading to camunda-nexus: https://artifacts.camunda.com/artifactory/camunda-internal/io/github/clementnero/maven-poc-833/camunda/connectors/infra-833-test/1.0.0/infra-833-test-1.0.0.pom.asc
    [INFO] Uploaded to camunda-nexus: https://artifacts.camunda.com/artifactory/camunda-internal/io/github/clementnero/maven-poc-833/camunda/connectors/infra-833-test/1.0.0/infra-833-test-1.0.0.pom.asc (659 B at 856 B/s)
    [INFO] Downloading from camunda-nexus: https://artifacts.camunda.com/artifactory/camunda-internal/io/github/clementnero/maven-poc-833/camunda/connectors/infra-833-test/maven-metadata.xml
    [INFO] Downloaded from camunda-nexus: https://artifacts.camunda.com/artifactory/camunda-internal/io/github/clementnero/maven-poc-833/camunda/connectors/infra-833-test/maven-metadata.xml (423 B at 5.2 kB/s)
    [INFO] Uploading to camunda-nexus: https://artifacts.camunda.com/artifactory/camunda-internal/io/github/clementnero/maven-poc-833/camunda/connectors/infra-833-test/maven-metadata.xml
    [INFO] Uploaded to camunda-nexus: https://artifacts.camunda.com/artifactory/camunda-internal/io/github/clementnero/maven-poc-833/camunda/connectors/infra-833-test/maven-metadata.xml (375 B at 1.0 kB/s)
    [INFO] Uploading to camunda-nexus: https://artifacts.camunda.com/artifactory/camunda-internal/io/github/clementnero/maven-poc-833/camunda/connectors/infra-833-test/1.0.0/infra-833-test-1.0.0.pom
    [INFO] Uploaded to camunda-nexus: https://artifacts.camunda.com/artifactory/camunda-internal/io/github/clementnero/maven-poc-833/camunda/connectors/infra-833-test/1.0.0/infra-833-test-1.0.0.pom (2.0 kB at 4.3 kB/s)
    [INFO]  * Bulk deploy of locally gathered snapshot artifacts finished.
    [INFO] Remote deploy finished with success.
    [INFO] 
    [INFO] --- central-publishing:0.7.0:publish (central-deploy) @ infra-833-test ---
    [INFO] Using Central baseUrl: https://central.sonatype.com
    [INFO] Using credentials from server id central in settings.xml
    [INFO] Using Usertoken auth, with namecode: g0xTmVDT
    [INFO] Staging 2 files
    [INFO] Staging /Users/clement.nero/camunda/connectors/infra-833-test/target/checkout/infra-833-test/pom.xml
    [INFO] Installing /Users/clement.nero/camunda/connectors/infra-833-test/target/checkout/infra-833-test/pom.xml to /Users/clement.nero/camunda/connectors/infra-833-test/target/checkout/infra-833-test/target/central-staging/io/github/clementnero/maven-poc-833/camunda/connectors/infra-833-test/1.0.0/infra-833-test-1.0.0.pom
    [INFO] Staging /Users/clement.nero/camunda/connectors/infra-833-test/target/checkout/infra-833-test/target/infra-833-test-1.0.0.pom.asc
    [INFO] Installing /Users/clement.nero/camunda/connectors/infra-833-test/target/checkout/infra-833-test/target/infra-833-test-1.0.0.pom.asc to /Users/clement.nero/camunda/connectors/infra-833-test/target/checkout/infra-833-test/target/central-staging/io/github/clementnero/maven-poc-833/camunda/connectors/infra-833-test/1.0.0/infra-833-test-1.0.0.pom.asc
    [INFO] Pre Bundling - deleted /Users/clement.nero/camunda/connectors/infra-833-test/target/checkout/infra-833-test/target/central-staging/io/github/clementnero/maven-poc-833/camunda/connectors/infra-833-test/maven-metadata-central-staging.xml
    [INFO] Generate checksums for dir: io/github/clementnero/maven-poc-833/camunda/connectors/infra-833-test/1.0.0
    [INFO] Going to create /Users/clement.nero/camunda/connectors/infra-833-test/target/checkout/infra-833-test/target/central-publishing/central-bundle.zip by bundling content at /Users/clement.nero/camunda/connectors/infra-833-test/target/checkout/infra-833-test/target/central-staging
    [INFO] Created bundle successfully /Users/clement.nero/camunda/connectors/infra-833-test/target/checkout/infra-833-test/target/central-staging/central-bundle.zip
    [INFO] Going to upload /Users/clement.nero/camunda/connectors/infra-833-test/target/checkout/infra-833-test/target/central-publishing/central-bundle.zip
    [INFO] Uploaded bundle successfully, deployment name: https://github.com/camunda/connectors - Infra 833 Test, deploymentId: 71884b79-7030-4c06-a6bb-f9175cae7373. Deployment will require manual publishing
    [INFO] Waiting until Deployment 71884b79-7030-4c06-a6bb-f9175cae7373 is validated
    [INFO] Deployment 71884b79-7030-4c06-a6bb-f9175cae7373 has been validated. To finish publishing visit https://central.sonatype.com/publishing/deployments
    [INFO] ------------------------------------------------------------------------
    [INFO] BUILD SUCCESS
    [INFO] ------------------------------------------------------------------------
    [INFO] Total time:  10.082 s
    [INFO] Finished at: 2025-06-15T10:59:13+02:00
    [INFO] ------------------------------------------------------------------------
[INFO] Cleaning up after release...
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  18.552 s
[INFO] Finished at: 2025-06-15T10:59:13+02:00
[INFO] ------------------------------------------------------------------------
```
</details>

Results:
- Artifactory: https://artifacts.camunda.com/ui/native/camunda-internal/io/github/clementnero/maven-poc-833/camunda/connectors/infra-833-test/1.0.0/
- Central Portal
    <img width="1585" alt="image" src="https://github.com/user-attachments/assets/05542f0d-3267-44fe-8941-2bf7150b5700" />

This changes has been tested the same way for all stable branches:
- `stable/8.8`
- `stable/8.7`
- `stable/8.6`
- `stable/8.5`
- `stable/8.4`

Merge conflicts for the RELEASE.yml worfklow when backporting changes will be fixed manually.

## Checklist

- [ ] PR has a **milestone** or the `no milestone` label.

