### PR TITLE
chore(email): reflect the real email inbound connector status when se…

### DIFF
--- a/connectors/email/src/main/java/io/camunda/connector/email/client/jakarta/inbound/JakartaEmailListener.java
+++ b/connectors/email/src/main/java/io/camunda/connector/email/client/jakarta/inbound/JakartaEmailListener.java
@@ -40,15 +40,17 @@ public class JakartaEmailListener implements EmailListener {
             .withBackoff(Duration.of(5, ChronoUnit.SECONDS), Duration.of(1, ChronoUnit.HOURS))
             .withMaxAttempts(INFINITE_RETRIES)
             .onRetry(
-                event ->
-                    context.log(
-                        activity ->
-                            activity
-                                .withSeverity(Severity.WARNING)
-                                .withTag("Context creation")
-                                .withMessage(
-                                    "Retrying after attempt %s failed ..."
-                                        .formatted(event.getAttemptCount()))))
+                event -> {
+                  context.reportHealth(Health.down(event.getLastException()));
+                  context.log(
+                      activity ->
+                          activity
+                              .withSeverity(Severity.WARNING)
+                              .withTag("Context creation")
+                              .withMessage(
+                                  "Retrying after attempt %s failed ..."
+                                      .formatted(event.getAttemptCount())));
+                })
             .build();
     this.pollingManagerFuture =
         Failsafe.with(retryPolicy)


### PR DESCRIPTION
This pull request makes a small but important improvement to the email connector's error handling. Now, whenever a retry is triggered due to a failure in the email listener, the system will actively report a "down" health status with the associated exception. This provides better visibility into failures and improves monitoring.

- Improved error reporting:
  * In `JakartaEmailListener.java`, the retry handler now calls `context.reportHealth(Health.down(event.getLastException()))` whenever a retry occurs, ensuring that health checks reflect the failure state during retries.