### PR TITLE
test(agentic-ai): temporarily disable flaky e2e tests involving documents

### DIFF
--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/langchain4j/Langchain4JAiAgentToolCallingTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/langchain4j/Langchain4JAiAgentToolCallingTests.java
@@ -34,6 +34,7 @@ import io.camunda.connector.e2e.agenticai.assertj.AgentResponseAssert;
 import io.camunda.connector.test.SlowTest;
 import java.util.List;
 import java.util.Map;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
@@ -54,6 +55,7 @@ public class Langchain4JAiAgentToolCallingTests extends BaseLangchain4JAiAgentTe
                 .hasNoResponseJson());
   }
 
+  @Disabled("https://github.com/camunda/connectors/issues/4950")
   @ParameterizedTest
   @CsvSource({
     "test.jpg,base64,image/jpeg",

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/langchain4j/Langchain4JAiAgentUserPromptDocumentsTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/langchain4j/Langchain4JAiAgentUserPromptDocumentsTests.java
@@ -37,11 +37,13 @@ import io.camunda.connector.test.SlowTest;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
 @SlowTest
+@Disabled("https://github.com/camunda/connectors/issues/4950")
 public class Langchain4JAiAgentUserPromptDocumentsTests extends BaseLangchain4JAiAgentTests {
 
   @ParameterizedTest


### PR DESCRIPTION
## Description

Temporarily disable flaky e2e tests

## Related issues

See https://github.com/camunda/connectors/issues/4950

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.

