### PR TITLE
fix(idp-extraction-connector): add document url as input for azure document intelligence

### DIFF
--- a/connectors/idp-extraction/pom.xml
+++ b/connectors/idp-extraction/pom.xml
@@ -71,7 +71,7 @@
     <dependency>
       <groupId>com.azure</groupId>
       <artifactId>azure-ai-documentintelligence</artifactId>
-      <version>1.0.2</version>
+      <version>1.0.3</version>
       <exclusions>
         <exclusion>
           <groupId>io.vertx</groupId>


### PR DESCRIPTION
## Description

This pull request enhances the Azure Document Intelligence integration by adding support for using document links as input for analysis, with a fallback to byte array input if link generation fails. It also introduces comprehensive tests to ensure this new logic works as intended.

**Azure Document Intelligence Caller Improvements:**

* Updated `AzureDocumentIntelligenceCaller` to first attempt document analysis using a generated document link via `DocumentLinkParameters`. If link generation fails (for example, if not supported by the document), the code now falls back to using the document's byte array as input. This improves flexibility and efficiency when working with documents that can be referenced by link.

* Upgraded the `azure-ai-documentintelligence` dependency from version 1.0.2 to 1.0.3 for improved compatibility and bug fixes.

**Testing Enhancements:**

* Added new tests to `AzureDocumentIntelligenceCallerTest` to cover:
  - Successful document link generation and analysis,
  - Fallback to byte array when link generation is not supported,
  - Fallback to byte array when link generation throws a generic exception.
  These tests ensure robust handling of different document input scenarios.

* Updated imports in both the main and test classes to support the new document link logic. [[1]](diffhunk://#diff-0dd2ff6c82457f70f71745482f8eb0cfccaafc07dd111265eecc3674fdad9b6fR18-R21) [[2]](diffhunk://#diff-e56a330987289b8dde5b6bd66cd4b3640f4b62f1fb2a1ef0d0d52ffa70a129f6R27-R35)

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes https://github.com/camunda/connectors/issues/5267

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.
- [x] Backport labels are added if these code changes should be backported. No backport label is added to the latest release, as this branch will be rebased onto main before the next release.

