### PR TITLE
fix: broken connector discovery test

### DIFF
--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/outbound/RuntimeStartupWithConnectorsFromSpiTests.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/outbound/RuntimeStartupWithConnectorsFromSpiTests.java
@@ -40,6 +40,6 @@ class RuntimeStartupWithConnectorsFromSpiTests {
 
   @Test
   public void httpConnectorLoadedViaSpi() {
-    assertDoesNotThrow(() -> jobWorkerManager.getJobWorker("TEST"));
+    assertDoesNotThrow(() -> jobWorkerManager.getJobWorker("io.camunda:test-outbound:1"));
   }
 }


### PR DESCRIPTION
## Description

Fixes a test issue introduced after upgrading to Camunda client 8.9.0-SNAPSHOT in #5704 

The internal API has changed and now returns a job worker by job type, not by name.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #

## Checklist

- [ ] PR has a **milestone** or the `no milestone` label.
- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest release, as this branch will be rebased onto main before the next release.

