### PR TITLE
fix(ci): install element-templates-cli in e2e-tests job

### DIFF
--- a/.github/workflows/RELEASE.yaml
+++ b/.github/workflows/RELEASE.yaml
@@ -244,6 +244,9 @@ jobs:
       - name: Install artifacts
         run: mvn -B install -DskipTests -DskipChecks -Pe2eExcluded
 
+      - name: Install element templates CLI
+        run: npm install --global element-templates-cli@$(jq -r '.devDependencies["element-templates-cli"]' .github/workflows/package.json)
+
       - name: Run E2E tests
         run: mvn -B verify -f connectors-e2e-test/pom.xml
 

--- a/.github/workflows/RELEASE.yaml
+++ b/.github/workflows/RELEASE.yaml
@@ -107,6 +107,11 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-
 
+      - name: Install Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+
       - name: Install element templates CLI
         run: npm install --global element-templates-cli@$(jq -r '.devDependencies["element-templates-cli"]' .github/workflows/package.json)
 
@@ -243,6 +248,11 @@ jobs:
 
       - name: Install artifacts
         run: mvn -B install -DskipTests -DskipChecks -Pe2eExcluded
+
+      - name: Install Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
 
       - name: Install element templates CLI
         run: npm install --global element-templates-cli@$(jq -r '.devDependencies["element-templates-cli"]' .github/workflows/package.json)


### PR DESCRIPTION
## Summary

- The `e2e-tests` job in `RELEASE.yaml` runs on a fresh runner but was missing the `Install element templates CLI` step
- This caused all `HttpTests` to fail with `java.io.IOException: Cannot run program "element-templates-cli": error=2, No such file or directory`
- The step already exists in the `setup` job, but each job gets its own runner so the install doesn't carry over
- Added the same `npm install --global element-templates-cli@...` step between "Install artifacts" and "Run E2E tests"

## Test plan

- [ ] Verify the next release run's `e2e-tests` job passes `HttpTests`

Fixes: https://github.com/camunda/connectors/actions/runs/25102505696/job/73801750588

🤖 Generated with [Claude Code](https://claude.com/claude-code)