### PR TITLE
docs: add documentation about maven cache in bulid commands

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -288,6 +288,9 @@ mvn clean package
 # Quick build, skip long-running tests (faster development)
 mvn clean package -Dquickly
 
+# Quick build with Maven cache (fastest for incremental builds)
+mvn clean install -DskipTests -DskipChecks -Dquickly -Dmaven.build.cache.enabled=true -T 1C
+
 # Generate element templates for connectors
 ./connectors/create-element-templates-symlinks.sh
 

--- a/README.md
+++ b/README.md
@@ -178,6 +178,12 @@ the [connector-runtime](connector-runtime) module.
 mvn clean package
 ```
 
+For faster incremental builds, you can use the Maven build cache:
+
+```bash
+mvn clean install -DskipTests -DskipChecks -Dquickly -Dmaven.build.cache.enabled=true -T 1C
+```
+
 ## Integration Tests
 
 To run the integration tests, you need to have Docker installed and running. We
@@ -217,4 +223,5 @@ You can also trigger this for already merged PRs by posting a comment on the PR 
 
 ## CI Secrets
 
-Secrets used by the CI jobs in this repository are stored in [Vault](https://vault.int.camunda.com/ui/vault/secrets/secret/kv/products%252Fconnectors%252Fci%252Fcommon/details).
+Secrets used by the CI jobs in this repository are stored
+in [Vault](https://vault.int.camunda.com/ui/vault/secrets/secret/kv/products%252Fconnectors%252Fci%252Fcommon/details).


### PR DESCRIPTION
## Description
This pull request improves the project documentation by adding instructions for faster incremental Maven builds using the Maven build cache. The updates aim to help developers speed up their local development workflow.

Documentation improvements:

* Added a new example command in `.github/copilot-instructions.md` for quick incremental builds with Maven cache enabled, including recommended flags for optimal speed.
* Updated the `README.md` to document the Maven cache build command, making it easier for developers to discover and use faster build options.

Minor formatting:

* Improved line breaks in the CI secrets section of the `README.md` for better readability.