### PR TITLE
fix(agentic-ai): Fix event handling not triggered when event toolCallResult is null

### DIFF
--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/agent/AgentMessagesHandlerImpl.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/agent/AgentMessagesHandlerImpl.java
@@ -31,6 +31,7 @@ import io.camunda.connector.agenticai.model.tool.ToolCallResult;
 import io.camunda.connector.api.error.ConnectorException;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -45,6 +46,14 @@ import org.slf4j.LoggerFactory;
 public class AgentMessagesHandlerImpl implements AgentMessagesHandler {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(AgentMessagesHandlerImpl.class);
+
+  private static final String EVENT_CONTENT_EMPTY =
+      "An event was triggered but no content was returned.";
+  private static final String EVENT_CONTENT_EMPTY_INTERRUPT_TOOL_CALLS_EMPTY_MESSAGE =
+      EVENT_CONTENT_EMPTY + " All in-flight tool executions were canceled.";
+  private static final String EVENT_CONTENT_EMPTY_WAIT_FOR_TOOL_CALL_RESULTS_EMPTY_MESSAGE =
+      EVENT_CONTENT_EMPTY
+          + " Execution waited for all in-flight tool executions to complete before proceeding.";
 
   private final GatewayToolHandlerRegistry gatewayToolHandlers;
   private final SystemPromptComposer systemPromptComposer;
@@ -78,14 +87,15 @@ public class AgentMessagesHandlerImpl implements AgentMessagesHandler {
       RuntimeMemory memory,
       UserPromptConfiguration userPrompt,
       List<ToolCallResult> toolCallResults) {
+    boolean interruptToolCallsOnEventResults = interruptToolCallsOnEventResults(executionContext);
 
+    // partitioned into 2 buckets - true -> with tool call ID, false -> without (from an event)
     final var partitionedByToolCallId =
         toolCallResults.stream().collect(Collectors.partitioningBy(result -> result.id() != null));
     final List<ToolCallResult> actualToolCallResults = partitionedByToolCallId.get(true);
     final List<Message> eventMessages =
         partitionedByToolCallId.get(false).stream()
-            .map(this::createEventMessage)
-            .filter(Objects::nonNull)
+            .map(eventResult -> createEventMessage(eventResult, interruptToolCallsOnEventResults))
             .toList();
 
     // throw an error when receiving tool call results on an empty context as
@@ -101,7 +111,6 @@ public class AgentMessagesHandlerImpl implements AgentMessagesHandler {
     List<Message> messages = new ArrayList<>();
     if (lastChatMessage instanceof AssistantMessage assistantMessage
         && assistantMessage.hasToolCalls()) {
-      boolean interruptToolCallsOnEventResults = interruptToolCallsOnEventResults(executionContext);
       boolean interruptMissingToolCalls =
           interruptToolCallsOnEventResults && !eventMessages.isEmpty();
 
@@ -196,28 +205,39 @@ public class AgentMessagesHandlerImpl implements AgentMessagesHandler {
         .build();
   }
 
-  private Message createEventMessage(ToolCallResult eventResult) {
-    if (eventResult.content() == null) {
-      return null;
-    }
+  private Message createEventMessage(
+      ToolCallResult eventResult, boolean interruptToolCallsOnEventResults) {
+    Object eventContent = eventResult.content();
 
-    Content contentBlock = null;
-    if (eventResult.content() instanceof String textContent) {
-      if (StringUtils.isNotBlank(textContent)) {
-        contentBlock = textContent(textContent);
-      }
+    List<Content> userMessageContent = new ArrayList<>();
+    if (isEventContentEmpty(eventContent)) {
+      userMessageContent.add(
+          textContent(
+              interruptToolCallsOnEventResults
+                  ? EVENT_CONTENT_EMPTY_INTERRUPT_TOOL_CALLS_EMPTY_MESSAGE
+                  : EVENT_CONTENT_EMPTY_WAIT_FOR_TOOL_CALL_RESULTS_EMPTY_MESSAGE));
     } else {
-      contentBlock = objectContent(eventResult.content());
-    }
-
-    if (contentBlock == null) {
-      return null;
+      userMessageContent.add(
+          switch (eventContent) {
+            case String textContent -> textContent(textContent);
+            default -> objectContent(eventContent);
+          });
     }
 
     return UserMessage.builder()
-        .content(List.of(contentBlock))
+        .content(userMessageContent)
         .metadata(defaultMessageMetadata())
         .build();
+  }
+
+  private boolean isEventContentEmpty(Object eventContent) {
+    return switch (eventContent) {
+      case null -> true;
+      case String textContent -> StringUtils.isBlank(textContent);
+      case Collection<?> collection -> collection.isEmpty();
+      case Map<?, ?> map -> map.isEmpty();
+      default -> false;
+    };
   }
 
   private boolean interruptToolCallsOnEventResults(AgentExecutionContext executionContext) {


### PR DESCRIPTION
## Description

When an event subprocess within an agentic AHSP completes, it does not trigger interruption of running tools if the event subprocess does not generate a payload as `toolCallResult` variable. This PR adapts this behavior by always creating a synthetic user message when there is no payload to ensure the agent process correctly interrupts running tools whenever an event is handled.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #6092

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.
- [x] Backport labels are added if these code changes should be backported. No backport label is added to the latest release, as this branch will be rebased onto main before the next release.

