### PR TITLE
chore(release): Automatically label issues closed by PRs with the rel…

### DIFF
--- a/.github/workflows/NOTIFY_PRS_RELEASED.yml
+++ b/.github/workflows/NOTIFY_PRS_RELEASED.yml
@@ -87,7 +87,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           VERSION: ${{ inputs.version }}
         run: |
-          LABEL_NAME="released/$VERSION"
+          LABEL_NAME="version:$VERSION"
           
           # Check if label exists, create if it doesn't
           if ! gh label list --json name --jq '.[].name' | grep -q "^${LABEL_NAME}$"; then
@@ -106,7 +106,7 @@ jobs:
           VERSION: ${{ inputs.version }}
         run: |
           RELEASE_URL="https://github.com/${{ github.repository }}/releases/tag/$VERSION"
-          LABEL_NAME="released/$VERSION"
+          LABEL_NAME="version:$VERSION"
           
           echo "Posting comments and labels on PRs..."
           


### PR DESCRIPTION
## Description

This pull request adds functionality to automatically label issues that are closed by a pull request when the PR is released. This helps ensure that both the PR and any related issues are consistently tracked with the appropriate label.

Labeling improvements:

* [`.github/workflows/NOTIFY_PRS_RELEASED.yml`](diffhunk://#diff-0c15367200a5e3da9f4dd51b3aa248582b5905e2f01aa72228a1bd0d8372b701R129-R133): Added a step to apply the same label to all issues closed by the PR, using GitHub CLI and `jq`.

<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes camunda/team-connectors/issues/1158


## Checklist

- [x] PR has a **milestone** or the `no milestone` label.
- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest release, as this branch will be rebased onto main before the next release.

