### PR TITLE
test(agentic-ai): wait for active inbound executable to fix flaky A2A e2e tests

### DIFF
--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/TestUtil.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/TestUtil.java
@@ -17,6 +17,8 @@
 package io.camunda.connector.e2e.agenticai;
 
 import io.camunda.connector.e2e.ZeebeTest;
+import io.camunda.connector.e2e.inbound.InboundConnectorTestConfiguration.InboundConnectorTestHelper;
+import io.camunda.connector.runtime.inbound.importer.ImportSchedulers;
 import io.camunda.process.test.api.CamundaAssert;
 import java.net.URI;
 import java.net.http.HttpClient;
@@ -67,5 +69,22 @@ public final class TestUtil {
             () ->
                 CamundaAssert.assertThat(zeebeTest.getProcessInstanceEvent())
                     .hasActiveElement(elementId, 1));
+  }
+
+  /**
+   * Waits for an inbound connector to be fully ready: triggers a process definition import, waits
+   * for the BPMN element to become active in the process, and waits for the inbound executable to
+   * be registered and healthy in the runtime registry. The last step is required because executable
+   * activation events are processed asynchronously, so without it incoming requests (e.g. webhook
+   * POSTs) may hit before the subscription is active.
+   */
+  public static void awaitInboundConnectorReady(
+      ZeebeTest zeebeTest,
+      String elementId,
+      ImportSchedulers importSchedulers,
+      InboundConnectorTestHelper testHelper) {
+    importSchedulers.scheduleLatestVersionImport();
+    waitForElementActivation(zeebeTest, elementId);
+    testHelper.awaitActiveInboundExecutable(elementId);
   }
 }

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/TestUtil.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/TestUtil.java
@@ -72,19 +72,21 @@ public final class TestUtil {
   }
 
   /**
-   * Waits for an inbound connector to be fully ready: triggers a process definition import, waits
-   * for the BPMN element to become active in the process, and waits for the inbound executable to
-   * be registered and healthy in the runtime registry. The last step is required because executable
-   * activation events are processed asynchronously, so without it incoming requests (e.g. webhook
-   * POSTs) may hit before the subscription is active.
+   * Waits for an inbound connector to be fully ready: waits for the BPMN element to become active
+   * in the process, triggers a process definition import, and waits for the inbound executable to
+   * be registered and healthy in the runtime registry. The order ensures that when the executable
+   * activates, the polling fetcher's first iteration already sees the running process instance at
+   * the catch event. The last step is required because executable activation events are processed
+   * asynchronously, so without it incoming requests (e.g. webhook POSTs) may hit before the
+   * subscription is active.
    */
   public static void awaitInboundConnectorReady(
       ZeebeTest zeebeTest,
       String elementId,
       ImportSchedulers importSchedulers,
       InboundConnectorTestHelper testHelper) {
-    importSchedulers.scheduleLatestVersionImport();
     waitForElementActivation(zeebeTest, elementId);
+    importSchedulers.scheduleLatestVersionImport();
     testHelper.awaitActiveInboundExecutable(elementId);
   }
 }

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/a2a/A2aStandaloneTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/a2a/A2aStandaloneTests.java
@@ -24,7 +24,6 @@ import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static com.github.tomakehurst.wiremock.stubbing.Scenario.STARTED;
 import static io.camunda.connector.e2e.agenticai.TestUtil.postWithDelay;
-import static io.camunda.connector.e2e.agenticai.TestUtil.waitForElementActivation;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.github.tomakehurst.wiremock.client.WireMock;
@@ -36,6 +35,7 @@ import io.camunda.connector.agenticai.a2a.client.common.model.result.A2aTask;
 import io.camunda.connector.agenticai.a2a.client.common.model.result.A2aTaskStatus;
 import io.camunda.connector.e2e.ZeebeTest;
 import io.camunda.connector.e2e.agenticai.BaseAgenticAiTest;
+import io.camunda.connector.e2e.agenticai.TestUtil;
 import io.camunda.connector.e2e.inbound.InboundConnectorTestConfiguration;
 import io.camunda.connector.e2e.inbound.InboundConnectorTestConfiguration.InboundConnectorTestHelper;
 import io.camunda.connector.runtime.inbound.importer.ImportSchedulers;
