### PR TITLE
ci: remove unused PAT

### DIFF
--- a/.github/workflows/RELEASE.yaml
+++ b/.github/workflows/RELEASE.yaml
@@ -92,12 +92,6 @@ jobs:
         env:
           RELEASE_VERSION: ${{ inputs.version }}
 
-      - uses: actions/checkout@v6
-        with:
-          token: ${{ secrets.PROTECTED_BRANCH_PAT }}
-          ref: ${{ github.ref }}
-          fetch-depth: 0
-
       - name: Prepare Java and Maven settings
         uses: actions/setup-java@v5
         with:


### PR DESCRIPTION
## Description

This pull request makes a small change to the release workflow configuration by removing the step that checks out the repository using a protected branch token. This simplifies the workflow and may improve security or maintainability.

- Removed the `actions/checkout@v6` step that used a protected branch token and custom ref in `.github/workflows/RELEASE.yaml`.


## Checklist

- [x] Backport labels are added if these code changes should be backported. No backport label is added to the latest
  release, as this branch will be rebased onto main before the next release. Example backport labels:
    - `backport stable/8.8`: for changes that should be included in the next 8.8.x release.
    - **or** `backport release-8.8.7`: for changes that should be included in the specific release 8.8.7, and this
      *release has already been created*. The release branch will be merged back into stable/8.8 later, so the change
      will be included in future 8.8.x releases as well.
- [ ] Tests/Integration tests for the changes have been added if applicable.

