### PR TITLE
feat(agentic-ai): Support retrieving A2A conversation history

### DIFF
--- a/connectors/agentic-ai/element-templates/agenticai-a2a-client-outbound-connector.json
+++ b/connectors/agentic-ai/element-templates/agenticai-a2a-client-outbound-connector.json
@@ -180,7 +180,31 @@
     "tooltip" : "Referenced documents that will be added to the message.",
     "type" : "String"
   }, {
-    "id" : "data.connectorMode.operation.timeout",
+    "id" : "data.connectorMode.operation.settings.historyLength",
+    "label" : "History length",
+    "description" : "The number of most recent messages from the task's history to retrieve in the response.",
+    "optional" : false,
+    "value" : 3,
+    "feel" : "optional",
+    "group" : "operation",
+    "binding" : {
+      "name" : "data.connectorMode.operation.settings.historyLength",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "allMatch" : [ {
+        "property" : "data.connectorMode.operation.type",
+        "equals" : "sendMessage",
+        "type" : "simple"
+      }, {
+        "property" : "data.connectorMode.type",
+        "equals" : "standalone",
+        "type" : "simple"
+      } ]
+    },
+    "type" : "Number"
+  }, {
+    "id" : "data.connectorMode.operation.settings.timeout",
     "label" : "Response timeout",
     "description" : "How long to wait for the remote agent response as ISO-8601 duration (example: <code>PT1M</code>).",
     "optional" : false,
@@ -188,7 +212,7 @@
     "feel" : "optional",
     "group" : "operation",
     "binding" : {
-      "name" : "data.connectorMode.operation.timeout",
+      "name" : "data.connectorMode.operation.settings.timeout",
       "type" : "zeebe:input"
     },
     "condition" : {
@@ -243,7 +267,25 @@
     },
     "type" : "Text"
   }, {
-    "id" : "data.connectorMode.toolOperation.timeout",
+    "id" : "data.connectorMode.toolOperation.sendMessageSettings.historyLength",
+    "label" : "History length",
+    "description" : "The number of most recent messages from the task's history to retrieve in the response.",
+    "optional" : false,
+    "value" : 3,
+    "feel" : "optional",
+    "group" : "operation",
+    "binding" : {
+      "name" : "data.connectorMode.toolOperation.sendMessageSettings.historyLength",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "data.connectorMode.type",
+      "equals" : "aiAgentTool",
+      "type" : "simple"
+    },
+    "type" : "Number"
+  }, {
+    "id" : "data.connectorMode.toolOperation.sendMessageSettings.timeout",
     "label" : "Response timeout",
     "description" : "How long to wait for the remote agent response as ISO-8601 duration (example: <code>PT1M</code>).",
     "optional" : false,
@@ -251,7 +293,7 @@
     "feel" : "optional",
     "group" : "operation",
     "binding" : {
-      "name" : "data.connectorMode.toolOperation.timeout",
+      "name" : "data.connectorMode.toolOperation.sendMessageSettings.timeout",
       "type" : "zeebe:input"
     },
     "condition" : {

--- a/connectors/agentic-ai/element-templates/hybrid/agenticai-a2a-client-outbound-connector-hybrid.json
+++ b/connectors/agentic-ai/element-templates/hybrid/agenticai-a2a-client-outbound-connector-hybrid.json
@@ -185,7 +185,31 @@
     "tooltip" : "Referenced documents that will be added to the message.",
     "type" : "String"
   }, {
-    "id" : "data.connectorMode.operation.timeout",
+    "id" : "data.connectorMode.operation.settings.historyLength",
+    "label" : "History length",
+    "description" : "The number of most recent messages from the task's history to retrieve in the response.",
+    "optional" : false,
+    "value" : 3,
+    "feel" : "optional",
+    "group" : "operation",
+    "binding" : {
+      "name" : "data.connectorMode.operation.settings.historyLength",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "allMatch" : [ {
+        "property" : "data.connectorMode.operation.type",
+        "equals" : "sendMessage",
+        "type" : "simple"
+      }, {
+        "property" : "data.connectorMode.type",
+        "equals" : "standalone",
+        "type" : "simple"
+      } ]
+    },
+    "type" : "Number"
+  }, {
+    "id" : "data.connectorMode.operation.settings.timeout",
     "label" : "Response timeout",
     "description" : "How long to wait for the remote agent response as ISO-8601 duration (example: <code>PT1M</code>).",
     "optional" : false,
@@ -193,7 +217,7 @@
     "feel" : "optional",
     "group" : "operation",
     "binding" : {
-      "name" : "data.connectorMode.operation.timeout",
+      "name" : "data.connectorMode.operation.settings.timeout",
       "type" : "zeebe:input"
     },
     "condition" : {
@@ -248,7 +272,25 @@
     },
     "type" : "Text"
   }, {
-    "id" : "data.connectorMode.toolOperation.timeout",
+    "id" : "data.connectorMode.toolOperation.sendMessageSettings.historyLength",
+    "label" : "History length",
+    "description" : "The number of most recent messages from the task's history to retrieve in the response.",
+    "optional" : false,
+    "value" : 3,
+    "feel" : "optional",
+    "group" : "operation",
+    "binding" : {
+      "name" : "data.connectorMode.toolOperation.sendMessageSettings.historyLength",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "data.connectorMode.type",
+      "equals" : "aiAgentTool",
+      "type" : "simple"
+    },
+    "type" : "Number"
+  }, {
+    "id" : "data.connectorMode.toolOperation.sendMessageSettings.timeout",
     "label" : "Response timeout",
     "description" : "How long to wait for the remote agent response as ISO-8601 duration (example: <code>PT1M</code>).",
     "optional" : false,
@@ -256,7 +298,7 @@
     "feel" : "optional",
     "group" : "operation",
     "binding" : {
-      "name" : "data.connectorMode.toolOperation.timeout",
+      "name" : "data.connectorMode.toolOperation.sendMessageSettings.timeout",
       "type" : "zeebe:input"
     },
     "condition" : {

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/a2a/client/api/A2aSdkClientFactory.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/a2a/client/api/A2aSdkClientFactory.java
@@ -12,5 +12,6 @@ import io.a2a.spec.AgentCard;
 import java.util.function.BiConsumer;
 
 public interface A2aSdkClientFactory {
-  Client buildClient(AgentCard agentCard, BiConsumer<ClientEvent, AgentCard> consumer);
+  Client buildClient(
+      AgentCard agentCard, BiConsumer<ClientEvent, AgentCard> consumer, int historyLength);
 }

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/a2a/client/convert/A2aSdkObjectConverterImpl.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/a2a/client/convert/A2aSdkObjectConverterImpl.java
@@ -28,7 +28,8 @@ public class A2aSdkObjectConverterImpl implements A2aSdkObjectConverter {
   public A2aMessage convert(Message message) {
     List<Content> contents = partToContentConverter.convert(message.getParts());
     return A2aMessage.builder()
-        .role(A2aMessage.Role.AGENT)
+        .role(
+            message.getRole() == Message.Role.AGENT ? A2aMessage.Role.AGENT : A2aMessage.Role.USER)
         .messageId(message.getMessageId())
         .contextId(message.getContextId())
         .referenceTaskIds(message.getReferenceTaskIds())
@@ -46,7 +47,15 @@ public class A2aSdkObjectConverterImpl implements A2aSdkObjectConverter {
         .status(convertStatus(task.getStatus()))
         .metadata(task.getMetadata())
         .artifacts(convertArtifacts(task))
+        .history(convertHistory(task.getHistory()))
         .build();
+  }
+
+  private List<A2aMessage> convertHistory(List<Message> history) {
+    if (history == null) {
+      return List.of();
+    }
+    return history.stream().map(this::convert).toList();
   }
 
   private List<A2aArtifact> convertArtifacts(Task task) {

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/a2a/client/impl/A2aMessageSenderImpl.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/a2a/client/impl/A2aMessageSenderImpl.java
@@ -57,7 +57,9 @@ public class A2aMessageSenderImpl implements A2aMessageSender {
           }
         };
 
-    Client client = clientFactory.buildClient(agentCard, consumer);
+    Client client =
+        clientFactory.buildClient(
+            agentCard, consumer, sendMessageOperation.settings().historyLength());
     try {
       client.sendMessage(message);
     } catch (A2AClientException e) {
@@ -65,7 +67,8 @@ public class A2aMessageSenderImpl implements A2aMessageSender {
     }
 
     try {
-      return response.get(sendMessageOperation.timeout().toMillis(), TimeUnit.MILLISECONDS);
+      return response.get(
+          sendMessageOperation.settings().timeout().toMillis(), TimeUnit.MILLISECONDS);
     } catch (TimeoutException e) {
       // TODO: should be a ConnectorException with a specific error code?
       throw new RuntimeException("Timed out waiting for response from agent.", e);

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/a2a/client/impl/A2aRequestHandlerImpl.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/a2a/client/impl/A2aRequestHandlerImpl.java
@@ -68,7 +68,7 @@ public class A2aRequestHandlerImpl implements A2aRequestHandler {
         return new SendMessageOperationConfiguration(
             new SendMessageOperationConfiguration.Parameters(
                 operation.params().get("message").toString(), List.of()),
-            operation.timeout());
+            operation.sendMessageSettings());
       }
       default ->
           throw new IllegalArgumentException(

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/a2a/client/model/A2aCommonSendMessageConfiguration.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/a2a/client/model/A2aCommonSendMessageConfiguration.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.agenticai.a2a.client.model;
+
+import io.camunda.connector.generator.dsl.Property;
+import io.camunda.connector.generator.java.annotation.TemplateProperty;
+import jakarta.validation.constraints.PositiveOrZero;
+import java.time.Duration;
+
+public record A2aCommonSendMessageConfiguration(
+    @PositiveOrZero
+        @TemplateProperty(
+            group = "operation",
+            label = "History length",
+            description =
+                "The number of most recent messages from the task's history to retrieve in the response.",
+            feel = Property.FeelMode.optional,
+            defaultValueType = TemplateProperty.DefaultValueType.Number,
+            defaultValue = "3")
+        Integer historyLength,
+    @TemplateProperty(
+            group = "operation",
+            label = "Response timeout",
+            description =
+                "How long to wait for the remote agent response as ISO-8601 duration (example: <code>PT1M</code>).",
+            defaultValue = "PT1M")
+        Duration timeout) {}

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/a2a/client/model/A2aStandaloneOperationConfiguration.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/a2a/client/model/A2aStandaloneOperationConfiguration.java
@@ -20,7 +20,6 @@ import io.camunda.connector.generator.java.annotation.TemplateSubType;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
-import java.time.Duration;
 import java.util.List;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
@@ -51,14 +50,7 @@ public sealed interface A2aStandaloneOperationConfiguration
 
   @TemplateSubType(id = SEND_MESSAGE_ID, label = "Send message")
   record SendMessageOperationConfiguration(
-      @Valid @NotNull Parameters params,
-      @TemplateProperty(
-              group = "operation",
-              label = "Response timeout",
-              description =
-                  "How long to wait for the remote agent response as ISO-8601 duration (example: <code>PT1M</code>).",
-              defaultValue = "PT1M")
-          Duration timeout)
+      @Valid @NotNull Parameters params, @Valid @NotNull A2aCommonSendMessageConfiguration settings)
       implements A2aStandaloneOperationConfiguration {
 
     @TemplateProperty(ignore = true)

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/a2a/client/model/A2aToolOperationConfiguration.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/a2a/client/model/A2aToolOperationConfiguration.java
@@ -9,8 +9,9 @@ package io.camunda.connector.agenticai.a2a.client.model;
 import io.camunda.connector.api.annotation.FEEL;
 import io.camunda.connector.generator.dsl.Property;
 import io.camunda.connector.generator.java.annotation.TemplateProperty;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
-import java.time.Duration;
+import jakarta.validation.constraints.NotNull;
 import java.util.Map;
 
 public record A2aToolOperationConfiguration(
@@ -36,10 +37,4 @@ public record A2aToolOperationConfiguration(
             feel = Property.FeelMode.required,
             optional = true)
         Map<String, Object> params,
-    @TemplateProperty(
-            group = "operation",
-            label = "Response timeout",
-            description =
-                "How long to wait for the remote agent response as ISO-8601 duration (example: <code>PT1M</code>).",
-            defaultValue = "PT1M")
-        Duration timeout) {}
+    @Valid @NotNull A2aCommonSendMessageConfiguration sendMessageSettings) {}

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/a2a/client/model/result/A2aTask.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/a2a/client/model/result/A2aTask.java
@@ -21,7 +21,8 @@ public record A2aTask(
     String contextId,
     A2aTaskStatus status,
     @JsonInclude(JsonInclude.Include.NON_EMPTY) Map<String, Object> metadata,
-    @JsonInclude(JsonInclude.Include.NON_EMPTY) List<A2aArtifact> artifacts)
+    @JsonInclude(JsonInclude.Include.NON_EMPTY) List<A2aArtifact> artifacts,
+    @JsonInclude(JsonInclude.Include.NON_EMPTY) List<A2aMessage> history)
     implements A2aSendMessageResult {
 
   public static final String TASK = "task";

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/a2a/client/sdk/A2aSdkClientFactoryImpl.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/a2a/client/sdk/A2aSdkClientFactoryImpl.java
@@ -19,10 +19,16 @@ import java.util.function.BiConsumer;
 public class A2aSdkClientFactoryImpl implements A2aSdkClientFactory {
 
   @Override
-  public Client buildClient(AgentCard agentCard, BiConsumer<ClientEvent, AgentCard> consumer) {
+  public Client buildClient(
+      AgentCard agentCard, BiConsumer<ClientEvent, AgentCard> consumer, int historyLength) {
     try {
       return Client.builder(agentCard)
-          .clientConfig(new ClientConfig.Builder().setStreaming(false).setPolling(false).build())
+          .clientConfig(
+              new ClientConfig.Builder()
+                  .setStreaming(false)
+                  .setPolling(false)
+                  .setHistoryLength(historyLength)
+                  .build())
           .withTransport(JSONRPCTransport.class, new JSONRPCTransportConfig())
           .addConsumer(consumer)
           .build();

--- a/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/a2a/client/impl/A2aMessageSenderTest.java
+++ b/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/a2a/client/impl/A2aMessageSenderTest.java
@@ -9,6 +9,7 @@ package io.camunda.connector.agenticai.a2a.client.impl;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
@@ -25,6 +26,7 @@ import io.a2a.spec.TextPart;
 import io.camunda.connector.agenticai.a2a.client.api.A2aSdkClientFactory;
 import io.camunda.connector.agenticai.a2a.client.api.A2aSendMessageResponseHandler;
 import io.camunda.connector.agenticai.a2a.client.convert.A2aDocumentToPartConverter;
+import io.camunda.connector.agenticai.a2a.client.model.A2aCommonSendMessageConfiguration;
 import io.camunda.connector.agenticai.a2a.client.model.A2aStandaloneOperationConfiguration.SendMessageOperationConfiguration;
 import io.camunda.connector.agenticai.a2a.client.model.A2aStandaloneOperationConfiguration.SendMessageOperationConfiguration.Parameters;
 import io.camunda.connector.agenticai.a2a.client.model.result.A2aMessage;
@@ -59,7 +61,7 @@ class A2aMessageSenderTest {
 
   @BeforeEach
   void setUp() {
-    when(clientFactory.buildClient(eq(agentCard), any()))
+    when(clientFactory.buildClient(eq(agentCard), any(), anyInt()))
         .thenAnswer(
             inv -> {
               consumerRef.set(inv.getArgument(1));
@@ -121,7 +123,8 @@ class A2aMessageSenderTest {
     Document document = mock(Document.class);
     var operation =
         new SendMessageOperationConfiguration(
-            new Parameters("hello", List.of(document)), Duration.ofSeconds(1));
+            new Parameters("hello", List.of(document)),
+            new A2aCommonSendMessageConfiguration(1, Duration.ofSeconds(1)));
 
     MessageEvent clientEvent = newMessageEvent();
     var expectedResult = messageResult(MESSAGE_ID);
@@ -155,7 +158,8 @@ class A2aMessageSenderTest {
   }
 
   private SendMessageOperationConfiguration newSendMessageOperation(Duration timeout) {
-    return new SendMessageOperationConfiguration(new Parameters("hello", null), timeout);
+    return new SendMessageOperationConfiguration(
+        new Parameters("hello", null), new A2aCommonSendMessageConfiguration(0, timeout));
   }
 
   private MessageEvent newMessageEvent() {

--- a/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/a2a/client/impl/A2aRequestHandlerTest.java
+++ b/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/a2a/client/impl/A2aRequestHandlerTest.java
@@ -18,6 +18,7 @@ import static org.mockito.Mockito.when;
 import io.a2a.spec.AgentCard;
 import io.camunda.connector.agenticai.a2a.client.api.A2aAgentCardFetcher;
 import io.camunda.connector.agenticai.a2a.client.api.A2aMessageSender;
+import io.camunda.connector.agenticai.a2a.client.model.A2aCommonSendMessageConfiguration;
 import io.camunda.connector.agenticai.a2a.client.model.A2aConnectorModeConfiguration;
 import io.camunda.connector.agenticai.a2a.client.model.A2aRequest;
 import io.camunda.connector.agenticai.a2a.client.model.A2aRequest.A2aRequestData;
@@ -80,7 +81,8 @@ class A2aRequestHandlerTest {
       var agentCard = mock(AgentCard.class);
       var operation =
           new SendMessageOperationConfiguration(
-              new Parameters("Hello", null), Duration.ofSeconds(1));
+              new Parameters("Hello", null),
+              new A2aCommonSendMessageConfiguration(1, Duration.ofSeconds(1)));
       var request =
           new A2aRequest(
               new A2aRequestData(
@@ -117,7 +119,10 @@ class A2aRequestHandlerTest {
     @Test
     void handleFetchAgentCard() {
       var operation =
-          new A2aToolOperationConfiguration("fetchAgentCard", null, Duration.ofSeconds(10));
+          new A2aToolOperationConfiguration(
+              "fetchAgentCard",
+              null,
+              new A2aCommonSendMessageConfiguration(1, Duration.ofSeconds(10)));
       var request =
           new A2aRequest(
               new A2aRequestData(
@@ -138,7 +143,8 @@ class A2aRequestHandlerTest {
     void handleSendMessage() {
       var params = Map.<String, Object>of("message", "Hello, agent!");
       var timeout = Duration.ofSeconds(45);
-      var operation = new A2aToolOperationConfiguration("sendMessage", params, timeout);
+      var commonConfiguration = new A2aCommonSendMessageConfiguration(10, timeout);
+      var operation = new A2aToolOperationConfiguration("sendMessage", params, commonConfiguration);
       var request =
           new A2aRequest(
               new A2aRequestData(
@@ -167,7 +173,7 @@ class A2aRequestHandlerTest {
       var convertedOperation = opCaptor.getValue();
       assertThat(convertedOperation.params().text()).isEqualTo("Hello, agent!");
       assertThat(convertedOperation.params().documents()).isEqualTo(List.of());
-      assertThat(convertedOperation.timeout()).isEqualTo(timeout);
+      assertThat(convertedOperation.settings()).isEqualTo(commonConfiguration);
 
       verify(agentCardFetcher).fetchAgentCardRaw(CONNECTION);
       verify(agentCardFetcher, never()).fetchAgentCard(CONNECTION);
@@ -175,7 +181,9 @@ class A2aRequestHandlerTest {
 
     @Test
     void throwsWhenMessageParamMissing() {
-      var operation = new A2aToolOperationConfiguration("sendMessage", null, Duration.ofSeconds(1));
+      var operation =
+          new A2aToolOperationConfiguration(
+              "sendMessage", null, new A2aCommonSendMessageConfiguration(1, Duration.ofSeconds(1)));
       var request =
           new A2aRequest(
               new A2aRequestData(
@@ -188,7 +196,9 @@ class A2aRequestHandlerTest {
 
     @Test
     void throwsWhenUnsupportedOperation() {
-      var operation = new A2aToolOperationConfiguration("unknown", Map.of(), Duration.ofSeconds(1));
+      var operation =
+          new A2aToolOperationConfiguration(
+              "unknown", Map.of(), new A2aCommonSendMessageConfiguration(1, Duration.ofSeconds(1)));
       var request =
           new A2aRequest(
               new A2aRequestData(


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
Add the A2A task history in our task model. Also add a configuration parameter for `historyLength`. This parameter is send to the remote agent in the send message operation.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #5560 

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.
- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest release, as this branch will be rebased onto main before the next release.