@@ -103,12 +103,7 @@ public class A2aStandaloneTests extends BaseAgenticAiTest {
             Map.of(
                 "responseRetrievalMode", "polling", "a2aServerUrl", wireMock.getHttpBaseUrl()));
 
-    // Trigger the import scheduler manually and wait for the polling executable to be active.
-    // Otherwise the test relies on the default 5s import scheduler tick + 1s event-queue tick,
-    // which combined with the polling intervals occasionally exceeds the 20s process completion
-    // timeout.
-    importSchedulers.scheduleLatestVersionImport();
-    inboundConnectorTestHelper.awaitActiveInboundExecutable(POLLING_ELEMENT_ID);
+    awaitInboundConnectorReady(zeebeTest, POLLING_ELEMENT_ID);
 
     zeebeTest.waitForProcessCompletion();
 
@@ -135,7 +130,7 @@ public class A2aStandaloneTests extends BaseAgenticAiTest {
                 "webhookUrl",
                 webhookUrl));
 
-    waitForWebhookElementActivation(zeebeTest);
+    awaitInboundConnectorReady(zeebeTest, WEBHOOK_ELEMENT_ID);
 
     // Post working state - should NOT activate webhook
     postWithDelay(
@@ -172,7 +167,7 @@ public class A2aStandaloneTests extends BaseAgenticAiTest {
                 "token",
                 token));
 
-    waitForWebhookElementActivation(zeebeTest);
+    awaitInboundConnectorReady(zeebeTest, WEBHOOK_ELEMENT_ID);
 
     // Post working state - should NOT activate webhook
     postWithDelay(
@@ -226,7 +221,7 @@ public class A2aStandaloneTests extends BaseAgenticAiTest {
                 "webhookUrl",
                 webhookUrl));
 
-    waitForWebhookElementActivation(zeebeTest);
+    awaitInboundConnectorReady(zeebeTest, WEBHOOK_ELEMENT_ID);
 
     // Post working state - should NOT activate webhook
     postWithDelay(
@@ -273,7 +268,7 @@ public class A2aStandaloneTests extends BaseAgenticAiTest {
                 "webhookUrl",
                 webhookUrl));
 
