### PR TITLE
Agentic AI: Set gateway handler type zeebe property on MCP element types

### DIFF
--- a/connectors/agentic-ai/element-templates/agenticai-mcp-client-outbound-connector.json
+++ b/connectors/agentic-ai/element-templates/agenticai-mcp-client-outbound-connector.json
@@ -49,6 +49,13 @@
     },
     "type" : "Hidden"
   }, {
+    "value" : "mcpClient",
+    "binding" : {
+      "name" : "io.camunda.agenticai.gateway.type",
+      "type" : "zeebe:property"
+    },
+    "type" : "Hidden"
+  }, {
     "id" : "data.client.clientId",
     "label" : "Client ID",
     "description" : "The MCP client ID. This needs to be configured on your connector runtime.",

--- a/connectors/agentic-ai/element-templates/agenticai-mcp-remote-client-outbound-connector.json
+++ b/connectors/agentic-ai/element-templates/agenticai-mcp-remote-client-outbound-connector.json
@@ -49,6 +49,13 @@
     },
     "type" : "Hidden"
   }, {
+    "value" : "mcpClient",
+    "binding" : {
+      "name" : "io.camunda.agenticai.gateway.type",
+      "type" : "zeebe:property"
+    },
+    "type" : "Hidden"
+  }, {
     "id" : "data.connection.sseUrl",
     "label" : "SSE URL",
     "optional" : false,

--- a/connectors/agentic-ai/element-templates/hybrid/agenticai-mcp-client-outbound-connector-hybrid.json
+++ b/connectors/agentic-ai/element-templates/hybrid/agenticai-mcp-client-outbound-connector-hybrid.json
@@ -54,6 +54,13 @@
     },
     "type" : "String"
   }, {
+    "value" : "mcpClient",
+    "binding" : {
+      "name" : "io.camunda.agenticai.gateway.type",
+      "type" : "zeebe:property"
+    },
+    "type" : "Hidden"
+  }, {
     "id" : "data.client.clientId",
     "label" : "Client ID",
     "description" : "The MCP client ID. This needs to be configured on your connector runtime.",

--- a/connectors/agentic-ai/element-templates/hybrid/agenticai-mcp-remote-client-outbound-connector-hybrid.json
+++ b/connectors/agentic-ai/element-templates/hybrid/agenticai-mcp-remote-client-outbound-connector-hybrid.json
@@ -54,6 +54,13 @@
     },
     "type" : "String"
   }, {
+    "value" : "mcpClient",
+    "binding" : {
+      "name" : "io.camunda.agenticai.gateway.type",
+      "type" : "zeebe:property"
+    },
+    "type" : "Hidden"
+  }, {
     "id" : "data.connection.sseUrl",
     "label" : "SSE URL",
     "optional" : false,

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/mcp/client/McpClientFunction.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/mcp/client/McpClientFunction.java
@@ -25,6 +25,7 @@ import io.camunda.connector.generator.java.annotation.ElementTemplate;
     engineVersion = "^8.8",
     version = 0,
     inputDataClass = McpClientRequest.class,
+    propertySources = McpClientPropertySource.class,
     defaultResultVariable = "toolCallResult",
     propertyGroups = {
       @ElementTemplate.PropertyGroup(id = "client", label = "MCP Client"),

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/mcp/client/McpClientPropertySource.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/mcp/client/McpClientPropertySource.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.agenticai.mcp.client;
+
+import io.camunda.connector.agenticai.adhoctoolsschema.resolver.GatewayToolDefinitionResolver;
+import io.camunda.connector.agenticai.mcp.discovery.McpClientGatewayToolHandler;
+import io.camunda.connector.generator.dsl.HiddenProperty;
+import io.camunda.connector.generator.dsl.PropertyBinding.ZeebeProperty;
+import io.camunda.connector.generator.dsl.PropertyBuilder;
+import io.camunda.connector.generator.java.annotation.PropertySource;
+import java.util.Collection;
+import java.util.List;
+
+public class McpClientPropertySource {
+  @PropertySource
+  public static Collection<PropertyBuilder> mcpClientGatewayProperties() {
+    return List.of(
+        HiddenProperty.builder()
+            .binding(new ZeebeProperty(GatewayToolDefinitionResolver.GATEWAY_TYPE_EXTENSION))
+            .value(McpClientGatewayToolHandler.GATEWAY_TYPE));
+  }
+}

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/mcp/client/McpRemoteClientFunction.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/mcp/client/McpRemoteClientFunction.java
@@ -25,6 +25,7 @@ import io.camunda.connector.generator.java.annotation.ElementTemplate;
     engineVersion = "^8.8",
     version = 0,
     inputDataClass = McpRemoteClientRequest.class,
+    propertySources = McpClientPropertySource.class,
     defaultResultVariable = "toolCallResult",
     propertyGroups = {
       @ElementTemplate.PropertyGroup(

--- a/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/annotation/ElementTemplate.java
+++ b/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/annotation/ElementTemplate.java
@@ -42,6 +42,12 @@ public @interface ElementTemplate {
   Class<?> outputDataClass() default Void.class;
 
   /**
+   * List of classes defining element template properties through @{@link PropertySource} annotated
+   * methods.
+   */
+  Class<?>[] propertySources() default {};
+
+  /**
    * Element template version. The version should be incremented every time the template is changed
    * to make use of the version upgrade mechanism in Camunda Modeler.
    *

--- a/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/annotation/PropertySource.java
+++ b/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/annotation/PropertySource.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.generator.java.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marks a method in a class referenced in {@link ElementTemplate#propertySources()} as property
+ * source.
+ *
+ * <p>The method must be public static and return a collection of {@link
+ * io.camunda.connector.generator.dsl.PropertyBuilder} objects.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD})
+public @interface PropertySource {}

--- a/element-template-generator/core/src/test/java/io/camunda/connector/generator/java/OutboundClassBasedTemplateGeneratorTest.java
+++ b/element-template-generator/core/src/test/java/io/camunda/connector/generator/java/OutboundClassBasedTemplateGeneratorTest.java
@@ -19,6 +19,7 @@ package io.camunda.connector.generator.java;
 import static io.camunda.connector.generator.java.util.TemplateGenerationStringUtil.camelCaseToSpaces;
 import static java.nio.file.Files.readAllBytes;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -28,10 +29,12 @@ import io.camunda.connector.generator.BaseTest;
 import io.camunda.connector.generator.api.GeneratorConfiguration;
 import io.camunda.connector.generator.api.GeneratorConfiguration.ConnectorElementType;
 import io.camunda.connector.generator.api.GeneratorConfiguration.ConnectorMode;
+import io.camunda.connector.generator.dsl.BooleanProperty;
 import io.camunda.connector.generator.dsl.BpmnType;
 import io.camunda.connector.generator.dsl.DropdownProperty;
 import io.camunda.connector.generator.dsl.DropdownProperty.DropdownChoice;
 import io.camunda.connector.generator.dsl.ElementTemplate.ElementTypeWrapper;
+import io.camunda.connector.generator.dsl.HiddenProperty;
 import io.camunda.connector.generator.dsl.Property.FeelMode;
 import io.camunda.connector.generator.dsl.PropertyBinding;
 import io.camunda.connector.generator.dsl.PropertyBinding.ZeebeInput;
@@ -41,6 +44,7 @@ import io.camunda.connector.generator.dsl.PropertyCondition;
 import io.camunda.connector.generator.dsl.PropertyCondition.AllMatch;
 import io.camunda.connector.generator.dsl.PropertyCondition.Equals;
 import io.camunda.connector.generator.dsl.PropertyConstraints.Pattern;
+import io.camunda.connector.generator.dsl.PropertyGroup;
 import io.camunda.connector.generator.dsl.StringProperty;
 import io.camunda.connector.generator.dsl.TextProperty;
 import io.camunda.connector.generator.java.example.outbound.MyConnectorFunction;
@@ -823,6 +827,51 @@ public class OutboundClassBasedTemplateGeneratorTest extends BaseTest {
       var group2 =
           template.groups().stream().filter(g -> "group2".equals(g.id())).findFirst().orElseThrow();
       assertThat(group2.openByDefault()).isNull();
+    }
+  }
+
+  @Nested
+  class PropertySources {
+
+    @Test
+    void addsPropertyGroupsDefinedByPropertySource() {
+      var template =
+          generator
+              .generate(MyConnectorFunction.MinimallyAnnotatedWithPropertySources.class)
+              .getFirst();
+
+      assertThat(template.groups())
+          .hasSizeGreaterThan(1)
+          .extracting(PropertyGroup::id, PropertyGroup::label)
+          .contains(tuple("propertySourceCustomGroup", "Property source custom group"));
+    }
+
+    @Test
+    void generatesPropertiesFromPropertySource() {
+      var template =
+          generator
+              .generate(MyConnectorFunction.MinimallyAnnotatedWithPropertySources.class)
+              .getFirst();
+
+      var hiddenProperty = getPropertyById("myPropertySourceZeebeProperty", template);
+      assertThat(hiddenProperty).isInstanceOf(HiddenProperty.class);
+      assertThat(hiddenProperty.getBinding())
+          .isEqualTo(new PropertyBinding.ZeebeProperty("myPropertySourceZeebeProperty"));
+      assertThat(hiddenProperty.getValue()).isEqualTo("myZeebePropertyValue");
+
+      var stringProperty = getPropertyById("myPropertySourceStringProperty", template);
+      assertThat(stringProperty).isInstanceOf(StringProperty.class);
+      assertThat(stringProperty.getGroup()).isEqualTo("group1");
+      assertThat(stringProperty.getLabel()).isEqualTo("PropertySource String Property");
+      assertThat(stringProperty.getBinding())
+          .isEqualTo(new ZeebeInput("myPropertySourceStringProperty"));
+
+      var booleanProperty = getPropertyById("myPropertySourceBooleanProperty", template);
+      assertThat(booleanProperty).isInstanceOf(BooleanProperty.class);
+      assertThat(booleanProperty.getGroup()).isEqualTo("propertySourceCustomGroup");
+      assertThat(booleanProperty.getLabel()).isEqualTo("PropertySource Boolean Property");
+      assertThat(booleanProperty.getBinding())
+          .isEqualTo(new PropertyBinding.ZeebeProperty("myPropertySourceBooleanProperty"));
     }
   }
 

--- a/element-template-generator/core/src/test/java/io/camunda/connector/generator/java/example/inbound/MyConnectorExecutable.java
+++ b/element-template-generator/core/src/test/java/io/camunda/connector/generator/java/example/inbound/MyConnectorExecutable.java
@@ -20,6 +20,7 @@ import io.camunda.connector.api.annotation.InboundConnector;
 import io.camunda.connector.api.inbound.InboundConnectorContext;
 import io.camunda.connector.api.inbound.InboundConnectorExecutable;
 import io.camunda.connector.generator.java.annotation.ElementTemplate;
+import io.camunda.connector.generator.java.example.outbound.MyPropertySource;
 
 public class MyConnectorExecutable implements InboundConnectorExecutable<InboundConnectorContext> {
 
@@ -40,6 +41,16 @@ public class MyConnectorExecutable implements InboundConnectorExecutable<Inbound
       inputDataClass = MyConnectorProperties.class,
       icon = "my-connector-icon.png")
   public static class MinimallyAnnotated extends MyConnectorExecutable {}
+
+  @InboundConnector(name = "my-inbound-connector", type = "my-inbound-connector-type")
+  @ElementTemplate(
+      engineVersion = "^8.7",
+      id = MyConnectorExecutable.ID,
+      name = MyConnectorExecutable.NAME,
+      inputDataClass = MyConnectorProperties.class,
+      propertySources = MyPropertySource.class,
+      icon = "my-connector-icon.png")
+  public static class MinimallyAnnotatedWithPropertySources extends MyConnectorExecutable {}
 
   @InboundConnector(name = "my-inbound-connector", type = "my-inbound-connector-type")
   @ElementTemplate(

--- a/element-template-generator/core/src/test/java/io/camunda/connector/generator/java/example/outbound/MyConnectorFunction.java
+++ b/element-template-generator/core/src/test/java/io/camunda/connector/generator/java/example/outbound/MyConnectorFunction.java
@@ -109,6 +109,18 @@ public abstract class MyConnectorFunction implements OutboundConnectorFunction {
       id = MyConnectorFunction.ID,
       name = MyConnectorFunction.NAME,
       inputDataClass = MyConnectorInput.class,
+      propertySources = MyPropertySource.class)
+  public static class MinimallyAnnotatedWithPropertySources extends MyConnectorFunction {}
+
+  @OutboundConnector(
+      name = "my-connector",
+      type = "my-connector-type",
+      inputVariables = {})
+  @ElementTemplate(
+      engineVersion = "^8.7",
+      id = MyConnectorFunction.ID,
+      name = MyConnectorFunction.NAME,
+      inputDataClass = MyConnectorInput.class,
       icon = "my-connector-icon.svg")
   public static class MinimallyAnnotatedWithSvgIcon extends MyConnectorFunction {}
 

--- a/element-template-generator/core/src/test/java/io/camunda/connector/generator/java/example/outbound/MyPropertySource.java
+++ b/element-template-generator/core/src/test/java/io/camunda/connector/generator/java/example/outbound/MyPropertySource.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.generator.java.example.outbound;
+
+import io.camunda.connector.generator.dsl.BooleanProperty;
+import io.camunda.connector.generator.dsl.HiddenProperty;
+import io.camunda.connector.generator.dsl.PropertyBinding.ZeebeInput;
+import io.camunda.connector.generator.dsl.PropertyBinding.ZeebeProperty;
+import io.camunda.connector.generator.dsl.PropertyBuilder;
+import io.camunda.connector.generator.dsl.StringProperty;
+import io.camunda.connector.generator.java.annotation.PropertySource;
+import java.util.List;
+
+public class MyPropertySource {
+
+  @PropertySource
+  public static List<PropertyBuilder> getFirstProperty() {
+    return List.of(
+        HiddenProperty.builder()
+            .id("myPropertySourceZeebeProperty")
+            .binding(new ZeebeProperty("myPropertySourceZeebeProperty"))
+            .value("myZeebePropertyValue"));
+  }
+
+  @PropertySource
+  public static List<PropertyBuilder> getOtherProperties() {
+    return List.of(
+        StringProperty.builder()
+            .id("myPropertySourceStringProperty")
+            .group("group1")
+            .label("PropertySource String Property")
+            .binding(new ZeebeInput("myPropertySourceStringProperty")),
+        BooleanProperty.builder()
+            .id("myPropertySourceBooleanProperty")
+            .group("propertySourceCustomGroup")
+            .label("PropertySource Boolean Property")
+            .binding(new ZeebeProperty("myPropertySourceBooleanProperty")));
+  }
+}


### PR DESCRIPTION
## Description

To add a zeebe property of `io.camunda.agenticai.gateway.type=mcpClient` to via generated MCP client connector templates, it is necessary to add the following property binding to the generated element templates:

```
{
    "value" : "mcpClient",
    "binding" : {
      "name" : "io.camunda.agenticai.gateway.type",
      "type" : "zeebe:property"
    },
    "type" : "Hidden"
  }
```

This PR adds an additional way to define properties generated for an element template by referencing `@PropertySource` annotated static methods which can return a list of properties of any kind, making it possible to define arbitrary properties without having to define them as part of the input data.

## Related issues

closes #4947

## Checklist

- [ ] PR has a **milestone** or the `no milestone` label.

