### PR TITLE
test(agentic-ai): use full ad-hoc sub-process element template in e2e tests

### DIFF
--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/AiAgentTestFixtures.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/AiAgentTestFixtures.java
@@ -43,7 +43,7 @@ public interface AiAgentTestFixtures {
           Map.entry("provider.openai.model.model", "gpt-4o"),
           Map.entry(
               "data.systemPrompt.prompt",
-              "You are a helpful AI assistant. Answer all the questions, but always be nice. Explain your thinking."),
+              "=\"You are a helpful AI assistant. Answer all the questions, but always be nice. Explain your thinking.\""),
           Map.entry(
               "data.userPrompt.prompt",
               "=if (is defined(followUpUserPrompt)) then followUpUserPrompt else userPrompt"),
@@ -66,7 +66,7 @@ public interface AiAgentTestFixtures {
           Map.entry("provider.openai.model.model", "gpt-4o"),
           Map.entry(
               "data.systemPrompt.prompt",
-              "You are a helpful AI assistant. Answer all the questions, but always be nice. Explain your thinking."),
+              "=\"You are a helpful AI assistant. Answer all the questions, but always be nice. Explain your thinking.\""),
           Map.entry(
               "data.userPrompt.prompt",
               "=if (is defined(followUpUserPrompt)) then followUpUserPrompt else userPrompt"),

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/BaseAiAgentJobWorkerTest.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/BaseAiAgentJobWorkerTest.java
@@ -21,11 +21,9 @@ import static io.camunda.connector.e2e.agenticai.aiagent.AiAgentTestFixtures.AI_
 import static io.camunda.connector.e2e.agenticai.aiagent.AiAgentTestFixtures.AI_AGENT_JOB_WORKER_ELEMENT_TEMPLATE_PROPERTIES;
 
 import io.camunda.connector.agenticai.aiagent.model.JobWorkerAgentResponse;
-import io.camunda.connector.e2e.ElementTemplate;
 import io.camunda.connector.e2e.ZeebeTest;
 import io.camunda.process.test.api.CamundaAssert;
 import java.util.Map;
-import java.util.function.Function;
 import org.assertj.core.api.ThrowingConsumer;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.Resource;
@@ -47,18 +45,6 @@ public abstract class BaseAiAgentJobWorkerTest extends BaseAiAgentTest {
   @Override
   protected Map<String, String> elementTemplateProperties() {
     return AI_AGENT_JOB_WORKER_ELEMENT_TEMPLATE_PROPERTIES;
-  }
-
-  @Override
-  protected ElementTemplate elementTemplateWithModifications(
-      String elementTemplatePath,
-      Function<ElementTemplate, ElementTemplate> elementTemplateModifier) {
-    final var elementTemplate =
-        super.elementTemplateWithModifications(elementTemplatePath, elementTemplateModifier);
-
-    // TODO JW remove this as soon as supported by the element template. Also, remove the attributes
-    // from the BPMN file as we want to test that they are properly applied via template
-    return elementTemplate.withoutProperty("outputElement").withoutProperty("outputCollection");
   }
 
   protected void assertAgentResponse(

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/resources/agentic-ai-ahsp-connectors-event.bpmn
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/resources/agentic-ai-ahsp-connectors-event.bpmn
@@ -8,7 +8,6 @@
     <bpmn:adHocSubProcess id="AI_Agent" name="AI Agent">
       <bpmn:documentation>My superpowered AI agent</bpmn:documentation>
       <bpmn:extensionElements>
-        <zeebe:adHoc outputCollection="toolCallResults" outputElement="={&#10;  id: toolCall._meta.id,&#10;  name: toolCall._meta.name,&#10;  content: toolCallResult&#10;}" />
         <zeebe:taskDefinition type="dummy" retries="0" />
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_0xt1jbl</bpmn:incoming>

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/resources/agentic-ai-ahsp-connectors-mcp.bpmn
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/resources/agentic-ai-ahsp-connectors-mcp.bpmn
@@ -7,7 +7,6 @@
     <bpmn:sequenceFlow id="Flow_1lbh2cw" sourceRef="StartEvent_1" targetRef="Gateway_1adi5t3" />
     <bpmn:adHocSubProcess id="AI_Agent" name="AI Agent">
       <bpmn:extensionElements>
-        <zeebe:adHoc outputCollection="toolCallResults" outputElement="={&#10;  id: toolCall._meta.id,&#10;  name: toolCall._meta.name,&#10;  content: toolCallResult&#10;}" />
         <zeebe:taskDefinition type="dummy" retries="0" />
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_1p3wcva</bpmn:incoming>

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/resources/agentic-ai-ahsp-connectors.bpmn
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/resources/agentic-ai-ahsp-connectors.bpmn
@@ -8,7 +8,6 @@
     <bpmn:adHocSubProcess id="AI_Agent" name="AI Agent">
       <bpmn:documentation>My superpowered AI agent</bpmn:documentation>
       <bpmn:extensionElements>
-        <zeebe:adHoc outputCollection="toolCallResults" outputElement="={&#10;  id: toolCall._meta.id,&#10;  name: toolCall._meta.name,&#10;  content: toolCallResult&#10;}" />
         <zeebe:taskDefinition type="dummy" retries="0" />
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_0xt1jbl</bpmn:incoming>


### PR DESCRIPTION
## Description

Updates e2e tests to start from an unconfigured ad-hoc sub-process and to apply the full template, including outputElement and collection.

Depends on latest version `0.5.0` of [element-templates-cli](https://github.com/bpmn-io/element-templates-cli).

## Related issues

closes #5238

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.
- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest release, as this branch will be rebased onto main before the next release.

