### PR TITLE
refactor(connector-runtime): adjustments to match the newly shaped job worker manager

### DIFF
--- a/connector-runtime/connector-runtime-application/src/main/resources/application.properties
+++ b/connector-runtime/connector-runtime-application/src/main/resources/application.properties
@@ -1,7 +1,7 @@
 server.port=8080
 
 management.server.base-path=/actuator
-management.endpoints.web.exposure.include=metrics,health,prometheus
+management.endpoints.web.exposure.include=metrics,health,prometheus,jobWorkers
 management.endpoint.health.group.readiness.include[]=zeebeClient,processDefinitionImport
 management.endpoint.health.show-components=always
 management.endpoint.health.show-details=always

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/OutboundConnectorRuntimeConfiguration.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/OutboundConnectorRuntimeConfiguration.java
@@ -31,7 +31,6 @@ import io.camunda.document.factory.DocumentFactory;
 import io.camunda.document.factory.DocumentFactoryImpl;
 import io.camunda.document.store.CamundaDocumentStore;
 import io.camunda.document.store.CamundaDocumentStoreImpl;
-import io.camunda.spring.client.jobhandling.CommandExceptionHandlingStrategy;
 import io.camunda.spring.client.jobhandling.JobWorkerManager;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.util.List;
@@ -73,7 +72,6 @@ public class OutboundConnectorRuntimeConfiguration {
   public OutboundConnectorManager outboundConnectorManager(
       JobWorkerManager jobWorkerManager,
       OutboundConnectorFactory connectorFactory,
-      CommandExceptionHandlingStrategy commandExceptionHandlingStrategy,
       SecretProviderAggregator secretProviderAggregator,
       ValidationProvider validationProvider,
       ConnectorsOutboundMetrics outboundMetrics,
@@ -82,7 +80,6 @@ public class OutboundConnectorRuntimeConfiguration {
     return new OutboundConnectorManager(
         jobWorkerManager,
         connectorFactory,
-        commandExceptionHandlingStrategy,
         secretProviderAggregator,
         validationProvider,
         documentFactory,

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/lifecycle/OutboundConnectorJobHandlerFactory.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/lifecycle/OutboundConnectorJobHandlerFactory.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.runtime.outbound.lifecycle;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.client.api.worker.JobHandler;
+import io.camunda.connector.api.outbound.OutboundConnectorFunction;
+import io.camunda.connector.api.validation.ValidationProvider;
+import io.camunda.connector.runtime.core.secret.SecretProviderAggregator;
+import io.camunda.connector.runtime.metrics.ConnectorsOutboundMetrics;
+import io.camunda.connector.runtime.outbound.jobhandling.SpringConnectorJobHandler;
+import io.camunda.document.factory.DocumentFactory;
+import io.camunda.spring.client.jobhandling.JobHandlerFactory;
+import io.camunda.spring.client.jobhandling.JobHandlerFactoryContext;
+import io.camunda.spring.client.metrics.DefaultNoopMetricsRecorder;
+
+public class OutboundConnectorJobHandlerFactory implements JobHandlerFactory {
+  private final ConnectorsOutboundMetrics outboundMetrics;
+  private final SecretProviderAggregator secretProviderAggregator;
+  private final ValidationProvider validationProvider;
+  private final DocumentFactory documentFactory;
+  private final ObjectMapper objectMapper;
+  private final OutboundConnectorFunction connectorFunction;
+
+  public OutboundConnectorJobHandlerFactory(
+      ConnectorsOutboundMetrics outboundMetrics,
+      SecretProviderAggregator secretProviderAggregator,
+      ValidationProvider validationProvider,
+      DocumentFactory documentFactory,
+      ObjectMapper objectMapper,
+      OutboundConnectorFunction connectorFunction) {
+    this.outboundMetrics = outboundMetrics;
+    this.secretProviderAggregator = secretProviderAggregator;
+    this.validationProvider = validationProvider;
+    this.documentFactory = documentFactory;
+    this.objectMapper = objectMapper;
+    this.connectorFunction = connectorFunction;
+  }
+
+  @Override
+  public JobHandler getJobHandler(JobHandlerFactoryContext context) {
+    return new SpringConnectorJobHandler(
+        outboundMetrics,
+        context.commandExceptionHandlingStrategy(),
+        secretProviderAggregator,
+        validationProvider,
+        documentFactory,
+        objectMapper,
+        connectorFunction,
+        new DefaultNoopMetricsRecorder());
+  }
+}

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/outbound/RuntimeStartupWithConnectorsFromEnvVarsTests.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/outbound/RuntimeStartupWithConnectorsFromEnvVarsTests.java
@@ -16,9 +16,7 @@
  */
 package io.camunda.connector.runtime.outbound;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 import io.camunda.connector.runtime.app.TestConnectorRuntimeApplication;
 import io.camunda.connector.test.SlowTest;
@@ -71,10 +69,19 @@ class RuntimeStartupWithConnectorsFromEnvVarsTests {
       return;
     }
     // Make sure the environment variables are used INSTEAD of SPI (which would load TEST)
-    assertFalse(jobWorkerManager.findJobWorkerConfigByName("TEST").isPresent());
+    assertFalse(
+        jobWorkerManager.getJobWorkers().values().stream()
+            .anyMatch(v -> "TEST".equals(v.getName())));
 
-    Optional<JobWorkerValue> testConnector = jobWorkerManager.findJobWorkerConfigByName("TEST2");
+    Optional<JobWorkerValue> testConnector =
+        jobWorkerManager.getJobWorkers().values().stream()
+            .filter(v -> "TEST2".equals(v.getName()))
+            .findFirst();
     assertTrue(testConnector.isPresent());
+    assertTrue(
+        jobWorkerManager.getJobWorkers().values().stream()
+            .anyMatch(v -> "TEST2".equals(v.getName())));
+
     assertEquals("non-default-TEST-task-type", testConnector.get().getType());
   }
 }

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/outbound/RuntimeStartupWithConnectorsFromSpiTests.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/outbound/RuntimeStartupWithConnectorsFromSpiTests.java
@@ -42,7 +42,10 @@ class RuntimeStartupWithConnectorsFromSpiTests {
 
   @Test
   public void httpConnectorLoadedViaSpi() {
-    Optional<JobWorkerValue> httpjson = jobWorkerManager.findJobWorkerConfigByName("TEST");
+    Optional<JobWorkerValue> httpjson =
+        jobWorkerManager.getJobWorkers().values().stream()
+            .filter(v -> "TEST".equals(v.getName()))
+            .findFirst();
     assertTrue(httpjson.isPresent());
   }
 }


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

This PR adjusts the connector runtime to match https://github.com/camunda/camunda/pull/36592

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.
- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest release, as this branch will be rebased onto main before the next release.

