### PR TITLE
refactor(agentic-ai): redesign conversation storage SPI

### DIFF
--- a/connectors/agentic-ai/AGENTS.md
+++ b/connectors/agentic-ai/AGENTS.md
@@ -74,8 +74,8 @@ framework/
 
 memory/
 ├── conversation/
-│   ├── ConversationStore       # Pluggable storage: executeInSession() callback pattern
-│   ├── ConversationSession     # Per-invocation: loadIntoRuntimeMemory/storeFromRuntimeMemory
+│   ├── ConversationStore       # Pluggable storage: createSession() factory pattern
+│   ├── ConversationSession     # Per-invocation: loadMessages/storeMessages (AutoCloseable)
 │   ├── ConversationContext     # Persistent reference (conversationId)
 │   ├── inprocess/              # In-process store (messages in agentContext variable)
 │   └── document/               # Camunda Document Storage backend
@@ -133,14 +133,15 @@ complete — handled via `CommandWrapper` retries. For detailed mechanics, see
 
 ### Conversation Session Lifecycle
 
-`ConversationStore.executeInSession()` wraps agent processing in a callback:
+`ConversationStore.createSession()` returns an `AutoCloseable` session used via try-with-resources:
 
 ```
-executeInSession(ctx, agentContext, session -> {
-    session.loadIntoRuntimeMemory(agentContext, runtimeMemory)
-    [add messages, call LLM, etc.]
-    session.storeFromRuntimeMemory(agentContext, runtimeMemory)
-}) → completeJob
+try (var session = store.createSession(ctx, agentContext)) {
+    var loaded = session.loadMessages(agentContext)
+    [add messages to runtime memory, call LLM, etc.]
+    var cursor = session.storeMessages(agentContext, request)
+    agentContext = agentContext.withConversation(cursor)
+} → completeJob
 ```
 
 For backend-specific behavior and failure handling, see [ai-agent.md §6](docs/reference/ai-agent.md#6-conversation-memory).

--- a/connectors/agentic-ai/AGENTS.md
+++ b/connectors/agentic-ai/AGENTS.md
@@ -83,9 +83,6 @@ memory/
     ├── RuntimeMemory           # Transient working memory for single execution
     └── MessageWindowRuntimeMemory  # Sliding window filter (keeps last N messages)
 
-jobworker/
-└── AiAgentSubProcessResponse  # AdHocSubProcessConnectorResponse for AHSP directives (element activation, completion condition)
-
 tool/
 ├── GatewayToolHandler          # Interface for gateway tools (MCP, A2A)
 └── GatewayToolHandlerRegistry  # Registry of gateway tool handlers
@@ -105,7 +102,9 @@ tool/
 
 **`ToolCallProcessVariable`** — flattened tool call for process variables: `{_meta: {id, name}, ...args}`.
 
-**`AiAgentSubProcessResponse`** — job completion directives: AHSP done/continue, cancel flags, element activations, variables. Implements `AdHocSubProcessConnectorResponse` — the runtime translates it into the Zeebe complete command with ad-hoc sub-process result configuration.
+**`AiAgentSubProcessConnectorResponse`** — job completion directives: AHSP done/continue, cancel flags, element activations, variables. Implements `AdHocSubProcessConnectorResponse` — the runtime translates it into the Zeebe complete command with ad-hoc sub-process result configuration.
+
+**`AiAgentTaskConnectorResponse`** — wraps `AgentResponse` as a `StandardConnectorResponse` for the task connector flavor. The runtime evaluates result expressions against the wrapped response value.
 
 For full record definitions, see [ai-agent.md §5](docs/reference/ai-agent.md#5-data-model).
 
@@ -141,7 +140,7 @@ try (var session = store.createSession(ctx, agentContext)) {
     [add messages to runtime memory, call LLM, etc.]
     var cursor = session.storeMessages(agentContext, request)
     agentContext = agentContext.withConversation(cursor)
-} → completeJob
+} → buildConnectorResponse
 ```
 
 For backend-specific behavior and failure handling, see [ai-agent.md §6](docs/reference/ai-agent.md#6-conversation-memory).

--- a/connectors/agentic-ai/docs/adr/002-consolidate-job-worker-into-sdk.md
+++ b/connectors/agentic-ai/docs/adr/002-consolidate-job-worker-into-sdk.md
@@ -60,5 +60,5 @@ Zeebe complete command with `.withResult().forAdHocSubProcess()` configuration. 
 - **Completion callbacks**: Extend `ConnectorResponse` with `onCompletionSuccess`/`onCompletionError` callbacks once
   `CommandWrapper` supports command outcome notification
 - **`cancelRemainingInstances` flag**: The mutable flag on `JobWorkerAgentExecutionContext` (set in
-  `handleAddedUserMessages()`, read in `completeJob()`) can be simplified by moving interrupted-tool-call detection
-  into `completeWithResponse()` via `executionContext.initialToolCallResults()`, eliminating the mutable state
+  `handleAddedUserMessages()`, read in `buildConnectorResponse()`) can be simplified by moving interrupted-tool-call detection
+  into `buildResponse()` via `executionContext.initialToolCallResults()`, eliminating the mutable state

--- a/connectors/agentic-ai/docs/adr/002-consolidate-job-worker-into-sdk.md
+++ b/connectors/agentic-ai/docs/adr/002-consolidate-job-worker-into-sdk.md
@@ -37,7 +37,7 @@ Chosen option: **Option 2 — Introduce a `ConnectorResponse` sealed interface h
 
 This decision depends on the `ConnectorResponse` sealed interface hierarchy added to the SDK in
 [#6781](https://github.com/camunda/connectors/pull/6781) (`io.camunda.connector.api.outbound`). With that in place,
-`AiAgentJobWorker` becomes a standard `@OutboundConnector`-annotated function that returns `AiAgentSubProcessResponse`
+`AiAgentJobWorker` becomes a standard `@OutboundConnector`-annotated function that returns `AiAgentSubProcessConnectorResponse`
 (implementing `AdHocSubProcessConnectorResponse`) from `execute()`. The runtime translates the response's
 `variables()`, `elementActivations()`, `completionConditionFulfilled()`, and `cancelRemainingInstances()` into the
 Zeebe complete command with `.withResult().forAdHocSubProcess()` configuration. The SDK handles everything else.

--- a/connectors/agentic-ai/docs/adr/003-conversation-storage-spi-redesign.md
+++ b/connectors/agentic-ai/docs/adr/003-conversation-storage-spi-redesign.md
@@ -1,0 +1,79 @@
+# Redesign Conversation Storage SPI: Factory Pattern with Decoupled Message Types
+
+* Deciders: Agentic AI Team
+* Date: Apr 20, 2026
+
+## Status
+
+**Implemented**
+
+## Context and Problem Statement
+
+The conversation storage SPI used a callback-based pattern (`executeInSession`) where the store
+created a session and invoked a handler callback within its scope. The session interface was coupled
+to `RuntimeMemory`, and `storeFromRuntimeMemory` returned a full `AgentContext` — mixing storage
+concerns with agent state assembly.
+
+Should we keep the callback pattern or switch to a factory pattern with decoupled message types?
+
+## Decision Drivers
+
+* **Lifecycle clarity**: The callback pattern obscured who owns the session lifecycle. For stores
+  managing external resources (e.g., AWS clients), the implicit lifecycle made it hard to reason
+  about cleanup guarantees.
+* **Coupling to RuntimeMemory**: `loadIntoRuntimeMemory` and `storeFromRuntimeMemory` forced the
+  session to know about `RuntimeMemory`, an in-process concern unrelated to storage.
+* **Responsibility creep**: `storeFromRuntimeMemory` returned a full `AgentContext`, meaning the
+  session was assembling agent state — not just persisting messages.
+* **Testability**: The callback pattern required wrapping all test logic inside lambda callbacks,
+  making tests harder to read and debug.
+* **Future extensibility**: Planned features (completion callbacks, reconciliation) need the caller
+  to hold a session reference across the request lifecycle, which the callback pattern doesn't
+  support.
+
+## Considered Options
+
+1. Keep the callback-based `executeInSession` pattern
+2. Switch to a factory pattern (`createSession`) with `AutoCloseable` sessions and decoupled message
+   types
+
+## Decision Outcome
+
+Chosen option: **Option 2 — Factory pattern with decoupled message types**.
+
+### Core changes
+
+- `ConversationStore.executeInSession(handler)` → `createSession()` returning `ConversationSession`
+- `ConversationSession` now extends `AutoCloseable`, used via try-with-resources
+- `loadIntoRuntimeMemory(agentContext, memory)` → `loadMessages(agentContext)` returning
+  `ConversationLoadResult`
+- `storeFromRuntimeMemory(agentContext, memory)` → `storeMessages(agentContext, request)` returning
+  only `ConversationContext` (storage cursor)
+- Caller assembles `AgentContext` via `agentContext.withConversation(cursor)`
+- `ConversationSessionHandler` deleted
+- `compensateFailedJobCompletion` removed (was deprecated, never invoked)
+- New wrapper types: `ConversationLoadResult`, `ConversationStoreRequest`
+
+### Consequences
+
+**Positive:**
+- Session lifecycle is explicit and visible in the code (try-with-resources)
+- AWS AgentCore client cleanup is now handled by `close()` instead of implicit callback scope
+- Sessions work with plain `List<Message>` (via wrapper types), no `RuntimeMemory` dependency
+- `storeMessages` returns only what it owns (the storage cursor), not the full agent state
+- Tests are simpler — direct method calls instead of callback lambdas
+- Wrapper types (`ConversationLoadResult`, `ConversationStoreRequest`) provide stable SPI types that
+  can be extended without breaking changes
+
+**Negative:**
+- Breaking change for custom `ConversationStore` implementations (see
+  [breaking-changes.md](../breaking-changes.md) for migration guide)
+
+### Future improvements
+
+- **Completion callbacks**: `ConversationStore.onJobCompleted` / `onJobCompletionFailed` hooks,
+  invoked after Zeebe confirms or rejects the job, enabling orphan cleanup and optimistic storage
+  strategies
+- **Execution identity**: `AgentContext.executionId` (platform-level stable identifier) to replace
+  `ConversationContext.conversationId()` as the primary execution key
+- **Schema versioning**: `AgentContext.schemaVersion` for explicit data migration across SPI changes

--- a/connectors/agentic-ai/docs/breaking-changes.md
+++ b/connectors/agentic-ai/docs/breaking-changes.md
@@ -1,0 +1,47 @@
+# Breaking Changes
+
+This document tracks breaking changes relevant to [AI Agent customization](https://docs.camunda.io/docs/next/components/connectors/out-of-the-box-connectors/agentic-ai-aiagent-customization/).
+
+## Conversation Storage SPI Redesign
+
+**ADR**: [003-conversation-storage-spi-redesign](adr/003-conversation-storage-spi-redesign.md)
+
+### `ConversationStore`
+
+- `executeInSession(AgentExecutionContext, AgentContext, ConversationSessionHandler<T>)` removed.
+  Use `createSession(AgentExecutionContext, AgentContext)` instead — returns a `ConversationSession`
+  that should be used via try-with-resources.
+- `compensateFailedJobCompletion(AgentExecutionContext, AgentContext, Throwable)` removed (was
+  deprecated and never invoked). Completion callbacks will be introduced in a follow-up.
+
+### `ConversationSession`
+
+- Now extends `AutoCloseable`. The default `close()` is a no-op; implementations managing
+  external resources (e.g., AWS clients) should override it.
+- `loadIntoRuntimeMemory(AgentContext, RuntimeMemory)` removed.
+  Use `loadMessages(AgentContext)` instead — returns a `ConversationLoadResult`.
+- `storeFromRuntimeMemory(AgentContext, RuntimeMemory)` removed.
+  Use `storeMessages(AgentContext, ConversationStoreRequest)` instead — returns a
+  `ConversationContext` (storage cursor). The caller assembles the full `AgentContext` via
+  `agentContext.withConversation(returnedContext)`.
+
+### `ConversationSessionHandler`
+
+- Deleted. No longer needed with the factory pattern.
+
+### New types
+
+- `ConversationLoadResult` — wraps `List<Message>` returned by `loadMessages`.
+- `ConversationStoreRequest` — wraps `List<Message>` passed to `storeMessages`.
+
+### Migration guide for custom implementations
+
+1. Replace `executeInSession(ctx, agentCtx, handler)` with `createSession(ctx, agentCtx)` returning
+   a `ConversationSession`.
+2. In your session, replace `loadIntoRuntimeMemory` with `loadMessages` returning a
+   `ConversationLoadResult`.
+3. Replace `storeFromRuntimeMemory` with `storeMessages` accepting a `ConversationStoreRequest` and
+   returning only the `ConversationContext`. Do not assemble the full `AgentContext` — the caller
+   does that.
+4. If your session manages external resources (connections, clients), override `close()`.
+5. Remove any `ConversationSessionHandler` references.

--- a/connectors/agentic-ai/docs/reference/ai-agent.md
+++ b/connectors/agentic-ai/docs/reference/ai-agent.md
@@ -397,6 +397,34 @@ ConversationStore (registered backend)
 
 See the [`CustomMemoryStorageConfiguration`](../../src/main/java/io/camunda/connector/agenticai/aiagent/model/request/MemoryStorageConfiguration.java) type for configuration, and [camunda-agentic-ai-customizations](https://github.com/maff/camunda-agentic-ai-customizations) for a working example with a JPA-backed store.
 
+### Storage Contract
+
+Every `ConversationStore` implementation must follow the **write-ahead with pointer-based visibility** pattern to guarantee correctness across retries.
+
+#### The fundamental invariant
+
+The `AgentContext` stored in Zeebe is the **sole source of truth** for which conversation data to read. The `ConversationContext` inside it acts as a pointer (storage cursor) to the data. The conversation store may write data ahead of Zeebe — but that data only becomes "committed" when Zeebe accepts the job completion containing the updated `AgentContext`.
+
+If job completion fails (e.g., the job was superseded), Zeebe retries with the **old** `AgentContext`, which contains the **old** pointer. The newly written data is invisible to the retry and becomes an orphan.
+
+#### Rules for implementations
+
+1. **`storeMessages` must always write to a new location.** Never mutate or overwrite the data that the current `ConversationContext` points to. Create a new version, snapshot, branch, or record — then return a new `ConversationContext` pointing to it. This ensures the old pointer always resolves to the old data.
+
+2. **`loadMessages` must be guided by the pointer.** Load only the data that the `ConversationContext` (from `agentContext.conversation()`) references. Do not load "latest" or "most recent" — that would break retry safety.
+
+3. **Orphaned writes are expected.** When job completion fails after `storeMessages`, the written data is never pointed to. Implementations should tolerate orphans and may clean them up via background processes or future completion callbacks.
+
+4. **`ConversationContext` must be serializable and self-contained.** It is persisted as part of the `agentContext` process variable in Zeebe. It must contain everything needed to locate the conversation data (e.g., a document reference, a version number, a branch pointer) — without relying on external state that could change between turns.
+
+#### How each built-in store satisfies this contract
+
+| Store | Write target | Pointer | Orphan on failure |
+|-------|-------------|---------|-------------------|
+| **InProcess** | `agentContext` variable itself (messages in `ConversationContext`) | The variable *is* the data | No orphan — variable update and job completion fail together |
+| **CamundaDocument** | New immutable document per turn | `document` reference in context | Orphaned document (tracked in `previousDocuments` for cleanup) |
+| **AwsAgentCore** | New branch per turn (events forked from previous turn's last event) | `branchName` + `lastEventId` | Orphaned branch (invisible without pointer, no parent-chain traversal reaches it) |
+
 ### ConversationSession Lifecycle
 
 `ConversationStore.createSession()` returns an `AutoCloseable` session. The handler manages it via try-with-resources:
@@ -419,7 +447,7 @@ try (var session = store.createSession(executionContext, agentContext)) {
 6. `session.close()` handles resource cleanup (e.g., closing AWS clients)
 7. Job completion sends the updated `AgentContext` back to Zeebe
 
-**Critical insight**: The conversation is stored **before** job completion. If job completion fails (e.g., job was superseded), the stored conversation state may be ahead of what Zeebe knows. On retry, the agent uses the old `agentContext` (with old document reference) — safe, just re-does the work.
+**Critical insight**: The conversation is stored **before** job completion. This is safe because all stores follow the write-ahead with pointer-based visibility contract — see [Storage Contract](#storage-contract) above.
 
 ---
 
@@ -660,14 +688,9 @@ This is the key gate: if no user messages were added (because tool results were 
 
 ### Challenge 2: Conversation Store Ahead of Zeebe
 
-**Problem**: The conversation is written to storage (document store or in-process context) **before** the job completion command is sent. If the job completion fails:
-- In-process store: The updated `agentContext` (including conversation) is in the completion variables that failed to send — so both fail together. Safe.
-- Document store: The document was already written. The `agentContext` variable in the completion command references this new document. If completion fails, the next job will use the OLD `agentContext` which references the OLD document. The new document becomes an orphan, but the agent state is consistent because it re-uses the old context.
+**Problem**: The conversation is written to storage **before** the job completion command is sent to Zeebe. If job completion fails, the store has data that Zeebe doesn't know about.
 
-**Mitigation**:
-- The "document ahead of Zeebe" scenario is benign for correctness: the old conversation is a valid subset, the agent simply re-does the LLM call
-- Completion callback hooks for stores are planned for a follow-up to enable proactive recovery
-- Document references accumulate in `previousDocuments` but old documents are harmless
+**Mitigation**: This is safe by design. All stores follow the [Storage Contract](#storage-contract): they write to a new location each turn, and the `ConversationContext` pointer in the old `AgentContext` still resolves to the old data. The newly written data becomes an orphan — harmless to correctness, and cleanable via future completion callbacks.
 
 ### Challenge 3: Duplicate LLM Calls on Rapid Tool Completion
 

--- a/connectors/agentic-ai/docs/reference/ai-agent.md
+++ b/connectors/agentic-ai/docs/reference/ai-agent.md
@@ -194,7 +194,7 @@ The loop operates as a distributed state machine between the connector runtime a
    - Store updated conversation back to memory store (via `ConversationSession`)
    - Transform tool calls and create response
 
-5. **Job completion** (`AiAgentSubProcessResponse`):
+5. **Job completion** (`AiAgentSubProcessConnectorResponse`):
    - Sets `agentContext` variable with updated state
    - If tool calls present:
      - `completionConditionFulfilled = false`
@@ -303,11 +303,11 @@ record AgentResponse(
 )
 ```
 
-### AiAgentSubProcessResponse (job worker specific)
+### AiAgentSubProcessConnectorResponse (job worker specific)
 
 Implements `AdHocSubProcessConnectorResponse` with job completion control:
 ```java
-record AiAgentSubProcessResponse(
+record AiAgentSubProcessConnectorResponse(
     AgentResponse agentResponse,
     boolean completionConditionFulfilled,   // true = AHSP done
     boolean cancelRemainingInstances,        // true = cancel active tools
@@ -519,7 +519,7 @@ SpringConnectorJobHandler.handle(jobClient, job)
   ├─ AiAgentJobWorker.execute(context)
   │    ├─ Binds variables to JobWorkerAgentRequest
   │    └─ agentRequestHandler.handleRequest(executionContext)
-  │         └─ Returns AiAgentSubProcessResponse (AdHocSubProcessConnectorResponse)
+  │         └─ Returns AiAgentSubProcessConnectorResponse (AdHocSubProcessConnectorResponse)
   │
   ├─ SpringConnectorJobHandler examines error expression
   │    └─ Checks for error expressions (BPMN error handling)
@@ -570,7 +570,7 @@ jobClient.newCompleteCommand(job)
 When the agent cannot proceed (e.g., not all tool call results are present yet, or discovery is in progress):
 
 ```java
-return AiAgentSubProcessResponse.builder()
+return AiAgentSubProcessConnectorResponse.builder()
     .completionConditionFulfilled(false)
     .cancelRemainingInstances(false)
     .build();
@@ -1014,7 +1014,7 @@ If the `processDefinitionKey` stored in the agent context doesn't match the curr
 ### Entry Points
 - `AiAgentFunction.execute()` → Connector (Task) entry point
 - `AiAgentJobWorker.execute()` → Job worker (Sub-process) entry point
-- `AiAgentJobWorker.execute()` wraps into `AiAgentSubProcessResponse` → handled by `SpringConnectorJobHandler`
+- `AiAgentJobWorker.execute()` wraps into `AiAgentSubProcessConnectorResponse` → handled by `SpringConnectorJobHandler`
 
 ### Core Agent Logic
 - `BaseAgentRequestHandler.handleRequest()` → Core orchestrator: init → memory → messages → LLM → response → complete
@@ -1024,7 +1024,7 @@ If the `processDefinitionKey` stored in the agent context doesn't match the curr
 - `AgentResponseHandlerImpl.createResponse()` → Response formatting
 
 ### Job Completion
-- `AiAgentSubProcessResponse.elementActivations()` → AHSP element activations from tool calls
+- `AiAgentSubProcessConnectorResponse.elementActivations()` → AHSP element activations from tool calls
 - `JobWorkerAgentRequestHandler.completeJob()` → Job worker completion logic (no-op vs response)
 
 ### Memory

--- a/connectors/agentic-ai/docs/reference/ai-agent.md
+++ b/connectors/agentic-ai/docs/reference/ai-agent.md
@@ -338,10 +338,10 @@ Memory is managed through a layered architecture:
 
 ```
 RuntimeMemory (in-process, transient)
-    ▲ loadIntoRuntimeMemory  │ storeFromRuntimeMemory
+    ▲ loadMessages           │ storeMessages
     │                        ▼
-ConversationSession (per-invocation, managed by store callback)
-    ▲ executeInSession       │ persist
+ConversationSession (per-invocation, AutoCloseable)
+    ▲ createSession          │ persist
     │                        ▼
 ConversationStore (registered backend)
     │
@@ -390,7 +390,7 @@ ConversationStore (registered backend)
 - See [AWS AgentCore Memory reference](aws-agentcore-memory.md) for full details
 
 **Custom implementations**: Fully pluggable via `ConversationStoreRegistry`. Users can register custom stores by:
-1. Implementing `ConversationStore` (with `executeInSession` callback), `ConversationSession`, and `ConversationContext`
+1. Implementing `ConversationStore` (with `createSession` factory method), `ConversationSession` (with `loadMessages`/`storeMessages`), and `ConversationContext`
 2. Annotating the custom `ConversationContext` with `@JsonTypeName("my-type")` and registering the subtype with the runtime `ObjectMapper` (e.g., via a Spring `Jackson2ObjectMapperBuilderCustomizer` calling `registerSubtypes()`)
 3. Selecting "Custom Implementation" as memory storage type in the element template and specifying the implementation type string
 4. Registering the store as a Spring component
@@ -399,24 +399,27 @@ See the [`CustomMemoryStorageConfiguration`](../../src/main/java/io/camunda/conn
 
 ### ConversationSession Lifecycle
 
-`ConversationStore.executeInSession()` wraps the agent processing in a callback that manages session lifecycle:
+`ConversationStore.createSession()` returns an `AutoCloseable` session. The handler manages it via try-with-resources:
 
 ```java
-conversationStore.executeInSession(executionContext, agentContext, session -> {
-    session.loadIntoRuntimeMemory(agentContext, runtimeMemory);   // load history
+try (var session = store.createSession(executionContext, agentContext)) {
+    var loadResult = session.loadMessages(agentContext);          // load history
+    runtimeMemory.addMessages(loadResult.messages());
     // [add messages, call LLM, etc.]
-    return session.storeFromRuntimeMemory(agentContext, runtimeMemory);  // persist
-});
+    var cursor = session.storeMessages(agentContext, request);    // persist
+    agentContext = agentContext.withConversation(cursor);          // assemble
+}
 ```
 
-1. `ConversationStore.executeInSession()` creates a session and invokes the callback
-2. `session.loadIntoRuntimeMemory(agentContext, runtimeMemory)` populates `RuntimeMemory` with stored history
+1. `ConversationStore.createSession()` creates and returns a session (the caller owns its lifecycle)
+2. `session.loadMessages(agentContext)` returns a `ConversationLoadResult` containing the stored message history
 3. Agent logic adds messages to `RuntimeMemory`, calls LLM, gets response
-4. `session.storeFromRuntimeMemory(agentContext, runtimeMemory)` persists and returns updated `AgentContext`
-5. The store manages session cleanup (resource deallocation) within the callback scope
-6. Job completion sends the updated `AgentContext` back to Zeebe
+4. `session.storeMessages(agentContext, request)` persists and returns only the `ConversationContext` (storage cursor)
+5. The caller assembles the updated `AgentContext` via `agentContext.withConversation(cursor)`
+6. `session.close()` handles resource cleanup (e.g., closing AWS clients)
+7. Job completion sends the updated `AgentContext` back to Zeebe
 
-**Critical insight**: The conversation is stored **before** job completion. If job completion fails (e.g., job was superseded), the stored conversation state may be ahead of what Zeebe knows. On retry, the agent uses the old `agentContext` (with old document reference) — safe, just re-does the work. The `compensateFailedJobCompletion()` hook on the store is available for recovery if needed (default is a no-op).
+**Critical insight**: The conversation is stored **before** job completion. If job completion fails (e.g., job was superseded), the stored conversation state may be ahead of what Zeebe knows. On retry, the agent uses the old `agentContext` (with old document reference) — safe, just re-does the work.
 
 ---
 
@@ -653,7 +656,7 @@ This is the key gate: if no user messages were added (because tool results were 
 **Mitigation**:
 - The `CommandWrapper` retries up to 3 times via `CommandExceptionHandlingStrategy`
 - The no-op completion pattern means most superseded jobs were doing nothing anyway
-- `ConversationStore.compensateFailedJobCompletion()` exists as an extension point for future completion callback support (currently a no-op, not yet invoked)
+- Completion callbacks for conversation stores are planned for a follow-up (not yet implemented)
 
 ### Challenge 2: Conversation Store Ahead of Zeebe
 
@@ -662,8 +665,8 @@ This is the key gate: if no user messages were added (because tool results were 
 - Document store: The document was already written. The `agentContext` variable in the completion command references this new document. If completion fails, the next job will use the OLD `agentContext` which references the OLD document. The new document becomes an orphan, but the agent state is consistent because it re-uses the old context.
 
 **Mitigation**:
-- The `compensateFailedJobCompletion()` hook is available for custom stores to perform recovery (default no-op)
 - The "document ahead of Zeebe" scenario is benign for correctness: the old conversation is a valid subset, the agent simply re-does the LLM call
+- Completion callback hooks for stores are planned for a follow-up to enable proactive recovery
 - Document references accumulate in `previousDocuments` but old documents are harmless
 
 ### Challenge 3: Duplicate LLM Calls on Rapid Tool Completion
@@ -1003,8 +1006,8 @@ If the `processDefinitionKey` stored in the agent context doesn't match the curr
 
 ### Memory
 - `ConversationStoreRegistryImpl.getConversationStore()` → Store resolution
-- `InProcessConversationSession.loadIntoRuntimeMemory()` / `storeFromRuntimeMemory()` → In-process persistence
-- `CamundaDocumentConversationSession.loadIntoRuntimeMemory()` / `storeFromRuntimeMemory()` → Document persistence
+- `InProcessConversationSession.loadMessages()` / `storeMessages()` → In-process persistence
+- `CamundaDocumentConversationSession.loadMessages()` / `storeMessages()` → Document persistence
 - `MessageWindowRuntimeMemory.filteredMessages()` → Context window sliding (used by BaseAgentRequestHandler)
 
 ### Tool Resolution

--- a/connectors/agentic-ai/docs/reference/ai-agent.md
+++ b/connectors/agentic-ai/docs/reference/ai-agent.md
@@ -559,7 +559,7 @@ jobClient.newCompleteCommand(job)
 
 3. **`completionConditionFulfilled`**: Directly controls whether the AHSP terminates. When `true`, the AHSP completes and output mappings propagate results to the parent process.
 
-4. **`cancelRemainingInstances`**: Used when event handling interrupts tool calls — cancels all still-running tool instances. Currently determined via a mutable flag on `JobWorkerAgentExecutionContext`, set as a side effect in `handleAddedUserMessages()`. **Future improvement**: move detection into `completeWithResponse()` by inspecting `executionContext.initialToolCallResults()` directly for interrupted results, eliminating the mutable state.
+4. **`cancelRemainingInstances`**: Used when event handling interrupts tool calls — cancels all still-running tool instances. Currently determined via a mutable flag on `JobWorkerAgentExecutionContext`, set as a side effect in `handleAddedUserMessages()`. **Future improvement**: move detection into `buildResponse()` by inspecting `executionContext.initialToolCallResults()` directly for interrupted results, eliminating the mutable state.
 
 5. **Async execution**: The complete command is sent asynchronously via `CommandWrapper` with up to 3 retries. This is important because:
    - The job may have been superseded (NOT_FOUND)
@@ -665,7 +665,7 @@ The method checks each tool call from the last assistant message against the ava
 // BaseAgentRequestHandler.handleRequest()
 var addedUserMessages = messagesHandler.addUserMessages(...);
 if (!modelCallPrerequisitesFulfilled(addedUserMessages)) {
-    return completeJob(executionContext, null, session);
+    return buildConnectorResponse(executionContext, null);
 }
 ```
 
@@ -1025,7 +1025,7 @@ If the `processDefinitionKey` stored in the agent context doesn't match the curr
 
 ### Job Completion
 - `AiAgentSubProcessConnectorResponse.elementActivations()` → AHSP element activations from tool calls
-- `JobWorkerAgentRequestHandler.completeJob()` → Job worker completion logic (no-op vs response)
+- `JobWorkerAgentRequestHandler.buildConnectorResponse()` → Job worker response assembly (no-op vs response)
 
 ### Memory
 - `ConversationStoreRegistryImpl.getConversationStore()` → Store resolution

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/AiAgentFunction.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/AiAgentFunction.java
@@ -95,7 +95,7 @@ public class AiAgentFunction implements OutboundConnectorFunction {
   }
 
   @Override
-  public AiAgentTaskResponse execute(OutboundConnectorContext context) {
+  public AiAgentTaskConnectorResponse execute(OutboundConnectorContext context) {
     var request = context.bindVariables(OutboundConnectorAgentRequest.class);
     var executionContext =
         new OutboundConnectorAgentExecutionContext(

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/AiAgentFunction.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/AiAgentFunction.java
@@ -95,7 +95,7 @@ public class AiAgentFunction implements OutboundConnectorFunction {
   }
 
   @Override
-  public AgentResponse execute(OutboundConnectorContext context) {
+  public AiAgentTaskResponse execute(OutboundConnectorContext context) {
     var request = context.bindVariables(OutboundConnectorAgentRequest.class);
     var executionContext =
         new OutboundConnectorAgentExecutionContext(

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/AiAgentJobWorker.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/AiAgentJobWorker.java
@@ -7,7 +7,6 @@
 package io.camunda.connector.agenticai.aiagent;
 
 import io.camunda.connector.agenticai.aiagent.agent.JobWorkerAgentRequestHandler;
-import io.camunda.connector.agenticai.aiagent.jobworker.AiAgentSubProcessResponse;
 import io.camunda.connector.agenticai.aiagent.model.JobWorkerAgentExecutionContext;
 import io.camunda.connector.agenticai.aiagent.model.request.JobWorkerAgentRequest;
 import io.camunda.connector.api.annotation.OutboundConnector;

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/AiAgentJobWorker.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/AiAgentJobWorker.java
@@ -54,7 +54,8 @@ public class AiAgentJobWorker implements OutboundConnectorFunction {
   }
 
   @Override
-  public AiAgentSubProcessResponse execute(OutboundConnectorContext context) throws Exception {
+  public AiAgentSubProcessConnectorResponse execute(OutboundConnectorContext context)
+      throws Exception {
     var request = context.bindVariables(JobWorkerAgentRequest.class);
     var executionContext = new JobWorkerAgentExecutionContext(context.getJobContext(), request);
     return agentRequestHandler.handleRequest(executionContext);

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/AiAgentSubProcessConnectorResponse.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/AiAgentSubProcessConnectorResponse.java
@@ -14,16 +14,16 @@ import java.util.Map;
 import org.springframework.lang.Nullable;
 
 @AgenticAiRecord
-public record AiAgentSubProcessResponse(
+public record AiAgentSubProcessConnectorResponse(
     @Nullable AgentResponse responseValue,
     Map<String, Object> variables,
     List<ElementActivation> elementActivations,
     boolean completionConditionFulfilled,
     boolean cancelRemainingInstances)
-    implements AdHocSubProcessConnectorResponse, AiAgentSubProcessResponseBuilder.With {
+    implements AdHocSubProcessConnectorResponse, AiAgentSubProcessConnectorResponseBuilder.With {
 
-  public static AiAgentSubProcessResponseBuilder builder() {
-    return AiAgentSubProcessResponseBuilder.builder();
+  public static AiAgentSubProcessConnectorResponseBuilder builder() {
+    return AiAgentSubProcessConnectorResponseBuilder.builder();
   }
 
   public record ToolCallElementActivation(String elementId, Map<String, Object> variables)

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/AiAgentSubProcessResponse.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/AiAgentSubProcessResponse.java
@@ -4,7 +4,7 @@
  * See the License.txt file for more information. You may not use this file
  * except in compliance with the proprietary license.
  */
-package io.camunda.connector.agenticai.aiagent.jobworker;
+package io.camunda.connector.agenticai.aiagent;
 
 import io.camunda.connector.agenticai.aiagent.model.AgentResponse;
 import io.camunda.connector.agenticai.model.AgenticAiRecord;

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/AiAgentTaskConnectorResponse.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/AiAgentTaskConnectorResponse.java
@@ -15,7 +15,7 @@ import org.springframework.lang.Nullable;
  * {@link AgentResponse} as a {@link StandardConnectorResponse} so the runtime evaluates it via
  * result expressions.
  */
-public record AiAgentTaskResponse(@Nullable AgentResponse agentResponse)
+public record AiAgentTaskConnectorResponse(@Nullable AgentResponse agentResponse)
     implements StandardConnectorResponse {
 
   @Override

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/AiAgentTaskResponse.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/AiAgentTaskResponse.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.agenticai.aiagent;
+
+import io.camunda.connector.agenticai.aiagent.model.AgentResponse;
+import io.camunda.connector.api.outbound.ConnectorResponse.StandardConnectorResponse;
+import org.springframework.lang.Nullable;
+
+/**
+ * Response type for the AI Agent task flavor (outbound connector on a service task). Wraps the
+ * {@link AgentResponse} as a {@link StandardConnectorResponse} so the runtime evaluates it via
+ * result expressions.
+ */
+public record AiAgentTaskResponse(@Nullable AgentResponse agentResponse)
+    implements StandardConnectorResponse {
+
+  @Override
+  public Object responseValue() {
+    return agentResponse;
+  }
+}

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/agent/AgentRequestHandler.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/agent/AgentRequestHandler.java
@@ -7,6 +7,7 @@
 package io.camunda.connector.agenticai.aiagent.agent;
 
 import io.camunda.connector.agenticai.aiagent.model.AgentExecutionContext;
+import io.camunda.connector.api.outbound.ConnectorResponse;
 
 /**
  * Main entry point for handling agent requests.
@@ -14,6 +15,6 @@ import io.camunda.connector.agenticai.aiagent.model.AgentExecutionContext;
  * <p>The agent response is expected to either return an agent response or to contain a list of tool
  * calls to handle through the process.
  */
-public interface AgentRequestHandler<C extends AgentExecutionContext, R> {
+public interface AgentRequestHandler<C extends AgentExecutionContext, R extends ConnectorResponse> {
   R handleRequest(C executionContext);
 }

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/agent/BaseAgentRequestHandler.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/agent/BaseAgentRequestHandler.java
@@ -22,6 +22,7 @@ import io.camunda.connector.agenticai.aiagent.tool.GatewayToolHandlerRegistry;
 import io.camunda.connector.agenticai.model.message.Message;
 import io.camunda.connector.agenticai.model.tool.ToolCallProcessVariable;
 import io.camunda.connector.agenticai.model.tool.ToolCallResult;
+import io.camunda.connector.api.outbound.ConnectorResponse;
 import java.util.List;
 import java.util.Optional;
 import org.apache.commons.lang3.tuple.Pair;
@@ -29,7 +30,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.lang.Nullable;
 
-public abstract class BaseAgentRequestHandler<C extends AgentExecutionContext, R>
+public abstract class BaseAgentRequestHandler<
+        C extends AgentExecutionContext, R extends ConnectorResponse>
     implements AgentRequestHandler<C, R> {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(BaseAgentRequestHandler.class);
@@ -71,14 +73,14 @@ public abstract class BaseAgentRequestHandler<C extends AgentExecutionContext, R
         LOGGER.debug(
             "AI Agent initialization returned direct response including {} tool calls. Completing job without further processing.",
             agentResponse.toolCalls().size());
-        yield completeJob(executionContext, agentResponse);
+        yield buildConnectorResponse(executionContext, agentResponse);
       }
 
       // discovery still in progress (not all tool call results present)
       case AgentDiscoveryInProgressInitializationResult ignored -> {
         LOGGER.debug(
             "AI Agent initialization tool discovery is still in progress. Completing job without further processing.");
-        yield completeJob(executionContext, null);
+        yield buildConnectorResponse(executionContext, null);
       }
 
       case AgentContextInitializationResult(
@@ -99,16 +101,16 @@ public abstract class BaseAgentRequestHandler<C extends AgentExecutionContext, R
     final var store =
         conversationStoreRegistry.getConversationStore(executionContext, agentContext);
 
-    AgentResponse agentResponse;
     try (var session = store.createSession(executionContext, agentContext)) {
-      agentResponse = processConversation(executionContext, agentContext, toolCallResults, session);
+      var agentResponse =
+          processConversation(executionContext, agentContext, toolCallResults, session);
+
+      LOGGER.debug(
+          "Request processing completed {} agent response, completing job",
+          agentResponse == null ? "without" : "with");
+
+      return buildConnectorResponse(executionContext, agentResponse);
     }
-
-    LOGGER.debug(
-        "Request processing completed {} agent response, completing job",
-        agentResponse == null ? "without" : "with");
-
-    return completeJob(executionContext, agentResponse);
   }
 
   private AgentResponse processConversation(
@@ -198,7 +200,7 @@ public abstract class BaseAgentRequestHandler<C extends AgentExecutionContext, R
     // no-op by default
   }
 
-  /** Handles job completion if needed. Agent response may be null. */
-  protected abstract R completeJob(
+  /** Builds the connector response from the agent response. Agent response may be null. */
+  protected abstract R buildConnectorResponse(
       final C executionContext, @Nullable final AgentResponse agentResponse);
 }

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/agent/BaseAgentRequestHandler.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/agent/BaseAgentRequestHandler.java
@@ -12,6 +12,7 @@ import io.camunda.connector.agenticai.aiagent.agent.AgentInitializationResult.Ag
 import io.camunda.connector.agenticai.aiagent.framework.AiFrameworkAdapter;
 import io.camunda.connector.agenticai.aiagent.memory.conversation.ConversationSession;
 import io.camunda.connector.agenticai.aiagent.memory.conversation.ConversationStoreRegistry;
+import io.camunda.connector.agenticai.aiagent.memory.conversation.ConversationStoreRequest;
 import io.camunda.connector.agenticai.aiagent.memory.runtime.MessageWindowRuntimeMemory;
 import io.camunda.connector.agenticai.aiagent.model.AgentContext;
 import io.camunda.connector.agenticai.aiagent.model.AgentExecutionContext;
@@ -93,15 +94,15 @@ public abstract class BaseAgentRequestHandler<C extends AgentExecutionContext, R
 
   private R handleRequest(
       final C executionContext,
-      final AgentContext agentContext,
+      AgentContext agentContext,
       final List<ToolCallResult> toolCallResults) {
-    final var conversationStore =
+    final var store =
         conversationStoreRegistry.getConversationStore(executionContext, agentContext);
-    final var agentResponse =
-        conversationStore.executeInSession(
-            executionContext,
-            agentContext,
-            session -> handleRequest(executionContext, agentContext, toolCallResults, session));
+
+    AgentResponse agentResponse;
+    try (var session = store.createSession(executionContext, agentContext)) {
+      agentResponse = processConversation(executionContext, agentContext, toolCallResults, session);
+    }
 
     LOGGER.debug(
         "Request processing completed {} agent response, completing job",
@@ -110,10 +111,10 @@ public abstract class BaseAgentRequestHandler<C extends AgentExecutionContext, R
     return completeJob(executionContext, agentResponse);
   }
 
-  private AgentResponse handleRequest(
+  private AgentResponse processConversation(
       final C executionContext,
       AgentContext agentContext,
-      List<ToolCallResult> toolCallResults,
+      final List<ToolCallResult> toolCallResults,
       ConversationSession session) {
     // set up memory and load from context if available
     final var runtimeMemory =
@@ -123,7 +124,8 @@ public abstract class BaseAgentRequestHandler<C extends AgentExecutionContext, R
                 .orElse(DEFAULT_CONTEXT_WINDOW_SIZE));
 
     LOGGER.trace("Loading previous conversation (if any) into runtime memory");
-    session.loadIntoRuntimeMemory(agentContext, runtimeMemory);
+    var loadResult = session.loadMessages(agentContext);
+    runtimeMemory.addMessages(loadResult.messages());
 
     // validate configured limits
     LOGGER.trace("Validating configured limits for agent execution");
@@ -179,7 +181,10 @@ public abstract class BaseAgentRequestHandler<C extends AgentExecutionContext, R
 
     // store memory reference to context
     LOGGER.debug("Storing runtime memory to conversation session");
-    agentContext = session.storeFromRuntimeMemory(agentContext, runtimeMemory);
+    var updatedConversation =
+        session.storeMessages(
+            agentContext, ConversationStoreRequest.of(runtimeMemory.allMessages()));
+    agentContext = agentContext.withConversation(updatedConversation);
 
     return responseHandler.createResponse(
         executionContext, agentContext, assistantMessage, processVariableToolCalls);

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/agent/BaseAgentRequestHandler.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/agent/BaseAgentRequestHandler.java
@@ -115,7 +115,7 @@ public abstract class BaseAgentRequestHandler<C extends AgentExecutionContext, R
       final C executionContext,
       AgentContext agentContext,
       final List<ToolCallResult> toolCallResults,
-      ConversationSession session) {
+      final ConversationSession session) {
     // set up memory and load from context if available
     final var runtimeMemory =
         new MessageWindowRuntimeMemory(

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/agent/JobWorkerAgentRequestHandler.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/agent/JobWorkerAgentRequestHandler.java
@@ -82,7 +82,7 @@ public class JobWorkerAgentRequestHandler
   }
 
   @Override
-  public AiAgentSubProcessResponse completeJob(
+  public AiAgentSubProcessResponse buildConnectorResponse(
       JobWorkerAgentExecutionContext executionContext, AgentResponse agentResponse) {
     if (agentResponse == null) {
       LOGGER.debug(

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/agent/JobWorkerAgentRequestHandler.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/agent/JobWorkerAgentRequestHandler.java
@@ -7,8 +7,8 @@
 package io.camunda.connector.agenticai.aiagent.agent;
 
 import io.camunda.connector.agenticai.aiagent.AiAgentJobWorker;
-import io.camunda.connector.agenticai.aiagent.AiAgentSubProcessResponse;
-import io.camunda.connector.agenticai.aiagent.AiAgentSubProcessResponse.ToolCallElementActivation;
+import io.camunda.connector.agenticai.aiagent.AiAgentSubProcessConnectorResponse;
+import io.camunda.connector.agenticai.aiagent.AiAgentSubProcessConnectorResponse.ToolCallElementActivation;
 import io.camunda.connector.agenticai.aiagent.framework.AiFrameworkAdapter;
 import io.camunda.connector.agenticai.aiagent.memory.conversation.ConversationStoreRegistry;
 import io.camunda.connector.agenticai.aiagent.model.AgentContext;
@@ -28,7 +28,8 @@ import org.slf4j.LoggerFactory;
 import org.springframework.util.CollectionUtils;
 
 public class JobWorkerAgentRequestHandler
-    extends BaseAgentRequestHandler<JobWorkerAgentExecutionContext, AiAgentSubProcessResponse> {
+    extends BaseAgentRequestHandler<
+        JobWorkerAgentExecutionContext, AiAgentSubProcessConnectorResponse> {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(JobWorkerAgentRequestHandler.class);
 
@@ -82,7 +83,7 @@ public class JobWorkerAgentRequestHandler
   }
 
   @Override
-  public AiAgentSubProcessResponse buildConnectorResponse(
+  public AiAgentSubProcessConnectorResponse buildConnectorResponse(
       JobWorkerAgentExecutionContext executionContext, AgentResponse agentResponse) {
     if (agentResponse == null) {
       LOGGER.debug(
@@ -91,7 +92,7 @@ public class JobWorkerAgentRequestHandler
 
       // no-op (do not activate elements, do not complete agent process) -> wait for next job to
       // proceed (e.g. by adding user messages or to complete tool call results)
-      return AiAgentSubProcessResponse.builder()
+      return AiAgentSubProcessConnectorResponse.builder()
           .completionConditionFulfilled(false)
           .cancelRemainingInstances(false)
           .build();
@@ -103,11 +104,11 @@ public class JobWorkerAgentRequestHandler
             agentResponse.toolCalls().stream().map(tc -> tc.metadata().name()).toList());
       }
 
-      return completeWithResponse(executionContext, agentResponse);
+      return buildResponse(executionContext, agentResponse);
     }
   }
 
-  private AiAgentSubProcessResponse completeWithResponse(
+  private AiAgentSubProcessConnectorResponse buildResponse(
       JobWorkerAgentExecutionContext executionContext, AgentResponse agentResponse) {
     boolean completionConditionFulfilled = agentResponse.toolCalls().isEmpty();
     boolean cancelRemainingInstances = executionContext.cancelRemainingInstances();
@@ -131,7 +132,7 @@ public class JobWorkerAgentRequestHandler
       variables.put(AiAgentJobWorker.TOOL_CALL_RESULTS_VARIABLE, List.of());
     }
 
-    return AiAgentSubProcessResponse.builder()
+    return AiAgentSubProcessConnectorResponse.builder()
         .responseValue(agentResponse)
         .variables(variables)
         .elementActivations(buildElementActivations(agentResponse))

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/agent/JobWorkerAgentRequestHandler.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/agent/JobWorkerAgentRequestHandler.java
@@ -7,9 +7,9 @@
 package io.camunda.connector.agenticai.aiagent.agent;
 
 import io.camunda.connector.agenticai.aiagent.AiAgentJobWorker;
+import io.camunda.connector.agenticai.aiagent.AiAgentSubProcessResponse;
+import io.camunda.connector.agenticai.aiagent.AiAgentSubProcessResponse.ToolCallElementActivation;
 import io.camunda.connector.agenticai.aiagent.framework.AiFrameworkAdapter;
-import io.camunda.connector.agenticai.aiagent.jobworker.AiAgentSubProcessResponse;
-import io.camunda.connector.agenticai.aiagent.jobworker.AiAgentSubProcessResponse.ToolCallElementActivation;
 import io.camunda.connector.agenticai.aiagent.memory.conversation.ConversationStoreRegistry;
 import io.camunda.connector.agenticai.aiagent.model.AgentContext;
 import io.camunda.connector.agenticai.aiagent.model.AgentResponse;

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/agent/OutboundConnectorAgentRequestHandler.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/agent/OutboundConnectorAgentRequestHandler.java
@@ -56,7 +56,7 @@ public class OutboundConnectorAgentRequestHandler
   }
 
   @Override
-  public AiAgentTaskResponse completeJob(
+  public AiAgentTaskResponse buildConnectorResponse(
       OutboundConnectorAgentExecutionContext executionContext, AgentResponse agentResponse) {
     return new AiAgentTaskResponse(agentResponse);
   }

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/agent/OutboundConnectorAgentRequestHandler.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/agent/OutboundConnectorAgentRequestHandler.java
@@ -8,7 +8,7 @@ package io.camunda.connector.agenticai.aiagent.agent;
 
 import static io.camunda.connector.agenticai.aiagent.agent.AgentErrorCodes.ERROR_CODE_NO_USER_MESSAGE_CONTENT;
 
-import io.camunda.connector.agenticai.aiagent.AiAgentTaskResponse;
+import io.camunda.connector.agenticai.aiagent.AiAgentTaskConnectorResponse;
 import io.camunda.connector.agenticai.aiagent.framework.AiFrameworkAdapter;
 import io.camunda.connector.agenticai.aiagent.memory.conversation.ConversationStoreRegistry;
 import io.camunda.connector.agenticai.aiagent.model.AgentContext;
@@ -21,7 +21,8 @@ import java.util.List;
 import org.springframework.util.CollectionUtils;
 
 public class OutboundConnectorAgentRequestHandler
-    extends BaseAgentRequestHandler<OutboundConnectorAgentExecutionContext, AiAgentTaskResponse> {
+    extends BaseAgentRequestHandler<
+        OutboundConnectorAgentExecutionContext, AiAgentTaskConnectorResponse> {
 
   public OutboundConnectorAgentRequestHandler(
       AgentInitializer agentInitializer,
@@ -56,8 +57,8 @@ public class OutboundConnectorAgentRequestHandler
   }
 
   @Override
-  public AiAgentTaskResponse buildConnectorResponse(
+  public AiAgentTaskConnectorResponse buildConnectorResponse(
       OutboundConnectorAgentExecutionContext executionContext, AgentResponse agentResponse) {
-    return new AiAgentTaskResponse(agentResponse);
+    return new AiAgentTaskConnectorResponse(agentResponse);
   }
 }

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/agent/OutboundConnectorAgentRequestHandler.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/agent/OutboundConnectorAgentRequestHandler.java
@@ -8,6 +8,7 @@ package io.camunda.connector.agenticai.aiagent.agent;
 
 import static io.camunda.connector.agenticai.aiagent.agent.AgentErrorCodes.ERROR_CODE_NO_USER_MESSAGE_CONTENT;
 
+import io.camunda.connector.agenticai.aiagent.AiAgentTaskResponse;
 import io.camunda.connector.agenticai.aiagent.framework.AiFrameworkAdapter;
 import io.camunda.connector.agenticai.aiagent.memory.conversation.ConversationStoreRegistry;
 import io.camunda.connector.agenticai.aiagent.model.AgentContext;
@@ -20,7 +21,7 @@ import java.util.List;
 import org.springframework.util.CollectionUtils;
 
 public class OutboundConnectorAgentRequestHandler
-    extends BaseAgentRequestHandler<OutboundConnectorAgentExecutionContext, AgentResponse> {
+    extends BaseAgentRequestHandler<OutboundConnectorAgentExecutionContext, AiAgentTaskResponse> {
 
   public OutboundConnectorAgentRequestHandler(
       AgentInitializer agentInitializer,
@@ -55,8 +56,8 @@ public class OutboundConnectorAgentRequestHandler
   }
 
   @Override
-  public AgentResponse completeJob(
+  public AiAgentTaskResponse completeJob(
       OutboundConnectorAgentExecutionContext executionContext, AgentResponse agentResponse) {
-    return agentResponse;
+    return new AiAgentTaskResponse(agentResponse);
   }
 }

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/memory/conversation/ConversationContext.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/memory/conversation/ConversationContext.java
@@ -13,8 +13,13 @@ import io.camunda.connector.agenticai.aiagent.memory.conversation.document.Camun
 import io.camunda.connector.agenticai.aiagent.memory.conversation.inprocess.InProcessConversationContext;
 
 /**
- * A record of a conversation, stored externally. This contains all the data needed to load the
- * conversation again.
+ * Storage cursor for a conversation. Contains all data needed to locate and load the conversation
+ * from the external store (e.g., a document reference, version number, or branch pointer).
+ *
+ * <p>This is persisted as part of the {@code agentContext} process variable in Zeebe and acts as
+ * the pointer in the write-ahead with pointer-based visibility contract — see {@link
+ * ConversationStore}. Implementations must be serializable and self-contained: they must not rely
+ * on external state that could change between turns.
  */
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
 @JsonSubTypes({

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/memory/conversation/ConversationLoadResult.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/memory/conversation/ConversationLoadResult.java
@@ -9,6 +9,7 @@ package io.camunda.connector.agenticai.aiagent.memory.conversation;
 import io.camunda.connector.agenticai.model.message.Message;
 import java.util.List;
 
+/** Result of loading a conversation from a {@link ConversationSession}. */
 public record ConversationLoadResult(List<Message> messages) {
 
   public static ConversationLoadResult of(List<Message> messages) {

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/memory/conversation/ConversationLoadResult.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/memory/conversation/ConversationLoadResult.java
@@ -8,12 +8,18 @@ package io.camunda.connector.agenticai.aiagent.memory.conversation;
 
 import io.camunda.connector.agenticai.model.message.Message;
 import java.util.List;
+import java.util.Objects;
 
 /** Result of loading a conversation from a {@link ConversationSession}. */
 public record ConversationLoadResult(List<Message> messages) {
 
+  public ConversationLoadResult {
+    Objects.requireNonNull(messages, "messages must not be null");
+    messages = List.copyOf(messages);
+  }
+
   public static ConversationLoadResult of(List<Message> messages) {
-    return new ConversationLoadResult(List.copyOf(messages));
+    return new ConversationLoadResult(messages);
   }
 
   public static ConversationLoadResult empty() {

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/memory/conversation/ConversationLoadResult.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/memory/conversation/ConversationLoadResult.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.agenticai.aiagent.memory.conversation;
+
+import io.camunda.connector.agenticai.model.message.Message;
+import java.util.List;
+
+public record ConversationLoadResult(List<Message> messages) {
+
+  public static ConversationLoadResult of(List<Message> messages) {
+    return new ConversationLoadResult(List.copyOf(messages));
+  }
+
+  public static ConversationLoadResult empty() {
+    return new ConversationLoadResult(List.of());
+  }
+}

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/memory/conversation/ConversationSession.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/memory/conversation/ConversationSession.java
@@ -8,14 +8,35 @@ package io.camunda.connector.agenticai.aiagent.memory.conversation;
 
 import io.camunda.connector.agenticai.aiagent.model.AgentContext;
 
+/**
+ * A per-turn session for loading and storing conversation messages. Created by {@link
+ * ConversationStore#createSession} and managed via try-with-resources.
+ *
+ * <p>Implementations must follow the write-ahead with pointer-based visibility contract described
+ * on {@link ConversationStore}: {@link #storeMessages} must write to a <b>new</b> location
+ * (version, snapshot, branch) and return a new {@link ConversationContext} pointing to it. It must
+ * never mutate or overwrite the data that the previous context points to.
+ *
+ * @see ConversationStore
+ */
 public interface ConversationSession extends AutoCloseable {
 
+  /**
+   * Loads the conversation history for the current agent context. The returned messages are those
+   * referenced by the {@link ConversationContext} in the given {@code agentContext} — not "latest"
+   * or "most recent", which would break retry safety.
+   *
+   * @return the loaded messages, or {@link ConversationLoadResult#empty()} if no previous
+   *     conversation exists
+   */
   ConversationLoadResult loadMessages(AgentContext agentContext);
 
   /**
-   * Stores messages and returns an updated ConversationContext (storage cursor). The caller is
-   * responsible for assembling the full AgentContext via {@code
-   * agentContext.withConversation(returnedContext)}.
+   * Persists the full message list and returns an updated {@link ConversationContext} (storage
+   * cursor) pointing to the newly written data. The caller is responsible for assembling the full
+   * {@code AgentContext} via {@code agentContext.withConversation(returnedContext)}.
+   *
+   * <p>Must write to a new location — never overwrite the data referenced by the current context.
    */
   ConversationContext storeMessages(AgentContext agentContext, ConversationStoreRequest request);
 

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/memory/conversation/ConversationSession.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/memory/conversation/ConversationSession.java
@@ -6,11 +6,19 @@
  */
 package io.camunda.connector.agenticai.aiagent.memory.conversation;
 
-import io.camunda.connector.agenticai.aiagent.memory.runtime.RuntimeMemory;
 import io.camunda.connector.agenticai.aiagent.model.AgentContext;
 
-public interface ConversationSession {
-  void loadIntoRuntimeMemory(AgentContext agentContext, RuntimeMemory memory);
+public interface ConversationSession extends AutoCloseable {
 
-  AgentContext storeFromRuntimeMemory(AgentContext agentContext, RuntimeMemory memory);
+  ConversationLoadResult loadMessages(AgentContext agentContext);
+
+  /**
+   * Stores messages and returns an updated ConversationContext (storage cursor). The caller is
+   * responsible for assembling the full AgentContext via {@code
+   * agentContext.withConversation(returnedContext)}.
+   */
+  ConversationContext storeMessages(AgentContext agentContext, ConversationStoreRequest request);
+
+  @Override
+  default void close() {}
 }

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/memory/conversation/ConversationStore.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/memory/conversation/ConversationStore.java
@@ -9,32 +9,10 @@ package io.camunda.connector.agenticai.aiagent.memory.conversation;
 import io.camunda.connector.agenticai.aiagent.model.AgentContext;
 import io.camunda.connector.agenticai.aiagent.model.AgentExecutionContext;
 
-/**
- * Responsible for storing and loading conversation records to external systems and loading them
- * into runtime memory.
- */
+/** Responsible for storing and loading conversation records to/from external systems. */
 public interface ConversationStore {
   String type();
 
-  /**
-   * Execute agent logic within a session handler which can take care of optional transactional
-   * behavior.
-   */
-  <T> T executeInSession(
-      AgentExecutionContext executionContext,
-      AgentContext agentContext,
-      ConversationSessionHandler<T> sessionHandler);
-
-  /**
-   * Entry point to compensate for failed job completion.
-   *
-   * <p>Note: this method is currently not called. Completion callback support will be added in a
-   * follow-up.
-   *
-   * @deprecated Not currently invoked. Will be re-integrated with completion callbacks in a
-   *     follow-up.
-   */
-  @Deprecated
-  default void compensateFailedJobCompletion(
-      AgentExecutionContext executionContext, AgentContext agentContext, Throwable failureReason) {}
+  ConversationSession createSession(
+      AgentExecutionContext executionContext, AgentContext agentContext);
 }

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/memory/conversation/ConversationStore.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/memory/conversation/ConversationStore.java
@@ -9,10 +9,27 @@ package io.camunda.connector.agenticai.aiagent.memory.conversation;
 import io.camunda.connector.agenticai.aiagent.model.AgentContext;
 import io.camunda.connector.agenticai.aiagent.model.AgentExecutionContext;
 
-/** Responsible for storing and loading conversation records to/from external systems. */
+/**
+ * Pluggable backend for persisting and loading conversation history.
+ *
+ * <p>All implementations must follow the <b>write-ahead with pointer-based visibility</b> contract:
+ * the {@link ConversationContext} returned by {@link ConversationSession#storeMessages} acts as a
+ * pointer to the stored data. That pointer only becomes authoritative once Zeebe accepts the job
+ * completion containing the updated {@code AgentContext}. If job completion fails, the retry uses
+ * the old pointer — so newly written data must never overwrite or mutate what the old pointer
+ * resolves to.
+ *
+ * @see ConversationSession
+ * @see ConversationContext
+ */
 public interface ConversationStore {
   String type();
 
+  /**
+   * Creates a new session for a single agent turn. The caller manages the session lifecycle via
+   * try-with-resources. Implementations may allocate external resources (connections, clients)
+   * here; they will be released when {@link ConversationSession#close()} is called.
+   */
   ConversationSession createSession(
       AgentExecutionContext executionContext, AgentContext agentContext);
 }

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/memory/conversation/ConversationStoreRequest.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/memory/conversation/ConversationStoreRequest.java
@@ -9,6 +9,7 @@ package io.camunda.connector.agenticai.aiagent.memory.conversation;
 import io.camunda.connector.agenticai.model.message.Message;
 import java.util.List;
 
+/** Request to store a conversation via {@link ConversationSession#storeMessages}. */
 public record ConversationStoreRequest(List<Message> messages) {
 
   public static ConversationStoreRequest of(List<Message> messages) {

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/memory/conversation/ConversationStoreRequest.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/memory/conversation/ConversationStoreRequest.java
@@ -6,7 +6,12 @@
  */
 package io.camunda.connector.agenticai.aiagent.memory.conversation;
 
-@FunctionalInterface
-public interface ConversationSessionHandler<T> {
-  T handleSession(ConversationSession session);
+import io.camunda.connector.agenticai.model.message.Message;
+import java.util.List;
+
+public record ConversationStoreRequest(List<Message> messages) {
+
+  public static ConversationStoreRequest of(List<Message> messages) {
+    return new ConversationStoreRequest(List.copyOf(messages));
+  }
 }

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/memory/conversation/ConversationStoreRequest.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/memory/conversation/ConversationStoreRequest.java
@@ -8,11 +8,17 @@ package io.camunda.connector.agenticai.aiagent.memory.conversation;
 
 import io.camunda.connector.agenticai.model.message.Message;
 import java.util.List;
+import java.util.Objects;
 
 /** Request to store a conversation via {@link ConversationSession#storeMessages}. */
 public record ConversationStoreRequest(List<Message> messages) {
 
+  public ConversationStoreRequest {
+    Objects.requireNonNull(messages, "messages must not be null");
+    messages = List.copyOf(messages);
+  }
+
   public static ConversationStoreRequest of(List<Message> messages) {
-    return new ConversationStoreRequest(List.copyOf(messages));
+    return new ConversationStoreRequest(messages);
   }
 }

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/memory/conversation/awsagentcore/AwsAgentCoreConversationSession.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/memory/conversation/awsagentcore/AwsAgentCoreConversationSession.java
@@ -8,9 +8,11 @@ package io.camunda.connector.agenticai.aiagent.memory.conversation.awsagentcore;
 
 import static io.camunda.connector.agenticai.aiagent.memory.conversation.ConversationUtil.loadConversationContext;
 
+import io.camunda.connector.agenticai.aiagent.memory.conversation.ConversationContext;
+import io.camunda.connector.agenticai.aiagent.memory.conversation.ConversationLoadResult;
 import io.camunda.connector.agenticai.aiagent.memory.conversation.ConversationSession;
+import io.camunda.connector.agenticai.aiagent.memory.conversation.ConversationStoreRequest;
 import io.camunda.connector.agenticai.aiagent.memory.conversation.awsagentcore.mapping.AwsAgentCoreConversationMapper;
-import io.camunda.connector.agenticai.aiagent.memory.runtime.RuntimeMemory;
 import io.camunda.connector.agenticai.aiagent.model.AgentContext;
 import io.camunda.connector.agenticai.aiagent.model.request.MemoryStorageConfiguration.AwsAgentCoreMemoryStorageConfiguration;
 import io.camunda.connector.agenticai.model.message.AssistantMessage;
@@ -41,8 +43,9 @@ import software.amazon.awssdk.services.bedrockagentcore.model.PayloadType;
 /**
  * Conversation session implementation for AWS AgentCore Memory.
  *
- * <p>Handles loading messages from AgentCore Memory into runtime memory and storing new messages
- * back to AgentCore Memory as conversational events.
+ * <p>Handles loading messages from AgentCore Memory and storing new messages back as conversational
+ * events. The session manages the lifecycle of the {@link BedrockAgentCoreClient} — it is closed
+ * when the session is closed.
  */
 public class AwsAgentCoreConversationSession implements ConversationSession {
 
@@ -72,18 +75,20 @@ public class AwsAgentCoreConversationSession implements ConversationSession {
   }
 
   @Override
-  public void loadIntoRuntimeMemory(AgentContext agentContext, RuntimeMemory memory) {
+  public ConversationLoadResult loadMessages(AgentContext agentContext) {
     previousConversationContext =
         loadConversationContext(agentContext, AwsAgentCoreConversationContext.class);
 
     validateConfigurationConsistency();
+
+    final List<Message> result = new ArrayList<>();
 
     if (previousConversationContext != null) {
       sessionId = previousConversationContext.conversationId();
       branchName = previousConversationContext.branchName();
       lastEventId = previousConversationContext.lastEventId();
       if (previousConversationContext.systemMessage() != null) {
-        memory.addMessage(previousConversationContext.systemMessage());
+        result.add(previousConversationContext.systemMessage());
       }
     } else {
       sessionId = UUID.randomUUID().toString();
@@ -91,18 +96,21 @@ public class AwsAgentCoreConversationSession implements ConversationSession {
 
     final List<Message> messages = loadMessagesFromAgentCore(sessionId, branchName);
     initialMessageCount = messages.size();
-    memory.addMessages(messages);
+    result.addAll(messages);
 
     LOGGER.debug(
         "Loaded {} messages from AgentCore Memory for session '{}' branch '{}'",
         messages.size(),
         sessionId,
         branchName != null ? branchName : "<main>");
+
+    return ConversationLoadResult.of(result);
   }
 
   @Override
-  public AgentContext storeFromRuntimeMemory(AgentContext agentContext, RuntimeMemory memory) {
-    final List<Message> allMessages = memory.allMessages();
+  public ConversationContext storeMessages(
+      AgentContext agentContext, ConversationStoreRequest request) {
+    final List<Message> allMessages = request.messages();
 
     // extract system message — needs to be preserved in context since AgentCore doesn't support it
     final SystemMessage systemMessage =
@@ -152,12 +160,16 @@ public class AwsAgentCoreConversationSession implements ConversationSession {
                 .memoryId(config.memoryId())
                 .actorId(config.actorId());
 
-    return agentContext.withConversation(
-        conversationContextBuilder
-            .branchName(branchName)
-            .lastEventId(lastEventId)
-            .systemMessage(systemMessage)
-            .build());
+    return conversationContextBuilder
+        .branchName(branchName)
+        .lastEventId(lastEventId)
+        .systemMessage(systemMessage)
+        .build();
+  }
+
+  @Override
+  public void close() {
+    client.close();
   }
 
   /**

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/memory/conversation/awsagentcore/AwsAgentCoreConversationStore.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/memory/conversation/awsagentcore/AwsAgentCoreConversationStore.java
@@ -6,7 +6,7 @@
  */
 package io.camunda.connector.agenticai.aiagent.memory.conversation.awsagentcore;
 
-import io.camunda.connector.agenticai.aiagent.memory.conversation.ConversationSessionHandler;
+import io.camunda.connector.agenticai.aiagent.memory.conversation.ConversationSession;
 import io.camunda.connector.agenticai.aiagent.memory.conversation.ConversationStore;
 import io.camunda.connector.agenticai.aiagent.memory.conversation.awsagentcore.mapping.AwsAgentCoreConversationMapper;
 import io.camunda.connector.agenticai.aiagent.model.AgentContext;
@@ -42,10 +42,8 @@ public class AwsAgentCoreConversationStore implements ConversationStore {
   }
 
   @Override
-  public <T> T executeInSession(
-      AgentExecutionContext executionContext,
-      AgentContext agentContext,
-      ConversationSessionHandler<T> sessionHandler) {
+  public ConversationSession createSession(
+      AgentExecutionContext executionContext, AgentContext agentContext) {
     final var config =
         Optional.ofNullable(executionContext.memory())
             .map(MemoryConfiguration::storage)
@@ -57,11 +55,8 @@ public class AwsAgentCoreConversationStore implements ConversationStore {
               .formatted(config != null ? config.getClass().getName() : "null"));
     }
 
-    try (BedrockAgentCoreClient client = clientFactory.createClient(agentCoreConfig)) {
-      final var session =
-          new AwsAgentCoreConversationSession(agentCoreConfig, client, conversationMapper);
-      return sessionHandler.handleSession(session);
-    }
+    final BedrockAgentCoreClient client = clientFactory.createClient(agentCoreConfig);
+    return new AwsAgentCoreConversationSession(agentCoreConfig, client, conversationMapper);
   }
 
   /** Factory interface for creating BedrockAgentCoreClient instances. */

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/memory/conversation/document/CamundaDocumentConversationSession.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/memory/conversation/document/CamundaDocumentConversationSession.java
@@ -9,11 +9,14 @@ package io.camunda.connector.agenticai.aiagent.memory.conversation.document;
 import static io.camunda.connector.agenticai.aiagent.memory.conversation.ConversationUtil.loadConversationContext;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import io.camunda.connector.agenticai.aiagent.memory.conversation.ConversationContext;
+import io.camunda.connector.agenticai.aiagent.memory.conversation.ConversationLoadResult;
 import io.camunda.connector.agenticai.aiagent.memory.conversation.ConversationSession;
-import io.camunda.connector.agenticai.aiagent.memory.runtime.RuntimeMemory;
+import io.camunda.connector.agenticai.aiagent.memory.conversation.ConversationStoreRequest;
 import io.camunda.connector.agenticai.aiagent.model.AgentContext;
 import io.camunda.connector.agenticai.aiagent.model.AgentExecutionContext;
 import io.camunda.connector.agenticai.aiagent.model.request.MemoryStorageConfiguration.CamundaDocumentMemoryStorageConfiguration;
+import io.camunda.connector.agenticai.model.message.Message;
 import io.camunda.connector.api.document.Document;
 import io.camunda.connector.api.document.DocumentCreationRequest;
 import io.camunda.connector.api.document.DocumentFactory;
@@ -77,24 +80,25 @@ public class CamundaDocumentConversationSession implements ConversationSession {
   }
 
   @Override
-  public void loadIntoRuntimeMemory(AgentContext agentContext, RuntimeMemory memory) {
+  public ConversationLoadResult loadMessages(AgentContext agentContext) {
     previousConversationContext =
         loadConversationContext(agentContext, CamundaDocumentConversationContext.class);
     if (previousConversationContext == null) {
-      return;
+      return ConversationLoadResult.empty();
     }
 
     try {
       final var content =
           conversationSerializer.readDocumentContent(previousConversationContext.document());
-      memory.addMessages(content.messages());
+      return ConversationLoadResult.of(content.messages());
     } catch (IOException e) {
       throw new RuntimeException("Failed to load conversation from documentReference", e);
     }
   }
 
   @Override
-  public AgentContext storeFromRuntimeMemory(AgentContext agentContext, RuntimeMemory memory) {
+  public ConversationContext storeMessages(
+      AgentContext agentContext, ConversationStoreRequest request) {
     final var conversationContextBuilder =
         previousConversationContext != null
             ? previousConversationContext.with()
@@ -102,7 +106,7 @@ public class CamundaDocumentConversationSession implements ConversationSession {
                 .conversationId(UUID.randomUUID().toString());
 
     final var updatedDocument =
-        createUpdatedDocument(memory, conversationContextBuilder.conversationId());
+        createUpdatedDocument(request.messages(), conversationContextBuilder.conversationId());
     conversationContextBuilder.document(updatedDocument);
 
     // after write succeeded, try to purge previous documents, but keep at least the last
@@ -115,12 +119,11 @@ public class CamundaDocumentConversationSession implements ConversationSession {
       conversationContextBuilder.previousDocuments(purgePreviousDocuments(previousDocuments));
     }
 
-    return agentContext.withConversation(conversationContextBuilder.build());
+    return conversationContextBuilder.build();
   }
 
-  private Document createUpdatedDocument(RuntimeMemory memory, String conversationId) {
-    final var content =
-        new CamundaDocumentConversationContext.DocumentContent(memory.allMessages());
+  private Document createUpdatedDocument(List<Message> messages, String conversationId) {
+    final var content = new CamundaDocumentConversationContext.DocumentContent(messages);
 
     String serialized;
     try {

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/memory/conversation/document/CamundaDocumentConversationStore.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/memory/conversation/document/CamundaDocumentConversationStore.java
@@ -7,7 +7,7 @@
 package io.camunda.connector.agenticai.aiagent.memory.conversation.document;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.camunda.connector.agenticai.aiagent.memory.conversation.ConversationSessionHandler;
+import io.camunda.connector.agenticai.aiagent.memory.conversation.ConversationSession;
 import io.camunda.connector.agenticai.aiagent.memory.conversation.ConversationStore;
 import io.camunda.connector.agenticai.aiagent.model.AgentContext;
 import io.camunda.connector.agenticai.aiagent.model.AgentExecutionContext;
@@ -40,10 +40,8 @@ public class CamundaDocumentConversationStore implements ConversationStore {
   }
 
   @Override
-  public <T> T executeInSession(
-      AgentExecutionContext executionContext,
-      AgentContext agentContext,
-      ConversationSessionHandler<T> sessionHandler) {
+  public ConversationSession createSession(
+      AgentExecutionContext executionContext, AgentContext agentContext) {
     final var config =
         Optional.ofNullable(executionContext.memory())
             .map(MemoryConfiguration::storage)
@@ -55,14 +53,7 @@ public class CamundaDocumentConversationStore implements ConversationStore {
               .formatted(config != null ? config.getClass().getName() : "null"));
     }
 
-    final var session =
-        new CamundaDocumentConversationSession(
-            documentConfig,
-            documentFactory,
-            documentStore,
-            conversationSerializer,
-            executionContext);
-
-    return sessionHandler.handleSession(session);
+    return new CamundaDocumentConversationSession(
+        documentConfig, documentFactory, documentStore, conversationSerializer, executionContext);
   }
 }

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/memory/conversation/inprocess/InProcessConversationSession.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/memory/conversation/inprocess/InProcessConversationSession.java
@@ -8,8 +8,10 @@ package io.camunda.connector.agenticai.aiagent.memory.conversation.inprocess;
 
 import static io.camunda.connector.agenticai.aiagent.memory.conversation.ConversationUtil.loadConversationContext;
 
+import io.camunda.connector.agenticai.aiagent.memory.conversation.ConversationContext;
+import io.camunda.connector.agenticai.aiagent.memory.conversation.ConversationLoadResult;
 import io.camunda.connector.agenticai.aiagent.memory.conversation.ConversationSession;
-import io.camunda.connector.agenticai.aiagent.memory.runtime.RuntimeMemory;
+import io.camunda.connector.agenticai.aiagent.memory.conversation.ConversationStoreRequest;
 import io.camunda.connector.agenticai.aiagent.model.AgentContext;
 import java.util.UUID;
 
@@ -18,26 +20,24 @@ public class InProcessConversationSession implements ConversationSession {
   private InProcessConversationContext previousConversationContext;
 
   @Override
-  public void loadIntoRuntimeMemory(AgentContext agentContext, RuntimeMemory memory) {
+  public ConversationLoadResult loadMessages(AgentContext agentContext) {
     previousConversationContext =
         loadConversationContext(agentContext, InProcessConversationContext.class);
     if (previousConversationContext == null) {
-      return;
+      return ConversationLoadResult.empty();
     }
 
-    memory.addMessages(previousConversationContext.messages());
+    return ConversationLoadResult.of(previousConversationContext.messages());
   }
 
   @Override
-  public AgentContext storeFromRuntimeMemory(AgentContext agentContext, RuntimeMemory memory) {
+  public ConversationContext storeMessages(
+      AgentContext agentContext, ConversationStoreRequest request) {
     final var conversationContextBuilder =
         previousConversationContext != null
             ? previousConversationContext.with()
             : InProcessConversationContext.builder().conversationId(UUID.randomUUID().toString());
 
-    final var conversationContext =
-        conversationContextBuilder.messages(memory.allMessages()).build();
-
-    return agentContext.withConversation(conversationContext);
+    return conversationContextBuilder.messages(request.messages()).build();
   }
 }

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/memory/conversation/inprocess/InProcessConversationStore.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/memory/conversation/inprocess/InProcessConversationStore.java
@@ -6,7 +6,7 @@
  */
 package io.camunda.connector.agenticai.aiagent.memory.conversation.inprocess;
 
-import io.camunda.connector.agenticai.aiagent.memory.conversation.ConversationSessionHandler;
+import io.camunda.connector.agenticai.aiagent.memory.conversation.ConversationSession;
 import io.camunda.connector.agenticai.aiagent.memory.conversation.ConversationStore;
 import io.camunda.connector.agenticai.aiagent.model.AgentContext;
 import io.camunda.connector.agenticai.aiagent.model.AgentExecutionContext;
@@ -20,10 +20,8 @@ public class InProcessConversationStore implements ConversationStore {
   }
 
   @Override
-  public <T> T executeInSession(
-      AgentExecutionContext executionContext,
-      AgentContext agentContext,
-      ConversationSessionHandler<T> sessionHandler) {
-    return sessionHandler.handleSession(new InProcessConversationSession());
+  public ConversationSession createSession(
+      AgentExecutionContext executionContext, AgentContext agentContext) {
+    return new InProcessConversationSession();
   }
 }

--- a/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/agent/OutboundConnectorAgentRequestHandlerTest.java
+++ b/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/agent/OutboundConnectorAgentRequestHandlerTest.java
@@ -115,7 +115,7 @@ class OutboundConnectorAgentRequestHandlerTest {
         .thenReturn(new AgentResponseInitializationResult(agentResponse));
 
     final var response = requestHandler.handleRequest(agentExecutionContext);
-    assertThat(response).isEqualTo(agentResponse);
+    assertThat(response.agentResponse()).isEqualTo(agentResponse);
 
     verifyNoInteractions(
         limitsValidator, messagesHandler, gatewayToolHandlers, framework, responseHandler);
@@ -159,17 +159,20 @@ class OutboundConnectorAgentRequestHandlerTest {
     assertThat(runtimeMemoryCaptor.getValue().allMessages())
         .containsExactlyElementsOf(expectedMessages);
 
-    assertThat(response.context().state()).isEqualTo(AgentState.READY);
-    assertThat(response.context().metrics()).isEqualTo(new AgentMetrics(1, new TokenUsage(10, 20)));
-    assertThat(response.context().conversation())
+    var agentResponse = response.agentResponse();
+    assertThat(agentResponse).isNotNull();
+    assertThat(agentResponse.context().state()).isEqualTo(AgentState.READY);
+    assertThat(agentResponse.context().metrics())
+        .isEqualTo(new AgentMetrics(1, new TokenUsage(10, 20)));
+    assertThat(agentResponse.context().conversation())
         .isNotNull()
         .isInstanceOfSatisfying(
             InProcessConversationContext.class,
             c -> assertThat(c.messages()).containsExactlyElementsOf(expectedMessages));
 
-    assertThat(response.responseMessage()).isEqualTo(assistantMessage);
-    assertThat(response.responseText()).isEqualTo(assistantMessageText);
-    assertThat(response.toolCalls()).isEmpty();
+    assertThat(agentResponse.responseMessage()).isEqualTo(assistantMessage);
+    assertThat(agentResponse.responseText()).isEqualTo(assistantMessageText);
+    assertThat(agentResponse.toolCalls()).isEmpty();
 
     verify(limitsValidator).validateConfiguredLimits(agentExecutionContext, INITIAL_AGENT_CONTEXT);
   }
@@ -217,17 +220,20 @@ class OutboundConnectorAgentRequestHandlerTest {
     assertThat(runtimeMemoryCaptor.getValue().allMessages())
         .containsExactlyElementsOf(expectedMessages);
 
-    assertThat(response.context().state()).isEqualTo(AgentState.READY);
-    assertThat(response.context().metrics()).isEqualTo(new AgentMetrics(1, new TokenUsage(10, 20)));
-    assertThat(response.context().conversation())
+    var agentResponse = response.agentResponse();
+    assertThat(agentResponse).isNotNull();
+    assertThat(agentResponse.context().state()).isEqualTo(AgentState.READY);
+    assertThat(agentResponse.context().metrics())
+        .isEqualTo(new AgentMetrics(1, new TokenUsage(10, 20)));
+    assertThat(agentResponse.context().conversation())
         .isNotNull()
         .isInstanceOfSatisfying(
             InProcessConversationContext.class,
             c -> assertThat(c.messages()).containsExactlyElementsOf(expectedMessages));
 
-    assertThat(response.responseMessage()).isEqualTo(assistantMessage);
-    assertThat(response.responseText()).isNull();
-    assertThat(response.toolCalls())
+    assertThat(agentResponse.responseMessage()).isEqualTo(assistantMessage);
+    assertThat(agentResponse.responseText()).isNull();
+    assertThat(agentResponse.toolCalls())
         .containsExactly(
             new ToolCallProcessVariable(
                 new ToolCallProcessVariable.ToolCallMetadata("abcdef_transformed", "getWeather"),

--- a/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/memory/conversation/awsagentcore/AwsAgentCoreConversationStoreTest.java
+++ b/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/memory/conversation/awsagentcore/AwsAgentCoreConversationStoreTest.java
@@ -18,17 +18,16 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import io.camunda.connector.agenticai.aiagent.memory.conversation.ConversationStoreRequest;
 import io.camunda.connector.agenticai.aiagent.memory.conversation.awsagentcore.AwsAgentCoreConversationStore.BedrockAgentCoreClientFactory;
 import io.camunda.connector.agenticai.aiagent.memory.conversation.awsagentcore.mapping.AwsAgentCoreConversationMapper;
-import io.camunda.connector.agenticai.aiagent.memory.runtime.DefaultRuntimeMemory;
-import io.camunda.connector.agenticai.aiagent.memory.runtime.RuntimeMemory;
 import io.camunda.connector.agenticai.aiagent.model.AgentContext;
 import io.camunda.connector.agenticai.aiagent.model.AgentExecutionContext;
-import io.camunda.connector.agenticai.aiagent.model.AgentResponse;
 import io.camunda.connector.agenticai.aiagent.model.request.MemoryConfiguration;
 import io.camunda.connector.agenticai.aiagent.model.request.MemoryStorageConfiguration.AwsAgentCoreMemoryStorageConfiguration;
 import io.camunda.connector.agenticai.aiagent.model.request.MemoryStorageConfiguration.InProcessMemoryStorageConfiguration;
 import io.camunda.connector.agenticai.model.message.AssistantMessage;
+import io.camunda.connector.agenticai.model.message.Message;
 import io.camunda.connector.agenticai.model.message.SystemMessage;
 import io.camunda.connector.agenticai.model.message.ToolCallResultMessage;
 import io.camunda.connector.agenticai.model.message.UserMessage;
@@ -36,6 +35,7 @@ import io.camunda.connector.agenticai.model.tool.ToolCall;
 import io.camunda.connector.agenticai.model.tool.ToolCallResult;
 import io.camunda.connector.agenticai.util.TestObjectMapperSupplier;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import org.json.JSONException;
@@ -78,7 +78,6 @@ class AwsAgentCoreConversationStoreTest {
   @Captor private ArgumentCaptor<ListEventsRequest> listEventsRequestCaptor;
 
   private AwsAgentCoreConversationStore store;
-  private RuntimeMemory memory;
   private AwsAgentCoreMemoryStorageConfiguration config;
 
   @BeforeEach
@@ -95,7 +94,6 @@ class AwsAgentCoreConversationStoreTest {
     var conversationMapper = new AwsAgentCoreConversationMapper(TestObjectMapperSupplier.INSTANCE);
 
     store = new AwsAgentCoreConversationStore(clientFactory, conversationMapper);
-    memory = new DefaultRuntimeMemory();
   }
 
   @Test
@@ -108,15 +106,7 @@ class AwsAgentCoreConversationStoreTest {
     final var agentContext = AgentContext.empty();
     when(executionContext.memory()).thenReturn(new MemoryConfiguration(null, 20));
 
-    assertThatThrownBy(
-            () ->
-                store.executeInSession(
-                    executionContext,
-                    agentContext,
-                    session -> {
-                      session.loadIntoRuntimeMemory(agentContext, memory);
-                      return agentResponse(agentContext);
-                    }))
+    assertThatThrownBy(() -> store.createSession(executionContext, agentContext))
         .isInstanceOf(IllegalStateException.class)
         .hasMessage(
             "Expected memory storage configuration to be of type AwsAgentCoreMemoryStorageConfiguration, but got: null");
@@ -128,15 +118,7 @@ class AwsAgentCoreConversationStoreTest {
     when(executionContext.memory())
         .thenReturn(new MemoryConfiguration(new InProcessMemoryStorageConfiguration(), 20));
 
-    assertThatThrownBy(
-            () ->
-                store.executeInSession(
-                    executionContext,
-                    agentContext,
-                    session -> {
-                      session.loadIntoRuntimeMemory(agentContext, memory);
-                      return agentResponse(agentContext);
-                    }))
+    assertThatThrownBy(() -> store.createSession(executionContext, agentContext))
         .isInstanceOf(IllegalStateException.class)
         .hasMessageStartingWith(
             "Expected memory storage configuration to be of type AwsAgentCoreMemoryStorageConfiguration, but got:")
@@ -163,16 +145,13 @@ class AwsAgentCoreConversationStoreTest {
             createEvent(Role.ASSISTANT, "Hi there!", Instant.now().minusSeconds(30)));
     mockListEventsResponse(events);
 
-    store.executeInSession(
-        executionContext,
-        agentContext,
-        session -> {
-          session.loadIntoRuntimeMemory(agentContext, memory);
-          return agentResponse(agentContext);
-        });
+    try (var session = store.createSession(executionContext, agentContext)) {
+      var loadResult = session.loadMessages(agentContext);
 
-    // Verify messages were loaded
-    assertThat(memory.allMessages()).hasSize(2);
+      // Verify messages were loaded
+      assertThat(loadResult.messages()).hasSize(2);
+    }
+
     verify(bedrockClient).listEventsPaginator(listEventsRequestCaptor.capture());
     final var request = listEventsRequestCaptor.getValue();
     assertThat(request.memoryId()).isEqualTo(MEMORY_ID);
@@ -197,17 +176,15 @@ class AwsAgentCoreConversationStoreTest {
     when(bedrockClient.createEvent(any(CreateEventRequest.class)))
         .thenReturn(createEventResponse());
 
-    final var result =
-        store.executeInSession(
-            executionContext,
-            agentContext,
-            session -> {
-              session.loadIntoRuntimeMemory(agentContext, memory);
-              // Add messages to memory
-              memory.addMessage(userMessage("Hello!"));
-              memory.addMessage(assistantMessage("Hi there!"));
-              return agentResponse(session.storeFromRuntimeMemory(agentContext, memory));
-            });
+    AgentContext updatedAgentContext;
+    try (var session = store.createSession(executionContext, agentContext)) {
+      session.loadMessages(agentContext);
+
+      List<Message> messages = List.of(userMessage("Hello!"), assistantMessage("Hi there!"));
+      var updatedConversation =
+          session.storeMessages(agentContext, ConversationStoreRequest.of(messages));
+      updatedAgentContext = agentContext.withConversation(updatedConversation);
+    }
 
     // Verify messages were stored
     verify(bedrockClient, times(2)).createEvent(createEventRequestCaptor.capture());
@@ -223,7 +200,7 @@ class AwsAgentCoreConversationStoreTest {
     assertThat(requests.get(0).branch()).isNull();
 
     // Verify conversation context was updated
-    final var conversation = result.context().conversation();
+    final var conversation = updatedAgentContext.conversation();
     assertThat(conversation).isInstanceOf(AwsAgentCoreConversationContext.class);
     final var agentCoreContext = (AwsAgentCoreConversationContext) conversation;
     assertThat(agentCoreContext.memoryId()).isEqualTo(MEMORY_ID);
@@ -256,15 +233,15 @@ class AwsAgentCoreConversationStoreTest {
     when(bedrockClient.createEvent(any(CreateEventRequest.class)))
         .thenReturn(createEventResponse());
 
-    store.executeInSession(
-        executionContext,
-        agentContext,
-        session -> {
-          session.loadIntoRuntimeMemory(agentContext, memory);
-          // Add one new message
-          memory.addMessage(userMessage("What's the weather?"));
-          return agentResponse(session.storeFromRuntimeMemory(agentContext, memory));
-        });
+    try (var session = store.createSession(executionContext, agentContext)) {
+      var loadResult = session.loadMessages(agentContext);
+
+      // Build messages list: loaded + one new
+      var allMessages = new ArrayList<>(loadResult.messages());
+      allMessages.add(userMessage("What's the weather?"));
+
+      session.storeMessages(agentContext, ConversationStoreRequest.of(allMessages));
+    }
 
     // Verify only 1 new message was stored (not the existing 2)
     verify(bedrockClient, times(1)).createEvent(createEventRequestCaptor.capture());
@@ -282,20 +259,19 @@ class AwsAgentCoreConversationStoreTest {
     // Mock empty list events response
     mockListEventsResponse(List.of());
 
-    final var result =
-        store.executeInSession(
-            executionContext,
-            agentContext,
-            session -> {
-              session.loadIntoRuntimeMemory(agentContext, memory);
-              return agentResponse(session.storeFromRuntimeMemory(agentContext, memory));
-            });
+    AgentContext updatedAgentContext;
+    try (var session = store.createSession(executionContext, agentContext)) {
+      var loadResult = session.loadMessages(agentContext);
+      assertThat(loadResult.messages()).isEmpty();
 
-    assertThat(memory.allMessages()).isEmpty();
+      var updatedConversation =
+          session.storeMessages(agentContext, ConversationStoreRequest.of(List.of()));
+      updatedAgentContext = agentContext.withConversation(updatedConversation);
+    }
 
     // Verify conversation context was created
-    final var conversation = result.context().conversation();
-    assertThat(conversation).isInstanceOf(AwsAgentCoreConversationContext.class);
+    assertThat(updatedAgentContext.conversation())
+        .isInstanceOf(AwsAgentCoreConversationContext.class);
   }
 
   @Test
@@ -304,13 +280,9 @@ class AwsAgentCoreConversationStoreTest {
     final var agentContext = AgentContext.empty();
     mockListEventsResponse(List.of());
 
-    store.executeInSession(
-        executionContext,
-        agentContext,
-        session -> {
-          session.loadIntoRuntimeMemory(agentContext, memory);
-          return agentResponse(agentContext);
-        });
+    try (var session = store.createSession(executionContext, agentContext)) {
+      session.loadMessages(agentContext);
+    }
 
     // Verify client factory was called with config including authentication
     verify(clientFactory).createClient(config);
@@ -336,19 +308,20 @@ class AwsAgentCoreConversationStoreTest {
     when(bedrockClient.createEvent(any(CreateEventRequest.class)))
         .thenReturn(createEventResponse());
 
-    final var result =
-        store.executeInSession(
-            executionContext,
-            agentContext,
-            session -> {
-              session.loadIntoRuntimeMemory(agentContext, memory);
-              // Add system message (should be skipped from AgentCore), user message, and assistant
-              // message
-              memory.addMessage(systemMessage("You are a helpful assistant."));
-              memory.addMessage(userMessage("Hello!"));
-              memory.addMessage(assistantMessage("Hi there!"));
-              return agentResponse(session.storeFromRuntimeMemory(agentContext, memory));
-            });
+    AwsAgentCoreConversationContext agentCoreContext;
+    try (var session = store.createSession(executionContext, agentContext)) {
+      session.loadMessages(agentContext);
+
+      // Add system message (should be skipped from AgentCore), user message, and assistant message
+      List<Message> messages =
+          List.of(
+              systemMessage("You are a helpful assistant."),
+              userMessage("Hello!"),
+              assistantMessage("Hi there!"));
+      var updatedConversation =
+          session.storeMessages(agentContext, ConversationStoreRequest.of(messages));
+      agentCoreContext = (AwsAgentCoreConversationContext) updatedConversation;
+    }
 
     // Verify only 2 messages were stored to AgentCore (user and assistant), system message was
     // skipped
@@ -359,9 +332,6 @@ class AwsAgentCoreConversationStoreTest {
     assertThat(requests.get(1).clientToken()).endsWith(":1");
 
     // Verify conversation context was updated with branch info
-    final var conversation = result.context().conversation();
-    assertThat(conversation).isInstanceOf(AwsAgentCoreConversationContext.class);
-    final var agentCoreContext = (AwsAgentCoreConversationContext) conversation;
     assertThat(agentCoreContext.lastEventId()).isNotNull();
 
     // Verify system message is preserved in the context
@@ -391,19 +361,15 @@ class AwsAgentCoreConversationStoreTest {
             createEvent(Role.ASSISTANT, "Hi there!", Instant.now().minusSeconds(30)));
     mockListEventsResponse(events);
 
-    store.executeInSession(
-        executionContext,
-        agentContext,
-        session -> {
-          session.loadIntoRuntimeMemory(agentContext, memory);
-          return agentResponse(agentContext);
-        });
+    try (var session = store.createSession(executionContext, agentContext)) {
+      var loadResult = session.loadMessages(agentContext);
 
-    // Verify 3 messages in memory: 1 system (restored) + 2 from AgentCore
-    assertThat(memory.allMessages()).hasSize(3);
-    assertThat(memory.allMessages().get(0)).isInstanceOf(SystemMessage.class);
-    assertThat(memory.allMessages().get(1)).isInstanceOf(UserMessage.class);
-    assertThat(memory.allMessages().get(2)).isInstanceOf(AssistantMessage.class);
+      // Verify 3 messages: 1 system (restored) + 2 from AgentCore
+      assertThat(loadResult.messages()).hasSize(3);
+      assertThat(loadResult.messages().get(0)).isInstanceOf(SystemMessage.class);
+      assertThat(loadResult.messages().get(1)).isInstanceOf(UserMessage.class);
+      assertThat(loadResult.messages().get(2)).isInstanceOf(AssistantMessage.class);
+    }
   }
 
   @Test
@@ -431,17 +397,16 @@ class AwsAgentCoreConversationStoreTest {
     final var toolCall2 =
         ToolCall.builder().id("call_456").name("getTime").arguments(Map.of()).build();
 
-    store.executeInSession(
-        executionContext,
-        agentContext,
-        session -> {
-          session.loadIntoRuntimeMemory(agentContext, memory);
-          memory.addMessage(userMessage("What's the weather and time in Seattle?"));
-          memory.addMessage(
+    try (var session = store.createSession(executionContext, agentContext)) {
+      session.loadMessages(agentContext);
+
+      List<Message> messages =
+          List.of(
+              userMessage("What's the weather and time in Seattle?"),
               assistantMessage(
                   "Let me check the weather and time for you.", List.of(toolCall1, toolCall2)));
-          return agentResponse(session.storeFromRuntimeMemory(agentContext, memory));
-        });
+      session.storeMessages(agentContext, ConversationStoreRequest.of(messages));
+    }
 
     // Verify 2 messages were stored
     verify(bedrockClient, times(2)).createEvent(createEventRequestCaptor.capture());
@@ -514,19 +479,15 @@ class AwsAgentCoreConversationStoreTest {
 
     mockListEventsResponse(List.of(event));
 
-    store.executeInSession(
-        executionContext,
-        agentContext,
-        session -> {
-          session.loadIntoRuntimeMemory(agentContext, memory);
-          return agentResponse(agentContext);
-        });
+    try (var session = store.createSession(executionContext, agentContext)) {
+      var loadResult = session.loadMessages(agentContext);
 
-    assertThat(memory.allMessages()).hasSize(1);
-    final var assistantMessage = (AssistantMessage) memory.allMessages().get(0);
-    assertThat(assistantMessage.hasToolCalls()).isTrue();
-    assertThat(assistantMessage.toolCalls()).hasSize(1);
-    assertThat(assistantMessage.toolCalls().get(0).id()).isEqualTo("call_123");
+      assertThat(loadResult.messages()).hasSize(1);
+      final var assistantMessage = (AssistantMessage) loadResult.messages().get(0);
+      assertThat(assistantMessage.hasToolCalls()).isTrue();
+      assertThat(assistantMessage.toolCalls()).hasSize(1);
+      assertThat(assistantMessage.toolCalls().get(0).id()).isEqualTo("call_123");
+    }
   }
 
   @Test
@@ -558,21 +519,17 @@ class AwsAgentCoreConversationStoreTest {
 
     mockListEventsResponse(List.of(event));
 
-    store.executeInSession(
-        executionContext,
-        agentContext,
-        session -> {
-          session.loadIntoRuntimeMemory(agentContext, memory);
-          return agentResponse(agentContext);
-        });
+    try (var session = store.createSession(executionContext, agentContext)) {
+      var loadResult = session.loadMessages(agentContext);
 
-    assertThat(memory.allMessages()).hasSize(1);
-    assertThat(memory.allMessages().get(0)).isInstanceOf(ToolCallResultMessage.class);
+      assertThat(loadResult.messages()).hasSize(1);
+      assertThat(loadResult.messages().get(0)).isInstanceOf(ToolCallResultMessage.class);
 
-    final var msg = (ToolCallResultMessage) memory.allMessages().get(0);
-    assertThat(msg.results()).hasSize(1);
-    assertThat(msg.results().get(0)).isInstanceOf(ToolCallResult.class);
-    assertThat(msg.results().get(0).content()).isEqualTo("tool output");
+      final var msg = (ToolCallResultMessage) loadResult.messages().get(0);
+      assertThat(msg.results()).hasSize(1);
+      assertThat(msg.results().get(0)).isInstanceOf(ToolCallResult.class);
+      assertThat(msg.results().get(0).content()).isEqualTo("tool output");
+    }
   }
 
   @Test
@@ -609,27 +566,23 @@ class AwsAgentCoreConversationStoreTest {
 
     mockListEventsResponse(List.of(event));
 
-    store.executeInSession(
-        executionContext,
-        agentContext,
-        session -> {
-          session.loadIntoRuntimeMemory(agentContext, memory);
-          return agentResponse(agentContext);
-        });
+    try (var session = store.createSession(executionContext, agentContext)) {
+      var loadResult = session.loadMessages(agentContext);
 
-    assertThat(memory.allMessages()).hasSize(1);
-    final var assistantMessage = (AssistantMessage) memory.allMessages().get(0);
+      assertThat(loadResult.messages()).hasSize(1);
+      final var assistantMessage = (AssistantMessage) loadResult.messages().get(0);
 
-    assertThat(assistantMessage.content()).hasSize(1);
-    assertThat(
-            ((io.camunda.connector.agenticai.model.message.content.TextContent)
-                    assistantMessage.content().get(0))
-                .text())
-        .isEqualTo("Let me check the weather for you.");
+      assertThat(assistantMessage.content()).hasSize(1);
+      assertThat(
+              ((io.camunda.connector.agenticai.model.message.content.TextContent)
+                      assistantMessage.content().get(0))
+                  .text())
+          .isEqualTo("Let me check the weather for you.");
 
-    assertThat(assistantMessage.hasToolCalls()).isTrue();
-    assertThat(assistantMessage.toolCalls()).hasSize(1);
-    assertThat(assistantMessage.toolCalls().get(0).id()).isEqualTo("call_123");
+      assertThat(assistantMessage.hasToolCalls()).isTrue();
+      assertThat(assistantMessage.toolCalls()).hasSize(1);
+      assertThat(assistantMessage.toolCalls().get(0).id()).isEqualTo("call_123");
+    }
   }
 
   @Test
@@ -659,23 +612,19 @@ class AwsAgentCoreConversationStoreTest {
 
     mockListEventsResponse(List.of(event));
 
-    store.executeInSession(
-        executionContext,
-        agentContext,
-        session -> {
-          session.loadIntoRuntimeMemory(agentContext, memory);
-          return agentResponse(agentContext);
-        });
+    try (var session = store.createSession(executionContext, agentContext)) {
+      var loadResult = session.loadMessages(agentContext);
 
-    assertThat(memory.allMessages()).hasSize(1);
-    final var assistantMessage = (AssistantMessage) memory.allMessages().get(0);
+      assertThat(loadResult.messages()).hasSize(1);
+      final var assistantMessage = (AssistantMessage) loadResult.messages().get(0);
 
-    // No assistant text was stored => empty content list
-    assertThat(assistantMessage.content()).isEmpty();
+      // No assistant text was stored => empty content list
+      assertThat(assistantMessage.content()).isEmpty();
 
-    assertThat(assistantMessage.hasToolCalls()).isTrue();
-    assertThat(assistantMessage.toolCalls()).hasSize(1);
-    assertThat(assistantMessage.toolCalls().get(0).id()).isEqualTo("call_123");
+      assertThat(assistantMessage.hasToolCalls()).isTrue();
+      assertThat(assistantMessage.toolCalls()).hasSize(1);
+      assertThat(assistantMessage.toolCalls().get(0).id()).isEqualTo("call_123");
+    }
   }
 
   @Test
@@ -696,16 +645,15 @@ class AwsAgentCoreConversationStoreTest {
         .thenThrow(BedrockAgentCoreException.builder().message("Service unavailable").build());
 
     assertThatThrownBy(
-            () ->
-                store.executeInSession(
-                    executionContext,
-                    agentContext,
-                    session -> {
-                      session.loadIntoRuntimeMemory(agentContext, memory);
-                      memory.addMessage(userMessage("Hello!"));
-                      memory.addMessage(assistantMessage("Hi there!"));
-                      return agentResponse(session.storeFromRuntimeMemory(agentContext, memory));
-                    }))
+            () -> {
+              try (var session = store.createSession(executionContext, agentContext)) {
+                session.loadMessages(agentContext);
+
+                List<Message> messages =
+                    List.of(userMessage("Hello!"), assistantMessage("Hi there!"));
+                session.storeMessages(agentContext, ConversationStoreRequest.of(messages));
+              }
+            })
         .isInstanceOf(IllegalStateException.class)
         .hasMessage("Failed to store conversation event to AgentCore Memory")
         .hasCauseInstanceOf(BedrockAgentCoreException.class);
@@ -731,14 +679,11 @@ class AwsAgentCoreConversationStoreTest {
         .thenThrow(BedrockAgentCoreException.builder().message("Access denied").build());
 
     assertThatThrownBy(
-            () ->
-                store.executeInSession(
-                    executionContext,
-                    agentContext,
-                    session -> {
-                      session.loadIntoRuntimeMemory(agentContext, memory);
-                      return agentResponse(agentContext);
-                    }))
+            () -> {
+              try (var session = store.createSession(executionContext, agentContext)) {
+                session.loadMessages(agentContext);
+              }
+            })
         .isInstanceOf(IllegalStateException.class)
         .hasMessage("Failed to load conversation history from AgentCore Memory")
         .hasCauseInstanceOf(BedrockAgentCoreException.class);
@@ -758,24 +703,20 @@ class AwsAgentCoreConversationStoreTest {
         .thenReturn(
             CreateEventResponse.builder().event(Event.builder().eventId("evt-2").build()).build());
 
-    final var turn1Result =
-        store.executeInSession(
-            executionContext,
-            turn1Context,
-            session -> {
-              session.loadIntoRuntimeMemory(turn1Context, memory);
-              memory.addMessage(userMessage("Hello!"));
-              memory.addMessage(assistantMessage("Hi there!"));
-              return agentResponse(session.storeFromRuntimeMemory(turn1Context, memory));
-            });
+    AwsAgentCoreConversationContext turn1ConversationContext;
+    try (var session = store.createSession(executionContext, turn1Context)) {
+      session.loadMessages(turn1Context);
 
-    final var turn1ConversationContext =
-        (AwsAgentCoreConversationContext) turn1Result.context().conversation();
+      List<Message> messages = List.of(userMessage("Hello!"), assistantMessage("Hi there!"));
+      var updatedConversation =
+          session.storeMessages(turn1Context, ConversationStoreRequest.of(messages));
+      turn1ConversationContext = (AwsAgentCoreConversationContext) updatedConversation;
+    }
+
     assertThat(turn1ConversationContext.branchName()).isNull();
     assertThat(turn1ConversationContext.lastEventId()).isEqualTo("evt-2");
 
     // === Turn 2: fork a new branch from evt-2 ===
-    final var turn2Memory = new DefaultRuntimeMemory();
     final var turn2Context = AgentContext.builder().conversation(turn1ConversationContext).build();
 
     final var turn2Events =
@@ -789,16 +730,18 @@ class AwsAgentCoreConversationStoreTest {
         .thenReturn(
             CreateEventResponse.builder().event(Event.builder().eventId("evt-4").build()).build());
 
-    final var turn2Result =
-        store.executeInSession(
-            executionContext,
-            turn2Context,
-            session -> {
-              session.loadIntoRuntimeMemory(turn2Context, turn2Memory);
-              turn2Memory.addMessage(userMessage("What's the weather?"));
-              turn2Memory.addMessage(assistantMessage("It's sunny!"));
-              return agentResponse(session.storeFromRuntimeMemory(turn2Context, turn2Memory));
-            });
+    AwsAgentCoreConversationContext turn2ConversationContext;
+    try (var session = store.createSession(executionContext, turn2Context)) {
+      var loadResult = session.loadMessages(turn2Context);
+
+      var allMessages = new ArrayList<>(loadResult.messages());
+      allMessages.add(userMessage("What's the weather?"));
+      allMessages.add(assistantMessage("It's sunny!"));
+
+      var updatedConversation =
+          session.storeMessages(turn2Context, ConversationStoreRequest.of(allMessages));
+      turn2ConversationContext = (AwsAgentCoreConversationContext) updatedConversation;
+    }
 
     // Capture all createEvent calls across both turns
     verify(bedrockClient, times(4)).createEvent(createEventRequestCaptor.capture());
@@ -815,8 +758,6 @@ class AwsAgentCoreConversationStoreTest {
     // Both events in turn 2 use the same branch
     assertThat(allRequests.get(3).branch().name()).isEqualTo(allRequests.get(2).branch().name());
 
-    final var turn2ConversationContext =
-        (AwsAgentCoreConversationContext) turn2Result.context().conversation();
     assertThat(turn2ConversationContext.branchName()).isEqualTo(allRequests.get(2).branch().name());
     assertThat(turn2ConversationContext.lastEventId()).isEqualTo("evt-4");
   }
@@ -846,14 +787,11 @@ class AwsAgentCoreConversationStoreTest {
             clientFactory, new AwsAgentCoreConversationMapper(TestObjectMapperSupplier.INSTANCE));
 
     assertThatThrownBy(
-            () ->
-                changedStore.executeInSession(
-                    executionContext,
-                    turn1Context,
-                    session -> {
-                      session.loadIntoRuntimeMemory(turn1Context, memory);
-                      return agentResponse(session.storeFromRuntimeMemory(turn1Context, memory));
-                    }))
+            () -> {
+              try (var session = changedStore.createSession(executionContext, turn1Context)) {
+                session.loadMessages(turn1Context);
+              }
+            })
         .isInstanceOf(IllegalStateException.class)
         .hasMessageContaining("memoryId changed between iterations");
   }
@@ -883,14 +821,11 @@ class AwsAgentCoreConversationStoreTest {
             clientFactory, new AwsAgentCoreConversationMapper(TestObjectMapperSupplier.INSTANCE));
 
     assertThatThrownBy(
-            () ->
-                changedStore.executeInSession(
-                    executionContext,
-                    turn1Context,
-                    session -> {
-                      session.loadIntoRuntimeMemory(turn1Context, memory);
-                      return agentResponse(session.storeFromRuntimeMemory(turn1Context, memory));
-                    }))
+            () -> {
+              try (var session = changedStore.createSession(executionContext, turn1Context)) {
+                session.loadMessages(turn1Context);
+              }
+            })
         .isInstanceOf(IllegalStateException.class)
         .hasMessageContaining("actorId changed between iterations");
   }
@@ -908,19 +843,26 @@ class AwsAgentCoreConversationStoreTest {
     mockListEventsResponse(events);
 
     // when
-    store.executeInSession(
-        executionContext,
-        agentContext,
-        session -> {
-          session.loadIntoRuntimeMemory(agentContext, memory);
+    try (var session = store.createSession(executionContext, agentContext)) {
+      var loadResult = session.loadMessages(agentContext);
 
-          // then - messages should be ordered by seq: User (0) before Assistant (1)
-          var messages = memory.allMessages();
-          assertThat(messages).hasSize(2);
-          assertThat(messages.get(0)).isInstanceOf(UserMessage.class);
-          assertThat(messages.get(1)).isInstanceOf(AssistantMessage.class);
-          return agentResponse(session.storeFromRuntimeMemory(agentContext, memory));
-        });
+      // then - messages should be ordered by seq: User (0) before Assistant (1)
+      assertThat(loadResult.messages()).hasSize(2);
+      assertThat(loadResult.messages().get(0)).isInstanceOf(UserMessage.class);
+      assertThat(loadResult.messages().get(1)).isInstanceOf(AssistantMessage.class);
+    }
+  }
+
+  @Test
+  void closesClientWhenSessionIsClosed() {
+    final var agentContext = AgentContext.empty();
+    mockListEventsResponse(List.of());
+
+    var session = store.createSession(executionContext, agentContext);
+    session.loadMessages(agentContext);
+    session.close();
+
+    verify(bedrockClient).close();
   }
 
   private Event createEventWithSeq(Role role, String text, Instant timestamp, String seq) {
@@ -967,9 +909,5 @@ class AwsAgentCoreConversationStoreTest {
     return CreateEventResponse.builder()
         .event(Event.builder().eventId("evt-" + (++eventCounter)).build())
         .build();
-  }
-
-  private AgentResponse agentResponse(AgentContext agentContext) {
-    return AgentResponse.builder().context(agentContext).toolCalls(List.of()).build();
   }
 }

--- a/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/memory/conversation/document/CamundaDocumentConversationStoreTest.java
+++ b/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/memory/conversation/document/CamundaDocumentConversationStoreTest.java
@@ -17,13 +17,11 @@ import static org.mockito.Mockito.when;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.connector.agenticai.aiagent.TestMessagesFixture;
+import io.camunda.connector.agenticai.aiagent.memory.conversation.ConversationStoreRequest;
 import io.camunda.connector.agenticai.aiagent.memory.conversation.TestConversationContext;
 import io.camunda.connector.agenticai.aiagent.memory.conversation.document.CamundaDocumentConversationContext.DocumentContent;
-import io.camunda.connector.agenticai.aiagent.memory.runtime.DefaultRuntimeMemory;
-import io.camunda.connector.agenticai.aiagent.memory.runtime.RuntimeMemory;
 import io.camunda.connector.agenticai.aiagent.model.AgentContext;
 import io.camunda.connector.agenticai.aiagent.model.AgentExecutionContext;
-import io.camunda.connector.agenticai.aiagent.model.AgentResponse;
 import io.camunda.connector.agenticai.aiagent.model.request.MemoryConfiguration;
 import io.camunda.connector.agenticai.aiagent.model.request.MemoryStorageConfiguration;
 import io.camunda.connector.agenticai.aiagent.model.request.MemoryStorageConfiguration.CamundaDocumentMemoryStorageConfiguration;
@@ -76,7 +74,6 @@ class CamundaDocumentConversationStoreTest {
   private AgentExecutionContext executionContext;
 
   private CamundaDocumentConversationStore store;
-  private RuntimeMemory memory;
 
   @Captor private ArgumentCaptor<DocumentCreationRequest> documentCreationRequestCaptor;
 
@@ -90,8 +87,6 @@ class CamundaDocumentConversationStoreTest {
                 20));
 
     store = new CamundaDocumentConversationStore(documentFactory, documentStore, objectMapper);
-
-    memory = new DefaultRuntimeMemory();
   }
 
   @Test
@@ -106,15 +101,7 @@ class CamundaDocumentConversationStoreTest {
     final var agentContext = AgentContext.empty();
     when(executionContext.memory()).thenReturn(new MemoryConfiguration(null, 20));
 
-    assertThatThrownBy(
-            () ->
-                store.executeInSession(
-                    executionContext,
-                    agentContext,
-                    session -> {
-                      session.loadIntoRuntimeMemory(agentContext, memory);
-                      return agentResponse(agentContext);
-                    }))
+    assertThatThrownBy(() -> store.createSession(executionContext, agentContext))
         .isInstanceOf(IllegalStateException.class)
         .hasMessage(
             "Expected memory storage configuration to be of type CamundaDocumentMemoryStorageConfiguration, but got: null");
@@ -128,15 +115,7 @@ class CamundaDocumentConversationStoreTest {
             new MemoryConfiguration(
                 new MemoryStorageConfiguration.InProcessMemoryStorageConfiguration(), 20));
 
-    assertThatThrownBy(
-            () ->
-                store.executeInSession(
-                    executionContext,
-                    agentContext,
-                    session -> {
-                      session.loadIntoRuntimeMemory(agentContext, memory);
-                      return agentResponse(agentContext);
-                    }))
+    assertThatThrownBy(() -> store.createSession(executionContext, agentContext))
         .isInstanceOf(IllegalStateException.class)
         .hasMessageStartingWith(
             "Expected memory storage configuration to be of type CamundaDocumentMemoryStorageConfiguration, but got:")
@@ -147,15 +126,10 @@ class CamundaDocumentConversationStoreTest {
   void supportsAgentContextWithoutPreviousConversation() {
     final var agentContext = AgentContext.empty();
 
-    store.executeInSession(
-        executionContext,
-        agentContext,
-        session -> {
-          session.loadIntoRuntimeMemory(agentContext, memory);
-          return agentResponse(agentContext);
-        });
+    var session = store.createSession(executionContext, agentContext);
+    var loadResult = session.loadMessages(agentContext);
 
-    assertThat(memory.allMessages()).isEmpty();
+    assertThat(loadResult.messages()).isEmpty();
   }
 
   @Test
@@ -169,15 +143,10 @@ class CamundaDocumentConversationStoreTest {
 
     final var agentContext = AgentContext.empty().withConversation(previousConversationContext);
 
-    store.executeInSession(
-        executionContext,
-        agentContext,
-        session -> {
-          session.loadIntoRuntimeMemory(agentContext, memory);
-          return agentResponse(agentContext);
-        });
+    var session = store.createSession(executionContext, agentContext);
+    var loadResult = session.loadMessages(agentContext);
 
-    assertThat(memory.allMessages()).containsExactlyElementsOf(TEST_MESSAGES);
+    assertThat(loadResult.messages()).containsExactlyElementsOf(TEST_MESSAGES);
   }
 
   @Test
@@ -185,35 +154,27 @@ class CamundaDocumentConversationStoreTest {
     final var agentContext =
         AgentContext.empty().withConversation(new TestConversationContext("dummy"));
 
-    assertThatThrownBy(
-            () ->
-                store.executeInSession(
-                    executionContext,
-                    agentContext,
-                    session -> {
-                      session.loadIntoRuntimeMemory(agentContext, memory);
-                      return agentResponse(agentContext);
-                    }))
+    var session = store.createSession(executionContext, agentContext);
+
+    assertThatThrownBy(() -> session.loadMessages(agentContext))
         .isInstanceOf(IllegalStateException.class)
         .hasMessage("Unsupported conversation context: TestConversationContext");
   }
 
   @Test
-  void storesRuntimeMemoryIntoAgentContext_withEmptyPreviousConversation() throws Exception {
+  void storesMessagesIntoConversationContext_withEmptyPreviousConversation() throws Exception {
     mockJobContext();
-    memory.addMessages(TEST_MESSAGES);
 
     final var document = mock(Document.class);
     when(documentFactory.create(documentCreationRequestCaptor.capture())).thenReturn(document);
 
     final var agentContext = AgentContext.empty();
-    final var updatedAgentContext =
-        store
-            .executeInSession(
-                executionContext,
-                agentContext,
-                session -> agentResponse(session.storeFromRuntimeMemory(agentContext, memory)))
-            .context();
+
+    var session = store.createSession(executionContext, agentContext);
+    session.loadMessages(agentContext);
+    var updatedConversation =
+        session.storeMessages(agentContext, ConversationStoreRequest.of(TEST_MESSAGES));
+    var updatedAgentContext = agentContext.withConversation(updatedConversation);
 
     assertThat(updatedAgentContext.conversation())
         .asInstanceOf(InstanceOfAssertFactories.type(CamundaDocumentConversationContext.class))
@@ -233,7 +194,7 @@ class CamundaDocumentConversationStoreTest {
   }
 
   @Test
-  void storesRuntimeMemoryIntoAgentContext_withExistingPreviousConversation() throws Exception {
+  void storesMessagesIntoConversationContext_withExistingPreviousConversation() throws Exception {
     mockJobContext();
 
     final var previousDocument = mock(Document.class);
@@ -251,19 +212,16 @@ class CamundaDocumentConversationStoreTest {
     final var userMessage = userMessage("User message");
 
     final var agentContext = AgentContext.empty().withConversation(previousConversationContext);
-    final var updatedAgentContext =
-        store
-            .executeInSession(
-                executionContext,
-                agentContext,
-                session -> {
-                  session.loadIntoRuntimeMemory(agentContext, memory);
 
-                  memory.addMessage(userMessage);
+    var session = store.createSession(executionContext, agentContext);
+    var loadResult = session.loadMessages(agentContext);
 
-                  return agentResponse(session.storeFromRuntimeMemory(agentContext, memory));
-                })
-            .context();
+    final var allMessages = new ArrayList<>(loadResult.messages());
+    allMessages.add(userMessage);
+
+    var updatedConversation =
+        session.storeMessages(agentContext, ConversationStoreRequest.of(allMessages));
+    var updatedAgentContext = agentContext.withConversation(updatedConversation);
 
     assertThat(updatedAgentContext.conversation())
         .asInstanceOf(InstanceOfAssertFactories.type(CamundaDocumentConversationContext.class))
@@ -318,16 +276,12 @@ class CamundaDocumentConversationStoreTest {
     when(documentFactory.create(documentCreationRequestCaptor.capture())).thenReturn(newDocument);
 
     final var agentContext = AgentContext.empty().withConversation(previousConversationContext);
-    final var updatedAgentContext =
-        store
-            .executeInSession(
-                executionContext,
-                agentContext,
-                session -> {
-                  session.loadIntoRuntimeMemory(agentContext, memory);
-                  return agentResponse(session.storeFromRuntimeMemory(agentContext, memory));
-                })
-            .context();
+
+    var session = store.createSession(executionContext, agentContext);
+    var loadResult = session.loadMessages(agentContext);
+    var updatedConversation =
+        session.storeMessages(agentContext, ConversationStoreRequest.of(loadResult.messages()));
+    var updatedAgentContext = agentContext.withConversation(updatedConversation);
 
     assertThat(updatedAgentContext.conversation())
         .asInstanceOf(InstanceOfAssertFactories.type(CamundaDocumentConversationContext.class))
@@ -372,16 +326,12 @@ class CamundaDocumentConversationStoreTest {
     when(documentFactory.create(documentCreationRequestCaptor.capture())).thenReturn(newDocument);
 
     final var agentContext = AgentContext.empty().withConversation(previousConversationContext);
-    final var updatedAgentContext =
-        store
-            .executeInSession(
-                executionContext,
-                agentContext,
-                session -> {
-                  session.loadIntoRuntimeMemory(agentContext, memory);
-                  return agentResponse(session.storeFromRuntimeMemory(agentContext, memory));
-                })
-            .context();
+
+    var session = store.createSession(executionContext, agentContext);
+    var loadResult = session.loadMessages(agentContext);
+    var updatedConversation =
+        session.storeMessages(agentContext, ConversationStoreRequest.of(loadResult.messages()));
+    var updatedAgentContext = agentContext.withConversation(updatedConversation);
 
     assertThat(updatedAgentContext.conversation())
         .asInstanceOf(InstanceOfAssertFactories.type(CamundaDocumentConversationContext.class))
@@ -395,10 +345,6 @@ class CamundaDocumentConversationStoreTest {
                       previousDocuments.get(2),
                       previousDocument);
             });
-  }
-
-  private AgentResponse agentResponse(AgentContext agentContext) {
-    return AgentResponse.builder().context(agentContext).build();
   }
 
   private void assertDocumentCreationRequest(

--- a/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/memory/conversation/document/CamundaDocumentConversationStoreTest.java
+++ b/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/memory/conversation/document/CamundaDocumentConversationStoreTest.java
@@ -126,10 +126,11 @@ class CamundaDocumentConversationStoreTest {
   void supportsAgentContextWithoutPreviousConversation() {
     final var agentContext = AgentContext.empty();
 
-    var session = store.createSession(executionContext, agentContext);
-    var loadResult = session.loadMessages(agentContext);
+    try (var session = store.createSession(executionContext, agentContext)) {
+      var loadResult = session.loadMessages(agentContext);
 
-    assertThat(loadResult.messages()).isEmpty();
+      assertThat(loadResult.messages()).isEmpty();
+    }
   }
 
   @Test
@@ -143,10 +144,11 @@ class CamundaDocumentConversationStoreTest {
 
     final var agentContext = AgentContext.empty().withConversation(previousConversationContext);
 
-    var session = store.createSession(executionContext, agentContext);
-    var loadResult = session.loadMessages(agentContext);
+    try (var session = store.createSession(executionContext, agentContext)) {
+      var loadResult = session.loadMessages(agentContext);
 
-    assertThat(loadResult.messages()).containsExactlyElementsOf(TEST_MESSAGES);
+      assertThat(loadResult.messages()).containsExactlyElementsOf(TEST_MESSAGES);
+    }
   }
 
   @Test
@@ -154,11 +156,11 @@ class CamundaDocumentConversationStoreTest {
     final var agentContext =
         AgentContext.empty().withConversation(new TestConversationContext("dummy"));
 
-    var session = store.createSession(executionContext, agentContext);
-
-    assertThatThrownBy(() -> session.loadMessages(agentContext))
-        .isInstanceOf(IllegalStateException.class)
-        .hasMessage("Unsupported conversation context: TestConversationContext");
+    try (var session = store.createSession(executionContext, agentContext)) {
+      assertThatThrownBy(() -> session.loadMessages(agentContext))
+          .isInstanceOf(IllegalStateException.class)
+          .hasMessage("Unsupported conversation context: TestConversationContext");
+    }
   }
 
   @Test
@@ -170,11 +172,13 @@ class CamundaDocumentConversationStoreTest {
 
     final var agentContext = AgentContext.empty();
 
-    var session = store.createSession(executionContext, agentContext);
-    session.loadMessages(agentContext);
-    var updatedConversation =
-        session.storeMessages(agentContext, ConversationStoreRequest.of(TEST_MESSAGES));
-    var updatedAgentContext = agentContext.withConversation(updatedConversation);
+    AgentContext updatedAgentContext;
+    try (var session = store.createSession(executionContext, agentContext)) {
+      session.loadMessages(agentContext);
+      var updatedConversation =
+          session.storeMessages(agentContext, ConversationStoreRequest.of(TEST_MESSAGES));
+      updatedAgentContext = agentContext.withConversation(updatedConversation);
+    }
 
     assertThat(updatedAgentContext.conversation())
         .asInstanceOf(InstanceOfAssertFactories.type(CamundaDocumentConversationContext.class))
@@ -213,15 +217,17 @@ class CamundaDocumentConversationStoreTest {
 
     final var agentContext = AgentContext.empty().withConversation(previousConversationContext);
 
-    var session = store.createSession(executionContext, agentContext);
-    var loadResult = session.loadMessages(agentContext);
+    AgentContext updatedAgentContext;
+    try (var session = store.createSession(executionContext, agentContext)) {
+      var loadResult = session.loadMessages(agentContext);
 
-    final var allMessages = new ArrayList<>(loadResult.messages());
-    allMessages.add(userMessage);
+      final var allMessages = new ArrayList<>(loadResult.messages());
+      allMessages.add(userMessage);
 
-    var updatedConversation =
-        session.storeMessages(agentContext, ConversationStoreRequest.of(allMessages));
-    var updatedAgentContext = agentContext.withConversation(updatedConversation);
+      var updatedConversation =
+          session.storeMessages(agentContext, ConversationStoreRequest.of(allMessages));
+      updatedAgentContext = agentContext.withConversation(updatedConversation);
+    }
 
     assertThat(updatedAgentContext.conversation())
         .asInstanceOf(InstanceOfAssertFactories.type(CamundaDocumentConversationContext.class))
@@ -277,11 +283,13 @@ class CamundaDocumentConversationStoreTest {
 
     final var agentContext = AgentContext.empty().withConversation(previousConversationContext);
 
-    var session = store.createSession(executionContext, agentContext);
-    var loadResult = session.loadMessages(agentContext);
-    var updatedConversation =
-        session.storeMessages(agentContext, ConversationStoreRequest.of(loadResult.messages()));
-    var updatedAgentContext = agentContext.withConversation(updatedConversation);
+    AgentContext updatedAgentContext;
+    try (var session = store.createSession(executionContext, agentContext)) {
+      var loadResult = session.loadMessages(agentContext);
+      var updatedConversation =
+          session.storeMessages(agentContext, ConversationStoreRequest.of(loadResult.messages()));
+      updatedAgentContext = agentContext.withConversation(updatedConversation);
+    }
 
     assertThat(updatedAgentContext.conversation())
         .asInstanceOf(InstanceOfAssertFactories.type(CamundaDocumentConversationContext.class))
@@ -327,11 +335,13 @@ class CamundaDocumentConversationStoreTest {
 
     final var agentContext = AgentContext.empty().withConversation(previousConversationContext);
 
-    var session = store.createSession(executionContext, agentContext);
-    var loadResult = session.loadMessages(agentContext);
-    var updatedConversation =
-        session.storeMessages(agentContext, ConversationStoreRequest.of(loadResult.messages()));
-    var updatedAgentContext = agentContext.withConversation(updatedConversation);
+    AgentContext updatedAgentContext;
+    try (var session = store.createSession(executionContext, agentContext)) {
+      var loadResult = session.loadMessages(agentContext);
+      var updatedConversation =
+          session.storeMessages(agentContext, ConversationStoreRequest.of(loadResult.messages()));
+      updatedAgentContext = agentContext.withConversation(updatedConversation);
+    }
 
     assertThat(updatedAgentContext.conversation())
         .asInstanceOf(InstanceOfAssertFactories.type(CamundaDocumentConversationContext.class))

--- a/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/memory/conversation/inprocess/InProcessConversationStoreTest.java
+++ b/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/memory/conversation/inprocess/InProcessConversationStoreTest.java
@@ -45,10 +45,11 @@ class InProcessConversationStoreTest {
   void supportsAgentContextWithoutPreviousConversation() {
     final var agentContext = AgentContext.empty();
 
-    var session = store.createSession(executionContext, agentContext);
-    var loadResult = session.loadMessages(agentContext);
+    try (var session = store.createSession(executionContext, agentContext)) {
+      var loadResult = session.loadMessages(agentContext);
 
-    assertThat(loadResult.messages()).isEmpty();
+      assertThat(loadResult.messages()).isEmpty();
+    }
   }
 
   @Test
@@ -58,10 +59,11 @@ class InProcessConversationStoreTest {
 
     final var agentContext = AgentContext.empty().withConversation(previousConversationContext);
 
-    var session = store.createSession(executionContext, agentContext);
-    var loadResult = session.loadMessages(agentContext);
+    try (var session = store.createSession(executionContext, agentContext)) {
+      var loadResult = session.loadMessages(agentContext);
 
-    assertThat(loadResult.messages()).containsExactlyElementsOf(TEST_MESSAGES);
+      assertThat(loadResult.messages()).containsExactlyElementsOf(TEST_MESSAGES);
+    }
   }
 
   @Test
@@ -69,30 +71,31 @@ class InProcessConversationStoreTest {
     final var agentContext =
         AgentContext.empty().withConversation(new TestConversationContext("dummy"));
 
-    var session = store.createSession(executionContext, agentContext);
-
-    assertThatThrownBy(() -> session.loadMessages(agentContext))
-        .isInstanceOf(IllegalStateException.class)
-        .hasMessage("Unsupported conversation context: TestConversationContext");
+    try (var session = store.createSession(executionContext, agentContext)) {
+      assertThatThrownBy(() -> session.loadMessages(agentContext))
+          .isInstanceOf(IllegalStateException.class)
+          .hasMessage("Unsupported conversation context: TestConversationContext");
+    }
   }
 
   @Test
   void storesMessagesIntoConversationContext_withEmptyPreviousConversation() {
     final var agentContext = AgentContext.empty();
 
-    var session = store.createSession(executionContext, agentContext);
-    session.loadMessages(agentContext);
-    var updatedConversation =
-        session.storeMessages(agentContext, ConversationStoreRequest.of(TEST_MESSAGES));
-    var updatedAgentContext = agentContext.withConversation(updatedConversation);
+    try (var session = store.createSession(executionContext, agentContext)) {
+      session.loadMessages(agentContext);
+      var updatedConversation =
+          session.storeMessages(agentContext, ConversationStoreRequest.of(TEST_MESSAGES));
+      var updatedAgentContext = agentContext.withConversation(updatedConversation);
 
-    assertThat(updatedAgentContext.conversation())
-        .asInstanceOf(InstanceOfAssertFactories.type(InProcessConversationContext.class))
-        .satisfies(
-            conversation -> {
-              assertThat(conversation.conversationId()).isNotEmpty();
-              assertThat(conversation.messages()).containsExactlyElementsOf(TEST_MESSAGES);
-            });
+      assertThat(updatedAgentContext.conversation())
+          .asInstanceOf(InstanceOfAssertFactories.type(InProcessConversationContext.class))
+          .satisfies(
+              conversation -> {
+                assertThat(conversation.conversationId()).isNotEmpty();
+                assertThat(conversation.messages()).containsExactlyElementsOf(TEST_MESSAGES);
+              });
+    }
   }
 
   @Test
@@ -104,26 +107,27 @@ class InProcessConversationStoreTest {
 
     final var agentContext = AgentContext.empty().withConversation(previousConversationContext);
 
-    var session = store.createSession(executionContext, agentContext);
-    var loadResult = session.loadMessages(agentContext);
+    try (var session = store.createSession(executionContext, agentContext)) {
+      var loadResult = session.loadMessages(agentContext);
 
-    final var allMessages = new ArrayList<>(loadResult.messages());
-    allMessages.add(userMessage);
+      final var allMessages = new ArrayList<>(loadResult.messages());
+      allMessages.add(userMessage);
 
-    var updatedConversation =
-        session.storeMessages(agentContext, ConversationStoreRequest.of(allMessages));
-    var updatedAgentContext = agentContext.withConversation(updatedConversation);
+      var updatedConversation =
+          session.storeMessages(agentContext, ConversationStoreRequest.of(allMessages));
+      var updatedAgentContext = agentContext.withConversation(updatedConversation);
 
-    assertThat(updatedAgentContext.conversation())
-        .asInstanceOf(InstanceOfAssertFactories.type(InProcessConversationContext.class))
-        .satisfies(
-            conversation -> {
-              final var expectedMessages = new ArrayList<>(TEST_MESSAGES);
-              expectedMessages.add(userMessage);
+      assertThat(updatedAgentContext.conversation())
+          .asInstanceOf(InstanceOfAssertFactories.type(InProcessConversationContext.class))
+          .satisfies(
+              conversation -> {
+                final var expectedMessages = new ArrayList<>(TEST_MESSAGES);
+                expectedMessages.add(userMessage);
 
-              assertThat(conversation.conversationId())
-                  .isEqualTo(previousConversationContext.conversationId());
-              assertThat(conversation.messages()).containsExactlyElementsOf(expectedMessages);
-            });
+                assertThat(conversation.conversationId())
+                    .isEqualTo(previousConversationContext.conversationId());
+                assertThat(conversation.messages()).containsExactlyElementsOf(expectedMessages);
+              });
+    }
   }
 }

--- a/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/memory/conversation/inprocess/InProcessConversationStoreTest.java
+++ b/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/memory/conversation/inprocess/InProcessConversationStoreTest.java
@@ -11,18 +11,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.camunda.connector.agenticai.aiagent.TestMessagesFixture;
+import io.camunda.connector.agenticai.aiagent.memory.conversation.ConversationStoreRequest;
 import io.camunda.connector.agenticai.aiagent.memory.conversation.TestConversationContext;
-import io.camunda.connector.agenticai.aiagent.memory.runtime.DefaultRuntimeMemory;
-import io.camunda.connector.agenticai.aiagent.memory.runtime.RuntimeMemory;
 import io.camunda.connector.agenticai.aiagent.model.AgentContext;
 import io.camunda.connector.agenticai.aiagent.model.AgentExecutionContext;
-import io.camunda.connector.agenticai.aiagent.model.AgentResponse;
-import io.camunda.connector.agenticai.aiagent.model.request.MemoryStorageConfiguration.InProcessMemoryStorageConfiguration;
 import io.camunda.connector.agenticai.model.message.Message;
 import java.util.ArrayList;
 import java.util.List;
 import org.assertj.core.api.InstanceOfAssertFactories;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -37,16 +33,11 @@ class InProcessConversationStoreTest {
 
   private final InProcessConversationStore store = new InProcessConversationStore();
 
-  private RuntimeMemory memory;
-
-  @BeforeEach
-  void setUp() {
-    memory = new DefaultRuntimeMemory();
-  }
-
   @Test
   void storeTypeIsAlignedWithConfiguration() {
-    final var configuration = new InProcessMemoryStorageConfiguration();
+    final var configuration =
+        new io.camunda.connector.agenticai.aiagent.model.request.MemoryStorageConfiguration
+            .InProcessMemoryStorageConfiguration();
     assertThat(store.type()).isEqualTo(configuration.storeType()).isEqualTo("in-process");
   }
 
@@ -54,15 +45,10 @@ class InProcessConversationStoreTest {
   void supportsAgentContextWithoutPreviousConversation() {
     final var agentContext = AgentContext.empty();
 
-    store.executeInSession(
-        executionContext,
-        agentContext,
-        session -> {
-          session.loadIntoRuntimeMemory(agentContext, memory);
-          return agentResponse(agentContext);
-        });
+    var session = store.createSession(executionContext, agentContext);
+    var loadResult = session.loadMessages(agentContext);
 
-    assertThat(memory.allMessages()).isEmpty();
+    assertThat(loadResult.messages()).isEmpty();
   }
 
   @Test
@@ -72,15 +58,10 @@ class InProcessConversationStoreTest {
 
     final var agentContext = AgentContext.empty().withConversation(previousConversationContext);
 
-    store.executeInSession(
-        executionContext,
-        agentContext,
-        session -> {
-          session.loadIntoRuntimeMemory(agentContext, memory);
-          return agentResponse(agentContext);
-        });
+    var session = store.createSession(executionContext, agentContext);
+    var loadResult = session.loadMessages(agentContext);
 
-    assertThat(memory.allMessages()).containsExactlyElementsOf(TEST_MESSAGES);
+    assertThat(loadResult.messages()).containsExactlyElementsOf(TEST_MESSAGES);
   }
 
   @Test
@@ -88,31 +69,22 @@ class InProcessConversationStoreTest {
     final var agentContext =
         AgentContext.empty().withConversation(new TestConversationContext("dummy"));
 
-    assertThatThrownBy(
-            () ->
-                store.executeInSession(
-                    executionContext,
-                    agentContext,
-                    session -> {
-                      session.loadIntoRuntimeMemory(agentContext, memory);
-                      return agentResponse(agentContext);
-                    }))
+    var session = store.createSession(executionContext, agentContext);
+
+    assertThatThrownBy(() -> session.loadMessages(agentContext))
         .isInstanceOf(IllegalStateException.class)
         .hasMessage("Unsupported conversation context: TestConversationContext");
   }
 
   @Test
-  void storesRuntimeMemoryIntoAgentContext_withEmptyPreviousConversation() {
-    memory.addMessages(TEST_MESSAGES);
-
+  void storesMessagesIntoConversationContext_withEmptyPreviousConversation() {
     final var agentContext = AgentContext.empty();
-    final var updatedAgentContext =
-        store
-            .executeInSession(
-                executionContext,
-                agentContext,
-                session -> agentResponse(session.storeFromRuntimeMemory(agentContext, memory)))
-            .context();
+
+    var session = store.createSession(executionContext, agentContext);
+    session.loadMessages(agentContext);
+    var updatedConversation =
+        session.storeMessages(agentContext, ConversationStoreRequest.of(TEST_MESSAGES));
+    var updatedAgentContext = agentContext.withConversation(updatedConversation);
 
     assertThat(updatedAgentContext.conversation())
         .asInstanceOf(InstanceOfAssertFactories.type(InProcessConversationContext.class))
@@ -124,26 +96,23 @@ class InProcessConversationStoreTest {
   }
 
   @Test
-  void storesRuntimeMemoryIntoAgentContext_withExistingPreviousConversation() {
+  void storesMessagesIntoConversationContext_withExistingPreviousConversation() {
     final var previousConversationContext =
         InProcessConversationContext.builder("test-conversation").messages(TEST_MESSAGES).build();
 
     final var userMessage = userMessage("User message");
 
     final var agentContext = AgentContext.empty().withConversation(previousConversationContext);
-    final var updatedAgentContext =
-        store
-            .executeInSession(
-                executionContext,
-                agentContext,
-                session -> {
-                  session.loadIntoRuntimeMemory(agentContext, memory);
 
-                  memory.addMessage(userMessage);
+    var session = store.createSession(executionContext, agentContext);
+    var loadResult = session.loadMessages(agentContext);
 
-                  return agentResponse(session.storeFromRuntimeMemory(agentContext, memory));
-                })
-            .context();
+    final var allMessages = new ArrayList<>(loadResult.messages());
+    allMessages.add(userMessage);
+
+    var updatedConversation =
+        session.storeMessages(agentContext, ConversationStoreRequest.of(allMessages));
+    var updatedAgentContext = agentContext.withConversation(updatedConversation);
 
     assertThat(updatedAgentContext.conversation())
         .asInstanceOf(InstanceOfAssertFactories.type(InProcessConversationContext.class))
@@ -156,9 +125,5 @@ class InProcessConversationStoreTest {
                   .isEqualTo(previousConversationContext.conversationId());
               assertThat(conversation.messages()).containsExactlyElementsOf(expectedMessages);
             });
-  }
-
-  private AgentResponse agentResponse(AgentContext agentContext) {
-    return AgentResponse.builder().context(agentContext).build();
   }
 }


### PR DESCRIPTION
## Description

Redesigns the conversation storage SPI from a callback-based pattern (`executeInSession`) to a factory-based pattern (`createSession`) for clearer lifecycle management and decoupling from `RuntimeMemory`.

**SPI changes:**
- `ConversationStore.executeInSession(handler)` → `createSession()` returning `AutoCloseable` session
- `ConversationSession` decoupled from `RuntimeMemory`: `loadMessages()` / `storeMessages()` work with `List<Message>` via wrapper types (`ConversationLoadResult`, `ConversationStoreRequest`)
- `storeMessages()` returns only `ConversationContext` (storage cursor); caller assembles `AgentContext`
- `ConversationSessionHandler` deleted, `compensateFailedJobCompletion` removed (was deprecated, never invoked)
- All 3 implementations migrated (InProcess, CamundaDocument, AwsAgentCore)
- AWS AgentCore client lifecycle now managed via `session.close()`

**Response type refactoring:**
- Introduce `AiAgentTaskConnectorResponse` implementing `StandardConnectorResponse` for the outbound task connector flavor
- Rename `AiAgentSubProcessResponse` to `AiAgentSubProcessConnectorResponse` to align with the `ConnectorResponse` hierarchy
- Tighten generic bound on `AgentRequestHandler` / `BaseAgentRequestHandler` to `R extends ConnectorResponse`
- Rename `completeJob` → `buildConnectorResponse` (the method only assembles the response, actual job completion happens in the runtime)

**Documentation:**
- ADR 003: [003-conversation-storage-spi-redesign.md](https://github.com/camunda/connectors/blob/agentic-ai-storage-refactoring/connectors/agentic-ai/docs/adr/003-conversation-storage-spi-redesign.md)
- [Storage Contract](https://github.com/camunda/connectors/blob/agentic-ai-storage-refactoring/connectors/agentic-ai/docs/reference/ai-agent.md#storage-contract) section in ai-agent.md — documents the write-ahead with pointer-based visibility pattern all store implementations must follow
- [Breaking changes](https://github.com/camunda/connectors/blob/agentic-ai-storage-refactoring/connectors/agentic-ai/docs/breaking-changes.md) with migration guide for custom implementations
- Javadoc on all SPI interfaces documenting the storage contract
- Updated `AGENTS.md` and `ai-agent.md` to reflect new API

## Related issues

closes #7019

## Checklist

- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest
  release, as this branch will be rebased onto main before the next release. Example backport labels:
    - `backport stable/8.8`: for changes that should be included in the next 8.8.x release.
    - **or** `backport release-8.8.7`: for changes that should be included in the specific release 8.8.7, and this
      *release has already been created*. The release branch will be merged back into stable/8.8 later, so the change
      will be included in future 8.8.x releases as well.
- [x] Tests/Integration tests for the changes have been added if applicable.
- [x] If the change requires a documentation update, it has been added to the appropriate section in the documentation.