### PR TITLE
fix(agentic-ai): deprecate v0/alpha element templates of AI Agent and AHSP schema connector

### DIFF
--- a/connectors/agentic-ai/element-templates/versioned/agenticai-adhoctoolsschema-outbound-connector-0.json
+++ b/connectors/agentic-ai/element-templates/versioned/agenticai-adhoctoolsschema-outbound-connector-0.json
@@ -7,6 +7,7 @@
     "keywords" : [ ]
   },
   "version" : 0,
+  "deprecated": true,
   "category" : {
     "id" : "connectors",
     "name" : "Connectors"

--- a/connectors/agentic-ai/element-templates/versioned/agenticai-aiagent-outbound-connector-0.json
+++ b/connectors/agentic-ai/element-templates/versioned/agenticai-aiagent-outbound-connector-0.json
@@ -7,6 +7,7 @@
     "keywords" : [ ]
   },
   "version" : 0,
+  "deprecated": true,
   "category" : {
     "id" : "connectors",
     "name" : "Connectors"


### PR DESCRIPTION
## Description

See discussion on https://camunda.slack.com/archives/C097RLZP0MB/p1755600183881039?thread_ts=1754515463.736389&cid=C097RLZP0MB.

## Related issues

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.
- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest release, as this branch will be rebased onto main before the next release.

