### PR TITLE
feat(inbound): Fetch only the latest process definitions

### DIFF
--- a/bundle/default-bundle/src/test/java/io/camunda/connector/runtime/app/DataImportConfiguration.java
+++ b/bundle/default-bundle/src/test/java/io/camunda/connector/runtime/app/DataImportConfiguration.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.runtime.app;
+
+import io.camunda.client.CamundaClient;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.IntStream;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.context.event.EventListener;
+
+@Configuration
+@Profile("data-import")
+public class DataImportConfiguration {
+  private CamundaClient client;
+
+  private static final int VERSIONS_PER_PROCESS = 100;
+  private static final int PROCESS_NUMBER = 500;
+
+  public DataImportConfiguration(CamundaClient client) {
+    this.client = client;
+  }
+
+  @EventListener(ApplicationReadyEvent.class)
+  public void testClient() {
+    try (ExecutorService executorService = Executors.newFixedThreadPool(10)) {
+      List<CompletableFuture<Void>> futures =
+          IntStream.range(0, PROCESS_NUMBER)
+              .mapToObj(
+                  i ->
+                      CompletableFuture.runAsync(
+                          () -> {
+                            System.out.println(
+                                "Deploying process versions for ID: process-" + i + "...");
+                            for (int j = 0; j < VERSIONS_PER_PROCESS; j++) {
+                              final String processId = "process-" + i;
+                              try (final InputStream resourceStream =
+                                  getClass()
+                                      .getClassLoader()
+                                      .getResourceAsStream("data-import/QA Review Process.bpmn")) {
+                                Objects.requireNonNull(
+                                    resourceStream,
+                                    "Resource not found: data-import/QA Review Process.bpmn");
+                                var asString = new String(resourceStream.readAllBytes());
+                                String updatedProcess =
+                                    asString
+                                        .replace("__PROCESS_ID__", processId)
+                                        .replace("__ACTIVITY_NAME__", i + "--" + j);
+                                client
+                                    .newDeployResourceCommand()
+                                    .addResourceStringUtf8(updatedProcess, processId + ".bpmn")
+                                    .send()
+                                    .join(60, TimeUnit.SECONDS);
+                                if (i % 10 == 0) {
+                                  Thread.sleep(5000); // let zeebe catch up with deployments
+                                }
+                              } catch (IOException | InterruptedException e) {
+                                throw new RuntimeException(e);
+                              }
+                            }
+                            System.out.println(
+                                "...Deployed all process versions for ID: process-" + i);
+                            try {
+                              Thread.sleep(5000);
+                            } catch (InterruptedException e) {
+                              throw new RuntimeException(e);
+                            }
+                          },
+                          executorService))
+              .toList();
+
+      CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).join();
+      executorService.shutdown();
+    }
+    System.out.println("All process versions deployed successfully.");
+  }
+}

