### PR TITLE
feat(agentic-ai): configure connectors HTTP proxy on MCP client connections

### DIFF
--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/autoconfigure/AgenticAiConnectorsAutoConfiguration.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/autoconfigure/AgenticAiConnectorsAutoConfiguration.java
@@ -58,11 +58,14 @@ import io.camunda.connector.agenticai.aiagent.systemprompt.SystemPromptContribut
 import io.camunda.connector.agenticai.aiagent.tool.GatewayToolHandler;
 import io.camunda.connector.agenticai.aiagent.tool.GatewayToolHandlerRegistry;
 import io.camunda.connector.agenticai.aiagent.tool.GatewayToolHandlerRegistryImpl;
+import io.camunda.connector.agenticai.common.AgenticAiHttpSupport;
 import io.camunda.connector.agenticai.mcp.client.configuration.McpClientConfiguration;
 import io.camunda.connector.agenticai.mcp.client.configuration.McpRemoteClientConfiguration;
 import io.camunda.connector.agenticai.mcp.discovery.configuration.McpDiscoveryConfiguration;
 import io.camunda.connector.api.document.DocumentFactory;
 import io.camunda.connector.api.validation.ValidationProvider;
+import io.camunda.connector.http.client.client.jdk.proxy.JdkHttpClientProxyConfigurator;
+import io.camunda.connector.http.client.proxy.ProxyConfiguration;
 import io.camunda.connector.runtime.annotation.ConnectorsObjectMapper;
 import io.camunda.connector.runtime.core.ConnectorResultHandler;
 import io.camunda.connector.runtime.core.document.store.CamundaDocumentStore;
