### PR TITLE
chore(github-action): modify the timeout for the CHECK_LICENSES job as it was always being cancelled

### DIFF
--- a/.github/workflows/CHECK_LICENSES.yml
+++ b/.github/workflows/CHECK_LICENSES.yml
@@ -16,7 +16,7 @@ jobs:
   analyze:
     name: Analyze dependencies
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 30
     steps:
     - uses: actions/checkout@v5
     # Import FOSSA_API_KEY and other secrets from Vault


### PR DESCRIPTION
## Description

The license check github action was always failing due to timeout issue, this fixes it

## Checklist

- [ ] PR has a **milestone** or the `no milestone` label.
- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest release, as this branch will be rebased onto main before the next release.

