### PR TITLE
other(element-template): add condition to ExtensionProperty annotation

### DIFF
--- a/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/annotation/ElementTemplate.java
+++ b/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/annotation/ElementTemplate.java
@@ -138,6 +138,9 @@ public @interface ElementTemplate {
     String name();
 
     String value();
+
+    TemplateProperty.PropertyCondition condition() default
+        @TemplateProperty.PropertyCondition(property = "");
   }
 
   @interface ConnectorElementType {

--- a/element-template-generator/core/src/test/java/io/camunda/connector/generator/java/InboundClassBasedTemplateGeneratorTest.java
+++ b/element-template-generator/core/src/test/java/io/camunda/connector/generator/java/InboundClassBasedTemplateGeneratorTest.java
@@ -34,6 +34,7 @@ import io.camunda.connector.generator.dsl.PropertyBinding;
 import io.camunda.connector.generator.dsl.PropertyBinding.MessageProperty;
 import io.camunda.connector.generator.dsl.PropertyBinding.ZeebeProperty;
 import io.camunda.connector.generator.dsl.PropertyBinding.ZeebeSubscriptionProperty;
+import io.camunda.connector.generator.dsl.PropertyCondition;
 import io.camunda.connector.generator.dsl.PropertyCondition.Equals;
 import io.camunda.connector.generator.dsl.PropertyCondition.IsActive;
 import io.camunda.connector.generator.dsl.StringProperty;
@@ -446,11 +447,14 @@ public class InboundClassBasedTemplateGeneratorTest extends BaseTest {
               assertThat(p).isInstanceOf(HiddenProperty.class);
               assertThat(p.getBinding()).isEqualTo(new ZeebeProperty("myExtensionProperty1"));
               assertThat(p.getValue()).isEqualTo("value1");
+              assertThat(p.getCondition()).isNull();
             },
             p -> {
               assertThat(p).isInstanceOf(HiddenProperty.class);
               assertThat(p.getBinding()).isEqualTo(new ZeebeProperty("myExtensionProperty2"));
               assertThat(p.getValue()).isEqualTo("value2");
+              assertThat(p.getCondition())
+                  .isEqualTo(new PropertyCondition.Equals("prop1", "value1"));
             });
   }
 }

--- a/element-template-generator/core/src/test/java/io/camunda/connector/generator/java/OutboundClassBasedTemplateGeneratorTest.java
+++ b/element-template-generator/core/src/test/java/io/camunda/connector/generator/java/OutboundClassBasedTemplateGeneratorTest.java
@@ -615,12 +615,14 @@ public class OutboundClassBasedTemplateGeneratorTest extends BaseTest {
                 assertThat(p.getBinding())
                     .isEqualTo(new PropertyBinding.ZeebeProperty("myExtensionProperty1"));
                 assertThat(p.getValue()).isEqualTo("value1");
+                assertThat(p.getCondition()).isNull();
               },
               p -> {
                 assertThat(p).isInstanceOf(HiddenProperty.class);
                 assertThat(p.getBinding())
                     .isEqualTo(new PropertyBinding.ZeebeProperty("myExtensionProperty2"));
                 assertThat(p.getValue()).isEqualTo("value2");
+                assertThat(p.getCondition()).isEqualTo(new Equals("booleanProperty", false));
               });
     }
   }

--- a/element-template-generator/core/src/test/java/io/camunda/connector/generator/java/example/inbound/MyConnectorExecutable.java
+++ b/element-template-generator/core/src/test/java/io/camunda/connector/generator/java/example/inbound/MyConnectorExecutable.java
@@ -21,6 +21,7 @@ import io.camunda.connector.api.inbound.InboundConnectorContext;
 import io.camunda.connector.api.inbound.InboundConnectorExecutable;
 import io.camunda.connector.generator.java.annotation.ElementTemplate;
 import io.camunda.connector.generator.java.annotation.ElementTemplate.ExtensionProperty;
+import io.camunda.connector.generator.java.annotation.TemplateProperty;
 
 public class MyConnectorExecutable implements InboundConnectorExecutable<InboundConnectorContext> {
 
@@ -50,7 +51,10 @@ public class MyConnectorExecutable implements InboundConnectorExecutable<Inbound
       inputDataClass = MyConnectorProperties.class,
       extensionProperties = {
         @ExtensionProperty(name = "myExtensionProperty1", value = "value1"),
-        @ExtensionProperty(name = "myExtensionProperty2", value = "value2"),
+        @ExtensionProperty(
+            name = "myExtensionProperty2",
+            value = "value2",
+            condition = @TemplateProperty.PropertyCondition(property = "prop1", equals = "value1")),
       },
       icon = "my-connector-icon.png")
   public static class MinimallyAnnotatedWithExtensionProperties extends MyConnectorExecutable {}

--- a/element-template-generator/core/src/test/java/io/camunda/connector/generator/java/example/outbound/MyConnectorFunction.java
+++ b/element-template-generator/core/src/test/java/io/camunda/connector/generator/java/example/outbound/MyConnectorFunction.java
@@ -23,6 +23,7 @@ import io.camunda.connector.generator.dsl.BpmnType;
 import io.camunda.connector.generator.java.annotation.ElementTemplate;
 import io.camunda.connector.generator.java.annotation.ElementTemplate.ConnectorElementType;
 import io.camunda.connector.generator.java.annotation.ElementTemplate.PropertyGroup;
+import io.camunda.connector.generator.java.annotation.TemplateProperty;
 
 public abstract class MyConnectorFunction implements OutboundConnectorFunction {
 
@@ -111,7 +112,13 @@ public abstract class MyConnectorFunction implements OutboundConnectorFunction {
       inputDataClass = MyConnectorInput.class,
       extensionProperties = {
         @ElementTemplate.ExtensionProperty(name = "myExtensionProperty1", value = "value1"),
-        @ElementTemplate.ExtensionProperty(name = "myExtensionProperty2", value = "value2"),
+        @ElementTemplate.ExtensionProperty(
+            name = "myExtensionProperty2",
+            value = "value2",
+            condition =
+                @TemplateProperty.PropertyCondition(
+                    property = "booleanProperty",
+                    equalsBoolean = TemplateProperty.EqualsBoolean.FALSE)),
       })
   public static class MinimallyAnnotatedWithExtensionProperties extends MyConnectorFunction {}
 


### PR DESCRIPTION
## Description

Add `condition` to `ElementTemplate.ExtensionProperty` annotation.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #5505 

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.
- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest release, as this branch will be rebased onto main before the next release.

