### PR TITLE
chore(deps): bump langchain4j to 1.4.0

### DIFF
--- a/connectors/embeddings-vector-database/src/main/java/io/camunda/connector/embeddingstore/AzureVectorStoreFactory.java
+++ b/connectors/embeddings-vector-database/src/main/java/io/camunda/connector/embeddingstore/AzureVectorStoreFactory.java
@@ -7,9 +7,6 @@
 package io.camunda.connector.embeddingstore;
 
 import com.azure.cosmos.ConsistencyLevel;
-import com.azure.cosmos.CosmosClient;
-import com.azure.cosmos.CosmosClientBuilder;
-import com.azure.cosmos.models.CosmosContainerProperties;
 import com.azure.cosmos.models.CosmosVectorDataType;
 import com.azure.cosmos.models.CosmosVectorDistanceFunction;
 import com.azure.cosmos.models.CosmosVectorEmbedding;
@@ -19,11 +16,11 @@ import com.azure.cosmos.models.CosmosVectorIndexType;
 import com.azure.cosmos.models.IncludedPath;
 import com.azure.cosmos.models.IndexingMode;
 import com.azure.cosmos.models.IndexingPolicy;
-import com.azure.cosmos.models.PartitionKeyDefinition;
 import com.azure.identity.ClientSecretCredential;
 import com.azure.identity.ClientSecretCredentialBuilder;
 import dev.langchain4j.data.segment.TextSegment;
 import dev.langchain4j.model.embedding.EmbeddingModel;
+import dev.langchain4j.store.embedding.azure.cosmos.nosql.AzureCosmosDBSearchQueryType;
 import dev.langchain4j.store.embedding.azure.cosmos.nosql.AzureCosmosDbNoSqlEmbeddingStore;
 import dev.langchain4j.store.embedding.azure.search.AzureAiSearchEmbeddingStore;
 import io.camunda.connector.model.embedding.vector.store.AzureAiSearchVectorStore;
