### PR TITLE
feat: Re-enable HTTP proxy support for MCP connectors

### DIFF
--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/mcp/client/configuration/mcpsdk/McpSdkMcpClientConfiguration.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/mcp/client/configuration/mcpsdk/McpSdkMcpClientConfiguration.java
@@ -7,6 +7,7 @@
 package io.camunda.connector.agenticai.mcp.client.configuration.mcpsdk;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.connector.agenticai.common.AgenticAiHttpProxySupport;
 import io.camunda.connector.agenticai.mcp.client.configuration.annotation.RuntimeMcpClientFactory;
 import io.camunda.connector.agenticai.mcp.client.framework.bootstrap.McpClientHeadersSupplierFactory;
 import io.camunda.connector.agenticai.mcp.client.framework.mcpsdk.McpSdkClientFactory;
@@ -34,7 +35,9 @@ public class McpSdkMcpClientConfiguration {
   @RuntimeMcpClientFactory
   public McpSdkClientFactory mcpSdkMcpClientFactory(
       @ConnectorsObjectMapper ObjectMapper objectMapper,
+      AgenticAiHttpProxySupport httpProxySupport,
       McpClientHeadersSupplierFactory headersSupplierFactory) {
-    return new McpSdkClientFactory(objectMapper, headersSupplierFactory);
+    return new McpSdkClientFactory(
+        objectMapper, httpProxySupport.getJdkHttpClientProxyConfigurator(), headersSupplierFactory);
   }
 }

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/mcp/client/configuration/mcpsdk/McpSdkMcpRemoteClientConfiguration.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/mcp/client/configuration/mcpsdk/McpSdkMcpRemoteClientConfiguration.java
@@ -7,6 +7,7 @@
 package io.camunda.connector.agenticai.mcp.client.configuration.mcpsdk;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.connector.agenticai.common.AgenticAiHttpProxySupport;
 import io.camunda.connector.agenticai.mcp.client.configuration.annotation.RemoteMcpClientFactory;
 import io.camunda.connector.agenticai.mcp.client.framework.bootstrap.McpClientHeadersSupplierFactory;
 import io.camunda.connector.agenticai.mcp.client.framework.mcpsdk.McpSdkClientFactory;
@@ -35,7 +36,9 @@ public class McpSdkMcpRemoteClientConfiguration {
   @RemoteMcpClientFactory
   public McpSdkClientFactory mcpSdkMcpRemoteClientFactory(
       @ConnectorsObjectMapper ObjectMapper objectMapper,
+      AgenticAiHttpProxySupport httpProxySupport,
       McpClientHeadersSupplierFactory headersSupplierFactory) {
-    return new McpSdkClientFactory(objectMapper, headersSupplierFactory);
+    return new McpSdkClientFactory(
+        objectMapper, httpProxySupport.getJdkHttpClientProxyConfigurator(), headersSupplierFactory);
   }
 }

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/mcp/client/framework/mcpsdk/McpSdkClientFactory.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/mcp/client/framework/mcpsdk/McpSdkClientFactory.java
@@ -12,6 +12,7 @@ import io.camunda.connector.agenticai.mcp.client.configuration.McpClientConfigur
 import io.camunda.connector.agenticai.mcp.client.execution.McpClientDelegate;
 import io.camunda.connector.agenticai.mcp.client.framework.bootstrap.McpClientHeadersSupplierFactory;
 import io.camunda.connector.agenticai.mcp.client.framework.mcpsdk.rpc.McpSdkMcpClientDelegate;
+import io.camunda.connector.http.client.client.jdk.proxy.JdkHttpClientProxyConfigurator;
 import io.modelcontextprotocol.client.McpClient;
 import io.modelcontextprotocol.client.transport.HttpClientSseClientTransport;
 import io.modelcontextprotocol.client.transport.HttpClientStreamableHttpTransport;
@@ -28,12 +29,17 @@ import java.util.Optional;
 public class McpSdkClientFactory implements McpClientFactory {
 
   public static final Duration DEFAULT_TIMEOUT = Duration.ofSeconds(30);
+
   private final ObjectMapper objectMapper;
+  private final JdkHttpClientProxyConfigurator proxyConfigurator;
   private final McpClientHeadersSupplierFactory headersSupplierFactory;
 
   public McpSdkClientFactory(
-      ObjectMapper objectMapper, McpClientHeadersSupplierFactory headersSupplierFactory) {
+      ObjectMapper objectMapper,
+      JdkHttpClientProxyConfigurator proxyConfigurator,
+      McpClientHeadersSupplierFactory headersSupplierFactory) {
     this.objectMapper = objectMapper;
+    this.proxyConfigurator = proxyConfigurator;
     this.headersSupplierFactory = headersSupplierFactory;
   }
 
@@ -82,6 +88,7 @@ public class McpSdkClientFactory implements McpClientFactory {
     return HttpClientStreamableHttpTransport.builder(streamableHttpConfig.url())
         .endpoint(
             streamableHttpConfig.url()) // see https://github.com/camunda/connectors/issues/6393
+        .customizeClient(proxyConfigurator::configure)
         .connectTimeout(timeout(streamableHttpConfig.timeout()))
         .supportedProtocolVersions(
             List.of(
@@ -102,13 +109,13 @@ public class McpSdkClientFactory implements McpClientFactory {
 
     return HttpClientSseClientTransport.builder(sseConfig.url())
         .sseEndpoint(sseConfig.url()) // see https://github.com/camunda/connectors/issues/6393
+        .customizeClient(proxyConfigurator::configure)
         .connectTimeout(timeout(sseConfig.timeout()))
         .customizeRequest(
             request -> {
               var headers = headerSuppliers.get();
               headers.forEach(request::header);
             })
-        // todo proxy configuration
         .build();
   }
 


### PR DESCRIPTION
## Description

Based on #6666

* Re-enables HTTP proxy support for MCP clients (originally implemented in #6335, reverted in #6524) with support for the new `_PLAIN_` env vars introduced in #6646 

## Related issues

closes #6250

## Checklist

- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest
  release, as this branch will be rebased onto main before the next release. Example backport labels:
    - `backport stable/8.8`: for changes that should be included in the next 8.8.x release.
    - **or** `backport release-8.8.7`: for changes that should be included in the specific release 8.8.7, and this
      *release has already been created*. The release branch will be merged back into stable/8.8 later, so the change
      will be included in future 8.8.x releases as well.
- [x] Tests/Integration tests for the changes have been added if applicable.

