### PR TITLE
fix: include exception details in activity error logs

### DIFF
--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/webhook/InboundWebhookRestController.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/webhook/InboundWebhookRestController.java
@@ -187,7 +187,7 @@ public class InboundWebhookRestController {
                   activity
                       .withSeverity(Severity.ERROR)
                       .withTag(payload.method())
-                      .withMessage("Webhook processing failed"));
+                      .withMessage("Webhook processing failed", e));
       response = buildErrorResponse(e);
     }
     return response;

--- a/connectors/http/polling/src/main/java/io/camunda/connector/http/polling/task/HttpRequestTask.java
+++ b/connectors/http/polling/src/main/java/io/camunda/connector/http/polling/task/HttpRequestTask.java
@@ -57,7 +57,7 @@ public class HttpRequestTask implements Runnable {
                     .withSeverity(Severity.ERROR)
                     .withTag(pollingRuntimeProperties.getMethod().toString())
                     .withMessage(
-                        "Error executing http request: " + pollingRuntimeProperties.getUrl()));
+                        "Error executing http request: " + pollingRuntimeProperties.getUrl(), e));
       }
     } catch (Exception e) {
       this.context.log(
@@ -65,7 +65,7 @@ public class HttpRequestTask implements Runnable {
               activity
                   .withSeverity(Severity.ERROR)
                   .withTag("http-request")
-                  .withMessage("Error binding properties for HTTP request"));
+                  .withMessage("Error binding properties for HTTP request", e));
     }
   }
 }

--- a/connectors/rabbitmq/src/main/java/io/camunda/connector/rabbitmq/inbound/RabbitMqConsumer.java
+++ b/connectors/rabbitmq/src/main/java/io/camunda/connector/rabbitmq/inbound/RabbitMqConsumer.java
@@ -67,7 +67,7 @@ public class RabbitMqConsumer extends DefaultConsumer {
               activity
                   .withSeverity(Severity.ERROR)
                   .withTag(ActivityLogTag.MESSAGE)
-                  .withMessage("NACK (requeue) - failed to correlate event"));
+                  .withMessage("NACK (requeue) - failed to correlate event", e));
       getChannel().basicReject(envelope.getDeliveryTag(), true);
     }
   }


### PR DESCRIPTION
## Description

This PR fixes a bug where exception details were accidentally omitted during the activity logging refactoring in PR #4817. When inbound connectors encounter errors, the activity logs now include the full exception stack trace, making debugging significantly easier.

### Background

During the activity logging refactoring (PR #4817, commit `tsxxnxml`), several catch blocks were migrated from SLF4J logging to the new Activity-based logging system. In the process, exception details were accidentally dropped in several locations.

**Before refactoring:**
```java
LOG.info("Webhook: {} failed with exception", connector.context().getDefinition(), e);
```

**After refactoring (broken):**
```java
.withMessage("Webhook processing failed")  // Exception lost
```

**This PR fixes it to:**
```java
.withMessage("Webhook processing failed", e)  // Exception included
```

This issue was discovered when debugging a Twilio webhook failure where no error details were visible in the logs.

### Changes Made

Fixed 4 locations where exceptions were completely ignored in activity logging:

1. **InboundWebhookRestController.java:190** - Webhook processing failures
2. **RabbitMqConsumer.java:70** - RabbitMQ correlation failures  
3. **HttpRequestTask.java:60** - HTTP polling request errors
4. **HttpRequestTask.java:68** - HTTP polling property binding errors

All fixes follow the pattern established in PR #5376 (which fixed similar issues in the Kafka connector).

### Pattern Used

Using the `withMessage(String message, Throwable exception)` overload:
- ✅ Human-readable context in the message
- ✅ Full stack trace from the exception
- ✅ Consistent with fix in PR #5376

### Testing

- ✅ Verified code compiles successfully
- ✅ Follows existing patterns in the codebase

## Related issues

Related to the activity logging refactoring:
- #4817 (original refactoring where exceptions were lost)
- #5376 (similar fix for Kafka connector)

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.
- [x] Backport labels are added if these code changes should be backported. No backport label is added to the latest release, as this branch will be rebased onto main before the next release.