### PR TITLE
chore: bump SaaS E2E versions to 8.10 

### DIFF
--- a/.github/workflows/FEATURE_BRANCH_HELM_TEST.yaml
+++ b/.github/workflows/FEATURE_BRANCH_HELM_TEST.yaml
@@ -191,12 +191,12 @@ jobs:
                       "correlation_id": "'"$CORRELATION_ID"'",
                       "source_repo": "${{ github.repository }}",
                       "source_sha": "${{ github.sha }}",
-                      "c8Version": "8.9",
-                      "zeebeVersion": "8.9-SNAPSHOT",
-                      "operateVersion": "8.9-SNAPSHOT",
-                      "tasklistVersion": "8.9-SNAPSHOT",
+                      "c8Version": "8.10",
+                      "zeebeVersion": "SNAPSHOT",
+                      "operateVersion": "SNAPSHOT",
+                      "tasklistVersion": "SNAPSHOT",
                       "connectorsVersion": "${{ needs.build-image.outputs.connectors-version }}",
-                      "optimizeVersion": "8.9-SNAPSHOT"
+                      "optimizeVersion": "8-SNAPSHOT"
                   }
                 }'
       - name: Observe build status


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
Bumps the SaaS E2E component versions in the feature branch Helm test workflow from 8.9 to 8.10
## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #

## Checklist

- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest
  release, as this branch will be rebased onto main before the next release. Example backport labels:
    - `backport stable/8.8`: for changes that should be included in the next 8.8.x release.
    - **or** `backport release-8.8.7`: for changes that should be included in the specific release 8.8.7, and this
      *release has already been created*. The release branch will be merged back into stable/8.8 later, so the change
      will be included in future 8.8.x releases as well.
- [ ] Tests/Integration tests for the changes have been added if applicable.
- [ ] If the change requires a documentation update, it has been added to the appropriate section in the documentation.


