### PR TITLE
fix(agentic-ai): Ignore blank assistant text to avoid IllegalArgumentException

### DIFF
--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/ChatMessageConverterImpl.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/ChatMessageConverterImpl.java
@@ -140,7 +140,7 @@ public class ChatMessageConverterImpl implements ChatMessageConverter {
     }
 
     final var aiMessage = chatResponse.aiMessage();
-    if (aiMessage.text() != null) {
+    if (StringUtils.isNotBlank(aiMessage.text())) {
       builder.content(List.of(TextContent.textContent(aiMessage.text())));
     }
 

--- a/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/ChatMessageConverterTest.java
+++ b/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/ChatMessageConverterTest.java
@@ -316,6 +316,17 @@ class ChatMessageConverterTest {
   }
 
   @Test
+  void toAssistantMessage_ignoresBlankText() {
+    final var aiMessage = AiMessage.builder().text("   ").build();
+
+    final var chatResponse = new ChatResponse.Builder().aiMessage(aiMessage).build();
+
+    final var result = chatMessageConverter.toAssistantMessage(chatResponse);
+
+    assertThat(result.content()).isEmpty();
+  }
+
+  @Test
   void toAssistantMessage_convertsFromChatResponse_withoutMetadata() {
     final var chatResponse =
         new ChatResponse.Builder().aiMessage(AiMessage.builder().build()).build();


### PR DESCRIPTION
##  summary 
Fix an intermittent incident where the Generic AI Agent connector throws IllegalArgumentException("Text cannot be null or empty") when the AI assistant returns blank or whitespace-only text. This change drops blank assistant text instead of constructing [TextContent] from it.


## Description

Problem :
Symptom: intermittent incidents labeled "Text cannot be null or empty" (issue #5226).
Root cause: [ChatMessageConverterImpl] created [TextContent] whenever [aiMessage.text() != null].
 The [TextContent] record constructor throws for blank or whitespace-only text, so certain AI responses caused an exception.
Solution :
Only create [TextContent] when the assistant text is non-blank:
[if (StringUtils.isNotBlank(aiMessage.text())) { ... }]
Added unit test: [toAssistantMessage_ignoresBlankText()] in [ChatMessageConverterTest].

Files changed :
Modified: [ChatMessageConverterImpl.java]
Modified: [ChatMessageConverterTest.java]

Tests & Verification 💯 
New unit test added and verified locally.
Module tests: — 987 tests passed, 0 failures (local verification).

<img width="1124" height="415" alt="Capture d&#39;écran 2025-12-24 040925" src="https://github.com/user-attachments/assets/203a674e-4802-4838-9396-c8458fb87f92" />


Low-risk: behavior only ignores blank assistant text (previously threw an exception). No public API changes.

##  Checklist 
 Implement fix with focused change
 Add unit test reproducing the issue
 Run module tests locally (all pass)
 Request review from agentic-ai maintainers

## Related issues
Potentially related to #5226


## Checklist

- [x] PR has a **milestone** or the `no milestone` label.
- [x] Backport labels are added if these code changes should be backported. No backport label is added to the latest release, as this branch will be rebased onto main before the next release.

