### PR TITLE
chore(docs-links): Fix azure blob storage url

### DIFF
--- a/connectors/microsoft/azure-blobstorage/element-templates/azure-blobstorage-outbound-connector.json
+++ b/connectors/microsoft/azure-blobstorage/element-templates/azure-blobstorage-outbound-connector.json
@@ -109,7 +109,7 @@
   }, {
     "id" : "authentication.tenantId",
     "label" : "Tenant id",
-    "description" : "The tenant id. Learn more in our <a href=\"https://docs.camunda.io/docs/8.8/components/connectors/out-of-the-box-connectors/azure-blob-storage/#o-auth-20\">documentation</a>.",
+    "description" : "The tenant id. Learn more in our <a href=\"https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/azure-blob-storage/#oauth-20\">documentation</a>.",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -129,7 +129,7 @@
   }, {
     "id" : "authentication.clientId",
     "label" : "Client id",
-    "description" : "The client if of the application. Learn more in our <a href=\"https://docs.camunda.io/docs/8.8/components/connectors/out-of-the-box-connectors/azure-blob-storage/#o-auth-20\">documentation</a>.",
+    "description" : "The client if of the application. Learn more in our <a href=\"https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/azure-blob-storage/#oauth-20\">documentation</a>.",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -149,7 +149,7 @@
   }, {
     "id" : "authentication.clientSecret",
     "label" : "Client secret",
-    "description" : "The client secret of the application. Learn more in our <a href=\"https://docs.camunda.io/docs/8.8/components/connectors/out-of-the-box-connectors/azure-blob-storage/#o-auth-20\">documentation</a>.",
+    "description" : "The client secret of the application. Learn more in our <a href=\"https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/azure-blob-storage/#oauth-20\">documentation</a>.",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -169,7 +169,7 @@
   }, {
     "id" : "authentication.accountUrl",
     "label" : "Account url",
-    "description" : "The account url of the storage account. Learn more in our <a href=\"https://docs.camunda.io/docs/8.8/components/connectors/out-of-the-box-connectors/azure-blob-storage/#o-auth-20\">documentation</a>.",
+    "description" : "The account url of the storage account. Learn more in our <a href=\"https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/azure-blob-storage/#oauth-20\">documentation</a>.",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true

--- a/connectors/microsoft/azure-blobstorage/element-templates/hybrid/azure-blobstorage-outbound-connector-hybrid.json
+++ b/connectors/microsoft/azure-blobstorage/element-templates/hybrid/azure-blobstorage-outbound-connector-hybrid.json
@@ -114,7 +114,7 @@
   }, {
     "id" : "authentication.tenantId",
     "label" : "Tenant id",
-    "description" : "The tenant id. Learn more in our <a href=\"https://docs.camunda.io/docs/8.8/components/connectors/out-of-the-box-connectors/azure-blob-storage/#o-auth-20\">documentation</a>.",
+    "description" : "The tenant id. Learn more in our <a href=\"https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/azure-blob-storage/#oauth-20\">documentation</a>.",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -134,7 +134,7 @@
   }, {
     "id" : "authentication.clientId",
     "label" : "Client id",
-    "description" : "The client if of the application. Learn more in our <a href=\"https://docs.camunda.io/docs/8.8/components/connectors/out-of-the-box-connectors/azure-blob-storage/#o-auth-20\">documentation</a>.",
+    "description" : "The client if of the application. Learn more in our <a href=\"https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/azure-blob-storage/#oauth-20\">documentation</a>.",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -154,7 +154,7 @@
   }, {
     "id" : "authentication.clientSecret",
     "label" : "Client secret",
-    "description" : "The client secret of the application. Learn more in our <a href=\"https://docs.camunda.io/docs/8.8/components/connectors/out-of-the-box-connectors/azure-blob-storage/#o-auth-20\">documentation</a>.",
+    "description" : "The client secret of the application. Learn more in our <a href=\"https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/azure-blob-storage/#oauth-20\">documentation</a>.",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -174,7 +174,7 @@
   }, {
     "id" : "authentication.accountUrl",
     "label" : "Account url",
-    "description" : "The account url of the storage account. Learn more in our <a href=\"https://docs.camunda.io/docs/8.8/components/connectors/out-of-the-box-connectors/azure-blob-storage/#o-auth-20\">documentation</a>.",
+    "description" : "The account url of the storage account. Learn more in our <a href=\"https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/azure-blob-storage/#oauth-20\">documentation</a>.",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true

--- a/connectors/microsoft/azure-blobstorage/src/main/java/io/camunda/connector/azure/blobstorage/model/request/auth/OAuthAuthentication.java
+++ b/connectors/microsoft/azure-blobstorage/src/main/java/io/camunda/connector/azure/blobstorage/model/request/auth/OAuthAuthentication.java
@@ -20,7 +20,7 @@ public record OAuthAuthentication(
         @TemplateProperty(
             group = "authentication",
             description =
-                "The tenant id. Learn more in our <a href=\"https://docs.camunda.io/docs/8.8/components/connectors/out-of-the-box-connectors/azure-blob-storage/#oauth-20\">documentation</a>.",
+                "The tenant id. Learn more in our <a href=\"https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/azure-blob-storage/#oauth-20\">documentation</a>.",
             feel = Property.FeelMode.optional)
         @NotBlank
         String tenantId,
@@ -28,7 +28,7 @@ public record OAuthAuthentication(
         @TemplateProperty(
             group = "authentication",
             description =
-                "The client if of the application. Learn more in our <a href=\"https://docs.camunda.io/docs/8.8/components/connectors/out-of-the-box-connectors/azure-blob-storage/#oauth-20\">documentation</a>.",
+                "The client if of the application. Learn more in our <a href=\"https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/azure-blob-storage/#oauth-20\">documentation</a>.",
             feel = Property.FeelMode.optional)
         @NotBlank
         String clientId,
@@ -36,7 +36,7 @@ public record OAuthAuthentication(
         @TemplateProperty(
             group = "authentication",
             description =
-                "The client secret of the application. Learn more in our <a href=\"https://docs.camunda.io/docs/8.8/components/connectors/out-of-the-box-connectors/azure-blob-storage/#oauth-20\">documentation</a>.",
+                "The client secret of the application. Learn more in our <a href=\"https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/azure-blob-storage/#oauth-20\">documentation</a>.",
             feel = Property.FeelMode.optional)
         @NotBlank
         String clientSecret,
@@ -44,7 +44,7 @@ public record OAuthAuthentication(
         @TemplateProperty(
             group = "authentication",
             description =
-                "The account url of the storage account. Learn more in our <a href=\"https://docs.camunda.io/docs/8.8/components/connectors/out-of-the-box-connectors/azure-blob-storage/#oauth-20\">documentation</a>.",
+                "The account url of the storage account. Learn more in our <a href=\"https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/azure-blob-storage/#oauth-20\">documentation</a>.",
             feel = Property.FeelMode.optional)
         @NotBlank
         String accountUrl)


### PR DESCRIPTION
## Description
Fixed the docs url.

## Related issues

See here: https://github.com/camunda/camunda-docs/pull/7425

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.
- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest release, as this branch will be rebased onto main before the next release.