-    waitForWebhookElementActivation(zeebeTest);
+    awaitInboundConnectorReady(zeebeTest, WEBHOOK_ELEMENT_ID);
 
     // Post working state - should NOT activate webhook
     postWithDelay(
@@ -307,15 +302,9 @@ public class A2aStandaloneTests extends BaseAgenticAiTest {
     assertVariablesWithWebhook(zeebeTest);
   }
 
-  private void waitForWebhookElementActivation(ZeebeTest zeebeTest) {
-    // manually trigger process definition import to register the webhook
-    importSchedulers.scheduleLatestVersionImport();
-    waitForElementActivation(zeebeTest, WEBHOOK_ELEMENT_ID);
-    // Activation events are processed asynchronously by the inbound executable registry, so we
-    // additionally wait for the webhook subscription to be registered and healthy. Otherwise an
-    // incoming POST may hit before the executable is active (returning 404), which leads to
-    // flaky tests when the test posts arrive on tight delays.
-    inboundConnectorTestHelper.awaitActiveInboundExecutable(WEBHOOK_ELEMENT_ID);
+  private void awaitInboundConnectorReady(ZeebeTest zeebeTest, String elementId) {
+    TestUtil.awaitInboundConnectorReady(
+        zeebeTest, elementId, importSchedulers, inboundConnectorTestHelper);
   }
 
   private BpmnModelInstance getBpmnModelWithNewId(String newProcessId) throws IOException {

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/a2a/A2aStandaloneTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/a2a/A2aStandaloneTests.java
@@ -70,6 +70,7 @@ import org.springframework.test.context.TestPropertySource;
 public class A2aStandaloneTests extends BaseAgenticAiTest {
 
   private static final String WEBHOOK_ELEMENT_ID = "Wait_For_Completion_Webhook";
+  private static final String POLLING_ELEMENT_ID = "Wait_For_Completion_Polling";
 
   @Autowired private InboundConnectorTestHelper inboundConnectorTestHelper;
   @Autowired private ImportSchedulers importSchedulers;
@@ -98,10 +99,18 @@ public class A2aStandaloneTests extends BaseAgenticAiTest {
     BpmnModelInstance bpmnModel = Bpmn.readModelFromStream(testProcess.getInputStream());
     ZeebeTest zeebeTest =
         createProcessInstance(
-                bpmnModel,
-                Map.of(
-                    "responseRetrievalMode", "polling", "a2aServerUrl", wireMock.getHttpBaseUrl()))
-            .waitForProcessCompletion();
+            bpmnModel,
+            Map.of(
+                "responseRetrievalMode", "polling", "a2aServerUrl", wireMock.getHttpBaseUrl()));
+
+    // Trigger the import scheduler manually and wait for the polling executable to be active.
+    // Otherwise the test relies on the default 5s import scheduler tick + 1s event-queue tick,
+    // which combined with the polling intervals occasionally exceeds the 20s process completion
+    // timeout.
+    importSchedulers.scheduleLatestVersionImport();
+    inboundConnectorTestHelper.awaitActiveInboundExecutable(POLLING_ELEMENT_ID);
+
+    zeebeTest.waitForProcessCompletion();
 
     CamundaAssert.assertThat(zeebeTest.getProcessInstanceEvent())
         .hasVariableSatisfies(
@@ -302,6 +311,11 @@ public class A2aStandaloneTests extends BaseAgenticAiTest {
     // manually trigger process definition import to register the webhook
     importSchedulers.scheduleLatestVersionImport();
     waitForElementActivation(zeebeTest, WEBHOOK_ELEMENT_ID);
+    // Activation events are processed asynchronously by the inbound executable registry, so we
+    // additionally wait for the webhook subscription to be registered and healthy. Otherwise an
+    // incoming POST may hit before the executable is active (returning 404), which leads to
+    // flaky tests when the test posts arrive on tight delays.
+    inboundConnectorTestHelper.awaitActiveInboundExecutable(WEBHOOK_ELEMENT_ID);
   }
 
   private BpmnModelInstance getBpmnModelWithNewId(String newProcessId) throws IOException {

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/a2a/A2aStandaloneTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/a2a/A2aStandaloneTests.java
@@ -100,8 +100,7 @@ public class A2aStandaloneTests extends BaseAgenticAiTest {
     ZeebeTest zeebeTest =
         createProcessInstance(
             bpmnModel,
-            Map.of(
-                "responseRetrievalMode", "polling", "a2aServerUrl", wireMock.getHttpBaseUrl()));
+            Map.of("responseRetrievalMode", "polling", "a2aServerUrl", wireMock.getHttpBaseUrl()));
 
     awaitInboundConnectorReady(zeebeTest, POLLING_ELEMENT_ID);
 

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/langchain4j/jobworker/L4JAiAgentJobWorkerA2aIntegrationTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/langchain4j/jobworker/L4JAiAgentJobWorkerA2aIntegrationTests.java
@@ -17,7 +17,6 @@
 package io.camunda.connector.e2e.agenticai.aiagent.langchain4j.jobworker;
 
 import static io.camunda.connector.e2e.agenticai.TestUtil.postWithDelay;
-import static io.camunda.connector.e2e.agenticai.TestUtil.waitForElementActivation;
 import static io.camunda.connector.e2e.agenticai.aiagent.AiAgentTestFixtures.HAIKU_TEXT;
 import static io.camunda.connector.e2e.agenticai.aiagent.langchain4j.Langchain4JAiAgentToolSpecifications.EXPECTED_A2A_TOOL_SPECIFICATIONS;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -34,6 +33,7 @@ import dev.langchain4j.model.output.TokenUsage;
 import io.camunda.connector.agenticai.aiagent.model.AgentMetrics;
 import io.camunda.connector.e2e.ElementTemplate;
 import io.camunda.connector.e2e.ZeebeTest;
+import io.camunda.connector.e2e.agenticai.TestUtil;
 import io.camunda.connector.e2e.agenticai.aiagent.langchain4j.common.L4JAiAgentA2aIntegrationTestSupport;
 import io.camunda.connector.e2e.agenticai.assertj.JobWorkerAgentResponseAssert;
 import io.camunda.connector.e2e.inbound.InboundConnectorTestConfiguration;
@@ -183,13 +183,7 @@ public class L4JAiAgentJobWorkerA2aIntegrationTests extends BaseL4JAiAgentJobWor
                 "userPrompt",
                 testSupport.initialUserPrompt));
 
-    // manually trigger process definition import to register the webhook
-    importSchedulers.scheduleLatestVersionImport();
-    waitForElementActivation(zeebeTest, WEBHOOK_ELEMENT_ID);
-    // Wait for the webhook executable to be registered & healthy before posting. The inbound
-    // executable registry processes activation events asynchronously, so without this wait the
-    // delayed POST could hit before the subscription is active and return 404.
-    inboundConnectorTestHelper.awaitActiveInboundExecutable(WEBHOOK_ELEMENT_ID);
+    awaitInboundConnectorReady(zeebeTest, WEBHOOK_ELEMENT_ID);
     postWithDelay(
         webhookUrl, testFileContent("exchange-rate-agent-webhook-payload.json").get(), 100);
 
@@ -208,5 +202,10 @@ public class L4JAiAgentJobWorkerA2aIntegrationTests extends BaseL4JAiAgentJobWor
                 .hasResponseText(expectedResponseText));
 
     assertThat(userFeedbackJobWorkerCounter.get()).isEqualTo(2);
+  }
+
+  private void awaitInboundConnectorReady(ZeebeTest zeebeTest, String elementId) {
+    TestUtil.awaitInboundConnectorReady(
+        zeebeTest, elementId, importSchedulers, inboundConnectorTestHelper);
   }
 }

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/langchain4j/jobworker/L4JAiAgentJobWorkerA2aIntegrationTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/langchain4j/jobworker/L4JAiAgentJobWorkerA2aIntegrationTests.java
@@ -186,6 +186,10 @@ public class L4JAiAgentJobWorkerA2aIntegrationTests extends BaseL4JAiAgentJobWor
     // manually trigger process definition import to register the webhook
     importSchedulers.scheduleLatestVersionImport();
     waitForElementActivation(zeebeTest, WEBHOOK_ELEMENT_ID);
+    // Wait for the webhook executable to be registered & healthy before posting. The inbound
+    // executable registry processes activation events asynchronously, so without this wait the
+    // delayed POST could hit before the subscription is active and return 404.
+    inboundConnectorTestHelper.awaitActiveInboundExecutable(WEBHOOK_ELEMENT_ID);
     postWithDelay(
         webhookUrl, testFileContent("exchange-rate-agent-webhook-payload.json").get(), 100);
 

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/langchain4j/jobworker/L4JAiAgentJobWorkerA2aIntegrationTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/langchain4j/jobworker/L4JAiAgentJobWorkerA2aIntegrationTests.java
@@ -183,7 +183,8 @@ public class L4JAiAgentJobWorkerA2aIntegrationTests extends BaseL4JAiAgentJobWor
                 "userPrompt",
                 testSupport.initialUserPrompt));
 
