### PR TITLE
feature(inbound-email-connector): the initial connection now has a retry mechanism for email inbound connector

### DIFF
--- a/connectors/email/pom.xml
+++ b/connectors/email/pom.xml
@@ -43,6 +43,10 @@
             <version>4.3.0</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>dev.failsafe</groupId>
+            <artifactId>failsafe</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/connectors/email/src/main/java/io/camunda/connector/email/client/jakarta/inbound/JakartaEmailListener.java
+++ b/connectors/email/src/main/java/io/camunda/connector/email/client/jakarta/inbound/JakartaEmailListener.java
@@ -6,16 +6,25 @@
  */
 package io.camunda.connector.email.client.jakarta.inbound;
 
+import dev.failsafe.Failsafe;
+import dev.failsafe.RetryPolicy;
+import io.camunda.connector.api.inbound.Activity;
+import io.camunda.connector.api.inbound.Health;
 import io.camunda.connector.api.inbound.InboundConnectorContext;
+import io.camunda.connector.api.inbound.Severity;
 import io.camunda.connector.email.client.EmailListener;
 import io.camunda.connector.email.client.jakarta.utils.JakartaUtils;
+import io.camunda.connector.email.exception.EmailConnectorException;
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
 import java.util.Objects;
 import java.util.concurrent.*;
 
 public class JakartaEmailListener implements EmailListener {
 
+  private static final int INFINITE_RETRIES = -1;
   private ScheduledExecutorService scheduledExecutorService;
-  private PollingManager pollingManager;
+  private CompletableFuture<PollingManager> pollingManagerFuture;
 
   public JakartaEmailListener() {}
 
@@ -25,10 +34,41 @@ public class JakartaEmailListener implements EmailListener {
 
   @Override
   public void startListener(InboundConnectorContext context) {
-    scheduledExecutorService = Executors.newSingleThreadScheduledExecutor();
-    pollingManager = PollingManager.create(context, new JakartaUtils());
-    scheduledExecutorService.scheduleWithFixedDelay(
-        pollingManager::poll, 0, pollingManager.delay(), TimeUnit.SECONDS);
+    scheduledExecutorService =
+        Executors.newSingleThreadScheduledExecutor(r -> new Thread(r, "Jakarta Email Listener"));
+    RetryPolicy<Object> retryPolicy =
+        RetryPolicy.builder()
+            .handle(EmailConnectorException.class)
+            .withBackoff(Duration.of(5, ChronoUnit.SECONDS), Duration.of(1, ChronoUnit.HOURS))
+            .withMaxAttempts(INFINITE_RETRIES)
+            .onRetry(
+                event ->
+                    context.log(
+                        Activity.level(Severity.WARNING)
+                            .tag("Context creation")
+                            .message(
+                                "Retrying after attempt %s failed ..."
+                                    .formatted(event.getAttemptCount()))))
+            .build();
+    this.pollingManagerFuture =
+        Failsafe.with(retryPolicy)
+            .with(scheduledExecutorService)
+            .getAsync(() -> PollingManager.create(context, new JakartaUtils()))
+            .whenComplete(
+                (pollingManager, throwable) -> {
+                  if (throwable != null) {
+                    context.reportHealth(Health.down(throwable));
+                    context.log(
+                        Activity.level(Severity.ERROR)
+                            .tag("Context creation")
+                            .message(throwable.getMessage()));
+                    this.stopListener();
+                  } else context.reportHealth(Health.up());
+                });
+    this.pollingManagerFuture.thenAccept(
+        pollingManager ->
+            scheduledExecutorService.scheduleWithFixedDelay(
+                pollingManager::poll, 0, pollingManager.delay(), TimeUnit.SECONDS));
   }
 
   @Override
@@ -39,7 +79,9 @@ public class JakartaEmailListener implements EmailListener {
         if (!this.scheduledExecutorService.awaitTermination(10, TimeUnit.SECONDS))
           this.scheduledExecutorService.shutdownNow();
       }
-      if (!Objects.isNull(pollingManager)) pollingManager.stop();
+      if (this.pollingManagerFuture.isDone() && !pollingManagerFuture.isCompletedExceptionally()) {
+        this.pollingManagerFuture.join().stop();
+      }
     } catch (InterruptedException e) {
       this.scheduledExecutorService.shutdownNow();
     }

--- a/connectors/email/src/main/java/io/camunda/connector/email/client/jakarta/inbound/PollingManager.java
+++ b/connectors/email/src/main/java/io/camunda/connector/email/client/jakarta/inbound/PollingManager.java
@@ -6,12 +6,12 @@
  */
 package io.camunda.connector.email.client.jakarta.inbound;
 
-import io.camunda.connector.api.error.ConnectorException;
 import io.camunda.connector.api.error.ConnectorRetryException;
 import io.camunda.connector.api.inbound.*;
 import io.camunda.connector.email.authentication.Authentication;
 import io.camunda.connector.email.client.jakarta.models.Email;
 import io.camunda.connector.email.client.jakarta.utils.JakartaUtils;
+import io.camunda.connector.email.exception.EmailConnectorException;
 import io.camunda.connector.email.inbound.model.*;
 import io.camunda.connector.email.response.ReadEmailResponse;
 import io.camunda.document.Document;
@@ -24,6 +24,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 import org.eclipse.angus.mail.imap.IMAPMessage;
+import org.eclipse.angus.mail.util.MailConnectException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -87,6 +88,16 @@ public class PollingManager {
             "If the post process action is `MOVE`, a target folder must be specified");
       return new PollingManager(
           connectorContext, emailListenerConfig, authentication, jakartaUtils, folder, store);
+    } catch (AuthenticationFailedException exception) {
+      connectorContext.log(
+          Activity.level(Severity.ERROR)
+              .tag("Authentication error")
+              .message("Authentication failed"));
+      throw new RuntimeException(exception);
+    } catch (MailConnectException exception) {
+      connectorContext.log(
+          Activity.level(Severity.ERROR).tag("Connection error").message("Connection failed"));
+      throw new EmailConnectorException(exception);
     } catch (MessagingException e) {
       try {
         if (folder != null && folder.isOpen()) {
@@ -96,9 +107,9 @@ public class PollingManager {
           store.close();
         }
       } catch (MessagingException ex) {
-        throw new RuntimeException(ex);
+        throw new EmailConnectorException(ex);
       }
-      throw new RuntimeException(e);
+      throw new EmailConnectorException(e);
     }
   }
 
