### PR TITLE
feat(a2a): add HTTP proxy support to A2A using a custom JDK client implementation

### DIFF
--- a/connectors/agentic-ai/pom.xml
+++ b/connectors/agentic-ai/pom.xml
@@ -191,7 +191,27 @@
 
     <dependency>
       <groupId>io.github.a2asdk</groupId>
+      <artifactId>a2a-java-sdk-common</artifactId>
+      <version>${version.a2asdk}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.github.a2asdk</groupId>
+      <artifactId>a2a-java-sdk-spec</artifactId>
+      <version>${version.a2asdk}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.github.a2asdk</groupId>
+      <artifactId>a2a-java-sdk-http-client</artifactId>
+      <version>${version.a2asdk}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.github.a2asdk</groupId>
       <artifactId>a2a-java-sdk-client</artifactId>
+      <version>${version.a2asdk}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.github.a2asdk</groupId>
+      <artifactId>a2a-java-sdk-client-transport-spi</artifactId>
       <version>${version.a2asdk}</version>
     </dependency>
     <dependency>
@@ -202,16 +222,6 @@
     <dependency>
       <groupId>io.github.a2asdk</groupId>
       <artifactId>a2a-java-sdk-client-transport-rest</artifactId>
-      <version>${version.a2asdk}</version>
-    </dependency>
-    <dependency>
-      <groupId>io.github.a2asdk</groupId>
-      <artifactId>a2a-java-sdk-spec</artifactId>
-      <version>${version.a2asdk}</version>
-    </dependency>
-    <dependency>
-      <groupId>io.github.a2asdk</groupId>
-      <artifactId>a2a-java-sdk-client-transport-spi</artifactId>
       <version>${version.a2asdk}</version>
     </dependency>
     <dependency>

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/a2a/client/common/A2aAgentCardFetcherImpl.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/a2a/client/common/A2aAgentCardFetcherImpl.java
@@ -10,10 +10,12 @@ import static io.camunda.connector.agenticai.a2a.client.common.A2aErrorCodes.ERR
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 import io.a2a.A2A;
+import io.a2a.client.http.A2AHttpClient;
 import io.a2a.spec.A2AClientError;
 import io.a2a.spec.AgentCard;
 import io.camunda.connector.agenticai.a2a.client.common.model.A2aConnectionConfiguration;
 import io.camunda.connector.agenticai.a2a.client.common.model.result.A2aAgentCard;
+import io.camunda.connector.agenticai.a2a.client.common.sdk.http.A2aHttpClientFactory;
 import io.camunda.connector.api.error.ConnectorException;
 import java.util.Collections;
 import org.apache.commons.collections4.CollectionUtils;