--- a/bundle/default-bundle/src/test/resources/data-import/QA Review Process.bpmn
+++ b/bundle/default-bundle/src/test/resources/data-import/QA Review Process.bpmn
@@ -1,0 +1,224 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Web Modeler" exporterVersion="516e48d" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.5.0">
+  <bpmn:process id="__PROCESS_ID__" name="QA Review Process" isExecutable="true">
+    <bpmn:serviceTask id="Activity_1k8vqkp" name="Add the deploy-preview label __ACTIVITY_NAME__" zeebe:modelerTemplate="io.camunda.connectors.HttpJson.v2" zeebe:modelerTemplateVersion="8" zeebe:modelerTemplateIcon="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTgiIGhlaWdodD0iMTgiIHZpZXdCb3g9IjAgMCAxOCAxOCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZD0iTTE3LjAzMzUgOC45OTk5N0MxNy4wMzM1IDEzLjQ0NzUgMTMuNDI4MSAxNy4wNTI5IDguOTgwNjUgMTcuMDUyOUM0LjUzMzE2IDE3LjA1MjkgMC45Mjc3NjUgMTMuNDQ3NSAwLjkyNzc2NSA4Ljk5OTk3QzAuOTI3NzY1IDQuNTUyNDggNC41MzMxNiAwLjk0NzA4MyA4Ljk4MDY1IDAuOTQ3MDgzQzEzLjQyODEgMC45NDcwODMgMTcuMDMzNSA0LjU1MjQ4IDE3LjAzMzUgOC45OTk5N1oiIGZpbGw9IiM1MDU1NjIiLz4KPHBhdGggZD0iTTQuOTMxMjYgMTQuMTU3MUw2Ljc4MTA2IDMuNzE0NzFIMTAuMTM3NUMxMS4xOTE3IDMuNzE0NzEgMTEuOTgyNCAzLjk4MzIzIDEyLjUwOTUgNC41MjAyN0MxMy4wNDY1IDUuMDQ3MzYgMTMuMzE1IDUuNzMzNTggMTMuMzE1IDYuNTc4OTJDMTMuMzE1IDcuNDQ0MTQgMTMuMDcxNCA4LjE1NTIyIDEyLjU4NDEgOC43MTIxNUMxMi4xMDY3IDkuMjU5MTMgMTEuNDU1MyA5LjYzNzA1IDEwLjYyOTggOS44NDU5TDEyLjA2MTkgMTQuMTU3MUgxMC4zMzE1TDkuMDMzNjQgMTAuMDI0OUg3LjI0MzUxTDYuNTEyNTQgMTQuMTU3MUg0LjkzMTI2Wk03LjQ5NzExIDguNTkyODFIOS4yNDI0OEM5Ljk5ODMyIDguNTkyODEgMTAuNTkwMSA4LjQyMzc0IDExLjAxNzcgOC4wODU2MUMxMS40NTUzIDcuNzM3NTMgMTEuNjc0MSA3LjI2NTEzIDExLjY3NDEgNi42Njg0MkMxMS42NzQxIDYuMTkxMDYgMTEuNTI0OSA1LjgxODExIDExLjIyNjUgNS41NDk1OUMxMC45MjgyIDUuMjcxMTMgMTAuNDU1OCA1LjEzMTkgOS44MDkzNiA1LjEzMTlIOC4xMDg3NEw3LjQ5NzExIDguNTkyODFaIiBmaWxsPSJ3aGl0ZSIvPgo8L3N2Zz4K">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="io.camunda:http-json:1" retries="3" />
+        <zeebe:ioMapping>
+          <zeebe:input source="bearer" target="authentication.type" />
+          <zeebe:input source="=&#34;{{secrets.CONNECTORS_GITHUB_TOKEN}}&#34;" target="authentication.token" />
+          <zeebe:input source="POST" target="method" />
+          <zeebe:input source="=&#34;https://api.github.com/repos/camunda/connectors/issues/&#34;+ string(issueNumber) + &#34;/labels&#34;" target="url" />
+          <zeebe:input source="20" target="connectionTimeoutInSeconds" />
+          <zeebe:input source="20" target="readTimeoutInSeconds" />
+          <zeebe:input source="={&#34;labels&#34;:[&#34;deploy-preview&#34;]}" target="body" />
+        </zeebe:ioMapping>
+        <zeebe:taskHeaders>
+          <zeebe:header key="resultVariable" value="addLabelResult" />
+          <zeebe:header key="retryBackoff" value="PT0S" />
+        </zeebe:taskHeaders>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_116puf6</bpmn:incoming>
+      <bpmn:outgoing>Flow_1n2u68i</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:serviceTask id="Activity_0gbcxry" name="Assign QA to this PR" zeebe:modelerTemplate="io.camunda.connectors.HttpJson.v2" zeebe:modelerTemplateVersion="8" zeebe:modelerTemplateIcon="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTgiIGhlaWdodD0iMTgiIHZpZXdCb3g9IjAgMCAxOCAxOCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZD0iTTE3LjAzMzUgOC45OTk5N0MxNy4wMzM1IDEzLjQ0NzUgMTMuNDI4MSAxNy4wNTI5IDguOTgwNjUgMTcuMDUyOUM0LjUzMzE2IDE3LjA1MjkgMC45Mjc3NjUgMTMuNDQ3NSAwLjkyNzc2NSA4Ljk5OTk3QzAuOTI3NzY1IDQuNTUyNDggNC41MzMxNiAwLjk0NzA4MyA4Ljk4MDY1IDAuOTQ3MDgzQzEzLjQyODEgMC45NDcwODMgMTcuMDMzNSA0LjU1MjQ4IDE3LjAzMzUgOC45OTk5N1oiIGZpbGw9IiM1MDU1NjIiLz4KPHBhdGggZD0iTTQuOTMxMjYgMTQuMTU3MUw2Ljc4MTA2IDMuNzE0NzFIMTAuMTM3NUMxMS4xOTE3IDMuNzE0NzEgMTEuOTgyNCAzLjk4MzIzIDEyLjUwOTUgNC41MjAyN0MxMy4wNDY1IDUuMDQ3MzYgMTMuMzE1IDUuNzMzNTggMTMuMzE1IDYuNTc4OTJDMTMuMzE1IDcuNDQ0MTQgMTMuMDcxNCA4LjE1NTIyIDEyLjU4NDEgOC43MTIxNUMxMi4xMDY3IDkuMjU5MTMgMTEuNDU1MyA5LjYzNzA1IDEwLjYyOTggOS44NDU5TDEyLjA2MTkgMTQuMTU3MUgxMC4zMzE1TDkuMDMzNjQgMTAuMDI0OUg3LjI0MzUxTDYuNTEyNTQgMTQuMTU3MUg0LjkzMTI2Wk03LjQ5NzExIDguNTkyODFIOS4yNDI0OEM5Ljk5ODMyIDguNTkyODEgMTAuNTkwMSA4LjQyMzc0IDExLjAxNzcgOC4wODU2MUMxMS40NTUzIDcuNzM3NTMgMTEuNjc0MSA3LjI2NTEzIDExLjY3NDEgNi42Njg0MkMxMS42NzQxIDYuMTkxMDYgMTEuNTI0OSA1LjgxODExIDExLjIyNjUgNS41NDk1OUMxMC45MjgyIDUuMjcxMTMgMTAuNDU1OCA1LjEzMTkgOS44MDkzNiA1LjEzMTlIOC4xMDg3NEw3LjQ5NzExIDguNTkyODFaIiBmaWxsPSJ3aGl0ZSIvPgo8L3N2Zz4K">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="io.camunda:http-json:1" retries="3" />
+        <zeebe:ioMapping>
+          <zeebe:input source="bearer" target="authentication.type" />
+          <zeebe:input source="=&#34;{{secrets.CONNECTORS_GITHUB_TOKEN}}&#34;" target="authentication.token" />
+          <zeebe:input source="POST" target="method" />
+          <zeebe:input source="=&#34;https://api.github.com/repos/camunda/connectors/issues/&#34;+ string(issueNumber) + &#34;/assignees&#34;" target="url" />
+          <zeebe:input source="20" target="connectionTimeoutInSeconds" />
+          <zeebe:input source="20" target="readTimeoutInSeconds" />
+          <zeebe:input source="={&#34;assignees&#34;:[&#34;Szik&#34;]}" target="body" />
+        </zeebe:ioMapping>
+        <zeebe:taskHeaders>
+          <zeebe:header key="resultVariable" value="assignPRResult" />
+          <zeebe:header key="retryBackoff" value="PT0S" />
+        </zeebe:taskHeaders>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1g5rlaz</bpmn:incoming>
+      <bpmn:outgoing>Flow_19mjomp</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:endEvent id="Event_13k5yii">
+      <bpmn:incoming>Flow_0e410lq</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_0ahaaas" sourceRef="Activity_1r1z7de" targetRef="Activity_05xcr4q" />
+    <bpmn:sequenceFlow id="Flow_0e410lq" sourceRef="Activity_0ioxwgn" targetRef="Event_13k5yii" />
+    <bpmn:sequenceFlow id="Flow_116puf6" sourceRef="Activity_05pqmfd" targetRef="Activity_1k8vqkp" />
+    <bpmn:sequenceFlow id="Flow_19mjomp" sourceRef="Activity_0gbcxry" targetRef="Activity_0ioxwgn" />
+    <bpmn:sequenceFlow id="Flow_1g5rlaz" sourceRef="Activity_05xcr4q" targetRef="Activity_0gbcxry" />
+    <bpmn:sequenceFlow id="Flow_1n2u68i" sourceRef="Activity_1k8vqkp" targetRef="Activity_1r1z7de" />
+    <bpmn:sequenceFlow id="Flow_1wwmgjt" sourceRef="StartEvent_1" targetRef="Activity_05pqmfd" />
+    <bpmn:serviceTask id="Activity_1r1z7de" name="Get the PR global id" zeebe:modelerTemplate="io.camunda.connectors.GraphQL.v1" zeebe:modelerTemplateVersion="6" zeebe:modelerTemplateIcon="data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHhtbG5zOnhsaW5rPSdodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rJyB2ZXJzaW9uPScxLjEnIGlkPSdHcmFwaFFMX0xvZ28nCiAgICAgeD0nMHB4JyB5PScwcHgnIHZpZXdCb3g9JzAgMCA0MDAgNDAwJyBlbmFibGUtYmFja2dyb3VuZD0nbmV3IDAgMCA0MDAgNDAwJyB4bWw6c3BhY2U9J3ByZXNlcnZlJz48Zz48Zz48Zz48cmVjdCB4PScxMjInIHk9Jy0wLjQnIHRyYW5zZm9ybT0nbWF0cml4KC0wLjg2NiAtMC41IDAuNSAtMC44NjYgMTYzLjMxOTYgMzYzLjMxMzYpJyBmaWxsPScjRTUzNUFCJyB3aWR0aD0nMTYuNicgaGVpZ2h0PSczMjAuMycvPjwvZz48L2c+PGc+PGc+PHJlY3QgeD0nMzkuOCcgeT0nMjcyLjInIGZpbGw9JyNFNTM1QUInIHdpZHRoPSczMjAuMycgaGVpZ2h0PScxNi42Jy8+PC9nPjwvZz48Zz48Zz48cmVjdCB4PSczNy45JyB5PSczMTIuMicgdHJhbnNmb3JtPSdtYXRyaXgoLTAuODY2IC0wLjUgMC41IC0wLjg2NiA4My4wNjkzIDY2My4zNDA5KScgZmlsbD0nI0U1MzVBQicgd2lkdGg9JzE4NScgaGVpZ2h0PScxNi42Jy8+PC9nPjwvZz48Zz48Zz48cmVjdCB4PScxNzcuMScgeT0nNzEuMScgdHJhbnNmb3JtPSdtYXRyaXgoLTAuODY2IC0wLjUgMC41IC0wLjg2NiA0NjMuMzQwOSAyODMuMDY5MyknIGZpbGw9JyNFNTM1QUInIHdpZHRoPScxODUnIGhlaWdodD0nMTYuNicvPjwvZz48L2c+PGc+PGc+PHJlY3QgeD0nMTIyLjEnIHk9Jy0xMycgdHJhbnNmb3JtPSdtYXRyaXgoLTAuNSAtMC44NjYgMC44NjYgLTAuNSAxMjYuNzkwMyAyMzIuMTIyMSknIGZpbGw9JyNFNTM1QUInIHdpZHRoPScxNi42JyBoZWlnaHQ9JzE4NScvPjwvZz48L2c+PGc+PGc+PHJlY3QgeD0nMTA5LjYnIHk9JzE1MS42JyB0cmFuc2Zvcm09J21hdHJpeCgtMC41IC0wLjg2NiAwLjg2NiAtMC41IDI2Ni4wODI4IDQ3My4zNzY2KScgZmlsbD0nI0U1MzVBQicgd2lkdGg9JzMyMC4zJyBoZWlnaHQ9JzE2LjYnLz48L2c+PC9nPjxnPjxnPjxyZWN0IHg9JzUyLjUnIHk9JzEwNy41JyBmaWxsPScjRTUzNUFCJyB3aWR0aD0nMTYuNicgaGVpZ2h0PScxODUnLz48L2c+PC9nPjxnPjxnPjxyZWN0IHg9JzMzMC45JyB5PScxMDcuNScgZmlsbD0nI0U1MzVBQicgd2lkdGg9JzE2LjYnIGhlaWdodD0nMTg1Jy8+PC9nPjwvZz48Zz48Zz48cmVjdCB4PScyNjIuNCcgeT0nMjQwLjEnIHRyYW5zZm9ybT0nbWF0cml4KC0wLjUgLTAuODY2IDAuODY2IC0wLjUgMTI2Ljc5NTMgNzE0LjI4NzUpJyBmaWxsPScjRTUzNUFCJyB3aWR0aD0nMTQuNScgaGVpZ2h0PScxNjAuOScvPjwvZz48L2c+PHBhdGgKICAgICAgICBmaWxsPScjRTUzNUFCJwogICAgICAgIGQ9J00zNjkuNSwyOTcuOWMtOS42LDE2LjctMzEsMjIuNC00Ny43LDEyLjhjLTE2LjctOS42LTIyLjQtMzEtMTIuOC00Ny43YzkuNi0xNi43LDMxLTIyLjQsNDcuNy0xMi44IEMzNzMuNSwyNTkuOSwzNzkuMiwyODEuMiwzNjkuNSwyOTcuOScvPjxwYXRoCiAgICAgICAgZmlsbD0nI0U1MzVBQicKICAgICAgICBkPSdNOTAuOSwxMzdjLTkuNiwxNi43LTMxLDIyLjQtNDcuNywxMi44Yy0xNi43LTkuNi0yMi40LTMxLTEyLjgtNDcuN2M5LjYtMTYuNywzMS0yMi40LDQ3LjctMTIuOCBDOTQuOCw5OSwxMDAuNSwxMjAuMyw5MC45LDEzNycvPjxwYXRoCiAgICAgICAgZmlsbD0nI0U1MzVBQicKICAgICAgICBkPSdNMzAuNSwyOTcuOWMtOS42LTE2LjctMy45LTM4LDEyLjgtNDcuN2MxNi43LTkuNiwzOC0zLjksNDcuNywxMi44YzkuNiwxNi43LDMuOSwzOC0xMi44LDQ3LjcgQzYxLjQsMzIwLjMsNDAuMSwzMTQuNiwzMC41LDI5Ny45Jy8+PHBhdGgKICAgICAgICBmaWxsPScjRTUzNUFCJwogICAgICAgIGQ9J00zMDkuMSwxMzdjLTkuNi0xNi43LTMuOS0zOCwxMi44LTQ3LjdjMTYuNy05LjYsMzgtMy45LDQ3LjcsMTIuOGM5LjYsMTYuNywzLjksMzgtMTIuOCw0Ny43IEMzNDAuMSwxNTkuNCwzMTguNywxNTMuNywzMDkuMSwxMzcnLz48cGF0aAogICAgICAgIGZpbGw9JyNFNTM1QUInCiAgICAgICAgZD0nTTIwMCwzOTUuOGMtMTkuMywwLTM0LjktMTUuNi0zNC45LTM0LjljMC0xOS4zLDE1LjYtMzQuOSwzNC45LTM0LjljMTkuMywwLDM0LjksMTUuNiwzNC45LDM0LjkgQzIzNC45LDM4MC4xLDIxOS4zLDM5NS44LDIwMCwzOTUuOCcvPjxwYXRoCiAgICAgICAgZmlsbD0nI0U1MzVBQicKICAgICAgICBkPSdNMjAwLDc0Yy0xOS4zLDAtMzQuOS0xNS42LTM0LjktMzQuOWMwLTE5LjMsMTUuNi0zNC45LDM0LjktMzQuOWMxOS4zLDAsMzQuOSwxNS42LDM0LjksMzQuOSBDMjM0LjksNTguNCwyMTkuMyw3NCwyMDAsNzQnLz48L2c+PC9zdmc+">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="io.camunda:connector-graphql:1" retries="3" />
+        <zeebe:ioMapping>
+          <zeebe:input source="bearer" target="authentication.type" />
+          <zeebe:input source="=&#34;{{secrets.CONNECTORS_GITHUB_TOKEN}}&#34;" target="authentication.token" />
+          <zeebe:input source="post" target="graphql.method" />
+          <zeebe:input source="https://api.github.com/graphql" target="graphql.url" />
+          <zeebe:input source="  query($organization: String!, $repoName: String!, $prNumber: Int!) {&#10;    repository(owner: $organization, name: $repoName) {&#10;      pullRequest(number: $prNumber) {&#10;        id&#10;        title&#10;        number&#10;        author {&#10;          login&#10;        }&#10;        projectItems(first: 1) {&#10;          ... on ProjectV2ItemConnection {&#10;            nodes {&#10;              ... on ProjectV2Item {&#10;                id&#10;              }&#10;            }&#10;          }&#10;        }&#10;      }&#10;    }&#10;  }" target="graphql.query" />
+          <zeebe:input source="={organization:&#34;camunda&#34;, repoName:&#34;connectors&#34;, prNumber:issueNumber}" target="graphql.variables" />
+          <zeebe:input source="20" target="graphql.connectionTimeoutInSeconds" />
+        </zeebe:ioMapping>
+        <zeebe:taskHeaders>
+          <zeebe:header key="resultVariable" value="getGlobalIdResult" />
+          <zeebe:header key="resultExpression" value="={globalId: response.body.data.repository.pullRequest.projectItems.nodes[1].id}" />
+          <zeebe:header key="retryBackoff" value="PT0S" />
+        </zeebe:taskHeaders>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1n2u68i</bpmn:incoming>
+      <bpmn:outgoing>Flow_0ahaaas</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:startEvent id="StartEvent_1" name="Listen for Labels change in PR" zeebe:modelerTemplate="io.camunda.connectors.webhook.GithubWebhookConnectorMessageStart.v1" zeebe:modelerTemplateVersion="1" zeebe:modelerTemplateIcon="data:image/svg+xml,%3Csvg width=&#39;18&#39; height=&#39;18&#39; viewBox=&#39;0 0 1024 1024&#39; fill=&#39;none&#39; xmlns=&#39;http://www.w3.org/2000/svg&#39;%3E%3Cpath fill-rule=&#39;evenodd&#39; clip-rule=&#39;evenodd&#39; d=&#39;M8 0C3.58 0 0 3.58 0 8C0 11.54 2.29 14.53 5.47 15.59C5.87 15.66 6.02 15.42 6.02 15.21C6.02 15.02 6.01 14.39 6.01 13.72C4 14.09 3.48 13.23 3.32 12.78C3.23 12.55 2.84 11.84 2.5 11.65C2.22 11.5 1.82 11.13 2.49 11.12C3.12 11.11 3.57 11.7 3.72 11.94C4.44 13.15 5.59 12.81 6.05 12.6C6.12 12.08 6.33 11.73 6.56 11.53C4.78 11.33 2.92 10.64 2.92 7.58C2.92 6.71 3.23 5.99 3.74 5.43C3.66 5.23 3.38 4.41 3.82 3.31C3.82 3.31 4.49 3.1 6.02 4.13C6.66 3.95 7.34 3.86 8.02 3.86C8.7 3.86 9.38 3.95 10.02 4.13C11.55 3.09 12.22 3.31 12.22 3.31C12.66 4.41 12.38 5.23 12.3 5.43C12.81 5.99 13.12 6.7 13.12 7.58C13.12 10.65 11.25 11.33 9.47 11.53C9.76 11.78 10.01 12.26 10.01 13.01C10.01 14.08 10 14.94 10 15.21C10 15.42 10.15 15.67 10.55 15.59C13.71 14.53 16 11.53 16 8C16 3.58 12.42 0 8 0Z&#39; transform=&#39;scale(64)&#39; fill=&#39;%231B1F23&#39;/%3E%3C/svg%3E">
+      <bpmn:extensionElements>
+        <zeebe:properties>
+          <zeebe:property name="inbound.type" value="io.camunda:webhook:1" />
+          <zeebe:property name="inbound.subtype" value="GitHubWebhook" />
+          <zeebe:property name="inbound.context" value="5a523c7a-f0a4-40f7-8269-ea97875aeb77" />
+          <zeebe:property name="inbound.shouldValidateHmac" value="enabled" />
+          <zeebe:property name="inbound.hmacSecret" value="|,i#7pv!]_rxjb`j&#34;?$]1vCmwcWCIHYOE@5&#38;Q`nFDj&#34;~b7bh,p4Ws].heJ=C}Eh" />
+          <zeebe:property name="inbound.hmacHeader" value="X-Hub-Signature-256" />
+          <zeebe:property name="inbound.hmacAlgorithm" value="sha_256" />
+          <zeebe:property name="inbound.activationCondition" value="=request.body.action = &#34;labeled&#34; and request.body.label.name = &#34;qa:required&#34;" />
+          <zeebe:property name="correlationRequired" value="notRequired" />
+          <zeebe:property name="resultVariable" value="result" />
+          <zeebe:property name="resultExpression" value="={repository: request.body.repository.name, owner:request.body.repository.owner.login, issueNumber: request.body.number, issueUrl: request.body.pull_request.html_url}" />
+        </zeebe:properties>
+      </bpmn:extensionElements>
+      <bpmn:outgoing>Flow_1wwmgjt</bpmn:outgoing>
+      <bpmn:messageEventDefinition id="MessageEventDefinition_0hgm22g" messageRef="Message_0s7e8ij" />
+    </bpmn:startEvent>
+    <bpmn:serviceTask id="Activity_05xcr4q" name="Move the PR to the &#34;In QA&#34; status" zeebe:modelerTemplate="io.camunda.connectors.GraphQL.v1" zeebe:modelerTemplateVersion="6" zeebe:modelerTemplateIcon="data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHhtbG5zOnhsaW5rPSdodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rJyB2ZXJzaW9uPScxLjEnIGlkPSdHcmFwaFFMX0xvZ28nCiAgICAgeD0nMHB4JyB5PScwcHgnIHZpZXdCb3g9JzAgMCA0MDAgNDAwJyBlbmFibGUtYmFja2dyb3VuZD0nbmV3IDAgMCA0MDAgNDAwJyB4bWw6c3BhY2U9J3ByZXNlcnZlJz48Zz48Zz48Zz48cmVjdCB4PScxMjInIHk9Jy0wLjQnIHRyYW5zZm9ybT0nbWF0cml4KC0wLjg2NiAtMC41IDAuNSAtMC44NjYgMTYzLjMxOTYgMzYzLjMxMzYpJyBmaWxsPScjRTUzNUFCJyB3aWR0aD0nMTYuNicgaGVpZ2h0PSczMjAuMycvPjwvZz48L2c+PGc+PGc+PHJlY3QgeD0nMzkuOCcgeT0nMjcyLjInIGZpbGw9JyNFNTM1QUInIHdpZHRoPSczMjAuMycgaGVpZ2h0PScxNi42Jy8+PC9nPjwvZz48Zz48Zz48cmVjdCB4PSczNy45JyB5PSczMTIuMicgdHJhbnNmb3JtPSdtYXRyaXgoLTAuODY2IC0wLjUgMC41IC0wLjg2NiA4My4wNjkzIDY2My4zNDA5KScgZmlsbD0nI0U1MzVBQicgd2lkdGg9JzE4NScgaGVpZ2h0PScxNi42Jy8+PC9nPjwvZz48Zz48Zz48cmVjdCB4PScxNzcuMScgeT0nNzEuMScgdHJhbnNmb3JtPSdtYXRyaXgoLTAuODY2IC0wLjUgMC41IC0wLjg2NiA0NjMuMzQwOSAyODMuMDY5MyknIGZpbGw9JyNFNTM1QUInIHdpZHRoPScxODUnIGhlaWdodD0nMTYuNicvPjwvZz48L2c+PGc+PGc+PHJlY3QgeD0nMTIyLjEnIHk9Jy0xMycgdHJhbnNmb3JtPSdtYXRyaXgoLTAuNSAtMC44NjYgMC44NjYgLTAuNSAxMjYuNzkwMyAyMzIuMTIyMSknIGZpbGw9JyNFNTM1QUInIHdpZHRoPScxNi42JyBoZWlnaHQ9JzE4NScvPjwvZz48L2c+PGc+PGc+PHJlY3QgeD0nMTA5LjYnIHk9JzE1MS42JyB0cmFuc2Zvcm09J21hdHJpeCgtMC41IC0wLjg2NiAwLjg2NiAtMC41IDI2Ni4wODI4IDQ3My4zNzY2KScgZmlsbD0nI0U1MzVBQicgd2lkdGg9JzMyMC4zJyBoZWlnaHQ9JzE2LjYnLz48L2c+PC9nPjxnPjxnPjxyZWN0IHg9JzUyLjUnIHk9JzEwNy41JyBmaWxsPScjRTUzNUFCJyB3aWR0aD0nMTYuNicgaGVpZ2h0PScxODUnLz48L2c+PC9nPjxnPjxnPjxyZWN0IHg9JzMzMC45JyB5PScxMDcuNScgZmlsbD0nI0U1MzVBQicgd2lkdGg9JzE2LjYnIGhlaWdodD0nMTg1Jy8+PC9nPjwvZz48Zz48Zz48cmVjdCB4PScyNjIuNCcgeT0nMjQwLjEnIHRyYW5zZm9ybT0nbWF0cml4KC0wLjUgLTAuODY2IDAuODY2IC0wLjUgMTI2Ljc5NTMgNzE0LjI4NzUpJyBmaWxsPScjRTUzNUFCJyB3aWR0aD0nMTQuNScgaGVpZ2h0PScxNjAuOScvPjwvZz48L2c+PHBhdGgKICAgICAgICBmaWxsPScjRTUzNUFCJwogICAgICAgIGQ9J00zNjkuNSwyOTcuOWMtOS42LDE2LjctMzEsMjIuNC00Ny43LDEyLjhjLTE2LjctOS42LTIyLjQtMzEtMTIuOC00Ny43YzkuNi0xNi43LDMxLTIyLjQsNDcuNy0xMi44IEMzNzMuNSwyNTkuOSwzNzkuMiwyODEuMiwzNjkuNSwyOTcuOScvPjxwYXRoCiAgICAgICAgZmlsbD0nI0U1MzVBQicKICAgICAgICBkPSdNOTAuOSwxMzdjLTkuNiwxNi43LTMxLDIyLjQtNDcuNywxMi44Yy0xNi43LTkuNi0yMi40LTMxLTEyLjgtNDcuN2M5LjYtMTYuNywzMS0yMi40LDQ3LjctMTIuOCBDOTQuOCw5OSwxMDAuNSwxMjAuMyw5MC45LDEzNycvPjxwYXRoCiAgICAgICAgZmlsbD0nI0U1MzVBQicKICAgICAgICBkPSdNMzAuNSwyOTcuOWMtOS42LTE2LjctMy45LTM4LDEyLjgtNDcuN2MxNi43LTkuNiwzOC0zLjksNDcuNywxMi44YzkuNiwxNi43LDMuOSwzOC0xMi44LDQ3LjcgQzYxLjQsMzIwLjMsNDAuMSwzMTQuNiwzMC41LDI5Ny45Jy8+PHBhdGgKICAgICAgICBmaWxsPScjRTUzNUFCJwogICAgICAgIGQ9J00zMDkuMSwxMzdjLTkuNi0xNi43LTMuOS0zOCwxMi44LTQ3LjdjMTYuNy05LjYsMzgtMy45LDQ3LjcsMTIuOGM5LjYsMTYuNywzLjksMzgtMTIuOCw0Ny43IEMzNDAuMSwxNTkuNCwzMTguNywxNTMuNywzMDkuMSwxMzcnLz48cGF0aAogICAgICAgIGZpbGw9JyNFNTM1QUInCiAgICAgICAgZD0nTTIwMCwzOTUuOGMtMTkuMywwLTM0LjktMTUuNi0zNC45LTM0LjljMC0xOS4zLDE1LjYtMzQuOSwzNC45LTM0LjljMTkuMywwLDM0LjksMTUuNiwzNC45LDM0LjkgQzIzNC45LDM4MC4xLDIxOS4zLDM5NS44LDIwMCwzOTUuOCcvPjxwYXRoCiAgICAgICAgZmlsbD0nI0U1MzVBQicKICAgICAgICBkPSdNMjAwLDc0Yy0xOS4zLDAtMzQuOS0xNS42LTM0LjktMzQuOWMwLTE5LjMsMTUuNi0zNC45LDM0LjktMzQuOWMxOS4zLDAsMzQuOSwxNS42LDM0LjksMzQuOSBDMjM0LjksNTguNCwyMTkuMyw3NCwyMDAsNzQnLz48L2c+PC9zdmc+">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="io.camunda:connector-graphql:1" retries="3" />
+        <zeebe:ioMapping>
+          <zeebe:input source="bearer" target="authentication.type" />
+          <zeebe:input source="=&#34;{{secrets.CONNECTORS_GITHUB_TOKEN}}&#34;" target="authentication.token" />
+          <zeebe:input source="post" target="graphql.method" />
+          <zeebe:input source="https://api.github.com/graphql" target="graphql.url" />
+          <zeebe:input source="mutation($projectItemId: ID!, $statusValue: String!) {&#10;    updateProjectV2ItemFieldValue(input: {&#10;      itemId: $projectItemId,&#10;      fieldId: &#34;PVTSSF_lADOACVKPs4ABzTyzgBC3fM&#34;,&#10;      value: {&#10;        singleSelectOptionId: $statusValue&#10;      },&#10;      projectId: &#34;PVT_kwDOACVKPs4ABzTy&#34;&#10;    }) {&#10;      projectV2Item {&#10;        id&#10;        fieldValueByName(name: &#34;Status&#34;) {&#10;          ... on ProjectV2ItemFieldSingleSelectValue {&#10;            name&#10;          }&#10;        }&#10;      }&#10;    }&#10;  }" target="graphql.query" />
+          <zeebe:input source="={projectItemId:globalId, statusValue:&#34;96fa6798&#34;}" target="graphql.variables" />
+          <zeebe:input source="20" target="graphql.connectionTimeoutInSeconds" />
+        </zeebe:ioMapping>
+        <zeebe:taskHeaders>
+          <zeebe:header key="resultVariable" value="updateStatusResult" />
+          <zeebe:header key="retryBackoff" value="PT0S" />
+        </zeebe:taskHeaders>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_0ahaaas</bpmn:incoming>
+      <bpmn:outgoing>Flow_1g5rlaz</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:serviceTask id="Activity_0ioxwgn" name="Notify QA that the PR is ready to be tested" zeebe:modelerTemplate="io.camunda.connectors.Slack.v1" zeebe:modelerTemplateVersion="5" zeebe:modelerTemplateIcon="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTI3IiBoZWlnaHQ9IjEyNyIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KICA8cGF0aCBkPSJNMjcuMiA4MGMwIDcuMy01LjkgMTMuMi0xMy4yIDEzLjJDNi43IDkzLjIuOCA4Ny4zLjggODBjMC03LjMgNS45LTEzLjIgMTMuMi0xMy4yaDEzLjJWODB6bTYuNiAwYzAtNy4zIDUuOS0xMy4yIDEzLjItMTMuMiA3LjMgMCAxMy4yIDUuOSAxMy4yIDEzLjJ2MzNjMCA3LjMtNS45IDEzLjItMTMuMiAxMy4yLTcuMyAwLTEzLjItNS45LTEzLjItMTMuMlY4MHoiIGZpbGw9IiNFMDFFNUEiLz4KICA8cGF0aCBkPSJNNDcgMjdjLTcuMyAwLTEzLjItNS45LTEzLjItMTMuMkMzMy44IDYuNSAzOS43LjYgNDcgLjZjNy4zIDAgMTMuMiA1LjkgMTMuMiAxMy4yVjI3SDQ3em0wIDYuN2M3LjMgMCAxMy4yIDUuOSAxMy4yIDEzLjIgMCA3LjMtNS45IDEzLjItMTMuMiAxMy4ySDEzLjlDNi42IDYwLjEuNyA1NC4yLjcgNDYuOWMwLTcuMyA1LjktMTMuMiAxMy4yLTEzLjJINDd6IiBmaWxsPSIjMzZDNUYwIi8+CiAgPHBhdGggZD0iTTk5LjkgNDYuOWMwLTcuMyA1LjktMTMuMiAxMy4yLTEzLjIgNy4zIDAgMTMuMiA1LjkgMTMuMiAxMy4yIDAgNy4zLTUuOSAxMy4yLTEzLjIgMTMuMkg5OS45VjQ2Ljl6bS02LjYgMGMwIDcuMy01LjkgMTMuMi0xMy4yIDEzLjItNy4zIDAtMTMuMi01LjktMTMuMi0xMy4yVjEzLjhDNjYuOSA2LjUgNzIuOC42IDgwLjEuNmM3LjMgMCAxMy4yIDUuOSAxMy4yIDEzLjJ2MzMuMXoiIGZpbGw9IiMyRUI2N0QiLz4KICA8cGF0aCBkPSJNODAuMSA5OS44YzcuMyAwIDEzLjIgNS45IDEzLjIgMTMuMiAwIDcuMy01LjkgMTMuMi0xMy4yIDEzLjItNy4zIDAtMTMuMi01LjktMTMuMi0xMy4yVjk5LjhoMTMuMnptMC02LjZjLTcuMyAwLTEzLjItNS45LTEzLjItMTMuMiAwLTcuMyA1LjktMTMuMiAxMy4yLTEzLjJoMzMuMWM3LjMgMCAxMy4yIDUuOSAxMy4yIDEzLjIgMCA3LjMtNS45IDEzLjItMTMuMiAxMy4ySDgwLjF6IiBmaWxsPSIjRUNCMjJFIi8+Cjwvc3ZnPgo=">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="io.camunda:slack:1" retries="3" />
+        <zeebe:ioMapping>
+          <zeebe:input source="=&#34;{{secrets.SLACK_CAMUNDA}}&#34;" target="token" />
+          <zeebe:input source="chat.postMessage" target="method" />
+          <zeebe:input source="messageBlock" target="data.messageType" />
+          <zeebe:input source="=[&#10;		{&#10;			&#34;type&#34;: &#34;section&#34;,&#10;			&#34;text&#34;: {&#10;				&#34;type&#34;: &#34;mrkdwn&#34;,&#10;				&#34;text&#34;: &#34;Hi &#60;@U06RRTNDV19&#62; :wave:&#34;&#10;			}&#10;		},&#10;		{&#10;			&#34;type&#34;: &#34;section&#34;,&#10;			&#34;text&#34;: {&#10;				&#34;type&#34;: &#34;mrkdwn&#34;,&#10;				&#34;text&#34;: &#34;The pull request &#60;&#34;+ string(issueUrl)+ &#34;|&#34; +string(issueNumber)+&#34;&#62; is ready to be tested :boom:&#34;&#10;			}&#10;		}&#10;	]" target="data.blockContent" />
+          <zeebe:input source="#connectors-qa" target="data.channel" />
+        </zeebe:ioMapping>
+        <zeebe:taskHeaders>
+          <zeebe:header key="resultVariable" value="slackResult" />
+          <zeebe:header key="retryBackoff" value="PT0S" />
+        </zeebe:taskHeaders>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_19mjomp</bpmn:incoming>
+      <bpmn:outgoing>Flow_0e410lq</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:serviceTask id="Activity_05pqmfd" name="Post the templated comment in the PR" zeebe:modelerTemplate="io.camunda.connectors.GitHub.v1" zeebe:modelerTemplateVersion="7" zeebe:modelerTemplateIcon="data:image/svg+xml;utf8,%3Csvg width=&#39;98&#39; height=&#39;96&#39; xmlns=&#39;http://www.w3.org/2000/svg&#39;%3E%3Cpath fill-rule=&#39;evenodd&#39; clip-rule=&#39;evenodd&#39; d=&#39;M48.854 0C21.839 0 0 22 0 49.217c0 21.756 13.993 40.172 33.405 46.69 2.427.49 3.316-1.059 3.316-2.362 0-1.141-.08-5.052-.08-9.127-13.59 2.934-16.42-5.867-16.42-5.867-2.184-5.704-5.42-7.17-5.42-7.17-4.448-3.015.324-3.015.324-3.015 4.934.326 7.523 5.052 7.523 5.052 4.367 7.496 11.404 5.378 14.235 4.074.404-3.178 1.699-5.378 3.074-6.6-10.839-1.141-22.243-5.378-22.243-24.283 0-5.378 1.94-9.778 5.014-13.2-.485-1.222-2.184-6.275.486-13.038 0 0 4.125-1.304 13.426 5.052a46.97 46.97 0 0 1 12.214-1.63c4.125 0 8.33.571 12.213 1.63 9.302-6.356 13.427-5.052 13.427-5.052 2.67 6.763.97 11.816.485 13.038 3.155 3.422 5.015 7.822 5.015 13.2 0 18.905-11.404 23.06-22.324 24.283 1.78 1.548 3.316 4.481 3.316 9.126 0 6.6-.08 11.897-.08 13.526 0 1.304.89 2.853 3.316 2.364 19.412-6.52 33.405-24.935 33.405-46.691C97.707 22 75.788 0 48.854 0z&#39; fill=&#39;%2324292f&#39;/%3E%3C/svg%3E">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="io.camunda:http-json:1" />
+        <zeebe:ioMapping>
+          <zeebe:input source="issues" target="operationGroup" />
+          <zeebe:input source="createIssueComment" target="operationType" />
+          <zeebe:input source="bearer" target="authentication.type" />
+          <zeebe:input source="=&#34;{{secrets.CONNECTORS_GITHUB_TOKEN}}&#34;" target="authentication.token" />
+          <zeebe:input source="post" target="method" />
+          <zeebe:input source="=owner" target="owner" />
+          <zeebe:input source="=repository" target="repo" />
+          <zeebe:input source="=issueNumber" target="issueNumber" />
+          <zeebe:input source="# QA information&#10;## Test Environment&#10;- Test required in (you can check both):&#10;  - [ ] SaaS&#10;  - [ ] SM&#10;- [ ] Create a new test for this feature in our [Pre Release Tests](https://modeler.ultrawombat.com/projects/017779a8-9459-4feb-8b47-eeef8b2717ef--connectors-pre-release-test) for @Szik to be able to test&#10;&#10;## Test Scope&#10;*Please describe the test scope, happy path, edge cases that come to your mind, and whatever you think might relevant to test*&#10;&#10;## Test Data&#10;*Please provide the test data, if needed (files, URLs, code snippets, FEEL expressions)*" target="githubBody" />
+          <zeebe:input source="={&#34;Content-Type&#34;:&#34;application/vnd.github+json&#34;, &#34;X-GitHub-Api-Version&#34;:&#34;2022-11-28&#34;}" target="headers" />
+          <zeebe:input source="={&#34;body&#34;:if githubBody = null then null else githubBody}" target="body" />
+          <zeebe:input source="20" target="connectionTimeoutInSeconds" />
+          <zeebe:input source="=&#34;https://api.github.com&#34;" target="baseUrl" />
+          <zeebe:input source="=baseUrl + &#34;/repos/&#34; + owner + &#34;/&#34; + repo + &#34;/issues/&#34; + string(issueNumber) + &#34;/comments&#34;" target="url" />
+        </zeebe:ioMapping>
+        <zeebe:taskHeaders>
+          <zeebe:header key="resultVariable" value="commentResponse" />
+        </zeebe:taskHeaders>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1wwmgjt</bpmn:incoming>
+      <bpmn:outgoing>Flow_116puf6</bpmn:outgoing>
+    </bpmn:serviceTask>
+  </bpmn:process>
+  <bpmn:message id="Message_0s7e8ij" name="b58bfb48-e6b1-42be-9bfc-97bbff97c8e7" zeebe:modelerTemplate="io.camunda.connectors.webhook.GithubWebhookConnectorMessageStart.v1" />
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_05sr4py">
+      <bpmndi:BPMNShape id="Activity_18gq68n_di" bpmnElement="Activity_1k8vqkp">
+        <dc:Bounds x="520" y="78" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0tnttre" bpmnElement="Activity_0gbcxry">
+        <dc:Bounds x="1210" y="78" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_13k5yii_di" bpmnElement="Event_13k5yii">
+        <dc:Bounds x="1662" y="100" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1v1dtfw_di" bpmnElement="Activity_1r1z7de">
+        <dc:Bounds x="720" y="78" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1xozsa8_di" bpmnElement="StartEvent_1">
+        <dc:Bounds x="172" y="100" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="151" y="143" width="81" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_17cmbxr_di" bpmnElement="Activity_05xcr4q">
+        <dc:Bounds x="980" y="78" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_05ipj9w_di" bpmnElement="Activity_0ioxwgn">
+        <dc:Bounds x="1420" y="78" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_18fshfm_di" bpmnElement="Activity_05pqmfd">
+        <dc:Bounds x="310" y="78" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_116puf6_di" bpmnElement="Flow_116puf6">
+        <di:waypoint x="410" y="118" />
+        <di:waypoint x="520" y="118" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1n2u68i_di" bpmnElement="Flow_1n2u68i">
+        <di:waypoint x="620" y="118" />
+        <di:waypoint x="720" y="118" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1g5rlaz_di" bpmnElement="Flow_1g5rlaz">
+        <di:waypoint x="1080" y="118" />
+        <di:waypoint x="1210" y="118" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_19mjomp_di" bpmnElement="Flow_19mjomp">
+        <di:waypoint x="1310" y="118" />
+        <di:waypoint x="1420" y="118" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0e410lq_di" bpmnElement="Flow_0e410lq">
+        <di:waypoint x="1520" y="118" />
+        <di:waypoint x="1662" y="118" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0ahaaas_di" bpmnElement="Flow_0ahaaas">
+        <di:waypoint x="820" y="118" />
+        <di:waypoint x="980" y="118" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1wwmgjt_di" bpmnElement="Flow_1wwmgjt">
+        <di:waypoint x="208" y="118" />
+        <di:waypoint x="310" y="118" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/connector-runtime/connector-runtime-spring/pom.xml
+++ b/connector-runtime/connector-runtime-spring/pom.xml
@@ -107,6 +107,10 @@
         <artifactId>connector-test</artifactId>
         <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>camunda-process-test-spring</artifactId>
