### PR TITLE
fix: add missing commas in ignore-templates.json

### DIFF
--- a/ignore-templates.json
+++ b/ignore-templates.json
@@ -4,7 +4,7 @@
   "io.camunda.connector.IdpStructuredExtractionOutBoundTemplate.v1",
   "io.camunda.connector.IdpUnstructuredExtractionOutBoundTemplate.v1",
   "io.camunda.connectors.aws.bedrock.agentcore.memory.v1",
-  "io.camunda.connectors.aws.bedrock.codeinterpreter.v1"
-  "io.camunda.connectors.aws.bedrock.agentcore.runtime.v1"
+  "io.camunda.connectors.aws.bedrock.codeinterpreter.v1",
+  "io.camunda.connectors.aws.bedrock.agentcore.runtime.v1",
   "io.camunda.connectors.aws.bedrock.knowledgebase.v1"
 ]


### PR DESCRIPTION
## Description

fix invalid json in `ignore-templates.json`

## Related issues

None

closes #

## Checklist

- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest
  release, as this branch will be rebased onto main before the next release. Example backport labels:
    - `backport stable/8.8`: for changes that should be included in the next 8.8.x release.
    - **or** `backport release-8.8.7`: for changes that should be included in the specific release 8.8.7, and this
      *release has already been created*. The release branch will be merged back into stable/8.8 later, so the change
      will be included in future 8.8.x releases as well.
- [ ] Tests/Integration tests for the changes have been added if applicable.
- [ ] If the change requires a documentation update, it has been added to the appropriate section in the documentation.


