### PR TITLE
chore(docker): create a way to have health check inside hardened image

### DIFF
--- a/bundle/camunda-saas-bundle/Dockerfile
+++ b/bundle/camunda-saas-bundle/Dockerfile
@@ -19,4 +19,9 @@ USER 1001:1001
 ENV CAMUNDA_CONNECTOR_RUNTIME_SAAS=true
 ENV CAMUNDA_CLIENT_AUTH_CREDENTIALS_CACHE_PATH=/tmp/connectors
 
+HEALTHCHECK --interval=30s --timeout=5s --retries=5 --start-period=30s \
+  CMD java -cp /opt/app/*-with-dependencies.jar \
+      -Dloader.main=io.camunda.connector.runtime.healthcheck.HealthCheckCommand \
+      org.springframework.boot.loader.launch.PropertiesLauncher
+
 ENTRYPOINT ["java", "--add-opens=java.base/java.util.concurrent=ALL-UNNAMED", "-cp", "/opt/app/*", "org.springframework.boot.loader.launch.PropertiesLauncher"]

--- a/bundle/camunda-saas-bundle/Dockerfile
+++ b/bundle/camunda-saas-bundle/Dockerfile
@@ -19,6 +19,7 @@ USER 1001:1001
 ENV CAMUNDA_CONNECTOR_RUNTIME_SAAS=true
 ENV CAMUNDA_CLIENT_AUTH_CREDENTIALS_CACHE_PATH=/tmp/connectors
 ENV MANAGEMENT_SERVER_PORT=9080
+ENV HEALTHCHECK_URL=http://localhost:9080/actuator/health/readiness
 
 HEALTHCHECK --interval=30s --timeout=5s --retries=5 --start-period=30s \
   CMD java -cp /opt/app/*-with-dependencies.jar \

--- a/bundle/camunda-saas-bundle/Dockerfile
+++ b/bundle/camunda-saas-bundle/Dockerfile
@@ -18,6 +18,7 @@ USER 1001:1001
 
 ENV CAMUNDA_CONNECTOR_RUNTIME_SAAS=true
 ENV CAMUNDA_CLIENT_AUTH_CREDENTIALS_CACHE_PATH=/tmp/connectors
+ENV MANAGEMENT_SERVER_PORT=9080
 
 HEALTHCHECK --interval=30s --timeout=5s --retries=5 --start-period=30s \
   CMD java -cp /opt/app/*-with-dependencies.jar \

--- a/bundle/camunda-saas-bundle/Dockerfile
+++ b/bundle/camunda-saas-bundle/Dockerfile
@@ -18,7 +18,6 @@ USER 1001:1001
 
 ENV CAMUNDA_CONNECTOR_RUNTIME_SAAS=true
 ENV CAMUNDA_CLIENT_AUTH_CREDENTIALS_CACHE_PATH=/tmp/connectors
-ENV MANAGEMENT_SERVER_PORT=9080
 ENV HEALTHCHECK_URL=http://localhost:9080/actuator/health/readiness
 
 HEALTHCHECK --interval=30s --timeout=5s --retries=5 --start-period=30s \

--- a/bundle/default-bundle/Dockerfile
+++ b/bundle/default-bundle/Dockerfile
@@ -27,6 +27,7 @@ RUN addgroup --gid 1001 camunda && adduser -S -G camunda -u 1001 --no-create-hom
 USER 1001:1001
 
 ENV CAMUNDA_CLIENT_AUTH_CREDENTIALS_CACHE_PATH=/tmp/connectors
+ENV HEALTHCHECK_URL=http://localhost:8080/actuator/health/readiness
 
 HEALTHCHECK --interval=30s --timeout=5s --retries=5 --start-period=30s \
   CMD java -cp /opt/app/*-with-dependencies.jar \

--- a/bundle/default-bundle/Dockerfile
+++ b/bundle/default-bundle/Dockerfile
@@ -27,4 +27,10 @@ RUN addgroup --gid 1001 camunda && adduser -S -G camunda -u 1001 --no-create-hom
 USER 1001:1001
 
 ENV CAMUNDA_CLIENT_AUTH_CREDENTIALS_CACHE_PATH=/tmp/connectors
+
+HEALTHCHECK --interval=30s --timeout=5s --retries=5 --start-period=30s \
+  CMD java -cp /opt/app/*-with-dependencies.jar \
+      -Dloader.main=io.camunda.connector.runtime.healthcheck.HealthCheckCommand \
+      org.springframework.boot.loader.launch.PropertiesLauncher
+
 ENTRYPOINT ["/start.sh"]

--- a/connector-runtime/connector-runtime-application/Dockerfile
+++ b/connector-runtime/connector-runtime-application/Dockerfile
@@ -29,4 +29,10 @@ USER 1001:1001
 
 # Use entry point to allow downstream images to add JVM arguments using CMD
 ENV CAMUNDA_CLIENT_AUTH_CREDENTIALS_CACHE_PATH=/tmp/connectors
+
+HEALTHCHECK --interval=30s --timeout=5s --retries=5 --start-period=30s \
+  CMD java -cp /opt/app/*-with-dependencies.jar \
+      -Dloader.main=io.camunda.connector.runtime.healthcheck.HealthCheckCommand \
+      org.springframework.boot.loader.launch.PropertiesLauncher
+
 ENTRYPOINT ["/start.sh"]

--- a/connector-runtime/connector-runtime-application/Dockerfile
+++ b/connector-runtime/connector-runtime-application/Dockerfile
@@ -29,6 +29,7 @@ USER 1001:1001
 
 # Use entry point to allow downstream images to add JVM arguments using CMD
 ENV CAMUNDA_CLIENT_AUTH_CREDENTIALS_CACHE_PATH=/tmp/connectors
+ENV HEALTHCHECK_URL=http://localhost:8080/actuator/health/readiness
 
 HEALTHCHECK --interval=30s --timeout=5s --retries=5 --start-period=30s \
   CMD java -cp /opt/app/*-with-dependencies.jar \

--- a/connector-runtime/connector-runtime-application/src/main/java/io/camunda/connector/runtime/healthcheck/HealthCheckCommand.java
+++ b/connector-runtime/connector-runtime-application/src/main/java/io/camunda/connector/runtime/healthcheck/HealthCheckCommand.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.runtime.healthcheck;
+
+import java.net.HttpURLConnection;
+import java.net.URI;
+
+/**
+ * Lightweight health check command that can be invoked as a standalone Java process by Docker
+ * HEALTHCHECK. This is necessary because hardened base images do not include wget or curl.
+ *
+ * <p>Checks the Spring Boot Actuator readiness endpoint and exits with code 0 on success (HTTP 200)
+ * or code 1 on failure.
+ *
+ * <p>The server port and base path can be configured via environment variables:
+ *
+ * <ul>
+ *   <li>{@code SERVER_PORT} — defaults to {@code 8080}
+ *   <li>{@code MANAGEMENT_SERVER_PORT} — if set, takes precedence over {@code SERVER_PORT}
+ *   <li>{@code MANAGEMENT_SERVER_BASE_PATH} — defaults to {@code /actuator}
+ * </ul>
+ */
+public class HealthCheckCommand {
+
+  public static void main(String[] args) {
+    HttpURLConnection connection = null;
+    try {
+      String port = resolvePort();
+      String basePath = resolveBasePath();
+      String url = "http://localhost:" + port + basePath + "/health/readiness";
+
+      connection = (HttpURLConnection) URI.create(url).toURL().openConnection();
+      connection.setRequestMethod("GET");
+      connection.setConnectTimeout(5000);
+      connection.setReadTimeout(5000);
+
+      int responseCode = connection.getResponseCode();
+      if (responseCode == HttpURLConnection.HTTP_OK) {
+        System.exit(0);
+      } else {
+        System.err.println("Health check failed with HTTP status: " + responseCode);
+        System.exit(1);
+      }
+    } catch (Exception e) {
+      System.err.println("Health check failed: " + e.getMessage());
+      System.exit(1);
+    } finally {
+      if (connection != null) {
+        connection.disconnect();
+      }
+    }
+  }
+
+  private static String resolvePort() {
+    String managementPort = System.getenv("MANAGEMENT_SERVER_PORT");
+    if (managementPort != null && !managementPort.isBlank()) {
+      return managementPort;
+    }
+    String serverPort = System.getenv("SERVER_PORT");
+    if (serverPort != null && !serverPort.isBlank()) {
+      return serverPort;
+    }
+    return "8080";
+  }
+
+  private static String resolveBasePath() {
+    String basePath = System.getenv("MANAGEMENT_SERVER_BASE_PATH");
+    if (basePath != null && !basePath.isBlank()) {
+      return basePath;
+    }
+    return "/actuator";
+  }
+}

