### PR TITLE
test: fix actuator tests

### DIFF
--- a/bundle/camunda-saas-bundle/src/test/java/io/camunda/connector/runtime/saas/SecurityConfigurationTest.java
+++ b/bundle/camunda-saas-bundle/src/test/java/io/camunda/connector/runtime/saas/SecurityConfigurationTest.java
@@ -38,8 +38,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.web.server.LocalManagementPort;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
-import org.springframework.http.HttpEntity;
-import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
@@ -72,8 +70,6 @@ public class SecurityConfigurationTest {
   @MockitoBean(answers = Answers.RETURNS_MOCKS)
   public SaaSSecretConfiguration saaSSecretConfiguration;
 
-  // needed to access /actuator endpoints
-  @Autowired RestTemplateBuilder restTemplateBuilder;
   @LocalManagementPort int managementPort;
   @Autowired private MockMvc mvc;
 
@@ -160,12 +156,12 @@ public class SecurityConfigurationTest {
   @Test
   public void actuatorEndpoint_isAccessible() {
     ResponseEntity<String> response =
-        restTemplateBuilder
+        new RestTemplateBuilder()
             .rootUri("http://localhost:" + managementPort + "/actuator")
             .connectTimeout(Duration.ofSeconds(60))
             .readTimeout(Duration.ofSeconds(60))
             .build()
-            .exchange("/metrics", HttpMethod.GET, new HttpEntity<>((Void) null), String.class);
+            .getForEntity("/metrics", String.class);
 
     assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
   }


### PR DESCRIPTION
## Description

This pull request simplifies the `SecurityConfigurationTest` class by removing the unnecessary injection of `RestTemplateBuilder` and refactoring the actuator endpoint test to use a newly instantiated builder. This makes the test setup cleaner and more self-contained.

Test code cleanup and simplification:

* Removed the `@Autowired RestTemplateBuilder restTemplateBuilder` field and related unused imports from `SecurityConfigurationTest.java`, as it is no longer needed for the tests. [[1]](diffhunk://#diff-df29f2fa4a5868c990896aa34ded07152ac2f0006caebe0ade89d7100f02dea3L41-L42) [[2]](diffhunk://#diff-df29f2fa4a5868c990896aa34ded07152ac2f0006caebe0ade89d7100f02dea3L75-L76)
* Updated the `actuatorEndpoint_isAccessible` test to instantiate a new `RestTemplateBuilder` directly, and simplified the HTTP request from using `exchange` to `getForEntity`.
