### PR TITLE
other(logging): log the exception when an error occurs

### DIFF
--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/outbound/ConnectorJobHandler.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/outbound/ConnectorJobHandler.java
@@ -194,7 +194,8 @@ public class ConnectorJobHandler implements JobHandler {
           "Exception while completing job: {} for tenant: {}, message: {}",
           job.getKey(),
           job.getTenantId(),
-          errorResult.exception().getMessage());
+          errorResult.exception().getMessage(),
+          errorResult.exception());
       failJob(jobClient, job, errorResult);
     }
   }

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/outbound/ConnectorJobHandler.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/outbound/ConnectorJobHandler.java
@@ -191,9 +191,8 @@ public class ConnectorJobHandler implements JobHandler {
       // Handle Java error, e.g. ConnectorException
       // these errors won't be handled ConnectorHelper.examineErrorExpression
       LOGGER.error(
-          "Exception while completing job: {} for tenant: {}, message: {}",
-          job.getKey(),
-          job.getTenantId(),
+          "Exception while completing job: {}, message: {}",
+          JobForLog.from(job),
           errorResult.exception().getMessage(),
           errorResult.exception());
       failJob(jobClient, job, errorResult);
@@ -236,5 +235,27 @@ public class ConnectorJobHandler implements JobHandler {
 
   protected void throwBpmnError(JobClient client, ActivatedJob job, BpmnError value) {
     prepareThrowBpmnErrorCommand(client, job, value).send().join();
+  }
+
+  record JobForLog(
+      Long key,
+      Map<String, String> customHeaders,
+      String tenantId,
+      String bpmnProcessId,
+      String type,
+      Long processDefinitionKey,
+      Integer processDefinitionVersion,
+      Long processInstanceKey) {
+    public static JobForLog from(ActivatedJob job) {
+      return new JobForLog(
+          job.getKey(),
+          job.getCustomHeaders(),
+          job.getTenantId(),
+          job.getBpmnProcessId(),
+          job.getType(),
+          job.getProcessDefinitionKey(),
+          job.getProcessDefinitionVersion(),
+          job.getProcessInstanceKey());
+    }
   }
 }


### PR DESCRIPTION
## Description

Log the exception in ConnectorJobHandler when an error occurs. Previously, we were logging the exception's message only.
Here's an example of the new log:
```
Exception while completing job: JobForLog[key=2251799813982047, customHeaders={elementTemplateId=io.camunda.connectors.HttpJson.v2, elementTemplateVersion=11, retryBackoff=PT0S}, tenantId=<default>, bpmnProcessId=Process_1wh3upd, type=io.camunda:http-json:1, processDefinitionKey=2251799813980804, processDefinitionVersion=1, processInstanceKey=2251799813982035], message: An error occurred while executing the request, or the connection was aborted
```
## Related issues

<!-- Which issues are closed by this PR or are related -->

closes https://github.com/camunda/connectors/issues/5117

## Checklist

- [ ] PR has a **milestone** or the `no milestone` label.
- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest release, as this branch will be rebased onto main before the next release.

