### PR TITLE
ci(release): add FOSSA release job for attribution/SBOM publishing

### DIFF
--- a/.github/workflows/RELEASE.yaml
+++ b/.github/workflows/RELEASE.yaml
@@ -425,12 +425,9 @@ jobs:
       connectors-version: ${{ github.event.release.tag_name }}
       release-branch: ${{ needs.setup.outputs.releaseBranch }}
 
-  # This job waits for the FOSSA scan (triggered by CHECK_LICENSES.yml)
-  # to complete, then creates releases in FOSSA and generates attribution/SBOM reports.
-  # Conditions:
-  # - Only runs for release tags
-  # - Skips release candidates (rc, alpha)
-  # - Depends on successful completion of all previous release jobs 
+  # This job waits for the FOSSA scan (triggered by CHECK_LICENSES.yml) to complete,
+  # then creates releases in FOSSA and generates attribution/SBOM reports.
+  # Runs on all releases (including RC and alpha) after successful completion of all release jobs.
   fossa_release:
     name: Create FOSSA releases and generate attribution/SBOM reports
     needs:
@@ -441,9 +438,7 @@ jobs:
       - helm-deploy
     runs-on: ubuntu-latest
 
-    # Only run for proper releases (not RC, not alpha) AND all previous jobs succeeded
     if: |
-      needs.setup.outputs.tagType == 'NORMAL' &&
       needs.setup.result == 'success' &&
       needs.maven-release.result == 'success' &&
       needs.docker-release.result == 'success' &&
@@ -451,7 +446,7 @@ jobs:
       needs.helm-deploy.result == 'success'
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ github.event.release.tag_name }}
       - name: Import Secrets


### PR DESCRIPTION
## Description

Add a new job to create releases in FOSSA portal and publish attribution/SBOM reports after successful releases.
The job:
- Runs after all release jobs successfully finished
- Only executes for stable releases (skips release candidates)
- Waits for FOSSA scan completion triggered by CHECK-LICENSES.yml
- Publishes reports to FOSSA release groups

As the release groups have to be created only once, and the process needs an API token with access rights that the machine accounts don't have, I created the release groups manually, using the recent `8.8.0` as the initial release:
```
fossa release-group create \
    -t camunda-connectors-attribution \
    -r 8.8.0 \
    --project-locator custom+50756/camunda/connectors \
    --project-branch release/8.8 \
    --project-revision 06d30427697bf690d7c98d68d1de21243cd0233c \
    --license-policy "Camunda8 Distribution" \
    --security-policy "Default Camunda" \
    --quality-policy "Major - 3 Policy" \
    --team "Connectors Team"

----> Created release group with id: 4945
----> and a new release with id: 21843

fossa release-group create \
    -t camunda-connectors-sbom \
    -r 8.8.0 \
    --project-locator custom+50756/camunda/connectors \
    --project-branch release/8.8 \
    --project-revision 06d30427697bf690d7c98d68d1de21243cd0233c \
    --license-policy "Camunda8 Distribution" \
    --security-policy "Default Camunda" \
    --quality-policy "Major - 3 Policy" \
    --team "Connectors Team"

----> Created release group with id: 4946
----> and a new release with id: 21844
```
- On the FOSSA UI I did set the release groups' FOSSA portal settings to "public"
- Then, using the Connectors FOSSA machine account's API key, I published the attribution and SBOM reports to the FOSSA portal:
```
curl \
    --request POST \
    --header "accept: application/json" \
    --header "Authorization: Bearer $FOSSA_API_KEY" \
    --url "https://app.fossa.com/api/project_group/4945/release/21843/attribution/TXT"\
"?includeDeepDependencies=true"\
"&includeDirectDependencies=true"\
"&includeLicenseList=true"\
"&includeLicenseScan=true"\
"&includeProjectLicense=true"\
"&includeCopyrightList=true"\
"&includeFileMatches=true"\
"&includeOpenVulnerabilities=true"\
"&includeClosedVulnerabilities=true"\
"&includeDependencySummary=true"\
"&includeLicenseHeaders=true"\
"&isPublishing=true"

curl \
    --request POST \
    --header "accept: application/json" \
    --header "Authorization: Bearer $FOSSA_API_KEY" \
    --url "https://app.fossa.com/api/project_group/4946/release/21844/attribution/CYCLONEDX_JSON"\
"?includeDeepDependencies=true"\
"&includeDirectDependencies=true"\
"&includeLicenseList=true"\
"&includeLicenseScan=true"\
"&includeProjectLicense=true"\
"&includeCopyrightList=true"\
"&includeFileMatches=true"\
"&includeOpenVulnerabilities=true"\
"&includeClosedVulnerabilities=true"\
"&includeDependencySummary=true"\
"&includeLicenseHeaders=true"\
"&isPublishing=true"
```
The reports can be checked below

- [Attribution TXT](https://portal.fossa.com/p/camunda/release/4945/21843)
- [SBOM](https://portal.fossa.com/p/camunda/release/4946/21844)


## Related issues

<!-- Which issues are closed by this PR or are related -->

Related: [Infra 854](https://github.com/camunda/team-infrastructure/issues/854)

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.
- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest release, as this branch will be rebased onto main before the next release.