@@ -65,17 +62,6 @@ public class AzureVectorStoreFactory {
       AzureCosmosDbNoSqlVectorStore azureCosmosDbNoSqlVectorStore, EmbeddingModel model) {
 
     final var cosmosDbNoSql = azureCosmosDbNoSqlVectorStore.azureCosmosDbNoSql();
-    final var cosmosClientBuilder = new CosmosClientBuilder();
-    cosmosClientBuilder.endpoint(cosmosDbNoSql.endpoint());
-    cosmosClientBuilder.consistencyLevel(mapConsistencyLevel(cosmosDbNoSql.consistencyLevel()));
-    cosmosClientBuilder.contentResponseOnWriteEnabled(true);
-
-    switch (cosmosDbNoSql.authentication()) {
-      case AzureAuthentication.AzureApiKeyAuthentication apiKey ->
-          cosmosClientBuilder.key(apiKey.apiKey());
-      case AzureAuthentication.AzureClientCredentialsAuthentication auth ->
-          cosmosClientBuilder.credential(buildClientSecretCredential(auth));
-    }
 
     final var embedding = new CosmosVectorEmbedding();
     embedding.setPath(COSMOS_DB_VECTOR_EMBEDDING_PATH);
@@ -89,28 +75,27 @@ public class AzureVectorStoreFactory {
     vectorIndexSpec.setPath(COSMOS_DB_VECTOR_EMBEDDING_PATH);
     vectorIndexSpec.setType(mapIndexType(cosmosDbNoSql.vectorIndexType()).toString());
 
-    final var partitionKeyDef = new PartitionKeyDefinition();
-    partitionKeyDef.setPaths(List.of(COSMOS_DB_PARTITION_KEY_PATH));
-
-    final var containerProperties =
-        new CosmosContainerProperties(cosmosDbNoSql.containerName(), partitionKeyDef);
     final var indexingPolicy = new IndexingPolicy();
     indexingPolicy.setIndexingMode(IndexingMode.CONSISTENT);
     indexingPolicy.setIncludedPaths(List.of(new IncludedPath("/*")));
-    containerProperties.setIndexingPolicy(indexingPolicy);
 
-    CosmosClient cosmosClient = cosmosClientBuilder.buildClient();
-    AzureCosmosDbNoSqlEmbeddingStore store =
+    var builder =
         AzureCosmosDbNoSqlEmbeddingStore.builder()
-            .cosmosClient(cosmosClient)
+            .endpoint(cosmosDbNoSql.endpoint())
             .databaseName(cosmosDbNoSql.databaseName())
             .containerName(cosmosDbNoSql.containerName())
             .cosmosVectorEmbeddingPolicy(embeddingPolicy)
-            .cosmosVectorIndexes(List.of(vectorIndexSpec))
-            .containerProperties(containerProperties)
-            .build();
-    //noinspection Convert2MethodRef
-    return ClosableEmbeddingStore.wrap(store, () -> cosmosClient.close());
+            .indexingPolicy(indexingPolicy)
+            .partitionKeyPath(COSMOS_DB_PARTITION_KEY_PATH)
+            .searchQueryType(AzureCosmosDBSearchQueryType.VECTOR);
+
+    switch (cosmosDbNoSql.authentication()) {
+      case AzureAuthentication.AzureApiKeyAuthentication apiKey -> builder.apiKey(apiKey.apiKey());
+      case AzureAuthentication.AzureClientCredentialsAuthentication auth ->
+          builder.tokenCredential(buildClientSecretCredential(auth));
+    }
+
+    return ClosableEmbeddingStore.wrap(builder.build());
   }
 
   private static ClientSecretCredential buildClientSecretCredential(

--- a/connectors/embeddings-vector-database/src/test/java/io/camunda/connector/embeddingstore/DefaultEmbeddingStoreFactoryTest.java
+++ b/connectors/embeddings-vector-database/src/test/java/io/camunda/connector/embeddingstore/DefaultEmbeddingStoreFactoryTest.java
@@ -9,7 +9,6 @@ package io.camunda.connector.embeddingstore;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.assertArg;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
@@ -19,14 +18,12 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.azure.core.credential.TokenCredential;
-import com.azure.cosmos.CosmosClientBuilder;
-import com.azure.cosmos.models.CosmosContainerProperties;
 import com.azure.cosmos.models.CosmosVectorDataType;
 import com.azure.cosmos.models.CosmosVectorDistanceFunction;
 import com.azure.cosmos.models.CosmosVectorEmbeddingPolicy;
-import com.azure.cosmos.models.CosmosVectorIndexType;
 import com.azure.cosmos.models.IncludedPath;
 import com.azure.cosmos.models.IndexingMode;
+import com.azure.cosmos.models.IndexingPolicy;
 import dev.langchain4j.model.embedding.EmbeddingModel;
 import dev.langchain4j.store.embedding.azure.cosmos.nosql.AzureCosmosDbNoSqlEmbeddingStore;
 import dev.langchain4j.store.embedding.azure.search.AzureAiSearchEmbeddingStore;
@@ -127,78 +124,55 @@ class DefaultEmbeddingStoreFactoryTest {
     private void testAzureCosmosDbNoSqlEmbeddingStoreCreation(
         AzureCosmosDbNoSqlVectorStore vectorStore, EmbeddingModel mockModel) {
       var builder = spy(AzureCosmosDbNoSqlEmbeddingStore.builder());
-      try (var mockedConstruction = Mockito.mockConstruction(CosmosClientBuilder.class)) {
-        try (var mockStore =
-            mockStatic(AzureCosmosDbNoSqlEmbeddingStore.class, Answers.CALLS_REAL_METHODS)) {
-          mockStore.when(AzureCosmosDbNoSqlEmbeddingStore::builder).thenReturn(builder);
+      try (var mockStore =
+          mockStatic(AzureCosmosDbNoSqlEmbeddingStore.class, Answers.CALLS_REAL_METHODS)) {
+        mockStore.when(AzureCosmosDbNoSqlEmbeddingStore::builder).thenReturn(builder);
 
-          doReturn(mock(AzureCosmosDbNoSqlEmbeddingStore.class)).when(builder).build();
-          ArgumentCaptor<CosmosVectorEmbeddingPolicy> embeddingPolicyCaptor =
-              ArgumentCaptor.forClass(CosmosVectorEmbeddingPolicy.class);
+        doReturn(mock(AzureCosmosDbNoSqlEmbeddingStore.class)).when(builder).build();
+        ArgumentCaptor<CosmosVectorEmbeddingPolicy> embeddingPolicyCaptor =
+            ArgumentCaptor.forClass(CosmosVectorEmbeddingPolicy.class);
 
-          factory.initializeVectorStore(vectorStore, mockModel, null);
-          verify(builder).build();
+        factory.initializeVectorStore(vectorStore, mockModel, null);
+        verify(builder).build();
 
-          CosmosClientBuilder cosmosClientBuilder = mockedConstruction.constructed().getFirst();
-          verifyCosmosClientBuilder(vectorStore, cosmosClientBuilder);
+        verify(builder).endpoint(vectorStore.azureCosmosDbNoSql().endpoint());
+        verify(builder).databaseName(vectorStore.azureCosmosDbNoSql().databaseName());
+        verify(builder).containerName(vectorStore.azureCosmosDbNoSql().containerName());
 
-          verify(builder).cosmosClient(any());
-          verify(builder).databaseName(vectorStore.azureCosmosDbNoSql().databaseName());
-          verify(builder).containerName(vectorStore.azureCosmosDbNoSql().containerName());
+        verify(builder).cosmosVectorEmbeddingPolicy(embeddingPolicyCaptor.capture());
+        assertThat(embeddingPolicyCaptor.getValue().getVectorEmbeddings().size()).isEqualTo(1);
+        var embedding = embeddingPolicyCaptor.getValue().getVectorEmbeddings().getFirst();
+        assertThat(embedding.getPath())
+            .isEqualTo(AzureVectorStoreFactory.COSMOS_DB_VECTOR_EMBEDDING_PATH);
+        assertThat(embedding.getDataType()).isEqualTo(CosmosVectorDataType.FLOAT32);
+        assertThat(embedding.getEmbeddingDimensions()).isEqualTo(mockModel.dimension());
+        assertThat(embedding.getDistanceFunction()).isEqualTo(CosmosVectorDistanceFunction.COSINE);
 
-          verify(builder).cosmosVectorEmbeddingPolicy(embeddingPolicyCaptor.capture());
-          assertThat(embeddingPolicyCaptor.getValue().getVectorEmbeddings().size()).isEqualTo(1);
-          var embedding = embeddingPolicyCaptor.getValue().getVectorEmbeddings().getFirst();
-          assertThat(embedding.getPath())
-              .isEqualTo(AzureVectorStoreFactory.COSMOS_DB_VECTOR_EMBEDDING_PATH);
-          assertThat(embedding.getDataType()).isEqualTo(CosmosVectorDataType.FLOAT32);
-          assertThat(embedding.getEmbeddingDimensions()).isEqualTo(mockModel.dimension());
-          assertThat(embedding.getDistanceFunction())
-              .isEqualTo(CosmosVectorDistanceFunction.COSINE);
+        ArgumentCaptor<IndexingPolicy> indexingPolicyCaptor =
+            ArgumentCaptor.forClass(IndexingPolicy.class);
+        verify(builder).indexingPolicy(indexingPolicyCaptor.capture());
+        var indexingPolicy = indexingPolicyCaptor.getValue();
+        assertThat(indexingPolicy.getIndexingMode()).isEqualTo(IndexingMode.CONSISTENT);
+        assertThat(indexingPolicy.getIncludedPaths())
+            .extracting(IncludedPath::getPath)
+            .containsExactly("/*");
 
-          verify(builder)
-              .cosmosVectorIndexes(
-                  assertArg(
-                      (vectorIndexes) -> {
-                        assertThat(vectorIndexes).hasSize(1);
-                        var vectorIndex = vectorIndexes.getFirst();
-                        assertThat(vectorIndex.getPath())
-                            .isEqualTo(AzureVectorStoreFactory.COSMOS_DB_VECTOR_EMBEDDING_PATH);
-                        assertThat(vectorIndex.getType())
-                            .isEqualTo(CosmosVectorIndexType.FLAT.toString());
-                      }));
+        verify(builder).partitionKeyPath(AzureVectorStoreFactory.COSMOS_DB_PARTITION_KEY_PATH);
+        verify(builder)
+            .searchQueryType(
+                dev.langchain4j.store.embedding.azure.cosmos.nosql.AzureCosmosDBSearchQueryType
+                    .VECTOR);
 
-          ArgumentCaptor<CosmosContainerProperties> containerPropertiesCaptor =
-              ArgumentCaptor.forClass(CosmosContainerProperties.class);
-          verify(builder).containerProperties(containerPropertiesCaptor.capture());
-
-          var containerProperties = containerPropertiesCaptor.getValue();
-          assertThat(containerProperties.getId())
-              .isEqualTo(vectorStore.azureCosmosDbNoSql().containerName());
-          assertThat(containerProperties.getPartitionKeyDefinition().getPaths())
-              .containsExactly(AzureVectorStoreFactory.COSMOS_DB_PARTITION_KEY_PATH);
-          assertThat(containerProperties.getIndexingPolicy().getIndexingMode())
-              .isEqualTo(IndexingMode.CONSISTENT);
-          assertThat(containerProperties.getIndexingPolicy().getIncludedPaths())
-              .extracting(IncludedPath::getPath)
-              .containsExactly("/*");
-        }
-      }
-    }
-
-    private static void verifyCosmosClientBuilder(
-        AzureCosmosDbNoSqlVectorStore vectorStore, CosmosClientBuilder cosmosClientBuilder) {
-      verify(cosmosClientBuilder).endpoint(vectorStore.azureCosmosDbNoSql().endpoint());
-      verify(cosmosClientBuilder).consistencyLevel(com.azure.cosmos.ConsistencyLevel.STRONG);
-      verify(cosmosClientBuilder).contentResponseOnWriteEnabled(true);
-      switch (vectorStore.azureCosmosDbNoSql().authentication()) {
-        case AzureAuthentication.AzureApiKeyAuthentication(String apiKey) -> {
-          verify(cosmosClientBuilder).key(apiKey);
-          verify(cosmosClientBuilder, never()).credential(any(TokenCredential.class));
-        }
-        case AzureAuthentication.AzureClientCredentialsAuthentication ignored -> {
-          verify(cosmosClientBuilder).credential(any(TokenCredential.class));
-          verify(cosmosClientBuilder, never()).key(anyString());
+        // Verify authentication set on the builder
+        switch (vectorStore.azureCosmosDbNoSql().authentication()) {
+          case AzureAuthentication.AzureApiKeyAuthentication(String apiKey) -> {
+            verify(builder).apiKey(apiKey);
+            verify(builder, never()).tokenCredential(any(TokenCredential.class));
+          }
+          case AzureAuthentication.AzureClientCredentialsAuthentication ignored -> {
+            verify(builder).tokenCredential(any(TokenCredential.class));
+            verify(builder, never()).apiKey(anyString());
+          }
         }
       }
     }

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -151,7 +151,7 @@ limitations under the License.</license.inlineheader>
     <version.auth0.jwt>4.5.0</version.auth0.jwt>
     <version.auth0.jwks>0.23.0</version.auth0.jwks>
     
-    <version.langchain4j>1.3.0</version.langchain4j>
+    <version.langchain4j>1.4.0</version.langchain4j>
 
     <!-- maven plugins (not managed by parent) -->
     <plugin.version.maven-enforcer-plugin>3.6.1</plugin.version.maven-enforcer-plugin>


### PR DESCRIPTION
## Description

Bump the version of `langchain4j` to `1.4.0` and adapt the code.
In the new version of `langchain4j` there has been `[some work](https://github.com/langchain4j/langchain4j/pull/3463)` on `AzureCosmosDbNoSqlEmbeddingStore` in order to expand its functionality. Now a `CosmosClient` is created inside the constructor, and so there is no need to pass an in instance of `CosmosClient` to the builder. The downside of this is that we cannot call the `close()` method on the instance of `CosmosClient` in order to release the resources.

## Checklist

- [ ] PR has a **milestone** or the `no milestone` label.
- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest release, as this branch will be rebased onto main before the next release.

