### PR TITLE
feat(agenticai): resolve external parameters

### DIFF
--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/adhoctoolsschema/processdefinition/CamundaClientProcessDefinitionAdHocToolElementsResolver.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/adhoctoolsschema/processdefinition/CamundaClientProcessDefinitionAdHocToolElementsResolver.java
@@ -8,10 +8,14 @@ package io.camunda.connector.agenticai.adhoctoolsschema.processdefinition;
 
 import static io.camunda.connector.agenticai.util.BpmnUtils.getElementDocumentation;
 import static io.camunda.connector.agenticai.util.BpmnUtils.getExtensionProperties;
+import static io.camunda.connector.agenticai.util.BpmnUtils.getExternalInputParameters;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.connector.agenticai.adhoctoolsschema.model.AdHocToolElement;
 import io.camunda.connector.agenticai.adhoctoolsschema.model.AdHocToolElementParameter;
 import io.camunda.connector.agenticai.adhoctoolsschema.processdefinition.feel.AdHocToolElementParameterExtractor;
+import io.camunda.connector.agenticai.util.BpmnUtils.InputSpecItem;
+import io.camunda.connector.agenticai.util.ObjectMapperConstants;
 import io.camunda.connector.api.error.ConnectorException;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
@@ -28,6 +32,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -36,6 +41,8 @@ public class CamundaClientProcessDefinitionAdHocToolElementsResolver
 
   private static final Logger LOGGER =
       LoggerFactory.getLogger(CamundaClientProcessDefinitionAdHocToolElementsResolver.class);
+
+  private static final ObjectMapper SCHEMA_OBJECT_MAPPER = new ObjectMapper();
 
   private static final String ERROR_CODE_AD_HOC_SUB_PROCESS_NOT_FOUND =
       "AD_HOC_SUB_PROCESS_NOT_FOUND";
