### PR TITLE
fix(agentic-ai): fix bean not found error in e2e tests

### DIFF
--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/BaseAgenticAiTest.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/BaseAgenticAiTest.java
@@ -24,7 +24,6 @@ import io.camunda.client.CamundaClient;
 import io.camunda.client.api.search.response.Incident;
 import io.camunda.connector.e2e.ZeebeTest;
 import io.camunda.connector.e2e.app.TestConnectorRuntimeApplication;
-import io.camunda.connector.runtime.inbound.importer.ProcessDefinitionImporter;
 import io.camunda.process.test.api.CamundaSpringProcessTest;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import java.io.File;
@@ -55,7 +54,6 @@ public abstract class BaseAgenticAiTest {
   @Autowired protected CamundaClient camundaClient;
   @Autowired protected ObjectMapper objectMapper;
   @Autowired protected ResourceLoader resourceLoader;
-  @Autowired private ProcessDefinitionImporter processDefinitionImporter;
   @TempDir protected File tempDir;
 
   protected ZeebeTest createProcessInstance(
@@ -126,9 +124,5 @@ public abstract class BaseAgenticAiTest {
         throw new RuntimeException(e);
       }
     };
-  }
-
-  protected void importProcessDefinitions() {
-    processDefinitionImporter.scheduleImport();
   }
 }

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/a2a/A2aStandaloneTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/a2a/A2aStandaloneTests.java
@@ -36,6 +36,7 @@ import io.camunda.connector.agenticai.a2a.client.common.model.result.A2aTask;
 import io.camunda.connector.agenticai.a2a.client.common.model.result.A2aTaskStatus;
 import io.camunda.connector.e2e.ZeebeTest;
 import io.camunda.connector.e2e.agenticai.BaseAgenticAiTest;
+import io.camunda.connector.runtime.inbound.importer.ProcessDefinitionImporter;
 import io.camunda.connector.test.utils.annotation.SlowTest;
 import io.camunda.process.test.api.CamundaAssert;
 import io.camunda.zeebe.model.bpmn.Bpmn;
@@ -49,6 +50,7 @@ import java.util.Map;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.core.io.Resource;
@@ -64,6 +66,8 @@ import org.springframework.test.context.TestPropertySource;
 public class A2aStandaloneTests extends BaseAgenticAiTest {
 
   private static final String WEBHOOK_ELEMENT_ID = "Wait_For_Completion_Webhook";
+
+  @Autowired private ProcessDefinitionImporter processDefinitionImporter;
 
   @Value("classpath:a2a-connectors-standalone.bpmn")
   protected Resource testProcess;
@@ -288,7 +292,7 @@ public class A2aStandaloneTests extends BaseAgenticAiTest {
 
   private void waitForWebhookElementActivation(ZeebeTest zeebeTest) {
     // manually trigger process definition import to register the webhook
-    importProcessDefinitions();
+    processDefinitionImporter.scheduleImport();
     waitForElementActivation(zeebeTest, WEBHOOK_ELEMENT_ID);
   }
 

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/langchain4j/jobworker/L4JAiAgentJobWorkerA2aIntegrationTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/langchain4j/jobworker/L4JAiAgentJobWorkerA2aIntegrationTests.java
@@ -36,6 +36,7 @@ import io.camunda.connector.e2e.ElementTemplate;
 import io.camunda.connector.e2e.ZeebeTest;
 import io.camunda.connector.e2e.agenticai.aiagent.langchain4j.common.L4JAiAgentA2aIntegrationTestSupport;
 import io.camunda.connector.e2e.agenticai.assertj.JobWorkerAgentResponseAssert;
+import io.camunda.connector.runtime.inbound.importer.ProcessDefinitionImporter;
 import io.camunda.connector.test.utils.annotation.SlowTest;
 import java.io.IOException;
 import java.util.List;
@@ -44,6 +45,7 @@ import java.util.function.Function;
 import org.apache.commons.lang3.tuple.Pair;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.core.io.Resource;
@@ -58,6 +60,8 @@ import org.springframework.test.context.TestPropertySource;
 public class L4JAiAgentJobWorkerA2aIntegrationTests extends BaseL4JAiAgentJobWorkerTest {
 
   public static final String WEBHOOK_ELEMENT_ID = "Wait_For_Completion_Webhook";
+
+  @Autowired private ProcessDefinitionImporter processDefinitionImporter;
 
   @Value("classpath:agentic-ai-ahsp-connectors-a2a.bpmn")
   protected Resource testProcessWithA2a;
@@ -172,7 +176,7 @@ public class L4JAiAgentJobWorkerA2aIntegrationTests extends BaseL4JAiAgentJobWor
                 testSupport.initialUserPrompt));
 
     // manually trigger process definition import to register the webhook
-    importProcessDefinitions();
+    processDefinitionImporter.scheduleImport();
     waitForElementActivation(zeebeTest, WEBHOOK_ELEMENT_ID);
     postWithDelay(
         webhookUrl, testFileContent("exchange-rate-agent-webhook-payload.json").get(), 100);

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/langchain4j/outboundconnector/L4JAiAgentConnectorA2aIntegrationTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/langchain4j/outboundconnector/L4JAiAgentConnectorA2aIntegrationTests.java
@@ -36,6 +36,7 @@ import io.camunda.connector.e2e.ElementTemplate;
 import io.camunda.connector.e2e.ZeebeTest;
 import io.camunda.connector.e2e.agenticai.aiagent.langchain4j.common.L4JAiAgentA2aIntegrationTestSupport;
 import io.camunda.connector.e2e.agenticai.assertj.AgentResponseAssert;
+import io.camunda.connector.runtime.inbound.importer.ProcessDefinitionImporter;
 import io.camunda.connector.test.utils.annotation.SlowTest;
 import java.io.IOException;
 import java.util.List;
@@ -44,6 +45,7 @@ import java.util.function.Function;
 import org.apache.commons.lang3.tuple.Pair;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.core.io.Resource;
@@ -58,6 +60,8 @@ import org.springframework.test.context.TestPropertySource;
 public class L4JAiAgentConnectorA2aIntegrationTests extends BaseL4JAiAgentConnectorTest {
 
   public static final String WEBHOOK_ELEMENT_ID = "Wait_For_Completion_Webhook";
+
+  @Autowired private ProcessDefinitionImporter processDefinitionImporter;
 
   @Value("classpath:agentic-ai-connectors-a2a.bpmn")
   protected Resource testProcessWithA2a;
@@ -172,7 +176,7 @@ public class L4JAiAgentConnectorA2aIntegrationTests extends BaseL4JAiAgentConnec
                 testSupport.initialUserPrompt));
 
     // manually trigger process definition import to register the webhook
-    importProcessDefinitions();
+    processDefinitionImporter.scheduleImport();
     waitForElementActivation(zeebeTest, WEBHOOK_ELEMENT_ID);
 
     postWithDelay(


### PR DESCRIPTION
## Description

The previous [PR](https://github.com/camunda/connectors/pull/5817) introduced an error in the Agentic AI e2e tests. The error comes from adding an auto-wired bean of type `ProcessDefinitionImporter` in the tests' parent class. The bean declaration is conditional on `camunda.connector.polling.enabled` being `true`. So this bean is not created for tests where `camunda.connector.polling.enabled` is set to `false`.

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.
- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest release, as this branch will be rebased onto main before the next release.

