### PR TITLE
fix: use Minimus base image for SaaS bundle Dockerfile

### DIFF
--- a/bundle/camunda-saas-bundle/Dockerfile
+++ b/bundle/camunda-saas-bundle/Dockerfile
@@ -1,19 +1,23 @@
-FROM eclipse-temurin:21.0.10_7-jre
+FROM reg.mini.dev/1212/openjre-base:v25.0.3-dev
+
+# If you don't have access to Minimus hardened base images, you can use public
+# base images like this instead on your own risk:
+# FROM eclipse-temurin:21.0.10_7-jre
 
 VOLUME /tmp
+
+WORKDIR /
+
+# Switch to root to allow setting up our own user and dirs
+USER root
 
 RUN mkdir /opt/app
 
 # Download connectors from maven central
 COPY target/*-with-dependencies.jar /opt/app/
 
-RUN apt-get update && \
-    apt-get upgrade -y && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
-
 # Create an unprivileged user / group and switch to that user
-RUN groupadd --gid 1001 camunda && useradd --no-create-home --gid 1001 --uid 1001 camunda
+RUN addgroup --gid 1001 camunda && adduser -S -G camunda -u 1001 --no-create-home camunda
 USER 1001:1001
 
 ENV CAMUNDA_CONNECTOR_RUNTIME_SAAS=true


### PR DESCRIPTION
## Summary

- The SaaS bundle `Dockerfile` was the only one still using `eclipse-temurin:21.0.10_7-jre` on `stable/8.8`, while the default bundle and connector-runtime-application already used the hardened Minimus base image
- Switches to `reg.mini.dev/1212/openjre-base:v25.0.3-dev` (same Java version, same as the other Dockerfiles on this branch)
- Removes the `apt-get` layer (not available in the minimal image)
- Aligns user creation to Alpine-style `addgroup`/`adduser`

The same fix for `stable/8.7` is in a separate PR.