### PR TITLE
feat(agentic-ai): Implement fetch agent card operation

### DIFF
--- a/connectors/agentic-ai/pom.xml
+++ b/connectors/agentic-ai/pom.xml
@@ -21,6 +21,7 @@
     <version.record-builder>49</version.record-builder>
     <version.groovy>4.0.28</version.groovy>
     <version.gmavenplus-plugin>4.2.1</version.gmavenplus-plugin>
+    <version.a2asdk>0.3.0.Beta1</version.a2asdk>
   </properties>
 
   <licenses>
@@ -128,6 +129,12 @@
           <artifactId>netty-resolver-dns-native-macos</artifactId>
         </exclusion>
       </exclusions>
+    </dependency>
+
+    <dependency>
+      <groupId>io.github.a2asdk</groupId>
+      <artifactId>a2a-java-sdk-client</artifactId>
+      <version>${version.a2asdk}</version>
     </dependency>
 
     <dependency>

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/a2a/client/A2AClientRequestHandlerImpl.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/a2a/client/A2AClientRequestHandlerImpl.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.agenticai.a2a.client;
+
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
+
+import io.a2a.A2A;
+import io.a2a.spec.A2AClientError;
+import io.a2a.spec.AgentCard;
+import io.camunda.connector.agenticai.a2a.client.model.A2aClientOperationConfiguration.FetchAgentCardOperationConfiguration;
+import io.camunda.connector.agenticai.a2a.client.model.A2aClientOperationConfiguration.SendMessageOperationConfiguration;
+import io.camunda.connector.agenticai.a2a.client.model.A2aClientRequest;
+import io.camunda.connector.agenticai.a2a.client.model.A2aClientRequest.A2aClientRequestData.ConnectionConfiguration;
+import io.camunda.connector.agenticai.a2a.client.model.result.A2aAgentCardResult;
+import io.camunda.connector.agenticai.a2a.client.model.result.A2aClientResult;
+import java.util.Collections;
+import org.apache.commons.collections4.CollectionUtils;
+
+public class A2AClientRequestHandlerImpl implements A2aClientRequestHandler {
+
+  @Override
+  public A2aClientResult handle(A2aClientRequest request) {
+    return switch (request.data().operation()) {
+      case FetchAgentCardOperationConfiguration ignored ->
+          fetchAgentCard(request.data().connection());
+      case SendMessageOperationConfiguration sendMessage -> null;
+    };
+  }
+
+  private A2aAgentCardResult fetchAgentCard(ConnectionConfiguration connection) {
+    final var relativeCardPath =
+        isNotBlank(connection.agentCardLocation()) ? connection.agentCardLocation() : null;
+    try {
+      AgentCard agentCard =
+          A2A.getAgentCard(connection.url(), relativeCardPath, Collections.emptyMap());
+      return convertAgentCard(agentCard);
+    } catch (A2AClientError e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private A2aAgentCardResult convertAgentCard(AgentCard agentCard) {
+    final var agentSkills =
+        agentCard.skills().stream()
+            .map(
+                agentSkill ->
+                    new A2aAgentCardResult.AgentSkill(
+                        agentSkill.id(),
+                        agentSkill.name(),
+                        agentSkill.description(),
+                        agentSkill.tags(),
+                        agentSkill.examples(),
+                        CollectionUtils.isEmpty(agentSkill.inputModes())
+                            ? agentCard.defaultInputModes()
+                            : agentSkill.inputModes(),
+                        CollectionUtils.isEmpty(agentSkill.outputModes())
+                            ? agentCard.defaultOutputModes()
+                            : agentSkill.outputModes()))
+            .toList();
+    return new A2aAgentCardResult(agentCard.name(), agentCard.description(), agentSkills);
+  }
+}

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/a2a/client/A2aClientFunction.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/a2a/client/A2aClientFunction.java
@@ -36,8 +36,15 @@ import io.camunda.connector.generator.java.annotation.ElementTemplate;
     icon = "a2a-client.svg")
 public class A2aClientFunction implements OutboundConnectorFunction {
 
+  private final A2aClientRequestHandler handler;
+
+  public A2aClientFunction(A2aClientRequestHandler handler) {
+    this.handler = handler;
+  }
+
   @Override
   public A2aClientResult execute(OutboundConnectorContext context) throws Exception {
-    return null;
+    final A2aClientRequest request = context.bindVariables(A2aClientRequest.class);
+    return handler.handle(request);
   }
 }

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/a2a/client/A2aClientRequestHandler.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/a2a/client/A2aClientRequestHandler.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.agenticai.a2a.client;
+
+import io.camunda.connector.agenticai.a2a.client.model.A2aClientRequest;
+import io.camunda.connector.agenticai.a2a.client.model.result.A2aClientResult;
+
+public interface A2aClientRequestHandler {
+  A2aClientResult handle(A2aClientRequest request);
+}

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/a2a/client/configuration/A2aClientConfiguration.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/a2a/client/configuration/A2aClientConfiguration.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.agenticai.a2a.client.configuration;
+
+import io.camunda.connector.agenticai.a2a.client.A2AClientRequestHandlerImpl;
+import io.camunda.connector.agenticai.a2a.client.A2aClientFunction;
+import io.camunda.connector.agenticai.a2a.client.A2aClientRequestHandler;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class A2aClientConfiguration {
+
+  @Bean
+  @ConditionalOnMissingBean
+  public A2aClientRequestHandler a2aClientRequestHandler() {
+    return new A2AClientRequestHandlerImpl();
+  }
+
+  @Bean
+  @ConditionalOnMissingBean
+  public A2aClientFunction a2aClientFunction(A2aClientRequestHandler handler) {
+    return new A2aClientFunction(handler);
+  }
+}

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/a2a/client/model/result/A2aAgentCardResult.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/a2a/client/model/result/A2aAgentCardResult.java
@@ -16,6 +16,8 @@ import java.util.List;
 public record A2aAgentCardResult(String name, String description, List<AgentSkill> skills)
     implements A2aClientResult {
 
+  @AgenticAiRecord
+  @JsonDeserialize(builder = AgentSkill.AgentSkillJacksonProxyBuilder.class)
   public record AgentSkill(
       String id,
       String name,
@@ -23,7 +25,15 @@ public record A2aAgentCardResult(String name, String description, List<AgentSkil
       List<String> tags,
       List<String> examples,
       List<String> inputModes,
-      List<String> outputModes) {}
+      List<String> outputModes) {
+
+    public static A2aAgentCardResultAgentSkillBuilder builder() {
+      return A2aAgentCardResultAgentSkillBuilder.builder();
+    }
+
+    @JsonPOJOBuilder(withPrefix = "")
+    public static class AgentSkillJacksonProxyBuilder extends A2aAgentCardResultAgentSkillBuilder {}
+  }
 
   public static A2aAgentCardResultBuilder builder() {
     return A2aAgentCardResultBuilder.builder();

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/autoconfigure/AgenticAiConnectorsAutoConfiguration.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/autoconfigure/AgenticAiConnectorsAutoConfiguration.java
@@ -9,6 +9,7 @@ package io.camunda.connector.agenticai.autoconfigure;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.client.CamundaClient;
 import io.camunda.client.jobhandling.CommandExceptionHandlingStrategy;
+import io.camunda.connector.agenticai.a2a.client.configuration.A2aClientConfiguration;
 import io.camunda.connector.agenticai.adhoctoolsschema.AdHocToolsSchemaFunction;
 import io.camunda.connector.agenticai.adhoctoolsschema.processdefinition.CachingProcessDefinitionAdHocToolElementsResolver;
 import io.camunda.connector.agenticai.adhoctoolsschema.processdefinition.CamundaClientProcessDefinitionAdHocToolElementsResolver;
@@ -77,7 +78,8 @@ import org.springframework.core.env.Environment;
   AgenticAiLangchain4JFrameworkConfiguration.class,
   McpDiscoveryConfiguration.class,
   McpClientConfiguration.class,
-  McpRemoteClientConfiguration.class
+  McpRemoteClientConfiguration.class,
+  A2aClientConfiguration.class
 })
 public class AgenticAiConnectorsAutoConfiguration {
 

--- a/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/a2a/client/A2AClientRequestHandlerImplTest.java
+++ b/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/a2a/client/A2AClientRequestHandlerImplTest.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+
+package io.camunda.connector.agenticai.a2a.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+import io.a2a.A2A;
+import io.a2a.spec.AgentCapabilities;
+import io.a2a.spec.AgentCard;
+import io.a2a.spec.AgentInterface;
+import io.a2a.spec.AgentSkill;
+import io.a2a.spec.TransportProtocol;
+import io.camunda.connector.agenticai.a2a.client.model.A2aClientOperationConfiguration.FetchAgentCardOperationConfiguration;
+import io.camunda.connector.agenticai.a2a.client.model.A2aClientRequest;
+import io.camunda.connector.agenticai.a2a.client.model.A2aClientRequest.A2aClientRequestData;
+import io.camunda.connector.agenticai.a2a.client.model.A2aClientRequest.A2aClientRequestData.ConnectionConfiguration;
+import io.camunda.connector.agenticai.a2a.client.model.result.A2aAgentCardResult;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.mockito.MockedStatic;
+
+class A2AClientRequestHandlerImplTest {
+
+  @Nested
+  class FetchAgentCard {
+
+    public static final String AGENT_URL = "https://a2a.example.com";
+    public static final List<String> DEFAULT_INPUT_MODES = List.of("text");
+    public static final List<String> DEFAULT_OUTPUT_MODES = List.of("application/json");
+
+    @Test
+    void fetchAgentCardWithCustomLocation() {
+      final var location = "abc/agent.json";
+      final var request = buildRequest(location);
+      final var handler = new A2AClientRequestHandlerImpl();
+      final var agentCard = createAgentCard(null, null);
+
+      try (MockedStatic<A2A> a2aStatic = mockStatic(A2A.class)) {
+        a2aStatic.when(() -> A2A.getAgentCard(anyString(), any(), anyMap())).thenReturn(agentCard);
+
+        final var result = handler.handle(request);
+
+        a2aStatic.verify(() -> A2A.getAgentCard(AGENT_URL, location, Collections.emptyMap()));
+        assertThat(result).isInstanceOf(A2aAgentCardResult.class);
+        assertAgentCard((A2aAgentCardResult) result, DEFAULT_INPUT_MODES, DEFAULT_OUTPUT_MODES);
+      }
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    void fetchAgentCardWithoutCustomLocation(String agentCardLocation) {
+      final var request = buildRequest(agentCardLocation);
+      final var handler = new A2AClientRequestHandlerImpl();
+      final var agentCard = createAgentCard(null, null);
+
+      try (MockedStatic<A2A> a2aStatic = mockStatic(A2A.class)) {
+        a2aStatic.when(() -> A2A.getAgentCard(anyString(), any(), anyMap())).thenReturn(agentCard);
+
+        final var result = handler.handle(request);
+
+        a2aStatic.verify(() -> A2A.getAgentCard(AGENT_URL, null, Collections.emptyMap()));
+        assertThat(result).isInstanceOf(A2aAgentCardResult.class);
+        assertAgentCard((A2aAgentCardResult) result, DEFAULT_INPUT_MODES, DEFAULT_OUTPUT_MODES);
+      }
+    }
+
+    @Test
+    void fetchAgentCardWithSkillsInputAndOutputMode() {
+      List<String> inputModes = List.of("text", "application/json");
+      List<String> outputModes = List.of("image/jpeg");
+      final var request = buildRequest(null);
+      final var handler = new A2AClientRequestHandlerImpl();
+      final var agentCard = createAgentCard(inputModes, outputModes);
+
+      try (MockedStatic<A2A> a2aStatic = mockStatic(A2A.class)) {
+        a2aStatic.when(() -> A2A.getAgentCard(anyString(), any(), anyMap())).thenReturn(agentCard);
+
+        final var result = handler.handle(request);
+
+        a2aStatic.verify(() -> A2A.getAgentCard(AGENT_URL, null, Collections.emptyMap()));
+        assertThat(result).isInstanceOf(A2aAgentCardResult.class);
+        assertAgentCard((A2aAgentCardResult) result, inputModes, outputModes);
+      }
+    }
+
+    private A2aClientRequest buildRequest(String agentCardLocation) {
+      final var connection = new ConnectionConfiguration(AGENT_URL, agentCardLocation);
+      final var data =
+          new A2aClientRequestData(connection, new FetchAgentCardOperationConfiguration());
+      return new A2aClientRequest(data);
+    }
+
+    private AgentCard createAgentCard(List<String> skillInputModes, List<String> skillOutputModes) {
+      return new AgentCard.Builder()
+          .name("Travel agent")
+          .description("Helps with travel bookings")
+          .url("http://localhost:9999")
+          .version("1.0.0")
+          .documentationUrl("http://example.com/docs")
+          .capabilities(
+              new AgentCapabilities.Builder()
+                  .streaming(true)
+                  .pushNotifications(true)
+                  .stateTransitionHistory(true)
+                  .build())
+          .defaultInputModes(DEFAULT_INPUT_MODES)
+          .defaultOutputModes(DEFAULT_OUTPUT_MODES)
+          .skills(
+              List.of(
+                  new AgentSkill.Builder()
+                      .id("hotel-booking")
+                      .name("Hotel Booking")
+                      .description("Book a hotel room")
+                      .tags(List.of("booking", "hotel"))
+                      .examples(List.of("Book a single room", "Book a double room"))
+                      .inputModes(skillInputModes)
+                      .outputModes(skillOutputModes)
+                      .build()))
+          .protocolVersion("0.3.0")
+          .additionalInterfaces(
+              List.of(
+                  new AgentInterface(
+                      TransportProtocol.JSONRPC.asString(), "http://localhost:9999")))
+          .build();
+    }
+
+    private void assertAgentCard(
+        A2aAgentCardResult agentCardResult, List<String> inputModes, List<String> outputModes) {
+      assertThat(agentCardResult.name()).isEqualTo("Travel agent");
+      assertThat(agentCardResult.description()).isEqualTo("Helps with travel bookings");
+      assertThat(agentCardResult.skills())
+          .containsExactly(
+              A2aAgentCardResult.AgentSkill.builder()
+                  .id("hotel-booking")
+                  .name("Hotel Booking")
+                  .description("Book a hotel room")
+                  .tags(List.of("booking", "hotel"))
+                  .examples(List.of("Book a single room", "Book a double room"))
+                  .inputModes(inputModes)
+                  .outputModes(outputModes)
+                  .build());
+    }
+  }
+}


### PR DESCRIPTION
## Description

Implement the Fetch Agent Card operation using the [A2A Java SDK](https://github.com/a2aproject/a2a-java). Use the server URL and the optional custom agent card location from the input configuration.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #5499

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.
- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest release, as this branch will be rebased onto main before the next release.

