### PR TITLE
other(slack): Improve error message for users in operate

### DIFF
--- a/connectors/slack/src/main/java/io/camunda/connector/slack/outbound/model/ChatPostMessageData.java
+++ b/connectors/slack/src/main/java/io/camunda/connector/slack/outbound/model/ChatPostMessageData.java
@@ -134,10 +134,14 @@ public record ChatPostMessageData(
     if (chatPostMessageResponse.isOk()) {
       return new ChatPostMessageSlackResponse(chatPostMessageResponse);
     } else {
-      throw new RuntimeException(
-          chatPostMessageResponse.getError()
-              + " caused by: "
-              + chatPostMessageResponse.getErrors().toString());
+      String error = chatPostMessageResponse.getError();
+      Object errors = chatPostMessageResponse.getErrors();
+      String errorMessage =
+          (error != null ? error : "Unknown error")
+              + (errors != null
+                  ? " caused by:" + errors.toString()
+                  : "No additional error details");
+      throw new RuntimeException(errorMessage);
     }
   }
 


### PR DESCRIPTION
## Description
Support more insights, why a slack request is failing, e.g. because message is too long.

## Related issues
https://camunda.slack.com/archives/C02JLRNQQ05/p1761168444527929

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.
- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest release, as this branch will be rebased onto main before the next release.

