### PR TITLE
fix(agentic-ai): don't use <tt> in in javadoc as it breaks API docs generation

### DIFF
--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/mcp/client/McpClientResultDocumentHandler.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/mcp/client/McpClientResultDocumentHandler.java
@@ -31,7 +31,7 @@ public class McpClientResultDocumentHandler {
    * convert it into documents, is implemented in the respective target class.
    *
    * @param clientResult the client result to convert potentially storable data for
-   * @return the <tt>clientResult</tt> if it is not an instance of {@link
+   * @return the {@code McpClientResult} if it is not an instance of {@link
    *     McpClientResultWithStorableData}, otherwise a new instance holding references to created
    *     documents for any storable data
    */

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/mcp/client/model/result/McpClientResultWithStorableData.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/mcp/client/model/result/McpClientResultWithStorableData.java
@@ -12,8 +12,8 @@ public interface McpClientResultWithStorableData {
 
   /**
    * Stores data that is marked as storable, e.g. binary data, as Camunda documents using the
-   * provided <tt>documentFactory</tt> and returns a new instance of the result holding references
-   * to the created documents.
+   * provided {@code DocumentFactory} and returns a new instance of the result holding references to
+   * the created documents.
    *
    * @param documentFactory responsible for creating the actual documents in Camunda.
    * @return a new instance of the result holding references to the created documents, if eligible
@@ -28,7 +28,7 @@ public interface McpClientResultWithStorableData {
   interface StorableMcpDataContainer<T> {
 
     /**
-     * If conditions are met, creates a Camunda document using the provided <tt>documentFactory</tt>
+     * If conditions are met, creates a Camunda document using the provided {@code DocumentFactory}
      * and returns a new value that holds a reference to the created document.
      *
      * @param documentFactory the document factory that is responsible to create the document in


### PR DESCRIPTION
## Description

Fix JavaDoc generation issues introduced in #6008 

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.
- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest release, as this branch will be rebased onto main before the next release.

