### PR TITLE
feat(element-template-generator): improve HTTP DSL auth deduplication and server URL visibility

### DIFF
--- a/element-template-generator/http-dsl/src/main/java/io/camunda/connector/generator/dsl/http/HttpAuthentication.java
+++ b/element-template-generator/http-dsl/src/main/java/io/camunda/connector/generator/dsl/http/HttpAuthentication.java
@@ -242,6 +242,10 @@ public interface HttpAuthentication {
       return new BasicAuth(key);
     }
 
+    public String key() {
+      return key;
+    }
+
     @Override
     public String label() {
       return "Basic";

--- a/element-template-generator/http-dsl/src/main/java/io/camunda/connector/generator/dsl/http/HttpOutboundElementTemplateBuilder.java
+++ b/element-template-generator/http-dsl/src/main/java/io/camunda/connector/generator/dsl/http/HttpOutboundElementTemplateBuilder.java
@@ -128,21 +128,29 @@ public class HttpOutboundElementTemplateBuilder {
     if (operations == null || operations.isEmpty()) {
       throw new IllegalStateException("Could not find any supported operations");
     }
-    return builder
-        .propertyGroups(
-            List.of(
-                // Property order is important, parameters must come before their targets (URL,
-                // headers, or body)
-                // otherwise they will not be resolved correctly by the FEEL engine in Zeebe
-                PropertyUtil.serverDiscriminatorPropertyGroup(servers),
-                PropertyUtil.operationDiscriminatorPropertyGroup(operations),
-                PropertyUtil.authPropertyGroup(authentication, operations),
-                PropertyUtil.parametersPropertyGroup(operations),
-                PropertyUtil.requestBodyPropertyGroup(operations),
-                PropertyUtil.urlPropertyGroup(),
-                PropertyGroup.OUTPUT_GROUP_OUTBOUND.apply(null, null),
-                PropertyGroup.ERROR_GROUP,
-                PropertyGroup.RETRIES_GROUP))
-        .build();
+
+    var serverGroup = PropertyUtil.serverDiscriminatorPropertyGroup(servers);
+    var operationGroup = PropertyUtil.operationDiscriminatorPropertyGroup(operations);
+    var authResult = PropertyUtil.authPropertyGroup(authentication, operations);
+
+    // If all auth properties are unconditional, auth can be placed before the operation dropdown
+    // (the modeler resolves conditions top-to-bottom, so conditional auth must follow operation).
+    List<PropertyGroup> groups = new ArrayList<>();
+    groups.add(serverGroup);
+    if (authResult.unconditional()) {
+      groups.add(authResult.group());
+      groups.add(operationGroup);
+    } else {
+      groups.add(operationGroup);
+      groups.add(authResult.group());
+    }
+    groups.add(PropertyUtil.parametersPropertyGroup(operations));
+    groups.add(PropertyUtil.requestBodyPropertyGroup(operations));
+    groups.add(PropertyUtil.urlPropertyGroup());
+    groups.add(PropertyGroup.OUTPUT_GROUP_OUTBOUND.apply(null, null));
+    groups.add(PropertyGroup.ERROR_GROUP);
+    groups.add(PropertyGroup.RETRIES_GROUP);
+
+    return builder.propertyGroups(groups).build();
   }
 }

