### PR TITLE
fix: Fix javadoc in MCP connector data models containing forbidden chars

### DIFF
--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/mcp/client/model/McpClientRequest.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/mcp/client/model/McpClientRequest.java
@@ -26,7 +26,8 @@ public record McpClientRequest(@Valid @NotNull McpClientRequestData data) {
      * deprecated structure, where filters are only applicable for MCP tools and not for other
      * connector modes, thus the filter being on this level instead of inside the connector mode.
      *
-     * @deprecated This is only used to ensure element templates of version below 2 are still supported
+     * @deprecated This is only used to ensure element templates of version below 2 are still
+     *     supported
      */
     @JsonCreator
     @Deprecated(forRemoval = true)

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/mcp/client/model/McpRemoteClientRequest.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/mcp/client/model/McpRemoteClientRequest.java
@@ -23,7 +23,8 @@ public record McpRemoteClientRequest(@Valid @NotNull McpRemoteClientRequestData 
      * deprecated structure, where filters are only applicable for MCP tools and not for other
      * connector modes, thus the filter being on this level instead of inside the connector mode.
      *
-     * @deprecated This is only used to ensure element templates of version below 2 are still supported
+     * @deprecated This is only used to ensure element templates of version below 2 are still
+     *     supported
      */
     @JsonCreator
     @Deprecated(forRemoval = true)


### PR DESCRIPTION
## Description

Fix javadoc containing forbidden characters which make the apidocs build failing

## Related issues
relates to #5841 


## Checklist

- [x] PR has a **milestone** or the `no milestone` label.
- [x] Backport labels are added if these code changes should be backported. No backport label is added to the latest release, as this branch will be rebased onto main before the next release.

