### PR TITLE
fix(agentic-ai): update Content-Type assertion for mcp-sdk 1.1.2

### DIFF
--- a/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/mcp/client/framework/mcpsdk/McpSdkClientFactoryTest.java
+++ b/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/mcp/client/framework/mcpsdk/McpSdkClientFactoryTest.java
@@ -6,6 +6,7 @@
  */
 package io.camunda.connector.agenticai.mcp.client.framework.mcpsdk;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.containing;
 import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
@@ -126,7 +127,7 @@ class McpSdkClientFactoryTest {
               WireMock.verify(
                   1,
                   postRequestedFor(urlPathEqualTo(endpoint))
-                      .withHeader("Content-Type", equalTo("application/json"))
+                      .withHeader("Content-Type", containing("application/json"))
                       .withHeader("Accept", equalTo("application/json, text/event-stream"))
                       .withHeader("Authorization", equalTo("Bearer test-token"))
                       .withHeader("X-Dummy", equalTo("Test")));


### PR DESCRIPTION
## Summary

- mcp-sdk 1.1.2 (bumped in #7039) now appends `; charset=UTF-8` to the `Content-Type` header on HTTP POST requests, changing it from `application/json` to `application/json; charset=UTF-8`.
- `McpSdkClientFactoryTest.createsStreamableHttpMcpClient` used a strict `equalTo("application/json")` WireMock assertion, causing all three parameterised test cases (`/mcp`, `/mcp/cluster`, `/abc123/mcp/cluster`) to fail in CI on that PR.
- Fix: switch the assertion to `containing("application/json")` so it accepts both forms.

## Changes

[`McpSdkClientFactoryTest.java`](connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/mcp/client/framework/mcpsdk/McpSdkClientFactoryTest.java) — one line changed + import added.

## Testing

```
mvn test -pl connectors/agentic-ai -Dtest=McpSdkClientFactoryTest
# Tests run: 9, Failures: 0, Errors: 0, Skipped: 0 — BUILD SUCCESS
```

This fix should be cherry-picked / merged into #7039 (or that PR rebased on top of this) to unblock the Renovate bump.