### PR TITLE
ci: update downstream result fetching alwaysgreen

### DIFF
--- a/.github/workflows/FEATURE_BRANCH_HELM_TEST.yaml
+++ b/.github/workflows/FEATURE_BRANCH_HELM_TEST.yaml
@@ -204,7 +204,7 @@ jobs:
           echo "Waiting for downstream E2E workflow run in camunda/c8-cross-component-e2e-tests for correlation id: $CORRELATION_ID"
 
           TARGET_REPO="camunda/c8-cross-component-e2e-tests"
-          WORKFLOW_FILE="playwright_saas_pr_trigger_monorepo.yml"
+          WORKFLOW_FILE="playwright_saas_pr_trigger_connectors.yml"
 
           gh_api_with_retry() {
             local endpoint="$1"


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

**What / Why**

- The upstream workflow triggers SaaS E2E tests in camunda/c8-cross-component-e2e-tests via repository_dispatch and then waits for the downstream workflow run to finish.
- Previously, the wait logic relied on timestamps (created_at > trigger_time) and could select unrelated downstream runs when multiple dispatches occurred around the same time.
- The polling also occasionally failed due to transient GitHub API errors (e.g. gh: Server Error (HTTP 502)).

**Changes**

- Add a deterministic correlation_id to the repository_dispatch client_payload.
- Update the downstream waiting logic to locate the downstream run by matching the correlation id in the downstream run’s display_title (enabled by downstream workflow run-name).
- Add retry/backoff around gh api calls and reduce API calls per polling iteration by fetching run JSON once and parsing status/conclusion from it.
- Remove the timestamp-based trigger-time step (no longer needed).

**Result**

- The workflow reliably waits for the correct downstream SaaS E2E run, even under high activity.
- Transient GitHub API 5xx errors no longer cause the job to fail immediately; the step retries and continues polling.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #

## Checklist

- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest
  release, as this branch will be rebased onto main before the next release. Example backport labels:
    - `backport stable/8.8`: for changes that should be included in the next 8.8.x release.
    - **or** `backport release-8.8.7`: for changes that should be included in the specific release 8.8.7, and this
      *release has already been created*. The release branch will be merged back into stable/8.8 later, so the change
      will be included in future 8.8.x releases as well.
- [ ] Tests/Integration tests for the changes have been added if applicable.

