### PR TITLE
fix(agentic-ai): update AWS Bedrock model field to use inference profile IDs

### DIFF
--- a/connectors/agentic-ai/element-templates/agenticai-aiagent-job-worker.json
+++ b/connectors/agentic-ai/element-templates/agenticai-aiagent-job-worker.json
@@ -776,7 +776,8 @@
     "label" : "Model",
     "description" : "Specify the model ID. Details in the <a href=\"https://docs.anthropic.com/en/docs/about-claude/models/all-models\" target=\"_blank\">documentation</a>.",
     "optional" : false,
-    "value" : "claude-3-5-sonnet-20240620",
+    "value" : "",
+    "placeholder" : "claude-3-5-sonnet-20240620",
     "constraints" : {
       "notEmpty" : true
     },
@@ -863,9 +864,10 @@
   }, {
     "id" : "provider.bedrock.model.model",
     "label" : "Model",
-    "description" : "Specify the model ID. Details in the <a href=\"https://docs.aws.amazon.com/bedrock/latest/userguide/model-ids.html\" target=\"_blank\">documentation</a>.",
+    "description" : "Specify an inference profile ID. Details in the <a href=\"https://docs.aws.amazon.com/bedrock/latest/userguide/inference-profiles-support.html\" target=\"_blank\">documentation</a>.",
     "optional" : false,
-    "value" : "anthropic.claude-3-5-sonnet-20240620-v1:0",
+    "value" : "",
+    "placeholder" : "global.anthropic.claude-sonnet-4-5-20250929-v1:0",
     "constraints" : {
       "notEmpty" : true
     },

--- a/connectors/agentic-ai/element-templates/agenticai-aiagent-job-worker.json
+++ b/connectors/agentic-ai/element-templates/agenticai-aiagent-job-worker.json
@@ -776,7 +776,6 @@
     "label" : "Model",
     "description" : "Specify the model ID. Details in the <a href=\"https://docs.anthropic.com/en/docs/about-claude/models/all-models\" target=\"_blank\">documentation</a>.",
     "optional" : false,
-    "value" : "",
     "placeholder" : "claude-3-5-sonnet-20240620",
     "constraints" : {
       "notEmpty" : true
@@ -866,7 +865,6 @@
     "label" : "Model",
     "description" : "Specify an inference profile ID. Details in the <a href=\"https://docs.aws.amazon.com/bedrock/latest/userguide/inference-profiles-support.html\" target=\"_blank\">documentation</a>.",
     "optional" : false,
-    "value" : "",
     "placeholder" : "global.anthropic.claude-sonnet-4-5-20250929-v1:0",
     "constraints" : {
       "notEmpty" : true

--- a/connectors/agentic-ai/element-templates/agenticai-aiagent-job-worker.json
+++ b/connectors/agentic-ai/element-templates/agenticai-aiagent-job-worker.json
@@ -776,7 +776,7 @@
     "label" : "Model",
     "description" : "Specify the model ID. Details in the <a href=\"https://docs.anthropic.com/en/docs/about-claude/models/all-models\" target=\"_blank\">documentation</a>.",
     "optional" : false,
-    "placeholder" : "claude-3-5-sonnet-20240620",
+    "placeholder" : "claude-sonnet-4-6",
     "constraints" : {
       "notEmpty" : true
     },
@@ -865,7 +865,7 @@
     "label" : "Model",
     "description" : "Specify an inference profile ID. Details in the <a href=\"https://docs.aws.amazon.com/bedrock/latest/userguide/inference-profiles-support.html\" target=\"_blank\">documentation</a>.",
     "optional" : false,
-    "placeholder" : "global.anthropic.claude-sonnet-4-5-20250929-v1:0",
+    "placeholder" : "global.anthropic.claude-sonnet-4-6",
     "constraints" : {
       "notEmpty" : true
     },

--- a/connectors/agentic-ai/element-templates/agenticai-aiagent-outbound-connector.json
+++ b/connectors/agentic-ai/element-templates/agenticai-aiagent-outbound-connector.json
@@ -755,7 +755,7 @@
     "label" : "Model",
     "description" : "Specify the model ID. Details in the <a href=\"https://docs.anthropic.com/en/docs/about-claude/models/all-models\" target=\"_blank\">documentation</a>.",
     "optional" : false,
-    "placeholder" : "claude-3-5-sonnet-20240620",
+    "placeholder" : "claude-sonnet-4-6",
     "constraints" : {
       "notEmpty" : true
     },
@@ -844,7 +844,7 @@
     "label" : "Model",
     "description" : "Specify an inference profile ID. Details in the <a href=\"https://docs.aws.amazon.com/bedrock/latest/userguide/inference-profiles-support.html\" target=\"_blank\">documentation</a>.",
     "optional" : false,
-    "placeholder" : "global.anthropic.claude-sonnet-4-5-20250929-v1:0",
+    "placeholder" : "global.anthropic.claude-sonnet-4-6",
     "constraints" : {
       "notEmpty" : true
     },

--- a/connectors/agentic-ai/element-templates/agenticai-aiagent-outbound-connector.json
+++ b/connectors/agentic-ai/element-templates/agenticai-aiagent-outbound-connector.json
@@ -755,7 +755,8 @@
     "label" : "Model",
     "description" : "Specify the model ID. Details in the <a href=\"https://docs.anthropic.com/en/docs/about-claude/models/all-models\" target=\"_blank\">documentation</a>.",
     "optional" : false,
-    "value" : "claude-3-5-sonnet-20240620",
+    "value" : "",
+    "placeholder" : "claude-3-5-sonnet-20240620",
     "constraints" : {
       "notEmpty" : true
     },
@@ -842,9 +843,10 @@
   }, {
     "id" : "provider.bedrock.model.model",
     "label" : "Model",
-    "description" : "Specify the model ID. Details in the <a href=\"https://docs.aws.amazon.com/bedrock/latest/userguide/model-ids.html\" target=\"_blank\">documentation</a>.",
+    "description" : "Specify an inference profile ID. Details in the <a href=\"https://docs.aws.amazon.com/bedrock/latest/userguide/inference-profiles-support.html\" target=\"_blank\">documentation</a>.",
     "optional" : false,
-    "value" : "anthropic.claude-3-5-sonnet-20240620-v1:0",
+    "value" : "",
+    "placeholder" : "global.anthropic.claude-sonnet-4-5-20250929-v1:0",
     "constraints" : {
       "notEmpty" : true
     },

--- a/connectors/agentic-ai/element-templates/agenticai-aiagent-outbound-connector.json
+++ b/connectors/agentic-ai/element-templates/agenticai-aiagent-outbound-connector.json
@@ -755,7 +755,6 @@
     "label" : "Model",
     "description" : "Specify the model ID. Details in the <a href=\"https://docs.anthropic.com/en/docs/about-claude/models/all-models\" target=\"_blank\">documentation</a>.",
     "optional" : false,
-    "value" : "",
     "placeholder" : "claude-3-5-sonnet-20240620",
     "constraints" : {
       "notEmpty" : true
@@ -845,7 +844,6 @@
     "label" : "Model",
     "description" : "Specify an inference profile ID. Details in the <a href=\"https://docs.aws.amazon.com/bedrock/latest/userguide/inference-profiles-support.html\" target=\"_blank\">documentation</a>.",
     "optional" : false,
-    "value" : "",
     "placeholder" : "global.anthropic.claude-sonnet-4-5-20250929-v1:0",
     "constraints" : {
       "notEmpty" : true

--- a/connectors/agentic-ai/element-templates/hybrid/agenticai-aiagent-job-worker-hybrid.json
+++ b/connectors/agentic-ai/element-templates/hybrid/agenticai-aiagent-job-worker-hybrid.json
@@ -781,7 +781,8 @@
     "label" : "Model",
     "description" : "Specify the model ID. Details in the <a href=\"https://docs.anthropic.com/en/docs/about-claude/models/all-models\" target=\"_blank\">documentation</a>.",
     "optional" : false,
-    "value" : "claude-3-5-sonnet-20240620",
+    "value" : "",
+    "placeholder" : "claude-3-5-sonnet-20240620",
     "constraints" : {
       "notEmpty" : true
     },
@@ -868,9 +869,10 @@
   }, {
     "id" : "provider.bedrock.model.model",
     "label" : "Model",
-    "description" : "Specify the model ID. Details in the <a href=\"https://docs.aws.amazon.com/bedrock/latest/userguide/model-ids.html\" target=\"_blank\">documentation</a>.",
+    "description" : "Specify an inference profile ID. Details in the <a href=\"https://docs.aws.amazon.com/bedrock/latest/userguide/inference-profiles-support.html\" target=\"_blank\">documentation</a>.",
     "optional" : false,
-    "value" : "anthropic.claude-3-5-sonnet-20240620-v1:0",
+    "value" : "",
+    "placeholder" : "global.anthropic.claude-sonnet-4-5-20250929-v1:0",
     "constraints" : {
       "notEmpty" : true
     },

--- a/connectors/agentic-ai/element-templates/hybrid/agenticai-aiagent-job-worker-hybrid.json
+++ b/connectors/agentic-ai/element-templates/hybrid/agenticai-aiagent-job-worker-hybrid.json
@@ -781,7 +781,6 @@
     "label" : "Model",
     "description" : "Specify the model ID. Details in the <a href=\"https://docs.anthropic.com/en/docs/about-claude/models/all-models\" target=\"_blank\">documentation</a>.",
     "optional" : false,
-    "value" : "",
     "placeholder" : "claude-3-5-sonnet-20240620",
     "constraints" : {
       "notEmpty" : true
@@ -871,7 +870,6 @@
     "label" : "Model",
     "description" : "Specify an inference profile ID. Details in the <a href=\"https://docs.aws.amazon.com/bedrock/latest/userguide/inference-profiles-support.html\" target=\"_blank\">documentation</a>.",
     "optional" : false,
-    "value" : "",
     "placeholder" : "global.anthropic.claude-sonnet-4-5-20250929-v1:0",
     "constraints" : {
       "notEmpty" : true

--- a/connectors/agentic-ai/element-templates/hybrid/agenticai-aiagent-job-worker-hybrid.json
+++ b/connectors/agentic-ai/element-templates/hybrid/agenticai-aiagent-job-worker-hybrid.json
@@ -781,7 +781,7 @@
     "label" : "Model",
     "description" : "Specify the model ID. Details in the <a href=\"https://docs.anthropic.com/en/docs/about-claude/models/all-models\" target=\"_blank\">documentation</a>.",
     "optional" : false,
-    "placeholder" : "claude-3-5-sonnet-20240620",
+    "placeholder" : "claude-sonnet-4-6",
     "constraints" : {
       "notEmpty" : true
     },
@@ -870,7 +870,7 @@
     "label" : "Model",
     "description" : "Specify an inference profile ID. Details in the <a href=\"https://docs.aws.amazon.com/bedrock/latest/userguide/inference-profiles-support.html\" target=\"_blank\">documentation</a>.",
     "optional" : false,
-    "placeholder" : "global.anthropic.claude-sonnet-4-5-20250929-v1:0",
+    "placeholder" : "global.anthropic.claude-sonnet-4-6",
     "constraints" : {
       "notEmpty" : true
     },

--- a/connectors/agentic-ai/element-templates/hybrid/agenticai-aiagent-outbound-connector-hybrid.json
+++ b/connectors/agentic-ai/element-templates/hybrid/agenticai-aiagent-outbound-connector-hybrid.json
@@ -760,7 +760,7 @@
     "label" : "Model",
     "description" : "Specify the model ID. Details in the <a href=\"https://docs.anthropic.com/en/docs/about-claude/models/all-models\" target=\"_blank\">documentation</a>.",
     "optional" : false,
-    "placeholder" : "claude-3-5-sonnet-20240620",
+    "placeholder" : "claude-sonnet-4-6",
     "constraints" : {
       "notEmpty" : true
     },
@@ -849,7 +849,7 @@
     "label" : "Model",
     "description" : "Specify an inference profile ID. Details in the <a href=\"https://docs.aws.amazon.com/bedrock/latest/userguide/inference-profiles-support.html\" target=\"_blank\">documentation</a>.",
     "optional" : false,
-    "placeholder" : "global.anthropic.claude-sonnet-4-5-20250929-v1:0",
+    "placeholder" : "global.anthropic.claude-sonnet-4-6",
     "constraints" : {
       "notEmpty" : true
     },

--- a/connectors/agentic-ai/element-templates/hybrid/agenticai-aiagent-outbound-connector-hybrid.json
+++ b/connectors/agentic-ai/element-templates/hybrid/agenticai-aiagent-outbound-connector-hybrid.json
@@ -760,7 +760,8 @@
     "label" : "Model",
     "description" : "Specify the model ID. Details in the <a href=\"https://docs.anthropic.com/en/docs/about-claude/models/all-models\" target=\"_blank\">documentation</a>.",
     "optional" : false,
-    "value" : "claude-3-5-sonnet-20240620",
+    "value" : "",
+    "placeholder" : "claude-3-5-sonnet-20240620",
     "constraints" : {
       "notEmpty" : true
     },
@@ -847,9 +848,10 @@
   }, {
     "id" : "provider.bedrock.model.model",
     "label" : "Model",
-    "description" : "Specify the model ID. Details in the <a href=\"https://docs.aws.amazon.com/bedrock/latest/userguide/model-ids.html\" target=\"_blank\">documentation</a>.",
+    "description" : "Specify an inference profile ID. Details in the <a href=\"https://docs.aws.amazon.com/bedrock/latest/userguide/inference-profiles-support.html\" target=\"_blank\">documentation</a>.",
     "optional" : false,
-    "value" : "anthropic.claude-3-5-sonnet-20240620-v1:0",
+    "value" : "",
+    "placeholder" : "global.anthropic.claude-sonnet-4-5-20250929-v1:0",
     "constraints" : {
       "notEmpty" : true
     },

--- a/connectors/agentic-ai/element-templates/hybrid/agenticai-aiagent-outbound-connector-hybrid.json
+++ b/connectors/agentic-ai/element-templates/hybrid/agenticai-aiagent-outbound-connector-hybrid.json
@@ -760,7 +760,6 @@
     "label" : "Model",
     "description" : "Specify the model ID. Details in the <a href=\"https://docs.anthropic.com/en/docs/about-claude/models/all-models\" target=\"_blank\">documentation</a>.",
     "optional" : false,
-    "value" : "",
     "placeholder" : "claude-3-5-sonnet-20240620",
     "constraints" : {
       "notEmpty" : true
@@ -850,7 +849,6 @@
     "label" : "Model",
     "description" : "Specify an inference profile ID. Details in the <a href=\"https://docs.aws.amazon.com/bedrock/latest/userguide/inference-profiles-support.html\" target=\"_blank\">documentation</a>.",
     "optional" : false,
-    "value" : "",
     "placeholder" : "global.anthropic.claude-sonnet-4-5-20250929-v1:0",
     "constraints" : {
       "notEmpty" : true

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/provider/AnthropicProviderConfiguration.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/provider/AnthropicProviderConfiguration.java
@@ -65,6 +65,7 @@ public record AnthropicProviderConfiguration(@Valid @NotNull AnthropicConnection
               feel = FeelMode.optional,
               defaultValue = "",
               defaultValueType = TemplateProperty.DefaultValueType.String,
+              placeholder = "claude-3-5-sonnet-20240620",
               constraints = @TemplateProperty.PropertyConstraints(notEmpty = true))
           String model,
       @Valid AnthropicModel.AnthropicModelParameters parameters) {

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/provider/AnthropicProviderConfiguration.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/provider/AnthropicProviderConfiguration.java
@@ -65,7 +65,7 @@ public record AnthropicProviderConfiguration(@Valid @NotNull AnthropicConnection
               feel = FeelMode.optional,
               defaultValue = "",
               defaultValueType = TemplateProperty.DefaultValueType.String,
-              placeholder = "claude-3-5-sonnet-20240620",
+              placeholder = "claude-sonnet-4-6",
               constraints = @TemplateProperty.PropertyConstraints(notEmpty = true))
           String model,
       @Valid AnthropicModel.AnthropicModelParameters parameters) {

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/provider/AnthropicProviderConfiguration.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/provider/AnthropicProviderConfiguration.java
@@ -63,7 +63,7 @@ public record AnthropicProviderConfiguration(@Valid @NotNull AnthropicConnection
                   "Specify the model ID. Details in the <a href=\"https://docs.anthropic.com/en/docs/about-claude/models/all-models\" target=\"_blank\">documentation</a>.",
               type = TemplateProperty.PropertyType.String,
               feel = FeelMode.optional,
-              defaultValue = "claude-3-5-sonnet-20240620",
+              defaultValue = "",
               defaultValueType = TemplateProperty.DefaultValueType.String,
               constraints = @TemplateProperty.PropertyConstraints(notEmpty = true))
           String model,

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/provider/BedrockProviderConfiguration.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/provider/BedrockProviderConfiguration.java
@@ -136,6 +136,7 @@ public record BedrockProviderConfiguration(@Valid @NotNull BedrockConnection bed
               feel = FeelMode.optional,
               defaultValue = "",
               defaultValueType = TemplateProperty.DefaultValueType.String,
+              placeholder = "global.anthropic.claude-sonnet-4-5-20250929-v1:0",
               constraints = @TemplateProperty.PropertyConstraints(notEmpty = true))
           String model,
       @Valid BedrockModel.BedrockModelParameters parameters) {

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/provider/BedrockProviderConfiguration.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/provider/BedrockProviderConfiguration.java
@@ -136,7 +136,7 @@ public record BedrockProviderConfiguration(@Valid @NotNull BedrockConnection bed
               feel = FeelMode.optional,
               defaultValue = "",
               defaultValueType = TemplateProperty.DefaultValueType.String,
-              placeholder = "global.anthropic.claude-sonnet-4-5-20250929-v1:0",
+              placeholder = "global.anthropic.claude-sonnet-4-6",
               constraints = @TemplateProperty.PropertyConstraints(notEmpty = true))
           String model,
       @Valid BedrockModel.BedrockModelParameters parameters) {

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/provider/BedrockProviderConfiguration.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/provider/BedrockProviderConfiguration.java
@@ -131,10 +131,10 @@ public record BedrockProviderConfiguration(@Valid @NotNull BedrockConnection bed
               group = "model",
               label = "Model",
               description =
-                  "Specify the model ID. Details in the <a href=\"https://docs.aws.amazon.com/bedrock/latest/userguide/model-ids.html\" target=\"_blank\">documentation</a>.",
+                  "Specify an inference profile ID. Details in the <a href=\"https://docs.aws.amazon.com/bedrock/latest/userguide/inference-profiles-support.html\" target=\"_blank\">documentation</a>.",
               type = TemplateProperty.PropertyType.String,
               feel = FeelMode.optional,
-              defaultValue = "anthropic.claude-3-5-sonnet-20240620-v1:0",
+              defaultValue = "",
               defaultValueType = TemplateProperty.DefaultValueType.String,
               constraints = @TemplateProperty.PropertyConstraints(notEmpty = true))
           String model,


### PR DESCRIPTION
## Description

Update the AWS Bedrock model field in the AI Agent connector element templates to use inference profile IDs. The previous description linked to the model IDs documentation page and used an outdated model ID as the default value. AWS Bedrock now requires inference profile IDs.

Changes:
- Updated description text and documentation link to https://docs.aws.amazon.com/bedrock/latest/userguide/inference-profiles-support.html
- Removed the outdated default model ID, replaced with a placeholder showing an example inference profile ID

## Related issues

closes #6875

## Checklist

- [ ] Backport labels are added if these code changes should be backported.