### PR TITLE
fix(secrets): If secrets are resolved to a Json value, the json is escaped to avoid future exception related to deserialization

### DIFF
--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/outbound/JobHandlerContextTest.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/outbound/JobHandlerContextTest.java
@@ -28,6 +28,7 @@ import io.camunda.connector.api.error.ConnectorInputException;
 import io.camunda.connector.api.secret.SecretProvider;
 import io.camunda.connector.api.validation.ValidationProvider;
 import io.camunda.connector.runtime.core.testutil.classexample.TestClass;
+import io.camunda.connector.runtime.core.testutil.classexample.TestClassString;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -77,6 +78,14 @@ class JobHandlerContextTest {
     when(activatedJob.getVariables()).thenReturn(json);
     when(secretProvider.getSecret(eq("FOO"), any())).thenReturn("1");
     assertThat(jobHandlerContext.bindVariables(TestClass.class).integer).isEqualTo(1);
+  }
+
+  @Test
+  void bindVariables_successJsonSecretAreEscaped() {
+    String json = "{ \"value\": \"{{secrets.FOO}}\" }";
+    when(activatedJob.getVariables()).thenReturn(json);
+    when(secretProvider.getSecret(eq("FOO"), any())).thenReturn("{\"key\": \"secret\"}");
+    assertThat(jobHandlerContext.bindVariables(TestClassString.class).value).isEqualTo("{\"key\": \"secret\"}");
   }
 
   @Test

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/testutil/classexample/TestClassString.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/testutil/classexample/TestClassString.java
@@ -1,0 +1,11 @@
+package io.camunda.connector.runtime.core.testutil.classexample;
+
+public class TestClassString {
+    public String value;
+
+    public TestClassString(String value) {
+        this.value = value;
+    }
+    public TestClassString() {
+    }
+}


### PR DESCRIPTION
## Description

Fix issue, exceptions were raised when secrets were a json value. This is now fixed, secrets are escaped if they are resolved to JSON string

## Related issues

closes https://github.com/camunda/connectors/issues/5183

## example 

<img width="906" height="618" alt="image" src="https://github.com/user-attachments/assets/38ea4657-af69-4e16-91cf-06802389cf30" />
<img width="932" height="485" alt="image" src="https://github.com/user-attachments/assets/c66a418b-caca-433c-b7c7-3a2adfab9ce5" />


JSON Secrets are properly managed

## Checklist

- [ ] PR has a **milestone** or the `no milestone` label.
- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest release, as this branch will be rebased onto main before the next release.

