### PR TITLE
fix: make tests less flaky on CI

### DIFF
--- a/connectors/email/src/test/java/io/camunda/connector/email/integration/ImapServerProxy.java
+++ b/connectors/email/src/test/java/io/camunda/connector/email/integration/ImapServerProxy.java
@@ -46,8 +46,8 @@ public class ImapServerProxy implements AutoCloseable {
   private void handle(Socket client) {
     try (client) {
       proxy(client);
-    } catch (IOException e) {
-      throw new RuntimeException(e);
+    } catch (IOException ignored) {
+      // Ignore
     }
   }
 
@@ -64,8 +64,8 @@ public class ImapServerProxy implements AutoCloseable {
                 () -> {
                   try {
                     pipeClientToServer(client.getInputStream(), backend.getOutputStream());
-                  } catch (IOException e) {
-                    throw new RuntimeException(e);
+                  } catch (IOException ignored) {
+                    // Ignore
                   }
                 });
         Future<?> f2 =
@@ -74,8 +74,8 @@ public class ImapServerProxy implements AutoCloseable {
                 () -> {
                   try {
                     pipeServerToClient(backend.getInputStream(), client.getOutputStream());
-                  } catch (IOException e) {
-                    throw new RuntimeException(e);
+                  } catch (IOException ignored) {
+                    // Ignore
                   }
                 });
         try {


### PR DESCRIPTION
This pull request improves the reliability and resource management of the `ImapServerProxy` test utility by tracking active socket pairs and ensuring proper cleanup during connection cuts and proxy shutdowns. The main changes are focused on managing socket connections and preventing resource leaks.

**Resource management and connection tracking:**

* Introduced a thread-safe `activePairs` set using `ConcurrentHashMap.newKeySet()` to keep track of active client-backend socket pairs in `ImapServerProxy`.
* Added the `SocketPair` class to encapsulate client and backend sockets, and updated the proxy logic to add pairs to `activePairs` when a connection is established, and remove them when the proxy is done. [[1]](diffhunk://#diff-ee23d91af768312a6cdfa2e1ccb66fcf68b06d23e8cc1137cf7648a5c02ede77R57-R60) [[2]](diffhunk://#diff-ee23d91af768312a6cdfa2e1ccb66fcf68b06d23e8cc1137cf7648a5c02ede77R89-R92) [[3]](diffhunk://#diff-ee23d91af768312a6cdfa2e1ccb66fcf68b06d23e8cc1137cf7648a5c02ede77R150-R159)

**Connection interruption handling:**

* Modified the `cutConnection()` method to iterate over all active socket pairs and shutdown the backend socket output, improving how simulated connection interruptions are handled in tests.