### PR TITLE
ci: install bc calculator in release workflow

### DIFF
--- a/.github/workflows/RELEASE.yaml
+++ b/.github/workflows/RELEASE.yaml
@@ -79,6 +79,8 @@ jobs:
           fetch-depth: 0
       - name: Install asdf & tools
         uses: asdf-vm/actions/install@v4
+      - name: Install bc calculator
+        run: sudo apt-get update && sudo apt-get install -y bc
       - name: Identify previous release version
         id: prev_version
         uses: camunda/infra-global-github-actions/previous-version@main


### PR DESCRIPTION
## Description

Installs the `bc` (basic calculator) CLI tool in the release workflow on the Ubuntu-based release runner (`gcp-core-2-release`).

The `bc` package is installed via `apt-get` after the asdf tools setup step in the `setup` job.

## Related issues

<!-- Which issues are closed by this PR or are related -->

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.
- [x] Backport labels are added if these code changes should be backported. No backport label is added to the latest release, as this branch will be rebased onto main before the next release.