### PR TITLE
ci: do not notify when the deploy snapshots steps are canceled

### DIFF
--- a/.github/workflows/DEPLOY_SNAPSHOTS.yaml
+++ b/.github/workflows/DEPLOY_SNAPSHOTS.yaml
@@ -245,7 +245,11 @@ jobs:
     name: Notify on failure
     runs-on: ubuntu-latest
     needs: [ deploy-snapshots, helm-deploy ]
-    if: failure() && !cancelled() && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/stable/') || startsWith(github.ref, 'refs/heads/alpha/'))
+    if: |
+      (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/stable/') || startsWith(github.ref, 'refs/heads/alpha/')) &&
+      (needs.deploy-snapshots.result == 'failure' || needs.helm-deploy.result == 'failure') &&
+      needs.deploy-snapshots.result != 'cancelled' &&
+      needs.helm-deploy.result != 'cancelled'
     steps:
       - name: Send Slack notification on failure
         uses: slackapi/slack-github-action@v2.1.1


### PR DESCRIPTION
## Description

This pull request updates the workflow condition for the "Notify on failure" job in the `.github/workflows/DEPLOY_SNAPSHOTS.yaml` file. The change makes the notification logic more precise by explicitly checking the results of the dependent jobs and ensuring notifications are only sent when a failure occurs (not a cancellation) on specific branches.

**Workflow logic improvements:**

* Updated the `if` condition for the "Notify on failure" job to trigger only when either `deploy-snapshots` or `helm-deploy` fails (but not if either is cancelled), and only on `main`, `stable/*`, or `alpha/*` branches. This prevents unnecessary notifications and improves clarity.
