### PR TITLE
fix: stackdriver dependency conflict

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -106,7 +106,7 @@ limitations under the License.</license.inlineheader>
     <version.google-auth-library-oauth2-http>1.42.1</version.google-auth-library-oauth2-http>
     <version.google-api-services-docs>v1-rev20260114-2.0.0</version.google-api-services-docs>
     <version.google-api-services-sheets>v4-rev20251110-2.0.0</version.google-api-services-sheets>
-    <version.google-libraries-bom>26.76.0</version.google-libraries-bom>
+    <version.google-libraries-bom>26.74.0</version.google-libraries-bom>
     <version.gson-extras>1.3.0</version.gson-extras>
 
     <version.httpcore>4.4.16</version.httpcore>

--- a/secret-providers/gcp-secret-provider/pom.xml
+++ b/secret-providers/gcp-secret-provider/pom.xml
@@ -14,7 +14,7 @@
   <packaging>jar</packaging>
 
   <properties>
-    <version.google-libraries-bom>26.76.0</version.google-libraries-bom>
+    <version.google-libraries-bom>26.74.0</version.google-libraries-bom>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

SaaS bundle does not start because of the version upgrade that Renovate silently introduced and we didn't detect the issue.

I will create another PR where I change the test so that it catches stuff like that and does not allow to merge - this will be a separate change because it needs to go via main and be backported to other branches.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #

## Checklist

- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest
  release, as this branch will be rebased onto main before the next release. Example backport labels:
    - `backport stable/8.8`: for changes that should be included in the next 8.8.x release.
    - **or** `backport release-8.8.7`: for changes that should be included in the specific release 8.8.7, and this
      *release has already been created*. The release branch will be merged back into stable/8.8 later, so the change
      will be included in future 8.8.x releases as well.
- [ ] Tests/Integration tests for the changes have been added if applicable.

