### PR TITLE
fix: configure loader.path for custom libs

### DIFF
--- a/bundle/default-bundle/start.sh
+++ b/bundle/default-bundle/start.sh
@@ -16,7 +16,7 @@ fi
 JAVA_OPTS="${JAVA_OPTS} --add-opens=java.base/java.util.concurrent=ALL-UNNAMED"
 
 # Configure loader.path for custom libraries
-JAVA_OPTS="${JAVA_OPTS} -Dloader.path=/opt/custom/*"
+JAVA_OPTS="${JAVA_OPTS} -Dloader.path=/opt/custom/"
 
 if [[ -n ${DEBUG_JVM_PRINT_JAVA_OPTS} ]]; then
   echo "Applied JVM options: $JAVA_OPTS"

--- a/bundle/default-bundle/start.sh
+++ b/bundle/default-bundle/start.sh
@@ -15,8 +15,11 @@ fi
 # For thread pool metrics with virtual threads
 JAVA_OPTS="${JAVA_OPTS} --add-opens=java.base/java.util.concurrent=ALL-UNNAMED"
 
+# Configure loader.path for custom libraries
+JAVA_OPTS="${JAVA_OPTS} -Dloader.path=/opt/custom/*"
+
 if [[ -n ${DEBUG_JVM_PRINT_JAVA_OPTS} ]]; then
   echo "Applied JVM options: $JAVA_OPTS"
 fi
 
-exec java ${JAVA_OPTS} -cp "/opt/app/*:/opt/custom/*" "org.springframework.boot.loader.launch.PropertiesLauncher"
+exec java ${JAVA_OPTS} -cp "/opt/app/*" "org.springframework.boot.loader.launch.PropertiesLauncher"

--- a/connector-runtime/connector-runtime-application/start.sh
+++ b/connector-runtime/connector-runtime-application/start.sh
@@ -15,8 +15,11 @@ fi
 # For thread pool metrics with virtual threads
 JAVA_OPTS="${JAVA_OPTS} --add-opens=java.base/java.util.concurrent=ALL-UNNAMED"
 
+# Configure loader.path for custom libraries
+JAVA_OPTS="${JAVA_OPTS} -Dloader.path=/opt/custom/"
+
 if [[ -n ${DEBUG_JVM_PRINT_JAVA_OPTS} ]]; then
   echo "Applied JVM options: $JAVA_OPTS"
 fi
 
-exec java ${JAVA_OPTS} -cp "/opt/app/*:/opt/custom/*" "org.springframework.boot.loader.launch.PropertiesLauncher"
+exec java ${JAVA_OPTS} -cp "/opt/app/*" "org.springframework.boot.loader.launch.PropertiesLauncher"


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

With the switch to using the PropertiesLauncher and ZIP jar, the classloading mechanism slightly changed.

To include additional connectors in the classpath, they should not be added via `-cp` directly. 

Instead, they have to be added with the property `-Dloader.path` as described here: https://docs.spring.io/spring-boot/specification/executable-jar/property-launcher.html

This PR fixes this for the bundle.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #

## Checklist

- [x] Backport labels are added if these code changes should be backported. No backport label is added to the latest
  release, as this branch will be rebased onto main before the next release. Example backport labels:
    - `backport stable/8.8`: for changes that should be included in the next 8.8.x release.
    - **or** `backport release-8.8.7`: for changes that should be included in the specific release 8.8.7, and this
      *release has already been created*. The release branch will be merged back into stable/8.8 later, so the change
      will be included in future 8.8.x releases as well.
- [ ] Tests/Integration tests for the changes have been added if applicable.
- [ ] If the change requires a documentation update, it has been added to the appropriate section in the documentation.