@@ -103,6 +110,14 @@ public class CamundaClientProcessDefinitionAdHocToolElementsResolver
   }
 
   private List<AdHocToolElementParameter> extractParameters(FlowNode element) {
+    final List<InputSpecItem> externalParams = getExternalInputParameters(element);
+    if (!externalParams.isEmpty()) {
+      return externalParams.stream()
+          .filter(spec -> spec.name() != null && !spec.name().isBlank())
+          .map(CamundaClientProcessDefinitionAdHocToolElementsResolver::toToolElementParameter)
+          .toList();
+    }
+
     final var ioMapping = element.getSingleExtensionElement(ZeebeIoMapping.class);
     if (ioMapping == null) {
       return Collections.emptyList();
@@ -113,6 +128,26 @@ public class CamundaClientProcessDefinitionAdHocToolElementsResolver
     result.addAll(extractParameters(element, ioMapping.getOutputs()));
 
     return result;
+  }
+
+  private static AdHocToolElementParameter toToolElementParameter(InputSpecItem spec) {
+    Map<String, Object> schema = null;
+    if (spec.schema() != null && !spec.schema().isBlank()) {
+      try {
+        schema =
+            SCHEMA_OBJECT_MAPPER.readValue(
+                spec.schema(), ObjectMapperConstants.STRING_OBJECT_MAP_TYPE_REFERENCE);
+      } catch (final Exception ignored) {
+        // invalid schema override — proceed without it
+      }
+    }
+    final String jsonType = spec.type() != null && !spec.type().isBlank() ? spec.type() : "string";
+    return new AdHocToolElementParameter(
+        "toolCall." + spec.name(),
+        spec.description(),
+        jsonType,
+        schema,
+        Map.of("required", spec.required()));
   }
 
   private List<AdHocToolElementParameter> extractParameters(

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/AiAgentJobWorker.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/AiAgentJobWorker.java
@@ -6,6 +6,7 @@
  */
 package io.camunda.connector.agenticai.aiagent;
 
+import io.camunda.connector.agenticai.adhoctoolsschema.processdefinition.ProcessDefinitionAdHocToolElementsResolver;
 import io.camunda.connector.agenticai.aiagent.agent.JobWorkerAgentRequestHandler;
 import io.camunda.connector.agenticai.aiagent.model.JobWorkerAgentExecutionContext;
 import io.camunda.connector.agenticai.aiagent.model.request.JobWorkerAgentRequest;
@@ -47,16 +48,21 @@ public class AiAgentJobWorker implements AgentConnectorFunction {
   public static final String TOOL_CALL_VARIABLE = "toolCall";
 
   private final JobWorkerAgentRequestHandler agentRequestHandler;
+  private final ProcessDefinitionAdHocToolElementsResolver toolElementsResolver;
 
-  public AiAgentJobWorker(JobWorkerAgentRequestHandler agentRequestHandler) {
+  public AiAgentJobWorker(
+      JobWorkerAgentRequestHandler agentRequestHandler,
+      ProcessDefinitionAdHocToolElementsResolver toolElementsResolver) {
     this.agentRequestHandler = agentRequestHandler;
+    this.toolElementsResolver = toolElementsResolver;
   }
 
   @Override
   public AiAgentSubProcessConnectorResponse execute(OutboundConnectorContext context)
       throws Exception {
     var request = context.bindVariables(JobWorkerAgentRequest.class);
-    var executionContext = new JobWorkerAgentExecutionContext(context.getJobContext(), request);
+    var executionContext =
+        new JobWorkerAgentExecutionContext(context.getJobContext(), request, toolElementsResolver);
     return agentRequestHandler.handleRequest(executionContext);
   }
 }

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/JobWorkerAgentExecutionContext.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/JobWorkerAgentExecutionContext.java
@@ -7,6 +7,8 @@
 package io.camunda.connector.agenticai.aiagent.model;
 
 import io.camunda.connector.agenticai.adhoctoolsschema.model.AdHocToolElement;
+import io.camunda.connector.agenticai.adhoctoolsschema.model.AdHocToolElementParameter;
+import io.camunda.connector.agenticai.adhoctoolsschema.processdefinition.ProcessDefinitionAdHocToolElementsResolver;
 import io.camunda.connector.agenticai.aiagent.model.request.EventHandlingConfiguration;
 import io.camunda.connector.agenticai.aiagent.model.request.JobWorkerAgentRequest;
 import io.camunda.connector.agenticai.aiagent.model.request.JobWorkerResponseConfiguration;
@@ -18,16 +20,29 @@ import io.camunda.connector.agenticai.aiagent.model.request.provider.ProviderCon
 import io.camunda.connector.agenticai.model.tool.ToolCallResult;
 import io.camunda.connector.api.outbound.JobContext;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class JobWorkerAgentExecutionContext implements AgentExecutionContext {
+
+  private static final Logger LOGGER =
+      LoggerFactory.getLogger(JobWorkerAgentExecutionContext.class);
+
   private final JobContext jobContext;
   private final JobWorkerAgentRequest request;
+  private final ProcessDefinitionAdHocToolElementsResolver toolElementsResolver;
   private boolean cancelRemainingInstances;
+  private List<AdHocToolElement> toolElements;
 
   public JobWorkerAgentExecutionContext(
-      final JobContext jobContext, final JobWorkerAgentRequest request) {
+      final JobContext jobContext,
+      final JobWorkerAgentRequest request,
+      final ProcessDefinitionAdHocToolElementsResolver toolElementsResolver) {
     this.jobContext = jobContext;
     this.request = request;
+    this.toolElementsResolver = toolElementsResolver;
   }
 
   @Override
@@ -47,7 +62,43 @@ public class JobWorkerAgentExecutionContext implements AgentExecutionContext {
 
   @Override
   public List<AdHocToolElement> toolElements() {
-    return request.toolElements();
+    if (toolElements != null) {
+      return toolElements;
+    }
+
+    return toolElements = enrichWithParameters(request.toolElements());
+  }
+
+  /**
+   * Zeebe's adHocSubProcessElements variable provides element metadata (id, name, documentation,
+   * zeebe:properties) but not tool parameters from specext:externalParameters or fromAi()
+   * expressions. This method enriches each element with parameters resolved from the BPMN XML.
+   */
+  private List<AdHocToolElement> enrichWithParameters(List<AdHocToolElement> zeebeElements) {
+    if (zeebeElements == null || zeebeElements.isEmpty() || toolElementsResolver == null) {
+      return zeebeElements;
+    }
+
+    try {
+      final Map<String, List<AdHocToolElementParameter>> paramsByElementId =
+          toolElementsResolver
+              .resolveToolElements(jobContext.getProcessDefinitionKey(), jobContext.getElementId())
+              .stream()
+              .collect(Collectors.toMap(AdHocToolElement::elementId, AdHocToolElement::parameters));
+
+      return zeebeElements.stream()
+          .map(
+              element ->
+                  element.withParameters(
+                      paramsByElementId.getOrDefault(element.elementId(), List.of())))
+          .toList();
+    } catch (Exception e) {
+      LOGGER.warn(
+          "Failed to enrich tool elements with parameters from process definition. "
+              + "Tool parameters will not be available for schema generation. Cause: {}",
+          e.getMessage());
+      return zeebeElements;
+    }
   }
 
   @Override

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/autoconfigure/AgenticAiConnectorsAutoConfiguration.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/autoconfigure/AgenticAiConnectorsAutoConfiguration.java
@@ -330,7 +330,9 @@ public class AgenticAiConnectorsAutoConfiguration {
   @ConditionalOnBooleanProperty(
       value = "camunda.connector.agenticai.aiagent.job-worker.enabled",
       matchIfMissing = true)
-  public AiAgentJobWorker aiAgentJobWorker(JobWorkerAgentRequestHandler agentRequestHandler) {
-    return new AiAgentJobWorker(agentRequestHandler);
+  public AiAgentJobWorker aiAgentJobWorker(
+      JobWorkerAgentRequestHandler agentRequestHandler,
+      ProcessDefinitionAdHocToolElementsResolver toolElementsResolver) {
+    return new AiAgentJobWorker(agentRequestHandler, toolElementsResolver);
   }
 }

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/util/BpmnUtils.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/util/BpmnUtils.java
@@ -9,14 +9,20 @@ package io.camunda.connector.agenticai.util;
 import io.camunda.zeebe.model.bpmn.instance.FlowNode;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeProperties;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeProperty;
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
+import org.camunda.bpm.model.xml.instance.DomElement;
 import org.camunda.bpm.model.xml.instance.ModelElementInstance;
 
 public final class BpmnUtils {
   private BpmnUtils() {}
+
+  public record InputSpecItem(
+      String name, String description, String type, boolean required, String schema) {}
 
   public static Optional<String> getElementDocumentation(FlowNode element) {
     return element.getDocumentations().stream()
@@ -34,5 +40,29 @@ public final class BpmnUtils {
 
     return extensionProperties.getProperties().stream()
         .collect(Collectors.toMap(ZeebeProperty::getName, ZeebeProperty::getValue));
+  }
+
+  public static List<InputSpecItem> getExternalInputParameters(FlowNode element) {
+    final var extensionElements = element.getExtensionElements();
+    if (extensionElements == null) {
+      return Collections.emptyList();
+    }
+    return extensionElements.getDomElement().getChildElements().stream()
+        .filter(child -> "externalParameters".equals(child.getLocalName()))
+        .flatMap(
+            extParams ->
+                extParams.getChildElements().stream()
+                    .filter(specEl -> "inputSpecification".equals(specEl.getLocalName()))
+                    .map(BpmnUtils::domElementToInputSpecItem))
+        .toList();
+  }
+
+  private static InputSpecItem domElementToInputSpecItem(DomElement el) {
+    return new InputSpecItem(
+        el.getAttribute(null, "name"),
+        el.getAttribute(null, "description"),
+        el.getAttribute(null, "type"),
+        Boolean.parseBoolean(el.getAttribute(null, "required")),
+        el.getAttribute(null, "schema"));
   }
 }

--- a/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/adhoctoolsschema/AdHocToolsSchemaFunctionIntegrationTest.java
+++ b/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/adhoctoolsschema/AdHocToolsSchemaFunctionIntegrationTest.java
@@ -70,6 +70,7 @@ class AdHocToolsSchemaFunctionIntegrationTest {
 
   private AdHocToolsSchemaFunction function;
   private AdHocToolsSchemaFunction functionWithGatewayToolDefinitionResolvers;
+  private CamundaClientProcessDefinitionAdHocToolElementsResolver toolElementsResolver;
 
   private String bpmnXml;
 
@@ -80,7 +81,7 @@ class AdHocToolsSchemaFunctionIntegrationTest {
             camundaClient,
             new AgenticAiConnectorsConfigurationProperties.RetriesProperties(
                 4, Duration.ofMillis(500)));
-    final var toolElementsResolver =
+    toolElementsResolver =
         new CamundaClientProcessDefinitionAdHocToolElementsResolver(
             procsssDefinitionClient, parameterExtractor);
 
@@ -150,6 +151,11 @@ class AdHocToolsSchemaFunctionIntegrationTest {
                 .name("A_Complex_Tool")
                 .description("A very complex tool")
                 .inputSchema(EXPECTED_EMPTY_SCHEMA)
+                .build(),
+            ToolDefinition.builder()
+                .name("Tool_With_Spec")
+                .description("A tool with external input spec")
+                .inputSchema(EXPECTED_EMPTY_SCHEMA)
                 .build());
 
     assertThat(result.toolDefinitions())
@@ -197,6 +203,11 @@ class AdHocToolsSchemaFunctionIntegrationTest {
             ToolDefinition.builder()
                 .name("An_Event")
                 .description("An event!")
+                .inputSchema(EXPECTED_EMPTY_SCHEMA)
+                .build(),
+            ToolDefinition.builder()
+                .name("Tool_With_Spec")
+                .description("A tool with external input spec")
                 .inputSchema(EXPECTED_EMPTY_SCHEMA)
                 .build());
     assertThat(result.toolDefinitions())
@@ -346,6 +357,35 @@ class AdHocToolsSchemaFunctionIntegrationTest {
               assertThat(e.getErrorCode()).isEqualTo("AD_HOC_TOOL_SCHEMA_INVALID");
               assertThat(e.getMessage()).isEqualTo("I can't generate this schema");
             });
+  }
+
+  @Test
+  void extractsParametersFromExternalInputSpec() {
+    // given
+    when(camundaClient.newProcessDefinitionGetXmlRequest(PROCESS_DEFINITION_KEY).send().join())
+        .thenReturn(bpmnXml);
+
+    // when — call resolver directly to inspect the extracted parameters
+    final var elements =
+        toolElementsResolver.resolveToolElements(PROCESS_DEFINITION_KEY, AD_HOC_SUB_PROCESS_ID);
+
+    // then
+    final var toolWithSpec =
+        elements.stream()
+            .filter(e -> "Tool_With_Spec".equals(e.elementId()))
+            .findFirst()
+            .orElseThrow(() -> new AssertionError("Tool_With_Spec element not found"));
+
+    assertThat(toolWithSpec.parameters())
+        .containsExactly(
+            new AdHocToolElementParameter(
+                "toolCall.userId", "The user ID", "string", null, Map.of("required", true)),
+            new AdHocToolElementParameter(
+                "toolCall.count",
+                "The count",
+                "integer",
+                Map.of("minimum", 0),
+                Map.of("required", false)));
   }
 
   private OutboundConnectorContext outboundConnectorContext(

--- a/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/AiAgentResponseListenerDelegationTest.java
+++ b/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/AiAgentResponseListenerDelegationTest.java
@@ -175,7 +175,7 @@ class AiAgentResponseListenerDelegationTest {
     @Test
     void onJobCompleted_invokesAgentListenerCarriedByResponse() {
       var listener = mock(AgentJobCompletionListener.class);
-      var function = new AiAgentJobWorker(null);
+      var function = new AiAgentJobWorker(null, null);
       var response =
           AiAgentSubProcessConnectorResponse.builder()
               .variables(Map.of())
@@ -193,7 +193,7 @@ class AiAgentResponseListenerDelegationTest {
     @Test
     void onJobCompletionFailed_invokesAgentListenerCarriedByResponse() {
       var listener = mock(AgentJobCompletionListener.class);
-      var function = new AiAgentJobWorker(null);
+      var function = new AiAgentJobWorker(null, null);
       var response =
           AiAgentSubProcessConnectorResponse.builder()
               .variables(Map.of())
@@ -212,7 +212,7 @@ class AiAgentResponseListenerDelegationTest {
 
     @Test
     void onJobCompletionFailed_noOpWhenResponseIsNull() {
-      var function = new AiAgentJobWorker(null);
+      var function = new AiAgentJobWorker(null, null);
       var listener = mock(AgentJobCompletionListener.class);
 
       function.onJobCompletionFailed(

--- a/connectors/agentic-ai/src/test/resources/ad-hoc-tools.bpmn
+++ b/connectors/agentic-ai/src/test/resources/ad-hoc-tools.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1gx9y68" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.34.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.8.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:specext="http://camunda.org/schema/spec-extension/1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1gx9y68" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.34.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.8.0">
   <bpmn:process id="Agentic_AI_Connectors" isExecutable="true">
     <bpmn:startEvent id="StartEvent_1">
       <bpmn:outgoing>Flow_0yrziwn</bpmn:outgoing>
@@ -48,6 +48,16 @@
         <bpmn:documentation>A simple tool</bpmn:documentation>
         <bpmn:extensionElements>
           <zeebe:script expression="=now()" resultVariable="toolCallResult" />
+        </bpmn:extensionElements>
+      </bpmn:scriptTask>
+      <bpmn:scriptTask id="Tool_With_Spec" name="Tool with spec">
+        <bpmn:documentation>A tool with external input spec</bpmn:documentation>
+        <bpmn:extensionElements>
+          <zeebe:script expression="=now()" resultVariable="toolCallResult" />
+          <specext:externalParameters>
+            <specext:inputSpecification name="userId" description="The user ID" type="string" required="true" />
+            <specext:inputSpecification name="count" description="The count" type="integer" required="false" schema="{&quot;minimum&quot;:0}" />
+          </specext:externalParameters>
         </bpmn:extensionElements>
       </bpmn:scriptTask>
       <bpmn:task id="Event_Follow_Up_Task" name="Event follow-up task">


### PR DESCRIPTION
**NOTE: this is just an experiment**

## Description

Resolves `externalParameters` in tool elements to create tool input schemas. This supersedes `fromAi` resolution if provided.

## Related issues

related to https://github.com/camunda/camunda/issues/52186