### PR TITLE
fix(OutboundConnector): add variables to fail JobCommand

### DIFF
--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/error/JobError.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/error/JobError.java
@@ -17,8 +17,44 @@
 package io.camunda.connector.runtime.core.error;
 
 import java.time.Duration;
+import java.util.HashMap;
 import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public record JobError(
     String errorMessage, Map<String, Object> variables, Integer retries, Duration retryBackoff)
-    implements ConnectorError {}
+    implements ConnectorError {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(JobError.class);
+
+  /**
+   * Returns a map of variables including the error message.
+   *
+   * <p>This method combines the variables from the JobError with an additional "error" key
+   * containing the error message. This is useful when creating ErrorResult instances that need to
+   * include both custom variables and the error message.
+   *
+   * <p><b>Important:</b> If the variables map already contains an "error" key, it will be
+   * overwritten with the error message from this JobError. This ensures the error message is always
+   * available in the process variables under the "error" key for visibility in Operate and other
+   * tools.
+   *
+   * @return a new mutable map containing all variables plus the error message under the "error" key
+   */
+  public Map<String, Object> variablesWithErrorMessage() {
+    if (variables == null) {
+      return Map.of("error", errorMessage);
+    }
+    var result = new HashMap<>(variables);
+    if (variables.containsKey("error")) {
+      LOGGER.debug(
+          "User-provided 'error' key in variables will be overwritten with the error message. "
+              + "Original value: {}, will be replaced with: {}",
+          variables.get("error"),
+          errorMessage);
+    }
+    result.put("error", errorMessage);
+    return result;
+  }
+}

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/SpringConnectorJobHandler.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/SpringConnectorJobHandler.java
@@ -42,7 +42,6 @@ import io.camunda.connector.runtime.core.secret.SecretProviderDiscovery;
 import io.camunda.connector.runtime.metrics.ConnectorMetrics;
 import java.time.Duration;
 import java.time.format.DateTimeParseException;
-import java.util.Map;
 import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -249,7 +248,7 @@ public class SpringConnectorJobHandler implements JobHandler {
             client,
             job,
             new ConnectorResult.ErrorResult(
-                Map.of("error", jobError.errorMessage()),
+                jobError.variablesWithErrorMessage(),
                 new RuntimeException(jobError.errorMessage()),
                 jobError.retries(),
                 jobError.retryBackoff()),

--- a/connector-runtime/feel-wrapper/src/main/java/io/camunda/connector/feel/FeelConnectorFunctionProvider.java
+++ b/connector-runtime/feel-wrapper/src/main/java/io/camunda/connector/feel/FeelConnectorFunctionProvider.java
@@ -171,10 +171,10 @@ public class FeelConnectorFunctionProvider extends JavaFunctionProvider {
       ValString message, ValContext variables, ValNumber retries, ValDayTimeDuration retryBackoff) {
     java.util.Map<String, Object> javaMap = new HashMap<>();
     javaMap.put(ERROR_TYPE_PROPERTY, JOB_ERROR_TYPE_VALUE);
-    javaMap.put(JOB_ERROR_FUNCTION_ARGUMENTS.get(0), message.value());
-    javaMap.put(JOB_ERROR_FUNCTION_ARGUMENTS.get(1), JavaConverters.asJava(variables.properties()));
-    javaMap.put(JOB_ERROR_FUNCTION_ARGUMENTS.get(2), retries.value());
-    javaMap.put(JOB_ERROR_FUNCTION_ARGUMENTS.get(3), retryBackoff.value());
+    javaMap.put(JOB_ERROR_FUNCTION_ARGUMENTS.get(0), message);
+    javaMap.put(JOB_ERROR_FUNCTION_ARGUMENTS.get(1), variables);
+    javaMap.put(JOB_ERROR_FUNCTION_ARGUMENTS.get(2), retries);
+    javaMap.put(JOB_ERROR_FUNCTION_ARGUMENTS.get(3), retryBackoff);
     return new ValContext(
         new Context.StaticContext(Map.from(JavaConverters.asScala(javaMap)), Map$.MODULE$.empty()));
   }

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/jobworker/AiAgentJobWorkerHandlerImpl.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/jobworker/AiAgentJobWorkerHandlerImpl.java
@@ -140,7 +140,7 @@ public class AiAgentJobWorkerHandlerImpl implements AiAgentJobWorkerHandler {
               jobClient,
               job,
               new ErrorResult(
-                  Map.of("error", jobError.errorMessage()),
+                  jobError.variablesWithErrorMessage(),
                   new RuntimeException(jobError.errorMessage()),
                   jobError.retries(),
                   jobError.retryBackoff()),


### PR DESCRIPTION
## Description

Add variables defined in the JobError to the FailCommand

## Related issues

<!-- Which issues are closed by this PR or are related -->

Closes #5979

## Checklist

- [X] PR has a **milestone** or the `no milestone` label.
- [x] Backport labels are added if these code changes should be backported. No backport label is added to the latest release, as this branch will be rebased onto main before the next release.

