### PR TITLE
fix: notify released PRs by default and ignore Helm Charts tests

### DIFF
--- a/.github/workflows/RELEASE.yaml
+++ b/.github/workflows/RELEASE.yaml
@@ -27,7 +27,7 @@ on:
         description: 'Notify PRs that they have been released'
         required: false
         type: boolean
-        default: false
+        default: true
 
 jobs:
 
@@ -613,10 +613,6 @@ jobs:
       !contains(inputs.version, 'rc') &&
       needs.setup.result == 'success' &&
       (needs.maven-release.result == 'success' || needs.maven-release.result == 'skipped') &&
-      (needs.docker-release.result == 'success' || needs.docker-release.result == 'skipped') &&
-      needs.bundle-and-build-changelog.result == 'success' &&
-      (needs.helm-deploy.result == 'success' || needs.helm-deploy.result == 'skipped') &&
-      (needs.fossa_release.result == 'success' || needs.fossa_release.result == 'skipped')
-
+      (needs.docker-release.result == 'success' || needs.docker-release.result == 'skipped')
     with:
       version: ${{ inputs.version }}


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
This pull request makes minor adjustments to the release workflow configuration. The default value for notifying pull requests about their release has been changed, and several job dependencies were removed to simplify the release process.

Workflow configuration updates:

* Changed the default value of the `notify-prs` input to `true` in `.github/workflows/RELEASE.yaml`, so pull requests will be notified of their release by default.

Release job dependency simplification:

* Removed dependencies on `bundle-and-build-changelog`, `helm-deploy`, and `fossa_release` jobs from the release condition in `.github/workflows/RELEASE.yaml`, streamlining the release job requirements.

