### PR TITLE
fix(agentic-ai): add missing LICENSE.txt

### DIFF
--- a/connectors/agentic-ai/LICENSE.txt
+++ b/connectors/agentic-ai/LICENSE.txt
@@ -1,0 +1,5 @@
+Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under one or more contributor license agreements and licensed to you under a proprietary license.
+You may not use this file except in compliance with the proprietary license.
+The proprietary license can be either the Camunda Self-Managed Free Edition license (available on Camunda’s website) or the Camunda Self-Managed Enterprise Edition license (a copy you obtain when you contact Camunda).
+The Camunda Self-Managed Free Edition comes for free but only allows for usage of the software (file) in non-production environments.
+If you want to use the software (file) in production, you need to purchase the Camunda Self-Managed Enterprise Edition.


### PR DESCRIPTION
## Description

Add missing `LICENSE.txt` file referenced from source file headers.

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.
- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest release, as this branch will be rebased onto main before the next release.

