### PR TITLE
other: notify PRs automatically, if the release is not an RC

### DIFF
--- a/.github/workflows/RELEASE.yaml
+++ b/.github/workflows/RELEASE.yaml
@@ -610,7 +610,8 @@ jobs:
       !contains(lower(inputs.version), 'rc') &&
       needs.setup.result == 'success' &&
       needs.maven-release.result == 'success' &&
-      needs.docker-release.result == 'success'
+      needs.docker-release.result == 'success' &&
+      needs.bundle-and-build-changelog.result == 'success'
     with:
       version: ${{ inputs.version }}
 


### PR DESCRIPTION
## Description
This pull request simplifies the release workflow by removing the `notify-prs` input parameter and ensuring that PR notifications are sent only for successful, non-RC releases. The changes also make the RC check case-insensitive and require both Maven and Docker releases to succeed before notifying PRs.

Workflow simplification:

* Removed the `notify-prs` input parameter from the workflow, streamlining the release process and reducing configuration complexity.

Notification logic improvements:

* Updated the condition to check for RC releases in a case-insensitive manner using `lower(inputs.version)`.
* Changed the logic to require both Maven and Docker releases to succeed (instead of allowing either to be skipped) before notifying PRs.