### PR TITLE
fix(8.7): preserve documents in FEEL blank object mapper (#6946)

### DIFF
--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/document/BlankObjectMapperDocumentSerializationTest.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/document/BlankObjectMapperDocumentSerializationTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.runtime.core.document;
+
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.connector.document.jackson.DocumentReferenceModel.CamundaDocumentMetadataModel;
+import io.camunda.connector.document.jackson.DocumentReferenceModel.CamundaDocumentReferenceModel;
+import io.camunda.connector.feel.jackson.FeelContextAwareObjectReader;
+import io.camunda.connector.feel.jackson.JacksonModuleFeelFunction;
+import io.camunda.document.CamundaDocument;
+import java.util.Map;
+import java.util.function.Supplier;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Regression test for GitHub issue #6946.
+ *
+ * <p>When a FEEL expression evaluates against a context that contains a {@link CamundaDocument},
+ * the FEEL deserializer ends up calling {@code AbstractFeelDeserializer.BLANK_OBJECT_MAPPER
+ * .valueToTree(contextMap)}. The bug is that on 8.7/8.8 {@code BLANK_OBJECT_MAPPER} is a vanilla
+ * {@code new ObjectMapper()} — {@code FAIL_ON_EMPTY_BEANS=true} and no document serializer
+ * registered — so {@code valueToTree} throws {@link
+ * com.fasterxml.jackson.databind.exc.InvalidDefinitionException} for any {@link CamundaDocument}.
+ *
+ * <p>This test reproduces the user-facing failure path through the public API
+ * ({@link FeelContextAwareObjectReader}) and asserts that no exception is thrown.
+ *
+ * <p>The test is red on stable/8.7 until {@code BLANK_OBJECT_MAPPER} is reconfigured to disable
+ * {@code FAIL_ON_EMPTY_BEANS} and register {@code JacksonModuleDocumentSerializer}.
+ */
+class BlankObjectMapperDocumentSerializationTest {
+
+  private record TargetType(Supplier<String> value) {}
+
+  @Test
+  void feelEvaluationWithDocumentInContextDoesNotThrow() {
+    ObjectMapper mapper = new ObjectMapper().registerModule(new JacksonModuleFeelFunction());
+
+    var metadata = new CamundaDocumentMetadataModel(null, null, null, null, null, null, null);
+    var reference = new CamundaDocumentReferenceModel("store-1", "doc-1", "hash-1", metadata);
+    // Real CamundaDocument, not a Mockito mock — Mockito's proxy exposes internal getters that
+    // make the bean non-empty and accidentally bypass the FAIL_ON_EMPTY_BEANS path we want to
+    // exercise. The store is unused here because no content is read.
+    Map<String, Object> feelContext =
+        Map.of("doc", new CamundaDocument(metadata, reference, null));
+
+    // The FEEL expression itself is trivial — the failure is triggered by serializing the
+    // context map (which contains a CamundaDocument) into a JsonNode for the FEEL engine,
+    // not by evaluating the expression.
+    String json = "{ \"value\": \"= \\\"hello\\\"\" }";
+
+    assertThatNoException()
+        .as(
+            "Issue #6946: FEEL deserialization must not fail when the context contains a "
+                + "CamundaDocument.")
+        .isThrownBy(
+            () ->
+                FeelContextAwareObjectReader.of(mapper)
+                    .withStaticContext(feelContext)
+                    .readValue(json, TargetType.class));
+  }
+}

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/document/BlankObjectMapperDocumentSerializationTest.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/document/BlankObjectMapperDocumentSerializationTest.java
@@ -38,8 +38,8 @@ import org.junit.jupiter.api.Test;
  * registered — so {@code valueToTree} throws {@link
  * com.fasterxml.jackson.databind.exc.InvalidDefinitionException} for any {@link CamundaDocument}.
  *
- * <p>This test reproduces the user-facing failure path through the public API
- * ({@link FeelContextAwareObjectReader}) and asserts that no exception is thrown.
+ * <p>This test reproduces the user-facing failure path through the public API ({@link
+ * FeelContextAwareObjectReader}) and asserts that no exception is thrown.
  *
  * <p>The test is red on stable/8.7 until {@code BLANK_OBJECT_MAPPER} is reconfigured to disable
  * {@code FAIL_ON_EMPTY_BEANS} and register {@code JacksonModuleDocumentSerializer}.
@@ -57,8 +57,7 @@ class BlankObjectMapperDocumentSerializationTest {
     // Real CamundaDocument, not a Mockito mock — Mockito's proxy exposes internal getters that
     // make the bean non-empty and accidentally bypass the FAIL_ON_EMPTY_BEANS path we want to
     // exercise. The store is unused here because no content is read.
-    Map<String, Object> feelContext =
-        Map.of("doc", new CamundaDocument(metadata, reference, null));
+    Map<String, Object> feelContext = Map.of("doc", new CamundaDocument(metadata, reference, null));
 
     // The FEEL expression itself is trivial — the failure is triggered by serializing the
     // context map (which contains a CamundaDocument) into a JsonNode for the FEEL engine,

--- a/connector-sdk/jackson-datatype-feel/pom.xml
+++ b/connector-sdk/jackson-datatype-feel/pom.xml
@@ -17,6 +17,11 @@
       <groupId>io.camunda.connector</groupId>
       <artifactId>connector-feel-wrapper</artifactId>
     </dependency>
+    <dependency>
+      <groupId>io.camunda.connector</groupId>
+      <artifactId>jackson-datatype-document</artifactId>
+      <version>${project.version}</version>
+    </dependency>
 
     <dependency>
       <groupId>org.junit.jupiter</groupId>

--- a/connector-sdk/jackson-datatype-feel/src/main/java/io/camunda/connector/feel/jackson/AbstractFeelDeserializer.java
+++ b/connector-sdk/jackson-datatype-feel/src/main/java/io/camunda/connector/feel/jackson/AbstractFeelDeserializer.java
@@ -20,8 +20,10 @@ import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.deser.ContextualDeserializer;
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import io.camunda.connector.document.jackson.JacksonModuleDocumentSerializer;
 import io.camunda.connector.feel.FeelEngineWrapper;
 import java.io.IOException;
 import java.util.function.Supplier;
@@ -39,8 +41,16 @@ public abstract class AbstractFeelDeserializer<T> extends StdDeserializer<T>
    * aware of any registered modules. It should not be used to deserialize the final result. For
    * final results, use the {@link DeserializationContext} object passed to {@link
    * #doDeserialize(JsonNode, JsonNode, DeserializationContext)} instead.
+   *
+   * <p>{@link SerializationFeature#FAIL_ON_EMPTY_BEANS} is disabled and {@link
+   * JacksonModuleDocumentSerializer} is registered so that FEEL contexts containing a {@code
+   * CamundaDocument} can be serialized into a tree without throwing — and so the document
+   * reference is preserved instead of being silently emptied. See issue #6946.
    */
-  protected static final ObjectMapper BLANK_OBJECT_MAPPER = new ObjectMapper();
+  protected static final ObjectMapper BLANK_OBJECT_MAPPER =
+      new ObjectMapper()
+          .disable(SerializationFeature.FAIL_ON_EMPTY_BEANS)
+          .registerModule(new JacksonModuleDocumentSerializer());
 
   protected AbstractFeelDeserializer(FeelEngineWrapper feelEngineWrapper, boolean relaxed) {
     super(String.class);

--- a/connector-sdk/jackson-datatype-feel/src/main/java/io/camunda/connector/feel/jackson/AbstractFeelDeserializer.java
+++ b/connector-sdk/jackson-datatype-feel/src/main/java/io/camunda/connector/feel/jackson/AbstractFeelDeserializer.java
@@ -44,8 +44,8 @@ public abstract class AbstractFeelDeserializer<T> extends StdDeserializer<T>
    *
    * <p>{@link SerializationFeature#FAIL_ON_EMPTY_BEANS} is disabled and {@link
    * JacksonModuleDocumentSerializer} is registered so that FEEL contexts containing a {@code
-   * CamundaDocument} can be serialized into a tree without throwing — and so the document
-   * reference is preserved instead of being silently emptied. See issue #6946.
+   * CamundaDocument} can be serialized into a tree without throwing — and so the document reference
+   * is preserved instead of being silently emptied. See issue #6946.
    */
   protected static final ObjectMapper BLANK_OBJECT_MAPPER =
       new ObjectMapper()


### PR DESCRIPTION
## Summary

- Fixes #6946 on `stable/8.7`. FEEL expressions evaluating against a context that contains a `CamundaDocument` no longer throw `InvalidDefinitionException`, and the document reference is preserved in the FEEL evaluation context instead of being lost.
- Reconfigures `AbstractFeelDeserializer.BLANK_OBJECT_MAPPER`:
  - disables `SerializationFeature.FAIL_ON_EMPTY_BEANS`
  - registers `JacksonModuleDocumentSerializer`
- Adds a direct dep on `jackson-datatype-document` from `jackson-datatype-feel`. No cycle: `jackson-datatype-document` only depends on `connector-document` and jackson, neither of which transitively reach `jackson-datatype-feel`.

## Commits

1. `test:` adds the regression test that reproduces the user-reported failure path. Red on `stable/8.7` without the fix. Test ported (not cherry-picked) because `CamundaDocument` lives in `io.camunda.document` on this branch (different from 8.8's `io.camunda.connector.runtime.core.document`).
2. `fix:` reconfigures `BLANK_OBJECT_MAPPER` so the test goes green.

## Why this fix specifically

Identical mechanism to the 8.8 fix — see PR for `stable/8.8` for the full rationale. Two minor branch-specific differences:

- The FEEL module lives at `connector-sdk/jackson-datatype-feel/` (not `connector-runtime/...`).
- The 8.7 parent POM does not manage the `jackson-datatype-document` artifact version, so the new dep specifies `<version>\${project.version}</version>` like other internal-module references on this branch (`connector-sdk/core/pom.xml`, `connector-sdk/feel-wrapper/pom.xml`).

## Test plan

- [x] `mvn -pl connector-runtime/connector-runtime-core test -Dtest=BlankObjectMapperDocumentSerializationTest` → red on commit 1, green on commit 2
- [x] `mvn -pl connector-sdk/jackson-datatype-feel test` → 38/38 green
- [ ] CI green

## Related

- main companion PR: regression test only
- 8.8 companion PR: same fix, paths differ

🤖 Generated with [Claude Code](https://claude.com/claude-code)