-    awaitInboundConnectorReady(zeebeTest, WEBHOOK_ELEMENT_ID);
+    TestUtil.awaitInboundConnectorReady(
+        zeebeTest, WEBHOOK_ELEMENT_ID, importSchedulers, inboundConnectorTestHelper);
     postWithDelay(
         webhookUrl, testFileContent("exchange-rate-agent-webhook-payload.json").get(), 100);
 
@@ -202,10 +203,5 @@ public class L4JAiAgentJobWorkerA2aIntegrationTests extends BaseL4JAiAgentJobWor
                 .hasResponseText(expectedResponseText));
 
     assertThat(userFeedbackJobWorkerCounter.get()).isEqualTo(2);
-  }
-
-  private void awaitInboundConnectorReady(ZeebeTest zeebeTest, String elementId) {
-    TestUtil.awaitInboundConnectorReady(
-        zeebeTest, elementId, importSchedulers, inboundConnectorTestHelper);
   }
 }

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/langchain4j/outboundconnector/L4JAiAgentConnectorA2aIntegrationTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/langchain4j/outboundconnector/L4JAiAgentConnectorA2aIntegrationTests.java
@@ -17,7 +17,6 @@
 package io.camunda.connector.e2e.agenticai.aiagent.langchain4j.outboundconnector;
 
 import static io.camunda.connector.e2e.agenticai.TestUtil.postWithDelay;
