### PR TITLE
refactor(secrets): Secrets are now prefixed by default

### DIFF
--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/secret/EnvironmentSecretProvider.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/secret/EnvironmentSecretProvider.java
@@ -44,17 +44,11 @@ public class EnvironmentSecretProvider implements SecretProvider {
     if (!StringUtils.hasText(prefix)) {
       LOG.warn(
           """
-                Connector secret environment variable prefix is not configured.
-                Currently, all environment variables will be exposed as connector secrets.
-                This is unsafe and will not be supported anymore in future releases.
-
-                Please configure a valid prefix using
-                `camunda.connectors.secretprovider.environment.prefix`
-                or
-                `CAMUNDA_CONNECTORS_SECRETPROVIDER_ENVIRONMENT_PREFIX`.
-
-                If `camunda.connector.secretprovider.environment.enabled` is set to true,
-                a prefix must be configured to avoid breaking changes in the future.
+                You are using connector environment secrets in unsafe mode. \
+                All environment variables are accessible as connector secrets. \
+                Please configure a meaningful secret prefix using \
+                `camunda.connector.secretprovider.environment.prefix` \
+                or `CAMUNDA_CONNECTOR_SECRETPROVIDER_ENVIRONMENT_PREFIX`.
                 """);
     } else {
       LOG.debug(
@@ -65,21 +59,50 @@ public class EnvironmentSecretProvider implements SecretProvider {
 
   @Override
   public String getSecret(String name, SecretContext context) {
-    if (!StringUtils.hasText(prefix)) {
-      LOG.warn(
-          "Accessing connector environment secrets without a configured prefix. This behavior is deprecated and will not be supported in a future release. "
-              + "Please set `camunda.connector.secretprovider.environment.prefix`. or `CAMUNDA_CONNECTOR_SECRETPROVIDER_ENVIRONMENT_PREFIX`.");
-    }
-    String secretName =
-        tenantAware
-            ? (processDefinitionAware
-                ? composeSecretNameTenantAwareProcessDefinitionAware(name, context)
-                : composeSecretNameTenantAware(name, context))
-            : (processDefinitionAware
-                ? composeSecretNameProcessDefinitionAware(name, context)
-                : composeSecretName(name));
+    String secretName = composeSecretName(name, context);
     LOG.debug("Getting secret value for name '{}'", secretName);
-    return environment.getProperty(secretName);
+
+    String secretValue = environment.getProperty(secretName);
+    if (secretValue != null) {
+      return secretValue;
+    }
+
+    // If prefix is configured and value was not found, check whether the unprefixed key exists.
+    // If so, log a warning explaining that the secret was rejected because it is missing the
+    // configured prefix.
+    if (StringUtils.hasText(prefix)) {
+      String unprefixedName = composeSecretNameWithPrefix(name, context, "");
+      if (environment.containsProperty(unprefixedName)) {
+        LOG.warn(
+            "Rejected connector secret '{}': environment variable '{}' exists but does not match "
+                + "the configured prefix '{}'. Rename it to '{}' to make it available as a "
+                + "connector secret.",
+            name,
+            unprefixedName,
+            prefix,
+            secretName);
+      }
+    }
+
+    return null;
+  }
+
+  /** Composes the full secret name using the configured prefix. */
+  private String composeSecretName(String name, SecretContext context) {
+    return composeSecretNameWithPrefix(name, context, prefix);
+  }
+
+  /** Composes the full secret name using the given prefix (may be empty for unprefixed lookup). */
+  private String composeSecretNameWithPrefix(
+      String name, SecretContext context, String effectivePrefix) {
+    String resolvedPrefix = StringUtils.hasText(effectivePrefix) ? effectivePrefix : "";
+    return tenantAware
+        ? (processDefinitionAware
+            ? composeSecretNameTenantAwareProcessDefinitionAware(name, context, resolvedPrefix)
+            : composeSecretNameTenantAware(name, context, resolvedPrefix))
+        : (processDefinitionAware
+            ? composeSecretNameProcessDefinitionAware(name, context, resolvedPrefix)
+            : composeSecretNameSimple(name, resolvedPrefix));
   }
 
   /**
@@ -88,8 +111,8 @@ public class EnvironmentSecretProvider implements SecretProvider {
    * @param name the secrets' name to find the value for
    * @return the final secret name
    */
-  private String composeSecretName(String name) {
-    return String.format("%s%s", StringUtils.hasText(prefix) ? prefix : "", name);
+  private String composeSecretNameSimple(String name, String resolvedPrefix) {
+    return String.format("%s%s", resolvedPrefix, name);
   }
 
   /**
@@ -99,9 +122,9 @@ public class EnvironmentSecretProvider implements SecretProvider {
    * @param context the context of where the secret is originated
    * @return the final secret name
    */
-  private String composeSecretNameTenantAware(String name, SecretContext context) {
-    return String.format(
-        "%s%s_%s", StringUtils.hasText(prefix) ? prefix : "", context.tenantId(), name);
+  private String composeSecretNameTenantAware(
+      String name, SecretContext context, String resolvedPrefix) {
+    return String.format("%s%s_%s", resolvedPrefix, context.tenantId(), name);
   }
 
   /**
@@ -110,9 +133,9 @@ public class EnvironmentSecretProvider implements SecretProvider {
    * @param name the secrets' name to find the value for
    * @return the final secret name
    */
-  private String composeSecretNameProcessDefinitionAware(String name, SecretContext context) {
-    return String.format(
-        "%s%s_%s", StringUtils.hasText(prefix) ? prefix : "", context.processDefinitionId(), name);
+  private String composeSecretNameProcessDefinitionAware(
+      String name, SecretContext context, String resolvedPrefix) {
+    return String.format("%s%s_%s", resolvedPrefix, context.processDefinitionId(), name);
   }
 
   /**
@@ -123,12 +146,8 @@ public class EnvironmentSecretProvider implements SecretProvider {
    * @return the final secret name
    */
   private String composeSecretNameTenantAwareProcessDefinitionAware(
-      String name, SecretContext context) {
+      String name, SecretContext context, String resolvedPrefix) {
     return String.format(
-        "%s%s_%s_%s",
-        StringUtils.hasText(prefix) ? prefix : "",
-        context.tenantId(),
-        context.processDefinitionId(),
-        name);
+        "%s%s_%s_%s", resolvedPrefix, context.tenantId(), context.processDefinitionId(), name);
   }
 }

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/secret/EnvironmentSecretProvider.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/secret/EnvironmentSecretProvider.java
@@ -106,9 +106,10 @@ public class EnvironmentSecretProvider implements SecretProvider {
   }
 
   /**
-   * returns the secret name in format ${prefix}${name}
+   * Returns the secret name in format {@code ${prefix}${name}}.
    *
-   * @param name the secrets' name to find the value for
+   * @param name the secret name to find the value for
+   * @param resolvedPrefix the prefix to prepend (may be empty)
    * @return the final secret name
    */
   private String composeSecretNameSimple(String name, String resolvedPrefix) {
@@ -116,10 +117,11 @@ public class EnvironmentSecretProvider implements SecretProvider {
   }
 
   /**
-   * returns the secret name in format ${prefix}${tenantId}_${name}
+   * Returns the secret name in format {@code ${prefix}${tenantId}_${name}}.
    *
-   * @param name the secrets' name to find the value for
+   * @param name the secret name to find the value for
    * @param context the context of where the secret is originated
+   * @param resolvedPrefix the prefix to prepend (may be empty)
    * @return the final secret name
    */
   private String composeSecretNameTenantAware(
@@ -128,9 +130,11 @@ public class EnvironmentSecretProvider implements SecretProvider {
   }
 
   /**
-   * returns the secret name in format ${prefix}${processDefinitionId}_${name}
+   * Returns the secret name in format {@code ${prefix}${processDefinitionId}_${name}}.
    *
-   * @param name the secrets' name to find the value for
+   * @param name the secret name to find the value for
+   * @param context the context of where the secret is originated
+   * @param resolvedPrefix the prefix to prepend (may be empty)
    * @return the final secret name
    */
   private String composeSecretNameProcessDefinitionAware(
@@ -139,10 +143,11 @@ public class EnvironmentSecretProvider implements SecretProvider {
   }
 
   /**
-   * returns the secret name in format ${prefix}${tenantId}_${processDefinitionId}_${name}
+   * Returns the secret name in format {@code ${prefix}${tenantId}_${processDefinitionId}_${name}}.
    *
-   * @param name the secrets' name to find the value for
+   * @param name the secret name to find the value for
    * @param context the context of where the secret is originated
+   * @param resolvedPrefix the prefix to prepend (may be empty)
    * @return the final secret name
    */
   private String composeSecretNameTenantAwareProcessDefinitionAware(

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/secret/EnvironmentSecretProviderTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/secret/EnvironmentSecretProviderTest.java
@@ -35,21 +35,29 @@ public class EnvironmentSecretProviderTest {
   }
 
   @Test
-  void shouldNotApplyPrefix() {
+  void shouldRejectSecretWithoutConfiguredPrefix() {
     MockEnvironment env = new MockEnvironment();
     env.setProperty("my-total-secret", "beebop");
     EnvironmentSecretProvider secretProvider =
-        new EnvironmentSecretProvider(env, null, false, false);
+        new EnvironmentSecretProvider(env, "SECRET_", false, false);
+    String myTotalSecret = secretProvider.getSecret("my-total-secret", null);
+    assertThat(myTotalSecret).isNull();
+  }
+
+  @Test
+  void shouldAllowAllSecretsInUnsafeMode() {
+    MockEnvironment env = new MockEnvironment();
+    env.setProperty("my-total-secret", "beebop");
+    EnvironmentSecretProvider secretProvider = new EnvironmentSecretProvider(env, "", false, false);
     String myTotalSecret = secretProvider.getSecret("my-total-secret", null);
     assertThat(myTotalSecret).isEqualTo("beebop");
   }
 
   @Test
-  void shouldApplyTenantId() {
+  void shouldApplyTenantIdInUnsafeMode() {
     MockEnvironment env = new MockEnvironment();
     env.setProperty("my-tenant_my-total-secret", "beebop");
-    EnvironmentSecretProvider secretProvider =
-        new EnvironmentSecretProvider(env, null, true, false);
+    EnvironmentSecretProvider secretProvider = new EnvironmentSecretProvider(env, "", true, false);
     String myTotalSecret =
         secretProvider.getSecret("my-total-secret", new SecretContext("my-tenant", "my-process"));
     assertThat(myTotalSecret).isEqualTo("beebop");
@@ -67,11 +75,10 @@ public class EnvironmentSecretProviderTest {
   }
 
   @Test
-  void shouldApplyProcessDefinitionId() {
+  void shouldApplyProcessDefinitionIdInUnsafeMode() {
     MockEnvironment env = new MockEnvironment();
     env.setProperty("my-process_my-total-secret", "beebop");
-    EnvironmentSecretProvider secretProvider =
-        new EnvironmentSecretProvider(env, null, false, true);
+    EnvironmentSecretProvider secretProvider = new EnvironmentSecretProvider(env, "", false, true);
     String myTotalSecret =
         secretProvider.getSecret("my-total-secret", new SecretContext("my-tenant", "my-process"));
     assertThat(myTotalSecret).isEqualTo("beebop");
@@ -89,10 +96,10 @@ public class EnvironmentSecretProviderTest {
   }
 
   @Test
-  void shouldApplyTenantIdAndProcessDefinitionId() {
+  void shouldApplyTenantIdAndProcessDefinitionIdInUnsafeMode() {
     MockEnvironment env = new MockEnvironment();
     env.setProperty("my-tenant_my-process_my-total-secret", "beebop");
-    EnvironmentSecretProvider secretProvider = new EnvironmentSecretProvider(env, null, true, true);
+    EnvironmentSecretProvider secretProvider = new EnvironmentSecretProvider(env, "", true, true);
     String myTotalSecret =
         secretProvider.getSecret("my-total-secret", new SecretContext("my-tenant", "my-process"));
     assertThat(myTotalSecret).isEqualTo("beebop");

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/main/java/io/camunda/connector/runtime/ConnectorsAutoConfiguration.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/main/java/io/camunda/connector/runtime/ConnectorsAutoConfiguration.java
@@ -77,7 +77,8 @@ public class ConnectorsAutoConfiguration {
   @Value("${camunda.connector.secretprovider.discovery.enabled:true}")
   Boolean secretProviderLookupEnabled;
 
-  @Value("${camunda.connector.secretprovider.environment.prefix:}")
+  @Value(
+      "${camunda.connector.secretprovider.environment.prefix:SECRET_}")
   String environmentSecretProviderPrefix;
 
   @Value("${camunda.connector.secretprovider.environment.tenantaware:false}")

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/main/java/io/camunda/connector/runtime/ConnectorsAutoConfiguration.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/main/java/io/camunda/connector/runtime/ConnectorsAutoConfiguration.java
@@ -77,8 +77,7 @@ public class ConnectorsAutoConfiguration {
   @Value("${camunda.connector.secretprovider.discovery.enabled:true}")
   Boolean secretProviderLookupEnabled;
 
-  @Value(
-      "${camunda.connector.secretprovider.environment.prefix:SECRET_}")
+  @Value("${camunda.connector.secretprovider.environment.prefix:SECRET_}")
   String environmentSecretProviderPrefix;
 
   @Value("${camunda.connector.secretprovider.environment.tenantaware:false}")


### PR DESCRIPTION
This pull request refines the handling of environment variable secrets in the `EnvironmentSecretProvider`, enforcing safer defaults and improving clarity in both code and logging. The changes ensure that when a prefix is configured, only secrets with the prefix are accessible, and attempts to access unprefixed secrets are rejected with clear warnings. The default prefix is now set to `SECRET_`, and tests have been updated to reflect the new logic.

**Secret resolution and enforcement improvements:**

* The `getSecret` method now strictly enforces the configured prefix: if a prefix is set, only secrets with that prefix can be accessed. If an unprefixed environment variable exists, a warning is logged and the secret is rejected.
* Helper methods for composing secret names have been refactored to consistently use the resolved prefix, reducing duplication and potential errors in secret key construction. [[1]](diffhunk://#diff-c059d11cb907bad8cbffa84a0d7521ce5f827a948a47b5637fd39ba656c4c594L91-R115) [[2]](diffhunk://#diff-c059d11cb907bad8cbffa84a0d7521ce5f827a948a47b5637fd39ba656c4c594L102-R127) [[3]](diffhunk://#diff-c059d11cb907bad8cbffa84a0d7521ce5f827a948a47b5637fd39ba656c4c594L113-R138) [[4]](diffhunk://#diff-c059d11cb907bad8cbffa84a0d7521ce5f827a948a47b5637fd39ba656c4c594L126-R151)

**Configuration and logging changes:**

* The default value for `environmentSecretProviderPrefix` is now `SECRET_`, promoting safer out-of-the-box behavior.
* The warning message when no prefix is set has been updated for clarity, emphasizing the risks of unsafe mode and instructing users to configure a prefix.

**Test updates:**

* Unit tests have been updated and extended to verify the new enforcement logic, including rejection of unprefixed secrets when a prefix is set, and correct secret resolution in both safe (prefixed) and unsafe (unprefixed) modes. Test names have been clarified to reflect the scenarios being tested. [[1]](diffhunk://#diff-f10a84f844a60adddd0d0d838cb224df7fcbc486208f4e55370810765d354badL38-R60) [[2]](diffhunk://#diff-f10a84f844a60adddd0d0d838cb224df7fcbc486208f4e55370810765d354badL70-R81) [[3]](diffhunk://#diff-f10a84f844a60adddd0d0d838cb224df7fcbc486208f4e55370810765d354badL92-R102)