### PR TITLE
fix: set testcontainers to test scope

### DIFF
--- a/connectors-e2e-test/connectors-e2e-test-rabbitmq/pom.xml
+++ b/connectors-e2e-test/connectors-e2e-test-rabbitmq/pom.xml
@@ -46,5 +46,12 @@
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+    <groupId>org.testcontainers</groupId>
+    <artifactId>rabbitmq</artifactId>
+    <version>${version.testcontainers}</version>
+    <scope>test</scope>
+  </dependency>
   </dependencies>
 </project>

--- a/connectors/rabbitmq/pom.xml
+++ b/connectors/rabbitmq/pom.xml
@@ -33,6 +33,7 @@
       <groupId>org.testcontainers</groupId>
       <artifactId>rabbitmq</artifactId>
       <version>${version.testcontainers}</version>
+      <scope>test</scope>
     </dependency>
 
     <!-- This dependency will be removed after camunda/zeebe#9859 is resolved. -->


### PR DESCRIPTION
## Description

The default bundle ships the `org.testcontainers:testcontainers` as a dependency of `io.camunda.connector:connector-rabbitmq`.

```
[INFO] +- io.camunda.connector:connector-rabbitmq:jar:8.8.0-SNAPSHOT:compile
[INFO] |  +- com.rabbitmq:amqp-client:jar:5.25.0:compile
[INFO] |  +- org.testcontainers:rabbitmq:jar:1.21.2:compile
[INFO] |  |  \- org.testcontainers:testcontainers:jar:1.21.2:compile
[INFO] |  |     +- junit:junit:jar:4.13.2:compile
[INFO] |  |     |  \- org.hamcrest:hamcrest-core:jar:3.0:compile
[INFO] |  |     |     \- org.hamcrest:hamcrest:jar:3.0:compile
[INFO] |  |     +- org.rnorth.duct-tape:duct-tape:jar:1.0.8:compile
[INFO] |  |     |  \- org.jetbrains:annotations:jar:17.0.0:compile
[INFO] |  |     +- com.github.docker-java:docker-java-api:jar:3.4.2:compile
[INFO] |  |     \- com.github.docker-java:docker-java-transport-zerodep:jar:3.4.2:compile
[INFO] |  |        \- com.github.docker-java:docker-java-transport:jar:3.4.2:compile
[INFO] |  \- org.apache.commons:commons-text:jar:1.13.1:compile
```

This PR sets the scope of the `org.testcontainers:testcontainers` dependency to `test`, so that the bundle no longer includes the testcontainers (+ some additional test dependencies) anymore:

```
[INFO] +- io.camunda.connector:connector-rabbitmq:jar:8.8.0-SNAPSHOT:compile
[INFO] |  +- com.rabbitmq:amqp-client:jar:5.25.0:compile
[INFO] |  \- org.apache.commons:commons-text:jar:1.13.1:compile
```

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #

## Checklist

- [ ] PR has a **milestone** or the `no milestone` label.

