### PR TITLE
fix(rest): Catch read timeouts so that we can display a meaningful error message

### DIFF
--- a/connector-commons/http-client/src/main/java/io/camunda/connector/http/client/client/apache/CustomApacheHttpClient.java
+++ b/connector-commons/http-client/src/main/java/io/camunda/connector/http/client/client/apache/CustomApacheHttpClient.java
@@ -25,6 +25,7 @@ import io.camunda.connector.http.client.exception.ConnectorExceptionMapper;
 import io.camunda.connector.http.client.model.HttpClientRequest;
 import io.camunda.connector.http.client.model.HttpClientResult;
 import java.io.IOException;
+import java.net.SocketTimeoutException;
 import java.util.Map;
 import javax.annotation.Nullable;
 import org.apache.hc.client5.http.ClientProtocolException;
@@ -70,6 +71,11 @@ public class CustomApacheHttpClient implements HttpClient {
       throw new ConnectorException(
           String.valueOf(HttpStatus.SC_SERVER_ERROR),
           "An error with the HTTP protocol occurred",
+          e);
+    } catch (SocketTimeoutException e) {
+      throw new ConnectorException(
+          String.valueOf(HttpStatus.SC_REQUEST_TIMEOUT),
+          "The request timed out. Please try increasing the read and connection timeouts.",
           e);
     } catch (IOException e) {
       throw new ConnectorException(

--- a/connector-commons/http-client/src/test/java/io/camunda/connector/http/client/client/apache/CustomApacheHttpClientTest.java
+++ b/connector-commons/http-client/src/test/java/io/camunda/connector/http/client/client/apache/CustomApacheHttpClientTest.java
@@ -613,7 +613,8 @@ public class CustomApacheHttpClientTest {
           assertThrows(ConnectorException.class, () -> customApacheHttpClient.execute(request));
       assertThat(e.getErrorCode()).isEqualTo(String.valueOf(HttpStatus.SC_REQUEST_TIMEOUT));
       assertThat(e.getMessage())
-          .contains("An error occurred while executing the request, or the connection was aborted");
+          .contains(
+              "The request timed out. Please try increasing the read and connection timeouts.");
     }
   }
 


### PR DESCRIPTION

## Description

This pull request improves how HTTP request timeouts are handled and reported in the Apache HTTP client implementation. The main change is the introduction of explicit handling for `SocketTimeoutException`, providing clearer error messages and more actionable feedback to users. Related tests have been updated to verify the new behavior.

## Related issues

closes https://github.com/camunda/connectors/issues/5514

## Checklist

- [ ] PR has a **milestone** or the `no milestone` label.
- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest release, as this branch will be rebased onto main before the next release.

