### PR TITLE
test(agentic-ai): simplify e2e test setup with newly added CPT methods

### DIFF
--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/AiAgentTestFixtures.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/AiAgentTestFixtures.java
@@ -30,6 +30,7 @@ public interface AiAgentTestFixtures {
   String AD_HOC_TOOLS_SCHEMA_ELEMENT_TEMPLATE_PATH =
       "../../connectors/agentic-ai/element-templates/agenticai-adhoctoolsschema-outbound-connector.json";
 
+  String AGENT_RESPONSE_VARIABLE = "agent";
   String AI_AGENT_TASK_ID = "AI_Agent";
   Map<String, String> AI_AGENT_ELEMENT_TEMPLATE_PROPERTIES =
       Map.ofEntries(

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/langchain4j/BaseLangchain4JAiAgentTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/langchain4j/BaseLangchain4JAiAgentTests.java
@@ -173,12 +173,14 @@ abstract class BaseLangchain4JAiAgentTests extends BaseAiAgentTest {
 
     assertLastChatRequest(1, testSetup.getLeft(), assertToolSpecifications);
 
-    final var agentResponse = getAgentResponse(testSetup.getRight());
-    AgentResponseAssert.assertThat(agentResponse)
-        .isReady()
-        .hasNoToolCalls()
-        .hasMetrics(new AgentMetrics(1, new AgentMetrics.TokenUsage(10, 20)))
-        .satisfies(agentResponseAssertions);
+    assertAgentResponse(
+        testSetup.getRight(),
+        agentResponse ->
+            AgentResponseAssert.assertThat(agentResponse)
+                .isReady()
+                .hasNoToolCalls()
+                .hasMetrics(new AgentMetrics(1, new AgentMetrics.TokenUsage(10, 20)))
+                .satisfies(agentResponseAssertions));
 
     assertThat(jobWorkerCounter.get()).isEqualTo(1);
 
@@ -249,12 +251,14 @@ abstract class BaseLangchain4JAiAgentTests extends BaseAiAgentTest {
 
     assertLastChatRequest(3, testSetup.getLeft(), assertToolSpecifications);
 
-    final var agentResponse = getAgentResponse(testSetup.getRight());
-    AgentResponseAssert.assertThat(agentResponse)
-        .isReady()
-        .hasNoToolCalls()
-        .hasMetrics(new AgentMetrics(3, new AgentMetrics.TokenUsage(121, 242)))
-        .satisfies(agentResponseAssertions);
+    assertAgentResponse(
+        testSetup.getRight(),
+        agentResponse ->
+            AgentResponseAssert.assertThat(agentResponse)
+                .isReady()
+                .hasNoToolCalls()
+                .hasMetrics(new AgentMetrics(3, new AgentMetrics.TokenUsage(121, 242)))
+                .satisfies(agentResponseAssertions));
 
     assertThat(jobWorkerCounter.get()).isEqualTo(2);
 

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/langchain4j/Langchain4JAiAgentElementTemplateRegressionTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/langchain4j/Langchain4JAiAgentElementTemplateRegressionTests.java
@@ -110,15 +110,17 @@ public class Langchain4JAiAgentElementTemplateRegressionTests extends BaseLangch
 
     assertLastChatRequest(3, expectedConversation, false);
 
-    final var agentResponse = getAgentResponse(zeebeTest);
     String expectedResponseText = ((AiMessage) expectedConversation.getLast()).text();
-    AgentResponseAssert.assertThat(agentResponse)
-        .isReady()
-        .hasNoToolCalls()
-        .hasMetrics(new AgentMetrics(3, new AgentMetrics.TokenUsage(121, 242)))
-        .hasResponseText(expectedResponseText)
-        .hasNoResponseMessage()
-        .hasNoResponseJson();
+    assertAgentResponse(
+        zeebeTest,
+        agentResponse ->
+            AgentResponseAssert.assertThat(agentResponse)
+                .isReady()
+                .hasNoToolCalls()
+                .hasMetrics(new AgentMetrics(3, new AgentMetrics.TokenUsage(121, 242)))
+                .hasResponseText(expectedResponseText)
+                .hasNoResponseMessage()
+                .hasNoResponseJson());
 
     assertThat(jobWorkerCounter.get()).isEqualTo(2);
   }

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/langchain4j/Langchain4JAiAgentFeedbackLoopTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/langchain4j/Langchain4JAiAgentFeedbackLoopTests.java
@@ -117,14 +117,16 @@ public class Langchain4JAiAgentFeedbackLoopTests extends BaseLangchain4JAiAgentT
 
     assertLastChatRequest(2, expectedConversation);
 
-    final var agentResponse = getAgentResponse(zeebeTest);
     String expectedResponseText = ((AiMessage) expectedConversation.getLast()).text();
-    AgentResponseAssert.assertThat(agentResponse)
-        .isReady()
-        .hasNoToolCalls()
-        .hasMetrics(new AgentMetrics(2, new AgentMetrics.TokenUsage(21, 42)))
-        .hasResponseMessageText(expectedResponseText)
-        .hasResponseText(expectedResponseText);
+    assertAgentResponse(
+        zeebeTest,
+        agentResponse ->
+            AgentResponseAssert.assertThat(agentResponse)
+                .isReady()
+                .hasNoToolCalls()
+                .hasMetrics(new AgentMetrics(2, new AgentMetrics.TokenUsage(21, 42)))
+                .hasResponseMessageText(expectedResponseText)
+                .hasResponseText(expectedResponseText));
 
     assertThat(jobWorkerCounter.get()).isEqualTo(2);
   }

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/langchain4j/Langchain4JAiAgentLimitsTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/langchain4j/Langchain4JAiAgentLimitsTests.java
@@ -28,6 +28,8 @@ import dev.langchain4j.model.output.FinishReason;
 import dev.langchain4j.model.output.TokenUsage;
 import io.camunda.connector.agenticai.aiagent.memory.conversation.inprocess.InProcessConversationContext;
 import io.camunda.connector.agenticai.model.message.AssistantMessage;
+import io.camunda.connector.agenticai.model.message.SystemMessage;
+import io.camunda.connector.agenticai.model.message.UserMessage;
 import io.camunda.connector.e2e.ElementTemplate;
 import io.camunda.connector.test.SlowTest;
 import java.util.Map;
@@ -91,20 +93,23 @@ public class Langchain4JAiAgentLimitsTests extends BaseLangchain4JAiAgentTests {
                       .formatted(expectedMaxModelCalls));
         });
 
