### PR TITLE
refactor(agentic-ai): improve A2A error handling

### DIFF
--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/a2a/client/agentic/tool/A2aGatewayToolHandler.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/a2a/client/agentic/tool/A2aGatewayToolHandler.java
@@ -22,7 +22,6 @@ import io.camunda.connector.agenticai.model.tool.GatewayToolDefinition;
 import io.camunda.connector.agenticai.model.tool.ToolCall;
 import io.camunda.connector.agenticai.model.tool.ToolCallResult;
 import io.camunda.connector.agenticai.model.tool.ToolDefinition;
-import io.camunda.connector.api.error.ConnectorException;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
@@ -218,7 +217,7 @@ public class A2aGatewayToolHandler implements GatewayToolHandler {
       return "This tool allows interaction with the remote A2A agent represented by the following agent card:\n%s"
           .formatted(agentCard);
     } catch (JsonProcessingException e) {
-      throw new ConnectorException(
+      throw new RuntimeException(
           "Failed to serialize A2A client tool description for tool %s: %s"
               .formatted(toolCallResult.name(), toolCallResult.content()),
           e);

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/a2a/client/common/A2aAgentCardFetcherImpl.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/a2a/client/common/A2aAgentCardFetcherImpl.java
@@ -6,6 +6,7 @@
  */
 package io.camunda.connector.agenticai.a2a.client.common;
 
+import static io.camunda.connector.agenticai.a2a.client.common.A2aErrorCodes.ERROR_CODE_A2A_CLIENT_AGENT_CARD_RETRIEVAL_FAILED;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 import io.a2a.A2A;
@@ -13,12 +14,12 @@ import io.a2a.spec.A2AClientError;
 import io.a2a.spec.AgentCard;
 import io.camunda.connector.agenticai.a2a.client.common.model.A2aConnectionConfiguration;
 import io.camunda.connector.agenticai.a2a.client.common.model.result.A2aAgentCard;
+import io.camunda.connector.api.error.ConnectorException;
 import java.util.Collections;
 import org.apache.commons.collections4.CollectionUtils;
 
 public class A2aAgentCardFetcherImpl implements A2aAgentCardFetcher {
 
-  // TODO: add caching?
   @Override
   public A2aAgentCard fetchAgentCard(A2aConnectionConfiguration connection) {
     AgentCard agentCard = fetchAgentCardRaw(connection);
@@ -32,7 +33,10 @@ public class A2aAgentCardFetcherImpl implements A2aAgentCardFetcher {
     try {
       return A2A.getAgentCard(connection.url(), relativeCardPath, Collections.emptyMap());
     } catch (A2AClientError e) {
-      throw new RuntimeException(e);
+      throw new ConnectorException(
+          ERROR_CODE_A2A_CLIENT_AGENT_CARD_RETRIEVAL_FAILED,
+          "Failed to load agent card from %s".formatted(connection.agentCardLocation()),
+          e);
     }
   }
 

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/a2a/client/common/A2aErrorCodes.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/a2a/client/common/A2aErrorCodes.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.agenticai.a2a.client.common;
+
+public interface A2aErrorCodes {
+  String ERROR_CODE_A2A_CLIENT_SEND_MESSAGE_RESPONSE_TIMEOUT =
+      "A2A_CLIENT_SEND_MESSAGE_RESPONSE_TIMEOUT";
+  String ERROR_CODE_A2A_CLIENT_AGENT_CARD_RETRIEVAL_FAILED =
+      "ERROR_CODE_A2A_CLIENT_AGENT_CARD_RETRIEVAL_FAILED";
+  String ERROR_CODE_A2A_CLIENT_SEND_MESSAGE_FAILED = "A2A_CLIENT_SEND_MESSAGE_FAILED";
+  String ERROR_CODE_A2A_CLIENT_TASK_RETRIEVAL_FAILED = "A2A_CLIENT_TASK_RETRIEVAL_FAILED";
+}

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/a2a/client/common/sdk/A2aSdkClient.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/a2a/client/common/sdk/A2aSdkClient.java
@@ -6,12 +6,16 @@
  */
 package io.camunda.connector.agenticai.a2a.client.common.sdk;
 
+import static io.camunda.connector.agenticai.a2a.client.common.A2aErrorCodes.ERROR_CODE_A2A_CLIENT_SEND_MESSAGE_FAILED;
+import static io.camunda.connector.agenticai.a2a.client.common.A2aErrorCodes.ERROR_CODE_A2A_CLIENT_TASK_RETRIEVAL_FAILED;
+
 import io.a2a.client.Client;
 import io.a2a.spec.A2AClientException;
 import io.a2a.spec.Message;
 import io.a2a.spec.Task;
 import io.a2a.spec.TaskQueryParams;
 import io.camunda.connector.agenticai.a2a.client.common.sdk.grpc.ManagedChannelFactory;
+import io.camunda.connector.api.error.ConnectorException;
 
 public class A2aSdkClient implements AutoCloseable {
   private final Client sdkClient;
@@ -26,7 +30,7 @@ public class A2aSdkClient implements AutoCloseable {
     try {
       sdkClient.sendMessage(message);
     } catch (A2AClientException e) {
-      throw new RuntimeException(e);
+      throw new ConnectorException(ERROR_CODE_A2A_CLIENT_SEND_MESSAGE_FAILED, e);
     }
   }
 
@@ -34,7 +38,7 @@ public class A2aSdkClient implements AutoCloseable {
     try {
       return sdkClient.getTask(request);
     } catch (A2AClientException e) {
-      throw new RuntimeException(e);
+      throw new ConnectorException(ERROR_CODE_A2A_CLIENT_TASK_RETRIEVAL_FAILED, e);
     }
   }
 

--- a/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/a2a/client/common/sdk/A2ASdkClientTest.java
+++ b/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/a2a/client/common/sdk/A2ASdkClientTest.java
@@ -19,6 +19,7 @@ import io.a2a.spec.Message;
 import io.a2a.spec.Task;
 import io.a2a.spec.TaskQueryParams;
 import io.camunda.connector.agenticai.a2a.client.common.sdk.grpc.ManagedChannelFactory;
+import io.camunda.connector.api.error.ConnectorException;
 import org.junit.jupiter.api.Test;
 
 class A2ASdkClientTest {
@@ -36,7 +37,7 @@ class A2ASdkClientTest {
   }
 
   @Test
-  void shouldWrapSendMessageA2AClientExceptionInRuntimeException() throws A2AClientException {
+  void shouldWrapSendMessageA2AClientExceptionInConnectorException() throws A2AClientException {
     Client sdkClient = mock(Client.class);
     ManagedChannelFactory channelFactory = mock(ManagedChannelFactory.class);
     A2aSdkClient client = new A2aSdkClient(sdkClient, channelFactory);
@@ -46,7 +47,8 @@ class A2ASdkClientTest {
     doThrow(expectedException).when(sdkClient).sendMessage(message);
 
     assertThatThrownBy(() -> client.sendMessage(message))
-        .isInstanceOf(RuntimeException.class)
+        .isInstanceOf(ConnectorException.class)
+        .hasFieldOrPropertyWithValue("errorCode", "A2A_CLIENT_SEND_MESSAGE_FAILED")
         .hasCause(expectedException);
   }
 
@@ -66,7 +68,7 @@ class A2ASdkClientTest {
   }
 
   @Test
-  void shouldWrapGetTaskA2AClientExceptionInRuntimeException() throws A2AClientException {
+  void shouldWrapGetTaskA2AClientExceptionInConnectorException() throws A2AClientException {
     Client sdkClient = mock(Client.class);
     ManagedChannelFactory channelFactory = mock(ManagedChannelFactory.class);
     A2aSdkClient client = new A2aSdkClient(sdkClient, channelFactory);
@@ -77,7 +79,8 @@ class A2ASdkClientTest {
     doThrow(expectedException).when(sdkClient).getTask(request);
 
     assertThatThrownBy(() -> client.getTask(request))
-        .isInstanceOf(RuntimeException.class)
+        .isInstanceOf(ConnectorException.class)
+        .hasFieldOrPropertyWithValue("errorCode", "A2A_CLIENT_TASK_RETRIEVAL_FAILED")
         .hasCause(expectedException);
   }
 

--- a/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/a2a/client/outbound/A2aMessageSenderTest.java
+++ b/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/a2a/client/outbound/A2aMessageSenderTest.java
@@ -31,6 +31,7 @@ import io.camunda.connector.agenticai.a2a.client.outbound.model.A2aSendMessageOp
 import io.camunda.connector.agenticai.a2a.client.outbound.model.A2aStandaloneOperationConfiguration.SendMessageOperationConfiguration;
 import io.camunda.connector.agenticai.model.message.content.TextContent;
 import io.camunda.connector.api.document.Document;
+import io.camunda.connector.api.error.ConnectorException;
 import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
@@ -175,7 +176,8 @@ class A2aMessageSenderTest {
     // Do not trigger consumer -> future never completes
     doAnswer(inv -> null).when(client).sendMessage(any());
     assertThatThrownBy(() -> messageSender.sendMessage(agentCard, operation))
-        .isInstanceOf(RuntimeException.class)
+        .isInstanceOf(ConnectorException.class)
+        .hasFieldOrPropertyWithValue("errorCode", "A2A_CLIENT_SEND_MESSAGE_RESPONSE_TIMEOUT")
         .hasMessageContaining("Timed out waiting for response from agent");
     verify(client).close();
   }


### PR DESCRIPTION
## Description

This PR enhances error handling in the A2A client implementation by replacing generic `RuntimeException` instances with structured `ConnectorException` instances that include specific error codes. This allows users to handle those specific error conditions.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #5621 

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.
- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest release, as this branch will be rebased onto main before the next release.

