### PR TITLE
fix(ci): update regexp for pull_request name check

### DIFF
--- a/.github/workflows/PULL_REQUEST_NAME_CHECK_ON_PR.yml
+++ b/.github/workflows/PULL_REQUEST_NAME_CHECK_ON_PR.yml
@@ -14,7 +14,7 @@ jobs:
         run: echo "$PR_TITLE"
       - name: Check if pull request name follows conventional commit regex
         run: |
-          PR_REGEX='^(feat|fix|docs|style|refactor|perf|test|chore|build|other|ci)\(?.+\)?: .+$'
+          PR_REGEX='^(feat|fix|docs|style|refactor|perf|test|chore|build|other|ci)(\(.+\))?: .+$'
           if [[ "$PR_TITLE" =~ $PR_REGEX ]]; then
             echo "Pull request name follows the conventional commit format."
           else


### PR DESCRIPTION
## Description

This pull request makes a small update to the pull request name validation regex in the `.github/workflows/PULL_REQUEST_NAME_CHECK_ON_PR.yml` workflow. The change improves the accuracy of the conventional commit format check by refining how the optional scope is matched in the regex.

Previous pattern examples: https://regex101.com/r/EJ12Nk/1
New pattern examples: https://regex101.com/r/MHuXbC/2

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.
- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest release, as this branch will be rebased onto main before the next release.

