### PR TITLE
fix: generate an empty Javadoc JAR for bundles without source code

### DIFF
--- a/bundle/default-bundle/pom.xml
+++ b/bundle/default-bundle/pom.xml
@@ -241,6 +241,27 @@
           <outputName>connectors-bundle-sbom</outputName>
         </configuration>
       </plugin>
+      <!--
+        This plugin execution creates a javadoc JAR to meet Sonatype requirements, even though there is no source code.
+        It includes any files in the /main/resources/javadoc directory if present.
+      -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>javadoc-jar</id>
+            <phase>package</phase>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+            <configuration>
+              <classifier>javadoc</classifier>
+              <classesDirectory>${basedir}/main/resources/javadoc</classesDirectory>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 


### PR DESCRIPTION
## Description

This PR addresses the Sonatype Central Portal requirement that all published artifacts must include a Javadoc JAR. It fixes an issue where the `connector-runtime-bundle` module, which contains no source code, was missing a Javadoc JAR by adding the generation of an empty Javadoc JAR for this bundle. 

