### PR TITLE
fix(bedrock): Remove temp and topP defaults

### DIFF
--- a/connectors/aws/aws-bedrock/src/main/java/io/camunda/connector/aws/bedrock/model/ConverseData.java
+++ b/connectors/aws/aws-bedrock/src/main/java/io/camunda/connector/aws/bedrock/model/ConverseData.java
@@ -79,7 +79,7 @@ public final class ConverseData implements RequestData {
       feel = Property.FeelMode.optional,
       optional = true,
       binding = @TemplateProperty.PropertyBinding(name = "data.temperature"))
-  private Float temperature = 0.5f;
+  private Float temperature;
 
   @TemplateProperty(
       label = "top P",
@@ -88,7 +88,7 @@ public final class ConverseData implements RequestData {
       feel = Property.FeelMode.optional,
       optional = true,
       binding = @TemplateProperty.PropertyBinding(name = "data.topP"))
-  private Float topP = 0.9f;
+  private Float topP;
 
   @TemplateProperty(
       label = "documents",


### PR DESCRIPTION
## Description
Removed the defaults, so models like claude sonnet 4.5 can be used.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes https://github.com/camunda/connectors/issues/5491

## Checklist

- [ ] PR has a **milestone** or the `no milestone` label.
- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest release, as this branch will be rebased onto main before the next release.

