### PR TITLE
feat: Add instructions to prevent META-INF file generation

### DIFF
--- a/element-template-generator/maven-plugin/README.md
+++ b/element-template-generator/maven-plugin/README.md
@@ -121,3 +121,23 @@ If used together with `generateHybridTemplates`, the file name of the hybrid tem
 If the element template is generated for multiple element types, the file name will be
 `my-custom-template-<element-type>.json`. If used together with `generateHybridTemplates`, the
 file name of the hybrid template will be `my-custom-template-<element-type>-hybrid.json`.
+
+## Prevent generation of META-INF file
+
+If the connector is meant to function as spring bean only (because it needs to inject beans in order to function properly), you will have to prevent the generation of the META-INF file for SPI.
+
+This can be done like this:
+
+```xml
+
+<configuration>
+  <connectors>
+    <connector>
+      <connectorClass>io.camunda.connector.MyConnector</connectorClass>
+      <writeMetaInfFileGeneration>false</writeMetaInfFileGeneration>
+    </connector>
+  </connectors>
+</configuration>
+```
+
+Otherwise, the according META-INF file is created.


### PR DESCRIPTION

## Description

<!-- Please explain the changes you made here. -->
Added instructions to prevent generation of META-INF file for SPI when using the connector as a Spring bean.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #

## Checklist

- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest
  release, as this branch will be rebased onto main before the next release. Example backport labels:
    - `backport stable/8.8`: for changes that should be included in the next 8.8.x release.
    - **or** `backport release-8.8.7`: for changes that should be included in the specific release 8.8.7, and this
      *release has already been created*. The release branch will be merged back into stable/8.8 later, so the change
      will be included in future 8.8.x releases as well.
- [ ] Tests/Integration tests for the changes have been added if applicable.

