### PR TITLE
ci: update valid PR names (add DEPS)

### DIFF
--- a/.github/workflows/PULL_REQUEST_NAME_CHECK_ON_PR.yml
+++ b/.github/workflows/PULL_REQUEST_NAME_CHECK_ON_PR.yml
@@ -14,7 +14,7 @@ jobs:
         run: echo "$PR_TITLE"
       - name: Check if pull request name follows conventional commit regex
         run: |
-          PR_REGEX='^(feat|fix|docs|style|refactor|perf|test|chore|build|other|ci)(\(.+\))?: .+$'
+          PR_REGEX='^(feat|fix|deps|docs|style|refactor|perf|test|chore|build|other|ci)(\(.+\))?: .+$'
           if [[ "$PR_TITLE" =~ $PR_REGEX ]]; then
             echo "Pull request name follows the conventional commit format."
           else


### PR DESCRIPTION
## Description
This pull request makes a small update to the pull request title validation workflow. The change adds support for the `deps` type in the conventional commit regex, ensuring that pull requests related to dependency updates are recognized as valid.

* Updated the regular expression in `.github/workflows/PULL_REQUEST_NAME_CHECK_ON_PR.yml` to include `deps` as a valid conventional commit type for pull request titles.