+    </dependency>
 
   </dependencies>
 </project>

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/importer/ProcessDefinitionSearch.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/importer/ProcessDefinitionSearch.java
@@ -22,10 +22,7 @@ import io.camunda.client.api.search.response.ProcessDefinition;
 import io.camunda.client.api.search.response.SearchResponse;
 import io.camunda.connector.runtime.inbound.search.SearchQueryClient;
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Optional;
-import java.util.Set;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -53,35 +50,23 @@ public class ProcessDefinitionSearch {
     LOG.trace("Running paginated query");
 
     String paginationIndex = null;
-    final Set<String> encounteredBpmnProcessIds = new HashSet<>();
-
     do {
       processDefinitionResult = searchQueryClient.queryProcessDefinitions(paginationIndex);
       String newPaginationIdx = processDefinitionResult.page().endCursor();
 
-      LOG.debug("A page of process definitions has been fetched, continuing...");
+      LOG.debug(
+          "A page of {} process definitions has been fetched, continuing...",
+          processDefinitionResult.items().size());
 
       if (isNotBlank(newPaginationIdx)) {
         paginationIndex = newPaginationIdx;
       }
 
-      // result is sorted by key in descending order, so we will always encounter the latest
-      // version first
-
-      LOG.debug("Sorting process definition results by descending order");
-      var items =
-          Optional.ofNullable(processDefinitionResult.items()).orElse(List.of()).stream()
-              .filter(
-                  definition ->
-                      !encounteredBpmnProcessIds.contains(definition.getProcessDefinitionId()))
-              .peek(
-                  definition -> encounteredBpmnProcessIds.add(definition.getProcessDefinitionId()))
-              .toList();
-
-      processDefinitions.addAll(items);
-
+      processDefinitions.addAll(processDefinitionResult.items());
     } while (processDefinitionResult.items() != null && !processDefinitionResult.items().isEmpty());
-    LOG.debug("Fetching process definitions has been correctly executed.");
+    LOG.debug(
+        "Fetching process definitions has been correctly executed: {} definitions found",
+        processDefinitions.size());
     return processDefinitions;
   }
 }

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/search/SearchQueryClientImpl.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/search/SearchQueryClientImpl.java
@@ -36,9 +36,7 @@ public class SearchQueryClientImpl implements SearchQueryClient {
   @Override
   public SearchResponse<ProcessDefinition> queryProcessDefinitions(String paginationIndex) {
     final var query =
-        camundaClient
-            .newProcessDefinitionSearchRequest()
-            .sort(s -> s.processDefinitionKey().desc());
+        camundaClient.newProcessDefinitionSearchRequest().filter(f -> f.isLatestVersion(true));
     if (paginationIndex != null) {
       query.page(p -> p.limit(PAGE_SIZE).after(paginationIndex));
     } else {

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/search/SearchQueryClientImpl.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/search/SearchQueryClientImpl.java
@@ -25,7 +25,8 @@ import java.io.ByteArrayInputStream;
 
 public class SearchQueryClientImpl implements SearchQueryClient {
 
-  private static final int PAGE_SIZE = 50;
+  private static final int DEFAULT_PAGE_LIMIT = 200;
+  private int limit = DEFAULT_PAGE_LIMIT;
 
   private final CamundaClient camundaClient;
 
@@ -33,14 +34,22 @@ public class SearchQueryClientImpl implements SearchQueryClient {
     this.camundaClient = camundaClient;
   }
 
+  SearchQueryClientImpl(CamundaClient camundaClient, int limit) {
+    this.camundaClient = camundaClient;
+    if (limit <= 0) {
+      throw new IllegalArgumentException("Page limit must be greater than zero");
+    }
+    this.limit = limit;
+  }
+
   @Override
   public SearchResponse<ProcessDefinition> queryProcessDefinitions(String paginationIndex) {
     final var query =
         camundaClient.newProcessDefinitionSearchRequest().filter(f -> f.isLatestVersion(true));
     if (paginationIndex != null) {
-      query.page(p -> p.limit(PAGE_SIZE).after(paginationIndex));
+      query.page(p -> p.limit(limit).after(paginationIndex));
     } else {
-      query.page(p -> p.limit(PAGE_SIZE));
+      query.page(p -> p.limit(limit));
     }
     return query.send().join();
   }
@@ -57,9 +66,9 @@ public class SearchQueryClientImpl implements SearchQueryClient {
                         .elementId(elementId)
                         .state(ElementInstanceState.ACTIVE));
     if (paginationIndex != null) {
-      query.page(p -> p.limit(PAGE_SIZE).after(paginationIndex));
+      query.page(p -> p.limit(limit).after(paginationIndex));
     } else {
-      query.page(p -> p.limit(PAGE_SIZE));
+      query.page(p -> p.limit(limit));
     }
     return query.send().join();
   }
@@ -72,9 +81,9 @@ public class SearchQueryClientImpl implements SearchQueryClient {
             .newVariableSearchRequest()
             .filter(v -> v.processInstanceKey(processInstanceKey).scopeKey(processInstanceKey));
     if (variablePaginationIndex != null) {
-      query.page(p -> p.limit(PAGE_SIZE).after(variablePaginationIndex));
+      query.page(p -> p.limit(limit).after(variablePaginationIndex));
     } else {
-      query.page(p -> p.limit(PAGE_SIZE));
+      query.page(p -> p.limit(limit));
     }
     return query.send().join();
   }

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/inbound/EmptyConfiguration.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/inbound/EmptyConfiguration.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.runtime.inbound;
+
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class EmptyConfiguration {}

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/inbound/search/SearchQueryClientTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/inbound/search/SearchQueryClientTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.runtime.inbound.search;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.connector.runtime.inbound.EmptyConfiguration;
+import io.camunda.connector.test.SlowTest;
+import io.camunda.process.test.api.CamundaSpringProcessTest;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.stream.IntStream;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SlowTest
+@SpringBootTest(classes = EmptyConfiguration.class)
+@CamundaSpringProcessTest
+public class SearchQueryClientTest {
+
+  @Autowired private CamundaClient camundaClient;
+
+  @Test
+  public void shouldFetchOnlyTheLatestProcessDefinitions() {
+    // Given
+    createAndDeployProcess("testProcess", 2);
+    waitForIndexing(2);
+
+    // When
+    SearchQueryClientImpl processDefinitionSearch = new SearchQueryClientImpl(camundaClient);
+    var result = processDefinitionSearch.queryProcessDefinitions(null);
+
+    // Then
+    assertThat(result.items()).hasSize(1);
+    var processDefinition = result.items().getFirst();
+    assertThat(processDefinition.getProcessDefinitionId()).isEqualTo("testProcess");
+    assertThat(processDefinition.getVersion()).isEqualTo(2);
+  }
+
+  @Test
+  public void shouldFetchOnlyTheLatestProcessDefinitions_whenPaginated() {
+    // Given
+    createAndDeployProcess("testProcess", 2);
+    createAndDeployProcess("testProcess2", 1);
+    waitForIndexing(3);
+
+    // When
+    SearchQueryClientImpl processDefinitionSearch = new SearchQueryClientImpl(camundaClient, 1);
+    var resultPage1 = processDefinitionSearch.queryProcessDefinitions(null);
+    var pageIndex = resultPage1.page().endCursor();
+    var allItems = new ArrayList<>(resultPage1.items());
+    var resultPage2 =
+        processDefinitionSearch.queryProcessDefinitions(pageIndex); // Fetch next page with 1 item
+    pageIndex = resultPage2.page().endCursor();
+    allItems.addAll(resultPage2.items());
+    // this page should be empty
+    var resultPage3 =
+        processDefinitionSearch.queryProcessDefinitions(pageIndex); // Fetch next page with 1 item
+    pageIndex = resultPage3.page().endCursor();
+
+    // Then
+    assertThat(pageIndex).isNull();
+    assertThat(resultPage3.items()).isEmpty();
+    assertThat(allItems).hasSize(2);
+    // result should be sorted by processId asc
+    var processDefinition = allItems.getFirst();
+    assertThat(processDefinition.getProcessDefinitionId()).isEqualTo("testProcess");
+    assertThat(processDefinition.getVersion()).isEqualTo(2);
+    var processDefinition2 = allItems.get(1);
+    assertThat(processDefinition2.getProcessDefinitionId()).isEqualTo("testProcess2");
+    assertThat(processDefinition2.getVersion()).isEqualTo(1);
+  }
+
+  private void createAndDeployProcess(String processId, int versions) {
+    IntStream.range(0, versions)
+        .forEach(
+            i -> {
+              BpmnModelInstance modelInstance;
+              modelInstance =
+                  Bpmn.createExecutableProcess(processId)
+                      .startEvent(RandomStringUtils.insecure().nextAlphanumeric(5))
+                      .endEvent()
+                      .done();
+              camundaClient
+                  .newDeployResourceCommand()
+                  .addProcessModel(modelInstance, processId + ".bpmn")
+                  .send()
+                  .join();
+            });
+  }
+
+  private void waitForIndexing(int expectedCount) {
+    // Wait for the process definitions to be indexed
+    Awaitility.await("should deploy process definitions and import in ES")
+        .atMost(Duration.ofSeconds(15))
+        .ignoreExceptions() // Ignore exceptions and continue retrying
+        .untilAsserted(
+            () -> {
+              final var result = camundaClient.newProcessDefinitionSearchRequest().send().join();
+              assertThat(result.items().size()).isEqualTo(expectedCount);
+            });
+  }
+}


### PR DESCRIPTION
## Description

The backend part has been implemented https://github.com/camunda/camunda/pull/33160.
Now we need to update Connectors to use the new filter: isLatestVersion.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes https://github.com/camunda/connectors/issues/5047

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.
- [x] Backport labels are added if these code changes should be backported. No backport label is added to the latest release, as this branch will be rebased onto main before the next release.

