### PR TITLE
chore(embeddings-vector-db): Dependency manage Apache Tika version

### DIFF
--- a/connectors/embeddings-vector-database/pom.xml
+++ b/connectors/embeddings-vector-database/pom.xml
@@ -23,6 +23,10 @@
     </license>
   </licenses>
 
+  <properties>
+    <version.apache-tika>3.2.3</version.apache-tika>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>io.camunda.connector</groupId>
@@ -74,6 +78,26 @@
     <dependency>
       <groupId>dev.langchain4j</groupId>
       <artifactId>langchain4j-document-parser-apache-tika</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.tika</groupId>
+          <artifactId>tika-core</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.tika</groupId>
+          <artifactId>tika-parsers-standard-package</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.tika</groupId>
+      <artifactId>tika-core</artifactId>
+      <version>${version.apache-tika}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.tika</groupId>
+      <artifactId>tika-parsers-standard-package</artifactId>
+      <version>${version.apache-tika}</version>
     </dependency>
 
     <dependency>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -150,9 +150,8 @@ limitations under the License.</license.inlineheader>
 
     <version.auth0.jwt>4.5.0</version.auth0.jwt>
     <version.auth0.jwks>0.23.0</version.auth0.jwks>
-
+    
     <version.langchain4j>1.3.0</version.langchain4j>
-    <version.apache-tika>3.2.3</version.apache-tika>
 
     <!-- maven plugins (not managed by parent) -->
     <plugin.version.maven-enforcer-plugin>3.6.2</plugin.version.maven-enforcer-plugin>
@@ -217,13 +216,6 @@ limitations under the License.</license.inlineheader>
         <groupId>dev.langchain4j</groupId>
         <artifactId>langchain4j-bom</artifactId>
         <version>${version.langchain4j}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.tika</groupId>
-        <artifactId>tika-bom</artifactId>
-        <version>${version.apache-tika}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
Allows to control the Apache Tika version to individually update it independent of Langchain4J in order to include latest security patches.

## Description

The Apache Tika version 3.0.0 provided by Langchain4J quite behind the latest `3.2.3` and does not include all security patches. After upgrading to `3.2.3`, the embeddings connector still works as expected with PDF files (tested manually + in tests).

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.
- [x] Backport labels are added if these code changes should be backported. No backport label is added to the latest release, as this branch will be rebased onto main before the next release.

