### PR TITLE
fix(ci): ensure sanitize step runs even when build fails

### DIFF
--- a/.github/workflows/NIGHTLY_E2E.yml
+++ b/.github/workflows/NIGHTLY_E2E.yml
@@ -104,6 +104,7 @@ jobs:
         uses: scacap/action-surefire-report@v1
 
       - name: Sanitize branch name for artifact
+        if: always()
         id: sanitize
         run: |
           SANITIZED="${BRANCH//\//-}"


### PR DESCRIPTION
## Description

Fix E2E workflow artifact upload issue where all branches were uploading artifacts with the same name (e.g., `surefire-reports--21851137202-1`), causing conflicts.

**Root cause:** When the "Build Connectors" step fails, the "Sanitize branch name for artifact" step was skipped (no `if: always()`), leaving `steps.sanitize.outputs.branch` empty. The upload step (which has `if: always()`) then ran with an empty branch name, resulting in all matrix jobs generating identical artifact names.

**Fix:** Added `if: always()` to the sanitize step to ensure it runs even when the build fails, so each branch gets a properly named artifact like `surefire-reports-main-21851137202-1`, `surefire-reports-stable-8.6-21851137202-1`, etc.

## Related issues

N/A - Found during investigation of workflow run failure

## Checklist

- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest
  release, as this branch will be rebased onto main before the next release. Example backport labels:
    - `backport stable/8.8`: for changes that should be included in the next 8.8.x release.
    - **or** `backport release-8.8.7`: for changes that should be included in the specific release 8.8.7, and this
      *release has already been created*. The release branch will be merged back into stable/8.8 later, so the change
      will be included in future 8.8.x releases as well.
- [x] Tests/Integration tests for the changes have been added if applicable. (N/A - workflow change only)