### PR TITLE
test: fix e2e test in 8.7

### DIFF
--- a/bundle/camunda-saas-bundle/src/test/java/io/camunda/connector/runtime/saas/InboundInstancesSecurityConfigurationTest.java
+++ b/bundle/camunda-saas-bundle/src/test/java/io/camunda/connector/runtime/saas/InboundInstancesSecurityConfigurationTest.java
@@ -49,7 +49,7 @@ import org.springframework.test.web.servlet.MockMvc;
       "management.endpoints.web.exposure.include=*"
     })
 @DirtiesContext
-@ActiveProfiles("test")
+@ActiveProfiles("test-saas")
 @AutoConfigureMockMvc
 @CamundaSpringProcessTest
 @SlowTest


### PR DESCRIPTION
## Description

After merging #6450 I forgot to adjust the profile in this E2E test so it started to fail. This PR fixes the issue.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #

## Checklist

- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest
  release, as this branch will be rebased onto main before the next release. Example backport labels:
    - `backport stable/8.8`: for changes that should be included in the next 8.8.x release.
    - **or** `backport release-8.8.7`: for changes that should be included in the specific release 8.8.7, and this
      *release has already been created*. The release branch will be merged back into stable/8.8 later, so the change
      will be included in future 8.8.x releases as well.
- [ ] Tests/Integration tests for the changes have been added if applicable.

