### PR TITLE
chore(saas): configure CredentialsProvider for SaaS directly (#5711)

### DIFF
--- a/bundle/camunda-saas-bundle/src/main/java/io/camunda/connector/runtime/saas/CamundaClientSaaSConfiguration.java
+++ b/bundle/camunda-saas-bundle/src/main/java/io/camunda/connector/runtime/saas/CamundaClientSaaSConfiguration.java
@@ -16,23 +16,14 @@
  */
 package io.camunda.connector.runtime.saas;
 
-import io.camunda.client.CamundaClientConfiguration;
 import io.camunda.client.CredentialsProvider;
-import io.camunda.client.api.JsonMapper;
 import io.camunda.client.impl.oauth.OAuthCredentialsProviderBuilder;
-import io.camunda.client.jobhandling.CamundaClientExecutorService;
-import io.camunda.client.spring.configuration.SpringCamundaClientConfiguration;
-import io.camunda.client.spring.properties.CamundaClientProperties;
 import io.camunda.connector.api.secret.SecretProvider;
-import io.grpc.ClientInterceptor;
-import java.util.List;
-import org.apache.hc.client5.http.async.AsyncExecChainHandler;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Primary;
 
 /**
  * This class configures the custom credentials provider for the Camunda client. If the default
@@ -61,24 +52,8 @@ public class CamundaClientSaaSConfiguration {
   }
 
   @Bean
-  @Primary
   @Conditional(AuthPropertiesNotPresentCondition.class)
-  public CamundaClientConfiguration saasCamundaClientConfiguration(
-      final CamundaClientProperties camundaClientProperties,
-      final JsonMapper jsonMapper,
-      final List<ClientInterceptor> interceptors,
-      final List<AsyncExecChainHandler> chainHandlers,
-      final CamundaClientExecutorService zeebeClientExecutorService) {
-    return new SpringCamundaClientConfiguration(
-        camundaClientProperties,
-        jsonMapper,
-        interceptors,
-        chainHandlers,
-        zeebeClientExecutorService,
-        internalConnectorsSecretCredentialsProvider());
-  }
-
-  public CredentialsProvider internalConnectorsSecretCredentialsProvider() {
+  public CredentialsProvider customConnectorsCredentialsProvider() {
     final var builder = new OAuthCredentialsProviderBuilder();
     builder.clientId(internalSecretProvider.getSecret(SECRET_NAME_CLIENT_ID, null));
     builder.clientSecret(internalSecretProvider.getSecret(SECRET_NAME_SECRET, null));

--- a/bundle/camunda-saas-bundle/src/test/java/io/camunda/connector/runtime/saas/auth/CustomCredentialsProviderNotUsedTest.java
+++ b/bundle/camunda-saas-bundle/src/test/java/io/camunda/connector/runtime/saas/auth/CustomCredentialsProviderNotUsedTest.java
@@ -16,13 +16,13 @@
  */
 package io.camunda.connector.runtime.saas.auth;
 
-import static org.junit.Assert.assertThrows;
+import static org.assertj.core.api.Assertions.assertThat;
 
+import io.camunda.client.CredentialsProvider;
 import io.camunda.connector.runtime.saas.SaaSConnectorRuntimeApplication;
 import io.camunda.connector.runtime.saas.SaaSSecretConfiguration;
 import org.junit.jupiter.api.Test;
 import org.mockito.Answers;
-import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.ApplicationContext;
@@ -52,8 +52,14 @@ public class CustomCredentialsProviderNotUsedTest {
 
   @Test
   public void credentialsProvidedInProperties_customCredentialsProviderNotUsed() {
-    assertThrows(
-        NoSuchBeanDefinitionException.class,
-        () -> applicationContext.getBean("saasCamundaClientConfiguration"));
+    // When client-id and client-secret are provided in properties,
+    // a CredentialsProvider bean should exist (from the Spring Boot starter),
+    // but the custom credentialsProvider bean from our configuration should not be registered
+    assertThat(applicationContext.getBean(CredentialsProvider.class)).isNotNull();
+    // The conditional bean "credentialsProvider" from CamundaClientSaaSConfiguration should not
+    // exist
+    var beansWithName = applicationContext.getBeansOfType(CredentialsProvider.class);
+    assertThat(beansWithName).doesNotContainKey("customConnectorsCredentialsProvider");
+    assertThat(beansWithName).containsKey("camundaClientCredentialsProvider");
   }
 }

--- a/bundle/camunda-saas-bundle/src/test/java/io/camunda/connector/runtime/saas/auth/CustomCredentialsProviderUsedTest.java
+++ b/bundle/camunda-saas-bundle/src/test/java/io/camunda/connector/runtime/saas/auth/CustomCredentialsProviderUsedTest.java
@@ -18,7 +18,7 @@ package io.camunda.connector.runtime.saas.auth;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.camunda.client.CamundaClientConfiguration;
+import io.camunda.client.CredentialsProvider;
 import io.camunda.connector.runtime.saas.SaaSConnectorRuntimeApplication;
 import io.camunda.connector.runtime.saas.SaaSSecretConfiguration;
 import org.junit.jupiter.api.Test;
@@ -38,8 +38,7 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
       "camunda.connector.secretprovider.discovery.enabled=false",
       "camunda.client.auth.token-url=https://weblogin.cloud.dev.ultrawombat.com/token",
       "camunda.client.auth.audience=connectors.dev.ultrawombat.com",
-      "camunda.client.auth.client-id=client-id",
-      "camunda.client.auth.client-secret=client-secret",
+      // NOTE: client-id and client-secret are NOT provided
       "spring.cloud.gcp.parametermanager.enabled=false"
     })
 @ActiveProfiles("test")
