### PR TITLE
[Backport release/8.7] ci(release): upgrade camunda-release-parent to 4.0.0 and switch to Central Portal deployment (#4889)

### DIFF
--- a/.github/workflows/RELEASE.yaml
+++ b/.github/workflows/RELEASE.yaml
@@ -133,7 +133,7 @@ jobs:
           MAVEN_GPG_PASSPHRASE: ${{ steps.secrets.outputs.MAVEN_CENTRAL_GPG_SIGNING_KEY_PASSPHRASE }}
 
       - name: Deploy artifacts to Artifactory and Maven Central (Staging)
-        run: mvn -B deploy -DskipTests -Psonatype-oss-release
+        run: mvn -B deploy -DskipTests -Pcentral-sonatype-publish
         env:
           NEXUS_USR: ${{ steps.secrets.outputs.ARTIFACTORY_USR }}
           NEXUS_PSW: ${{ steps.secrets.outputs.ARTIFACTORY_PSW }}

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.camunda</groupId>
     <artifactId>camunda-release-parent</artifactId>
-    <version>3.10.0</version>
+    <version>4.0.0</version>
     <!-- do not remove empty tag - http://jira.codehaus.org/browse/MNG-4687 -->
     <relativePath/>
   </parent>
@@ -68,7 +68,6 @@ limitations under the License.</license.inlineheader>
     <!-- release parent settings -->
     <nexus.snapshot.repository>https://artifacts.camunda.com/artifactory/connectors-snapshots/</nexus.snapshot.repository>
     <nexus.release.repository>https://artifacts.camunda.com/artifactory/connectors/</nexus.release.repository>
-    <nexus.sonatype.url>https://s01.oss.sonatype.org</nexus.sonatype.url>
 
     <!-- Camunda internal libraries -->
     <version.zeebe>8.7.6</version.zeebe>
@@ -949,7 +948,7 @@ limitations under the License.</license.inlineheader>
     </profile>
 
     <profile>
-      <id>sonatype-oss-release</id>
+      <id>central-sonatype-publish</id>
       <build>
         <pluginManagement>
           <plugins>


### PR DESCRIPTION
## Description

Backport of https://github.com/camunda/connectors/pull/4889 to release/8.7.

