### PR TITLE
refactor(agentic-ai): pass auth schemes and credentials for push notification

### DIFF
--- a/connectors/agentic-ai/element-templates/agenticai-a2a-client-outbound-connector.json
+++ b/connectors/agentic-ai/element-templates/agenticai-a2a-client-outbound-connector.json
@@ -313,16 +313,14 @@
     },
     "type" : "String"
   }, {
-    "id" : "data.connectorMode.operation.settings.responseRetrievalMode.authorizationType",
-    "label" : "Authorization type",
-    "description" : "The authorization type required by the webhook.",
+    "id" : "data.connectorMode.operation.settings.responseRetrievalMode.authenticationSchemes",
+    "label" : "Authentication schemes",
+    "description" : "A list of authentication schemes required by the webhook.",
     "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
+    "feel" : "required",
     "group" : "operation",
     "binding" : {
-      "name" : "data.connectorMode.operation.settings.responseRetrievalMode.authorizationType",
+      "name" : "data.connectorMode.operation.settings.responseRetrievalMode.authenticationSchemes",
       "type" : "zeebe:input"
     },
     "condition" : {
@@ -340,20 +338,34 @@
         "type" : "simple"
       } ]
     },
-    "type" : "Dropdown",
-    "choices" : [ {
-      "name" : "None",
-      "value" : "NONE"
-    }, {
-      "name" : "Basic",
-      "value" : "BASIC"
-    }, {
-      "name" : "API key",
-      "value" : "API_KEY"
-    }, {
-      "name" : "Bearer token",
-      "value" : "BEARER_TOKEN"
-    } ]
+    "type" : "String"
+  }, {
+    "id" : "data.connectorMode.operation.settings.responseRetrievalMode.credentials",
+    "label" : "Authentication credentials",
+    "description" : "Credentials to authenticate the webhook request.",
+    "optional" : false,
+    "feel" : "optional",
+    "group" : "operation",
+    "binding" : {
+      "name" : "data.connectorMode.operation.settings.responseRetrievalMode.credentials",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "allMatch" : [ {
+        "property" : "data.connectorMode.operation.settings.responseRetrievalMode.type",
+        "equals" : "notification",
+        "type" : "simple"
+      }, {
+        "property" : "data.connectorMode.operation.type",
+        "equals" : "sendMessage",
+        "type" : "simple"
+      }, {
+        "property" : "data.connectorMode.type",
+        "equals" : "standalone",
+        "type" : "simple"
+      } ]
+    },
+    "type" : "String"
   }, {
     "id" : "data.connectorMode.operation.settings.historyLength",
     "label" : "History length",
@@ -494,16 +506,14 @@
     },
     "type" : "String"
   }, {
-    "id" : "data.connectorMode.toolOperation.sendMessageSettings.responseRetrievalMode.authorizationType",
-    "label" : "Authorization type",
-    "description" : "The authorization type required by the webhook.",
+    "id" : "data.connectorMode.toolOperation.sendMessageSettings.responseRetrievalMode.authenticationSchemes",
+    "label" : "Authentication schemes",
+    "description" : "A list of authentication schemes required by the webhook.",
     "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
+    "feel" : "required",
     "group" : "operation",
     "binding" : {
-      "name" : "data.connectorMode.toolOperation.sendMessageSettings.responseRetrievalMode.authorizationType",
+      "name" : "data.connectorMode.toolOperation.sendMessageSettings.responseRetrievalMode.authenticationSchemes",
       "type" : "zeebe:input"
     },
     "condition" : {
@@ -517,20 +527,30 @@
         "type" : "simple"
       } ]
     },
