### PR TITLE
other(agentic-ai): un-ignore A2A element templates

### DIFF
--- a/ignore-templates.json
+++ b/ignore-templates.json
@@ -1,6 +1,3 @@
 [
-  "io.camunda.connector.IdpExtractionOutBoundTemplate.v1",
-  "io.camunda.connectors.agenticai.a2a.client.v0",
-  "io.camunda.connectors.agenticai.a2a.polling.intermediate.v0",
-  "io.camunda.connectors.agenticai.a2a.polling.receive.v0"
+  "io.camunda.connector.IdpExtractionOutBoundTemplate.v1"
 ]


### PR DESCRIPTION
## Description

The A2A client element templates can now be published in the next alpha release. 

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.
- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest release, as this branch will be rebased onto main before the next release.

