### PR TITLE
fix(agentic-ai): fix NPE when agent context flag is null

### DIFF
--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/agent/JobWorkerAgentRequestHandler.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/agent/JobWorkerAgentRequestHandler.java
@@ -169,7 +169,8 @@ public class JobWorkerAgentRequestHandler
             .responseJson(agentResponse.responseJson())
             .responseMessage(agentResponse.responseMessage());
 
-    if (executionContext.response().includeAgentContext() == true) {
+    if (executionContext.response() != null
+        && Boolean.TRUE.equals(executionContext.response().includeAgentContext())) {
       LOGGER.debug("Including agent context in response variable");
       builder = builder.context(agentResponse.context());
     }


### PR DESCRIPTION
## Description

Fixes NPE raised when the `Boolean` value is null.

Note: I did not add a dedicated test for this now as we don't have a setup ready where this can easily be added, but might add it in a follow-up.

## Related issues

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.
- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest release, as this branch will be rebased onto main before the next release.

