### PR TITLE
chore(deployment): Undo setting name manually

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -969,10 +969,6 @@ limitations under the License.</license.inlineheader>
 
     <profile>
       <id>central-sonatype-publish</id>
-      <properties>
-        <serverId>central</serverId>
-        <deploymentName>${project.groupId}:${project.artifactId}:${project.version}</deploymentName>
-      </properties>
       <build>
         <pluginManagement>
           <plugins>


### PR DESCRIPTION
## Description
Undoing setting the deployment name manually as it did not work.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.

