### PR TITLE
fix(GHA): switch to self-hosted runner 

### DIFF
--- a/.github/workflows/DEPLOY_SNAPSHOTS.yaml
+++ b/.github/workflows/DEPLOY_SNAPSHOTS.yaml
@@ -16,7 +16,7 @@ defaults:
 jobs:
   deploy-snapshots:
     name: Deploy snapshot artifacts
-    runs-on: ubuntu-latest
+    runs-on: gcp-core-2-default
     concurrency:
       group: deploy-snapshots-${{ github.ref }}
       cancel-in-progress: true

--- a/.github/workflows/RELEASE.yaml
+++ b/.github/workflows/RELEASE.yaml
@@ -64,7 +64,7 @@ jobs:
   setup:
     needs: create-release
     name: Prepare the repository
-    runs-on: ubuntu-latest
+    runs-on: gcp-core-2-release
     permissions:
       contents: write
       checks: write


### PR DESCRIPTION
## Description

By using self-hosted runners we can avoid running out of disk space as has previously happened [here](https://github.com/camunda/connectors/actions/runs/20561286265)


## Checklist

- [x] PR has a **milestone** or the `no milestone` label.
- [X] Backport labels are added if these code changes should be backported. No backport label is added to the latest release, as this branch will be rebased onto main before the next release.

