### PR TITLE
fix(deps): revert update com.microsoft.sqlserver:mssql-jdbc to v13 (main)"

### DIFF
--- a/connectors/jdbc/pom.xml
+++ b/connectors/jdbc/pom.xml
@@ -56,7 +56,7 @@
     <dependency>
       <groupId>com.microsoft.sqlserver</groupId>
       <artifactId>mssql-jdbc</artifactId>
-      <version>13.2.0.jre11</version>
+      <version>12.10.1.jre11</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Reverts camunda/connectors#5255

The original PR introduced a build failure due to a transitive dependency requiring Java 24