### PR TITLE
fix(vector-db,runtime): exclude Elasticsearch auto configuration as it auto-configures a RestClient + health check

### DIFF
--- a/bundle/camunda-saas-bundle/src/main/java/io/camunda/connector/runtime/saas/SaaSConnectorRuntimeApplication.java
+++ b/bundle/camunda-saas-bundle/src/main/java/io/camunda/connector/runtime/saas/SaaSConnectorRuntimeApplication.java
@@ -18,9 +18,10 @@ package io.camunda.connector.runtime.saas;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.elasticsearch.ElasticsearchRestClientAutoConfiguration;
 import org.springframework.context.annotation.ComponentScan;
 
-@SpringBootApplication
+@SpringBootApplication(exclude = {ElasticsearchRestClientAutoConfiguration.class})
 @ComponentScan(basePackages = "io.camunda.connector")
 public class SaaSConnectorRuntimeApplication {
 

--- a/connector-runtime/connector-runtime-application/src/main/java/io/camunda/connector/runtime/app/ConnectorRuntimeApplication.java
+++ b/connector-runtime/connector-runtime-application/src/main/java/io/camunda/connector/runtime/app/ConnectorRuntimeApplication.java
@@ -18,8 +18,9 @@ package io.camunda.connector.runtime.app;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.elasticsearch.ElasticsearchRestClientAutoConfiguration;
 
-@SpringBootApplication
+@SpringBootApplication(exclude = {ElasticsearchRestClientAutoConfiguration.class})
 public class ConnectorRuntimeApplication {
 
   public static void main(String[] args) {

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/app/TestConnectorRuntimeApplication.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/app/TestConnectorRuntimeApplication.java
@@ -19,8 +19,9 @@ package io.camunda.connector.runtime.app;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.elasticsearch.ElasticsearchRestClientAutoConfiguration;
 
-@SpringBootApplication
+@SpringBootApplication(exclude = {ElasticsearchRestClientAutoConfiguration.class})
 @ImportAutoConfiguration({
   io.camunda.connector.runtime.InboundConnectorsAutoConfiguration.class,
   io.camunda.connector.runtime.OutboundConnectorsAutoConfiguration.class,

--- a/connectors-e2e-test/connectors-e2e-test-base/src/main/java/io/camunda/connector/e2e/app/TestConnectorRuntimeApplication.java
+++ b/connectors-e2e-test/connectors-e2e-test-base/src/main/java/io/camunda/connector/e2e/app/TestConnectorRuntimeApplication.java
@@ -22,11 +22,12 @@ import io.camunda.document.store.InMemoryDocumentStore;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.elasticsearch.ElasticsearchRestClientAutoConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Primary;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
-@SpringBootApplication
+@SpringBootApplication(exclude = {ElasticsearchRestClientAutoConfiguration.class})
 @ImportAutoConfiguration({
   io.camunda.connector.runtime.InboundConnectorsAutoConfiguration.class,
   io.camunda.connector.runtime.OutboundConnectorsAutoConfiguration.class,


### PR DESCRIPTION
## Description

Spring Boot auto-configures an ElasticSearch client going to the default URL (localhost:9200) + a health check as soon as the ES library is available on the classpath. This excludes the autoconfiguration, leading to no ES beans and no health indicator for ES being produces out of the box.

## Related issues

closes #5118 

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.
- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest release, as this branch will be rebased onto main before the next release.

