### PR TITLE
other(ci): fix stable branch name

### DIFF
--- a/.github/workflows/DEPLOY_SNAPSHOTS.yaml
+++ b/.github/workflows/DEPLOY_SNAPSHOTS.yaml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
       - 'stable/**'
+      - 'alpha/**'
   workflow_dispatch: { }
 
 defaults:


### PR DESCRIPTION
## Description

We renamed our branches from `release` to `stable`

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #

## Checklist

- [ ] PR has a **milestone** or the `no milestone` label.
- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest release, as this branch will be rebased onto main before the next release.

