### PR TITLE
refactor(vector-db): use camel case IDs

### DIFF
--- a/connectors/embeddings-vector-database/element-templates/embeddings-vector-database-outbound-connector.json
+++ b/connectors/embeddings-vector-database/element-templates/embeddings-vector-database-outbound-connector.json
@@ -1050,7 +1050,7 @@
   }, {
     "id" : "vectorStore.aiSearch.authentication.type",
     "label" : "Authentication",
-    "description" : "Specify the Azure OpenAI authentication strategy.",
+    "description" : "Specify the Azure authentication strategy.",
     "value" : "apiKey",
     "group" : "embeddingsStore",
     "binding" : {
@@ -1239,7 +1239,7 @@
   }, {
     "id" : "vectorStore.azureCosmosDbNoSql.authentication.type",
     "label" : "Authentication",
-    "description" : "Specify the Azure OpenAI authentication strategy.",
+    "description" : "Specify the Azure authentication strategy.",
     "value" : "apiKey",
     "group" : "embeddingsStore",
     "binding" : {

--- a/connectors/embeddings-vector-database/element-templates/embeddings-vector-database-outbound-connector.json
+++ b/connectors/embeddings-vector-database/element-templates/embeddings-vector-database-outbound-connector.json
@@ -1522,7 +1522,7 @@
       "value" : "DISK_ANN"
     } ]
   }, {
-    "id" : "vectorStore.elasticSearch.baseUrl",
+    "id" : "vectorStore.elasticsearch.baseUrl",
     "label" : "Base URL",
     "description" : "Elasticsearch base URL, i.e. http(s)://host:port",
     "optional" : false,
@@ -1532,7 +1532,7 @@
     "feel" : "optional",
     "group" : "embeddingsStore",
     "binding" : {
-      "name" : "vectorStore.elasticSearch.baseUrl",
+      "name" : "vectorStore.elasticsearch.baseUrl",
       "type" : "zeebe:input"
     },
     "condition" : {
@@ -1542,7 +1542,7 @@
     },
     "type" : "String"
   }, {
-    "id" : "vectorStore.elasticSearch.userName",
+    "id" : "vectorStore.elasticsearch.userName",
     "label" : "Username",
     "description" : "Elasticsearch username",
     "optional" : false,
@@ -1552,7 +1552,7 @@
     "feel" : "optional",
     "group" : "embeddingsStore",
     "binding" : {
-      "name" : "vectorStore.elasticSearch.userName",
+      "name" : "vectorStore.elasticsearch.userName",
       "type" : "zeebe:input"
     },
     "condition" : {
@@ -1562,7 +1562,7 @@
     },
     "type" : "String"
   }, {
-    "id" : "vectorStore.elasticSearch.password",
+    "id" : "vectorStore.elasticsearch.password",
     "label" : "Password",
     "description" : "Elasticsearch password",
     "optional" : false,
@@ -1572,7 +1572,7 @@
     "feel" : "optional",
     "group" : "embeddingsStore",
     "binding" : {
-      "name" : "vectorStore.elasticSearch.password",
+      "name" : "vectorStore.elasticsearch.password",
       "type" : "zeebe:input"
     },
     "condition" : {
@@ -1582,7 +1582,7 @@
     },
     "type" : "String"
   }, {
-    "id" : "vectorStore.elasticSearch.indexName",
+    "id" : "vectorStore.elasticsearch.indexName",
     "label" : "Index name",
     "description" : "Elasticsearch index",
     "optional" : false,
@@ -1592,7 +1592,7 @@
     "feel" : "optional",
     "group" : "embeddingsStore",
     "binding" : {
-      "name" : "vectorStore.elasticSearch.indexName",
+      "name" : "vectorStore.elasticsearch.indexName",
       "type" : "zeebe:input"
     },
     "condition" : {

--- a/connectors/embeddings-vector-database/element-templates/embeddings-vector-database-outbound-connector.json
+++ b/connectors/embeddings-vector-database/element-templates/embeddings-vector-database-outbound-connector.json
@@ -136,7 +136,7 @@
     "id" : "embeddingModelProvider.modelProvider",
     "label" : "Model provider",
     "description" : "Select embedding model provider",
-    "value" : "BEDROCK_MODEL_PROVIDER",
+    "value" : "bedrockModelProvider",
     "group" : "embeddingModel",
     "binding" : {
       "name" : "embeddingModelProvider.modelProvider",
@@ -145,16 +145,16 @@
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "Azure OpenAI",
-      "value" : "AZURE_OPEN_AI_MODEL_PROVIDER"
+      "value" : "azureOpenAiModelProvider"
     }, {
       "name" : "AWS Bedrock",
-      "value" : "BEDROCK_MODEL_PROVIDER"
+      "value" : "bedrockModelProvider"
     }, {
       "name" : "Google Vertex AI",
-      "value" : "VERTEX_AI_MODEL_PROVIDER"
+      "value" : "vertexAiModelProvider"
     }, {
       "name" : "OpenAI",
-      "value" : "OPEN_AI_MODEL_PROVIDER"
+      "value" : "openAiModelProvider"
     } ]
   }, {
     "id" : "embeddingModelProvider.azureOpenAi.endpoint",
@@ -172,7 +172,7 @@
     },
     "condition" : {
       "property" : "embeddingModelProvider.modelProvider",
-      "equals" : "AZURE_OPEN_AI_MODEL_PROVIDER",
+      "equals" : "azureOpenAiModelProvider",
       "type" : "simple"
     },
     "type" : "String"
@@ -188,7 +188,7 @@
     },
     "condition" : {
       "property" : "embeddingModelProvider.modelProvider",
-      "equals" : "AZURE_OPEN_AI_MODEL_PROVIDER",
+      "equals" : "azureOpenAiModelProvider",
       "type" : "simple"
     },
     "type" : "Dropdown",
@@ -219,7 +219,7 @@
         "type" : "simple"
       }, {
         "property" : "embeddingModelProvider.modelProvider",
-        "equals" : "AZURE_OPEN_AI_MODEL_PROVIDER",
+        "equals" : "azureOpenAiModelProvider",
         "type" : "simple"
       } ]
     },
@@ -245,7 +245,7 @@
         "type" : "simple"
       }, {
         "property" : "embeddingModelProvider.modelProvider",
-        "equals" : "AZURE_OPEN_AI_MODEL_PROVIDER",
+        "equals" : "azureOpenAiModelProvider",
         "type" : "simple"
       } ]
     },
@@ -271,7 +271,7 @@
         "type" : "simple"
       }, {
         "property" : "embeddingModelProvider.modelProvider",
-        "equals" : "AZURE_OPEN_AI_MODEL_PROVIDER",
+        "equals" : "azureOpenAiModelProvider",
         "type" : "simple"
       } ]
     },
@@ -297,7 +297,7 @@
         "type" : "simple"
       }, {
         "property" : "embeddingModelProvider.modelProvider",
-        "equals" : "AZURE_OPEN_AI_MODEL_PROVIDER",
+        "equals" : "azureOpenAiModelProvider",
         "type" : "simple"
       } ]
     },
@@ -320,7 +320,7 @@
         "type" : "simple"
       }, {
         "property" : "embeddingModelProvider.modelProvider",
-        "equals" : "AZURE_OPEN_AI_MODEL_PROVIDER",
+        "equals" : "azureOpenAiModelProvider",
         "type" : "simple"
       } ]
     },
@@ -341,7 +341,7 @@
     },
     "condition" : {
       "property" : "embeddingModelProvider.modelProvider",
-      "equals" : "AZURE_OPEN_AI_MODEL_PROVIDER",
+      "equals" : "azureOpenAiModelProvider",
       "type" : "simple"
     },
     "type" : "String"
@@ -358,7 +358,7 @@
     },
     "condition" : {
       "property" : "embeddingModelProvider.modelProvider",
-      "equals" : "AZURE_OPEN_AI_MODEL_PROVIDER",
+      "equals" : "azureOpenAiModelProvider",
       "type" : "simple"
     },
     "type" : "Number"
@@ -376,7 +376,7 @@
     },
     "condition" : {
       "property" : "embeddingModelProvider.modelProvider",
-      "equals" : "AZURE_OPEN_AI_MODEL_PROVIDER",
+      "equals" : "azureOpenAiModelProvider",
       "type" : "simple"
     },
     "type" : "Number"
@@ -393,7 +393,7 @@
     },
     "condition" : {
       "property" : "embeddingModelProvider.modelProvider",
-      "equals" : "AZURE_OPEN_AI_MODEL_PROVIDER",
+      "equals" : "azureOpenAiModelProvider",
       "type" : "simple"
     },
     "type" : "String"
@@ -413,7 +413,7 @@
     },
     "condition" : {
       "property" : "embeddingModelProvider.modelProvider",
-      "equals" : "BEDROCK_MODEL_PROVIDER",
+      "equals" : "bedrockModelProvider",
       "type" : "simple"
     },
     "type" : "String"
@@ -433,7 +433,7 @@
     },
     "condition" : {
       "property" : "embeddingModelProvider.modelProvider",
-      "equals" : "BEDROCK_MODEL_PROVIDER",
+      "equals" : "bedrockModelProvider",
       "type" : "simple"
     },
     "type" : "String"
@@ -453,7 +453,7 @@
     },
     "condition" : {
       "property" : "embeddingModelProvider.modelProvider",
-      "equals" : "BEDROCK_MODEL_PROVIDER",
+      "equals" : "bedrockModelProvider",
       "type" : "simple"
     },
     "type" : "String"
@@ -473,7 +473,7 @@
     },
     "condition" : {
       "property" : "embeddingModelProvider.modelProvider",
-      "equals" : "BEDROCK_MODEL_PROVIDER",
+      "equals" : "bedrockModelProvider",
       "type" : "simple"
     },
     "type" : "Dropdown",
@@ -507,7 +507,7 @@
         "type" : "simple"
       }, {
         "property" : "embeddingModelProvider.modelProvider",
-        "equals" : "BEDROCK_MODEL_PROVIDER",
+        "equals" : "bedrockModelProvider",
         "type" : "simple"
       } ]
     },
@@ -533,7 +533,7 @@
         "type" : "simple"
       }, {
         "property" : "embeddingModelProvider.modelProvider",
-        "equals" : "BEDROCK_MODEL_PROVIDER",
+        "equals" : "bedrockModelProvider",
         "type" : "simple"
       } ]
     },
@@ -570,7 +570,7 @@
         "type" : "simple"
       }, {
         "property" : "embeddingModelProvider.modelProvider",
-        "equals" : "BEDROCK_MODEL_PROVIDER",
+        "equals" : "bedrockModelProvider",
         "type" : "simple"
       } ]
     },
@@ -589,7 +589,7 @@
     },
     "condition" : {
       "property" : "embeddingModelProvider.modelProvider",
-      "equals" : "BEDROCK_MODEL_PROVIDER",
+      "equals" : "bedrockModelProvider",
       "type" : "simple"
     },
     "type" : "Number"
@@ -609,7 +609,7 @@
     },
     "condition" : {
       "property" : "embeddingModelProvider.modelProvider",
-      "equals" : "VERTEX_AI_MODEL_PROVIDER",
+      "equals" : "vertexAiModelProvider",
       "type" : "simple"
     },
     "type" : "String"
@@ -629,7 +629,7 @@
     },
     "condition" : {
       "property" : "embeddingModelProvider.modelProvider",
-      "equals" : "VERTEX_AI_MODEL_PROVIDER",
+      "equals" : "vertexAiModelProvider",
       "type" : "simple"
     },
     "type" : "String"
@@ -645,7 +645,7 @@
     },
     "condition" : {
       "property" : "embeddingModelProvider.modelProvider",
-      "equals" : "VERTEX_AI_MODEL_PROVIDER",
+      "equals" : "vertexAiModelProvider",
       "type" : "simple"
     },
     "type" : "Dropdown",
@@ -677,7 +677,7 @@
         "type" : "simple"
       }, {
         "property" : "embeddingModelProvider.modelProvider",
-        "equals" : "VERTEX_AI_MODEL_PROVIDER",
+        "equals" : "vertexAiModelProvider",
         "type" : "simple"
       } ]
     },
@@ -698,7 +698,7 @@
     },
     "condition" : {
       "property" : "embeddingModelProvider.modelProvider",
-      "equals" : "VERTEX_AI_MODEL_PROVIDER",
+      "equals" : "vertexAiModelProvider",
       "type" : "simple"
     },
     "type" : "String"
@@ -718,7 +718,7 @@
     },
     "condition" : {
       "property" : "embeddingModelProvider.modelProvider",
-      "equals" : "VERTEX_AI_MODEL_PROVIDER",
+      "equals" : "vertexAiModelProvider",
       "type" : "simple"
     },
     "type" : "Number"
@@ -736,7 +736,7 @@
     },
     "condition" : {
       "property" : "embeddingModelProvider.modelProvider",
-      "equals" : "VERTEX_AI_MODEL_PROVIDER",
+      "equals" : "vertexAiModelProvider",
       "type" : "simple"
     },
     "type" : "String"
@@ -754,7 +754,7 @@
     },
     "condition" : {
       "property" : "embeddingModelProvider.modelProvider",
-      "equals" : "VERTEX_AI_MODEL_PROVIDER",
+      "equals" : "vertexAiModelProvider",
       "type" : "simple"
     },
     "type" : "Number"
@@ -773,7 +773,7 @@
     },
     "condition" : {
       "property" : "embeddingModelProvider.modelProvider",
-      "equals" : "OPEN_AI_MODEL_PROVIDER",
+      "equals" : "openAiModelProvider",
       "type" : "simple"
     },
     "type" : "String"
@@ -793,7 +793,7 @@
     },
     "condition" : {
       "property" : "embeddingModelProvider.modelProvider",
-      "equals" : "OPEN_AI_MODEL_PROVIDER",
+      "equals" : "openAiModelProvider",
       "type" : "simple"
     },
     "type" : "String"
@@ -810,7 +810,7 @@
     },
     "condition" : {
       "property" : "embeddingModelProvider.modelProvider",
-      "equals" : "OPEN_AI_MODEL_PROVIDER",
+      "equals" : "openAiModelProvider",
       "type" : "simple"
     },
     "type" : "String"
@@ -827,7 +827,7 @@
     },
     "condition" : {
       "property" : "embeddingModelProvider.modelProvider",
-      "equals" : "OPEN_AI_MODEL_PROVIDER",
+      "equals" : "openAiModelProvider",
       "type" : "simple"
     },
     "type" : "String"
@@ -844,7 +844,7 @@
     },
     "condition" : {
       "property" : "embeddingModelProvider.modelProvider",
-      "equals" : "OPEN_AI_MODEL_PROVIDER",
+      "equals" : "openAiModelProvider",
       "type" : "simple"
     },
     "type" : "Number"
@@ -862,7 +862,7 @@
     },
     "condition" : {
       "property" : "embeddingModelProvider.modelProvider",
-      "equals" : "OPEN_AI_MODEL_PROVIDER",
+      "equals" : "openAiModelProvider",
       "type" : "simple"
     },
     "type" : "Number"
@@ -879,7 +879,7 @@
     },
     "condition" : {
       "property" : "embeddingModelProvider.modelProvider",
-      "equals" : "OPEN_AI_MODEL_PROVIDER",
+      "equals" : "openAiModelProvider",
       "type" : "simple"
     },
     "type" : "String"
@@ -895,7 +895,7 @@
     },
     "condition" : {
       "property" : "embeddingModelProvider.modelProvider",
-      "equals" : "OPEN_AI_MODEL_PROVIDER",
+      "equals" : "openAiModelProvider",
       "type" : "simple"
     },
     "tooltip" : "Base URL of OpenAI API. The default is 'https://api.openai.com/v1/'",
@@ -904,7 +904,7 @@
     "id" : "vectorStore.vectorStore",
     "label" : "Embeddings store",
     "description" : "Select embedding store",
-    "value" : "STORE_ELASTICSEARCH",
+    "value" : "elasticsearchStore",
     "group" : "embeddingsStore",
     "binding" : {
       "name" : "vectorStore.storeType",
@@ -913,19 +913,19 @@
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "Amazon Managed OpenSearch",
-      "value" : "STORE_AMAZON_MANAGED_OPENSEARCH"
+      "value" : "amazonManagedOpenSearchStore"
     }, {
       "name" : "Azure AI Search",
-      "value" : "STORE_AZURE_AI_SEARCH"
+      "value" : "azureAiSearchStore"
     }, {
       "name" : "Azure Cosmos DB NoSQL",
-      "value" : "STORE_AZURE_COSMOS_DB_NO_SQL"
+      "value" : "azureCosmosDbNoSqlStore"
     }, {
       "name" : "Elasticsearch",
-      "value" : "STORE_ELASTICSEARCH"
+      "value" : "elasticsearchStore"
     }, {
       "name" : "OpenSearch",
-      "value" : "STORE_OPENSEARCH"
+      "value" : "openSearchStore"
     } ]
   }, {
     "id" : "vectorStore.amazonManagedOpensearch.accessKey",
@@ -943,7 +943,7 @@
     },
     "condition" : {
       "property" : "vectorStore.vectorStore",
-      "equals" : "STORE_AMAZON_MANAGED_OPENSEARCH",
+      "equals" : "amazonManagedOpenSearchStore",
       "type" : "simple"
     },
     "type" : "String"
@@ -963,7 +963,7 @@
     },
     "condition" : {
       "property" : "vectorStore.vectorStore",
-      "equals" : "STORE_AMAZON_MANAGED_OPENSEARCH",
+      "equals" : "amazonManagedOpenSearchStore",
       "type" : "simple"
     },
     "type" : "String"
@@ -983,7 +983,7 @@
     },
     "condition" : {
       "property" : "vectorStore.vectorStore",
-      "equals" : "STORE_AMAZON_MANAGED_OPENSEARCH",
+      "equals" : "amazonManagedOpenSearchStore",
       "type" : "simple"
     },
     "type" : "String"
@@ -1003,7 +1003,7 @@
     },
     "condition" : {
       "property" : "vectorStore.vectorStore",
-      "equals" : "STORE_AMAZON_MANAGED_OPENSEARCH",
+      "equals" : "amazonManagedOpenSearchStore",
       "type" : "simple"
     },
     "type" : "String"
