### PR TITLE
chore: kafka consumer group logging

### DIFF
--- a/connectors/kafka/element-templates/hybrid/kafka-inbound-connector-boundary-hybrid.json
+++ b/connectors/kafka/element-templates/hybrid/kafka-inbound-connector-boundary-hybrid.json
@@ -138,6 +138,7 @@
       "name" : "groupId",
       "type" : "zeebe:property"
     },
+    "tooltip" : "It is strongly recommended to provide an explicit consumer group ID. Use a stable, application-specific identifier that represents the logical consumer group in your application (for example, <code>my-app-order-processor</code>). Leaving this empty auto-generates an ID that may change across connector upgrades, causing message replay.",
     "type" : "String"
   }, {
     "id" : "additionalProperties",

--- a/connectors/kafka/element-templates/hybrid/kafka-inbound-connector-intermediate-hybrid.json
+++ b/connectors/kafka/element-templates/hybrid/kafka-inbound-connector-intermediate-hybrid.json
@@ -138,6 +138,7 @@
       "name" : "groupId",
       "type" : "zeebe:property"
     },
+    "tooltip" : "It is strongly recommended to provide an explicit consumer group ID. Use a stable, application-specific identifier that represents the logical consumer group in your application (for example, <code>my-app-order-processor</code>). Leaving this empty auto-generates an ID that may change across connector upgrades, causing message replay.",
     "type" : "String"
   }, {
     "id" : "additionalProperties",

--- a/connectors/kafka/element-templates/hybrid/kafka-inbound-connector-receive-hybrid.json
+++ b/connectors/kafka/element-templates/hybrid/kafka-inbound-connector-receive-hybrid.json
@@ -137,6 +137,7 @@
       "name" : "groupId",
       "type" : "zeebe:property"
     },
+    "tooltip" : "It is strongly recommended to provide an explicit consumer group ID. Use a stable, application-specific identifier that represents the logical consumer group in your application (for example, <code>my-app-order-processor</code>). Leaving this empty auto-generates an ID that may change across connector upgrades, causing message replay.",
     "type" : "String"
   }, {
     "id" : "additionalProperties",

--- a/connectors/kafka/element-templates/hybrid/kafka-inbound-connector-start-message-hybrid.json
+++ b/connectors/kafka/element-templates/hybrid/kafka-inbound-connector-start-message-hybrid.json
@@ -138,6 +138,7 @@
       "name" : "groupId",
       "type" : "zeebe:property"
     },
+    "tooltip" : "It is strongly recommended to provide an explicit consumer group ID. Use a stable, application-specific identifier that represents the logical consumer group in your application (for example, <code>my-app-order-processor</code>). Leaving this empty auto-generates an ID that may change across connector upgrades, causing message replay.",
     "type" : "String"
   }, {
     "id" : "additionalProperties",

--- a/connectors/kafka/element-templates/kafka-inbound-connector-boundary.json
+++ b/connectors/kafka/element-templates/kafka-inbound-connector-boundary.json
@@ -133,6 +133,7 @@
       "name" : "groupId",
       "type" : "zeebe:property"
     },
+    "tooltip" : "It is strongly recommended to provide an explicit consumer group ID. Use a stable, application-specific identifier that represents the logical consumer group in your application (for example, <code>my-app-order-processor</code>). Leaving this empty auto-generates an ID that may change across connector upgrades, causing message replay.",
     "type" : "String"
   }, {
     "id" : "additionalProperties",

--- a/connectors/kafka/element-templates/kafka-inbound-connector-intermediate.json
+++ b/connectors/kafka/element-templates/kafka-inbound-connector-intermediate.json
@@ -133,6 +133,7 @@
       "name" : "groupId",
       "type" : "zeebe:property"
     },
