### PR TITLE
ci: fix workflow Slack notifications

### DIFF
--- a/.github/workflows/DEPLOY_SNAPSHOTS.yaml
+++ b/.github/workflows/DEPLOY_SNAPSHOTS.yaml
@@ -243,7 +243,7 @@ jobs:
   notify-failure:
     name: Notify on failure
     runs-on: ubuntu-latest
-    needs: [deploy-snapshots, helm-deploy]
+    needs: [ deploy-snapshots, helm-deploy ]
     if: failure()
     steps:
       - name: Send Slack notification on failure
@@ -254,5 +254,5 @@ jobs:
           payload: |
             {
               "channel": "${{ secrets.CONNECTORS_SUPPORT_SLACK_CHANNEL_ID }}",
-              "text": ":alarm: <@connector-medic> Deploy snapshots workflow failed on branch `${{ github.ref_name }}`.\nCheck details: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+              "text": ":alarm: @connector-medic Deploy snapshots workflow failed on branch `${{ github.ref_name }}`.\nCheck details: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
             }

--- a/.github/workflows/RELEASE.yaml
+++ b/.github/workflows/RELEASE.yaml
@@ -623,7 +623,7 @@ jobs:
   notify-failure:
     name: Notify on failure
     runs-on: ubuntu-latest
-    needs: [create-release, setup, maven-release, docker-release, bundle-and-build-changelog, helm-deploy, fossa_release]
+    needs: [ create-release, setup, maven-release, docker-release, bundle-and-build-changelog, helm-deploy, fossa_release ]
     if: failure()
     steps:
       - name: Send Slack notification on failure
@@ -634,5 +634,5 @@ jobs:
           payload: |
             {
               "channel": "${{ secrets.CONNECTORS_QA_SLACK_CHANNEL_ID }}",
-              "text": ":alarm: <@connectors-release-manager> Release workflow failed for version `${{ inputs.version }}`.\nCheck details: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+              "text": ":alarm: @connectors-release-manager Release workflow failed for version `${{ inputs.version }}`.\nCheck details: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
             }


### PR DESCRIPTION
## Description

This pull request makes a small update to the Slack notification messages in the GitHub Actions workflows. The change replaces Slack user mention syntax from the user ID format (`<@user>`) to the plain text format (`@user`) for better clarity or compatibility.

- Updated Slack notification messages in `.github/workflows/DEPLOY_SNAPSHOTS.yaml` and `.github/workflows/RELEASE.yaml` to use `@username` instead of `<@username>` for mentioning users in failure alerts. [[1]](diffhunk://#diff-08017f549e52064d6e997595cc8eeed77e33a0af288f64281b187bc5f24d9431L257-R257) [[2]](diffhunk://#diff-7c90c3dea924e481fe4ec37ecf28a6dcd64d17a06a2f633c095994572e48a3ceL637-R637)
