### PR TITLE
chore: Use hardened Docker base images from Minimus to reduce CVEs

### DIFF
--- a/.github/workflows/BUILD_FEATURE_BRANCH.yaml
+++ b/.github/workflows/BUILD_FEATURE_BRANCH.yaml
@@ -24,6 +24,7 @@ jobs:
           secrets: |
             secret/data/products/connectors/ci/common ARTIFACTORY_USR | CI_LDAP_USER;
             secret/data/products/connectors/ci/common ARTIFACTORY_PSW | CI_LDAP_PASSWORD;
+            secret/data/products/connectors/ci/common REGISTRY_MINIMUS_PSW;
 
       - name: Restore cache
         uses: actions/cache@v4
@@ -66,12 +67,19 @@ jobs:
       - name: Set up Docker Build
         uses: docker/setup-buildx-action@v3
 
-      - name: Login to Docker Hub
+      - name: Login to Harbor
         uses: docker/login-action@v3
         with:
           registry: registry.camunda.cloud
           username: ${{ steps.secrets.outputs.CI_LDAP_USER }}
           password: ${{ steps.secrets.outputs.CI_LDAP_PASSWORD }}
+
+      - name: Login to Minimus
+        uses: docker/login-action@v3
+        with:
+          registry: reg.mini.dev
+          username: minimus
+          password: ${{ steps.secrets.outputs.REGISTRY_MINIMUS_PSW }}
 
       # Publish Docker images for Preview environments
       - name: Build and Push Docker Image tag ${{ env.TAG }} - bundle-default

--- a/.github/workflows/DEPLOY_SNAPSHOTS.yaml
+++ b/.github/workflows/DEPLOY_SNAPSHOTS.yaml
@@ -59,6 +59,7 @@ jobs:
             secret/data/products/connectors/ci/common DOCKERHUB_PASSWORD;
             secret/data/products/connectors/ci/common ARTIFACTORY_USR;
             secret/data/products/connectors/ci/common ARTIFACTORY_PSW;
+            secret/data/products/connectors/ci/common REGISTRY_MINIMUS_PSW;
 
       - name: Restore cache
         uses: actions/cache@v4
@@ -139,6 +140,13 @@ jobs:
         with:
           username: ${{ steps.secrets.outputs.DOCKERHUB_USER }}
           password: ${{ steps.secrets.outputs.DOCKERHUB_PASSWORD }}
+
+      - name: Login to Minimus
+        uses: docker/login-action@v3
+        with:
+          registry: reg.mini.dev
+          username: minimus
+          password: ${{ steps.secrets.outputs.REGISTRY_MINIMUS_PSW }}
 
       - name: Build and Push Docker Image - connector-runtime
         uses: docker/build-push-action@v6

--- a/.github/workflows/RELEASE.yaml
+++ b/.github/workflows/RELEASE.yaml
@@ -358,6 +358,7 @@ jobs:
           secrets: |
             secret/data/products/connectors/ci/common DOCKERHUB_USER;
             secret/data/products/connectors/ci/common DOCKERHUB_PASSWORD;
+            secret/data/products/connectors/ci/common REGISTRY_MINIMUS_PSW;
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -372,6 +373,13 @@ jobs:
         with:
           username: ${{ steps.secrets.outputs.DOCKERHUB_USER }}
           password: ${{ steps.secrets.outputs.DOCKERHUB_PASSWORD }}
+
+      - name: Login to Minimus
+        uses: docker/login-action@v3
+        with:
+          registry: reg.mini.dev
+          username: minimus
+          password: ${{ steps.secrets.outputs.REGISTRY_MINIMUS_PSW }}
 
       # Build & push bundle docker images (with version tag)
 

