### PR TITLE
fix: saas bundle dependency scope

### DIFF
--- a/bundle/camunda-saas-bundle/pom.xml
+++ b/bundle/camunda-saas-bundle/pom.xml
@@ -89,6 +89,10 @@
       <groupId>org.springframework</groupId>
       <artifactId>spring-web</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.springframework.security</groupId>
+      <artifactId>spring-security-core</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>com.google.cloud</groupId>
@@ -156,11 +160,6 @@
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-test</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.springframework.security</groupId>
-      <artifactId>spring-security-core</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -279,6 +278,7 @@
               <ignoredDependencies>
                 <dependency>com.fasterxml.jackson.core:jackson-databind</dependency>
                 <dependency>io.camunda.connector:connector-object-mapper</dependency>
+                <dependency>org.springframework.security:spring-security-core</dependency>
               </ignoredDependencies>
             </configuration>
           </execution>


### PR DESCRIPTION
## Description

The SaaS bundle was not starting due to a missing runtime dependency on spring-security-core
it was accidentally marked as test-only during dependency plugin enrollment

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #

## Checklist

- [ ] PR has a **milestone** or the `no milestone` label.
- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest release, as this branch will be rebased onto main before the next release.

