### PR TITLE
other: Remove code owners for .github et .ci folders

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -11,6 +11,9 @@
 renovate.json
 **/*.yaml
 **/*.yml
+.github/**/*.yaml
+.github/**/*.yml
+.ci/preview-environments/charts/c8sm/*.yaml
 **/Dockerfile
 **/docker-images.properties
 .tool-versions


### PR DESCRIPTION
This pull request updates the `CODEOWNERS` file to expand ownership coverage for YAML files. The main change is the addition of several new patterns to ensure that files in commonly used configuration directories are properly tracked.

Ownership coverage expansion:

* Added `.github/**/*.yaml` and `.github/**/*.yml` to include GitHub workflow and configuration YAML files.
* Added `.ci/preview-environments/charts/c8sm/*.yaml` to cover CI chart YAML files in the preview environments directory.