### PR TITLE
ci: update alwaysgreen image tags

### DIFF
--- a/.github/workflows/FEATURE_BRANCH_HELM_TEST.yaml
+++ b/.github/workflows/FEATURE_BRANCH_HELM_TEST.yaml
@@ -177,11 +177,11 @@ jobs:
                       "source_repo": "${{ github.repository }}",
                       "source_sha": "${{ github.sha }}",
                       "c8Version": "8.9",
-                      "zeebeVersion": "SNAPSHOT",
-                      "operateVersion": "SNAPSHOT",
-                      "tasklistVersion": "SNAPSHOT",
+                      "zeebeVersion": "8.9-SNAPSHOT",
+                      "operateVersion": "8.9-SNAPSHOT",
+                      "tasklistVersion": "8.9-SNAPSHOT",
                       "connectorsVersion": "${{ needs.build-image.outputs.connectors-version }}",
-                      "optimizeVersion": "8-SNAPSHOT"
+                      "optimizeVersion": "8.9-SNAPSHOT"
                   }
                 }'
       - name: Observe build status


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

Now that the `8.9-SNAPSHOT` image tags are available, the AlwaysGreen WF needs to be updated to use these vs. `SNAPSHOT` for `8.9`.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #

## Checklist

- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest
  release, as this branch will be rebased onto main before the next release. Example backport labels:
    - `backport stable/8.8`: for changes that should be included in the next 8.8.x release.
    - **or** `backport release-8.8.7`: for changes that should be included in the specific release 8.8.7, and this
      *release has already been created*. The release branch will be merged back into stable/8.8 later, so the change
      will be included in future 8.8.x releases as well.
- [ ] Tests/Integration tests for the changes have been added if applicable.

