### PR TITLE
docs(agentic-ai): Add ADR document for decision on substituting MCP client framework

### DIFF
--- a/connectors/agentic-ai/docs/adr/001-replace-mcp-client-framework.md
+++ b/connectors/agentic-ai/docs/adr/001-replace-mcp-client-framework.md
@@ -49,7 +49,7 @@ substitute default options, like JSON serdes library, HTTP transport implementat
 ### Negative Consequences
 
 * Migration effort required for existing codebase
-* Potential requirement to temporary parallel support for both implementations during migration period
+* Potential requirement to temporarily support both implementations in parallel during the migration period
 
 ## Pros and Cons of the Options
 


### PR DESCRIPTION
## Description

reopening #6425 due to unsynced PR after pushing...

* Adding (our first 🚀 ) ADR document to the agentic-ai connector module
* The ADR is about replacing langchain4j-mcp MCP client framework with official MCP Java SDK from https://modelcontextprotocol.io/
## Related issues

relates to https://github.com/camunda/connectors/issues/6084

## Checklist

- [x] Backport labels are added if these code changes should be backported. No backport label is added to the latest
  release, as this branch will be rebased onto main before the next release. Example backport labels:
    - `backport stable/8.8`: for changes that should be included in the next 8.8.x release.
    - **or** `backport release-8.8.7`: for changes that should be included in the specific release 8.8.7, and this
      *release has already been created*. The release branch will be merged back into stable/8.8 later, so the change
      will be included in future 8.8.x releases as well.
- [x] Tests/Integration tests for the changes have been added if applicable.