@@ -1023,7 +1023,7 @@
     },
     "condition" : {
       "property" : "vectorStore.vectorStore",
-      "equals" : "STORE_AMAZON_MANAGED_OPENSEARCH",
+      "equals" : "amazonManagedOpenSearchStore",
       "type" : "simple"
     },
     "type" : "String"
@@ -1043,7 +1043,7 @@
     },
     "condition" : {
       "property" : "vectorStore.vectorStore",
-      "equals" : "STORE_AZURE_AI_SEARCH",
+      "equals" : "azureAiSearchStore",
       "type" : "simple"
     },
     "type" : "String"
@@ -1059,7 +1059,7 @@
     },
     "condition" : {
       "property" : "vectorStore.vectorStore",
-      "equals" : "STORE_AZURE_AI_SEARCH",
+      "equals" : "azureAiSearchStore",
       "type" : "simple"
     },
     "type" : "Dropdown",
@@ -1090,7 +1090,7 @@
         "type" : "simple"
       }, {
         "property" : "vectorStore.vectorStore",
-        "equals" : "STORE_AZURE_AI_SEARCH",
+        "equals" : "azureAiSearchStore",
         "type" : "simple"
       } ]
     },
@@ -1116,7 +1116,7 @@
         "type" : "simple"
       }, {
         "property" : "vectorStore.vectorStore",
-        "equals" : "STORE_AZURE_AI_SEARCH",
+        "equals" : "azureAiSearchStore",
         "type" : "simple"
       } ]
     },
@@ -1142,7 +1142,7 @@
         "type" : "simple"
       }, {
         "property" : "vectorStore.vectorStore",
-        "equals" : "STORE_AZURE_AI_SEARCH",
+        "equals" : "azureAiSearchStore",
         "type" : "simple"
       } ]
     },
@@ -1168,7 +1168,7 @@
         "type" : "simple"
       }, {
         "property" : "vectorStore.vectorStore",
-        "equals" : "STORE_AZURE_AI_SEARCH",
+        "equals" : "azureAiSearchStore",
         "type" : "simple"
       } ]
     },
@@ -1191,7 +1191,7 @@
         "type" : "simple"
       }, {
         "property" : "vectorStore.vectorStore",
-        "equals" : "STORE_AZURE_AI_SEARCH",
+        "equals" : "azureAiSearchStore",
         "type" : "simple"
       } ]
     },
@@ -1212,7 +1212,7 @@
     },
     "condition" : {
       "property" : "vectorStore.vectorStore",
-      "equals" : "STORE_AZURE_AI_SEARCH",
+      "equals" : "azureAiSearchStore",
       "type" : "simple"
     },
     "type" : "String"
@@ -1232,7 +1232,7 @@
     },
     "condition" : {
       "property" : "vectorStore.vectorStore",
-      "equals" : "STORE_AZURE_COSMOS_DB_NO_SQL",
+      "equals" : "azureCosmosDbNoSqlStore",
       "type" : "simple"
     },
     "type" : "String"
@@ -1248,7 +1248,7 @@
     },
     "condition" : {
       "property" : "vectorStore.vectorStore",
-      "equals" : "STORE_AZURE_COSMOS_DB_NO_SQL",
+      "equals" : "azureCosmosDbNoSqlStore",
       "type" : "simple"
     },
     "type" : "Dropdown",
@@ -1279,7 +1279,7 @@
         "type" : "simple"
       }, {
         "property" : "vectorStore.vectorStore",
-        "equals" : "STORE_AZURE_COSMOS_DB_NO_SQL",
+        "equals" : "azureCosmosDbNoSqlStore",
         "type" : "simple"
       } ]
     },
@@ -1305,7 +1305,7 @@
         "type" : "simple"
       }, {
         "property" : "vectorStore.vectorStore",
-        "equals" : "STORE_AZURE_COSMOS_DB_NO_SQL",
+        "equals" : "azureCosmosDbNoSqlStore",
         "type" : "simple"
       } ]
     },
@@ -1331,7 +1331,7 @@
         "type" : "simple"
       }, {
         "property" : "vectorStore.vectorStore",
-        "equals" : "STORE_AZURE_COSMOS_DB_NO_SQL",
+        "equals" : "azureCosmosDbNoSqlStore",
         "type" : "simple"
       } ]
     },
@@ -1357,7 +1357,7 @@
         "type" : "simple"
       }, {
         "property" : "vectorStore.vectorStore",
-        "equals" : "STORE_AZURE_COSMOS_DB_NO_SQL",
+        "equals" : "azureCosmosDbNoSqlStore",
         "type" : "simple"
       } ]
     },
@@ -1380,7 +1380,7 @@
         "type" : "simple"
       }, {
         "property" : "vectorStore.vectorStore",
-        "equals" : "STORE_AZURE_COSMOS_DB_NO_SQL",
+        "equals" : "azureCosmosDbNoSqlStore",
         "type" : "simple"
       } ]
     },
@@ -1401,7 +1401,7 @@
     },
     "condition" : {
       "property" : "vectorStore.vectorStore",
-      "equals" : "STORE_AZURE_COSMOS_DB_NO_SQL",
+      "equals" : "azureCosmosDbNoSqlStore",
       "type" : "simple"
     },
     "type" : "String"
@@ -1421,7 +1421,7 @@
     },
     "condition" : {
       "property" : "vectorStore.vectorStore",
-      "equals" : "STORE_AZURE_COSMOS_DB_NO_SQL",
+      "equals" : "azureCosmosDbNoSqlStore",
       "type" : "simple"
     },
     "type" : "String"
@@ -1441,7 +1441,7 @@
     },
     "condition" : {
       "property" : "vectorStore.vectorStore",
-      "equals" : "STORE_AZURE_COSMOS_DB_NO_SQL",
+      "equals" : "azureCosmosDbNoSqlStore",
       "type" : "simple"
     },
     "type" : "Dropdown",
@@ -1477,7 +1477,7 @@
     },
     "condition" : {
       "property" : "vectorStore.vectorStore",
-      "equals" : "STORE_AZURE_COSMOS_DB_NO_SQL",
+      "equals" : "azureCosmosDbNoSqlStore",
       "type" : "simple"
     },
     "type" : "Dropdown",
@@ -1507,7 +1507,7 @@
     },
     "condition" : {
       "property" : "vectorStore.vectorStore",
-      "equals" : "STORE_AZURE_COSMOS_DB_NO_SQL",
+      "equals" : "azureCosmosDbNoSqlStore",
       "type" : "simple"
     },
     "type" : "Dropdown",
@@ -1537,7 +1537,7 @@
     },
     "condition" : {
       "property" : "vectorStore.vectorStore",
-      "equals" : "STORE_ELASTICSEARCH",
+      "equals" : "elasticsearchStore",
       "type" : "simple"
     },
     "type" : "String"
@@ -1557,7 +1557,7 @@
     },
     "condition" : {
       "property" : "vectorStore.vectorStore",
-      "equals" : "STORE_ELASTICSEARCH",
+      "equals" : "elasticsearchStore",
       "type" : "simple"
     },
     "type" : "String"
@@ -1577,7 +1577,7 @@
     },
     "condition" : {
       "property" : "vectorStore.vectorStore",
-      "equals" : "STORE_ELASTICSEARCH",
+      "equals" : "elasticsearchStore",
       "type" : "simple"
     },
     "type" : "String"
@@ -1597,7 +1597,7 @@
     },
     "condition" : {
       "property" : "vectorStore.vectorStore",
-      "equals" : "STORE_ELASTICSEARCH",
+      "equals" : "elasticsearchStore",
       "type" : "simple"
     },
     "type" : "String"
@@ -1617,7 +1617,7 @@
     },
     "condition" : {
       "property" : "vectorStore.vectorStore",
-      "equals" : "STORE_OPENSEARCH",
+      "equals" : "openSearchStore",
       "type" : "simple"
     },
     "type" : "String"
@@ -1637,7 +1637,7 @@
     },
     "condition" : {
       "property" : "vectorStore.vectorStore",
-      "equals" : "STORE_OPENSEARCH",
+      "equals" : "openSearchStore",
       "type" : "simple"
     },
     "type" : "String"
@@ -1657,7 +1657,7 @@
     },
     "condition" : {
       "property" : "vectorStore.vectorStore",
-      "equals" : "STORE_OPENSEARCH",
+      "equals" : "openSearchStore",
       "type" : "simple"
     },
     "type" : "String"
@@ -1677,7 +1677,7 @@
     },
     "condition" : {
       "property" : "vectorStore.vectorStore",
-      "equals" : "STORE_OPENSEARCH",
+      "equals" : "openSearchStore",
       "type" : "simple"
     },
     "type" : "String"
@@ -1761,7 +1761,7 @@
   }, {
     "id" : "vectorDatabaseConnectorOperation.documentSplitter.documentSplitter",
     "label" : "Document splitting strategy",
-    "value" : "DOCUMENT_SPLITTER_RECURSIVE",
+    "value" : "documentSplitterRecursive",
     "group" : "document",
     "binding" : {
       "name" : "vectorDatabaseConnectorOperation.documentSplitter.splitterType",
@@ -1775,10 +1775,10 @@
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "Recursive",
-      "value" : "DOCUMENT_SPLITTER_RECURSIVE"
+      "value" : "documentSplitterRecursive"
     }, {
       "name" : "Do not split",
-      "value" : "DOCUMENT_SPLITTER_NONE"
+      "value" : "documentSplitterNone"
     } ]
   }, {
     "id" : "vectorDatabaseConnectorOperation.documentSplitter.document.splitter.recursive.maxSegmentSizeInChars",
@@ -1798,7 +1798,7 @@
     "condition" : {
       "allMatch" : [ {
         "property" : "vectorDatabaseConnectorOperation.documentSplitter.documentSplitter",
-        "equals" : "DOCUMENT_SPLITTER_RECURSIVE",
+        "equals" : "documentSplitterRecursive",
         "type" : "simple"
       }, {
         "property" : "vectorDatabaseConnectorOperation.operationType",
@@ -1825,7 +1825,7 @@
     "condition" : {
       "allMatch" : [ {
         "property" : "vectorDatabaseConnectorOperation.documentSplitter.documentSplitter",
-        "equals" : "DOCUMENT_SPLITTER_RECURSIVE",
+        "equals" : "documentSplitterRecursive",
         "type" : "simple"
       }, {
         "property" : "vectorDatabaseConnectorOperation.operationType",

--- a/connectors/embeddings-vector-database/element-templates/hybrid/embeddings-vector-database-outbound-connector-hybrid.json
+++ b/connectors/embeddings-vector-database/element-templates/hybrid/embeddings-vector-database-outbound-connector-hybrid.json
@@ -1527,7 +1527,7 @@
       "value" : "DISK_ANN"
     } ]
   }, {
-    "id" : "vectorStore.elasticSearch.baseUrl",
+    "id" : "vectorStore.elasticsearch.baseUrl",
     "label" : "Base URL",
     "description" : "Elasticsearch base URL, i.e. http(s)://host:port",
     "optional" : false,
@@ -1537,7 +1537,7 @@
     "feel" : "optional",
     "group" : "embeddingsStore",
     "binding" : {
-      "name" : "vectorStore.elasticSearch.baseUrl",
+      "name" : "vectorStore.elasticsearch.baseUrl",
       "type" : "zeebe:input"
     },
     "condition" : {
@@ -1547,7 +1547,7 @@
     },
     "type" : "String"
   }, {
-    "id" : "vectorStore.elasticSearch.userName",
+    "id" : "vectorStore.elasticsearch.userName",
     "label" : "Username",
     "description" : "Elasticsearch username",
     "optional" : false,
@@ -1557,7 +1557,7 @@
     "feel" : "optional",
     "group" : "embeddingsStore",
     "binding" : {
-      "name" : "vectorStore.elasticSearch.userName",
+      "name" : "vectorStore.elasticsearch.userName",
       "type" : "zeebe:input"
     },
     "condition" : {
@@ -1567,7 +1567,7 @@
     },
     "type" : "String"
   }, {
-    "id" : "vectorStore.elasticSearch.password",
+    "id" : "vectorStore.elasticsearch.password",
     "label" : "Password",
     "description" : "Elasticsearch password",
     "optional" : false,
@@ -1577,7 +1577,7 @@
     "feel" : "optional",
     "group" : "embeddingsStore",
     "binding" : {
-      "name" : "vectorStore.elasticSearch.password",
+      "name" : "vectorStore.elasticsearch.password",
       "type" : "zeebe:input"
     },
     "condition" : {
@@ -1587,7 +1587,7 @@
     },
     "type" : "String"
   }, {
-    "id" : "vectorStore.elasticSearch.indexName",
+    "id" : "vectorStore.elasticsearch.indexName",
     "label" : "Index name",
     "description" : "Elasticsearch index",
     "optional" : false,
@@ -1597,7 +1597,7 @@
     "feel" : "optional",
     "group" : "embeddingsStore",
     "binding" : {
-      "name" : "vectorStore.elasticSearch.indexName",
+      "name" : "vectorStore.elasticsearch.indexName",
       "type" : "zeebe:input"
     },
     "condition" : {

--- a/connectors/embeddings-vector-database/element-templates/hybrid/embeddings-vector-database-outbound-connector-hybrid.json
+++ b/connectors/embeddings-vector-database/element-templates/hybrid/embeddings-vector-database-outbound-connector-hybrid.json
@@ -7,7 +7,7 @@
     "keywords" : [ ]
   },
   "documentationRef" : "https://docs.camunda.io/docs/8.8/components/connectors/out-of-the-box-connectors/embeddings-vector-db/",
-  "version" : 1,
+  "version" : 2,
   "category" : {
     "id" : "connectors",
     "name" : "Connectors"
@@ -1843,7 +1843,7 @@
     "id" : "version",
     "label" : "Version",
     "description" : "Version of the element template",
-    "value" : "1",
+    "value" : "2",
     "group" : "connector",
     "binding" : {
       "key" : "elementTemplateVersion",

--- a/connectors/embeddings-vector-database/element-templates/hybrid/embeddings-vector-database-outbound-connector-hybrid.json
+++ b/connectors/embeddings-vector-database/element-templates/hybrid/embeddings-vector-database-outbound-connector-hybrid.json
@@ -141,7 +141,7 @@
     "id" : "embeddingModelProvider.modelProvider",
     "label" : "Model provider",
     "description" : "Select embedding model provider",
-    "value" : "BEDROCK_MODEL_PROVIDER",
+    "value" : "bedrockModelProvider",
     "group" : "embeddingModel",
     "binding" : {
       "name" : "embeddingModelProvider.modelProvider",
@@ -150,16 +150,16 @@
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "Azure OpenAI",
-      "value" : "AZURE_OPEN_AI_MODEL_PROVIDER"
+      "value" : "azureOpenAiModelProvider"
     }, {
       "name" : "AWS Bedrock",
-      "value" : "BEDROCK_MODEL_PROVIDER"
+      "value" : "bedrockModelProvider"
     }, {
       "name" : "Google Vertex AI",
-      "value" : "VERTEX_AI_MODEL_PROVIDER"
+      "value" : "vertexAiModelProvider"
     }, {
       "name" : "OpenAI",
-      "value" : "OPEN_AI_MODEL_PROVIDER"
+      "value" : "openAiModelProvider"
     } ]
   }, {
     "id" : "embeddingModelProvider.azureOpenAi.endpoint",
@@ -177,7 +177,7 @@
     },
     "condition" : {
       "property" : "embeddingModelProvider.modelProvider",
-      "equals" : "AZURE_OPEN_AI_MODEL_PROVIDER",
+      "equals" : "azureOpenAiModelProvider",
       "type" : "simple"
     },
     "type" : "String"
@@ -193,7 +193,7 @@
     },
     "condition" : {
       "property" : "embeddingModelProvider.modelProvider",
-      "equals" : "AZURE_OPEN_AI_MODEL_PROVIDER",
+      "equals" : "azureOpenAiModelProvider",
       "type" : "simple"
     },
     "type" : "Dropdown",
@@ -224,7 +224,7 @@
         "type" : "simple"
       }, {
         "property" : "embeddingModelProvider.modelProvider",
-        "equals" : "AZURE_OPEN_AI_MODEL_PROVIDER",
+        "equals" : "azureOpenAiModelProvider",
         "type" : "simple"
       } ]
     },
@@ -250,7 +250,7 @@
         "type" : "simple"
       }, {
         "property" : "embeddingModelProvider.modelProvider",
-        "equals" : "AZURE_OPEN_AI_MODEL_PROVIDER",
+        "equals" : "azureOpenAiModelProvider",
         "type" : "simple"
       } ]
     },
@@ -276,7 +276,7 @@
         "type" : "simple"
       }, {
         "property" : "embeddingModelProvider.modelProvider",
-        "equals" : "AZURE_OPEN_AI_MODEL_PROVIDER",
+        "equals" : "azureOpenAiModelProvider",
         "type" : "simple"
       } ]
     },
@@ -302,7 +302,7 @@
         "type" : "simple"
       }, {
         "property" : "embeddingModelProvider.modelProvider",
-        "equals" : "AZURE_OPEN_AI_MODEL_PROVIDER",
+        "equals" : "azureOpenAiModelProvider",
         "type" : "simple"
       } ]
     },
@@ -325,7 +325,7 @@
         "type" : "simple"
       }, {
         "property" : "embeddingModelProvider.modelProvider",
-        "equals" : "AZURE_OPEN_AI_MODEL_PROVIDER",
+        "equals" : "azureOpenAiModelProvider",
         "type" : "simple"
       } ]
     },
@@ -346,7 +346,7 @@
     },
     "condition" : {
       "property" : "embeddingModelProvider.modelProvider",
-      "equals" : "AZURE_OPEN_AI_MODEL_PROVIDER",
+      "equals" : "azureOpenAiModelProvider",
       "type" : "simple"
     },
     "type" : "String"
@@ -363,7 +363,7 @@
     },
     "condition" : {
       "property" : "embeddingModelProvider.modelProvider",
-      "equals" : "AZURE_OPEN_AI_MODEL_PROVIDER",
+      "equals" : "azureOpenAiModelProvider",
       "type" : "simple"
     },
     "type" : "Number"
