### PR TITLE
feat(document-handling): Add external document feature

### DIFF
--- a/connector-sdk/document/pom.xml
+++ b/connector-sdk/document/pom.xml
@@ -29,6 +29,21 @@
       <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
 </project>

--- a/connector-sdk/document/src/main/java/io/camunda/document/ExternalDocument.java
+++ b/connector-sdk/document/src/main/java/io/camunda/document/ExternalDocument.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.document;
+
+import io.camunda.client.api.response.DocumentMetadata;
+import io.camunda.document.reference.DocumentReference;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.time.OffsetDateTime;
+import java.util.Base64;
+import java.util.Map;
+import java.util.UUID;
+import javax.annotation.Nullable;
+
+public class ExternalDocument implements Document {
+
+  private final DocumentMetadata metadata;
+  private final HttpURLConnection connection;
+
+  public ExternalDocument(String url, @Nullable String name, HttpURLConnection connection) {
+    try {
+      if (connection == null) {
+        URL urlObj = new URL(url);
+        connection = (HttpURLConnection) urlObj.openConnection();
+        connection.setRequestMethod("GET");
+        connection.connect();
+        connection.getContentLengthLong();
+        connection.getContentType();
+      }
+      this.connection = connection;
+
+      metadata = createMetadata(name);
+    } catch (IOException e) {
+      throw new RuntimeException("Failed to connect to external document URL: " + url, e);
+    }
+  }
+
+  public ExternalDocument(String url, @Nullable String name) {
+    this(url, name, null);
+  }
+
+  private DocumentMetadata createMetadata(@Nullable String name) {
+    return new DocumentMetadata() {
+      @Override
+      public String getContentType() {
+        return connection.getContentType();
+      }
+
+      @Override
+      public OffsetDateTime getExpiresAt() {
+        return null;
+      }
+
+      @Override
+      public Long getSize() {
+        return connection.getContentLengthLong();
+      }
+
+      @Override
+      public String getFileName() {
+        return name == null ? UUID.randomUUID().toString() : name;
+      }
+
+      @Override
+      public String getProcessDefinitionId() {
+        return "";
+      }
+
+      @Override
+      public Long getProcessInstanceKey() {
+        return 0L;
+      }
+
+      @Override
+      public Map<String, Object> getCustomProperties() {
+        return Map.of();
+      }
+    };
+  }
+
+  @Override
+  public DocumentMetadata metadata() {
+    return metadata;
+  }
+
+  @Override
+  public String asBase64() {
+    return Base64.getEncoder().encodeToString(asByteArray());
+  }
+
+  @Override
+  public InputStream asInputStream() {
+    try {
+      return connection.getInputStream();
+    } catch (IOException e) {
+      throw new RuntimeException(
+          "Failed to download external document: " + connection.getURL().toString(), e);
+    }
+  }
+
+  @Override
+  public byte[] asByteArray() {
+    try (InputStream inputStream = asInputStream()) {
+      return inputStream.readAllBytes();
+    } catch (IOException e) {
+      return null;
+    }
+  }
+
+  @Override
+  public DocumentReference reference() {
+    return null;
+  }
+
+  @Override
+  public String generateLink(DocumentLinkParameters parameters) {
+    return connection.getURL().toString();
+  }
+}

--- a/connector-sdk/document/src/main/java/io/camunda/document/factory/DocumentFactoryImpl.java
+++ b/connector-sdk/document/src/main/java/io/camunda/document/factory/DocumentFactoryImpl.java
@@ -18,6 +18,7 @@ package io.camunda.document.factory;
 
 import io.camunda.document.CamundaDocument;
 import io.camunda.document.Document;
+import io.camunda.document.ExternalDocument;
 import io.camunda.document.reference.DocumentReference;
 import io.camunda.document.reference.DocumentReference.CamundaDocumentReference;
 import io.camunda.document.reference.DocumentReference.ExternalDocumentReference;
