### PR TITLE
fix(application.properties): a duplicate camunda.client.prefer-rest-over-grpc was present in application.properties file

### DIFF
--- a/bundle/default-bundle/src/test/resources/application.properties
+++ b/bundle/default-bundle/src/test/resources/application.properties
@@ -22,4 +22,3 @@ camunda.client.mode=self-managed
 # Config for use with docker-compose-core.yml
 #camunda.client.auth.username=demo
 #camunda.client.auth.password=demo
-camunda.client.prefer-rest-over-grpc=false


### PR DESCRIPTION
## Description

a duplicate camunda.client.prefer-rest-over-grpc was present in application.properties file

## Related issues

This was introduced [here](https://github.com/camunda/connectors/pull/5269/files) 

## Checklist

- [ ] PR has a **milestone** or the `no milestone` label.
- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest release, as this branch will be rebased onto main before the next release.