@@ -381,7 +381,7 @@
     },
     "condition" : {
       "property" : "embeddingModelProvider.modelProvider",
-      "equals" : "AZURE_OPEN_AI_MODEL_PROVIDER",
+      "equals" : "azureOpenAiModelProvider",
       "type" : "simple"
     },
     "type" : "Number"
@@ -398,7 +398,7 @@
     },
     "condition" : {
       "property" : "embeddingModelProvider.modelProvider",
-      "equals" : "AZURE_OPEN_AI_MODEL_PROVIDER",
+      "equals" : "azureOpenAiModelProvider",
       "type" : "simple"
     },
     "type" : "String"
@@ -418,7 +418,7 @@
     },
     "condition" : {
       "property" : "embeddingModelProvider.modelProvider",
-      "equals" : "BEDROCK_MODEL_PROVIDER",
+      "equals" : "bedrockModelProvider",
       "type" : "simple"
     },
     "type" : "String"
@@ -438,7 +438,7 @@
     },
     "condition" : {
       "property" : "embeddingModelProvider.modelProvider",
-      "equals" : "BEDROCK_MODEL_PROVIDER",
+      "equals" : "bedrockModelProvider",
       "type" : "simple"
     },
     "type" : "String"
@@ -458,7 +458,7 @@
     },
     "condition" : {
       "property" : "embeddingModelProvider.modelProvider",
-      "equals" : "BEDROCK_MODEL_PROVIDER",
+      "equals" : "bedrockModelProvider",
       "type" : "simple"
     },
     "type" : "String"
@@ -478,7 +478,7 @@
     },
     "condition" : {
       "property" : "embeddingModelProvider.modelProvider",
-      "equals" : "BEDROCK_MODEL_PROVIDER",
+      "equals" : "bedrockModelProvider",
       "type" : "simple"
     },
     "type" : "Dropdown",
@@ -512,7 +512,7 @@
         "type" : "simple"
       }, {
         "property" : "embeddingModelProvider.modelProvider",
-        "equals" : "BEDROCK_MODEL_PROVIDER",
+        "equals" : "bedrockModelProvider",
         "type" : "simple"
       } ]
     },
@@ -538,7 +538,7 @@
         "type" : "simple"
       }, {
         "property" : "embeddingModelProvider.modelProvider",
-        "equals" : "BEDROCK_MODEL_PROVIDER",
+        "equals" : "bedrockModelProvider",
         "type" : "simple"
       } ]
     },
@@ -575,7 +575,7 @@
         "type" : "simple"
       }, {
         "property" : "embeddingModelProvider.modelProvider",
-        "equals" : "BEDROCK_MODEL_PROVIDER",
+        "equals" : "bedrockModelProvider",
         "type" : "simple"
       } ]
     },
@@ -594,7 +594,7 @@
     },
     "condition" : {
       "property" : "embeddingModelProvider.modelProvider",
-      "equals" : "BEDROCK_MODEL_PROVIDER",
+      "equals" : "bedrockModelProvider",
       "type" : "simple"
     },
     "type" : "Number"
@@ -614,7 +614,7 @@
     },
     "condition" : {
       "property" : "embeddingModelProvider.modelProvider",
-      "equals" : "VERTEX_AI_MODEL_PROVIDER",
+      "equals" : "vertexAiModelProvider",
       "type" : "simple"
     },
     "type" : "String"
@@ -634,7 +634,7 @@
     },
     "condition" : {
       "property" : "embeddingModelProvider.modelProvider",
-      "equals" : "VERTEX_AI_MODEL_PROVIDER",
+      "equals" : "vertexAiModelProvider",
       "type" : "simple"
     },
     "type" : "String"
@@ -650,7 +650,7 @@
     },
     "condition" : {
       "property" : "embeddingModelProvider.modelProvider",
-      "equals" : "VERTEX_AI_MODEL_PROVIDER",
+      "equals" : "vertexAiModelProvider",
       "type" : "simple"
     },
     "type" : "Dropdown",
@@ -682,7 +682,7 @@
         "type" : "simple"
       }, {
         "property" : "embeddingModelProvider.modelProvider",
-        "equals" : "VERTEX_AI_MODEL_PROVIDER",
+        "equals" : "vertexAiModelProvider",
         "type" : "simple"
       } ]
     },
@@ -703,7 +703,7 @@
     },
     "condition" : {
       "property" : "embeddingModelProvider.modelProvider",
-      "equals" : "VERTEX_AI_MODEL_PROVIDER",
+      "equals" : "vertexAiModelProvider",
       "type" : "simple"
     },
     "type" : "String"
@@ -723,7 +723,7 @@
     },
     "condition" : {
       "property" : "embeddingModelProvider.modelProvider",
-      "equals" : "VERTEX_AI_MODEL_PROVIDER",
+      "equals" : "vertexAiModelProvider",
       "type" : "simple"
     },
     "type" : "Number"
@@ -741,7 +741,7 @@
     },
     "condition" : {
       "property" : "embeddingModelProvider.modelProvider",
-      "equals" : "VERTEX_AI_MODEL_PROVIDER",
+      "equals" : "vertexAiModelProvider",
       "type" : "simple"
     },
     "type" : "String"
@@ -759,7 +759,7 @@
     },
     "condition" : {
       "property" : "embeddingModelProvider.modelProvider",
-      "equals" : "VERTEX_AI_MODEL_PROVIDER",
+      "equals" : "vertexAiModelProvider",
       "type" : "simple"
     },
     "type" : "Number"
@@ -778,7 +778,7 @@
     },
     "condition" : {
       "property" : "embeddingModelProvider.modelProvider",
-      "equals" : "OPEN_AI_MODEL_PROVIDER",
+      "equals" : "openAiModelProvider",
       "type" : "simple"
     },
     "type" : "String"
@@ -798,7 +798,7 @@
     },
     "condition" : {
       "property" : "embeddingModelProvider.modelProvider",
-      "equals" : "OPEN_AI_MODEL_PROVIDER",
+      "equals" : "openAiModelProvider",
       "type" : "simple"
     },
     "type" : "String"
@@ -815,7 +815,7 @@
     },
     "condition" : {
       "property" : "embeddingModelProvider.modelProvider",
-      "equals" : "OPEN_AI_MODEL_PROVIDER",
+      "equals" : "openAiModelProvider",
       "type" : "simple"
     },
     "type" : "String"
@@ -832,7 +832,7 @@
     },
     "condition" : {
       "property" : "embeddingModelProvider.modelProvider",
-      "equals" : "OPEN_AI_MODEL_PROVIDER",
+      "equals" : "openAiModelProvider",
       "type" : "simple"
     },
     "type" : "String"
@@ -849,7 +849,7 @@
     },
     "condition" : {
       "property" : "embeddingModelProvider.modelProvider",
-      "equals" : "OPEN_AI_MODEL_PROVIDER",
+      "equals" : "openAiModelProvider",
       "type" : "simple"
     },
     "type" : "Number"
@@ -867,7 +867,7 @@
     },
     "condition" : {
       "property" : "embeddingModelProvider.modelProvider",
-      "equals" : "OPEN_AI_MODEL_PROVIDER",
+      "equals" : "openAiModelProvider",
       "type" : "simple"
     },
     "type" : "Number"
@@ -884,7 +884,7 @@
     },
     "condition" : {
       "property" : "embeddingModelProvider.modelProvider",
-      "equals" : "OPEN_AI_MODEL_PROVIDER",
+      "equals" : "openAiModelProvider",
       "type" : "simple"
     },
     "type" : "String"
@@ -900,7 +900,7 @@
     },
     "condition" : {
       "property" : "embeddingModelProvider.modelProvider",
-      "equals" : "OPEN_AI_MODEL_PROVIDER",
+      "equals" : "openAiModelProvider",
       "type" : "simple"
     },
     "tooltip" : "Base URL of OpenAI API. The default is 'https://api.openai.com/v1/'",
@@ -909,7 +909,7 @@
     "id" : "vectorStore.vectorStore",
     "label" : "Embeddings store",
     "description" : "Select embedding store",
-    "value" : "STORE_ELASTICSEARCH",
+    "value" : "elasticsearchStore",
     "group" : "embeddingsStore",
     "binding" : {
       "name" : "vectorStore.storeType",
@@ -918,19 +918,19 @@
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "Amazon Managed OpenSearch",
-      "value" : "STORE_AMAZON_MANAGED_OPENSEARCH"
+      "value" : "amazonManagedOpenSearchStore"
     }, {
       "name" : "Azure AI Search",
-      "value" : "STORE_AZURE_AI_SEARCH"
+      "value" : "azureAiSearchStore"
     }, {
       "name" : "Azure Cosmos DB NoSQL",
-      "value" : "STORE_AZURE_COSMOS_DB_NO_SQL"
+      "value" : "azureCosmosDbNoSqlStore"
     }, {
       "name" : "Elasticsearch",
-      "value" : "STORE_ELASTICSEARCH"
+      "value" : "elasticsearchStore"
     }, {
       "name" : "OpenSearch",
-      "value" : "STORE_OPENSEARCH"
+      "value" : "openSearchStore"
     } ]
   }, {
     "id" : "vectorStore.amazonManagedOpensearch.accessKey",
@@ -948,7 +948,7 @@
     },
     "condition" : {
       "property" : "vectorStore.vectorStore",
-      "equals" : "STORE_AMAZON_MANAGED_OPENSEARCH",
+      "equals" : "amazonManagedOpenSearchStore",
       "type" : "simple"
     },
     "type" : "String"
@@ -968,7 +968,7 @@
     },
     "condition" : {
       "property" : "vectorStore.vectorStore",
-      "equals" : "STORE_AMAZON_MANAGED_OPENSEARCH",
+      "equals" : "amazonManagedOpenSearchStore",
       "type" : "simple"
     },
     "type" : "String"
@@ -988,7 +988,7 @@
     },
     "condition" : {
       "property" : "vectorStore.vectorStore",
-      "equals" : "STORE_AMAZON_MANAGED_OPENSEARCH",
+      "equals" : "amazonManagedOpenSearchStore",
       "type" : "simple"
     },
     "type" : "String"
@@ -1008,7 +1008,7 @@
     },
     "condition" : {
       "property" : "vectorStore.vectorStore",
-      "equals" : "STORE_AMAZON_MANAGED_OPENSEARCH",
+      "equals" : "amazonManagedOpenSearchStore",
       "type" : "simple"
     },
     "type" : "String"
@@ -1028,7 +1028,7 @@
     },
     "condition" : {
       "property" : "vectorStore.vectorStore",
-      "equals" : "STORE_AMAZON_MANAGED_OPENSEARCH",
+      "equals" : "amazonManagedOpenSearchStore",
       "type" : "simple"
     },
     "type" : "String"
@@ -1048,7 +1048,7 @@
     },
     "condition" : {
       "property" : "vectorStore.vectorStore",
-      "equals" : "STORE_AZURE_AI_SEARCH",
+      "equals" : "azureAiSearchStore",
       "type" : "simple"
     },
     "type" : "String"
@@ -1064,7 +1064,7 @@
     },
     "condition" : {
       "property" : "vectorStore.vectorStore",
-      "equals" : "STORE_AZURE_AI_SEARCH",
+      "equals" : "azureAiSearchStore",
       "type" : "simple"
     },
     "type" : "Dropdown",
@@ -1095,7 +1095,7 @@
         "type" : "simple"
       }, {
         "property" : "vectorStore.vectorStore",
-        "equals" : "STORE_AZURE_AI_SEARCH",
+        "equals" : "azureAiSearchStore",
         "type" : "simple"
       } ]
     },
@@ -1121,7 +1121,7 @@
         "type" : "simple"
       }, {
         "property" : "vectorStore.vectorStore",
-        "equals" : "STORE_AZURE_AI_SEARCH",
+        "equals" : "azureAiSearchStore",
         "type" : "simple"
       } ]
     },
@@ -1147,7 +1147,7 @@
         "type" : "simple"
       }, {
         "property" : "vectorStore.vectorStore",
-        "equals" : "STORE_AZURE_AI_SEARCH",
+        "equals" : "azureAiSearchStore",
         "type" : "simple"
       } ]
     },
@@ -1173,7 +1173,7 @@
         "type" : "simple"
       }, {
         "property" : "vectorStore.vectorStore",
-        "equals" : "STORE_AZURE_AI_SEARCH",
+        "equals" : "azureAiSearchStore",
         "type" : "simple"
       } ]
     },
@@ -1196,7 +1196,7 @@
         "type" : "simple"
       }, {
         "property" : "vectorStore.vectorStore",
-        "equals" : "STORE_AZURE_AI_SEARCH",
+        "equals" : "azureAiSearchStore",
         "type" : "simple"
       } ]
     },
@@ -1217,7 +1217,7 @@
     },
     "condition" : {
       "property" : "vectorStore.vectorStore",
-      "equals" : "STORE_AZURE_AI_SEARCH",
+      "equals" : "azureAiSearchStore",
       "type" : "simple"
     },
     "type" : "String"
@@ -1237,7 +1237,7 @@
     },
     "condition" : {
       "property" : "vectorStore.vectorStore",
-      "equals" : "STORE_AZURE_COSMOS_DB_NO_SQL",
+      "equals" : "azureCosmosDbNoSqlStore",
       "type" : "simple"
     },
     "type" : "String"
@@ -1253,7 +1253,7 @@
     },
     "condition" : {
       "property" : "vectorStore.vectorStore",
-      "equals" : "STORE_AZURE_COSMOS_DB_NO_SQL",
+      "equals" : "azureCosmosDbNoSqlStore",
       "type" : "simple"
     },
     "type" : "Dropdown",
@@ -1284,7 +1284,7 @@
         "type" : "simple"
       }, {
         "property" : "vectorStore.vectorStore",
-        "equals" : "STORE_AZURE_COSMOS_DB_NO_SQL",
+        "equals" : "azureCosmosDbNoSqlStore",
         "type" : "simple"
       } ]
     },
@@ -1310,7 +1310,7 @@
         "type" : "simple"
       }, {
         "property" : "vectorStore.vectorStore",
-        "equals" : "STORE_AZURE_COSMOS_DB_NO_SQL",
+        "equals" : "azureCosmosDbNoSqlStore",
         "type" : "simple"
       } ]
     },
@@ -1336,7 +1336,7 @@
         "type" : "simple"
       }, {
         "property" : "vectorStore.vectorStore",
-        "equals" : "STORE_AZURE_COSMOS_DB_NO_SQL",
+        "equals" : "azureCosmosDbNoSqlStore",
         "type" : "simple"
       } ]
     },
@@ -1362,7 +1362,7 @@
         "type" : "simple"
       }, {
         "property" : "vectorStore.vectorStore",
-        "equals" : "STORE_AZURE_COSMOS_DB_NO_SQL",
+        "equals" : "azureCosmosDbNoSqlStore",
         "type" : "simple"
       } ]
     },
@@ -1385,7 +1385,7 @@
         "type" : "simple"
       }, {
         "property" : "vectorStore.vectorStore",
-        "equals" : "STORE_AZURE_COSMOS_DB_NO_SQL",
+        "equals" : "azureCosmosDbNoSqlStore",
         "type" : "simple"
       } ]
     },
@@ -1406,7 +1406,7 @@
     },
     "condition" : {
       "property" : "vectorStore.vectorStore",
-      "equals" : "STORE_AZURE_COSMOS_DB_NO_SQL",
+      "equals" : "azureCosmosDbNoSqlStore",
       "type" : "simple"
     },
     "type" : "String"
@@ -1426,7 +1426,7 @@
     },
     "condition" : {
       "property" : "vectorStore.vectorStore",
-      "equals" : "STORE_AZURE_COSMOS_DB_NO_SQL",
+      "equals" : "azureCosmosDbNoSqlStore",
       "type" : "simple"
     },
     "type" : "String"
@@ -1446,7 +1446,7 @@
     },
     "condition" : {
       "property" : "vectorStore.vectorStore",
-      "equals" : "STORE_AZURE_COSMOS_DB_NO_SQL",
+      "equals" : "azureCosmosDbNoSqlStore",
       "type" : "simple"
     },
     "type" : "Dropdown",
@@ -1482,7 +1482,7 @@
     },
     "condition" : {
       "property" : "vectorStore.vectorStore",
-      "equals" : "STORE_AZURE_COSMOS_DB_NO_SQL",
+      "equals" : "azureCosmosDbNoSqlStore",
       "type" : "simple"
     },
     "type" : "Dropdown",
@@ -1512,7 +1512,7 @@
     },
     "condition" : {
       "property" : "vectorStore.vectorStore",
-      "equals" : "STORE_AZURE_COSMOS_DB_NO_SQL",
+      "equals" : "azureCosmosDbNoSqlStore",
       "type" : "simple"
     },
     "type" : "Dropdown",
@@ -1542,7 +1542,7 @@
     },
     "condition" : {
       "property" : "vectorStore.vectorStore",
-      "equals" : "STORE_ELASTICSEARCH",
+      "equals" : "elasticsearchStore",
       "type" : "simple"
     },
     "type" : "String"
@@ -1562,7 +1562,7 @@
     },
     "condition" : {
       "property" : "vectorStore.vectorStore",
-      "equals" : "STORE_ELASTICSEARCH",
+      "equals" : "elasticsearchStore",
       "type" : "simple"
     },
     "type" : "String"
@@ -1582,7 +1582,7 @@
     },
     "condition" : {
       "property" : "vectorStore.vectorStore",
-      "equals" : "STORE_ELASTICSEARCH",
+      "equals" : "elasticsearchStore",
       "type" : "simple"
     },
     "type" : "String"
@@ -1602,7 +1602,7 @@
     },
     "condition" : {
       "property" : "vectorStore.vectorStore",
-      "equals" : "STORE_ELASTICSEARCH",
+      "equals" : "elasticsearchStore",
       "type" : "simple"
     },
     "type" : "String"
@@ -1622,7 +1622,7 @@
     },
     "condition" : {
       "property" : "vectorStore.vectorStore",
-      "equals" : "STORE_OPENSEARCH",
+      "equals" : "openSearchStore",
       "type" : "simple"
     },
     "type" : "String"
