### PR TITLE
fix(runtime): add message to health status update activity logs

### DIFF
--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImpl.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImpl.java
@@ -270,14 +270,27 @@ public class InboundConnectorContextImpl extends AbstractConnectorContext
 
   @Override
   public void reportHealth(Health health) {
-    this.health = health;
-    var activityLog = Activity.newBuilder().andReportHealth(health).build();
+    if (health == null) {
+      throw new IllegalArgumentException("Health must not be null");
+    }
+    if (health.equals(this.health)) {
+      return;
+    }
+    var activityLog =
+        Activity.newBuilder()
+            .withTag(ActivityLogTag.HEALTH)
+            .withMessage(
+                String.format("Health status changed to %s, details: %s",
+                    health.getStatus(),
+                    health.getDetails()))
+            .andReportHealth(health).build();
     // append the activity log to store the health status change history
     activityLogWriter.log(
         new ActivityLogEntry(
             ExecutableId.fromDeduplicationId(connectorDetails.deduplicationId()),
             ActivitySource.CONNECTOR,
             activityLog));
+    this.health = health;
   }
 
   @Override

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImpl.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImpl.java
@@ -280,10 +280,11 @@ public class InboundConnectorContextImpl extends AbstractConnectorContext
         Activity.newBuilder()
             .withTag(ActivityLogTag.HEALTH)
             .withMessage(
-                String.format("Health status changed to %s, details: %s",
-                    health.getStatus(),
-                    health.getDetails()))
-            .andReportHealth(health).build();
+                String.format(
+                    "Health status changed to %s, details: %s",
+                    health.getStatus(), health.getDetails()))
+            .andReportHealth(health)
+            .build();
     // append the activity log to store the health status change history
     activityLogWriter.log(
         new ActivityLogEntry(

--- a/connector-sdk/core/src/main/java/io/camunda/connector/api/inbound/ActivityLogTag.java
+++ b/connector-sdk/core/src/main/java/io/camunda/connector/api/inbound/ActivityLogTag.java
@@ -30,4 +30,5 @@ public class ActivityLogTag {
   public static final String LIFECYCLE = "Lifecycle";
   public static final String QUEUEING = "Queueing";
   public static final String ACTIVATION = "Activation";
+  public static final String HEALTH = "Health";
 }

--- a/connectors/http/polling/src/main/java/io/camunda/connector/http/polling/HttpPollingConnector.java
+++ b/connectors/http/polling/src/main/java/io/camunda/connector/http/polling/HttpPollingConnector.java
@@ -43,7 +43,7 @@ import io.camunda.connector.http.polling.task.ProcessInstancesFetcherTask;
           templateIdOverride = "io.camunda.connectors.http.Polling.Boundary",
           templateNameOverride = "HTTP Polling Boundary Catch Event Connector")
     })
-@InboundConnector(name = "HTTP_POLLING", type = "io.camunda:http-polling:1")
+@InboundConnector(name = "HTTP Polling Connector", type = "io.camunda:http-polling:1")
 public class HttpPollingConnector
     implements InboundConnectorExecutable<InboundIntermediateConnectorContext> {
 


### PR DESCRIPTION
## Description

- Add a meaningful message to automatic activity logs that are triggered on health status updates (otherwise they appear empty in the console)
- Only add those activity logs when the status change is new (otherwise they are logged all the time for some connectors)
- Change polling connector name to the format used in other connectors.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #

## Checklist

- [ ] PR has a **milestone** or the `no milestone` label.
- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest release, as this branch will be rebased onto main before the next release.

