### PR TITLE
ci: always check for updated SNAPSHOT dependencies in CI

### DIFF
--- a/.github/workflows/DEPLOY_SNAPSHOTS.yaml
+++ b/.github/workflows/DEPLOY_SNAPSHOTS.yaml
@@ -114,7 +114,7 @@ jobs:
           echo "::notice::Docker version will be: ${MINOR_VERSION}-SNAPSHOT"
 
       - name: Build Artifacts
-        run: mvn -B compile generate-sources source:jar javadoc:jar deploy -DskipTests
+        run: mvn -B -U compile generate-sources source:jar javadoc:jar deploy -DskipTests
         env:
           MAVEN_USERNAME: ${{ steps.secrets.outputs.ARTIFACTORY_USR }}
           MAVEN_PASSWORD: ${{ steps.secrets.outputs.ARTIFACTORY_PSW }}

--- a/.github/workflows/NIGHTLY_E2E.yml
+++ b/.github/workflows/NIGHTLY_E2E.yml
@@ -97,7 +97,7 @@ jobs:
         run: npm install --global element-templates-cli@$(jq -r '.devDependencies["element-templates-cli"]' .github/workflows/package.json)
 
       - name: Build Connectors
-        run: mvn --batch-mode clean test -PcheckFormat
+        run: mvn --batch-mode -U clean test -PcheckFormat
 
       - name: Publish Test Report
         if: always()

--- a/.github/workflows/RELEASE.yaml
+++ b/.github/workflows/RELEASE.yaml
@@ -122,7 +122,7 @@ jobs:
           RELEASE_VERSION: ${{ inputs.version }}
 
       - name: Compile and Test
-        run: mvn -B package generate-sources source:jar javadoc:jar
+        run: mvn -B -U package generate-sources source:jar javadoc:jar
 
       - name: Publish Test Report
         if: always()
@@ -312,7 +312,7 @@ jobs:
 
       - name: Deploy artifacts to Artifactory and Maven Central (Staging)
         if: "! contains(inputs.version, 'rc')"
-        run: mvn deploy -DskipTests -PcheckFormat -Pcentral-sonatype-publish -Pe2eExcluded
+        run: mvn -U deploy -DskipTests -PcheckFormat -Pcentral-sonatype-publish -Pe2eExcluded
         env:
           NEXUS_USR: ${{ steps.secrets.outputs.ARTIFACTORY_USR }}
           NEXUS_PSW: ${{ steps.secrets.outputs.ARTIFACTORY_PSW }}
@@ -322,7 +322,7 @@ jobs:
 
       - name: Deploy artifacts to Artifactory
         if: "contains(inputs.version, 'rc')"
-        run: mvn deploy -DskipTests -PcheckFormat -Pcentral-sonatype-publish -Dskip.central.release=true -Pe2eExcluded
+        run: mvn -U deploy -DskipTests -PcheckFormat -Pcentral-sonatype-publish -Dskip.central.release=true -Pe2eExcluded
         env:
           NEXUS_USR: ${{ steps.secrets.outputs.ARTIFACTORY_USR }}
           NEXUS_PSW: ${{ steps.secrets.outputs.ARTIFACTORY_PSW }}

--- a/.github/workflows/RUN_UNIQUET.yml
+++ b/.github/workflows/RUN_UNIQUET.yml
@@ -20,7 +20,7 @@ jobs:
 
       - name: install-uniquet
         run: |
-          mvn install -DskipTests -pl element-template-generator/uniquet -am
+          mvn -U install -DskipTests -pl element-template-generator/uniquet -am
 
       - name: run-uniquet
         run: |

--- a/.github/workflows/TEST_FEATURE_BRANCH.yml
+++ b/.github/workflows/TEST_FEATURE_BRANCH.yml
@@ -109,7 +109,7 @@ jobs:
 
       # Build
       - name: Build Connectors
-        run: mvn --batch-mode clean test javadoc:javadoc -PcheckFormat -Dquickly
+        run: mvn --batch-mode -U clean test javadoc:javadoc -PcheckFormat -Dquickly
 
       - name: Publish Test Report
         if: always() && steps.internal.outputs.internal == 'true'


### PR DESCRIPTION
## Description

Add `-U` flag to Maven **build, test, and deploy** commands in CI workflows to force checking for updated SNAPSHOT dependencies on remote repositories. This prevents issues with stale or broken SNAPSHOT dependencies being cached in CI, which can cause intermittent test failures.

According to the [Maven CLI documentation](https://maven.apache.org/ref/current/maven-embedder/cli.html), the `-U` flag:
> **Forces a check for missing releases and updated snapshots on remote repositories**

This bypasses Maven's default 'daily' updatePolicy and ensures CI always uses the latest available SNAPSHOT versions.

### Scope of changes

The `-U` flag is added **only to commands that resolve dependencies**:
- `mvn clean test` / `mvn package` / `mvn install` / `mvn deploy` - build and deployment commands
- `mvn compile generate-sources source:jar javadoc:jar` - artifact generation

Commands that **do not** resolve SNAPSHOT dependencies remain unchanged:
- `mvn versions:set` - only sets project version, doesn't resolve dependencies
- `mvn help:evaluate` - only evaluates project properties
- `mvn cyclonedx:makeAggregateBom` - generates SBOM from already-resolved dependencies

### Why `-U` flag instead of `updatePolicy: always`?

Maven's `updatePolicy` setting is **per-repository**, not a global configuration. To achieve the same effect via `updatePolicy`, we would need to:

1. Define a profile in `maven-settings-action`
2. Explicitly configure **every repository** used in the build (central, camunda-nexus, confluent, shibboleth, etc.)
3. Set `<updatePolicy>always</updatePolicy>` in the `<snapshots>` section for each repository individually

The `-U` flag provides a simpler, more maintainable solution:
- **Single point of control**: One flag per Maven command instead of maintaining repository configurations
- **Applies globally**: Automatically covers all repositories without explicit enumeration
- **Explicit and visible**: The intent is immediately clear when reading the workflow
- **Less configuration overhead**: No need to keep settings.xml profiles in sync with repository changes

## Related issues

Related to investigation of test failures in PR #5988 where upstream SNAPSHOT dependencies may have caused transient CI failures.

## Checklist

- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest
  release, as this branch will be rebased onto main before the next release. Example backport labels:
    - `backport stable/8.8`: for changes that should be included in the next 8.8.x release.
    - **or** `backport release-8.8.7`: for changes that should be included in the specific release 8.8.7, and this
      *release has already been created*. The release branch will be merged back into stable/8.8 later, so the change
      will be included in future 8.8.x releases as well.
- [x] Tests/Integration tests for the changes have been added if applicable.