### PR TITLE
[Backport stable/8.8] fix(agentic-ai): fix MCP tool name detection with tools containing ___ separator

### DIFF
--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/mcp/discovery/McpClientGatewayToolHandler.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/mcp/discovery/McpClientGatewayToolHandler.java
@@ -6,6 +6,7 @@
  */
 package io.camunda.connector.agenticai.mcp.discovery;
 
+import static io.camunda.connector.agenticai.mcp.discovery.McpToolCallIdentifier.MCP_NAMESPACE_SEPARATOR;
 import static io.camunda.connector.agenticai.mcp.discovery.McpToolCallIdentifier.MCP_PREFIX;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -23,6 +24,7 @@ import io.camunda.connector.agenticai.model.tool.ToolCall;
 import io.camunda.connector.agenticai.model.tool.ToolCallResult;
 import io.camunda.connector.agenticai.model.tool.ToolDefinition;
 import io.camunda.connector.agenticai.util.ObjectMapperConstants;
+import io.camunda.connector.api.error.ConnectorException;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -38,6 +40,9 @@ public class McpClientGatewayToolHandler implements GatewayToolHandler {
 
   public static final String PROPERTY_MCP_CLIENTS = "mcpClients";
   public static final String MCP_TOOLS_DISCOVERY_PREFIX = MCP_PREFIX + "toolsList_";
+
+  private static final String ERROR_CODE_MCP_GATEWAY_INVALID_TOOL_DEFINITIONS =
+      "MCP_GATEWAY_INVALID_TOOL_DEFINITIONS";
 
   private final ObjectMapper objectMapper;
 
@@ -63,6 +68,8 @@ public class McpClientGatewayToolHandler implements GatewayToolHandler {
       return new GatewayToolDiscoveryInitiationResult(agentContext, List.of());
     }
 
+    validateMcpToolDefinitions(mcpGatewayToolDefinitions);
+
     final var updatedAgentContext =
         agentContext.withProperty(
             PROPERTY_MCP_CLIENTS,
@@ -80,6 +87,23 @@ public class McpClientGatewayToolHandler implements GatewayToolHandler {
             .toList();
 
     return new GatewayToolDiscoveryInitiationResult(updatedAgentContext, discoveryToolCalls);
+  }
+
+  private void validateMcpToolDefinitions(List<GatewayToolDefinition> mcpGatewayToolDefinitions) {
+    final var invalidMcpTools =
+        mcpGatewayToolDefinitions.stream()
+            .map(GatewayToolDefinition::name)
+            .filter(name -> name.contains(MCP_NAMESPACE_SEPARATOR))
+            .toList();
+
+    if (!invalidMcpTools.isEmpty()) {
+      throw new ConnectorException(
+          ERROR_CODE_MCP_GATEWAY_INVALID_TOOL_DEFINITIONS,
+          "Invalid MCP client activity ID(s) detected: [%s]. Activity IDs must not contain the reserved separator '%s'. Please rename the affected activities in the BPMN model."
+              .formatted(
+                  invalidMcpTools.stream().map("'%s'"::formatted).collect(Collectors.joining(", ")),
+                  MCP_NAMESPACE_SEPARATOR));
+    }
   }
 
   @Override

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/mcp/discovery/McpToolCallIdentifier.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/mcp/discovery/McpToolCallIdentifier.java
@@ -6,9 +6,7 @@
  */
 package io.camunda.connector.agenticai.mcp.discovery;
 
-import java.util.Arrays;
 import java.util.regex.Pattern;
-import org.apache.commons.lang3.StringUtils;
 
 /**
  * Holds a fully qualified MCP tool definition name (including the BPMN element ID + the MCP tool
@@ -31,38 +29,24 @@ public record McpToolCallIdentifier(String elementName, String mcpToolName) {
       Pattern.compile(
           "^"
               + MCP_PREFIX
-              + "(?<elementName>.+)"
+              + "(?<elementName>\\S+?)"
               + MCP_NAMESPACE_SEPARATOR
-              + "(?<mcpToolName>.+)$");
+              + "(?<mcpToolName>\\S+)$");
 
   public String fullyQualifiedName() {
     return MCP_PREFIX + elementName + MCP_NAMESPACE_SEPARATOR + mcpToolName;
   }
 
   public static boolean isMcpToolCallIdentifier(String toolCallName) {
-    return !StringUtils.isBlank(toolCallName)
-        && MCP_TOOL_CALL_PATTERN.matcher(toolCallName).matches();
+    return toolCallName != null && MCP_TOOL_CALL_PATTERN.matcher(toolCallName).matches();
   }
 
   public static McpToolCallIdentifier fromToolCallName(String toolCallName) {
-    if (!toolCallName.startsWith(MCP_PREFIX)) {
+    var matcher = MCP_TOOL_CALL_PATTERN.matcher(toolCallName);
+    if (!matcher.matches()) {
       throw invalidToolCallNameException(toolCallName);
     }
-
-    final var parts =
-        Arrays.stream(toolCallName.substring(MCP_PREFIX.length()).split(MCP_NAMESPACE_SEPARATOR))
-            .toList()
-            .stream()
-            .map(String::trim)
-            .toList();
-
-    if (parts.size() != 2
-        || StringUtils.isBlank(parts.get(0))
-        || StringUtils.isBlank(parts.get(1))) {
-      throw invalidToolCallNameException(toolCallName);
-    }
-
-    return new McpToolCallIdentifier(parts.get(0), parts.get(1));
+    return new McpToolCallIdentifier(matcher.group("elementName"), matcher.group("mcpToolName"));
   }
 
   private static IllegalArgumentException invalidToolCallNameException(String toolCallName) {

--- a/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/mcp/discovery/McpClientGatewayToolHandlerTest.java
+++ b/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/mcp/discovery/McpClientGatewayToolHandlerTest.java
@@ -8,6 +8,7 @@ package io.camunda.connector.agenticai.mcp.discovery;
 
 import static io.camunda.connector.agenticai.mcp.discovery.McpClientGatewayToolHandler.PROPERTY_MCP_CLIENTS;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -19,15 +20,18 @@ import io.camunda.connector.agenticai.model.tool.GatewayToolDefinition;
 import io.camunda.connector.agenticai.model.tool.ToolCall;
 import io.camunda.connector.agenticai.model.tool.ToolCallResult;
 import io.camunda.connector.agenticai.model.tool.ToolDefinition;
+import io.camunda.connector.api.error.ConnectorException;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
+import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 class McpClientGatewayToolHandlerTest {
 
@@ -89,6 +93,46 @@ class McpClientGatewayToolHandlerTest {
                 assertThat(toolCall.id()).isEqualTo("MCP_toolsList_mcp2");
                 assertThat(toolCall.name()).isEqualTo("mcp2");
                 assertThat(toolCall.arguments()).containsExactly(Map.entry("method", "tools/list"));
+              });
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"mcp___client", "mcp_____client", "name___", "___name"})
+    void throwsException_whenMcpGatewayToolDefinitionNameContainsSeparator(String invalidName) {
+      var agentContext = AgentContext.empty();
+      var gatewayToolDefinitions = List.of(createGatewayToolDefinition("mcpClient", invalidName));
+
+      assertThatThrownBy(() -> handler.initiateToolDiscovery(agentContext, gatewayToolDefinitions))
+          .isInstanceOf(ConnectorException.class)
+          .asInstanceOf(InstanceOfAssertFactories.type(ConnectorException.class))
+          .satisfies(
+              e -> {
+                assertThat(e.getErrorCode()).isEqualTo("MCP_GATEWAY_INVALID_TOOL_DEFINITIONS");
+                assertThat(e.getMessage())
+                    .isEqualTo(
+                        "Invalid MCP client activity ID(s) detected: ['%s']. Activity IDs must not contain the reserved separator '___'. Please rename the affected activities in the BPMN model."
+                            .formatted(invalidName));
+              });
+    }
+
+    @Test
+    void throwsException_listingAllInvalidNames() {
+      var agentContext = AgentContext.empty();
+      var gatewayToolDefinitions =
+          List.of(
+              createGatewayToolDefinition("mcpClient", "mcp___1"),
+              createGatewayToolDefinition("mcpClient", "valid"),
+              createGatewayToolDefinition("mcpClient", "mcp___2"));
+
+      assertThatThrownBy(() -> handler.initiateToolDiscovery(agentContext, gatewayToolDefinitions))
+          .isInstanceOf(ConnectorException.class)
+          .asInstanceOf(InstanceOfAssertFactories.type(ConnectorException.class))
+          .satisfies(
+              e -> {
+                assertThat(e.getErrorCode()).isEqualTo("MCP_GATEWAY_INVALID_TOOL_DEFINITIONS");
+                assertThat(e.getMessage())
+                    .isEqualTo(
+                        "Invalid MCP client activity ID(s) detected: ['mcp___1', 'mcp___2']. Activity IDs must not contain the reserved separator '___'. Please rename the affected activities in the BPMN model.");
               });
     }
 

--- a/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/mcp/discovery/McpToolCallIdentifierTest.java
+++ b/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/mcp/discovery/McpToolCallIdentifierTest.java
@@ -82,7 +82,9 @@ class McpToolCallIdentifierTest {
           arguments("MCP_element123___tool_action"),
           arguments("MCP_element_name___tool_name"),
           arguments("MCP_a___b"),
-          arguments("MCP_very-long-element-name___very-long-tool-name"));
+          arguments("MCP_very-long-element-name___very-long-tool-name"),
+          arguments("MCP_element___tool___with___separators"),
+          arguments("MCP_Activity_1mlgkr7___loan-affordability___loan-affordability"));
     }
 
     static Stream<Arguments> invalidMcpToolCallNames() {
@@ -127,6 +129,16 @@ class McpToolCallIdentifierTest {
       assertThat(result.mcpToolName()).isEqualTo("b");
     }
 
+    @Test
+    void parsesCorrectly_whenToolNameHasSeparator() {
+      var result =
+          McpToolCallIdentifier.fromToolCallName(
+              "MCP_Activity_1mlgkr7___loan-affordability___loan-affordability");
+
+      assertThat(result.elementName()).isEqualTo("Activity_1mlgkr7");
+      assertThat(result.mcpToolName()).isEqualTo("loan-affordability___loan-affordability");
+    }
+
     @ParameterizedTest
     @ValueSource(
         strings = {
@@ -134,8 +146,7 @@ class McpToolCallIdentifierTest {
           "MCP____tool", // missing element name
           "MCP___", // missing both
           "element___tool", // missing prefix
-          "MCP_element_tool", // missing separator
-          "MCP_element___tool___extra" // too many parts
+          "MCP_element_tool" // missing separator
         })
     void throwsException_whenInvalidToolCallName(String invalidToolCallName) {
       assertThatThrownBy(() -> McpToolCallIdentifier.fromToolCallName(invalidToolCallName))
@@ -189,7 +200,9 @@ class McpToolCallIdentifierTest {
           arguments("a", "b"),
           arguments("element-with-dashes", "tool-with-dashes"),
           arguments("element_with_underscores", "tool_with_underscores"),
-          arguments("CamelCaseElement", "CamelCaseTool"));
+          arguments("CamelCaseElement", "CamelCaseTool"),
+          arguments("Activity_1mlgkr7", "loan-affordability___loan-affordability"),
+          arguments("element", "tool___with___separators"));
     }
   }
 }


### PR DESCRIPTION
# Description
Backport of #6527 to `stable/8.8`.