### PR TITLE
feat(agentic-ai): add support for Azure OpenAI models

### DIFF
--- a/connectors/agentic-ai/element-templates/agenticai-aiagent-outbound-connector.json
+++ b/connectors/agentic-ai/element-templates/agenticai-aiagent-outbound-connector.json
@@ -91,11 +91,11 @@
       "name" : "Anthropic",
       "value" : "anthropic"
     }, {
-      "name" : "Azure OpenAI",
-      "value" : "azureOpenAi"
-    }, {
       "name" : "AWS Bedrock",
       "value" : "bedrock"
+    }, {
+      "name" : "Azure OpenAI",
+      "value" : "azureOpenAi"
     }, {
       "name" : "OpenAI",
       "value" : "openai"
@@ -136,6 +136,117 @@
     },
     "type" : "String"
   }, {
+    "id" : "provider.bedrock.region",
+    "label" : "Region",
+    "description" : "Specify the AWS region (example: <code>eu-west-1</code>)",
+    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "provider",
+    "binding" : {
+      "name" : "provider.bedrock.region",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "provider.type",
+      "equals" : "bedrock",
+      "type" : "simple"
+    },
+    "type" : "String"
+  }, {
+    "id" : "provider.bedrock.endpoint",
+    "label" : "Endpoint",
+    "description" : "Specify endpoint if need to use a custom API endpoint",
+    "optional" : true,
+    "group" : "provider",
+    "binding" : {
+      "name" : "provider.bedrock.endpoint",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "provider.type",
+      "equals" : "bedrock",
+      "type" : "simple"
+    },
+    "type" : "Hidden"
+  }, {
+    "id" : "provider.bedrock.authentication.type",
+    "label" : "Authentication",
+    "description" : "Specify the AWS authentication strategy. Learn more at the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-bedrock/#authentication\" target=\"_blank\">documentation page</a>",
+    "value" : "credentials",
+    "group" : "provider",
+    "binding" : {
+      "name" : "provider.bedrock.authentication.type",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "provider.type",
+      "equals" : "bedrock",
+      "type" : "simple"
+    },
+    "type" : "Dropdown",
+    "choices" : [ {
+      "name" : "Credentials",
+      "value" : "credentials"
+    }, {
+      "name" : "Default Credentials Chain (Hybrid/Self-Managed only)",
+      "value" : "defaultCredentialsChain"
+    } ]
+  }, {
+    "id" : "provider.bedrock.authentication.accessKey",
+    "label" : "Access key",
+    "description" : "Provide an IAM access key tailored to a user, equipped with the necessary permissions",
+    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "provider",
+    "binding" : {
+      "name" : "provider.bedrock.authentication.accessKey",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "allMatch" : [ {
+        "property" : "provider.bedrock.authentication.type",
+        "equals" : "credentials",
+        "type" : "simple"
+      }, {
+        "property" : "provider.type",
+        "equals" : "bedrock",
+        "type" : "simple"
+      } ]
+    },
+    "type" : "String"
+  }, {
+    "id" : "provider.bedrock.authentication.secretKey",
+    "label" : "Secret key",
+    "description" : "Provide a secret key of a user with permissions to invoke specified AWS Lambda function",
+    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "provider",
+    "binding" : {
+      "name" : "provider.bedrock.authentication.secretKey",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "allMatch" : [ {
+        "property" : "provider.bedrock.authentication.type",
+        "equals" : "credentials",
+        "type" : "simple"
+      }, {
+        "property" : "provider.type",
+        "equals" : "bedrock",
+        "type" : "simple"
+      } ]
+    },
+    "type" : "String"
+  }, {
     "id" : "provider.azureOpenAi.endpoint",
     "label" : "Endpoint",
     "description" : "Specify Azure OpenAI endpoint. Details in the <a href=\"https://learn.microsoft.com/en-us/azure/ai-foundry/openai/reference\" target=\"_blank\">documentation</a>.",
@@ -158,7 +269,7 @@
   }, {
     "id" : "provider.azureOpenAi.authentication.type",
     "label" : "Authentication",
-    "description" : "Specify the Azure OpenAI authentication strategy. Learn more at the <a href=\"https://docs.langchain4j.dev/integrations/language-models/azure-open-ai\" target=\"_blank\">documentation page</a>",
+    "description" : "Specify the Azure OpenAI authentication strategy.",
     "value" : "apiKey",
     "group" : "provider",
     "binding" : {
@@ -300,117 +411,6 @@
       }, {
         "property" : "provider.type",
         "equals" : "azureOpenAi",
-        "type" : "simple"
-      } ]
-    },
-    "type" : "String"
-  }, {
-    "id" : "provider.bedrock.region",
-    "label" : "Region",
-    "description" : "Specify the AWS region (example: <code>eu-west-1</code>)",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "feel" : "optional",
-    "group" : "provider",
-    "binding" : {
-      "name" : "provider.bedrock.region",
-      "type" : "zeebe:input"
-    },
-    "condition" : {
-      "property" : "provider.type",
-      "equals" : "bedrock",
-      "type" : "simple"
-    },
-    "type" : "String"
-  }, {
-    "id" : "provider.bedrock.endpoint",
-    "label" : "Endpoint",
-    "description" : "Specify endpoint if need to use a custom API endpoint",
-    "optional" : true,
-    "group" : "provider",
-    "binding" : {
-      "name" : "provider.bedrock.endpoint",
-      "type" : "zeebe:input"
-    },
-    "condition" : {
-      "property" : "provider.type",
-      "equals" : "bedrock",
-      "type" : "simple"
-    },
-    "type" : "Hidden"
-  }, {
-    "id" : "provider.bedrock.authentication.type",
-    "label" : "Authentication",
-    "description" : "Specify the AWS authentication strategy. Learn more at the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-bedrock/#authentication\" target=\"_blank\">documentation page</a>",
-    "value" : "credentials",
-    "group" : "provider",
-    "binding" : {
-      "name" : "provider.bedrock.authentication.type",
-      "type" : "zeebe:input"
-    },
-    "condition" : {
-      "property" : "provider.type",
-      "equals" : "bedrock",
-      "type" : "simple"
-    },
-    "type" : "Dropdown",
-    "choices" : [ {
-      "name" : "Credentials",
-      "value" : "credentials"
-    }, {
-      "name" : "Default Credentials Chain (Hybrid/Self-Managed only)",
-      "value" : "defaultCredentialsChain"
-    } ]
-  }, {
-    "id" : "provider.bedrock.authentication.accessKey",
-    "label" : "Access key",
-    "description" : "Provide an IAM access key tailored to a user, equipped with the necessary permissions",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "feel" : "optional",
-    "group" : "provider",
-    "binding" : {
-      "name" : "provider.bedrock.authentication.accessKey",
-      "type" : "zeebe:input"
-    },
-    "condition" : {
-      "allMatch" : [ {
-        "property" : "provider.bedrock.authentication.type",
-        "equals" : "credentials",
-        "type" : "simple"
-      }, {
-        "property" : "provider.type",
-        "equals" : "bedrock",
-        "type" : "simple"
-      } ]
-    },
-    "type" : "String"
-  }, {
-    "id" : "provider.bedrock.authentication.secretKey",
-    "label" : "Secret key",
-    "description" : "Provide a secret key of a user with permissions to invoke specified AWS Lambda function",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "feel" : "optional",
-    "group" : "provider",
-    "binding" : {
-      "name" : "provider.bedrock.authentication.secretKey",
-      "type" : "zeebe:input"
-    },
-    "condition" : {
-      "allMatch" : [ {
-        "property" : "provider.bedrock.authentication.type",
-        "equals" : "credentials",
-        "type" : "simple"
-      }, {
-        "property" : "provider.type",
-        "equals" : "bedrock",
         "type" : "simple"
       } ]
     },
@@ -593,77 +593,6 @@
     "tooltip" : "Integer greater than 0. Recommended for advanced use cases only (you usually only need to use temperature). <br><br>Details in the <a href=\"https://docs.anthropic.com/en/api/messages#body-top-k\" target=\"_blank\">documentation</a>.",
     "type" : "Number"
   }, {
-    "id" : "provider.azureOpenAi.model.deploymentName",
-    "label" : "Model deployment name",
-    "description" : "Specify the model deployment name. Details in the <a href=\"https://learn.microsoft.com/en-us/azure/ai-foundry/openai/reference\" target=\"_blank\">documentation</a>.",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "feel" : "optional",
-    "group" : "model",
-    "binding" : {
-      "name" : "provider.azureOpenAi.model.deploymentName",
-      "type" : "zeebe:input"
-    },
-    "condition" : {
-      "property" : "provider.type",
-      "equals" : "azureOpenAi",
-      "type" : "simple"
-    },
-    "type" : "String"
-  }, {
-    "id" : "provider.azureOpenAi.model.parameters.maxTokens",
-    "label" : "Maximum tokens",
-    "optional" : true,
-    "feel" : "required",
-    "group" : "model",
-    "binding" : {
-      "name" : "provider.azureOpenAi.model.parameters.maxTokens",
-      "type" : "zeebe:input"
-    },
-    "condition" : {
-      "property" : "provider.type",
-      "equals" : "azureOpenAi",
-      "type" : "simple"
-    },
-    "tooltip" : "The maximum number of tokens per request to generate before stopping. <br><br>Details in the <a href=\"https://learn.microsoft.com/en-us/azure/ai-foundry/openai/reference#request-body\" target=\"_blank\">documentation</a>.",
-    "type" : "Number"
-  }, {
-    "id" : "provider.azureOpenAi.model.parameters.temperature",
-    "label" : "Temperature",
-    "optional" : true,
-    "feel" : "required",
-    "group" : "model",
-    "binding" : {
-      "name" : "provider.azureOpenAi.model.parameters.temperature",
-      "type" : "zeebe:input"
-    },
-    "condition" : {
-      "property" : "provider.type",
-      "equals" : "azureOpenAi",
-      "type" : "simple"
-    },
-    "tooltip" : "Floating point number between 0 and 2. The higher the number, the more randomness will be injected into the response. <br><br>Details in the <a href=\"https://learn.microsoft.com/en-us/azure/ai-foundry/openai/reference#request-body\" target=\"_blank\">documentation</a>.",
-    "type" : "Number"
-  }, {
-    "id" : "provider.azureOpenAi.model.parameters.topP",
-    "label" : "top P",
-    "optional" : true,
-    "feel" : "required",
-    "group" : "model",
-    "binding" : {
-      "name" : "provider.azureOpenAi.model.parameters.topP",
-      "type" : "zeebe:input"
-    },
-    "condition" : {
-      "property" : "provider.type",
-      "equals" : "azureOpenAi",
-      "type" : "simple"
-    },
-    "tooltip" : "Recommended for advanced use cases only (you usually only need to use temperature). <br><br>Details in the <a href=\"https://learn.microsoft.com/en-us/azure/ai-foundry/openai/reference#request-body\" target=\"_blank\">documentation</a>.",
-    "type" : "Number"
-  }, {
     "id" : "provider.bedrock.model.model",
     "label" : "Model",
     "description" : "Specify the model ID. Details in the <a href=\"https://docs.aws.amazon.com/bedrock/latest/userguide/model-ids.html\" target=\"_blank\">documentation</a>.",
@@ -734,6 +663,77 @@
       "type" : "simple"
     },
     "tooltip" : "Floating point number between 0 and 1. Recommended for advanced use cases only (you usually only need to use temperature). <br><br>Details in the <a href=\"https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_InferenceConfiguration.html\" target=\"_blank\">documentation</a>.",
