### PR TITLE
fix(agentic-ai): fix tests using CamundaClient's usePlaintext() method

### DIFF
--- a/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/agent/JobWorkerAgentRequestHandlerTest.java
+++ b/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/agent/JobWorkerAgentRequestHandlerTest.java
@@ -142,7 +142,6 @@ class JobWorkerAgentRequestHandlerTest {
   void setUp(final WireMockRuntimeInfo wireMockRuntimeInfo) throws URISyntaxException {
     camundaClient =
         CamundaClient.newClientBuilder()
-            .usePlaintext()
             .preferRestOverGrpc(true)
             .restAddress(new URI(wireMockRuntimeInfo.getHttpBaseUrl()))
             .build();

--- a/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/jobworker/AiAgentJobWorkerErrorHandlerTest.java
+++ b/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/jobworker/AiAgentJobWorkerErrorHandlerTest.java
@@ -62,7 +62,6 @@ class AiAgentJobWorkerErrorHandlerTest {
     camundaClient =
         spy(
             CamundaClient.newClientBuilder()
-                .usePlaintext()
                 .preferRestOverGrpc(true)
                 .restAddress(new URI(wireMockRuntimeInfo.getHttpBaseUrl()))
                 .build());


### PR DESCRIPTION
## Description

Update tests using `CamundaClient` to not use the removed `usePlaintext()` method.

## Related issues

<!-- Which issues are closed by this PR or are related -->

See https://camunda.slack.com/archives/C08BHU6JQJG/p1757575038528339

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.
- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest release, as this branch will be rebased onto main before the next release.

