### PR TITLE
feat(agentic-ai): add an OpenAI compatible provider

### DIFF
--- a/connectors/agentic-ai/element-templates/agenticai-aiagent-job-worker.json
+++ b/connectors/agentic-ai/element-templates/agenticai-aiagent-job-worker.json
@@ -119,6 +119,9 @@
     }, {
       "name" : "OpenAI",
       "value" : "openai"
+    }, {
+      "name" : "OpenAI Compatible",
+      "value" : "openaiCompatible"
     } ]
   }, {
     "id" : "provider.anthropic.endpoint",
@@ -615,6 +618,60 @@
     },
     "type" : "String"
   }, {
+    "id" : "provider.openaiCompatible.endpoint",
+    "label" : "API endpoint",
+    "description" : "API endpoint.",
+    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "provider",
+    "binding" : {
+      "name" : "provider.openaiCompatible.endpoint",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "provider.type",
+      "equals" : "openaiCompatible",
+      "type" : "simple"
+    },
+    "tooltip" : "Specify an endpoint to use the connector with an OpenAI compatible API. ",
+    "type" : "String"
+  }, {
+    "id" : "provider.openaiCompatible.authentication.apiKey",
+    "label" : "API key",
+    "optional" : true,
+    "feel" : "optional",
+    "group" : "provider",
+    "binding" : {
+      "name" : "provider.openaiCompatible.authentication.apiKey",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "provider.type",
+      "equals" : "openaiCompatible",
+      "type" : "simple"
+    },
+    "type" : "String"
+  }, {
+    "id" : "provider.openaiCompatible.headers",
+    "label" : "Headers",
+    "description" : "Map of HTTP headers to add to the request.",
+    "optional" : true,
+    "feel" : "required",
+    "group" : "provider",
+    "binding" : {
+      "name" : "provider.openaiCompatible.headers",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "provider.type",
+      "equals" : "openaiCompatible",
+      "type" : "simple"
+    },
+    "type" : "String"
+  }, {
     "id" : "provider.anthropic.model.model",
     "label" : "Model",
     "description" : "Specify the model ID. Details in the <a href=\"https://docs.anthropic.com/en/docs/about-claude/models/all-models\" target=\"_blank\">documentation</a>.",
@@ -1006,6 +1063,95 @@
     },
     "tooltip" : "Recommended for advanced use cases only (you usually only need to use temperature). <br><br>Details in the <a href=\"https://platform.openai.com/docs/api-reference/chat/create#chat-create-top_p\" target=\"_blank\">documentation</a>.",
     "type" : "Number"
+  }, {
+    "id" : "provider.openaiCompatible.model.model",
+    "label" : "Model",
+    "description" : "Specify the model ID. Details in the <a href=\"https://platform.openai.com/docs/models\" target=\"_blank\">documentation</a>.",
+    "optional" : false,
+    "value" : "gpt-4o",
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "model",
+    "binding" : {
+      "name" : "provider.openaiCompatible.model.model",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "provider.type",
+      "equals" : "openaiCompatible",
+      "type" : "simple"
+    },
+    "type" : "String"
+  }, {
+    "id" : "provider.openaiCompatible.model.parameters.maxCompletionTokens",
+    "label" : "Maximum completion tokens",
+    "optional" : true,
+    "feel" : "required",
+    "group" : "model",
+    "binding" : {
+      "name" : "provider.openaiCompatible.model.parameters.maxCompletionTokens",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "provider.type",
+      "equals" : "openaiCompatible",
+      "type" : "simple"
+    },
+    "tooltip" : "The maximum number of tokens per request to generate before stopping. <br><br>Details in the <a href=\"https://platform.openai.com/docs/api-reference/chat/create#chat-create-max_completion_tokens\" target=\"_blank\">documentation</a>.",
+    "type" : "Number"
+  }, {
+    "id" : "provider.openaiCompatible.model.parameters.temperature",
+    "label" : "Temperature",
+    "optional" : true,
+    "feel" : "required",
+    "group" : "model",
+    "binding" : {
+      "name" : "provider.openaiCompatible.model.parameters.temperature",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "provider.type",
+      "equals" : "openaiCompatible",
+      "type" : "simple"
+    },
+    "tooltip" : "Floating point number between 0 and 2. The higher the number, the more randomness will be injected into the response. <br><br>Details in the <a href=\"https://platform.openai.com/docs/api-reference/chat/create#chat-create-temperature\" target=\"_blank\">documentation</a>.",
+    "type" : "Number"
+  }, {
+    "id" : "provider.openaiCompatible.model.parameters.topP",
+    "label" : "top P",
+    "optional" : true,
+    "feel" : "required",
+    "group" : "model",
+    "binding" : {
+      "name" : "provider.openaiCompatible.model.parameters.topP",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "provider.type",
+      "equals" : "openaiCompatible",
+      "type" : "simple"
+    },
+    "tooltip" : "Recommended for advanced use cases only (you usually only need to use temperature). <br><br>Details in the <a href=\"https://platform.openai.com/docs/api-reference/chat/create#chat-create-top_p\" target=\"_blank\">documentation</a>.",
+    "type" : "Number"
+  }, {
+    "id" : "provider.openaiCompatible.model.parameters.customParameters",
+    "label" : "Custom parameters",
+    "description" : "Map of additional request parameters to include.",
+    "optional" : true,
+    "feel" : "required",
+    "group" : "model",
+    "binding" : {
+      "name" : "provider.openaiCompatible.model.parameters.customParameters",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "provider.type",
+      "equals" : "openaiCompatible",
+      "type" : "simple"
+    },
+    "type" : "String"
   }, {
     "id" : "data.systemPrompt.prompt",
     "label" : "System prompt",

--- a/connectors/agentic-ai/element-templates/agenticai-aiagent-job-worker.json
+++ b/connectors/agentic-ai/element-templates/agenticai-aiagent-job-worker.json
@@ -620,7 +620,6 @@
   }, {
     "id" : "provider.openaiCompatible.endpoint",
     "label" : "API endpoint",
-    "description" : "API endpoint.",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -653,6 +652,7 @@
       "equals" : "openaiCompatible",
       "type" : "simple"
     },
