### PR TITLE
Adjust bug label format and add note in bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.md
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.md
@@ -1,7 +1,7 @@
 ---
 name: Bug report
 about: Report a problem and help us fix it.
-labels: "kind:bug"
+labels: "kind/bug"
 ---
 
 
@@ -25,4 +25,4 @@ __Environment__
 
 - OS: [e.g. Windows 7]
 - Library version: [e.g. 2.0.0]
-- Camunda version: [e.g. 8.0.4 (self-managed)]
+- Camunda version: [e.g. 8.0.4 (self-managed)] --> please also use affects/8.X label


### PR DESCRIPTION
Updated bug report template to correct label format kind/bug and add note about using affects/8.X label.

## Description

<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #

## Checklist

- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest
  release, as this branch will be rebased onto main before the next release. Example backport labels:
    - `backport stable/8.8`: for changes that should be included in the next 8.8.x release.
    - **or** `backport release-8.8.7`: for changes that should be included in the specific release 8.8.7, and this
      *release has already been created*. The release branch will be merged back into stable/8.8 later, so the change
      will be included in future 8.8.x releases as well.
- [ ] Tests/Integration tests for the changes have been added if applicable.

