### PR TITLE
others(kafka-connector): introducing schema property group and others minor changes

### DIFF
--- a/connectors/kafka/element-templates/hybrid/kafka-inbound-connector-boundary-hybrid.json
+++ b/connectors/kafka/element-templates/hybrid/kafka-inbound-connector-boundary-hybrid.json
@@ -27,8 +27,8 @@
     "id" : "kafka",
     "label" : "Kafka"
   }, {
-    "id" : "message",
-    "label" : "Message deserialization"
+    "id" : "schema",
+    "label" : "Schema"
   }, {
     "id" : "activation",
     "label" : "Activation"
@@ -189,7 +189,7 @@
     "id" : "schemaStrategy.type",
     "label" : "Schema strategy",
     "value" : "noSchema",
-    "group" : "kafka",
+    "group" : "schema",
     "binding" : {
       "name" : "schemaStrategy.type",
       "type" : "zeebe:property"
@@ -199,19 +199,39 @@
       "name" : "No schema",
       "value" : "noSchema"
     }, {
-      "name" : "Inline schema",
+      "name" : "Avro Inline schema",
       "value" : "inlineSchema"
     }, {
-      "name" : "Schema registry",
+      "name" : "Confluent Schema registry",
       "value" : "schemaRegistry"
     } ]
+  }, {
+    "id" : "schemaStrategy.avro.schema",
+    "label" : "Schema",
+    "description" : "Avro inline schema for the message value",
+    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "required",
+    "group" : "schema",
+    "binding" : {
+      "name" : "schemaStrategy.schema",
+      "type" : "zeebe:property"
+    },
+    "condition" : {
+      "property" : "schemaStrategy.type",
+      "equals" : "inlineSchema",
+      "type" : "simple"
+    },
+    "type" : "Text"
   }, {
     "id" : "schemaStrategy.schemaType",
     "label" : "Schema type",
     "description" : "Select the schema type. For details, visit the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/kafka/?kafka=inbound\" target=\"_blank\">documentation</a>",
     "optional" : false,
     "value" : "avro",
-    "group" : "kafka",
+    "group" : "schema",
     "binding" : {
       "name" : "schemaStrategy.schemaType",
       "type" : "zeebe:property"
@@ -226,7 +246,7 @@
       "name" : "JSON",
       "value" : "json"
     }, {
-      "name" : "Avro (alpha)",
+      "name" : "Avro",
       "value" : "avro"
     } ]
   }, {
@@ -237,7 +257,7 @@
     "constraints" : {
       "notEmpty" : true
     },
-    "group" : "kafka",
+    "group" : "schema",
     "binding" : {
       "name" : "schemaStrategy.schemaRegistryUrl",
       "type" : "zeebe:property"
@@ -248,26 +268,6 @@
       "type" : "simple"
     },
     "type" : "String"
-  }, {
-    "id" : "schemaStrategy.avro.schema",
-    "label" : "Schema",
-    "description" : "Inline schema (Avro) for the message value",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "feel" : "required",
-    "group" : "message",
-    "binding" : {
-      "name" : "schemaStrategy.schema",
-      "type" : "zeebe:property"
-    },
-    "condition" : {
-      "property" : "schemaStrategy.type",
-      "equals" : "inlineSchema",
-      "type" : "simple"
-    },
-    "type" : "Text"
   }, {
     "id" : "activationCondition",
     "label" : "Activation condition",

--- a/connectors/kafka/element-templates/hybrid/kafka-inbound-connector-intermediate-hybrid.json
+++ b/connectors/kafka/element-templates/hybrid/kafka-inbound-connector-intermediate-hybrid.json
@@ -27,8 +27,8 @@
     "id" : "kafka",
     "label" : "Kafka"
   }, {
-    "id" : "message",
-    "label" : "Message deserialization"
+    "id" : "schema",
+    "label" : "Schema"
   }, {
     "id" : "activation",
     "label" : "Activation"
@@ -189,7 +189,7 @@
     "id" : "schemaStrategy.type",
     "label" : "Schema strategy",
     "value" : "noSchema",
-    "group" : "kafka",
+    "group" : "schema",
     "binding" : {
       "name" : "schemaStrategy.type",
       "type" : "zeebe:property"
@@ -199,19 +199,39 @@
       "name" : "No schema",
       "value" : "noSchema"
     }, {
-      "name" : "Inline schema",
+      "name" : "Avro Inline schema",
       "value" : "inlineSchema"
     }, {
-      "name" : "Schema registry",
+      "name" : "Confluent Schema registry",
       "value" : "schemaRegistry"
     } ]
