### PR TITLE
fix(agentic-ai): remove wrongly added `toolCallResults` input variable

### DIFF
--- a/connectors/agentic-ai/bin/transform-ai-agent-job-worker-template.groovy
+++ b/connectors/agentic-ai/bin/transform-ai-agent-job-worker-template.groovy
@@ -102,15 +102,6 @@ json.properties.each { property ->
         updatedProperties.add(property)
 
         updatedProperties.add([
-            id: "toolCallResults",
-            binding: [
-                name: "toolCallResults",
-                type: "zeebe:input"
-            ],
-            type: "Hidden"
-        ])
-
-        updatedProperties.add([
             id: "outputCollection",
             binding: [
                 property: "outputCollection",

--- a/connectors/agentic-ai/element-templates/agenticai-aiagent-job-worker.json
+++ b/connectors/agentic-ai/element-templates/agenticai-aiagent-job-worker.json
@@ -78,13 +78,6 @@
     },
     "type" : "Hidden"
   }, {
-    "id" : "toolCallResults",
-    "binding" : {
-      "name" : "toolCallResults",
-      "type" : "zeebe:input"
-    },
-    "type" : "Hidden"
-  }, {
     "id" : "outputCollection",
     "binding" : {
       "property" : "outputCollection",

--- a/connectors/agentic-ai/element-templates/hybrid/agenticai-aiagent-job-worker-hybrid.json
+++ b/connectors/agentic-ai/element-templates/hybrid/agenticai-aiagent-job-worker-hybrid.json
@@ -83,13 +83,6 @@
     },
     "type" : "String"
   }, {
-    "id" : "toolCallResults",
-    "binding" : {
-      "name" : "toolCallResults",
-      "type" : "zeebe:input"
-    },
-    "type" : "Hidden"
-  }, {
     "id" : "outputCollection",
     "binding" : {
       "property" : "outputCollection",

--- a/connectors/agentic-ai/examples/ai-agent-chat-with-tools/ai-agent-ahsp-chat-with-tools.bpmn
+++ b/connectors/agentic-ai/examples/ai-agent-chat-with-tools/ai-agent-ahsp-chat-with-tools.bpmn
@@ -41,7 +41,6 @@
         <zeebe:adHoc outputCollection="toolCallResults" outputElement="={&#10;  id: toolCall._meta.id,&#10;  name: toolCall._meta.name,&#10;  content: toolCallResult&#10;}" />
         <zeebe:taskDefinition type="io.camunda.agenticai:aiagent-job-worker:1" />
         <zeebe:ioMapping>
-          <zeebe:input target="toolCallResults" />
           <zeebe:input source="bedrock" target="provider.type" />
           <zeebe:input source="us-east-1" target="provider.bedrock.region" />
           <zeebe:input source="credentials" target="provider.bedrock.authentication.type" />


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
The script that transforms the outbound connector element template to the AHSP job worker element templates adds a hidden `toolCallResults` input variable mapping that takes `null` as value. This overrides the value of the `toolCallResults` variable defined in `zeebe:adHoc`. When the AHSP is activated for the first time through an event sub-process this leads to an incident since the engine expects `toolCallResults` to be an array and not `null`.
To fix this we just remove the redundant `toolCallResults` from the element template.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #5325

## Checklist

- [ ] PR has a **milestone** or the `no milestone` label.
- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest release, as this branch will be rebased onto main before the next release.

