### PR TITLE
chore(clean-up): Remove AWS rollout feature flag

### DIFF
--- a/bundle/camunda-saas-bundle/src/main/java/io/camunda/connector/runtime/saas/SaaSSecretConfiguration.java
+++ b/bundle/camunda-saas-bundle/src/main/java/io/camunda/connector/runtime/saas/SaaSSecretConfiguration.java
@@ -47,15 +47,12 @@ public class SaaSSecretConfiguration {
   @Value("${camunda.saas.cluster.provider:gcp}")
   private String clusterProvider;
 
-  @Value("${camunda.saas.secrets.useAwsSecretProvider:false}")
-  private boolean useAwsSecretProvider;
-
   private AbstractSecretProvider secretProvider;
   private AbstractSecretProvider internalSecretProvider;
 
   @Bean
   public SecretProvider getSecretProvider() {
-    if (useAwsSecretProvider && Objects.equals(clusterProvider, "aws")) {
+    if (Objects.equals(clusterProvider, "aws")) {
       secretProvider = new AwsSecretProvider(clusterId, secretsNamePrefix);
     } else {
       secretProvider = new GcpSecretProvider(clusterId, secretsProjectId, secretsNamePrefix);
@@ -64,7 +61,7 @@ public class SaaSSecretConfiguration {
   }
 
   public SecretProvider getInternalSecretProvider() {
-    if (useAwsSecretProvider && Objects.equals(clusterProvider, "aws")) {
+    if (Objects.equals(clusterProvider, "aws")) {
       internalSecretProvider = new AwsSecretProvider(clusterId, secretsInternalNamePrefix);
     } else {
       internalSecretProvider =


### PR DESCRIPTION
## Description
Removing this feature flag, as it was only needed for rollout.

Operator PR: https://github.com/camunda/camunda-operator/pull/5199

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #5300

## Checklist

- [x] Backport labels are added if these code changes should be backported. No backport label is added to the latest
  release, as this branch will be rebased onto main before the next release. Example backport labels:
    - `backport stable/8.8`: for changes that should be included in the next 8.8.x release.
    - **or** `backport release-8.8.7`: for changes that should be included in the specific release 8.8.7, and this
      *release has already been created*. The release branch will be merged back into stable/8.8 later, so the change
      will be included in future 8.8.x releases as well.
- [ ] Tests/Integration tests for the changes have been added if applicable.