+  }, {
+    "id" : "schemaStrategy.avro.schema",
+    "label" : "Schema",
+    "description" : "Avro inline schema for the message value",
+    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "required",
+    "group" : "schema",
+    "binding" : {
+      "name" : "schemaStrategy.schema",
+      "type" : "zeebe:property"
+    },
+    "condition" : {
+      "property" : "schemaStrategy.type",
+      "equals" : "inlineSchema",
+      "type" : "simple"
+    },
+    "type" : "Text"
   }, {
     "id" : "schemaStrategy.schemaType",
     "label" : "Schema type",
     "description" : "Select the schema type. For details, visit the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/kafka/?kafka=inbound\" target=\"_blank\">documentation</a>",
     "optional" : false,
     "value" : "avro",
-    "group" : "kafka",
+    "group" : "schema",
     "binding" : {
       "name" : "schemaStrategy.schemaType",
       "type" : "zeebe:property"
@@ -226,7 +246,7 @@
       "name" : "JSON",
       "value" : "json"
     }, {
-      "name" : "Avro (alpha)",
+      "name" : "Avro",
       "value" : "avro"
     } ]
   }, {
@@ -237,7 +257,7 @@
     "constraints" : {
       "notEmpty" : true
     },
-    "group" : "kafka",
+    "group" : "schema",
     "binding" : {
       "name" : "schemaStrategy.schemaRegistryUrl",
       "type" : "zeebe:property"
@@ -248,26 +268,6 @@
       "type" : "simple"
     },
     "type" : "String"
-  }, {
-    "id" : "schemaStrategy.avro.schema",
-    "label" : "Schema",
-    "description" : "Inline schema (Avro) for the message value",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "feel" : "required",
-    "group" : "message",
-    "binding" : {
-      "name" : "schemaStrategy.schema",
-      "type" : "zeebe:property"
-    },
-    "condition" : {
-      "property" : "schemaStrategy.type",
-      "equals" : "inlineSchema",
-      "type" : "simple"
-    },
-    "type" : "Text"
   }, {
     "id" : "activationCondition",
     "label" : "Activation condition",

--- a/connectors/kafka/element-templates/hybrid/kafka-inbound-connector-start-message-hybrid.json
+++ b/connectors/kafka/element-templates/hybrid/kafka-inbound-connector-start-message-hybrid.json
@@ -27,8 +27,8 @@
     "id" : "kafka",
     "label" : "Kafka"
   }, {
-    "id" : "message",
-    "label" : "Message deserialization"
+    "id" : "schema",
+    "label" : "Schema"
   }, {
     "id" : "activation",
     "label" : "Activation"
@@ -189,7 +189,7 @@
     "id" : "schemaStrategy.type",
     "label" : "Schema strategy",
     "value" : "noSchema",
-    "group" : "kafka",
+    "group" : "schema",
     "binding" : {
       "name" : "schemaStrategy.type",
       "type" : "zeebe:property"
@@ -199,19 +199,39 @@
       "name" : "No schema",
       "value" : "noSchema"
     }, {
-      "name" : "Inline schema",
+      "name" : "Avro Inline schema",
       "value" : "inlineSchema"
     }, {
-      "name" : "Schema registry",
+      "name" : "Confluent Schema registry",
       "value" : "schemaRegistry"
     } ]
+  }, {
+    "id" : "schemaStrategy.avro.schema",
+    "label" : "Schema",
+    "description" : "Avro inline schema for the message value",
+    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "required",
+    "group" : "schema",
+    "binding" : {
+      "name" : "schemaStrategy.schema",
+      "type" : "zeebe:property"
+    },
+    "condition" : {
+      "property" : "schemaStrategy.type",
+      "equals" : "inlineSchema",
+      "type" : "simple"
+    },
+    "type" : "Text"
   }, {
     "id" : "schemaStrategy.schemaType",
     "label" : "Schema type",
     "description" : "Select the schema type. For details, visit the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/kafka/?kafka=inbound\" target=\"_blank\">documentation</a>",
     "optional" : false,
     "value" : "avro",
-    "group" : "kafka",
+    "group" : "schema",
     "binding" : {
       "name" : "schemaStrategy.schemaType",
       "type" : "zeebe:property"
@@ -226,7 +246,7 @@
       "name" : "JSON",
       "value" : "json"
     }, {
-      "name" : "Avro (alpha)",
+      "name" : "Avro",
       "value" : "avro"
     } ]
   }, {
@@ -237,7 +257,7 @@
     "constraints" : {
       "notEmpty" : true
     },
-    "group" : "kafka",
+    "group" : "schema",
     "binding" : {
       "name" : "schemaStrategy.schemaRegistryUrl",
       "type" : "zeebe:property"
@@ -248,26 +268,6 @@
       "type" : "simple"
     },
     "type" : "String"
-  }, {
-    "id" : "schemaStrategy.avro.schema",
-    "label" : "Schema",
-    "description" : "Inline schema (Avro) for the message value",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "feel" : "required",
-    "group" : "message",
-    "binding" : {
-      "name" : "schemaStrategy.schema",
-      "type" : "zeebe:property"
-    },
-    "condition" : {
-      "property" : "schemaStrategy.type",
-      "equals" : "inlineSchema",
-      "type" : "simple"
-    },
-    "type" : "Text"
   }, {
     "id" : "activationCondition",
     "label" : "Activation condition",

--- a/connectors/kafka/element-templates/hybrid/kafka-outbound-connector-hybrid.json
+++ b/connectors/kafka/element-templates/hybrid/kafka-outbound-connector-hybrid.json
@@ -26,6 +26,9 @@
     "id" : "kafka",
     "label" : "Kafka"
   }, {
+    "id" : "schema",
+    "label" : "Schema"
+  }, {
     "id" : "message",
     "label" : "Message"
   }, {
@@ -105,10 +108,22 @@
     },
     "type" : "String"
   }, {
+    "id" : "additionalProperties",
+    "label" : "Additional properties",
+    "description" : "Provide additional Kafka producer properties in JSON",
+    "optional" : true,
+    "feel" : "required",
+    "group" : "kafka",
+    "binding" : {
+      "name" : "additionalProperties",
+      "type" : "zeebe:input"
+    },
+    "type" : "String"
+  }, {
     "id" : "schemaStrategy.type",
     "label" : "Schema strategy",
     "value" : "noSchema",
-    "group" : "kafka",
+    "group" : "schema",
     "binding" : {
       "name" : "schemaStrategy.type",
       "type" : "zeebe:input"
@@ -118,19 +133,59 @@
       "name" : "No schema",
       "value" : "noSchema"
     }, {
-      "name" : "Inline schema",
+      "name" : "Avro Inline schema",
       "value" : "inlineSchema"
     }, {
-      "name" : "Schema registry",
+      "name" : "Confluent Schema registry",
       "value" : "schemaRegistry"
     } ]
