### PR TITLE
deps(elasticsearch): exclude es major updates by renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -112,7 +112,9 @@
         "major"
       ],
       "matchPackageNames": [
-        "org.opensearch.client:opensearch-java"
+        "org.opensearch.client:opensearch-java",
+        "co.elastic.clients:elasticsearch-java",
+        "org.elasticsearch.client:elasticsearch-rest-client"
       ],
       "enabled": false
     }


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
Elasticsearch client was downgraded [here](https://github.com/camunda/connectors/pull/6494) but we did not exclude major updates from renovate.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #

## Checklist

- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest
  release, as this branch will be rebased onto main before the next release. Example backport labels:
    - `backport stable/8.8`: for changes that should be included in the next 8.8.x release.
    - **or** `backport release-8.8.7`: for changes that should be included in the specific release 8.8.7, and this
      *release has already been created*. The release branch will be merged back into stable/8.8 later, so the change
      will be included in future 8.8.x releases as well.
- [ ] Tests/Integration tests for the changes have been added if applicable.

