### PR TITLE
chore: adds changelog link to infra-global-github-actions renovate PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -68,6 +68,15 @@
         "com.google.http-client:google-http-client"
       ],
       "enabled": false
+    },
+    {
+      "matchPackageNames": [
+        "camunda/infra-global-github-actions"
+      ],
+      "matchUpdateTypes": [
+        "digest"
+      ],
+      "changelogUrl": "{{sourceUrl}}/compare/{{currentDigest}}..{{newDigest}}"
     }
   ],
   "baseBranches": [


### PR DESCRIPTION
## Description

This should add a changelog link to the version comparison

## Related issues

ask-infra question: https://camunda.slack.com/archives/C5AHF1D8T/p1751383162159839

## Checklist

- [ ] PR has a **milestone** or the `no milestone` label.