+  }, {
+    "id" : "schemaStrategy.avro.schema",
+    "label" : "Schema",
+    "description" : "Avro inline schema for the message value",
+    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "required",
+    "group" : "schema",
+    "binding" : {
+      "name" : "schemaStrategy.schema",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "schemaStrategy.type",
+      "equals" : "inlineSchema",
+      "type" : "simple"
+    },
+    "type" : "Text"
+  }, {
+    "id" : "schemaStrategy.schema",
+    "label" : "Schema",
+    "description" : "Schema (JSON or AVRO) for the message value",
+    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "required",
+    "group" : "schema",
+    "binding" : {
+      "name" : "schemaStrategy.schema",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "schemaStrategy.type",
+      "equals" : "schemaRegistry",
+      "type" : "simple"
+    },
+    "type" : "Text"
   }, {
     "id" : "schemaStrategy.schemaType",
     "label" : "Schema type",
     "description" : "Select the schema type. For details, visit the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/kafka/?kafka=inbound\" target=\"_blank\">documentation</a>",
     "optional" : false,
     "value" : "avro",
-    "group" : "kafka",
+    "group" : "schema",
     "binding" : {
       "name" : "schemaStrategy.schemaType",
       "type" : "zeebe:input"
@@ -145,7 +200,7 @@
       "name" : "JSON",
       "value" : "json"
     }, {
-      "name" : "Avro (alpha)",
+      "name" : "Avro",
       "value" : "avro"
     } ]
   }, {
@@ -157,7 +212,7 @@
       "notEmpty" : true
     },
     "feel" : "optional",
-    "group" : "kafka",
+    "group" : "schema",
     "binding" : {
       "name" : "schemaStrategy.schemaRegistryUrl",
       "type" : "zeebe:input"
@@ -166,30 +221,6 @@
       "property" : "schemaStrategy.type",
       "equals" : "schemaRegistry",
       "type" : "simple"
-    },
-    "type" : "String"
-  }, {
-    "id" : "headers",
-    "label" : "Headers",
-    "description" : "Provide Kafka producer headers in JSON",
-    "optional" : true,
-    "feel" : "required",
-    "group" : "kafka",
-    "binding" : {
-      "name" : "headers",
-      "type" : "zeebe:input"
-    },
-    "type" : "String"
-  }, {
-    "id" : "additionalProperties",
-    "label" : "Additional properties",
-    "description" : "Provide additional Kafka producer properties in JSON",
-    "optional" : true,
-    "feel" : "required",
-    "group" : "kafka",
-    "binding" : {
-      "name" : "additionalProperties",
-      "type" : "zeebe:input"
     },
     "type" : "String"
   }, {
@@ -220,45 +251,17 @@
     },
     "type" : "String"
   }, {
-    "id" : "schemaStrategy.avro.schema",
-    "label" : "Schema",
-    "description" : "Inline schema (Avro) for the message value",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
+    "id" : "headers",
+    "label" : "Headers",
+    "description" : "Provide Kafka producer headers in JSON",
+    "optional" : true,
     "feel" : "required",
     "group" : "message",
     "binding" : {
-      "name" : "schemaStrategy.schema",
+      "name" : "headers",
       "type" : "zeebe:input"
     },
-    "condition" : {
-      "property" : "schemaStrategy.type",
-      "equals" : "inlineSchema",
-      "type" : "simple"
-    },
-    "type" : "Text"
-  }, {
-    "id" : "schemaStrategy.schema",
-    "label" : "Schema",
-    "description" : "Schema (JSON or AVRO) for the message value",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "feel" : "required",
-    "group" : "message",
-    "binding" : {
-      "name" : "schemaStrategy.schema",
-      "type" : "zeebe:input"
-    },
-    "condition" : {
-      "property" : "schemaStrategy.type",
-      "equals" : "schemaRegistry",
-      "type" : "simple"
-    },
-    "type" : "Text"
+    "type" : "String"
   }, {
     "id" : "version",
     "label" : "Version",

--- a/connectors/kafka/element-templates/kafka-inbound-connector-boundary.json
+++ b/connectors/kafka/element-templates/kafka-inbound-connector-boundary.json
@@ -24,8 +24,8 @@
     "id" : "kafka",
     "label" : "Kafka"
   }, {
-    "id" : "message",
-    "label" : "Message deserialization"
+    "id" : "schema",
+    "label" : "Schema"
   }, {
     "id" : "activation",
     "label" : "Activation"
@@ -184,7 +184,7 @@
     "id" : "schemaStrategy.type",
     "label" : "Schema strategy",
     "value" : "noSchema",
-    "group" : "kafka",
+    "group" : "schema",
     "binding" : {
       "name" : "schemaStrategy.type",
       "type" : "zeebe:property"
@@ -194,19 +194,39 @@
       "name" : "No schema",
       "value" : "noSchema"
     }, {
-      "name" : "Inline schema",
+      "name" : "Avro Inline schema",
       "value" : "inlineSchema"
     }, {
-      "name" : "Schema registry",
+      "name" : "Confluent Schema registry",
       "value" : "schemaRegistry"
     } ]
