### PR TITLE
ci: enable E2E tests in integration workflow

### DIFF
--- a/.github/workflows/INTEGRATION_TEST.yml
+++ b/.github/workflows/INTEGRATION_TEST.yml
@@ -160,7 +160,7 @@ jobs:
       # test-enabled enables testing generally, both IT and E2E tests.
       test-enabled: true
       # e2e-enabled is our way to disable E2E tests if needed.
-      e2e-enabled: false
+      e2e-enabled: true
       # This scenario installs a full Camunda 8 cluster with Keycloak and Elasticsearch being external. 
       # This keycloak realm and elasticsearch prefixes are all randomly generated at installation time.
       scenario: keycloak-original


### PR DESCRIPTION
This change enables the e2e tests. These had been disabled so only helm install and ITs run while we hardened the CI. That is now complete and e2e can be enabled too

## Description

<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #

## Checklist

- [ ] PR has a **milestone** or the `no milestone` label.
- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest release, as this branch will be rebased onto main before the next release.