+    "type" : "Number"
+  }, {
+    "id" : "provider.azureOpenAi.model.deploymentName",
+    "label" : "Model deployment name",
+    "description" : "Specify the model deployment name. Details in the <a href=\"https://learn.microsoft.com/en-us/azure/ai-foundry/openai/reference\" target=\"_blank\">documentation</a>.",
+    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "model",
+    "binding" : {
+      "name" : "provider.azureOpenAi.model.deploymentName",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "provider.type",
+      "equals" : "azureOpenAi",
+      "type" : "simple"
+    },
+    "type" : "String"
+  }, {
+    "id" : "provider.azureOpenAi.model.parameters.maxTokens",
+    "label" : "Maximum tokens",
+    "optional" : true,
+    "feel" : "required",
+    "group" : "model",
+    "binding" : {
+      "name" : "provider.azureOpenAi.model.parameters.maxTokens",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "provider.type",
+      "equals" : "azureOpenAi",
+      "type" : "simple"
+    },
+    "tooltip" : "The maximum number of tokens per request to generate before stopping. <br><br>Details in the <a href=\"https://learn.microsoft.com/en-us/azure/ai-foundry/openai/reference#request-body\" target=\"_blank\">documentation</a>.",
+    "type" : "Number"
+  }, {
+    "id" : "provider.azureOpenAi.model.parameters.temperature",
+    "label" : "Temperature",
+    "optional" : true,
+    "feel" : "required",
+    "group" : "model",
+    "binding" : {
+      "name" : "provider.azureOpenAi.model.parameters.temperature",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "provider.type",
+      "equals" : "azureOpenAi",
+      "type" : "simple"
+    },
+    "tooltip" : "Floating point number between 0 and 2. The higher the number, the more randomness will be injected into the response. <br><br>Details in the <a href=\"https://learn.microsoft.com/en-us/azure/ai-foundry/openai/reference#request-body\" target=\"_blank\">documentation</a>.",
+    "type" : "Number"
+  }, {
+    "id" : "provider.azureOpenAi.model.parameters.topP",
+    "label" : "top P",
+    "optional" : true,
+    "feel" : "required",
+    "group" : "model",
+    "binding" : {
+      "name" : "provider.azureOpenAi.model.parameters.topP",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "provider.type",
+      "equals" : "azureOpenAi",
+      "type" : "simple"
+    },
+    "tooltip" : "Recommended for advanced use cases only (you usually only need to use temperature). <br><br>Details in the <a href=\"https://learn.microsoft.com/en-us/azure/ai-foundry/openai/reference#request-body\" target=\"_blank\">documentation</a>.",
     "type" : "Number"
   }, {
     "id" : "provider.openai.model.model",

--- a/connectors/agentic-ai/element-templates/agenticai-aiagent-outbound-connector.json
+++ b/connectors/agentic-ai/element-templates/agenticai-aiagent-outbound-connector.json
@@ -91,6 +91,9 @@
       "name" : "Anthropic",
       "value" : "anthropic"
     }, {
+      "name" : "Azure OpenAI",
+      "value" : "azureOpenAi"
+    }, {
       "name" : "AWS Bedrock",
       "value" : "bedrock"
     }, {
@@ -130,6 +133,175 @@
       "property" : "provider.type",
       "equals" : "anthropic",
       "type" : "simple"
+    },
+    "type" : "String"
+  }, {
+    "id" : "provider.azureOpenAi.endpoint",
+    "label" : "Endpoint",
+    "description" : "Specify Azure OpenAI endpoint. Details in the <a href=\"https://learn.microsoft.com/en-us/azure/ai-foundry/openai/reference\" target=\"_blank\">documentation</a>.",
+    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "provider",
+    "binding" : {
+      "name" : "provider.azureOpenAi.endpoint",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "provider.type",
+      "equals" : "azureOpenAi",
+      "type" : "simple"
+    },
+    "type" : "String"
+  }, {
+    "id" : "provider.azureOpenAi.authentication.type",
+    "label" : "Authentication",
+    "description" : "Specify the Azure OpenAI authentication strategy. Learn more at the <a href=\"https://docs.langchain4j.dev/integrations/language-models/azure-open-ai\" target=\"_blank\">documentation page</a>",
+    "value" : "apiKey",
+    "group" : "provider",
+    "binding" : {
+      "name" : "provider.azureOpenAi.authentication.type",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "provider.type",
+      "equals" : "azureOpenAi",
+      "type" : "simple"
+    },
+    "type" : "Dropdown",
+    "choices" : [ {
+      "name" : "API key",
+      "value" : "apiKey"
+    }, {
+      "name" : "Client credentials",
+      "value" : "clientCredentials"
+    } ]
+  }, {
+    "id" : "provider.azureOpenAi.authentication.apiKey",
+    "label" : "API key",
+    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "provider",
+    "binding" : {
+      "name" : "provider.azureOpenAi.authentication.apiKey",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "allMatch" : [ {
+        "property" : "provider.azureOpenAi.authentication.type",
+        "equals" : "apiKey",
+        "type" : "simple"
+      }, {
+        "property" : "provider.type",
+        "equals" : "azureOpenAi",
+        "type" : "simple"
+      } ]
+    },
+    "type" : "String"
+  }, {
+    "id" : "provider.azureOpenAi.authentication.clientId",
+    "label" : "Client ID",
+    "description" : "ID of a Microsoft Entra application",
+    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "provider",
+    "binding" : {
+      "name" : "provider.azureOpenAi.authentication.clientId",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "allMatch" : [ {
+        "property" : "provider.azureOpenAi.authentication.type",
+        "equals" : "clientCredentials",
+        "type" : "simple"
+      }, {
+        "property" : "provider.type",
+        "equals" : "azureOpenAi",
+        "type" : "simple"
+      } ]
+    },
+    "type" : "String"
+  }, {
+    "id" : "provider.azureOpenAi.authentication.clientSecret",
+    "label" : "Client secret",
+    "description" : "Secret of a Microsoft Entra application",
+    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "provider",
+    "binding" : {
+      "name" : "provider.azureOpenAi.authentication.clientSecret",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "allMatch" : [ {
+        "property" : "provider.azureOpenAi.authentication.type",
+        "equals" : "clientCredentials",
+        "type" : "simple"
+      }, {
+        "property" : "provider.type",
+        "equals" : "azureOpenAi",
+        "type" : "simple"
+      } ]
+    },
+    "type" : "String"
+  }, {
+    "id" : "provider.azureOpenAi.authentication.tenantId",
+    "label" : "Tenant ID",
+    "description" : "ID of a Microsoft Entra tenant. Details in the <a href=\"https://learn.microsoft.com/en-us/entra/fundamentals/how-to-find-tenant\" target=\"_blank\">documentation</a>.",
+    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "provider",
+    "binding" : {
+      "name" : "provider.azureOpenAi.authentication.tenantId",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "allMatch" : [ {
+        "property" : "provider.azureOpenAi.authentication.type",
+        "equals" : "clientCredentials",
+        "type" : "simple"
+      }, {
+        "property" : "provider.type",
+        "equals" : "azureOpenAi",
+        "type" : "simple"
+      } ]
+    },
+    "type" : "String"
+  }, {
+    "id" : "provider.azureOpenAi.authentication.authorityHost",
+    "label" : "Authority host",
+    "description" : "Authority host URL for the Microsoft Entra application. Defaults to <code>https://login.microsoftonline.com</code>. This can also contain an OAuth 2.0 token endpoint.",
+    "optional" : true,
+    "feel" : "optional",
+    "group" : "provider",
+    "binding" : {
+      "name" : "provider.azureOpenAi.authentication.authorityHost",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "allMatch" : [ {
+        "property" : "provider.azureOpenAi.authentication.type",
+        "equals" : "clientCredentials",
+        "type" : "simple"
+      }, {
+        "property" : "provider.type",
+        "equals" : "azureOpenAi",
+        "type" : "simple"
+      } ]
     },
     "type" : "String"
   }, {
@@ -185,11 +357,11 @@
     },
     "type" : "Dropdown",
     "choices" : [ {
-      "name" : "Default Credentials Chain (Hybrid/Self-Managed only)",
-      "value" : "defaultCredentialsChain"
-    }, {
       "name" : "Credentials",
       "value" : "credentials"
+    }, {
+      "name" : "Default Credentials Chain (Hybrid/Self-Managed only)",
+      "value" : "defaultCredentialsChain"
     } ]
   }, {
     "id" : "provider.bedrock.authentication.accessKey",
@@ -421,6 +593,77 @@
     "tooltip" : "Integer greater than 0. Recommended for advanced use cases only (you usually only need to use temperature). <br><br>Details in the <a href=\"https://docs.anthropic.com/en/api/messages#body-top-k\" target=\"_blank\">documentation</a>.",
     "type" : "Number"
   }, {
+    "id" : "provider.azureOpenAi.model.deploymentName",
+    "label" : "Model deployment name",
+    "description" : "Specify the model deployment name. Details in the <a href=\"https://learn.microsoft.com/en-us/azure/ai-foundry/openai/reference\" target=\"_blank\">documentation</a>.",
+    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "model",
+    "binding" : {
+      "name" : "provider.azureOpenAi.model.deploymentName",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "provider.type",
+      "equals" : "azureOpenAi",
+      "type" : "simple"
+    },
+    "type" : "String"
+  }, {
+    "id" : "provider.azureOpenAi.model.parameters.maxTokens",
+    "label" : "Maximum tokens",
+    "optional" : true,
+    "feel" : "required",
+    "group" : "model",
+    "binding" : {
+      "name" : "provider.azureOpenAi.model.parameters.maxTokens",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "provider.type",
+      "equals" : "azureOpenAi",
+      "type" : "simple"
+    },
+    "tooltip" : "The maximum number of tokens per request to generate before stopping. <br><br>Details in the <a href=\"https://learn.microsoft.com/en-us/azure/ai-foundry/openai/reference#request-body\" target=\"_blank\">documentation</a>.",
+    "type" : "Number"
+  }, {
+    "id" : "provider.azureOpenAi.model.parameters.temperature",
+    "label" : "Temperature",
+    "optional" : true,
+    "feel" : "required",
+    "group" : "model",
+    "binding" : {
+      "name" : "provider.azureOpenAi.model.parameters.temperature",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "provider.type",
+      "equals" : "azureOpenAi",
+      "type" : "simple"
+    },
+    "tooltip" : "Floating point number between 0 and 2. The higher the number, the more randomness will be injected into the response. <br><br>Details in the <a href=\"https://learn.microsoft.com/en-us/azure/ai-foundry/openai/reference#request-body\" target=\"_blank\">documentation</a>.",
+    "type" : "Number"
+  }, {
+    "id" : "provider.azureOpenAi.model.parameters.topP",
+    "label" : "top P",
+    "optional" : true,
+    "feel" : "required",
+    "group" : "model",
+    "binding" : {
+      "name" : "provider.azureOpenAi.model.parameters.topP",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "provider.type",
+      "equals" : "azureOpenAi",
+      "type" : "simple"
+    },
+    "tooltip" : "Recommended for advanced use cases only (you usually only need to use temperature). <br><br>Details in the <a href=\"https://learn.microsoft.com/en-us/azure/ai-foundry/openai/reference#request-body\" target=\"_blank\">documentation</a>.",
+    "type" : "Number"
+  }, {
     "id" : "provider.bedrock.model.model",
     "label" : "Model",
     "description" : "Specify the model ID. Details in the <a href=\"https://docs.aws.amazon.com/bedrock/latest/userguide/model-ids.html\" target=\"_blank\">documentation</a>.",
@@ -568,7 +811,7 @@
     "id" : "data.systemPrompt.prompt",
     "label" : "System prompt",
     "optional" : false,
-    "value" : "You are **TaskAgent**, a helpful, generic chat agent that can handle a wide variety of customer requests using your own domain knowledge **and** any tools explicitly provided to you at runtime.\n\nIf tools are provided, you should prefer them instead of guessing an answer. You can call the same tool multiple times by providing different input values. Don't guess any tools which were not explicitely configured. If no tool matches the request, try to generate an answer. If you're not able to find a good answer, return with a message stating why you're not able to.\n\nWrap minimal, inspectable reasoning in *exactly* this XML template:\n\n<thinking>\n  <context>…briefly state the customer’s need and current state…</context>\n  <reflection>…list candidate tools, justify which you will call next and why…</reflection>\n</thinking>\n\nReveal **no** additional private reasoning outside these tags.\n",
+    "value" : "You are **TaskAgent**, a helpful, generic chat agent that can handle a wide variety of customer requests using your own domain knowledge **and** any tools explicitly provided to you at runtime.\n\nIf tools are provided, you should prefer them instead of guessing an answer. You can call the same tool multiple times by providing different input values. Don't guess any tools which were not explicitly configured. If no tool matches the request, try to generate an answer. If you're not able to find a good answer, return with a message stating why you're not able to.\n\nWrap minimal, inspectable reasoning in *exactly* this XML template:\n\n<thinking>\n  <context>…briefly state the customer’s need and current state…</context>\n  <reflection>…list candidate tools, justify which you will call next and why…</reflection>\n</thinking>\n\nReveal **no** additional private reasoning outside these tags.\n",
     "constraints" : {
       "notEmpty" : true
     },

--- a/connectors/agentic-ai/element-templates/hybrid/agenticai-aiagent-outbound-connector-hybrid.json
+++ b/connectors/agentic-ai/element-templates/hybrid/agenticai-aiagent-outbound-connector-hybrid.json
@@ -96,6 +96,9 @@
       "name" : "Anthropic",
       "value" : "anthropic"
     }, {
+      "name" : "Azure OpenAI",
+      "value" : "azureOpenAi"
+    }, {
       "name" : "AWS Bedrock",
       "value" : "bedrock"
     }, {
@@ -135,6 +138,175 @@
       "property" : "provider.type",
       "equals" : "anthropic",
       "type" : "simple"
+    },
+    "type" : "String"
+  }, {
+    "id" : "provider.azureOpenAi.endpoint",
+    "label" : "Endpoint",
+    "description" : "Specify Azure OpenAI endpoint. Details in the <a href=\"https://learn.microsoft.com/en-us/azure/ai-foundry/openai/reference\" target=\"_blank\">documentation</a>.",
+    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "provider",
+    "binding" : {
+      "name" : "provider.azureOpenAi.endpoint",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "provider.type",
+      "equals" : "azureOpenAi",
+      "type" : "simple"
+    },
+    "type" : "String"
+  }, {
+    "id" : "provider.azureOpenAi.authentication.type",
+    "label" : "Authentication",
+    "description" : "Specify the Azure OpenAI authentication strategy. Learn more at the <a href=\"https://docs.langchain4j.dev/integrations/language-models/azure-open-ai\" target=\"_blank\">documentation page</a>",
+    "value" : "apiKey",
+    "group" : "provider",
+    "binding" : {
+      "name" : "provider.azureOpenAi.authentication.type",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "provider.type",
+      "equals" : "azureOpenAi",
+      "type" : "simple"
+    },
+    "type" : "Dropdown",
+    "choices" : [ {
+      "name" : "API key",
+      "value" : "apiKey"
+    }, {
+      "name" : "Client credentials",
+      "value" : "clientCredentials"
+    } ]
+  }, {
+    "id" : "provider.azureOpenAi.authentication.apiKey",
+    "label" : "API key",
+    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "provider",
+    "binding" : {
+      "name" : "provider.azureOpenAi.authentication.apiKey",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "allMatch" : [ {
+        "property" : "provider.azureOpenAi.authentication.type",
+        "equals" : "apiKey",
+        "type" : "simple"
+      }, {
+        "property" : "provider.type",
+        "equals" : "azureOpenAi",
+        "type" : "simple"
+      } ]
+    },
+    "type" : "String"
+  }, {
+    "id" : "provider.azureOpenAi.authentication.clientId",
+    "label" : "Client ID",
+    "description" : "ID of a Microsoft Entra application",
+    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "provider",
+    "binding" : {
+      "name" : "provider.azureOpenAi.authentication.clientId",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "allMatch" : [ {
+        "property" : "provider.azureOpenAi.authentication.type",
+        "equals" : "clientCredentials",
+        "type" : "simple"
+      }, {
+        "property" : "provider.type",
+        "equals" : "azureOpenAi",
+        "type" : "simple"
+      } ]
+    },
+    "type" : "String"
+  }, {
+    "id" : "provider.azureOpenAi.authentication.clientSecret",
+    "label" : "Client secret",
+    "description" : "Secret of a Microsoft Entra application",
+    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "provider",
+    "binding" : {
+      "name" : "provider.azureOpenAi.authentication.clientSecret",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "allMatch" : [ {
+        "property" : "provider.azureOpenAi.authentication.type",
+        "equals" : "clientCredentials",
+        "type" : "simple"
+      }, {
+        "property" : "provider.type",
+        "equals" : "azureOpenAi",
+        "type" : "simple"
+      } ]
+    },
+    "type" : "String"
+  }, {
+    "id" : "provider.azureOpenAi.authentication.tenantId",
+    "label" : "Tenant ID",
+    "description" : "ID of a Microsoft Entra tenant. Details in the <a href=\"https://learn.microsoft.com/en-us/entra/fundamentals/how-to-find-tenant\" target=\"_blank\">documentation</a>.",
+    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "provider",
+    "binding" : {
+      "name" : "provider.azureOpenAi.authentication.tenantId",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "allMatch" : [ {
+        "property" : "provider.azureOpenAi.authentication.type",
+        "equals" : "clientCredentials",
+        "type" : "simple"
+      }, {
+        "property" : "provider.type",
+        "equals" : "azureOpenAi",
+        "type" : "simple"
+      } ]
+    },
+    "type" : "String"
+  }, {
+    "id" : "provider.azureOpenAi.authentication.authorityHost",
+    "label" : "Authority host",
+    "description" : "Authority host URL for the Microsoft Entra application. Defaults to <code>https://login.microsoftonline.com</code>. This can also contain an OAuth 2.0 token endpoint.",
+    "optional" : true,
+    "feel" : "optional",
+    "group" : "provider",
+    "binding" : {
+      "name" : "provider.azureOpenAi.authentication.authorityHost",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "allMatch" : [ {
+        "property" : "provider.azureOpenAi.authentication.type",
+        "equals" : "clientCredentials",
+        "type" : "simple"
+      }, {
+        "property" : "provider.type",
+        "equals" : "azureOpenAi",
+        "type" : "simple"
+      } ]
     },
     "type" : "String"
   }, {
@@ -190,11 +362,11 @@
     },
     "type" : "Dropdown",
     "choices" : [ {
-      "name" : "Default Credentials Chain (Hybrid/Self-Managed only)",
-      "value" : "defaultCredentialsChain"
-    }, {
       "name" : "Credentials",
       "value" : "credentials"
+    }, {
+      "name" : "Default Credentials Chain (Hybrid/Self-Managed only)",
+      "value" : "defaultCredentialsChain"
     } ]
   }, {
     "id" : "provider.bedrock.authentication.accessKey",
@@ -426,6 +598,77 @@
     "tooltip" : "Integer greater than 0. Recommended for advanced use cases only (you usually only need to use temperature). <br><br>Details in the <a href=\"https://docs.anthropic.com/en/api/messages#body-top-k\" target=\"_blank\">documentation</a>.",
     "type" : "Number"
   }, {
+    "id" : "provider.azureOpenAi.model.deploymentName",
+    "label" : "Model deployment name",
+    "description" : "Specify the model deployment name. Details in the <a href=\"https://learn.microsoft.com/en-us/azure/ai-foundry/openai/reference\" target=\"_blank\">documentation</a>.",
+    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "model",
+    "binding" : {
+      "name" : "provider.azureOpenAi.model.deploymentName",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "provider.type",
+      "equals" : "azureOpenAi",
+      "type" : "simple"
+    },
+    "type" : "String"
+  }, {
+    "id" : "provider.azureOpenAi.model.parameters.maxTokens",
+    "label" : "Maximum tokens",
+    "optional" : true,
+    "feel" : "required",
+    "group" : "model",
+    "binding" : {
+      "name" : "provider.azureOpenAi.model.parameters.maxTokens",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "provider.type",
+      "equals" : "azureOpenAi",
+      "type" : "simple"
+    },
+    "tooltip" : "The maximum number of tokens per request to generate before stopping. <br><br>Details in the <a href=\"https://learn.microsoft.com/en-us/azure/ai-foundry/openai/reference#request-body\" target=\"_blank\">documentation</a>.",
+    "type" : "Number"
+  }, {
+    "id" : "provider.azureOpenAi.model.parameters.temperature",
+    "label" : "Temperature",
+    "optional" : true,
+    "feel" : "required",
+    "group" : "model",
+    "binding" : {
+      "name" : "provider.azureOpenAi.model.parameters.temperature",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "provider.type",
+      "equals" : "azureOpenAi",
+      "type" : "simple"
+    },
+    "tooltip" : "Floating point number between 0 and 2. The higher the number, the more randomness will be injected into the response. <br><br>Details in the <a href=\"https://learn.microsoft.com/en-us/azure/ai-foundry/openai/reference#request-body\" target=\"_blank\">documentation</a>.",
+    "type" : "Number"
+  }, {
+    "id" : "provider.azureOpenAi.model.parameters.topP",
+    "label" : "top P",
+    "optional" : true,
+    "feel" : "required",
+    "group" : "model",
+    "binding" : {
+      "name" : "provider.azureOpenAi.model.parameters.topP",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "provider.type",
+      "equals" : "azureOpenAi",
+      "type" : "simple"
+    },
+    "tooltip" : "Recommended for advanced use cases only (you usually only need to use temperature). <br><br>Details in the <a href=\"https://learn.microsoft.com/en-us/azure/ai-foundry/openai/reference#request-body\" target=\"_blank\">documentation</a>.",
+    "type" : "Number"
+  }, {
     "id" : "provider.bedrock.model.model",
     "label" : "Model",
     "description" : "Specify the model ID. Details in the <a href=\"https://docs.aws.amazon.com/bedrock/latest/userguide/model-ids.html\" target=\"_blank\">documentation</a>.",
@@ -573,7 +816,7 @@
     "id" : "data.systemPrompt.prompt",
     "label" : "System prompt",
     "optional" : false,
-    "value" : "You are **TaskAgent**, a helpful, generic chat agent that can handle a wide variety of customer requests using your own domain knowledge **and** any tools explicitly provided to you at runtime.\n\nIf tools are provided, you should prefer them instead of guessing an answer. You can call the same tool multiple times by providing different input values. Don't guess any tools which were not explicitely configured. If no tool matches the request, try to generate an answer. If you're not able to find a good answer, return with a message stating why you're not able to.\n\nWrap minimal, inspectable reasoning in *exactly* this XML template:\n\n<thinking>\n  <context>…briefly state the customer’s need and current state…</context>\n  <reflection>…list candidate tools, justify which you will call next and why…</reflection>\n</thinking>\n\nReveal **no** additional private reasoning outside these tags.\n",
+    "value" : "You are **TaskAgent**, a helpful, generic chat agent that can handle a wide variety of customer requests using your own domain knowledge **and** any tools explicitly provided to you at runtime.\n\nIf tools are provided, you should prefer them instead of guessing an answer. You can call the same tool multiple times by providing different input values. Don't guess any tools which were not explicitly configured. If no tool matches the request, try to generate an answer. If you're not able to find a good answer, return with a message stating why you're not able to.\n\nWrap minimal, inspectable reasoning in *exactly* this XML template:\n\n<thinking>\n  <context>…briefly state the customer’s need and current state…</context>\n  <reflection>…list candidate tools, justify which you will call next and why…</reflection>\n</thinking>\n\nReveal **no** additional private reasoning outside these tags.\n",
     "constraints" : {
       "notEmpty" : true
     },

--- a/connectors/agentic-ai/element-templates/hybrid/agenticai-aiagent-outbound-connector-hybrid.json
+++ b/connectors/agentic-ai/element-templates/hybrid/agenticai-aiagent-outbound-connector-hybrid.json
@@ -96,11 +96,11 @@
       "name" : "Anthropic",
       "value" : "anthropic"
     }, {
-      "name" : "Azure OpenAI",
-      "value" : "azureOpenAi"
-    }, {
       "name" : "AWS Bedrock",
       "value" : "bedrock"
+    }, {
+      "name" : "Azure OpenAI",
+      "value" : "azureOpenAi"
     }, {
       "name" : "OpenAI",
       "value" : "openai"
@@ -141,6 +141,117 @@
     },
     "type" : "String"
   }, {
+    "id" : "provider.bedrock.region",
+    "label" : "Region",
+    "description" : "Specify the AWS region (example: <code>eu-west-1</code>)",
+    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "provider",
+    "binding" : {
+      "name" : "provider.bedrock.region",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "provider.type",
+      "equals" : "bedrock",
+      "type" : "simple"
+    },
+    "type" : "String"
+  }, {
+    "id" : "provider.bedrock.endpoint",
+    "label" : "Endpoint",
+    "description" : "Specify endpoint if need to use a custom API endpoint",
+    "optional" : true,
+    "group" : "provider",
+    "binding" : {
+      "name" : "provider.bedrock.endpoint",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "provider.type",
+      "equals" : "bedrock",
+      "type" : "simple"
+    },
+    "type" : "Hidden"
+  }, {
+    "id" : "provider.bedrock.authentication.type",
+    "label" : "Authentication",
+    "description" : "Specify the AWS authentication strategy. Learn more at the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-bedrock/#authentication\" target=\"_blank\">documentation page</a>",
+    "value" : "credentials",
+    "group" : "provider",
+    "binding" : {
+      "name" : "provider.bedrock.authentication.type",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "provider.type",
+      "equals" : "bedrock",
+      "type" : "simple"
+    },
+    "type" : "Dropdown",
+    "choices" : [ {
+      "name" : "Credentials",
+      "value" : "credentials"
+    }, {
+      "name" : "Default Credentials Chain (Hybrid/Self-Managed only)",
+      "value" : "defaultCredentialsChain"
+    } ]
+  }, {
+    "id" : "provider.bedrock.authentication.accessKey",
+    "label" : "Access key",
+    "description" : "Provide an IAM access key tailored to a user, equipped with the necessary permissions",
+    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "provider",
+    "binding" : {
+      "name" : "provider.bedrock.authentication.accessKey",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "allMatch" : [ {
+        "property" : "provider.bedrock.authentication.type",
+        "equals" : "credentials",
+        "type" : "simple"
+      }, {
+        "property" : "provider.type",
+        "equals" : "bedrock",
+        "type" : "simple"
+      } ]
+    },
+    "type" : "String"
+  }, {
+    "id" : "provider.bedrock.authentication.secretKey",
+    "label" : "Secret key",
+    "description" : "Provide a secret key of a user with permissions to invoke specified AWS Lambda function",
+    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "provider",
+    "binding" : {
+      "name" : "provider.bedrock.authentication.secretKey",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "allMatch" : [ {
+        "property" : "provider.bedrock.authentication.type",
+        "equals" : "credentials",
+        "type" : "simple"
+      }, {
+        "property" : "provider.type",
+        "equals" : "bedrock",
+        "type" : "simple"
+      } ]
+    },
+    "type" : "String"
+  }, {
     "id" : "provider.azureOpenAi.endpoint",
     "label" : "Endpoint",
     "description" : "Specify Azure OpenAI endpoint. Details in the <a href=\"https://learn.microsoft.com/en-us/azure/ai-foundry/openai/reference\" target=\"_blank\">documentation</a>.",
@@ -163,7 +274,7 @@
   }, {
     "id" : "provider.azureOpenAi.authentication.type",
     "label" : "Authentication",
-    "description" : "Specify the Azure OpenAI authentication strategy. Learn more at the <a href=\"https://docs.langchain4j.dev/integrations/language-models/azure-open-ai\" target=\"_blank\">documentation page</a>",
+    "description" : "Specify the Azure OpenAI authentication strategy.",
     "value" : "apiKey",
     "group" : "provider",
     "binding" : {
@@ -305,117 +416,6 @@
       }, {
         "property" : "provider.type",
         "equals" : "azureOpenAi",
-        "type" : "simple"
-      } ]
-    },
-    "type" : "String"
-  }, {
-    "id" : "provider.bedrock.region",
-    "label" : "Region",
-    "description" : "Specify the AWS region (example: <code>eu-west-1</code>)",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "feel" : "optional",
-    "group" : "provider",
-    "binding" : {
-      "name" : "provider.bedrock.region",
-      "type" : "zeebe:input"
-    },
-    "condition" : {
-      "property" : "provider.type",
-      "equals" : "bedrock",
-      "type" : "simple"
-    },
-    "type" : "String"
-  }, {
-    "id" : "provider.bedrock.endpoint",
-    "label" : "Endpoint",
-    "description" : "Specify endpoint if need to use a custom API endpoint",
-    "optional" : true,
-    "group" : "provider",
-    "binding" : {
-      "name" : "provider.bedrock.endpoint",
-      "type" : "zeebe:input"
-    },
-    "condition" : {
-      "property" : "provider.type",
-      "equals" : "bedrock",
-      "type" : "simple"
-    },
-    "type" : "Hidden"
-  }, {
-    "id" : "provider.bedrock.authentication.type",
-    "label" : "Authentication",
-    "description" : "Specify the AWS authentication strategy. Learn more at the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-bedrock/#authentication\" target=\"_blank\">documentation page</a>",
-    "value" : "credentials",
-    "group" : "provider",
-    "binding" : {
-      "name" : "provider.bedrock.authentication.type",
-      "type" : "zeebe:input"
-    },
-    "condition" : {
-      "property" : "provider.type",
-      "equals" : "bedrock",
-      "type" : "simple"
-    },
-    "type" : "Dropdown",
-    "choices" : [ {
-      "name" : "Credentials",
-      "value" : "credentials"
-    }, {
-      "name" : "Default Credentials Chain (Hybrid/Self-Managed only)",
-      "value" : "defaultCredentialsChain"
-    } ]
-  }, {
-    "id" : "provider.bedrock.authentication.accessKey",
-    "label" : "Access key",
-    "description" : "Provide an IAM access key tailored to a user, equipped with the necessary permissions",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "feel" : "optional",
-    "group" : "provider",
-    "binding" : {
-      "name" : "provider.bedrock.authentication.accessKey",
-      "type" : "zeebe:input"
-    },
-    "condition" : {
-      "allMatch" : [ {
-        "property" : "provider.bedrock.authentication.type",
-        "equals" : "credentials",
-        "type" : "simple"
-      }, {
-        "property" : "provider.type",
-        "equals" : "bedrock",
-        "type" : "simple"
-      } ]
-    },
-    "type" : "String"
-  }, {
-    "id" : "provider.bedrock.authentication.secretKey",
-    "label" : "Secret key",
-    "description" : "Provide a secret key of a user with permissions to invoke specified AWS Lambda function",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "feel" : "optional",
-    "group" : "provider",
-    "binding" : {
-      "name" : "provider.bedrock.authentication.secretKey",
-      "type" : "zeebe:input"
-    },
-    "condition" : {
-      "allMatch" : [ {
-        "property" : "provider.bedrock.authentication.type",
-        "equals" : "credentials",
-        "type" : "simple"
-      }, {
-        "property" : "provider.type",
-        "equals" : "bedrock",
         "type" : "simple"
       } ]
     },
@@ -598,77 +598,6 @@
     "tooltip" : "Integer greater than 0. Recommended for advanced use cases only (you usually only need to use temperature). <br><br>Details in the <a href=\"https://docs.anthropic.com/en/api/messages#body-top-k\" target=\"_blank\">documentation</a>.",
     "type" : "Number"
   }, {
-    "id" : "provider.azureOpenAi.model.deploymentName",
-    "label" : "Model deployment name",
-    "description" : "Specify the model deployment name. Details in the <a href=\"https://learn.microsoft.com/en-us/azure/ai-foundry/openai/reference\" target=\"_blank\">documentation</a>.",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "feel" : "optional",
-    "group" : "model",
-    "binding" : {
-      "name" : "provider.azureOpenAi.model.deploymentName",
-      "type" : "zeebe:input"
-    },
-    "condition" : {
-      "property" : "provider.type",
-      "equals" : "azureOpenAi",
-      "type" : "simple"
-    },
-    "type" : "String"
-  }, {
-    "id" : "provider.azureOpenAi.model.parameters.maxTokens",
-    "label" : "Maximum tokens",
-    "optional" : true,
-    "feel" : "required",
-    "group" : "model",
-    "binding" : {
-      "name" : "provider.azureOpenAi.model.parameters.maxTokens",
-      "type" : "zeebe:input"
-    },
-    "condition" : {
-      "property" : "provider.type",
-      "equals" : "azureOpenAi",
-      "type" : "simple"
-    },
-    "tooltip" : "The maximum number of tokens per request to generate before stopping. <br><br>Details in the <a href=\"https://learn.microsoft.com/en-us/azure/ai-foundry/openai/reference#request-body\" target=\"_blank\">documentation</a>.",
-    "type" : "Number"
-  }, {
-    "id" : "provider.azureOpenAi.model.parameters.temperature",
-    "label" : "Temperature",
-    "optional" : true,
-    "feel" : "required",
-    "group" : "model",
-    "binding" : {
-      "name" : "provider.azureOpenAi.model.parameters.temperature",
-      "type" : "zeebe:input"
-    },
-    "condition" : {
-      "property" : "provider.type",
-      "equals" : "azureOpenAi",
-      "type" : "simple"
-    },
-    "tooltip" : "Floating point number between 0 and 2. The higher the number, the more randomness will be injected into the response. <br><br>Details in the <a href=\"https://learn.microsoft.com/en-us/azure/ai-foundry/openai/reference#request-body\" target=\"_blank\">documentation</a>.",
-    "type" : "Number"
-  }, {
-    "id" : "provider.azureOpenAi.model.parameters.topP",
-    "label" : "top P",
-    "optional" : true,
-    "feel" : "required",
-    "group" : "model",
-    "binding" : {
-      "name" : "provider.azureOpenAi.model.parameters.topP",
-      "type" : "zeebe:input"
-    },
-    "condition" : {
-      "property" : "provider.type",
-      "equals" : "azureOpenAi",
-      "type" : "simple"
-    },
-    "tooltip" : "Recommended for advanced use cases only (you usually only need to use temperature). <br><br>Details in the <a href=\"https://learn.microsoft.com/en-us/azure/ai-foundry/openai/reference#request-body\" target=\"_blank\">documentation</a>.",
-    "type" : "Number"
-  }, {
     "id" : "provider.bedrock.model.model",
     "label" : "Model",
     "description" : "Specify the model ID. Details in the <a href=\"https://docs.aws.amazon.com/bedrock/latest/userguide/model-ids.html\" target=\"_blank\">documentation</a>.",
@@ -739,6 +668,77 @@
       "type" : "simple"
     },
     "tooltip" : "Floating point number between 0 and 1. Recommended for advanced use cases only (you usually only need to use temperature). <br><br>Details in the <a href=\"https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_InferenceConfiguration.html\" target=\"_blank\">documentation</a>.",
