### PR TITLE
ci: remove the Release GHA failure notification, this is handled by the release process now

### DIFF
--- a/.github/workflows/RELEASE.yaml
+++ b/.github/workflows/RELEASE.yaml
@@ -614,20 +614,3 @@ jobs:
       needs.bundle-and-build-changelog.result == 'success'
     with:
       version: ${{ inputs.version }}
-
-  notify-failure:
-    name: Notify on failure
-    runs-on: ubuntu-latest
-    needs: [ create-release, setup, maven-release, docker-release, bundle-and-build-changelog, helm-deploy, fossa_release ]
-    if: failure()
-    steps:
-      - name: Send Slack notification on failure
-        uses: slackapi/slack-github-action@v2.1.1
-        with:
-          token: ${{ secrets.CONNECTORS_SLACK_BOT_TOKEN }}
-          method: chat.postMessage
-          payload: |
-            {
-              "channel": "${{ secrets.CONNECTORS_QA_SLACK_CHANNEL_ID }}",
-              "text": ":alarm: ${{ secrets.CONNECTORS_RELEASE_MANAGER_SLACK_GROUP_ID }} Release workflow failed for version `${{ inputs.version }}`.\nCheck details: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-            }


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
This pull request simplifies the release workflow by removing the automatic Slack notification step that was triggered on workflow failures.

Workflow changes:

* Removed the `notify-failure` job from `.github/workflows/RELEASE.yaml`, which previously sent a Slack notification to the QA channel when the release workflow failed.


## Checklist

- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest
  release, as this branch will be rebased onto main before the next release. Example backport labels:
    - `backport stable/8.8`: for changes that should be included in the next 8.8.x release.
    - **or** `backport release-8.8.7`: for changes that should be included in the specific release 8.8.7, and this
      *release has already been created*. The release branch will be merged back into stable/8.8 later, so the change
      will be included in future 8.8.x releases as well.
- [ ] Tests/Integration tests for the changes have been added if applicable.

