### PR TITLE
fix(test): remove @Test annotation as @Disabled was not enough in CI,…

### DIFF
--- a/connectors/email/src/test/java/io/camunda/connector/email/integration/InboundRecoveringTest.java
+++ b/connectors/email/src/test/java/io/camunda/connector/email/integration/InboundRecoveringTest.java
@@ -98,7 +98,7 @@ public class InboundRecoveringTest extends BaseEmailTest {
       intermittently captures and reports them as test failures.
       Tracked in: https://github.com/camunda/connectors/issues/6819
       """)
-  @Test
+  // @Test
   public void pollingManagerBreaksAndRecoverAfterServerNotResponding() throws Exception {
     JakartaEmailListener jakartaEmailListener = new JakartaEmailListener();
     try (ImapServerProxy proxyImap =


### PR DESCRIPTION
This pull request makes a small change to the email connector integration tests by disabling a flaky test that intermittently fails due to issues with the GreenMail IMAP handler.

* Disabled the `pollingManagerBreaksAndRecoverAfterServerNotResponding` test in `InboundRecoveringTest.java` by commenting out the `@Test` annotation, as it intermittently fails and is tracked in issue #6819.