### PR TITLE
feat(runtime): add reset executable endpoint

### DIFF
--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/ExecutableId.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/ExecutableId.java
@@ -37,9 +37,8 @@ public class ExecutableId {
     this.id = id;
   }
 
-  /** Only used for deserialization, in the InboundInstancesRestController for instance. */
   @JsonCreator
-  private static ExecutableId fromHashedId(String id) {
+  public static ExecutableId fromHashedId(String id) {
     return new ExecutableId(id);
   }
 

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/controller/ActiveInboundConnectorResponse.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/controller/ActiveInboundConnectorResponse.java
@@ -16,9 +16,11 @@
  */
 package io.camunda.connector.runtime.inbound.controller;
 
+import io.camunda.connector.api.inbound.Activity;
 import io.camunda.connector.api.inbound.Health;
 import io.camunda.connector.runtime.core.inbound.ExecutableId;
 import io.camunda.connector.runtime.core.inbound.ProcessElementWithRuntimeData;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
@@ -29,4 +31,5 @@ public record ActiveInboundConnectorResponse(
     List<ProcessElementWithRuntimeData> elements,
     Map<String, String> data,
     Health health,
-    Long activationTimestamp) {}
+    Long activationTimestamp,
+    Collection<Activity> logs) {}

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/controller/InboundConnectorRestController.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/controller/InboundConnectorRestController.java
@@ -83,7 +83,7 @@ public class InboundConnectorRestController {
       String tenantId, String bpmnProcessId, String elementId, String hostname) {
     var result =
         executableRegistry.query(
-            new ActiveExecutableQuery(bpmnProcessId, elementId, null, tenantId));
+            f -> f.bpmnProcessId(bpmnProcessId).elementId(elementId).tenantId(tenantId));
     return result.stream()
         .map(ActiveExecutableResponse::logs)
         .filter(Predicate.not(Collection::isEmpty))
@@ -106,12 +106,10 @@ public class InboundConnectorRestController {
   private List<ActiveInboundConnectorResponse> getActiveInboundConnectors(
       String bpmnProcessId, String elementId, String type, String tenantId) {
     return executableRegistry
-        .query(new ActiveExecutableQuery(bpmnProcessId, elementId, type, tenantId))
+        .query(
+            f -> f.bpmnProcessId(bpmnProcessId).elementId(elementId).type(type).tenantId(tenantId))
         .stream()
-        .map(
-            response ->
-                connectorDataMapper.createActiveInboundConnectorResponse(
-                    response, ConnectorDataMapper.WEBHOOK_MAPPER))
+        .map(connectorDataMapper::createActiveInboundConnectorResponse)
         .collect(Collectors.toList());
   }
 }

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/controller/InboundInstancesRestController.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/controller/InboundInstancesRestController.java
@@ -84,13 +84,12 @@ public class InboundInstancesRestController {
   public ActiveInboundConnectorResponse getConnectorInstanceExecutable(
       HttpServletRequest request,
       @RequestHeader(name = X_CAMUNDA_FORWARDED_FOR, required = false) String forwardedFor,
-      @PathVariable(name = "type") String type,
       @PathVariable(name = "executableId") String executableId) {
     return Optional.ofNullable(
             instanceForwardingRouter.forwardToInstancesAndReduceOrLocal(
                 request,
                 forwardedFor,
-                () -> inboundInstancesService.findExecutable(type, executableId),
+                () -> inboundInstancesService.findExecutable(executableId),
                 new TypeReference<>() {}))
         .orElseThrow(
             () -> new DataNotFoundException(ActiveInboundConnectorResponse.class, executableId));
@@ -100,13 +99,12 @@ public class InboundInstancesRestController {
   public List<InstanceAwareModel.InstanceAwareHealth> getConnectorInstanceExecutableHealth(
       HttpServletRequest request,
       @RequestHeader(name = X_CAMUNDA_FORWARDED_FOR, required = false) String forwardedFor,
-      @PathVariable(name = "type") String type,
       @PathVariable(name = "executableId") String executableId) {
 
     return instanceForwardingRouter.forwardToInstancesAndReduceOrLocal(
         request,
         forwardedFor,
-        () -> inboundInstancesService.findInstanceAwareHealth(type, executableId, hostname),
+        () -> inboundInstancesService.findInstanceAwareHealth(executableId, hostname),
         new TypeReference<>() {});
   }
 
@@ -114,12 +112,11 @@ public class InboundInstancesRestController {
   public List<InstanceAwareModel.InstanceAwareActivity> getConnectorInstanceExecutableLogs(
       HttpServletRequest request,
       @RequestHeader(name = X_CAMUNDA_FORWARDED_FOR, required = false) String forwardedFor,
-      @PathVariable(name = "type") String type,
       @PathVariable(name = "executableId") String executableId) {
     return instanceForwardingRouter.forwardToInstancesAndReduceOrLocal(
         request,
         forwardedFor,
-        () -> inboundInstancesService.findInstanceAwareActivityLogs(type, executableId, hostname),
+        () -> inboundInstancesService.findInstanceAwareActivityLogs(executableId, hostname),
         new TypeReference<>() {});
   }
 
@@ -127,13 +124,12 @@ public class InboundInstancesRestController {
   public ActiveInboundConnectorResponse resetConnectorInstanceExecutable(
       HttpServletRequest request,
       @RequestHeader(name = X_CAMUNDA_FORWARDED_FOR, required = false) String forwardedFor,
-      @PathVariable(name = "type") String type,
       @PathVariable(name = "executableId") String executableId) {
     return Optional.ofNullable(
             instanceForwardingRouter.forwardToInstancesAndReduceOrLocal(
                 request,
                 forwardedFor,
-                () -> inboundInstancesService.resetExecutable(type, executableId),
+                () -> inboundInstancesService.resetExecutable(executableId),
                 new TypeReference<>() {}))
         .orElseThrow(
             () -> new DataNotFoundException(ActiveInboundConnectorResponse.class, executableId));

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/controller/InboundInstancesRestController.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/controller/InboundInstancesRestController.java
@@ -80,7 +80,7 @@ public class InboundInstancesRestController {
         .orElseThrow(() -> new DataNotFoundException(ConnectorInstances.class, type));
   }
 
-  @GetMapping("/{type}/executables/{executableId}")
+  @GetMapping({"/{type}/executables/{executableId}", "/executables/{executableId}"})
   public ActiveInboundConnectorResponse getConnectorInstanceExecutable(
       HttpServletRequest request,
       @RequestHeader(name = X_CAMUNDA_FORWARDED_FOR, required = false) String forwardedFor,
@@ -95,7 +95,7 @@ public class InboundInstancesRestController {
             () -> new DataNotFoundException(ActiveInboundConnectorResponse.class, executableId));
   }
 
-  @GetMapping("/{type}/executables/{executableId}/health")
+  @GetMapping({"/{type}/executables/{executableId}/health", "/executables/{executableId}/health"})
   public List<InstanceAwareModel.InstanceAwareHealth> getConnectorInstanceExecutableHealth(
       HttpServletRequest request,
       @RequestHeader(name = X_CAMUNDA_FORWARDED_FOR, required = false) String forwardedFor,
@@ -108,7 +108,7 @@ public class InboundInstancesRestController {
         new TypeReference<>() {});
   }
 
-  @GetMapping("/{type}/executables/{executableId}/logs")
+  @GetMapping({"/{type}/executables/{executableId}/logs", "/executables/{executableId}/logs"})
   public List<InstanceAwareModel.InstanceAwareActivity> getConnectorInstanceExecutableLogs(
       HttpServletRequest request,
       @RequestHeader(name = X_CAMUNDA_FORWARDED_FOR, required = false) String forwardedFor,
@@ -120,7 +120,7 @@ public class InboundInstancesRestController {
         new TypeReference<>() {});
   }
 
-  @PostMapping("/{type}/executables/{executableId}/reset")
+  @PostMapping("/executables/{executableId}/reset")
   public ActiveInboundConnectorResponse resetConnectorInstanceExecutable(
       HttpServletRequest request,
       @RequestHeader(name = X_CAMUNDA_FORWARDED_FOR, required = false) String forwardedFor,

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/controller/InboundInstancesRestController.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/controller/InboundInstancesRestController.java
@@ -122,4 +122,20 @@ public class InboundInstancesRestController {
         () -> inboundInstancesService.findInstanceAwareActivityLogs(type, executableId, hostname),
         new TypeReference<>() {});
   }
+
+  @PostMapping("/{type}/executables/{executableId}/reset")
+  public ActiveInboundConnectorResponse resetConnectorInstanceExecutable(
+      HttpServletRequest request,
+      @RequestHeader(name = X_CAMUNDA_FORWARDED_FOR, required = false) String forwardedFor,
+      @PathVariable(name = "type") String type,
+      @PathVariable(name = "executableId") String executableId) {
+    return Optional.ofNullable(
+            instanceForwardingRouter.forwardToInstancesAndReduceOrLocal(
+                request,
+                forwardedFor,
+                () -> inboundInstancesService.resetExecutable(type, executableId),
+                new TypeReference<>() {}))
+        .orElseThrow(
+            () -> new DataNotFoundException(ActiveInboundConnectorResponse.class, executableId));
+  }
 }

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/executable/ActiveExecutableQuery.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/executable/ActiveExecutableQuery.java
@@ -16,5 +16,64 @@
  */
 package io.camunda.connector.runtime.inbound.executable;
 
-public record ActiveExecutableQuery(
-    String bpmnProcessId, String elementId, String type, String tenantId) {}
+import io.camunda.connector.runtime.core.inbound.ExecutableId;
+
+/** Mutable filter used with the consumer-based {@code query} API. */
+public class ActiveExecutableQuery {
+
+  private String bpmnProcessId;
+  private String elementId;
+  private String type;
+  private String tenantId;
+  private ExecutableId executableId;
+
+  public ActiveExecutableQuery bpmnProcessId(String bpmnProcessId) {
+    this.bpmnProcessId = bpmnProcessId;
+    return this;
+  }
+
+  public ActiveExecutableQuery elementId(String elementId) {
+    this.elementId = elementId;
+    return this;
+  }
+
+  public ActiveExecutableQuery type(String type) {
+    this.type = type;
+    return this;
+  }
+
+  public ActiveExecutableQuery tenantId(String tenantId) {
+    this.tenantId = tenantId;
+    return this;
+  }
+
+  public ActiveExecutableQuery executableId(ExecutableId executableId) {
+    this.executableId = executableId;
+    return this;
+  }
+
+  public ActiveExecutableQuery executableId(String executableId) {
+    this.executableId = executableId == null ? null : ExecutableId.fromHashedId(executableId);
+    return this;
+  }
+
+  public String bpmnProcessId() {
+    return bpmnProcessId;
+  }
+
+  public String elementId() {
+    return elementId;
+  }
+
+  public String type() {
+    return type;
+  }
+
+  public String tenantId() {
+    return tenantId;
+  }
+
+  public ExecutableId executableId() {
+    return executableId;
+  }
+}

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/executable/BatchExecutableProcessor.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/executable/BatchExecutableProcessor.java
@@ -176,16 +176,9 @@ public class BatchExecutableProcessor {
                   "Webhook connectors are not supported in this environment")));
       return new ConnectorNotRegistered(validData, id);
     }
+    final Activated activated;
     try {
-      if (executable instanceof WebhookConnectorExecutable) {
-        LOG.debug("Registering webhook: {}", data.type());
-        if (webhookConnectorRegistry.register(
-            new RegisteredExecutable.Activated(executable, context, id))) {
-          executable.activate(context);
-        }
-      } else {
-        executable.activate(context);
-      }
+      activated = doActivate(executable, context, id);
     } catch (Exception e) {
       LOG.error("Failed to activate connector", e);
       connectorsInboundMetrics.increaseActivationFailure(data.connectorElements().getFirst());
@@ -201,7 +194,28 @@ public class BatchExecutableProcessor {
                     "Activated inbound connector %s with deduplication ID '%s'",
                     data.type(), data.deduplicationId())));
     connectorsInboundMetrics.increaseActivation(data.connectorElements().getFirst());
-    return new Activated(executable, context, id);
+    return activated;
+  }
+
+  /**
+   * Handles the webhook registration (if applicable) and activates the executable. Throws on
+   * failure so callers can apply their own error-handling strategy.
+   */
+  private Activated doActivate(
+      InboundConnectorExecutable<InboundConnectorContext> executable,
+      InboundConnectorManagementContext context,
+      ExecutableId id)
+      throws Exception {
+    var activated = new Activated(executable, context, id);
+    if (executable instanceof WebhookConnectorExecutable) {
+      LOG.debug("Registering webhook: {}", context.getDefinition().type());
+      if (webhookConnectorRegistry.register(activated)) {
+        executable.activate(context);
+      }
+    } else {
+      executable.activate(context);
+    }
+    return activated;
   }
 
   /** Deactivates a single inbound connector. */
