### PR TITLE
feat(agentic-ai): support service account credentials for VertexAI

### DIFF
--- a/connectors/agentic-ai/element-templates/agenticai-aiagent-outbound-connector.json
+++ b/connectors/agentic-ai/element-templates/agenticai-aiagent-outbound-connector.json
@@ -97,7 +97,7 @@
       "name" : "Azure OpenAI",
       "value" : "azureOpenAi"
     }, {
-      "name" : "Google Vertex AI (Hybrid/Self-Managed only)",
+      "name" : "Google Vertex AI",
       "value" : "google-vertex-ai"
     }, {
       "name" : "OpenAI",
@@ -458,6 +458,55 @@
       "property" : "provider.type",
       "equals" : "google-vertex-ai",
       "type" : "simple"
+    },
+    "type" : "String"
+  }, {
+    "id" : "provider.googleVertexAi.authentication.type",
+    "label" : "Authentication",
+    "description" : "Specify the Google Vertex AI authentication strategy.",
+    "value" : "serviceAccountCredentials",
+    "group" : "provider",
+    "binding" : {
+      "name" : "provider.googleVertexAi.authentication.type",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "provider.type",
+      "equals" : "google-vertex-ai",
+      "type" : "simple"
+    },
+    "type" : "Dropdown",
+    "choices" : [ {
+      "name" : "Service account credentials",
+      "value" : "serviceAccountCredentials"
+    }, {
+      "name" : "Application default credentials (Hybrid/Self-Managed only)",
+      "value" : "applicationDefaultCredentials"
+    } ]
+  }, {
+    "id" : "provider.googleVertexAi.authentication.jsonKey",
+    "label" : "JSON key of the service account",
+    "description" : "This is the key of the service account in JSON format.",
+    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "provider",
+    "binding" : {
+      "name" : "provider.googleVertexAi.authentication.jsonKey",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "allMatch" : [ {
+        "property" : "provider.googleVertexAi.authentication.type",
+        "equals" : "serviceAccountCredentials",
+        "type" : "simple"
+      }, {
+        "property" : "provider.type",
+        "equals" : "google-vertex-ai",
+        "type" : "simple"
+      } ]
     },
     "type" : "String"
   }, {

--- a/connectors/agentic-ai/element-templates/hybrid/agenticai-aiagent-outbound-connector-hybrid.json
+++ b/connectors/agentic-ai/element-templates/hybrid/agenticai-aiagent-outbound-connector-hybrid.json
@@ -102,7 +102,7 @@
       "name" : "Azure OpenAI",
       "value" : "azureOpenAi"
     }, {
-      "name" : "Google Vertex AI (Hybrid/Self-Managed only)",
+      "name" : "Google Vertex AI",
       "value" : "google-vertex-ai"
     }, {
       "name" : "OpenAI",
@@ -463,6 +463,55 @@
       "property" : "provider.type",
       "equals" : "google-vertex-ai",
       "type" : "simple"
+    },
+    "type" : "String"
+  }, {
+    "id" : "provider.googleVertexAi.authentication.type",
+    "label" : "Authentication",
+    "description" : "Specify the Google Vertex AI authentication strategy.",
+    "value" : "serviceAccountCredentials",
+    "group" : "provider",
+    "binding" : {
+      "name" : "provider.googleVertexAi.authentication.type",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "provider.type",
+      "equals" : "google-vertex-ai",
+      "type" : "simple"
+    },
+    "type" : "Dropdown",
+    "choices" : [ {
+      "name" : "Service account credentials",
+      "value" : "serviceAccountCredentials"
+    }, {
+      "name" : "Application default credentials (Hybrid/Self-Managed only)",
+      "value" : "applicationDefaultCredentials"
+    } ]
+  }, {
+    "id" : "provider.googleVertexAi.authentication.jsonKey",
+    "label" : "JSON key of the service account",
+    "description" : "This is the key of the service account in JSON format.",
+    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "provider",
+    "binding" : {
+      "name" : "provider.googleVertexAi.authentication.jsonKey",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "allMatch" : [ {
+        "property" : "provider.googleVertexAi.authentication.type",
+        "equals" : "serviceAccountCredentials",
+        "type" : "simple"
+      }, {
+        "property" : "provider.type",
+        "equals" : "google-vertex-ai",
+        "type" : "simple"
+      } ]
     },
     "type" : "String"
   }, {

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/ChatModelFactoryImpl.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/ChatModelFactoryImpl.java
@@ -44,7 +44,7 @@ import software.amazon.awssdk.services.bedrockruntime.BedrockRuntimeClient;
 
 public class ChatModelFactoryImpl implements ChatModelFactory {
 
-  private static final Logger log = LoggerFactory.getLogger(ChatModelFactoryImpl.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(ChatModelFactoryImpl.class);
 
   @Override
   public ChatModel createChatModel(ProviderConfiguration providerConfiguration) {
@@ -168,9 +168,7 @@ public class ChatModelFactoryImpl implements ChatModelFactory {
             .modelName(connection.model().model());
 
     if (connection.authentication() instanceof ServiceAccountCredentialsAuthentication sac) {
-      ServiceAccountCredentials serviceAccountCredentials = createServiceAccountCredentials(sac);
-      builder.credentials(
-          serviceAccountCredentials.createScoped("https://www.googleapis.com/auth/cloud-platform"));
+      builder.credentials(createGoogleServiceAccountCredentials(sac));
     }
 
     final var modelParameters = connection.model().parameters();
@@ -184,13 +182,13 @@ public class ChatModelFactoryImpl implements ChatModelFactory {
     return builder;
   }
 
-  private ServiceAccountCredentials createServiceAccountCredentials(
+  private ServiceAccountCredentials createGoogleServiceAccountCredentials(
       ServiceAccountCredentialsAuthentication sac) {
     try {
       return ServiceAccountCredentials.fromStream(
           new ByteArrayInputStream(sac.jsonKey().getBytes(StandardCharsets.UTF_8)));
     } catch (IOException e) {
-      log.error("Failed to parse service account credentials", e);
+      LOGGER.error("Failed to parse service account credentials", e);
       throw new ConnectorInputException(
           "Authentication failed for provided service account credentials", e);
     }

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/provider/GoogleVertexAiProviderConfiguration.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/provider/GoogleVertexAiProviderConfiguration.java
@@ -8,8 +8,11 @@ package io.camunda.connector.agenticai.aiagent.model.request.provider;
 
 import static io.camunda.connector.agenticai.aiagent.model.request.provider.GoogleVertexAiProviderConfiguration.GOOGLE_VERTEX_AI_ID;
 
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import io.camunda.connector.agenticai.util.ConnectorUtils;
 import io.camunda.connector.generator.dsl.Property;
+import io.camunda.connector.generator.java.annotation.TemplateDiscriminatorProperty;
 import io.camunda.connector.generator.java.annotation.TemplateProperty;
 import io.camunda.connector.generator.java.annotation.TemplateSubType;
 import jakarta.validation.Valid;
@@ -18,7 +21,7 @@ import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
-@TemplateSubType(id = GOOGLE_VERTEX_AI_ID, label = "Google Vertex AI (Hybrid/Self-Managed only)")
+@TemplateSubType(id = GOOGLE_VERTEX_AI_ID, label = "Google Vertex AI")
 public record GoogleVertexAiProviderConfiguration(
     @Valid @NotNull GoogleVertexAiConnection googleVertexAi) implements ProviderConfiguration {
 
@@ -44,12 +47,52 @@ public record GoogleVertexAiProviderConfiguration(
               feel = Property.FeelMode.optional,
               constraints = @TemplateProperty.PropertyConstraints(notEmpty = true))
           String location,
+      @Valid @NotNull GoogleVertexAiAuthentication authentication,
       @Valid @NotNull GoogleVertexAiProviderConfiguration.GoogleVertexAiModel model) {
 
     @AssertFalse(message = "Google Vertex AI is not supported on SaaS")
     public boolean isUsedInSaaS() {
-      return ConnectorUtils.isSaaS();
+      return ConnectorUtils.isSaaS()
+          && authentication
+              instanceof GoogleVertexAiAuthentication.ApplicationDefaultCredentialsAuthentication;
     }
+  }
+
+  @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+  @JsonSubTypes({
+    @JsonSubTypes.Type(
+        value = GoogleVertexAiAuthentication.ServiceAccountCredentialsAuthentication.class,
+        name = "serviceAccountCredentials"),
+    @JsonSubTypes.Type(
+        value = GoogleVertexAiAuthentication.ApplicationDefaultCredentialsAuthentication.class,
+        name = "applicationDefaultCredentials"),
+  })
+  @TemplateDiscriminatorProperty(
+      label = "Authentication",
+      group = "provider",
+      name = "type",
+      defaultValue = "serviceAccountCredentials",
+      description = "Specify the Google Vertex AI authentication strategy.")
+  public sealed interface GoogleVertexAiAuthentication {
+    @TemplateSubType(id = "serviceAccountCredentials", label = "Service account credentials")
+    record ServiceAccountCredentialsAuthentication(
+        @TemplateProperty(
+                group = "provider",
+                label = "JSON key of the service account",
+                description = "This is the key of the service account in JSON format.")
+            @NotBlank
+            String jsonKey)
+        implements GoogleVertexAiAuthentication {
+      @Override
+      public String toString() {
+        return "ServiceAccountCredentialsAuthentication{jsonKey=[REDACTED]}";
+      }
+    }
+
+    @TemplateSubType(
+        id = "applicationDefaultCredentials",
+        label = "Application default credentials (Hybrid/Self-Managed only)")
+    record ApplicationDefaultCredentialsAuthentication() implements GoogleVertexAiAuthentication {}
   }
 
   public record GoogleVertexAiModel(

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/provider/GoogleVertexAiProviderConfiguration.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/provider/GoogleVertexAiProviderConfiguration.java
@@ -76,11 +76,13 @@ public record GoogleVertexAiProviderConfiguration(
   public sealed interface GoogleVertexAiAuthentication {
     @TemplateSubType(id = "serviceAccountCredentials", label = "Service account credentials")
     record ServiceAccountCredentialsAuthentication(
-        @TemplateProperty(
+        @NotBlank
+            @TemplateProperty(
                 group = "provider",
                 label = "JSON key of the service account",
-                description = "This is the key of the service account in JSON format.")
-            @NotBlank
+                description = "This is the key of the service account in JSON format.",
+                feel = Property.FeelMode.optional,
+                constraints = @TemplateProperty.PropertyConstraints(notEmpty = true))
             String jsonKey)
         implements GoogleVertexAiAuthentication {
       @Override

--- a/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/ChatModelFactoryTest.java
+++ b/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/ChatModelFactoryTest.java
@@ -11,13 +11,18 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyDouble;
 import static org.mockito.ArgumentMatchers.anyFloat;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import com.azure.core.credential.TokenCredential;
 import com.azure.identity.ClientSecretCredential;
+import com.google.auth.oauth2.ServiceAccountCredentials;
 import dev.langchain4j.model.anthropic.AnthropicChatModel;
 import dev.langchain4j.model.anthropic.AnthropicChatModel.AnthropicChatModelBuilder;
 import dev.langchain4j.model.azure.AzureOpenAiChatModel;
@@ -46,6 +51,7 @@ import io.camunda.connector.agenticai.aiagent.model.request.provider.BedrockProv
 import io.camunda.connector.agenticai.aiagent.model.request.provider.BedrockProviderConfiguration.BedrockModel.BedrockModelParameters;
 import io.camunda.connector.agenticai.aiagent.model.request.provider.GoogleVertexAiProviderConfiguration;
 import io.camunda.connector.agenticai.aiagent.model.request.provider.GoogleVertexAiProviderConfiguration.GoogleVertexAiAuthentication.ApplicationDefaultCredentialsAuthentication;
+import io.camunda.connector.agenticai.aiagent.model.request.provider.GoogleVertexAiProviderConfiguration.GoogleVertexAiAuthentication.ServiceAccountCredentialsAuthentication;
 import io.camunda.connector.agenticai.aiagent.model.request.provider.GoogleVertexAiProviderConfiguration.GoogleVertexAiConnection;
 import io.camunda.connector.agenticai.aiagent.model.request.provider.GoogleVertexAiProviderConfiguration.GoogleVertexAiModel;
 import io.camunda.connector.agenticai.aiagent.model.request.provider.GoogleVertexAiProviderConfiguration.GoogleVertexAiModel.GoogleVertexAiModelParameters;
@@ -67,7 +73,6 @@ import org.mockito.Answers;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.MockedStatic;
-import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.stubbing.Answer;
@@ -160,7 +165,7 @@ class ChatModelFactoryTest {
       doAnswer(chatModelResultCaptor).when(chatModelBuilder).build();
 
       try (MockedStatic<AnthropicChatModel> chatModelMock =
-          Mockito.mockStatic(AnthropicChatModel.class, Answers.CALLS_REAL_METHODS)) {
+          mockStatic(AnthropicChatModel.class, Answers.CALLS_REAL_METHODS)) {
         chatModelMock.when(AnthropicChatModel::builder).thenReturn(chatModelBuilder);
 
         final var chatModel = chatModelFactory.createChatModel(providerConfig);
@@ -269,7 +274,7 @@ class ChatModelFactoryTest {
       doAnswer(chatModelResultCaptor).when(chatModelBuilder).build();
 
       try (MockedStatic<AzureOpenAiChatModel> chatModelMock =
-          Mockito.mockStatic(AzureOpenAiChatModel.class, Answers.CALLS_REAL_METHODS)) {
+          mockStatic(AzureOpenAiChatModel.class, Answers.CALLS_REAL_METHODS)) {
         chatModelMock.when(AzureOpenAiChatModel::builder).thenReturn(chatModelBuilder);
 
         final var chatModel = chatModelFactory.createChatModel(providerConfig);
@@ -432,9 +437,9 @@ class ChatModelFactoryTest {
       doAnswer(chatModelResultCaptor).when(chatModelBuilder).build();
 
       try (MockedStatic<BedrockRuntimeClient> clientMock =
-              Mockito.mockStatic(BedrockRuntimeClient.class, Answers.CALLS_REAL_METHODS);
+              mockStatic(BedrockRuntimeClient.class, Answers.CALLS_REAL_METHODS);
           MockedStatic<BedrockChatModel> chatModelMock =
-              Mockito.mockStatic(BedrockChatModel.class, Answers.CALLS_REAL_METHODS)) {
+              mockStatic(BedrockChatModel.class, Answers.CALLS_REAL_METHODS)) {
         clientMock.when(BedrockRuntimeClient::builder).thenReturn(clientBuilder);
         chatModelMock.when(BedrockChatModel::builder).thenReturn(chatModelBuilder);
 
@@ -515,6 +520,40 @@ class ChatModelFactoryTest {
           });
     }
 
+    @Test
+    void createsGoogleVertexAiChatModelWithServiceAccountCredential() {
+      final var providerConfig =
+          new GoogleVertexAiProviderConfiguration(
+              new GoogleVertexAiConnection(
+                  PROJECT_ID,
+                  LOCATION,
+                  new ServiceAccountCredentialsAuthentication("{}"),
+                  new GoogleVertexAiModel(MODEL, DEFAULT_MODEL_PARAMETERS)));
+
+      try (final var staticMockedSac = mockStatic(ServiceAccountCredentials.class)) {
+        final var mockedSac = mock(ServiceAccountCredentials.class);
+        when(mockedSac.createScoped(anyString())).thenReturn(mockedSac);
+        staticMockedSac
+            .when(() -> ServiceAccountCredentials.fromStream(any()))
+            .thenReturn(mockedSac);
+
+        testGoogleVertexAiChatModelBuilder(
+            providerConfig,
+            (builder) -> {
+              verify(builder).location(LOCATION);
+              verify(builder).project(PROJECT_ID);
+              verify(builder).credentials(mockedSac);
+              verify(builder).modelName(MODEL);
+              verify(builder).maxOutputTokens(DEFAULT_MODEL_PARAMETERS.maxOutputTokens());
+              verify(builder).temperature(DEFAULT_MODEL_PARAMETERS.temperature());
+              verify(builder).topP(DEFAULT_MODEL_PARAMETERS.topP());
+              verify(builder).topK(DEFAULT_MODEL_PARAMETERS.topK());
+            });
+
+        staticMockedSac.verify(() -> ServiceAccountCredentials.fromStream(any()));
+      }
+    }
+
     private void testGoogleVertexAiChatModelBuilder(
         GoogleVertexAiProviderConfiguration providerConfig,
         ThrowingConsumer<VertexAiGeminiChatModelBuilder> builderAssertions) {
@@ -523,7 +562,7 @@ class ChatModelFactoryTest {
       doAnswer(chatModelResultCaptor).when(chatModelBuilder).build();
 
       try (MockedStatic<VertexAiGeminiChatModel> chatModelMock =
-          Mockito.mockStatic(VertexAiGeminiChatModel.class, Answers.CALLS_REAL_METHODS)) {
+          mockStatic(VertexAiGeminiChatModel.class, Answers.CALLS_REAL_METHODS)) {
         chatModelMock.when(VertexAiGeminiChatModel::builder).thenReturn(chatModelBuilder);
 
         final var chatModel = chatModelFactory.createChatModel(providerConfig);
@@ -658,7 +697,7 @@ class ChatModelFactoryTest {
       doAnswer(chatModelResultCaptor).when(chatModelBuilder).build();
 
       try (MockedStatic<OpenAiChatModel> chatModelMock =
-          Mockito.mockStatic(OpenAiChatModel.class, Answers.CALLS_REAL_METHODS)) {
+          mockStatic(OpenAiChatModel.class, Answers.CALLS_REAL_METHODS)) {
         chatModelMock.when(OpenAiChatModel::builder).thenReturn(chatModelBuilder);
 
         final var chatModel = chatModelFactory.createChatModel(providerConfig);

--- a/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/ChatModelFactoryTest.java
+++ b/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/ChatModelFactoryTest.java
@@ -45,6 +45,7 @@ import io.camunda.connector.agenticai.aiagent.model.request.provider.BedrockProv
 import io.camunda.connector.agenticai.aiagent.model.request.provider.BedrockProviderConfiguration.BedrockModel;
 import io.camunda.connector.agenticai.aiagent.model.request.provider.BedrockProviderConfiguration.BedrockModel.BedrockModelParameters;
 import io.camunda.connector.agenticai.aiagent.model.request.provider.GoogleVertexAiProviderConfiguration;
+import io.camunda.connector.agenticai.aiagent.model.request.provider.GoogleVertexAiProviderConfiguration.GoogleVertexAiAuthentication.ApplicationDefaultCredentialsAuthentication;
 import io.camunda.connector.agenticai.aiagent.model.request.provider.GoogleVertexAiProviderConfiguration.GoogleVertexAiConnection;
 import io.camunda.connector.agenticai.aiagent.model.request.provider.GoogleVertexAiProviderConfiguration.GoogleVertexAiModel;
 import io.camunda.connector.agenticai.aiagent.model.request.provider.GoogleVertexAiProviderConfiguration.GoogleVertexAiModel.GoogleVertexAiModelParameters;
@@ -473,7 +474,10 @@ class ChatModelFactoryTest {
       final var providerConfig =
           new GoogleVertexAiProviderConfiguration(
               new GoogleVertexAiConnection(
-                  PROJECT_ID, LOCATION, new GoogleVertexAiModel(MODEL, DEFAULT_MODEL_PARAMETERS)));
+                  PROJECT_ID,
+                  LOCATION,
+                  new ApplicationDefaultCredentialsAuthentication(),
+                  new GoogleVertexAiModel(MODEL, DEFAULT_MODEL_PARAMETERS)));
 
       testGoogleVertexAiChatModelBuilder(
           providerConfig,
@@ -496,7 +500,10 @@ class ChatModelFactoryTest {
       final var providerConfig =
           new GoogleVertexAiProviderConfiguration(
               new GoogleVertexAiConnection(
-                  PROJECT_ID, LOCATION, new GoogleVertexAiModel(MODEL, modelParameters)));
+                  PROJECT_ID,
+                  LOCATION,
+                  new ApplicationDefaultCredentialsAuthentication(),
+                  new GoogleVertexAiModel(MODEL, modelParameters)));
 
       testGoogleVertexAiChatModelBuilder(
           providerConfig,

--- a/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/model/request/ProviderConfigurationTest.java
+++ b/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/model/request/ProviderConfigurationTest.java
@@ -113,6 +113,8 @@ class ProviderConfigurationTest {
       return new GoogleVertexAiProviderConfiguration.GoogleVertexAiConnection(
           "my-project-id",
           "us-central1",
+          new GoogleVertexAiProviderConfiguration.GoogleVertexAiAuthentication
+              .ApplicationDefaultCredentialsAuthentication(),
           new GoogleVertexAiProviderConfiguration.GoogleVertexAiModel(
               "gemini-1.5-flash",
               new GoogleVertexAiProviderConfiguration.GoogleVertexAiModel

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -151,7 +151,7 @@ limitations under the License.</license.inlineheader>
     <version.auth0.jwt>4.5.0</version.auth0.jwt>
     <version.auth0.jwks>0.22.2</version.auth0.jwks>
     
-    <version.langchain4j>1.1.0</version.langchain4j>
+    <version.langchain4j>1.2.0</version.langchain4j>
 
     <!-- maven plugins (not managed by parent) -->
     <plugin.version.maven-enforcer-plugin>3.6.1</plugin.version.maven-enforcer-plugin>


### PR DESCRIPTION
## Description

The latest L4J release,1.2.0, supports other Google authentication methods than the only supported method of application default credentials. We can now support service account credentials.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #5095 

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.
- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest release, as this branch will be rebased onto main before the next release.