-import static io.camunda.connector.e2e.agenticai.TestUtil.waitForElementActivation;
 import static io.camunda.connector.e2e.agenticai.aiagent.AiAgentTestFixtures.HAIKU_TEXT;
 import static io.camunda.connector.e2e.agenticai.aiagent.langchain4j.Langchain4JAiAgentToolSpecifications.EXPECTED_A2A_TOOL_SPECIFICATIONS;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -34,6 +33,7 @@ import dev.langchain4j.model.output.TokenUsage;
 import io.camunda.connector.agenticai.aiagent.model.AgentMetrics;
 import io.camunda.connector.e2e.ElementTemplate;
 import io.camunda.connector.e2e.ZeebeTest;
+import io.camunda.connector.e2e.agenticai.TestUtil;
 import io.camunda.connector.e2e.agenticai.aiagent.langchain4j.common.L4JAiAgentA2aIntegrationTestSupport;
 import io.camunda.connector.e2e.agenticai.assertj.AgentResponseAssert;
 import io.camunda.connector.e2e.inbound.InboundConnectorTestConfiguration;
@@ -183,13 +183,7 @@ public class L4JAiAgentConnectorA2aIntegrationTests extends BaseL4JAiAgentConnec
                 "userPrompt",
                 testSupport.initialUserPrompt));
 
-    // manually trigger process definition import to register the webhook
-    importSchedulers.scheduleLatestVersionImport();
-    waitForElementActivation(zeebeTest, WEBHOOK_ELEMENT_ID);
-    // Wait for the webhook executable to be registered & healthy before posting. The inbound
-    // executable registry processes activation events asynchronously, so without this wait the
-    // delayed POST could hit before the subscription is active and return 404.
-    inboundConnectorTestHelper.awaitActiveInboundExecutable(WEBHOOK_ELEMENT_ID);
+    awaitInboundConnectorReady(zeebeTest, WEBHOOK_ELEMENT_ID);
 
     postWithDelay(
         webhookUrl, testFileContent("exchange-rate-agent-webhook-payload.json").get(), 100);
@@ -209,5 +203,10 @@ public class L4JAiAgentConnectorA2aIntegrationTests extends BaseL4JAiAgentConnec
                 .hasResponseText(expectedResponseText));
 
     assertThat(userFeedbackJobWorkerCounter.get()).isEqualTo(2);
+  }
+
+  private void awaitInboundConnectorReady(ZeebeTest zeebeTest, String elementId) {
+    TestUtil.awaitInboundConnectorReady(
+        zeebeTest, elementId, importSchedulers, inboundConnectorTestHelper);
   }
 }

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/langchain4j/outboundconnector/L4JAiAgentConnectorA2aIntegrationTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/langchain4j/outboundconnector/L4JAiAgentConnectorA2aIntegrationTests.java
@@ -186,6 +186,10 @@ public class L4JAiAgentConnectorA2aIntegrationTests extends BaseL4JAiAgentConnec
     // manually trigger process definition import to register the webhook
     importSchedulers.scheduleLatestVersionImport();
     waitForElementActivation(zeebeTest, WEBHOOK_ELEMENT_ID);
+    // Wait for the webhook executable to be registered & healthy before posting. The inbound
+    // executable registry processes activation events asynchronously, so without this wait the
+    // delayed POST could hit before the subscription is active and return 404.
+    inboundConnectorTestHelper.awaitActiveInboundExecutable(WEBHOOK_ELEMENT_ID);
 
     postWithDelay(
         webhookUrl, testFileContent("exchange-rate-agent-webhook-payload.json").get(), 100);

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/langchain4j/outboundconnector/L4JAiAgentConnectorA2aIntegrationTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/langchain4j/outboundconnector/L4JAiAgentConnectorA2aIntegrationTests.java
@@ -183,7 +183,8 @@ public class L4JAiAgentConnectorA2aIntegrationTests extends BaseL4JAiAgentConnec
                 "userPrompt",
                 testSupport.initialUserPrompt));
 
-    awaitInboundConnectorReady(zeebeTest, WEBHOOK_ELEMENT_ID);
+    TestUtil.awaitInboundConnectorReady(
+        zeebeTest, WEBHOOK_ELEMENT_ID, importSchedulers, inboundConnectorTestHelper);
 
     postWithDelay(
         webhookUrl, testFileContent("exchange-rate-agent-webhook-payload.json").get(), 100);
