### PR TITLE
chore: Add aws-bedrock-knowledgebase and aws-bedrock-agentcore-runtime to agentic-ai codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -10,8 +10,6 @@
 /connectors/aws/aws-bedrock-knowledgebase @camunda/connectors-agentic-ai @camunda/connectors
 /connectors/aws/aws-bedrock-agentcore-runtime @camunda/connectors-agentic-ai @camunda/connectors
 
-
-
 # These files are excluded so that Renovate can automatically merge dependency upgrades
 renovate.json
 **/*.yaml

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -7,6 +7,10 @@
 /connectors/embeddings-vector-database @camunda/connectors-agentic-ai @camunda/connectors
 /connectors-e2e-test/connectors-e2e-test-agentic-ai @camunda/connectors-agentic-ai @camunda/connectors
 /connectors/aws/aws-bedrock-codeinterpreter @camunda/connectors-agentic-ai @camunda/connectors
+/connectors/aws/aws-bedrock-knowledgebase @camunda/connectors-agentic-ai @camunda/connectors
+/connectors/aws/aws-bedrock-agentcore-runtime @camunda/connectors-agentic-ai @camunda/connectors
+
+
 
 # These files are excluded so that Renovate can automatically merge dependency upgrades
 renovate.json


### PR DESCRIPTION
Added new AWS connectors to CODEOWNERS for ownership management.