### PR TITLE
ci(snapshot): update snapshot name to 8.5-SNAPSHOT

### DIFF
--- a/.github/workflows/DEPLOY_8.5_SNAPSHOTS.yaml
+++ b/.github/workflows/DEPLOY_8.5_SNAPSHOTS.yaml
@@ -1,0 +1,132 @@
+name: Deploy 8.5 snapshots
+
+on:
+  push:
+    branches:
+      - release/8.5
+  workflow_dispatch: { }
+
+defaults:
+  run:
+    # use bash shell by default to ensure pipefail behavior is the default
+    # see https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#exit-codes-and-error-action-preference
+    shell: bash
+
+jobs:
+  deploy-snapshots:
+    name: Deploy snapshot artifacts
+    runs-on: ubuntu-latest
+    concurrency: deploy-snapshots
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Import Secrets
+        id: secrets # important to refer to it in later steps
+        uses: hashicorp/vault-action@v3.4.0
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          exportEnv: false # we rely on step outputs, no need for environment variables
+          secrets: |
+            secret/data/products/connectors/ci/common DOCKERHUB_USER;
+            secret/data/products/connectors/ci/common DOCKERHUB_PASSWORD;
+            secret/data/products/connectors/ci/common ARTIFACTORY_USR;
+            secret/data/products/connectors/ci/common ARTIFACTORY_PSW;
+
+      - name: Restore cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+
+      - name: Setup Java Build
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+          server-id: camunda-nexus
+          server-username: MAVEN_USERNAME
+          server-password: MAVEN_PASSWORD
+
+      # Use CI Nexus as co-located pull-through cache for Maven artifacts via ~/.m2/settings.xml
+      - name: 'Create settings.xml'
+        uses: s4u/maven-settings-action@v3.1.0
+        with:
+          githubServer: false
+          servers: |
+            [{
+               "id": "camunda-nexus",
+               "username": "${{ steps.secrets.outputs.ARTIFACTORY_USR }}",
+               "password": "${{ steps.secrets.outputs.ARTIFACTORY_PSW }}"
+             }]
+          mirrors: '[{"url": "https://repository.nexus.camunda.cloud/content/groups/internal/", "id": "camunda-nexus", "mirrorOf": "*,!shibboleth,!confluent", "name": "camunda Nexus"}]'
+
+      - name: Build Artifacts
+        run: mvn -B compile generate-sources source:jar javadoc:jar deploy -DskipTests
+        env:
+          MAVEN_USERNAME: ${{ steps.secrets.outputs.ARTIFACTORY_USR }}
+          MAVEN_PASSWORD: ${{ steps.secrets.outputs.ARTIFACTORY_PSW }}
+
+      - name: Lint Connector Bundle Dockerfile - SaaS
+        uses: hadolint/hadolint-action@v3.1.0
+        with:
+          dockerfile: bundle/camunda-saas-bundle/Dockerfile
+
+      - name: Lint Connector Bundle Dockerfile - default-bundle
+        uses: hadolint/hadolint-action@v3.1.0
+        with:
+          dockerfile: bundle/default-bundle/Dockerfile
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: 'arm64,arm'
+
+      - name: Set up Docker Build
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ steps.secrets.outputs.DOCKERHUB_USER }}
+          password: ${{ steps.secrets.outputs.DOCKERHUB_PASSWORD }}
+
+      - name: Build and Push Docker Image tag 8.5-SNAPSHOT - connector-runtime
+        uses: docker/build-push-action@v6
+        with:
+          context: connector-runtime/connector-runtime-application/
+          push: true
+          tags: camunda/connectors:8.5-SNAPSHOT
+          platforms: linux/amd64,linux/arm64
+          provenance: false
+
+      - name: Build and Push Docker Image tag 8.5-SNAPSHOT - bundle-default
+        uses: docker/build-push-action@v6
+        with:
+          context: bundle/default-bundle/
+          push: true
+          tags: camunda/connectors-bundle:8.5-SNAPSHOT
+          platforms: linux/amd64,linux/arm64
+          provenance: false
+
+      - name: Build and Push Docker Image tag 8.5-SNAPSHOT - bundle-saas
+        uses: docker/build-push-action@v6
+        with:
+          context: bundle/camunda-saas-bundle/
+          push: true
+          tags: camunda/connectors-bundle-saas:8.5-SNAPSHOT
+          platforms: linux/amd64,linux/arm64
+          provenance: false
+
+  helm-deploy:
+    needs: deploy-snapshots
+    name: Helm chart Integration Tests
+    uses: ./.github/workflows/INTEGRATION_TEST.yml
+    secrets: inherit
+    with:
+      connectors-version: 8.5-SNAPSHOT
+      release-branch: main


### PR DESCRIPTION
## Description

Add a new deploy snapshot job for 8.5-SNAPSHOT

## Related issues

<!-- Which issues are closed by this PR or are related -->

https://github.com/camunda/connectors/issues/4978

## Checklist

- [ ] PR has a **milestone** or the `no milestone` label.
- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest release, as this branch will be rebased onto main before the next release.

