### PR TITLE
fix(graphql): throw ConnectorException on GraphQL 200 responses containing errors

### DIFF
--- a/connectors/http/graphql/src/main/java/io/camunda/connector/http/graphql/GraphQLFunction.java
+++ b/connectors/http/graphql/src/main/java/io/camunda/connector/http/graphql/GraphQLFunction.java
@@ -8,14 +8,19 @@ package io.camunda.connector.http.graphql;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.connector.api.annotation.OutboundConnector;
+import io.camunda.connector.api.error.ConnectorExceptionBuilder;
 import io.camunda.connector.api.outbound.OutboundConnectorContext;
 import io.camunda.connector.api.outbound.OutboundConnectorFunction;
 import io.camunda.connector.generator.java.annotation.ElementTemplate;
 import io.camunda.connector.http.base.HttpService;
 import io.camunda.connector.http.base.model.HttpCommonRequest;
+import io.camunda.connector.http.base.model.HttpCommonResult;
 import io.camunda.connector.http.graphql.model.GraphQLRequest;
 import io.camunda.connector.http.graphql.utils.GraphQLRequestMapper;
 import io.camunda.connector.jackson.ConnectorsObjectMapperSupplier;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -55,11 +60,34 @@ public class GraphQLFunction implements OutboundConnectorFunction {
     this.graphQLRequestMapper = new GraphQLRequestMapper(objectMapper);
   }
 
+  static final String GRAPHQL_ERROR_CODE = "GRAPHQL_ERROR";
+
   @Override
   public Object execute(OutboundConnectorContext context) {
     var graphQLRequest = context.bindVariables(GraphQLRequest.class);
     HttpCommonRequest commonRequest = graphQLRequestMapper.toHttpCommonRequest(graphQLRequest);
     LOGGER.debug("Executing graphql connector with request {}", commonRequest);
-    return httpService.executeConnectorRequest(commonRequest, context);
+    var rawResult = httpService.executeConnectorRequest(commonRequest, context);
+    if (!(rawResult instanceof HttpCommonResult result)) {
+      return rawResult;
+    }
+    if (result.body() instanceof Map<?, ?> body
+        && body.get("errors") instanceof List<?> errors
+        && !errors.isEmpty()) {
+      var firstMessage =
+          errors.get(0) instanceof Map<?, ?> firstError
+                  && firstError.get("message") instanceof String msg
+              ? msg
+              : "GraphQL response contains errors";
+      var responseVariables = new HashMap<String, Object>();
+      responseVariables.put("body", result.body());
+      responseVariables.put("headers", result.headers());
+      throw new ConnectorExceptionBuilder()
+          .errorCode(GRAPHQL_ERROR_CODE)
+          .message(firstMessage)
+          .errorVariables(Map.of("response", responseVariables))
+          .build();
+    }
+    return result;
   }
 }

--- a/connectors/http/graphql/src/test/java/io/camunda/connector/http/graphql/GraphQLFunctionTest.java
+++ b/connectors/http/graphql/src/test/java/io/camunda/connector/http/graphql/GraphQLFunctionTest.java
@@ -10,12 +10,15 @@ import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.any;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static io.camunda.connector.http.graphql.GraphQLFunction.GRAPHQL_ERROR_CODE;
 import static org.apache.http.entity.ContentType.APPLICATION_JSON;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.catchException;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import io.camunda.connector.api.error.ConnectorException;
 import io.camunda.connector.api.error.ConnectorInputException;
 import io.camunda.connector.api.secret.SecretContext;
 import io.camunda.connector.api.secret.SecretProvider;
