### PR TITLE
fix(agentic-ai): only set ResponseFormat if it is configured to be JSON

### DIFF
--- a/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/Langchain4JAiFrameworkAdapterTest.java
+++ b/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/Langchain4JAiFrameworkAdapterTest.java
@@ -136,33 +136,30 @@ class Langchain4JAiFrameworkAdapterTest {
   }
 
   @Test
-  void requestsTextResponseWhenConfigured() {
+  void doesNotExplicitelyConfigureResponseFormatWhenTextFormatIsConfigured() {
     adapter.executeChatRequest(createExecutionContext(), AGENT_CONTEXT, runtimeMemory);
 
     final var chatRequest = chatRequestCaptor.getValue();
-    assertThat(chatRequest.responseFormat().type()).isEqualTo(ResponseFormatType.TEXT);
-    assertThat(chatRequest.responseFormat().jsonSchema()).isNull();
+    assertThat(chatRequest.responseFormat()).isNull();
   }
 
   @Test
-  void requestsTextResponseIfResponseConfigurationIsMissing() {
+  void doesNotExplicitelyConfigureResponseFormatWhenResponseConfigurationIsMissing() {
     adapter.executeChatRequest(createExecutionContext(null), AGENT_CONTEXT, runtimeMemory);
 
     final var chatRequest = chatRequestCaptor.getValue();
-    assertThat(chatRequest.responseFormat().type()).isEqualTo(ResponseFormatType.TEXT);
-    assertThat(chatRequest.responseFormat().jsonSchema()).isNull();
+    assertThat(chatRequest.responseFormat()).isNull();
   }
 
   @Test
-  void requestsTextResponseIfResponseFormatConfigurationIsMissing() {
+  void doesNotExplicitelyConfigureResponseFormatWhenResponseFormatConfigurationIsMissing() {
     adapter.executeChatRequest(
         createExecutionContext(new OutboundConnectorResponseConfiguration(null, false)),
         AGENT_CONTEXT,
         runtimeMemory);
 
     final var chatRequest = chatRequestCaptor.getValue();
-    assertThat(chatRequest.responseFormat().type()).isEqualTo(ResponseFormatType.TEXT);
-    assertThat(chatRequest.responseFormat().jsonSchema()).isNull();
+    assertThat(chatRequest.responseFormat()).isNull();
   }
 
   @Test


### PR DESCRIPTION
## Description

The Anthropic chat model throws a validation exception as soon as the response format is set (even to TEXT) as it only supports text responses. While this is  a bug which should be addressed upstream, we can work around this issue by only configuring the format if we explicitely want to use JSON mode.

## Related issues

closes #5434 

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.
- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest release, as this branch will be rebased onto main before the next release.