@@ -254,7 +268,7 @@ public class BatchExecutableProcessor {
             LOG.info(
                 "Resetting activated inbound connector of type '{}'",
                 activated.context().getDefinition().type());
-            deactivateBatch(List.of(activated));
+            deactivateSingle(activated);
             yield new RegisteredExecutable.Cancelled(
                 activated.executable(), activated.context(), null, activated.id());
           }
@@ -271,21 +285,24 @@ public class BatchExecutableProcessor {
                       + ". Only Activated or Cancelled executables can be reset.");
         };
 
-    var noRetry =
-        ConnectorRetryException.builder().retries(0).backoffDuration(Duration.ZERO).build();
-    return restartFromContext(cancelled, noRetry);
+    return doRestartFromContext(cancelled, 0, Duration.ZERO);
   }
 
   public CompletableFuture<Activated> restartFromContext(
       RegisteredExecutable.Cancelled cancelled, ConnectorRetryException retryException) {
+    return doRestartFromContext(
+        cancelled, retryException.getRetries(), retryException.getBackoffDuration());
+  }
 
+  private CompletableFuture<Activated> doRestartFromContext(
+      RegisteredExecutable.Cancelled cancelled, int maxRetries, Duration backoff) {
     InboundConnectorExecutable<InboundConnectorContext> newExecutable =
         connectorFactory.getInstance(cancelled.context().getDefinition().type());
     LOG.warn("Inbound connector executable has requested its reactivation");
     try {
       RetryPolicy<Object> retryPolicy =
           RetryPolicy.builder()
-              .withDelay(retryException.getBackoffDuration())
+              .withDelay(backoff)
               .onFailedAttempt(
                   event ->
                       LOG.error(
@@ -298,7 +315,7 @@ public class BatchExecutableProcessor {
                           "Failure #{} to reactivate connector: {}. Retrying.",
                           event.getAttemptCount(),
                           cancelled.context().getDefinition().type()))
-              .withMaxRetries(retryException.getRetries())
+              .withMaxRetries(maxRetries)
               .build();
       return Failsafe.with(retryPolicy)
           .getAsync(() -> tryRestart(newExecutable, cancelled.context()));
@@ -313,9 +330,9 @@ public class BatchExecutableProcessor {
     try {
       var executableId =
           ExecutableId.fromDeduplicationId(context.getDefinition().deduplicationId());
-      executable.activate(context);
+      var activated = doActivate(executable, context, executableId);
       LOG.info("Activation successful for {}", context.getDefinition().type());
-      return new Activated(executable, context, executableId);
+      return activated;
     } catch (Exception e) {
       throw new RuntimeException(e);
     }

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/executable/BatchExecutableProcessor.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/executable/BatchExecutableProcessor.java
@@ -43,6 +43,7 @@ import io.camunda.connector.runtime.inbound.executable.RegisteredExecutable.Fail
 import io.camunda.connector.runtime.inbound.executable.RegisteredExecutable.InvalidDefinition;
 import io.camunda.connector.runtime.inbound.webhook.WebhookConnectorRegistry;
 import io.camunda.connector.runtime.metrics.ConnectorsInboundMetrics;
+import java.time.Duration;
 import java.util.*;
 import java.util.concurrent.*;
 import java.util.function.Consumer;
@@ -230,6 +231,44 @@ public class BatchExecutableProcessor {
             activated.context().connectorElements().getFirst());
       }
     }
+  }
+
+  /**
+   * Resets an executable by deactivating it (if currently active) and re-activating it with a fresh
+   * instance, reusing the same context. Only {@link Activated} and {@link
+   * RegisteredExecutable.Cancelled} states are supported.
+   *
+   * @param executable the executable to reset
+   * @return a {@link CompletableFuture} that resolves to the new {@link Activated} executable
+   * @throws IllegalStateException if the executable is not in a resettable state
+   */
+  public CompletableFuture<Activated> restartFromContext(RegisteredExecutable executable) {
+    RegisteredExecutable.Cancelled cancelled =
+        switch (executable) {
+          case Activated activated -> {
+            LOG.info(
+                "Resetting activated inbound connector of type '{}'",
+                activated.context().getDefinition().type());
+            deactivateBatch(List.of(activated));
+            yield new RegisteredExecutable.Cancelled(
+                activated.executable(), activated.context(), null, activated.id());
+          }
+          case RegisteredExecutable.Cancelled c -> {
+            LOG.info(
+                "Resetting cancelled inbound connector of type '{}'",
+                c.context().getDefinition().type());
+            yield c;
+          }
+          default ->
+              throw new IllegalStateException(
+                  "Cannot reset connector in state: "
+                      + executable.getClass().getSimpleName()
+                      + ". Only Activated or Cancelled executables can be reset.");
+        };
+
+    var noRetry =
+        ConnectorRetryException.builder().retries(0).backoffDuration(Duration.ZERO).build();
+    return restartFromContext(cancelled, noRetry);
   }
 
   public CompletableFuture<Activated> restartFromContext(

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/executable/BatchExecutableProcessor.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/executable/BatchExecutableProcessor.java
@@ -204,32 +204,37 @@ public class BatchExecutableProcessor {
     return new Activated(executable, context, id);
   }
 
+  /** Deactivates a single inbound connector. */
+  public void deactivateSingle(RegisteredExecutable executable) {
+    if (executable instanceof Activated activated) {
+      try {
+        if (activated.executable() instanceof WebhookConnectorExecutable) {
+          LOG.debug("Unregistering webhook: {}", activated.context().getDefinition().type());
+          webhookConnectorRegistry.deregister(activated);
+        }
+        activated.executable().deactivate();
+        log(
+            executable.id(),
+            Activity.newBuilder()
+                .withSeverity(Severity.INFO)
+                .withTag(ActivityLogTag.LIFECYCLE)
+                .withMessage(
+                    "Deactivated executable: "
+                        + activated.context().getDefinition().type()
+                        + " with executable ID "
+                        + activated.id()));
+      } catch (Exception e) {
+        LOG.error("Failed to deactivate executable", e);
+      }
+      connectorsInboundMetrics.increaseDeactivation(
+          activated.context().connectorElements().getFirst());
+    }
+  }
+
   /** Deactivates a batch of inbound connectors. */
   public void deactivateBatch(List<RegisteredExecutable> executables) {
-    for (var activeExecutable : executables) {
-      if (activeExecutable instanceof Activated activated) {
-        try {
-          if (activated.executable() instanceof WebhookConnectorExecutable) {
-            LOG.debug("Unregistering webhook: {}", activated.context().getDefinition().type());
-            webhookConnectorRegistry.deregister(activated);
-          }
-          activated.executable().deactivate();
-          log(
-              activeExecutable.id(),
-              Activity.newBuilder()
-                  .withSeverity(Severity.INFO)
-                  .withTag(ActivityLogTag.LIFECYCLE)
-                  .withMessage(
-                      "Deactivated executable: "
-                          + activated.context().getDefinition().type()
-                          + " with executable ID "
-                          + activated.id()));
-        } catch (Exception e) {
-          LOG.error("Failed to deactivate executable", e);
-        }
-        connectorsInboundMetrics.increaseDeactivation(
-            activated.context().connectorElements().getFirst());
-      }
+    for (var executable : executables) {
+      deactivateSingle(executable);
     }
   }
 

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/executable/ConnectorDataMapper.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/executable/ConnectorDataMapper.java
@@ -16,44 +16,20 @@
  */
 package io.camunda.connector.runtime.inbound.executable;
 
-import io.camunda.connector.api.inbound.webhook.WebhookConnectorExecutable;
 import io.camunda.connector.runtime.core.inbound.InboundConnectorElement;
 import io.camunda.connector.runtime.inbound.controller.ActiveInboundConnectorResponse;
 import java.util.Map;
-import java.util.function.Function;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class ConnectorDataMapper {
 
-  private static final Logger LOG = LoggerFactory.getLogger(ConnectorDataMapper.class);
-
-  public static final Function<ActiveExecutableResponse, Map<String, String>> WEBHOOK_MAPPER =
-      (ActiveExecutableResponse response) -> {
-        Map<String, String> data = Map.of();
-        var executableClass = response.executableClass();
-
-        if (executableClass != null
-            && WebhookConnectorExecutable.class.isAssignableFrom(executableClass)) {
-          try {
-            var properties = response.elements().getFirst().connectorLevelProperties();
-            var contextPath = properties.get("inbound.context");
-            data = Map.of("path", contextPath);
-          } catch (Exception e) {
-            LOG.error("ERROR: webhook connector doesn't have context path property", e);
-          }
-        }
-        return data;
-      };
-
-  private Map<String, String> allPropertiesMapper(ActiveExecutableResponse response) {
+  private static Map<String, String> allPropertiesMapper(ActiveExecutableResponse response) {
     return response.elements().getFirst().connectorLevelProperties();
   }
 
   public ActiveInboundConnectorResponse createActiveInboundConnectorResponse(
-      ActiveExecutableResponse connector,
-      Function<ActiveExecutableResponse, Map<String, String>> dataMapper) {
+      ActiveExecutableResponse connector) {
     var elements = connector.elements();
+    var logs = connector.logs();
     var type = elements.getFirst().type();
     var tenantId = elements.getFirst().element().tenantId();
     return new ActiveInboundConnectorResponse(
@@ -61,13 +37,9 @@ public class ConnectorDataMapper {
         type,
         tenantId,
         elements.stream().map(InboundConnectorElement::element).toList(),
-        dataMapper.apply(connector),
+        allPropertiesMapper(connector),
         connector.health(),
-        connector.activationTimestamp());
-  }
-
-  public ActiveInboundConnectorResponse createActiveInboundConnectorResponse(
-      ActiveExecutableResponse connector) {
-    return createActiveInboundConnectorResponse(connector, this::allPropertiesMapper);
+        connector.activationTimestamp(),
+        logs);
   }
 }

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/executable/InboundExecutableQueryService.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/executable/InboundExecutableQueryService.java
@@ -82,6 +82,10 @@ public class InboundExecutableQueryService {
       return false;
     }
 
+    if (query == null) {
+      return true;
+    }
+
     var firstElement = elements.getFirst();
 
     if (query.type() != null && !query.type().equals(firstElement.type())) {
@@ -94,11 +98,12 @@ public class InboundExecutableQueryService {
         && !query.bpmnProcessId().equals(firstElement.element().bpmnProcessId())) {
       return false;
     }
+    if (query.executableId() != null && !query.executableId().equals(response.executableId())) {
+      return false;
+    }
     if (query.elementId() != null) {
-      boolean hasMatchingElement =
-          elements.stream()
-              .anyMatch(element -> element.element().elementId().equals(query.elementId()));
-      return hasMatchingElement;
+      return elements.stream()
+          .anyMatch(element -> element.element().elementId().equals(query.elementId()));
     }
     return true;
   }

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/executable/InboundExecutableRegistry.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/executable/InboundExecutableRegistry.java
@@ -16,6 +16,7 @@
  */
 package io.camunda.connector.runtime.inbound.executable;
 
+import io.camunda.connector.runtime.core.inbound.ExecutableId;
 import java.util.List;
 
 public interface InboundExecutableRegistry {
@@ -25,4 +26,14 @@ public interface InboundExecutableRegistry {
   List<ActiveExecutableResponse> query(ActiveExecutableQuery query);
 
   String getConnectorName(String type);
+
+  /**
+   * Resets the executable with the given ID by deactivating it and re-activating it with a fresh
+   * instance. Only executables in {@code Activated} or {@code Cancelled} state can be reset.
+   *
+   * @param id the ID of the executable to reset
+   * @throws IllegalArgumentException if no executable with the given ID is found
+   * @throws IllegalStateException if the executable is not in a resettable state
+   */
+  void reset(ExecutableId id);
 }

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/executable/InboundExecutableRegistry.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/executable/InboundExecutableRegistry.java
@@ -17,23 +17,36 @@
 package io.camunda.connector.runtime.inbound.executable;
 
 import io.camunda.connector.runtime.core.inbound.ExecutableId;
+import io.camunda.connector.runtime.inbound.executable.RegisteredExecutable.Activated;
 import java.util.List;
+import java.util.function.Consumer;
 
 public interface InboundExecutableRegistry {
 
   void publishEvent(InboundExecutableEvent event);
 
-  List<ActiveExecutableResponse> query(ActiveExecutableQuery query);
+  /**
+   * Query executables matching the given filter criteria.
+   *
+   * <p>Example usage: {@code registry.query(f -> f.bpmnProcessId("myProcess").tenantId("tenant1"))}
+   *
+   * @param filter consumer that configures the query filter
+   * @return list of matching executable responses
+   */
+  List<ActiveExecutableResponse> query(Consumer<ActiveExecutableQuery> filter);
 
   String getConnectorName(String type);
 
   /**
    * Resets the executable with the given ID by deactivating it and re-activating it with a fresh
-   * instance. Only executables in {@code Activated} or {@code Cancelled} state can be reset.
+   * instance. Only executables in {@code Activated} or {@code Cancelled} state can be reset. Blocks
+   * until the restart completes and returns the new {@link Activated} executable.
    *
    * @param id the ID of the executable to reset
+   * @return the new {@link Activated} executable after the reset
    * @throws IllegalArgumentException if no executable with the given ID is found
    * @throws IllegalStateException if the executable is not in a resettable state
+   * @throws RuntimeException if the restart fails
    */
-  void reset(ExecutableId id);
+  RegisteredExecutable reset(ExecutableId id);
 }

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/executable/InboundExecutableRegistryImpl.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/executable/InboundExecutableRegistryImpl.java
@@ -298,6 +298,26 @@ public class InboundExecutableRegistryImpl implements InboundExecutableRegistry 
     return queryService.getConnectorName(type);
   }
 
+  @Override
+  public void reset(ExecutableId id) {
+    var current = stateStore.get(id);
+    if (current == null) {
+      throw new IllegalArgumentException("No executable found with ID: " + id);
+    }
+    batchExecutableProcessor
+        .restartFromContext(current)
+        .thenAccept(
+            newActivated -> {
+              stateStore.replace(id, newActivated);
+              LOG.info("Connector executable '{}' reset successfully", id);
+            })
+        .exceptionally(
+            e -> {
+              LOG.error("Failed to reset connector executable '{}'", id, e);
+              return null;
+            });
+  }
+
   @Scheduled(fixedDelay = 30000)
   void logHealthStatus() {
     var health = queryService.aggregateHealth();

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/executable/InboundExecutableRegistryImpl.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/executable/InboundExecutableRegistryImpl.java
@@ -25,16 +25,15 @@ import io.camunda.connector.runtime.core.inbound.InboundConnectorManagementConte
 import io.camunda.connector.runtime.core.inbound.activitylog.ActivityLogRegistry;
 import io.camunda.connector.runtime.core.inbound.details.InboundConnectorDetails;
 import io.camunda.connector.runtime.inbound.executable.InboundExecutableStateTransitionService.ActionType;
+import io.camunda.connector.runtime.inbound.executable.InboundExecutableStateTransitionService.PlannedAction;
 import io.camunda.connector.runtime.inbound.executable.InboundExecutableStateTransitionService.StateTransitionPlan;
 import io.camunda.connector.runtime.inbound.executable.InboundExecutableStateTransitionService.TargetState;
 import io.camunda.connector.runtime.inbound.executable.RegisteredExecutable.Activated;
 import io.camunda.connector.runtime.inbound.executable.RegisteredExecutable.Cancelled;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
+import java.util.*;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
+import java.util.function.Consumer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -289,7 +288,9 @@ public class InboundExecutableRegistryImpl implements InboundExecutableRegistry 
   }
 
   @Override
-  public List<ActiveExecutableResponse> query(ActiveExecutableQuery query) {
+  public List<ActiveExecutableResponse> query(Consumer<ActiveExecutableQuery> filter) {
+    var query = new ActiveExecutableQuery();
+    Optional.ofNullable(filter).ifPresent(f -> f.accept(query));
     return queryService.query(query);
   }
 
@@ -299,23 +300,65 @@ public class InboundExecutableRegistryImpl implements InboundExecutableRegistry 
   }
 
   @Override
-  public void reset(ExecutableId id) {
+  public RegisteredExecutable reset(ExecutableId id) {
+    // Peek at the current state to determine the process lock key before entering the synchronized
+    // block. This prevents a race condition where a concurrent redeploy (handleProcessStateChanged)
+    // could run during restart, leaving the newly-activated executable invisible to the state
+    // machine (zombie connector).
+    var processLockKey = extractProcessLockKey(validateResettable(id));
+    synchronized (processLockKey.intern()) {
+      // Re-validate inside the lock; state may have changed since the peek
+      var current = validateResettable(id);
+
+      // Reuse the standard state-transition pipeline: build a target state from the current
+      // elements and issue a RESTART plan. On activation failure, activateBatch stores a
+      // FailedToActivate entry so the executable remains visible and retryable by operators.
+      var targetState =
+          stateTransitionService.computeTargetState(extractContext(current).connectorElements());
+      executeStateTransition(
+          new StateTransitionPlan(List.of(new PlannedAction(id, ActionType.RESTART))), targetState);
+
+      var result = stateStore.get(id);
+      LOG.info(
+          "Connector executable '{}' reset, new state: {}",
+          id,
+          result == null ? "absent" : result.getClass().getSimpleName());
+      return result;
+    }
+  }
+
+  private RegisteredExecutable validateResettable(ExecutableId id) {
     var current = stateStore.get(id);
     if (current == null) {
       throw new IllegalArgumentException("No executable found with ID: " + id);
     }
-    batchExecutableProcessor
-        .restartFromContext(current)
-        .thenAccept(
-            newActivated -> {
-              stateStore.replace(id, newActivated);
-              LOG.info("Connector executable '{}' reset successfully", id);
-            })
-        .exceptionally(
-            e -> {
-              LOG.error("Failed to reset connector executable '{}'", id, e);
-              return null;
-            });
+    if (!(current instanceof Activated) && !(current instanceof Cancelled)) {
+      throw new IllegalStateException(
+          "Cannot reset executable '"
+              + id
+              + "': must be in Activated or Cancelled state, but was: "
+              + current.getClass().getSimpleName());
+    }
+    return current;
+  }
+
+  /**
+   * Derives the process-level lock key from a registered executable, matching the key used by
+   * {@link #handleProcessStateChanged} to synchronize state transitions.
+   */
+  private String extractProcessLockKey(RegisteredExecutable executable) {
+    var element = extractContext(executable).connectorElements().getFirst();
+    return element.tenantId() + element.element().bpmnProcessId();
+  }
+
+  private InboundConnectorManagementContext extractContext(RegisteredExecutable executable) {
+    return switch (executable) {
+      case Activated a -> a.context();
+      case Cancelled c -> c.context();
+      default ->
+          throw new IllegalArgumentException(
+              "Cannot extract context from: " + executable.getClass().getSimpleName());
+    };
   }
 
   @Scheduled(fixedDelay = 30000)

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/executable/InboundExecutableRegistryImpl.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/executable/InboundExecutableRegistryImpl.java
@@ -116,9 +116,9 @@ public class InboundExecutableRegistryImpl implements InboundExecutableRegistry 
         event.elementsByProcessDefinitionKey().size());
     LOG.debug("Received target elements: {}", event.elementsByProcessDefinitionKey());
 
-    var processId = event.tenantId() + event.bpmnProcessId();
+    var processLockKey = processLockKey(event.tenantId(), event.bpmnProcessId());
 
-    synchronized (processId.intern()) {
+    synchronized (processLockKey.intern()) {
       try {
         List<InboundConnectorElement> allElements =
             event.elementsByProcessDefinitionKey().values().stream().flatMap(List::stream).toList();
@@ -348,7 +348,11 @@ public class InboundExecutableRegistryImpl implements InboundExecutableRegistry 
    */
   private String extractProcessLockKey(RegisteredExecutable executable) {
     var element = extractContext(executable).connectorElements().getFirst();
-    return element.tenantId() + element.element().bpmnProcessId();
+    return processLockKey(element.tenantId(), element.element().bpmnProcessId());
+  }
+
+  private String processLockKey(String tenantId, String bpmnProcessId) {
+    return tenantId + bpmnProcessId;
   }
 
   private InboundConnectorManagementContext extractContext(RegisteredExecutable executable) {

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/instances/service/InboundInstancesService.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/instances/service/InboundInstancesService.java
@@ -16,9 +16,7 @@
  */
 package io.camunda.connector.runtime.instances.service;
 
-import io.camunda.connector.api.inbound.Activity;
 import io.camunda.connector.api.inbound.Health;
-import io.camunda.connector.runtime.core.inbound.ProcessElementWithRuntimeData;
 import io.camunda.connector.runtime.inbound.controller.ActiveInboundConnectorResponse;
 import io.camunda.connector.runtime.inbound.controller.exception.DataNotFoundException;
 import io.camunda.connector.runtime.inbound.executable.ActiveExecutableQuery;
@@ -27,6 +25,7 @@ import io.camunda.connector.runtime.inbound.executable.ConnectorInstances;
 import io.camunda.connector.runtime.inbound.executable.InboundExecutableRegistry;
 import io.camunda.connector.runtime.instances.InstanceAwareModel;
 import java.util.List;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 public class InboundInstancesService {
@@ -39,8 +38,8 @@ public class InboundInstancesService {
   }
 
   public List<InstanceAwareModel.InstanceAwareHealth> findInstanceAwareHealth(
-      String type, String executableId, String hostname) {
-    var executable = findExecutable(type, executableId);
+      String executableId, String hostname) {
+    var executable = findExecutable(executableId);
     Health health = executable.health();
     return List.of(
         new InstanceAwareModel.InstanceAwareHealth(
@@ -48,32 +47,9 @@ public class InboundInstancesService {
   }
 
   public List<InstanceAwareModel.InstanceAwareActivity> findInstanceAwareActivityLogs(
-      String type, String executableId, String hostname) {
-    var executable = findExecutable(type, executableId);
-    var processIds =
-        executable.elements().stream()
-            .map(ProcessElementWithRuntimeData::bpmnProcessId)
-            .distinct()
-            .toList();
-    if (processIds.size() > 1) {
-      throw new RuntimeException(
-          "Multiple process ids found for the id: "
-              + executableId
-              + ". This is not supported yet.");
-    }
-    var processId = processIds.getFirst();
-    var result =
-        executableRegistry
-            .query(new ActiveExecutableQuery(processId, null, type, executable.tenantId()))
-            .stream()
-            .filter(
-                activeExecutableResponse ->
-                    activeExecutableResponse.executableId().getId().equals(executableId))
-            .findFirst();
-    if (result.isEmpty()) {
-      throw new DataNotFoundException(Activity.class, executableId);
-    }
-    return result.get().logs().stream()
+      String executableId, String hostname) {
+    var executable = findExecutable(executableId);
+    return executable.logs().stream()
         .map(
             activity ->
                 new InstanceAwareModel.InstanceAwareActivity(
@@ -85,14 +61,8 @@ public class InboundInstancesService {
         .toList();
   }
 
-  public ActiveInboundConnectorResponse findExecutable(String type, String executableId) {
-    var instance = findConnectorInstancesOfType(type);
-    var executables =
-        instance.instances().stream()
-            .filter(
-                activeInboundConnectorResponse ->
-                    activeInboundConnectorResponse.executableId().getId().equals(executableId))
-            .toList();
+  public ActiveInboundConnectorResponse findExecutable(String executableId) {
+    var executables = getActiveInboundConnectors(f -> f.executableId(executableId));
     if (executables.isEmpty()) {
       throw new DataNotFoundException(ActiveInboundConnectorResponse.class, executableId);
     }
@@ -100,7 +70,7 @@ public class InboundInstancesService {
   }
 
   public ConnectorInstances findConnectorInstancesOfType(String type) {
-    var connectorInstances = getConnectorsInstances(type);
+    var connectorInstances = getConnectorsInstances(f -> f.type(type));
     if (connectorInstances.isEmpty()) {
       throw new DataNotFoundException(ConnectorInstances.class, type);
     }
@@ -112,17 +82,18 @@ public class InboundInstancesService {
   }
 
   /**
-   * Resets the connector executable identified by the given type and executable ID. The executable
-   * is deactivated and re-activated with a fresh instance while keeping its current context.
+   * Resets the connector executable identified by the given executable ID. The executable is
+   * deactivated and re-activated with a fresh instance while keeping its current context. Blocks
+   * until the restart completes.
    *
-   * @param type the connector type
    * @param executableId the executable ID
-   * @return the updated {@link ActiveInboundConnectorResponse} after reset
+   * @return the {@link ActiveInboundConnectorResponse} of the newly activated executable
+   * @throws RuntimeException if the restart fails
    */
-  public ActiveInboundConnectorResponse resetExecutable(String type, String executableId) {
-    var executable = findExecutable(type, executableId);
+  public ActiveInboundConnectorResponse resetExecutable(String executableId) {
+    var executable = findExecutable(executableId);
     executableRegistry.reset(executable.executableId());
-    return findExecutable(type, executableId);
+    return findExecutable(executableId);
   }
 
   /**
@@ -130,10 +101,12 @@ public class InboundInstancesService {
    * connector type. Changing the response format will break the c4-connectors, so make sure to
    * update the c4-connectors as well.
    *
-   * @param type the connectorId to filter by (also called 'connectorId')
+   * @param filter the filter to apply when querying the active executables. If null, no filter is
+   *     applied and all active executables are returned.
+   * @return a list of {@link ConnectorInstances} grouped by connector type
    */
-  private List<ConnectorInstances> getConnectorsInstances(String type) {
-    var activeInboundConnectors = getActiveInboundConnectors(type);
+  private List<ConnectorInstances> getConnectorsInstances(Consumer<ActiveExecutableQuery> filter) {
+    var activeInboundConnectors = getActiveInboundConnectors(filter);
     return activeInboundConnectors.stream()
         .collect(Collectors.groupingBy(ActiveInboundConnectorResponse::type, Collectors.toList()))
         .entrySet()
@@ -145,8 +118,9 @@ public class InboundInstancesService {
         .toList();
   }
 
-  private List<ActiveInboundConnectorResponse> getActiveInboundConnectors(String type) {
-    return executableRegistry.query(new ActiveExecutableQuery(null, null, type, null)).stream()
+  private List<ActiveInboundConnectorResponse> getActiveInboundConnectors(
+      Consumer<ActiveExecutableQuery> filter) {
+    return executableRegistry.query(filter).stream()
         .map(connectorDataMapper::createActiveInboundConnectorResponse)
         .collect(Collectors.toList());
   }

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/instances/service/InboundInstancesService.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/instances/service/InboundInstancesService.java
@@ -112,6 +112,20 @@ public class InboundInstancesService {
   }
 
   /**
+   * Resets the connector executable identified by the given type and executable ID. The executable
+   * is deactivated and re-activated with a fresh instance while keeping its current context.
+   *
+   * @param type the connector type
+   * @param executableId the executable ID
+   * @return the updated {@link ActiveInboundConnectorResponse} after reset
+   */
+  public ActiveInboundConnectorResponse resetExecutable(String type, String executableId) {
+    var executable = findExecutable(type, executableId);
+    executableRegistry.reset(executable.executableId());
+    return findExecutable(type, executableId);
+  }
+
+  /**
    * Be aware that this API is used by c4-connectors to get the active inbound connectors grouped by
    * connector type. Changing the response format will break the c4-connectors, so make sure to
    * update the c4-connectors as well.

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/inbound/executable/InboundExecutableRegistryTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/inbound/executable/InboundExecutableRegistryTest.java
@@ -89,7 +89,7 @@ public class InboundExecutableRegistryTest {
         new ProcessStateChanged("id", "tenant", Map.of(0L, List.of(element1, element2))));
 
     // then
-    var result = registry.query(new ActiveExecutableQuery(null, elementId, null, null));
+    var result = registry.query(f -> f.elementId(elementId));
     assertThat(result.getFirst().health().getStatus()).isEqualTo(Status.DOWN);
     assertThat(result.getFirst().health().getError().message())
         .contains("Invalid connector definition: All elements in a group must have the same type");
@@ -166,7 +166,7 @@ public class InboundExecutableRegistryTest {
     registry.handleEvent(new ProcessStateChanged("id", "tenant", Map.of(0L, List.of(element))));
 
     // then
-    var result = registry.query(new ActiveExecutableQuery(null, elementId, null, null));
+    var result = registry.query(f -> f.elementId(elementId));
     assertThat(result.getFirst().health().getStatus()).isEqualTo(Status.DOWN);
     assertThat(result.getFirst().health().getError().message()).contains("failed");
   }
@@ -208,7 +208,7 @@ public class InboundExecutableRegistryTest {
     verify(executable2).activate(mockContext);
     verify(executable1).deactivate();
 
-    var results = registry.query(new ActiveExecutableQuery(null, null, null, null));
+    var results = registry.query(f -> {});
     assertThat(results.size()).isEqualTo(2);
     assertThat(results.stream().allMatch(r -> r.health().getStatus() == Status.DOWN)).isTrue();
   }
@@ -251,7 +251,7 @@ public class InboundExecutableRegistryTest {
     verify(executable1).activate(mockContext);
     verifyNoMoreInteractions(executable1);
 
-    var results = registry.query(new ActiveExecutableQuery(null, null, null, null));
+    var results = registry.query(f -> {});
     assertThat(results.size()).isEqualTo(2);
     // One should be healthy (activated), one should be down (not registered)
     assertThat(results.stream().filter(r -> r.health().getStatus() == Status.UP).count())
@@ -276,7 +276,7 @@ public class InboundExecutableRegistryTest {
     registry.handleEvent(new ProcessStateChanged("id", "tenant", Map.of(0L, List.of(element))));
 
     // then
-    var result = registry.query(new ActiveExecutableQuery(null, elementId, null, null));
+    var result = registry.query(f -> f.elementId(elementId));
     assertThat(result.getFirst().health().getStatus()).isEqualTo(Status.DOWN);
     assertThat(result.getFirst().health().getError().message())
         .contains("Connector unknown-type not registered");
@@ -549,7 +549,9 @@ public class InboundExecutableRegistryTest {
     registry.handleEvent(new ProcessStateChanged("id", "tenant", Map.of(0L, List.of(element))));
 
     // then
-    var result = registry.query(new ActiveExecutableQuery("id", elementId, "type1", "tenant"));
+    var result =
+        registry.query(
+            f -> f.bpmnProcessId("id").elementId(elementId).type("type1").tenantId("tenant"));
     assertThat(result.getFirst().logs())
         .hasSize(1)
         .first()
@@ -581,7 +583,7 @@ public class InboundExecutableRegistryTest {
     registry.handleEvent(new ProcessStateChanged("id", "tenant", Map.of(0L, List.of(element))));
 
     // then
-    var result = registry.query(new ActiveExecutableQuery(null, elementId, null, null));
+    var result = registry.query(f -> f.elementId(elementId));
     assertThat(result.getFirst().logs()).isEmpty();
   }
 
@@ -604,11 +606,7 @@ public class InboundExecutableRegistryTest {
     when(factory.getInstance(any())).thenReturn(executable);
 
     registry.handleEvent(new ProcessStateChanged("id", "tenant", Map.of(0L, List.of(element))));
-    var executableId =
-        registry
-            .query(new ActiveExecutableQuery(null, elementId, null, null))
-            .getFirst()
-            .executableId();
+    var executableId = registry.query(f -> f.elementId(elementId)).getFirst().executableId();
 
     // when - send empty process state to trigger deactivation of all connectors in this process
     registry.handleEvent(new ProcessStateChanged("id", "tenant", Map.of()));
@@ -669,7 +667,7 @@ public class InboundExecutableRegistryTest {
     registry.handleEvent(new ProcessStateChanged("id", "tenant", Map.of(0L, List.of(element))));
 
     // then
-    var result = registry.query(new ActiveExecutableQuery(null, elementId, null, null));
+    var result = registry.query(f -> f.elementId(elementId));
     var logs = result.getFirst().logs();
     assertThat(logs).hasSize(2);
     assertThat(logs)

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/instances/helpers/ActiveInboundConnectorResponseHelper.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/instances/helpers/ActiveInboundConnectorResponseHelper.java
@@ -52,7 +52,8 @@ public class ActiveInboundConnectorResponseHelper {
         List.of(),
         Map.of("dataKey", "dataValue"),
         health,
-        activationTimestamp);
+        activationTimestamp,
+        List.of());
   }
 
   public static Stream<Arguments> getConnectorInstancesWithExpectedResult() {

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/instances/helpers/ConnectorInstancesListResponseHelper.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/instances/helpers/ConnectorInstancesListResponseHelper.java
@@ -52,7 +52,8 @@ public class ConnectorInstancesListResponseHelper {
         List.of(),
         Map.of("dataKey", "dataValue"),
         health,
-        activationTimestamp);
+        activationTimestamp,
+        List.of());
   }
 
   public static Stream<Arguments> getConnectorInstancesListsWithExpectedResult() {

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/instances/reducer/ActiveInboundConnectorResponseReducerTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/instances/reducer/ActiveInboundConnectorResponseReducerTest.java
@@ -87,7 +87,8 @@ public class ActiveInboundConnectorResponseReducerTest {
             List.of(),
             Map.of("dataKey", "dataValue"),
             health1,
-            activationTime1);
+            activationTime1,
+            List.of());
     ActiveInboundConnectorResponse response2 =
         new ActiveInboundConnectorResponse(
             ExecutableId.fromDeduplicationId("executableId"),
@@ -96,7 +97,8 @@ public class ActiveInboundConnectorResponseReducerTest {
             List.of(),
             Map.of("dataKey", "dataValue"),
             health2,
-            activationTime2);
+            activationTime2,
+            List.of());
 
     // when
     ActiveInboundConnectorResponse reducedResponse = reducer.reduce(response1, response2);

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/instances/service/DefaultInstanceForwardingServiceTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/instances/service/DefaultInstanceForwardingServiceTest.java
@@ -51,7 +51,8 @@ public class DefaultInstanceForwardingServiceTest {
                     List.of(),
                     Map.of("dataKey", "dataValue"),
                     Health.down(),
-                    System.currentTimeMillis())));
+                    System.currentTimeMillis(),
+                    List.of())));
     DefaultInstanceForwardingService service =
         new DefaultInstanceForwardingService(mockHttpClient, "localhost");
     var mockHttpServletRequest = new MockHttpServletRequest(method, path);

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/inbound/BaseMultiInstancesTest.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/inbound/BaseMultiInstancesTest.java
@@ -30,15 +30,14 @@ import io.camunda.connector.runtime.core.inbound.ExecutableId;
 import io.camunda.connector.runtime.core.inbound.InboundConnectorElement;
 import io.camunda.connector.runtime.core.inbound.ProcessElementWithRuntimeData;
 import io.camunda.connector.runtime.core.inbound.correlation.MessageCorrelationPoint;
-import io.camunda.connector.runtime.inbound.executable.ActiveExecutableQuery;
-import io.camunda.connector.runtime.inbound.executable.ActiveExecutableResponse;
-import io.camunda.connector.runtime.inbound.executable.InboundExecutableRegistry;
+import io.camunda.connector.runtime.inbound.executable.*;
 import io.camunda.connector.runtime.instances.service.DefaultInstanceForwardingService;
 import io.camunda.connector.runtime.instances.service.InstanceForwardingService;
 import java.net.http.HttpClient;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Consumer;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -68,6 +67,7 @@ abstract class BaseMultiInstancesTest {
           (path) -> List.of("http://localhost:" + port1 + path, "http://localhost:" + port2 + path),
           ConnectorsObjectMapperSupplier.getCopy());
 
+  static final ExecutableId UNKNOWN_ID = ExecutableId.fromHashedId("abcdef");
   static final ExecutableId RANDOM_ID_1 = ExecutableId.fromDeduplicationId("theid1");
   static final ExecutableId ONLY_IN_RUNTIME_1_ID =
       ExecutableId.fromDeduplicationId("onlyInRuntime1");
@@ -80,13 +80,29 @@ abstract class BaseMultiInstancesTest {
   static final String TYPE_3_ONLY_IN_RUNTIME_1 = "onlyInRuntime1Type3";
 
   static final Activity RUNTIME2_ACTIVITY1 =
-      Activity.level(Severity.DEBUG).tag("runtime2").message("myMessage");
+      Activity.newBuilder()
+          .withSeverity(Severity.DEBUG)
+          .withTag("runtime2")
+          .withMessage("myMessage")
+          .build();
   static final Activity RUNTIME2_ACTIVITY2 =
-      Activity.level(Severity.WARNING).tag("runtime2").message("myMessage2");
+      Activity.newBuilder()
+          .withSeverity(Severity.WARNING)
+          .withTag("runtime2")
+          .withMessage("myMessage2")
+          .build();
   static final Activity RUNTIME1_ACTIVITY1 =
-      Activity.level(Severity.INFO).tag("runtime1").message("myMessage");
+      Activity.newBuilder()
+          .withSeverity(Severity.INFO)
+          .withTag("runtime1")
+          .withMessage("myMessage")
+          .build();
   static final Activity RUNTIME1_ACTIVITY2 =
-      Activity.level(Severity.ERROR).tag("runtime1").message("myMessage2");
+      Activity.newBuilder()
+          .withSeverity(Severity.ERROR)
+          .withTag("runtime1")
+          .withMessage("myMessage2")
+          .build();
 
   static class AnotherExecutable implements InboundConnectorExecutable<InboundConnectorContext> {
 
@@ -184,201 +200,165 @@ abstract class BaseMultiInstancesTest {
   }
 
   Answer<Object> getInstance1Executables() {
-    return invocationOnMock ->
-        "UNKNOWN-ID".equals(invocationOnMock.getArgument(0, ActiveExecutableQuery.class).type())
-            ? Collections.emptyList()
-            : Stream.of(
-                    new ActiveExecutableResponse(
-                        ONLY_IN_RUNTIME_1_ID,
-                        TestWebhookExecutable.class,
-                        List.of(
-                            new InboundConnectorElement(
-                                Map.of("inbound.context", "myPath", "inbound.type", TYPE_1),
-                                new MessageCorrelationPoint.StandaloneMessageCorrelationPoint(
-                                    "myPath", "=expression", "=myPath", null),
-                                new ProcessElementWithRuntimeData(
-                                    "ProcessA", 1, 1, "elementIdProcessA", "tenantId"))),
-                        Health.up(),
-                        List.of(),
-                        System.currentTimeMillis()),
-                    new ActiveExecutableResponse(
-                        RANDOM_ID_1,
-                        TestWebhookExecutable.class,
-                        List.of(
-                            new InboundConnectorElement(
-                                Map.of("inbound.context", "myPath", "inbound.type", TYPE_1),
-                                new MessageCorrelationPoint.StandaloneMessageCorrelationPoint(
-                                    "myPath", "=expression", "=myPath", null),
-                                new ProcessElementWithRuntimeData(
-                                    "ProcessA", 1, 1, "elementId2ProcessA", "tenantId"))),
-                        Health.up(),
-                        List.of(),
-                        System.currentTimeMillis()),
-                    new ActiveExecutableResponse(
-                        RANDOM_ID_2,
-                        AnotherExecutable.class,
-                        List.of(
-                            new InboundConnectorElement(
-                                Map.of(
-                                    "inbound.other.prop", "myOtherValue", "inbound.type", TYPE_2),
-                                new MessageCorrelationPoint.StandaloneMessageCorrelationPoint(
-                                    "myPath", "=expression", "=myPath", null),
-                                new ProcessElementWithRuntimeData(
-                                    "ProcessB", 2, 1, "", "tenantId"))),
-                        Health.up(),
-                        Collections.emptyList(),
-                        System.currentTimeMillis()),
-                    new ActiveExecutableResponse(
-                        RANDOM_ID_3,
-                        AnotherExecutable.class,
-                        List.of(
-                            new InboundConnectorElement(
-                                Map.of(
-                                    "inbound.other.prop", "myOtherValue2", "inbound.type", TYPE_2),
-                                new MessageCorrelationPoint.StandaloneMessageCorrelationPoint(
-                                    "myPath", "=expression", "=myPath", null),
-                                new ProcessElementWithRuntimeData(
-                                    "ProcessC", 2, 1, "id1", "tenantId")),
-                            new InboundConnectorElement(
-                                Map.of(
-                                    "inbound.other.prop",
-                                    "myOtherValue2_2",
-                                    "inbound.type",
-                                    TYPE_2),
-                                new MessageCorrelationPoint.StandaloneMessageCorrelationPoint(
-                                    "myPath", "=expression2", "=myPath2", null),
-                                new ProcessElementWithRuntimeData(
-                                    "ProcessC", 2, 1, "id2", "tenantId"))),
-                        Health.unknown("Test unknown key", "Test unknown value"),
-                        List.of(RUNTIME1_ACTIVITY1, RUNTIME1_ACTIVITY2),
-                        System.currentTimeMillis()))
-                .filter(
-                    response -> {
-                      var query = invocationOnMock.getArgument(0, ActiveExecutableQuery.class);
-                      var providedType = query.type();
-                      var elementId = query.elementId();
-                      var processId = query.bpmnProcessId();
-                      return switch (providedType) {
-                        case null -> {
-                          if (elementId != null && processId != null) {
-                            yield response.elements().stream()
-                                .anyMatch(
-                                    element ->
-                                        elementId.equals(element.element().elementId())
-                                            && processId.equals(element.element().bpmnProcessId()));
-                          } else {
-                            yield true;
-                          }
-                        }
-                        case TYPE_1 ->
-                            response.executableId().equals(RANDOM_ID_1)
-                                || response.executableId().equals(ONLY_IN_RUNTIME_1_ID);
-                        case TYPE_2 ->
-                            response.executableId().equals(RANDOM_ID_2)
-                                || response.executableId().equals(RANDOM_ID_3);
-                        default -> false;
-                      };
-                    })
-                .toList();
+    return invocationOnMock -> {
+      Consumer<ActiveExecutableQuery> filter = invocationOnMock.getArgument(0);
+      var query = new ActiveExecutableQuery();
+      if (filter != null) filter.accept(query);
+      return Stream.of(
+              new ActiveExecutableResponse(
+                  ONLY_IN_RUNTIME_1_ID,
+                  TestWebhookExecutable.class,
+                  List.of(
+                      new InboundConnectorElement(
+                          Map.of("inbound.context", "myPath", "inbound.type", TYPE_1),
+                          new MessageCorrelationPoint.StandaloneMessageCorrelationPoint(
+                              "myPath", "=expression", "=myPath", null),
+                          new ProcessElementWithRuntimeData(
+                              "ProcessA", 1, 1, "elementIdProcessA", "tenantId"))),
+                  Health.up(),
+                  List.of(),
+                  System.currentTimeMillis()),
+              new ActiveExecutableResponse(
+                  RANDOM_ID_1,
+                  TestWebhookExecutable.class,
+                  List.of(
+                      new InboundConnectorElement(
+                          Map.of("inbound.context", "myPath", "inbound.type", TYPE_1),
+                          new MessageCorrelationPoint.StandaloneMessageCorrelationPoint(
+                              "myPath", "=expression", "=myPath", null),
+                          new ProcessElementWithRuntimeData(
+                              "ProcessA", 1, 1, "elementId2ProcessA", "tenantId"))),
+                  Health.up(),
+                  List.of(),
+                  System.currentTimeMillis()),
+              new ActiveExecutableResponse(
+                  RANDOM_ID_2,
+                  AnotherExecutable.class,
+                  List.of(
+                      new InboundConnectorElement(
+                          Map.of("inbound.other.prop", "myOtherValue", "inbound.type", TYPE_2),
+                          new MessageCorrelationPoint.StandaloneMessageCorrelationPoint(
+                              "myPath", "=expression", "=myPath", null),
+                          new ProcessElementWithRuntimeData("ProcessB", 2, 1, "", "tenantId"))),
+                  Health.up(),
+                  Collections.emptyList(),
+                  System.currentTimeMillis()),
+              new ActiveExecutableResponse(
+                  RANDOM_ID_3,
+                  AnotherExecutable.class,
+                  List.of(
+                      new InboundConnectorElement(
+                          Map.of("inbound.other.prop", "myOtherValue2", "inbound.type", TYPE_2),
+                          new MessageCorrelationPoint.StandaloneMessageCorrelationPoint(
+                              "myPath", "=expression", "=myPath", null),
+                          new ProcessElementWithRuntimeData("ProcessC", 2, 1, "id1", "tenantId")),
+                      new InboundConnectorElement(
+                          Map.of("inbound.other.prop", "myOtherValue2_2", "inbound.type", TYPE_2),
+                          new MessageCorrelationPoint.StandaloneMessageCorrelationPoint(
+                              "myPath", "=expression2", "=myPath2", null),
+                          new ProcessElementWithRuntimeData("ProcessC", 2, 1, "id2", "tenantId"))),
+                  Health.unknown("Test unknown key", "Test unknown value"),
+                  List.of(RUNTIME1_ACTIVITY1, RUNTIME1_ACTIVITY2),
+                  System.currentTimeMillis()))
+          .filter(response -> matchesQuery(response, query))
+          .toList();
+    };
   }
 
   Answer<Object> getInstance2Executables() {
-    return invocationOnMock ->
-        "UNKNOWN-ID".equals(invocationOnMock.getArgument(0, ActiveExecutableQuery.class).type())
-            ? Collections.emptyList()
-            : Stream.of(
-                    new ActiveExecutableResponse(
-                        ONLY_IN_RUNTIME_2_ID,
-                        TestWebhookExecutable.class,
-                        List.of(
-                            new InboundConnectorElement(
-                                Map.of("inbound.context", "myPath", "inbound.type", TYPE_1),
-                                new MessageCorrelationPoint.StandaloneMessageCorrelationPoint(
-                                    "myPath", "=expression", "=myPath", null),
-                                new ProcessElementWithRuntimeData(
-                                    "ProcessA", 1, 1, "elementIdProcessA", "tenantId"))),
-                        Health.up(),
-                        List.of(),
-                        System.currentTimeMillis()),
-                    new ActiveExecutableResponse(
-                        RANDOM_ID_1,
-                        TestWebhookExecutable.class,
-                        List.of(
-                            new InboundConnectorElement(
-                                Map.of("inbound.context", "myPath", "inbound.type", TYPE_1),
-                                new MessageCorrelationPoint.StandaloneMessageCorrelationPoint(
-                                    "myPath", "=expression", "=myPath", null),
-                                new ProcessElementWithRuntimeData(
-                                    "ProcessA", 1, 1, "elementId2ProcessA", "tenantId"))),
-                        Health.down(new IllegalArgumentException("Test error message")),
-                        List.of(),
-                        System.currentTimeMillis()),
-                    new ActiveExecutableResponse(
-                        RANDOM_ID_2,
-                        AnotherExecutable.class,
-                        List.of(
-                            new InboundConnectorElement(
-                                Map.of(
-                                    "inbound.other.prop", "myOtherValue", "inbound.type", TYPE_2),
-                                new MessageCorrelationPoint.StandaloneMessageCorrelationPoint(
-                                    "myPath", "=expression", "=myPath", null),
-                                new ProcessElementWithRuntimeData(
-                                    "ProcessB", 2, 1, "", "tenantId"))),
-                        Health.unknown("Test unknown key", "Test unknown value"),
-                        List.of(
-                            Activity.level(Severity.INFO).tag("runtime2").message("myMessage1")),
-                        System.currentTimeMillis()),
-                    new ActiveExecutableResponse(
-                        RANDOM_ID_3,
-                        AnotherExecutable.class,
-                        List.of(
-                            new InboundConnectorElement(
-                                Map.of(
-                                    "inbound.other.prop", "myOtherValue2", "inbound.type", TYPE_2),
-                                new MessageCorrelationPoint.StandaloneMessageCorrelationPoint(
-                                    "myPath", "=expression", "=myPath", null),
-                                new ProcessElementWithRuntimeData(
-                                    "ProcessC", 2, 1, "id1", "tenantId")),
-                            new InboundConnectorElement(
-                                Map.of(
-                                    "inbound.other.prop",
-                                    "myOtherValue2_2",
-                                    "inbound.type",
-                                    TYPE_2),
-                                new MessageCorrelationPoint.StandaloneMessageCorrelationPoint(
-                                    "myPath", "=expression2", "=myPath2", null),
-                                new ProcessElementWithRuntimeData(
-                                    "ProcessC", 2, 1, "id2", "tenantId"))),
-                        Health.up(),
-                        List.of(RUNTIME2_ACTIVITY1, RUNTIME2_ACTIVITY2),
-                        System.currentTimeMillis()))
-                .filter(
-                    response -> {
-                      var query = invocationOnMock.getArgument(0, ActiveExecutableQuery.class);
-                      var providedType = query.type();
-                      var elementId = query.elementId();
-                      var processId = query.bpmnProcessId();
-                      return switch (providedType) {
-                        case null -> {
-                          if (elementId != null && processId != null) {
-                            yield response.elements().stream()
-                                .anyMatch(
-                                    element ->
-                                        elementId.equals(element.element().elementId())
-                                            && processId.equals(element.element().bpmnProcessId()));
-                          } else {
-                            yield true;
-                          }
-                        }
-                        case TYPE_1 ->
-                            response.executableId().equals(RANDOM_ID_1)
-                                || response.executableId().equals(ONLY_IN_RUNTIME_2_ID);
-                        case TYPE_2 ->
-                            response.executableId().equals(RANDOM_ID_2)
-                                || response.executableId().equals(RANDOM_ID_3);
-                        default -> false;
-                      };
-                    })
-                .toList();
+    return invocationOnMock -> {
+      Consumer<ActiveExecutableQuery> filter = invocationOnMock.getArgument(0);
+      var query = new ActiveExecutableQuery();
+      if (filter != null) filter.accept(query);
+      return Stream.of(
+              new ActiveExecutableResponse(
+                  ONLY_IN_RUNTIME_2_ID,
+                  TestWebhookExecutable.class,
+                  List.of(
+                      new InboundConnectorElement(
+                          Map.of("inbound.context", "myPath", "inbound.type", TYPE_1),
+                          new MessageCorrelationPoint.StandaloneMessageCorrelationPoint(
+                              "myPath", "=expression", "=myPath", null),
+                          new ProcessElementWithRuntimeData(
+                              "ProcessA", 1, 1, "elementIdProcessA", "tenantId"))),
+                  Health.up(),
+                  List.of(),
+                  System.currentTimeMillis()),
+              new ActiveExecutableResponse(
+                  RANDOM_ID_1,
+                  TestWebhookExecutable.class,
+                  List.of(
+                      new InboundConnectorElement(
+                          Map.of("inbound.context", "myPath", "inbound.type", TYPE_1),
+                          new MessageCorrelationPoint.StandaloneMessageCorrelationPoint(
+                              "myPath", "=expression", "=myPath", null),
+                          new ProcessElementWithRuntimeData(
+                              "ProcessA", 1, 1, "elementId2ProcessA", "tenantId"))),
+                  Health.down(new IllegalArgumentException("Test error message")),
+                  List.of(),
+                  System.currentTimeMillis()),
+              new ActiveExecutableResponse(
+                  RANDOM_ID_2,
+                  AnotherExecutable.class,
+                  List.of(
+                      new InboundConnectorElement(
+                          Map.of("inbound.other.prop", "myOtherValue", "inbound.type", TYPE_2),
+                          new MessageCorrelationPoint.StandaloneMessageCorrelationPoint(
+                              "myPath", "=expression", "=myPath", null),
+                          new ProcessElementWithRuntimeData("ProcessB", 2, 1, "", "tenantId"))),
+                  Health.unknown("Test unknown key", "Test unknown value"),
+                  List.of(
+                      Activity.newBuilder()
+                          .withSeverity(Severity.INFO)
+                          .withTag("runtime2")
+                          .withMessage("myMessage1")
+                          .build()),
+                  System.currentTimeMillis()),
+              new ActiveExecutableResponse(
+                  RANDOM_ID_3,
+                  AnotherExecutable.class,
+                  List.of(
+                      new InboundConnectorElement(
+                          Map.of("inbound.other.prop", "myOtherValue2", "inbound.type", TYPE_2),
+                          new MessageCorrelationPoint.StandaloneMessageCorrelationPoint(
+                              "myPath", "=expression", "=myPath", null),
+                          new ProcessElementWithRuntimeData("ProcessC", 2, 1, "id1", "tenantId")),
+                      new InboundConnectorElement(
+                          Map.of("inbound.other.prop", "myOtherValue2_2", "inbound.type", TYPE_2),
+                          new MessageCorrelationPoint.StandaloneMessageCorrelationPoint(
+                              "myPath", "=expression2", "=myPath2", null),
+                          new ProcessElementWithRuntimeData("ProcessC", 2, 1, "id2", "tenantId"))),
+                  Health.up(),
+                  List.of(RUNTIME2_ACTIVITY1, RUNTIME2_ACTIVITY2),
+                  System.currentTimeMillis()))
+          .filter(response -> matchesQuery(response, query))
+          .toList();
+    };
+  }
+
+  private boolean matchesQuery(ActiveExecutableResponse response, ActiveExecutableQuery query) {
+    var elements = response.elements();
+    if (elements.isEmpty()) {
+      return false;
+    }
+    var firstElement = elements.getFirst();
+    if (query.type() != null && !query.type().equals(firstElement.type())) {
+      return false;
+    }
+    if (query.tenantId() != null && !query.tenantId().equals(firstElement.tenantId())) {
+      return false;
+    }
+    if (query.bpmnProcessId() != null
+        && !query.bpmnProcessId().equals(firstElement.element().bpmnProcessId())) {
+      return false;
+    }
+    if (query.executableId() != null && !query.executableId().equals(response.executableId())) {
+      return false;
+    }
+    if (query.elementId() != null) {
+      return elements.stream()
+          .anyMatch(element -> query.elementId().equals(element.element().elementId()));
+    }
+    return true;
   }
 }

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/inbound/InboundEndpointTest.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/inbound/InboundEndpointTest.java
@@ -87,7 +87,7 @@ public class InboundEndpointTest {
 
     var response = statusController.getActiveInboundConnectors(null, null, null);
     assertEquals(1, response.size());
-    assertEquals("myPath", response.getFirst().data().get("path"));
+    assertEquals("myPath", response.getFirst().data().get("inbound.context"));
   }
 
   @Test

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/inbound/InboundInstancesRestControllerMultiInstancesTest.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/inbound/InboundInstancesRestControllerMultiInstancesTest.java
@@ -142,22 +142,6 @@ class InboundInstancesRestControllerMultiInstancesTest extends BaseMultiInstance
     assertThat(404, equalTo(response.getStatusCode().value()));
   }
 
-  @Test
-  public void shouldReturn404_whenUnknownConnectorTypeAndValidExecutableId() {
-    var response =
-        restTemplate.getForEntity(
-            "http://localhost:"
-                + port1
-                + "/inbound-instances/UNKNOWN-ID/executables/"
-                + RANDOM_ID_1.getId(),
-            String.class);
-    assertThat(
-        response.getBody(),
-        containsString(
-            "Data of type 'ActiveInboundConnectorResponse' with id 'e379ef68540767f31108eb2fa581814616895690cc92bc5e955e1001743e49b9' not found"));
-    assertThat(404, equalTo(response.getStatusCode().value()));
-  }
-
   private static Stream<Arguments> provideExecutableIds() {
     return Stream.of(
         Arguments.of(RANDOM_ID_1),

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/inbound/InboundInstancesRestControllerTest.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/inbound/InboundInstancesRestControllerTest.java
@@ -20,8 +20,10 @@ import static org.hamcrest.Matchers.containsString;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -89,88 +91,75 @@ class InboundInstancesRestControllerTest {
     when(executableRegistry.getConnectorName(TYPE_2)).thenReturn("AnotherType");
     when(executableRegistry.query(any()))
         .thenAnswer(
-            invocationOnMock ->
-                "UNKNOWN-ID"
-                        .equals(invocationOnMock.getArgument(0, ActiveExecutableQuery.class).type())
-                    ? Collections.emptyList()
-                    : Stream.of(
-                            new ActiveExecutableResponse(
-                                RANDOM_ID_1,
-                                TestWebhookExecutable.class,
-                                List.of(
-                                    new InboundConnectorElement(
-                                        Map.of("inbound.context", "myPath", "inbound.type", TYPE_1),
-                                        new StandaloneMessageCorrelationPoint(
-                                            "myPath", "=expression", "=myPath", null),
-                                        new ProcessElementWithRuntimeData(
-                                            "ProcessA", 1, 1, "", ""))),
-                                Health.up(),
-                                Collections.emptyList(),
-                                System.currentTimeMillis()),
-                            new ActiveExecutableResponse(
-                                RANDOM_ID_2,
-                                AnotherExecutable.class,
-                                List.of(
-                                    new InboundConnectorElement(
-                                        Map.of(
-                                            "inbound.other.prop",
-                                            "myOtherValue",
-                                            "inbound.type",
-                                            TYPE_2),
-                                        new StandaloneMessageCorrelationPoint(
-                                            "myPath", "=expression", "=myPath", null),
-                                        new ProcessElementWithRuntimeData(
-                                            "ProcessB", 2, 1, "", ""))),
-                                Health.up(),
-                                Collections.emptyList(),
-                                System.currentTimeMillis()),
-                            new ActiveExecutableResponse(
-                                RANDOM_ID_3,
-                                AnotherExecutable.class,
-                                List.of(
-                                    new InboundConnectorElement(
-                                        Map.of(
-                                            "inbound.other.prop",
-                                            "myOtherValue2",
-                                            "inbound.type",
-                                            TYPE_2),
-                                        new StandaloneMessageCorrelationPoint(
-                                            "myPath", "=expression", "=myPath", null),
-                                        new ProcessElementWithRuntimeData(
-                                            "ProcessC", 2, 1, "id1", "")),
-                                    new InboundConnectorElement(
-                                        Map.of(
-                                            "inbound.other.prop",
-                                            "myOtherValue2_2",
-                                            "inbound.type",
-                                            TYPE_2),
-                                        new StandaloneMessageCorrelationPoint(
-                                            "myPath", "=expression2", "=myPath2", null),
-                                        new ProcessElementWithRuntimeData(
-                                            "ProcessC", 2, 1, "id2", ""))),
-                                Health.up(),
-                                List.of(
-                                    Activity.level(Severity.INFO).tag("myTag").message("myMessage"),
-                                    Activity.level(Severity.ERROR)
-                                        .tag("myTag2")
-                                        .message("myMessage2")),
-                                System.currentTimeMillis()))
-                        .filter(
-                            response -> {
-                              var providedType =
-                                  invocationOnMock
-                                      .getArgument(0, ActiveExecutableQuery.class)
-                                      .type();
-                              return switch (providedType) {
-                                case null -> true;
-                                case TYPE_1 -> response.executableId().equals(RANDOM_ID_1);
-                                case TYPE_2 ->
-                                    response.executableId().equals(RANDOM_ID_2)
-                                        || response.executableId().equals(RANDOM_ID_3);
-                                default -> false;
-                              };
-                            })
-                        .toList());
+            invocationOnMock -> {
+              java.util.function.Consumer<ActiveExecutableQuery> filter =
+                  invocationOnMock.getArgument(0);
+              var query = new ActiveExecutableQuery();
+              if (filter != null) filter.accept(query);
+              return Stream.of(
+                      new ActiveExecutableResponse(
+                          RANDOM_ID_1,
+                          TestWebhookExecutable.class,
+                          List.of(
+                              new InboundConnectorElement(
+                                  Map.of("inbound.context", "myPath", "inbound.type", TYPE_1),
+                                  new StandaloneMessageCorrelationPoint(
+                                      "myPath", "=expression", "=myPath", null),
+                                  new ProcessElementWithRuntimeData("ProcessA", 1, 1, "", ""))),
+                          Health.up(),
+                          Collections.emptyList(),
+                          System.currentTimeMillis()),
+                      new ActiveExecutableResponse(
+                          RANDOM_ID_2,
+                          AnotherExecutable.class,
+                          List.of(
+                              new InboundConnectorElement(
+                                  Map.of(
+                                      "inbound.other.prop", "myOtherValue", "inbound.type", TYPE_2),
+                                  new StandaloneMessageCorrelationPoint(
+                                      "myPath", "=expression", "=myPath", null),
+                                  new ProcessElementWithRuntimeData("ProcessB", 2, 1, "", ""))),
+                          Health.up(),
+                          Collections.emptyList(),
+                          System.currentTimeMillis()),
+                      new ActiveExecutableResponse(
+                          RANDOM_ID_3,
+                          AnotherExecutable.class,
+                          List.of(
+                              new InboundConnectorElement(
+                                  Map.of(
+                                      "inbound.other.prop",
+                                      "myOtherValue2",
+                                      "inbound.type",
+                                      TYPE_2),
+                                  new StandaloneMessageCorrelationPoint(
+                                      "myPath", "=expression", "=myPath", null),
+                                  new ProcessElementWithRuntimeData("ProcessC", 2, 1, "id1", "")),
+                              new InboundConnectorElement(
+                                  Map.of(
+                                      "inbound.other.prop",
+                                      "myOtherValue2_2",
+                                      "inbound.type",
+                                      TYPE_2),
+                                  new StandaloneMessageCorrelationPoint(
+                                      "myPath", "=expression2", "=myPath2", null),
+                                  new ProcessElementWithRuntimeData("ProcessC", 2, 1, "id2", ""))),
+                          Health.up(),
+                          List.of(
+                              Activity.newBuilder()
+                                  .withSeverity(Severity.INFO)
+                                  .withTag("myTag")
+                                  .withMessage("myMessage")
+                                  .build(),
+                              Activity.newBuilder()
+                                  .withSeverity(Severity.ERROR)
+                                  .withTag("myTag2")
+                                  .withMessage("myMessage2")
+                                  .build()),
+                          System.currentTimeMillis()))
+                  .filter(response -> matchesQuery(response, query))
+                  .toList();
+            });
   }
 
   @Test
@@ -247,18 +236,6 @@ class InboundInstancesRestControllerTest {
   }
 
   @Test
-  public void shouldReturn404_whenUnknownConnectorTypeAndValidExecutableId() throws Exception {
-    mockMvc
-        .perform(get("/inbound-instances/UNKNOWN-ID/executables/" + RANDOM_ID_1.getId()))
-        .andExpect(status().isNotFound())
-        .andExpect(
-            content()
-                .string(
-                    containsString(
-                        "Data of type 'ConnectorInstances' with id 'UNKNOWN-ID' not found")));
-  }
-
-  @Test
   public void shouldReturnSingleExecutable() throws Exception {
     var response =
         mockMvc
@@ -321,5 +298,78 @@ class InboundInstancesRestControllerTest {
     var log2 = logs.stream().filter(a -> a.severity() == Severity.ERROR).findFirst().get();
     assertEquals("myTag2", log2.tag());
     assertEquals("myMessage2", log2.message());
+  }
+
+  @Test
+  public void shouldResetConnectorInstanceExecutable() throws Exception {
+    // reset() on the registry does nothing (happy path) — the subsequent findExecutable()
+    // re-uses the existing query mock and returns the same response
+    var response =
+        mockMvc
+            .perform(
+                post(
+                    "/inbound-instances/"
+                        + TYPE_1
+                        + "/executables/"
+                        + RANDOM_ID_1.getId()
+                        + "/reset"))
+            .andExpect(status().isOk())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+
+    ActiveInboundConnectorResponse executable =
+        ConnectorsObjectMapperSupplier.getCopy()
+            .readValue(response, ActiveInboundConnectorResponse.class);
+    assertEquals(RANDOM_ID_1, executable.executableId());
+    assertEquals("ProcessA", executable.elements().getFirst().bpmnProcessId());
+  }
+
+  @Test
+  public void shouldReturn404_whenResettingUnknownExecutableId() throws Exception {
+    mockMvc
+        .perform(post("/inbound-instances/" + TYPE_1 + "/executables/UNKNOWN-ID/reset"))
+        .andExpect(status().isNotFound())
+        .andExpect(
+            content()
+                .string(
+                    containsString(
+                        "Data of type 'ActiveInboundConnectorResponse' with id 'UNKNOWN-ID' not found")));
+  }
+
+  @Test
+  public void shouldReturn500_whenResetFails() throws Exception {
+    doThrow(new RuntimeException("Reset failed")).when(executableRegistry).reset(RANDOM_ID_1);
+
+    mockMvc
+        .perform(
+            post("/inbound-instances/" + TYPE_1 + "/executables/" + RANDOM_ID_1.getId() + "/reset"))
+        .andExpect(status().isInternalServerError());
+  }
+
+  private boolean matchesQuery(ActiveExecutableResponse response, ActiveExecutableQuery query) {
+    var elements = response.elements();
+    if (elements.isEmpty()) {
+      return false;
+    }
+    var firstElement = elements.getFirst();
+    if (query.type() != null && !query.type().equals(firstElement.type())) {
+      return false;
+    }
+    if (query.tenantId() != null && !query.tenantId().equals(firstElement.tenantId())) {
+      return false;
+    }
+    if (query.bpmnProcessId() != null
+        && !query.bpmnProcessId().equals(firstElement.element().bpmnProcessId())) {
+      return false;
+    }
+    if (query.executableId() != null && !query.executableId().equals(response.executableId())) {
+      return false;
+    }
+    if (query.elementId() != null) {
+      return elements.stream()
+          .anyMatch(element -> query.elementId().equals(element.element().elementId()));
+    }
+    return true;
   }
 }

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/inbound/InboundInstancesRestControllerTest.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/inbound/InboundInstancesRestControllerTest.java
@@ -306,13 +306,7 @@ class InboundInstancesRestControllerTest {
     // re-uses the existing query mock and returns the same response
     var response =
         mockMvc
-            .perform(
-                post(
-                    "/inbound-instances/"
-                        + TYPE_1
-                        + "/executables/"
-                        + RANDOM_ID_1.getId()
-                        + "/reset"))
+            .perform(post("/inbound-instances/executables/" + RANDOM_ID_1.getId() + "/reset"))
             .andExpect(status().isOk())
             .andReturn()
             .getResponse()
@@ -328,7 +322,7 @@ class InboundInstancesRestControllerTest {
   @Test
   public void shouldReturn404_whenResettingUnknownExecutableId() throws Exception {
     mockMvc
-        .perform(post("/inbound-instances/" + TYPE_1 + "/executables/UNKNOWN-ID/reset"))
+        .perform(post("/inbound-instances/executables/UNKNOWN-ID/reset"))
         .andExpect(status().isNotFound())
         .andExpect(
             content()
@@ -342,9 +336,52 @@ class InboundInstancesRestControllerTest {
     doThrow(new RuntimeException("Reset failed")).when(executableRegistry).reset(RANDOM_ID_1);
 
     mockMvc
-        .perform(
-            post("/inbound-instances/" + TYPE_1 + "/executables/" + RANDOM_ID_1.getId() + "/reset"))
+        .perform(post("/inbound-instances/executables/" + RANDOM_ID_1.getId() + "/reset"))
         .andExpect(status().isInternalServerError());
+  }
+
+  @Test
+  public void shouldReturnSingleExecutable_withoutType() throws Exception {
+    var response =
+        mockMvc
+            .perform(get("/inbound-instances/executables/" + RANDOM_ID_1.getId()))
+            .andExpect(status().isOk())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+
+    ActiveInboundConnectorResponse executable =
+        ConnectorsObjectMapperSupplier.getCopy()
+            .readValue(response, ActiveInboundConnectorResponse.class);
+    assertEquals(RANDOM_ID_1, executable.executableId());
+    assertEquals("ProcessA", executable.elements().getFirst().bpmnProcessId());
+  }
+
+  @Test
+  public void shouldReturnActivityLogs_withoutType() throws Exception {
+    var response =
+        mockMvc
+            .perform(get("/inbound-instances/executables/" + RANDOM_ID_3.getId() + "/logs"))
+            .andExpect(status().isOk())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+
+    List<Activity> logs =
+        ConnectorsObjectMapperSupplier.getCopy().readValue(response, new TypeReference<>() {});
+    assertEquals(2, logs.size());
+  }
+
+  @Test
+  public void shouldReturn404_whenUnknownExecutableId_withoutType() throws Exception {
+    mockMvc
+        .perform(get("/inbound-instances/executables/UNKNOWN-ID"))
+        .andExpect(status().isNotFound())
+        .andExpect(
+            content()
+                .string(
+                    containsString(
+                        "Data of type 'ActiveInboundConnectorResponse' with id 'UNKNOWN-ID' not found")));
   }
 
   private boolean matchesQuery(ActiveExecutableResponse response, ActiveExecutableQuery query) {

--- a/connectors-e2e-test/connectors-e2e-test-base/src/main/java/io/camunda/connector/e2e/inbound/InboundConnectorTestConfiguration.java
+++ b/connectors-e2e-test/connectors-e2e-test-base/src/main/java/io/camunda/connector/e2e/inbound/InboundConnectorTestConfiguration.java
@@ -19,7 +19,6 @@ package io.camunda.connector.e2e.inbound;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
-import io.camunda.connector.runtime.inbound.executable.ActiveExecutableQuery;
 import io.camunda.connector.runtime.inbound.executable.InboundExecutableRegistry;
 import io.camunda.connector.runtime.inbound.state.ProcessDefinitionInspector;
 import java.time.Duration;
@@ -77,8 +76,7 @@ public class InboundConnectorTestConfiguration {
           .atMost(waitDuration)
           .untilAsserted(
               () -> {
-                var allExecutables =
-                    executableRegistry.query(new ActiveExecutableQuery(null, null, null, null));
+                var allExecutables = executableRegistry.query(f -> {});
                 assertThat(allExecutables).isEmpty();
               });
     }

--- a/connectors-e2e-test/connectors-e2e-test-inbound-runtime/src/test/java/io/camunda/connector/e2e/inbound/ActivationConditionMultiVersionTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-inbound-runtime/src/test/java/io/camunda/connector/e2e/inbound/ActivationConditionMultiVersionTests.java
@@ -26,7 +26,6 @@ import io.camunda.connector.e2e.BpmnFile;
 import io.camunda.connector.e2e.ElementTemplate;
 import io.camunda.connector.e2e.inbound.InboundConnectorTestConfiguration.InboundConnectorTestHelper;
 import io.camunda.connector.runtime.core.inbound.correlation.InboundCorrelationHandler;
-import io.camunda.connector.runtime.inbound.executable.ActiveExecutableQuery;
 import io.camunda.connector.runtime.inbound.executable.ActiveExecutableResponse;
 import io.camunda.connector.runtime.inbound.executable.InboundExecutableRegistry;
 import io.camunda.connector.test.utils.annotation.SlowTest;
@@ -139,7 +138,7 @@ public class ActivationConditionMultiVersionTests {
   }
 
   private List<ActiveExecutableResponse> queryExecutables(String processId) {
-    return executableRegistry.query(new ActiveExecutableQuery(processId, null, null, null));
+    return executableRegistry.query(f -> f.bpmnProcessId(processId));
   }
 
   private void awaitHealthyExecutable(String processId) {

--- a/connectors-e2e-test/connectors-e2e-test-inbound-runtime/src/test/java/io/camunda/connector/e2e/inbound/InboundConnectorMultiVersionTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-inbound-runtime/src/test/java/io/camunda/connector/e2e/inbound/InboundConnectorMultiVersionTests.java
@@ -24,7 +24,6 @@ import io.camunda.connector.api.inbound.Health;
 import io.camunda.connector.e2e.BpmnFile;
 import io.camunda.connector.e2e.ElementTemplate;
 import io.camunda.connector.e2e.inbound.InboundConnectorTestConfiguration.InboundConnectorTestHelper;
-import io.camunda.connector.runtime.inbound.executable.ActiveExecutableQuery;
 import io.camunda.connector.runtime.inbound.executable.ActiveExecutableResponse;
 import io.camunda.connector.runtime.inbound.executable.InboundExecutableRegistry;
 import io.camunda.connector.test.utils.annotation.SlowTest;
@@ -287,7 +286,7 @@ public class InboundConnectorMultiVersionTests {
 
   /** Queries executables for the given process. */
   private List<ActiveExecutableResponse> queryExecutables(String processId) {
-    return executableRegistry.query(new ActiveExecutableQuery(processId, null, null, null));
+    return executableRegistry.query(f -> f.bpmnProcessId(processId));
   }
 
   /** Waits for executables to reach the expected count for the given process. */


### PR DESCRIPTION
## Description

This pull request introduces several improvements and refactorings to the inbound connector runtime, focusing on making the querying and management of connector executables more flexible and robust. The changes include replacing the immutable `ActiveExecutableQuery` record with a mutable, builder-style class, updating the query API to use this new approach, and adding the ability to reset (deactivate and reactivate) connector executables via the REST API. Additionally, the handling of connector responses and activity logs has been streamlined and improved.

**Key changes:**

### Query API and Filtering Improvements

- Replaced the immutable `ActiveExecutableQuery` record with a mutable class that uses builder-style setters, allowing for more flexible and readable query construction. The query API now accepts a function to configure the query object, enabling more expressive and composable queries. (`ActiveExecutableQuery.java`, `InboundConnectorRestController.java`, `InboundExecutableQueryService.java`) [[1]](diffhunk://#diff-f6ba30f8fd3a5ea131db4c6c7ac326cf57b03eca794aac3d6cc34f05d9ac61cfL19-R95) [[2]](diffhunk://#diff-308fdcb86c7df9aad10cf1811708f7d79e7bbe8ff4283dba8381bda89f506fdeL86-R86) [[3]](diffhunk://#diff-308fdcb86c7df9aad10cf1811708f7d79e7bbe8ff4283dba8381bda89f506fdeL109-R112) [[4]](diffhunk://#diff-b3641951876bc7d433c5dc818f1aaf647c1359f65bcc475b40c90b0c2d2ffcf9R97-L101)

- Added support for filtering by `executableId` in queries, improving the precision of executable lookups. (`ActiveExecutableQuery.java`, `InboundExecutableQueryService.java`) [[1]](diffhunk://#diff-f6ba30f8fd3a5ea131db4c6c7ac326cf57b03eca794aac3d6cc34f05d9ac61cfL19-R95) [[2]](diffhunk://#diff-b3641951876bc7d433c5dc818f1aaf647c1359f65bcc475b40c90b0c2d2ffcf9R97-L101)

### Executable Lifecycle Management

- Added a new REST endpoint to reset (deactivate and reactivate) connector instance executables, enabling runtime recovery and reconfiguration without manual intervention. (`InboundInstancesRestController.java`)

- Refactored the executable activation and deactivation logic: extracted activation into a `doActivate` method, split out single/batch deactivation, and introduced a robust reset mechanism (`restartFromContext`) with retry support. (`BatchExecutableProcessor.java`) [[1]](diffhunk://#diff-9ae8b175edaeeee07a58efb8d7375f21b95e071b6a4d142ad26b27b410d21202R179-R181) [[2]](diffhunk://#diff-9ae8b175edaeeee07a58efb8d7375f21b95e071b6a4d142ad26b27b410d21202L203-R231) [[3]](diffhunk://#diff-9ae8b175edaeeee07a58efb8d7375f21b95e071b6a4d142ad26b27b410d21202R247-R305) [[4]](diffhunk://#diff-9ae8b175edaeeee07a58efb8d7375f21b95e071b6a4d142ad26b27b410d21202L257-R318) [[5]](diffhunk://#diff-9ae8b175edaeeee07a58efb8d7375f21b95e071b6a4d142ad26b27b410d21202L272-R335)

### Response and Data Handling

- Updated the `ActiveInboundConnectorResponse` to include a `logs` field (collection of `Activity`), ensuring activity logs are available in API responses. (`ActiveInboundConnectorResponse.java`, `ConnectorDataMapper.java`) [[1]](diffhunk://#diff-42af31265ebeb96e31c59ce6f67cb2affe6995777a1da9a2fe7d9dc1462d38c3R19-R23) [[2]](diffhunk://#diff-42af31265ebeb96e31c59ce6f67cb2affe6995777a1da9a2fe7d9dc1462d38c3L32-R35) [[3]](diffhunk://#diff-c747f67e6d4be564bf08794ed362e9eed81c7af1ac3ecbe6426c8dbca8361b4dL19-R43)

- Simplified the `ConnectorDataMapper` by removing the specialized webhook data mapping logic and always returning all connector-level properties. (`ConnectorDataMapper.java`)

### Minor and Supporting Changes

- Made `ExecutableId.fromHashedId` public to support its use in the new query API. (`ExecutableId.java`)

- Updated controller methods to remove unnecessary parameters and align with the new query and service method signatures. (`InboundInstancesRestController.java`) [[1]](diffhunk://#diff-714ab41e3f6a9ca0161d8c939d3b0064ebd88d06c544e04c50ed9b355867f469L93-R93) [[2]](diffhunk://#diff-714ab41e3f6a9ca0161d8c939d3b0064ebd88d06c544e04c50ed9b355867f469L109-R109) [[3]](diffhunk://#diff-714ab41e3f6a9ca0161d8c939d3b0064ebd88d06c544e04c50ed9b355867f469L122-R140)

These changes collectively improve the maintainability, flexibility, and robustness of the inbound connector management subsystem.

## Related issues

<!-- Which issues are closed by this PR or are related -->
closes https://github.com/camunda/connectors/issues/6737

## Checklist

- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest
  release, as this branch will be rebased onto main before the next release. Example backport labels:
    - `backport stable/8.8`: for changes that should be included in the next 8.8.x release.
    - **or** `backport release-8.8.7`: for changes that should be included in the specific release 8.8.7, and this
      *release has already been created*. The release branch will be merged back into stable/8.8 later, so the change
      will be included in future 8.8.x releases as well.
- [ ] Tests/Integration tests for the changes have been added if applicable.

