### PR TITLE
test: add test case for polling connector with cluster vars

### DIFF
--- a/connectors-e2e-test/connectors-e2e-test-http/src/test/java/io/camunda/connector/e2e/PollingConnectorTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-http/src/test/java/io/camunda/connector/e2e/PollingConnectorTests.java
@@ -26,6 +26,7 @@ import static org.mockito.Mockito.when;
 
 import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
 import io.camunda.client.CamundaClient;
+import io.camunda.client.api.command.ProblemException;
 import io.camunda.client.api.search.response.ProcessDefinition;
 import io.camunda.connector.e2e.app.TestConnectorRuntimeApplication;
 import io.camunda.connector.test.utils.annotation.SlowTest;
@@ -156,20 +157,16 @@ public class PollingConnectorTests {
     Awaitility.await("cluster variable " + variableName + " should be available")
         .atMost(CLUSTER_VAR_TIMEOUT)
         .pollInterval(Duration.ofMillis(500))
-        .ignoreExceptions()
+        .ignoreExceptionsMatching(
+            e -> e instanceof ProblemException && e.getMessage().contains("404"))
         .until(
-            () -> {
-              try {
-                var result =
-                    camundaClient
+            () ->
+                camundaClient
                         .newEvaluateExpressionCommand()
                         .expression("=camunda.vars.env." + variableName)
                         .send()
-                        .join();
-                return result.getResult() != null;
-              } catch (Exception e) {
-                return false;
-              }
-            });
+                        .join()
+                        .getResult()
+                    != null);
   }
 }

--- a/connectors-e2e-test/connectors-e2e-test-http/src/test/java/io/camunda/connector/e2e/PollingConnectorTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-http/src/test/java/io/camunda/connector/e2e/PollingConnectorTests.java
@@ -31,7 +31,10 @@ import io.camunda.connector.e2e.app.TestConnectorRuntimeApplication;
 import io.camunda.connector.test.utils.annotation.SlowTest;
 import io.camunda.process.test.api.CamundaSpringProcessTest;
 import io.camunda.zeebe.model.bpmn.instance.Process;
+import java.time.Duration;
 import java.util.Map;
+import java.util.UUID;
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -53,6 +56,8 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 @SlowTest
 @ExtendWith(MockitoExtension.class)
 public class PollingConnectorTests {
+
+  private static final Duration CLUSTER_VAR_TIMEOUT = Duration.ofSeconds(30);
 
   @RegisterExtension
   static WireMockExtension wm =
@@ -100,5 +105,71 @@ public class PollingConnectorTests {
 
     bpmnTest.waitForProcessCompletion();
     assertThat(bpmnTest.getProcessInstanceEvent()).hasVariable("isOrderSuccessful", "true");
+  }
+
+  @Test
+  void shouldResolveClusterVariableInUrlAndTerminate() {
+    wm.stubFor(
+        get(urlEqualTo("/mock"))
+            .willReturn(
+                aResponse()
+                    .withHeader("Content-Type", "application/json")
+                    .withBody("{\"orderId\": \"1234\", \"successfulOrder\": \"true\"}")
+                    .withStatus(200)));
+
+    var variableName =
+        "pollingUrlVar_" + UUID.randomUUID().toString().replace("-", "").substring(0, 8);
+    var variableValue = "mock";
+    camundaClient
+        .newGloballyScopedClusterVariableCreateRequest()
+        .create(variableName, variableValue)
+        .send()
+        .join();
+    awaitClusterVariableAvailable(variableName);
+
+    var mockUrl =
+        "=&#34;http://localhost:" + wm.getPort() + "/&#34; + camunda.vars.env." + variableName;
+
+    var model =
+        replace(
+            "polling_connector.bpmn",
+            replace("URL_SET", mockUrl),
+            replace("CORRELATION_KEY_EXPRESSION", "=body.orderId"),
+            replace("CORRELATION_KEY_PROCESS", "=orderId"),
+            replace(
+                "RESULT_EXPRESSION", "={ &#34;isOrderSuccessful&#34; : body.successfulOrder  }"));
+
+    when(processDef.getProcessDefinitionKey()).thenReturn(2L);
+    when(processDef.getTenantId())
+        .thenReturn(camundaClient.getConfiguration().getDefaultTenantId());
+    when(processDef.getProcessDefinitionId())
+        .thenReturn(model.getModelElementsByType(Process.class).stream().findFirst().get().getId());
+
+    var bpmnTest =
+        ZeebeTest.with(camundaClient).deploy(model).createInstance(Map.of("orderId", "1234"));
+
+    bpmnTest.waitForProcessCompletion();
+    assertThat(bpmnTest.getProcessInstanceEvent()).hasVariable("isOrderSuccessful", "true");
+  }
+
+  private void awaitClusterVariableAvailable(String variableName) {
+    Awaitility.await("cluster variable " + variableName + " should be available")
+        .atMost(CLUSTER_VAR_TIMEOUT)
+        .pollInterval(Duration.ofMillis(500))
+        .ignoreExceptions()
+        .until(
+            () -> {
+              try {
+                var result =
+                    camundaClient
+                        .newEvaluateExpressionCommand()
+                        .expression("=camunda.vars.env." + variableName)
+                        .send()
+                        .join();
+                return result.getResult() != null;
+              } catch (Exception e) {
+                return false;
+              }
+            });
   }
 }


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
I forgot to add a test case for the polling connector in #6667 where it would use a cluster variable.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #

## Checklist

- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest
  release, as this branch will be rebased onto main before the next release. Example backport labels:
    - `backport stable/8.8`: for changes that should be included in the next 8.8.x release.
    - **or** `backport release-8.8.7`: for changes that should be included in the specific release 8.8.7, and this
      *release has already been created*. The release branch will be merged back into stable/8.8 later, so the change
      will be included in future 8.8.x releases as well.
- [ ] Tests/Integration tests for the changes have been added if applicable.

