### PR TITLE
fix(vector-db): Mark v1 element template as deprecated and set engine version compatibility to 8.8

### DIFF
--- a/connectors/embeddings-vector-database/element-templates/versioned/embeddings-vector-database-outbound-connector-1.json
+++ b/connectors/embeddings-vector-database/element-templates/versioned/embeddings-vector-database-outbound-connector-1.json
@@ -8,7 +8,9 @@
   },
   "documentationRef" : "https://docs.camunda.io/docs/8.8/components/connectors/out-of-the-box-connectors/embeddings-vector-db/",
   "version" : 1,
-  "deprecated": true,
+  "deprecated": {
+    "message": "Replace with version >= 2 of the Embeddings Vector DB Outbound Connector template."
+  },
   "category" : {
     "id" : "connectors",
     "name" : "Connectors"


### PR DESCRIPTION
## Description

Sets the engine compatibility version to `^8.8` and marks the v1 version as deprecated.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #5772

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.
- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest release, as this branch will be rebased onto main before the next release.

