### PR TITLE
fix(idp-extraction-connector): added custom deserialization for headers map

### DIFF
--- a/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/client/ai/OpenAiClient.java
+++ b/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/client/ai/OpenAiClient.java
@@ -41,22 +41,28 @@ public class OpenAiClient extends AiClient {
   }
 
   /**
-   * Sanitizes header values by replacing non-ASCII whitespace characters (e.g., Line Separator
-   * U+2028, Paragraph Separator U+2029) with regular spaces, and stripping leading/trailing
-   * whitespace. This prevents JDK HttpClient from rejecting headers containing invisible Unicode
-   * characters introduced by copy-paste artifacts or secret store formatting.
+   * Sanitizes header values by replacing characters outside the RFC 7230 field-value range (e.g.,
+   * Unicode Line Separator U+2028, control characters) with regular spaces, and stripping
+   * leading/trailing whitespace. Headers with null or blank values are skipped. This prevents JDK
+   * HttpClient from rejecting headers containing invisible characters introduced by copy-paste
+   * artifacts or secret store formatting.
    */
   private static Map<String, String> sanitizeHeaderValues(Map<String, String> headers) {
     Map<String, String> sanitized = new LinkedHashMap<>(headers.size());
     for (var entry : headers.entrySet()) {
-      String value = entry.getValue();
-      sanitized.put(entry.getKey(), value != null ? sanitizeHeaderValue(value) : null);
+      String value = sanitizeHeaderValue(entry.getValue());
+      if (value != null) {
+        sanitized.put(entry.getKey(), value);
+      }
     }
     return sanitized;
   }
 
   private static String sanitizeHeaderValue(String value) {
-    // Replace non-ASCII characters (e.g. U+2028 Line Separator from copy-paste) with spaces
+    if (value == null || value.isBlank()) {
+      return null;
+    }
+    // Replace characters outside the RFC 7230 field-value range with spaces
     return value.replaceAll("[^\\x09\\x20-\\x7E\\x80-\\xFF]", " ").strip();
   }
 }

--- a/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/client/ai/OpenAiClient.java
+++ b/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/client/ai/OpenAiClient.java
@@ -10,16 +10,18 @@ import dev.langchain4j.model.chat.request.ResponseFormat;
 import dev.langchain4j.model.openai.OpenAiChatModel;
 import io.camunda.connector.idp.extraction.client.ai.base.AiClient;
 import io.camunda.connector.idp.extraction.model.ConverseData;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 public class OpenAiClient extends AiClient {
 
   public OpenAiClient(String endpoint, Map<String, String> headers, ConverseData converseData) {
+    var sanitizedHeaders = sanitizeHeaderValues(headers);
     var builder =
         OpenAiChatModel.builder()
             .baseUrl(endpoint)
             .modelName(converseData.modelId())
-            .customHeaders(headers)
+            .customHeaders(sanitizedHeaders)
             .responseFormat(ResponseFormat.JSON);
 
     // Commenting out the max tokens assignment because it negatively impacts responses
@@ -36,5 +38,25 @@ public class OpenAiClient extends AiClient {
     }
 
     this.chatModel = builder.build();
+  }
+
+  /**
+   * Sanitizes header values by replacing non-ASCII whitespace characters (e.g., Line Separator
+   * U+2028, Paragraph Separator U+2029) with regular spaces, and stripping leading/trailing
+   * whitespace. This prevents JDK HttpClient from rejecting headers containing invisible Unicode
+   * characters introduced by copy-paste artifacts or secret store formatting.
+   */
+  private static Map<String, String> sanitizeHeaderValues(Map<String, String> headers) {
+    Map<String, String> sanitized = new LinkedHashMap<>(headers.size());
+    for (var entry : headers.entrySet()) {
+      String value = entry.getValue();
+      sanitized.put(entry.getKey(), value != null ? sanitizeHeaderValue(value) : null);
+    }
+    return sanitized;
+  }
+
+  private static String sanitizeHeaderValue(String value) {
+    // Replace non-ASCII characters (e.g. U+2028 Line Separator from copy-paste) with spaces
+    return value.replaceAll("[^\\x09\\x20-\\x7E\\x80-\\xFF]", " ").strip();
   }
 }

