### PR TITLE
fix(idp-extraction-connector): add new idp templates to ignore-templates.json

### DIFF
--- a/ignore-templates.json
+++ b/ignore-templates.json
@@ -1,3 +1,6 @@
 [
-  "io.camunda.connector.IdpExtractionOutBoundTemplate.v1"
+  "io.camunda.connector.IdpExtractionOutBoundTemplate.v1",
+  "io.camunda.connector.IdpClassificationOutBoundTemplate.v1",
+  "io.camunda.connector.IdpStructuredExtractionOutBoundTemplate.v1",
+  "io.camunda.connector.IdpUnstructuredExtractionOutBoundTemplate.v1"
 ]


### PR DESCRIPTION
## Description

This pull request updates the `ignore-templates.json` file to expand the list of ignored templates for connectors. Three new templates related to IDP (Intelligent Document Processing) outbound operations are now included in the ignore list.

**Template ignore list update:**

* Added `io.camunda.connector.IdpClassificationOutBoundTemplate.v1`, `io.camunda.connector.IdpStructuredExtractionOutBoundTemplate.v1`, and `io.camunda.connector.IdpUnstructuredExtractionOutBoundTemplate.v1` to the `ignore-templates.json` file.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes https://github.com/camunda/connectors/issues/6470

## Checklist

- [x] Backport labels are added if these code changes should be backported. No backport label is added to the latest
  release, as this branch will be rebased onto main before the next release. Example backport labels:
    - `backport stable/8.8`: for changes that should be included in the next 8.8.x release.
    - **or** `backport release-8.8.7`: for changes that should be included in the specific release 8.8.7, and this
      *release has already been created*. The release branch will be merged back into stable/8.8 later, so the change
      will be included in future 8.8.x releases as well.
- [x] Tests/Integration tests for the changes have been added if applicable.

