### PR TITLE
other(build): remove redundant identity repo from pom

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -705,18 +705,6 @@ limitations under the License.</license.inlineheader>
       <url>https://artifacts.camunda.com/artifactory/zeebe-io-snapshots/</url>
     </repository>
 
-    <repository>
-      <releases>
-        <enabled>true</enabled>
-      </releases>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-      <id>identity</id>
-      <name>Identity Repository</name>
-      <url>https://artifacts.camunda.com/artifactory/camunda-identity/</url>
-    </repository>
-
     <!-- opensaml dependencies for soap connector -->
     <repository>
       <id>shibboleth</id>


### PR DESCRIPTION
## Description

Identity repo is not needed anymore as we don't depend on Identity since 8.7.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #

## Checklist

- [ ] PR has a **milestone** or the `no milestone` label.
- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest release, as this branch will be rebased onto main before the next release.