+    "tooltip" : "Leave blank if using HTTP headers for authentication.<br>If an Authentication header is specified in the headers, then the API key is ignored.",
     "type" : "String"
   }, {
     "id" : "provider.openaiCompatible.headers",

--- a/connectors/agentic-ai/element-templates/agenticai-aiagent-outbound-connector.json
+++ b/connectors/agentic-ai/element-templates/agenticai-aiagent-outbound-connector.json
@@ -603,7 +603,6 @@
   }, {
     "id" : "provider.openaiCompatible.endpoint",
     "label" : "API endpoint",
-    "description" : "API endpoint.",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -636,6 +635,7 @@
       "equals" : "openaiCompatible",
       "type" : "simple"
     },
+    "tooltip" : "Leave blank if using HTTP headers for authentication.<br>If an Authentication header is specified in the headers, then the API key is ignored.",
     "type" : "String"
   }, {
     "id" : "provider.openaiCompatible.headers",

--- a/connectors/agentic-ai/element-templates/agenticai-aiagent-outbound-connector.json
+++ b/connectors/agentic-ai/element-templates/agenticai-aiagent-outbound-connector.json
@@ -102,6 +102,9 @@
     }, {
       "name" : "OpenAI",
       "value" : "openai"
+    }, {
+      "name" : "OpenAI Compatible",
+      "value" : "openaiCompatible"
     } ]
   }, {
     "id" : "provider.anthropic.endpoint",
@@ -598,6 +601,60 @@
     },
     "type" : "String"
   }, {
+    "id" : "provider.openaiCompatible.endpoint",
+    "label" : "API endpoint",
+    "description" : "API endpoint.",
+    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "provider",
+    "binding" : {
+      "name" : "provider.openaiCompatible.endpoint",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "provider.type",
+      "equals" : "openaiCompatible",
+      "type" : "simple"
+    },
+    "tooltip" : "Specify an endpoint to use the connector with an OpenAI compatible API. ",
+    "type" : "String"
+  }, {
+    "id" : "provider.openaiCompatible.authentication.apiKey",
+    "label" : "API key",
+    "optional" : true,
+    "feel" : "optional",
+    "group" : "provider",
+    "binding" : {
+      "name" : "provider.openaiCompatible.authentication.apiKey",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "provider.type",
+      "equals" : "openaiCompatible",
+      "type" : "simple"
+    },
+    "type" : "String"
+  }, {
+    "id" : "provider.openaiCompatible.headers",
+    "label" : "Headers",
+    "description" : "Map of HTTP headers to add to the request.",
+    "optional" : true,
+    "feel" : "required",
+    "group" : "provider",
+    "binding" : {
+      "name" : "provider.openaiCompatible.headers",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "provider.type",
+      "equals" : "openaiCompatible",
+      "type" : "simple"
+    },
+    "type" : "String"
+  }, {
     "id" : "provider.anthropic.model.model",
     "label" : "Model",
     "description" : "Specify the model ID. Details in the <a href=\"https://docs.anthropic.com/en/docs/about-claude/models/all-models\" target=\"_blank\">documentation</a>.",
@@ -989,6 +1046,95 @@
     },
     "tooltip" : "Recommended for advanced use cases only (you usually only need to use temperature). <br><br>Details in the <a href=\"https://platform.openai.com/docs/api-reference/chat/create#chat-create-top_p\" target=\"_blank\">documentation</a>.",
     "type" : "Number"
