### PR TITLE
fix: remove @FEEL from Bearer token attribute

### DIFF
--- a/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/model/auth/BearerAuthentication.java
+++ b/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/model/auth/BearerAuthentication.java
@@ -6,15 +6,13 @@
  */
 package io.camunda.connector.http.base.model.auth;
 
-import io.camunda.connector.api.annotation.FEEL;
 import io.camunda.connector.generator.java.annotation.TemplateProperty;
 import io.camunda.connector.generator.java.annotation.TemplateSubType;
 import jakarta.validation.constraints.NotEmpty;
 
 @TemplateSubType(id = BearerAuthentication.TYPE, label = "Bearer token")
 public record BearerAuthentication(
-    @FEEL @NotEmpty @TemplateProperty(group = "authentication", label = "Bearer token")
-        String token)
+    @NotEmpty @TemplateProperty(group = "authentication", label = "Bearer token") String token)
     implements Authentication {
 
   @TemplateProperty(ignore = true)


### PR DESCRIPTION
## Description
This pull request makes a small change to the `BearerAuthentication` record by removing the `@FEEL` annotation from the `token` field. This simplifies the field's annotations and may affect how the token is processed or validated.

- Removed the `@FEEL` annotation from the `token` field in the `BearerAuthentication` record in `BearerAuthentication.java`.


This was missed during backports from main.