### PR TITLE
test(connectors): Add test for unknown enum values using default value

### DIFF
--- a/connector-commons/connector-object-mapper/src/test/java/io/camunda/connector/jackson/ConnectorsObjectMapperSupplierTest.java
+++ b/connector-commons/connector-object-mapper/src/test/java/io/camunda/connector/jackson/ConnectorsObjectMapperSupplierTest.java
@@ -18,6 +18,7 @@ package io.camunda.connector.jackson;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.fasterxml.jackson.annotation.JsonEnumDefaultValue;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.exc.MismatchedInputException;
@@ -64,4 +65,21 @@ class ConnectorsObjectMapperSupplierTest {
   }
 
   private record TestRecordWithString(String value) {}
+
+  @Test
+  void unknownEnumValueShouldBeDeserializedUsingDefaultValue() throws JsonProcessingException {
+    final var objectMapper = ConnectorsObjectMapperSupplier.getCopy();
+    final var json = "{\"status\":\"PAUSED\"}";
+    var actual = objectMapper.readValue(json, TestRecordWithEnum.class);
+    assertThat(actual.status()).isEqualTo(TestStatus.UNKNOWN);
+  }
+
+  private enum TestStatus {
+    ACTIVE,
+    INACTIVE,
+    @JsonEnumDefaultValue
+    UNKNOWN
+  }
+
+  private record TestRecordWithEnum(TestStatus status) {}
 }


### PR DESCRIPTION
## Description

Added a unit test to verify that unknown enum values in JSON are deserialized to the default enum value when using the ObjectMapper from ConnectorsObjectMapperSupplier. 

It covers the case where the ObjectMapper has:

    .enable(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE)

For example, this enum:

    private enum TestStatus {
      ACTIVE,
      INACTIVE,
      @JsonEnumDefaultValue
      UNKNOWN
    }

and a record:

    private record TestRecordWithEnum(TestStatus status) {}

if the JSON contains an unknown value like:

    {"status":"PAUSED"}

the ObjectMapper will map it to TestStatus.UNKNOWN.

This test make sure that this behavior does not break in future changes and does not affect production runtime behavior and also prevents regressions in the `ObjectMapper` configuration

## Related issues

<!-- None -->

N/A

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.
- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest release, as this branch will be rebased onto main before the next release.
