### PR TITLE
docs(agentic-ai): add Hybrid/Self-Managed only suffix to custom storage implementation label

### DIFF
--- a/connectors/agentic-ai/element-templates/agenticai-aiagent-outbound-connector.json
+++ b/connectors/agentic-ai/element-templates/agenticai-aiagent-outbound-connector.json
@@ -934,7 +934,7 @@
       "name" : "Camunda Document Storage",
       "value" : "camunda-document"
     }, {
-      "name" : "Custom Implementation",
+      "name" : "Custom Implementation (Hybrid/Self-Managed only)",
       "value" : "custom"
     } ]
   }, {

--- a/connectors/agentic-ai/element-templates/hybrid/agenticai-aiagent-outbound-connector-hybrid.json
+++ b/connectors/agentic-ai/element-templates/hybrid/agenticai-aiagent-outbound-connector-hybrid.json
@@ -939,7 +939,7 @@
       "name" : "Camunda Document Storage",
       "value" : "camunda-document"
     }, {
-      "name" : "Custom Implementation",
+      "name" : "Custom Implementation (Hybrid/Self-Managed only)",
       "value" : "custom"
     } ]
   }, {

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/MemoryStorageConfiguration.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/MemoryStorageConfiguration.java
@@ -80,7 +80,7 @@ public sealed interface MemoryStorageConfiguration
     }
   }
 
-  @TemplateSubType(id = "custom", label = "Custom Implementation")
+  @TemplateSubType(id = "custom", label = "Custom Implementation (Hybrid/Self-Managed only)")
   record CustomMemoryStorageConfiguration(
       @FEEL
           @TemplateProperty(


### PR DESCRIPTION
## Description

Quick win to make it more explicit that a custom implementation can only be used in hybrid/self-managed environments. This is the same as for the AWS Default Credential chain config.

## Related issues

related to #4998 

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.
- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest release, as this branch will be rebased onto main before the next release.

