### PR TITLE
chore(inbound-importer): Make process definition search page size configurable

### DIFF
--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/search/SearchQueryClientImpl.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/search/SearchQueryClientImpl.java
@@ -22,11 +22,11 @@ import io.camunda.client.api.search.response.*;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import java.io.ByteArrayInputStream;
+import org.springframework.beans.factory.annotation.Value;
 
 public class SearchQueryClientImpl implements SearchQueryClient {
-
-  private static final int DEFAULT_PAGE_LIMIT = 200;
-  private int limit = DEFAULT_PAGE_LIMIT;
+  @Value("${camunda.connector.process-definition-search.page-size:200}")
+  private int limit;
 
   private final CamundaClient camundaClient;
 


### PR DESCRIPTION
## Description
Make process definition search page size configurable for 8.8

## Related issues
closes #5229

PR for 8.7 is here: https://github.com/camunda/connectors/pull/5241

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.
- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest release, as this branch will be rebased onto main before the next release.

