### PR TITLE
chore(deps): add node to asdf

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,4 @@
 java temurin-25.0.1+8.0.LTS
 maven 3.9.12
 pre-commit 4.5.0
+nodejs 24.12.0


### PR DESCRIPTION
## Description

Running the release process involves invoking npm [here](https://github.com/camunda/connectors/blob/d1eb15aa313bbcf67259610f06f7e32dd250fbc1/.github/workflows/RELEASE.yaml#L119), which isn't present on 
self-hosted runners by default.

Using Node.js 24.12.0 instead of 25.x due to libatomic dependency issues on some systems.

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.
- [x] Backport labels are added if these code changes should be backported. No backport label is added to the latest release, as this branch will be rebased onto main before the next release.