### PR TITLE
fix(document-handling): support ExternalDocumentReference serializati…

### DIFF
--- a/connector-runtime/jackson-datatype-document/pom.xml
+++ b/connector-runtime/jackson-datatype-document/pom.xml
@@ -28,28 +28,18 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.assertj</groupId>
-      <artifactId>assertj-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-junit-jupiter</artifactId>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.skyscreamer</groupId>
       <artifactId>jsonassert</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.fasterxml.jackson.datatype</groupId>
-      <artifactId>jackson-datatype-jdk8</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/connector-runtime/jackson-datatype-document/src/main/java/io/camunda/connector/document/jackson/serializer/DocumentSerializer.java
+++ b/connector-runtime/jackson-datatype-document/src/main/java/io/camunda/connector/document/jackson/serializer/DocumentSerializer.java
@@ -20,7 +20,9 @@ import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import io.camunda.connector.api.document.Document;
+import io.camunda.connector.api.document.DocumentReference;
 import io.camunda.connector.api.document.DocumentReference.CamundaDocumentReference;
+import io.camunda.connector.document.jackson.DocumentReferenceModel;
 import io.camunda.connector.document.jackson.DocumentReferenceModel.CamundaDocumentMetadataModel;
 import io.camunda.connector.document.jackson.DocumentReferenceModel.CamundaDocumentReferenceModel;
 import java.io.IOException;
@@ -34,20 +36,27 @@ public class DocumentSerializer extends JsonSerializer<Document> {
       Document document, JsonGenerator jsonGenerator, SerializerProvider serializerProvider)
       throws IOException {
     var reference = document.reference();
-    if (!(reference instanceof CamundaDocumentReference camundaReference)) {
+    if (reference
+        instanceof DocumentReference.ExternalDocumentReference externalDocumentReference) {
+      final var model =
+          new DocumentReferenceModel.ExternalDocumentReferenceModel(
+              externalDocumentReference.url(), externalDocumentReference.name());
+      jsonGenerator.writeObject(model);
+    } else if (reference instanceof CamundaDocumentReference camundaReference) {
+      final CamundaDocumentReferenceModel model;
+      if (camundaReference instanceof CamundaDocumentReferenceModel camundaModel) {
+        model = camundaModel;
+      } else {
+        model =
+            new CamundaDocumentReferenceModel(
+                camundaReference.getStoreId(),
+                camundaReference.getDocumentId(),
+                camundaReference.getContentHash(),
+                new CamundaDocumentMetadataModel(camundaReference.getMetadata()));
+      }
+      jsonGenerator.writeObject(model);
+    } else {
       throw new IllegalArgumentException("Unsupported document reference type: " + reference);
     }
-    final CamundaDocumentReferenceModel model;
-    if (camundaReference instanceof CamundaDocumentReferenceModel camundaModel) {
-      model = camundaModel;
-    } else {
-      model =
-          new CamundaDocumentReferenceModel(
-              camundaReference.getStoreId(),
-              camundaReference.getDocumentId(),
-              camundaReference.getContentHash(),
-              new CamundaDocumentMetadataModel(camundaReference.getMetadata()));
-    }
-    jsonGenerator.writeObject(model);
   }
 }

--- a/connector-runtime/jackson-datatype-document/src/test/java/io/camunda/connector/document/jackson/serializer/DocumentSerializerTest.java
+++ b/connector-runtime/jackson-datatype-document/src/test/java/io/camunda/connector/document/jackson/serializer/DocumentSerializerTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.document.jackson.serializer;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.connector.api.document.Document;
+import io.camunda.connector.api.document.DocumentReference;
+import io.camunda.connector.document.jackson.DocumentReferenceModel.CamundaDocumentMetadataModel;
+import io.camunda.connector.document.jackson.DocumentReferenceModel.CamundaDocumentReferenceModel;
+import io.camunda.connector.document.jackson.DocumentReferenceModel.ExternalDocumentReferenceModel;
+import io.camunda.connector.document.jackson.JacksonModuleDocumentSerializer;
+import org.json.JSONException;
+import org.junit.jupiter.api.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
+
+class DocumentSerializerTest {
+
+  private final ObjectMapper objectMapper =
+      new ObjectMapper().registerModule(new JacksonModuleDocumentSerializer());
+
+  @Test
+  void shouldReturnJsonForExternalDocument() throws JsonProcessingException, JSONException {
+    var ref = new ExternalDocumentReferenceModel("https://example.com/file.pdf", "file.pdf");
+    var document = mock(Document.class);
+    when(document.reference()).thenReturn(ref);
+
+    var result = objectMapper.writeValueAsString(document);
+
+    JSONAssert.assertEquals(
+        """
+        {
+          "camunda.document.type": "external",
+          "url": "https://example.com/file.pdf",
+          "name": "file.pdf"
+        }
+        """,
+        result,
+        true);
+  }
+
+  @Test
+  void shouldReturnJsonForCamundaDocument() throws JsonProcessingException, JSONException {
+    var metadata = new CamundaDocumentMetadataModel(null, null, null, null, null, null, null);
+    var ref = new CamundaDocumentReferenceModel("store-1", "doc-42", "abc123", metadata);
+    var document = mock(Document.class);
+    when(document.reference()).thenReturn(ref);
+
+    var result = objectMapper.writeValueAsString(document);
+
+    JSONAssert.assertEquals(
+        """
+        {
+          "camunda.document.type": "camunda",
+          "storeId": "store-1",
+          "documentId": "doc-42",
+          "contentHash": "abc123",
+          "metadata": {}
+        }
+        """,
+        result,
+        true);
+  }
+
+  @Test
+  void shouldThrowExceptionForUnsupportedDocument() {
+    var unsupportedRef = mock(DocumentReference.class);
+    var document = mock(Document.class);
+    when(document.reference()).thenReturn(unsupportedRef);
+
+    assertThatThrownBy(() -> objectMapper.writeValueAsString(document))
+        .hasCauseInstanceOf(IllegalArgumentException.class)
+        .cause()
+        .hasMessageContaining("Unsupported document reference type");
+  }
+}


### PR DESCRIPTION
…on (#6790)

* fix(document-handling): support ExternalDocumentReference serialization



* Update connector-runtime/jackson-datatype-document/pom.xml



---------



(cherry picked from commit 96ccc334e0998771c59ade836128135f74d1d67d)

## Description

<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #

## Checklist

- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest
  release, as this branch will be rebased onto main before the next release. Example backport labels:
    - `backport stable/8.8`: for changes that should be included in the next 8.8.x release.
    - **or** `backport release-8.8.7`: for changes that should be included in the specific release 8.8.7, and this
      *release has already been created*. The release branch will be merged back into stable/8.8 later, so the change
      will be included in future 8.8.x releases as well.
- [ ] Tests/Integration tests for the changes have been added if applicable.

