### PR TITLE
fix(agentic-ai): Add support for null JSON schema type to define nullable properties

### DIFF
--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/JsonSchemaConstants.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/JsonSchemaConstants.java
@@ -15,6 +15,7 @@ public abstract class JsonSchemaConstants {
   public static final String TYPE_INTEGER = "integer";
   public static final String TYPE_BOOLEAN = "boolean";
   public static final String TYPE_ARRAY = "array";
+  public static final String TYPE_NULL = "null";
 
   public static final String PROPERTY_TYPE = "type";
   public static final String PROPERTY_DESCRIPTION = "description";

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/jsonschema/JsonSchemaElementDeserializer.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/jsonschema/JsonSchemaElementDeserializer.java
@@ -19,6 +19,7 @@ import static io.camunda.connector.agenticai.JsonSchemaConstants.PROPERTY_TYPE;
 import static io.camunda.connector.agenticai.JsonSchemaConstants.TYPE_ARRAY;
 import static io.camunda.connector.agenticai.JsonSchemaConstants.TYPE_BOOLEAN;
 import static io.camunda.connector.agenticai.JsonSchemaConstants.TYPE_INTEGER;
+import static io.camunda.connector.agenticai.JsonSchemaConstants.TYPE_NULL;
 import static io.camunda.connector.agenticai.JsonSchemaConstants.TYPE_NUMBER;
 import static io.camunda.connector.agenticai.JsonSchemaConstants.TYPE_OBJECT;
 import static io.camunda.connector.agenticai.JsonSchemaConstants.TYPE_STRING;
@@ -36,6 +37,7 @@ import dev.langchain4j.model.chat.request.json.JsonArraySchema;
 import dev.langchain4j.model.chat.request.json.JsonBooleanSchema;
 import dev.langchain4j.model.chat.request.json.JsonEnumSchema;
 import dev.langchain4j.model.chat.request.json.JsonIntegerSchema;
+import dev.langchain4j.model.chat.request.json.JsonNullSchema;
 import dev.langchain4j.model.chat.request.json.JsonNumberSchema;
 import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
 import dev.langchain4j.model.chat.request.json.JsonReferenceSchema;
@@ -76,6 +78,7 @@ public class JsonSchemaElementDeserializer extends JsonDeserializer<JsonSchemaEl
       case TYPE_INTEGER -> createIntegerSchema(node);
       case TYPE_BOOLEAN -> createBooleanSchema(node);
       case TYPE_ARRAY -> createArraySchema(node, objectMapper);
+      case TYPE_NULL -> new JsonNullSchema();
       case null, default ->
           throw new IllegalArgumentException(
               "Unknown JSON schema element type '%s'".formatted(nodeType));

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/jsonschema/JsonSchemaElementSerializer.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/jsonschema/JsonSchemaElementSerializer.java
@@ -19,6 +19,7 @@ import static io.camunda.connector.agenticai.JsonSchemaConstants.PROPERTY_TYPE;
 import static io.camunda.connector.agenticai.JsonSchemaConstants.TYPE_ARRAY;
 import static io.camunda.connector.agenticai.JsonSchemaConstants.TYPE_BOOLEAN;
 import static io.camunda.connector.agenticai.JsonSchemaConstants.TYPE_INTEGER;
+import static io.camunda.connector.agenticai.JsonSchemaConstants.TYPE_NULL;
 import static io.camunda.connector.agenticai.JsonSchemaConstants.TYPE_NUMBER;
 import static io.camunda.connector.agenticai.JsonSchemaConstants.TYPE_OBJECT;
 import static io.camunda.connector.agenticai.JsonSchemaConstants.TYPE_STRING;
@@ -31,6 +32,7 @@ import dev.langchain4j.model.chat.request.json.JsonArraySchema;
 import dev.langchain4j.model.chat.request.json.JsonBooleanSchema;
 import dev.langchain4j.model.chat.request.json.JsonEnumSchema;
 import dev.langchain4j.model.chat.request.json.JsonIntegerSchema;
+import dev.langchain4j.model.chat.request.json.JsonNullSchema;
 import dev.langchain4j.model.chat.request.json.JsonNumberSchema;
 import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
 import dev.langchain4j.model.chat.request.json.JsonReferenceSchema;
@@ -52,6 +54,7 @@ public class JsonSchemaElementSerializer extends JsonSerializer<JsonSchemaElemen
       case JsonNumberSchema numberSchema -> serializeNumberSchema(numberSchema, gen);
       case JsonIntegerSchema integerSchema -> serializeIntegerSchema(integerSchema, gen);
       case JsonBooleanSchema booleanSchema -> serializeBooleanSchema(booleanSchema, gen);
+      case JsonNullSchema ignored -> serializeNullSchema(gen);
       case JsonReferenceSchema referenceSchema -> serializeReferenceSchema(referenceSchema, gen);
       case JsonArraySchema arraySchema -> serializeArraySchema(arraySchema, gen);
       case JsonAnyOfSchema anyOfSchema -> serializeAnyOfSchema(anyOfSchema, gen);
@@ -167,6 +170,12 @@ public class JsonSchemaElementSerializer extends JsonSerializer<JsonSchemaElemen
       gen.writeStringField(PROPERTY_DESCRIPTION, schema.description());
     }
 
+    gen.writeEndObject();
+  }
+
+  private void serializeNullSchema(JsonGenerator gen) throws IOException {
+    gen.writeStartObject();
+    gen.writeStringField(PROPERTY_TYPE, TYPE_NULL);
     gen.writeEndObject();
   }
 


### PR DESCRIPTION
## Description

Adds support for `JsonNullSchema` while serializing/deserializing JSON schema from the L4J data structure.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #5570

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.
- [x] Backport labels are added if these code changes should be backported. No backport label is added to the latest release, as this branch will be rebased onto main before the next release.

