### PR TITLE
fix(GHA): set SNAPSHOT version in deploy-snapshots

### DIFF
--- a/.github/workflows/DEPLOY_8.8._SNAPSHOTS.yaml
+++ b/.github/workflows/DEPLOY_8.8._SNAPSHOTS.yaml
@@ -64,7 +64,8 @@ jobs:
                "password": "${{ steps.secrets.outputs.ARTIFACTORY_PSW }}"
              }]
           mirrors: '[{"url": "https://repository.nexus.camunda.cloud/content/groups/internal/", "id": "camunda-nexus", "mirrorOf": "*,!confluent,!shibboleth", "name": "camunda Nexus"}]'
-
+      - name: Set version to 8.8-SNAPSHOT
+        run: mvn -B versions:set -DnewVersion=8.8-SNAPSHOT -DgenerateBackupPoms=false -f parent
       - name: Build Artifacts
         run: mvn -B compile generate-sources source:jar javadoc:jar deploy -DskipTests
         env:


### PR DESCRIPTION
## Description

We shouldn't overwrite released artifacts

## Related issues

See https://github.com/camunda/connectors/issues/5672

## Checklist

- [X] PR has a **milestone** or the `no milestone` label.
- [X] Backport labels are added if these code changes should be backported. No backport label is added to the latest release, as this branch will be rebased onto main before the next release.

