### PR TITLE
chore(maven): change maven version

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,4 +1,4 @@
 java temurin-21.0.10+7.0.LTS
-maven 3.9.12
+maven 3.9.14
 pre-commit 4.5.1
 nodejs 24.14.0


### PR DESCRIPTION
This pull request updates the version of Maven used in the project to ensure compatibility with the latest features and bug fixes.

Dependency update:

* Updated Maven version from `3.9.12` to `3.9.14` in `.tool-versions` to keep build tooling up-to-date.