### PR TITLE
other(ci): release workflow fixes post-merge

### DIFF
--- a/.github/workflows/RELEASE.yaml
+++ b/.github/workflows/RELEASE.yaml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Version to release (e.g., 8.7.0, 8.7.1)'
+        description: 'Version to release (e.g., 8.7.0, 8.7.1). Make sure to select the correct branch.'
         required: true
         type: string
       skip-maven-release:
@@ -15,6 +15,11 @@ on:
         default: false
       skip-docker-release:
         description: 'Skip Docker release'
+        required: false
+        type: boolean
+        default: false
+      latest:
+        description: 'Mark this release as latest (push latest docker tags & mark GitHub release latest)'
         required: false
         type: boolean
         default: false
@@ -39,6 +44,7 @@ jobs:
           name: ${{ inputs.version }}
           draft: false
           prerelease: false
+          make_latest: ${{ inputs.latest && 'true' || 'false' }}
           generate_release_notes: false
           target_commitish: ${{ github.ref }}
           body: |
@@ -56,6 +62,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      checks: write
     outputs:
       tagType: ${{ steps.prev_version.outputs.release_type }}
       releaseBranch: ${{ steps.determine_release_branch.outputs.releaseBranch }}
@@ -398,13 +405,15 @@ jobs:
       - name: Log latest tag push decision
         run: |
           echo "Tag type: ${{ needs.setup.outputs.tagType }}"
-          if [[ "${{ needs.setup.outputs.tagType }}" == "NORMAL" ]]; then
-            echo "This is a NORMAL release - will push 'latest' tags for bundle-default and bundle-saas"
+          echo "Latest input: ${{ inputs.latest }}"
+          if [[ "${{ inputs.latest }}" == "true" && "${{ needs.setup.outputs.tagType }}" == "NORMAL" ]]; then
+            echo "Will push 'latest' tags for all images"
           else
-            echo "This is NOT a NORMAL release - will NOT push 'latest' tags for bundle-default and bundle-saas"
+            echo "Will NOT push 'latest' tags (either latest not requested or not a NORMAL release)"
           fi
 
       - name: Build and Push Docker Image tag latest - connector-runtime
+        if: ${{ inputs.latest && needs.setup.outputs.tagType == 'NORMAL' }}
         uses: docker/build-push-action@v6
         with:
           context: connector-runtime/connector-runtime-application/
@@ -414,7 +423,7 @@ jobs:
           provenance: false
 
       - name: Build and Push Docker Image tag latest - bundle-default
-        if: ${{ needs.setup.outputs.tagType == 'NORMAL' }}
+        if: ${{ inputs.latest && needs.setup.outputs.tagType == 'NORMAL' }}
         uses: docker/build-push-action@v6
         with:
           context: bundle/default-bundle/
@@ -424,7 +433,7 @@ jobs:
           provenance: false
 
       - name: Build and Push Docker Image tag latest - bundle-saas
-        if: ${{ needs.setup.outputs.tagType == 'NORMAL' }}
+        if: ${{ inputs.latest && needs.setup.outputs.tagType == 'NORMAL' }}
         uses: docker/build-push-action@v6
         with:
           context: bundle/camunda-saas-bundle/
@@ -436,7 +445,7 @@ jobs:
       # Update README in Dockerhub
 
       - name: Push README to Dockerhub - bundle-default
-        if: ${{ needs.setup.outputs.tagType == 'NORMAL' }}
+        if: ${{ inputs.latest && needs.setup.outputs.tagType == 'NORMAL' }}
         uses: christian-korneck/update-container-description-action@v1
         env:
           DOCKER_USER: ${{ steps.secrets.outputs.DOCKERHUB_USER }}
@@ -448,7 +457,7 @@ jobs:
           short_description: 'Camunda out-of-the-box Connectors Bundle'
 
       - name: Push README to Dockerhub - bundle-saas
-        if: ${{ needs.setup.outputs.tagType == 'NORMAL' }}
+        if: ${{ inputs.latest && needs.setup.outputs.tagType == 'NORMAL' }}
         uses: christian-korneck/update-container-description-action@v1
         env:
           DOCKER_USER: ${{ steps.secrets.outputs.DOCKERHUB_USER }}
@@ -492,6 +501,7 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           prerelease: ${{ needs.setup.outputs.tagType != 'NORMAL' }}
+          make_latest: ${{ (inputs.latest && needs.setup.outputs.tagType == 'NORMAL') && 'true' || 'false' }}
           body: ${{ steps.changelog.outputs.changes }}
           tag_name: ${{ inputs.version }}
           files: |


### PR DESCRIPTION
## Description

This PR fixes some problems found while testing #5745.

- Adds a new input to mark release as latest (this will push docker latest tag and mark GH release as latest)
- Fixes a permissions issue with publishing test results
- Adds a warning to select the right branch

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #

## Checklist

- [ ] PR has a **milestone** or the `no milestone` label.
- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest release, as this branch will be rebased onto main before the next release.