-    "type" : "Dropdown",
-    "choices" : [ {
-      "name" : "None",
-      "value" : "NONE"
-    }, {
-      "name" : "Basic",
-      "value" : "BASIC"
-    }, {
-      "name" : "API key",
-      "value" : "API_KEY"
-    }, {
-      "name" : "Bearer token",
-      "value" : "BEARER_TOKEN"
-    } ]
+    "type" : "String"
+  }, {
+    "id" : "data.connectorMode.toolOperation.sendMessageSettings.responseRetrievalMode.credentials",
+    "label" : "Authentication credentials",
+    "description" : "Credentials to authenticate the webhook request.",
+    "optional" : false,
+    "feel" : "optional",
+    "group" : "operation",
+    "binding" : {
+      "name" : "data.connectorMode.toolOperation.sendMessageSettings.responseRetrievalMode.credentials",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "allMatch" : [ {
+        "property" : "data.connectorMode.toolOperation.sendMessageSettings.responseRetrievalMode.type",
+        "equals" : "notification",
+        "type" : "simple"
+      }, {
+        "property" : "data.connectorMode.type",
+        "equals" : "aiAgentTool",
+        "type" : "simple"
+      } ]
+    },
+    "type" : "String"
   }, {
     "id" : "data.connectorMode.toolOperation.sendMessageSettings.historyLength",
     "label" : "History length",

--- a/connectors/agentic-ai/element-templates/hybrid/agenticai-a2a-client-outbound-connector-hybrid.json
+++ b/connectors/agentic-ai/element-templates/hybrid/agenticai-a2a-client-outbound-connector-hybrid.json
@@ -318,16 +318,14 @@
     },
     "type" : "String"
   }, {
-    "id" : "data.connectorMode.operation.settings.responseRetrievalMode.authorizationType",
-    "label" : "Authorization type",
-    "description" : "The authorization type required by the webhook.",
+    "id" : "data.connectorMode.operation.settings.responseRetrievalMode.authenticationSchemes",
+    "label" : "Authentication schemes",
+    "description" : "A list of authentication schemes required by the webhook.",
     "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
+    "feel" : "required",
     "group" : "operation",
     "binding" : {
-      "name" : "data.connectorMode.operation.settings.responseRetrievalMode.authorizationType",
+      "name" : "data.connectorMode.operation.settings.responseRetrievalMode.authenticationSchemes",
       "type" : "zeebe:input"
     },
     "condition" : {
@@ -345,20 +343,34 @@
         "type" : "simple"
       } ]
     },
-    "type" : "Dropdown",
-    "choices" : [ {
-      "name" : "None",
-      "value" : "NONE"
-    }, {
-      "name" : "Basic",
-      "value" : "BASIC"
-    }, {
-      "name" : "API key",
-      "value" : "API_KEY"
-    }, {
-      "name" : "Bearer token",
-      "value" : "BEARER_TOKEN"
-    } ]
+    "type" : "String"
+  }, {
+    "id" : "data.connectorMode.operation.settings.responseRetrievalMode.credentials",
+    "label" : "Authentication credentials",
+    "description" : "Credentials to authenticate the webhook request.",
+    "optional" : false,
+    "feel" : "optional",
+    "group" : "operation",
+    "binding" : {
+      "name" : "data.connectorMode.operation.settings.responseRetrievalMode.credentials",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "allMatch" : [ {
+        "property" : "data.connectorMode.operation.settings.responseRetrievalMode.type",
+        "equals" : "notification",
+        "type" : "simple"
+      }, {
+        "property" : "data.connectorMode.operation.type",
+        "equals" : "sendMessage",
+        "type" : "simple"
+      }, {
+        "property" : "data.connectorMode.type",
+        "equals" : "standalone",
+        "type" : "simple"
+      } ]
+    },
+    "type" : "String"
   }, {
     "id" : "data.connectorMode.operation.settings.historyLength",
     "label" : "History length",
@@ -499,16 +511,14 @@
     },
     "type" : "String"
   }, {
-    "id" : "data.connectorMode.toolOperation.sendMessageSettings.responseRetrievalMode.authorizationType",
-    "label" : "Authorization type",
-    "description" : "The authorization type required by the webhook.",
+    "id" : "data.connectorMode.toolOperation.sendMessageSettings.responseRetrievalMode.authenticationSchemes",
+    "label" : "Authentication schemes",
+    "description" : "A list of authentication schemes required by the webhook.",
     "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
+    "feel" : "required",
     "group" : "operation",
     "binding" : {
-      "name" : "data.connectorMode.toolOperation.sendMessageSettings.responseRetrievalMode.authorizationType",
+      "name" : "data.connectorMode.toolOperation.sendMessageSettings.responseRetrievalMode.authenticationSchemes",
       "type" : "zeebe:input"
     },
     "condition" : {
@@ -522,20 +532,30 @@
         "type" : "simple"
       } ]
     },
