### PR TITLE
fix: log ERROR ActivityLog when reporting Health.down

### DIFF
--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImpl.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImpl.java
@@ -306,6 +306,7 @@ public class InboundConnectorContextImpl extends AbstractConnectorContext
                 String.format(
                     "Health status changed to %s, details: %s",
                     health.getStatus(), health.getDetails()))
+            .withSeverity(health.getStatus() == Health.Status.UP ? Severity.INFO : Severity.ERROR)
             .andReportHealth(health)
             .build();
     // append the activity log to store the health status change history

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImplTest.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImplTest.java
@@ -21,6 +21,9 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.connector.api.annotation.FEEL;
+import io.camunda.connector.api.inbound.ActivityLogTag;
+import io.camunda.connector.api.inbound.Health;
+import io.camunda.connector.api.inbound.Severity;
 import io.camunda.connector.api.secret.SecretProvider;
 import io.camunda.connector.runtime.core.FooBarSecretProvider;
 import io.camunda.connector.runtime.core.TestObjectMapperSupplier;
@@ -153,6 +156,56 @@ class InboundConnectorContextImplTest {
 
     // then
     assertThat(properties.get("stringMap")).isEqualTo("={\"keyString\":null}");
+  }
+
+  @Test
+  void reportHealth_shouldLogInfoSeverityWhenStatusIsUp() {
+    // given
+    var definition = getInboundConnectorDefinition(Map.of());
+    var health = Health.up();
+    InboundConnectorContextImpl inboundConnectorContext =
+        new InboundConnectorContextImpl(
+            secretProvider, (e) -> {}, definition, null, (e) -> {}, mapper, activityLogRegistry);
+
+    // when
+    inboundConnectorContext.reportHealth(health);
+
+    // then
+    var logs =
+        activityLogRegistry.getLogs(ExecutableId.fromDeduplicationId(definition.deduplicationId()));
+    assertThat(logs)
+        .singleElement()
+        .satisfies(
+            log -> {
+              assertThat(log.tag()).isEqualTo(ActivityLogTag.HEALTH);
+              assertThat(log.healthChange()).isEqualTo(health);
+              assertThat(log.severity()).isEqualTo(Severity.INFO);
+            });
+  }
+
+  @Test
+  void reportHealth_shouldLogErrorSeverityWhenStatusIsDown() {
+    // given
+    var definition = getInboundConnectorDefinition(Map.of());
+    var health = Health.down();
+    InboundConnectorContextImpl inboundConnectorContext =
+        new InboundConnectorContextImpl(
+            secretProvider, (e) -> {}, definition, null, (e) -> {}, mapper, activityLogRegistry);
+
+    // when
+    inboundConnectorContext.reportHealth(health);
+
+    // then
+    var logs =
+        activityLogRegistry.getLogs(ExecutableId.fromDeduplicationId(definition.deduplicationId()));
+    assertThat(logs)
+        .singleElement()
+        .satisfies(
+            log -> {
+              assertThat(log.tag()).isEqualTo(ActivityLogTag.HEALTH);
+              assertThat(log.healthChange()).isEqualTo(health);
+              assertThat(log.severity()).isEqualTo(Severity.ERROR);
+            });
   }
 
   private TestPropertiesClass createTestClass() {


### PR DESCRIPTION
## Description
This pull request enhances the way health status changes are logged in the inbound connector context by introducing severity levels to activity logs. It also adds comprehensive tests to ensure the correct severity is set based on the health status.

**Activity log severity improvements:**

* The `reportHealth` method in `InboundConnectorContextImpl` now logs health status changes with a severity level: `INFO` for `UP` status and `ERROR` for other statuses.

**Testing enhancements:**

* Added tests in `InboundConnectorContextImplTest` to verify that the correct severity (`INFO` or `ERROR`) is set in the activity log when reporting health status changes.
* Imported necessary classes (`ActivityLogTag`, `Health`, `Severity`) in the test file to support the new tests.

## Checklist

- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest
  release, as this branch will be rebased onto main before the next release. Example backport labels:
    - `backport stable/8.8`: for changes that should be included in the next 8.8.x release.
    - **or** `backport release-8.8.7`: for changes that should be included in the specific release 8.8.7, and this
      *release has already been created*. The release branch will be merged back into stable/8.8 later, so the change
      will be included in future 8.8.x releases as well.
- [ ] Tests/Integration tests for the changes have been added if applicable.
- [ ] If the change requires a documentation update, it has been added to the appropriate section in the documentation.