+    "type" : "Number"
+  }, {
+    "id" : "provider.azureOpenAi.model.deploymentName",
+    "label" : "Model deployment name",
+    "description" : "Specify the model deployment name. Details in the <a href=\"https://learn.microsoft.com/en-us/azure/ai-foundry/openai/reference\" target=\"_blank\">documentation</a>.",
+    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "model",
+    "binding" : {
+      "name" : "provider.azureOpenAi.model.deploymentName",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "provider.type",
+      "equals" : "azureOpenAi",
+      "type" : "simple"
+    },
+    "type" : "String"
+  }, {
+    "id" : "provider.azureOpenAi.model.parameters.maxTokens",
+    "label" : "Maximum tokens",
+    "optional" : true,
+    "feel" : "required",
+    "group" : "model",
+    "binding" : {
+      "name" : "provider.azureOpenAi.model.parameters.maxTokens",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "provider.type",
+      "equals" : "azureOpenAi",
+      "type" : "simple"
+    },
+    "tooltip" : "The maximum number of tokens per request to generate before stopping. <br><br>Details in the <a href=\"https://learn.microsoft.com/en-us/azure/ai-foundry/openai/reference#request-body\" target=\"_blank\">documentation</a>.",
+    "type" : "Number"
+  }, {
+    "id" : "provider.azureOpenAi.model.parameters.temperature",
+    "label" : "Temperature",
+    "optional" : true,
+    "feel" : "required",
+    "group" : "model",
+    "binding" : {
+      "name" : "provider.azureOpenAi.model.parameters.temperature",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "provider.type",
+      "equals" : "azureOpenAi",
+      "type" : "simple"
+    },
+    "tooltip" : "Floating point number between 0 and 2. The higher the number, the more randomness will be injected into the response. <br><br>Details in the <a href=\"https://learn.microsoft.com/en-us/azure/ai-foundry/openai/reference#request-body\" target=\"_blank\">documentation</a>.",
+    "type" : "Number"
+  }, {
+    "id" : "provider.azureOpenAi.model.parameters.topP",
+    "label" : "top P",
+    "optional" : true,
+    "feel" : "required",
+    "group" : "model",
+    "binding" : {
+      "name" : "provider.azureOpenAi.model.parameters.topP",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "provider.type",
+      "equals" : "azureOpenAi",
+      "type" : "simple"
+    },
+    "tooltip" : "Recommended for advanced use cases only (you usually only need to use temperature). <br><br>Details in the <a href=\"https://learn.microsoft.com/en-us/azure/ai-foundry/openai/reference#request-body\" target=\"_blank\">documentation</a>.",
     "type" : "Number"
   }, {
     "id" : "provider.openai.model.model",

--- a/connectors/agentic-ai/pom.xml
+++ b/connectors/agentic-ai/pom.xml
@@ -70,11 +70,27 @@
     </dependency>
     <dependency>
       <groupId>dev.langchain4j</groupId>
+      <artifactId>langchain4j-azure-open-ai</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>dev.langchain4j</groupId>
       <artifactId>langchain4j-bedrock</artifactId>
     </dependency>
     <dependency>
       <groupId>dev.langchain4j</groupId>
       <artifactId>langchain4j-open-ai</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.azure</groupId>
+      <artifactId>azure-identity</artifactId>
+      <scope>compile</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-resolver-dns-native-macos</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/ChatModelFactoryImpl.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/ChatModelFactoryImpl.java
@@ -6,7 +6,9 @@
  */
 package io.camunda.connector.agenticai.aiagent.framework.langchain4j;
 
+import com.azure.identity.ClientSecretCredentialBuilder;
 import dev.langchain4j.model.anthropic.AnthropicChatModel;
+import dev.langchain4j.model.azure.AzureOpenAiChatModel;
 import dev.langchain4j.model.bedrock.BedrockChatModel;
 import dev.langchain4j.model.bedrock.BedrockChatRequestParameters;
 import dev.langchain4j.model.chat.ChatModel;
@@ -14,12 +16,15 @@ import dev.langchain4j.model.openai.OpenAiChatModel;
 import dev.langchain4j.model.openai.OpenAiChatRequestParameters;
 import io.camunda.connector.agenticai.aiagent.model.request.ProviderConfiguration;
 import io.camunda.connector.agenticai.aiagent.model.request.ProviderConfiguration.AnthropicProviderConfiguration;
+import io.camunda.connector.agenticai.aiagent.model.request.ProviderConfiguration.AzureOpenAiProviderConfiguration.AzureAuthentication.AzureApiKeyAuthentication;
+import io.camunda.connector.agenticai.aiagent.model.request.ProviderConfiguration.AzureOpenAiProviderConfiguration.AzureAuthentication.AzureClientCredentialsAuthentication;
 import io.camunda.connector.agenticai.aiagent.model.request.ProviderConfiguration.BedrockProviderConfiguration;
 import io.camunda.connector.agenticai.aiagent.model.request.ProviderConfiguration.BedrockProviderConfiguration.AwsAuthentication.AwsDefaultCredentialsChainAuthentication;
 import io.camunda.connector.agenticai.aiagent.model.request.ProviderConfiguration.BedrockProviderConfiguration.AwsAuthentication.AwsStaticCredentialsAuthentication;
 import io.camunda.connector.agenticai.aiagent.model.request.ProviderConfiguration.OpenAiProviderConfiguration;
 import java.net.URI;
 import java.util.Optional;
+import org.apache.commons.lang3.StringUtils;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
@@ -33,6 +38,8 @@ public class ChatModelFactoryImpl implements ChatModelFactory {
     return switch (providerConfiguration) {
       case AnthropicProviderConfiguration anthropic ->
           createAnthropicChatModelBuilder(anthropic).build();
+      case ProviderConfiguration.AzureOpenAiProviderConfiguration azureOpenAi ->
+          createAzureOpenAiChatModelBuilder(azureOpenAi).build();
       case BedrockProviderConfiguration bedrock -> createBedrockChatModelBuilder(bedrock).build();
       case OpenAiProviderConfiguration openai -> createOpenaiChatModelBuilder(openai).build();
     };
@@ -57,6 +64,40 @@ public class ChatModelFactoryImpl implements ChatModelFactory {
       Optional.ofNullable(modelParameters.temperature()).ifPresent(builder::temperature);
       Optional.ofNullable(modelParameters.topP()).ifPresent(builder::topP);
       Optional.ofNullable(modelParameters.topK()).ifPresent(builder::topK);
+    }
+
+    return builder;
+  }
+
+  protected AzureOpenAiChatModel.Builder createAzureOpenAiChatModelBuilder(
+      ProviderConfiguration.AzureOpenAiProviderConfiguration configuration) {
+    final var connection = configuration.azureOpenAi();
+    final var builder =
+        AzureOpenAiChatModel.builder()
+            .endpoint(connection.endpoint())
+            .deploymentName(configuration.azureOpenAi().model().deploymentName());
+
+    switch (connection.authentication()) {
+      case AzureApiKeyAuthentication azureApiKeyAuthentication ->
+          builder.apiKey(azureApiKeyAuthentication.apiKey());
+      case AzureClientCredentialsAuthentication auth -> {
+        ClientSecretCredentialBuilder clientSecretCredentialBuilder =
+            new ClientSecretCredentialBuilder()
+                .clientId(auth.clientId())
+                .clientSecret(auth.clientSecret())
+                .tenantId(auth.tenantId());
+        if (StringUtils.isNotBlank(auth.authorityHost())) {
+          clientSecretCredentialBuilder.authorityHost(auth.authorityHost());
+        }
+        builder.tokenCredential(clientSecretCredentialBuilder.build());
+      }
+    }
+
+    final var modelParameters = connection.model().parameters();
+    if (modelParameters != null) {
+      Optional.ofNullable(modelParameters.maxTokens()).ifPresent(builder::maxTokens);
+      Optional.ofNullable(modelParameters.temperature()).ifPresent(builder::temperature);
+      Optional.ofNullable(modelParameters.topP()).ifPresent(builder::topP);
     }
 
     return builder;

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/ChatModelFactoryImpl.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/ChatModelFactoryImpl.java
@@ -16,6 +16,7 @@ import dev.langchain4j.model.openai.OpenAiChatModel;
 import dev.langchain4j.model.openai.OpenAiChatRequestParameters;
 import io.camunda.connector.agenticai.aiagent.model.request.ProviderConfiguration;
 import io.camunda.connector.agenticai.aiagent.model.request.ProviderConfiguration.AnthropicProviderConfiguration;
+import io.camunda.connector.agenticai.aiagent.model.request.ProviderConfiguration.AzureOpenAiProviderConfiguration;
 import io.camunda.connector.agenticai.aiagent.model.request.ProviderConfiguration.AzureOpenAiProviderConfiguration.AzureAuthentication.AzureApiKeyAuthentication;
 import io.camunda.connector.agenticai.aiagent.model.request.ProviderConfiguration.AzureOpenAiProviderConfiguration.AzureAuthentication.AzureClientCredentialsAuthentication;
 import io.camunda.connector.agenticai.aiagent.model.request.ProviderConfiguration.BedrockProviderConfiguration;
@@ -38,7 +39,7 @@ public class ChatModelFactoryImpl implements ChatModelFactory {
     return switch (providerConfiguration) {
       case AnthropicProviderConfiguration anthropic ->
           createAnthropicChatModelBuilder(anthropic).build();
-      case ProviderConfiguration.AzureOpenAiProviderConfiguration azureOpenAi ->
+      case AzureOpenAiProviderConfiguration azureOpenAi ->
           createAzureOpenAiChatModelBuilder(azureOpenAi).build();
       case BedrockProviderConfiguration bedrock -> createBedrockChatModelBuilder(bedrock).build();
       case OpenAiProviderConfiguration openai -> createOpenaiChatModelBuilder(openai).build();
@@ -70,7 +71,7 @@ public class ChatModelFactoryImpl implements ChatModelFactory {
   }
 
   protected AzureOpenAiChatModel.Builder createAzureOpenAiChatModelBuilder(
-      ProviderConfiguration.AzureOpenAiProviderConfiguration configuration) {
+      AzureOpenAiProviderConfiguration configuration) {
     final var connection = configuration.azureOpenAi();
     final var builder =
         AzureOpenAiChatModel.builder()

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/AgentRequest.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/AgentRequest.java
@@ -93,7 +93,7 @@ public record AgentRequest(
           """
 You are **TaskAgent**, a helpful, generic chat agent that can handle a wide variety of customer requests using your own domain knowledge **and** any tools explicitly provided to you at runtime.
 
-If tools are provided, you should prefer them instead of guessing an answer. You can call the same tool multiple times by providing different input values. Don't guess any tools which were not explicitely configured. If no tool matches the request, try to generate an answer. If you're not able to find a good answer, return with a message stating why you're not able to.
+If tools are provided, you should prefer them instead of guessing an answer. You can call the same tool multiple times by providing different input values. Don't guess any tools which were not explicitly configured. If no tool matches the request, try to generate an answer. If you're not able to find a good answer, return with a message stating why you're not able to.
 
 Wrap minimal, inspectable reasoning in *exactly* this XML template:
 

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/ProviderConfiguration.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/ProviderConfiguration.java
@@ -32,11 +32,11 @@ import java.util.Map;
       value = ProviderConfiguration.AnthropicProviderConfiguration.class,
       name = ANTHROPIC_ID),
   @JsonSubTypes.Type(
-      value = ProviderConfiguration.AzureOpenAiProviderConfiguration.class,
-      name = AZURE_OPENAI_ID),
-  @JsonSubTypes.Type(
       value = ProviderConfiguration.BedrockProviderConfiguration.class,
       name = BEDROCK_ID),
+  @JsonSubTypes.Type(
+      value = ProviderConfiguration.AzureOpenAiProviderConfiguration.class,
+      name = AZURE_OPENAI_ID),
   @JsonSubTypes.Type(
       value = ProviderConfiguration.OpenAiProviderConfiguration.class,
       name = OPENAI_ID)
@@ -139,160 +139,6 @@ public sealed interface ProviderConfiguration {
                   feel = Property.FeelMode.required,
                   optional = true)
               Integer topK) {}
-    }
-  }
-
-  @TemplateSubType(id = AZURE_OPENAI_ID, label = "Azure OpenAI")
-  record AzureOpenAiProviderConfiguration(@Valid @NotNull AzureOpenAiConnection azureOpenAi)
-      implements ProviderConfiguration {
-
-    @TemplateProperty(ignore = true)
-    public static final String AZURE_OPENAI_ID = "azureOpenAi";
-
-    public record AzureOpenAiConnection(
-        @FEEL
-            @TemplateProperty(
-                group = "provider",
-                description =
-                    "Specify Azure OpenAI endpoint. Details in the <a href=\"https://learn.microsoft.com/en-us/azure/ai-foundry/openai/reference\" target=\"_blank\">documentation</a>.",
-                constraints = @PropertyConstraints(notEmpty = true))
-            String endpoint,
-        @Valid @NotNull AzureAuthentication authentication,
-        @Valid @NotNull AzureOpenAiModel model) {}
-
-    @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
-    @JsonSubTypes({
-      @JsonSubTypes.Type(
-          value =
-              AzureOpenAiProviderConfiguration.AzureAuthentication.AzureApiKeyAuthentication.class,
-          name = "apiKey"),
-      @JsonSubTypes.Type(
-          value =
-              AzureOpenAiProviderConfiguration.AzureAuthentication
-                  .AzureClientCredentialsAuthentication.class,
-          name = "clientCredentials")
-    })
-    @TemplateDiscriminatorProperty(
-        label = "Authentication",
-        group = "provider",
-        name = "type",
-        defaultValue = "apiKey",
-        description =
-            "Specify the Azure OpenAI authentication strategy. Learn more at the <a href=\"https://docs.langchain4j.dev/integrations/language-models/azure-open-ai\" target=\"_blank\">documentation page</a>")
-    public sealed interface AzureAuthentication {
-      @TemplateSubType(id = "apiKey", label = "API key")
-      record AzureApiKeyAuthentication(
-          @NotBlank
-              @TemplateProperty(
-                  group = "provider",
-                  label = "API key",
-                  type = TemplateProperty.PropertyType.String,
-                  feel = Property.FeelMode.optional,
-                  constraints = @PropertyConstraints(notEmpty = true))
-              String apiKey)
-          implements AzureAuthentication {
-
-        @Override
-        public @NotNull String toString() {
-          return "AzureApiKeyAuthentication{apiKey=[REDACTED]}";
-        }
-      }
-
-      @TemplateSubType(id = "clientCredentials", label = "Client credentials")
-      record AzureClientCredentialsAuthentication(
-          @NotBlank
-              @TemplateProperty(
-                  group = "provider",
-                  label = "Client ID",
-                  description = "ID of a Microsoft Entra application",
-                  type = TemplateProperty.PropertyType.String,
-                  feel = Property.FeelMode.optional,
-                  constraints = @PropertyConstraints(notEmpty = true))
-              String clientId,
-          @NotBlank
-              @TemplateProperty(
-                  group = "provider",
-                  label = "Client secret",
-                  description = "Secret of a Microsoft Entra application",
-                  type = TemplateProperty.PropertyType.String,
-                  feel = Property.FeelMode.optional,
-                  constraints = @PropertyConstraints(notEmpty = true))
-              String clientSecret,
-          @NotBlank
-              @TemplateProperty(
-                  group = "provider",
-                  label = "Tenant ID",
-                  description =
-                      "ID of a Microsoft Entra tenant. Details in the <a href=\"https://learn.microsoft.com/en-us/entra/fundamentals/how-to-find-tenant\" target=\"_blank\">documentation</a>.",
-                  type = TemplateProperty.PropertyType.String,
-                  feel = Property.FeelMode.optional)
-              String tenantId,
-          @TemplateProperty(
-                  group = "provider",
-                  label = "Authority host",
-                  description =
-                      "Authority host URL for the Microsoft Entra application. Defaults to <code>https://login.microsoftonline.com</code>. This can also contain an OAuth 2.0 token endpoint.",
-                  type = TemplateProperty.PropertyType.String,
-                  feel = Property.FeelMode.optional,
-                  optional = true)
-              String authorityHost)
-          implements AzureAuthentication {
-
-        @Override
-        public String toString() {
-          return "AzureClientCredentialsAuthentication{clientId=%s, clientSecret=[REDACTED]}, tenantId=%s, authorityHost=%s}"
-              .formatted(clientId, tenantId, authorityHost);
-        }
-      }
-    }
-
-    public record AzureOpenAiModel(
-        @NotBlank
-            @TemplateProperty(
-                group = "model",
-                label = "Model deployment name",
-                description =
-                    "Specify the model deployment name. Details in the <a href=\"https://learn.microsoft.com/en-us/azure/ai-foundry/openai/reference\" target=\"_blank\">documentation</a>.",
-                type = TemplateProperty.PropertyType.String,
-                feel = Property.FeelMode.optional,
-                constraints = @PropertyConstraints(notEmpty = true))
-            String deploymentName,
-        @Valid
-            ProviderConfiguration.AzureOpenAiProviderConfiguration.AzureOpenAiModel
-                    .AzureOpenAiModelParameters
-                parameters) {
-
-      public record AzureOpenAiModelParameters(
-          @Min(0)
-              @TemplateProperty(
-                  group = "model",
-                  label = "Maximum tokens",
-                  tooltip =
-                      "The maximum number of tokens per request to generate before stopping. <br><br>Details in the <a href=\"https://learn.microsoft.com/en-us/azure/ai-foundry/openai/reference#request-body\" target=\"_blank\">documentation</a>.",
-                  type = TemplateProperty.PropertyType.Number,
-                  feel = Property.FeelMode.required,
-                  optional = true)
-              Integer maxTokens,
-          @Min(0)
-              @TemplateProperty(
-                  group = "model",
-                  label = "Temperature",
-                  tooltip =
-                      "Floating point number between 0 and 2. The higher the number, the more randomness will be injected into the response. <br><br>Details in the <a href=\"https://learn.microsoft.com/en-us/azure/ai-foundry/openai/reference#request-body\" target=\"_blank\">documentation</a>.",
-                  type = TemplateProperty.PropertyType.Number,
-                  feel = Property.FeelMode.required,
-                  optional = true)
-              Double temperature,
-          @Min(0)
-              @TemplateProperty(
-                  group = "model",
-                  label = "top P",
-                  tooltip =
-                      "Recommended for advanced use cases only (you usually only need to use temperature). <br><br>Details in the <a href=\"https://learn.microsoft.com/en-us/azure/ai-foundry/openai/reference#request-body\" target=\"_blank\">documentation</a>.",
-                  type = TemplateProperty.PropertyType.Number,
-                  feel = Property.FeelMode.required,
-                  optional = true)
-              Double topP) {}
     }
   }
 
@@ -416,6 +262,159 @@ public sealed interface ProviderConfiguration {
                   label = "top P",
                   tooltip =
                       "Floating point number between 0 and 1. Recommended for advanced use cases only (you usually only need to use temperature). <br><br>Details in the <a href=\"https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_InferenceConfiguration.html\" target=\"_blank\">documentation</a>.",
+                  type = TemplateProperty.PropertyType.Number,
+                  feel = Property.FeelMode.required,
+                  optional = true)
+              Double topP) {}
+    }
+  }
+
+  @TemplateSubType(id = AZURE_OPENAI_ID, label = "Azure OpenAI")
+  record AzureOpenAiProviderConfiguration(@Valid @NotNull AzureOpenAiConnection azureOpenAi)
+      implements ProviderConfiguration {
+
+    @TemplateProperty(ignore = true)
+    public static final String AZURE_OPENAI_ID = "azureOpenAi";
+
+    public record AzureOpenAiConnection(
+        @FEEL
+            @TemplateProperty(
+                group = "provider",
+                description =
+                    "Specify Azure OpenAI endpoint. Details in the <a href=\"https://learn.microsoft.com/en-us/azure/ai-foundry/openai/reference\" target=\"_blank\">documentation</a>.",
+                constraints = @PropertyConstraints(notEmpty = true))
+            String endpoint,
+        @Valid @NotNull AzureAuthentication authentication,
+        @Valid @NotNull AzureOpenAiModel model) {}
+
+    @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+    @JsonSubTypes({
+      @JsonSubTypes.Type(
+          value =
+              AzureOpenAiProviderConfiguration.AzureAuthentication.AzureApiKeyAuthentication.class,
+          name = "apiKey"),
+      @JsonSubTypes.Type(
+          value =
+              AzureOpenAiProviderConfiguration.AzureAuthentication
+                  .AzureClientCredentialsAuthentication.class,
+          name = "clientCredentials")
+    })
+    @TemplateDiscriminatorProperty(
+        label = "Authentication",
+        group = "provider",
+        name = "type",
+        defaultValue = "apiKey",
+        description = "Specify the Azure OpenAI authentication strategy.")
+    public sealed interface AzureAuthentication {
+      @TemplateSubType(id = "apiKey", label = "API key")
+      record AzureApiKeyAuthentication(
+          @NotBlank
+              @TemplateProperty(
+                  group = "provider",
+                  label = "API key",
+                  type = TemplateProperty.PropertyType.String,
+                  feel = Property.FeelMode.optional,
+                  constraints = @PropertyConstraints(notEmpty = true))
+              String apiKey)
+          implements AzureAuthentication {
+
+        @Override
+        public @NotNull String toString() {
+          return "AzureApiKeyAuthentication{apiKey=[REDACTED]}";
+        }
+      }
+
+      @TemplateSubType(id = "clientCredentials", label = "Client credentials")
+      record AzureClientCredentialsAuthentication(
+          @NotBlank
+              @TemplateProperty(
+                  group = "provider",
+                  label = "Client ID",
+                  description = "ID of a Microsoft Entra application",
+                  type = TemplateProperty.PropertyType.String,
+                  feel = Property.FeelMode.optional,
+                  constraints = @PropertyConstraints(notEmpty = true))
+              String clientId,
+          @NotBlank
+              @TemplateProperty(
+                  group = "provider",
+                  label = "Client secret",
+                  description = "Secret of a Microsoft Entra application",
+                  type = TemplateProperty.PropertyType.String,
+                  feel = Property.FeelMode.optional,
+                  constraints = @PropertyConstraints(notEmpty = true))
+              String clientSecret,
+          @NotBlank
+              @TemplateProperty(
+                  group = "provider",
+                  label = "Tenant ID",
+                  description =
+                      "ID of a Microsoft Entra tenant. Details in the <a href=\"https://learn.microsoft.com/en-us/entra/fundamentals/how-to-find-tenant\" target=\"_blank\">documentation</a>.",
+                  type = TemplateProperty.PropertyType.String,
+                  feel = Property.FeelMode.optional)
+              String tenantId,
+          @TemplateProperty(
+                  group = "provider",
+                  label = "Authority host",
+                  description =
+                      "Authority host URL for the Microsoft Entra application. Defaults to <code>https://login.microsoftonline.com</code>. This can also contain an OAuth 2.0 token endpoint.",
+                  type = TemplateProperty.PropertyType.String,
+                  feel = Property.FeelMode.optional,
+                  optional = true)
+              String authorityHost)
+          implements AzureAuthentication {
+
+        @Override
+        public String toString() {
+          return "AzureClientCredentialsAuthentication{clientId=%s, clientSecret=[REDACTED]}, tenantId=%s, authorityHost=%s}"
+              .formatted(clientId, tenantId, authorityHost);
+        }
+      }
+    }
+
+    public record AzureOpenAiModel(
+        @NotBlank
+            @TemplateProperty(
+                group = "model",
+                label = "Model deployment name",
+                description =
+                    "Specify the model deployment name. Details in the <a href=\"https://learn.microsoft.com/en-us/azure/ai-foundry/openai/reference\" target=\"_blank\">documentation</a>.",
+                type = TemplateProperty.PropertyType.String,
+                feel = Property.FeelMode.optional,
+                constraints = @PropertyConstraints(notEmpty = true))
+            String deploymentName,
+        @Valid
+            ProviderConfiguration.AzureOpenAiProviderConfiguration.AzureOpenAiModel
+                    .AzureOpenAiModelParameters
+                parameters) {
+
+      public record AzureOpenAiModelParameters(
+          @Min(0)
+              @TemplateProperty(
+                  group = "model",
+                  label = "Maximum tokens",
+                  tooltip =
+                      "The maximum number of tokens per request to generate before stopping. <br><br>Details in the <a href=\"https://learn.microsoft.com/en-us/azure/ai-foundry/openai/reference#request-body\" target=\"_blank\">documentation</a>.",
+                  type = TemplateProperty.PropertyType.Number,
+                  feel = Property.FeelMode.required,
+                  optional = true)
+              Integer maxTokens,
+          @Min(0)
+              @TemplateProperty(
+                  group = "model",
+                  label = "Temperature",
+                  tooltip =
+                      "Floating point number between 0 and 2. The higher the number, the more randomness will be injected into the response. <br><br>Details in the <a href=\"https://learn.microsoft.com/en-us/azure/ai-foundry/openai/reference#request-body\" target=\"_blank\">documentation</a>.",
+                  type = TemplateProperty.PropertyType.Number,
+                  feel = Property.FeelMode.required,
+                  optional = true)
+              Double temperature,
+          @Min(0)
+              @TemplateProperty(
+                  group = "model",
+                  label = "top P",
+                  tooltip =
+                      "Recommended for advanced use cases only (you usually only need to use temperature). <br><br>Details in the <a href=\"https://learn.microsoft.com/en-us/azure/ai-foundry/openai/reference#request-body\" target=\"_blank\">documentation</a>.",
                   type = TemplateProperty.PropertyType.Number,
                   feel = Property.FeelMode.required,
                   optional = true)

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/ProviderConfiguration.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/ProviderConfiguration.java
@@ -7,6 +7,7 @@
 package io.camunda.connector.agenticai.aiagent.model.request;
 
 import static io.camunda.connector.agenticai.aiagent.model.request.ProviderConfiguration.AnthropicProviderConfiguration.ANTHROPIC_ID;
+import static io.camunda.connector.agenticai.aiagent.model.request.ProviderConfiguration.AzureOpenAiProviderConfiguration.AZURE_OPENAI_ID;
 import static io.camunda.connector.agenticai.aiagent.model.request.ProviderConfiguration.BedrockProviderConfiguration.BEDROCK_ID;
 import static io.camunda.connector.agenticai.aiagent.model.request.ProviderConfiguration.OpenAiProviderConfiguration.OPENAI_ID;
 
@@ -31,6 +32,9 @@ import java.util.Map;
       value = ProviderConfiguration.AnthropicProviderConfiguration.class,
       name = ANTHROPIC_ID),
   @JsonSubTypes.Type(
+      value = ProviderConfiguration.AzureOpenAiProviderConfiguration.class,
+      name = AZURE_OPENAI_ID),
+  @JsonSubTypes.Type(
       value = ProviderConfiguration.BedrockProviderConfiguration.class,
       name = BEDROCK_ID),
   @JsonSubTypes.Type(
@@ -43,10 +47,7 @@ import java.util.Map;
     name = "type",
     description = "Specify the LLM provider to use.",
     defaultValue = ANTHROPIC_ID)
-public sealed interface ProviderConfiguration
-    permits ProviderConfiguration.AnthropicProviderConfiguration,
-        ProviderConfiguration.BedrockProviderConfiguration,
-        ProviderConfiguration.OpenAiProviderConfiguration {
+public sealed interface ProviderConfiguration {
 
   @TemplateSubType(id = ANTHROPIC_ID, label = "Anthropic")
   record AnthropicProviderConfiguration(@Valid @NotNull AnthropicConnection anthropic)
@@ -74,7 +75,13 @@ public sealed interface ProviderConfiguration
                 type = TemplateProperty.PropertyType.String,
                 feel = Property.FeelMode.optional,
                 constraints = @PropertyConstraints(notEmpty = true))
-            String apiKey) {}
+            String apiKey) {
+
+      @Override
+      public String toString() {
+        return "AnthropicAuthentication{apiKey=[REDACTED]}";
+      }
+    }
 
     public record AnthropicModel(
         @NotBlank
@@ -135,6 +142,160 @@ public sealed interface ProviderConfiguration
     }
   }
 
+  @TemplateSubType(id = AZURE_OPENAI_ID, label = "Azure OpenAI")
+  record AzureOpenAiProviderConfiguration(@Valid @NotNull AzureOpenAiConnection azureOpenAi)
+      implements ProviderConfiguration {
+
+    @TemplateProperty(ignore = true)
+    public static final String AZURE_OPENAI_ID = "azureOpenAi";
+
+    public record AzureOpenAiConnection(
+        @FEEL
+            @TemplateProperty(
+                group = "provider",
+                description =
+                    "Specify Azure OpenAI endpoint. Details in the <a href=\"https://learn.microsoft.com/en-us/azure/ai-foundry/openai/reference\" target=\"_blank\">documentation</a>.",
+                constraints = @PropertyConstraints(notEmpty = true))
+            String endpoint,
+        @Valid @NotNull AzureAuthentication authentication,
+        @Valid @NotNull AzureOpenAiModel model) {}
+
+    @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+    @JsonSubTypes({
+      @JsonSubTypes.Type(
+          value =
+              AzureOpenAiProviderConfiguration.AzureAuthentication.AzureApiKeyAuthentication.class,
+          name = "apiKey"),
+      @JsonSubTypes.Type(
+          value =
+              AzureOpenAiProviderConfiguration.AzureAuthentication
+                  .AzureClientCredentialsAuthentication.class,
+          name = "clientCredentials")
+    })
+    @TemplateDiscriminatorProperty(
+        label = "Authentication",
+        group = "provider",
+        name = "type",
+        defaultValue = "apiKey",
+        description =
+            "Specify the Azure OpenAI authentication strategy. Learn more at the <a href=\"https://docs.langchain4j.dev/integrations/language-models/azure-open-ai\" target=\"_blank\">documentation page</a>")
+    public sealed interface AzureAuthentication {
+      @TemplateSubType(id = "apiKey", label = "API key")
+      record AzureApiKeyAuthentication(
+          @NotBlank
+              @TemplateProperty(
+                  group = "provider",
+                  label = "API key",
+                  type = TemplateProperty.PropertyType.String,
+                  feel = Property.FeelMode.optional,
+                  constraints = @PropertyConstraints(notEmpty = true))
+              String apiKey)
+          implements AzureAuthentication {
+
+        @Override
+        public @NotNull String toString() {
+          return "AzureApiKeyAuthentication{apiKey=[REDACTED]}";
+        }
+      }
+
+      @TemplateSubType(id = "clientCredentials", label = "Client credentials")
+      record AzureClientCredentialsAuthentication(
+          @NotBlank
+              @TemplateProperty(
+                  group = "provider",
+                  label = "Client ID",
+                  description = "ID of a Microsoft Entra application",
+                  type = TemplateProperty.PropertyType.String,
+                  feel = Property.FeelMode.optional,
+                  constraints = @PropertyConstraints(notEmpty = true))
+              String clientId,
+          @NotBlank
+              @TemplateProperty(
+                  group = "provider",
+                  label = "Client secret",
+                  description = "Secret of a Microsoft Entra application",
+                  type = TemplateProperty.PropertyType.String,
+                  feel = Property.FeelMode.optional,
+                  constraints = @PropertyConstraints(notEmpty = true))
+              String clientSecret,
+          @NotBlank
+              @TemplateProperty(
+                  group = "provider",
+                  label = "Tenant ID",
+                  description =
+                      "ID of a Microsoft Entra tenant. Details in the <a href=\"https://learn.microsoft.com/en-us/entra/fundamentals/how-to-find-tenant\" target=\"_blank\">documentation</a>.",
+                  type = TemplateProperty.PropertyType.String,
+                  feel = Property.FeelMode.optional)
+              String tenantId,
+          @TemplateProperty(
+                  group = "provider",
+                  label = "Authority host",
+                  description =
+                      "Authority host URL for the Microsoft Entra application. Defaults to <code>https://login.microsoftonline.com</code>. This can also contain an OAuth 2.0 token endpoint.",
+                  type = TemplateProperty.PropertyType.String,
+                  feel = Property.FeelMode.optional,
+                  optional = true)
+              String authorityHost)
+          implements AzureAuthentication {
+
+        @Override
+        public String toString() {
+          return "AzureClientCredentialsAuthentication{clientId=%s, clientSecret=[REDACTED]}, tenantId=%s, authorityHost=%s}"
+              .formatted(clientId, tenantId, authorityHost);
+        }
+      }
+    }
+
+    public record AzureOpenAiModel(
+        @NotBlank
+            @TemplateProperty(
+                group = "model",
+                label = "Model deployment name",
+                description =
+                    "Specify the model deployment name. Details in the <a href=\"https://learn.microsoft.com/en-us/azure/ai-foundry/openai/reference\" target=\"_blank\">documentation</a>.",
+                type = TemplateProperty.PropertyType.String,
+                feel = Property.FeelMode.optional,
+                constraints = @PropertyConstraints(notEmpty = true))
+            String deploymentName,
+        @Valid
+            ProviderConfiguration.AzureOpenAiProviderConfiguration.AzureOpenAiModel
+                    .AzureOpenAiModelParameters
+                parameters) {
+
+      public record AzureOpenAiModelParameters(
+          @Min(0)
+              @TemplateProperty(
+                  group = "model",
+                  label = "Maximum tokens",
+                  tooltip =
+                      "The maximum number of tokens per request to generate before stopping. <br><br>Details in the <a href=\"https://learn.microsoft.com/en-us/azure/ai-foundry/openai/reference#request-body\" target=\"_blank\">documentation</a>.",
+                  type = TemplateProperty.PropertyType.Number,
+                  feel = Property.FeelMode.required,
+                  optional = true)
+              Integer maxTokens,
+          @Min(0)
+              @TemplateProperty(
+                  group = "model",
+                  label = "Temperature",
+                  tooltip =
+                      "Floating point number between 0 and 2. The higher the number, the more randomness will be injected into the response. <br><br>Details in the <a href=\"https://learn.microsoft.com/en-us/azure/ai-foundry/openai/reference#request-body\" target=\"_blank\">documentation</a>.",
+                  type = TemplateProperty.PropertyType.Number,
+                  feel = Property.FeelMode.required,
+                  optional = true)
+              Double temperature,
+          @Min(0)
+              @TemplateProperty(
+                  group = "model",
+                  label = "top P",
+                  tooltip =
+                      "Recommended for advanced use cases only (you usually only need to use temperature). <br><br>Details in the <a href=\"https://learn.microsoft.com/en-us/azure/ai-foundry/openai/reference#request-body\" target=\"_blank\">documentation</a>.",
+                  type = TemplateProperty.PropertyType.Number,
+                  feel = Property.FeelMode.required,
+                  optional = true)
+              Double topP) {}
+    }
+  }
+
   @TemplateSubType(id = BEDROCK_ID, label = "AWS Bedrock")
   record BedrockProviderConfiguration(@Valid @NotNull BedrockConnection bedrock)
       implements ProviderConfiguration {
@@ -183,9 +344,7 @@ public sealed interface ProviderConfiguration
         defaultValue = "credentials",
         description =
             "Specify the AWS authentication strategy. Learn more at the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-bedrock/#authentication\" target=\"_blank\">documentation page</a>")
-    public sealed interface AwsAuthentication
-        permits AwsAuthentication.AwsDefaultCredentialsChainAuthentication,
-            AwsAuthentication.AwsStaticCredentialsAuthentication {
+    public sealed interface AwsAuthentication {
       @TemplateSubType(id = "credentials", label = "Credentials")
       record AwsStaticCredentialsAuthentication(
           @TemplateProperty(
@@ -320,7 +479,14 @@ public sealed interface ProviderConfiguration
                 type = TemplateProperty.PropertyType.String,
                 feel = Property.FeelMode.optional,
                 optional = true)
-            String projectId) {}
+            String projectId) {
+
+      @Override
+      public String toString() {
+        return "OpenAiAuthentication{apiKey=[REDACTED], organizationId=%s, projectId=%s}"
+            .formatted(organizationId, projectId);
+      }
+    }
 
     public record OpenAiModel(
         @NotBlank

--- a/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/ChatModelFactoryTest.java
+++ b/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/ChatModelFactoryTest.java
@@ -13,8 +13,11 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 
+import com.azure.core.credential.TokenCredential;
+import com.azure.identity.ClientSecretCredential;
 import dev.langchain4j.model.anthropic.AnthropicChatModel;
 import dev.langchain4j.model.anthropic.AnthropicChatModel.AnthropicChatModelBuilder;
+import dev.langchain4j.model.azure.AzureOpenAiChatModel;
 import dev.langchain4j.model.bedrock.BedrockChatModel;
 import dev.langchain4j.model.bedrock.BedrockChatRequestParameters;
 import dev.langchain4j.model.chat.request.ChatRequestParameters;
@@ -26,6 +29,11 @@ import io.camunda.connector.agenticai.aiagent.model.request.ProviderConfiguratio
 import io.camunda.connector.agenticai.aiagent.model.request.ProviderConfiguration.AnthropicProviderConfiguration.AnthropicConnection;
 import io.camunda.connector.agenticai.aiagent.model.request.ProviderConfiguration.AnthropicProviderConfiguration.AnthropicModel;
 import io.camunda.connector.agenticai.aiagent.model.request.ProviderConfiguration.AnthropicProviderConfiguration.AnthropicModel.AnthropicModelParameters;
+import io.camunda.connector.agenticai.aiagent.model.request.ProviderConfiguration.AzureOpenAiProviderConfiguration;
+import io.camunda.connector.agenticai.aiagent.model.request.ProviderConfiguration.AzureOpenAiProviderConfiguration.AzureAuthentication.AzureApiKeyAuthentication;
+import io.camunda.connector.agenticai.aiagent.model.request.ProviderConfiguration.AzureOpenAiProviderConfiguration.AzureAuthentication.AzureClientCredentialsAuthentication;
+import io.camunda.connector.agenticai.aiagent.model.request.ProviderConfiguration.AzureOpenAiProviderConfiguration.AzureOpenAiConnection;
+import io.camunda.connector.agenticai.aiagent.model.request.ProviderConfiguration.AzureOpenAiProviderConfiguration.AzureOpenAiModel.AzureOpenAiModelParameters;
 import io.camunda.connector.agenticai.aiagent.model.request.ProviderConfiguration.BedrockProviderConfiguration;
 import io.camunda.connector.agenticai.aiagent.model.request.ProviderConfiguration.BedrockProviderConfiguration.AwsAuthentication;
 import io.camunda.connector.agenticai.aiagent.model.request.ProviderConfiguration.BedrockProviderConfiguration.BedrockConnection;
@@ -154,6 +162,86 @@ class ChatModelFactoryTest {
 
     static Stream<AnthropicModelParameters> nullModelParameters() {
       return Stream.of(new AnthropicModelParameters(null, null, null, null));
+    }
+  }
+
+  @Nested
+  class AzureOpenAiChatModelFactoryTest {
+
+    private static final String AZURE_OPENAI_API_KEY = "azureOpenAiApiKey";
+    private static final String AZURE_OPENAI_ENDPOINT = "azure-openai-endpoint.local";
+    private static final String AZURE_OPENAI_DEPLOYMENT_NAME = "gpt-4o";
+    private static final String CLIENT_ID = "clientId";
+    private static final String CLIENT_SECRET = "clientSecret";
+    private static final String TENANT_ID = "tenantId";
+
+    private static final AzureOpenAiModelParameters DEFAULT_MODEL_PARAMETERS =
+        new AzureOpenAiModelParameters(10, 1.0, 0.8);
+
+    @Captor ArgumentCaptor<TokenCredential> tokenCredentialsCapture;
+
+    @Test
+    void createsAzureOpenAiChatModelWithApiKey() {
+      final var providerConfig =
+          new AzureOpenAiProviderConfiguration(
+              new AzureOpenAiConnection(
+                  AZURE_OPENAI_ENDPOINT,
+                  new AzureApiKeyAuthentication(AZURE_OPENAI_API_KEY),
+                  new AzureOpenAiProviderConfiguration.AzureOpenAiModel(
+                      AZURE_OPENAI_DEPLOYMENT_NAME, DEFAULT_MODEL_PARAMETERS)));
+
+      testAzureOpenAiChatModelBuilder(
+          providerConfig,
+          (builder) -> {
+            verify(builder).apiKey(AZURE_OPENAI_API_KEY);
+            verify(builder, never()).tokenCredential(any());
+          });
+    }
+
+    @Test
+    void createsAzureOpenAiChatModelWithClientCredentials() {
+      final var providerConfig =
+          new AzureOpenAiProviderConfiguration(
+              new AzureOpenAiConnection(
+                  AZURE_OPENAI_ENDPOINT,
+                  new AzureClientCredentialsAuthentication(
+                      CLIENT_ID, CLIENT_SECRET, TENANT_ID, null),
+                  new AzureOpenAiProviderConfiguration.AzureOpenAiModel(
+                      AZURE_OPENAI_DEPLOYMENT_NAME, DEFAULT_MODEL_PARAMETERS)));
+
+      testAzureOpenAiChatModelBuilder(
+          providerConfig,
+          (builder) -> {
+            verify(builder, never()).apiKey(any());
+            verify(builder).tokenCredential(tokenCredentialsCapture.capture());
+            final var tokenCredential = tokenCredentialsCapture.getValue();
+            assertThat(tokenCredential).isNotNull().isInstanceOf(ClientSecretCredential.class);
+          });
+    }
+
+    private void testAzureOpenAiChatModelBuilder(
+        AzureOpenAiProviderConfiguration providerConfig,
+        ThrowingConsumer<AzureOpenAiChatModel.Builder> builderAssertions) {
+      final var chatModelBuilder = spy(AzureOpenAiChatModel.builder());
+      final var chatModelResultCaptor = new ResultCaptor<AzureOpenAiChatModel>();
+      doAnswer(chatModelResultCaptor).when(chatModelBuilder).build();
+
+      try (MockedStatic<AzureOpenAiChatModel> chatModelMock =
+          Mockito.mockStatic(AzureOpenAiChatModel.class, Answers.CALLS_REAL_METHODS)) {
+        chatModelMock.when(AzureOpenAiChatModel::builder).thenReturn(chatModelBuilder);
+
+        final var chatModel = chatModelFactory.createChatModel(providerConfig);
+        assertThat(chatModel).isNotNull().isInstanceOf(AzureOpenAiChatModel.class);
+        assertThat(chatModel).isSameAs(chatModelResultCaptor.getResult());
+
+        verify(chatModelBuilder).endpoint(AZURE_OPENAI_ENDPOINT);
+        verify(chatModelBuilder).deploymentName(AZURE_OPENAI_DEPLOYMENT_NAME);
+        verify(chatModelBuilder).maxTokens(DEFAULT_MODEL_PARAMETERS.maxTokens());
+        verify(chatModelBuilder).temperature(DEFAULT_MODEL_PARAMETERS.temperature());
+        verify(chatModelBuilder).topP(DEFAULT_MODEL_PARAMETERS.topP());
+
+        builderAssertions.accept(chatModelBuilder);
+      }
     }
   }
 

--- a/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/ChatModelFactoryTest.java
+++ b/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/ChatModelFactoryTest.java
@@ -8,6 +8,8 @@ package io.camunda.connector.agenticai.aiagent.framework.langchain4j;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyDouble;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
@@ -52,6 +54,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Answers;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
@@ -134,10 +137,10 @@ class ChatModelFactoryTest {
       testAnthropicChatModelBuilder(
           providerConfig,
           (builder) -> {
-            verify(builder, never()).maxTokens(DEFAULT_MODEL_PARAMETERS.maxTokens());
-            verify(builder, never()).temperature(DEFAULT_MODEL_PARAMETERS.temperature());
-            verify(builder, never()).topP(DEFAULT_MODEL_PARAMETERS.topP());
-            verify(builder, never()).topK(DEFAULT_MODEL_PARAMETERS.topK());
+            verify(builder, never()).maxTokens(anyInt());
+            verify(builder, never()).temperature(anyDouble());
+            verify(builder, never()).topP(anyDouble());
+            verify(builder, never()).topK(anyInt());
           });
     }
 
@@ -194,18 +197,23 @@ class ChatModelFactoryTest {
           providerConfig,
           (builder) -> {
             verify(builder).apiKey(AZURE_OPENAI_API_KEY);
+            verify(builder).maxTokens(DEFAULT_MODEL_PARAMETERS.maxTokens());
+            verify(builder).temperature(DEFAULT_MODEL_PARAMETERS.temperature());
+            verify(builder).topP(DEFAULT_MODEL_PARAMETERS.topP());
             verify(builder, never()).tokenCredential(any());
           });
     }
 
-    @Test
-    void createsAzureOpenAiChatModelWithClientCredentials() {
+    @ParameterizedTest
+    @NullSource
+    @ValueSource(strings = {"https://some-authortiy-host"})
+    void createsAzureOpenAiChatModelWithClientCredentials(String authorityHost) {
       final var providerConfig =
           new AzureOpenAiProviderConfiguration(
               new AzureOpenAiConnection(
                   AZURE_OPENAI_ENDPOINT,
                   new AzureClientCredentialsAuthentication(
-                      CLIENT_ID, CLIENT_SECRET, TENANT_ID, null),
+                      CLIENT_ID, CLIENT_SECRET, TENANT_ID, authorityHost),
                   new AzureOpenAiProviderConfiguration.AzureOpenAiModel(
                       AZURE_OPENAI_DEPLOYMENT_NAME, DEFAULT_MODEL_PARAMETERS)));
 
@@ -213,9 +221,35 @@ class ChatModelFactoryTest {
           providerConfig,
           (builder) -> {
             verify(builder, never()).apiKey(any());
+            verify(builder).maxTokens(DEFAULT_MODEL_PARAMETERS.maxTokens());
+            verify(builder).temperature(DEFAULT_MODEL_PARAMETERS.temperature());
+            verify(builder).topP(DEFAULT_MODEL_PARAMETERS.topP());
             verify(builder).tokenCredential(tokenCredentialsCapture.capture());
             final var tokenCredential = tokenCredentialsCapture.getValue();
             assertThat(tokenCredential).isNotNull().isInstanceOf(ClientSecretCredential.class);
+          });
+    }
+
+    @ParameterizedTest
+    @NullSource
+    @MethodSource("nullModelParameters")
+    void createsAzureOpenAiChatModelWithNullModelParameters(
+        AzureOpenAiModelParameters modelParameters) {
+      final var providerConfig =
+          new AzureOpenAiProviderConfiguration(
+              new AzureOpenAiConnection(
+                  AZURE_OPENAI_ENDPOINT,
+                  new AzureClientCredentialsAuthentication(
+                      CLIENT_ID, CLIENT_SECRET, TENANT_ID, null),
+                  new AzureOpenAiProviderConfiguration.AzureOpenAiModel(
+                      AZURE_OPENAI_DEPLOYMENT_NAME, modelParameters)));
+
+      testAzureOpenAiChatModelBuilder(
+          providerConfig,
+          (builder) -> {
+            verify(builder, never()).maxTokens(anyInt());
+            verify(builder, never()).temperature(anyDouble());
+            verify(builder, never()).topP(anyDouble());
           });
     }
 
@@ -236,12 +270,12 @@ class ChatModelFactoryTest {
 
         verify(chatModelBuilder).endpoint(AZURE_OPENAI_ENDPOINT);
         verify(chatModelBuilder).deploymentName(AZURE_OPENAI_DEPLOYMENT_NAME);
-        verify(chatModelBuilder).maxTokens(DEFAULT_MODEL_PARAMETERS.maxTokens());
-        verify(chatModelBuilder).temperature(DEFAULT_MODEL_PARAMETERS.temperature());
-        verify(chatModelBuilder).topP(DEFAULT_MODEL_PARAMETERS.topP());
-
         builderAssertions.accept(chatModelBuilder);
       }
+    }
+
+    static Stream<AzureOpenAiModelParameters> nullModelParameters() {
+      return Stream.of(new AzureOpenAiModelParameters(null, null, null));
     }
   }
 


### PR DESCRIPTION
## Description

Support Azure OpenAI models in the Agentic-AI connector. 
Two authentication mechanisms are supported:
 1. API key authentication
 2. [Client secret credentials](https://learn.microsoft.com/en-us/java/api/com.azure.identity.clientsecretcredentialbuilder?view=azure-java-stable) authentication

When using client secret credentials, it is mandatory to specify _Client ID_, _Client secret_, and _Tenant ID_. The _Authority host_ parameter is optional and can be used to specify a custom OAuth2 token endpoint. This can cover the use case mentioned in [this thread](https://camunda.slack.com/archives/C08BHU6JQJG/p1749644316436459).

The documentation PR will follow.

## Related issues

closes #4815

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.
- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest release, as this branch will be rebased onto main before the next release.