--- a/element-template-generator/http-dsl/src/main/java/io/camunda/connector/generator/dsl/http/PropertyUtil.java
+++ b/element-template-generator/http-dsl/src/main/java/io/camunda/connector/generator/dsl/http/PropertyUtil.java
@@ -35,10 +35,10 @@ import io.camunda.connector.generator.java.util.TemplatePropertiesUtil;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 public class PropertyUtil {
 
@@ -47,14 +47,14 @@ public class PropertyUtil {
   static final String OPERATION_PATH_INPUT_NAME = "operationPath";
 
   /**
-   * Create a pre-configured property builder for the auth type discriminator. Add a condition if
-   * necessary.
+   * Create a pre-configured property builder for the auth type discriminator. The caller is
+   * responsible for setting the final {@code id} on the returned builder. {@code availableTypes}
+   * must be a {@link List} so that the default selection (first element) is deterministic.
    */
-  static PropertyBuilder authDiscriminatorPropertyPrefab(
-      Collection<HttpAuthentication> availableTypes) {
+  static PropertyBuilder authDiscriminatorPropertyPrefab(List<HttpAuthentication> availableTypes) {
 
     if (availableTypes.isEmpty()) {
-      throw new RuntimeException("No auth types, expected at least one");
+      throw new IllegalArgumentException("No auth types, expected at least one");
     }
     var choices =
         availableTypes.stream()
@@ -65,8 +65,8 @@ public class PropertyUtil {
                     label += " (" + apiKey.key() + ")";
                   }
                   if (type instanceof HttpAuthentication.BasicAuth basicAuth
-                      && !basicAuth.key.isEmpty()) {
-                    label += " (" + basicAuth.key + ")";
+                      && !basicAuth.key().isEmpty()) {
+                    label += " (" + basicAuth.key() + ")";
                   }
                   return new DropdownProperty.DropdownChoice(label, type.id());
                 })
@@ -74,7 +74,6 @@ public class PropertyUtil {
 
     return DropdownProperty.builder()
         .choices(choices)
-        .id("authType")
         .group("authentication")
         .label("Authentication")
         .optional(false)
@@ -103,7 +102,7 @@ public class PropertyUtil {
                 .choices(
                     operations.stream()
                         .map(operation -> new DropdownChoice(operation.label(), operation.id()))
-                        .collect(Collectors.toList()))
+                        .toList())
                 .id(OPERATION_DISCRIMINATOR_PROPERTY_ID)
                 .group("operation")
                 .value(operations.iterator().next().id())
@@ -113,9 +112,10 @@ public class PropertyUtil {
   }
 
   static PropertyGroup serverDiscriminatorPropertyGroup(Collection<HttpServerData> servers) {
+    Collection<HttpServerData> configuredServers = servers == null ? List.of() : servers;
     List<Property> properties = new ArrayList<>();
 
-    if (servers == null || servers.isEmpty()) {
+    if (configuredServers.isEmpty()) {
       // add a visible property for base URL, no servers configured
       properties.add(
           StringProperty.builder()
@@ -126,25 +126,28 @@ public class PropertyUtil {
               .constraints(PropertyConstraints.builder().notEmpty(true).build())
               .feel(FeelMode.optional)
               .build());
-    } else if (servers.size() == 1) {
-      // invisible but hard-coded, as there is only one server
+    } else if (configuredServers.size() == 1) {
+      // single server: visible and pre-filled, but editable
       properties.add(
-          HiddenProperty.builder()
+          StringProperty.builder()
               .id("baseUrl")
               .group("server")
-              .value(servers.iterator().next().baseUrl())
+              .label("Base URL")
+              .value(configuredServers.iterator().next().baseUrl())
               .binding(new ZeebeInput("baseUrl"))
+              .constraints(PropertyConstraints.builder().notEmpty(true).build())
+              .feel(FeelMode.optional)
               .build());
     } else {
       // multiple servers, add a dropdown
       properties.add(
           DropdownProperty.builder()
               .choices(
-                  servers.stream()
+                  configuredServers.stream()
                       .map(server -> new DropdownChoice(server.label(), server.baseUrl()))
-                      .collect(Collectors.toList()))
+                      .toList())
               .id("baseUrl")
-              .value(servers.iterator().next().baseUrl())
+              .value(configuredServers.iterator().next().baseUrl())
               .label("Server")
               .group("server")
               .binding(new ZeebeInput("baseUrl"))
@@ -153,101 +156,144 @@ public class PropertyUtil {
     return PropertyGroup.builder().id("server").label("Server").properties(properties).build();
   }
 
-  static PropertyGroup authPropertyGroup(
+  /**
+   * Result of {@link #authPropertyGroup}. Carries both the generated group and whether all auth
+   * properties are unconditional, so callers do not have to re-derive that fact.
+   */
+  record AuthGroupResult(PropertyGroup group, boolean unconditional) {}
+
+  static AuthGroupResult authPropertyGroup(
       Collection<HttpAuthentication> authentications, Collection<HttpOperation> operations) {
+    Collection<HttpAuthentication> configuredAuthentications =
+        authentications == null ? List.of() : authentications;
 
-    var operationsWithoutCustomAuth =
-        operations.stream()
-            .filter(
-                op -> op.authenticationOverride() == null || op.authenticationOverride().isEmpty())
-            .map(HttpOperation::id)
-            .toList();
+    // Group operations by their effective auth configuration.
+    // Order of first appearance is preserved via LinkedHashMap.
+    LinkedHashMap<List<AuthFingerprint>, List<HttpAuthentication>> authKeyToTypes =
+        new LinkedHashMap<>();
+    LinkedHashMap<List<AuthFingerprint>, List<String>> authKeyToOpIds = new LinkedHashMap<>();
 
-    List<Property> properties = new ArrayList<>();
-    if (authentications.size() > 1) {
-      var discriminator =
-          authDiscriminatorPropertyPrefab(authentications)
-              .condition(
-                  new OneOf(OPERATION_DISCRIMINATOR_PROPERTY_ID, operationsWithoutCustomAuth))
-              .build();
-      properties.add(discriminator);
-    } else if (!authentications.isEmpty()) {
-      // only one auth type, no need for discriminator
-      properties.add(
-          HiddenProperty.builder()
-              .id(AUTH_DISCRIMINATOR_PROPERTY_ID)
-              .group("authentication")
-              .value(authentications.iterator().next().id())
-              .binding(new ZeebeInput(AUTH_DISCRIMINATOR_PROPERTY_ID))
-              .condition(
-                  new OneOf(OPERATION_DISCRIMINATOR_PROPERTY_ID, operationsWithoutCustomAuth))
-              .build());
-    }
-
-    // handle default auth types
-    for (var authentication : authentications) {
-      var authProperties =
-          HttpAuthentication.getPropertyPrefabs(authentication).stream()
-              .map(
-                  builder ->
-                      builder
-                          .condition(
-                              new AllMatch(
-                                  new Equals(AUTH_DISCRIMINATOR_PROPERTY_ID, authentication.id()),
-                                  new OneOf(
-                                      OPERATION_DISCRIMINATOR_PROPERTY_ID,
-                                      operationsWithoutCustomAuth)))
-                          .build())
-              .toList();
-
-      properties.addAll(authProperties);
-    }
-
-    // handle operation-specific auth types
     for (var operation : operations) {
-      if (operation.authenticationOverride() == null) {
+      List<HttpAuthentication> effectiveAuth =
+          (operation.authenticationOverride() != null
+                  && !operation.authenticationOverride().isEmpty())
+              ? operation.authenticationOverride()
+              : new ArrayList<>(configuredAuthentications);
+
+      // Skip operations with no effective auth (caller passed empty authentications and this
+      // operation has no override; the resulting template simply has no auth section).
+      if (effectiveAuth.isEmpty()) {
         continue;
       }
-      var authDiscriminator = operation.id() + "_" + "authType";
-      final boolean addedDiscriminator;
-      if (operation.authenticationOverride().size() > 1) {
-        addedDiscriminator = true;
-        properties.add(
-            authDiscriminatorPropertyPrefab(operation.authenticationOverride())
-                .id(authDiscriminator)
-                .condition(new Equals(OPERATION_DISCRIMINATOR_PROPERTY_ID, operation.id()))
-                .build());
+
+      List<AuthFingerprint> key = effectiveAuth.stream().map(AuthFingerprint::from).toList();
+      authKeyToTypes.putIfAbsent(key, effectiveAuth);
+      authKeyToOpIds.computeIfAbsent(key, k -> new ArrayList<>()).add(operation.id());
+    }
+
+    boolean unconditional = authKeyToTypes.size() == 1;
+
+    List<Property> properties = new ArrayList<>();
+
+    for (var entry : authKeyToTypes.entrySet()) {
+      List<AuthFingerprint> key = entry.getKey();
+      List<HttpAuthentication> auths = entry.getValue();
+      // Sort op IDs so the prefix is the lexicographically smallest ID in the group,
+      // independent of the order in which operations were registered.
+      List<String> opIds = authKeyToOpIds.get(key).stream().sorted().toList();
+
+      // In the conditional (multi-group) case each group gets a scoped discriminator ID to avoid
+      // duplicate property IDs across groups. The prefix is the sorted-first op ID of the group.
+      String discriminatorId =
+          unconditional ? AUTH_DISCRIMINATOR_PROPERTY_ID : opIds.getFirst() + "_authType";
+
+      // --- discriminator property ---
+      if (auths.size() > 1) {
+        var discriminatorBuilder = authDiscriminatorPropertyPrefab(auths).id(discriminatorId);
+        if (!unconditional) {
+          discriminatorBuilder.condition(new OneOf(OPERATION_DISCRIMINATOR_PROPERTY_ID, opIds));
+        }
+        properties.add(discriminatorBuilder.build());
       } else {
-        addedDiscriminator = false;
+        // single auth type — hidden discriminator
+        var discriminatorBuilder =
+            HiddenProperty.builder()
+                .id(discriminatorId)
+                .group("authentication")
+                .value(auths.getFirst().id())
+                .binding(new ZeebeInput(AUTH_DISCRIMINATOR_PROPERTY_ID));
+        if (!unconditional) {
+          discriminatorBuilder.condition(new OneOf(OPERATION_DISCRIMINATOR_PROPERTY_ID, opIds));
+        }
+        properties.add(discriminatorBuilder.build());
       }
-      for (var authentication : operation.authenticationOverride()) {
+
+      // --- auth field properties ---
+      for (var authentication : auths) {
         var authProperties =
-            HttpAuthentication.getPropertyPrefabs(authentication).stream() // size1 = 4
+            HttpAuthentication.getPropertyPrefabs(authentication).stream()
                 .map(
                     builder -> {
-                      String id = operation.id() + "_" + builder.getId();
-                      builder.id(id); // shade property ids
-                      if (addedDiscriminator) {
-                        builder.condition(
-                            new AllMatch(
-                                new Equals(authDiscriminator, authentication.id()),
-                                new Equals(OPERATION_DISCRIMINATOR_PROPERTY_ID, operation.id())));
+                      if (unconditional && auths.size() == 1) {
+                        // single auth for all ops — no condition at all
+                        return builder.build();
+                      } else if (unconditional) {
+                        // multiple auth types but unconditional (all ops share same multi-auth set)
+                        return builder
+                            .condition(new Equals(discriminatorId, authentication.id()))
+                            .build();
                       } else {
-                        builder.condition(
-                            new Equals(OPERATION_DISCRIMINATOR_PROPERTY_ID, operation.id()));
+                        // conditional — scope to the ops in this group
+                        // prefix field IDs with the sorted-first op ID to avoid duplicates
+                        String fieldId = opIds.getFirst() + "_" + builder.getId();
+                        return builder
+                            .id(fieldId)
+                            .condition(
+                                new AllMatch(
+                                    new Equals(discriminatorId, authentication.id()),
+                                    new OneOf(OPERATION_DISCRIMINATOR_PROPERTY_ID, opIds)))
+                            .build();
                       }
-                      return builder.build();
                     })
                 .toList();
-        properties.addAll(authProperties); // here the duplicated are generated
+        properties.addAll(authProperties);
       }
     }
 
-    return PropertyGroup.builder()
-        .id("authentication")
-        .label("Authentication")
-        .properties(properties)
-        .build();
+    PropertyGroup group =
+        PropertyGroup.builder()
+            .id("authentication")
+            .label("Authentication")
+            .properties(properties)
+            .build();
+    return new AuthGroupResult(group, unconditional);
+  }
+
+  private record AuthFingerprint(String id, List<String> details) {
+
+    private static AuthFingerprint from(HttpAuthentication authentication) {
+      return switch (authentication) {
+        case HttpAuthentication.BasicAuth basicAuth ->
+            new AuthFingerprint(authentication.id(), List.of(basicAuth.key()));
+        case HttpAuthentication.ApiKey apiKey ->
+            new AuthFingerprint(
+                authentication.id(),
+                List.of(
+                    apiKey.in() == null ? "" : apiKey.in(),
+                    apiKey.key() == null ? "" : apiKey.key(),
+                    apiKey.value() == null ? "" : apiKey.value()));
+        case HttpAuthentication.OAuth2 oauth2 ->
+            new AuthFingerprint(
+                authentication.id(),
+                List.of(
+                    oauth2.tokenUrl() == null ? "" : oauth2.tokenUrl(),
+                    oauth2.scopes().stream()
+                        .sorted()
+                        .reduce((left, right) -> left + "\u0000" + right)
+                        .orElse("")));
+        default -> new AuthFingerprint(authentication.id(), List.of());
+      };
+    }
   }
 
   static PropertyGroup parametersPropertyGroup(Collection<HttpOperation> operations) {

--- a/element-template-generator/http-dsl/src/test/java/io/camunda/connector/generator/dsl/http/HttpOutboundElementTemplateBuilderTest.java
+++ b/element-template-generator/http-dsl/src/test/java/io/camunda/connector/generator/dsl/http/HttpOutboundElementTemplateBuilderTest.java
@@ -155,7 +155,7 @@ public class HttpOutboundElementTemplateBuilderTest {
     }
 
     @Test
-    void singleServer_noVisibleExpected() {
+    void singleServer_visibleStringExpected() {
       // given
       var servers = List.of(new HttpServerData("https://example.com", "Example server"));
 
@@ -165,7 +165,7 @@ public class HttpOutboundElementTemplateBuilderTest {
 
       // then
       var serverProperty = findByBindingName("baseUrl", properties);
-      assertThat(serverProperty.getType()).isEqualTo("Hidden");
+      assertThat(serverProperty.getType()).isEqualTo("String");
       assertThat(serverProperty.getBinding()).isInstanceOf(ZeebeInput.class);
       assertThat(serverProperty.getValue()).isEqualTo("https://example.com");
     }

--- a/element-template-generator/http-dsl/src/test/java/io/camunda/connector/generator/dsl/http/PropertyUtilTest.java
+++ b/element-template-generator/http-dsl/src/test/java/io/camunda/connector/generator/dsl/http/PropertyUtilTest.java
@@ -16,17 +16,265 @@
  */
 package io.camunda.connector.generator.dsl.http;
 
+import static io.camunda.connector.generator.dsl.http.PropertyUtil.authPropertyGroup;
 import static io.camunda.connector.generator.dsl.http.PropertyUtil.parametersPropertyGroup;
+import static io.camunda.connector.generator.dsl.http.PropertyUtil.serverDiscriminatorPropertyGroup;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.camunda.connector.generator.api.GeneratorConfiguration.ConnectorElementType;
+import io.camunda.connector.generator.dsl.ElementTemplate;
 import io.camunda.connector.generator.dsl.Property;
+import io.camunda.connector.generator.dsl.PropertyBinding.ZeebeInput;
 import io.camunda.connector.generator.dsl.PropertyGroup;
+import io.camunda.connector.generator.dsl.http.HttpAuthentication.BearerAuth;
+import io.camunda.connector.generator.dsl.http.HttpAuthentication.NoAuth;
+import io.camunda.connector.generator.dsl.http.HttpAuthentication.OAuth2;
 import io.camunda.connector.generator.dsl.http.HttpOperationProperty.Target;
+import io.camunda.connector.generator.java.annotation.BpmnType;
 import io.camunda.connector.http.base.model.HttpMethod;
 import java.util.List;
+import java.util.Set;
 import org.junit.jupiter.api.Test;
 
 public class PropertyUtilTest {
+
+  // ---------------------------------------------------------------------------
+  // Helpers
+  // ---------------------------------------------------------------------------
+
+  private static HttpOperation opWithAuth(String id, List<HttpAuthentication> authOverride) {
+    return new HttpOperation(
+        id,
+        id,
+        HttpFeelBuilder.string().part("/path"),
+        HttpMethod.GET,
+        null,
+        List.of(),
+        authOverride);
+  }
+
+  private static HttpOperation opNoOverride(String id) {
+    return opWithAuth(id, null);
+  }
+
+  // ---------------------------------------------------------------------------
+  // serverDiscriminatorPropertyGroup
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void serverDiscriminator_singleServer_shouldBeStringPropertyWithServerUrl() {
+    var server = new HttpServerData("https://api.example.com", "Example API");
+    var group = serverDiscriminatorPropertyGroup(List.of(server));
+
+    assertThat(group.properties()).hasSize(1);
+    var prop = group.properties().getFirst();
+    assertThat(prop.getType()).isEqualTo("String");
+    assertThat(prop.getValue()).isEqualTo("https://api.example.com");
+    assertThat(prop.getId()).isEqualTo("baseUrl");
+  }
+
+  @Test
+  void serverDiscriminator_noServers_shouldBeStringPropertyWithNoDefaultValue() {
+    var group = serverDiscriminatorPropertyGroup(List.of());
+
+    assertThat(group.properties()).hasSize(1);
+    var prop = group.properties().getFirst();
+    assertThat(prop.getType()).isEqualTo("String");
+    assertThat(prop.getId()).isEqualTo("baseUrl");
+  }
+
+  @Test
+  void serverDiscriminator_nullServers_shouldBehaveLikeNoServers() {
+    var group = serverDiscriminatorPropertyGroup(null);
+
+    assertThat(group.properties()).hasSize(1);
+    var prop = group.properties().getFirst();
+    assertThat(prop.getType()).isEqualTo("String");
+    assertThat(prop.getId()).isEqualTo("baseUrl");
+  }
+
+  @Test
+  void serverDiscriminator_multipleServers_shouldBeDropdown() {
+    var servers =
+        List.of(
+            new HttpServerData("https://api1.example.com", "API 1"),
+            new HttpServerData("https://api2.example.com", "API 2"));
+    var group = serverDiscriminatorPropertyGroup(servers);
+
+    assertThat(group.properties()).hasSize(1);
+    assertThat(group.properties().getFirst().getType()).isEqualTo("Dropdown");
+  }
+
+  // ---------------------------------------------------------------------------
+  // authPropertyGroup — deduplication
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void authGroup_allOpsWithSameSingleOverrideAuth_shouldBeUnconditional() {
+    // All 3 operations have the same bearer auth override — the Console API scenario
+    var bearer = BearerAuth.INSTANCE;
+    var op1 = opWithAuth("op1", List.of(bearer));
+    var op2 = opWithAuth("op2", List.of(bearer));
+    var op3 = opWithAuth("op3", List.of(bearer));
+
+    List<HttpAuthentication> globalAuth = List.of(NoAuth.INSTANCE);
+    var result = authPropertyGroup(globalAuth, List.of(op1, op2, op3));
+
+    assertThat(result.unconditional()).isTrue();
+    // All properties must have no condition
+    assertThat(result.group().properties()).isNotEmpty();
+    assertThat(result.group().properties()).allMatch(p -> p.getCondition() == null);
+  }
+
+  @Test
+  void authGroup_allOpsWithSameSingleOverrideAuth_shouldEmitExactlyOneSetOfProperties() {
+    var bearer = BearerAuth.INSTANCE;
+    var ops =
+        List.of(
+            opWithAuth("op1", List.of(bearer)),
+            opWithAuth("op2", List.of(bearer)),
+            opWithAuth("op3", List.of(bearer)));
+
+    List<HttpAuthentication> globalAuth = List.of(NoAuth.INSTANCE);
+    var result = authPropertyGroup(globalAuth, ops);
+
+    // BearerAuth emits: hidden authType discriminator + hidden bearer type setter + bearer token
+    // = 3 properties. Should have exactly 3, not 3×3=9
+    assertThat(result.group().properties()).hasSize(3);
+  }
+
+  @Test
+  void authGroup_mixedOps_someGlobalSomeOverride_shouldBeConditional() {
+    var bearer = BearerAuth.INSTANCE;
+    List<HttpAuthentication> globalAuth = List.of(NoAuth.INSTANCE);
+
+    var opGlobal1 = opNoOverride("op1");
+    var opGlobal2 = opNoOverride("op2");
+    var opOverride = opWithAuth("op3", List.of(bearer));
+
+    var result = authPropertyGroup(globalAuth, List.of(opGlobal1, opGlobal2, opOverride));
+
+    assertThat(result.unconditional()).isFalse();
+    // At least some properties must have conditions
+    assertThat(result.group().properties()).anyMatch(p -> p.getCondition() != null);
+  }
+
+  @Test
+  void authGroup_mixedOps_shouldNotDuplicatePropertiesForSharedAuth() {
+    var bearer = BearerAuth.INSTANCE;
+    List<HttpAuthentication> globalAuth = List.of(NoAuth.INSTANCE);
+
+    // op1 and op2 both override with bearer — should produce one set of bearer props
+    var op1 = opWithAuth("op1", List.of(bearer));
+    var op2 = opWithAuth("op2", List.of(bearer));
+    var op3 = opNoOverride("op3"); // uses global NoAuth
+
+    var result = authPropertyGroup(globalAuth, List.of(op1, op2, op3));
+
+    // bearer group: 3 props (authType discriminator + bearer type + token)
+    // noAuth group: 2 props (authType discriminator + noAuth type)
+    // total: 5 — not 3+3+2=8 (the pre-dedup count)
+    assertThat(result.group().properties()).hasSize(5);
+  }
+
+  @Test
+  void authGroup_distinctOauthConfigsWithSameId_shouldNotBeDeduplicated() {
+    var contactsOauth = new OAuth2("https://token.example.com", Set.of("read:contacts"));
+    var dealsOauth = new OAuth2("https://token.example.com", Set.of("read:deals"));
+
+    var contacts = opWithAuth("contacts", List.of(contactsOauth));
+    var deals = opWithAuth("deals", List.of(dealsOauth));
+
+    var result = authPropertyGroup(List.of(NoAuth.INSTANCE), List.of(contacts, deals));
+
+    assertThat(result.unconditional()).isFalse();
+    assertThat(result.group().properties())
+        .filteredOn(
+            property ->
+                property.getBinding() instanceof ZeebeInput binding
+                    && "authentication.scopes".equals(binding.name()))
+        .extracting(Property::getValue)
+        .containsExactlyInAnyOrder("read:contacts", "read:deals");
+  }
+
+  // ---------------------------------------------------------------------------
+  // HttpOutboundElementTemplateBuilder — group ordering
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void builder_unconditionalAuth_shouldPlaceAuthBeforeOperation() {
+    var bearer = BearerAuth.INSTANCE;
+    var op1 = opWithAuth("op1", List.of(bearer));
+    var op2 = opWithAuth("op2", List.of(bearer));
+
+    List<HttpAuthentication> globalAuth = List.of(NoAuth.INSTANCE);
+    ElementTemplate template =
+        HttpOutboundElementTemplateBuilder.create()
+            .id("test")
+            .name("Test")
+            .servers(new HttpServerData("https://api.example.com", "Example"))
+            .operations(List.of(op1, op2))
+            .authentication(globalAuth)
+            .elementType(
+                new ConnectorElementType(Set.of(BpmnType.TASK), BpmnType.SERVICE_TASK, null, null))
+            .build();
+
+    List<String> groupIds = template.groups().stream().map(PropertyGroup::id).toList();
+    int authIdx = groupIds.indexOf("authentication");
+    int opIdx = groupIds.indexOf("operation");
+    assertThat(authIdx).isLessThan(opIdx);
+  }
+
+  @Test
+  void builder_conditionalAuth_shouldPlaceOperationBeforeAuth() {
+    var bearer = BearerAuth.INSTANCE;
+    // op1 uses bearer override, op2 uses global NoAuth → mixed → conditional
+    var op1 = opWithAuth("op1", List.of(bearer));
+    var op2 = opNoOverride("op2");
+
+    List<HttpAuthentication> globalAuth = List.of(NoAuth.INSTANCE);
+    ElementTemplate template =
+        HttpOutboundElementTemplateBuilder.create()
+            .id("test")
+            .name("Test")
+            .servers(new HttpServerData("https://api.example.com", "Example"))
+            .operations(List.of(op1, op2))
+            .authentication(globalAuth)
+            .elementType(
+                new ConnectorElementType(Set.of(BpmnType.TASK), BpmnType.SERVICE_TASK, null, null))
+            .build();
+
+    List<String> groupIds = template.groups().stream().map(PropertyGroup::id).toList();
+    int authIdx = groupIds.indexOf("authentication");
+    int opIdx = groupIds.indexOf("operation");
+    assertThat(opIdx).isLessThan(authIdx);
+  }
+
+  @Test
+  void builder_nullServers_shouldBehaveLikeEmptyServers() {
+    var template =
+        HttpOutboundElementTemplateBuilder.create()
+            .id("test")
+            .name("Test")
+            .operations(List.of(opNoOverride("op1")))
+            .authentication(List.of(NoAuth.INSTANCE))
+            .elementType(
+                new ConnectorElementType(Set.of(BpmnType.TASK), BpmnType.SERVICE_TASK, null, null))
+            .build();
+
+    var serverGroup =
+        template.groups().stream().filter(group -> "server".equals(group.id())).findFirst();
+
+    assertThat(serverGroup).isPresent();
+    assertThat(serverGroup.orElseThrow().properties()).hasSize(1);
+    assertThat(serverGroup.orElseThrow().properties().getFirst().getId()).isEqualTo("baseUrl");
+    assertThat(serverGroup.orElseThrow().properties().getFirst().getType()).isEqualTo("String");
+  }
+
+  // ---------------------------------------------------------------------------
+  // Original test
+  // ---------------------------------------------------------------------------
+
   @Test
   void shouldAddCorrectHeader() {
     // given


### PR DESCRIPTION
## Description

This PR improves the OpenAPI-to-element-template generation pipeline in the HTTP DSL in two areas:

### 1. `baseUrl` always editable

Previously, when an OpenAPI spec contained exactly one server, the generator emitted a `Hidden` property for `baseUrl`, pre-filled with the server URL. This meant users could not override the URL from the Modeler without editing the template.

The single-server branch now emits a `StringProperty` (visible, editable) with the server URL as the pre-filled default — matching the behaviour of the no-servers branch. Multi-server specs (dropdown) are unchanged.

### 2. Auth deduplication across operations

**Problem:** The previous implementation emitted one full set of auth properties per operation, regardless of whether multiple operations shared identical authentication requirements. For an API with 50 operations all using the same Bearer token, this produced 50 copies of the same auth fields — making templates unwieldy and the Modeler panel difficult to navigate.

**Approach:** Operations are grouped by their *effective auth* — `authenticationOverride` if set, else the global `authentications` list. The grouping key is the ordered list of auth IDs. A `LinkedHashMap` preserves first-appearance order.

Two cases arise:

- **Unconditional** (all ops share a single auth group): Auth properties are emitted once, with no conditions. The auth group is placed *before* the operation dropdown in the properties panel, since no property needs to reference `operationId` to scope its visibility.
- **Conditional / multi-group** (ops have different auth): Each group gets a scoped discriminator ID (`<firstOpId>_authType`) and field IDs prefixed with `<firstOpId>_` to prevent duplicate property ID collisions. Each group's properties carry an `OneOf(operationId, [...ops in group])` condition. In this case, auth properties are placed *after* the operation dropdown, because the Modeler resolves conditions top-to-bottom and the `operationId` discriminator must already be resolved.

**Why ordering matters:** The Modeler evaluates conditions in property order. A condition referencing `operationId` on a property that appears *before* `operationId` in the template will always be unresolved. The dynamic reordering ensures the correct evaluation order for both the conditional and unconditional cases.

**Edge case:** Callers that pass an empty `authentications` list (e.g. tests) and operations with no override produce an empty effective-auth list. These operations are now skipped in the grouping loop rather than crashing with `NoSuchElementException`.

### Files changed

- `PropertyUtil.java`: single-server `StringProperty` (Change 1); `authPropertyGroup` rewrite with deduplication (Change 2)
- `HttpOutboundElementTemplateBuilder.java`: dynamic auth/operation group ordering (Change 3)
- `HttpOutboundElementTemplateBuilderTest.java`: `singleServer_noVisibleExpected` → `singleServer_visibleStringExpected`, updated assertion
- `PropertyUtilTest.java`: 10 new unit tests covering unconditional, conditional, single-auth, multi-auth, and empty-auth scenarios

## Related issues

closes #

## Checklist

- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest
  release, as this branch will be rebased onto main before the next release. Example backport labels:
    - `backport stable/8.8`: for changes that should be included in the next 8.8.x release.
    - **or** `backport release-8.8.7`: for changes that should be included in the specific release 8.8.7, and this
      *release has already been created*. The release branch will be merged back into stable/8.8 later, so the change
      will be included in future 8.8.x releases as well.
- [x] Tests/Integration tests for the changes have been added if applicable.