### PR TITLE
fix(hugging-face): updated hugging face connector template

### DIFF
--- a/connectors/hugging-face/element-templates/hugging-face-connector.json
+++ b/connectors/hugging-face/element-templates/hugging-face-connector.json
@@ -2,7 +2,7 @@
   "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
   "name": "Hugging Face Outbound Connector",
   "id": "io.camunda.connectors.HuggingFace.v1",
-  "version": 2,
+  "version": 3,
   "engines": {
     "camunda": "^8.5"
   },
@@ -58,7 +58,7 @@
       "label": "Hugging Face API key",
       "group": "authentication",
       "feel": "optional",
-      "description": "Your Hugging Face API key",
+      "description": "Your Hugging Face API key. Get one at <a href=\"https://huggingface.co/settings/tokens\" target=\"_blank\">huggingface.co/settings/tokens</a>",
       "type": "String",
       "binding": {
         "type": "zeebe:input",
@@ -69,31 +69,40 @@
       }
     },
     {
-      "label": "Model",
+      "label": "Model ID",
       "group": "input",
       "feel": "optional",
-      "description": "Desired model name",
+      "description": "Full model repository ID (e.g., meta-llama/Llama-3.2-3B-Instruct, mistralai/Mistral-7B-Instruct-v0.3). Browse models at <a href=\"https://huggingface.co/models\" target=\"_blank\">huggingface.co/models</a>",
       "type": "String",
       "binding": {
         "type": "zeebe:input",
-        "name": "modelName"
+        "name": "modelId"
       },
       "constraints": {
         "notEmpty": true
       }
     },
     {
-      "label": "Input",
+      "label": "Messages",
       "group": "input",
       "feel": "required",
-      "description": "Desired input for your model. <a href=\"https://huggingface.co/docs/api-inference/detailed_parameters\" target=\"_blank\">See official documentation</a>",
+      "description": "Chat messages array in format: [{\"role\": \"user\", \"content\": \"Your message\"}]. Use 'system' role for instructions and 'user' role for queries. <a href=\"https://huggingface.co/docs/inference-providers/index#http--curl\" target=\"_blank\">See documentation</a>",
       "type": "Text",
       "binding": {
         "type": "zeebe:input",
-        "name": "body"
+        "name": "messages"
       },
       "constraints": {
         "notEmpty": true
+      }
+    },
+    {
+      "id": "bodyExpression",
+      "type": "Hidden",
+      "value": "={\"model\": modelId, \"messages\": messages, \"stream\": false}",
+      "binding": {
+        "type": "zeebe:input",
+        "name": "body"
       }
     },
     {
@@ -109,7 +118,7 @@
     {
       "group": "endpoint",
       "type": "Hidden",
-      "value": "=\"https://api-inference.huggingface.co/models/\"+modelName",
+      "value": "=\"https://router.huggingface.co/v1/chat/completions\"",
       "binding": {
         "type": "zeebe:input",
         "name": "url"
@@ -127,7 +136,7 @@
     },
     {
       "label": "Result expression",
-      "description": "Expression to map the response into process variables. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-expression\" target=\"_blank\">documentation</a>",
+      "description": "Expression to map the response into process variables. For chat completion, use: =response.body.choices[1].message.content to get the AI response. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-expression\" target=\"_blank\">documentation</a>",
       "group": "output",
       "type": "Text",
       "feel": "required",
@@ -171,7 +180,7 @@
       "id": "version",
       "label": "Version",
       "description": "Version of the element template",
-      "value": "2",
+      "value": "3",
       "group": "connector",
       "binding": {
         "key": "elementTemplateVersion",


### PR DESCRIPTION
## Description
Fixed hugging face connector issue, we were getting **410 gone** status because hugging face old endpoint is no more supported and now they have new endpoint `https://router.huggingface.co/v1/chat/completions`.

They also changed the request format. 

**Request format:**
```
{
  "model":"openai/gpt-oss-120b",
  "messages":[
    {"role":"user","content":"Hello!"}
  ],
  "stream":false
}
```

and now their response contains an array of choices. To get **content** we have to use this `response.choices[0].message.content`

**Payload change**: The connector now builds the request body as a JSON object using a hidden input (bodyExpression) with this structure:
```
{
      "id": "bodyExpression",
      "type": "Hidden",
      "value": "={\"model\": modelId, \"messages\": messages, \"stream\": false}",
      "binding": {
        "type": "zeebe:input",
        "name": "body"
      }
}
```

**Template screenshot:**
<br>
<img width="795" height="582" alt="hf-template" 
     src="https://github.com/user-attachments/assets/434f5312-f714-4043-8c9d-7874c050f444" 
     style="border:2px solid #ccc; box-shadow: 3px 3px 8px rgba(0,0,0,0.3); margin-bottom:20px;" />

**Operate screenshot:**
<br>
<img width="864" height="560" alt="hf-operate" 
     src="https://github.com/user-attachments/assets/803d12c5-2960-470f-84a0-8a45e3be0eb1" 
     style="border:2px solid #ccc; box-shadow: 3px 3px 8px rgba(0,0,0,0.3);" />


This is breaking change because users have to follow request/response format.


<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #6302

## Checklist

- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest
  release, as this branch will be rebased onto main before the next release. Example backport labels:
    - `backport stable/8.8`: for changes that should be included in the next 8.8.x release.
    - **or** `backport release-8.8.7`: for changes that should be included in the specific release 8.8.7, and this
      *release has already been created*. The release branch will be merged back into stable/8.8 later, so the change
      will be included in future 8.8.x releases as well.
- [ ] Tests/Integration tests for the changes have been added if applicable.

