### PR TITLE
feat(core): the secret provider is tenant aware

### DIFF
--- a/bundle/camunda-saas-bundle/src/main/java/io/camunda/connector/runtime/saas/CamundaClientSaaSConfiguration.java
+++ b/bundle/camunda-saas-bundle/src/main/java/io/camunda/connector/runtime/saas/CamundaClientSaaSConfiguration.java
@@ -80,8 +80,8 @@ public class CamundaClientSaaSConfiguration {
 
   public CredentialsProvider internalConnectorsSecretCredentialsProvider() {
     final var builder = new OAuthCredentialsProviderBuilder();
-    builder.clientId(internalSecretProvider.getSecret(SECRET_NAME_CLIENT_ID));
-    builder.clientSecret(internalSecretProvider.getSecret(SECRET_NAME_SECRET));
+    builder.clientId(internalSecretProvider.getSecret(SECRET_NAME_CLIENT_ID, null));
+    builder.clientSecret(internalSecretProvider.getSecret(SECRET_NAME_SECRET, null));
     builder.authorizationServerUrl(camundaClientTokenUrl);
     builder.audience(camundaClientAudience);
     builder.credentialsCachePath(credentialsCachePath);

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/DefaultProcessElementContext.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/DefaultProcessElementContext.java
@@ -19,6 +19,7 @@ package io.camunda.connector.runtime.core.inbound;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.connector.api.inbound.ProcessElement;
 import io.camunda.connector.api.inbound.ProcessElementContext;
+import io.camunda.connector.api.secret.SecretContext;
 import io.camunda.connector.api.secret.SecretProvider;
 import io.camunda.connector.api.validation.ValidationProvider;
 import io.camunda.connector.runtime.core.AbstractConnectorContext;
@@ -67,7 +68,10 @@ public class DefaultProcessElementContext extends AbstractConnectorContext
     if (propertiesWithSecrets == null) {
       propertiesWithSecrets =
           InboundPropertyHandler.getPropertiesWithSecrets(
-              getSecretHandler(), objectMapper, properties);
+              getSecretHandler(),
+              objectMapper,
+              properties,
+              new SecretContext(connectorElement.tenantId()));
     }
     return propertiesWithSecrets;
   }

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImpl.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImpl.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.EvictingQueue;
 import io.camunda.connector.api.error.ConnectorInputException;
 import io.camunda.connector.api.inbound.*;
+import io.camunda.connector.api.secret.SecretContext;
 import io.camunda.connector.api.secret.SecretProvider;
 import io.camunda.connector.api.validation.ValidationProvider;
 import io.camunda.connector.feel.FeelEngineWrapperException;
