### PR TITLE
fix: add filter to message subscription stats query

### DIFF
--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/search/SearchQueryClientImpl.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/search/SearchQueryClientImpl.java
@@ -54,10 +54,12 @@ public class SearchQueryClientImpl implements SearchQueryClient {
   @Override
   public ProcessDefinitionMessageSubscriptionStatistics queryMessageSubscriptionStatistics(
       String paginationIndex) {
-    final var query = camundaClient.newProcessDefinitionMessageSubscriptionStatisticsRequest()
-        .filter(
-            subscription ->
-                subscription.messageSubscriptionState(MessageSubscriptionState.CREATED));
+    final var query =
+        camundaClient
+            .newProcessDefinitionMessageSubscriptionStatisticsRequest()
+            .filter(
+                subscription ->
+                    subscription.messageSubscriptionState(MessageSubscriptionState.CREATED));
     if (paginationIndex != null) {
       query.page(p -> p.limit(limit).after(paginationIndex));
     } else {

--- a/connectors-e2e-test/connectors-e2e-test-inbound-runtime/src/test/java/io/camunda/connector/e2e/inbound/InboundConnectorMultiVersionTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-inbound-runtime/src/test/java/io/camunda/connector/e2e/inbound/InboundConnectorMultiVersionTests.java
@@ -650,8 +650,7 @@ public class InboundConnectorMultiVersionTests {
     }
 
     @Test
-    void
-        deployV1StartInstance_deployV2WithoutConnector_afterCorrelation_v1ShouldBeDeactivated() {
+    void deployV1StartInstance_deployV2WithoutConnector_afterCorrelation_v1ShouldBeDeactivated() {
       // This test verifies that the messageSubscriptionState(CREATED) filter correctly excludes
       // subscriptions that are no longer in CREATED state. Once all CREATED subscriptions for a
       // process version are gone (e.g., after message correlation), the old version should no


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

We were missing the filter on the message subscription statistics query. We only want active ('CREATED') subscriptions to adequately activate related inbound connectors.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #

## Checklist

- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest
  release, as this branch will be rebased onto main before the next release. Example backport labels:
    - `backport stable/8.8`: for changes that should be included in the next 8.8.x release.
    - **or** `backport release-8.8.7`: for changes that should be included in the specific release 8.8.7, and this
      *release has already been created*. The release branch will be merged back into stable/8.8 later, so the change
      will be included in future 8.8.x releases as well.
- [ ] Tests/Integration tests for the changes have been added if applicable.

