### PR TITLE
chore(agentic-ai): bump element template version for 8.10

### DIFF
--- a/connectors/agentic-ai/AI_AGENT.md
+++ b/connectors/agentic-ai/AI_AGENT.md
@@ -230,6 +230,6 @@ leading to the following result
 | Connector Info            |                                                                       |
 | ---                       | ---                                                                   |
 | Type                      | io.camunda.agenticai:aiagent:1                                                            |
-| Version                   | 7                                                         |
+| Version                   | 10                                                         |
 | Supported element types   |     |
 

--- a/connectors/agentic-ai/element-templates/agenticai-aiagent-job-worker.json
+++ b/connectors/agentic-ai/element-templates/agenticai-aiagent-job-worker.json
@@ -6,8 +6,8 @@
   "metadata" : {
     "keywords" : [ "AI", "AI Agent", "agentic orchestration" ]
   },
-  "documentationRef" : "https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/agentic-ai-aiagent-subprocess/",
-  "version" : 7,
+  "documentationRef" : "https://docs.camunda.io/docs/8.10/components/connectors/out-of-the-box-connectors/agentic-ai-aiagent-subprocess/",
+  "version" : 10,
   "category" : {
     "id" : "connectors",
     "name" : "Connectors"
@@ -17,7 +17,7 @@
     "value" : "bpmn:AdHocSubProcess"
   },
   "engines" : {
-    "camunda" : "^8.9"
+    "camunda" : "^8.10"
   },
   "groups" : [ {
     "id" : "provider",
@@ -776,7 +776,6 @@
     "label" : "Model",
     "description" : "Specify the model ID. Details in the <a href=\"https://docs.anthropic.com/en/docs/about-claude/models/all-models\" target=\"_blank\">documentation</a>.",
     "optional" : false,
-    "placeholder" : "claude-sonnet-4-6",
     "constraints" : {
       "notEmpty" : true
     },
@@ -791,6 +790,7 @@
       "equals" : "anthropic",
       "type" : "simple"
     },
+    "placeholder" : "claude-sonnet-4-6",
     "type" : "String"
   }, {
     "id" : "provider.anthropic.model.parameters.maxTokens",
@@ -865,7 +865,6 @@
     "label" : "Model",
     "description" : "Specify an inference profile ID. Details in the <a href=\"https://docs.aws.amazon.com/bedrock/latest/userguide/inference-profiles-support.html\" target=\"_blank\">documentation</a>.",
     "optional" : false,
-    "placeholder" : "global.anthropic.claude-sonnet-4-6",
     "constraints" : {
       "notEmpty" : true
     },
@@ -880,6 +879,7 @@
       "equals" : "bedrock",
       "type" : "simple"
     },