+  }, {
+    "id" : "provider.openaiCompatible.model.model",
+    "label" : "Model",
+    "description" : "Specify the model ID. Details in the <a href=\"https://platform.openai.com/docs/models\" target=\"_blank\">documentation</a>.",
+    "optional" : false,
+    "value" : "gpt-4o",
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "model",
+    "binding" : {
+      "name" : "provider.openaiCompatible.model.model",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "provider.type",
+      "equals" : "openaiCompatible",
+      "type" : "simple"
+    },
+    "type" : "String"
+  }, {
+    "id" : "provider.openaiCompatible.model.parameters.maxCompletionTokens",
+    "label" : "Maximum completion tokens",
+    "optional" : true,
+    "feel" : "required",
+    "group" : "model",
+    "binding" : {
+      "name" : "provider.openaiCompatible.model.parameters.maxCompletionTokens",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "provider.type",
+      "equals" : "openaiCompatible",
+      "type" : "simple"
+    },
+    "tooltip" : "The maximum number of tokens per request to generate before stopping. <br><br>Details in the <a href=\"https://platform.openai.com/docs/api-reference/chat/create#chat-create-max_completion_tokens\" target=\"_blank\">documentation</a>.",
+    "type" : "Number"
+  }, {
+    "id" : "provider.openaiCompatible.model.parameters.temperature",
+    "label" : "Temperature",
+    "optional" : true,
+    "feel" : "required",
+    "group" : "model",
+    "binding" : {
+      "name" : "provider.openaiCompatible.model.parameters.temperature",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "provider.type",
+      "equals" : "openaiCompatible",
+      "type" : "simple"
+    },
+    "tooltip" : "Floating point number between 0 and 2. The higher the number, the more randomness will be injected into the response. <br><br>Details in the <a href=\"https://platform.openai.com/docs/api-reference/chat/create#chat-create-temperature\" target=\"_blank\">documentation</a>.",
+    "type" : "Number"
+  }, {
+    "id" : "provider.openaiCompatible.model.parameters.topP",
+    "label" : "top P",
+    "optional" : true,
+    "feel" : "required",
+    "group" : "model",
+    "binding" : {
+      "name" : "provider.openaiCompatible.model.parameters.topP",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "provider.type",
+      "equals" : "openaiCompatible",
+      "type" : "simple"
+    },
+    "tooltip" : "Recommended for advanced use cases only (you usually only need to use temperature). <br><br>Details in the <a href=\"https://platform.openai.com/docs/api-reference/chat/create#chat-create-top_p\" target=\"_blank\">documentation</a>.",
+    "type" : "Number"
+  }, {
+    "id" : "provider.openaiCompatible.model.parameters.customParameters",
+    "label" : "Custom parameters",
+    "description" : "Map of additional request parameters to include.",
+    "optional" : true,
+    "feel" : "required",
+    "group" : "model",
+    "binding" : {
+      "name" : "provider.openaiCompatible.model.parameters.customParameters",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "provider.type",
+      "equals" : "openaiCompatible",
+      "type" : "simple"
+    },
+    "type" : "String"
   }, {
     "id" : "data.systemPrompt.prompt",
     "label" : "System prompt",

--- a/connectors/agentic-ai/element-templates/hybrid/agenticai-aiagent-job-worker-hybrid.json
+++ b/connectors/agentic-ai/element-templates/hybrid/agenticai-aiagent-job-worker-hybrid.json
@@ -625,7 +625,6 @@
   }, {
     "id" : "provider.openaiCompatible.endpoint",
     "label" : "API endpoint",
-    "description" : "API endpoint.",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -658,6 +657,7 @@
       "equals" : "openaiCompatible",
       "type" : "simple"
     },
