### PR TITLE
Backport 7135 to stable/8.8

### DIFF
--- a/connectors/webhook/src/main/java/io/camunda/connector/inbound/authorization/ApiKeyAuthHandler.java
+++ b/connectors/webhook/src/main/java/io/camunda/connector/inbound/authorization/ApiKeyAuthHandler.java
@@ -13,6 +13,8 @@ import io.camunda.connector.inbound.authorization.AuthorizationResult.Failure.In
 import io.camunda.connector.inbound.authorization.AuthorizationResult.Success;
 import io.camunda.connector.inbound.model.WebhookAuthorization.ApiKeyAuth;
 import io.camunda.connector.inbound.utils.HttpWebhookUtil;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
 import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -40,9 +42,13 @@ final class ApiKeyAuthHandler extends WebhookAuthorizationHandler<ApiKeyAuth> {
       if (apiKeyValue == null) {
         return API_KEY_MISSING_RESULT;
       }
-      if (!apiKeyValue.equals(expectedAuthorization.apiKey())) {
+
+      if (!MessageDigest.isEqual(
+          apiKeyValue.getBytes(StandardCharsets.UTF_8),
+          expectedAuthorization.apiKey().getBytes(StandardCharsets.UTF_8))) {
         return API_KEY_INVALID_RESULT;
       }
+
       return Success.INSTANCE;
     } catch (Exception e) {
       LOG.info("Error while extracting API key value", e);

--- a/connectors/webhook/src/main/java/io/camunda/connector/inbound/authorization/BasicAuthHandler.java
+++ b/connectors/webhook/src/main/java/io/camunda/connector/inbound/authorization/BasicAuthHandler.java
@@ -12,6 +12,7 @@ import io.camunda.connector.inbound.authorization.AuthorizationResult.Failure.In
 import io.camunda.connector.inbound.authorization.AuthorizationResult.Success;
 import io.camunda.connector.inbound.model.WebhookAuthorization.BasicAuth;
 import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
 import java.util.Base64;
 import java.util.Map.Entry;
 import java.util.stream.Collectors;
@@ -36,7 +37,10 @@ final class BasicAuthHandler extends WebhookAuthorizationHandler<BasicAuth> {
     String expectedAuth = expectedAuthorization.username() + ":" + expectedAuthorization.password();
     String actualAuth =
         new String(Base64.getDecoder().decode(authValue.getBytes(StandardCharsets.UTF_8)));
-    if (!expectedAuth.equals(actualAuth)) {
+
+    if (!MessageDigest.isEqual(
+        expectedAuth.getBytes(StandardCharsets.UTF_8),
+        actualAuth.getBytes(StandardCharsets.UTF_8))) {
       return AUTH_HEADER_INVALID_RESULT;
     }
     return Success.INSTANCE;

--- a/connectors/webhook/src/main/java/io/camunda/connector/inbound/signature/HMACSignatureValidator.java
+++ b/connectors/webhook/src/main/java/io/camunda/connector/inbound/signature/HMACSignatureValidator.java
@@ -10,6 +10,7 @@ import io.camunda.connector.api.error.ConnectorException;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.security.InvalidKeyException;
+import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Map;
 import java.util.TreeMap;
@@ -17,12 +18,8 @@ import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
 import javax.xml.bind.DatatypeConverter;
 import org.apache.commons.codec.binary.Hex;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class HMACSignatureValidator {
-
-  private static final Logger LOG = LoggerFactory.getLogger(HMACSignatureValidator.class);
 
   private final byte[] requestBody;
   private final Map<String, String> headers;
@@ -67,9 +64,8 @@ public class HMACSignatureValidator {
       throw new ConnectorException("Expected HMAC header " + hmacHeader + ", but was not present");
     }
     final String providedHmac = caseInsensitiveHeaders.get(hmacHeader);
-    LOG.debug("Given HMAC from webhook call: {}", providedHmac);
 
-    if (providedHmac == null || providedHmac.length() == 0) {
+    if (providedHmac == null || providedHmac.isEmpty()) {
       return false;
     }
 
@@ -92,9 +88,14 @@ public class HMACSignatureValidator {
 
     // The Twilio produce base64 version
     String expectedBase64HmacString = DatatypeConverter.printBase64Binary(expectedHmac);
-    LOG.debug("Computed HMAC from webhook body: {}", expectedHmacString);
-    return providedHmac.equals(expectedHmacString)
-        || providedHmacWithoutTag.equals(expectedHmacString)
-        || providedHmac.equals(expectedBase64HmacString);
+
+    byte[] providedHmacBytes = providedHmac.getBytes(StandardCharsets.UTF_8);
+    byte[] providedHmacWithoutTagBytes = providedHmacWithoutTag.getBytes(StandardCharsets.UTF_8);
+    byte[] expectedHmacBytes = expectedHmacString.getBytes(StandardCharsets.UTF_8);
+    byte[] expectedBase64HmacBytes = expectedBase64HmacString.getBytes(StandardCharsets.UTF_8);
+
+    return MessageDigest.isEqual(providedHmacBytes, expectedHmacBytes)
+        || MessageDigest.isEqual(providedHmacWithoutTagBytes, expectedHmacBytes)
+        || MessageDigest.isEqual(providedHmacBytes, expectedBase64HmacBytes);
   }
 }


### PR DESCRIPTION
## Description

Backport of #7135 to `stable/8.8` branch

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #

## Checklist

- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest
  release, as this branch will be rebased onto main before the next release. Example backport labels:
    - `backport stable/8.8`: for changes that should be included in the next 8.8.x release.
    - **or** `backport release-8.8.7`: for changes that should be included in the specific release 8.8.7, and this
      *release has already been created*. The release branch will be merged back into stable/8.8 later, so the change
      will be included in future 8.8.x releases as well.
- [ ] Tests/Integration tests for the changes have been added if applicable.
- [ ] If the change requires a documentation update, it has been added to the appropriate section in the documentation.


