### PR TITLE
fix(rest): do not add JSON content type if there's no request body

### DIFF
--- a/http-client/src/main/java/io/camunda/connector/http/client/client/apache/builder/parts/ApacheRequestHeadersBuilder.java
+++ b/http-client/src/main/java/io/camunda/connector/http/client/client/apache/builder/parts/ApacheRequestHeadersBuilder.java
@@ -36,7 +36,7 @@ public class ApacheRequestHeadersBuilder implements ApacheRequestPartBuilder {
 
     var hasContentTypeHeader =
         headers.entrySet().stream().anyMatch(e -> e.getKey().equalsIgnoreCase(CONTENT_TYPE));
-    if (request.getMethod().supportsBody && !hasContentTypeHeader) {
+    if (request.getMethod().supportsBody && request.hasBody() && !hasContentTypeHeader) {
       // default content type
       builder.addHeader(CONTENT_TYPE, APPLICATION_JSON.getMimeType());
     }

--- a/http-client/src/test/java/io/camunda/connector/http/client/client/apache/ApacheRequestFactoryTest.java
+++ b/http-client/src/test/java/io/camunda/connector/http/client/client/apache/ApacheRequestFactoryTest.java
@@ -551,11 +551,12 @@ public class ApacheRequestFactoryTest {
 
     @ParameterizedTest
     @EnumSource(HttpMethod.class)
-    public void shouldSetContentType_whenNullProvidedAndPost(HttpMethod method)
+    public void shouldSetContentType_whenNullProvidedAndPostAndBody(HttpMethod method)
         throws ProtocolException {
       // given request without content type
       HttpClientRequest request = new HttpClientRequest();
       request.setMethod(method);
+      request.setBody(Map.of("key", "value"));
       Map<String, String> headers = new HashMap<>();
       headers.put(HttpHeaders.CONTENT_TYPE, null);
       headers.put(HttpHeaders.ACCEPT, null);
@@ -576,11 +577,13 @@ public class ApacheRequestFactoryTest {
     }
 
     @Test
-    public void shouldSetJsonContentType_WhenNotProvidedAndSupportsBody() throws Exception {
+    public void shouldSetJsonContentType_WhenNotProvidedAndSupportsBodyAndHasBody()
+        throws Exception {
       // given request without headers
       HttpClientRequest request = new HttpClientRequest();
       request.setMethod(HttpMethod.POST);
       request.setUrl("theurl");
+      request.setBody(Map.of("key", "value"));
 
       // when
       ClassicHttpRequest httpRequest = ApacheRequestFactory.get().createHttpRequest(request);
@@ -591,13 +594,32 @@ public class ApacheRequestFactoryTest {
       assertThat(headers.getValue()).isEqualTo(ContentType.APPLICATION_JSON.getMimeType());
     }
 
-    @Test
-    public void shouldSetJsonContentType_WhenNotProvidedAndSupportsBodyAndSomeHeadersExist()
+    @ParameterizedTest
+    @EnumSource(HttpMethod.class)
+    public void shouldNotAddContentType_WhenNotProvidedAndDoesNotSupportBody(HttpMethod method)
         throws Exception {
+      // given request without headers
+      HttpClientRequest request = new HttpClientRequest();
+      request.setMethod(method);
+      request.setUrl("theurl");
+
+      // when
+      ClassicHttpRequest httpRequest = ApacheRequestFactory.get().createHttpRequest(request);
+
+      // then
+      Header headers = httpRequest.getHeader(HttpHeaders.CONTENT_TYPE);
+      assertNull(headers);
+    }
+
+    @Test
+    public void
+        shouldSetJsonContentType_WhenNotProvidedAndSupportsBodyAndSomeHeadersExistAndHasBody()
+            throws Exception {
       // given request without headers
       HttpClientRequest request = new HttpClientRequest();
       request.setHeaders(Map.of("Authorization", "Bearer token"));
       request.setMethod(HttpMethod.POST);
+      request.setBody(Map.of("key", "value", "key2", "value2"));
       request.setUrl("theurl");
 
       // when


### PR DESCRIPTION
## Description

Do not add a ContentType header if there's no body


## Related issues

<!-- Which issues are closed by this PR or are related -->

closes https://github.com/camunda/connectors/issues/5075

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.
- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest release, as this branch will be rebased onto main before the next release.

