### PR TITLE
build: bump spotless-maven-plugin to 3.4.0

### DIFF
--- a/connectors-e2e-test/connectors-e2e-test-message/src/test/java/io/camunda/connector/e2e/MessageTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-message/src/test/java/io/camunda/connector/e2e/MessageTests.java
@@ -131,7 +131,7 @@ public class MessageTests {
 
   @Test
   @Disabled(
-      """
+"""
 Unauthorized access to correlate message REST API:
 Details from surefire report:
 2025-03-03T08:45:02.658+01:00 DEBUG 99400 --- [pool-7-thread-1] i.c.c.r.c.outbound.ConnectorJobHandler   : Exception while processing job: 2251799813685359 for tenant: <default>

--- a/connectors/email/src/main/java/io/camunda/connector/email/client/jakarta/utils/JakartaUtils.java
+++ b/connectors/email/src/main/java/io/camunda/connector/email/client/jakarta/utils/JakartaUtils.java
@@ -284,8 +284,8 @@ public class JakartaUtils {
       throws MessagingException, IOException {
     BodyPart bodyPart = multipart.getBodyPart(i);
     switch (bodyPart.getContent()) {
-      case InputStream attachment when Part.ATTACHMENT.equalsIgnoreCase(
-              bodyPart.getDisposition()) ->
+      case InputStream attachment
+          when Part.ATTACHMENT.equalsIgnoreCase(bodyPart.getDisposition()) ->
           emailBodyBuilder.addAttachment(
               new EmailAttachment(
                   attachment,

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -155,7 +155,7 @@ limitations under the License.</license.inlineheader>
     <plugin.version.maven-resources-plugin>3.2.0</plugin.version.maven-resources-plugin>
     <plugin.version.maven-shade-plugin>3.6.2</plugin.version.maven-shade-plugin>
     <plugin.version.maven-surefire-plugin>3.5.5</plugin.version.maven-surefire-plugin>
-    <plugin.version.spotless-maven-plugin>2.46.1</plugin.version.spotless-maven-plugin>
+    <plugin.version.spotless-maven-plugin>3.4.0</plugin.version.spotless-maven-plugin>
     <plugin.version.maven-jar-plugin>3.5.0</plugin.version.maven-jar-plugin>
   </properties>
 


### PR DESCRIPTION
## Summary
- Bump `spotless-maven-plugin` from **2.46.1** → **3.4.0** on `stable/8.7` to align with `main` and `stable/8.9`.
- Having different Spotless versions across branches caused code to be formatted inconsistently, leading to build issues when switching branches.
- Includes the reformatted files produced by `mvn spotless:apply` under 3.4.0 (Java text-block indentation).

## Test plan
- [ ] CI: `mvn spotless:check` passes (verified locally)
- [ ] CI: full build green

🤖 Generated with [Claude Code](https://claude.com/claude-code)