### PR TITLE
chore(CI): Add stable branch to license check workflow

### DIFF
--- a/.github/workflows/CHECK_LICENSES.yml
+++ b/.github/workflows/CHECK_LICENSES.yml
@@ -10,6 +10,7 @@ on:
     branches:
       - main
       - release/*
+      - stable/*
     tags:
       - '*'
 


### PR DESCRIPTION
This pull request makes a small update to the GitHub Actions workflow configuration. The change ensures that the `CHECK_LICENSES` workflow will also run on pushes to branches matching the `stable/*` pattern.## Description

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.
- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest release, as this branch will be rebased onto main before the next release.

