### PR TITLE
chore(ci): Fix QA workflow

### DIFF
--- a/.github/workflows/ENFORCE_QA_APPROVAL.yml
+++ b/.github/workflows/ENFORCE_QA_APPROVAL.yml
@@ -37,11 +37,11 @@ jobs:
             const repoOwner = context.repo.owner;
             const repoName = context.repo.repo;
             
-            const octokit = new github.constructor({
+            const githubWithOrgAccess = new github.constructor({
               auth: process.env.TOKEN,
             });
-            
-            const teamMembersResponse = await octokit.rest.teams.listMembersInOrg({
+  
+            const teamMembersResponse = await githubWithOrgAccess.rest.teams.listMembersInOrg({
               org: "camunda",
               team_slug: "qa-engineering",
             })


### PR DESCRIPTION
## Description

PR changes succeeded [here](https://github.com/camunda/connectors/actions/runs/17543923710)
I think we need to force-merge this, as we can use `pull_request` instead of `pull_request_target` to fix this, but there is nothing similar for `pull_request_review`. Who has permissions to do this?

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.
- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest release, as this branch will be rebased onto main before the next release.

