### PR TITLE
other(debug): Add support agents to the allowed users for manage and run

### DIFF
--- a/bundle/camunda-saas-bundle/src/main/java/io/camunda/connector/runtime/saas/security/InboundInstancesSecurityConfiguration.java
+++ b/bundle/camunda-saas-bundle/src/main/java/io/camunda/connector/runtime/saas/security/InboundInstancesSecurityConfiguration.java
@@ -42,7 +42,7 @@ public class InboundInstancesSecurityConfiguration {
   @Value("${camunda.connector.auth.console.audience:}")
   private String consoleAudience;
 
-  @Value("${camunda.connector.auth.allowed.roles:owner,admin}")
+  @Value("${camunda.connector.auth.allowed.roles:owner,admin,supportagent}")
   private List<String> allowedRoles;
 
   @Value("${camunda.connector.auth.issuer}")

--- a/bundle/camunda-saas-bundle/src/main/resources/application.properties
+++ b/bundle/camunda-saas-bundle/src/main/resources/application.properties
@@ -27,7 +27,7 @@ camunda.connector.inbound.log.size=100
 # Default is 1h and can be overridden by the connector configuration
 #camunda.connector.inbound.message.ttl=PT1H
 camunda.connector.secretprovider.discovery.enabled=false
-camunda.connector.auth.allowed.roles=owner,admin
+camunda.connector.auth.allowed.roles=owner,admin,supportagent
 camunda.endpoints.cors.mappings=/inbound-instances/**
 camunda.endpoints.cors.allow.credentials=true
 

--- a/bundle/camunda-saas-bundle/src/main/resources/application.properties
+++ b/bundle/camunda-saas-bundle/src/main/resources/application.properties
@@ -27,7 +27,6 @@ camunda.connector.inbound.log.size=100
 # Default is 1h and can be overridden by the connector configuration
 #camunda.connector.inbound.message.ttl=PT1H
 camunda.connector.secretprovider.discovery.enabled=false
-camunda.connector.auth.allowed.roles=owner,admin,supportagent
 camunda.endpoints.cors.mappings=/inbound-instances/**
 camunda.endpoints.cors.allow.credentials=true
 


### PR DESCRIPTION
## Description

This pull request introduces a minor update to the allowed roles for authentication in the inbound instances security configuration. The change adds `supportagent` to the list of allowed roles, enabling users with this role to access the relevant functionality.

Authentication and authorization:

* Updated the `allowedRoles` property in `InboundInstancesSecurityConfiguration` to include the `supportagent` role.
* Modified the `application.properties` configuration file to add `supportagent` to the `camunda.connector.auth.allowed.roles` property.

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.
- [x] Backport labels are added if these code changes should be backported. No backport label is added to the latest release, as this branch will be rebased onto main before the next release.

