### PR TITLE
fix(embeddings-vector-database): Fix failing database connection due to breaking cosmos-db sdk

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -139,7 +139,7 @@ limitations under the License.</license.inlineheader>
     <version.microsoft-graph-core>3.6.5</version.microsoft-graph-core>
     <version.azure-identity>1.18.1</version.azure-identity>
     <version.azure-core>1.57.0</version.azure-core>
-    <version.azure-cosmos>4.76</version.azure-cosmos>
+    <version.azure-cosmos>4.76.0</version.azure-cosmos>
 
     <version.bouncycastle>1.83</version.bouncycastle>
     <version.box-sdk>4.16.4</version.box-sdk>


### PR DESCRIPTION

## Description

* Upgrade `azure-cosmos` dependency to 4.76 as latest upgrade to `4.71-beta1` introduced connection errors due to SSL Handshake Exceptions

## Related issues

closes #5946 

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.
- [x] Backport labels are added if these code changes should be backported. No backport label is added to the latest release, as this branch will be rebased onto main before the next release.

