### PR TITLE
fix(deps): revert deps scope change in bundle

### DIFF
--- a/bundle/camunda-saas-bundle/pom.xml
+++ b/bundle/camunda-saas-bundle/pom.xml
@@ -168,16 +168,6 @@
       <artifactId>connector-test-utils</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>io.camunda.connector</groupId>
-      <artifactId>connector-object-mapper</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-databind</artifactId>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 
   <build>
@@ -276,6 +266,10 @@
           <execution>
             <id>analyze-dependencies</id>
             <configuration>
+              <ignoredDependencies>
+                <dependency>com.fasterxml.jackson.core:jackson-databind</dependency>
+                <dependency>io.camunda.connector:connector-object-mapper</dependency>
+              </ignoredDependencies>
             </configuration>
           </execution>
         </executions>

--- a/bundle/default-bundle/pom.xml
+++ b/bundle/default-bundle/pom.xml
@@ -23,13 +23,11 @@
     <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>camunda-client-java</artifactId>
-      <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>io.camunda.connector</groupId>
       <artifactId>connector-runtime-core</artifactId>
-      <scope>test</scope>
     </dependency>
 
 
@@ -369,6 +367,8 @@
             <configuration>
               <ignoredDependencies>
                 <dependency>io.camunda.connector:connector-runtime-application</dependency>
+                <dependency>io.camunda:camunda-client-java</dependency>
+                <dependency>io.camunda.connector:connector-runtime-core</dependency>
                 <dependency>org.springframework:spring-context</dependency>
                 <dependency>org.springframework:spring-core</dependency>
                 <dependency>org.springframework.boot:spring-boot</dependency>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -252,13 +252,13 @@ limitations under the License.</license.inlineheader>
         <version>${project.version}</version>
       </dependency>
 
-        <dependency>
-            <groupId>io.camunda.connector</groupId>
-            <artifactId>connector-utils</artifactId>
-            <version>${project.version}</version>
-        </dependency>
+      <dependency>
+        <groupId>io.camunda.connector</groupId>
+        <artifactId>connector-utils</artifactId>
+        <version>${project.version}</version>
+      </dependency>
 
-        <dependency>
+      <dependency>
         <groupId>io.camunda.connector</groupId>
         <artifactId>http-client</artifactId>
         <version>${project.version}</version>


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

In #5738 I accidentally added test scopes for some dependencies that are required in runtime, which resulted in snapshot image not starting.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #

## Checklist

- [ ] PR has a **milestone** or the `no milestone` label.
- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest release, as this branch will be rebased onto main before the next release.

