### PR TITLE
fix: Fix validation for non-present query parameters in openai compatible config

### DIFF
--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/provider/OpenAiCompatibleProviderConfiguration.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/provider/OpenAiCompatibleProviderConfiguration.java
@@ -52,8 +52,7 @@ public record OpenAiCompatibleProviderConfiguration(
               description = "Map of query parameters to add to the request URL.",
               feel = Property.FeelMode.required,
               optional = true)
-          @Valid
-          Map<@NotBlank String, String> queryParameters,
+          Map<String, String> queryParameters,
       @Valid TimeoutConfiguration timeouts,
       @Valid @NotNull OpenAiCompatibleModel model) {}
 


### PR DESCRIPTION
## Description

Removing validation annotations on the optional and later introduced `queryParameters` of `OpenAiCompatibleConnection` as it was not null-lenient in that case.

## Related issues
-

## Checklist

- [x] Backport labels are added if these code changes should be backported. No backport label is added to the latest
  release, as this branch will be rebased onto main before the next release. Example backport labels:
    - `backport stable/8.8`: for changes that should be included in the next 8.8.x release.
    - **or** `backport release-8.8.7`: for changes that should be included in the specific release 8.8.7, and this
      *release has already been created*. The release branch will be merged back into stable/8.8 later, so the change
      will be included in future 8.8.x releases as well.
- [x] Tests/Integration tests for the changes have been added if applicable.

