### PR TITLE
fix(idp-extraction-connector): add OpenAI API spec provider

### DIFF
--- a/connectors/idp-extraction/element-templates/hybrid/hybrid-idp-extraction-outbound-connector-hybrid.json
+++ b/connectors/idp-extraction/element-templates/hybrid/hybrid-idp-extraction-outbound-connector-hybrid.json
@@ -164,6 +164,9 @@
     }, {
       "name" : "GCP Provider",
       "value" : "gcp"
+    }, {
+      "name" : "OpenAi API Specification Provider",
+      "value" : "openaispec"
     } ]
   }, {
     "id" : "baseRequest.authentication.type",
@@ -739,6 +742,45 @@
         "equals" : "gcp",
         "type" : "simple"
       } ]
+    },
+    "type" : "String"
+  }, {
+    "id" : "baseRequest.openAiEndpoint",
+    "label" : "OpenAI Spec Endpoint",
+    "description" : "Specify the OpenAI compatible specification endpoint.",
+    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "group" : "configuration",
+    "binding" : {
+      "name" : "baseRequest.openAiEndpoint",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "baseRequest.type",
+      "equals" : "openaispec",
+      "type" : "simple"
+    },
+    "type" : "Text"
+  }, {
+    "id" : "baseRequest.openAiHeaders",
+    "label" : "Headers",
+    "description" : "Map of HTTP headers to add to the request.",
+    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "required",
+    "group" : "configuration",
+    "binding" : {
+      "name" : "baseRequest.openAiHeaders",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "baseRequest.type",
+      "equals" : "openaispec",
+      "type" : "simple"
     },
     "type" : "String"
   }, {

--- a/connectors/idp-extraction/element-templates/idp-extraction-outbound-connector.json
+++ b/connectors/idp-extraction/element-templates/idp-extraction-outbound-connector.json
@@ -159,6 +159,9 @@
     }, {
       "name" : "GCP Provider",
       "value" : "gcp"
+    }, {
+      "name" : "OpenAi API Specification Provider",
+      "value" : "openaispec"
     } ]
   }, {
     "id" : "baseRequest.authentication.type",
@@ -734,6 +737,45 @@
         "equals" : "gcp",
         "type" : "simple"
       } ]
