### PR TITLE
fix: filter elements when activating inbound for older versions

### DIFF
--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/state/ProcessStateManagerImpl.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/state/ProcessStateManagerImpl.java
@@ -17,6 +17,8 @@
 package io.camunda.connector.runtime.inbound.state;
 
 import io.camunda.connector.runtime.core.inbound.InboundConnectorElement;
+import io.camunda.connector.runtime.core.inbound.correlation.MessageStartEventCorrelationPoint;
+import io.camunda.connector.runtime.core.inbound.correlation.StartEventCorrelationPoint;
 import io.camunda.connector.runtime.inbound.executable.InboundExecutableEvent;
 import io.camunda.connector.runtime.inbound.executable.InboundExecutableRegistry;
 import io.camunda.connector.runtime.inbound.state.model.ImportResult;
@@ -68,8 +70,19 @@ public class ProcessStateManagerImpl implements ProcessStateManager {
     try {
       Map<Long, List<InboundConnectorElement>> elementsByVersion = new HashMap<>();
 
+      // Determine the latest version key (highest value)
+      Long latestVersionKey = activeVersionKeys.stream().max(Long::compareTo).orElse(null);
+
       for (Long versionKey : activeVersionKeys) {
         var elements = getConnectors(processRef, versionKey);
+
+        // For non-latest versions, filter out start events.
+        // Start events should always use the latest version - there's no reason to keep
+        // older versions' start events active since new instances always start on the latest.
+        if (!versionKey.equals(latestVersionKey)) {
+          elements = filterStartEvents(elements, versionKey);
+        }
+
         // Include version even if it has no connectors - registry needs to know about it
         elementsByVersion.put(versionKey, elements);
       }
@@ -93,6 +106,40 @@ public class ProcessStateManagerImpl implements ProcessStateManager {
           processRef.tenantId(),
           e);
     }
+  }
+
+  /**
+   * Filters out start event elements from non-latest versions. Start events (both plain and
+   * message-based) should always use the latest version since new process instances are always
+   * created on the latest version. Keeping older versions' start events would cause
+   * "TooManyMatchingElements" errors when both have blank activation conditions.
+   *
+   * <p>Intermediate catch events and boundary events are NOT filtered here - they may have active
+   * subscriptions from running process instances that need to be correlated.
+   */
+  private List<InboundConnectorElement> filterStartEvents(
+      List<InboundConnectorElement> elements, Long versionKey) {
+
+    var filtered =
+        elements.stream()
+            .filter(
+                element -> {
+                  var correlationPoint = element.correlationPoint();
+                  // Filter out start events (both plain and message-based)
+                  return !(correlationPoint instanceof StartEventCorrelationPoint)
+                      && !(correlationPoint instanceof MessageStartEventCorrelationPoint);
+                  // Keep intermediate catch events and boundary events
+                })
+            .toList();
+
+    if (filtered.size() < elements.size()) {
+      LOG.debug(
+          "Filtered out {} start event element(s) from non-latest version {}",
+          elements.size() - filtered.size(),
+          versionKey);
+    }
+
+    return filtered;
   }
 
   private List<InboundConnectorElement> getConnectors(

--- a/connectors-e2e-test/connectors-e2e-test-inbound-runtime/src/test/java/io/camunda/connector/e2e/inbound/InboundConnectorMultiVersionTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-inbound-runtime/src/test/java/io/camunda/connector/e2e/inbound/InboundConnectorMultiVersionTests.java
@@ -227,6 +227,20 @@ public class InboundConnectorMultiVersionTests {
         .done();
   }
 
+  /**
+   * Creates a BPMN model with a message start event connector for testing start event scenarios.
+   * Uses the existing BPMN file which has a message start event element.
+   *
+   * @param configValue a generic configuration value (affects AUTO deduplication hash)
+   * @param deduplicationId optional custom deduplication ID (null for AUTO mode)
+   * @return the BPMN model instance
+   */
+  private BpmnModelInstance createMessageStartEventProcess(
+      String configValue, String deduplicationId) {
+    // Use the existing BPMN file which now contains a message start event
+    return createInboundConnectorProcess(configValue, deduplicationId, "messageStartEvent");
+  }
+
   private String getResourcePath(String resourceName) {
     var resource = getClass().getClassLoader().getResource(resourceName);
     if (resource == null) {
@@ -805,6 +819,96 @@ public class InboundConnectorMultiVersionTests {
           .isEqualTo(keyV1);
       assertThat(executables2.getFirst().elements().getFirst().element().processDefinitionKey())
           .isEqualTo(keyV2);
+    }
+  }
+
+  @Nested
+  class StartEventFilteringForNonLatestVersions {
+
+    @Test
+    void deployV1WithMessageStartEvent_deployV2SameConfig_v1StartEventShouldBeFiltered() {
+      // This test verifies that start events from non-latest versions are filtered out.
+      // Start events should always use the latest version since new process instances
+      // are always created on the latest version.
+
+      // Given: v1 deployed with message start event connector
+      var model1 = createMessageStartEventProcess("config-a", "shared-start-dedup");
+      long keyV1 = deploy(model1);
+      waitForProcessDefinitionIndexed(keyV1);
+      awaitHealthyExecutable(testProcessId);
+
+      // Verify v1 has one executable with one element
+      var executablesV1 = queryExecutables(testProcessId);
+      assertThat(executablesV1).hasSize(1);
+      assertThat(executablesV1.getFirst().elements()).hasSize(1);
+      assertThat(executablesV1.getFirst().elements().getFirst().element().processDefinitionKey())
+          .isEqualTo(keyV1);
+
+      // When: Deploy v2 with SAME connector config (deduplicated by deduplication ID)
+      var model2 = createMessageStartEventProcess("config-a", "shared-start-dedup");
+      long keyV2 = deploy(model2);
+      waitForProcessDefinitionIndexed(keyV2);
+
+      // Then: Only v2's start event element should be present
+      // v1's start event is filtered out because start events from non-latest versions
+      // are not needed - new process instances always start on the latest version
+      Awaitility.await("should have single executable with only v2 start event element")
+          .atMost(AWAIT_TIMEOUT)
+          .untilAsserted(
+              () -> {
+                var executables = queryExecutables(testProcessId);
+                assertThat(executables).hasSize(1);
+                assertThat(executables.getFirst().health().getStatus()).isEqualTo(Health.Status.UP);
+
+                // Only v2 should be represented (v1's start event filtered out)
+                var elements = executables.getFirst().elements();
+                assertThat(elements).hasSize(1);
+                assertThat(elements.getFirst().element().processDefinitionKey()).isEqualTo(keyV2);
+              });
+    }
+
+    @Test
+    void deployV1WithIntermediateCatchEvent_deployV2SameConfig_bothElementsShouldBePresent() {
+      // This test verifies that intermediate catch events are NOT filtered out
+      // (only start events are filtered). Intermediate catch events from older versions
+      // may have active subscriptions from running process instances.
+
+      // Given: v1 deployed with intermediate catch event connector
+      var model1 = createInboundConnectorProcess("config-a", "shared-catch-dedup");
+      long keyV1 = deploy(model1);
+      waitForProcessDefinitionIndexed(keyV1);
+      awaitHealthyExecutable(testProcessId);
+
+      // Start an instance on v1 to create a message subscription
+      camundaClient
+          .newCreateInstanceCommand()
+          .processDefinitionKey(keyV1)
+          .variable("correlationKey", "test-correlation-key")
+          .send()
+          .join();
+
+      // When: Deploy v2 with SAME connector config (deduplicated)
+      var model2 = createInboundConnectorProcess("config-a", "shared-catch-dedup");
+      long keyV2 = deploy(model2);
+      waitForProcessDefinitionIndexed(keyV2);
+
+      // Then: Both v1 and v2 elements should be present
+      // Intermediate catch events are not filtered - v1 has an active subscription
+      Awaitility.await("should have single executable with both version elements")
+          .atMost(AWAIT_TIMEOUT)
+          .untilAsserted(
+              () -> {
+                var executables = queryExecutables(testProcessId);
+                assertThat(executables).hasSize(1);
+                assertThat(executables.getFirst().health().getStatus()).isEqualTo(Health.Status.UP);
+
+                // Both v1 and v2 should be represented
+                var processDefKeys =
+                    executables.getFirst().elements().stream()
+                        .map(e -> e.element().processDefinitionKey())
+                        .collect(Collectors.toSet());
+                assertThat(processDefKeys).containsExactlyInAnyOrder(keyV1, keyV2);
+              });
     }
   }
 

--- a/connectors-e2e-test/connectors-e2e-test-inbound-runtime/src/test/resources/bpmn/inbound-test-process.bpmn
+++ b/connectors-e2e-test/connectors-e2e-test-inbound-runtime/src/test/resources/bpmn/inbound-test-process.bpmn
@@ -4,8 +4,13 @@
     <bpmn:startEvent id="plainStartEvent">
       <bpmn:outgoing>Flow_start_to_catch1</bpmn:outgoing>
     </bpmn:startEvent>
+    <bpmn:startEvent id="messageStartEvent">
+      <bpmn:outgoing>Flow_msgstart_to_catch1</bpmn:outgoing>
+      <bpmn:messageEventDefinition id="MessageEventDefinition_1" messageRef="Message_1" />
+    </bpmn:startEvent>
     <bpmn:intermediateThrowEvent id="catchEvent1">
       <bpmn:incoming>Flow_start_to_catch1</bpmn:incoming>
+      <bpmn:incoming>Flow_msgstart_to_catch1</bpmn:incoming>
       <bpmn:outgoing>Flow_catch1_to_catch2</bpmn:outgoing>
     </bpmn:intermediateThrowEvent>
     <bpmn:intermediateThrowEvent id="catchEvent2">
@@ -16,13 +21,18 @@
       <bpmn:incoming>Flow_catch2_to_end</bpmn:incoming>
     </bpmn:endEvent>
     <bpmn:sequenceFlow id="Flow_start_to_catch1" sourceRef="plainStartEvent" targetRef="catchEvent1" />
+    <bpmn:sequenceFlow id="Flow_msgstart_to_catch1" sourceRef="messageStartEvent" targetRef="catchEvent1" />
     <bpmn:sequenceFlow id="Flow_catch1_to_catch2" sourceRef="catchEvent1" targetRef="catchEvent2" />
     <bpmn:sequenceFlow id="Flow_catch2_to_end" sourceRef="catchEvent2" targetRef="endEvent" />
   </bpmn:process>
+  <bpmn:message id="Message_1" name="testMessage" />
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="inboundTestProcess">
       <bpmndi:BPMNShape id="StartEvent_1_di" bpmnElement="plainStartEvent">
         <dc:Bounds x="182" y="82" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="MessageStartEvent_di" bpmnElement="messageStartEvent">
+        <dc:Bounds x="182" y="162" width="36" height="36" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_catch1_di" bpmnElement="catchEvent1">
         <dc:Bounds x="272" y="82" width="36" height="36" />
@@ -35,6 +45,12 @@
       </bpmndi:BPMNShape>
       <bpmndi:BPMNEdge id="Flow_start_to_catch1_di" bpmnElement="Flow_start_to_catch1">
         <di:waypoint x="218" y="100" />
+        <di:waypoint x="272" y="100" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_msgstart_to_catch1_di" bpmnElement="Flow_msgstart_to_catch1">
+        <di:waypoint x="218" y="180" />
+        <di:waypoint x="245" y="180" />
+        <di:waypoint x="245" y="100" />
         <di:waypoint x="272" y="100" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_catch1_to_catch2_di" bpmnElement="Flow_catch1_to_catch2">


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

This is Phase 1 of the fix for #6324 

In this PR I added filtering of inbound connector elements to activate based on whether or not they are actually part of an active message subscription. This helps reduce the chance of users having issues after upgrading their processes to new versions.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #

## Checklist

- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest
  release, as this branch will be rebased onto main before the next release. Example backport labels:
    - `backport stable/8.8`: for changes that should be included in the next 8.8.x release.
    - **or** `backport release-8.8.7`: for changes that should be included in the specific release 8.8.7, and this
      *release has already been created*. The release branch will be merged back into stable/8.8 later, so the change
      will be included in future 8.8.x releases as well.
- [ ] Tests/Integration tests for the changes have been added if applicable.

