### PR TITLE
chore(java-docs): Fix link to removed class

### DIFF
--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/outbound/ConnectorResult.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/outbound/ConnectorResult.java
@@ -19,7 +19,6 @@ package io.camunda.connector.runtime.core.outbound;
 import java.time.Duration;
 import java.util.Map;
 
-/** Result container for the {@link ConnectorJobHandler} */
 public sealed interface ConnectorResult {
 
   Object responseValue();


### PR DESCRIPTION
## Description
The ConnectorJobHandler was replaced with the SpringConnectorJobHandler, but i could not link it there as it is in another package, so i removed it.

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.
- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest release, as this branch will be rebased onto main before the next release.

