### PR TITLE
test(agentic-ai): Fix document e2e test flakiness

### DIFF
--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/AiAgentTestFixtures.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/AiAgentTestFixtures.java
@@ -48,7 +48,9 @@ public interface AiAgentTestFixtures {
           Map.entry("data.tools.containerElementId", "Agent_Tools"),
           Map.entry("data.tools.toolCallResults", "=toolCallResults"),
           Map.entry("data.memory.maxMessages", "=50"),
-          Map.entry("data.response.includeAssistantMessage", "=true"));
+          Map.entry("data.response.includeAssistantMessage", "=true"),
+          Map.entry("retryCount", "3"),
+          Map.entry("retryBackoff", "PT2S"));
 
   String HAIKU_TEXT = "Endless waves whisper | moonlight dances on the tide | secrets drift below.";
   String HAIKU_JSON =

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/resources/agentic-ai-connectors.bpmn
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/resources/agentic-ai-connectors.bpmn
@@ -88,7 +88,7 @@
             <zeebe:header key="elementTemplateVersion" value="10" />
             <zeebe:header key="elementTemplateId" value="io.camunda.connectors.HttpJson.v2" />
             <zeebe:header key="resultExpression" value="={&#10;  toolCallResult: {&#10;    status: response.status,&#10;    document: response.document&#10;  }&#10;}" />
-            <zeebe:header key="retryBackoff" value="PT0S" />
+            <zeebe:header key="retryBackoff" value="PT2S" />
           </zeebe:taskHeaders>
         </bpmn:extensionElements>
       </bpmn:serviceTask>
@@ -215,7 +215,7 @@
           <zeebe:header key="elementTemplateVersion" value="10" />
           <zeebe:header key="elementTemplateId" value="io.camunda.connectors.HttpJson.v2" />
           <zeebe:header key="resultExpression" value="={&#10;  document: response.document&#10;}" />
-          <zeebe:header key="retryBackoff" value="PT0S" />
+          <zeebe:header key="retryBackoff" value="PT2S" />
         </zeebe:taskHeaders>
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_1t4ktrm</bpmn:incoming>


### PR DESCRIPTION
## Description

Add retries/retryBackoff to connectors in e2e process using document handling as sometimes the document API returns an invalid header (probably when called too early). This should reduce test flakiness.

## Related issues

https://camunda.slack.com/archives/C05Q7C4HJ5Q/p1750132271777109


## Checklist

- [x] PR has a **milestone** or the `no milestone` label.

