### PR TITLE
fix: bump spring-boot to 3.5.14 to address CVE-2026-40973

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -87,7 +87,7 @@ limitations under the License.</license.inlineheader>
     <version.failsafe>3.3.2</version.failsafe>
     <version.hamcrest>3.0</version.hamcrest>
 
-    <version.spring-boot>3.5.13</version.spring-boot>
+    <version.spring-boot>3.5.14</version.spring-boot>
     <version.spring-cloud-gcp-starter-logging>5.13.11</version.spring-cloud-gcp-starter-logging>
     <version.logback>1.5.32</version.logback>
 


### PR DESCRIPTION
## Summary

Bumps `org.springframework.boot:spring-boot` from `3.5.13` to `3.5.14` to address CVE-2026-40973.

**Severity**: 7.0 (High)
**Advisory**: https://nvd.nist.gov/vuln/detail/CVE-2026-40973

### Vulnerability summary
A local attacker with access to the same system can exploit predictable temporary directory handling in Spring Boot. When persistent session storage is enabled, an attacker may hijack the `ApplicationTemp` directory to intercept session data, impersonate authenticated users, or execute arbitrary code via a gadget chain. The root cause is insufficient ownership verification of the temporary directory combined with predictable naming conventions.

### Impact on Connectors
Only `stable/8.7` was affected (running `3.5.13`). Branches `stable/8.8`, `stable/8.9`, and `main` were already on fixed versions.