### PR TITLE
refactor(agentic-ai): remove experimental from MCP client connector names

### DIFF
--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/mcp/client/McpClientFunction.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/mcp/client/McpClientFunction.java
@@ -16,9 +16,9 @@ import io.camunda.connector.api.outbound.OutboundConnectorFunction;
 import io.camunda.connector.generator.java.annotation.ElementTemplate;
 
 @OutboundConnector(
-    name = "MCP Client (experimental)",
+    name = "MCP Client",
     inputVariables = {"data"},
-    type = McpClientFunction.MCP_CLIENT_TYPE)
+    type = "io.camunda.agenticai:mcpclient:0")
 @ElementTemplate(
     id = "io.camunda.connectors.agenticai.mcp.client.v0",
     name = "MCP Client (experimental)",
@@ -40,9 +40,6 @@ import io.camunda.connector.generator.java.annotation.ElementTemplate;
     },
     icon = "mcp-client.svg")
 public class McpClientFunction implements OutboundConnectorFunction {
-
-  public static final String MCP_CLIENT_BASE_TYPE = "io.camunda.agenticai:mcpclient";
-  public static final String MCP_CLIENT_TYPE = MCP_CLIENT_BASE_TYPE + ":0";
 
   private final McpClientHandler handler;
 

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/mcp/client/McpRemoteClientFunction.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/mcp/client/McpRemoteClientFunction.java
@@ -16,9 +16,9 @@ import io.camunda.connector.api.outbound.OutboundConnectorFunction;
 import io.camunda.connector.generator.java.annotation.ElementTemplate;
 
 @OutboundConnector(
-    name = "MCP Remote Client (experimental)",
+    name = "MCP Remote Client",
     inputVariables = {"data"},
-    type = McpRemoteClientFunction.MCP_REMOTE_CLIENT_TYPE)
+    type = "io.camunda.agenticai:mcpremoteclient:0")
 @ElementTemplate(
     id = "io.camunda.connectors.agenticai.mcp.remoteclient.v0",
     name = "MCP Remote Client (experimental)",
@@ -44,9 +44,6 @@ import io.camunda.connector.generator.java.annotation.ElementTemplate;
     },
     icon = "mcp-client.svg")
 public class McpRemoteClientFunction implements OutboundConnectorFunction {
-
-  public static final String MCP_REMOTE_CLIENT_BASE_TYPE = "io.camunda.agenticai:mcpremoteclient";
-  public static final String MCP_REMOTE_CLIENT_TYPE = MCP_REMOTE_CLIENT_BASE_TYPE + ":0";
 
   private final McpRemoteClientHandler handler;
 


### PR DESCRIPTION
## Description

Remove the `experimental` from the MCP client connector name to have stable name to refer to in [hybrid mode](https://docs.camunda.io/docs/next/guides/use-connectors-in-hybrid-mode/). The name is still kept in the element template.

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.

