### PR TITLE
chore: upgrade AWS SDK v2 to 2.41.6 and consolidate version properties

### DIFF
--- a/connectors/aws/aws-base/pom.xml
+++ b/connectors/aws/aws-base/pom.xml
@@ -38,7 +38,7 @@
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>auth</artifactId>
-      <version>${version.software-aws-java-sdk}</version>
+      <version>${version.aws-sdk2}</version>
     </dependency>
 
     <dependency>

--- a/connectors/aws/aws-bedrock/pom.xml
+++ b/connectors/aws/aws-bedrock/pom.xml
@@ -37,7 +37,7 @@
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>bedrockruntime</artifactId>
-      <version>${version.software-aws-java-sdk}</version>
+      <version>${version.aws-sdk2}</version>
     </dependency>
 
     <dependency>

--- a/connectors/aws/aws-s3/pom.xml
+++ b/connectors/aws/aws-s3/pom.xml
@@ -37,17 +37,17 @@
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>s3</artifactId>
-      <version>${version.software-aws-java-sdk}</version>
+      <version>${version.aws-sdk2}</version>
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>aws-core</artifactId>
-      <version>${version.software-aws-java-sdk}</version>
+      <version>${version.aws-sdk2}</version>
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>regions</artifactId>
-      <version>${version.software-aws-java-sdk}</version>
+      <version>${version.aws-sdk2}</version>
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>

--- a/connectors/idp-extraction/pom.xml
+++ b/connectors/idp-extraction/pom.xml
@@ -46,19 +46,19 @@
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>bedrockruntime</artifactId>
-      <version>${version.software-aws-java-sdk}</version>
+      <version>${version.aws-sdk2}</version>
     </dependency>
 
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>textract</artifactId>
-      <version>${version.software-aws-java-sdk}</version>
+      <version>${version.aws-sdk2}</version>
     </dependency>
 
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>s3</artifactId>
-      <version>${version.software-aws-java-sdk}</version>
+      <version>${version.aws-sdk2}</version>
     </dependency>
 
     <dependency>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -96,12 +96,10 @@ limitations under the License.</license.inlineheader>
     <version.logback>1.5.21</version.logback>
 
     <version.aws-java-sdk>1.12.794</version.aws-java-sdk>
-    <version.software-aws-java-sdk>2.40.0</version.software-aws-java-sdk>
+    <version.aws-sdk2>2.41.6</version.aws-sdk2>
     <version.aws-java-sdk-sts>1.12.794</version.aws-java-sdk-sts>
-    <version.software-aws-java-sdk-sts>2.40.0</version.software-aws-java-sdk-sts>
     <version.aws-lambda-java-events>3.16.1</version.aws-lambda-java-events>
     <version.aws-lambda-java-core>1.4.0</version.aws-lambda-java-core>
-    <version.aws-sdk-secretsmanager>2.40.0</version.aws-sdk-secretsmanager>
 
     <version.localstack>2.0.2</version.localstack>
 
@@ -455,37 +453,37 @@ limitations under the License.</license.inlineheader>
       <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>bedrockruntime</artifactId>
-        <version>${version.software-aws-java-sdk}</version>
+        <version>${version.aws-sdk2}</version>
       </dependency>
       <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>sdk-core</artifactId>
-        <version>${version.software-aws-java-sdk}</version>
+        <version>${version.aws-sdk2}</version>
       </dependency>
       <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>aws-core</artifactId>
-        <version>${version.software-aws-java-sdk}</version>
+        <version>${version.aws-sdk2}</version>
       </dependency>
       <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>auth</artifactId>
-        <version>${version.software-aws-java-sdk}</version>
+        <version>${version.aws-sdk2}</version>
       </dependency>
       <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>regions</artifactId>
-        <version>${version.software-aws-java-sdk}</version>
+        <version>${version.aws-sdk2}</version>
       </dependency>
       <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>http-auth-spi</artifactId>
-        <version>${version.software-aws-java-sdk}</version>
+        <version>${version.aws-sdk2}</version>
       </dependency>
       <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>http-auth</artifactId>
-        <version>${version.software-aws-java-sdk}</version>
+        <version>${version.aws-sdk2}</version>
       </dependency>
 
       <dependency>

--- a/secret-providers/aws/pom.xml
+++ b/secret-providers/aws/pom.xml
@@ -21,7 +21,7 @@
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>secretsmanager</artifactId>
-      <version>${version.aws-sdk-secretsmanager}</version>
+      <version>${version.aws-sdk2}</version>
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>


### PR DESCRIPTION
## Description

This PR upgrades the AWS SDK v2 from version 2.40.0 to 2.41.6 (latest release) and consolidates three separate version properties into a single `version.aws-sdk2` property.

### Changes:
- **Consolidated version properties**: Replaced `version.software-aws-java-sdk`, `version.software-aws-java-sdk-sts`, and `version.aws-sdk-secretsmanager` with a single `version.aws-sdk2` property
- **Upgraded AWS SDK v2**: Updated from 2.40.0 to 2.41.6
- **Updated all references**: Modified 6 POM files to use the new consolidated property

### Files modified:
- `parent/pom.xml` - Consolidated properties and updated dependency versions
- `connectors/aws/aws-base/pom.xml`
- `connectors/aws/aws-bedrock/pom.xml`
- `connectors/aws/aws-s3/pom.xml`
- `connectors/idp-extraction/pom.xml`
- `secret-providers/aws/pom.xml`

## Related issues

<!-- Which issues are closed by this PR or are related -->

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.
- [x] Backport labels are added if these code changes should be backported. No backport label is added to the latest release, as this branch will be rebased onto main before the next release.