### PR TITLE
build: upgrade Maven from 3.9.9 to 3.9.12

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
 java temurin-25.0.1+8.0.LTS
-maven 3.9.9
+maven 3.9.12
 pre-commit 4.5.0

--- a/element-template-generator/maven-plugin/pom.xml
+++ b/element-template-generator/maven-plugin/pom.xml
@@ -15,7 +15,7 @@
   <packaging>maven-plugin</packaging>
 
   <properties>
-    <version.maven-plugin-api>3.9.11</version.maven-plugin-api>
+    <version.maven-plugin-api>3.9.12</version.maven-plugin-api>
     <version.maven-plugin-annotations>3.15.2</version.maven-plugin-annotations>
     <version.maven-plugin-plugin>3.15.2</version.maven-plugin-plugin>
     <version.maven-project>2.2.1</version.maven-project>


### PR DESCRIPTION
## Description

Maven 3.9.9 is no longer available on the Apache CDN (`dlcdn.apache.org`), causing CI failures in the `asdf install` step during the "Deploy snapshot artifacts" job as the fallback URL can't be read from on self-hosted runners.

This PR udates maven instead of adding more actions as a workaround.

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.
- [x] Backport labels are added if these code changes should be backported. No backport label is added to the latest release, as this branch will be rebased onto main before the next release.