### PR TITLE
chore(cve-fix): Increase Java versions

### DIFF
--- a/.github/workflows/CHECK_LICENSES.yml
+++ b/.github/workflows/CHECK_LICENSES.yml
@@ -39,7 +39,7 @@ jobs:
       uses: actions/setup-java@v4
       with:
         distribution: 'temurin'
-        java-version: '21'
+        java-version: '21.0.9'
     - name: Update Maven settings.xml
       uses: s4u/maven-settings-action@v3.1.0
       with:

--- a/.github/workflows/CREATE_RELEASE_BRANCH.yml
+++ b/.github/workflows/CREATE_RELEASE_BRANCH.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: '17'
+          java-version: '17.0.17'
 
       - name: Configure git user
         run: |

--- a/.github/workflows/DEPLOY_SNAPSHOTS.yaml
+++ b/.github/workflows/DEPLOY_SNAPSHOTS.yaml
@@ -71,7 +71,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: '21'
+          java-version: '21.0.9'
           server-id: camunda-nexus
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD

--- a/.github/workflows/RELEASE.yaml
+++ b/.github/workflows/RELEASE.yaml
@@ -98,7 +98,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
-          java-version: '21'
+          java-version: '21.0.9'
 
       - name: Restore cache
         uses: actions/cache@v4
@@ -247,7 +247,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
-          java-version: '21'
+          java-version: '21.0.9'
 
       - name: Import Secrets
         id: secrets

--- a/.github/workflows/TEST_FEATURE_BRANCH.yml
+++ b/.github/workflows/TEST_FEATURE_BRANCH.yml
@@ -38,7 +38,7 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: '21'
+          java-version: '21.0.9'
 
       # Use CI Nexus as co-located pull-through cache for Maven artifacts via ~/.m2/settings.xml
       - name: 'Create settings.xml'


### PR DESCRIPTION
## Description

Fix for this: https://openjdk.org/groups/vulnerability/advisories/2025-10-21

Docker images are already on fixed versions:
:white_check_mark: 8.9 uses 25.0.1 (updated on 10.11)
:white_check_mark: 8.8 uses 21.0.9 (updated by renovate today, check with release-manager, it will be included)
:white_check_mark: 8.7 uses 21.0.9 (updated on 10.11)
:white_check_mark: 8.6 uses 21.0.9 (updated on 10.11)

Github action runner images are also fine
:white_check_mark: ubuntu-latest, which is on 17.0.17 and not affected
:white_check_mark: ubuntu-24.04, which is ubuntu-latest
:white_check_mark: macos-latest, which is on 21.0.9 and not affected

:red_circle: Only thing to fix is the version set by action/setup-java step, which is included in this PR.

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.
- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest release, as this branch will be rebased onto main before the next release.

