### PR TITLE
ci(alwaysGreen): Add SaaS Smoke Tests For AlwaysGreen

### DIFF
--- a/.github/workflows/FEATURE_BRANCH_HELM_TEST.yaml
+++ b/.github/workflows/FEATURE_BRANCH_HELM_TEST.yaml
@@ -127,7 +127,7 @@ jobs:
           push: true
           tags: registry.camunda.cloud/team-connectors/connectors-bundle-saas:${{ env.TAG }}
 
-  helm-test-branch:
+  trigger-sm-e2e:
     needs: [ build-image ]
     uses: ./.github/workflows/INTEGRATION_TEST.yml
     secrets: inherit


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

This PR adds the AlwaysGreen Smoke Tests to the PR triggered AlwaysGreen workflow.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #6103 

## Checklist

- [ ] PR has a **milestone** or the `no milestone` label.
- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest release, as this branch will be rebased onto main before the next release.