@@ -41,9 +42,9 @@ public class DocumentFactoryImpl implements DocumentFactory {
       return new CamundaDocument(
           camundaDocumentReference.getMetadata(), camundaDocumentReference, documentStore);
     }
-    if (reference instanceof ExternalDocumentReference ignored) {
-      throw new IllegalArgumentException(
-          "External document references are not yet supported: " + reference.getClass());
+    if (reference instanceof ExternalDocumentReference externalDocumentReference) {
+      return new ExternalDocument(
+          externalDocumentReference.url(), externalDocumentReference.name());
     }
     throw new IllegalArgumentException("Unknown document reference type: " + reference.getClass());
   }

--- a/connector-sdk/document/src/main/java/io/camunda/intrinsic/functions/DocumentFunction.java
+++ b/connector-sdk/document/src/main/java/io/camunda/intrinsic/functions/DocumentFunction.java
@@ -14,17 +14,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.camunda.document.reference;
+package io.camunda.intrinsic.functions;
 
-import io.camunda.client.api.response.DocumentReferenceResponse;
+import io.camunda.document.ExternalDocument;
+import io.camunda.intrinsic.IntrinsicFunction;
+import io.camunda.intrinsic.IntrinsicFunctionProvider;
+import javax.annotation.Nullable;
 
-public interface DocumentReference {
-
-  interface CamundaDocumentReference extends DocumentReference, DocumentReferenceResponse {}
-
-  interface ExternalDocumentReference extends DocumentReference {
-    String url();
-
-    String name();
+public class DocumentFunction implements IntrinsicFunctionProvider {
+  @IntrinsicFunction(name = "document")
+  public ExternalDocument execute(String url, @Nullable String name) {
+    return new ExternalDocument(url, name);
   }
 }

--- a/connector-sdk/document/src/main/resources/META-INF/services/io.camunda.intrinsic.IntrinsicFunctionProvider
+++ b/connector-sdk/document/src/main/resources/META-INF/services/io.camunda.intrinsic.IntrinsicFunctionProvider
@@ -2,3 +2,4 @@ io.camunda.intrinsic.functions.Base64Function
 io.camunda.intrinsic.functions.CreateLinkFunction
 io.camunda.intrinsic.functions.GetJsonFunction
 io.camunda.intrinsic.functions.GetTextFunction
+io.camunda.intrinsic.functions.DocumentFunction

--- a/connector-sdk/document/src/test/java/io/camunda/document/ExternalDocumentTest.java
+++ b/connector-sdk/document/src/test/java/io/camunda/document/ExternalDocumentTest.java
@@ -106,7 +106,12 @@ class ExternalDocumentTest {
             })) {
 
       RuntimeException exception =
-          assertThrows(RuntimeException.class, () -> new ExternalDocument(mockUrl, "fail.txt"));
+          assertThrows(
+              RuntimeException.class,
+              () -> {
+                var d = new ExternalDocument(mockUrl, "fail.txt");
+                d.asBase64();
+              });
 
       assertTrue(exception.getMessage().contains("Failed to connect to external document URL"));
     }