@@ -1642,7 +1642,7 @@
     },
     "condition" : {
       "property" : "vectorStore.vectorStore",
-      "equals" : "STORE_OPENSEARCH",
+      "equals" : "openSearchStore",
       "type" : "simple"
     },
     "type" : "String"
@@ -1662,7 +1662,7 @@
     },
     "condition" : {
       "property" : "vectorStore.vectorStore",
-      "equals" : "STORE_OPENSEARCH",
+      "equals" : "openSearchStore",
       "type" : "simple"
     },
     "type" : "String"
@@ -1682,7 +1682,7 @@
     },
     "condition" : {
       "property" : "vectorStore.vectorStore",
-      "equals" : "STORE_OPENSEARCH",
+      "equals" : "openSearchStore",
       "type" : "simple"
     },
     "type" : "String"
@@ -1766,7 +1766,7 @@
   }, {
     "id" : "vectorDatabaseConnectorOperation.documentSplitter.documentSplitter",
     "label" : "Document splitting strategy",
-    "value" : "DOCUMENT_SPLITTER_RECURSIVE",
+    "value" : "documentSplitterRecursive",
     "group" : "document",
     "binding" : {
       "name" : "vectorDatabaseConnectorOperation.documentSplitter.splitterType",
@@ -1780,10 +1780,10 @@
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "Recursive",
-      "value" : "DOCUMENT_SPLITTER_RECURSIVE"
+      "value" : "documentSplitterRecursive"
     }, {
       "name" : "Do not split",
-      "value" : "DOCUMENT_SPLITTER_NONE"
+      "value" : "documentSplitterNone"
     } ]
   }, {
     "id" : "vectorDatabaseConnectorOperation.documentSplitter.document.splitter.recursive.maxSegmentSizeInChars",
@@ -1803,7 +1803,7 @@
     "condition" : {
       "allMatch" : [ {
         "property" : "vectorDatabaseConnectorOperation.documentSplitter.documentSplitter",
-        "equals" : "DOCUMENT_SPLITTER_RECURSIVE",
+        "equals" : "documentSplitterRecursive",
         "type" : "simple"
       }, {
         "property" : "vectorDatabaseConnectorOperation.operationType",
@@ -1830,7 +1830,7 @@
     "condition" : {
       "allMatch" : [ {
         "property" : "vectorDatabaseConnectorOperation.documentSplitter.documentSplitter",
-        "equals" : "DOCUMENT_SPLITTER_RECURSIVE",
+        "equals" : "documentSplitterRecursive",
         "type" : "simple"
       }, {
         "property" : "vectorDatabaseConnectorOperation.operationType",

--- a/connectors/embeddings-vector-database/element-templates/hybrid/embeddings-vector-database-outbound-connector-hybrid.json
+++ b/connectors/embeddings-vector-database/element-templates/hybrid/embeddings-vector-database-outbound-connector-hybrid.json
@@ -1055,7 +1055,7 @@
   }, {
     "id" : "vectorStore.aiSearch.authentication.type",
     "label" : "Authentication",
-    "description" : "Specify the Azure OpenAI authentication strategy.",
+    "description" : "Specify the Azure authentication strategy.",
     "value" : "apiKey",
     "group" : "embeddingsStore",
     "binding" : {
@@ -1244,7 +1244,7 @@
   }, {
     "id" : "vectorStore.azureCosmosDbNoSql.authentication.type",
     "label" : "Authentication",
-    "description" : "Specify the Azure OpenAI authentication strategy.",
+    "description" : "Specify the Azure authentication strategy.",
     "value" : "apiKey",
     "group" : "embeddingsStore",
     "binding" : {

--- a/connectors/embeddings-vector-database/element-templates/versioned/embeddings-vector-database-outbound-connector-1.json
+++ b/connectors/embeddings-vector-database/element-templates/versioned/embeddings-vector-database-outbound-connector-1.json
@@ -7,7 +7,7 @@
     "keywords" : [ ]
   },
   "documentationRef" : "https://docs.camunda.io/docs/8.8/components/connectors/out-of-the-box-connectors/embeddings-vector-db/",
-  "version" : 2,
+  "version" : 1,
   "category" : {
     "id" : "connectors",
     "name" : "Connectors"
@@ -136,7 +136,7 @@
     "id" : "embeddingModelProvider.modelProvider",
     "label" : "Model provider",
     "description" : "Select embedding model provider",
-    "value" : "bedrockModelProvider",
+    "value" : "BEDROCK_MODEL_PROVIDER",
     "group" : "embeddingModel",
     "binding" : {
       "name" : "embeddingModelProvider.modelProvider",
@@ -145,19 +145,19 @@
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "Azure OpenAI",
-      "value" : "azureOpenAiModelProvider"
+      "value" : "AZURE_OPEN_AI_MODEL_PROVIDER"
     }, {
       "name" : "AWS Bedrock",
-      "value" : "bedrockModelProvider"
+      "value" : "BEDROCK_MODEL_PROVIDER"
     }, {
       "name" : "Google Vertex AI",
-      "value" : "vertexAiModelProvider"
+      "value" : "VERTEX_AI_MODEL_PROVIDER"
     }, {
       "name" : "OpenAI",
-      "value" : "openAiModelProvider"
+      "value" : "OPEN_AI_MODEL_PROVIDER"
     } ]
   }, {
-    "id" : "embeddingModelProvider.azureOpenAi.endpoint",
+    "id" : "embeddingModelProvider.endpoint",
     "label" : "Endpoint",
     "description" : "Specify Azure OpenAI endpoint. Details in the <a href=\"https://learn.microsoft.com/en-us/azure/ai-foundry/openai/reference\" target=\"_blank\">documentation</a>.",
     "optional" : false,
@@ -167,28 +167,28 @@
     "feel" : "optional",
     "group" : "embeddingModel",
     "binding" : {
-      "name" : "embeddingModelProvider.azureOpenAi.endpoint",
+      "name" : "embeddingModelProvider.endpoint",
       "type" : "zeebe:input"
     },
     "condition" : {
       "property" : "embeddingModelProvider.modelProvider",
-      "equals" : "azureOpenAiModelProvider",
+      "equals" : "AZURE_OPEN_AI_MODEL_PROVIDER",
       "type" : "simple"
     },
     "type" : "String"
   }, {
-    "id" : "embeddingModelProvider.azureOpenAi.authentication.type",
+    "id" : "embeddingModelProvider.authentication.type",
     "label" : "Authentication",
     "description" : "Specify the Azure OpenAI authentication strategy.",
     "value" : "apiKey",
     "group" : "embeddingModel",
     "binding" : {
-      "name" : "embeddingModelProvider.azureOpenAi.authentication.type",
+      "name" : "embeddingModelProvider.authentication.type",
       "type" : "zeebe:input"
     },
     "condition" : {
       "property" : "embeddingModelProvider.modelProvider",
-      "equals" : "azureOpenAiModelProvider",
+      "equals" : "AZURE_OPEN_AI_MODEL_PROVIDER",
       "type" : "simple"
     },
     "type" : "Dropdown",
@@ -200,7 +200,7 @@
       "value" : "clientCredentials"
     } ]
   }, {
-    "id" : "embeddingModelProvider.azureOpenAi.authentication.apiKey",
+    "id" : "embeddingModelProvider.authentication.apiKey",
     "label" : "API key",
     "optional" : false,
     "constraints" : {
@@ -209,23 +209,23 @@
     "feel" : "optional",
     "group" : "embeddingModel",
     "binding" : {
-      "name" : "embeddingModelProvider.azureOpenAi.authentication.apiKey",
+      "name" : "embeddingModelProvider.authentication.apiKey",
       "type" : "zeebe:input"
     },
     "condition" : {
       "allMatch" : [ {
-        "property" : "embeddingModelProvider.azureOpenAi.authentication.type",
+        "property" : "embeddingModelProvider.authentication.type",
         "equals" : "apiKey",
         "type" : "simple"
       }, {
         "property" : "embeddingModelProvider.modelProvider",
-        "equals" : "azureOpenAiModelProvider",
+        "equals" : "AZURE_OPEN_AI_MODEL_PROVIDER",
         "type" : "simple"
       } ]
     },
     "type" : "String"
   }, {
-    "id" : "embeddingModelProvider.azureOpenAi.authentication.clientId",
+    "id" : "embeddingModelProvider.authentication.clientId",
     "label" : "Client ID",
     "description" : "ID of a Microsoft Entra application",
     "optional" : false,
@@ -235,23 +235,23 @@
     "feel" : "optional",
     "group" : "embeddingModel",
     "binding" : {
-      "name" : "embeddingModelProvider.azureOpenAi.authentication.clientId",
+      "name" : "embeddingModelProvider.authentication.clientId",
       "type" : "zeebe:input"
     },
     "condition" : {
       "allMatch" : [ {
-        "property" : "embeddingModelProvider.azureOpenAi.authentication.type",
+        "property" : "embeddingModelProvider.authentication.type",
         "equals" : "clientCredentials",
         "type" : "simple"
       }, {
         "property" : "embeddingModelProvider.modelProvider",
-        "equals" : "azureOpenAiModelProvider",
+        "equals" : "AZURE_OPEN_AI_MODEL_PROVIDER",
         "type" : "simple"
       } ]
     },
     "type" : "String"
   }, {
-    "id" : "embeddingModelProvider.azureOpenAi.authentication.clientSecret",
+    "id" : "embeddingModelProvider.authentication.clientSecret",
     "label" : "Client secret",
     "description" : "Secret of a Microsoft Entra application",
     "optional" : false,
@@ -261,23 +261,23 @@
     "feel" : "optional",
     "group" : "embeddingModel",
     "binding" : {
-      "name" : "embeddingModelProvider.azureOpenAi.authentication.clientSecret",
+      "name" : "embeddingModelProvider.authentication.clientSecret",
       "type" : "zeebe:input"
     },
     "condition" : {
       "allMatch" : [ {
-        "property" : "embeddingModelProvider.azureOpenAi.authentication.type",
+        "property" : "embeddingModelProvider.authentication.type",
         "equals" : "clientCredentials",
         "type" : "simple"
       }, {
         "property" : "embeddingModelProvider.modelProvider",
-        "equals" : "azureOpenAiModelProvider",
+        "equals" : "AZURE_OPEN_AI_MODEL_PROVIDER",
         "type" : "simple"
       } ]
     },
     "type" : "String"
   }, {
-    "id" : "embeddingModelProvider.azureOpenAi.authentication.tenantId",
+    "id" : "embeddingModelProvider.authentication.tenantId",
     "label" : "Tenant ID",
     "description" : "ID of a Microsoft Entra tenant. Details in the <a href=\"https://learn.microsoft.com/en-us/entra/fundamentals/how-to-find-tenant\" target=\"_blank\">documentation</a>.",
     "optional" : false,
@@ -287,46 +287,46 @@
     "feel" : "optional",
     "group" : "embeddingModel",
     "binding" : {
-      "name" : "embeddingModelProvider.azureOpenAi.authentication.tenantId",
+      "name" : "embeddingModelProvider.authentication.tenantId",
       "type" : "zeebe:input"
     },
     "condition" : {
       "allMatch" : [ {
-        "property" : "embeddingModelProvider.azureOpenAi.authentication.type",
+        "property" : "embeddingModelProvider.authentication.type",
         "equals" : "clientCredentials",
         "type" : "simple"
       }, {
         "property" : "embeddingModelProvider.modelProvider",
-        "equals" : "azureOpenAiModelProvider",
+        "equals" : "AZURE_OPEN_AI_MODEL_PROVIDER",
         "type" : "simple"
       } ]
     },
     "type" : "String"
   }, {
-    "id" : "embeddingModelProvider.azureOpenAi.authentication.authorityHost",
+    "id" : "embeddingModelProvider.authentication.authorityHost",
     "label" : "Authority host",
     "description" : "Authority host URL for the Microsoft Entra application. Defaults to <code>https://login.microsoftonline.com</code>. This can also contain an OAuth 2.0 token endpoint.",
     "optional" : true,
     "feel" : "optional",
     "group" : "embeddingModel",
     "binding" : {
-      "name" : "embeddingModelProvider.azureOpenAi.authentication.authorityHost",
+      "name" : "embeddingModelProvider.authentication.authorityHost",
       "type" : "zeebe:input"
     },
     "condition" : {
       "allMatch" : [ {
-        "property" : "embeddingModelProvider.azureOpenAi.authentication.type",
+        "property" : "embeddingModelProvider.authentication.type",
         "equals" : "clientCredentials",
         "type" : "simple"
       }, {
         "property" : "embeddingModelProvider.modelProvider",
-        "equals" : "azureOpenAiModelProvider",
+        "equals" : "AZURE_OPEN_AI_MODEL_PROVIDER",
         "type" : "simple"
       } ]
     },
     "type" : "String"
   }, {
-    "id" : "embeddingModelProvider.azureOpenAi.deploymentName",
+    "id" : "embeddingModelProvider.deploymentName",
     "label" : "Model deployment name",
     "description" : "Specify the model deployment name. Details in the <a href=\"https://learn.microsoft.com/en-us/azure/ai-foundry/openai/reference\" target=\"_blank\">documentation</a>.",
     "optional" : false,
@@ -336,34 +336,34 @@
     "feel" : "optional",
     "group" : "embeddingModel",
     "binding" : {
-      "name" : "embeddingModelProvider.azureOpenAi.deploymentName",
+      "name" : "embeddingModelProvider.deploymentName",
       "type" : "zeebe:input"
     },
     "condition" : {
       "property" : "embeddingModelProvider.modelProvider",
-      "equals" : "azureOpenAiModelProvider",
+      "equals" : "AZURE_OPEN_AI_MODEL_PROVIDER",
       "type" : "simple"
     },
     "type" : "String"
   }, {
-    "id" : "embeddingModelProvider.azureOpenAi.dimensions",
+    "id" : "embeddingModelProvider.dimensions",
     "label" : "Embedding dimensions",
     "description" : "The size of the vector used to represent data. If not specified, the default model dimensions are used. Details in the <a href=\"https://platform.openai.com/docs/guides/embeddings\" target=\"_blank\">documentation</a>.",
     "optional" : true,
     "feel" : "required",
     "group" : "embeddingModel",
     "binding" : {
-      "name" : "embeddingModelProvider.azureOpenAi.dimensions",
+      "name" : "embeddingModelProvider.dimensions",
       "type" : "zeebe:input"
     },
     "condition" : {
       "property" : "embeddingModelProvider.modelProvider",
-      "equals" : "azureOpenAiModelProvider",
+      "equals" : "AZURE_OPEN_AI_MODEL_PROVIDER",
       "type" : "simple"
     },
     "type" : "Number"
   }, {
-    "id" : "embeddingModelProvider.azureOpenAi.maxRetries",
+    "id" : "embeddingModelProvider.maxRetries",
     "label" : "Max retries",
     "description" : "Max retries",
     "optional" : true,
@@ -371,34 +371,34 @@
     "feel" : "static",
     "group" : "embeddingModel",
     "binding" : {
-      "name" : "embeddingModelProvider.azureOpenAi.maxRetries",
+      "name" : "embeddingModelProvider.maxRetries",
       "type" : "zeebe:input"
     },
     "condition" : {
       "property" : "embeddingModelProvider.modelProvider",
-      "equals" : "azureOpenAiModelProvider",
+      "equals" : "AZURE_OPEN_AI_MODEL_PROVIDER",
       "type" : "simple"
     },
     "type" : "Number"
   }, {
-    "id" : "embeddingModelProvider.azureOpenAi.customHeaders",
+    "id" : "embeddingModelProvider.customHeaders",
     "label" : "Custom headers",
     "description" : "Map of custom HTTP headers to add to the request.",
     "optional" : true,
     "feel" : "required",
     "group" : "embeddingModel",
     "binding" : {
-      "name" : "embeddingModelProvider.azureOpenAi.customHeaders",
+      "name" : "embeddingModelProvider.customHeaders",
       "type" : "zeebe:input"
     },
     "condition" : {
       "property" : "embeddingModelProvider.modelProvider",
-      "equals" : "azureOpenAiModelProvider",
+      "equals" : "AZURE_OPEN_AI_MODEL_PROVIDER",
       "type" : "simple"
     },
     "type" : "String"
   }, {
-    "id" : "embeddingModelProvider.bedrock.accessKey",
+    "id" : "embeddingModelProvider.bedrockAccessKey",
     "label" : "Access key",
     "description" : "Provide an IAM access key tailored to a user, equipped with the necessary permissions",
     "optional" : false,
@@ -408,17 +408,17 @@
     "feel" : "optional",
     "group" : "embeddingModel",
     "binding" : {
-      "name" : "embeddingModelProvider.bedrock.accessKey",
+      "name" : "embeddingModelProvider.accessKey",
       "type" : "zeebe:input"
     },
     "condition" : {
       "property" : "embeddingModelProvider.modelProvider",
-      "equals" : "bedrockModelProvider",
+      "equals" : "BEDROCK_MODEL_PROVIDER",
       "type" : "simple"
     },
     "type" : "String"
   }, {
-    "id" : "embeddingModelProvider.bedrock.secretKey",
+    "id" : "embeddingModelProvider.bedrockSecretKey",
     "label" : "Secret key",
     "description" : "Provide a secret key associated with the access key",
     "optional" : false,
@@ -428,17 +428,17 @@
     "feel" : "optional",
     "group" : "embeddingModel",
     "binding" : {
-      "name" : "embeddingModelProvider.bedrock.secretKey",
+      "name" : "embeddingModelProvider.secretKey",
       "type" : "zeebe:input"
     },
     "condition" : {
       "property" : "embeddingModelProvider.modelProvider",
-      "equals" : "bedrockModelProvider",
+      "equals" : "BEDROCK_MODEL_PROVIDER",
       "type" : "simple"
     },
     "type" : "String"
   }, {
-    "id" : "embeddingModelProvider.bedrock.region",
+    "id" : "embeddingModelProvider.bedrockRegion",
     "label" : "Region",
     "description" : "AWS Bedrock region",
     "optional" : false,
@@ -448,17 +448,17 @@
     "feel" : "optional",
     "group" : "embeddingModel",
     "binding" : {
-      "name" : "embeddingModelProvider.bedrock.region",
+      "name" : "embeddingModelProvider.region",
       "type" : "zeebe:input"
     },
     "condition" : {
       "property" : "embeddingModelProvider.modelProvider",
-      "equals" : "bedrockModelProvider",
+      "equals" : "BEDROCK_MODEL_PROVIDER",
       "type" : "simple"
     },
     "type" : "String"
   }, {
-    "id" : "embeddingModelProvider.bedrock.modelName",
+    "id" : "embeddingModelProvider.modelName",
     "label" : "Model name",
     "description" : "Bedrock model name or identifier",
     "optional" : false,
@@ -468,12 +468,12 @@
     },
     "group" : "embeddingModel",
     "binding" : {
-      "name" : "embeddingModelProvider.bedrock.modelName",
+      "name" : "embeddingModelProvider.modelName",
       "type" : "zeebe:input"
     },
     "condition" : {
       "property" : "embeddingModelProvider.modelProvider",
-      "equals" : "bedrockModelProvider",
+      "equals" : "BEDROCK_MODEL_PROVIDER",
       "type" : "simple"
     },
     "type" : "Dropdown",
@@ -488,7 +488,7 @@
       "value" : "TitanEmbedTextV2"
     } ]
   }, {
-    "id" : "embeddingModelProvider.bedrock.customModelName",
+    "id" : "embeddingModelProvider.bedrockCustomModelName",
     "label" : "Custom model name",
     "optional" : false,
     "constraints" : {
@@ -497,7 +497,7 @@
     "feel" : "optional",
     "group" : "embeddingModel",
     "binding" : {
-      "name" : "embeddingModelProvider.bedrock.customModelName",
+      "name" : "embeddingModelProvider.customModelName",
       "type" : "zeebe:input"
     },
     "condition" : {
@@ -507,13 +507,13 @@
         "type" : "simple"
       }, {
         "property" : "embeddingModelProvider.modelProvider",
-        "equals" : "bedrockModelProvider",
+        "equals" : "BEDROCK_MODEL_PROVIDER",
         "type" : "simple"
       } ]
     },
     "type" : "String"
   }, {
-    "id" : "embeddingModelProvider.bedrock.dimensions",
+    "id" : "embeddingModelProvider.bedrockDimensions",
     "label" : "Embedding dimensions",
     "description" : "The size of the vector used to represent data",
     "optional" : false,
@@ -523,7 +523,7 @@
     },
     "group" : "embeddingModel",
     "binding" : {
-      "name" : "embeddingModelProvider.bedrock.dimensions",
+      "name" : "embeddingModelProvider.dimensions",
       "type" : "zeebe:input"
     },
     "condition" : {
@@ -533,7 +533,7 @@
         "type" : "simple"
       }, {
         "property" : "embeddingModelProvider.modelProvider",
-        "equals" : "bedrockModelProvider",
+        "equals" : "BEDROCK_MODEL_PROVIDER",
         "type" : "simple"
       } ]
     },
