### PR TITLE
fix: disable test profile in SaaS context test

### DIFF
--- a/bundle/camunda-saas-bundle/src/test/java/io/camunda/connector/runtime/saas/TestSpringContextStartup.java
+++ b/bundle/camunda-saas-bundle/src/test/java/io/camunda/connector/runtime/saas/TestSpringContextStartup.java
@@ -21,7 +21,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Answers;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @SpringBootTest(


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

This PR removes the "test" profile from the SaaS bundle integration test.

If we add the test profile, stackdriver logging config will not be in place and we might not catch issues related to logging configuration. After this is merged, this test will be closer to a production setup and catch more potential issues.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #

## Checklist

- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest
  release, as this branch will be rebased onto main before the next release. Example backport labels:
    - `backport stable/8.8`: for changes that should be included in the next 8.8.x release.
    - **or** `backport release-8.8.7`: for changes that should be included in the specific release 8.8.7, and this
      *release has already been created*. The release branch will be merged back into stable/8.8 later, so the change
      will be included in future 8.8.x releases as well.
- [ ] Tests/Integration tests for the changes have been added if applicable.

