### PR TITLE
ci: fix e2e tests

### DIFF
--- a/connectors-e2e-test/connectors-e2e-test-csv/src/test/java/io/camunda/connector/e2e/csv/CsvConnectorTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-csv/src/test/java/io/camunda/connector/e2e/csv/CsvConnectorTests.java
@@ -34,8 +34,6 @@ import org.junit.jupiter.api.io.TempDir;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.annotation.DirtiesContext.ClassMode;
 
 @SpringBootTest(
     classes = {TestConnectorRuntimeApplication.class},
@@ -48,7 +46,6 @@ import org.springframework.test.annotation.DirtiesContext.ClassMode;
 @CamundaSpringProcessTest
 @SlowTest
 @ExtendWith(MockitoExtension.class)
-@DirtiesContext(classMode = ClassMode.AFTER_EACH_TEST_METHOD)
 public class CsvConnectorTests {
 
   private static final String ELEMENT_TEMPLATE_PATH =


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
This pull request makes a minor change to the `CsvConnectorTests` test class by removing the `@DirtiesContext` annotation. This will prevent the Spring test context from being reset after each test method, which can improve test performance when context isolation is not needed.

* Removed the `@DirtiesContext(classMode = ClassMode.AFTER_EACH_TEST_METHOD)` annotation from the `CsvConnectorTests` class to avoid resetting the Spring context after each test. [[1]](diffhunk://#diff-036c1805d4dacab7fbbcc275b3918080366388f51d551ad7483bd24cd21ada16L37-L38) [[2]](diffhunk://#diff-036c1805d4dacab7fbbcc275b3918080366388f51d551ad7483bd24cd21ada16L51)