### PR TITLE
chore(renovate): block dev.langchain4j:* updates >= 1.4.0

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -91,6 +91,16 @@
         "release/8.5"
       ],
       "enabled": false
+    },
+    {
+      "description": "Exclude dev.langchain4j artifacts >= 1.4.0",
+      "matchManagers": [
+        "maven"
+      ],
+      "matchPackagePrefixes": [
+        "dev.langchain4j:"
+      ],
+      "allowedVersions": "< 1.4.0"
     }
   ],
   "baseBranches": [


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
The current latest version of langchain4j, `1.4.0`, contains some bugs. Until they are fixed we renovate should not propose updates to this package.

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.
- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest release, as this branch will be rebased onto main before the next release.

