### PR TITLE
ci: can trigger e2e manually

### DIFF
--- a/.github/workflows/NIGHTLY_E2E.yml
+++ b/.github/workflows/NIGHTLY_E2E.yml
@@ -11,8 +11,8 @@ jobs:
 
   get-branches:
     runs-on: ubuntu-latest
-    # Only run if scheduled/manual OR if the 'e2e-tests' label was added
-    if: github.event_name != 'pull_request' || github.event.label.name == 'e2e-tests'
+    # Only run if scheduled/manual OR if the 'e2e-tests' label was added on a non-fork PR
+    if: github.event_name != 'pull_request' || (github.event.label.name == 'e2e-tests' && github.event.pull_request.head.repo.fork == false)
     outputs:
       branches: ${{ steps.set-matrix.outputs.branches }}
     steps:


### PR DESCRIPTION
## Description

This pull request updates the `NIGHTLY_E2E.yml` GitHub Actions workflow to allow end-to-end (E2E) tests to be triggered on pull requests when the `e2e-tests` label is added, in addition to the existing nightly and manual triggers. It also adjusts the logic for selecting branches to test and makes a minor improvement to the Slack notification message.

**Workflow trigger and logic improvements:**

* Added a new trigger so the workflow runs when a pull request is labeled, specifically when the `e2e-tests` label is added.
* Updated the `get-branches` job to only test the pull request’s head branch when triggered by a labeled pull request, and to test `main` and all `stable/*` branches for scheduled or manual runs.

**Notification improvements:**

* Updated the Slack notification message to be more generic, changing "Nightly E2E test run failed" to "E2E test run failed" to reflect the new trigger options.