### PR TITLE
other(util): introduce pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,26 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+- repo: meta
+  hooks:
+      - id: check-hooks-apply
+      - id: check-useless-excludes
+-   repo: local
+    hooks:
+        - id: spotless
+          language: system
+          name: Spotless
+          entry: bash -c 'mvn spotless:check; rc=$?; if [[ $rc -ne 0 ]]; then mvn spotless:apply &>/dev/null; echo "Files were reformatted"; fi; exit $rc'
+            # By default, hooks will receive a list of changed files.
+            # However, this doesn't integrate well with Maven plugins,
+            # which operate on the entire project.
+            # Therefore, we prevent pre-commit from passing changed files to the hook and
+            # always run it anyway
+          always_run: true
+          files: ^$
+        - id: license-check
+          language: system
+          name: License Check
+          entry: bash -c 'mvn license:check; rc=$?; if [[ $rc -ne 0 ]]; then mvn license:apply &>/dev/null; echo "Invalid License found and fixed"; fi; exit $rc'
+          always_run: true
+          files: ^$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
       - id: license-check
         language: system
         name: License Check
-        entry: bash -c 'mvn license:check; rc=$?; if [[ $rc -ne 0 ]]; then mvn license:apply &>/dev/null; echo "Invalid License found and fixed"; fi; exit $rc'
+        entry: bash -c 'mvn license:check; rc=$?; if [[ $rc -ne 0 ]]; then mvn license:format &>/dev/null; echo "Invalid License found and fixed"; fi; exit $rc'
         # By default, hooks will receive a list of changed files.
         # However, this doesn't integrate well with Maven plugins,
         # which operate on the entire project.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,20 +7,20 @@ repos:
       - id: check-useless-excludes
 -   repo: local
     hooks:
-        - id: spotless
-          language: system
-          name: Spotless
-          entry: bash -c 'mvn spotless:check; rc=$?; if [[ $rc -ne 0 ]]; then mvn spotless:apply &>/dev/null; echo "Files were reformatted"; fi; exit $rc'
-            # By default, hooks will receive a list of changed files.
-            # However, this doesn't integrate well with Maven plugins,
-            # which operate on the entire project.
-            # Therefore, we prevent pre-commit from passing changed files to the hook and
-            # always run it anyway
-          always_run: true
-          files: ^$
-        - id: license-check
-          language: system
-          name: License Check
-          entry: bash -c 'mvn license:check; rc=$?; if [[ $rc -ne 0 ]]; then mvn license:apply &>/dev/null; echo "Invalid License found and fixed"; fi; exit $rc'
-          always_run: true
-          files: ^$
+      - id: license-check
+        language: system
+        name: License Check
+        entry: bash -c 'mvn license:check; rc=$?; if [[ $rc -ne 0 ]]; then mvn license:apply &>/dev/null; echo "Invalid License found and fixed"; fi; exit $rc'
+        # By default, hooks will receive a list of changed files.
+        # However, this doesn't integrate well with Maven plugins,
+        # which operate on the entire project.
+        # Therefore, we prevent pre-commit from passing changed files to the hook and
+        # always run it anyway
+        always_run: true
+        files: ^$
+      - id: spotless
+        language: system
+        name: Spotless
+        entry: bash -c 'mvn spotless:check; rc=$?; if [[ $rc -ne 0 ]]; then mvn spotless:apply &>/dev/null; echo "Files were reformatted"; fi; exit $rc'
+        always_run: true
+        files: ^$

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,3 @@
 java temurin-21.0.7+6.0.LTS
 maven 3.9.9
+pre-commit 4.2.0

--- a/README.md
+++ b/README.md
@@ -48,9 +48,8 @@ When in doubt, refer to the `LICENSE` file in the respective module.
 
 ## Setup
 
-Download these utilities:
-
-* [`asdf`](https://asdf-vm.com/) for managing Java and Maven versions
+Download [`asdf`](https://asdf-vm.com/) and run `asdf install` to install our tools.
+Afterwards, run `pre-commit install` to set up the pre-commit hooks.
 
 The [Connector SDK](connector-sdk) uses Java 17, unlike the rest of this repository.
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,8 @@ When in doubt, refer to the `LICENSE` file in the respective module.
 
 ## Setup
 
-Download [`asdf`](https://asdf-vm.com/) and run `asdf install` to install our tools.
+Download [`asdf`](https://asdf-vm.com/), install the required plugins with `asdf plugin add <tool>` where `<tool>`
+is java, maven and pre-commit and run `asdf install` to install our tools.
 Afterwards, run `pre-commit install` to set up the pre-commit hooks.
 
 The [Connector SDK](connector-sdk) uses Java 17, unlike the rest of this repository.

--- a/bundle/README.md
+++ b/bundle/README.md
@@ -11,7 +11,8 @@ To add more connectors to the image, follow the examples in the [Connector Runti
 
 # Docker Compose
 
-The Connectors Bundle is also part of the Camunda [docker-compose resources](https://github.com/camunda/camunda-platform) Docker Compose release.
+The Connectors Bundle is also part of the Camunda
+[docker-compose resources](https://github.com/camunda/camunda-distributions/tree/main/docker-compose) Docker Compose release.
 
 # Secrets
 

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/DefaultInboundConnectorFactory.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/DefaultInboundConnectorFactory.java
@@ -45,8 +45,8 @@ public class DefaultInboundConnectorFactory implements InboundConnectorFactory {
 
   public DefaultInboundConnectorFactory() {
     loadConnectorConfigurations();
-    if (configurations.size() > 0) {
-      LOG.debug("Registered inbound connectors: " + configurations);
+    if (!configurations.isEmpty()) {
+      LOG.debug("Registered inbound connectors: {}", configurations);
     } else {
       LOG.warn("No inbound connectors discovered");
     }


### PR DESCRIPTION
## Description

As discussed in the Architecture session this PR introduces an initial implementation of a [pre-commit](https://pre-commit.com) setup.

Due to the particular nature of Maven tools being project and not file based, I had to implement some workarounds.

Usually pre-commit would detect changed files and fail on that alone, however due to us not accepting any file arguments, we have to explicitly check via exit code.

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.