-    final var agentResponse = getAgentResponse(zeebeTest);
-    assertThat(agentResponse.context().metrics().modelCalls()).isEqualTo(expectedMaxModelCalls);
+    assertAgentResponse(
+        zeebeTest,
+        agentResponse -> {
+          assertThat(agentResponse.context().metrics().modelCalls())
+              .isEqualTo(expectedMaxModelCalls);
 
-    final var conversationMessages =
-        ((InProcessConversationContext) agentResponse.context().conversation()).messages();
-    assertThat(conversationMessages)
-        .filteredOn(
-            msg -> msg instanceof io.camunda.connector.agenticai.model.message.SystemMessage)
-        .hasSize(1);
-    assertThat(conversationMessages)
-        .filteredOn(msg -> msg instanceof AssistantMessage)
-        .hasSize(expectedMaxModelCalls);
-    assertThat(conversationMessages)
-        .filteredOn(msg -> msg instanceof io.camunda.connector.agenticai.model.message.UserMessage)
-        .hasSize(expectedMaxModelCalls);
+          final var conversationMessages =
+              ((InProcessConversationContext) agentResponse.context().conversation()).messages();
+          assertThat(conversationMessages)
+              .filteredOn(msg -> msg instanceof SystemMessage)
+              .hasSize(1);
+          assertThat(conversationMessages)
+              .filteredOn(msg -> msg instanceof AssistantMessage)
+              .hasSize(expectedMaxModelCalls);
+          assertThat(conversationMessages)
+              .filteredOn(msg -> msg instanceof UserMessage)
+              .hasSize(expectedMaxModelCalls);
+        });
   }
 }

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/langchain4j/Langchain4JAiAgentMcpIntegrationTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/langchain4j/Langchain4JAiAgentMcpIntegrationTests.java
@@ -217,14 +217,16 @@ public class Langchain4JAiAgentMcpIntegrationTests extends BaseLangchain4JAiAgen
 
     assertLastChatRequest(3, expectedConversation);
 
-    final var agentResponse = getAgentResponse(zeebeTest);
     String expectedResponseText = ((AiMessage) expectedConversation.getLast()).text();
