### PR TITLE
other(inbound): Return a specific error code when Inbound activation fails due to CONNECTOR_NOT_REGISTERED

### DIFF
--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/executable/InboundExecutableRegistryImpl.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/executable/InboundExecutableRegistryImpl.java
@@ -47,6 +47,8 @@ import org.springframework.scheduling.annotation.Scheduled;
 
 public class InboundExecutableRegistryImpl implements InboundExecutableRegistry {
 
+  private static final String ACTIVATION_FAILURE = "ACTIVATION_FAILURE";
+  private static final String CONNECTOR_NOT_REGISTERED = "CONNECTOR_NOT_REGISTERED";
   private final BlockingQueue<InboundExecutableEvent> eventQueue;
   private final ExecutorService executorService;
 
@@ -290,7 +292,7 @@ public class InboundExecutableRegistryImpl implements InboundExecutableRegistry 
               id,
               null,
               failed.data().connectorElements(),
-              Health.down(new Error("Activation failure", failed.reason())),
+              Health.down(new Error(ACTIVATION_FAILURE, failed.reason())),
               List.of());
       case ConnectorNotRegistered notRegistered ->
           new ActiveExecutableResponse(
@@ -299,7 +301,7 @@ public class InboundExecutableRegistryImpl implements InboundExecutableRegistry 
               notRegistered.data().connectorElements(),
               Health.down(
                   new Error(
-                      "Activation failure",
+                      CONNECTOR_NOT_REGISTERED,
                       "Connector " + notRegistered.data().type() + " not registered")),
               List.of());
       case InvalidDefinition invalid ->
@@ -309,7 +311,7 @@ public class InboundExecutableRegistryImpl implements InboundExecutableRegistry 
               invalid.data().connectorElements(),
               Health.down(
                   new Error(
-                      "Activation failure", "Invalid connector definition: " + invalid.reason())),
+                      ACTIVATION_FAILURE, "Invalid connector definition: " + invalid.reason())),
               List.of());
     };
   }


### PR DESCRIPTION
Backport of https://github.com/camunda/connectors/pull/5669