### PR TITLE
chore(ci): Use GH app for team members

### DIFF
--- a/.github/workflows/AUTO_ASSIGN.yml
+++ b/.github/workflows/AUTO_ASSIGN.yml
@@ -60,7 +60,6 @@ jobs:
         uses: Joxtacy/auto-assign-reviewers@v0.1.0
         with:
           github_token: ${{ steps.app-token.outputs.token }}
-          # Team members to consider for assignment can later be fetched from GitHub automatically
           team_members: ${{ steps.get-members.outputs.team_members }}
           # Adjust these weights to prioritize different factors
           weight_open_prs: 0          # Default: 10


### PR DESCRIPTION
## Description

This pull request updates the `.github/workflows/AUTO_ASSIGN.yml` workflow to securely fetch team member information and credentials from HashiCorp Vault, and to generate a GitHub App token dynamically for reviewer assignment. This enhances security and automation by removing hardcoded secrets and team member lists.

**Security and automation improvements:**

* Added a step to import secrets (`GITHUB_APP_ID` and `GITHUB_APP_PRIVATE_KEY`) from HashiCorp Vault using the `hashicorp/vault-action` for secure credential management.
* Introduced a step to generate a GitHub App token dynamically using the imported credentials, replacing the use of the static `GITHUB_TOKEN`.

**Reviewer assignment enhancements:**

* Added a step to fetch the current list of team members from the GitHub API, removing the need to maintain a hardcoded list.
* Updated the reviewer assignment step to use the dynamically generated GitHub App token and the fetched team members list, improving flexibility and security.
