### PR TITLE
fix: bump Maven to 3.9.15 — 3.9.14 removed from Apache CDN (backport #7094)

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,4 +1,4 @@
 java temurin-21.0.11+10.0.LTS
-maven 3.9.14
+maven 3.9.15
 pre-commit 4.6.0
 nodejs 24.15.0


### PR DESCRIPTION
Backport of #7094 to `stable/8.8`.

## Summary
- Bumps Maven to `3.9.15` in `.tool-versions`; `3.9.14` was removed from the Apache CDN, breaking CI.

## Conflict resolution
- `.tool-versions` conflicted on the Java line (main is on Java 25; `stable/8.8` is on Java 21). Kept `java temurin-21.0.11+10.0.LTS` and applied only the Maven version bump.

## Test plan
- [ ] CI green on this branch