### PR TITLE
chore: Add agentic-ai team as codeowners for aws-bedrock-agentcore-long-term-memory module

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -9,6 +9,7 @@
 /connectors/aws/aws-bedrock-codeinterpreter @camunda/connectors-agentic-ai @camunda/connectors
 /connectors/aws/aws-bedrock-knowledgebase @camunda/connectors-agentic-ai @camunda/connectors
 /connectors/aws/aws-bedrock-agentcore-runtime @camunda/connectors-agentic-ai @camunda/connectors
+/connectors/aws/aws-bedrock-agentcore-long-term-memory @camunda/connectors-agentic-ai @camunda/connectors
 
 # These files are excluded so that Renovate can automatically merge dependency upgrades
 renovate.json


### PR DESCRIPTION
## Description

Added ownership for aws-bedrock-agentcore-long-term-memory to @camunda/connectors-agentic-ai team
