### PR TITLE
chore(camunda): bump camunda version to 8.9.0

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -70,7 +70,7 @@ limitations under the License.</license.inlineheader>
     <nexus.release.repository>https://artifacts.camunda.com/artifactory/connectors/</nexus.release.repository>
 
     <!-- Camunda internal libraries -->
-    <version.camunda>8.9.0-SNAPSHOT</version.camunda>
+    <version.camunda>8.9.0</version.camunda>
     <version.feel-engine>1.21.0</version.feel-engine>
     <version.camunda-xml-model>7.24.0</version.camunda-xml-model>
 


### PR DESCRIPTION
This pull request updates the Camunda dependency version in the parent Maven configuration from a snapshot to a stable release.

- Dependency version update:
  * Updated the `version.camunda` property in `parent/pom.xml` from `8.9.0-SNAPSHOT` to the stable `8.9.0` release.