-    AgentResponseAssert.assertThat(agentResponse)
-        .isReady()
-        .hasNoToolCalls()
-        .hasMetrics(new AgentMetrics(3, new AgentMetrics.TokenUsage(121, 242)))
-        .hasResponseMessageText(expectedResponseText)
-        .hasResponseText(expectedResponseText);
+    assertAgentResponse(
+        zeebeTest,
+        agentResponse ->
+            AgentResponseAssert.assertThat(agentResponse)
+                .isReady()
+                .hasNoToolCalls()
+                .hasMetrics(new AgentMetrics(3, new AgentMetrics.TokenUsage(121, 242)))
+                .hasResponseMessageText(expectedResponseText)
+                .hasResponseText(expectedResponseText));
 
     assertThat(jobWorkerCounter.get()).isEqualTo(2);
 

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/langchain4j/Langchain4JAiAgentToolCallingTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/langchain4j/Langchain4JAiAgentToolCallingTests.java
@@ -150,14 +150,16 @@ public class Langchain4JAiAgentToolCallingTests extends BaseLangchain4JAiAgentTe
 
     assertLastChatRequest(3, expectedConversation);
 
-    final var agentResponse = getAgentResponse(zeebeTest);
     String expectedResponseText = ((AiMessage) expectedConversation.getLast()).text();
-    AgentResponseAssert.assertThat(agentResponse)
-        .isReady()
-        .hasNoToolCalls()
-        .hasMetrics(new AgentMetrics(3, new AgentMetrics.TokenUsage(121, 242)))
-        .hasResponseMessageText(expectedResponseText)
-        .hasResponseText(expectedResponseText);
+    assertAgentResponse(
+        zeebeTest,
+        agentResponse ->
+            AgentResponseAssert.assertThat(agentResponse)
+                .isReady()
+                .hasNoToolCalls()
+                .hasMetrics(new AgentMetrics(3, new AgentMetrics.TokenUsage(121, 242)))
+                .hasResponseMessageText(expectedResponseText)
+                .hasResponseText(expectedResponseText));
 
     assertThat(jobWorkerCounter.get()).isEqualTo(2);
   }

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/langchain4j/Langchain4JAiAgentUserPromptDocumentsTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/langchain4j/Langchain4JAiAgentUserPromptDocumentsTests.java
@@ -98,14 +98,16 @@ public class Langchain4JAiAgentUserPromptDocumentsTests extends BaseLangchain4JA
 
     assertLastChatRequest(1, expectedConversation);
 
-    final var agentResponse = getAgentResponse(zeebeTest);
     String expectedResponseText = ((AiMessage) expectedConversation.getLast()).text();
-    AgentResponseAssert.assertThat(agentResponse)
-        .isReady()
-        .hasNoToolCalls()
-        .hasMetrics(new AgentMetrics(1, new AgentMetrics.TokenUsage(10, 20)))
-        .hasResponseMessageText(expectedResponseText)
-        .hasResponseText(expectedResponseText);
+    assertAgentResponse(
+        zeebeTest,
+        agentResponse ->
+            AgentResponseAssert.assertThat(agentResponse)
+                .isReady()
+                .hasNoToolCalls()
+                .hasMetrics(new AgentMetrics(1, new AgentMetrics.TokenUsage(10, 20)))
+                .hasResponseMessageText(expectedResponseText)
+                .hasResponseText(expectedResponseText));
 
     assertThat(jobWorkerCounter.get()).isEqualTo(1);
   }
@@ -153,14 +155,16 @@ public class Langchain4JAiAgentUserPromptDocumentsTests extends BaseLangchain4JA
 
     assertLastChatRequest(1, expectedConversation);
 
-    final var agentResponse = getAgentResponse(zeebeTest);
     String expectedResponseText = ((AiMessage) expectedConversation.getLast()).text();
-    AgentResponseAssert.assertThat(agentResponse)
-        .isReady()
-        .hasNoToolCalls()
-        .hasMetrics(new AgentMetrics(1, new AgentMetrics.TokenUsage(10, 20)))
-        .hasResponseMessageText(expectedResponseText)
-        .hasResponseText(expectedResponseText);
+    assertAgentResponse(
+        zeebeTest,
+        agentResponse ->
+            AgentResponseAssert.assertThat(agentResponse)
+                .isReady()
+                .hasNoToolCalls()
+                .hasMetrics(new AgentMetrics(1, new AgentMetrics.TokenUsage(10, 20)))
+                .hasResponseMessageText(expectedResponseText)
+                .hasResponseText(expectedResponseText));
 
     assertThat(jobWorkerCounter.get()).isEqualTo(1);
   }


### PR DESCRIPTION
## Description

With https://github.com/camunda/camunda/pull/35105 and https://github.com/camunda/camunda/pull/35171 implemented we can remove a bit of manual variable handling from e2e tests.

## Related issues

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.
- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest release, as this branch will be rebased onto main before the next release.

