### PR TITLE
ci: fix surefire report names in E2E test workflow

### DIFF
--- a/.github/workflows/NIGHTLY_E2E.yml
+++ b/.github/workflows/NIGHTLY_E2E.yml
@@ -1,4 +1,4 @@
-name: Nightly E2E test run
+name: E2E test run
 
 on:
   workflow_dispatch:
@@ -103,9 +103,11 @@ jobs:
         if: always()
         uses: scacap/action-surefire-report@v1
 
-      - name: Sanitize branch name
+      - name: Sanitize branch name for artifact
         id: sanitize
-        run: echo "SANITIZED_BRANCH=${BRANCH//\//-}" >> $GITHUB_ENV
+        run: |
+          SANITIZED="${BRANCH//\//-}"
+          echo "branch=$SANITIZED" >> $GITHUB_OUTPUT
         env:
           BRANCH: ${{ matrix.branch }}
 
@@ -113,7 +115,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v6
         with:
-          name: surefire-reports-${{ env.SANITIZED_BRANCH }}
+          name: surefire-reports-${{ steps.sanitize.outputs.branch }}-${{ github.run_id }}-${{ github.run_attempt }}
           path: '**/target/surefire-reports/*.xml'
 
       - name: Send Slack notification on failure


### PR DESCRIPTION
## Description

This pull request updates the `.github/workflows/NIGHTLY_E2E.yml` workflow configuration to improve artifact naming and clarify step descriptions. The most significant changes are focused on how branch names are sanitized and how artifacts are named for easier identification.

**Workflow improvements:**

* Changed the workflow name from "Nightly E2E test run" to "E2E test run" for broader applicability.

**Artifact naming and branch sanitization:**

* Updated the "Sanitize branch name" step to output the sanitized branch name as `branch` using `GITHUB_OUTPUT`, improving compatibility with later steps.
* Enhanced the artifact upload step to use the sanitized branch name along with the GitHub run ID and attempt number in the artifact name, making artifacts easier to identify and distinguish between runs.
* Clarified the name of the branch sanitization step to "Sanitize branch name for artifact" for better readability.