### PR TITLE
fix: Use MessageDigest based equality for auth string comparisons

### DIFF
--- a/connectors/webhook/src/main/java/io/camunda/connector/inbound/authorization/ApiKeyAuthHandler.java
+++ b/connectors/webhook/src/main/java/io/camunda/connector/inbound/authorization/ApiKeyAuthHandler.java
@@ -13,6 +13,8 @@ import io.camunda.connector.inbound.authorization.AuthorizationResult.Failure.In
 import io.camunda.connector.inbound.authorization.AuthorizationResult.Success;
 import io.camunda.connector.inbound.model.WebhookAuthorization.ApiKeyAuth;
 import io.camunda.connector.inbound.utils.HttpWebhookUtil;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
 import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -40,7 +42,9 @@ final class ApiKeyAuthHandler extends WebhookAuthorizationHandler<ApiKeyAuth> {
       if (apiKeyValue == null) {
         return API_KEY_MISSING_RESULT;
       }
-      if (!apiKeyValue.equals(expectedAuthorization.apiKey())) {
+      if (!MessageDigest.isEqual(
+          apiKeyValue.getBytes(StandardCharsets.UTF_8),
+          expectedAuthorization.apiKey().getBytes(StandardCharsets.UTF_8))) {
         return API_KEY_INVALID_RESULT;
       }
       return Success.INSTANCE;

--- a/connectors/webhook/src/main/java/io/camunda/connector/inbound/authorization/BasicAuthHandler.java
+++ b/connectors/webhook/src/main/java/io/camunda/connector/inbound/authorization/BasicAuthHandler.java
@@ -13,6 +13,7 @@ import io.camunda.connector.inbound.authorization.AuthorizationResult.Failure.In
 import io.camunda.connector.inbound.authorization.AuthorizationResult.Success;
 import io.camunda.connector.inbound.model.WebhookAuthorization.BasicAuth;
 import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
 import java.util.Base64;
 import java.util.Map.Entry;
 import java.util.stream.Collectors;
@@ -37,7 +38,9 @@ final class BasicAuthHandler extends WebhookAuthorizationHandler<BasicAuth> {
     String expectedAuth = expectedAuthorization.username() + ":" + expectedAuthorization.password();
     String actualAuth =
         new String(Base64.getDecoder().decode(authValue.getBytes(StandardCharsets.UTF_8)));
-    if (!expectedAuth.equals(actualAuth)) {
+    if (!MessageDigest.isEqual(
+        expectedAuth.getBytes(StandardCharsets.UTF_8),
+        actualAuth.getBytes(StandardCharsets.UTF_8))) {
       return AUTH_HEADER_INVALID_RESULT;
     }
     return Success.INSTANCE;

--- a/connectors/webhook/src/main/java/io/camunda/connector/inbound/signature/HMACSignatureValidator.java
+++ b/connectors/webhook/src/main/java/io/camunda/connector/inbound/signature/HMACSignatureValidator.java
@@ -10,6 +10,7 @@ import io.camunda.connector.api.error.ConnectorException;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.security.InvalidKeyException;
+import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Base64;
 import java.util.Map;
@@ -93,8 +94,12 @@ public class HMACSignatureValidator {
     // The Twilio produce base64 version
     String expectedBase64HmacString = Base64.getEncoder().encodeToString(expectedHmac);
     LOG.debug("Computed HMAC from webhook body: {}", expectedHmacString);
-    return providedHmac.equals(expectedHmacString)
-        || providedHmacWithoutTag.equals(expectedHmacString)
-        || providedHmac.equals(expectedBase64HmacString);
+    byte[] providedHmacBytes = providedHmac.getBytes(StandardCharsets.UTF_8);
+    byte[] providedHmacWithoutTagBytes = providedHmacWithoutTag.getBytes(StandardCharsets.UTF_8);
+    byte[] expectedHmacBytes = expectedHmacString.getBytes(StandardCharsets.UTF_8);
+    byte[] expectedBase64HmacBytes = expectedBase64HmacString.getBytes(StandardCharsets.UTF_8);
+    return MessageDigest.isEqual(providedHmacBytes, expectedHmacBytes)
+        || MessageDigest.isEqual(providedHmacWithoutTagBytes, expectedHmacBytes)
+        || MessageDigest.isEqual(providedHmacBytes, expectedBase64HmacBytes);
   }
 }

--- a/connectors/webhook/src/main/java/io/camunda/connector/inbound/signature/HMACSignatureValidator.java
+++ b/connectors/webhook/src/main/java/io/camunda/connector/inbound/signature/HMACSignatureValidator.java
@@ -18,12 +18,8 @@ import java.util.TreeMap;
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
 import org.apache.commons.codec.binary.Hex;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class HMACSignatureValidator {
-
-  private static final Logger LOG = LoggerFactory.getLogger(HMACSignatureValidator.class);
 
   private final byte[] requestBody;
   private final Map<String, String> headers;
@@ -68,7 +64,6 @@ public class HMACSignatureValidator {
       throw new ConnectorException("Expected HMAC header " + hmacHeader + ", but was not present");
     }
     final String providedHmac = caseInsensitiveHeaders.get(hmacHeader);
-    LOG.debug("Given HMAC from webhook call: {}", providedHmac);
 
     if (providedHmac == null || providedHmac.length() == 0) {
       return false;
@@ -93,7 +88,7 @@ public class HMACSignatureValidator {
 
     // The Twilio produce base64 version
     String expectedBase64HmacString = Base64.getEncoder().encodeToString(expectedHmac);
-    LOG.debug("Computed HMAC from webhook body: {}", expectedHmacString);
+
     byte[] providedHmacBytes = providedHmac.getBytes(StandardCharsets.UTF_8);
     byte[] providedHmacWithoutTagBytes = providedHmacWithoutTag.getBytes(StandardCharsets.UTF_8);
     byte[] expectedHmacBytes = expectedHmacString.getBytes(StandardCharsets.UTF_8);


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

## Related issues
This pull request improves the security of authorization and signature validation logic by replacing direct string comparisons with constant-time byte array comparisons using `MessageDigest.isEqual`. This helps prevent timing attacks in sensitive authentication code. The most important changes are grouped by the type of authentication mechanism.

**Security improvements for API key and Basic authentication:**

* Updated `ApiKeyAuthHandler` to use `MessageDigest.isEqual` for comparing API keys in a constant-time manner, replacing direct string equality checks. [[1]](diffhunk://#diff-413fa472fb305775749db2d1b70b6078df8e5ee8c3e44e8296891f13b3d44776R16-R17) [[2]](diffhunk://#diff-413fa472fb305775749db2d1b70b6078df8e5ee8c3e44e8296891f13b3d44776L43-R47)
* Updated `BasicAuthHandler` to use `MessageDigest.isEqual` for comparing the constructed username:password string to the provided credentials, replacing direct string equality checks. [[1]](diffhunk://#diff-a595e90d3b1b51cc3f79ac9eeb3423d975aa9f9a9774f4eab44e132385dabc0eR16) [[2]](diffhunk://#diff-a595e90d3b1b51cc3f79ac9eeb3423d975aa9f9a9774f4eab44e132385dabc0eL40-R43)

**Security improvements for HMAC signature validation:**

* Updated `HMACSignatureValidator` to use `MessageDigest.isEqual` for comparing HMAC signatures, replacing direct string equality checks, to ensure constant-time comparison and prevent timing attacks. [[1]](diffhunk://#diff-1c9c76c2aa2f69c8942d14c7419eebba72f3a9cb7dda1d14a3077be5517ce4f0R13) [[2]](diffhunk://#diff-1c9c76c2aa2f69c8942d14c7419eebba72f3a9cb7dda1d14a3077be5517ce4f0L96-R103)
<!-- Which issues are closed by this PR or are related -->

closes https://github.com/camunda/team-connectors/issues/1210

## Checklist

- [x] Backport labels are added if these code changes should be backported. No backport label is added to the latest
  release, as this branch will be rebased onto main before the next release. Example backport labels:
    - `backport stable/8.8`: for changes that should be included in the next 8.8.x release.
    - **or** `backport release-8.8.7`: for changes that should be included in the specific release 8.8.7, and this
      *release has already been created*. The release branch will be merged back into stable/8.8 later, so the change
      will be included in future 8.8.x releases as well.
- [ ] Tests/Integration tests for the changes have been added if applicable.
- [ ] If the change requires a documentation update, it has been added to the appropriate section in the documentation.


