### PR TITLE
other(ci): revert permissions change

### DIFF
--- a/.github/workflows/CHECK_LICENSES.yml
+++ b/.github/workflows/CHECK_LICENSES.yml
@@ -13,9 +13,6 @@ on:
     tags:
       - '*'
 
-permissions:
-  contents: read
-
 jobs:
   fork-guard:
     name: Skip if external fork

--- a/.github/workflows/TEST_FEATURE_BRANCH.yml
+++ b/.github/workflows/TEST_FEATURE_BRANCH.yml
@@ -13,9 +13,6 @@ on:
   merge_group:
     branches: [ main ]
 
-permissions:
-  contents: read
-
 jobs:
   test-branch:
 


### PR DESCRIPTION
## Description

The permission change leads to a problem when publishing test results in the CI (TEST_FEATURE_BRANCH). As for CHECK_LICENSES, it is redundant because the workflow is not intended for external PRs anyway.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #

## Checklist

- [ ] PR has a **milestone** or the `no milestone` label.
- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest release, as this branch will be rebased onto main before the next release.

