### PR TITLE
fix(self-managed): fix SM so that inbound polling can be disabled again

### DIFF
--- a/connector-runtime/connector-runtime-application/src/main/java/io/camunda/connector/runtime/app/ConnectorRuntimeApplication.java
+++ b/connector-runtime/connector-runtime-application/src/main/java/io/camunda/connector/runtime/app/ConnectorRuntimeApplication.java
@@ -18,10 +18,8 @@ package io.camunda.connector.runtime.app;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.context.annotation.ComponentScan;
 
 @SpringBootApplication
-@ComponentScan(basePackages = "io.camunda.connector")
 public class ConnectorRuntimeApplication {
 
   public static void main(String[] args) {


### PR DESCRIPTION
## Description
[Slack discussion](https://camunda.slack.com/archives/C02JLRNQQ05/p1750069574377079)

Support ticket:
https://jira.camunda.com/browse/SUPPORT-27750


This PR removes the `@ComponentScan` annotation from the `ConnectorRuntimeApplication` class to address an issue where some beans (e.g InboundConnectorRestController) become required dependencies, even when inbound connectors are not in use.

### Context
In Camunda 8.7.3, users reported that the application fails to start if the Operate client is disabled — even though inbound connectors are not active. The error pointed to the `InboundConnectorRestController` bean, which was being picked up due to a `@ComponentScan` annotation [introduced in 8.7.](https://github.com/camunda/connectors/pull/4698/files)

### Investigation
@jonathanlukas first raised the issue and confirmed that disabling connector polling (CAMUNDA_CONNECTOR_POLLING_ENABLED=false) did not prevent the failure.

Further analysis revealed that the root cause was the `@ComponentScan` introduced to support the message outbound connector.

### Solution
We remove the `@ComponentScan` annotation from `ConnectorRuntimeApplication` to avoid loading optional components like the `InboundConnectorRestController` (and inbound configurations in general) when they are not needed.