-    "type" : "Dropdown",
-    "choices" : [ {
-      "name" : "None",
-      "value" : "NONE"
-    }, {
-      "name" : "Basic",
-      "value" : "BASIC"
-    }, {
-      "name" : "API key",
-      "value" : "API_KEY"
-    }, {
-      "name" : "Bearer token",
-      "value" : "BEARER_TOKEN"
-    } ]
+    "type" : "String"
+  }, {
+    "id" : "data.connectorMode.toolOperation.sendMessageSettings.responseRetrievalMode.credentials",
+    "label" : "Authentication credentials",
+    "description" : "Credentials to authenticate the webhook request.",
+    "optional" : false,
+    "feel" : "optional",
+    "group" : "operation",
+    "binding" : {
+      "name" : "data.connectorMode.toolOperation.sendMessageSettings.responseRetrievalMode.credentials",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "allMatch" : [ {
+        "property" : "data.connectorMode.toolOperation.sendMessageSettings.responseRetrievalMode.type",
+        "equals" : "notification",
+        "type" : "simple"
+      }, {
+        "property" : "data.connectorMode.type",
+        "equals" : "aiAgentTool",
+        "type" : "simple"
+      } ]
+    },
+    "type" : "String"
   }, {
     "id" : "data.connectorMode.toolOperation.sendMessageSettings.historyLength",
     "label" : "History length",

--- a/connectors/agentic-ai/examples/a2a/a2a-agent-integration/a2a-agent-execution-subprocess.bpmn
+++ b/connectors/agentic-ai/examples/a2a/a2a-agent-integration/a2a-agent-execution-subprocess.bpmn
@@ -67,12 +67,16 @@
       <bpmn:extensionElements>
         <zeebe:taskDefinition type="io.camunda.agenticai:a2aclient:0" retries="3" />
         <zeebe:ioMapping>
+          <zeebe:input target="data.connectorMode.toolOperation.sendMessageSettings.responseRetrievalMode.authenticationScheme" />
           <zeebe:input source="=a2aAgentUrl" target="data.connection.url" />
           <zeebe:input source="aiAgentTool" target="data.connectorMode.type" />
           <zeebe:input source="=toolCall.operation" target="data.connectorMode.toolOperation.operation" />
           <zeebe:input source="=toolCall.params" target="data.connectorMode.toolOperation.params" />
+          <zeebe:input source="notification" target="data.connectorMode.toolOperation.sendMessageSettings.responseRetrievalMode.type" />
+          <zeebe:input source="http://localhost:8085/inbound/31761c21-8a04-4569-aad0-eb9bb601d729" target="data.connectorMode.toolOperation.sendMessageSettings.responseRetrievalMode.webhookUrl" />
+          <zeebe:input source="=[&#34;Basic&#34;]" target="data.connectorMode.toolOperation.sendMessageSettings.responseRetrievalMode.authenticationSchemes" />
+          <zeebe:input source="bXl1c2VyOm15cGFzc3dvcmQ=" target="data.connectorMode.toolOperation.sendMessageSettings.responseRetrievalMode.credentials" />
           <zeebe:input source="=3" target="data.connectorMode.toolOperation.sendMessageSettings.historyLength" />
-          <zeebe:input source="polling" target="data.connectorMode.toolOperation.sendMessageSettings.responseRetrievalMode.type" />
           <zeebe:input source="PT1M" target="data.connectorMode.toolOperation.sendMessageSettings.timeout" />
         </zeebe:ioMapping>
         <zeebe:taskHeaders>

--- a/connectors/agentic-ai/examples/a2a/a2a-push-notification/a2a-push-notification-example.bpmn
+++ b/connectors/agentic-ai/examples/a2a/a2a-push-notification/a2a-push-notification-example.bpmn
@@ -11,14 +11,16 @@
       <bpmn:extensionElements>
         <zeebe:taskDefinition type="io.camunda.agenticai:a2aclient:0" retries="3" />
         <zeebe:ioMapping>
+          <zeebe:input source="NONE" target="data.connectorMode.operation.settings.responseRetrievalMode.authorizationType" />
           <zeebe:input source="http://localhost:11001" target="data.connection.url" />
           <zeebe:input source="standalone" target="data.connectorMode.type" />
           <zeebe:input source="sendMessage" target="data.connectorMode.operation.type" />
           <zeebe:input source="=if is defined(messageText) then&#10;  messageText&#10;else&#10;  &#34;Hey!&#34;" target="data.connectorMode.operation.params.text" />
-          <zeebe:input source="=3" target="data.connectorMode.operation.settings.historyLength" />
           <zeebe:input source="notification" target="data.connectorMode.operation.settings.responseRetrievalMode.type" />
           <zeebe:input source="http://localhost:8085/inbound/my-webhook-id" target="data.connectorMode.operation.settings.responseRetrievalMode.webhookUrl" />
-          <zeebe:input source="NONE" target="data.connectorMode.operation.settings.responseRetrievalMode.authorizationType" />
+          <zeebe:input target="data.connectorMode.operation.settings.responseRetrievalMode.authenticationSchemes" />
+          <zeebe:input target="data.connectorMode.operation.settings.responseRetrievalMode.credentials" />
+          <zeebe:input source="=3" target="data.connectorMode.operation.settings.historyLength" />
           <zeebe:input source="PT1M" target="data.connectorMode.operation.settings.timeout" />
         </zeebe:ioMapping>
         <zeebe:taskHeaders>
@@ -74,7 +76,7 @@
     </bpmn:textAnnotation>
     <bpmn:association id="Association_1cprgwa" associationDirection="None" sourceRef="Event_1y152vy" targetRef="TextAnnotation_1buc8q1" />
   </bpmn:process>
-  <bpmn:message id="Message_0bldhbt" name="c9411cf3-162a-49bd-98f3-87eddadb8381" zeebe:modelerTemplate="io.camunda.connectors.agenticai.a2a.client.webhook.intermediate.v0">
+  <bpmn:message id="Message_0bldhbt" name="8928288c-6d65-41b5-b9b3-36466dc7156d" zeebe:modelerTemplate="io.camunda.connectors.agenticai.a2a.client.webhook.intermediate.v0">
     <bpmn:extensionElements>
       <zeebe:subscription correlationKey="=internal_clientResponse.id" />
     </bpmn:extensionElements>

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/a2a/client/common/sdk/A2aSdkClientConfig.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/a2a/client/common/sdk/A2aSdkClientConfig.java
@@ -7,6 +7,7 @@
 package io.camunda.connector.agenticai.a2a.client.common.sdk;
 
 import io.camunda.connector.agenticai.model.AgenticAiRecord;
+import java.util.List;
 import javax.annotation.Nullable;
 
 @AgenticAiRecord
@@ -19,5 +20,5 @@ public record A2aSdkClientConfig(
     }
   }
 
