### PR TITLE
fix: avoid using singleton credentials provider for aws

### DIFF
--- a/connectors/aws/aws-base/src/main/java/io/camunda/connector/aws/CredentialsProviderSupportV2.java
+++ b/connectors/aws/aws-base/src/main/java/io/camunda/connector/aws/CredentialsProviderSupportV2.java
@@ -24,6 +24,6 @@ public class CredentialsProviderSupportV2 {
           AwsBasicCredentials.create(sca.accessKey(), sca.secretKey()));
     }
     LOGGER.debug("Falling to DefaultCredentialsProvider for AWS authentication (using aws sdk v2)");
-    return DefaultCredentialsProvider.create();
+    return DefaultCredentialsProvider.builder().build();
   }
 }


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

`DefaultCredentialsProvider.create()` is deprecated in the SDK and should not be used. It does NOT create a new instance of the credentials provider, contrary to what the name suggests. Instead it returns a singleton instance. This causes race conditions when the same provider is used by different threads.

We have observed this in a customer support ticket: https://jira.camunda.com/browse/SUPPORT-30933

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #

## Checklist

- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest
  release, as this branch will be rebased onto main before the next release. Example backport labels:
    - `backport stable/8.8`: for changes that should be included in the next 8.8.x release.
    - **or** `backport release-8.8.7`: for changes that should be included in the specific release 8.8.7, and this
      *release has already been created*. The release branch will be merged back into stable/8.8 later, so the change
      will be included in future 8.8.x releases as well.
- [ ] Tests/Integration tests for the changes have been added if applicable.

