### PR TITLE
other(tests): Fix CPT docker image name from zeebe to camunda

### DIFF
--- a/connectors-e2e-test/connectors-e2e-test-base/src/main/resources/application.properties
+++ b/connectors-e2e-test/connectors-e2e-test-base/src/main/resources/application.properties
@@ -3,4 +3,4 @@ logging.level.io.camunda.process.test=info
 logging.level.org.testcontainers=warn
 logging.level.tc=warn
 logging.level.io.camunda.connector=debug
-io.camunda.process.test.camundaDockerImageName=camunda/zeebe:SNAPSHOT
+io.camunda.process.test.camundaVersion=SNAPSHOT


### PR DESCRIPTION
## Description

This pull request makes a small configuration update to the `application.properties` file for the e2e test base. The change updates the property for specifying the Camunda version.

* Replaced the `io.camunda.process.test.camundaDockerImageName` property with `io.camunda.process.test.camundaVersion`, simplifying the configuration for specifying the Camunda version.


## Checklist

- [x] PR has a **milestone** or the `no milestone` label.
- [x] Backport labels are added if these code changes should be backported. No backport label is added to the latest release, as this branch will be rebased onto main before the next release.

