### PR TITLE
chore: add resolveExternalRefs as option when generate templates via …

### DIFF
--- a/element-template-generator/openapi-parser/src/main/java/io/camunda/connector/generator/openapi/OpenApiGenerationSource.java
+++ b/element-template-generator/openapi-parser/src/main/java/io/camunda/connector/generator/openapi/OpenApiGenerationSource.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.parser.OpenAPIV3Parser;
+import io.swagger.v3.parser.core.models.ParseOptions;
 import java.io.IOException;
 import java.util.List;
 import java.util.Set;
@@ -37,27 +38,45 @@ public record OpenApiGenerationSource(
    * @param rawBody If true, the generated template will contain a JSON property "body" that
    *     contains the raw request body example. If false, the body will be parsed and transformed
    *     into individual properties when possible. Default: false.
+   * @param resolveExternalRefs If false, the parser will not follow external {@code $ref}
+   *     references (remote URLs or local files). Disable this to prevent unintended network or
+   *     filesystem access when processing untrusted specs. Default: true (backward-compatible).
    */
-  public record Options(boolean rawBody) {}
+  public record Options(boolean rawBody, boolean resolveExternalRefs) {
 
-  static final String USAGE = "[operation-id] openapi-outbound [openapi-file]... [--raw-body]";
-
-  public OpenApiGenerationSource(List<String> cliParams) {
-    this(fetchOpenApi(cliParams), extractOperationIds(cliParams), extractOptions(cliParams));
+    /** Backward-compatible constructor: {@code resolveExternalRefs} defaults to {@code true}. */
+    public Options(boolean rawBody) {
+      this(rawBody, true);
+    }
   }
 
-  private static OpenAPI fetchOpenApi(List<String> cliParams) {
+  static final String USAGE =
+      "[operation-id] openapi-outbound [openapi-file]... [--raw-body] [--no-resolve-refs]";
+
+  public OpenApiGenerationSource(List<String> cliParams) {
+    this(cliParams, extractOptions(cliParams));
+  }
+
+  private OpenApiGenerationSource(List<String> cliParams, Options options) {
+    this(fetchOpenApi(cliParams, options), extractOperationIds(cliParams), options);
+  }
+
+  private static OpenAPI fetchOpenApi(List<String> cliParams, Options options) {
     if (cliParams.isEmpty()) {
       throw new IllegalArgumentException(
           "OpenAPI file path or URL must be provided as first parameter");
     }
     var openApiPathOrContent = cliParams.get(0);
     var openApiParser = new OpenAPIV3Parser();
+
+    ParseOptions parseOptions = new ParseOptions();
+    parseOptions.setResolve(options.resolveExternalRefs());
+
     try {
       if (isValidJSON(openApiPathOrContent) || isValidYAML(openApiPathOrContent)) {
-        return openApiParser.readContents(openApiPathOrContent).getOpenAPI();
+        return openApiParser.readContents(openApiPathOrContent, null, parseOptions).getOpenAPI();
       }
-      return openApiParser.read(openApiPathOrContent);
+      return openApiParser.read(openApiPathOrContent, null, parseOptions);
     } catch (Exception e) {
       throw new IllegalArgumentException(
           "Failed to parse OpenAPI file from "
@@ -97,6 +116,8 @@ public record OpenApiGenerationSource(
   }
 
   private static Options extractOptions(List<String> cliParams) {
-    return new Options(cliParams.stream().anyMatch(param -> param.equals("--raw-body")));
+    boolean rawBody = cliParams.stream().anyMatch(param -> param.equals("--raw-body"));
+    boolean resolveExternalRefs = !cliParams.contains("--no-resolve-refs");
+    return new Options(rawBody, resolveExternalRefs);
   }
 }

--- a/element-template-generator/openapi-parser/src/main/java/io/camunda/connector/generator/openapi/OpenApiOutboundTemplateGenerator.java
+++ b/element-template-generator/openapi-parser/src/main/java/io/camunda/connector/generator/openapi/OpenApiOutboundTemplateGenerator.java
@@ -54,8 +54,24 @@ public class OpenApiOutboundTemplateGenerator
   private static final ConnectorElementType DEFAULT_ELEMENT_TYPE =
       new ConnectorElementType(Set.of(BpmnType.TASK), BpmnType.SERVICE_TASK, null, null);
 
+  private final boolean resolveExternalRefs;
+
+  /**
+   * Default constructor. External {@code $ref} resolution is <strong>enabled</strong> to preserve
+   * backward compatibility.
+   */
   public OpenApiOutboundTemplateGenerator() {
+    this(true);
+  }
+
+  /**
+   * @param resolveExternalRefs When {@code false}, the parser will not follow external {@code $ref}
+   *     references (remote URLs or local files). Set to {@code false} when processing untrusted
+   *     specs to prevent unintended network or filesystem access.
+   */
+  public OpenApiOutboundTemplateGenerator(boolean resolveExternalRefs) {
     super();
+    this.resolveExternalRefs = resolveExternalRefs;
     // workaround for https://github.com/swagger-api/swagger-parser/issues/1857 (large yaml files)
     System.setProperty("maxYamlCodePoints", String.valueOf(Integer.MAX_VALUE));
   }
@@ -69,7 +85,11 @@ public class OpenApiOutboundTemplateGenerator
 
   @Override
   public OpenApiGenerationSource prepareInput(List<String> parameters) {
-    return new OpenApiGenerationSource(parameters);
+    var params = new ArrayList<>(parameters);
+    if (!resolveExternalRefs && !params.contains("--no-resolve-refs")) {
+      params.add("--no-resolve-refs");
+    }
+    return new OpenApiGenerationSource(params);
   }
 
   public String getUsage() {

--- a/element-template-generator/openapi-parser/src/main/java/io/camunda/connector/generator/openapi/util/BodyUtil.java
+++ b/element-template-generator/openapi-parser/src/main/java/io/camunda/connector/generator/openapi/util/BodyUtil.java
@@ -46,10 +46,18 @@ public class BodyUtil {
       return new Raw("");
     }
     if (requestBody.get$ref() != null) {
+      var ref = requestBody.get$ref();
+      if (!ref.startsWith("#/")) {
+        throw new IllegalArgumentException(
+            "External $ref '"
+                + ref
+                + "' cannot be resolved: the spec contains a reference to an external file or URL "
+                + "that was not inlined during parsing. Either remove '--no-resolve-refs' so the "
+                + "parser can follow the reference, or replace the external $ref with an inline "
+                + "schema definition.");
+      }
       requestBody =
-          components
-              .getRequestBodies()
-              .get(requestBody.get$ref().replace("#/components/requestBodies/", ""));
+          components.getRequestBodies().get(ref.replace("#/components/requestBodies/", ""));
     }
     Schema<?> schema = null;
     var content = requestBody.getContent();

--- a/element-template-generator/openapi-parser/src/main/java/io/camunda/connector/generator/openapi/util/ParameterUtil.java
+++ b/element-template-generator/openapi-parser/src/main/java/io/camunda/connector/generator/openapi/util/ParameterUtil.java
@@ -116,7 +116,17 @@ public class ParameterUtil {
 
   public static Schema<?> getSchemaOrFromComponents(Schema<?> schema, Components components) {
     if (schema.get$ref() != null) {
-      return components.getSchemas().get(schema.get$ref().replace("#/components/schemas/", ""));
+      var ref = schema.get$ref();
+      if (!ref.startsWith("#/")) {
+        throw new IllegalArgumentException(
+            "External $ref '"
+                + ref
+                + "' cannot be resolved: the spec contains a reference to an external file or URL "
+                + "that was not inlined during parsing. Either remove '--no-resolve-refs' so the "
+                + "parser can follow the reference, or replace the external $ref with an inline "
+                + "schema definition.");
+      }
+      return components.getSchemas().get(ref.replace("#/components/schemas/", ""));
     }
     return schema;
   }

--- a/element-template-generator/openapi-parser/src/test/java/io/camunda/connector/generator/openapi/BodyUtilTest.java
+++ b/element-template-generator/openapi-parser/src/test/java/io/camunda/connector/generator/openapi/BodyUtilTest.java
@@ -17,6 +17,7 @@
 package io.camunda.connector.generator.openapi;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.camunda.connector.generator.dsl.http.HttpOperationProperty;
 import io.camunda.connector.generator.openapi.util.BodyUtil;
@@ -131,5 +132,47 @@ public class BodyUtilTest {
         """,
         ((Raw) result).rawBody(),
         true);
+  }
+
+  // -------------------------------------------------------------------------
+  // External $ref guards
+  // -------------------------------------------------------------------------
+
+  @Test
+  void parseBody_requestBodyWithExternalRef_throwsIllegalArgumentException() {
+    // given – requestBody carries an unresolved external $ref (e.g. --no-resolve-refs was used)
+    var requestBody = new RequestBody();
+    requestBody.set$ref("./external-bodies.json#/components/requestBodies/CreateUser");
+
+    var components = new Components();
+    var options = new OpenApiGenerationSource.Options(false);
+
+    // when / then
+    assertThatThrownBy(() -> BodyUtil.parseBody(requestBody, components, options))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("./external-bodies.json#/components/requestBodies/CreateUser")
+        .hasMessageContaining("External $ref");
+  }
+
+  @Test
+  void parseBody_mediaTypeSchemaWithExternalRef_throwsIllegalArgumentException() {
+    // given – the schema inside the media type carries an unresolved external $ref
+    var externalRefSchema = new Schema<>();
+    externalRefSchema.set$ref("./user-schema.json#/components/schemas/User");
+
+    var requestBody =
+        new RequestBody()
+            .content(
+                new Content()
+                    .addMediaType("application/json", new MediaType().schema(externalRefSchema)));
+
+    var components = new Components();
+    var options = new OpenApiGenerationSource.Options(false);
+
+    // when / then
+    assertThatThrownBy(() -> BodyUtil.parseBody(requestBody, components, options))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("./user-schema.json#/components/schemas/User")
+        .hasMessageContaining("External $ref");
   }
 }

--- a/element-template-generator/openapi-parser/src/test/java/io/camunda/connector/generator/openapi/OpenApiGenerationSourceTest.java
+++ b/element-template-generator/openapi-parser/src/test/java/io/camunda/connector/generator/openapi/OpenApiGenerationSourceTest.java
@@ -1,0 +1,348 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.generator.openapi;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+public class OpenApiGenerationSourceTest {
+
+  // language=yaml
+  private static final String SPEC_WITH_INTERNAL_REF =
+      """
+      openapi: 3.0.3
+      info:
+        title: Test API
+        version: 1.0.0
+      servers:
+        - url: https://api.example.com/v1
+      paths:
+        /users:
+          get:
+            operationId: listUsers
+            responses:
+              '200':
+                description: A list of users.
+                content:
+                  application/json:
+                    schema:
+                      $ref: '#/components/schemas/User'
+      components:
+        schemas:
+          User:
+            type: object
+            properties:
+              id:
+                type: string
+                format: uuid
+              name:
+                type: string
+                example: Jane Doe
+      """;
+
+  /**
+   * KEY security test. Verifies that external file references are NOT followed when {@code
+   * --no-resolve-refs} is passed.
+   *
+   * <p>The test writes two real files into a temp directory: an OpenAPI spec referencing an
+   * adjacent schema file via a relative {@code $ref: './user-schema.json'}, and the schema file
+   * itself containing a sentinel property.
+   *
+   * <p>The parser behaviour depends on the {@code resolveExternalRefs} option:
+   *
+   * <ul>
+   *   <li>{@code resolveExternalRefs=true} (default): the parser reads {@code user-schema.json},
+   *       pulls it into {@code components}, and rewrites the {@code $ref} to {@code
+   *       #/components/schemas/user-schema}. The assertion {@code isEqualTo("./user-schema.json")}
+   *       then <strong>fails</strong>, exposing the bug.
+   *   <li>{@code resolveExternalRefs=false} (opt-in via {@code --no-resolve-refs}): the {@code
+   *       $ref} is left untouched as the original relative path. Both assertions pass.
+   * </ul>
+   */
+  @Test
+  void shouldNotFollowExternalFileRef_whenNoResolveRefsIsSet(@TempDir Path tempDir)
+      throws IOException {
+    // language=json
+    Files.writeString(
+        tempDir.resolve("user-schema.json"),
+        """
+        {
+          "type": "object",
+          "properties": {
+            "sentinelProperty": { "type": "string" }
+          }
+        }
+        """);
+
+    // language=yaml
+    Files.writeString(
+        tempDir.resolve("openapi.yaml"),
+        """
+        openapi: 3.0.3
+        info:
+          title: Test
+          version: 1.0.0
+        servers:
+          - url: https://api.example.com/v1
+        paths:
+          /users:
+            post:
+              operationId: createUser
+              requestBody:
+                required: true
+                content:
+                  application/json:
+                    schema:
+                      $ref: './user-schema.json'
+              responses:
+                '201':
+                  description: Created
+        """);
+
+    // --no-resolve-refs sets Options.resolveExternalRefs=false, preventing the parser
+    // from following relative $refs to files on the local filesystem.
+    var source =
+        new OpenApiGenerationSource(
+            List.of(tempDir.resolve("openapi.yaml").toString(), "--no-resolve-refs"));
+    var schema =
+        source
+            .openAPI()
+            .getPaths()
+            .get("/users")
+            .getPost()
+            .getRequestBody()
+            .getContent()
+            .get("application/json")
+            .getSchema();
+
+    // With resolveExternalRefs=false: $ref is unchanged — the external file was never read.
+    // With resolveExternalRefs=true: $ref is rewritten to '#/components/schemas/user-schema'.
+    assertThat(schema.get$ref())
+        .as("External $ref must not be rewritten (local file must not be read)")
+        .isEqualTo("./user-schema.json");
+
+    // Complementary: the external schema must not have been pulled into components.
+    var schemas =
+        source.openAPI().getComponents() != null
+            ? source.openAPI().getComponents().getSchemas()
+            : null;
+    assertThat(schemas)
+        .as("External schema must not be imported into components")
+        .satisfiesAnyOf(
+            s -> assertThat(s).isNull(), s -> assertThat(s).doesNotContainKey("user-schema"));
+  }
+
+  /**
+   * Verifies that the default behaviour (backward-compatible) still resolves external file
+   * references when {@code --no-resolve-refs} is NOT passed.
+   */
+  @Test
+  void shouldFollowExternalFileRef_byDefault(@TempDir Path tempDir) throws IOException {
+    // language=json
+    Files.writeString(
+        tempDir.resolve("user-schema.json"),
+        """
+        {
+          "type": "object",
+          "properties": {
+            "sentinelProperty": { "type": "string" }
+          }
+        }
+        """);
+
+    // language=yaml
+    Files.writeString(
+        tempDir.resolve("openapi.yaml"),
+        """
+        openapi: 3.0.3
+        info:
+          title: Test
+          version: 1.0.0
+        servers:
+          - url: https://api.example.com/v1
+        paths:
+          /users:
+            post:
+              operationId: createUser
+              requestBody:
+                required: true
+                content:
+                  application/json:
+                    schema:
+                      $ref: './user-schema.json'
+              responses:
+                '201':
+                  description: Created
+        """);
+
+    // No --no-resolve-refs flag: resolveExternalRefs defaults to true (backward-compatible).
+    var source = new OpenApiGenerationSource(List.of(tempDir.resolve("openapi.yaml").toString()));
+    var schema =
+        source
+            .openAPI()
+            .getPaths()
+            .get("/users")
+            .getPost()
+            .getRequestBody()
+            .getContent()
+            .get("application/json")
+            .getSchema();
+
+    // $ref is rewritten to #/components/schemas/... because the file was read and inlined.
+    assertThat(schema.get$ref())
+        .as("External $ref must be rewritten when resolveExternalRefs=true (default)")
+        .startsWith("#/components/schemas/");
+  }
+
+  /**
+   * Verifies that {@link OpenApiOutboundTemplateGenerator#prepareInput} injects {@code
+   * --no-resolve-refs} when the generator is constructed with {@code resolveExternalRefs=false}, so
+   * callers that use the generator (e.g. Web Modeler) only need to configure the generator — they
+   * do not have to know about the CLI flag themselves.
+   */
+  @Test
+  void generatorWithResolveDisabled_shouldNotFollowExternalFileRef(@TempDir Path tempDir)
+      throws IOException {
+    Files.writeString(
+        tempDir.resolve("user-schema.json"),
+        """
+        { "type": "object", "properties": { "sentinelProperty": { "type": "string" } } }
+        """);
+
+    // language=yaml
+    Files.writeString(
+        tempDir.resolve("openapi.yaml"),
+        """
+        openapi: 3.0.3
+        info:
+          title: Test
+          version: 1.0.0
+        servers:
+          - url: https://api.example.com/v1
+        paths:
+          /users:
+            post:
+              operationId: createUser
+              requestBody:
+                required: true
+                content:
+                  application/json:
+                    schema:
+                      $ref: './user-schema.json'
+              responses:
+                '201':
+                  description: Created
+        """);
+
+    var generator = new OpenApiOutboundTemplateGenerator(/* resolveExternalRefs= */ false);
+    var source = generator.prepareInput(List.of(tempDir.resolve("openapi.yaml").toString()));
+
+    var schema =
+        source
+            .openAPI()
+            .getPaths()
+            .get("/users")
+            .getPost()
+            .getRequestBody()
+            .getContent()
+            .get("application/json")
+            .getSchema();
+
+    assertThat(schema.get$ref())
+        .as("External $ref must not be rewritten when generator is configured with resolve=false")
+        .isEqualTo("./user-schema.json");
+  }
+
+  /**
+   * Verifies that the default {@link OpenApiOutboundTemplateGenerator} (no-arg constructor) still
+   * resolves external refs, preserving backward compatibility for existing callers.
+   */
+  @Test
+  void generatorDefault_shouldFollowExternalFileRef(@TempDir Path tempDir) throws IOException {
+    Files.writeString(
+        tempDir.resolve("user-schema.json"),
+        """
+        { "type": "object", "properties": { "sentinelProperty": { "type": "string" } } }
+        """);
+
+    // language=yaml
+    Files.writeString(
+        tempDir.resolve("openapi.yaml"),
+        """
+        openapi: 3.0.3
+        info:
+          title: Test
+          version: 1.0.0
+        servers:
+          - url: https://api.example.com/v1
+        paths:
+          /users:
+            post:
+              operationId: createUser
+              requestBody:
+                required: true
+                content:
+                  application/json:
+                    schema:
+                      $ref: './user-schema.json'
+              responses:
+                '201':
+                  description: Created
+        """);
+
+    var generator = new OpenApiOutboundTemplateGenerator(); // default: resolve=true
+    var source = generator.prepareInput(List.of(tempDir.resolve("openapi.yaml").toString()));
+
+    var schema =
+        source
+            .openAPI()
+            .getPaths()
+            .get("/users")
+            .getPost()
+            .getRequestBody()
+            .getContent()
+            .get("application/json")
+            .getSchema();
+
+    assertThat(schema.get$ref())
+        .as("External $ref must be rewritten by default (backward-compatible behaviour)")
+        .startsWith("#/components/schemas/");
+  }
+
+  /**
+   * Regression guard. Ensures that using {@code resolve=false} does not break access to schemas
+   * declared inline within the {@code components} section of the same document.
+   */
+  @Test
+  void shouldStillParseInlineSchemasFromComponents() {
+    var source = new OpenApiGenerationSource(List.of(SPEC_WITH_INTERNAL_REF));
+
+    assertThat(source.openAPI()).isNotNull();
+    assertThat(source.openAPI().getComponents().getSchemas()).containsKey("User");
+
+    var userSchema = source.openAPI().getComponents().getSchemas().get("User");
+    assertThat(userSchema.getProperties())
+        .as("Inline component schema properties must be parsed correctly")
+        .containsKeys("id", "name");
+  }
+}

--- a/element-template-generator/openapi-parser/src/test/java/io/camunda/connector/generator/openapi/OpenApiGenerationSourceTest.java
+++ b/element-template-generator/openapi-parser/src/test/java/io/camunda/connector/generator/openapi/OpenApiGenerationSourceTest.java
@@ -335,7 +335,7 @@ public class OpenApiGenerationSourceTest {
    */
   @Test
   void shouldStillParseInlineSchemasFromComponents() {
-    var source = new OpenApiGenerationSource(List.of(SPEC_WITH_INTERNAL_REF));
+    var source = new OpenApiGenerationSource(List.of(SPEC_WITH_INTERNAL_REF, "--no-resolve-refs"));
 
     assertThat(source.openAPI()).isNotNull();
     assertThat(source.openAPI().getComponents().getSchemas()).containsKey("User");

--- a/element-template-generator/openapi-parser/src/test/java/io/camunda/connector/generator/openapi/OperationUtilTest.java
+++ b/element-template-generator/openapi-parser/src/test/java/io/camunda/connector/generator/openapi/OperationUtilTest.java
@@ -22,6 +22,7 @@ import io.camunda.connector.generator.dsl.http.OperationParseResult;
 import io.camunda.connector.generator.openapi.util.OperationUtil;
 import java.util.List;
 import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -78,5 +79,73 @@ public class OperationUtilTest {
                 p -> p.id().equals("Content-Type") && p.example().equals("multipart/form-data"));
 
     assertThat(hasMatch).isEqualTo(expectHeaderIsAdded);
+  }
+
+  /**
+   * Regression / safety test. When {@code --no-resolve-refs} is active the swagger-parser leaves
+   * external {@code $ref} values untouched. Downstream code ({@link
+   * OperationUtil#extractOperations} wraps each operation in a try-catch, so the operation must be
+   * reported as <em>unsupported</em> with a meaningful reason rather than propagating an unhandled
+   * NPE or silent {@code null}.
+   */
+  @Test
+  void extractOperations_specWithExternalRef_noResolve_operationMarkedUnsupported() {
+    // language=yaml — the requestBody schema is an unresolved external $ref
+    // language=yaml
+    var specWithExternalRef =
+        """
+        openapi: 3.0.3
+        info:
+          title: Test API
+          version: 1.0.0
+        servers:
+          - url: https://api.example.com/v1
+        paths:
+          /users:
+            post:
+              operationId: createUser
+              requestBody:
+                required: true
+                content:
+                  application/json:
+                    schema:
+                      $ref: './user-schema.json'
+              responses:
+                '201':
+                  description: Created
+          /health:
+            get:
+              operationId: healthCheck
+              responses:
+                '200':
+                  description: OK
+        """;
+
+    // Parse with --no-resolve-refs so external $refs are left unresolved
+    var source = new OpenApiGenerationSource(List.of(specWithExternalRef, "--no-resolve-refs"));
+
+    // when
+    var results =
+        OperationUtil.extractOperations(
+            source.openAPI(), source.includeOperations(), source.options());
+
+    // then – both operations are returned (not an exception), but the one with the external
+    // $ref is marked unsupported while the plain GET is supported
+    assertThat(results).hasSize(2);
+
+    var createUser = results.stream().filter(r -> "createUser".equals(r.id())).findFirst();
+    assertThat(createUser).isPresent();
+    assertThat(createUser.get().supported())
+        .as("createUser references an unresolved external $ref and must be unsupported")
+        .isFalse();
+    assertThat(createUser.get().info())
+        .as("reason must mention the unresolved external $ref")
+        .containsIgnoringCase("External $ref");
+
+    var healthCheck = results.stream().filter(r -> "healthCheck".equals(r.id())).findFirst();
+    assertThat(healthCheck).isPresent();
+    assertThat(healthCheck.get().supported())
+        .as("healthCheck has no external $ref and must still be supported")
+        .isTrue();
   }
 }

--- a/element-template-generator/openapi-parser/src/test/java/io/camunda/connector/generator/openapi/ParameterUtilTest.java
+++ b/element-template-generator/openapi-parser/src/test/java/io/camunda/connector/generator/openapi/ParameterUtilTest.java
@@ -17,11 +17,14 @@
 package io.camunda.connector.generator.openapi;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.camunda.connector.generator.openapi.util.ParameterUtil;
+import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.media.Schema;
 import io.swagger.v3.oas.models.parameters.Parameter;
 import java.util.List;
+import java.util.Map;
 import org.json.JSONException;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -129,6 +132,56 @@ public class ParameterUtilTest {
 
       // then
       assertThat(property.example()).isEqualTo("foo");
+    }
+  }
+
+  @Nested
+  class ExternalRefs {
+
+    @Test
+    void getSchemaOrFromComponents_externalRef_throwsIllegalArgumentException() {
+      // given – a schema whose $ref points to an external file (not yet resolved)
+      var schema = new Schema<>();
+      schema.set$ref("./specification/paths/foo.json#/components/schemas/User");
+
+      var components = new Components();
+
+      // when / then
+      assertThatThrownBy(() -> ParameterUtil.getSchemaOrFromComponents(schema, components))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("./specification/paths/foo.json#/components/schemas/User")
+          .hasMessageContaining("External $ref");
+    }
+
+    @Test
+    void getSchemaOrFromComponents_internalRef_resolvesFromComponents() {
+      // given – an internal $ref that lives in #/components/schemas
+      var userSchema = new Schema<>().type("object");
+
+      var schema = new Schema<>();
+      schema.set$ref("#/components/schemas/User");
+
+      var components = new Components();
+      components.setSchemas(Map.of("User", userSchema));
+
+      // when
+      var resolved = ParameterUtil.getSchemaOrFromComponents(schema, components);
+
+      // then
+      assertThat(resolved).isSameAs(userSchema);
+    }
+
+    @Test
+    void getSchemaOrFromComponents_noRef_returnsSchemaAsIs() {
+      // given – schema with no $ref at all
+      var schema = new Schema<>().type("string");
+      var components = new Components();
+
+      // when
+      var resolved = ParameterUtil.getSchemaOrFromComponents(schema, components);
+
+      // then
+      assertThat(resolved).isSameAs(schema);
     }
   }
 }


### PR DESCRIPTION
…openAPI spec

## Description
Add the resolveExternalReference as option to override the default **true** from OPENapi Generator and avoid load external references. 
<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes https://github.com/camunda/camunda-hub/issues/12824

## Checklist

- [x] Backport labels are added if these code changes should be backported. No backport label is added to the latest
  release, as this branch will be rebased onto main before the next release. Example backport labels:
    - `backport stable/8.8`: for changes that should be included in the next 8.8.x release.
    - **or** `backport release-8.8.7`: for changes that should be included in the specific release 8.8.7, and this
      *release has already been created*. The release branch will be merged back into stable/8.8 later, so the change
      will be included in future 8.8.x releases as well.
- [x] Tests/Integration tests for the changes have been added if applicable.

