### PR TITLE
fix(agentic-ai): filter chat response metadata stored as part of conversation

### DIFF
--- a/connectors/agentic-ai/AI_AGENT.md
+++ b/connectors/agentic-ai/AI_AGENT.md
@@ -146,7 +146,7 @@ leading to the following result
     } ],
     "metadata" : {
       "framework" : {
-        "finishReason" : "STOP",
+        "id" : "chatcmpl-123",
         "tokenUsage" : {
           "inputTokenCount" : 5,
           "outputTokenCount" : 6,

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/ChatMessageConverterImpl.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/ChatMessageConverterImpl.java
@@ -31,6 +31,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.util.CollectionUtils;
@@ -158,8 +159,16 @@ public class ChatMessageConverterImpl implements ChatMessageConverter {
     }
 
     final var metadata = new LinkedHashMap<String, Object>();
-    metadata.put("id", chatResponseMetadata.id());
-    metadata.put("tokenUsage", serializedTokenUsage(chatResponseMetadata.tokenUsage()));
+    Optional.ofNullable(chatResponseMetadata.id())
+        .filter(StringUtils::isNotBlank)
+        .ifPresent(id -> metadata.put("id", id));
+    Optional.ofNullable(chatResponseMetadata.finishReason())
+        .ifPresent(finishReason -> metadata.put("finishReason", finishReason.name()));
+
+    final var tokenUsage = serializedTokenUsage(chatResponseMetadata.tokenUsage());
+    if (!tokenUsage.isEmpty()) {
+      metadata.put("tokenUsage", tokenUsage);
+    }
 
     return metadata;
   }

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/ChatMessageConverterImpl.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/ChatMessageConverterImpl.java
@@ -15,6 +15,7 @@ import dev.langchain4j.data.message.ToolExecutionResultMessage;
 import dev.langchain4j.internal.Json;
 import dev.langchain4j.model.chat.response.ChatResponse;
 import dev.langchain4j.model.chat.response.ChatResponseMetadata;
+import dev.langchain4j.model.output.TokenUsage;
 import io.camunda.connector.agenticai.aiagent.framework.langchain4j.tool.ToolCallConverter;
 import io.camunda.connector.agenticai.model.message.AssistantMessage;
 import io.camunda.connector.agenticai.model.message.AssistantMessageBuilder;
@@ -26,12 +27,17 @@ import io.camunda.connector.agenticai.model.message.content.TextContent;
 import io.camunda.connector.agenticai.util.ObjectMapperConstants;
 import io.camunda.connector.api.error.ConnectorException;
 import java.time.ZonedDateTime;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.util.CollectionUtils;
 
 public class ChatMessageConverterImpl implements ChatMessageConverter {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(ChatMessageConverterImpl.class);
 
   private final ContentConverter contentConverter;
   private final ToolCallConverter toolCallConverter;
@@ -145,18 +151,32 @@ public class ChatMessageConverterImpl implements ChatMessageConverter {
     return builder;
   }
 
-  protected Map<String, Object> serializedChatResponseMetadata(ChatResponseMetadata metadata) {
-    if (metadata == null) {
+  protected Map<String, Object> serializedChatResponseMetadata(
+      ChatResponseMetadata chatResponseMetadata) {
+    if (chatResponseMetadata == null) {
+      return Map.of();
+    }
+
+    final var metadata = new LinkedHashMap<String, Object>();
+    metadata.put("id", chatResponseMetadata.id());
+    metadata.put("tokenUsage", serializedTokenUsage(chatResponseMetadata.tokenUsage()));
+
+    return metadata;
+  }
+
+  protected Map<String, Object> serializedTokenUsage(TokenUsage tokenUsage) {
+    if (tokenUsage == null) {
       return Map.of();
     }
 
     try {
       return objectMapper.readValue(
-          Json.toJson(metadata), ObjectMapperConstants.STRING_OBJECT_MAP_TYPE_REFERENCE);
+          Json.toJson(tokenUsage), ObjectMapperConstants.STRING_OBJECT_MAP_TYPE_REFERENCE);
     } catch (JsonProcessingException e) {
-      throw new RuntimeException(
-          "Failed to deserialize chat response metadata: %s"
-              .formatted(humanReadableJsonProcessingExceptionMessage(e)));
+      LOGGER.warn(
+          "Failed to deserialize token usage metadata: {}",
+          humanReadableJsonProcessingExceptionMessage(e));
+      return Map.of();
     }
   }
 

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/AgentResponse.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/AgentResponse.java
@@ -91,13 +91,13 @@ public record AgentResponse(
                 Map.of(
                     "framework",
                     Map.ofEntries(
+                        Map.entry("id", "chatcmpl-123"),
                         Map.entry(
                             "tokenUsage",
                             Map.of(
                                 "inputTokenCount", 5,
                                 "outputTokenCount", 6,
-                                "totalTokenCount", 11)),
-                        Map.entry("finishReason", "STOP"))))
+                                "totalTokenCount", 11)))))
             .build();
 
     return AgentResponse.builder()

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/AgentResponse.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/AgentResponse.java
@@ -92,6 +92,7 @@ public record AgentResponse(
                     "framework",
                     Map.ofEntries(
                         Map.entry("id", "chatcmpl-123"),
+                        Map.entry("finishReason", "STOP"),
                         Map.entry(
                             "tokenUsage",
                             Map.of(

--- a/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/ChatMessageConverterTest.java
+++ b/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/ChatMessageConverterTest.java
@@ -9,6 +9,7 @@ package io.camunda.connector.agenticai.aiagent.framework.langchain4j;
 import static io.camunda.connector.agenticai.model.message.content.TextContent.textContent;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.entry;
 import static org.assertj.core.api.Assertions.within;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
@@ -21,8 +22,11 @@ import dev.langchain4j.data.message.AiMessage;
 import dev.langchain4j.data.message.ChatMessage;
 import dev.langchain4j.data.message.Content;
 import dev.langchain4j.data.message.ToolExecutionResultMessage;
+import dev.langchain4j.http.client.SuccessfulHttpResponse;
 import dev.langchain4j.model.chat.response.ChatResponse;
 import dev.langchain4j.model.chat.response.ChatResponseMetadata;
+import dev.langchain4j.model.openai.OpenAiChatResponseMetadata;
+import dev.langchain4j.model.openai.OpenAiTokenUsage;
 import dev.langchain4j.model.output.FinishReason;
 import dev.langchain4j.model.output.TokenUsage;
 import io.camunda.connector.agenticai.aiagent.framework.langchain4j.tool.ToolCallConverter;
@@ -39,6 +43,7 @@ import io.camunda.connector.api.document.Document;
 import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import org.assertj.core.api.InstanceOfAssertFactories;
@@ -198,7 +203,7 @@ class ChatMessageConverterTest {
 
     final var chatResponseMetadata =
         ChatResponseMetadata.builder()
-            .finishReason(FinishReason.STOP)
+            .id("chatcmpl-123")
             .tokenUsage(new TokenUsage(10, 20))
             .build();
 
@@ -226,10 +231,54 @@ class ChatMessageConverterTest {
     assertThat(result.metadata()).containsKey("framework");
     assertThat(result.metadata().get("framework"))
         .asInstanceOf(InstanceOfAssertFactories.MAP)
-        .containsEntry("finishReason", "STOP")
-        .containsEntry(
-            "tokenUsage",
-            Map.of("inputTokenCount", 10, "outputTokenCount", 20, "totalTokenCount", 30));
+        .containsExactly(
+            entry("id", "chatcmpl-123"),
+            entry(
+                "tokenUsage",
+                Map.of("inputTokenCount", 10, "outputTokenCount", 20, "totalTokenCount", 30)));
+  }
+
+  @Test
+  void toAssistantMessage_containsOnlyBasicMetadata() {
+    final var aiMessage = AiMessage.builder().text("AI response").build();
+
+    final var chatResponseMetadata =
+        OpenAiChatResponseMetadata.builder()
+            .id("chatcmpl-123")
+            .finishReason(FinishReason.STOP)
+            .tokenUsage(
+                OpenAiTokenUsage.builder()
+                    .inputTokenCount(10)
+                    .inputTokensDetails(
+                        OpenAiTokenUsage.InputTokensDetails.builder().cachedTokens(1).build())
+                    .outputTokenCount(20)
+                    .totalTokenCount(30)
+                    .build())
+            .serviceTier("super-premium")
+            .rawHttpResponse(
+                SuccessfulHttpResponse.builder()
+                    .statusCode(200)
+                    .headers(Map.of("x-my-header", List.of("dummy")))
+                    .body("AI response")
+                    .build())
+            .build();
+
+    final var chatResponse =
+        new ChatResponse.Builder().aiMessage(aiMessage).metadata(chatResponseMetadata).build();
+
+    final var result = chatMessageConverter.toAssistantMessage(chatResponse);
+
+    final var expectedTokenUsage = new LinkedHashMap<String, Object>();
+    expectedTokenUsage.put("inputTokenCount", 10);
+    expectedTokenUsage.put("inputTokensDetails", Map.of("cachedTokens", 1));
+    expectedTokenUsage.put("outputTokenCount", 20);
+    expectedTokenUsage.put("outputTokensDetails", null);
+    expectedTokenUsage.put("totalTokenCount", 30);
+
+    assertThat(result.metadata().get("framework"))
+        .asInstanceOf(InstanceOfAssertFactories.MAP)
+        .containsExactly(entry("id", "chatcmpl-123"), entry("tokenUsage", expectedTokenUsage))
+        .doesNotContainKeys("serviceTier", "rawHttpResponse");
   }
 
   @Test
@@ -237,10 +286,7 @@ class ChatMessageConverterTest {
     final var aiMessage = AiMessage.builder().build();
 
     final var chatResponseMetadata =
-        ChatResponseMetadata.builder()
-            .finishReason(FinishReason.STOP)
-            .tokenUsage(new TokenUsage(10, 0))
-            .build();
+        ChatResponseMetadata.builder().id("chatcmpl-123").tokenUsage(new TokenUsage(10, 0)).build();
 
     final var chatResponse =
         new ChatResponse.Builder().aiMessage(aiMessage).metadata(chatResponseMetadata).build();
@@ -252,10 +298,24 @@ class ChatMessageConverterTest {
     assertThat(result.metadata()).containsKey("framework");
     assertThat(result.metadata().get("framework"))
         .asInstanceOf(InstanceOfAssertFactories.MAP)
-        .containsEntry("finishReason", "STOP")
-        .containsEntry(
-            "tokenUsage",
-            Map.of("inputTokenCount", 10, "outputTokenCount", 0, "totalTokenCount", 10));
+        .containsExactly(
+            entry("id", "chatcmpl-123"),
+            entry(
+                "tokenUsage",
+                Map.of("inputTokenCount", 10, "outputTokenCount", 0, "totalTokenCount", 10)));
+  }
+
+  @Test
+  void toAssistantMessage_convertsFromChatResponse_withoutMetadata() {
+    final var chatResponse =
+        new ChatResponse.Builder().aiMessage(AiMessage.builder().build()).build();
+
+    final var result = chatMessageConverter.toAssistantMessage(chatResponse);
+
+    assertThat(result.metadata()).containsKey("framework");
+    assertThat(result.metadata().get("framework"))
+        .asInstanceOf(InstanceOfAssertFactories.MAP)
+        .containsExactly(entry("id", null), entry("tokenUsage", Map.of()));
   }
 
   @Test


### PR DESCRIPTION
## Description

Reduces to the metadata stored from a LLM response to only include ID and token usage. This avoids bloat on the stored conversation (see linked issue for an example).

## Related issues

closes #5425 

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.
- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest release, as this branch will be rebased onto main before the next release.

