### PR TITLE
fix: simulate error in shouldReturnBody test case

### DIFF
--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/document/DocumentHelperTest.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/document/DocumentHelperTest.java
@@ -42,6 +42,8 @@ public class DocumentHelperTest {
 
   @Test
   public void shouldReturnBody_whenMapInputWithoutDocumentAndWithNullValues() {
+
+    throw new RuntimeException("oops");
     // given
     DocumentHelper documentHelper = new DocumentHelper();
     Map<String, Object> input = new HashMap<>();


### PR DESCRIPTION
Added a RuntimeException throw in the test case to simulate an error scenario.

## Description

<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #

## Checklist

- [ ] PR has a **milestone** or the `no milestone` label.
- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest release, as this branch will be rebased onto main before the next release.