@@ -41,6 +44,8 @@ public class GraphQLFunctionTest extends BaseTest {
       "src/test/resources/requests/success-test-cases.json";
   private static final String FAIL_CASES_RESOURCE_PATH =
       "src/test/resources/requests/fail-test-cases.json";
+  private static final String GRAPHQL_200_WITH_ERRORS_CASES_RESOURCE_PATH =
+      "src/test/resources/requests/graphql-200-with-errors-test-cases.json";
 
   private GraphQLFunction functionUnderTest;
 
@@ -50,6 +55,10 @@ public class GraphQLFunctionTest extends BaseTest {
 
   private static Stream<String> failCases() throws IOException {
     return loadTestCasesFromResourceFile(FAIL_CASES_RESOURCE_PATH);
+  }
+
+  private static Stream<String> graphql200WithErrorsCases() throws IOException {
+    return loadTestCasesFromResourceFile(GRAPHQL_200_WITH_ERRORS_CASES_RESOURCE_PATH);
   }
 
   @BeforeEach
@@ -112,6 +121,60 @@ public class GraphQLFunctionTest extends BaseTest {
         graphQLRequestMapper.toHttpCommonRequest(context.bindVariables(GraphQLRequest.class));
     // then
     assertThat(request.getConnectionTimeoutInSeconds()).isEqualTo(expectedTimeInSeconds);
+  }
+
+  @ParameterizedTest(name = "Executing test case: {0}")
+  @MethodSource("graphql200WithErrorsCases")
+  void shouldThrowConnectorException_WhenResponseContains200WithErrors(final String input) {
+    stubFor(
+        any(urlPathEqualTo("/http-endpoint"))
+            .willReturn(
+                aResponse()
+                    .withStatus(200)
+                    .withHeader("Content-Type", "application/json")
+                    .withBody(
+                        "{\"data\":null,\"errors\":[{\"message\":\"Cannot query field 'unknownField' on type 'Query'\"}]}")));
+
+    final var context =
+        OutboundConnectorContextBuilder.create()
+            .variables(input)
+            .secrets(new StaticSecretProvider("foo"))
+            .build();
+
+    assertThatThrownBy(() -> functionUnderTest.execute(context))
+        .isInstanceOf(ConnectorException.class)
+        .satisfies(
+            ex -> {
+              var ce = (ConnectorException) ex;
+              assertThat(ce.getErrorCode()).isEqualTo(GRAPHQL_ERROR_CODE);
+              assertThat(ce.getMessage())
+                  .isEqualTo("Cannot query field 'unknownField' on type 'Query'");
+              @SuppressWarnings("unchecked")
+              var response = (java.util.Map<String, Object>) ce.getErrorVariables().get("response");
+              assertThat(response).containsKey("body");
+              assertThat(response).containsKey("headers");
+            });
+  }
+
+  @ParameterizedTest(name = "Executing test case: {0}")
+  @MethodSource("graphql200WithErrorsCases")
+  void shouldReturnResult_WhenResponseContains200WithOnlyData(final String input) {
+    stubFor(
+        any(urlPathEqualTo("/http-endpoint"))
+            .willReturn(
+                aResponse()
+                    .withStatus(200)
+                    .withHeader("Content-Type", "application/json")
+                    .withBody("{\"data\":{\"user\":{\"id\":\"1\",\"name\":\"Alice\"}}}")));
+
+    final var context =
+        OutboundConnectorContextBuilder.create()
+            .variables(input)
+            .secrets(new StaticSecretProvider("foo"))
+            .build();
+
+    var result = functionUnderTest.execute(context);
+    assertThat(result).isInstanceOf(HttpCommonResult.class);
   }
 
   private HttpCommonResult arrange(String input) throws Exception {

--- a/connectors/http/graphql/src/test/resources/requests/graphql-200-with-errors-test-cases.json
+++ b/connectors/http/graphql/src/test/resources/requests/graphql-200-with-errors-test-cases.json
@@ -1,0 +1,13 @@
+[
+  {
+    "descriptionOfTest": "GraphQL 200 response containing top-level errors array",
+    "authentication": {
+      "type": "noAuth"
+    },
+    "graphql": {
+      "method": "post",
+      "url": "http://localhost:8085/http-endpoint",
+      "query": "{ hero { name } }"
+    }
+  }
+]


### PR DESCRIPTION
## Description

A GraphQL server can return HTTP `200 OK` while still reporting errors in the response body (e.g. `{"data": null, "errors": [{"message": "..."}]}`). This is valid per the GraphQL over HTTP spec, but the connector was silently treating these responses as successes, making it impossible to trigger `errorExpression` in a process.

This is a first pass at implementing the fix — I welcome any edits you see fit.

**Root cause:** `CustomResponseHandler` only throws for HTTP status ≥ 400. A `200 + errors` response bypassed it entirely and was returned as a `SuccessResult`.

**Fix (`GraphQLFunction.java`):**
- After the HTTP call, check if the response body is a `Map` with a non-empty `errors` list
- If so, throw a `ConnectorException` with:
  - Error code `GRAPHQL_ERROR`
  - The first GraphQL error's `message` as the exception message
  - `errorVariables = {response: {body: ..., headers: ...}}` — consistent with `ConnectorExceptionMapper` so existing `errorExpression` patterns work
- Safe `instanceof HttpCommonResult` guard (avoids a blind cast that would break when `storeResponse` is enabled and returns a `Document`)

**Tests added/strengthened (`GraphQLFunctionTest.java`):**
- `shouldThrowConnectorException_WhenResponseContains200WithErrors` — asserts `errorCode`, exception message, and `errorVariables` shape (`response.body` + `response.headers` present)
- `shouldReturnResult_WhenResponseContains200WithOnlyData` — regression test: clean `200` with only `data` (no `errors` key) still returns `HttpCommonResult` without throwing

## Related issues

closes #6702

## Checklist

- [x] Backport labels are added if these code changes should be backported. No backport label is added to the latest
  release, as this branch will be rebased onto main before the next release. Example backport labels:
    - `backport stable/8.8`: for changes that should be included in the next 8.8.x release.
    - **or** `backport release-8.8.7`: for changes that should be included in the specific release 8.8.7, and this
      *release has already been created*. The release branch will be merged back into stable/8.8 later, so the change
      will be included in future 8.8.x releases as well.
- [x] Tests/Integration tests for the changes have been added if applicable.