### PR TITLE
other(tests): Fix CPT docker image name from zeebe to camunda

### DIFF
--- a/connectors-e2e-test/connectors-e2e-test-base/src/main/resources/application.properties
+++ b/connectors-e2e-test/connectors-e2e-test-base/src/main/resources/application.properties
@@ -3,4 +3,4 @@ logging.level.io.camunda.process.test=info
 logging.level.org.testcontainers=warn
 logging.level.tc=warn
 logging.level.io.camunda.connector=debug
-io.camunda.process.test.camundaDockerImageName=camunda/zeebe:SNAPSHOT
+io.camunda.process.test.camundaVersion=SNAPSHOT


### PR DESCRIPTION
## Description

This pull request updates a configuration property in the `application.properties` file to improve clarity regarding the Camunda version used in tests.

Configuration update:

* Changed the property `io.camunda.process.test.camundaDockerImageName` to `io.camunda.process.test.camundaVersion`, making the configuration more explicit about the Camunda version being used (`SNAPSHOT`).
