### PR TITLE
other: lower function doesn't exist

### DIFF
--- a/.github/workflows/RELEASE.yaml
+++ b/.github/workflows/RELEASE.yaml
@@ -607,7 +607,7 @@ jobs:
 
     # Automatically notify PRs for non-RC releases (case-insensitive check)
     if: |
-      !contains(lower(inputs.version), 'rc') &&
+      !contains(inputs.version, 'rc') &&
       needs.setup.result == 'success' &&
       needs.maven-release.result == 'success' &&
       needs.docker-release.result == 'success' &&


### PR DESCRIPTION
## Description

This pull request makes a minor update to the release workflow configuration. The change removes the redundant use of the `lower()` function when checking for 'rc' in the release version string, simplifying the condition.

- Simplified the condition in `.github/workflows/RELEASE.yaml` by removing the unnecessary `lower()` function from the check for 'rc' in the version string.