### PR TITLE
other(ci): fix commit message in RUN_UNIQUET workflow

### DIFF
--- a/.github/workflows/RUN_UNIQUET.yml
+++ b/.github/workflows/RUN_UNIQUET.yml
@@ -34,7 +34,7 @@ jobs:
           commit-message: "other(element-template): single element template file"
           committer: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
           base: main
-          title: "others(element-template): single element template file generation"
+          title: "other(element-template): single element template file generation"
           labels: "no milestone"
           body: |
             This PR sets the new single element template file containing all necessary references.


### PR DESCRIPTION
`others` is not a valid commit type => should be `other`

## Description

<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #

## Checklist

- [ ] PR has a **milestone** or the `no milestone` label.
- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest release, as this branch will be rebased onto main before the next release.

