### PR TITLE
refactor: use message subscription statistics endpoint

### DIFF
--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/importer/Importers.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/importer/Importers.java
@@ -16,7 +16,6 @@
  */
 package io.camunda.connector.runtime.inbound.importer;
 
-import io.camunda.client.api.search.response.MessageSubscription;
 import io.camunda.connector.runtime.inbound.search.SearchQueryClient;
 import io.camunda.connector.runtime.inbound.state.model.ImportResult;
 import io.camunda.connector.runtime.inbound.state.model.ImportResult.ImportType;
@@ -71,15 +70,16 @@ public class Importers {
     LOGGER.debug("Starting import of ACTIVE versions");
 
     Map<ProcessDefinitionRef, Set<Long>> result =
-        PaginatedSearchUtil.queryAllPages(searchQueryClient::queryMessageSubscriptions).stream()
-            .filter(Importers::isProcessDefinitionKeyNotNull)
+        PaginatedSearchUtil.queryAllPages(searchQueryClient::queryMessageSubscriptionStatistics)
+            .stream()
             .collect(
                 Collectors.groupingBy(
-                    subscription ->
+                    stats ->
                         new ProcessDefinitionRef(
-                            subscription.getProcessDefinitionId(), subscription.getTenantId()),
+                            stats.getProcessDefinitionId(), stats.getTenantId()),
                     Collectors.mapping(
-                        MessageSubscription::getProcessDefinitionKey, Collectors.toSet())));
+                        stats -> Long.parseLong(stats.getProcessDefinitionKey()),
+                        Collectors.toSet())));
 
     LOGGER.debug("Imported {} active process versions", result.size());
     if (LOGGER.isTraceEnabled()) {
@@ -96,23 +96,5 @@ public class Importers {
     }
 
     return new ImportResult(result, ImportType.HAVE_ACTIVE_SUBSCRIPTIONS);
-  }
-
-  // Backward compatibility filter & warning when we run against older Camunda versions
-  private static boolean warningAlreadyLogged = false;
-
-  private static boolean isProcessDefinitionKeyNotNull(MessageSubscription subscription) {
-    if (subscription.getProcessDefinitionKey() != null) {
-      return true;
-    }
-    if (!warningAlreadyLogged) {
-      LOGGER.warn(
-          "Imported MessageSubscription without processDefinitionKey. "
-              + "This is a version compatibility issue. "
-              + "Inbound connectors relying on active subscriptions may not work as expected. "
-              + "Upgrade to Camunda Platform 8.9+ to remove this warning.");
-      warningAlreadyLogged = true;
-    }
-    return false;
   }
 }

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/search/SearchQueryClient.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/search/SearchQueryClient.java
@@ -17,10 +17,10 @@
 package io.camunda.connector.runtime.inbound.search;
 
 import io.camunda.client.api.search.response.ElementInstance;
-import io.camunda.client.api.search.response.MessageSubscription;
 import io.camunda.client.api.search.response.ProcessDefinition;
 import io.camunda.client.api.search.response.SearchResponse;
 import io.camunda.client.api.search.response.Variable;
+import io.camunda.client.api.statistics.response.ProcessDefinitionMessageSubscriptionStatistics;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 
 /** Wrapper over Zeebe client for search query methods. Enables easier mocking and testing. */
