### PR TITLE
test(agentic-ai): add e2e tests for event sub-process

### DIFF
--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/langchain4j/jobworker/L4JAiAgentJobWorkerEventsTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/langchain4j/jobworker/L4JAiAgentJobWorkerEventsTests.java
@@ -1,0 +1,206 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.e2e.agenticai.aiagent.langchain4j.jobworker;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.SystemMessage;
+import dev.langchain4j.data.message.ToolExecutionResultMessage;
+import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.model.chat.response.ChatResponseMetadata;
+import dev.langchain4j.model.output.FinishReason;
+import dev.langchain4j.model.output.TokenUsage;
+import io.camunda.connector.agenticai.aiagent.model.AgentMetrics;
+import io.camunda.connector.e2e.agenticai.assertj.JobWorkerAgentResponseAssert;
+import io.camunda.connector.test.SlowTest;
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.Resource;
+
+@SlowTest
+public class L4JAiAgentJobWorkerEventsTests extends BaseL4JAiAgentJobWorkerTest {
+
+  @Value("classpath:agentic-ai-ahsp-connectors-event.bpmn")
+  private Resource testProcessWithEvent;
+
+  private static final long MESSAGE_PUBLICATION_DELAY = 2000;
+
+  @Test
+  void messagePublishedBeforeProcessActivation() throws Exception {
+    final var initialUserPrompt = "Explore some of your tools!";
+
+    final var expectedConversation =
+        List.of(
+            new SystemMessage(
+                "You are a helpful AI assistant. Answer all the questions, but always be nice. Explain your thinking."),
+            new UserMessage(initialUserPrompt),
+            new UserMessage("Updated message from event: do not use any tools anymore."),
+            new AiMessage(
+                "Alright, I will not use any tools anymore. How can I assist you further?"));
+
+    mockChatInteractions(
+        ChatInteraction.of(
+            ChatResponse.builder()
+                .metadata(
+                    ChatResponseMetadata.builder()
+                        .finishReason(FinishReason.STOP)
+                        .tokenUsage(new TokenUsage(100, 200))
+                        .build())
+                .aiMessage((AiMessage) expectedConversation.get(3))
+                .build(),
+            userSatisfiedFeedback()));
+
+    publishMessage();
+
+    final var zeebeTest =
+        createProcessInstance(
+            testProcessWithEvent,
+            e -> e,
+            Map.of("action", "executeAgent", "userPrompt", initialUserPrompt));
+
+    zeebeTest.waitForProcessCompletion();
+
+    assertLastChatRequest(expectedConversation, false);
+
+    String expectedResponseText = ((AiMessage) expectedConversation.getLast()).text();
+    assertAgentResponse(
+        zeebeTest,
+        agentResponse ->
+            JobWorkerAgentResponseAssert.assertThat(agentResponse)
+                .isReady()
+                .hasMetrics(new AgentMetrics(1, new AgentMetrics.TokenUsage(100, 200)))
+                .hasResponseMessageText(expectedResponseText)
+                .hasResponseText(expectedResponseText));
+
+    assertThat(jobWorkerCounter.get()).isEqualTo(1);
+  }
+
+  @Test
+  void nonInterruptingMessagePublishedAfterProcessActivation() throws Exception {
+    executesAgentWithToolCallingAndEvent(false);
+  }
+
+  @Test
+  void interruptingMessagePublishedAfterProcessActivation() throws Exception {
+    executesAgentWithToolCallingAndEvent(true);
+  }
+
+  private void executesAgentWithToolCallingAndEvent(boolean interruptToolCalls) throws Exception {
+    final var initialUserPrompt = "Explore some of your tools!";
+    final var secondToolResult =
+        interruptToolCalls
+            ? "Tool execution was canceled."
+            : "No results for 'Where does this data come from?'";
+
+    final var expectedConversation =
+        List.of(
+            new SystemMessage(
+                "You are a helpful AI assistant. Answer all the questions, but always be nice. Explain your thinking."),
+            new UserMessage(initialUserPrompt),
+            new AiMessage(
+                "The user asked me to call some of my tools. I will call the superflux calculation and the task with a text input schema as they look interesting to me.",
+                List.of(
+                    ToolExecutionRequest.builder()
+                        .id("aaa111")
+                        .name("SuperfluxProduct")
+                        .arguments("{\"a\": 5, \"b\": 3}")
+                        .build(),
+                    ToolExecutionRequest.builder()
+                        .id("bbb222")
+                        .name("Search_The_Web")
+                        .arguments("{\"searchQuery\": \"Where does this data come from?\"}")
+                        .build())),
+            new ToolExecutionResultMessage("aaa111", "SuperfluxProduct", "24"),
+            new ToolExecutionResultMessage("bbb222", "Search_The_Web", secondToolResult),
+            new UserMessage("Updated message from event: do not use any tools anymore."),
+            new AiMessage(
+                "Alright, I will not use any tools anymore. How can I assist you further?"));
+
+    mockChatInteractions(
+        ChatInteraction.of(
+            ChatResponse.builder()
+                .metadata(
+                    ChatResponseMetadata.builder()
+                        .finishReason(FinishReason.TOOL_EXECUTION)
+                        .tokenUsage(new TokenUsage(10, 20))
+                        .build())
+                .aiMessage((AiMessage) expectedConversation.get(2))
+                .build()),
+        ChatInteraction.of(
+            ChatResponse.builder()
+                .metadata(
+                    ChatResponseMetadata.builder()
+                        .finishReason(FinishReason.STOP)
+                        .tokenUsage(new TokenUsage(100, 200))
+                        .build())
+                .aiMessage((AiMessage) expectedConversation.get(6))
+                .build(),
+            userSatisfiedFeedback()));
+
+    final var zeebeTest =
+        createProcessInstance(
+            testProcessWithEvent,
+            e ->
+                interruptToolCalls ? e.property("data.events.behavior", "INTERRUPT_TOOL_CALLS") : e,
+            Map.of("action", "executeAgent", "userPrompt", initialUserPrompt));
+
+    publishMessageWithDelay();
+
+    zeebeTest.waitForProcessCompletion();
+
+    assertLastChatRequest(expectedConversation, false);
+
+    String expectedResponseText = ((AiMessage) expectedConversation.getLast()).text();
+    assertAgentResponse(
+        zeebeTest,
+        agentResponse ->
+            JobWorkerAgentResponseAssert.assertThat(agentResponse)
+                .isReady()
+                .hasMetrics(new AgentMetrics(2, new AgentMetrics.TokenUsage(110, 220)))
+                .hasResponseMessageText(expectedResponseText)
+                .hasResponseText(expectedResponseText));
+
+    assertThat(jobWorkerCounter.get()).isEqualTo(1);
+  }
+
+  private void publishMessage() {
+    var messageKey =
+        camundaClient
+            .newPublishMessageCommand()
+            .messageName("ai-agent-message")
+            .correlationKey("ai-agent-message-correlation")
+            .variable("messageFromEvent", "do not use any tools anymore.")
+            .timeToLive(Duration.of(5, ChronoUnit.SECONDS))
+            .execute()
+            .getMessageKey();
+    System.out.println("Published message with key: " + messageKey);
+  }
+
+  private void publishMessageWithDelay() {
+    CompletableFuture.delayedExecutor(MESSAGE_PUBLICATION_DELAY, TimeUnit.MILLISECONDS)
+        .execute(this::publishMessage);
+  }
+}

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/resources/agentic-ai-ahsp-connectors-event.bpmn
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/resources/agentic-ai-ahsp-connectors-event.bpmn
@@ -1,0 +1,305 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bioc="http://bpmn.io/schema/bpmn/biocolor/1.0" xmlns:color="http://www.omg.org/spec/BPMN/non-normative/color/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1gx9y68" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.39.0-rc.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.8.0">
+  <bpmn:process id="Agentic_AI_Connectors" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1lbh2cw</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_1lbh2cw" sourceRef="StartEvent_1" targetRef="Gateway_1adi5t3" />
+    <bpmn:adHocSubProcess id="AI_Agent" name="AI Agent">
+      <bpmn:documentation>My superpowered AI agent</bpmn:documentation>
+      <bpmn:extensionElements>
+        <zeebe:adHoc outputCollection="toolCallResults" outputElement="={&#10;  id: toolCall._meta.id,&#10;  name: toolCall._meta.name,&#10;  content: toolCallResult&#10;}" />
+        <zeebe:taskDefinition type="dummy" retries="0" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_0xt1jbl</bpmn:incoming>
+      <bpmn:outgoing>Flow_1xcihlq</bpmn:outgoing>
+      <bpmn:scriptTask id="GetDateAndTime" name="Get Date and Time">
+        <bpmn:documentation>Returns the current date and time including the timezone.</bpmn:documentation>
+        <bpmn:extensionElements>
+          <zeebe:script expression="=now()" resultVariable="toolCallResult" />
+        </bpmn:extensionElements>
+      </bpmn:scriptTask>
+      <bpmn:scriptTask id="SuperfluxProduct" name="Superflux Product Calculation">
+        <bpmn:documentation>Calculates the superflux product (a very complicated method only this tool can do) given two input numbers</bpmn:documentation>
+        <bpmn:extensionElements>
+          <zeebe:script expression="=3 * (inputA + inputB)" resultVariable="toolCallResult" />
+          <zeebe:ioMapping>
+            <zeebe:input source="=fromAi(toolCall.a, &#34;The first number to be superflux calculated.&#34;, &#34;number&#34;)" target="inputA" />
+            <zeebe:input source="=fromAi(toolCall.b, &#34;The second number to be superflux calculated.&#34;, &#34;number&#34;)" target="inputB" />
+          </zeebe:ioMapping>
+        </bpmn:extensionElements>
+      </bpmn:scriptTask>
+      <bpmn:subProcess id="Event_Subprocess" name="" triggeredByEvent="true">
+        <bpmn:scriptTask id="Event_Follow_Up_Task" name="Event follow-up task">
+          <bpmn:extensionElements>
+            <zeebe:script expression="=&#34;Updated message from event: &#34; + messageFromEvent" resultVariable="toolCallResult" />
+          </bpmn:extensionElements>
+          <bpmn:incoming>Flow_1lr5g2f</bpmn:incoming>
+        </bpmn:scriptTask>
+        <bpmn:startEvent id="An_Event" name="An Event!" isInterrupting="false">
+          <bpmn:outgoing>Flow_1lr5g2f</bpmn:outgoing>
+          <bpmn:messageEventDefinition id="MessageEventDefinition_18sycls" messageRef="Message_1yi97dl" />
+        </bpmn:startEvent>
+        <bpmn:sequenceFlow id="Flow_1lr5g2f" sourceRef="An_Event" targetRef="Event_Follow_Up_Task" />
+      </bpmn:subProcess>
+      <bpmn:scriptTask id="Search_The_Web" name="Search The Web">
+        <bpmn:documentation>Do a web search to find the needed information.</bpmn:documentation>
+        <bpmn:extensionElements>
+          <zeebe:script expression="={&#10;  searchQuery: searchQuery,&#10;  items: []&#10;}" resultVariable="searchResults" />
+          <zeebe:ioMapping>
+            <zeebe:input source="=fromAi(toolCall.searchQuery, &#34;The search query to use&#34;)" target="searchQuery" />
+          </zeebe:ioMapping>
+        </bpmn:extensionElements>
+        <bpmn:outgoing>Flow_0y5jpx6</bpmn:outgoing>
+      </bpmn:scriptTask>
+      <bpmn:intermediateCatchEvent id="Timer_Event" name="Timer">
+        <bpmn:incoming>Flow_0y5jpx6</bpmn:incoming>
+        <bpmn:outgoing>Flow_19shwk2</bpmn:outgoing>
+        <bpmn:timerEventDefinition id="TimerEventDefinition_1jx19o4">
+          <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">PT5S</bpmn:timeDuration>
+        </bpmn:timerEventDefinition>
+      </bpmn:intermediateCatchEvent>
+      <bpmn:scriptTask id="Activity_04kfkv3" name="Follow-up task">
+        <bpmn:extensionElements>
+          <zeebe:script expression="=&#34;No results for &#39;&#34; + searchResults.searchQuery + &#34;&#39;&#34;" resultVariable="toolCallResult" />
+        </bpmn:extensionElements>
+        <bpmn:incoming>Flow_19shwk2</bpmn:incoming>
+      </bpmn:scriptTask>
+      <bpmn:sequenceFlow id="Flow_19shwk2" sourceRef="Timer_Event" targetRef="Activity_04kfkv3" />
+      <bpmn:sequenceFlow id="Flow_0y5jpx6" sourceRef="Search_The_Web" targetRef="Timer_Event" />
+    </bpmn:adHocSubProcess>
+    <bpmn:exclusiveGateway id="Gateway_1onk6us">
+      <bpmn:incoming>Flow_1tj3t23</bpmn:incoming>
+      <bpmn:incoming>Flow_03sjqe3</bpmn:incoming>
+      <bpmn:outgoing>Flow_0xt1jbl</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:endEvent id="EndEvent_ExecuteAgent">
+      <bpmn:incoming>Flow_0c1l0bw</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_0c131w3" sourceRef="User_Feedback" targetRef="Gateway_17hr3ni" />
+    <bpmn:exclusiveGateway id="Gateway_17hr3ni" name="User satisfied?">
+      <bpmn:incoming>Flow_0c131w3</bpmn:incoming>
+      <bpmn:outgoing>Flow_0c1l0bw</bpmn:outgoing>
+      <bpmn:outgoing>Flow_05fbx02</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="Flow_0c1l0bw" sourceRef="Gateway_17hr3ni" targetRef="EndEvent_ExecuteAgent">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=userSatisfied</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:intermediateThrowEvent id="Event_1n6o9ea" name="User follow-up">
+      <bpmn:incoming>Flow_05fbx02</bpmn:incoming>
+      <bpmn:linkEventDefinition id="LinkEventDefinition_0z3eidt" name="user_follow_up" />
+    </bpmn:intermediateThrowEvent>
+    <bpmn:sequenceFlow id="Flow_05fbx02" sourceRef="Gateway_17hr3ni" targetRef="Event_1n6o9ea">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=userSatisfied = null or userSatisfied = false</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_1tj3t23" sourceRef="Event_18sa5ab" targetRef="Gateway_1onk6us" />
+    <bpmn:intermediateCatchEvent id="Event_18sa5ab" name="Handle user follow-up">
+      <bpmn:outgoing>Flow_1tj3t23</bpmn:outgoing>
+      <bpmn:linkEventDefinition id="LinkEventDefinition_0sqwncd" name="user_follow_up" />
+    </bpmn:intermediateCatchEvent>
+    <bpmn:serviceTask id="User_Feedback" name="User Feedback">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="user_feedback" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1xcihlq</bpmn:incoming>
+      <bpmn:outgoing>Flow_0c131w3</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:exclusiveGateway id="Gateway_1adi5t3" name="Includes files?" default="Flow_17zri9w">
+      <bpmn:incoming>Flow_1lbh2cw</bpmn:incoming>
+      <bpmn:outgoing>Flow_1t4ktrm</bpmn:outgoing>
+      <bpmn:outgoing>Flow_17zri9w</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="Flow_1t4ktrm" name="yes" sourceRef="Gateway_1adi5t3" targetRef="Activity_0brv2z1">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=is defined(downloadUrls) and not(is empty(downloadUrls))</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_147xwje" sourceRef="Activity_0brv2z1" targetRef="Gateway_0jd9imt" />
+    <bpmn:exclusiveGateway id="Gateway_0jd9imt">
+      <bpmn:incoming>Flow_147xwje</bpmn:incoming>
+      <bpmn:incoming>Flow_17zri9w</bpmn:incoming>
+      <bpmn:outgoing>Flow_03sjqe3</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="Flow_03sjqe3" sourceRef="Gateway_0jd9imt" targetRef="Gateway_1onk6us" />
+    <bpmn:sequenceFlow id="Flow_17zri9w" name="No files" sourceRef="Gateway_1adi5t3" targetRef="Gateway_0jd9imt" />
+    <bpmn:serviceTask id="Activity_0brv2z1" name="Download files" zeebe:modelerTemplate="io.camunda.connectors.HttpJson.v2" zeebe:modelerTemplateVersion="10" zeebe:modelerTemplateIcon="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTgiIGhlaWdodD0iMTgiIHZpZXdCb3g9IjAgMCAxOCAxOCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZD0iTTE3LjAzMzUgOC45OTk5N0MxNy4wMzM1IDEzLjQ0NzUgMTMuNDI4MSAxNy4wNTI5IDguOTgwNjUgMTcuMDUyOUM0LjUzMzE2IDE3LjA1MjkgMC45Mjc3NjUgMTMuNDQ3NSAwLjkyNzc2NSA4Ljk5OTk3QzAuOTI3NzY1IDQuNTUyNDggNC41MzMxNiAwLjk0NzA4MyA4Ljk4MDY1IDAuOTQ3MDgzQzEzLjQyODEgMC45NDcwODMgMTcuMDMzNSA0LjU1MjQ4IDE3LjAzMzUgOC45OTk5N1oiIGZpbGw9IiM1MDU1NjIiLz4KPHBhdGggZD0iTTQuOTMxMjYgMTQuMTU3MUw2Ljc4MTA2IDMuNzE0NzFIMTAuMTM3NUMxMS4xOTE3IDMuNzE0NzEgMTEuOTgyNCAzLjk4MzIzIDEyLjUwOTUgNC41MjAyN0MxMy4wNDY1IDUuMDQ3MzYgMTMuMzE1IDUuNzMzNTggMTMuMzE1IDYuNTc4OTJDMTMuMzE1IDcuNDQ0MTQgMTMuMDcxNCA4LjE1NTIyIDEyLjU4NDEgOC43MTIxNUMxMi4xMDY3IDkuMjU5MTMgMTEuNDU1MyA5LjYzNzA1IDEwLjYyOTggOS44NDU5TDEyLjA2MTkgMTQuMTU3MUgxMC4zMzE1TDkuMDMzNjQgMTAuMDI0OUg3LjI0MzUxTDYuNTEyNTQgMTQuMTU3MUg0LjkzMTI2Wk03LjQ5NzExIDguNTkyODFIOS4yNDI0OEM5Ljk5ODMyIDguNTkyODEgMTAuNTkwMSA4LjQyMzc0IDExLjAxNzcgOC4wODU2MUMxMS40NTUzIDcuNzM3NTMgMTEuNjc0MSA3LjI2NTEzIDExLjY3NDEgNi42Njg0MkMxMS42NzQxIDYuMTkxMDYgMTEuNTI0OSA1LjgxODExIDExLjIyNjUgNS41NDk1OUMxMC45MjgyIDUuMjcxMTMgMTAuNDU1OCA1LjEzMTkgOS44MDkzNiA1LjEzMTlIOC4xMDg3NEw3LjQ5NzExIDguNTkyODFaIiBmaWxsPSJ3aGl0ZSIvPgo8L3N2Zz4K">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="io.camunda:http-json:1" retries="3" />
+        <zeebe:ioMapping>
+          <zeebe:input source="noAuth" target="authentication.type" />
+          <zeebe:input source="GET" target="method" />
+          <zeebe:input source="=downloadUrl" target="url" />
+          <zeebe:input source="=true" target="storeResponse" />
+          <zeebe:input source="=20" target="connectionTimeoutInSeconds" />
+          <zeebe:input source="=20" target="readTimeoutInSeconds" />
+          <zeebe:input source="=false" target="ignoreNullValues" />
+        </zeebe:ioMapping>
+        <zeebe:taskHeaders>
+          <zeebe:header key="elementTemplateVersion" value="10" />
+          <zeebe:header key="elementTemplateId" value="io.camunda.connectors.HttpJson.v2" />
+          <zeebe:header key="resultExpression" value="={&#10;  document: response.document&#10;}" />
+          <zeebe:header key="retryBackoff" value="PT2S" />
+        </zeebe:taskHeaders>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1t4ktrm</bpmn:incoming>
+      <bpmn:outgoing>Flow_147xwje</bpmn:outgoing>
+      <bpmn:multiInstanceLoopCharacteristics>
+        <bpmn:extensionElements>
+          <zeebe:loopCharacteristics inputCollection="=downloadUrls" inputElement="downloadUrl" outputCollection="downloadedFiles" outputElement="=document" />
+        </bpmn:extensionElements>
+      </bpmn:multiInstanceLoopCharacteristics>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="Flow_0xt1jbl" sourceRef="Gateway_1onk6us" targetRef="AI_Agent" />
+    <bpmn:sequenceFlow id="Flow_1xcihlq" sourceRef="AI_Agent" targetRef="User_Feedback" />
+  </bpmn:process>
+  <bpmn:message id="Message_1yi97dl" name="ai-agent-message">
+    <bpmn:extensionElements>
+      <zeebe:subscription correlationKey="=&#34;ai-agent-message-correlation&#34;" />
+    </bpmn:extensionElements>
+  </bpmn:message>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Agentic_AI_Connectors">
+      <bpmndi:BPMNShape id="StartEvent_1_di" bpmnElement="StartEvent_1">
+        <dc:Bounds x="152" y="202" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_005wn4n_di" bpmnElement="AI_Agent" isExpanded="true">
+        <dc:Bounds x="780" y="170" width="350" height="540" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1sbkoqq_di" bpmnElement="GetDateAndTime">
+        <dc:Bounds x="830" y="220" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0x0a1hy" bpmnElement="SuperfluxProduct">
+        <dc:Bounds x="970" y="220" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0rjolnk" bpmnElement="Event_Subprocess" isExpanded="true">
+        <dc:Bounds x="810" y="560" width="290" height="130" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0mulp05" bpmnElement="Event_Follow_Up_Task">
+        <dc:Bounds x="980" y="580" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0n2qxpu" bpmnElement="An_Event">
+        <dc:Bounds x="837" y="602" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="832" y="645" width="48" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="BPMNEdge_1rloedc" bpmnElement="Flow_1lr5g2f">
+        <di:waypoint x="873" y="620" />
+        <di:waypoint x="980" y="620" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="BPMNShape_17cbwhd" bpmnElement="Search_The_Web">
+        <dc:Bounds x="830" y="330" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1mvvb8k_di" bpmnElement="Timer_Event">
+        <dc:Bounds x="1002" y="352" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1006" y="322" width="29" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1o3zv6d" bpmnElement="Activity_04kfkv3">
+        <dc:Bounds x="970" y="450" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_19shwk2_di" bpmnElement="Flow_19shwk2">
+        <di:waypoint x="1020" y="388" />
+        <di:waypoint x="1020" y="450" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0y5jpx6_di" bpmnElement="Flow_0y5jpx6">
+        <di:waypoint x="930" y="370" />
+        <di:waypoint x="1002" y="370" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Gateway_1onk6us_di" bpmnElement="Gateway_1onk6us" isMarkerVisible="true">
+        <dc:Bounds x="665" y="195" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0i39jej_di" bpmnElement="EndEvent_ExecuteAgent">
+        <dc:Bounds x="1482" y="202" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_17hr3ni_di" bpmnElement="Gateway_17hr3ni" isMarkerVisible="true">
+        <dc:Bounds x="1375" y="195" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1364" y="252" width="73" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_00sn6c6_di" bpmnElement="Event_1n6o9ea" bioc:stroke="#6b3c00" bioc:fill="#ffe0b2" color:background-color="#ffe0b2" color:border-color="#6b3c00">
+        <dc:Bounds x="1382" y="112" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1364" y="89" width="71" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1drpxpw_di" bpmnElement="Event_18sa5ab" bioc:stroke="#6b3c00" bioc:fill="#ffe0b2" color:background-color="#ffe0b2" color:border-color="#6b3c00">
+        <dc:Bounds x="672" y="112" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="660" y="82" width="60" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1cuoacs_di" bpmnElement="User_Feedback">
+        <dc:Bounds x="1200" y="180" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_1adi5t3_di" bpmnElement="Gateway_1adi5t3" isMarkerVisible="true">
+        <dc:Bounds x="265" y="195" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="255" y="252" width="70" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0jd9imt_di" bpmnElement="Gateway_0jd9imt" isMarkerVisible="true">
+        <dc:Bounds x="545" y="195" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0q0nxis_di" bpmnElement="Activity_0brv2z1">
+        <dc:Bounds x="390" y="180" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1lbh2cw_di" bpmnElement="Flow_1lbh2cw">
+        <di:waypoint x="188" y="220" />
+        <di:waypoint x="265" y="220" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0c131w3_di" bpmnElement="Flow_0c131w3">
+        <di:waypoint x="1300" y="220" />
+        <di:waypoint x="1375" y="220" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0c1l0bw_di" bpmnElement="Flow_0c1l0bw">
+        <di:waypoint x="1425" y="220" />
+        <di:waypoint x="1482" y="220" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_05fbx02_di" bpmnElement="Flow_05fbx02">
+        <di:waypoint x="1400" y="195" />
+        <di:waypoint x="1400" y="148" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1tj3t23_di" bpmnElement="Flow_1tj3t23">
+        <di:waypoint x="690" y="148" />
+        <di:waypoint x="690" y="195" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1t4ktrm_di" bpmnElement="Flow_1t4ktrm">
+        <di:waypoint x="315" y="220" />
+        <di:waypoint x="390" y="220" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="344" y="202" width="18" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_147xwje_di" bpmnElement="Flow_147xwje">
+        <di:waypoint x="490" y="220" />
+        <di:waypoint x="545" y="220" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_03sjqe3_di" bpmnElement="Flow_03sjqe3">
+        <di:waypoint x="595" y="220" />
+        <di:waypoint x="665" y="220" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_17zri9w_di" bpmnElement="Flow_17zri9w">
+        <di:waypoint x="290" y="195" />
+        <di:waypoint x="290" y="130" />
+        <di:waypoint x="570" y="130" />
+        <di:waypoint x="570" y="195" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="412" y="112" width="37" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0xt1jbl_di" bpmnElement="Flow_0xt1jbl">
+        <di:waypoint x="715" y="220" />
+        <di:waypoint x="780" y="220" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1xcihlq_di" bpmnElement="Flow_1xcihlq">
+        <di:waypoint x="1130" y="220" />
+        <di:waypoint x="1200" y="220" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>


### PR DESCRIPTION
## Description

E2E tests are missing for https://github.com/camunda/connectors/pull/5236. This PR adds some E2E tests on a simple BPMN process definition. Two event behaviors are tested: 1) wait for all tool call results, 2) interrupt active tool calls. For the former case there are two tests: 1) when the event is submitted before the process is activated, 2) when the event is submitted after the process activation. For the latter case there is one test for when the event is submitted after the process activation.


## Checklist

- [x] PR has a **milestone** or the `no milestone` label.
- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest release, as this branch will be rebased onto main before the next release.

