### PR TITLE
fix(polling-connectors): IntermediateThrowEvent was missing and feel was not available for URL

### DIFF
--- a/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/model/HttpCommonRequest.java
+++ b/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/model/HttpCommonRequest.java
@@ -34,7 +34,7 @@ public class HttpCommonRequest {
   @FEEL
   @NotBlank
   @Pattern(regexp = "^(=|(http://|https://|secrets|\\{\\{).*$)", message = "Must be a http(s) URL")
-  @TemplateProperty(group = "endpoint", label = "URL")
+  @TemplateProperty(group = "endpoint", label = "URL", feel = FeelMode.optional)
   private String url;
 
   @Valid private Authentication authentication;

--- a/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/model/HttpCommonRequest.java
+++ b/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/model/HttpCommonRequest.java
@@ -100,6 +100,7 @@ public class HttpCommonRequest {
       defaultValueType = TemplateProperty.DefaultValueType.Boolean,
       defaultValue = "false",
       description = "Store the response as a document in the document store")
+  @FEEL
   private boolean storeResponse;
 
   @TemplateProperty(

--- a/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/model/HttpCommonRequest.java
+++ b/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/model/HttpCommonRequest.java
@@ -100,7 +100,6 @@ public class HttpCommonRequest {
       defaultValueType = TemplateProperty.DefaultValueType.Boolean,
       defaultValue = "false",
       description = "Store the response as a document in the document store")
-  @FEEL
   private boolean storeResponse;
 
   @TemplateProperty(

--- a/connectors/http/polling/element-templates/http-polling-boundary-catch-event-connector.json
+++ b/connectors/http/polling/element-templates/http-polling-boundary-catch-event-connector.json
@@ -394,6 +394,7 @@
         "message" : "Must be a http(s) URL"
       }
     },
+    "feel" : "optional",
     "group" : "endpoint",
     "binding" : {
       "name" : "url",

--- a/connectors/http/polling/element-templates/http-polling-boundary-catch-event-connector.json
+++ b/connectors/http/polling/element-templates/http-polling-boundary-catch-event-connector.json
@@ -1,698 +1,475 @@
 {
-  "$schema" : "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
-  "name" : "HTTP Polling Boundary Catch Event Connector",
-  "id" : "io.camunda.connectors.http.Polling.Boundary",
-  "description" : "Polls endpoint at regular intervals",
-  "metadata" : {
-    "keywords" : [ ]
+  "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+  "name": "HTTP Polling Boundary Catch Event Connector",
+  "id": "io.camunda.connectors.http.Polling.Boundary",
+  "version": 3,
+  "description": "Polls endpoint at regular intervals",
+  "icon": {
+    "contents": "data:image/svg+xml;utf8,%3C%3Fxml version='1.0'%3F%3E%3Csvg width='18' height='18' xmlns='http://www.w3.org/2000/svg' xmlns:svg='http://www.w3.org/2000/svg'%3E%3Cg class='layer'%3E%3Ctitle%3ELayer 1%3C/title%3E%3Cpath d='m17.03,9c0,4.45 -3.6,8.05 -8.05,8.05c-4.45,0 -8.05,-3.6 -8.05,-8.05c0,-4.45 3.6,-8.05 8.05,-8.05c4.45,0 8.05,3.6 8.05,8.05z' fill='%23505562' id='svg_1'/%3E%3Cpath d='m4.93,14.16l1.85,-10.45l3.36,0c1.05,0 1.84,0.27 2.37,0.81c0.54,0.53 0.8,1.21 0.8,2.06c0,0.86 -0.24,1.58 -0.73,2.13c-0.47,0.55 -1.12,0.93 -1.95,1.14l-0.48,0.09l-0.53,0.03l-0.6,0.05l-1.79,0l-0.73,4.14l-1.58,0zm2.57,-5.57l1.74,0c0.76,0 1.35,-0.17 1.78,-0.5c0.44,-0.35 0.65,-0.82 0.65,-1.42c0,-0.48 -0.15,-0.85 -0.44,-1.12c-0.3,-0.28 -0.77,-0.42 -1.42,-0.42l-1.7,0l-0.61,3.46z' fill='white' id='svg_2'/%3E%3C/g%3E%3C/svg%3E"
   },
-  "documentationRef" : "https://docs.camunda.io/docs/components/connectors/protocol/polling/",
-  "version" : 3,
-  "category" : {
-    "id" : "connectors",
-    "name" : "Connectors"
+  "documentationRef": "https://docs.camunda.io/docs/components/connectors/protocol/polling/",
+  "category": {
+    "id": "connectors",
+    "name": "Connectors"
   },
-  "appliesTo" : [ "bpmn:BoundaryEvent" ],
-  "elementType" : {
-    "value" : "bpmn:BoundaryEvent",
-    "eventDefinition" : "bpmn:MessageEventDefinition"
+  "appliesTo": [
+    "bpmn:BoundaryEvent"
+  ],
+  "elementType": {
+    "value": "bpmn:BoundaryEvent",
+    "eventDefinition": "bpmn:MessageEventDefinition"
   },
-  "engines" : {
-    "camunda" : "^8.3"
-  },
-  "groups" : [ {
-    "id" : "authentication",
-    "label" : "Authentication"
-  }, {
-    "id" : "endpoint",
-    "label" : "HTTP Polling configuration"
-  }, {
-    "id" : "payload",
-    "label" : "Payload"
-  }, {
-    "id" : "timeout",
-    "label" : "Connect timeout"
-  }, {
-    "id" : "activation",
-    "label" : "Activation"
-  }, {
-    "id" : "correlation",
-    "label" : "Correlation",
-    "tooltip" : "Learn more about message correlation in the <a href=\"https://docs.camunda.io/docs/components/concepts/messages/#message-correlation-overview\">documentation</a>."
-  }, {
-    "id" : "deduplication",
-    "label" : "Deduplication",
-    "tooltip" : "Deduplication allows you to configure multiple inbound connector elements to reuse the same backend (consumer/thread/endpoint) by sharing the same deduplication ID."
-  }, {
-    "id" : "output",
-    "label" : "Output mapping"
-  } ],
-  "properties" : [ {
-    "value" : "io.camunda:http-polling:1",
-    "binding" : {
-      "name" : "inbound.type",
-      "type" : "zeebe:property"
+  "groups": [
+    {
+      "id": "authentication",
+      "label": "Authentication"
     },
-    "type" : "Hidden"
-  }, {
-    "id" : "DEFAULT_HTTP_REQUEST_INTERVAL",
-    "label" : "DEFAULT_HTTP_REQUEST_INTERVAL",
-    "feel" : "optional",
-    "binding" : {
-      "name" : "DEFAULT_HTTP_REQUEST_INTERVAL",
-      "type" : "zeebe:property"
+    {
+      "id": "endpoint",
+      "label": "HTTP Polling configuration"
     },
-    "type" : "String"
-  }, {
-    "id" : "DEFAULT_PROCESS_POLLING_INTERVAL",
-    "label" : "DEFAULT_PROCESS_POLLING_INTERVAL",
-    "feel" : "optional",
-    "binding" : {
-      "name" : "DEFAULT_PROCESS_POLLING_INTERVAL",
-      "type" : "zeebe:property"
+    {
+      "id": "input",
+      "label": "Payload"
     },
-    "type" : "String"
-  }, {
-    "id" : "httpRequestInterval",
-    "label" : "Http request interval",
-    "feel" : "optional",
-    "binding" : {
-      "name" : "httpRequestInterval",
-      "type" : "zeebe:property"
+    {
+      "id": "activation",
+      "label": "Condition to proceed"
     },
-    "type" : "String"
-  }, {
-    "id" : "processPollingInterval",
-    "label" : "Process polling interval",
-    "feel" : "optional",
-    "binding" : {
-      "name" : "processPollingInterval",
-      "type" : "zeebe:property"
+    {
+      "id": "timer",
+      "label": "Timer"
     },
-    "type" : "String"
-  }, {
-    "id" : "authentication.type",
-    "label" : "Type",
-    "description" : "Choose the authentication type. Select 'None' if no authentication is necessary",
-    "value" : "noAuth",
-    "group" : "authentication",
-    "binding" : {
-      "name" : "authentication.type",
-      "type" : "zeebe:property"
+    {
+      "id": "timeout",
+      "label": "Connect timeout"
     },
-    "type" : "Dropdown",
-    "choices" : [ {
-      "name" : "API key",
-      "value" : "apiKey"
-    }, {
-      "name" : "Basic",
-      "value" : "basic"
-    }, {
-      "name" : "Bearer token",
-      "value" : "bearer"
-    }, {
-      "name" : "None",
-      "value" : "noAuth"
-    }, {
-      "name" : "OAuth 2.0",
-      "value" : "oauth-client-credentials-flow"
-    } ]
-  }, {
-    "id" : "authentication.apiKeyLocation",
-    "label" : "Api key location",
-    "description" : "Choose type: Send API key in header or as query parameter.",
-    "optional" : false,
-    "value" : "headers",
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "group" : "authentication",
-    "binding" : {
-      "name" : "authentication.apiKeyLocation",
-      "type" : "zeebe:property"
-    },
-    "condition" : {
-      "property" : "authentication.type",
-      "equals" : "apiKey",
-      "type" : "simple"
-    },
-    "type" : "Dropdown",
-    "choices" : [ {
-      "name" : "Headers",
-      "value" : "headers"
-    }, {
-      "name" : "Query parameters",
-      "value" : "query"
-    } ]
-  }, {
-    "id" : "authentication.name",
-    "label" : "API key name",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "group" : "authentication",
-    "binding" : {
-      "name" : "authentication.name",
-      "type" : "zeebe:property"
-    },
-    "condition" : {
-      "property" : "authentication.type",
-      "equals" : "apiKey",
-      "type" : "simple"
-    },
-    "type" : "String"
-  }, {
-    "id" : "authentication.value",
-    "label" : "API key value",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "group" : "authentication",
-    "binding" : {
-      "name" : "authentication.value",
-      "type" : "zeebe:property"
-    },
-    "condition" : {
-      "property" : "authentication.type",
-      "equals" : "apiKey",
-      "type" : "simple"
-    },
-    "type" : "String"
-  }, {
-    "id" : "authentication.username",
-    "label" : "Username",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "group" : "authentication",
-    "binding" : {
-      "name" : "authentication.username",
-      "type" : "zeebe:property"
-    },
-    "condition" : {
-      "property" : "authentication.type",
-      "equals" : "basic",
-      "type" : "simple"
-    },
-    "type" : "String"
-  }, {
-    "id" : "authentication.password",
-    "label" : "Password",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "group" : "authentication",
-    "binding" : {
-      "name" : "authentication.password",
-      "type" : "zeebe:property"
-    },
-    "condition" : {
-      "property" : "authentication.type",
-      "equals" : "basic",
-      "type" : "simple"
-    },
-    "type" : "String"
-  }, {
-    "id" : "authentication.token",
-    "label" : "Bearer token",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "group" : "authentication",
-    "binding" : {
-      "name" : "authentication.token",
-      "type" : "zeebe:property"
-    },
-    "condition" : {
-      "property" : "authentication.type",
-      "equals" : "bearer",
-      "type" : "simple"
-    },
-    "type" : "String"
-  }, {
-    "id" : "authentication.oauthTokenEndpoint",
-    "label" : "OAuth 2.0 token endpoint",
-    "description" : "The OAuth token endpoint",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true,
-      "pattern" : {
-        "value" : "^(=|(http://|https://|secrets|\\{\\{).*$)",
-        "message" : "Must be a http(s) URL"
+    {
+      "id": "variable-mapping",
+      "label": "Response mapping"
+    }
+  ],
+  "properties": [
+    {
+      "type": "Hidden",
+      "value": "io.camunda:http-polling:1",
+      "binding": {
+        "type": "zeebe:property",
+        "name": "inbound.type"
       }
     },
-    "group" : "authentication",
-    "binding" : {
-      "name" : "authentication.oauthTokenEndpoint",
-      "type" : "zeebe:property"
-    },
-    "condition" : {
-      "property" : "authentication.type",
-      "equals" : "oauth-client-credentials-flow",
-      "type" : "simple"
-    },
-    "type" : "String"
-  }, {
-    "id" : "authentication.clientId",
-    "label" : "Client ID",
-    "description" : "Your application's client ID from the OAuth client",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "group" : "authentication",
-    "binding" : {
-      "name" : "authentication.clientId",
-      "type" : "zeebe:property"
-    },
-    "condition" : {
-      "property" : "authentication.type",
-      "equals" : "oauth-client-credentials-flow",
-      "type" : "simple"
-    },
-    "type" : "String"
-  }, {
-    "id" : "authentication.clientSecret",
-    "label" : "Client secret",
-    "description" : "Your application's client secret from the OAuth client",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "group" : "authentication",
-    "binding" : {
-      "name" : "authentication.clientSecret",
-      "type" : "zeebe:property"
-    },
-    "condition" : {
-      "property" : "authentication.type",
-      "equals" : "oauth-client-credentials-flow",
-      "type" : "simple"
-    },
-    "type" : "String"
-  }, {
-    "id" : "authentication.audience",
-    "label" : "Audience",
-    "description" : "The unique identifier of the target API you want to access",
-    "optional" : true,
-    "group" : "authentication",
-    "binding" : {
-      "name" : "authentication.audience",
-      "type" : "zeebe:property"
-    },
-    "condition" : {
-      "property" : "authentication.type",
-      "equals" : "oauth-client-credentials-flow",
-      "type" : "simple"
-    },
-    "type" : "String"
-  }, {
-    "id" : "authentication.clientAuthentication",
-    "label" : "Client authentication",
-    "description" : "Send client ID and client secret as Basic Auth request in the header, or as client credentials in the request body",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "group" : "authentication",
-    "binding" : {
-      "name" : "authentication.clientAuthentication",
-      "type" : "zeebe:property"
-    },
-    "condition" : {
-      "property" : "authentication.type",
-      "equals" : "oauth-client-credentials-flow",
-      "type" : "simple"
-    },
-    "type" : "Dropdown",
-    "choices" : [ {
-      "name" : "Send client credentials in body",
-      "value" : "credentialsBody"
-    }, {
-      "name" : "Send as Basic Auth header",
-      "value" : "basicAuthHeader"
-    } ]
-  }, {
-    "id" : "authentication.scopes",
-    "label" : "Scopes",
-    "description" : "The scopes which you want to request authorization for (e.g.read:contacts)",
-    "optional" : true,
-    "group" : "authentication",
-    "binding" : {
-      "name" : "authentication.scopes",
-      "type" : "zeebe:property"
-    },
-    "condition" : {
-      "property" : "authentication.type",
-      "equals" : "oauth-client-credentials-flow",
-      "type" : "simple"
-    },
-    "type" : "String"
-  }, {
-    "id" : "method",
-    "label" : "Method",
-    "optional" : false,
-    "value" : "GET",
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "group" : "endpoint",
-    "binding" : {
-      "name" : "method",
-      "type" : "zeebe:property"
-    },
-    "type" : "Dropdown",
-    "choices" : [ {
-      "name" : "POST",
-      "value" : "POST"
-    }, {
-      "name" : "GET",
-      "value" : "GET"
-    }, {
-      "name" : "DELETE",
-      "value" : "DELETE"
-    }, {
-      "name" : "PATCH",
-      "value" : "PATCH"
-    }, {
-      "name" : "PUT",
-      "value" : "PUT"
-    } ]
-  }, {
-    "id" : "url",
-    "label" : "URL",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true,
-      "pattern" : {
-        "value" : "^(=|(http://|https://|secrets|\\{\\{).*$)",
-        "message" : "Must be a http(s) URL"
+    {
+      "type": "Hidden",
+      "generatedValue": {
+        "type": "uuid"
+      },
+      "binding": {
+        "type": "bpmn:Message#property",
+        "name": "name"
       }
     },
-    "feel" : "optional",
-    "group" : "endpoint",
-    "binding" : {
-      "name" : "url",
-      "type" : "zeebe:property"
-    },
-    "type" : "String"
-  }, {
-    "id" : "headers",
-    "label" : "Headers",
-    "description" : "Map of HTTP headers to add to the request",
-    "optional" : true,
-    "feel" : "required",
-    "group" : "endpoint",
-    "binding" : {
-      "name" : "headers",
-      "type" : "zeebe:property"
-    },
-    "type" : "String"
-  }, {
-    "id" : "queryParameters",
-    "label" : "Query parameters",
-    "description" : "Map of query parameters to add to the request URL",
-    "optional" : true,
-    "feel" : "required",
-    "group" : "endpoint",
-    "binding" : {
-      "name" : "queryParameters",
-      "type" : "zeebe:property"
-    },
-    "type" : "String"
-  }, {
-    "id" : "storeResponse",
-    "label" : "Store response",
-    "description" : "Store the response as a document in the document store",
-    "optional" : false,
-    "value" : false,
-    "feel" : "static",
-    "group" : "endpoint",
-    "binding" : {
-      "name" : "storeResponse",
-      "type" : "zeebe:property"
-    },
-    "type" : "Boolean"
-  }, {
-    "id" : "skipEncoding",
-    "label" : "Skip URL encoding",
-    "description" : "Skip the default URL decoding and encoding behavior",
-    "optional" : true,
-    "group" : "endpoint",
-    "binding" : {
-      "name" : "skipEncoding",
-      "type" : "zeebe:property"
-    },
-    "type" : "Hidden"
-  }, {
-    "id" : "body",
-    "label" : "Request body",
-    "description" : "Payload to send with the request",
-    "optional" : true,
-    "feel" : "optional",
-    "group" : "payload",
-    "binding" : {
-      "name" : "body",
-      "type" : "zeebe:property"
-    },
-    "condition" : {
-      "property" : "method",
-      "oneOf" : [ "POST", "PUT", "PATCH" ],
-      "type" : "simple"
-    },
-    "type" : "Text"
-  }, {
-    "id" : "ignoreNullValues",
-    "label" : "Ignore null values",
-    "optional" : false,
-    "value" : false,
-    "feel" : "static",
-    "group" : "payload",
-    "binding" : {
-      "name" : "ignoreNullValues",
-      "type" : "zeebe:property"
-    },
-    "tooltip" : "Null values will not be sent",
-    "type" : "Boolean"
-  }, {
-    "id" : "connectionTimeoutInSeconds",
-    "label" : "Connection timeout in seconds",
-    "description" : "Defines the connection timeout in seconds, or 0 for an infinite timeout",
-    "optional" : false,
-    "value" : "20",
-    "constraints" : {
-      "notEmpty" : true,
-      "pattern" : {
-        "value" : "^\\d+$",
-        "message" : "Must be a number"
+    {
+      "label": "Type",
+      "id": "authenticationType",
+      "group": "authentication",
+      "description": "Choose the authentication type. Select 'None' if no authentication is necessary",
+      "value": "noAuth",
+      "type": "Dropdown",
+      "choices": [
+        {
+          "name": "None",
+          "value": "noAuth"
+        },
+        {
+          "name": "Basic",
+          "value": "basic"
+        },
+        {
+          "name": "Bearer token",
+          "value": "bearer"
+        },
+        {
+          "name": "OAuth 2.0",
+          "value": "oauth-client-credentials-flow"
+        }
+      ],
+      "binding": {
+        "type": "zeebe:property",
+        "name": "authentication.type"
       }
     },
-    "group" : "timeout",
-    "binding" : {
-      "name" : "connectionTimeoutInSeconds",
-      "type" : "zeebe:property"
-    },
-    "type" : "String"
-  }, {
-    "id" : "readTimeoutInSeconds",
-    "label" : "Read timeout in seconds",
-    "description" : "Timeout in seconds to read data from an established connection or 0 for an infinite timeout",
-    "optional" : false,
-    "value" : "20",
-    "constraints" : {
-      "notEmpty" : true,
-      "pattern" : {
-        "value" : "^\\d+$",
-        "message" : "Must be a number"
+    {
+      "id": "method",
+      "label": "Method",
+      "group": "endpoint",
+      "type": "Dropdown",
+      "value": "get",
+      "choices": [
+        {
+          "name": "GET",
+          "value": "get"
+        },
+        {
+          "name": "POST",
+          "value": "post"
+        },
+        {
+          "name": "PATCH",
+          "value": "patch"
+        },
+        {
+          "name": "PUT",
+          "value": "put"
+        },
+        {
+          "name": "DELETE",
+          "value": "delete"
+        }
+      ],
+      "binding": {
+        "type": "zeebe:property",
+        "name": "method"
       }
     },
-    "group" : "timeout",
-    "binding" : {
-      "name" : "readTimeoutInSeconds",
-      "type" : "zeebe:property"
-    },
-    "type" : "String"
-  }, {
-    "id" : "activationCondition",
-    "label" : "Activation condition",
-    "description" : "Condition under which the Connector triggers. Leave empty to catch all events",
-    "optional" : true,
-    "feel" : "required",
-    "group" : "activation",
-    "binding" : {
-      "name" : "activationCondition",
-      "type" : "zeebe:property"
-    },
-    "type" : "String"
-  }, {
-    "id" : "consumeUnmatchedEvents",
-    "label" : "Consume unmatched events",
-    "value" : true,
-    "group" : "activation",
-    "binding" : {
-      "name" : "consumeUnmatchedEvents",
-      "type" : "zeebe:property"
-    },
-    "tooltip" : "Unmatched events are rejected by default, allowing the upstream service to handle the error. Check this box to consume unmatched events and return a success response",
-    "type" : "Boolean"
-  }, {
-    "id" : "correlationKeyProcess",
-    "label" : "Correlation key (process)",
-    "description" : "Sets up the correlation key from process variables",
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "feel" : "required",
-    "group" : "correlation",
-    "binding" : {
-      "name" : "correlationKey",
-      "type" : "bpmn:Message#zeebe:subscription#property"
-    },
-    "type" : "String"
-  }, {
-    "id" : "correlationKeyPayload",
-    "label" : "Correlation key (payload)",
-    "description" : "Extracts the correlation key from the incoming message payload",
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "feel" : "required",
-    "group" : "correlation",
-    "binding" : {
-      "name" : "correlationKeyExpression",
-      "type" : "zeebe:property"
-    },
-    "type" : "String"
-  }, {
-    "id" : "messageIdExpression",
-    "label" : "Message ID expression",
-    "description" : "Expression to extract unique identifier of a message",
-    "optional" : true,
-    "feel" : "required",
-    "group" : "correlation",
-    "binding" : {
-      "name" : "messageIdExpression",
-      "type" : "zeebe:property"
-    },
-    "type" : "String"
-  }, {
-    "id" : "messageTtl",
-    "label" : "Message TTL",
-    "description" : "Time-to-live for the message in the broker (ISO-8601 duration)",
-    "optional" : true,
-    "constraints" : {
-      "notEmpty" : false,
-      "pattern" : {
-        "value" : "^(PT.*|)$",
-        "message" : "must be an ISO-8601 duration"
+    {
+      "label": "URL",
+      "group": "endpoint",
+      "type": "String",
+      "feel": "optional",
+      "binding": {
+        "type": "zeebe:property",
+        "name": "url"
+      },
+      "constraints": {
+        "notEmpty": true,
+        "pattern": {
+          "value": "^(=|(https?://|secrets\\..+|\\{\\{secrets\\..+\\}\\}).*$)",
+          "message": "must be a http(s) URL"
+        }
       }
     },
-    "feel" : "optional",
-    "group" : "correlation",
-    "binding" : {
-      "name" : "messageTtl",
-      "type" : "zeebe:property"
+    {
+      "label": "Query parameters",
+      "description": "Map of query parameters to add to the request URL",
+      "group": "endpoint",
+      "type": "Text",
+      "feel": "required",
+      "binding": {
+        "type": "zeebe:property",
+        "name": "queryParameters"
+      },
+      "optional": true
     },
-    "type" : "String"
-  }, {
-    "id" : "messageNameUuid",
-    "generatedValue" : {
-      "type" : "uuid"
+    {
+      "label": "HTTP headers",
+      "description": "Map of HTTP headers to add to the request",
+      "group": "endpoint",
+      "type": "Text",
+      "feel": "required",
+      "binding": {
+        "type": "zeebe:property",
+        "name": "headers"
+      },
+      "optional": true
     },
-    "group" : "correlation",
-    "binding" : {
-      "name" : "name",
-      "type" : "bpmn:Message#property"
+    {
+      "label": "Interval",
+      "description": "The delay between HTTP requests, defined as ISO 8601 durations format. <a href='https://docs.camunda.io/docs/components/modeler/bpmn/timer-events/#time-duration' target='_blank'>How to configure a time duration</a>",
+      "group": "endpoint",
+      "type": "String",
+      "feel": "optional",
+      "value": "PT50S",
+      "binding": {
+        "type": "zeebe:property",
+        "name": "httpRequestInterval"
+      },
+      "constraints": {
+        "notEmpty": true,
+        "pattern": {
+          "value": "^P(?=\\d|T\\d)(?:\\d+Y)?(?:\\d+M)?(?:\\d+W)?(?:\\d+D)?(?:T(?:\\d+H)?(?:\\d+M)?(?:\\d+(?:\\.\\d{1,3})?S)?)$",
+          "message": "value must be defined"
+        }
+      },
+      "optional": false
     },
-    "type" : "Hidden"
-  }, {
-    "id" : "deduplicationModeManualFlag",
-    "label" : "Manual mode",
-    "description" : "By default, similar connectors receive the same deduplication ID. Customize by activating manual mode",
-    "value" : false,
-    "group" : "deduplication",
-    "binding" : {
-      "name" : "deduplicationModeManualFlag",
-      "type" : "zeebe:property"
+    {
+      "group": "endpoint",
+      "type": "Hidden",
+      "value": "PT5S",
+      "binding": {
+        "type": "zeebe:property",
+        "name": "processPollingInterval"
+      },
+      "optional": true
     },
-    "type" : "Boolean"
-  }, {
-    "id" : "deduplicationId",
-    "label" : "Deduplication ID",
-    "constraints" : {
-      "notEmpty" : true,
-      "pattern" : {
-        "value" : "^[a-zA-Z0-9_-]+$",
-        "message" : "can only contain alphanumeric characters, dashes, and underscores"
+    {
+      "label": "Bearer token",
+      "group": "authentication",
+      "type": "String",
+      "feel": "optional",
+      "binding": {
+        "type": "zeebe:property",
+        "name": "authentication.token"
+      },
+      "constraints": {
+        "notEmpty": true
+      },
+      "condition": {
+        "property": "authenticationType",
+        "equals": "bearer"
       }
     },
-    "group" : "deduplication",
-    "binding" : {
-      "name" : "deduplicationId",
-      "type" : "zeebe:property"
+    {
+      "label": "OAuth token endpoint",
+      "description": "The OAuth token endpoint",
+      "group": "authentication",
+      "type": "String",
+      "feel": "optional",
+      "binding": {
+        "type": "zeebe:property",
+        "name": "authentication.oauthTokenEndpoint"
+      },
+      "constraints": {
+        "notEmpty": true
+      },
+      "condition": {
+        "property": "authenticationType",
+        "equals": "oauth-client-credentials-flow"
+      }
     },
-    "condition" : {
-      "property" : "deduplicationModeManualFlag",
-      "equals" : true,
-      "type" : "simple"
+    {
+      "label": "Client ID",
+      "description": "Your application's client ID from the OAuth client",
+      "group": "authentication",
+      "type": "String",
+      "feel": "optional",
+      "binding": {
+        "type": "zeebe:property",
+        "name": "authentication.clientId"
+      },
+      "constraints": {
+        "notEmpty": true
+      },
+      "condition": {
+        "property": "authenticationType",
+        "equals": "oauth-client-credentials-flow"
+      }
     },
-    "type" : "String"
-  }, {
-    "id" : "deduplicationModeManual",
-    "value" : "MANUAL",
-    "group" : "deduplication",
-    "binding" : {
-      "name" : "deduplicationMode",
-      "type" : "zeebe:property"
+    {
+      "label": "Client secret",
+      "description": "Your application's client secret from the OAuth client",
+      "group": "authentication",
+      "type": "String",
+      "feel": "optional",
+      "binding": {
+        "type": "zeebe:property",
+        "name": "authentication.clientSecret"
+      },
+      "constraints": {
+        "notEmpty": true
+      },
+      "condition": {
+        "property": "authenticationType",
+        "equals": "oauth-client-credentials-flow"
+      }
     },
-    "condition" : {
-      "property" : "deduplicationId",
-      "isActive" : true,
-      "type" : "simple"
+    {
+      "label": "Scopes",
+      "description": "The scopes which you want to request authorization for (e.g.read:contacts)",
+      "group": "authentication",
+      "type": "String",
+      "feel": "optional",
+      "optional": true,
+      "binding": {
+        "type": "zeebe:property",
+        "name": "authentication.scopes"
+      },
+      "condition": {
+        "property": "authenticationType",
+        "equals": "oauth-client-credentials-flow"
+      }
     },
-    "type" : "Hidden"
-  }, {
-    "id" : "deduplicationModeAuto",
-    "value" : "AUTO",
-    "group" : "deduplication",
-    "binding" : {
-      "name" : "deduplicationMode",
-      "type" : "zeebe:property"
+    {
+      "label": "Audience",
+      "description": "The unique identifier of the target API you want to access",
+      "group": "authentication",
+      "type": "String",
+      "feel": "optional",
+      "optional": true,
+      "binding": {
+        "type": "zeebe:property",
+        "name": "authentication.audience"
+      },
+      "condition": {
+        "property": "authenticationType",
+        "equals": "oauth-client-credentials-flow"
+      }
     },
-    "condition" : {
-      "property" : "deduplicationId",
-      "isActive" : false,
-      "type" : "simple"
+    {
+      "label": "Client authentication",
+      "id": "authentication.clientAuthentication",
+      "group": "authentication",
+      "description": "Send client ID and client secret as Basic Auth request in the header, or as client credentials in the request body",
+      "value": "basicAuthHeader",
+      "type": "Dropdown",
+      "choices": [
+        {
+          "name": "Send client credentials in body",
+          "value": "credentialsBody"
+        },
+        {
+          "name": "Send as Basic Auth header",
+          "value": "basicAuthHeader"
+        }
+      ],
+      "binding": {
+        "type": "zeebe:property",
+        "name": "authentication.clientAuthentication"
+      },
+      "condition": {
+        "property": "authenticationType",
+        "equals": "oauth-client-credentials-flow"
+      }
     },
-    "type" : "Hidden"
-  }, {
-    "id" : "resultVariable",
-    "label" : "Result variable",
-    "description" : "Name of variable to store the response in",
-    "group" : "output",
-    "binding" : {
-      "name" : "resultVariable",
-      "type" : "zeebe:property"
+    {
+      "label": "Username",
+      "group": "authentication",
+      "type": "String",
+      "feel": "optional",
+      "binding": {
+        "type": "zeebe:property",
+        "name": "authentication.username"
+      },
+      "constraints": {
+        "notEmpty": true
+      },
+      "condition": {
+        "property": "authenticationType",
+        "equals": "basic"
+      }
     },
-    "type" : "String"
-  }, {
-    "id" : "resultExpression",
-    "label" : "Result expression",
-    "description" : "Expression to map the response into process variables",
-    "feel" : "required",
-    "group" : "output",
-    "binding" : {
-      "name" : "resultExpression",
-      "type" : "zeebe:property"
+    {
+      "label": "Password",
+      "group": "authentication",
+      "type": "String",
+      "feel": "optional",
+      "binding": {
+        "type": "zeebe:property",
+        "name": "authentication.password"
+      },
+      "constraints": {
+        "notEmpty": true
+      },
+      "condition": {
+        "property": "authenticationType",
+        "equals": "basic"
+      }
     },
-    "type" : "Text"
-  } ],
-  "icon" : {
-    "contents" : "data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0nMS4wJz8+Cjxzdmcgd2lkdGg9JzE4JyBoZWlnaHQ9JzE4JyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnPgogICAgPGcgY2xhc3M9J2xheWVyJz4KICAgICAgICA8dGl0bGU+TGF5ZXIgMTwvdGl0bGU+CiAgICAgICAgPHBhdGggZD0nbTE3LjAzLDljMCw0LjQ1IC0zLjYsOC4wNSAtOC4wNSw4LjA1Yy00LjQ1LDAgLTguMDUsLTMuNiAtOC4wNSwtOC4wNWMwLC00LjQ1IDMuNiwtOC4wNSA4LjA1LC04LjA1YzQuNDUsMCA4LjA1LDMuNiA4LjA1LDguMDV6JwogICAgICAgICAgICAgIGZpbGw9JyM1MDU1NjInIGlkPSdzdmdfMScvPgogICAgICAgIDxwYXRoIGQ9J200LjkzLDE0LjE2bDEuODUsLTEwLjQ1bDMuMzYsMGMxLjA1LDAgMS44NCwwLjI3IDIuMzcsMC44MWMwLjU0LDAuNTMgMC44LDEuMjEgMC44LDIuMDZjMCwwLjg2IC0wLjI0LDEuNTggLTAuNzMsMi4xM2MtMC40NywwLjU1IC0xLjEyLDAuOTMgLTEuOTUsMS4xNGwtMC40OCwwLjA5bC0wLjUzLDAuMDNsLTAuNiwwLjA1bC0xLjc5LDBsLTAuNzMsNC4xNGwtMS41OCwwem0yLjU3LC01LjU3bDEuNzQsMGMwLjc2LDAgMS4zNSwtMC4xNyAxLjc4LC0wLjVjMC40NCwtMC4zNSAwLjY1LC0wLjgyIDAuNjUsLTEuNDJjMCwtMC40OCAtMC4xNSwtMC44NSAtMC40NCwtMS4xMmMtMC4zLC0wLjI4IC0wLjc3LC0wLjQyIC0xLjQyLC0wLjQybC0xLjcsMGwtMC42MSwzLjQ2eicKICAgICAgICAgICAgICBmaWxsPSd3aGl0ZScgaWQ9J3N2Z18yJy8+CiAgICA8L2c+Cjwvc3ZnPg=="
+    {
+      "label": "Request body",
+      "description": "Payload to send with the request",
+      "group": "input",
+      "type": "Text",
+      "feel": "optional",
+      "binding": {
+        "type": "zeebe:property",
+        "name": "body"
+      },
+      "condition": {
+        "property": "method",
+        "oneOf": [
+          "post",
+          "put",
+          "patch"
+        ]
+      },
+      "optional": true
+    },
+    {
+      "label": "Correlation key (process)",
+      "type": "String",
+      "group": "activation",
+      "feel": "required",
+      "description": "Sets up the correlation key from process variables",
+      "binding": {
+        "type": "bpmn:Message#zeebe:subscription#property",
+        "name": "correlationKey"
+      },
+      "constraints": {
+        "notEmpty": true
+      }
+    },
+    {
+      "label": "Correlation key (payload)",
+      "type": "String",
+      "group": "activation",
+      "feel": "required",
+      "binding": {
+        "type": "zeebe:property",
+        "name": "correlationKeyExpression"
+      },
+      "description": "Extracts the correlation key from the incoming message payload",
+      "constraints": {
+        "notEmpty": true
+      }
+    },
+    {
+      "label": "Condition",
+      "type": "String",
+      "group": "activation",
+      "feel": "required",
+      "optional": true,
+      "binding": {
+        "type": "zeebe:property",
+        "name": "activationCondition"
+      },
+      "description": "Condition under which the connector triggers. Leave empty to catch all events. <a href='https://docs.camunda.io/docs/components/connectors/protocol/http-webhook/#make-your-http-webhook-connector-for-receiving-messages-executable' target='_blank'>See documentation</a>"
+    },
+    {
+      "label": "Connection timeout",
+      "description": "Sets the timeout in seconds to establish a connection or 0 for an infinite timeout",
+      "group": "endpoint",
+      "type": "String",
+      "value": "20",
+      "binding": {
+        "type": "zeebe:property",
+        "name": "connectionTimeoutInSeconds"
+      },
+      "optional": true,
+      "feel": "optional",
+      "constraints": {
+        "notEmpty": false,
+        "pattern": {
+          "value": "^(=|([0-9]+|secrets\\..+|\\{\\{secrets\\..+\\}\\})$)",
+          "message": "must be a timeout in seconds (default value is 20 seconds) or a FEEL expression"
+        }
+      }
+    },
+    {
+      "label": "Result variable",
+      "type": "String",
+      "group": "variable-mapping",
+      "optional": true,
+      "binding": {
+        "type": "zeebe:property",
+        "name": "resultVariable"
+      },
+      "description": "Name of variable to store the result of the connector in"
+    },
+    {
+      "label": "Result expression",
+      "type": "String",
+      "group": "variable-mapping",
+      "feel": "required",
+      "optional": true,
+      "binding": {
+        "type": "zeebe:property",
+        "name": "resultExpression"
+      },
+      "description": "Expression to map the inbound payload to process variables"
+    }
+  ],
+  "engines": {
+    "camunda": "^8.3"
   }
 }

--- a/connectors/http/polling/element-templates/http-polling-connector.json
+++ b/connectors/http/polling/element-templates/http-polling-connector.json
@@ -1,698 +1,476 @@
 {
-  "$schema" : "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
-  "name" : "HTTP Polling Intermediate Catch Event Connector",
-  "id" : "io.camunda.connectors.http.Polling",
-  "description" : "Polls endpoint at regular intervals",
-  "metadata" : {
-    "keywords" : [ ]
+  "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+  "name": "HTTP Polling Intermediate Catch Event Connector",
+  "id": "io.camunda.connectors.http.Polling",
+  "version": 3,
+  "description": "Polls endpoint at regular intervals",
+  "icon": {
+    "contents": "data:image/svg+xml;utf8,%3C%3Fxml version='1.0'%3F%3E%3Csvg width='18' height='18' xmlns='http://www.w3.org/2000/svg' xmlns:svg='http://www.w3.org/2000/svg'%3E%3Cg class='layer'%3E%3Ctitle%3ELayer 1%3C/title%3E%3Cpath d='m17.03,9c0,4.45 -3.6,8.05 -8.05,8.05c-4.45,0 -8.05,-3.6 -8.05,-8.05c0,-4.45 3.6,-8.05 8.05,-8.05c4.45,0 8.05,3.6 8.05,8.05z' fill='%23505562' id='svg_1'/%3E%3Cpath d='m4.93,14.16l1.85,-10.45l3.36,0c1.05,0 1.84,0.27 2.37,0.81c0.54,0.53 0.8,1.21 0.8,2.06c0,0.86 -0.24,1.58 -0.73,2.13c-0.47,0.55 -1.12,0.93 -1.95,1.14l-0.48,0.09l-0.53,0.03l-0.6,0.05l-1.79,0l-0.73,4.14l-1.58,0zm2.57,-5.57l1.74,0c0.76,0 1.35,-0.17 1.78,-0.5c0.44,-0.35 0.65,-0.82 0.65,-1.42c0,-0.48 -0.15,-0.85 -0.44,-1.12c-0.3,-0.28 -0.77,-0.42 -1.42,-0.42l-1.7,0l-0.61,3.46z' fill='white' id='svg_2'/%3E%3C/g%3E%3C/svg%3E"
   },
-  "documentationRef" : "https://docs.camunda.io/docs/components/connectors/protocol/polling/",
-  "version" : 3,
-  "category" : {
-    "id" : "connectors",
-    "name" : "Connectors"
+  "documentationRef": "https://docs.camunda.io/docs/components/connectors/protocol/polling/",
+  "category": {
+    "id": "connectors",
+    "name": "Connectors"
   },
-  "appliesTo" : [ "bpmn:IntermediateCatchEvent", "bpmn:IntermediateThrowEvent" ],
-  "elementType" : {
-    "value" : "bpmn:IntermediateCatchEvent",
-    "eventDefinition" : "bpmn:MessageEventDefinition"
+  "appliesTo": [
+    "bpmn:IntermediateCatchEvent",
+    "bpmn:IntermediateThrowEvent"
+  ],
+  "elementType": {
+    "value": "bpmn:IntermediateCatchEvent",
+    "eventDefinition": "bpmn:MessageEventDefinition"
   },
-  "engines" : {
-    "camunda" : "^8.3"
-  },
-  "groups" : [ {
-    "id" : "authentication",
-    "label" : "Authentication"
-  }, {
-    "id" : "endpoint",
-    "label" : "HTTP Polling configuration"
-  }, {
-    "id" : "payload",
-    "label" : "Payload"
-  }, {
-    "id" : "timeout",
-    "label" : "Connect timeout"
-  }, {
-    "id" : "activation",
-    "label" : "Activation"
-  }, {
-    "id" : "correlation",
-    "label" : "Correlation",
-    "tooltip" : "Learn more about message correlation in the <a href=\"https://docs.camunda.io/docs/components/concepts/messages/#message-correlation-overview\">documentation</a>."
-  }, {
-    "id" : "deduplication",
-    "label" : "Deduplication",
-    "tooltip" : "Deduplication allows you to configure multiple inbound connector elements to reuse the same backend (consumer/thread/endpoint) by sharing the same deduplication ID."
-  }, {
-    "id" : "output",
-    "label" : "Output mapping"
-  } ],
-  "properties" : [ {
-    "value" : "io.camunda:http-polling:1",
-    "binding" : {
-      "name" : "inbound.type",
-      "type" : "zeebe:property"
+  "groups": [
+    {
+      "id": "authentication",
+      "label": "Authentication"
     },
-    "type" : "Hidden"
-  }, {
-    "id" : "DEFAULT_HTTP_REQUEST_INTERVAL",
-    "label" : "DEFAULT_HTTP_REQUEST_INTERVAL",
-    "feel" : "optional",
-    "binding" : {
-      "name" : "DEFAULT_HTTP_REQUEST_INTERVAL",
-      "type" : "zeebe:property"
+    {
+      "id": "endpoint",
+      "label": "HTTP Polling configuration"
     },
-    "type" : "String"
-  }, {
-    "id" : "DEFAULT_PROCESS_POLLING_INTERVAL",
-    "label" : "DEFAULT_PROCESS_POLLING_INTERVAL",
-    "feel" : "optional",
-    "binding" : {
-      "name" : "DEFAULT_PROCESS_POLLING_INTERVAL",
-      "type" : "zeebe:property"
+    {
+      "id": "input",
+      "label": "Payload"
     },
-    "type" : "String"
-  }, {
-    "id" : "httpRequestInterval",
-    "label" : "Http request interval",
-    "feel" : "optional",
-    "binding" : {
-      "name" : "httpRequestInterval",
-      "type" : "zeebe:property"
+    {
+      "id": "activation",
+      "label": "Condition to proceed"
     },
-    "type" : "String"
-  }, {
-    "id" : "processPollingInterval",
-    "label" : "Process polling interval",
-    "feel" : "optional",
-    "binding" : {
-      "name" : "processPollingInterval",
-      "type" : "zeebe:property"
+    {
+      "id": "timer",
+      "label": "Timer"
     },
-    "type" : "String"
-  }, {
-    "id" : "authentication.type",
-    "label" : "Type",
-    "description" : "Choose the authentication type. Select 'None' if no authentication is necessary",
-    "value" : "noAuth",
-    "group" : "authentication",
-    "binding" : {
-      "name" : "authentication.type",
-      "type" : "zeebe:property"
+    {
+      "id": "timeout",
+      "label": "Connect timeout"
     },
-    "type" : "Dropdown",
-    "choices" : [ {
-      "name" : "API key",
-      "value" : "apiKey"
-    }, {
-      "name" : "Basic",
-      "value" : "basic"
-    }, {
-      "name" : "Bearer token",
-      "value" : "bearer"
-    }, {
-      "name" : "None",
-      "value" : "noAuth"
-    }, {
-      "name" : "OAuth 2.0",
-      "value" : "oauth-client-credentials-flow"
-    } ]
-  }, {
-    "id" : "authentication.apiKeyLocation",
-    "label" : "Api key location",
-    "description" : "Choose type: Send API key in header or as query parameter.",
-    "optional" : false,
-    "value" : "headers",
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "group" : "authentication",
-    "binding" : {
-      "name" : "authentication.apiKeyLocation",
-      "type" : "zeebe:property"
-    },
-    "condition" : {
-      "property" : "authentication.type",
-      "equals" : "apiKey",
-      "type" : "simple"
-    },
-    "type" : "Dropdown",
-    "choices" : [ {
-      "name" : "Headers",
-      "value" : "headers"
-    }, {
-      "name" : "Query parameters",
-      "value" : "query"
-    } ]
-  }, {
-    "id" : "authentication.name",
-    "label" : "API key name",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "group" : "authentication",
-    "binding" : {
-      "name" : "authentication.name",
-      "type" : "zeebe:property"
-    },
-    "condition" : {
-      "property" : "authentication.type",
-      "equals" : "apiKey",
-      "type" : "simple"
-    },
-    "type" : "String"
-  }, {
-    "id" : "authentication.value",
-    "label" : "API key value",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "group" : "authentication",
-    "binding" : {
-      "name" : "authentication.value",
-      "type" : "zeebe:property"
-    },
-    "condition" : {
-      "property" : "authentication.type",
-      "equals" : "apiKey",
-      "type" : "simple"
-    },
-    "type" : "String"
-  }, {
-    "id" : "authentication.username",
-    "label" : "Username",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "group" : "authentication",
-    "binding" : {
-      "name" : "authentication.username",
-      "type" : "zeebe:property"
-    },
-    "condition" : {
-      "property" : "authentication.type",
-      "equals" : "basic",
-      "type" : "simple"
-    },
-    "type" : "String"
-  }, {
-    "id" : "authentication.password",
-    "label" : "Password",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "group" : "authentication",
-    "binding" : {
-      "name" : "authentication.password",
-      "type" : "zeebe:property"
-    },
-    "condition" : {
-      "property" : "authentication.type",
-      "equals" : "basic",
-      "type" : "simple"
-    },
-    "type" : "String"
-  }, {
-    "id" : "authentication.token",
-    "label" : "Bearer token",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "group" : "authentication",
-    "binding" : {
-      "name" : "authentication.token",
-      "type" : "zeebe:property"
-    },
-    "condition" : {
-      "property" : "authentication.type",
-      "equals" : "bearer",
-      "type" : "simple"
-    },
-    "type" : "String"
-  }, {
-    "id" : "authentication.oauthTokenEndpoint",
-    "label" : "OAuth 2.0 token endpoint",
-    "description" : "The OAuth token endpoint",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true,
-      "pattern" : {
-        "value" : "^(=|(http://|https://|secrets|\\{\\{).*$)",
-        "message" : "Must be a http(s) URL"
+    {
+      "id": "variable-mapping",
+      "label": "Response mapping"
+    }
+  ],
+  "properties": [
+    {
+      "type": "Hidden",
+      "value": "io.camunda:http-polling:1",
+      "binding": {
+        "type": "zeebe:property",
+        "name": "inbound.type"
       }
     },
-    "group" : "authentication",
-    "binding" : {
-      "name" : "authentication.oauthTokenEndpoint",
-      "type" : "zeebe:property"
-    },
-    "condition" : {
-      "property" : "authentication.type",
-      "equals" : "oauth-client-credentials-flow",
-      "type" : "simple"
-    },
-    "type" : "String"
-  }, {
-    "id" : "authentication.clientId",
-    "label" : "Client ID",
-    "description" : "Your application's client ID from the OAuth client",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "group" : "authentication",
-    "binding" : {
-      "name" : "authentication.clientId",
-      "type" : "zeebe:property"
-    },
-    "condition" : {
-      "property" : "authentication.type",
-      "equals" : "oauth-client-credentials-flow",
-      "type" : "simple"
-    },
-    "type" : "String"
-  }, {
-    "id" : "authentication.clientSecret",
-    "label" : "Client secret",
-    "description" : "Your application's client secret from the OAuth client",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "group" : "authentication",
-    "binding" : {
-      "name" : "authentication.clientSecret",
-      "type" : "zeebe:property"
-    },
-    "condition" : {
-      "property" : "authentication.type",
-      "equals" : "oauth-client-credentials-flow",
-      "type" : "simple"
-    },
-    "type" : "String"
-  }, {
-    "id" : "authentication.audience",
-    "label" : "Audience",
-    "description" : "The unique identifier of the target API you want to access",
-    "optional" : true,
-    "group" : "authentication",
-    "binding" : {
-      "name" : "authentication.audience",
-      "type" : "zeebe:property"
-    },
-    "condition" : {
-      "property" : "authentication.type",
-      "equals" : "oauth-client-credentials-flow",
-      "type" : "simple"
-    },
-    "type" : "String"
-  }, {
-    "id" : "authentication.clientAuthentication",
-    "label" : "Client authentication",
-    "description" : "Send client ID and client secret as Basic Auth request in the header, or as client credentials in the request body",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "group" : "authentication",
-    "binding" : {
-      "name" : "authentication.clientAuthentication",
-      "type" : "zeebe:property"
-    },
-    "condition" : {
-      "property" : "authentication.type",
-      "equals" : "oauth-client-credentials-flow",
-      "type" : "simple"
-    },
-    "type" : "Dropdown",
-    "choices" : [ {
-      "name" : "Send client credentials in body",
-      "value" : "credentialsBody"
-    }, {
-      "name" : "Send as Basic Auth header",
-      "value" : "basicAuthHeader"
-    } ]
-  }, {
-    "id" : "authentication.scopes",
-    "label" : "Scopes",
-    "description" : "The scopes which you want to request authorization for (e.g.read:contacts)",
-    "optional" : true,
-    "group" : "authentication",
-    "binding" : {
-      "name" : "authentication.scopes",
-      "type" : "zeebe:property"
-    },
-    "condition" : {
-      "property" : "authentication.type",
-      "equals" : "oauth-client-credentials-flow",
-      "type" : "simple"
-    },
-    "type" : "String"
-  }, {
-    "id" : "method",
-    "label" : "Method",
-    "optional" : false,
-    "value" : "GET",
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "group" : "endpoint",
-    "binding" : {
-      "name" : "method",
-      "type" : "zeebe:property"
-    },
-    "type" : "Dropdown",
-    "choices" : [ {
-      "name" : "POST",
-      "value" : "POST"
-    }, {
-      "name" : "GET",
-      "value" : "GET"
-    }, {
-      "name" : "DELETE",
-      "value" : "DELETE"
-    }, {
-      "name" : "PATCH",
-      "value" : "PATCH"
-    }, {
-      "name" : "PUT",
-      "value" : "PUT"
-    } ]
-  }, {
-    "id" : "url",
-    "label" : "URL",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true,
-      "pattern" : {
-        "value" : "^(=|(http://|https://|secrets|\\{\\{).*$)",
-        "message" : "Must be a http(s) URL"
+    {
+      "type": "Hidden",
+      "generatedValue": {
+        "type": "uuid"
+      },
+      "binding": {
+        "type": "bpmn:Message#property",
+        "name": "name"
       }
     },
-    "feel" : "optional",
-    "group" : "endpoint",
-    "binding" : {
-      "name" : "url",
-      "type" : "zeebe:property"
-    },
-    "type" : "String"
-  }, {
-    "id" : "headers",
-    "label" : "Headers",
-    "description" : "Map of HTTP headers to add to the request",
-    "optional" : true,
-    "feel" : "required",
-    "group" : "endpoint",
-    "binding" : {
-      "name" : "headers",
-      "type" : "zeebe:property"
-    },
-    "type" : "String"
-  }, {
-    "id" : "queryParameters",
-    "label" : "Query parameters",
-    "description" : "Map of query parameters to add to the request URL",
-    "optional" : true,
-    "feel" : "required",
-    "group" : "endpoint",
-    "binding" : {
-      "name" : "queryParameters",
-      "type" : "zeebe:property"
-    },
-    "type" : "String"
-  }, {
-    "id" : "storeResponse",
-    "label" : "Store response",
-    "description" : "Store the response as a document in the document store",
-    "optional" : false,
-    "value" : false,
-    "feel" : "static",
-    "group" : "endpoint",
-    "binding" : {
-      "name" : "storeResponse",
-      "type" : "zeebe:property"
-    },
-    "type" : "Boolean"
-  }, {
-    "id" : "skipEncoding",
-    "label" : "Skip URL encoding",
-    "description" : "Skip the default URL decoding and encoding behavior",
-    "optional" : true,
-    "group" : "endpoint",
-    "binding" : {
-      "name" : "skipEncoding",
-      "type" : "zeebe:property"
-    },
-    "type" : "Hidden"
-  }, {
-    "id" : "body",
-    "label" : "Request body",
-    "description" : "Payload to send with the request",
-    "optional" : true,
-    "feel" : "optional",
-    "group" : "payload",
-    "binding" : {
-      "name" : "body",
-      "type" : "zeebe:property"
-    },
-    "condition" : {
-      "property" : "method",
-      "oneOf" : [ "POST", "PUT", "PATCH" ],
-      "type" : "simple"
-    },
-    "type" : "Text"
-  }, {
-    "id" : "ignoreNullValues",
-    "label" : "Ignore null values",
-    "optional" : false,
-    "value" : false,
-    "feel" : "static",
-    "group" : "payload",
-    "binding" : {
-      "name" : "ignoreNullValues",
-      "type" : "zeebe:property"
-    },
-    "tooltip" : "Null values will not be sent",
-    "type" : "Boolean"
-  }, {
-    "id" : "connectionTimeoutInSeconds",
-    "label" : "Connection timeout in seconds",
-    "description" : "Defines the connection timeout in seconds, or 0 for an infinite timeout",
-    "optional" : false,
-    "value" : "20",
-    "constraints" : {
-      "notEmpty" : true,
-      "pattern" : {
-        "value" : "^\\d+$",
-        "message" : "Must be a number"
+    {
+      "label": "Type",
+      "id": "authenticationType",
+      "group": "authentication",
+      "description": "Choose the authentication type. Select 'None' if no authentication is necessary",
+      "value": "noAuth",
+      "type": "Dropdown",
+      "choices": [
+        {
+          "name": "None",
+          "value": "noAuth"
+        },
+        {
+          "name": "Basic",
+          "value": "basic"
+        },
+        {
+          "name": "Bearer token",
+          "value": "bearer"
+        },
+        {
+          "name": "OAuth 2.0",
+          "value": "oauth-client-credentials-flow"
+        }
+      ],
+      "binding": {
+        "type": "zeebe:property",
+        "name": "authentication.type"
       }
     },
-    "group" : "timeout",
-    "binding" : {
-      "name" : "connectionTimeoutInSeconds",
-      "type" : "zeebe:property"
-    },
-    "type" : "String"
-  }, {
-    "id" : "readTimeoutInSeconds",
-    "label" : "Read timeout in seconds",
-    "description" : "Timeout in seconds to read data from an established connection or 0 for an infinite timeout",
-    "optional" : false,
-    "value" : "20",
-    "constraints" : {
-      "notEmpty" : true,
-      "pattern" : {
-        "value" : "^\\d+$",
-        "message" : "Must be a number"
+    {
+      "id": "method",
+      "label": "Method",
+      "group": "endpoint",
+      "type": "Dropdown",
+      "value": "get",
+      "choices": [
+        {
+          "name": "GET",
+          "value": "get"
+        },
+        {
+          "name": "POST",
+          "value": "post"
+        },
+        {
+          "name": "PATCH",
+          "value": "patch"
+        },
+        {
+          "name": "PUT",
+          "value": "put"
+        },
+        {
+          "name": "DELETE",
+          "value": "delete"
+        }
+      ],
+      "binding": {
+        "type": "zeebe:property",
+        "name": "method"
       }
     },
-    "group" : "timeout",
-    "binding" : {
-      "name" : "readTimeoutInSeconds",
-      "type" : "zeebe:property"
-    },
-    "type" : "String"
-  }, {
-    "id" : "activationCondition",
-    "label" : "Activation condition",
-    "description" : "Condition under which the Connector triggers. Leave empty to catch all events",
-    "optional" : true,
-    "feel" : "required",
-    "group" : "activation",
-    "binding" : {
-      "name" : "activationCondition",
-      "type" : "zeebe:property"
-    },
-    "type" : "String"
-  }, {
-    "id" : "consumeUnmatchedEvents",
-    "label" : "Consume unmatched events",
-    "value" : true,
-    "group" : "activation",
-    "binding" : {
-      "name" : "consumeUnmatchedEvents",
-      "type" : "zeebe:property"
-    },
-    "tooltip" : "Unmatched events are rejected by default, allowing the upstream service to handle the error. Check this box to consume unmatched events and return a success response",
-    "type" : "Boolean"
-  }, {
-    "id" : "correlationKeyProcess",
-    "label" : "Correlation key (process)",
-    "description" : "Sets up the correlation key from process variables",
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "feel" : "required",
-    "group" : "correlation",
-    "binding" : {
-      "name" : "correlationKey",
-      "type" : "bpmn:Message#zeebe:subscription#property"
-    },
-    "type" : "String"
-  }, {
-    "id" : "correlationKeyPayload",
-    "label" : "Correlation key (payload)",
-    "description" : "Extracts the correlation key from the incoming message payload",
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "feel" : "required",
-    "group" : "correlation",
-    "binding" : {
-      "name" : "correlationKeyExpression",
-      "type" : "zeebe:property"
-    },
-    "type" : "String"
-  }, {
-    "id" : "messageIdExpression",
-    "label" : "Message ID expression",
-    "description" : "Expression to extract unique identifier of a message",
-    "optional" : true,
-    "feel" : "required",
-    "group" : "correlation",
-    "binding" : {
-      "name" : "messageIdExpression",
-      "type" : "zeebe:property"
-    },
-    "type" : "String"
-  }, {
-    "id" : "messageTtl",
-    "label" : "Message TTL",
-    "description" : "Time-to-live for the message in the broker (ISO-8601 duration)",
-    "optional" : true,
-    "constraints" : {
-      "notEmpty" : false,
-      "pattern" : {
-        "value" : "^(PT.*|)$",
-        "message" : "must be an ISO-8601 duration"
+    {
+      "label": "URL",
+      "group": "endpoint",
+      "type": "String",
+      "feel": "optional",
+      "binding": {
+        "type": "zeebe:property",
+        "name": "url"
+      },
+      "constraints": {
+        "notEmpty": true,
+        "pattern": {
+          "value": "^(=|(https?://|secrets\\..+|\\{\\{secrets\\..+\\}\\}).*$)",
+          "message": "must be a http(s) URL"
+        }
       }
     },
-    "feel" : "optional",
-    "group" : "correlation",
-    "binding" : {
-      "name" : "messageTtl",
-      "type" : "zeebe:property"
+    {
+      "label": "Query parameters",
+      "description": "Map of query parameters to add to the request URL",
+      "group": "endpoint",
+      "type": "Text",
+      "feel": "required",
+      "binding": {
+        "type": "zeebe:property",
+        "name": "queryParameters"
+      },
+      "optional": true
     },
-    "type" : "String"
-  }, {
-    "id" : "messageNameUuid",
-    "generatedValue" : {
-      "type" : "uuid"
+    {
+      "label": "HTTP headers",
+      "description": "Map of HTTP headers to add to the request",
+      "group": "endpoint",
+      "type": "Text",
+      "feel": "required",
+      "binding": {
+        "type": "zeebe:property",
+        "name": "headers"
+      },
+      "optional": true
     },
-    "group" : "correlation",
-    "binding" : {
-      "name" : "name",
-      "type" : "bpmn:Message#property"
+    {
+      "label": "Interval",
+      "description": "The delay between HTTP requests, defined as ISO 8601 durations format. <a href='https://docs.camunda.io/docs/components/modeler/bpmn/timer-events/#time-duration' target='_blank'>How to configure a time duration</a>",
+      "group": "endpoint",
+      "type": "String",
+      "feel": "optional",
+      "value": "PT50S",
+      "binding": {
+        "type": "zeebe:property",
+        "name": "httpRequestInterval"
+      },
+      "constraints": {
+        "notEmpty": true,
+        "pattern": {
+          "value": "^P(?=\\d|T\\d)(?:\\d+Y)?(?:\\d+M)?(?:\\d+W)?(?:\\d+D)?(?:T(?:\\d+H)?(?:\\d+M)?(?:\\d+(?:\\.\\d{1,3})?S)?)$",
+          "message": "value must be defined"
+        }
+      },
+      "optional": false
     },
-    "type" : "Hidden"
-  }, {
-    "id" : "deduplicationModeManualFlag",
-    "label" : "Manual mode",
-    "description" : "By default, similar connectors receive the same deduplication ID. Customize by activating manual mode",
-    "value" : false,
-    "group" : "deduplication",
-    "binding" : {
-      "name" : "deduplicationModeManualFlag",
-      "type" : "zeebe:property"
+    {
+      "group": "endpoint",
+      "type": "Hidden",
+      "value": "PT5S",
+      "binding": {
+        "type": "zeebe:property",
+        "name": "processPollingInterval"
+      },
+      "optional": true
     },
-    "type" : "Boolean"
-  }, {
-    "id" : "deduplicationId",
-    "label" : "Deduplication ID",
-    "constraints" : {
-      "notEmpty" : true,
-      "pattern" : {
-        "value" : "^[a-zA-Z0-9_-]+$",
-        "message" : "can only contain alphanumeric characters, dashes, and underscores"
+    {
+      "label": "Bearer token",
+      "group": "authentication",
+      "type": "String",
+      "feel": "optional",
+      "binding": {
+        "type": "zeebe:property",
+        "name": "authentication.token"
+      },
+      "constraints": {
+        "notEmpty": true
+      },
+      "condition": {
+        "property": "authenticationType",
+        "equals": "bearer"
       }
     },
-    "group" : "deduplication",
-    "binding" : {
-      "name" : "deduplicationId",
-      "type" : "zeebe:property"
+    {
+      "label": "OAuth token endpoint",
+      "description": "The OAuth token endpoint",
+      "group": "authentication",
+      "type": "String",
+      "feel": "optional",
+      "binding": {
+        "type": "zeebe:property",
+        "name": "authentication.oauthTokenEndpoint"
+      },
+      "constraints": {
+        "notEmpty": true
+      },
+      "condition": {
+        "property": "authenticationType",
+        "equals": "oauth-client-credentials-flow"
+      }
     },
-    "condition" : {
-      "property" : "deduplicationModeManualFlag",
-      "equals" : true,
-      "type" : "simple"
+    {
+      "label": "Client ID",
+      "description": "Your application's client ID from the OAuth client",
+      "group": "authentication",
+      "type": "String",
+      "feel": "optional",
+      "binding": {
+        "type": "zeebe:property",
+        "name": "authentication.clientId"
+      },
+      "constraints": {
+        "notEmpty": true
+      },
+      "condition": {
+        "property": "authenticationType",
+        "equals": "oauth-client-credentials-flow"
+      }
     },
-    "type" : "String"
-  }, {
-    "id" : "deduplicationModeManual",
-    "value" : "MANUAL",
-    "group" : "deduplication",
-    "binding" : {
-      "name" : "deduplicationMode",
-      "type" : "zeebe:property"
+    {
+      "label": "Client secret",
+      "description": "Your application's client secret from the OAuth client",
+      "group": "authentication",
+      "type": "String",
+      "feel": "optional",
+      "binding": {
+        "type": "zeebe:property",
+        "name": "authentication.clientSecret"
+      },
+      "constraints": {
+        "notEmpty": true
+      },
+      "condition": {
+        "property": "authenticationType",
+        "equals": "oauth-client-credentials-flow"
+      }
     },
-    "condition" : {
-      "property" : "deduplicationId",
-      "isActive" : true,
-      "type" : "simple"
+    {
+      "label": "Scopes",
+      "description": "The scopes which you want to request authorization for (e.g.read:contacts)",
+      "group": "authentication",
+      "type": "String",
+      "feel": "optional",
+      "optional": true,
+      "binding": {
+        "type": "zeebe:property",
+        "name": "authentication.scopes"
+      },
+      "condition": {
+        "property": "authenticationType",
+        "equals": "oauth-client-credentials-flow"
+      }
     },
-    "type" : "Hidden"
-  }, {
-    "id" : "deduplicationModeAuto",
-    "value" : "AUTO",
-    "group" : "deduplication",
-    "binding" : {
-      "name" : "deduplicationMode",
-      "type" : "zeebe:property"
+    {
+      "label": "Audience",
+      "description": "The unique identifier of the target API you want to access",
+      "group": "authentication",
+      "type": "String",
+      "feel": "optional",
+      "optional": true,
+      "binding": {
+        "type": "zeebe:property",
+        "name": "authentication.audience"
+      },
+      "condition": {
+        "property": "authenticationType",
+        "equals": "oauth-client-credentials-flow"
+      }
     },
-    "condition" : {
-      "property" : "deduplicationId",
-      "isActive" : false,
-      "type" : "simple"
+    {
+      "label": "Client authentication",
+      "id": "authentication.clientAuthentication",
+      "group": "authentication",
+      "description": "Send client ID and client secret as Basic Auth request in the header, or as client credentials in the request body",
+      "value": "basicAuthHeader",
+      "type": "Dropdown",
+      "choices": [
+        {
+          "name": "Send client credentials in body",
+          "value": "credentialsBody"
+        },
+        {
+          "name": "Send as Basic Auth header",
+          "value": "basicAuthHeader"
+        }
+      ],
+      "binding": {
+        "type": "zeebe:property",
+        "name": "authentication.clientAuthentication"
+      },
+      "condition": {
+        "property": "authenticationType",
+        "equals": "oauth-client-credentials-flow"
+      }
     },
-    "type" : "Hidden"
-  }, {
-    "id" : "resultVariable",
-    "label" : "Result variable",
-    "description" : "Name of variable to store the response in",
-    "group" : "output",
-    "binding" : {
-      "name" : "resultVariable",
-      "type" : "zeebe:property"
+    {
+      "label": "Username",
+      "group": "authentication",
+      "type": "String",
+      "feel": "optional",
+      "binding": {
+        "type": "zeebe:property",
+        "name": "authentication.username"
+      },
+      "constraints": {
+        "notEmpty": true
+      },
+      "condition": {
+        "property": "authenticationType",
+        "equals": "basic"
+      }
     },
-    "type" : "String"
-  }, {
-    "id" : "resultExpression",
-    "label" : "Result expression",
-    "description" : "Expression to map the response into process variables",
-    "feel" : "required",
-    "group" : "output",
-    "binding" : {
-      "name" : "resultExpression",
-      "type" : "zeebe:property"
+    {
+      "label": "Password",
+      "group": "authentication",
+      "type": "String",
+      "feel": "optional",
+      "binding": {
+        "type": "zeebe:property",
+        "name": "authentication.password"
+      },
+      "constraints": {
+        "notEmpty": true
+      },
+      "condition": {
+        "property": "authenticationType",
+        "equals": "basic"
+      }
     },
-    "type" : "Text"
-  } ],
-  "icon" : {
-    "contents" : "data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0nMS4wJz8+Cjxzdmcgd2lkdGg9JzE4JyBoZWlnaHQ9JzE4JyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnPgogICAgPGcgY2xhc3M9J2xheWVyJz4KICAgICAgICA8dGl0bGU+TGF5ZXIgMTwvdGl0bGU+CiAgICAgICAgPHBhdGggZD0nbTE3LjAzLDljMCw0LjQ1IC0zLjYsOC4wNSAtOC4wNSw4LjA1Yy00LjQ1LDAgLTguMDUsLTMuNiAtOC4wNSwtOC4wNWMwLC00LjQ1IDMuNiwtOC4wNSA4LjA1LC04LjA1YzQuNDUsMCA4LjA1LDMuNiA4LjA1LDguMDV6JwogICAgICAgICAgICAgIGZpbGw9JyM1MDU1NjInIGlkPSdzdmdfMScvPgogICAgICAgIDxwYXRoIGQ9J200LjkzLDE0LjE2bDEuODUsLTEwLjQ1bDMuMzYsMGMxLjA1LDAgMS44NCwwLjI3IDIuMzcsMC44MWMwLjU0LDAuNTMgMC44LDEuMjEgMC44LDIuMDZjMCwwLjg2IC0wLjI0LDEuNTggLTAuNzMsMi4xM2MtMC40NywwLjU1IC0xLjEyLDAuOTMgLTEuOTUsMS4xNGwtMC40OCwwLjA5bC0wLjUzLDAuMDNsLTAuNiwwLjA1bC0xLjc5LDBsLTAuNzMsNC4xNGwtMS41OCwwem0yLjU3LC01LjU3bDEuNzQsMGMwLjc2LDAgMS4zNSwtMC4xNyAxLjc4LC0wLjVjMC40NCwtMC4zNSAwLjY1LC0wLjgyIDAuNjUsLTEuNDJjMCwtMC40OCAtMC4xNSwtMC44NSAtMC40NCwtMS4xMmMtMC4zLC0wLjI4IC0wLjc3LC0wLjQyIC0xLjQyLC0wLjQybC0xLjcsMGwtMC42MSwzLjQ2eicKICAgICAgICAgICAgICBmaWxsPSd3aGl0ZScgaWQ9J3N2Z18yJy8+CiAgICA8L2c+Cjwvc3ZnPg=="
+    {
+      "label": "Request body",
+      "description": "Payload to send with the request",
+      "group": "input",
+      "type": "Text",
+      "feel": "optional",
+      "binding": {
+        "type": "zeebe:property",
+        "name": "body"
+      },
+      "condition": {
+        "property": "method",
+        "oneOf": [
+          "post",
+          "put",
+          "patch"
+        ]
+      },
+      "optional": true
+    },
+    {
+      "label": "Correlation key (process)",
+      "type": "String",
+      "group": "activation",
+      "feel": "required",
+      "description": "Sets up the correlation key from process variables",
+      "binding": {
+        "type": "bpmn:Message#zeebe:subscription#property",
+        "name": "correlationKey"
+      },
+      "constraints": {
+        "notEmpty": true
+      }
+    },
+    {
+      "label": "Correlation key (payload)",
+      "type": "String",
+      "group": "activation",
+      "feel": "required",
+      "binding": {
+        "type": "zeebe:property",
+        "name": "correlationKeyExpression"
+      },
+      "description": "Extracts the correlation key from the incoming message payload",
+      "constraints": {
+        "notEmpty": true
+      }
+    },
+    {
+      "label": "Condition",
+      "type": "String",
+      "group": "activation",
+      "feel": "required",
+      "optional": true,
+      "binding": {
+        "type": "zeebe:property",
+        "name": "activationCondition"
+      },
+      "description": "Condition under which the connector triggers. Leave empty to catch all events. <a href='https://docs.camunda.io/docs/components/connectors/protocol/http-webhook/#make-your-http-webhook-connector-for-receiving-messages-executable' target='_blank'>See documentation</a>"
+    },
+    {
+      "label": "Connection timeout",
+      "description": "Sets the timeout in seconds to establish a connection or 0 for an infinite timeout",
+      "group": "endpoint",
+      "type": "String",
+      "value": "20",
+      "binding": {
+        "type": "zeebe:property",
+        "name": "connectionTimeoutInSeconds"
+      },
+      "optional": true,
+      "feel": "optional",
+      "constraints": {
+        "notEmpty": false,
+        "pattern": {
+          "value": "^(=|([0-9]+|secrets\\..+|\\{\\{secrets\\..+\\}\\})$)",
+          "message": "must be a timeout in seconds (default value is 20 seconds) or a FEEL expression"
+        }
+      }
+    },
+    {
+      "label": "Result variable",
+      "type": "String",
+      "group": "variable-mapping",
+      "optional": true,
+      "binding": {
+        "type": "zeebe:property",
+        "name": "resultVariable"
+      },
+      "description": "Name of variable to store the result of the connector in"
+    },
+    {
+      "label": "Result expression",
+      "type": "String",
+      "group": "variable-mapping",
+      "feel": "required",
+      "optional": true,
+      "binding": {
+        "type": "zeebe:property",
+        "name": "resultExpression"
+      },
+      "description": "Expression to map the inbound payload to process variables"
+    }
+  ],
+  "engines": {
+    "camunda": "^8.3"
   }
 }

--- a/connectors/http/polling/element-templates/http-polling-connector.json
+++ b/connectors/http/polling/element-templates/http-polling-connector.json
@@ -12,7 +12,7 @@
     "id" : "connectors",
     "name" : "Connectors"
   },
-  "appliesTo" : [ "bpmn:IntermediateCatchEvent" ],
+  "appliesTo" : [ "bpmn:IntermediateCatchEvent", "bpmn:IntermediateThrowEvent" ],
   "elementType" : {
     "value" : "bpmn:IntermediateCatchEvent",
     "eventDefinition" : "bpmn:MessageEventDefinition"
@@ -394,6 +394,7 @@
         "message" : "Must be a http(s) URL"
       }
     },
+    "feel" : "optional",
     "group" : "endpoint",
     "binding" : {
       "name" : "url",

--- a/connectors/http/polling/pom.xml
+++ b/connectors/http/polling/pom.xml
@@ -54,7 +54,7 @@
 
   <build>
     <plugins>
-      <plugin>
+      <!--<plugin>
         <groupId>io.camunda.connector</groupId>
         <artifactId>element-template-generator-maven-plugin</artifactId>
         <version>${project.version}</version>
@@ -74,8 +74,8 @@
               </files>
               <generateHybridTemplates>false</generateHybridTemplates>
               <features>
-                <ACKNOWLEDGEMENT_STRATEGY_SELECTION>true</ACKNOWLEDGEMENT_STRATEGY_SELECTION>
-                <INBOUND_DEDUPLICATION>true</INBOUND_DEDUPLICATION>
+                <ACKNOWLEDGEMENT_STRATEGY_SELECTION>false</ACKNOWLEDGEMENT_STRATEGY_SELECTION>
+                <INBOUND_DEDUPLICATION>false</INBOUND_DEDUPLICATION>
               </features>
             </connector>
           </connectors>
@@ -84,7 +84,7 @@
             <includeDependency>io.camunda.connector:connector-http-base</includeDependency>
           </includeDependencies>
         </configuration>
-      </plugin>
+      </plugin>-->
     </plugins>
   </build>
 </project>

--- a/connectors/http/polling/src/main/java/io/camunda/connector/http/polling/HttpPollingConnector.java
+++ b/connectors/http/polling/src/main/java/io/camunda/connector/http/polling/HttpPollingConnector.java
@@ -35,7 +35,7 @@ import org.slf4j.LoggerFactory;
     },
     elementTypes = {
       @ElementTemplate.ConnectorElementType(
-          appliesTo = BpmnType.INTERMEDIATE_CATCH_EVENT,
+          appliesTo = {BpmnType.INTERMEDIATE_THROW_EVENT, BpmnType.INTERMEDIATE_CATCH_EVENT},
           elementType = BpmnType.INTERMEDIATE_CATCH_EVENT,
           templateIdOverride = "io.camunda.connectors.http.Polling",
           templateNameOverride = "HTTP Polling Intermediate Catch Event Connector"),


### PR DESCRIPTION
## Description

IntermediateThrowEvent was missing and feel was not available for URL

I could not find other differences beyond the group renaming, new features in authentication, endpoint configurations, timeouts, activation, correlation, and deduplication.



