### PR TITLE
chore(renovate): undo exclusion of langchain4j

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -92,16 +92,6 @@
         "digest"
       ],
       "changelogUrl": "https://github.com/camunda/infra-global-github-actions/compare/{{currentDigest}}..{{newDigest}}"
-    },
-    {
-      "description": "Exclude dev.langchain4j artifacts >= 1.4.0",
-      "matchManagers": [
-        "maven"
-      ],
-      "allowedVersions": "< 1.4.0",
-      "matchPackageNames": [
-        "dev.langchain4j:{/,}**"
-      ]
     }
   ],
   "baseBranchPatterns": [


### PR DESCRIPTION
## Description

We are [now using](https://github.com/camunda/connectors/pull/5620) the latest version of langchain4j, which fixed the bugs introduced in 1.4.0.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #5340 

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.
- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest release, as this branch will be rebased onto main before the next release.

