### PR TITLE
chore(deps): bump operate client to 8.7.1-rc1

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -72,7 +72,7 @@ limitations under the License.</license.inlineheader>
     <!-- Camunda internal libraries -->
     <version.zeebe>8.7.6</version.zeebe>
     <version.camunda-process-test>8.7.6</version.camunda-process-test>
-    <version.operate-client>8.7.0</version.operate-client>
+    <version.operate-client>8.7.1-rc1</version.operate-client>
     <version.feel-engine>1.19.3</version.feel-engine>
     <!-- Third party dependencies -->
 


### PR DESCRIPTION
## Description

This PR upgrades the Operate client to the new version where `client_assertion` flow is supported

## Related issues

<!-- Which issues are closed by this PR or are related -->

related #4938 

## Checklist

- [ ] PR has a **milestone** or the `no milestone` label.

