### PR TITLE
fix(renovate): Modify CODEOWNERS for Renovate and file exclusions

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -6,7 +6,12 @@
 /connectors/idp-extraction @camunda/connectors-idp @camunda/connectors
 /connectors/embeddings-vector-database @camunda/connectors-agentic-ai @camunda/connectors
 /connectors-e2e-test/connectors-e2e-test-agentic-ai @camunda/connectors-agentic-ai @camunda/connectors
+
 # These files are excluded so that Renovate can automatically merge dependency upgrades
-renovate.json5
-.ci/preview-environments/charts/c8sm/Chart.yaml
+renovate.json
+**/*.yaml
+**/*.yml
+**/Dockerfile
+**/docker-images.properties
+.tool-versions
 **/pom.xml


### PR DESCRIPTION
This pull request updates the `CODEOWNERS` file to improve automation and ownership assignment for various configuration and dependency management files. The main changes are focused on ensuring that files related to dependency upgrades and build configurations are correctly handled by automation tools like Renovate.

Ownership and automation improvements:

* Updated the list of files excluded for Renovate automation, replacing specific file names with more general patterns to cover all YAML, YML, Dockerfile, and related configuration files.
* Changed the reference to the Renovate configuration file from `renovate.json5` to `renovate.json`.