### PR TITLE
test(agentic-ai): add missing test for Google Vertex AI provider

### DIFF
--- a/connectors/agentic-ai/element-templates/agenticai-aiagent-outbound-connector.json
+++ b/connectors/agentic-ai/element-templates/agenticai-aiagent-outbound-connector.json
@@ -441,8 +441,8 @@
     },
     "type" : "String"
   }, {
-    "id" : "provider.googleVertexAi.location",
-    "label" : "Location",
+    "id" : "provider.googleVertexAi.region",
+    "label" : "Region",
     "description" : "Specify the region where AI inference should take place",
     "optional" : false,
     "constraints" : {
@@ -451,7 +451,7 @@
     "feel" : "optional",
     "group" : "provider",
     "binding" : {
-      "name" : "provider.googleVertexAi.location",
+      "name" : "provider.googleVertexAi.region",
       "type" : "zeebe:input"
     },
     "condition" : {

--- a/connectors/agentic-ai/element-templates/hybrid/agenticai-aiagent-outbound-connector-hybrid.json
+++ b/connectors/agentic-ai/element-templates/hybrid/agenticai-aiagent-outbound-connector-hybrid.json
@@ -446,8 +446,8 @@
     },
     "type" : "String"
   }, {
-    "id" : "provider.googleVertexAi.location",
-    "label" : "Location",
+    "id" : "provider.googleVertexAi.region",
+    "label" : "Region",
     "description" : "Specify the region where AI inference should take place",
     "optional" : false,
     "constraints" : {
@@ -456,7 +456,7 @@
     "feel" : "optional",
     "group" : "provider",
     "binding" : {
-      "name" : "provider.googleVertexAi.location",
+      "name" : "provider.googleVertexAi.region",
       "type" : "zeebe:input"
     },
     "condition" : {

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/ChatModelFactoryImpl.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/ChatModelFactoryImpl.java
@@ -164,7 +164,7 @@ public class ChatModelFactoryImpl implements ChatModelFactory {
     final var builder =
         VertexAiGeminiChatModel.builder()
             .project(connection.projectId())
-            .location(connection.location())
+            .location(connection.region())
             .modelName(connection.model().model());
 
     if (connection.authentication() instanceof ServiceAccountCredentialsAuthentication sac) {

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/provider/GoogleVertexAiProviderConfiguration.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/provider/GoogleVertexAiProviderConfiguration.java
@@ -41,12 +41,12 @@ public record GoogleVertexAiProviderConfiguration(
       @NotBlank
           @TemplateProperty(
               group = "provider",
-              label = "Location",
+              label = "Region",
               description = "Specify the region where AI inference should take place",
               type = TemplateProperty.PropertyType.String,
               feel = Property.FeelMode.optional,
               constraints = @TemplateProperty.PropertyConstraints(notEmpty = true))
-          String location,
+          String region,
       @Valid @NotNull GoogleVertexAiAuthentication authentication,
       @Valid @NotNull GoogleVertexAiProviderConfiguration.GoogleVertexAiModel model) {
 

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/util/ConnectorUtils.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/util/ConnectorUtils.java
@@ -7,9 +7,12 @@
 package io.camunda.connector.agenticai.util;
 
 public final class ConnectorUtils {
+
+  public static final String CONNECTOR_RUNTIME_SAAS_ENV_VARIABLE = "CAMUNDA_CONNECTOR_RUNTIME_SAAS";
+
   private ConnectorUtils() {}
 
   public static boolean isSaaS() {
-    return System.getenv().containsKey("CAMUNDA_CONNECTOR_RUNTIME_SAAS");
+    return System.getenv().containsKey(CONNECTOR_RUNTIME_SAAS_ENV_VARIABLE);
   }
 }

--- a/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/ChatModelFactoryTest.java
+++ b/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/ChatModelFactoryTest.java
@@ -468,7 +468,7 @@ class ChatModelFactoryTest {
   class GoogleVertexAiChatModelFactoryTest {
 
     private static final String PROJECT_ID = "projectId";
-    private static final String LOCATION = "us-central1";
+    private static final String REGION = "us-central1";
     private static final String MODEL = "gemini-2.5-pro";
 
     private static final GoogleVertexAiModelParameters DEFAULT_MODEL_PARAMETERS =
@@ -480,14 +480,14 @@ class ChatModelFactoryTest {
           new GoogleVertexAiProviderConfiguration(
               new GoogleVertexAiConnection(
                   PROJECT_ID,
-                  LOCATION,
+                  REGION,
                   new ApplicationDefaultCredentialsAuthentication(),
                   new GoogleVertexAiModel(MODEL, DEFAULT_MODEL_PARAMETERS)));
 
       testGoogleVertexAiChatModelBuilder(
           providerConfig,
           (builder) -> {
-            verify(builder).location(LOCATION);
+            verify(builder).location(REGION);
             verify(builder).project(PROJECT_ID);
             verify(builder).modelName(MODEL);
             verify(builder).maxOutputTokens(DEFAULT_MODEL_PARAMETERS.maxOutputTokens());
@@ -506,7 +506,7 @@ class ChatModelFactoryTest {
           new GoogleVertexAiProviderConfiguration(
               new GoogleVertexAiConnection(
                   PROJECT_ID,
-                  LOCATION,
+                  REGION,
                   new ApplicationDefaultCredentialsAuthentication(),
                   new GoogleVertexAiModel(MODEL, modelParameters)));
 
@@ -526,7 +526,7 @@ class ChatModelFactoryTest {
           new GoogleVertexAiProviderConfiguration(
               new GoogleVertexAiConnection(
                   PROJECT_ID,
-                  LOCATION,
+                  REGION,
                   new ServiceAccountCredentialsAuthentication("{}"),
                   new GoogleVertexAiModel(MODEL, DEFAULT_MODEL_PARAMETERS)));
 
@@ -540,7 +540,7 @@ class ChatModelFactoryTest {
         testGoogleVertexAiChatModelBuilder(
             providerConfig,
             (builder) -> {
-              verify(builder).location(LOCATION);
+              verify(builder).location(REGION);
               verify(builder).project(PROJECT_ID);
               verify(builder).credentials(mockedSac);
               verify(builder).modelName(MODEL);


### PR DESCRIPTION
## Description

There is a missing integration test for the Google Vertex AI provider to make sure it is allowed in SaaS environment when Google service account credentials are used.

At the same time I renamed `location` to `region` in `GoogleVertexAiConnection` to be consistent with other connectors.


## Checklist

- [x] PR has a **milestone** or the `no milestone` label.
- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest release, as this branch will be rebased onto main before the next release.

