### PR TITLE
chore(renovate): temporarily switch to daily schedule

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,8 +2,7 @@
   "extends": [
     "config:recommended",
     "group:allNonMajor",
-    "schedule:earlyMondays",
-    "schedule:automergeNonOfficeHours"
+    "schedule:daily"
   ],
   "timezone": "Europe/Berlin",
   "labels": [


### PR DESCRIPTION
## Description

This PR will switch the Renovate updates to daily temporarily. This will allow us to verify more quickly whether the recent changes work.

I will revert this PR when the change is verified.

## Related issues

<!-- Which issues are closed by this PR or are related -->

related to #5227 

## Checklist

- [ ] PR has a **milestone** or the `no milestone` label.
- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest release, as this branch will be rebased onto main before the next release.

