### PR TITLE
fix: apply A2A test case fix to connector tests

### DIFF
--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/TestUtil.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/TestUtil.java
@@ -16,13 +16,7 @@
  */
 package io.camunda.connector.e2e.agenticai;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.awaitility.Awaitility.await;
-
 import io.camunda.connector.e2e.ZeebeTest;
-import io.camunda.connector.runtime.inbound.executable.ActiveExecutableQuery;
-import io.camunda.connector.runtime.inbound.executable.InboundExecutableRegistry;
-import io.camunda.connector.runtime.inbound.state.ProcessDefinitionInspector;
 import io.camunda.process.test.api.CamundaAssert;
 import java.net.URI;
 import java.net.http.HttpClient;
@@ -73,21 +67,5 @@ public final class TestUtil {
             () ->
                 CamundaAssert.assertThat(zeebeTest.getProcessInstanceEvent())
                     .hasActiveElement(elementId, 1));
-  }
-
-  /** Waits until there are no active executables in the registry. */
-  public static void awaitNoActiveInboundExecutables(
-      ProcessDefinitionInspector processDefinitionInspector,
-      InboundExecutableRegistry executableRegistry) {
-    processDefinitionInspector.clearCache();
-
-    await("all executables should be cleaned up from previous tests")
-        .atMost(10, TimeUnit.SECONDS)
-        .untilAsserted(
-            () -> {
-              var allExecutables =
-                  executableRegistry.query(new ActiveExecutableQuery(null, null, null, null));
-              assertThat(allExecutables).isEmpty();
-            });
   }
 }

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/langchain4j/jobworker/L4JAiAgentJobWorkerA2aIntegrationTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/langchain4j/jobworker/L4JAiAgentJobWorkerA2aIntegrationTests.java
@@ -16,7 +16,6 @@
  */
 package io.camunda.connector.e2e.agenticai.aiagent.langchain4j.jobworker;
 
-import static io.camunda.connector.e2e.agenticai.TestUtil.awaitNoActiveInboundExecutables;
 import static io.camunda.connector.e2e.agenticai.TestUtil.postWithDelay;
 import static io.camunda.connector.e2e.agenticai.TestUtil.waitForElementActivation;
 import static io.camunda.connector.e2e.agenticai.aiagent.AiAgentTestFixtures.HAIKU_TEXT;
@@ -37,9 +36,9 @@ import io.camunda.connector.e2e.ElementTemplate;
 import io.camunda.connector.e2e.ZeebeTest;
 import io.camunda.connector.e2e.agenticai.aiagent.langchain4j.common.L4JAiAgentA2aIntegrationTestSupport;
 import io.camunda.connector.e2e.agenticai.assertj.JobWorkerAgentResponseAssert;
-import io.camunda.connector.runtime.inbound.executable.InboundExecutableRegistry;
+import io.camunda.connector.e2e.inbound.InboundConnectorTestConfiguration;
+import io.camunda.connector.e2e.inbound.InboundConnectorTestConfiguration.InboundConnectorTestHelper;
 import io.camunda.connector.runtime.inbound.importer.ImportSchedulers;
-import io.camunda.connector.runtime.inbound.state.ProcessDefinitionInspector;
 import io.camunda.connector.test.utils.annotation.SlowTest;
 import java.io.IOException;
 import java.util.List;
@@ -51,6 +50,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.context.annotation.Import;
 import org.springframework.core.io.Resource;
 import org.springframework.test.context.TestPropertySource;
 
@@ -60,13 +60,13 @@ import org.springframework.test.context.TestPropertySource;
       "camunda.connector.polling.enabled=true",
       "camunda.connector.webhook.enabled=true"
     })
