### PR TITLE
fix(etg): Ignore static fields

### DIFF
--- a/connector-commons/connector-utils/src/main/java/io/camunda/connector/util/reflection/ReflectionUtil.java
+++ b/connector-commons/connector-utils/src/main/java/io/camunda/connector/util/reflection/ReflectionUtil.java
@@ -54,10 +54,27 @@ public class ReflectionUtil {
     return annotation;
   }
 
+  /**
+   * Returns all non-static (instance) fields declared in the given type and its superclasses.
+   * Static fields are excluded to prevent constants from being treated as connector properties
+   * during element template generation.
+   *
+   * @param type the class to inspect
+   * @return a list of all non-static fields in the type hierarchy
+   */
   public static List<Field> getAllFields(Class<?> type) {
     return getAllFields(new ArrayList<>(), type);
   }
 
+  /**
+   * Collects all non-static (instance) fields declared in the given type and its superclasses into
+   * the provided list. Static fields are excluded to prevent constants from being treated as
+   * connector properties during element template generation.
+   *
+   * @param fields the list to accumulate fields into
+   * @param type the class to inspect
+   * @return the same list with all non-static fields added
+   */
   public static List<Field> getAllFields(List<Field> fields, Class<?> type) {
     for (Field field : type.getDeclaredFields()) {
       if (!Modifier.isStatic(field.getModifiers())) {

--- a/connector-commons/connector-utils/src/main/java/io/camunda/connector/util/reflection/ReflectionUtil.java
+++ b/connector-commons/connector-utils/src/main/java/io/camunda/connector/util/reflection/ReflectionUtil.java
@@ -22,6 +22,7 @@ import io.camunda.connector.api.annotation.Variable;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 import java.lang.reflect.Parameter;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -58,8 +59,11 @@ public class ReflectionUtil {
   }
 
   public static List<Field> getAllFields(List<Field> fields, Class<?> type) {
-    fields.addAll(Arrays.asList(type.getDeclaredFields()));
-
+    for (Field field : type.getDeclaredFields()) {
+      if (!Modifier.isStatic(field.getModifiers())) {
+        fields.add(field);
+      }
+    }
     if (type.getSuperclass() != null) {
       getAllFields(fields, type.getSuperclass());
     }

--- a/connector-commons/connector-utils/src/main/java/io/camunda/connector/util/reflection/ReflectionUtil.java
+++ b/connector-commons/connector-utils/src/main/java/io/camunda/connector/util/reflection/ReflectionUtil.java
@@ -54,27 +54,10 @@ public class ReflectionUtil {
     return annotation;
   }
 
-  /**
-   * Returns all non-static (instance) fields declared in the given type and its superclasses.
-   * Static fields are excluded to prevent constants from being treated as connector properties
-   * during element template generation.
-   *
-   * @param type the class to inspect
-   * @return a list of all non-static fields in the type hierarchy
-   */
   public static List<Field> getAllFields(Class<?> type) {
     return getAllFields(new ArrayList<>(), type);
   }
 
-  /**
-   * Collects all non-static (instance) fields declared in the given type and its superclasses into
-   * the provided list. Static fields are excluded to prevent constants from being treated as
-   * connector properties during element template generation.
-   *
-   * @param fields the list to accumulate fields into
-   * @param type the class to inspect
-   * @return the same list with all non-static fields added
-   */
   public static List<Field> getAllFields(List<Field> fields, Class<?> type) {
     for (Field field : type.getDeclaredFields()) {
       if (!Modifier.isStatic(field.getModifiers())) {

--- a/connectors/microsoft/teams/element-templates/hybrid/microsoft-teams-outbound-connector-hybrid.json
+++ b/connectors/microsoft/teams/element-templates/hybrid/microsoft-teams-outbound-connector-hybrid.json
@@ -52,26 +52,6 @@
     },
     "type" : "String"
   }, {
-    "id" : "data.EXPAND_VALUE",
-    "label" : "EXPAND_VALUE",
-    "feel" : "optional",
-    "binding" : {
-      "name" : "data.EXPAND_VALUE",
-      "type" : "zeebe:input"
-    },
-    "condition" : {
-      "allMatch" : [ {
-        "property" : "data.channelMethod",
-        "equals" : "listChannelMessages",
-        "type" : "simple"
-      }, {
-        "property" : "data.type",
-        "equals" : "channel",
-        "type" : "simple"
-      } ]
-    },
-    "type" : "String"
-  }, {
     "id" : "authentication.type",
     "label" : "Type",
     "description" : "Authentication type depends on your Microsoft Entra (Azure AD) configuration. See <a href='https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/microsoft-teams/'>connector documentation</a>",

--- a/connectors/microsoft/teams/element-templates/microsoft-teams-outbound-connector.json
+++ b/connectors/microsoft/teams/element-templates/microsoft-teams-outbound-connector.json
@@ -47,26 +47,6 @@
     },
     "type" : "Hidden"
   }, {
-    "id" : "data.EXPAND_VALUE",
-    "label" : "EXPAND_VALUE",
-    "feel" : "optional",
-    "binding" : {
-      "name" : "data.EXPAND_VALUE",
-      "type" : "zeebe:input"
-    },
-    "condition" : {
-      "allMatch" : [ {
-        "property" : "data.channelMethod",
-        "equals" : "listChannelMessages",
-        "type" : "simple"
-      }, {
-        "property" : "data.type",
-        "equals" : "channel",
-        "type" : "simple"
-      } ]
-    },
-    "type" : "String"
-  }, {
     "id" : "authentication.type",
     "label" : "Type",
     "description" : "Authentication type depends on your Microsoft Entra (Azure AD) configuration. See <a href='https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/microsoft-teams/'>connector documentation</a>",

--- a/element-template-generator/core/src/test/java/io/camunda/connector/generator/java/OutboundClassBasedTemplateGeneratorTest.java
+++ b/element-template-generator/core/src/test/java/io/camunda/connector/generator/java/OutboundClassBasedTemplateGeneratorTest.java
@@ -644,8 +644,7 @@ public class OutboundClassBasedTemplateGeneratorTest extends BaseTest {
 
     @Test
     void staticFields_areNotGeneratedAsProperties() {
-      var template =
-          generator.generate(MyConnectorFunction.WithStaticFields.class).getFirst();
+      var template = generator.generate(MyConnectorFunction.WithStaticFields.class).getFirst();
       var propertyIds =
           template.properties().stream().map(Property::getId).collect(Collectors.toSet());
 

--- a/element-template-generator/core/src/test/java/io/camunda/connector/generator/java/OutboundClassBasedTemplateGeneratorTest.java
+++ b/element-template-generator/core/src/test/java/io/camunda/connector/generator/java/OutboundClassBasedTemplateGeneratorTest.java
@@ -33,6 +33,7 @@ import io.camunda.connector.generator.dsl.DropdownProperty.DropdownChoice;
 import io.camunda.connector.generator.dsl.ElementTemplate.ElementTypeWrapper;
 import io.camunda.connector.generator.dsl.HiddenProperty;
 import io.camunda.connector.generator.dsl.NumberProperty;
+import io.camunda.connector.generator.dsl.Property;
 import io.camunda.connector.generator.dsl.PropertyBinding;
 import io.camunda.connector.generator.dsl.PropertyBinding.ZeebeInput;
 import io.camunda.connector.generator.dsl.PropertyBinding.ZeebeTaskDefinition;
@@ -639,6 +640,17 @@ public class OutboundClassBasedTemplateGeneratorTest extends BaseTest {
                 assertThat(p.getValue()).isEqualTo("value2");
                 assertThat(p.getCondition()).isEqualTo(new Equals("booleanProperty", false));
               });
+    }
+
+    @Test
+    void staticFields_areNotGeneratedAsProperties() {
+      var template =
+          generator.generate(MyConnectorFunction.WithStaticFields.class).getFirst();
+      var propertyIds =
+          template.properties().stream().map(Property::getId).collect(Collectors.toSet());
+
+      assertThat(propertyIds).contains("instanceField");
+      assertThat(propertyIds).doesNotContain("STATIC_CONSTANT");
     }
   }
 

--- a/element-template-generator/core/src/test/java/io/camunda/connector/generator/java/example/outbound/MyConnectorFunction.java
+++ b/element-template-generator/core/src/test/java/io/camunda/connector/generator/java/example/outbound/MyConnectorFunction.java
@@ -160,6 +160,18 @@ public abstract class MyConnectorFunction implements OutboundConnectorFunction {
       engineVersion = "^8.7",
       id = MyConnectorFunction.ID,
       name = MyConnectorFunction.NAME,
+      inputDataClass = StaticFieldInput.class)
+  public static class WithStaticFields extends MyConnectorFunction {
+    record StaticFieldInput(String instanceField) {
+      static final String STATIC_CONSTANT = "constant";
+    }
+  }
+
+  @OutboundConnector(name = "my-connector", type = "my-connector-type")
+  @ElementTemplate(
+      engineVersion = "^8.7",
+      id = MyConnectorFunction.ID,
+      name = MyConnectorFunction.NAME,
       inputDataClass = MyConnectorInput.class,
       elementTypes = {
         @ConnectorElementType(appliesTo = BpmnType.TASK, elementType = BpmnType.SERVICE_TASK),

--- a/element-template-generator/core/src/test/java/io/camunda/connector/generator/java/example/outbound/MyConnectorFunction.java
+++ b/element-template-generator/core/src/test/java/io/camunda/connector/generator/java/example/outbound/MyConnectorFunction.java
@@ -26,6 +26,7 @@ import io.camunda.connector.generator.java.annotation.ElementTemplate;
 import io.camunda.connector.generator.java.annotation.ElementTemplate.ConnectorElementType;
 import io.camunda.connector.generator.java.annotation.ElementTemplate.PropertyGroup;
 import io.camunda.connector.generator.java.annotation.TemplateProperty;
+import io.camunda.connector.generator.java.example.outbound.MyConnectorFunction.WithStaticFields.StaticFieldInput;
 
 public abstract class MyConnectorFunction implements OutboundConnectorFunction {
 


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

Remove static fields from ETG. Only affected connector is microsoft team, which had this one property added, which was never displayed as the condition could not be true (wrong order).

## Checklist

- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest
  release, as this branch will be rebased onto main before the next release. Example backport labels:
    - `backport stable/8.8`: for changes that should be included in the next 8.8.x release.
    - **or** `backport release-8.8.7`: for changes that should be included in the specific release 8.8.7, and this
      *release has already been created*. The release branch will be merged back into stable/8.8 later, so the change
      will be included in future 8.8.x releases as well.
- [ ] Tests/Integration tests for the changes have been added if applicable.
- [ ] If the change requires a documentation update, it has been added to the appropriate section in the documentation.


