### PR TITLE
chore(ci): Test and fix docs version bump on minor release

### DIFF
--- a/.github/workflows/RELEASE.yaml
+++ b/.github/workflows/RELEASE.yaml
@@ -56,6 +56,7 @@ jobs:
             
             This message will be replaced with the full changelog once the release process completes.
 
+
   setup:
     needs: create-release
     name: Prepare the repository
@@ -161,7 +162,6 @@ jobs:
           path: .
           include-hidden-files: 'true'
 
-
   e2e-tests:
     needs: setup
     name: Run E2E tests
@@ -233,7 +233,6 @@ jobs:
           name: e2e-surefire-reports
           path: 'connectors-e2e-test/**/target/surefire-reports/*.xml'
 
-
   version-bump-docs-links:
     needs: [setup, e2e-tests]
     name: Version bump documentation links, if this is the first minor release
@@ -245,6 +244,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
+          ref: ${{ github.ref }}
           fetch-depth: 0
 
       - name: Fetch main branch
@@ -294,6 +294,7 @@ jobs:
           title: "chore(docs-links): bump versions from ${{ steps.version_check.outputs.previous_minor }} to ${{ steps.version_check.outputs.current_minor }}"
           body: |
             This bumps docs version of latest's element templates of a connector to latest minor version.
+
 
   maven-release:
     needs: [setup, e2e-tests]
@@ -586,6 +587,7 @@ jobs:
             bundle/default-bundle/target/connectors-bundle-sbom.xml
             connectors-bundle-templates-${{ inputs.version }}.tar.gz
             connectors-bundle-templates-${{ inputs.version }}.zip
+
 
   helm-deploy:
     needs: [ setup, e2e-tests, docker-release ]

--- a/connectors/aws/aws-comprehend/element-templates/aws-comprehend-outbound-connector.json
+++ b/connectors/aws/aws-comprehend/element-templates/aws-comprehend-outbound-connector.json
@@ -6,7 +6,7 @@
   "metadata" : {
     "keywords" : [ ]
   },
