### PR TITLE
chore(infra): upgrade external-secrets apiversion

### DIFF
--- a/.ci/preview-environments/charts/c8sm/templates/secrets.yml
+++ b/.ci/preview-environments/charts/c8sm/templates/secrets.yml
@@ -21,7 +21,7 @@ data:
   # Set to an empty JSON to comply with kubernetes.io/dockerconfigjson requirements
   .dockerconfigjson: "e30="
 ---
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: registry-camunda-cloud


### PR DESCRIPTION
## Description

This pull request updates the Kubernetes manifest for the `registry-camunda-cloud` secret to use a newer version of the ExternalSecrets API.

Kubernetes manifest update:

* Changed the `apiVersion` in `.ci/preview-environments/charts/c8sm/templates/secrets.yml` from `external-secrets.io/v1beta1` to `external-secrets.io/v1` to use the stable API version for ExternalSecrets.
## Related issues

## Related to

- https://github.com/camunda/team-infrastructure/issues/883

## Checklist

- [ ] PR has a **milestone** or the `no milestone` label.
- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest release, as this branch will be rebased onto main before the next release.

