### PR TITLE
fix(agentic-ai): fix API key's tooltip in OpenAI-compatible provider

### DIFF
--- a/connectors/agentic-ai/element-templates/agenticai-aiagent-job-worker.json
+++ b/connectors/agentic-ai/element-templates/agenticai-aiagent-job-worker.json
@@ -617,7 +617,7 @@
       "equals" : "openaiCompatible",
       "type" : "simple"
     },
-    "tooltip" : "Leave blank if using HTTP headers for authentication.<br>If an Authentication header is specified in the headers, then the API key is ignored.",
+    "tooltip" : "Leave blank if using HTTP headers for authentication.<br>If an Authorization header is specified in the headers, then the API key is ignored.",
     "type" : "String"
   }, {
     "id" : "provider.openaiCompatible.headers",

--- a/connectors/agentic-ai/element-templates/agenticai-aiagent-outbound-connector.json
+++ b/connectors/agentic-ai/element-templates/agenticai-aiagent-outbound-connector.json
@@ -600,7 +600,7 @@
       "equals" : "openaiCompatible",
       "type" : "simple"
     },
-    "tooltip" : "Leave blank if using HTTP headers for authentication.<br>If an Authentication header is specified in the headers, then the API key is ignored.",
+    "tooltip" : "Leave blank if using HTTP headers for authentication.<br>If an Authorization header is specified in the headers, then the API key is ignored.",
     "type" : "String"
   }, {
     "id" : "provider.openaiCompatible.headers",

--- a/connectors/agentic-ai/element-templates/hybrid/agenticai-aiagent-job-worker-hybrid.json
+++ b/connectors/agentic-ai/element-templates/hybrid/agenticai-aiagent-job-worker-hybrid.json
@@ -622,7 +622,7 @@
       "equals" : "openaiCompatible",
       "type" : "simple"
     },
-    "tooltip" : "Leave blank if using HTTP headers for authentication.<br>If an Authentication header is specified in the headers, then the API key is ignored.",
+    "tooltip" : "Leave blank if using HTTP headers for authentication.<br>If an Authorization header is specified in the headers, then the API key is ignored.",
     "type" : "String"
   }, {
     "id" : "provider.openaiCompatible.headers",

--- a/connectors/agentic-ai/element-templates/hybrid/agenticai-aiagent-outbound-connector-hybrid.json
+++ b/connectors/agentic-ai/element-templates/hybrid/agenticai-aiagent-outbound-connector-hybrid.json
@@ -605,7 +605,7 @@
       "equals" : "openaiCompatible",
       "type" : "simple"
     },
-    "tooltip" : "Leave blank if using HTTP headers for authentication.<br>If an Authentication header is specified in the headers, then the API key is ignored.",
+    "tooltip" : "Leave blank if using HTTP headers for authentication.<br>If an Authorization header is specified in the headers, then the API key is ignored.",
     "type" : "String"
   }, {
     "id" : "provider.openaiCompatible.headers",

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/provider/OpenAiCompatibleProviderConfiguration.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/provider/OpenAiCompatibleProviderConfiguration.java
@@ -51,7 +51,7 @@ public record OpenAiCompatibleProviderConfiguration(
               group = "provider",
               label = "API key",
               tooltip =
-                  "Leave blank if using HTTP headers for authentication.<br>If an Authentication header is specified in the headers, then the API key is ignored.",
+                  "Leave blank if using HTTP headers for authentication.<br>If an Authorization header is specified in the headers, then the API key is ignored.",
               type = TemplateProperty.PropertyType.String,
               feel = Property.FeelMode.optional,
               optional = true)


### PR DESCRIPTION
## Description

In the tooltip for API key in OpenAI compatible provider configuration we use the word **Authentication header** instead of **Authorization header**.

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.
- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest release, as this branch will be rebased onto main before the next release.

