### PR TITLE
refactor(connector-runtime): revert refactor outbound connector registration (#5124)

### DIFF
--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/ConnectorFactory.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/ConnectorFactory.java
@@ -41,4 +41,15 @@ public interface ConnectorFactory<T, C extends ConnectorConfiguration> {
    * @return Connector instance
    */
   T getInstance(String type);
+
+  /**
+   * Dynamically register a new Connector configuration. If a connector with the same type already
+   * exists, it will be overridden by the new configuration.
+   *
+   * @param configuration Configuration to register
+   */
+  void registerConfiguration(C configuration);
+
+  /** Reload all connectors from classpath and reset all manually registered connectors */
+  void resetConfigurations();
 }

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/DefaultInboundConnectorFactory.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/DefaultInboundConnectorFactory.java
@@ -93,6 +93,11 @@ public class DefaultInboundConnectorFactory implements InboundConnectorFactory {
     configurations.add(configuration);
   }
 
+  @Override
+  public void resetConfigurations() {
+    loadConnectorConfigurations();
+  }
+
   protected void loadConnectorConfigurations() {
     if (EnvVarsConnectorDiscovery.isInboundConfigured()) {
       configurations = EnvVarsConnectorDiscovery.discoverInbound();

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/InboundConnectorFactory.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/InboundConnectorFactory.java
@@ -23,13 +23,4 @@ import io.camunda.connector.runtime.core.config.InboundConnectorConfiguration;
 
 public interface InboundConnectorFactory
     extends ConnectorFactory<
-        InboundConnectorExecutable<InboundConnectorContext>, InboundConnectorConfiguration> {
-
-  /**
-   * Dynamically register a new Connector configuration. If a connector with the same type already
-   * exists, it will be overridden by the new configuration.
-   *
-   * @param configuration Configuration to register
-   */
-  void registerConfiguration(InboundConnectorConfiguration configuration);
-}
+        InboundConnectorExecutable<InboundConnectorContext>, InboundConnectorConfiguration> {}

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/outbound/OutboundConnectorDiscoveryTest.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/outbound/OutboundConnectorDiscoveryTest.java
@@ -19,15 +19,17 @@ package io.camunda.connector.runtime.core.outbound;
 import static io.camunda.connector.runtime.core.testutil.TestUtil.withEnvVars;
 
 import io.camunda.connector.runtime.core.config.OutboundConnectorConfiguration;
-import java.util.*;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class OutboundConnectorDiscoveryTest {
 
-  private static DefaultOutboundConnectorFactory getFactory(
-      OutboundConnectorConfiguration... configurations) {
-    return new DefaultOutboundConnectorFactory(List.of(configurations));
+  private static DefaultOutboundConnectorFactory getFactory() {
+    return new DefaultOutboundConnectorFactory(
+        OutboundConnectorDiscovery.loadConnectorConfigurations());
   }
 
   @Test
@@ -143,14 +145,16 @@ public class OutboundConnectorDiscoveryTest {
   @Test
   public void shouldOverrideWhenRegisteredManually() {
 
-    // given SPI configuration and manual registration
-    DefaultOutboundConnectorFactory factory =
-        getFactory(
-            new OutboundConnectorConfiguration(
-                "ANNOTATED",
-                new String[] {"foo", "bar"},
-                "io.camunda:annotated",
-                NotAnnotatedFunction.class));
+    // given SPI configuration
+    DefaultOutboundConnectorFactory factory = getFactory();
+
+    // when
+    factory.registerConfiguration(
+        new OutboundConnectorConfiguration(
+            "ANNOTATED",
+            new String[] {"foo", "bar"},
+            "io.camunda:annotated",
+            NotAnnotatedFunction.class));
 
     // then
     var registrations = factory.getConfigurations();

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/lifecycle/OutboundConnectorAnnotationProcessor.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/lifecycle/OutboundConnectorAnnotationProcessor.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.runtime.outbound.lifecycle;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.connector.api.annotation.OutboundConnector;
+import io.camunda.connector.api.outbound.OutboundConnectorFunction;
+import io.camunda.connector.runtime.core.config.ConnectorConfigurationOverrides;
+import io.camunda.connector.runtime.core.config.OutboundConnectorConfiguration;
+import io.camunda.connector.runtime.core.outbound.OutboundConnectorFactory;
+import io.camunda.spring.client.annotation.processor.AbstractCamundaAnnotationProcessor;
+import io.camunda.spring.client.bean.BeanInfo;
+import io.camunda.spring.client.bean.ClassInfo;
+import java.lang.invoke.MethodHandles;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.core.env.Environment;
+
+/** */
+public class OutboundConnectorAnnotationProcessor extends AbstractCamundaAnnotationProcessor {
+
+  private static final Logger LOGGER =
+      LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+  private final Environment environment;
+  private final OutboundConnectorManager outboundConnectorManager;
+  private final OutboundConnectorFactory outboundConnectorFactory;
+
+  public OutboundConnectorAnnotationProcessor(
+      Environment environment,
+      final OutboundConnectorManager outboundConnectorManager,
+      final OutboundConnectorFactory outboundConnectorFactory) {
+    this.environment = environment;
+    this.outboundConnectorManager = outboundConnectorManager;
+    this.outboundConnectorFactory = outboundConnectorFactory;
+  }
+
+  @Override
+  public boolean isApplicableFor(ClassInfo beanInfo) {
+    return beanInfo.hasClassAnnotation(OutboundConnector.class);
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public void configureFor(ClassInfo beanInfo) {
+    beanInfo
+        .getAnnotation(OutboundConnector.class)
+        .map(outboundConnector -> registerOutboundConnector(outboundConnector, beanInfo));
+  }
+
+  private OutboundConnectorConfiguration registerOutboundConnector(
+      OutboundConnector outboundConnector, BeanInfo beanInfo) {
+    final var configurationOverrides =
+        new ConnectorConfigurationOverrides(outboundConnector.name(), environment::getProperty);
+
+    OutboundConnectorConfiguration configuration =
+        new OutboundConnectorConfiguration(
+            outboundConnector.name(),
+            outboundConnector.inputVariables(),
+            configurationOverrides.typeOverride().orElse(outboundConnector.type()),
+            (Class<? extends OutboundConnectorFunction>) beanInfo.getTargetClass(),
+            () -> (OutboundConnectorFunction) beanInfo.getBean(),
+            configurationOverrides.timeoutOverride().orElse(null));
+    LOGGER.info(
+        "Configuring outbound connector {} of bean '{}'", configuration, beanInfo.getBeanName());
+    outboundConnectorFactory.registerConfiguration(configuration);
+    return configuration;
+  }
+
+  @Override
+  public void start(final CamundaClient client) {
+    outboundConnectorManager.start(client);
+  }
+
+  @Override
+  public void stop(CamundaClient client) {
+    outboundConnectorManager.stop();
+  }
+}

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/lifecycle/OutboundConnectorManager.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/lifecycle/OutboundConnectorManager.java
@@ -27,7 +27,6 @@ import io.camunda.connector.runtime.core.secret.SecretProviderAggregator;
 import io.camunda.connector.runtime.metrics.ConnectorsOutboundMetrics;
 import io.camunda.connector.runtime.outbound.jobhandling.SpringConnectorJobHandler;
 import io.camunda.document.factory.DocumentFactory;
-import io.camunda.spring.client.annotation.processor.CamundaClientLifecycleAware;
 import io.camunda.spring.client.annotation.value.JobWorkerValue;
 import io.camunda.spring.client.jobhandling.CommandExceptionHandlingStrategy;
 import io.camunda.spring.client.jobhandling.JobWorkerManager;
@@ -39,7 +38,7 @@ import java.util.TreeSet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class OutboundConnectorManager implements CamundaClientLifecycleAware {
+public class OutboundConnectorManager {
 
   private static final Logger LOG = LoggerFactory.getLogger(OutboundConnectorManager.class);
   private final JobWorkerManager jobWorkerManager;
@@ -70,8 +69,7 @@ public class OutboundConnectorManager implements CamundaClientLifecycleAware {
     this.outboundMetrics = outboundMetrics;
   }
 
-  @Override
-  public void onStart(final CamundaClient client) {
+  public void start(final CamundaClient client) {
     // Currently, existing Spring beans have a higher priority
     // One result is that you will not disable Spring Bean Connectors by providing environment
     // variables for a specific connector
@@ -82,8 +80,7 @@ public class OutboundConnectorManager implements CamundaClientLifecycleAware {
     outboundConnectors.forEach(connector -> openWorkerForOutboundConnector(client, connector));
   }
 
-  @Override
-  public void onStop(CamundaClient client) {
+  public void stop() {
     jobWorkerManager.closeAllOpenWorkers();
   }
 

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/lifecycle/OutboundConnectorAnnotationProcessorTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/lifecycle/OutboundConnectorAnnotationProcessorTest.java
@@ -17,33 +17,49 @@
 package io.camunda.connector.runtime.outbound.lifecycle;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
 
+import io.camunda.client.CamundaClient;
 import io.camunda.connector.api.annotation.OutboundConnector;
 import io.camunda.connector.api.outbound.OutboundConnectorContext;
 import io.camunda.connector.api.outbound.OutboundConnectorFunction;
 import io.camunda.connector.runtime.core.config.OutboundConnectorConfiguration;
 import io.camunda.connector.runtime.core.outbound.OutboundConnectorFactory;
-import io.camunda.connector.runtime.outbound.OutboundConnectorRuntimeConfiguration;
-import java.util.List;
-import org.assertj.core.api.Assertions;
 import org.assertj.core.api.ThrowingConsumer;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Component;
 
+@ExtendWith(MockitoExtension.class)
 class OutboundConnectorAnnotationProcessorTest {
+
+  @Mock private CamundaClient camundaClient;
+  @Mock private OutboundConnectorManager outboundConnectorManager;
+  @Mock private OutboundConnectorFactory outboundConnectorFactory;
+
+  @Captor private ArgumentCaptor<OutboundConnectorConfiguration> registeredConfigurationCaptor;
 
   private final ApplicationContextRunner contextRunner =
       new ApplicationContextRunner()
+          .withBean(CamundaClient.class, () -> camundaClient)
+          .withBean(OutboundConnectorManager.class, () -> outboundConnectorManager)
+          .withBean(OutboundConnectorFactory.class, () -> outboundConnectorFactory)
           .withUserConfiguration(TestConfig.class, AnnotatedFunction.class);
 
   private static class TestConfig {
     @Bean
-    public OutboundConnectorFactory outboundFactory(
-        Environment env, List<OutboundConnectorFunction> functions) {
-      return (new OutboundConnectorRuntimeConfiguration()).outboundConnectorFactory(env, functions);
+    public OutboundConnectorAnnotationProcessor annotationProcessor(
+        Environment environment,
+        OutboundConnectorManager manager,
+        OutboundConnectorFactory factory) {
+      return new OutboundConnectorAnnotationProcessor(environment, manager, factory);
     }
   }
 
@@ -106,17 +122,12 @@ class OutboundConnectorAnnotationProcessorTest {
       ThrowingConsumer<OutboundConnectorConfiguration> configurationAssertions) {
     configuredContextRunner.run(
         context -> {
-          var outboundConnectorFactory = context.getBean(OutboundConnectorFactory.class);
-          Assertions.assertThatList(outboundConnectorFactory.getConfigurations())
-              .anyMatch(
-                  e -> {
-                    try {
-                      configurationAssertions.accept(e);
-                      return true;
-                    } catch (Exception ex) {
-                      return false;
-                    }
-                  });
+          context.getBean(OutboundConnectorAnnotationProcessor.class).onStart(camundaClient);
+
+          verify(outboundConnectorFactory)
+              .registerConfiguration(registeredConfigurationCaptor.capture());
+
+          assertThat(registeredConfigurationCaptor.getValue()).satisfies(configurationAssertions);
         });
   }
 }


### PR DESCRIPTION
## Description

This reverts commit 04f67524e01449a60457d89d8c687bbdce75c6bd.
This approach is incompatible with #4980

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #

## Checklist

- [ ] PR has a **milestone** or the `no milestone` label.
- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest release, as this branch will be rebased onto main before the next release.