--- a/connector-runtime/connector-runtime-application/src/main/java/io/camunda/connector/runtime/healthcheck/HealthCheckCommand.java
+++ b/connector-runtime/connector-runtime-application/src/main/java/io/camunda/connector/runtime/healthcheck/HealthCheckCommand.java
@@ -26,11 +26,12 @@ import java.net.URI;
  * <p>Checks the Spring Boot Actuator readiness endpoint and exits with code 0 on success (HTTP 200)
  * or code 1 on failure.
  *
- * <p>The server port and base path can be configured via environment variables:
+ * <p>The health check URL can be configured via environment variables:
  *
  * <ul>
- *   <li>{@code SERVER_PORT} — defaults to {@code 8080}
+ *   <li>{@code HEALTHCHECK_URL} — full URL override; if set, all other variables are ignored
  *   <li>{@code MANAGEMENT_SERVER_PORT} — if set, takes precedence over {@code SERVER_PORT}
+ *   <li>{@code SERVER_PORT} — defaults to {@code 8080}
  *   <li>{@code MANAGEMENT_SERVER_BASE_PATH} — defaults to {@code /actuator}
  * </ul>
  */
@@ -39,9 +40,7 @@ public class HealthCheckCommand {
   public static void main(String[] args) {
     HttpURLConnection connection = null;
     try {
-      String port = resolvePort();
-      String basePath = resolveBasePath();
-      String url = "http://localhost:" + port + basePath + "/health/readiness";
+      String url = resolveUrl();
 
       connection = (HttpURLConnection) URI.create(url).toURL().openConnection();
       connection.setRequestMethod("GET");
@@ -63,6 +62,14 @@ public class HealthCheckCommand {
         connection.disconnect();
       }
     }
+  }
+
+  private static String resolveUrl() {
+    String url = System.getenv("HEALTHCHECK_URL");
+    if (url != null && !url.isBlank()) {
+      return url;
+    }
+    return "http://localhost:" + resolvePort() + resolveBasePath() + "/health/readiness";
   }
 
   private static String resolvePort() {

--- a/connector-runtime/connector-runtime-application/src/main/java/io/camunda/connector/runtime/healthcheck/HealthCheckCommand.java
+++ b/connector-runtime/connector-runtime-application/src/main/java/io/camunda/connector/runtime/healthcheck/HealthCheckCommand.java
@@ -69,26 +69,6 @@ public class HealthCheckCommand {
     if (url != null && !url.isBlank()) {
       return url;
     }
-    return "http://localhost:" + resolvePort() + resolveBasePath() + "/health/readiness";
-  }
-
-  private static String resolvePort() {
-    String managementPort = System.getenv("MANAGEMENT_SERVER_PORT");
-    if (managementPort != null && !managementPort.isBlank()) {
-      return managementPort;
-    }
-    String serverPort = System.getenv("SERVER_PORT");
-    if (serverPort != null && !serverPort.isBlank()) {
-      return serverPort;
-    }
-    return "8080";
-  }
-
-  private static String resolveBasePath() {
-    String basePath = System.getenv("MANAGEMENT_SERVER_BASE_PATH");
-    if (basePath != null && !basePath.isBlank()) {
-      return basePath;
-    }
-    return "/actuator";
+    return "http://localhost:8080/actuator/health/readiness";
   }
 }


### PR DESCRIPTION
This pull request introduces a Docker health check mechanism for the connector runtime images, ensuring reliable readiness detection without relying on external tools like `curl` or `wget`. The health check is implemented via a new lightweight Java command that queries the Spring Boot Actuator readiness endpoint. The Dockerfiles for all relevant bundles are updated to use this new health check.

Health check implementation:

* Added a new `HealthCheckCommand` Java class in `connector-runtime/connector-runtime-application/src/main/java/io/camunda/connector/runtime/healthcheck/HealthCheckCommand.java` that performs an HTTP GET to the `/actuator/health/readiness` endpoint and exits with code 0 on success, or 1 on failure. It supports configurable ports and base paths via environment variables.

Dockerfile updates for health check:

* Updated `bundle/camunda-saas-bundle/Dockerfile` to include the new `HEALTHCHECK` instruction, invoking the `HealthCheckCommand` for readiness checks.
* Updated `bundle/default-bundle/Dockerfile` to add the same health check mechanism.
* Updated `connector-runtime/connector-runtime-application/Dockerfile` to add the health check using the new Java command.


# TEST

It was locally tested with success 

<img width="1639" height="386" alt="image" src="https://github.com/user-attachments/assets/00a10ab4-997f-41ee-a67f-43c871f06b10" />