### PR TITLE
fix(deps): fix connectors dependency version

### DIFF
--- a/connectors/agentic-ai/pom.xml
+++ b/connectors/agentic-ai/pom.xml
@@ -69,7 +69,7 @@
     <dependency>
       <groupId>io.camunda.connector</groupId>
       <artifactId>connector-webhook</artifactId>
-      <version>${version.camunda}</version>
+      <version>${project.version}</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
## Description

Internal connectors dependencies should be referenced via `${project.version}`. `${version.camunda}` is for monorepo dependencies

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #

## Checklist

- [ ] PR has a **milestone** or the `no milestone` label.
- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest release, as this branch will be rebased onto main before the next release.

