### PR TITLE
docs(agentic-ai): Add ADR document for decision on substituting MCP client framework

### DIFF
--- a/connectors/agentic-ai/docs/adr/001-replace-mcp-client-framework.md
+++ b/connectors/agentic-ai/docs/adr/001-replace-mcp-client-framework.md
@@ -91,7 +91,7 @@ The migration follows a side-by-side implementation strategy:
 2. **Configuration-based selection**: Use configuration properties to select active implementation
 3. **Domain model mapping**: Create dedicated RPC request classes that map MCP SDK types to internal domain models
 4. **Gradual migration**: Introduce MCP-SDK implementation in coexistence with existing Lanchain4J implementation. Then
-   assure quality of implementation by exploration and comparison. Finally, deprecate langchain4j implementation and
+   assure quality of implementation by exploration and comparison. Finally, remove langchain4j based implementation and
    switch to `mcpsdk` as runtime default.
 
 ## References


### PR DESCRIPTION
## Description

* Adding (our first 🚀 ) ADR document to the agentic-ai connector module
* The ADR is about replacing `langchain4j-mcp` MCP client framework with official `MCP Java SDK` from https://modelcontextprotocol.io

## Related issues

relates to #6084 

## Checklist

- [x] Backport labels are added if these code changes should be backported. No backport label is added to the latest
  release, as this branch will be rebased onto main before the next release. Example backport labels:
    - `backport stable/8.8`: for changes that should be included in the next 8.8.x release.
    - **or** `backport release-8.8.7`: for changes that should be included in the specific release 8.8.7, and this
      *release has already been created*. The release branch will be merged back into stable/8.8 later, so the change
      will be included in future 8.8.x releases as well.
- [x] Tests/Integration tests for the changes have been added if applicable.