--- a/README.md
+++ b/README.md
@@ -214,3 +214,7 @@ For example, add a label `backport release/8.3` to backport a PR to the `release
 the PR is meged.
 
 You can also trigger this for already merged PRs by posting a comment on the PR containing `/backport`.
+
+## CI Secrets
+
+Secrets used by the CI jobs in this repository are stored in [Vault](https://vault.int.camunda.com/ui/vault/secrets/secret/kv/products%252Fconnectors%252Fci%252Fcommon/details).

--- a/bundle/default-bundle/Dockerfile
+++ b/bundle/default-bundle/Dockerfile
@@ -1,6 +1,15 @@
-FROM eclipse-temurin:21.0.9_10-jre
+FROM reg.mini.dev/1212/openjre-base:25.0.1-dev
+
+# If you don't have access to Minimus hardened base images, you can use public
+# base images like this instead on your own risk:
+#FROM eclipse-temurin:21.0.9_10-jre
 
 VOLUME /tmp
+
+WORKDIR /
+
+# Switch to root to allow setting up our own user and dirs
+USER root
 
 # The /opt/app is used for the Connectors runtime, and out-of-the-box connectors
 # Use the /opt/custom to mount your own connectors, secret providers, or include other jars into the classpath
@@ -8,17 +17,13 @@ RUN mkdir /opt/app && mkdir /opt/custom
 
 COPY target/*-with-dependencies.jar /opt/app/
 
-RUN apt-get update && \
-    apt-get upgrade -y && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
-
 # Using the start script from the base connector runtime image
 COPY start.sh /start.sh
-RUN chmod +x start.sh
+RUN chmod +x /start.sh
 
 # Create an unprivileged user / group and switch to that user
-RUN groupadd --gid 1001 camunda && useradd --no-create-home --gid 1001 --uid 1001 camunda
+RUN addgroup --gid 1001 camunda && adduser -S -G camunda -u 1001 --no-create-home camunda
+
 USER 1001:1001
 
 ENV CAMUNDA_CLIENT_AUTH_CREDENTIALS_CACHE_PATH=/tmp/connectors

--- a/connector-runtime/connector-runtime-application/Dockerfile
+++ b/connector-runtime/connector-runtime-application/Dockerfile
@@ -1,26 +1,30 @@
-FROM eclipse-temurin:21.0.9_10-jre
+FROM reg.mini.dev/1212/openjre-base:25.0.1-dev
+
+# If you don't have access to Minimus hardened base images, you can use public
+# base images like this instead on your own risk:
+#FROM eclipse-temurin:21.0.9_10-jre
 
 VOLUME /tmp
+
+WORKDIR /
+
+# Switch to root to allow setting up our own user and dirs
+USER root
 
 # The /opt/app is used for the Connectors runtime, and out-of-the-box connectors
 # Use the /opt/custom to mount your own connectors, secret providers, or include other jars into the classpath
 RUN mkdir /opt/app && mkdir /opt/custom
 
 COPY start.sh /start.sh
-RUN chmod +x start.sh
+RUN chmod +x /start.sh
 
 # Copy Connector runtime from local build
 COPY target/*-with-dependencies.jar /opt/app/
 # It can also be downloaded from Maven Central instead
 # ADD https://s01.oss.sonatype.org/content/repositories/releases/io/camunda/connector/connector-runtime-application/${VERSION}/connector-runtime-application-${VERSION}-with-dependencies.jar /opt/app/runtime.jar
 
-RUN apt-get update && \
-    apt-get upgrade -y && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
-
 # Create an unprivileged user / group and switch to that user
-RUN groupadd --gid 1001 camunda && useradd --no-create-home --gid 1001 --uid 1001 camunda
+RUN addgroup --gid 1001 camunda && adduser -S -G camunda -u 1001 --no-create-home camunda
 USER 1001:1001
 
 # Use entry point to allow downstream images to add JVM arguments using CMD

--- a/renovate.json
+++ b/renovate.json
@@ -25,6 +25,14 @@
       "datasourceTemplate": "docker"
     }
   ],
+  "hostRules": [
+    {
+      "hostType": "docker",
+      "matchHost": "https://reg.mini.dev",
+      "username": "minimus",
+      "password": "{{ secrets.INFRA_MINIMUS_REGISTRY_TOKEN }}"
+    }
+  ],
   "packageRules": [
     {
       "matchManagers": [


### PR DESCRIPTION
## Description

Backport of https://github.com/camunda/product-hub/issues/3312 to Connectors 8.8.

I analyzed the `camunda/connectors:8.8.5` Docker image (based on Ubuntu still) in comparison with `camunda/connectors:8.9.0-alpha3` (after its conversion to Minimus). The goal here is to figure out what might break for customers when going from Connectors 8.8.5 to a future 8.8.6 release (Ubuntu -> Minimus).

✔️ Notable outcomes of [backwards-compatibility check](https://docs.google.com/spreadsheets/d/19K3HpIMTyk_ucRM-a38YUy79sAtjGxzsFrQ9LM4M_ro/edit?gid=0#gid=0) for `camunda/connectors` Docker image:

* The previous Ubuntu-based `camunda/connectors:8.8.x` images included software that we don't provide under new Minimus images:
    * `curl` would be absent (but `wget` is present) ✔️
    * [GnuPG utilities](https://www.gnupg.org/) would be absent (fewer CVEs!) ✔️
    * [C library for locale (i18n) database](https://packages.debian.org/bullseye/locales) would be absent (no known impact) ✔️
    * [Perl](https://www.perl.org/) would be absent (no impact) ✔️ 
    * ~Q: Do we think customers expect the availability of the above software, OR does any connector need it?~ A: No
* Minimus does not allow installing packages like Ubuntu did (we have to accept this in order to use Minimus at all) ✔️
    * It is an antipattern, and if a customer really needs this https://github.com/camunda/connectors is open-source so they can build their own images
* Minimus has more/different preinstalled packages but pledges to remove CVEs from them for us

~I can adjust the PR in case we need to provide any of the above missing software if we have a strong reason to believe it is needed.~ (Not needed for now)

Manual QA needed since CI has less checks than on `main`:

* ✔️ test in SM locally (startup working fine, no obviously missing binaries, files or paths)
* and/or merge and test `camunda/connectors:8.8-SNAPSHOT`

## Related issues

Related to https://github.com/camunda/product-hub/issues/3355

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.
- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest release, as this branch will be rebased onto main before the next release.

