### PR TITLE
fix(slack): fix plaintext wrapping and formatting #5807

### DIFF
--- a/connectors/slack/src/main/java/io/camunda/connector/slack/outbound/model/ChatPostMessageData.java
+++ b/connectors/slack/src/main/java/io/camunda/connector/slack/outbound/model/ChatPostMessageData.java
@@ -123,12 +123,22 @@ public record ChatPostMessageData(
     if (StringUtils.isNotBlank(thread)) {
       requestBuilder.threadTs(thread);
     }
-    requestBuilder.blocks(
-        BlockBuilder.create(new FileUploader(methodsClient))
-            .documents(documents)
-            .text(text)
-            .blockContent(blockContent)
-            .getLayoutBlocks());
+    if (MessageType.plainText.equals(messageType)) {
+      requestBuilder.text(text);
+      if (documents != null && !documents.isEmpty()) {
+        requestBuilder.blocks(
+            BlockBuilder.create(new FileUploader(methodsClient))
+                .documents(documents)
+                .getLayoutBlocks());
+      }
+    } else {
+      requestBuilder.blocks(
+          BlockBuilder.create(new FileUploader(methodsClient))
+              .documents(documents)
+              .text(text)
+              .blockContent(blockContent)
+              .getLayoutBlocks());
+    }
     ChatPostMessageResponse chatPostMessageResponse =
         methodsClient.chatPostMessage(requestBuilder.build());
     if (chatPostMessageResponse.isOk()) {

--- a/connectors/slack/src/test/java/io/camunda/connector/slack/outbound/model/ChatPostMessageDataTest.java
+++ b/connectors/slack/src/test/java/io/camunda/connector/slack/outbound/model/ChatPostMessageDataTest.java
@@ -260,7 +260,7 @@ class ChatPostMessageDataTest {
         new ChatPostMessageData(
             "test@test.com",
             "thread_ts",
-            MessageType.plainText,
+            MessageType.messageBlock,
             "test",
             objectMapper.readTree(blockContent),
             List.of());


### PR DESCRIPTION
## Description

fixed a bug where long text messages (85+ characters) were wrapping and treadted as blocks layout in slack ui. i have seprated the logic, now plaintexts messages are using standard slack text field and now taking full width in chat window.

this issue came from these two commits 
https://github.com/camunda/connectors/commit/c95a1a9f87656e7323bcc17e6a421283c68e5714 this was root commit which caused the issue
this commit https://github.com/camunda/connectors/commit/eb7d7d001d2f304dbe9e7ce831c451659eba11ff removed the separate code path for plaintex (after this there was only one way to send message which was blocks).

<img width="947" height="500" alt="Untitled drawing" src="https://github.com/user-attachments/assets/f693d812-19b2-4cda-adbe-bc5a6a9fc079" />


## Related issues

closes #5807

## Checklist

- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest
  release, as this branch will be rebased onto main before the next release. Example backport labels:
    - `backport stable/8.8`: for changes that should be included in the next 8.8.x release.
    - **or** `backport release-8.8.7`: for changes that should be included in the specific release 8.8.7, and this
      *release has already been created*. The release branch will be merged back into stable/8.8 later, so the change
      will be included in future 8.8.x releases as well.
- [x] Tests/Integration tests for the changes have been added if applicable.

