### PR TITLE
refactor(vector-db): better structure element template configuration

### DIFF
--- a/connectors/embeddings-vector-database/element-templates/embeddings-vector-database-outbound-connector.json
+++ b/connectors/embeddings-vector-database/element-templates/embeddings-vector-database-outbound-connector.json
@@ -1227,7 +1227,7 @@
     "feel" : "optional",
     "group" : "embeddingsStore",
     "binding" : {
-      "name" : "vectorStore.endpoint",
+      "name" : "vectorStore.azureCosmosDbNoSql.endpoint",
       "type" : "zeebe:input"
     },
     "condition" : {
@@ -1237,13 +1237,13 @@
     },
     "type" : "String"
   }, {
-    "id" : "vectorStore.azureCosmosDbAuthentication.type",
+    "id" : "vectorStore.azureCosmosDbNoSql.authentication.type",
     "label" : "Authentication",
     "description" : "Specify the Azure OpenAI authentication strategy.",
     "value" : "apiKey",
     "group" : "embeddingsStore",
     "binding" : {
-      "name" : "vectorStore.azureCosmosDbAuthentication.type",
+      "name" : "vectorStore.azureCosmosDbNoSql.authentication.type",
       "type" : "zeebe:input"
     },
     "condition" : {
@@ -1260,7 +1260,7 @@
       "value" : "clientCredentials"
     } ]
   }, {
-    "id" : "vectorStore.azureCosmosDbAuthentication.apiKey",
+    "id" : "vectorStore.azureCosmosDbNoSql.authentication.apiKey",
     "label" : "API key",
     "optional" : false,
     "constraints" : {
@@ -1269,12 +1269,12 @@
     "feel" : "optional",
     "group" : "embeddingsStore",
     "binding" : {
-      "name" : "vectorStore.azureCosmosDbAuthentication.apiKey",
+      "name" : "vectorStore.azureCosmosDbNoSql.authentication.apiKey",
       "type" : "zeebe:input"
     },
     "condition" : {
       "allMatch" : [ {
-        "property" : "vectorStore.azureCosmosDbAuthentication.type",
+        "property" : "vectorStore.azureCosmosDbNoSql.authentication.type",
         "equals" : "apiKey",
         "type" : "simple"
       }, {
@@ -1285,7 +1285,7 @@
     },
     "type" : "String"
   }, {
-    "id" : "vectorStore.azureCosmosDbAuthentication.clientId",
+    "id" : "vectorStore.azureCosmosDbNoSql.authentication.clientId",
     "label" : "Client ID",
     "description" : "ID of a Microsoft Entra application",
     "optional" : false,
@@ -1295,12 +1295,12 @@
     "feel" : "optional",
     "group" : "embeddingsStore",
     "binding" : {
-      "name" : "vectorStore.azureCosmosDbAuthentication.clientId",
+      "name" : "vectorStore.azureCosmosDbNoSql.authentication.clientId",
       "type" : "zeebe:input"
     },
     "condition" : {
       "allMatch" : [ {
-        "property" : "vectorStore.azureCosmosDbAuthentication.type",
+        "property" : "vectorStore.azureCosmosDbNoSql.authentication.type",
         "equals" : "clientCredentials",
         "type" : "simple"
       }, {
@@ -1311,7 +1311,7 @@
     },
     "type" : "String"
   }, {
-    "id" : "vectorStore.azureCosmosDbAuthentication.clientSecret",
+    "id" : "vectorStore.azureCosmosDbNoSql.authentication.clientSecret",
     "label" : "Client secret",
     "description" : "Secret of a Microsoft Entra application",
     "optional" : false,
@@ -1321,12 +1321,12 @@
     "feel" : "optional",
     "group" : "embeddingsStore",
     "binding" : {
-      "name" : "vectorStore.azureCosmosDbAuthentication.clientSecret",
+      "name" : "vectorStore.azureCosmosDbNoSql.authentication.clientSecret",
       "type" : "zeebe:input"
     },
     "condition" : {
       "allMatch" : [ {
-        "property" : "vectorStore.azureCosmosDbAuthentication.type",
+        "property" : "vectorStore.azureCosmosDbNoSql.authentication.type",
         "equals" : "clientCredentials",
         "type" : "simple"
       }, {
@@ -1337,7 +1337,7 @@
     },
     "type" : "String"
   }, {
-    "id" : "vectorStore.azureCosmosDbAuthentication.tenantId",
+    "id" : "vectorStore.azureCosmosDbNoSql.authentication.tenantId",
     "label" : "Tenant ID",
     "description" : "ID of a Microsoft Entra tenant. Details in the <a href=\"https://learn.microsoft.com/en-us/entra/fundamentals/how-to-find-tenant\" target=\"_blank\">documentation</a>.",
     "optional" : false,
@@ -1347,12 +1347,12 @@
     "feel" : "optional",
     "group" : "embeddingsStore",
     "binding" : {
-      "name" : "vectorStore.azureCosmosDbAuthentication.tenantId",
+      "name" : "vectorStore.azureCosmosDbNoSql.authentication.tenantId",
       "type" : "zeebe:input"
     },
     "condition" : {
       "allMatch" : [ {
-        "property" : "vectorStore.azureCosmosDbAuthentication.type",
+        "property" : "vectorStore.azureCosmosDbNoSql.authentication.type",
         "equals" : "clientCredentials",
         "type" : "simple"
       }, {
@@ -1363,19 +1363,19 @@
     },
     "type" : "String"
   }, {
-    "id" : "vectorStore.azureCosmosDbAuthentication.authorityHost",
+    "id" : "vectorStore.azureCosmosDbNoSql.authentication.authorityHost",
     "label" : "Authority host",
     "description" : "Authority host URL for the Microsoft Entra application. Defaults to <code>https://login.microsoftonline.com</code>. This can also contain an OAuth 2.0 token endpoint.",
     "optional" : true,
     "feel" : "optional",
     "group" : "embeddingsStore",
     "binding" : {
-      "name" : "vectorStore.azureCosmosDbAuthentication.authorityHost",
+      "name" : "vectorStore.azureCosmosDbNoSql.authentication.authorityHost",
       "type" : "zeebe:input"
     },
     "condition" : {
       "allMatch" : [ {
-        "property" : "vectorStore.azureCosmosDbAuthentication.type",
+        "property" : "vectorStore.azureCosmosDbNoSql.authentication.type",
         "equals" : "clientCredentials",
         "type" : "simple"
       }, {
@@ -1396,7 +1396,7 @@
     "feel" : "optional",
     "group" : "embeddingsStore",
     "binding" : {
-      "name" : "vectorStore.databaseName",
+      "name" : "vectorStore.azureCosmosDbNoSql.databaseName",
       "type" : "zeebe:input"
     },
     "condition" : {
@@ -1416,7 +1416,7 @@
     "feel" : "optional",
     "group" : "embeddingsStore",
     "binding" : {
-      "name" : "vectorStore.containerName",
+      "name" : "vectorStore.azureCosmosDbNoSql.containerName",
       "type" : "zeebe:input"
     },
     "condition" : {
@@ -1436,7 +1436,7 @@
     },
     "group" : "embeddingsStore",
     "binding" : {
-      "name" : "vectorStore.consistencyLevel",
+      "name" : "vectorStore.azureCosmosDbNoSql.consistencyLevel",
       "type" : "zeebe:input"
     },
     "condition" : {
@@ -1472,7 +1472,7 @@
     },
     "group" : "embeddingsStore",
     "binding" : {
-      "name" : "vectorStore.distanceFunction",
+      "name" : "vectorStore.azureCosmosDbNoSql.distanceFunction",
       "type" : "zeebe:input"
     },
     "condition" : {
@@ -1502,7 +1502,7 @@
     },
     "group" : "embeddingsStore",
     "binding" : {
-      "name" : "vectorStore.vectorIndexType",
+      "name" : "vectorStore.azureCosmosDbNoSql.vectorIndexType",
       "type" : "zeebe:input"
     },
     "condition" : {

--- a/connectors/embeddings-vector-database/element-templates/embeddings-vector-database-outbound-connector.json
+++ b/connectors/embeddings-vector-database/element-templates/embeddings-vector-database-outbound-connector.json
@@ -759,7 +759,7 @@
     },
     "type" : "Number"
   }, {
-    "id" : "embeddingModelProvider.openAiApiKey",
+    "id" : "embeddingModelProvider.openAi.apiKey",
     "label" : "OpenAI API key",
     "optional" : false,
     "constraints" : {
@@ -768,7 +768,7 @@
     "feel" : "optional",
     "group" : "embeddingModel",
     "binding" : {
-      "name" : "embeddingModelProvider.apiKey",
+      "name" : "embeddingModelProvider.openAi.apiKey",
       "type" : "zeebe:input"
     },
     "condition" : {
@@ -778,7 +778,7 @@
     },
     "type" : "String"
   }, {
-    "id" : "embeddingModelProvider.openAiModelName",
+    "id" : "embeddingModelProvider.openAi.modelName",
     "label" : "Model name",
     "description" : "Specify the model name. Details in the <a href=\"https://platform.openai.com/docs/guides/embeddings\" target=\"_blank\">documentation</a>.",
     "optional" : false,
@@ -788,7 +788,7 @@
     "feel" : "optional",
     "group" : "embeddingModel",
     "binding" : {
-      "name" : "embeddingModelProvider.modelName",
+      "name" : "embeddingModelProvider.openAi.modelName",
       "type" : "zeebe:input"
     },
     "condition" : {
@@ -798,14 +798,14 @@
     },
     "type" : "String"
   }, {
-    "id" : "embeddingModelProvider.openAiOrganizationId",
+    "id" : "embeddingModelProvider.openAi.organizationId",
     "label" : "Organization ID",
     "description" : "For members of multiple organizations. Details in the <a href=\"https://platform.openai.com/docs/api-reference/authentication\" target=\"_blank\">documentation</a>.",
     "optional" : true,
     "feel" : "optional",
     "group" : "embeddingModel",
     "binding" : {
-      "name" : "embeddingModelProvider.organizationId",
+      "name" : "embeddingModelProvider.openAi.organizationId",
       "type" : "zeebe:input"
     },
     "condition" : {
@@ -815,14 +815,14 @@
     },
     "type" : "String"
   }, {
-    "id" : "embeddingModelProvider.openAiProjectId",
+    "id" : "embeddingModelProvider.openAi.projectId",
     "label" : "Project ID",
     "description" : "For accounts with multiple projects. Details in the <a href=\"https://platform.openai.com/docs/api-reference/authentication\" target=\"_blank\">documentation</a>.",
     "optional" : true,
     "feel" : "optional",
     "group" : "embeddingModel",
     "binding" : {
-      "name" : "embeddingModelProvider.projectId",
+      "name" : "embeddingModelProvider.openAi.projectId",
       "type" : "zeebe:input"
     },
     "condition" : {
@@ -832,14 +832,14 @@
     },
     "type" : "String"
   }, {
-    "id" : "embeddingModelProvider.openAiDimensions",
+    "id" : "embeddingModelProvider.openAi.dimensions",
     "label" : "Embedding dimensions",
     "description" : "The size of the vector used to represent data. If not specified, the default model dimensions are used. Details in the <a href=\"https://platform.openai.com/docs/guides/embeddings\" target=\"_blank\">documentation</a>.",
     "optional" : true,
     "feel" : "required",
     "group" : "embeddingModel",
     "binding" : {
-      "name" : "embeddingModelProvider.dimensions",
+      "name" : "embeddingModelProvider.openAi.dimensions",
       "type" : "zeebe:input"
     },
     "condition" : {
@@ -849,7 +849,7 @@
     },
     "type" : "Number"
   }, {
-    "id" : "embeddingModelProvider.openAiMaxRetries",
+    "id" : "embeddingModelProvider.openAi.maxRetries",
     "label" : "Max retries",
     "description" : "Max retries",
     "optional" : true,
@@ -857,7 +857,7 @@
     "feel" : "static",
     "group" : "embeddingModel",
     "binding" : {
-      "name" : "embeddingModelProvider.maxRetries",
+      "name" : "embeddingModelProvider.openAi.maxRetries",
       "type" : "zeebe:input"
     },
     "condition" : {
@@ -867,14 +867,14 @@
     },
     "type" : "Number"
   }, {
-    "id" : "embeddingModelProvider.openAiCustomHeaders",
+    "id" : "embeddingModelProvider.openAi.customHeaders",
     "label" : "Custom headers",
     "description" : "Map of custom HTTP headers to add to the request.",
     "optional" : true,
     "feel" : "required",
     "group" : "embeddingModel",
     "binding" : {
-      "name" : "embeddingModelProvider.customHeaders",
+      "name" : "embeddingModelProvider.openAi.customHeaders",
       "type" : "zeebe:input"
     },
     "condition" : {
@@ -884,13 +884,13 @@
     },
     "type" : "String"
   }, {
-    "id" : "embeddingModelProvider.openAiBaseUrl",
+    "id" : "embeddingModelProvider.openAi.baseUrl",
     "label" : "Custom base URL",
     "optional" : true,
     "feel" : "optional",
     "group" : "embeddingModel",
     "binding" : {
-      "name" : "embeddingModelProvider.baseUrl",
+      "name" : "embeddingModelProvider.openAi.baseUrl",
       "type" : "zeebe:input"
     },
     "condition" : {

--- a/connectors/embeddings-vector-database/element-templates/embeddings-vector-database-outbound-connector.json
+++ b/connectors/embeddings-vector-database/element-templates/embeddings-vector-database-outbound-connector.json
@@ -938,7 +938,7 @@
     "feel" : "optional",
     "group" : "embeddingsStore",
     "binding" : {
-      "name" : "vectorStore.accessKey",
+      "name" : "vectorStore.amazonManagedOpensearch.accessKey",
       "type" : "zeebe:input"
     },
     "condition" : {
@@ -958,7 +958,7 @@
     "feel" : "optional",
     "group" : "embeddingsStore",
     "binding" : {
-      "name" : "vectorStore.secretKey",
+      "name" : "vectorStore.amazonManagedOpensearch.secretKey",
       "type" : "zeebe:input"
     },
     "condition" : {
@@ -978,7 +978,7 @@
     "feel" : "optional",
     "group" : "embeddingsStore",
     "binding" : {
-      "name" : "vectorStore.serverUrl",
+      "name" : "vectorStore.amazonManagedOpensearch.serverUrl",
       "type" : "zeebe:input"
     },
     "condition" : {
@@ -998,7 +998,7 @@
     "feel" : "optional",
     "group" : "embeddingsStore",
     "binding" : {
-      "name" : "vectorStore.region",
+      "name" : "vectorStore.amazonManagedOpensearch.region",
       "type" : "zeebe:input"
     },
     "condition" : {
@@ -1018,7 +1018,7 @@
     "feel" : "optional",
     "group" : "embeddingsStore",
     "binding" : {
-      "name" : "vectorStore.indexName",
+      "name" : "vectorStore.amazonManagedOpensearch.indexName",
       "type" : "zeebe:input"
     },
     "condition" : {

--- a/connectors/embeddings-vector-database/element-templates/embeddings-vector-database-outbound-connector.json
+++ b/connectors/embeddings-vector-database/element-templates/embeddings-vector-database-outbound-connector.json
@@ -594,7 +594,7 @@
     },
     "type" : "Number"
   }, {
-    "id" : "embeddingModelProvider.projectId",
+    "id" : "embeddingModelProvider.googleVertexAi.projectId",
     "label" : "Project ID",
     "description" : "Google Cloud project ID",
     "optional" : false,
@@ -604,7 +604,7 @@
     "feel" : "optional",
     "group" : "embeddingModel",
     "binding" : {
-      "name" : "embeddingModelProvider.projectId",
+      "name" : "embeddingModelProvider.googleVertexAi.projectId",
       "type" : "zeebe:input"
     },
     "condition" : {
@@ -614,7 +614,7 @@
     },
     "type" : "String"
   }, {
-    "id" : "embeddingModelProvider.region",
+    "id" : "embeddingModelProvider.googleVertexAi.region",
     "label" : "Region",
     "description" : "Google Cloud region for Vertex AI",
     "optional" : false,
@@ -624,7 +624,7 @@
     "feel" : "optional",
     "group" : "embeddingModel",
     "binding" : {
-      "name" : "embeddingModelProvider.region",
+      "name" : "embeddingModelProvider.googleVertexAi.region",
       "type" : "zeebe:input"
     },
     "condition" : {
@@ -634,13 +634,13 @@
     },
     "type" : "String"
   }, {
-    "id" : "embeddingModelProvider.vertexAiAuthentication.type",
+    "id" : "embeddingModelProvider.googleVertexAi.authentication.type",
     "label" : "Authentication",
     "description" : "Specify the Google Vertex AI authentication strategy.",
     "value" : "serviceAccountCredentials",
     "group" : "embeddingModel",
     "binding" : {
-      "name" : "embeddingModelProvider.vertexAiAuthentication.type",
+      "name" : "embeddingModelProvider.googleVertexAi.authentication.type",
       "type" : "zeebe:input"
     },
     "condition" : {
@@ -657,7 +657,7 @@
       "value" : "applicationDefaultCredentials"
     } ]
   }, {
-    "id" : "embeddingModelProvider.vertexAiAuthentication.jsonKey",
+    "id" : "embeddingModelProvider.googleVertexAi.authentication.jsonKey",
     "label" : "JSON key of the service account",
     "description" : "This is the key of the service account in JSON format.",
     "optional" : false,
@@ -667,12 +667,12 @@
     "feel" : "optional",
     "group" : "embeddingModel",
     "binding" : {
-      "name" : "embeddingModelProvider.vertexAiAuthentication.jsonKey",
+      "name" : "embeddingModelProvider.googleVertexAi.authentication.jsonKey",
       "type" : "zeebe:input"
     },
     "condition" : {
       "allMatch" : [ {
-        "property" : "embeddingModelProvider.vertexAiAuthentication.type",
+        "property" : "embeddingModelProvider.googleVertexAi.authentication.type",
         "equals" : "serviceAccountCredentials",
         "type" : "simple"
       }, {
@@ -683,7 +683,7 @@
     },
     "type" : "String"
   }, {
-    "id" : "embeddingModelProvider.vertexAiModelName",
+    "id" : "embeddingModelProvider.googleVertexAi.modelName",
     "label" : "Model name",
     "description" : "Vertex AI embedding model name",
     "optional" : false,
@@ -693,7 +693,7 @@
     "feel" : "optional",
     "group" : "embeddingModel",
     "binding" : {
-      "name" : "embeddingModelProvider.modelName",
+      "name" : "embeddingModelProvider.googleVertexAi.modelName",
       "type" : "zeebe:input"
     },
     "condition" : {
@@ -703,7 +703,7 @@
     },
     "type" : "String"
   }, {
-    "id" : "embeddingModelProvider.vertexAiDimensions",
+    "id" : "embeddingModelProvider.googleVertexAi.dimensions",
     "label" : "Embedding dimensions",
     "description" : "The size of the vector used to represent data. Details in the <a href=\"https://cloud.google.com/vertex-ai/generative-ai/docs/embeddings/get-text-embeddings\" target=\"_blank\">documentation</a>.",
     "optional" : false,
@@ -713,7 +713,7 @@
     "feel" : "required",
     "group" : "embeddingModel",
     "binding" : {
-      "name" : "embeddingModelProvider.dimensions",
+      "name" : "embeddingModelProvider.googleVertexAi.dimensions",
       "type" : "zeebe:input"
     },
     "condition" : {
@@ -723,7 +723,7 @@
     },
     "type" : "Number"
   }, {
-    "id" : "embeddingModelProvider.publisher",
+    "id" : "embeddingModelProvider.googleVertexAi.publisher",
     "label" : "Publisher",
     "description" : "The publisher of the Vertex AI model (e.g., 'google', 'third-party'). Optional.",
     "optional" : true,
@@ -731,7 +731,7 @@
     "feel" : "optional",
     "group" : "embeddingModel",
     "binding" : {
-      "name" : "embeddingModelProvider.publisher",
+      "name" : "embeddingModelProvider.googleVertexAi.publisher",
       "type" : "zeebe:input"
     },
     "condition" : {
@@ -741,7 +741,7 @@
     },
     "type" : "String"
   }, {
-    "id" : "embeddingModelProvider.vertexAiMaxRetries",
+    "id" : "embeddingModelProvider.googleVertexAi.maxRetries",
     "label" : "Max retries",
     "description" : "Max retries",
     "optional" : true,
@@ -749,7 +749,7 @@
     "feel" : "static",
     "group" : "embeddingModel",
     "binding" : {
-      "name" : "embeddingModelProvider.maxRetries",
+      "name" : "embeddingModelProvider.googleVertexAi.maxRetries",
       "type" : "zeebe:input"
     },
     "condition" : {

--- a/connectors/embeddings-vector-database/element-templates/embeddings-vector-database-outbound-connector.json
+++ b/connectors/embeddings-vector-database/element-templates/embeddings-vector-database-outbound-connector.json
@@ -157,7 +157,7 @@
       "value" : "OPEN_AI_MODEL_PROVIDER"
     } ]
   }, {
-    "id" : "embeddingModelProvider.endpoint",
+    "id" : "embeddingModelProvider.azureOpenAi.endpoint",
     "label" : "Endpoint",
     "description" : "Specify Azure OpenAI endpoint. Details in the <a href=\"https://learn.microsoft.com/en-us/azure/ai-foundry/openai/reference\" target=\"_blank\">documentation</a>.",
     "optional" : false,
@@ -167,7 +167,7 @@
     "feel" : "optional",
     "group" : "embeddingModel",
     "binding" : {
-      "name" : "embeddingModelProvider.endpoint",
+      "name" : "embeddingModelProvider.azureOpenAi.endpoint",
       "type" : "zeebe:input"
     },
     "condition" : {
@@ -177,13 +177,13 @@
     },
     "type" : "String"
   }, {
-    "id" : "embeddingModelProvider.authentication.type",
+    "id" : "embeddingModelProvider.azureOpenAi.authentication.type",
     "label" : "Authentication",
     "description" : "Specify the Azure OpenAI authentication strategy.",
     "value" : "apiKey",
     "group" : "embeddingModel",
     "binding" : {
-      "name" : "embeddingModelProvider.authentication.type",
+      "name" : "embeddingModelProvider.azureOpenAi.authentication.type",
       "type" : "zeebe:input"
     },
     "condition" : {
@@ -200,7 +200,7 @@
       "value" : "clientCredentials"
     } ]
   }, {
-    "id" : "embeddingModelProvider.authentication.apiKey",
+    "id" : "embeddingModelProvider.azureOpenAi.authentication.apiKey",
     "label" : "API key",
     "optional" : false,
     "constraints" : {
@@ -209,12 +209,12 @@
     "feel" : "optional",
     "group" : "embeddingModel",
     "binding" : {
-      "name" : "embeddingModelProvider.authentication.apiKey",
+      "name" : "embeddingModelProvider.azureOpenAi.authentication.apiKey",
       "type" : "zeebe:input"
     },
     "condition" : {
       "allMatch" : [ {
-        "property" : "embeddingModelProvider.authentication.type",
+        "property" : "embeddingModelProvider.azureOpenAi.authentication.type",
         "equals" : "apiKey",
         "type" : "simple"
       }, {
@@ -225,7 +225,7 @@
     },
     "type" : "String"
   }, {
-    "id" : "embeddingModelProvider.authentication.clientId",
+    "id" : "embeddingModelProvider.azureOpenAi.authentication.clientId",
     "label" : "Client ID",
     "description" : "ID of a Microsoft Entra application",
     "optional" : false,
@@ -235,12 +235,12 @@
     "feel" : "optional",
     "group" : "embeddingModel",
     "binding" : {
-      "name" : "embeddingModelProvider.authentication.clientId",
+      "name" : "embeddingModelProvider.azureOpenAi.authentication.clientId",
       "type" : "zeebe:input"
     },
     "condition" : {
       "allMatch" : [ {
-        "property" : "embeddingModelProvider.authentication.type",
+        "property" : "embeddingModelProvider.azureOpenAi.authentication.type",
         "equals" : "clientCredentials",
         "type" : "simple"
       }, {
@@ -251,7 +251,7 @@
     },
     "type" : "String"
   }, {
-    "id" : "embeddingModelProvider.authentication.clientSecret",
+    "id" : "embeddingModelProvider.azureOpenAi.authentication.clientSecret",
     "label" : "Client secret",
     "description" : "Secret of a Microsoft Entra application",
     "optional" : false,
@@ -261,12 +261,12 @@
     "feel" : "optional",
     "group" : "embeddingModel",
     "binding" : {
-      "name" : "embeddingModelProvider.authentication.clientSecret",
+      "name" : "embeddingModelProvider.azureOpenAi.authentication.clientSecret",
       "type" : "zeebe:input"
     },
     "condition" : {
       "allMatch" : [ {
-        "property" : "embeddingModelProvider.authentication.type",
+        "property" : "embeddingModelProvider.azureOpenAi.authentication.type",
         "equals" : "clientCredentials",
         "type" : "simple"
       }, {
@@ -277,7 +277,7 @@
     },
     "type" : "String"
   }, {
-    "id" : "embeddingModelProvider.authentication.tenantId",
+    "id" : "embeddingModelProvider.azureOpenAi.authentication.tenantId",
     "label" : "Tenant ID",
     "description" : "ID of a Microsoft Entra tenant. Details in the <a href=\"https://learn.microsoft.com/en-us/entra/fundamentals/how-to-find-tenant\" target=\"_blank\">documentation</a>.",
     "optional" : false,
@@ -287,12 +287,12 @@
     "feel" : "optional",
     "group" : "embeddingModel",
     "binding" : {
-      "name" : "embeddingModelProvider.authentication.tenantId",
+      "name" : "embeddingModelProvider.azureOpenAi.authentication.tenantId",
       "type" : "zeebe:input"
     },
     "condition" : {
       "allMatch" : [ {
-        "property" : "embeddingModelProvider.authentication.type",
+        "property" : "embeddingModelProvider.azureOpenAi.authentication.type",
         "equals" : "clientCredentials",
         "type" : "simple"
       }, {
@@ -303,19 +303,19 @@
     },
     "type" : "String"
   }, {
-    "id" : "embeddingModelProvider.authentication.authorityHost",
+    "id" : "embeddingModelProvider.azureOpenAi.authentication.authorityHost",
     "label" : "Authority host",
     "description" : "Authority host URL for the Microsoft Entra application. Defaults to <code>https://login.microsoftonline.com</code>. This can also contain an OAuth 2.0 token endpoint.",
     "optional" : true,
     "feel" : "optional",
     "group" : "embeddingModel",
     "binding" : {
-      "name" : "embeddingModelProvider.authentication.authorityHost",
+      "name" : "embeddingModelProvider.azureOpenAi.authentication.authorityHost",
       "type" : "zeebe:input"
     },
     "condition" : {
       "allMatch" : [ {
-        "property" : "embeddingModelProvider.authentication.type",
+        "property" : "embeddingModelProvider.azureOpenAi.authentication.type",
         "equals" : "clientCredentials",
         "type" : "simple"
       }, {
@@ -326,7 +326,7 @@
     },
     "type" : "String"
   }, {
-    "id" : "embeddingModelProvider.deploymentName",
+    "id" : "embeddingModelProvider.azureOpenAi.deploymentName",
     "label" : "Model deployment name",
     "description" : "Specify the model deployment name. Details in the <a href=\"https://learn.microsoft.com/en-us/azure/ai-foundry/openai/reference\" target=\"_blank\">documentation</a>.",
     "optional" : false,
@@ -336,7 +336,7 @@
     "feel" : "optional",
     "group" : "embeddingModel",
     "binding" : {
-      "name" : "embeddingModelProvider.deploymentName",
+      "name" : "embeddingModelProvider.azureOpenAi.deploymentName",
       "type" : "zeebe:input"
     },
     "condition" : {
@@ -346,14 +346,14 @@
     },
     "type" : "String"
   }, {
-    "id" : "embeddingModelProvider.dimensions",
+    "id" : "embeddingModelProvider.azureOpenAi.dimensions",
     "label" : "Embedding dimensions",
     "description" : "The size of the vector used to represent data. If not specified, the default model dimensions are used. Details in the <a href=\"https://platform.openai.com/docs/guides/embeddings\" target=\"_blank\">documentation</a>.",
     "optional" : true,
     "feel" : "required",
     "group" : "embeddingModel",
     "binding" : {
-      "name" : "embeddingModelProvider.dimensions",
+      "name" : "embeddingModelProvider.azureOpenAi.dimensions",
       "type" : "zeebe:input"
     },
     "condition" : {
@@ -363,7 +363,7 @@
     },
     "type" : "Number"
   }, {
-    "id" : "embeddingModelProvider.maxRetries",
+    "id" : "embeddingModelProvider.azureOpenAi.maxRetries",
     "label" : "Max retries",
     "description" : "Max retries",
     "optional" : true,
@@ -371,7 +371,7 @@
     "feel" : "static",
     "group" : "embeddingModel",
     "binding" : {
-      "name" : "embeddingModelProvider.maxRetries",
+      "name" : "embeddingModelProvider.azureOpenAi.maxRetries",
       "type" : "zeebe:input"
     },
     "condition" : {
@@ -381,14 +381,14 @@
     },
     "type" : "Number"
   }, {
-    "id" : "embeddingModelProvider.customHeaders",
+    "id" : "embeddingModelProvider.azureOpenAi.customHeaders",
     "label" : "Custom headers",
     "description" : "Map of custom HTTP headers to add to the request.",
     "optional" : true,
     "feel" : "required",
     "group" : "embeddingModel",
     "binding" : {
-      "name" : "embeddingModelProvider.customHeaders",
+      "name" : "embeddingModelProvider.azureOpenAi.customHeaders",
       "type" : "zeebe:input"
     },
     "condition" : {

--- a/connectors/embeddings-vector-database/element-templates/embeddings-vector-database-outbound-connector.json
+++ b/connectors/embeddings-vector-database/element-templates/embeddings-vector-database-outbound-connector.json
@@ -1522,7 +1522,7 @@
       "value" : "DISK_ANN"
     } ]
   }, {
-    "id" : "vectorStore.embeddingsStore.elasticsearch.baseUrl",
+    "id" : "vectorStore.elasticSearch.baseUrl",
     "label" : "Base URL",
     "description" : "Elasticsearch base URL, i.e. http(s)://host:port",
     "optional" : false,
@@ -1532,7 +1532,7 @@
     "feel" : "optional",
     "group" : "embeddingsStore",
     "binding" : {
-      "name" : "vectorStore.baseUrl",
+      "name" : "vectorStore.elasticSearch.baseUrl",
       "type" : "zeebe:input"
     },
     "condition" : {
@@ -1542,7 +1542,7 @@
     },
     "type" : "String"
   }, {
-    "id" : "vectorStore.embeddingsStore.elasticsearch.username",
+    "id" : "vectorStore.elasticSearch.userName",
     "label" : "Username",
     "description" : "Elasticsearch username",
     "optional" : false,
@@ -1552,7 +1552,7 @@
     "feel" : "optional",
     "group" : "embeddingsStore",
     "binding" : {
-      "name" : "vectorStore.userName",
+      "name" : "vectorStore.elasticSearch.userName",
       "type" : "zeebe:input"
     },
     "condition" : {
@@ -1562,7 +1562,7 @@
     },
     "type" : "String"
   }, {
-    "id" : "vectorStore.embeddingsStore.elasticsearch.password",
+    "id" : "vectorStore.elasticSearch.password",
     "label" : "Password",
     "description" : "Elasticsearch password",
     "optional" : false,
@@ -1572,7 +1572,7 @@
     "feel" : "optional",
     "group" : "embeddingsStore",
     "binding" : {
-      "name" : "vectorStore.password",
+      "name" : "vectorStore.elasticSearch.password",
       "type" : "zeebe:input"
     },
     "condition" : {
@@ -1582,7 +1582,7 @@
     },
     "type" : "String"
   }, {
-    "id" : "vectorStore.embeddingsStore.elasticsearch.indexName",
+    "id" : "vectorStore.elasticSearch.indexName",
     "label" : "Index name",
     "description" : "Elasticsearch index",
     "optional" : false,
@@ -1592,7 +1592,7 @@
     "feel" : "optional",
     "group" : "embeddingsStore",
     "binding" : {
-      "name" : "vectorStore.indexName",
+      "name" : "vectorStore.elasticSearch.indexName",
       "type" : "zeebe:input"
     },
     "condition" : {

--- a/connectors/embeddings-vector-database/element-templates/embeddings-vector-database-outbound-connector.json
+++ b/connectors/embeddings-vector-database/element-templates/embeddings-vector-database-outbound-connector.json
@@ -1602,7 +1602,7 @@
     },
     "type" : "String"
   }, {
-    "id" : "vectorStore.embeddingsStore.opensearch.baseUrl",
+    "id" : "vectorStore.openSearch.baseUrl",
     "label" : "Base URL",
     "description" : "OpenSearch base URL, i.e. http(s)://host:port",
     "optional" : false,
@@ -1612,7 +1612,7 @@
     "feel" : "optional",
     "group" : "embeddingsStore",
     "binding" : {
-      "name" : "vectorStore.baseUrl",
+      "name" : "vectorStore.openSearch.baseUrl",
       "type" : "zeebe:input"
     },
     "condition" : {
@@ -1622,7 +1622,7 @@
     },
     "type" : "String"
   }, {
-    "id" : "vectorStore.embeddingsStore.opensearch.username",
+    "id" : "vectorStore.openSearch.userName",
     "label" : "Username",
     "description" : "OpenSearch username",
     "optional" : false,
@@ -1632,7 +1632,7 @@
     "feel" : "optional",
     "group" : "embeddingsStore",
     "binding" : {
-      "name" : "vectorStore.userName",
+      "name" : "vectorStore.openSearch.userName",
       "type" : "zeebe:input"
     },
     "condition" : {
@@ -1642,7 +1642,7 @@
     },
     "type" : "String"
   }, {
-    "id" : "vectorStore.embeddingsStore.opensearch.password",
+    "id" : "vectorStore.openSearch.password",
     "label" : "Password",
     "description" : "OpenSearch password",
     "optional" : false,
@@ -1652,7 +1652,7 @@
     "feel" : "optional",
     "group" : "embeddingsStore",
     "binding" : {
-      "name" : "vectorStore.password",
+      "name" : "vectorStore.openSearch.password",
       "type" : "zeebe:input"
     },
     "condition" : {
@@ -1662,7 +1662,7 @@
     },
     "type" : "String"
   }, {
-    "id" : "vectorStore.embeddingsStore.opensearch.indexName",
+    "id" : "vectorStore.openSearch.indexName",
     "label" : "Index name",
     "description" : "OpenSearch index",
     "optional" : false,
@@ -1672,7 +1672,7 @@
     "feel" : "optional",
     "group" : "embeddingsStore",
     "binding" : {
-      "name" : "vectorStore.indexName",
+      "name" : "vectorStore.openSearch.indexName",
       "type" : "zeebe:input"
     },
     "condition" : {

--- a/connectors/embeddings-vector-database/element-templates/embeddings-vector-database-outbound-connector.json
+++ b/connectors/embeddings-vector-database/element-templates/embeddings-vector-database-outbound-connector.json
@@ -1028,7 +1028,7 @@
     },
     "type" : "String"
   }, {
-    "id" : "vectorStore.azureAiSearch.endpoint",
+    "id" : "vectorStore.aiSearch.endpoint",
     "label" : "Endpoint",
     "description" : "Specify Azure AI Search endpoint. Details in the <a href=\"https://learn.microsoft.com/en-us/azure/search/\" target=\"_blank\">documentation</a>.",
     "optional" : false,
@@ -1038,7 +1038,7 @@
     "feel" : "optional",
     "group" : "embeddingsStore",
     "binding" : {
-      "name" : "vectorStore.endpoint",
+      "name" : "vectorStore.aiSearch.endpoint",
       "type" : "zeebe:input"
     },
     "condition" : {
@@ -1048,13 +1048,13 @@
     },
     "type" : "String"
   }, {
-    "id" : "vectorStore.azureAiSearchAuthentication.type",
+    "id" : "vectorStore.aiSearch.authentication.type",
     "label" : "Authentication",
     "description" : "Specify the Azure OpenAI authentication strategy.",
     "value" : "apiKey",
     "group" : "embeddingsStore",
     "binding" : {
-      "name" : "vectorStore.azureAiSearchAuthentication.type",
+      "name" : "vectorStore.aiSearch.authentication.type",
       "type" : "zeebe:input"
     },
     "condition" : {
@@ -1071,7 +1071,7 @@
       "value" : "clientCredentials"
     } ]
   }, {
-    "id" : "vectorStore.azureAiSearchAuthentication.apiKey",
+    "id" : "vectorStore.aiSearch.authentication.apiKey",
     "label" : "API key",
     "optional" : false,
     "constraints" : {
@@ -1080,12 +1080,12 @@
     "feel" : "optional",
     "group" : "embeddingsStore",
     "binding" : {
-      "name" : "vectorStore.azureAiSearchAuthentication.apiKey",
+      "name" : "vectorStore.aiSearch.authentication.apiKey",
       "type" : "zeebe:input"
     },
     "condition" : {
       "allMatch" : [ {
-        "property" : "vectorStore.azureAiSearchAuthentication.type",
+        "property" : "vectorStore.aiSearch.authentication.type",
         "equals" : "apiKey",
         "type" : "simple"
       }, {
@@ -1096,7 +1096,7 @@
     },
     "type" : "String"
   }, {
-    "id" : "vectorStore.azureAiSearchAuthentication.clientId",
+    "id" : "vectorStore.aiSearch.authentication.clientId",
     "label" : "Client ID",
     "description" : "ID of a Microsoft Entra application",
     "optional" : false,
@@ -1106,12 +1106,12 @@
     "feel" : "optional",
     "group" : "embeddingsStore",
     "binding" : {
-      "name" : "vectorStore.azureAiSearchAuthentication.clientId",
+      "name" : "vectorStore.aiSearch.authentication.clientId",
       "type" : "zeebe:input"
     },
     "condition" : {
       "allMatch" : [ {
-        "property" : "vectorStore.azureAiSearchAuthentication.type",
+        "property" : "vectorStore.aiSearch.authentication.type",
         "equals" : "clientCredentials",
         "type" : "simple"
       }, {
@@ -1122,7 +1122,7 @@
     },
     "type" : "String"
   }, {
-    "id" : "vectorStore.azureAiSearchAuthentication.clientSecret",
+    "id" : "vectorStore.aiSearch.authentication.clientSecret",
     "label" : "Client secret",
     "description" : "Secret of a Microsoft Entra application",
     "optional" : false,
@@ -1132,12 +1132,12 @@
     "feel" : "optional",
     "group" : "embeddingsStore",
     "binding" : {
-      "name" : "vectorStore.azureAiSearchAuthentication.clientSecret",
+      "name" : "vectorStore.aiSearch.authentication.clientSecret",
       "type" : "zeebe:input"
     },
     "condition" : {
       "allMatch" : [ {
-        "property" : "vectorStore.azureAiSearchAuthentication.type",
+        "property" : "vectorStore.aiSearch.authentication.type",
         "equals" : "clientCredentials",
         "type" : "simple"
       }, {
@@ -1148,7 +1148,7 @@
     },
     "type" : "String"
   }, {
-    "id" : "vectorStore.azureAiSearchAuthentication.tenantId",
+    "id" : "vectorStore.aiSearch.authentication.tenantId",
     "label" : "Tenant ID",
     "description" : "ID of a Microsoft Entra tenant. Details in the <a href=\"https://learn.microsoft.com/en-us/entra/fundamentals/how-to-find-tenant\" target=\"_blank\">documentation</a>.",
     "optional" : false,
@@ -1158,12 +1158,12 @@
     "feel" : "optional",
     "group" : "embeddingsStore",
     "binding" : {
-      "name" : "vectorStore.azureAiSearchAuthentication.tenantId",
+      "name" : "vectorStore.aiSearch.authentication.tenantId",
       "type" : "zeebe:input"
     },
     "condition" : {
       "allMatch" : [ {
-        "property" : "vectorStore.azureAiSearchAuthentication.type",
+        "property" : "vectorStore.aiSearch.authentication.type",
         "equals" : "clientCredentials",
         "type" : "simple"
       }, {
@@ -1174,19 +1174,19 @@
     },
     "type" : "String"
   }, {
-    "id" : "vectorStore.azureAiSearchAuthentication.authorityHost",
+    "id" : "vectorStore.aiSearch.authentication.authorityHost",
     "label" : "Authority host",
     "description" : "Authority host URL for the Microsoft Entra application. Defaults to <code>https://login.microsoftonline.com</code>. This can also contain an OAuth 2.0 token endpoint.",
     "optional" : true,
     "feel" : "optional",
     "group" : "embeddingsStore",
     "binding" : {
-      "name" : "vectorStore.azureAiSearchAuthentication.authorityHost",
+      "name" : "vectorStore.aiSearch.authentication.authorityHost",
       "type" : "zeebe:input"
     },
     "condition" : {
       "allMatch" : [ {
-        "property" : "vectorStore.azureAiSearchAuthentication.type",
+        "property" : "vectorStore.aiSearch.authentication.type",
         "equals" : "clientCredentials",
         "type" : "simple"
       }, {
@@ -1197,7 +1197,7 @@
     },
     "type" : "String"
   }, {
-    "id" : "vectorStore.azureAiSearch.indexName",
+    "id" : "vectorStore.aiSearch.indexName",
     "label" : "Index name",
     "description" : "The name of the search index. When storing embeddings this index is created or updated automatically.",
     "optional" : false,
@@ -1207,7 +1207,7 @@
     "feel" : "optional",
     "group" : "embeddingsStore",
     "binding" : {
-      "name" : "vectorStore.indexName",
+      "name" : "vectorStore.aiSearch.indexName",
       "type" : "zeebe:input"
     },
     "condition" : {

--- a/connectors/embeddings-vector-database/element-templates/embeddings-vector-database-outbound-connector.json
+++ b/connectors/embeddings-vector-database/element-templates/embeddings-vector-database-outbound-connector.json
@@ -398,7 +398,7 @@
     },
     "type" : "String"
   }, {
-    "id" : "embeddingModelProvider.bedrockAccessKey",
+    "id" : "embeddingModelProvider.bedrock.accessKey",
     "label" : "Access key",
     "description" : "Provide an IAM access key tailored to a user, equipped with the necessary permissions",
     "optional" : false,
@@ -408,7 +408,7 @@
     "feel" : "optional",
     "group" : "embeddingModel",
     "binding" : {
-      "name" : "embeddingModelProvider.accessKey",
+      "name" : "embeddingModelProvider.bedrock.accessKey",
       "type" : "zeebe:input"
     },
     "condition" : {
@@ -418,7 +418,7 @@
     },
     "type" : "String"
   }, {
-    "id" : "embeddingModelProvider.bedrockSecretKey",
+    "id" : "embeddingModelProvider.bedrock.secretKey",
     "label" : "Secret key",
     "description" : "Provide a secret key associated with the access key",
     "optional" : false,
@@ -428,7 +428,7 @@
     "feel" : "optional",
     "group" : "embeddingModel",
     "binding" : {
-      "name" : "embeddingModelProvider.secretKey",
+      "name" : "embeddingModelProvider.bedrock.secretKey",
       "type" : "zeebe:input"
     },
     "condition" : {
@@ -438,7 +438,7 @@
     },
     "type" : "String"
   }, {
-    "id" : "embeddingModelProvider.bedrockRegion",
+    "id" : "embeddingModelProvider.bedrock.region",
     "label" : "Region",
     "description" : "AWS Bedrock region",
     "optional" : false,
@@ -448,7 +448,7 @@
     "feel" : "optional",
     "group" : "embeddingModel",
     "binding" : {
-      "name" : "embeddingModelProvider.region",
+      "name" : "embeddingModelProvider.bedrock.region",
       "type" : "zeebe:input"
     },
     "condition" : {
@@ -458,7 +458,7 @@
     },
     "type" : "String"
   }, {
-    "id" : "embeddingModelProvider.modelName",
+    "id" : "embeddingModelProvider.bedrock.modelName",
     "label" : "Model name",
     "description" : "Bedrock model name or identifier",
     "optional" : false,
@@ -468,7 +468,7 @@
     },
     "group" : "embeddingModel",
     "binding" : {
-      "name" : "embeddingModelProvider.modelName",
+      "name" : "embeddingModelProvider.bedrock.modelName",
       "type" : "zeebe:input"
     },
     "condition" : {
@@ -488,7 +488,7 @@
       "value" : "TitanEmbedTextV2"
     } ]
   }, {
-    "id" : "embeddingModelProvider.bedrockCustomModelName",
+    "id" : "embeddingModelProvider.bedrock.customModelName",
     "label" : "Custom model name",
     "optional" : false,
     "constraints" : {
@@ -497,7 +497,7 @@
     "feel" : "optional",
     "group" : "embeddingModel",
     "binding" : {
-      "name" : "embeddingModelProvider.customModelName",
+      "name" : "embeddingModelProvider.bedrock.customModelName",
       "type" : "zeebe:input"
     },
     "condition" : {
@@ -513,7 +513,7 @@
     },
     "type" : "String"
   }, {
-    "id" : "embeddingModelProvider.bedrockDimensions",
+    "id" : "embeddingModelProvider.bedrock.dimensions",
     "label" : "Embedding dimensions",
     "description" : "The size of the vector used to represent data",
     "optional" : false,
@@ -523,7 +523,7 @@
     },
     "group" : "embeddingModel",
     "binding" : {
-      "name" : "embeddingModelProvider.dimensions",
+      "name" : "embeddingModelProvider.bedrock.dimensions",
       "type" : "zeebe:input"
     },
     "condition" : {
@@ -549,7 +549,7 @@
       "value" : "D1024"
     } ]
   }, {
-    "id" : "embeddingModelProvider.bedrockNormalize",
+    "id" : "embeddingModelProvider.bedrock.normalize",
     "label" : "Normalize",
     "description" : "Normalize vector",
     "optional" : false,
@@ -560,7 +560,7 @@
     "feel" : "static",
     "group" : "embeddingModel",
     "binding" : {
-      "name" : "embeddingModelProvider.normalize",
+      "name" : "embeddingModelProvider.bedrock.normalize",
       "type" : "zeebe:input"
     },
     "condition" : {
@@ -576,7 +576,7 @@
     },
     "type" : "Boolean"
   }, {
-    "id" : "embeddingModelProvider.bedrockMaxRetries",
+    "id" : "embeddingModelProvider.bedrock.maxRetries",
     "label" : "Max retries",
     "description" : "Max retries",
     "optional" : false,
@@ -584,7 +584,7 @@
     "feel" : "static",
     "group" : "embeddingModel",
     "binding" : {
-      "name" : "embeddingModelProvider.maxRetries",
+      "name" : "embeddingModelProvider.bedrock.maxRetries",
       "type" : "zeebe:input"
     },
     "condition" : {

--- a/connectors/embeddings-vector-database/element-templates/hybrid/embeddings-vector-database-outbound-connector-hybrid.json
+++ b/connectors/embeddings-vector-database/element-templates/hybrid/embeddings-vector-database-outbound-connector-hybrid.json
@@ -943,7 +943,7 @@
     "feel" : "optional",
     "group" : "embeddingsStore",
     "binding" : {
-      "name" : "vectorStore.accessKey",
+      "name" : "vectorStore.amazonManagedOpensearch.accessKey",
       "type" : "zeebe:input"
     },
     "condition" : {
@@ -963,7 +963,7 @@
     "feel" : "optional",
     "group" : "embeddingsStore",
     "binding" : {
-      "name" : "vectorStore.secretKey",
+      "name" : "vectorStore.amazonManagedOpensearch.secretKey",
       "type" : "zeebe:input"
     },
     "condition" : {
@@ -983,7 +983,7 @@
     "feel" : "optional",
     "group" : "embeddingsStore",
     "binding" : {
-      "name" : "vectorStore.serverUrl",
+      "name" : "vectorStore.amazonManagedOpensearch.serverUrl",
       "type" : "zeebe:input"
     },
     "condition" : {
@@ -1003,7 +1003,7 @@
     "feel" : "optional",
     "group" : "embeddingsStore",
     "binding" : {
-      "name" : "vectorStore.region",
+      "name" : "vectorStore.amazonManagedOpensearch.region",
       "type" : "zeebe:input"
     },
     "condition" : {
@@ -1023,7 +1023,7 @@
     "feel" : "optional",
     "group" : "embeddingsStore",
     "binding" : {
-      "name" : "vectorStore.indexName",
+      "name" : "vectorStore.amazonManagedOpensearch.indexName",
       "type" : "zeebe:input"
     },
     "condition" : {

--- a/connectors/embeddings-vector-database/element-templates/hybrid/embeddings-vector-database-outbound-connector-hybrid.json
+++ b/connectors/embeddings-vector-database/element-templates/hybrid/embeddings-vector-database-outbound-connector-hybrid.json
@@ -599,7 +599,7 @@
     },
     "type" : "Number"
   }, {
-    "id" : "embeddingModelProvider.projectId",
+    "id" : "embeddingModelProvider.googleVertexAi.projectId",
     "label" : "Project ID",
     "description" : "Google Cloud project ID",
     "optional" : false,
@@ -609,7 +609,7 @@
     "feel" : "optional",
     "group" : "embeddingModel",
     "binding" : {
-      "name" : "embeddingModelProvider.projectId",
+      "name" : "embeddingModelProvider.googleVertexAi.projectId",
       "type" : "zeebe:input"
     },
     "condition" : {
@@ -619,7 +619,7 @@
     },
     "type" : "String"
   }, {
-    "id" : "embeddingModelProvider.region",
+    "id" : "embeddingModelProvider.googleVertexAi.region",
     "label" : "Region",
     "description" : "Google Cloud region for Vertex AI",
     "optional" : false,
@@ -629,7 +629,7 @@
     "feel" : "optional",
     "group" : "embeddingModel",
     "binding" : {
-      "name" : "embeddingModelProvider.region",
+      "name" : "embeddingModelProvider.googleVertexAi.region",
       "type" : "zeebe:input"
     },
     "condition" : {
@@ -639,13 +639,13 @@
     },
     "type" : "String"
   }, {
-    "id" : "embeddingModelProvider.vertexAiAuthentication.type",
+    "id" : "embeddingModelProvider.googleVertexAi.authentication.type",
     "label" : "Authentication",
     "description" : "Specify the Google Vertex AI authentication strategy.",
     "value" : "serviceAccountCredentials",
     "group" : "embeddingModel",
     "binding" : {
-      "name" : "embeddingModelProvider.vertexAiAuthentication.type",
+      "name" : "embeddingModelProvider.googleVertexAi.authentication.type",
       "type" : "zeebe:input"
     },
     "condition" : {
@@ -662,7 +662,7 @@
       "value" : "applicationDefaultCredentials"
     } ]
   }, {
-    "id" : "embeddingModelProvider.vertexAiAuthentication.jsonKey",
+    "id" : "embeddingModelProvider.googleVertexAi.authentication.jsonKey",
     "label" : "JSON key of the service account",
     "description" : "This is the key of the service account in JSON format.",
     "optional" : false,
@@ -672,12 +672,12 @@
     "feel" : "optional",
     "group" : "embeddingModel",
     "binding" : {
-      "name" : "embeddingModelProvider.vertexAiAuthentication.jsonKey",
+      "name" : "embeddingModelProvider.googleVertexAi.authentication.jsonKey",
       "type" : "zeebe:input"
     },
     "condition" : {
       "allMatch" : [ {
-        "property" : "embeddingModelProvider.vertexAiAuthentication.type",
+        "property" : "embeddingModelProvider.googleVertexAi.authentication.type",
         "equals" : "serviceAccountCredentials",
         "type" : "simple"
       }, {
@@ -688,7 +688,7 @@
     },
     "type" : "String"
   }, {
-    "id" : "embeddingModelProvider.vertexAiModelName",
+    "id" : "embeddingModelProvider.googleVertexAi.modelName",
     "label" : "Model name",
     "description" : "Vertex AI embedding model name",
     "optional" : false,
@@ -698,7 +698,7 @@
     "feel" : "optional",
     "group" : "embeddingModel",
     "binding" : {
-      "name" : "embeddingModelProvider.modelName",
+      "name" : "embeddingModelProvider.googleVertexAi.modelName",
       "type" : "zeebe:input"
     },
     "condition" : {
@@ -708,7 +708,7 @@
     },
     "type" : "String"
   }, {
-    "id" : "embeddingModelProvider.vertexAiDimensions",
+    "id" : "embeddingModelProvider.googleVertexAi.dimensions",
     "label" : "Embedding dimensions",
     "description" : "The size of the vector used to represent data. Details in the <a href=\"https://cloud.google.com/vertex-ai/generative-ai/docs/embeddings/get-text-embeddings\" target=\"_blank\">documentation</a>.",
     "optional" : false,
@@ -718,7 +718,7 @@
     "feel" : "required",
     "group" : "embeddingModel",
     "binding" : {
-      "name" : "embeddingModelProvider.dimensions",
+      "name" : "embeddingModelProvider.googleVertexAi.dimensions",
       "type" : "zeebe:input"
     },
     "condition" : {
@@ -728,7 +728,7 @@
     },
     "type" : "Number"
   }, {
-    "id" : "embeddingModelProvider.publisher",
+    "id" : "embeddingModelProvider.googleVertexAi.publisher",
     "label" : "Publisher",
     "description" : "The publisher of the Vertex AI model (e.g., 'google', 'third-party'). Optional.",
     "optional" : true,
@@ -736,7 +736,7 @@
     "feel" : "optional",
     "group" : "embeddingModel",
     "binding" : {
-      "name" : "embeddingModelProvider.publisher",
+      "name" : "embeddingModelProvider.googleVertexAi.publisher",
       "type" : "zeebe:input"
     },
     "condition" : {
@@ -746,7 +746,7 @@
     },
     "type" : "String"
   }, {
-    "id" : "embeddingModelProvider.vertexAiMaxRetries",
+    "id" : "embeddingModelProvider.googleVertexAi.maxRetries",
     "label" : "Max retries",
     "description" : "Max retries",
     "optional" : true,
@@ -754,7 +754,7 @@
     "feel" : "static",
     "group" : "embeddingModel",
     "binding" : {
-      "name" : "embeddingModelProvider.maxRetries",
+      "name" : "embeddingModelProvider.googleVertexAi.maxRetries",
       "type" : "zeebe:input"
     },
     "condition" : {

--- a/connectors/embeddings-vector-database/element-templates/hybrid/embeddings-vector-database-outbound-connector-hybrid.json
+++ b/connectors/embeddings-vector-database/element-templates/hybrid/embeddings-vector-database-outbound-connector-hybrid.json
@@ -403,7 +403,7 @@
     },
     "type" : "String"
   }, {
-    "id" : "embeddingModelProvider.bedrockAccessKey",
+    "id" : "embeddingModelProvider.bedrock.accessKey",
     "label" : "Access key",
     "description" : "Provide an IAM access key tailored to a user, equipped with the necessary permissions",
     "optional" : false,
@@ -413,7 +413,7 @@
     "feel" : "optional",
     "group" : "embeddingModel",
     "binding" : {
-      "name" : "embeddingModelProvider.accessKey",
+      "name" : "embeddingModelProvider.bedrock.accessKey",
       "type" : "zeebe:input"
     },
     "condition" : {
@@ -423,7 +423,7 @@
     },
     "type" : "String"
   }, {
-    "id" : "embeddingModelProvider.bedrockSecretKey",
+    "id" : "embeddingModelProvider.bedrock.secretKey",
     "label" : "Secret key",
     "description" : "Provide a secret key associated with the access key",
     "optional" : false,
@@ -433,7 +433,7 @@
     "feel" : "optional",
     "group" : "embeddingModel",
     "binding" : {
-      "name" : "embeddingModelProvider.secretKey",
+      "name" : "embeddingModelProvider.bedrock.secretKey",
       "type" : "zeebe:input"
     },
     "condition" : {
@@ -443,7 +443,7 @@
     },
     "type" : "String"
   }, {
-    "id" : "embeddingModelProvider.bedrockRegion",
+    "id" : "embeddingModelProvider.bedrock.region",
     "label" : "Region",
     "description" : "AWS Bedrock region",
     "optional" : false,
@@ -453,7 +453,7 @@
     "feel" : "optional",
     "group" : "embeddingModel",
     "binding" : {
-      "name" : "embeddingModelProvider.region",
+      "name" : "embeddingModelProvider.bedrock.region",
       "type" : "zeebe:input"
     },
     "condition" : {
@@ -463,7 +463,7 @@
     },
     "type" : "String"
   }, {
-    "id" : "embeddingModelProvider.modelName",
+    "id" : "embeddingModelProvider.bedrock.modelName",
     "label" : "Model name",
     "description" : "Bedrock model name or identifier",
     "optional" : false,
@@ -473,7 +473,7 @@
     },
     "group" : "embeddingModel",
     "binding" : {
-      "name" : "embeddingModelProvider.modelName",
+      "name" : "embeddingModelProvider.bedrock.modelName",
       "type" : "zeebe:input"
     },
     "condition" : {
@@ -493,7 +493,7 @@
       "value" : "TitanEmbedTextV2"
     } ]
   }, {
-    "id" : "embeddingModelProvider.bedrockCustomModelName",
+    "id" : "embeddingModelProvider.bedrock.customModelName",
     "label" : "Custom model name",
     "optional" : false,
     "constraints" : {
@@ -502,7 +502,7 @@
     "feel" : "optional",
     "group" : "embeddingModel",
     "binding" : {
-      "name" : "embeddingModelProvider.customModelName",
+      "name" : "embeddingModelProvider.bedrock.customModelName",
       "type" : "zeebe:input"
     },
     "condition" : {
@@ -518,7 +518,7 @@
     },
     "type" : "String"
   }, {
-    "id" : "embeddingModelProvider.bedrockDimensions",
+    "id" : "embeddingModelProvider.bedrock.dimensions",
     "label" : "Embedding dimensions",
     "description" : "The size of the vector used to represent data",
     "optional" : false,
@@ -528,7 +528,7 @@
     },
     "group" : "embeddingModel",
     "binding" : {
-      "name" : "embeddingModelProvider.dimensions",
+      "name" : "embeddingModelProvider.bedrock.dimensions",
       "type" : "zeebe:input"
     },
     "condition" : {
@@ -554,7 +554,7 @@
       "value" : "D1024"
     } ]
   }, {
-    "id" : "embeddingModelProvider.bedrockNormalize",
+    "id" : "embeddingModelProvider.bedrock.normalize",
     "label" : "Normalize",
     "description" : "Normalize vector",
     "optional" : false,
@@ -565,7 +565,7 @@
     "feel" : "static",
     "group" : "embeddingModel",
     "binding" : {
-      "name" : "embeddingModelProvider.normalize",
+      "name" : "embeddingModelProvider.bedrock.normalize",
       "type" : "zeebe:input"
     },
     "condition" : {
@@ -581,7 +581,7 @@
     },
     "type" : "Boolean"
   }, {
-    "id" : "embeddingModelProvider.bedrockMaxRetries",
+    "id" : "embeddingModelProvider.bedrock.maxRetries",
     "label" : "Max retries",
     "description" : "Max retries",
     "optional" : false,
@@ -589,7 +589,7 @@
     "feel" : "static",
     "group" : "embeddingModel",
     "binding" : {
-      "name" : "embeddingModelProvider.maxRetries",
+      "name" : "embeddingModelProvider.bedrock.maxRetries",
       "type" : "zeebe:input"
     },
     "condition" : {

--- a/connectors/embeddings-vector-database/element-templates/hybrid/embeddings-vector-database-outbound-connector-hybrid.json
+++ b/connectors/embeddings-vector-database/element-templates/hybrid/embeddings-vector-database-outbound-connector-hybrid.json
@@ -162,7 +162,7 @@
       "value" : "OPEN_AI_MODEL_PROVIDER"
     } ]
   }, {
-    "id" : "embeddingModelProvider.endpoint",
+    "id" : "embeddingModelProvider.azureOpenAi.endpoint",
     "label" : "Endpoint",
     "description" : "Specify Azure OpenAI endpoint. Details in the <a href=\"https://learn.microsoft.com/en-us/azure/ai-foundry/openai/reference\" target=\"_blank\">documentation</a>.",
     "optional" : false,
@@ -172,7 +172,7 @@
     "feel" : "optional",
     "group" : "embeddingModel",
     "binding" : {
-      "name" : "embeddingModelProvider.endpoint",
+      "name" : "embeddingModelProvider.azureOpenAi.endpoint",
       "type" : "zeebe:input"
     },
     "condition" : {
@@ -182,13 +182,13 @@
     },
     "type" : "String"
   }, {
-    "id" : "embeddingModelProvider.authentication.type",
+    "id" : "embeddingModelProvider.azureOpenAi.authentication.type",
     "label" : "Authentication",
     "description" : "Specify the Azure OpenAI authentication strategy.",
     "value" : "apiKey",
     "group" : "embeddingModel",
     "binding" : {
-      "name" : "embeddingModelProvider.authentication.type",
+      "name" : "embeddingModelProvider.azureOpenAi.authentication.type",
       "type" : "zeebe:input"
     },
     "condition" : {
@@ -205,7 +205,7 @@
       "value" : "clientCredentials"
     } ]
   }, {
-    "id" : "embeddingModelProvider.authentication.apiKey",
+    "id" : "embeddingModelProvider.azureOpenAi.authentication.apiKey",
     "label" : "API key",
     "optional" : false,
     "constraints" : {
@@ -214,12 +214,12 @@
     "feel" : "optional",
     "group" : "embeddingModel",
     "binding" : {
-      "name" : "embeddingModelProvider.authentication.apiKey",
+      "name" : "embeddingModelProvider.azureOpenAi.authentication.apiKey",
       "type" : "zeebe:input"
     },
     "condition" : {
       "allMatch" : [ {
-        "property" : "embeddingModelProvider.authentication.type",
+        "property" : "embeddingModelProvider.azureOpenAi.authentication.type",
         "equals" : "apiKey",
         "type" : "simple"
       }, {
@@ -230,7 +230,7 @@
     },
     "type" : "String"
   }, {
-    "id" : "embeddingModelProvider.authentication.clientId",
+    "id" : "embeddingModelProvider.azureOpenAi.authentication.clientId",
     "label" : "Client ID",
     "description" : "ID of a Microsoft Entra application",
     "optional" : false,
@@ -240,12 +240,12 @@
     "feel" : "optional",
     "group" : "embeddingModel",
     "binding" : {
-      "name" : "embeddingModelProvider.authentication.clientId",
+      "name" : "embeddingModelProvider.azureOpenAi.authentication.clientId",
       "type" : "zeebe:input"
     },
     "condition" : {
       "allMatch" : [ {
-        "property" : "embeddingModelProvider.authentication.type",
+        "property" : "embeddingModelProvider.azureOpenAi.authentication.type",
         "equals" : "clientCredentials",
         "type" : "simple"
       }, {
@@ -256,7 +256,7 @@
     },
     "type" : "String"
   }, {
-    "id" : "embeddingModelProvider.authentication.clientSecret",
+    "id" : "embeddingModelProvider.azureOpenAi.authentication.clientSecret",
     "label" : "Client secret",
     "description" : "Secret of a Microsoft Entra application",
     "optional" : false,
@@ -266,12 +266,12 @@
     "feel" : "optional",
     "group" : "embeddingModel",
     "binding" : {
-      "name" : "embeddingModelProvider.authentication.clientSecret",
+      "name" : "embeddingModelProvider.azureOpenAi.authentication.clientSecret",
       "type" : "zeebe:input"
     },
     "condition" : {
       "allMatch" : [ {
-        "property" : "embeddingModelProvider.authentication.type",
+        "property" : "embeddingModelProvider.azureOpenAi.authentication.type",
         "equals" : "clientCredentials",
         "type" : "simple"
       }, {
@@ -282,7 +282,7 @@
     },
     "type" : "String"
   }, {
-    "id" : "embeddingModelProvider.authentication.tenantId",
+    "id" : "embeddingModelProvider.azureOpenAi.authentication.tenantId",
     "label" : "Tenant ID",
     "description" : "ID of a Microsoft Entra tenant. Details in the <a href=\"https://learn.microsoft.com/en-us/entra/fundamentals/how-to-find-tenant\" target=\"_blank\">documentation</a>.",
     "optional" : false,
@@ -292,12 +292,12 @@
     "feel" : "optional",
     "group" : "embeddingModel",
     "binding" : {
-      "name" : "embeddingModelProvider.authentication.tenantId",
+      "name" : "embeddingModelProvider.azureOpenAi.authentication.tenantId",
       "type" : "zeebe:input"
     },
     "condition" : {
       "allMatch" : [ {
-        "property" : "embeddingModelProvider.authentication.type",
+        "property" : "embeddingModelProvider.azureOpenAi.authentication.type",
         "equals" : "clientCredentials",
         "type" : "simple"
       }, {
@@ -308,19 +308,19 @@
     },
     "type" : "String"
   }, {
-    "id" : "embeddingModelProvider.authentication.authorityHost",
+    "id" : "embeddingModelProvider.azureOpenAi.authentication.authorityHost",
     "label" : "Authority host",
     "description" : "Authority host URL for the Microsoft Entra application. Defaults to <code>https://login.microsoftonline.com</code>. This can also contain an OAuth 2.0 token endpoint.",
     "optional" : true,
     "feel" : "optional",
     "group" : "embeddingModel",
     "binding" : {
-      "name" : "embeddingModelProvider.authentication.authorityHost",
+      "name" : "embeddingModelProvider.azureOpenAi.authentication.authorityHost",
       "type" : "zeebe:input"
     },
     "condition" : {
       "allMatch" : [ {
-        "property" : "embeddingModelProvider.authentication.type",
+        "property" : "embeddingModelProvider.azureOpenAi.authentication.type",
         "equals" : "clientCredentials",
         "type" : "simple"
       }, {
@@ -331,7 +331,7 @@
     },
     "type" : "String"
   }, {
-    "id" : "embeddingModelProvider.deploymentName",
+    "id" : "embeddingModelProvider.azureOpenAi.deploymentName",
     "label" : "Model deployment name",
     "description" : "Specify the model deployment name. Details in the <a href=\"https://learn.microsoft.com/en-us/azure/ai-foundry/openai/reference\" target=\"_blank\">documentation</a>.",
     "optional" : false,
@@ -341,7 +341,7 @@
     "feel" : "optional",
     "group" : "embeddingModel",
     "binding" : {
-      "name" : "embeddingModelProvider.deploymentName",
+      "name" : "embeddingModelProvider.azureOpenAi.deploymentName",
       "type" : "zeebe:input"
     },
     "condition" : {
@@ -351,14 +351,14 @@
     },
     "type" : "String"
   }, {
-    "id" : "embeddingModelProvider.dimensions",
+    "id" : "embeddingModelProvider.azureOpenAi.dimensions",
     "label" : "Embedding dimensions",
     "description" : "The size of the vector used to represent data. If not specified, the default model dimensions are used. Details in the <a href=\"https://platform.openai.com/docs/guides/embeddings\" target=\"_blank\">documentation</a>.",
     "optional" : true,
     "feel" : "required",
     "group" : "embeddingModel",
     "binding" : {
-      "name" : "embeddingModelProvider.dimensions",
+      "name" : "embeddingModelProvider.azureOpenAi.dimensions",
       "type" : "zeebe:input"
     },
     "condition" : {
@@ -368,7 +368,7 @@
     },
     "type" : "Number"
   }, {
-    "id" : "embeddingModelProvider.maxRetries",
+    "id" : "embeddingModelProvider.azureOpenAi.maxRetries",
     "label" : "Max retries",
     "description" : "Max retries",
     "optional" : true,
@@ -376,7 +376,7 @@
     "feel" : "static",
     "group" : "embeddingModel",
     "binding" : {
-      "name" : "embeddingModelProvider.maxRetries",
+      "name" : "embeddingModelProvider.azureOpenAi.maxRetries",
       "type" : "zeebe:input"
     },
     "condition" : {
@@ -386,14 +386,14 @@
     },
     "type" : "Number"
   }, {
-    "id" : "embeddingModelProvider.customHeaders",
+    "id" : "embeddingModelProvider.azureOpenAi.customHeaders",
     "label" : "Custom headers",
     "description" : "Map of custom HTTP headers to add to the request.",
     "optional" : true,
     "feel" : "required",
     "group" : "embeddingModel",
     "binding" : {
-      "name" : "embeddingModelProvider.customHeaders",
+      "name" : "embeddingModelProvider.azureOpenAi.customHeaders",
       "type" : "zeebe:input"
     },
     "condition" : {

--- a/connectors/embeddings-vector-database/element-templates/hybrid/embeddings-vector-database-outbound-connector-hybrid.json
+++ b/connectors/embeddings-vector-database/element-templates/hybrid/embeddings-vector-database-outbound-connector-hybrid.json
@@ -1232,7 +1232,7 @@
     "feel" : "optional",
     "group" : "embeddingsStore",
     "binding" : {
-      "name" : "vectorStore.endpoint",
+      "name" : "vectorStore.azureCosmosDbNoSql.endpoint",
       "type" : "zeebe:input"
     },
     "condition" : {
@@ -1242,13 +1242,13 @@
     },
     "type" : "String"
   }, {
-    "id" : "vectorStore.azureCosmosDbAuthentication.type",
+    "id" : "vectorStore.azureCosmosDbNoSql.authentication.type",
     "label" : "Authentication",
     "description" : "Specify the Azure OpenAI authentication strategy.",
     "value" : "apiKey",
     "group" : "embeddingsStore",
     "binding" : {
-      "name" : "vectorStore.azureCosmosDbAuthentication.type",
+      "name" : "vectorStore.azureCosmosDbNoSql.authentication.type",
       "type" : "zeebe:input"
     },
     "condition" : {
@@ -1265,7 +1265,7 @@
       "value" : "clientCredentials"
     } ]
   }, {
-    "id" : "vectorStore.azureCosmosDbAuthentication.apiKey",
+    "id" : "vectorStore.azureCosmosDbNoSql.authentication.apiKey",
     "label" : "API key",
     "optional" : false,
     "constraints" : {
@@ -1274,12 +1274,12 @@
     "feel" : "optional",
     "group" : "embeddingsStore",
     "binding" : {
-      "name" : "vectorStore.azureCosmosDbAuthentication.apiKey",
+      "name" : "vectorStore.azureCosmosDbNoSql.authentication.apiKey",
       "type" : "zeebe:input"
     },
     "condition" : {
       "allMatch" : [ {
-        "property" : "vectorStore.azureCosmosDbAuthentication.type",
+        "property" : "vectorStore.azureCosmosDbNoSql.authentication.type",
         "equals" : "apiKey",
         "type" : "simple"
       }, {
@@ -1290,7 +1290,7 @@
     },
     "type" : "String"
   }, {
-    "id" : "vectorStore.azureCosmosDbAuthentication.clientId",
+    "id" : "vectorStore.azureCosmosDbNoSql.authentication.clientId",
     "label" : "Client ID",
     "description" : "ID of a Microsoft Entra application",
     "optional" : false,
@@ -1300,12 +1300,12 @@
     "feel" : "optional",
     "group" : "embeddingsStore",
     "binding" : {
-      "name" : "vectorStore.azureCosmosDbAuthentication.clientId",
+      "name" : "vectorStore.azureCosmosDbNoSql.authentication.clientId",
       "type" : "zeebe:input"
     },
     "condition" : {
       "allMatch" : [ {
-        "property" : "vectorStore.azureCosmosDbAuthentication.type",
+        "property" : "vectorStore.azureCosmosDbNoSql.authentication.type",
         "equals" : "clientCredentials",
         "type" : "simple"
       }, {
@@ -1316,7 +1316,7 @@
     },
     "type" : "String"
   }, {
-    "id" : "vectorStore.azureCosmosDbAuthentication.clientSecret",
+    "id" : "vectorStore.azureCosmosDbNoSql.authentication.clientSecret",
     "label" : "Client secret",
     "description" : "Secret of a Microsoft Entra application",
     "optional" : false,
@@ -1326,12 +1326,12 @@
     "feel" : "optional",
     "group" : "embeddingsStore",
     "binding" : {
-      "name" : "vectorStore.azureCosmosDbAuthentication.clientSecret",
+      "name" : "vectorStore.azureCosmosDbNoSql.authentication.clientSecret",
       "type" : "zeebe:input"
     },
     "condition" : {
       "allMatch" : [ {
-        "property" : "vectorStore.azureCosmosDbAuthentication.type",
+        "property" : "vectorStore.azureCosmosDbNoSql.authentication.type",
         "equals" : "clientCredentials",
         "type" : "simple"
       }, {
@@ -1342,7 +1342,7 @@
     },
     "type" : "String"
   }, {
-    "id" : "vectorStore.azureCosmosDbAuthentication.tenantId",
+    "id" : "vectorStore.azureCosmosDbNoSql.authentication.tenantId",
     "label" : "Tenant ID",
     "description" : "ID of a Microsoft Entra tenant. Details in the <a href=\"https://learn.microsoft.com/en-us/entra/fundamentals/how-to-find-tenant\" target=\"_blank\">documentation</a>.",
     "optional" : false,
@@ -1352,12 +1352,12 @@
     "feel" : "optional",
     "group" : "embeddingsStore",
     "binding" : {
-      "name" : "vectorStore.azureCosmosDbAuthentication.tenantId",
+      "name" : "vectorStore.azureCosmosDbNoSql.authentication.tenantId",
       "type" : "zeebe:input"
     },
     "condition" : {
       "allMatch" : [ {
-        "property" : "vectorStore.azureCosmosDbAuthentication.type",
+        "property" : "vectorStore.azureCosmosDbNoSql.authentication.type",
         "equals" : "clientCredentials",
         "type" : "simple"
       }, {
@@ -1368,19 +1368,19 @@
     },
     "type" : "String"
   }, {
-    "id" : "vectorStore.azureCosmosDbAuthentication.authorityHost",
+    "id" : "vectorStore.azureCosmosDbNoSql.authentication.authorityHost",
     "label" : "Authority host",
     "description" : "Authority host URL for the Microsoft Entra application. Defaults to <code>https://login.microsoftonline.com</code>. This can also contain an OAuth 2.0 token endpoint.",
     "optional" : true,
     "feel" : "optional",
     "group" : "embeddingsStore",
     "binding" : {
-      "name" : "vectorStore.azureCosmosDbAuthentication.authorityHost",
+      "name" : "vectorStore.azureCosmosDbNoSql.authentication.authorityHost",
       "type" : "zeebe:input"
     },
     "condition" : {
       "allMatch" : [ {
-        "property" : "vectorStore.azureCosmosDbAuthentication.type",
+        "property" : "vectorStore.azureCosmosDbNoSql.authentication.type",
         "equals" : "clientCredentials",
         "type" : "simple"
       }, {
@@ -1401,7 +1401,7 @@
     "feel" : "optional",
     "group" : "embeddingsStore",
     "binding" : {
-      "name" : "vectorStore.databaseName",
+      "name" : "vectorStore.azureCosmosDbNoSql.databaseName",
       "type" : "zeebe:input"
     },
     "condition" : {
@@ -1421,7 +1421,7 @@
     "feel" : "optional",
     "group" : "embeddingsStore",
     "binding" : {
-      "name" : "vectorStore.containerName",
+      "name" : "vectorStore.azureCosmosDbNoSql.containerName",
       "type" : "zeebe:input"
     },
     "condition" : {
@@ -1441,7 +1441,7 @@
     },
     "group" : "embeddingsStore",
     "binding" : {
-      "name" : "vectorStore.consistencyLevel",
+      "name" : "vectorStore.azureCosmosDbNoSql.consistencyLevel",
       "type" : "zeebe:input"
     },
     "condition" : {
@@ -1477,7 +1477,7 @@
     },
     "group" : "embeddingsStore",
     "binding" : {
-      "name" : "vectorStore.distanceFunction",
+      "name" : "vectorStore.azureCosmosDbNoSql.distanceFunction",
       "type" : "zeebe:input"
     },
     "condition" : {
@@ -1507,7 +1507,7 @@
     },
     "group" : "embeddingsStore",
     "binding" : {
-      "name" : "vectorStore.vectorIndexType",
+      "name" : "vectorStore.azureCosmosDbNoSql.vectorIndexType",
       "type" : "zeebe:input"
     },
     "condition" : {

--- a/connectors/embeddings-vector-database/element-templates/hybrid/embeddings-vector-database-outbound-connector-hybrid.json
+++ b/connectors/embeddings-vector-database/element-templates/hybrid/embeddings-vector-database-outbound-connector-hybrid.json
@@ -1527,7 +1527,7 @@
       "value" : "DISK_ANN"
     } ]
   }, {
-    "id" : "vectorStore.embeddingsStore.elasticsearch.baseUrl",
+    "id" : "vectorStore.elasticSearch.baseUrl",
     "label" : "Base URL",
     "description" : "Elasticsearch base URL, i.e. http(s)://host:port",
     "optional" : false,
@@ -1537,7 +1537,7 @@
     "feel" : "optional",
     "group" : "embeddingsStore",
     "binding" : {
-      "name" : "vectorStore.baseUrl",
+      "name" : "vectorStore.elasticSearch.baseUrl",
       "type" : "zeebe:input"
     },
     "condition" : {
@@ -1547,7 +1547,7 @@
     },
     "type" : "String"
   }, {
-    "id" : "vectorStore.embeddingsStore.elasticsearch.username",
+    "id" : "vectorStore.elasticSearch.userName",
     "label" : "Username",
     "description" : "Elasticsearch username",
     "optional" : false,
@@ -1557,7 +1557,7 @@
     "feel" : "optional",
     "group" : "embeddingsStore",
     "binding" : {
-      "name" : "vectorStore.userName",
+      "name" : "vectorStore.elasticSearch.userName",
       "type" : "zeebe:input"
     },
     "condition" : {
@@ -1567,7 +1567,7 @@
     },
     "type" : "String"
   }, {
-    "id" : "vectorStore.embeddingsStore.elasticsearch.password",
+    "id" : "vectorStore.elasticSearch.password",
     "label" : "Password",
     "description" : "Elasticsearch password",
     "optional" : false,
@@ -1577,7 +1577,7 @@
     "feel" : "optional",
     "group" : "embeddingsStore",
     "binding" : {
-      "name" : "vectorStore.password",
+      "name" : "vectorStore.elasticSearch.password",
       "type" : "zeebe:input"
     },
     "condition" : {
@@ -1587,7 +1587,7 @@
     },
     "type" : "String"
   }, {
-    "id" : "vectorStore.embeddingsStore.elasticsearch.indexName",
+    "id" : "vectorStore.elasticSearch.indexName",
     "label" : "Index name",
     "description" : "Elasticsearch index",
     "optional" : false,
@@ -1597,7 +1597,7 @@
     "feel" : "optional",
     "group" : "embeddingsStore",
     "binding" : {
-      "name" : "vectorStore.indexName",
+      "name" : "vectorStore.elasticSearch.indexName",
       "type" : "zeebe:input"
     },
     "condition" : {

--- a/connectors/embeddings-vector-database/element-templates/hybrid/embeddings-vector-database-outbound-connector-hybrid.json
+++ b/connectors/embeddings-vector-database/element-templates/hybrid/embeddings-vector-database-outbound-connector-hybrid.json
@@ -764,7 +764,7 @@
     },
     "type" : "Number"
   }, {
-    "id" : "embeddingModelProvider.openAiApiKey",
+    "id" : "embeddingModelProvider.openAi.apiKey",
     "label" : "OpenAI API key",
     "optional" : false,
     "constraints" : {
@@ -773,7 +773,7 @@
     "feel" : "optional",
     "group" : "embeddingModel",
     "binding" : {
-      "name" : "embeddingModelProvider.apiKey",
+      "name" : "embeddingModelProvider.openAi.apiKey",
       "type" : "zeebe:input"
     },
     "condition" : {
@@ -783,7 +783,7 @@
     },
     "type" : "String"
   }, {
-    "id" : "embeddingModelProvider.openAiModelName",
+    "id" : "embeddingModelProvider.openAi.modelName",
     "label" : "Model name",
     "description" : "Specify the model name. Details in the <a href=\"https://platform.openai.com/docs/guides/embeddings\" target=\"_blank\">documentation</a>.",
     "optional" : false,
@@ -793,7 +793,7 @@
     "feel" : "optional",
     "group" : "embeddingModel",
     "binding" : {
-      "name" : "embeddingModelProvider.modelName",
+      "name" : "embeddingModelProvider.openAi.modelName",
       "type" : "zeebe:input"
     },
     "condition" : {
@@ -803,14 +803,14 @@
     },
     "type" : "String"
   }, {
-    "id" : "embeddingModelProvider.openAiOrganizationId",
+    "id" : "embeddingModelProvider.openAi.organizationId",
     "label" : "Organization ID",
     "description" : "For members of multiple organizations. Details in the <a href=\"https://platform.openai.com/docs/api-reference/authentication\" target=\"_blank\">documentation</a>.",
     "optional" : true,
     "feel" : "optional",
     "group" : "embeddingModel",
     "binding" : {
-      "name" : "embeddingModelProvider.organizationId",
+      "name" : "embeddingModelProvider.openAi.organizationId",
       "type" : "zeebe:input"
     },
     "condition" : {
@@ -820,14 +820,14 @@
     },
     "type" : "String"
   }, {
-    "id" : "embeddingModelProvider.openAiProjectId",
+    "id" : "embeddingModelProvider.openAi.projectId",
     "label" : "Project ID",
     "description" : "For accounts with multiple projects. Details in the <a href=\"https://platform.openai.com/docs/api-reference/authentication\" target=\"_blank\">documentation</a>.",
     "optional" : true,
     "feel" : "optional",
     "group" : "embeddingModel",
     "binding" : {
-      "name" : "embeddingModelProvider.projectId",
+      "name" : "embeddingModelProvider.openAi.projectId",
       "type" : "zeebe:input"
     },
     "condition" : {
@@ -837,14 +837,14 @@
     },
     "type" : "String"
   }, {
-    "id" : "embeddingModelProvider.openAiDimensions",
+    "id" : "embeddingModelProvider.openAi.dimensions",
     "label" : "Embedding dimensions",
     "description" : "The size of the vector used to represent data. If not specified, the default model dimensions are used. Details in the <a href=\"https://platform.openai.com/docs/guides/embeddings\" target=\"_blank\">documentation</a>.",
     "optional" : true,
     "feel" : "required",
     "group" : "embeddingModel",
     "binding" : {
-      "name" : "embeddingModelProvider.dimensions",
+      "name" : "embeddingModelProvider.openAi.dimensions",
       "type" : "zeebe:input"
     },
     "condition" : {
@@ -854,7 +854,7 @@
     },
     "type" : "Number"
   }, {
-    "id" : "embeddingModelProvider.openAiMaxRetries",
+    "id" : "embeddingModelProvider.openAi.maxRetries",
     "label" : "Max retries",
     "description" : "Max retries",
     "optional" : true,
@@ -862,7 +862,7 @@
     "feel" : "static",
     "group" : "embeddingModel",
     "binding" : {
-      "name" : "embeddingModelProvider.maxRetries",
+      "name" : "embeddingModelProvider.openAi.maxRetries",
       "type" : "zeebe:input"
     },
     "condition" : {
@@ -872,14 +872,14 @@
     },
     "type" : "Number"
   }, {
-    "id" : "embeddingModelProvider.openAiCustomHeaders",
+    "id" : "embeddingModelProvider.openAi.customHeaders",
     "label" : "Custom headers",
     "description" : "Map of custom HTTP headers to add to the request.",
     "optional" : true,
     "feel" : "required",
     "group" : "embeddingModel",
     "binding" : {
-      "name" : "embeddingModelProvider.customHeaders",
+      "name" : "embeddingModelProvider.openAi.customHeaders",
       "type" : "zeebe:input"
     },
     "condition" : {
@@ -889,13 +889,13 @@
     },
     "type" : "String"
   }, {
-    "id" : "embeddingModelProvider.openAiBaseUrl",
+    "id" : "embeddingModelProvider.openAi.baseUrl",
     "label" : "Custom base URL",
     "optional" : true,
     "feel" : "optional",
     "group" : "embeddingModel",
     "binding" : {
-      "name" : "embeddingModelProvider.baseUrl",
+      "name" : "embeddingModelProvider.openAi.baseUrl",
       "type" : "zeebe:input"
     },
     "condition" : {

--- a/connectors/embeddings-vector-database/element-templates/hybrid/embeddings-vector-database-outbound-connector-hybrid.json
+++ b/connectors/embeddings-vector-database/element-templates/hybrid/embeddings-vector-database-outbound-connector-hybrid.json
@@ -1607,7 +1607,7 @@
     },
     "type" : "String"
   }, {
-    "id" : "vectorStore.embeddingsStore.opensearch.baseUrl",
+    "id" : "vectorStore.openSearch.baseUrl",
     "label" : "Base URL",
     "description" : "OpenSearch base URL, i.e. http(s)://host:port",
     "optional" : false,
@@ -1617,7 +1617,7 @@
     "feel" : "optional",
     "group" : "embeddingsStore",
     "binding" : {
-      "name" : "vectorStore.baseUrl",
+      "name" : "vectorStore.openSearch.baseUrl",
       "type" : "zeebe:input"
     },
     "condition" : {
@@ -1627,7 +1627,7 @@
     },
     "type" : "String"
   }, {
-    "id" : "vectorStore.embeddingsStore.opensearch.username",
+    "id" : "vectorStore.openSearch.userName",
     "label" : "Username",
     "description" : "OpenSearch username",
     "optional" : false,
@@ -1637,7 +1637,7 @@
     "feel" : "optional",
     "group" : "embeddingsStore",
     "binding" : {
-      "name" : "vectorStore.userName",
+      "name" : "vectorStore.openSearch.userName",
       "type" : "zeebe:input"
     },
     "condition" : {
@@ -1647,7 +1647,7 @@
     },
     "type" : "String"
   }, {
-    "id" : "vectorStore.embeddingsStore.opensearch.password",
+    "id" : "vectorStore.openSearch.password",
     "label" : "Password",
     "description" : "OpenSearch password",
     "optional" : false,
@@ -1657,7 +1657,7 @@
     "feel" : "optional",
     "group" : "embeddingsStore",
     "binding" : {
-      "name" : "vectorStore.password",
+      "name" : "vectorStore.openSearch.password",
       "type" : "zeebe:input"
     },
     "condition" : {
@@ -1667,7 +1667,7 @@
     },
     "type" : "String"
   }, {
-    "id" : "vectorStore.embeddingsStore.opensearch.indexName",
+    "id" : "vectorStore.openSearch.indexName",
     "label" : "Index name",
     "description" : "OpenSearch index",
     "optional" : false,
@@ -1677,7 +1677,7 @@
     "feel" : "optional",
     "group" : "embeddingsStore",
     "binding" : {
-      "name" : "vectorStore.indexName",
+      "name" : "vectorStore.openSearch.indexName",
       "type" : "zeebe:input"
     },
     "condition" : {

--- a/connectors/embeddings-vector-database/element-templates/hybrid/embeddings-vector-database-outbound-connector-hybrid.json
+++ b/connectors/embeddings-vector-database/element-templates/hybrid/embeddings-vector-database-outbound-connector-hybrid.json
@@ -1033,7 +1033,7 @@
     },
     "type" : "String"
   }, {
-    "id" : "vectorStore.azureAiSearch.endpoint",
+    "id" : "vectorStore.aiSearch.endpoint",
     "label" : "Endpoint",
     "description" : "Specify Azure AI Search endpoint. Details in the <a href=\"https://learn.microsoft.com/en-us/azure/search/\" target=\"_blank\">documentation</a>.",
     "optional" : false,
@@ -1043,7 +1043,7 @@
     "feel" : "optional",
     "group" : "embeddingsStore",
     "binding" : {
-      "name" : "vectorStore.endpoint",
+      "name" : "vectorStore.aiSearch.endpoint",
       "type" : "zeebe:input"
     },
     "condition" : {
@@ -1053,13 +1053,13 @@
     },
     "type" : "String"
   }, {
-    "id" : "vectorStore.azureAiSearchAuthentication.type",
+    "id" : "vectorStore.aiSearch.authentication.type",
     "label" : "Authentication",
     "description" : "Specify the Azure OpenAI authentication strategy.",
     "value" : "apiKey",
     "group" : "embeddingsStore",
     "binding" : {
-      "name" : "vectorStore.azureAiSearchAuthentication.type",
+      "name" : "vectorStore.aiSearch.authentication.type",
       "type" : "zeebe:input"
     },
     "condition" : {
@@ -1076,7 +1076,7 @@
       "value" : "clientCredentials"
     } ]
   }, {
-    "id" : "vectorStore.azureAiSearchAuthentication.apiKey",
+    "id" : "vectorStore.aiSearch.authentication.apiKey",
     "label" : "API key",
     "optional" : false,
     "constraints" : {
@@ -1085,12 +1085,12 @@
     "feel" : "optional",
     "group" : "embeddingsStore",
     "binding" : {
-      "name" : "vectorStore.azureAiSearchAuthentication.apiKey",
+      "name" : "vectorStore.aiSearch.authentication.apiKey",
       "type" : "zeebe:input"
     },
     "condition" : {
       "allMatch" : [ {
-        "property" : "vectorStore.azureAiSearchAuthentication.type",
+        "property" : "vectorStore.aiSearch.authentication.type",
         "equals" : "apiKey",
         "type" : "simple"
       }, {
@@ -1101,7 +1101,7 @@
     },
     "type" : "String"
   }, {
-    "id" : "vectorStore.azureAiSearchAuthentication.clientId",
+    "id" : "vectorStore.aiSearch.authentication.clientId",
     "label" : "Client ID",
     "description" : "ID of a Microsoft Entra application",
     "optional" : false,
@@ -1111,12 +1111,12 @@
     "feel" : "optional",
     "group" : "embeddingsStore",
     "binding" : {
-      "name" : "vectorStore.azureAiSearchAuthentication.clientId",
+      "name" : "vectorStore.aiSearch.authentication.clientId",
       "type" : "zeebe:input"
     },
     "condition" : {
       "allMatch" : [ {
-        "property" : "vectorStore.azureAiSearchAuthentication.type",
+        "property" : "vectorStore.aiSearch.authentication.type",
         "equals" : "clientCredentials",
         "type" : "simple"
       }, {
@@ -1127,7 +1127,7 @@
     },
     "type" : "String"
   }, {
-    "id" : "vectorStore.azureAiSearchAuthentication.clientSecret",
+    "id" : "vectorStore.aiSearch.authentication.clientSecret",
     "label" : "Client secret",
     "description" : "Secret of a Microsoft Entra application",
     "optional" : false,
@@ -1137,12 +1137,12 @@
     "feel" : "optional",
     "group" : "embeddingsStore",
     "binding" : {
-      "name" : "vectorStore.azureAiSearchAuthentication.clientSecret",
+      "name" : "vectorStore.aiSearch.authentication.clientSecret",
       "type" : "zeebe:input"
     },
     "condition" : {
       "allMatch" : [ {
-        "property" : "vectorStore.azureAiSearchAuthentication.type",
+        "property" : "vectorStore.aiSearch.authentication.type",
         "equals" : "clientCredentials",
         "type" : "simple"
       }, {
@@ -1153,7 +1153,7 @@
     },
     "type" : "String"
   }, {
-    "id" : "vectorStore.azureAiSearchAuthentication.tenantId",
+    "id" : "vectorStore.aiSearch.authentication.tenantId",
     "label" : "Tenant ID",
     "description" : "ID of a Microsoft Entra tenant. Details in the <a href=\"https://learn.microsoft.com/en-us/entra/fundamentals/how-to-find-tenant\" target=\"_blank\">documentation</a>.",
     "optional" : false,
@@ -1163,12 +1163,12 @@
     "feel" : "optional",
     "group" : "embeddingsStore",
     "binding" : {
-      "name" : "vectorStore.azureAiSearchAuthentication.tenantId",
+      "name" : "vectorStore.aiSearch.authentication.tenantId",
       "type" : "zeebe:input"
     },
     "condition" : {
       "allMatch" : [ {
-        "property" : "vectorStore.azureAiSearchAuthentication.type",
+        "property" : "vectorStore.aiSearch.authentication.type",
         "equals" : "clientCredentials",
         "type" : "simple"
       }, {
@@ -1179,19 +1179,19 @@
     },
     "type" : "String"
   }, {
-    "id" : "vectorStore.azureAiSearchAuthentication.authorityHost",
+    "id" : "vectorStore.aiSearch.authentication.authorityHost",
     "label" : "Authority host",
     "description" : "Authority host URL for the Microsoft Entra application. Defaults to <code>https://login.microsoftonline.com</code>. This can also contain an OAuth 2.0 token endpoint.",
     "optional" : true,
     "feel" : "optional",
     "group" : "embeddingsStore",
     "binding" : {
-      "name" : "vectorStore.azureAiSearchAuthentication.authorityHost",
+      "name" : "vectorStore.aiSearch.authentication.authorityHost",
       "type" : "zeebe:input"
     },
     "condition" : {
       "allMatch" : [ {
-        "property" : "vectorStore.azureAiSearchAuthentication.type",
+        "property" : "vectorStore.aiSearch.authentication.type",
         "equals" : "clientCredentials",
         "type" : "simple"
       }, {
@@ -1202,7 +1202,7 @@
     },
     "type" : "String"
   }, {
-    "id" : "vectorStore.azureAiSearch.indexName",
+    "id" : "vectorStore.aiSearch.indexName",
     "label" : "Index name",
     "description" : "The name of the search index. When storing embeddings this index is created or updated automatically.",
     "optional" : false,
@@ -1212,7 +1212,7 @@
     "feel" : "optional",
     "group" : "embeddingsStore",
     "binding" : {
-      "name" : "vectorStore.indexName",
+      "name" : "vectorStore.aiSearch.indexName",
       "type" : "zeebe:input"
     },
     "condition" : {

--- a/connectors/embeddings-vector-database/src/main/java/io/camunda/connector/embeddingmodel/DefaultEmbeddingModelFactory.java
+++ b/connectors/embeddings-vector-database/src/main/java/io/camunda/connector/embeddingmodel/DefaultEmbeddingModelFactory.java
@@ -116,24 +116,25 @@ public class DefaultEmbeddingModelFactory {
 
   private EmbeddingModel createVertexAiEmbeddingModel(
       GoogleVertexAiEmbeddingModelProvider provider) {
+    final var googleVertexAi = provider.googleVertexAi();
     final var publisher =
-        StringUtils.isNotBlank(provider.publisher())
-            ? provider.publisher()
+        StringUtils.isNotBlank(googleVertexAi.publisher())
+            ? googleVertexAi.publisher()
             : GoogleVertexAiEmbeddingModelProvider.VERTEX_AI_DEFAULT_PUBLISHER;
     VertexAiEmbeddingModel.Builder builder =
         VertexAiEmbeddingModel.builder()
-            .project(provider.projectId())
-            .location(provider.region())
+            .project(googleVertexAi.projectId())
+            .location(googleVertexAi.region())
             .publisher(publisher)
-            .modelName(provider.modelName())
-            .outputDimensionality(provider.dimensions())
+            .modelName(googleVertexAi.modelName())
+            .outputDimensionality(googleVertexAi.dimensions())
             .taskType(VertexAiEmbeddingModel.TaskType.RETRIEVAL_DOCUMENT);
 
-    if (provider.vertexAiAuthentication() instanceof ServiceAccountCredentialsAuthentication sac) {
+    if (googleVertexAi.authentication() instanceof ServiceAccountCredentialsAuthentication sac) {
       builder.credentials(createGoogleServiceAccountCredentials(sac));
     }
 
-    Optional.ofNullable(provider.maxRetries()).ifPresent(builder::maxRetries);
+    Optional.ofNullable(googleVertexAi.maxRetries()).ifPresent(builder::maxRetries);
 
     return builder.build();
   }

--- a/connectors/embeddings-vector-database/src/main/java/io/camunda/connector/embeddingmodel/DefaultEmbeddingModelFactory.java
+++ b/connectors/embeddings-vector-database/src/main/java/io/camunda/connector/embeddingmodel/DefaultEmbeddingModelFactory.java
@@ -49,19 +49,17 @@ public class DefaultEmbeddingModelFactory {
 
   private EmbeddingModel createAzureOpenAiEmbeddingModel(
       AzureOpenAiEmbeddingModelProvider azureOpenAiEmbeddingModelProvider) {
+    final var azureOpenAi = azureOpenAiEmbeddingModelProvider.azureOpenAi();
     AzureOpenAiEmbeddingModel.Builder builder =
         AzureOpenAiEmbeddingModel.builder()
-            .endpoint(azureOpenAiEmbeddingModelProvider.endpoint())
-            .deploymentName(azureOpenAiEmbeddingModelProvider.deploymentName());
+            .endpoint(azureOpenAi.endpoint())
+            .deploymentName(azureOpenAi.deploymentName());
 
-    Optional.ofNullable(azureOpenAiEmbeddingModelProvider.dimensions())
-        .ifPresent(builder::dimensions);
-    Optional.ofNullable(azureOpenAiEmbeddingModelProvider.maxRetries())
-        .ifPresent(builder::maxRetries);
-    Optional.ofNullable(azureOpenAiEmbeddingModelProvider.customHeaders())
-        .ifPresent(builder::customHeaders);
+    Optional.ofNullable(azureOpenAi.dimensions()).ifPresent(builder::dimensions);
+    Optional.ofNullable(azureOpenAi.maxRetries()).ifPresent(builder::maxRetries);
+    Optional.ofNullable(azureOpenAi.customHeaders()).ifPresent(builder::customHeaders);
 
-    switch (azureOpenAiEmbeddingModelProvider.authentication()) {
+    switch (azureOpenAi.authentication()) {
       case AzureAuthentication.AzureApiKeyAuthentication apiKey -> builder.apiKey(apiKey.apiKey());
       case AzureAuthentication.AzureClientCredentialsAuthentication auth -> {
         ClientSecretCredentialBuilder clientSecretCredentialBuilder =

--- a/connectors/embeddings-vector-database/src/main/java/io/camunda/connector/embeddingmodel/DefaultEmbeddingModelFactory.java
+++ b/connectors/embeddings-vector-database/src/main/java/io/camunda/connector/embeddingmodel/DefaultEmbeddingModelFactory.java
@@ -97,19 +97,16 @@ public class DefaultEmbeddingModelFactory {
 
   private EmbeddingModel createOpenAiEmbeddingModel(
       OpenAiEmbeddingModelProvider openAiEmbeddingModelProvider) {
+    final var openAi = openAiEmbeddingModelProvider.openAi();
     OpenAiEmbeddingModel.OpenAiEmbeddingModelBuilder builder =
-        OpenAiEmbeddingModel.builder()
-            .apiKey(openAiEmbeddingModelProvider.apiKey())
-            .modelName(openAiEmbeddingModelProvider.modelName());
+        OpenAiEmbeddingModel.builder().apiKey(openAi.apiKey()).modelName(openAi.modelName());
 
-    Optional.ofNullable(openAiEmbeddingModelProvider.organizationId())
-        .ifPresent(builder::organizationId);
-    Optional.ofNullable(openAiEmbeddingModelProvider.projectId()).ifPresent(builder::projectId);
-    Optional.ofNullable(openAiEmbeddingModelProvider.baseUrl()).ifPresent(builder::baseUrl);
-    Optional.ofNullable(openAiEmbeddingModelProvider.customHeaders())
-        .ifPresent(builder::customHeaders);
-    Optional.ofNullable(openAiEmbeddingModelProvider.dimensions()).ifPresent(builder::dimensions);
-    Optional.ofNullable(openAiEmbeddingModelProvider.maxRetries()).ifPresent(builder::maxRetries);
+    Optional.ofNullable(openAi.organizationId()).ifPresent(builder::organizationId);
+    Optional.ofNullable(openAi.projectId()).ifPresent(builder::projectId);
+    Optional.ofNullable(openAi.baseUrl()).ifPresent(builder::baseUrl);
+    Optional.ofNullable(openAi.customHeaders()).ifPresent(builder::customHeaders);
+    Optional.ofNullable(openAi.dimensions()).ifPresent(builder::dimensions);
+    Optional.ofNullable(openAi.maxRetries()).ifPresent(builder::maxRetries);
 
     return builder.build();
   }

--- a/connectors/embeddings-vector-database/src/main/java/io/camunda/connector/embeddingmodel/DefaultEmbeddingModelFactory.java
+++ b/connectors/embeddings-vector-database/src/main/java/io/camunda/connector/embeddingmodel/DefaultEmbeddingModelFactory.java
@@ -80,23 +80,20 @@ public class DefaultEmbeddingModelFactory {
 
   private EmbeddingModel createBedrockEmbeddingModel(
       BedrockEmbeddingModelProvider bedrockEmbeddingModelProvider) {
+    final var bedrock = bedrockEmbeddingModelProvider.bedrock();
     return BedrockTitanEmbeddingModel.builder()
-        .model(bedrockEmbeddingModelProvider.resolveSelectedModelName())
+        .model(bedrock.resolveSelectedModelName())
         .dimensions(
-            bedrockEmbeddingModelProvider.modelName() == BedrockModels.TitanEmbedTextV2
-                ? bedrockEmbeddingModelProvider.dimensions().getDimensions()
+            bedrock.modelName() == BedrockModels.TitanEmbedTextV2
+                ? bedrock.dimensions().getDimensions()
                 : null)
         .normalize(
-            bedrockEmbeddingModelProvider.modelName() == BedrockModels.TitanEmbedTextV2
-                ? bedrockEmbeddingModelProvider.normalize()
-                : null)
-        .region(Region.of(bedrockEmbeddingModelProvider.region()))
-        .maxRetries(bedrockEmbeddingModelProvider.maxRetries())
+            bedrock.modelName() == BedrockModels.TitanEmbedTextV2 ? bedrock.normalize() : null)
+        .region(Region.of(bedrock.region()))
+        .maxRetries(bedrock.maxRetries())
         .credentialsProvider(
             StaticCredentialsProvider.create(
-                AwsBasicCredentials.create(
-                    bedrockEmbeddingModelProvider.accessKey(),
-                    bedrockEmbeddingModelProvider.secretKey())))
+                AwsBasicCredentials.create(bedrock.accessKey(), bedrock.secretKey())))
         .build();
   }
 

--- a/connectors/embeddings-vector-database/src/main/java/io/camunda/connector/embeddingstore/AzureVectorStoreFactory.java
+++ b/connectors/embeddings-vector-database/src/main/java/io/camunda/connector/embeddingstore/AzureVectorStoreFactory.java
@@ -43,14 +43,15 @@ public class AzureVectorStoreFactory {
       AzureAiSearchVectorStore azureAiSearchVectorStore,
       EmbeddingModel model,
       VectorDatabaseConnectorOperation operation) {
+    final var aiSearch = azureAiSearchVectorStore.aiSearch();
     final var embeddingStoreBuilder =
         AzureAiSearchEmbeddingStore.builder()
-            .endpoint(azureAiSearchVectorStore.endpoint())
-            .indexName(azureAiSearchVectorStore.indexName())
+            .endpoint(aiSearch.endpoint())
+            .indexName(aiSearch.indexName())
             .dimensions(model.dimension())
             .createOrUpdateIndex(operation instanceof EmbedDocumentOperation);
 
-    switch (azureAiSearchVectorStore.azureAiSearchAuthentication()) {
+    switch (aiSearch.authentication()) {
       case AzureAuthentication.AzureApiKeyAuthentication apiKey ->
           embeddingStoreBuilder.apiKey(apiKey.apiKey());
       case AzureAuthentication.AzureClientCredentialsAuthentication auth -> {

--- a/connectors/embeddings-vector-database/src/main/java/io/camunda/connector/embeddingstore/AzureVectorStoreFactory.java
+++ b/connectors/embeddings-vector-database/src/main/java/io/camunda/connector/embeddingstore/AzureVectorStoreFactory.java
@@ -65,13 +65,13 @@ public class AzureVectorStoreFactory {
   public EmbeddingStore<TextSegment> createCosmosDbNoSqlVectorStore(
       AzureCosmosDbNoSqlVectorStore azureCosmosDbNoSqlVectorStore, EmbeddingModel model) {
 
+    final var cosmosDbNoSql = azureCosmosDbNoSqlVectorStore.azureCosmosDbNoSql();
     final var cosmosClientBuilder = new CosmosClientBuilder();
-    cosmosClientBuilder.endpoint(azureCosmosDbNoSqlVectorStore.endpoint());
-    cosmosClientBuilder.consistencyLevel(
-        mapConsistencyLevel(azureCosmosDbNoSqlVectorStore.consistencyLevel()));
+    cosmosClientBuilder.endpoint(cosmosDbNoSql.endpoint());
+    cosmosClientBuilder.consistencyLevel(mapConsistencyLevel(cosmosDbNoSql.consistencyLevel()));
     cosmosClientBuilder.contentResponseOnWriteEnabled(true);
 
-    switch (azureCosmosDbNoSqlVectorStore.azureCosmosDbAuthentication()) {
+    switch (cosmosDbNoSql.authentication()) {
       case AzureAuthentication.AzureApiKeyAuthentication apiKey ->
           cosmosClientBuilder.key(apiKey.apiKey());
       case AzureAuthentication.AzureClientCredentialsAuthentication auth ->
@@ -82,22 +82,19 @@ public class AzureVectorStoreFactory {
     embedding.setPath(COSMOS_DB_VECTOR_EMBEDDING_PATH);
     embedding.setDataType(CosmosVectorDataType.FLOAT32);
     embedding.setEmbeddingDimensions(model.dimension());
-    embedding.setDistanceFunction(
-        mapDistanceFunction(azureCosmosDbNoSqlVectorStore.distanceFunction()));
+    embedding.setDistanceFunction(mapDistanceFunction(cosmosDbNoSql.distanceFunction()));
     final var embeddingPolicy = new CosmosVectorEmbeddingPolicy();
     embeddingPolicy.setCosmosVectorEmbeddings(List.of(embedding));
 
     final var vectorIndexSpec = new CosmosVectorIndexSpec();
     vectorIndexSpec.setPath(COSMOS_DB_VECTOR_EMBEDDING_PATH);
-    vectorIndexSpec.setType(
-        mapIndexType(azureCosmosDbNoSqlVectorStore.vectorIndexType()).toString());
+    vectorIndexSpec.setType(mapIndexType(cosmosDbNoSql.vectorIndexType()).toString());
 
     final var partitionKeyDef = new PartitionKeyDefinition();
     partitionKeyDef.setPaths(List.of(COSMOS_DB_PARTITION_KEY_PATH));
 
     final var containerProperties =
-        new CosmosContainerProperties(
-            azureCosmosDbNoSqlVectorStore.containerName(), partitionKeyDef);
+        new CosmosContainerProperties(cosmosDbNoSql.containerName(), partitionKeyDef);
     final var indexingPolicy = new IndexingPolicy();
     indexingPolicy.setIndexingMode(IndexingMode.CONSISTENT);
     indexingPolicy.setIncludedPaths(List.of(new IncludedPath("/*")));
@@ -105,8 +102,8 @@ public class AzureVectorStoreFactory {
 
     return AzureCosmosDbNoSqlEmbeddingStore.builder()
         .cosmosClient(cosmosClientBuilder.buildClient())
-        .databaseName(azureCosmosDbNoSqlVectorStore.databaseName())
-        .containerName(azureCosmosDbNoSqlVectorStore.containerName())
+        .databaseName(cosmosDbNoSql.databaseName())
+        .containerName(cosmosDbNoSql.containerName())
         .cosmosVectorEmbeddingPolicy(embeddingPolicy)
         .cosmosVectorIndexes(List.of(vectorIndexSpec))
         .containerProperties(containerProperties)

--- a/connectors/embeddings-vector-database/src/main/java/io/camunda/connector/embeddingstore/DefaultEmbeddingStoreFactory.java
+++ b/connectors/embeddings-vector-database/src/main/java/io/camunda/connector/embeddingstore/DefaultEmbeddingStoreFactory.java
@@ -57,22 +57,22 @@ public class DefaultEmbeddingStoreFactory {
 
   private EmbeddingStore<TextSegment> initializeElasticSearchVectorStore(
       ElasticSearchVectorStore elasticSearchVectorStore) {
+    final var elasticSearch = elasticSearchVectorStore.elasticSearch();
     RestClientBuilder restClientBuilder =
-        RestClient.builder(HttpHost.create(elasticSearchVectorStore.baseUrl()));
+        RestClient.builder(HttpHost.create(elasticSearch.baseUrl()));
 
-    if (!isNullOrBlank(elasticSearchVectorStore.userName())) {
+    if (!isNullOrBlank(elasticSearch.userName())) {
       CredentialsProvider provider = new BasicCredentialsProvider();
       provider.setCredentials(
           AuthScope.ANY,
-          new UsernamePasswordCredentials(
-              elasticSearchVectorStore.userName(), elasticSearchVectorStore.password()));
+          new UsernamePasswordCredentials(elasticSearch.userName(), elasticSearch.password()));
       restClientBuilder.setHttpClientConfigCallback(
           httpClientBuilder -> httpClientBuilder.setDefaultCredentialsProvider(provider));
     }
 
     return ElasticsearchEmbeddingStore.builder()
         .restClient(restClientBuilder.build())
-        .indexName(elasticSearchVectorStore.indexName())
+        .indexName(elasticSearch.indexName())
         .build();
   }
 

--- a/connectors/embeddings-vector-database/src/main/java/io/camunda/connector/embeddingstore/DefaultEmbeddingStoreFactory.java
+++ b/connectors/embeddings-vector-database/src/main/java/io/camunda/connector/embeddingstore/DefaultEmbeddingStoreFactory.java
@@ -78,11 +78,12 @@ public class DefaultEmbeddingStoreFactory {
 
   private EmbeddingStore<TextSegment> initializeOpenSearchVectorStore(
       OpenSearchVectorStore openSearchVectorStore) {
+    final var openSearch = openSearchVectorStore.openSearch();
     return OpenSearchEmbeddingStore.builder()
-        .serverUrl(openSearchVectorStore.baseUrl())
-        .userName(openSearchVectorStore.userName())
-        .password(openSearchVectorStore.password())
-        .indexName(openSearchVectorStore.indexName())
+        .serverUrl(openSearch.baseUrl())
+        .userName(openSearch.userName())
+        .password(openSearch.password())
+        .indexName(openSearch.indexName())
         .build();
   }
 

--- a/connectors/embeddings-vector-database/src/main/java/io/camunda/connector/embeddingstore/DefaultEmbeddingStoreFactory.java
+++ b/connectors/embeddings-vector-database/src/main/java/io/camunda/connector/embeddingstore/DefaultEmbeddingStoreFactory.java
@@ -88,19 +88,21 @@ public class DefaultEmbeddingStoreFactory {
 
   private EmbeddingStore<TextSegment> initializeAmazonManagedOpenSearchVectorStore(
       AmazonManagedOpenSearchVectorStore amazonManagedOpenSearchVectorStore) {
+    final var amazonManagedOpenSearch =
+        amazonManagedOpenSearchVectorStore.amazonManagedOpensearch();
     return OpenSearchEmbeddingStore.builder()
         .serviceName("es") // for managed AWS OS
-        .serverUrl(amazonManagedOpenSearchVectorStore.serverUrl())
-        .region(amazonManagedOpenSearchVectorStore.region())
+        .serverUrl(amazonManagedOpenSearch.serverUrl())
+        .region(amazonManagedOpenSearch.region())
         .options(
             AwsSdk2TransportOptions.builder()
                 .setCredentials(
                     StaticCredentialsProvider.create(
                         AwsBasicCredentials.create(
-                            amazonManagedOpenSearchVectorStore.accessKey(),
-                            amazonManagedOpenSearchVectorStore.secretKey())))
+                            amazonManagedOpenSearch.accessKey(),
+                            amazonManagedOpenSearch.secretKey())))
                 .build())
-        .indexName(amazonManagedOpenSearchVectorStore.indexName())
+        .indexName(amazonManagedOpenSearch.indexName())
         .build();
   }
 }

--- a/connectors/embeddings-vector-database/src/main/java/io/camunda/connector/model/embedding/models/AzureOpenAiEmbeddingModelProvider.java
+++ b/connectors/embeddings-vector-database/src/main/java/io/camunda/connector/model/embedding/models/AzureOpenAiEmbeddingModelProvider.java
@@ -22,54 +22,57 @@ import java.util.Map;
 @TemplateSubType(
     label = "Azure OpenAI",
     id = AzureOpenAiEmbeddingModelProvider.AZURE_OPEN_AI_MODEL_PROVIDER)
-public record AzureOpenAiEmbeddingModelProvider(
-    @NotBlank
-        @TemplateProperty(
-            group = "embeddingModel",
-            label = "Endpoint",
-            description =
-                "Specify Azure OpenAI endpoint. Details in the <a href=\"https://learn.microsoft.com/en-us/azure/ai-foundry/openai/reference\" target=\"_blank\">documentation</a>.",
-            constraints = @TemplateProperty.PropertyConstraints(notEmpty = true))
-        String endpoint,
-    @Valid @NotNull AzureAuthentication authentication,
-    @NotBlank
-        @TemplateProperty(
-            group = "embeddingModel",
-            label = "Model deployment name",
-            description =
-                "Specify the model deployment name. Details in the <a href=\"https://learn.microsoft.com/en-us/azure/ai-foundry/openai/reference\" target=\"_blank\">documentation</a>.",
-            type = TemplateProperty.PropertyType.String,
-            feel = Property.FeelMode.optional,
-            constraints = @TemplateProperty.PropertyConstraints(notEmpty = true))
-        String deploymentName,
-    @TemplateProperty(
-            group = "embeddingModel",
-            label = "Embedding dimensions",
-            description =
-                "The size of the vector used to represent data. If not specified, the default model dimensions are used. Details in the <a href=\"https://platform.openai.com/docs/guides/embeddings\" target=\"_blank\">documentation</a>.",
-            feel = Property.FeelMode.required,
-            type = TemplateProperty.PropertyType.Number,
-            optional = true)
-        Integer dimensions,
-    @TemplateProperty(
-            group = "embeddingModel",
-            label = "Max retries",
-            description = "Max retries",
-            defaultValueType = DefaultValueType.Number,
-            defaultValue = "3",
-            optional = true)
-        Integer maxRetries,
-    @FEEL
-        @TemplateProperty(
-            group = "embeddingModel",
-            label = "Custom headers",
-            description = "Map of custom HTTP headers to add to the request.",
-            feel = Property.FeelMode.required,
-            optional = true)
-        Map<String, String> customHeaders)
+public record AzureOpenAiEmbeddingModelProvider(@Valid @NotNull Configuration azureOpenAi)
     implements EmbeddingModelProvider {
+
   @TemplateProperty(ignore = true)
   public static final String AZURE_OPEN_AI_MODEL_PROVIDER = "AZURE_OPEN_AI_MODEL_PROVIDER";
+
+  public record Configuration(
+      @NotBlank
+          @TemplateProperty(
+              group = "embeddingModel",
+              label = "Endpoint",
+              description =
+                  "Specify Azure OpenAI endpoint. Details in the <a href=\"https://learn.microsoft.com/en-us/azure/ai-foundry/openai/reference\" target=\"_blank\">documentation</a>.",
+              constraints = @TemplateProperty.PropertyConstraints(notEmpty = true))
+          String endpoint,
+      @Valid @NotNull AzureAuthentication authentication,
+      @NotBlank
+          @TemplateProperty(
+              group = "embeddingModel",
+              label = "Model deployment name",
+              description =
+                  "Specify the model deployment name. Details in the <a href=\"https://learn.microsoft.com/en-us/azure/ai-foundry/openai/reference\" target=\"_blank\">documentation</a>.",
+              type = TemplateProperty.PropertyType.String,
+              feel = Property.FeelMode.optional,
+              constraints = @TemplateProperty.PropertyConstraints(notEmpty = true))
+          String deploymentName,
+      @TemplateProperty(
+              group = "embeddingModel",
+              label = "Embedding dimensions",
+              description =
+                  "The size of the vector used to represent data. If not specified, the default model dimensions are used. Details in the <a href=\"https://platform.openai.com/docs/guides/embeddings\" target=\"_blank\">documentation</a>.",
+              feel = Property.FeelMode.required,
+              type = TemplateProperty.PropertyType.Number,
+              optional = true)
+          Integer dimensions,
+      @TemplateProperty(
+              group = "embeddingModel",
+              label = "Max retries",
+              description = "Max retries",
+              defaultValueType = DefaultValueType.Number,
+              defaultValue = "3",
+              optional = true)
+          Integer maxRetries,
+      @FEEL
+          @TemplateProperty(
+              group = "embeddingModel",
+              label = "Custom headers",
+              description = "Map of custom HTTP headers to add to the request.",
+              feel = Property.FeelMode.required,
+              optional = true)
+          Map<String, String> customHeaders) {}
 
   @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
   @JsonSubTypes({

--- a/connectors/embeddings-vector-database/src/main/java/io/camunda/connector/model/embedding/models/BedrockEmbeddingModelProvider.java
+++ b/connectors/embeddings-vector-database/src/main/java/io/camunda/connector/model/embedding/models/BedrockEmbeddingModelProvider.java
@@ -13,105 +13,103 @@ import io.camunda.connector.generator.java.annotation.TemplateProperty.DefaultVa
 import io.camunda.connector.generator.java.annotation.TemplateProperty.PropertyCondition;
 import io.camunda.connector.generator.java.annotation.TemplateProperty.PropertyConstraints;
 import io.camunda.connector.generator.java.annotation.TemplateSubType;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 
 @TemplateSubType(label = "AWS Bedrock", id = BedrockEmbeddingModelProvider.BEDROCK_MODEL_PROVIDER)
-public record BedrockEmbeddingModelProvider(
-    @NotBlank
-        @TemplateProperty(
-            group = "embeddingModel",
-            id = "bedrockAccessKey",
-            label = "Access key",
-            description =
-                "Provide an IAM access key tailored to a user, equipped with the necessary permissions")
-        String accessKey,
-    @NotBlank
-        @TemplateProperty(
-            group = "embeddingModel",
-            id = "bedrockSecretKey",
-            label = "Secret key",
-            description = "Provide a secret key associated with the access key")
-        String secretKey,
-    @NotBlank
-        @TemplateProperty(
-            group = "embeddingModel",
-            id = "bedrockRegion",
-            label = "Region",
-            description = "AWS Bedrock region")
-        String region,
-    @NotBlank
-        @TemplateProperty(
-            group = "embeddingModel",
-            id = "modelName",
-            label = "Model name",
-            feel = Property.FeelMode.required,
-            type = TemplateProperty.PropertyType.Dropdown,
-            constraints = @TemplateProperty.PropertyConstraints(notEmpty = true),
-            description = "Bedrock model name or identifier",
-            defaultValue = "TitanEmbedTextV2")
-        BedrockModels modelName,
-    @TemplateProperty(
-            group = "embeddingModel",
-            id = "bedrockCustomModelName",
-            label = "Custom model name",
-            feel = FeelMode.optional,
-            constraints = @PropertyConstraints(notEmpty = true),
-            condition =
-                @PropertyCondition(
-                    property = "embeddingModelProvider.modelName",
-                    equals = "Custom"))
-        String customModelName,
-    @NotBlank
-        @TemplateProperty(
-            group = "embeddingModel",
-            id = "bedrockDimensions",
-            label = "Embedding dimensions",
-            description = "The size of the vector used to represent data",
-            feel = Property.FeelMode.required,
-            type = TemplateProperty.PropertyType.Dropdown,
-            constraints = @TemplateProperty.PropertyConstraints(notEmpty = true),
-            defaultValue = "D1024",
-            condition =
-                @PropertyCondition(
-                    property = "embeddingModelProvider.modelName",
-                    equals = "TitanEmbedTextV2"))
-        BedrockDimensions dimensions,
-    @NotBlank
-        @TemplateProperty(
-            group = "embeddingModel",
-            id = "bedrockNormalize",
-            label = "Normalize",
-            description = "Normalize vector",
-            defaultValueType = DefaultValueType.Boolean,
-            defaultValue = "false",
-            condition =
-                @PropertyCondition(
-                    property = "embeddingModelProvider.modelName",
-                    equals = "TitanEmbedTextV2"))
-        Boolean normalize,
-    @TemplateProperty(
-            group = "embeddingModel",
-            id = "bedrockMaxRetries",
-            label = "Max retries",
-            description = "Max retries",
-            defaultValueType = DefaultValueType.Number,
-            defaultValue = "3")
-        Integer maxRetries)
+public record BedrockEmbeddingModelProvider(@Valid @NotNull Configuration bedrock)
     implements EmbeddingModelProvider {
+
   @TemplateProperty(ignore = true)
   public static final String BEDROCK_MODEL_PROVIDER = "BEDROCK_MODEL_PROVIDER";
 
-  public String resolveSelectedModelName() {
-    if (modelName == BedrockModels.Custom) {
-      return customModelName;
-    } else {
-      return modelName.getModelName();
-    }
-  }
+  public record Configuration(
+      @NotBlank
+          @TemplateProperty(
+              group = "embeddingModel",
+              label = "Access key",
+              description =
+                  "Provide an IAM access key tailored to a user, equipped with the necessary permissions")
+          String accessKey,
+      @NotBlank
+          @TemplateProperty(
+              group = "embeddingModel",
+              label = "Secret key",
+              description = "Provide a secret key associated with the access key")
+          String secretKey,
+      @NotBlank
+          @TemplateProperty(
+              group = "embeddingModel",
+              label = "Region",
+              description = "AWS Bedrock region")
+          String region,
+      @NotBlank
+          @TemplateProperty(
+              group = "embeddingModel",
+              label = "Model name",
+              feel = Property.FeelMode.required,
+              type = TemplateProperty.PropertyType.Dropdown,
+              constraints = @TemplateProperty.PropertyConstraints(notEmpty = true),
+              description = "Bedrock model name or identifier",
+              defaultValue = "TitanEmbedTextV2")
+          BedrockModels modelName,
+      @TemplateProperty(
+              group = "embeddingModel",
+              label = "Custom model name",
+              feel = FeelMode.optional,
+              constraints = @PropertyConstraints(notEmpty = true),
+              condition =
+                  @PropertyCondition(
+                      property = "embeddingModelProvider.modelName",
+                      equals = "Custom"))
+          String customModelName,
+      @NotBlank
+          @TemplateProperty(
+              group = "embeddingModel",
+              label = "Embedding dimensions",
+              description = "The size of the vector used to represent data",
+              feel = Property.FeelMode.required,
+              type = TemplateProperty.PropertyType.Dropdown,
+              constraints = @TemplateProperty.PropertyConstraints(notEmpty = true),
+              defaultValue = "D1024",
+              condition =
+                  @PropertyCondition(
+                      property = "embeddingModelProvider.modelName",
+                      equals = "TitanEmbedTextV2"))
+          BedrockDimensions dimensions,
+      @NotBlank
+          @TemplateProperty(
+              group = "embeddingModel",
+              label = "Normalize",
+              description = "Normalize vector",
+              defaultValueType = DefaultValueType.Boolean,
+              defaultValue = "false",
+              condition =
+                  @PropertyCondition(
+                      property = "embeddingModelProvider.modelName",
+                      equals = "TitanEmbedTextV2"))
+          Boolean normalize,
+      @TemplateProperty(
+              group = "embeddingModel",
+              label = "Max retries",
+              description = "Max retries",
+              defaultValueType = DefaultValueType.Number,
+              defaultValue = "3")
+          Integer maxRetries) {
 
-  @Override
-  public String toString() {
-    return "BedrockEmbeddingModel{accessKey='[REDACTED]', secretKey='[REDACTED]', region='%s', modelName='%s', customModelName='%s', dimensions=%s, normalize=%s, maxRetries=%d}"
-        .formatted(region, modelName, customModelName, dimensions, normalize, maxRetries);
+    public String resolveSelectedModelName() {
+      if (modelName == BedrockModels.Custom) {
+        return customModelName;
+      } else {
+        return modelName.getModelName();
+      }
+    }
+
+    @Override
+    public String toString() {
+      return "Configuration{accessKey='[REDACTED]', secretKey='[REDACTED]', region='%s', modelName='%s', customModelName='%s', dimensions=%s, normalize=%s, maxRetries=%d}"
+          .formatted(region, modelName, customModelName, dimensions, normalize, maxRetries);
+    }
   }
 }

--- a/connectors/embeddings-vector-database/src/main/java/io/camunda/connector/model/embedding/models/BedrockEmbeddingModelProvider.java
+++ b/connectors/embeddings-vector-database/src/main/java/io/camunda/connector/model/embedding/models/BedrockEmbeddingModelProvider.java
@@ -108,7 +108,7 @@ public record BedrockEmbeddingModelProvider(@Valid @NotNull Configuration bedroc
 
     @Override
     public String toString() {
-      return "Configuration{accessKey='[REDACTED]', secretKey='[REDACTED]', region='%s', modelName='%s', customModelName='%s', dimensions=%s, normalize=%s, maxRetries=%d}"
+      return "BedrockEmbeddingModelProvider.Configuration{accessKey='[REDACTED]', secretKey='[REDACTED]', region='%s', modelName='%s', customModelName='%s', dimensions=%s, normalize=%s, maxRetries=%d}"
           .formatted(region, modelName, customModelName, dimensions, normalize, maxRetries);
     }
   }

--- a/connectors/embeddings-vector-database/src/main/java/io/camunda/connector/model/embedding/models/GoogleVertexAiEmbeddingModelProvider.java
+++ b/connectors/embeddings-vector-database/src/main/java/io/camunda/connector/model/embedding/models/GoogleVertexAiEmbeddingModelProvider.java
@@ -21,72 +21,73 @@ import jakarta.validation.constraints.Positive;
 @TemplateSubType(
     label = "Google Vertex AI",
     id = GoogleVertexAiEmbeddingModelProvider.VERTEX_AI_MODEL_PROVIDER)
-public record GoogleVertexAiEmbeddingModelProvider(
-    @NotBlank
-        @TemplateProperty(
-            group = "embeddingModel",
-            label = "Project ID",
-            description = "Google Cloud project ID",
-            constraints = @TemplateProperty.PropertyConstraints(notEmpty = true))
-        String projectId,
-    @NotBlank
-        @TemplateProperty(
-            group = "embeddingModel",
-            label = "Region",
-            description = "Google Cloud region for Vertex AI",
-            constraints = @TemplateProperty.PropertyConstraints(notEmpty = true))
-        String region,
-    @Valid @NotNull GoogleVertexAiAuthentication vertexAiAuthentication,
-    @NotBlank
-        @TemplateProperty(
-            group = "embeddingModel",
-            label = "Model name",
-            id = "vertexAiModelName",
-            description = "Vertex AI embedding model name",
-            feel = Property.FeelMode.optional,
-            constraints = @TemplateProperty.PropertyConstraints(notEmpty = true))
-        String modelName,
-    @NotNull
-        @Positive
-        @TemplateProperty(
-            group = "embeddingModel",
-            label = "Embedding dimensions",
-            id = "vertexAiDimensions",
-            description =
-                "The size of the vector used to represent data. Details in the <a href=\"https://cloud.google.com/vertex-ai/generative-ai/docs/embeddings/get-text-embeddings\" target=\"_blank\">documentation</a>.",
-            feel = Property.FeelMode.required,
-            type = TemplateProperty.PropertyType.Number,
-            constraints = @TemplateProperty.PropertyConstraints(notEmpty = true))
-        Integer dimensions,
-    @TemplateProperty(
-            group = "embeddingModel",
-            label = "Publisher",
-            description =
-                "The publisher of the Vertex AI model (e.g., 'google', 'third-party'). Optional.",
-            defaultValue = VERTEX_AI_DEFAULT_PUBLISHER,
-            optional = true)
-        String publisher,
-    @TemplateProperty(
-            group = "embeddingModel",
-            label = "Max retries",
-            id = "vertexAiMaxRetries",
-            description = "Max retries",
-            defaultValueType = TemplateProperty.DefaultValueType.Number,
-            defaultValue = "3",
-            optional = true)
-        Integer maxRetries)
+public record GoogleVertexAiEmbeddingModelProvider(@Valid @NotNull Configuration googleVertexAi)
     implements EmbeddingModelProvider {
+
   @TemplateProperty(ignore = true)
   public static final String VERTEX_AI_MODEL_PROVIDER = "VERTEX_AI_MODEL_PROVIDER";
 
   @TemplateProperty(ignore = true)
   public static final String VERTEX_AI_DEFAULT_PUBLISHER = "google";
 
-  @AssertFalse(message = "Google Vertex AI is not supported on SaaS")
-  public boolean isUsedInSaaS() {
-    return System.getenv().containsKey("CAMUNDA_CONNECTOR_RUNTIME_SAAS")
-        && vertexAiAuthentication
-            instanceof GoogleVertexAiAuthentication.ApplicationDefaultCredentialsAuthentication;
+  public record Configuration(
+      @NotBlank
+          @TemplateProperty(
+              group = "embeddingModel",
+              label = "Project ID",
+              description = "Google Cloud project ID",
+              constraints = @TemplateProperty.PropertyConstraints(notEmpty = true))
+          String projectId,
+      @NotBlank
+          @TemplateProperty(
+              group = "embeddingModel",
+              label = "Region",
+              description = "Google Cloud region for Vertex AI",
+              constraints = @TemplateProperty.PropertyConstraints(notEmpty = true))
+          String region,
+      @Valid @NotNull GoogleVertexAiAuthentication authentication,
+      @NotBlank
+          @TemplateProperty(
+              group = "embeddingModel",
+              label = "Model name",
+              description = "Vertex AI embedding model name",
+              feel = Property.FeelMode.optional,
+              constraints = @TemplateProperty.PropertyConstraints(notEmpty = true))
+          String modelName,
+      @NotNull
+          @Positive
+          @TemplateProperty(
+              group = "embeddingModel",
+              label = "Embedding dimensions",
+              description =
+                  "The size of the vector used to represent data. Details in the <a href=\"https://cloud.google.com/vertex-ai/generative-ai/docs/embeddings/get-text-embeddings\" target=\"_blank\">documentation</a>.",
+              feel = Property.FeelMode.required,
+              type = TemplateProperty.PropertyType.Number,
+              constraints = @TemplateProperty.PropertyConstraints(notEmpty = true))
+          Integer dimensions,
+      @TemplateProperty(
+              group = "embeddingModel",
+              label = "Publisher",
+              description =
+                  "The publisher of the Vertex AI model (e.g., 'google', 'third-party'). Optional.",
+              defaultValue = VERTEX_AI_DEFAULT_PUBLISHER,
+              optional = true)
+          String publisher,
+      @TemplateProperty(
+              group = "embeddingModel",
+              label = "Max retries",
+              description = "Max retries",
+              defaultValueType = TemplateProperty.DefaultValueType.Number,
+              defaultValue = "3",
+              optional = true)
+          Integer maxRetries) {
+
+    @AssertFalse(message = "Google application default credentials is not supported on SaaS")
+    public boolean isApplicationDefaultCredentialsUsedInSaaS() {
+      return System.getenv().containsKey("CAMUNDA_CONNECTOR_RUNTIME_SAAS")
+          && authentication()
+              instanceof GoogleVertexAiAuthentication.ApplicationDefaultCredentialsAuthentication;
+    }
   }
 
   @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")

--- a/connectors/embeddings-vector-database/src/main/java/io/camunda/connector/model/embedding/models/OpenAiEmbeddingModelProvider.java
+++ b/connectors/embeddings-vector-database/src/main/java/io/camunda/connector/model/embedding/models/OpenAiEmbeddingModelProvider.java
@@ -11,96 +11,94 @@ import io.camunda.connector.generator.dsl.Property;
 import io.camunda.connector.generator.java.annotation.TemplateProperty;
 import io.camunda.connector.generator.java.annotation.TemplateProperty.DefaultValueType;
 import io.camunda.connector.generator.java.annotation.TemplateSubType;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import java.util.Map;
 
 @TemplateSubType(label = "OpenAI", id = OpenAiEmbeddingModelProvider.OPEN_AI_MODEL_PROVIDER)
-public record OpenAiEmbeddingModelProvider(
-    @NotBlank
-        @TemplateProperty(
-            group = "embeddingModel",
-            id = "openAiApiKey",
-            label = "OpenAI API key",
-            type = TemplateProperty.PropertyType.String,
-            feel = Property.FeelMode.optional,
-            constraints = @TemplateProperty.PropertyConstraints(notEmpty = true))
-        String apiKey,
-    @NotBlank
-        @TemplateProperty(
-            group = "embeddingModel",
-            label = "Model name",
-            id = "openAiModelName",
-            description =
-                "Specify the model name. Details in the <a href=\"https://platform.openai.com/docs/guides/embeddings\" target=\"_blank\">documentation</a>.",
-            type = TemplateProperty.PropertyType.String,
-            feel = Property.FeelMode.optional,
-            constraints = @TemplateProperty.PropertyConstraints(notEmpty = true))
-        String modelName,
-    @TemplateProperty(
-            group = "embeddingModel",
-            label = "Organization ID",
-            id = "openAiOrganizationId",
-            description =
-                "For members of multiple organizations. Details in the <a href=\"https://platform.openai.com/docs/api-reference/authentication\" target=\"_blank\">documentation</a>.",
-            type = TemplateProperty.PropertyType.String,
-            feel = Property.FeelMode.optional,
-            optional = true)
-        String organizationId,
-    @TemplateProperty(
-            group = "embeddingModel",
-            label = "Project ID",
-            id = "openAiProjectId",
-            description =
-                "For accounts with multiple projects. Details in the <a href=\"https://platform.openai.com/docs/api-reference/authentication\" target=\"_blank\">documentation</a>.",
-            type = TemplateProperty.PropertyType.String,
-            feel = Property.FeelMode.optional,
-            optional = true)
-        String projectId,
-    @TemplateProperty(
-            group = "embeddingModel",
-            id = "openAiDimensions",
-            label = "Embedding dimensions",
-            description =
-                "The size of the vector used to represent data. If not specified, the default model dimensions are used. Details in the <a href=\"https://platform.openai.com/docs/guides/embeddings\" target=\"_blank\">documentation</a>.",
-            feel = Property.FeelMode.required,
-            type = TemplateProperty.PropertyType.Number,
-            optional = true)
-        Integer dimensions,
-    @TemplateProperty(
-            group = "embeddingModel",
-            id = "openAiMaxRetries",
-            label = "Max retries",
-            description = "Max retries",
-            defaultValueType = DefaultValueType.Number,
-            defaultValue = "3",
-            optional = true)
-        Integer maxRetries,
-    @FEEL
-        @TemplateProperty(
-            group = "embeddingModel",
-            label = "Custom headers",
-            id = "openAiCustomHeaders",
-            description = "Map of custom HTTP headers to add to the request.",
-            feel = Property.FeelMode.required,
-            optional = true)
-        Map<String, String> customHeaders,
-    @TemplateProperty(
-            group = "embeddingModel",
-            id = "openAiBaseUrl",
-            label = "Custom base URL",
-            tooltip = "Base URL of OpenAI API. The default is 'https://api.openai.com/v1/'",
-            feel = Property.FeelMode.optional,
-            type = TemplateProperty.PropertyType.String,
-            optional = true)
-        String baseUrl)
+public record OpenAiEmbeddingModelProvider(@Valid @NotNull Configuration openAi)
     implements EmbeddingModelProvider {
+
   @TemplateProperty(ignore = true)
   public static final String OPEN_AI_MODEL_PROVIDER = "OPEN_AI_MODEL_PROVIDER";
 
-  @Override
-  public String toString() {
-    return "OpenAiEmbeddingModelProvider{apiKey=[REDACTED], modelName=%s, organizationId=%s, projectId=%s, dimensions=%d, maxRetries=%d, headers=%s, baseUrl='%s'}"
-        .formatted(
-            modelName, organizationId, projectId, dimensions, maxRetries, customHeaders, baseUrl);
+  public record Configuration(
+      @NotBlank
+          @TemplateProperty(
+              group = "embeddingModel",
+              label = "OpenAI API key",
+              type = TemplateProperty.PropertyType.String,
+              feel = Property.FeelMode.optional,
+              constraints = @TemplateProperty.PropertyConstraints(notEmpty = true))
+          String apiKey,
+      @NotBlank
+          @TemplateProperty(
+              group = "embeddingModel",
+              label = "Model name",
+              description =
+                  "Specify the model name. Details in the <a href=\"https://platform.openai.com/docs/guides/embeddings\" target=\"_blank\">documentation</a>.",
+              type = TemplateProperty.PropertyType.String,
+              feel = Property.FeelMode.optional,
+              constraints = @TemplateProperty.PropertyConstraints(notEmpty = true))
+          String modelName,
+      @TemplateProperty(
+              group = "embeddingModel",
+              label = "Organization ID",
+              description =
+                  "For members of multiple organizations. Details in the <a href=\"https://platform.openai.com/docs/api-reference/authentication\" target=\"_blank\">documentation</a>.",
+              type = TemplateProperty.PropertyType.String,
+              feel = Property.FeelMode.optional,
+              optional = true)
+          String organizationId,
+      @TemplateProperty(
+              group = "embeddingModel",
+              label = "Project ID",
+              description =
+                  "For accounts with multiple projects. Details in the <a href=\"https://platform.openai.com/docs/api-reference/authentication\" target=\"_blank\">documentation</a>.",
+              type = TemplateProperty.PropertyType.String,
+              feel = Property.FeelMode.optional,
+              optional = true)
+          String projectId,
+      @TemplateProperty(
+              group = "embeddingModel",
+              label = "Embedding dimensions",
+              description =
+                  "The size of the vector used to represent data. If not specified, the default model dimensions are used. Details in the <a href=\"https://platform.openai.com/docs/guides/embeddings\" target=\"_blank\">documentation</a>.",
+              feel = Property.FeelMode.required,
+              type = TemplateProperty.PropertyType.Number,
+              optional = true)
+          Integer dimensions,
+      @TemplateProperty(
+              group = "embeddingModel",
+              label = "Max retries",
+              description = "Max retries",
+              defaultValueType = DefaultValueType.Number,
+              defaultValue = "3",
+              optional = true)
+          Integer maxRetries,
+      @FEEL
+          @TemplateProperty(
+              group = "embeddingModel",
+              label = "Custom headers",
+              description = "Map of custom HTTP headers to add to the request.",
+              feel = Property.FeelMode.required,
+              optional = true)
+          Map<String, String> customHeaders,
+      @TemplateProperty(
+              group = "embeddingModel",
+              label = "Custom base URL",
+              tooltip = "Base URL of OpenAI API. The default is 'https://api.openai.com/v1/'",
+              feel = Property.FeelMode.optional,
+              type = TemplateProperty.PropertyType.String,
+              optional = true)
+          String baseUrl) {
+
+    @Override
+    public String toString() {
+      return "Configuration{apiKey=[REDACTED], modelName=%s, organizationId=%s, projectId=%s, dimensions=%d, maxRetries=%d, headers=%s, baseUrl='%s'}"
+          .formatted(
+              modelName, organizationId, projectId, dimensions, maxRetries, customHeaders, baseUrl);
+    }
   }
 }

--- a/connectors/embeddings-vector-database/src/main/java/io/camunda/connector/model/embedding/vector/store/AmazonManagedOpenSearchVectorStore.java
+++ b/connectors/embeddings-vector-database/src/main/java/io/camunda/connector/model/embedding/vector/store/AmazonManagedOpenSearchVectorStore.java
@@ -8,55 +8,56 @@ package io.camunda.connector.model.embedding.vector.store;
 
 import io.camunda.connector.generator.java.annotation.TemplateProperty;
 import io.camunda.connector.generator.java.annotation.TemplateSubType;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 
 @TemplateSubType(
     label = "Amazon Managed OpenSearch",
     id = AmazonManagedOpenSearchVectorStore.STORE_AMAZON_MANAGED_OPENSEARCH)
 public record AmazonManagedOpenSearchVectorStore(
-    @NotBlank
-        @TemplateProperty(
-            group = "embeddingsStore",
-            id = "amazonManagedOpensearch.accessKey",
-            label = "Access key",
-            description =
-                "Provide an IAM access key tailored to a user, equipped with the necessary permissions")
-        String accessKey,
-    @NotBlank
-        @TemplateProperty(
-            group = "embeddingsStore",
-            id = "amazonManagedOpensearch.secretKey",
-            label = "Secret key",
-            description = "Provide a secret key associated with the access key")
-        String secretKey,
-    @NotBlank
-        @TemplateProperty(
-            group = "embeddingsStore",
-            id = "amazonManagedOpensearch.serverUrl",
-            label = "Server URL",
-            description = "Provide a fully qualified server URL")
-        String serverUrl,
-    @NotBlank
-        @TemplateProperty(
-            group = "embeddingsStore",
-            id = "amazonManagedOpensearch.region",
-            label = "Region",
-            description = "Provide an instance region")
-        String region,
-    @NotBlank
-        @TemplateProperty(
-            group = "embeddingsStore",
-            id = "amazonManagedOpensearch.indexName",
-            label = "Index name",
-            description = "Provide an index to store embeddings")
-        String indexName)
-    implements EmbeddingsVectorStore {
+    @Valid @NotNull Configuration amazonManagedOpensearch) implements EmbeddingsVectorStore {
+
   @TemplateProperty(ignore = true)
   public static final String STORE_AMAZON_MANAGED_OPENSEARCH = "STORE_AMAZON_MANAGED_OPENSEARCH";
 
-  @Override
-  public String toString() {
-    return "AmazonManagedOpenSearchVectorStore(accessKey=[REDACTED], secretKey=[REDACTED], serverUrl='%s', region='%s', indexName='%s')"
-        .formatted(serverUrl, region, indexName);
+  public record Configuration(
+      @NotBlank
+          @TemplateProperty(
+              group = "embeddingsStore",
+              label = "Access key",
+              description =
+                  "Provide an IAM access key tailored to a user, equipped with the necessary permissions")
+          String accessKey,
+      @NotBlank
+          @TemplateProperty(
+              group = "embeddingsStore",
+              label = "Secret key",
+              description = "Provide a secret key associated with the access key")
+          String secretKey,
+      @NotBlank
+          @TemplateProperty(
+              group = "embeddingsStore",
+              label = "Server URL",
+              description = "Provide a fully qualified server URL")
+          String serverUrl,
+      @NotBlank
+          @TemplateProperty(
+              group = "embeddingsStore",
+              label = "Region",
+              description = "Provide an instance region")
+          String region,
+      @NotBlank
+          @TemplateProperty(
+              group = "embeddingsStore",
+              label = "Index name",
+              description = "Provide an index to store embeddings")
+          String indexName) {
+
+    @Override
+    public String toString() {
+      return "Configuration(accessKey=[REDACTED], secretKey=[REDACTED], serverUrl='%s', region='%s', indexName='%s')"
+          .formatted(serverUrl, region, indexName);
+    }
   }
 }

--- a/connectors/embeddings-vector-database/src/main/java/io/camunda/connector/model/embedding/vector/store/AzureAiSearchVectorStore.java
+++ b/connectors/embeddings-vector-database/src/main/java/io/camunda/connector/model/embedding/vector/store/AzureAiSearchVectorStore.java
@@ -14,29 +14,29 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
 @TemplateSubType(label = "Azure AI Search", id = AzureAiSearchVectorStore.STORE_AZURE_AI_SEARCH)
-public record AzureAiSearchVectorStore(
-    @NotBlank
-        @TemplateProperty(
-            group = "embeddingsStore",
-            label = "Endpoint",
-            id = "azureAiSearch.endpoint",
-            description =
-                "Specify Azure AI Search endpoint. Details in the <a href=\"https://learn.microsoft.com/en-us/azure/search/\" target=\"_blank\">documentation</a>.",
-            constraints = @TemplateProperty.PropertyConstraints(notEmpty = true))
-        String endpoint,
-    @Valid @NotNull AzureAuthentication azureAiSearchAuthentication,
-    @NotBlank
-        @TemplateProperty(
-            group = "embeddingsStore",
-            label = "Index name",
-            id = "azureAiSearch.indexName",
-            description =
-                "The name of the search index. When storing embeddings this index is created or updated automatically.",
-            feel = Property.FeelMode.optional,
-            constraints = @TemplateProperty.PropertyConstraints(notEmpty = true))
-        String indexName)
+public record AzureAiSearchVectorStore(@Valid @NotNull Configuration aiSearch)
     implements EmbeddingsVectorStore {
 
   @TemplateProperty(ignore = true)
   public static final String STORE_AZURE_AI_SEARCH = "STORE_AZURE_AI_SEARCH";
+
+  public record Configuration(
+      @NotBlank
+          @TemplateProperty(
+              group = "embeddingsStore",
+              label = "Endpoint",
+              description =
+                  "Specify Azure AI Search endpoint. Details in the <a href=\"https://learn.microsoft.com/en-us/azure/search/\" target=\"_blank\">documentation</a>.",
+              constraints = @TemplateProperty.PropertyConstraints(notEmpty = true))
+          String endpoint,
+      @Valid @NotNull AzureAuthentication authentication,
+      @NotBlank
+          @TemplateProperty(
+              group = "embeddingsStore",
+              label = "Index name",
+              description =
+                  "The name of the search index. When storing embeddings this index is created or updated automatically.",
+              feel = Property.FeelMode.optional,
+              constraints = @TemplateProperty.PropertyConstraints(notEmpty = true))
+          String indexName) {}
 }

--- a/connectors/embeddings-vector-database/src/main/java/io/camunda/connector/model/embedding/vector/store/AzureCosmosDbNoSqlVectorStore.java
+++ b/connectors/embeddings-vector-database/src/main/java/io/camunda/connector/model/embedding/vector/store/AzureCosmosDbNoSqlVectorStore.java
@@ -17,72 +17,68 @@ import jakarta.validation.constraints.NotNull;
 @TemplateSubType(
     label = "Azure Cosmos DB NoSQL",
     id = AzureCosmosDbNoSqlVectorStore.STORE_AZURE_COSMOS_DB_NO_SQL)
-public record AzureCosmosDbNoSqlVectorStore(
-    @NotBlank
-        @TemplateProperty(
-            group = "embeddingsStore",
-            id = "azureCosmosDbNoSql.endpoint",
-            label = "Endpoint",
-            description =
-                "Specify Azure Cosmos DB endpoint. Details in the <a href=\"https://learn.microsoft.com/en-us/azure/cosmos-db/\" target=\"_blank\">documentation</a>.",
-            constraints = @TemplateProperty.PropertyConstraints(notEmpty = true))
-        String endpoint,
-    @Valid @NotNull AzureAuthentication azureCosmosDbAuthentication,
-    @NotBlank
-        @TemplateProperty(
-            group = "embeddingsStore",
-            id = "azureCosmosDbNoSql.databaseName",
-            label = "Database name",
-            description = "Specify the name of the Azure Cosmos DB NoSQL database.",
-            constraints = @TemplateProperty.PropertyConstraints(notEmpty = true))
-        String databaseName,
-    @NotBlank
-        @TemplateProperty(
-            group = "embeddingsStore",
-            id = "azureCosmosDbNoSql.containerName",
-            label = "Container name",
-            description = "Specify the name of the Azure Cosmos DB NoSQL container.",
-            constraints = @TemplateProperty.PropertyConstraints(notEmpty = true))
-        String containerName,
-    @NotBlank
-        @TemplateProperty(
-            group = "embeddingsStore",
-            id = "azureCosmosDbNoSql.consistencyLevel",
-            label = "Consistency level",
-            description = "Specify the consistency level for the Azure Cosmos DB NoSQL store.",
-            feel = Property.FeelMode.required,
-            type = TemplateProperty.PropertyType.Dropdown,
-            defaultValue = "EVENTUAL",
-            constraints = @TemplateProperty.PropertyConstraints(notEmpty = true))
-        ConsistencyLevel consistencyLevel,
-    @NotBlank
-        @TemplateProperty(
-            group = "embeddingsStore",
-            id = "azureCosmosDbNoSql.distanceFunction",
-            label = "Distance function",
-            description =
-                "The metric used to compute distance/similarity. Details in the <a href=\"https://learn.microsoft.com/en-us/azure/cosmos-db/nosql/vector-search\" target=\"_blank\">documentation</a>.",
-            feel = Property.FeelMode.required,
-            type = TemplateProperty.PropertyType.Dropdown,
-            defaultValue = "COSINE",
-            constraints = @TemplateProperty.PropertyConstraints(notEmpty = true))
-        DistanceFunction distanceFunction,
-    @NotBlank
-        @TemplateProperty(
-            group = "embeddingsStore",
-            id = "azureCosmosDbNoSql.vectorIndexType",
-            label = "Vector index type",
-            description =
-                "The type of vector index type to use. Details in the <a href=\"https://learn.microsoft.com/en-us/azure/cosmos-db/nosql/vector-search\" target=\"_blank\">documentation</a>.",
-            feel = Property.FeelMode.required,
-            type = TemplateProperty.PropertyType.Dropdown,
-            defaultValue = "FLAT",
-            constraints = @TemplateProperty.PropertyConstraints(notEmpty = true))
-        IndexType vectorIndexType)
+public record AzureCosmosDbNoSqlVectorStore(@Valid @NotNull Configuration azureCosmosDbNoSql)
     implements EmbeddingsVectorStore {
 
   @TemplateProperty(ignore = true)
   public static final String STORE_AZURE_COSMOS_DB_NO_SQL = "STORE_AZURE_COSMOS_DB_NO_SQL";
+
+  public record Configuration(
+      @NotBlank
+          @TemplateProperty(
+              group = "embeddingsStore",
+              label = "Endpoint",
+              description =
+                  "Specify Azure Cosmos DB endpoint. Details in the <a href=\"https://learn.microsoft.com/en-us/azure/cosmos-db/\" target=\"_blank\">documentation</a>.",
+              constraints = @TemplateProperty.PropertyConstraints(notEmpty = true))
+          String endpoint,
+      @Valid @NotNull AzureAuthentication authentication,
+      @NotBlank
+          @TemplateProperty(
+              group = "embeddingsStore",
+              label = "Database name",
+              description = "Specify the name of the Azure Cosmos DB NoSQL database.",
+              constraints = @TemplateProperty.PropertyConstraints(notEmpty = true))
+          String databaseName,
+      @NotBlank
+          @TemplateProperty(
+              group = "embeddingsStore",
+              label = "Container name",
+              description = "Specify the name of the Azure Cosmos DB NoSQL container.",
+              constraints = @TemplateProperty.PropertyConstraints(notEmpty = true))
+          String containerName,
+      @NotBlank
+          @TemplateProperty(
+              group = "embeddingsStore",
+              label = "Consistency level",
+              description = "Specify the consistency level for the Azure Cosmos DB NoSQL store.",
+              feel = Property.FeelMode.required,
+              type = TemplateProperty.PropertyType.Dropdown,
+              defaultValue = "EVENTUAL",
+              constraints = @TemplateProperty.PropertyConstraints(notEmpty = true))
+          ConsistencyLevel consistencyLevel,
+      @NotBlank
+          @TemplateProperty(
+              group = "embeddingsStore",
+              label = "Distance function",
+              description =
+                  "The metric used to compute distance/similarity. Details in the <a href=\"https://learn.microsoft.com/en-us/azure/cosmos-db/nosql/vector-search\" target=\"_blank\">documentation</a>.",
+              feel = Property.FeelMode.required,
+              type = TemplateProperty.PropertyType.Dropdown,
+              defaultValue = "COSINE",
+              constraints = @TemplateProperty.PropertyConstraints(notEmpty = true))
+          DistanceFunction distanceFunction,
+      @NotBlank
+          @TemplateProperty(
+              group = "embeddingsStore",
+              label = "Vector index type",
+              description =
+                  "The type of vector index type to use. Details in the <a href=\"https://learn.microsoft.com/en-us/azure/cosmos-db/nosql/vector-search\" target=\"_blank\">documentation</a>.",
+              feel = Property.FeelMode.required,
+              type = TemplateProperty.PropertyType.Dropdown,
+              defaultValue = "FLAT",
+              constraints = @TemplateProperty.PropertyConstraints(notEmpty = true))
+          IndexType vectorIndexType) {}
 
   public enum ConsistencyLevel {
     @DropdownItem(label = "Strong")

--- a/connectors/embeddings-vector-database/src/main/java/io/camunda/connector/model/embedding/vector/store/ElasticSearchVectorStore.java
+++ b/connectors/embeddings-vector-database/src/main/java/io/camunda/connector/model/embedding/vector/store/ElasticSearchVectorStore.java
@@ -8,45 +8,46 @@ package io.camunda.connector.model.embedding.vector.store;
 
 import io.camunda.connector.generator.java.annotation.TemplateProperty;
 import io.camunda.connector.generator.java.annotation.TemplateSubType;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 
 @TemplateSubType(label = "Elasticsearch", id = ElasticSearchVectorStore.STORE_ELASTICSEARCH)
-public record ElasticSearchVectorStore(
-    @NotBlank
-        @TemplateProperty(
-            group = "embeddingsStore",
-            id = "embeddingsStore.elasticsearch.baseUrl",
-            label = "Base URL",
-            description = "Elasticsearch base URL, i.e. http(s)://host:port")
-        String baseUrl,
-    @NotBlank
-        @TemplateProperty(
-            group = "embeddingsStore",
-            id = "embeddingsStore.elasticsearch.username",
-            label = "Username",
-            description = "Elasticsearch username")
-        String userName,
-    @NotBlank
-        @TemplateProperty(
-            group = "embeddingsStore",
-            id = "embeddingsStore.elasticsearch.password",
-            label = "Password",
-            description = "Elasticsearch password")
-        String password,
-    @NotBlank
-        @TemplateProperty(
-            group = "embeddingsStore",
-            id = "embeddingsStore.elasticsearch.indexName",
-            label = "Index name",
-            description = "Elasticsearch index")
-        String indexName)
+public record ElasticSearchVectorStore(@Valid @NotNull Configuration elasticSearch)
     implements EmbeddingsVectorStore {
+
   @TemplateProperty(ignore = true)
   public static final String STORE_ELASTICSEARCH = "STORE_ELASTICSEARCH";
 
-  @Override
-  public String toString() {
-    return "ElasticSearchVectorStore{baseUrl='%s', userName='%s', password='[REDACTED]', indexName='%s'}"
-        .formatted(baseUrl, userName, indexName);
+  public record Configuration(
+      @NotBlank
+          @TemplateProperty(
+              group = "embeddingsStore",
+              label = "Base URL",
+              description = "Elasticsearch base URL, i.e. http(s)://host:port")
+          String baseUrl,
+      @NotBlank
+          @TemplateProperty(
+              group = "embeddingsStore",
+              label = "Username",
+              description = "Elasticsearch username")
+          String userName,
+      @NotBlank
+          @TemplateProperty(
+              group = "embeddingsStore",
+              label = "Password",
+              description = "Elasticsearch password")
+          String password,
+      @NotBlank
+          @TemplateProperty(
+              group = "embeddingsStore",
+              label = "Index name",
+              description = "Elasticsearch index")
+          String indexName) {
+    @Override
+    public String toString() {
+      return "Configuration{baseUrl='%s', userName='%s', password='[REDACTED]', indexName='%s'}"
+          .formatted(baseUrl, userName, indexName);
+    }
   }
 }

--- a/connectors/embeddings-vector-database/src/main/java/io/camunda/connector/model/embedding/vector/store/OpenSearchVectorStore.java
+++ b/connectors/embeddings-vector-database/src/main/java/io/camunda/connector/model/embedding/vector/store/OpenSearchVectorStore.java
@@ -8,45 +8,47 @@ package io.camunda.connector.model.embedding.vector.store;
 
 import io.camunda.connector.generator.java.annotation.TemplateProperty;
 import io.camunda.connector.generator.java.annotation.TemplateSubType;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 
 @TemplateSubType(label = "OpenSearch", id = OpenSearchVectorStore.STORE_OPENSEARCH)
-public record OpenSearchVectorStore(
-    @NotBlank
-        @TemplateProperty(
-            group = "embeddingsStore",
-            id = "embeddingsStore.opensearch.baseUrl",
-            label = "Base URL",
-            description = "OpenSearch base URL, i.e. http(s)://host:port")
-        String baseUrl,
-    @NotBlank
-        @TemplateProperty(
-            group = "embeddingsStore",
-            id = "embeddingsStore.opensearch.username",
-            label = "Username",
-            description = "OpenSearch username")
-        String userName,
-    @NotBlank
-        @TemplateProperty(
-            group = "embeddingsStore",
-            id = "embeddingsStore.opensearch.password",
-            label = "Password",
-            description = "OpenSearch password")
-        String password,
-    @NotBlank
-        @TemplateProperty(
-            group = "embeddingsStore",
-            id = "embeddingsStore.opensearch.indexName",
-            label = "Index name",
-            description = "OpenSearch index")
-        String indexName)
+public record OpenSearchVectorStore(@Valid @NotNull Configuration openSearch)
     implements EmbeddingsVectorStore {
+
   @TemplateProperty(ignore = true)
   public static final String STORE_OPENSEARCH = "STORE_OPENSEARCH";
 
-  @Override
-  public String toString() {
-    return "OpenSearchVectorStore{baseUrl='%s', userName='%s', password='[REDACTED]', indexName='%s'}"
-        .formatted(baseUrl, userName, indexName);
+  public record Configuration(
+      @NotBlank
+          @TemplateProperty(
+              group = "embeddingsStore",
+              label = "Base URL",
+              description = "OpenSearch base URL, i.e. http(s)://host:port")
+          String baseUrl,
+      @NotBlank
+          @TemplateProperty(
+              group = "embeddingsStore",
+              label = "Username",
+              description = "OpenSearch username")
+          String userName,
+      @NotBlank
+          @TemplateProperty(
+              group = "embeddingsStore",
+              label = "Password",
+              description = "OpenSearch password")
+          String password,
+      @NotBlank
+          @TemplateProperty(
+              group = "embeddingsStore",
+              label = "Index name",
+              description = "OpenSearch index")
+          String indexName) {
+
+    @Override
+    public String toString() {
+      return "Configuration{baseUrl='%s', userName='%s', password='[REDACTED]', indexName='%s'}"
+          .formatted(baseUrl, userName, indexName);
+    }
   }
 }

--- a/connectors/embeddings-vector-database/src/test/java/io/camunda/connector/embeddingmodel/DefaultEmbeddingModelFactoryTest.java
+++ b/connectors/embeddings-vector-database/src/test/java/io/camunda/connector/embeddingmodel/DefaultEmbeddingModelFactoryTest.java
@@ -243,13 +243,14 @@ class DefaultEmbeddingModelFactoryTest {
     void createVertexAiEmbeddingModel() {
       var provider =
           new GoogleVertexAiEmbeddingModelProvider(
-              PROJECT_ID,
-              REGION,
-              new ApplicationDefaultCredentialsAuthentication(),
-              MODEL_NAME,
-              DIMENSIONS,
-              PUBLISHER,
-              MAX_RETRIES);
+              new GoogleVertexAiEmbeddingModelProvider.Configuration(
+                  PROJECT_ID,
+                  REGION,
+                  new ApplicationDefaultCredentialsAuthentication(),
+                  MODEL_NAME,
+                  DIMENSIONS,
+                  PUBLISHER,
+                  MAX_RETRIES));
       testVertexAiEmbeddingModelBuilder(
           provider,
           (builder) -> {
@@ -264,13 +265,14 @@ class DefaultEmbeddingModelFactoryTest {
     void createVertexAiEmbeddingModelWithServiceAccountCredentials() {
       var provider =
           new GoogleVertexAiEmbeddingModelProvider(
-              PROJECT_ID,
-              REGION,
-              new ServiceAccountCredentialsAuthentication("{}"),
-              MODEL_NAME,
-              DIMENSIONS,
-              PUBLISHER,
-              MAX_RETRIES);
+              new GoogleVertexAiEmbeddingModelProvider.Configuration(
+                  PROJECT_ID,
+                  REGION,
+                  new ServiceAccountCredentialsAuthentication("{}"),
+                  MODEL_NAME,
+                  DIMENSIONS,
+                  PUBLISHER,
+                  MAX_RETRIES));
       try (final var staticMockedSac = mockStatic(ServiceAccountCredentials.class)) {
         final var mockedSac = mock(ServiceAccountCredentials.class);
         when(mockedSac.createScoped(anyString())).thenReturn(mockedSac);
@@ -295,13 +297,14 @@ class DefaultEmbeddingModelFactoryTest {
     void createVertexAiEmbeddingModelWithMandatoryParametersOnly() {
       var provider =
           new GoogleVertexAiEmbeddingModelProvider(
-              PROJECT_ID,
-              REGION,
-              new ApplicationDefaultCredentialsAuthentication(),
-              MODEL_NAME,
-              DIMENSIONS,
-              null,
-              null);
+              new GoogleVertexAiEmbeddingModelProvider.Configuration(
+                  PROJECT_ID,
+                  REGION,
+                  new ApplicationDefaultCredentialsAuthentication(),
+                  MODEL_NAME,
+                  DIMENSIONS,
+                  null,
+                  null));
 
       testVertexAiEmbeddingModelBuilder(
           provider,

--- a/connectors/embeddings-vector-database/src/test/java/io/camunda/connector/embeddingmodel/DefaultEmbeddingModelFactoryTest.java
+++ b/connectors/embeddings-vector-database/src/test/java/io/camunda/connector/embeddingmodel/DefaultEmbeddingModelFactoryTest.java
@@ -138,19 +138,20 @@ class DefaultEmbeddingModelFactoryTest {
     void createAzureOpenAiEmbeddingModelWithAllParameters() {
       AzureOpenAiEmbeddingModelProvider provider =
           new AzureOpenAiEmbeddingModelProvider(
-              AZURE_OPENAI_ENDPOINT,
-              new AzureApiKeyAuthentication(AZURE_OPENAI_API_KEY),
-              AZURE_OPENAI_DEPLOYMENT_NAME,
-              1536,
-              5,
-              Map.of("X-Test-Header", "value"));
+              new AzureOpenAiEmbeddingModelProvider.Configuration(
+                  AZURE_OPENAI_ENDPOINT,
+                  new AzureApiKeyAuthentication(AZURE_OPENAI_API_KEY),
+                  AZURE_OPENAI_DEPLOYMENT_NAME,
+                  1536,
+                  5,
+                  Map.of("X-Test-Header", "value")));
 
       testAzureOpenAiEmbeddingModelBuilder(
           provider,
           (builder) -> {
-            verify(builder).dimensions(provider.dimensions());
-            verify(builder).maxRetries(provider.maxRetries());
-            verify(builder).customHeaders(provider.customHeaders());
+            verify(builder).dimensions(provider.azureOpenAi().dimensions());
+            verify(builder).maxRetries(provider.azureOpenAi().maxRetries());
+            verify(builder).customHeaders(provider.azureOpenAi().customHeaders());
           });
     }
 
@@ -158,12 +159,13 @@ class DefaultEmbeddingModelFactoryTest {
     void createAzureOpenAiEmbeddingModelWithoutOptionalParameters() {
       AzureOpenAiEmbeddingModelProvider provider =
           new AzureOpenAiEmbeddingModelProvider(
-              AZURE_OPENAI_ENDPOINT,
-              new AzureApiKeyAuthentication(AZURE_OPENAI_API_KEY),
-              AZURE_OPENAI_DEPLOYMENT_NAME,
-              null,
-              null,
-              null);
+              new AzureOpenAiEmbeddingModelProvider.Configuration(
+                  AZURE_OPENAI_ENDPOINT,
+                  new AzureApiKeyAuthentication(AZURE_OPENAI_API_KEY),
+                  AZURE_OPENAI_DEPLOYMENT_NAME,
+                  null,
+                  null,
+                  null));
 
       testAzureOpenAiEmbeddingModelBuilder(
           provider,
@@ -180,20 +182,21 @@ class DefaultEmbeddingModelFactoryTest {
     void createAzureOpenAiEmbeddingModelWithClientCredentials(String authorityHost) {
       AzureOpenAiEmbeddingModelProvider provider =
           new AzureOpenAiEmbeddingModelProvider(
-              AZURE_OPENAI_ENDPOINT,
-              new AzureClientCredentialsAuthentication(
-                  "client-id", "client-secret", "tenant-id", authorityHost),
-              AZURE_OPENAI_DEPLOYMENT_NAME,
-              1536,
-              5,
-              Map.of("X-Test-Header", "value"));
+              new AzureOpenAiEmbeddingModelProvider.Configuration(
+                  AZURE_OPENAI_ENDPOINT,
+                  new AzureClientCredentialsAuthentication(
+                      "client-id", "client-secret", "tenant-id", authorityHost),
+                  AZURE_OPENAI_DEPLOYMENT_NAME,
+                  1536,
+                  5,
+                  Map.of("X-Test-Header", "value")));
 
       testAzureOpenAiEmbeddingModelBuilder(
           provider,
           (builder) -> {
-            verify(builder).dimensions(provider.dimensions());
-            verify(builder).maxRetries(provider.maxRetries());
-            verify(builder).customHeaders(provider.customHeaders());
+            verify(builder).dimensions(provider.azureOpenAi().dimensions());
+            verify(builder).maxRetries(provider.azureOpenAi().maxRetries());
+            verify(builder).customHeaders(provider.azureOpenAi().customHeaders());
           });
     }
 
@@ -211,7 +214,7 @@ class DefaultEmbeddingModelFactoryTest {
         verify(builder).endpoint(AZURE_OPENAI_ENDPOINT);
         verify(builder).deploymentName(AZURE_OPENAI_DEPLOYMENT_NAME);
 
-        switch (provider.authentication()) {
+        switch (provider.azureOpenAi().authentication()) {
           case AzureAuthentication.AzureApiKeyAuthentication(String apiKey) -> {
             verify(builder).apiKey(apiKey);
             verify(builder, never()).tokenCredential(any(TokenCredential.class));

--- a/connectors/embeddings-vector-database/src/test/java/io/camunda/connector/embeddingmodel/DefaultEmbeddingModelFactoryTest.java
+++ b/connectors/embeddings-vector-database/src/test/java/io/camunda/connector/embeddingmodel/DefaultEmbeddingModelFactoryTest.java
@@ -71,24 +71,25 @@ class DefaultEmbeddingModelFactoryTest {
     void createOpenAiEmbeddingModelWithAllParameters() {
       OpenAiEmbeddingModelProvider provider =
           new OpenAiEmbeddingModelProvider(
-              OPEN_AI_API_KEY,
-              OPEN_AI_MODEL_NAME,
-              "test-org-id",
-              "test-project-id",
-              1536,
-              5,
-              Map.of("X-Test-Header", "value"),
-              "https://custom.openai.com/v1/");
+              new OpenAiEmbeddingModelProvider.Configuration(
+                  OPEN_AI_API_KEY,
+                  OPEN_AI_MODEL_NAME,
+                  "test-org-id",
+                  "test-project-id",
+                  1536,
+                  5,
+                  Map.of("X-Test-Header", "value"),
+                  "https://custom.openai.com/v1/"));
 
       testOpenAiEmbeddingModelBuilder(
           provider,
           (builder) -> {
-            verify(builder).organizationId(provider.organizationId());
-            verify(builder).projectId(provider.projectId());
-            verify(builder).dimensions(provider.dimensions());
-            verify(builder).maxRetries(provider.maxRetries());
-            verify(builder).customHeaders(provider.customHeaders());
-            verify(builder).baseUrl(provider.baseUrl());
+            verify(builder).organizationId(provider.openAi().organizationId());
+            verify(builder).projectId(provider.openAi().projectId());
+            verify(builder).dimensions(provider.openAi().dimensions());
+            verify(builder).maxRetries(provider.openAi().maxRetries());
+            verify(builder).customHeaders(provider.openAi().customHeaders());
+            verify(builder).baseUrl(provider.openAi().baseUrl());
           });
     }
 
@@ -96,7 +97,8 @@ class DefaultEmbeddingModelFactoryTest {
     void createOpenAiEmbeddingModelWithoutOptionalParameters() {
       OpenAiEmbeddingModelProvider provider =
           new OpenAiEmbeddingModelProvider(
-              OPEN_AI_API_KEY, OPEN_AI_MODEL_NAME, null, null, null, null, null, null);
+              new OpenAiEmbeddingModelProvider.Configuration(
+                  OPEN_AI_API_KEY, OPEN_AI_MODEL_NAME, null, null, null, null, null, null));
 
       testOpenAiEmbeddingModelBuilder(
           provider,

--- a/connectors/embeddings-vector-database/src/test/java/io/camunda/connector/embeddingstore/DefaultEmbeddingStoreFactoryTest.java
+++ b/connectors/embeddings-vector-database/src/test/java/io/camunda/connector/embeddingstore/DefaultEmbeddingStoreFactoryTest.java
@@ -205,9 +205,10 @@ class DefaultEmbeddingStoreFactoryTest {
   class AzureAiSearchVectorStoreTests {
     private final AzureAiSearchVectorStore azureAiSearchVectorStore =
         new AzureAiSearchVectorStore(
-            "https://your-search-service.search.windows.net",
-            new AzureAuthentication.AzureApiKeyAuthentication("api-key"),
-            "searchindex");
+            new AzureAiSearchVectorStore.Configuration(
+                "https://your-search-service.search.windows.net",
+                new AzureAuthentication.AzureApiKeyAuthentication("api-key"),
+                "searchindex"));
 
     private final EmbeddingModel model = mock(EmbeddingModel.class);
 
@@ -234,10 +235,11 @@ class DefaultEmbeddingStoreFactoryTest {
     void createsAzureAiSearchVectorStoreWithClientCredentials(String authorityHost) {
       AzureAiSearchVectorStore azureAiSearchVectorStore =
           new AzureAiSearchVectorStore(
-              "https://your-search-service.search.windows.net",
-              new AzureAuthentication.AzureClientCredentialsAuthentication(
-                  "client-id", "client-secret", "tenant-id", authorityHost),
-              "searchindex");
+              new AzureAiSearchVectorStore.Configuration(
+                  "https://your-search-service.search.windows.net",
+                  new AzureAuthentication.AzureClientCredentialsAuthentication(
+                      "client-id", "client-secret", "tenant-id", authorityHost),
+                  "searchindex"));
       testAzureAiSearchEmbeddingStoreCreation(
           azureAiSearchVectorStore, model, mock(EmbedDocumentOperation.class));
     }
@@ -257,12 +259,12 @@ class DefaultEmbeddingStoreFactoryTest {
             azureAiSearchVectorStore, mockModel, mock(EmbedDocumentOperation.class));
         verify(builder).build();
 
-        verify(builder).endpoint(azureAiSearchVectorStore.endpoint());
-        verify(builder).indexName(azureAiSearchVectorStore.indexName());
+        verify(builder).endpoint(azureAiSearchVectorStore.aiSearch().endpoint());
+        verify(builder).indexName(azureAiSearchVectorStore.aiSearch().indexName());
         verify(builder).dimensions(mockModel.dimension());
         verify(builder).createOrUpdateIndex(operation instanceof EmbedDocumentOperation);
 
-        switch (azureAiSearchVectorStore.azureAiSearchAuthentication()) {
+        switch (azureAiSearchVectorStore.aiSearch().authentication()) {
           case AzureAuthentication.AzureApiKeyAuthentication(String apiKey) -> {
             verify(builder).apiKey(apiKey);
             verify(builder, never()).tokenCredential(any(TokenCredential.class));

--- a/connectors/embeddings-vector-database/src/test/java/io/camunda/connector/embeddingstore/DefaultEmbeddingStoreFactoryTest.java
+++ b/connectors/embeddings-vector-database/src/test/java/io/camunda/connector/embeddingstore/DefaultEmbeddingStoreFactoryTest.java
@@ -91,13 +91,14 @@ class DefaultEmbeddingStoreFactoryTest {
       when(mockModel.dimension()).thenReturn(512);
       final var azureCosmosDbNoSqlVectorStore =
           new AzureCosmosDbNoSqlVectorStore(
-              "https://example.documents.azure.com:443/",
-              new AzureAuthentication.AzureApiKeyAuthentication("api-key"),
-              "database-name",
-              "container-name",
-              AzureCosmosDbNoSqlVectorStore.ConsistencyLevel.STRONG,
-              AzureCosmosDbNoSqlVectorStore.DistanceFunction.COSINE,
-              AzureCosmosDbNoSqlVectorStore.IndexType.FLAT);
+              new AzureCosmosDbNoSqlVectorStore.Configuration(
+                  "https://example.documents.azure.com:443/",
+                  new AzureAuthentication.AzureApiKeyAuthentication("api-key"),
+                  "database-name",
+                  "container-name",
+                  AzureCosmosDbNoSqlVectorStore.ConsistencyLevel.STRONG,
+                  AzureCosmosDbNoSqlVectorStore.DistanceFunction.COSINE,
+                  AzureCosmosDbNoSqlVectorStore.IndexType.FLAT));
 
       testAzureCosmosDbNoSqlEmbeddingStoreCreation(azureCosmosDbNoSqlVectorStore, mockModel);
     }
@@ -110,14 +111,15 @@ class DefaultEmbeddingStoreFactoryTest {
       when(mockModel.dimension()).thenReturn(512);
       final var azureCosmosDbNoSqlVectorStore =
           new AzureCosmosDbNoSqlVectorStore(
-              "https://example.documents.azure.com:443/",
-              new AzureAuthentication.AzureClientCredentialsAuthentication(
-                  "client-id", "client-secret", "tenant-id", authorityHost),
-              "database-name",
-              "container-name",
-              AzureCosmosDbNoSqlVectorStore.ConsistencyLevel.STRONG,
-              AzureCosmosDbNoSqlVectorStore.DistanceFunction.COSINE,
-              AzureCosmosDbNoSqlVectorStore.IndexType.FLAT);
+              new AzureCosmosDbNoSqlVectorStore.Configuration(
+                  "https://example.documents.azure.com:443/",
+                  new AzureAuthentication.AzureClientCredentialsAuthentication(
+                      "client-id", "client-secret", "tenant-id", authorityHost),
+                  "database-name",
+                  "container-name",
+                  AzureCosmosDbNoSqlVectorStore.ConsistencyLevel.STRONG,
+                  AzureCosmosDbNoSqlVectorStore.DistanceFunction.COSINE,
+                  AzureCosmosDbNoSqlVectorStore.IndexType.FLAT));
 
       testAzureCosmosDbNoSqlEmbeddingStoreCreation(azureCosmosDbNoSqlVectorStore, mockModel);
     }
@@ -141,8 +143,8 @@ class DefaultEmbeddingStoreFactoryTest {
           verifyCosmosClientBuilder(vectorStore, cosmosClientBuilder);
 
           verify(builder).cosmosClient(any());
-          verify(builder).databaseName(vectorStore.databaseName());
-          verify(builder).containerName(vectorStore.containerName());
+          verify(builder).databaseName(vectorStore.azureCosmosDbNoSql().databaseName());
+          verify(builder).containerName(vectorStore.azureCosmosDbNoSql().containerName());
 
           verify(builder).cosmosVectorEmbeddingPolicy(embeddingPolicyCaptor.capture());
           assertThat(embeddingPolicyCaptor.getValue().getVectorEmbeddings().size()).isEqualTo(1);
@@ -171,7 +173,8 @@ class DefaultEmbeddingStoreFactoryTest {
           verify(builder).containerProperties(containerPropertiesCaptor.capture());
 
           var containerProperties = containerPropertiesCaptor.getValue();
-          assertThat(containerProperties.getId()).isEqualTo(vectorStore.containerName());
+          assertThat(containerProperties.getId())
+              .isEqualTo(vectorStore.azureCosmosDbNoSql().containerName());
           assertThat(containerProperties.getPartitionKeyDefinition().getPaths())
               .containsExactly(AzureVectorStoreFactory.COSMOS_DB_PARTITION_KEY_PATH);
           assertThat(containerProperties.getIndexingPolicy().getIndexingMode())
@@ -185,10 +188,10 @@ class DefaultEmbeddingStoreFactoryTest {
 
     private static void verifyCosmosClientBuilder(
         AzureCosmosDbNoSqlVectorStore vectorStore, CosmosClientBuilder cosmosClientBuilder) {
-      verify(cosmosClientBuilder).endpoint(vectorStore.endpoint());
+      verify(cosmosClientBuilder).endpoint(vectorStore.azureCosmosDbNoSql().endpoint());
       verify(cosmosClientBuilder).consistencyLevel(com.azure.cosmos.ConsistencyLevel.STRONG);
       verify(cosmosClientBuilder).contentResponseOnWriteEnabled(true);
-      switch (vectorStore.azureCosmosDbAuthentication()) {
+      switch (vectorStore.azureCosmosDbNoSql().authentication()) {
         case AzureAuthentication.AzureApiKeyAuthentication(String apiKey) -> {
           verify(cosmosClientBuilder).key(apiKey);
           verify(cosmosClientBuilder, never()).credential(any(TokenCredential.class));

--- a/connectors/embeddings-vector-database/src/test/java/io/camunda/connector/fixture/EmbeddingModelProviderFixture.java
+++ b/connectors/embeddings-vector-database/src/test/java/io/camunda/connector/fixture/EmbeddingModelProviderFixture.java
@@ -14,13 +14,14 @@ public class EmbeddingModelProviderFixture {
 
   public static BedrockEmbeddingModelProvider createDefaultBedrockEmbeddingModel() {
     return new BedrockEmbeddingModelProvider(
-        "ACCESS_KEY",
-        "SECRET_KEY",
-        "us-east-1",
-        BedrockModels.TitanEmbedTextV2,
-        null,
-        BedrockDimensions.D1024,
-        false,
-        3);
+        new BedrockEmbeddingModelProvider.Configuration(
+            "ACCESS_KEY",
+            "SECRET_KEY",
+            "us-east-1",
+            BedrockModels.TitanEmbedTextV2,
+            null,
+            BedrockDimensions.D1024,
+            false,
+            3));
   }
 }

--- a/connectors/embeddings-vector-database/src/test/java/io/camunda/connector/fixture/EmbeddingsVectorStoreFixture.java
+++ b/connectors/embeddings-vector-database/src/test/java/io/camunda/connector/fixture/EmbeddingsVectorStoreFixture.java
@@ -14,7 +14,8 @@ public class EmbeddingsVectorStoreFixture {
 
   public static ElasticSearchVectorStore createElasticSearchVectorStore() {
     return new ElasticSearchVectorStore(
-        "https://elastic.local:9200", "elastic", "changeme", "embeddings_idx");
+        new ElasticSearchVectorStore.Configuration(
+            "https://elastic.local:9200", "elastic", "changeme", "embeddings_idx"));
   }
 
   public static OpenSearchVectorStore createOpenSearchVectorStore() {

--- a/connectors/embeddings-vector-database/src/test/java/io/camunda/connector/fixture/EmbeddingsVectorStoreFixture.java
+++ b/connectors/embeddings-vector-database/src/test/java/io/camunda/connector/fixture/EmbeddingsVectorStoreFixture.java
@@ -24,6 +24,7 @@ public class EmbeddingsVectorStoreFixture {
 
   public static AmazonManagedOpenSearchVectorStore createAmazonManagedOpenVectorStore() {
     return new AmazonManagedOpenSearchVectorStore(
-        "ACCESS_KEY", "SECRET_KEY", "https://opensearch.aws", "us-east-1", "embeddings_idx");
+        new AmazonManagedOpenSearchVectorStore.Configuration(
+            "ACCESS_KEY", "SECRET_KEY", "https://opensearch.aws", "us-east-1", "embeddings_idx"));
   }
 }

--- a/connectors/embeddings-vector-database/src/test/java/io/camunda/connector/fixture/EmbeddingsVectorStoreFixture.java
+++ b/connectors/embeddings-vector-database/src/test/java/io/camunda/connector/fixture/EmbeddingsVectorStoreFixture.java
@@ -20,7 +20,8 @@ public class EmbeddingsVectorStoreFixture {
 
   public static OpenSearchVectorStore createOpenSearchVectorStore() {
     return new OpenSearchVectorStore(
-        "https://opensearch.local:9200", "opensearch", "changeme", "embeddings_idx");
+        new OpenSearchVectorStore.Configuration(
+            "https://opensearch.local:9200", "opensearch", "changeme", "embeddings_idx"));
   }
 
   public static AmazonManagedOpenSearchVectorStore createAmazonManagedOpenVectorStore() {

--- a/connectors/embeddings-vector-database/src/test/java/io/camunda/connector/model/embedding/models/GoogleVertexAiEmbeddingModelProviderTest.java
+++ b/connectors/embeddings-vector-database/src/test/java/io/camunda/connector/model/embedding/models/GoogleVertexAiEmbeddingModelProviderTest.java
@@ -43,7 +43,7 @@ class GoogleVertexAiEmbeddingModelProviderTest {
     assertThat(violations)
         .hasSize(1)
         .extracting(ConstraintViolation::getMessage)
-        .containsExactly("Google Vertex AI is not supported on SaaS");
+        .containsExactly("Google application default credentials is not supported on SaaS");
   }
 
   @Test
@@ -70,23 +70,25 @@ class GoogleVertexAiEmbeddingModelProviderTest {
 
   private GoogleVertexAiEmbeddingModelProvider createProviderWithDefaultCredentials() {
     return new GoogleVertexAiEmbeddingModelProvider(
-        "my-project-id",
-        "us-central1",
-        new GoogleVertexAiAuthentication.ApplicationDefaultCredentialsAuthentication(),
-        "embedding-model",
-        768,
-        "google",
-        3);
+        new GoogleVertexAiEmbeddingModelProvider.Configuration(
+            "my-project-id",
+            "us-central1",
+            new GoogleVertexAiAuthentication.ApplicationDefaultCredentialsAuthentication(),
+            "embedding-model",
+            768,
+            "google",
+            3));
   }
 
   private GoogleVertexAiEmbeddingModelProvider createProviderWithServiceAccountCredentials() {
     return new GoogleVertexAiEmbeddingModelProvider(
-        "my-project-id",
-        "us-central1",
-        new GoogleVertexAiAuthentication.ServiceAccountCredentialsAuthentication("{}"),
-        "embedding-model",
-        768,
-        "google",
-        3);
+        new GoogleVertexAiEmbeddingModelProvider.Configuration(
+            "my-project-id",
+            "us-central1",
+            new GoogleVertexAiAuthentication.ServiceAccountCredentialsAuthentication("{}"),
+            "embedding-model",
+            768,
+            "google",
+            3));
   }
 }


### PR DESCRIPTION
## Description

When the sealed interface implementations have a flat structure we can easily run into duplicate ID errors when the element template is generated as multiple implementations could have the same field names. One approach to avoid the errors is to customize the IDs or use different field names.
A more elegant approach is to introduce one level of hierarchy by adding the fields to an inner record and having a reference to this inner record in the main record. We should make sure the name of this field is unique in all the implementations of the sealed interface. We use this approach in the Agentic AI connector.

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.
- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest release, as this branch will be rebased onto main before the next release.

