### PR TITLE
fix(GHA): CI improvements for self-hosted runners

### DIFF
--- a/.github/workflows/DEPLOY_SNAPSHOTS.yaml
+++ b/.github/workflows/DEPLOY_SNAPSHOTS.yaml
@@ -16,7 +16,7 @@ defaults:
 jobs:
   deploy-snapshots:
     name: Deploy snapshot artifacts
-    runs-on: ubuntu-latest
+    runs-on: gcp-core-2-default
     concurrency:
       group: deploy-snapshots-${{ github.ref }}
       cancel-in-progress: true
@@ -25,7 +25,8 @@ jobs:
       branch: ${{ steps.version.outputs.branch }}
     steps:
       - uses: actions/checkout@v4
-
+      - name: Install asdf & tools
+        uses: asdf-vm/actions/install@v4
       - name: Determine branch and version
         id: version
         run: |

--- a/.github/workflows/RELEASE.yaml
+++ b/.github/workflows/RELEASE.yaml
@@ -59,7 +59,7 @@ jobs:
   setup:
     needs: create-release
     name: Prepare the repository
-    runs-on: ubuntu-latest
+    runs-on: gcp-core-2-release
     permissions:
       contents: write
       checks: write
@@ -72,6 +72,8 @@ jobs:
         with:
           ref: ${{ github.ref }}
           fetch-depth: 0
+      - name: Install asdf & tools
+        uses: asdf-vm/actions/install@v4
       - name: Identify previous release version
         id: prev_version
         uses: camunda/infra-global-github-actions/previous-version@main

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,3 @@
 java temurin-21.0.9+10.0.LTS
-maven 3.9.9
+maven 3.9.12
+pre-commit 4.5.0


### PR DESCRIPTION
## Summary

Backport of CI improvements from main to stable/8.6:

- Switch to self-hosted runners (gcp-core-2-default/gcp-core-2-release) to avoid disk space issues
- Add asdf & tools installation step for Maven/Java availability on self-hosted runners
- Update Maven from 3.9.9 to 3.9.12 (3.9.9 no longer available on Apache CDN)
- Add pre-commit to .tool-versions

Combines changes from PRs #5990, #6002, #6006