### PR TITLE
chore: quick fix for SNAPSHOT SAAS, before the credential bean is used

### DIFF
--- a/bundle/camunda-saas-bundle/src/main/resources/application.properties
+++ b/bundle/camunda-saas-bundle/src/main/resources/application.properties
@@ -29,5 +29,7 @@ camunda.connector.inbound.log.size=100
 camunda.connector.secretprovider.discovery.enabled=false
 camunda.endpoints.cors.mappings=/inbound-instances/**
 camunda.endpoints.cors.allow.credentials=true
-
 server.max-http-request-header-size=1MB
+# To be removed when implementing proper auth for SaaS
+# https://github.com/camunda/connectors/issues/5710
+camunda.client.auth.method=none


### PR DESCRIPTION
## Description

This should temporarily fix this [issue](https://camunda.slack.com/archives/C02JLRNQQ05/p1763047603125409)

## Checklist

- [ ] PR has a **milestone** or the `no milestone` label.
- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest release, as this branch will be rebased onto main before the next release.