+@Import(InboundConnectorTestConfiguration.class)
 public class L4JAiAgentJobWorkerA2aIntegrationTests extends BaseL4JAiAgentJobWorkerTest {
 
   public static final String WEBHOOK_ELEMENT_ID = "Wait_For_Completion_Webhook";
 
+  @Autowired private InboundConnectorTestHelper inboundConnectorTestHelper;
   @Autowired private ImportSchedulers importSchedulers;
-  @Autowired private InboundExecutableRegistry executableRegistry;
-  @Autowired private ProcessDefinitionInspector processDefinitionInspector;
 
   @Value("classpath:agentic-ai-ahsp-connectors-a2a.bpmn")
   protected Resource testProcessWithA2a;
@@ -85,9 +85,8 @@ public class L4JAiAgentJobWorkerA2aIntegrationTests extends BaseL4JAiAgentJobWor
     testSupport.setUpWireMockStubs(wireMock, (testFile) -> testFileContent(testFile).get());
     webhookUrl = "http://localhost:%s/inbound/test-webhook-id".formatted(port);
 
-    // Wait for any executables from previous tests to be cleaned up
-    // This prevents flakiness due to state carryover between tests
-    awaitNoActiveInboundExecutables(processDefinitionInspector, executableRegistry);
+    // clear process definition caches & reset executables from previous tests
+    inboundConnectorTestHelper.setUpTest();
   }
 
   @Override

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/langchain4j/outboundconnector/L4JAiAgentConnectorA2aIntegrationTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/langchain4j/outboundconnector/L4JAiAgentConnectorA2aIntegrationTests.java
@@ -16,7 +16,6 @@
  */
 package io.camunda.connector.e2e.agenticai.aiagent.langchain4j.outboundconnector;
 
-import static io.camunda.connector.e2e.agenticai.TestUtil.awaitNoActiveInboundExecutables;
 import static io.camunda.connector.e2e.agenticai.TestUtil.postWithDelay;
 import static io.camunda.connector.e2e.agenticai.TestUtil.waitForElementActivation;
 import static io.camunda.connector.e2e.agenticai.aiagent.AiAgentTestFixtures.HAIKU_TEXT;
@@ -37,9 +36,9 @@ import io.camunda.connector.e2e.ElementTemplate;
 import io.camunda.connector.e2e.ZeebeTest;
 import io.camunda.connector.e2e.agenticai.aiagent.langchain4j.common.L4JAiAgentA2aIntegrationTestSupport;
 import io.camunda.connector.e2e.agenticai.assertj.AgentResponseAssert;
-import io.camunda.connector.runtime.inbound.executable.InboundExecutableRegistry;
+import io.camunda.connector.e2e.inbound.InboundConnectorTestConfiguration;
+import io.camunda.connector.e2e.inbound.InboundConnectorTestConfiguration.InboundConnectorTestHelper;
 import io.camunda.connector.runtime.inbound.importer.ImportSchedulers;
-import io.camunda.connector.runtime.inbound.state.ProcessDefinitionInspector;
 import io.camunda.connector.test.utils.annotation.SlowTest;
 import java.io.IOException;
 import java.util.List;
@@ -51,6 +50,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.context.annotation.Import;
 import org.springframework.core.io.Resource;
 import org.springframework.test.context.TestPropertySource;
 
@@ -60,13 +60,13 @@ import org.springframework.test.context.TestPropertySource;
       "camunda.connector.polling.enabled=true",
       "camunda.connector.webhook.enabled=true"
     })
+@Import(InboundConnectorTestConfiguration.class)
 public class L4JAiAgentConnectorA2aIntegrationTests extends BaseL4JAiAgentConnectorTest {
 
   public static final String WEBHOOK_ELEMENT_ID = "Wait_For_Completion_Webhook";
 
+  @Autowired private InboundConnectorTestHelper inboundConnectorTestHelper;
   @Autowired private ImportSchedulers importSchedulers;
-  @Autowired private InboundExecutableRegistry executableRegistry;
-  @Autowired private ProcessDefinitionInspector processDefinitionInspector;
 
   @Value("classpath:agentic-ai-connectors-a2a.bpmn")
   protected Resource testProcessWithA2a;
@@ -85,9 +85,8 @@ public class L4JAiAgentConnectorA2aIntegrationTests extends BaseL4JAiAgentConnec
     testSupport.setUpWireMockStubs(wireMock, (testFile) -> testFileContent(testFile).get());
     webhookUrl = "http://localhost:%s/inbound/test-webhook-id".formatted(port);
 
-    // Wait for any executables from previous tests to be cleaned up
-    // This prevents flakiness due to state carryover between tests
-    awaitNoActiveInboundExecutables(processDefinitionInspector, executableRegistry);
+    // clear process definition caches & reset executables from previous tests
+    inboundConnectorTestHelper.setUpTest();
   }
 
   @Override

