### PR TITLE
fix(agentic-ai): Un-hide MCP remote client timeout setting

### DIFF
--- a/connectors/agentic-ai/element-templates/agenticai-mcp-remote-client-outbound-connector.json
+++ b/connectors/agentic-ai/element-templates/agenticai-mcp-remote-client-outbound-connector.json
@@ -131,6 +131,7 @@
     "label" : "Timeout",
     "description" : "Timeout for individual HTTP requests as ISO-8601 duration (example: <code>PT30S</code>)",
     "optional" : true,
+    "feel" : "optional",
     "group" : "transport",
     "binding" : {
       "name" : "data.transport.http.timeout",
@@ -141,7 +142,7 @@
       "equals" : "http",
       "type" : "simple"
     },
-    "type" : "Hidden"
+    "type" : "String"
   }, {
     "id" : "data.transport.sse.url",
     "label" : "URL",
@@ -184,6 +185,7 @@
     "label" : "Timeout",
     "description" : "Timeout for individual HTTP requests as ISO-8601 duration (example: <code>PT30S</code>)",
     "optional" : true,
+    "feel" : "optional",
     "group" : "transport",
     "binding" : {
       "name" : "data.transport.sse.timeout",
@@ -194,7 +196,7 @@
       "equals" : "sse",
       "type" : "simple"
     },
-    "type" : "Hidden"
+    "type" : "String"
   }, {
     "id" : "data.transport.http.authentication.type",
     "label" : "Type",

--- a/connectors/agentic-ai/element-templates/hybrid/agenticai-mcp-remote-client-outbound-connector-hybrid.json
+++ b/connectors/agentic-ai/element-templates/hybrid/agenticai-mcp-remote-client-outbound-connector-hybrid.json
@@ -136,6 +136,7 @@
     "label" : "Timeout",
     "description" : "Timeout for individual HTTP requests as ISO-8601 duration (example: <code>PT30S</code>)",
     "optional" : true,
+    "feel" : "optional",
     "group" : "transport",
     "binding" : {
       "name" : "data.transport.http.timeout",
@@ -146,7 +147,7 @@
       "equals" : "http",
       "type" : "simple"
     },
-    "type" : "Hidden"
+    "type" : "String"
   }, {
     "id" : "data.transport.sse.url",
     "label" : "URL",
@@ -189,6 +190,7 @@
     "label" : "Timeout",
     "description" : "Timeout for individual HTTP requests as ISO-8601 duration (example: <code>PT30S</code>)",
     "optional" : true,
+    "feel" : "optional",
     "group" : "transport",
     "binding" : {
       "name" : "data.transport.sse.timeout",
@@ -199,7 +201,7 @@
       "equals" : "sse",
       "type" : "simple"
     },
-    "type" : "Hidden"
+    "type" : "String"
   }, {
     "id" : "data.transport.http.authentication.type",
     "label" : "Type",

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/mcp/client/model/McpRemoteClientTransportConfiguration.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/mcp/client/model/McpRemoteClientTransportConfiguration.java
@@ -80,8 +80,8 @@ public sealed interface McpRemoteClientTransportConfiguration
                 group = "transport",
                 description =
                     "Timeout for individual HTTP requests as ISO-8601 duration (example: <code>PT30S</code>)",
-                type = TemplateProperty.PropertyType.Hidden,
-                feel = Property.FeelMode.disabled,
+                type = TemplateProperty.PropertyType.String,
+                feel = Property.FeelMode.optional,
                 optional = true)
             Duration timeout)
         implements McpRemoteClientConnection {
@@ -121,8 +121,8 @@ public sealed interface McpRemoteClientTransportConfiguration
                 group = "transport",
                 description =
                     "Timeout for individual HTTP requests as ISO-8601 duration (example: <code>PT30S</code>)",
-                type = TemplateProperty.PropertyType.Hidden,
-                feel = Property.FeelMode.disabled,
+                type = TemplateProperty.PropertyType.String,
+                feel = Property.FeelMode.optional,
                 optional = true)
             Duration timeout)
         implements McpRemoteClientConnection {


### PR DESCRIPTION
## Description

The timeout setting for MCP Remote Clients was supported before, but hidden. This makes it available in the default element template.

## Related issues

follow up to #5652

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.
- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest release, as this branch will be rebased onto main before the next release.

