### PR TITLE
fix(slack): Does not send plain text with documents

### DIFF
--- a/connectors/slack/src/main/java/io/camunda/connector/slack/outbound/model/ChatPostMessageData.java
+++ b/connectors/slack/src/main/java/io/camunda/connector/slack/outbound/model/ChatPostMessageData.java
@@ -128,6 +128,7 @@ public record ChatPostMessageData(
       if (documents != null && !documents.isEmpty()) {
         requestBuilder.blocks(
             BlockBuilder.create(new FileUploader(methodsClient))
+                .text(text)
                 .documents(documents)
                 .getLayoutBlocks());
       }

--- a/connectors/slack/src/test/java/io/camunda/connector/slack/outbound/model/ChatPostMessageDataTest.java
+++ b/connectors/slack/src/test/java/io/camunda/connector/slack/outbound/model/ChatPostMessageDataTest.java
@@ -167,6 +167,10 @@ class ChatPostMessageDataTest {
       ChatPostMessageRequest value = chatPostMessageRequest.getValue();
       assertThat(value.getChannel()).isEqualTo(USERID);
       assertThat(value.isLinkNames()).isTrue();
+      assertThat(value.getText()).isEqualTo("test");
+      assertThat(value.getBlocks())
+          .anyMatch(block -> block instanceof com.slack.api.model.block.SectionBlock)
+          .anyMatch(block -> block instanceof com.slack.api.model.block.FileBlock);
     }
   }
 


### PR DESCRIPTION
## Description

Plain text was not send when adding documents as attachments. I fixed this. I also checked this change does not reintroduce [this bug](https://github.com/camunda/connectors/issues/5807). As this slack api is a bit unpredictable, please let me know of edge cases i might want to check.

## Related issues

<!-- Which issues are closed by this PR or are related -->

None, just found it

## Checklist

- [x] Backport labels are added if these code changes should be backported. No backport label is added to the latest
  release, as this branch will be rebased onto main before the next release. Example backport labels:
    - `backport stable/8.8`: for changes that should be included in the next 8.8.x release.
    - **or** `backport release-8.8.7`: for changes that should be included in the specific release 8.8.7, and this
      *release has already been created*. The release branch will be merged back into stable/8.8 later, so the change
      will be included in future 8.8.x releases as well.
- [x] Tests/Integration tests for the changes have been added if applicable.
- [ ] If the change requires a documentation update, it has been added to the appropriate section in the documentation.


