### PR TITLE
fix(idp-extraction-connector): (WIP) added integration for azure

### DIFF
--- a/connectors/idp-extraction/element-templates/hybrid/hybrid-idp-extraction-outbound-connector-hybrid.json
+++ b/connectors/idp-extraction/element-templates/hybrid/hybrid-idp-extraction-outbound-connector-hybrid.json
@@ -159,6 +159,9 @@
       "name" : "Amazon Web Services Provider",
       "value" : "aws"
     }, {
+      "name" : "Azure Provider",
+      "value" : "azure"
+    }, {
       "name" : "GCP Provider",
       "value" : "gcp"
     } ]
@@ -479,6 +482,109 @@
       "type" : "simple"
     },
     "type" : "Hidden"
+  }, {
+    "id" : "baseRequest.documentIntelligenceConfiguration.endpoint",
+    "label" : "Azure Document Intelligence Endpoint",
+    "description" : "Specify the endpoint of the Azure Document Intelligence",
+    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "group" : "configuration",
+    "binding" : {
+      "name" : "baseRequest.documentIntelligenceConfiguration.endpoint",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "baseRequest.type",
+      "equals" : "azure",
+      "type" : "simple"
+    },
+    "type" : "Text"
+  }, {
+    "id" : "baseRequest.documentIntelligenceConfiguration.apiKey",
+    "label" : "Azure Document Intelligence API Key",
+    "description" : "Specify the API key of the Azure Document Intelligence",
+    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "group" : "configuration",
+    "binding" : {
+      "name" : "baseRequest.documentIntelligenceConfiguration.apiKey",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "baseRequest.type",
+      "equals" : "azure",
+      "type" : "simple"
+    },
+    "type" : "Text"
+  }, {
+    "id" : "baseRequest.aiFoundryConfig.usingOpenAI",
+    "label" : "Model type",
+    "description" : "Specify if the Azure AI Foundry is using OpenAI",
+    "optional" : false,
+    "value" : "false",
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "group" : "configuration",
+    "binding" : {
+      "name" : "baseRequest.aiFoundryConfig.usingOpenAI",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "baseRequest.type",
+      "equals" : "azure",
+      "type" : "simple"
+    },
+    "type" : "Dropdown",
+    "choices" : [ {
+      "name" : "Base Azure Foundry model",
+      "value" : "false"
+    }, {
+      "name" : "Azure OpenAI model",
+      "value" : "true"
+    } ]
+  }, {
+    "id" : "baseRequest.aiFoundryConfig.endpoint",
+    "label" : "Azure AI Foundry Endpoint",
+    "description" : "Specify the endpoint of the Azure AI Foundry",
+    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "group" : "configuration",
+    "binding" : {
+      "name" : "baseRequest.aiFoundryConfig.endpoint",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "baseRequest.type",
+      "equals" : "azure",
+      "type" : "simple"
+    },
+    "type" : "Text"
+  }, {
+    "id" : "baseRequest.aiFoundryConfig.apiKey",
+    "label" : "Azure AI Foundry API Key",
+    "description" : "Specify the API key of the Azure AI Foundry",
+    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "group" : "configuration",
+    "binding" : {
+      "name" : "baseRequest.aiFoundryConfig.apiKey",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "baseRequest.type",
+      "equals" : "azure",
+      "type" : "simple"
+    },
+    "type" : "Text"
   }, {
     "id" : "baseRequest.configuration.type",
     "label" : "Request configuration",

--- a/connectors/idp-extraction/element-templates/idp-extraction-outbound-connector.json
+++ b/connectors/idp-extraction/element-templates/idp-extraction-outbound-connector.json
@@ -154,6 +154,9 @@
       "name" : "Amazon Web Services Provider",
       "value" : "aws"
     }, {
+      "name" : "Azure Provider",
+      "value" : "azure"
+    }, {
       "name" : "GCP Provider",
       "value" : "gcp"
     } ]
@@ -474,6 +477,109 @@
       "type" : "simple"
     },
     "type" : "Hidden"
