### PR TITLE
[Backport release/8.8] ci(release): upgrade camunda-release-parent to 4.0.0 and switch to Central Portal deployment (#4889)

### DIFF
--- a/.github/workflows/RELEASE.yaml
+++ b/.github/workflows/RELEASE.yaml
@@ -168,7 +168,7 @@ jobs:
 
       - name: Deploy artifacts to Artifactory and Maven Central (Staging)
         if: "! contains(github.event.release.tag_name, 'rc')"
-        run: mvn deploy -DskipTests -PcheckFormat -Psonatype-oss-release
+        run: mvn deploy -DskipTests -PcheckFormat -Pcentral-sonatype-publish
         env:
           NEXUS_USR: ${{ steps.secrets.outputs.ARTIFACTORY_USR }}
           NEXUS_PSW: ${{ steps.secrets.outputs.ARTIFACTORY_PSW }}
@@ -178,7 +178,7 @@ jobs:
 
       - name: Deploy artifacts to Artifactory
         if: "contains(github.event.release.tag_name, 'rc')"
-        run: mvn deploy -DskipTests -PcheckFormat -Psonatype-oss-release -Dskip.central.release=true
+        run: mvn deploy -DskipTests -PcheckFormat -Pcentral-sonatype-publish -Dskip.central.release=true
         env:
           NEXUS_USR: ${{ steps.secrets.outputs.ARTIFACTORY_USR }}
           NEXUS_PSW: ${{ steps.secrets.outputs.ARTIFACTORY_PSW }}

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.camunda</groupId>
     <artifactId>camunda-release-parent</artifactId>
-    <version>3.9.1</version>
+    <version>4.0.0</version>
     <!-- do not remove empty tag - http://jira.codehaus.org/browse/MNG-4687 -->
     <relativePath/>
   </parent>
@@ -68,7 +68,6 @@ limitations under the License.</license.inlineheader>
     <!-- release parent settings -->
     <nexus.snapshot.repository>https://artifacts.camunda.com/artifactory/connectors-snapshots/</nexus.snapshot.repository>
     <nexus.release.repository>https://artifacts.camunda.com/artifactory/connectors/</nexus.release.repository>
-    <nexus.sonatype.url>https://s01.oss.sonatype.org</nexus.sonatype.url>
 
     <!-- Camunda internal libraries -->
     <version.camunda>8.8.0-alpha5-rc1</version.camunda>
@@ -970,7 +969,7 @@ limitations under the License.</license.inlineheader>
     </profile>
 
     <profile>
-      <id>sonatype-oss-release</id>
+      <id>central-sonatype-publish</id>
       <build>
         <pluginManagement>
           <plugins>


### PR DESCRIPTION
## Description

Backport of https://github.com/camunda/connectors/pull/4889 to release/8.8.