### PR TITLE
other(release): Set a custom Maven deployment name

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,6 +10,10 @@
     <relativePath>parent/pom.xml</relativePath>
   </parent>
 
+  <properties>
+    <deploymentName>${project.groupId}:${project.artifactId}:${project.version}</deploymentName>
+  </properties>
+
   <artifactId>connectors-bundle-parent</artifactId>
   <packaging>pom</packaging>
 


### PR DESCRIPTION
## Description

Explicitly set the Maven deployment name so that it won't default to "Deployment" anymore.