### PR TITLE
fix(element-template-generator): reproducible parameter order for OpenAPI

### DIFF
--- a/element-template-generator/openapi-parser/src/main/java/io/camunda/connector/generator/openapi/util/OperationUtil.java
+++ b/element-template-generator/openapi-parser/src/main/java/io/camunda/connector/generator/openapi/util/OperationUtil.java
@@ -31,8 +31,7 @@ import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.Operation;
 import io.swagger.v3.oas.models.parameters.RequestBody;
 import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -144,12 +143,11 @@ public class OperationUtil {
     try {
       var parameters = operation.getParameters();
       Set<HttpOperationProperty> properties =
-          new HashSet<>(
-              parameters == null
-                  ? Collections.emptySet()
-                  : parameters.stream()
-                      .map(parameter -> ParameterUtil.transformToProperty(parameter, components))
-                      .collect(Collectors.toSet()));
+          parameters == null
+              ? new LinkedHashSet<>()
+              : parameters.stream()
+                  .map(parameter -> ParameterUtil.transformToProperty(parameter, components))
+                  .collect(Collectors.toCollection(LinkedHashSet::new));
 
       var label = method.name() + " " + path;
 


### PR DESCRIPTION
## Description

Currently the output order of parameters in generated templates from OpenAPI schemas are not reproducible. Even tho the OpenAPI schema is unchanged, the generated template will have often differently ordered parameters for each generator run.

This PR makes sure the template will be the same, by just using a `LinkedHashSet`, instead of a `HashSet`.