### PR TITLE
other(CI): remove pull_request event to check-license workflow 2

### DIFF
--- a/.github/workflows/CHECK_LICENSES.yml
+++ b/.github/workflows/CHECK_LICENSES.yml
@@ -12,10 +12,6 @@ on:
       - release/*
     tags:
       - '*'
-  pull_request:
-    types:
-      - opened
-      - synchronize
 
 jobs:
   analyze:


### PR DESCRIPTION
## Description

Remove `pull_request` event from check license so that externals contributors can contribute.

## Checklist

- [ ] PR has a **milestone** or the `no milestone` label.
- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest release, as this branch will be rebased onto main before the next release.