+    "tooltip" : "Leave blank if using HTTP headers for authentication.<br>If an Authentication header is specified in the headers, then the API key is ignored.",
     "type" : "String"
   }, {
     "id" : "provider.openaiCompatible.headers",

--- a/connectors/agentic-ai/element-templates/hybrid/agenticai-aiagent-job-worker-hybrid.json
+++ b/connectors/agentic-ai/element-templates/hybrid/agenticai-aiagent-job-worker-hybrid.json
@@ -124,6 +124,9 @@
     }, {
       "name" : "OpenAI",
       "value" : "openai"
+    }, {
+      "name" : "OpenAI Compatible",
+      "value" : "openaiCompatible"
     } ]
   }, {
     "id" : "provider.anthropic.endpoint",
@@ -620,6 +623,60 @@
     },
     "type" : "String"
   }, {
+    "id" : "provider.openaiCompatible.endpoint",
+    "label" : "API endpoint",
+    "description" : "API endpoint.",
+    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "provider",
+    "binding" : {
+      "name" : "provider.openaiCompatible.endpoint",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "provider.type",
+      "equals" : "openaiCompatible",
+      "type" : "simple"
+    },
+    "tooltip" : "Specify an endpoint to use the connector with an OpenAI compatible API. ",
+    "type" : "String"
+  }, {
+    "id" : "provider.openaiCompatible.authentication.apiKey",
+    "label" : "API key",
+    "optional" : true,
+    "feel" : "optional",
+    "group" : "provider",
+    "binding" : {
+      "name" : "provider.openaiCompatible.authentication.apiKey",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "provider.type",
+      "equals" : "openaiCompatible",
+      "type" : "simple"
+    },
+    "type" : "String"
+  }, {
+    "id" : "provider.openaiCompatible.headers",
+    "label" : "Headers",
+    "description" : "Map of HTTP headers to add to the request.",
+    "optional" : true,
+    "feel" : "required",
+    "group" : "provider",
+    "binding" : {
+      "name" : "provider.openaiCompatible.headers",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "provider.type",
+      "equals" : "openaiCompatible",
+      "type" : "simple"
+    },
+    "type" : "String"
+  }, {
     "id" : "provider.anthropic.model.model",
     "label" : "Model",
     "description" : "Specify the model ID. Details in the <a href=\"https://docs.anthropic.com/en/docs/about-claude/models/all-models\" target=\"_blank\">documentation</a>.",
@@ -1011,6 +1068,95 @@
     },
     "tooltip" : "Recommended for advanced use cases only (you usually only need to use temperature). <br><br>Details in the <a href=\"https://platform.openai.com/docs/api-reference/chat/create#chat-create-top_p\" target=\"_blank\">documentation</a>.",
     "type" : "Number"
+  }, {
+    "id" : "provider.openaiCompatible.model.model",
+    "label" : "Model",
+    "description" : "Specify the model ID. Details in the <a href=\"https://platform.openai.com/docs/models\" target=\"_blank\">documentation</a>.",
+    "optional" : false,
+    "value" : "gpt-4o",
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "model",
+    "binding" : {
+      "name" : "provider.openaiCompatible.model.model",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "provider.type",
+      "equals" : "openaiCompatible",
+      "type" : "simple"
+    },
+    "type" : "String"
+  }, {
+    "id" : "provider.openaiCompatible.model.parameters.maxCompletionTokens",
+    "label" : "Maximum completion tokens",
+    "optional" : true,
+    "feel" : "required",
+    "group" : "model",
+    "binding" : {
+      "name" : "provider.openaiCompatible.model.parameters.maxCompletionTokens",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "provider.type",
+      "equals" : "openaiCompatible",
+      "type" : "simple"
+    },
+    "tooltip" : "The maximum number of tokens per request to generate before stopping. <br><br>Details in the <a href=\"https://platform.openai.com/docs/api-reference/chat/create#chat-create-max_completion_tokens\" target=\"_blank\">documentation</a>.",
+    "type" : "Number"
+  }, {
+    "id" : "provider.openaiCompatible.model.parameters.temperature",
+    "label" : "Temperature",
+    "optional" : true,
+    "feel" : "required",
+    "group" : "model",
+    "binding" : {
+      "name" : "provider.openaiCompatible.model.parameters.temperature",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "provider.type",
+      "equals" : "openaiCompatible",
+      "type" : "simple"
+    },
+    "tooltip" : "Floating point number between 0 and 2. The higher the number, the more randomness will be injected into the response. <br><br>Details in the <a href=\"https://platform.openai.com/docs/api-reference/chat/create#chat-create-temperature\" target=\"_blank\">documentation</a>.",
+    "type" : "Number"
+  }, {
+    "id" : "provider.openaiCompatible.model.parameters.topP",
+    "label" : "top P",
+    "optional" : true,
+    "feel" : "required",
+    "group" : "model",
+    "binding" : {
+      "name" : "provider.openaiCompatible.model.parameters.topP",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "provider.type",
+      "equals" : "openaiCompatible",
+      "type" : "simple"
+    },
+    "tooltip" : "Recommended for advanced use cases only (you usually only need to use temperature). <br><br>Details in the <a href=\"https://platform.openai.com/docs/api-reference/chat/create#chat-create-top_p\" target=\"_blank\">documentation</a>.",
+    "type" : "Number"
+  }, {
+    "id" : "provider.openaiCompatible.model.parameters.customParameters",
+    "label" : "Custom parameters",
+    "description" : "Map of additional request parameters to include.",
+    "optional" : true,
+    "feel" : "required",
+    "group" : "model",
+    "binding" : {
+      "name" : "provider.openaiCompatible.model.parameters.customParameters",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "provider.type",
+      "equals" : "openaiCompatible",
+      "type" : "simple"
+    },
+    "type" : "String"
   }, {
     "id" : "data.systemPrompt.prompt",
     "label" : "System prompt",

--- a/connectors/agentic-ai/element-templates/hybrid/agenticai-aiagent-outbound-connector-hybrid.json
+++ b/connectors/agentic-ai/element-templates/hybrid/agenticai-aiagent-outbound-connector-hybrid.json
@@ -107,6 +107,9 @@
     }, {
       "name" : "OpenAI",
       "value" : "openai"
+    }, {
+      "name" : "OpenAI Compatible",
+      "value" : "openaiCompatible"
     } ]
   }, {
     "id" : "provider.anthropic.endpoint",
@@ -603,6 +606,60 @@
     },
     "type" : "String"
   }, {
+    "id" : "provider.openaiCompatible.endpoint",
+    "label" : "API endpoint",
+    "description" : "API endpoint.",
+    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "provider",
+    "binding" : {
+      "name" : "provider.openaiCompatible.endpoint",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "provider.type",
+      "equals" : "openaiCompatible",
+      "type" : "simple"
+    },
+    "tooltip" : "Specify an endpoint to use the connector with an OpenAI compatible API. ",
+    "type" : "String"
+  }, {
+    "id" : "provider.openaiCompatible.authentication.apiKey",
+    "label" : "API key",
+    "optional" : true,
+    "feel" : "optional",
+    "group" : "provider",
+    "binding" : {
+      "name" : "provider.openaiCompatible.authentication.apiKey",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "provider.type",
+      "equals" : "openaiCompatible",
+      "type" : "simple"
+    },
+    "type" : "String"
+  }, {
+    "id" : "provider.openaiCompatible.headers",
+    "label" : "Headers",
+    "description" : "Map of HTTP headers to add to the request.",
+    "optional" : true,
+    "feel" : "required",
+    "group" : "provider",
+    "binding" : {
+      "name" : "provider.openaiCompatible.headers",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "provider.type",
+      "equals" : "openaiCompatible",
+      "type" : "simple"
+    },
+    "type" : "String"
+  }, {
     "id" : "provider.anthropic.model.model",
     "label" : "Model",
     "description" : "Specify the model ID. Details in the <a href=\"https://docs.anthropic.com/en/docs/about-claude/models/all-models\" target=\"_blank\">documentation</a>.",
@@ -994,6 +1051,95 @@
     },
     "tooltip" : "Recommended for advanced use cases only (you usually only need to use temperature). <br><br>Details in the <a href=\"https://platform.openai.com/docs/api-reference/chat/create#chat-create-top_p\" target=\"_blank\">documentation</a>.",
     "type" : "Number"
