### PR TITLE
fix: add activity log back to the executable registry query response + tests for inbound connector lifecycle

### DIFF
--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/activitylog/ActivityLogRegistry.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/activitylog/ActivityLogRegistry.java
@@ -19,9 +19,7 @@ package io.camunda.connector.runtime.core.inbound.activitylog;
 import com.google.common.collect.EvictingQueue;
 import io.camunda.connector.api.inbound.Activity;
 import io.camunda.connector.runtime.core.inbound.ExecutableId;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Queue;
+import java.util.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
@@ -43,7 +41,9 @@ public class ActivityLogRegistry implements ActivityLogWriter {
   }
 
   public Queue<Activity> getLogs(ExecutableId executableId) {
-    return activityLogs.get(executableId);
+    return Optional.ofNullable(activityLogs.get(executableId))
+        .orElseGet(
+            () -> EvictingQueue.create(0)); // Return empty queue if no logs for the executable
   }
 
   @Override

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/activitylog/ActivityLogRegistry.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/activitylog/ActivityLogRegistry.java
@@ -40,10 +40,12 @@ public class ActivityLogRegistry implements ActivityLogWriter {
     this(100); // Default size, can be overridden
   }
 
-  public Queue<Activity> getLogs(ExecutableId executableId) {
-    return Optional.ofNullable(activityLogs.get(executableId))
-        .orElseGet(
-            () -> EvictingQueue.create(0)); // Return empty queue if no logs for the executable
+  public Collection<Activity> getLogs(ExecutableId executableId) {
+    synchronized (activityLogs) {
+      return Optional.ofNullable(activityLogs.get(executableId))
+          .<Collection<Activity>>map(queue -> Collections.unmodifiableList(new ArrayList<>(queue)))
+          .orElse(Collections.emptyList());
+    }
   }
 
   @Override
@@ -57,8 +59,10 @@ public class ActivityLogRegistry implements ActivityLogWriter {
       case ERROR, WARNING -> LOG.warn(message); // errors would be too noisy
     }
     MDC.clear();
-    activityLogs
-        .computeIfAbsent(logEntry.executableId(), key -> EvictingQueue.create(maxLogSize))
-        .add(logEntry.activity());
+    synchronized (activityLogs) {
+      activityLogs
+          .computeIfAbsent(logEntry.executableId(), key -> EvictingQueue.create(maxLogSize))
+          .add(logEntry.activity());
+    }
   }
 }

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/InboundConnectorRuntimeConfiguration.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/InboundConnectorRuntimeConfiguration.java
@@ -144,8 +144,10 @@ public class InboundConnectorRuntimeConfiguration {
   @ConditionalOnMissingBean
   public InboundExecutableRegistry inboundExecutableRegistry(
       InboundConnectorFactory inboundConnectorFactory,
-      BatchExecutableProcessor batchExecutableProcessor) {
-    return new InboundExecutableRegistryImpl(inboundConnectorFactory, batchExecutableProcessor);
+      BatchExecutableProcessor batchExecutableProcessor,
+      ActivityLogRegistry activityLogRegistry) {
+    return new InboundExecutableRegistryImpl(
+        inboundConnectorFactory, batchExecutableProcessor, activityLogRegistry);
   }
 
   @Bean

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/executable/InboundExecutableQueryService.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/executable/InboundExecutableQueryService.java
@@ -19,13 +19,13 @@ package io.camunda.connector.runtime.inbound.executable;
 import io.camunda.connector.api.inbound.Health;
 import io.camunda.connector.api.inbound.Health.Status;
 import io.camunda.connector.runtime.core.inbound.InboundConnectorFactory;
+import io.camunda.connector.runtime.core.inbound.activitylog.ActivityLogRegistry;
 import io.camunda.connector.runtime.inbound.executable.RegisteredExecutable.Activated;
 import io.camunda.connector.runtime.inbound.executable.RegisteredExecutable.Cancelled;
 import io.camunda.connector.runtime.inbound.executable.RegisteredExecutable.ConnectorNotRegistered;
 import io.camunda.connector.runtime.inbound.executable.RegisteredExecutable.FailedToActivate;
 import io.camunda.connector.runtime.inbound.executable.RegisteredExecutable.InvalidDefinition;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -34,11 +34,15 @@ public class InboundExecutableQueryService {
 
   private final InboundExecutableStateStore stateStore;
   private final InboundConnectorFactory connectorFactory;
+  private final ActivityLogRegistry activityLogRegistry;
 
   public InboundExecutableQueryService(
-      InboundExecutableStateStore stateStore, InboundConnectorFactory connectorFactory) {
+      InboundExecutableStateStore stateStore,
+      InboundConnectorFactory connectorFactory,
+      ActivityLogRegistry activityLogRegistry) {
     this.stateStore = stateStore;
     this.connectorFactory = connectorFactory;
+    this.activityLogRegistry = activityLogRegistry;
   }
 
   /**
@@ -117,7 +121,7 @@ public class InboundExecutableQueryService {
         activated.executable().getClass(),
         context.connectorElements(),
         context.getHealth(),
-        Collections.emptyList(),
+        activityLogRegistry.getLogs(activated.id()),
         context.getActivationTimestamp());
   }
 
@@ -129,7 +133,7 @@ public class InboundExecutableQueryService {
         cancelled.executable().getClass(),
         context.connectorElements(),
         Health.down(cancelled.exceptionThrown()),
-        Collections.emptyList(),
+        activityLogRegistry.getLogs(cancelled.id()),
         context.getActivationTimestamp());
   }
 
@@ -141,7 +145,7 @@ public class InboundExecutableQueryService {
         null,
         data.connectorElements(),
         Health.down(new RuntimeException("Connector " + data.type() + " not registered")),
-        Collections.emptyList(),
+        activityLogRegistry.getLogs(notRegistered.id()),
         null);
   }
 
@@ -153,7 +157,7 @@ public class InboundExecutableQueryService {
         null,
         data.connectorElements(),
         Health.down(new RuntimeException(failed.reason())),
-        Collections.emptyList(),
+        activityLogRegistry.getLogs(failed.id()),
         null);
   }
 
@@ -165,7 +169,7 @@ public class InboundExecutableQueryService {
         null,
         data.connectorElements(),
         Health.down(new RuntimeException("Invalid connector definition: " + invalid.reason())),
-        Collections.emptyList(),
+        activityLogRegistry.getLogs(invalid.id()),
         null);
   }
 

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/executable/InboundExecutableRegistryImpl.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/executable/InboundExecutableRegistryImpl.java
@@ -22,6 +22,7 @@ import io.camunda.connector.runtime.core.inbound.ExecutableId;
 import io.camunda.connector.runtime.core.inbound.InboundConnectorElement;
 import io.camunda.connector.runtime.core.inbound.InboundConnectorFactory;
 import io.camunda.connector.runtime.core.inbound.InboundConnectorManagementContext;
+import io.camunda.connector.runtime.core.inbound.activitylog.ActivityLogRegistry;
 import io.camunda.connector.runtime.core.inbound.details.InboundConnectorDetails;
 import io.camunda.connector.runtime.inbound.executable.InboundExecutableStateTransitionService.ActionType;
 import io.camunda.connector.runtime.inbound.executable.InboundExecutableStateTransitionService.StateTransitionPlan;
@@ -53,7 +54,9 @@ public class InboundExecutableRegistryImpl implements InboundExecutableRegistry 
   private final BlockingQueue<InboundExecutableEvent> eventQueue = new LinkedBlockingQueue<>();
 
   public InboundExecutableRegistryImpl(
-      InboundConnectorFactory connectorFactory, BatchExecutableProcessor batchExecutableProcessor) {
+      InboundConnectorFactory connectorFactory,
+      BatchExecutableProcessor batchExecutableProcessor,
+      ActivityLogRegistry activityLogRegistry) {
 
     this.stateStore = new InMemoryInboundExecutableStateStore();
     var deduplicationScopesByType =
@@ -65,7 +68,8 @@ public class InboundExecutableRegistryImpl implements InboundExecutableRegistry 
                     (a, b) -> a));
     this.stateTransitionService =
         new InboundExecutableStateTransitionService(deduplicationScopesByType, stateStore);
-    this.queryService = new InboundExecutableQueryService(stateStore, connectorFactory);
+    this.queryService =
+        new InboundExecutableQueryService(stateStore, connectorFactory, activityLogRegistry);
     this.batchExecutableProcessor = batchExecutableProcessor;
   }
 

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/inbound/executable/InboundExecutableRegistryTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/inbound/executable/InboundExecutableRegistryTest.java
@@ -52,6 +52,7 @@ public class InboundExecutableRegistryTest {
   private InboundConnectorFactory factory;
   private InboundConnectorContextFactory contextFactory;
   private BatchExecutableProcessor batchProcessor;
+  private ActivityLogRegistry activityLogRegistry = new ActivityLogRegistry();
   private InboundExecutableRegistryImpl registry;
 
   @BeforeEach
@@ -62,8 +63,8 @@ public class InboundExecutableRegistryTest {
     var inboundMetrics = mock(ConnectorsInboundMetrics.class);
     batchProcessor =
         new BatchExecutableProcessor(
-            factory, contextFactory, inboundMetrics, null, new ActivityLogRegistry());
-    registry = new InboundExecutableRegistryImpl(factory, batchProcessor);
+            factory, contextFactory, inboundMetrics, null, activityLogRegistry);
+    registry = new InboundExecutableRegistryImpl(factory, batchProcessor, activityLogRegistry);
   }
 
   @Test
@@ -522,5 +523,161 @@ public class InboundExecutableRegistryTest {
     // then
     verify(executable).deactivate();
     verify(executable, timeout(5000).times(3)).activate(any());
+  }
+
+  // -------------------------------------------------------------------------
+  // Activity log tests
+  // -------------------------------------------------------------------------
+
+  @Test
+  public void activityLog_successfulActivation_shouldContainLifecycleEntry() throws Exception {
+    // given
+    var elementId = "elementId";
+    var element =
+        new InboundConnectorElement(
+            Map.of(Keywords.INBOUND_TYPE_KEYWORD, "type1"),
+            new StartEventCorrelationPoint("processId", 0, 0),
+            new ProcessElementWithRuntimeData("id", 0, 0, elementId, "tenant"));
+    var executable = mock(InboundConnectorExecutable.class);
+    var context = mock(InboundConnectorManagementContext.class);
+    // Required so matchesQuery can match on elementId/bpmnProcessId/type/tenantId
+    when(context.connectorElements()).thenReturn(List.of(element));
+    when(contextFactory.createContext(any(), any(), any(), any())).thenReturn(context);
+    when(factory.getInstance(any())).thenReturn(executable);
+
+    // when
+    registry.handleEvent(new ProcessStateChanged("id", "tenant", Map.of(0L, List.of(element))));
+
+    // then
+    var result = registry.query(new ActiveExecutableQuery("id", elementId, "type1", "tenant"));
+    assertThat(result.getFirst().logs())
+        .hasSize(1)
+        .first()
+        .satisfies(
+            log -> {
+              assertThat(log.severity()).isEqualTo(Severity.INFO);
+              assertThat(log.tag()).isEqualTo(ActivityLogTag.LIFECYCLE);
+              assertThat(log.message()).contains("Activated inbound connector");
+              assertThat(log.message()).contains("type1");
+            });
+  }
+
+  @Test
+  public void activityLog_activationFailure_shouldNotContainAnyEntries() throws Exception {
+    // given
+    var elementId = "elementId";
+    var element =
+        new InboundConnectorElement(
+            Map.of(Keywords.INBOUND_TYPE_KEYWORD, "type1"),
+            new StartEventCorrelationPoint("processId", 0, 0),
+            new ProcessElementWithRuntimeData("id", 0, 0, elementId, "tenant"));
+    var executable = mock(InboundConnectorExecutable.class);
+    var context = mock(InboundConnectorManagementContext.class);
+    when(contextFactory.createContext(any(), any(), any(), any())).thenReturn(context);
+    when(factory.getInstance(any())).thenReturn(executable);
+    doThrow(new RuntimeException("activation failed")).when(executable).activate(any());
+
+    // when
+    registry.handleEvent(new ProcessStateChanged("id", "tenant", Map.of(0L, List.of(element))));
+
+    // then
+    var result = registry.query(new ActiveExecutableQuery(null, elementId, null, null));
+    assertThat(result.getFirst().logs()).isEmpty();
+  }
+
+  @Test
+  public void activityLog_deactivation_shouldContainBothActivationAndDeactivationEntries()
+      throws Exception {
+    // given
+    var elementId = "elementId";
+    var element =
+        new InboundConnectorElement(
+            Map.of(Keywords.INBOUND_TYPE_KEYWORD, "type1"),
+            new StartEventCorrelationPoint("processId", 0, 0),
+            new ProcessElementWithRuntimeData("id", 0, 0, elementId, "tenant"));
+    var executable = mock(InboundConnectorExecutable.class);
+    var context = mock(InboundConnectorManagementContext.class);
+    when(context.getDefinition())
+        .thenReturn(new InboundConnectorDefinition("type1", "tenant", "id", null));
+    when(context.connectorElements()).thenReturn(List.of(element));
+    when(contextFactory.createContext(any(), any(), any(), any())).thenReturn(context);
+    when(factory.getInstance(any())).thenReturn(executable);
+
+    registry.handleEvent(new ProcessStateChanged("id", "tenant", Map.of(0L, List.of(element))));
+    var executableId =
+        registry
+            .query(new ActiveExecutableQuery(null, elementId, null, null))
+            .getFirst()
+            .executableId();
+
+    // when - send empty process state to trigger deactivation of all connectors in this process
+    registry.handleEvent(new ProcessStateChanged("id", "tenant", Map.of()));
+
+    // then
+    var logs = activityLogRegistry.getLogs(executableId);
+    assertThat(logs).hasSize(2);
+    assertThat(logs)
+        .extracting(Activity::message)
+        .anySatisfy(msg -> assertThat(msg).contains("Activated"))
+        .anySatisfy(msg -> assertThat(msg).contains("Deactivated"));
+    assertThat(logs).extracting(Activity::tag).containsOnly(ActivityLogTag.LIFECYCLE);
+  }
+
+  @Test
+  public void activityLog_connectorWritesLog_shouldAppearAlongsideRuntimeLogs() throws Exception {
+    // given
+    var elementId = "elementId";
+    var element =
+        new InboundConnectorElement(
+            Map.of(Keywords.INBOUND_TYPE_KEYWORD, "type1"),
+            new StartEventCorrelationPoint("processId", 0, 0),
+            new ProcessElementWithRuntimeData("id", 0, 0, elementId, "tenant"));
+    var executable = mock(InboundConnectorExecutable.class);
+
+    // The deduplication ID in legacy mode is: tenantId + "-" + processDefinitionKey + "-" +
+    // elementId
+    var connectorDetails = mock(ValidInboundConnectorDetails.class);
+    when(connectorDetails.deduplicationId()).thenReturn("tenant-0-elementId");
+    when(connectorDetails.rawPropertiesWithoutKeywords()).thenReturn(Map.of());
+    when(connectorDetails.connectorElements()).thenReturn(List.of(element));
+
+    var realContext =
+        new InboundConnectorContextImpl(
+            mock(SecretProvider.class),
+            mock(ValidationProvider.class),
+            connectorDetails,
+            null,
+            t -> {},
+            new ObjectMapper(),
+            activityLogRegistry);
+
+    when(contextFactory.createContext(any(), any(), any(), any())).thenReturn(realContext);
+    when(factory.getInstance(any())).thenReturn(executable);
+    doAnswer(
+            invocation -> {
+              realContext.log(
+                  a ->
+                      a.withSeverity(Severity.DEBUG)
+                          .withTag(ActivityLogTag.CONSUMER)
+                          .withMessage("Custom connector log entry"));
+              return null;
+            })
+        .when(executable)
+        .activate(any());
+
+    // when
+    registry.handleEvent(new ProcessStateChanged("id", "tenant", Map.of(0L, List.of(element))));
+
+    // then
+    var result = registry.query(new ActiveExecutableQuery(null, elementId, null, null));
+    var logs = result.getFirst().logs();
+    assertThat(logs).hasSize(2);
+    assertThat(logs)
+        .extracting(Activity::tag)
+        .containsExactlyInAnyOrder(ActivityLogTag.LIFECYCLE, ActivityLogTag.CONSUMER);
+    assertThat(logs)
+        .extracting(Activity::message)
+        .anySatisfy(msg -> assertThat(msg).contains("Activated inbound connector"))
+        .anySatisfy(msg -> assertThat(msg).isEqualTo("Custom connector log entry"));
   }
 }


### PR DESCRIPTION
## Description
This pull request enhances the activity logging and querying capabilities for inbound connectors by integrating the `ActivityLogRegistry` throughout the runtime and improving test coverage. The changes ensure that activity logs are consistently available for all executable states and can be queried alongside connector state information.

**Integration of Activity Logging:**

* The `ActivityLogRegistry` is now injected into key components (`InboundExecutableRegistryImpl`, `InboundExecutableQueryService`, and related configuration), ensuring that activity logs are available wherever connector state is queried or managed. [[1]](diffhunk://#diff-a3a55d8400a31bac71ec78a1887007574903f2135ba0663621f4094e613264b2L147-R150) [[2]](diffhunk://#diff-f55c043dc03e36aea6eb4264a3c09e1d2db6c111d68f6bad766fa4b3e35a3a48R25) [[3]](diffhunk://#diff-f55c043dc03e36aea6eb4264a3c09e1d2db6c111d68f6bad766fa4b3e35a3a48L56-R59) [[4]](diffhunk://#diff-f55c043dc03e36aea6eb4264a3c09e1d2db6c111d68f6bad766fa4b3e35a3a48L68-R72) [[5]](diffhunk://#diff-b3641951876bc7d433c5dc818f1aaf647c1359f65bcc475b40c90b0c2d2ffcf9R22-L28) [[6]](diffhunk://#diff-b3641951876bc7d433c5dc818f1aaf647c1359f65bcc475b40c90b0c2d2ffcf9R37-R45) [[7]](diffhunk://#diff-1833efc324257e73fe3b91779b32fbec5df8dd2a30638f48081fa4fc7c5ffbf4R55) [[8]](diffhunk://#diff-1833efc324257e73fe3b91779b32fbec5df8dd2a30638f48081fa4fc7c5ffbf4L65-R67)

* The `getLogs` method in `ActivityLogRegistry` now returns an empty queue if no logs exist for a given executable, preventing potential null pointer issues when querying logs.

**Activity Log Querying Improvements:**

* All query responses for connector states (activated, cancelled, not registered, failed to activate, invalid definition) now include the relevant activity logs by calling `activityLogRegistry.getLogs(...)` instead of returning empty lists. This ensures that logs are always available in query responses. [[1]](diffhunk://#diff-b3641951876bc7d433c5dc818f1aaf647c1359f65bcc475b40c90b0c2d2ffcf9L120-R124) [[2]](diffhunk://#diff-b3641951876bc7d433c5dc818f1aaf647c1359f65bcc475b40c90b0c2d2ffcf9L132-R136) [[3]](diffhunk://#diff-b3641951876bc7d433c5dc818f1aaf647c1359f65bcc475b40c90b0c2d2ffcf9L144-R148) [[4]](diffhunk://#diff-b3641951876bc7d433c5dc818f1aaf647c1359f65bcc475b40c90b0c2d2ffcf9L156-R160) [[5]](diffhunk://#diff-b3641951876bc7d433c5dc818f1aaf647c1359f65bcc475b40c90b0c2d2ffcf9L168-R172)

**Testing Enhancements:**

* New and expanded tests in `InboundExecutableRegistryTest` verify that activity logs are correctly recorded for activations, deactivations, activation failures, and custom connector log entries, ensuring robust end-to-end activity logging.

**Code Cleanliness:**

* Minor import cleanups were performed to remove unused imports, keeping the codebase tidy. [[1]](diffhunk://#diff-fdf439b1ba257204b5afe1dc1c7cefb053cee6d2048a8d814b6c900e868a5d31L22-R22) [[2]](diffhunk://#diff-b3641951876bc7d433c5dc818f1aaf647c1359f65bcc475b40c90b0c2d2ffcf9R22-L28)

These changes collectively improve the observability and reliability of inbound connector activity tracking across the runtime.

## Checklist

- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest
  release, as this branch will be rebased onto main before the next release. Example backport labels:
    - `backport stable/8.8`: for changes that should be included in the next 8.8.x release.
    - **or** `backport release-8.8.7`: for changes that should be included in the specific release 8.8.7, and this
      *release has already been created*. The release branch will be merged back into stable/8.8 later, so the change
      will be included in future 8.8.x releases as well.
- [ ] Tests/Integration tests for the changes have been added if applicable.

