### PR TITLE
fix(etg): handle primitive operation parameters correctly

### DIFF
--- a/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/processor/AnnotationProcessor.java
+++ b/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/processor/AnnotationProcessor.java
@@ -19,14 +19,17 @@ package io.camunda.connector.generator.java.processor;
 import io.camunda.connector.generator.dsl.PropertyBuilder;
 import io.camunda.connector.generator.java.annotation.TemplateProperty;
 import io.camunda.connector.generator.java.util.TemplateGenerationContext;
-import java.lang.reflect.Field;
+import java.lang.reflect.AnnotatedElement;
 
-public interface FieldProcessor {
+public interface AnnotationProcessor {
 
   void process(
-      Field field, PropertyBuilder propertyBuilder, final TemplateGenerationContext context);
+      AnnotatedElement field,
+      Class<?> type,
+      PropertyBuilder propertyBuilder,
+      final TemplateGenerationContext context);
 
-  static boolean isOptional(Field field) {
+  static boolean isOptional(AnnotatedElement field) {
     var annotation = field.getAnnotation(TemplateProperty.class);
     if (annotation == null) {
       return TemplateProperty.OPTIONAL_DEFAULT;

--- a/element-template-generator/core/src/test/java/io/camunda/connector/generator/java/OutboundClassBasedTemplateGeneratorTest.java
+++ b/element-template-generator/core/src/test/java/io/camunda/connector/generator/java/OutboundClassBasedTemplateGeneratorTest.java
@@ -33,6 +33,7 @@ import io.camunda.connector.generator.dsl.DropdownProperty;
 import io.camunda.connector.generator.dsl.DropdownProperty.DropdownChoice;
 import io.camunda.connector.generator.dsl.ElementTemplate.ElementTypeWrapper;
 import io.camunda.connector.generator.dsl.HiddenProperty;
+import io.camunda.connector.generator.dsl.NumberProperty;
 import io.camunda.connector.generator.dsl.Property.FeelMode;
 import io.camunda.connector.generator.dsl.PropertyBinding;
 import io.camunda.connector.generator.dsl.PropertyBinding.ZeebeInput;
@@ -46,6 +47,7 @@ import io.camunda.connector.generator.dsl.StringProperty;
 import io.camunda.connector.generator.dsl.TextProperty;
 import io.camunda.connector.generator.java.example.outbound.MyConnectorFunction;
 import io.camunda.connector.generator.java.example.outbound.OperationAnnotatedConnector;
+import io.camunda.connector.generator.java.example.outbound.OperationAnnotatedConnectorWithPrimitiveTypes;
 import io.camunda.connector.generator.java.example.outbound.SingleOperationAnnotatedConnector;
 import java.io.File;
 import java.io.IOException;
@@ -1044,6 +1046,50 @@ public class OutboundClassBasedTemplateGeneratorTest extends BaseTest {
 
       HiddenProperty operationProperty = (HiddenProperty) getPropertyById("operation", template);
       assertThat(operationProperty.getValue()).isEqualTo("operation-1");
+    }
+
+    @Test
+    void operationWithPrimitiveParametersAnnotated() {
+      var template =
+          generator.generate(OperationAnnotatedConnectorWithPrimitiveTypes.class).getFirst();
+      assertThat(template.id()).isNotNull();
+
+      NumberProperty propertyA = (NumberProperty) getPropertyById("add:a", template);
+      NumberProperty propertyB = (NumberProperty) getPropertyById("add:b", template);
+      assertThat(propertyA.getType()).isEqualTo("Number");
+      assertThat(propertyB.getType()).isEqualTo("Number");
+      assertThat(propertyA.getBinding()).isEqualTo(new ZeebeInput("a"));
+      assertThat(propertyB.getBinding()).isEqualTo(new ZeebeInput("b"));
+
+      NumberProperty propertyAWithTemplateProperty =
+          (NumberProperty) getPropertyById("addWithVariableAndTemplateProperty:a", template);
+      NumberProperty propertyBWithTemplateProperty =
+          (NumberProperty) getPropertyById("addWithVariableAndTemplateProperty:b", template);
+      assertThat(propertyAWithTemplateProperty.getType()).isEqualTo("Number");
+      assertThat(propertyBWithTemplateProperty.getType()).isEqualTo("Number");
+      assertThat(propertyAWithTemplateProperty.getBinding()).isEqualTo(new ZeebeInput("a"));
+      assertThat(propertyBWithTemplateProperty.getBinding()).isEqualTo(new ZeebeInput("b"));
+
+      // TODO: all header params are currently forced to String, even if the method parameter is
+      // of a different type. Do we want to change this?
+
+      StringProperty propertyAWithHeader =
+          (StringProperty) getPropertyById("addWithHeader:a", template);
+      StringProperty propertyBWithHeader =
+          (StringProperty) getPropertyById("addWithHeader:b", template);
+      assertThat(propertyAWithHeader.getBinding())
+          .isEqualTo(new PropertyBinding.ZeebeTaskHeader("a"));
+      assertThat(propertyBWithHeader.getBinding())
+          .isEqualTo(new PropertyBinding.ZeebeTaskHeader("b"));
+
+      StringProperty propertyAWithHeaderAndTemplateProperty =
+          (StringProperty) getPropertyById("addWithHeaderAndTemplateProperty:a", template);
+      StringProperty propertyBWithHeaderAndTemplateProperty =
+          (StringProperty) getPropertyById("addWithHeaderAndTemplateProperty:b", template);
+      assertThat(propertyAWithHeaderAndTemplateProperty.getBinding())
+          .isEqualTo(new PropertyBinding.ZeebeTaskHeader("a"));
+      assertThat(propertyBWithHeaderAndTemplateProperty.getBinding())
+          .isEqualTo(new PropertyBinding.ZeebeTaskHeader("b"));
     }
   }
 }

--- a/element-template-generator/core/src/test/java/io/camunda/connector/generator/java/example/outbound/OperationAnnotatedConnectorWithPrimitiveTypes.java
+++ b/element-template-generator/core/src/test/java/io/camunda/connector/generator/java/example/outbound/OperationAnnotatedConnectorWithPrimitiveTypes.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.generator.java.example.outbound;
+
+import io.camunda.connector.api.annotation.Header;
+import io.camunda.connector.api.annotation.Operation;
+import io.camunda.connector.api.annotation.OutboundConnector;
+import io.camunda.connector.api.annotation.Variable;
+import io.camunda.connector.api.outbound.OutboundConnectorProvider;
+import io.camunda.connector.generator.java.annotation.ElementTemplate;
+import io.camunda.connector.generator.java.annotation.TemplateProperty;
+
+@OutboundConnector(name = "Connector with primitive types", type = "primitive-types-connector")
+@ElementTemplate(id = "primitive-types-connector-id", name = "Connector with primitive types")
+public class OperationAnnotatedConnectorWithPrimitiveTypes implements OutboundConnectorProvider {
+
+  @Operation(name = "Add two integers", id = "add")
+  public int addWithVariable(@Variable("a") int a, @Variable("b") int b) {
+    return a + b;
+  }
+
+  @Operation(
+      name = "Add two integers with variable and template property",
+      id = "addWithVariableAndTemplateProperty")
+  public int addWithVariableAndTemplateProperty(
+      @Variable @TemplateProperty(id = "a") int a, @Variable @TemplateProperty(id = "b") int b) {
+    return a + b;
+  }
+
+  @Operation(name = "Add two integers with headers", id = "addWithHeader")
+  public int addWithHeader(@Header("a") int a, @Header("b") int b) {
+    return a + b;
+  }
+
+  @Operation(
+      name = "Add two integers with headers and template properties",
+      id = "addWithHeaderAndTemplateProperty")
+  public int addWithHeaderAndTemplateProperty(
+      @Header @TemplateProperty(id = "a") int a, @Header @TemplateProperty(id = "b") int b) {
+    return a + b;
+  }
+}


### PR DESCRIPTION
## Description

When working with operation connectors, I noticed that parameters of primitive types are not handled correctly by the ETG (either ignored or treated as composite classes, which in case of `String` or boxed types results in a lot of garbage properties).

This PR adds separate handling for primitive operation parameters.

❓ **Unresolved question:** Should Header parameters always be of type string in the element template? smth like Number or other types could also be useful. I haven't changed this yet.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #

## Checklist

- [ ] PR has a **milestone** or the `no milestone` label.
- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest release, as this branch will be rebased onto main before the next release.

