### PR TITLE
test(agentic-ai): fix flaky e2e document handling tests

### DIFF
--- a/connector-sdk/document/src/main/java/io/camunda/document/store/InMemoryDocumentStore.java
+++ b/connector-sdk/document/src/main/java/io/camunda/document/store/InMemoryDocumentStore.java
@@ -55,6 +55,10 @@ public class InMemoryDocumentStore implements CamundaDocumentStore {
 
           @Override
           public OffsetDateTime getExpiresAt() {
+            if (request.timeToLive() != null) {
+              return OffsetDateTime.now().plus(request.timeToLive());
+            }
+
             return null;
           }
 

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/langchain4j/BaseLangchain4JAiAgentTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/langchain4j/BaseLangchain4JAiAgentTests.java
@@ -51,6 +51,8 @@ import io.camunda.connector.e2e.agenticai.aiagent.BaseAiAgentTest;
 import io.camunda.connector.e2e.agenticai.assertj.AgentResponseAssert;
 import io.camunda.connector.e2e.agenticai.assertj.ToolExecutionRequestEqualsPredicate;
 import io.camunda.connector.test.SlowTest;
+import io.camunda.document.store.CamundaDocumentStore;
+import io.camunda.document.store.InMemoryDocumentStore;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -67,12 +69,17 @@ import org.junit.jupiter.api.BeforeEach;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Primary;
 import org.springframework.core.io.Resource;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 
 @SlowTest
 @WireMockTest
+@Import(BaseLangchain4JAiAgentTests.CamundaDocumentTestConfiguration.class)
 abstract class BaseLangchain4JAiAgentTests extends BaseAiAgentTest {
   @MockitoBean private ChatModelFactory chatModelFactory;
   @Mock protected ChatModel chatModel;
@@ -84,8 +91,20 @@ abstract class BaseLangchain4JAiAgentTests extends BaseAiAgentTest {
   protected final AtomicReference<Map<String, Object>> userFeedbackVariables =
       new AtomicReference<>(Collections.emptyMap());
 
+  @TestConfiguration
+  static class CamundaDocumentTestConfiguration {
+
+    @Bean
+    @Primary
+    public CamundaDocumentStore camundaDocumentStore() {
+      return InMemoryDocumentStore.INSTANCE;
+    }
+  }
+
   @BeforeEach
   void setUp() {
+    InMemoryDocumentStore.INSTANCE.clear();
+
     when(chatModelFactory.createChatModel(any())).thenReturn(chatModel);
     openUserFeedbackJobWorker();
 

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/langchain4j/BaseLangchain4JAiAgentTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/langchain4j/BaseLangchain4JAiAgentTests.java
@@ -18,14 +18,14 @@ package io.camunda.connector.e2e.agenticai.aiagent.langchain4j;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
-import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.when;
 
-import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
 import dev.langchain4j.agent.tool.ToolExecutionRequest;
 import dev.langchain4j.agent.tool.ToolSpecification;
 import dev.langchain4j.data.message.AiMessage;
@@ -64,7 +64,6 @@ import org.assertj.core.api.ThrowingConsumer;
 import org.assertj.core.api.recursive.comparison.RecursiveComparisonConfiguration;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.extension.RegisterExtension;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
@@ -73,11 +72,8 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 
 @SlowTest
+@WireMockTest
 abstract class BaseLangchain4JAiAgentTests extends BaseAiAgentTest {
-  @RegisterExtension
-  static WireMockExtension wm =
-      WireMockExtension.newInstance().options(wireMockConfig().dynamicPort()).build();
-
   @MockitoBean private ChatModelFactory chatModelFactory;
   @Mock protected ChatModel chatModel;
   @Captor protected ArgumentCaptor<ChatRequest> chatRequestCaptor;
@@ -95,7 +91,7 @@ abstract class BaseLangchain4JAiAgentTests extends BaseAiAgentTest {
 
     // WireMock returns the content type for the YAML file as application/json, so
     // we need to override the stub manually
-    wm.stubFor(
+    stubFor(
         get(urlPathEqualTo("/test.yaml"))
             .willReturn(
                 aResponse()

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/langchain4j/Langchain4JAiAgentMemoryStorageTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/langchain4j/Langchain4JAiAgentMemoryStorageTests.java
@@ -18,7 +18,6 @@ package io.camunda.connector.e2e.agenticai.aiagent.langchain4j;
 
 import static io.camunda.connector.e2e.agenticai.aiagent.AiAgentTestFixtures.FEEDBACK_LOOP_RESPONSE_TEXT;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.entry;
 import static org.assertj.core.api.Assertions.within;
 
 import io.camunda.connector.agenticai.aiagent.memory.conversation.document.CamundaDocumentConversationContext;
@@ -28,6 +27,7 @@ import io.camunda.connector.test.SlowTest;
 import io.camunda.document.reference.DocumentReference.CamundaDocumentReference;
 import java.time.Duration;
 import java.time.OffsetDateTime;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 
 @SlowTest
@@ -92,9 +92,10 @@ public class Langchain4JAiAgentMemoryStorageTests extends BaseLangchain4JAiAgent
                                       OffsetDateTime.now().plusHours(1),
                                       within(Duration.ofSeconds(20)));
                               assertThat(doc.getMetadata().getCustomProperties())
-                                  .containsExactly(
-                                      entry("conversationId", conversation.id()),
-                                      entry("customProperty", "customValue"));
+                                  .containsExactlyInAnyOrderEntriesOf(
+                                      Map.ofEntries(
+                                          Map.entry("conversationId", conversation.id()),
+                                          Map.entry("customProperty", "customValue")));
                             });
                   });
         });

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/langchain4j/Langchain4JAiAgentToolCallingTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/langchain4j/Langchain4JAiAgentToolCallingTests.java
@@ -19,6 +19,7 @@ package io.camunda.connector.e2e.agenticai.aiagent.langchain4j;
 import static io.camunda.connector.e2e.agenticai.aiagent.AiAgentTestFixtures.FEEDBACK_LOOP_RESPONSE_TEXT;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
 import dev.langchain4j.agent.tool.ToolExecutionRequest;
 import dev.langchain4j.data.message.AiMessage;
 import dev.langchain4j.data.message.SystemMessage;
@@ -67,7 +68,8 @@ public class Langchain4JAiAgentToolCallingTests extends BaseLangchain4JAiAgentTe
     "test.xml,text,application/xml",
     "test.yaml,text,application/yaml"
   })
