### PR TITLE
chore(maven): change spring boot version

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -89,7 +89,7 @@ limitations under the License.</license.inlineheader>
     <version.failsafe>3.3.2</version.failsafe>
     <version.hamcrest>3.0</version.hamcrest>
 
-    <version.spring-boot>3.5.12</version.spring-boot>
+    <version.spring-boot>3.5.13</version.spring-boot>
     <version.spring-cloud-gcp-starter-logging>7.4.5</version.spring-cloud-gcp-starter-logging>
     <version.logback>1.5.32</version.logback>
 


### PR DESCRIPTION
This pull request updates the Spring Boot dependency version in the project configuration to address version alignment or potential bug fixes.

Dependency version update:

* Updated the `version.spring-boot` property in `parent/pom.xml` from `3.5.12` to `3.5.13` to ensure the project uses the latest compatible Spring Boot release.