### PR TITLE
chore(RabbitMQ): bump to version 4.1.1

### DIFF
--- a/connectors-e2e-test/connectors-e2e-test-rabbitmq/src/test/java/io/camunda/connector/e2e/BaseRabbitMqTest.java
+++ b/connectors-e2e-test/connectors-e2e-test-rabbitmq/src/test/java/io/camunda/connector/e2e/BaseRabbitMqTest.java
@@ -34,6 +34,8 @@ public abstract class BaseRabbitMqTest {
   protected static final String OUTBOUND_ELEMENT_TEMPLATE_PATH =
       "../../connectors/rabbitmq/element-templates/rabbitmq-outbound-connector.json";
   protected static final String INTERMEDIATE_CATCH_EVENT_BPMN = "intermediate-catch-event.bpmn";
+  public static final String RABBITMQ_TEST_IMAGE = "rabbitmq:4.1.1-management-alpine";
+
   @TempDir File tempDir;
 
   @Autowired CamundaClient camundaClient;

--- a/connectors-e2e-test/connectors-e2e-test-rabbitmq/src/test/java/io/camunda/connector/e2e/RabbitMqInboundStartEventTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-rabbitmq/src/test/java/io/camunda/connector/e2e/RabbitMqInboundStartEventTests.java
@@ -73,8 +73,7 @@ public class RabbitMqInboundStartEventTests extends BaseRabbitMqTest {
 
   @BeforeAll
   public static void setup() throws IOException, TimeoutException {
-    rabbitMQContainer =
-        new RabbitMQContainer(DockerImageName.parse("rabbitmq:3.7.25-management-alpine"));
+    rabbitMQContainer = new RabbitMQContainer(DockerImageName.parse(RABBITMQ_TEST_IMAGE));
     rabbitMQContainer.start();
     PORT = String.valueOf(rabbitMQContainer.getAmqpPort());
     factory = new ConnectionFactory();

--- a/connectors-e2e-test/connectors-e2e-test-rabbitmq/src/test/java/io/camunda/connector/e2e/RabbitMqOutboundTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-rabbitmq/src/test/java/io/camunda/connector/e2e/RabbitMqOutboundTests.java
@@ -68,11 +68,11 @@ public class RabbitMqOutboundTests extends BaseRabbitMqTest {
 
   @BeforeAll
   public static void setup() throws IOException, TimeoutException {
-    rabbitMQContainer =
-        new RabbitMQContainer(DockerImageName.parse("rabbitmq:3.7.25-management-alpine"));
+    rabbitMQContainer = new RabbitMQContainer(DockerImageName.parse(RABBITMQ_TEST_IMAGE));
     rabbitMQContainer.start();
     PORT = String.valueOf(rabbitMQContainer.getAmqpPort());
     factory = new ConnectionFactory();
+
     factory.setHost(rabbitMQContainer.getHost());
     factory.setPort(rabbitMQContainer.getAmqpPort());
     factory.setUsername(rabbitMQContainer.getAdminUsername());

--- a/connectors/rabbitmq/src/test/java/io/camunda/connector/rabbitmq/BaseTest.java
+++ b/connectors/rabbitmq/src/test/java/io/camunda/connector/rabbitmq/BaseTest.java
@@ -20,6 +20,7 @@ import java.util.stream.Stream;
 import org.junit.jupiter.params.provider.Arguments;
 
 public abstract class BaseTest {
+  public static final String RABBITMQ_TEST_IMAGE = "rabbitmq:4.1.1-management-alpine";
 
   protected ObjectMapper objectMapper = ObjectMapperSupplier.instance();
 

--- a/connectors/rabbitmq/src/test/java/io/camunda/connector/rabbitmq/integration/RabbitMqIntegrationTest.java
+++ b/connectors/rabbitmq/src/test/java/io/camunda/connector/rabbitmq/integration/RabbitMqIntegrationTest.java
@@ -10,6 +10,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.testcontainers.shaded.org.awaitility.Awaitility.await;
 
+import io.camunda.connector.api.inbound.InboundConnectorDefinition;
 import io.camunda.connector.api.outbound.OutboundConnectorContext;
 import io.camunda.connector.api.outbound.OutboundConnectorFunction;
 import io.camunda.connector.rabbitmq.BaseTest;
@@ -28,15 +29,16 @@ import io.camunda.connector.rabbitmq.outbound.model.RabbitMqMessage;
 import io.camunda.connector.rabbitmq.outbound.model.RabbitMqOutboundRouting;
 import io.camunda.connector.rabbitmq.outbound.model.RabbitMqRequest;
 import io.camunda.connector.rabbitmq.supplier.ObjectMapperSupplier;
+import io.camunda.connector.test.SlowTest;
 import io.camunda.connector.test.inbound.InboundConnectorContextBuilder;
 import io.camunda.connector.test.inbound.InboundConnectorContextBuilder.TestInboundConnectorContext;
 import io.camunda.connector.test.outbound.OutboundConnectorContextBuilder;
 import io.camunda.connector.validation.impl.DefaultValidationProvider;
 import java.time.Duration;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
@@ -44,13 +46,13 @@ import org.junit.jupiter.api.TestMethodOrder;
 import org.testcontainers.containers.RabbitMQContainer;
 import org.testcontainers.junit.jupiter.Container;
 
-@Disabled // to be run manually
+@SlowTest
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 public class RabbitMqIntegrationTest extends BaseTest {
 
   @Container
   private static final RabbitMQContainer rabbitMq =
-      new RabbitMQContainer("rabbitmq:3.7.25-management-alpine")
+      new RabbitMQContainer(BaseTest.RABBITMQ_TEST_IMAGE)
           .withUser(Authentication.USERNAME, Authentication.PASSWORD, Set.of("administrator"))
           .withVhost(Routing.VIRTUAL_HOST)
           .withPermission(Routing.VIRTUAL_HOST, Authentication.USERNAME, ".*", ".*", ".*")
@@ -119,7 +121,10 @@ public class RabbitMqIntegrationTest extends BaseTest {
     properties.setRouting(routingData);
 
     TestInboundConnectorContext context =
-        InboundConnectorContextBuilder.create().properties(properties).build();
+        InboundConnectorContextBuilder.create()
+            .definition(new InboundConnectorDefinition(null, null, null, List.of()))
+            .properties(properties)
+            .build();
 
     // When
     executable.activate(context);
@@ -184,7 +189,10 @@ public class RabbitMqIntegrationTest extends BaseTest {
     properties.setRouting(routingData);
 
     TestInboundConnectorContext contextInbound =
-        InboundConnectorContextBuilder.create().properties(properties).build();
+        InboundConnectorContextBuilder.create()
+            .definition(new InboundConnectorDefinition(null, null, null, List.of()))
+            .properties(properties)
+            .build();
 
     // When
     executable.activate(contextInbound);


### PR DESCRIPTION
## Description

I updated the RabbitMQ version to 4.1.1 and enabled a previously disabled test

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.