+  }, {
+    "id" : "schemaStrategy.avro.schema",
+    "label" : "Schema",
+    "description" : "Avro inline schema for the message value",
+    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "required",
+    "group" : "schema",
+    "binding" : {
+      "name" : "schemaStrategy.schema",
+      "type" : "zeebe:property"
+    },
+    "condition" : {
+      "property" : "schemaStrategy.type",
+      "equals" : "inlineSchema",
+      "type" : "simple"
+    },
+    "type" : "Text"
   }, {
     "id" : "schemaStrategy.schemaType",
     "label" : "Schema type",
     "description" : "Select the schema type. For details, visit the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/kafka/?kafka=inbound\" target=\"_blank\">documentation</a>",
     "optional" : false,
     "value" : "avro",
-    "group" : "kafka",
+    "group" : "schema",
     "binding" : {
       "name" : "schemaStrategy.schemaType",
       "type" : "zeebe:property"
@@ -221,7 +241,7 @@
       "name" : "JSON",
       "value" : "json"
     }, {
-      "name" : "Avro (alpha)",
+      "name" : "Avro",
       "value" : "avro"
     } ]
   }, {
@@ -232,7 +252,7 @@
     "constraints" : {
       "notEmpty" : true
     },
-    "group" : "kafka",
+    "group" : "schema",
     "binding" : {
       "name" : "schemaStrategy.schemaRegistryUrl",
       "type" : "zeebe:property"
@@ -243,26 +263,6 @@
       "type" : "simple"
     },
     "type" : "String"
-  }, {
-    "id" : "schemaStrategy.avro.schema",
-    "label" : "Schema",
-    "description" : "Inline schema (Avro) for the message value",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "feel" : "required",
-    "group" : "message",
-    "binding" : {
-      "name" : "schemaStrategy.schema",
-      "type" : "zeebe:property"
-    },
-    "condition" : {
-      "property" : "schemaStrategy.type",
-      "equals" : "inlineSchema",
-      "type" : "simple"
-    },
-    "type" : "Text"
   }, {
     "id" : "activationCondition",
     "label" : "Activation condition",

--- a/connectors/kafka/element-templates/kafka-inbound-connector-intermediate.json
+++ b/connectors/kafka/element-templates/kafka-inbound-connector-intermediate.json
@@ -24,8 +24,8 @@
     "id" : "kafka",
     "label" : "Kafka"
   }, {
-    "id" : "message",
-    "label" : "Message deserialization"
+    "id" : "schema",
+    "label" : "Schema"
   }, {
     "id" : "activation",
     "label" : "Activation"
@@ -184,7 +184,7 @@
     "id" : "schemaStrategy.type",
     "label" : "Schema strategy",
     "value" : "noSchema",
-    "group" : "kafka",
+    "group" : "schema",
     "binding" : {
       "name" : "schemaStrategy.type",
       "type" : "zeebe:property"
@@ -194,19 +194,39 @@
       "name" : "No schema",
       "value" : "noSchema"
     }, {
-      "name" : "Inline schema",
+      "name" : "Avro Inline schema",
       "value" : "inlineSchema"
     }, {
-      "name" : "Schema registry",
+      "name" : "Confluent Schema registry",
       "value" : "schemaRegistry"
     } ]
+  }, {
+    "id" : "schemaStrategy.avro.schema",
+    "label" : "Schema",
+    "description" : "Avro inline schema for the message value",
+    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "required",
+    "group" : "schema",
+    "binding" : {
+      "name" : "schemaStrategy.schema",
+      "type" : "zeebe:property"
+    },
+    "condition" : {
+      "property" : "schemaStrategy.type",
+      "equals" : "inlineSchema",
+      "type" : "simple"
+    },
+    "type" : "Text"
   }, {
     "id" : "schemaStrategy.schemaType",
     "label" : "Schema type",
     "description" : "Select the schema type. For details, visit the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/kafka/?kafka=inbound\" target=\"_blank\">documentation</a>",
     "optional" : false,
     "value" : "avro",
-    "group" : "kafka",
+    "group" : "schema",
     "binding" : {
       "name" : "schemaStrategy.schemaType",
       "type" : "zeebe:property"
@@ -221,7 +241,7 @@
       "name" : "JSON",
       "value" : "json"
     }, {
-      "name" : "Avro (alpha)",
+      "name" : "Avro",
       "value" : "avro"
     } ]
   }, {
@@ -232,7 +252,7 @@
     "constraints" : {
       "notEmpty" : true
     },
-    "group" : "kafka",
+    "group" : "schema",
     "binding" : {
       "name" : "schemaStrategy.schemaRegistryUrl",
       "type" : "zeebe:property"
@@ -243,26 +263,6 @@
       "type" : "simple"
     },
     "type" : "String"
-  }, {
-    "id" : "schemaStrategy.avro.schema",
-    "label" : "Schema",
-    "description" : "Inline schema (Avro) for the message value",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "feel" : "required",
-    "group" : "message",
-    "binding" : {
-      "name" : "schemaStrategy.schema",
-      "type" : "zeebe:property"
-    },
-    "condition" : {
-      "property" : "schemaStrategy.type",
-      "equals" : "inlineSchema",
-      "type" : "simple"
-    },
-    "type" : "Text"
   }, {
     "id" : "activationCondition",
     "label" : "Activation condition",

--- a/connectors/kafka/element-templates/kafka-inbound-connector-start-message.json
+++ b/connectors/kafka/element-templates/kafka-inbound-connector-start-message.json
@@ -24,8 +24,8 @@
     "id" : "kafka",
     "label" : "Kafka"
   }, {
-    "id" : "message",
-    "label" : "Message deserialization"
+    "id" : "schema",
+    "label" : "Schema"
   }, {
     "id" : "activation",
     "label" : "Activation"
@@ -184,7 +184,7 @@
     "id" : "schemaStrategy.type",
     "label" : "Schema strategy",
     "value" : "noSchema",
-    "group" : "kafka",
+    "group" : "schema",
     "binding" : {
       "name" : "schemaStrategy.type",
       "type" : "zeebe:property"
@@ -194,19 +194,39 @@
       "name" : "No schema",
       "value" : "noSchema"
     }, {
-      "name" : "Inline schema",
+      "name" : "Avro Inline schema",
       "value" : "inlineSchema"
     }, {
-      "name" : "Schema registry",
+      "name" : "Confluent Schema registry",
       "value" : "schemaRegistry"
     } ]
