### PR TITLE
ci(nightly): fix the uploaded test result names

### DIFF
--- a/.github/workflows/NIGHTLY_E2E.yml
+++ b/.github/workflows/NIGHTLY_E2E.yml
@@ -90,11 +90,17 @@ jobs:
         if: always()
         uses: scacap/action-surefire-report@v1
 
+      - name: Sanitize branch name
+        id: sanitize
+        run: echo "SANITIZED_BRANCH=${BRANCH//\//-}" >> $GITHUB_ENV
+        env:
+          BRANCH: ${{ matrix.branch }}
+
       - name: Upload detailed surefire reports
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: surefire-reports-${{ matrix.branch }}
+          name: surefire-reports-${{ env.SANITIZED_BRANCH }}
           path: '**/target/surefire-reports/*.xml'
 
       - name: Send Slack notification on failure


### PR DESCRIPTION
## Description

This pull request makes a small but important improvement to the nightly end-to-end workflow by ensuring that uploaded artifact names are unique per branch. This is accomplished by sanitizing the branch name to replace slashes with dashes and appending it to the artifact name.

Workflow improvements:

* Added a step to sanitize the branch name by replacing slashes (`/`) with dashes (`-`), storing the result in the `SANITIZED_BRANCH` environment variable. This ensures branch names are safe for use in file and artifact names.
* Updated the artifact upload step to include the sanitized branch name in the artifact's name, making it easier to distinguish reports from different branches.