### PR TITLE
chore(renovate): Allow renovate-approve to approve PRs

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -9,13 +9,13 @@
 /connectors/aws/aws-bedrock-codeinterpreter @camunda/connectors-agentic-ai @camunda/connectors
 
 # These files are excluded so that Renovate can automatically merge dependency upgrades
-renovate.json
-**/*.yaml
-**/*.yml
-.github/**/*.yaml
-.github/**/*.yml
-.ci/preview-environments/charts/c8sm/*.yaml
-**/Dockerfile
-**/docker-images.properties
-.tool-versions
-**/pom.xml
+renovate.json @app/renovate-approve @camunda/connectors
+**/*.yaml @app/renovate-approve @camunda/connectors
+**/*.yml @app/renovate-approve @camunda/connectors
+.github/**/*.yaml @app/renovate-approve @camunda/connectors
+.github/**/*.yml @app/renovate-approve @camunda/connectors
+.ci/preview-environments/charts/c8sm/*.yaml @app/renovate-approve @camunda/connectors
+**/Dockerfile @app/renovate-approve @camunda/connectors
+**/docker-images.properties @app/renovate-approve @camunda/connectors
+.tool-versions @app/renovate-approve @camunda/connectors
+**/pom.xml @app/renovate-approve @camunda/connectors

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -8,14 +8,14 @@
 /connectors-e2e-test/connectors-e2e-test-agentic-ai @camunda/connectors-agentic-ai @camunda/connectors
 /connectors/aws/aws-bedrock-codeinterpreter @camunda/connectors-agentic-ai @camunda/connectors
 
-# These files are owned by renovate-approve (and connectors) so Renovate can auto-approve/automerge dependency upgrades under branch protection rules
-renovate.json @app/renovate-approve @camunda/connectors
-**/*.yaml @app/renovate-approve @camunda/connectors
-**/*.yml @app/renovate-approve @camunda/connectors
-.github/**/*.yaml @app/renovate-approve @camunda/connectors
-.github/**/*.yml @app/renovate-approve @camunda/connectors
-.ci/preview-environments/charts/c8sm/*.yaml @app/renovate-approve @camunda/connectors
-**/Dockerfile @app/renovate-approve @camunda/connectors
-**/docker-images.properties @app/renovate-approve @camunda/connectors
-.tool-versions @app/renovate-approve @camunda/connectors
-**/pom.xml @app/renovate-approve @camunda/connectors
+# These files are excluded so that Renovate can automatically merge dependency upgrades
+renovate.json
+**/*.yaml
+**/*.yml
+.github/**/*.yaml
+.github/**/*.yml
+.ci/preview-environments/charts/c8sm/*.yaml
+**/Dockerfile
+**/docker-images.properties
+.tool-versions
+**/pom.xml

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -8,7 +8,7 @@
 /connectors-e2e-test/connectors-e2e-test-agentic-ai @camunda/connectors-agentic-ai @camunda/connectors
 /connectors/aws/aws-bedrock-codeinterpreter @camunda/connectors-agentic-ai @camunda/connectors
 
-# These files are excluded so that Renovate can automatically merge dependency upgrades
+# These files are owned by renovate-approve (and connectors) so Renovate can auto-approve/automerge dependency upgrades under branch protection rules
 renovate.json @app/renovate-approve @camunda/connectors
 **/*.yaml @app/renovate-approve @camunda/connectors
 **/*.yml @app/renovate-approve @camunda/connectors

--- a/renovate.json
+++ b/renovate.json
@@ -1,8 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended",
-    "group:allNonMajor"
+    "config:recommended"
   ],
   "commitMessagePrefix": "deps:",
   "dependencyDashboard": true,
@@ -39,6 +38,18 @@
     }
   ],
   "packageRules": [
+    {
+      "groupName": "all non-major dependencies",
+      "groupSlug": "all-minor-patch",
+      "matchPackageNames": [
+        "*"
+      ],
+      "matchUpdateTypes": [
+        "minor",
+        "patch"
+      ],
+      "automerge": true
+    },
     {
       "matchManagers": [
         "maven",
@@ -104,7 +115,8 @@
       "matchUpdateTypes": [
         "digest"
       ],
-      "changelogUrl": "https://github.com/camunda/infra-global-github-actions/compare/{{currentDigest}}..{{newDigest}}"
+      "changelogUrl": "https://github.com/camunda/infra-global-github-actions/compare/{{currentDigest}}..{{newDigest}}",
+      "schedule": ["on sunday"]
     },
     {
       "description": "Disable major version updates to prevent breaking transitive dependency compatibility with langchain4j.",


### PR DESCRIPTION
## Description

- reverted code owners file changes
- added all non major group to rules manually and enabled automerging for them
- restricted infra update to once a week as the digest updates are a bit execessiv
- auto-approval seems not possible for target main, if we need this we might want to reach out to IT to change this on the github camunda org level.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #5907

## Checklist

- [x] Backport labels are added if these code changes should be backported. No backport label is added to the latest
  release, as this branch will be rebased onto main before the next release. Example backport labels:
    - `backport stable/8.8`: for changes that should be included in the next 8.8.x release.
    - **or** `backport release-8.8.7`: for changes that should be included in the specific release 8.8.7, and this
      *release has already been created*. The release branch will be merged back into stable/8.8 later, so the change
      will be included in future 8.8.x releases as well.
- [ ] Tests/Integration tests for the changes have been added if applicable.

