### PR TITLE
fix(agentic-ai): adapt e2e tests for updated response handling (not explicitely setting TEXT)

### DIFF
--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/langchain4j/jobworker/L4JAiAgentJobWorkerResponseHandlingTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/langchain4j/jobworker/L4JAiAgentJobWorkerResponseHandlingTests.java
@@ -41,13 +41,7 @@ public class L4JAiAgentJobWorkerResponseHandlingTests extends BaseL4JAiAgentJobW
     @AfterEach
     void verifyRequestedResponseFormat() {
       final var lastChatRequest = chatRequestCaptor.getValue();
-      assertThat(lastChatRequest.responseFormat())
-          .isNotNull()
-          .satisfies(
-              format -> {
-                assertThat(format.type()).isEqualTo(ResponseFormatType.TEXT);
-                assertThat(format.jsonSchema()).isNull();
-              });
+      assertThat(lastChatRequest.responseFormat()).isNull();
     }
 
     @Test

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/langchain4j/outboundconnector/L4JAiAgentConnectorResponseHandlingTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/langchain4j/outboundconnector/L4JAiAgentConnectorResponseHandlingTests.java
@@ -41,13 +41,7 @@ public class L4JAiAgentConnectorResponseHandlingTests extends BaseL4JAiAgentConn
     @AfterEach
     void verifyRequestedResponseFormat() {
       final var lastChatRequest = chatRequestCaptor.getValue();
-      assertThat(lastChatRequest.responseFormat())
-          .isNotNull()
-          .satisfies(
-              format -> {
-                assertThat(format.type()).isEqualTo(ResponseFormatType.TEXT);
-                assertThat(format.jsonSchema()).isNull();
-              });
+      assertThat(lastChatRequest.responseFormat()).isNull();
     }
 
     @Test

--- a/connectors/agentic-ai/AI_AGENT.md
+++ b/connectors/agentic-ai/AI_AGENT.md
@@ -146,6 +146,7 @@ leading to the following result
     } ],
     "metadata" : {
       "framework" : {
+        "finishReason" : "STOP",
         "id" : "chatcmpl-123",
         "tokenUsage" : {
           "inputTokenCount" : 5,


### PR DESCRIPTION
## Description

Follow up to #5434 to fix missed e2e tests.

## Related issues

closes #5434

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.
- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest release, as this branch will be rebased onto main before the next release.

