### PR TITLE
test: fix NonProxyHostsTest

### DIFF
--- a/connector-commons/http-client/src/test/java/io/camunda/connector/http/client/proxy/NonProxyHostsTest.java
+++ b/connector-commons/http-client/src/test/java/io/camunda/connector/http/client/proxy/NonProxyHostsTest.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.stream.Stream;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -27,6 +28,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 public class NonProxyHostsTest {
 
+  @BeforeEach
   @AfterEach
   public void clearSystemProperties() {
     System.clearProperty("http.nonProxyHosts");


### PR DESCRIPTION
## Description

During local builds on my machine I see an error with the test suite from time to time. System properties are reset after each test but not before the first test runs, so the first test in the suite would fail if properties are dirtied. Adding a `@BeforeEach` together with `@AfterEach` on the test method fixed the issue.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #

## Checklist

- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest
  release, as this branch will be rebased onto main before the next release. Example backport labels:
    - `backport stable/8.8`: for changes that should be included in the next 8.8.x release.
    - **or** `backport release-8.8.7`: for changes that should be included in the specific release 8.8.7, and this
      *release has already been created*. The release branch will be merged back into stable/8.8 later, so the change
      will be included in future 8.8.x releases as well.
- [ ] Tests/Integration tests for the changes have been added if applicable.