+    "placeholder" : "global.anthropic.claude-sonnet-4-6",
     "type" : "String"
   }, {
     "id" : "provider.bedrock.model.parameters.maxTokens",
@@ -1550,7 +1550,7 @@
     "id" : "version",
     "label" : "Version",
     "description" : "Version of the element template",
-    "value" : "7",
+    "value" : "10",
     "group" : "connector",
     "binding" : {
       "key" : "elementTemplateVersion",

--- a/connectors/agentic-ai/element-templates/agenticai-aiagent-outbound-connector.json
+++ b/connectors/agentic-ai/element-templates/agenticai-aiagent-outbound-connector.json
@@ -6,8 +6,8 @@
   "metadata" : {
     "keywords" : [ "AI", "AI Agent", "agentic orchestration" ]
   },
-  "documentationRef" : "https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/agentic-ai-aiagent-task/",
-  "version" : 7,
+  "documentationRef" : "https://docs.camunda.io/docs/8.10/components/connectors/out-of-the-box-connectors/agentic-ai-aiagent-task/",
+  "version" : 10,
   "category" : {
     "id" : "connectors",
     "name" : "Connectors"
@@ -17,7 +17,7 @@
     "value" : "bpmn:ServiceTask"
   },
   "engines" : {
-    "camunda" : "^8.9"
+    "camunda" : "^8.10"
   },
   "groups" : [ {
     "id" : "provider",
@@ -755,7 +755,6 @@
     "label" : "Model",
     "description" : "Specify the model ID. Details in the <a href=\"https://docs.anthropic.com/en/docs/about-claude/models/all-models\" target=\"_blank\">documentation</a>.",
     "optional" : false,
-    "placeholder" : "claude-sonnet-4-6",
     "constraints" : {
       "notEmpty" : true
     },
@@ -770,6 +769,7 @@
       "equals" : "anthropic",
       "type" : "simple"
     },
+    "placeholder" : "claude-sonnet-4-6",
     "type" : "String"
   }, {
     "id" : "provider.anthropic.model.parameters.maxTokens",
@@ -844,7 +844,6 @@
     "label" : "Model",
     "description" : "Specify an inference profile ID. Details in the <a href=\"https://docs.aws.amazon.com/bedrock/latest/userguide/inference-profiles-support.html\" target=\"_blank\">documentation</a>.",
     "optional" : false,
-    "placeholder" : "global.anthropic.claude-sonnet-4-6",
     "constraints" : {
       "notEmpty" : true
     },
@@ -859,6 +858,7 @@
       "equals" : "bedrock",
       "type" : "simple"
     },
+    "placeholder" : "global.anthropic.claude-sonnet-4-6",
     "type" : "String"
   }, {
     "id" : "provider.bedrock.model.parameters.maxTokens",
@@ -1524,7 +1524,7 @@
     "id" : "version",
     "label" : "Version",
     "description" : "Version of the element template",
-    "value" : "7",
+    "value" : "10",
     "group" : "connector",
     "binding" : {
       "key" : "elementTemplateVersion",

--- a/connectors/agentic-ai/element-templates/hybrid/agenticai-aiagent-job-worker-hybrid.json
+++ b/connectors/agentic-ai/element-templates/hybrid/agenticai-aiagent-job-worker-hybrid.json
@@ -6,8 +6,8 @@
   "metadata" : {
     "keywords" : [ "AI", "AI Agent", "agentic orchestration" ]
   },
-  "documentationRef" : "https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/agentic-ai-aiagent-subprocess/",
-  "version" : 7,
+  "documentationRef" : "https://docs.camunda.io/docs/8.10/components/connectors/out-of-the-box-connectors/agentic-ai-aiagent-subprocess/",
+  "version" : 10,
   "category" : {
     "id" : "connectors",
     "name" : "Connectors"
@@ -17,7 +17,7 @@
     "value" : "bpmn:AdHocSubProcess"
   },
   "engines" : {
-    "camunda" : "^8.9"
+    "camunda" : "^8.10"
   },
   "groups" : [ {
     "id" : "taskDefinitionType",
@@ -781,7 +781,6 @@
     "label" : "Model",
     "description" : "Specify the model ID. Details in the <a href=\"https://docs.anthropic.com/en/docs/about-claude/models/all-models\" target=\"_blank\">documentation</a>.",
     "optional" : false,
-    "placeholder" : "claude-sonnet-4-6",
     "constraints" : {
       "notEmpty" : true
     },
@@ -796,6 +795,7 @@
       "equals" : "anthropic",
       "type" : "simple"
     },
+    "placeholder" : "claude-sonnet-4-6",
     "type" : "String"
   }, {
     "id" : "provider.anthropic.model.parameters.maxTokens",
@@ -870,7 +870,6 @@
     "label" : "Model",
     "description" : "Specify an inference profile ID. Details in the <a href=\"https://docs.aws.amazon.com/bedrock/latest/userguide/inference-profiles-support.html\" target=\"_blank\">documentation</a>.",
     "optional" : false,
-    "placeholder" : "global.anthropic.claude-sonnet-4-6",
     "constraints" : {
       "notEmpty" : true
     },
@@ -885,6 +884,7 @@
       "equals" : "bedrock",
       "type" : "simple"
     },
+    "placeholder" : "global.anthropic.claude-sonnet-4-6",
     "type" : "String"
   }, {
     "id" : "provider.bedrock.model.parameters.maxTokens",
@@ -1555,7 +1555,7 @@
     "id" : "version",
     "label" : "Version",
     "description" : "Version of the element template",
-    "value" : "7",
+    "value" : "10",
     "group" : "connector",
     "binding" : {
       "key" : "elementTemplateVersion",

--- a/connectors/agentic-ai/element-templates/versioned/agenticai-aiagent-job-worker-7.json
+++ b/connectors/agentic-ai/element-templates/versioned/agenticai-aiagent-job-worker-7.json
@@ -1,28 +1,25 @@
 {
   "$schema" : "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
-  "name" : "Hybrid AI Agent Task",
-  "id" : "io.camunda.connectors.agenticai.aiagent.v1-hybrid",
-  "description" : "Execute a single AI-powered action with tool calling capabilities",
+  "name" : "AI Agent Sub-process",
+  "id" : "io.camunda.connectors.agenticai.aiagent.jobworker.v1",
+  "description" : "Run a multi-step AI reasoning loop with dynamic tool selection",
   "metadata" : {
     "keywords" : [ "AI", "AI Agent", "agentic orchestration" ]
   },
-  "documentationRef" : "https://docs.camunda.io/docs/8.10/components/connectors/out-of-the-box-connectors/agentic-ai-aiagent-task/",
-  "version" : 10,
+  "documentationRef" : "https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/agentic-ai-aiagent-subprocess/",
+  "version" : 7,
   "category" : {
     "id" : "connectors",
     "name" : "Connectors"
   },
-  "appliesTo" : [ "bpmn:Task" ],
+  "appliesTo" : [ "bpmn:SubProcess" ],
   "elementType" : {
-    "value" : "bpmn:ServiceTask"
+    "value" : "bpmn:AdHocSubProcess"
   },
   "engines" : {
-    "camunda" : "^8.10"
+    "camunda" : "^8.9"
   },
   "groups" : [ {
-    "id" : "taskDefinitionType",
-    "label" : "Task definition type"
-  }, {
     "id" : "provider",
     "label" : "Model provider",
     "openByDefault" : false
@@ -55,9 +52,14 @@
     "label" : "Limits",
     "openByDefault" : false
   }, {
+    "id" : "events",
+    "label" : "Event handling",
+    "tooltip" : "Configure how event sub-process results are handled. Results are added as user messages to the running agent.",
+    "openByDefault" : false
+  }, {
     "id" : "response",
     "label" : "Response",
-    "tooltip" : "Configuration of the model response format and how to map the model response to the connector result.<br><br>Depending on the selection, the model response will be available as <code>response.responseText</code> or <code>response.responseJson</code>.<br><br>See <a href=\"https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/agentic-ai-aiagent-task/#response\">documentation</a> for details.",
+    "tooltip" : "Configuration of the model response format and how to map the model response to the connector result.<br><br>Depending on the selection, the model response will be available as <code>response.responseText</code> or <code>response.responseJson</code>.<br><br>See <a href=\"https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/agentic-ai-aiagent-subprocess/#response\">documentation</a> for details.",
     "openByDefault" : false
   }, {
     "id" : "connector",
@@ -73,14 +75,28 @@
     "label" : "Retries"
   } ],
   "properties" : [ {
-    "id" : "taskDefinitionType",
-    "value" : "io.camunda.agenticai:aiagent:1",
-    "group" : "taskDefinitionType",
+    "value" : "io.camunda.agenticai:aiagent-job-worker:1",
     "binding" : {
       "property" : "type",
       "type" : "zeebe:taskDefinition"
     },
-    "type" : "String"
+    "type" : "Hidden"
+  }, {
+    "id" : "outputCollection",
+    "binding" : {
+      "property" : "outputCollection",
+      "type" : "zeebe:adHoc"
+    },
+    "value" : "toolCallResults",
+    "type" : "Hidden"
+  }, {
+    "id" : "outputElement",
+    "binding" : {
+      "property" : "outputElement",
+      "type" : "zeebe:adHoc"
+    },
+    "value" : "={\n  id: toolCall._meta.id,\n  name: toolCall._meta.name,\n  content: toolCallResult\n}",
+    "type" : "Hidden"
   }, {
     "id" : "provider.type",
     "label" : "Provider",
@@ -760,6 +776,7 @@
     "label" : "Model",
     "description" : "Specify the model ID. Details in the <a href=\"https://docs.anthropic.com/en/docs/about-claude/models/all-models\" target=\"_blank\">documentation</a>.",
     "optional" : false,
+    "placeholder" : "claude-sonnet-4-6",
     "constraints" : {
       "notEmpty" : true
     },
@@ -774,7 +791,6 @@
       "equals" : "anthropic",
       "type" : "simple"
     },
-    "placeholder" : "claude-sonnet-4-6",
     "type" : "String"
   }, {
     "id" : "provider.anthropic.model.parameters.maxTokens",
@@ -849,6 +865,7 @@
     "label" : "Model",
     "description" : "Specify an inference profile ID. Details in the <a href=\"https://docs.aws.amazon.com/bedrock/latest/userguide/inference-profiles-support.html\" target=\"_blank\">documentation</a>.",
     "optional" : false,
+    "placeholder" : "global.anthropic.claude-sonnet-4-6",
     "constraints" : {
       "notEmpty" : true
     },
@@ -863,7 +880,6 @@
       "equals" : "bedrock",
       "type" : "simple"
     },
-    "placeholder" : "global.anthropic.claude-sonnet-4-6",
     "type" : "String"
   }, {
     "id" : "provider.bedrock.model.parameters.maxTokens",
@@ -1276,50 +1292,20 @@
       "name" : "data.userPrompt.documents",
       "type" : "zeebe:input"
     },
-    "tooltip" : "Referenced documents will be automatically added to the user prompt. <a href=\"https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/agentic-ai-aiagent-task/\" target=\"_blank\">See documentation</a> for details and supported file types.",
+    "tooltip" : "Referenced documents will be automatically added to the user prompt. <a href=\"https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/agentic-ai-aiagent-subprocess/\" target=\"_blank\">See documentation</a> for details and supported file types.",
     "type" : "String"
   }, {
-    "id" : "data.tools.containerElementId",
-    "label" : "Ad-hoc sub-process ID",
-    "description" : "ID of the sub-process that contains the tools the AI agent can use.",
-    "optional" : true,
-    "feel" : "optional",
-    "group" : "tools",
-    "binding" : {
-      "name" : "data.tools.containerElementId",
-      "type" : "zeebe:input"
-    },
-    "tooltip" : "Add an ad-hoc sub-process ID to attach the AI agent to the tools. Ensure your process includes a tools feedback loop routing into the ad-hoc sub-process and back to the AI agent connector. <a href=\"https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/agentic-ai-aiagent-task/\" target=\"_blank\">See documentation</a> for details.",
-    "type" : "String"
-  }, {
-    "id" : "data.tools.toolCallResults",
-    "label" : "Tool call results",
-    "description" : "Tool call results as returned by the sub-process.",
-    "optional" : true,
-    "feel" : "required",
-    "group" : "tools",
-    "binding" : {
-      "name" : "data.tools.toolCallResults",
-      "type" : "zeebe:input"
-    },
-    "tooltip" : "This defines where to handle tool call results returned by the ad-hoc sub-process. Model this as part of your process and route it into the tools feedback loop. <a href=\"https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/agentic-ai-aiagent-task/\" target=\"_blank\">See documentation</a> for details.",
-    "type" : "Text"
-  }, {
-    "id" : "data.agentContext",
+    "id" : "agentContext",
     "label" : "Agent context",
-    "description" : "Avoid reusing context variables across agents to prevent issues with stale data or tool access.",
+    "description" : "Initial agent context from previous interactions. Avoid reusing context variables across agents to prevent issues with stale data or tool access.",
     "optional" : false,
-    "value" : "=agent.context",
-    "constraints" : {
-      "notEmpty" : true
-    },
     "feel" : "required",
     "group" : "memory",
     "binding" : {
-      "name" : "data.context",
+      "name" : "agentContext",
       "type" : "zeebe:input"
     },
-    "tooltip" : "The agent context variable containing all relevant data for the agent to support the feedback loop between user requests, tool calls and LLM responses. Make sure this variable points to the <code>context</code> variable which is returned from the agent response. <a href=\"https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/agentic-ai-aiagent-task/\" target=\"_blank\">See documentation</a> for details.",
+    "tooltip" : "The agent context variable containing all relevant data for the agent to support the feedback loop between user requests, tool calls and LLM responses. Make sure this variable points to the <code>context</code> variable which is returned from the agent response. <a href=\"https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/agentic-ai-aiagent-subprocess/\" target=\"_blank\">See documentation</a> for details.",
     "type" : "Text"
   }, {
     "id" : "data.memory.storage.type",
@@ -1425,7 +1411,7 @@
       "name" : "data.memory.contextWindowSize",
       "type" : "zeebe:input"
     },
-    "tooltip" : "Use this to limit the number of messages which are sent to the model. The agent will only send the most recent messages up to the configured limit to the LLM. Older messages will be kept in the conversation store, but not sent to the model. <a href=\"https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/agentic-ai-aiagent-task/\" target=\"_blank\">See documentation</a> for details.",
+    "tooltip" : "Use this to limit the number of messages which are sent to the model. The agent will only send the most recent messages up to the configured limit to the LLM. Older messages will be kept in the conversation store, but not sent to the model. <a href=\"https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/agentic-ai-aiagent-subprocess/\" target=\"_blank\">See documentation</a> for details.",
     "type" : "Number"
   }, {
     "id" : "data.limits.maxModelCalls",
@@ -1440,6 +1426,28 @@
       "type" : "zeebe:input"
     },
     "type" : "Number"
+  }, {
+    "id" : "data.events.behavior",
+    "label" : "Event handling behavior",
+    "description" : "Behavior on completing an event sub-process.",
+    "optional" : false,
+    "value" : "WAIT_FOR_TOOL_CALL_RESULTS",
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "group" : "events",
+    "binding" : {
+      "name" : "data.events.behavior",
+      "type" : "zeebe:input"
+    },
+    "type" : "Dropdown",
+    "choices" : [ {
+      "name" : "Wait for tool call results",
+      "value" : "WAIT_FOR_TOOL_CALL_RESULTS"
+    }, {
+      "name" : "Cancel tool calls",
+      "value" : "INTERRUPT_TOOL_CALLS"
+    } ]
   }, {
     "id" : "data.response.format.type",
     "label" : "Response format",
@@ -1526,10 +1534,23 @@
     "tooltip" : "In addition to the text content, the assistant message may include multiple additional content blocks and metadata (such as token usage). The message will be available as <code>response.responseMessage</code>.",
     "type" : "Boolean"
   }, {
+    "id" : "data.response.includeAgentContext",
+    "label" : "Include agent context",
+    "description" : "Include the agent context as part of the result object.",
+    "optional" : true,
+    "feel" : "static",
+    "group" : "response",
+    "binding" : {
+      "name" : "data.response.includeAgentContext",
+      "type" : "zeebe:input"
+    },
+    "tooltip" : "Use this option if you need to re-inject the previous agent context into a future agent execution, for example when modeling a user feedback loop between an agent and a user task.",
+    "type" : "Boolean"
+  }, {
     "id" : "version",
     "label" : "Version",
     "description" : "Version of the element template",
-    "value" : "10",
+    "value" : "7",
     "group" : "connector",
     "binding" : {
       "key" : "elementTemplateVersion",
@@ -1540,7 +1561,7 @@
     "id" : "id",
     "label" : "ID",
     "description" : "ID of the element template",
-    "value" : "io.camunda.connectors.agenticai.aiagent.v1",
+    "value" : "io.camunda.connectors.agenticai.aiagent.jobworker.v1",
     "group" : "connector",
     "binding" : {
       "key" : "elementTemplateId",
@@ -1554,21 +1575,10 @@
     "value" : "agent",
     "group" : "output",
     "binding" : {
-      "key" : "resultVariable",
-      "type" : "zeebe:taskHeader"
+      "source" : "=agent",
+      "type" : "zeebe:output"
     },
     "type" : "String"
-  }, {
-    "id" : "resultExpression",
-    "label" : "Result expression",
-    "description" : "Expression to map the response into process variables",
-    "feel" : "required",
-    "group" : "output",
-    "binding" : {
-      "key" : "resultExpression",
-      "type" : "zeebe:taskHeader"
-    },
-    "type" : "Text"
   }, {
     "id" : "errorExpression",
     "label" : "Error expression",
@@ -1603,6 +1613,12 @@
       "type" : "zeebe:taskHeader"
     },
     "type" : "String"
+  }, {
+    "binding" : {
+      "name" : "agent",
+      "type" : "zeebe:input"
+    },
+    "type" : "Hidden"
   } ],
   "icon" : {
     "contents" : "data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMzIiIGhlaWdodD0iMzIiIHZpZXdCb3g9IjAgMCAzMiAzMiIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPGNpcmNsZSBjeD0iMTYiIGN5PSIxNiIgcj0iMTYiIGZpbGw9IiNBNTZFRkYiLz4KPG1hc2sgaWQ9InBhdGgtMi1vdXRzaWRlLTFfMTg1XzYiIG1hc2tVbml0cz0idXNlclNwYWNlT25Vc2UiIHg9IjQiIHk9IjQiIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgZmlsbD0iYmxhY2siPgo8cmVjdCBmaWxsPSJ3aGl0ZSIgeD0iNCIgeT0iNCIgd2lkdGg9IjI0IiBoZWlnaHQ9IjI0Ii8+CjxwYXRoIGZpbGwtcnVsZT0iZXZlbm9kZCIgY2xpcC1ydWxlPSJldmVub2RkIiBkPSJNMjAuMDEwNSAxMi4wOTg3QzE4LjQ5IDEwLjU4OTQgMTcuMTU5NCA4LjEwODE0IDE2LjE3OTkgNi4wMTEwM0MxNi4xNTIgNi4wMDQ1MSAxNi4xMTc2IDYgMTYuMDc5NCA2QzE2LjA0MTEgNiAxNi4wMDY2IDYuMDA0NTEgMTUuOTc4OCA2LjAxMTA0QzE0Ljk5OTQgOC4xMDgxNCAxMy42Njk3IDEwLjU4ODkgMTIuMTQ4MSAxMi4wOTgxQzEwLjYyNjkgMTMuNjA3MSA4LjEyNTY4IDE0LjkyNjQgNi4wMTE1NyAxNS44OTgxQzYuMDA0NzQgMTUuOTI2MSA2IDE1Ljk2MTEgNiAxNkM2IDE2LjAzODcgNi4wMDQ2OCAxNi4wNzM2IDYuMDExNDQgMTYuMTAxNEM4LjEyNTE5IDE3LjA3MjkgMTAuNjI2MiAxOC4zOTE5IDEyLjE0NzcgMTkuOTAxNkMxMy42Njk3IDIxLjQxMDcgMTQuOTk5NiAyMy44OTIgMTUuOTc5MSAyNS45ODlDMTYuMDA2OCAyNS45OTU2IDE2LjA0MTEgMjYgMTYuMDc5MyAyNkMxNi4xMTc1IDI2IDE2LjE1MTkgMjUuOTk1NCAxNi4xNzk2IDI1Ljk4OUMxNy4xNTkxIDIzLjg5MiAxOC40ODg4IDIxLjQxMSAyMC4wMDk5IDE5LjkwMjFNMjAuMDA5OSAxOS45MDIxQzIxLjUyNTMgMTguMzk4NyAyMy45NDY1IDE3LjA2NjkgMjUuOTkxNSAxNi4wODI0QzI1Ljk5NjUgMTYuMDU5MyAyNiAxNi4wMzEgMjYgMTUuOTk5N0MyNiAxNS45Njg0IDI1Ljk5NjUgMTUuOTQwMyAyNS45OTE1IDE1LjkxNzFDMjMuOTQ3NCAxNC45MzI3IDIxLjUyNTkgMTMuNjAxIDIwLjAxMDUgMTIuMDk4NyIvPgo8L21hc2s+CjxwYXRoIGZpbGwtcnVsZT0iZXZlbm9kZCIgY2xpcC1ydWxlPSJldmVub2RkIiBkPSJNMjAuMDEwNSAxMi4wOTg3QzE4LjQ5IDEwLjU4OTQgMTcuMTU5NCA4LjEwODE0IDE2LjE3OTkgNi4wMTEwM0MxNi4xNTIgNi4wMDQ1MSAxNi4xMTc2IDYgMTYuMDc5NCA2QzE2LjA0MTEgNiAxNi4wMDY2IDYuMDA0NTEgMTUuOTc4OCA2LjAxMTA0QzE0Ljk5OTQgOC4xMDgxNCAxMy42Njk3IDEwLjU4ODkgMTIuMTQ4MSAxMi4wOTgxQzEwLjYyNjkgMTMuNjA3MSA4LjEyNTY4IDE0LjkyNjQgNi4wMTE1NyAxNS44OTgxQzYuMDA0NzQgMTUuOTI2MSA2IDE1Ljk2MTEgNiAxNkM2IDE2LjAzODcgNi4wMDQ2OCAxNi4wNzM2IDYuMDExNDQgMTYuMTAxNEM4LjEyNTE5IDE3LjA3MjkgMTAuNjI2MiAxOC4zOTE5IDEyLjE0NzcgMTkuOTAxNkMxMy42Njk3IDIxLjQxMDcgMTQuOTk5NiAyMy44OTIgMTUuOTc5MSAyNS45ODlDMTYuMDA2OCAyNS45OTU2IDE2LjA0MTEgMjYgMTYuMDc5MyAyNkMxNi4xMTc1IDI2IDE2LjE1MTkgMjUuOTk1NCAxNi4xNzk2IDI1Ljk4OUMxNy4xNTkxIDIzLjg5MiAxOC40ODg4IDIxLjQxMSAyMC4wMDk5IDE5LjkwMjFNMjAuMDA5OSAxOS45MDIxQzIxLjUyNTMgMTguMzk4NyAyMy45NDY1IDE3LjA2NjkgMjUuOTkxNSAxNi4wODI0QzI1Ljk5NjUgMTYuMDU5MyAyNiAxNi4wMzEgMjYgMTUuOTk5N0MyNiAxNS45Njg0IDI1Ljk5NjUgMTUuOTQwMyAyNS45OTE1IDE1LjkxNzFDMjMuOTQ3NCAxNC45MzI3IDIxLjUyNTkgMTMuNjAxIDIwLjAxMDUgMTIuMDk4NyIgZmlsbD0id2hpdGUiLz4KPHBhdGggZmlsbC1ydWxlPSJldmVub2RkIiBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGQ9Ik0yMC4wMTA1IDEyLjA5ODdDMTguNDkgMTAuNTg5NCAxNy4xNTk0IDguMTA4MTQgMTYuMTc5OSA2LjAxMTAzQzE2LjE1MiA2LjAwNDUxIDE2LjExNzYgNiAxNi4wNzk0IDZDMTYuMDQxMSA2IDE2LjAwNjYgNi4wMDQ1MSAxNS45Nzg4IDYuMDExMDRDMTQuOTk5NCA4LjEwODE0IDEzLjY2OTcgMTAuNTg4OSAxMi4xNDgxIDEyLjA5ODFDMTAuNjI2OSAxMy42MDcxIDguMTI1NjggMTQuOTI2NCA2LjAxMTU3IDE1Ljg5ODFDNi4wMDQ3NCAxNS45MjYxIDYgMTUuOTYxMSA2IDE2QzYgMTYuMDM4NyA2LjAwNDY4IDE2LjA3MzYgNi4wMTE0NCAxNi4xMDE0QzguMTI1MTkgMTcuMDcyOSAxMC42MjYyIDE4LjM5MTkgMTIuMTQ3NyAxOS45MDE2QzEzLjY2OTcgMjEuNDEwNyAxNC45OTk2IDIzLjg5MiAxNS45NzkxIDI1Ljk4OUMxNi4wMDY4IDI1Ljk5NTYgMTYuMDQxMSAyNiAxNi4wNzkzIDI2QzE2LjExNzUgMjYgMTYuMTUxOSAyNS45OTU0IDE2LjE3OTYgMjUuOTg5QzE3LjE1OTEgMjMuODkyIDE4LjQ4ODggMjEuNDExIDIwLjAwOTkgMTkuOTAyMU0yMC4wMDk5IDE5LjkwMjFDMjEuNTI1MyAxOC4zOTg3IDIzLjk0NjUgMTcuMDY2OSAyNS45OTE1IDE2LjA4MjRDMjUuOTk2NSAxNi4wNTkzIDI2IDE2LjAzMSAyNiAxNS45OTk3QzI2IDE1Ljk2ODQgMjUuOTk2NSAxNS45NDAzIDI1Ljk5MTUgMTUuOTE3MUMyMy45NDc0IDE0LjkzMjcgMjEuNTI1OSAxMy42MDEgMjAuMDEwNSAxMi4wOTg3IiBzdHJva2U9IiM0OTFEOEIiIHN0cm9rZS13aWR0aD0iNCIgc3Ryb2tlLWxpbmVqb2luPSJyb3VuZCIgbWFzaz0idXJsKCNwYXRoLTItb3V0c2lkZS0xXzE4NV82KSIvPgo8L3N2Zz4K"

--- a/connectors/agentic-ai/element-templates/versioned/agenticai-aiagent-outbound-connector-7.json
+++ b/connectors/agentic-ai/element-templates/versioned/agenticai-aiagent-outbound-connector-7.json
@@ -1,13 +1,13 @@
 {
   "$schema" : "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
-  "name" : "Hybrid AI Agent Task",
-  "id" : "io.camunda.connectors.agenticai.aiagent.v1-hybrid",
+  "name" : "AI Agent Task",
+  "id" : "io.camunda.connectors.agenticai.aiagent.v1",
   "description" : "Execute a single AI-powered action with tool calling capabilities",
   "metadata" : {
     "keywords" : [ "AI", "AI Agent", "agentic orchestration" ]
   },
-  "documentationRef" : "https://docs.camunda.io/docs/8.10/components/connectors/out-of-the-box-connectors/agentic-ai-aiagent-task/",
-  "version" : 10,
+  "documentationRef" : "https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/agentic-ai-aiagent-task/",
+  "version" : 7,
   "category" : {
     "id" : "connectors",
     "name" : "Connectors"
@@ -17,12 +17,9 @@
     "value" : "bpmn:ServiceTask"
   },
   "engines" : {
-    "camunda" : "^8.10"
+    "camunda" : "^8.9"
   },
   "groups" : [ {
-    "id" : "taskDefinitionType",
-    "label" : "Task definition type"
-  }, {
     "id" : "provider",
     "label" : "Model provider",
     "openByDefault" : false
@@ -73,14 +70,12 @@
     "label" : "Retries"
   } ],
   "properties" : [ {
-    "id" : "taskDefinitionType",
     "value" : "io.camunda.agenticai:aiagent:1",
-    "group" : "taskDefinitionType",
     "binding" : {
       "property" : "type",
       "type" : "zeebe:taskDefinition"
     },
-    "type" : "String"
+    "type" : "Hidden"
   }, {
     "id" : "provider.type",
     "label" : "Provider",
@@ -760,6 +755,7 @@
     "label" : "Model",
     "description" : "Specify the model ID. Details in the <a href=\"https://docs.anthropic.com/en/docs/about-claude/models/all-models\" target=\"_blank\">documentation</a>.",
     "optional" : false,
+    "placeholder" : "claude-sonnet-4-6",
     "constraints" : {
       "notEmpty" : true
     },
@@ -774,7 +770,6 @@
       "equals" : "anthropic",
       "type" : "simple"
     },
-    "placeholder" : "claude-sonnet-4-6",
     "type" : "String"
   }, {
     "id" : "provider.anthropic.model.parameters.maxTokens",
@@ -849,6 +844,7 @@
     "label" : "Model",
     "description" : "Specify an inference profile ID. Details in the <a href=\"https://docs.aws.amazon.com/bedrock/latest/userguide/inference-profiles-support.html\" target=\"_blank\">documentation</a>.",
     "optional" : false,
+    "placeholder" : "global.anthropic.claude-sonnet-4-6",
     "constraints" : {
       "notEmpty" : true
     },
@@ -863,7 +859,6 @@
       "equals" : "bedrock",
       "type" : "simple"
     },
-    "placeholder" : "global.anthropic.claude-sonnet-4-6",
     "type" : "String"
   }, {
     "id" : "provider.bedrock.model.parameters.maxTokens",
@@ -1529,7 +1524,7 @@
     "id" : "version",
     "label" : "Version",
     "description" : "Version of the element template",
-    "value" : "10",
+    "value" : "7",
     "group" : "connector",
     "binding" : {
       "key" : "elementTemplateVersion",

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/AiAgentFunction.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/AiAgentFunction.java
@@ -37,9 +37,9 @@ import io.camunda.connector.generator.java.annotation.ElementTemplate.PropertyGr
     description = "Execute a single AI-powered action with tool calling capabilities",
     metadata = @ElementTemplate.Metadata(keywords = {"AI", "AI Agent", "agentic orchestration"}),
     documentationRef =
-        "https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/agentic-ai-aiagent-task/",
-    engineVersion = "^8.9",
-    version = 7,
+        "https://docs.camunda.io/docs/8.10/components/connectors/out-of-the-box-connectors/agentic-ai-aiagent-task/",
+    engineVersion = "^8.10",
+    version = 10,
     inputDataClass = OutboundConnectorAgentRequest.class,
     outputDataClass = AgentResponse.class,
     defaultResultVariable = "agent",


### PR DESCRIPTION
## Description

Bump ET version to 10 to keep versions 8 and 9 reserved for potential 8.9 bugfixes.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #

## Checklist

- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest
  release, as this branch will be rebased onto main before the next release. Example backport labels:
    - `backport stable/8.8`: for changes that should be included in the next 8.8.x release.
    - **or** `backport release-8.8.7`: for changes that should be included in the specific release 8.8.7, and this
      *release has already been created*. The release branch will be merged back into stable/8.8 later, so the change
      will be included in future 8.8.x releases as well.
- [ ] Tests/Integration tests for the changes have been added if applicable.
- [ ] If the change requires a documentation update, it has been added to the appropriate section in the documentation.


