### PR TITLE
other(pom): downgrade spring zeebe due to an incompatibility

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -72,7 +72,10 @@ limitations under the License.</license.inlineheader>
     <!-- Camunda internal libraries -->
     <version.zeebe>8.5.16</version.zeebe>
     <version.feel-engine>1.19.3</version.feel-engine>
-    <version.spring-zeebe>8.5.19</version.spring-zeebe>
+
+    <!-- DO NOT UPGRADE THIS VERSION, VERSIONS AFTER 8.5.18 ARE NOT COMPATIBLE -->
+    <version.spring-zeebe>8.5.18</version.spring-zeebe>
+
     <version.identity-sdk>8.5.5</version.identity-sdk>
 
     <!-- Third party dependencies -->


### PR DESCRIPTION
## Description

Downgrade spring zeebe as 8.5.19 is not compatible.
See [this](https://camunda.slack.com/archives/C02JLRNQQ05/p1754305698036009) discussion.