### PR TITLE
fix(deps): downgrade AWS SDK from 2.40.4 to 2.40.0 to remediate regression

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -96,12 +96,12 @@ limitations under the License.</license.inlineheader>
     <version.logback>1.5.21</version.logback>
 
     <version.aws-java-sdk>1.12.794</version.aws-java-sdk>
-    <version.software-aws-java-sdk>2.40.4</version.software-aws-java-sdk>
+    <version.software-aws-java-sdk>2.40.0</version.software-aws-java-sdk>
     <version.aws-java-sdk-sts>1.12.794</version.aws-java-sdk-sts>
-    <version.software-aws-java-sdk-sts>2.40.4</version.software-aws-java-sdk-sts>
+    <version.software-aws-java-sdk-sts>2.40.0</version.software-aws-java-sdk-sts>
     <version.aws-lambda-java-events>3.16.1</version.aws-lambda-java-events>
     <version.aws-lambda-java-core>1.4.0</version.aws-lambda-java-core>
-    <version.aws-sdk-secretsmanager>2.40.4</version.aws-sdk-secretsmanager>
+    <version.aws-sdk-secretsmanager>2.40.0</version.aws-sdk-secretsmanager>
 
     <version.localstack>2.0.2</version.localstack>
 


### PR DESCRIPTION
## Description

Downgrades AWS SDK (`software.amazon.awssdk`) from 2.40.4 to 2.40.0 to remediate a regression in the newest SDK version.

The regression affects `SecretsManagerClient.builder()` with `DefaultAwsRegionProviderChain` in `secret-providers/aws/src/main/java/io/camunda/connector/secret/providers/AwsSecretProvider.java`.

Changes:
- `version.software-aws-java-sdk`: 2.40.4 → 2.40.0
- `version.software-aws-java-sdk-sts`: 2.40.4 → 2.40.0
- `version.aws-sdk-secretsmanager`: 2.40.4 → 2.40.0

## Related issues

closes #6042

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.
- [x] Backport labels are added if these code changes should be backported. No backport label is added to the latest release, as this branch will be rebased onto main before the next release.