### PR TITLE
other(build): stop publishing bundle jars to central

### DIFF
--- a/bundle/camunda-saas-bundle/pom.xml
+++ b/bundle/camunda-saas-bundle/pom.xml
@@ -13,6 +13,7 @@
 
   <properties>
     <skip.central.release>true</skip.central.release>
+    <skip.camunda.release>false</skip.camunda.release>
   </properties>
 
   <dependencies>

--- a/bundle/camunda-saas-bundle/pom.xml
+++ b/bundle/camunda-saas-bundle/pom.xml
@@ -11,6 +11,10 @@
   <name>Connector Runtime Bundle Saas</name>
   <packaging>jar</packaging>
 
+  <properties>
+    <skip.central.release>true</skip.central.release>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>io.camunda.connector</groupId>

--- a/bundle/camunda-saas-bundle/pom.xml
+++ b/bundle/camunda-saas-bundle/pom.xml
@@ -13,7 +13,7 @@
 
   <properties>
     <skip.central.release>true</skip.central.release>
-    <skip.camunda.release>false</skip.camunda.release>
+    <skip.camunda.release>true</skip.camunda.release>
   </properties>
 
   <dependencies>

--- a/bundle/default-bundle/pom.xml
+++ b/bundle/default-bundle/pom.xml
@@ -14,6 +14,7 @@
 
   <properties>
     <skip.central.release>true</skip.central.release>
+    <skip.camunda.release>false</skip.camunda.release>
   </properties>
 
   <dependencies>

--- a/bundle/default-bundle/pom.xml
+++ b/bundle/default-bundle/pom.xml
@@ -12,6 +12,10 @@
   <name>Connector Runtime Bundle</name>
   <description>Connectors Runtime Bundle including out-of-the-box connectors</description>
 
+  <properties>
+    <skip.central.release>true</skip.central.release>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>io.camunda.connector</groupId>

--- a/bundle/default-bundle/pom.xml
+++ b/bundle/default-bundle/pom.xml
@@ -14,7 +14,7 @@
 
   <properties>
     <skip.central.release>true</skip.central.release>
-    <skip.camunda.release>false</skip.camunda.release>
+    <skip.camunda.release>true</skip.camunda.release>
   </properties>
 
   <dependencies>

--- a/connector-runtime/connector-runtime-application/pom.xml
+++ b/connector-runtime/connector-runtime-application/pom.xml
@@ -13,6 +13,11 @@
   <artifactId>connector-runtime-application</artifactId>
   <name>Connector Runtime Application</name>
 
+  <properties>
+    <skip.central.release>true</skip.central.release>
+    <skip.camunda.release>false</skip.camunda.release>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>io.camunda.connector</groupId>

--- a/connector-runtime/connector-runtime-application/pom.xml
+++ b/connector-runtime/connector-runtime-application/pom.xml
@@ -15,7 +15,7 @@
 
   <properties>
     <skip.central.release>true</skip.central.release>
-    <skip.camunda.release>false</skip.camunda.release>
+    <skip.camunda.release>true</skip.camunda.release>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
## Description

Stop publishing executable bundles to maven central

## Related issues

<!-- Which issues are closed by this PR or are related -->

related to https://github.com/camunda/connectors/issues/5328

## Checklist

- [ ] PR has a **milestone** or the `no milestone` label.
- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest release, as this branch will be rebased onto main before the next release.

