### PR TITLE
fix: disable helm integration tests for main because we do not have a 8.9 helm chart yet

### DIFF
--- a/.github/workflows/INTEGRATION_TEST.yml
+++ b/.github/workflows/INTEGRATION_TEST.yml
@@ -78,6 +78,7 @@ jobs:
           echo "Helm dir: ${{ steps.determine-helm-dir.outputs.helm-dir }}"
 
   helm-deploy:
+    if: github.ref != 'refs/heads/main'
     needs: prepare-inputs
     name: Helm chart Integration Tests
     uses: camunda/camunda-platform-helm/.github/workflows/test-integration-template.yaml@main


### PR DESCRIPTION


## Description

There are noisy alerts lately due to these failing helm chart integration tests. These are not expected to pass on main, since main of connectors (and camunda core) is referring to 8.9 builds and the helm chart is only on 8.8 at the moment.

This PR adds a conditional disabling the helm integration tests on main.

<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #

## Checklist

- [ ] PR has a **milestone** or the `no milestone` label.
- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest release, as this branch will be rebased onto main before the next release.

