### PR TITLE
fix: Remove dynamic team lookup as we are lacking permission with our token

### DIFF
--- a/.github/workflows/AUTO_ASSIGN.yml
+++ b/.github/workflows/AUTO_ASSIGN.yml
@@ -24,18 +24,12 @@ jobs:
       github.event.pull_request.head.repo.full_name == github.repository &&
       contains(github.event.pull_request.requested_teams.*.slug, 'connectors')
     steps:
-      - id: get-members
-        uses: garnertb/get-team-members@v1
-        with:
-          org: camunda
-          team_slug: connectors
-          token: ${{ secrets.GITHUB_TOKEN }}
       - name: Assign Reviewer
         uses: Joxtacy/auto-assign-reviewers@v0.1.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           # Team members to consider for assignment can later be fetched from GitHub automatically
-          team_members: ${{ steps.get-members.outputs.members }}
+          team_members: 'sbuettner,ztefanie,johnBgood,vringar,mathias-vandaele,chillleader'
           # Adjust these weights to prioritize different factors
           weight_open_prs: 0          # Default: 10
           weight_lines_per_100: 0     # Default: 1


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #

## Checklist

- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest
  release, as this branch will be rebased onto main before the next release. Example backport labels:
    - `backport stable/8.8`: for changes that should be included in the next 8.8.x release.
    - **or** `backport release-8.8.7`: for changes that should be included in the specific release 8.8.7, and this
      *release has already been created*. The release branch will be merged back into stable/8.8 later, so the change
      will be included in future 8.8.x releases as well.
- [ ] Tests/Integration tests for the changes have been added if applicable.

