### PR TITLE
test(agentic-ai): Revert "temporarily disable MCP authentication tests"

### DIFF
--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/mcp/authentication/McpAuthenticationTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/mcp/authentication/McpAuthenticationTests.java
@@ -16,11 +16,9 @@
  */
 package io.camunda.connector.e2e.agenticai.mcp.authentication;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Nested;
 import org.springframework.test.context.TestPropertySource;
 
-@Disabled
 public class McpAuthenticationTests {
 
   @Nested


### PR DESCRIPTION
## Description

This reverts commit d752175208bc7158da6481166ffe29ee2d79ea84.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #

## Checklist

- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest
  release, as this branch will be rebased onto main before the next release. Example backport labels:
    - `backport stable/8.8`: for changes that should be included in the next 8.8.x release.
    - **or** `backport release-8.8.7`: for changes that should be included in the specific release 8.8.7, and this
      *release has already been created*. The release branch will be merged back into stable/8.8 later, so the change
      will be included in future 8.8.x releases as well.
- [ ] Tests/Integration tests for the changes have been added if applicable.
- [ ] If the change requires a documentation update, it has been added to the appropriate section in the documentation.


