### PR TITLE
refactor(agentic-ai): rename alpha to experimental in MCP connectors

### DIFF
--- a/connectors/agentic-ai/element-templates/agenticai-mcp-client-outbound-connector.json
+++ b/connectors/agentic-ai/element-templates/agenticai-mcp-client-outbound-connector.json
@@ -1,6 +1,6 @@
 {
   "$schema" : "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
-  "name" : "MCP Client (alpha)",
+  "name" : "MCP Client (experimental)",
   "id" : "io.camunda.connectors.agenticai.mcp.client.v0",
   "description" : "MCP (Model Context Protocol) client using MCP connections configured on the connector runtime. Only supports tool operations. Compatible with 8.8.0-alpha6 or later.",
   "metadata" : {

--- a/connectors/agentic-ai/element-templates/agenticai-mcp-remote-client-outbound-connector.json
+++ b/connectors/agentic-ai/element-templates/agenticai-mcp-remote-client-outbound-connector.json
@@ -1,6 +1,6 @@
 {
   "$schema" : "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
-  "name" : "MCP Remote Client (alpha)",
+  "name" : "MCP Remote Client (experimental)",
   "id" : "io.camunda.connectors.agenticai.mcp.remoteclient.v0",
   "description" : "MCP (Model Context Protocol) client, operating on temporary remote connections. Only supports tool operations. Compatible with 8.8.0-alpha6 or later.",
   "metadata" : {

--- a/connectors/agentic-ai/element-templates/hybrid/agenticai-mcp-client-outbound-connector-hybrid.json
+++ b/connectors/agentic-ai/element-templates/hybrid/agenticai-mcp-client-outbound-connector-hybrid.json
@@ -1,6 +1,6 @@
 {
   "$schema" : "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
-  "name" : "Hybrid MCP Client (alpha)",
+  "name" : "Hybrid MCP Client (experimental)",
   "id" : "io.camunda.connectors.agenticai.mcp.client.v0-hybrid",
   "description" : "MCP (Model Context Protocol) client using MCP connections configured on the connector runtime. Only supports tool operations. Compatible with 8.8.0-alpha6 or later.",
   "metadata" : {

--- a/connectors/agentic-ai/element-templates/hybrid/agenticai-mcp-remote-client-outbound-connector-hybrid.json
+++ b/connectors/agentic-ai/element-templates/hybrid/agenticai-mcp-remote-client-outbound-connector-hybrid.json
@@ -1,6 +1,6 @@
 {
   "$schema" : "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
-  "name" : "Hybrid MCP Remote Client (alpha)",
+  "name" : "Hybrid MCP Remote Client (experimental)",
   "id" : "io.camunda.connectors.agenticai.mcp.remoteclient.v0-hybrid",
   "description" : "MCP (Model Context Protocol) client, operating on temporary remote connections. Only supports tool operations. Compatible with 8.8.0-alpha6 or later.",
   "metadata" : {

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/mcp/client/McpClientFunction.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/mcp/client/McpClientFunction.java
@@ -14,12 +14,12 @@ import io.camunda.connector.api.outbound.OutboundConnectorFunction;
 import io.camunda.connector.generator.java.annotation.ElementTemplate;
 
 @OutboundConnector(
-    name = "MCP Client (alpha)",
+    name = "MCP Client (experimental)",
     inputVariables = {"data"},
     type = McpClientFunction.MCP_CLIENT_TYPE)
 @ElementTemplate(
     id = "io.camunda.connectors.agenticai.mcp.client.v0",
-    name = "MCP Client (alpha)",
+    name = "MCP Client (experimental)",
     description =
         "MCP (Model Context Protocol) client using MCP connections configured on the connector runtime. Only supports tool operations. Compatible with 8.8.0-alpha6 or later.",
     engineVersion = "^8.8",

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/mcp/client/McpRemoteClientFunction.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/mcp/client/McpRemoteClientFunction.java
@@ -14,12 +14,12 @@ import io.camunda.connector.api.outbound.OutboundConnectorFunction;
 import io.camunda.connector.generator.java.annotation.ElementTemplate;
 
 @OutboundConnector(
-    name = "MCP Remote Client (alpha)",
+    name = "MCP Remote Client (experimental)",
     inputVariables = {"data"},
     type = McpRemoteClientFunction.MCP_REMOTE_CLIENT_TYPE)
 @ElementTemplate(
     id = "io.camunda.connectors.agenticai.mcp.remoteclient.v0",
-    name = "MCP Remote Client (alpha)",
+    name = "MCP Remote Client (experimental)",
     description =
         "MCP (Model Context Protocol) client, operating on temporary remote connections. Only supports tool operations. Compatible with 8.8.0-alpha6 or later.",
     engineVersion = "^8.8",


### PR DESCRIPTION
## Description

Rename MCP clients from alpha to experimental.

## Related issues

follow up to #4822 

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.