@@ -28,7 +28,8 @@ public interface SearchQueryClient {
 
   SearchResponse<ProcessDefinition> queryProcessDefinitions(String paginationIndex);
 
-  SearchResponse<MessageSubscription> queryMessageSubscriptions(String paginationIndex);
+  ProcessDefinitionMessageSubscriptionStatistics queryMessageSubscriptionStatistics(
+      String paginationIndex);
 
   SearchResponse<ElementInstance> queryActiveFlowNodes(
       long processDefinitionKey, String elementId, String paginationIndex);

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/search/SearchQueryClientImpl.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/search/SearchQueryClientImpl.java
@@ -19,6 +19,7 @@ package io.camunda.connector.runtime.inbound.search;
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.search.enums.ElementInstanceState;
 import io.camunda.client.api.search.response.*;
+import io.camunda.client.api.statistics.response.ProcessDefinitionMessageSubscriptionStatistics;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import java.io.ByteArrayInputStream;
@@ -49,8 +50,9 @@ public class SearchQueryClientImpl implements SearchQueryClient {
   }
 
   @Override
-  public SearchResponse<MessageSubscription> queryMessageSubscriptions(String paginationIndex) {
-    final var query = camundaClient.newMessageSubscriptionSearchRequest();
+  public ProcessDefinitionMessageSubscriptionStatistics queryMessageSubscriptionStatistics(
+      String paginationIndex) {
+    final var query = camundaClient.newProcessDefinitionMessageSubscriptionStatisticsRequest();
     if (paginationIndex != null) {
       query.page(p -> p.limit(limit).after(paginationIndex));
     } else {

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/inbound/search/SearchQueryClientTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/inbound/search/SearchQueryClientTest.java
@@ -92,7 +92,7 @@ public class SearchQueryClientTest {
   }
 
   @Test
-  public void shouldFetchMessageSubscriptions() {
+  public void shouldFetchMessageSubscriptionStatistics() {
     // Given
     BpmnModelInstance modelInstance =
         Bpmn.createExecutableProcess("messageProcess")
@@ -120,57 +120,78 @@ public class SearchQueryClientTest {
 
     // When
     SearchQueryClientImpl searchClient = new SearchQueryClientImpl(camundaClient, 200);
-    var result = searchClient.queryMessageSubscriptions(null);
+    var result = searchClient.queryMessageSubscriptionStatistics(null);
 
     // Then
     assertThat(result.items()).isNotEmpty();
-    var subscription =
-        result.items().stream().filter(s -> s.getMessageName().equals("testMessage")).findFirst();
-    assertThat(subscription).isPresent();
-    assertThat(subscription.get().getMessageName()).isEqualTo("testMessage");
+    var stats =
+        result.items().stream()
+            .filter(s -> "messageProcess".equals(s.getProcessDefinitionId()))
+            .findFirst();
+    assertThat(stats).isPresent();
+    assertThat(stats.get().getActiveSubscriptions()).isGreaterThan(0);
   }
 
   @Test
-  public void shouldFetchMessageSubscriptions_whenPaginated() {
-    // Given - create multiple message subscriptions
-    BpmnModelInstance modelInstance =
-        Bpmn.createExecutableProcess("multiMessageProcess")
+  public void shouldFetchMessageSubscriptionStatistics_whenPaginated() {
+    // Given - create multiple processes with message subscriptions
+    BpmnModelInstance modelInstance1 =
+        Bpmn.createExecutableProcess("paginatedProcess1")
             .startEvent()
             .intermediateCatchEvent("message1")
-            .message(m -> m.name("message1").zeebeCorrelationKeyExpression("key"))
-            .intermediateCatchEvent("message2")
-            .message(m -> m.name("message2").zeebeCorrelationKeyExpression("key"))
+            .message(m -> m.name("msg1").zeebeCorrelationKeyExpression("key"))
             .endEvent()
             .done();
+    BpmnModelInstance modelInstance2 =
+        Bpmn.createExecutableProcess("paginatedProcess2")
+            .startEvent()
+            .intermediateCatchEvent("message2")
+            .message(m -> m.name("msg2").zeebeCorrelationKeyExpression("key"))
+            .endEvent()
+            .done();
+
     camundaClient
         .newDeployResourceCommand()
-        .addProcessModel(modelInstance, "multiMessageProcess.bpmn")
+        .addProcessModel(modelInstance1, "paginatedProcess1.bpmn")
+        .send()
+        .join();
+    camundaClient
+        .newDeployResourceCommand()
+        .addProcessModel(modelInstance2, "paginatedProcess2.bpmn")
         .send()
         .join();
 
     camundaClient
         .newCreateInstanceCommand()
-        .bpmnProcessId("multiMessageProcess")
+        .bpmnProcessId("paginatedProcess1")
         .latestVersion()
-        .variables("{\"key\": \"test\"}")
+        .variables("{\"key\": \"test1\"}")
+        .send()
+        .join();
+    camundaClient
+        .newCreateInstanceCommand()
+        .bpmnProcessId("paginatedProcess2")
+        .latestVersion()
+        .variables("{\"key\": \"test2\"}")
         .send()
         .join();
 
     waitForMessageSubscription();
 
-    // When - fetch with pagination
+    // When - fetch with pagination (page size 1)
     SearchQueryClientImpl searchClient = new SearchQueryClientImpl(camundaClient, 1);
-    var resultPage1 = searchClient.queryMessageSubscriptions(null);
+    var resultPage1 = searchClient.queryMessageSubscriptionStatistics(null);
     assertThat(resultPage1.items()).isNotEmpty();
 
     var allItems = new ArrayList<>(resultPage1.items());
 
     if (resultPage1.page().endCursor() != null) {
-      var resultPage2 = searchClient.queryMessageSubscriptions(resultPage1.page().endCursor());
+      var resultPage2 =
+          searchClient.queryMessageSubscriptionStatistics(resultPage1.page().endCursor());
       allItems.addAll(resultPage2.items());
     }
 
-    // Then - verify we fetched at least one subscription
+    // Then - verify we fetched statistics
     assertThat(allItems).isNotEmpty();
   }
 


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

Refactored the process of importing active message subscriptions by switching from querying individual message subscriptions to querying message subscription statistics.

This was decided in https://camunda.slack.com/archives/C072SGECL9W/p1772635156515009

This change makes importing more efficient because we don't have to paginate through all message subscriptions individually but instead get a grouped per-process-definition view.

## Related issues

<!-- Which issues are closed by this PR or are related -->

related #6324 

## Checklist

- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest
  release, as this branch will be rebased onto main before the next release. Example backport labels:
    - `backport stable/8.8`: for changes that should be included in the next 8.8.x release.
    - **or** `backport release-8.8.7`: for changes that should be included in the specific release 8.8.7, and this
      *release has already been created*. The release branch will be merged back into stable/8.8 later, so the change
      will be included in future 8.8.x releases as well.
- [ ] Tests/Integration tests for the changes have been added if applicable.