--- a/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/jackson/StringToMapDeserializer.java
+++ b/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/jackson/StringToMapDeserializer.java
@@ -30,15 +30,19 @@ public class StringToMapDeserializer extends JsonDeserializer<Map<String, String
     JsonNode node = p.readValueAsTree();
 
     if (node.isObject()) {
-      return p.getCodec().readValue(node.traverse(p.getCodec()), MAP_TYPE_REF);
+      try (JsonParser nodeParser = node.traverse(p.getCodec())) {
+        return p.getCodec().readValue(nodeParser, MAP_TYPE_REF);
+      }
     }
 
     if (node.isTextual()) {
       String text = node.textValue().trim();
-      return p.getCodec().readValue(p.getCodec().getFactory().createParser(text), MAP_TYPE_REF);
+      try (JsonParser textParser = p.getCodec().getFactory().createParser(text)) {
+        return p.getCodec().readValue(textParser, MAP_TYPE_REF);
+      }
     }
 
-    throw ctxt.weirdStringException(
-        node.toString(), Map.class, "Expected a JSON object or a JSON string representing a map");
+    throw ctxt.wrongTokenException(
+        p, Map.class, node.asToken(), "Expected a JSON object or a JSON string representing a map");
   }
 }

--- a/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/jackson/StringToMapDeserializer.java
+++ b/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/jackson/StringToMapDeserializer.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.idp.extraction.jackson;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonNode;
+import java.io.IOException;
+import java.util.Map;
+
+/**
+ * Custom deserializer that handles both a proper JSON object and a JSON-encoded string for {@code
+ * Map<String, String>} fields. This is needed because outbound connector variables may arrive as
+ * strings when FEEL evaluation doesn't occur (e.g., missing '=' prefix, old template version, or
+ * Zeebe serialization behavior).
+ */
+public class StringToMapDeserializer extends JsonDeserializer<Map<String, String>> {
+
+  private static final TypeReference<Map<String, String>> MAP_TYPE_REF = new TypeReference<>() {};
+
+  @Override
+  public Map<String, String> deserialize(JsonParser p, DeserializationContext ctxt)
+      throws IOException {
+    JsonNode node = p.readValueAsTree();
+
+    if (node.isObject()) {
+      return p.getCodec().readValue(node.traverse(p.getCodec()), MAP_TYPE_REF);
+    }
+
+    if (node.isTextual()) {
+      String text = node.textValue().trim();
+      return p.getCodec().readValue(p.getCodec().getFactory().createParser(text), MAP_TYPE_REF);
+    }
+
+    throw ctxt.weirdStringException(
+        node.toString(), Map.class, "Expected a JSON object or a JSON string representing a map");
+  }
+}

--- a/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/model/providers/OpenAiProvider.java
+++ b/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/model/providers/OpenAiProvider.java
@@ -6,10 +6,11 @@
  */
 package io.camunda.connector.idp.extraction.model.providers;
 
-import io.camunda.connector.api.annotation.FEEL;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.camunda.connector.generator.java.annotation.FeelMode;
 import io.camunda.connector.generator.java.annotation.TemplateProperty;
 import io.camunda.connector.generator.java.annotation.TemplateSubType;
+import io.camunda.connector.idp.extraction.jackson.StringToMapDeserializer;
 import jakarta.validation.constraints.NotNull;
 import java.util.Map;
 
