### PR TITLE
chore(pom): add missing <name> tags based on artifactId value

### DIFF
--- a/bundle/camunda-saas-bundle/pom.xml
+++ b/bundle/camunda-saas-bundle/pom.xml
@@ -8,6 +8,7 @@
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>connector-runtime-bundle-saas</artifactId>
+  <name>Connector Runtime Bundle Saas</name>
   <packaging>jar</packaging>
 
   <dependencies>

--- a/bundle/default-bundle/pom.xml
+++ b/bundle/default-bundle/pom.xml
@@ -9,6 +9,7 @@
   </parent>
   <artifactId>connector-runtime-bundle</artifactId>
   <packaging>jar</packaging>
+  <name>Connector Runtime Bundle</name>
   <description>Connectors Runtime Bundle including out-of-the-box connectors</description>
 
   <dependencies>

--- a/bundle/pom.xml
+++ b/bundle/pom.xml
@@ -5,6 +5,8 @@
   <artifactId>connector-runtime-bundle-parent</artifactId>
   <packaging>pom</packaging>
 
+  <name>Connector Runtime Bundle Parent</name>
+
   <parent>
     <groupId>io.camunda.connector</groupId>
     <artifactId>connector-parent</artifactId>

--- a/connector-runtime/connector-runtime-application/pom.xml
+++ b/connector-runtime/connector-runtime-application/pom.xml
@@ -11,6 +11,7 @@
   </parent>
 
   <artifactId>connector-runtime-application</artifactId>
+  <name>Connector Runtime Application</name>
 
   <dependencies>
     <dependency>

--- a/connector-runtime/connector-runtime-spring/pom.xml
+++ b/connector-runtime/connector-runtime-spring/pom.xml
@@ -11,6 +11,7 @@
   </parent>
 
   <artifactId>connector-runtime-spring</artifactId>
+  <name>Connector Runtime Spring</name>
 
   <dependencies>
     <!-- Spring dependencies (scope: provided) -->

--- a/connector-runtime/spring-boot-starter-camunda-connectors/pom.xml
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/pom.xml
@@ -11,6 +11,7 @@
   </parent>
 
   <artifactId>spring-boot-starter-camunda-connectors</artifactId>
+  <name>Spring Boot Starter Camunda Connectors</name>
 
   <description>
     An implementation of the Camunda Connector Runtime based on Spring Zeebe.

--- a/connector-sdk/feel-wrapper/pom.xml
+++ b/connector-sdk/feel-wrapper/pom.xml
@@ -10,6 +10,7 @@
   </parent>
 
   <artifactId>connector-feel-wrapper</artifactId>
+  <name>Connector Feel Wrapper</name>
   <description>Common FEEL and Jackson configurations for Camunda Connectors</description>
 
   <dependencies>

--- a/connector-sdk/jackson-datatype-document/pom.xml
+++ b/connector-sdk/jackson-datatype-document/pom.xml
@@ -9,6 +9,7 @@
   </parent>
 
   <artifactId>jackson-datatype-document</artifactId>
+  <name>Jackson Datatype Document</name>
   <description>Jackson module to handle Connector SDK file objects</description>
 
   <dependencies>

--- a/connector-sdk/jackson-datatype-feel/pom.xml
+++ b/connector-sdk/jackson-datatype-feel/pom.xml
@@ -9,6 +9,7 @@
   </parent>
 
   <artifactId>jackson-datatype-feel</artifactId>
+  <name>Jackson Datatype Feel</name>
   <description>Jackson module to evaluate FEEL expressions on deserialization</description>
 
   <dependencies>

--- a/connectors-e2e-test/connectors-e2e-email/pom.xml
+++ b/connectors-e2e-test/connectors-e2e-email/pom.xml
@@ -10,6 +10,7 @@
     </parent>
 
     <artifactId>connectors-e2e-email</artifactId>
+    <name>Connectors E2e Email</name>
 
     <properties>
         <maven.compiler.source>21</maven.compiler.source>

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/pom.xml
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/pom.xml
@@ -10,6 +10,7 @@
   </parent>
 
   <description>Agentic AI E2E Tests</description>
+  <name>Connectors E2e Test Agentic Ai</name>
   <artifactId>connectors-e2e-test-agentic-ai</artifactId>
   <packaging>jar</packaging>
 

