### PR TITLE
fix(docs): wrong groupId for Camunda connector dependency

### DIFF
--- a/connector-runtime/README.md
+++ b/connector-runtime/README.md
@@ -53,7 +53,7 @@ For example:
 ```xml
   <dependencies>
     <dependency>
-      <groupId>io.camunda</groupId>
+      <groupId>io.camunda.connector</groupId>
       <artifactId>spring-boot-starter-camunda-connectors</artifactId>
       <version>${version.spring-zeebe}</version>
     </dependency>


### PR DESCRIPTION
Wrong groupId for spring-boot-starter-camunda-connectors

## Description
Wrong groupId in documentation. Took me a while to figure out.

## Related issues



closes #

## Checklist

- [ ] PR has a **milestone** or the `no milestone` label.
- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest release, as this branch will be rebased onto main before the next release.

