### PR TITLE
fix(agentic-ai): Make user prompt mandatory

### DIFF
--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/PromptConfiguration.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/PromptConfiguration.java
@@ -10,6 +10,7 @@ import io.camunda.connector.api.document.Document;
 import io.camunda.connector.feel.annotation.FEEL;
 import io.camunda.connector.generator.dsl.Property;
 import io.camunda.connector.generator.java.annotation.TemplateProperty;
+import jakarta.validation.constraints.NotBlank;
 import java.util.List;
 
 public interface PromptConfiguration {
@@ -45,7 +46,8 @@ Reveal **no** additional private reasoning outside these tags.\"""";
   }
 
   record UserPromptConfiguration(
-      @FEEL
+      @NotBlank
+          @FEEL
           @TemplateProperty(
               group = "userPrompt",
               label = "User prompt",

--- a/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/model/request/PromptConfigurationTest.java
+++ b/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/model/request/PromptConfigurationTest.java
@@ -7,9 +7,11 @@
 package io.camunda.connector.agenticai.aiagent.model.request;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
 
 import io.camunda.connector.agenticai.aiagent.model.request.PromptConfiguration.SystemPromptConfiguration;
 import io.camunda.connector.agenticai.aiagent.model.request.PromptConfiguration.UserPromptConfiguration;
+import jakarta.validation.ConstraintViolation;
 import jakarta.validation.Validator;
 import java.util.List;
 import org.junit.jupiter.api.Nested;
@@ -24,7 +26,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 @ExtendWith(SpringExtension.class)
 @Import(ValidationAutoConfiguration.class)
-class OutboundConnectorAgentRequestTest {
+class PromptConfigurationTest {
 
   @Autowired private Validator validator;
 
@@ -47,11 +49,13 @@ class OutboundConnectorAgentRequestTest {
     @ParameterizedTest
     @NullAndEmptySource
     @ValueSource(strings = {"  "})
-    void supportsEmptyUserPrompt(String prompt) {
+    void doesNotSupportEmptyUserPrompt(String prompt) {
       final var userPrompt = new UserPromptConfiguration(prompt, List.of());
 
-      assertThat(validator.validate(userPrompt)).isEmpty();
-      assertThat(userPrompt.prompt()).isEqualTo(prompt);
+      assertThat(validator.validate(userPrompt))
+          .hasSize(1)
+          .extracting(c -> c.getPropertyPath().toString(), ConstraintViolation::getMessage)
+          .contains(tuple("prompt", "must not be blank"));
     }
   }
 }


### PR DESCRIPTION
## Description

Makes the user prompt text mandatory by validating it on the request object. While there may be more detailed checks (e.g. only validate it based on history/when it is really needed (e.g. first interaction, follow-up interactions), this should catch most misconfiguration cases early.

## Related issues

closes #5393

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.
- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest release, as this branch will be rebased onto main before the next release.

