### PR TITLE
ci(snapshot): update snapshot name to 8.7-SNAPSHOT

### DIFF
--- a/.github/workflows/DEPLOY_8.7_SNAPSHOTS.yaml
+++ b/.github/workflows/DEPLOY_8.7_SNAPSHOTS.yaml
@@ -95,30 +95,30 @@ jobs:
           username: ${{ steps.secrets.outputs.DOCKERHUB_USER }}
           password: ${{ steps.secrets.outputs.DOCKERHUB_PASSWORD }}
 
-      - name: Build and Push Docker Image tag 8.7.0-SNAPSHOT - connector-runtime
+      - name: Build and Push Docker Image tag 8.7-SNAPSHOT - connector-runtime
         uses: docker/build-push-action@v6
         with:
           context: connector-runtime/connector-runtime-application/
           push: true
-          tags: camunda/connectors:8.7.0-SNAPSHOT
+          tags: camunda/connectors:8.7-SNAPSHOT
           platforms: linux/amd64,linux/arm64
           provenance: false
 
-      - name: Build and Push Docker Image tag 8.7.0-SNAPSHOT - bundle-default
+      - name: Build and Push Docker Image tag 8.7-SNAPSHOT - bundle-default
         uses: docker/build-push-action@v6
         with:
           context: bundle/default-bundle/
           push: true
-          tags: camunda/connectors-bundle:8.7.0-SNAPSHOT
+          tags: camunda/connectors-bundle:8.7-SNAPSHOT
           platforms: linux/amd64,linux/arm64
           provenance: false
 
-      - name: Build and Push Docker Image tag 8.7.0-SNAPSHOT - bundle-saas
+      - name: Build and Push Docker Image tag 8.7-SNAPSHOT - bundle-saas
         uses: docker/build-push-action@v6
         with:
           context: bundle/camunda-saas-bundle/
           push: true
-          tags: camunda/connectors-bundle-saas:8.7.0-SNAPSHOT
+          tags: camunda/connectors-bundle-saas:8.7-SNAPSHOT
           platforms: linux/amd64,linux/arm64
           provenance: false
 


### PR DESCRIPTION
## Description

Rename snapshot from 8.7.0-SNAPSHOT to 8.7-SNAPSHOT

## Related issues

<!-- Which issues are closed by this PR or are related -->

https://github.com/camunda/connectors/issues/4978

## Checklist

- [ ] PR has a **milestone** or the `no milestone` label.
- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest release, as this branch will be rebased onto main before the next release.