@@ -94,6 +97,12 @@ import org.springframework.core.env.Environment;
   A2aClientWebhookConfiguration.class
 })
 public class AgenticAiConnectorsAutoConfiguration {
+
+  @Bean
+  @ConditionalOnMissingBean
+  public AgenticAiHttpSupport agenticAiHttpSupport() {
+    return new AgenticAiHttpSupport(new JdkHttpClientProxyConfigurator(new ProxyConfiguration()));
+  }
 
   @Bean
   @ConditionalOnMissingBean

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/common/AgenticAiHttpSupport.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/common/AgenticAiHttpSupport.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.agenticai.common;
+
+import io.camunda.connector.http.client.client.jdk.proxy.JdkHttpClientProxyConfigurator;
+
+/** Provides HTTP support utilities for Agentic AI connectors, including proxy configuration. */
+public class AgenticAiHttpSupport {
+  private final JdkHttpClientProxyConfigurator jdkHttpClientProxyConfigurator;
+
+  public AgenticAiHttpSupport(JdkHttpClientProxyConfigurator jdkHttpClientProxyConfigurator) {
+    this.jdkHttpClientProxyConfigurator = jdkHttpClientProxyConfigurator;
+  }
+
+  public JdkHttpClientProxyConfigurator getJdkHttpClientProxyConfigurator() {
+    return jdkHttpClientProxyConfigurator;
+  }
+}

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/mcp/client/configuration/mcpsdk/McpSdkMcpClientConfiguration.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/mcp/client/configuration/mcpsdk/McpSdkMcpClientConfiguration.java
@@ -7,6 +7,7 @@
 package io.camunda.connector.agenticai.mcp.client.configuration.mcpsdk;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.connector.agenticai.common.AgenticAiHttpSupport;
 import io.camunda.connector.agenticai.mcp.client.configuration.annotation.RuntimeMcpClientFactory;
 import io.camunda.connector.agenticai.mcp.client.framework.bootstrap.McpClientHeadersSupplierFactory;
 import io.camunda.connector.agenticai.mcp.client.framework.mcpsdk.McpSdkClientFactory;
@@ -34,7 +35,9 @@ public class McpSdkMcpClientConfiguration {
   @RuntimeMcpClientFactory
   public McpSdkClientFactory mcpSdkMcpClientFactory(
       @ConnectorsObjectMapper ObjectMapper objectMapper,
+      AgenticAiHttpSupport httpSupport,
       McpClientHeadersSupplierFactory headersSupplierFactory) {
-    return new McpSdkClientFactory(objectMapper, headersSupplierFactory);
+    return new McpSdkClientFactory(
+        objectMapper, httpSupport.getJdkHttpClientProxyConfigurator(), headersSupplierFactory);
   }
 }

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/mcp/client/configuration/mcpsdk/McpSdkMcpRemoteClientConfiguration.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/mcp/client/configuration/mcpsdk/McpSdkMcpRemoteClientConfiguration.java
@@ -7,6 +7,7 @@
 package io.camunda.connector.agenticai.mcp.client.configuration.mcpsdk;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.connector.agenticai.common.AgenticAiHttpSupport;
 import io.camunda.connector.agenticai.mcp.client.configuration.annotation.RemoteMcpClientFactory;
 import io.camunda.connector.agenticai.mcp.client.framework.bootstrap.McpClientHeadersSupplierFactory;
 import io.camunda.connector.agenticai.mcp.client.framework.mcpsdk.McpSdkClientFactory;
@@ -35,7 +36,9 @@ public class McpSdkMcpRemoteClientConfiguration {
   @RemoteMcpClientFactory
   public McpSdkClientFactory mcpSdkMcpRemoteClientFactory(
       @ConnectorsObjectMapper ObjectMapper objectMapper,
+      AgenticAiHttpSupport httpSupport,
       McpClientHeadersSupplierFactory headersSupplierFactory) {
-    return new McpSdkClientFactory(objectMapper, headersSupplierFactory);
+    return new McpSdkClientFactory(
+        objectMapper, httpSupport.getJdkHttpClientProxyConfigurator(), headersSupplierFactory);
   }
 }

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/mcp/client/framework/mcpsdk/McpSdkClientFactory.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/mcp/client/framework/mcpsdk/McpSdkClientFactory.java
@@ -12,6 +12,7 @@ import io.camunda.connector.agenticai.mcp.client.configuration.McpClientConfigur
 import io.camunda.connector.agenticai.mcp.client.execution.McpClientDelegate;
 import io.camunda.connector.agenticai.mcp.client.framework.bootstrap.McpClientHeadersSupplierFactory;
 import io.camunda.connector.agenticai.mcp.client.framework.mcpsdk.rpc.McpSdkMcpClientDelegate;
+import io.camunda.connector.http.client.client.jdk.proxy.JdkHttpClientProxyConfigurator;
 import io.modelcontextprotocol.client.McpClient;
 import io.modelcontextprotocol.client.transport.HttpClientSseClientTransport;
 import io.modelcontextprotocol.client.transport.HttpClientStreamableHttpTransport;
@@ -28,12 +29,17 @@ import java.util.Optional;
 public class McpSdkClientFactory implements McpClientFactory {
 
   public static final Duration DEFAULT_TIMEOUT = Duration.ofSeconds(30);
+
   private final ObjectMapper objectMapper;
+  private final JdkHttpClientProxyConfigurator proxyConfigurator;
   private final McpClientHeadersSupplierFactory headersSupplierFactory;
 
   public McpSdkClientFactory(
-      ObjectMapper objectMapper, McpClientHeadersSupplierFactory headersSupplierFactory) {
+      ObjectMapper objectMapper,
+      JdkHttpClientProxyConfigurator proxyConfigurator,
+      McpClientHeadersSupplierFactory headersSupplierFactory) {
     this.objectMapper = objectMapper;
+    this.proxyConfigurator = proxyConfigurator;
     this.headersSupplierFactory = headersSupplierFactory;
   }
 
@@ -82,6 +88,7 @@ public class McpSdkClientFactory implements McpClientFactory {
     return HttpClientStreamableHttpTransport.builder(streamableHttpConfig.url())
         .endpoint(
             streamableHttpConfig.url()) // see https://github.com/camunda/connectors/issues/6393
+        .customizeClient(proxyConfigurator::configure)
         .connectTimeout(timeout(streamableHttpConfig.timeout()))
         .supportedProtocolVersions(
             List.of(
@@ -103,13 +110,13 @@ public class McpSdkClientFactory implements McpClientFactory {
 
     return HttpClientSseClientTransport.builder(sseConfig.url())
         .sseEndpoint(sseConfig.url()) // see https://github.com/camunda/connectors/issues/6393
+        .customizeClient(proxyConfigurator::configure)
         .connectTimeout(timeout(sseConfig.timeout()))
         .customizeRequest(
             request -> {
               var headers = headerSuppliers.get();
               headers.forEach(request::header);
             })
-        // todo proxy configuration
         .build();
   }
 

--- a/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/autoconfigure/AgenticAiConnectorsAutoConfigurationTest.java
+++ b/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/autoconfigure/AgenticAiConnectorsAutoConfigurationTest.java
@@ -41,6 +41,7 @@ import io.camunda.connector.agenticai.aiagent.memory.conversation.ConversationSt
 import io.camunda.connector.agenticai.aiagent.memory.conversation.document.CamundaDocumentConversationStore;
 import io.camunda.connector.agenticai.aiagent.memory.conversation.inprocess.InProcessConversationStore;
 import io.camunda.connector.agenticai.aiagent.tool.GatewayToolHandlerRegistry;
+import io.camunda.connector.agenticai.common.AgenticAiHttpSupport;
 import java.util.List;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
@@ -54,6 +55,7 @@ class AgenticAiConnectorsAutoConfigurationTest {
 
   private static final List<Class<?>> AGENTIC_AI_BEANS =
       List.of(
+          AgenticAiHttpSupport.class,
           AdHocToolElementParameterExtractor.class,
           AdHocToolSchemaGenerator.class,
           AdHocToolsSchemaResolver.class,


### PR DESCRIPTION
## Description

Based on #6334

Configures the HTTP proxy configured via `CONNECTORS_HTTP_PROXY*` variables on the MCP client connector.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #6250

## Checklist

- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest
  release, as this branch will be rebased onto main before the next release. Example backport labels:
    - `backport stable/8.8`: for changes that should be included in the next 8.8.x release.
    - **or** `backport release-8.8.7`: for changes that should be included in the specific release 8.8.7, and this
      *release has already been created*. The release branch will be merged back into stable/8.8 later, so the change
      will be included in future 8.8.x releases as well.
- [x] Tests/Integration tests for the changes have been added if applicable.

