### PR TITLE
fix: revert "deps(vector-db): bump langchain4j to 1.4.0 (#5330)"

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -151,7 +151,7 @@ limitations under the License.</license.inlineheader>
     <version.auth0.jwt>4.5.0</version.auth0.jwt>
     <version.auth0.jwks>0.23.0</version.auth0.jwks>
     
-    <version.langchain4j>1.4.0</version.langchain4j>
+    <version.langchain4j>1.3.0</version.langchain4j>
 
     <!-- maven plugins (not managed by parent) -->
     <plugin.version.maven-enforcer-plugin>3.6.1</plugin.version.maven-enforcer-plugin>


### PR DESCRIPTION
This reverts commit 56745f0c64c7685aba7ae39fba1d7c1f7ac025b1.

## Description

There is a [bug](https://github.com/langchain4j/langchain4j/issues/3634) in L4J when we retrieve embeddings. We cannot use the new version of L4J until the bug is fixed.

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.
- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest release, as this branch will be rebased onto main before the next release.

