### PR TITLE
feat(agentic-ai): use top-level keywords field in element templates

### DIFF
--- a/connectors/agentic-ai/element-templates/agenticai-a2a-client-outbound-connector.json
+++ b/connectors/agentic-ai/element-templates/agenticai-a2a-client-outbound-connector.json
@@ -3,9 +3,7 @@
   "name" : "A2A Client (early access)",
   "id" : "io.camunda.connectors.agenticai.a2a.client.v0",
   "description" : "Agent-to-Agent (A2A) client, enabling discovering remote agents' Agent Cards as well as sending messages to remote agents.",
-  "metadata" : {
-    "keywords" : [ ]
-  },
+  "keywords" : ["A2A", "agent-to-agent", "multi-agent", "remote agent", "agent communication", "AI agent", "agentic"],
   "documentationRef" : "https://docs.camunda.io/docs/8.9/components/early-access/alpha/a2a-client/a2a-client-connector/",
   "version" : 0,
   "category" : {

--- a/connectors/agentic-ai/element-templates/agenticai-a2a-client-polling-inbound-connector-intermediate.json
+++ b/connectors/agentic-ai/element-templates/agenticai-a2a-client-polling-inbound-connector-intermediate.json
@@ -3,9 +3,7 @@
   "name" : "A2A Client Polling Intermediate Catch Event Connector (early access)",
   "id" : "io.camunda.connectors.agenticai.a2a.client.polling.intermediate.v0",
   "description" : "Agent-to-Agent (A2A) polling inbound connector. Supports polling asynchronous tasks, but can also directly correlate messages and synchronously completed tasks.",
-  "metadata" : {
-    "keywords" : [ ]
-  },
+  "keywords" : ["A2A", "agent-to-agent", "polling", "intermediate catch event", "inbound", "asynchronous", "multi-agent", "agentic"],
   "documentationRef" : "https://docs.camunda.io/docs/8.9/components/early-access/alpha/a2a-client/a2a-client-polling-connector/",
   "version" : 0,
   "category" : {

--- a/connectors/agentic-ai/element-templates/agenticai-a2a-client-polling-inbound-connector-receive.json
+++ b/connectors/agentic-ai/element-templates/agenticai-a2a-client-polling-inbound-connector-receive.json
@@ -3,9 +3,7 @@
   "name" : "A2A Client Polling Receive Task Connector (early access)",
   "id" : "io.camunda.connectors.agenticai.a2a.client.polling.receive.v0",
   "description" : "Agent-to-Agent (A2A) polling inbound connector. Supports polling asynchronous tasks, but can also directly correlate messages and synchronously completed tasks.",
-  "metadata" : {
-    "keywords" : [ ]
-  },
+  "keywords" : ["A2A", "agent-to-agent", "polling", "receive task", "inbound", "asynchronous", "multi-agent", "agentic"],
   "documentationRef" : "https://docs.camunda.io/docs/8.9/components/early-access/alpha/a2a-client/a2a-client-polling-connector/",
   "version" : 0,
   "category" : {

--- a/connectors/agentic-ai/element-templates/agenticai-a2a-client-webhook-inbound-connector-intermediate.json
+++ b/connectors/agentic-ai/element-templates/agenticai-a2a-client-webhook-inbound-connector-intermediate.json
@@ -3,9 +3,7 @@
   "name" : "A2A Client Webhook Intermediate Catch Event Connector (early access)",
   "id" : "io.camunda.connectors.agenticai.a2a.client.webhook.intermediate.v0",
   "description" : "Agent-to-Agent (A2A) webhook inbound connector that can be used to receive callbacks from remote A2A servers.",
-  "metadata" : {
-    "keywords" : [ ]
-  },
+  "keywords" : ["A2A", "agent-to-agent", "webhook", "intermediate catch event", "inbound", "callback", "multi-agent", "agentic"],
   "documentationRef" : "https://docs.camunda.io/docs/8.9/components/early-access/alpha/a2a-client/a2a-client-webhook-connector/",
   "version" : 0,
   "category" : {

--- a/connectors/agentic-ai/element-templates/agenticai-a2a-client-webhook-inbound-connector-receive.json
+++ b/connectors/agentic-ai/element-templates/agenticai-a2a-client-webhook-inbound-connector-receive.json
@@ -3,9 +3,7 @@
   "name" : "A2A Client Webhook Receive Task Connector (early access)",
   "id" : "io.camunda.connectors.agenticai.a2a.client.webhook.receive.v0",
   "description" : "Agent-to-Agent (A2A) webhook inbound connector that can be used to receive callbacks from remote A2A servers.",
-  "metadata" : {
-    "keywords" : [ ]
-  },
+  "keywords" : ["A2A", "agent-to-agent", "webhook", "receive task", "inbound", "callback", "multi-agent", "agentic"],
   "documentationRef" : "https://docs.camunda.io/docs/8.9/components/early-access/alpha/a2a-client/a2a-client-webhook-connector/",
   "version" : 0,
   "category" : {

--- a/connectors/agentic-ai/element-templates/agenticai-adhoctoolsschema-outbound-connector.json
+++ b/connectors/agentic-ai/element-templates/agenticai-adhoctoolsschema-outbound-connector.json
@@ -3,9 +3,7 @@
   "name" : "Ad-hoc tools schema",
   "id" : "io.camunda.connectors.agenticai.adhoctoolsschema.v1",
   "description" : "Connector to fetch tools schema information from an ad-hoc sub-process.",
-  "metadata" : {
-    "keywords" : [ ]
-  },
+  "keywords" : ["ad-hoc tools", "tools schema", "ad-hoc sub-process", "tool discovery", "AI agent", "agentic", "BPMN"],
   "documentationRef" : "https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/agentic-ai-ad-hoc-tools-schema-resolver/",
   "version" : 2,
   "category" : {

--- a/connectors/agentic-ai/element-templates/agenticai-aiagent-job-worker.json
+++ b/connectors/agentic-ai/element-templates/agenticai-aiagent-job-worker.json
@@ -3,9 +3,7 @@
   "name" : "AI Agent Sub-process",
   "id" : "io.camunda.connectors.agenticai.aiagent.jobworker.v1",
   "description" : "Run a multi-step AI reasoning loop with dynamic tool selection",
-  "metadata" : {
-    "keywords" : [ "AI", "AI Agent", "agentic orchestration" ]
-  },
+  "keywords" : ["AI", "AI Agent", "agentic orchestration", "LLM", "language model", "reasoning", "multi-step", "agentic", "tool selection"],
   "documentationRef" : "https://docs.camunda.io/docs/8.10/components/connectors/out-of-the-box-connectors/agentic-ai-aiagent-subprocess/",
   "version" : 10,
   "category" : {

--- a/connectors/agentic-ai/element-templates/agenticai-aiagent-outbound-connector.json
+++ b/connectors/agentic-ai/element-templates/agenticai-aiagent-outbound-connector.json
@@ -3,9 +3,7 @@
   "name" : "AI Agent Task",
   "id" : "io.camunda.connectors.agenticai.aiagent.v1",
   "description" : "Execute a single AI-powered action with tool calling capabilities",
-  "metadata" : {
-    "keywords" : [ "AI", "AI Agent", "agentic orchestration" ]
-  },
+  "keywords" : ["AI", "AI Agent", "agentic orchestration", "LLM", "language model", "tool calling", "agentic", "GPT", "Claude", "OpenAI"],
   "documentationRef" : "https://docs.camunda.io/docs/8.10/components/connectors/out-of-the-box-connectors/agentic-ai-aiagent-task/",
   "version" : 10,
   "category" : {

--- a/connectors/agentic-ai/element-templates/agenticai-mcp-client-outbound-connector.json
+++ b/connectors/agentic-ai/element-templates/agenticai-mcp-client-outbound-connector.json
@@ -3,9 +3,7 @@
   "name" : "MCP Client",
   "id" : "io.camunda.connectors.agenticai.mcp.client.v0",
   "description" : "MCP (Model Context Protocol) client using MCP connections configured on the connector runtime.",
-  "metadata" : {
-    "keywords" : [ ]
-  },
+  "keywords" : ["MCP", "Model Context Protocol", "tool server", "AI tools", "AI agent", "agentic"],
   "documentationRef" : "https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/agentic-ai-mcp-client-connector/",
   "version" : 2,
   "category" : {

--- a/connectors/agentic-ai/element-templates/agenticai-mcp-remote-client-outbound-connector.json
+++ b/connectors/agentic-ai/element-templates/agenticai-mcp-remote-client-outbound-connector.json
@@ -3,9 +3,7 @@
   "name" : "MCP Remote Client",
   "id" : "io.camunda.connectors.agenticai.mcp.remoteclient.v0",
   "description" : "MCP (Model Context Protocol) client, operating on temporary remote connections.",
-  "metadata" : {
-    "keywords" : [ ]
-  },
+  "keywords" : ["MCP", "Model Context Protocol", "remote tool server", "AI tools", "AI agent", "SSE", "streamable HTTP", "agentic"],
   "documentationRef" : "https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/agentic-ai-mcp-remote-client-connector/",
   "version" : 2,
   "category" : {

--- a/connectors/agentic-ai/element-templates/hybrid/agenticai-a2a-client-outbound-connector-hybrid.json
+++ b/connectors/agentic-ai/element-templates/hybrid/agenticai-a2a-client-outbound-connector-hybrid.json
@@ -3,9 +3,7 @@
   "name" : "Hybrid A2A Client (early access)",
   "id" : "io.camunda.connectors.agenticai.a2a.client.v0-hybrid",
   "description" : "Agent-to-Agent (A2A) client, enabling discovering remote agents' Agent Cards as well as sending messages to remote agents.",
-  "metadata" : {
-    "keywords" : [ ]
-  },
+  "keywords" : ["A2A", "agent-to-agent", "multi-agent", "remote agent", "agent communication", "AI agent", "agentic"],
   "documentationRef" : "https://docs.camunda.io/docs/8.9/components/early-access/alpha/a2a-client/a2a-client-connector/",
   "version" : 0,
   "category" : {

--- a/connectors/agentic-ai/element-templates/hybrid/agenticai-adhoctoolsschema-outbound-connector-hybrid.json
+++ b/connectors/agentic-ai/element-templates/hybrid/agenticai-adhoctoolsschema-outbound-connector-hybrid.json
@@ -3,9 +3,7 @@
   "name" : "Hybrid Ad-hoc tools schema",
   "id" : "io.camunda.connectors.agenticai.adhoctoolsschema.v1-hybrid",
   "description" : "Connector to fetch tools schema information from an ad-hoc sub-process.",
-  "metadata" : {
-    "keywords" : [ ]
-  },
+  "keywords" : ["ad-hoc tools", "tools schema", "ad-hoc sub-process", "tool discovery", "AI agent", "agentic", "BPMN"],
   "documentationRef" : "https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/agentic-ai-ad-hoc-tools-schema-resolver/",
   "version" : 2,
   "category" : {

--- a/connectors/agentic-ai/element-templates/hybrid/agenticai-aiagent-job-worker-hybrid.json
+++ b/connectors/agentic-ai/element-templates/hybrid/agenticai-aiagent-job-worker-hybrid.json
@@ -3,9 +3,7 @@
   "name" : "Hybrid AI Agent Sub-process",
   "id" : "io.camunda.connectors.agenticai.aiagent.jobworker.v1-hybrid",
   "description" : "Run a multi-step AI reasoning loop with dynamic tool selection",
-  "metadata" : {
-    "keywords" : [ "AI", "AI Agent", "agentic orchestration" ]
-  },
+  "keywords" : ["AI", "AI Agent", "agentic orchestration", "LLM", "language model", "reasoning", "multi-step", "agentic", "tool selection"],
   "documentationRef" : "https://docs.camunda.io/docs/8.10/components/connectors/out-of-the-box-connectors/agentic-ai-aiagent-subprocess/",
   "version" : 10,
   "category" : {

--- a/connectors/agentic-ai/element-templates/hybrid/agenticai-aiagent-outbound-connector-hybrid.json
+++ b/connectors/agentic-ai/element-templates/hybrid/agenticai-aiagent-outbound-connector-hybrid.json
@@ -3,9 +3,7 @@
   "name" : "Hybrid AI Agent Task",
   "id" : "io.camunda.connectors.agenticai.aiagent.v1-hybrid",
   "description" : "Execute a single AI-powered action with tool calling capabilities",
-  "metadata" : {
-    "keywords" : [ "AI", "AI Agent", "agentic orchestration" ]
-  },
+  "keywords" : ["AI", "AI Agent", "agentic orchestration", "LLM", "language model", "tool calling", "agentic", "GPT", "Claude", "OpenAI"],
   "documentationRef" : "https://docs.camunda.io/docs/8.10/components/connectors/out-of-the-box-connectors/agentic-ai-aiagent-task/",
   "version" : 10,
   "category" : {

--- a/connectors/agentic-ai/element-templates/hybrid/agenticai-mcp-client-outbound-connector-hybrid.json
+++ b/connectors/agentic-ai/element-templates/hybrid/agenticai-mcp-client-outbound-connector-hybrid.json
@@ -3,9 +3,7 @@
   "name" : "Hybrid MCP Client",
   "id" : "io.camunda.connectors.agenticai.mcp.client.v0-hybrid",
   "description" : "MCP (Model Context Protocol) client using MCP connections configured on the connector runtime.",
-  "metadata" : {
-    "keywords" : [ ]
-  },
+  "keywords" : ["MCP", "Model Context Protocol", "tool server", "AI tools", "AI agent", "agentic"],
   "documentationRef" : "https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/agentic-ai-mcp-client-connector/",
   "version" : 2,
   "category" : {

--- a/connectors/agentic-ai/element-templates/hybrid/agenticai-mcp-remote-client-outbound-connector-hybrid.json
+++ b/connectors/agentic-ai/element-templates/hybrid/agenticai-mcp-remote-client-outbound-connector-hybrid.json
@@ -3,9 +3,7 @@
   "name" : "Hybrid MCP Remote Client",
   "id" : "io.camunda.connectors.agenticai.mcp.remoteclient.v0-hybrid",
   "description" : "MCP (Model Context Protocol) client, operating on temporary remote connections.",
-  "metadata" : {
-    "keywords" : [ ]
-  },
+  "keywords" : ["MCP", "Model Context Protocol", "remote tool server", "AI tools", "AI agent", "SSE", "streamable HTTP", "agentic"],
   "documentationRef" : "https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/agentic-ai-mcp-remote-client-connector/",
   "version" : 2,
   "category" : {


### PR DESCRIPTION
Closes #6964

## Summary

- Moves `metadata.keywords` to the top-level `keywords` field in all 10 agentic-ai element templates (plus their 6 hybrid variants)
- Expands keyword lists for AI Agent Task, AI Agent Sub-process, MCP Client, MCP Remote Client, A2A Client, Ad-hoc tools schema, and all A2A inbound connector templates to improve discoverability in Camunda Modeler search
- Follows the same pattern established in #6963 for the other connector team-owned templates

> Auto-implemented by scheduled Claude Code agent. Please review carefully before merging."