### PR TITLE
fix: disable test profile in SaaS context test (#6431)

### DIFF
--- a/bundle/camunda-saas-bundle/src/main/java/io/camunda/connector/runtime/saas/SaaSConfiguration.java
+++ b/bundle/camunda-saas-bundle/src/main/java/io/camunda/connector/runtime/saas/SaaSConfiguration.java
@@ -28,7 +28,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 
 @Configuration
-@Profile("!test")
+@Profile("!test-saas")
 public class SaaSConfiguration {
 
   @Value("${camunda.saas.secrets.projectId:#{null}}")

--- a/bundle/camunda-saas-bundle/src/test/java/io/camunda/connector/runtime/saas/SecurityConfigurationTest.java
+++ b/bundle/camunda-saas-bundle/src/test/java/io/camunda/connector/runtime/saas/SecurityConfigurationTest.java
@@ -62,10 +62,10 @@ import org.springframework.test.web.servlet.MockMvc;
       "camunda.operate.client.baseUrl=" + MockSaaSConfiguration.OPERATE_CLIENT_BASEURL,
       "camunda.connector.secretprovider.discovery.enabled=false",
       "operate.client.profile=oidc",
-      "management.endpoints.web.exposure.include=*"
+      "management.endpoints.web.exposure.include=*",
     })
 @DirtiesContext
-@ActiveProfiles("test")
+@ActiveProfiles("test-saas")
 @AutoConfigureMockMvc
 @CamundaSpringProcessTest
 @SlowTest

--- a/bundle/camunda-saas-bundle/src/test/java/io/camunda/connector/runtime/saas/TestSpringContextStartup.java
+++ b/bundle/camunda-saas-bundle/src/test/java/io/camunda/connector/runtime/saas/TestSpringContextStartup.java
@@ -21,6 +21,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest(
     classes = {SaaSConnectorRuntimeApplication.class, MockSaaSConfiguration.class},
@@ -35,7 +36,9 @@ import org.springframework.boot.test.context.SpringBootTest;
       "camunda.operate.client.baseUrl=" + MockSaaSConfiguration.OPERATE_CLIENT_BASEURL,
       "camunda.connector.secretprovider.discovery.enabled=false",
       "operate.client.profile=oidc",
+      "connectors.log.appender=stackdriver"
     })
+@ActiveProfiles("test-saas")
 // @ActiveProfiles("test")
 // uncomment if you want readable logs
 // we keep it disabled to test the setup e2e with stackdriver logging configuration as in prod


### PR DESCRIPTION
Backport #6431 to 8.7


---------


(cherry picked from commit 00cc67370138aca9c9ba3839ace49653b75002c8)

## Description

<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #

## Checklist

- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest
  release, as this branch will be rebased onto main before the next release. Example backport labels:
    - `backport stable/8.8`: for changes that should be included in the next 8.8.x release.
    - **or** `backport release-8.8.7`: for changes that should be included in the specific release 8.8.7, and this
      *release has already been created*. The release branch will be merged back into stable/8.8 later, so the change
      will be included in future 8.8.x releases as well.
- [ ] Tests/Integration tests for the changes have been added if applicable.

