### PR TITLE
chore(github): Automatically add bugs to the quality board

### DIFF
--- a/.github/workflows/ADD_TO_PROJECT.yml
+++ b/.github/workflows/ADD_TO_PROJECT.yml
@@ -58,7 +58,7 @@ jobs:
   add-quality-board:
     name: Add issue to quality board project if its a bug
     runs-on: ubuntu-latest
-    if: contains(github.event.label.name, 'bug') || contains(github.event.issue.labels.*.name, 'bug') || contains(github.event.issue.type.*.name, 'bug') || contains(github.event.pull_request.labels.*.name, 'bug')
+    if: (contains(github.event.label.name, 'bug') || contains(github.event.issue.labels.*.name, 'bug') || contains(github.event.issue.type.*.name, 'bug')) &&  github.event_name != 'pull_request'
     steps:
       - uses: actions/add-to-project@v1.0.2
         with:

--- a/.github/workflows/ADD_TO_PROJECT.yml
+++ b/.github/workflows/ADD_TO_PROJECT.yml
@@ -58,7 +58,7 @@ jobs:
   add-quality-board:
     name: Add issue to quality board project if its a bug
     runs-on: ubuntu-latest
-    if: contains(github.event.issue.labels.*.name, 'bug') || contains(github.event.issue.type.*.name, 'bug')
+    if: contains(github.event.issue.labels.*.name, 'bug') || contains(github.event.issue.type.*.name, 'bug') || contains(github.event.pull_request.labels.*.name, 'bug')
     steps:
       - uses: actions/add-to-project@v1.0.2
         with:

--- a/.github/workflows/ADD_TO_PROJECT.yml
+++ b/.github/workflows/ADD_TO_PROJECT.yml
@@ -58,7 +58,6 @@ jobs:
   add-quality-board:
     name: Add issue to quality board project if its a bug
     runs-on: ubuntu-latest
-    if: contains(github.event.issue.labels.*.name, 'bug') || contains(github.event.issue.type.*.name, 'bug') || contains(github.event.pull_request.labels.*.name, 'bug')
     steps:
       - uses: actions/add-to-project@v1.0.2
         with:

--- a/.github/workflows/ADD_TO_PROJECT.yml
+++ b/.github/workflows/ADD_TO_PROJECT.yml
@@ -54,3 +54,13 @@ jobs:
         with:
           project-url: https://github.com/orgs/camunda/projects/23/views/1
           github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
+
+  add-quality-board:
+    name: Add issue to quality board project if its a bug
+    runs-on: ubuntu-latest
+    if: contains(github.event.issue.labels.*.name, 'bug') || contains(github.event.issue.type.*.name, 'bug')
+    steps:
+      - uses: actions/add-to-project@v1.0.2
+        with:
+          project-url: https://github.com/orgs/camunda/projects/187/views/1
+          github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}

--- a/.github/workflows/ADD_TO_PROJECT.yml
+++ b/.github/workflows/ADD_TO_PROJECT.yml
@@ -58,6 +58,7 @@ jobs:
   add-quality-board:
     name: Add issue to quality board project if its a bug
     runs-on: ubuntu-latest
+    if: contains(github.event.label.name, 'bug') || contains(github.event.issue.labels.*.name, 'bug') || contains(github.event.issue.type.*.name, 'bug') || contains(github.event.pull_request.labels.*.name, 'bug')
     steps:
       - uses: actions/add-to-project@v1.0.2
         with:


### PR DESCRIPTION
## Related issues

<!-- Which issues are closed by this PR or are related -->

closes https://github.com/camunda/team-connectors/issues/1084

## Checklist

- [ ] PR has a **milestone** or the `no milestone` label.
- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest release, as this branch will be rebased onto main before the next release.

