### PR TITLE
fix: bump Maven to 3.9.15 — 3.9.14 removed from Apache CDN

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,4 +1,4 @@
 java temurin-25.0.3+9.0.LTS
-maven 3.9.14
+maven 3.9.15
 pre-commit 4.6.0
 nodejs 24.15.0


### PR DESCRIPTION
## Summary
- Maven 3.9.14 was delisted from the Apache CDN (404 on primary mirror, timeouts on archive fallback), breaking the `Install asdf & tools` step in CI
- Bumps `.tool-versions` to `maven 3.9.15` which is the current latest available version

## Test plan
- [ ] Verify CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)