@@ -28,7 +29,7 @@ public final class OpenAiProvider implements ProviderConfig {
   @NotNull
   private String openAiEndpoint;
 
-  @FEEL
+  @JsonDeserialize(using = StringToMapDeserializer.class)
   @TemplateProperty(
       id = "openAiHeaders",
       label = "Headers",

--- a/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/request/common/ai/OpenAiRequest.java
+++ b/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/request/common/ai/OpenAiRequest.java
@@ -6,10 +6,11 @@
  */
 package io.camunda.connector.idp.extraction.request.common.ai;
 
-import io.camunda.connector.api.annotation.FEEL;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.camunda.connector.generator.java.annotation.FeelMode;
 import io.camunda.connector.generator.java.annotation.TemplateProperty;
 import io.camunda.connector.generator.java.annotation.TemplateSubType;
+import io.camunda.connector.idp.extraction.jackson.StringToMapDeserializer;
 import jakarta.validation.constraints.NotNull;
 import java.util.Map;
 
@@ -26,7 +27,7 @@ public record OpenAiRequest(
             constraints = @TemplateProperty.PropertyConstraints(notEmpty = true))
         @NotNull
         String openAiEndpoint,
-    @FEEL
+    @JsonDeserialize(using = StringToMapDeserializer.class)
         @TemplateProperty(
             id = "openAiHeaders",
             label = "Headers",

--- a/connectors/idp-extraction/src/test/java/io/camunda/connector/idp/extraction/client/ai/OpenAiClientTest.java
+++ b/connectors/idp-extraction/src/test/java/io/camunda/connector/idp/extraction/client/ai/OpenAiClientTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.idp.extraction.client.ai;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Method;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class OpenAiClientTest {
+
+  /**
+   * Invokes the private sanitizeHeaderValues method via reflection for isolated testing of the
+   * sanitization logic without constructing a full OpenAiChatModel.
+   */
+  @SuppressWarnings("unchecked")
+  private static Map<String, String> invokeSanitize(Map<String, String> headers) throws Exception {
+    Method method = OpenAiClient.class.getDeclaredMethod("sanitizeHeaderValues", Map.class);
+    method.setAccessible(true);
+    return (Map<String, String>) method.invoke(null, headers);
+  }
+
+  @Test
+  void shouldPassThroughValidHeaderValues() throws Exception {
+    var headers = Map.of("Authorization", "Bearer sk-proj-abc123");
+
+    var result = invokeSanitize(headers);
+
+    assertThat(result).containsEntry("Authorization", "Bearer sk-proj-abc123");
+  }
+
+  @Test
+  void shouldReplaceUnicodeSeparatorWithSpace() throws Exception {
+    // U+2028 Line Separator between "Bearer" and "token"
+    var headers = Map.of("Authorization", "Bearer\u2028token");
+
+    var result = invokeSanitize(headers);
+
+    assertThat(result).containsEntry("Authorization", "Bearer token");
+  }
+
+  @Test
+  void shouldReplaceParagraphSeparator() throws Exception {
+    // U+2029 Paragraph Separator
+    var headers = Map.of("Authorization", "Bearer\u2029token");
+
+    var result = invokeSanitize(headers);
+
+    assertThat(result).containsEntry("Authorization", "Bearer token");
+  }
+
+  @Test
+  void shouldStripLeadingAndTrailingWhitespace() throws Exception {
+    var headers = Map.of("Authorization", "  Bearer token  ");
+
+    var result = invokeSanitize(headers);
+
+    assertThat(result).containsEntry("Authorization", "Bearer token");
+  }
+
+  @Test
+  void shouldSkipNullValues() throws Exception {
+    var headers = new LinkedHashMap<String, String>();
+    headers.put("Authorization", "Bearer token");
+    headers.put("X-Empty", null);
+
+    var result = invokeSanitize(headers);
+
+    assertThat(result).containsEntry("Authorization", "Bearer token").doesNotContainKey("X-Empty");
+  }
+
+  @Test
+  void shouldSkipBlankValues() throws Exception {
+    var headers = new LinkedHashMap<String, String>();
+    headers.put("Authorization", "Bearer token");
+    headers.put("X-Blank", "   ");
+
+    var result = invokeSanitize(headers);
+
+    assertThat(result).containsEntry("Authorization", "Bearer token").doesNotContainKey("X-Blank");
+  }
+
+  @Test
+  void shouldReplaceControlCharacters() throws Exception {
+    // Newline and carriage return in header value
+    var headers = Map.of("Authorization", "Bearer\ntoken\r123");
+
+    var result = invokeSanitize(headers);
+
+    assertThat(result).containsEntry("Authorization", "Bearer token 123");
+  }
+}

--- a/connectors/idp-extraction/src/test/java/io/camunda/connector/idp/extraction/jackson/StringToMapDeserializerTest.java
+++ b/connectors/idp-extraction/src/test/java/io/camunda/connector/idp/extraction/jackson/StringToMapDeserializerTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.idp.extraction.jackson;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class StringToMapDeserializerTest {
+
+  private final ObjectMapper objectMapper = new ObjectMapper();
+
+  record TestRecord(
+      @JsonDeserialize(using = StringToMapDeserializer.class) Map<String, String> headers) {}
+
+  @Test
+  void shouldDeserializeJsonObject() throws JsonProcessingException {
+    var json =
+        """
+        {"headers": {"Authorization": "Bearer token123", "Content-Type": "application/json"}}
+        """;
+
+    var result = objectMapper.readValue(json, TestRecord.class);
+
+    assertThat(result.headers())
+        .containsEntry("Authorization", "Bearer token123")
+        .containsEntry("Content-Type", "application/json")
+        .hasSize(2);
+  }
+
+  @Test
+  void shouldDeserializeJsonString() throws JsonProcessingException {
+    var json =
+        """
+        {"headers": "{\\"Authorization\\": \\"Bearer token123\\", \\"Content-Type\\": \\"application/json\\"}"}
+        """;
+
+    var result = objectMapper.readValue(json, TestRecord.class);
+
+    assertThat(result.headers())
+        .containsEntry("Authorization", "Bearer token123")
+        .containsEntry("Content-Type", "application/json")
+        .hasSize(2);
+  }
+
+  @Test
+  void shouldDeserializeSingleEntryString() throws JsonProcessingException {
+    var json =
+        """
+        {"headers": "{\\"Authorization\\": \\"Bearer sk-proj-abc123\\"}"}
+        """;
+
+    var result = objectMapper.readValue(json, TestRecord.class);
+
+    assertThat(result.headers()).containsEntry("Authorization", "Bearer sk-proj-abc123").hasSize(1);
+  }
+
+  @Test
+  void shouldFailOnInvalidJsonString() {
+    var json =
+        """
+        {"headers": "not-valid-json"}
+        """;
+
+    assertThatThrownBy(() -> objectMapper.readValue(json, TestRecord.class))
+        .isInstanceOf(JsonProcessingException.class);
+  }
+
+  @Test
+  void shouldFailOnArrayInput() {
+    var json =
+        """
+        {"headers": ["a", "b"]}
+        """;
+
+    assertThatThrownBy(() -> objectMapper.readValue(json, TestRecord.class))
+        .isInstanceOf(JsonProcessingException.class);
+  }
+}


### PR DESCRIPTION
## Description

Fixes deserialization of [openAiHeaders](vscode-file://vscode-Fixes deserialization of openAiHeaders (Map<String, String>) in the IDP Extraction connector when FEEL evaluation is disabled for outbound connectors.

Since PR #6210 introduced a separate outboundConnectorObjectMapper with `@feel` processing disabled, Map-typed fields that arrive as JSON strings can no longer rely on the `FeelDeserializer` to coerce them. This caused a `MismatchedInputException` at runtime.

**Testing:**

* Added `StringToMapDeserializerTest` to verify correct deserialization from both JSON objects and strings, and to ensure invalid inputs are properly rejected.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes https://github.com/camunda/connectors/issues/6935

## Checklist

- [x] Backport labels are added if these code changes should be backported. No backport label is added to the latest
  release, as this branch will be rebased onto main before the next release. Example backport labels:
    - `backport stable/8.8`: for changes that should be included in the next 8.8.x release.
    - **or** `backport release-8.8.7`: for changes that should be included in the specific release 8.8.7, and this
      *release has already been created*. The release branch will be merged back into stable/8.8 later, so the change
      will be included in future 8.8.x releases as well.
- [x] Tests/Integration tests for the changes have been added if applicable.
- [x] If the change requires a documentation update, it has been added to the appropriate section in the documentation.


