### PR TITLE
chore(deps): disable renovate for google http client on 8.7 and 8.6 branches

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -58,6 +58,16 @@
         "io.camunda.connector{/,}**"
       ],
       "enabled": false
+    },
+    {
+      "matchBaseBranches": [
+        "release/8.6",
+        "release/8.7"
+      ],
+      "matchPackagePrefixes": [
+        "com.google.http-client:google-http-client"
+      ],
+      "enabled": false
     }
   ],
   "baseBranches": [


### PR DESCRIPTION
## Description

#4878 has pinned the version. We don't want to upgrade it because it's a breaking change - we only upgrade it in 8.8+. Prior to 8.6, a different mechanism had been used for encoding.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #

## Checklist

- [ ] PR has a **milestone** or the `no milestone` label.