-  void supportsDocumentResponsesFromToolCalls(String filename, String type, String mimeType)
+  void supportsDocumentResponsesFromToolCalls(
+      String filename, String type, String mimeType, WireMockRuntimeInfo wireMock)
       throws Exception {
     DownloadFileToolResult expectedDownloadFileResult;
     if (type.equals("text")) {
@@ -95,7 +97,9 @@ public class Langchain4JAiAgentToolCallingTests extends BaseLangchain4JAiAgentTe
                     ToolExecutionRequest.builder()
                         .id("aaa111")
                         .name("Download_A_File")
-                        .arguments("{\"url\": \"%s\"}".formatted(wm.baseUrl() + "/" + filename))
+                        .arguments(
+                            "{\"url\": \"%s\"}"
+                                .formatted(wireMock.getHttpBaseUrl() + "/" + filename))
                         .build())),
             new ToolExecutionResultMessage(
                 "aaa111",

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/langchain4j/Langchain4JAiAgentToolCallingTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/langchain4j/Langchain4JAiAgentToolCallingTests.java
@@ -56,9 +56,16 @@ public class Langchain4JAiAgentToolCallingTests extends BaseLangchain4JAiAgentTe
 
   @ParameterizedTest
   @CsvSource({
+    "test.csv,text,text/csv",
+    "test.gif,base64,image/gif",
     "test.jpg,base64,image/jpeg",
     "test.json,text,application/json",
-    "test.pdf,base64,application/pdf"
+    "test.pdf,base64,application/pdf",
+    "test.png,base64,image/png",
+    "test.txt,text,text/plain",
+    "test.webp,base64,image/webp",
+    "test.xml,text,application/xml",
+    "test.yaml,text,application/yaml"
   })
   void supportsDocumentResponsesFromToolCalls(String filename, String type, String mimeType)
       throws Exception {

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/langchain4j/Langchain4JAiAgentUserPromptDocumentsTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/langchain4j/Langchain4JAiAgentUserPromptDocumentsTests.java
@@ -19,6 +19,7 @@ package io.camunda.connector.e2e.agenticai.aiagent.langchain4j;
 import static io.camunda.connector.e2e.agenticai.aiagent.AiAgentTestFixtures.AI_AGENT_TASK_ID;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
 import dev.langchain4j.data.message.AiMessage;
 import dev.langchain4j.data.message.Content;
 import dev.langchain4j.data.message.ImageContent;
@@ -58,7 +59,7 @@ public class Langchain4JAiAgentUserPromptDocumentsTests extends BaseLangchain4JA
         "test.xml",
         "test.yaml"
       })