@@ -187,7 +198,13 @@ public class PollingManager {
     } catch (Exception e) {
       this.connectorContext.log(
           Activity.level(Severity.ERROR).tag("mail-polling").message(e.getMessage()));
-      this.connectorContext.cancel(new ConnectorException(e.getMessage(), e));
+      this.connectorContext.cancel(
+          ConnectorRetryException.builder()
+              .cause(e)
+              .message(e.getMessage())
+              .retries(1)
+              .backoffDuration(Duration.of(5, ChronoUnit.SECONDS))
+              .build());
     }
   }
 
@@ -204,8 +221,8 @@ public class PollingManager {
           ConnectorRetryException.builder()
               .cause(e)
               .message(e.getMessage())
-              .retries(2)
-              .backoffDuration(Duration.of(3, ChronoUnit.SECONDS))
+              .retries(1)
+              .backoffDuration(Duration.of(5, ChronoUnit.SECONDS))
               .build());
     }
   }

--- a/connectors/email/src/main/java/io/camunda/connector/email/client/jakarta/utils/JakartaUtils.java
+++ b/connectors/email/src/main/java/io/camunda/connector/email/client/jakarta/utils/JakartaUtils.java
@@ -178,9 +178,10 @@ public class JakartaUtils {
         Optional.of(folderPath)
             .map(string -> string.split(REGEX_PATH_SPLITTER))
             .map(strings -> String.join(String.valueOf(separator), strings))
-            .orElseThrow(() -> new RuntimeException("No folder has been set"));
+            .orElseThrow(() -> new MessagingException("No folder has been set"));
     Folder folder = store.getFolder(formattedPath);
-    if (!folder.exists()) throw new RuntimeException("Folder " + formattedPath + " does not exist");
+    if (!folder.exists())
+      throw new MessagingException("Folder " + formattedPath + " does not exist");
     return folder;
   }
 
@@ -284,8 +285,8 @@ public class JakartaUtils {
       throws MessagingException, IOException {
     BodyPart bodyPart = multipart.getBodyPart(i);
     switch (bodyPart.getContent()) {
-      case InputStream attachment when Part.ATTACHMENT.equalsIgnoreCase(
-              bodyPart.getDisposition()) ->
+      case InputStream attachment
+          when Part.ATTACHMENT.equalsIgnoreCase(bodyPart.getDisposition()) ->
           emailBodyBuilder.addAttachment(
               new EmailAttachment(
                   attachment,

--- a/connectors/email/src/main/java/io/camunda/connector/email/exception/EmailConnectorException.java
+++ b/connectors/email/src/main/java/io/camunda/connector/email/exception/EmailConnectorException.java
@@ -1,0 +1,7 @@
+package io.camunda.connector.email.exception;
+
+import jakarta.mail.MessagingException;
+
+public class EmailConnectorException extends RuntimeException {
+  public EmailConnectorException(MessagingException e) {}
+}


### PR DESCRIPTION
## Description

All connection failures now trigger a retry mechanism with an exponential backoff, expect if credentials are wrong, then the connector is deactivated.

## Related issues

closes https://github.com/camunda/connectors/issues/4911

## Checklist

- [ ] PR has a **milestone** or the `no milestone` label.

