### PR TITLE
fix(ci): transform release branch names to base branch for Helm chart lookup

### DIFF
--- a/.github/workflows/INTEGRATION_TEST.yml
+++ b/.github/workflows/INTEGRATION_TEST.yml
@@ -114,8 +114,26 @@ jobs:
           if [ -z "${{ inputs.helm-dir }}" ]; then
             echo ">>> Branch taken: LOOKUP FROM helm-git-refs.json"
             LOOKUP_KEY="${{ inputs.release-branch || github.ref_name }}"
-            echo "Looking up key: '${LOOKUP_KEY}'"
-            helm_dir_from_map=$(jq -r ".[\"${{ inputs.release-branch || github.ref_name }}\"]" .github/workflows/helm-git-refs.json)
+            echo "Initial lookup key: '${LOOKUP_KEY}'"
+            
+            # Transform release-x.y.z branches to their base branch for lookup
+            # Format: release-x.y.z(-alphaN)?(-rcM)?
+            if [[ "$LOOKUP_KEY" =~ ^release-([0-9]+)\.([0-9]+)\.[0-9]+ ]]; then
+              MAJOR="${BASH_REMATCH[1]}"
+              MINOR="${BASH_REMATCH[2]}"
+              if [[ "$LOOKUP_KEY" == *"alpha"* ]]; then
+                # Alpha releases use main as base
+                LOOKUP_KEY="main"
+                echo "Detected alpha release branch, using 'main' as lookup key"
+              else
+                # Regular releases (including RC) use stable/x.y as base
+                LOOKUP_KEY="stable/${MAJOR}.${MINOR}"
+                echo "Detected release branch, transformed to '${LOOKUP_KEY}'"
+              fi
+            fi
+            
+            echo "Final lookup key: '${LOOKUP_KEY}'"
+            helm_dir_from_map=$(jq -r ".[\"${LOOKUP_KEY}\"]" .github/workflows/helm-git-refs.json)
             echo "Found helm-dir: '${helm_dir_from_map}'"
             if [ -z "$helm_dir_from_map" ] || [ "$helm_dir_from_map" == "null" ]; then
               echo "::error::Could not determine Helm chart dir to use, please provide helm-dir input or adjust the mappings in .github/workflows/helm-git-refs.json"


### PR DESCRIPTION
## Summary

- Transform `release-x.y.z` branch names to `stable/x.y` before looking up the Helm chart directory in `helm-git-refs.json`
- Alpha release branches (containing `alpha` in name) use `main` as their base branch instead

This fixes the Helm integration tests failing on release branches because they couldn't find a matching entry in `helm-git-refs.json`.

Closes the issue seen in: https://github.com/camunda/connectors/actions/runs/20758154081