### PR TITLE
ci(renovate): update renovate.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -76,7 +76,7 @@
       "matchUpdateTypes": [
         "digest"
       ],
-      "changelogUrl": "{{sourceUrl}}/compare/{{currentDigest}}..{{newDigest}}"
+      "changelogUrl": "https://github.com/camunda/infra-global-github-actions/compare/{{currentDigest}}..{{newDigest}}"
     }
   ],
   "baseBranches": [


### PR DESCRIPTION
## Description

Try use the hardcoded path instead of the `{{ sourceUrl }}` template string to circumvent the problems with changelog url

## Related issues

ask-infra-question: https://camunda.slack.com/archives/C5AHF1D8T/p1751383162159839

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.
- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest release, as this branch will be rebased onto main before the next release.

