### PR TITLE
fix(agentic-ai): Align A2A default inbound polling timeout to the documentation

### DIFF
--- a/connectors/agentic-ai/element-templates/agenticai-a2a-client-polling-inbound-connector-intermediate.json
+++ b/connectors/agentic-ai/element-templates/agenticai-a2a-client-polling-inbound-connector-intermediate.json
@@ -134,7 +134,7 @@
     "label" : "Task polling interval",
     "description" : "The delay between A2A task polling requests, defined as ISO 8601 durations format. <a href='https://docs.camunda.io/docs/components/modeler/bpmn/timer-events/#time-duration' target='_blank'>How to configure a time duration</a>",
     "optional" : false,
-    "value" : "PT30S",
+    "value" : "PT10S",
     "feel" : "optional",
     "group" : "polling",
     "binding" : {

--- a/connectors/agentic-ai/element-templates/agenticai-a2a-client-polling-inbound-connector-receive.json
+++ b/connectors/agentic-ai/element-templates/agenticai-a2a-client-polling-inbound-connector-receive.json
@@ -133,7 +133,7 @@
     "label" : "Task polling interval",
     "description" : "The delay between A2A task polling requests, defined as ISO 8601 durations format. <a href='https://docs.camunda.io/docs/components/modeler/bpmn/timer-events/#time-duration' target='_blank'>How to configure a time duration</a>",
     "optional" : false,
-    "value" : "PT30S",
+    "value" : "PT10S",
     "feel" : "optional",
     "group" : "polling",
     "binding" : {

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/a2a/client/inbound/polling/model/A2aPollingActivationProperties.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/a2a/client/inbound/polling/model/A2aPollingActivationProperties.java
@@ -31,7 +31,7 @@ public record A2aPollingActivationProperties(
           @TemplateProperty(
               id = "taskPollingInterval",
               group = "polling",
-              defaultValue = "PT30S",
+              defaultValue = "PT10S",
               binding = @TemplateProperty.PropertyBinding(name = "taskPollingInterval"),
               description =
                   "The delay between A2A task polling requests, defined as ISO 8601 durations format. <a href='https://docs.camunda.io/docs/components/modeler/bpmn/timer-events/#time-duration' target='_blank'>How to configure a time duration</a>",
@@ -44,7 +44,7 @@ public record A2aPollingActivationProperties(
       }
 
       if (taskPollingInterval == null) {
-        taskPollingInterval = Duration.ofSeconds(30);
+        taskPollingInterval = Duration.ofSeconds(10);
       }
     }
   }


### PR DESCRIPTION
## Description

See https://github.com/camunda/camunda-docs/pull/7423#discussion_r2586441015

Part of https://github.com/camunda/product-hub/issues/2924

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.
- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest release, as this branch will be rebased onto main before the next release.

