### PR TITLE
chore(maven): change maven version

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,4 +1,4 @@
 java temurin-25.0.2+10.0.LTS
-maven 3.9.12
+maven 3.9.14
 pre-commit 4.5.1
 nodejs 24.14.1


### PR DESCRIPTION
This pull request updates the Maven version in the `.tool-versions` file to ensure the project uses the latest compatible build tools.

Tooling update:

* Upgraded Maven from version 3.9.12 to 3.9.14 in `.tool-versions` to keep the build process up to date.