### PR TITLE
other(ci): use Nexus for internal builds and Artifactory for external ones

### DIFF
--- a/.github/workflows/TEST_FEATURE_BRANCH.yml
+++ b/.github/workflows/TEST_FEATURE_BRANCH.yml
@@ -22,11 +22,34 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
 
+      # Determine internal build:
+      # Internal if repository owner is camunda AND (not a PR from a fork).
+      # For pull_request: !github.event.pull_request.head.repo.fork
+      # For push/merge_group: repository is always base repo if owner matches.
+      # We avoid using secrets for fork pushes because this workflow file exists only in base repo; fork pushes wouldn't have camunda owner.
+      - name: Set internal build flag
+        id: internal
+        run: |
+          if [ "${{ github.repository_owner }}" = "camunda" ]; then
+            if [ "${{ github.event_name }}" = "pull_request" ]; then
+              if [ "${{ github.event.pull_request.head.repo.fork }}" = "false" ]; then
+                echo "internal=true" >> $GITHUB_OUTPUT
+              else
+                echo "internal=false" >> $GITHUB_OUTPUT
+              fi
+            else
+              echo "internal=true" >> $GITHUB_OUTPUT
+            fi
+          else
+            echo "internal=false" >> $GITHUB_OUTPUT
+          fi
+
+      # Restore cache (distinct key for internal vs external to avoid mixing artifacts)
       - name: Restore cache
         uses: actions/cache@v4
         with:
           path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}-${{ steps.internal.outputs.internal == 'true' && 'internal' || 'external' }}
           restore-keys: |
             ${{ runner.os }}-maven-
 
@@ -42,6 +65,45 @@ jobs:
       - name: Install element templates CLI
         run: npm install --global element-templates-cli@$(jq -r '.devDependencies["element-templates-cli"]' .github/workflows/package.json)
 
+      # Internal-only: fetch Nexus credentials from Vault and create settings.xml with mirror
+      - name: Import Nexus Secrets (internal only)
+        if: ${{ steps.internal.outputs.internal == 'true' }}
+        id: secrets
+        uses: hashicorp/vault-action@v3.4.0
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          exportEnv: false # we rely on step outputs, no need for environment variables
+          secrets: |
+            secret/data/products/connectors/ci/common ARTIFACTORY_USR;
+            secret/data/products/connectors/ci/common ARTIFACTORY_PSW;
+            secret/data/github.com/organizations/camunda MAVEN_CENTRAL_DEPLOYMENT_USR;
+            secret/data/github.com/organizations/camunda MAVEN_CENTRAL_DEPLOYMENT_PSW;
+            secret/data/github.com/organizations/camunda MAVEN_CENTRAL_GPG_SIGNING_KEY_PASSPHRASE;
+            secret/data/github.com/organizations/camunda MAVEN_CENTRAL_GPG_SIGNING_KEY_SEC;
+
+      - name: Create internal Maven settings.xml (Nexus mirror)
+        if: ${{ steps.internal.outputs.internal == 'true' }}
+        uses: s4u/maven-settings-action@v4.0.0
+        with:
+          githubServer: false
+          servers: |
+            [{
+               "id": "camunda-nexus",
+               "username": "${{ steps.secrets.outputs.ARTIFACTORY_USR }}",
+               "password": "${{ steps.secrets.outputs.ARTIFACTORY_PSW }}"
+             },
+            {
+               "id": "central",
+               "username": "${{ steps.secrets.outputs.MAVEN_CENTRAL_DEPLOYMENT_USR }}",
+               "password": "${{ steps.secrets.outputs.MAVEN_CENTRAL_DEPLOYMENT_PSW }}"
+             }
+            ]
+          mirrors: '[{"url": "https://repository.nexus.camunda.cloud/content/groups/internal/", "id": "camunda-nexus", "mirrorOf": "*,!confluent,!shibboleth", "name": "camunda Nexus"}]'
+
+      # Build
       - name: Build Connectors
         run: mvn --batch-mode clean test -PcheckFormat -Dquickly
 
@@ -80,5 +142,3 @@ jobs:
             exit 1
           fi
         shell: bash
-
-


### PR DESCRIPTION
## Description

This pull request updates the `.github/workflows/TEST_FEATURE_BRANCH.yml` workflow to improve CI security and reliability by distinguishing between internal and external builds.

The workflow now uses different build processes depending on whether the build is internal (from the main repository) or external (from a fork), ensuring secrets and internal resources are only accessible to trusted builds.

Build isolation and security:

* Added a step to determine if the build is internal by checking if the repository owner is `camunda` and, for pull requests, that the PR is not from a fork. This sets an `internal` flag for use in later steps.
* Updated the Maven cache key to include the `internal` flag, preventing cache sharing between internal and external builds and avoiding artifact contamination.

Internal-only Nexus credentials and Maven configuration:

* For internal builds, added steps to fetch Nexus credentials from Vault and create a custom `settings.xml` file with a Nexus mirror, enabling access to internal repositories.
* Internal builds now use the Nexus mirror for Maven operations, while external builds use default public repositories, ensuring secrets and internal resources are not exposed to forks.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #5706 

## Checklist

- [ ] PR has a **milestone** or the `no milestone` label.
- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest release, as this branch will be rebased onto main before the next release.