+  }, {
+    "id" : "schemaStrategy.avro.schema",
+    "label" : "Schema",
+    "description" : "Avro inline schema for the message value",
+    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "required",
+    "group" : "schema",
+    "binding" : {
+      "name" : "schemaStrategy.schema",
+      "type" : "zeebe:property"
+    },
+    "condition" : {
+      "property" : "schemaStrategy.type",
+      "equals" : "inlineSchema",
+      "type" : "simple"
+    },
+    "type" : "Text"
   }, {
     "id" : "schemaStrategy.schemaType",
     "label" : "Schema type",
     "description" : "Select the schema type. For details, visit the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/kafka/?kafka=inbound\" target=\"_blank\">documentation</a>",
     "optional" : false,
     "value" : "avro",
-    "group" : "kafka",
+    "group" : "schema",
     "binding" : {
       "name" : "schemaStrategy.schemaType",
       "type" : "zeebe:property"
@@ -221,7 +241,7 @@
       "name" : "JSON",
       "value" : "json"
     }, {
-      "name" : "Avro (alpha)",
+      "name" : "Avro",
       "value" : "avro"
     } ]
   }, {
@@ -232,7 +252,7 @@
     "constraints" : {
       "notEmpty" : true
     },
-    "group" : "kafka",
+    "group" : "schema",
     "binding" : {
       "name" : "schemaStrategy.schemaRegistryUrl",
       "type" : "zeebe:property"
@@ -243,26 +263,6 @@
       "type" : "simple"
     },
     "type" : "String"
-  }, {
-    "id" : "schemaStrategy.avro.schema",
-    "label" : "Schema",
-    "description" : "Inline schema (Avro) for the message value",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "feel" : "required",
-    "group" : "message",
-    "binding" : {
-      "name" : "schemaStrategy.schema",
-      "type" : "zeebe:property"
-    },
-    "condition" : {
-      "property" : "schemaStrategy.type",
-      "equals" : "inlineSchema",
-      "type" : "simple"
-    },
-    "type" : "Text"
   }, {
     "id" : "activationCondition",
     "label" : "Activation condition",

--- a/connectors/kafka/element-templates/kafka-outbound-connector.json
+++ b/connectors/kafka/element-templates/kafka-outbound-connector.json
@@ -23,6 +23,9 @@
     "id" : "kafka",
     "label" : "Kafka"
   }, {
+    "id" : "schema",
+    "label" : "Schema"
+  }, {
     "id" : "message",
     "label" : "Message"
   }, {
@@ -100,10 +103,22 @@
     },
     "type" : "String"
   }, {
+    "id" : "additionalProperties",
+    "label" : "Additional properties",
+    "description" : "Provide additional Kafka producer properties in JSON",
+    "optional" : true,
+    "feel" : "required",
+    "group" : "kafka",
+    "binding" : {
+      "name" : "additionalProperties",
+      "type" : "zeebe:input"
+    },
+    "type" : "String"
+  }, {
     "id" : "schemaStrategy.type",
     "label" : "Schema strategy",
     "value" : "noSchema",
-    "group" : "kafka",
+    "group" : "schema",
     "binding" : {
       "name" : "schemaStrategy.type",
       "type" : "zeebe:input"
@@ -113,19 +128,59 @@
       "name" : "No schema",
       "value" : "noSchema"
     }, {
-      "name" : "Inline schema",
+      "name" : "Avro Inline schema",
       "value" : "inlineSchema"
     }, {
-      "name" : "Schema registry",
+      "name" : "Confluent Schema registry",
       "value" : "schemaRegistry"
     } ]
+  }, {
+    "id" : "schemaStrategy.avro.schema",
+    "label" : "Schema",
+    "description" : "Avro inline schema for the message value",
+    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "required",
+    "group" : "schema",
+    "binding" : {
+      "name" : "schemaStrategy.schema",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "schemaStrategy.type",
+      "equals" : "inlineSchema",
+      "type" : "simple"
+    },
+    "type" : "Text"
+  }, {
+    "id" : "schemaStrategy.schema",
+    "label" : "Schema",
+    "description" : "Schema (JSON or AVRO) for the message value",
+    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "required",
+    "group" : "schema",
+    "binding" : {
+      "name" : "schemaStrategy.schema",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "schemaStrategy.type",
+      "equals" : "schemaRegistry",
+      "type" : "simple"
+    },
+    "type" : "Text"
   }, {
     "id" : "schemaStrategy.schemaType",
     "label" : "Schema type",
     "description" : "Select the schema type. For details, visit the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/kafka/?kafka=inbound\" target=\"_blank\">documentation</a>",
     "optional" : false,
     "value" : "avro",
-    "group" : "kafka",
+    "group" : "schema",
     "binding" : {
       "name" : "schemaStrategy.schemaType",
       "type" : "zeebe:input"
@@ -140,7 +195,7 @@
       "name" : "JSON",
       "value" : "json"
     }, {
-      "name" : "Avro (alpha)",
+      "name" : "Avro",
       "value" : "avro"
     } ]
   }, {
@@ -152,7 +207,7 @@
       "notEmpty" : true
     },
     "feel" : "optional",
