### PR TITLE
fix: slack connector user can now use mentions without using an ID

### DIFF
--- a/bundle/default-bundle/src/test/resources/application-local.properties
+++ b/bundle/default-bundle/src/test/resources/application-local.properties
@@ -10,5 +10,5 @@ camunda.client.auth.token-url=null
 camunda.endpoints.cors.allowed.origins=http://localhost:6006
 camunda.endpoints.cors.mappings=/inbound-instances/**
 camunda.client.prefer-rest-over-grpc=false
-camunda.client.rest-address=http://localhost:8088
+camunda.client.rest-address=http://localhost:8080
 camunda.connector.oauth.cache.skew-buffer=PT9S

--- a/connectors/slack/src/main/java/io/camunda/connector/slack/outbound/model/ChatPostMessageData.java
+++ b/connectors/slack/src/main/java/io/camunda/connector/slack/outbound/model/ChatPostMessageData.java
@@ -124,6 +124,7 @@ public record ChatPostMessageData(
     }
     if (MessageType.plainText.equals(messageType)) {
       requestBuilder.text(text);
+      requestBuilder.linkNames(true);
       if (documents != null && !documents.isEmpty()) {
         requestBuilder.blocks(
             BlockBuilder.create(new FileUploader(methodsClient))

--- a/connectors/slack/src/test/java/io/camunda/connector/slack/outbound/model/ChatPostMessageDataTest.java
+++ b/connectors/slack/src/test/java/io/camunda/connector/slack/outbound/model/ChatPostMessageDataTest.java
@@ -119,6 +119,7 @@ class ChatPostMessageDataTest {
     // Then
     ChatPostMessageRequest value = chatPostMessageRequest.getValue();
     assertThat(value.getChannel()).isEqualTo(USERID);
+    assertThat(value.isLinkNames()).isTrue();
   }
 
   @Test
@@ -165,6 +166,7 @@ class ChatPostMessageDataTest {
       // Then
       ChatPostMessageRequest value = chatPostMessageRequest.getValue();
       assertThat(value.getChannel()).isEqualTo(USERID);
+      assertThat(value.isLinkNames()).isTrue();
     }
   }
 
@@ -238,6 +240,7 @@ class ChatPostMessageDataTest {
     // Then
     ChatPostMessageRequest value = chatPostMessageRequest.getValue();
     assertThat(value.getChannel()).isEqualTo(USERID);
+    assertThat(value.isLinkNames()).isFalse();
   }
 
   @Test


### PR DESCRIPTION
## Description

This pull request introduces a small but important improvement to the way plain text messages are sent via Slack. Specifically, it ensures that user and channel mentions in plain text messages are automatically linked, enhancing the user experience.

* When sending plain text messages, the `linkNames` property is now set to `true` in the Slack API request, so user and channel mentions will be properly linked.

## Checklist

- [x] Backport labels are added if these code changes should be backported. No backport label is added to the latest
  release, as this branch will be rebased onto main before the next release. Example backport labels:
    - `backport stable/8.8`: for changes that should be included in the next 8.8.x release.
    - **or** `backport release-8.8.7`: for changes that should be included in the specific release 8.8.7, and this
      *release has already been created*. The release branch will be merged back into stable/8.8 later, so the change
      will be included in future 8.8.x releases as well.
- [x] Tests/Integration tests for the changes have been added if applicable.

