### PR TITLE
chore(npm-publishing): Migrate auth to trusted publishers approach

### DIFF
--- a/.github/workflows/PUBLISH_NPM_PACKAGE.yml
+++ b/.github/workflows/PUBLISH_NPM_PACKAGE.yml
@@ -1,3 +1,4 @@
+# Do not rename this file, as the file name is part of the npm auth configuration. Learn more here: https://docs.npmjs.com/trusted-publishers
 name: Deploying npm package
 run-name: Deploying npm package version ${{ inputs.npm-package-version }}
 
@@ -8,6 +9,11 @@ on:
         description: 'New version number of the npm package to publish'
         type: string
         required: true
+
+permissions:
+  id-token: write  # Required for OIDC
+  contents: write
+  pull-requests: write
 
 jobs:
   build-test-publish:
@@ -54,8 +60,6 @@ jobs:
         if: success()
         working-directory: element-template-generator/npm
         run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Create pull request to main branch
         uses: peter-evans/create-pull-request@v7

--- a/element-template-generator/npm/package.json
+++ b/element-template-generator/npm/package.json
@@ -12,5 +12,9 @@
   "devDependencies": {
     "mocha": "^11.7.1",
     "prettier": "3.7.4"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/camunda/connectors"
   }
 }


### PR DESCRIPTION
## Description

Migrated to trusted publishing for our npm packages as our token expired yesterday.
See here: https://docs.npmjs.com/trusted-publishers

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.
- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest release, as this branch will be rebased onto main before the next release.

