### PR TITLE
test(agentic-ai): temporarily disable flaky e2e tests involving document conversation memory storage

### DIFF
--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/langchain4j/Langchain4JAiAgentMemoryStorageTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/langchain4j/Langchain4JAiAgentMemoryStorageTests.java
@@ -28,6 +28,7 @@ import io.camunda.connector.test.SlowTest;
 import io.camunda.document.reference.DocumentReference.CamundaDocumentReference;
 import java.time.Duration;
 import java.time.OffsetDateTime;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 @SlowTest
@@ -56,6 +57,7 @@ public class Langchain4JAiAgentMemoryStorageTests extends BaseLangchain4JAiAgent
   }
 
   @Test
+  @Disabled("https://github.com/camunda/connectors/issues/4950")
   void camundaDocumentStorage() throws Exception {
     testInteractionWithToolsAndUserFeedbackLoops(
         elementTemplate ->


### PR DESCRIPTION
## Description

Temporarily disable flaky e2e tests involving camunda document conversation storage.

## Related issues

See https://github.com/camunda/connectors/issues/4950

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.

