### PR TITLE
feat(agentic-ai): Dynamic system prompt composition

### DIFF
--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/systemprompt/SystemPromptComposer.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/systemprompt/SystemPromptComposer.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.agenticai.aiagent.systemprompt;
+
+import io.camunda.connector.agenticai.aiagent.model.AgentContext;
+import io.camunda.connector.agenticai.aiagent.model.AgentExecutionContext;
+import io.camunda.connector.agenticai.aiagent.model.request.PromptConfiguration.SystemPromptConfiguration;
+
+/**
+ * Composes the final system prompt by combining a base prompt with contributions from registered
+ * contributors.
+ */
+public interface SystemPromptComposer {
+
+  String composeSystemPrompt(
+      AgentExecutionContext executionContext,
+      AgentContext agentContext,
+      SystemPromptConfiguration baseSystemPrompt);
+}

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/systemprompt/SystemPromptComposerImpl.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/systemprompt/SystemPromptComposerImpl.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.agenticai.aiagent.systemprompt;
+
+import io.camunda.connector.agenticai.aiagent.model.AgentContext;
+import io.camunda.connector.agenticai.aiagent.model.AgentExecutionContext;
+import io.camunda.connector.agenticai.aiagent.model.request.PromptConfiguration.SystemPromptConfiguration;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Default implementation of {@link SystemPromptComposer} that composes system prompts by
+ * concatenating the base prompt with contributions from registered {@link SystemPromptContributor}
+ * instances.
+ *
+ * <p>Contributors are applied in order based on their {@link SystemPromptContributor#getOrder()}
+ * value, with lower values being applied first.
+ */
+public class SystemPromptComposerImpl implements SystemPromptComposer {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(SystemPromptComposerImpl.class);
+  private static final String SEPARATOR = "\n\n";
+
+  private final List<SystemPromptContributor> contributors;
+
+  public SystemPromptComposerImpl(List<SystemPromptContributor> contributors) {
+    this.contributors =
+        contributors.stream()
+            .sorted(Comparator.comparingInt(SystemPromptContributor::getOrder))
+            .toList();
+    if (LOGGER.isDebugEnabled()) {
+      LOGGER.debug("Initialized SystemPromptComposer with {} contributors", contributors.size());
+    }
+  }
+
+  @Override
+  public String composeSystemPrompt(
+      AgentExecutionContext executionContext,
+      AgentContext agentContext,
+      SystemPromptConfiguration baseSystemPrompt) {
+
+    ArrayList<String> composed = new ArrayList<>();
+
+    String basePrompt = baseSystemPrompt.prompt();
+    if (StringUtils.isNotBlank(basePrompt)) {
+      composed.add(basePrompt);
+      LOGGER.trace("Added base system prompt");
+    }
+
+    contributors.forEach(
+        contributor -> {
+          String contribution = contributor.contributeSystemPrompt(executionContext, agentContext);
+          if (StringUtils.isNotBlank(contribution)) {
+            composed.add(contribution);
+            LOGGER.debug(
+                "Added system prompt contribution from {}", contributor.getClass().getSimpleName());
+          }
+        });
+
+    return String.join(SEPARATOR, composed);
+  }
+}

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/systemprompt/SystemPromptContributor.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/systemprompt/SystemPromptContributor.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.agenticai.aiagent.systemprompt;
+
+import io.camunda.connector.agenticai.aiagent.model.AgentContext;
+import io.camunda.connector.agenticai.aiagent.model.AgentExecutionContext;
+
+/**
+ * Contributes additional instructions to the AI agent's system prompt. Implementations can provide
+ * domain-specific, protocol-specific, or context-specific instructions that will be composed with
+ * the base system prompt.
+ *
+ * <p>Contributors are automatically discovered via Spring's dependency injection and composed in
+ * order based on {@link #getOrder()}.
+ */
+public interface SystemPromptContributor {
+
+  /**
+   * Returns the additional system prompt content to be appended.
+   *
+   * @param executionContext The current agent execution context
+   * @param agentContext The current agent context
+   * @return The system prompt contribution, or null/empty if no contribution needed
+   */
+  String contributeSystemPrompt(AgentExecutionContext executionContext, AgentContext agentContext);
+
+  /**
+   * Determines the order in which this contributor's content is appended. Lower values are appended
+   * first.
+   *
+   * @return The order value (default: 0)
+   */
+  default int getOrder() {
+    return 0;
+  }
+}

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/autoconfigure/AgenticAiConnectorsAutoConfiguration.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/autoconfigure/AgenticAiConnectorsAutoConfiguration.java
@@ -47,6 +47,9 @@ import io.camunda.connector.agenticai.aiagent.memory.conversation.ConversationSt
 import io.camunda.connector.agenticai.aiagent.memory.conversation.ConversationStoreRegistryImpl;
 import io.camunda.connector.agenticai.aiagent.memory.conversation.document.CamundaDocumentConversationStore;
 import io.camunda.connector.agenticai.aiagent.memory.conversation.inprocess.InProcessConversationStore;
+import io.camunda.connector.agenticai.aiagent.systemprompt.SystemPromptComposer;
+import io.camunda.connector.agenticai.aiagent.systemprompt.SystemPromptComposerImpl;
+import io.camunda.connector.agenticai.aiagent.systemprompt.SystemPromptContributor;
 import io.camunda.connector.agenticai.aiagent.tool.GatewayToolHandler;
 import io.camunda.connector.agenticai.aiagent.tool.GatewayToolHandlerRegistry;
 import io.camunda.connector.agenticai.aiagent.tool.GatewayToolHandlerRegistryImpl;
@@ -185,9 +188,16 @@ public class AgenticAiConnectorsAutoConfiguration {
 
   @Bean
   @ConditionalOnMissingBean
+  public SystemPromptComposer aiAgentSystemPromptComposer(
+      List<SystemPromptContributor> contributors) {
+    return new SystemPromptComposerImpl(contributors);
+  }
+
+  @Bean
+  @ConditionalOnMissingBean
   public AgentMessagesHandler aiAgentMessagesHandler(
-      GatewayToolHandlerRegistry gatewayToolHandlers) {
-    return new AgentMessagesHandlerImpl(gatewayToolHandlers);
+      GatewayToolHandlerRegistry gatewayToolHandlers, SystemPromptComposer systemPromptComposer) {
+    return new AgentMessagesHandlerImpl(gatewayToolHandlers, systemPromptComposer);
   }
 
   @Bean

--- a/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/agent/AgentMessagesHandlerTest.java
+++ b/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/agent/AgentMessagesHandlerTest.java
@@ -35,6 +35,8 @@ import io.camunda.connector.agenticai.aiagent.model.AgentState;
 import io.camunda.connector.agenticai.aiagent.model.request.EventHandlingConfiguration;
 import io.camunda.connector.agenticai.aiagent.model.request.PromptConfiguration.SystemPromptConfiguration;
 import io.camunda.connector.agenticai.aiagent.model.request.PromptConfiguration.UserPromptConfiguration;
+import io.camunda.connector.agenticai.aiagent.systemprompt.SystemPromptComposer;
+import io.camunda.connector.agenticai.aiagent.systemprompt.SystemPromptComposerImpl;
 import io.camunda.connector.agenticai.aiagent.tool.GatewayToolHandlerRegistry;
 import io.camunda.connector.agenticai.model.message.Message;
 import io.camunda.connector.agenticai.model.message.ToolCallResultMessage;
@@ -74,10 +76,12 @@ class AgentMessagesHandlerTest {
 
   private AgentMessagesHandler messagesHandler;
   private RuntimeMemory runtimeMemory;
+  private SystemPromptComposer systemPromptComposer;
 
   @BeforeEach
   void setUp() {
-    messagesHandler = new AgentMessagesHandlerImpl(gatewayToolHandlers);
+    systemPromptComposer = new SystemPromptComposerImpl(List.of());
+    messagesHandler = new AgentMessagesHandlerImpl(gatewayToolHandlers, systemPromptComposer);
     runtimeMemory = spy(new DefaultRuntimeMemory());
   }
 

--- a/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/systemprompt/SystemPromptComposerImplTest.java
+++ b/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/systemprompt/SystemPromptComposerImplTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.agenticai.aiagent.systemprompt;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import io.camunda.connector.agenticai.aiagent.model.AgentContext;
+import io.camunda.connector.agenticai.aiagent.model.AgentExecutionContext;
+import io.camunda.connector.agenticai.aiagent.model.request.PromptConfiguration.SystemPromptConfiguration;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EmptySource;
+import org.junit.jupiter.params.provider.NullSource;
+
+class SystemPromptComposerImplTest {
+
+  @Test
+  void shouldComposeWithBasePromptOnly() {
+    SystemPromptComposer composer = new SystemPromptComposerImpl(List.of());
+    AgentExecutionContext executionContext = mock(AgentExecutionContext.class);
+    AgentContext agentContext = mock(AgentContext.class);
+    SystemPromptConfiguration config = new SystemPromptConfiguration("Base prompt");
+
+    String result = composer.composeSystemPrompt(executionContext, agentContext, config);
+
+    assertThat(result).isEqualTo("Base prompt");
+  }
+
+  @Test
+  void shouldComposeWithSingleContributor() {
+    SystemPromptContributor contributor = (ctx, agentCtx) -> "Additional instructions";
+    SystemPromptComposer composer = new SystemPromptComposerImpl(List.of(contributor));
+
+    AgentExecutionContext executionContext = mock(AgentExecutionContext.class);
+    AgentContext agentContext = mock(AgentContext.class);
+    SystemPromptConfiguration config = new SystemPromptConfiguration("Base prompt");
+
+    String result = composer.composeSystemPrompt(executionContext, agentContext, config);
+
+    assertThat(result).isEqualTo("Base prompt\n\nAdditional instructions");
+  }
+
+  @Test
+  void shouldComposeWithMultipleContributorsInOrder() {
+    SystemPromptContributor contributor1 =
+        new SystemPromptContributor() {
+          @Override
+          public String contributeSystemPrompt(AgentExecutionContext ctx, AgentContext agentCtx) {
+            return "First contribution";
+          }
+
+          @Override
+          public int getOrder() {
+            return 10;
+          }
+        };
+
+    SystemPromptContributor contributor2 =
+        new SystemPromptContributor() {
+          @Override
+          public String contributeSystemPrompt(AgentExecutionContext ctx, AgentContext agentCtx) {
+            return "Second contribution";
+          }
+
+          @Override
+          public int getOrder() {
+            return 20;
+          }
+        };
+
+    // Add in reverse order to test sorting
+    SystemPromptComposer composer =
+        new SystemPromptComposerImpl(List.of(contributor2, contributor1));
+
+    AgentExecutionContext executionContext = mock(AgentExecutionContext.class);
+    AgentContext agentContext = mock(AgentContext.class);
+    SystemPromptConfiguration config = new SystemPromptConfiguration("Base prompt");
+
+    String result = composer.composeSystemPrompt(executionContext, agentContext, config);
+
+    assertThat(result).isEqualTo("Base prompt\n\nFirst contribution\n\nSecond contribution");
+  }
+
+  @ParameterizedTest
+  @NullSource
+  @EmptySource
+  void shouldSkipNullOrEmptyContributions(String contribution) {
+    SystemPromptContributor contributor1 = (ctx, agentCtx) -> "Valid contribution";
+    SystemPromptContributor contributor2 = (ctx, agentCtx) -> contribution;
+    SystemPromptContributor contributor3 = (ctx, agentCtx) -> "Another valid";
+
+    SystemPromptComposer composer =
+        new SystemPromptComposerImpl(List.of(contributor1, contributor2, contributor3));
+
+    AgentExecutionContext executionContext = mock(AgentExecutionContext.class);
+    AgentContext agentContext = mock(AgentContext.class);
+    SystemPromptConfiguration config = new SystemPromptConfiguration("Base prompt");
+
+    String result = composer.composeSystemPrompt(executionContext, agentContext, config);
+
+    assertThat(result).isEqualTo("Base prompt\n\nValid contribution\n\nAnother valid");
+  }
+
+  @Test
+  void shouldHandleEmptyBasePrompt() {
+    SystemPromptContributor contributor = (ctx, agentCtx) -> "Contribution";
+    SystemPromptComposer composer = new SystemPromptComposerImpl(List.of(contributor));
+
+    AgentExecutionContext executionContext = mock(AgentExecutionContext.class);
+    AgentContext agentContext = mock(AgentContext.class);
+    SystemPromptConfiguration config = new SystemPromptConfiguration("");
+
+    String result = composer.composeSystemPrompt(executionContext, agentContext, config);
+
+    assertThat(result).isEqualTo("Contribution");
+  }
+}


### PR DESCRIPTION
## Description

 Implements composable system prompt architecture to dynamically inject additional instructions into AI agent prompts.

 ### Key Changes

- `SystemPromptContributor` interface for pluggable prompt contributions
- `SystemPromptComposer` service that combines base prompt with ordered contributions
- Updated `AgentMessagesHandlerImpl` to use composer

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #5588

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.
- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest release, as this branch will be rebased onto main before the next release.

