### PR TITLE
chore(junit): remove Junit 4

### DIFF
--- a/connector-commons/http-client/pom.xml
+++ b/connector-commons/http-client/pom.xml
@@ -121,8 +121,8 @@ limitations under the License.</license.inlineheader>
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/connector-commons/http-client/src/test/java/io/camunda/connector/http/client/client/apache/CustomResponseHandlerTest.java
+++ b/connector-commons/http-client/src/test/java/io/camunda/connector/http/client/client/apache/CustomResponseHandlerTest.java
@@ -17,7 +17,7 @@
 package io.camunda.connector.http.client.client.apache;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import io.camunda.connector.api.error.ConnectorException;

--- a/connectors-e2e-test/connectors-e2e-test-aws/connectors-e2e-test-aws-base/pom.xml
+++ b/connectors-e2e-test/connectors-e2e-test-aws/connectors-e2e-test-aws-base/pom.xml
@@ -19,7 +19,7 @@
     <dependencies>
         <dependency>
             <groupId>org.testcontainers</groupId>
-            <artifactId>localstack</artifactId>
+            <artifactId>testcontainers-localstack</artifactId>
             <version>${version.localstack}</version>
         </dependency>
         <dependency>
@@ -68,7 +68,7 @@
 
         <dependency>
             <groupId>org.testcontainers</groupId>
-            <artifactId>junit-jupiter</artifactId>
+            <artifactId>testcontainers-junit-jupiter</artifactId>
         </dependency>
     </dependencies>
 

--- a/connectors/pom.xml
+++ b/connectors/pom.xml
@@ -100,7 +100,7 @@ except in compliance with the proprietary license.</license.inlineheader>
     </dependency>
     <dependency>
       <groupId>org.testcontainers</groupId>
-      <artifactId>junit-jupiter</artifactId>
+      <artifactId>testcontainers-junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -101,7 +101,7 @@ limitations under the License.</license.inlineheader>
     <version.aws-lambda-java-core>1.4.0</version.aws-lambda-java-core>
     <version.aws-sdk-secretsmanager>2.40.0</version.aws-sdk-secretsmanager>
 
-    <version.localstack>1.21.3</version.localstack>
+    <version.localstack>2.0.2</version.localstack>
 
     <version.google-api-client>2.8.1</version.google-api-client>
 

--- a/secret-providers/aws/pom.xml
+++ b/secret-providers/aws/pom.xml
@@ -25,8 +25,8 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/secret-providers/aws/src/test/java/AwsSecretProviderTest.java
+++ b/secret-providers/aws/src/test/java/AwsSecretProviderTest.java
@@ -15,11 +15,11 @@
  * limitations under the License.
  */
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import io.camunda.connector.api.secret.SecretProvider;
 import java.util.ServiceLoader;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class AwsSecretProviderTest {
   @Test

--- a/secret-providers/gcp/pom.xml
+++ b/secret-providers/gcp/pom.xml
@@ -37,8 +37,8 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/secret-providers/gcp/src/test/java/GcpSecretProviderTest.java
+++ b/secret-providers/gcp/src/test/java/GcpSecretProviderTest.java
@@ -14,11 +14,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import io.camunda.connector.api.secret.SecretProvider;
 import java.util.ServiceLoader;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class GcpSecretProviderTest {
 


### PR DESCRIPTION
## Description

Remove all plain Junit imports ( checked via `rg --pcre2 'org\.junit\.(?!jupiter)' .`)
and fix up some imports missed in the test containers update. 
No more non-prefixed test containers exist in the codebase
`rg '>org\.testcontainers' -A 2 . | rg --pcre2 '<artifactId>(?!testcontainer)'`

## Checklist

- [X] PR has a **milestone** or the `no milestone` label.
- [X] Backport labels are added if these code changes should be backported. No backport label is added to the latest release, as this branch will be rebased onto main before the next release.