+    },
+    "type" : "String"
+  }, {
+    "id" : "baseRequest.openAiEndpoint",
+    "label" : "OpenAI Spec Endpoint",
+    "description" : "Specify the OpenAI compatible specification endpoint.",
+    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "group" : "configuration",
+    "binding" : {
+      "name" : "baseRequest.openAiEndpoint",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "baseRequest.type",
+      "equals" : "openaispec",
+      "type" : "simple"
+    },
+    "type" : "Text"
+  }, {
+    "id" : "baseRequest.openAiHeaders",
+    "label" : "Headers",
+    "description" : "Map of HTTP headers to add to the request.",
+    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "required",
+    "group" : "configuration",
+    "binding" : {
+      "name" : "baseRequest.openAiHeaders",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "baseRequest.type",
+      "equals" : "openaispec",
+      "type" : "simple"
     },
     "type" : "String"
   }, {

--- a/connectors/idp-extraction/pom.xml
+++ b/connectors/idp-extraction/pom.xml
@@ -103,6 +103,16 @@
         </exclusion>
       </exclusions>
     </dependency>
+
+    <dependency>
+      <groupId>dev.langchain4j</groupId>
+      <artifactId>langchain4j</artifactId>
+    </dependency>
+    
+    <dependency>
+      <groupId>dev.langchain4j</groupId>
+      <artifactId>langchain4j-open-ai</artifactId>
+    </dependency>
   </dependencies>
 
   <build>

--- a/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/caller/OpenAiSpecCaller.java
+++ b/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/caller/OpenAiSpecCaller.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.idp.extraction.caller;
+
+import dev.langchain4j.data.message.SystemMessage;
+import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.model.openai.OpenAiChatModel;
+import io.camunda.connector.idp.extraction.model.ExtractionRequestData;
+import io.camunda.connector.idp.extraction.model.LlmModel;
+import io.camunda.connector.idp.extraction.model.providers.OpenAiSpecProvider;
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class OpenAiSpecCaller {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(OpenAiSpecCaller.class);
+
+  public String call(
+      ExtractionRequestData input, OpenAiSpecProvider provider, String extractedText) {
+    try {
+      LOGGER.debug("Creating OpenAI chat model with endpoint: {}", provider.getOpenAiEndpoint());
+
+      OpenAiChatModel chatModel = createChatModel(input, provider);
+
+      // Get the LLM model based on the model ID, defaulting to CLAUDE
+      LlmModel llmModel = LlmModel.fromId(input.converseData().modelId());
+
+      String systemPrompt = llmModel.getSystemPrompt();
+      String userMessage = llmModel.getMessage(extractedText, input.taxonomyItems());
+
+      LOGGER.debug("Sending request to OpenAI API");
+      var response =
+          llmModel.isSystemPromptAllowed()
+              ? chatModel.chat(
+                  List.of(SystemMessage.from(systemPrompt), UserMessage.from(userMessage)))
+              : chatModel.chat(List.of(UserMessage.from(userMessage)));
+      String responseText = response.aiMessage().text();
+
+      LOGGER.debug("Received response from OpenAI API");
+      return responseText;
+
+    } catch (Exception e) {
+      LOGGER.error("Error calling OpenAI API: {}", e.getMessage(), e);
+      throw new RuntimeException("Failed to call OpenAI API", e);
+    }
+  }
+
+  private OpenAiChatModel createChatModel(
+      ExtractionRequestData input, OpenAiSpecProvider provider) {
+    var converseData = input.converseData();
+
+    var builder =
+        OpenAiChatModel.builder()
+            .baseUrl(provider.getOpenAiEndpoint())
+            .modelName(converseData.modelId())
+            .customHeaders(provider.getOpenAiHeaders())
+            .responseFormat("json_object");
+
+    if (converseData.maxTokens() != null) {
+      builder.maxTokens(converseData.maxTokens());
+    }
+
+    if (converseData.temperature() != null) {
+      builder.temperature(converseData.temperature().doubleValue());
+    }
+
+    if (converseData.topP() != null) {
+      builder.topP(converseData.topP().doubleValue());
+    }
+
+    return builder.build();
+  }
+}

--- a/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/model/providers/OpenAiSpecProvider.java
+++ b/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/model/providers/OpenAiSpecProvider.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.idp.extraction.model.providers;
+
+import io.camunda.connector.feel.annotation.FEEL;
+import io.camunda.connector.generator.dsl.Property;
+import io.camunda.connector.generator.java.annotation.TemplateProperty;
+import io.camunda.connector.generator.java.annotation.TemplateSubType;
+import jakarta.validation.constraints.NotNull;
+import java.util.Map;
+
+@TemplateSubType(id = "openaispec", label = "OpenAi API Specification Provider")
+public final class OpenAiSpecProvider implements ProviderConfig {
+
+  @TemplateProperty(
+      id = "openAiEndpoint",
+      label = "OpenAI Spec Endpoint",
+      group = "configuration",
+      type = TemplateProperty.PropertyType.Text,
+      description = "Specify the OpenAI compatible specification endpoint.",
+      binding = @TemplateProperty.PropertyBinding(name = "openAiEndpoint"),
+      feel = Property.FeelMode.disabled,
+      constraints = @TemplateProperty.PropertyConstraints(notEmpty = true))
+  @NotNull
+  private String openAiEndpoint;
+
+  @FEEL
+  @TemplateProperty(
+      id = "openAiHeaders",
+      label = "Headers",
+      group = "configuration",
+      description = "Map of HTTP headers to add to the request.",
+      feel = Property.FeelMode.required,
+      constraints = @TemplateProperty.PropertyConstraints(notEmpty = true))
+  @NotNull
+  private Map<String, String> openAiHeaders;
+
+  public String getOpenAiEndpoint() {
+    return openAiEndpoint;
+  }
+
+  public void setOpenAiEndpoint(String openAiEndpoint) {
+    this.openAiEndpoint = openAiEndpoint;
+  }
+
+  public Map<String, String> getOpenAiHeaders() {
+    return openAiHeaders;
+  }
+
+  public void setOpenAiHeaders(Map<String, String> openAiHeaders) {
+    this.openAiHeaders = openAiHeaders;
+  }
+}

--- a/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/model/providers/ProviderConfig.java
+++ b/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/model/providers/ProviderConfig.java
@@ -16,7 +16,9 @@ import jakarta.validation.constraints.NotNull;
   @JsonSubTypes.Type(value = AwsProvider.class, name = "aws"),
   @JsonSubTypes.Type(value = AzureProvider.class, name = "azure"),
   @JsonSubTypes.Type(value = GcpProvider.class, name = "gcp"),
+  @JsonSubTypes.Type(value = OpenAiSpecProvider.class, name = "openaispec")
 })
 @NotNull
 @TemplateDiscriminatorProperty(label = "Hyperscaler providers", group = "provider", name = "type")
