### PR TITLE
chore(build-plugin): Remove maven enforcer plugin in sonatype profile

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -984,17 +984,6 @@ limitations under the License.</license.inlineheader>
             </plugin>
           </plugins>
         </pluginManagement>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-enforcer-plugin</artifactId>
-            <configuration>
-              <rules>
-                <requireReleaseDeps/>
-              </rules>
-            </configuration>
-          </plugin>
-        </plugins>
       </build>
     </profile>
   </profiles>


### PR DESCRIPTION
## Description
Fix for this error: https://github.com/camunda/connectors/actions/runs/15853486889/job/44700800606

Let me know if that is a valid approach.

I guess this plugin rule was not applied before either, as then 8.8 release would have failed too and it now becomes active, after the sonatype changes, but I am not sure, whats going on.

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.

