### PR TITLE
fix(polling): add the payload group for the body to be visible

### DIFF
--- a/connectors/http/polling/element-templates/http-polling-boundary-catch-event-connector.json
+++ b/connectors/http/polling/element-templates/http-polling-boundary-catch-event-connector.json
@@ -27,6 +27,9 @@
     "id" : "endpoint",
     "label" : "HTTP Polling configuration"
   }, {
+    "id" : "payload",
+    "label" : "Payload"
+  }, {
     "id" : "interval",
     "label" : "HTTP Polling Interval"
   }, {
@@ -396,6 +399,23 @@
       "type" : "zeebe:property"
     },
     "type" : "Hidden"
+  }, {
+    "id" : "body",
+    "label" : "Request body",
+    "description" : "Payload to send with the request",
+    "optional" : true,
+    "feel" : "optional",
+    "group" : "payload",
+    "binding" : {
+      "name" : "body",
+      "type" : "zeebe:property"
+    },
+    "condition" : {
+      "property" : "method",
+      "oneOf" : [ "POST", "PUT", "PATCH" ],
+      "type" : "simple"
+    },
+    "type" : "Text"
   }, {
     "id" : "httpRequestInterval",
     "label" : "Http request interval",

--- a/connectors/http/polling/element-templates/http-polling-connector.json
+++ b/connectors/http/polling/element-templates/http-polling-connector.json
@@ -27,6 +27,9 @@
     "id" : "endpoint",
     "label" : "HTTP Polling configuration"
   }, {
+    "id" : "payload",
+    "label" : "Payload"
+  }, {
     "id" : "interval",
     "label" : "HTTP Polling Interval"
   }, {
@@ -396,6 +399,23 @@
       "type" : "zeebe:property"
     },
     "type" : "Hidden"
+  }, {
+    "id" : "body",
+    "label" : "Request body",
+    "description" : "Payload to send with the request",
+    "optional" : true,
+    "feel" : "optional",
+    "group" : "payload",
+    "binding" : {
+      "name" : "body",
+      "type" : "zeebe:property"
+    },
+    "condition" : {
+      "property" : "method",
+      "oneOf" : [ "POST", "PUT", "PATCH" ],
+      "type" : "simple"
+    },
+    "type" : "Text"
   }, {
     "id" : "httpRequestInterval",
     "label" : "Http request interval",

--- a/connectors/http/polling/src/main/java/io/camunda/connector/http/polling/HttpPollingConnector.java
+++ b/connectors/http/polling/src/main/java/io/camunda/connector/http/polling/HttpPollingConnector.java
@@ -28,6 +28,7 @@ import io.camunda.connector.http.polling.task.ProcessInstancesFetcherTask;
     propertyGroups = {
       @ElementTemplate.PropertyGroup(id = "authentication", label = "Authentication"),
       @ElementTemplate.PropertyGroup(id = "endpoint", label = "HTTP Polling configuration"),
+      @ElementTemplate.PropertyGroup(id = "payload", label = "Payload"),
       @ElementTemplate.PropertyGroup(id = "interval", label = "HTTP Polling Interval"),
       @ElementTemplate.PropertyGroup(id = "timeout", label = "Connection timeout"),
     },


### PR DESCRIPTION
## Description

The property group was not added

## Related issues

closes https://github.com/camunda/connectors/issues/5601

## Checklist

- [ ] PR has a **milestone** or the `no milestone` label.
- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest release, as this branch will be rebased onto main before the next release.

