### PR TITLE
chore(ci): Add workflow to bump docs links on minor release

### DIFF
--- a/.github/workflows/UPDATE_DOC_LINKS_TO_NEW_MINOR.yml
+++ b/.github/workflows/UPDATE_DOC_LINKS_TO_NEW_MINOR.yml
@@ -1,0 +1,49 @@
+name: update_doc_links_to_new_minor
+
+on:
+  workflow_dispatch:
+    inputs:
+      from-version:
+        description: 'Previous latest minor version, e.g. 8.7'
+        type: string
+        required: true
+      to-version:
+        description: 'New latest minor version, e.g. 8.8'
+        type: string
+        required: true
+
+jobs:
+  version_bump_docs_links:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Fetch main branch
+        run: git fetch origin main
+
+      - name: Configure git user
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Collect connector template links
+        run: |
+          chmod +x ./.github/workflows/scripts/version_bump_all_element_templates_docs_links_versions.sh
+          ./.github/workflows/scripts/version_bump_all_element_templates_docs_links_versions.sh ${{inputs.from-version}} ${{inputs.to-version}}
+        shell: bash
+
+      - name: Create pull request to main branch
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: chore/bump-npm-package-version
+          commit-message: "ci: bump docs version from ${{inputs.from-version}} to ${{ inputs.to-version}}"
+          committer: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
+          base: main
+          title: "chore(docs-links): bump versions from ${{inputs.from-version}} to ${{ inputs.to-version}}"
+          labels: "no milestone"
+          body: |
+            This bumps docs version of latest's element templates of a connector to latest minor version.

--- a/.github/workflows/scripts/version_bump_all_element_templates_docs_links_versions.sh
+++ b/.github/workflows/scripts/version_bump_all_element_templates_docs_links_versions.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+FROM_VERSION="$1"
+TO_VERSION="$2"
+
+if [ -z "$FROM_VERSION" ] || [ -z "$TO_VERSION" ]; then
+  echo "Usage: $0 <FROM_VERSION> <TO_VERSION>"
+  exit 1
+fi
+
+update_links_in_file() {
+  local file_path="$1"
+
+  # Escape dots in versions for use in regex
+  escaped_from_version=$(printf '%s\n' "$FROM_VERSION" | sed 's/\./\\./g')
+  escaped_to_version=$(printf '%s\n' "$TO_VERSION" | sed 's/\./\\./g')
+
+  sed -i -E "s|(https://docs.camunda.io/docs/)$escaped_from_version/|\1$escaped_to_version/|g" "$file_path"
+}
+
+# Find all JSON files in "element-templates" directories (excluding versioned subdirs)
+find . -type d -name "element-templates" | while read -r dir; do
+  find "$dir" -path "$dir/versioned" -prune -o -type f -name "*.json" -print | while read -r file; do
+    echo "Updating links in: $file"
+    update_links_in_file "$file"
+  done
+done


### PR DESCRIPTION
## Description
This PR adds a new workflow to version bump docs links in latest element templates. 
A PR like this is created: https://github.com/camunda/connectors/pull/5092

## Related issues
closes #https://github.com/camunda/connectors/issues/4791

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.
- [x] Backport labels are added if these code changes should be backported. No backport label is added to the latest release, as this branch will be rebased onto main before the next release.