+  }, {
+    "id" : "provider.openaiCompatible.model.model",
+    "label" : "Model",
+    "description" : "Specify the model ID. Details in the <a href=\"https://platform.openai.com/docs/models\" target=\"_blank\">documentation</a>.",
+    "optional" : false,
+    "value" : "gpt-4o",
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "model",
+    "binding" : {
+      "name" : "provider.openaiCompatible.model.model",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "provider.type",
+      "equals" : "openaiCompatible",
+      "type" : "simple"
+    },
+    "type" : "String"
+  }, {
+    "id" : "provider.openaiCompatible.model.parameters.maxCompletionTokens",
+    "label" : "Maximum completion tokens",
+    "optional" : true,
+    "feel" : "required",
+    "group" : "model",
+    "binding" : {
+      "name" : "provider.openaiCompatible.model.parameters.maxCompletionTokens",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "provider.type",
+      "equals" : "openaiCompatible",
+      "type" : "simple"
+    },
+    "tooltip" : "The maximum number of tokens per request to generate before stopping. <br><br>Details in the <a href=\"https://platform.openai.com/docs/api-reference/chat/create#chat-create-max_completion_tokens\" target=\"_blank\">documentation</a>.",
+    "type" : "Number"
+  }, {
+    "id" : "provider.openaiCompatible.model.parameters.temperature",
+    "label" : "Temperature",
+    "optional" : true,
+    "feel" : "required",
+    "group" : "model",
+    "binding" : {
+      "name" : "provider.openaiCompatible.model.parameters.temperature",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "provider.type",
+      "equals" : "openaiCompatible",
+      "type" : "simple"
+    },
+    "tooltip" : "Floating point number between 0 and 2. The higher the number, the more randomness will be injected into the response. <br><br>Details in the <a href=\"https://platform.openai.com/docs/api-reference/chat/create#chat-create-temperature\" target=\"_blank\">documentation</a>.",
+    "type" : "Number"
+  }, {
+    "id" : "provider.openaiCompatible.model.parameters.topP",
+    "label" : "top P",
+    "optional" : true,
+    "feel" : "required",
+    "group" : "model",
+    "binding" : {
+      "name" : "provider.openaiCompatible.model.parameters.topP",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "provider.type",
+      "equals" : "openaiCompatible",
+      "type" : "simple"
+    },
+    "tooltip" : "Recommended for advanced use cases only (you usually only need to use temperature). <br><br>Details in the <a href=\"https://platform.openai.com/docs/api-reference/chat/create#chat-create-top_p\" target=\"_blank\">documentation</a>.",
+    "type" : "Number"
+  }, {
+    "id" : "provider.openaiCompatible.model.parameters.customParameters",
+    "label" : "Custom parameters",
+    "description" : "Map of additional request parameters to include.",
+    "optional" : true,
+    "feel" : "required",
+    "group" : "model",
+    "binding" : {
+      "name" : "provider.openaiCompatible.model.parameters.customParameters",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "provider.type",
+      "equals" : "openaiCompatible",
+      "type" : "simple"
+    },
+    "type" : "String"
   }, {
     "id" : "data.systemPrompt.prompt",
     "label" : "System prompt",

--- a/connectors/agentic-ai/element-templates/hybrid/agenticai-aiagent-outbound-connector-hybrid.json
+++ b/connectors/agentic-ai/element-templates/hybrid/agenticai-aiagent-outbound-connector-hybrid.json
@@ -608,7 +608,6 @@
   }, {
     "id" : "provider.openaiCompatible.endpoint",
     "label" : "API endpoint",
-    "description" : "API endpoint.",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -641,6 +640,7 @@
       "equals" : "openaiCompatible",
       "type" : "simple"
     },