@@ -210,7 +211,10 @@ public class InboundConnectorContextImpl extends AbstractConnectorContext
     if (propertiesWithSecrets == null) {
       propertiesWithSecrets =
           InboundPropertyHandler.getPropertiesWithSecrets(
-              getSecretHandler(), objectMapper, properties);
+              getSecretHandler(),
+              objectMapper,
+              properties,
+              new SecretContext(connectorDetails.tenantId()));
     }
     return propertiesWithSecrets;
   }

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/InboundPropertyHandler.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/InboundPropertyHandler.java
@@ -19,6 +19,7 @@ package io.camunda.connector.runtime.core.inbound;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.connector.api.secret.SecretContext;
 import io.camunda.connector.runtime.core.secret.SecretHandler;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -106,10 +107,14 @@ public class InboundPropertyHandler {
   }
 
   public static Map<String, Object> getPropertiesWithSecrets(
-      SecretHandler secretHandler, ObjectMapper objectMapper, Map<String, Object> properties) {
+      SecretHandler secretHandler,
+      ObjectMapper objectMapper,
+      Map<String, Object> properties,
+      SecretContext secretContext) {
     try {
       var propertiesAsJsonString = objectMapper.writeValueAsString(properties);
-      var propertiesWithSecretsJson = secretHandler.replaceSecrets(propertiesAsJsonString);
+      var propertiesWithSecretsJson =
+          secretHandler.replaceSecrets(propertiesAsJsonString, secretContext);
       return objectMapper.readValue(propertiesWithSecretsJson, new TypeReference<>() {});
     } catch (JsonProcessingException e) {
       throw new RuntimeException(e);

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/outbound/JobHandlerContext.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/outbound/JobHandlerContext.java
@@ -25,6 +25,7 @@ import io.camunda.client.api.response.ActivatedJob;
 import io.camunda.connector.api.error.ConnectorInputException;
 import io.camunda.connector.api.outbound.JobContext;
 import io.camunda.connector.api.outbound.OutboundConnectorContext;
+import io.camunda.connector.api.secret.SecretContext;
 import io.camunda.connector.api.secret.SecretProvider;
 import io.camunda.connector.api.validation.ValidationProvider;
 import io.camunda.connector.runtime.core.AbstractConnectorContext;
@@ -74,7 +75,9 @@ public class JobHandlerContext extends AbstractConnectorContext
 
   private String getJsonReplacedWithSecrets() {
     if (jsonWithSecrets == null) {
-      jsonWithSecrets = getSecretHandler().replaceSecrets(job.getVariables());
+      jsonWithSecrets =
+          getSecretHandler()
+              .replaceSecrets(job.getVariables(), new SecretContext(job.getTenantId()));
     }
     return jsonWithSecrets;
   }

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/outbound/OutboundConnectorExceptionHandler.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/outbound/OutboundConnectorExceptionHandler.java
@@ -22,6 +22,7 @@ import io.camunda.client.api.response.ActivatedJob;
 import io.camunda.connector.api.error.ConnectorException;
 import io.camunda.connector.api.error.ConnectorInputException;
 import io.camunda.connector.api.error.ConnectorRetryException;
+import io.camunda.connector.api.secret.SecretContext;
 import io.camunda.connector.api.secret.SecretProvider;
 import io.camunda.connector.runtime.core.error.InvalidBackOffDurationException;
 import io.camunda.connector.runtime.core.secret.SecretUtil;
@@ -67,7 +68,9 @@ public class OutboundConnectorExceptionHandler {
   public ConnectorResult.ErrorResult manageConnectorJobHandlerException(
       Exception e, ActivatedJob job, Duration retryBackoffDuration) {
     List<String> secrets =
-        this.secretProvider.fetchAll(SecretUtil.retrieveSecretKeysInInput(job.getVariables()));
+        this.secretProvider.fetchAll(
+            SecretUtil.retrieveSecretKeysInInput(job.getVariables()),
+            new SecretContext(job.getTenantId()));
     return switch (e) {
       case InvalidBackOffDurationException invalidBackOffDurationException ->
           handleBackOffException(invalidBackOffDurationException, secrets);
@@ -146,7 +149,9 @@ public class OutboundConnectorExceptionHandler {
 
   public ConnectorResult.ErrorResult handleFinalResultException(Exception ex, ActivatedJob job) {
     List<String> secrets =
-        this.secretProvider.fetchAll(SecretUtil.retrieveSecretKeysInInput(job.getVariables()));
+        this.secretProvider.fetchAll(
+            SecretUtil.retrieveSecretKeysInInput(job.getVariables()),
+            new SecretContext(job.getTenantId()));
     Exception newException = new Exception(hideSecretsFromMessage(ex.getMessage(), secrets), ex);
     LOGGER.error(
         "Exception while processing job: {} for tenant: {}, message: {}",

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretHandler.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretHandler.java
@@ -17,28 +17,29 @@
 package io.camunda.connector.runtime.core.secret;
 
 import io.camunda.connector.api.error.ConnectorInputException;
+import io.camunda.connector.api.secret.SecretContext;
 import io.camunda.connector.api.secret.SecretProvider;
 import java.util.Optional;
-import java.util.function.Function;
 
 public class SecretHandler {
 
   protected final SecretProvider secretProvider;
 
-  protected Function<String, String> secretReplacer;
+  protected SecretReplacer secretReplacer;
 
   public SecretHandler(final SecretProvider secretProvider) {
     this.secretProvider = secretProvider;
     secretReplacer =
-        name ->
-            Optional.ofNullable(secretProvider.getSecret(name))
+        (name, context) ->
+            Optional.ofNullable(secretProvider.getSecret(name, context))
                 .orElseThrow(
                     () ->
                         new ConnectorInputException(
-                            String.format("Secret with name '%s' is not available", name), null));
+                            String.format("Secret with context '%s' is not available", context),
+                            null));
   }
 
-  public String replaceSecrets(String input) {
-    return SecretUtil.replaceSecrets(input, secretReplacer);
+  public String replaceSecrets(String input, SecretContext context) {
+    return SecretUtil.replaceSecrets(input, context, secretReplacer);
   }
 }

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretHandler.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretHandler.java
@@ -35,8 +35,7 @@ public class SecretHandler {
                 .orElseThrow(
                     () ->
                         new ConnectorInputException(
-                            String.format("Secret with context '%s' is not available", context),
-                            null));
+                            String.format("Secret with name '%s' is not available", name), null));
   }
 
   public String replaceSecrets(String input, SecretContext context) {

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretProviderAggregator.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretProviderAggregator.java
@@ -16,6 +16,7 @@
  */
 package io.camunda.connector.runtime.core.secret;
 
+import io.camunda.connector.api.secret.SecretContext;
 import io.camunda.connector.api.secret.SecretProvider;
 import java.util.Collections;
 import java.util.List;
@@ -43,9 +44,9 @@ public class SecretProviderAggregator implements SecretProvider {
    * @param secretName the name of the secret
    * @return the secret value
    */
-  public String getSecret(String secretName) {
+  public String getSecret(String secretName, SecretContext context) {
     for (SecretProvider secretProvider : secretProviders) {
-      String secret = secretProvider.getSecret(secretName);
+      String secret = secretProvider.getSecret(secretName, context);
       if (secret != null) {
         LOG.debug(
             "Resolved secret '{}' from provider '{}'",

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretReplacer.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretReplacer.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.camunda.connector.runtime.core.secret;
 
 import io.camunda.connector.api.secret.SecretContext;

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretReplacer.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretReplacer.java
@@ -1,0 +1,7 @@
+package io.camunda.connector.runtime.core.secret;
+
+import io.camunda.connector.api.secret.SecretContext;
+
+public interface SecretReplacer {
+  String replaceSecrets(String name, SecretContext secretContext);
+}

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/FooBarSecretProvider.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/FooBarSecretProvider.java
@@ -18,6 +18,7 @@ package io.camunda.connector.runtime.core;
 
 import static java.util.Collections.singletonMap;
 
+import io.camunda.connector.api.secret.SecretContext;
 import io.camunda.connector.api.secret.SecretProvider;
 import java.util.Map;
 
@@ -29,7 +30,7 @@ public class FooBarSecretProvider implements SecretProvider {
   private static final Map<String, String> SECRETS = singletonMap(SECRET_NAME, SECRET_VALUE);
 
   @Override
-  public String getSecret(String value) {
+  public String getSecret(String value, SecretContext context) {
     return SECRETS.get(value);
   }
 }

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/NoOpSecretProvider.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/NoOpSecretProvider.java
@@ -16,12 +16,13 @@
  */
 package io.camunda.connector.runtime.core;
 
+import io.camunda.connector.api.secret.SecretContext;
 import io.camunda.connector.api.secret.SecretProvider;
 
 public class NoOpSecretProvider implements SecretProvider {
 
   @Override
-  public String getSecret(String value) {
+  public String getSecret(String value, SecretContext context) {
     return null;
   }
 }

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/SecretUtilTests.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/SecretUtilTests.java
@@ -56,7 +56,7 @@ public class SecretUtilTests {
     var secretReplacer = mock(SecretReplacer.class);
     SecretUtil.replaceSecrets(input, null, secretReplacer);
     if (shouldDetect) {
-      verify(secretReplacer).replaceSecrets(secret, any());
+      verify(secretReplacer).replaceSecrets(eq(secret), any());
     } else {
       verifyNoInteractions(secretReplacer);
     }

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/SecretUtilTests.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/SecretUtilTests.java
@@ -17,13 +17,14 @@
 package io.camunda.connector.runtime.core;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 
+import io.camunda.connector.runtime.core.secret.SecretReplacer;
 import io.camunda.connector.runtime.core.secret.SecretUtil;
 import java.util.Map;
-import java.util.function.Function;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
@@ -52,10 +53,10 @@ public class SecretUtilTests {
     "secrets.?,,false"
   })
   void testSecretPattern(String input, String secret, Boolean shouldDetect) {
-    var secretReplacer = mock(Function.class);
-    SecretUtil.replaceSecrets(input, secretReplacer);
+    var secretReplacer = mock(SecretReplacer.class);
+    SecretUtil.replaceSecrets(input, null, secretReplacer);
     if (shouldDetect) {
-      verify(secretReplacer).apply(secret);
+      verify(secretReplacer).replaceSecrets(secret, any());
     } else {
       verifyNoInteractions(secretReplacer);
     }
@@ -77,8 +78,8 @@ public class SecretUtilTests {
       },
       delimiter = '|') // delimiter is needed to escape the comma in the json
   void testSecretReplacementWithJsonInput(String input, String output) {
-    Function<String, String> secretReplacer = (name) -> secrets.get(name);
-    var result = SecretUtil.replaceSecrets(input, secretReplacer);
+    SecretReplacer secretReplacer = (name, context) -> secrets.get(name);
+    var result = SecretUtil.replaceSecrets(input, null, secretReplacer);
     assertThat(result).isEqualTo(output);
   }
 }

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/outbound/JobHandlerContextTest.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/outbound/JobHandlerContextTest.java
@@ -18,6 +18,7 @@ package io.camunda.connector.runtime.core.outbound;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -62,7 +63,7 @@ class JobHandlerContextTest {
   void bindVariables_failedSecretAreBounded() {
     String json = "{ \"integer\": \"{{secrets.FOO}}\"";
     when(activatedJob.getVariables()).thenReturn(json);
-    when(secretProvider.getSecret("FOO", null)).thenReturn("secret");
+    when(secretProvider.getSecret(eq("FOO"), any())).thenReturn("secret");
     Exception thrown =
         assertThrows(
             ConnectorInputException.class, () -> jobHandlerContext.bindVariables(TestClass.class));
@@ -74,7 +75,7 @@ class JobHandlerContextTest {
   void bindVariables_successSecretAreBounded() {
     String json = "{ \"integer\": {{secrets.FOO}} }";
     when(activatedJob.getVariables()).thenReturn(json);
-    when(secretProvider.getSecret("FOO", null)).thenReturn("1");
+    when(secretProvider.getSecret(eq("FOO"), any())).thenReturn("1");
     assertThat(jobHandlerContext.bindVariables(TestClass.class).integer).isEqualTo(1);
   }
 
@@ -82,7 +83,7 @@ class JobHandlerContextTest {
   void bindVariables_secretIsNotAvailable() {
     String json = "{ \"integer\": {{secrets.FOO2}} }";
     when(activatedJob.getVariables()).thenReturn(json);
-    when(secretProvider.getSecret("FOO2", null)).thenReturn(null);
+    when(secretProvider.getSecret(eq("FOO2"), any())).thenReturn(null);
     assertThrows(
         ConnectorInputException.class, () -> jobHandlerContext.bindVariables(TestClass.class));
   }

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/outbound/JobHandlerContextTest.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/outbound/JobHandlerContextTest.java
@@ -62,7 +62,7 @@ class JobHandlerContextTest {
   void bindVariables_failedSecretAreBounded() {
     String json = "{ \"integer\": \"{{secrets.FOO}}\"";
     when(activatedJob.getVariables()).thenReturn(json);
-    when(secretProvider.getSecret("FOO")).thenReturn("secret");
+    when(secretProvider.getSecret("FOO", null)).thenReturn("secret");
     Exception thrown =
         assertThrows(
             ConnectorInputException.class, () -> jobHandlerContext.bindVariables(TestClass.class));
@@ -74,7 +74,7 @@ class JobHandlerContextTest {
   void bindVariables_successSecretAreBounded() {
     String json = "{ \"integer\": {{secrets.FOO}} }";
     when(activatedJob.getVariables()).thenReturn(json);
-    when(secretProvider.getSecret("FOO")).thenReturn("1");
+    when(secretProvider.getSecret("FOO", null)).thenReturn("1");
     assertThat(jobHandlerContext.bindVariables(TestClass.class).integer).isEqualTo(1);
   }
 
@@ -82,7 +82,7 @@ class JobHandlerContextTest {
   void bindVariables_secretIsNotAvailable() {
     String json = "{ \"integer\": {{secrets.FOO2}} }";
     when(activatedJob.getVariables()).thenReturn(json);
-    when(secretProvider.getSecret("FOO2")).thenReturn(null);
+    when(secretProvider.getSecret("FOO2", null)).thenReturn(null);
     assertThrows(
         ConnectorInputException.class, () -> jobHandlerContext.bindVariables(TestClass.class));
   }

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/secret/SecretProviderAggregatorTest.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/secret/SecretProviderAggregatorTest.java
@@ -33,7 +33,7 @@ public class SecretProviderAggregatorTest {
     SecretProviderAggregator aggregator = new SecretProviderAggregator(override);
 
     // when
-    var secret = aggregator.getSecret(FooBarSecretProvider.SECRET_NAME);
+    var secret = aggregator.getSecret(FooBarSecretProvider.SECRET_NAME, null);
 
     // then SPI provider not used
     assertThat(aggregator.getSecretProviders()).containsExactlyElementsOf(override);
@@ -47,7 +47,7 @@ public class SecretProviderAggregatorTest {
         new SecretProviderAggregator(SecretProviderDiscovery.discoverSecretProviders());
 
     // when
-    var secret = aggregator.getSecret(FooBarSecretProvider.SECRET_NAME);
+    var secret = aggregator.getSecret(FooBarSecretProvider.SECRET_NAME, null);
 
     // then
     assertThat(aggregator.getSecretProviders()).hasSize(2);

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/secret/ConsoleSecretProvider.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/secret/ConsoleSecretProvider.java
@@ -19,6 +19,7 @@ package io.camunda.connector.runtime.secret;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
+import io.camunda.connector.api.secret.SecretContext;
 import io.camunda.connector.api.secret.SecretProvider;
 import io.camunda.connector.runtime.secret.console.ConsoleSecretApiClient;
 import java.time.Duration;
@@ -54,7 +55,7 @@ public class ConsoleSecretProvider implements SecretProvider {
   }
 
   @Override
-  public String getSecret(String name) {
+  public String getSecret(String name, SecretContext context) {
     LOGGER.debug("Resolving secret for key: {}", name);
     return secretsCache.getUnchecked(CACHE_KEY).getOrDefault(name, null);
   }

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/secret/EnvironmentSecretProvider.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/secret/EnvironmentSecretProvider.java
@@ -67,7 +67,7 @@ public class EnvironmentSecretProvider implements SecretProvider {
   }
 
   /**
-   * returns the secret name in format (${prefix}_)${tenantId}_${name}
+   * returns the secret name in format ${prefix}${tenantId}_${name}
    *
    * @param name the secrets' name to find the value for
    * @param context the context of where the secret is originated
@@ -75,6 +75,6 @@ public class EnvironmentSecretProvider implements SecretProvider {
    */
   private String composeSecretNameTenantAware(String name, SecretContext context) {
     return String.format(
-        "%s%s_%s", StringUtils.hasText(prefix) ? prefix + "_" : "", context.tenantId(), name);
+        "%s%s_%s", StringUtils.hasText(prefix) ? prefix : "", context.tenantId(), name);
   }
 }

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/secret/EnvironmentSecretProvider.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/secret/EnvironmentSecretProvider.java
@@ -16,6 +16,7 @@
  */
 package io.camunda.connector.runtime.secret;
 
+import io.camunda.connector.api.secret.SecretContext;
 import io.camunda.connector.api.secret.SecretProvider;
 import jakarta.annotation.PostConstruct;
 import org.slf4j.Logger;
@@ -27,10 +28,12 @@ public class EnvironmentSecretProvider implements SecretProvider {
   private static final Logger LOG = LoggerFactory.getLogger(EnvironmentSecretProvider.class);
   private final Environment environment;
   private final String prefix;
+  private final boolean tenantAware;
 
-  public EnvironmentSecretProvider(Environment environment, String prefix) {
+  public EnvironmentSecretProvider(Environment environment, String prefix, boolean tenantAware) {
     this.environment = environment;
     this.prefix = prefix;
+    this.tenantAware = tenantAware;
   }
 
   @PostConstruct
@@ -46,8 +49,31 @@ public class EnvironmentSecretProvider implements SecretProvider {
   }
 
   @Override
-  public String getSecret(String name) {
-    String prefixedName = !StringUtils.hasText(prefix) ? name : prefix + name;
+  public String getSecret(String name, SecretContext context) {
+    String prefixedName =
+        tenantAware ? composeSecretNameTenantAware(name, context) : composeSecretName(name);
     return environment.getProperty(prefixedName);
+  }
+
+  /**
+   * returns the secret name in format ${prefix}${name}
+   *
+   * @param name the secrets' name to find the value for
+   * @return the final secret name
+   */
+  private String composeSecretName(String name) {
+    return String.format("%s%s", StringUtils.hasText(prefix) ? prefix : "", name);
+  }
+
+  /**
+   * returns the secret name in format ${prefix}${tenantId}${name}
+   *
+   * @param name the secrets' name to find the value for
+   * @param context the context of where the secret is originated
+   * @return the final secret name
+   */
+  private String composeSecretNameTenantAware(String name, SecretContext context) {
+    return String.format(
+        "%s%s_%s", StringUtils.hasText(prefix) ? prefix + "_" : "", context.tenantId(), name);
   }
 }

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/secret/EnvironmentSecretProvider.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/secret/EnvironmentSecretProvider.java
@@ -50,9 +50,10 @@ public class EnvironmentSecretProvider implements SecretProvider {
 
   @Override
   public String getSecret(String name, SecretContext context) {
-    String prefixedName =
+    String secretName =
         tenantAware ? composeSecretNameTenantAware(name, context) : composeSecretName(name);
-    return environment.getProperty(prefixedName);
+    LOG.debug("Getting secret value for name '{}'", secretName);
+    return environment.getProperty(secretName);
   }
 
   /**
@@ -66,7 +67,7 @@ public class EnvironmentSecretProvider implements SecretProvider {
   }
 
   /**
-   * returns the secret name in format ${prefix}${tenantId}${name}
+   * returns the secret name in format (${prefix}_)${tenantId}_${name}
    *
    * @param name the secrets' name to find the value for
    * @param context the context of where the secret is originated

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/secret/ConsoleSecretProviderTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/secret/ConsoleSecretProviderTest.java
@@ -73,7 +73,7 @@ public class ConsoleSecretProviderTest {
 
     // Test the provider
     var consoleSecretProvider = new ConsoleSecretProvider(client, Duration.ofSeconds(1));
-    assertThat(consoleSecretProvider.getSecret("secretKey")).isEqualTo("secretValue");
+    assertThat(consoleSecretProvider.getSecret("secretKey", null)).isEqualTo("secretValue");
   }
 
   @Test
@@ -98,7 +98,7 @@ public class ConsoleSecretProviderTest {
             .willReturn(ResponseDefinitionBuilder.okForJson(secretsResponse)));
 
     var consoleSecretProvider = new ConsoleSecretProvider(client, Duration.ofMillis(1));
-    assertThat(consoleSecretProvider.getSecret("secretKey")).isEqualTo("secretValue");
+    assertThat(consoleSecretProvider.getSecret("secretKey", null)).isEqualTo("secretValue");
 
     // Sleep so cache requires a new refresh
     Thread.sleep(10);
@@ -110,7 +110,7 @@ public class ConsoleSecretProviderTest {
             .willReturn(ResponseDefinitionBuilder.responseDefinition().withStatus(500)));
 
     // Previously cached secret should still be resolved
-    assertThat(consoleSecretProvider.getSecret("secretKey")).isEqualTo("secretValue");
+    assertThat(consoleSecretProvider.getSecret("secretKey", null)).isEqualTo("secretValue");
 
     // Sleep so cache requires a new refresh
     Thread.sleep(10);
@@ -123,6 +123,6 @@ public class ConsoleSecretProviderTest {
             .willReturn(ResponseDefinitionBuilder.okForJson(secretsResponse)));
 
     // New secrets should be resolved
-    assertThat(consoleSecretProvider.getSecret("secretKey")).isEqualTo("newSecretValue");
+    assertThat(consoleSecretProvider.getSecret("secretKey", null)).isEqualTo("newSecretValue");
   }
 }

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/secret/EnvironmentSecretProviderTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/secret/EnvironmentSecretProviderTest.java
@@ -52,4 +52,14 @@ public class EnvironmentSecretProviderTest {
         secretProvider.getSecret("my-total-secret", new SecretContext("my-tenant"));
     assertThat(myTotalSecret).isEqualTo("beebop");
   }
+
+  @Test
+  void shouldApplyPrefixAndContext() {
+    MockEnvironment env = new MockEnvironment();
+    env.setProperty("secrets.my-tenant_my-total-secret", "beebop");
+    EnvironmentSecretProvider secretProvider = new EnvironmentSecretProvider(env, "secrets.", true);
+    String myTotalSecret =
+        secretProvider.getSecret("my-total-secret", new SecretContext("my-tenant"));
+    assertThat(myTotalSecret).isEqualTo("beebop");
+  }
 }

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/secret/EnvironmentSecretProviderTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/secret/EnvironmentSecretProviderTest.java
@@ -18,6 +18,7 @@ package io.camunda.connector.runtime.secret;
 
 import static org.assertj.core.api.Assertions.*;
 
+import io.camunda.connector.api.secret.SecretContext;
 import org.junit.jupiter.api.Test;
 import org.springframework.mock.env.MockEnvironment;
 
@@ -27,8 +28,28 @@ public class EnvironmentSecretProviderTest {
   void shouldApplyPrefix() {
     MockEnvironment env = new MockEnvironment();
     env.setProperty("secrets.my-total-secret", "beebop");
-    EnvironmentSecretProvider secretProvider = new EnvironmentSecretProvider(env, "secrets.");
-    String myTotalSecret = secretProvider.getSecret("my-total-secret");
+    EnvironmentSecretProvider secretProvider =
+        new EnvironmentSecretProvider(env, "secrets.", false);
+    String myTotalSecret = secretProvider.getSecret("my-total-secret", null);
+    assertThat(myTotalSecret).isEqualTo("beebop");
+  }
+
+  @Test
+  void shouldNotApplyPrefix() {
+    MockEnvironment env = new MockEnvironment();
+    env.setProperty("my-total-secret", "beebop");
+    EnvironmentSecretProvider secretProvider = new EnvironmentSecretProvider(env, null, false);
+    String myTotalSecret = secretProvider.getSecret("my-total-secret", null);
+    assertThat(myTotalSecret).isEqualTo("beebop");
+  }
+
+  @Test
+  void shouldApplyContext() {
+    MockEnvironment env = new MockEnvironment();
+    env.setProperty("my-tenant_my-total-secret", "beebop");
+    EnvironmentSecretProvider secretProvider = new EnvironmentSecretProvider(env, null, true);
+    String myTotalSecret =
+        secretProvider.getSecret("my-total-secret", new SecretContext("my-tenant"));
     assertThat(myTotalSecret).isEqualTo("beebop");
   }
 }

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/main/java/io/camunda/connector/runtime/ConnectorProperties.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/main/java/io/camunda/connector/runtime/ConnectorProperties.java
@@ -39,7 +39,7 @@ public record ConnectorProperties(Polling polling, Webhook webhook, SecretProvid
   /**
    * Configuration for the {@link org.springframework.core.env.Environment} based secret provider
    */
-  public record Environment(boolean enabled, String prefix) {}
+  public record Environment(boolean enabled, String prefix, boolean tenantAware) {}
 
   public record ConsoleSecretProvider(boolean enabled, String endpoint, String audience) {}
 }

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/main/java/io/camunda/connector/runtime/OutboundConnectorsAutoConfiguration.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/main/java/io/camunda/connector/runtime/OutboundConnectorsAutoConfiguration.java
@@ -65,6 +65,9 @@ public class OutboundConnectorsAutoConfiguration {
   @Value("${camunda.connector.secretprovider.environment.prefix:}")
   String environmentSecretProviderPrefix;
 
+  @Value("${camunda.connector.secretprovider.environment.tenantaware:false}")
+  boolean environmentSecretProviderTenantAware;
+
   @Value(
       "${camunda.connector.secretprovider.console.endpoint:https://cluster-api.cloud.camunda.io/secrets}")
   String consoleSecretsApiEndpoint;
@@ -105,7 +108,8 @@ public class OutboundConnectorsAutoConfiguration {
       havingValue = "true",
       matchIfMissing = true)
   public EnvironmentSecretProvider defaultSecretProvider(Environment environment) {
-    return new EnvironmentSecretProvider(environment, environmentSecretProviderPrefix);
+    return new EnvironmentSecretProvider(
+        environment, environmentSecretProviderPrefix, environmentSecretProviderTenantAware);
   }
 
   @Bean

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/inbound/WebhookControllerPlainJavaTests.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/inbound/WebhookControllerPlainJavaTests.java
@@ -33,6 +33,8 @@ import io.camunda.connector.api.inbound.webhook.WebhookConnectorExecutable;
 import io.camunda.connector.api.inbound.webhook.WebhookProcessingPayload;
 import io.camunda.connector.api.inbound.webhook.WebhookResult;
 import io.camunda.connector.api.json.ConnectorsObjectMapperSupplier;
+import io.camunda.connector.api.secret.SecretContext;
+import io.camunda.connector.api.secret.SecretProvider;
 import io.camunda.connector.runtime.core.inbound.InboundConnectorContextImpl;
 import io.camunda.connector.runtime.core.inbound.InboundConnectorElement;
 import io.camunda.connector.runtime.core.inbound.correlation.InboundCorrelationHandler;
@@ -154,7 +156,7 @@ public class WebhookControllerPlainJavaTests {
   public static InboundConnectorContextImpl buildContext(ValidInboundConnectorDetails def) {
     var context =
         new InboundConnectorContextImpl(
-            name -> null,
+            new NullSecretProvider(),
             new DefaultValidationProvider(),
             def,
             mock(InboundCorrelationHandler.class),
@@ -183,5 +185,12 @@ public class WebhookControllerPlainJavaTests {
         new StartEventCorrelationPoint(bpmnProcessId, version, processDefinitionKey),
         new ProcessElement(
             bpmnProcessId, version, processDefinitionKey, "testElement", "<default>"));
+  }
+
+  private static class NullSecretProvider implements SecretProvider {
+    @Override
+    public String getSecret(String name, SecretContext context) {
+      return null;
+    }
   }
 }

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/secret/CustomSecretProviderAggregatorTest.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/secret/CustomSecretProviderAggregatorTest.java
@@ -18,6 +18,7 @@ package io.camunda.connector.runtime.secret;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.camunda.connector.api.secret.SecretContext;
 import io.camunda.connector.api.secret.SecretProvider;
 import io.camunda.connector.runtime.app.TestConnectorRuntimeApplication;
 import io.camunda.connector.runtime.core.secret.SecretProviderAggregator;
@@ -45,8 +46,8 @@ public class CustomSecretProviderAggregatorTest {
   void customAggregatorCanOverrideDefault() {
     // given 2 secret providers defined in the spring context
     // and a custom secret provider aggregator
-    assertThat(secretProviderAggregator.getSecret("FOO")).isEqualTo("CUSTOM");
-    assertThat(secretProviderAggregator.getSecret("BAR")).isEqualTo("CUSTOM");
+    assertThat(secretProviderAggregator.getSecret("FOO", null)).isEqualTo("CUSTOM");
+    assertThat(secretProviderAggregator.getSecret("BAR", null)).isEqualTo("CUSTOM");
   }
 
   @Component
@@ -57,7 +58,7 @@ public class CustomSecretProviderAggregatorTest {
     }
 
     @Override
-    public String getSecret(String secretName) {
+    public String getSecret(String secretName, SecretContext context) {
       return "CUSTOM";
     }
   }

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/secret/EnvironmentSecretProviderTest.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/secret/EnvironmentSecretProviderTest.java
@@ -42,7 +42,7 @@ public class EnvironmentSecretProviderTest {
   void springEnvironmentSecretProviderShouldBePresent() {
     // Spring environment based secret provider should look up values from properties
     assertThat(secretProviderAggregator.getSecretProviders().size()).isEqualTo(1);
-    var actualSecretValue = secretProviderAggregator.getSecret("test.secret");
+    var actualSecretValue = secretProviderAggregator.getSecret("test.secret", null);
     assertThat(actualSecretValue).isNotNull();
     assertThat(actualSecretValue).isEqualTo(expectedSecretValue);
   }

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/secret/SPISecretProviderTest.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/secret/SPISecretProviderTest.java
@@ -36,6 +36,6 @@ public class SPISecretProviderTest {
     // given only the SPI secret provider is defined and no spring beans secret providers
     // then it should be discovered
     assertThat(secretProviderAggregator.getSecretProviders().size()).isEqualTo(1);
-    assertThat(secretProviderAggregator.getSecret("SPI")).isEqualTo("SPI");
+    assertThat(secretProviderAggregator.getSecret("SPI", null)).isEqualTo("SPI");
   }
 }

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/secret/SpringSecretProviderTest.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/secret/SpringSecretProviderTest.java
@@ -41,9 +41,9 @@ public class SpringSecretProviderTest {
   void secretProviderIsLoadedFromSpringContext() {
     // given 2 secret providers defined in the spring context
     // then the secret provider aggregator should be able to find them
-    assertThat(secretProviderAggregator.getSecret("FOO")).isEqualTo("FOO");
-    assertThat(secretProviderAggregator.getSecret("BAR")).isEqualTo("BAR");
+    assertThat(secretProviderAggregator.getSecret("FOO", null)).isEqualTo("FOO");
+    assertThat(secretProviderAggregator.getSecret("BAR", null)).isEqualTo("BAR");
     // and SPI secret provider should not be loaded
-    assertThat(secretProviderAggregator.getSecret("SPI")).isNull();
+    assertThat(secretProviderAggregator.getSecret("SPI", null)).isNull();
   }
 }

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/secret/providers/BarSpringSecretProvider.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/secret/providers/BarSpringSecretProvider.java
@@ -16,6 +16,7 @@
  */
 package io.camunda.connector.runtime.secret.providers;
 
+import io.camunda.connector.api.secret.SecretContext;
 import io.camunda.connector.api.secret.SecretProvider;
 import org.springframework.stereotype.Component;
 
@@ -23,7 +24,7 @@ import org.springframework.stereotype.Component;
 public class BarSpringSecretProvider implements SecretProvider {
 
   @Override
-  public String getSecret(String s) {
+  public String getSecret(String s, SecretContext context) {
     if ("BAR".equals(s)) {
       return "BAR";
     } else {

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/secret/providers/FooSpringSecretProvider.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/secret/providers/FooSpringSecretProvider.java
@@ -16,6 +16,7 @@
  */
 package io.camunda.connector.runtime.secret.providers;
 
+import io.camunda.connector.api.secret.SecretContext;
 import io.camunda.connector.api.secret.SecretProvider;
 import org.springframework.stereotype.Component;
 
@@ -23,7 +24,7 @@ import org.springframework.stereotype.Component;
 public class FooSpringSecretProvider implements SecretProvider {
 
   @Override
-  public String getSecret(String s) {
+  public String getSecret(String s, SecretContext context) {
     if ("FOO".equals(s)) {
       return "FOO";
     } else {

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/secret/providers/SpiSecretProvider.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/secret/providers/SpiSecretProvider.java
@@ -16,13 +16,14 @@
  */
 package io.camunda.connector.runtime.secret.providers;
 
+import io.camunda.connector.api.secret.SecretContext;
 import io.camunda.connector.api.secret.SecretProvider;
 
 // note this is not defined as a Spring bean
 public class SpiSecretProvider implements SecretProvider {
 
   @Override
-  public String getSecret(String s) {
+  public String getSecret(String s, SecretContext context) {
     if ("SPI".equals(s)) {
       return "SPI";
     } else {

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/utils/TestSecretProvider.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/utils/TestSecretProvider.java
@@ -18,6 +18,7 @@ package io.camunda.connector.runtime.utils;
 
 import static java.util.Collections.singletonMap;
 
+import io.camunda.connector.api.secret.SecretContext;
 import io.camunda.connector.api.secret.SecretProvider;
 import java.util.Map;
 
@@ -29,7 +30,7 @@ public class TestSecretProvider implements SecretProvider {
   private static final Map<String, String> SECRETS = singletonMap(SECRET_NAME, SECRET_VALUE);
 
   @Override
-  public String getSecret(String value) {
+  public String getSecret(String value, SecretContext context) {
     return SECRETS.get(value);
   }
 }

--- a/connector-sdk/core/src/main/java/io/camunda/connector/api/secret/SecretContext.java
+++ b/connector-sdk/core/src/main/java/io/camunda/connector/api/secret/SecretContext.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.camunda.connector.api.secret;
 
 public record SecretContext(String tenantId) {}

--- a/connector-sdk/core/src/main/java/io/camunda/connector/api/secret/SecretContext.java
+++ b/connector-sdk/core/src/main/java/io/camunda/connector/api/secret/SecretContext.java
@@ -1,0 +1,3 @@
+package io.camunda.connector.api.secret;
+
+public record SecretContext(String tenantId) {}

--- a/connector-sdk/core/src/main/java/io/camunda/connector/api/secret/SecretProvider.java
+++ b/connector-sdk/core/src/main/java/io/camunda/connector/api/secret/SecretProvider.java
@@ -32,9 +32,22 @@ public interface SecretProvider {
    * @return the secret's value for the given name, if it exists. Otherwise, <code>null</code> is
    *     returned.
    */
-  String getSecret(String name);
+  @Deprecated
+  default String getSecret(String name) {
+    return getSecret(name, null);
+  }
 
-  default List<String> fetchAll(List<String> keys) {
-    return keys.stream().map(this::getSecret).filter(Objects::nonNull).toList();
+  /**
+   * @param name - the secret's name to find a value for
+   * @param context - the secret context for which a value should be provided
+   * @return the secret's value for the given name, if it exists. Otherwise, <code>null</code> is
+   *     returned.
+   */
+  default String getSecret(String name, SecretContext context) {
+    return getSecret(name);
+  }
+
+  default List<String> fetchAll(List<String> keys, SecretContext context) {
+    return keys.stream().map(key -> getSecret(key, context)).filter(Objects::nonNull).toList();
   }
 }

--- a/connector-sdk/test/src/main/java/io/camunda/connector/test/MapSecretProvider.java
+++ b/connector-sdk/test/src/main/java/io/camunda/connector/test/MapSecretProvider.java
@@ -1,0 +1,18 @@
+package io.camunda.connector.test;
+
+import io.camunda.connector.api.secret.SecretContext;
+import io.camunda.connector.api.secret.SecretProvider;
+import java.util.Map;
+
+public class MapSecretProvider implements SecretProvider {
+  private final Map<String, String> secrets;
+
+  public MapSecretProvider(Map<String, String> secrets) {
+    this.secrets = secrets;
+  }
+
+  @Override
+  public String getSecret(String name, SecretContext context) {
+    return secrets.get(name);
+  }
+}

--- a/connector-sdk/test/src/main/java/io/camunda/connector/test/MapSecretProvider.java
+++ b/connector-sdk/test/src/main/java/io/camunda/connector/test/MapSecretProvider.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.camunda.connector.test;
 
 import io.camunda.connector.api.secret.SecretContext;

--- a/connector-sdk/test/src/main/java/io/camunda/connector/test/inbound/InboundConnectorContextBuilder.java
+++ b/connector-sdk/test/src/main/java/io/camunda/connector/test/inbound/InboundConnectorContextBuilder.java
@@ -29,6 +29,7 @@ import io.camunda.connector.runtime.core.AbstractConnectorContext;
 import io.camunda.connector.runtime.core.inbound.InboundConnectorElement;
 import io.camunda.connector.runtime.core.inbound.InboundConnectorReportingContext;
 import io.camunda.connector.test.ConnectorContextTestUtil;
+import io.camunda.connector.test.MapSecretProvider;
 import io.camunda.document.Document;
 import io.camunda.document.factory.DocumentFactory;
 import io.camunda.document.factory.DocumentFactoryImpl;
@@ -49,7 +50,7 @@ import org.jetbrains.annotations.NotNull;
 public class InboundConnectorContextBuilder {
 
   protected final Map<String, String> secrets = new HashMap<>();
-  protected SecretProvider secretProvider = secrets::get;
+  protected SecretProvider secretProvider = new MapSecretProvider(secrets);
   protected Map<String, Object> properties;
   protected InboundConnectorDefinition definition;
   protected ValidationProvider validationProvider;
@@ -227,7 +228,7 @@ public class InboundConnectorContextBuilder {
       this.activationTimestamp = System.currentTimeMillis();
       try {
         propertiesWithSecrets =
-            getSecretHandler().replaceSecrets(objectMapper.writeValueAsString(properties));
+            getSecretHandler().replaceSecrets(objectMapper.writeValueAsString(properties), null);
       } catch (JsonProcessingException e) {
         throw new RuntimeException(e);
       }

--- a/connector-sdk/test/src/main/java/io/camunda/connector/test/outbound/OutboundConnectorContextBuilder.java
+++ b/connector-sdk/test/src/main/java/io/camunda/connector/test/outbound/OutboundConnectorContextBuilder.java
@@ -27,6 +27,7 @@ import io.camunda.connector.api.validation.ValidationProvider;
 import io.camunda.connector.document.jackson.JacksonModuleDocumentDeserializer;
 import io.camunda.connector.runtime.core.AbstractConnectorContext;
 import io.camunda.connector.test.ConnectorContextTestUtil;
+import io.camunda.connector.test.MapSecretProvider;
 import io.camunda.document.Document;
 import io.camunda.document.factory.DocumentFactory;
 import io.camunda.document.factory.DocumentFactoryImpl;
@@ -41,7 +42,7 @@ public class OutboundConnectorContextBuilder {
 
   protected final Map<String, String> secrets = new HashMap<>();
   protected final Map<String, String> headers = new HashMap<>();
-  protected SecretProvider secretProvider = secrets::get;
+  protected SecretProvider secretProvider = new MapSecretProvider(secrets);
   protected ValidationProvider validationProvider;
   protected Map<String, Object> variables;
   protected DocumentFactory documentFactory =
@@ -198,7 +199,7 @@ public class OutboundConnectorContextBuilder {
       super(secretProvider, validationProvider);
       try {
         var asString = objectMapper.writeValueAsString(variables);
-        variablesWithSecrets = getSecretHandler().replaceSecrets(asString);
+        variablesWithSecrets = getSecretHandler().replaceSecrets(asString, null);
       } catch (JsonProcessingException e) {
         throw new RuntimeException(e);
       }

--- a/connector-sdk/test/src/test/java/io/camunda/connector/test/inbound/InboundConnectorContextBuilderTest.java
+++ b/connector-sdk/test/src/test/java/io/camunda/connector/test/inbound/InboundConnectorContextBuilderTest.java
@@ -79,7 +79,7 @@ public class InboundConnectorContextBuilderTest {
   public void shouldProvideSecret() {
     var context =
         InboundConnectorContextBuilder.create().properties("{}").secret("foo", "FOO").build();
-    var replaced = context.getSecretHandler().replaceSecrets("secrets.foo");
+    var replaced = context.getSecretHandler().replaceSecrets("secrets.foo", null);
     assertThat(replaced).isEqualTo("FOO");
   }
 
@@ -87,7 +87,7 @@ public class InboundConnectorContextBuilderTest {
   public void shouldThrowOnMissingSecret() {
     var context =
         InboundConnectorContextBuilder.create().properties("{}").secret("x", "FOO").build();
-    Executable replacement = () -> context.getSecretHandler().replaceSecrets("secrets.foo");
+    Executable replacement = () -> context.getSecretHandler().replaceSecrets("secrets.foo", null);
     assertThrows(
         ConnectorInputException.class, replacement, "Secret with name 'foo' is not available");
   }
@@ -100,7 +100,7 @@ public class InboundConnectorContextBuilderTest {
             .secret("foo", "FOO")
             .secret("bar", "BAR")
             .build();
-    var replaced = context.getSecretHandler().replaceSecrets("secrets.foo secrets.bar");
+    var replaced = context.getSecretHandler().replaceSecrets("secrets.foo secrets.bar", null);
     assertThat(replaced).isEqualTo("FOO BAR");
   }
 
@@ -108,7 +108,7 @@ public class InboundConnectorContextBuilderTest {
   public void shouldProvideSecretWithParentheses() {
     var context =
         InboundConnectorContextBuilder.create().properties("{}").secret("foo", "FOO").build();
-    var replaced = context.getSecretHandler().replaceSecrets("{{secrets.foo}}");
+    var replaced = context.getSecretHandler().replaceSecrets("{{secrets.foo}}", null);
     assertThat(replaced).isEqualTo("FOO");
   }
 
@@ -120,7 +120,8 @@ public class InboundConnectorContextBuilderTest {
             .secret("foo", "FOO")
             .secret("bar", "BAR")
             .build();
-    var replaced = context.getSecretHandler().replaceSecrets("{{secrets.foo}} {{secrets.bar}}");
+    var replaced =
+        context.getSecretHandler().replaceSecrets("{{secrets.foo}} {{secrets.bar}}", null);
     assertThat(replaced).isEqualTo("FOO BAR");
   }
 

--- a/connector-sdk/test/src/test/java/io/camunda/connector/test/outbound/OutboundConnectorContextBuilderTest.java
+++ b/connector-sdk/test/src/test/java/io/camunda/connector/test/outbound/OutboundConnectorContextBuilderTest.java
@@ -79,7 +79,7 @@ public class OutboundConnectorContextBuilderTest {
   public void shouldProvideSecret() {
     var context =
         OutboundConnectorContextBuilder.create().variables("{}").secret("foo", "FOO").build();
-    var replaced = context.getSecretHandler().replaceSecrets("secrets.foo");
+    var replaced = context.getSecretHandler().replaceSecrets("secrets.foo", null);
     assertThat(replaced).isEqualTo("FOO");
   }
 
@@ -87,7 +87,7 @@ public class OutboundConnectorContextBuilderTest {
   public void shouldThrowOnMissingSecret() {
     var context =
         OutboundConnectorContextBuilder.create().variables("{}").secret("x", "FOO").build();
-    Executable replacement = () -> context.getSecretHandler().replaceSecrets("secrets.foo");
+    Executable replacement = () -> context.getSecretHandler().replaceSecrets("secrets.foo", null);
     assertThrows(
         ConnectorInputException.class, replacement, "Secret with name 'foo' is not available");
   }
@@ -100,7 +100,7 @@ public class OutboundConnectorContextBuilderTest {
             .secret("foo", "FOO")
             .secret("bar", "BAR")
             .build();
-    var replaced = context.getSecretHandler().replaceSecrets("secrets.foo secrets.bar");
+    var replaced = context.getSecretHandler().replaceSecrets("secrets.foo secrets.bar", null);
     assertThat(replaced).isEqualTo("FOO BAR");
   }
 
@@ -108,7 +108,7 @@ public class OutboundConnectorContextBuilderTest {
   public void shouldProvideSecretWithParentheses() {
     var context =
         OutboundConnectorContextBuilder.create().variables("{}").secret("foo", "FOO").build();
-    var replaced = context.getSecretHandler().replaceSecrets("{{secrets.foo}}");
+    var replaced = context.getSecretHandler().replaceSecrets("{{secrets.foo}}", null);
     assertThat(replaced).isEqualTo("FOO");
   }
 
@@ -120,7 +120,8 @@ public class OutboundConnectorContextBuilderTest {
             .secret("foo", "FOO")
             .secret("bar", "BAR")
             .build();
-    var replaced = context.getSecretHandler().replaceSecrets("{{secrets.foo}} {{secrets.bar}}");
+    var replaced =
+        context.getSecretHandler().replaceSecrets("{{secrets.foo}} {{secrets.bar}}", null);
     assertThat(replaced).isEqualTo("FOO BAR");
   }
 

--- a/connectors/http/polling/src/test/java/io/camunda/connector/http/polling/model/PollingIntervalConfigurationTest.java
+++ b/connectors/http/polling/src/test/java/io/camunda/connector/http/polling/model/PollingIntervalConfigurationTest.java
@@ -11,6 +11,7 @@ import static org.mockito.Mockito.when;
 
 import com.google.common.collect.EvictingQueue;
 import io.camunda.connector.api.json.ConnectorsObjectMapperSupplier;
+import io.camunda.connector.api.secret.SecretContext;
 import io.camunda.connector.api.secret.SecretProvider;
 import io.camunda.connector.runtime.core.inbound.InboundConnectorContextImpl;
 import io.camunda.connector.runtime.core.inbound.details.InboundConnectorDetails.ValidInboundConnectorDetails;
@@ -36,7 +37,8 @@ public class PollingIntervalConfigurationTest {
 
   @BeforeEach
   public void setUp() {
-    SecretProvider secretProvider = name -> name; // Simplified secret provider for testing purposes
+    SecretProvider secretProvider =
+        new MirrorSecretProvider(); // Simplified secret provider for testing purposes
     properties = new HashMap<>();
     when(connectorData.rawPropertiesWithoutKeywords()).thenReturn(properties);
     inboundConnectorContext =
@@ -85,5 +87,12 @@ public class PollingIntervalConfigurationTest {
         Arguments.of("PT2H", 7200000L),
         Arguments.of("P1DT12H", 129600000L),
         Arguments.of(null, 5000));
+  }
+
+  private static class MirrorSecretProvider implements SecretProvider {
+    @Override
+    public String getSecret(String name, SecretContext context) {
+      return name;
+    }
   }
 }

--- a/connectors/http/rest/src/test/java/io/camunda/connector/http/rest/HttpJsonFunctionTest.java
+++ b/connectors/http/rest/src/test/java/io/camunda/connector/http/rest/HttpJsonFunctionTest.java
@@ -27,6 +27,8 @@ import com.github.tomakehurst.wiremock.admin.model.ServeEventQuery;
 import com.github.tomakehurst.wiremock.junit5.WireMockTest;
 import com.github.tomakehurst.wiremock.stubbing.ServeEvent;
 import io.camunda.connector.api.error.ConnectorInputException;
+import io.camunda.connector.api.secret.SecretContext;
+import io.camunda.connector.api.secret.SecretProvider;
 import io.camunda.connector.http.base.model.HttpCommonResult;
 import io.camunda.connector.test.outbound.OutboundConnectorContextBuilder;
 import io.camunda.connector.validation.impl.DefaultValidationProvider;
@@ -87,7 +89,7 @@ public class HttpJsonFunctionTest extends BaseTest {
         OutboundConnectorContextBuilder.create()
             .variables(input)
             .validation(new DefaultValidationProvider())
-            .secrets(name -> "foo")
+            .secrets(new StaticSecretProvider("foo"))
             .build();
 
     // when
@@ -163,7 +165,18 @@ public class HttpJsonFunctionTest extends BaseTest {
 
   private HttpCommonResult arrange(String input) throws Exception {
     final var context =
-        OutboundConnectorContextBuilder.create().variables(input).secrets(name -> "foo").build();
+        OutboundConnectorContextBuilder.create()
+            .variables(input)
+            .secrets(new StaticSecretProvider("foo"))
+            .build();
     return (HttpCommonResult) functionUnderTest.execute(context);
+  }
+
+  private record StaticSecretProvider(String secret) implements SecretProvider {
+
+    @Override
+    public String getSecret(String name, SecretContext context) {
+      return secret;
+    }
   }
 }

--- a/secret-providers/gcp-secret-provider/src/main/java/io/camunda/connector/runtime/cloud/GcpSecretManagerSecretProvider.java
+++ b/secret-providers/gcp-secret-provider/src/main/java/io/camunda/connector/runtime/cloud/GcpSecretManagerSecretProvider.java
@@ -29,6 +29,7 @@ import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import io.camunda.connector.api.error.ConnectorException;
+import io.camunda.connector.api.secret.SecretContext;
 import io.camunda.connector.api.secret.SecretProvider;
 import java.util.Map;
 import java.util.Objects;
@@ -128,7 +129,7 @@ public class GcpSecretManagerSecretProvider implements SecretProvider {
   }
 
   @Override
-  public String getSecret(String name) {
+  public String getSecret(String name, SecretContext context) {
     try {
       return secretsCache.get(CACHE_KEY).get(name);
     } catch (ExecutionException e) {


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

This PR extends the secret provider to be context aware.

This will not change the current behaviour but allow secret providers to respect a context when resolving secrets.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.
- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest release, as this branch will be rebased onto main before the next release.

