### PR TITLE
ci(nightly): fix the uploaded test result names

### DIFF
--- a/.github/workflows/NIGHTLY_E2E.yml
+++ b/.github/workflows/NIGHTLY_E2E.yml
@@ -94,7 +94,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: surefire-reports
+          name: surefire-reports-${{ matrix.branch }}
           path: '**/target/surefire-reports/*.xml'
 
       - name: Send Slack notification on failure


### PR DESCRIPTION
## Description

This pull request makes a small update to the artifact naming convention in the nightly E2E workflow. The change ensures that the uploaded artifact name includes the branch name, which helps distinguish reports from different branches.

* The `name` field for the uploaded artifact in `.github/workflows/NIGHTLY_E2E.yml` now includes the branch name using `${{ matrix.branch }}`
