### PR TITLE
chore(inbound-importer): Make process definition search page size configurable

### DIFF
--- a/bundle/camunda-saas-bundle/src/main/resources/application.properties
+++ b/bundle/camunda-saas-bundle/src/main/resources/application.properties
@@ -9,6 +9,7 @@ camunda.connector.webhook.enabled=true
 camunda.connector.secret-provider.discovery.enabled=false
 camunda.connector.secret-provider.environment.enabled=false
 camunda.connector.secret-provider.console.enabled=false
+# camunda.connector.process-definition-search.page-size=20
 camunda.client.zeebe.execution-threads=10
 camunda.client.zeebe.defaults.max-jobs-active=32
 camunda.client.zeebe.defaults.stream-enabled=true

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/importer/ProcessDefinitionSearch.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/importer/ProcessDefinitionSearch.java
@@ -30,6 +30,7 @@ import java.util.Optional;
 import java.util.Set;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.util.CollectionUtils;
 
 /**
@@ -37,8 +38,8 @@ import org.springframework.util.CollectionUtils;
  * index.
  */
 public class ProcessDefinitionSearch {
-
-  private static final int PAGE_SIZE = 50;
+  @Value("${camunda.connector.process-definition-search.page-size:50}")
+  private int pageSize;
 
   private static final Logger LOG = LoggerFactory.getLogger(ProcessDefinitionImporter.class);
   private final CamundaOperateClient camundaOperateClient;
@@ -66,7 +67,7 @@ public class ProcessDefinitionSearch {
             new SearchQuery.Builder()
                 .searchAfter(paginationIndex)
                 .sort(new Sort("key", SortOrder.DESC))
-                .size(PAGE_SIZE)
+                .size(pageSize)
                 .build();
         processDefinitionResult =
             camundaOperateClient.searchProcessDefinitionResults(processDefinitionQuery);


### PR DESCRIPTION
## Description

Make it configurable for 8.7
PR for 8.8 is here: https://github.com/camunda/connectors/pull/5243


## Checklist

- [x] PR has a **milestone** or the `no milestone` label.
- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest release, as this branch will be rebased onto main before the next release.

