### PR TITLE
refactor(agentic-ai): Resolve MCP client authentication headers on every request

### DIFF
--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/mcp/client/framework/langchain4j/Langchain4JMcpClientFactory.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/mcp/client/framework/langchain4j/Langchain4JMcpClientFactory.java
@@ -61,10 +61,7 @@ public class Langchain4JMcpClientFactory implements McpClientFactory<McpClient> 
           new StreamableHttpMcpTransport.Builder()
               .url(http.url())
               .timeout(http.timeout())
-              .customHeaders(
-                  headersSupplierFactory
-                      .createHttpHeadersSupplier(http)
-                      .get()) // TODO remove .get() call with L4J > 1.8.0
+              .customHeaders(headersSupplierFactory.createHttpHeadersSupplier(http))
               .logRequests(loggingResolver.logHttpRequests(clientId, config))
               .logResponses(loggingResolver.logHttpResponses(clientId, config))
               .build();
@@ -73,10 +70,7 @@ public class Langchain4JMcpClientFactory implements McpClientFactory<McpClient> 
           new HttpMcpTransport.Builder()
               .sseUrl(sse.url())
               .timeout(sse.timeout())
-              .customHeaders(
-                  headersSupplierFactory
-                      .createHttpHeadersSupplier(sse)
-                      .get()) // TODO remove .get() call with L4J > 1.8.0
+              .customHeaders(headersSupplierFactory.createHttpHeadersSupplier(sse))
               .logRequests(loggingResolver.logHttpRequests(clientId, config))
               .logResponses(loggingResolver.logHttpResponses(clientId, config))
               .build();

--- a/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/mcp/client/framework/langchain4j/Langchain4JMcpClientFactoryTest.java
+++ b/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/mcp/client/framework/langchain4j/Langchain4JMcpClientFactoryTest.java
@@ -32,10 +32,13 @@ import io.camunda.connector.agenticai.mcp.client.model.auth.BearerAuthentication
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Supplier;
 import org.assertj.core.api.ThrowingConsumer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.MockedConstruction;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -63,6 +66,8 @@ class Langchain4JMcpClientFactoryTest {
   @Mock private HttpMcpTransport sseMcpTransport;
 
   @Mock private Langchain4JMcpClientHeadersSupplierFactory headersSupplierFactory;
+
+  @Captor private ArgumentCaptor<Supplier<Map<String, String>>> headersSupplierCaptor;
 
   private Langchain4JMcpClientLoggingResolver loggingResolver;
   private Langchain4JMcpClientFactory factory;
@@ -185,9 +190,11 @@ class Langchain4JMcpClientFactoryTest {
             final var transportBuilder = mockedTransportBuilder.constructed().getFirst();
             verify(transportBuilder).url(streamableHttpTransportConfig.url());
             verify(transportBuilder).timeout(streamableHttpTransportConfig.timeout());
-            verify(transportBuilder).customHeaders(EXPECTED_HEADERS);
             verify(transportBuilder).logRequests(false);
             verify(transportBuilder).logResponses(false);
+
+            verify(transportBuilder).customHeaders(headersSupplierCaptor.capture());
+            assertThat(headersSupplierCaptor.getValue().get()).isEqualTo(EXPECTED_HEADERS);
 
             verifyMcpClientBuilder(
                 mockedMcpClientConstruction.constructed().getFirst(), streamableHttpMcpTransport);
@@ -254,9 +261,11 @@ class Langchain4JMcpClientFactoryTest {
             final var transportBuilder = mockedTransportBuilder.constructed().getFirst();
             verify(transportBuilder).sseUrl(sseConfig.url());
             verify(transportBuilder).timeout(sseConfig.timeout());
-            verify(transportBuilder).customHeaders(EXPECTED_HEADERS);
             verify(transportBuilder).logRequests(false);
             verify(transportBuilder).logResponses(false);
+
+            verify(transportBuilder).customHeaders(headersSupplierCaptor.capture());
+            assertThat(headersSupplierCaptor.getValue().get()).isEqualTo(EXPECTED_HEADERS);
 
             verifyMcpClientBuilder(
                 mockedMcpClientConstruction.constructed().getFirst(), sseMcpTransport);


### PR DESCRIPTION
## Description

Fixes open TODO depending on L4J 1.9.0 updated to resolve headers on every HTTP call, not only on initialization.

## Related issues

closes #5762

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.
- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest release, as this branch will be rebased onto main before the next release.

