### PR TITLE
[Backport stable/8.9] test(agentic-ai): wait for active inbound executable to fix flaky A2A e2e tests

### DIFF
--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/TestUtil.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/TestUtil.java
@@ -17,6 +17,8 @@
 package io.camunda.connector.e2e.agenticai;
 
 import io.camunda.connector.e2e.ZeebeTest;
+import io.camunda.connector.e2e.inbound.InboundConnectorTestConfiguration.InboundConnectorTestHelper;
+import io.camunda.connector.runtime.inbound.importer.ImportSchedulers;
 import io.camunda.process.test.api.CamundaAssert;
 import java.net.URI;
 import java.net.http.HttpClient;
@@ -67,5 +69,24 @@ public final class TestUtil {
             () ->
                 CamundaAssert.assertThat(zeebeTest.getProcessInstanceEvent())
                     .hasActiveElement(elementId, 1));
+  }
+
+  /**
+   * Waits for an inbound connector to be fully ready: waits for the BPMN element to become active
+   * in the process, triggers a process definition import, and waits for the inbound executable to
+   * be registered and healthy in the runtime registry. The order ensures that when the executable
+   * activates, the polling fetcher's first iteration already sees the running process instance at
+   * the catch event. The last step is required because executable activation events are processed
+   * asynchronously, so without it incoming requests (e.g. webhook POSTs) may hit before the
+   * subscription is active.
+   */
+  public static void awaitInboundConnectorReady(
+      ZeebeTest zeebeTest,
+      String elementId,
+      ImportSchedulers importSchedulers,
+      InboundConnectorTestHelper testHelper) {
+    waitForElementActivation(zeebeTest, elementId);
+    importSchedulers.scheduleLatestVersionImport();
+    testHelper.awaitActiveInboundExecutable(elementId);
   }
 }

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/a2a/A2aStandaloneTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/a2a/A2aStandaloneTests.java
@@ -24,7 +24,6 @@ import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static com.github.tomakehurst.wiremock.stubbing.Scenario.STARTED;
 import static io.camunda.connector.e2e.agenticai.TestUtil.postWithDelay;
-import static io.camunda.connector.e2e.agenticai.TestUtil.waitForElementActivation;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.github.tomakehurst.wiremock.client.WireMock;
@@ -36,6 +35,7 @@ import io.camunda.connector.agenticai.a2a.client.common.model.result.A2aTask;
 import io.camunda.connector.agenticai.a2a.client.common.model.result.A2aTaskStatus;
 import io.camunda.connector.e2e.ZeebeTest;
 import io.camunda.connector.e2e.agenticai.BaseAgenticAiTest;
+import io.camunda.connector.e2e.agenticai.TestUtil;
 import io.camunda.connector.e2e.inbound.InboundConnectorTestConfiguration;
 import io.camunda.connector.e2e.inbound.InboundConnectorTestConfiguration.InboundConnectorTestHelper;
 import io.camunda.connector.runtime.inbound.importer.ImportSchedulers;