-    "group" : "kafka",
+    "group" : "schema",
     "binding" : {
       "name" : "schemaStrategy.schemaRegistryUrl",
       "type" : "zeebe:input"
@@ -161,30 +216,6 @@
       "property" : "schemaStrategy.type",
       "equals" : "schemaRegistry",
       "type" : "simple"
-    },
-    "type" : "String"
-  }, {
-    "id" : "headers",
-    "label" : "Headers",
-    "description" : "Provide Kafka producer headers in JSON",
-    "optional" : true,
-    "feel" : "required",
-    "group" : "kafka",
-    "binding" : {
-      "name" : "headers",
-      "type" : "zeebe:input"
-    },
-    "type" : "String"
-  }, {
-    "id" : "additionalProperties",
-    "label" : "Additional properties",
-    "description" : "Provide additional Kafka producer properties in JSON",
-    "optional" : true,
-    "feel" : "required",
-    "group" : "kafka",
-    "binding" : {
-      "name" : "additionalProperties",
-      "type" : "zeebe:input"
     },
     "type" : "String"
   }, {
@@ -215,45 +246,17 @@
     },
     "type" : "String"
   }, {
-    "id" : "schemaStrategy.avro.schema",
-    "label" : "Schema",
-    "description" : "Inline schema (Avro) for the message value",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
+    "id" : "headers",
+    "label" : "Headers",
+    "description" : "Provide Kafka producer headers in JSON",
+    "optional" : true,
     "feel" : "required",
     "group" : "message",
     "binding" : {
-      "name" : "schemaStrategy.schema",
+      "name" : "headers",
       "type" : "zeebe:input"
     },
-    "condition" : {
-      "property" : "schemaStrategy.type",
-      "equals" : "inlineSchema",
-      "type" : "simple"
-    },
-    "type" : "Text"
-  }, {
-    "id" : "schemaStrategy.schema",
-    "label" : "Schema",
-    "description" : "Schema (JSON or AVRO) for the message value",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "feel" : "required",
-    "group" : "message",
-    "binding" : {
-      "name" : "schemaStrategy.schema",
-      "type" : "zeebe:input"
-    },
-    "condition" : {
-      "property" : "schemaStrategy.type",
-      "equals" : "schemaRegistry",
-      "type" : "simple"
-    },
-    "type" : "Text"
+    "type" : "String"
   }, {
     "id" : "version",
     "label" : "Version",

--- a/connectors/kafka/src/main/java/io/camunda/connector/kafka/converter/GenericRecordDecoder.java
+++ b/connectors/kafka/src/main/java/io/camunda/connector/kafka/converter/GenericRecordDecoder.java
@@ -16,7 +16,7 @@ import org.apache.avro.generic.GenericRecord;
 
 public class GenericRecordDecoder {
 
-  public GenericRecord decode(Schema schema, Map<String, Object> data) {
+  public GenericRecord envelope(Schema schema, Map<String, Object> data) {
     GenericRecord record = new GenericData.Record(schema);
 
     for (Map.Entry<String, Object> entry : data.entrySet()) {
@@ -34,7 +34,7 @@ public class GenericRecordDecoder {
         }
         // If the field value is a nested Map, convert it to GenericRecord
         else if (fieldValue instanceof Map && fieldSchema.getType() == Schema.Type.RECORD) {
-          fieldValue = decode(fieldSchema, (Map<String, Object>) fieldValue);
+          fieldValue = envelope(fieldSchema, (Map<String, Object>) fieldValue);
         } else if (fieldValue instanceof List<?>) {
           fieldValue = handleListType((List<?>) fieldValue, fieldSchema);
         }
@@ -50,7 +50,7 @@ public class GenericRecordDecoder {
   private Object handleUnionType(Schema unionSchema, Object value) {
     for (Schema schema : unionSchema.getTypes()) {
       if (schema.getType() == Schema.Type.RECORD && value instanceof Map) {
-        return decode(schema, (Map<String, Object>) value);
+        return envelope(schema, (Map<String, Object>) value);
       } else if (schema.getType() == Schema.Type.ARRAY && value instanceof List) {
         return handleListType((List<?>) value, schema);
       }
@@ -64,7 +64,7 @@ public class GenericRecordDecoder {
 
     for (Object item : value) {
       if (item instanceof Map && elementSchema.getType() == Schema.Type.RECORD) {
-        list.add(decode(elementSchema, (Map<String, Object>) item));
+        list.add(envelope(elementSchema, (Map<String, Object>) item));
       } else {
         list.add(item);
       }

--- a/connectors/kafka/src/main/java/io/camunda/connector/kafka/inbound/KafkaExecutable.java
+++ b/connectors/kafka/src/main/java/io/camunda/connector/kafka/inbound/KafkaExecutable.java
@@ -30,7 +30,7 @@ import org.slf4j.LoggerFactory;
     id = "io.camunda.connectors.webhook",
     name = "Kafka Event Connector",
     icon = "icon.svg",
-    version = 7,
+    version = 8,
     inputDataClass = KafkaConnectorProperties.class,
     description = "Consume Kafka messages",
     documentationRef =
@@ -38,7 +38,7 @@ import org.slf4j.LoggerFactory;
     propertyGroups = {
       @ElementTemplate.PropertyGroup(id = "authentication", label = "Authentication"),
       @ElementTemplate.PropertyGroup(id = "kafka", label = "Kafka"),
-      @ElementTemplate.PropertyGroup(id = "message", label = "Message deserialization"),
+      @ElementTemplate.PropertyGroup(id = "schema", label = "Schema")
     },
     elementTypes = {
       @ElementTemplate.ConnectorElementType(

--- a/connectors/kafka/src/main/java/io/camunda/connector/kafka/inbound/KafkaExecutable.java
+++ b/connectors/kafka/src/main/java/io/camunda/connector/kafka/inbound/KafkaExecutable.java
@@ -30,7 +30,7 @@ import org.slf4j.LoggerFactory;
     id = "io.camunda.connectors.webhook",
     name = "Kafka Event Connector",
     icon = "icon.svg",
-    version = 8,
+    version = 7,
     inputDataClass = KafkaConnectorProperties.class,
     description = "Consume Kafka messages",
     documentationRef =

--- a/connectors/kafka/src/main/java/io/camunda/connector/kafka/model/schema/AbstractSchemaRegistryStrategy.java
+++ b/connectors/kafka/src/main/java/io/camunda/connector/kafka/model/schema/AbstractSchemaRegistryStrategy.java
@@ -13,14 +13,14 @@ import jakarta.validation.constraints.NotBlank;
 
 public abstract class AbstractSchemaRegistryStrategy {
   @TemplateProperty(
-      group = "kafka",
+      group = "schema",
       label = "Schema type",
       id = "schemaType",
       defaultValue = "avro",
       type = TemplateProperty.PropertyType.Dropdown,
       choices = {
         @TemplateProperty.DropdownPropertyChoice(value = "json", label = "JSON"),
-        @TemplateProperty.DropdownPropertyChoice(value = "avro", label = "Avro (alpha)")
+        @TemplateProperty.DropdownPropertyChoice(value = "avro", label = "Avro")
       },
       description =
           "Select the schema type. For details, visit the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/kafka/?kafka=inbound\" target=\"_blank\">documentation</a>")
@@ -28,7 +28,7 @@ public abstract class AbstractSchemaRegistryStrategy {
 
   @NotBlank
   @TemplateProperty(
-      group = "kafka",
+      group = "schema",
       label = "Schema registry URL",
       description = "Provide the schema registry URL",
       constraints = @TemplateProperty.PropertyConstraints(notEmpty = true))

--- a/connectors/kafka/src/main/java/io/camunda/connector/kafka/model/schema/AvroInlineSchemaStrategy.java
+++ b/connectors/kafka/src/main/java/io/camunda/connector/kafka/model/schema/AvroInlineSchemaStrategy.java
@@ -14,17 +14,17 @@ import io.camunda.connector.generator.dsl.Property;
 import io.camunda.connector.generator.java.annotation.TemplateProperty;
 import io.camunda.connector.generator.java.annotation.TemplateSubType;
 
-@TemplateSubType(id = TYPE, label = "Inline schema")
+@TemplateSubType(id = TYPE, label = "Avro Inline schema")
 public record AvroInlineSchemaStrategy(
     @FEEL
         @TemplateProperty(
             id = "avro.schema",
-            group = "message",
+            group = "schema",
             feel = Property.FeelMode.required,
             type = TemplateProperty.PropertyType.Text,
             label = "Schema",
             constraints = @TemplateProperty.PropertyConstraints(notEmpty = true),
-            description = "Inline schema (Avro) for the message value")
+            description = "Avro inline schema for the message value")
         String schema)
     implements InboundSchemaStrategy, OutboundSchemaStrategy {
 

--- a/connectors/kafka/src/main/java/io/camunda/connector/kafka/model/schema/InboundSchemaRegistryStrategy.java
+++ b/connectors/kafka/src/main/java/io/camunda/connector/kafka/model/schema/InboundSchemaRegistryStrategy.java
@@ -11,7 +11,7 @@ import io.camunda.connector.generator.java.annotation.TemplateProperty;
 import io.camunda.connector.generator.java.annotation.TemplateSubType;
 import io.camunda.connector.kafka.model.SchemaType;
 
-@TemplateSubType(id = "schemaRegistry", label = "Schema registry")
+@TemplateSubType(id = "schemaRegistry", label = "Confluent Schema registry")
 public final class InboundSchemaRegistryStrategy extends AbstractSchemaRegistryStrategy
     implements InboundSchemaStrategy {
   @TemplateProperty(ignore = true)

--- a/connectors/kafka/src/main/java/io/camunda/connector/kafka/model/schema/InboundSchemaStrategy.java
+++ b/connectors/kafka/src/main/java/io/camunda/connector/kafka/model/schema/InboundSchemaStrategy.java
@@ -13,7 +13,7 @@ import io.camunda.connector.generator.java.annotation.TemplateDiscriminatorPrope
 
 @TemplateDiscriminatorProperty(
     label = "Schema strategy",
-    group = "kafka",
+    group = "schema",
     name = "type",
     defaultValue = NoSchemaStrategy.TYPE)
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")

--- a/connectors/kafka/src/main/java/io/camunda/connector/kafka/model/schema/OutboundSchemaRegistryStrategy.java
+++ b/connectors/kafka/src/main/java/io/camunda/connector/kafka/model/schema/OutboundSchemaRegistryStrategy.java
@@ -15,7 +15,7 @@ import io.camunda.connector.generator.java.annotation.TemplateProperty;
 import io.camunda.connector.generator.java.annotation.TemplateSubType;
 import io.camunda.connector.kafka.model.SchemaType;
 
-@TemplateSubType(id = TYPE, label = "Schema registry")
+@TemplateSubType(id = TYPE, label = "Confluent Schema registry")
 public final class OutboundSchemaRegistryStrategy extends AbstractSchemaRegistryStrategy
     implements OutboundSchemaStrategy {
 
@@ -25,7 +25,7 @@ public final class OutboundSchemaRegistryStrategy extends AbstractSchemaRegistry
   @FEEL
   @TemplateProperty(
       id = "schema",
-      group = "message",
+      group = "schema",
       feel = Property.FeelMode.required,
       type = TemplateProperty.PropertyType.Text,
       label = "Schema",

--- a/connectors/kafka/src/main/java/io/camunda/connector/kafka/model/schema/OutboundSchemaStrategy.java
+++ b/connectors/kafka/src/main/java/io/camunda/connector/kafka/model/schema/OutboundSchemaStrategy.java
@@ -13,7 +13,7 @@ import io.camunda.connector.generator.java.annotation.TemplateDiscriminatorPrope
 
 @TemplateDiscriminatorProperty(
     label = "Schema strategy",
-    group = "kafka",
+    group = "schema",
     name = "type",
     defaultValue = NoSchemaStrategy.TYPE)
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")

--- a/connectors/kafka/src/main/java/io/camunda/connector/kafka/outbound/KafkaConnectorFunction.java
+++ b/connectors/kafka/src/main/java/io/camunda/connector/kafka/outbound/KafkaConnectorFunction.java
@@ -41,10 +41,11 @@ import org.apache.kafka.clients.producer.RecordMetadata;
     name = "Kafka Outbound Connector",
     description = "Produce Kafka message",
     inputDataClass = KafkaConnectorRequest.class,
-    version = 6,
+    version = 7,
     propertyGroups = {
       @ElementTemplate.PropertyGroup(id = "authentication", label = "Authentication"),
       @ElementTemplate.PropertyGroup(id = "kafka", label = "Kafka"),
+      @ElementTemplate.PropertyGroup(id = "schema", label = "Schema"),
       @ElementTemplate.PropertyGroup(id = "message", label = "Message")
     },
     documentationRef =

--- a/connectors/kafka/src/main/java/io/camunda/connector/kafka/outbound/KafkaConnectorFunction.java
+++ b/connectors/kafka/src/main/java/io/camunda/connector/kafka/outbound/KafkaConnectorFunction.java
@@ -41,7 +41,7 @@ import org.apache.kafka.clients.producer.RecordMetadata;
     name = "Kafka Outbound Connector",
     description = "Produce Kafka message",
     inputDataClass = KafkaConnectorRequest.class,
-    version = 7,
+    version = 6,
     propertyGroups = {
       @ElementTemplate.PropertyGroup(id = "authentication", label = "Authentication"),
       @ElementTemplate.PropertyGroup(id = "kafka", label = "Kafka"),

--- a/connectors/kafka/src/main/java/io/camunda/connector/kafka/outbound/model/KafkaConnectorRequest.java
+++ b/connectors/kafka/src/main/java/io/camunda/connector/kafka/outbound/model/KafkaConnectorRequest.java
@@ -23,7 +23,7 @@ public record KafkaConnectorRequest(
     @Valid @NotNull KafkaMessage message,
     @Valid OutboundSchemaStrategy schemaStrategy,
     @TemplateProperty(
-            group = "kafka",
+            group = "message",
             label = "Headers",
             optional = true,
             feel = Property.FeelMode.required,

--- a/connectors/kafka/src/main/java/io/camunda/connector/kafka/outbound/model/ProducerRecordFactory.java
+++ b/connectors/kafka/src/main/java/io/camunda/connector/kafka/outbound/model/ProducerRecordFactory.java
@@ -83,7 +83,7 @@ public class ProducerRecordFactory {
     var schemaString = strategy.getSchema();
     return switch (strategy.getSchemaType()) {
       case AVRO ->
-          GENERIC_RECORD_DECODER.decode(
+          GENERIC_RECORD_DECODER.envelope(
               new Schema.Parser().parse(schemaString), (Map) messageValue);
       case JSON -> JSON_ENVELOPE_DECODER.decode(schemaString, (Map) messageValue);
     };

--- a/connectors/kafka/src/test/java/io/camunda/connector/kafka/converter/GenericRecordDecoderTest.java
+++ b/connectors/kafka/src/test/java/io/camunda/connector/kafka/converter/GenericRecordDecoderTest.java
@@ -34,7 +34,7 @@ public class GenericRecordDecoderTest {
   }
 
   @Test
-  public void shouldDecodeMap_whenAllFieldAreSet() {
+  public void shouldEnvelopeMap_whenAllFieldAreSet() {
     // when
     Map<String, Object> value = new HashMap<>();
     value.put("name", "John Doe");
@@ -52,7 +52,7 @@ public class GenericRecordDecoderTest {
     value.put("colleagues", List.of(colleague));
 
     // when
-    GenericRecord record = genericRecordDecoder.decode(schema, value);
+    GenericRecord record = genericRecordDecoder.envelope(schema, value);
 
     // then
     assertThat(record.get("name")).isEqualTo("John Doe");


### PR DESCRIPTION
## Description

Create a separate property group for "Schema"

Move Headers to the "Message" group for the Outbound Connector

Rename "Inline Schema" to "Avro Inline Schema"

Rename the Schema Registry Type from "Avro (alpha)" to just "Avro"

Rename the "Schema Registry" to "Confluent Schema Registry"

Refine the naming of the decode method from `decode` to `envelope`

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #

## Checklist

- [ ] PR has a **milestone** or the `no milestone` label.

