### PR TITLE
ci: do not notify of failures on cancellation

### DIFF
--- a/.github/workflows/DEPLOY_SNAPSHOTS.yaml
+++ b/.github/workflows/DEPLOY_SNAPSHOTS.yaml
@@ -245,7 +245,7 @@ jobs:
     name: Notify on failure
     runs-on: ubuntu-latest
     needs: [ deploy-snapshots, helm-deploy ]
-    if: failure() && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/stable/') || startsWith(github.ref, 'refs/heads/alpha/'))
+    if: failure() && !cancelled() && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/stable/') || startsWith(github.ref, 'refs/heads/alpha/'))
     steps:
       - name: Send Slack notification on failure
         uses: slackapi/slack-github-action@v2.1.1


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

Do not notify about failures when workflows get cancelled.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #

## Checklist

- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest
  release, as this branch will be rebased onto main before the next release. Example backport labels:
    - `backport stable/8.8`: for changes that should be included in the next 8.8.x release.
    - **or** `backport release-8.8.7`: for changes that should be included in the specific release 8.8.7, and this
      *release has already been created*. The release branch will be merged back into stable/8.8 later, so the change
      will be included in future 8.8.x releases as well.
- [ ] Tests/Integration tests for the changes have been added if applicable.

