### PR TITLE
[Backport release/8.8] fix(agentic-ai): only set the AI Agent state to ready when all tool discovery results are present

### DIFF
--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/langchain4j/Langchain4JAiAgentToolSpecifications.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/langchain4j/Langchain4JAiAgentToolSpecifications.java
@@ -163,6 +163,23 @@ public interface Langchain4JAiAgentToolSpecifications {
                       .build())
               .build(),
           ToolSpecification.builder()
+              .name("MCP_Another_Remote_MCP_Client___toolA")
+              .description("The first tool")
+              .parameters(
+                  JsonObjectSchema.builder()
+                      .addStringProperty("paramA1", "The first parameter")
+                      .addNumberProperty("paramA2", "The second parameter")
+                      .build())
+              .build(),
+          ToolSpecification.builder()
+              .name("MCP_Another_Remote_MCP_Client___toolC")
+              .description("The third tool")
+              .parameters(
+                  JsonObjectSchema.builder()
+                      .addStringProperty("paramC1", "The first parameter")
+                      .build())
+              .build(),
+          ToolSpecification.builder()
               .name("MCP_Filesystem_MCP_Flow___toolA")
               .description("The first tool")
               .parameters(

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/langchain4j/outboundconnector/L4JAiAgentConnectorMcpIntegrationTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/langchain4j/outboundconnector/L4JAiAgentConnectorMcpIntegrationTests.java
@@ -20,9 +20,11 @@ import static io.camunda.connector.e2e.agenticai.aiagent.AiAgentTestFixtures.HAI
 import static io.camunda.connector.e2e.agenticai.aiagent.langchain4j.Langchain4JAiAgentToolSpecifications.EXPECTED_MCP_TOOL_SPECIFICATIONS;
 import static io.camunda.connector.e2e.agenticai.aiagent.langchain4j.Langchain4JAiAgentToolSpecifications.MCP_TOOL_SPECIFICATIONS;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.assertArg;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -42,10 +44,12 @@ import io.camunda.connector.agenticai.aiagent.model.AgentMetrics;
 import io.camunda.connector.agenticai.mcp.client.McpClientRegistry;
 import io.camunda.connector.agenticai.mcp.client.McpRemoteClientRegistry;
 import io.camunda.connector.agenticai.mcp.client.McpRemoteClientRegistry.McpRemoteClientIdentifier;
+import io.camunda.connector.agenticai.mcp.client.model.McpRemoteClientRequest.McpRemoteClientRequestData.HttpConnectionConfiguration;
 import io.camunda.connector.e2e.agenticai.assertj.AgentResponseAssert;
 import io.camunda.connector.test.utils.annotation.SlowTest;
 import io.camunda.process.test.api.CamundaAssert;
 import java.io.IOException;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
@@ -71,10 +75,17 @@ public class L4JAiAgentConnectorMcpIntegrationTests extends BaseL4JAiAgentConnec
 
   @Mock private McpClient aMcpClient;
   @Mock private McpClient aRemoteMcpClient;
+  @Mock private McpClient anotherRemoteMcpClient;
   @Mock private McpClient filesystemMcpClient;
 
   @Captor private ArgumentCaptor<ToolExecutionRequest> aMcpClientToolExecutionRequestCaptor;
   @Captor private ArgumentCaptor<ToolExecutionRequest> aRemoteMcpClientToolExecutionRequestCaptor;
+
+  @Captor
+  private ArgumentCaptor<ToolExecutionRequest> anotherRemoteMcpClientToolExecutionRequestCaptor;
+
+  private final Map<String, HttpConnectionConfiguration> requestedRemoteMcpClients =
+      new LinkedHashMap<>();
 
   @BeforeEach
   void mockMcpClients() {
@@ -82,6 +93,7 @@ public class L4JAiAgentConnectorMcpIntegrationTests extends BaseL4JAiAgentConnec
     when(aMcpClient.listTools()).thenReturn(MCP_TOOL_SPECIFICATIONS);
 
     when(aRemoteMcpClient.listTools()).thenReturn(MCP_TOOL_SPECIFICATIONS);
+    when(anotherRemoteMcpClient.listTools()).thenReturn(MCP_TOOL_SPECIFICATIONS);
 
     when(filesystemMcpClient.key()).thenReturn("filesystem");
     when(filesystemMcpClient.listTools()).thenReturn(MCP_TOOL_SPECIFICATIONS);
@@ -90,22 +102,30 @@ public class L4JAiAgentConnectorMcpIntegrationTests extends BaseL4JAiAgentConnec
     doReturn(aMcpClient).when(mcpClientRegistry).getClient("a-mcp-client");
     doReturn(filesystemMcpClient).when(mcpClientRegistry).getClient("filesystem");
 
-    // remote MCP client configured only on the process
+    // remote MCP clients configured only on the process
+    requestedRemoteMcpClients.clear();
     doAnswer(
             i -> {
               final McpRemoteClientIdentifier clientId = i.getArgument(0);
-              when(aRemoteMcpClient.key()).thenReturn(clientId.toString());
-              return aRemoteMcpClient;
+              final HttpConnectionConfiguration connection = i.getArgument(1);
+              requestedRemoteMcpClients.put(clientId.elementId(), connection);
+
+              return switch (clientId.elementId()) {
+                case "A_Remote_MCP_Client" -> {
+                  when(aRemoteMcpClient.key()).thenReturn(clientId.toString());
+                  yield aRemoteMcpClient;
+                }
+                case "Another_Remote_MCP_Client" -> {
+                  when(anotherRemoteMcpClient.key()).thenReturn(clientId.toString());
+                  yield anotherRemoteMcpClient;
+                }
+                default ->
+                    throw new IllegalArgumentException(
+                        "Unexpected remote MCP client ID: " + clientId.elementId());
+              };
             })
         .when(remoteMcpClientRegistry)
-        .getClient(
-            assertArg(
-                clientId -> assertThat(clientId.elementId()).isEqualTo("A_Remote_MCP_Client")),
-            assertArg(
-                connection -> {
-                  assertThat(connection.sseUrl()).isEqualTo("http://localhost:1234/sse");
-                  assertThat(connection.timeout()).isNull();
-                }));
+        .getClient(any(McpRemoteClientIdentifier.class), any(HttpConnectionConfiguration.class));
   }
 
   @Override
@@ -134,6 +154,7 @@ public class L4JAiAgentConnectorMcpIntegrationTests extends BaseL4JAiAgentConnec
             // MCP tool discovery start
             "A_MCP_Client",
             "A_Remote_MCP_Client",
+            "Another_Remote_MCP_Client",
             "Filesystem_MCP_Flow",
             // MCP tool discovery end
 
@@ -142,7 +163,25 @@ public class L4JAiAgentConnectorMcpIntegrationTests extends BaseL4JAiAgentConnec
 
     verify(aMcpClient).listTools();
     verify(aRemoteMcpClient).listTools();
+    verify(anotherRemoteMcpClient).listTools();
     verify(filesystemMcpClient).listTools();
+
+    verify(chatModel, times(1)).chat(any(ChatRequest.class));
+
+    assertThat(requestedRemoteMcpClients)
+        .hasSize(2)
+        .hasEntrySatisfying(
+            "A_Remote_MCP_Client",
+            connection -> {
+              assertThat(connection.sseUrl()).isEqualTo("http://localhost:1234/sse");
+              assertThat(connection.timeout()).isNull();
+            })
+        .hasEntrySatisfying(
+            "Another_Remote_MCP_Client",
+            connection -> {
+              assertThat(connection.sseUrl()).isEqualTo("http://localhost:2345/sse");
+              assertThat(connection.timeout()).isNull();
+            });
   }
 
   @Test