-public sealed interface ProviderConfig permits AwsProvider, AzureProvider, GcpProvider {}
+public sealed interface ProviderConfig
+    permits AwsProvider, AzureProvider, GcpProvider, OpenAiSpecProvider {}

--- a/connectors/idp-extraction/src/test/java/io/camunda/connector/idp/extraction/caller/OpenAiSpecCallerTest.java
+++ b/connectors/idp-extraction/src/test/java/io/camunda/connector/idp/extraction/caller/OpenAiSpecCallerTest.java
@@ -1,0 +1,206 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.idp.extraction.caller;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.model.openai.OpenAiChatModel;
+import io.camunda.connector.idp.extraction.model.ConverseData;
+import io.camunda.connector.idp.extraction.model.ExtractionRequestData;
+import io.camunda.connector.idp.extraction.model.providers.OpenAiSpecProvider;
+import io.camunda.connector.idp.extraction.util.ExtractionTestUtils;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class OpenAiSpecCallerTest {
+
+  private static class TestOpenAiSpecCaller extends OpenAiSpecCaller {
+    private final OpenAiChatModel mockModel;
+
+    public TestOpenAiSpecCaller(OpenAiChatModel mockModel) {
+      this.mockModel = mockModel;
+    }
+
+    @Override
+    public String call(
+        ExtractionRequestData input, OpenAiSpecProvider provider, String extractedText) {
+      try {
+        ChatResponse response = mockModel.chat(anyList());
+        return response.aiMessage().text();
+      } catch (Exception e) {
+        throw new RuntimeException("Failed to call OpenAI API", e);
+      }
+    }
+  }
+
+  private OpenAiSpecProvider createProvider() {
+    OpenAiSpecProvider provider = new OpenAiSpecProvider();
+    provider.setOpenAiEndpoint("https://api.openai.com/v1");
+    provider.setOpenAiHeaders(Map.of("Authorization", "Bearer test-token"));
+    return provider;
+  }
+
+  private ExtractionRequestData createTestRequestData(String modelId) {
+    ConverseData converseData = new ConverseData(modelId, 512, 0.5f, 0.9f);
+    return new ExtractionRequestData(
+        ExtractionTestUtils.TEXTRACT_EXTRACTION_REQUEST_DATA.document(),
+        ExtractionTestUtils.TEXTRACT_EXTRACTION_REQUEST_DATA.extractionType(),
+        ExtractionTestUtils.TEXTRACT_EXTRACTION_REQUEST_DATA.taxonomyItems(),
+        ExtractionTestUtils.TEXTRACT_EXTRACTION_REQUEST_DATA.includedFields(),
+        ExtractionTestUtils.TEXTRACT_EXTRACTION_REQUEST_DATA.renameMappings(),
+        ExtractionTestUtils.TEXTRACT_EXTRACTION_REQUEST_DATA.delimiter(),
+        converseData);
+  }
+
+  @Test
+  void executeSuccessfulExtraction() {
+    String expectedResponse =
+        """
+        {
+          "name": "John Smith",
+          "age": 32
+        }
+        """;
+
+    OpenAiChatModel mockChatModel = mock(OpenAiChatModel.class);
+    ChatResponse mockResponse = mock(ChatResponse.class);
+    AiMessage mockAiMessage = mock(AiMessage.class);
+
+    when(mockResponse.aiMessage()).thenReturn(mockAiMessage);
+    when(mockAiMessage.text()).thenReturn(expectedResponse);
+    when(mockChatModel.chat(anyList())).thenReturn(mockResponse);
+
+    try (MockedStatic<OpenAiChatModel> chatModelMockedStatic = mockStatic(OpenAiChatModel.class)) {
+      OpenAiSpecProvider provider = createProvider();
+      TestOpenAiSpecCaller testCaller = new TestOpenAiSpecCaller(mockChatModel);
+
+      String result =
+          testCaller.call(createTestRequestData("gpt-4"), provider, "extracted text content");
+
+      assertEquals(expectedResponse, result);
+    }
+  }
+
+  @Test
+  void executeWithClaudeModel() {
+    String expectedResponse =
+        """
+        {
+          "supplier": "ACME Corp",
+          "amount": "1250.00"
+        }
+        """;
+
+    OpenAiChatModel mockChatModel = mock(OpenAiChatModel.class);
+    ChatResponse mockResponse = mock(ChatResponse.class);
+    AiMessage mockAiMessage = mock(AiMessage.class);
+
+    when(mockResponse.aiMessage()).thenReturn(mockAiMessage);
+    when(mockAiMessage.text()).thenReturn(expectedResponse);
+    when(mockChatModel.chat(anyList())).thenReturn(mockResponse);
+
+    OpenAiSpecProvider provider = createProvider();
+    TestOpenAiSpecCaller testCaller = new TestOpenAiSpecCaller(mockChatModel);
+
+    String result =
+        testCaller.call(
+            createTestRequestData("anthropic.claude-3-5-sonnet-20240620-v1:0"),
+            provider,
+            "Invoice from ACME Corp for $1250.00");
+
+    assertEquals(expectedResponse, result);
+  }
+
+  @Test
+  void executeWithGeminiModel() {
+    String expectedResponse =
+        """
+        {
+          "document_type": "receipt",
+          "total": "45.99"
+        }
+        """;
+
+    OpenAiChatModel mockChatModel = mock(OpenAiChatModel.class);
+    ChatResponse mockResponse = mock(ChatResponse.class);
+    AiMessage mockAiMessage = mock(AiMessage.class);
+
+    when(mockResponse.aiMessage()).thenReturn(mockAiMessage);
+    when(mockAiMessage.text()).thenReturn(expectedResponse);
+    when(mockChatModel.chat(anyList())).thenReturn(mockResponse);
+
+    OpenAiSpecProvider provider = createProvider();
+    TestOpenAiSpecCaller testCaller = new TestOpenAiSpecCaller(mockChatModel);
+
+    String result =
+        testCaller.call(
+            createTestRequestData("gemini-1.5-pro"), provider, "Receipt showing total of $45.99");
+
+    assertEquals(expectedResponse, result);
+  }
+
+  @Test
+  void executeWithApiFailure() {
+    OpenAiChatModel mockChatModel = mock(OpenAiChatModel.class);
+    when(mockChatModel.chat(anyList())).thenThrow(new RuntimeException("API Error"));
+
+    OpenAiSpecProvider provider = createProvider();
+    TestOpenAiSpecCaller testCaller = new TestOpenAiSpecCaller(mockChatModel);
+
+    RuntimeException exception =
+        assertThrows(
+            RuntimeException.class,
+            () ->
+                testCaller.call(
+                    createTestRequestData("gpt-4"), provider, "extracted text content"));
+
+    assertEquals("Failed to call OpenAI API", exception.getMessage());
+  }
+
+  @Test
+  void testWithDifferentModelParameters() {
+    String expectedResponse = "{ \"result\": \"success\" }";
+
+    OpenAiChatModel mockChatModel = mock(OpenAiChatModel.class);
+    ChatResponse mockResponse = mock(ChatResponse.class);
+    AiMessage mockAiMessage = mock(AiMessage.class);
+
+    when(mockResponse.aiMessage()).thenReturn(mockAiMessage);
+    when(mockAiMessage.text()).thenReturn(expectedResponse);
+    when(mockChatModel.chat(anyList())).thenReturn(mockResponse);
+
+    OpenAiSpecProvider provider = createProvider();
+    TestOpenAiSpecCaller testCaller = new TestOpenAiSpecCaller(mockChatModel);
+
+    // Test with different converse data parameters (null values)
+    ConverseData converseDataWithNulls = new ConverseData("gpt-3.5-turbo", null, null, null);
+    ExtractionRequestData requestData =
+        new ExtractionRequestData(
+            ExtractionTestUtils.TEXTRACT_EXTRACTION_REQUEST_DATA.document(),
+            ExtractionTestUtils.TEXTRACT_EXTRACTION_REQUEST_DATA.extractionType(),
+            ExtractionTestUtils.TEXTRACT_EXTRACTION_REQUEST_DATA.taxonomyItems(),
+            ExtractionTestUtils.TEXTRACT_EXTRACTION_REQUEST_DATA.includedFields(),
+            ExtractionTestUtils.TEXTRACT_EXTRACTION_REQUEST_DATA.renameMappings(),
+            ExtractionTestUtils.TEXTRACT_EXTRACTION_REQUEST_DATA.delimiter(),
+            converseDataWithNulls);
+
+    String result = testCaller.call(requestData, provider, "test content");
+
+    assertEquals(expectedResponse, result);
+  }
+}

