### PR TITLE
fix: Backport #6452 to stable/8.8

### DIFF
--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/langchain4j/jobworker/L4JAiAgentJobWorkerLimitsTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/langchain4j/jobworker/L4JAiAgentJobWorkerLimitsTests.java
@@ -100,7 +100,7 @@ public class L4JAiAgentJobWorkerLimitsTests extends BaseL4JAiAgentJobWorkerTest 
         incident -> {
           assertThat(incident.getElementId()).isEqualTo(AI_AGENT_TASK_ID);
           assertThat(incident.getErrorMessage())
-              .isEqualTo(
+              .startsWith(
                   "Maximum number of model calls reached (modelCalls: %1$d, limit: %1$d)"
                       .formatted(expectedMaxModelCalls));
         });

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/langchain4j/outboundconnector/L4JAiAgentConnectorLimitsTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/langchain4j/outboundconnector/L4JAiAgentConnectorLimitsTests.java
@@ -88,7 +88,7 @@ public class L4JAiAgentConnectorLimitsTests extends BaseL4JAiAgentConnectorTest 
         incident -> {
           assertThat(incident.getElementId()).isEqualTo(AI_AGENT_TASK_ID);
           assertThat(incident.getErrorMessage())
-              .isEqualTo(
+              .startsWith(
                   "Maximum number of model calls reached (modelCalls: %1$d, limit: %1$d)"
                       .formatted(expectedMaxModelCalls));
         });


### PR DESCRIPTION
## Description

Backport of #6452 to `stable/8.8`.

## Related issues

closes #

## Checklist

- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest
  release, as this branch will be rebased onto main before the next release. Example backport labels:
    - `backport stable/8.8`: for changes that should be included in the next 8.8.x release.
    - **or** `backport release-8.8.7`: for changes that should be included in the specific release 8.8.7, and this
      *release has already been created*. The release branch will be merged back into stable/8.8 later, so the change
      will be included in future 8.8.x releases as well.
- [ ] Tests/Integration tests for the changes have been added if applicable.

