### PR TITLE
fix(tests): small fixes related to greenmail 2.1.7

### DIFF
--- a/connectors/email/src/test/java/io/camunda/connector/email/integration/ImapServerProxy.java
+++ b/connectors/email/src/test/java/io/camunda/connector/email/integration/ImapServerProxy.java
@@ -108,6 +108,9 @@ public class ImapServerProxy implements AutoCloseable {
       while ((n = byteReceivedFromServer.read(buf)) >= 0) {
         byteToSendToClient.write(buf, 0, n);
         byteToSendToClient.flush();
+        if (!successMode.get()) {
+          return;
+        }
       }
     } catch (Exception ignored) {
     }

--- a/connectors/email/src/test/java/io/camunda/connector/email/integration/InboundRecoveringTest.java
+++ b/connectors/email/src/test/java/io/camunda/connector/email/integration/InboundRecoveringTest.java
@@ -89,7 +89,7 @@ public class InboundRecoveringTest extends BaseEmailTest {
       proxyImap.cutConnection();
 
       await()
-          .atMost(6, TimeUnit.SECONDS)
+          .atMost(5, TimeUnit.SECONDS)
           .untilAsserted(
               () ->
                   // We want to check health was down for at least 1 times


### PR DESCRIPTION
## Description

Since renovate has set greenmail to version 2.1.7, we need to silent server to client piping

From my understanding, this test was not working with 2.1.7 because of this modification
<img width="673" height="45" alt="image" src="https://github.com/user-attachments/assets/8b39bc50-43d7-4b7e-8069-fabbd83f073b" />

When killing the connection, the newly introduced condition was throwing, messing up our test.

In my first pick, I replace the connection killing by just silently stopping the link between client and server, so client cannot send anymore to server, but server could still send bytes.

We need to silent that side as well, otherwise this introduces flakyness in our CI, was working locally though

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.
- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest release, as this branch will be rebased onto main before the next release.