+  }, {
+    "id" : "baseRequest.documentIntelligenceConfiguration.endpoint",
+    "label" : "Azure Document Intelligence Endpoint",
+    "description" : "Specify the endpoint of the Azure Document Intelligence",
+    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "group" : "configuration",
+    "binding" : {
+      "name" : "baseRequest.documentIntelligenceConfiguration.endpoint",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "baseRequest.type",
+      "equals" : "azure",
+      "type" : "simple"
+    },
+    "type" : "Text"
+  }, {
+    "id" : "baseRequest.documentIntelligenceConfiguration.apiKey",
+    "label" : "Azure Document Intelligence API Key",
+    "description" : "Specify the API key of the Azure Document Intelligence",
+    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "group" : "configuration",
+    "binding" : {
+      "name" : "baseRequest.documentIntelligenceConfiguration.apiKey",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "baseRequest.type",
+      "equals" : "azure",
+      "type" : "simple"
+    },
+    "type" : "Text"
+  }, {
+    "id" : "baseRequest.aiFoundryConfig.usingOpenAI",
+    "label" : "Model type",
+    "description" : "Specify if the Azure AI Foundry is using OpenAI",
+    "optional" : false,
+    "value" : "false",
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "group" : "configuration",
+    "binding" : {
+      "name" : "baseRequest.aiFoundryConfig.usingOpenAI",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "baseRequest.type",
+      "equals" : "azure",
+      "type" : "simple"
+    },
+    "type" : "Dropdown",
+    "choices" : [ {
+      "name" : "Base Azure Foundry model",
+      "value" : "false"
+    }, {
+      "name" : "Azure OpenAI model",
+      "value" : "true"
+    } ]
+  }, {
+    "id" : "baseRequest.aiFoundryConfig.endpoint",
+    "label" : "Azure AI Foundry Endpoint",
+    "description" : "Specify the endpoint of the Azure AI Foundry",
+    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "group" : "configuration",
+    "binding" : {
+      "name" : "baseRequest.aiFoundryConfig.endpoint",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "baseRequest.type",
+      "equals" : "azure",
+      "type" : "simple"
+    },
+    "type" : "Text"
+  }, {
+    "id" : "baseRequest.aiFoundryConfig.apiKey",
+    "label" : "Azure AI Foundry API Key",
+    "description" : "Specify the API key of the Azure AI Foundry",
+    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "group" : "configuration",
+    "binding" : {
+      "name" : "baseRequest.aiFoundryConfig.apiKey",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "baseRequest.type",
+      "equals" : "azure",
+      "type" : "simple"
+    },
+    "type" : "Text"
   }, {
     "id" : "baseRequest.configuration.type",
     "label" : "Request configuration",

--- a/connectors/idp-extraction/pom.xml
+++ b/connectors/idp-extraction/pom.xml
@@ -68,6 +68,24 @@
       <artifactId>google-cloud-document-ai</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>com.azure</groupId>
+      <artifactId>azure-ai-documentintelligence</artifactId>
+      <version>1.0.2</version>
+    </dependency>
+
+    <dependency>
+      <groupId>com.azure</groupId>
+      <artifactId>azure-ai-inference</artifactId>
+      <version>1.0.0-beta.5</version>
+    </dependency>
+
+    <dependency>
+            <groupId>com.azure</groupId>
+            <artifactId>azure-ai-openai</artifactId>
+            <version>1.0.0-beta.16</version>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/caller/AzureAIFoundryCaller.java
+++ b/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/caller/AzureAIFoundryCaller.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.idp.extraction.caller;
+
+import com.azure.ai.inference.ChatCompletionsClient;
+import com.azure.ai.inference.models.ChatCompletions;
+import com.azure.ai.inference.models.ChatCompletionsOptions;
+import com.azure.ai.inference.models.ChatRequestMessage;
+import com.azure.ai.inference.models.ChatRequestSystemMessage;
+import com.azure.ai.inference.models.ChatRequestUserMessage;
+import com.azure.ai.openai.OpenAIClient;
+import io.camunda.connector.idp.extraction.model.ExtractionRequestData;
+import io.camunda.connector.idp.extraction.model.LlmModel;
+import io.camunda.connector.idp.extraction.model.providers.AzureProvider;
+import io.camunda.connector.idp.extraction.supplier.AzureAIFoundrySupplier;
+import java.util.ArrayList;
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class AzureAIFoundryCaller {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(AzureAIFoundryCaller.class);
+
+  public String call(ExtractionRequestData input, AzureProvider baseRequest, String extractedText) {
+    LOGGER.debug("Calling Azure AI Foundry with extraction request data: {}", input);
+
+    try {
+
+      // Determine the LLM model from the model ID
+      LlmModel llmModel = LlmModel.fromId(input.converseData().modelId());
+
+      if (baseRequest.getAiFoundryConfig().isUsingOpenAI()) {
+        return callOpenAIClient(input, baseRequest, extractedText, llmModel);
+      } else {
+        return callChatCompletionsClient(input, baseRequest, extractedText, llmModel);
+      }
+
+    } catch (Exception e) {
+      LOGGER.error("Error calling Azure AI Foundry", e);
+      throw new RuntimeException("Failed to call Azure AI Foundry: " + e.getMessage(), e);
+    }
+  }
+
+  private String callOpenAIClient(
+      ExtractionRequestData input,
+      AzureProvider baseRequest,
+      String extractedText,
+      LlmModel llmModel) {
+    OpenAIClient client = AzureAIFoundrySupplier.getOpenAIClient(baseRequest);
+
+    // Build the messages for the chat completion
+    List<com.azure.ai.openai.models.ChatRequestMessage> messages =
+        buildOpenAIMessages(input, extractedText, llmModel);
+
+    // Create the chat completions options for OpenAI client
+    com.azure.ai.openai.models.ChatCompletionsOptions options =
+        new com.azure.ai.openai.models.ChatCompletionsOptions(messages);
+    options.setModel(input.converseData().modelId());
+    options.setTemperature(input.converseData().temperature().doubleValue());
+    options.setMaxTokens(input.converseData().maxTokens());
+    options.setTopP(input.converseData().topP().doubleValue());
+
+    // Make the call to Azure AI Foundry
+    com.azure.ai.openai.models.ChatCompletions response =
+        client.getChatCompletions(input.converseData().modelId(), options);
+
+    // Extract and return the response text
+    String responseText = response.getChoices().get(0).getMessage().getContent();
+    LOGGER.debug("Azure AI Foundry response: {}", responseText);
+
+    return responseText;
+  }
+
+  private String callChatCompletionsClient(
+      ExtractionRequestData input,
+      AzureProvider baseRequest,
+      String extractedText,
+      LlmModel llmModel) {
+    ChatCompletionsClient client = AzureAIFoundrySupplier.getChatCompletionsClient(baseRequest);
+
+    // Build the messages for the chat completion
+    List<ChatRequestMessage> messages = buildMessages(input, extractedText, llmModel);
+
+    // Create the chat completions options for ChatCompletions client
+    ChatCompletionsOptions options = new ChatCompletionsOptions(messages);
+    options.setModel(input.converseData().modelId());
+    options.setTemperature(input.converseData().temperature().doubleValue());
+    options.setMaxTokens(input.converseData().maxTokens());
+    options.setTopP(input.converseData().topP().doubleValue());
+
+    // Make the call to Azure AI Foundry
+    ChatCompletions response = client.complete(options);
+
+    // Extract and return the response text
+    String responseText = response.getChoices().get(0).getMessage().getContent();
+    LOGGER.debug("Azure AI Foundry response: {}", responseText);
+
+    return responseText;
+  }
+
+  private List<ChatRequestMessage> buildMessages(
+      ExtractionRequestData input, String extractedText, LlmModel llmModel) {
+    List<ChatRequestMessage> messages = new ArrayList<>();
+
+    // Build the user message using the LlmModel template
+    String userMessage = llmModel.getMessage(extractedText, input.taxonomyItems());
+
+    // Check if system prompts are allowed for this model
+    if (llmModel.isSystemPromptAllowed()) {
+      // Add system message first
+      messages.add(new ChatRequestSystemMessage(llmModel.getSystemPrompt()));
+      // Add user message
+      messages.add(new ChatRequestUserMessage(userMessage));
+    } else {
+      // For models that don't support system prompts, combine system and user messages
+      String combinedMessage = String.format("%s%n%s", llmModel.getSystemPrompt(), userMessage);
+      messages.add(new ChatRequestUserMessage(combinedMessage));
+    }
+
+    return messages;
+  }
+
+  private List<com.azure.ai.openai.models.ChatRequestMessage> buildOpenAIMessages(
+      ExtractionRequestData input, String extractedText, LlmModel llmModel) {
+    List<com.azure.ai.openai.models.ChatRequestMessage> messages = new ArrayList<>();
+
+    // Build the user message using the LlmModel template
+    String userMessage = llmModel.getMessage(extractedText, input.taxonomyItems());
+
+    // Check if system prompts are allowed for this model
+    if (llmModel.isSystemPromptAllowed()) {
+      // Add system message first
+      messages.add(
+          new com.azure.ai.openai.models.ChatRequestSystemMessage(llmModel.getSystemPrompt()));
+      // Add user message
+      messages.add(new com.azure.ai.openai.models.ChatRequestUserMessage(userMessage));
+    } else {
+      // For models that don't support system prompts, combine system and user messages
+      String combinedMessage = String.format("%s%n%s", llmModel.getSystemPrompt(), userMessage);
+      messages.add(new com.azure.ai.openai.models.ChatRequestUserMessage(combinedMessage));
+    }
+
+    return messages;
+  }
+}

--- a/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/caller/AzureDocumentIntelligenceCaller.java
+++ b/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/caller/AzureDocumentIntelligenceCaller.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.idp.extraction.caller;
+
+import com.azure.ai.documentintelligence.DocumentIntelligenceClient;
+import com.azure.ai.documentintelligence.DocumentIntelligenceClientBuilder;
+import com.azure.ai.documentintelligence.models.AnalyzeDocumentOptions;
+import com.azure.ai.documentintelligence.models.AnalyzeOperationDetails;
+import com.azure.ai.documentintelligence.models.AnalyzeResult;
+import com.azure.ai.documentintelligence.models.DocumentLine;
+import com.azure.ai.documentintelligence.models.DocumentPage;
+import com.azure.core.credential.AzureKeyCredential;
+import com.azure.core.util.polling.SyncPoller;
+import io.camunda.connector.idp.extraction.model.ExtractionRequestData;
+import io.camunda.connector.idp.extraction.model.providers.AzureProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class AzureDocumentIntelligenceCaller {
+
+  private static final Logger LOGGER =
+      LoggerFactory.getLogger(AzureDocumentIntelligenceCaller.class);
+
+  public String call(ExtractionRequestData input, AzureProvider baseRequest) {
+    LOGGER.debug("Calling Azure Document Intelligence with extraction request data: {}", input);
+
+    DocumentIntelligenceClient documentIntelligenceClient =
+        new DocumentIntelligenceClientBuilder()
+            .endpoint(baseRequest.getDocumentIntelligenceConfiguration().getEndpoint())
+            .credential(
+                new AzureKeyCredential(
+                    baseRequest.getDocumentIntelligenceConfiguration().getApiKey()))
+            .buildClient();
+
+    try {
+      // Use the prebuilt-read model for general text extraction
+      SyncPoller<AnalyzeOperationDetails, AnalyzeResult> analyzePoller =
+          documentIntelligenceClient.beginAnalyzeDocument(
+              "prebuilt-read", new AnalyzeDocumentOptions(input.document().asByteArray()));
+
+      // Wait for analysis to complete and get results
+      AnalyzeResult result = analyzePoller.getFinalResult();
+
+      // Extract text from all pages
+      StringBuilder extractedText = new StringBuilder();
+
+      if (result.getPages() != null) {
+        for (DocumentPage page : result.getPages()) {
+          if (page.getLines() != null) {
+            for (DocumentLine line : page.getLines()) {
+              extractedText.append(line.getContent());
+              extractedText.append("\n");
+            }
+          }
+        }
+      }
+
+      return extractedText.toString().trim();
+
+    } catch (Exception e) {
+      throw new RuntimeException("Failed to extract text from document: " + e.getMessage(), e);
+    }
+  }
+}

--- a/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/model/providers/AzureProvider.java
+++ b/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/model/providers/AzureProvider.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.idp.extraction.model.providers;
+
+import io.camunda.connector.generator.java.annotation.TemplateSubType;
+import io.camunda.connector.idp.extraction.model.providers.azure.AIFoundryConfig;
+import io.camunda.connector.idp.extraction.model.providers.azure.DocumentIntelligenceConfiguration;
+
+@TemplateSubType(id = "azure", label = "Azure Provider")
+public final class AzureProvider implements ProviderConfig {
+
+  private DocumentIntelligenceConfiguration documentIntelligenceConfiguration;
+  private AIFoundryConfig aiFoundryConfig;
+
+  public DocumentIntelligenceConfiguration getDocumentIntelligenceConfiguration() {
+    return documentIntelligenceConfiguration;
+  }
+
+  public AIFoundryConfig getAiFoundryConfig() {
+    return aiFoundryConfig;
+  }
+}

--- a/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/model/providers/ProviderConfig.java
+++ b/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/model/providers/ProviderConfig.java
@@ -14,8 +14,9 @@ import jakarta.validation.constraints.NotNull;
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type", defaultImpl = AwsProvider.class)
 @JsonSubTypes({
   @JsonSubTypes.Type(value = AwsProvider.class, name = "aws"),
+  @JsonSubTypes.Type(value = AzureProvider.class, name = "azure"),
   @JsonSubTypes.Type(value = GcpProvider.class, name = "gcp"),
 })
 @NotNull
 @TemplateDiscriminatorProperty(label = "Hyperscaler providers", group = "provider", name = "type")
-public sealed interface ProviderConfig permits AwsProvider, GcpProvider {}
+public sealed interface ProviderConfig permits AwsProvider, AzureProvider, GcpProvider {}

--- a/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/model/providers/azure/AIFoundryConfig.java
+++ b/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/model/providers/azure/AIFoundryConfig.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.idp.extraction.model.providers.azure;
+
+import static io.camunda.connector.generator.java.annotation.TemplateProperty.PropertyType.Dropdown;
+
+import io.camunda.connector.generator.dsl.Property;
+import io.camunda.connector.generator.java.annotation.TemplateProperty;
+import jakarta.validation.constraints.NotNull;
+
+public class AIFoundryConfig {
+
+  @TemplateProperty(
+      id = "usingOpenAI",
+      label = "Model type",
+      group = "configuration",
+      type = Dropdown,
+      description = "Specify if the Azure AI Foundry is using OpenAI",
+      defaultValue = "false",
+      constraints = @TemplateProperty.PropertyConstraints(notEmpty = true),
+      choices = {
+        @TemplateProperty.DropdownPropertyChoice(
+            label = "Base Azure Foundry model",
+            value = "false"),
+        @TemplateProperty.DropdownPropertyChoice(label = "Azure OpenAI model", value = "true")
+      })
+  boolean usingOpenAI;
+
+  @TemplateProperty(
+      id = "endpoint",
+      label = "Azure AI Foundry Endpoint",
+      group = "configuration",
+      type = TemplateProperty.PropertyType.Text,
+      description = "Specify the endpoint of the Azure AI Foundry",
+      binding = @TemplateProperty.PropertyBinding(name = "endpoint"),
+      feel = Property.FeelMode.disabled,
+      constraints = @TemplateProperty.PropertyConstraints(notEmpty = true))
+  @NotNull
+  private String endpoint;
+
+  @TemplateProperty(
+      id = "apiKey",
+      label = "Azure AI Foundry API Key",
+      group = "configuration",
+      type = TemplateProperty.PropertyType.Text,
+      description = "Specify the API key of the Azure AI Foundry",
+      binding = @TemplateProperty.PropertyBinding(name = "apiKey"),
+      feel = Property.FeelMode.disabled,
+      constraints = @TemplateProperty.PropertyConstraints(notEmpty = true))
+  @NotNull
+  private String apiKey;
+
+  public boolean isUsingOpenAI() {
+    return usingOpenAI;
+  }
+
+  public String getEndpoint() {
+    return endpoint;
+  }
+
+  public String getApiKey() {
+    return apiKey;
+  }
+}

--- a/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/model/providers/azure/DocumentIntelligenceConfiguration.java
+++ b/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/model/providers/azure/DocumentIntelligenceConfiguration.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.idp.extraction.model.providers.azure;
+
+import io.camunda.connector.generator.dsl.Property;
+import io.camunda.connector.generator.java.annotation.TemplateProperty;
+import org.jetbrains.annotations.NotNull;
+
+public class DocumentIntelligenceConfiguration {
+
+  @TemplateProperty(
+      id = "endpoint",
+      label = "Azure Document Intelligence Endpoint",
+      group = "configuration",
+      type = TemplateProperty.PropertyType.Text,
+      description = "Specify the endpoint of the Azure Document Intelligence",
+      binding = @TemplateProperty.PropertyBinding(name = "endpoint"),
+      feel = Property.FeelMode.disabled,
+      constraints = @TemplateProperty.PropertyConstraints(notEmpty = true))
+  @NotNull
+  private String endpoint;
+
+  @TemplateProperty(
+      id = "apiKey",
+      label = "Azure Document Intelligence API Key",
+      group = "configuration",
+      type = TemplateProperty.PropertyType.Text,
+      description = "Specify the API key of the Azure Document Intelligence",
+      binding = @TemplateProperty.PropertyBinding(name = "apiKey"),
+      feel = Property.FeelMode.disabled,
+      constraints = @TemplateProperty.PropertyConstraints(notEmpty = true))
+  @NotNull
+  private String apiKey;
+
+  public String getApiKey() {
+    return apiKey;
+  }
+
+  public void setApiKey(String apiKey) {
+    this.apiKey = apiKey;
+  }
+
+  public String getEndpoint() {
+    return endpoint;
+  }
+
+  public void setEndpoint(String endpoint) {
+    this.endpoint = endpoint;
+  }
+}

--- a/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/supplier/AzureAIFoundrySupplier.java
+++ b/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/supplier/AzureAIFoundrySupplier.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.idp.extraction.supplier;
+
+import com.azure.ai.inference.ChatCompletionsClient;
+import com.azure.ai.inference.ChatCompletionsClientBuilder;
+import com.azure.ai.openai.OpenAIClient;
+import com.azure.ai.openai.OpenAIClientBuilder;
+import com.azure.core.credential.AzureKeyCredential;
+import io.camunda.connector.idp.extraction.model.providers.AzureProvider;
+import io.camunda.connector.idp.extraction.model.providers.azure.AIFoundryConfig;
+
+public final class AzureAIFoundrySupplier {
+
+  private AzureAIFoundrySupplier() {}
+
+  public static ChatCompletionsClient getChatCompletionsClient(AzureProvider baseRequest) {
+    AIFoundryConfig configuration = baseRequest.getAiFoundryConfig();
+    return new ChatCompletionsClientBuilder()
+        .endpoint(configuration.getEndpoint())
+        .credential(new AzureKeyCredential(configuration.getApiKey()))
+        .buildClient();
+  }
+
+  public static OpenAIClient getOpenAIClient(AzureProvider baseRequest) {
+    AIFoundryConfig configuration = baseRequest.getAiFoundryConfig();
+    return new OpenAIClientBuilder()
+        .endpoint(configuration.getEndpoint())
+        .credential(new AzureKeyCredential(configuration.getApiKey()))
+        .buildClient();
+  }
+}

--- a/connectors/idp-extraction/src/test/java/io/camunda/connector/idp/extraction/service/UnstructuredServiceTest.java
+++ b/connectors/idp-extraction/src/test/java/io/camunda/connector/idp/extraction/service/UnstructuredServiceTest.java
@@ -16,6 +16,8 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.connector.api.error.ConnectorException;
+import io.camunda.connector.idp.extraction.caller.AzureAIFoundryCaller;
+import io.camunda.connector.idp.extraction.caller.AzureDocumentIntelligenceCaller;
 import io.camunda.connector.idp.extraction.caller.BedrockCaller;
 import io.camunda.connector.idp.extraction.caller.PollingTextractCaller;
 import io.camunda.connector.idp.extraction.caller.VertexCaller;
@@ -41,6 +43,8 @@ public class UnstructuredServiceTest {
 
   @Mock private PollingTextractCaller pollingTextractCaller;
   @Mock private BedrockCaller bedrockCaller;
+  @Mock private AzureAIFoundryCaller azureAIFoundryCaller;
+  @Mock private AzureDocumentIntelligenceCaller azureDocumentIntelligenceCaller;
 
   private UnstructuredService unstructuredService;
 
@@ -61,7 +65,9 @@ public class UnstructuredServiceTest {
             pollingTextractCaller,
             bedrockCaller,
             vertexCaller,
-            objectMapper);
+            objectMapper,
+            azureAIFoundryCaller,
+            azureDocumentIntelligenceCaller);
   }
 
   @Test


