### PR TITLE
fix(operate-client): Increase version

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -72,7 +72,7 @@ limitations under the License.</license.inlineheader>
     <!-- Camunda internal libraries -->
     <version.zeebe>8.7.6</version.zeebe>
     <version.camunda-process-test>8.7.6</version.camunda-process-test>
-    <version.operate-client>8.7.1-rc1</version.operate-client>
+    <version.operate-client>8.7.1</version.operate-client>
     <version.feel-engine>1.19.3</version.feel-engine>
     <!-- Third party dependencies -->
 


### PR DESCRIPTION
## Description

increase the operate client version, which supports client_assertion. 

Released just now: https://github.com/camunda-community-hub/camunda-operate-client-java/actions

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.

