### PR TITLE
fix(GHA): install all required tools

### DIFF
--- a/.github/workflows/DEPLOY_SNAPSHOTS.yaml
+++ b/.github/workflows/DEPLOY_SNAPSHOTS.yaml
@@ -25,7 +25,8 @@ jobs:
       branch: ${{ steps.version.outputs.branch }}
     steps:
       - uses: actions/checkout@v6
-
+      - name: Install asdf & tools
+        uses: asdf-vm/actions/install@v4
       - name: Determine branch and version
         id: version
         run: |

--- a/.github/workflows/RELEASE.yaml
+++ b/.github/workflows/RELEASE.yaml
@@ -77,6 +77,8 @@ jobs:
         with:
           ref: ${{ github.ref }}
           fetch-depth: 0
+      - name: Install asdf & tools
+        uses: asdf-vm/actions/install@v4
       - name: Identify previous release version
         id: prev_version
         uses: camunda/infra-global-github-actions/previous-version@main


### PR DESCRIPTION
## Description

On self-hosted runners, maven isn't present by default. We need to add it.

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.
- [x] Backport labels are added if these code changes should be backported. No backport label is added to the latest release, as this branch will be rebased onto main before the next release.

