### PR TITLE
fix: helm chart version branch release/8.6

### DIFF
--- a/.github/workflows/helm-git-refs.json
+++ b/.github/workflows/helm-git-refs.json
@@ -1,5 +1,5 @@
 {
-  "main": "camunda-platform-alpha",
+  "main": "camunda-platform-8.6",
   "release/8.7": "camunda-platform-alpha",
   "release/8.6": "camunda-platform-8.6",
   "release/8.5": "camunda-platform-8.5",


### PR DESCRIPTION
## Description
changing helm chart dir name for correct version in helm-git-refs.json from in `release/8.6`
`camunda-platform-alpha` > `camunda-platform-8.6`

## Related issues
see [slack](https://camunda.slack.com/archives/C05K4TAEPDW/p1757505356756499)
closes #

## Checklist

- [ ] PR has a **milestone** or the `no milestone` label.
- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest release, as this branch will be rebased onto main before the next release.

