### PR TITLE
fix: bump spring-boot to 3.5.14 (stable/8.7)

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -87,7 +87,7 @@ limitations under the License.</license.inlineheader>
     <version.failsafe>3.3.2</version.failsafe>
     <version.hamcrest>3.0</version.hamcrest>
 
-    <version.spring-boot>3.5.13</version.spring-boot>
+    <version.spring-boot>3.5.14</version.spring-boot>
     <version.spring-cloud-gcp-starter-logging>5.13.11</version.spring-cloud-gcp-starter-logging>
     <version.logback>1.5.32</version.logback>
 


### PR DESCRIPTION
## Summary

Bumps `org.springframework.boot:spring-boot-*` from `3.5.13` to `3.5.14`.

Security fix. Details in the internal tracking issue: camunda/team-connectors#1201