-  "documentationRef" : "https://docs.camunda.io/docs/8.7/components/connectors/out-of-the-box-connectors/amazon-comprehend/",
+  "documentationRef" : "https://docs.camunda.io/docs/8.8/components/connectors/out-of-the-box-connectors/amazon-comprehend/",
   "version" : 2,
   "category" : {
     "id" : "connectors",

--- a/connectors/aws/aws-comprehend/element-templates/hybrid/aws-comprehend-outbound-connector-hybrid.json
+++ b/connectors/aws/aws-comprehend/element-templates/hybrid/aws-comprehend-outbound-connector-hybrid.json
@@ -6,7 +6,7 @@
   "metadata" : {
     "keywords" : [ ]
   },
-  "documentationRef" : "https://docs.camunda.io/docs/8.7/components/connectors/out-of-the-box-connectors/amazon-comprehend/",
+  "documentationRef" : "https://docs.camunda.io/docs/8.8/components/connectors/out-of-the-box-connectors/amazon-comprehend/",
   "version" : 2,
   "category" : {
     "id" : "connectors",

--- a/connectors/aws/aws-comprehend/src/main/java/io/camunda/connector/comprehend/ComprehendConnectorFunction.java
+++ b/connectors/aws/aws-comprehend/src/main/java/io/camunda/connector/comprehend/ComprehendConnectorFunction.java
@@ -35,7 +35,7 @@ import io.camunda.connector.generator.java.annotation.ElementTemplate;
       @ElementTemplate.PropertyGroup(id = "input", label = "Data Configuration and Processing")
     },
     documentationRef =
-        "https://docs.camunda.io/docs/8.7/components/connectors/out-of-the-box-connectors/amazon-comprehend/",
+        "https://docs.camunda.io/docs/8.8/components/connectors/out-of-the-box-connectors/amazon-comprehend/",
     icon = "icon.svg")
 public class ComprehendConnectorFunction implements OutboundConnectorFunction {
 

--- a/connectors/aws/aws-s3/element-templates/aws-s3-outbound-connector.json
+++ b/connectors/aws/aws-s3/element-templates/aws-s3-outbound-connector.json
@@ -6,7 +6,7 @@
   "metadata" : {
     "keywords" : [ ]
   },
-  "documentationRef" : "https://docs.camunda.io/docs/8.7/components/connectors/out-of-the-box-connectors/amazon-s3/",
+  "documentationRef" : "https://docs.camunda.io/docs/8.8/components/connectors/out-of-the-box-connectors/amazon-s3/",
   "version" : 2,
   "category" : {
     "id" : "connectors",

--- a/connectors/aws/aws-s3/element-templates/hybrid/aws-s3-outbound-connector-hybrid.json
+++ b/connectors/aws/aws-s3/element-templates/hybrid/aws-s3-outbound-connector-hybrid.json
@@ -6,7 +6,7 @@
   "metadata" : {
     "keywords" : [ ]
   },
-  "documentationRef" : "https://docs.camunda.io/docs/8.7/components/connectors/out-of-the-box-connectors/amazon-s3/",
+  "documentationRef" : "https://docs.camunda.io/docs/8.8/components/connectors/out-of-the-box-connectors/amazon-s3/",
   "version" : 2,
   "category" : {
     "id" : "connectors",

--- a/connectors/aws/aws-s3/src/main/java/io/camunda/connector/aws/s3/S3ConnectorFunction.java
+++ b/connectors/aws/aws-s3/src/main/java/io/camunda/connector/aws/s3/S3ConnectorFunction.java
@@ -36,7 +36,7 @@ import java.util.function.Function;
       @ElementTemplate.PropertyGroup(id = "downloadObject", label = "Download an object"),
     },
     documentationRef =
-        "https://docs.camunda.io/docs/8.7/components/connectors/out-of-the-box-connectors/amazon-s3/",
+        "https://docs.camunda.io/docs/8.8/components/connectors/out-of-the-box-connectors/amazon-s3/",
     icon = "icon.svg")
 public class S3ConnectorFunction implements OutboundConnectorFunction {
 

--- a/connectors/box/element-templates/box-outbound-connector.json
+++ b/connectors/box/element-templates/box-outbound-connector.json
@@ -6,7 +6,7 @@
   "metadata" : {
     "keywords" : [ ]
   },
-  "documentationRef" : "https://docs.camunda.io/docs/8.7/components/connectors/out-of-the-box-connectors/box/",
+  "documentationRef" : "https://docs.camunda.io/docs/8.8/components/connectors/out-of-the-box-connectors/box/",
   "version" : 2,
   "category" : {
     "id" : "connectors",

--- a/connectors/box/element-templates/hybrid/box-outbound-connector-hybrid.json
+++ b/connectors/box/element-templates/hybrid/box-outbound-connector-hybrid.json
@@ -6,7 +6,7 @@
   "metadata" : {
     "keywords" : [ ]
   },
-  "documentationRef" : "https://docs.camunda.io/docs/8.7/components/connectors/out-of-the-box-connectors/box/",
+  "documentationRef" : "https://docs.camunda.io/docs/8.8/components/connectors/out-of-the-box-connectors/box/",
   "version" : 2,
   "category" : {
     "id" : "connectors",

--- a/connectors/box/src/main/java/io/camunda/connector/box/BoxFunction.java
+++ b/connectors/box/src/main/java/io/camunda/connector/box/BoxFunction.java
@@ -28,7 +28,7 @@ import io.camunda.connector.generator.java.annotation.ElementTemplate;
       @ElementTemplate.PropertyGroup(id = "operation", label = "Operation"),
     },
     documentationRef =
-        "https://docs.camunda.io/docs/8.7/components/connectors/out-of-the-box-connectors/box/",
+        "https://docs.camunda.io/docs/8.8/components/connectors/out-of-the-box-connectors/box/",
     icon = "icon.svg")
 public class BoxFunction implements OutboundConnectorFunction {
 

--- a/connectors/google/google-gemini/element-templates/google-gemini-outbound-connector.json
+++ b/connectors/google/google-gemini/element-templates/google-gemini-outbound-connector.json
@@ -6,7 +6,7 @@
   "metadata" : {
     "keywords" : [ ]
   },
-  "documentationRef" : "https://docs.camunda.io/docs/8.7/components/connectors/out-of-the-box-connectors/google-gemini/",
+  "documentationRef" : "https://docs.camunda.io/docs/8.8/components/connectors/out-of-the-box-connectors/google-gemini/",
   "version" : 3,
   "category" : {
     "id" : "connectors",

--- a/connectors/google/google-gemini/element-templates/hybrid/google-gemini-outbound-connector-hybrid.json
+++ b/connectors/google/google-gemini/element-templates/hybrid/google-gemini-outbound-connector-hybrid.json
@@ -6,7 +6,7 @@
   "metadata" : {
     "keywords" : [ ]
   },
-  "documentationRef" : "https://docs.camunda.io/docs/8.7/components/connectors/out-of-the-box-connectors/google-gemini/",
+  "documentationRef" : "https://docs.camunda.io/docs/8.8/components/connectors/out-of-the-box-connectors/google-gemini/",
   "version" : 3,
   "category" : {
     "id" : "connectors",

--- a/connectors/google/google-gemini/src/main/java/io/camunda/connector/gemini/GeminiConnectorFunction.java
+++ b/connectors/google/google-gemini/src/main/java/io/camunda/connector/gemini/GeminiConnectorFunction.java
@@ -36,7 +36,7 @@ import java.util.HashMap;
       @ElementTemplate.PropertyGroup(id = "input", label = "Configure input")
     },
     documentationRef =
-        "https://docs.camunda.io/docs/8.7/components/connectors/out-of-the-box-connectors/google-gemini/",
+        "https://docs.camunda.io/docs/8.8/components/connectors/out-of-the-box-connectors/google-gemini/",
     icon = "icon.svg")
 public class GeminiConnectorFunction implements OutboundConnectorFunction {
 


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
- added ref to github checkout to not revert changes done in setup step
- tested and works, created PR here: https://github.com/camunda/connectors/pull/6900
- bumping links to 8.8


## Checklist

- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest
  release, as this branch will be rebased onto main before the next release. Example backport labels:
    - `backport stable/8.8`: for changes that should be included in the next 8.8.x release.
    - **or** `backport release-8.8.7`: for changes that should be included in the specific release 8.8.7, and this
      *release has already been created*. The release branch will be merged back into stable/8.8 later, so the change
      will be included in future 8.8.x releases as well.
- [ ] Tests/Integration tests for the changes have been added if applicable.

