### PR TITLE
feat: update Camunda Client API to 8.10 and support job completion listeners

### DIFF
--- a/bundle/camunda-saas-bundle/src/test/java/io/camunda/connector/runtime/saas/InboundInstancesSecurityConfigurationTest.java
+++ b/bundle/camunda-saas-bundle/src/test/java/io/camunda/connector/runtime/saas/InboundInstancesSecurityConfigurationTest.java
@@ -24,6 +24,7 @@ import io.camunda.connector.test.utils.annotation.SlowTest;
 import io.camunda.connector.test.utils.oidc.MockOidcServer;
 import io.camunda.process.test.api.CamundaSpringProcessTest;
 import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.mockito.Answers;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -66,6 +67,15 @@ public class InboundInstancesSecurityConfigurationTest {
   static void registerOidcProperties(DynamicPropertyRegistry registry) {
     registry.add("camunda.connector.auth.issuer", OIDC_SERVER::issuer);
     registry.add("camunda.client.auth.token-url", OIDC_SERVER::tokenUrl);
+  }
+
+  @BeforeAll
+  static void beforeAll() {
+    OIDC_SERVER.stubTokenResponse(
+        200,
+        """
+        {"access_token":"test-token","token_type":"Bearer","expires_in":3600}
+        """);
   }
 
   @AfterAll

--- a/bundle/camunda-saas-bundle/src/test/java/io/camunda/connector/runtime/saas/SecurityConfigurationTest.java
+++ b/bundle/camunda-saas-bundle/src/test/java/io/camunda/connector/runtime/saas/SecurityConfigurationTest.java
@@ -32,6 +32,7 @@ import io.camunda.connector.test.utils.oidc.MockOidcServer;
 import io.camunda.process.test.api.CamundaSpringProcessTest;
 import java.time.Duration;
 import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.mockito.Answers;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -73,6 +74,15 @@ public class SecurityConfigurationTest {
   static void registerOidcProperties(DynamicPropertyRegistry registry) {
     registry.add("camunda.connector.auth.issuer", OIDC_SERVER::issuer);
     registry.add("camunda.client.auth.token-url", OIDC_SERVER::tokenUrl);
+  }
+
+  @BeforeAll
+  static void beforeAll() {
+    OIDC_SERVER.stubTokenResponse(
+        200,
+        """
+        {"access_token":"test-token","token_type":"Bearer","expires_in":3600}
+        """);
   }
 
   @AfterAll

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/OutboundConnectorRuntimeConfiguration.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/OutboundConnectorRuntimeConfiguration.java
@@ -18,7 +18,7 @@ package io.camunda.connector.runtime.outbound;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.client.CamundaClient;
-import io.camunda.client.jobhandling.CommandExceptionHandlingStrategy;
+import io.camunda.client.jobhandling.JobCallbackCommandWrapperFactory;
 import io.camunda.client.jobhandling.JobWorkerManager;
 import io.camunda.client.metrics.MetricsRecorder;
 import io.camunda.connector.api.document.DocumentFactory;
@@ -104,7 +104,7 @@ public class OutboundConnectorRuntimeConfiguration {
   public OutboundConnectorManager outboundConnectorManager(
       JobWorkerManager jobWorkerManager,
       OutboundConnectorFactory connectorFactory,
-      CommandExceptionHandlingStrategy commandExceptionHandlingStrategy,
+      JobCallbackCommandWrapperFactory jobCallbackCommandWrapperFactory,
       SecretProviderAggregator secretProviderAggregator,
       ValidationProvider validationProvider,
       MetricsRecorder metricsRecorder,
@@ -113,7 +113,7 @@ public class OutboundConnectorRuntimeConfiguration {
     return new OutboundConnectorManager(
         jobWorkerManager,
         connectorFactory,
-        commandExceptionHandlingStrategy,
+        jobCallbackCommandWrapperFactory,
         secretProviderAggregator,
         validationProvider,
         documentFactory,

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/SpringConnectorJobHandler.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/SpringConnectorJobHandler.java
@@ -37,6 +37,9 @@ import io.camunda.connector.api.outbound.ConnectorResponse.AdHocSubProcessConnec
 import io.camunda.connector.api.outbound.ConnectorResponse.AdHocSubProcessConnectorResponse.ElementActivation;
 import io.camunda.connector.api.outbound.ConnectorResponse.StandardConnectorResponse;
 import io.camunda.connector.api.outbound.JobCompletionFailure;
+import io.camunda.connector.api.outbound.JobCompletionFailure.BpmnErrorThrown;
+import io.camunda.connector.api.outbound.JobCompletionFailure.CommandFailure;
+import io.camunda.connector.api.outbound.JobCompletionFailure.JobErrorRaised;
 import io.camunda.connector.api.outbound.JobCompletionListener;
 import io.camunda.connector.api.outbound.OutboundConnectorContext;
 import io.camunda.connector.api.outbound.OutboundConnectorFunction;
@@ -61,6 +64,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -205,9 +209,7 @@ public class SpringConnectorJobHandler implements JobHandler {
           () -> handleFinalResult(client, job, context, finalResult, counterMetricsContext));
     } catch (Exception ex) {
       notifyJobCompletionFailed(
-          context,
-          connectorResponseOrNull(finalResult),
-          new JobCompletionFailure.CommandFailure.CommandFailed(ex));
+          context, connectorResponseOrNull(finalResult), new CommandFailure.CommandFailed(ex));
       failJob(
           client,
           job,
@@ -233,12 +235,11 @@ public class SpringConnectorJobHandler implements JobHandler {
           JobForLog.from(job),
           errorResult.exception().getMessage(),
           errorResult.exception());
+
       // pre-response failure path: function threw before returning a response, so notify with a
       // null response (subscribers to JobCompletionListener can still react)
       notifyJobCompletionFailed(
-          context,
-          null,
-          new JobCompletionFailure.CommandFailure.CommandFailed(errorResult.exception()));
+          context, null, new CommandFailure.CommandFailed(errorResult.exception()));
       failJob(jobClient, job, errorResult, counterMetricsContext);
     }
   }
@@ -256,23 +257,21 @@ public class SpringConnectorJobHandler implements JobHandler {
       case BpmnError bpmnError -> {
         LOGGER.debug(
             "Throwing BPMN error for job {} with code {}", job.getKey(), bpmnError.errorCode());
-        var future = throwBpmnError(client, job, bpmnError, counterMetricsContext);
-        if (call instanceof JobCompletionListener) {
-          future.whenComplete(
-              (outcome, throwable) ->
-                  notifyJobCompletionFailed(
-                      context,
-                      response,
-                      new JobCompletionFailure.BpmnErrorThrown(
-                          bpmnError.errorCode(),
-                          bpmnError.errorMessage(),
-                          bpmnError.variables(),
-                          toCommandFailure(outcome, throwable))));
-        }
+        var bpmnErrorFuture = throwBpmnError(client, job, bpmnError, counterMetricsContext);
+        notifyFailureOnCommandOutcome(
+            bpmnErrorFuture,
+            context,
+            response,
+            completionFailure ->
+                new BpmnErrorThrown(
+                    bpmnError.errorCode(),
+                    bpmnError.errorMessage(),
+                    bpmnError.variables(),
+                    completionFailure));
       }
       case JobError jobError -> {
         LOGGER.debug("Throwing incident for job {}", job.getKey());
-        var future =
+        var failJobFuture =
             failJob(
                 client,
                 job,
@@ -282,52 +281,58 @@ public class SpringConnectorJobHandler implements JobHandler {
                     jobError.retries(),
                     jobError.retryBackoff()),
                 counterMetricsContext);
-        if (call instanceof JobCompletionListener) {
-          future.whenComplete(
-              (outcome, throwable) ->
-                  notifyJobCompletionFailed(
-                      context,
-                      response,
-                      new JobCompletionFailure.JobErrorRaised(
-                          jobError.errorMessage(),
-                          jobError.variablesWithErrorMessage(),
-                          toCommandFailure(outcome, throwable))));
-        }
+        notifyFailureOnCommandOutcome(
+            failJobFuture,
+            context,
+            response,
+            completionFailure ->
+                new JobErrorRaised(
+                    jobError.errorMessage(),
+                    jobError.variablesWithErrorMessage(),
+                    completionFailure));
       }
-      case IgnoreError ignoreError -> {
-        if (finalResult instanceof ConnectorResult.SuccessResult successResult
-            && successResult.connectorResponse() instanceof AdHocSubProcessConnectorResponse) {
-          LOGGER.debug(
-              "IgnoreError not supported for AdHocSubProcessConnectorResponse, job {}",
-              job.getKey());
-          var cause =
-              new UnsupportedOperationException("IgnoreError is not supported for this connector");
-          var future =
-              failJob(
-                  client,
-                  job,
-                  new ConnectorResult.ErrorResult(ignoreError.variables(), cause, 0, null),
-                  counterMetricsContext);
-          if (call instanceof JobCompletionListener) {
-            // listener-relevant failure is the IgnoreError misuse, not the failJob outcome
-            future.whenComplete(
-                (outcome, throwable) ->
-                    notifyJobCompletionFailed(
-                        context,
-                        response,
-                        new JobCompletionFailure.CommandFailure.CommandFailed(cause)));
-          }
-        } else {
-          LOGGER.debug("Ignoring error for job {}", job.getKey());
-          completeJob(
+      case IgnoreError ignoreError ->
+          handleIgnoreError(
+              client, job, context, finalResult, response, ignoreError, counterMetricsContext);
+    }
+  }
+
+  private void handleIgnoreError(
+      JobClient client,
+      ActivatedJob job,
+      OutboundConnectorContext context,
+      ConnectorResult finalResult,
+      ConnectorResponse response,
+      IgnoreError ignoreError,
+      CounterMetricsContext counterMetricsContext) {
+    if (finalResult instanceof ConnectorResult.SuccessResult successResult
+        && successResult.connectorResponse() instanceof AdHocSubProcessConnectorResponse) {
+      LOGGER.debug(
+          "IgnoreError not supported for AdHocSubProcessConnectorResponse, job {}", job.getKey());
+      var cause =
+          new UnsupportedOperationException("IgnoreError is not supported for this connector");
+      var failJobFuture =
+          failJob(
               client,
               job,
-              context,
-              new ConnectorResult.SuccessResult(
-                  StandardConnectorResponse.of(null), ignoreError.variables()),
+              new ConnectorResult.ErrorResult(ignoreError.variables(), cause, 0, null),
               counterMetricsContext);
-        }
-      }
+
+      // listener-relevant failure is the IgnoreError misuse, not the failJob outcome
+      notifyFailureOnCommandOutcome(
+          failJobFuture,
+          context,
+          response,
+          completionFailure -> new CommandFailure.CommandFailed(cause));
+    } else {
+      LOGGER.debug("Ignoring error for job {}", job.getKey());
+      completeJob(
+          client,
+          job,
+          context,
+          new ConnectorResult.SuccessResult(
+              StandardConnectorResponse.of(null), ignoreError.variables()),
+          counterMetricsContext);
     }
   }
 
@@ -417,18 +422,14 @@ public class SpringConnectorJobHandler implements JobHandler {
               prepareAdHocSubProcessCompleteJobCommand(client, job, ahsp);
         };
 
-    var future =
+    var completeJobFuture =
         jobCallbackCommandWrapperFactory
             .create(command, job.getDeadline(), counterMetricsContext, MAX_ZEEBE_COMMAND_RETRIES)
             .executeAsync();
 
-    if (call instanceof JobCompletionListener) {
-      future.whenComplete(
-          (outcome, error) ->
-              notifyJobCompletionOutcome(context, connectorResponse, outcome, error));
-    }
+    notifyOnCommandOutcome(completeJobFuture, context, connectorResponse);
 
-    return future;
+    return completeJobFuture;
   }
 
   private static JobCallbackFinalCommandStep<CompleteJobResponse> prepareCompleteJobCommand(
@@ -477,42 +478,13 @@ public class SpringConnectorJobHandler implements JobHandler {
         : null;
   }
 
-  /**
-   * Translates an internal {@link CommandOutcome} into the SDK-level {@link
-   * JobCompletionFailure.CommandFailure}. Returns {@code null} for a successful outcome so it can
-   * be embedded directly in {@link JobCompletionFailure.BpmnErrorThrown} / {@link
-   * JobCompletionFailure.JobErrorRaised}.
-   */
-  private static JobCompletionFailure.CommandFailure toCommandFailure(
-      CommandOutcome outcome, Throwable throwable) {
-    if (throwable != null) {
-      return new JobCompletionFailure.CommandFailure.CommandFailed(throwable);
-    }
-    return switch (outcome) {
-      case CommandOutcome.Completed c -> null;
-      case CommandOutcome.Failed f ->
-          new JobCompletionFailure.CommandFailure.CommandFailed(f.cause());
-      case CommandOutcome.Ignored i ->
-          new JobCompletionFailure.CommandFailure.CommandIgnored(i.cause());
-    };
-  }
-
-  private void notifyJobCompletionOutcome(
-      OutboundConnectorContext context,
-      ConnectorResponse response,
-      CommandOutcome outcome,
-      Throwable error) {
+  private void notifyJobCompleted(OutboundConnectorContext context, ConnectorResponse response) {
     if (!(call instanceof JobCompletionListener listener)) {
       return;
     }
 
     try {
-      var commandFailure = toCommandFailure(outcome, error);
-      if (commandFailure == null) {
-        listener.onJobCompleted(context, response);
-      } else {
-        listener.onJobCompletionFailed(context, response, commandFailure);
-      }
+      listener.onJobCompleted(context, response);
     } catch (Exception e) {
       LOGGER.warn("JobCompletionListener callback failed", e);
     }
@@ -529,5 +501,64 @@ public class SpringConnectorJobHandler implements JobHandler {
     } catch (Exception e) {
       LOGGER.warn("JobCompletionListener callback failed", e);
     }
+  }
+
+  /**
+   * Dispatches the listener once a Zeebe command future resolves: success → {@link
+   * #notifyJobCompleted}, failure (rejection or future exception) → {@link
+   * #notifyJobCompletionFailed} with the {@link CommandFailure} derived from the outcome.
+   *
+   * <p>Used by the {@code completeJob} path, where success and failure are both possible.
+   */
+  private void notifyOnCommandOutcome(
+      CompletableFuture<CommandOutcome> future,
+      OutboundConnectorContext context,
+      ConnectorResponse response) {
+    future.whenComplete(
+        (outcome, throwable) -> {
+          var commandFailure = toCommandFailure(outcome, throwable);
+          if (commandFailure == null) {
+            notifyJobCompleted(context, response);
+          } else {
+            notifyJobCompletionFailed(context, response, commandFailure);
+          }
+        });
+  }
+
+  /**
+   * Dispatches a {@link #notifyJobCompletionFailed} once a Zeebe command future resolves, building
+   * the failure via {@code failureBuilder} from the resolved {@link CommandFailure} (which is
+   * {@code null} when the command was accepted).
+   *
+   * <p>Used by paths that always end in failure regardless of the command outcome (BPMN error, job
+   * error, IgnoreError misuse) — the builder produces the appropriate {@link JobCompletionFailure}
+   * subtype and embeds the command outcome where applicable.
+   */
+  private void notifyFailureOnCommandOutcome(
+      CompletableFuture<CommandOutcome> future,
+      OutboundConnectorContext context,
+      ConnectorResponse response,
+      Function<CommandFailure, JobCompletionFailure> failureBuilder) {
+    future.whenComplete(
+        (outcome, throwable) ->
+            notifyJobCompletionFailed(
+                context, response, failureBuilder.apply(toCommandFailure(outcome, throwable))));
+  }
+
+  /**
+   * Translates an internal {@link CommandOutcome} into the SDK-level {@link CommandFailure}.
+   * Returns {@code null} for a successful outcome so it can be embedded directly in {@link
+   * BpmnErrorThrown} / {@link JobErrorRaised}.
+   */
+  private static CommandFailure toCommandFailure(CommandOutcome outcome, Throwable throwable) {
+    if (throwable != null) {
+      return new CommandFailure.CommandFailed(throwable);
+    }
+
+    return switch (outcome) {
+      case CommandOutcome.Completed c -> null;
+      case CommandOutcome.Failed f -> new CommandFailure.CommandFailed(f.cause());
+      case CommandOutcome.Ignored i -> new CommandFailure.CommandIgnored(i.cause());
+    };
   }
 }

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/SpringConnectorJobHandler.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/SpringConnectorJobHandler.java
@@ -207,7 +207,7 @@ public class SpringConnectorJobHandler implements JobHandler {
       notifyJobCompletionFailed(
           context,
           connectorResponseOrNull(finalResult),
-          new JobCompletionFailure.CommandFailed(ex));
+          new JobCompletionFailure.CommandFailure.CommandFailed(ex));
       failJob(
           client,
           job,
@@ -236,7 +236,9 @@ public class SpringConnectorJobHandler implements JobHandler {
       // pre-response failure path: function threw before returning a response, so notify with a
       // null response (subscribers to JobCompletionListener can still react)
       notifyJobCompletionFailed(
-          context, null, new JobCompletionFailure.CommandFailed(errorResult.exception()));
+          context,
+          null,
+          new JobCompletionFailure.CommandFailure.CommandFailed(errorResult.exception()));
       failJob(jobClient, job, errorResult, counterMetricsContext);
     }
   }
@@ -254,29 +256,43 @@ public class SpringConnectorJobHandler implements JobHandler {
       case BpmnError bpmnError -> {
         LOGGER.debug(
             "Throwing BPMN error for job {} with code {}", job.getKey(), bpmnError.errorCode());
-        notifyJobCompletionFailed(
-            context,
-            response,
-            new JobCompletionFailure.BpmnErrorThrown(
-                bpmnError.errorCode(), bpmnError.errorMessage(), bpmnError.variables()));
-        throwBpmnError(client, job, bpmnError, counterMetricsContext);
+        var future = throwBpmnError(client, job, bpmnError, counterMetricsContext);
+        if (call instanceof JobCompletionListener) {
+          future.whenComplete(
+              (outcome, throwable) ->
+                  notifyJobCompletionFailed(
+                      context,
+                      response,
+                      new JobCompletionFailure.BpmnErrorThrown(
+                          bpmnError.errorCode(),
+                          bpmnError.errorMessage(),
+                          bpmnError.variables(),
+                          toCommandFailure(outcome, throwable))));
+        }
       }
       case JobError jobError -> {
         LOGGER.debug("Throwing incident for job {}", job.getKey());
-        notifyJobCompletionFailed(
-            context,
-            response,
-            new JobCompletionFailure.JobErrorRaised(
-                jobError.errorMessage(), jobError.variablesWithErrorMessage()));
-        failJob(
-            client,
-            job,
-            new ConnectorResult.ErrorResult(
-                jobError.variablesWithErrorMessage(),
-                new RuntimeException(jobError.errorMessage()),
-                jobError.retries(),
-                jobError.retryBackoff()),
-            counterMetricsContext);
+        var future =
+            failJob(
+                client,
+                job,
+                new ConnectorResult.ErrorResult(
+                    jobError.variablesWithErrorMessage(),
+                    new RuntimeException(jobError.errorMessage()),
+                    jobError.retries(),
+                    jobError.retryBackoff()),
+                counterMetricsContext);
+        if (call instanceof JobCompletionListener) {
+          future.whenComplete(
+              (outcome, throwable) ->
+                  notifyJobCompletionFailed(
+                      context,
+                      response,
+                      new JobCompletionFailure.JobErrorRaised(
+                          jobError.errorMessage(),
+                          jobError.variablesWithErrorMessage(),
+                          toCommandFailure(outcome, throwable))));
+        }
       }
       case IgnoreError ignoreError -> {
         if (finalResult instanceof ConnectorResult.SuccessResult successResult
@@ -286,13 +302,21 @@ public class SpringConnectorJobHandler implements JobHandler {
               job.getKey());
           var cause =
               new UnsupportedOperationException("IgnoreError is not supported for this connector");
-          notifyJobCompletionFailed(
-              context, response, new JobCompletionFailure.CommandFailed(cause));
-          failJob(
-              client,
-              job,
-              new ConnectorResult.ErrorResult(ignoreError.variables(), cause, 0, null),
-              counterMetricsContext);
+          var future =
+              failJob(
+                  client,
+                  job,
+                  new ConnectorResult.ErrorResult(ignoreError.variables(), cause, 0, null),
+                  counterMetricsContext);
+          if (call instanceof JobCompletionListener) {
+            // listener-relevant failure is the IgnoreError misuse, not the failJob outcome
+            future.whenComplete(
+                (outcome, throwable) ->
+                    notifyJobCompletionFailed(
+                        context,
+                        response,
+                        new JobCompletionFailure.CommandFailure.CommandFailed(cause)));
+          }
         } else {
           LOGGER.debug("Ignoring error for job {}", job.getKey());
           completeJob(
@@ -453,6 +477,26 @@ public class SpringConnectorJobHandler implements JobHandler {
         : null;
   }
 
+  /**
+   * Translates an internal {@link CommandOutcome} into the SDK-level {@link
+   * JobCompletionFailure.CommandFailure}. Returns {@code null} for a successful outcome so it can
+   * be embedded directly in {@link JobCompletionFailure.BpmnErrorThrown} / {@link
+   * JobCompletionFailure.JobErrorRaised}.
+   */
+  private static JobCompletionFailure.CommandFailure toCommandFailure(
+      CommandOutcome outcome, Throwable throwable) {
+    if (throwable != null) {
+      return new JobCompletionFailure.CommandFailure.CommandFailed(throwable);
+    }
+    return switch (outcome) {
+      case CommandOutcome.Completed c -> null;
+      case CommandOutcome.Failed f ->
+          new JobCompletionFailure.CommandFailure.CommandFailed(f.cause());
+      case CommandOutcome.Ignored i ->
+          new JobCompletionFailure.CommandFailure.CommandIgnored(i.cause());
+    };
+  }
+
   private void notifyJobCompletionOutcome(
       OutboundConnectorContext context,
       ConnectorResponse response,
@@ -463,19 +507,11 @@ public class SpringConnectorJobHandler implements JobHandler {
     }
 
     try {
-      if (error != null) {
-        listener.onJobCompletionFailed(
-            context, response, new JobCompletionFailure.CommandFailed(error));
+      var commandFailure = toCommandFailure(outcome, error);
+      if (commandFailure == null) {
+        listener.onJobCompleted(context, response);
       } else {
-        switch (outcome) {
-          case CommandOutcome.Completed c -> listener.onJobCompleted(context, response);
-          case CommandOutcome.Failed f ->
-              listener.onJobCompletionFailed(
-                  context, response, new JobCompletionFailure.CommandFailed(f.cause()));
-          case CommandOutcome.Ignored i ->
-              listener.onJobCompletionFailed(
-                  context, response, new JobCompletionFailure.CommandIgnored(i.cause()));
-        }
+        listener.onJobCompletionFailed(context, response, commandFailure);
       }
     } catch (Exception e) {
       LOGGER.warn("JobCompletionListener callback failed", e);

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/SpringConnectorJobHandler.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/SpringConnectorJobHandler.java
@@ -55,7 +55,6 @@ import io.camunda.connector.runtime.core.outbound.JobHandlerContext;
 import io.camunda.connector.runtime.core.secret.SecretProviderAggregator;
 import io.camunda.connector.runtime.core.secret.SecretProviderDiscovery;
 import io.camunda.connector.runtime.metrics.ConnectorMetrics;
-import jakarta.annotation.Nullable;
 import java.time.Duration;
 import java.time.format.DateTimeParseException;
 import java.util.List;
@@ -146,17 +145,17 @@ public class SpringConnectorJobHandler implements JobHandler {
         job.getKey(),
         job.getType(),
         job.getTenantId());
-    ConnectorResult result = getConnectorResult(job);
-    processFinalResult(client, job, result, counterMetricsContext);
+    var context =
+        new JobHandlerContext(
+            job, getSecretProvider(), validationProvider, documentFactory, objectMapper);
+    ConnectorResult result = getConnectorResult(job, context);
+    processFinalResult(client, job, context, result, counterMetricsContext);
   }
 
-  private ConnectorResult getConnectorResult(ActivatedJob job) {
+  private ConnectorResult getConnectorResult(ActivatedJob job, OutboundConnectorContext context) {
     Duration retryBackoff = null;
     try {
       retryBackoff = getBackoffDuration(job);
-      var context =
-          new JobHandlerContext(
-              job, getSecretProvider(), validationProvider, documentFactory, objectMapper);
 
       var connectorResponse = getConnectorResponse(context);
 
@@ -190,6 +189,7 @@ public class SpringConnectorJobHandler implements JobHandler {
   private void processFinalResult(
       JobClient client,
       ActivatedJob job,
+      OutboundConnectorContext context,
       ConnectorResult finalResult,
       CounterMetricsContext counterMetricsContext) {
     try {
@@ -200,11 +200,14 @@ public class SpringConnectorJobHandler implements JobHandler {
               new ErrorExpressionJobContext(
                   new ErrorExpressionJobContext.ErrorExpressionJob(job.getRetries())));
       optionalConnectorError.ifPresentOrElse(
-          error -> handleConnectorError(client, job, finalResult, error, counterMetricsContext),
-          () -> handleFinalResult(client, job, finalResult, counterMetricsContext));
+          error ->
+              handleConnectorError(client, job, context, finalResult, error, counterMetricsContext),
+          () -> handleFinalResult(client, job, context, finalResult, counterMetricsContext));
     } catch (Exception ex) {
       notifyJobCompletionFailed(
-          extractJobCompletionListener(finalResult), new JobCompletionFailure.CommandFailed(ex));
+          context,
+          connectorResponseOrNull(finalResult),
+          new JobCompletionFailure.CommandFailed(ex));
       failJob(
           client,
           job,
@@ -216,16 +219,12 @@ public class SpringConnectorJobHandler implements JobHandler {
   private void handleFinalResult(
       JobClient jobClient,
       ActivatedJob job,
+      OutboundConnectorContext context,
       ConnectorResult finalResult,
       CounterMetricsContext counterMetricsContext) {
     if (finalResult instanceof ConnectorResult.SuccessResult successResult) {
       LOGGER.info("Completing job: {} for tenant: {}", job.getKey(), job.getTenantId());
-      completeJob(
-          jobClient,
-          job,
-          successResult,
-          extractJobCompletionListener(finalResult),
-          counterMetricsContext);
+      completeJob(jobClient, job, context, successResult, counterMetricsContext);
     } else if (finalResult instanceof ConnectorResult.ErrorResult errorResult) {
       // Handle Java error, e.g. ConnectorException
       // these errors won't be handled ConnectorHelper.examineErrorExpression
@@ -234,6 +233,10 @@ public class SpringConnectorJobHandler implements JobHandler {
           JobForLog.from(job),
           errorResult.exception().getMessage(),
           errorResult.exception());
+      // pre-response failure path: function threw before returning a response, so notify with a
+      // null response (subscribers to JobCompletionListener can still react)
+      notifyJobCompletionFailed(
+          context, null, new JobCompletionFailure.CommandFailed(errorResult.exception()));
       failJob(jobClient, job, errorResult, counterMetricsContext);
     }
   }
@@ -241,17 +244,19 @@ public class SpringConnectorJobHandler implements JobHandler {
   private void handleConnectorError(
       JobClient client,
       ActivatedJob job,
+      OutboundConnectorContext context,
       ConnectorResult finalResult,
       ConnectorError error,
       CounterMetricsContext counterMetricsContext) {
-    var listener = extractJobCompletionListener(finalResult);
+    var response = connectorResponseOrNull(finalResult);
 
     switch (error) {
       case BpmnError bpmnError -> {
         LOGGER.debug(
             "Throwing BPMN error for job {} with code {}", job.getKey(), bpmnError.errorCode());
         notifyJobCompletionFailed(
-            listener,
+            context,
+            response,
             new JobCompletionFailure.BpmnErrorThrown(
                 bpmnError.errorCode(), bpmnError.errorMessage(), bpmnError.variables()));
         throwBpmnError(client, job, bpmnError, counterMetricsContext);
@@ -259,7 +264,8 @@ public class SpringConnectorJobHandler implements JobHandler {
       case JobError jobError -> {
         LOGGER.debug("Throwing incident for job {}", job.getKey());
         notifyJobCompletionFailed(
-            listener,
+            context,
+            response,
             new JobCompletionFailure.JobErrorRaised(
                 jobError.errorMessage(), jobError.variablesWithErrorMessage()));
         failJob(
@@ -280,7 +286,8 @@ public class SpringConnectorJobHandler implements JobHandler {
               job.getKey());
           var cause =
               new UnsupportedOperationException("IgnoreError is not supported for this connector");
-          notifyJobCompletionFailed(listener, new JobCompletionFailure.CommandFailed(cause));
+          notifyJobCompletionFailed(
+              context, response, new JobCompletionFailure.CommandFailed(cause));
           failJob(
               client,
               job,
@@ -291,9 +298,9 @@ public class SpringConnectorJobHandler implements JobHandler {
           completeJob(
               client,
               job,
+              context,
               new ConnectorResult.SuccessResult(
                   StandardConnectorResponse.of(null), ignoreError.variables()),
-              listener,
               counterMetricsContext);
         }
       }
@@ -374,8 +381,8 @@ public class SpringConnectorJobHandler implements JobHandler {
   private CompletableFuture<CommandOutcome> completeJob(
       JobClient client,
       ActivatedJob job,
+      OutboundConnectorContext context,
       ConnectorResult.SuccessResult result,
-      @Nullable JobCompletionListener listener,
       CounterMetricsContext counterMetricsContext) {
     ConnectorResponse connectorResponse = result.connectorResponse();
 
@@ -391,8 +398,10 @@ public class SpringConnectorJobHandler implements JobHandler {
             .create(command, job.getDeadline(), counterMetricsContext, MAX_ZEEBE_COMMAND_RETRIES)
             .executeAsync();
 
-    if (listener != null) {
-      future.whenComplete((outcome, error) -> notifyJobCompletionOutcome(listener, outcome, error));
+    if (call instanceof JobCompletionListener) {
+      future.whenComplete(
+          (outcome, error) ->
+              notifyJobCompletionOutcome(context, connectorResponse, outcome, error));
     }
 
     return future;
@@ -438,26 +447,34 @@ public class SpringConnectorJobHandler implements JobHandler {
         : null;
   }
 
-  private static JobCompletionListener extractJobCompletionListener(ConnectorResult result) {
-    if (result instanceof ConnectorResult.SuccessResult successResult
-        && successResult.connectorResponse() instanceof JobCompletionListener listener) {
-      return listener;
-    }
-    return null;
+  private static ConnectorResponse connectorResponseOrNull(ConnectorResult result) {
+    return result instanceof ConnectorResult.SuccessResult successResult
+        ? successResult.connectorResponse()
+        : null;
   }
 
-  private static void notifyJobCompletionOutcome(
-      JobCompletionListener listener, CommandOutcome outcome, Throwable error) {
+  private void notifyJobCompletionOutcome(
+      OutboundConnectorContext context,
+      ConnectorResponse response,
+      CommandOutcome outcome,
+      Throwable error) {
+    if (!(call instanceof JobCompletionListener listener)) {
+      return;
+    }
+
     try {
       if (error != null) {
-        listener.onJobCompletionFailed(new JobCompletionFailure.CommandFailed(error));
+        listener.onJobCompletionFailed(
+            context, response, new JobCompletionFailure.CommandFailed(error));
       } else {
         switch (outcome) {
-          case CommandOutcome.Completed c -> listener.onJobCompleted();
+          case CommandOutcome.Completed c -> listener.onJobCompleted(context, response);
           case CommandOutcome.Failed f ->
-              listener.onJobCompletionFailed(new JobCompletionFailure.CommandFailed(f.cause()));
+              listener.onJobCompletionFailed(
+                  context, response, new JobCompletionFailure.CommandFailed(f.cause()));
           case CommandOutcome.Ignored i ->
-              listener.onJobCompletionFailed(new JobCompletionFailure.CommandIgnored(i.cause()));
+              listener.onJobCompletionFailed(
+                  context, response, new JobCompletionFailure.CommandIgnored(i.cause()));
         }
       }
     } catch (Exception e) {
@@ -465,13 +482,14 @@ public class SpringConnectorJobHandler implements JobHandler {
     }
   }
 
-  private static void notifyJobCompletionFailed(
-      JobCompletionListener listener, JobCompletionFailure failure) {
-    if (listener == null) {
+  private void notifyJobCompletionFailed(
+      OutboundConnectorContext context, ConnectorResponse response, JobCompletionFailure failure) {
+    if (!(call instanceof JobCompletionListener listener)) {
       return;
     }
+
     try {
-      listener.onJobCompletionFailed(failure);
+      listener.onJobCompletionFailed(context, response, failure);
     } catch (Exception e) {
       LOGGER.warn("JobCompletionListener callback failed", e);
     }

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/SpringConnectorJobHandler.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/SpringConnectorJobHandler.java
@@ -19,15 +19,15 @@ package io.camunda.connector.runtime.outbound.job;
 import static java.util.Objects.requireNonNullElse;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.camunda.client.api.command.FinalCommandStep;
+import io.camunda.client.api.command.JobCallbackFinalCommandStep;
 import io.camunda.client.api.response.ActivatedJob;
 import io.camunda.client.api.response.CompleteJobResponse;
 import io.camunda.client.api.response.FailJobResponse;
 import io.camunda.client.api.response.ThrowErrorResponse;
 import io.camunda.client.api.worker.JobClient;
 import io.camunda.client.api.worker.JobHandler;
-import io.camunda.client.jobhandling.CommandExceptionHandlingStrategy;
-import io.camunda.client.jobhandling.CommandWrapper;
+import io.camunda.client.jobhandling.CommandOutcome;
+import io.camunda.client.jobhandling.JobCallbackCommandWrapperFactory;
 import io.camunda.client.metrics.MetricsRecorder;
 import io.camunda.client.metrics.MetricsRecorder.CounterMetricsContext;
 import io.camunda.client.metrics.MetricsRecorder.TimerMetricsContext;
@@ -58,6 +58,7 @@ import java.time.format.DateTimeParseException;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -72,7 +73,7 @@ public class SpringConnectorJobHandler implements JobHandler {
   private static final Logger LOGGER = LoggerFactory.getLogger(SpringConnectorJobHandler.class);
   private static final int MAX_ZEEBE_COMMAND_RETRIES = 3;
   private final OutboundConnectorFunction call;
-  private final CommandExceptionHandlingStrategy commandExceptionHandlingStrategy;
+  private final JobCallbackCommandWrapperFactory jobCallbackCommandWrapperFactory;
   private final MetricsRecorder connectorsOutboundMetrics;
   private final OutboundConnectorExceptionHandler outboundConnectorExceptionHandler;
   private final ConnectorResultHandler connectorResultHandler;
@@ -83,7 +84,7 @@ public class SpringConnectorJobHandler implements JobHandler {
 
   public SpringConnectorJobHandler(
       MetricsRecorder outboundMetrics,
-      CommandExceptionHandlingStrategy commandExceptionHandlingStrategy,
+      JobCallbackCommandWrapperFactory jobCallbackCommandWrapperFactory,
       SecretProviderAggregator secretProviderAggregator,
       ValidationProvider validationProvider,
       DocumentFactory documentFactory,
@@ -97,7 +98,7 @@ public class SpringConnectorJobHandler implements JobHandler {
     this.outboundConnectorExceptionHandler =
         new OutboundConnectorExceptionHandler(getSecretProvider());
     this.connectorResultHandler = new ConnectorResultHandler(objectMapper);
-    this.commandExceptionHandlingStrategy = commandExceptionHandlingStrategy;
+    this.jobCallbackCommandWrapperFactory = jobCallbackCommandWrapperFactory;
     this.connectorsOutboundMetrics = outboundMetrics;
   }
 
@@ -296,23 +297,18 @@ public class SpringConnectorJobHandler implements JobHandler {
     }
   }
 
-  private void failJob(
+  private CompletableFuture<CommandOutcome> failJob(
       JobClient client,
       ActivatedJob job,
       ConnectorResult.ErrorResult result,
       CounterMetricsContext counterMetricsContext) {
-    FinalCommandStep<FailJobResponse> commandStep = prepareFailJobCommand(client, job, result);
-    new CommandWrapper(
-            commandStep,
-            job,
-            commandExceptionHandlingStrategy,
-            connectorsOutboundMetrics,
-            counterMetricsContext,
-            MAX_ZEEBE_COMMAND_RETRIES)
+    final var command = prepareFailJobCommand(client, job, result);
+    return jobCallbackCommandWrapperFactory
+        .create(command, job.getDeadline(), counterMetricsContext, MAX_ZEEBE_COMMAND_RETRIES)
         .executeAsync();
   }
 
-  private static FinalCommandStep<FailJobResponse> prepareFailJobCommand(
+  private static JobCallbackFinalCommandStep<FailJobResponse> prepareFailJobCommand(
       JobClient client, ActivatedJob job, ConnectorResult.ErrorResult result) {
     var retries = result.retries();
     var baseMessage = result.exception().getMessage();
@@ -334,24 +330,18 @@ public class SpringConnectorJobHandler implements JobHandler {
     return command;
   }
 
-  private void throwBpmnError(
+  private CompletableFuture<CommandOutcome> throwBpmnError(
       JobClient client,
       ActivatedJob job,
       BpmnError value,
       CounterMetricsContext counterMetricsContext) {
-    FinalCommandStep<ThrowErrorResponse> commandStep =
-        prepareThrowBpmnErrorCommand(client, job, value);
-    new CommandWrapper(
-            commandStep,
-            job,
-            commandExceptionHandlingStrategy,
-            connectorsOutboundMetrics,
-            counterMetricsContext,
-            MAX_ZEEBE_COMMAND_RETRIES)
+    final var command = prepareThrowBpmnErrorCommand(client, job, value);
+    return jobCallbackCommandWrapperFactory
+        .create(command, job.getDeadline(), counterMetricsContext, MAX_ZEEBE_COMMAND_RETRIES)
         .executeAsync();
   }
 
-  private static FinalCommandStep<ThrowErrorResponse> prepareThrowBpmnErrorCommand(
+  private static JobCallbackFinalCommandStep<ThrowErrorResponse> prepareThrowBpmnErrorCommand(
       JobClient client, ActivatedJob job, BpmnError error) {
     var command =
         client.newThrowErrorCommand(job).errorCode(error.errorCode()).variables(error.variables());
@@ -362,37 +352,33 @@ public class SpringConnectorJobHandler implements JobHandler {
     return command;
   }
 
-  private void completeJob(
+  private CompletableFuture<CommandOutcome> completeJob(
       JobClient client,
       ActivatedJob job,
       ConnectorResult.SuccessResult result,
       CounterMetricsContext counterMetricsContext) {
     ConnectorResponse connectorResponse = result.connectorResponse();
 
-    FinalCommandStep<CompleteJobResponse> commandStep =
+    final var command =
         switch (connectorResponse) {
           case StandardConnectorResponse ignored -> prepareCompleteJobCommand(client, job, result);
           case AdHocSubProcessConnectorResponse ahsp ->
               prepareAdHocSubProcessCompleteJobCommand(client, job, ahsp);
         };
 
-    new CommandWrapper(
-            commandStep,
-            job,
-            commandExceptionHandlingStrategy,
-            connectorsOutboundMetrics,
-            counterMetricsContext,
-            MAX_ZEEBE_COMMAND_RETRIES)
+    return jobCallbackCommandWrapperFactory
+        .create(command, job.getDeadline(), counterMetricsContext, MAX_ZEEBE_COMMAND_RETRIES)
         .executeAsync();
   }
 
-  private static FinalCommandStep<CompleteJobResponse> prepareCompleteJobCommand(
+  private static JobCallbackFinalCommandStep<CompleteJobResponse> prepareCompleteJobCommand(
       JobClient client, ActivatedJob job, ConnectorResult.SuccessResult result) {
     return client.newCompleteCommand(job).variables(result.variables());
   }
 
-  private static FinalCommandStep<CompleteJobResponse> prepareAdHocSubProcessCompleteJobCommand(
-      JobClient client, ActivatedJob job, AdHocSubProcessConnectorResponse connectorResponse) {
+  private static JobCallbackFinalCommandStep<CompleteJobResponse>
+      prepareAdHocSubProcessCompleteJobCommand(
+          JobClient client, ActivatedJob job, AdHocSubProcessConnectorResponse connectorResponse) {
     Map<String, Object> variables = requireNonNullElse(connectorResponse.variables(), Map.of());
     return client
         .newCompleteCommand(job)

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/SpringConnectorJobHandler.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/SpringConnectorJobHandler.java
@@ -39,6 +39,7 @@ import io.camunda.connector.api.outbound.ConnectorResponse.StandardConnectorResp
 import io.camunda.connector.api.outbound.JobCompletionFailure;
 import io.camunda.connector.api.outbound.JobCompletionFailure.BpmnErrorThrown;
 import io.camunda.connector.api.outbound.JobCompletionFailure.CommandFailure;
+import io.camunda.connector.api.outbound.JobCompletionFailure.ExecutionFailed;
 import io.camunda.connector.api.outbound.JobCompletionFailure.JobErrorRaised;
 import io.camunda.connector.api.outbound.JobCompletionListener;
 import io.camunda.connector.api.outbound.OutboundConnectorContext;
@@ -208,13 +209,17 @@ public class SpringConnectorJobHandler implements JobHandler {
               handleConnectorError(client, job, context, finalResult, error, counterMetricsContext),
           () -> handleFinalResult(client, job, context, finalResult, counterMetricsContext));
     } catch (Exception ex) {
-      notifyJobCompletionFailed(
-          context, connectorResponseOrNull(finalResult), new CommandFailure.CommandFailed(ex));
-      failJob(
-          client,
-          job,
-          this.outboundConnectorExceptionHandler.handleFinalResultException(ex, job),
-          counterMetricsContext);
+      var failJobFuture =
+          failJob(
+              client,
+              job,
+              this.outboundConnectorExceptionHandler.handleFinalResultException(ex, job),
+              counterMetricsContext);
+      notifyFailureOnCommandOutcome(
+          failJobFuture,
+          context,
+          connectorResponseOrNull(finalResult),
+          completionFailure -> new ExecutionFailed(ex, completionFailure));
     }
   }
 
@@ -238,9 +243,12 @@ public class SpringConnectorJobHandler implements JobHandler {
 
       // pre-response failure path: function threw before returning a response, so notify with a
       // null response (subscribers to JobCompletionListener can still react)
-      notifyJobCompletionFailed(
-          context, null, new CommandFailure.CommandFailed(errorResult.exception()));
-      failJob(jobClient, job, errorResult, counterMetricsContext);
+      var failJobFuture = failJob(jobClient, job, errorResult, counterMetricsContext);
+      notifyFailureOnCommandOutcome(
+          failJobFuture,
+          context,
+          null,
+          completionFailure -> new ExecutionFailed(errorResult.exception(), completionFailure));
     }
   }
 
@@ -318,12 +326,11 @@ public class SpringConnectorJobHandler implements JobHandler {
               new ConnectorResult.ErrorResult(ignoreError.variables(), cause, 0, null),
               counterMetricsContext);
 
-      // listener-relevant failure is the IgnoreError misuse, not the failJob outcome
       notifyFailureOnCommandOutcome(
           failJobFuture,
           context,
           response,
-          completionFailure -> new CommandFailure.CommandFailed(cause));
+          completionFailure -> new ExecutionFailed(cause, completionFailure));
     } else {
       LOGGER.debug("Ignoring error for job {}", job.getKey());
       completeJob(
@@ -427,7 +434,15 @@ public class SpringConnectorJobHandler implements JobHandler {
             .create(command, job.getDeadline(), counterMetricsContext, MAX_ZEEBE_COMMAND_RETRIES)
             .executeAsync();
 
-    notifyOnCommandOutcome(completeJobFuture, context, connectorResponse);
+    completeJobFuture.whenComplete(
+        (outcome, throwable) -> {
+          var commandFailure = commandFailureOrNull(outcome, throwable);
+          if (commandFailure == null) {
+            notifyJobCompleted(context, connectorResponse);
+          } else {
+            notifyJobCompletionFailed(context, connectorResponse, commandFailure);
+          }
+        });
 
     return completeJobFuture;
   }
@@ -472,10 +487,24 @@ public class SpringConnectorJobHandler implements JobHandler {
         : null;
   }
 
-  private static ConnectorResponse connectorResponseOrNull(ConnectorResult result) {
-    return result instanceof ConnectorResult.SuccessResult successResult
-        ? successResult.connectorResponse()
-        : null;
+  /**
+   * Dispatches a {@link #notifyJobCompletionFailed} once a Zeebe command future resolves, building
+   * the failure via {@code failureBuilder} from the resolved {@link CommandFailure} (which is
+   * {@code null} when the command was accepted).
+   *
+   * <p>Used by paths that always end in failure regardless of the command outcome (BPMN error, job
+   * error, IgnoreError misuse) — the builder produces the appropriate {@link JobCompletionFailure}
+   * subtype and embeds the command outcome where applicable.
+   */
+  private void notifyFailureOnCommandOutcome(
+      CompletableFuture<CommandOutcome> future,
+      OutboundConnectorContext context,
+      ConnectorResponse response,
+      Function<CommandFailure, JobCompletionFailure> failureBuilder) {
+    future.whenComplete(
+        (outcome, throwable) ->
+            notifyJobCompletionFailed(
+                context, response, failureBuilder.apply(commandFailureOrNull(outcome, throwable))));
   }
 
   private void notifyJobCompleted(OutboundConnectorContext context, ConnectorResponse response) {
@@ -503,54 +532,19 @@ public class SpringConnectorJobHandler implements JobHandler {
     }
   }
 
-  /**
-   * Dispatches the listener once a Zeebe command future resolves: success → {@link
-   * #notifyJobCompleted}, failure (rejection or future exception) → {@link
-   * #notifyJobCompletionFailed} with the {@link CommandFailure} derived from the outcome.
-   *
-   * <p>Used by the {@code completeJob} path, where success and failure are both possible.
-   */
-  private void notifyOnCommandOutcome(
-      CompletableFuture<CommandOutcome> future,
-      OutboundConnectorContext context,
-      ConnectorResponse response) {
-    future.whenComplete(
-        (outcome, throwable) -> {
-          var commandFailure = toCommandFailure(outcome, throwable);
-          if (commandFailure == null) {
-            notifyJobCompleted(context, response);
-          } else {
-            notifyJobCompletionFailed(context, response, commandFailure);
-          }
-        });
-  }
-
-  /**
-   * Dispatches a {@link #notifyJobCompletionFailed} once a Zeebe command future resolves, building
-   * the failure via {@code failureBuilder} from the resolved {@link CommandFailure} (which is
-   * {@code null} when the command was accepted).
-   *
-   * <p>Used by paths that always end in failure regardless of the command outcome (BPMN error, job
-   * error, IgnoreError misuse) — the builder produces the appropriate {@link JobCompletionFailure}
-   * subtype and embeds the command outcome where applicable.
-   */
-  private void notifyFailureOnCommandOutcome(
-      CompletableFuture<CommandOutcome> future,
-      OutboundConnectorContext context,
-      ConnectorResponse response,
-      Function<CommandFailure, JobCompletionFailure> failureBuilder) {
-    future.whenComplete(
-        (outcome, throwable) ->
-            notifyJobCompletionFailed(
-                context, response, failureBuilder.apply(toCommandFailure(outcome, throwable))));
+  private static ConnectorResponse connectorResponseOrNull(ConnectorResult result) {
+    return result instanceof ConnectorResult.SuccessResult successResult
+        ? successResult.connectorResponse()
+        : null;
   }
 
   /**
    * Translates an internal {@link CommandOutcome} into the SDK-level {@link CommandFailure}.
-   * Returns {@code null} for a successful outcome so it can be embedded directly in {@link
-   * BpmnErrorThrown} / {@link JobErrorRaised}.
+   * Returns {@code null} for a successful outcome so it can be embedded directly into the optional
+   * {@code commandFailure} field of {@link ExecutionFailed}, {@link BpmnErrorThrown}, or {@link
+   * JobErrorRaised}.
    */
-  private static CommandFailure toCommandFailure(CommandOutcome outcome, Throwable throwable) {
+  private static CommandFailure commandFailureOrNull(CommandOutcome outcome, Throwable throwable) {
     if (throwable != null) {
       return new CommandFailure.CommandFailed(throwable);
     }

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/SpringConnectorJobHandler.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/SpringConnectorJobHandler.java
@@ -36,6 +36,8 @@ import io.camunda.connector.api.outbound.ConnectorResponse;
 import io.camunda.connector.api.outbound.ConnectorResponse.AdHocSubProcessConnectorResponse;
 import io.camunda.connector.api.outbound.ConnectorResponse.AdHocSubProcessConnectorResponse.ElementActivation;
 import io.camunda.connector.api.outbound.ConnectorResponse.StandardConnectorResponse;
+import io.camunda.connector.api.outbound.JobCompletionFailure;
+import io.camunda.connector.api.outbound.JobCompletionListener;
 import io.camunda.connector.api.outbound.OutboundConnectorContext;
 import io.camunda.connector.api.outbound.OutboundConnectorFunction;
 import io.camunda.connector.api.secret.SecretProvider;
@@ -53,6 +55,7 @@ import io.camunda.connector.runtime.core.outbound.JobHandlerContext;
 import io.camunda.connector.runtime.core.secret.SecretProviderAggregator;
 import io.camunda.connector.runtime.core.secret.SecretProviderDiscovery;
 import io.camunda.connector.runtime.metrics.ConnectorMetrics;
+import jakarta.annotation.Nullable;
 import java.time.Duration;
 import java.time.format.DateTimeParseException;
 import java.util.List;
@@ -197,9 +200,11 @@ public class SpringConnectorJobHandler implements JobHandler {
               new ErrorExpressionJobContext(
                   new ErrorExpressionJobContext.ErrorExpressionJob(job.getRetries())));
       optionalConnectorError.ifPresentOrElse(
-          error -> handleBPMNError(client, job, finalResult, error, counterMetricsContext),
+          error -> handleConnectorError(client, job, finalResult, error, counterMetricsContext),
           () -> handleFinalResult(client, job, finalResult, counterMetricsContext));
     } catch (Exception ex) {
+      notifyJobCompletionFailed(
+          extractJobCompletionListener(finalResult), new JobCompletionFailure.CommandFailed(ex));
       failJob(
           client,
           job,
@@ -215,7 +220,12 @@ public class SpringConnectorJobHandler implements JobHandler {
       CounterMetricsContext counterMetricsContext) {
     if (finalResult instanceof ConnectorResult.SuccessResult successResult) {
       LOGGER.info("Completing job: {} for tenant: {}", job.getKey(), job.getTenantId());
-      completeJob(jobClient, job, successResult, counterMetricsContext);
+      completeJob(
+          jobClient,
+          job,
+          successResult,
+          extractJobCompletionListener(finalResult),
+          counterMetricsContext);
     } else if (finalResult instanceof ConnectorResult.ErrorResult errorResult) {
       // Handle Java error, e.g. ConnectorException
       // these errors won't be handled ConnectorHelper.examineErrorExpression
@@ -228,20 +238,30 @@ public class SpringConnectorJobHandler implements JobHandler {
     }
   }
 
-  private void handleBPMNError(
+  private void handleConnectorError(
       JobClient client,
       ActivatedJob job,
       ConnectorResult finalResult,
       ConnectorError error,
       CounterMetricsContext counterMetricsContext) {
+    var listener = extractJobCompletionListener(finalResult);
+
     switch (error) {
       case BpmnError bpmnError -> {
         LOGGER.debug(
             "Throwing BPMN error for job {} with code {}", job.getKey(), bpmnError.errorCode());
+        notifyJobCompletionFailed(
+            listener,
+            new JobCompletionFailure.BpmnErrorThrown(
+                bpmnError.errorCode(), bpmnError.errorMessage(), bpmnError.variables()));
         throwBpmnError(client, job, bpmnError, counterMetricsContext);
       }
       case JobError jobError -> {
         LOGGER.debug("Throwing incident for job {}", job.getKey());
+        notifyJobCompletionFailed(
+            listener,
+            new JobCompletionFailure.JobErrorRaised(
+                jobError.errorMessage(), jobError.variablesWithErrorMessage()));
         failJob(
             client,
             job,
@@ -258,15 +278,13 @@ public class SpringConnectorJobHandler implements JobHandler {
           LOGGER.debug(
               "IgnoreError not supported for AdHocSubProcessConnectorResponse, job {}",
               job.getKey());
+          var cause =
+              new UnsupportedOperationException("IgnoreError is not supported for this connector");
+          notifyJobCompletionFailed(listener, new JobCompletionFailure.CommandFailed(cause));
           failJob(
               client,
               job,
-              new ConnectorResult.ErrorResult(
-                  ignoreError.variables(),
-                  new UnsupportedOperationException(
-                      "IgnoreError is not supported for this connector"),
-                  0,
-                  null),
+              new ConnectorResult.ErrorResult(ignoreError.variables(), cause, 0, null),
               counterMetricsContext);
         } else {
           LOGGER.debug("Ignoring error for job {}", job.getKey());
@@ -275,6 +293,7 @@ public class SpringConnectorJobHandler implements JobHandler {
               job,
               new ConnectorResult.SuccessResult(
                   StandardConnectorResponse.of(null), ignoreError.variables()),
+              listener,
               counterMetricsContext);
         }
       }
@@ -356,6 +375,7 @@ public class SpringConnectorJobHandler implements JobHandler {
       JobClient client,
       ActivatedJob job,
       ConnectorResult.SuccessResult result,
+      @Nullable JobCompletionListener listener,
       CounterMetricsContext counterMetricsContext) {
     ConnectorResponse connectorResponse = result.connectorResponse();
 
@@ -366,9 +386,16 @@ public class SpringConnectorJobHandler implements JobHandler {
               prepareAdHocSubProcessCompleteJobCommand(client, job, ahsp);
         };
 
-    return jobCallbackCommandWrapperFactory
-        .create(command, job.getDeadline(), counterMetricsContext, MAX_ZEEBE_COMMAND_RETRIES)
-        .executeAsync();
+    var future =
+        jobCallbackCommandWrapperFactory
+            .create(command, job.getDeadline(), counterMetricsContext, MAX_ZEEBE_COMMAND_RETRIES)
+            .executeAsync();
+
+    if (listener != null) {
+      future.whenComplete((outcome, error) -> notifyJobCompletionOutcome(listener, outcome, error));
+    }
+
+    return future;
   }
 
   private static JobCallbackFinalCommandStep<CompleteJobResponse> prepareCompleteJobCommand(
@@ -409,5 +436,44 @@ public class SpringConnectorJobHandler implements JobHandler {
     return message != null
         ? message.substring(0, Math.min(message.length(), MAX_ERROR_MESSAGE_LENGTH))
         : null;
+  }
+
+  private static JobCompletionListener extractJobCompletionListener(ConnectorResult result) {
+    if (result instanceof ConnectorResult.SuccessResult successResult
+        && successResult.connectorResponse() instanceof JobCompletionListener listener) {
+      return listener;
+    }
+    return null;
+  }
+
+  private static void notifyJobCompletionOutcome(
+      JobCompletionListener listener, CommandOutcome outcome, Throwable error) {
+    try {
+      if (error != null) {
+        listener.onJobCompletionFailed(new JobCompletionFailure.CommandFailed(error));
+      } else {
+        switch (outcome) {
+          case CommandOutcome.Completed c -> listener.onJobCompleted();
+          case CommandOutcome.Failed f ->
+              listener.onJobCompletionFailed(new JobCompletionFailure.CommandFailed(f.cause()));
+          case CommandOutcome.Ignored i ->
+              listener.onJobCompletionFailed(new JobCompletionFailure.CommandIgnored(i.cause()));
+        }
+      }
+    } catch (Exception e) {
+      LOGGER.warn("JobCompletionListener callback failed", e);
+    }
+  }
+
+  private static void notifyJobCompletionFailed(
+      JobCompletionListener listener, JobCompletionFailure failure) {
+    if (listener == null) {
+      return;
+    }
+    try {
+      listener.onJobCompletionFailed(failure);
+    } catch (Exception e) {
+      LOGGER.warn("JobCompletionListener callback failed", e);
+    }
   }
 }

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/SpringConnectorJobHandler.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/SpringConnectorJobHandler.java
@@ -209,14 +209,14 @@ public class SpringConnectorJobHandler implements JobHandler {
               handleConnectorError(client, job, context, finalResult, error, counterMetricsContext),
           () -> handleFinalResult(client, job, context, finalResult, counterMetricsContext));
     } catch (Exception ex) {
-      var failJobFuture =
+      CompletableFuture<CommandOutcome> failJobRequest =
           failJob(
               client,
               job,
               this.outboundConnectorExceptionHandler.handleFinalResultException(ex, job),
               counterMetricsContext);
       notifyFailureOnCommandOutcome(
-          failJobFuture,
+          failJobRequest,
           context,
           connectorResponseOrNull(finalResult),
           completionFailure -> new ExecutionFailed(ex, completionFailure));
@@ -243,9 +243,10 @@ public class SpringConnectorJobHandler implements JobHandler {
 
       // pre-response failure path: function threw before returning a response, so notify with a
       // null response (subscribers to JobCompletionListener can still react)
-      var failJobFuture = failJob(jobClient, job, errorResult, counterMetricsContext);
+      CompletableFuture<CommandOutcome> failJobRequest =
+          failJob(jobClient, job, errorResult, counterMetricsContext);
       notifyFailureOnCommandOutcome(
-          failJobFuture,
+          failJobRequest,
           context,
           null,
           completionFailure -> new ExecutionFailed(errorResult.exception(), completionFailure));
@@ -265,9 +266,10 @@ public class SpringConnectorJobHandler implements JobHandler {
       case BpmnError bpmnError -> {
         LOGGER.debug(
             "Throwing BPMN error for job {} with code {}", job.getKey(), bpmnError.errorCode());
-        var bpmnErrorFuture = throwBpmnError(client, job, bpmnError, counterMetricsContext);
+        CompletableFuture<CommandOutcome> throwBpmnErrorRequest =
+            throwBpmnError(client, job, bpmnError, counterMetricsContext);
         notifyFailureOnCommandOutcome(
-            bpmnErrorFuture,
+            throwBpmnErrorRequest,
             context,
             response,
             completionFailure ->
@@ -279,7 +281,7 @@ public class SpringConnectorJobHandler implements JobHandler {
       }
       case JobError jobError -> {
         LOGGER.debug("Throwing incident for job {}", job.getKey());
-        var failJobFuture =
+        CompletableFuture<CommandOutcome> failJobRequest =
             failJob(
                 client,
                 job,
@@ -290,7 +292,7 @@ public class SpringConnectorJobHandler implements JobHandler {
                     jobError.retryBackoff()),
                 counterMetricsContext);
         notifyFailureOnCommandOutcome(
-            failJobFuture,
+            failJobRequest,
             context,
             response,
             completionFailure ->
@@ -319,7 +321,7 @@ public class SpringConnectorJobHandler implements JobHandler {
           "IgnoreError not supported for AdHocSubProcessConnectorResponse, job {}", job.getKey());
       var cause =
           new UnsupportedOperationException("IgnoreError is not supported for this connector");
-      var failJobFuture =
+      CompletableFuture<CommandOutcome> failJobRequest =
           failJob(
               client,
               job,
@@ -327,7 +329,7 @@ public class SpringConnectorJobHandler implements JobHandler {
               counterMetricsContext);
 
       notifyFailureOnCommandOutcome(
-          failJobFuture,
+          failJobRequest,
           context,
           response,
           completionFailure -> new ExecutionFailed(cause, completionFailure));
@@ -429,12 +431,12 @@ public class SpringConnectorJobHandler implements JobHandler {
               prepareAdHocSubProcessCompleteJobCommand(client, job, ahsp);
         };
 
-    var completeJobFuture =
+    CompletableFuture<CommandOutcome> completeJobRequest =
         jobCallbackCommandWrapperFactory
             .create(command, job.getDeadline(), counterMetricsContext, MAX_ZEEBE_COMMAND_RETRIES)
             .executeAsync();
 
-    completeJobFuture.whenComplete(
+    completeJobRequest.whenComplete(
         (outcome, throwable) -> {
           var commandFailure = commandFailureOrNull(outcome, throwable);
           if (commandFailure == null) {
@@ -444,7 +446,7 @@ public class SpringConnectorJobHandler implements JobHandler {
           }
         });
 
-    return completeJobFuture;
+    return completeJobRequest;
   }
 
   private static JobCallbackFinalCommandStep<CompleteJobResponse> prepareCompleteJobCommand(
@@ -497,11 +499,11 @@ public class SpringConnectorJobHandler implements JobHandler {
    * subtype and embeds the command outcome where applicable.
    */
   private void notifyFailureOnCommandOutcome(
-      CompletableFuture<CommandOutcome> future,
+      CompletableFuture<CommandOutcome> request,
       OutboundConnectorContext context,
       ConnectorResponse response,
       Function<CommandFailure, JobCompletionFailure> failureBuilder) {
-    future.whenComplete(
+    request.whenComplete(
         (outcome, throwable) ->
             notifyJobCompletionFailed(
                 context, response, failureBuilder.apply(commandFailureOrNull(outcome, throwable))));

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/lifecycle/OutboundConnectorManager.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/lifecycle/OutboundConnectorManager.java
@@ -21,7 +21,7 @@ import io.camunda.client.CamundaClient;
 import io.camunda.client.annotation.value.JobWorkerValue;
 import io.camunda.client.annotation.value.SourceAware;
 import io.camunda.client.annotation.value.SourceAware.FromAnnotation;
-import io.camunda.client.jobhandling.CommandExceptionHandlingStrategy;
+import io.camunda.client.jobhandling.JobCallbackCommandWrapperFactory;
 import io.camunda.client.jobhandling.JobHandlerFactory;
 import io.camunda.client.jobhandling.JobWorkerManager;
 import io.camunda.client.jobhandling.ManagedJobWorker;
@@ -46,7 +46,7 @@ public class OutboundConnectorManager implements CamundaClientLifecycleAware {
   private static final Logger LOG = LoggerFactory.getLogger(OutboundConnectorManager.class);
   private final JobWorkerManager jobWorkerManager;
   private final OutboundConnectorFactory connectorFactory;
-  private final CommandExceptionHandlingStrategy commandExceptionHandlingStrategy;
+  private final JobCallbackCommandWrapperFactory jobCallbackCommandWrapperFactory;
   private final SecretProviderAggregator secretProviderAggregator;
   private final ValidationProvider validationProvider;
   private final ObjectMapper objectMapper;
@@ -56,7 +56,7 @@ public class OutboundConnectorManager implements CamundaClientLifecycleAware {
   public OutboundConnectorManager(
       JobWorkerManager jobWorkerManager,
       OutboundConnectorFactory connectorFactory,
-      CommandExceptionHandlingStrategy commandExceptionHandlingStrategy,
+      JobCallbackCommandWrapperFactory jobCallbackCommandWrapperFactory,
       SecretProviderAggregator secretProviderAggregator,
       ValidationProvider validationProvider,
       DocumentFactory documentFactory,
@@ -64,7 +64,7 @@ public class OutboundConnectorManager implements CamundaClientLifecycleAware {
       MetricsRecorder metricsRecorder) {
     this.jobWorkerManager = jobWorkerManager;
     this.connectorFactory = connectorFactory;
-    this.commandExceptionHandlingStrategy = commandExceptionHandlingStrategy;
+    this.jobCallbackCommandWrapperFactory = jobCallbackCommandWrapperFactory;
     this.secretProviderAggregator = secretProviderAggregator;
     this.validationProvider = validationProvider;
     this.documentFactory = documentFactory;
@@ -110,7 +110,7 @@ public class OutboundConnectorManager implements CamundaClientLifecycleAware {
         ctx ->
             new SpringConnectorJobHandler(
                 metricsRecorder,
-                commandExceptionHandlingStrategy,
+                jobCallbackCommandWrapperFactory,
                 secretProviderAggregator,
                 validationProvider,
                 documentFactory,

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/inbound/search/ProcessInstanceClientImplTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/inbound/search/ProcessInstanceClientImplTest.java
@@ -26,6 +26,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.client.api.search.response.ElementInstance;
 import io.camunda.client.api.search.response.SearchResponse;
 import io.camunda.client.api.search.response.Variable;
+import io.camunda.client.impl.CamundaObjectMapper;
 import io.camunda.client.impl.search.response.ElementInstanceImpl;
 import io.camunda.client.impl.search.response.SearchResponseImpl;
 import io.camunda.client.impl.search.response.SearchResponsePageImpl;
@@ -145,7 +146,7 @@ class ProcessInstanceClientImplTest {
     item.setScopeKey(key);
     item.setName(name);
     item.setValue(value);
-    return new VariableImpl(item);
+    return new VariableImpl(item, new CamundaObjectMapper());
   }
 
   @SafeVarargs

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/job/SpringConnectorJobHandlerTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/job/SpringConnectorJobHandlerTest.java
@@ -50,6 +50,8 @@ import io.camunda.connector.api.outbound.ConnectorResponse.AdHocSubProcessConnec
 import io.camunda.connector.api.outbound.ConnectorResponse.AdHocSubProcessConnectorResponse.ElementActivation;
 import io.camunda.connector.api.outbound.ConnectorResponse.StandardConnectorResponse;
 import io.camunda.connector.api.outbound.JobCompletionFailure;
+import io.camunda.connector.api.outbound.JobCompletionFailure.CommandFailure.CommandFailed;
+import io.camunda.connector.api.outbound.JobCompletionFailure.ExecutionFailed;
 import io.camunda.connector.api.outbound.JobCompletionListener;
 import io.camunda.connector.api.outbound.OutboundConnectorContext;
 import io.camunda.connector.api.outbound.OutboundConnectorFunction;
@@ -2037,7 +2039,9 @@ class SpringConnectorJobHandlerTest {
     void listenerNotifiedWhenErrorExpressionEvaluationFails() throws Exception {
       var listener = mock(JobCompletionListener.class);
       var function = new TestListenerFunction(Map.of("key", "value"), listener);
-      var handler = newConnectorJobHandler(function);
+      var handler =
+          newConnectorJobHandler(
+              function, CompletableFuture.completedFuture(new CommandOutcome.Completed(null, 1)));
 
       // expression returning a non-object value causes examineErrorExpression to throw
       JobBuilder.create()
@@ -2047,14 +2051,17 @@ class SpringConnectorJobHandlerTest {
       var captor = ArgumentCaptor.forClass(JobCompletionFailure.class);
       verify(listener).onJobCompletionFailed(any(), any(ConnectorResponse.class), captor.capture());
       assertThat(captor.getValue())
-          .isInstanceOf(JobCompletionFailure.CommandFailure.CommandFailed.class);
+          .isInstanceOfSatisfying(
+              ExecutionFailed.class, failure -> assertThat(failure.commandFailure()).isNull());
     }
 
     @Test
     void listenerNotifiedWithNullResponseWhenExecuteThrows() throws Exception {
       var listener = mock(JobCompletionListener.class);
       var function = new TestListenerFunction(new RuntimeException("execute exploded"), listener);
-      var handler = newConnectorJobHandler(function);
+      var handler =
+          newConnectorJobHandler(
+              function, CompletableFuture.completedFuture(new CommandOutcome.Completed(null, 1)));
 
       JobBuilder.create().executeAndCaptureResult(handler, false);
 
@@ -2062,8 +2069,36 @@ class SpringConnectorJobHandlerTest {
       verify(listener).onJobCompletionFailed(any(), eq(null), captor.capture());
       assertThat(captor.getValue())
           .isInstanceOfSatisfying(
-              JobCompletionFailure.CommandFailure.CommandFailed.class,
-              failure -> assertThat(failure.cause()).hasMessage("execute exploded"));
+              ExecutionFailed.class,
+              failure -> {
+                assertThat(failure.cause()).hasMessage("execute exploded");
+                assertThat(failure.commandFailure()).isNull();
+              });
+    }
+
+    @Test
+    void executionFailedCarriesCommandFailureWhenFailJobRejected() throws Exception {
+      var listener = mock(JobCompletionListener.class);
+      var function = new TestListenerFunction(new RuntimeException("execute exploded"), listener);
+      var failJobCause = new RuntimeException("Zeebe rejected failJob");
+      var handler =
+          newConnectorJobHandler(
+              function,
+              CompletableFuture.completedFuture(new CommandOutcome.Failed(failJobCause, 3)));
+
+      JobBuilder.create().executeAndCaptureResult(handler, false);
+
+      var captor = ArgumentCaptor.forClass(JobCompletionFailure.class);
+      verify(listener).onJobCompletionFailed(any(), eq(null), captor.capture());
+      assertThat(captor.getValue())
+          .isInstanceOfSatisfying(
+              ExecutionFailed.class,
+              failure -> {
+                assertThat(failure.cause()).hasMessage("execute exploded");
+                assertThat(failure.commandFailure()).isInstanceOf(CommandFailed.class);
+                assertThat(((CommandFailed) failure.commandFailure()).cause())
+                    .isSameAs(failJobCause);
+              });
     }
 
     @Test

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/job/SpringConnectorJobHandlerTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/job/SpringConnectorJobHandlerTest.java
@@ -35,7 +35,7 @@ import static org.mockito.Mockito.when;
 import io.camunda.client.api.command.FailJobCommandStep1;
 import io.camunda.client.api.worker.BackoffSupplier;
 import io.camunda.client.api.worker.JobClient;
-import io.camunda.client.jobhandling.DefaultCommandExceptionHandlingStrategy;
+import io.camunda.client.jobhandling.JobCallbackCommandWrapperFactory;
 import io.camunda.client.metrics.MicrometerMetricsRecorder;
 import io.camunda.connector.api.document.DocumentFactory;
 import io.camunda.connector.api.error.ConnectorException;
@@ -98,11 +98,13 @@ class SpringConnectorJobHandlerTest {
 
       protected static SpringConnectorJobHandler newConnectorJobHandler(
           OutboundConnectorFunction call, SecretProviderAggregator secretProviderAggregator) {
+        var metricsRecorder = new MicrometerMetricsRecorder(new SimpleMeterRegistry());
         return new SpringConnectorJobHandler(
-            new MicrometerMetricsRecorder(new SimpleMeterRegistry()),
-            new DefaultCommandExceptionHandlingStrategy(
+            metricsRecorder,
+            new JobCallbackCommandWrapperFactory(
                 BackoffSupplier.newBackoffBuilder().build(),
-                Executors.newSingleThreadScheduledExecutor()),
+                Executors.newSingleThreadScheduledExecutor(),
+                metricsRecorder),
             secretProviderAggregator,
             new DefaultValidationProvider(),
             mock(DocumentFactory.class),

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/job/SpringConnectorJobHandlerTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/job/SpringConnectorJobHandlerTest.java
@@ -26,6 +26,7 @@ import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
@@ -44,11 +45,13 @@ import io.camunda.connector.api.error.ConnectorException;
 import io.camunda.connector.api.error.ConnectorExceptionBuilder;
 import io.camunda.connector.api.error.ConnectorInputException;
 import io.camunda.connector.api.error.ConnectorRetryExceptionBuilder;
+import io.camunda.connector.api.outbound.ConnectorResponse;
 import io.camunda.connector.api.outbound.ConnectorResponse.AdHocSubProcessConnectorResponse;
 import io.camunda.connector.api.outbound.ConnectorResponse.AdHocSubProcessConnectorResponse.ElementActivation;
 import io.camunda.connector.api.outbound.ConnectorResponse.StandardConnectorResponse;
 import io.camunda.connector.api.outbound.JobCompletionFailure;
 import io.camunda.connector.api.outbound.JobCompletionListener;
+import io.camunda.connector.api.outbound.OutboundConnectorContext;
 import io.camunda.connector.api.outbound.OutboundConnectorFunction;
 import io.camunda.connector.api.secret.SecretContext;
 import io.camunda.connector.runtime.JobBuilder;
@@ -1722,8 +1725,8 @@ class SpringConnectorJobHandlerTest {
     @Test
     void listenerNotifiedWithBpmnErrorThrownOnBpmnErrorExpression() throws Exception {
       var listener = mock(JobCompletionListener.class);
-      var response = new TestListenerResponse(Map.of("status", "fail"), listener);
-      var handler = newConnectorJobHandler(context -> response);
+      var function = new TestListenerFunction(Map.of("status", "fail"), listener);
+      var handler = newConnectorJobHandler(function);
 
       JobBuilder.create()
           .withErrorExpressionHeader(
@@ -1731,7 +1734,7 @@ class SpringConnectorJobHandlerTest {
           .executeAndCaptureResult(handler, false, true);
 
       var captor = ArgumentCaptor.forClass(JobCompletionFailure.class);
-      verify(listener).onJobCompletionFailed(captor.capture());
+      verify(listener).onJobCompletionFailed(any(), any(ConnectorResponse.class), captor.capture());
       assertThat(captor.getValue())
           .isInstanceOfSatisfying(
               JobCompletionFailure.BpmnErrorThrown.class,
@@ -1745,8 +1748,8 @@ class SpringConnectorJobHandlerTest {
     @Test
     void listenerNotifiedWithBpmnErrorThrownWithVariables() throws Exception {
       var listener = mock(JobCompletionListener.class);
-      var response = new TestListenerResponse(Map.of("status", "fail"), listener);
-      var handler = newConnectorJobHandler(context -> response);
+      var function = new TestListenerFunction(Map.of("status", "fail"), listener);
+      var handler = newConnectorJobHandler(function);
 
       JobBuilder.create()
           .withErrorExpressionHeader(
@@ -1754,7 +1757,7 @@ class SpringConnectorJobHandlerTest {
           .executeAndCaptureResult(handler, false, true);
 
       var captor = ArgumentCaptor.forClass(JobCompletionFailure.class);
-      verify(listener).onJobCompletionFailed(captor.capture());
+      verify(listener).onJobCompletionFailed(any(), any(ConnectorResponse.class), captor.capture());
       assertThat(captor.getValue())
           .isInstanceOfSatisfying(
               JobCompletionFailure.BpmnErrorThrown.class,
@@ -1769,8 +1772,8 @@ class SpringConnectorJobHandlerTest {
     @Test
     void listenerNotifiedWithJobErrorRaisedOnJobErrorExpression() throws Exception {
       var listener = mock(JobCompletionListener.class);
-      var response = new TestListenerResponse(Map.of("status", "fail"), listener);
-      var handler = newConnectorJobHandler(context -> response);
+      var function = new TestListenerFunction(Map.of("status", "fail"), listener);
+      var handler = newConnectorJobHandler(function);
 
       JobBuilder.create()
           .withErrorExpressionHeader(
@@ -1778,7 +1781,7 @@ class SpringConnectorJobHandlerTest {
           .executeAndCaptureResult(handler, false, false);
 
       var captor = ArgumentCaptor.forClass(JobCompletionFailure.class);
-      verify(listener).onJobCompletionFailed(captor.capture());
+      verify(listener).onJobCompletionFailed(any(), any(ConnectorResponse.class), captor.capture());
       assertThat(captor.getValue())
           .isInstanceOfSatisfying(
               JobCompletionFailure.JobErrorRaised.class,
@@ -1792,8 +1795,8 @@ class SpringConnectorJobHandlerTest {
     @Test
     void listenerNotifiedWithJobErrorRaisedWithVariables() throws Exception {
       var listener = mock(JobCompletionListener.class);
-      var response = new TestListenerResponse(Map.of("status", "fail"), listener);
-      var handler = newConnectorJobHandler(context -> response);
+      var function = new TestListenerFunction(Map.of("status", "fail"), listener);
+      var handler = newConnectorJobHandler(function);
 
       JobBuilder.create()
           .withErrorExpressionHeader(
@@ -1801,7 +1804,7 @@ class SpringConnectorJobHandlerTest {
           .executeAndCaptureResult(handler, false, false);
 
       var captor = ArgumentCaptor.forClass(JobCompletionFailure.class);
-      verify(listener).onJobCompletionFailed(captor.capture());
+      verify(listener).onJobCompletionFailed(any(), any(ConnectorResponse.class), captor.capture());
       assertThat(captor.getValue())
           .isInstanceOfSatisfying(
               JobCompletionFailure.JobErrorRaised.class,
@@ -1816,8 +1819,8 @@ class SpringConnectorJobHandlerTest {
     @Test
     void listenerNotifiedWithJobErrorRaisedWithRetriesAndBackoff() throws Exception {
       var listener = mock(JobCompletionListener.class);
-      var response = new TestListenerResponse(Map.of("status", "fail"), listener);
-      var handler = newConnectorJobHandler(context -> response);
+      var function = new TestListenerFunction(Map.of("status", "fail"), listener);
+      var handler = newConnectorJobHandler(function);
 
       JobBuilder.create()
           .withErrorExpressionHeader(
@@ -1825,7 +1828,7 @@ class SpringConnectorJobHandlerTest {
           .executeAndCaptureResult(handler, false, false);
 
       var captor = ArgumentCaptor.forClass(JobCompletionFailure.class);
-      verify(listener).onJobCompletionFailed(captor.capture());
+      verify(listener).onJobCompletionFailed(any(), any(ConnectorResponse.class), captor.capture());
       // retries and backoff control the FailJob command, not the notification
       assertThat(captor.getValue())
           .isInstanceOfSatisfying(
@@ -1840,31 +1843,29 @@ class SpringConnectorJobHandlerTest {
     @Test
     void listenerNotifiedOnSuccessfulCompletion() throws Exception {
       var listener = mock(JobCompletionListener.class);
-      var response = new TestListenerResponse(Map.of("key", "value"), listener);
+      var function = new TestListenerFunction(Map.of("key", "value"), listener);
       var handler =
           newConnectorJobHandler(
-              context -> response,
-              CompletableFuture.completedFuture(new CommandOutcome.Completed(null, 1)));
+              function, CompletableFuture.completedFuture(new CommandOutcome.Completed(null, 1)));
 
       JobBuilder.create().execute(handler);
 
-      verify(listener).onJobCompleted();
+      verify(listener).onJobCompleted(any(), any(ConnectorResponse.class));
     }
 
     @Test
     void listenerNotifiedWithCommandIgnoredOnIgnoredOutcome() throws Exception {
       var listener = mock(JobCompletionListener.class);
-      var response = new TestListenerResponse(Map.of("key", "value"), listener);
+      var function = new TestListenerFunction(Map.of("key", "value"), listener);
       var cause = new RuntimeException("NOT_FOUND");
       var handler =
           newConnectorJobHandler(
-              context -> response,
-              CompletableFuture.completedFuture(new CommandOutcome.Ignored(cause, 1)));
+              function, CompletableFuture.completedFuture(new CommandOutcome.Ignored(cause, 1)));
 
       JobBuilder.create().execute(handler);
 
       var captor = ArgumentCaptor.forClass(JobCompletionFailure.class);
-      verify(listener).onJobCompletionFailed(captor.capture());
+      verify(listener).onJobCompletionFailed(any(), any(ConnectorResponse.class), captor.capture());
       assertThat(captor.getValue())
           .isInstanceOfSatisfying(
               JobCompletionFailure.CommandIgnored.class,
@@ -1874,17 +1875,16 @@ class SpringConnectorJobHandlerTest {
     @Test
     void listenerNotifiedWithCommandFailedOnFailedOutcome() throws Exception {
       var listener = mock(JobCompletionListener.class);
-      var response = new TestListenerResponse(Map.of("key", "value"), listener);
+      var function = new TestListenerFunction(Map.of("key", "value"), listener);
       var cause = new RuntimeException("command failed");
       var handler =
           newConnectorJobHandler(
-              context -> response,
-              CompletableFuture.completedFuture(new CommandOutcome.Failed(cause, 3)));
+              function, CompletableFuture.completedFuture(new CommandOutcome.Failed(cause, 3)));
 
       JobBuilder.create().execute(handler);
 
       var captor = ArgumentCaptor.forClass(JobCompletionFailure.class);
-      verify(listener).onJobCompletionFailed(captor.capture());
+      verify(listener).onJobCompletionFailed(any(), any(ConnectorResponse.class), captor.capture());
       assertThat(captor.getValue())
           .isInstanceOfSatisfying(
               JobCompletionFailure.CommandFailed.class,
@@ -1894,15 +1894,14 @@ class SpringConnectorJobHandlerTest {
     @Test
     void listenerNotifiedWithCommandFailedOnFutureException() throws Exception {
       var listener = mock(JobCompletionListener.class);
-      var response = new TestListenerResponse(Map.of("key", "value"), listener);
+      var function = new TestListenerFunction(Map.of("key", "value"), listener);
       var cause = new RuntimeException("future failed");
-      var handler =
-          newConnectorJobHandler(context -> response, CompletableFuture.failedFuture(cause));
+      var handler = newConnectorJobHandler(function, CompletableFuture.failedFuture(cause));
 
       JobBuilder.create().execute(handler);
 
       var captor = ArgumentCaptor.forClass(JobCompletionFailure.class);
-      verify(listener).onJobCompletionFailed(captor.capture());
+      verify(listener).onJobCompletionFailed(any(), any(ConnectorResponse.class), captor.capture());
       assertThat(captor.getValue())
           .isInstanceOfSatisfying(
               JobCompletionFailure.CommandFailed.class,
@@ -1912,17 +1911,18 @@ class SpringConnectorJobHandlerTest {
     @Test
     void throwingListenerOnCompletionDoesNotPropagate() throws Exception {
       var listener = mock(JobCompletionListener.class);
-      doThrow(new RuntimeException("listener exploded")).when(listener).onJobCompleted();
-      var response = new TestListenerResponse(Map.of("key", "value"), listener);
+      doThrow(new RuntimeException("listener exploded"))
+          .when(listener)
+          .onJobCompleted(any(), any());
+      var function = new TestListenerFunction(Map.of("key", "value"), listener);
       var handler =
           newConnectorJobHandler(
-              context -> response,
-              CompletableFuture.completedFuture(new CommandOutcome.Completed(null, 1)));
+              function, CompletableFuture.completedFuture(new CommandOutcome.Completed(null, 1)));
 
       // should not throw despite listener failure
       JobBuilder.create().execute(handler);
 
-      verify(listener).onJobCompleted();
+      verify(listener).onJobCompleted(any(), any(ConnectorResponse.class));
     }
 
     @Test
@@ -1930,9 +1930,9 @@ class SpringConnectorJobHandlerTest {
       var listener = mock(JobCompletionListener.class);
       doThrow(new RuntimeException("listener exploded"))
           .when(listener)
-          .onJobCompletionFailed(any());
-      var response = new TestListenerResponse(Map.of("status", "fail"), listener);
-      var handler = newConnectorJobHandler(context -> response);
+          .onJobCompletionFailed(any(), any(), any());
+      var function = new TestListenerFunction(Map.of("status", "fail"), listener);
+      var handler = newConnectorJobHandler(function);
 
       // should not throw despite listener failure
       JobBuilder.create()
@@ -1940,31 +1940,30 @@ class SpringConnectorJobHandlerTest {
               "=if response.status = \"fail\" then bpmnError(\"ERR\", \"boom\") else null")
           .executeAndCaptureResult(handler, false, true);
 
-      verify(listener).onJobCompletionFailed(any());
+      verify(listener).onJobCompletionFailed(any(), any(ConnectorResponse.class), any());
     }
 
     @Test
     void listenerNotifiedOnIgnoreErrorCompletion() throws Exception {
       var listener = mock(JobCompletionListener.class);
-      var response = new TestListenerResponse(Map.of("status", "fail"), listener);
+      var function = new TestListenerFunction(Map.of("status", "fail"), listener);
       var handler =
           newConnectorJobHandler(
-              context -> response,
-              CompletableFuture.completedFuture(new CommandOutcome.Completed(null, 1)));
+              function, CompletableFuture.completedFuture(new CommandOutcome.Completed(null, 1)));
 
       JobBuilder.create()
           .withErrorExpressionHeader(
               "=if response.status = \"fail\" then ignoreError({\"recovered\": true}) else null")
           .executeAndCaptureResult(handler);
 
-      verify(listener).onJobCompleted();
+      verify(listener).onJobCompleted(any(), any(ConnectorResponse.class));
     }
 
     @Test
     void listenerNotifiedWhenErrorExpressionEvaluationFails() throws Exception {
       var listener = mock(JobCompletionListener.class);
-      var response = new TestListenerResponse(Map.of("key", "value"), listener);
-      var handler = newConnectorJobHandler(context -> response);
+      var function = new TestListenerFunction(Map.of("key", "value"), listener);
+      var handler = newConnectorJobHandler(function);
 
       // expression returning a non-object value causes examineErrorExpression to throw
       JobBuilder.create()
@@ -1972,13 +1971,29 @@ class SpringConnectorJobHandlerTest {
           .executeAndCaptureResult(handler, false);
 
       var captor = ArgumentCaptor.forClass(JobCompletionFailure.class);
-      verify(listener).onJobCompletionFailed(captor.capture());
+      verify(listener).onJobCompletionFailed(any(), any(ConnectorResponse.class), captor.capture());
       assertThat(captor.getValue()).isInstanceOf(JobCompletionFailure.CommandFailed.class);
     }
 
     @Test
+    void listenerNotifiedWithNullResponseWhenExecuteThrows() throws Exception {
+      var listener = mock(JobCompletionListener.class);
+      var function = new TestListenerFunction(new RuntimeException("execute exploded"), listener);
+      var handler = newConnectorJobHandler(function);
+
+      JobBuilder.create().executeAndCaptureResult(handler, false);
+
+      var captor = ArgumentCaptor.forClass(JobCompletionFailure.class);
+      verify(listener).onJobCompletionFailed(any(), eq(null), captor.capture());
+      assertThat(captor.getValue())
+          .isInstanceOfSatisfying(
+              JobCompletionFailure.CommandFailed.class,
+              failure -> assertThat(failure.cause()).hasMessage("execute exploded"));
+    }
+
+    @Test
     void noListenerDoesNotCrash() throws Exception {
-      // response that does NOT implement JobCompletionListener
+      // function that does NOT implement JobCompletionListener
       var handler =
           newConnectorJobHandler(
               context -> StandardConnectorResponse.of(Map.of("key", "value")),
@@ -1988,18 +2003,37 @@ class SpringConnectorJobHandlerTest {
       JobBuilder.create().execute(handler);
     }
 
-    /** Response that implements both StandardConnectorResponse and JobCompletionListener. */
-    private record TestListenerResponse(Object responseValue, JobCompletionListener delegate)
-        implements StandardConnectorResponse, JobCompletionListener {
+    /** Function that implements both OutboundConnectorFunction and JobCompletionListener. */
+    private static final class TestListenerFunction
+        implements OutboundConnectorFunction, JobCompletionListener {
 
-      @Override
-      public void onJobCompleted() {
-        delegate.onJobCompleted();
+      private final Object responseOrException;
+      private final JobCompletionListener delegate;
+
+      TestListenerFunction(Object responseOrException, JobCompletionListener delegate) {
+        this.responseOrException = responseOrException;
+        this.delegate = delegate;
       }
 
       @Override
-      public void onJobCompletionFailed(JobCompletionFailure failure) {
-        delegate.onJobCompletionFailed(failure);
+      public Object execute(OutboundConnectorContext context) throws Exception {
+        if (responseOrException instanceof Exception ex) {
+          throw ex;
+        }
+        return responseOrException;
+      }
+
+      @Override
+      public void onJobCompleted(OutboundConnectorContext context, ConnectorResponse response) {
+        delegate.onJobCompleted(context, response);
+      }
+
+      @Override
+      public void onJobCompletionFailed(
+          OutboundConnectorContext context,
+          ConnectorResponse response,
+          JobCompletionFailure failure) {
+        delegate.onJobCompletionFailed(context, response, failure);
       }
     }
   }

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/job/SpringConnectorJobHandlerTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/job/SpringConnectorJobHandlerTest.java
@@ -20,13 +20,14 @@ package io.camunda.connector.runtime.outbound.job;
 import static io.camunda.connector.runtime.core.Keywords.ERROR_EXPRESSION_KEYWORD;
 import static io.camunda.connector.runtime.core.Keywords.RESULT_EXPRESSION_KEYWORD;
 import static io.camunda.connector.runtime.core.Keywords.RESULT_VARIABLE_KEYWORD;
-import static io.camunda.connector.runtime.outbound.job.SpringConnectorJobHandlerTest.OutputTests.ResultVariableTests.newConnectorJobHandler;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.contains;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -35,6 +36,7 @@ import static org.mockito.Mockito.when;
 import io.camunda.client.api.command.FailJobCommandStep1;
 import io.camunda.client.api.worker.BackoffSupplier;
 import io.camunda.client.api.worker.JobClient;
+import io.camunda.client.jobhandling.CommandOutcome;
 import io.camunda.client.jobhandling.JobCallbackCommandWrapperFactory;
 import io.camunda.client.metrics.MicrometerMetricsRecorder;
 import io.camunda.connector.api.document.DocumentFactory;
@@ -45,6 +47,8 @@ import io.camunda.connector.api.error.ConnectorRetryExceptionBuilder;
 import io.camunda.connector.api.outbound.ConnectorResponse.AdHocSubProcessConnectorResponse;
 import io.camunda.connector.api.outbound.ConnectorResponse.AdHocSubProcessConnectorResponse.ElementActivation;
 import io.camunda.connector.api.outbound.ConnectorResponse.StandardConnectorResponse;
+import io.camunda.connector.api.outbound.JobCompletionFailure;
+import io.camunda.connector.api.outbound.JobCompletionListener;
 import io.camunda.connector.api.outbound.OutboundConnectorFunction;
 import io.camunda.connector.api.secret.SecretContext;
 import io.camunda.connector.runtime.JobBuilder;
@@ -60,9 +64,12 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Stream;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -90,33 +97,52 @@ class SpringConnectorJobHandlerTest {
     private final UUID field = UUID.randomUUID();
   }
 
+  private static final ScheduledExecutorService commandScheduler =
+      Executors.newSingleThreadScheduledExecutor();
+
+  @AfterAll
+  static void shutdownScheduler() {
+    commandScheduler.shutdownNow();
+  }
+
+  private SpringConnectorJobHandler newConnectorJobHandler(OutboundConnectorFunction call) {
+    return newConnectorJobHandler(
+        call, new SecretProviderAggregator(List.of(new FooBarSecretProvider())));
+  }
+
+  private SpringConnectorJobHandler newConnectorJobHandler(
+      OutboundConnectorFunction call, SecretProviderAggregator secretProviderAggregator) {
+    var metricsRecorder = new MicrometerMetricsRecorder(new SimpleMeterRegistry());
+    return new SpringConnectorJobHandler(
+        metricsRecorder,
+        new JobCallbackCommandWrapperFactory(
+            BackoffSupplier.newBackoffBuilder().build(), commandScheduler, metricsRecorder),
+        secretProviderAggregator,
+        new DefaultValidationProvider(),
+        mock(DocumentFactory.class),
+        TestObjectMapperSupplier.INSTANCE,
+        call);
+  }
+
+  private SpringConnectorJobHandler newConnectorJobHandler(
+      OutboundConnectorFunction call, CompletableFuture<CommandOutcome> outcome) {
+    var factory = mock(JobCallbackCommandWrapperFactory.class, RETURNS_DEEP_STUBS);
+    when(factory.create(any(), anyLong(), any(), anyInt()).executeAsync()).thenReturn(outcome);
+    return new SpringConnectorJobHandler(
+        new MicrometerMetricsRecorder(new SimpleMeterRegistry()),
+        factory,
+        new SecretProviderAggregator(List.of(new FooBarSecretProvider())),
+        new DefaultValidationProvider(),
+        mock(DocumentFactory.class),
+        TestObjectMapperSupplier.INSTANCE,
+        call);
+  }
+
   @Nested
   class OutputTests {
 
     @Nested
     class ResultVariableTests {
-
-      protected static SpringConnectorJobHandler newConnectorJobHandler(
-          OutboundConnectorFunction call, SecretProviderAggregator secretProviderAggregator) {
-        var metricsRecorder = new MicrometerMetricsRecorder(new SimpleMeterRegistry());
-        return new SpringConnectorJobHandler(
-            metricsRecorder,
-            new JobCallbackCommandWrapperFactory(
-                BackoffSupplier.newBackoffBuilder().build(),
-                Executors.newSingleThreadScheduledExecutor(),
-                metricsRecorder),
-            secretProviderAggregator,
-            new DefaultValidationProvider(),
-            mock(DocumentFactory.class),
-            TestObjectMapperSupplier.INSTANCE,
-            call);
-      }
-
-      protected static SpringConnectorJobHandler newConnectorJobHandler(
-          OutboundConnectorFunction call) {
-        return newConnectorJobHandler(
-            call, new SecretProviderAggregator(List.of(new FooBarSecretProvider())));
-      }
 
       @ParameterizedTest
       @NullSource
@@ -1687,6 +1713,294 @@ class SpringConnectorJobHandlerTest {
       assertThat(result.variables()).isEqualTo(Map.of("key", "value"));
       assertThat(result.completionConditionFulfilled()).isTrue();
       assertThat(result.elementActivations()).isEmpty();
+    }
+  }
+
+  @Nested
+  class JobCompletionListenerTests {
+
+    @Test
+    void listenerNotifiedWithBpmnErrorThrownOnBpmnErrorExpression() throws Exception {
+      var listener = mock(JobCompletionListener.class);
+      var response = new TestListenerResponse(Map.of("status", "fail"), listener);
+      var handler = newConnectorJobHandler(context -> response);
+
+      JobBuilder.create()
+          .withErrorExpressionHeader(
+              "=if response.status = \"fail\" then bpmnError(\"ERR_001\", \"test error\") else null")
+          .executeAndCaptureResult(handler, false, true);
+
+      var captor = ArgumentCaptor.forClass(JobCompletionFailure.class);
+      verify(listener).onJobCompletionFailed(captor.capture());
+      assertThat(captor.getValue())
+          .isInstanceOfSatisfying(
+              JobCompletionFailure.BpmnErrorThrown.class,
+              failure -> {
+                assertThat(failure.errorCode()).isEqualTo("ERR_001");
+                assertThat(failure.errorMessage()).isEqualTo("test error");
+                assertThat(failure.variables()).isEmpty();
+              });
+    }
+
+    @Test
+    void listenerNotifiedWithBpmnErrorThrownWithVariables() throws Exception {
+      var listener = mock(JobCompletionListener.class);
+      var response = new TestListenerResponse(Map.of("status", "fail"), listener);
+      var handler = newConnectorJobHandler(context -> response);
+
+      JobBuilder.create()
+          .withErrorExpressionHeader(
+              "=if response.status = \"fail\" then bpmnError(\"ERR_002\", \"with vars\", {detail: \"info\"}) else null")
+          .executeAndCaptureResult(handler, false, true);
+
+      var captor = ArgumentCaptor.forClass(JobCompletionFailure.class);
+      verify(listener).onJobCompletionFailed(captor.capture());
+      assertThat(captor.getValue())
+          .isInstanceOfSatisfying(
+              JobCompletionFailure.BpmnErrorThrown.class,
+              failure -> {
+                assertThat(failure.errorCode()).isEqualTo("ERR_002");
+                assertThat(failure.errorMessage()).isEqualTo("with vars");
+                assertThat(failure.variables())
+                    .containsExactlyInAnyOrderEntriesOf(Map.of("detail", "info"));
+              });
+    }
+
+    @Test
+    void listenerNotifiedWithJobErrorRaisedOnJobErrorExpression() throws Exception {
+      var listener = mock(JobCompletionListener.class);
+      var response = new TestListenerResponse(Map.of("status", "fail"), listener);
+      var handler = newConnectorJobHandler(context -> response);
+
+      JobBuilder.create()
+          .withErrorExpressionHeader(
+              "=if response.status = \"fail\" then jobError(\"something went wrong\") else null")
+          .executeAndCaptureResult(handler, false, false);
+
+      var captor = ArgumentCaptor.forClass(JobCompletionFailure.class);
+      verify(listener).onJobCompletionFailed(captor.capture());
+      assertThat(captor.getValue())
+          .isInstanceOfSatisfying(
+              JobCompletionFailure.JobErrorRaised.class,
+              failure -> {
+                assertThat(failure.errorMessage()).isEqualTo("something went wrong");
+                assertThat(failure.variables())
+                    .containsExactlyInAnyOrderEntriesOf(Map.of("error", "something went wrong"));
+              });
+    }
+
+    @Test
+    void listenerNotifiedWithJobErrorRaisedWithVariables() throws Exception {
+      var listener = mock(JobCompletionListener.class);
+      var response = new TestListenerResponse(Map.of("status", "fail"), listener);
+      var handler = newConnectorJobHandler(context -> response);
+
+      JobBuilder.create()
+          .withErrorExpressionHeader(
+              "=if response.status = \"fail\" then jobError(\"failed\", {detail: \"more info\"}) else null")
+          .executeAndCaptureResult(handler, false, false);
+
+      var captor = ArgumentCaptor.forClass(JobCompletionFailure.class);
+      verify(listener).onJobCompletionFailed(captor.capture());
+      assertThat(captor.getValue())
+          .isInstanceOfSatisfying(
+              JobCompletionFailure.JobErrorRaised.class,
+              failure -> {
+                assertThat(failure.errorMessage()).isEqualTo("failed");
+                assertThat(failure.variables())
+                    .containsExactlyInAnyOrderEntriesOf(
+                        Map.of("detail", "more info", "error", "failed"));
+              });
+    }
+
+    @Test
+    void listenerNotifiedWithJobErrorRaisedWithRetriesAndBackoff() throws Exception {
+      var listener = mock(JobCompletionListener.class);
+      var response = new TestListenerResponse(Map.of("status", "fail"), listener);
+      var handler = newConnectorJobHandler(context -> response);
+
+      JobBuilder.create()
+          .withErrorExpressionHeader(
+              "=if response.status = \"fail\" then jobError(\"retry me\", {}, 2, @\"PT30S\") else null")
+          .executeAndCaptureResult(handler, false, false);
+
+      var captor = ArgumentCaptor.forClass(JobCompletionFailure.class);
+      verify(listener).onJobCompletionFailed(captor.capture());
+      // retries and backoff control the FailJob command, not the notification
+      assertThat(captor.getValue())
+          .isInstanceOfSatisfying(
+              JobCompletionFailure.JobErrorRaised.class,
+              failure -> {
+                assertThat(failure.errorMessage()).isEqualTo("retry me");
+                assertThat(failure.variables())
+                    .containsExactlyInAnyOrderEntriesOf(Map.of("error", "retry me"));
+              });
+    }
+
+    @Test
+    void listenerNotifiedOnSuccessfulCompletion() throws Exception {
+      var listener = mock(JobCompletionListener.class);
+      var response = new TestListenerResponse(Map.of("key", "value"), listener);
+      var handler =
+          newConnectorJobHandler(
+              context -> response,
+              CompletableFuture.completedFuture(new CommandOutcome.Completed(null, 1)));
+
+      JobBuilder.create().execute(handler);
+
+      verify(listener).onJobCompleted();
+    }
+
+    @Test
+    void listenerNotifiedWithCommandIgnoredOnIgnoredOutcome() throws Exception {
+      var listener = mock(JobCompletionListener.class);
+      var response = new TestListenerResponse(Map.of("key", "value"), listener);
+      var cause = new RuntimeException("NOT_FOUND");
+      var handler =
+          newConnectorJobHandler(
+              context -> response,
+              CompletableFuture.completedFuture(new CommandOutcome.Ignored(cause, 1)));
+
+      JobBuilder.create().execute(handler);
+
+      var captor = ArgumentCaptor.forClass(JobCompletionFailure.class);
+      verify(listener).onJobCompletionFailed(captor.capture());
+      assertThat(captor.getValue())
+          .isInstanceOfSatisfying(
+              JobCompletionFailure.CommandIgnored.class,
+              failure -> assertThat(failure.cause()).isSameAs(cause));
+    }
+
+    @Test
+    void listenerNotifiedWithCommandFailedOnFailedOutcome() throws Exception {
+      var listener = mock(JobCompletionListener.class);
+      var response = new TestListenerResponse(Map.of("key", "value"), listener);
+      var cause = new RuntimeException("command failed");
+      var handler =
+          newConnectorJobHandler(
+              context -> response,
+              CompletableFuture.completedFuture(new CommandOutcome.Failed(cause, 3)));
+
+      JobBuilder.create().execute(handler);
+
+      var captor = ArgumentCaptor.forClass(JobCompletionFailure.class);
+      verify(listener).onJobCompletionFailed(captor.capture());
+      assertThat(captor.getValue())
+          .isInstanceOfSatisfying(
+              JobCompletionFailure.CommandFailed.class,
+              failure -> assertThat(failure.cause()).isSameAs(cause));
+    }
+
+    @Test
+    void listenerNotifiedWithCommandFailedOnFutureException() throws Exception {
+      var listener = mock(JobCompletionListener.class);
+      var response = new TestListenerResponse(Map.of("key", "value"), listener);
+      var cause = new RuntimeException("future failed");
+      var handler =
+          newConnectorJobHandler(context -> response, CompletableFuture.failedFuture(cause));
+
+      JobBuilder.create().execute(handler);
+
+      var captor = ArgumentCaptor.forClass(JobCompletionFailure.class);
+      verify(listener).onJobCompletionFailed(captor.capture());
+      assertThat(captor.getValue())
+          .isInstanceOfSatisfying(
+              JobCompletionFailure.CommandFailed.class,
+              failure -> assertThat(failure.cause()).isSameAs(cause));
+    }
+
+    @Test
+    void throwingListenerOnCompletionDoesNotPropagate() throws Exception {
+      var listener = mock(JobCompletionListener.class);
+      doThrow(new RuntimeException("listener exploded")).when(listener).onJobCompleted();
+      var response = new TestListenerResponse(Map.of("key", "value"), listener);
+      var handler =
+          newConnectorJobHandler(
+              context -> response,
+              CompletableFuture.completedFuture(new CommandOutcome.Completed(null, 1)));
+
+      // should not throw despite listener failure
+      JobBuilder.create().execute(handler);
+
+      verify(listener).onJobCompleted();
+    }
+
+    @Test
+    void throwingListenerOnFailureDoesNotPropagate() throws Exception {
+      var listener = mock(JobCompletionListener.class);
+      doThrow(new RuntimeException("listener exploded"))
+          .when(listener)
+          .onJobCompletionFailed(any());
+      var response = new TestListenerResponse(Map.of("status", "fail"), listener);
+      var handler = newConnectorJobHandler(context -> response);
+
+      // should not throw despite listener failure
+      JobBuilder.create()
+          .withErrorExpressionHeader(
+              "=if response.status = \"fail\" then bpmnError(\"ERR\", \"boom\") else null")
+          .executeAndCaptureResult(handler, false, true);
+
+      verify(listener).onJobCompletionFailed(any());
+    }
+
+    @Test
+    void listenerNotifiedOnIgnoreErrorCompletion() throws Exception {
+      var listener = mock(JobCompletionListener.class);
+      var response = new TestListenerResponse(Map.of("status", "fail"), listener);
+      var handler =
+          newConnectorJobHandler(
+              context -> response,
+              CompletableFuture.completedFuture(new CommandOutcome.Completed(null, 1)));
+
+      JobBuilder.create()
+          .withErrorExpressionHeader(
+              "=if response.status = \"fail\" then ignoreError({\"recovered\": true}) else null")
+          .executeAndCaptureResult(handler);
+
+      verify(listener).onJobCompleted();
+    }
+
+    @Test
+    void listenerNotifiedWhenErrorExpressionEvaluationFails() throws Exception {
+      var listener = mock(JobCompletionListener.class);
+      var response = new TestListenerResponse(Map.of("key", "value"), listener);
+      var handler = newConnectorJobHandler(context -> response);
+
+      // expression returning a non-object value causes examineErrorExpression to throw
+      JobBuilder.create()
+          .withErrorExpressionHeader("=\"not an error object\"")
+          .executeAndCaptureResult(handler, false);
+
+      var captor = ArgumentCaptor.forClass(JobCompletionFailure.class);
+      verify(listener).onJobCompletionFailed(captor.capture());
+      assertThat(captor.getValue()).isInstanceOf(JobCompletionFailure.CommandFailed.class);
+    }
+
+    @Test
+    void noListenerDoesNotCrash() throws Exception {
+      // response that does NOT implement JobCompletionListener
+      var handler =
+          newConnectorJobHandler(
+              context -> StandardConnectorResponse.of(Map.of("key", "value")),
+              CompletableFuture.completedFuture(new CommandOutcome.Completed(null, 1)));
+
+      // should not throw
+      JobBuilder.create().execute(handler);
+    }
+
+    /** Response that implements both StandardConnectorResponse and JobCompletionListener. */
+    private record TestListenerResponse(Object responseValue, JobCompletionListener delegate)
+        implements StandardConnectorResponse, JobCompletionListener {
+
+      @Override
+      public void onJobCompleted() {
+        delegate.onJobCompleted();
+      }
+
+      @Override
+      public void onJobCompletionFailed(JobCompletionFailure failure) {
+        delegate.onJobCompletionFailed(failure);
+      }
     }
   }
 }

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/job/SpringConnectorJobHandlerTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/job/SpringConnectorJobHandlerTest.java
@@ -1726,7 +1726,9 @@ class SpringConnectorJobHandlerTest {
     void listenerNotifiedWithBpmnErrorThrownOnBpmnErrorExpression() throws Exception {
       var listener = mock(JobCompletionListener.class);
       var function = new TestListenerFunction(Map.of("status", "fail"), listener);
-      var handler = newConnectorJobHandler(function);
+      var handler =
+          newConnectorJobHandler(
+              function, CompletableFuture.completedFuture(new CommandOutcome.Completed(null, 1)));
 
       JobBuilder.create()
           .withErrorExpressionHeader(
@@ -1742,6 +1744,7 @@ class SpringConnectorJobHandlerTest {
                 assertThat(failure.errorCode()).isEqualTo("ERR_001");
                 assertThat(failure.errorMessage()).isEqualTo("test error");
                 assertThat(failure.variables()).isEmpty();
+                assertThat(failure.commandFailure()).isNull();
               });
     }
 
@@ -1749,7 +1752,9 @@ class SpringConnectorJobHandlerTest {
     void listenerNotifiedWithBpmnErrorThrownWithVariables() throws Exception {
       var listener = mock(JobCompletionListener.class);
       var function = new TestListenerFunction(Map.of("status", "fail"), listener);
-      var handler = newConnectorJobHandler(function);
+      var handler =
+          newConnectorJobHandler(
+              function, CompletableFuture.completedFuture(new CommandOutcome.Completed(null, 1)));
 
       JobBuilder.create()
           .withErrorExpressionHeader(
@@ -1766,6 +1771,36 @@ class SpringConnectorJobHandlerTest {
                 assertThat(failure.errorMessage()).isEqualTo("with vars");
                 assertThat(failure.variables())
                     .containsExactlyInAnyOrderEntriesOf(Map.of("detail", "info"));
+                assertThat(failure.commandFailure()).isNull();
+              });
+    }
+
+    @Test
+    void listenerNotifiedWithBpmnErrorAndCommandFailureWhenThrowBpmnErrorRejected()
+        throws Exception {
+      var listener = mock(JobCompletionListener.class);
+      var function = new TestListenerFunction(Map.of("status", "fail"), listener);
+      var cause = new RuntimeException("Zeebe rejected throwBpmnError");
+      var handler =
+          newConnectorJobHandler(
+              function, CompletableFuture.completedFuture(new CommandOutcome.Failed(cause, 3)));
+
+      JobBuilder.create()
+          .withErrorExpressionHeader(
+              "=if response.status = \"fail\" then bpmnError(\"ERR_X\", \"boom\") else null")
+          .executeAndCaptureResult(handler, false, true);
+
+      var captor = ArgumentCaptor.forClass(JobCompletionFailure.class);
+      verify(listener).onJobCompletionFailed(any(), any(ConnectorResponse.class), captor.capture());
+      assertThat(captor.getValue())
+          .isInstanceOfSatisfying(
+              JobCompletionFailure.BpmnErrorThrown.class,
+              failure -> {
+                assertThat(failure.errorCode()).isEqualTo("ERR_X");
+                assertThat(failure.commandFailure())
+                    .isInstanceOfSatisfying(
+                        JobCompletionFailure.CommandFailure.CommandFailed.class,
+                        cf -> assertThat(cf.cause()).isSameAs(cause));
               });
     }
 
@@ -1773,7 +1808,9 @@ class SpringConnectorJobHandlerTest {
     void listenerNotifiedWithJobErrorRaisedOnJobErrorExpression() throws Exception {
       var listener = mock(JobCompletionListener.class);
       var function = new TestListenerFunction(Map.of("status", "fail"), listener);
-      var handler = newConnectorJobHandler(function);
+      var handler =
+          newConnectorJobHandler(
+              function, CompletableFuture.completedFuture(new CommandOutcome.Completed(null, 1)));
 
       JobBuilder.create()
           .withErrorExpressionHeader(
@@ -1789,6 +1826,7 @@ class SpringConnectorJobHandlerTest {
                 assertThat(failure.errorMessage()).isEqualTo("something went wrong");
                 assertThat(failure.variables())
                     .containsExactlyInAnyOrderEntriesOf(Map.of("error", "something went wrong"));
+                assertThat(failure.commandFailure()).isNull();
               });
     }
 
@@ -1796,7 +1834,9 @@ class SpringConnectorJobHandlerTest {
     void listenerNotifiedWithJobErrorRaisedWithVariables() throws Exception {
       var listener = mock(JobCompletionListener.class);
       var function = new TestListenerFunction(Map.of("status", "fail"), listener);
-      var handler = newConnectorJobHandler(function);
+      var handler =
+          newConnectorJobHandler(
+              function, CompletableFuture.completedFuture(new CommandOutcome.Completed(null, 1)));
 
       JobBuilder.create()
           .withErrorExpressionHeader(
@@ -1813,6 +1853,7 @@ class SpringConnectorJobHandlerTest {
                 assertThat(failure.variables())
                     .containsExactlyInAnyOrderEntriesOf(
                         Map.of("detail", "more info", "error", "failed"));
+                assertThat(failure.commandFailure()).isNull();
               });
     }
 
@@ -1820,7 +1861,9 @@ class SpringConnectorJobHandlerTest {
     void listenerNotifiedWithJobErrorRaisedWithRetriesAndBackoff() throws Exception {
       var listener = mock(JobCompletionListener.class);
       var function = new TestListenerFunction(Map.of("status", "fail"), listener);
-      var handler = newConnectorJobHandler(function);
+      var handler =
+          newConnectorJobHandler(
+              function, CompletableFuture.completedFuture(new CommandOutcome.Completed(null, 1)));
 
       JobBuilder.create()
           .withErrorExpressionHeader(
@@ -1837,6 +1880,35 @@ class SpringConnectorJobHandlerTest {
                 assertThat(failure.errorMessage()).isEqualTo("retry me");
                 assertThat(failure.variables())
                     .containsExactlyInAnyOrderEntriesOf(Map.of("error", "retry me"));
+                assertThat(failure.commandFailure()).isNull();
+              });
+    }
+
+    @Test
+    void listenerNotifiedWithJobErrorAndCommandFailureWhenFailJobRejected() throws Exception {
+      var listener = mock(JobCompletionListener.class);
+      var function = new TestListenerFunction(Map.of("status", "fail"), listener);
+      var cause = new RuntimeException("Zeebe rejected failJob");
+      var handler =
+          newConnectorJobHandler(
+              function, CompletableFuture.completedFuture(new CommandOutcome.Ignored(cause, 1)));
+
+      JobBuilder.create()
+          .withErrorExpressionHeader(
+              "=if response.status = \"fail\" then jobError(\"boom\") else null")
+          .executeAndCaptureResult(handler, false, false);
+
+      var captor = ArgumentCaptor.forClass(JobCompletionFailure.class);
+      verify(listener).onJobCompletionFailed(any(), any(ConnectorResponse.class), captor.capture());
+      assertThat(captor.getValue())
+          .isInstanceOfSatisfying(
+              JobCompletionFailure.JobErrorRaised.class,
+              failure -> {
+                assertThat(failure.errorMessage()).isEqualTo("boom");
+                assertThat(failure.commandFailure())
+                    .isInstanceOfSatisfying(
+                        JobCompletionFailure.CommandFailure.CommandIgnored.class,
+                        cf -> assertThat(cf.cause()).isSameAs(cause));
               });
     }
 
@@ -1868,7 +1940,7 @@ class SpringConnectorJobHandlerTest {
       verify(listener).onJobCompletionFailed(any(), any(ConnectorResponse.class), captor.capture());
       assertThat(captor.getValue())
           .isInstanceOfSatisfying(
-              JobCompletionFailure.CommandIgnored.class,
+              JobCompletionFailure.CommandFailure.CommandIgnored.class,
               failure -> assertThat(failure.cause()).isSameAs(cause));
     }
 
@@ -1887,7 +1959,7 @@ class SpringConnectorJobHandlerTest {
       verify(listener).onJobCompletionFailed(any(), any(ConnectorResponse.class), captor.capture());
       assertThat(captor.getValue())
           .isInstanceOfSatisfying(
-              JobCompletionFailure.CommandFailed.class,
+              JobCompletionFailure.CommandFailure.CommandFailed.class,
               failure -> assertThat(failure.cause()).isSameAs(cause));
     }
 
@@ -1904,7 +1976,7 @@ class SpringConnectorJobHandlerTest {
       verify(listener).onJobCompletionFailed(any(), any(ConnectorResponse.class), captor.capture());
       assertThat(captor.getValue())
           .isInstanceOfSatisfying(
-              JobCompletionFailure.CommandFailed.class,
+              JobCompletionFailure.CommandFailure.CommandFailed.class,
               failure -> assertThat(failure.cause()).isSameAs(cause));
     }
 
@@ -1932,7 +2004,9 @@ class SpringConnectorJobHandlerTest {
           .when(listener)
           .onJobCompletionFailed(any(), any(), any());
       var function = new TestListenerFunction(Map.of("status", "fail"), listener);
-      var handler = newConnectorJobHandler(function);
+      var handler =
+          newConnectorJobHandler(
+              function, CompletableFuture.completedFuture(new CommandOutcome.Completed(null, 1)));
 
       // should not throw despite listener failure
       JobBuilder.create()
@@ -1972,7 +2046,8 @@ class SpringConnectorJobHandlerTest {
 
       var captor = ArgumentCaptor.forClass(JobCompletionFailure.class);
       verify(listener).onJobCompletionFailed(any(), any(ConnectorResponse.class), captor.capture());
-      assertThat(captor.getValue()).isInstanceOf(JobCompletionFailure.CommandFailed.class);
+      assertThat(captor.getValue())
+          .isInstanceOf(JobCompletionFailure.CommandFailure.CommandFailed.class);
     }
 
     @Test
@@ -1987,7 +2062,7 @@ class SpringConnectorJobHandlerTest {
       verify(listener).onJobCompletionFailed(any(), eq(null), captor.capture());
       assertThat(captor.getValue())
           .isInstanceOfSatisfying(
-              JobCompletionFailure.CommandFailed.class,
+              JobCompletionFailure.CommandFailure.CommandFailed.class,
               failure -> assertThat(failure.cause()).hasMessage("execute exploded"));
     }
 

--- a/connector-sdk/core/pom.xml
+++ b/connector-sdk/core/pom.xml
@@ -26,6 +26,11 @@
           <artifactId>jackson-databind</artifactId>
           <scope>provided</scope>
       </dependency>
+
+      <dependency>
+          <groupId>org.jspecify</groupId>
+          <artifactId>jspecify</artifactId>
+      </dependency>
   </dependencies>
 
 </project>

--- a/connector-sdk/core/src/main/java/io/camunda/connector/api/outbound/JobCompletionFailure.java
+++ b/connector-sdk/core/src/main/java/io/camunda/connector/api/outbound/JobCompletionFailure.java
@@ -17,28 +17,57 @@
 package io.camunda.connector.api.outbound;
 
 import java.util.Map;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Describes why a job completion did not succeed. Used as the parameter for {@link
  * JobCompletionListener#onJobCompletionFailed}.
+ *
+ * <p>The hierarchy separates two concerns:
+ *
+ * <ul>
+ *   <li>{@link CommandFailure} — Zeebe rejected or ignored the command we sent.
+ *   <li>{@link BpmnErrorThrown} / {@link JobErrorRaised} — the connector decided not to complete
+ *       normally (via an error expression). They optionally carry a {@link CommandFailure} to
+ *       surface the case where the throwBpmnError / failJob command itself was rejected by Zeebe.
+ * </ul>
  */
 public sealed interface JobCompletionFailure {
 
+  /** Failure modes originating from the Zeebe command outcome. */
+  sealed interface CommandFailure extends JobCompletionFailure {
+
+    /**
+     * The job could not be completed successfully. This covers Zeebe command failures (network
+     * error, internal error after retries) as well as runtime-level rejections (e.g., unsupported
+     * error expression for the connector type).
+     */
+    record CommandFailed(Throwable cause) implements CommandFailure {}
+
+    /** The job was superseded — the command got NOT_FOUND (e.g., job was already completed). */
+    record CommandIgnored(Throwable cause) implements CommandFailure {}
+  }
+
   /**
-   * The job could not be completed successfully. This covers Zeebe command failures (network error,
-   * internal error after retries) as well as runtime-level rejections (e.g., unsupported error
-   * expression for the connector type).
+   * A failJob command was issued (e.g., from error expression evaluation).
+   *
+   * @param commandFailure {@code null} if Zeebe accepted the failJob command; populated if the
+   *     command itself was rejected.
    */
-  record CommandFailed(Throwable cause) implements JobCompletionFailure {}
-
-  /** The job was superseded — the command got NOT_FOUND (e.g., job was already completed). */
-  record CommandIgnored(Throwable cause) implements JobCompletionFailure {}
-
-  /** A failJob command was issued (e.g., from error expression evaluation). */
-  record JobErrorRaised(String errorMessage, Map<String, Object> variables)
+  record JobErrorRaised(
+      String errorMessage, Map<String, Object> variables, @Nullable CommandFailure commandFailure)
       implements JobCompletionFailure {}
 
-  /** A throwBpmnError command was issued (e.g., from error expression evaluation). */
-  record BpmnErrorThrown(String errorCode, String errorMessage, Map<String, Object> variables)
+  /**
+   * A throwBpmnError command was issued (e.g., from error expression evaluation).
+   *
+   * @param commandFailure {@code null} if Zeebe accepted the throwBpmnError command; populated if
+   *     the command itself was rejected.
+   */
+  record BpmnErrorThrown(
+      String errorCode,
+      String errorMessage,
+      Map<String, Object> variables,
+      @Nullable CommandFailure commandFailure)
       implements JobCompletionFailure {}
 }

--- a/connector-sdk/core/src/main/java/io/camunda/connector/api/outbound/JobCompletionFailure.java
+++ b/connector-sdk/core/src/main/java/io/camunda/connector/api/outbound/JobCompletionFailure.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.api.outbound;
+
+import java.util.Map;
+
+/**
+ * Describes why a job completion did not succeed. Used as the parameter for {@link
+ * JobCompletionListener#onJobCompletionFailed}.
+ */
+public sealed interface JobCompletionFailure {
+
+  /**
+   * The job could not be completed successfully. This covers Zeebe command failures (network error,
+   * internal error after retries) as well as runtime-level rejections (e.g., unsupported error
+   * expression for the connector type).
+   */
+  record CommandFailed(Throwable cause) implements JobCompletionFailure {}
+
+  /** The job was superseded — the command got NOT_FOUND (e.g., job was already completed). */
+  record CommandIgnored(Throwable cause) implements JobCompletionFailure {}
+
+  /** A failJob command was issued (e.g., from error expression evaluation). */
+  record JobErrorRaised(String errorMessage, Map<String, Object> variables)
+      implements JobCompletionFailure {}
+
+  /** A throwBpmnError command was issued (e.g., from error expression evaluation). */
+  record BpmnErrorThrown(String errorCode, String errorMessage, Map<String, Object> variables)
+      implements JobCompletionFailure {}
+}

--- a/connector-sdk/core/src/main/java/io/camunda/connector/api/outbound/JobCompletionFailure.java
+++ b/connector-sdk/core/src/main/java/io/camunda/connector/api/outbound/JobCompletionFailure.java
@@ -23,14 +23,20 @@ import org.jspecify.annotations.Nullable;
  * Describes why a job completion did not succeed. Used as the parameter for {@link
  * JobCompletionListener#onJobCompletionFailed}.
  *
- * <p>The hierarchy separates two concerns:
+ * <p>The hierarchy separates "things went wrong" from "the connector deliberately chose to fail":
  *
  * <ul>
  *   <li>{@link CommandFailure} — Zeebe rejected or ignored the command we sent.
- *   <li>{@link BpmnErrorThrown} / {@link JobErrorRaised} — the connector decided not to complete
- *       normally (via an error expression). They optionally carry a {@link CommandFailure} to
- *       surface the case where the throwBpmnError / failJob command itself was rejected by Zeebe.
+ *   <li>{@link ExecutionFailed} — the connector or runtime hit an error before/while producing a
+ *       usable response (function exception, error-expression evaluation failure, runtime-
+ *       synthesized rejection).
+ *   <li>{@link BpmnErrorThrown} / {@link JobErrorRaised} — the connector deliberately chose not to
+ *       complete normally (via an error expression).
  * </ul>
+ *
+ * <p>{@link ExecutionFailed}, {@link BpmnErrorThrown} and {@link JobErrorRaised} each carry an
+ * optional {@link CommandFailure} that surfaces whether the failJob / throwBpmnError command sent
+ * in response was itself accepted by Zeebe.
  */
 public sealed interface JobCompletionFailure {
 
@@ -38,9 +44,8 @@ public sealed interface JobCompletionFailure {
   sealed interface CommandFailure extends JobCompletionFailure {
 
     /**
-     * The job could not be completed successfully. This covers Zeebe command failures (network
-     * error, internal error after retries) as well as runtime-level rejections (e.g., unsupported
-     * error expression for the connector type).
+     * Zeebe rejected the command we sent (network error, internal error after retries, or other
+     * server-side rejection).
      */
     record CommandFailed(Throwable cause) implements CommandFailure {}
 
@@ -49,13 +54,15 @@ public sealed interface JobCompletionFailure {
   }
 
   /**
-   * A failJob command was issued (e.g., from error expression evaluation).
+   * Job completion failed because the connector or runtime hit an error before/while producing a
+   * usable response. Covers connector function exceptions, error-expression evaluation failures,
+   * and runtime-synthesized rejections (e.g., {@code IgnoreError} used by a connector that doesn't
+   * support it).
    *
-   * @param commandFailure {@code null} if Zeebe accepted the failJob command; populated if the
-   *     command itself was rejected.
+   * @param commandFailure {@code null} if Zeebe accepted the failJob command sent in response;
+   *     populated if the command itself was rejected.
    */
-  record JobErrorRaised(
-      String errorMessage, Map<String, Object> variables, @Nullable CommandFailure commandFailure)
+  record ExecutionFailed(Throwable cause, @Nullable CommandFailure commandFailure)
       implements JobCompletionFailure {}
 
   /**
@@ -69,5 +76,15 @@ public sealed interface JobCompletionFailure {
       String errorMessage,
       Map<String, Object> variables,
       @Nullable CommandFailure commandFailure)
+      implements JobCompletionFailure {}
+
+  /**
+   * A failJob command was issued (e.g., from error expression evaluation).
+   *
+   * @param commandFailure {@code null} if Zeebe accepted the failJob command; populated if the
+   *     command itself was rejected.
+   */
+  record JobErrorRaised(
+      String errorMessage, Map<String, Object> variables, @Nullable CommandFailure commandFailure)
       implements JobCompletionFailure {}
 }

--- a/connector-sdk/core/src/main/java/io/camunda/connector/api/outbound/JobCompletionListener.java
+++ b/connector-sdk/core/src/main/java/io/camunda/connector/api/outbound/JobCompletionListener.java
@@ -22,10 +22,11 @@ import org.jspecify.annotations.Nullable;
  * Optional callbacks for job completion outcomes. An {@link OutboundConnectorFunction} can
  * implement this interface to receive notification after the Zeebe command is dispatched.
  *
- * <p>For the completeJob path, callbacks fire asynchronously after the command future resolves. For
- * failJob and throwBpmnError paths (triggered by error expressions or pre-response failures),
- * callbacks fire synchronously before the command is dispatched, since the outcome is already
- * determined.
+ * <p>Callbacks fire asynchronously after the corresponding Zeebe command future ({@code
+ * completeJob}, {@code failJob}, or {@code throwBpmnError}) resolves. The associated {@link
+ * JobCompletionFailure} subtype reflects the path that produced the outcome, with an optional
+ * {@code commandFailure} field surfacing the case where the response command was itself rejected by
+ * Zeebe.
  */
 public interface JobCompletionListener {
 

--- a/connector-sdk/core/src/main/java/io/camunda/connector/api/outbound/JobCompletionListener.java
+++ b/connector-sdk/core/src/main/java/io/camunda/connector/api/outbound/JobCompletionListener.java
@@ -16,22 +16,41 @@
  */
 package io.camunda.connector.api.outbound;
 
+import org.jspecify.annotations.Nullable;
+
 /**
- * Callbacks for job completion outcomes. Connector responses can implement this interface to
- * receive notification after the Zeebe command is dispatched.
+ * Optional callbacks for job completion outcomes. An {@link OutboundConnectorFunction} can
+ * implement this interface to receive notification after the Zeebe command is dispatched.
  *
  * <p>For the completeJob path, callbacks fire asynchronously after the command future resolves. For
- * failJob and throwBpmnError paths (triggered by error expressions), callbacks fire synchronously
- * before the command is dispatched, since the outcome is already determined.
+ * failJob and throwBpmnError paths (triggered by error expressions or pre-response failures),
+ * callbacks fire synchronously before the command is dispatched, since the outcome is already
+ * determined.
  */
 public interface JobCompletionListener {
 
-  /** Called when the job was successfully completed (completeJob command accepted by Zeebe). */
-  void onJobCompleted();
+  /**
+   * Called when the job was successfully completed (completeJob command accepted by Zeebe).
+   *
+   * @param context the connector context for the job
+   * @param response the connector response that was used to complete the job
+   */
+  void onJobCompleted(OutboundConnectorContext context, ConnectorResponse response);
 
   /**
    * Called when the job was not successfully completed. This covers command failures, superseded
-   * jobs, error expression failures, and BPMN errors.
+   * jobs, error expression failures, BPMN errors, and pre-response failures (variable
+   * binding/validation/{@code execute()} throwing).
+   *
+   * <p>The {@code response} argument is {@code null} when no response was produced (e.g. the
+   * connector function threw before returning).
+   *
+   * @param context the connector context for the job
+   * @param response the connector response, or {@code null} if no response was produced
+   * @param failure the failure that caused job completion to fail
    */
-  void onJobCompletionFailed(JobCompletionFailure failure);
+  void onJobCompletionFailed(
+      OutboundConnectorContext context,
+      @Nullable ConnectorResponse response,
+      JobCompletionFailure failure);
 }

--- a/connector-sdk/core/src/main/java/io/camunda/connector/api/outbound/JobCompletionListener.java
+++ b/connector-sdk/core/src/main/java/io/camunda/connector/api/outbound/JobCompletionListener.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.api.outbound;
+
+/**
+ * Callbacks for job completion outcomes. Connector responses can implement this interface to
+ * receive notification after the Zeebe command is dispatched.
+ *
+ * <p>For the completeJob path, callbacks fire asynchronously after the command future resolves. For
+ * failJob and throwBpmnError paths (triggered by error expressions), callbacks fire synchronously
+ * before the command is dispatched, since the outcome is already determined.
+ */
+public interface JobCompletionListener {
+
+  /** Called when the job was successfully completed (completeJob command accepted by Zeebe). */
+  void onJobCompleted();
+
+  /**
+   * Called when the job was not successfully completed. This covers command failures, superseded
+   * jobs, error expression failures, and BPMN errors.
+   */
+  void onJobCompletionFailed(JobCompletionFailure failure);
+}

--- a/connector-sdk/core/src/main/java/io/camunda/connector/api/outbound/OutboundConnectorFunction.java
+++ b/connector-sdk/core/src/main/java/io/camunda/connector/api/outbound/OutboundConnectorFunction.java
@@ -19,6 +19,10 @@ package io.camunda.connector.api.outbound;
 /**
  * Central function interface of a connector. This will be called from the environment-specific
  * runtime.
+ *
+ * <p>Implementations may additionally implement {@link JobCompletionListener} to receive
+ * notifications after the Zeebe completion command resolves (success, BPMN error, command failure,
+ * or pre-response failure).
  */
 public interface OutboundConnectorFunction {
 
@@ -27,7 +31,10 @@ public interface OutboundConnectorFunction {
    * to fetch objects provided by the environment transparently.
    *
    * <p>The connector can return any serializable object that will be passed to the
-   * environment-specific runtime.
+   * environment-specific runtime. Returning a {@link ConnectorResponse} subtype (e.g. {@link
+   * ConnectorResponse.StandardConnectorResponse} or {@link
+   * ConnectorResponse.AdHocSubProcessConnectorResponse}) gives finer control over how the runtime
+   * completes the job; any other object is wrapped in a standard response.
    *
    * <p>Checked exceptions can be handled by the connector if desired. The environment-specifc
    * runtime will also take care of catching all checked exceptions from the connector function.

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/langchain4j/jobworker/L4JAiAgentJobWorkerMemoryStorageTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/langchain4j/jobworker/L4JAiAgentJobWorkerMemoryStorageTests.java
@@ -19,25 +19,43 @@ package io.camunda.connector.e2e.agenticai.aiagent.langchain4j.jobworker;
 import static io.camunda.connector.e2e.agenticai.aiagent.AiAgentTestFixtures.FEEDBACK_LOOP_RESPONSE_TEXT;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.within;
+import static org.awaitility.Awaitility.await;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.verify;
 
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.model.chat.response.ChatResponseMetadata;
+import dev.langchain4j.model.output.FinishReason;
+import dev.langchain4j.model.output.TokenUsage;
 import io.camunda.connector.agenticai.aiagent.memory.conversation.awsagentcore.AwsAgentCoreConversationContext;
 import io.camunda.connector.agenticai.aiagent.memory.conversation.document.CamundaDocumentConversationContext;
+import io.camunda.connector.agenticai.aiagent.memory.conversation.document.CamundaDocumentConversationStore;
 import io.camunda.connector.agenticai.aiagent.memory.conversation.inprocess.InProcessConversationContext;
+import io.camunda.connector.agenticai.aiagent.model.AgentExecutionContext;
 import io.camunda.connector.api.document.DocumentReference.CamundaDocumentReference;
 import io.camunda.connector.e2e.agenticai.AgentCoreMemoryTestConfiguration;
 import io.camunda.connector.e2e.agenticai.InMemoryBedrockAgentCoreClientFactory;
 import io.camunda.connector.e2e.agenticai.assertj.JobWorkerAgentResponseAssert;
+import io.camunda.connector.runtime.core.document.store.CamundaDocumentStore;
 import io.camunda.connector.test.utils.annotation.SlowTest;
 import java.time.Duration;
 import java.time.OffsetDateTime;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.context.annotation.Import;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 
 @SlowTest
 @Import(AgentCoreMemoryTestConfiguration.class)
 public class L4JAiAgentJobWorkerMemoryStorageTests extends BaseL4JAiAgentJobWorkerTest {
+
+  @MockitoSpyBean private CamundaDocumentConversationStore documentConversationStore;
+  @MockitoSpyBean private CamundaDocumentStore documentStore;
 
   @BeforeEach
   void clearAgentCoreMemoryStore() {
@@ -111,6 +129,76 @@ public class L4JAiAgentJobWorkerMemoryStorageTests extends BaseL4JAiAgentJobWork
                             });
                   });
         });
+  }
+
+  @Test
+  void camundaDocumentStorage_cleansUpOrphanedDocumentOnJobCompletionFailure() throws Exception {
+    // capture the job key from the createSession call on the spy
+    var jobKey = new AtomicLong();
+    doAnswer(
+            invocation -> {
+              AgentExecutionContext executionContext = invocation.getArgument(0);
+              jobKey.set(executionContext.jobContext().getJobKey());
+              return invocation.callRealMethod();
+            })
+        .when(documentConversationStore)
+        .createSession(any(), any());
+
+    // capture the reference of the document created by storeMessages during this job —
+    // this is the document that becomes orphaned when job completion fails
+    var createdReference = new AtomicReference<CamundaDocumentReference>();
+    doAnswer(
+            invocation -> {
+              CamundaDocumentReference ref = (CamundaDocumentReference) invocation.callRealMethod();
+              createdReference.set(ref);
+              return ref;
+            })
+        .when(documentStore)
+        .createDocument(any());
+
+    final var initialUserPrompt = "Write a haiku about the sea";
+    final var responseText = "Waves crash on the shore";
+
+    doAnswer(
+            invocation -> {
+              // fail the job via Zeebe API — causes the subsequent completeJob to be rejected
+              camundaClient
+                  .newFailCommand(jobKey.get())
+                  .retries(0)
+                  .errorMessage("Deliberately failed for e2e test")
+                  .send()
+                  .join();
+
+              return ChatResponse.builder()
+                  .metadata(
+                      ChatResponseMetadata.builder()
+                          .finishReason(FinishReason.STOP)
+                          .tokenUsage(new TokenUsage(10, 20))
+                          .build())
+                  .aiMessage(new AiMessage(responseText))
+                  .build();
+            })
+        .when(chatModel)
+        .chat(chatRequestCaptor.capture());
+
+    createProcessInstance(
+        elementTemplate ->
+            elementTemplate
+                .property("data.memory.storage.type", "camunda-document")
+                .property("data.memory.storage.timeToLive", "PT1H"),
+        Map.of("userPrompt", initialUserPrompt));
+
+    // verify that onJobCompletionFailed deleted the exact document that was written by
+    // storeMessages — the orphaned document that no Zeebe pointer will ever reference
+    await()
+        .alias("onJobCompletionFailed should clean up the orphaned document")
+        .atMost(Duration.ofSeconds(30))
+        .pollInterval(Duration.ofMillis(500))
+        .untilAsserted(
+            () -> {
+              assertThat(createdReference.get()).isNotNull();
+              verify(documentStore).deleteDocument(createdReference.get());
+            });
   }
 
   @Test

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/langchain4j/outboundconnector/L4JAiAgentConnectorMemoryStorageTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/langchain4j/outboundconnector/L4JAiAgentConnectorMemoryStorageTests.java
@@ -19,25 +19,43 @@ package io.camunda.connector.e2e.agenticai.aiagent.langchain4j.outboundconnector
 import static io.camunda.connector.e2e.agenticai.aiagent.AiAgentTestFixtures.FEEDBACK_LOOP_RESPONSE_TEXT;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.within;
+import static org.awaitility.Awaitility.await;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.verify;
 
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.model.chat.response.ChatResponseMetadata;
+import dev.langchain4j.model.output.FinishReason;
+import dev.langchain4j.model.output.TokenUsage;
 import io.camunda.connector.agenticai.aiagent.memory.conversation.awsagentcore.AwsAgentCoreConversationContext;
 import io.camunda.connector.agenticai.aiagent.memory.conversation.document.CamundaDocumentConversationContext;
+import io.camunda.connector.agenticai.aiagent.memory.conversation.document.CamundaDocumentConversationStore;
 import io.camunda.connector.agenticai.aiagent.memory.conversation.inprocess.InProcessConversationContext;
+import io.camunda.connector.agenticai.aiagent.model.AgentExecutionContext;
 import io.camunda.connector.api.document.DocumentReference.CamundaDocumentReference;
 import io.camunda.connector.e2e.agenticai.AgentCoreMemoryTestConfiguration;
 import io.camunda.connector.e2e.agenticai.InMemoryBedrockAgentCoreClientFactory;
 import io.camunda.connector.e2e.agenticai.assertj.AgentResponseAssert;
+import io.camunda.connector.runtime.core.document.store.CamundaDocumentStore;
 import io.camunda.connector.test.utils.annotation.SlowTest;
 import java.time.Duration;
 import java.time.OffsetDateTime;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.context.annotation.Import;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 
 @SlowTest
 @Import(AgentCoreMemoryTestConfiguration.class)
 public class L4JAiAgentConnectorMemoryStorageTests extends BaseL4JAiAgentConnectorTest {
+
+  @MockitoSpyBean private CamundaDocumentConversationStore documentConversationStore;
+  @MockitoSpyBean private CamundaDocumentStore documentStore;
 
   @BeforeEach
   void clearAgentCoreMemoryStore() {
@@ -111,6 +129,76 @@ public class L4JAiAgentConnectorMemoryStorageTests extends BaseL4JAiAgentConnect
                             });
                   });
         });
+  }
+
+  @Test
+  void camundaDocumentStorage_cleansUpOrphanedDocumentOnJobCompletionFailure() throws Exception {
+    // capture the job key from the createSession call on the spy
+    var jobKey = new AtomicLong();
+    doAnswer(
+            invocation -> {
+              AgentExecutionContext executionContext = invocation.getArgument(0);
+              jobKey.set(executionContext.jobContext().getJobKey());
+              return invocation.callRealMethod();
+            })
+        .when(documentConversationStore)
+        .createSession(any(), any());
+
+    // capture the reference of the document created by storeMessages during this job —
+    // this is the document that becomes orphaned when job completion fails
+    var createdReference = new AtomicReference<CamundaDocumentReference>();
+    doAnswer(
+            invocation -> {
+              CamundaDocumentReference ref = (CamundaDocumentReference) invocation.callRealMethod();
+              createdReference.set(ref);
+              return ref;
+            })
+        .when(documentStore)
+        .createDocument(any());
+
+    final var initialUserPrompt = "Write a haiku about the sea";
+    final var responseText = "Waves crash on the shore";
+
+    doAnswer(
+            invocation -> {
+              // fail the job via Zeebe API — causes the subsequent completeJob to be rejected
+              camundaClient
+                  .newFailCommand(jobKey.get())
+                  .retries(0)
+                  .errorMessage("Deliberately failed for e2e test")
+                  .send()
+                  .join();
+
+              return ChatResponse.builder()
+                  .metadata(
+                      ChatResponseMetadata.builder()
+                          .finishReason(FinishReason.STOP)
+                          .tokenUsage(new TokenUsage(10, 20))
+                          .build())
+                  .aiMessage(new AiMessage(responseText))
+                  .build();
+            })
+        .when(chatModel)
+        .chat(chatRequestCaptor.capture());
+
+    createProcessInstance(
+        elementTemplate ->
+            elementTemplate
+                .property("data.memory.storage.type", "camunda-document")
+                .property("data.memory.storage.timeToLive", "PT1H"),
+        Map.of("userPrompt", initialUserPrompt));
+
+    // verify that onJobCompletionFailed deleted the exact document that was written by
+    // storeMessages — the orphaned document that no Zeebe pointer will ever reference
+    await()
+        .alias("onJobCompletionFailed should clean up the orphaned document")
+        .atMost(Duration.ofSeconds(30))
+        .pollInterval(Duration.ofMillis(500))
+        .untilAsserted(
+            () -> {
+              assertThat(createdReference.get()).isNotNull();
+              verify(documentStore).deleteDocument(createdReference.get());
+            });
   }
 
   @Test

--- a/connectors-e2e-test/connectors-e2e-test-http/src/test/java/io/camunda/connector/e2e/HttpTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-http/src/test/java/io/camunda/connector/e2e/HttpTests.java
@@ -57,10 +57,8 @@ import java.util.Map;
 import java.util.Set;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.api.io.TempDir;
-import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
@@ -76,7 +74,6 @@ import wiremock.com.fasterxml.jackson.databind.node.JsonNodeFactory;
     },
     webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @CamundaSpringProcessTest
-@ExtendWith(MockitoExtension.class)
 public class HttpTests {
 
   @RegisterExtension

--- a/connectors/agentic-ai/docs/adr/002-consolidate-job-worker-into-sdk.md
+++ b/connectors/agentic-ai/docs/adr/002-consolidate-job-worker-into-sdk.md
@@ -51,14 +51,13 @@ Zeebe complete command with `.withResult().forAdHocSubProcess()` configuration. 
 - Future SDK improvements automatically apply to both AI Agent flavors
 
 **Negative:**
-- Job completion callbacks (success/error notification) are not yet supported — the callback mechanism on
-  `CommandWrapper` needs to be implemented in a follow-up
-- `ConversationStore.compensateFailedJobCompletion()` is deprecated and currently not invoked — it will be removed once completion callbacks are implemented
+- ~~Job completion callbacks were not yet supported~~ — resolved: `JobCompletionListener` added to
+  the SDK, wired via `JobCallbackCommandWrapperFactory` in the runtime
+- ~~`ConversationStore.compensateFailedJobCompletion()` was deprecated~~ — resolved: removed and
+  replaced by `onJobCompleted` / `onJobCompletionFailed` hooks
 
 ### Future improvements
 
-- **Completion callbacks**: Extend `ConnectorResponse` with `onCompletionSuccess`/`onCompletionError` callbacks once
-  `CommandWrapper` supports command outcome notification
 - **`cancelRemainingInstances` flag**: The mutable flag on `JobWorkerAgentExecutionContext` (set in
   `handleAddedUserMessages()`, read in `buildConnectorResponse()`) can be simplified by moving interrupted-tool-call detection
   into `buildResponse()` via `executionContext.initialToolCallResults()`, eliminating the mutable state

--- a/connectors/agentic-ai/docs/adr/003-conversation-storage-spi-redesign.md
+++ b/connectors/agentic-ai/docs/adr/003-conversation-storage-spi-redesign.md
@@ -71,9 +71,6 @@ Chosen option: **Option 2 — Factory pattern with decoupled message types**.
 
 ### Future improvements
 
-- **Completion callbacks**: `ConversationStore.onJobCompleted` / `onJobCompletionFailed` hooks,
-  invoked after Zeebe confirms or rejects the job, enabling orphan cleanup and optimistic storage
-  strategies
 - **Execution identity**: `AgentContext.executionId` (platform-level stable identifier) to replace
   `ConversationContext.conversationId()` as the primary execution key
 - **Schema versioning**: `AgentContext.schemaVersion` for explicit data migration across SPI changes

--- a/connectors/agentic-ai/docs/breaking-changes.md
+++ b/connectors/agentic-ai/docs/breaking-changes.md
@@ -12,7 +12,8 @@ This document tracks breaking changes relevant to [AI Agent customization](https
   Use `createSession(AgentExecutionContext, AgentContext)` instead — returns a `ConversationSession`
   that should be used via try-with-resources.
 - `compensateFailedJobCompletion(AgentExecutionContext, AgentContext, Throwable)` removed (was
-  deprecated and never invoked). Completion callbacks will be introduced in a follow-up.
+  deprecated and never invoked). Replaced by `onJobCompleted(AgentContext)` and
+  `onJobCompletionFailed(AgentContext, JobCompletionFailure)` — both default no-ops.
 
 ### `ConversationSession`
 

--- a/connectors/agentic-ai/docs/breaking-changes.md
+++ b/connectors/agentic-ai/docs/breaking-changes.md
@@ -12,8 +12,11 @@ This document tracks breaking changes relevant to [AI Agent customization](https
   Use `createSession(AgentExecutionContext, AgentContext)` instead — returns a `ConversationSession`
   that should be used via try-with-resources.
 - `compensateFailedJobCompletion(AgentExecutionContext, AgentContext, Throwable)` removed (was
-  deprecated and never invoked). Replaced by `onJobCompleted(AgentContext)` and
-  `onJobCompletionFailed(AgentContext, JobCompletionFailure)` — both default no-ops.
+  deprecated and never invoked). Replaced by
+  `onJobCompleted(AgentExecutionContext, AgentContext)` and
+  `onJobCompletionFailed(AgentExecutionContext, AgentContext, JobCompletionFailure)` — both default
+  no-ops. The execution context is provided so implementations can create temporary sessions for
+  compensation if needed.
 
 ### `ConversationSession`
 

--- a/connectors/agentic-ai/docs/reference/ai-agent.md
+++ b/connectors/agentic-ai/docs/reference/ai-agent.md
@@ -413,7 +413,7 @@ If job completion fails (e.g., the job was superseded), Zeebe retries with the *
 
 2. **`loadMessages` must be guided by the pointer.** Load only the data that the `ConversationContext` (from `agentContext.conversation()`) references. Do not load "latest" or "most recent" — that would break retry safety.
 
-3. **Orphaned writes are expected.** When job completion fails after `storeMessages`, the written data is never pointed to. Implementations should tolerate orphans and may clean them up via background processes or future completion callbacks.
+3. **Orphaned writes are expected.** When job completion fails after `storeMessages`, the written data is never pointed to. Implementations should tolerate orphans and may clean them up via the `onJobCompleted` / `onJobCompletionFailed` completion callbacks (see below).
 
 4. **`ConversationContext` must be serializable and self-contained.** It is persisted as part of the `agentContext` process variable in Zeebe. It must contain everything needed to locate the conversation data (e.g., a document reference, a version number, a branch pointer) — without relying on external state that could change between turns.
 
@@ -448,6 +448,33 @@ try (var session = store.createSession(executionContext, agentContext)) {
 7. Job completion sends the updated `AgentContext` back to Zeebe
 
 **Critical insight**: The conversation is stored **before** job completion. This is safe because all stores follow the write-ahead with pointer-based visibility contract — see [Storage Contract](#storage-contract) above.
+
+### Completion Callbacks
+
+After Zeebe accepts or rejects the job completion command, the runtime notifies the connector response
+via `JobCompletionListener` (from the connector SDK). Both `AiAgentTaskResponse` and
+`AiAgentSubProcessResponse` implement this interface and delegate to the conversation store's
+`onJobCompleted` / `onJobCompletionFailed` hooks.
+
+```
+storeMessages(...)  →  completeJob to Zeebe  →  Zeebe responds  →  callback fires
+                                                   ├─ accepted  →  store.onJobCompleted(context)
+                                                   └─ rejected  →  store.onJobCompletionFailed(context, failure)
+```
+
+**Callback timing:**
+- **completeJob path**: asynchronous — fires after the Zeebe command future resolves
+- **Error expression paths** (failJob, throwBpmnError): synchronous — fires before the command is dispatched, since the outcome is already determined by the error expression
+
+**Best-effort guarantee**: Callbacks may never fire (e.g., runtime crash before command dispatch). They are optimizations for cleanup (e.g., orphan removal), not correctness mechanisms. The [Storage Contract](#storage-contract) ensures correctness without callbacks.
+
+**`JobCompletionFailure` variants:**
+- `CommandFailed(cause)` — job could not be completed (Zeebe command failure or runtime rejection)
+- `CommandIgnored(cause)` — job was superseded (NOT_FOUND)
+- `JobErrorRaised(errorMessage, variables)` — failJob command issued via error expression
+- `BpmnErrorThrown(errorCode, errorMessage, variables)` — throwBpmnError command issued via error expression
+
+`CamundaDocumentConversationStore` overrides `onJobCompletionFailed` to clean up orphaned documents. Other built-in stores use the default no-op implementations. Custom stores can override either hook for cleanup or bookkeeping.
 
 ---
 
@@ -682,15 +709,15 @@ This is the key gate: if no user messages were added (because tool results were 
 **Problem**: When a tool completes, Zeebe creates a new job. The previous job may still be processing. Completing the old job results in `NOT_FOUND`.
 
 **Mitigation**:
-- The `CommandWrapper` retries up to 3 times via `CommandExceptionHandlingStrategy`
+- The `JobCallbackCommandWrapperFactory` retries up to 3 times with backoff
 - The no-op completion pattern means most superseded jobs were doing nothing anyway
-- Completion callbacks for conversation stores are planned for a follow-up (not yet implemented)
+- Superseded jobs produce a `CommandIgnored` outcome — the conversation store receives `onJobCompletionFailed` with a `CommandIgnored` failure
 
 ### Challenge 2: Conversation Store Ahead of Zeebe
 
 **Problem**: The conversation is written to storage **before** the job completion command is sent to Zeebe. If job completion fails, the store has data that Zeebe doesn't know about.
 
-**Mitigation**: This is safe by design. All stores follow the [Storage Contract](#storage-contract): they write to a new location each turn, and the `ConversationContext` pointer in the old `AgentContext` still resolves to the old data. The newly written data becomes an orphan — harmless to correctness, and cleanable via future completion callbacks.
+**Mitigation**: This is safe by design. All stores follow the [Storage Contract](#storage-contract): they write to a new location each turn, and the `ConversationContext` pointer in the old `AgentContext` still resolves to the old data. The newly written data becomes an orphan — harmless to correctness. Stores can use the `onJobCompletionFailed` callback to proactively clean up orphaned data.
 
 ### Challenge 3: Duplicate LLM Calls on Rapid Tool Completion
 

--- a/connectors/agentic-ai/docs/reference/ai-agent.md
+++ b/connectors/agentic-ai/docs/reference/ai-agent.md
@@ -451,28 +451,43 @@ try (var session = store.createSession(executionContext, agentContext)) {
 
 ### Completion Callbacks
 
-After Zeebe accepts or rejects the job completion command, the runtime notifies the connector response
-via `JobCompletionListener` (from the connector SDK). Both `AiAgentTaskConnectorResponse` and
-`AiAgentSubProcessConnectorResponse` implement this interface and delegate to the conversation
-store's `onJobCompleted` / `onJobCompletionFailed` hooks.
+After Zeebe accepts or rejects the job-completion command, the runtime notifies the connector
+function via `JobCompletionListener` (from the connector SDK). Both `AiAgentFunction` and
+`AiAgentJobWorker` implement this interface (via the shared `AgentConnectorFunction` mixin) and
+delegate to an internal `AgentJobCompletionListener` carried by the response, which in turn
+invokes the conversation store's `onJobCompleted` / `onJobCompletionFailed` hooks.
 
 ```
-storeMessages(...)  →  completeJob to Zeebe  →  Zeebe responds  →  callback fires
-                                                   ├─ accepted  →  store.onJobCompleted(executionContext, context)
-                                                   └─ rejected  →  store.onJobCompletionFailed(executionContext, context, failure)
+storeMessages(...)  →  Zeebe command sent  →  command future resolves  →  callback fires
+                                                                           ├─ accepted  →  store.onJobCompleted(executionContext, context)
+                                                                           └─ rejected  →  store.onJobCompletionFailed(executionContext, context, failure)
 ```
 
-**Callback timing:**
-- **completeJob path**: asynchronous — fires after the Zeebe command future resolves
-- **Error expression paths** (failJob, throwBpmnError): synchronous — fires before the command is dispatched, since the outcome is already determined by the error expression
+Carrying the callback on the response is what keeps the conversation store and agent context in
+scope: both are captured during request handling and dispatched once the Zeebe command resolves.
+
+**Callback timing**: All paths are asynchronous — callbacks fire only after the corresponding
+Zeebe command (`completeJob`, `failJob`, or `throwBpmnError`) resolves. This applies uniformly
+to successful completion, error-expression paths, and pre-response failures.
 
 **Best-effort guarantee**: Callbacks may never fire (e.g., runtime crash before command dispatch). They are optimizations for cleanup (e.g., orphan removal), not correctness mechanisms. The [Storage Contract](#storage-contract) ensures correctness without callbacks.
 
-**`JobCompletionFailure` variants:**
-- `CommandFailed(cause)` — job could not be completed (Zeebe command failure or runtime rejection)
-- `CommandIgnored(cause)` — job was superseded (NOT_FOUND)
-- `JobErrorRaised(errorMessage, variables)` — failJob command issued via error expression
-- `BpmnErrorThrown(errorCode, errorMessage, variables)` — throwBpmnError command issued via error expression
+**`JobCompletionFailure` hierarchy:**
+
+- `CommandFailure` (sealed) — Zeebe rejected the command we sent:
+  - `CommandFailed(cause)` — server-side rejection (network, internal error after retries)
+  - `CommandIgnored(cause)` — the job was superseded (`NOT_FOUND`)
+- `ExecutionFailed(cause, commandFailure?)` — connector or runtime hit an error before/while
+  producing a response (function exception, error-expression evaluation, IgnoreError used by an
+  unsupported connector type)
+- `BpmnErrorThrown(errorCode, errorMessage, variables, commandFailure?)` — `throwBpmnError`
+  dispatched via error expression
+- `JobErrorRaised(errorMessage, variables, commandFailure?)` — `failJob` dispatched via error
+  expression
+
+The optional `commandFailure` field on `ExecutionFailed`, `BpmnErrorThrown`, and `JobErrorRaised`
+surfaces the case where the failJob/throwBpmnError command sent in response was itself rejected
+by Zeebe. It is `null` when Zeebe accepted the response command.
 
 `CamundaDocumentConversationStore` overrides `onJobCompletionFailed` to clean up orphaned documents. Other built-in stores use the default no-op implementations. Custom stores can override either hook for cleanup or bookkeeping.
 

--- a/connectors/agentic-ai/docs/reference/ai-agent.md
+++ b/connectors/agentic-ai/docs/reference/ai-agent.md
@@ -452,14 +452,14 @@ try (var session = store.createSession(executionContext, agentContext)) {
 ### Completion Callbacks
 
 After Zeebe accepts or rejects the job completion command, the runtime notifies the connector response
-via `JobCompletionListener` (from the connector SDK). Both `AiAgentTaskResponse` and
-`AiAgentSubProcessResponse` implement this interface and delegate to the conversation store's
-`onJobCompleted` / `onJobCompletionFailed` hooks.
+via `JobCompletionListener` (from the connector SDK). Both `AiAgentTaskConnectorResponse` and
+`AiAgentSubProcessConnectorResponse` implement this interface and delegate to the conversation
+store's `onJobCompleted` / `onJobCompletionFailed` hooks.
 
 ```
 storeMessages(...)  →  completeJob to Zeebe  →  Zeebe responds  →  callback fires
-                                                   ├─ accepted  →  store.onJobCompleted(context)
-                                                   └─ rejected  →  store.onJobCompletionFailed(context, failure)
+                                                   ├─ accepted  →  store.onJobCompleted(executionContext, context)
+                                                   └─ rejected  →  store.onJobCompletionFailed(executionContext, context, failure)
 ```
 
 **Callback timing:**

--- a/connectors/agentic-ai/pom.xml
+++ b/connectors/agentic-ai/pom.xml
@@ -60,11 +60,6 @@
 
     <dependency>
       <groupId>io.camunda</groupId>
-      <artifactId>camunda-spring-boot-starter</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>io.camunda</groupId>
       <artifactId>camunda-client-java</artifactId>
     </dependency>
     <dependency>
@@ -300,11 +295,6 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>io.camunda.connector</groupId>
-      <artifactId>connector-feel</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/AgentConnectorFunction.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/AgentConnectorFunction.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.agenticai.aiagent;
+
+import io.camunda.connector.agenticai.aiagent.agent.AgentJobCompletionListener;
+import io.camunda.connector.api.outbound.ConnectorResponse;
+import io.camunda.connector.api.outbound.JobCompletionFailure;
+import io.camunda.connector.api.outbound.JobCompletionListener;
+import io.camunda.connector.api.outbound.OutboundConnectorContext;
+import io.camunda.connector.api.outbound.OutboundConnectorFunction;
+
+/**
+ * Common contract for AI agent connector functions: an {@link OutboundConnectorFunction} that also
+ * acts as the SDK-level {@link JobCompletionListener}. The default callback implementations
+ * delegate to an {@link AgentJobCompletionListener} carried by the response, so per-execution state
+ * (conversation store, agent context, ...) captured during {@code execute()} stays in scope when
+ * the Zeebe completion command resolves.
+ */
+public interface AgentConnectorFunction extends OutboundConnectorFunction, JobCompletionListener {
+
+  @Override
+  ConnectorResponse execute(OutboundConnectorContext context) throws Exception;
+
+  @Override
+  default void onJobCompleted(OutboundConnectorContext context, ConnectorResponse response) {
+    if (response instanceof AgentJobCompletionListener listener) {
+      listener.onJobCompleted();
+    }
+  }
+
+  @Override
+  default void onJobCompletionFailed(
+      OutboundConnectorContext context, ConnectorResponse response, JobCompletionFailure failure) {
+    if (response instanceof AgentJobCompletionListener listener) {
+      listener.onJobCompletionFailed(failure);
+    }
+  }
+}

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/AiAgentFunction.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/AiAgentFunction.java
@@ -13,7 +13,6 @@ import io.camunda.connector.agenticai.aiagent.model.OutboundConnectorAgentExecut
 import io.camunda.connector.agenticai.aiagent.model.request.OutboundConnectorAgentRequest;
 import io.camunda.connector.api.annotation.OutboundConnector;
 import io.camunda.connector.api.outbound.OutboundConnectorContext;
-import io.camunda.connector.api.outbound.OutboundConnectorFunction;
 import io.camunda.connector.generator.java.annotation.ElementTemplate;
 import io.camunda.connector.generator.java.annotation.ElementTemplate.PropertyGroup;
 
@@ -83,7 +82,7 @@ import io.camunda.connector.generator.java.annotation.ElementTemplate.PropertyGr
           openByDefault = false)
     },
     icon = "aiagent.svg")
-public class AiAgentFunction implements OutboundConnectorFunction {
+public class AiAgentFunction implements AgentConnectorFunction {
   private final ProcessDefinitionAdHocToolElementsResolver toolElementsResolver;
   private final OutboundConnectorAgentRequestHandler agentRequestHandler;
 

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/AiAgentJobWorker.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/AiAgentJobWorker.java
@@ -11,7 +11,6 @@ import io.camunda.connector.agenticai.aiagent.model.JobWorkerAgentExecutionConte
 import io.camunda.connector.agenticai.aiagent.model.request.JobWorkerAgentRequest;
 import io.camunda.connector.api.annotation.OutboundConnector;
 import io.camunda.connector.api.outbound.OutboundConnectorContext;
-import io.camunda.connector.api.outbound.OutboundConnectorFunction;
 
 /**
  * AI Agent job worker implementation (acting on an ad-hoc sub-process).
@@ -33,7 +32,7 @@ import io.camunda.connector.api.outbound.OutboundConnectorFunction;
       AiAgentJobWorker.PROVIDER_VARIABLE,
       AiAgentJobWorker.DATA_VARIABLE
     })
-public class AiAgentJobWorker implements OutboundConnectorFunction {
+public class AiAgentJobWorker implements AgentConnectorFunction {
 
   public static final String JOB_WORKER_NAME = "AI Agent Job Worker";
   public static final String JOB_WORKER_TYPE = "io.camunda.agenticai:aiagent-job-worker:1";

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/AiAgentSubProcessConnectorResponse.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/AiAgentSubProcessConnectorResponse.java
@@ -6,11 +6,11 @@
  */
 package io.camunda.connector.agenticai.aiagent;
 
+import io.camunda.connector.agenticai.aiagent.agent.AgentJobCompletionListener;
 import io.camunda.connector.agenticai.aiagent.model.AgentResponse;
 import io.camunda.connector.agenticai.model.AgenticAiRecord;
 import io.camunda.connector.api.outbound.ConnectorResponse.AdHocSubProcessConnectorResponse;
 import io.camunda.connector.api.outbound.JobCompletionFailure;
-import io.camunda.connector.api.outbound.JobCompletionListener;
 import java.util.List;
 import java.util.Map;
 import org.springframework.lang.Nullable;
@@ -22,9 +22,9 @@ public record AiAgentSubProcessConnectorResponse(
     List<ElementActivation> elementActivations,
     boolean completionConditionFulfilled,
     boolean cancelRemainingInstances,
-    @Nullable JobCompletionListener completionListener)
+    @Nullable AgentJobCompletionListener completionListener)
     implements AdHocSubProcessConnectorResponse,
-        JobCompletionListener,
+        AgentJobCompletionListener,
         AiAgentSubProcessConnectorResponseBuilder.With {
 
   public static AiAgentSubProcessConnectorResponseBuilder builder() {

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/AiAgentSubProcessConnectorResponse.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/AiAgentSubProcessConnectorResponse.java
@@ -9,6 +9,8 @@ package io.camunda.connector.agenticai.aiagent;
 import io.camunda.connector.agenticai.aiagent.model.AgentResponse;
 import io.camunda.connector.agenticai.model.AgenticAiRecord;
 import io.camunda.connector.api.outbound.ConnectorResponse.AdHocSubProcessConnectorResponse;
+import io.camunda.connector.api.outbound.JobCompletionFailure;
+import io.camunda.connector.api.outbound.JobCompletionListener;
 import java.util.List;
 import java.util.Map;
 import org.springframework.lang.Nullable;
@@ -19,11 +21,28 @@ public record AiAgentSubProcessConnectorResponse(
     Map<String, Object> variables,
     List<ElementActivation> elementActivations,
     boolean completionConditionFulfilled,
-    boolean cancelRemainingInstances)
-    implements AdHocSubProcessConnectorResponse, AiAgentSubProcessConnectorResponseBuilder.With {
+    boolean cancelRemainingInstances,
+    @Nullable JobCompletionListener completionListener)
+    implements AdHocSubProcessConnectorResponse,
+        JobCompletionListener,
+        AiAgentSubProcessConnectorResponseBuilder.With {
 
   public static AiAgentSubProcessConnectorResponseBuilder builder() {
     return AiAgentSubProcessConnectorResponseBuilder.builder();
+  }
+
+  @Override
+  public void onJobCompleted() {
+    if (completionListener != null) {
+      completionListener.onJobCompleted();
+    }
+  }
+
+  @Override
+  public void onJobCompletionFailed(JobCompletionFailure failure) {
+    if (completionListener != null) {
+      completionListener.onJobCompletionFailed(failure);
+    }
   }
 
   public record ToolCallElementActivation(String elementId, Map<String, Object> variables)

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/AiAgentTaskConnectorResponse.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/AiAgentTaskConnectorResponse.java
@@ -6,19 +6,20 @@
  */
 package io.camunda.connector.agenticai.aiagent;
 
+import io.camunda.connector.agenticai.aiagent.agent.AgentJobCompletionListener;
 import io.camunda.connector.agenticai.aiagent.model.AgentResponse;
 import io.camunda.connector.api.outbound.ConnectorResponse.StandardConnectorResponse;
 import io.camunda.connector.api.outbound.JobCompletionFailure;
-import io.camunda.connector.api.outbound.JobCompletionListener;
 import org.springframework.lang.Nullable;
 
 /**
- * Response type for the AI Agent task flavor (outbound connector on a service task). Delegates job
- * completion callbacks to the provided listener.
+ * Response type for the AI Agent task flavor (outbound connector on a service task). Carries an
+ * optional {@link AgentJobCompletionListener} so the connector function can dispatch lifecycle
+ * callbacks once the Zeebe completion command has resolved.
  */
 public record AiAgentTaskConnectorResponse(
-    @Nullable AgentResponse agentResponse, @Nullable JobCompletionListener completionListener)
-    implements StandardConnectorResponse, JobCompletionListener {
+    @Nullable AgentResponse agentResponse, @Nullable AgentJobCompletionListener completionListener)
+    implements StandardConnectorResponse, AgentJobCompletionListener {
 
   @Override
   public Object responseValue() {

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/AiAgentTaskConnectorResponse.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/AiAgentTaskConnectorResponse.java
@@ -8,18 +8,34 @@ package io.camunda.connector.agenticai.aiagent;
 
 import io.camunda.connector.agenticai.aiagent.model.AgentResponse;
 import io.camunda.connector.api.outbound.ConnectorResponse.StandardConnectorResponse;
+import io.camunda.connector.api.outbound.JobCompletionFailure;
+import io.camunda.connector.api.outbound.JobCompletionListener;
 import org.springframework.lang.Nullable;
 
 /**
- * Response type for the AI Agent task flavor (outbound connector on a service task). Wraps the
- * {@link AgentResponse} as a {@link StandardConnectorResponse} so the runtime evaluates it via
- * result expressions.
+ * Response type for the AI Agent task flavor (outbound connector on a service task). Delegates job
+ * completion callbacks to the provided listener.
  */
-public record AiAgentTaskConnectorResponse(@Nullable AgentResponse agentResponse)
-    implements StandardConnectorResponse {
+public record AiAgentTaskConnectorResponse(
+    @Nullable AgentResponse agentResponse, @Nullable JobCompletionListener completionListener)
+    implements StandardConnectorResponse, JobCompletionListener {
 
   @Override
   public Object responseValue() {
     return agentResponse;
+  }
+
+  @Override
+  public void onJobCompleted() {
+    if (completionListener != null) {
+      completionListener.onJobCompleted();
+    }
+  }
+
+  @Override
+  public void onJobCompletionFailed(JobCompletionFailure failure) {
+    if (completionListener != null) {
+      completionListener.onJobCompletionFailed(failure);
+    }
   }
 }

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/agent/AgentJobCompletionListener.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/agent/AgentJobCompletionListener.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.agenticai.aiagent.agent;
+
+import io.camunda.connector.api.outbound.JobCompletionFailure;
+
+/**
+ * Internal lifecycle callback used to thread post-completion hooks from the agent request handler
+ * to the connector function.
+ *
+ * <p>Implementations capture per-execution state (e.g. conversation store, agent context) at the
+ * point the response is built. The connector function delegates to it from its SDK-level {@link
+ * io.camunda.connector.api.outbound.JobCompletionListener} once Zeebe has accepted or rejected the
+ * job completion command.
+ */
+public interface AgentJobCompletionListener {
+
+  default void onJobCompleted() {}
+
+  default void onJobCompletionFailed(JobCompletionFailure failure) {}
+}

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/agent/BaseAgentRequestHandler.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/agent/BaseAgentRequestHandler.java
@@ -11,6 +11,7 @@ import io.camunda.connector.agenticai.aiagent.agent.AgentInitializationResult.Ag
 import io.camunda.connector.agenticai.aiagent.agent.AgentInitializationResult.AgentResponseInitializationResult;
 import io.camunda.connector.agenticai.aiagent.framework.AiFrameworkAdapter;
 import io.camunda.connector.agenticai.aiagent.memory.conversation.ConversationSession;
+import io.camunda.connector.agenticai.aiagent.memory.conversation.ConversationStore;
 import io.camunda.connector.agenticai.aiagent.memory.conversation.ConversationStoreRegistry;
 import io.camunda.connector.agenticai.aiagent.memory.conversation.ConversationStoreRequest;
 import io.camunda.connector.agenticai.aiagent.memory.runtime.MessageWindowRuntimeMemory;
@@ -23,6 +24,8 @@ import io.camunda.connector.agenticai.model.message.Message;
 import io.camunda.connector.agenticai.model.tool.ToolCallProcessVariable;
 import io.camunda.connector.agenticai.model.tool.ToolCallResult;
 import io.camunda.connector.api.outbound.ConnectorResponse;
+import io.camunda.connector.api.outbound.JobCompletionFailure;
+import io.camunda.connector.api.outbound.JobCompletionListener;
 import java.util.List;
 import java.util.Optional;
 import org.apache.commons.lang3.tuple.Pair;
@@ -73,14 +76,14 @@ public abstract class BaseAgentRequestHandler<
         LOGGER.debug(
             "AI Agent initialization returned direct response including {} tool calls. Completing job without further processing.",
             agentResponse.toolCalls().size());
-        yield buildConnectorResponse(executionContext, agentResponse);
+        yield buildConnectorResponse(executionContext, agentResponse, null);
       }
 
       // discovery still in progress (not all tool call results present)
       case AgentDiscoveryInProgressInitializationResult ignored -> {
         LOGGER.debug(
             "AI Agent initialization tool discovery is still in progress. Completing job without further processing.");
-        yield buildConnectorResponse(executionContext, null);
+        yield buildConnectorResponse(executionContext, null, null);
       }
 
       case AgentContextInitializationResult(
@@ -109,7 +112,8 @@ public abstract class BaseAgentRequestHandler<
           "Request processing completed {} agent response, completing job",
           agentResponse == null ? "without" : "with");
 
-      return buildConnectorResponse(executionContext, agentResponse);
+      var completionListener = createStoreCompletionListener(store, agentResponse);
+      return buildConnectorResponse(executionContext, agentResponse, completionListener);
     }
   }
 
@@ -200,7 +204,28 @@ public abstract class BaseAgentRequestHandler<
     // no-op by default
   }
 
-  /** Builds the connector response from the agent response. Agent response may be null. */
+  /** Builds the connector response from the agent response. Agent response and listener may be null. */
   protected abstract R buildConnectorResponse(
-      final C executionContext, @Nullable final AgentResponse agentResponse);
+      final C executionContext,
+      @Nullable final AgentResponse agentResponse,
+      @Nullable final JobCompletionListener completionListener);
+
+  private static JobCompletionListener createStoreCompletionListener(
+      ConversationStore store, @Nullable AgentResponse agentResponse) {
+    if (agentResponse == null) {
+      return null;
+    }
+    var context = agentResponse.context();
+    return new JobCompletionListener() {
+      @Override
+      public void onJobCompleted() {
+        store.onJobCompleted(context);
+      }
+
+      @Override
+      public void onJobCompletionFailed(JobCompletionFailure failure) {
+        store.onJobCompletionFailed(context, failure);
+      }
+    };
+  }
 }

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/agent/BaseAgentRequestHandler.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/agent/BaseAgentRequestHandler.java
@@ -112,7 +112,8 @@ public abstract class BaseAgentRequestHandler<
           "Request processing completed {} agent response, completing job",
           agentResponse == null ? "without" : "with");
 
-      var completionListener = createStoreCompletionListener(store, agentResponse);
+      var completionListener =
+          createStoreCompletionListener(executionContext, store, agentResponse);
       return buildConnectorResponse(executionContext, agentResponse, completionListener);
     }
   }
@@ -212,8 +213,9 @@ public abstract class BaseAgentRequestHandler<
       @Nullable final AgentResponse agentResponse,
       @Nullable final JobCompletionListener completionListener);
 
-  private static JobCompletionListener createStoreCompletionListener(
-      ConversationStore store, @Nullable AgentResponse agentResponse) {
+  private static <C extends AgentExecutionContext>
+      JobCompletionListener createStoreCompletionListener(
+          C executionContext, ConversationStore store, @Nullable AgentResponse agentResponse) {
     if (agentResponse == null) {
       return null;
     }
@@ -221,12 +223,12 @@ public abstract class BaseAgentRequestHandler<
     return new JobCompletionListener() {
       @Override
       public void onJobCompleted() {
-        store.onJobCompleted(context);
+        store.onJobCompleted(executionContext, context);
       }
 
       @Override
       public void onJobCompletionFailed(JobCompletionFailure failure) {
-        store.onJobCompletionFailed(context, failure);
+        store.onJobCompletionFailed(executionContext, context, failure);
       }
     };
   }

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/agent/BaseAgentRequestHandler.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/agent/BaseAgentRequestHandler.java
@@ -204,7 +204,9 @@ public abstract class BaseAgentRequestHandler<
     // no-op by default
   }
 
-  /** Builds the connector response from the agent response. Agent response and listener may be null. */
+  /**
+   * Builds the connector response from the agent response. Agent response and listener may be null.
+   */
   protected abstract R buildConnectorResponse(
       final C executionContext,
       @Nullable final AgentResponse agentResponse,

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/agent/BaseAgentRequestHandler.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/agent/BaseAgentRequestHandler.java
@@ -25,7 +25,6 @@ import io.camunda.connector.agenticai.model.tool.ToolCallProcessVariable;
 import io.camunda.connector.agenticai.model.tool.ToolCallResult;
 import io.camunda.connector.api.outbound.ConnectorResponse;
 import io.camunda.connector.api.outbound.JobCompletionFailure;
-import io.camunda.connector.api.outbound.JobCompletionListener;
 import java.util.List;
 import java.util.Optional;
 import org.apache.commons.lang3.tuple.Pair;
@@ -211,16 +210,16 @@ public abstract class BaseAgentRequestHandler<
   protected abstract R buildConnectorResponse(
       final C executionContext,
       @Nullable final AgentResponse agentResponse,
-      @Nullable final JobCompletionListener completionListener);
+      @Nullable final AgentJobCompletionListener completionListener);
 
   private static <C extends AgentExecutionContext>
-      JobCompletionListener createStoreCompletionListener(
+      AgentJobCompletionListener createStoreCompletionListener(
           C executionContext, ConversationStore store, @Nullable AgentResponse agentResponse) {
     if (agentResponse == null) {
       return null;
     }
     var context = agentResponse.context();
-    return new JobCompletionListener() {
+    return new AgentJobCompletionListener() {
       @Override
       public void onJobCompleted() {
         store.onJobCompleted(executionContext, context);

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/agent/JobWorkerAgentRequestHandler.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/agent/JobWorkerAgentRequestHandler.java
@@ -20,6 +20,7 @@ import io.camunda.connector.agenticai.model.message.Message;
 import io.camunda.connector.agenticai.model.message.ToolCallResultMessage;
 import io.camunda.connector.agenticai.model.tool.ToolCallResult;
 import io.camunda.connector.api.outbound.ConnectorResponse.AdHocSubProcessConnectorResponse.ElementActivation;
+import io.camunda.connector.api.outbound.JobCompletionListener;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -84,7 +85,9 @@ public class JobWorkerAgentRequestHandler
 
   @Override
   public AiAgentSubProcessConnectorResponse buildConnectorResponse(
-      JobWorkerAgentExecutionContext executionContext, AgentResponse agentResponse) {
+      JobWorkerAgentExecutionContext executionContext,
+      AgentResponse agentResponse,
+      JobCompletionListener completionListener) {
     if (agentResponse == null) {
       LOGGER.debug(
           "No agent response provided, completing job {} without response",
@@ -104,12 +107,14 @@ public class JobWorkerAgentRequestHandler
             agentResponse.toolCalls().stream().map(tc -> tc.metadata().name()).toList());
       }
 
-      return buildResponse(executionContext, agentResponse);
+      return buildResponse(executionContext, agentResponse, completionListener);
     }
   }
 
   private AiAgentSubProcessConnectorResponse buildResponse(
-      JobWorkerAgentExecutionContext executionContext, AgentResponse agentResponse) {
+      JobWorkerAgentExecutionContext executionContext,
+      AgentResponse agentResponse,
+      JobCompletionListener completionListener) {
     boolean completionConditionFulfilled = agentResponse.toolCalls().isEmpty();
     boolean cancelRemainingInstances = executionContext.cancelRemainingInstances();
 
@@ -138,6 +143,7 @@ public class JobWorkerAgentRequestHandler
         .elementActivations(buildElementActivations(agentResponse))
         .completionConditionFulfilled(completionConditionFulfilled)
         .cancelRemainingInstances(cancelRemainingInstances)
+        .completionListener(completionListener)
         .build();
   }
 

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/agent/JobWorkerAgentRequestHandler.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/agent/JobWorkerAgentRequestHandler.java
@@ -20,7 +20,6 @@ import io.camunda.connector.agenticai.model.message.Message;
 import io.camunda.connector.agenticai.model.message.ToolCallResultMessage;
 import io.camunda.connector.agenticai.model.tool.ToolCallResult;
 import io.camunda.connector.api.outbound.ConnectorResponse.AdHocSubProcessConnectorResponse.ElementActivation;
-import io.camunda.connector.api.outbound.JobCompletionListener;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -87,7 +86,7 @@ public class JobWorkerAgentRequestHandler
   public AiAgentSubProcessConnectorResponse buildConnectorResponse(
       JobWorkerAgentExecutionContext executionContext,
       AgentResponse agentResponse,
-      JobCompletionListener completionListener) {
+      AgentJobCompletionListener completionListener) {
     if (agentResponse == null) {
       LOGGER.debug(
           "No agent response provided, completing job {} without response",
@@ -114,7 +113,7 @@ public class JobWorkerAgentRequestHandler
   private AiAgentSubProcessConnectorResponse buildResponse(
       JobWorkerAgentExecutionContext executionContext,
       AgentResponse agentResponse,
-      JobCompletionListener completionListener) {
+      AgentJobCompletionListener completionListener) {
     boolean completionConditionFulfilled = agentResponse.toolCalls().isEmpty();
     boolean cancelRemainingInstances = executionContext.cancelRemainingInstances();
 

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/agent/OutboundConnectorAgentRequestHandler.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/agent/OutboundConnectorAgentRequestHandler.java
@@ -17,6 +17,7 @@ import io.camunda.connector.agenticai.aiagent.model.OutboundConnectorAgentExecut
 import io.camunda.connector.agenticai.aiagent.tool.GatewayToolHandlerRegistry;
 import io.camunda.connector.agenticai.model.message.Message;
 import io.camunda.connector.api.error.ConnectorException;
+import io.camunda.connector.api.outbound.JobCompletionListener;
 import java.util.List;
 import org.springframework.util.CollectionUtils;
 
@@ -58,7 +59,9 @@ public class OutboundConnectorAgentRequestHandler
 
   @Override
   public AiAgentTaskConnectorResponse buildConnectorResponse(
-      OutboundConnectorAgentExecutionContext executionContext, AgentResponse agentResponse) {
-    return new AiAgentTaskConnectorResponse(agentResponse);
+      OutboundConnectorAgentExecutionContext executionContext,
+      AgentResponse agentResponse,
+      JobCompletionListener completionListener) {
+    return new AiAgentTaskConnectorResponse(agentResponse, completionListener);
   }
 }

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/agent/OutboundConnectorAgentRequestHandler.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/agent/OutboundConnectorAgentRequestHandler.java
@@ -17,7 +17,6 @@ import io.camunda.connector.agenticai.aiagent.model.OutboundConnectorAgentExecut
 import io.camunda.connector.agenticai.aiagent.tool.GatewayToolHandlerRegistry;
 import io.camunda.connector.agenticai.model.message.Message;
 import io.camunda.connector.api.error.ConnectorException;
-import io.camunda.connector.api.outbound.JobCompletionListener;
 import java.util.List;
 import org.springframework.util.CollectionUtils;
 
@@ -61,7 +60,7 @@ public class OutboundConnectorAgentRequestHandler
   public AiAgentTaskConnectorResponse buildConnectorResponse(
       OutboundConnectorAgentExecutionContext executionContext,
       AgentResponse agentResponse,
-      JobCompletionListener completionListener) {
+      AgentJobCompletionListener completionListener) {
     return new AiAgentTaskConnectorResponse(agentResponse, completionListener);
   }
 }

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/memory/conversation/ConversationStore.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/memory/conversation/ConversationStore.java
@@ -37,12 +37,22 @@ public interface ConversationStore {
   /**
    * Best-effort: the job carrying the given agentContext was accepted by Zeebe. Implementations may
    * use this to clean up previous state (old documents, orphaned branches).
+   *
+   * <p>Receives the same execution context as {@link #createSession} so implementations can create
+   * a temporary session for post-commit actions if needed.
    */
-  default void onJobCompleted(AgentContext committedContext) {}
+  default void onJobCompleted(
+      AgentExecutionContext executionContext, AgentContext committedContext) {}
 
   /**
    * Best-effort: the job was not accepted. The store may have written state that Zeebe doesn't know
    * about.
+   *
+   * <p>Receives the same execution context as {@link #createSession} so implementations can create
+   * a temporary session for compensation if needed.
    */
-  default void onJobCompletionFailed(AgentContext failedContext, JobCompletionFailure failure) {}
+  default void onJobCompletionFailed(
+      AgentExecutionContext executionContext,
+      AgentContext failedContext,
+      JobCompletionFailure failure) {}
 }

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/memory/conversation/ConversationStore.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/memory/conversation/ConversationStore.java
@@ -8,6 +8,7 @@ package io.camunda.connector.agenticai.aiagent.memory.conversation;
 
 import io.camunda.connector.agenticai.aiagent.model.AgentContext;
 import io.camunda.connector.agenticai.aiagent.model.AgentExecutionContext;
+import io.camunda.connector.api.outbound.JobCompletionFailure;
 
 /**
  * Pluggable backend for persisting and loading conversation history.
@@ -32,4 +33,16 @@ public interface ConversationStore {
    */
   ConversationSession createSession(
       AgentExecutionContext executionContext, AgentContext agentContext);
+
+  /**
+   * Best-effort: the job carrying the given agentContext was accepted by Zeebe. Implementations may
+   * use this to clean up previous state (old documents, orphaned branches).
+   */
+  default void onJobCompleted(AgentContext committedContext) {}
+
+  /**
+   * Best-effort: the job was not accepted. The store may have written state that Zeebe doesn't know
+   * about.
+   */
+  default void onJobCompletionFailed(AgentContext failedContext, JobCompletionFailure failure) {}
 }

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/memory/conversation/document/CamundaDocumentConversationStore.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/memory/conversation/document/CamundaDocumentConversationStore.java
@@ -67,7 +67,10 @@ public class CamundaDocumentConversationStore implements ConversationStore {
   }
 
   @Override
-  public void onJobCompletionFailed(AgentContext failedContext, JobCompletionFailure failure) {
+  public void onJobCompletionFailed(
+      AgentExecutionContext executionContext,
+      AgentContext failedContext,
+      JobCompletionFailure failure) {
     var ctx = loadConversationContext(failedContext, CamundaDocumentConversationContext.class);
     if (ctx == null) {
       return;

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/memory/conversation/document/CamundaDocumentConversationStore.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/memory/conversation/document/CamundaDocumentConversationStore.java
@@ -6,6 +6,8 @@
  */
 package io.camunda.connector.agenticai.aiagent.memory.conversation.document;
 
+import static io.camunda.connector.agenticai.aiagent.memory.conversation.ConversationUtil.loadConversationContext;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.connector.agenticai.aiagent.memory.conversation.ConversationSession;
 import io.camunda.connector.agenticai.aiagent.memory.conversation.ConversationStore;
@@ -14,10 +16,17 @@ import io.camunda.connector.agenticai.aiagent.model.AgentExecutionContext;
 import io.camunda.connector.agenticai.aiagent.model.request.MemoryConfiguration;
 import io.camunda.connector.agenticai.aiagent.model.request.MemoryStorageConfiguration.CamundaDocumentMemoryStorageConfiguration;
 import io.camunda.connector.api.document.DocumentFactory;
+import io.camunda.connector.api.document.DocumentReference.CamundaDocumentReference;
+import io.camunda.connector.api.outbound.JobCompletionFailure;
 import io.camunda.connector.runtime.core.document.store.CamundaDocumentStore;
 import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class CamundaDocumentConversationStore implements ConversationStore {
+
+  private static final Logger LOGGER =
+      LoggerFactory.getLogger(CamundaDocumentConversationStore.class);
 
   public static final String TYPE = "camunda-document";
 
@@ -55,5 +64,27 @@ public class CamundaDocumentConversationStore implements ConversationStore {
 
     return new CamundaDocumentConversationSession(
         documentConfig, documentFactory, documentStore, conversationSerializer, executionContext);
+  }
+
+  @Override
+  public void onJobCompletionFailed(AgentContext failedContext, JobCompletionFailure failure) {
+    var ctx = loadConversationContext(failedContext, CamundaDocumentConversationContext.class);
+    if (ctx == null) {
+      return;
+    }
+
+    // ctx.document() is the document written by storeMessages during this job — it became
+    // orphaned because Zeebe rejected the job completion, so no pointer will ever reference it
+    var document = ctx.document();
+    if (document.reference() instanceof CamundaDocumentReference camundaDocumentReference) {
+      try {
+        documentStore.deleteDocument(camundaDocumentReference);
+      } catch (Exception e) {
+        LOGGER.warn(
+            "Failed to delete orphaned document after job completion failure: {}",
+            camundaDocumentReference,
+            e);
+      }
+    }
   }
 }

--- a/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/AiAgentResponseListenerDelegationTest.java
+++ b/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/AiAgentResponseListenerDelegationTest.java
@@ -8,9 +8,13 @@ package io.camunda.connector.agenticai.aiagent;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 
+import io.camunda.connector.agenticai.aiagent.agent.AgentJobCompletionListener;
+import io.camunda.connector.api.outbound.ConnectorResponse;
+import io.camunda.connector.api.outbound.ConnectorResponse.StandardConnectorResponse;
 import io.camunda.connector.api.outbound.JobCompletionFailure;
-import io.camunda.connector.api.outbound.JobCompletionListener;
+import io.camunda.connector.api.outbound.OutboundConnectorContext;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Nested;
@@ -19,11 +23,11 @@ import org.junit.jupiter.api.Test;
 class AiAgentResponseListenerDelegationTest {
 
   @Nested
-  class TaskResponseTests {
+  class TaskResponseDelegationTests {
 
     @Test
     void onJobCompleted_delegatesToListener() {
-      var listener = mock(JobCompletionListener.class);
+      var listener = mock(AgentJobCompletionListener.class);
       var response = new AiAgentTaskConnectorResponse(null, listener);
 
       response.onJobCompleted();
@@ -33,7 +37,7 @@ class AiAgentResponseListenerDelegationTest {
 
     @Test
     void onJobCompletionFailed_delegatesToListener() {
-      var listener = mock(JobCompletionListener.class);
+      var listener = mock(AgentJobCompletionListener.class);
       var failure = new JobCompletionFailure.CommandFailed(new RuntimeException("test"));
       var response = new AiAgentTaskConnectorResponse(null, listener);
 
@@ -61,11 +65,11 @@ class AiAgentResponseListenerDelegationTest {
   }
 
   @Nested
-  class SubProcessResponseTests {
+  class SubProcessResponseDelegationTests {
 
     @Test
     void onJobCompleted_delegatesToListener() {
-      var listener = mock(JobCompletionListener.class);
+      var listener = mock(AgentJobCompletionListener.class);
       var response = buildResponse(listener);
 
       response.onJobCompleted();
@@ -75,7 +79,7 @@ class AiAgentResponseListenerDelegationTest {
 
     @Test
     void onJobCompletionFailed_delegatesToListener() {
-      var listener = mock(JobCompletionListener.class);
+      var listener = mock(AgentJobCompletionListener.class);
       var failure = new JobCompletionFailure.CommandFailed(new RuntimeException("test"));
       var response = buildResponse(listener);
 
@@ -101,7 +105,7 @@ class AiAgentResponseListenerDelegationTest {
           new JobCompletionFailure.CommandFailed(new RuntimeException("test")));
     }
 
-    private AiAgentSubProcessConnectorResponse buildResponse(JobCompletionListener listener) {
+    private AiAgentSubProcessConnectorResponse buildResponse(AgentJobCompletionListener listener) {
       return AiAgentSubProcessConnectorResponse.builder()
           .variables(Map.of())
           .elementActivations(List.of())
@@ -109,6 +113,110 @@ class AiAgentResponseListenerDelegationTest {
           .cancelRemainingInstances(false)
           .completionListener(listener)
           .build();
+    }
+  }
+
+  @Nested
+  class TaskFunctionDelegationTests {
+
+    @Test
+    void onJobCompleted_invokesAgentListenerCarriedByResponse() {
+      var listener = mock(AgentJobCompletionListener.class);
+      var function = new AiAgentFunction(null, null);
+      var response = new AiAgentTaskConnectorResponse(null, listener);
+
+      function.onJobCompleted(mock(OutboundConnectorContext.class), response);
+
+      verify(listener).onJobCompleted();
+    }
+
+    @Test
+    void onJobCompletionFailed_invokesAgentListenerCarriedByResponse() {
+      var listener = mock(AgentJobCompletionListener.class);
+      var function = new AiAgentFunction(null, null);
+      var response = new AiAgentTaskConnectorResponse(null, listener);
+      var failure = new JobCompletionFailure.CommandFailed(new RuntimeException("test"));
+
+      function.onJobCompletionFailed(mock(OutboundConnectorContext.class), response, failure);
+
+      verify(listener).onJobCompletionFailed(failure);
+    }
+
+    @Test
+    void onJobCompletionFailed_noOpWhenResponseIsNull() {
+      var function = new AiAgentFunction(null, null);
+
+      // pre-response failure (e.g. execute() threw): no response to delegate to
+      function.onJobCompletionFailed(
+          mock(OutboundConnectorContext.class),
+          null,
+          new JobCompletionFailure.CommandFailed(new RuntimeException("boom")));
+    }
+
+    @Test
+    void onJobCompletionFailed_noOpWhenResponseIsNotAgentResponse() {
+      var function = new AiAgentFunction(null, null);
+      var foreignResponse = StandardConnectorResponse.of(Map.of("foo", "bar"));
+
+      // should not throw
+      function.onJobCompletionFailed(
+          mock(OutboundConnectorContext.class),
+          foreignResponse,
+          new JobCompletionFailure.CommandFailed(new RuntimeException("boom")));
+    }
+  }
+
+  @Nested
+  class JobWorkerFunctionDelegationTests {
+
+    @Test
+    void onJobCompleted_invokesAgentListenerCarriedByResponse() {
+      var listener = mock(AgentJobCompletionListener.class);
+      var function = new AiAgentJobWorker(null);
+      var response =
+          AiAgentSubProcessConnectorResponse.builder()
+              .variables(Map.of())
+              .elementActivations(List.of())
+              .completionConditionFulfilled(false)
+              .cancelRemainingInstances(false)
+              .completionListener(listener)
+              .build();
+
+      function.onJobCompleted(mock(OutboundConnectorContext.class), response);
+
+      verify(listener).onJobCompleted();
+    }
+
+    @Test
+    void onJobCompletionFailed_invokesAgentListenerCarriedByResponse() {
+      var listener = mock(AgentJobCompletionListener.class);
+      var function = new AiAgentJobWorker(null);
+      var response =
+          AiAgentSubProcessConnectorResponse.builder()
+              .variables(Map.of())
+              .elementActivations(List.of())
+              .completionConditionFulfilled(false)
+              .cancelRemainingInstances(false)
+              .completionListener(listener)
+              .build();
+      var failure = new JobCompletionFailure.CommandFailed(new RuntimeException("test"));
+
+      function.onJobCompletionFailed(mock(OutboundConnectorContext.class), response, failure);
+
+      verify(listener).onJobCompletionFailed(failure);
+    }
+
+    @Test
+    void onJobCompletionFailed_noOpWhenResponseIsNull() {
+      var function = new AiAgentJobWorker(null);
+      var listener = mock(AgentJobCompletionListener.class);
+
+      function.onJobCompletionFailed(
+          mock(OutboundConnectorContext.class),
+          (ConnectorResponse) null,
+          new JobCompletionFailure.CommandFailed(new RuntimeException("boom")));
+
+      verifyNoInteractions(listener);
     }
   }
 }

--- a/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/AiAgentResponseListenerDelegationTest.java
+++ b/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/AiAgentResponseListenerDelegationTest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.agenticai.aiagent;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import io.camunda.connector.api.outbound.JobCompletionFailure;
+import io.camunda.connector.api.outbound.JobCompletionListener;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class AiAgentResponseListenerDelegationTest {
+
+  @Nested
+  class TaskResponseTests {
+
+    @Test
+    void onJobCompleted_delegatesToListener() {
+      var listener = mock(JobCompletionListener.class);
+      var response = new AiAgentTaskConnectorResponse(null, listener);
+
+      response.onJobCompleted();
+
+      verify(listener).onJobCompleted();
+    }
+
+    @Test
+    void onJobCompletionFailed_delegatesToListener() {
+      var listener = mock(JobCompletionListener.class);
+      var failure = new JobCompletionFailure.CommandFailed(new RuntimeException("test"));
+      var response = new AiAgentTaskConnectorResponse(null, listener);
+
+      response.onJobCompletionFailed(failure);
+
+      verify(listener).onJobCompletionFailed(failure);
+    }
+
+    @Test
+    void onJobCompleted_noOpWithNullListener() {
+      var response = new AiAgentTaskConnectorResponse(null, null);
+
+      // should not throw
+      response.onJobCompleted();
+    }
+
+    @Test
+    void onJobCompletionFailed_noOpWithNullListener() {
+      var response = new AiAgentTaskConnectorResponse(null, null);
+
+      // should not throw
+      response.onJobCompletionFailed(
+          new JobCompletionFailure.CommandFailed(new RuntimeException("test")));
+    }
+  }
+
+  @Nested
+  class SubProcessResponseTests {
+
+    @Test
+    void onJobCompleted_delegatesToListener() {
+      var listener = mock(JobCompletionListener.class);
+      var response = buildResponse(listener);
+
+      response.onJobCompleted();
+
+      verify(listener).onJobCompleted();
+    }
+
+    @Test
+    void onJobCompletionFailed_delegatesToListener() {
+      var listener = mock(JobCompletionListener.class);
+      var failure = new JobCompletionFailure.CommandFailed(new RuntimeException("test"));
+      var response = buildResponse(listener);
+
+      response.onJobCompletionFailed(failure);
+
+      verify(listener).onJobCompletionFailed(failure);
+    }
+
+    @Test
+    void onJobCompleted_noOpWithNullListener() {
+      var response = buildResponse(null);
+
+      // should not throw
+      response.onJobCompleted();
+    }
+
+    @Test
+    void onJobCompletionFailed_noOpWithNullListener() {
+      var response = buildResponse(null);
+
+      // should not throw
+      response.onJobCompletionFailed(
+          new JobCompletionFailure.CommandFailed(new RuntimeException("test")));
+    }
+
+    private AiAgentSubProcessConnectorResponse buildResponse(JobCompletionListener listener) {
+      return AiAgentSubProcessConnectorResponse.builder()
+          .variables(Map.of())
+          .elementActivations(List.of())
+          .completionConditionFulfilled(false)
+          .cancelRemainingInstances(false)
+          .completionListener(listener)
+          .build();
+    }
+  }
+}

--- a/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/AiAgentResponseListenerDelegationTest.java
+++ b/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/AiAgentResponseListenerDelegationTest.java
@@ -38,7 +38,8 @@ class AiAgentResponseListenerDelegationTest {
     @Test
     void onJobCompletionFailed_delegatesToListener() {
       var listener = mock(AgentJobCompletionListener.class);
-      var failure = new JobCompletionFailure.CommandFailed(new RuntimeException("test"));
+      var failure =
+          new JobCompletionFailure.CommandFailure.CommandFailed(new RuntimeException("test"));
       var response = new AiAgentTaskConnectorResponse(null, listener);
 
       response.onJobCompletionFailed(failure);
@@ -60,7 +61,7 @@ class AiAgentResponseListenerDelegationTest {
 
       // should not throw
       response.onJobCompletionFailed(
-          new JobCompletionFailure.CommandFailed(new RuntimeException("test")));
+          new JobCompletionFailure.CommandFailure.CommandFailed(new RuntimeException("test")));
     }
   }
 
@@ -80,7 +81,8 @@ class AiAgentResponseListenerDelegationTest {
     @Test
     void onJobCompletionFailed_delegatesToListener() {
       var listener = mock(AgentJobCompletionListener.class);
-      var failure = new JobCompletionFailure.CommandFailed(new RuntimeException("test"));
+      var failure =
+          new JobCompletionFailure.CommandFailure.CommandFailed(new RuntimeException("test"));
       var response = buildResponse(listener);
 
       response.onJobCompletionFailed(failure);
@@ -102,7 +104,7 @@ class AiAgentResponseListenerDelegationTest {
 
       // should not throw
       response.onJobCompletionFailed(
-          new JobCompletionFailure.CommandFailed(new RuntimeException("test")));
+          new JobCompletionFailure.CommandFailure.CommandFailed(new RuntimeException("test")));
     }
 
     private AiAgentSubProcessConnectorResponse buildResponse(AgentJobCompletionListener listener) {
@@ -135,7 +137,8 @@ class AiAgentResponseListenerDelegationTest {
       var listener = mock(AgentJobCompletionListener.class);
       var function = new AiAgentFunction(null, null);
       var response = new AiAgentTaskConnectorResponse(null, listener);
-      var failure = new JobCompletionFailure.CommandFailed(new RuntimeException("test"));
+      var failure =
+          new JobCompletionFailure.CommandFailure.CommandFailed(new RuntimeException("test"));
 
       function.onJobCompletionFailed(mock(OutboundConnectorContext.class), response, failure);
 
@@ -150,7 +153,7 @@ class AiAgentResponseListenerDelegationTest {
       function.onJobCompletionFailed(
           mock(OutboundConnectorContext.class),
           null,
-          new JobCompletionFailure.CommandFailed(new RuntimeException("boom")));
+          new JobCompletionFailure.CommandFailure.CommandFailed(new RuntimeException("boom")));
     }
 
     @Test
@@ -162,7 +165,7 @@ class AiAgentResponseListenerDelegationTest {
       function.onJobCompletionFailed(
           mock(OutboundConnectorContext.class),
           foreignResponse,
-          new JobCompletionFailure.CommandFailed(new RuntimeException("boom")));
+          new JobCompletionFailure.CommandFailure.CommandFailed(new RuntimeException("boom")));
     }
   }
 
@@ -199,7 +202,8 @@ class AiAgentResponseListenerDelegationTest {
               .cancelRemainingInstances(false)
               .completionListener(listener)
               .build();
-      var failure = new JobCompletionFailure.CommandFailed(new RuntimeException("test"));
+      var failure =
+          new JobCompletionFailure.CommandFailure.CommandFailed(new RuntimeException("test"));
 
       function.onJobCompletionFailed(mock(OutboundConnectorContext.class), response, failure);
 
@@ -214,7 +218,7 @@ class AiAgentResponseListenerDelegationTest {
       function.onJobCompletionFailed(
           mock(OutboundConnectorContext.class),
           (ConnectorResponse) null,
-          new JobCompletionFailure.CommandFailed(new RuntimeException("boom")));
+          new JobCompletionFailure.CommandFailure.CommandFailed(new RuntimeException("boom")));
 
       verifyNoInteractions(listener);
     }

--- a/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/memory/conversation/document/CamundaDocumentConversationStoreTest.java
+++ b/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/memory/conversation/document/CamundaDocumentConversationStoreTest.java
@@ -373,7 +373,9 @@ class CamundaDocumentConversationStoreTest {
     var agentContext = AgentContext.empty().withConversation(conversationContext);
 
     store.onJobCompletionFailed(
-        agentContext, new JobCompletionFailure.CommandFailed(new RuntimeException("test")));
+        executionContext,
+        agentContext,
+        new JobCompletionFailure.CommandFailed(new RuntimeException("test")));
 
     verify(documentStore).deleteDocument(documentReference);
   }
@@ -393,7 +395,9 @@ class CamundaDocumentConversationStoreTest {
 
     // should not throw
     store.onJobCompletionFailed(
-        agentContext, new JobCompletionFailure.CommandFailed(new RuntimeException("test")));
+        executionContext,
+        agentContext,
+        new JobCompletionFailure.CommandFailed(new RuntimeException("test")));
 
     verify(documentStore).deleteDocument(documentReference);
   }
@@ -403,7 +407,9 @@ class CamundaDocumentConversationStoreTest {
     var agentContext = AgentContext.empty();
 
     store.onJobCompletionFailed(
-        agentContext, new JobCompletionFailure.CommandFailed(new RuntimeException("test")));
+        executionContext,
+        agentContext,
+        new JobCompletionFailure.CommandFailed(new RuntimeException("test")));
 
     verifyNoInteractions(documentStore);
   }
@@ -418,7 +424,9 @@ class CamundaDocumentConversationStoreTest {
     var agentContext = AgentContext.empty().withConversation(conversationContext);
 
     store.onJobCompletionFailed(
-        agentContext, new JobCompletionFailure.CommandFailed(new RuntimeException("test")));
+        executionContext,
+        agentContext,
+        new JobCompletionFailure.CommandFailed(new RuntimeException("test")));
 
     verify(documentStore, never()).deleteDocument(any());
   }

--- a/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/memory/conversation/document/CamundaDocumentConversationStoreTest.java
+++ b/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/memory/conversation/document/CamundaDocumentConversationStoreTest.java
@@ -9,9 +9,12 @@ package io.camunda.connector.agenticai.aiagent.memory.conversation.document;
 import static io.camunda.connector.agenticai.aiagent.TestMessagesFixture.userMessage;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -29,7 +32,9 @@ import io.camunda.connector.agenticai.model.message.Message;
 import io.camunda.connector.api.document.Document;
 import io.camunda.connector.api.document.DocumentCreationRequest;
 import io.camunda.connector.api.document.DocumentFactory;
+import io.camunda.connector.api.document.DocumentReference;
 import io.camunda.connector.api.document.DocumentReference.CamundaDocumentReference;
+import io.camunda.connector.api.outbound.JobCompletionFailure;
 import io.camunda.connector.jackson.ConnectorsObjectMapperSupplier;
 import io.camunda.connector.runtime.core.document.store.CamundaDocumentStore;
 import java.io.ByteArrayInputStream;
@@ -355,6 +360,67 @@ class CamundaDocumentConversationStoreTest {
                       previousDocuments.get(2),
                       previousDocument);
             });
+  }
+
+  @Test
+  void onJobCompletionFailed_deletesOrphanedDocument() {
+    var documentReference = mock(CamundaDocumentReference.class);
+    var document = mock(Document.class);
+    when(document.reference()).thenReturn(documentReference);
+
+    var conversationContext =
+        CamundaDocumentConversationContext.builder("test-conversation").document(document).build();
+    var agentContext = AgentContext.empty().withConversation(conversationContext);
+
+    store.onJobCompletionFailed(
+        agentContext, new JobCompletionFailure.CommandFailed(new RuntimeException("test")));
+
+    verify(documentStore).deleteDocument(documentReference);
+  }
+
+  @Test
+  void onJobCompletionFailed_swallowsDeleteFailure() {
+    var documentReference = mock(CamundaDocumentReference.class);
+    var document = mock(Document.class);
+    when(document.reference()).thenReturn(documentReference);
+    doThrow(new RuntimeException("delete failed"))
+        .when(documentStore)
+        .deleteDocument(documentReference);
+
+    var conversationContext =
+        CamundaDocumentConversationContext.builder("test-conversation").document(document).build();
+    var agentContext = AgentContext.empty().withConversation(conversationContext);
+
+    // should not throw
+    store.onJobCompletionFailed(
+        agentContext, new JobCompletionFailure.CommandFailed(new RuntimeException("test")));
+
+    verify(documentStore).deleteDocument(documentReference);
+  }
+
+  @Test
+  void onJobCompletionFailed_noOpWithoutConversationContext() {
+    var agentContext = AgentContext.empty();
+
+    store.onJobCompletionFailed(
+        agentContext, new JobCompletionFailure.CommandFailed(new RuntimeException("test")));
+
+    verifyNoInteractions(documentStore);
+  }
+
+  @Test
+  void onJobCompletionFailed_noOpForNonCamundaDocumentReference() {
+    var document = mock(Document.class);
+    when(document.reference()).thenReturn(mock(DocumentReference.class));
+
+    var conversationContext =
+        CamundaDocumentConversationContext.builder("test-conversation").document(document).build();
+    var agentContext = AgentContext.empty().withConversation(conversationContext);
+
+    store.onJobCompletionFailed(
+        agentContext, new JobCompletionFailure.CommandFailed(new RuntimeException("test")));
+
+    verify(documentStore, never()).deleteDocument(any());
   }
 
   private void assertDocumentCreationRequest(

--- a/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/memory/conversation/document/CamundaDocumentConversationStoreTest.java
+++ b/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/memory/conversation/document/CamundaDocumentConversationStoreTest.java
@@ -375,7 +375,7 @@ class CamundaDocumentConversationStoreTest {
     store.onJobCompletionFailed(
         executionContext,
         agentContext,
-        new JobCompletionFailure.CommandFailed(new RuntimeException("test")));
+        new JobCompletionFailure.CommandFailure.CommandFailed(new RuntimeException("test")));
 
     verify(documentStore).deleteDocument(documentReference);
   }
@@ -397,7 +397,7 @@ class CamundaDocumentConversationStoreTest {
     store.onJobCompletionFailed(
         executionContext,
         agentContext,
-        new JobCompletionFailure.CommandFailed(new RuntimeException("test")));
+        new JobCompletionFailure.CommandFailure.CommandFailed(new RuntimeException("test")));
 
     verify(documentStore).deleteDocument(documentReference);
   }
@@ -409,7 +409,7 @@ class CamundaDocumentConversationStoreTest {
     store.onJobCompletionFailed(
         executionContext,
         agentContext,
-        new JobCompletionFailure.CommandFailed(new RuntimeException("test")));
+        new JobCompletionFailure.CommandFailure.CommandFailed(new RuntimeException("test")));
 
     verifyNoInteractions(documentStore);
   }
@@ -426,7 +426,7 @@ class CamundaDocumentConversationStoreTest {
     store.onJobCompletionFailed(
         executionContext,
         agentContext,
-        new JobCompletionFailure.CommandFailed(new RuntimeException("test")));
+        new JobCompletionFailure.CommandFailure.CommandFailed(new RuntimeException("test")));
 
     verify(documentStore, never()).deleteDocument(any());
   }

--- a/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/autoconfigure/TestConfig.java
+++ b/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/autoconfigure/TestConfig.java
@@ -10,14 +10,9 @@ import static org.mockito.Mockito.mock;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.client.CamundaClient;
-import io.camunda.client.jobhandling.CommandExceptionHandlingStrategy;
-import io.camunda.client.metrics.DefaultNoopMetricsRecorder;
-import io.camunda.client.metrics.MetricsRecorder;
 import io.camunda.connector.api.document.DocumentFactory;
-import io.camunda.connector.feel.FeelExpressionEvaluator;
 import io.camunda.connector.runtime.annotation.ConnectorsObjectMapper;
 import io.camunda.connector.runtime.core.document.store.CamundaDocumentStore;
-import io.camunda.connector.runtime.core.secret.SecretProviderAggregator;
 import org.springframework.context.annotation.Bean;
 
 class TestConfig {
@@ -40,25 +35,5 @@ class TestConfig {
   @Bean
   public CamundaDocumentStore documentStore() {
     return mock(CamundaDocumentStore.class);
-  }
-
-  @Bean
-  public FeelExpressionEvaluator feelExpressionEvaluator() {
-    return mock(FeelExpressionEvaluator.class);
-  }
-
-  @Bean
-  public SecretProviderAggregator secretProviderAggregator() {
-    return mock(SecretProviderAggregator.class);
-  }
-
-  @Bean
-  public CommandExceptionHandlingStrategy commandExceptionHandlingStrategy() {
-    return mock(CommandExceptionHandlingStrategy.class);
-  }
-
-  @Bean
-  public MetricsRecorder metricsRecorder() {
-    return new DefaultNoopMetricsRecorder();
   }
 }

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -70,7 +70,7 @@ limitations under the License.</license.inlineheader>
     <nexus.release.repository>https://artifacts.camunda.com/artifactory/connectors/</nexus.release.repository>
 
     <!-- Camunda internal libraries -->
-    <version.camunda>8.9.2</version.camunda>
+    <version.camunda>8.10.0-SNAPSHOT</version.camunda>
     <version.feel-engine>1.21.0</version.feel-engine>
     <version.camunda-xml-model>7.24.0</version.camunda-xml-model>
 


### PR DESCRIPTION
## Description

Based on #6784

Adds job completion callbacks to the connector SDK and wires them through the runtime into the agentic-ai conversation store SPI.  Depends on camunda/camunda#49396 for the `JobCallbackCommandWrapperFactory` / `CommandOutcome` APIs.

**SDK + Runtime:**
- Bump `version.camunda` to `8.10.0-SNAPSHOT` for `JobCallbackCommandWrapperFactory` / `CommandOutcome` APIs
- Migrate `SpringConnectorJobHandler` from `CommandWrapper`/`CommandExceptionHandlingStrategy` to the new callback-aware command APIs
- Add `JobCompletionListener` and `JobCompletionFailure` interfaces to the connector SDK — `OutboundConnectorFunction` implementations can optionally implement `JobCompletionListener` to receive lifecycle notifications after Zeebe command dispatch
- `JobCompletionFailure` is a sealed hierarchy: `CommandFailure` (sub-sealed; Zeebe-side rejections — `CommandFailed` / `CommandIgnored`), `ExecutionFailed` (connector function exceptions, error-expression evaluation failures, runtime-synthesized rejections), `BpmnErrorThrown`, `JobErrorRaised`. The latter three carry an optional `CommandFailure` to surface the case where the failJob/throwBpmnError command sent in response was itself rejected
- `SpringConnectorJobHandler` notifies all listener callbacks asynchronously after the relevant Zeebe command future resolves (completeJob, throwBpmnError, failJob)
- Unit tests cover BPMN error, job error, IgnoreError, completeJob outcomes (success/Failed/Ignored), pre-response failures, and command-failure-on-response paths

**Agentic AI:**
- `AiAgentFunction` and `AiAgentJobWorker` implement `JobCompletionListener` (via the shared `AgentConnectorFunction` mixin) and delegate to an internal `AgentJobCompletionListener` carried by the response. The internal listener captures per-execution state (conversation store + agent context) at response build time, so callbacks fire with full context once Zeebe resolves
- Add `onJobCompleted(AgentExecutionContext, AgentContext)` and `onJobCompletionFailed(AgentExecutionContext, AgentContext, JobCompletionFailure)` default hooks to `ConversationStore` — the execution context is provided so implementations can create temporary sessions for compensation if needed
- Implement `onJobCompletionFailed` on `CamundaDocumentConversationStore` to delete the orphaned document written by `storeMessages` when job completion is rejected by Zeebe
- Unit tests for response delegation, function-level delegation, and document store orphan cleanup
- Clean up `TestConfig` (remove unused beans from custom job handler era) and unused test dependencies

**Agentic AI E2E:**
- Add e2e tests for both job worker and outbound connector flavors verifying orphaned document cleanup after job completion failure (fails the job via Zeebe API during execution, then verifies the exact document created by `storeMessages` is deleted by `onJobCompletionFailed`)

## Related issues

closes #7020

Based on #6784. Depends on camunda/camunda#49396 for the `JobCallbackCommandWrapperFactory` / `CommandOutcome` APIs.

## Checklist

- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest
  release, as this branch will be rebased onto main before the next release. Example backport labels:
    - `backport stable/8.8`: for changes that should be included in the next 8.8.x release.
    - **or** `backport release-8.8.7`: for changes that should be included in the specific release 8.8.7, and this
      *release has already been created*. The release branch will be merged back into stable/8.8 later, so the change
      will be included in future 8.8.x releases as well.
- [x] Tests/Integration tests for the changes have been added if applicable.
- [x] If the change requires a documentation update, it has been added to the appropriate section in the documentation.
