### PR TITLE
chore(helm): change helm-git-refs.json

### DIFF
--- a/.github/workflows/helm-git-refs.json
+++ b/.github/workflows/helm-git-refs.json
@@ -1,6 +1,6 @@
 {
-  "main": "camunda-platform-8.9",
-  "alpha/8.9": "camunda-platform-8.9",
+  "main": "camunda-platform-8.10",
+  "stable/8.9": "camunda-platform-8.9",
   "stable/8.8": "camunda-platform-8.8",
   "stable/8.7": "camunda-platform-8.7",
   "stable/8.6": "camunda-platform-8.6"


### PR DESCRIPTION
This pull request updates the Helm Git references configuration to track the latest release branch for the main development line and clarifies the naming of release branches.

- Release branch tracking:
  * Updated the `main` branch to now track `camunda-platform-8.10`, reflecting the latest development version.
  * Changed the previous `alpha/8.9` reference to `stable/8.9`, aligning with the stable release naming convention.