+    "tooltip" : "Leave blank if using HTTP headers for authentication.<br>If an Authentication header is specified in the headers, then the API key is ignored.",
     "type" : "String"
   }, {
     "id" : "provider.openaiCompatible.headers",

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/ChatModelFactoryImpl.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/ChatModelFactoryImpl.java
@@ -25,6 +25,8 @@ import io.camunda.connector.agenticai.aiagent.model.request.provider.BedrockProv
 import io.camunda.connector.agenticai.aiagent.model.request.provider.BedrockProviderConfiguration.AwsAuthentication.AwsStaticCredentialsAuthentication;
 import io.camunda.connector.agenticai.aiagent.model.request.provider.GoogleVertexAiProviderConfiguration;
 import io.camunda.connector.agenticai.aiagent.model.request.provider.GoogleVertexAiProviderConfiguration.GoogleVertexAiAuthentication.ServiceAccountCredentialsAuthentication;
+import io.camunda.connector.agenticai.aiagent.model.request.provider.OpenAiCompatibleProviderConfiguration;
+import io.camunda.connector.agenticai.aiagent.model.request.provider.OpenAiCompatibleProviderConfiguration.OpenAiCompatibleAuthentication;
 import io.camunda.connector.agenticai.aiagent.model.request.provider.OpenAiProviderConfiguration;
 import io.camunda.connector.agenticai.aiagent.model.request.provider.ProviderConfiguration;
 import io.camunda.connector.api.error.ConnectorInputException;
@@ -57,6 +59,8 @@ public class ChatModelFactoryImpl implements ChatModelFactory {
       case GoogleVertexAiProviderConfiguration vertexAi ->
           createGoogleVertexAiChatModelBuilder(vertexAi).build();
       case OpenAiProviderConfiguration openai -> createOpenaiChatModelBuilder(openai).build();
+      case OpenAiCompatibleProviderConfiguration openaiCompatible ->
+          createOpenaiCompatibleChatModelBuilder(openaiCompatible).build();
     };
   }
 