### PR DESCRIPTION
## Description

This pull request introduces support for Azure as a new hyperscaler provider in the IDP extraction connectors. It adds configurations for Azure Document Intelligence and Azure AI Foundry, enabling document analysis and AI-based text extraction. The most important changes include extending the provider configuration, adding new Azure-specific classes, updating templates, and integrating Azure dependencies.

### Azure Provider Integration:

* **Provider Configuration Update**: Added `AzureProvider` to the `ProviderConfig` interface, enabling Azure as a supported hyperscaler provider. (`connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/model/providers/ProviderConfig.java`)
* **New Azure Provider Class**: Created `AzureProvider` to encapsulate configurations for Azure Document Intelligence and Azure AI Foundry. (`connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/model/providers/AzureProvider.java`)

### Azure-Specific Configurations:

* **Azure Document Intelligence Configuration**: Added `DocumentIntelligenceConfiguration` class for endpoint and API key settings. (`connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/model/providers/azure/DocumentIntelligenceConfiguration.java`)
* **Azure AI Foundry Configuration**: Added `AIFoundryConfig` class to support OpenAI and base Azure Foundry models, including endpoint and API key settings. (`connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/model/providers/azure/AIFoundryConfig.java`)

### Functional Enhancements:

* **Azure Document Intelligence Caller**: Implemented `AzureDocumentIntelligenceCaller` for document analysis using Azure's prebuilt-read model. (`connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/caller/AzureDocumentIntelligenceCaller.java`)
* **Azure AI Foundry Caller**: Implemented `AzureAIFoundryCaller` to handle AI-based text extraction using OpenAI or Azure Foundry models. (`connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/caller/AzureAIFoundryCaller.java`)