--- a/connectors/idp-extraction/src/test/java/io/camunda/connector/idp/extraction/service/UnstructuredServiceTest.java
+++ b/connectors/idp-extraction/src/test/java/io/camunda/connector/idp/extraction/service/UnstructuredServiceTest.java
@@ -19,6 +19,7 @@ import io.camunda.connector.api.error.ConnectorException;
 import io.camunda.connector.idp.extraction.caller.AzureAiFoundryCaller;
 import io.camunda.connector.idp.extraction.caller.AzureDocumentIntelligenceCaller;
 import io.camunda.connector.idp.extraction.caller.BedrockCaller;
+import io.camunda.connector.idp.extraction.caller.OpenAiSpecCaller;
 import io.camunda.connector.idp.extraction.caller.PollingTextractCaller;
 import io.camunda.connector.idp.extraction.caller.VertexCaller;
 import io.camunda.connector.idp.extraction.model.ExtractionRequest;
@@ -45,6 +46,7 @@ public class UnstructuredServiceTest {
   @Mock private BedrockCaller bedrockCaller;
   @Mock private AzureAiFoundryCaller azureAiFoundryCaller;
   @Mock private AzureDocumentIntelligenceCaller azureDocumentIntelligenceCaller;
+  @Mock private OpenAiSpecCaller openAiSpecCaller;
 
   private UnstructuredService unstructuredService;
 
@@ -67,7 +69,8 @@ public class UnstructuredServiceTest {
             vertexCaller,
             objectMapper,
             azureAiFoundryCaller,
-            azureDocumentIntelligenceCaller);
+            azureDocumentIntelligenceCaller,
+            openAiSpecCaller);
   }
 
   @Test


