### PR TITLE
chore(ci): rename next release branch to alpha; simplify renovate config

### DIFF
--- a/.github/workflows/CREATE_RELEASE_BRANCH.yml
+++ b/.github/workflows/CREATE_RELEASE_BRANCH.yml
@@ -43,13 +43,13 @@ jobs:
         id: set-snapshot-version
         run: |
           MINOR_VERSION=${RELEASE_VERSION%.*}
-          git checkout -b release/${MINOR_VERSION}
+          git checkout -b alpha/${MINOR_VERSION}
           mvn -B versions:set -DnewVersion=${RELEASE_VERSION}-SNAPSHOT -DgenerateBackupPoms=false -f parent
           git commit -am "ci: set next snapshot version"
-          git push origin release/${MINOR_VERSION}
+          git push origin alpha/${MINOR_VERSION}
           git checkout main
-          git cherry-pick release/${MINOR_VERSION}
-          echo "branchName=temp-release/${RELEASE_VERSION%.*}" >> $GITHUB_OUTPUT
+          git cherry-pick alpha/${MINOR_VERSION}
+          echo "branchName=temp-alpha/${RELEASE_VERSION%.*}" >> $GITHUB_OUTPUT
         env:
           RELEASE_VERSION: ${{ github.event.inputs.version }}
 

--- a/renovate.json
+++ b/renovate.json
@@ -105,9 +105,6 @@
   ],
   "baseBranches": [
     "main",
-    "release/8.4",
-    "release/8.5",
-    "release/8.6",
-    "release/8.7"
+    "release/*"
   ]
 }


### PR DESCRIPTION
## Description

Rename the next release branch to `alpha` - and simplify the renovate config accordingly.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes https://github.com/camunda/connectors/issues/5409

## Checklist

- [ ] PR has a **milestone** or the `no milestone` label.
- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest release, as this branch will be rebased onto main before the next release.

