### PR TITLE
other: fix helm chart for 8.9

### DIFF
--- a/.github/workflows/helm-git-refs.json
+++ b/.github/workflows/helm-git-refs.json
@@ -1,5 +1,6 @@
 {
-  "main": "camunda-platform-8.8",
+  "main": "camunda-platform-8.9",
+  "release/8.9": "camunda-platform-8.9",
   "release/8.8": "camunda-platform-8.8",
   "release/8.7": "camunda-platform-8.7",
   "release/8.6": "camunda-platform-8.6",


### PR DESCRIPTION
## Description

fix helm git refs for 8.9

## Checklist

- [ ] PR has a **milestone** or the `no milestone` label.
- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest release, as this branch will be rebased onto main before the next release.