### Template and Dependency Updates:

* **Template Modifications**: Updated element templates to include Azure provider options and configurations for Document Intelligence and AI Foundry. (`connectors/idp-extraction/element-templates/hybrid/hybrid-idp-extraction-outbound-connector-hybrid.json`) [[1]](diffhunk://#diff-7f6522a91d253ff95b16d40e75031b47c71dc71037d0e99682ad718b1c10e5e4R161-R163) [[2]](diffhunk://#diff-7f6522a91d253ff95b16d40e75031b47c71dc71037d0e99682ad718b1c10e5e4R485-R587)  
  (`connectors/idp-extraction/element-templates/idp-extraction-outbound-connector.json`) [[1]](diffhunk://#diff-25cc7be9c0d059bf8019472e4294ad91e5bcb0a329f514563cddef97f25dad6aR156-R158) [[2]](diffhunk://#diff-25cc7be9c0d059bf8019472e4294ad91e5bcb0a329f514563cddef97f25dad6aR480-R582)
* **Dependency Additions**: Added Azure SDK dependencies for AI Document Intelligence, AI Inference, and OpenAI. (`connectors/idp-extraction/pom.xml`)

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #

## Checklist

- [ ] PR has a **milestone** or the `no milestone` label.
- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest release, as this branch will be rebased onto main before the next release.

