### PR TITLE
fix(ETG): Fix group generation for element templates

### DIFF
--- a/element-template-generator/core/src/main/java/io/camunda/connector/generator/dsl/PropertyBuilder.java
+++ b/element-template-generator/core/src/main/java/io/camunda/connector/generator/dsl/PropertyBuilder.java
@@ -49,6 +49,10 @@ public abstract class PropertyBuilder {
     return condition;
   }
 
+  public String getGroup() {
+    return group;
+  }
+
   public PropertyBuilder id(String name) {
     this.id = name;
     return this;

--- a/element-template-generator/core/src/main/java/io/camunda/connector/generator/dsl/PropertyGroup.java
+++ b/element-template-generator/core/src/main/java/io/camunda/connector/generator/dsl/PropertyGroup.java
@@ -26,6 +26,7 @@ import io.camunda.connector.generator.dsl.PropertyCondition.Equals;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.function.BiFunction;
 import java.util.stream.Stream;
 
@@ -193,6 +194,10 @@ public record PropertyGroup(
 
     private PropertyGroupBuilder() {}
 
+    public String getId() {
+      return id;
+    }
+
     public PropertyGroupBuilder id(String id) {
       this.id = id;
       return this;
@@ -254,6 +259,22 @@ public record PropertyGroup(
       if (id == null) {
         throw new IllegalStateException("id is required before properties can be set");
       }
+    }
+
+    @Override
+    public boolean equals(Object object) {
+      if (object == null || getClass() != object.getClass()) return false;
+      PropertyGroupBuilder that = (PropertyGroupBuilder) object;
+      return Objects.equals(properties, that.properties)
+          && Objects.equals(id, that.id)
+          && Objects.equals(label, that.label)
+          && Objects.equals(tooltip, that.tooltip)
+          && Objects.equals(openByDefault, that.openByDefault);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(properties, id, label, tooltip, openByDefault);
     }
   }
 }

--- a/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/util/OperationBasedConnectorUtil.java
+++ b/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/util/OperationBasedConnectorUtil.java
@@ -160,15 +160,20 @@ public class OperationBasedConnectorUtil {
       Operation operation,
       Variable variable,
       boolean shouldMapParameterBindings) {
-    property
-        .id(concatenateOperationIdAndPropertyId(getOperationId(operation), property.getId()))
-        .condition(mapCondition(property.getCondition(), operation))
-        .group(OPERATION_GROUP_ID);
-
+    setTemplatePropertyValues(property, operation);
     if (shouldMapParameterBindings) {
       property.binding(mapBinding(property.getBinding(), variable));
     }
     return property;
+  }
+
+  private static void setTemplatePropertyValues(PropertyBuilder property, Operation operation) {
+    var id = concatenateOperationIdAndPropertyId(getOperationId(operation), property.getId());
+    var group =
+        property.getGroup() == null || property.getGroup().isBlank()
+            ? OPERATION_GROUP_ID
+            : property.getGroup();
+    property.id(id).condition(mapCondition(property.getCondition(), operation)).group(group);
   }
 
   private static PropertyCondition mapCondition(PropertyCondition condition, Operation operation) {

--- a/element-template-generator/core/src/test/java/io/camunda/connector/generator/java/OutboundClassBasedTemplateGeneratorTest.java
+++ b/element-template-generator/core/src/test/java/io/camunda/connector/generator/java/OutboundClassBasedTemplateGeneratorTest.java
@@ -761,9 +761,8 @@ public class OutboundClassBasedTemplateGeneratorTest extends BaseTest {
           .containsExactlyInAnyOrder(
               new DropdownChoice("Conditional sub type", "conditionalSubType"));
 
-      var annotatedStringProperty =
-          assertThat(discriminatorProperty.getCondition())
-              .isEqualTo(new Equals("annotatedStringProperty", "value"));
+      assertThat(discriminatorProperty.getCondition())
+          .isEqualTo(new Equals("annotatedStringProperty", "value"));
     }
   }
 
@@ -787,12 +786,30 @@ public class OutboundClassBasedTemplateGeneratorTest extends BaseTest {
     }
 
     @Test
+    void allInPredefinedGroups() {
+      var template =
+          generator.generate(MyConnectorFunction.AllPropertiesInPredefinedGroups.class).getFirst();
+      checkPropertyGroups(
+          List.of(
+              Map.entry("predefinedGroup1", "Predefined Group One"),
+              Map.entry("predefinedGroup2", "Predefined Group Two"),
+              Map.entry("predefinedGroup3", "Predefined Group Three"),
+              Map.entry("connector", "Connector"),
+              Map.entry("output", "Output mapping"),
+              Map.entry("error", "Error handling"),
+              Map.entry("retries", "Retries")),
+          template,
+          false);
+    }
+
+    @Test
     void propertyGroups_orderedAndLabeledByAnnotation() {
       var template = generator.generate(MyConnectorFunction.FullyAnnotated.class).getFirst();
       checkPropertyGroups(
           List.of(
               Map.entry("group2", "Group Two"),
               Map.entry("group1", "Group One"),
+              Map.entry("customGroup", "Custom group"),
               Map.entry("connector", "Connector"),
               Map.entry("output", "Output mapping"),
               Map.entry("error", "Error handling"),
@@ -1004,6 +1021,7 @@ public class OutboundClassBasedTemplateGeneratorTest extends BaseTest {
       assertThat(template.id()).isNotNull();
       assertThat(template.id()).isEqualTo(OperationAnnotatedConnector.ID);
       assertThat(template.name()).isEqualTo(OperationAnnotatedConnector.NAME);
+      assertThat(template.properties()).hasSize(14);
 
       DropdownProperty operationProperty =
           (DropdownProperty) getPropertyById("operation", template);
@@ -1017,9 +1035,17 @@ public class OutboundClassBasedTemplateGeneratorTest extends BaseTest {
 
       var propOp1P1 = getPropertyById("operation-1:p1", template);
       assertThat(propOp1P1.getCondition()).isNotNull();
+      assertThat(propOp1P1.getGroup()).isNotNull();
+      assertThat(propOp1P1.getGroup()).isEqualTo("customGroup");
+
+      var customGroup =
+          template.groups().stream().filter(g -> g.id().equals("customGroup")).findFirst().get();
+      assertThat(customGroup.id()).isEqualTo("customGroup");
+      assertThat(customGroup.label()).isEqualTo("Custom Group");
 
       // Verify that the referenced operation property is properly prefixed
       var propOp1P2 = getPropertyById("operation-1:param2", template);
+      assertThat(propOp1P2.getGroup()).isEqualTo("operation");
       assertThat(propOp1P2.getCondition()).isInstanceOf(AllMatch.class);
       assertThat(((AllMatch) propOp1P2.getCondition()).allMatch())
           .containsExactlyInAnyOrder(

--- a/element-template-generator/core/src/test/java/io/camunda/connector/generator/java/example/outbound/MyConnectorFunction.java
+++ b/element-template-generator/core/src/test/java/io/camunda/connector/generator/java/example/outbound/MyConnectorFunction.java
@@ -16,6 +16,8 @@
  */
 package io.camunda.connector.generator.java.example.outbound;
 
+import static io.camunda.connector.generator.java.example.outbound.MyConnectorFunction.AllPropertiesInPredefinedGroups.*;
+
 import io.camunda.connector.api.annotation.OutboundConnector;
 import io.camunda.connector.api.outbound.OutboundConnectorContext;
 import io.camunda.connector.api.outbound.OutboundConnectorFunction;
@@ -39,10 +41,7 @@ public abstract class MyConnectorFunction implements OutboundConnectorFunction {
     return null;
   }
 
-  @OutboundConnector(
-      name = "my-connector",
-      type = "my-connector-type",
-      inputVariables = {})
+  @OutboundConnector(name = "my-connector", type = "my-connector-type")
   @ElementTemplate(
       engineVersion = "^8.7",
       id = MyConnectorFunction.ID,
@@ -66,10 +65,7 @@ public abstract class MyConnectorFunction implements OutboundConnectorFunction {
       })
   public static class FullyAnnotated extends MyConnectorFunction {}
 
-  @OutboundConnector(
-      name = "my-connector",
-      type = "my-connector-type",
-      inputVariables = {})
+  @OutboundConnector(name = "my-connector", type = "my-connector-type")
   @ElementTemplate(
       engineVersion = "^8.7",
       id = MyConnectorFunction.ID,
@@ -77,10 +73,26 @@ public abstract class MyConnectorFunction implements OutboundConnectorFunction {
       inputDataClass = MyConnectorInput.class)
   public static class MinimallyAnnotated extends MyConnectorFunction {}
 
-  @OutboundConnector(
-      name = "my-connector",
-      type = "my-connector-type",
-      inputVariables = {})
+  @OutboundConnector(name = "my-connector", type = "my-connector-type")
+  @ElementTemplate(
+      engineVersion = "^8.7",
+      id = MyConnectorFunction.ID,
+      name = MyConnectorFunction.NAME,
+      inputDataClass = PredefinedGroupInput.class,
+      propertyGroups = {
+        @PropertyGroup(id = "predefinedGroup1", label = "Predefined Group One"),
+        @PropertyGroup(id = "predefinedGroup2", label = "Predefined Group Two"),
+        @PropertyGroup(id = "predefinedGroup3", label = "Predefined Group Three")
+      })
+  public static class AllPropertiesInPredefinedGroups extends MyConnectorFunction {
+
+    record PredefinedGroupInput(
+        @TemplateProperty(group = "predefinedGroup1") String property1,
+        @TemplateProperty(group = "predefinedGroup2") String property2,
+        @TemplateProperty(group = "predefinedGroup3") String property3) {}
+  }
+
+  @OutboundConnector(name = "my-connector", type = "my-connector-type")
   @ElementTemplate(
       engineVersion = "^8.7",
       id = MyConnectorFunction.ID,
@@ -89,10 +101,7 @@ public abstract class MyConnectorFunction implements OutboundConnectorFunction {
       defaultResultVariable = "myResultVariable")
   public static class MinimallyAnnotatedWithResultVariable extends MyConnectorFunction {}
 
-  @OutboundConnector(
-      name = "my-connector",
-      type = "my-connector-type",
-      inputVariables = {})
+  @OutboundConnector(name = "my-connector", type = "my-connector-type")
   @ElementTemplate(
       engineVersion = "^8.7",
       id = MyConnectorFunction.ID,
@@ -101,10 +110,7 @@ public abstract class MyConnectorFunction implements OutboundConnectorFunction {
       defaultResultExpression = "={ myResponse: response }")
   public static class MinimallyAnnotatedWithResultExpression extends MyConnectorFunction {}
 
-  @OutboundConnector(
-      name = "my-connector",
-      type = "my-connector-type",
-      inputVariables = {})
+  @OutboundConnector(name = "my-connector", type = "my-connector-type")
   @ElementTemplate(
       engineVersion = "^8.7",
       id = MyConnectorFunction.ID,
@@ -122,10 +128,7 @@ public abstract class MyConnectorFunction implements OutboundConnectorFunction {
       })
   public static class MinimallyAnnotatedWithExtensionProperties extends MyConnectorFunction {}
 
-  @OutboundConnector(
-      name = "my-connector",
-      type = "my-connector-type",
-      inputVariables = {})
+  @OutboundConnector(name = "my-connector", type = "my-connector-type")
   @ElementTemplate(
       engineVersion = "^8.7",
       id = MyConnectorFunction.ID,
@@ -134,10 +137,7 @@ public abstract class MyConnectorFunction implements OutboundConnectorFunction {
       icon = "my-connector-icon.svg")
   public static class MinimallyAnnotatedWithSvgIcon extends MyConnectorFunction {}
 
-  @OutboundConnector(
-      name = "my-connector",
-      type = "my-connector-type",
-      inputVariables = {})
+  @OutboundConnector(name = "my-connector", type = "my-connector-type")
   @ElementTemplate(
       engineVersion = "^8.7",
       id = MyConnectorFunction.ID,
@@ -146,10 +146,7 @@ public abstract class MyConnectorFunction implements OutboundConnectorFunction {
       icon = "my-connector-icon.png")
   public static class MinimallyAnnotatedWithPngIcon extends MyConnectorFunction {}
 
-  @OutboundConnector(
-      name = "my-connector",
-      type = "my-connector-type",
-      inputVariables = {})
+  @OutboundConnector(name = "my-connector", type = "my-connector-type")
   @ElementTemplate(
       engineVersion = "^8.7",
       id = MyConnectorFunction.ID,
@@ -158,10 +155,7 @@ public abstract class MyConnectorFunction implements OutboundConnectorFunction {
       icon = "my-connector-icon.png")
   public static class WithDuplicatePropertyIds extends MyConnectorFunction {}
 
-  @OutboundConnector(
-      name = "my-connector",
-      type = "my-connector-type",
-      inputVariables = {})
+  @OutboundConnector(name = "my-connector", type = "my-connector-type")
   @ElementTemplate(
       engineVersion = "^8.7",
       id = MyConnectorFunction.ID,

--- a/element-template-generator/core/src/test/java/io/camunda/connector/generator/java/example/outbound/OperationAnnotatedConnector.java
+++ b/element-template-generator/core/src/test/java/io/camunda/connector/generator/java/example/outbound/OperationAnnotatedConnector.java
@@ -32,7 +32,8 @@ import io.camunda.connector.generator.java.annotation.TemplateProperty.PropertyC
 @ElementTemplate(
     engineVersion = "^8.8",
     id = OperationAnnotatedConnector.ID,
-    name = OperationAnnotatedConnector.NAME)
+    name = OperationAnnotatedConnector.NAME,
+    propertyGroups = {@ElementTemplate.PropertyGroup(id = "customGroup", label = "Custom Group")})
 public class OperationAnnotatedConnector implements OutboundConnectorProvider {
 
   public static final String ID = "operation-annotated-connector-id";
@@ -40,7 +41,13 @@ public class OperationAnnotatedConnector implements OutboundConnectorProvider {
   public static final String NAME = "Operation Annotated Connector";
 
   record Operation1Request(
-      @TemplateProperty(id = "p1") String param1,
+      @TemplateProperty(
+              id = "p1",
+              group = "customGroup",
+              label = "p1 Label",
+              description = "p1 Description",
+              tooltip = "p1 tooltip")
+          String param1,
       @TemplateProperty(condition = @PropertyCondition(property = "p1", equals = "myValue"))
           String param2) {}
 


### PR DESCRIPTION
## Description

This pull request improves the handling of property groups in the element template generator, making group assignment more robust and allowing for explicit group definitions via annotations for `@Operation` based Connectors.

**Enhancements to property group handling:**

* The generator now supports explicit assignment of properties to predefined groups via the `@ElementTemplate.PropertyGroup` annotation, ensuring properties are grouped and ordered as specified by the user. Properties not assigned to a group are handled more predictably. [[1]](diffhunk://#diff-097505a14eb0fde017bcec8f9a2eb68dbecc55ae0069cf0f15315c796fc864e4R124-R135) [[2]](diffhunk://#diff-097505a14eb0fde017bcec8f9a2eb68dbecc55ae0069cf0f15315c796fc864e4R153-R165) [[3]](diffhunk://#diff-08164d25b979964e0cf0ba4e0e59944d7768d21145a8c0b43c211e0206d9a6ddL69-R95) [[4]](diffhunk://#diff-08164d25b979964e0cf0ba4e0e59944d7768d21145a8c0b43c211e0206d9a6ddL104-R113) [[5]](diffhunk://#diff-08164d25b979964e0cf0ba4e0e59944d7768d21145a8c0b43c211e0206d9a6ddL125-R131) [[6]](diffhunk://#diff-08164d25b979964e0cf0ba4e0e59944d7768d21145a8c0b43c211e0206d9a6ddL137-R140) [[7]](diffhunk://#diff-08164d25b979964e0cf0ba4e0e59944d7768d21145a8c0b43c211e0206d9a6ddL149-R149) [[8]](diffhunk://#diff-08164d25b979964e0cf0ba4e0e59944d7768d21145a8c0b43c211e0206d9a6ddL161-R158)
* The `PropertyBuilder` and `PropertyGroupBuilder` classes now expose `getGroup()` and `getId()` methods, respectively, to facilitate group assignment and retrieval during template generation. [[1]](diffhunk://#diff-5dddfafb6a7dc9dda5c1f4d86eca4e72fd4703de8f58e18e1ad9f86be4ad639dR52-R55) [[2]](diffhunk://#diff-16fe7b2c38075e54a465076d509c121eb31947292d47961aa9d63d3f5c18f311R197-R200)
* The property mapping utility now ensures that a property’s group is only overwritten if it is not already set, preserving explicit group assignments.

**Code quality and maintainability:**

* The `PropertyGroupBuilder` class now implements `equals` and `hashCode`, improving reliability when comparing or storing group builders.
* Minor improvements such as import optimizations and null checks were added for robustness. [[1]](diffhunk://#diff-16fe7b2c38075e54a465076d509c121eb31947292d47961aa9d63d3f5c18f311R29) [[2]](diffhunk://#diff-097505a14eb0fde017bcec8f9a2eb68dbecc55ae0069cf0f15315c796fc864e4L32)

**Expanded test coverage and examples:**

* Tests now verify correct grouping and ordering of properties, including scenarios where all properties are assigned to predefined groups. [[1]](diffhunk://#diff-58c2c0bb2e4cacc9b55f5f98cff5715ee2624631291759b72040f7b297b67ee1R788-R812) [[2]](diffhunk://#diff-58c2c0bb2e4cacc9b55f5f98cff5715ee2624631291759b72040f7b297b67ee1R1024) [[3]](diffhunk://#diff-58c2c0bb2e4cacc9b55f5f98cff5715ee2624631291759b72040f7b297b67ee1R1038-R1048)
* Example connectors and test classes have been updated to demonstrate and validate the new group assignment and annotation features. [[1]](diffhunk://#diff-08164d25b979964e0cf0ba4e0e59944d7768d21145a8c0b43c211e0206d9a6ddL42-R44) [[2]](diffhunk://#diff-563dae1dd016a9461d4e63f9ade9aed8d94af7d8bd5e08c44507a278aa4e0f5eL35-R50)

These changes make property group handling more flexible and predictable, and improve the maintainability and test coverage of the codebase.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #6178 

## Checklist

- [x] PR has a **milestone** or the `no milestone` label.
- [x] Backport labels are added if these code changes should be backported. No backport label is added to the latest release, as this branch will be rebased onto main before the next release.

