### PR TITLE
test(fix-ut): use a know ID for the StartEvent creation in SearchQueryClientTest

### DIFF
--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/inbound/search/SearchQueryClientTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/inbound/search/SearchQueryClientTest.java
@@ -27,7 +27,6 @@ import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.stream.IntStream;
-import org.apache.commons.lang3.RandomStringUtils;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -98,7 +97,7 @@ public class SearchQueryClientTest {
               BpmnModelInstance modelInstance;
               modelInstance =
                   Bpmn.createExecutableProcess(processId)
-                      .startEvent(RandomStringUtils.insecure().nextAlphanumeric(5))
+                      .startEvent("StartEvent" + i)
                       .endEvent()
                       .done();
               camundaClient


### PR DESCRIPTION
## Description
Fix flaky test by using a known id for the StartEvent.
Using Random string created forbidden IDs from Zeebe's perspective.