@@ -203,10 +204,5 @@ public class L4JAiAgentConnectorA2aIntegrationTests extends BaseL4JAiAgentConnec
                 .hasResponseText(expectedResponseText));
 
     assertThat(userFeedbackJobWorkerCounter.get()).isEqualTo(2);
-  }
-
-  private void awaitInboundConnectorReady(ZeebeTest zeebeTest, String elementId) {
-    TestUtil.awaitInboundConnectorReady(
-        zeebeTest, elementId, importSchedulers, inboundConnectorTestHelper);
   }
 }

--- a/connectors-e2e-test/connectors-e2e-test-base/src/main/java/io/camunda/connector/e2e/inbound/InboundConnectorTestConfiguration.java
+++ b/connectors-e2e-test/connectors-e2e-test-base/src/main/java/io/camunda/connector/e2e/inbound/InboundConnectorTestConfiguration.java
@@ -19,6 +19,7 @@ package io.camunda.connector.e2e.inbound;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
+import io.camunda.connector.api.inbound.Health;
 import io.camunda.connector.runtime.inbound.executable.InboundExecutableRegistry;
 import io.camunda.connector.runtime.inbound.state.ProcessDefinitionInspector;
 import java.time.Duration;
@@ -39,6 +40,7 @@ public class InboundConnectorTestConfiguration {
   public static class InboundConnectorTestHelper {
 
     private static final Duration DEFAULT_AWAIT_NO_EXECUTABLES_TIMEOUT = Duration.ofSeconds(10);
+    private static final Duration DEFAULT_AWAIT_ACTIVE_EXECUTABLE_TIMEOUT = Duration.ofSeconds(15);
 
     private final CacheManager cacheManager;
     private final InboundExecutableRegistry executableRegistry;
@@ -78,6 +80,38 @@ public class InboundConnectorTestConfiguration {
               () -> {
                 var allExecutables = executableRegistry.query(f -> {});
                 assertThat(allExecutables).isEmpty();
+              });
+    }
+
+    /**
+     * Waits until an inbound executable for the given BPMN element id is registered and reports
+     * health {@link Health.Status#UP}. This is needed in addition to waiting for the BPMN element
+     * to become active because the inbound executable registry processes activation events
+     * asynchronously, so the subscription may not yet be reachable (e.g. a webhook would return
+     * 404) when the element activates in the process.
+     */
+    public void awaitActiveInboundExecutable(String elementId) {
+      awaitActiveInboundExecutable(elementId, DEFAULT_AWAIT_ACTIVE_EXECUTABLE_TIMEOUT);
+    }
+
+    /** See {@link #awaitActiveInboundExecutable(String)}. */
+    public void awaitActiveInboundExecutable(String elementId, Duration waitDuration) {
+      await("inbound executable for element '" + elementId + "' should be active and healthy")
+          .atMost(waitDuration)
+          .untilAsserted(
+              () -> {
+                var executables = executableRegistry.query(f -> f.elementId(elementId));
+                assertThat(executables)
+                    .as("executable for element '%s' should be registered", elementId)
+                    .isNotEmpty();
+                assertThat(executables)
+                    .allSatisfy(
+                        executable ->
+                            assertThat(executable.health().getStatus())
+                                .as(
+                                    "executable for element '%s' should be UP, got: %s",
+                                    elementId, executable.health())
+                                .isEqualTo(Health.Status.UP));
               });
     }
   }


### PR DESCRIPTION
## Description

The A2A webhook and polling e2e tests waited only for the BPMN catch event to become active before sending requests. But the inbound executable registry processes activation events asynchronously (queued and drained by a `@Scheduled(fixedDelay = 1000)` task), so the BPMN element could be active while the inbound subscription was still being registered. Webhook POSTs sent on tight delays (100/300/500 ms) sometimes hit before the executable was up, returning 404 and causing flaky failures.

The fix adds a wait step that polls the executable registry until the executable for the element is registered and reports `Health.Status.UP`, and applies the same readiness check uniformly to both webhook and polling tests.

## Related issues

closes #7033

## Checklist

- [x] Tests/Integration tests for the changes have been added if applicable.
- [x] Backport labels are added if these code changes should be backported.
- [ ] If the change requires a documentation update, it has been added to the appropriate section in the documentation.

https://claude.ai/code/session_01VryXBTEiQY8Jbp9ZKxhLTs