@@ -217,6 +221,38 @@ public class ChatModelFactoryImpl implements ChatModelFactory {
       Optional.ofNullable(modelParameters.temperature())
           .ifPresent(requestParametersBuilder::temperature);
       Optional.ofNullable(modelParameters.topP()).ifPresent(requestParametersBuilder::topP);
+
+      builder.defaultRequestParameters(requestParametersBuilder.build());
+    }
+
+    return builder;
+  }
+
+  protected OpenAiChatModel.OpenAiChatModelBuilder createOpenaiCompatibleChatModelBuilder(
+      OpenAiCompatibleProviderConfiguration configuration) {
+    final var connection = configuration.openaiCompatible();
+
+    final var builder =
+        OpenAiChatModel.builder()
+            .modelName(connection.model().model())
+            .baseUrl(connection.endpoint());
+
+    // apiKey is optional for compatible providers
+    Optional.ofNullable(connection.authentication())
+        .map(OpenAiCompatibleAuthentication::apiKey)
+        .ifPresent(builder::apiKey);
+    Optional.ofNullable(connection.headers()).ifPresent(builder::customHeaders);
+
+    final var modelParameters = connection.model().parameters();
+    if (modelParameters != null) {
+      final var requestParametersBuilder = OpenAiChatRequestParameters.builder();
+      Optional.ofNullable(modelParameters.maxCompletionTokens())
+          .ifPresent(requestParametersBuilder::maxCompletionTokens);
+      Optional.ofNullable(modelParameters.temperature())
+          .ifPresent(requestParametersBuilder::temperature);
+      Optional.ofNullable(modelParameters.topP()).ifPresent(requestParametersBuilder::topP);
+      Optional.ofNullable(modelParameters.customParameters())
+          .ifPresent(requestParametersBuilder::customParameters);
 
       builder.defaultRequestParameters(requestParametersBuilder.build());
     }

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/provider/OpenAiCompatibleProviderConfiguration.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/provider/OpenAiCompatibleProviderConfiguration.java
@@ -30,7 +30,6 @@ public record OpenAiCompatibleProviderConfiguration(
           @TemplateProperty(
               group = "provider",
               label = "API endpoint",
-              description = "API endpoint.",
               tooltip = "Specify an endpoint to use the connector with an OpenAI compatible API. ",
               type = TemplateProperty.PropertyType.String,
               feel = Property.FeelMode.optional,
@@ -51,6 +50,8 @@ public record OpenAiCompatibleProviderConfiguration(
       @TemplateProperty(
               group = "provider",
               label = "API key",
+              tooltip =
+                  "Leave blank if using HTTP headers for authentication.<br>If an Authentication header is specified in the headers, then the API key is ignored.",
               type = TemplateProperty.PropertyType.String,
               feel = Property.FeelMode.optional,
               optional = true)

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/provider/OpenAiCompatibleProviderConfiguration.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/provider/OpenAiCompatibleProviderConfiguration.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.agenticai.aiagent.model.request.provider;
+
+import static io.camunda.connector.agenticai.aiagent.model.request.provider.OpenAiCompatibleProviderConfiguration.OPENAI_COMPATIBLE_ID;
+
+import io.camunda.connector.feel.annotation.FEEL;
+import io.camunda.connector.generator.dsl.Property;
+import io.camunda.connector.generator.java.annotation.TemplateProperty;
+import io.camunda.connector.generator.java.annotation.TemplateSubType;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.util.Map;
+
+@TemplateSubType(id = OPENAI_COMPATIBLE_ID, label = "OpenAI Compatible")
+public record OpenAiCompatibleProviderConfiguration(
+    @Valid @NotNull OpenAiCompatibleConnection openaiCompatible) implements ProviderConfiguration {
+
+  @TemplateProperty(ignore = true)
+  public static final String OPENAI_COMPATIBLE_ID = "openaiCompatible";
+
+  public record OpenAiCompatibleConnection(
+      @NotBlank
+          @TemplateProperty(
+              group = "provider",
+              label = "API endpoint",
+              description = "API endpoint.",
+              tooltip = "Specify an endpoint to use the connector with an OpenAI compatible API. ",
+              type = TemplateProperty.PropertyType.String,
+              feel = Property.FeelMode.optional,
+              constraints = @TemplateProperty.PropertyConstraints(notEmpty = true))
+          String endpoint,
+      @Valid OpenAiCompatibleAuthentication authentication,
+      @FEEL
+          @TemplateProperty(
+              group = "provider",
+              label = "Headers",
+              description = "Map of HTTP headers to add to the request.",
+              feel = Property.FeelMode.required,
+              optional = true)
+          Map<String, String> headers,
+      @Valid @NotNull OpenAiCompatibleModel model) {}
+
+  public record OpenAiCompatibleAuthentication(
+      @TemplateProperty(
+              group = "provider",
+              label = "API key",
+              type = TemplateProperty.PropertyType.String,
+              feel = Property.FeelMode.optional,
+              optional = true)
+          String apiKey) {
+
+    @Override
+    public String toString() {
+      return "OpenAiCompatibleAuthentication{apiKey=[REDACTED]}";
+    }
+  }
+
+  public record OpenAiCompatibleModel(
+      @NotBlank
+          @TemplateProperty(
+              group = "model",
+              label = "Model",
+              description =
+                  "Specify the model ID. Details in the <a href=\"https://platform.openai.com/docs/models\" target=\"_blank\">documentation</a>.",
+              type = TemplateProperty.PropertyType.String,
+              feel = Property.FeelMode.optional,
+              defaultValue = "gpt-4o",
+              defaultValueType = TemplateProperty.DefaultValueType.String,
+              constraints = @TemplateProperty.PropertyConstraints(notEmpty = true))
+          String model,
+      @Valid OpenAiCompatibleModel.OpenAiCompatibleModelParameters parameters) {
+
+    public record OpenAiCompatibleModelParameters(
+        @Min(0)
+            @TemplateProperty(
+                group = "model",
+                label = "Maximum completion tokens",
+                tooltip =
+                    "The maximum number of tokens per request to generate before stopping. <br><br>Details in the <a href=\"https://platform.openai.com/docs/api-reference/chat/create#chat-create-max_completion_tokens\" target=\"_blank\">documentation</a>.",
+                type = TemplateProperty.PropertyType.Number,
+                feel = Property.FeelMode.required,
+                optional = true)
+            Integer maxCompletionTokens,
+        @Min(0)
+            @TemplateProperty(
+                group = "model",
+                label = "Temperature",
+                tooltip =
+                    "Floating point number between 0 and 2. The higher the number, the more randomness will be injected into the response. <br><br>Details in the <a href=\"https://platform.openai.com/docs/api-reference/chat/create#chat-create-temperature\" target=\"_blank\">documentation</a>.",
+                type = TemplateProperty.PropertyType.Number,
+                feel = Property.FeelMode.required,
+                optional = true)
+            Double temperature,
+        @Min(0)
+            @TemplateProperty(
+                group = "model",
+                label = "top P",
+                tooltip =
+                    "Recommended for advanced use cases only (you usually only need to use temperature). <br><br>Details in the <a href=\"https://platform.openai.com/docs/api-reference/chat/create#chat-create-top_p\" target=\"_blank\">documentation</a>.",
+                type = TemplateProperty.PropertyType.Number,
+                feel = Property.FeelMode.required,
+                optional = true)
+            Double topP,
+        @FEEL
+            @TemplateProperty(
+                group = "model",
+                label = "Custom parameters",
+                description = "Map of additional request parameters to include.",
+                feel = Property.FeelMode.required,
+                optional = true)
+            Map<String, Object> customParameters) {}
+  }
+}

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/provider/ProviderConfiguration.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/provider/ProviderConfiguration.java
@@ -10,6 +10,7 @@ import static io.camunda.connector.agenticai.aiagent.model.request.provider.Anth
 import static io.camunda.connector.agenticai.aiagent.model.request.provider.AzureOpenAiProviderConfiguration.AZURE_OPENAI_ID;
 import static io.camunda.connector.agenticai.aiagent.model.request.provider.BedrockProviderConfiguration.BEDROCK_ID;
 import static io.camunda.connector.agenticai.aiagent.model.request.provider.GoogleVertexAiProviderConfiguration.GOOGLE_VERTEX_AI_ID;
+import static io.camunda.connector.agenticai.aiagent.model.request.provider.OpenAiCompatibleProviderConfiguration.OPENAI_COMPATIBLE_ID;
 import static io.camunda.connector.agenticai.aiagent.model.request.provider.OpenAiProviderConfiguration.OPENAI_ID;
 
 import com.fasterxml.jackson.annotation.JsonSubTypes;
@@ -22,7 +23,10 @@ import io.camunda.connector.generator.java.annotation.TemplateDiscriminatorPrope
   @JsonSubTypes.Type(value = BedrockProviderConfiguration.class, name = BEDROCK_ID),
   @JsonSubTypes.Type(value = AzureOpenAiProviderConfiguration.class, name = AZURE_OPENAI_ID),
   @JsonSubTypes.Type(value = GoogleVertexAiProviderConfiguration.class, name = GOOGLE_VERTEX_AI_ID),
-  @JsonSubTypes.Type(value = OpenAiProviderConfiguration.class, name = OPENAI_ID)
+  @JsonSubTypes.Type(value = OpenAiProviderConfiguration.class, name = OPENAI_ID),
+  @JsonSubTypes.Type(
+      value = OpenAiCompatibleProviderConfiguration.class,
+      name = OPENAI_COMPATIBLE_ID)
 })
 @TemplateDiscriminatorProperty(
     label = "Provider",
@@ -35,4 +39,5 @@ public sealed interface ProviderConfiguration
         BedrockProviderConfiguration,
         AzureOpenAiProviderConfiguration,
         GoogleVertexAiProviderConfiguration,
-        OpenAiProviderConfiguration {}
+        OpenAiProviderConfiguration,
+        OpenAiCompatibleProviderConfiguration {}


### PR DESCRIPTION
## Description

We currently have the OpenAI configuration including support for a custom endpoint + custom parameters, but it makes the configuration a bit cumbersome as:
- custom endpoint/parameters are not needed when using OpenAI
- API key is required, but might not be needed when using an OpenAI compatible endpoint (for example Ollama for local testing)
- by looking at the model selection, it might not be obvious that we support OpenAI compatible APIs

In this PR we create a dedicated config entry "OpenAI Compatible", exposing the following configuration options:

- API Endpoint (required)
- API Key (optional)
- HTTP Headers (optional)

On the model configuration, it exposes the same properties as we currently expose for OpenAI, plus a "Custom parameters" property accepting a `Map<String, Object>` of properties which is added to the JSON body by L4J.

The custom endpoint/parameters of the OpenAI configuration are remove in this [PR](https://github.com/camunda/connectors/pull/5312).

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #5085 

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.
- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest release, as this branch will be rebased onto main before the next release.

