### PR TITLE
feat(runtime): Add env variable override support to connectors registered as Spring beans

### DIFF
--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/ConnectorUtil.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/ConnectorUtil.java
@@ -20,10 +20,10 @@ import io.camunda.connector.api.annotation.InboundConnector;
 import io.camunda.connector.api.annotation.OutboundConnector;
 import io.camunda.connector.api.inbound.InboundConnectorExecutable;
 import io.camunda.connector.api.outbound.OutboundConnectorFunction;
+import io.camunda.connector.runtime.core.config.ConnectorConfigurationOverrides;
 import io.camunda.connector.runtime.core.config.InboundConnectorConfiguration;
 import io.camunda.connector.runtime.core.config.OutboundConnectorConfiguration;
 import java.util.Arrays;
-import java.util.Map;
 import java.util.Optional;
 
 public final class ConnectorUtil {
@@ -32,19 +32,15 @@ public final class ConnectorUtil {
 
   public static Optional<OutboundConnectorConfiguration> getOutboundConnectorConfiguration(
       Class<? extends OutboundConnectorFunction> cls) {
-    Map<String, String> env = System.getenv();
     var annotation = Optional.ofNullable(cls.getAnnotation(OutboundConnector.class));
     if (annotation.isPresent()) {
-      final var normalizedConnectorName =
-          toConnectorTypeEnvVariable(toNormalizedConnectorName(annotation.get().name()));
-      final var normalizedConnectorTimeout =
-          toConnectorTimeoutEnvVariable(toNormalizedConnectorName(annotation.get().name()));
+      final var configurationOverrides =
+          new ConnectorConfigurationOverrides(annotation.get().name(), System::getenv);
       final var type =
-          Optional.ofNullable(env.get(normalizedConnectorName)).orElse(annotation.get().type());
-      final var timeout =
-          Optional.ofNullable(env.get(normalizedConnectorTimeout))
-              .map(Long::parseLong)
-              .orElse(null);
+          Optional.ofNullable(configurationOverrides.typeOverride())
+              .orElse(annotation.get().type());
+      final var timeout = configurationOverrides.timeoutOverride();
+
       return Optional.of(
           new OutboundConnectorConfiguration(
               annotation.get().name(), annotation.get().inputVariables(), type, cls, timeout));
@@ -65,13 +61,14 @@ public final class ConnectorUtil {
 
   public static Optional<InboundConnectorConfiguration> getInboundConnectorConfiguration(
       Class<? extends InboundConnectorExecutable> cls) {
-    Map<String, String> env = System.getenv();
     var annotation = Optional.ofNullable(cls.getAnnotation(InboundConnector.class));
     if (annotation.isPresent()) {
-      final var normalizedConnectorName =
-          toConnectorTypeEnvVariable(toNormalizedConnectorName(annotation.get().name()));
+      final var configurationOverrides =
+          new ConnectorConfigurationOverrides(annotation.get().name(), System::getenv);
       final var type =
-          Optional.ofNullable(env.get(normalizedConnectorName)).orElse(annotation.get().type());
+          Optional.ofNullable(configurationOverrides.typeOverride())
+              .orElse(annotation.get().type());
+
       final var deduplicationProperties = Arrays.asList(annotation.get().deduplicationProperties());
       return Optional.of(
           new InboundConnectorConfiguration(
@@ -89,17 +86,5 @@ public final class ConnectorUtil {
                     String.format(
                         "InboundConnectorExecutable %s is missing @InboundConnector annotation",
                         cls)));
-  }
-
-  private static String toNormalizedConnectorName(final String connectorName) {
-    return connectorName.trim().replaceAll("[^a-zA-Z0-9_ ]", "").replaceAll(" ", "_").toUpperCase();
-  }
-
-  private static String toConnectorTypeEnvVariable(final String normalizedConnectorName) {
-    return "CONNECTOR_" + normalizedConnectorName + "_TYPE";
-  }
-
-  private static String toConnectorTimeoutEnvVariable(final String normalizedConnectorName) {
-    return "CONNECTOR_" + normalizedConnectorName + "_TIMEOUT";
   }
 }

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/ConnectorUtil.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/ConnectorUtil.java
@@ -32,20 +32,19 @@ public final class ConnectorUtil {
 
   public static Optional<OutboundConnectorConfiguration> getOutboundConnectorConfiguration(
       Class<? extends OutboundConnectorFunction> cls) {
-    var annotation = Optional.ofNullable(cls.getAnnotation(OutboundConnector.class));
-    if (annotation.isPresent()) {
-      final var configurationOverrides =
-          new ConnectorConfigurationOverrides(annotation.get().name(), System::getenv);
-      final var type =
-          Optional.ofNullable(configurationOverrides.typeOverride())
-              .orElse(annotation.get().type());
-      final var timeout = configurationOverrides.timeoutOverride();
+    return Optional.ofNullable(cls.getAnnotation(OutboundConnector.class))
+        .map(
+            annotation -> {
+              final var configurationOverrides =
+                  new ConnectorConfigurationOverrides(annotation.name(), System::getenv);
 
-      return Optional.of(
-          new OutboundConnectorConfiguration(
-              annotation.get().name(), annotation.get().inputVariables(), type, cls, timeout));
-    }
-    return Optional.empty();
+              return new OutboundConnectorConfiguration(
+                  annotation.name(),
+                  annotation.inputVariables(),
+                  configurationOverrides.typeOverride().orElse(annotation.type()),
+                  cls,
+                  configurationOverrides.timeoutOverride().orElse(null));
+            });
   }
 
   public static OutboundConnectorConfiguration getRequiredOutboundConnectorConfiguration(
@@ -61,20 +60,20 @@ public final class ConnectorUtil {
 
   public static Optional<InboundConnectorConfiguration> getInboundConnectorConfiguration(
       Class<? extends InboundConnectorExecutable> cls) {
-    var annotation = Optional.ofNullable(cls.getAnnotation(InboundConnector.class));
-    if (annotation.isPresent()) {
-      final var configurationOverrides =
-          new ConnectorConfigurationOverrides(annotation.get().name(), System::getenv);
-      final var type =
-          Optional.ofNullable(configurationOverrides.typeOverride())
-              .orElse(annotation.get().type());
+    return Optional.ofNullable(cls.getAnnotation(InboundConnector.class))
+        .map(
+            annotation -> {
+              final var configurationOverrides =
+                  new ConnectorConfigurationOverrides(annotation.name(), System::getenv);
+              final var deduplicationProperties =
+                  Arrays.asList(annotation.deduplicationProperties());
 
-      final var deduplicationProperties = Arrays.asList(annotation.get().deduplicationProperties());
-      return Optional.of(
-          new InboundConnectorConfiguration(
-              annotation.get().name(), type, cls, deduplicationProperties));
-    }
-    return Optional.empty();
+              return new InboundConnectorConfiguration(
+                  annotation.name(),
+                  configurationOverrides.typeOverride().orElse(annotation.type()),
+                  cls,
+                  deduplicationProperties);
+            });
   }
 
   public static InboundConnectorConfiguration getRequiredInboundConnectorConfiguration(

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/config/ConnectorConfigurationOverrides.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/config/ConnectorConfigurationOverrides.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.runtime.core.config;
+
+import java.util.Optional;
+import java.util.function.Function;
+
+public class ConnectorConfigurationOverrides {
+  private final String normalizedConnectorName;
+  private final Function<String, String> propertySource;
+
+  public ConnectorConfigurationOverrides(
+      String connectorName, Function<String, String> propertySource) {
+    this.normalizedConnectorName = toNormalizedConnectorName(connectorName);
+    this.propertySource = propertySource;
+  }
+
+  public String typeOverride() {
+    return getProperty("CONNECTOR_" + normalizedConnectorName + "_TYPE");
+  }
+
+  public Long timeoutOverride() {
+    return Optional.ofNullable(getProperty("CONNECTOR_" + normalizedConnectorName + "_TIMEOUT"))
+        .map(Long::parseLong)
+        .orElse(null);
+  }
+
+  private String getProperty(String propertyName) {
+    return propertySource.apply(propertyName);
+  }
+
+  private String toNormalizedConnectorName(final String connectorName) {
+    return connectorName.trim().replaceAll("[^a-zA-Z0-9_ ]", "").replaceAll(" ", "_").toUpperCase();
+  }
+}

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/config/ConnectorConfigurationOverrides.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/config/ConnectorConfigurationOverrides.java
@@ -19,6 +19,18 @@ package io.camunda.connector.runtime.core.config;
 import java.util.Optional;
 import java.util.function.Function;
 
+/**
+ * Handles connector overrides such as type and timeout using environment variables.
+ *
+ * <p>Lookup is done by normalizing the connector name to a set of variables to look for. For
+ * example, for a connector named "My Connector", the following environment variables will be
+ * checked:
+ *
+ * <ul>
+ *   <li>CONNECTOR_MY_CONNECTOR_TYPE
+ *   <li>CONNECTOR_MY_CONNECTOR_TIMEOUT
+ * </ul>
+ */
 public class ConnectorConfigurationOverrides {
   private static final String TYPE_PROPERTY_TPL = "CONNECTOR_%s_TYPE";
   private static final String TIMEOUT_PROPERTY_TPL = "CONNECTOR_%s_TIMEOUT";
@@ -45,6 +57,20 @@ public class ConnectorConfigurationOverrides {
     return propertySource.apply(propertyName);
   }
 
+  /**
+   * Replaces everything except alphanumeric characters, underscores, and spaces with an empty
+   * string, replaces spaces with underscores, and converts to uppercase.
+   *
+   * <p>Examples:
+   *
+   * <ul>
+   *   <li>"My connector" -> "MY_CONNECTOR"
+   *   <li>"My super-fancy connector" -> "MY_SUPERFANCY_CONNECTOR"
+   *   <li>"my_connector" -> "MY_CONNECTOR"
+   *   <li>"my-connector" -> "MYCONNECTOR"
+   *   <li>"my.connector" -> "MYCONNECTOR"
+   * </ul>
+   */
   private String toNormalizedConnectorName(final String connectorName) {
     return connectorName.trim().replaceAll("[^a-zA-Z0-9_ ]", "").replaceAll(" ", "_").toUpperCase();
   }

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/config/ConnectorConfigurationOverrides.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/config/ConnectorConfigurationOverrides.java
@@ -29,14 +29,13 @@ public class ConnectorConfigurationOverrides {
     this.propertySource = propertySource;
   }
 
-  public String typeOverride() {
-    return getProperty("CONNECTOR_" + normalizedConnectorName + "_TYPE");
+  public Optional<String> typeOverride() {
+    return Optional.ofNullable(getProperty("CONNECTOR_" + normalizedConnectorName + "_TYPE"));
   }
 
-  public Long timeoutOverride() {
+  public Optional<Long> timeoutOverride() {
     return Optional.ofNullable(getProperty("CONNECTOR_" + normalizedConnectorName + "_TIMEOUT"))
-        .map(Long::parseLong)
-        .orElse(null);
+        .map(Long::parseLong);
   }
 
   private String getProperty(String propertyName) {

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/config/ConnectorConfigurationOverrides.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/config/ConnectorConfigurationOverrides.java
@@ -20,6 +20,9 @@ import java.util.Optional;
 import java.util.function.Function;
 
 public class ConnectorConfigurationOverrides {
+  private static final String TYPE_PROPERTY_TPL = "CONNECTOR_%s_TYPE";
+  private static final String TIMEOUT_PROPERTY_TPL = "CONNECTOR_%s_TIMEOUT";
+
   private final String normalizedConnectorName;
   private final Function<String, String> propertySource;
 
@@ -30,11 +33,11 @@ public class ConnectorConfigurationOverrides {
   }
 
   public Optional<String> typeOverride() {
-    return Optional.ofNullable(getProperty("CONNECTOR_" + normalizedConnectorName + "_TYPE"));
+    return Optional.ofNullable(getProperty(TYPE_PROPERTY_TPL.formatted(normalizedConnectorName)));
   }
 
   public Optional<Long> timeoutOverride() {
-    return Optional.ofNullable(getProperty("CONNECTOR_" + normalizedConnectorName + "_TIMEOUT"))
+    return Optional.ofNullable(getProperty(TIMEOUT_PROPERTY_TPL.formatted(normalizedConnectorName)))
         .map(Long::parseLong);
   }
 

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/InboundConnectorRuntimeConfiguration.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/InboundConnectorRuntimeConfiguration.java
@@ -53,6 +53,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
+import org.springframework.core.env.Environment;
 
 @Configuration
 @Import({
@@ -67,8 +68,9 @@ public class InboundConnectorRuntimeConfiguration {
   private Duration messageTtl;
 
   @Bean
-  public static InboundConnectorBeanDefinitionProcessor inboundConnectorBeanDefinitionProcessor() {
-    return new InboundConnectorBeanDefinitionProcessor();
+  public static InboundConnectorBeanDefinitionProcessor inboundConnectorBeanDefinitionProcessor(
+      Environment environment) {
+    return new InboundConnectorBeanDefinitionProcessor(environment);
   }
 
   @Bean

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/OutboundConnectorRuntimeConfiguration.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/OutboundConnectorRuntimeConfiguration.java
@@ -36,6 +36,7 @@ import io.micrometer.core.instrument.MeterRegistry;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
 
 @Configuration
 public class OutboundConnectorRuntimeConfiguration {
@@ -79,8 +80,8 @@ public class OutboundConnectorRuntimeConfiguration {
 
   @Bean
   public OutboundConnectorAnnotationProcessor annotationProcessor(
-      OutboundConnectorManager manager, OutboundConnectorFactory factory) {
-    return new OutboundConnectorAnnotationProcessor(manager, factory);
+      Environment environment, OutboundConnectorManager manager, OutboundConnectorFactory factory) {
+    return new OutboundConnectorAnnotationProcessor(environment, manager, factory);
   }
 
   @Bean

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/inbound/InboundConnectorBeanDefinitionProcessorTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/inbound/InboundConnectorBeanDefinitionProcessorTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.runtime.inbound;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+
+import io.camunda.connector.api.annotation.InboundConnector;
+import io.camunda.connector.api.inbound.InboundConnectorContext;
+import io.camunda.connector.api.inbound.InboundConnectorExecutable;
+import io.camunda.connector.runtime.core.config.InboundConnectorConfiguration;
+import io.camunda.connector.runtime.core.inbound.InboundConnectorFactory;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Scope;
+import org.springframework.core.env.Environment;
+import org.springframework.stereotype.Component;
+
+@ExtendWith(MockitoExtension.class)
+class InboundConnectorBeanDefinitionProcessorTest {
+
+  @Mock private InboundConnectorFactory inboundConnectorFactory;
+  @Captor private ArgumentCaptor<InboundConnectorConfiguration> registeredConfigurationCaptor;
+
+  private final ApplicationContextRunner contextRunner =
+      new ApplicationContextRunner()
+          .withBean(InboundConnectorFactory.class, () -> inboundConnectorFactory)
+          .withUserConfiguration(TestConfig.class, AnnotatedExecutable.class);
+
+  private static class TestConfig {
+    @Bean
+    public static InboundConnectorBeanDefinitionProcessor inboundConnectorBeanDefinitionProcessor(
+        Environment environment) {
+      return new InboundConnectorBeanDefinitionProcessor(environment);
+    }
+  }
+
+  @Test
+  void registersInboundConnectorFunctionBean() {
+    contextRunner.run(
+        context -> {
+          verify(inboundConnectorFactory)
+              .registerConfiguration(registeredConfigurationCaptor.capture());
+
+          assertThat(registeredConfigurationCaptor.getValue())
+              .satisfies(
+                  config -> {
+                    assertThat(config.name()).isEqualTo("My Executable");
+                    assertThat(config.type()).isEqualTo("io.camunda:annotated");
+                    assertThat(config.deduplicationProperties()).containsExactly("id");
+                    assertThat(config.customInstanceSupplier().get())
+                        .isInstanceOf(AnnotatedExecutable.class);
+                  });
+        });
+  }
+
+  @Test
+  void overridesType() {
+    contextRunner
+        .withPropertyValues("CONNECTOR_MY_EXECUTABLE_TYPE=io.camunda:overridden")
+        .run(
+            context -> {
+              verify(inboundConnectorFactory)
+                  .registerConfiguration(registeredConfigurationCaptor.capture());
+
+              assertThat(registeredConfigurationCaptor.getValue())
+                  .satisfies(
+                      config -> {
+                        assertThat(config.name()).isEqualTo("My Executable");
+                        assertThat(config.type()).isEqualTo("io.camunda:overridden");
+                        assertThat(config.deduplicationProperties()).containsExactly("id");
+                        assertThat(config.customInstanceSupplier().get())
+                            .isInstanceOf(AnnotatedExecutable.class);
+                      });
+            });
+  }
+}
+
+@InboundConnector(
+    name = "My Executable",
+    type = "io.camunda:annotated",
+    deduplicationProperties = {"id"})
+@Component
+@Scope("prototype")
+class AnnotatedExecutable implements InboundConnectorExecutable {
+
+  @Override
+  public void activate(InboundConnectorContext context) {}
+
+  @Override
+  public void deactivate() {}
+}

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/lifecycle/OutboundConnectorAnnotationProcessorTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/lifecycle/OutboundConnectorAnnotationProcessorTest.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.runtime.outbound.lifecycle;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.connector.api.annotation.OutboundConnector;
+import io.camunda.connector.api.outbound.OutboundConnectorContext;
+import io.camunda.connector.api.outbound.OutboundConnectorFunction;
+import io.camunda.connector.runtime.core.config.OutboundConnectorConfiguration;
+import io.camunda.connector.runtime.core.outbound.OutboundConnectorFactory;
+import org.assertj.core.api.ThrowingConsumer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.core.env.Environment;
+import org.springframework.stereotype.Component;
+
+@ExtendWith(MockitoExtension.class)
+class OutboundConnectorAnnotationProcessorTest {
+
+  @Mock private CamundaClient camundaClient;
+  @Mock private OutboundConnectorManager outboundConnectorManager;
+  @Mock private OutboundConnectorFactory outboundConnectorFactory;
+
+  @Captor private ArgumentCaptor<OutboundConnectorConfiguration> registeredConfigurationCaptor;
+
+  private final ApplicationContextRunner contextRunner =
+      new ApplicationContextRunner()
+          .withBean(CamundaClient.class, () -> camundaClient)
+          .withBean(OutboundConnectorManager.class, () -> outboundConnectorManager)
+          .withBean(OutboundConnectorFactory.class, () -> outboundConnectorFactory)
+          .withUserConfiguration(TestConfig.class, AnnotatedFunction.class);
+
+  private static class TestConfig {
+    @Bean
+    public OutboundConnectorAnnotationProcessor annotationProcessor(
+        Environment environment,
+        OutboundConnectorManager manager,
+        OutboundConnectorFactory factory) {
+      return new OutboundConnectorAnnotationProcessor(environment, manager, factory);
+    }
+  }
+
+  @Test
+  void registersOutboundConnectorFunctionBean() {
+    runTest(
+        contextRunner,
+        config -> {
+          assertThat(config.name()).isEqualTo("My Function");
+          assertThat(config.type()).isEqualTo("io.camunda:annotated");
+          assertThat(config.inputVariables()).isEqualTo(new String[] {"a", "b"});
+          assertThat(config.timeout()).isNull();
+          assertThat(config.customInstanceSupplier().get()).isInstanceOf(AnnotatedFunction.class);
+        });
+  }
+
+  @Test
+  void overridesType() {
+    runTest(
+        contextRunner.withPropertyValues("CONNECTOR_MY_FUNCTION_TYPE=io.camunda:overridden"),
+        config -> {
+          assertThat(config.name()).isEqualTo("My Function");
+          assertThat(config.type()).isEqualTo("io.camunda:overridden");
+          assertThat(config.inputVariables()).isEqualTo(new String[] {"a", "b"});
+          assertThat(config.timeout()).isNull();
+          assertThat(config.customInstanceSupplier().get()).isInstanceOf(AnnotatedFunction.class);
+        });
+  }
+
+  @Test
+  void overridesTimeout() {
+    runTest(
+        contextRunner.withPropertyValues("CONNECTOR_MY_FUNCTION_TIMEOUT=123456"),
+        config -> {
+          assertThat(config.name()).isEqualTo("My Function");
+          assertThat(config.type()).isEqualTo("io.camunda:annotated");
+          assertThat(config.inputVariables()).isEqualTo(new String[] {"a", "b"});
+          assertThat(config.timeout()).isEqualTo(123456L);
+          assertThat(config.customInstanceSupplier().get()).isInstanceOf(AnnotatedFunction.class);
+        });
+  }
+
+  @Test
+  void overridesTypeAndTimeout() {
+    runTest(
+        contextRunner.withPropertyValues(
+            "CONNECTOR_MY_FUNCTION_TYPE=io.camunda:overridden",
+            "CONNECTOR_MY_FUNCTION_TIMEOUT=123456"),
+        config -> {
+          assertThat(config.name()).isEqualTo("My Function");
+          assertThat(config.type()).isEqualTo("io.camunda:overridden");
+          assertThat(config.inputVariables()).isEqualTo(new String[] {"a", "b"});
+          assertThat(config.timeout()).isEqualTo(123456L);
+          assertThat(config.customInstanceSupplier().get()).isInstanceOf(AnnotatedFunction.class);
+        });
+  }
+
+  private void runTest(
+      ApplicationContextRunner configuredContextRunner,
+      ThrowingConsumer<OutboundConnectorConfiguration> configurationAssertions) {
+    configuredContextRunner.run(
+        context -> {
+          context.getBean(OutboundConnectorAnnotationProcessor.class).onStart(camundaClient);
+
+          verify(outboundConnectorFactory)
+              .registerConfiguration(registeredConfigurationCaptor.capture());
+
+          assertThat(registeredConfigurationCaptor.getValue()).satisfies(configurationAssertions);
+        });
+  }
+}
+
+@OutboundConnector(
+    name = "My Function",
+    inputVariables = {"a", "b"},
+    type = "io.camunda:annotated")
+@Component
+class AnnotatedFunction implements OutboundConnectorFunction {
+  @Override
+  public Object execute(OutboundConnectorContext context) throws Exception {
+    return null;
+  }
+}


### PR DESCRIPTION
## Description

Adds support to override type and timeout (outbound) for connectors registered as Spring beans.

1. Refactors the override logic into a `ConnectorConfigurationOverrides` class handling the lookup from a property source (which is still `System.getEnv()` for non-spring connectors).
    - As part of this, the Optional handling in ConnectorUtil was simplified.
2. Reuses the configuration overrides for connectors registered as Spring beans in `InboundConnectorBeanDefinitionProcessor` and `OutboundConnectorAnnotationProcessor`, relying on the Spring `Environment` as property source.
3. Adds missing tests for existing logic + new tests for the Spring approach.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #4874

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.