--- a/connectors-e2e-test/connectors-e2e-test-automation-anywhere/pom.xml
+++ b/connectors-e2e-test/connectors-e2e-test-automation-anywhere/pom.xml
@@ -10,6 +10,7 @@
   </parent>
 
   <description>Tests</description>
+  <name>Connectors E2e Test Automation Anywhere</name>
   <artifactId>connectors-e2e-test-automation-anywhere</artifactId>
   <packaging>jar</packaging>
 

--- a/connectors-e2e-test/connectors-e2e-test-aws/connectors-e2e-test-aws-event-bridge/pom.xml
+++ b/connectors-e2e-test/connectors-e2e-test-aws/connectors-e2e-test-aws-event-bridge/pom.xml
@@ -11,6 +11,7 @@
     </parent>
 
     <artifactId>connectors-e2e-test-aws-event-bridge</artifactId>
+    <name>Connectors E2e Test Aws Event Bridge</name>
 
     <dependencies>
         <dependency>

--- a/connectors-e2e-test/connectors-e2e-test-base/pom.xml
+++ b/connectors-e2e-test/connectors-e2e-test-base/pom.xml
@@ -10,6 +10,7 @@
     </parent>
 
     <description>Connectors Test Base project</description>
+    <name>Connectors E2e Test Base</name>
     <artifactId>connectors-e2e-test-base</artifactId>
     <packaging>jar</packaging>
 

--- a/connectors-e2e-test/connectors-e2e-test-easy-post/pom.xml
+++ b/connectors-e2e-test/connectors-e2e-test-easy-post/pom.xml
@@ -10,6 +10,7 @@
   </parent>
 
   <description>Tests</description>
+  <name>Connectors E2e Test Easy Post</name>
   <artifactId>connectors-e2e-test-easy-post</artifactId>
   <packaging>jar</packaging>
 

--- a/connectors-e2e-test/connectors-e2e-test-http/pom.xml
+++ b/connectors-e2e-test/connectors-e2e-test-http/pom.xml
@@ -10,6 +10,7 @@
   </parent>
 
   <description>Tests</description>
+  <name>Connectors E2e Test Http</name>
   <artifactId>connectors-e2e-test-http</artifactId>
   <packaging>jar</packaging>
 

--- a/connectors-e2e-test/connectors-e2e-test-kafka/pom.xml
+++ b/connectors-e2e-test/connectors-e2e-test-kafka/pom.xml
@@ -10,6 +10,7 @@
   </parent>
 
   <description>Tests</description>
+  <name>Connectors E2e Test Kafka</name>
   <artifactId>connectors-e2e-test-kafka</artifactId>
   <packaging>jar</packaging>
 

--- a/connectors-e2e-test/connectors-e2e-test-message/pom.xml
+++ b/connectors-e2e-test/connectors-e2e-test-message/pom.xml
@@ -7,6 +7,7 @@
   </parent>
   
   <description>Tests</description>
+  <name>Connectors E2e Test Message</name>
   <artifactId>connectors-e2e-test-message</artifactId>
   <packaging>jar</packaging>
   

--- a/connectors-e2e-test/connectors-e2e-test-rabbitmq/pom.xml
+++ b/connectors-e2e-test/connectors-e2e-test-rabbitmq/pom.xml
@@ -10,6 +10,7 @@
   </parent>
 
   <description>Tests</description>
+  <name>Connectors E2e Test Rabbitmq</name>
   <artifactId>connectors-e2e-test-rabbitmq</artifactId>
   <packaging>jar</packaging>
 

--- a/connectors-e2e-test/connectors-e2e-test-soap/pom.xml
+++ b/connectors-e2e-test/connectors-e2e-test-soap/pom.xml
@@ -10,6 +10,7 @@
   </parent>
 
   <description>SOAP Connector tests</description>
+  <name>Connectors E2e Test Soap</name>
   <artifactId>connectors-e2e-test-soap</artifactId>
   <packaging>jar</packaging>
 


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

The Central Portal validation rules now require each module to have a <name> tag defined in its pom.xml.
This PR adds the missing <name> tags to all affected modules. The names have been automatically derived from the corresponding artifactId by:
- Replacing hyphens (-) with spaces
- Capitalizing the first letter of each word

Validation error:
<img width="1249" alt="image" src="https://github.com/user-attachments/assets/3551b5e7-f4e3-4c65-8f07-9ea2afaf5847" />