@@ -70,6 +70,7 @@ import org.springframework.test.context.TestPropertySource;
 public class A2aStandaloneTests extends BaseAgenticAiTest {
 
   private static final String WEBHOOK_ELEMENT_ID = "Wait_For_Completion_Webhook";
+  private static final String POLLING_ELEMENT_ID = "Wait_For_Completion_Polling";
 
   @Autowired private InboundConnectorTestHelper inboundConnectorTestHelper;
   @Autowired private ImportSchedulers importSchedulers;
@@ -98,10 +99,12 @@ public class A2aStandaloneTests extends BaseAgenticAiTest {
     BpmnModelInstance bpmnModel = Bpmn.readModelFromStream(testProcess.getInputStream());
     ZeebeTest zeebeTest =
         createProcessInstance(
-                bpmnModel,
-                Map.of(
-                    "responseRetrievalMode", "polling", "a2aServerUrl", wireMock.getHttpBaseUrl()))
-            .waitForProcessCompletion();
+            bpmnModel,
+            Map.of("responseRetrievalMode", "polling", "a2aServerUrl", wireMock.getHttpBaseUrl()));
+
+    awaitInboundConnectorReady(zeebeTest, POLLING_ELEMENT_ID);
+
+    zeebeTest.waitForProcessCompletion();
 
     CamundaAssert.assertThat(zeebeTest.getProcessInstanceEvent())
         .hasVariableSatisfies(
@@ -126,7 +129,7 @@ public class A2aStandaloneTests extends BaseAgenticAiTest {
                 "webhookUrl",
                 webhookUrl));
 
-    waitForWebhookElementActivation(zeebeTest);
+    awaitInboundConnectorReady(zeebeTest, WEBHOOK_ELEMENT_ID);
 
     // Post working state - should NOT activate webhook
     postWithDelay(
@@ -163,7 +166,7 @@ public class A2aStandaloneTests extends BaseAgenticAiTest {
                 "token",
                 token));
 
-    waitForWebhookElementActivation(zeebeTest);
+    awaitInboundConnectorReady(zeebeTest, WEBHOOK_ELEMENT_ID);
 
     // Post working state - should NOT activate webhook
     postWithDelay(
@@ -217,7 +220,7 @@ public class A2aStandaloneTests extends BaseAgenticAiTest {
                 "webhookUrl",
                 webhookUrl));
 
-    waitForWebhookElementActivation(zeebeTest);
+    awaitInboundConnectorReady(zeebeTest, WEBHOOK_ELEMENT_ID);
 
     // Post working state - should NOT activate webhook
     postWithDelay(
@@ -264,7 +267,7 @@ public class A2aStandaloneTests extends BaseAgenticAiTest {
                 "webhookUrl",
                 webhookUrl));
 
-    waitForWebhookElementActivation(zeebeTest);
+    awaitInboundConnectorReady(zeebeTest, WEBHOOK_ELEMENT_ID);
 
     // Post working state - should NOT activate webhook
     postWithDelay(
@@ -298,10 +301,9 @@ public class A2aStandaloneTests extends BaseAgenticAiTest {
     assertVariablesWithWebhook(zeebeTest);
   }
 
-  private void waitForWebhookElementActivation(ZeebeTest zeebeTest) {
-    // manually trigger process definition import to register the webhook
-    importSchedulers.scheduleLatestVersionImport();
-    waitForElementActivation(zeebeTest, WEBHOOK_ELEMENT_ID);
+  private void awaitInboundConnectorReady(ZeebeTest zeebeTest, String elementId) {
+    TestUtil.awaitInboundConnectorReady(
+        zeebeTest, elementId, importSchedulers, inboundConnectorTestHelper);
   }
 
   private BpmnModelInstance getBpmnModelWithNewId(String newProcessId) throws IOException {

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/langchain4j/jobworker/L4JAiAgentJobWorkerA2aIntegrationTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/langchain4j/jobworker/L4JAiAgentJobWorkerA2aIntegrationTests.java
@@ -17,7 +17,6 @@
 package io.camunda.connector.e2e.agenticai.aiagent.langchain4j.jobworker;
 
 import static io.camunda.connector.e2e.agenticai.TestUtil.postWithDelay;
-import static io.camunda.connector.e2e.agenticai.TestUtil.waitForElementActivation;
 import static io.camunda.connector.e2e.agenticai.aiagent.AiAgentTestFixtures.HAIKU_TEXT;
 import static io.camunda.connector.e2e.agenticai.aiagent.langchain4j.Langchain4JAiAgentToolSpecifications.EXPECTED_A2A_TOOL_SPECIFICATIONS;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -34,6 +33,7 @@ import dev.langchain4j.model.output.TokenUsage;
 import io.camunda.connector.agenticai.aiagent.model.AgentMetrics;
 import io.camunda.connector.e2e.ElementTemplate;
 import io.camunda.connector.e2e.ZeebeTest;
+import io.camunda.connector.e2e.agenticai.TestUtil;
 import io.camunda.connector.e2e.agenticai.aiagent.langchain4j.common.L4JAiAgentA2aIntegrationTestSupport;
 import io.camunda.connector.e2e.agenticai.assertj.JobWorkerAgentResponseAssert;
 import io.camunda.connector.e2e.inbound.InboundConnectorTestConfiguration;
@@ -183,9 +183,8 @@ public class L4JAiAgentJobWorkerA2aIntegrationTests extends BaseL4JAiAgentJobWor
                 "userPrompt",
                 testSupport.initialUserPrompt));
 
-    // manually trigger process definition import to register the webhook
-    importSchedulers.scheduleLatestVersionImport();
-    waitForElementActivation(zeebeTest, WEBHOOK_ELEMENT_ID);
+    TestUtil.awaitInboundConnectorReady(
+        zeebeTest, WEBHOOK_ELEMENT_ID, importSchedulers, inboundConnectorTestHelper);
     postWithDelay(
         webhookUrl, testFileContent("exchange-rate-agent-webhook-payload.json").get(), 100);
 

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/langchain4j/outboundconnector/L4JAiAgentConnectorA2aIntegrationTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/langchain4j/outboundconnector/L4JAiAgentConnectorA2aIntegrationTests.java
@@ -17,7 +17,6 @@
 package io.camunda.connector.e2e.agenticai.aiagent.langchain4j.outboundconnector;
 
 import static io.camunda.connector.e2e.agenticai.TestUtil.postWithDelay;
-import static io.camunda.connector.e2e.agenticai.TestUtil.waitForElementActivation;
 import static io.camunda.connector.e2e.agenticai.aiagent.AiAgentTestFixtures.HAIKU_TEXT;
 import static io.camunda.connector.e2e.agenticai.aiagent.langchain4j.Langchain4JAiAgentToolSpecifications.EXPECTED_A2A_TOOL_SPECIFICATIONS;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -34,6 +33,7 @@ import dev.langchain4j.model.output.TokenUsage;
 import io.camunda.connector.agenticai.aiagent.model.AgentMetrics;
 import io.camunda.connector.e2e.ElementTemplate;
 import io.camunda.connector.e2e.ZeebeTest;
+import io.camunda.connector.e2e.agenticai.TestUtil;
 import io.camunda.connector.e2e.agenticai.aiagent.langchain4j.common.L4JAiAgentA2aIntegrationTestSupport;
 import io.camunda.connector.e2e.agenticai.assertj.AgentResponseAssert;
 import io.camunda.connector.e2e.inbound.InboundConnectorTestConfiguration;
@@ -183,9 +183,8 @@ public class L4JAiAgentConnectorA2aIntegrationTests extends BaseL4JAiAgentConnec
                 "userPrompt",
                 testSupport.initialUserPrompt));
 