+    "tooltip" : "It is strongly recommended to provide an explicit consumer group ID. Use a stable, application-specific identifier that represents the logical consumer group in your application (for example, <code>my-app-order-processor</code>). Leaving this empty auto-generates an ID that may change across connector upgrades, causing message replay.",
     "type" : "String"
   }, {
     "id" : "additionalProperties",

--- a/connectors/kafka/element-templates/kafka-inbound-connector-receive.json
+++ b/connectors/kafka/element-templates/kafka-inbound-connector-receive.json
@@ -132,6 +132,7 @@
       "name" : "groupId",
       "type" : "zeebe:property"
     },
+    "tooltip" : "It is strongly recommended to provide an explicit consumer group ID. Use a stable, application-specific identifier that represents the logical consumer group in your application (for example, <code>my-app-order-processor</code>). Leaving this empty auto-generates an ID that may change across connector upgrades, causing message replay.",
     "type" : "String"
   }, {
     "id" : "additionalProperties",

--- a/connectors/kafka/element-templates/kafka-inbound-connector-start-message.json
+++ b/connectors/kafka/element-templates/kafka-inbound-connector-start-message.json
@@ -133,6 +133,7 @@
       "name" : "groupId",
       "type" : "zeebe:property"
     },
+    "tooltip" : "It is strongly recommended to provide an explicit consumer group ID. Use a stable, application-specific identifier that represents the logical consumer group in your application (for example, <code>my-app-order-processor</code>). Leaving this empty auto-generates an ID that may change across connector upgrades, causing message replay.",
     "type" : "String"
   }, {
     "id" : "additionalProperties",

--- a/connectors/kafka/src/main/java/io/camunda/connector/kafka/inbound/KafkaConnectorProperties.java
+++ b/connectors/kafka/src/main/java/io/camunda/connector/kafka/inbound/KafkaConnectorProperties.java
@@ -41,7 +41,12 @@ public record KafkaConnectorProperties(
             group = "kafka",
             label = "Consumer group ID",
             description =
-                "Provide the consumer group ID used by the connector. Leave empty for an automatically generated one")
+                "Provide the consumer group ID used by the connector. Leave empty for an automatically generated one",
+            tooltip =
+                "It is strongly recommended to provide an explicit consumer group ID. "
+                    + "Use a stable, application-specific identifier that represents the logical consumer group in your application "
+                    + "(for example, <code>my-app-order-processor</code>). "
+                    + "Leaving this empty auto-generates an ID that may change across connector upgrades, causing message replay.")
         String groupId,
     @FEEL
         @TemplateProperty(

--- a/connectors/kafka/src/main/java/io/camunda/connector/kafka/inbound/KafkaExecutable.java
+++ b/connectors/kafka/src/main/java/io/camunda/connector/kafka/inbound/KafkaExecutable.java
@@ -102,6 +102,30 @@ public class KafkaExecutable implements InboundConnectorExecutable<InboundConnec
 
       KafkaConnectorProperties elementProps =
           context.bindProperties(KafkaConnectorProperties.class);
+
+      // TODO: In 8.10, make groupId mandatory and remove auto-generation (see
+      // https://github.com/camunda/connectors/issues/6767)
+      if (elementProps.groupId() == null) {
+        context.log(
+            activity ->
+                activity
+                    .withSeverity(Severity.WARNING)
+                    .withTag(ActivityLogTag.CONSUMER)
+                    .withMessage(
+                        "No consumer group ID configured — an auto-generated ID will be used. "
+                            + "This is not recommended: the generated ID may change across connector upgrades, "
+                            + "causing the connector to be treated as a new consumer group and potentially replay messages. "
+                            + "Set an explicit Consumer Group ID in the connector configuration."));
+      }
+
+      var effectiveGroupId = KafkaPropertyTransformer.resolveGroupId(elementProps, context);
+      context.log(
+          activity ->
+              activity
+                  .withSeverity(Severity.INFO)
+                  .withTag(ActivityLogTag.CONSUMER)
+                  .withMessage("Using consumer group ID: " + effectiveGroupId));
+
       this.kafkaConnectorConsumer =
           new KafkaConnectorConsumer(consumerCreatorFunction, context, elementProps, retryPolicy);
       this.kafkaConnectorConsumer.startConsumer();

--- a/connectors/kafka/src/main/java/io/camunda/connector/kafka/inbound/KafkaExecutable.java
+++ b/connectors/kafka/src/main/java/io/camunda/connector/kafka/inbound/KafkaExecutable.java
@@ -20,6 +20,7 @@ import java.time.Duration;
 import java.util.Properties;
 import java.util.function.Function;
 import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -105,7 +106,15 @@ public class KafkaExecutable implements InboundConnectorExecutable<InboundConnec
 
       // TODO: In 8.10, make groupId mandatory and remove auto-generation (see
       // https://github.com/camunda/connectors/issues/6767)
-      if (elementProps.groupId() == null) {
+      var kafkaProps = KafkaPropertyTransformer.getKafkaProperties(elementProps, context);
+      var effectiveGroupId = kafkaProps.getProperty(ConsumerConfig.GROUP_ID_CONFIG);
+      boolean groupIdExplicitlySet =
+          elementProps.groupId() != null
+              || (elementProps.additionalProperties() != null
+                  && elementProps
+                      .additionalProperties()
+                      .containsKey(ConsumerConfig.GROUP_ID_CONFIG));
+      if (!groupIdExplicitlySet) {
         context.log(
             activity ->
                 activity
@@ -117,8 +126,6 @@ public class KafkaExecutable implements InboundConnectorExecutable<InboundConnec
                             + "causing the connector to be treated as a new consumer group and potentially replay messages. "
                             + "Set an explicit Consumer Group ID in the connector configuration."));
       }
-
-      var effectiveGroupId = KafkaPropertyTransformer.resolveGroupId(elementProps, context);
       context.log(
           activity ->
               activity

--- a/connectors/kafka/src/main/java/io/camunda/connector/kafka/inbound/KafkaPropertyTransformer.java
+++ b/connectors/kafka/src/main/java/io/camunda/connector/kafka/inbound/KafkaPropertyTransformer.java
@@ -86,7 +86,7 @@ public class KafkaPropertyTransformer {
     return kafkaProps;
   }
 
-  private static String resolveGroupId(
+  static String resolveGroupId(
       KafkaConnectorProperties kafkaConnectorProperties, InboundConnectorContext context) {
     var clientId = kafkaConnectorProperties.groupId();
     if (kafkaConnectorProperties.groupId() == null) {
@@ -96,6 +96,8 @@ public class KafkaPropertyTransformer {
   }
 
   private static String computeGroupId(InboundConnectorContext context) {
+    // TODO: In 8.10, remove auto-generation and make groupId mandatory (see
+    // https://github.com/camunda/connectors/issues/6767)
     return DEFAULT_GROUP_ID_PREFIX + "-" + context.getDefinition().deduplicationId();
   }
 

--- a/connectors/kafka/src/main/java/io/camunda/connector/kafka/inbound/KafkaPropertyTransformer.java
+++ b/connectors/kafka/src/main/java/io/camunda/connector/kafka/inbound/KafkaPropertyTransformer.java
@@ -86,7 +86,7 @@ public class KafkaPropertyTransformer {
     return kafkaProps;
   }
 
-  static String resolveGroupId(
+  private static String resolveGroupId(
       KafkaConnectorProperties kafkaConnectorProperties, InboundConnectorContext context) {
     var clientId = kafkaConnectorProperties.groupId();
     if (kafkaConnectorProperties.groupId() == null) {


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

- New activity log statements for Kafka connector to show the used consumer group ID and warn the user if no custom group ID is specified
- Tooltip in the element template that urges the user to define a group ID

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #6767 

## Checklist

- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest
  release, as this branch will be rebased onto main before the next release. Example backport labels:
    - `backport stable/8.8`: for changes that should be included in the next 8.8.x release.
    - **or** `backport release-8.8.7`: for changes that should be included in the specific release 8.8.7, and this
      *release has already been created*. The release branch will be merged back into stable/8.8 later, so the change
      will be included in future 8.8.x releases as well.
- [ ] Tests/Integration tests for the changes have been added if applicable.

