### PR TITLE
Backport #5589: fix(saas-bundle): remove operate from liveness check

### DIFF
--- a/bundle/camunda-saas-bundle/src/main/resources/application.properties
+++ b/bundle/camunda-saas-bundle/src/main/resources/application.properties
@@ -4,7 +4,9 @@ management.server.port=9080
 management.context-path=/actuator
 management.endpoints.web.exposure.include=metrics,health,prometheus,loggers
 management.endpoint.health.group.readiness.include[]=zeebeClient,operate
-
+management.endpoint.health.group.liveness.include[]=zeebeClient
+management.endpoint.health.show-components=always
+management.endpoint.health.show-details=always
 camunda.connector.polling.enabled=true
 camunda.connector.polling.interval=5000
 camunda.connector.secrets.cache.millis=5000

--- a/bundle/default-bundle/src/main/resources/application.properties
+++ b/bundle/default-bundle/src/main/resources/application.properties
@@ -3,6 +3,7 @@ server.port=8080
 management.server.base-path=/actuator
 management.endpoints.web.exposure.include=metrics,health,prometheus
 management.endpoint.health.group.readiness.include[]=zeebeClient,operate
+management.endpoint.health.group.liveness.include[]=zeebeClient
 management.endpoint.health.show-components=always
 management.endpoint.health.show-details=always
 


### PR DESCRIPTION
## Description

This backports PR #5589 to the release/8.6 branch to prevent elevated levels of downtime on spot instances.

**Original PR:** https://github.com/camunda/connectors/pull/5589
**Cherry-picked commit:** c4fc855d75f4ff78c827844a3e6c5e10c598b92f

### Changes
- Removes Operate from the liveness check while keeping it in readiness checks
- Adds proper health endpoint configuration for both SaaS and default bundles
- Updates application.properties files in both camunda-saas-bundle and default-bundle

The liveness check should only include critical components that are absolutely required for the application to function, while readiness checks can include components like Operate that may be temporarily unavailable but don't require pod restarts.

## Related issues

Closes #5595 

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.