### PR TITLE
fix(agentic-ai): Normalize AI agent document content type by lowercasing and trimming

### DIFF
--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/document/DocumentToContentConverterImpl.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/document/DocumentToContentConverterImpl.java
@@ -16,6 +16,7 @@ import io.camunda.connector.api.document.Document;
 import io.camunda.connector.api.document.DocumentMetadata;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hc.core5.http.ContentType;
@@ -73,6 +74,7 @@ public class DocumentToContentConverterImpl implements DocumentToContentConverte
     return Optional.ofNullable(camundaDocument.metadata())
         .map(DocumentMetadata::getContentType)
         .filter(StringUtils::isNotBlank)
+        .map(s -> s.toLowerCase(Locale.ROOT))
         .map(ContentType::parse)
         .orElseThrow(
             () ->

--- a/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/document/DocumentToContentConverterTest.java
+++ b/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/document/DocumentToContentConverterTest.java
@@ -122,8 +122,8 @@ class DocumentToContentConverterTest {
   }
 
   @ParameterizedTest
-  @ValueSource(strings = {"image/png", "Image/Png", "IMAGE/PNG", "ImAgE/PnG"})
-  void shouldConvertContentTypeToLowercase(String contentType) {
+  @ValueSource(strings = {"image/png", "Image/Png  ", "IMAGE/PNG", "ImAgE/PnG"})
+  void shouldConvertContentTypeToLowercaseAndTrim(String contentType) {
     when(document.metadata().getContentType()).thenReturn(contentType);
     when(document.asBase64()).thenReturn(DUMMY_B64_VALUE);
 
@@ -134,7 +134,7 @@ class DocumentToContentConverterTest {
         .satisfies(
             imageContent -> {
               assertThat(imageContent.image().mimeType())
-                  .isEqualTo(contentType.toLowerCase(Locale.ROOT));
+                  .isEqualTo(contentType.toLowerCase(Locale.ROOT).trim());
             });
   }
 

--- a/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/document/DocumentToContentConverterTest.java
+++ b/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/document/DocumentToContentConverterTest.java
@@ -16,6 +16,7 @@ import dev.langchain4j.data.message.ImageContent;
 import dev.langchain4j.data.message.PdfFileContent;
 import dev.langchain4j.data.message.TextContent;
 import io.camunda.connector.api.document.Document;
+import java.util.Locale;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -118,6 +119,23 @@ class DocumentToContentConverterTest {
 
     verify(document, never()).asByteArray();
     verify(document, never()).asInputStream();
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"image/png", "Image/Png", "IMAGE/PNG", "ImAgE/PnG"})
+  void shouldConvertContentTypeToLowercase(String contentType) {
+    when(document.metadata().getContentType()).thenReturn(contentType);
+    when(document.asBase64()).thenReturn(DUMMY_B64_VALUE);
+
+    var content = converter.convert(document);
+
+    assertThat(content)
+        .asInstanceOf(InstanceOfAssertFactories.type(ImageContent.class))
+        .satisfies(
+            imageContent -> {
+              assertThat(imageContent.image().mimeType())
+                  .isEqualTo(contentType.toLowerCase(Locale.ROOT));
+            });
   }
 
   @Test

--- a/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/document/DocumentToContentConverterTest.java
+++ b/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/document/DocumentToContentConverterTest.java
@@ -16,7 +16,6 @@ import dev.langchain4j.data.message.ImageContent;
 import dev.langchain4j.data.message.PdfFileContent;
 import dev.langchain4j.data.message.TextContent;
 import io.camunda.connector.api.document.Document;
-import java.util.Locale;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -133,8 +132,7 @@ class DocumentToContentConverterTest {
         .asInstanceOf(InstanceOfAssertFactories.type(ImageContent.class))
         .satisfies(
             imageContent -> {
-              assertThat(imageContent.image().mimeType())
-                  .isEqualTo(contentType.toLowerCase(Locale.ROOT).trim());
+              assertThat(imageContent.image().mimeType()).isEqualTo("image/png");
             });
   }
 


### PR DESCRIPTION
## Description

Some providers, like OpenAI do not allow content types for e.g. images to be uppercased, i.e. `IMAGE/PNG`.
Thus, the content type is normalized for AI agent document inputs by lowercasing and trimming them.


## Related issues

closes #7009

## Checklist

- [x] Backport labels are added if these code changes should be backported. No backport label is added to the latest
  release, as this branch will be rebased onto main before the next release. Example backport labels:
    - `backport stable/8.8`: for changes that should be included in the next 8.8.x release.
    - **or** `backport release-8.8.7`: for changes that should be included in the specific release 8.8.7, and this
      *release has already been created*. The release branch will be merged back into stable/8.8 later, so the change
      will be included in future 8.8.x releases as well.
- [x] Tests/Integration tests for the changes have been added if applicable.
- [ ] If the change requires a documentation update, it has been added to the appropriate section in the documentation.


