### PR TITLE
chore(deps): block further spring-zeebe version bumps for 8.5

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -77,6 +77,17 @@
         "digest"
       ],
       "changelogUrl": "https://github.com/camunda/infra-global-github-actions/compare/{{currentDigest}}..{{newDigest}}"
+    },
+    {
+      "description": "No further Spring-Zeebe (community) updates on 8.5 due to broken compatibility",
+      "matchManagers": [
+        "maven"
+      ],
+      "matchPackagePrefixes": [
+        "io.camunda.spring"
+      ],
+      "matchBranch": "release/8.5",
+      "enabled": false
     }
   ],
   "baseBranches": [


### PR DESCRIPTION
## Description

Context (internal discussion): https://camunda.slack.com/archives/C02JLRNQQ05/p1754305698036009

Spring-zeebe 8.5.19+ is incompatible with Connectors 8.5, therefore we should stick with 8.5.18 until 8.5 is EOL (October 2025). This rule can be removed after that along with the whole 8.5 branch in this config.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #

## Checklist

- [ ] PR has a **milestone** or the `no milestone` label.
- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest release, as this branch will be rebased onto main before the next release.

