### PR TITLE
fix: slack connector user can now use mentions without using an ID (#…6804)

### DIFF
--- a/connectors/slack/src/main/java/io/camunda/connector/slack/outbound/model/ChatPostMessageData.java
+++ b/connectors/slack/src/main/java/io/camunda/connector/slack/outbound/model/ChatPostMessageData.java
@@ -125,6 +125,7 @@ public record ChatPostMessageData(
     }
     if (MessageType.plainText.equals(messageType)) {
       requestBuilder.text(text);
+      requestBuilder.linkNames(true);
       if (documents != null && !documents.isEmpty()) {
         requestBuilder.blocks(
             BlockBuilder.create(new FileUploader(methodsClient))

--- a/connectors/slack/src/test/java/io/camunda/connector/slack/outbound/model/ChatPostMessageDataTest.java
+++ b/connectors/slack/src/test/java/io/camunda/connector/slack/outbound/model/ChatPostMessageDataTest.java
@@ -121,6 +121,7 @@ class ChatPostMessageDataTest {
     // Then
     ChatPostMessageRequest value = chatPostMessageRequest.getValue();
     assertThat(value.getChannel()).isEqualTo(USERID);
+    assertThat(value.isLinkNames()).isTrue();
   }
 
   @Test
@@ -167,6 +168,7 @@ class ChatPostMessageDataTest {
       // Then
       ChatPostMessageRequest value = chatPostMessageRequest.getValue();
       assertThat(value.getChannel()).isEqualTo(USERID);
+      assertThat(value.isLinkNames()).isTrue();
     }
   }
 
@@ -240,6 +242,7 @@ class ChatPostMessageDataTest {
     // Then
     ChatPostMessageRequest value = chatPostMessageRequest.getValue();
     assertThat(value.getChannel()).isEqualTo(USERID);
+    assertThat(value.isLinkNames()).isFalse();
   }
 
   @Test


### PR DESCRIPTION


* fix: slack connector user can now use mentions without using an ID

* test: add assertions for linkNames behavior in ChatPostMessageDataTest (#6805)

Agent-Logs-Url: https://github.com/camunda/connectors/sessions/c0d9223d-df3d-4c96-b6df-b3b580126cf6




---------



(cherry picked from commit 09fec0176b7d68c6755ebfa30e54251efe1b8c4f)

## Description

<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #

## Checklist

- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest
  release, as this branch will be rebased onto main before the next release. Example backport labels:
    - `backport stable/8.8`: for changes that should be included in the next 8.8.x release.
    - **or** `backport release-8.8.7`: for changes that should be included in the specific release 8.8.7, and this
      *release has already been created*. The release branch will be merged back into stable/8.8 later, so the change
      will be included in future 8.8.x releases as well.
- [ ] Tests/Integration tests for the changes have been added if applicable.

