### PR TITLE
test(runtime): fix search query client test

### DIFF
--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/inbound/search/SearchQueryClientTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/inbound/search/SearchQueryClientTest.java
@@ -46,7 +46,8 @@ public class SearchQueryClientTest {
     waitForIndexing(2);
 
     // When
-    SearchQueryClientImpl processDefinitionSearch = new SearchQueryClientImpl(camundaClient);
+    // must pass the limit as it is not injected by spring when created manually
+    SearchQueryClientImpl processDefinitionSearch = new SearchQueryClientImpl(camundaClient, 200);
     var result = processDefinitionSearch.queryProcessDefinitions(null);
 
     // Then


### PR DESCRIPTION
## Description

Found another failing test that's only visible in the nightly runs. Not sure how the error was introduced, but the page limit is set to 0 as `@Value` inside the `SearchQueryClientImpl` does not have any effect during manual object creation.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #

## Checklist

- [ ] PR has a **milestone** or the `no milestone` label.
- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest release, as this branch will be rebased onto main before the next release.

