### PR TITLE
ci: publish Test reports only for internal PRs

### DIFF
--- a/.github/workflows/TEST_FEATURE_BRANCH.yml
+++ b/.github/workflows/TEST_FEATURE_BRANCH.yml
@@ -108,13 +108,13 @@ jobs:
         run: mvn --batch-mode clean test -PcheckFormat -Dquickly
 
       - name: Publish Test Report
-        if: always()
+        if: always() && steps.internal.outputs.internal == 'true'
         uses: scacap/action-surefire-report@v1
         with:
           check_name: 'Publish Test Report'
 
       - name: Upload detailed surefire reports
-        if: always()
+        if: always() && steps.internal.outputs.internal == 'true'
         uses: actions/upload-artifact@v6
         with:
           name: surefire-reports


### PR DESCRIPTION
## Description

This pull request makes a minor update to the GitHub Actions workflow. The change ensures that the "Publish Test Report" and "Upload detailed surefire reports" steps only run if a specific internal condition is met, in addition to always running.

- Workflow execution:
  * Updated the `if` conditions for the "Publish Test Report" and "Upload detailed surefire reports" steps in `.github/workflows/TEST_FEATURE_BRANCH.yml` to require that `steps.internal.outputs.internal == 'true'` as well as `always()`.

## Related issues

https://camunda.slack.com/archives/C02JLRNQQ05/p1767886343350929

## Checklist

- [ ] PR has a **milestone** or the `no milestone` label.
- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest release, as this branch will be rebased onto main before the next release.

