### PR TITLE
feat(agentic-ai): remove endpoint and headers from OpenAI provider

### DIFF
--- a/connectors/agentic-ai/element-templates/agenticai-aiagent-job-worker.json
+++ b/connectors/agentic-ai/element-templates/agenticai-aiagent-job-worker.json
@@ -587,41 +587,6 @@
     },
     "type" : "String"
   }, {
-    "id" : "provider.openai.endpoint",
-    "label" : "Custom API endpoint",
-    "description" : "Optional custom API endpoint.",
-    "optional" : true,
-    "feel" : "optional",
-    "group" : "provider",
-    "binding" : {
-      "name" : "provider.openai.endpoint",
-      "type" : "zeebe:input"
-    },
-    "condition" : {
-      "property" : "provider.type",
-      "equals" : "openai",
-      "type" : "simple"
-    },
-    "tooltip" : "Configure a custom OpenAI compatible API endpoint to use the connector with an OpenAI compatible API. Typically ends in <code>/v1</code>.",
-    "type" : "String"
-  }, {
-    "id" : "provider.openai.headers",
-    "label" : "Custom headers",
-    "description" : "Map of custom HTTP headers to add to the request.",
-    "optional" : true,
-    "feel" : "required",
-    "group" : "provider",
-    "binding" : {
-      "name" : "provider.openai.headers",
-      "type" : "zeebe:input"
-    },
-    "condition" : {
-      "property" : "provider.type",
-      "equals" : "openai",
-      "type" : "simple"
-    },
-    "type" : "String"
-  }, {
     "id" : "provider.anthropic.model.model",
     "label" : "Model",
     "description" : "Specify the model ID. Details in the <a href=\"https://docs.anthropic.com/en/docs/about-claude/models/all-models\" target=\"_blank\">documentation</a>.",

--- a/connectors/agentic-ai/element-templates/agenticai-aiagent-outbound-connector.json
+++ b/connectors/agentic-ai/element-templates/agenticai-aiagent-outbound-connector.json
@@ -563,41 +563,6 @@
     },
     "type" : "String"
   }, {
-    "id" : "provider.openai.endpoint",
-    "label" : "Custom API endpoint",
-    "description" : "Optional custom API endpoint.",
-    "optional" : true,
-    "feel" : "optional",
-    "group" : "provider",
-    "binding" : {
-      "name" : "provider.openai.endpoint",
-      "type" : "zeebe:input"
-    },
-    "condition" : {
-      "property" : "provider.type",
-      "equals" : "openai",
-      "type" : "simple"
-    },
-    "tooltip" : "Configure a custom OpenAI compatible API endpoint to use the connector with an OpenAI compatible API. Typically ends in <code>/v1</code>.",
-    "type" : "String"
-  }, {
-    "id" : "provider.openai.headers",
-    "label" : "Custom headers",
-    "description" : "Map of custom HTTP headers to add to the request.",
-    "optional" : true,
-    "feel" : "required",
-    "group" : "provider",
-    "binding" : {
-      "name" : "provider.openai.headers",
-      "type" : "zeebe:input"
-    },
-    "condition" : {
-      "property" : "provider.type",
-      "equals" : "openai",
-      "type" : "simple"
-    },
-    "type" : "String"
-  }, {
     "id" : "provider.anthropic.model.model",
     "label" : "Model",
     "description" : "Specify the model ID. Details in the <a href=\"https://docs.anthropic.com/en/docs/about-claude/models/all-models\" target=\"_blank\">documentation</a>.",

--- a/connectors/agentic-ai/element-templates/hybrid/agenticai-aiagent-job-worker-hybrid.json
+++ b/connectors/agentic-ai/element-templates/hybrid/agenticai-aiagent-job-worker-hybrid.json
@@ -592,41 +592,6 @@
     },
     "type" : "String"
   }, {
-    "id" : "provider.openai.endpoint",
-    "label" : "Custom API endpoint",
-    "description" : "Optional custom API endpoint.",
-    "optional" : true,
-    "feel" : "optional",
-    "group" : "provider",
-    "binding" : {
-      "name" : "provider.openai.endpoint",
-      "type" : "zeebe:input"
-    },
-    "condition" : {
-      "property" : "provider.type",
-      "equals" : "openai",
-      "type" : "simple"
-    },
-    "tooltip" : "Configure a custom OpenAI compatible API endpoint to use the connector with an OpenAI compatible API. Typically ends in <code>/v1</code>.",
-    "type" : "String"
-  }, {
-    "id" : "provider.openai.headers",
-    "label" : "Custom headers",
-    "description" : "Map of custom HTTP headers to add to the request.",
-    "optional" : true,
-    "feel" : "required",
-    "group" : "provider",
-    "binding" : {
-      "name" : "provider.openai.headers",
-      "type" : "zeebe:input"
-    },
-    "condition" : {
-      "property" : "provider.type",
-      "equals" : "openai",
-      "type" : "simple"
-    },
-    "type" : "String"
-  }, {
     "id" : "provider.anthropic.model.model",
     "label" : "Model",
     "description" : "Specify the model ID. Details in the <a href=\"https://docs.anthropic.com/en/docs/about-claude/models/all-models\" target=\"_blank\">documentation</a>.",

--- a/connectors/agentic-ai/element-templates/hybrid/agenticai-aiagent-outbound-connector-hybrid.json
+++ b/connectors/agentic-ai/element-templates/hybrid/agenticai-aiagent-outbound-connector-hybrid.json
@@ -568,41 +568,6 @@
     },
     "type" : "String"
   }, {
-    "id" : "provider.openai.endpoint",
-    "label" : "Custom API endpoint",
-    "description" : "Optional custom API endpoint.",
-    "optional" : true,
-    "feel" : "optional",
-    "group" : "provider",
-    "binding" : {
-      "name" : "provider.openai.endpoint",
-      "type" : "zeebe:input"
-    },
-    "condition" : {
-      "property" : "provider.type",
-      "equals" : "openai",
-      "type" : "simple"
-    },
-    "tooltip" : "Configure a custom OpenAI compatible API endpoint to use the connector with an OpenAI compatible API. Typically ends in <code>/v1</code>.",
-    "type" : "String"
-  }, {
-    "id" : "provider.openai.headers",
-    "label" : "Custom headers",
-    "description" : "Map of custom HTTP headers to add to the request.",
-    "optional" : true,
-    "feel" : "required",
-    "group" : "provider",
-    "binding" : {
-      "name" : "provider.openai.headers",
-      "type" : "zeebe:input"
-    },
-    "condition" : {
-      "property" : "provider.type",
-      "equals" : "openai",
-      "type" : "simple"
-    },
-    "type" : "String"
-  }, {
     "id" : "provider.anthropic.model.model",
     "label" : "Model",
     "description" : "Specify the model ID. Details in the <a href=\"https://docs.anthropic.com/en/docs/about-claude/models/all-models\" target=\"_blank\">documentation</a>.",

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/ChatModelFactoryImpl.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/ChatModelFactoryImpl.java
@@ -206,8 +206,6 @@ public class ChatModelFactoryImpl implements ChatModelFactory {
     Optional.ofNullable(connection.authentication().organizationId())
         .ifPresent(builder::organizationId);
     Optional.ofNullable(connection.authentication().projectId()).ifPresent(builder::projectId);
-    Optional.ofNullable(connection.endpoint()).ifPresent(builder::baseUrl);
-    Optional.ofNullable(connection.headers()).ifPresent(builder::customHeaders);
 
     final var modelParameters = connection.model().parameters();
     if (modelParameters != null) {

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/provider/OpenAiProviderConfiguration.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/provider/OpenAiProviderConfiguration.java
@@ -8,7 +8,6 @@ package io.camunda.connector.agenticai.aiagent.model.request.provider;
 
 import static io.camunda.connector.agenticai.aiagent.model.request.provider.OpenAiProviderConfiguration.OPENAI_ID;
 
-import io.camunda.connector.feel.annotation.FEEL;
 import io.camunda.connector.generator.dsl.Property;
 import io.camunda.connector.generator.java.annotation.TemplateProperty;
 import io.camunda.connector.generator.java.annotation.TemplateSubType;
@@ -16,7 +15,6 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
-import java.util.Map;
 
 @TemplateSubType(id = OPENAI_ID, label = "OpenAI")
 public record OpenAiProviderConfiguration(@Valid @NotNull OpenAiConnection openai)
@@ -26,27 +24,7 @@ public record OpenAiProviderConfiguration(@Valid @NotNull OpenAiConnection opena
   public static final String OPENAI_ID = "openai";
 
   public record OpenAiConnection(
-      @Valid @NotNull OpenAiAuthentication authentication,
-      @TemplateProperty(
-              group = "provider",
-              label = "Custom API endpoint",
-              description = "Optional custom API endpoint.",
-              tooltip =
-                  "Configure a custom OpenAI compatible API endpoint to use the connector with an OpenAI compatible API. "
-                      + "Typically ends in <code>/v1</code>.",
-              type = TemplateProperty.PropertyType.String,
-              feel = Property.FeelMode.optional,
-              optional = true)
-          String endpoint,
-      @FEEL
-          @TemplateProperty(
-              group = "provider",
-              label = "Custom headers",
-              description = "Map of custom HTTP headers to add to the request.",
-              feel = Property.FeelMode.required,
-              optional = true)
-          Map<String, String> headers,
-      @Valid @NotNull OpenAiModel model) {}
+      @Valid @NotNull OpenAiAuthentication authentication, @Valid @NotNull OpenAiModel model) {}
 
   public record OpenAiAuthentication(
       @NotBlank

--- a/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/ChatModelFactoryTest.java
+++ b/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/ChatModelFactoryTest.java
@@ -59,7 +59,6 @@ import io.camunda.connector.agenticai.aiagent.model.request.provider.OpenAiProvi
 import io.camunda.connector.agenticai.aiagent.model.request.provider.OpenAiProviderConfiguration.OpenAiConnection;
 import io.camunda.connector.agenticai.aiagent.model.request.provider.OpenAiProviderConfiguration.OpenAiModel.OpenAiModelParameters;
 import java.net.URI;
-import java.util.Map;
 import java.util.stream.Stream;
 import org.assertj.core.api.ThrowingConsumer;
 import org.junit.jupiter.api.Nested;
@@ -595,8 +594,6 @@ class ChatModelFactoryTest {
           new OpenAiProviderConfiguration(
               new OpenAiConnection(
                   new OpenAiProviderConfiguration.OpenAiAuthentication(OPEN_AI_API_KEY, null, null),
-                  null,
-                  Map.of(),
                   new OpenAiProviderConfiguration.OpenAiModel(
                       OPEN_AI_MODEL, DEFAULT_MODEL_PARAMETERS)));
 
@@ -627,8 +624,6 @@ class ChatModelFactoryTest {
               new OpenAiConnection(
                   new OpenAiProviderConfiguration.OpenAiAuthentication(
                       OPEN_AI_API_KEY, "MY_ORG_ID", "MY_PROJECT_ID"),
-                  null,
-                  Map.of(),
                   new OpenAiProviderConfiguration.OpenAiModel(
                       OPEN_AI_MODEL, DEFAULT_MODEL_PARAMETERS)));
 
@@ -640,25 +635,6 @@ class ChatModelFactoryTest {
           });
     }
 
-    @Test
-    void createsOpenAiChatModelWithCustomEndpointAndHeaders() {
-      final var providerConfig =
-          new OpenAiProviderConfiguration(
-              new OpenAiConnection(
-                  new OpenAiProviderConfiguration.OpenAiAuthentication(OPEN_AI_API_KEY, null, null),
-                  "https://my-custom-endpoint.local/openai/v1",
-                  Map.of("my-header", "my-value"),
-                  new OpenAiProviderConfiguration.OpenAiModel(
-                      OPEN_AI_MODEL, DEFAULT_MODEL_PARAMETERS)));
-
-      testOpenAiChatModelBuilder(
-          providerConfig,
-          (builder) -> {
-            verify(builder).baseUrl("https://my-custom-endpoint.local/openai/v1");
-            verify(builder).customHeaders(Map.of("my-header", "my-value"));
-          });
-    }
-
     @ParameterizedTest
     @NullSource
     @MethodSource("nullModelParameters")
@@ -667,8 +643,6 @@ class ChatModelFactoryTest {
           new OpenAiProviderConfiguration(
               new OpenAiConnection(
                   new OpenAiProviderConfiguration.OpenAiAuthentication(OPEN_AI_API_KEY, null, null),
-                  null,
-                  Map.of(),
                   new OpenAiProviderConfiguration.OpenAiModel(OPEN_AI_MODEL, modelParameters)));
 
       testOpenAiChatModelBuilder(


### PR DESCRIPTION
## Description

The follow up of https://github.com/camunda/connectors/pull/5311 in order to remove the custom endpoint and headers properties from the OpenAI provider configuration.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #5085 

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.
- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest release, as this branch will be rebased onto main before the next release.