-  void handlesDocumentType(String filename) throws Exception {
+  void handlesDocumentType(String filename, WireMockRuntimeInfo wireMock) throws Exception {
     final var initialUserPrompt = "Summarize the following document";
     final var expectedConversation =
         List.of(
@@ -92,7 +93,7 @@ public class Langchain4JAiAgentUserPromptDocumentsTests extends BaseLangchain4JA
                     "userPrompt",
                     initialUserPrompt,
                     "downloadUrls",
-                    List.of(wm.baseUrl() + "/" + filename)))
+                    List.of(wireMock.getHttpBaseUrl() + "/" + filename)))
             .waitForProcessCompletion();
 
     assertLastChatRequest(1, expectedConversation);
@@ -110,7 +111,7 @@ public class Langchain4JAiAgentUserPromptDocumentsTests extends BaseLangchain4JA
   }
 
   @Test
-  void handlesMultipleDocuments() throws Exception {
+  void handlesMultipleDocuments(WireMockRuntimeInfo wireMock) throws Exception {
     final var initialUserPrompt = "Summarize the following documents";
     final var expectedConversation =
         List.of(
@@ -145,7 +146,9 @@ public class Langchain4JAiAgentUserPromptDocumentsTests extends BaseLangchain4JA
                     "userPrompt",
                     initialUserPrompt,
                     "downloadUrls",
-                    List.of(wm.baseUrl() + "/test.txt", wm.baseUrl() + "/test.jpg")))
+                    List.of(
+                        wireMock.getHttpBaseUrl() + "/test.txt",
+                        wireMock.getHttpBaseUrl() + "/test.jpg")))
             .waitForProcessCompletion();
 
     assertLastChatRequest(1, expectedConversation);
@@ -163,7 +166,7 @@ public class Langchain4JAiAgentUserPromptDocumentsTests extends BaseLangchain4JA
   }
 
   @Test
-  void raisesIncidentWhenDocumentTypeIsNotSupported() throws Exception {
+  void raisesIncidentWhenDocumentTypeIsNotSupported(WireMockRuntimeInfo wireMock) throws Exception {
     final var zeebeTest =
         createProcessInstance(
                 Map.of(
@@ -172,7 +175,7 @@ public class Langchain4JAiAgentUserPromptDocumentsTests extends BaseLangchain4JA
                     "userPrompt",
                     "Summarize the following document",
                     "downloadUrls",
-                    List.of(wm.baseUrl() + "/unsupported.zip")))
+                    List.of(wireMock.getHttpBaseUrl() + "/unsupported.zip")))
             .waitForActiveIncidents();
 
     assertIncident(

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/langchain4j/Langchain4JAiAgentUserPromptDocumentsTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/langchain4j/Langchain4JAiAgentUserPromptDocumentsTests.java
@@ -45,7 +45,19 @@ import org.junit.jupiter.params.provider.ValueSource;
 public class Langchain4JAiAgentUserPromptDocumentsTests extends BaseLangchain4JAiAgentTests {
 
   @ParameterizedTest
-  @ValueSource(strings = {"test.jpg", "test.json", "test.pdf"})
+  @ValueSource(
+      strings = {
+        "test.csv",
+        "test.gif",
+        "test.jpg",
+        "test.json",
+        "test.pdf",
+        "test.png",
+        "test.txt",
+        "test.webp",
+        "test.xml",
+        "test.yaml"
+      })
   void handlesDocumentType(String filename) throws Exception {
     final var initialUserPrompt = "Summarize the following document";
     final var expectedConversation =
@@ -177,9 +189,13 @@ public class Langchain4JAiAgentUserPromptDocumentsTests extends BaseLangchain4JA
     final Supplier<String> b64 = testFileContentBase64(filename);
 
     return switch (filename) {
-      case "test.txt", "test.json" -> TextContent.from(text.get());
+      case "test.txt", "test.yaml", "test.csv", "test.json", "test.xml" ->
+          TextContent.from(text.get());
       case "test.pdf" -> PdfFileContent.from(PdfFile.builder().base64Data(b64.get()).build());
+      case "test.gif" -> ImageContent.from(b64.get(), "image/gif", ImageContent.DetailLevel.AUTO);
       case "test.jpg" -> ImageContent.from(b64.get(), "image/jpeg", ImageContent.DetailLevel.AUTO);
+      case "test.png" -> ImageContent.from(b64.get(), "image/png", ImageContent.DetailLevel.AUTO);
+      case "test.webp" -> ImageContent.from(b64.get(), "image/webp", ImageContent.DetailLevel.AUTO);
       default -> throw new IllegalStateException("Unsupported file: " + filename);
     };
   }


### PR DESCRIPTION
## Description

Attempts to fix the e2e tests involving document handling by using an in memory document store, similar to what we already do in `connectors-e2e-test-http`.

## Related issues

closes #4950 

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.

