### PR TITLE
fix(rest): Fix unsupported feature of rest connector in 8.6

### DIFF
--- a/connectors/http/rest/README.md
+++ b/connectors/http/rest/README.md
@@ -235,6 +235,6 @@ leading to the following result
 | Connector Info            |                                                                       |
 | ---                       | ---                                                                   |
 | Type                      | io.camunda:http-json:1                                                            |
-| Version                   | 11                                                         |
+| Version                   | 12                                                         |
 | Supported element types   |     |
 

--- a/connectors/http/rest/element-templates/hybrid/http-json-connector-hybrid.json
+++ b/connectors/http/rest/element-templates/hybrid/http-json-connector-hybrid.json
@@ -7,7 +7,7 @@
     "keywords" : [ ]
   },
   "documentationRef" : "https://docs.camunda.io/docs/components/connectors/protocol/rest/",
-  "version" : 11,
+  "version" : 12,
   "category" : {
     "id" : "connectors",
     "name" : "Connectors"
@@ -499,7 +499,7 @@
     "id" : "version",
     "label" : "Version",
     "description" : "Version of the element template",
-    "value" : "11",
+    "value" : "12",
     "group" : "connector",
     "binding" : {
       "key" : "elementTemplateVersion",

--- a/connectors/http/rest/element-templates/versioned/http-json-connector-10.json
+++ b/connectors/http/rest/element-templates/versioned/http-json-connector-10.json
@@ -531,20 +531,6 @@
       "type": "Text"
     },
     {
-      "id": "ignoreNullValues",
-      "label": "Ignore null values",
-      "optional": false,
-      "value": false,
-      "feel": "static",
-      "group": "payload",
-      "binding": {
-        "name": "ignoreNullValues",
-        "type": "zeebe:input"
-      },
-      "tooltip": "Null values will not be sent",
-      "type": "Boolean"
-    },
-    {
       "id": "resultVariable",
       "label": "Result variable",
       "description": "Name of variable to store the response in",

--- a/connectors/http/rest/element-templates/versioned/http-json-connector-11.json
+++ b/connectors/http/rest/element-templates/versioned/http-json-connector-11.json
@@ -7,7 +7,7 @@
     "keywords" : [ ]
   },
   "documentationRef" : "https://docs.camunda.io/docs/components/connectors/protocol/rest/",
-  "version" : 12,
+  "version" : 11,
   "category" : {
     "id" : "connectors",
     "name" : "Connectors"
@@ -478,23 +478,10 @@
     },
     "type" : "Text"
   }, {
-    "id" : "ignoreNullValues",
-    "label" : "Ignore null values",
-    "optional" : false,
-    "value" : false,
-    "feel" : "static",
-    "group" : "payload",
-    "binding" : {
-      "name" : "ignoreNullValues",
-      "type" : "zeebe:input"
-    },
-    "tooltip" : "Null values will not be sent",
-    "type" : "Boolean"
-  }, {
     "id" : "version",
     "label" : "Version",
     "description" : "Version of the element template",
-    "value" : "12",
+    "value" : "11",
     "group" : "connector",
     "binding" : {
       "key" : "elementTemplateVersion",

--- a/connectors/http/rest/src/main/java/io/camunda/connector/http/rest/HttpJsonFunction.java
+++ b/connectors/http/rest/src/main/java/io/camunda/connector/http/rest/HttpJsonFunction.java
@@ -50,7 +50,7 @@ import io.camunda.connector.http.rest.model.HttpJsonRequest;
     description = "Invoke REST API",
     inputDataClass = HttpJsonRequest.class,
     outputDataClass = HttpCommonResult.class,
-    version = 11,
+    version = 12,
     propertyGroups = {
       @PropertyGroup(id = "authentication", label = "Authentication"),
       @PropertyGroup(id = "endpoint", label = "HTTP endpoint"),


### PR DESCRIPTION
## Description

Andreas figured out that the "ignore null values" checkbox when sending rest requests does not work on 8.6. I checked and the feature was only implemented/backported in 8.7 and 8.8, but the Connectors template shows compatibility with ">8.3".

so currently we have this:
```
version: 11
engine version: "^8.3"
ignoreNullValues: present

version: 10
engine version: "^8.3"
ignoreNullValues: present

version: 9 -> Missing completely

version: 8
engine version: "^8.6"
ignoreNullValues: not present
```

and we want:

```
version: 12
engine version: "^8.7"
ignoreNullValues: present

version: 11
engine version: "^8.3"
ignoreNullValues: not present

version: 10
engine version: "^8.3"
ignoreNullValues: not present

version: 9 -> Missing completely

version: 8
engine version: "^8.6"
ignoreNullValues: not present
```

So i changed engine version of version 12 to ^8.7 and removed the flag from previous versions (11 and 10)

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #

## Checklist

- [ ] PR has a **milestone** or the `no milestone` label.
- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest release, as this branch will be rebased onto main before the next release.

