### PR TITLE
fix(vector-db): add missing validation annotations

### DIFF
--- a/connectors/embeddings-vector-database/element-templates/embeddings-vector-database-outbound-connector.json
+++ b/connectors/embeddings-vector-database/element-templates/embeddings-vector-database-outbound-connector.json
@@ -100,9 +100,6 @@
     "description" : "Limit number of returned results",
     "optional" : false,
     "value" : 5,
-    "constraints" : {
-      "notEmpty" : true
-    },
     "feel" : "static",
     "group" : "query",
     "binding" : {
@@ -554,9 +551,6 @@
     "description" : "Normalize vector",
     "optional" : false,
     "value" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
     "feel" : "static",
     "group" : "embeddingModel",
     "binding" : {
@@ -1786,9 +1780,6 @@
     "description" : "Max splitting segment size in chars",
     "optional" : false,
     "value" : 500,
-    "constraints" : {
-      "notEmpty" : true
-    },
     "feel" : "static",
     "group" : "document",
     "binding" : {
@@ -1813,9 +1804,6 @@
     "description" : "Max segment splitting overlap size in chars",
     "optional" : false,
     "value" : 80,
-    "constraints" : {
-      "notEmpty" : true
-    },
     "feel" : "static",
     "group" : "document",
     "binding" : {

--- a/connectors/embeddings-vector-database/element-templates/hybrid/embeddings-vector-database-outbound-connector-hybrid.json
+++ b/connectors/embeddings-vector-database/element-templates/hybrid/embeddings-vector-database-outbound-connector-hybrid.json
@@ -105,9 +105,6 @@
     "description" : "Limit number of returned results",
     "optional" : false,
     "value" : 5,
-    "constraints" : {
-      "notEmpty" : true
-    },
     "feel" : "static",
     "group" : "query",
     "binding" : {
@@ -559,9 +556,6 @@
     "description" : "Normalize vector",
     "optional" : false,
     "value" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
     "feel" : "static",
     "group" : "embeddingModel",
     "binding" : {
@@ -1791,9 +1785,6 @@
     "description" : "Max splitting segment size in chars",
     "optional" : false,
     "value" : 500,
-    "constraints" : {
-      "notEmpty" : true
-    },
     "feel" : "static",
     "group" : "document",
     "binding" : {
@@ -1818,9 +1809,6 @@
     "description" : "Max segment splitting overlap size in chars",
     "optional" : false,
     "value" : 80,
-    "constraints" : {
-      "notEmpty" : true
-    },
     "feel" : "static",
     "group" : "document",
     "binding" : {

--- a/connectors/embeddings-vector-database/src/main/java/io/camunda/connector/model/EmbeddingsVectorDBRequest.java
+++ b/connectors/embeddings-vector-database/src/main/java/io/camunda/connector/model/EmbeddingsVectorDBRequest.java
@@ -9,8 +9,10 @@ package io.camunda.connector.model;
 import io.camunda.connector.model.embedding.models.EmbeddingModelProvider;
 import io.camunda.connector.model.embedding.vector.store.EmbeddingsVectorStore;
 import io.camunda.connector.model.operation.VectorDatabaseConnectorOperation;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
 
 public record EmbeddingsVectorDBRequest(
-    VectorDatabaseConnectorOperation vectorDatabaseConnectorOperation,
-    EmbeddingModelProvider embeddingModelProvider,
-    EmbeddingsVectorStore vectorStore) {}
+    @Valid @NotNull VectorDatabaseConnectorOperation vectorDatabaseConnectorOperation,
+    @Valid @NotNull EmbeddingModelProvider embeddingModelProvider,
+    @Valid @NotNull EmbeddingsVectorStore vectorStore) {}

--- a/connectors/embeddings-vector-database/src/main/java/io/camunda/connector/model/embedding/models/BedrockEmbeddingModelProvider.java
+++ b/connectors/embeddings-vector-database/src/main/java/io/camunda/connector/model/embedding/models/BedrockEmbeddingModelProvider.java
@@ -44,7 +44,7 @@ public record BedrockEmbeddingModelProvider(@Valid @NotNull Configuration bedroc
               label = "Region",
               description = "AWS Bedrock region")
           String region,
-      @NotBlank
+      @NotNull
           @TemplateProperty(
               group = "embeddingModel",
               label = "Model name",
@@ -64,8 +64,7 @@ public record BedrockEmbeddingModelProvider(@Valid @NotNull Configuration bedroc
                       property = "embeddingModelProvider.bedrock.modelName",
                       equals = "Custom"))
           String customModelName,
-      @NotBlank
-          @TemplateProperty(
+      @TemplateProperty(
               group = "embeddingModel",
               label = "Embedding dimensions",
               description = "The size of the vector used to represent data",
@@ -78,8 +77,7 @@ public record BedrockEmbeddingModelProvider(@Valid @NotNull Configuration bedroc
                       property = "embeddingModelProvider.bedrock.modelName",
                       equals = "TitanEmbedTextV2"))
           BedrockDimensions dimensions,
-      @NotBlank
-          @TemplateProperty(
+      @TemplateProperty(
               group = "embeddingModel",
               label = "Normalize",
               description = "Normalize vector",

--- a/connectors/embeddings-vector-database/src/main/java/io/camunda/connector/model/embedding/splitter/RecursiveDocumentSplitter.java
+++ b/connectors/embeddings-vector-database/src/main/java/io/camunda/connector/model/embedding/splitter/RecursiveDocumentSplitter.java
@@ -9,11 +9,11 @@ package io.camunda.connector.model.embedding.splitter;
 import io.camunda.connector.generator.java.annotation.TemplateProperty;
 import io.camunda.connector.generator.java.annotation.TemplateProperty.DefaultValueType;
 import io.camunda.connector.generator.java.annotation.TemplateSubType;
-import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Min;
 
 @TemplateSubType(label = "Recursive", id = RecursiveDocumentSplitter.RECURSIVE_DOCUMENT_SPLITTER)
 public record RecursiveDocumentSplitter(
-    @NotBlank
+    @Min(1)
         @TemplateProperty(
             group = "document",
             id = "document.splitter.recursive.maxSegmentSizeInChars",
@@ -22,7 +22,7 @@ public record RecursiveDocumentSplitter(
             defaultValueType = DefaultValueType.Number,
             defaultValue = "500")
         Integer maxSegmentSizeInChars,
-    @NotBlank
+    @Min(1)
         @TemplateProperty(
             group = "document",
             id = "document.splitter.recursive.maxOverlapSizeInChars",

--- a/connectors/embeddings-vector-database/src/main/java/io/camunda/connector/model/embedding/vector/store/AzureCosmosDbNoSqlVectorStore.java
+++ b/connectors/embeddings-vector-database/src/main/java/io/camunda/connector/model/embedding/vector/store/AzureCosmosDbNoSqlVectorStore.java
@@ -47,7 +47,7 @@ public record AzureCosmosDbNoSqlVectorStore(@Valid @NotNull Configuration azureC
               description = "Specify the name of the Azure Cosmos DB NoSQL container.",
               constraints = @TemplateProperty.PropertyConstraints(notEmpty = true))
           String containerName,
-      @NotBlank
+      @NotNull
           @TemplateProperty(
               group = "embeddingsStore",
               label = "Consistency level",
@@ -57,7 +57,7 @@ public record AzureCosmosDbNoSqlVectorStore(@Valid @NotNull Configuration azureC
               defaultValue = "EVENTUAL",
               constraints = @TemplateProperty.PropertyConstraints(notEmpty = true))
           ConsistencyLevel consistencyLevel,
-      @NotBlank
+      @NotNull
           @TemplateProperty(
               group = "embeddingsStore",
               label = "Distance function",
@@ -68,7 +68,7 @@ public record AzureCosmosDbNoSqlVectorStore(@Valid @NotNull Configuration azureC
               defaultValue = "COSINE",
               constraints = @TemplateProperty.PropertyConstraints(notEmpty = true))
           DistanceFunction distanceFunction,
-      @NotBlank
+      @NotNull
           @TemplateProperty(
               group = "embeddingsStore",
               label = "Vector index type",

--- a/connectors/embeddings-vector-database/src/main/java/io/camunda/connector/model/operation/EmbedDocumentOperation.java
+++ b/connectors/embeddings-vector-database/src/main/java/io/camunda/connector/model/operation/EmbedDocumentOperation.java
@@ -16,13 +16,13 @@ import io.camunda.connector.generator.java.annotation.TemplateProperty.PropertyC
 import io.camunda.connector.generator.java.annotation.TemplateSubType;
 import io.camunda.connector.model.embedding.splitter.DocumentSplitter;
 import io.camunda.document.Document;
-import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import java.util.List;
 
 @TemplateSubType(label = "Embed document", id = EMBED_DOCUMENT_OPERATION)
 public record EmbedDocumentOperation(
-    @NotBlank
+    @NotNull
         @TemplateProperty(
             group = "document",
             id = "documentSource",
@@ -33,8 +33,7 @@ public record EmbedDocumentOperation(
             description = "Whether you want to embed a Camunda document file or plain text",
             defaultValue = "CamundaDocument")
         EmbedDocumentSource documentSource,
-    @NotBlank
-        @TemplateProperty(
+    @TemplateProperty(
             group = "document",
             id = "documentSourceFromProcessVariable",
             label = "Plain text to embed",
@@ -45,8 +44,7 @@ public record EmbedDocumentOperation(
                     property = "vectorDatabaseConnectorOperation.documentSource",
                     equals = "PlainText"))
         String documentSourceFromProcessVariable,
-    @NotBlank
-        @TemplateProperty(
+    @TemplateProperty(
             label = "Documents",
             group = "document",
             id = "newDocuments",
@@ -58,7 +56,7 @@ public record EmbedDocumentOperation(
                     property = "vectorDatabaseConnectorOperation.documentSource",
                     equals = "CamundaDocument"))
         List<Document> newDocuments,
-    @NotNull DocumentSplitter documentSplitter)
+    @NotNull @Valid DocumentSplitter documentSplitter)
     implements VectorDatabaseConnectorOperation {
   @TemplateProperty(ignore = true)
   public static final String EMBED_DOCUMENT_OPERATION = "embedDocumentOperation";

--- a/connectors/embeddings-vector-database/src/main/java/io/camunda/connector/model/operation/RetrieveDocumentOperation.java
+++ b/connectors/embeddings-vector-database/src/main/java/io/camunda/connector/model/operation/RetrieveDocumentOperation.java
@@ -11,6 +11,7 @@ import static io.camunda.connector.model.operation.RetrieveDocumentOperation.RET
 import io.camunda.connector.generator.java.annotation.TemplateProperty;
 import io.camunda.connector.generator.java.annotation.TemplateProperty.DefaultValueType;
 import io.camunda.connector.generator.java.annotation.TemplateSubType;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
@@ -24,7 +25,7 @@ public record RetrieveDocumentOperation(
             label = "Search query",
             description = "Document lookup query")
         String query,
-    @NotBlank
+    @Min(1)
         @TemplateProperty(
             group = "query",
             id = "query.maxResults",


### PR DESCRIPTION
## Description

There is no validation annotations on the fields of `EmbeddingsVectorDBRequest`. Hence the request data is not validated. 
This PR adds the required validation annotations and fixes the validation annotations that are incorrectly used.


## Checklist

- [x] PR has a **milestone** or the `no milestone` label.
- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest release, as this branch will be rebased onto main before the next release.

