### PR TITLE
chore: exclude npm package files from CODEOWNERS for Renovate automerge

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -21,3 +21,5 @@ renovate.json
 **/docker-images.properties
 .tool-versions
 **/pom.xml
+**/package.json
+**/package-lock.json


### PR DESCRIPTION
## Summary

- Adds `**/package.json` and `**/package-lock.json` to the CODEOWNERS exclusion list so Renovate can automerge dependency upgrades that touch npm files (e.g. prettier bumps in `element-template-generator/npm/`)
- Without this, those files fall under the default `* @camunda/connectors` ownership and `renovate-approve` (which has no team membership) cannot satisfy the codeowner requirement

Fixes: camunda/connectors#6970 (Renovate PR for stable/8.8 blocked from automerge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)