### PR TITLE
ci: fix TEST BRANCH job name

### DIFF
--- a/.github/workflows/NIGHTLY_E2E.yml
+++ b/.github/workflows/NIGHTLY_E2E.yml
@@ -32,7 +32,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  run-tests:
+  run-e2e-tests:
     name: (${{ matrix.branch }}) Nightly E2E test run
     needs: get-branches
     runs-on: ubuntu-latest

--- a/.github/workflows/TEST_FEATURE_BRANCH.yml
+++ b/.github/workflows/TEST_FEATURE_BRANCH.yml
@@ -18,7 +18,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  test-branch:
+  run-tests:
 
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Description

This pull request makes minor updates to the naming of jobs in GitHub Actions workflow files to improve clarity and consistency.
The goal is to use the same job name across all the branches, currently only main + 8.9 use the name `test-branch`. Other use the name `run-tests`.
This causes issues when configuring required tests, as the names are different for release-8.8.x and release-8.9.X for instance.

- **Workflow job renaming:**
  - Renamed the `run-tests` job to `run-e2e-tests` in the `.github/workflows/NIGHTLY_E2E.yml` file for clearer identification of end-to-end test runs.
  - Renamed the `test-branch` job to `run-tests` in the `.github/workflows/TEST_FEATURE_BRANCH.yml` file to standardize job naming.