--- a/connectors-e2e-test/connectors-e2e-test-base/pom.xml
+++ b/connectors-e2e-test/connectors-e2e-test-base/pom.xml
@@ -59,6 +59,7 @@
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
+            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.skyscreamer</groupId>

--- a/connectors-e2e-test/connectors-e2e-test-base/src/main/java/io/camunda/connector/e2e/inbound/InboundConnectorTestConfiguration.java
+++ b/connectors-e2e-test/connectors-e2e-test-base/src/main/java/io/camunda/connector/e2e/inbound/InboundConnectorTestConfiguration.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.e2e.inbound;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import io.camunda.connector.runtime.inbound.executable.ActiveExecutableQuery;
+import io.camunda.connector.runtime.inbound.executable.InboundExecutableRegistry;
+import io.camunda.connector.runtime.inbound.state.ProcessDefinitionInspector;
+import java.time.Duration;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+
+@TestConfiguration
+public class InboundConnectorTestConfiguration {
+
+  @Bean
+  public InboundConnectorTestHelper inboundConnectorTestHelper(
+      ProcessDefinitionInspector processDefinitionInspector,
+      InboundExecutableRegistry executableRegistry) {
+    return new InboundConnectorTestHelper(processDefinitionInspector, executableRegistry);
+  }
+
+  public static class InboundConnectorTestHelper {
+
+    private static final Duration DEFAULT_AWAIT_NO_EXECUTABLES_TIMEOUT = Duration.ofSeconds(10);
+
+    private final ProcessDefinitionInspector processDefinitionInspector;
+    private final InboundExecutableRegistry executableRegistry;
+
+    public InboundConnectorTestHelper(
+        ProcessDefinitionInspector processDefinitionInspector,
+        InboundExecutableRegistry executableRegistry) {
+      this.processDefinitionInspector = processDefinitionInspector;
+      this.executableRegistry = executableRegistry;
+    }
+
+    public void setUpTest() {
+      // PD keys can duplicate across tests (this does not happen in real world)
+      // So we clear the inspector cache to avoid cross-test interference
+      clearProcessDefinitionCache();
+
+      // Wait for any executables from previous tests to be cleaned up
+      // This prevents flakiness due to state carryover between tests
+      awaitNoActiveInboundExecutables();
+    }
+
+    public void clearProcessDefinitionCache() {
+      processDefinitionInspector.clearCache();
+    }
+
+    /** Waits until there are no active executables in the registry. */
+    public void awaitNoActiveInboundExecutables() {
+      awaitNoActiveInboundExecutables(DEFAULT_AWAIT_NO_EXECUTABLES_TIMEOUT);
+    }
+
+    /** Waits until there are no active executables in the registry. */
+    public void awaitNoActiveInboundExecutables(Duration waitDuration) {
+      await("all executables should be cleaned up from previous tests")
+          .atMost(waitDuration)
+          .untilAsserted(
+              () -> {
+                var allExecutables =
+                    executableRegistry.query(new ActiveExecutableQuery(null, null, null, null));
+                assertThat(allExecutables).isEmpty();
+              });
+    }
+  }
+}


### PR DESCRIPTION
## Description

Applies A2A test fixes implemented in #6209 to the connector tests as well (we adapted the job worker + standalone tests, but missed this one) + extracts the needed setup into a reusable test helper component.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #

## Checklist

- [x] Backport labels are added if these code changes should be backported. No backport label is added to the latest
  release, as this branch will be rebased onto main before the next release. Example backport labels:
    - `backport stable/8.8`: for changes that should be included in the next 8.8.x release.
    - **or** `backport release-8.8.7`: for changes that should be included in the specific release 8.8.7, and this
      *release has already been created*. The release branch will be merged back into stable/8.8 later, so the change
      will be included in future 8.8.x releases as well.
- [ ] Tests/Integration tests for the changes have been added if applicable.