@@ -549,7 +549,7 @@
       "value" : "D1024"
     } ]
   }, {
-    "id" : "embeddingModelProvider.bedrock.normalize",
+    "id" : "embeddingModelProvider.bedrockNormalize",
     "label" : "Normalize",
     "description" : "Normalize vector",
     "optional" : false,
@@ -560,7 +560,7 @@
     "feel" : "static",
     "group" : "embeddingModel",
     "binding" : {
-      "name" : "embeddingModelProvider.bedrock.normalize",
+      "name" : "embeddingModelProvider.normalize",
       "type" : "zeebe:input"
     },
     "condition" : {
@@ -570,13 +570,13 @@
         "type" : "simple"
       }, {
         "property" : "embeddingModelProvider.modelProvider",
-        "equals" : "bedrockModelProvider",
+        "equals" : "BEDROCK_MODEL_PROVIDER",
         "type" : "simple"
       } ]
     },
     "type" : "Boolean"
   }, {
-    "id" : "embeddingModelProvider.bedrock.maxRetries",
+    "id" : "embeddingModelProvider.bedrockMaxRetries",
     "label" : "Max retries",
     "description" : "Max retries",
     "optional" : false,
@@ -584,17 +584,17 @@
     "feel" : "static",
     "group" : "embeddingModel",
     "binding" : {
-      "name" : "embeddingModelProvider.bedrock.maxRetries",
+      "name" : "embeddingModelProvider.maxRetries",
       "type" : "zeebe:input"
     },
     "condition" : {
       "property" : "embeddingModelProvider.modelProvider",
-      "equals" : "bedrockModelProvider",
+      "equals" : "BEDROCK_MODEL_PROVIDER",
       "type" : "simple"
     },
     "type" : "Number"
   }, {
-    "id" : "embeddingModelProvider.googleVertexAi.projectId",
+    "id" : "embeddingModelProvider.projectId",
     "label" : "Project ID",
     "description" : "Google Cloud project ID",
     "optional" : false,
@@ -604,17 +604,17 @@
     "feel" : "optional",
     "group" : "embeddingModel",
     "binding" : {
-      "name" : "embeddingModelProvider.googleVertexAi.projectId",
+      "name" : "embeddingModelProvider.projectId",
       "type" : "zeebe:input"
     },
     "condition" : {
       "property" : "embeddingModelProvider.modelProvider",
-      "equals" : "vertexAiModelProvider",
+      "equals" : "VERTEX_AI_MODEL_PROVIDER",
       "type" : "simple"
     },
     "type" : "String"
   }, {
-    "id" : "embeddingModelProvider.googleVertexAi.region",
+    "id" : "embeddingModelProvider.region",
     "label" : "Region",
     "description" : "Google Cloud region for Vertex AI",
     "optional" : false,
@@ -624,28 +624,28 @@
     "feel" : "optional",
     "group" : "embeddingModel",
     "binding" : {
-      "name" : "embeddingModelProvider.googleVertexAi.region",
+      "name" : "embeddingModelProvider.region",
       "type" : "zeebe:input"
     },
     "condition" : {
       "property" : "embeddingModelProvider.modelProvider",
-      "equals" : "vertexAiModelProvider",
+      "equals" : "VERTEX_AI_MODEL_PROVIDER",
       "type" : "simple"
     },
     "type" : "String"
   }, {
-    "id" : "embeddingModelProvider.googleVertexAi.authentication.type",
+    "id" : "embeddingModelProvider.vertexAiAuthentication.type",
     "label" : "Authentication",
     "description" : "Specify the Google Vertex AI authentication strategy.",
     "value" : "serviceAccountCredentials",
     "group" : "embeddingModel",
     "binding" : {
-      "name" : "embeddingModelProvider.googleVertexAi.authentication.type",
+      "name" : "embeddingModelProvider.vertexAiAuthentication.type",
       "type" : "zeebe:input"
     },
     "condition" : {
       "property" : "embeddingModelProvider.modelProvider",
-      "equals" : "vertexAiModelProvider",
+      "equals" : "VERTEX_AI_MODEL_PROVIDER",
       "type" : "simple"
     },
     "type" : "Dropdown",
@@ -657,7 +657,7 @@
       "value" : "applicationDefaultCredentials"
     } ]
   }, {
-    "id" : "embeddingModelProvider.googleVertexAi.authentication.jsonKey",
+    "id" : "embeddingModelProvider.vertexAiAuthentication.jsonKey",
     "label" : "JSON key of the service account",
     "description" : "This is the key of the service account in JSON format.",
     "optional" : false,
@@ -667,23 +667,23 @@
     "feel" : "optional",
     "group" : "embeddingModel",
     "binding" : {
-      "name" : "embeddingModelProvider.googleVertexAi.authentication.jsonKey",
+      "name" : "embeddingModelProvider.vertexAiAuthentication.jsonKey",
       "type" : "zeebe:input"
     },
     "condition" : {
       "allMatch" : [ {
-        "property" : "embeddingModelProvider.googleVertexAi.authentication.type",
+        "property" : "embeddingModelProvider.vertexAiAuthentication.type",
         "equals" : "serviceAccountCredentials",
         "type" : "simple"
       }, {
         "property" : "embeddingModelProvider.modelProvider",
-        "equals" : "vertexAiModelProvider",
+        "equals" : "VERTEX_AI_MODEL_PROVIDER",
         "type" : "simple"
       } ]
     },
     "type" : "String"
   }, {
-    "id" : "embeddingModelProvider.googleVertexAi.modelName",
+    "id" : "embeddingModelProvider.vertexAiModelName",
     "label" : "Model name",
     "description" : "Vertex AI embedding model name",
     "optional" : false,
@@ -693,17 +693,17 @@
     "feel" : "optional",
     "group" : "embeddingModel",
     "binding" : {
-      "name" : "embeddingModelProvider.googleVertexAi.modelName",
+      "name" : "embeddingModelProvider.modelName",
       "type" : "zeebe:input"
     },
     "condition" : {
       "property" : "embeddingModelProvider.modelProvider",
-      "equals" : "vertexAiModelProvider",
+      "equals" : "VERTEX_AI_MODEL_PROVIDER",
       "type" : "simple"
     },
     "type" : "String"
   }, {
-    "id" : "embeddingModelProvider.googleVertexAi.dimensions",
+    "id" : "embeddingModelProvider.vertexAiDimensions",
     "label" : "Embedding dimensions",
     "description" : "The size of the vector used to represent data. Details in the <a href=\"https://cloud.google.com/vertex-ai/generative-ai/docs/embeddings/get-text-embeddings\" target=\"_blank\">documentation</a>.",
     "optional" : false,
@@ -713,17 +713,17 @@
     "feel" : "required",
     "group" : "embeddingModel",
     "binding" : {
-      "name" : "embeddingModelProvider.googleVertexAi.dimensions",
+      "name" : "embeddingModelProvider.dimensions",
       "type" : "zeebe:input"
     },
     "condition" : {
       "property" : "embeddingModelProvider.modelProvider",
-      "equals" : "vertexAiModelProvider",
+      "equals" : "VERTEX_AI_MODEL_PROVIDER",
       "type" : "simple"
     },
     "type" : "Number"
   }, {
-    "id" : "embeddingModelProvider.googleVertexAi.publisher",
+    "id" : "embeddingModelProvider.publisher",
     "label" : "Publisher",
     "description" : "The publisher of the Vertex AI model (e.g., 'google', 'third-party'). Optional.",
     "optional" : true,
@@ -731,17 +731,17 @@
     "feel" : "optional",
     "group" : "embeddingModel",
     "binding" : {
-      "name" : "embeddingModelProvider.googleVertexAi.publisher",
+      "name" : "embeddingModelProvider.publisher",
       "type" : "zeebe:input"
     },
     "condition" : {
       "property" : "embeddingModelProvider.modelProvider",
-      "equals" : "vertexAiModelProvider",
+      "equals" : "VERTEX_AI_MODEL_PROVIDER",
       "type" : "simple"
     },
     "type" : "String"
   }, {
-    "id" : "embeddingModelProvider.googleVertexAi.maxRetries",
+    "id" : "embeddingModelProvider.vertexAiMaxRetries",
     "label" : "Max retries",
     "description" : "Max retries",
     "optional" : true,
@@ -749,17 +749,17 @@
     "feel" : "static",
     "group" : "embeddingModel",
     "binding" : {
-      "name" : "embeddingModelProvider.googleVertexAi.maxRetries",
+      "name" : "embeddingModelProvider.maxRetries",
       "type" : "zeebe:input"
     },
     "condition" : {
       "property" : "embeddingModelProvider.modelProvider",
-      "equals" : "vertexAiModelProvider",
+      "equals" : "VERTEX_AI_MODEL_PROVIDER",
       "type" : "simple"
     },
     "type" : "Number"
   }, {
-    "id" : "embeddingModelProvider.openAi.apiKey",
+    "id" : "embeddingModelProvider.openAiApiKey",
     "label" : "OpenAI API key",
     "optional" : false,
     "constraints" : {
@@ -768,17 +768,17 @@
     "feel" : "optional",
     "group" : "embeddingModel",
     "binding" : {
-      "name" : "embeddingModelProvider.openAi.apiKey",
+      "name" : "embeddingModelProvider.apiKey",
       "type" : "zeebe:input"
     },
     "condition" : {
       "property" : "embeddingModelProvider.modelProvider",
-      "equals" : "openAiModelProvider",
+      "equals" : "OPEN_AI_MODEL_PROVIDER",
       "type" : "simple"
     },
     "type" : "String"
   }, {
-    "id" : "embeddingModelProvider.openAi.modelName",
+    "id" : "embeddingModelProvider.openAiModelName",
     "label" : "Model name",
     "description" : "Specify the model name. Details in the <a href=\"https://platform.openai.com/docs/guides/embeddings\" target=\"_blank\">documentation</a>.",
     "optional" : false,
@@ -788,68 +788,68 @@
     "feel" : "optional",
     "group" : "embeddingModel",
     "binding" : {
-      "name" : "embeddingModelProvider.openAi.modelName",
+      "name" : "embeddingModelProvider.modelName",
       "type" : "zeebe:input"
     },
     "condition" : {
       "property" : "embeddingModelProvider.modelProvider",
-      "equals" : "openAiModelProvider",
+      "equals" : "OPEN_AI_MODEL_PROVIDER",
       "type" : "simple"
     },
     "type" : "String"
   }, {
-    "id" : "embeddingModelProvider.openAi.organizationId",
+    "id" : "embeddingModelProvider.openAiOrganizationId",
     "label" : "Organization ID",
     "description" : "For members of multiple organizations. Details in the <a href=\"https://platform.openai.com/docs/api-reference/authentication\" target=\"_blank\">documentation</a>.",
     "optional" : true,
     "feel" : "optional",
     "group" : "embeddingModel",
     "binding" : {
-      "name" : "embeddingModelProvider.openAi.organizationId",
+      "name" : "embeddingModelProvider.organizationId",
       "type" : "zeebe:input"
     },
     "condition" : {
       "property" : "embeddingModelProvider.modelProvider",
-      "equals" : "openAiModelProvider",
+      "equals" : "OPEN_AI_MODEL_PROVIDER",
       "type" : "simple"
     },
     "type" : "String"
   }, {
-    "id" : "embeddingModelProvider.openAi.projectId",
+    "id" : "embeddingModelProvider.openAiProjectId",
     "label" : "Project ID",
     "description" : "For accounts with multiple projects. Details in the <a href=\"https://platform.openai.com/docs/api-reference/authentication\" target=\"_blank\">documentation</a>.",
     "optional" : true,
     "feel" : "optional",
     "group" : "embeddingModel",
     "binding" : {
-      "name" : "embeddingModelProvider.openAi.projectId",
+      "name" : "embeddingModelProvider.projectId",
       "type" : "zeebe:input"
     },
     "condition" : {
       "property" : "embeddingModelProvider.modelProvider",
-      "equals" : "openAiModelProvider",
+      "equals" : "OPEN_AI_MODEL_PROVIDER",
       "type" : "simple"
     },
     "type" : "String"
   }, {
-    "id" : "embeddingModelProvider.openAi.dimensions",
+    "id" : "embeddingModelProvider.openAiDimensions",
     "label" : "Embedding dimensions",
     "description" : "The size of the vector used to represent data. If not specified, the default model dimensions are used. Details in the <a href=\"https://platform.openai.com/docs/guides/embeddings\" target=\"_blank\">documentation</a>.",
     "optional" : true,
     "feel" : "required",
     "group" : "embeddingModel",
     "binding" : {
-      "name" : "embeddingModelProvider.openAi.dimensions",
+      "name" : "embeddingModelProvider.dimensions",
       "type" : "zeebe:input"
     },
     "condition" : {
       "property" : "embeddingModelProvider.modelProvider",
-      "equals" : "openAiModelProvider",
+      "equals" : "OPEN_AI_MODEL_PROVIDER",
       "type" : "simple"
     },
     "type" : "Number"
   }, {
-    "id" : "embeddingModelProvider.openAi.maxRetries",
+    "id" : "embeddingModelProvider.openAiMaxRetries",
     "label" : "Max retries",
     "description" : "Max retries",
     "optional" : true,
@@ -857,45 +857,45 @@
     "feel" : "static",
     "group" : "embeddingModel",
     "binding" : {
-      "name" : "embeddingModelProvider.openAi.maxRetries",
+      "name" : "embeddingModelProvider.maxRetries",
       "type" : "zeebe:input"
     },
     "condition" : {
       "property" : "embeddingModelProvider.modelProvider",
-      "equals" : "openAiModelProvider",
+      "equals" : "OPEN_AI_MODEL_PROVIDER",
       "type" : "simple"
     },
     "type" : "Number"
   }, {
-    "id" : "embeddingModelProvider.openAi.customHeaders",
+    "id" : "embeddingModelProvider.openAiCustomHeaders",
     "label" : "Custom headers",
     "description" : "Map of custom HTTP headers to add to the request.",
     "optional" : true,
     "feel" : "required",
     "group" : "embeddingModel",
     "binding" : {
-      "name" : "embeddingModelProvider.openAi.customHeaders",
+      "name" : "embeddingModelProvider.customHeaders",
       "type" : "zeebe:input"
     },
     "condition" : {
       "property" : "embeddingModelProvider.modelProvider",
-      "equals" : "openAiModelProvider",
+      "equals" : "OPEN_AI_MODEL_PROVIDER",
       "type" : "simple"
     },
     "type" : "String"
   }, {
-    "id" : "embeddingModelProvider.openAi.baseUrl",
+    "id" : "embeddingModelProvider.openAiBaseUrl",
     "label" : "Custom base URL",
     "optional" : true,
     "feel" : "optional",
     "group" : "embeddingModel",
     "binding" : {
-      "name" : "embeddingModelProvider.openAi.baseUrl",
+      "name" : "embeddingModelProvider.baseUrl",
       "type" : "zeebe:input"
     },
     "condition" : {
       "property" : "embeddingModelProvider.modelProvider",
-      "equals" : "openAiModelProvider",
+      "equals" : "OPEN_AI_MODEL_PROVIDER",
       "type" : "simple"
     },
     "tooltip" : "Base URL of OpenAI API. The default is 'https://api.openai.com/v1/'",
@@ -904,7 +904,7 @@
     "id" : "vectorStore.vectorStore",
     "label" : "Embeddings store",
     "description" : "Select embedding store",
-    "value" : "elasticsearchStore",
+    "value" : "STORE_ELASTICSEARCH",
     "group" : "embeddingsStore",
     "binding" : {
       "name" : "vectorStore.storeType",
@@ -913,19 +913,19 @@
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "Amazon Managed OpenSearch",
-      "value" : "amazonManagedOpenSearchStore"
+      "value" : "STORE_AMAZON_MANAGED_OPENSEARCH"
     }, {
       "name" : "Azure AI Search",
-      "value" : "azureAiSearchStore"
+      "value" : "STORE_AZURE_AI_SEARCH"
     }, {
       "name" : "Azure Cosmos DB NoSQL",
-      "value" : "azureCosmosDbNoSqlStore"
+      "value" : "STORE_AZURE_COSMOS_DB_NO_SQL"
     }, {
       "name" : "Elasticsearch",
-      "value" : "elasticsearchStore"
+      "value" : "STORE_ELASTICSEARCH"
     }, {
       "name" : "OpenSearch",
-      "value" : "openSearchStore"
+      "value" : "STORE_OPENSEARCH"
     } ]
   }, {
     "id" : "vectorStore.amazonManagedOpensearch.accessKey",
@@ -938,12 +938,12 @@
     "feel" : "optional",
     "group" : "embeddingsStore",
     "binding" : {
-      "name" : "vectorStore.amazonManagedOpensearch.accessKey",
+      "name" : "vectorStore.accessKey",
       "type" : "zeebe:input"
     },
     "condition" : {
       "property" : "vectorStore.vectorStore",
-      "equals" : "amazonManagedOpenSearchStore",
+      "equals" : "STORE_AMAZON_MANAGED_OPENSEARCH",
       "type" : "simple"
     },
     "type" : "String"
@@ -958,12 +958,12 @@
     "feel" : "optional",
     "group" : "embeddingsStore",
     "binding" : {
-      "name" : "vectorStore.amazonManagedOpensearch.secretKey",
+      "name" : "vectorStore.secretKey",
       "type" : "zeebe:input"
     },
     "condition" : {
       "property" : "vectorStore.vectorStore",
-      "equals" : "amazonManagedOpenSearchStore",
+      "equals" : "STORE_AMAZON_MANAGED_OPENSEARCH",
       "type" : "simple"
     },
     "type" : "String"
@@ -978,12 +978,12 @@
     "feel" : "optional",
     "group" : "embeddingsStore",
     "binding" : {
-      "name" : "vectorStore.amazonManagedOpensearch.serverUrl",
+      "name" : "vectorStore.serverUrl",
       "type" : "zeebe:input"
     },
     "condition" : {
       "property" : "vectorStore.vectorStore",
-      "equals" : "amazonManagedOpenSearchStore",
+      "equals" : "STORE_AMAZON_MANAGED_OPENSEARCH",
       "type" : "simple"
     },
     "type" : "String"
@@ -998,12 +998,12 @@
     "feel" : "optional",
     "group" : "embeddingsStore",
     "binding" : {
-      "name" : "vectorStore.amazonManagedOpensearch.region",
+      "name" : "vectorStore.region",
       "type" : "zeebe:input"
     },
     "condition" : {
       "property" : "vectorStore.vectorStore",
-      "equals" : "amazonManagedOpenSearchStore",
+      "equals" : "STORE_AMAZON_MANAGED_OPENSEARCH",
       "type" : "simple"
     },
     "type" : "String"
@@ -1018,17 +1018,17 @@
     "feel" : "optional",
     "group" : "embeddingsStore",
     "binding" : {
-      "name" : "vectorStore.amazonManagedOpensearch.indexName",
+      "name" : "vectorStore.indexName",
       "type" : "zeebe:input"
     },
     "condition" : {
       "property" : "vectorStore.vectorStore",
-      "equals" : "amazonManagedOpenSearchStore",
+      "equals" : "STORE_AMAZON_MANAGED_OPENSEARCH",
       "type" : "simple"
     },
     "type" : "String"
   }, {
-    "id" : "vectorStore.aiSearch.endpoint",
+    "id" : "vectorStore.azureAiSearch.endpoint",
     "label" : "Endpoint",
     "description" : "Specify Azure AI Search endpoint. Details in the <a href=\"https://learn.microsoft.com/en-us/azure/search/\" target=\"_blank\">documentation</a>.",
     "optional" : false,
@@ -1038,28 +1038,28 @@
     "feel" : "optional",
     "group" : "embeddingsStore",
     "binding" : {
-      "name" : "vectorStore.aiSearch.endpoint",
+      "name" : "vectorStore.endpoint",
       "type" : "zeebe:input"
     },
     "condition" : {
       "property" : "vectorStore.vectorStore",
-      "equals" : "azureAiSearchStore",
+      "equals" : "STORE_AZURE_AI_SEARCH",
       "type" : "simple"
     },
     "type" : "String"
   }, {
-    "id" : "vectorStore.aiSearch.authentication.type",
+    "id" : "vectorStore.azureAiSearchAuthentication.type",
     "label" : "Authentication",
     "description" : "Specify the Azure OpenAI authentication strategy.",
     "value" : "apiKey",
     "group" : "embeddingsStore",
     "binding" : {
-      "name" : "vectorStore.aiSearch.authentication.type",
+      "name" : "vectorStore.azureAiSearchAuthentication.type",
       "type" : "zeebe:input"
     },
     "condition" : {
       "property" : "vectorStore.vectorStore",
-      "equals" : "azureAiSearchStore",
+      "equals" : "STORE_AZURE_AI_SEARCH",
       "type" : "simple"
     },
     "type" : "Dropdown",
@@ -1071,7 +1071,7 @@
       "value" : "clientCredentials"
     } ]
   }, {
-    "id" : "vectorStore.aiSearch.authentication.apiKey",
+    "id" : "vectorStore.azureAiSearchAuthentication.apiKey",
     "label" : "API key",
     "optional" : false,
     "constraints" : {
@@ -1080,23 +1080,23 @@
     "feel" : "optional",
     "group" : "embeddingsStore",
     "binding" : {
-      "name" : "vectorStore.aiSearch.authentication.apiKey",
+      "name" : "vectorStore.azureAiSearchAuthentication.apiKey",
       "type" : "zeebe:input"
     },
     "condition" : {
       "allMatch" : [ {
-        "property" : "vectorStore.aiSearch.authentication.type",
+        "property" : "vectorStore.azureAiSearchAuthentication.type",
         "equals" : "apiKey",
         "type" : "simple"
       }, {
         "property" : "vectorStore.vectorStore",
-        "equals" : "azureAiSearchStore",
+        "equals" : "STORE_AZURE_AI_SEARCH",
         "type" : "simple"
       } ]
     },
     "type" : "String"
   }, {
-    "id" : "vectorStore.aiSearch.authentication.clientId",
+    "id" : "vectorStore.azureAiSearchAuthentication.clientId",
     "label" : "Client ID",
     "description" : "ID of a Microsoft Entra application",
     "optional" : false,
@@ -1106,23 +1106,23 @@
     "feel" : "optional",
     "group" : "embeddingsStore",
     "binding" : {
-      "name" : "vectorStore.aiSearch.authentication.clientId",
+      "name" : "vectorStore.azureAiSearchAuthentication.clientId",
       "type" : "zeebe:input"
     },
     "condition" : {
       "allMatch" : [ {
-        "property" : "vectorStore.aiSearch.authentication.type",
+        "property" : "vectorStore.azureAiSearchAuthentication.type",
         "equals" : "clientCredentials",
         "type" : "simple"
       }, {
         "property" : "vectorStore.vectorStore",
-        "equals" : "azureAiSearchStore",
+        "equals" : "STORE_AZURE_AI_SEARCH",
         "type" : "simple"
       } ]
     },
     "type" : "String"
   }, {
-    "id" : "vectorStore.aiSearch.authentication.clientSecret",
+    "id" : "vectorStore.azureAiSearchAuthentication.clientSecret",
     "label" : "Client secret",
     "description" : "Secret of a Microsoft Entra application",
     "optional" : false,
@@ -1132,23 +1132,23 @@
     "feel" : "optional",
     "group" : "embeddingsStore",
     "binding" : {
-      "name" : "vectorStore.aiSearch.authentication.clientSecret",
+      "name" : "vectorStore.azureAiSearchAuthentication.clientSecret",
       "type" : "zeebe:input"
     },
     "condition" : {
       "allMatch" : [ {
-        "property" : "vectorStore.aiSearch.authentication.type",
+        "property" : "vectorStore.azureAiSearchAuthentication.type",
         "equals" : "clientCredentials",
         "type" : "simple"
       }, {
         "property" : "vectorStore.vectorStore",
-        "equals" : "azureAiSearchStore",
+        "equals" : "STORE_AZURE_AI_SEARCH",
         "type" : "simple"
       } ]
     },
     "type" : "String"
   }, {
-    "id" : "vectorStore.aiSearch.authentication.tenantId",
+    "id" : "vectorStore.azureAiSearchAuthentication.tenantId",
     "label" : "Tenant ID",
     "description" : "ID of a Microsoft Entra tenant. Details in the <a href=\"https://learn.microsoft.com/en-us/entra/fundamentals/how-to-find-tenant\" target=\"_blank\">documentation</a>.",
     "optional" : false,
@@ -1158,46 +1158,46 @@
     "feel" : "optional",
     "group" : "embeddingsStore",
     "binding" : {
-      "name" : "vectorStore.aiSearch.authentication.tenantId",
+      "name" : "vectorStore.azureAiSearchAuthentication.tenantId",
       "type" : "zeebe:input"
     },
     "condition" : {
       "allMatch" : [ {
-        "property" : "vectorStore.aiSearch.authentication.type",
+        "property" : "vectorStore.azureAiSearchAuthentication.type",
         "equals" : "clientCredentials",
         "type" : "simple"
       }, {
         "property" : "vectorStore.vectorStore",
-        "equals" : "azureAiSearchStore",
+        "equals" : "STORE_AZURE_AI_SEARCH",
         "type" : "simple"
       } ]
     },
     "type" : "String"
   }, {
-    "id" : "vectorStore.aiSearch.authentication.authorityHost",
+    "id" : "vectorStore.azureAiSearchAuthentication.authorityHost",
     "label" : "Authority host",
     "description" : "Authority host URL for the Microsoft Entra application. Defaults to <code>https://login.microsoftonline.com</code>. This can also contain an OAuth 2.0 token endpoint.",
     "optional" : true,
     "feel" : "optional",
     "group" : "embeddingsStore",
     "binding" : {
-      "name" : "vectorStore.aiSearch.authentication.authorityHost",
+      "name" : "vectorStore.azureAiSearchAuthentication.authorityHost",
       "type" : "zeebe:input"
     },
     "condition" : {
       "allMatch" : [ {
-        "property" : "vectorStore.aiSearch.authentication.type",
+        "property" : "vectorStore.azureAiSearchAuthentication.type",
         "equals" : "clientCredentials",
         "type" : "simple"
       }, {
         "property" : "vectorStore.vectorStore",
-        "equals" : "azureAiSearchStore",
+        "equals" : "STORE_AZURE_AI_SEARCH",
         "type" : "simple"
       } ]
     },
     "type" : "String"
   }, {
-    "id" : "vectorStore.aiSearch.indexName",
+    "id" : "vectorStore.azureAiSearch.indexName",
     "label" : "Index name",
     "description" : "The name of the search index. When storing embeddings this index is created or updated automatically.",
     "optional" : false,
@@ -1207,12 +1207,12 @@
     "feel" : "optional",
     "group" : "embeddingsStore",
     "binding" : {
-      "name" : "vectorStore.aiSearch.indexName",
+      "name" : "vectorStore.indexName",
       "type" : "zeebe:input"
     },
     "condition" : {
       "property" : "vectorStore.vectorStore",
-      "equals" : "azureAiSearchStore",
+      "equals" : "STORE_AZURE_AI_SEARCH",
       "type" : "simple"
     },
     "type" : "String"
@@ -1227,28 +1227,28 @@
     "feel" : "optional",
     "group" : "embeddingsStore",
     "binding" : {
-      "name" : "vectorStore.azureCosmosDbNoSql.endpoint",
+      "name" : "vectorStore.endpoint",
       "type" : "zeebe:input"
     },
     "condition" : {
       "property" : "vectorStore.vectorStore",
-      "equals" : "azureCosmosDbNoSqlStore",
+      "equals" : "STORE_AZURE_COSMOS_DB_NO_SQL",
       "type" : "simple"
     },
     "type" : "String"
   }, {
-    "id" : "vectorStore.azureCosmosDbNoSql.authentication.type",
+    "id" : "vectorStore.azureCosmosDbAuthentication.type",
     "label" : "Authentication",
     "description" : "Specify the Azure OpenAI authentication strategy.",
     "value" : "apiKey",
     "group" : "embeddingsStore",
     "binding" : {
-      "name" : "vectorStore.azureCosmosDbNoSql.authentication.type",
+      "name" : "vectorStore.azureCosmosDbAuthentication.type",
       "type" : "zeebe:input"
     },
     "condition" : {
       "property" : "vectorStore.vectorStore",
-      "equals" : "azureCosmosDbNoSqlStore",
+      "equals" : "STORE_AZURE_COSMOS_DB_NO_SQL",
       "type" : "simple"
     },
     "type" : "Dropdown",
@@ -1260,7 +1260,7 @@
       "value" : "clientCredentials"
     } ]
   }, {
-    "id" : "vectorStore.azureCosmosDbNoSql.authentication.apiKey",
+    "id" : "vectorStore.azureCosmosDbAuthentication.apiKey",
     "label" : "API key",
     "optional" : false,
     "constraints" : {
@@ -1269,23 +1269,23 @@
     "feel" : "optional",
     "group" : "embeddingsStore",
     "binding" : {
-      "name" : "vectorStore.azureCosmosDbNoSql.authentication.apiKey",
+      "name" : "vectorStore.azureCosmosDbAuthentication.apiKey",
       "type" : "zeebe:input"
     },
     "condition" : {
       "allMatch" : [ {
-        "property" : "vectorStore.azureCosmosDbNoSql.authentication.type",
+        "property" : "vectorStore.azureCosmosDbAuthentication.type",
         "equals" : "apiKey",
         "type" : "simple"
       }, {
         "property" : "vectorStore.vectorStore",
-        "equals" : "azureCosmosDbNoSqlStore",
+        "equals" : "STORE_AZURE_COSMOS_DB_NO_SQL",
         "type" : "simple"
       } ]
     },
     "type" : "String"
   }, {
-    "id" : "vectorStore.azureCosmosDbNoSql.authentication.clientId",
+    "id" : "vectorStore.azureCosmosDbAuthentication.clientId",
     "label" : "Client ID",
     "description" : "ID of a Microsoft Entra application",
     "optional" : false,
@@ -1295,23 +1295,23 @@
     "feel" : "optional",
     "group" : "embeddingsStore",
     "binding" : {
-      "name" : "vectorStore.azureCosmosDbNoSql.authentication.clientId",
+      "name" : "vectorStore.azureCosmosDbAuthentication.clientId",
       "type" : "zeebe:input"
     },
     "condition" : {
       "allMatch" : [ {
-        "property" : "vectorStore.azureCosmosDbNoSql.authentication.type",
+        "property" : "vectorStore.azureCosmosDbAuthentication.type",
         "equals" : "clientCredentials",
         "type" : "simple"
       }, {
         "property" : "vectorStore.vectorStore",
-        "equals" : "azureCosmosDbNoSqlStore",
+        "equals" : "STORE_AZURE_COSMOS_DB_NO_SQL",
         "type" : "simple"
       } ]
     },
     "type" : "String"
   }, {
-    "id" : "vectorStore.azureCosmosDbNoSql.authentication.clientSecret",
+    "id" : "vectorStore.azureCosmosDbAuthentication.clientSecret",
     "label" : "Client secret",
     "description" : "Secret of a Microsoft Entra application",
     "optional" : false,
@@ -1321,23 +1321,23 @@
     "feel" : "optional",
     "group" : "embeddingsStore",
     "binding" : {
-      "name" : "vectorStore.azureCosmosDbNoSql.authentication.clientSecret",
+      "name" : "vectorStore.azureCosmosDbAuthentication.clientSecret",
       "type" : "zeebe:input"
     },
     "condition" : {
       "allMatch" : [ {
-        "property" : "vectorStore.azureCosmosDbNoSql.authentication.type",
+        "property" : "vectorStore.azureCosmosDbAuthentication.type",
         "equals" : "clientCredentials",
         "type" : "simple"
       }, {
         "property" : "vectorStore.vectorStore",
-        "equals" : "azureCosmosDbNoSqlStore",
+        "equals" : "STORE_AZURE_COSMOS_DB_NO_SQL",
         "type" : "simple"
       } ]
     },
     "type" : "String"
   }, {
-    "id" : "vectorStore.azureCosmosDbNoSql.authentication.tenantId",
+    "id" : "vectorStore.azureCosmosDbAuthentication.tenantId",
     "label" : "Tenant ID",
     "description" : "ID of a Microsoft Entra tenant. Details in the <a href=\"https://learn.microsoft.com/en-us/entra/fundamentals/how-to-find-tenant\" target=\"_blank\">documentation</a>.",
     "optional" : false,
@@ -1347,40 +1347,40 @@
     "feel" : "optional",
     "group" : "embeddingsStore",
     "binding" : {
-      "name" : "vectorStore.azureCosmosDbNoSql.authentication.tenantId",
+      "name" : "vectorStore.azureCosmosDbAuthentication.tenantId",
       "type" : "zeebe:input"
     },
     "condition" : {
       "allMatch" : [ {
-        "property" : "vectorStore.azureCosmosDbNoSql.authentication.type",
+        "property" : "vectorStore.azureCosmosDbAuthentication.type",
         "equals" : "clientCredentials",
         "type" : "simple"
       }, {
         "property" : "vectorStore.vectorStore",
-        "equals" : "azureCosmosDbNoSqlStore",
+        "equals" : "STORE_AZURE_COSMOS_DB_NO_SQL",
         "type" : "simple"
       } ]
     },
     "type" : "String"
   }, {
-    "id" : "vectorStore.azureCosmosDbNoSql.authentication.authorityHost",
+    "id" : "vectorStore.azureCosmosDbAuthentication.authorityHost",
     "label" : "Authority host",
     "description" : "Authority host URL for the Microsoft Entra application. Defaults to <code>https://login.microsoftonline.com</code>. This can also contain an OAuth 2.0 token endpoint.",
     "optional" : true,
     "feel" : "optional",
     "group" : "embeddingsStore",
     "binding" : {
-      "name" : "vectorStore.azureCosmosDbNoSql.authentication.authorityHost",
+      "name" : "vectorStore.azureCosmosDbAuthentication.authorityHost",
       "type" : "zeebe:input"
     },
     "condition" : {
       "allMatch" : [ {
-        "property" : "vectorStore.azureCosmosDbNoSql.authentication.type",
+        "property" : "vectorStore.azureCosmosDbAuthentication.type",
         "equals" : "clientCredentials",
         "type" : "simple"
       }, {
         "property" : "vectorStore.vectorStore",
-        "equals" : "azureCosmosDbNoSqlStore",
+        "equals" : "STORE_AZURE_COSMOS_DB_NO_SQL",
         "type" : "simple"
       } ]
     },
@@ -1396,12 +1396,12 @@
     "feel" : "optional",
     "group" : "embeddingsStore",
     "binding" : {
-      "name" : "vectorStore.azureCosmosDbNoSql.databaseName",
+      "name" : "vectorStore.databaseName",
       "type" : "zeebe:input"
     },
     "condition" : {
       "property" : "vectorStore.vectorStore",
-      "equals" : "azureCosmosDbNoSqlStore",
+      "equals" : "STORE_AZURE_COSMOS_DB_NO_SQL",
       "type" : "simple"
     },
     "type" : "String"
@@ -1416,12 +1416,12 @@
     "feel" : "optional",
     "group" : "embeddingsStore",
     "binding" : {
-      "name" : "vectorStore.azureCosmosDbNoSql.containerName",
+      "name" : "vectorStore.containerName",
       "type" : "zeebe:input"
     },
     "condition" : {
       "property" : "vectorStore.vectorStore",
-      "equals" : "azureCosmosDbNoSqlStore",
+      "equals" : "STORE_AZURE_COSMOS_DB_NO_SQL",
       "type" : "simple"
     },
     "type" : "String"
@@ -1436,12 +1436,12 @@
     },
     "group" : "embeddingsStore",
     "binding" : {
-      "name" : "vectorStore.azureCosmosDbNoSql.consistencyLevel",
+      "name" : "vectorStore.consistencyLevel",
       "type" : "zeebe:input"
     },
     "condition" : {
       "property" : "vectorStore.vectorStore",
-      "equals" : "azureCosmosDbNoSqlStore",
+      "equals" : "STORE_AZURE_COSMOS_DB_NO_SQL",
       "type" : "simple"
     },
     "type" : "Dropdown",
@@ -1472,12 +1472,12 @@
     },
     "group" : "embeddingsStore",
     "binding" : {
-      "name" : "vectorStore.azureCosmosDbNoSql.distanceFunction",
+      "name" : "vectorStore.distanceFunction",
       "type" : "zeebe:input"
     },
     "condition" : {
       "property" : "vectorStore.vectorStore",
-      "equals" : "azureCosmosDbNoSqlStore",
+      "equals" : "STORE_AZURE_COSMOS_DB_NO_SQL",
       "type" : "simple"
     },
     "type" : "Dropdown",
