### PR TITLE
feat(element-template-generator): add placeholder support to @TemplateProperty

### DIFF
--- a/element-template-generator/annotations/src/main/java/io/camunda/connector/generator/java/annotation/TemplateProperty.java
+++ b/element-template-generator/annotations/src/main/java/io/camunda/connector/generator/java/annotation/TemplateProperty.java
@@ -116,6 +116,9 @@ public @interface TemplateProperty {
   /** Tooltip for the property */
   String tooltip() default "";
 
+  /** Placeholder text shown in the property input field when it is empty (String and Text only) */
+  String placeholder() default "";
+
   enum PropertyType {
     Boolean,
     Number,

--- a/element-template-generator/core/src/main/java/io/camunda/connector/generator/dsl/BooleanProperty.java
+++ b/element-template-generator/core/src/main/java/io/camunda/connector/generator/dsl/BooleanProperty.java
@@ -49,6 +49,7 @@ public final class BooleanProperty extends Property {
         binding,
         condition,
         tooltip,
+        null,
         exampleValue,
         TYPE);
   }

--- a/element-template-generator/core/src/main/java/io/camunda/connector/generator/dsl/DropdownProperty.java
+++ b/element-template-generator/core/src/main/java/io/camunda/connector/generator/dsl/DropdownProperty.java
@@ -53,6 +53,7 @@ public final class DropdownProperty extends Property {
         binding,
         condition,
         tooltip,
+        null,
         exampleValue,
         TYPE);
     this.choices = choices;

--- a/element-template-generator/core/src/main/java/io/camunda/connector/generator/dsl/HiddenProperty.java
+++ b/element-template-generator/core/src/main/java/io/camunda/connector/generator/dsl/HiddenProperty.java
@@ -48,6 +48,7 @@ public final class HiddenProperty extends Property {
         condition,
         null,
         null,
+        null,
         TYPE);
   }
 

--- a/element-template-generator/core/src/main/java/io/camunda/connector/generator/dsl/NumberProperty.java
+++ b/element-template-generator/core/src/main/java/io/camunda/connector/generator/dsl/NumberProperty.java
@@ -49,6 +49,7 @@ public final class NumberProperty extends Property {
         binding,
         condition,
         tooltip,
+        null,
         exampleValue,
         TYPE);
   }

--- a/element-template-generator/core/src/main/java/io/camunda/connector/generator/dsl/Property.java
+++ b/element-template-generator/core/src/main/java/io/camunda/connector/generator/dsl/Property.java
@@ -42,6 +42,7 @@ public abstract sealed class Property
   protected final PropertyBinding binding;
   protected final PropertyCondition condition;
   protected final String tooltip;
+  protected final String placeholder;
   protected final Object exampleValue;
   protected final String type;
 
@@ -60,6 +61,7 @@ public abstract sealed class Property
       PropertyBinding binding,
       PropertyCondition condition,
       String tooltip,
+      String placeholder,
       Object exampleValue,
       String type) {
     this.id = id;
@@ -74,6 +76,7 @@ public abstract sealed class Property
     this.binding = binding;
     this.condition = condition;
     this.tooltip = tooltip;
+    this.placeholder = placeholder;
     this.type = type;
     this.exampleValue = exampleValue;
   }
