### PR TITLE
feat: add /outbound endpoint to get information about our outbound connectors

### DIFF
--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/ConnectorFactory.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/ConnectorFactory.java
@@ -16,6 +16,7 @@
  */
 package io.camunda.connector.runtime.core;
 
+import io.camunda.connector.runtime.core.common.AbstractConnectorFactory;
 import io.camunda.connector.runtime.core.config.ConnectorConfiguration;
 import java.util.Collection;
 
@@ -28,11 +29,24 @@ import java.util.Collection;
 public interface ConnectorFactory<T, C extends ConnectorConfiguration> {
 
   /**
-   * List all available configurations loaded by the runtime
+   * List all active connector configurations loaded by the runtime. A configuration is considered
+   * active when it has not been disabled via the {@code CONNECTOR_<NAME>_DISABLED} environment
+   * variable.
    *
-   * @return List of available configurations
+   * @return list of active {@link ConnectorConfiguration} entries; never {@code null}
+   * @see #getRuntimeConfigurations()
    */
-  Collection<C> getConfigurations();
+  Collection<C> getActiveConfigurations();
+
+  /**
+   * List all connector configurations loaded by the runtime, including those that have been
+   * disabled via the {@code CONNECTOR_<NAME>_DISABLED} environment variable.
+   *
+   * @return list of all {@link
+   *     io.camunda.connector.runtime.core.common.AbstractConnectorFactory.ConnectorRuntimeConfiguration}
+   *     entries; never {@code null}
+   */
+  Collection<AbstractConnectorFactory.ConnectorRuntimeConfiguration<C>> getRuntimeConfigurations();
 
   /**
    * Create a Connector instance by type

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/common/AbstractConnectorFactory.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/common/AbstractConnectorFactory.java
@@ -20,7 +20,11 @@ import io.camunda.connector.runtime.core.ConnectorFactory;
 import io.camunda.connector.runtime.core.config.ConnectorConfiguration;
 import io.camunda.connector.runtime.core.discovery.DisabledConnectorEnvVarsConfig;
 import java.text.MessageFormat;
-import java.util.*;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 /**

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/common/AbstractConnectorFactory.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/common/AbstractConnectorFactory.java
@@ -37,7 +37,11 @@ public abstract class AbstractConnectorFactory<T, C extends ConnectorConfigurati
       new DisabledConnectorEnvVarsConfig();
 
   public record ConnectorRuntimeConfiguration<T extends ConnectorConfiguration>(
-      T config, boolean isActive) {}
+      T config, boolean isActive) {
+    public Optional<T> getActiveConfig() {
+      return isActive ? Optional.of(config) : Optional.empty();
+    }
+  }
 
   private Map<String, ConnectorRuntimeConfiguration<C>> configurations = new HashMap<>();
 
@@ -49,15 +53,13 @@ public abstract class AbstractConnectorFactory<T, C extends ConnectorConfigurati
   @Override
   public List<C> getActiveConfigurations() {
     return configurations.values().stream()
-        .filter(ConnectorRuntimeConfiguration::isActive)
-        .map(ConnectorRuntimeConfiguration::config)
+        .flatMap(configuration -> configuration.getActiveConfig().stream())
         .collect(Collectors.toList());
   }
 
   protected Optional<C> getActiveConfiguration(String type) {
     return Optional.ofNullable(configurations.get(type))
-        .filter(ConnectorRuntimeConfiguration::isActive)
-        .map(ConnectorRuntimeConfiguration::config);
+        .flatMap(ConnectorRuntimeConfiguration::getActiveConfig);
   }
 
   /**

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/common/AbstractConnectorFactory.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/common/AbstractConnectorFactory.java
@@ -20,11 +20,7 @@ import io.camunda.connector.runtime.core.ConnectorFactory;
 import io.camunda.connector.runtime.core.config.ConnectorConfiguration;
 import io.camunda.connector.runtime.core.discovery.DisabledConnectorEnvVarsConfig;
 import java.text.MessageFormat;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
 import java.util.stream.Collectors;
 
 /**
@@ -41,24 +37,27 @@ public abstract class AbstractConnectorFactory<T, C extends ConnectorConfigurati
       new DisabledConnectorEnvVarsConfig();
 
   public record ConnectorRuntimeConfiguration<T extends ConnectorConfiguration>(
-      T config, boolean isActive) {
-    public Optional<T> getActiveConfig() {
-      return isActive ? Optional.of(config) : Optional.empty();
-    }
-  }
+      T config, boolean isActive) {}
 
   private Map<String, ConnectorRuntimeConfiguration<C>> configurations = new HashMap<>();
 
   @Override
-  public Collection<C> getConfigurations() {
+  public Collection<ConnectorRuntimeConfiguration<C>> getRuntimeConfigurations() {
+    return List.copyOf(configurations.values());
+  }
+
+  @Override
+  public List<C> getActiveConfigurations() {
     return configurations.values().stream()
-        .flatMap(e -> e.getActiveConfig().stream())
+        .filter(ConnectorRuntimeConfiguration::isActive)
+        .map(ConnectorRuntimeConfiguration::config)
         .collect(Collectors.toList());
   }
 
   protected Optional<C> getActiveConfiguration(String type) {
     return Optional.ofNullable(configurations.get(type))
-        .flatMap(ConnectorRuntimeConfiguration::getActiveConfig);
+        .filter(ConnectorRuntimeConfiguration::isActive)
+        .map(ConnectorRuntimeConfiguration::config);
   }
 
   /**

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/common/AbstractConnectorFactory.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/common/AbstractConnectorFactory.java
@@ -37,11 +37,7 @@ public abstract class AbstractConnectorFactory<T, C extends ConnectorConfigurati
       new DisabledConnectorEnvVarsConfig();
 
   public record ConnectorRuntimeConfiguration<T extends ConnectorConfiguration>(
-      T config, boolean isActive) {
-    public Optional<T> getActiveConfig() {
-      return isActive ? Optional.of(config) : Optional.empty();
-    }
-  }
+      T config, boolean isActive) {}
 
   private Map<String, ConnectorRuntimeConfiguration<C>> configurations = new HashMap<>();
 
@@ -53,13 +49,15 @@ public abstract class AbstractConnectorFactory<T, C extends ConnectorConfigurati
   @Override
   public List<C> getActiveConfigurations() {
     return configurations.values().stream()
-        .flatMap(configuration -> configuration.getActiveConfig().stream())
+        .filter(ConnectorRuntimeConfiguration::isActive)
+        .map(ConnectorRuntimeConfiguration::config)
         .collect(Collectors.toList());
   }
 
   protected Optional<C> getActiveConfiguration(String type) {
     return Optional.ofNullable(configurations.get(type))
-        .flatMap(ConnectorRuntimeConfiguration::getActiveConfig);
+        .filter(ConnectorRuntimeConfiguration::isActive)
+        .map(ConnectorRuntimeConfiguration::config);
   }
 
   /**

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/DefaultInboundConnectorFactory.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/DefaultInboundConnectorFactory.java
@@ -55,7 +55,7 @@ public class DefaultInboundConnectorFactory
       input = SPIConnectorDiscovery.discoverInbound();
     }
     initializeConfigurations(input);
-    var config = getConfigurations();
+    var config = getActiveConfigurations();
     if (!config.isEmpty()) {
       LOG.debug("Registered inbound connectors: {}", config);
     } else {

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/outbound/DefaultOutboundConnectorFactory.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/outbound/DefaultOutboundConnectorFactory.java
@@ -137,7 +137,6 @@ public class DefaultOutboundConnectorFactory
 
   @Override
   public OutboundConnectorFunction getInstance(String type) {
-
     return this.getActiveConfiguration(type)
         .map(this::getCachedInstance)
         .orElseThrow(

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/inbound/InboundConnectorDiscoveryTest.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/inbound/InboundConnectorDiscoveryTest.java
@@ -59,7 +59,7 @@ public class InboundConnectorDiscoveryTest {
 
     // when
     Collection<InboundConnectorConfiguration> registrations =
-        withEnvVars(env, () -> getFactory().getConfigurations());
+        withEnvVars(env, () -> getFactory().getActiveConfigurations());
 
     // then
     Assertions.assertThat(registrations).hasSize(3);
@@ -97,7 +97,8 @@ public class InboundConnectorDiscoveryTest {
         };
 
     // then
-    Assertions.assertThatThrownBy(() -> withEnvVars(env, () -> getFactory().getConfigurations()))
+    Assertions.assertThatThrownBy(
+            () -> withEnvVars(env, () -> getFactory().getActiveConfigurations()))
         .hasMessage(
             "Type not specified: Please configure it via CONNECTOR_NOT_ANNOTATED_TYPE environment variable");
   }
@@ -113,7 +114,8 @@ public class InboundConnectorDiscoveryTest {
         };
 
     // then
-    Assertions.assertThatThrownBy(() -> withEnvVars(env, () -> getFactory().getConfigurations()))
+    Assertions.assertThatThrownBy(
+            () -> withEnvVars(env, () -> getFactory().getActiveConfigurations()))
         .hasMessage("Failed to load io.camunda.connector.runtime.jobworker.impl.outbound.NotFound");
   }
 
@@ -121,7 +123,8 @@ public class InboundConnectorDiscoveryTest {
   public void shouldConfigureViaSPI() {
 
     // when
-    Collection<InboundConnectorConfiguration> registrations = getFactory().getConfigurations();
+    Collection<InboundConnectorConfiguration> registrations =
+        getFactory().getActiveConfigurations();
 
     // then
     Assertions.assertThat(registrations).hasSize(1);
@@ -157,7 +160,7 @@ public class InboundConnectorDiscoveryTest {
 
     // when
     Collection<InboundConnectorConfiguration> registrations =
-        withEnvVars(env, () -> getFactory().getConfigurations());
+        withEnvVars(env, () -> getFactory().getActiveConfigurations());
 
     // then
     Assertions.assertThat(registrations).isEmpty();

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/outbound/OutboundConnectorDiscoveryTest.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/outbound/OutboundConnectorDiscoveryTest.java
@@ -54,7 +54,7 @@ public class OutboundConnectorDiscoveryTest {
 
     // when
     Collection<OutboundConnectorConfiguration> registrations =
-        withEnvVars(env, () -> DiscoveryUtils.getFactory().getConfigurations());
+        withEnvVars(env, () -> DiscoveryUtils.getFactory().getActiveConfigurations());
 
     // then
     Assertions.assertThat(registrations).hasSize(3);
@@ -100,7 +100,7 @@ public class OutboundConnectorDiscoveryTest {
 
     // then
     Assertions.assertThatThrownBy(
-            () -> withEnvVars(env, () -> DiscoveryUtils.getFactory().getConfigurations()))
+            () -> withEnvVars(env, () -> DiscoveryUtils.getFactory().getActiveConfigurations()))
         .hasMessage(
             "Type not specified: Please configure it via CONNECTOR_NOT_ANNOTATED_TYPE environment variable");
   }
@@ -117,7 +117,7 @@ public class OutboundConnectorDiscoveryTest {
 
     // then
     Assertions.assertThatThrownBy(
-            () -> withEnvVars(env, () -> DiscoveryUtils.getFactory().getConfigurations()))
+            () -> withEnvVars(env, () -> DiscoveryUtils.getFactory().getActiveConfigurations()))
         .hasMessage("Failed to load io.camunda.connector.runtime.jobworker.impl.outbound.NotFound");
   }
 
@@ -125,7 +125,7 @@ public class OutboundConnectorDiscoveryTest {
   public void shouldConfigureViaSPI() {
 
     // when
-    var registrations = DiscoveryUtils.getFactory().getConfigurations();
+    var registrations = DiscoveryUtils.getFactory().getActiveConfigurations();
 
     // then
     Assertions.assertThat(registrations).hasSize(1);
@@ -155,7 +155,7 @@ public class OutboundConnectorDiscoveryTest {
 
     // when
     Collection<OutboundConnectorConfiguration> registrations =
-        withEnvVars(env, () -> DiscoveryUtils.getFactory().getConfigurations());
+        withEnvVars(env, () -> DiscoveryUtils.getFactory().getActiveConfigurations());
 
     // then
     Assertions.assertThat(registrations).isEmpty();

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/InboundConnectorRuntimeConfiguration.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/InboundConnectorRuntimeConfiguration.java
@@ -46,6 +46,7 @@ import io.camunda.connector.runtime.inbound.state.ProcessStateContainerImpl;
 import io.camunda.connector.runtime.inbound.state.ProcessStateManager;
 import io.camunda.connector.runtime.inbound.state.ProcessStateManagerImpl;
 import io.camunda.connector.runtime.inbound.webhook.WebhookConnectorRegistry;
+import io.camunda.connector.runtime.instances.service.InboundInstancesService;
 import io.camunda.connector.runtime.metrics.ConnectorsInboundMetrics;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.time.Duration;
@@ -146,6 +147,13 @@ public class InboundConnectorRuntimeConfiguration {
       ActivityLogRegistry activityLogRegistry) {
     return new InboundExecutableRegistryImpl(
         inboundConnectorFactory, batchExecutableProcessor, activityLogRegistry);
+  }
+
+  @Bean
+  @ConditionalOnMissingBean
+  public InboundInstancesService inboundInstancesService(
+      InboundExecutableRegistry inboundExecutableRegistry) {
+    return new InboundInstancesService(inboundExecutableRegistry);
   }
 
   @Bean

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/controller/InboundConnectorRestController.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/controller/InboundConnectorRestController.java
@@ -27,7 +27,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.web.bind.annotation.*;
 
@@ -43,7 +42,7 @@ public class InboundConnectorRestController {
 
   public InboundConnectorRestController(
       InboundExecutableRegistry executableRegistry,
-      @Autowired(required = false) InstanceForwardingRouter instanceForwardingRouter) {
+      InstanceForwardingRouter instanceForwardingRouter) {
     this.executableRegistry = executableRegistry;
     this.instanceForwardingRouter = instanceForwardingRouter;
   }

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/controller/InboundInstancesRestController.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/controller/InboundInstancesRestController.java
@@ -27,6 +27,7 @@ import io.camunda.connector.runtime.instances.service.InstanceForwardingRouter;
 import jakarta.servlet.http.HttpServletRequest;
 import java.util.List;
 import java.util.Optional;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.web.bind.annotation.*;
 
@@ -48,7 +49,7 @@ public class InboundInstancesRestController {
   private String hostname;
 
   public InboundInstancesRestController(
-      InstanceForwardingRouter instanceForwardingRouter,
+      @Autowired(required = false) InstanceForwardingRouter instanceForwardingRouter,
       InboundInstancesService inboundInstancesService) {
     this.instanceForwardingRouter = instanceForwardingRouter;
     this.inboundInstancesService = inboundInstancesService;

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/controller/InboundInstancesRestController.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/controller/InboundInstancesRestController.java
@@ -27,7 +27,6 @@ import io.camunda.connector.runtime.instances.service.InstanceForwardingRouter;
 import jakarta.servlet.http.HttpServletRequest;
 import java.util.List;
 import java.util.Optional;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.web.bind.annotation.*;
 
@@ -49,7 +48,7 @@ public class InboundInstancesRestController {
   private String hostname;
 
   public InboundInstancesRestController(
-      @Autowired(required = false) InstanceForwardingRouter instanceForwardingRouter,
+      InstanceForwardingRouter instanceForwardingRouter,
       InboundInstancesService inboundInstancesService) {
     this.instanceForwardingRouter = instanceForwardingRouter;
     this.inboundInstancesService = inboundInstancesService;

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/executable/InboundExecutableQueryService.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/executable/InboundExecutableQueryService.java
@@ -66,7 +66,7 @@ public class InboundExecutableQueryService {
    */
   public String getConnectorName(String type) {
     try {
-      return connectorFactory.getConfigurations().stream()
+      return connectorFactory.getActiveConfigurations().stream()
           .filter(configuration -> configuration.type().equals(type))
           .findFirst()
           .map(configuration -> configuration.name())

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/executable/InboundExecutableRegistryImpl.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/executable/InboundExecutableRegistryImpl.java
@@ -59,7 +59,7 @@ public class InboundExecutableRegistryImpl implements InboundExecutableRegistry 
 
     this.stateStore = new InMemoryInboundExecutableStateStore();
     var deduplicationScopesByType =
-        connectorFactory.getConfigurations().stream()
+        connectorFactory.getActiveConfigurations().stream()
             .collect(
                 java.util.stream.Collectors.toMap(
                     config -> config.type(),

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/instances/InstanceForwardingConfiguration.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/instances/InstanceForwardingConfiguration.java
@@ -17,13 +17,13 @@
 package io.camunda.connector.runtime.instances;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.camunda.connector.runtime.inbound.executable.InboundExecutableRegistry;
 import io.camunda.connector.runtime.instances.service.DefaultInstanceForwardingService;
-import io.camunda.connector.runtime.instances.service.InboundInstancesService;
+import io.camunda.connector.runtime.instances.service.ForwardingInstanceForwardingRouter;
 import io.camunda.connector.runtime.instances.service.InstanceForwardingRouter;
 import io.camunda.connector.runtime.instances.service.InstanceForwardingService;
-import org.springframework.beans.factory.annotation.Autowired;
+import io.camunda.connector.runtime.instances.service.LocalInstanceForwardingRouter;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
@@ -50,16 +50,16 @@ public class InstanceForwardingConfiguration {
   }
 
   @Bean
-  @ConditionalOnMissingBean
-  public InstanceForwardingRouter instanceForwardingRouter(
-      @Autowired(required = false) InstanceForwardingService instanceForwardingService) {
-    return new InstanceForwardingRouter(instanceForwardingService);
+  @ConditionalOnBean(InstanceForwardingService.class)
+  @ConditionalOnMissingBean(InstanceForwardingRouter.class)
+  public InstanceForwardingRouter forwardingInstanceForwardingRouter(
+      InstanceForwardingService instanceForwardingService) {
+    return new ForwardingInstanceForwardingRouter(instanceForwardingService);
   }
 
   @Bean
-  @ConditionalOnMissingBean
-  public InboundInstancesService inboundInstancesService(
-      InboundExecutableRegistry inboundExecutableRegistry) {
-    return new InboundInstancesService(inboundExecutableRegistry);
+  @ConditionalOnMissingBean(InstanceForwardingRouter.class)
+  public InstanceForwardingRouter localInstanceForwardingRouter() {
+    return new LocalInstanceForwardingRouter();
   }
 }

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/instances/reducer/ReducerRegistry.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/instances/reducer/ReducerRegistry.java
@@ -20,27 +20,40 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import io.camunda.connector.runtime.inbound.controller.ActiveInboundConnectorResponse;
 import io.camunda.connector.runtime.inbound.executable.ConnectorInstances;
 import io.camunda.connector.runtime.instances.InstanceAwareModel;
+import io.camunda.connector.runtime.outbound.controller.OutboundConnectorResponse;
 import java.lang.reflect.Type;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 public class ReducerRegistry {
-  private final Map<Type, Reducer<?>> reducers =
-      Map.of(
-          new TypeReference<ConnectorInstances>() {}.getType(),
-          new ConnectorInstancesReducer(),
-          new TypeReference<List<ConnectorInstances>>() {}.getType(),
-          new ConnectorInstancesListReducer(),
-          new TypeReference<ActiveInboundConnectorResponse>() {}.getType(),
-          new ActiveInboundConnectorResponseReducer(),
-          new TypeReference<List<InstanceAwareModel.InstanceAwareActivity>>() {}.getType(),
-          Reducers.mergeListsReducer(),
-          new TypeReference<
-              List<Collection<InstanceAwareModel.InstanceAwareActivity>>>() {}.getType(),
-          Reducers.mergeListsReducer(),
-          new TypeReference<List<InstanceAwareModel.InstanceAwareHealth>>() {}.getType(),
-          Reducers.mergeListsReducer());
+  private final Map<Type, Reducer<?>> reducers;
+
+  public ReducerRegistry() {
+    reducers = new HashMap<>();
+    reducers.put(
+        new TypeReference<ConnectorInstances>() {}.getType(), new ConnectorInstancesReducer());
+    reducers.put(
+        new TypeReference<List<ConnectorInstances>>() {}.getType(),
+        new ConnectorInstancesListReducer());
+    reducers.put(
+        new TypeReference<ActiveInboundConnectorResponse>() {}.getType(),
+        new ActiveInboundConnectorResponseReducer());
+    reducers.put(
+        new TypeReference<List<InstanceAwareModel.InstanceAwareActivity>>() {}.getType(),
+        Reducers.mergeListsReducer());
+    reducers.put(
+        new TypeReference<
+            List<Collection<InstanceAwareModel.InstanceAwareActivity>>>() {}.getType(),
+        Reducers.mergeListsReducer());
+    reducers.put(
+        new TypeReference<List<InstanceAwareModel.InstanceAwareHealth>>() {}.getType(),
+        Reducers.mergeListsReducer());
+    reducers.put(
+        new TypeReference<List<OutboundConnectorResponse>>() {}.getType(),
+        Reducers.mergeListsReducer());
+  }
 
   @SuppressWarnings("unchecked")
   public <T> Reducer<T> getReducer(TypeReference<T> typeRef) {

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/instances/service/ForwardingInstanceForwardingRouter.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/instances/service/ForwardingInstanceForwardingRouter.java
@@ -42,12 +42,20 @@ public class ForwardingInstanceForwardingRouter implements InstanceForwardingRou
       Supplier<T> localImplementation,
       TypeReference<T> typeReference) {
     if (StringUtils.isBlank(forwardedFor)) {
-      LOGGER.debug(
-          "Forwarding request to instances: {}",
-          request.getRequestURL().toString() + "?" + request.getQueryString());
+      final String sanitizedQuery = sanitizeForLog(request.getQueryString());
+      final String requestUri =
+          request.getRequestURL().toString() + (sanitizedQuery.isEmpty() ? "" : "?" + sanitizedQuery);
+      LOGGER.debug("Forwarding request to instances: {}", requestUri);
       return instanceForwardingService.forwardAndReduce(request, typeReference);
     }
     LOGGER.debug("Request was already forwarded, performing local call for request: {}", request);
     return localImplementation.get();
+  }
+
+  private static String sanitizeForLog(String value) {
+    if (value == null) {
+      return "";
+    }
+    return value.replace('\r', '_').replace('\n', '_');
   }
 }

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/instances/service/ForwardingInstanceForwardingRouter.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/instances/service/ForwardingInstanceForwardingRouter.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.runtime.instances.service;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.function.Supplier;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** Router used when instance forwarding is configured. */
+public class ForwardingInstanceForwardingRouter implements InstanceForwardingRouter {
+
+  private static final Logger LOGGER =
+      LoggerFactory.getLogger(ForwardingInstanceForwardingRouter.class);
+
+  private final InstanceForwardingService instanceForwardingService;
+
+  public ForwardingInstanceForwardingRouter(InstanceForwardingService instanceForwardingService) {
+    this.instanceForwardingService = instanceForwardingService;
+  }
+
+  @Override
+  public <T> T forwardToInstancesAndReduceOrLocal(
+      HttpServletRequest request,
+      String forwardedFor,
+      Supplier<T> localImplementation,
+      TypeReference<T> typeReference) {
+    if (StringUtils.isBlank(forwardedFor)) {
+      LOGGER.debug(
+          "Forwarding request to instances: {}",
+          request.getRequestURL().toString() + "?" + request.getQueryString());
+      return instanceForwardingService.forwardAndReduce(request, typeReference);
+    }
+    LOGGER.debug("Request was already forwarded, performing local call for request: {}", request);
+    return localImplementation.get();
+  }
+}

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/instances/service/ForwardingInstanceForwardingRouter.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/instances/service/ForwardingInstanceForwardingRouter.java
@@ -44,7 +44,8 @@ public class ForwardingInstanceForwardingRouter implements InstanceForwardingRou
     if (StringUtils.isBlank(forwardedFor)) {
       final String sanitizedQuery = sanitizeForLog(request.getQueryString());
       final String requestUri =
-          request.getRequestURL().toString() + (sanitizedQuery.isEmpty() ? "" : "?" + sanitizedQuery);
+          request.getRequestURL().toString()
+              + (sanitizedQuery.isEmpty() ? "" : "?" + sanitizedQuery);
       LOGGER.debug("Forwarding request to instances: {}", requestUri);
       return instanceForwardingService.forwardAndReduce(request, typeReference);
     }

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/instances/service/LocalInstanceForwardingRouter.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/instances/service/LocalInstanceForwardingRouter.java
@@ -19,17 +19,22 @@ package io.camunda.connector.runtime.instances.service;
 import com.fasterxml.jackson.core.type.TypeReference;
 import jakarta.servlet.http.HttpServletRequest;
 import java.util.function.Supplier;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-public interface InstanceForwardingRouter {
-  /**
-   * This method is used to forward the request to the instances or local service depending on the
-   * configuration.
-   *
-   * @see io.camunda.connector.runtime.instances.InstanceForwardingConfiguration
-   */
-  <T> T forwardToInstancesAndReduceOrLocal(
+/** Router used when instance forwarding is not configured. */
+public class LocalInstanceForwardingRouter implements InstanceForwardingRouter {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(LocalInstanceForwardingRouter.class);
+
+  @Override
+  public <T> T forwardToInstancesAndReduceOrLocal(
       HttpServletRequest request,
       String forwardedFor,
       Supplier<T> localImplementation,
-      TypeReference<T> typeReference);
+      TypeReference<T> typeReference) {
+    LOGGER.debug(
+        "Instance forwarding is not configured, performing local call for request: {}", request);
+    return localImplementation.get();
+  }
 }

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/instances/service/OutboundConnectorsService.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/instances/service/OutboundConnectorsService.java
@@ -21,28 +21,46 @@ import io.camunda.connector.runtime.core.config.OutboundConnectorConfiguration;
 import io.camunda.connector.runtime.core.outbound.OutboundConnectorFactory;
 import io.camunda.connector.runtime.inbound.controller.exception.DataNotFoundException;
 import io.camunda.connector.runtime.outbound.controller.OutboundConnectorResponse;
+import io.camunda.connector.runtime.outbound.jobstream.GatewayJobStreamClient;
+import io.camunda.connector.runtime.outbound.jobstream.GatewayResult;
+import io.camunda.connector.runtime.outbound.jobstream.StreamConnectivity;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class OutboundConnectorsService {
 
+  private static final Logger LOG = LoggerFactory.getLogger(OutboundConnectorsService.class);
+
   private final OutboundConnectorFactory connectorFactory;
+  private final Optional<GatewayJobStreamClient> gatewayJobStreamClient;
 
   public OutboundConnectorsService(OutboundConnectorFactory connectorFactory) {
+    this(connectorFactory, Optional.empty());
+  }
+
+  public OutboundConnectorsService(
+      OutboundConnectorFactory connectorFactory,
+      Optional<GatewayJobStreamClient> gatewayJobStreamClient) {
     this.connectorFactory = connectorFactory;
+    this.gatewayJobStreamClient = gatewayJobStreamClient;
   }
 
   public List<OutboundConnectorResponse> findAll(String runtimeId) {
+    GatewayResult gateway = queryGateway();
     return connectorFactory.getRuntimeConfigurations().stream()
-        .map(config -> toResponse(config, runtimeId))
+        .map(config -> toResponse(config, runtimeId, gateway))
         .toList();
   }
 
   public List<OutboundConnectorResponse> findByType(String type, String runtimeId) {
+    GatewayResult gateway = queryGateway();
     var results =
         connectorFactory.getRuntimeConfigurations().stream()
             .filter(config -> config.config().type().equals(type))
-            .map(config -> toResponse(config, runtimeId))
+            .map(config -> toResponse(config, runtimeId, gateway))
             .toList();
     if (results.isEmpty()) {
       throw new DataNotFoundException(OutboundConnectorResponse.class, type);
@@ -50,9 +68,35 @@ public class OutboundConnectorsService {
     return results;
   }
 
+  private GatewayResult queryGateway() {
+    if (gatewayJobStreamClient.isEmpty()) {
+      return new GatewayResult.Failure.Unknown();
+    }
+    try {
+      return new GatewayResult.Success(gatewayJobStreamClient.get().fetchJobStreams());
+    } catch (Exception e) {
+      LOG.warn("Failed to fetch job streams from gateway: {}", e.getMessage());
+      return new GatewayResult.Failure.Unreachable();
+    }
+  }
+
   private OutboundConnectorResponse toResponse(
       AbstractConnectorFactory.ConnectorRuntimeConfiguration<OutboundConnectorConfiguration> config,
-      String runtimeId) {
+      String runtimeId,
+      GatewayResult gateway) {
+    String jobType = config.config().type();
+    StreamConnectivity connectivity =
+        switch (gateway) {
+          case GatewayResult.Failure f -> StreamConnectivity.unavailable(f.gatewayState());
+          case GatewayResult.Success s -> StreamConnectivity.compute(jobType, s.streams());
+        };
+    return buildResponse(config, runtimeId, connectivity);
+  }
+
+  private OutboundConnectorResponse buildResponse(
+      AbstractConnectorFactory.ConnectorRuntimeConfiguration<OutboundConnectorConfiguration> config,
+      String runtimeId,
+      StreamConnectivity connectivity) {
     var connectorConfig = config.config();
     return new OutboundConnectorResponse(
         connectorConfig.name(),
@@ -60,6 +104,9 @@ public class OutboundConnectorsService {
         Arrays.asList(connectorConfig.inputVariables()),
         connectorConfig.timeout(),
         config.isActive(),
-        runtimeId);
+        runtimeId,
+        connectivity.gatewayState(),
+        connectivity.brokerState(),
+        connectivity.streamIds());
   }
 }

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/instances/service/OutboundConnectorsService.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/instances/service/OutboundConnectorsService.java
@@ -24,7 +24,6 @@ import io.camunda.connector.runtime.outbound.controller.OutboundConnectorRespons
 import io.camunda.connector.runtime.outbound.jobstream.GatewayJobStreamClient;
 import io.camunda.connector.runtime.outbound.jobstream.GatewayResult;
 import io.camunda.connector.runtime.outbound.jobstream.StreamConnectivity;
-import java.util.Arrays;
 import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -99,7 +98,9 @@ public class OutboundConnectorsService {
     return new OutboundConnectorResponse(
         connectorConfig.name(),
         connectorConfig.type(),
-        Arrays.asList(connectorConfig.inputVariables()),
+        connectorConfig.inputVariables() == null
+            ? List.of()
+            : List.of(connectorConfig.inputVariables()),
         connectorConfig.timeout(),
         config.isActive(),
         runtimeId,

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/instances/service/OutboundConnectorsService.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/instances/service/OutboundConnectorsService.java
@@ -26,7 +26,6 @@ import io.camunda.connector.runtime.outbound.jobstream.GatewayResult;
 import io.camunda.connector.runtime.outbound.jobstream.StreamConnectivity;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -35,15 +34,14 @@ public class OutboundConnectorsService {
   private static final Logger LOG = LoggerFactory.getLogger(OutboundConnectorsService.class);
 
   private final OutboundConnectorFactory connectorFactory;
-  private final Optional<GatewayJobStreamClient> gatewayJobStreamClient;
+  private final GatewayJobStreamClient gatewayJobStreamClient;
 
   public OutboundConnectorsService(OutboundConnectorFactory connectorFactory) {
-    this(connectorFactory, Optional.empty());
+    this(connectorFactory, null);
   }
 
   public OutboundConnectorsService(
-      OutboundConnectorFactory connectorFactory,
-      Optional<GatewayJobStreamClient> gatewayJobStreamClient) {
+      OutboundConnectorFactory connectorFactory, GatewayJobStreamClient gatewayJobStreamClient) {
     this.connectorFactory = connectorFactory;
     this.gatewayJobStreamClient = gatewayJobStreamClient;
   }
@@ -69,11 +67,11 @@ public class OutboundConnectorsService {
   }
 
   private GatewayResult queryGateway() {
-    if (gatewayJobStreamClient.isEmpty()) {
+    if (gatewayJobStreamClient == null) {
       return new GatewayResult.Failure.Unknown();
     }
     try {
-      return new GatewayResult.Success(gatewayJobStreamClient.get().fetchJobStreams());
+      return new GatewayResult.Success(gatewayJobStreamClient.fetchJobStreams());
     } catch (Exception e) {
       LOG.warn("Failed to fetch job streams from gateway: {}", e.getMessage());
       return new GatewayResult.Failure.Unreachable();

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/instances/service/OutboundConnectorsService.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/instances/service/OutboundConnectorsService.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.runtime.instances.service;
+
+import io.camunda.connector.runtime.core.common.AbstractConnectorFactory;
+import io.camunda.connector.runtime.core.config.OutboundConnectorConfiguration;
+import io.camunda.connector.runtime.core.outbound.OutboundConnectorFactory;
+import io.camunda.connector.runtime.inbound.controller.exception.DataNotFoundException;
+import io.camunda.connector.runtime.outbound.controller.OutboundConnectorResponse;
+import java.util.Arrays;
+import java.util.List;
+
+public class OutboundConnectorsService {
+
+  private final OutboundConnectorFactory connectorFactory;
+
+  public OutboundConnectorsService(OutboundConnectorFactory connectorFactory) {
+    this.connectorFactory = connectorFactory;
+  }
+
+  public List<OutboundConnectorResponse> findAll(String runtimeId) {
+    return connectorFactory.getRuntimeConfigurations().stream()
+        .map(config -> toResponse(config, runtimeId))
+        .toList();
+  }
+
+  public List<OutboundConnectorResponse> findByType(String type, String runtimeId) {
+    var results =
+        connectorFactory.getRuntimeConfigurations().stream()
+            .filter(config -> config.config().type().equals(type))
+            .map(config -> toResponse(config, runtimeId))
+            .toList();
+    if (results.isEmpty()) {
+      throw new DataNotFoundException(OutboundConnectorResponse.class, type);
+    }
+    return results;
+  }
+
+  private OutboundConnectorResponse toResponse(
+      AbstractConnectorFactory.ConnectorRuntimeConfiguration<OutboundConnectorConfiguration> config,
+      String runtimeId) {
+    var connectorConfig = config.config();
+    return new OutboundConnectorResponse(
+        connectorConfig.name(),
+        connectorConfig.type(),
+        Arrays.asList(connectorConfig.inputVariables()),
+        connectorConfig.timeout(),
+        config.isActive(),
+        runtimeId);
+  }
+}

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/OutboundConnectorRuntimeConfiguration.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/OutboundConnectorRuntimeConfiguration.java
@@ -39,10 +39,10 @@ import io.camunda.connector.runtime.outbound.controller.OutboundConnectorsRestCo
 import io.camunda.connector.runtime.outbound.jobstream.GatewayJobStreamClient;
 import io.camunda.connector.runtime.outbound.lifecycle.OutboundConnectorManager;
 import java.util.List;
-import java.util.Optional;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -81,10 +81,13 @@ public class OutboundConnectorRuntimeConfiguration {
   }
 
   @Bean
+  @ConditionalOnProperty(
+      name = "camunda.connector.gateway.monitoring.enabled",
+      havingValue = "true")
   public GatewayJobStreamClient gatewayJobStreamClient(
       CamundaClient camundaClient,
       @ConnectorsObjectMapper ObjectMapper mapper,
-      @Value("${camunda.connector.gateway.monitoring-port:9600}") int monitoringPort) {
+      @Value("${camunda.connector.gateway.monitoring.port:9600}") int monitoringPort) {
     return new GatewayJobStreamClient(camundaClient, monitoringPort, mapper);
   }
 
@@ -93,7 +96,7 @@ public class OutboundConnectorRuntimeConfiguration {
       OutboundConnectorFactory outboundConnectorConfigurationRegistry,
       @Autowired(required = false) GatewayJobStreamClient gatewayJobStreamClient) {
     return new OutboundConnectorsService(
-        outboundConnectorConfigurationRegistry, Optional.ofNullable(gatewayJobStreamClient));
+        outboundConnectorConfigurationRegistry, gatewayJobStreamClient);
   }
 
   @Bean

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/OutboundConnectorRuntimeConfiguration.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/OutboundConnectorRuntimeConfiguration.java
@@ -34,6 +34,7 @@ import io.camunda.connector.runtime.core.outbound.DefaultOutboundConnectorFactor
 import io.camunda.connector.runtime.core.outbound.OutboundConnectorFactory;
 import io.camunda.connector.runtime.core.secret.SecretProviderAggregator;
 import io.camunda.connector.runtime.core.validation.ValidationUtil;
+import io.camunda.connector.runtime.instances.InstanceForwardingConfiguration;
 import io.camunda.connector.runtime.instances.service.OutboundConnectorsService;
 import io.camunda.connector.runtime.outbound.controller.OutboundConnectorsRestController;
 import io.camunda.connector.runtime.outbound.jobstream.GatewayJobStreamClient;
@@ -49,7 +50,7 @@ import org.springframework.context.annotation.Import;
 import org.springframework.core.env.Environment;
 
 @Configuration
-@Import(OutboundConnectorsRestController.class)
+@Import({OutboundConnectorsRestController.class, InstanceForwardingConfiguration.class})
 public class OutboundConnectorRuntimeConfiguration {
 
   @Bean

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/OutboundConnectorRuntimeConfiguration.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/OutboundConnectorRuntimeConfiguration.java
@@ -34,16 +34,22 @@ import io.camunda.connector.runtime.core.outbound.DefaultOutboundConnectorFactor
 import io.camunda.connector.runtime.core.outbound.OutboundConnectorFactory;
 import io.camunda.connector.runtime.core.secret.SecretProviderAggregator;
 import io.camunda.connector.runtime.core.validation.ValidationUtil;
+import io.camunda.connector.runtime.instances.service.OutboundConnectorsService;
+import io.camunda.connector.runtime.outbound.controller.OutboundConnectorsRestController;
 import io.camunda.connector.runtime.outbound.lifecycle.OutboundConnectorManager;
 import java.util.List;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
 import org.springframework.core.env.Environment;
 
 @Configuration
+@Import(OutboundConnectorsRestController.class)
 public class OutboundConnectorRuntimeConfiguration {
 
   @Bean
+  @ConditionalOnMissingBean(OutboundConnectorFactory.class)
   public DefaultOutboundConnectorFactory outboundConnectorConfigurationRegistry(
       @ConnectorsObjectMapper ObjectMapper mapper,
       ValidationProvider validationProvider,
@@ -68,6 +74,12 @@ public class OutboundConnectorRuntimeConfiguration {
   @Bean
   ValidationProvider validationProvider() {
     return ValidationUtil.discoverDefaultValidationProviderImplementation();
+  }
+
+  @Bean
+  public OutboundConnectorsService outboundConnectorsService(
+      OutboundConnectorFactory outboundConnectorConfigurationRegistry) {
+    return new OutboundConnectorsService(outboundConnectorConfigurationRegistry);
   }
 
   @Bean

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/OutboundConnectorRuntimeConfiguration.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/OutboundConnectorRuntimeConfiguration.java
@@ -36,8 +36,12 @@ import io.camunda.connector.runtime.core.secret.SecretProviderAggregator;
 import io.camunda.connector.runtime.core.validation.ValidationUtil;
 import io.camunda.connector.runtime.instances.service.OutboundConnectorsService;
 import io.camunda.connector.runtime.outbound.controller.OutboundConnectorsRestController;
+import io.camunda.connector.runtime.outbound.jobstream.GatewayJobStreamClient;
 import io.camunda.connector.runtime.outbound.lifecycle.OutboundConnectorManager;
 import java.util.List;
+import java.util.Optional;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -77,9 +81,19 @@ public class OutboundConnectorRuntimeConfiguration {
   }
 
   @Bean
+  public GatewayJobStreamClient gatewayJobStreamClient(
+      CamundaClient camundaClient,
+      @ConnectorsObjectMapper ObjectMapper mapper,
+      @Value("${camunda.connector.gateway.monitoring-port:9600}") int monitoringPort) {
+    return new GatewayJobStreamClient(camundaClient, monitoringPort, mapper);
+  }
+
+  @Bean
   public OutboundConnectorsService outboundConnectorsService(
-      OutboundConnectorFactory outboundConnectorConfigurationRegistry) {
-    return new OutboundConnectorsService(outboundConnectorConfigurationRegistry);
+      OutboundConnectorFactory outboundConnectorConfigurationRegistry,
+      @Autowired(required = false) GatewayJobStreamClient gatewayJobStreamClient) {
+    return new OutboundConnectorsService(
+        outboundConnectorConfigurationRegistry, Optional.ofNullable(gatewayJobStreamClient));
   }
 
   @Bean

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/controller/OutboundConnectorResponse.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/controller/OutboundConnectorResponse.java
@@ -16,6 +16,10 @@
  */
 package io.camunda.connector.runtime.outbound.controller;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import io.camunda.connector.runtime.outbound.jobstream.BrokerConnectivityState;
+import io.camunda.connector.runtime.outbound.jobstream.GatewayConnectivityState;
 import java.util.List;
 
 /**
@@ -27,11 +31,33 @@ import java.util.List;
  * @param timeout job timeout in milliseconds, or {@code null} if not configured
  * @param enabled whether the connector is enabled or not
  * @param runtimeId hostname of the runtime node that reported this entry
+ * @param gatewayConnectivityState whether the gateway monitoring endpoint is reachable and the
+ *     connector has a registered client stream; {@code null} when not configured
+ * @param brokerConnectivityState how many brokers have the connector's stream as a consumer; {@code
+ *     null} unless {@code gatewayConnectivityState} is {@code CONNECTED}
+ * @param streamIds server-side stream IDs for the matched client streams; useful for debugging;
+ *     {@code null} unless {@code gatewayConnectivityState} is {@code CONNECTED}
  */
+@JsonInclude(Include.NON_NULL)
 public record OutboundConnectorResponse(
     String name,
     String type,
     List<String> inputVariables,
     Long timeout,
     boolean enabled,
-    String runtimeId) {}
+    String runtimeId,
+    GatewayConnectivityState gatewayConnectivityState,
+    BrokerConnectivityState brokerConnectivityState,
+    List<String> streamIds) {
+
+  /** Convenience constructor without stream enrichment (backward-compatible). */
+  public OutboundConnectorResponse(
+      String name,
+      String type,
+      List<String> inputVariables,
+      Long timeout,
+      boolean enabled,
+      String runtimeId) {
+    this(name, type, inputVariables, timeout, enabled, runtimeId, null, null, null);
+  }
+}

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/controller/OutboundConnectorResponse.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/controller/OutboundConnectorResponse.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.runtime.outbound.controller;
+
+import java.util.List;
+
+/**
+ * Represents a registered outbound connector on a specific runtime node.
+ *
+ * @param name connector name as declared in {@code @OutboundConnector}
+ * @param type job type the worker subscribes to
+ * @param inputVariables variables fetched from the job
+ * @param timeout job timeout in milliseconds, or {@code null} if not configured
+ * @param enabled whether the connector is enabled or not
+ * @param runtimeId hostname of the runtime node that reported this entry
+ */
+public record OutboundConnectorResponse(
+    String name,
+    String type,
+    List<String> inputVariables,
+    Long timeout,
+    boolean enabled,
+    String runtimeId) {}

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/controller/OutboundConnectorsRestController.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/controller/OutboundConnectorsRestController.java
@@ -25,7 +25,6 @@ import io.camunda.connector.runtime.instances.service.OutboundConnectorsService;
 import jakarta.servlet.http.HttpServletRequest;
 import java.util.List;
 import java.util.Optional;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -44,7 +43,7 @@ public class OutboundConnectorsRestController {
   private String hostname;
 
   public OutboundConnectorsRestController(
-      @Autowired(required = false) InstanceForwardingRouter instanceForwardingRouter,
+      InstanceForwardingRouter instanceForwardingRouter,
       OutboundConnectorsService outboundConnectorsService) {
     this.instanceForwardingRouter = instanceForwardingRouter;
     this.outboundConnectorsService = outboundConnectorsService;

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/controller/OutboundConnectorsRestController.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/controller/OutboundConnectorsRestController.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.runtime.outbound.controller;
+
+import static io.camunda.connector.runtime.core.http.InstanceForwardingHttpClient.X_CAMUNDA_FORWARDED_FOR;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import io.camunda.connector.runtime.inbound.controller.exception.DataNotFoundException;
+import io.camunda.connector.runtime.instances.service.InstanceForwardingRouter;
+import io.camunda.connector.runtime.instances.service.OutboundConnectorsService;
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/outbound")
+public class OutboundConnectorsRestController {
+
+  private final InstanceForwardingRouter instanceForwardingRouter;
+  private final OutboundConnectorsService outboundConnectorsService;
+
+  @Value("${camunda.connector.hostname:${HOSTNAME:localhost}}")
+  private String hostname;
+
+  public OutboundConnectorsRestController(
+      @Autowired(required = false) InstanceForwardingRouter instanceForwardingRouter,
+      OutboundConnectorsService outboundConnectorsService) {
+    this.instanceForwardingRouter = instanceForwardingRouter;
+    this.outboundConnectorsService = outboundConnectorsService;
+  }
+
+  @GetMapping
+  public List<OutboundConnectorResponse> getOutboundConnectors(
+      HttpServletRequest request,
+      @RequestHeader(name = X_CAMUNDA_FORWARDED_FOR, required = false) String forwardedFor) {
+    return instanceForwardingRouter.forwardToInstancesAndReduceOrLocal(
+        request,
+        forwardedFor,
+        () -> outboundConnectorsService.findAll(hostname),
+        new TypeReference<>() {});
+  }
+
+  @GetMapping("/{type}")
+  public List<OutboundConnectorResponse> getOutboundConnectorByType(
+      HttpServletRequest request,
+      @RequestHeader(name = X_CAMUNDA_FORWARDED_FOR, required = false) String forwardedFor,
+      @PathVariable(name = "type") String type) {
+    return Optional.ofNullable(
+            instanceForwardingRouter.forwardToInstancesAndReduceOrLocal(
+                request,
+                forwardedFor,
+                () -> outboundConnectorsService.findByType(type, hostname),
+                new TypeReference<>() {}))
+        .orElseThrow(() -> new DataNotFoundException(OutboundConnectorResponse.class, type));
+  }
+}

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/jobstream/BrokerConnectivityState.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/jobstream/BrokerConnectivityState.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.runtime.outbound.jobstream;
+
+/**
+ * Describes the connectivity state of an outbound connector worker to the Zeebe brokers.
+ *
+ * <ul>
+ *   <li>{@code NONE} – No client stream is registered as a consumer in any broker's remote stream.
+ *   <li>{@code PARTIALLY_CONNECTED} – Client streams exist on the gateway, but they do not appear
+ *       as consumers in <b>every</b> broker's remote stream. This may indicate a transient issue;
+ *       restart the gateway if it persists.
+ *   <li>{@code ALL_CONNECTED} – All client streams for this job type are registered as consumers on
+ *       all broker remote streams.
+ * </ul>
+ */
+public enum BrokerConnectivityState {
+  NONE,
+  PARTIALLY_CONNECTED,
+  ALL_CONNECTED
+}

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/jobstream/ClientJobStream.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/jobstream/ClientJobStream.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.runtime.outbound.jobstream;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.util.List;
+
+/** A client-side job stream as registered on the gateway. */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record ClientJobStream(String jobType, ClientStreamId id, List<Integer> connectedTo) {}

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/jobstream/ClientStreamId.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/jobstream/ClientStreamId.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.runtime.outbound.jobstream;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+/** Identifies a client job stream on the gateway. */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record ClientStreamId(String serverStreamId, int localId) {}

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/jobstream/GatewayConnectivityState.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/jobstream/GatewayConnectivityState.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.runtime.outbound.jobstream;
+
+/**
+ * Describes the connectivity state of an outbound connector worker as observed via the Zeebe
+ * gateway job-streams actuator endpoint.
+ *
+ * <ul>
+ *   <li>{@code UNKNOWN} – No {@code GatewayJobStreamClient} bean is configured; stream state cannot
+ *       be determined.
+ *   <li>{@code UNREACHABLE} – A client is configured but the gateway monitoring endpoint threw an
+ *       exception or returned a non-200 response.
+ *   <li>{@code NONE} – The gateway is reachable but no client stream exists for this job type. The
+ *       worker is not visible to the gateway and should be restarted.
+ *   <li>{@code CONNECTED} – A client stream for this job type exists on the gateway. See {@link
+ *       BrokerConnectivityState} for the downstream broker connection detail.
+ * </ul>
+ */
+public enum GatewayConnectivityState {
+  UNKNOWN,
+  UNREACHABLE,
+  NOT_CONNECTED,
+  CONNECTED
+}

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/jobstream/GatewayJobStreamClient.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/jobstream/GatewayJobStreamClient.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.runtime.outbound.jobstream;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.client.CamundaClient;
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+
+/**
+ * Fetches job-stream data from the Zeebe gateway monitoring endpoint ({@code
+ * /actuator/jobstreams}). The monitoring port defaults to {@code 9600} but can be overridden via
+ * {@code camunda.connector.gateway.monitoring-port}.
+ *
+ * <p>The gateway host is inferred from the REST address exposed by {@link CamundaClient}.
+ */
+public class GatewayJobStreamClient {
+
+  private static final String JOB_STREAMS_PATH = "/actuator/jobstreams";
+
+  private final URI monitoringBaseUri;
+  private final ObjectMapper objectMapper;
+  private final HttpClient httpClient;
+
+  public GatewayJobStreamClient(
+      CamundaClient camundaClient, int monitoringPort, ObjectMapper objectMapper) {
+    this.objectMapper = objectMapper;
+    this.httpClient = HttpClient.newHttpClient();
+
+    URI restAddress = camundaClient.getConfiguration().getRestAddress();
+    this.monitoringBaseUri =
+        URI.create(restAddress.getScheme() + "://" + restAddress.getHost() + ":" + monitoringPort);
+  }
+
+  /**
+   * Fetches the current job-stream state from the gateway monitoring endpoint.
+   *
+   * @return the parsed {@link JobStreamsResponse}
+   * @throws IOException if the endpoint returns a non-200 status
+   * @throws Exception if the request fails for any other reason (network error, parse error, etc.)
+   */
+  public JobStreamsResponse fetchJobStreams() throws Exception {
+    URI uri = monitoringBaseUri.resolve(JOB_STREAMS_PATH);
+    HttpRequest request = HttpRequest.newBuilder(uri).GET().build();
+    HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+    if (response.statusCode() != 200) {
+      throw new IOException(
+          "Gateway job-streams endpoint returned status " + response.statusCode() + ": " + uri);
+    }
+    return objectMapper.readValue(response.body(), JobStreamsResponse.class);
+  }
+}

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/jobstream/GatewayResult.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/jobstream/GatewayResult.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.runtime.outbound.jobstream;
+
+/**
+ * Represents the outcome of querying the gateway job-stream actuator endpoint.
+ *
+ * <ul>
+ *   <li>{@link Success} – the gateway was reachable and returned stream data.
+ *   <li>{@link Failure.Unreachable} – the gateway was configured but could not be reached.
+ *   <li>{@link Failure.Unknown} – no gateway monitoring URL is configured.
+ * </ul>
+ */
+public sealed interface GatewayResult permits GatewayResult.Success, GatewayResult.Failure {
+
+  record Success(JobStreamsResponse streams) implements GatewayResult {}
+
+  sealed interface Failure extends GatewayResult
+      permits GatewayResult.Failure.Unreachable, GatewayResult.Failure.Unknown {
+
+    GatewayConnectivityState gatewayState();
+
+    /** Gateway was configured but could not be reached (network error, timeout, etc.). */
+    record Unreachable() implements Failure {
+      @Override
+      public GatewayConnectivityState gatewayState() {
+        return GatewayConnectivityState.UNREACHABLE;
+      }
+    }
+
+    /** No gateway monitoring URL is configured — connectivity is simply not known. */
+    record Unknown() implements Failure {
+      @Override
+      public GatewayConnectivityState gatewayState() {
+        return GatewayConnectivityState.UNKNOWN;
+      }
+    }
+  }
+}

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/jobstream/JobStreamsResponse.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/jobstream/JobStreamsResponse.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.runtime.outbound.jobstream;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.util.List;
+
+/** Full response from the Zeebe gateway {@code /actuator/jobstreams} endpoint. */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record JobStreamsResponse(List<RemoteJobStream> remote, List<ClientJobStream> client) {}

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/jobstream/RemoteJobStream.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/jobstream/RemoteJobStream.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.runtime.outbound.jobstream;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.util.List;
+import java.util.Map;
+
+/** A remote (broker-side) job stream as reported by the gateway. */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record RemoteJobStream(String jobType, List<Map<String, String>> consumers) {}

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/jobstream/StreamConnectivity.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/jobstream/StreamConnectivity.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.runtime.outbound.jobstream;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Captures the connectivity state of a single connector job type as observed from both the gateway
+ * (client streams) and the brokers (remote streams).
+ *
+ * @param gatewayState whether the connector is registered as a client stream on the gateway
+ * @param brokerState whether the gateway stream is propagated to all brokers; {@code null} when
+ *     {@code gatewayState} is not {@link GatewayConnectivityState#CONNECTED}
+ * @param streamIds the server-side stream IDs observed for this job type; {@code null} when the
+ *     gateway is unreachable or not configured
+ */
+public record StreamConnectivity(
+    GatewayConnectivityState gatewayState,
+    BrokerConnectivityState brokerState,
+    List<String> streamIds) {
+
+  /** Convenience factory for cases where the gateway could not be queried. */
+  public static StreamConnectivity unavailable(GatewayConnectivityState gatewayState) {
+    return new StreamConnectivity(gatewayState, null, null);
+  }
+
+  /**
+   * Computes the connectivity state for a given job type from a live gateway job streams snapshot.
+   */
+  public static StreamConnectivity compute(String jobType, JobStreamsResponse jobStreams) {
+    List<ClientJobStream> clientStreams =
+        jobStreams.client().stream().filter(s -> jobType.equals(s.jobType())).toList();
+
+    if (clientStreams.isEmpty()) {
+      return unavailable(GatewayConnectivityState.NOT_CONNECTED);
+    }
+
+    List<String> streamIds =
+        clientStreams.stream()
+            .map(s -> s.id() != null ? s.id().serverStreamId() : null)
+            .filter(Objects::nonNull)
+            .distinct()
+            .toList();
+
+    List<RemoteJobStream> remoteStreams =
+        jobStreams.remote().stream().filter(s -> jobType.equals(s.jobType())).toList();
+
+    BrokerConnectivityState brokerState = computeBrokerState(Set.copyOf(streamIds), remoteStreams);
+
+    return new StreamConnectivity(
+        GatewayConnectivityState.CONNECTED, brokerState, streamIds.isEmpty() ? null : streamIds);
+  }
+
+  private static BrokerConnectivityState computeBrokerState(
+      Set<String> clientStreamIds, List<RemoteJobStream> remoteStreams) {
+    if (remoteStreams.isEmpty()) {
+      return BrokerConnectivityState.NONE;
+    }
+    boolean allConnected =
+        remoteStreams.stream()
+            .allMatch(
+                remote ->
+                    remote.consumers() != null
+                        && remote.consumers().stream()
+                            .anyMatch(consumer -> clientStreamIds.contains(consumer.get("id"))));
+    return allConnected
+        ? BrokerConnectivityState.ALL_CONNECTED
+        : BrokerConnectivityState.PARTIALLY_CONNECTED;
+  }
+}

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/lifecycle/OutboundConnectorManager.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/lifecycle/OutboundConnectorManager.java
@@ -79,7 +79,7 @@ public class OutboundConnectorManager implements CamundaClientLifecycleAware {
     // variables for a specific connector
     Set<OutboundConnectorConfiguration> outboundConnectors =
         new TreeSet<>(new OutboundConnectorConfigurationComparator());
-    outboundConnectors.addAll(connectorFactory.getConfigurations());
+    outboundConnectors.addAll(connectorFactory.getActiveConfigurations());
     outboundConnectors.forEach(connector -> openWorkerForOutboundConnector(client, connector));
   }
 

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/inbound/executable/InboundExecutableRegistryTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/inbound/executable/InboundExecutableRegistryTest.java
@@ -58,7 +58,7 @@ public class InboundExecutableRegistryTest {
   @BeforeEach
   public void prepareMocks() {
     factory = mock(InboundConnectorFactory.class);
-    when(factory.getConfigurations()).thenReturn(List.of());
+    when(factory.getActiveConfigurations()).thenReturn(List.of());
     contextFactory = mock(DefaultInboundConnectorContextFactory.class);
     var inboundMetrics = mock(ConnectorsInboundMetrics.class);
     batchProcessor =

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/instances/InstanceForwardingConfigurationTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/instances/InstanceForwardingConfigurationTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.runtime.instances;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.connector.runtime.instances.service.ForwardingInstanceForwardingRouter;
+import io.camunda.connector.runtime.instances.service.InstanceForwardingRouter;
+import io.camunda.connector.runtime.instances.service.LocalInstanceForwardingRouter;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+class InstanceForwardingConfigurationTest {
+
+  private final ApplicationContextRunner contextRunner =
+      new ApplicationContextRunner()
+          .withUserConfiguration(InstanceForwardingConfiguration.class)
+          .withBean(ObjectMapper.class, ObjectMapper::new);
+
+  @Test
+  void shouldCreateLocalRouter_whenHeadlessServiceUrlIsNotConfigured() {
+    contextRunner.run(
+        context -> {
+          assertThat(context).hasSingleBean(InstanceForwardingRouter.class);
+          assertThat(context.getBean(InstanceForwardingRouter.class))
+              .isInstanceOf(LocalInstanceForwardingRouter.class);
+        });
+  }
+
+  @Test
+  void shouldCreateForwardingRouter_whenHeadlessServiceUrlIsConfigured() {
+    contextRunner
+        .withPropertyValues("camunda.connector.headless.serviceurl=http://connectors-headless")
+        .run(
+            context -> {
+              assertThat(context).hasSingleBean(InstanceForwardingRouter.class);
+              assertThat(context.getBean(InstanceForwardingRouter.class))
+                  .isInstanceOf(ForwardingInstanceForwardingRouter.class);
+            });
+  }
+}

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/instances/reducer/OutboundConnectorResponseListReducerTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/instances/reducer/OutboundConnectorResponseListReducerTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.runtime.instances.reducer;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import io.camunda.connector.runtime.outbound.controller.OutboundConnectorResponse;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+public class OutboundConnectorResponseListReducerTest {
+
+  private final Reducer<List<OutboundConnectorResponse>> reducer =
+      new ReducerRegistry().getReducer(new TypeReference<>() {});
+
+  @Test
+  void shouldMergeResponsesFromTwoNodes() {
+    var node1 =
+        List.of(
+            new OutboundConnectorResponse(
+                "HTTP JSON",
+                "io.camunda:http-json:1",
+                List.of("method", "url"),
+                30000L,
+                true,
+                "node-1"),
+            new OutboundConnectorResponse(
+                "Slack", "io.camunda:slack:1", List.of("channel"), null, true, "node-1"));
+
+    var node2 =
+        List.of(
+            new OutboundConnectorResponse(
+                "HTTP JSON",
+                "io.camunda:http-json:1",
+                List.of("method", "url"),
+                30000L,
+                true,
+                "node-2"),
+            new OutboundConnectorResponse(
+                "Slack", "io.camunda:slack:1", List.of("channel"), null, true, "node-2"));
+
+    List<OutboundConnectorResponse> result = reducer.reduce(node1, node2);
+
+    assertEquals(4, result.size());
+    assertTrue(result.containsAll(node1));
+    assertTrue(result.containsAll(node2));
+  }
+
+  @Test
+  void shouldReturnOtherNode_whenOneNodeReturnsEmpty() {
+    var node1 = List.<OutboundConnectorResponse>of();
+    var node2 =
+        List.of(
+            new OutboundConnectorResponse(
+                "HTTP JSON",
+                "io.camunda:http-json:1",
+                List.of("method", "url"),
+                null,
+                true,
+                "node-2"));
+
+    List<OutboundConnectorResponse> result = reducer.reduce(node1, node2);
+
+    assertEquals(1, result.size());
+    assertTrue(result.containsAll(node2));
+  }
+}

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/instances/reducer/ReducerRegistryTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/instances/reducer/ReducerRegistryTest.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import io.camunda.connector.runtime.inbound.executable.ConnectorInstances;
+import io.camunda.connector.runtime.outbound.controller.OutboundConnectorResponse;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 
@@ -48,5 +49,17 @@ public class ReducerRegistryTest {
 
     // then
     assertThat(reducer).isNotNull().isInstanceOf(ConnectorInstancesListReducer.class);
+  }
+
+  @Test
+  public void shouldReturnReducer_forOutboundConnectorResponseList() {
+    // given
+    var targetClass = new TypeReference<List<OutboundConnectorResponse>>() {};
+
+    // when
+    var reducer = reducerRegistry.getReducer(targetClass);
+
+    // then
+    assertThat(reducer).isNotNull();
   }
 }

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/instances/service/InstanceForwardingRouterTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/instances/service/InstanceForwardingRouterTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.runtime.instances.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+class InstanceForwardingRouterTest {
+
+  private static final TypeReference<String> RESPONSE_TYPE = new TypeReference<>() {};
+
+  @Test
+  void localRouter_shouldAlwaysUseLocalImplementation() {
+    var router = new LocalInstanceForwardingRouter();
+    var request = new MockHttpServletRequest("GET", "/inbound-instances");
+
+    var result =
+        router.forwardToInstancesAndReduceOrLocal(
+            request, null, () -> "local response", RESPONSE_TYPE);
+
+    assertThat(result).isEqualTo("local response");
+  }
+
+  @Test
+  void forwardingRouter_shouldForward_whenRequestWasNotAlreadyForwarded() {
+    var forwardingService = mock(InstanceForwardingService.class);
+    var router = new ForwardingInstanceForwardingRouter(forwardingService);
+    var request = new MockHttpServletRequest("GET", "/inbound-instances");
+    var localCalled = new AtomicBoolean(false);
+    when(forwardingService.forwardAndReduce(request, RESPONSE_TYPE))
+        .thenReturn("forwarded response");
+
+    var result =
+        router.forwardToInstancesAndReduceOrLocal(
+            request,
+            null,
+            () -> {
+              localCalled.set(true);
+              return "local response";
+            },
+            RESPONSE_TYPE);
+
+    assertThat(result).isEqualTo("forwarded response");
+    assertThat(localCalled).isFalse();
+    verify(forwardingService).forwardAndReduce(request, RESPONSE_TYPE);
+  }
+
+  @Test
+  void forwardingRouter_shouldUseLocalImplementation_whenRequestWasAlreadyForwarded() {
+    var forwardingService = mock(InstanceForwardingService.class);
+    var router = new ForwardingInstanceForwardingRouter(forwardingService);
+    var request = new MockHttpServletRequest("GET", "/inbound-instances");
+
+    var result =
+        router.forwardToInstancesAndReduceOrLocal(
+            request, "runtime-1", () -> "local response", RESPONSE_TYPE);
+
+    assertThat(result).isEqualTo("local response");
+    verify(forwardingService, never()).forwardAndReduce(request, RESPONSE_TYPE);
+  }
+}

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/instances/service/OutboundConnectorsServiceTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/instances/service/OutboundConnectorsServiceTest.java
@@ -35,7 +35,6 @@ import io.camunda.connector.runtime.outbound.jobstream.JobStreamsResponse;
 import io.camunda.connector.runtime.outbound.jobstream.RemoteJobStream;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -79,7 +78,7 @@ class OutboundConnectorsServiceTest {
   void shouldReturnUnreachable_whenGatewayClientThrows() throws Exception {
     when(gatewayClient.fetchJobStreams()).thenThrow(new RuntimeException("connection refused"));
 
-    var service = new OutboundConnectorsService(factory, Optional.of(gatewayClient));
+    var service = new OutboundConnectorsService(factory, gatewayClient);
     var results = service.findAll(RUNTIME_ID);
 
     assertEquals(1, results.size());
@@ -98,7 +97,7 @@ class OutboundConnectorsServiceTest {
     when(gatewayClient.fetchJobStreams())
         .thenReturn(new JobStreamsResponse(List.of(), List.of())); // no streams at all
 
-    var service = new OutboundConnectorsService(factory, Optional.of(gatewayClient));
+    var service = new OutboundConnectorsService(factory, gatewayClient);
     var results = service.findAll(RUNTIME_ID);
 
     assertThat(results).hasSize(1);
@@ -119,7 +118,7 @@ class OutboundConnectorsServiceTest {
     when(gatewayClient.fetchJobStreams())
         .thenReturn(new JobStreamsResponse(List.of(brokerStream), List.of(clientStream)));
 
-    var service = new OutboundConnectorsService(factory, Optional.of(gatewayClient));
+    var service = new OutboundConnectorsService(factory, gatewayClient);
     var results = service.findAll(RUNTIME_ID);
 
     assertThat(results).hasSize(1);
@@ -139,7 +138,7 @@ class OutboundConnectorsServiceTest {
             new JobStreamsResponse(
                 List.of(connectedBroker, disconnectedBroker), List.of(clientStream)));
 
-    var service = new OutboundConnectorsService(factory, Optional.of(gatewayClient));
+    var service = new OutboundConnectorsService(factory, gatewayClient);
     var results = service.findAll(RUNTIME_ID);
 
     assertThat(results.getFirst().brokerConnectivityState())
@@ -152,7 +151,7 @@ class OutboundConnectorsServiceTest {
     when(gatewayClient.fetchJobStreams())
         .thenReturn(new JobStreamsResponse(List.of(), List.of(clientStream)));
 
-    var service = new OutboundConnectorsService(factory, Optional.of(gatewayClient));
+    var service = new OutboundConnectorsService(factory, gatewayClient);
     var results = service.findAll(RUNTIME_ID);
 
     assertThat(results.getFirst().brokerConnectivityState())
@@ -167,7 +166,7 @@ class OutboundConnectorsServiceTest {
   void shouldPopulateResponseMetadata() throws Exception {
     when(gatewayClient.fetchJobStreams()).thenReturn(new JobStreamsResponse(List.of(), List.of()));
 
-    var service = new OutboundConnectorsService(factory, Optional.of(gatewayClient));
+    var service = new OutboundConnectorsService(factory, gatewayClient);
     var response = service.findAll(RUNTIME_ID).getFirst();
 
     assertThat(response.name()).isEqualTo("HTTP JSON");
@@ -196,7 +195,7 @@ class OutboundConnectorsServiceTest {
                     true)));
     when(gatewayClient.fetchJobStreams()).thenReturn(new JobStreamsResponse(List.of(), List.of()));
 
-    var service = new OutboundConnectorsService(factory, Optional.of(gatewayClient));
+    var service = new OutboundConnectorsService(factory, gatewayClient);
     var results = service.findByType(TYPE, RUNTIME_ID);
 
     assertThat(results).hasSize(1);
@@ -207,7 +206,7 @@ class OutboundConnectorsServiceTest {
   void findByType_shouldThrowDataNotFoundException_whenTypeUnknown() throws Exception {
     when(gatewayClient.fetchJobStreams()).thenReturn(new JobStreamsResponse(List.of(), List.of()));
 
-    var service = new OutboundConnectorsService(factory, Optional.of(gatewayClient));
+    var service = new OutboundConnectorsService(factory, gatewayClient);
 
     assertThatThrownBy(() -> service.findByType("io.camunda:unknown:1", RUNTIME_ID))
         .isInstanceOf(DataNotFoundException.class);

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/instances/service/OutboundConnectorsServiceTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/instances/service/OutboundConnectorsServiceTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.runtime.instances.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.camunda.connector.runtime.core.common.AbstractConnectorFactory.ConnectorRuntimeConfiguration;
+import io.camunda.connector.runtime.core.config.OutboundConnectorConfiguration;
+import io.camunda.connector.runtime.core.outbound.OutboundConnectorFactory;
+import io.camunda.connector.runtime.outbound.jobstream.GatewayConnectivityState;
+import io.camunda.connector.runtime.outbound.jobstream.GatewayJobStreamClient;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+class OutboundConnectorsServiceTest {
+
+  private static final String RUNTIME_ID = "test-node";
+  private static final String TYPE = "io.camunda:http-json:1";
+
+  private final OutboundConnectorFactory factory = mock(OutboundConnectorFactory.class);
+
+  @Test
+  void shouldReturnUnknown_whenNoGatewayClientConfigured() {
+    when(factory.getRuntimeConfigurations())
+        .thenReturn(
+            List.of(
+                new ConnectorRuntimeConfiguration<>(
+                    new OutboundConnectorConfiguration(
+                        "HTTP JSON", new String[] {"url"}, TYPE, () -> null, null),
+                    true)));
+
+    var service = new OutboundConnectorsService(factory, Optional.empty());
+    var results = service.findAll(RUNTIME_ID);
+
+    assertEquals(1, results.size());
+    assertEquals(GatewayConnectivityState.UNKNOWN, results.getFirst().gatewayConnectivityState());
+  }
+
+  @Test
+  void shouldReturnUnreachable_whenGatewayClientThrows() throws Exception {
+    when(factory.getRuntimeConfigurations())
+        .thenReturn(
+            List.of(
+                new ConnectorRuntimeConfiguration<>(
+                    new OutboundConnectorConfiguration(
+                        "HTTP JSON", new String[] {"url"}, TYPE, () -> null, null),
+                    true)));
+
+    GatewayJobStreamClient client = mock(GatewayJobStreamClient.class);
+    when(client.fetchJobStreams()).thenThrow(new RuntimeException("connection refused"));
+
+    var service = new OutboundConnectorsService(factory, Optional.of(client));
+    var results = service.findAll(RUNTIME_ID);
+
+    assertEquals(1, results.size());
+    assertEquals(
+        GatewayConnectivityState.UNREACHABLE, results.getFirst().gatewayConnectivityState());
+  }
+}

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/instances/service/OutboundConnectorsServiceTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/instances/service/OutboundConnectorsServiceTest.java
@@ -16,6 +16,8 @@
  */
 package io.camunda.connector.runtime.instances.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -23,21 +25,32 @@ import static org.mockito.Mockito.when;
 import io.camunda.connector.runtime.core.common.AbstractConnectorFactory.ConnectorRuntimeConfiguration;
 import io.camunda.connector.runtime.core.config.OutboundConnectorConfiguration;
 import io.camunda.connector.runtime.core.outbound.OutboundConnectorFactory;
+import io.camunda.connector.runtime.inbound.controller.exception.DataNotFoundException;
+import io.camunda.connector.runtime.outbound.jobstream.BrokerConnectivityState;
+import io.camunda.connector.runtime.outbound.jobstream.ClientJobStream;
+import io.camunda.connector.runtime.outbound.jobstream.ClientStreamId;
 import io.camunda.connector.runtime.outbound.jobstream.GatewayConnectivityState;
 import io.camunda.connector.runtime.outbound.jobstream.GatewayJobStreamClient;
+import io.camunda.connector.runtime.outbound.jobstream.JobStreamsResponse;
+import io.camunda.connector.runtime.outbound.jobstream.RemoteJobStream;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 class OutboundConnectorsServiceTest {
 
   private static final String RUNTIME_ID = "test-node";
   private static final String TYPE = "io.camunda:http-json:1";
+  private static final String OTHER_TYPE = "io.camunda:rabbitmq:1";
+  private static final String STREAM_ID = "stream-abc-123";
 
   private final OutboundConnectorFactory factory = mock(OutboundConnectorFactory.class);
+  private final GatewayJobStreamClient gatewayClient = mock(GatewayJobStreamClient.class);
 
-  @Test
-  void shouldReturnUnknown_whenNoGatewayClientConfigured() {
+  @BeforeEach
+  void setupFactory() {
     when(factory.getRuntimeConfigurations())
         .thenReturn(
             List.of(
@@ -45,32 +58,158 @@ class OutboundConnectorsServiceTest {
                     new OutboundConnectorConfiguration(
                         "HTTP JSON", new String[] {"url"}, TYPE, () -> null, null),
                     true)));
+  }
 
-    var service = new OutboundConnectorsService(factory, Optional.empty());
+  // ---------------------------------------------------------------------------
+  // Gateway not configured / unreachable
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void shouldReturnUnknown_whenNoGatewayClientConfigured() {
+    var service = new OutboundConnectorsService(factory);
     var results = service.findAll(RUNTIME_ID);
 
     assertEquals(1, results.size());
     assertEquals(GatewayConnectivityState.UNKNOWN, results.getFirst().gatewayConnectivityState());
+    assertThat(results.getFirst().brokerConnectivityState()).isNull();
+    assertThat(results.getFirst().streamIds()).isNull();
   }
 
   @Test
   void shouldReturnUnreachable_whenGatewayClientThrows() throws Exception {
-    when(factory.getRuntimeConfigurations())
-        .thenReturn(
-            List.of(
-                new ConnectorRuntimeConfiguration<>(
-                    new OutboundConnectorConfiguration(
-                        "HTTP JSON", new String[] {"url"}, TYPE, () -> null, null),
-                    true)));
+    when(gatewayClient.fetchJobStreams()).thenThrow(new RuntimeException("connection refused"));
 
-    GatewayJobStreamClient client = mock(GatewayJobStreamClient.class);
-    when(client.fetchJobStreams()).thenThrow(new RuntimeException("connection refused"));
-
-    var service = new OutboundConnectorsService(factory, Optional.of(client));
+    var service = new OutboundConnectorsService(factory, Optional.of(gatewayClient));
     var results = service.findAll(RUNTIME_ID);
 
     assertEquals(1, results.size());
     assertEquals(
         GatewayConnectivityState.UNREACHABLE, results.getFirst().gatewayConnectivityState());
+    assertThat(results.getFirst().brokerConnectivityState()).isNull();
+    assertThat(results.getFirst().streamIds()).isNull();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Gateway reachable — client stream absent
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void shouldReturnNotConnected_whenNoClientStreamForJobType() throws Exception {
+    when(gatewayClient.fetchJobStreams())
+        .thenReturn(new JobStreamsResponse(List.of(), List.of())); // no streams at all
+
+    var service = new OutboundConnectorsService(factory, Optional.of(gatewayClient));
+    var results = service.findAll(RUNTIME_ID);
+
+    assertThat(results).hasSize(1);
+    assertThat(results.getFirst().gatewayConnectivityState())
+        .isEqualTo(GatewayConnectivityState.NOT_CONNECTED);
+    assertThat(results.getFirst().brokerConnectivityState()).isNull();
+    assertThat(results.getFirst().streamIds()).isNull();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Gateway reachable — client stream present
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void shouldReturnConnectedAndAllBrokers_whenFullyConnected() throws Exception {
+    var clientStream = new ClientJobStream(TYPE, new ClientStreamId(STREAM_ID, 0), List.of(0));
+    var brokerStream = new RemoteJobStream(TYPE, List.of(Map.of("id", STREAM_ID)));
+    when(gatewayClient.fetchJobStreams())
+        .thenReturn(new JobStreamsResponse(List.of(brokerStream), List.of(clientStream)));
+
+    var service = new OutboundConnectorsService(factory, Optional.of(gatewayClient));
+    var results = service.findAll(RUNTIME_ID);
+
+    assertThat(results).hasSize(1);
+    var response = results.getFirst();
+    assertThat(response.gatewayConnectivityState()).isEqualTo(GatewayConnectivityState.CONNECTED);
+    assertThat(response.brokerConnectivityState()).isEqualTo(BrokerConnectivityState.ALL_CONNECTED);
+    assertThat(response.streamIds()).containsExactly(STREAM_ID);
+  }
+
+  @Test
+  void shouldReturnPartiallyConnected_whenOnlyOneBrokerHasConsumer() throws Exception {
+    var clientStream = new ClientJobStream(TYPE, new ClientStreamId(STREAM_ID, 0), List.of(0));
+    var connectedBroker = new RemoteJobStream(TYPE, List.of(Map.of("id", STREAM_ID)));
+    var disconnectedBroker = new RemoteJobStream(TYPE, List.of());
+    when(gatewayClient.fetchJobStreams())
+        .thenReturn(
+            new JobStreamsResponse(
+                List.of(connectedBroker, disconnectedBroker), List.of(clientStream)));
+
+    var service = new OutboundConnectorsService(factory, Optional.of(gatewayClient));
+    var results = service.findAll(RUNTIME_ID);
+
+    assertThat(results.getFirst().brokerConnectivityState())
+        .isEqualTo(BrokerConnectivityState.PARTIALLY_CONNECTED);
+  }
+
+  @Test
+  void shouldReturnNoneBrokerState_whenNoRemoteStreamsForJobType() throws Exception {
+    var clientStream = new ClientJobStream(TYPE, new ClientStreamId(STREAM_ID, 0), List.of(0));
+    when(gatewayClient.fetchJobStreams())
+        .thenReturn(new JobStreamsResponse(List.of(), List.of(clientStream)));
+
+    var service = new OutboundConnectorsService(factory, Optional.of(gatewayClient));
+    var results = service.findAll(RUNTIME_ID);
+
+    assertThat(results.getFirst().brokerConnectivityState())
+        .isEqualTo(BrokerConnectivityState.NONE);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Metadata correctness
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void shouldPopulateResponseMetadata() throws Exception {
+    when(gatewayClient.fetchJobStreams()).thenReturn(new JobStreamsResponse(List.of(), List.of()));
+
+    var service = new OutboundConnectorsService(factory, Optional.of(gatewayClient));
+    var response = service.findAll(RUNTIME_ID).getFirst();
+
+    assertThat(response.name()).isEqualTo("HTTP JSON");
+    assertThat(response.type()).isEqualTo(TYPE);
+    assertThat(response.inputVariables()).containsExactly("url");
+    assertThat(response.runtimeId()).isEqualTo(RUNTIME_ID);
+    assertThat(response.enabled()).isTrue();
+  }
+
+  // ---------------------------------------------------------------------------
+  // findByType
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void findByType_shouldReturnOnlyMatchingType() throws Exception {
+    when(factory.getRuntimeConfigurations())
+        .thenReturn(
+            List.of(
+                new ConnectorRuntimeConfiguration<>(
+                    new OutboundConnectorConfiguration(
+                        "HTTP JSON", new String[] {"url"}, TYPE, () -> null, null),
+                    true),
+                new ConnectorRuntimeConfiguration<>(
+                    new OutboundConnectorConfiguration(
+                        "RabbitMQ", new String[] {"message"}, OTHER_TYPE, () -> null, null),
+                    true)));
+    when(gatewayClient.fetchJobStreams()).thenReturn(new JobStreamsResponse(List.of(), List.of()));
+
+    var service = new OutboundConnectorsService(factory, Optional.of(gatewayClient));
+    var results = service.findByType(TYPE, RUNTIME_ID);
+
+    assertThat(results).hasSize(1);
+    assertThat(results.getFirst().type()).isEqualTo(TYPE);
+  }
+
+  @Test
+  void findByType_shouldThrowDataNotFoundException_whenTypeUnknown() throws Exception {
+    when(gatewayClient.fetchJobStreams()).thenReturn(new JobStreamsResponse(List.of(), List.of()));
+
+    var service = new OutboundConnectorsService(factory, Optional.of(gatewayClient));
+
+    assertThatThrownBy(() -> service.findByType("io.camunda:unknown:1", RUNTIME_ID))
+        .isInstanceOf(DataNotFoundException.class);
   }
 }

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/jobstream/GatewayJobStreamClientTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/jobstream/GatewayJobStreamClientTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.runtime.outbound.jobstream;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.ok;
+import static com.github.tomakehurst.wiremock.client.WireMock.okJson;
+import static com.github.tomakehurst.wiremock.client.WireMock.serverError;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.verify;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import io.camunda.client.CamundaClient;
+import io.camunda.connector.jackson.ConnectorsObjectMapperSupplier;
+import java.io.IOException;
+import java.net.URI;
+import org.junit.jupiter.api.Test;
+
+@WireMockTest
+class GatewayJobStreamClientTest {
+
+  private static final String JOB_STREAMS_PATH = "/actuator/jobstreams";
+  private static final String REST_ADDRESS = "http://localhost:26500";
+  private static final String JOB_TYPE = "io.camunda:http-json:1";
+  private static final String STREAM_ID = "stream-abc-123";
+
+  @Test
+  void fetchJobStreams_shouldDeriveMonitoringEndpointFromRestAddressAndDeserializeResponse(
+      WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
+    stubFor(
+        get(JOB_STREAMS_PATH)
+            .willReturn(
+                okJson(
+                    """
+                    {
+                      "remote": [
+                        {
+                          "jobType": "io.camunda:http-json:1",
+                          "consumers": [{"id": "stream-abc-123"}],
+                          "ignoredRemoteField": "ignored"
+                        }
+                      ],
+                      "client": [
+                        {
+                          "jobType": "io.camunda:http-json:1",
+                          "id": {"serverStreamId": "stream-abc-123", "localId": 7},
+                          "connectedTo": [0, 1],
+                          "ignoredClientField": "ignored"
+                        }
+                      ],
+                      "ignoredTopLevelField": "ignored"
+                    }
+                    """)));
+    var client = newClient(wmRuntimeInfo.getHttpPort());
+
+    JobStreamsResponse result = client.fetchJobStreams();
+
+    assertThat(result.remote()).hasSize(1);
+    assertThat(result.remote().getFirst().jobType()).isEqualTo(JOB_TYPE);
+    assertThat(result.remote().getFirst().consumers().getFirst()).containsEntry("id", STREAM_ID);
+    assertThat(result.client()).hasSize(1);
+    assertThat(result.client().getFirst().jobType()).isEqualTo(JOB_TYPE);
+    assertThat(result.client().getFirst().id().serverStreamId()).isEqualTo(STREAM_ID);
+    assertThat(result.client().getFirst().id().localId()).isEqualTo(7);
+    assertThat(result.client().getFirst().connectedTo()).containsExactly(0, 1);
+    verify(getRequestedFor(urlEqualTo(JOB_STREAMS_PATH)));
+  }
+
+  @Test
+  void fetchJobStreams_shouldThrowIOException_whenEndpointReturnsNon200(
+      WireMockRuntimeInfo wmRuntimeInfo) {
+    stubFor(get(JOB_STREAMS_PATH).willReturn(serverError().withBody("boom")));
+    var client = newClient(wmRuntimeInfo.getHttpPort());
+
+    assertThatThrownBy(client::fetchJobStreams)
+        .isInstanceOf(IOException.class)
+        .hasMessageContaining("Gateway job-streams endpoint returned status 500")
+        .hasMessageContaining(JOB_STREAMS_PATH);
+    verify(getRequestedFor(urlEqualTo(JOB_STREAMS_PATH)));
+  }
+
+  @Test
+  void fetchJobStreams_shouldPropagateParseError_whenEndpointReturnsMalformedJson(
+      WireMockRuntimeInfo wmRuntimeInfo) {
+    stubFor(get(JOB_STREAMS_PATH).willReturn(ok().withBody("{")));
+    var client = newClient(wmRuntimeInfo.getHttpPort());
+
+    assertThatThrownBy(client::fetchJobStreams).isInstanceOf(JsonProcessingException.class);
+    verify(getRequestedFor(urlEqualTo(JOB_STREAMS_PATH)));
+  }
+
+  private GatewayJobStreamClient newClient(int monitoringPort) {
+    CamundaClient camundaClient = mock(CamundaClient.class, RETURNS_DEEP_STUBS);
+    when(camundaClient.getConfiguration().getRestAddress()).thenReturn(URI.create(REST_ADDRESS));
+    return new GatewayJobStreamClient(
+        camundaClient, monitoringPort, ConnectorsObjectMapperSupplier.getCopy());
+  }
+}

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/jobstream/StreamConnectivityTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/jobstream/StreamConnectivityTest.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.runtime.outbound.jobstream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class StreamConnectivityTest {
+
+  private static final String JOB_TYPE = "io.camunda:http-json:1";
+  private static final String OTHER_TYPE = "io.camunda:rabbitmq:1";
+  private static final String STREAM_ID = "stream-abc-123";
+
+  // ---------------------------------------------------------------------------
+  // unavailable()
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void unavailable_shouldSetGatewayStateAndNullFields() {
+    var result = StreamConnectivity.unavailable(GatewayConnectivityState.UNREACHABLE);
+
+    assertThat(result.gatewayState()).isEqualTo(GatewayConnectivityState.UNREACHABLE);
+    assertThat(result.brokerState()).isNull();
+    assertThat(result.streamIds()).isNull();
+  }
+
+  // ---------------------------------------------------------------------------
+  // compute() — no client stream
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void compute_shouldReturnNotConnected_whenNoClientStreamForJobType() {
+    var jobStreams =
+        new JobStreamsResponse(
+            List.of(new RemoteJobStream(JOB_TYPE, List.of())), List.of() // no client streams
+            );
+
+    var result = StreamConnectivity.compute(JOB_TYPE, jobStreams);
+
+    assertThat(result.gatewayState()).isEqualTo(GatewayConnectivityState.NOT_CONNECTED);
+    assertThat(result.brokerState()).isNull();
+    assertThat(result.streamIds()).isNull();
+  }
+
+  @Test
+  void compute_shouldReturnNotConnected_whenClientStreamExistsForOtherTypeOnly() {
+    var clientStream =
+        new ClientJobStream(OTHER_TYPE, new ClientStreamId(STREAM_ID, 0), List.of(0));
+    var jobStreams = new JobStreamsResponse(List.of(), List.of(clientStream));
+
+    var result = StreamConnectivity.compute(JOB_TYPE, jobStreams);
+
+    assertThat(result.gatewayState()).isEqualTo(GatewayConnectivityState.NOT_CONNECTED);
+  }
+
+  // ---------------------------------------------------------------------------
+  // compute() — client stream present, broker states
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void compute_shouldReturnNonBrokerState_whenNoRemoteStreams() {
+    var clientStream = new ClientJobStream(JOB_TYPE, new ClientStreamId(STREAM_ID, 0), List.of(0));
+    var jobStreams = new JobStreamsResponse(List.of(), List.of(clientStream));
+
+    var result = StreamConnectivity.compute(JOB_TYPE, jobStreams);
+
+    assertThat(result.gatewayState()).isEqualTo(GatewayConnectivityState.CONNECTED);
+    assertThat(result.brokerState()).isEqualTo(BrokerConnectivityState.NONE);
+    assertThat(result.streamIds()).containsExactly(STREAM_ID);
+  }
+
+  @Test
+  void compute_shouldReturnAllConnected_whenAllBrokersHaveConsumer() {
+    var clientStream = new ClientJobStream(JOB_TYPE, new ClientStreamId(STREAM_ID, 0), List.of(0));
+    var broker1 = new RemoteJobStream(JOB_TYPE, List.of(Map.of("id", STREAM_ID)));
+    var broker2 = new RemoteJobStream(JOB_TYPE, List.of(Map.of("id", STREAM_ID)));
+    var jobStreams = new JobStreamsResponse(List.of(broker1, broker2), List.of(clientStream));
+
+    var result = StreamConnectivity.compute(JOB_TYPE, jobStreams);
+
+    assertThat(result.gatewayState()).isEqualTo(GatewayConnectivityState.CONNECTED);
+    assertThat(result.brokerState()).isEqualTo(BrokerConnectivityState.ALL_CONNECTED);
+    assertThat(result.streamIds()).containsExactly(STREAM_ID);
+  }
+
+  @Test
+  void compute_shouldReturnPartiallyConnected_whenOnlyOneBrokerHasConsumer() {
+    var clientStream = new ClientJobStream(JOB_TYPE, new ClientStreamId(STREAM_ID, 0), List.of(0));
+    var connectedBroker = new RemoteJobStream(JOB_TYPE, List.of(Map.of("id", STREAM_ID)));
+    var disconnectedBroker = new RemoteJobStream(JOB_TYPE, List.of()); // no consumers
+    var jobStreams =
+        new JobStreamsResponse(List.of(connectedBroker, disconnectedBroker), List.of(clientStream));
+
+    var result = StreamConnectivity.compute(JOB_TYPE, jobStreams);
+
+    assertThat(result.gatewayState()).isEqualTo(GatewayConnectivityState.CONNECTED);
+    assertThat(result.brokerState()).isEqualTo(BrokerConnectivityState.PARTIALLY_CONNECTED);
+  }
+
+  @Test
+  void compute_shouldReturnPartiallyConnected_whenBrokerConsumerIdDoesNotMatch() {
+    var clientStream = new ClientJobStream(JOB_TYPE, new ClientStreamId(STREAM_ID, 0), List.of(0));
+    var brokerWithWrongConsumer =
+        new RemoteJobStream(JOB_TYPE, List.of(Map.of("id", "other-stream-id")));
+    var jobStreams =
+        new JobStreamsResponse(List.of(brokerWithWrongConsumer), List.of(clientStream));
+
+    var result = StreamConnectivity.compute(JOB_TYPE, jobStreams);
+
+    assertThat(result.brokerState()).isEqualTo(BrokerConnectivityState.PARTIALLY_CONNECTED);
+  }
+
+  // ---------------------------------------------------------------------------
+  // compute() — stream ID edge cases
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void compute_shouldFilterOutNullStreamIds() {
+    var clientStreamWithNullId = new ClientJobStream(JOB_TYPE, null, List.of(0));
+    var jobStreams = new JobStreamsResponse(List.of(), List.of(clientStreamWithNullId));
+
+    var result = StreamConnectivity.compute(JOB_TYPE, jobStreams);
+
+    // Gateway connected (client stream exists) but streamIds null (all ids were null)
+    assertThat(result.gatewayState()).isEqualTo(GatewayConnectivityState.CONNECTED);
+    assertThat(result.streamIds()).isNull();
+  }
+
+  @Test
+  void compute_shouldDeduplicateStreamIds_whenMultipleClientStreamsShareSameId() {
+    var stream1 = new ClientJobStream(JOB_TYPE, new ClientStreamId(STREAM_ID, 0), List.of(0));
+    var stream2 = new ClientJobStream(JOB_TYPE, new ClientStreamId(STREAM_ID, 1), List.of(1));
+    var jobStreams = new JobStreamsResponse(List.of(), List.of(stream1, stream2));
+
+    var result = StreamConnectivity.compute(JOB_TYPE, jobStreams);
+
+    assertThat(result.streamIds()).containsExactly(STREAM_ID);
+  }
+
+  @Test
+  void compute_shouldOnlyConsiderRemoteStreamsMatchingJobType() {
+    var clientStream = new ClientJobStream(JOB_TYPE, new ClientStreamId(STREAM_ID, 0), List.of(0));
+    // remote stream is for a different type — should be ignored
+    var otherRemote = new RemoteJobStream(OTHER_TYPE, List.of(Map.of("id", STREAM_ID)));
+    var jobStreams = new JobStreamsResponse(List.of(otherRemote), List.of(clientStream));
+
+    var result = StreamConnectivity.compute(JOB_TYPE, jobStreams);
+
+    // No remote streams for JOB_TYPE → NONE
+    assertThat(result.brokerState()).isEqualTo(BrokerConnectivityState.NONE);
+  }
+}

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/lifecycle/OutboundRegistryTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/lifecycle/OutboundRegistryTest.java
@@ -118,7 +118,7 @@ class OutboundRegistryTest {
     configuredContextRunner.run(
         context -> {
           var outboundConnectorRegistry = context.getBean(DefaultOutboundConnectorFactory.class);
-          Assertions.assertThatStream(outboundConnectorRegistry.getConfigurations().stream())
+          Assertions.assertThatStream(outboundConnectorRegistry.getActiveConfigurations().stream())
               .anyMatch(
                   e -> {
                     try {

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/main/java/io/camunda/connector/runtime/OutboundConnectorsAutoConfiguration.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/main/java/io/camunda/connector/runtime/OutboundConnectorsAutoConfiguration.java
@@ -18,6 +18,7 @@ package io.camunda.connector.runtime;
 
 import io.camunda.client.jobhandling.CamundaClientExecutorService;
 import io.camunda.client.metrics.MeteredCamundaClientExecutorService;
+import io.camunda.connector.runtime.instances.InstanceForwardingConfiguration;
 import io.camunda.connector.runtime.outbound.OutboundConnectorRuntimeConfiguration;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.util.concurrent.Executors;
@@ -30,7 +31,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 
 @AutoConfiguration
-@Import(OutboundConnectorRuntimeConfiguration.class)
+@Import({OutboundConnectorRuntimeConfiguration.class, InstanceForwardingConfiguration.class})
 public class OutboundConnectorsAutoConfiguration {
 
   @Bean

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/inbound/InboundEndpointTest.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/inbound/InboundEndpointTest.java
@@ -34,6 +34,7 @@ import io.camunda.connector.runtime.core.inbound.correlation.MessageCorrelationP
 import io.camunda.connector.runtime.inbound.controller.InboundConnectorRestController;
 import io.camunda.connector.runtime.inbound.executable.ActiveExecutableResponse;
 import io.camunda.connector.runtime.inbound.executable.InboundExecutableRegistry;
+import io.camunda.connector.runtime.instances.service.LocalInstanceForwardingRouter;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -83,7 +84,7 @@ public class InboundEndpointTest {
                     System.currentTimeMillis())));
 
     InboundConnectorRestController statusController =
-        new InboundConnectorRestController(executableRegistry, null);
+        new InboundConnectorRestController(executableRegistry, new LocalInstanceForwardingRouter());
 
     var response = statusController.getActiveInboundConnectors(null, null, null);
     assertEquals(1, response.size());
@@ -110,7 +111,7 @@ public class InboundEndpointTest {
                     System.currentTimeMillis())));
 
     InboundConnectorRestController statusController =
-        new InboundConnectorRestController(executableRegistry, null);
+        new InboundConnectorRestController(executableRegistry, new LocalInstanceForwardingRouter());
 
     var response = statusController.getActiveInboundConnectors(null, null, null);
     assertEquals(1, response.size());

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/inbound/InboundInstancesRestControllerMultiInstancesTest.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/inbound/InboundInstancesRestControllerMultiInstancesTest.java
@@ -19,6 +19,8 @@ package io.camunda.connector.runtime.inbound;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
 
 import io.camunda.connector.api.inbound.*;
 import io.camunda.connector.runtime.core.inbound.ExecutableId;
@@ -276,5 +278,22 @@ class InboundInstancesRestControllerMultiInstancesTest extends BaseMultiInstance
         logs.getFirst(),
         equalTo(
             new InstanceAwareModel.InstanceAwareHealth(Health.Status.UP, null, null, "instance1")));
+  }
+
+  @Test
+  public void shouldReturnEmptyList_whenNoConnectors() {
+    reset(executableRegistry1, executableRegistry2);
+    when(executableRegistry1.query(any())).thenReturn(Collections.emptyList());
+    when(executableRegistry2.query(any())).thenReturn(Collections.emptyList());
+
+    ResponseEntity<List<ConnectorInstances>> response =
+        restTemplate.exchange(
+            "http://localhost:" + port1 + "/inbound-instances",
+            HttpMethod.GET,
+            null,
+            new ParameterizedTypeReference<>() {});
+
+    List<ConnectorInstances> instance = response.getBody();
+    assertEquals(0, instance.size());
   }
 }

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/inbound/SpringBasedInboundConnectorTest.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/inbound/SpringBasedInboundConnectorTest.java
@@ -34,7 +34,7 @@ public class SpringBasedInboundConnectorTest {
   @Test
   void springBasedConnectorPresent() {
     var connectorConfig =
-        inboundConnectorFactory.getConfigurations().stream()
+        inboundConnectorFactory.getActiveConfigurations().stream()
             .filter(c -> c.name().equals("TEST_INBOUND_SPRING"))
             .findFirst()
             .get();

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/outbound/BaseOutboundMultiInstancesTest.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/outbound/BaseOutboundMultiInstancesTest.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.runtime.outbound;
+
+import static org.mockito.Mockito.when;
+
+import io.camunda.connector.jackson.ConnectorsObjectMapperSupplier;
+import io.camunda.connector.runtime.app.TestConnectorRuntimeApplication;
+import io.camunda.connector.runtime.core.common.AbstractConnectorFactory.ConnectorRuntimeConfiguration;
+import io.camunda.connector.runtime.core.config.OutboundConnectorConfiguration;
+import io.camunda.connector.runtime.core.http.InstanceForwardingHttpClient;
+import io.camunda.connector.runtime.core.outbound.OutboundConnectorFactory;
+import io.camunda.connector.runtime.instances.service.DefaultInstanceForwardingService;
+import io.camunda.connector.runtime.instances.service.InstanceForwardingService;
+import java.net.http.HttpClient;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.mockito.Mockito;
+import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.boot.restclient.RestTemplateBuilder;
+import org.springframework.boot.resttestclient.TestRestTemplate;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.support.GenericApplicationContext;
+import org.springframework.http.converter.StringHttpMessageConverter;
+import org.springframework.http.converter.json.JacksonJsonHttpMessageConverter;
+import tools.jackson.databind.json.JsonMapper;
+
+abstract class BaseOutboundMultiInstancesTest {
+
+  static final String TYPE_1 = "io.camunda:http-json:1";
+  static final String TYPE_2 = "io.camunda:slack:1";
+  static final String TYPE_ONLY_IN_INSTANCE_2 = "io.camunda:only-in-instance-2:1";
+  static final String TYPE_DISABLED_IN_INSTANCE_1 = "io.camunda:disabled-in-instance-1:1";
+
+  final int port1 = 18082;
+  final int port2 = 18083;
+
+  final OutboundConnectorFactory connectorFactory1 = Mockito.mock(OutboundConnectorFactory.class);
+  final OutboundConnectorFactory connectorFactory2 = Mockito.mock(OutboundConnectorFactory.class);
+
+  final InstanceForwardingHttpClient instanceForwardingHttpClient =
+      new InstanceForwardingHttpClient(
+          HttpClient.newHttpClient(),
+          (path) -> List.of("http://localhost:" + port1 + path, "http://localhost:" + port2 + path),
+          ConnectorsObjectMapperSupplier.getCopy());
+
+  final TestRestTemplate restTemplate =
+      new TestRestTemplate(
+          new RestTemplateBuilder()
+              .messageConverters(
+                  new StringHttpMessageConverter(),
+                  new JacksonJsonHttpMessageConverter(JsonMapper.builderWithJackson2Defaults())));
+
+  ConfigurableApplicationContext context1;
+  ConfigurableApplicationContext context2;
+
+  @AfterEach
+  void tearDown() {
+    if (context1 != null) context1.close();
+    if (context2 != null) context2.close();
+  }
+
+  @BeforeEach
+  void init() {
+    context1 =
+        new SpringApplicationBuilder(TestConnectorRuntimeApplication.class)
+            .properties(
+                "server.port=" + port1,
+                "spring.application.name=instance1",
+                "camunda.connector.hostname=instance1",
+                "camunda.connector.headless.serviceurl=http://whatever:8080")
+            .initializers(
+                ctx -> {
+                  ((GenericApplicationContext) ctx)
+                      .registerBean(OutboundConnectorFactory.class, () -> connectorFactory1);
+                  ((GenericApplicationContext) ctx)
+                      .registerBean(
+                          InstanceForwardingHttpClient.class, () -> instanceForwardingHttpClient);
+                  ((GenericApplicationContext) ctx)
+                      .registerBean(
+                          InstanceForwardingService.class,
+                          () ->
+                              new DefaultInstanceForwardingService(
+                                  instanceForwardingHttpClient, "instance1"));
+                })
+            .run();
+
+    context2 =
+        new SpringApplicationBuilder(TestConnectorRuntimeApplication.class)
+            .properties(
+                "server.port=" + port2,
+                "spring.application.name=instance2",
+                "camunda.connector.hostname=instance2",
+                "camunda.connector.headless.serviceurl=http://whatever:8080")
+            .initializers(
+                ctx -> {
+                  ((GenericApplicationContext) ctx)
+                      .registerBean(OutboundConnectorFactory.class, () -> connectorFactory2);
+                  ((GenericApplicationContext) ctx)
+                      .registerBean(
+                          InstanceForwardingHttpClient.class, () -> instanceForwardingHttpClient);
+                  ((GenericApplicationContext) ctx)
+                      .registerBean(
+                          InstanceForwardingService.class,
+                          () ->
+                              new DefaultInstanceForwardingService(
+                                  instanceForwardingHttpClient, "instance2"));
+                })
+            .run();
+
+    // instance1: TYPE_1 (enabled), TYPE_2 (enabled), TYPE_DISABLED_IN_INSTANCE_1 (disabled)
+    when(connectorFactory1.getRuntimeConfigurations())
+        .thenReturn(
+            List.of(
+                new ConnectorRuntimeConfiguration<>(
+                    new OutboundConnectorConfiguration(
+                        "HTTP JSON", new String[] {"method", "url"}, TYPE_1, () -> null, 30000L),
+                    true),
+                new ConnectorRuntimeConfiguration<>(
+                    new OutboundConnectorConfiguration(
+                        "Slack", new String[] {"channel"}, TYPE_2, () -> null, null),
+                    true),
+                new ConnectorRuntimeConfiguration<>(
+                    new OutboundConnectorConfiguration(
+                        "Disabled In Instance 1",
+                        new String[] {},
+                        TYPE_DISABLED_IN_INSTANCE_1,
+                        () -> null,
+                        null),
+                    false)));
+
+    // instance2: TYPE_1 (enabled), TYPE_2 (enabled), TYPE_ONLY_IN_INSTANCE_2 (enabled)
+    when(connectorFactory2.getRuntimeConfigurations())
+        .thenReturn(
+            List.of(
+                new ConnectorRuntimeConfiguration<>(
+                    new OutboundConnectorConfiguration(
+                        "HTTP JSON", new String[] {"method", "url"}, TYPE_1, () -> null, 30000L),
+                    true),
+                new ConnectorRuntimeConfiguration<>(
+                    new OutboundConnectorConfiguration(
+                        "Slack", new String[] {"channel"}, TYPE_2, () -> null, null),
+                    true),
+                new ConnectorRuntimeConfiguration<>(
+                    new OutboundConnectorConfiguration(
+                        "Only In Instance 2",
+                        new String[] {},
+                        TYPE_ONLY_IN_INSTANCE_2,
+                        () -> null,
+                        null),
+                    true)));
+  }
+}

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/outbound/JobRetriesIntegrationTest.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/outbound/JobRetriesIntegrationTest.java
@@ -224,7 +224,7 @@ public class JobRetriesIntegrationTest {
     @Primary
     public OutboundConnectorFactory mockConnectorFactory() {
       var mock = Mockito.mock(OutboundConnectorFactory.class);
-      when(mock.getConfigurations())
+      when(mock.getActiveConfigurations())
           .thenReturn(
               Arrays.asList(
                   new OutboundConnectorConfiguration(

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/outbound/OutboundConnectorsRestControllerMultiInstancesTest.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/outbound/OutboundConnectorsRestControllerMultiInstancesTest.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.runtime.outbound;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.camunda.connector.runtime.outbound.controller.OutboundConnectorResponse;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+
+@ExtendWith(MockitoExtension.class)
+class OutboundConnectorsRestControllerMultiInstancesTest extends BaseOutboundMultiInstancesTest {
+
+  @Test
+  void shouldReturnConnectorsFromAllNodes() {
+    ResponseEntity<List<OutboundConnectorResponse>> response =
+        restTemplate.exchange(
+            "http://localhost:" + port1 + "/outbound",
+            HttpMethod.GET,
+            null,
+            new ParameterizedTypeReference<>() {});
+
+    var connectors = response.getBody();
+    // instance1: 3 (2 enabled + 1 disabled), instance2: 3 (all enabled)
+    assertEquals(6, connectors.size());
+
+    var instance1Connectors =
+        connectors.stream().filter(c -> "instance1".equals(c.runtimeId())).toList();
+    var instance2Connectors =
+        connectors.stream().filter(c -> "instance2".equals(c.runtimeId())).toList();
+
+    assertEquals(3, instance1Connectors.size());
+    assertEquals(3, instance2Connectors.size());
+
+    // instance1 has a disabled connector
+    var disabledInInstance1 =
+        instance1Connectors.stream()
+            .filter(c -> TYPE_DISABLED_IN_INSTANCE_1.equals(c.type()))
+            .findFirst()
+            .orElseThrow();
+    assertFalse(disabledInInstance1.enabled());
+
+    // all other connectors on instance1 are enabled
+    instance1Connectors.stream()
+        .filter(c -> !TYPE_DISABLED_IN_INSTANCE_1.equals(c.type()))
+        .forEach(c -> assertTrue(c.enabled()));
+
+    // all connectors on instance2 are enabled
+    instance2Connectors.forEach(c -> assertTrue(c.enabled()));
+  }
+
+  @Test
+  void shouldReturnConnectorByType_fromAllNodes() {
+    ResponseEntity<List<OutboundConnectorResponse>> response =
+        restTemplate.exchange(
+            "http://localhost:" + port1 + "/outbound/" + TYPE_1,
+            HttpMethod.GET,
+            null,
+            new ParameterizedTypeReference<>() {});
+
+    var connectors = response.getBody();
+    // TYPE_1 is registered on both nodes → one entry per node, both enabled
+    assertEquals(2, connectors.size());
+    assertTrue(connectors.stream().anyMatch(c -> "instance1".equals(c.runtimeId())));
+    assertTrue(connectors.stream().anyMatch(c -> "instance2".equals(c.runtimeId())));
+    connectors.forEach(c -> assertEquals(TYPE_1, c.type()));
+    connectors.forEach(c -> assertTrue(c.enabled()));
+  }
+
+  @Test
+  void shouldReturnDisabledConnector_fromNodeWhereItIsDisabled() {
+    ResponseEntity<List<OutboundConnectorResponse>> response =
+        restTemplate.exchange(
+            "http://localhost:" + port1 + "/outbound/" + TYPE_DISABLED_IN_INSTANCE_1,
+            HttpMethod.GET,
+            null,
+            new ParameterizedTypeReference<>() {});
+
+    var connectors = response.getBody();
+    // Only instance1 has this connector, and it is disabled there
+    assertEquals(1, connectors.size());
+    assertEquals("instance1", connectors.getFirst().runtimeId());
+    assertFalse(connectors.getFirst().enabled());
+  }
+
+  @Test
+  void shouldReturnConnectorOnlyInOneNode_whenTypeFilteredToThatNode() {
+    ResponseEntity<List<OutboundConnectorResponse>> response =
+        restTemplate.exchange(
+            "http://localhost:" + port1 + "/outbound/" + TYPE_ONLY_IN_INSTANCE_2,
+            HttpMethod.GET,
+            null,
+            new ParameterizedTypeReference<>() {});
+
+    var connectors = response.getBody();
+    // Only instance2 has this connector, and it is enabled
+    assertEquals(1, connectors.size());
+    assertEquals("instance2", connectors.getFirst().runtimeId());
+    assertTrue(connectors.getFirst().enabled());
+  }
+
+  @Test
+  void shouldReturn404_whenTypeNotFoundOnAnyNode() {
+    var response =
+        restTemplate.getForEntity(
+            "http://localhost:" + port1 + "/outbound/unknown-type", String.class);
+
+    assertThat(404, equalTo(response.getStatusCode().value()));
+    assertThat(
+        response.getBody(),
+        containsString(
+            "Data of type 'OutboundConnectorResponse' with id 'unknown-type' not found"));
+  }
+}

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/outbound/OutboundConnectorsRestControllerTest.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/outbound/OutboundConnectorsRestControllerTest.java
@@ -19,7 +19,6 @@ package io.camunda.connector.runtime.outbound;
 import static org.hamcrest.Matchers.containsString;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -33,6 +32,7 @@ import io.camunda.connector.runtime.core.common.AbstractConnectorFactory.Connect
 import io.camunda.connector.runtime.core.config.OutboundConnectorConfiguration;
 import io.camunda.connector.runtime.core.outbound.OutboundConnectorFactory;
 import io.camunda.connector.runtime.outbound.controller.OutboundConnectorResponse;
+import io.camunda.connector.runtime.outbound.jobstream.GatewayConnectivityState;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -95,18 +95,20 @@ class OutboundConnectorsRestControllerTest {
     assertEquals(30000L, http.timeout());
     assertEquals("localhost", http.runtimeId());
     assertTrue(http.enabled());
+    assertEquals(GatewayConnectivityState.UNKNOWN, http.gatewayConnectivityState());
 
     var slack = connectors.stream().filter(c -> c.type().equals(TYPE_2)).findFirst().orElseThrow();
     assertEquals("Slack", slack.name());
     assertEquals(List.of("channel", "message"), slack.inputVariables());
-    assertNull(slack.timeout());
     assertEquals("localhost", slack.runtimeId());
     assertTrue(slack.enabled());
+    assertEquals(GatewayConnectivityState.UNKNOWN, slack.gatewayConnectivityState());
 
     var disabled =
         connectors.stream().filter(c -> c.type().equals(TYPE_DISABLED)).findFirst().orElseThrow();
     assertEquals("Disabled Connector", disabled.name());
     assertFalse(disabled.enabled());
+    assertEquals(GatewayConnectivityState.UNKNOWN, disabled.gatewayConnectivityState());
   }
 
   @Test

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/outbound/OutboundConnectorsRestControllerTest.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/outbound/OutboundConnectorsRestControllerTest.java
@@ -53,7 +53,6 @@ class OutboundConnectorsRestControllerTest {
   private static final String TYPE_1 = "io.camunda:http-json:1";
   private static final String TYPE_2 = "io.camunda:slack:1";
   private static final String TYPE_DISABLED = "io.camunda:disabled-connector:1";
-  private static final String LOCALHOST = "localhost";
 
   @BeforeEach
   void init() {

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/outbound/OutboundConnectorsRestControllerTest.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/outbound/OutboundConnectorsRestControllerTest.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.runtime.outbound;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import io.camunda.connector.jackson.ConnectorsObjectMapperSupplier;
+import io.camunda.connector.runtime.app.TestConnectorRuntimeApplication;
+import io.camunda.connector.runtime.core.common.AbstractConnectorFactory.ConnectorRuntimeConfiguration;
+import io.camunda.connector.runtime.core.config.OutboundConnectorConfiguration;
+import io.camunda.connector.runtime.core.outbound.OutboundConnectorFactory;
+import io.camunda.connector.runtime.outbound.controller.OutboundConnectorResponse;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest(classes = TestConnectorRuntimeApplication.class)
+@AutoConfigureMockMvc
+class OutboundConnectorsRestControllerTest {
+
+  @Autowired private MockMvc mockMvc;
+
+  @MockitoBean private OutboundConnectorFactory connectorFactory;
+
+  private static final String TYPE_1 = "io.camunda:http-json:1";
+  private static final String TYPE_2 = "io.camunda:slack:1";
+  private static final String TYPE_DISABLED = "io.camunda:disabled-connector:1";
+  private static final String LOCALHOST = "localhost";
+
+  @BeforeEach
+  void init() {
+    when(connectorFactory.getRuntimeConfigurations())
+        .thenReturn(
+            List.of(
+                new ConnectorRuntimeConfiguration<>(
+                    new OutboundConnectorConfiguration(
+                        "HTTP JSON", new String[] {"method", "url"}, TYPE_1, () -> null, 30000L),
+                    true),
+                new ConnectorRuntimeConfiguration<>(
+                    new OutboundConnectorConfiguration(
+                        "Slack", new String[] {"channel", "message"}, TYPE_2, () -> null, null),
+                    true),
+                new ConnectorRuntimeConfiguration<>(
+                    new OutboundConnectorConfiguration(
+                        "Disabled Connector", new String[] {}, TYPE_DISABLED, () -> null, null),
+                    false)));
+  }
+
+  @Test
+  void shouldReturnAllOutboundConnectors() throws Exception {
+    var response =
+        mockMvc
+            .perform(get("/outbound"))
+            .andExpect(status().isOk())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+
+    List<OutboundConnectorResponse> connectors =
+        ConnectorsObjectMapperSupplier.getCopy().readValue(response, new TypeReference<>() {});
+
+    assertEquals(3, connectors.size());
+
+    var http = connectors.stream().filter(c -> c.type().equals(TYPE_1)).findFirst().orElseThrow();
+    assertEquals("HTTP JSON", http.name());
+    assertEquals(List.of("method", "url"), http.inputVariables());
+    assertEquals(30000L, http.timeout());
+    assertEquals("localhost", http.runtimeId());
+    assertTrue(http.enabled());
+
+    var slack = connectors.stream().filter(c -> c.type().equals(TYPE_2)).findFirst().orElseThrow();
+    assertEquals("Slack", slack.name());
+    assertEquals(List.of("channel", "message"), slack.inputVariables());
+    assertNull(slack.timeout());
+    assertEquals("localhost", slack.runtimeId());
+    assertTrue(slack.enabled());
+
+    var disabled =
+        connectors.stream().filter(c -> c.type().equals(TYPE_DISABLED)).findFirst().orElseThrow();
+    assertEquals("Disabled Connector", disabled.name());
+    assertFalse(disabled.enabled());
+  }
+
+  @Test
+  void shouldReturnConnectorByType() throws Exception {
+    var response =
+        mockMvc
+            .perform(get("/outbound/" + TYPE_1))
+            .andExpect(status().isOk())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+
+    List<OutboundConnectorResponse> connectors =
+        ConnectorsObjectMapperSupplier.getCopy().readValue(response, new TypeReference<>() {});
+
+    assertEquals(1, connectors.size());
+    assertEquals(TYPE_1, connectors.getFirst().type());
+    assertEquals("HTTP JSON", connectors.getFirst().name());
+    assertTrue(connectors.getFirst().enabled());
+  }
+
+  @Test
+  void shouldReturnDisabledConnector_whenQueriedByType() throws Exception {
+    var response =
+        mockMvc
+            .perform(get("/outbound/" + TYPE_DISABLED))
+            .andExpect(status().isOk())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+
+    List<OutboundConnectorResponse> connectors =
+        ConnectorsObjectMapperSupplier.getCopy().readValue(response, new TypeReference<>() {});
+
+    assertEquals(1, connectors.size());
+    assertFalse(connectors.getFirst().enabled());
+  }
+
+  @Test
+  void shouldReturn404_whenUnknownType() throws Exception {
+    mockMvc
+        .perform(get("/outbound/unknown-type"))
+        .andExpect(status().isNotFound())
+        .andExpect(
+            content()
+                .string(
+                    containsString(
+                        "Data of type 'OutboundConnectorResponse' with id 'unknown-type' not found")));
+  }
+}

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/outbound/SpringBasedOutboundConnectorTest.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/outbound/SpringBasedOutboundConnectorTest.java
@@ -36,7 +36,7 @@ public class SpringBasedOutboundConnectorTest {
   @Test
   void springBasedConnectorPresent() throws Exception {
     var connectorConfig =
-        outboundConnectorFactory.getConfigurations().stream()
+        outboundConnectorFactory.getActiveConfigurations().stream()
             .filter(c -> c.name().equals("TEST_SPRING"))
             .findFirst()
             .get();


### PR DESCRIPTION

 ## Add `/outbound` endpoint to expose outbound connector state

  ### Summary

  - Adds `GET /outbound` and `GET /outbound/{type}` endpoints to the connector runtime, mirroring the existing `/inbound` API
  - Each entry reports connector metadata (name, job type, input variables, timeout, enabled state) enriched with live job-stream connectivity observed from the Zeebe gateway and broker actuators
  - Supports multi-instance deployments via the same `X-Camunda-Forwarded-For` forwarding and reduction pattern used by inbound endpoints

  ### API structure

  `GET /outbound` returns a list of `OutboundConnectorResponse`:

  ```json
  [
    {
      "name": "HTTP REST",
      "type": "io.camunda:http-json:1",
      "inputVariables": ["url", "method", "headers"],
      "timeout": 300000,
      "enabled": true,
      "runtimeId": "pod-abc123",
      "gatewayConnectivityState": "CONNECTED",
      "brokerConnectivityState": "ALL_CONNECTED",
      "streamIds": ["stream-1a2b"]
    }
  ]
  ```

  **`gatewayConnectivityState`** (always present when a `GatewayJobStreamClient` bean is configured):

  | Value | Meaning |
  |---|---|
  | `UNKNOWN` | No `GatewayJobStreamClient` configured — stream state cannot be determined |
  | `UNREACHABLE` | Gateway monitoring endpoint is down or returned an error |
  | `NOT_CONNECTED` | Gateway is reachable but no client stream exists for this job type |
  | `CONNECTED` | Client stream registered on the gateway — see `brokerConnectivityState` |

  **`brokerConnectivityState`** (only present when `gatewayConnectivityState` is `CONNECTED`):

  | Value | Meaning |
  |---|---|
  | `NONE` | No broker has this connector's stream as a consumer |
  | `PARTIALLY_CONNECTED` | Stream exists on the gateway but not propagated to all brokers |
  | `ALL_CONNECTED` | Stream is visible as a consumer on all broker remote streams |

  > `gatewayConnectivityState`, `brokerConnectivityState`, and `streamIds` are omitted when no `GatewayJobStreamClient` is configured, keeping the response backward-compatible for runtimes that don't expose the gateway actuator.

  ### Test plan

  - [x] `GET /outbound` returns all registered connectors
  - [x] `GET /outbound/{type}` returns matching connectors; 404 when type is unknown
  - [x] `gatewayConnectivityState` / `brokerConnectivityState` are omitted when no gateway client is configured
  - [x] Multi-instance: responses are correctly forwarded and reduced across runtime pods

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #

## Checklist

- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest
  release, as this branch will be rebased onto main before the next release. Example backport labels:
    - `backport stable/8.8`: for changes that should be included in the next 8.8.x release.
    - **or** `backport release-8.8.7`: for changes that should be included in the specific release 8.8.7, and this
      *release has already been created*. The release branch will be merged back into stable/8.8 later, so the change
      will be included in future 8.8.x releases as well.
- [ ] Tests/Integration tests for the changes have been added if applicable.
- [ ] If the change requires a documentation update, it has been added to the appropriate section in the documentation.