--- a/connector-sdk/document/src/test/java/io/camunda/document/ExternalDocumentTest.java
+++ b/connector-sdk/document/src/test/java/io/camunda/document/ExternalDocumentTest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.document;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import io.camunda.client.api.response.DocumentMetadata;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.Base64;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockedConstruction;
+import org.mockito.MockitoAnnotations;
+
+class ExternalDocumentTest {
+
+  @Mock HttpURLConnection mockConnection;
+
+  String mockUrl = "http://example.com";
+  byte[] fileContent = "test content".getBytes();
+
+  @BeforeEach
+  void setup() throws Exception {
+    MockitoAnnotations.openMocks(this);
+    when(mockConnection.getContentLengthLong()).thenReturn((long) fileContent.length);
+    when(mockConnection.getContentType()).thenReturn("application/pdf");
+    when(mockConnection.getInputStream()).thenReturn(new ByteArrayInputStream(fileContent));
+    when(mockConnection.getURL()).thenReturn(new URL(mockUrl));
+  }
+
+  @Test
+  void shouldLoadMetadataCorrectlyWithGivenName() throws Exception {
+    HttpURLConnection mockConnection = mock(HttpURLConnection.class);
+    when(mockConnection.getContentLengthLong()).thenReturn(1234L);
+    when(mockConnection.getContentType()).thenReturn("application/pdf");
+    URL fakeUrl = new URL("http://example.com");
+    ExternalDocument doc = new ExternalDocument(fakeUrl.toString(), "test.pdf", mockConnection);
+
+    DocumentMetadata metadata = doc.metadata();
+
+    assertEquals("test.pdf", metadata.getFileName());
+    assertEquals(1234L, metadata.getSize());
+    assertEquals("application/pdf", metadata.getContentType());
+  }
+
+  @Test
+  void shouldGenerateRandomFileNameIfNameIsNull() {
+    ExternalDocument doc = new ExternalDocument(mockUrl, null, mockConnection);
+    DocumentMetadata metadata = doc.metadata();
+
+    assertNotNull(metadata.getFileName());
+    assertDoesNotThrow(() -> UUID.fromString(metadata.getFileName()));
+  }
+
+  @Test
+  void shouldReturnCorrectBase64Content() {
+    ExternalDocument doc = new ExternalDocument(mockUrl, "test.txt", mockConnection);
+    String base64 = doc.asBase64();
+
+    assertEquals(Base64.getEncoder().encodeToString(fileContent), base64);
+  }
+
+  @Test
+  void shouldReturnByteArray() {
+    ExternalDocument doc = new ExternalDocument(mockUrl, "test.txt", mockConnection);
+    byte[] bytes = doc.asByteArray();
+
+    assertArrayEquals(fileContent, bytes);
+  }
+
+  @Test
+  void shouldReturnUrlAsLink() {
+    ExternalDocument doc = new ExternalDocument(mockUrl, "test.txt", mockConnection);
+
+    String link = doc.generateLink(null);
+    assertEquals(mockUrl, link);
+  }
+
+  @Test
+  void shouldThrowExceptionWhenConnectionFails() throws Exception {
+    try (MockedConstruction<URL> mockedURL =
+        mockConstruction(
+            URL.class,
+            (mockUrlObj, context) -> {
+              when(mockUrlObj.openConnection()).thenThrow(new IOException("Connection failed"));
+            })) {
+
+      RuntimeException exception =
+          assertThrows(RuntimeException.class, () -> new ExternalDocument(mockUrl, "fail.txt"));
+
+      assertTrue(exception.getMessage().contains("Failed to connect to external document URL"));
+    }
+  }
+}

--- a/connector-sdk/jackson-datatype-document/src/main/java/io/camunda/connector/document/jackson/DocumentReferenceModel.java
+++ b/connector-sdk/jackson-datatype-document/src/main/java/io/camunda/connector/document/jackson/DocumentReferenceModel.java
@@ -29,6 +29,7 @@ import io.camunda.connector.document.jackson.DocumentReferenceModel.ExternalDocu
 import io.camunda.document.reference.DocumentReference;
 import java.time.OffsetDateTime;
 import java.util.Map;
+import javax.annotation.Nullable;
 
 @JsonTypeInfo(
     use = JsonTypeInfo.Id.NAME,
@@ -132,7 +133,7 @@ public sealed interface DocumentReferenceModel extends DocumentReference {
     }
   }
 
-  record ExternalDocumentReferenceModel(String url)
+  record ExternalDocumentReferenceModel(String url, @Nullable String name)
       implements DocumentReferenceModel, ExternalDocumentReference {
 
     @JsonProperty(DISCRIMINATOR_KEY)


### PR DESCRIPTION
## Description
Added the `documents` intrinsic function.
I tested this with the teams and gcs connector.

docs PR: https://github.com/camunda/camunda-docs/pull/6232

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes [#4399](https://github.com/camunda/connectors/issues/4399)

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.
- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest release, as this branch will be rebased onto main before the next release.

