### PR TITLE
other(e2e): fx AWS e2e test

### DIFF
--- a/connectors-e2e-test/connectors-e2e-test-aws/connectors-e2e-test-aws-event-bridge/src/test/java/io/camunda/connector/e2e/AwsEventBridgeTest.java
+++ b/connectors-e2e-test/connectors-e2e-test-aws/connectors-e2e-test-aws-event-bridge/src/test/java/io/camunda/connector/e2e/AwsEventBridgeTest.java
@@ -116,7 +116,7 @@ public class AwsEventBridgeTest extends BaseAwsTest {
             .property("authentication.accessKey", localstack.getAccessKey())
             .property("authentication.secretKey", localstack.getSecretKey())
             .property("configuration.region", localstack.getRegion())
-            .property("input.eventBusName", EVENT_BUS_NAME)
+            .property("input.eventBusName", "=\"" + EVENT_BUS_NAME + "\"")
             .property("input.source", SOURCE)
             .property("input.detailType", DETAIL_TYPE)
             .property("input.detail", "=" + DETAIL)


### PR DESCRIPTION
## Description

This pull request makes a minor adjustment to the way the `eventBusName` property is set in the AWS EventBridge connector end-to-end test. The change modifies the value assignment format to ensure proper handling by the test framework.

* Changed the assignment of `input.eventBusName` to use the format `="EVENT_BUS_NAME"` instead of just `EVENT_BUS_NAME` in the `testEventBridgeConnectorFunction` method in `AwsEventBridgeTest.java`

This change was required after upgrading `element-templates-cli` to 0.5.0