### PR TITLE
chore(refactoring): Extract ReflectionUtil into dedicated module

### DIFF
--- a/connector-commons/connector-utils/pom.xml
+++ b/connector-commons/connector-utils/pom.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>io.camunda.connector</groupId>
+    <artifactId>connector-commons</artifactId>
+    <version>8.8.0-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+
+  <artifactId>connector-utils</artifactId>
+  <name>Connector Utils</name>
+  <packaging>jar</packaging>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.camunda.connector</groupId>
+      <artifactId>connector-core</artifactId>
+    </dependency>
+
+    <!-- Jackson databind & datatype dependencies -->
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-jsr310</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-jdk8</artifactId>
+    </dependency>
+
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/connector-commons/connector-utils/src/main/java/io/camunda/connector/util/reflection/ReflectionUtil.java
+++ b/connector-commons/connector-utils/src/main/java/io/camunda/connector/util/reflection/ReflectionUtil.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.camunda.connector.api.reflection;
+package io.camunda.connector.util.reflection;
 
 import io.camunda.connector.api.annotation.Header;
 import io.camunda.connector.api.annotation.Operation;

--- a/connector-commons/pom.xml
+++ b/connector-commons/pom.xml
@@ -19,6 +19,7 @@
   <modules>
     <module>connector-object-mapper</module>
     <module>http-client</module>
+    <module>connector-utils</module>
   </modules>
 
 </project>

--- a/connector-runtime/connector-runtime-core/pom.xml
+++ b/connector-runtime/connector-runtime-core/pom.xml
@@ -41,6 +41,11 @@
     </dependency>
 
     <dependency>
+      <groupId>io.camunda.connector</groupId>
+      <artifactId>connector-utils</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>camunda-client-java</artifactId>
       <version>${version.camunda}</version>

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/ConnectorConfigurationUtil.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/ConnectorConfigurationUtil.java
@@ -16,8 +16,8 @@
  */
 package io.camunda.connector.runtime.core;
 
-import static io.camunda.connector.api.reflection.ReflectionUtil.getMethodsAnnotatedWith;
-import static io.camunda.connector.api.reflection.ReflectionUtil.getVariableName;
+import static io.camunda.connector.util.reflection.ReflectionUtil.getMethodsAnnotatedWith;
+import static io.camunda.connector.util.reflection.ReflectionUtil.getVariableName;
 
 import io.camunda.connector.api.annotation.InboundConnector;
 import io.camunda.connector.api.annotation.Operation;
@@ -25,11 +25,10 @@ import io.camunda.connector.api.annotation.OutboundConnector;
 import io.camunda.connector.api.annotation.Variable;
 import io.camunda.connector.api.inbound.InboundConnectorExecutable;
 import io.camunda.connector.api.outbound.OutboundConnectorFunction;
-import io.camunda.connector.api.reflection.ReflectionUtil;
-import io.camunda.connector.api.reflection.ReflectionUtil.MethodWithAnnotation;
 import io.camunda.connector.runtime.core.config.ConnectorConfigurationOverrides;
 import io.camunda.connector.runtime.core.config.InboundConnectorConfiguration;
 import io.camunda.connector.runtime.core.config.OutboundConnectorConfiguration;
+import io.camunda.connector.util.reflection.ReflectionUtil.MethodWithAnnotation;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.util.*;
@@ -105,8 +104,7 @@ public final class ConnectorConfigurationUtil {
     }
   }
 