@@ -151,6 +190,9 @@ public class L4JAiAgentConnectorMcpIntegrationTests extends BaseL4JAiAgentConnec
         .thenReturn("A MCP Client result");
     when(aRemoteMcpClient.executeTool(aRemoteMcpClientToolExecutionRequestCaptor.capture()))
         .thenReturn("A Remote MCP Client result");
+    when(anotherRemoteMcpClient.executeTool(
+            anotherRemoteMcpClientToolExecutionRequestCaptor.capture()))
+        .thenReturn("Another Remote MCP Client result");
 
     final var initialUserPrompt = "Explore some of your MCP tools!";
     final var expectedConversation =
@@ -159,7 +201,7 @@ public class L4JAiAgentConnectorMcpIntegrationTests extends BaseL4JAiAgentConnec
                 "You are a helpful AI assistant. Answer all the questions, but always be nice. Explain your thinking."),
             new UserMessage(initialUserPrompt),
             new AiMessage(
-                "The user asked me to call some of my MCP tools. I will call MCP_A_MCP_Client___toolA and MCP_A_Remote_MCP_Client___toolC as they look interesting to me.",
+                "The user asked me to call some of my MCP tools. I will call MCP_A_MCP_Client___toolA, MCP_A_Remote_MCP_Client___toolC, and MCP_Another_Remote_MCP_Client___toolA as they look interesting to me.",
                 List.of(
                     ToolExecutionRequest.builder()
                         .id("aaa111")
@@ -170,16 +212,26 @@ public class L4JAiAgentConnectorMcpIntegrationTests extends BaseL4JAiAgentConnec
                         .id("ccc222")
                         .name("MCP_A_Remote_MCP_Client___toolC")
                         .arguments("{\"paramC1\": \"someOtherValue\"}")
+                        .build(),
+                    ToolExecutionRequest.builder()
+                        .id("aaa333")
+                        .name("MCP_Another_Remote_MCP_Client___toolA")
+                        .arguments("{\"paramA1\": \"someValue2\", \"paramA2\": 6}")
                         .build())),
             new ToolExecutionResultMessage(
                 "aaa111", "MCP_A_MCP_Client___toolA", "A MCP Client result"),
             new ToolExecutionResultMessage(
                 "ccc222", "MCP_A_Remote_MCP_Client___toolC", "A Remote MCP Client result"),
