### PR TITLE
chore: only disable analyze execution of maven dependency plugin in e2e tests, not the whole plugin

### DIFF
--- a/connectors-e2e-test/pom.xml
+++ b/connectors-e2e-test/pom.xml
@@ -17,6 +17,7 @@
 
   <properties>
     <skip.central.release>true</skip.central.release>
+    <maven.dependency.analyze.skip>true</maven.dependency.analyze.skip>
   </properties>
 
   <modules>
@@ -42,17 +43,4 @@
       <artifactId>connector-test-utils</artifactId>
     </dependency>
   </dependencies>
-
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-dependency-plugin</artifactId>
-        <configuration>
-          <skip>true</skip>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
-
 </project>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -184,6 +184,9 @@ limitations under the License.</license.inlineheader>
     <plugin.version.maven-surefire-plugin>3.5.4</plugin.version.maven-surefire-plugin>
     <plugin.version.spotless-maven-plugin>3.2.1</plugin.version.spotless-maven-plugin>
     <plugin.version.maven-jar-plugin>3.5.0</plugin.version.maven-jar-plugin>
+
+    <plugin.version.maven-dependency-plugin>3.9.0</plugin.version.maven-dependency-plugin>
+    <maven.dependency.analyze.skip>false</maven.dependency.analyze.skip>
   </properties>
 
   <dependencyManagement>
@@ -972,7 +975,7 @@ limitations under the License.</license.inlineheader>
         </plugin>
         <plugin>
           <artifactId>maven-dependency-plugin</artifactId>
-          <version>3.9.0</version>
+          <version>${plugin.version.maven-dependency-plugin}</version>
           <executions>
             <execution>
               <id>analyze-dependencies</id>
@@ -981,6 +984,7 @@ limitations under the License.</license.inlineheader>
               </goals>
               <phase>process-test-classes</phase>
               <configuration>
+                <skip>${maven.dependency.analyze.skip}</skip>
                 <failOnWarning>true</failOnWarning>
                 <ignoreUnusedRuntime>true</ignoreUnusedRuntime>
                 <ignoredUnusedDeclaredDependencies>


### PR DESCRIPTION
## Description

When running dependency commands like `mvn dependency:tree` in one of the e2e test modules, this currently returns with a message that the plugin is disabled. 

```
❯ mvn -f connectors-e2e-test/connectors-e2e-test-agentic-ai/pom.xml dependency:tree
[INFO] Scanning for projects...
[INFO] Inspecting build with total of 1 modules...
[INFO] Not installing Nexus Staging features:
[INFO]  * Preexisting staging related goal bindings found in 1 modules.
[INFO]
[INFO] --------< io.camunda.connector:connectors-e2e-test-agentic-ai >---------
[INFO] Building Connectors E2e Test Agentic Ai 8.9.0-SNAPSHOT
[INFO]   from pom.xml
[INFO] --------------------------------[ jar ]---------------------------------
[INFO]
[INFO] --- dependency:3.9.0:tree (default-cli) @ connectors-e2e-test-agentic-ai ---
[INFO] Skipping plugin execution
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  0.751 s
[INFO] Finished at: 2026-01-23T08:48:46+01:00
[INFO] ------------------------------------------------------------------------
```

As it is beneficial being able to inspect how dependencies are pulled into a module, this PR updates the config to not disable the whole plugin for e2e tests, but only the analyze execution, controlled by a property.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.
- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest release, as this branch will be rebased onto main before the next release.

