### PR TITLE
fix: implement missing businessId methods in test dummies

### DIFF
--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/testutil/command/CreateCommandDummy.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/testutil/command/CreateCommandDummy.java
@@ -123,4 +123,9 @@ public class CreateCommandDummy
   public CreateProcessInstanceCommandStep1 useGrpc() {
     return this;
   }
+
+  @Override
+  public CreateProcessInstanceCommandStep3 businessId(String businessId) {
+    return this;
+  }
 }

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/testutil/response/ProcessInstanceEventDummy.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/testutil/response/ProcessInstanceEventDummy.java
@@ -45,4 +45,9 @@ public class ProcessInstanceEventDummy implements ProcessInstanceEvent {
   public Set<String> getTags() {
     return Set.of();
   }
+
+  @Override
+  public String getBusinessId() {
+    return null;
+  }
 }


### PR DESCRIPTION
## Description

camunda-client library is updated and new version added 2 new methods in its interfaces.
`businessId(String businessId)` on `CreateProcessInstanceCommandStep3`
and
`getBusinessId()` on `ProcessInstanceEvent`.

Our 2 classes `CreateCommandDummy` and `ProcessInstanceEventDummy` implement these interface but they are not updated to implement these methods, so builds were breaking.

This PR implements these methods.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #6465

## Checklist

- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest
  release, as this branch will be rebased onto main before the next release. Example backport labels:
    - `backport stable/8.8`: for changes that should be included in the next 8.8.x release.
    - **or** `backport release-8.8.7`: for changes that should be included in the specific release 8.8.7, and this
      *release has already been created*. The release branch will be merged back into stable/8.8 later, so the change
      will be included in future 8.8.x releases as well.
- [ ] Tests/Integration tests for the changes have been added if applicable.

