### PR TITLE
fix(runtime): A result expression with a null mappedResponse can lead…

### DIFF
--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/ConnectorHelper.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/ConnectorHelper.java
@@ -59,9 +59,13 @@ public class ConnectorHelper {
       var mappedResponseJson =
           FEEL_ENGINE_WRAPPER.evaluateToJson(
               resultExpression, responseContent, wrapResponse(responseContent));
-      var mappedResponse =
-          parseJsonVarsAsTypeOrThrow(mappedResponseJson, Map.class, resultExpression);
-      outputVariables.putAll(mappedResponse);
+      if (mappedResponseJson != null) {
+        var mappedResponse =
+            parseJsonVarsAsTypeOrThrow(mappedResponseJson, Map.class, resultExpression);
+        if (mappedResponse != null) {
+          outputVariables.putAll(mappedResponse);
+        }
+      }
     }
 
     return outputVariables;

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/ConnectorHelperTest.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/ConnectorHelperTest.java
@@ -16,13 +16,14 @@
  */
 package io.camunda.connector.runtime.core;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Map;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 class ConnectorHelperTest {
@@ -30,9 +31,17 @@ class ConnectorHelperTest {
   @Test
   void feelEngineWrapperTest() throws JsonProcessingException {
     final var jsonDeserialized = Map.of("data", LocalDate.of(2024, 1, 1));
-    Assertions.assertThat(
-            ConnectorHelper.FEEL_ENGINE_WRAPPER.evaluateToJson("{res: data}", jsonDeserialized))
+    assertThat(ConnectorHelper.FEEL_ENGINE_WRAPPER.evaluateToJson("{res: data}", jsonDeserialized))
         .isEqualTo("{\"res\":\"2024-01-01\"}");
+
+    assertThat(ConnectorHelper.FEEL_ENGINE_WRAPPER.evaluateToJson("\"test\"", jsonDeserialized))
+        .isEqualTo("\"test\"");
+
+    assertThat(ConnectorHelper.FEEL_ENGINE_WRAPPER.evaluateToJson("test", jsonDeserialized))
+        .isEqualTo(null);
+
+    assertThat(ConnectorHelper.FEEL_ENGINE_WRAPPER.evaluateToJson("null", jsonDeserialized))
+        .isEqualTo(null);
 
     final var jsonDeserialized2 =
         Map.of(
@@ -55,7 +64,7 @@ class ConnectorHelperTest {
 				""",
                 jsonDeserialized2),
             new TypeReference<Map<String, Object>>() {});
-    Assertions.assertThat(actual)
+    assertThat(actual)
         .contains(
             Map.entry("res1", "2024-01-01"),
             Map.entry("res2", "hallo2024-01-01"),

--- a/connector-sdk/feel-wrapper/src/main/java/io/camunda/connector/feel/FeelEngineWrapper.java
+++ b/connector-sdk/feel-wrapper/src/main/java/io/camunda/connector/feel/FeelEngineWrapper.java
@@ -268,8 +268,10 @@ public class FeelEngineWrapper {
    */
   public String evaluateToJson(final String expression, final Object... variables) {
     try {
-
-      return resultToJson(evaluateInternal(expression, variables));
+      var result = evaluateInternal(expression, variables);
+      if (result != null) {
+        return resultToJson(result);
+      } else return null;
     } catch (Exception e) {
       throw new FeelEngineWrapperException(e.getMessage(), expression, variables, e);
     }


### PR DESCRIPTION
… to a NullPointerException

## Description

## Related issues

closes #4298

## Checklist

- [ ] PR has a **milestone** or the `no milestone` label.
- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest release, as this branch will be rebased onto main before the next release.

