### PR TITLE
ci: fix job names

### DIFF
--- a/.github/workflows/BUILD_FEATURE_BRANCH.yaml
+++ b/.github/workflows/BUILD_FEATURE_BRANCH.yaml
@@ -7,7 +7,7 @@ on:
       - '!main'
 
 jobs:
-  run-tests:
+  build-pr-image-and-push:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/NIGHTLY_E2E.yml
+++ b/.github/workflows/NIGHTLY_E2E.yml
@@ -31,7 +31,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  run-tests:
+  run-e2e-tests:
     name: (${{ matrix.branch }}) Nightly E2E test run
     needs: get-branches
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description
This pull request updates the naming of jobs in two GitHub Actions workflow files to provide clearer descriptions of their purposes.

Workflow job renaming:

* Renamed the `run-tests` job to `build-pr-image-and-push` in `.github/workflows/BUILD_FEATURE_BRANCH.yaml` to more accurately reflect that the job builds and pushes a PR image.
* Renamed the `run-tests` job to `run-e2e-tests` in `.github/workflows/NIGHTLY_E2E.yml` to clarify that the job is responsible for running nightly end-to-end tests.