### PR TITLE
chore(keywords): Move metadata.keywords to root level for agentic-ai templates

### DIFF
--- a/connectors/agentic-ai/element-templates/agenticai-a2a-client-outbound-connector.json
+++ b/connectors/agentic-ai/element-templates/agenticai-a2a-client-outbound-connector.json
@@ -3,9 +3,7 @@
   "name" : "A2A Client (early access)",
   "id" : "io.camunda.connectors.agenticai.a2a.client.v0",
   "description" : "Agent-to-Agent (A2A) client, enabling discovering remote agents' Agent Cards as well as sending messages to remote agents.",
-  "metadata" : {
-    "keywords" : [ ]
-  },
+  "keywords" : [ "A2A", "agent-to-agent", "agentic orchestration", "multi-agent" ],
   "documentationRef" : "https://docs.camunda.io/docs/8.9/components/early-access/alpha/a2a-client/a2a-client-connector/",
   "version" : 0,
   "category" : {

--- a/connectors/agentic-ai/element-templates/agenticai-a2a-client-polling-inbound-connector-intermediate.json
+++ b/connectors/agentic-ai/element-templates/agenticai-a2a-client-polling-inbound-connector-intermediate.json
@@ -3,9 +3,7 @@
   "name" : "A2A Client Polling Intermediate Catch Event Connector (early access)",
   "id" : "io.camunda.connectors.agenticai.a2a.client.polling.intermediate.v0",
   "description" : "Agent-to-Agent (A2A) polling inbound connector. Supports polling asynchronous tasks, but can also directly correlate messages and synchronously completed tasks.",
-  "metadata" : {
-    "keywords" : [ ]
-  },
+  "keywords" : [ "A2A", "agent-to-agent", "agentic orchestration", "multi-agent", "polling" ],
   "documentationRef" : "https://docs.camunda.io/docs/8.9/components/early-access/alpha/a2a-client/a2a-client-polling-connector/",
   "version" : 0,
   "category" : {

--- a/connectors/agentic-ai/element-templates/agenticai-a2a-client-polling-inbound-connector-receive.json
+++ b/connectors/agentic-ai/element-templates/agenticai-a2a-client-polling-inbound-connector-receive.json
@@ -3,9 +3,7 @@
   "name" : "A2A Client Polling Receive Task Connector (early access)",
   "id" : "io.camunda.connectors.agenticai.a2a.client.polling.receive.v0",
   "description" : "Agent-to-Agent (A2A) polling inbound connector. Supports polling asynchronous tasks, but can also directly correlate messages and synchronously completed tasks.",
-  "metadata" : {
-    "keywords" : [ ]
-  },
+  "keywords" : [ "A2A", "agent-to-agent", "agentic orchestration", "multi-agent", "polling" ],
   "documentationRef" : "https://docs.camunda.io/docs/8.9/components/early-access/alpha/a2a-client/a2a-client-polling-connector/",
   "version" : 0,
   "category" : {

--- a/connectors/agentic-ai/element-templates/agenticai-a2a-client-webhook-inbound-connector-intermediate.json
+++ b/connectors/agentic-ai/element-templates/agenticai-a2a-client-webhook-inbound-connector-intermediate.json
@@ -3,9 +3,7 @@
   "name" : "A2A Client Webhook Intermediate Catch Event Connector (early access)",
   "id" : "io.camunda.connectors.agenticai.a2a.client.webhook.intermediate.v0",
   "description" : "Agent-to-Agent (A2A) webhook inbound connector that can be used to receive callbacks from remote A2A servers.",
-  "metadata" : {
-    "keywords" : [ ]
-  },
+  "keywords" : [ "A2A", "agent-to-agent", "agentic orchestration", "multi-agent", "webhook" ],
   "documentationRef" : "https://docs.camunda.io/docs/8.9/components/early-access/alpha/a2a-client/a2a-client-webhook-connector/",
   "version" : 0,
   "category" : {

--- a/connectors/agentic-ai/element-templates/agenticai-a2a-client-webhook-inbound-connector-receive.json
+++ b/connectors/agentic-ai/element-templates/agenticai-a2a-client-webhook-inbound-connector-receive.json
@@ -3,9 +3,7 @@
   "name" : "A2A Client Webhook Receive Task Connector (early access)",
   "id" : "io.camunda.connectors.agenticai.a2a.client.webhook.receive.v0",
   "description" : "Agent-to-Agent (A2A) webhook inbound connector that can be used to receive callbacks from remote A2A servers.",
-  "metadata" : {
-    "keywords" : [ ]
-  },
+  "keywords" : [ "A2A", "agent-to-agent", "agentic orchestration", "multi-agent", "webhook" ],
   "documentationRef" : "https://docs.camunda.io/docs/8.9/components/early-access/alpha/a2a-client/a2a-client-webhook-connector/",
   "version" : 0,
   "category" : {

--- a/connectors/agentic-ai/element-templates/agenticai-adhoctoolsschema-outbound-connector.json
+++ b/connectors/agentic-ai/element-templates/agenticai-adhoctoolsschema-outbound-connector.json
@@ -3,9 +3,7 @@
   "name" : "Ad-hoc tools schema",
   "id" : "io.camunda.connectors.agenticai.adhoctoolsschema.v1",
   "description" : "Connector to fetch tools schema information from an ad-hoc sub-process.",
-  "metadata" : {
-    "keywords" : [ ]
-  },
+  "keywords" : [ "ad-hoc tools", "tool schema", "agentic orchestration", "AI", "agent tools" ],
   "documentationRef" : "https://docs.camunda.io/docs/8.8/components/connectors/out-of-the-box-connectors/agentic-ai-ad-hoc-tools-schema-resolver/",
   "version" : 2,
   "category" : {

--- a/connectors/agentic-ai/element-templates/agenticai-aiagent-job-worker.json
+++ b/connectors/agentic-ai/element-templates/agenticai-aiagent-job-worker.json
@@ -3,9 +3,7 @@
   "name" : "AI Agent Sub-process",
   "id" : "io.camunda.connectors.agenticai.aiagent.jobworker.v1",
   "description" : "Run a multi-step AI reasoning loop with dynamic tool selection",
-  "metadata" : {
-    "keywords" : [ "AI", "AI Agent", "agentic orchestration" ]
-  },
+  "keywords" : [ "AI", "AI Agent", "agentic orchestration", "tool calling", "LLM", "agent", "reasoning loop" ],
   "documentationRef" : "https://docs.camunda.io/docs/8.10/components/connectors/out-of-the-box-connectors/agentic-ai-aiagent-subprocess/",
   "version" : 10,
   "category" : {

--- a/connectors/agentic-ai/element-templates/agenticai-aiagent-outbound-connector.json
+++ b/connectors/agentic-ai/element-templates/agenticai-aiagent-outbound-connector.json
@@ -3,9 +3,7 @@
   "name" : "AI Agent Task",
   "id" : "io.camunda.connectors.agenticai.aiagent.v1",
   "description" : "Execute a single AI-powered action with tool calling capabilities",
-  "metadata" : {
-    "keywords" : [ "AI", "AI Agent", "agentic orchestration" ]
-  },
+  "keywords" : [ "AI", "AI Agent", "agentic orchestration", "tool calling", "LLM", "agent" ],
   "documentationRef" : "https://docs.camunda.io/docs/8.10/components/connectors/out-of-the-box-connectors/agentic-ai-aiagent-task/",
   "version" : 10,
   "category" : {

--- a/connectors/agentic-ai/element-templates/agenticai-mcp-client-outbound-connector.json
+++ b/connectors/agentic-ai/element-templates/agenticai-mcp-client-outbound-connector.json
@@ -3,9 +3,7 @@
   "name" : "MCP Client",
   "id" : "io.camunda.connectors.agenticai.mcp.client.v0",
   "description" : "MCP (Model Context Protocol) client using MCP connections configured on the connector runtime.",
-  "metadata" : {
-    "keywords" : [ ]
-  },
+  "keywords" : [ "MCP", "Model Context Protocol", "AI tools", "agentic orchestration", "LLM tools" ],
   "documentationRef" : "https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/agentic-ai-mcp-client-connector/",
   "version" : 2,
   "category" : {

--- a/connectors/agentic-ai/element-templates/agenticai-mcp-remote-client-outbound-connector.json
+++ b/connectors/agentic-ai/element-templates/agenticai-mcp-remote-client-outbound-connector.json
@@ -3,9 +3,7 @@
   "name" : "MCP Remote Client",
   "id" : "io.camunda.connectors.agenticai.mcp.remoteclient.v0",
   "description" : "MCP (Model Context Protocol) client, operating on temporary remote connections.",
-  "metadata" : {
-    "keywords" : [ ]
-  },
+  "keywords" : [ "MCP", "Model Context Protocol", "AI tools", "agentic orchestration", "remote tools" ],
   "documentationRef" : "https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/agentic-ai-mcp-remote-client-connector/",
   "version" : 2,
   "category" : {

--- a/connectors/agentic-ai/element-templates/hybrid/agenticai-a2a-client-outbound-connector-hybrid.json
+++ b/connectors/agentic-ai/element-templates/hybrid/agenticai-a2a-client-outbound-connector-hybrid.json
@@ -3,9 +3,7 @@
   "name" : "Hybrid A2A Client (early access)",
   "id" : "io.camunda.connectors.agenticai.a2a.client.v0-hybrid",
   "description" : "Agent-to-Agent (A2A) client, enabling discovering remote agents' Agent Cards as well as sending messages to remote agents.",
-  "metadata" : {
-    "keywords" : [ ]
-  },
+  "keywords" : [ "A2A", "agent-to-agent", "agentic orchestration", "multi-agent" ],
   "documentationRef" : "https://docs.camunda.io/docs/8.9/components/early-access/alpha/a2a-client/a2a-client-connector/",
   "version" : 0,
   "category" : {

--- a/connectors/agentic-ai/element-templates/hybrid/agenticai-adhoctoolsschema-outbound-connector-hybrid.json
+++ b/connectors/agentic-ai/element-templates/hybrid/agenticai-adhoctoolsschema-outbound-connector-hybrid.json
@@ -3,9 +3,7 @@
   "name" : "Hybrid Ad-hoc tools schema",
   "id" : "io.camunda.connectors.agenticai.adhoctoolsschema.v1-hybrid",
   "description" : "Connector to fetch tools schema information from an ad-hoc sub-process.",
-  "metadata" : {
-    "keywords" : [ ]
-  },
+  "keywords" : [ "ad-hoc tools", "tool schema", "agentic orchestration", "AI", "agent tools" ],
   "documentationRef" : "https://docs.camunda.io/docs/8.8/components/connectors/out-of-the-box-connectors/agentic-ai-ad-hoc-tools-schema-resolver/",
   "version" : 2,
   "category" : {

--- a/connectors/agentic-ai/element-templates/hybrid/agenticai-aiagent-job-worker-hybrid.json
+++ b/connectors/agentic-ai/element-templates/hybrid/agenticai-aiagent-job-worker-hybrid.json
@@ -3,9 +3,7 @@
   "name" : "Hybrid AI Agent Sub-process",
   "id" : "io.camunda.connectors.agenticai.aiagent.jobworker.v1-hybrid",
   "description" : "Run a multi-step AI reasoning loop with dynamic tool selection",
-  "metadata" : {
-    "keywords" : [ "AI", "AI Agent", "agentic orchestration" ]
-  },
+  "keywords" : [ "AI", "AI Agent", "agentic orchestration", "tool calling", "LLM", "agent", "reasoning loop" ],
   "documentationRef" : "https://docs.camunda.io/docs/8.10/components/connectors/out-of-the-box-connectors/agentic-ai-aiagent-subprocess/",
   "version" : 10,
   "category" : {

--- a/connectors/agentic-ai/element-templates/hybrid/agenticai-aiagent-outbound-connector-hybrid.json
+++ b/connectors/agentic-ai/element-templates/hybrid/agenticai-aiagent-outbound-connector-hybrid.json
@@ -3,9 +3,7 @@
   "name" : "Hybrid AI Agent Task",
   "id" : "io.camunda.connectors.agenticai.aiagent.v1-hybrid",
   "description" : "Execute a single AI-powered action with tool calling capabilities",
-  "metadata" : {
-    "keywords" : [ "AI", "AI Agent", "agentic orchestration" ]
-  },
+  "keywords" : [ "AI", "AI Agent", "agentic orchestration", "tool calling", "LLM", "agent" ],
   "documentationRef" : "https://docs.camunda.io/docs/8.10/components/connectors/out-of-the-box-connectors/agentic-ai-aiagent-task/",
   "version" : 10,
   "category" : {

--- a/connectors/agentic-ai/element-templates/hybrid/agenticai-mcp-client-outbound-connector-hybrid.json
+++ b/connectors/agentic-ai/element-templates/hybrid/agenticai-mcp-client-outbound-connector-hybrid.json
@@ -3,9 +3,7 @@
   "name" : "Hybrid MCP Client",
   "id" : "io.camunda.connectors.agenticai.mcp.client.v0-hybrid",
   "description" : "MCP (Model Context Protocol) client using MCP connections configured on the connector runtime.",
-  "metadata" : {
-    "keywords" : [ ]
-  },
+  "keywords" : [ "MCP", "Model Context Protocol", "AI tools", "agentic orchestration", "LLM tools" ],
   "documentationRef" : "https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/agentic-ai-mcp-client-connector/",
   "version" : 2,
   "category" : {

--- a/connectors/agentic-ai/element-templates/hybrid/agenticai-mcp-remote-client-outbound-connector-hybrid.json
+++ b/connectors/agentic-ai/element-templates/hybrid/agenticai-mcp-remote-client-outbound-connector-hybrid.json
@@ -3,9 +3,7 @@
   "name" : "Hybrid MCP Remote Client",
   "id" : "io.camunda.connectors.agenticai.mcp.remoteclient.v0-hybrid",
   "description" : "MCP (Model Context Protocol) client, operating on temporary remote connections.",
-  "metadata" : {
-    "keywords" : [ ]
-  },
+  "keywords" : [ "MCP", "Model Context Protocol", "AI tools", "agentic orchestration", "remote tools" ],
   "documentationRef" : "https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/agentic-ai-mcp-remote-client-connector/",
   "version" : 2,
   "category" : {

--- a/connectors/agentic-ai/element-templates/versioned/agenticai-adhoctoolsschema-outbound-connector-0.json
+++ b/connectors/agentic-ai/element-templates/versioned/agenticai-adhoctoolsschema-outbound-connector-0.json
@@ -3,9 +3,7 @@
   "name" : "Ad-hoc subprocess tools schema (alpha)",
   "id" : "io.camunda.connectors.agenticai.adhoctoolsschema.v0",
   "description" : "Connector to fetch tools schema information from an ad-hoc subprocess",
-  "metadata" : {
-    "keywords" : [ ]
-  },
+  "keywords" : [ "ad-hoc tools", "tool schema", "agentic orchestration", "AI", "agent tools" ],
   "version" : 0,
   "deprecated": true,
   "category" : {

--- a/connectors/agentic-ai/element-templates/versioned/agenticai-adhoctoolsschema-outbound-connector-1.json
+++ b/connectors/agentic-ai/element-templates/versioned/agenticai-adhoctoolsschema-outbound-connector-1.json
@@ -3,9 +3,7 @@
   "name" : "Ad-hoc tools schema",
   "id" : "io.camunda.connectors.agenticai.adhoctoolsschema.v1",
   "description" : "Connector to fetch tools schema information from an ad-hoc sub-process. Compatible with 8.8.0-alpha6 or later.",
-  "metadata" : {
-    "keywords" : [ ]
-  },
+  "keywords" : [ "ad-hoc tools", "tool schema", "agentic orchestration", "AI", "agent tools" ],
   "documentationRef" : "https://docs.camunda.io/docs/8.8/components/connectors/out-of-the-box-connectors/agentic-ai-ad-hoc-tools-schema-resolver/",
   "version" : 1,
   "deprecated": true,

--- a/connectors/agentic-ai/element-templates/versioned/agenticai-aiagent-job-worker-3.json
+++ b/connectors/agentic-ai/element-templates/versioned/agenticai-aiagent-job-worker-3.json
@@ -3,9 +3,7 @@
   "name" : "AI Agent Subprocess",
   "id" : "io.camunda.connectors.agenticai.aiagent.jobworker.v1",
   "description" : "Processes user requests with an integrated, customizable toolbox and services for dynamic workflows.",
-  "metadata" : {
-    "keywords" : [ "AI", "AI Agent", "agentic orchestration" ]
-  },
+  "keywords" : [ "AI", "AI Agent", "agentic orchestration", "tool calling", "LLM", "agent", "reasoning loop" ],
   "documentationRef" : "https://docs.camunda.io/docs/8.8/components/connectors/out-of-the-box-connectors/agentic-ai-aiagent/",
   "version" : 3,
   "category" : {

--- a/connectors/agentic-ai/element-templates/versioned/agenticai-aiagent-job-worker-4.json
+++ b/connectors/agentic-ai/element-templates/versioned/agenticai-aiagent-job-worker-4.json
@@ -3,9 +3,7 @@
   "name" : "AI Agent Sub-process",
   "id" : "io.camunda.connectors.agenticai.aiagent.jobworker.v1",
   "description" : "Run a multi-step AI reasoning loop with dynamic tool selection",
-  "metadata" : {
-    "keywords" : [ "AI", "AI Agent", "agentic orchestration" ]
-  },
+  "keywords" : [ "AI", "AI Agent", "agentic orchestration", "tool calling", "LLM", "agent", "reasoning loop" ],
   "documentationRef" : "https://docs.camunda.io/docs/8.8/components/connectors/out-of-the-box-connectors/agentic-ai-aiagent/",
   "version" : 4,
   "category" : {

--- a/connectors/agentic-ai/element-templates/versioned/agenticai-aiagent-job-worker-5.json
+++ b/connectors/agentic-ai/element-templates/versioned/agenticai-aiagent-job-worker-5.json
@@ -3,9 +3,7 @@
   "name" : "AI Agent Sub-process",
   "id" : "io.camunda.connectors.agenticai.aiagent.jobworker.v1",
   "description" : "Run a multi-step AI reasoning loop with dynamic tool selection",
-  "metadata" : {
-    "keywords" : [ "AI", "AI Agent", "agentic orchestration" ]
-  },
+  "keywords" : [ "AI", "AI Agent", "agentic orchestration", "tool calling", "LLM", "agent", "reasoning loop" ],
   "documentationRef" : "https://docs.camunda.io/docs/8.8/components/connectors/out-of-the-box-connectors/agentic-ai-aiagent/",
   "version" : 5,
   "category" : {

--- a/connectors/agentic-ai/element-templates/versioned/agenticai-aiagent-job-worker-6.json
+++ b/connectors/agentic-ai/element-templates/versioned/agenticai-aiagent-job-worker-6.json
@@ -3,9 +3,7 @@
   "name" : "AI Agent Sub-process",
   "id" : "io.camunda.connectors.agenticai.aiagent.jobworker.v1",
   "description" : "Run a multi-step AI reasoning loop with dynamic tool selection",
-  "metadata" : {
-    "keywords" : [ "AI", "AI Agent", "agentic orchestration" ]
-  },
+  "keywords" : [ "AI", "AI Agent", "agentic orchestration", "tool calling", "LLM", "agent", "reasoning loop" ],
   "documentationRef" : "https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/agentic-ai-aiagent-subprocess/",
   "version" : 6,
   "category" : {

--- a/connectors/agentic-ai/element-templates/versioned/agenticai-aiagent-job-worker-7.json
+++ b/connectors/agentic-ai/element-templates/versioned/agenticai-aiagent-job-worker-7.json
@@ -3,9 +3,7 @@
   "name" : "AI Agent Sub-process",
   "id" : "io.camunda.connectors.agenticai.aiagent.jobworker.v1",
   "description" : "Run a multi-step AI reasoning loop with dynamic tool selection",
-  "metadata" : {
-    "keywords" : [ "AI", "AI Agent", "agentic orchestration" ]
-  },
+  "keywords" : [ "AI", "AI Agent", "agentic orchestration", "tool calling", "LLM", "agent", "reasoning loop" ],
   "documentationRef" : "https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/agentic-ai-aiagent-subprocess/",
   "version" : 7,
   "category" : {

--- a/connectors/agentic-ai/element-templates/versioned/agenticai-aiagent-outbound-connector-0.json
+++ b/connectors/agentic-ai/element-templates/versioned/agenticai-aiagent-outbound-connector-0.json
@@ -3,9 +3,7 @@
   "name" : "AI Agent (alpha)",
   "id" : "io.camunda.connectors.agenticai.aiagent.v0",
   "description" : "AI Agent connector",
-  "metadata" : {
-    "keywords" : [ ]
-  },
+  "keywords" : [ "AI", "AI Agent", "agentic orchestration", "tool calling", "LLM", "agent" ],
   "version" : 0,
   "deprecated": true,
   "category" : {

--- a/connectors/agentic-ai/element-templates/versioned/agenticai-aiagent-outbound-connector-1.json
+++ b/connectors/agentic-ai/element-templates/versioned/agenticai-aiagent-outbound-connector-1.json
@@ -3,9 +3,7 @@
   "name" : "AI Agent",
   "id" : "io.camunda.connectors.agenticai.aiagent.v1",
   "description" : "Provides a generic AI agent implementation handling the feedback loop between user requests, tool calls and LLM responses. Compatible with 8.8.0-alpha6 or later.",
-  "metadata" : {
-    "keywords" : [ ]
-  },
+  "keywords" : [ "AI", "AI Agent", "agentic orchestration", "tool calling", "LLM", "agent" ],
   "documentationRef" : "https://docs.camunda.io/docs/8.8/components/connectors/out-of-the-box-connectors/agentic-ai-aiagent/",
   "version" : 1,
   "deprecated": true,

--- a/connectors/agentic-ai/element-templates/versioned/agenticai-aiagent-outbound-connector-2.json
+++ b/connectors/agentic-ai/element-templates/versioned/agenticai-aiagent-outbound-connector-2.json
@@ -3,9 +3,7 @@
   "name" : "AI Agent",
   "id" : "io.camunda.connectors.agenticai.aiagent.v1",
   "description" : "Provides a generic AI agent implementation handling the feedback loop between user requests, tool calls and LLM responses. Compatible with 8.8.0-alpha7 or later.",
-  "metadata" : {
-    "keywords" : [ ]
-  },
+  "keywords" : [ "AI", "AI Agent", "agentic orchestration", "tool calling", "LLM", "agent" ],
   "documentationRef" : "https://docs.camunda.io/docs/8.8/components/connectors/out-of-the-box-connectors/agentic-ai-aiagent/",
   "version" : 2,
   "deprecated": true,

--- a/connectors/agentic-ai/element-templates/versioned/agenticai-aiagent-outbound-connector-3.json
+++ b/connectors/agentic-ai/element-templates/versioned/agenticai-aiagent-outbound-connector-3.json
@@ -3,9 +3,7 @@
   "name" : "AI Agent Task",
   "id" : "io.camunda.connectors.agenticai.aiagent.v1",
   "description" : "Execute a single AI-powered action with tool calling capabilities",
-  "metadata" : {
-    "keywords" : [ "AI", "AI Agent", "agentic orchestration" ]
-  },
+  "keywords" : [ "AI", "AI Agent", "agentic orchestration", "tool calling", "LLM", "agent" ],
   "documentationRef" : "https://docs.camunda.io/docs/8.8/components/connectors/out-of-the-box-connectors/agentic-ai-aiagent/",
   "version" : 3,
   "category" : {

--- a/connectors/agentic-ai/element-templates/versioned/agenticai-aiagent-outbound-connector-4.json
+++ b/connectors/agentic-ai/element-templates/versioned/agenticai-aiagent-outbound-connector-4.json
@@ -3,9 +3,7 @@
   "name" : "AI Agent Task",
   "id" : "io.camunda.connectors.agenticai.aiagent.v1",
   "description" : "Execute a single AI-powered action with tool calling capabilities",
-  "metadata" : {
-    "keywords" : [ "AI", "AI Agent", "agentic orchestration" ]
-  },
+  "keywords" : [ "AI", "AI Agent", "agentic orchestration", "tool calling", "LLM", "agent" ],
   "documentationRef" : "https://docs.camunda.io/docs/8.8/components/connectors/out-of-the-box-connectors/agentic-ai-aiagent/",
   "version" : 4,
   "category" : {

--- a/connectors/agentic-ai/element-templates/versioned/agenticai-aiagent-outbound-connector-5.json
+++ b/connectors/agentic-ai/element-templates/versioned/agenticai-aiagent-outbound-connector-5.json
@@ -3,9 +3,7 @@
   "name" : "AI Agent Task",
   "id" : "io.camunda.connectors.agenticai.aiagent.v1",
   "description" : "Execute a single AI-powered action with tool calling capabilities",
-  "metadata" : {
-    "keywords" : [ "AI", "AI Agent", "agentic orchestration" ]
-  },
+  "keywords" : [ "AI", "AI Agent", "agentic orchestration", "tool calling", "LLM", "agent" ],
   "documentationRef" : "https://docs.camunda.io/docs/8.8/components/connectors/out-of-the-box-connectors/agentic-ai-aiagent/",
   "version" : 5,
   "category" : {

--- a/connectors/agentic-ai/element-templates/versioned/agenticai-aiagent-outbound-connector-6.json
+++ b/connectors/agentic-ai/element-templates/versioned/agenticai-aiagent-outbound-connector-6.json
@@ -3,9 +3,7 @@
   "name" : "AI Agent Task",
   "id" : "io.camunda.connectors.agenticai.aiagent.v1",
   "description" : "Execute a single AI-powered action with tool calling capabilities",
-  "metadata" : {
-    "keywords" : [ "AI", "AI Agent", "agentic orchestration" ]
-  },
+  "keywords" : [ "AI", "AI Agent", "agentic orchestration", "tool calling", "LLM", "agent" ],
   "documentationRef" : "https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/agentic-ai-aiagent-task/",
   "version" : 6,
   "category" : {

--- a/connectors/agentic-ai/element-templates/versioned/agenticai-aiagent-outbound-connector-7.json
+++ b/connectors/agentic-ai/element-templates/versioned/agenticai-aiagent-outbound-connector-7.json
@@ -3,9 +3,7 @@
   "name" : "AI Agent Task",
   "id" : "io.camunda.connectors.agenticai.aiagent.v1",
   "description" : "Execute a single AI-powered action with tool calling capabilities",
-  "metadata" : {
-    "keywords" : [ "AI", "AI Agent", "agentic orchestration" ]
-  },
+  "keywords" : [ "AI", "AI Agent", "agentic orchestration", "tool calling", "LLM", "agent" ],
   "documentationRef" : "https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/agentic-ai-aiagent-task/",
   "version" : 7,
   "category" : {

--- a/connectors/agentic-ai/element-templates/versioned/agenticai-mcp-client-outbound-connector-0.json
+++ b/connectors/agentic-ai/element-templates/versioned/agenticai-mcp-client-outbound-connector-0.json
@@ -3,9 +3,7 @@
   "name" : "MCP Client (early access)",
   "id" : "io.camunda.connectors.agenticai.mcp.client.v0",
   "description" : "MCP (Model Context Protocol) client using MCP connections configured on the connector runtime. Only supports tool operations.",
-  "metadata" : {
-    "keywords" : [ ]
-  },
+  "keywords" : [ "MCP", "Model Context Protocol", "AI tools", "agentic orchestration", "LLM tools" ],
   "version" : 0,
   "category" : {
     "id" : "connectors",

--- a/connectors/agentic-ai/element-templates/versioned/agenticai-mcp-client-outbound-connector-1.json
+++ b/connectors/agentic-ai/element-templates/versioned/agenticai-mcp-client-outbound-connector-1.json
@@ -3,9 +3,7 @@
   "name" : "MCP Client (early access)",
   "id" : "io.camunda.connectors.agenticai.mcp.client.v0",
   "description" : "MCP (Model Context Protocol) client using MCP connections configured on the connector runtime.",
-  "metadata" : {
-    "keywords" : [ ]
-  },
+  "keywords" : [ "MCP", "Model Context Protocol", "AI tools", "agentic orchestration", "LLM tools" ],
   "version" : 1,
   "category" : {
     "id" : "connectors",

--- a/connectors/agentic-ai/element-templates/versioned/agenticai-mcp-remote-client-outbound-connector-0.json
+++ b/connectors/agentic-ai/element-templates/versioned/agenticai-mcp-remote-client-outbound-connector-0.json
@@ -3,9 +3,7 @@
   "name" : "MCP Remote Client (early access)",
   "id" : "io.camunda.connectors.agenticai.mcp.remoteclient.v0",
   "description" : "MCP (Model Context Protocol) client, operating on temporary remote connections. Only supports tool operations.",
-  "metadata" : {
-    "keywords" : [ ]
-  },
+  "keywords" : [ "MCP", "Model Context Protocol", "AI tools", "agentic orchestration", "remote tools" ],
   "version" : 0,
   "category" : {
     "id" : "connectors",

--- a/connectors/agentic-ai/element-templates/versioned/agenticai-mcp-remote-client-outbound-connector-1.json
+++ b/connectors/agentic-ai/element-templates/versioned/agenticai-mcp-remote-client-outbound-connector-1.json
@@ -3,9 +3,7 @@
   "name" : "MCP Remote Client (early access)",
   "id" : "io.camunda.connectors.agenticai.mcp.remoteclient.v0",
   "description" : "MCP (Model Context Protocol) client, operating on temporary remote connections.",
-  "metadata" : {
-    "keywords" : [ ]
-  },
+  "keywords" : [ "MCP", "Model Context Protocol", "AI tools", "agentic orchestration", "remote tools" ],
   "version" : 1,
   "category" : {
     "id" : "connectors",


### PR DESCRIPTION
Closes #6964

## Summary

- Moves `metadata.keywords` to the top-level `keywords` field in all 35 agentic-ai element templates (main, hybrid, and versioned), matching the behaviour already applied to other connectors in PR #6963
- Enriches previously-empty keyword lists with relevant terms for each connector type (AI Agent, MCP Client, MCP Remote Client, Ad-hoc tools schema, A2A Client variants)

| Template type | Keywords |
|---|---|
| AI Agent Task | AI, AI Agent, agentic orchestration, tool calling, LLM, agent |
| AI Agent Sub-process | AI, AI Agent, agentic orchestration, tool calling, LLM, agent, reasoning loop |
| Ad-hoc tools schema | ad-hoc tools, tool schema, agentic orchestration, AI, agent tools |
| MCP Client | MCP, Model Context Protocol, AI tools, agentic orchestration, LLM tools |
| MCP Remote Client | MCP, Model Context Protocol, AI tools, agentic orchestration, remote tools |
| A2A Client outbound | A2A, agent-to-agent, agentic orchestration, multi-agent |
| A2A Client polling inbound | A2A, agent-to-agent, agentic orchestration, multi-agent, polling |
| A2A Client webhook inbound | A2A, agent-to-agent, agentic orchestration, multi-agent, webhook |

> Auto-implemented by scheduled Claude Code agent. Please review carefully before merging.