### PR TITLE
other: Automatically create the released label

### DIFF
--- a/.github/workflows/NOTIFY_PRS_RELEASED.yml
+++ b/.github/workflows/NOTIFY_PRS_RELEASED.yml
@@ -81,6 +81,24 @@ jobs:
           echo "Found $PR_COUNT PRs to notify"
           echo "pr_count=$PR_COUNT" >> $GITHUB_OUTPUT
 
+      - name: Create release label
+        if: steps.extract_prs.outputs.pr_count != '0'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          LABEL_NAME="released/$VERSION"
+          
+          # Check if label exists, create if it doesn't
+          if ! gh label list --json name --jq '.[].name' | grep -q "^${LABEL_NAME}$"; then
+            echo "Creating label: $LABEL_NAME"
+            gh label create "$LABEL_NAME" --description "Released in version $VERSION" --color "0e8a16" || {
+              echo "Warning: Failed to create label (may already exist or insufficient permissions)"
+            }
+          else
+            echo "Label $LABEL_NAME already exists"
+          fi
+
       - name: Post comments and labels on PRs
         if: steps.extract_prs.outputs.pr_count != '0'
         env:
@@ -103,7 +121,7 @@ jobs:
                 echo "Warning: Failed to post comment on PR #$PR_NUMBER (it may be from a fork or deleted)"
               }
           
-              # Add label (create if it doesn't exist)
+              # Add label
               gh pr edit "$PR_NUMBER" --add-label "$LABEL_NAME" || {
                 echo "Warning: Failed to add label to PR #$PR_NUMBER (it may be from a fork or deleted)"
               }


### PR DESCRIPTION
This pull request updates the `.github/workflows/NOTIFY_PRS_RELEASED.yml` workflow to improve how release labels are managed and applied to pull requests. The main change is the addition of a step to ensure the release label for the current version exists before attempting to add it to PRs, making the workflow more robust and reducing errors when labeling PRs.

**Label management improvements:**

* Added a workflow step to create the release label (`released/$VERSION`) if it does not already exist, using the GitHub CLI. This ensures the label is available before attempting to apply it to PRs.

**Label application simplification:**

* Updated the PR labeling step to only add the label (removing redundant logic to create the label during this step, since label creation is now handled separately).


Related to https://github.com/camunda/team-connectors/issues/1147