+            new ToolExecutionResultMessage(
+                "aaa333",
+                "MCP_Another_Remote_MCP_Client___toolA",
+                "Another Remote MCP Client result"),
             new AiMessage(
                 """
                       I called some of my MCP tools and got the following results:
                       MCP_A_MCP_Client___toolA: A MCP Client result
-                      MCP_A_Remote_MCP_Client___toolC: A Remote MCP Client result"""),
+                      MCP_A_Remote_MCP_Client___toolC: A Remote MCP Client result
+                      MCP_Another_Remote_MCP_Client___toolA: Another Remote MCP Client result"""),
             new UserMessage("Ok thanks, anything else?"),
             new AiMessage("No."));
 
@@ -200,7 +252,7 @@ public class L4JAiAgentConnectorMcpIntegrationTests extends BaseL4JAiAgentConnec
                         .finishReason(FinishReason.STOP)
                         .tokenUsage(new TokenUsage(100, 200))
                         .build())
-                .aiMessage((AiMessage) expectedConversation.get(5))
+                .aiMessage((AiMessage) expectedConversation.get(6))
                 .build(),
             userFollowUpFeedback("Ok thanks, anything else?")),
         ChatInteraction.of(
@@ -210,7 +262,7 @@ public class L4JAiAgentConnectorMcpIntegrationTests extends BaseL4JAiAgentConnec
                         .finishReason(FinishReason.STOP)
                         .tokenUsage(new TokenUsage(11, 22))
                         .build())
-                .aiMessage((AiMessage) expectedConversation.get(7))
+                .aiMessage((AiMessage) expectedConversation.get(8))
                 .build(),
             userSatisfiedFeedback()));
 
@@ -238,6 +290,7 @@ public class L4JAiAgentConnectorMcpIntegrationTests extends BaseL4JAiAgentConnec
 
     verify(aMcpClient).listTools();
     verify(aRemoteMcpClient).listTools();
+    verify(anotherRemoteMcpClient).listTools();
     verify(filesystemMcpClient).listTools();
 
     verify(aMcpClient)
@@ -258,6 +311,18 @@ public class L4JAiAgentConnectorMcpIntegrationTests extends BaseL4JAiAgentConnec
                   JSONAssert.assertEquals(
                       "{\"paramC1\": \"someOtherValue\"}", toolExecutionRequest.arguments(), true);
                 }));
+    verify(anotherRemoteMcpClient)
+        .executeTool(
+            assertArg(
+                toolExecutionRequest -> {
+                  assertThat(toolExecutionRequest.name()).isEqualTo("toolA");
+                  JSONAssert.assertEquals(
+                      "{\"paramA1\": \"someValue2\", \"paramA2\": 6}",
+                      toolExecutionRequest.arguments(),
+                      true);
+                }));
+
+    verify(chatModel, times(3)).chat(any(ChatRequest.class));
   }
 
   @Override
@@ -273,6 +338,8 @@ public class L4JAiAgentConnectorMcpIntegrationTests extends BaseL4JAiAgentConnec
             "MCP_A_MCP_Client___toolC",
             "MCP_A_Remote_MCP_Client___toolA",
             "MCP_A_Remote_MCP_Client___toolC",
+            "MCP_Another_Remote_MCP_Client___toolA",
+            "MCP_Another_Remote_MCP_Client___toolC",
             "MCP_Filesystem_MCP_Flow___toolA",
             "MCP_Filesystem_MCP_Flow___toolB",
             "MCP_Filesystem_MCP_Flow___toolC");
@@ -296,6 +363,15 @@ public class L4JAiAgentConnectorMcpIntegrationTests extends BaseL4JAiAgentConnec
     assertThat(chatRequest.toolSpecifications())
         .filteredOn(
             toolSpecification -> toolSpecification.name().equals("MCP_A_Remote_MCP_Client___toolC"))
+        .hasSize(1)
+        .first()
+        .usingRecursiveComparison()
+        .ignoringFields("name")
+        .isEqualTo(MCP_TOOL_SPECIFICATIONS.get(2));
+    assertThat(chatRequest.toolSpecifications())
+        .filteredOn(
+            toolSpecification ->
+                toolSpecification.name().equals("MCP_Another_Remote_MCP_Client___toolC"))
         .hasSize(1)
         .first()
         .usingRecursiveComparison()

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/resources/agentic-ai-ahsp-connectors-mcp.bpmn
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/resources/agentic-ai-ahsp-connectors-mcp.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bioc="http://bpmn.io/schema/bpmn/biocolor/1.0" xmlns:color="http://www.omg.org/spec/BPMN/non-normative/color/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1gx9y68" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.37.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.8.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bioc="http://bpmn.io/schema/bpmn/biocolor/1.0" xmlns:color="http://www.omg.org/spec/BPMN/non-normative/color/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1gx9y68" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.41.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.8.0">
   <bpmn:process id="Agentic_AI_Connectors_MCP" isExecutable="true">
     <bpmn:startEvent id="StartEvent_1">
       <bpmn:outgoing>Flow_1lbh2cw</bpmn:outgoing>
@@ -91,6 +91,27 @@
           <zeebe:taskDefinition type="io.camunda.agenticai:mcpremoteclient:0" retries="3" />
           <zeebe:ioMapping>
             <zeebe:input source="http://localhost:1234/sse" target="data.connection.sseUrl" />
+            <zeebe:input source="=[&#34;toolA&#34;, &#34;toolB&#34;, &#34;toolC&#34;]" target="data.tools.included" />
+            <zeebe:input source="=[&#34;toolB&#34;]" target="data.tools.excluded" />
+            <zeebe:input source="=toolCall.method" target="data.operation.method" />
+            <zeebe:input source="=toolCall.params" target="data.operation.params" />
+          </zeebe:ioMapping>
+          <zeebe:taskHeaders>
+            <zeebe:header key="elementTemplateVersion" value="0" />
+            <zeebe:header key="elementTemplateId" value="io.camunda.connectors.agenticai.mcp.remoteclient.v0" />
+            <zeebe:header key="resultVariable" value="toolCallResult" />
+            <zeebe:header key="retryBackoff" value="PT0S" />
+          </zeebe:taskHeaders>
+          <zeebe:properties>
+            <zeebe:property name="io.camunda.agenticai.gateway.type" value="mcpClient" />
+          </zeebe:properties>
+        </bpmn:extensionElements>
+      </bpmn:serviceTask>
+      <bpmn:serviceTask id="Another_Remote_MCP_Client" name="Another Remote MCP Client" zeebe:modelerTemplate="io.camunda.connectors.agenticai.mcp.remoteclient.v0" zeebe:modelerTemplateVersion="0" zeebe:modelerTemplateIcon="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyMDAiIGhlaWdodD0iMjAwIiBmaWxsPSJub25lIiB2aWV3Qm94PSIwIDAgMjAwIDIwMCI+CiAgICA8cGF0aCBkPSJNMjUgOTcuODUyOEw5Mi44ODIzIDI5Ljk3MDZDMTAyLjI1NSAyMC41OTggMTE3LjQ1MSAyMC41OTggMTI2LjgyMyAyOS45NzA2VjI5Ljk3MDZDMTM2LjE5NiAzOS4zNDMxIDEzNi4xOTYgNTQuNTM5MSAxMjYuODIzIDYzLjkxMTdMNzUuNTU4MSAxMTUuMTc3IiBzdHJva2U9ImJsYWNrIiBzdHJva2Utd2lkdGg9IjEyIiBzdHJva2UtbGluZWNhcD0icm91bmQiLz4KICAgIDxwYXRoIGQ9Ik03Ni4yNjUzIDExNC40N0wxMjYuODIzIDYzLjkxMTdDMTM2LjE5NiA1NC41MzkxIDE1MS4zOTIgNTQuNTM5MSAxNjAuNzY1IDYzLjkxMTdMMTYxLjExOCA2NC4yNjUyQzE3MC40OTEgNzMuNjM3OCAxNzAuNDkxIDg4LjgzMzggMTYxLjExOCA5OC4yMDYzTDk5LjcyNDggMTU5LjZDOTYuNjAwNiAxNjIuNzI0IDk2LjYwMDYgMTY3Ljc4OSA5OS43MjQ4IDE3MC45MTNMMTEyLjMzMSAxODMuNTIiIHN0cm9rZT0iYmxhY2siIHN0cm9rZS13aWR0aD0iMTIiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCIvPgogICAgPHBhdGggZD0iTTEwOS44NTMgNDYuOTQxMUw1OS42NDgyIDk3LjE0NTdDNTAuMjc1NyAxMDYuNTE4IDUwLjI3NTcgMTIxLjcxNCA1OS42NDgyIDEzMS4wODdWMTMxLjA4N0M2OS4wMjA4IDE0MC40NTkgODQuMjE2OCAxNDAuNDU5IDkzLjU4OTQgMTMxLjA4N0wxNDMuNzk0IDgwLjg4MjIiIHN0cm9rZT0iYmxhY2siIHN0cm9rZS13aWR0aD0iMTIiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCIvPgo8L3N2Zz4K">
+        <bpmn:extensionElements>
+          <zeebe:taskDefinition type="io.camunda.agenticai:mcpremoteclient:0" retries="3" />
+          <zeebe:ioMapping>
+            <zeebe:input source="http://localhost:2345/sse" target="data.connection.sseUrl" />
             <zeebe:input source="=[&#34;toolA&#34;, &#34;toolB&#34;, &#34;toolC&#34;]" target="data.tools.included" />
             <zeebe:input source="=[&#34;toolB&#34;]" target="data.tools.excluded" />
             <zeebe:input source="=toolCall.method" target="data.operation.method" />
@@ -307,6 +328,10 @@ else
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_1fx0n0u_di" bpmnElement="A_Remote_MCP_Client">
         <dc:Bounds x="1310" y="250" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0qr17v6" bpmnElement="Another_Remote_MCP_Client">
+        <dc:Bounds x="1430" y="250" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_19s4fqs_di" bpmnElement="Filesystem_MCP_Flow">

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/resources/agentic-ai-connectors-mcp.bpmn
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/resources/agentic-ai-connectors-mcp.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bioc="http://bpmn.io/schema/bpmn/biocolor/1.0" xmlns:color="http://www.omg.org/spec/BPMN/non-normative/color/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1gx9y68" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.39.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.8.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bioc="http://bpmn.io/schema/bpmn/biocolor/1.0" xmlns:color="http://www.omg.org/spec/BPMN/non-normative/color/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1gx9y68" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.41.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.8.0">
   <bpmn:process id="Agentic_AI_Connectors_MCP" isExecutable="true">
     <bpmn:startEvent id="StartEvent_1">
       <bpmn:outgoing>Flow_1lbh2cw</bpmn:outgoing>
@@ -99,6 +99,27 @@
           <zeebe:taskDefinition type="io.camunda.agenticai:mcpremoteclient:0" retries="3" />
           <zeebe:ioMapping>
             <zeebe:input source="http://localhost:1234/sse" target="data.connection.sseUrl" />
+            <zeebe:input source="=[&#34;toolA&#34;, &#34;toolB&#34;, &#34;toolC&#34;]" target="data.tools.included" />
+            <zeebe:input source="=[&#34;toolB&#34;]" target="data.tools.excluded" />
+            <zeebe:input source="=toolCall.method" target="data.operation.method" />
+            <zeebe:input source="=toolCall.params" target="data.operation.params" />
+          </zeebe:ioMapping>
+          <zeebe:taskHeaders>
+            <zeebe:header key="elementTemplateVersion" value="0" />
+            <zeebe:header key="elementTemplateId" value="io.camunda.connectors.agenticai.mcp.remoteclient.v0" />
+            <zeebe:header key="resultVariable" value="toolCallResult" />
+            <zeebe:header key="retryBackoff" value="PT0S" />
+          </zeebe:taskHeaders>
+          <zeebe:properties>
+            <zeebe:property name="io.camunda.agenticai.gateway.type" value="mcpClient" />
+          </zeebe:properties>
+        </bpmn:extensionElements>
+      </bpmn:serviceTask>
+      <bpmn:serviceTask id="Another_Remote_MCP_Client" name="Another Remote MCP Client" zeebe:modelerTemplate="io.camunda.connectors.agenticai.mcp.remoteclient.v0" zeebe:modelerTemplateVersion="0" zeebe:modelerTemplateIcon="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyMDAiIGhlaWdodD0iMjAwIiBmaWxsPSJub25lIiB2aWV3Qm94PSIwIDAgMjAwIDIwMCI+CiAgICA8cGF0aCBkPSJNMjUgOTcuODUyOEw5Mi44ODIzIDI5Ljk3MDZDMTAyLjI1NSAyMC41OTggMTE3LjQ1MSAyMC41OTggMTI2LjgyMyAyOS45NzA2VjI5Ljk3MDZDMTM2LjE5NiAzOS4zNDMxIDEzNi4xOTYgNTQuNTM5MSAxMjYuODIzIDYzLjkxMTdMNzUuNTU4MSAxMTUuMTc3IiBzdHJva2U9ImJsYWNrIiBzdHJva2Utd2lkdGg9IjEyIiBzdHJva2UtbGluZWNhcD0icm91bmQiLz4KICAgIDxwYXRoIGQ9Ik03Ni4yNjUzIDExNC40N0wxMjYuODIzIDYzLjkxMTdDMTM2LjE5NiA1NC41MzkxIDE1MS4zOTIgNTQuNTM5MSAxNjAuNzY1IDYzLjkxMTdMMTYxLjExOCA2NC4yNjUyQzE3MC40OTEgNzMuNjM3OCAxNzAuNDkxIDg4LjgzMzggMTYxLjExOCA5OC4yMDYzTDk5LjcyNDggMTU5LjZDOTYuNjAwNiAxNjIuNzI0IDk2LjYwMDYgMTY3Ljc4OSA5OS43MjQ4IDE3MC45MTNMMTEyLjMzMSAxODMuNTIiIHN0cm9rZT0iYmxhY2siIHN0cm9rZS13aWR0aD0iMTIiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCIvPgogICAgPHBhdGggZD0iTTEwOS44NTMgNDYuOTQxMUw1OS42NDgyIDk3LjE0NTdDNTAuMjc1NyAxMDYuNTE4IDUwLjI3NTcgMTIxLjcxNCA1OS42NDgyIDEzMS4wODdWMTMxLjA4N0M2OS4wMjA4IDE0MC40NTkgODQuMjE2OCAxNDAuNDU5IDkzLjU4OTQgMTMxLjA4N0wxNDMuNzk0IDgwLjg4MjIiIHN0cm9rZT0iYmxhY2siIHN0cm9rZS13aWR0aD0iMTIiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCIvPgo8L3N2Zz4K">
+        <bpmn:extensionElements>
+          <zeebe:taskDefinition type="io.camunda.agenticai:mcpremoteclient:0" retries="3" />
+          <zeebe:ioMapping>
+            <zeebe:input source="http://localhost:2345/sse" target="data.connection.sseUrl" />
             <zeebe:input source="=[&#34;toolA&#34;, &#34;toolB&#34;, &#34;toolC&#34;]" target="data.tools.included" />
             <zeebe:input source="=[&#34;toolB&#34;]" target="data.tools.excluded" />
             <zeebe:input source="=toolCall.method" target="data.operation.method" />
@@ -352,14 +373,6 @@ else
       <bpmndi:BPMNShape id="Activity_0zm24e8_di" bpmnElement="Download_A_File">
         <dc:Bounds x="920" y="850" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="BPMNShape_1mw2r64" bpmnElement="A_MCP_Client">
-        <dc:Bounds x="1270" y="640" width="100" height="80" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_1fx0n0u_di" bpmnElement="A_Remote_MCP_Client">
-        <dc:Bounds x="1390" y="640" width="100" height="80" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_19s4fqs_di" bpmnElement="Filesystem_MCP_Flow">
         <dc:Bounds x="1267" y="792" width="36" height="36" />
         <bpmndi:BPMNLabel>
@@ -390,6 +403,18 @@ else
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_0ke4gic_di" bpmnElement="Activity_0mdux6v">
         <dc:Bounds x="1325" y="910" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1mw2r64" bpmnElement="A_MCP_Client">
+        <dc:Bounds x="1260" y="640" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1fx0n0u_di" bpmnElement="A_Remote_MCP_Client">
+        <dc:Bounds x="1380" y="640" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_18xm2ng" bpmnElement="Another_Remote_MCP_Client">
+        <dc:Bounds x="1500" y="640" width="100" height="80" />
+        <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNEdge id="Flow_095717l_di" bpmnElement="Flow_095717l">
         <di:waypoint x="1020" y="780" />

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/resources/expected-schema-result-mcp-discovery-disabled.json
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/resources/expected-schema-result-mcp-discovery-disabled.json
@@ -81,6 +81,15 @@
       }
     },
     {
+      "name": "Another_Remote_MCP_Client",
+      "description": "Another Remote MCP Client",
+      "inputSchema": {
+        "properties": {},
+        "type": "object",
+        "required": []
+      }
+    },
+    {
       "name": "Filesystem_MCP_Flow",
       "description": "Filesystem MCP Flow",
       "inputSchema": {

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/resources/expected-schema-result-mcp.json
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/resources/expected-schema-result-mcp.json
@@ -76,6 +76,11 @@
     },
     {
       "type": "mcpClient",
+      "name": "Another_Remote_MCP_Client",
+      "description": "Another Remote MCP Client"
+    },
+    {
+      "type": "mcpClient",
       "name": "Filesystem_MCP_Flow",
       "description": "Filesystem MCP Flow"
     }

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/agent/AgentInitializationResult.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/agent/AgentInitializationResult.java
@@ -13,11 +13,14 @@ import java.util.List;
 
 public sealed interface AgentInitializationResult
     permits AgentInitializationResult.AgentContextInitializationResult,
+        AgentInitializationResult.AgentDiscoveryInProgressInitializationResult,
         AgentInitializationResult.AgentResponseInitializationResult {
 
   record AgentContextInitializationResult(
       AgentContext agentContext, List<ToolCallResult> toolCallResults)
       implements AgentInitializationResult {}
+
+  record AgentDiscoveryInProgressInitializationResult() implements AgentInitializationResult {}
 
   record AgentResponseInitializationResult(AgentResponse agentResponse)
       implements AgentInitializationResult {}

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/agent/AgentInitializerImpl.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/agent/AgentInitializerImpl.java
@@ -8,6 +8,7 @@ package io.camunda.connector.agenticai.aiagent.agent;
 
 import io.camunda.connector.agenticai.adhoctoolsschema.schema.AdHocToolsSchemaResolver;
 import io.camunda.connector.agenticai.aiagent.agent.AgentInitializationResult.AgentContextInitializationResult;
+import io.camunda.connector.agenticai.aiagent.agent.AgentInitializationResult.AgentDiscoveryInProgressInitializationResult;
 import io.camunda.connector.agenticai.aiagent.agent.AgentInitializationResult.AgentResponseInitializationResult;
 import io.camunda.connector.agenticai.aiagent.model.AgentContext;
 import io.camunda.connector.agenticai.aiagent.model.AgentExecutionContext;
@@ -102,6 +103,10 @@ public class AgentInitializerImpl implements AgentInitializer {
 
   private AgentInitializationResult handleToolDiscoveryResults(
       AgentContext agentContext, List<ToolCallResult> toolCallResults) {
+    if (!gatewayToolHandlers.allToolDiscoveryResultsPresent(agentContext, toolCallResults)) {
+      return new AgentDiscoveryInProgressInitializationResult();
+    }
+
     final var gatewayToolDiscoveryResult =
         gatewayToolHandlers.handleToolDiscoveryResults(agentContext, toolCallResults);
 

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/agent/BaseAgentRequestHandler.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/agent/BaseAgentRequestHandler.java
@@ -7,6 +7,7 @@
 package io.camunda.connector.agenticai.aiagent.agent;
 
 import io.camunda.connector.agenticai.aiagent.agent.AgentInitializationResult.AgentContextInitializationResult;
+import io.camunda.connector.agenticai.aiagent.agent.AgentInitializationResult.AgentDiscoveryInProgressInitializationResult;
 import io.camunda.connector.agenticai.aiagent.agent.AgentInitializationResult.AgentResponseInitializationResult;
 import io.camunda.connector.agenticai.aiagent.framework.AiFrameworkAdapter;
 import io.camunda.connector.agenticai.aiagent.memory.conversation.ConversationSession;
@@ -73,6 +74,13 @@ public abstract class BaseAgentRequestHandler<C extends AgentExecutionContext, R
         yield completeJob(executionContext, agentResponse, null);
       }
 
+      // discovery still in progress (not all tool call results present)
+      case AgentDiscoveryInProgressInitializationResult ignored -> {
+        LOGGER.debug(
+            "AI Agent initialization tool discovery is still in progress. Completing job without further processing.");
+        yield completeJob(executionContext, null, null);
+      }
+
       case AgentContextInitializationResult(
           AgentContext agentContext,
           List<ToolCallResult> toolCallResults) -> {
@@ -130,7 +138,7 @@ public abstract class BaseAgentRequestHandler<C extends AgentExecutionContext, R
     // update memory with user messages/tool call responses
     if (LOGGER.isDebugEnabled()) {
       LOGGER.debug(
-          "Adding user messages including {} tool call results for the following tool call results: {}",
+          "Adding user messages including the following {} tool call results: {}",
           toolCallResults.size(),
           toolCallResults.stream().map(tcr -> Pair.of(tcr.id(), tcr.name())).toList());
     }

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/tool/GatewayToolHandler.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/tool/GatewayToolHandler.java
@@ -26,6 +26,13 @@ public interface GatewayToolHandler extends GatewayToolCallTransformer {
   GatewayToolDiscoveryInitiationResult initiateToolDiscovery(
       AgentContext agentContext, List<GatewayToolDefinition> gatewayToolDefinitions);
 
+  /**
+   * Determines whether requested tool discovery results are present in the list of tool call
+   * results.
+   */
+  boolean allToolDiscoveryResultsPresent(
+      AgentContext agentContext, List<ToolCallResult> toolCallResults);
+
   /** Defines whether this specific handler is able to handle the given tool call result. */
   boolean handlesToolDiscoveryResult(ToolCallResult toolCallResult);
 

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/tool/GatewayToolHandlerRegistry.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/tool/GatewayToolHandlerRegistry.java
@@ -19,6 +19,9 @@ public interface GatewayToolHandlerRegistry extends GatewayToolCallTransformer {
   GatewayToolDiscoveryInitiationResult initiateToolDiscovery(
       AgentContext agentContext, List<GatewayToolDefinition> gatewayToolDefinitions);
 
+  boolean allToolDiscoveryResultsPresent(
+      AgentContext agentContext, List<ToolCallResult> toolCallResults);
+
   GatewayToolDiscoveryResult handleToolDiscoveryResults(
       AgentContext agentContext, List<ToolCallResult> toolCallResults);
 }

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/tool/GatewayToolHandlerRegistryImpl.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/tool/GatewayToolHandlerRegistryImpl.java
@@ -68,6 +68,13 @@ public class GatewayToolHandlerRegistryImpl implements GatewayToolHandlerRegistr
   }
 
   @Override
+  public boolean allToolDiscoveryResultsPresent(
+      final AgentContext agentContext, final List<ToolCallResult> toolCallResults) {
+    return handlers.values().stream()
+        .allMatch(handler -> handler.allToolDiscoveryResultsPresent(agentContext, toolCallResults));
+  }
+
+  @Override
   public GatewayToolDiscoveryResult handleToolDiscoveryResults(
       final AgentContext agentContext, final List<ToolCallResult> toolCallResults) {
     // group tool call results by gateway type - keep non-gateway tool call results in DEFAULT_TYPE

--- a/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/tool/GatewayToolHandlerRegistryTest.java
+++ b/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/tool/GatewayToolHandlerRegistryTest.java
@@ -199,6 +199,54 @@ class GatewayToolHandlerRegistryTest {
     }
 
     @Nested
+    class AllToolDiscoveryResultsPresent {
+
+      private static final List<ToolCallResult> TOOL_CALL_RESULTS =
+          List.of(
+              ToolCallResult.builder().id("result1").name("tool1").content("content1").build(),
+              ToolCallResult.builder().id("result2").name("tool2").content("content2").build());
+
+      @Test
+      void returnsTrue_whenAllHandlersReturnTrue() {
+        when(handlerA.allToolDiscoveryResultsPresent(AGENT_CONTEXT, TOOL_CALL_RESULTS))
+            .thenReturn(true);
+        when(handlerB.allToolDiscoveryResultsPresent(AGENT_CONTEXT, TOOL_CALL_RESULTS))
+            .thenReturn(true);
+
+        assertThat(registry.allToolDiscoveryResultsPresent(AGENT_CONTEXT, TOOL_CALL_RESULTS))
+            .isTrue();
+      }
+
+      @Test
+      void returnsFalse_whenAnyHandlerReturnsFalse() {
+        when(handlerA.allToolDiscoveryResultsPresent(AGENT_CONTEXT, TOOL_CALL_RESULTS))
+            .thenReturn(true);
+        when(handlerB.allToolDiscoveryResultsPresent(AGENT_CONTEXT, TOOL_CALL_RESULTS))
+            .thenReturn(false);
+
+        assertThat(registry.allToolDiscoveryResultsPresent(AGENT_CONTEXT, TOOL_CALL_RESULTS))
+            .isFalse();
+      }
+
+      @Test
+      void returnsFalse_whenFirstHandlerReturnsFalse() {
+        when(handlerA.allToolDiscoveryResultsPresent(AGENT_CONTEXT, TOOL_CALL_RESULTS))
+            .thenReturn(false);
+
+        assertThat(registry.allToolDiscoveryResultsPresent(AGENT_CONTEXT, TOOL_CALL_RESULTS))
+            .isFalse();
+      }
+
+      @Test
+      void returnsTrue_whenNoHandlersAreRegistered() {
+        final var emptyRegistry = new GatewayToolHandlerRegistryImpl();
+
+        assertThat(emptyRegistry.allToolDiscoveryResultsPresent(AGENT_CONTEXT, TOOL_CALL_RESULTS))
+            .isTrue();
+      }
+    }
+
+    @Nested
     class HandleToolDiscoveryResults {
 
       @Test

--- a/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/mcp/discovery/McpClientGatewayToolHandlerTest.java
+++ b/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/mcp/discovery/McpClientGatewayToolHandlerTest.java
@@ -110,6 +110,89 @@ class McpClientGatewayToolHandlerTest {
   }
 
   @Nested
+  class AllToolDiscoveryResultsPresent {
+
+    @Test
+    void returnsTrue_whenAllMcpClientToolDiscoveryResultsPresent() {
+      var agentContext =
+          AgentContext.empty().withProperty(PROPERTY_MCP_CLIENTS, List.of("mcp1", "mcp2"));
+      var toolCallResults =
+          List.of(
+              ToolCallResult.builder()
+                  .id("MCP_toolsList_mcp1")
+                  .name("mcp1")
+                  .content("result1")
+                  .build(),
+              ToolCallResult.builder()
+                  .id("MCP_toolsList_mcp2")
+                  .name("mcp2")
+                  .content("result2")
+                  .build());
+
+      assertThat(handler.allToolDiscoveryResultsPresent(agentContext, toolCallResults)).isTrue();
+    }
+
+    @Test
+    void returnsFalse_whenSomeMcpClientToolDiscoveryResultsMissing() {
+      var agentContext =
+          AgentContext.empty().withProperty(PROPERTY_MCP_CLIENTS, List.of("mcp1", "mcp2"));
+      var toolCallResults =
+          List.of(
+              ToolCallResult.builder()
+                  .id("MCP_toolsList_mcp1")
+                  .name("mcp1")
+                  .content("result1")
+                  .build());
+
+      assertThat(handler.allToolDiscoveryResultsPresent(agentContext, toolCallResults)).isFalse();
+    }
+
+    @Test
+    void returnsFalse_whenNoToolCallResultsProvided() {
+      var agentContext =
+          AgentContext.empty().withProperty(PROPERTY_MCP_CLIENTS, List.of("mcp1", "mcp2"));
+      var toolCallResults = List.<ToolCallResult>of();
+
+      assertThat(handler.allToolDiscoveryResultsPresent(agentContext, toolCallResults)).isFalse();
+    }
+
+    @Test
+    void returnsTrue_whenNoMcpClientsConfigured() {
+      var agentContext = AgentContext.empty();
+      var toolCallResults = List.<ToolCallResult>of();
+
+      assertThat(handler.allToolDiscoveryResultsPresent(agentContext, toolCallResults)).isTrue();
+    }
+
+    @Test
+    void returnsTrue_whenEmptyMcpClientsList() {
+      var agentContext = AgentContext.empty().withProperty(PROPERTY_MCP_CLIENTS, List.of());
+      var toolCallResults = List.<ToolCallResult>of();
+
+      assertThat(handler.allToolDiscoveryResultsPresent(agentContext, toolCallResults)).isTrue();
+    }
+
+    @Test
+    void ignoresNonDiscoveryToolCallResults() {
+      var agentContext = AgentContext.empty().withProperty(PROPERTY_MCP_CLIENTS, List.of("mcp1"));
+      var toolCallResults =
+          List.of(
+              ToolCallResult.builder()
+                  .id("MCP_toolsList_mcp1")
+                  .name("mcp1")
+                  .content("result1")
+                  .build(),
+              ToolCallResult.builder()
+                  .id("regular_tool_call")
+                  .name("regular_tool")
+                  .content("result")
+                  .build());
+
+      assertThat(handler.allToolDiscoveryResultsPresent(agentContext, toolCallResults)).isTrue();
+    }
+  }
+
+  @Nested
   class ToolDiscoveryResultHandling {
 
     @ParameterizedTest


### PR DESCRIPTION
# Description

Manually created backport of #5708 to `release/8.8` due to conflicts on the non-existing A2A code parts.