### PR TITLE
docs(agentic-ai): Add README for Agentic AI element templates

### DIFF
--- a/connectors/agentic-ai/AGENTS.md
+++ b/connectors/agentic-ai/AGENTS.md
@@ -273,6 +273,33 @@ Tool naming: `A2A_<elementName>` — one A2A element = one tool (an entire remot
 The job worker template is auto-generated from the outbound template via
 `bin/transform-ai-agent-job-worker-template.groovy` (gmavenplus-plugin, `process-classes` phase).
 
+### Version index README
+
+[`element-templates/README.md`](element-templates/README.md) is a user-facing
+index (linked from the Camunda Marketplace) that maps each connector to the
+latest template version per Camunda minor release. It must stay in sync with the
+JSON files every time a template version is bumped or a new connector is added.
+
+When `versionHistoryEnabled` moves a superseded template into
+`element-templates/versioned/`, update the README as follows:
+
+1. **Identify the new minimum Camunda version** — check the `engines.camunda`
+   field of the new template (e.g. `^8.10`).
+2. **Same minimum as the current top row** → replace the top row: update the
+   template version and the file link (the link now points at the file in
+   `versioned/`, since the newest template in the main folder replaced it).
+3. **Higher minimum than the current top row** → insert a new row at the top
+   with the new minimum Camunda version and template version, and move the
+   previous top row's link under `versioned/`.
+4. **AI Agent has two tables** (Task + Sub-process). They share the same
+   template version numbers, so update both.
+5. **New connector** → add a new section in the same order as the existing
+   ones (AI Agent, MCP Client, A2A, Ad-hoc tools schema) with an intro
+   paragraph linking to the `docs.camunda.io` overview page for that connector.
+
+Do not list `element-templates/hybrid/` templates in the README — they are
+intentionally omitted.
+
 ## Key Entry Points
 
 | File                                          | Purpose                                      |
@@ -313,6 +340,8 @@ When making code changes to this module, update the relevant documentation to re
 
 - **This file (`AGENTS.md`)**: Update if the change affects high-level architecture, key concepts, build commands, or
   entry points.
+- **`element-templates/README.md`**: Update whenever an element template version is bumped, a template is moved into
+  `versioned/`, or a new connector is added. See [Version index README](#version-index-readme) for the update rules.
 - **`docs/reference/ai-agent.md`**: Update for changes to the core agent framework — orchestration, memory, tool
   resolution, converters, configuration, error handling.
 - **`docs/reference/mcp.md`**: Update for changes to MCP client integration — data model, client lifecycle, transport,

--- a/connectors/agentic-ai/CLAUDE.md
+++ b/connectors/agentic-ai/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/connectors/agentic-ai/element-templates/README.md
+++ b/connectors/agentic-ai/element-templates/README.md
@@ -5,8 +5,7 @@ for the Agentic AI connectors shipped with Camunda.
 
 The latest template of each connector lives directly in this folder. Older revisions
 that are still compatible with previous Camunda minor versions are kept in
-[`versioned/`](./versioned/). Hybrid variants are published in
-[`hybrid/`](./hybrid/) and are intentionally omitted from the tables below.
+[`versioned/`](./versioned/).
 
 ## Which template do I need?
 
@@ -18,49 +17,57 @@ field in each JSON file captures the same information (e.g. `^8.9` means
 For example, if you are on Camunda 8.9, use the AI Agent template version `7`;
 if you are on Camunda 8.10, use version `10`.
 
-## AI Agent
+## AI Agent connectors
 
-The AI Agent ships in two flavors that share the same versioning scheme:
+The AI Agent ships in two flavors that share the same versioning scheme.
 
-- **AI Agent Task** — outbound connector (`io.camunda.connectors.agenticai.aiagent.v1`)
-- **AI Agent Sub-process** — job worker (`io.camunda.connectors.agenticai.aiagent.jobworker.v1`)
+### AI Agent Task (outbound connector)
 
-| Minimum Camunda minor | Template version | AI Agent Task | AI Agent Sub-process |
+`io.camunda.connectors.agenticai.aiagent.v1`
+
+| Minimum Camunda minor | Template version | Connector     | File |
 | --- | --- | --- | --- |
-| 8.10 | 10 | [`agenticai-aiagent-outbound-connector.json`](./agenticai-aiagent-outbound-connector.json) | [`agenticai-aiagent-job-worker.json`](./agenticai-aiagent-job-worker.json) |
-| 8.9  | 7  | [`versioned/agenticai-aiagent-outbound-connector-7.json`](./versioned/agenticai-aiagent-outbound-connector-7.json) | [`versioned/agenticai-aiagent-job-worker-7.json`](./versioned/agenticai-aiagent-job-worker-7.json) |
-| 8.8  | 5  | [`versioned/agenticai-aiagent-outbound-connector-5.json`](./versioned/agenticai-aiagent-outbound-connector-5.json) | [`versioned/agenticai-aiagent-job-worker-5.json`](./versioned/agenticai-aiagent-job-worker-5.json) |
+| 8.10 | 10 | AI Agent Task | [`agenticai-aiagent-outbound-connector.json`](./agenticai-aiagent-outbound-connector.json) |
+| 8.9  | 7  | AI Agent Task | [`versioned/agenticai-aiagent-outbound-connector-7.json`](./versioned/agenticai-aiagent-outbound-connector-7.json) |
+| 8.8  | 5  | AI Agent Task | [`versioned/agenticai-aiagent-outbound-connector-5.json`](./versioned/agenticai-aiagent-outbound-connector-5.json) |
 
-## MCP clients
+### AI Agent Sub-process (job worker)
 
-Clients for the [Model Context Protocol](https://modelcontextprotocol.io/):
+`io.camunda.connectors.agenticai.aiagent.jobworker.v1`
 
-- **MCP Client** — local MCP client (`io.camunda.connectors.agenticai.mcp.client.v0`)
-- **MCP Remote Client** — remote MCP client (`io.camunda.connectors.agenticai.mcp.remoteclient.v0`)
-
-| Minimum Camunda minor | Template version | MCP Client | MCP Remote Client |
+| Minimum Camunda minor | Template version | Connector            | File |
 | --- | --- | --- | --- |
-| 8.9 | 2 | [`agenticai-mcp-client-outbound-connector.json`](./agenticai-mcp-client-outbound-connector.json) | [`agenticai-mcp-remote-client-outbound-connector.json`](./agenticai-mcp-remote-client-outbound-connector.json) |
-| 8.8 | 0 | [`versioned/agenticai-mcp-client-outbound-connector-0.json`](./versioned/agenticai-mcp-client-outbound-connector-0.json) | [`versioned/agenticai-mcp-remote-client-outbound-connector-0.json`](./versioned/agenticai-mcp-remote-client-outbound-connector-0.json) |
+| 8.10 | 10 | AI Agent Sub-process | [`agenticai-aiagent-job-worker.json`](./agenticai-aiagent-job-worker.json) |
+| 8.9  | 7  | AI Agent Sub-process | [`versioned/agenticai-aiagent-job-worker-7.json`](./versioned/agenticai-aiagent-job-worker-7.json) |
+| 8.8  | 5  | AI Agent Sub-process | [`versioned/agenticai-aiagent-job-worker-5.json`](./versioned/agenticai-aiagent-job-worker-5.json) |
+
+## MCP Client connectors
+
+Clients for the [Model Context Protocol](https://modelcontextprotocol.io/).
+
+| Minimum Camunda minor | Template version | Connector         | File |
+| --- | --- | --- | --- |
+| 8.9 | 2 | MCP Client        | [`agenticai-mcp-client-outbound-connector.json`](./agenticai-mcp-client-outbound-connector.json) |
+| 8.8 | 0 | MCP Client        | [`versioned/agenticai-mcp-client-outbound-connector-0.json`](./versioned/agenticai-mcp-client-outbound-connector-0.json) |
+| 8.9 | 2 | MCP Remote Client | [`agenticai-mcp-remote-client-outbound-connector.json`](./agenticai-mcp-remote-client-outbound-connector.json) |
+| 8.8 | 0 | MCP Remote Client | [`versioned/agenticai-mcp-remote-client-outbound-connector-0.json`](./versioned/agenticai-mcp-remote-client-outbound-connector-0.json) |
 
 ## A2A connectors
 
 Connectors implementing the [Agent2Agent protocol](https://a2a-protocol.org/).
-All A2A templates are currently at version `0` and require Camunda 8.9 or later.
 
-| Minimum Camunda minor | Template version | Connector | File |
+| Minimum Camunda minor | Template version | Connector                                     | File |
 | --- | --- | --- | --- |
-| 8.9 | 0 | A2A Client (outbound)                             | [`agenticai-a2a-client-outbound-connector.json`](./agenticai-a2a-client-outbound-connector.json) |
-| 8.9 | 0 | A2A Client Polling — Intermediate Catch Event     | [`agenticai-a2a-client-polling-inbound-connector-intermediate.json`](./agenticai-a2a-client-polling-inbound-connector-intermediate.json) |
-| 8.9 | 0 | A2A Client Polling — Receive Task                 | [`agenticai-a2a-client-polling-inbound-connector-receive.json`](./agenticai-a2a-client-polling-inbound-connector-receive.json) |
-| 8.9 | 0 | A2A Client Webhook — Intermediate Catch Event     | [`agenticai-a2a-client-webhook-inbound-connector-intermediate.json`](./agenticai-a2a-client-webhook-inbound-connector-intermediate.json) |
-| 8.9 | 0 | A2A Client Webhook — Receive Task                 | [`agenticai-a2a-client-webhook-inbound-connector-receive.json`](./agenticai-a2a-client-webhook-inbound-connector-receive.json) |
+| 8.9 | 0 | A2A Client (outbound)                         | [`agenticai-a2a-client-outbound-connector.json`](./agenticai-a2a-client-outbound-connector.json) |
+| 8.9 | 0 | A2A Client Polling — Intermediate Catch Event | [`agenticai-a2a-client-polling-inbound-connector-intermediate.json`](./agenticai-a2a-client-polling-inbound-connector-intermediate.json) |
+| 8.9 | 0 | A2A Client Polling — Receive Task             | [`agenticai-a2a-client-polling-inbound-connector-receive.json`](./agenticai-a2a-client-polling-inbound-connector-receive.json) |
+| 8.9 | 0 | A2A Client Webhook — Intermediate Catch Event | [`agenticai-a2a-client-webhook-inbound-connector-intermediate.json`](./agenticai-a2a-client-webhook-inbound-connector-intermediate.json) |
+| 8.9 | 0 | A2A Client Webhook — Receive Task             | [`agenticai-a2a-client-webhook-inbound-connector-receive.json`](./agenticai-a2a-client-webhook-inbound-connector-receive.json) |
 
-## Ad-hoc tools schema
+## Ad-hoc tools schema connectors
 
-Resolves the tools available in an ad-hoc sub-process
-(`io.camunda.connectors.agenticai.adhoctoolsschema.v1`).
+Resolves the tools available in an ad-hoc sub-process.
 
-| Minimum Camunda minor | Template version | File |
-| --- | --- | --- |
-| 8.8 | 2 | [`agenticai-adhoctoolsschema-outbound-connector.json`](./agenticai-adhoctoolsschema-outbound-connector.json) |
+| Minimum Camunda minor | Template version | Connector           | File |
+| --- | --- | --- | --- |
+| 8.8 | 2 | Ad-hoc tools schema | [`agenticai-adhoctoolsschema-outbound-connector.json`](./agenticai-adhoctoolsschema-outbound-connector.json) |

--- a/connectors/agentic-ai/element-templates/README.md
+++ b/connectors/agentic-ai/element-templates/README.md
@@ -23,8 +23,6 @@ The AI Agent ships in two flavors that share the same versioning scheme.
 
 ### AI Agent Task
 
-`io.camunda.connectors.agenticai.aiagent.v1`
-
 | Connector     | Minimum Camunda version | Template version | File |
 | --- | --- | --- | --- |
 | AI Agent Task | 8.10 | 10 | [`agenticai-aiagent-outbound-connector.json`](./agenticai-aiagent-outbound-connector.json) |
@@ -32,8 +30,6 @@ The AI Agent ships in two flavors that share the same versioning scheme.
 | AI Agent Task | 8.8  | 5  | [`versioned/agenticai-aiagent-outbound-connector-5.json`](./versioned/agenticai-aiagent-outbound-connector-5.json) |
 
 ### AI Agent Sub-process
-
-`io.camunda.connectors.agenticai.aiagent.jobworker.v1`
 
 | Connector            | Minimum Camunda version | Template version | File |
 | --- | --- | --- | --- |

--- a/connectors/agentic-ai/element-templates/README.md
+++ b/connectors/agentic-ai/element-templates/README.md
@@ -21,53 +21,53 @@ if you are on Camunda 8.10, use version `10`.
 
 The AI Agent ships in two flavors that share the same versioning scheme.
 
-### AI Agent Task (outbound connector)
+### AI Agent Task
 
 `io.camunda.connectors.agenticai.aiagent.v1`
 
-| Minimum Camunda version | Template version | Connector     | File |
+| Connector     | Minimum Camunda version | Template version | File |
 | --- | --- | --- | --- |
-| 8.10 | 10 | AI Agent Task | [`agenticai-aiagent-outbound-connector.json`](./agenticai-aiagent-outbound-connector.json) |
-| 8.9  | 7  | AI Agent Task | [`versioned/agenticai-aiagent-outbound-connector-7.json`](./versioned/agenticai-aiagent-outbound-connector-7.json) |
-| 8.8  | 5  | AI Agent Task | [`versioned/agenticai-aiagent-outbound-connector-5.json`](./versioned/agenticai-aiagent-outbound-connector-5.json) |
+| AI Agent Task | 8.10 | 10 | [`agenticai-aiagent-outbound-connector.json`](./agenticai-aiagent-outbound-connector.json) |
+| AI Agent Task | 8.9  | 7  | [`versioned/agenticai-aiagent-outbound-connector-7.json`](./versioned/agenticai-aiagent-outbound-connector-7.json) |
+| AI Agent Task | 8.8  | 5  | [`versioned/agenticai-aiagent-outbound-connector-5.json`](./versioned/agenticai-aiagent-outbound-connector-5.json) |
 
-### AI Agent Sub-process (job worker)
+### AI Agent Sub-process
 
 `io.camunda.connectors.agenticai.aiagent.jobworker.v1`
 
-| Minimum Camunda version | Template version | Connector            | File |
+| Connector            | Minimum Camunda version | Template version | File |
 | --- | --- | --- | --- |
-| 8.10 | 10 | AI Agent Sub-process | [`agenticai-aiagent-job-worker.json`](./agenticai-aiagent-job-worker.json) |
-| 8.9  | 7  | AI Agent Sub-process | [`versioned/agenticai-aiagent-job-worker-7.json`](./versioned/agenticai-aiagent-job-worker-7.json) |
-| 8.8  | 5  | AI Agent Sub-process | [`versioned/agenticai-aiagent-job-worker-5.json`](./versioned/agenticai-aiagent-job-worker-5.json) |
+| AI Agent Sub-process | 8.10 | 10 | [`agenticai-aiagent-job-worker.json`](./agenticai-aiagent-job-worker.json) |
+| AI Agent Sub-process | 8.9  | 7  | [`versioned/agenticai-aiagent-job-worker-7.json`](./versioned/agenticai-aiagent-job-worker-7.json) |
+| AI Agent Sub-process | 8.8  | 5  | [`versioned/agenticai-aiagent-job-worker-5.json`](./versioned/agenticai-aiagent-job-worker-5.json) |
 
 ## MCP Client connectors
 
 Clients for the [Model Context Protocol](https://modelcontextprotocol.io/).
 
-| Minimum Camunda version | Template version | Connector         | File |
+| Connector         | Minimum Camunda version | Template version | File |
 | --- | --- | --- | --- |
-| 8.9 | 2 | MCP Client        | [`agenticai-mcp-client-outbound-connector.json`](./agenticai-mcp-client-outbound-connector.json) |
-| 8.8 | 0 | MCP Client        | [`versioned/agenticai-mcp-client-outbound-connector-0.json`](./versioned/agenticai-mcp-client-outbound-connector-0.json) |
-| 8.9 | 2 | MCP Remote Client | [`agenticai-mcp-remote-client-outbound-connector.json`](./agenticai-mcp-remote-client-outbound-connector.json) |
-| 8.8 | 0 | MCP Remote Client | [`versioned/agenticai-mcp-remote-client-outbound-connector-0.json`](./versioned/agenticai-mcp-remote-client-outbound-connector-0.json) |
+| MCP Client        | 8.9 | 2 | [`agenticai-mcp-client-outbound-connector.json`](./agenticai-mcp-client-outbound-connector.json) |
+| MCP Client        | 8.8 | 0 | [`versioned/agenticai-mcp-client-outbound-connector-0.json`](./versioned/agenticai-mcp-client-outbound-connector-0.json) |
+| MCP Remote Client | 8.9 | 2 | [`agenticai-mcp-remote-client-outbound-connector.json`](./agenticai-mcp-remote-client-outbound-connector.json) |
+| MCP Remote Client | 8.8 | 0 | [`versioned/agenticai-mcp-remote-client-outbound-connector-0.json`](./versioned/agenticai-mcp-remote-client-outbound-connector-0.json) |
 
 ## A2A connectors
 
 Connectors implementing the [Agent2Agent protocol](https://a2a-protocol.org/).
 
-| Minimum Camunda version | Template version | Connector                                     | File |
+| Connector                                     | Minimum Camunda version | Template version | File |
 | --- | --- | --- | --- |
-| 8.9 | 0 | A2A Client (outbound)                         | [`agenticai-a2a-client-outbound-connector.json`](./agenticai-a2a-client-outbound-connector.json) |
-| 8.9 | 0 | A2A Client Polling — Intermediate Catch Event | [`agenticai-a2a-client-polling-inbound-connector-intermediate.json`](./agenticai-a2a-client-polling-inbound-connector-intermediate.json) |
-| 8.9 | 0 | A2A Client Polling — Receive Task             | [`agenticai-a2a-client-polling-inbound-connector-receive.json`](./agenticai-a2a-client-polling-inbound-connector-receive.json) |
-| 8.9 | 0 | A2A Client Webhook — Intermediate Catch Event | [`agenticai-a2a-client-webhook-inbound-connector-intermediate.json`](./agenticai-a2a-client-webhook-inbound-connector-intermediate.json) |
-| 8.9 | 0 | A2A Client Webhook — Receive Task             | [`agenticai-a2a-client-webhook-inbound-connector-receive.json`](./agenticai-a2a-client-webhook-inbound-connector-receive.json) |
+| A2A Client (outbound)                         | 8.9 | 0 | [`agenticai-a2a-client-outbound-connector.json`](./agenticai-a2a-client-outbound-connector.json) |
+| A2A Client Polling — Intermediate Catch Event | 8.9 | 0 | [`agenticai-a2a-client-polling-inbound-connector-intermediate.json`](./agenticai-a2a-client-polling-inbound-connector-intermediate.json) |
+| A2A Client Polling — Receive Task             | 8.9 | 0 | [`agenticai-a2a-client-polling-inbound-connector-receive.json`](./agenticai-a2a-client-polling-inbound-connector-receive.json) |
+| A2A Client Webhook — Intermediate Catch Event | 8.9 | 0 | [`agenticai-a2a-client-webhook-inbound-connector-intermediate.json`](./agenticai-a2a-client-webhook-inbound-connector-intermediate.json) |
+| A2A Client Webhook — Receive Task             | 8.9 | 0 | [`agenticai-a2a-client-webhook-inbound-connector-receive.json`](./agenticai-a2a-client-webhook-inbound-connector-receive.json) |
 
 ## Ad-hoc tools schema connectors
 
 Resolves the tools available in an ad-hoc sub-process.
 
-| Minimum Camunda version | Template version | Connector           | File |
+| Connector           | Minimum Camunda version | Template version | File |
 | --- | --- | --- | --- |
-| 8.8 | 2 | Ad-hoc tools schema | [`agenticai-adhoctoolsschema-outbound-connector.json`](./agenticai-adhoctoolsschema-outbound-connector.json) |
+| Ad-hoc tools schema | 8.8 | 2 | [`agenticai-adhoctoolsschema-outbound-connector.json`](./agenticai-adhoctoolsschema-outbound-connector.json) |

--- a/connectors/agentic-ai/element-templates/README.md
+++ b/connectors/agentic-ai/element-templates/README.md
@@ -9,7 +9,7 @@ that are still compatible with previous Camunda minor versions are kept in
 
 ## Which template do I need?
 
-Pick the highest template version whose *minimum Camunda minor version* is less
+Pick the highest template version whose *minimum Camunda version* is less
 than or equal to the Camunda version you are running. The `engines.camunda`
 field in each JSON file captures the same information (e.g. `^8.9` means
 "requires Camunda 8.9 or later").
@@ -25,7 +25,7 @@ The AI Agent ships in two flavors that share the same versioning scheme.
 
 `io.camunda.connectors.agenticai.aiagent.v1`
 
-| Minimum Camunda minor | Template version | Connector     | File |
+| Minimum Camunda version | Template version | Connector     | File |
 | --- | --- | --- | --- |
 | 8.10 | 10 | AI Agent Task | [`agenticai-aiagent-outbound-connector.json`](./agenticai-aiagent-outbound-connector.json) |
 | 8.9  | 7  | AI Agent Task | [`versioned/agenticai-aiagent-outbound-connector-7.json`](./versioned/agenticai-aiagent-outbound-connector-7.json) |
@@ -35,7 +35,7 @@ The AI Agent ships in two flavors that share the same versioning scheme.
 
 `io.camunda.connectors.agenticai.aiagent.jobworker.v1`
 
-| Minimum Camunda minor | Template version | Connector            | File |
+| Minimum Camunda version | Template version | Connector            | File |
 | --- | --- | --- | --- |
 | 8.10 | 10 | AI Agent Sub-process | [`agenticai-aiagent-job-worker.json`](./agenticai-aiagent-job-worker.json) |
 | 8.9  | 7  | AI Agent Sub-process | [`versioned/agenticai-aiagent-job-worker-7.json`](./versioned/agenticai-aiagent-job-worker-7.json) |
@@ -45,7 +45,7 @@ The AI Agent ships in two flavors that share the same versioning scheme.
 
 Clients for the [Model Context Protocol](https://modelcontextprotocol.io/).
 
-| Minimum Camunda minor | Template version | Connector         | File |
+| Minimum Camunda version | Template version | Connector         | File |
 | --- | --- | --- | --- |
 | 8.9 | 2 | MCP Client        | [`agenticai-mcp-client-outbound-connector.json`](./agenticai-mcp-client-outbound-connector.json) |
 | 8.8 | 0 | MCP Client        | [`versioned/agenticai-mcp-client-outbound-connector-0.json`](./versioned/agenticai-mcp-client-outbound-connector-0.json) |
@@ -56,7 +56,7 @@ Clients for the [Model Context Protocol](https://modelcontextprotocol.io/).
 
 Connectors implementing the [Agent2Agent protocol](https://a2a-protocol.org/).
 
-| Minimum Camunda minor | Template version | Connector                                     | File |
+| Minimum Camunda version | Template version | Connector                                     | File |
 | --- | --- | --- | --- |
 | 8.9 | 0 | A2A Client (outbound)                         | [`agenticai-a2a-client-outbound-connector.json`](./agenticai-a2a-client-outbound-connector.json) |
 | 8.9 | 0 | A2A Client Polling — Intermediate Catch Event | [`agenticai-a2a-client-polling-inbound-connector-intermediate.json`](./agenticai-a2a-client-polling-inbound-connector-intermediate.json) |
@@ -68,6 +68,6 @@ Connectors implementing the [Agent2Agent protocol](https://a2a-protocol.org/).
 
 Resolves the tools available in an ad-hoc sub-process.
 
-| Minimum Camunda minor | Template version | Connector           | File |
+| Minimum Camunda version | Template version | Connector           | File |
 | --- | --- | --- | --- |
 | 8.8 | 2 | Ad-hoc tools schema | [`agenticai-adhoctoolsschema-outbound-connector.json`](./agenticai-adhoctoolsschema-outbound-connector.json) |

--- a/connectors/agentic-ai/element-templates/README.md
+++ b/connectors/agentic-ai/element-templates/README.md
@@ -1,0 +1,66 @@
+# Agentic AI element templates
+
+This directory contains the [element templates](https://docs.camunda.io/docs/components/modeler/desktop-modeler/element-templates/about-templates/)
+for the Agentic AI connectors shipped with Camunda.
+
+The latest template of each connector lives directly in this folder. Older revisions
+that are still compatible with previous Camunda minor versions are kept in
+[`versioned/`](./versioned/). Hybrid variants are published in
+[`hybrid/`](./hybrid/) and are intentionally omitted from the tables below.
+
+## Which template do I need?
+
+Pick the highest template version whose *minimum Camunda minor version* is less
+than or equal to the Camunda version you are running. The `engines.camunda`
+field in each JSON file captures the same information (e.g. `^8.9` means
+"requires Camunda 8.9 or later").
+
+For example, if you are on Camunda 8.9, use the AI Agent template version `7`;
+if you are on Camunda 8.10, use version `10`.
+
+## AI Agent
+
+The AI Agent ships in two flavors that share the same versioning scheme:
+
+- **AI Agent Task** — outbound connector (`io.camunda.connectors.agenticai.aiagent.v1`)
+- **AI Agent Sub-process** — job worker (`io.camunda.connectors.agenticai.aiagent.jobworker.v1`)
+
+| Minimum Camunda minor | Template version | AI Agent Task | AI Agent Sub-process |
+| --- | --- | --- | --- |
+| 8.10 | 10 | [`agenticai-aiagent-outbound-connector.json`](./agenticai-aiagent-outbound-connector.json) | [`agenticai-aiagent-job-worker.json`](./agenticai-aiagent-job-worker.json) |
+| 8.9  | 7  | [`versioned/agenticai-aiagent-outbound-connector-7.json`](./versioned/agenticai-aiagent-outbound-connector-7.json) | [`versioned/agenticai-aiagent-job-worker-7.json`](./versioned/agenticai-aiagent-job-worker-7.json) |
+| 8.8  | 5  | [`versioned/agenticai-aiagent-outbound-connector-5.json`](./versioned/agenticai-aiagent-outbound-connector-5.json) | [`versioned/agenticai-aiagent-job-worker-5.json`](./versioned/agenticai-aiagent-job-worker-5.json) |
+
+## MCP clients
+
+Clients for the [Model Context Protocol](https://modelcontextprotocol.io/):
+
+- **MCP Client** — local MCP client (`io.camunda.connectors.agenticai.mcp.client.v0`)
+- **MCP Remote Client** — remote MCP client (`io.camunda.connectors.agenticai.mcp.remoteclient.v0`)
+
+| Minimum Camunda minor | Template version | MCP Client | MCP Remote Client |
+| --- | --- | --- | --- |
+| 8.9 | 2 | [`agenticai-mcp-client-outbound-connector.json`](./agenticai-mcp-client-outbound-connector.json) | [`agenticai-mcp-remote-client-outbound-connector.json`](./agenticai-mcp-remote-client-outbound-connector.json) |
+| 8.8 | 0 | [`versioned/agenticai-mcp-client-outbound-connector-0.json`](./versioned/agenticai-mcp-client-outbound-connector-0.json) | [`versioned/agenticai-mcp-remote-client-outbound-connector-0.json`](./versioned/agenticai-mcp-remote-client-outbound-connector-0.json) |
+
+## A2A connectors
+
+Connectors implementing the [Agent2Agent protocol](https://a2a-protocol.org/).
+All A2A templates are currently at version `0` and require Camunda 8.9 or later.
+
+| Minimum Camunda minor | Template version | Connector | File |
+| --- | --- | --- | --- |
+| 8.9 | 0 | A2A Client (outbound)                             | [`agenticai-a2a-client-outbound-connector.json`](./agenticai-a2a-client-outbound-connector.json) |
+| 8.9 | 0 | A2A Client Polling — Intermediate Catch Event     | [`agenticai-a2a-client-polling-inbound-connector-intermediate.json`](./agenticai-a2a-client-polling-inbound-connector-intermediate.json) |
+| 8.9 | 0 | A2A Client Polling — Receive Task                 | [`agenticai-a2a-client-polling-inbound-connector-receive.json`](./agenticai-a2a-client-polling-inbound-connector-receive.json) |
+| 8.9 | 0 | A2A Client Webhook — Intermediate Catch Event     | [`agenticai-a2a-client-webhook-inbound-connector-intermediate.json`](./agenticai-a2a-client-webhook-inbound-connector-intermediate.json) |
+| 8.9 | 0 | A2A Client Webhook — Receive Task                 | [`agenticai-a2a-client-webhook-inbound-connector-receive.json`](./agenticai-a2a-client-webhook-inbound-connector-receive.json) |
+
+## Ad-hoc tools schema
+
+Resolves the tools available in an ad-hoc sub-process
+(`io.camunda.connectors.agenticai.adhoctoolsschema.v1`).
+
+| Minimum Camunda minor | Template version | File |
+| --- | --- | --- |
+| 8.8 | 2 | [`agenticai-adhoctoolsschema-outbound-connector.json`](./agenticai-adhoctoolsschema-outbound-connector.json) |

--- a/connectors/agentic-ai/element-templates/README.md
+++ b/connectors/agentic-ai/element-templates/README.md
@@ -19,6 +19,7 @@ if you are on Camunda 8.10, use version `10`.
 
 ## AI Agent connectors
 
+See the [AI Agent connector documentation](https://docs.camunda.io/docs/next/components/connectors/out-of-the-box-connectors/agentic-ai-aiagent/).
 The AI Agent ships in two flavors that share the same versioning scheme.
 
 ### AI Agent Task
@@ -40,6 +41,7 @@ The AI Agent ships in two flavors that share the same versioning scheme.
 ## MCP Client connectors
 
 Clients for the [Model Context Protocol](https://modelcontextprotocol.io/).
+See the [MCP Client connector documentation](https://docs.camunda.io/docs/next/components/connectors/out-of-the-box-connectors/agentic-ai-mcp-client/).
 
 | Connector         | Minimum Camunda version | Template version | File |
 | --- | --- | --- | --- |
@@ -51,6 +53,7 @@ Clients for the [Model Context Protocol](https://modelcontextprotocol.io/).
 ## A2A connectors
 
 Connectors implementing the [Agent2Agent protocol](https://a2a-protocol.org/).
+See the [A2A Client connector documentation](https://docs.camunda.io/docs/next/components/early-access/alpha/a2a-client/).
 
 | Connector                                     | Minimum Camunda version | Template version | File |
 | --- | --- | --- | --- |
@@ -63,6 +66,7 @@ Connectors implementing the [Agent2Agent protocol](https://a2a-protocol.org/).
 ## Ad-hoc tools schema connector
 
 Resolves the tools available in an ad-hoc sub-process.
+See the [Ad-hoc tools schema resolver documentation](https://docs.camunda.io/docs/next/components/connectors/out-of-the-box-connectors/agentic-ai-ad-hoc-tools-schema-resolver/).
 
 | Connector           | Minimum Camunda version | Template version | File |
 | --- | --- | --- | --- |

--- a/connectors/agentic-ai/element-templates/README.md
+++ b/connectors/agentic-ai/element-templates/README.md
@@ -64,7 +64,7 @@ Connectors implementing the [Agent2Agent protocol](https://a2a-protocol.org/).
 | A2A Client Webhook — Intermediate Catch Event | 8.9 | 0 | [`agenticai-a2a-client-webhook-inbound-connector-intermediate.json`](./agenticai-a2a-client-webhook-inbound-connector-intermediate.json) |
 | A2A Client Webhook — Receive Task             | 8.9 | 0 | [`agenticai-a2a-client-webhook-inbound-connector-receive.json`](./agenticai-a2a-client-webhook-inbound-connector-receive.json) |
 
-## Ad-hoc tools schema connectors
+## Ad-hoc tools schema connector
 
 Resolves the tools available in an ad-hoc sub-process.
 


### PR DESCRIPTION
## Description

This PR adds a comprehensive README documentation for the Agentic AI element templates directory. The README provides:

- An overview of the element templates for Agentic AI connectors
- Guidance on selecting the correct template version based on Camunda version
- Reference tables for all available templates organized by category:
  - AI Agent (Task and Sub-process variants)
  - MCP clients (local and remote)
  - A2A connectors (outbound and inbound variants)
  - Ad-hoc tools schema
- Links to template files in both the main directory and versioned subdirectories

This documentation helps users understand the template versioning scheme and quickly locate the appropriate template for their Camunda deployment.

More context: https://camunda.slack.com/archives/C08BHU6JQJG/p1776681506097209

## Related issues

<!-- Which issues are closed by this PR or are related -->

## Checklist

- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest
  release, as this branch will be rebased onto main before the next release. Example backport labels:
    - `backport stable/8.8`: for changes that should be included in the next 8.8.x release.
    - **or** `backport release-8.8.7`: for changes that should be included in the specific release 8.8.7, and this
      *release has already been created*. The release branch will be merged back into stable/8.8 later, so the change
      will be included in future 8.8.x releases as well.
- [ ] Tests/Integration tests for the changes have been added if applicable. (N/A - documentation only)
- [ ] If the change requires a documentation update, it has been added to the appropriate section in the documentation.

https://claude.ai/code/session_01GtbncksQEbu7FyoKuLxmNn