### PR TITLE
build: bump spotless-maven-plugin to 3.4.0

### DIFF
--- a/connectors-e2e-test/connectors-e2e-test-message/src/test/java/io/camunda/connector/e2e/MessageTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-message/src/test/java/io/camunda/connector/e2e/MessageTests.java
@@ -131,7 +131,7 @@ public class MessageTests {
 
   @Test
   @Disabled(
-      """
+"""
 Unauthorized access to correlate message REST API:
 Details from surefire report:
 2025-03-03T08:45:02.658+01:00 DEBUG 99400 --- [pool-7-thread-1] i.c.c.r.c.outbound.ConnectorJobHandler   : Exception while processing job: 2251799813685359 for tenant: <default>

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/agent/BaseAgentRequestHandler.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/agent/BaseAgentRequestHandler.java
@@ -82,8 +82,8 @@ public abstract class BaseAgentRequestHandler<C extends AgentExecutionContext, R
       }
 
       case AgentContextInitializationResult(
-          AgentContext agentContext,
-          List<ToolCallResult> toolCallResults) -> {
+              AgentContext agentContext,
+              List<ToolCallResult> toolCallResults) -> {
         LOGGER.debug(
             "Handling agent request with {} tool call results",
             toolCallResults != null ? toolCallResults.size() : 0);

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/PromptConfiguration.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/PromptConfiguration.java
@@ -30,7 +30,7 @@ public interface PromptConfiguration {
 
     @TemplateProperty(ignore = true)
     public static final String DEFAULT_SYSTEM_PROMPT =
-        """
+"""
 "You are **TaskAgent**, a helpful, generic chat agent that can handle a wide variety of customer requests using your own domain knowledge **and** any tools explicitly provided to you at runtime.
 
 If tools are provided, you should prefer them instead of guessing an answer. You can call the same tool multiple times by providing different input values. Don't guess any tools which were not explicitly configured. If no tool matches the request, try to generate an answer. If you're not able to find a good answer, return with a message stating why you're not able to.

--- a/connectors/email/src/main/java/io/camunda/connector/email/client/jakarta/utils/JakartaUtils.java
+++ b/connectors/email/src/main/java/io/camunda/connector/email/client/jakarta/utils/JakartaUtils.java
@@ -286,8 +286,8 @@ public class JakartaUtils {
       throws MessagingException, IOException {
     BodyPart bodyPart = multipart.getBodyPart(i);
     switch (bodyPart.getContent()) {
-      case InputStream attachment when Part.ATTACHMENT.equalsIgnoreCase(
-              bodyPart.getDisposition()) ->
+      case InputStream attachment
+          when Part.ATTACHMENT.equalsIgnoreCase(bodyPart.getDisposition()) ->
           emailBodyBuilder.addAttachment(
               new EmailAttachment(
                   attachment,

--- a/connectors/embeddings-vector-database/src/test/java/io/camunda/connector/fixture/EmbeddingsVectorDBRequestFixture.java
+++ b/connectors/embeddings-vector-database/src/test/java/io/camunda/connector/fixture/EmbeddingsVectorDBRequestFixture.java
@@ -15,7 +15,7 @@ import java.util.List;
 public class EmbeddingsVectorDBRequestFixture {
 
   private static final String CONVERSATION =
-      """
+"""
 [{"user":"operator123","message":"Hey how are you?"},{"user":"customer9000","message":"Yes I am fine, just busy with RAG connector"}]
 """;
 

--- a/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/caller/VertexCaller.java
+++ b/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/caller/VertexCaller.java
@@ -125,11 +125,11 @@ public class VertexCaller {
                 ImageContent.DetailLevel.AUTO);
 
         case "text/plain",
-                "text/html",
-                "text/markdown",
-                "application/json",
-                "application/xml",
-                "text/csv" ->
+            "text/html",
+            "text/markdown",
+            "application/json",
+            "application/xml",
+            "text/csv" ->
             new TextContent("Document content:\n" + new String(document.asByteArray()));
 
         default -> {

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -163,7 +163,7 @@ limitations under the License.</license.inlineheader>
     <plugin.version.maven-resources-plugin>3.5.0</plugin.version.maven-resources-plugin>
     <plugin.version.maven-shade-plugin>3.6.2</plugin.version.maven-shade-plugin>
     <plugin.version.maven-surefire-plugin>3.5.5</plugin.version.maven-surefire-plugin>
-    <plugin.version.spotless-maven-plugin>2.46.1</plugin.version.spotless-maven-plugin>
+    <plugin.version.spotless-maven-plugin>3.4.0</plugin.version.spotless-maven-plugin>
     <plugin.version.maven-jar-plugin>3.5.0</plugin.version.maven-jar-plugin>
   </properties>
 


### PR DESCRIPTION
## Summary
- Bump `spotless-maven-plugin` from **2.46.1** → **3.4.0** on `stable/8.8` to align with `main` and `stable/8.9`.
- Having different Spotless versions across branches caused code to be formatted inconsistently, leading to build issues when switching branches.
- Includes the reformatted files produced by `mvn spotless:apply` under 3.4.0 (mostly Java text-block indentation).

## Test plan
- [ ] CI: `mvn spotless:check` passes (verified locally)
- [ ] CI: full build green

🤖 Generated with [Claude Code](https://claude.com/claude-code)