-  public record PushNotificationConfig(String url, String authScheme) {}
+  public record PushNotificationConfig(String url, List<String> authSchemes, String credentials) {}
 }

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/a2a/client/common/sdk/A2aSdkClientFactoryImpl.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/a2a/client/common/sdk/A2aSdkClientFactoryImpl.java
@@ -21,8 +21,6 @@ import io.a2a.spec.PushNotificationAuthenticationInfo;
 import io.a2a.spec.PushNotificationConfig;
 import io.camunda.connector.agenticai.a2a.client.common.configuration.A2aClientCommonConfigurationProperties.TransportConfiguration;
 import io.camunda.connector.agenticai.a2a.client.common.sdk.grpc.ManagedChannelFactory;
-import java.util.List;
-import java.util.Optional;
 import java.util.function.BiConsumer;
 
 public class A2aSdkClientFactoryImpl implements A2aSdkClientFactory {
@@ -54,10 +52,7 @@ public class A2aSdkClientFactoryImpl implements A2aSdkClientFactory {
     if (pushNotificationConfig != null) {
       final var authenticationInfo =
           new PushNotificationAuthenticationInfo(
-              Optional.ofNullable(pushNotificationConfig.authScheme())
-                  .map(List::of)
-                  .orElse(List.of()),
-              null);
+              pushNotificationConfig.authSchemes(), pushNotificationConfig.credentials());
       clientConfigBuilder.setPushNotificationConfig(
           new PushNotificationConfig.Builder()
               .url(pushNotificationConfig.url())

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/a2a/client/outbound/A2aMessageSenderImpl.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/a2a/client/outbound/A2aMessageSenderImpl.java
@@ -29,7 +29,6 @@ import java.util.concurrent.TimeoutException;
 import java.util.function.BiConsumer;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.jetbrains.annotations.NotNull;
 
 public class A2aMessageSenderImpl implements A2aMessageSender {
   private final A2aDocumentToPartConverter documentToPartConverter;
@@ -77,7 +76,7 @@ public class A2aMessageSenderImpl implements A2aMessageSender {
     }
   }
 
-  private static @NotNull A2aSdkClientConfig createA2aSdkClientConfig(
+  private static A2aSdkClientConfig createA2aSdkClientConfig(
       A2aCommonSendMessageConfiguration settings) {
     final var retrievalMode = settings.responseRetrievalMode();
 
@@ -85,7 +84,9 @@ public class A2aMessageSenderImpl implements A2aMessageSender {
     if (retrievalMode instanceof Notification notification) {
       pushNotificationConfig =
           new A2aSdkClientConfig.PushNotificationConfig(
-              notification.webhookUrl(), notification.authorizationType().toA2aSecurityScheme());
+              notification.webhookUrl(),
+              notification.authenticationSchemes(),
+              notification.credentials());
     }
     final var blocking = retrievalMode instanceof A2aResponseRetrievalMode.Blocking;
     return new A2aSdkClientConfig(settings.historyLength(), blocking, pushNotificationConfig);

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/a2a/client/outbound/model/A2aCommonSendMessageConfiguration.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/a2a/client/outbound/model/A2aCommonSendMessageConfiguration.java
@@ -9,7 +9,6 @@ package io.camunda.connector.agenticai.a2a.client.outbound.model;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import io.camunda.connector.generator.dsl.Property;
-import io.camunda.connector.generator.java.annotation.DropdownItem;
 import io.camunda.connector.generator.java.annotation.TemplateDiscriminatorProperty;
 import io.camunda.connector.generator.java.annotation.TemplateProperty;
 import io.camunda.connector.generator.java.annotation.TemplateSubType;
@@ -18,6 +17,7 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.PositiveOrZero;
 import java.time.Duration;
+import java.util.List;
 
 public record A2aCommonSendMessageConfiguration(
     @Valid @NotNull
@@ -80,34 +80,25 @@ public record A2aCommonSendMessageConfiguration(
                 description = "The webhook URL where the remote agent will send the response.",
                 feel = Property.FeelMode.optional)
             String webhookUrl,
-        @NotNull
-            @TemplateProperty(
+        @TemplateProperty(
                 group = "operation",
-                label = "Authorization type",
-                description = "The authorization type required by the webhook.",
-                type = TemplateProperty.PropertyType.Dropdown)
-            AuthorizationType authorizationType)
+                label = "Authentication schemes",
+                description = "A list of authentication schemes required by the webhook.",
+                feel = Property.FeelMode.required)
+            List<String> authenticationSchemes,
+        @TemplateProperty(
+                group = "operation",
+                label = "Authentication credentials",
+                description = "Credentials to authenticate the webhook request.",
+                feel = Property.FeelMode.optional)
+            String credentials)
         implements A2aResponseRetrievalMode {
       @TemplateProperty(ignore = true)
       public static final String NOTIFICATION_ID = "notification";
 
-      public enum AuthorizationType {
-        @DropdownItem(label = "None")
-        NONE,
-        @DropdownItem(label = "Basic")
-        BASIC,
-        @DropdownItem(label = "API key")
-        API_KEY,
-        @DropdownItem(label = "Bearer token")
-        BEARER_TOKEN;
-
-        public String toA2aSecurityScheme() {
-          return switch (this) {
-            case NONE -> null;
-            case BASIC -> "Basic";
-            case API_KEY -> "ApiKey";
-            case BEARER_TOKEN -> "Bearer";
-          };
+      public Notification {
+        if (authenticationSchemes == null) {
+          authenticationSchemes = List.of();
         }
       }
     }

--- a/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/a2a/client/common/sdk/A2aSdkClientConfigTest.java
+++ b/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/a2a/client/common/sdk/A2aSdkClientConfigTest.java
@@ -2,6 +2,7 @@ package io.camunda.connector.agenticai.a2a.client.common.sdk;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import java.util.List;
 import org.junit.jupiter.api.Test;
 
 /*
@@ -22,7 +23,8 @@ class A2aSdkClientConfigTest {
                 new A2aSdkClientConfig(
                     10,
                     true,
-                    new A2aSdkClientConfig.PushNotificationConfig("http://example.com", "Bearer")));
+                    new A2aSdkClientConfig.PushNotificationConfig(
+                        "http://example.com", List.of("Bearer"), null)));
     assertEquals("Cannot enable both blocking and push notifications.", exception.getMessage());
   }
 }


### PR DESCRIPTION
## Description

Added authentication schemes and credentials properties to push notification configuration to reflect push notification security configuration as specified by the A2A specifications. I removed the drop down selection of the schemes in favor of a fully custom list of security schemes.

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.
- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest release, as this branch will be rebased onto main before the next release.

