### PR TITLE
ci: don't fail the job if only cache restore failed

### DIFF
--- a/.github/workflows/DEPLOY_SNAPSHOTS.yaml
+++ b/.github/workflows/DEPLOY_SNAPSHOTS.yaml
@@ -64,6 +64,7 @@ jobs:
 
       - name: Restore cache
         uses: actions/cache@v5
+        continue-on-error: true  # Cache failures should not fail the build
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}


### PR DESCRIPTION
## Description
This pull request makes a minor improvement to the deployment workflow by ensuring that cache restoration failures do not cause the build to fail.

* Workflow robustness: Added `continue-on-error: true` to the cache restoration step in `.github/workflows/DEPLOY_SNAPSHOTS.yaml`, so that cache failures will not fail the build.