-  public static Set<String> getInputVariables(
-      List<ReflectionUtil.MethodWithAnnotation<Operation>> operations) {
+  public static Set<String> getInputVariables(List<MethodWithAnnotation<Operation>> operations) {
     Set<String> variables = new HashSet<>();
     operations.forEach(
         method -> {

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/outbound/operation/ConnectorOperations.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/outbound/operation/ConnectorOperations.java
@@ -16,16 +16,16 @@
  */
 package io.camunda.connector.runtime.core.outbound.operation;
 
-import static io.camunda.connector.api.reflection.ReflectionUtil.*;
+import static io.camunda.connector.util.reflection.ReflectionUtil.*;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.connector.api.annotation.Header;
 import io.camunda.connector.api.annotation.Operation;
 import io.camunda.connector.api.annotation.Variable;
 import io.camunda.connector.api.outbound.OutboundConnectorContext;
-import io.camunda.connector.api.reflection.ReflectionUtil.MethodWithAnnotation;
 import io.camunda.connector.api.validation.ValidationProvider;
 import io.camunda.connector.runtime.core.outbound.operation.ParameterDescriptor.Context;
+import io.camunda.connector.util.reflection.ReflectionUtil.MethodWithAnnotation;
 import java.lang.reflect.Method;
 import java.lang.reflect.Parameter;
 import java.util.Arrays;

--- a/element-template-generator/core/pom.xml
+++ b/element-template-generator/core/pom.xml
@@ -23,10 +23,14 @@
       <groupId>io.camunda.connector</groupId>
       <artifactId>connector-object-mapper</artifactId>
     </dependency>
-      <dependency>
-          <groupId>io.camunda.connector</groupId>
-          <artifactId>connector-feel-wrapper</artifactId>
-      </dependency>
+    <dependency>
+      <groupId>io.camunda.connector</groupId>
+      <artifactId>connector-utils</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.camunda.connector</groupId>
+      <artifactId>connector-feel-wrapper</artifactId>
+    </dependency>
     <dependency>
       <groupId>io.camunda.connector</groupId>
       <artifactId>jackson-datatype-feel</artifactId>

--- a/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/ClassBasedDocsGenerator.java
+++ b/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/ClassBasedDocsGenerator.java
@@ -17,13 +17,13 @@
 package io.camunda.connector.generator.java;
 
 import static com.fasterxml.jackson.databind.MapperFeature.SORT_PROPERTIES_ALPHABETICALLY;
+import static io.camunda.connector.util.reflection.ReflectionUtil.getRequiredAnnotation;
 import static java.lang.Boolean.TRUE;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectWriter;
 import com.fasterxml.jackson.databind.SerializationFeature;
-import io.camunda.connector.api.reflection.ReflectionUtil;
 import io.camunda.connector.feel.FeelEngineWrapper;
 import io.camunda.connector.generator.api.DocsGenerator;
 import io.camunda.connector.generator.api.DocsGeneratorConfiguration;
@@ -136,8 +136,7 @@ public class ClassBasedDocsGenerator implements DocsGenerator<Class<?>> {
   @Override
   public Doc generate(Class<?> connectorDefinition, DocsGeneratorConfiguration configuration) {
 
-    ElementTemplate template =
-        ReflectionUtil.getRequiredAnnotation(connectorDefinition, ElementTemplate.class);
+    ElementTemplate template = getRequiredAnnotation(connectorDefinition, ElementTemplate.class);
     TemplateGenerationContext templateGenerationContext =
         TemplateGenerationContextUtil.createContext(
             connectorDefinition, GeneratorConfiguration.DEFAULT);

--- a/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/ClassBasedTemplateGenerator.java
+++ b/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/ClassBasedTemplateGenerator.java
@@ -23,8 +23,6 @@ import io.camunda.connector.api.annotation.Operation;
 import io.camunda.connector.api.inbound.InboundConnectorExecutable;
 import io.camunda.connector.api.outbound.OutboundConnectorFunction;
 import io.camunda.connector.api.outbound.OutboundConnectorProvider;
-import io.camunda.connector.api.reflection.ReflectionUtil;
-import io.camunda.connector.api.reflection.ReflectionUtil.MethodWithAnnotation;
 import io.camunda.connector.generator.api.ElementTemplateGenerator;
 import io.camunda.connector.generator.api.GeneratorConfiguration;
 import io.camunda.connector.generator.api.GeneratorConfiguration.ConnectorElementType;
@@ -35,6 +33,8 @@ import io.camunda.connector.generator.dsl.PropertyGroup.PropertyGroupBuilder;
 import io.camunda.connector.generator.java.annotation.ElementTemplate;
 import io.camunda.connector.generator.java.util.*;
 import io.camunda.connector.generator.java.util.TemplateGenerationContext.Outbound;
+import io.camunda.connector.util.reflection.ReflectionUtil;
+import io.camunda.connector.util.reflection.ReflectionUtil.MethodWithAnnotation;
 import java.util.*;
 import java.util.regex.Pattern;
 

--- a/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/util/OperationBasedConnectorUtil.java
+++ b/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/util/OperationBasedConnectorUtil.java
@@ -16,16 +16,16 @@
  */
 package io.camunda.connector.generator.java.util;
 
-import static io.camunda.connector.api.reflection.ReflectionUtil.*;
 import static io.camunda.connector.generator.java.processor.TemplatePropertyFieldProcessor.buildCondition;
 import static io.camunda.connector.generator.java.processor.TemplatePropertyFieldProcessor.getValue;
+import static io.camunda.connector.util.reflection.ReflectionUtil.*;
 
 import io.camunda.connector.api.annotation.Header;
 import io.camunda.connector.api.annotation.Operation;
 import io.camunda.connector.api.annotation.Variable;
-import io.camunda.connector.api.reflection.ReflectionUtil;
 import io.camunda.connector.generator.dsl.*;
 import io.camunda.connector.generator.java.annotation.TemplateProperty;
+import io.camunda.connector.util.reflection.ReflectionUtil.MethodWithAnnotation;
 import java.lang.reflect.Parameter;
 import java.util.Comparator;
 import java.util.List;
@@ -39,7 +39,7 @@ public class OperationBasedConnectorUtil {
   public static String VARIABLE_PATH_SEPARATOR = ".";
 
   public static PropertyBuilder createOperationsProperty(
-      List<ReflectionUtil.MethodWithAnnotation<Operation>> methods) {
+      List<MethodWithAnnotation<Operation>> methods) {
     if (methods.isEmpty()) {
       throw new IllegalArgumentException("No operations found for the connector.");
     }
@@ -73,13 +73,12 @@ public class OperationBasedConnectorUtil {
   }
 
   public static List<PropertyBuilder> getOperationProperties(
-      List<ReflectionUtil.MethodWithAnnotation<Operation>> methods,
-      TemplateGenerationContext context) {
+      List<MethodWithAnnotation<Operation>> methods, TemplateGenerationContext context) {
     return methods.stream().flatMap(m -> getOperationProperties(m, context).stream()).toList();
   }
 
   private static List<PropertyBuilder> getOperationProperties(
-      ReflectionUtil.MethodWithAnnotation<Operation> method, TemplateGenerationContext context) {
+      MethodWithAnnotation<Operation> method, TemplateGenerationContext context) {
     Operation operation = method.annotation();
     List<Parameter> parameters =
         method.parameters().stream()

--- a/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/util/TemplateGenerationContextUtil.java
+++ b/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/util/TemplateGenerationContextUtil.java
@@ -16,9 +16,10 @@
  */
 package io.camunda.connector.generator.java.util;
 
+import static io.camunda.connector.util.reflection.ReflectionUtil.getRequiredAnnotation;
+
 import io.camunda.connector.api.annotation.InboundConnector;
 import io.camunda.connector.api.annotation.OutboundConnector;
-import io.camunda.connector.api.reflection.ReflectionUtil;
 import io.camunda.connector.generator.api.GeneratorConfiguration;
 import io.camunda.connector.generator.dsl.BpmnType;
 import io.camunda.connector.generator.java.annotation.ElementTemplate;
@@ -84,7 +85,7 @@ public class TemplateGenerationContextUtil {
       Class<?> connectorDefinition,
       GeneratorConfiguration configuration,
       OutboundConnector connector) {
-    var template = ReflectionUtil.getRequiredAnnotation(connectorDefinition, ElementTemplate.class);
+    var template = getRequiredAnnotation(connectorDefinition, ElementTemplate.class);
 
     GeneratorConfiguration mergedConfig = ConfigurationUtil.fromAnnotation(template, configuration);
     var elementTypes = mergedConfig.elementTypes();
@@ -106,7 +107,7 @@ public class TemplateGenerationContextUtil {
       Class<?> connectorDefinition,
       GeneratorConfiguration configuration,
       InboundConnector connector) {
-    var template = ReflectionUtil.getRequiredAnnotation(connectorDefinition, ElementTemplate.class);
+    var template = getRequiredAnnotation(connectorDefinition, ElementTemplate.class);
 
     GeneratorConfiguration mergedConfig = ConfigurationUtil.fromAnnotation(template, configuration);
     var elementTypes = mergedConfig.elementTypes();

--- a/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/util/TemplatePropertiesUtil.java
+++ b/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/util/TemplatePropertiesUtil.java
@@ -16,7 +16,7 @@
  */
 package io.camunda.connector.generator.java.util;
 
-import static io.camunda.connector.api.reflection.ReflectionUtil.getAllFields;
+import static io.camunda.connector.util.reflection.ReflectionUtil.getAllFields;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import io.camunda.connector.generator.dsl.*;

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -233,7 +233,13 @@ limitations under the License.</license.inlineheader>
         <version>${project.version}</version>
       </dependency>
 
-      <dependency>
+        <dependency>
+            <groupId>io.camunda.connector</groupId>
+            <artifactId>connector-utils</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
         <groupId>io.camunda.connector</groupId>
         <artifactId>http-client</artifactId>
         <version>${project.version}</version>


### PR DESCRIPTION
This pull request introduces a new `connector-utils` module to centralize and share utility code, specifically reflection utilities, across multiple connector-related projects. The main changes involve moving the `ReflectionUtil` class and its usages from the SDK/core module to the new `connector-utils` module, and updating dependencies and imports throughout the codebase to use this new module.

**Module and Dependency Updates:**

* Added the new `connector-utils` Maven module, including its own `pom.xml` and necessary dependencies such as Jackson and JUnit, and registered it in the parent and commons project files. [[1]](diffhunk://#diff-6a944e89c21b936f5d178265f0d5fa3532e4069415547609d637b33e36e2748fR1-R50) [[2]](diffhunk://#diff-95c89c0e6afb14c222d0a152f86426606eedf5cf8008476512fe67af31a2bd7fR22) [[3]](diffhunk://#diff-b5a06276719e759fe07dfe6f75d781be5f83d2215179d82bdb195ad035348214R236-R241)
* Updated the `connector-runtime-core` and `element-template-generator/core` modules to depend on `connector-utils` for shared utilities. [[1]](diffhunk://#diff-cb248c6680c44aeada68f225ba46714037acfa03c9ae606c6d813ed7589c70d3R43-R47) [[2]](diffhunk://#diff-753ee2c5b708fe2b639493d710a50608f740d8bae668ddc60da885d59e2c6976R26-R29)

**Refactoring and Codebase Simplification:**

* Moved the `ReflectionUtil` class from `connector-sdk/core` to `connector-commons/connector-utils`, and updated its package to `io.camunda.connector.util.reflection`. All references and imports to `ReflectionUtil` throughout the codebase have been updated accordingly.
* Changed method signatures and usages to use the relocated `MethodWithAnnotation` type from the new package, simplifying and standardizing reflection-based logic. [[1]](diffhunk://#diff-6c21ab4812a8728fe03d0c0a9834e7794e760c6e6568bdc1158820c835c64ce4L19-R31) [[2]](diffhunk://#diff-6c21ab4812a8728fe03d0c0a9834e7794e760c6e6568bdc1158820c835c64ce4L108-R107) [[3]](diffhunk://#diff-29e2b869698d91e78c3b2f9e423c72cf284bd1a03795369599ffd59935b55417L19-R28) [[4]](diffhunk://#diff-58b1c0af7b02e70dc2dcd666a494d188c19104bfcdd61dd21ed9b806b255accfR20-L26) [[5]](diffhunk://#diff-58b1c0af7b02e70dc2dcd666a494d188c19104bfcdd61dd21ed9b806b255accfL139-R139) [[6]](diffhunk://#diff-097505a14eb0fde017bcec8f9a2eb68dbecc55ae0069cf0f15315c796fc864e4L26-L27) [[7]](diffhunk://#diff-097505a14eb0fde017bcec8f9a2eb68dbecc55ae0069cf0f15315c796fc864e4R36-R37) [[8]](diffhunk://#diff-e4c9ed4195086bcbc253e90011bce9114568898c5d191263e5ee4dd226bcb18bL19-R28) [[9]](diffhunk://#diff-e4c9ed4195086bcbc253e90011bce9114568898c5d191263e5ee4dd226bcb18bL42-R42) [[10]](diffhunk://#diff-e4c9ed4195086bcbc253e90011bce9114568898c5d191263e5ee4dd226bcb18bL76-R81) [[11]](diffhunk://#diff-7bdf7eb268c171f75b1d014660d37790334cea563cb4e9d7a1db41042a06c966R19-L21) [[12]](diffhunk://#diff-7bdf7eb268c171f75b1d014660d37790334cea563cb4e9d7a1db41042a06c966L87-R88) [[13]](diffhunk://#diff-7bdf7eb268c171f75b1d014660d37790334cea563cb4e9d7a1db41042a06c966L109-R110) [[14]](diffhunk://#diff-01fd4a94753202352bff770fa6a127ee72f3cfb8d62351e0bbfc4c8c9045a965L19-R19)

These changes make reflection utilities reusable across connector modules, reduce code duplication, and improve maintainability.