### PR DESCRIPTION
## Description

This pull request introduces support for an OpenAI-compatible API provider in the IDP extraction connector. It adds new configuration options for specifying an OpenAI endpoint and custom headers, integrates the provider into the extraction service, and includes the necessary dependencies and implementation for making requests to OpenAI-like APIs.

**OpenAI API Provider Integration:**

* Added a new provider type, `"OpenAi API Specification Provider"` (`openaispec`), to the available provider options in both `hybrid-idp-extraction-outbound-connector-hybrid.json` and `idp-extraction-outbound-connector.json`. [[1]](diffhunk://#diff-7f6522a91d253ff95b16d40e75031b47c71dc71037d0e99682ad718b1c10e5e4R167-R169) [[2]](diffhunk://#diff-25cc7be9c0d059bf8019472e4294ad91e5bcb0a329f514563cddef97f25dad6aR162-R164)
* Introduced new configuration fields for the OpenAI provider: `openAiEndpoint` (endpoint URL) and `openAiHeaders` (HTTP headers), with validation and conditional display logic in both element templates. [[1]](diffhunk://#diff-7f6522a91d253ff95b16d40e75031b47c71dc71037d0e99682ad718b1c10e5e4R747-R785) [[2]](diffhunk://#diff-25cc7be9c0d059bf8019472e4294ad91e5bcb0a329f514563cddef97f25dad6aR742-R780)
* Added the `OpenAiSpecProvider` class to represent the new provider, and updated the `ProviderConfig` interface to support it. [[1]](diffhunk://#diff-6b4664e7651355b4cfd6364ae514e311ae29029d2e32911b5b516f04cc2e716eR1-R57) [[2]](diffhunk://#diff-47f3738725adc7a01f25375feb6ea23d0e23d06a078cfd82b92f81464f31b40cR19-R24)

**Implementation and Service Integration:**

* Implemented the `OpenAiSpecCaller` class, which builds and sends requests to the specified OpenAI-compatible endpoint using the `langchain4j` library, and processes responses.
* Updated the `UnstructuredService` class to support extraction using the new OpenAI provider, including wiring up the new caller and handling the provider in the extraction logic. [[1]](diffhunk://#diff-fcde2abb9aa3978be0db860e5283760bb73824ccc871f024074bc60cce9b380cR16) [[2]](diffhunk://#diff-fcde2abb9aa3978be0db860e5283760bb73824ccc871f024074bc60cce9b380cR26-R37) [[3]](diffhunk://#diff-fcde2abb9aa3978be0db860e5283760bb73824ccc871f024074bc60cce9b380cR65-R66) [[4]](diffhunk://#diff-fcde2abb9aa3978be0db860e5283760bb73824ccc871f024074bc60cce9b380cR77) [[5]](diffhunk://#diff-fcde2abb9aa3978be0db860e5283760bb73824ccc871f024074bc60cce9b380cL82-R90) [[6]](diffhunk://#diff-fcde2abb9aa3978be0db860e5283760bb73824ccc871f024074bc60cce9b380cR100) [[7]](diffhunk://#diff-fcde2abb9aa3978be0db860e5283760bb73824ccc871f024074bc60cce9b380cR110) [[8]](diffhunk://#diff-fcde2abb9aa3978be0db860e5283760bb73824ccc871f024074bc60cce9b380cR177-R198)

**Dependencies:**

* Added `langchain4j` and `langchain4j-open-ai` dependencies to the Maven configuration to enable OpenAI API integration.

**PDF Extraction Enhancement:**

* Improved PDF text extraction by switching to use an `InputStream` and `RandomAccessReadBuffer` for better resource management.

## Related issues

closes https://github.com/camunda/connectors/issues/5316

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.
- [x] Backport labels are added if these code changes should be backported. No backport label is added to the latest release, as this branch will be rebased onto main before the next release.

