### PR TITLE
fix(inbound-email): similar changes than the one we had to make in 8.8, so that the polling never stops

### DIFF
--- a/connectors/email/src/main/java/io/camunda/connector/email/client/jakarta/inbound/PollingManager.java
+++ b/connectors/email/src/main/java/io/camunda/connector/email/client/jakarta/inbound/PollingManager.java
@@ -274,6 +274,10 @@ public class PollingManager {
   public void stop() {
     try {
       if (this.folder.isOpen()) this.folder.close();
+    } catch (MessagingException e) {
+      throw new RuntimeException(e);
+    }
+    try {
       if (this.store.isConnected()) this.store.close();
     } catch (MessagingException e) {
       throw new RuntimeException(e);


### PR DESCRIPTION
## Description

brings this [commit](https://github.com/camunda/connectors/commit/2bbf5743c073d2e051f1abdbf4988f670f0842da) to 8.7

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #

## Checklist

- [ ] PR has a **milestone** or the `no milestone` label.
- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest release, as this branch will be rebased onto main before the next release.

