### PR TITLE
feat(etg): Support open api specs without operationids

### DIFF
--- a/element-template-generator/http-dsl/src/main/java/io/camunda/connector/generator/dsl/http/OperationParseResult.java
+++ b/element-template-generator/http-dsl/src/main/java/io/camunda/connector/generator/dsl/http/OperationParseResult.java
@@ -30,4 +30,10 @@ public record OperationParseResult(
     boolean supported,
     String description,
     @JsonInclude(Include.NON_EMPTY) String info,
-    @JsonIgnore HttpOperationBuilder builder) {}
+    @JsonIgnore HttpOperationBuilder builder) {
+  public OperationParseResult {
+    if (id == null) {
+      id = method.name() + "_" + path;
+    }
+  }
+}


### PR DESCRIPTION
## Description
Added fallback ids, if openapi operationIds are null.

## Related issues
closes #https://github.com/camunda/connectors/issues/4984
related to: https://github.com/camunda/web-modeler/issues/14345

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.
- [x] Backport labels are added if these code changes should be backported. No backport label is added to the latest release, as this branch will be rebased onto main before the next release.

