### PR TITLE
fix(ci): fix fossa release workflow input parameter

### DIFF
--- a/.github/workflows/RELEASE.yaml
+++ b/.github/workflows/RELEASE.yaml
@@ -466,14 +466,14 @@ jobs:
       - name: Wait for FOSSA scan completion
         uses: camunda/infra-global-github-actions/fossa/wait-for-scan@ad3fd49c6526b19c2fe15f2d279e68dea2da278f
         with:
-          fossa-api-key: ${{ steps.secrets.outputs.FOSSA_API_KEY }}
+          api-key: ${{ steps.secrets.outputs.FOSSA_API_KEY }}
           branch: ${{ steps.fossa-context.outputs.head-ref }}
           project-id: "custom+50756/camunda/connectors"
           revision-id: ${{ steps.fossa-context.outputs.head-revision }}
       - name: Create FOSSA releases and generate reports
         uses: camunda/infra-global-github-actions/fossa/release@ad3fd49c6526b19c2fe15f2d279e68dea2da278f
         with:
-          fossa-api-key: ${{ steps.secrets.outputs.FOSSA_API_KEY }}
+          api-key: ${{ steps.secrets.outputs.FOSSA_API_KEY }}
           branch: ${{ steps.fossa-context.outputs.head-ref }}
           project-id: "custom+50756/camunda/connectors"
           attribution-release-group-id: "4945" # https://app.fossa.com/projects/group/4945


### PR DESCRIPTION
## Description

This PR fixes FOSSA release workflow's input parameter name

## Related issues

<!-- Which issues are closed by this PR or are related -->

Fixes https://github.com/camunda/connectors/pull/5591

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.
- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest release, as this branch will be rebased onto main before the next release.

