### PR TITLE
fix(webhook): Fix webhook and possible http client nullpointer exception

### DIFF
--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/webhook/InboundWebhookRestController.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/webhook/InboundWebhookRestController.java
@@ -45,7 +45,6 @@ import jakarta.servlet.http.HttpServletRequest;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -86,10 +85,10 @@ public class InboundWebhookRestController {
   }
 
   protected static Object escapeValue(Object value) {
-    if (Objects.requireNonNull(value) instanceof String s) {
-      return HtmlUtils.htmlEscape(s);
-    }
-    return value;
+    return switch (value) {
+      case String s -> HtmlUtils.htmlEscape(s);
+      case null, default -> value;
+    };
   }
 
   @RequestMapping(

--- a/connector-runtime/spring-boot-starter-camunda-connectors/pom.xml
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/pom.xml
@@ -21,7 +21,6 @@
     <dependency>
       <groupId>io.camunda.connector</groupId>
       <artifactId>connector-runtime-spring</artifactId>
-      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>io.camunda.connector</groupId>

--- a/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/client/apache/builder/parts/ApacheRequestBodyBuilder.java
+++ b/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/client/apache/builder/parts/ApacheRequestBodyBuilder.java
@@ -119,8 +119,15 @@ public class ApacheRequestBodyBuilder implements ApacheRequestPartBuilder {
     builder.setMode(HttpMultipartMode.LEGACY);
     Optional.ofNullable(contentType.getParameter("boundary")).ifPresent(builder::setBoundary);
     for (Map.Entry<?, ?> entry : body.entrySet()) {
-      builder.addTextBody(
-          String.valueOf(entry.getKey()), String.valueOf(entry.getValue()), MULTIPART_FORM_DATA);
+      switch (entry.getValue()) {
+        case Document document -> streamDocumentContent(entry, document, builder);
+        case null -> {}
+        default ->
+            builder.addTextBody(
+                String.valueOf(entry.getKey()),
+                String.valueOf(entry.getValue()),
+                MULTIPART_FORM_DATA);
+      }
     }
     return builder.build();
   }

--- a/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/client/apache/builder/parts/ApacheRequestBodyBuilder.java
+++ b/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/client/apache/builder/parts/ApacheRequestBodyBuilder.java
@@ -120,7 +120,6 @@ public class ApacheRequestBodyBuilder implements ApacheRequestPartBuilder {
     Optional.ofNullable(contentType.getParameter("boundary")).ifPresent(builder::setBoundary);
     for (Map.Entry<?, ?> entry : body.entrySet()) {
       switch (entry.getValue()) {
-        case Document document -> streamDocumentContent(entry, document, builder);
         case null -> {}
         default ->
             builder.addTextBody(


### PR DESCRIPTION
## Description

This bug was reported: https://github.com/camunda/connectors/issues/5355
I investigated it and figured out it only happens in 8.6 as it was already fixed with this PR, but the backport to 8.6 failed:
https://github.com/camunda/connectors/pull/3518

So I just backported this PR to 8.6 and removed document releated switch-case-case.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #5355

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.
- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest release, as this branch will be rebased onto main before the next release.

