### PR TITLE
ci: notify Deploy snapshot failure only for main and stable/alpha branches

### DIFF
--- a/.github/workflows/DEPLOY_SNAPSHOTS.yaml
+++ b/.github/workflows/DEPLOY_SNAPSHOTS.yaml
@@ -245,7 +245,7 @@ jobs:
     name: Notify on failure
     runs-on: ubuntu-latest
     needs: [ deploy-snapshots, helm-deploy ]
-    if: failure()
+    if: failure() && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/stable/') || startsWith(github.ref, 'refs/heads/alpha/'))
     steps:
       - name: Send Slack notification on failure
         uses: slackapi/slack-github-action@v2.1.1


### PR DESCRIPTION
## Description

This pull request makes a targeted improvement to the deployment workflow by restricting Slack failure notifications to relevant branches. Now, notifications will only be sent if the failure occurs on the `main`, `stable/*`, or `alpha/*` branches.

Deployment workflow update:

* [`.github/workflows/DEPLOY_SNAPSHOTS.yaml`](diffhunk://#diff-08017f549e52064d6e997595cc8eeed77e33a0af288f64281b187bc5f24d9431L248-R248): Modified the condition for sending Slack notifications on failure to trigger only for the `main`, `stable/*`, and `alpha/*` branches.

## Checklist

- [x] Backport labels are added if these code changes should be backported. No backport label is added to the latest
  release, as this branch will be rebased onto main before the next release. Example backport labels:
    - `backport stable/8.8`: for changes that should be included in the next 8.8.x release.
    - **or** `backport release-8.8.7`: for changes that should be included in the specific release 8.8.7, and this
      *release has already been created*. The release branch will be merged back into stable/8.8 later, so the change
      will be included in future 8.8.x releases as well.
- [ ] Tests/Integration tests for the changes have been added if applicable.

