### PR TITLE
feat: add liveness probe and exit on OOM

### DIFF
--- a/bundle/camunda-saas-bundle/Dockerfile
+++ b/bundle/camunda-saas-bundle/Dockerfile
@@ -25,4 +25,4 @@ HEALTHCHECK --interval=30s --timeout=5s --retries=5 --start-period=30s \
       -Dloader.main=io.camunda.connector.runtime.healthcheck.HealthCheckCommand \
       org.springframework.boot.loader.launch.PropertiesLauncher
 
-ENTRYPOINT ["java", "--add-opens=java.base/java.util.concurrent=ALL-UNNAMED", "-cp", "/opt/app/*", "org.springframework.boot.loader.launch.PropertiesLauncher"]
+ENTRYPOINT ["java", "--add-opens=java.base/java.util.concurrent=ALL-UNNAMED", "-XX:+ExitOnOutOfMemoryError", "-XX:+HeapDumpOnOutOfMemoryError", "-XX:HeapDumpPath=/tmp", "-cp", "/opt/app/*", "org.springframework.boot.loader.launch.PropertiesLauncher"]

--- a/bundle/default-bundle/src/main/resources/application.properties
+++ b/bundle/default-bundle/src/main/resources/application.properties
@@ -5,6 +5,7 @@ logging.pattern.level=%5p %mdc
 management.server.base-path=/actuator
 management.endpoints.web.exposure.include=metrics,health,prometheus,loggers
 management.endpoint.health.group.readiness.include[]=zeebeClient,processDefinitionImport
+management.endpoint.health.group.liveness.include[]=zeebeClient
 management.endpoint.health.show-components=always
 management.endpoint.health.show-details=always
 

--- a/bundle/default-bundle/start.sh
+++ b/bundle/default-bundle/start.sh
@@ -21,7 +21,7 @@ JAVA_OPTS="${JAVA_OPTS} -Dloader.path=/opt/custom/"
 # Exit immediately and dump heap on OOM to ease diagnostics
 JAVA_OPTS="${JAVA_OPTS} -XX:+ExitOnOutOfMemoryError -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp"
 
-if [[ -n ${DEBUG_JVM_PRINT_JAVA_OPTS} ]]; then
+if [[ -n "${DEBUG_JVM_PRINT_JAVA_OPTS}" ]]; then
   echo "Applied JVM options: $JAVA_OPTS"
 fi
 

--- a/bundle/default-bundle/start.sh
+++ b/bundle/default-bundle/start.sh
@@ -18,6 +18,9 @@ JAVA_OPTS="${JAVA_OPTS} --add-opens=java.base/java.util.concurrent=ALL-UNNAMED"
 # Configure loader.path for custom libraries
 JAVA_OPTS="${JAVA_OPTS} -Dloader.path=/opt/custom/"
 
+# Exit immediately and dump heap on OOM to ease diagnostics
+JAVA_OPTS="${JAVA_OPTS} -XX:+ExitOnOutOfMemoryError -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp"
+
 if [[ -n ${DEBUG_JVM_PRINT_JAVA_OPTS} ]]; then
   echo "Applied JVM options: $JAVA_OPTS"
 fi

--- a/connector-runtime/connector-runtime-application/src/main/resources/application.properties
+++ b/connector-runtime/connector-runtime-application/src/main/resources/application.properties
@@ -5,6 +5,7 @@ logging.pattern.level=%5p %mdc
 management.server.base-path=/actuator
 management.endpoints.web.exposure.include=metrics,health,prometheus,loggers
 management.endpoint.health.group.readiness.include[]=zeebeClient
+management.endpoint.health.group.liveness.include[]=zeebeClient
 management.endpoint.health.show-components=always
 management.endpoint.health.show-details=always
 

--- a/connector-runtime/connector-runtime-application/start.sh
+++ b/connector-runtime/connector-runtime-application/start.sh
@@ -21,7 +21,7 @@ JAVA_OPTS="${JAVA_OPTS} -Dloader.path=/opt/custom/"
 # Exit immediately and dump heap on OOM to ease diagnostics
 JAVA_OPTS="${JAVA_OPTS} -XX:+ExitOnOutOfMemoryError -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp"
 
-if [[ -n ${DEBUG_JVM_PRINT_JAVA_OPTS} ]]; then
+if [[ -n "${DEBUG_JVM_PRINT_JAVA_OPTS}" ]]; then
   echo "Applied JVM options: $JAVA_OPTS"
 fi
 

--- a/connector-runtime/connector-runtime-application/start.sh
+++ b/connector-runtime/connector-runtime-application/start.sh
@@ -18,6 +18,9 @@ JAVA_OPTS="${JAVA_OPTS} --add-opens=java.base/java.util.concurrent=ALL-UNNAMED"
 # Configure loader.path for custom libraries
 JAVA_OPTS="${JAVA_OPTS} -Dloader.path=/opt/custom/"
 
+# Exit immediately and dump heap on OOM to ease diagnostics
+JAVA_OPTS="${JAVA_OPTS} -XX:+ExitOnOutOfMemoryError -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp"
+
 if [[ -n ${DEBUG_JVM_PRINT_JAVA_OPTS} ]]; then
   echo "Applied JVM options: $JAVA_OPTS"
 fi


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
This pull request introduces enhancements to application health monitoring and JVM diagnostics for both the default bundle and connector runtime applications. The main changes are the addition of liveness health checks for the `zeebeClient` component and improved JVM options to aid in diagnosing out-of-memory errors.

**Health monitoring improvements:**

* Added `zeebeClient` to the liveness health group in `application.properties` for both the default bundle and connector runtime, allowing for more granular health checks. [[1]](diffhunk://#diff-2952fdd0f4289377a92f491f1cfbe2e23d82574dd2839120c2f71af8de71619cR8) [[2]](diffhunk://#diff-b430eb161ba12caea509eaa43ce07fdb3480958c359160c0028518f5c0c1dc51R8)

**JVM diagnostics and configuration:**

* Updated `start.sh` scripts to include JVM options that trigger an immediate exit and generate a heap dump on out-of-memory errors, making it easier to diagnose memory issues.
* (Note: There are unresolved merge conflict markers in the `start.sh` scripts that should be addressed before merging.)

## Checklist

- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest
  release, as this branch will be rebased onto main before the next release. Example backport labels:
    - `backport stable/8.8`: for changes that should be included in the next 8.8.x release.
    - **or** `backport release-8.8.7`: for changes that should be included in the specific release 8.8.7, and this
      *release has already been created*. The release branch will be merged back into stable/8.8 later, so the change
      will be included in future 8.8.x releases as well.
- [ ] Tests/Integration tests for the changes have been added if applicable.
- [ ] If the change requires a documentation update, it has been added to the appropriate section in the documentation.