@@ -24,6 +26,12 @@ public class A2aAgentCardFetcherImpl implements A2aAgentCardFetcher {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(A2aAgentCardFetcherImpl.class);
   private static final String DEFAULT_AGENT_CARD_PATH = ".well-known/agent-card.json";
+
+  private final A2AHttpClient httpClient;
+
+  public A2aAgentCardFetcherImpl(A2aHttpClientFactory httpClientFactory) {
+    this.httpClient = httpClientFactory.createHttpClient();
+  }
 
   @Override
   public A2aAgentCard fetchAgentCard(A2aConnectionConfiguration connection) {
@@ -39,7 +47,8 @@ public class A2aAgentCardFetcherImpl implements A2aAgentCardFetcher {
             ? connection.agentCardLocation()
             : DEFAULT_AGENT_CARD_PATH;
     try {
-      return A2A.getAgentCard(connection.url(), relativeCardPath, Collections.emptyMap());
+      return A2A.getAgentCard(
+          httpClient, connection.url(), relativeCardPath, Collections.emptyMap());
     } catch (A2AClientError e) {
       throw new ConnectorException(
           ERROR_CODE_A2A_CLIENT_AGENT_CARD_RETRIEVAL_FAILED,

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/a2a/client/common/configuration/A2aClientCommonConfiguration.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/a2a/client/common/configuration/A2aClientCommonConfiguration.java
@@ -14,6 +14,8 @@ import io.camunda.connector.agenticai.a2a.client.common.convert.A2aSdkObjectConv
 import io.camunda.connector.agenticai.a2a.client.common.convert.A2aSdkObjectConverterImpl;
 import io.camunda.connector.agenticai.a2a.client.common.sdk.A2aSdkClientFactory;
 import io.camunda.connector.agenticai.a2a.client.common.sdk.A2aSdkClientFactoryImpl;
+import io.camunda.connector.agenticai.a2a.client.common.sdk.http.A2aHttpClientFactory;
+import io.camunda.connector.agenticai.common.AgenticAiHttpProxySupport;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
@@ -38,14 +40,20 @@ public class A2aClientCommonConfiguration {
 
   @Bean
   @ConditionalOnMissingBean
-  public A2aAgentCardFetcher a2aAgentCardFetcher() {
-    return new A2aAgentCardFetcherImpl();
+  public A2aHttpClientFactory a2aHttpClientFactory(AgenticAiHttpProxySupport proxySupport) {
+    return new A2aHttpClientFactory(proxySupport);
+  }
+
+  @Bean
+  @ConditionalOnMissingBean
+  public A2aAgentCardFetcher a2aAgentCardFetcher(A2aHttpClientFactory httpClientFactory) {
+    return new A2aAgentCardFetcherImpl(httpClientFactory);
   }
 
   @Bean
   @ConditionalOnMissingBean
   public A2aSdkClientFactory a2aSdkClientFactory(
-      A2aClientCommonConfigurationProperties properties) {
-    return new A2aSdkClientFactoryImpl(properties.transport());
+      A2aClientCommonConfigurationProperties properties, A2aHttpClientFactory httpClientFactory) {
+    return new A2aSdkClientFactoryImpl(properties.transport(), httpClientFactory);
   }
 }

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/a2a/client/common/sdk/A2aSdkClientFactoryImpl.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/a2a/client/common/sdk/A2aSdkClientFactoryImpl.java
@@ -9,6 +9,7 @@ package io.camunda.connector.agenticai.a2a.client.common.sdk;
 import io.a2a.client.Client;
 import io.a2a.client.ClientEvent;
 import io.a2a.client.config.ClientConfig;
+import io.a2a.client.http.A2AHttpClient;
 import io.a2a.client.transport.grpc.GrpcTransport;
 import io.a2a.client.transport.grpc.GrpcTransportConfig;
 import io.a2a.client.transport.jsonrpc.JSONRPCTransport;
@@ -21,6 +22,7 @@ import io.a2a.spec.PushNotificationAuthenticationInfo;
 import io.a2a.spec.PushNotificationConfig;
 import io.camunda.connector.agenticai.a2a.client.common.configuration.A2aClientCommonConfigurationProperties.TransportConfiguration;
 import io.camunda.connector.agenticai.a2a.client.common.sdk.grpc.ManagedChannelFactory;
+import io.camunda.connector.agenticai.a2a.client.common.sdk.http.A2aHttpClientFactory;
 import java.util.function.BiConsumer;
 import org.apache.commons.lang3.StringUtils;
 
@@ -29,10 +31,12 @@ public class A2aSdkClientFactoryImpl implements A2aSdkClientFactory {
   private final RestTransportConfig restTransportConfig;
   private final TransportConfiguration transportConfiguration;
 
-  public A2aSdkClientFactoryImpl(TransportConfiguration transportConfiguration) {
+  public A2aSdkClientFactoryImpl(
+      TransportConfiguration transportConfiguration, A2aHttpClientFactory httpClientFactory) {
     this.transportConfiguration = transportConfiguration;
-    this.jsonrpcTransportConfig = new JSONRPCTransportConfig();
-    this.restTransportConfig = new RestTransportConfig();
+    A2AHttpClient httpClient = httpClientFactory.createHttpClient();
+    this.jsonrpcTransportConfig = new JSONRPCTransportConfig(httpClient);
+    this.restTransportConfig = new RestTransportConfig(httpClient);
   }
 
   @Override

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/a2a/client/common/sdk/http/A2aHttpClientFactory.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/a2a/client/common/sdk/http/A2aHttpClientFactory.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.agenticai.a2a.client.common.sdk.http;
+
+import io.a2a.client.http.A2AHttpClient;
+import io.camunda.connector.agenticai.common.AgenticAiHttpProxySupport;
+import java.net.http.HttpClient;
+
+/** Factory for creating proxy-configured {@link A2AHttpClient} instances. */
+public class A2aHttpClientFactory {
+
+  private final AgenticAiHttpProxySupport proxySupport;
+
+  public A2aHttpClientFactory(AgenticAiHttpProxySupport proxySupport) {
+    this.proxySupport = proxySupport;
+  }
+
+  public A2AHttpClient createHttpClient() {
+    HttpClient httpClient =
+        proxySupport
+            .getJdkHttpClientProxyConfigurator()
+            .configure(
+                HttpClient.newBuilder()
+                    .version(HttpClient.Version.HTTP_2)
+                    .followRedirects(HttpClient.Redirect.NORMAL))
+            .build();
+
+    return new CustomJdkA2AHttpClient(httpClient);
+  }
+}

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/a2a/client/common/sdk/http/CustomJdkA2AHttpClient.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/a2a/client/common/sdk/http/CustomJdkA2AHttpClient.java
@@ -1,0 +1,345 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.agenticai.a2a.client.common.sdk.http;
+
+import static java.net.HttpURLConnection.HTTP_FORBIDDEN;
+import static java.net.HttpURLConnection.HTTP_MULT_CHOICE;
+import static java.net.HttpURLConnection.HTTP_OK;
+import static java.net.HttpURLConnection.HTTP_UNAUTHORIZED;
+
+import io.a2a.client.http.A2AHttpClient;
+import io.a2a.client.http.A2AHttpResponse;
+import io.a2a.common.A2AErrorMessages;
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.net.http.HttpResponse.BodyHandler;
+import java.net.http.HttpResponse.BodyHandlers;
+import java.net.http.HttpResponse.BodySubscribers;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Flow;
+import java.util.function.Consumer;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Copy of {@link io.a2a.client.http.JdkA2AHttpClient} from the A2A SDK with an added constructor
+ * accepting a pre-configured {@link HttpClient} instance. This enables HTTP proxy support for A2A
+ * client communications.
+ *
+ * <p>Original source: <a
+ * href="https://github.com/a2aproject/a2a-java/blob/main/http-client/src/main/java/io/a2a/client/http/JdkA2AHttpClient.java">JdkA2AHttpClient.java</a>
+ *
+ * <p>TODO: Remove this class once the upstream PR is released: <a
+ * href="https://github.com/a2aproject/a2a-java/pull/745">a2a-java#745</a>
+ */
+public class CustomJdkA2AHttpClient implements A2AHttpClient {
+
+  private final HttpClient httpClient;
+
+  public CustomJdkA2AHttpClient() {
+    this(
+        HttpClient.newBuilder()
+            .version(HttpClient.Version.HTTP_2)
+            .followRedirects(HttpClient.Redirect.NORMAL)
+            .build());
+  }
+
+  public CustomJdkA2AHttpClient(HttpClient httpClient) {
+    this.httpClient = httpClient;
+  }
+
+  @Override
+  public GetBuilder createGet() {
+    return new JdkGetBuilder();
+  }
+
+  @Override
+  public PostBuilder createPost() {
+    return new JdkPostBuilder();
+  }
+
+  @Override
+  public DeleteBuilder createDelete() {
+    return new JdkDeleteBuilder();
+  }
+
+  private abstract class JdkBuilder<T extends Builder<T>> implements Builder<T> {
+    private String url = "";
+    private Map<String, String> headers = new HashMap<>();
+
+    @Override
+    public T url(String url) {
+      this.url = url;
+      return self();
+    }
+
+    @Override
+    public T addHeader(String name, String value) {
+      headers.put(name, value);
+      return self();
+    }
+
+    @Override
+    public T addHeaders(Map<String, String> headers) {
+      if (headers != null && !headers.isEmpty()) {
+        for (Map.Entry<String, String> entry : headers.entrySet()) {
+          addHeader(entry.getKey(), entry.getValue());
+        }
+      }
+      return self();
+    }
+
+    @SuppressWarnings("unchecked")
+    T self() {
+      return (T) this;
+    }
+
+    protected HttpRequest.Builder createRequestBuilder() throws IOException {
+      HttpRequest.Builder builder = HttpRequest.newBuilder().uri(URI.create(url));
+      for (Map.Entry<String, String> headerEntry : headers.entrySet()) {
+        builder.header(headerEntry.getKey(), headerEntry.getValue());
+      }
+      return builder;
+    }
+
+    protected CompletableFuture<Void> asyncRequest(
+        HttpRequest request,
+        Consumer<String> messageConsumer,
+        Consumer<Throwable> errorConsumer,
+        Runnable completeRunnable) {
+      Flow.Subscriber<String> subscriber =
+          new Flow.Subscriber<String>() {
+            private Flow.@Nullable Subscription subscription;
+            private volatile boolean errorRaised = false;
+
+            @Override
+            public void onSubscribe(Flow.Subscription subscription) {
+              this.subscription = subscription;
+              this.subscription.request(1);
+            }
+
+            @Override
+            public void onNext(String item) {
+              // SSE messages sometimes start with "data:". Strip that off
+              if (item != null && item.startsWith("data:")) {
+                item = item.substring(5).trim();
+                if (!item.isEmpty()) {
+                  messageConsumer.accept(item);
+                }
+              }
+              if (subscription != null) {
+                subscription.request(1);
+              }
+            }
+
+            @Override
+            public void onError(Throwable throwable) {
+              if (!errorRaised) {
+                errorRaised = true;
+                errorConsumer.accept(throwable);
+              }
+              if (subscription != null) {
+                subscription.cancel();
+              }
+            }
+
+            @Override
+            public void onComplete() {
+              if (!errorRaised) {
+                completeRunnable.run();
+              }
+              if (subscription != null) {
+                subscription.cancel();
+              }
+            }
+          };
+
+      // Create a custom body handler that checks status before processing body
+      BodyHandler<Void> bodyHandler =
+          responseInfo -> {
+            // Check for authentication/authorization errors only
+            if (responseInfo.statusCode() == HTTP_UNAUTHORIZED
+                || responseInfo.statusCode() == HTTP_FORBIDDEN) {
+              final String errorMessage;
+              if (responseInfo.statusCode() == HTTP_UNAUTHORIZED) {
+                errorMessage = A2AErrorMessages.AUTHENTICATION_FAILED;
+              } else {
+                errorMessage = A2AErrorMessages.AUTHORIZATION_FAILED;
+              }
+              // Return a body subscriber that immediately signals error
+              return BodySubscribers.fromSubscriber(
+                  new Flow.Subscriber<List<ByteBuffer>>() {
+                    @Override
+                    public void onSubscribe(Flow.Subscription subscription) {
+                      subscriber.onError(new IOException(errorMessage));
+                    }
+
+                    @Override
+                    public void onNext(List<ByteBuffer> item) {
+                      // Should not be called
+                    }
+
+                    @Override
+                    public void onError(Throwable throwable) {
+                      // Should not be called
+                    }
+
+                    @Override
+                    public void onComplete() {
+                      // Should not be called
+                    }
+                  });
+            } else {
+              // For all other status codes (including other errors), proceed with normal line
+              // subscriber
+              return BodyHandlers.fromLineSubscriber(subscriber).apply(responseInfo);
+            }
+          };
+
+      // Send the response async, and let the subscriber handle the lines.
+      return httpClient
+          .sendAsync(request, bodyHandler)
+          .thenAccept(
+              response -> {
+                // Handle non-authentication/non-authorization errors here
+                if (!isSuccessStatus(response.statusCode())
+                    && response.statusCode() != HTTP_UNAUTHORIZED
+                    && response.statusCode() != HTTP_FORBIDDEN) {
+                  subscriber.onError(
+                      new IOException(
+                          "Request failed with status "
+                              + response.statusCode()
+                              + ":"
+                              + response.body()));
+                }
+              });
+    }
+  }
+
+  private class JdkGetBuilder extends JdkBuilder<GetBuilder> implements A2AHttpClient.GetBuilder {
+
+    private HttpRequest.Builder createRequestBuilder(boolean SSE) throws IOException {
+      HttpRequest.Builder builder = super.createRequestBuilder().GET();
+      if (SSE) {
+        builder.header("Accept", "text/event-stream");
+      }
+      return builder;
+    }
+
+    @Override
+    public A2AHttpResponse get() throws IOException, InterruptedException {
+      HttpRequest request = createRequestBuilder(false).build();
+      HttpResponse<String> response =
+          httpClient.send(request, BodyHandlers.ofString(StandardCharsets.UTF_8));
+      return new JdkHttpResponse(response);
+    }
+
+    @Override
+    public CompletableFuture<Void> getAsyncSSE(
+        Consumer<String> messageConsumer,
+        Consumer<Throwable> errorConsumer,
+        Runnable completeRunnable)
+        throws IOException, InterruptedException {
+      HttpRequest request = createRequestBuilder(true).build();
+      return super.asyncRequest(request, messageConsumer, errorConsumer, completeRunnable);
+    }
+  }
+
+  private class JdkDeleteBuilder extends JdkBuilder<DeleteBuilder>
+      implements A2AHttpClient.DeleteBuilder {
+
+    @Override
+    public A2AHttpResponse delete() throws IOException, InterruptedException {
+      HttpRequest request = super.createRequestBuilder().DELETE().build();
+      HttpResponse<String> response =
+          httpClient.send(request, BodyHandlers.ofString(StandardCharsets.UTF_8));
+      return new JdkHttpResponse(response);
+    }
+  }
+
+  private class JdkPostBuilder extends JdkBuilder<PostBuilder>
+      implements A2AHttpClient.PostBuilder {
+    String body = "";
+
+    @Override
+    public PostBuilder body(String body) {
+      this.body = body;
+      return self();
+    }
+
+    private HttpRequest.Builder createRequestBuilder(boolean SSE) throws IOException {
+      HttpRequest.Builder builder =
+          super.createRequestBuilder()
+              .POST(HttpRequest.BodyPublishers.ofString(body, StandardCharsets.UTF_8));
+      if (SSE) {
+        builder.header("Accept", "text/event-stream");
+      }
+      return builder;
+    }
+
+    @Override
+    public A2AHttpResponse post() throws IOException, InterruptedException {
+      HttpRequest request =
+          createRequestBuilder(false)
+              .POST(HttpRequest.BodyPublishers.ofString(body, StandardCharsets.UTF_8))
+              .build();
+      HttpResponse<String> response =
+          httpClient.send(request, BodyHandlers.ofString(StandardCharsets.UTF_8));
+
+      if (response.statusCode() == HTTP_UNAUTHORIZED) {
+        throw new IOException(A2AErrorMessages.AUTHENTICATION_FAILED);
+      } else if (response.statusCode() == HTTP_FORBIDDEN) {
+        throw new IOException(A2AErrorMessages.AUTHORIZATION_FAILED);
+      }
+
+      return new JdkHttpResponse(response);
+    }
+
+    @Override
+    public CompletableFuture<Void> postAsyncSSE(
+        Consumer<String> messageConsumer,
+        Consumer<Throwable> errorConsumer,
+        Runnable completeRunnable)
+        throws IOException, InterruptedException {
+      HttpRequest request = createRequestBuilder(true).build();
+      return super.asyncRequest(request, messageConsumer, errorConsumer, completeRunnable);
+    }
+  }
+
+  private record JdkHttpResponse(HttpResponse<String> response) implements A2AHttpResponse {
+
+    @Override
+    public int status() {
+      return response.statusCode();
+    }
+
+    @Override
+    public boolean success() { // Send the request and get the response
+      return success(response);
+    }
+
+    static boolean success(HttpResponse<?> response) {
+      return response.statusCode() >= HTTP_OK && response.statusCode() < HTTP_MULT_CHOICE;
+    }
+
+    @Override
+    public String body() {
+      return response.body();
+    }
+  }
+
+  private static boolean isSuccessStatus(int statusCode) {
+    return statusCode >= HTTP_OK && statusCode < HTTP_MULT_CHOICE;
+  }
+}

--- a/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/a2a/client/common/A2aAgentCardFetcherTest.java
+++ b/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/a2a/client/common/A2aAgentCardFetcherTest.java
@@ -12,9 +12,12 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyMap;
 import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
 
 import io.a2a.A2A;
+import io.a2a.client.http.A2AHttpClient;
 import io.a2a.spec.A2AClientError;
 import io.a2a.spec.AgentCapabilities;
 import io.a2a.spec.AgentCard;
@@ -23,6 +26,7 @@ import io.a2a.spec.AgentSkill;
 import io.a2a.spec.TransportProtocol;
 import io.camunda.connector.agenticai.a2a.client.common.model.A2aConnectionConfiguration;
 import io.camunda.connector.agenticai.a2a.client.common.model.result.A2aAgentCard;
+import io.camunda.connector.agenticai.a2a.client.common.sdk.http.A2aHttpClientFactory;
 import io.camunda.connector.api.error.ConnectorException;
 import java.util.Collections;
 import java.util.List;
@@ -37,7 +41,15 @@ class A2aAgentCardFetcherTest {
   public static final List<String> DEFAULT_INPUT_MODES = List.of("text");
   public static final List<String> DEFAULT_OUTPUT_MODES = List.of("application/json");
 
-  private final A2aAgentCardFetcher agentCardFetcher = new A2aAgentCardFetcherImpl();
+  private final A2AHttpClient mockHttpClient = mock(A2AHttpClient.class);
+  private final A2aAgentCardFetcher agentCardFetcher =
+      new A2aAgentCardFetcherImpl(mockHttpClientFactory());
+
+  private A2aHttpClientFactory mockHttpClientFactory() {
+    A2aHttpClientFactory factory = mock(A2aHttpClientFactory.class);
+    when(factory.createHttpClient()).thenReturn(mockHttpClient);
+    return factory;
+  }
 
   @Test
   void fetchAgentCardWithCustomLocation() {
@@ -46,11 +58,14 @@ class A2aAgentCardFetcherTest {
     final var agentCard = createAgentCard(null, null);
 
     try (MockedStatic<A2A> a2aStatic = mockStatic(A2A.class)) {
-      a2aStatic.when(() -> A2A.getAgentCard(anyString(), any(), anyMap())).thenReturn(agentCard);
+      a2aStatic
+          .when(() -> A2A.getAgentCard(any(A2AHttpClient.class), anyString(), any(), anyMap()))
+          .thenReturn(agentCard);
 
       final var result = agentCardFetcher.fetchAgentCard(request);
 
-      a2aStatic.verify(() -> A2A.getAgentCard(AGENT_URL, location, Collections.emptyMap()));
+      a2aStatic.verify(
+          () -> A2A.getAgentCard(mockHttpClient, AGENT_URL, location, Collections.emptyMap()));
       assertAgentCard(result, DEFAULT_INPUT_MODES, DEFAULT_OUTPUT_MODES);
     }
   }
@@ -62,12 +77,19 @@ class A2aAgentCardFetcherTest {
     final var agentCard = createAgentCard(null, null);
 
     try (MockedStatic<A2A> a2aStatic = mockStatic(A2A.class)) {
-      a2aStatic.when(() -> A2A.getAgentCard(anyString(), any(), anyMap())).thenReturn(agentCard);
+      a2aStatic
+          .when(() -> A2A.getAgentCard(any(A2AHttpClient.class), anyString(), any(), anyMap()))
+          .thenReturn(agentCard);
 
       final var result = agentCardFetcher.fetchAgentCard(request);
 
       a2aStatic.verify(
-          () -> A2A.getAgentCard(AGENT_URL, ".well-known/agent-card.json", Collections.emptyMap()));
+          () ->
+              A2A.getAgentCard(
+                  mockHttpClient,
+                  AGENT_URL,
+                  ".well-known/agent-card.json",
+                  Collections.emptyMap()));
       assertAgentCard(result, DEFAULT_INPUT_MODES, DEFAULT_OUTPUT_MODES);
     }
   }
@@ -80,12 +102,19 @@ class A2aAgentCardFetcherTest {
     final var agentCard = createAgentCard(inputModes, outputModes);
 
     try (MockedStatic<A2A> a2aStatic = mockStatic(A2A.class)) {
-      a2aStatic.when(() -> A2A.getAgentCard(anyString(), any(), anyMap())).thenReturn(agentCard);
+      a2aStatic
+          .when(() -> A2A.getAgentCard(any(A2AHttpClient.class), anyString(), any(), anyMap()))
+          .thenReturn(agentCard);
 
       final var result = agentCardFetcher.fetchAgentCard(request);
 
       a2aStatic.verify(
-          () -> A2A.getAgentCard(AGENT_URL, ".well-known/agent-card.json", Collections.emptyMap()));
+          () ->
+              A2A.getAgentCard(
+                  mockHttpClient,
+                  AGENT_URL,
+                  ".well-known/agent-card.json",
+                  Collections.emptyMap()));
       assertAgentCard(result, inputModes, outputModes);
     }
   }
@@ -135,7 +164,7 @@ class A2aAgentCardFetcherTest {
 
     try (MockedStatic<A2A> a2aStatic = mockStatic(A2A.class)) {
       a2aStatic
-          .when(() -> A2A.getAgentCard(anyString(), any(), anyMap()))
+          .when(() -> A2A.getAgentCard(any(A2AHttpClient.class), anyString(), any(), anyMap()))
           .thenThrow(expectedException);
 
       assertThatThrownBy(() -> agentCardFetcher.fetchAgentCard(request))
@@ -155,7 +184,7 @@ class A2aAgentCardFetcherTest {
 
     try (MockedStatic<A2A> a2aStatic = mockStatic(A2A.class)) {
       a2aStatic
-          .when(() -> A2A.getAgentCard(anyString(), any(), anyMap()))
+          .when(() -> A2A.getAgentCard(any(A2AHttpClient.class), anyString(), any(), anyMap()))
           .thenThrow(expectedException);
 
       assertThatThrownBy(() -> agentCardFetcher.fetchAgentCard(request))

--- a/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/a2a/client/common/sdk/A2aSdkClientFactoryTest.java
+++ b/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/a2a/client/common/sdk/A2aSdkClientFactoryTest.java
@@ -11,10 +11,12 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.*;
 
 import io.a2a.client.Client;
+import io.a2a.client.http.A2AHttpClient;
 import io.a2a.spec.AgentCard;
 import io.a2a.spec.TransportProtocol;
 import io.camunda.connector.agenticai.a2a.client.common.configuration.A2aClientCommonConfigurationProperties.TransportConfiguration;
 import io.camunda.connector.agenticai.a2a.client.common.configuration.A2aClientCommonConfigurationProperties.TransportConfiguration.GrpcConfiguration;
+import io.camunda.connector.agenticai.a2a.client.common.sdk.http.A2aHttpClientFactory;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -24,10 +26,17 @@ import org.mockito.Answers;
 
 class A2aSdkClientFactoryTest {
 
+  private static A2aHttpClientFactory mockHttpClientFactory() {
+    A2aHttpClientFactory factory = mock(A2aHttpClientFactory.class);
+    when(factory.createHttpClient()).thenReturn(mock(A2AHttpClient.class));
+    return factory;
+  }
+
   @Test
   void createsClientWithGrpcTransportWithTls() {
     final var transportConfig = new TransportConfiguration(new GrpcConfiguration(true));
-    A2aSdkClientFactory factory = new A2aSdkClientFactoryImpl(transportConfig);
+    A2aSdkClientFactory factory =
+        new A2aSdkClientFactoryImpl(transportConfig, mockHttpClientFactory());
     AgentCard agentCard = mock(AgentCard.class);
 
     when(agentCard.preferredTransport()).thenReturn(TransportProtocol.GRPC.asString());
@@ -43,7 +52,8 @@ class A2aSdkClientFactoryTest {
   @Test
   void createsClientWithGrpcTransportWithoutTls() {
     final var transportConfig = new TransportConfiguration(new GrpcConfiguration(false));
-    A2aSdkClientFactory factory = new A2aSdkClientFactoryImpl(transportConfig);
+    A2aSdkClientFactory factory =
+        new A2aSdkClientFactoryImpl(transportConfig, mockHttpClientFactory());
     AgentCard agentCard = mock(AgentCard.class);
 
     when(agentCard.preferredTransport()).thenReturn(TransportProtocol.GRPC.asString());
@@ -59,7 +69,8 @@ class A2aSdkClientFactoryTest {
   @Test
   void createsClientWithRestTransport() {
     final var transportConfig = new TransportConfiguration(new GrpcConfiguration(true));
-    A2aSdkClientFactory factory = new A2aSdkClientFactoryImpl(transportConfig);
+    A2aSdkClientFactory factory =
+        new A2aSdkClientFactoryImpl(transportConfig, mockHttpClientFactory());
     AgentCard agentCard = mock(AgentCard.class);
 
     when(agentCard.preferredTransport()).thenReturn(TransportProtocol.HTTP_JSON.asString());
@@ -75,7 +86,8 @@ class A2aSdkClientFactoryTest {
   @Test
   void createsClientWithJsonRpcTransport() {
     final var transportConfig = new TransportConfiguration(new GrpcConfiguration(true));
-    A2aSdkClientFactory factory = new A2aSdkClientFactoryImpl(transportConfig);
+    A2aSdkClientFactory factory =
+        new A2aSdkClientFactoryImpl(transportConfig, mockHttpClientFactory());
     AgentCard agentCard = mock(AgentCard.class);
 
     when(agentCard.preferredTransport()).thenReturn(TransportProtocol.JSONRPC.asString());
@@ -91,7 +103,8 @@ class A2aSdkClientFactoryTest {
   @Test
   void factoryCanCreateMultipleClients() {
     final var transportConfig = new TransportConfiguration(new GrpcConfiguration(true));
-    A2aSdkClientFactory factory = new A2aSdkClientFactoryImpl(transportConfig);
+    A2aSdkClientFactory factory =
+        new A2aSdkClientFactoryImpl(transportConfig, mockHttpClientFactory());
 
     AgentCard agentCard1 = mock(AgentCard.class);
     when(agentCard1.preferredTransport()).thenReturn(TransportProtocol.GRPC.asString());
@@ -115,7 +128,8 @@ class A2aSdkClientFactoryTest {
   @Test
   void closingClientDoesNotThrowException() {
     final var transportConfig = new TransportConfiguration(new GrpcConfiguration(true));
-    A2aSdkClientFactory factory = new A2aSdkClientFactoryImpl(transportConfig);
+    A2aSdkClientFactory factory =
+        new A2aSdkClientFactoryImpl(transportConfig, mockHttpClientFactory());
     AgentCard agentCard = mock(AgentCard.class);
 
     when(agentCard.preferredTransport()).thenReturn(TransportProtocol.GRPC.asString());
@@ -132,7 +146,8 @@ class A2aSdkClientFactoryTest {
   @Test
   void throwsRuntimeExceptionWhenClientBuildingFails() {
     final var transportConfig = new TransportConfiguration(new GrpcConfiguration(true));
-    A2aSdkClientFactory factory = new A2aSdkClientFactoryImpl(transportConfig);
+    A2aSdkClientFactory factory =
+        new A2aSdkClientFactoryImpl(transportConfig, mockHttpClientFactory());
     AgentCard agentCard = mock(AgentCard.class);
     // Set up an invalid configuration that will cause A2AClientException
     when(agentCard.preferredTransport()).thenReturn(null);
@@ -146,7 +161,8 @@ class A2aSdkClientFactoryTest {
   @ValueSource(booleans = {true, false})
   void passesCorrectParametersToClientConfigBuilderWithoutPushNotification(Boolean blocking) {
     final var transportConfig = new TransportConfiguration(new GrpcConfiguration(true));
-    A2aSdkClientFactory factory = new A2aSdkClientFactoryImpl(transportConfig);
+    A2aSdkClientFactory factory =
+        new A2aSdkClientFactoryImpl(transportConfig, mockHttpClientFactory());
     AgentCard agentCard = mock(AgentCard.class);
 
     when(agentCard.preferredTransport()).thenReturn(TransportProtocol.GRPC.asString());
@@ -182,7 +198,8 @@ class A2aSdkClientFactoryTest {
     String credentials = authScheme != null ? "test-credentials-" + authScheme : null;
     List<String> authSchemes = authScheme != null ? List.of(authScheme) : List.of();
     final var transportConfig = new TransportConfiguration(new GrpcConfiguration(true));
-    A2aSdkClientFactory factory = new A2aSdkClientFactoryImpl(transportConfig);
+    A2aSdkClientFactory factory =
+        new A2aSdkClientFactoryImpl(transportConfig, mockHttpClientFactory());
     AgentCard agentCard = mock(AgentCard.class);
 
     when(agentCard.preferredTransport()).thenReturn(TransportProtocol.GRPC.asString());

--- a/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/a2a/client/common/sdk/http/A2aHttpClientFactoryTest.java
+++ b/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/a2a/client/common/sdk/http/A2aHttpClientFactoryTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.agenticai.a2a.client.common.sdk.http;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.a2a.client.http.A2AHttpClient;
+import io.camunda.connector.agenticai.common.AgenticAiHttpProxySupport;
+import io.camunda.connector.http.client.client.jdk.proxy.JdkHttpClientProxyConfigurator;
+import java.net.http.HttpClient;
+import org.junit.jupiter.api.Test;
+
+class A2aHttpClientFactoryTest {
+
+  @Test
+  void createsHttpClientWithProxyConfiguration() {
+    var proxySupport = mock(AgenticAiHttpProxySupport.class);
+    var proxyConfigurator = mock(JdkHttpClientProxyConfigurator.class);
+    when(proxySupport.getJdkHttpClientProxyConfigurator()).thenReturn(proxyConfigurator);
+    when(proxyConfigurator.configure(any(HttpClient.Builder.class)))
+        .thenAnswer(invocation -> invocation.getArgument(0));
+
+    var factory = new A2aHttpClientFactory(proxySupport);
+    A2AHttpClient httpClient = factory.createHttpClient();
+
+    assertThat(httpClient).isNotNull().isInstanceOf(CustomJdkA2AHttpClient.class);
+    verify(proxyConfigurator).configure(any(HttpClient.Builder.class));
+  }
+}

--- a/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/a2a/client/common/sdk/http/CustomJdkA2AHttpClientTest.java
+++ b/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/a2a/client/common/sdk/http/CustomJdkA2AHttpClientTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.agenticai.a2a.client.common.sdk.http;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.http.HttpClient;
+import org.junit.jupiter.api.Test;
+
+class CustomJdkA2AHttpClientTest {
+
+  @Test
+  void defaultConstructorCreatesClient() {
+    var client = new CustomJdkA2AHttpClient();
+    assertThat(client.createGet()).isNotNull();
+    assertThat(client.createPost()).isNotNull();
+    assertThat(client.createDelete()).isNotNull();
+  }
+
+  @Test
+  void customHttpClientConstructorCreatesClient() {
+    HttpClient httpClient =
+        HttpClient.newBuilder()
+            .version(HttpClient.Version.HTTP_2)
+            .followRedirects(HttpClient.Redirect.NORMAL)
+            .build();
+    var client = new CustomJdkA2AHttpClient(httpClient);
+    assertThat(client.createGet()).isNotNull();
+    assertThat(client.createPost()).isNotNull();
+    assertThat(client.createDelete()).isNotNull();
+  }
+}


### PR DESCRIPTION
## Description

Configures the HTTP client used for A2A to use the configured proxy.

## Related issues

closes #6384 

## Checklist

- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest
  release, as this branch will be rebased onto main before the next release. Example backport labels:
    - `backport stable/8.8`: for changes that should be included in the next 8.8.x release.
    - **or** `backport release-8.8.7`: for changes that should be included in the specific release 8.8.7, and this
      *release has already been created*. The release branch will be merged back into stable/8.8 later, so the change
      will be included in future 8.8.x releases as well.
- [x] Tests/Integration tests for the changes have been added if applicable.

