### PR TITLE
fix(deps): downgrade elasticsearch client

### DIFF
--- a/bundle/pom.xml
+++ b/bundle/pom.xml
@@ -6,11 +6,8 @@
   <packaging>pom</packaging>
 
   <name>Connectors Bundle</name>
-   <properties>
-     <elasticsearch-java.version>8.19.11</elasticsearch-java.version>
-   </properties>
 
-   <parent>
+  <parent>
     <groupId>io.camunda.connector</groupId>
     <artifactId>connector-parent</artifactId>
     <relativePath>../parent/pom.xml</relativePath>
@@ -213,12 +210,6 @@
         <groupId>io.camunda.connector</groupId>
         <artifactId>connector-embeddings-vector-database</artifactId>
         <version>${project.version}</version>
-      </dependency>
-      <!-- Override Spring Boot BOM elasticsearch version to match langchain4j requirements -->
-      <dependency>
-        <groupId>co.elastic.clients</groupId>
-        <artifactId>elasticsearch-java</artifactId>
-        <version>${elasticsearch-java.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -171,7 +171,7 @@ limitations under the License.</license.inlineheader>
 
     <version.langchain4j>1.11.0</version.langchain4j>
     <version.mcp-sdk>0.17.2</version.mcp-sdk>
-    <version.elasticsearch-rest-client>8.19.11</version.elasticsearch-rest-client>
+    <version.elasticsearch-java-client>8.19.11</version.elasticsearch-java-client>
 
     <version.scala>3.8.1</version.scala>
 
@@ -646,10 +646,16 @@ limitations under the License.</license.inlineheader>
         </exclusions>
       </dependency>
 
+      <!-- Override Spring Boot BOM elasticsearch version to match langchain4j requirements -->
+      <dependency>
+        <groupId>co.elastic.clients</groupId>
+        <artifactId>elasticsearch-java</artifactId>
+        <version>${version.elasticsearch-java-client}</version>
+      </dependency>
       <dependency>
         <groupId>org.elasticsearch.client</groupId>
         <artifactId>elasticsearch-rest-client</artifactId>
-        <version>${version.elasticsearch-rest-client}</version>
+        <version>${version.elasticsearch-java-client}</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

Spring Boot 4 has upgraded the elasticsearch java client to 9.x. This new client is not compatible with elasticsearch 8.x that is supported in the embedding vector database. We need to downgrade the ES client to 8.x. 

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #

## Checklist

- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest
  release, as this branch will be rebased onto main before the next release. Example backport labels:
    - `backport stable/8.8`: for changes that should be included in the next 8.8.x release.
    - **or** `backport release-8.8.7`: for changes that should be included in the specific release 8.8.7, and this
      *release has already been created*. The release branch will be merged back into stable/8.8 later, so the change
      will be included in future 8.8.x releases as well.
- [ ] Tests/Integration tests for the changes have been added if applicable.

