### PR TITLE
chore(secret): pin localstack version

### DIFF
--- a/connectors-e2e-test/connectors-e2e-test-aws/connectors-e2e-test-aws-base/src/test/java/io/camunda/connector/e2e/BaseAwsTest.java
+++ b/connectors-e2e-test/connectors-e2e-test-aws/connectors-e2e-test-aws-base/src/test/java/io/camunda/connector/e2e/BaseAwsTest.java
@@ -56,7 +56,7 @@ import org.testcontainers.utility.DockerImageName;
 @ExtendWith(MockitoExtension.class)
 public abstract class BaseAwsTest {
   private static final DockerImageName localstackImage =
-      DockerImageName.parse("localstack/localstack");
+      DockerImageName.parse("localstack/localstack:4.8.0");
   @TempDir File tempDir;
   @Autowired ZeebeClient zeebeClient;
   @MockBean ProcessDefinitionSearch processDefinitionSearch;


### PR DESCRIPTION
This pull request makes a small but important update to the `BaseAwsTest` class by specifying a fixed version for the LocalStack Docker image. Instead of using the latest version, the image is now pinned to version `4.8.0`, which helps ensure consistent and reproducible test environments.

* Pin Docker image for LocalStack to version `4.8.0` in `BaseAwsTest.java` to improve test consistency.