@@ -52,6 +51,11 @@ public class CustomCredentialsProviderUsedTest {
 
   @Test
   public void credentialsNotProvidedInProperties_customCredentialsProviderUsed() {
-    assertThat(applicationContext.getBean(CamundaClientConfiguration.class)).isNotNull();
+    // When client-id and client-secret are NOT provided in properties,
+    // our custom credentialsProvider bean should be created
+    assertThat(applicationContext.getBean(CredentialsProvider.class)).isNotNull();
+    var beansWithName = applicationContext.getBeansOfType(CredentialsProvider.class);
+    assertThat(beansWithName).containsKey("customConnectorsCredentialsProvider");
+    assertThat(beansWithName).doesNotContainKey("camundaClientCredentialsProvider");
   }
 }


### PR DESCRIPTION
This pull request refactors the way credentials providers are configured and tested for the Camunda SaaS Connector. The main change is to simplify and clarify the conditional creation of a custom `CredentialsProvider` bean, depending on whether authentication properties are provided. The related tests are updated to explicitly check for the presence or absence of the custom credentials provider bean.

**Configuration changes:**

* Refactored `CamundaClientSaaSConfiguration` to remove the conditional `CamundaClientConfiguration` bean and instead directly provide a conditional custom `CredentialsProvider` bean named `customConnectorsCredentialsProvider`. This bean is only created if authentication properties are not present.
* Removed unused imports and cleaned up the configuration file for clarity and maintainability.

**Test updates:**

* Updated `CustomCredentialsProviderNotUsedTest` to assert that when authentication properties are present, only the default credentials provider bean exists, and the custom credentials provider bean is not registered. [[1]](diffhunk://#diff-01979cb7aa590e91a83511acac46543ba9a6551053a25707ddd6b2dfd7a3d689L55-R63) [[2]](diffhunk://#diff-01979cb7aa590e91a83511acac46543ba9a6551053a25707ddd6b2dfd7a3d689L19-L25)
* Updated `CustomCredentialsProviderUsedTest` to assert that when authentication properties are missing, the custom credentials provider bean is registered and the default bean is not. Also clarified test configuration to ensure client-id and client-secret are not provided. [[1]](diffhunk://#diff-f63044cdc394075747fff9a40db6d920f07fe6e84f5b38715a76512a6827ababL55-R59) [[2]](diffhunk://#diff-f63044cdc394075747fff9a40db6d920f07fe6e84f5b38715a76512a6827ababL41-R41) [[3]](diffhunk://#diff-f63044cdc394075747fff9a40db6d920f07fe6e84f5b38715a76512a6827ababL21-R21)* Initial plan

