### PR TITLE
refactor(http-webhook): extract HMAC verification logic

### DIFF
--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/a2a/client/inbound/webhook/A2aClientWebhookExecutable.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/a2a/client/inbound/webhook/A2aClientWebhookExecutable.java
@@ -31,7 +31,6 @@ import io.camunda.connector.inbound.authorization.AuthorizationResult.Failure;
 import io.camunda.connector.inbound.authorization.WebhookAuthorizationHandler;
 import io.camunda.connector.inbound.signature.HMACVerifier;
 import java.io.IOException;
-import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -127,11 +126,7 @@ public class A2aClientWebhookExecutable implements WebhookConnectorExecutable {
   }
 
   private void verifyHmac(WebhookProcessingPayload payload) {
-    var shouldValidateHmac =
-        Optional.ofNullable(props.shouldValidateHmac())
-            .filter(choice -> enabled.name().equals(choice))
-            .isPresent();
-    if (shouldValidateHmac) {
+    if (enabled.equals(props.shouldValidateHmac())) {
       hmacVerifier.verifySignature(payload);
     }
   }

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/a2a/client/inbound/webhook/model/A2aWebhookProperties.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/a2a/client/inbound/webhook/model/A2aWebhookProperties.java
@@ -10,11 +10,12 @@ import io.camunda.connector.api.annotation.FEEL;
 import io.camunda.connector.generator.dsl.Property;
 import io.camunda.connector.generator.dsl.Property.FeelMode;
 import io.camunda.connector.generator.java.annotation.TemplateProperty;
-import io.camunda.connector.generator.java.annotation.TemplateProperty.DropdownPropertyChoice;
 import io.camunda.connector.generator.java.annotation.TemplateProperty.PropertyCondition;
 import io.camunda.connector.generator.java.annotation.TemplateProperty.PropertyType;
 import io.camunda.connector.inbound.model.HMACScope;
 import io.camunda.connector.inbound.model.WebhookAuthorization;
+import io.camunda.connector.inbound.signature.HMACAlgoCustomerChoice;
+import io.camunda.connector.inbound.signature.HMACSwitchCustomerChoice;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -54,12 +55,8 @@ public record A2aWebhookProperties(
             description =
                 "Choose whether HMAC verification is enabled. <a href='https://docs.camunda.io/docs/components/connectors/protocol/http-webhook/#make-your-http-webhook-connector-for-receiving-messages-executable' target='_blank'>See documentation</a> and <a href='https://docs.camunda.io/docs/components/connectors/protocol/http-webhook/#example' target='_blank'>example</a> that explains how to use HMAC-related fields",
             defaultValue = "disabled",
-            type = PropertyType.Dropdown,
-            choices = {
-              @DropdownPropertyChoice(label = "Enabled", value = "enabled"),
-              @DropdownPropertyChoice(label = "Disabled", value = "disabled")
-            })
-        String shouldValidateHmac,
+            type = PropertyType.Dropdown)
+        HMACSwitchCustomerChoice shouldValidateHmac,
     @TemplateProperty(
             id = "hmacSecret",
             label = "HMAC secret key",
@@ -87,14 +84,9 @@ public record A2aWebhookProperties(
             description = "Choose HMAC algorithm",
             defaultValue = "sha_256",
             type = PropertyType.Dropdown,
-            choices = {
-              @DropdownPropertyChoice(label = "SHA-1", value = "sha_1"),
-              @DropdownPropertyChoice(label = "SHA-256", value = "sha_256"),
-              @DropdownPropertyChoice(label = "SHA-512", value = "sha_512")
-            },
             condition =
                 @PropertyCondition(property = "inbound.shouldValidateHmac", equals = "enabled"))
-        String hmacAlgorithm,
+        HMACAlgoCustomerChoice hmacAlgorithm,
     @TemplateProperty(
             id = "hmacScopes",
             label = "HMAC scopes",

--- a/connectors/webhook/src/main/java/io/camunda/connector/inbound/HttpWebhookExecutable.java
+++ b/connectors/webhook/src/main/java/io/camunda/connector/inbound/HttpWebhookExecutable.java
@@ -32,7 +32,6 @@ import io.camunda.connector.inbound.utils.HttpMethods;
 import io.camunda.connector.inbound.utils.HttpWebhookUtil;
 import jakarta.annotation.Nullable;
 import java.util.Map;
-import java.util.Optional;
 import java.util.function.Function;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -148,11 +147,7 @@ public class HttpWebhookExecutable implements WebhookConnectorExecutable {
   }
 
   private void verifyHmac(WebhookProcessingPayload payload) {
-    var shouldValidateHmac =
-        Optional.ofNullable(props.shouldValidateHmac())
-            .filter(choice -> enabled.name().equals(choice))
-            .isPresent();
-    if (shouldValidateHmac) {
+    if (enabled.equals(props.shouldValidateHmac())) {
       hmacVerifier.verifySignature(payload);
     }
   }

--- a/connectors/webhook/src/main/java/io/camunda/connector/inbound/model/WebhookConnectorProperties.java
+++ b/connectors/webhook/src/main/java/io/camunda/connector/inbound/model/WebhookConnectorProperties.java
@@ -14,6 +14,8 @@ import io.camunda.connector.generator.java.annotation.TemplateProperty;
 import io.camunda.connector.generator.java.annotation.TemplateProperty.DropdownPropertyChoice;
 import io.camunda.connector.generator.java.annotation.TemplateProperty.PropertyCondition;
 import io.camunda.connector.generator.java.annotation.TemplateProperty.PropertyType;
+import io.camunda.connector.inbound.signature.HMACAlgoCustomerChoice;
+import io.camunda.connector.inbound.signature.HMACSwitchCustomerChoice;
 import io.camunda.connector.inbound.utils.HttpMethods;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
@@ -56,12 +58,8 @@ public record WebhookConnectorProperties(
             description =
                 "Choose whether HMAC verification is enabled. <a href='https://docs.camunda.io/docs/components/connectors/protocol/http-webhook/#make-your-http-webhook-connector-for-receiving-messages-executable' target='_blank'>See documentation</a> and <a href='https://docs.camunda.io/docs/components/connectors/protocol/http-webhook/#example' target='_blank'>example</a> that explains how to use HMAC-related fields",
             defaultValue = "disabled",
-            type = PropertyType.Dropdown,
-            choices = {
-              @DropdownPropertyChoice(label = "Enabled", value = "enabled"),
-              @DropdownPropertyChoice(label = "Disabled", value = "disabled")
-            })
-        String shouldValidateHmac,
+            type = PropertyType.Dropdown)
+        HMACSwitchCustomerChoice shouldValidateHmac,
     @TemplateProperty(
             id = "hmacSecret",
             label = "HMAC secret key",
@@ -89,14 +87,9 @@ public record WebhookConnectorProperties(
             description = "Choose HMAC algorithm",
             defaultValue = "sha_256",
             type = PropertyType.Dropdown,
-            choices = {
-              @DropdownPropertyChoice(label = "SHA-1", value = "sha_1"),
-              @DropdownPropertyChoice(label = "SHA-256", value = "sha_256"),
-              @DropdownPropertyChoice(label = "SHA-512", value = "sha_512")
-            },
             condition =
                 @PropertyCondition(property = "inbound.shouldValidateHmac", equals = "enabled"))
-        String hmacAlgorithm,
+        HMACAlgoCustomerChoice hmacAlgorithm,
     @TemplateProperty(
             id = "hmacScopes",
             label = "HMAC scopes",

--- a/connectors/webhook/src/main/java/io/camunda/connector/inbound/signature/HMACAlgoCustomerChoice.java
+++ b/connectors/webhook/src/main/java/io/camunda/connector/inbound/signature/HMACAlgoCustomerChoice.java
@@ -6,9 +6,14 @@
  */
 package io.camunda.connector.inbound.signature;
 
+import io.camunda.connector.generator.java.annotation.DropdownItem;
+
 public enum HMACAlgoCustomerChoice {
+  @DropdownItem(label = "SHA-1")
   sha_1("HmacSHA1", "sha1"),
+  @DropdownItem(label = "SHA-256")
   sha_256("HmacSHA256", "sha256"),
+  @DropdownItem(label = "SHA-512")
   sha_512("HmacSHA512", "sha512");
 
   private final String algoReference;

--- a/connectors/webhook/src/main/java/io/camunda/connector/inbound/signature/HMACSwitchCustomerChoice.java
+++ b/connectors/webhook/src/main/java/io/camunda/connector/inbound/signature/HMACSwitchCustomerChoice.java
@@ -6,7 +6,11 @@
  */
 package io.camunda.connector.inbound.signature;
 
+import io.camunda.connector.generator.java.annotation.DropdownItem;
+
 public enum HMACSwitchCustomerChoice {
+  @DropdownItem(label = "Enabled")
   enabled,
+  @DropdownItem(label = "Disabled")
   disabled
 }

--- a/connectors/webhook/src/main/java/io/camunda/connector/inbound/signature/HMACVerifier.java
+++ b/connectors/webhook/src/main/java/io/camunda/connector/inbound/signature/HMACVerifier.java
@@ -21,10 +21,13 @@ public class HMACVerifier {
   private final HMACScope[] hmacScopes;
   private final String hmacHeader;
   private final String hmacSecret;
-  private final String hmacAlgorithm;
+  private final HMACAlgoCustomerChoice hmacAlgorithm;
 
   public HMACVerifier(
-      HMACScope[] hmacScopes, String hmacHeader, String hmacSecret, String hmacAlgorithm) {
+      HMACScope[] hmacScopes,
+      String hmacHeader,
+      String hmacSecret,
+      HMACAlgoCustomerChoice hmacAlgorithm) {
     this.hmacScopes = hmacScopes;
     this.hmacHeader = hmacHeader;
     this.hmacSecret = hmacSecret;
@@ -53,11 +56,7 @@ public class HMACVerifier {
       throws NoSuchAlgorithmException, InvalidKeyException, IOException {
     final HMACSignatureValidator hmacSignatureValidator =
         new HMACSignatureValidator(
-            signatureData,
-            payload.headers(),
-            hmacHeader,
-            hmacSecret,
-            HMACAlgoCustomerChoice.valueOf(hmacAlgorithm));
+            signatureData, payload.headers(), hmacHeader, hmacSecret, hmacAlgorithm);
     return hmacSignatureValidator.isRequestValid();
   }
 }

--- a/connectors/webhook/src/test/java/io/camunda/connector/inbound/signature/HMACVerifierTest.java
+++ b/connectors/webhook/src/test/java/io/camunda/connector/inbound/signature/HMACVerifierTest.java
@@ -6,6 +6,7 @@
  */
 package io.camunda.connector.inbound.signature;
 
+import static io.camunda.connector.inbound.signature.HMACAlgoCustomerChoice.sha_256;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
@@ -26,11 +27,7 @@ class HMACVerifierTest {
   @Test
   void verifySignature_WhenSignatureMatches_ShouldNotThrowException() {
     HMACVerifier verifier =
-        new HMACVerifier(
-            new HMACScope[] {HMACScope.BODY},
-            "X-HMAC-Sig",
-            "mySecretKey",
-            HMACAlgoCustomerChoice.sha_256.name());
+        new HMACVerifier(new HMACScope[] {HMACScope.BODY}, "X-HMAC-Sig", "mySecretKey", sha_256);
 
     WebhookProcessingPayload payload = mock(WebhookProcessingPayload.class);
     when(payload.method()).thenReturn(HttpMethods.post.name());
@@ -49,11 +46,7 @@ class HMACVerifierTest {
   @Test
   void verifySignature_WhenSignatureDoesNotMatch_ShouldThrowException() {
     HMACVerifier verifier =
-        new HMACVerifier(
-            new HMACScope[] {HMACScope.BODY},
-            "X-HMAC-Sig",
-            "mySecretKey",
-            HMACAlgoCustomerChoice.sha_256.name());
+        new HMACVerifier(new HMACScope[] {HMACScope.BODY}, "X-HMAC-Sig", "mySecretKey", sha_256);
 
     WebhookProcessingPayload payload = mock(WebhookProcessingPayload.class);
     when(payload.method()).thenReturn(HttpMethods.post.name());


### PR DESCRIPTION
## Description

The A2A webhook connector is very similar to the HTTP webhook connector. The major difference is that we need to transform the payload to our A2A model. That's why the agentic-ai module has a dependency on the `connector-webhook`. In order to avoid duplicating the logic for HMAC verification we need to extract this logic in a class so that it can be used from the A2A code. 

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.
- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest release, as this branch will be rebased onto main before the next release.

