### PR TITLE
fix(google-maps): Fix address line null in validate address

### DIFF
--- a/connectors/google-maps-platform/element-templates/google-maps-platform-connector.json
+++ b/connectors/google-maps-platform/element-templates/google-maps-platform-connector.json
@@ -2,7 +2,7 @@
   "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
   "name": "Google Maps Platform Outbound Connector",
   "id": "io.camunda.connectors.GoogleMapsPlatform.v1",
-  "version": 4,
+  "version": 5,
   "engines": {
     "camunda": "^8.3"
   },
@@ -187,7 +187,7 @@
       "optional": false,
       "binding": {
         "type": "zeebe:input",
-        "name": "addressValue"
+        "name": "body.address.addressLines"
       },
       "constraints": {
         "notEmpty": true
@@ -357,25 +357,6 @@
         "property": "operationType",
         "oneOf": [
           "calculateDistance"
-        ]
-      }
-    },
-    {
-      "group": "input",
-      "type": "Hidden",
-      "optional": false,
-      "value": "=\"[\"+addressValue+\"]\"",
-      "binding": {
-        "type": "zeebe:input",
-        "name": "body.address.addressLines"
-      },
-      "constraints": {
-        "notEmpty": true
-      },
-      "condition": {
-        "property": "operationType",
-        "oneOf": [
-          "validateAddress"
         ]
       }
     },


### PR DESCRIPTION
## Description
Fix address line always null in requests.

Bug reported here: https://camunda.slack.com/archives/C02JLRNQQ05/p1750873921679819


## Checklist

- [x] PR has a **milestone** or the `no milestone` label.

