### PR TITLE
fix(agentic-ai): properly provide Spring configuration metadata for the agentic AI module

### DIFF
--- a/connectors/agentic-ai/pom.xml
+++ b/connectors/agentic-ai/pom.xml
@@ -38,6 +38,11 @@
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-autoconfigure</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-configuration-processor</artifactId>
+      <optional>true</optional>
+    </dependency>
 
     <dependency>
       <groupId>io.camunda.connector</groupId>
@@ -101,6 +106,11 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
           <annotationProcessorPaths>
+            <path>
+              <groupId>org.springframework.boot</groupId>
+              <artifactId>spring-boot-configuration-processor</artifactId>
+              <version>${version.spring-boot}</version>
+            </path>
             <path>
               <groupId>io.soabase.record-builder</groupId>
               <artifactId>record-builder-processor</artifactId>

--- a/connectors/agentic-ai/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/connectors/agentic-ai/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1,0 +1,34 @@
+{
+  "properties": [
+    {
+      "name": "camunda.connector.agenticai.enabled",
+      "type": "java.lang.Boolean",
+      "description": "Whether to enable the Agentic AI integration.",
+      "defaultValue": "true"
+    },
+    {
+      "name": "camunda.connector.agenticai.aiagent.enabled",
+      "type": "java.lang.Boolean",
+      "description": "Whether to enable/register the AI Agent outbound connector.",
+      "defaultValue": "true"
+    },
+    {
+      "name": "camunda.connector.agenticai.ad-hoc-tools-schema-resolver.enabled",
+      "type": "java.lang.Boolean",
+      "description": "Whether to enable/register the Ad-hoc tools schema outbound connector.",
+      "defaultValue": "true"
+    },
+    {
+      "name": "camunda.connector.agenticai.mcp.client.enabled",
+      "type": "java.lang.Boolean",
+      "description": "Whether to enable/register the MCP Client outbound connector.",
+      "defaultValue": "false"
+    },
+    {
+      "name": "camunda.connector.agenticai.mcp.remote-client.enabled",
+      "type": "java.lang.Boolean",
+      "description": "Whether to enable/register the MCP Remote Client outbound connector.",
+      "defaultValue": "true"
+    }
+  ]
+}


### PR DESCRIPTION
## Description

Provide Spring Configuration Metadata for configuration exposed by the `connector-agentic-ai` module for better UX when using with a custom [Spring Boot runtime](https://docs.camunda.io/docs/next/components/connectors/custom-built-connectors/connector-sdk/#spring-boot-starter-runtime).

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.