@@ -1502,12 +1502,12 @@
     },
     "group" : "embeddingsStore",
     "binding" : {
-      "name" : "vectorStore.azureCosmosDbNoSql.vectorIndexType",
+      "name" : "vectorStore.vectorIndexType",
       "type" : "zeebe:input"
     },
     "condition" : {
       "property" : "vectorStore.vectorStore",
-      "equals" : "azureCosmosDbNoSqlStore",
+      "equals" : "STORE_AZURE_COSMOS_DB_NO_SQL",
       "type" : "simple"
     },
     "type" : "Dropdown",
@@ -1522,7 +1522,7 @@
       "value" : "DISK_ANN"
     } ]
   }, {
-    "id" : "vectorStore.elasticsearch.baseUrl",
+    "id" : "vectorStore.embeddingsStore.elasticsearch.baseUrl",
     "label" : "Base URL",
     "description" : "Elasticsearch base URL, i.e. http(s)://host:port",
     "optional" : false,
@@ -1532,17 +1532,17 @@
     "feel" : "optional",
     "group" : "embeddingsStore",
     "binding" : {
-      "name" : "vectorStore.elasticsearch.baseUrl",
+      "name" : "vectorStore.baseUrl",
       "type" : "zeebe:input"
     },
     "condition" : {
       "property" : "vectorStore.vectorStore",
-      "equals" : "elasticsearchStore",
+      "equals" : "STORE_ELASTICSEARCH",
       "type" : "simple"
     },
     "type" : "String"
   }, {
-    "id" : "vectorStore.elasticsearch.userName",
+    "id" : "vectorStore.embeddingsStore.elasticsearch.username",
     "label" : "Username",
     "description" : "Elasticsearch username",
     "optional" : false,
@@ -1552,17 +1552,17 @@
     "feel" : "optional",
     "group" : "embeddingsStore",
     "binding" : {
-      "name" : "vectorStore.elasticsearch.userName",
+      "name" : "vectorStore.userName",
       "type" : "zeebe:input"
     },
     "condition" : {
       "property" : "vectorStore.vectorStore",
-      "equals" : "elasticsearchStore",
+      "equals" : "STORE_ELASTICSEARCH",
       "type" : "simple"
     },
     "type" : "String"
   }, {
-    "id" : "vectorStore.elasticsearch.password",
+    "id" : "vectorStore.embeddingsStore.elasticsearch.password",
     "label" : "Password",
     "description" : "Elasticsearch password",
     "optional" : false,
@@ -1572,17 +1572,17 @@
     "feel" : "optional",
     "group" : "embeddingsStore",
     "binding" : {
-      "name" : "vectorStore.elasticsearch.password",
+      "name" : "vectorStore.password",
       "type" : "zeebe:input"
     },
     "condition" : {
       "property" : "vectorStore.vectorStore",
-      "equals" : "elasticsearchStore",
+      "equals" : "STORE_ELASTICSEARCH",
       "type" : "simple"
     },
     "type" : "String"
   }, {
-    "id" : "vectorStore.elasticsearch.indexName",
+    "id" : "vectorStore.embeddingsStore.elasticsearch.indexName",
     "label" : "Index name",
     "description" : "Elasticsearch index",
     "optional" : false,
@@ -1592,17 +1592,17 @@
     "feel" : "optional",
     "group" : "embeddingsStore",
     "binding" : {
-      "name" : "vectorStore.elasticsearch.indexName",
+      "name" : "vectorStore.indexName",
       "type" : "zeebe:input"
     },
     "condition" : {
       "property" : "vectorStore.vectorStore",
-      "equals" : "elasticsearchStore",
+      "equals" : "STORE_ELASTICSEARCH",
       "type" : "simple"
     },
     "type" : "String"
   }, {
-    "id" : "vectorStore.openSearch.baseUrl",
+    "id" : "vectorStore.embeddingsStore.opensearch.baseUrl",
     "label" : "Base URL",
     "description" : "OpenSearch base URL, i.e. http(s)://host:port",
     "optional" : false,
@@ -1612,17 +1612,17 @@
     "feel" : "optional",
     "group" : "embeddingsStore",
     "binding" : {
-      "name" : "vectorStore.openSearch.baseUrl",
+      "name" : "vectorStore.baseUrl",
       "type" : "zeebe:input"
     },
     "condition" : {
       "property" : "vectorStore.vectorStore",
-      "equals" : "openSearchStore",
+      "equals" : "STORE_OPENSEARCH",
       "type" : "simple"
     },
     "type" : "String"
   }, {
-    "id" : "vectorStore.openSearch.userName",
+    "id" : "vectorStore.embeddingsStore.opensearch.username",
     "label" : "Username",
     "description" : "OpenSearch username",
     "optional" : false,
@@ -1632,17 +1632,17 @@
     "feel" : "optional",
     "group" : "embeddingsStore",
     "binding" : {
-      "name" : "vectorStore.openSearch.userName",
+      "name" : "vectorStore.userName",
       "type" : "zeebe:input"
     },
     "condition" : {
       "property" : "vectorStore.vectorStore",
-      "equals" : "openSearchStore",
+      "equals" : "STORE_OPENSEARCH",
       "type" : "simple"
     },
     "type" : "String"
   }, {
-    "id" : "vectorStore.openSearch.password",
+    "id" : "vectorStore.embeddingsStore.opensearch.password",
     "label" : "Password",
     "description" : "OpenSearch password",
     "optional" : false,
@@ -1652,17 +1652,17 @@
     "feel" : "optional",
     "group" : "embeddingsStore",
     "binding" : {
-      "name" : "vectorStore.openSearch.password",
+      "name" : "vectorStore.password",
       "type" : "zeebe:input"
     },
     "condition" : {
       "property" : "vectorStore.vectorStore",
-      "equals" : "openSearchStore",
+      "equals" : "STORE_OPENSEARCH",
       "type" : "simple"
     },
     "type" : "String"
   }, {
-    "id" : "vectorStore.openSearch.indexName",
+    "id" : "vectorStore.embeddingsStore.opensearch.indexName",
     "label" : "Index name",
     "description" : "OpenSearch index",
     "optional" : false,
@@ -1672,12 +1672,12 @@
     "feel" : "optional",
     "group" : "embeddingsStore",
     "binding" : {
-      "name" : "vectorStore.openSearch.indexName",
+      "name" : "vectorStore.indexName",
       "type" : "zeebe:input"
     },
     "condition" : {
       "property" : "vectorStore.vectorStore",
-      "equals" : "openSearchStore",
+      "equals" : "STORE_OPENSEARCH",
       "type" : "simple"
     },
     "type" : "String"
@@ -1761,7 +1761,7 @@
   }, {
     "id" : "vectorDatabaseConnectorOperation.documentSplitter.documentSplitter",
     "label" : "Document splitting strategy",
-    "value" : "documentSplitterRecursive",
+    "value" : "DOCUMENT_SPLITTER_RECURSIVE",
     "group" : "document",
     "binding" : {
       "name" : "vectorDatabaseConnectorOperation.documentSplitter.splitterType",
@@ -1775,10 +1775,10 @@
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "Recursive",
-      "value" : "documentSplitterRecursive"
+      "value" : "DOCUMENT_SPLITTER_RECURSIVE"
     }, {
       "name" : "Do not split",
-      "value" : "documentSplitterNone"
+      "value" : "DOCUMENT_SPLITTER_NONE"
     } ]
   }, {
     "id" : "vectorDatabaseConnectorOperation.documentSplitter.document.splitter.recursive.maxSegmentSizeInChars",
@@ -1798,7 +1798,7 @@
     "condition" : {
       "allMatch" : [ {
         "property" : "vectorDatabaseConnectorOperation.documentSplitter.documentSplitter",
-        "equals" : "documentSplitterRecursive",
+        "equals" : "DOCUMENT_SPLITTER_RECURSIVE",
         "type" : "simple"
       }, {
         "property" : "vectorDatabaseConnectorOperation.operationType",
@@ -1825,7 +1825,7 @@
     "condition" : {
       "allMatch" : [ {
         "property" : "vectorDatabaseConnectorOperation.documentSplitter.documentSplitter",
-        "equals" : "documentSplitterRecursive",
+        "equals" : "DOCUMENT_SPLITTER_RECURSIVE",
         "type" : "simple"
       }, {
         "property" : "vectorDatabaseConnectorOperation.operationType",
@@ -1838,7 +1838,7 @@
     "id" : "version",
     "label" : "Version",
     "description" : "Version of the element template",
-    "value" : "2",
+    "value" : "1",
     "group" : "connector",
     "binding" : {
       "key" : "elementTemplateVersion",

--- a/connectors/embeddings-vector-database/src/main/java/io/camunda/connector/EmbeddingsVectorDBFunction.java
+++ b/connectors/embeddings-vector-database/src/main/java/io/camunda/connector/EmbeddingsVectorDBFunction.java
@@ -23,7 +23,7 @@ import io.camunda.connector.model.EmbeddingsVectorDBRequest;
     name = "Embeddings Vector DB Outbound Connector",
     description = "Embed and download documents with vector databases",
     inputDataClass = EmbeddingsVectorDBRequest.class,
-    version = 1,
+    version = 2,
     propertyGroups = {
       @ElementTemplate.PropertyGroup(id = "operation", label = "Operation"),
       @ElementTemplate.PropertyGroup(id = "query", label = "Query"),

--- a/connectors/embeddings-vector-database/src/main/java/io/camunda/connector/embeddingstore/DefaultEmbeddingStoreFactory.java
+++ b/connectors/embeddings-vector-database/src/main/java/io/camunda/connector/embeddingstore/DefaultEmbeddingStoreFactory.java
@@ -16,7 +16,7 @@ import dev.langchain4j.store.embedding.opensearch.OpenSearchEmbeddingStore;
 import io.camunda.connector.model.embedding.vector.store.AmazonManagedOpenSearchVectorStore;
 import io.camunda.connector.model.embedding.vector.store.AzureAiSearchVectorStore;
 import io.camunda.connector.model.embedding.vector.store.AzureCosmosDbNoSqlVectorStore;
-import io.camunda.connector.model.embedding.vector.store.ElasticSearchVectorStore;
+import io.camunda.connector.model.embedding.vector.store.ElasticsearchVectorStore;
 import io.camunda.connector.model.embedding.vector.store.EmbeddingsVectorStore;
 import io.camunda.connector.model.embedding.vector.store.OpenSearchVectorStore;
 import io.camunda.connector.model.operation.VectorDatabaseConnectorOperation;
@@ -40,8 +40,8 @@ public class DefaultEmbeddingStoreFactory {
       EmbeddingModel model,
       VectorDatabaseConnectorOperation operation) {
     return switch (embeddingsVectorStore) {
-      case ElasticSearchVectorStore elasticSearchVectorStore ->
-          initializeElasticSearchVectorStore(elasticSearchVectorStore);
+      case ElasticsearchVectorStore elasticsearchVectorStore ->
+          initializeElasticsearchVectorStore(elasticsearchVectorStore);
       case OpenSearchVectorStore openSearchVectorStore ->
           initializeOpenSearchVectorStore(openSearchVectorStore);
       case AmazonManagedOpenSearchVectorStore amazonManagedOpenSearchVectorStore ->
@@ -55,24 +55,24 @@ public class DefaultEmbeddingStoreFactory {
     };
   }
 
-  private EmbeddingStore<TextSegment> initializeElasticSearchVectorStore(
-      ElasticSearchVectorStore elasticSearchVectorStore) {
-    final var elasticSearch = elasticSearchVectorStore.elasticSearch();
+  private EmbeddingStore<TextSegment> initializeElasticsearchVectorStore(
+      ElasticsearchVectorStore elasticsearchVectorStore) {
+    final var elasticsearch = elasticsearchVectorStore.elasticsearch();
     RestClientBuilder restClientBuilder =
-        RestClient.builder(HttpHost.create(elasticSearch.baseUrl()));
+        RestClient.builder(HttpHost.create(elasticsearch.baseUrl()));
 
-    if (!isNullOrBlank(elasticSearch.userName())) {
+    if (!isNullOrBlank(elasticsearch.userName())) {
       CredentialsProvider provider = new BasicCredentialsProvider();
       provider.setCredentials(
           AuthScope.ANY,
-          new UsernamePasswordCredentials(elasticSearch.userName(), elasticSearch.password()));
+          new UsernamePasswordCredentials(elasticsearch.userName(), elasticsearch.password()));
       restClientBuilder.setHttpClientConfigCallback(
           httpClientBuilder -> httpClientBuilder.setDefaultCredentialsProvider(provider));
     }
 
     return ElasticsearchEmbeddingStore.builder()
         .restClient(restClientBuilder.build())
-        .indexName(elasticSearch.indexName())
+        .indexName(elasticsearch.indexName())
         .build();
   }
 

--- a/connectors/embeddings-vector-database/src/main/java/io/camunda/connector/model/embedding/models/AzureOpenAiEmbeddingModelProvider.java
+++ b/connectors/embeddings-vector-database/src/main/java/io/camunda/connector/model/embedding/models/AzureOpenAiEmbeddingModelProvider.java
@@ -26,7 +26,7 @@ public record AzureOpenAiEmbeddingModelProvider(@Valid @NotNull Configuration az
     implements EmbeddingModelProvider {
 
   @TemplateProperty(ignore = true)
-  public static final String AZURE_OPEN_AI_MODEL_PROVIDER = "AZURE_OPEN_AI_MODEL_PROVIDER";
+  public static final String AZURE_OPEN_AI_MODEL_PROVIDER = "azureOpenAiModelProvider";
 
   public record Configuration(
       @NotBlank

--- a/connectors/embeddings-vector-database/src/main/java/io/camunda/connector/model/embedding/models/BedrockEmbeddingModelProvider.java
+++ b/connectors/embeddings-vector-database/src/main/java/io/camunda/connector/model/embedding/models/BedrockEmbeddingModelProvider.java
@@ -22,7 +22,7 @@ public record BedrockEmbeddingModelProvider(@Valid @NotNull Configuration bedroc
     implements EmbeddingModelProvider {
 
   @TemplateProperty(ignore = true)
-  public static final String BEDROCK_MODEL_PROVIDER = "BEDROCK_MODEL_PROVIDER";
+  public static final String BEDROCK_MODEL_PROVIDER = "bedrockModelProvider";
 
   public record Configuration(
       @NotBlank

--- a/connectors/embeddings-vector-database/src/main/java/io/camunda/connector/model/embedding/models/BedrockEmbeddingModelProvider.java
+++ b/connectors/embeddings-vector-database/src/main/java/io/camunda/connector/model/embedding/models/BedrockEmbeddingModelProvider.java
@@ -108,7 +108,7 @@ public record BedrockEmbeddingModelProvider(@Valid @NotNull Configuration bedroc
 
     @Override
     public String toString() {
-      return "BedrockEmbeddingModelProvider.Configuration{accessKey='[REDACTED]', secretKey='[REDACTED]', region='%s', modelName='%s', customModelName='%s', dimensions=%s, normalize=%s, maxRetries=%d}"
+      return "Configuration{accessKey='[REDACTED]', secretKey='[REDACTED]', region='%s', modelName='%s', customModelName='%s', dimensions=%s, normalize=%s, maxRetries=%d}"
           .formatted(region, modelName, customModelName, dimensions, normalize, maxRetries);
     }
   }

--- a/connectors/embeddings-vector-database/src/main/java/io/camunda/connector/model/embedding/models/GoogleVertexAiEmbeddingModelProvider.java
+++ b/connectors/embeddings-vector-database/src/main/java/io/camunda/connector/model/embedding/models/GoogleVertexAiEmbeddingModelProvider.java
@@ -25,7 +25,7 @@ public record GoogleVertexAiEmbeddingModelProvider(@Valid @NotNull Configuration
     implements EmbeddingModelProvider {
 
   @TemplateProperty(ignore = true)
-  public static final String VERTEX_AI_MODEL_PROVIDER = "VERTEX_AI_MODEL_PROVIDER";
+  public static final String VERTEX_AI_MODEL_PROVIDER = "vertexAiModelProvider";
 
   @TemplateProperty(ignore = true)
   public static final String VERTEX_AI_DEFAULT_PUBLISHER = "google";

--- a/connectors/embeddings-vector-database/src/main/java/io/camunda/connector/model/embedding/models/OpenAiEmbeddingModelProvider.java
+++ b/connectors/embeddings-vector-database/src/main/java/io/camunda/connector/model/embedding/models/OpenAiEmbeddingModelProvider.java
@@ -21,7 +21,7 @@ public record OpenAiEmbeddingModelProvider(@Valid @NotNull Configuration openAi)
     implements EmbeddingModelProvider {
 
   @TemplateProperty(ignore = true)
-  public static final String OPEN_AI_MODEL_PROVIDER = "OPEN_AI_MODEL_PROVIDER";
+  public static final String OPEN_AI_MODEL_PROVIDER = "openAiModelProvider";
 
   public record Configuration(
       @NotBlank

--- a/connectors/embeddings-vector-database/src/main/java/io/camunda/connector/model/embedding/splitter/DocumentSplitterRecursive.java
+++ b/connectors/embeddings-vector-database/src/main/java/io/camunda/connector/model/embedding/splitter/DocumentSplitterRecursive.java
@@ -33,5 +33,5 @@ public record DocumentSplitterRecursive(
         Integer maxOverlapSizeInChars)
     implements DocumentSplitter {
   @TemplateProperty(ignore = true)
-  public static final String DOCUMENT_SPLITTER_RECURSIVE = "DOCUMENT_SPLITTER_RECURSIVE";
+  public static final String DOCUMENT_SPLITTER_RECURSIVE = "documentSplitterRecursive";
 }

--- a/connectors/embeddings-vector-database/src/main/java/io/camunda/connector/model/embedding/splitter/NoopDocumentSplitter.java
+++ b/connectors/embeddings-vector-database/src/main/java/io/camunda/connector/model/embedding/splitter/NoopDocumentSplitter.java
@@ -12,5 +12,5 @@ import io.camunda.connector.generator.java.annotation.TemplateSubType;
 @TemplateSubType(label = "Do not split", id = NoopDocumentSplitter.DOCUMENT_SPLITTER_NONE)
 public record NoopDocumentSplitter() implements DocumentSplitter {
   @TemplateProperty(ignore = true)
-  public static final String DOCUMENT_SPLITTER_NONE = "DOCUMENT_SPLITTER_NONE";
+  public static final String DOCUMENT_SPLITTER_NONE = "documentSplitterNone";
 }

--- a/connectors/embeddings-vector-database/src/main/java/io/camunda/connector/model/embedding/vector/store/AmazonManagedOpenSearchVectorStore.java
+++ b/connectors/embeddings-vector-database/src/main/java/io/camunda/connector/model/embedding/vector/store/AmazonManagedOpenSearchVectorStore.java
@@ -14,12 +14,12 @@ import jakarta.validation.constraints.NotNull;
 
 @TemplateSubType(
     label = "Amazon Managed OpenSearch",
-    id = AmazonManagedOpenSearchVectorStore.STORE_AMAZON_MANAGED_OPENSEARCH)
+    id = AmazonManagedOpenSearchVectorStore.AMAZON_MANAGED_OPENSEARCH_STORE)
 public record AmazonManagedOpenSearchVectorStore(
     @Valid @NotNull Configuration amazonManagedOpensearch) implements EmbeddingsVectorStore {
 
   @TemplateProperty(ignore = true)
-  public static final String STORE_AMAZON_MANAGED_OPENSEARCH = "STORE_AMAZON_MANAGED_OPENSEARCH";
+  public static final String AMAZON_MANAGED_OPENSEARCH_STORE = "amazonManagedOpenSearchStore";
 
   public record Configuration(
       @NotBlank

--- a/connectors/embeddings-vector-database/src/main/java/io/camunda/connector/model/embedding/vector/store/AzureAiSearchVectorStore.java
+++ b/connectors/embeddings-vector-database/src/main/java/io/camunda/connector/model/embedding/vector/store/AzureAiSearchVectorStore.java
@@ -13,12 +13,12 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
-@TemplateSubType(label = "Azure AI Search", id = AzureAiSearchVectorStore.STORE_AZURE_AI_SEARCH)
+@TemplateSubType(label = "Azure AI Search", id = AzureAiSearchVectorStore.AZURE_AI_SEARCH_STORE)
 public record AzureAiSearchVectorStore(@Valid @NotNull Configuration aiSearch)
     implements EmbeddingsVectorStore {
 
   @TemplateProperty(ignore = true)
-  public static final String STORE_AZURE_AI_SEARCH = "STORE_AZURE_AI_SEARCH";
+  public static final String AZURE_AI_SEARCH_STORE = "azureAiSearchStore";
 
   public record Configuration(
       @NotBlank

--- a/connectors/embeddings-vector-database/src/main/java/io/camunda/connector/model/embedding/vector/store/AzureAuthentication.java
+++ b/connectors/embeddings-vector-database/src/main/java/io/camunda/connector/model/embedding/vector/store/AzureAuthentication.java
@@ -27,7 +27,7 @@ import jakarta.validation.constraints.NotNull;
     group = "embeddingsStore",
     name = "type",
     defaultValue = "apiKey",
-    description = "Specify the Azure OpenAI authentication strategy.")
+    description = "Specify the Azure authentication strategy.")
 public sealed interface AzureAuthentication {
   @TemplateSubType(id = "apiKey", label = "API key")
   record AzureApiKeyAuthentication(

--- a/connectors/embeddings-vector-database/src/main/java/io/camunda/connector/model/embedding/vector/store/AzureCosmosDbNoSqlVectorStore.java
+++ b/connectors/embeddings-vector-database/src/main/java/io/camunda/connector/model/embedding/vector/store/AzureCosmosDbNoSqlVectorStore.java
@@ -16,12 +16,12 @@ import jakarta.validation.constraints.NotNull;
 
 @TemplateSubType(
     label = "Azure Cosmos DB NoSQL",
-    id = AzureCosmosDbNoSqlVectorStore.STORE_AZURE_COSMOS_DB_NO_SQL)
+    id = AzureCosmosDbNoSqlVectorStore.AZURE_COSMOS_DB_NO_SQL_STORE)
 public record AzureCosmosDbNoSqlVectorStore(@Valid @NotNull Configuration azureCosmosDbNoSql)
     implements EmbeddingsVectorStore {
 
   @TemplateProperty(ignore = true)
-  public static final String STORE_AZURE_COSMOS_DB_NO_SQL = "STORE_AZURE_COSMOS_DB_NO_SQL";
+  public static final String AZURE_COSMOS_DB_NO_SQL_STORE = "azureCosmosDbNoSqlStore";
 
   public record Configuration(
       @NotBlank

--- a/connectors/embeddings-vector-database/src/main/java/io/camunda/connector/model/embedding/vector/store/ElasticSearchVectorStore.java
+++ b/connectors/embeddings-vector-database/src/main/java/io/camunda/connector/model/embedding/vector/store/ElasticSearchVectorStore.java
@@ -12,12 +12,12 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
-@TemplateSubType(label = "Elasticsearch", id = ElasticSearchVectorStore.STORE_ELASTICSEARCH)
+@TemplateSubType(label = "Elasticsearch", id = ElasticSearchVectorStore.ELASTICSEARCH_STORE)
 public record ElasticSearchVectorStore(@Valid @NotNull Configuration elasticSearch)
     implements EmbeddingsVectorStore {
 
   @TemplateProperty(ignore = true)
-  public static final String STORE_ELASTICSEARCH = "STORE_ELASTICSEARCH";
+  public static final String ELASTICSEARCH_STORE = "elasticsearchStore";
 
   public record Configuration(
       @NotBlank

--- a/connectors/embeddings-vector-database/src/main/java/io/camunda/connector/model/embedding/vector/store/ElasticsearchVectorStore.java
+++ b/connectors/embeddings-vector-database/src/main/java/io/camunda/connector/model/embedding/vector/store/ElasticsearchVectorStore.java
@@ -12,8 +12,8 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
-@TemplateSubType(label = "Elasticsearch", id = ElasticSearchVectorStore.ELASTICSEARCH_STORE)
-public record ElasticSearchVectorStore(@Valid @NotNull Configuration elasticSearch)
+@TemplateSubType(label = "Elasticsearch", id = ElasticsearchVectorStore.ELASTICSEARCH_STORE)
+public record ElasticsearchVectorStore(@Valid @NotNull Configuration elasticsearch)
     implements EmbeddingsVectorStore {
 
   @TemplateProperty(ignore = true)

--- a/connectors/embeddings-vector-database/src/main/java/io/camunda/connector/model/embedding/vector/store/EmbeddingsVectorStore.java
+++ b/connectors/embeddings-vector-database/src/main/java/io/camunda/connector/model/embedding/vector/store/EmbeddingsVectorStore.java
@@ -16,25 +16,25 @@ import io.camunda.connector.generator.java.annotation.TemplateDiscriminatorPrope
 @JsonSubTypes({
   @JsonSubTypes.Type(
       value = ElasticSearchVectorStore.class,
-      name = ElasticSearchVectorStore.STORE_ELASTICSEARCH),
+      name = ElasticSearchVectorStore.ELASTICSEARCH_STORE),
   @JsonSubTypes.Type(
       value = OpenSearchVectorStore.class,
-      name = OpenSearchVectorStore.STORE_OPENSEARCH),
+      name = OpenSearchVectorStore.OPEN_SEARCH_STORE),
   @JsonSubTypes.Type(
       value = AmazonManagedOpenSearchVectorStore.class,
-      name = AmazonManagedOpenSearchVectorStore.STORE_AMAZON_MANAGED_OPENSEARCH),
+      name = AmazonManagedOpenSearchVectorStore.AMAZON_MANAGED_OPENSEARCH_STORE),
   @JsonSubTypes.Type(
       value = AzureCosmosDbNoSqlVectorStore.class,
-      name = AzureCosmosDbNoSqlVectorStore.STORE_AZURE_COSMOS_DB_NO_SQL),
+      name = AzureCosmosDbNoSqlVectorStore.AZURE_COSMOS_DB_NO_SQL_STORE),
   @JsonSubTypes.Type(
       value = AzureAiSearchVectorStore.class,
-      name = AzureAiSearchVectorStore.STORE_AZURE_AI_SEARCH),
+      name = AzureAiSearchVectorStore.AZURE_AI_SEARCH_STORE),
 })
 @TemplateDiscriminatorProperty(
     name = "storeType",
     id = "vectorStore",
     group = "embeddingsStore",
-    defaultValue = ElasticSearchVectorStore.STORE_ELASTICSEARCH,
+    defaultValue = ElasticSearchVectorStore.ELASTICSEARCH_STORE,
     label = "Embeddings store",
     description = "Select embedding store")
 public sealed interface EmbeddingsVectorStore

--- a/connectors/embeddings-vector-database/src/main/java/io/camunda/connector/model/embedding/vector/store/EmbeddingsVectorStore.java
+++ b/connectors/embeddings-vector-database/src/main/java/io/camunda/connector/model/embedding/vector/store/EmbeddingsVectorStore.java
@@ -15,8 +15,8 @@ import io.camunda.connector.generator.java.annotation.TemplateDiscriminatorPrope
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "storeType")
 @JsonSubTypes({
   @JsonSubTypes.Type(
-      value = ElasticSearchVectorStore.class,
-      name = ElasticSearchVectorStore.ELASTICSEARCH_STORE),
+      value = ElasticsearchVectorStore.class,
+      name = ElasticsearchVectorStore.ELASTICSEARCH_STORE),
   @JsonSubTypes.Type(
       value = OpenSearchVectorStore.class,
       name = OpenSearchVectorStore.OPEN_SEARCH_STORE),
@@ -34,12 +34,12 @@ import io.camunda.connector.generator.java.annotation.TemplateDiscriminatorPrope
     name = "storeType",
     id = "vectorStore",
     group = "embeddingsStore",
-    defaultValue = ElasticSearchVectorStore.ELASTICSEARCH_STORE,
+    defaultValue = ElasticsearchVectorStore.ELASTICSEARCH_STORE,
     label = "Embeddings store",
     description = "Select embedding store")
 public sealed interface EmbeddingsVectorStore
     permits AmazonManagedOpenSearchVectorStore,
         AzureAiSearchVectorStore,
         AzureCosmosDbNoSqlVectorStore,
-        ElasticSearchVectorStore,
+        ElasticsearchVectorStore,
         OpenSearchVectorStore {}

--- a/connectors/embeddings-vector-database/src/main/java/io/camunda/connector/model/embedding/vector/store/OpenSearchVectorStore.java
+++ b/connectors/embeddings-vector-database/src/main/java/io/camunda/connector/model/embedding/vector/store/OpenSearchVectorStore.java
@@ -12,12 +12,12 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
-@TemplateSubType(label = "OpenSearch", id = OpenSearchVectorStore.STORE_OPENSEARCH)
+@TemplateSubType(label = "OpenSearch", id = OpenSearchVectorStore.OPEN_SEARCH_STORE)
 public record OpenSearchVectorStore(@Valid @NotNull Configuration openSearch)
     implements EmbeddingsVectorStore {
 
   @TemplateProperty(ignore = true)
-  public static final String STORE_OPENSEARCH = "STORE_OPENSEARCH";
+  public static final String OPEN_SEARCH_STORE = "openSearchStore";
 
   public record Configuration(
       @NotBlank

--- a/connectors/embeddings-vector-database/src/test/java/io/camunda/connector/embeddingstore/DefaultEmbeddingStoreFactoryTest.java
+++ b/connectors/embeddings-vector-database/src/test/java/io/camunda/connector/embeddingstore/DefaultEmbeddingStoreFactoryTest.java
@@ -53,12 +53,12 @@ class DefaultEmbeddingStoreFactoryTest {
   DefaultEmbeddingStoreFactory factory = new DefaultEmbeddingStoreFactory();
 
   @Test
-  void createsElasticSearchVectorStore() {
+  void createsElasticsearchVectorStore() {
     final var mockModel = Mockito.mock(EmbeddingModel.class);
 
     final var store =
         factory.initializeVectorStore(
-            EmbeddingsVectorStoreFixture.createElasticSearchVectorStore(), mockModel, null);
+            EmbeddingsVectorStoreFixture.createElasticsearchVectorStore(), mockModel, null);
     assertThat(store).isInstanceOf(ElasticsearchEmbeddingStore.class);
   }
 

--- a/connectors/embeddings-vector-database/src/test/java/io/camunda/connector/fixture/EmbeddingsVectorDBRequestFixture.java
+++ b/connectors/embeddings-vector-database/src/test/java/io/camunda/connector/fixture/EmbeddingsVectorDBRequestFixture.java
@@ -23,7 +23,7 @@ public class EmbeddingsVectorDBRequestFixture {
     final var operation = new RetrieveDocumentOperation("What is RAG?", 5, 0.6);
     final var embeddingModeProvider =
         EmbeddingModelProviderFixture.createDefaultBedrockEmbeddingModel();
-    final var vectorStore = EmbeddingsVectorStoreFixture.createElasticSearchVectorStore();
+    final var vectorStore = EmbeddingsVectorStoreFixture.createElasticsearchVectorStore();
     final var request =
         new EmbeddingsVectorDBRequest(operation, embeddingModeProvider, vectorStore);
     return request;

--- a/connectors/embeddings-vector-database/src/test/java/io/camunda/connector/fixture/EmbeddingsVectorStoreFixture.java
+++ b/connectors/embeddings-vector-database/src/test/java/io/camunda/connector/fixture/EmbeddingsVectorStoreFixture.java
@@ -7,14 +7,14 @@
 package io.camunda.connector.fixture;
 
 import io.camunda.connector.model.embedding.vector.store.AmazonManagedOpenSearchVectorStore;
-import io.camunda.connector.model.embedding.vector.store.ElasticSearchVectorStore;
+import io.camunda.connector.model.embedding.vector.store.ElasticsearchVectorStore;
 import io.camunda.connector.model.embedding.vector.store.OpenSearchVectorStore;
 
 public class EmbeddingsVectorStoreFixture {
 
-  public static ElasticSearchVectorStore createElasticSearchVectorStore() {
-    return new ElasticSearchVectorStore(
-        new ElasticSearchVectorStore.Configuration(
+  public static ElasticsearchVectorStore createElasticsearchVectorStore() {
+    return new ElasticsearchVectorStore(
+        new ElasticsearchVectorStore.Configuration(
             "https://elastic.local:9200", "elastic", "changeme", "embeddings_idx"));
   }
 


### PR DESCRIPTION
## Description

To make this connector consistent with other connectors we should use camel case IDs for sealed interface implementations. 
Also, I rename `ElasticSearch` to `Elasticsearch` everywhere.
Finally I bump the connector version to 2, the version 1 being the one before the merge of [this PR](https://github.com/camunda/connectors/pull/5202).

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.
- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest release, as this branch will be rebased onto main before the next release.