-    // manually trigger process definition import to register the webhook
-    importSchedulers.scheduleLatestVersionImport();
-    waitForElementActivation(zeebeTest, WEBHOOK_ELEMENT_ID);
+    TestUtil.awaitInboundConnectorReady(
+        zeebeTest, WEBHOOK_ELEMENT_ID, importSchedulers, inboundConnectorTestHelper);
 
     postWithDelay(
         webhookUrl, testFileContent("exchange-rate-agent-webhook-payload.json").get(), 100);

--- a/connectors-e2e-test/connectors-e2e-test-base/src/main/java/io/camunda/connector/e2e/inbound/InboundConnectorTestConfiguration.java
+++ b/connectors-e2e-test/connectors-e2e-test-base/src/main/java/io/camunda/connector/e2e/inbound/InboundConnectorTestConfiguration.java
@@ -19,6 +19,7 @@ package io.camunda.connector.e2e.inbound;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
+import io.camunda.connector.api.inbound.Health;
 import io.camunda.connector.runtime.inbound.executable.ActiveExecutableQuery;
 import io.camunda.connector.runtime.inbound.executable.InboundExecutableRegistry;
 import io.camunda.connector.runtime.inbound.state.ProcessDefinitionInspector;
@@ -40,6 +41,7 @@ public class InboundConnectorTestConfiguration {
   public static class InboundConnectorTestHelper {
 
     private static final Duration DEFAULT_AWAIT_NO_EXECUTABLES_TIMEOUT = Duration.ofSeconds(10);
+    private static final Duration DEFAULT_AWAIT_ACTIVE_EXECUTABLE_TIMEOUT = Duration.ofSeconds(15);
 
     private final CacheManager cacheManager;
     private final InboundExecutableRegistry executableRegistry;
@@ -80,6 +82,40 @@ public class InboundConnectorTestConfiguration {
                 var allExecutables =
                     executableRegistry.query(new ActiveExecutableQuery(null, null, null, null));
                 assertThat(allExecutables).isEmpty();
+              });
+    }
+
+    /**
+     * Waits until an inbound executable for the given BPMN element id is registered and reports
+     * health {@link Health.Status#UP}. This is needed in addition to waiting for the BPMN element
+     * to become active because the inbound executable registry processes activation events
+     * asynchronously, so the subscription may not yet be reachable (e.g. a webhook would return
+     * 404) when the element activates in the process.
+     */
+    public void awaitActiveInboundExecutable(String elementId) {
+      awaitActiveInboundExecutable(elementId, DEFAULT_AWAIT_ACTIVE_EXECUTABLE_TIMEOUT);
+    }
+
+    /** See {@link #awaitActiveInboundExecutable(String)}. */
+    public void awaitActiveInboundExecutable(String elementId, Duration waitDuration) {
+      await("inbound executable for element '" + elementId + "' should be active and healthy")
+          .atMost(waitDuration)
+          .untilAsserted(
+              () -> {
+                var executables =
+                    executableRegistry.query(
+                        new ActiveExecutableQuery(null, elementId, null, null));
+                assertThat(executables)
+                    .as("executable for element '%s' should be registered", elementId)
+                    .isNotEmpty();
+                assertThat(executables)
+                    .allSatisfy(
+                        executable ->
+                            assertThat(executable.health().getStatus())
+                                .as(
+                                    "executable for element '%s' should be UP, got: %s",
+                                    elementId, executable.health())
+                                .isEqualTo(Health.Status.UP));
               });
     }
   }


### PR DESCRIPTION
# Description

Backport of #7100 to `stable/8.9`.