@@ -131,6 +134,10 @@ public abstract sealed class Property
 
   public String getTooltip() {
     return tooltip;
+  }
+
+  public String getPlaceholder() {
+    return placeholder;
   }
 
   public Boolean getOptional() {

--- a/element-template-generator/core/src/main/java/io/camunda/connector/generator/dsl/PropertyBuilder.java
+++ b/element-template-generator/core/src/main/java/io/camunda/connector/generator/dsl/PropertyBuilder.java
@@ -33,6 +33,7 @@ public abstract class PropertyBuilder {
   protected String type;
   protected PropertyCondition condition;
   protected String tooltip;
+  protected String placeholder;
   protected Object exampleValue;
 
   protected PropertyBuilder() {}
@@ -116,6 +117,11 @@ public abstract class PropertyBuilder {
 
   public PropertyBuilder tooltip(String tooltip) {
     this.tooltip = tooltip;
+    return this;
+  }
+
+  public PropertyBuilder placeholder(String placeholder) {
+    this.placeholder = placeholder;
     return this;
   }
 

--- a/element-template-generator/core/src/main/java/io/camunda/connector/generator/dsl/StringProperty.java
+++ b/element-template-generator/core/src/main/java/io/camunda/connector/generator/dsl/StringProperty.java
@@ -35,6 +35,7 @@ public final class StringProperty extends Property {
       PropertyBinding binding,
       PropertyCondition condition,
       String tooltip,
+      String placeholder,
       Object exampleValue) {
     super(
         name,
@@ -49,6 +50,7 @@ public final class StringProperty extends Property {
         binding,
         condition,
         tooltip,
+        placeholder,
         exampleValue,
         TYPE);
   }
@@ -82,6 +84,7 @@ public final class StringProperty extends Property {
           binding,
           condition,
           tooltip,
+          placeholder,
           exampleValue);
     }
   }

--- a/element-template-generator/core/src/main/java/io/camunda/connector/generator/dsl/TextProperty.java
+++ b/element-template-generator/core/src/main/java/io/camunda/connector/generator/dsl/TextProperty.java
@@ -35,6 +35,7 @@ public final class TextProperty extends Property {
       PropertyBinding binding,
       PropertyCondition condition,
       String tooltip,
+      String placeholder,
       Object exampleValue) {
     super(
         name,
@@ -49,6 +50,7 @@ public final class TextProperty extends Property {
         binding,
         condition,
         tooltip,
+        placeholder,
         exampleValue,
         TYPE);
   }
@@ -82,6 +84,7 @@ public final class TextProperty extends Property {
           binding,
           condition,
           tooltip,
+          placeholder,
           exampleValue);
     }
   }

--- a/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/processor/TemplatePropertyAnnotationProcessor.java
+++ b/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/processor/TemplatePropertyAnnotationProcessor.java
@@ -150,6 +150,12 @@ public class TemplatePropertyAnnotationProcessor implements AnnotationProcessor 
     if (!annotation.description().isBlank()) {
       builder.description(annotation.description());
     }
+    if (!annotation.tooltip().isBlank()) {
+      builder.tooltip(annotation.tooltip());
+    }
+    if (!annotation.placeholder().isBlank()) {
+      builder.placeholder(annotation.placeholder());
+    }
     if (!annotation.defaultValue().isBlank()) {
       builder.value(getValue(annotation, type, isOutbound(context)));
     }

--- a/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/util/OperationBasedConnectorUtil.java
+++ b/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/util/OperationBasedConnectorUtil.java
@@ -141,6 +141,7 @@ public class OperationBasedConnectorUtil {
               !templateProperty.group().isBlank() ? templateProperty.group() : OPERATION_GROUP_ID)
           .label(templateProperty.label())
           .tooltip(templateProperty.tooltip())
+          .placeholder(templateProperty.placeholder())
           .description(templateProperty.description())
           .feel(templateProperty.feel());
 

--- a/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/util/TemplatePropertiesUtil.java
+++ b/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/util/TemplatePropertiesUtil.java
@@ -195,7 +195,7 @@ public class TemplatePropertiesUtil {
     var variableAnnotation = declaredProperty.getAnnotation(Variable.class);
     var headerAnnotation = declaredProperty.getAnnotation(Header.class);
 
-    String name, label, tooltip = null, exampleValue = null;
+    String name, label, tooltip = null, exampleValue = null, placeholder = null;
     String bindingName = declaredName;
     if (templatePropertyAnnotation != null) {
       if (templatePropertyAnnotation.ignore()) {
@@ -219,6 +219,9 @@ public class TemplatePropertiesUtil {
       }
       if (!templatePropertyAnnotation.exampleValue().isBlank()) {
         exampleValue = templatePropertyAnnotation.exampleValue();
+      }
+      if (!templatePropertyAnnotation.placeholder().isBlank()) {
+        placeholder = templatePropertyAnnotation.placeholder();
       }
     } else {
       name = declaredName;
@@ -247,6 +250,7 @@ public class TemplatePropertiesUtil {
             .id(name)
             .label(label)
             .tooltip(tooltip)
+            .placeholder(placeholder)
             .exampleValue(exampleValue)
             .binding(createBinding(bindingName, context));
 

--- a/element-template-generator/core/src/test/java/io/camunda/connector/generator/java/OutboundClassBasedTemplateGeneratorTest.java
+++ b/element-template-generator/core/src/test/java/io/camunda/connector/generator/java/OutboundClassBasedTemplateGeneratorTest.java
@@ -585,6 +585,13 @@ public class OutboundClassBasedTemplateGeneratorTest extends BaseTest {
     }
 
     @Test
+    void annotatedProperty_placeholderPresent() {
+      var template = generator.generate(MyConnectorFunction.MinimallyAnnotated.class).getFirst();
+      var property = getPropertyById("annotatedStringProperty", template);
+      assertThat(property.getPlaceholder()).isEqualTo("placeholder");
+    }
+
+    @Test
     void booleanProperty() {
       var template = generator.generate(MyConnectorFunction.MinimallyAnnotated.class).getFirst();
       var property = getPropertyById("booleanProperty", template);

--- a/element-template-generator/core/src/test/java/io/camunda/connector/generator/java/example/outbound/MyConnectorInput.java
+++ b/element-template-generator/core/src/test/java/io/camunda/connector/generator/java/example/outbound/MyConnectorInput.java
@@ -49,7 +49,8 @@ public record MyConnectorInput(
             description = "description",
             constraints = @TemplateProperty.PropertyConstraints(notEmpty = true),
             exampleValue = "My example value",
-            tooltip = "tooltip")
+            tooltip = "tooltip",
+            placeholder = "placeholder")
         String annotatedStringProperty,
     String notAnnotatedStringProperty,
     Object objectProperty,


### PR DESCRIPTION
## Description

Adds `placeholder` support to the element-template-generator so it can be declared via `@TemplateProperty(placeholder = "...")` Java annotations and is correctly emitted in generated JSON element templates.

The [Zeebe element-template JSON schema](https://unpkg.com/@camunda/element-templates-json-schema/resources/schema.json) supports a `placeholder` field for `String` and `Text` property types. Previously there was no way to set it from Java annotations — developers had to manually add `"placeholder"` to generated templates, which would be overwritten on every regeneration.

Also fixes a silent bug: `@TemplateProperty(tooltip = "...")` was declared in the annotation since its introduction but was never extracted by `TemplatePropertyAnnotationProcessor` on class-based connectors (it only worked via the `OperationBasedConnectorUtil` path).

### Changes

**`element-template-generator/annotations`**
- Add `String placeholder() default ""` to `@TemplateProperty`

**`element-template-generator/core`** — DSL model
- `Property`: add `placeholder` field, constructor param, `getPlaceholder()` getter
- `PropertyBuilder`: add `placeholder` field and builder method
- `StringProperty`, `TextProperty`: pass `placeholder` through constructor and builder
- `BooleanProperty`, `NumberProperty`, `DropdownProperty`, `HiddenProperty`: pass `null` (placeholder is only valid for String/Text per schema)

**`element-template-generator/core`** — annotation processing
- `TemplatePropertyAnnotationProcessor`: extract `tooltip` (bugfix) and `placeholder` from annotation
- `TemplatePropertiesUtil`: extract and pass `placeholder`
- `OperationBasedConnectorUtil`: pass `placeholder` alongside existing `tooltip`

**Tests**
- `MyConnectorInput`: add `placeholder = "placeholder"` to test annotation
- `OutboundClassBasedTemplateGeneratorTest`: add `annotatedProperty_placeholderPresent` test

## Related issues

Closes #6878

## Checklist

- [x] Milestone set
- [ ] Backport labels set (if applicable)
