### PR TITLE
fix(agentic-ai): do not parse JSON schema via platform-provided ObjectMapper

### DIFF
--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/autoconfigure/AgenticAiConnectorsAutoConfiguration.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/autoconfigure/AgenticAiConnectorsAutoConfiguration.java
@@ -60,8 +60,8 @@ public class AgenticAiConnectorsAutoConfiguration {
 
   @Bean
   @ConditionalOnMissingBean
-  public FeelInputParamExtractor feelInputParamExtractor(ObjectMapper objectMapper) {
-    return new FeelInputParamExtractorImpl(objectMapper);
+  public FeelInputParamExtractor feelInputParamExtractor() {
+    return new FeelInputParamExtractorImpl();
   }
 
   @Bean

--- a/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/adhoctoolsschema/feel/FeelInputParamExtractorTest.java
+++ b/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/adhoctoolsschema/feel/FeelInputParamExtractorTest.java
@@ -9,10 +9,6 @@ package io.camunda.connector.agenticai.adhoctoolsschema.feel;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import io.camunda.connector.api.json.ConnectorsObjectMapperSupplier;
-import io.camunda.connector.document.jackson.JacksonModuleDocumentDeserializer.DocumentModuleSettings;
-import io.camunda.document.factory.DocumentFactoryImpl;
-import io.camunda.document.store.InMemoryDocumentStore;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
@@ -22,11 +18,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 class FeelInputParamExtractorTest {
 
-  private final FeelInputParamExtractor extractor =
-      new FeelInputParamExtractorImpl(
-          ConnectorsObjectMapperSupplier.getCopy(
-              new DocumentFactoryImpl(InMemoryDocumentStore.INSTANCE),
-              DocumentModuleSettings.create()));
+  private final FeelInputParamExtractor extractor = new FeelInputParamExtractorImpl();
 
   @ParameterizedTest
   @MethodSource("testFeelExpressionsWithExpectedInputParams")


### PR DESCRIPTION
## Description

Currently, we use the platform-provided ObjectMapper (with document storage support) to parse the JSON schema from a Scala structure into a Java map. This leads to the following problems:

- When special keys such as `camunda.document.type` are present in the schema, resolution will fail as it will try to deserialize a document.
- Unnecessary conversion as the FEEL Scala engine has a `forJava()` builder and can directly return Java types.

This changes the resolution logic to use the `forJava()` builder and removes ObjectMapper conversions within the schema resolving logic.

## Related issues

closes #4997 

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.

