### PR TITLE
other(dx): Add validator for element templates

### DIFF
--- a/element-template-generator/pom.xml
+++ b/element-template-generator/pom.xml
@@ -26,6 +26,7 @@
     <module>openapi-parser</module>
     <module>postman-collections-parser</module>
     <module>uniquet</module>
+    <module>validator</module>
   </modules>
 
 </project>

--- a/element-template-generator/validator/README.md
+++ b/element-template-generator/validator/README.md
@@ -20,9 +20,19 @@ This produces an appassembler launcher at
 
 # scan a specific directory (overrides the default ./connectors)
 ./.../element-template-validator -d path/to/connectors
+
+# override the JSON-schema URL (e.g. point at a local copy)
+./.../element-template-validator --schema-url file:///path/to/schema.json
+# or via env var:
+CAMUNDA_TEMPLATE_SCHEMA_URL=file:///path/to/schema.json ./.../element-template-validator
 ```
 
 Exit code is `0` if no findings, `1` otherwise.
+
+The schema URL defaults to a **pinned** version
+(`@camunda/zeebe-element-templates-json-schema@<version>`) so validator behavior is reproducible
+across CI runs and local machines. Bump the constant in `SchemaRule.SCHEMA_VERSION` deliberately,
+in lockstep with the connectors-team upgrade.
 
 Files inside any `versioned/` directory are skipped by the single-file rules — they represent
 frozen historical releases and are not modifiable retroactively. Multi-file rules still see them.

--- a/element-template-generator/validator/README.md
+++ b/element-template-generator/validator/README.md
@@ -1,0 +1,76 @@
+# Element Template Validator
+
+Validates Camunda element templates (`connectors/**/element-templates/**/*.json`) against the
+upstream JSON schema and a set of semantic rules.
+
+## Build
+
+```bash
+mvn package -DskipTests -pl element-template-generator/validator -am
+```
+
+This produces an appassembler launcher at
+`element-template-generator/validator/target/appassembler/bin/element-template-validator`.
+
+## Run
+
+```bash
+# from the repo root, scans every element-templates/*.json under ./connectors
+./element-template-generator/validator/target/appassembler/bin/element-template-validator
+
+# scan a specific directory (overrides the default ./connectors)
+./.../element-template-validator -d path/to/connectors
+```
+
+Exit code is `0` if no findings, `1` otherwise.
+
+Files inside any `versioned/` directory are skipped by the single-file rules — they represent
+frozen historical releases and are not modifiable retroactively. Multi-file rules still see them.
+
+Templates under `connectors/agentic-ai/` are skipped entirely — those are generated/maintained
+outside the standard connector workflow and intentionally diverge from the conventions enforced
+here.
+
+## Rules
+
+### Structural rules (always run; failures short-circuit semantic rules for that file)
+
+| Rule id          | What it checks                                                                                                                                              |
+|------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `json-parse`     | The file is syntactically valid JSON.                                                                                                                       |
+| `duplicate-keys` | No object contains the same key twice. Mirrors the duplicate-key check the Camunda Web Modeler runs at editor save-time. Reports the offending line/column. |
+
+### Single-file rules (run on every non-versioned template)
+
+| Rule id                       | What it checks                                                                                                                                                                                                |
+|-------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `schema`                      | Conformance to the upstream Camunda element-template JSON schema (fetched at startup).                                                                                                                        |
+| `preset-target-exists`        | Each `presets` entry's key references an existing top-level property; if the property declares `choices`, the preset value must be one of them.                                                               |
+| `condition-target-exists`     | Every `property` referenced from a `condition` (simple `{property, equals\|oneOf}` or compound `{allMatch: [...]}`) must exist in the template's top-level `properties[]`.                                    |
+| `condition-value-in-choices`  | When a condition compares against a property that declares `choices`, the `equals` / `oneOf` value(s) must be one of the declared choices. Choice sets are unioned across duplicate ids (lenient by default). |
+| `condition-property-order`    | Any property B with a `condition` (anywhere in its subtree, including nested `choices[*]` and `allMatch`) referencing property A must appear after A in `properties[]`. Forward-references and self-references are flagged. References to non-existent properties are skipped (handled by `condition-target-exists`). |
+| `group-target-exists`         | Each property's `group` must reference a `groups[].id`.                                                                                                                                                       |
+| `default-value-in-choices`    | For Dropdown properties with both a default `value` and a `choices` list, the default must be one of the choices.                                                                                             |
+| `unique-group-id`             | No two `groups[]` entries may share an `id`.                                                                                                                                                                  |
+| `unique-property-id`          | No two `properties[]` entries may share an `id` within the same template. Exception: duplicate-id properties whose visibility `condition`s are pairwise mutually exclusive (same gating `property`, disjoint `equals`/`oneOf` value sets) are tolerated — that's the established "switching" pattern (e.g. one Dropdown variant per parent operationGroup). Properties without a condition are always live, so any duplicate involving an unconditional property is still flagged. |
+| `task-definition-binding-form`| The legacy binding type `zeebe:taskDefinition:type` is not allowed; use the canonical form `{ "type": "zeebe:taskDefinition", "property": "type" }`. The schema accepts both spellings, but generator output and all current templates use the canonical form. |
+| `empty-group`                 | Every declared `groups[].id` must be referenced by at least one property.                                                                                                                                     |
+
+### Multi-file rules (run once over the full set, including `versioned/`)
+
+| Rule id                          | What it checks                                                                                                                                                                                |
+|----------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `hybrid-parity`                  | For every `hybrid/<base>-hybrid.json`, the non-hybrid sibling must exist and declare the same `properties[].id` and `groups[].id`. Known-intentional differences (`taskDefinitionType`, `connectorType` on the hybrid side; `deduplication*`, `consumeUnmatchedEvents`, `messageTtl` on the non-hybrid side) are allowlisted. |
+| `versioned-template-consistency` | For each `versioned/<base>-<N>.json`, the file's `version` field must equal `N`. Files whose filename suffix starts with `0` (e.g. `-0`, `-01`, `-02`) are pre-versioning snapshots — a missing `version` field is tolerated, but a present one must still match. |
+| `current-version-bump`           | For each non-versioned template, the `version` field must be exactly one higher than the highest-versioned snapshot under the same `element-templates/` subtree that shares the same `id`. If no snapshot shares the id (e.g. an intentional `.vN` → `.v(N+1)` rename starts a new lineage), the rule is silent. |
+| `unique-id-version`              | No two templates (current or versioned) may share both the same `id` and the same `version`. The Modeler dedupes by id+version on import, so duplicates collide silently. Catches snapshots that weren't promoted to a new version and content changes that forgot to bump the version. |
+
+The schema rule runs first as a gate. If it produces findings for a file, semantic
+rules are skipped for that file to avoid noisy cascades.
+
+## Adding a rule
+
+1. Implement `io.camunda.connector.validator.core.Rule` (single-file) or
+   `io.camunda.connector.validator.core.MultiFileRule` (cross-file).
+2. Add it to the corresponding list in `ValidatorCommand`.
+3. Write a fixture-driven unit test in `src/test/java/.../rule/`.

--- a/element-template-generator/validator/README.md
+++ b/element-template-generator/validator/README.md
@@ -20,14 +20,35 @@ This produces an appassembler launcher at
 
 # scan a specific directory (overrides the default ./connectors)
 ./.../element-template-validator -d path/to/connectors
-
-# override the JSON-schema URL (e.g. point at a local copy)
-./.../element-template-validator --schema-url file:///path/to/schema.json
-# or via env var:
-CAMUNDA_TEMPLATE_SCHEMA_URL=file:///path/to/schema.json ./.../element-template-validator
 ```
 
 Exit code is `0` if no findings, `1` otherwise.
+
+### Options
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `-d`, `--directory` | `./connectors` | Root directory to scan for `element-templates/*.json` files. |
+| `--schema-url` | pinned unpkg.com URL | HTTP/HTTPS URL of the JSON schema. Falls back to `CAMUNDA_TEMPLATE_SCHEMA_URL` env var, then the pinned default. Only `http`/`https` URLs are supported. |
+| `--skip-directory` | `target, node_modules, .git, .idea, .m2` | Directory names pruned during traversal (by exact name, not path). Repeatable or comma-separated. When specified, replaces the default set entirely. |
+| `--skip-connector` | `agentic-ai` | Connector directory names skipped entirely. Repeatable or comma-separated. When specified, replaces the default set entirely. |
+| `--no-color` | off | Disable ANSI color in the output. Color is also auto-disabled when no console is attached (e.g. when output is piped or captured by CI). |
+
+```bash
+# override the schema URL
+./.../element-template-validator --schema-url https://example.com/schema.json
+# or via env var:
+CAMUNDA_TEMPLATE_SCHEMA_URL=https://example.com/schema.json ./.../element-template-validator
+
+# add a custom directory to skip (replaces the default set — include defaults if you still want them)
+./.../element-template-validator --skip-directory target,node_modules,.git,.idea,.m2,my-dir
+
+# skip an additional connector
+./.../element-template-validator --skip-connector agentic-ai --skip-connector my-connector
+
+# disable color (e.g. when piping output)
+./.../element-template-validator --no-color | tee report.txt
+```
 
 The schema URL defaults to a **pinned** version
 (`@camunda/zeebe-element-templates-json-schema@<version>`) so validator behavior is reproducible
@@ -37,9 +58,9 @@ in lockstep with the connectors-team upgrade.
 Files inside any `versioned/` directory are skipped by the single-file rules — they represent
 frozen historical releases and are not modifiable retroactively. Multi-file rules still see them.
 
-Templates under `connectors/agentic-ai/` are skipped entirely — those are generated/maintained
-outside the standard connector workflow and intentionally diverge from the conventions enforced
-here.
+Connector directories listed in `--skip-connector` are skipped entirely. The default (`agentic-ai`)
+covers templates generated/maintained outside the standard connector workflow that intentionally
+diverge from the conventions enforced here.
 
 ## Rules
 

--- a/element-template-generator/validator/pom.xml
+++ b/element-template-generator/validator/pom.xml
@@ -1,0 +1,122 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>io.camunda.connector</groupId>
+    <artifactId>element-template-generator-parent</artifactId>
+    <relativePath>../pom.xml</relativePath>
+    <version>8.10.0-SNAPSHOT</version>
+  </parent>
+
+  <name>Element Template Validator</name>
+  <description>Validates Camunda element templates against the JSON schema and custom semantic rules</description>
+  <artifactId>element-template-validator</artifactId>
+  <packaging>jar</packaging>
+
+  <properties>
+    <maven.compiler.source>21</maven.compiler.source>
+    <maven.compiler.target>21</maven.compiler.target>
+    <version.picocli>4.7.7</version.picocli>
+    <version.json-schema-validator>1.5.4</version.json-schema-validator>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>info.picocli</groupId>
+      <artifactId>picocli</artifactId>
+      <version>${version.picocli}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>com.networknt</groupId>
+      <artifactId>json-schema-validator</artifactId>
+      <version>${version.json-schema-validator}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-nop</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <annotationProcessorPaths>
+            <path>
+              <groupId>info.picocli</groupId>
+              <artifactId>picocli-codegen</artifactId>
+              <version>4.7.7</version>
+            </path>
+          </annotationProcessorPaths>
+          <compilerArgs>
+            <arg>-Aproject=${project.groupId}/${project.artifactId}</arg>
+          </compilerArgs>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>appassembler-maven-plugin</artifactId>
+        <version>2.1.0</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>assemble</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <programs>
+            <program>
+              <mainClass>io.camunda.connector.validator.Main</mainClass>
+              <id>element-template-validator</id>
+            </program>
+          </programs>
+        </configuration>
+      </plugin>
+      <plugin>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>analyze-dependencies</id>
+            <configuration>
+              <ignoredDependencies>
+                <ignoredDependency>org.slf4j:slf4j-nop</ignoredDependency>
+              </ignoredDependencies>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/element-template-generator/validator/src/main/java/io/camunda/connector/validator/Main.java
+++ b/element-template-generator/validator/src/main/java/io/camunda/connector/validator/Main.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.validator;
+
+import io.camunda.connector.validator.command.ValidatorCommand;
+import picocli.CommandLine;
+
+public class Main {
+  public static void main(String[] args) {
+    int exitCode = new CommandLine(new ValidatorCommand()).execute(args);
+    System.exit(exitCode);
+  }
+}

--- a/element-template-generator/validator/src/main/java/io/camunda/connector/validator/command/ValidatorCommand.java
+++ b/element-template-generator/validator/src/main/java/io/camunda/connector/validator/command/ValidatorCommand.java
@@ -42,8 +42,10 @@ import io.camunda.connector.validator.rule.VersionedTemplateConsistencyRule;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.Callable;
 import picocli.CommandLine;
 
@@ -60,6 +62,35 @@ public class ValidatorCommand implements Callable<Integer> {
   private Path root = Path.of("connectors");
 
   @CommandLine.Option(
+      names = "--skip-directory",
+      split = ",",
+      description =
+          "Directory names pruned during template discovery (by exact name, not path). "
+              + "Repeatable; comma-separated values are also accepted. "
+              + "When specified, replaces the default set entirely. "
+              + "Default: target, node_modules, .git, .idea, .m2.")
+  private Set<String> skippedDirectories =
+      new LinkedHashSet<>(TemplateFinder.DEFAULT_SKIPPED_DIRECTORIES);
+
+  @CommandLine.Option(
+      names = "--skip-connector",
+      split = ",",
+      description =
+          "Connector directory names whose templates are skipped entirely (by exact name, not path). "
+              + "Repeatable; comma-separated values are also accepted. "
+              + "When specified, replaces the default set entirely. "
+              + "Default: agentic-ai.")
+  private Set<String> skippedConnectors =
+      new LinkedHashSet<>(TemplateFinder.DEFAULT_SKIPPED_CONNECTORS);
+
+  @CommandLine.Option(
+      names = "--no-color",
+      description =
+          "Disable ANSI color in the output. Color is auto-disabled when no console is attached "
+              + "(e.g. when output is redirected to a file or CI log capture).")
+  private boolean noColor;
+
+  @CommandLine.Option(
       names = "--schema-url",
       description =
           "Override the JSON-schema URL used by the schema rule. If unset, falls back to the "
@@ -71,7 +102,7 @@ public class ValidatorCommand implements Callable<Integer> {
 
   @Override
   public Integer call() {
-    List<Path> all = TemplateFinder.findAll(root);
+    List<Path> all = TemplateFinder.findAll(root, skippedDirectories, skippedConnectors);
     if (all.isEmpty()) {
       System.out.printf("No element-templates/*.json files found under %s%n", root);
       return 0;
@@ -86,7 +117,8 @@ public class ValidatorCommand implements Callable<Integer> {
     findings.addAll(runSingleFileRules(templates, schemaRule));
     findings.addAll(runMultiFileRules(templates));
 
-    ReportPrinter.print(findings, templates.size(), System.out);
+    boolean colorEnabled = !noColor && System.console() != null;
+    ReportPrinter.print(findings, templates.size(), System.out, colorEnabled);
     return findings.stream().anyMatch(f -> f.severity() == Severity.ERROR) ? 1 : 0;
   }
 

--- a/element-template-generator/validator/src/main/java/io/camunda/connector/validator/command/ValidatorCommand.java
+++ b/element-template-generator/validator/src/main/java/io/camunda/connector/validator/command/ValidatorCommand.java
@@ -59,6 +59,16 @@ public class ValidatorCommand implements Callable<Integer> {
           "Root directory to scan for element-templates/*.json files. Defaults to ./connectors.")
   private Path root = Path.of("connectors");
 
+  @CommandLine.Option(
+      names = "--schema-url",
+      description =
+          "Override the JSON-schema URL used by the schema rule. If unset, falls back to the "
+              + "CAMUNDA_TEMPLATE_SCHEMA_URL environment variable, then to the pinned default "
+              + "(zeebe-element-templates-json-schema@"
+              + SchemaRule.SCHEMA_VERSION
+              + ").")
+  private String schemaUrl;
+
   @Override
   public Integer call() {
     List<Path> all = TemplateFinder.findAll(root);
@@ -72,11 +82,23 @@ public class ValidatorCommand implements Callable<Integer> {
 
     Map<Path, JsonNode> templates = loaded.templates();
 
-    findings.addAll(runSingleFileRules(templates));
+    SchemaRule schemaRule = new SchemaRule(resolveSchemaUrl());
+    findings.addAll(runSingleFileRules(templates, schemaRule));
     findings.addAll(runMultiFileRules(templates));
 
     ReportPrinter.print(findings, templates.size(), System.out);
     return findings.stream().anyMatch(f -> f.severity() == Severity.ERROR) ? 1 : 0;
+  }
+
+  private String resolveSchemaUrl() {
+    if (schemaUrl != null && !schemaUrl.isBlank()) {
+      return schemaUrl;
+    }
+    String fromEnv = System.getenv("CAMUNDA_TEMPLATE_SCHEMA_URL");
+    if (fromEnv != null && !fromEnv.isBlank()) {
+      return fromEnv;
+    }
+    return SchemaRule.SCHEMA_URL;
   }
 
   private static LoadResult loadTemplates(List<Path> all) {
@@ -93,8 +115,7 @@ public class ValidatorCommand implements Callable<Integer> {
     return new LoadResult(templates, parseFindings);
   }
 
-  private static List<Finding> runSingleFileRules(Map<Path, JsonNode> templates) {
-    Rule schema = new SchemaRule();
+  private static List<Finding> runSingleFileRules(Map<Path, JsonNode> templates, Rule schema) {
     List<Rule> rules =
         List.of(
             new PresetTargetExistsRule(),

--- a/element-template-generator/validator/src/main/java/io/camunda/connector/validator/command/ValidatorCommand.java
+++ b/element-template-generator/validator/src/main/java/io/camunda/connector/validator/command/ValidatorCommand.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.validator.command;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.camunda.connector.validator.core.Finding;
+import io.camunda.connector.validator.core.MultiFileRule;
+import io.camunda.connector.validator.core.ReportPrinter;
+import io.camunda.connector.validator.core.Rule;
+import io.camunda.connector.validator.core.Severity;
+import io.camunda.connector.validator.core.TemplateFinder;
+import io.camunda.connector.validator.core.TemplateLoader;
+import io.camunda.connector.validator.rule.ConditionPropertyOrderRule;
+import io.camunda.connector.validator.rule.ConditionTargetExistsRule;
+import io.camunda.connector.validator.rule.ConditionValueInChoicesRule;
+import io.camunda.connector.validator.rule.CurrentVersionBumpRule;
+import io.camunda.connector.validator.rule.DefaultValueInChoicesRule;
+import io.camunda.connector.validator.rule.EmptyGroupRule;
+import io.camunda.connector.validator.rule.GroupTargetExistsRule;
+import io.camunda.connector.validator.rule.HybridParityRule;
+import io.camunda.connector.validator.rule.PresetTargetExistsRule;
+import io.camunda.connector.validator.rule.SchemaRule;
+import io.camunda.connector.validator.rule.TaskDefinitionBindingFormRule;
+import io.camunda.connector.validator.rule.UniqueGroupIdRule;
+import io.camunda.connector.validator.rule.UniqueIdVersionRule;
+import io.camunda.connector.validator.rule.UniquePropertyIdRule;
+import io.camunda.connector.validator.rule.VersionedTemplateConsistencyRule;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Callable;
+import picocli.CommandLine;
+
+@CommandLine.Command(
+    name = "element-template-validator",
+    description = "Validates Camunda element templates against schema and semantic rules.",
+    mixinStandardHelpOptions = true)
+public class ValidatorCommand implements Callable<Integer> {
+
+  @CommandLine.Option(
+      names = {"-d", "--directory"},
+      description =
+          "Root directory to scan for element-templates/*.json files. Defaults to ./connectors.")
+  private Path root = Path.of("connectors");
+
+  @Override
+  public Integer call() {
+    List<Path> all = TemplateFinder.findAll(root);
+    if (all.isEmpty()) {
+      System.out.printf("No element-templates/*.json files found under %s%n", root);
+      return 0;
+    }
+
+    LoadResult loaded = loadTemplates(all);
+    List<Finding> findings = new ArrayList<>(loaded.parseFindings());
+
+    Map<Path, JsonNode> templates = loaded.templates();
+
+    findings.addAll(runSingleFileRules(templates));
+    findings.addAll(runMultiFileRules(templates));
+
+    ReportPrinter.print(findings, templates.size(), System.out);
+    return findings.stream().anyMatch(f -> f.severity() == Severity.ERROR) ? 1 : 0;
+  }
+
+  private static LoadResult loadTemplates(List<Path> all) {
+    Map<Path, JsonNode> templates = new LinkedHashMap<>();
+    List<Finding> parseFindings = new ArrayList<>();
+    for (Path path : all) {
+      TemplateLoader.Result result = TemplateLoader.load(path);
+      if (result.ok()) {
+        templates.put(path, result.node());
+      } else {
+        parseFindings.add(result.finding());
+      }
+    }
+    return new LoadResult(templates, parseFindings);
+  }
+
+  private static List<Finding> runSingleFileRules(Map<Path, JsonNode> templates) {
+    Rule schema = new SchemaRule();
+    List<Rule> rules =
+        List.of(
+            new PresetTargetExistsRule(),
+            new ConditionTargetExistsRule(),
+            new ConditionValueInChoicesRule(),
+            new ConditionPropertyOrderRule(),
+            new GroupTargetExistsRule(),
+            new DefaultValueInChoicesRule(),
+            new UniqueGroupIdRule(),
+            new UniquePropertyIdRule(),
+            new EmptyGroupRule(),
+            new TaskDefinitionBindingFormRule());
+    List<Finding> findings = new ArrayList<>();
+    for (Map.Entry<Path, JsonNode> entry : templates.entrySet()) {
+      Path path = entry.getKey();
+      if (TemplateFinder.isVersioned(path)) {
+        continue;
+      }
+      JsonNode tree = entry.getValue();
+      // Schema rule runs first; if it produces findings, skip semantic rules for that file
+      // to avoid cascades of noisy follow-on errors.
+      List<Finding> schemaFindings = schema.apply(path, tree);
+      findings.addAll(schemaFindings);
+      if (!schemaFindings.isEmpty()) {
+        continue;
+      }
+      for (Rule rule : rules) {
+        findings.addAll(rule.apply(path, tree));
+      }
+    }
+    return findings;
+  }
+
+  private static List<Finding> runMultiFileRules(Map<Path, JsonNode> templates) {
+    List<MultiFileRule> multiFileRules =
+        List.of(
+            new HybridParityRule(),
+            new VersionedTemplateConsistencyRule(),
+            new CurrentVersionBumpRule(),
+            new UniqueIdVersionRule());
+    List<Finding> findings = new ArrayList<>();
+    for (MultiFileRule rule : multiFileRules) {
+      findings.addAll(rule.apply(templates));
+    }
+    return findings;
+  }
+
+  private record LoadResult(Map<Path, JsonNode> templates, List<Finding> parseFindings) {}
+}

--- a/element-template-generator/validator/src/main/java/io/camunda/connector/validator/core/ElementTemplate.java
+++ b/element-template-generator/validator/src/main/java/io/camunda/connector/validator/core/ElementTemplate.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.validator.core;
+
+/** JSON field names used in the Camunda element-template schema. */
+public final class ElementTemplate {
+
+  private ElementTemplate() {}
+
+  public static final String PROPERTIES = "properties";
+  public static final String GROUPS = "groups";
+  public static final String ID = "id";
+  public static final String VERSION = "version";
+
+  public static final String CHOICES = "choices";
+  public static final String VALUE = "value";
+  public static final String TYPE = "type";
+  public static final String GROUP = "group";
+
+  public static final String CONDITION = "condition";
+  public static final String PROPERTY = "property";
+  public static final String EQUALS = "equals";
+  public static final String ONE_OF = "oneOf";
+  public static final String ALL_MATCH = "allMatch";
+
+  public static final String PRESETS = "presets";
+  public static final String BINDING = "binding";
+}

--- a/element-template-generator/validator/src/main/java/io/camunda/connector/validator/core/Finding.java
+++ b/element-template-generator/validator/src/main/java/io/camunda/connector/validator/core/Finding.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.validator.core;
+
+import java.nio.file.Path;
+
+public record Finding(
+    Path file, String jsonPointer, String ruleId, Severity severity, String message) {
+
+  public static Finding error(Path file, String jsonPointer, String ruleId, String message) {
+    return new Finding(file, jsonPointer, ruleId, Severity.ERROR, message);
+  }
+}

--- a/element-template-generator/validator/src/main/java/io/camunda/connector/validator/core/JsonPointers.java
+++ b/element-template-generator/validator/src/main/java/io/camunda/connector/validator/core/JsonPointers.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.validator.core;
+
+public final class JsonPointers {
+
+  private JsonPointers() {}
+
+  /** RFC 6901 reference-token escaping: '~' → '~0' and '/' → '~1'. */
+  public static String escape(String segment) {
+    return segment.replace("~", "~0").replace("/", "~1");
+  }
+}

--- a/element-template-generator/validator/src/main/java/io/camunda/connector/validator/core/MultiFileRule.java
+++ b/element-template-generator/validator/src/main/java/io/camunda/connector/validator/core/MultiFileRule.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.validator.core;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * A rule that needs to look at the full set of templates at once — for example, to compare a
+ * versioned template against its current sibling, or to assert hybrid/non-hybrid parity. The map
+ * passed in covers every template the finder discovered, including those inside {@code versioned/}.
+ */
+public interface MultiFileRule {
+
+  String id();
+
+  List<Finding> apply(Map<Path, JsonNode> templates);
+}

--- a/element-template-generator/validator/src/main/java/io/camunda/connector/validator/core/MultiFileRule.java
+++ b/element-template-generator/validator/src/main/java/io/camunda/connector/validator/core/MultiFileRule.java
@@ -28,7 +28,11 @@ import java.util.Map;
  */
 public interface MultiFileRule {
 
-  String id();
+  default String id() {
+    String name = getClass().getSimpleName();
+    if (name.endsWith("Rule")) name = name.substring(0, name.length() - 4);
+    return name.replaceAll("([A-Z])", "-$1").toLowerCase().replaceFirst("^-", "");
+  }
 
   List<Finding> apply(Map<Path, JsonNode> templates);
 }

--- a/element-template-generator/validator/src/main/java/io/camunda/connector/validator/core/ReportPrinter.java
+++ b/element-template-generator/validator/src/main/java/io/camunda/connector/validator/core/ReportPrinter.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.validator.core;
+
+import java.io.PrintStream;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
+public final class ReportPrinter {
+
+  private ReportPrinter() {}
+
+  public static void print(List<Finding> findings, int filesScanned, PrintStream out) {
+    Map<Path, List<Finding>> byFile = new TreeMap<>();
+    for (Finding f : findings) {
+      byFile.computeIfAbsent(f.file(), k -> new ArrayList<>()).add(f);
+    }
+
+    for (Map.Entry<Path, List<Finding>> e : byFile.entrySet()) {
+      out.println(e.getKey());
+      for (Finding f : e.getValue()) {
+        out.printf("  %-5s  %-32s  %s%n", f.severity(), f.ruleId(), f.jsonPointer());
+        out.printf("         %s%n", f.message());
+      }
+      out.println();
+    }
+
+    if (findings.isEmpty()) {
+      out.printf("Scanned %d template(s). No findings.%n", filesScanned);
+    } else {
+      out.printf(
+          "Scanned %d template(s). %d finding(s) in %d file(s). Run failed.%n",
+          filesScanned, findings.size(), byFile.size());
+    }
+  }
+}

--- a/element-template-generator/validator/src/main/java/io/camunda/connector/validator/core/ReportPrinter.java
+++ b/element-template-generator/validator/src/main/java/io/camunda/connector/validator/core/ReportPrinter.java
@@ -25,29 +25,69 @@ import java.util.TreeMap;
 
 public final class ReportPrinter {
 
+  private static final String RESET = "\033[0m";
+  private static final String BOLD = "\033[1m";
+  private static final String RED = "\033[31m";
+  private static final String YELLOW = "\033[33m";
+  private static final String CYAN = "\033[36m";
+  private static final String GREEN = "\033[32m";
+
   private ReportPrinter() {}
 
-  public static void print(List<Finding> findings, int filesScanned, PrintStream out) {
+  /**
+   * Prints the validation report. Color is enabled when a real console is attached; pass {@code
+   * colorEnabled = false} to suppress (e.g. via {@code --no-color}).
+   */
+  public static void print(
+      List<Finding> findings, int filesScanned, PrintStream out, boolean colorEnabled) {
     Map<Path, List<Finding>> byFile = new TreeMap<>();
     for (Finding f : findings) {
       byFile.computeIfAbsent(f.file(), k -> new ArrayList<>()).add(f);
     }
 
     for (Map.Entry<Path, List<Finding>> e : byFile.entrySet()) {
-      out.println(e.getKey());
+      out.println(color(BOLD, e.getKey().toString(), colorEnabled));
       for (Finding f : e.getValue()) {
-        out.printf("  %-5s  %-32s  %s%n", f.severity(), f.ruleId(), f.jsonPointer());
+        String severity = colorBySeverity(f.severity(), colorEnabled);
+        String ruleId = color(CYAN, f.ruleId(), colorEnabled);
+        out.printf("  %-5s  %-40s  %s%n", severity, ruleId, f.jsonPointer());
         out.printf("         %s%n", f.message());
       }
       out.println();
     }
 
     if (findings.isEmpty()) {
-      out.printf("Scanned %d template(s). No findings.%n", filesScanned);
+      out.println(
+          color(GREEN, "Scanned " + filesScanned + " template(s). No findings.", colorEnabled));
     } else {
-      out.printf(
-          "Scanned %d template(s). %d finding(s) in %d file(s). Run failed.%n",
-          filesScanned, findings.size(), byFile.size());
+      out.println(
+          color(
+              RED,
+              "Scanned "
+                  + filesScanned
+                  + " template(s). "
+                  + findings.size()
+                  + " finding(s) in "
+                  + byFile.size()
+                  + " file(s). Run failed.",
+              colorEnabled));
     }
+  }
+
+  /** Convenience overload — auto-detects color support via {@code System.console()}. */
+  public static void print(List<Finding> findings, int filesScanned, PrintStream out) {
+    print(findings, filesScanned, out, System.console() != null);
+  }
+
+  private static String colorBySeverity(Severity severity, boolean colorEnabled) {
+    String label = severity.name();
+    return switch (severity) {
+      case ERROR -> color(RED, label, colorEnabled);
+      case WARN -> color(YELLOW, label, colorEnabled);
+    };
+  }
+
+  private static String color(String ansi, String text, boolean colorEnabled) {
+    return colorEnabled ? ansi + text + RESET : text;
   }
 }

--- a/element-template-generator/validator/src/main/java/io/camunda/connector/validator/core/Rule.java
+++ b/element-template-generator/validator/src/main/java/io/camunda/connector/validator/core/Rule.java
@@ -22,7 +22,11 @@ import java.util.List;
 
 public interface Rule {
 
-  String id();
+  default String id() {
+    String name = getClass().getSimpleName();
+    if (name.endsWith("Rule")) name = name.substring(0, name.length() - 4);
+    return name.replaceAll("([A-Z])", "-$1").toLowerCase().replaceFirst("^-", "");
+  }
 
   List<Finding> apply(Path file, JsonNode template);
 }

--- a/element-template-generator/validator/src/main/java/io/camunda/connector/validator/core/Rule.java
+++ b/element-template-generator/validator/src/main/java/io/camunda/connector/validator/core/Rule.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.validator.core;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.nio.file.Path;
+import java.util.List;
+
+public interface Rule {
+
+  String id();
+
+  List<Finding> apply(Path file, JsonNode template);
+}

--- a/element-template-generator/validator/src/main/java/io/camunda/connector/validator/core/Severity.java
+++ b/element-template-generator/validator/src/main/java/io/camunda/connector/validator/core/Severity.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.validator.core;
+
+public enum Severity {
+  ERROR,
+  WARN
+}

--- a/element-template-generator/validator/src/main/java/io/camunda/connector/validator/core/TemplateFinder.java
+++ b/element-template-generator/validator/src/main/java/io/camunda/connector/validator/core/TemplateFinder.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.validator.core;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Stream;
+
+public final class TemplateFinder {
+
+  public static final String VERSIONED_SEGMENT = "versioned";
+  private static final String ELEMENT_TEMPLATES_SEGMENT = "element-templates";
+  private static final Set<String> SKIPPED_DIRECTORIES =
+      Set.of("target", "node_modules", ".git", ".idea", ".m2");
+
+  /**
+   * Connector directories whose templates the validator skips entirely. Agentic-AI templates are
+   * generated/maintained outside the standard connector workflow and intentionally diverge from the
+   * conventions enforced here.
+   */
+  private static final Set<String> SKIPPED_CONNECTORS = Set.of("agentic-ai");
+
+  private TemplateFinder() {}
+
+  /** Files inside any {@code versioned/} directory are excluded. */
+  public static List<Path> find(Path root) {
+    return walk(root, false);
+  }
+
+  /** All element-template JSONs, including those inside {@code versioned/}. */
+  public static List<Path> findAll(Path root) {
+    return walk(root, true);
+  }
+
+  public static boolean isVersioned(Path path) {
+    for (Path segment : path) {
+      if (VERSIONED_SEGMENT.equals(segment.toString())) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static List<Path> walk(Path root, boolean includeVersioned) {
+    try (Stream<Path> walk = Files.walk(root)) {
+      return walk.filter(p -> isElementTemplateJson(p, includeVersioned)).sorted().toList();
+    } catch (IOException e) {
+      throw new RuntimeException("Failed to walk " + root, e);
+    }
+  }
+
+  private static boolean isElementTemplateJson(Path path, boolean includeVersioned) {
+    if (!Files.isRegularFile(path)) {
+      return false;
+    }
+    if (!path.getFileName().toString().endsWith(".json")) {
+      return false;
+    }
+    boolean inElementTemplates = false;
+    for (Path segment : path) {
+      String name = segment.toString();
+      if (SKIPPED_DIRECTORIES.contains(name)) {
+        return false;
+      }
+      if (SKIPPED_CONNECTORS.contains(name)) {
+        return false;
+      }
+      if (!includeVersioned && VERSIONED_SEGMENT.equals(name)) {
+        return false;
+      }
+      if (ELEMENT_TEMPLATES_SEGMENT.equals(name)) {
+        inElementTemplates = true;
+      }
+    }
+    return inElementTemplates;
+  }
+}

--- a/element-template-generator/validator/src/main/java/io/camunda/connector/validator/core/TemplateFinder.java
+++ b/element-template-generator/validator/src/main/java/io/camunda/connector/validator/core/TemplateFinder.java
@@ -17,11 +17,14 @@
 package io.camunda.connector.validator.core;
 
 import java.io.IOException;
+import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Stream;
 
 public final class TemplateFinder {
 
@@ -59,36 +62,50 @@ public final class TemplateFinder {
   }
 
   private static List<Path> walk(Path root, boolean includeVersioned) {
-    try (Stream<Path> walk = Files.walk(root)) {
-      return walk.filter(p -> isElementTemplateJson(p, includeVersioned)).sorted().toList();
+    List<Path> results = new ArrayList<>();
+    try {
+      Files.walkFileTree(
+          root,
+          new SimpleFileVisitor<Path>() {
+            @Override
+            public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) {
+              Path name = dir.getFileName();
+              if (name == null) {
+                return FileVisitResult.CONTINUE;
+              }
+              String dirName = name.toString();
+              if (SKIPPED_DIRECTORIES.contains(dirName)
+                  || SKIPPED_CONNECTORS.contains(dirName)
+                  || (!includeVersioned && VERSIONED_SEGMENT.equals(dirName))) {
+                return FileVisitResult.SKIP_SUBTREE;
+              }
+              return FileVisitResult.CONTINUE;
+            }
+
+            @Override
+            public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
+              if (isElementTemplateJson(file)) {
+                results.add(file);
+              }
+              return FileVisitResult.CONTINUE;
+            }
+          });
     } catch (IOException e) {
       throw new RuntimeException("Failed to walk " + root, e);
     }
+    results.sort(null);
+    return results;
   }
 
-  private static boolean isElementTemplateJson(Path path, boolean includeVersioned) {
-    if (!Files.isRegularFile(path)) {
-      return false;
-    }
+  private static boolean isElementTemplateJson(Path path) {
     if (!path.getFileName().toString().endsWith(".json")) {
       return false;
     }
-    boolean inElementTemplates = false;
     for (Path segment : path) {
-      String name = segment.toString();
-      if (SKIPPED_DIRECTORIES.contains(name)) {
-        return false;
-      }
-      if (SKIPPED_CONNECTORS.contains(name)) {
-        return false;
-      }
-      if (!includeVersioned && VERSIONED_SEGMENT.equals(name)) {
-        return false;
-      }
-      if (ELEMENT_TEMPLATES_SEGMENT.equals(name)) {
-        inElementTemplates = true;
+      if (ELEMENT_TEMPLATES_SEGMENT.equals(segment.toString())) {
+        return true;
       }
     }
-    return inElementTemplates;
+    return false;
   }
 }

--- a/element-template-generator/validator/src/main/java/io/camunda/connector/validator/core/TemplateFinder.java
+++ b/element-template-generator/validator/src/main/java/io/camunda/connector/validator/core/TemplateFinder.java
@@ -30,26 +30,39 @@ public final class TemplateFinder {
 
   public static final String VERSIONED_SEGMENT = "versioned";
   private static final String ELEMENT_TEMPLATES_SEGMENT = "element-templates";
-  private static final Set<String> SKIPPED_DIRECTORIES =
+
+  /** Directory names pruned during traversal when no override is supplied. */
+  public static final Set<String> DEFAULT_SKIPPED_DIRECTORIES =
       Set.of("target", "node_modules", ".git", ".idea", ".m2");
 
   /**
-   * Connector directories whose templates the validator skips entirely. Agentic-AI templates are
-   * generated/maintained outside the standard connector workflow and intentionally diverge from the
-   * conventions enforced here.
+   * Connector directories whose templates the validator skips entirely by default. Agentic-AI
+   * templates are generated/maintained outside the standard connector workflow and intentionally
+   * diverge from the conventions enforced here.
    */
-  private static final Set<String> SKIPPED_CONNECTORS = Set.of("agentic-ai");
+  public static final Set<String> DEFAULT_SKIPPED_CONNECTORS = Set.of("agentic-ai");
 
   private TemplateFinder() {}
 
   /** Files inside any {@code versioned/} directory are excluded. */
   public static List<Path> find(Path root) {
-    return walk(root, false);
+    return walk(root, false, DEFAULT_SKIPPED_DIRECTORIES, DEFAULT_SKIPPED_CONNECTORS);
+  }
+
+  /** Files inside any {@code versioned/} directory are excluded. */
+  public static List<Path> find(Path root, Set<String> skippedDirs, Set<String> skippedConnectors) {
+    return walk(root, false, skippedDirs, skippedConnectors);
   }
 
   /** All element-template JSONs, including those inside {@code versioned/}. */
   public static List<Path> findAll(Path root) {
-    return walk(root, true);
+    return walk(root, true, DEFAULT_SKIPPED_DIRECTORIES, DEFAULT_SKIPPED_CONNECTORS);
+  }
+
+  /** All element-template JSONs, including those inside {@code versioned/}. */
+  public static List<Path> findAll(
+      Path root, Set<String> skippedDirs, Set<String> skippedConnectors) {
+    return walk(root, true, skippedDirs, skippedConnectors);
   }
 
   public static boolean isVersioned(Path path) {
@@ -61,7 +74,8 @@ public final class TemplateFinder {
     return false;
   }
 
-  private static List<Path> walk(Path root, boolean includeVersioned) {
+  private static List<Path> walk(
+      Path root, boolean includeVersioned, Set<String> skippedDirs, Set<String> skippedConnectors) {
     List<Path> results = new ArrayList<>();
     try {
       Files.walkFileTree(
@@ -74,8 +88,8 @@ public final class TemplateFinder {
                 return FileVisitResult.CONTINUE;
               }
               String dirName = name.toString();
-              if (SKIPPED_DIRECTORIES.contains(dirName)
-                  || SKIPPED_CONNECTORS.contains(dirName)
+              if (skippedDirs.contains(dirName)
+                  || skippedConnectors.contains(dirName)
                   || (!includeVersioned && VERSIONED_SEGMENT.equals(dirName))) {
                 return FileVisitResult.SKIP_SUBTREE;
               }

--- a/element-template-generator/validator/src/main/java/io/camunda/connector/validator/core/TemplateLoader.java
+++ b/element-template-generator/validator/src/main/java/io/camunda/connector/validator/core/TemplateLoader.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.validator.core;
+
+import com.fasterxml.jackson.core.JsonLocation;
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.nio.file.Path;
+
+/**
+ * Parses element-template JSON files. Strict mode rejects duplicate object keys — which Jackson
+ * would otherwise silently coalesce (last-wins) — and surfaces them as a {@code duplicate-keys}
+ * finding instead of {@code json-parse}. Mirrors the duplicate-key check that the Camunda Web
+ * Modeler runs at editor save-time.
+ */
+public final class TemplateLoader {
+
+  public static final String DUPLICATE_KEYS_RULE = "duplicate-keys";
+  public static final String JSON_PARSE_RULE = "json-parse";
+
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  static {
+    MAPPER.getFactory().enable(JsonParser.Feature.STRICT_DUPLICATE_DETECTION);
+  }
+
+  private TemplateLoader() {}
+
+  public static Result load(Path path) {
+    try {
+      return new Result(MAPPER.readTree(path.toFile()), null);
+    } catch (JsonParseException e) {
+      String original = e.getOriginalMessage();
+      if (original != null && original.startsWith("Duplicate field")) {
+        JsonLocation loc = e.getLocation();
+        String where =
+            loc == null ? "" : " at line " + loc.getLineNr() + ", column " + loc.getColumnNr();
+        return new Result(
+            null, Finding.error(path, "/", DUPLICATE_KEYS_RULE, original + where + "."));
+      }
+      return new Result(
+          null,
+          Finding.error(path, "/", JSON_PARSE_RULE, "Failed to parse JSON: " + e.getMessage()));
+    } catch (IOException e) {
+      return new Result(
+          null,
+          Finding.error(path, "/", JSON_PARSE_RULE, "Failed to parse JSON: " + e.getMessage()));
+    }
+  }
+
+  public record Result(JsonNode node, Finding finding) {
+    public boolean ok() {
+      return finding == null;
+    }
+  }
+}

--- a/element-template-generator/validator/src/main/java/io/camunda/connector/validator/rule/ConditionPropertyOrderRule.java
+++ b/element-template-generator/validator/src/main/java/io/camunda/connector/validator/rule/ConditionPropertyOrderRule.java
@@ -23,7 +23,6 @@ import io.camunda.connector.validator.core.Rule;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
@@ -78,9 +77,7 @@ public class ConditionPropertyOrderRule implements Rule {
       Path file,
       List<Finding> findings) {
     if (node.isObject()) {
-      Iterator<Map.Entry<String, JsonNode>> fields = node.fields();
-      while (fields.hasNext()) {
-        Map.Entry<String, JsonNode> entry = fields.next();
+      for (Map.Entry<String, JsonNode> entry : node.properties()) {
         String childPointer = pointer + "/" + JsonPointers.escape(entry.getKey());
         if ("condition".equals(entry.getKey()) && entry.getValue().isObject()) {
           checkCondition(

--- a/element-template-generator/validator/src/main/java/io/camunda/connector/validator/rule/ConditionPropertyOrderRule.java
+++ b/element-template-generator/validator/src/main/java/io/camunda/connector/validator/rule/ConditionPropertyOrderRule.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.validator.rule;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.camunda.connector.validator.core.Finding;
+import io.camunda.connector.validator.core.JsonPointers;
+import io.camunda.connector.validator.core.Rule;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Any property B whose subtree contains a {@code condition} referencing property A must appear
+ * after A in the {@code properties[]} array. Includes conditions nested inside {@code choices[*]}
+ * and inside {@code allMatch} compounds.
+ *
+ * <p>This catches forward-references that are technically not rejected by the schema but break the
+ * natural fill-in order: the user can't pick a value for B before they've picked A. It also
+ * naturally enforces "step 1 discriminator before step 2 discriminator" — the step-2 property's
+ * condition references step 1, so the ordering check applies.
+ *
+ * <p>References to property ids that don't exist in the template are ignored here (they're caught
+ * by {@code condition-target-exists}). When the referenced id has multiple occurrences (the
+ * mutually-exclusive switching pattern), the rule uses the first occurrence's index.
+ */
+public class ConditionPropertyOrderRule implements Rule {
+
+  public static final String ID = "condition-property-order";
+
+  @Override
+  public String id() {
+    return ID;
+  }
+
+  @Override
+  public List<Finding> apply(Path file, JsonNode template) {
+    JsonNode properties = template.path("properties");
+    if (!properties.isArray()) {
+      return List.of();
+    }
+    Map<String, Integer> firstIndexById = new HashMap<>();
+    for (int i = 0; i < properties.size(); i++) {
+      JsonNode idNode = properties.get(i).path("id");
+      if (idNode.isTextual()) {
+        firstIndexById.putIfAbsent(idNode.asText(), i);
+      }
+    }
+    List<Finding> findings = new ArrayList<>();
+    for (int i = 0; i < properties.size(); i++) {
+      walk(properties.get(i), "/properties/" + i, i, firstIndexById, file, findings);
+    }
+    return findings;
+  }
+
+  private void walk(
+      JsonNode node,
+      String pointer,
+      int ownerIndex,
+      Map<String, Integer> firstIndexById,
+      Path file,
+      List<Finding> findings) {
+    if (node.isObject()) {
+      Iterator<Map.Entry<String, JsonNode>> fields = node.fields();
+      while (fields.hasNext()) {
+        Map.Entry<String, JsonNode> entry = fields.next();
+        String childPointer = pointer + "/" + JsonPointers.escape(entry.getKey());
+        if ("condition".equals(entry.getKey()) && entry.getValue().isObject()) {
+          checkCondition(
+              entry.getValue(), childPointer, ownerIndex, firstIndexById, file, findings);
+        }
+        walk(entry.getValue(), childPointer, ownerIndex, firstIndexById, file, findings);
+      }
+    } else if (node.isArray()) {
+      for (int i = 0; i < node.size(); i++) {
+        walk(node.get(i), pointer + "/" + i, ownerIndex, firstIndexById, file, findings);
+      }
+    }
+  }
+
+  private void checkCondition(
+      JsonNode condition,
+      String conditionPointer,
+      int ownerIndex,
+      Map<String, Integer> firstIndexById,
+      Path file,
+      List<Finding> findings) {
+    JsonNode propertyRef = condition.path("property");
+    if (propertyRef.isTextual()) {
+      String referencedId = propertyRef.asText();
+      Integer referencedIndex = firstIndexById.get(referencedId);
+      if (referencedIndex != null && referencedIndex >= ownerIndex) {
+        String reason =
+            referencedIndex == ownerIndex
+                ? "the property itself"
+                : "a property at index " + referencedIndex + " (after this one)";
+        findings.add(
+            Finding.error(
+                file,
+                conditionPointer + "/property",
+                ID,
+                "Condition references \""
+                    + referencedId
+                    + "\" — "
+                    + reason
+                    + ". Conditions must reference properties that appear earlier in properties[]."));
+      }
+    }
+    JsonNode allMatch = condition.path("allMatch");
+    if (allMatch.isArray()) {
+      for (int j = 0; j < allMatch.size(); j++) {
+        JsonNode sub = allMatch.get(j);
+        if (sub.isObject()) {
+          checkCondition(
+              sub, conditionPointer + "/allMatch/" + j, ownerIndex, firstIndexById, file, findings);
+        }
+      }
+    }
+  }
+}

--- a/element-template-generator/validator/src/main/java/io/camunda/connector/validator/rule/ConditionPropertyOrderRule.java
+++ b/element-template-generator/validator/src/main/java/io/camunda/connector/validator/rule/ConditionPropertyOrderRule.java
@@ -17,6 +17,7 @@
 package io.camunda.connector.validator.rule;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import io.camunda.connector.validator.core.ElementTemplate;
 import io.camunda.connector.validator.core.Finding;
 import io.camunda.connector.validator.core.JsonPointers;
 import io.camunda.connector.validator.core.Rule;
@@ -42,22 +43,15 @@ import java.util.Map;
  */
 public class ConditionPropertyOrderRule implements Rule {
 
-  public static final String ID = "condition-property-order";
-
-  @Override
-  public String id() {
-    return ID;
-  }
-
   @Override
   public List<Finding> apply(Path file, JsonNode template) {
-    JsonNode properties = template.path("properties");
+    JsonNode properties = template.path(ElementTemplate.PROPERTIES);
     if (!properties.isArray()) {
       return List.of();
     }
     Map<String, Integer> firstIndexById = new HashMap<>();
     for (int i = 0; i < properties.size(); i++) {
-      JsonNode idNode = properties.get(i).path("id");
+      JsonNode idNode = properties.get(i).path(ElementTemplate.ID);
       if (idNode.isTextual()) {
         firstIndexById.putIfAbsent(idNode.asText(), i);
       }
@@ -79,7 +73,7 @@ public class ConditionPropertyOrderRule implements Rule {
     if (node.isObject()) {
       for (Map.Entry<String, JsonNode> entry : node.properties()) {
         String childPointer = pointer + "/" + JsonPointers.escape(entry.getKey());
-        if ("condition".equals(entry.getKey()) && entry.getValue().isObject()) {
+        if (ElementTemplate.CONDITION.equals(entry.getKey()) && entry.getValue().isObject()) {
           checkCondition(
               entry.getValue(), childPointer, ownerIndex, firstIndexById, file, findings);
         }
@@ -99,7 +93,7 @@ public class ConditionPropertyOrderRule implements Rule {
       Map<String, Integer> firstIndexById,
       Path file,
       List<Finding> findings) {
-    JsonNode propertyRef = condition.path("property");
+    JsonNode propertyRef = condition.path(ElementTemplate.PROPERTY);
     if (propertyRef.isTextual()) {
       String referencedId = propertyRef.asText();
       Integer referencedIndex = firstIndexById.get(referencedId);
@@ -112,7 +106,7 @@ public class ConditionPropertyOrderRule implements Rule {
             Finding.error(
                 file,
                 conditionPointer + "/property",
-                ID,
+                id(),
                 "Condition references \""
                     + referencedId
                     + "\" — "
@@ -120,7 +114,7 @@ public class ConditionPropertyOrderRule implements Rule {
                     + ". Conditions must reference properties that appear earlier in properties[]."));
       }
     }
-    JsonNode allMatch = condition.path("allMatch");
+    JsonNode allMatch = condition.path(ElementTemplate.ALL_MATCH);
     if (allMatch.isArray()) {
       for (int j = 0; j < allMatch.size(); j++) {
         JsonNode sub = allMatch.get(j);

--- a/element-template-generator/validator/src/main/java/io/camunda/connector/validator/rule/ConditionTargetExistsRule.java
+++ b/element-template-generator/validator/src/main/java/io/camunda/connector/validator/rule/ConditionTargetExistsRule.java
@@ -17,6 +17,7 @@
 package io.camunda.connector.validator.rule;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import io.camunda.connector.validator.core.ElementTemplate;
 import io.camunda.connector.validator.core.Finding;
 import io.camunda.connector.validator.core.JsonPointers;
 import io.camunda.connector.validator.core.Rule;
@@ -41,13 +42,6 @@ import java.util.Set;
  */
 public class ConditionTargetExistsRule implements Rule {
 
-  public static final String ID = "condition-target-exists";
-
-  @Override
-  public String id() {
-    return ID;
-  }
-
   @Override
   public List<Finding> apply(Path file, JsonNode template) {
     Set<String> propertyIds = collectPropertyIds(template);
@@ -58,12 +52,12 @@ public class ConditionTargetExistsRule implements Rule {
 
   private Set<String> collectPropertyIds(JsonNode template) {
     Set<String> ids = new HashSet<>();
-    JsonNode props = template.path("properties");
+    JsonNode props = template.path(ElementTemplate.PROPERTIES);
     if (!props.isArray()) {
       return ids;
     }
     for (JsonNode prop : props) {
-      JsonNode idNode = prop.path("id");
+      JsonNode idNode = prop.path(ElementTemplate.ID);
       if (idNode.isTextual()) {
         ids.add(idNode.asText());
       }
@@ -76,7 +70,7 @@ public class ConditionTargetExistsRule implements Rule {
     if (node.isObject()) {
       for (Map.Entry<String, JsonNode> entry : node.properties()) {
         String childPointer = pointer + "/" + JsonPointers.escape(entry.getKey());
-        if ("condition".equals(entry.getKey()) && entry.getValue().isObject()) {
+        if (ElementTemplate.CONDITION.equals(entry.getKey()) && entry.getValue().isObject()) {
           checkCondition(entry.getValue(), childPointer, file, propertyIds, findings);
         }
         walk(entry.getValue(), childPointer, file, propertyIds, findings);
@@ -94,7 +88,7 @@ public class ConditionTargetExistsRule implements Rule {
       Path file,
       Set<String> propertyIds,
       List<Finding> findings) {
-    JsonNode propertyRef = condition.path("property");
+    JsonNode propertyRef = condition.path(ElementTemplate.PROPERTY);
     if (propertyRef.isTextual()) {
       String referencedId = propertyRef.asText();
       if (!propertyIds.contains(referencedId)) {
@@ -102,14 +96,14 @@ public class ConditionTargetExistsRule implements Rule {
             Finding.error(
                 file,
                 conditionPointer + "/property",
-                ID,
+                id(),
                 "Condition references property \""
                     + referencedId
                     + "\" which does not exist in this template."));
       }
     }
 
-    JsonNode allMatch = condition.path("allMatch");
+    JsonNode allMatch = condition.path(ElementTemplate.ALL_MATCH);
     if (allMatch.isArray()) {
       for (int i = 0; i < allMatch.size(); i++) {
         JsonNode sub = allMatch.get(i);

--- a/element-template-generator/validator/src/main/java/io/camunda/connector/validator/rule/ConditionTargetExistsRule.java
+++ b/element-template-generator/validator/src/main/java/io/camunda/connector/validator/rule/ConditionTargetExistsRule.java
@@ -23,7 +23,6 @@ import io.camunda.connector.validator.core.Rule;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -75,9 +74,7 @@ public class ConditionTargetExistsRule implements Rule {
   private void walk(
       JsonNode node, String pointer, Path file, Set<String> propertyIds, List<Finding> findings) {
     if (node.isObject()) {
-      Iterator<Map.Entry<String, JsonNode>> fields = node.fields();
-      while (fields.hasNext()) {
-        Map.Entry<String, JsonNode> entry = fields.next();
+      for (Map.Entry<String, JsonNode> entry : node.properties()) {
         String childPointer = pointer + "/" + JsonPointers.escape(entry.getKey());
         if ("condition".equals(entry.getKey()) && entry.getValue().isObject()) {
           checkCondition(entry.getValue(), childPointer, file, propertyIds, findings);

--- a/element-template-generator/validator/src/main/java/io/camunda/connector/validator/rule/ConditionTargetExistsRule.java
+++ b/element-template-generator/validator/src/main/java/io/camunda/connector/validator/rule/ConditionTargetExistsRule.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.validator.rule;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.camunda.connector.validator.core.Finding;
+import io.camunda.connector.validator.core.JsonPointers;
+import io.camunda.connector.validator.core.Rule;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Every property referenced from a {@code condition} must exist in the template's top-level {@code
+ * properties[]}.
+ *
+ * <p>Supported condition shapes (matching the upstream Camunda element-template schema):
+ *
+ * <ul>
+ *   <li>Simple: {@code { "property": "X", "equals": Y }} or {@code { "property": "X", "oneOf": [
+ *       ... ] }}
+ *   <li>Compound: {@code { "allMatch": [ <simple>, <simple>, ... ] }}
+ * </ul>
+ */
+public class ConditionTargetExistsRule implements Rule {
+
+  public static final String ID = "condition-target-exists";
+
+  @Override
+  public String id() {
+    return ID;
+  }
+
+  @Override
+  public List<Finding> apply(Path file, JsonNode template) {
+    Set<String> propertyIds = collectPropertyIds(template);
+    List<Finding> findings = new ArrayList<>();
+    walk(template, "", file, propertyIds, findings);
+    return findings;
+  }
+
+  private Set<String> collectPropertyIds(JsonNode template) {
+    Set<String> ids = new HashSet<>();
+    JsonNode props = template.path("properties");
+    if (!props.isArray()) {
+      return ids;
+    }
+    for (JsonNode prop : props) {
+      JsonNode idNode = prop.path("id");
+      if (idNode.isTextual()) {
+        ids.add(idNode.asText());
+      }
+    }
+    return ids;
+  }
+
+  private void walk(
+      JsonNode node, String pointer, Path file, Set<String> propertyIds, List<Finding> findings) {
+    if (node.isObject()) {
+      Iterator<Map.Entry<String, JsonNode>> fields = node.fields();
+      while (fields.hasNext()) {
+        Map.Entry<String, JsonNode> entry = fields.next();
+        String childPointer = pointer + "/" + JsonPointers.escape(entry.getKey());
+        if ("condition".equals(entry.getKey()) && entry.getValue().isObject()) {
+          checkCondition(entry.getValue(), childPointer, file, propertyIds, findings);
+        }
+        walk(entry.getValue(), childPointer, file, propertyIds, findings);
+      }
+    } else if (node.isArray()) {
+      for (int i = 0; i < node.size(); i++) {
+        walk(node.get(i), pointer + "/" + i, file, propertyIds, findings);
+      }
+    }
+  }
+
+  private void checkCondition(
+      JsonNode condition,
+      String conditionPointer,
+      Path file,
+      Set<String> propertyIds,
+      List<Finding> findings) {
+    JsonNode propertyRef = condition.path("property");
+    if (propertyRef.isTextual()) {
+      String referencedId = propertyRef.asText();
+      if (!propertyIds.contains(referencedId)) {
+        findings.add(
+            Finding.error(
+                file,
+                conditionPointer + "/property",
+                ID,
+                "Condition references property \""
+                    + referencedId
+                    + "\" which does not exist in this template."));
+      }
+    }
+
+    JsonNode allMatch = condition.path("allMatch");
+    if (allMatch.isArray()) {
+      for (int i = 0; i < allMatch.size(); i++) {
+        JsonNode sub = allMatch.get(i);
+        if (sub.isObject()) {
+          checkCondition(sub, conditionPointer + "/allMatch/" + i, file, propertyIds, findings);
+        }
+      }
+    }
+  }
+}

--- a/element-template-generator/validator/src/main/java/io/camunda/connector/validator/rule/ConditionValueInChoicesRule.java
+++ b/element-template-generator/validator/src/main/java/io/camunda/connector/validator/rule/ConditionValueInChoicesRule.java
@@ -24,7 +24,6 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -89,9 +88,7 @@ public class ConditionValueInChoicesRule implements Rule {
       Map<String, Set<String>> choicesById,
       List<Finding> findings) {
     if (node.isObject()) {
-      Iterator<Map.Entry<String, JsonNode>> fields = node.fields();
-      while (fields.hasNext()) {
-        Map.Entry<String, JsonNode> entry = fields.next();
+      for (Map.Entry<String, JsonNode> entry : node.properties()) {
         String childPointer = pointer + "/" + JsonPointers.escape(entry.getKey());
         if ("condition".equals(entry.getKey()) && entry.getValue().isObject()) {
           checkCondition(entry.getValue(), childPointer, file, choicesById, findings);

--- a/element-template-generator/validator/src/main/java/io/camunda/connector/validator/rule/ConditionValueInChoicesRule.java
+++ b/element-template-generator/validator/src/main/java/io/camunda/connector/validator/rule/ConditionValueInChoicesRule.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.validator.rule;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.camunda.connector.validator.core.Finding;
+import io.camunda.connector.validator.core.JsonPointers;
+import io.camunda.connector.validator.core.Rule;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * When a condition compares against a property that declares {@code choices}, the {@code equals} or
+ * {@code oneOf} value(s) must be one of the declared choices — otherwise the condition can never
+ * fire. Catches typos on the value side of conditions, the counterpart to {@link
+ * ConditionTargetExistsRule}.
+ *
+ * <p>For properties whose {@code choices} differ across {@code condition} branches (e.g. {@code
+ * eventOperationType} per {@code operationGroup}), the rule unions all choices for that id — a
+ * lenient default that avoids false positives at the cost of missing some bugs.
+ */
+public class ConditionValueInChoicesRule implements Rule {
+
+  public static final String ID = "condition-value-in-choices";
+
+  @Override
+  public String id() {
+    return ID;
+  }
+
+  @Override
+  public List<Finding> apply(Path file, JsonNode template) {
+    Map<String, Set<String>> choicesById = collectChoiceUnion(template);
+    if (choicesById.isEmpty()) {
+      return List.of();
+    }
+    List<Finding> findings = new ArrayList<>();
+    walk(template, "", file, choicesById, findings);
+    return findings;
+  }
+
+  private Map<String, Set<String>> collectChoiceUnion(JsonNode template) {
+    Map<String, Set<String>> result = new HashMap<>();
+    JsonNode props = template.path("properties");
+    if (!props.isArray()) {
+      return result;
+    }
+    for (JsonNode prop : props) {
+      JsonNode idNode = prop.path("id");
+      JsonNode choicesNode = prop.path("choices");
+      if (!idNode.isTextual() || !choicesNode.isArray()) {
+        continue;
+      }
+      Set<String> choices = result.computeIfAbsent(idNode.asText(), k -> new HashSet<>());
+      for (JsonNode c : choicesNode) {
+        JsonNode v = c.path("value");
+        if (v.isTextual()) {
+          choices.add(v.asText());
+        }
+      }
+    }
+    return result;
+  }
+
+  private void walk(
+      JsonNode node,
+      String pointer,
+      Path file,
+      Map<String, Set<String>> choicesById,
+      List<Finding> findings) {
+    if (node.isObject()) {
+      Iterator<Map.Entry<String, JsonNode>> fields = node.fields();
+      while (fields.hasNext()) {
+        Map.Entry<String, JsonNode> entry = fields.next();
+        String childPointer = pointer + "/" + JsonPointers.escape(entry.getKey());
+        if ("condition".equals(entry.getKey()) && entry.getValue().isObject()) {
+          checkCondition(entry.getValue(), childPointer, file, choicesById, findings);
+        }
+        walk(entry.getValue(), childPointer, file, choicesById, findings);
+      }
+    } else if (node.isArray()) {
+      for (int i = 0; i < node.size(); i++) {
+        walk(node.get(i), pointer + "/" + i, file, choicesById, findings);
+      }
+    }
+  }
+
+  private void checkCondition(
+      JsonNode condition,
+      String conditionPointer,
+      Path file,
+      Map<String, Set<String>> choicesById,
+      List<Finding> findings) {
+    JsonNode propertyRef = condition.path("property");
+    if (propertyRef.isTextual()) {
+      String referencedId = propertyRef.asText();
+      Set<String> choices = choicesById.get(referencedId);
+      if (choices != null && !choices.isEmpty()) {
+        JsonNode equals = condition.path("equals");
+        if (equals.isTextual() && !choices.contains(equals.asText())) {
+          findings.add(
+              Finding.error(
+                  file,
+                  conditionPointer + "/equals",
+                  ID,
+                  "Condition value \""
+                      + equals.asText()
+                      + "\" is not a declared choice of property \""
+                      + referencedId
+                      + "\"."));
+        }
+        JsonNode oneOf = condition.path("oneOf");
+        if (oneOf.isArray()) {
+          for (int i = 0; i < oneOf.size(); i++) {
+            JsonNode v = oneOf.get(i);
+            if (v.isTextual() && !choices.contains(v.asText())) {
+              findings.add(
+                  Finding.error(
+                      file,
+                      conditionPointer + "/oneOf/" + i,
+                      ID,
+                      "Condition value \""
+                          + v.asText()
+                          + "\" is not a declared choice of property \""
+                          + referencedId
+                          + "\"."));
+            }
+          }
+        }
+      }
+    }
+
+    JsonNode allMatch = condition.path("allMatch");
+    if (allMatch.isArray()) {
+      for (int i = 0; i < allMatch.size(); i++) {
+        JsonNode sub = allMatch.get(i);
+        if (sub.isObject()) {
+          checkCondition(sub, conditionPointer + "/allMatch/" + i, file, choicesById, findings);
+        }
+      }
+    }
+  }
+}

--- a/element-template-generator/validator/src/main/java/io/camunda/connector/validator/rule/ConditionValueInChoicesRule.java
+++ b/element-template-generator/validator/src/main/java/io/camunda/connector/validator/rule/ConditionValueInChoicesRule.java
@@ -17,6 +17,7 @@
 package io.camunda.connector.validator.rule;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import io.camunda.connector.validator.core.ElementTemplate;
 import io.camunda.connector.validator.core.Finding;
 import io.camunda.connector.validator.core.JsonPointers;
 import io.camunda.connector.validator.core.Rule;
@@ -40,13 +41,6 @@ import java.util.Set;
  */
 public class ConditionValueInChoicesRule implements Rule {
 
-  public static final String ID = "condition-value-in-choices";
-
-  @Override
-  public String id() {
-    return ID;
-  }
-
   @Override
   public List<Finding> apply(Path file, JsonNode template) {
     Map<String, Set<String>> choicesById = collectChoiceUnion(template);
@@ -60,19 +54,19 @@ public class ConditionValueInChoicesRule implements Rule {
 
   private Map<String, Set<String>> collectChoiceUnion(JsonNode template) {
     Map<String, Set<String>> result = new HashMap<>();
-    JsonNode props = template.path("properties");
+    JsonNode props = template.path(ElementTemplate.PROPERTIES);
     if (!props.isArray()) {
       return result;
     }
     for (JsonNode prop : props) {
-      JsonNode idNode = prop.path("id");
-      JsonNode choicesNode = prop.path("choices");
+      JsonNode idNode = prop.path(ElementTemplate.ID);
+      JsonNode choicesNode = prop.path(ElementTemplate.CHOICES);
       if (!idNode.isTextual() || !choicesNode.isArray()) {
         continue;
       }
       Set<String> choices = result.computeIfAbsent(idNode.asText(), k -> new HashSet<>());
       for (JsonNode c : choicesNode) {
-        JsonNode v = c.path("value");
+        JsonNode v = c.path(ElementTemplate.VALUE);
         if (v.isTextual()) {
           choices.add(v.asText());
         }
@@ -90,7 +84,7 @@ public class ConditionValueInChoicesRule implements Rule {
     if (node.isObject()) {
       for (Map.Entry<String, JsonNode> entry : node.properties()) {
         String childPointer = pointer + "/" + JsonPointers.escape(entry.getKey());
-        if ("condition".equals(entry.getKey()) && entry.getValue().isObject()) {
+        if (ElementTemplate.CONDITION.equals(entry.getKey()) && entry.getValue().isObject()) {
           checkCondition(entry.getValue(), childPointer, file, choicesById, findings);
         }
         walk(entry.getValue(), childPointer, file, choicesById, findings);
@@ -108,25 +102,25 @@ public class ConditionValueInChoicesRule implements Rule {
       Path file,
       Map<String, Set<String>> choicesById,
       List<Finding> findings) {
-    JsonNode propertyRef = condition.path("property");
+    JsonNode propertyRef = condition.path(ElementTemplate.PROPERTY);
     if (propertyRef.isTextual()) {
       String referencedId = propertyRef.asText();
       Set<String> choices = choicesById.get(referencedId);
       if (choices != null && !choices.isEmpty()) {
-        JsonNode equals = condition.path("equals");
+        JsonNode equals = condition.path(ElementTemplate.EQUALS);
         if (equals.isTextual() && !choices.contains(equals.asText())) {
           findings.add(
               Finding.error(
                   file,
                   conditionPointer + "/equals",
-                  ID,
+                  id(),
                   "Condition value \""
                       + equals.asText()
                       + "\" is not a declared choice of property \""
                       + referencedId
                       + "\"."));
         }
-        JsonNode oneOf = condition.path("oneOf");
+        JsonNode oneOf = condition.path(ElementTemplate.ONE_OF);
         if (oneOf.isArray()) {
           for (int i = 0; i < oneOf.size(); i++) {
             JsonNode v = oneOf.get(i);
@@ -135,7 +129,7 @@ public class ConditionValueInChoicesRule implements Rule {
                   Finding.error(
                       file,
                       conditionPointer + "/oneOf/" + i,
-                      ID,
+                      id(),
                       "Condition value \""
                           + v.asText()
                           + "\" is not a declared choice of property \""
@@ -147,7 +141,7 @@ public class ConditionValueInChoicesRule implements Rule {
       }
     }
 
-    JsonNode allMatch = condition.path("allMatch");
+    JsonNode allMatch = condition.path(ElementTemplate.ALL_MATCH);
     if (allMatch.isArray()) {
       for (int i = 0; i < allMatch.size(); i++) {
         JsonNode sub = allMatch.get(i);

--- a/element-template-generator/validator/src/main/java/io/camunda/connector/validator/rule/CurrentVersionBumpRule.java
+++ b/element-template-generator/validator/src/main/java/io/camunda/connector/validator/rule/CurrentVersionBumpRule.java
@@ -17,6 +17,7 @@
 package io.camunda.connector.validator.rule;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import io.camunda.connector.validator.core.ElementTemplate;
 import io.camunda.connector.validator.core.Finding;
 import io.camunda.connector.validator.core.MultiFileRule;
 import io.camunda.connector.validator.core.TemplateFinder;
@@ -37,13 +38,6 @@ import java.util.Map;
  */
 public class CurrentVersionBumpRule implements MultiFileRule {
 
-  public static final String ID = "current-version-bump";
-
-  @Override
-  public String id() {
-    return ID;
-  }
-
   @Override
   public List<Finding> apply(Map<Path, JsonNode> templates) {
     Map<String, Integer> highestSnapshotByScope = new HashMap<>();
@@ -56,7 +50,7 @@ public class CurrentVersionBumpRule implements MultiFileRule {
       if (scopeKey == null) {
         continue;
       }
-      JsonNode versionNode = entry.getValue().path("version");
+      JsonNode versionNode = entry.getValue().path(ElementTemplate.VERSION);
       if (!versionNode.isNumber()) {
         continue;
       }
@@ -78,14 +72,14 @@ public class CurrentVersionBumpRule implements MultiFileRule {
         continue;
       }
       int expected = maxSnapshot + 1;
-      JsonNode versionNode = entry.getValue().path("version");
-      String tmplId = entry.getValue().path("id").asText();
+      JsonNode versionNode = entry.getValue().path(ElementTemplate.VERSION);
+      String tmplId = entry.getValue().path(ElementTemplate.ID).asText();
       if (!versionNode.isNumber()) {
         findings.add(
             Finding.error(
                 path,
                 "/version",
-                ID,
+                id(),
                 "Current template missing 'version' field; highest versioned snapshot with id \""
                     + tmplId
                     + "\" is "
@@ -101,7 +95,7 @@ public class CurrentVersionBumpRule implements MultiFileRule {
             Finding.error(
                 path,
                 "/version",
-                ID,
+                id(),
                 "Current template version is "
                     + current
                     + " but highest versioned snapshot with id \""
@@ -117,7 +111,7 @@ public class CurrentVersionBumpRule implements MultiFileRule {
   }
 
   private static String scopeKey(Path path, JsonNode template) {
-    String tmplId = template.path("id").asText("");
+    String tmplId = template.path(ElementTemplate.ID).asText("");
     if (tmplId.isEmpty()) {
       return null;
     }

--- a/element-template-generator/validator/src/main/java/io/camunda/connector/validator/rule/CurrentVersionBumpRule.java
+++ b/element-template-generator/validator/src/main/java/io/camunda/connector/validator/rule/CurrentVersionBumpRule.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.validator.rule;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.camunda.connector.validator.core.Finding;
+import io.camunda.connector.validator.core.MultiFileRule;
+import io.camunda.connector.validator.core.TemplateFinder;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * For each non-versioned template, locate the highest-versioned snapshot in the same connector's
+ * {@code element-templates/} subtree that shares the same {@code id}. If one exists, the current
+ * template's {@code version} field must be exactly that snapshot's version plus one.
+ *
+ * <p>If no versioned snapshot shares the same id, the rule is silent — this naturally handles
+ * intentional id renames ({@code .v0} → {@code .v1}) where the current template starts a new
+ * lineage with no historical sibling under the new id.
+ */
+public class CurrentVersionBumpRule implements MultiFileRule {
+
+  public static final String ID = "current-version-bump";
+
+  @Override
+  public String id() {
+    return ID;
+  }
+
+  @Override
+  public List<Finding> apply(Map<Path, JsonNode> templates) {
+    Map<String, Integer> highestSnapshotByScope = new HashMap<>();
+    for (Map.Entry<Path, JsonNode> entry : templates.entrySet()) {
+      Path path = entry.getKey();
+      if (!TemplateFinder.isVersioned(path)) {
+        continue;
+      }
+      String scopeKey = scopeKey(path, entry.getValue());
+      if (scopeKey == null) {
+        continue;
+      }
+      JsonNode versionNode = entry.getValue().path("version");
+      if (!versionNode.isNumber()) {
+        continue;
+      }
+      highestSnapshotByScope.merge(scopeKey, versionNode.asInt(), Math::max);
+    }
+
+    List<Finding> findings = new ArrayList<>();
+    for (Map.Entry<Path, JsonNode> entry : templates.entrySet()) {
+      Path path = entry.getKey();
+      if (TemplateFinder.isVersioned(path)) {
+        continue;
+      }
+      String scopeKey = scopeKey(path, entry.getValue());
+      if (scopeKey == null) {
+        continue;
+      }
+      Integer maxSnapshot = highestSnapshotByScope.get(scopeKey);
+      if (maxSnapshot == null) {
+        continue;
+      }
+      int expected = maxSnapshot + 1;
+      JsonNode versionNode = entry.getValue().path("version");
+      String tmplId = entry.getValue().path("id").asText();
+      if (!versionNode.isNumber()) {
+        findings.add(
+            Finding.error(
+                path,
+                "/version",
+                ID,
+                "Current template missing 'version' field; highest versioned snapshot with id \""
+                    + tmplId
+                    + "\" is "
+                    + maxSnapshot
+                    + ", expected "
+                    + expected
+                    + "."));
+        continue;
+      }
+      int current = versionNode.asInt();
+      if (current != expected) {
+        findings.add(
+            Finding.error(
+                path,
+                "/version",
+                ID,
+                "Current template version is "
+                    + current
+                    + " but highest versioned snapshot with id \""
+                    + tmplId
+                    + "\" is "
+                    + maxSnapshot
+                    + "; expected "
+                    + expected
+                    + "."));
+      }
+    }
+    return findings;
+  }
+
+  private static String scopeKey(Path path, JsonNode template) {
+    String tmplId = template.path("id").asText("");
+    if (tmplId.isEmpty()) {
+      return null;
+    }
+    Path elementTemplatesDir = elementTemplatesDir(path);
+    if (elementTemplatesDir == null) {
+      return null;
+    }
+    return elementTemplatesDir + "::" + tmplId;
+  }
+
+  private static Path elementTemplatesDir(Path path) {
+    Path p = path.getParent();
+    while (p != null) {
+      Path name = p.getFileName();
+      if (name != null && "element-templates".equals(name.toString())) {
+        return p;
+      }
+      p = p.getParent();
+    }
+    return null;
+  }
+}

--- a/element-template-generator/validator/src/main/java/io/camunda/connector/validator/rule/DefaultValueInChoicesRule.java
+++ b/element-template-generator/validator/src/main/java/io/camunda/connector/validator/rule/DefaultValueInChoicesRule.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.validator.rule;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.camunda.connector.validator.core.Finding;
+import io.camunda.connector.validator.core.Rule;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * For Dropdown properties that declare both a default {@code value} and a {@code choices} list, the
+ * default must be one of the declared choices.
+ */
+public class DefaultValueInChoicesRule implements Rule {
+
+  public static final String ID = "default-value-in-choices";
+
+  @Override
+  public String id() {
+    return ID;
+  }
+
+  @Override
+  public List<Finding> apply(Path file, JsonNode template) {
+    JsonNode properties = template.path("properties");
+    if (!properties.isArray()) {
+      return List.of();
+    }
+    List<Finding> findings = new ArrayList<>();
+    for (int i = 0; i < properties.size(); i++) {
+      JsonNode property = properties.get(i);
+      JsonNode type = property.path("type");
+      JsonNode defaultValue = property.path("value");
+      JsonNode choices = property.path("choices");
+      if (!"Dropdown".equals(type.asText("")) || !defaultValue.isTextual() || !choices.isArray()) {
+        continue;
+      }
+      Set<String> choiceValues = new HashSet<>();
+      for (JsonNode c : choices) {
+        JsonNode v = c.path("value");
+        if (v.isTextual()) {
+          choiceValues.add(v.asText());
+        }
+      }
+      if (!choiceValues.isEmpty() && !choiceValues.contains(defaultValue.asText())) {
+        String propertyId = property.path("id").asText("");
+        findings.add(
+            Finding.error(
+                file,
+                "/properties/" + i + "/value",
+                ID,
+                "Default value \""
+                    + defaultValue.asText()
+                    + "\" of property \""
+                    + propertyId
+                    + "\" is not one of its declared choices."));
+      }
+    }
+    return findings;
+  }
+}

--- a/element-template-generator/validator/src/main/java/io/camunda/connector/validator/rule/DefaultValueInChoicesRule.java
+++ b/element-template-generator/validator/src/main/java/io/camunda/connector/validator/rule/DefaultValueInChoicesRule.java
@@ -17,6 +17,7 @@
 package io.camunda.connector.validator.rule;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import io.camunda.connector.validator.core.ElementTemplate;
 import io.camunda.connector.validator.core.Finding;
 import io.camunda.connector.validator.core.Rule;
 import java.nio.file.Path;
@@ -31,42 +32,35 @@ import java.util.Set;
  */
 public class DefaultValueInChoicesRule implements Rule {
 
-  public static final String ID = "default-value-in-choices";
-
-  @Override
-  public String id() {
-    return ID;
-  }
-
   @Override
   public List<Finding> apply(Path file, JsonNode template) {
-    JsonNode properties = template.path("properties");
+    JsonNode properties = template.path(ElementTemplate.PROPERTIES);
     if (!properties.isArray()) {
       return List.of();
     }
     List<Finding> findings = new ArrayList<>();
     for (int i = 0; i < properties.size(); i++) {
       JsonNode property = properties.get(i);
-      JsonNode type = property.path("type");
-      JsonNode defaultValue = property.path("value");
-      JsonNode choices = property.path("choices");
+      JsonNode type = property.path(ElementTemplate.TYPE);
+      JsonNode defaultValue = property.path(ElementTemplate.VALUE);
+      JsonNode choices = property.path(ElementTemplate.CHOICES);
       if (!"Dropdown".equals(type.asText("")) || !defaultValue.isTextual() || !choices.isArray()) {
         continue;
       }
       Set<String> choiceValues = new HashSet<>();
       for (JsonNode c : choices) {
-        JsonNode v = c.path("value");
+        JsonNode v = c.path(ElementTemplate.VALUE);
         if (v.isTextual()) {
           choiceValues.add(v.asText());
         }
       }
       if (!choiceValues.isEmpty() && !choiceValues.contains(defaultValue.asText())) {
-        String propertyId = property.path("id").asText("");
+        String propertyId = property.path(ElementTemplate.ID).asText("");
         findings.add(
             Finding.error(
                 file,
                 "/properties/" + i + "/value",
-                ID,
+                id(),
                 "Default value \""
                     + defaultValue.asText()
                     + "\" of property \""

--- a/element-template-generator/validator/src/main/java/io/camunda/connector/validator/rule/EmptyGroupRule.java
+++ b/element-template-generator/validator/src/main/java/io/camunda/connector/validator/rule/EmptyGroupRule.java
@@ -17,6 +17,7 @@
 package io.camunda.connector.validator.rule;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import io.camunda.connector.validator.core.ElementTemplate;
 import io.camunda.connector.validator.core.Finding;
 import io.camunda.connector.validator.core.Rule;
 import java.nio.file.Path;
@@ -30,24 +31,17 @@ import java.util.Set;
  */
 public class EmptyGroupRule implements Rule {
 
-  public static final String ID = "empty-group";
-
-  @Override
-  public String id() {
-    return ID;
-  }
-
   @Override
   public List<Finding> apply(Path file, JsonNode template) {
-    JsonNode groups = template.path("groups");
+    JsonNode groups = template.path(ElementTemplate.GROUPS);
     if (!groups.isArray()) {
       return List.of();
     }
     Set<String> referenced = new HashSet<>();
-    JsonNode properties = template.path("properties");
+    JsonNode properties = template.path(ElementTemplate.PROPERTIES);
     if (properties.isArray()) {
       for (JsonNode prop : properties) {
-        JsonNode g = prop.path("group");
+        JsonNode g = prop.path(ElementTemplate.GROUP);
         if (g.isTextual()) {
           referenced.add(g.asText());
         }
@@ -56,7 +50,7 @@ public class EmptyGroupRule implements Rule {
 
     List<Finding> findings = new ArrayList<>();
     for (int i = 0; i < groups.size(); i++) {
-      JsonNode idNode = groups.get(i).path("id");
+      JsonNode idNode = groups.get(i).path(ElementTemplate.ID);
       if (!idNode.isTextual()) {
         continue;
       }
@@ -66,7 +60,7 @@ public class EmptyGroupRule implements Rule {
             Finding.error(
                 file,
                 "/groups/" + i + "/id",
-                ID,
+                id(),
                 "Group \"" + groupId + "\" is declared but no property references it."));
       }
     }

--- a/element-template-generator/validator/src/main/java/io/camunda/connector/validator/rule/EmptyGroupRule.java
+++ b/element-template-generator/validator/src/main/java/io/camunda/connector/validator/rule/EmptyGroupRule.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.validator.rule;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.camunda.connector.validator.core.Finding;
+import io.camunda.connector.validator.core.Rule;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Each declared {@code groups[].id} must be referenced by at least one property's {@code group}.
+ */
+public class EmptyGroupRule implements Rule {
+
+  public static final String ID = "empty-group";
+
+  @Override
+  public String id() {
+    return ID;
+  }
+
+  @Override
+  public List<Finding> apply(Path file, JsonNode template) {
+    JsonNode groups = template.path("groups");
+    if (!groups.isArray()) {
+      return List.of();
+    }
+    Set<String> referenced = new HashSet<>();
+    JsonNode properties = template.path("properties");
+    if (properties.isArray()) {
+      for (JsonNode prop : properties) {
+        JsonNode g = prop.path("group");
+        if (g.isTextual()) {
+          referenced.add(g.asText());
+        }
+      }
+    }
+
+    List<Finding> findings = new ArrayList<>();
+    for (int i = 0; i < groups.size(); i++) {
+      JsonNode idNode = groups.get(i).path("id");
+      if (!idNode.isTextual()) {
+        continue;
+      }
+      String groupId = idNode.asText();
+      if (!referenced.contains(groupId)) {
+        findings.add(
+            Finding.error(
+                file,
+                "/groups/" + i + "/id",
+                ID,
+                "Group \"" + groupId + "\" is declared but no property references it."));
+      }
+    }
+    return findings;
+  }
+}

--- a/element-template-generator/validator/src/main/java/io/camunda/connector/validator/rule/GroupTargetExistsRule.java
+++ b/element-template-generator/validator/src/main/java/io/camunda/connector/validator/rule/GroupTargetExistsRule.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.validator.rule;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.camunda.connector.validator.core.Finding;
+import io.camunda.connector.validator.core.Rule;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Each property's {@code group} must reference an existing {@code groups[].id}. Catches typos that
+ * silently hide a property's section header in the modeler.
+ */
+public class GroupTargetExistsRule implements Rule {
+
+  public static final String ID = "group-target-exists";
+
+  @Override
+  public String id() {
+    return ID;
+  }
+
+  @Override
+  public List<Finding> apply(Path file, JsonNode template) {
+    Set<String> groupIds = new HashSet<>();
+    JsonNode groups = template.path("groups");
+    if (groups.isArray()) {
+      for (JsonNode g : groups) {
+        JsonNode idNode = g.path("id");
+        if (idNode.isTextual()) {
+          groupIds.add(idNode.asText());
+        }
+      }
+    }
+
+    List<Finding> findings = new ArrayList<>();
+    JsonNode properties = template.path("properties");
+    if (!properties.isArray()) {
+      return findings;
+    }
+    for (int i = 0; i < properties.size(); i++) {
+      JsonNode property = properties.get(i);
+      JsonNode groupRef = property.path("group");
+      if (!groupRef.isTextual()) {
+        continue;
+      }
+      String referenced = groupRef.asText();
+      if (!groupIds.contains(referenced)) {
+        findings.add(
+            Finding.error(
+                file,
+                "/properties/" + i + "/group",
+                ID,
+                "Property references group \""
+                    + referenced
+                    + "\" which is not declared in groups[]."));
+      }
+    }
+    return findings;
+  }
+}

--- a/element-template-generator/validator/src/main/java/io/camunda/connector/validator/rule/GroupTargetExistsRule.java
+++ b/element-template-generator/validator/src/main/java/io/camunda/connector/validator/rule/GroupTargetExistsRule.java
@@ -17,6 +17,7 @@
 package io.camunda.connector.validator.rule;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import io.camunda.connector.validator.core.ElementTemplate;
 import io.camunda.connector.validator.core.Finding;
 import io.camunda.connector.validator.core.Rule;
 import java.nio.file.Path;
@@ -31,20 +32,13 @@ import java.util.Set;
  */
 public class GroupTargetExistsRule implements Rule {
 
-  public static final String ID = "group-target-exists";
-
-  @Override
-  public String id() {
-    return ID;
-  }
-
   @Override
   public List<Finding> apply(Path file, JsonNode template) {
     Set<String> groupIds = new HashSet<>();
-    JsonNode groups = template.path("groups");
+    JsonNode groups = template.path(ElementTemplate.GROUPS);
     if (groups.isArray()) {
       for (JsonNode g : groups) {
-        JsonNode idNode = g.path("id");
+        JsonNode idNode = g.path(ElementTemplate.ID);
         if (idNode.isTextual()) {
           groupIds.add(idNode.asText());
         }
@@ -52,13 +46,13 @@ public class GroupTargetExistsRule implements Rule {
     }
 
     List<Finding> findings = new ArrayList<>();
-    JsonNode properties = template.path("properties");
+    JsonNode properties = template.path(ElementTemplate.PROPERTIES);
     if (!properties.isArray()) {
       return findings;
     }
     for (int i = 0; i < properties.size(); i++) {
       JsonNode property = properties.get(i);
-      JsonNode groupRef = property.path("group");
+      JsonNode groupRef = property.path(ElementTemplate.GROUP);
       if (!groupRef.isTextual()) {
         continue;
       }
@@ -68,7 +62,7 @@ public class GroupTargetExistsRule implements Rule {
             Finding.error(
                 file,
                 "/properties/" + i + "/group",
-                ID,
+                id(),
                 "Property references group \""
                     + referenced
                     + "\" which is not declared in groups[]."));

--- a/element-template-generator/validator/src/main/java/io/camunda/connector/validator/rule/HybridParityRule.java
+++ b/element-template-generator/validator/src/main/java/io/camunda/connector/validator/rule/HybridParityRule.java
@@ -1,0 +1,186 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.validator.rule;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.camunda.connector.validator.core.Finding;
+import io.camunda.connector.validator.core.MultiFileRule;
+import io.camunda.connector.validator.core.TemplateFinder;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * For every {@code .../element-templates/hybrid/<base>-hybrid.json}, the non-hybrid sibling at
+ * {@code .../element-templates/<base>.json} (or, where the file naming uses a {@code hybrid-}
+ * prefix as well, with that prefix stripped) must exist and declare the same set of {@code
+ * properties[].id} and {@code groups[].id}. Catches drift where one side gains/loses a property the
+ * other doesn't.
+ */
+public class HybridParityRule implements MultiFileRule {
+
+  public static final String ID = "hybrid-parity";
+
+  /** Properties / groups that are by design present only in the hybrid sibling (self-managed). */
+  private static final Set<String> HYBRID_ONLY_ALLOWED =
+      Set.of("taskDefinitionType", "connectorType");
+
+  /** Properties / groups that are by design present only in the non-hybrid sibling (SaaS). */
+  private static final Set<String> NON_HYBRID_ONLY_ALLOWED =
+      Set.of(
+          "deduplication",
+          "deduplicationId",
+          "deduplicationModeAuto",
+          "deduplicationModeManual",
+          "deduplicationModeManualFlag",
+          "consumeUnmatchedEvents",
+          "messageTtl");
+
+  @Override
+  public String id() {
+    return ID;
+  }
+
+  @Override
+  public List<Finding> apply(Map<Path, JsonNode> templates) {
+    List<Finding> findings = new ArrayList<>();
+    for (Map.Entry<Path, JsonNode> entry : templates.entrySet()) {
+      Path hybrid = entry.getKey();
+      if (!isHybridTemplate(hybrid) || TemplateFinder.isVersioned(hybrid)) {
+        continue;
+      }
+      Path sibling = findSibling(hybrid, templates.keySet());
+      if (sibling == null) {
+        findings.add(
+            Finding.error(
+                hybrid,
+                "/",
+                ID,
+                "Hybrid template has no matching non-hybrid sibling at "
+                    + expectedSiblingHint(hybrid)
+                    + "."));
+        continue;
+      }
+      JsonNode hybridTemplate = entry.getValue();
+      JsonNode mainTemplate = templates.get(sibling);
+      compareIdSet(hybrid, hybridTemplate, mainTemplate, sibling, "properties", findings);
+      compareIdSet(hybrid, hybridTemplate, mainTemplate, sibling, "groups", findings);
+    }
+    return findings;
+  }
+
+  private void compareIdSet(
+      Path hybrid,
+      JsonNode hybridTemplate,
+      JsonNode mainTemplate,
+      Path mainPath,
+      String collectionField,
+      List<Finding> findings) {
+    Set<String> hybridIds = collectIds(hybridTemplate, collectionField);
+    Set<String> mainIds = collectIds(mainTemplate, collectionField);
+
+    Set<String> onlyInHybrid = new LinkedHashSet<>(hybridIds);
+    onlyInHybrid.removeAll(mainIds);
+    onlyInHybrid.removeIf(HYBRID_ONLY_ALLOWED::contains);
+    Set<String> onlyInMain = new LinkedHashSet<>(mainIds);
+    onlyInMain.removeAll(hybridIds);
+    onlyInMain.removeIf(NON_HYBRID_ONLY_ALLOWED::contains);
+
+    if (!onlyInHybrid.isEmpty()) {
+      findings.add(
+          Finding.error(
+              hybrid,
+              "/" + collectionField,
+              ID,
+              "Hybrid declares "
+                  + collectionField
+                  + " not present in non-hybrid sibling ("
+                  + mainPath.getFileName()
+                  + "): "
+                  + onlyInHybrid
+                  + "."));
+    }
+    if (!onlyInMain.isEmpty()) {
+      findings.add(
+          Finding.error(
+              hybrid,
+              "/" + collectionField,
+              ID,
+              "Non-hybrid sibling ("
+                  + mainPath.getFileName()
+                  + ") declares "
+                  + collectionField
+                  + " not present in hybrid: "
+                  + onlyInMain
+                  + "."));
+    }
+  }
+
+  private Set<String> collectIds(JsonNode template, String field) {
+    Set<String> ids = new LinkedHashSet<>();
+    JsonNode arr = template.path(field);
+    if (arr.isArray()) {
+      for (JsonNode item : arr) {
+        JsonNode id = item.path("id");
+        if (id.isTextual()) {
+          ids.add(id.asText());
+        }
+      }
+    }
+    return ids;
+  }
+
+  private static boolean isHybridTemplate(Path path) {
+    String name = path.getFileName().toString();
+    if (!name.endsWith("-hybrid.json")) {
+      return false;
+    }
+    for (Path segment : path) {
+      if ("hybrid".equals(segment.toString())) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static Path findSibling(Path hybrid, Set<Path> known) {
+    Path elementTemplatesDir = hybrid.getParent().getParent();
+    String name = hybrid.getFileName().toString();
+    String base = name.substring(0, name.length() - "-hybrid.json".length());
+    Path direct = elementTemplatesDir.resolve(base + ".json");
+    if (known.contains(direct)) {
+      return direct;
+    }
+    if (base.startsWith("hybrid-")) {
+      Path stripped = elementTemplatesDir.resolve(base.substring("hybrid-".length()) + ".json");
+      if (known.contains(stripped)) {
+        return stripped;
+      }
+    }
+    return null;
+  }
+
+  private static String expectedSiblingHint(Path hybrid) {
+    Path elementTemplatesDir = hybrid.getParent().getParent();
+    String name = hybrid.getFileName().toString();
+    String base = name.substring(0, name.length() - "-hybrid.json".length());
+    return elementTemplatesDir.resolve(base + ".json").toString();
+  }
+}

--- a/element-template-generator/validator/src/main/java/io/camunda/connector/validator/rule/HybridParityRule.java
+++ b/element-template-generator/validator/src/main/java/io/camunda/connector/validator/rule/HybridParityRule.java
@@ -17,6 +17,7 @@
 package io.camunda.connector.validator.rule;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import io.camunda.connector.validator.core.ElementTemplate;
 import io.camunda.connector.validator.core.Finding;
 import io.camunda.connector.validator.core.MultiFileRule;
 import io.camunda.connector.validator.core.TemplateFinder;
@@ -36,8 +37,6 @@ import java.util.Set;
  */
 public class HybridParityRule implements MultiFileRule {
 
-  public static final String ID = "hybrid-parity";
-
   /** Properties / groups that are by design present only in the hybrid sibling (self-managed). */
   private static final Set<String> HYBRID_ONLY_ALLOWED =
       Set.of("taskDefinitionType", "connectorType");
@@ -54,11 +53,6 @@ public class HybridParityRule implements MultiFileRule {
           "messageTtl");
 
   @Override
-  public String id() {
-    return ID;
-  }
-
-  @Override
   public List<Finding> apply(Map<Path, JsonNode> templates) {
     List<Finding> findings = new ArrayList<>();
     for (Map.Entry<Path, JsonNode> entry : templates.entrySet()) {
@@ -72,7 +66,7 @@ public class HybridParityRule implements MultiFileRule {
             Finding.error(
                 hybrid,
                 "/",
-                ID,
+                id(),
                 "Hybrid template has no matching non-hybrid sibling at "
                     + expectedSiblingHint(hybrid)
                     + "."));
@@ -108,7 +102,7 @@ public class HybridParityRule implements MultiFileRule {
           Finding.error(
               hybrid,
               "/" + collectionField,
-              ID,
+              id(),
               "Hybrid declares "
                   + collectionField
                   + " not present in non-hybrid sibling ("
@@ -122,7 +116,7 @@ public class HybridParityRule implements MultiFileRule {
           Finding.error(
               hybrid,
               "/" + collectionField,
-              ID,
+              id(),
               "Non-hybrid sibling ("
                   + mainPath.getFileName()
                   + ") declares "
@@ -138,7 +132,7 @@ public class HybridParityRule implements MultiFileRule {
     JsonNode arr = template.path(field);
     if (arr.isArray()) {
       for (JsonNode item : arr) {
-        JsonNode id = item.path("id");
+        JsonNode id = item.path(ElementTemplate.ID);
         if (id.isTextual()) {
           ids.add(id.asText());
         }

--- a/element-template-generator/validator/src/main/java/io/camunda/connector/validator/rule/PresetTargetExistsRule.java
+++ b/element-template-generator/validator/src/main/java/io/camunda/connector/validator/rule/PresetTargetExistsRule.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.validator.rule;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.camunda.connector.validator.core.Finding;
+import io.camunda.connector.validator.core.JsonPointers;
+import io.camunda.connector.validator.core.Rule;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Each entry in any {@code presets} object must reference a property {@code id} that exists in the
+ * template's top-level {@code properties[]}, and the value must be one of the property's declared
+ * {@code choices} (when choices are declared).
+ *
+ * <p>The {@code presets} field is an object keyed by property id, e.g.
+ *
+ * <pre>{@code
+ * "presets": { "operationGroup": "actions", "eventOperationType": "createWorkflowDispatchEvent" }
+ * }</pre>
+ *
+ * <p>The rule scans for {@code presets} objects anywhere in the tree, so it covers the typical
+ * {@code template.steps[].steps[].presets} nesting as well as any other location.
+ */
+public class PresetTargetExistsRule implements Rule {
+
+  public static final String ID = "preset-target-exists";
+
+  @Override
+  public String id() {
+    return ID;
+  }
+
+  @Override
+  public List<Finding> apply(Path file, JsonNode template) {
+    Map<String, Set<String>> propertyChoices = collectPropertyChoices(template);
+    List<Finding> findings = new ArrayList<>();
+    walk(template, "", file, propertyChoices, findings);
+    return findings;
+  }
+
+  private Map<String, Set<String>> collectPropertyChoices(JsonNode template) {
+    Map<String, Set<String>> result = new HashMap<>();
+    JsonNode props = template.path("properties");
+    if (!props.isArray()) {
+      return result;
+    }
+    for (JsonNode prop : props) {
+      JsonNode idNode = prop.path("id");
+      if (!idNode.isTextual()) {
+        continue;
+      }
+      String propertyId = idNode.asText();
+      Set<String> choices = new HashSet<>();
+      JsonNode choicesNode = prop.path("choices");
+      if (choicesNode.isArray()) {
+        for (JsonNode choice : choicesNode) {
+          JsonNode value = choice.path("value");
+          if (value.isTextual()) {
+            choices.add(value.asText());
+          }
+        }
+      }
+      result.put(propertyId, choices);
+    }
+    return result;
+  }
+
+  private void walk(
+      JsonNode node,
+      String pointer,
+      Path file,
+      Map<String, Set<String>> propertyChoices,
+      List<Finding> findings) {
+    if (node.isObject()) {
+      Iterator<Map.Entry<String, JsonNode>> fields = node.fields();
+      while (fields.hasNext()) {
+        Map.Entry<String, JsonNode> entry = fields.next();
+        String childPointer = pointer + "/" + JsonPointers.escape(entry.getKey());
+        if ("presets".equals(entry.getKey()) && entry.getValue().isObject()) {
+          checkPresets(entry.getValue(), childPointer, file, propertyChoices, findings);
+        }
+        walk(entry.getValue(), childPointer, file, propertyChoices, findings);
+      }
+    } else if (node.isArray()) {
+      for (int i = 0; i < node.size(); i++) {
+        walk(node.get(i), pointer + "/" + i, file, propertyChoices, findings);
+      }
+    }
+  }
+
+  private void checkPresets(
+      JsonNode presets,
+      String presetsPointer,
+      Path file,
+      Map<String, Set<String>> propertyChoices,
+      List<Finding> findings) {
+    Iterator<Map.Entry<String, JsonNode>> entries = presets.fields();
+    while (entries.hasNext()) {
+      Map.Entry<String, JsonNode> entry = entries.next();
+      String propertyId = entry.getKey();
+      JsonNode value = entry.getValue();
+      String entryPointer = presetsPointer + "/" + JsonPointers.escape(propertyId);
+
+      if (!propertyChoices.containsKey(propertyId)) {
+        findings.add(
+            Finding.error(
+                file,
+                entryPointer,
+                ID,
+                "Preset references property \""
+                    + propertyId
+                    + "\" which does not exist in this template."));
+        continue;
+      }
+
+      if (!value.isTextual()) {
+        continue;
+      }
+      Set<String> choices = propertyChoices.get(propertyId);
+      if (!choices.isEmpty() && !choices.contains(value.asText())) {
+        findings.add(
+            Finding.error(
+                file,
+                entryPointer,
+                ID,
+                "Preset value \""
+                    + value.asText()
+                    + "\" is not one of the declared choices for property \""
+                    + propertyId
+                    + "\"."));
+      }
+    }
+  }
+}

--- a/element-template-generator/validator/src/main/java/io/camunda/connector/validator/rule/PresetTargetExistsRule.java
+++ b/element-template-generator/validator/src/main/java/io/camunda/connector/validator/rule/PresetTargetExistsRule.java
@@ -17,6 +17,7 @@
 package io.camunda.connector.validator.rule;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import io.camunda.connector.validator.core.ElementTemplate;
 import io.camunda.connector.validator.core.Finding;
 import io.camunda.connector.validator.core.JsonPointers;
 import io.camunda.connector.validator.core.Rule;
@@ -44,13 +45,6 @@ import java.util.Set;
  */
 public class PresetTargetExistsRule implements Rule {
 
-  public static final String ID = "preset-target-exists";
-
-  @Override
-  public String id() {
-    return ID;
-  }
-
   @Override
   public List<Finding> apply(Path file, JsonNode template) {
     Map<String, Set<String>> propertyChoices = collectPropertyChoices(template);
@@ -61,22 +55,22 @@ public class PresetTargetExistsRule implements Rule {
 
   private Map<String, Set<String>> collectPropertyChoices(JsonNode template) {
     Map<String, Set<String>> result = new HashMap<>();
-    JsonNode props = template.path("properties");
+    JsonNode props = template.path(ElementTemplate.PROPERTIES);
     if (!props.isArray()) {
       return result;
     }
     for (JsonNode prop : props) {
-      JsonNode idNode = prop.path("id");
+      JsonNode idNode = prop.path(ElementTemplate.ID);
       if (!idNode.isTextual()) {
         continue;
       }
       // Union choice sets across duplicate ids so the mutually-exclusive switching pattern
       // (same id, different conditions, possibly different choices) does not lose values.
       Set<String> choices = result.computeIfAbsent(idNode.asText(), k -> new HashSet<>());
-      JsonNode choicesNode = prop.path("choices");
+      JsonNode choicesNode = prop.path(ElementTemplate.CHOICES);
       if (choicesNode.isArray()) {
         for (JsonNode choice : choicesNode) {
-          JsonNode value = choice.path("value");
+          JsonNode value = choice.path(ElementTemplate.VALUE);
           if (value.isTextual()) {
             choices.add(value.asText());
           }
@@ -95,7 +89,7 @@ public class PresetTargetExistsRule implements Rule {
     if (node.isObject()) {
       for (Map.Entry<String, JsonNode> entry : node.properties()) {
         String childPointer = pointer + "/" + JsonPointers.escape(entry.getKey());
-        if ("presets".equals(entry.getKey()) && entry.getValue().isObject()) {
+        if (ElementTemplate.PRESETS.equals(entry.getKey()) && entry.getValue().isObject()) {
           checkPresets(entry.getValue(), childPointer, file, propertyChoices, findings);
         }
         walk(entry.getValue(), childPointer, file, propertyChoices, findings);
@@ -123,7 +117,7 @@ public class PresetTargetExistsRule implements Rule {
             Finding.error(
                 file,
                 entryPointer,
-                ID,
+                id(),
                 "Preset references property \""
                     + propertyId
                     + "\" which does not exist in this template."));
@@ -139,7 +133,7 @@ public class PresetTargetExistsRule implements Rule {
             Finding.error(
                 file,
                 entryPointer,
-                ID,
+                id(),
                 "Preset value \""
                     + value.asText()
                     + "\" is not one of the declared choices for property \""

--- a/element-template-generator/validator/src/main/java/io/camunda/connector/validator/rule/PresetTargetExistsRule.java
+++ b/element-template-generator/validator/src/main/java/io/camunda/connector/validator/rule/PresetTargetExistsRule.java
@@ -70,8 +70,9 @@ public class PresetTargetExistsRule implements Rule {
       if (!idNode.isTextual()) {
         continue;
       }
-      String propertyId = idNode.asText();
-      Set<String> choices = new HashSet<>();
+      // Union choice sets across duplicate ids so the mutually-exclusive switching pattern
+      // (same id, different conditions, possibly different choices) does not lose values.
+      Set<String> choices = result.computeIfAbsent(idNode.asText(), k -> new HashSet<>());
       JsonNode choicesNode = prop.path("choices");
       if (choicesNode.isArray()) {
         for (JsonNode choice : choicesNode) {
@@ -81,7 +82,6 @@ public class PresetTargetExistsRule implements Rule {
           }
         }
       }
-      result.put(propertyId, choices);
     }
     return result;
   }

--- a/element-template-generator/validator/src/main/java/io/camunda/connector/validator/rule/PresetTargetExistsRule.java
+++ b/element-template-generator/validator/src/main/java/io/camunda/connector/validator/rule/PresetTargetExistsRule.java
@@ -24,7 +24,6 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -94,9 +93,7 @@ public class PresetTargetExistsRule implements Rule {
       Map<String, Set<String>> propertyChoices,
       List<Finding> findings) {
     if (node.isObject()) {
-      Iterator<Map.Entry<String, JsonNode>> fields = node.fields();
-      while (fields.hasNext()) {
-        Map.Entry<String, JsonNode> entry = fields.next();
+      for (Map.Entry<String, JsonNode> entry : node.properties()) {
         String childPointer = pointer + "/" + JsonPointers.escape(entry.getKey());
         if ("presets".equals(entry.getKey()) && entry.getValue().isObject()) {
           checkPresets(entry.getValue(), childPointer, file, propertyChoices, findings);
@@ -116,9 +113,7 @@ public class PresetTargetExistsRule implements Rule {
       Path file,
       Map<String, Set<String>> propertyChoices,
       List<Finding> findings) {
-    Iterator<Map.Entry<String, JsonNode>> entries = presets.fields();
-    while (entries.hasNext()) {
-      Map.Entry<String, JsonNode> entry = entries.next();
+    for (Map.Entry<String, JsonNode> entry : presets.properties()) {
       String propertyId = entry.getKey();
       JsonNode value = entry.getValue();
       String entryPointer = presetsPointer + "/" + JsonPointers.escape(propertyId);

--- a/element-template-generator/validator/src/main/java/io/camunda/connector/validator/rule/SchemaRule.java
+++ b/element-template-generator/validator/src/main/java/io/camunda/connector/validator/rule/SchemaRule.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.validator.rule;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.networknt.schema.JsonSchema;
+import com.networknt.schema.JsonSchemaFactory;
+import com.networknt.schema.SchemaValidatorsConfig;
+import com.networknt.schema.SpecVersion;
+import com.networknt.schema.ValidationMessage;
+import io.camunda.connector.validator.core.Finding;
+import io.camunda.connector.validator.core.Rule;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Validates each template against the upstream Camunda element-template JSON schema.
+ *
+ * <p>Schema is fetched once at construction from {@link #SCHEMA_URL}. If the fetch fails the
+ * constructor throws — failing loudly is preferable to silently skipping schema validation.
+ */
+public class SchemaRule implements Rule {
+
+  public static final String ID = "schema";
+  public static final String SCHEMA_URL =
+      "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json";
+
+  private final JsonSchema schema;
+
+  public SchemaRule() {
+    this(SCHEMA_URL);
+  }
+
+  public SchemaRule(String schemaUrl) {
+    this.schema = loadSchema(schemaUrl);
+  }
+
+  @Override
+  public String id() {
+    return ID;
+  }
+
+  @Override
+  public List<Finding> apply(Path file, JsonNode template) {
+    Set<ValidationMessage> messages = schema.validate(template);
+    return messages.stream()
+        .map(m -> Finding.error(file, m.getInstanceLocation().toString(), ID, m.getMessage()))
+        .toList();
+  }
+
+  private static JsonSchema loadSchema(String url) {
+    try {
+      HttpClient client =
+          HttpClient.newBuilder()
+              .followRedirects(HttpClient.Redirect.NORMAL)
+              .connectTimeout(Duration.ofSeconds(10))
+              .build();
+      HttpRequest request =
+          HttpRequest.newBuilder(URI.create(url)).timeout(Duration.ofSeconds(20)).GET().build();
+      HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+      if (response.statusCode() / 100 != 2) {
+        throw new IllegalStateException(
+            "Failed to fetch schema from " + url + ": HTTP " + response.statusCode());
+      }
+      ObjectMapper mapper = new ObjectMapper();
+      JsonNode schemaNode = mapper.readTree(response.body());
+      JsonSchemaFactory factory = JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V7);
+      SchemaValidatorsConfig config = new SchemaValidatorsConfig();
+      return factory.getSchema(schemaNode, config);
+    } catch (IOException e) {
+      throw new UncheckedIOException("Failed to fetch element-template schema from " + url, e);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new RuntimeException("Interrupted while fetching schema", e);
+    }
+  }
+}

--- a/element-template-generator/validator/src/main/java/io/camunda/connector/validator/rule/SchemaRule.java
+++ b/element-template-generator/validator/src/main/java/io/camunda/connector/validator/rule/SchemaRule.java
@@ -45,8 +45,18 @@ import java.util.Set;
 public class SchemaRule implements Rule {
 
   public static final String ID = "schema";
+
+  /**
+   * Pinned schema version. Bump deliberately (in lockstep with the connectors-team upgrade) rather
+   * than tracking {@code latest}, so validator behavior is reproducible across CI runs and local
+   * machines. Override at runtime via {@code --schema-url} or {@code CAMUNDA_TEMPLATE_SCHEMA_URL}.
+   */
+  public static final String SCHEMA_VERSION = "0.40.0";
+
   public static final String SCHEMA_URL =
-      "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json";
+      "https://unpkg.com/@camunda/zeebe-element-templates-json-schema@"
+          + SCHEMA_VERSION
+          + "/resources/schema.json";
 
   private final JsonSchema schema;
 

--- a/element-template-generator/validator/src/main/java/io/camunda/connector/validator/rule/SchemaRule.java
+++ b/element-template-generator/validator/src/main/java/io/camunda/connector/validator/rule/SchemaRule.java
@@ -44,8 +44,6 @@ import java.util.Set;
  */
 public class SchemaRule implements Rule {
 
-  public static final String ID = "schema";
-
   /**
    * Pinned schema version. Bump deliberately (in lockstep with the connectors-team upgrade) rather
    * than tracking {@code latest}, so validator behavior is reproducible across CI runs and local
@@ -69,15 +67,10 @@ public class SchemaRule implements Rule {
   }
 
   @Override
-  public String id() {
-    return ID;
-  }
-
-  @Override
   public List<Finding> apply(Path file, JsonNode template) {
     Set<ValidationMessage> messages = schema.validate(template);
     return messages.stream()
-        .map(m -> Finding.error(file, m.getInstanceLocation().toString(), ID, m.getMessage()))
+        .map(m -> Finding.error(file, m.getInstanceLocation().toString(), id(), m.getMessage()))
         .toList();
   }
 

--- a/element-template-generator/validator/src/main/java/io/camunda/connector/validator/rule/TaskDefinitionBindingFormRule.java
+++ b/element-template-generator/validator/src/main/java/io/camunda/connector/validator/rule/TaskDefinitionBindingFormRule.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.validator.rule;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.camunda.connector.validator.core.Finding;
+import io.camunda.connector.validator.core.Rule;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * The legacy binding type {@code zeebe:taskDefinition:type} must not be used; the canonical form is
+ * {@code zeebe:taskDefinition} with {@code property: "type"} (and likewise for other taskDefinition
+ * properties such as {@code retries}).
+ *
+ * <p>The element-template JSON schema currently accepts both spellings without warning, but the
+ * generator and all newer templates use the canonical form. Hand-written templates that copy older
+ * patterns can still drift to the legacy form — this rule prevents that.
+ */
+public class TaskDefinitionBindingFormRule implements Rule {
+
+  public static final String ID = "task-definition-binding-form";
+  private static final String LEGACY_BINDING_TYPE = "zeebe:taskDefinition:type";
+
+  @Override
+  public String id() {
+    return ID;
+  }
+
+  @Override
+  public List<Finding> apply(Path file, JsonNode template) {
+    JsonNode properties = template.path("properties");
+    if (!properties.isArray()) {
+      return List.of();
+    }
+    List<Finding> findings = new ArrayList<>();
+    for (int i = 0; i < properties.size(); i++) {
+      JsonNode binding = properties.get(i).path("binding");
+      if (!binding.isObject()) {
+        continue;
+      }
+      JsonNode bindingType = binding.path("type");
+      if (bindingType.isTextual() && LEGACY_BINDING_TYPE.equals(bindingType.asText())) {
+        findings.add(
+            Finding.error(
+                file,
+                "/properties/" + i + "/binding/type",
+                ID,
+                "Legacy binding type \""
+                    + LEGACY_BINDING_TYPE
+                    + "\" is not allowed. Use { \"type\": \"zeebe:taskDefinition\", \"property\":"
+                    + " \"type\" } instead."));
+      }
+    }
+    return findings;
+  }
+}

--- a/element-template-generator/validator/src/main/java/io/camunda/connector/validator/rule/TaskDefinitionBindingFormRule.java
+++ b/element-template-generator/validator/src/main/java/io/camunda/connector/validator/rule/TaskDefinitionBindingFormRule.java
@@ -17,6 +17,7 @@
 package io.camunda.connector.validator.rule;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import io.camunda.connector.validator.core.ElementTemplate;
 import io.camunda.connector.validator.core.Finding;
 import io.camunda.connector.validator.core.Rule;
 import java.nio.file.Path;
@@ -33,34 +34,27 @@ import java.util.List;
  * patterns can still drift to the legacy form — this rule prevents that.
  */
 public class TaskDefinitionBindingFormRule implements Rule {
-
-  public static final String ID = "task-definition-binding-form";
   private static final String LEGACY_BINDING_TYPE = "zeebe:taskDefinition:type";
 
   @Override
-  public String id() {
-    return ID;
-  }
-
-  @Override
   public List<Finding> apply(Path file, JsonNode template) {
-    JsonNode properties = template.path("properties");
+    JsonNode properties = template.path(ElementTemplate.PROPERTIES);
     if (!properties.isArray()) {
       return List.of();
     }
     List<Finding> findings = new ArrayList<>();
     for (int i = 0; i < properties.size(); i++) {
-      JsonNode binding = properties.get(i).path("binding");
+      JsonNode binding = properties.get(i).path(ElementTemplate.BINDING);
       if (!binding.isObject()) {
         continue;
       }
-      JsonNode bindingType = binding.path("type");
+      JsonNode bindingType = binding.path(ElementTemplate.TYPE);
       if (bindingType.isTextual() && LEGACY_BINDING_TYPE.equals(bindingType.asText())) {
         findings.add(
             Finding.error(
                 file,
                 "/properties/" + i + "/binding/type",
-                ID,
+                id(),
                 "Legacy binding type \""
                     + LEGACY_BINDING_TYPE
                     + "\" is not allowed. Use { \"type\": \"zeebe:taskDefinition\", \"property\":"

--- a/element-template-generator/validator/src/main/java/io/camunda/connector/validator/rule/UniqueGroupIdRule.java
+++ b/element-template-generator/validator/src/main/java/io/camunda/connector/validator/rule/UniqueGroupIdRule.java
@@ -17,6 +17,7 @@
 package io.camunda.connector.validator.rule;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import io.camunda.connector.validator.core.ElementTemplate;
 import io.camunda.connector.validator.core.Finding;
 import io.camunda.connector.validator.core.Rule;
 import java.nio.file.Path;
@@ -28,23 +29,16 @@ import java.util.Map;
 /** Each entry in {@code groups[]} must have a unique {@code id}. */
 public class UniqueGroupIdRule implements Rule {
 
-  public static final String ID = "unique-group-id";
-
-  @Override
-  public String id() {
-    return ID;
-  }
-
   @Override
   public List<Finding> apply(Path file, JsonNode template) {
-    JsonNode groups = template.path("groups");
+    JsonNode groups = template.path(ElementTemplate.GROUPS);
     if (!groups.isArray()) {
       return List.of();
     }
     Map<String, Integer> firstSeen = new HashMap<>();
     List<Finding> findings = new ArrayList<>();
     for (int i = 0; i < groups.size(); i++) {
-      JsonNode idNode = groups.get(i).path("id");
+      JsonNode idNode = groups.get(i).path(ElementTemplate.ID);
       if (!idNode.isTextual()) {
         continue;
       }
@@ -55,7 +49,7 @@ public class UniqueGroupIdRule implements Rule {
             Finding.error(
                 file,
                 "/groups/" + i + "/id",
-                ID,
+                id(),
                 "Duplicate group id \""
                     + groupId
                     + "\" — first declared at /groups/"

--- a/element-template-generator/validator/src/main/java/io/camunda/connector/validator/rule/UniqueGroupIdRule.java
+++ b/element-template-generator/validator/src/main/java/io/camunda/connector/validator/rule/UniqueGroupIdRule.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.validator.rule;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.camunda.connector.validator.core.Finding;
+import io.camunda.connector.validator.core.Rule;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/** Each entry in {@code groups[]} must have a unique {@code id}. */
+public class UniqueGroupIdRule implements Rule {
+
+  public static final String ID = "unique-group-id";
+
+  @Override
+  public String id() {
+    return ID;
+  }
+
+  @Override
+  public List<Finding> apply(Path file, JsonNode template) {
+    JsonNode groups = template.path("groups");
+    if (!groups.isArray()) {
+      return List.of();
+    }
+    Map<String, Integer> firstSeen = new HashMap<>();
+    List<Finding> findings = new ArrayList<>();
+    for (int i = 0; i < groups.size(); i++) {
+      JsonNode idNode = groups.get(i).path("id");
+      if (!idNode.isTextual()) {
+        continue;
+      }
+      String groupId = idNode.asText();
+      Integer previous = firstSeen.putIfAbsent(groupId, i);
+      if (previous != null) {
+        findings.add(
+            Finding.error(
+                file,
+                "/groups/" + i + "/id",
+                ID,
+                "Duplicate group id \""
+                    + groupId
+                    + "\" — first declared at /groups/"
+                    + previous
+                    + "/id."));
+      }
+    }
+    return findings;
+  }
+}

--- a/element-template-generator/validator/src/main/java/io/camunda/connector/validator/rule/UniqueIdVersionRule.java
+++ b/element-template-generator/validator/src/main/java/io/camunda/connector/validator/rule/UniqueIdVersionRule.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.validator.rule;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.camunda.connector.validator.core.Finding;
+import io.camunda.connector.validator.core.MultiFileRule;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * No two element templates — current or versioned snapshot — may share both the same {@code id}
+ * <em>and</em> the same {@code version}. The Camunda Web Modeler dedupes templates by id+version
+ * when importing (highest-version-wins), so duplicates collide silently — masking accidental
+ * copies, snapshots that weren't promoted to a new version, or content changes that didn't bump the
+ * version field.
+ *
+ * <p>Templates missing {@code id} or {@code version} are skipped (other rules flag those).
+ */
+public class UniqueIdVersionRule implements MultiFileRule {
+
+  public static final String ID = "unique-id-version";
+
+  @Override
+  public String id() {
+    return ID;
+  }
+
+  @Override
+  public List<Finding> apply(Map<Path, JsonNode> templates) {
+    Map<String, List<Path>> byKey = new LinkedHashMap<>();
+    for (Map.Entry<Path, JsonNode> entry : templates.entrySet()) {
+      JsonNode template = entry.getValue();
+      JsonNode idNode = template.path("id");
+      JsonNode versionNode = template.path("version");
+      if (!idNode.isTextual() || !versionNode.isNumber()) {
+        continue;
+      }
+      String key = idNode.asText() + "@" + versionNode.asInt();
+      byKey.computeIfAbsent(key, k -> new ArrayList<>()).add(entry.getKey());
+    }
+    List<Finding> findings = new ArrayList<>();
+    for (Map.Entry<String, List<Path>> entry : byKey.entrySet()) {
+      List<Path> paths = entry.getValue();
+      if (paths.size() < 2) {
+        continue;
+      }
+      String[] parts = entry.getKey().split("@", 2);
+      String tmplId = parts[0];
+      String version = parts[1];
+      for (Path p : paths) {
+        String others =
+            paths.stream()
+                .filter(q -> !q.equals(p))
+                .map(Path::toString)
+                .collect(Collectors.joining(", "));
+        findings.add(
+            Finding.error(
+                p,
+                "/",
+                ID,
+                "Duplicate id+version: id=\""
+                    + tmplId
+                    + "\", version="
+                    + version
+                    + " also declared in: "
+                    + others));
+      }
+    }
+    return findings;
+  }
+}

--- a/element-template-generator/validator/src/main/java/io/camunda/connector/validator/rule/UniqueIdVersionRule.java
+++ b/element-template-generator/validator/src/main/java/io/camunda/connector/validator/rule/UniqueIdVersionRule.java
@@ -17,6 +17,7 @@
 package io.camunda.connector.validator.rule;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import io.camunda.connector.validator.core.ElementTemplate;
 import io.camunda.connector.validator.core.Finding;
 import io.camunda.connector.validator.core.MultiFileRule;
 import java.nio.file.Path;
@@ -37,20 +38,13 @@ import java.util.stream.Collectors;
  */
 public class UniqueIdVersionRule implements MultiFileRule {
 
-  public static final String ID = "unique-id-version";
-
-  @Override
-  public String id() {
-    return ID;
-  }
-
   @Override
   public List<Finding> apply(Map<Path, JsonNode> templates) {
     Map<String, List<Path>> byKey = new LinkedHashMap<>();
     for (Map.Entry<Path, JsonNode> entry : templates.entrySet()) {
       JsonNode template = entry.getValue();
-      JsonNode idNode = template.path("id");
-      JsonNode versionNode = template.path("version");
+      JsonNode idNode = template.path(ElementTemplate.ID);
+      JsonNode versionNode = template.path(ElementTemplate.VERSION);
       if (!idNode.isTextual() || !versionNode.isNumber()) {
         continue;
       }
@@ -76,7 +70,7 @@ public class UniqueIdVersionRule implements MultiFileRule {
             Finding.error(
                 p,
                 "/",
-                ID,
+                id(),
                 "Duplicate id+version: id=\""
                     + tmplId
                     + "\", version="

--- a/element-template-generator/validator/src/main/java/io/camunda/connector/validator/rule/UniquePropertyIdRule.java
+++ b/element-template-generator/validator/src/main/java/io/camunda/connector/validator/rule/UniquePropertyIdRule.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.validator.rule;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.camunda.connector.validator.core.Finding;
+import io.camunda.connector.validator.core.Rule;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Within a single template, no two entries in {@code properties[]} may share the same {@code id} —
+ * with one exception: duplicate-id properties whose visibility {@code condition}s are pairwise
+ * mutually exclusive are tolerated. That pattern is used in templates where a parent dropdown (e.g.
+ * {@code resourceType} / {@code operationType}) selects which of several variants is shown, and
+ * only one is ever live at a time.
+ *
+ * <p>"Mutually exclusive" here means: each pair of conditions targets the same {@code property},
+ * with disjoint {@code equals}/{@code oneOf} value sets — or any sub-condition pair inside their
+ * {@code allMatch} compounds is mutually exclusive. Properties without a condition are always live,
+ * so any duplicate involving an unconditional property is still flagged.
+ */
+public class UniquePropertyIdRule implements Rule {
+
+  public static final String ID = "unique-property-id";
+
+  @Override
+  public String id() {
+    return ID;
+  }
+
+  @Override
+  public List<Finding> apply(Path file, JsonNode template) {
+    JsonNode properties = template.path("properties");
+    if (!properties.isArray()) {
+      return List.of();
+    }
+    Map<String, List<Integer>> indicesById = new LinkedHashMap<>();
+    for (int i = 0; i < properties.size(); i++) {
+      JsonNode idNode = properties.get(i).path("id");
+      if (!idNode.isTextual()) {
+        continue;
+      }
+      indicesById.computeIfAbsent(idNode.asText(), k -> new ArrayList<>()).add(i);
+    }
+
+    List<Finding> findings = new ArrayList<>();
+    for (Map.Entry<String, List<Integer>> entry : indicesById.entrySet()) {
+      List<Integer> indices = entry.getValue();
+      if (indices.size() < 2) {
+        continue;
+      }
+      if (allPairsMutuallyExclusive(indices, properties)) {
+        continue;
+      }
+      String propertyId = entry.getKey();
+      int firstIndex = indices.get(0);
+      for (int k = 1; k < indices.size(); k++) {
+        int duplicateIndex = indices.get(k);
+        findings.add(
+            Finding.error(
+                file,
+                "/properties/" + duplicateIndex + "/id",
+                ID,
+                "Property id \""
+                    + propertyId
+                    + "\" is already declared at /properties/"
+                    + firstIndex
+                    + "/id."));
+      }
+    }
+    return findings;
+  }
+
+  private static boolean allPairsMutuallyExclusive(List<Integer> indices, JsonNode properties) {
+    for (int i = 0; i < indices.size(); i++) {
+      JsonNode condA = properties.get(indices.get(i)).path("condition");
+      if (!condA.isObject()) {
+        return false;
+      }
+      for (int j = i + 1; j < indices.size(); j++) {
+        JsonNode condB = properties.get(indices.get(j)).path("condition");
+        if (!condB.isObject()) {
+          return false;
+        }
+        if (!mutuallyExclusive(condA, condB)) {
+          return false;
+        }
+      }
+    }
+    return true;
+  }
+
+  private static boolean mutuallyExclusive(JsonNode c1, JsonNode c2) {
+    JsonNode p1 = c1.path("property");
+    JsonNode p2 = c2.path("property");
+    if (p1.isTextual() && p2.isTextual() && p1.asText().equals(p2.asText())) {
+      Set<String> v1 = collectSimpleValues(c1);
+      Set<String> v2 = collectSimpleValues(c2);
+      if (!v1.isEmpty() && !v2.isEmpty() && Collections.disjoint(v1, v2)) {
+        return true;
+      }
+    }
+    JsonNode am1 = c1.path("allMatch");
+    if (am1.isArray()) {
+      for (JsonNode sub : am1) {
+        if (sub.isObject() && mutuallyExclusive(sub, c2)) {
+          return true;
+        }
+      }
+    }
+    JsonNode am2 = c2.path("allMatch");
+    if (am2.isArray()) {
+      for (JsonNode sub : am2) {
+        if (sub.isObject() && mutuallyExclusive(c1, sub)) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  private static Set<String> collectSimpleValues(JsonNode condition) {
+    Set<String> values = new HashSet<>();
+    JsonNode equals = condition.path("equals");
+    if (equals.isTextual()) {
+      values.add(equals.asText());
+    }
+    JsonNode oneOf = condition.path("oneOf");
+    if (oneOf.isArray()) {
+      for (JsonNode v : oneOf) {
+        if (v.isTextual()) {
+          values.add(v.asText());
+        }
+      }
+    }
+    return values;
+  }
+}

--- a/element-template-generator/validator/src/main/java/io/camunda/connector/validator/rule/UniquePropertyIdRule.java
+++ b/element-template-generator/validator/src/main/java/io/camunda/connector/validator/rule/UniquePropertyIdRule.java
@@ -17,6 +17,7 @@
 package io.camunda.connector.validator.rule;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import io.camunda.connector.validator.core.ElementTemplate;
 import io.camunda.connector.validator.core.Finding;
 import io.camunda.connector.validator.core.Rule;
 import java.nio.file.Path;
@@ -42,22 +43,15 @@ import java.util.Set;
  */
 public class UniquePropertyIdRule implements Rule {
 
-  public static final String ID = "unique-property-id";
-
-  @Override
-  public String id() {
-    return ID;
-  }
-
   @Override
   public List<Finding> apply(Path file, JsonNode template) {
-    JsonNode properties = template.path("properties");
+    JsonNode properties = template.path(ElementTemplate.PROPERTIES);
     if (!properties.isArray()) {
       return List.of();
     }
     Map<String, List<Integer>> indicesById = new LinkedHashMap<>();
     for (int i = 0; i < properties.size(); i++) {
-      JsonNode idNode = properties.get(i).path("id");
+      JsonNode idNode = properties.get(i).path(ElementTemplate.ID);
       if (!idNode.isTextual()) {
         continue;
       }
@@ -81,7 +75,7 @@ public class UniquePropertyIdRule implements Rule {
             Finding.error(
                 file,
                 "/properties/" + duplicateIndex + "/id",
-                ID,
+                id(),
                 "Property id \""
                     + propertyId
                     + "\" is already declared at /properties/"
@@ -94,12 +88,12 @@ public class UniquePropertyIdRule implements Rule {
 
   private static boolean allPairsMutuallyExclusive(List<Integer> indices, JsonNode properties) {
     for (int i = 0; i < indices.size(); i++) {
-      JsonNode condA = properties.get(indices.get(i)).path("condition");
+      JsonNode condA = properties.get(indices.get(i)).path(ElementTemplate.CONDITION);
       if (!condA.isObject()) {
         return false;
       }
       for (int j = i + 1; j < indices.size(); j++) {
-        JsonNode condB = properties.get(indices.get(j)).path("condition");
+        JsonNode condB = properties.get(indices.get(j)).path(ElementTemplate.CONDITION);
         if (!condB.isObject()) {
           return false;
         }
@@ -112,8 +106,8 @@ public class UniquePropertyIdRule implements Rule {
   }
 
   private static boolean mutuallyExclusive(JsonNode c1, JsonNode c2) {
-    JsonNode p1 = c1.path("property");
-    JsonNode p2 = c2.path("property");
+    JsonNode p1 = c1.path(ElementTemplate.PROPERTY);
+    JsonNode p2 = c2.path(ElementTemplate.PROPERTY);
     if (p1.isTextual() && p2.isTextual() && p1.asText().equals(p2.asText())) {
       Set<String> v1 = collectSimpleValues(c1);
       Set<String> v2 = collectSimpleValues(c2);
@@ -121,7 +115,7 @@ public class UniquePropertyIdRule implements Rule {
         return true;
       }
     }
-    JsonNode am1 = c1.path("allMatch");
+    JsonNode am1 = c1.path(ElementTemplate.ALL_MATCH);
     if (am1.isArray()) {
       for (JsonNode sub : am1) {
         if (sub.isObject() && mutuallyExclusive(sub, c2)) {
@@ -129,7 +123,7 @@ public class UniquePropertyIdRule implements Rule {
         }
       }
     }
-    JsonNode am2 = c2.path("allMatch");
+    JsonNode am2 = c2.path(ElementTemplate.ALL_MATCH);
     if (am2.isArray()) {
       for (JsonNode sub : am2) {
         if (sub.isObject() && mutuallyExclusive(c1, sub)) {
@@ -142,11 +136,11 @@ public class UniquePropertyIdRule implements Rule {
 
   private static Set<String> collectSimpleValues(JsonNode condition) {
     Set<String> values = new HashSet<>();
-    JsonNode equals = condition.path("equals");
+    JsonNode equals = condition.path(ElementTemplate.EQUALS);
     if (equals.isTextual()) {
       values.add(equals.asText());
     }
-    JsonNode oneOf = condition.path("oneOf");
+    JsonNode oneOf = condition.path(ElementTemplate.ONE_OF);
     if (oneOf.isArray()) {
       for (JsonNode v : oneOf) {
         if (v.isTextual()) {

--- a/element-template-generator/validator/src/main/java/io/camunda/connector/validator/rule/VersionedTemplateConsistencyRule.java
+++ b/element-template-generator/validator/src/main/java/io/camunda/connector/validator/rule/VersionedTemplateConsistencyRule.java
@@ -17,6 +17,7 @@
 package io.camunda.connector.validator.rule;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import io.camunda.connector.validator.core.ElementTemplate;
 import io.camunda.connector.validator.core.Finding;
 import io.camunda.connector.validator.core.MultiFileRule;
 import io.camunda.connector.validator.core.TemplateFinder;
@@ -42,14 +43,7 @@ import java.util.regex.Pattern;
  */
 public class VersionedTemplateConsistencyRule implements MultiFileRule {
 
-  public static final String ID = "versioned-template-consistency";
-
   private static final Pattern VERSIONED_NAME = Pattern.compile("^(.+)-(\\d+)\\.json$");
-
-  @Override
-  public String id() {
-    return ID;
-  }
 
   @Override
   public List<Finding> apply(Map<Path, JsonNode> templates) {
@@ -65,7 +59,7 @@ public class VersionedTemplateConsistencyRule implements MultiFileRule {
             Finding.error(
                 path,
                 "/",
-                ID,
+                id(),
                 "Versioned template filename does not follow the {base}-{version}.json pattern."));
         continue;
       }
@@ -78,7 +72,7 @@ public class VersionedTemplateConsistencyRule implements MultiFileRule {
             Finding.error(
                 path,
                 "/",
-                ID,
+                id(),
                 "Versioned template filename suffix \""
                     + filenameVersionStr
                     + "\" is not a valid version number."));
@@ -87,7 +81,7 @@ public class VersionedTemplateConsistencyRule implements MultiFileRule {
       boolean preVersioningSnapshot = filenameVersionStr.startsWith("0");
 
       JsonNode template = entry.getValue();
-      JsonNode versionNode = template.path("version");
+      JsonNode versionNode = template.path(ElementTemplate.VERSION);
       boolean versionMissing = !versionNode.isNumber();
       if (versionMissing && preVersioningSnapshot) {
         continue;
@@ -97,7 +91,7 @@ public class VersionedTemplateConsistencyRule implements MultiFileRule {
             Finding.error(
                 path,
                 "/version",
-                ID,
+                id(),
                 "Filename suffix says version "
                     + filenameVersion
                     + " but the template declares "

--- a/element-template-generator/validator/src/main/java/io/camunda/connector/validator/rule/VersionedTemplateConsistencyRule.java
+++ b/element-template-generator/validator/src/main/java/io/camunda/connector/validator/rule/VersionedTemplateConsistencyRule.java
@@ -70,7 +70,20 @@ public class VersionedTemplateConsistencyRule implements MultiFileRule {
         continue;
       }
       String filenameVersionStr = m.group(2);
-      int filenameVersion = Integer.parseInt(filenameVersionStr);
+      int filenameVersion;
+      try {
+        filenameVersion = Integer.parseInt(filenameVersionStr);
+      } catch (NumberFormatException e) {
+        findings.add(
+            Finding.error(
+                path,
+                "/",
+                ID,
+                "Versioned template filename suffix \""
+                    + filenameVersionStr
+                    + "\" is not a valid version number."));
+        continue;
+      }
       boolean preVersioningSnapshot = filenameVersionStr.startsWith("0");
 
       JsonNode template = entry.getValue();

--- a/element-template-generator/validator/src/main/java/io/camunda/connector/validator/rule/VersionedTemplateConsistencyRule.java
+++ b/element-template-generator/validator/src/main/java/io/camunda/connector/validator/rule/VersionedTemplateConsistencyRule.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.validator.rule;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.camunda.connector.validator.core.Finding;
+import io.camunda.connector.validator.core.MultiFileRule;
+import io.camunda.connector.validator.core.TemplateFinder;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * For each {@code .../element-templates/versioned/<base>-<N>.json}, the file's {@code version}
+ * field must equal {@code N} (the suffix in the filename). Catches snapshots whose version field
+ * drifted from or never matched the filename suffix.
+ *
+ * <p>Note: this rule does <em>not</em> require {@code id} stability across versioned snapshots. The
+ * team intentionally bumps the id suffix ({@code .v0} → {@code .v1}) on breaking template changes
+ * so old instances do not auto-upgrade.
+ *
+ * <p>Snapshots whose filename suffix starts with {@code 0} (e.g. {@code -0}, {@code -01}, {@code
+ * -02}) are pre-versioning artifacts written before the {@code version} field was tracked. For
+ * those, a missing {@code version} field is tolerated; if present, it must still match.
+ */
+public class VersionedTemplateConsistencyRule implements MultiFileRule {
+
+  public static final String ID = "versioned-template-consistency";
+
+  private static final Pattern VERSIONED_NAME = Pattern.compile("^(.+)-(\\d+)\\.json$");
+
+  @Override
+  public String id() {
+    return ID;
+  }
+
+  @Override
+  public List<Finding> apply(Map<Path, JsonNode> templates) {
+    List<Finding> findings = new ArrayList<>();
+    for (Map.Entry<Path, JsonNode> entry : templates.entrySet()) {
+      Path path = entry.getKey();
+      if (!TemplateFinder.isVersioned(path)) {
+        continue;
+      }
+      Matcher m = VERSIONED_NAME.matcher(path.getFileName().toString());
+      if (!m.matches()) {
+        findings.add(
+            Finding.error(
+                path,
+                "/",
+                ID,
+                "Versioned template filename does not follow the {base}-{version}.json pattern."));
+        continue;
+      }
+      String filenameVersionStr = m.group(2);
+      int filenameVersion = Integer.parseInt(filenameVersionStr);
+      boolean preVersioningSnapshot = filenameVersionStr.startsWith("0");
+
+      JsonNode template = entry.getValue();
+      JsonNode versionNode = template.path("version");
+      boolean versionMissing = !versionNode.isNumber();
+      if (versionMissing && preVersioningSnapshot) {
+        continue;
+      }
+      if (versionMissing || versionNode.asInt() != filenameVersion) {
+        findings.add(
+            Finding.error(
+                path,
+                "/version",
+                ID,
+                "Filename suffix says version "
+                    + filenameVersion
+                    + " but the template declares "
+                    + versionNode.asText("<missing>")
+                    + "."));
+      }
+    }
+    return findings;
+  }
+}

--- a/element-template-generator/validator/src/test/java/io/camunda/connector/validator/core/TemplateLoaderTest.java
+++ b/element-template-generator/validator/src/test/java/io/camunda/connector/validator/core/TemplateLoaderTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.validator.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class TemplateLoaderTest {
+
+  @Test
+  void validJson_loadsNode(@TempDir Path tmp) throws Exception {
+    Path file = tmp.resolve("ok.json");
+    Files.writeString(file, "{ \"id\": \"foo\", \"version\": 1 }");
+    TemplateLoader.Result result = TemplateLoader.load(file);
+    assertThat(result.ok()).isTrue();
+    assertThat(result.node().get("id").asText()).isEqualTo("foo");
+  }
+
+  @Test
+  void duplicateKey_emitsDuplicateKeysFinding(@TempDir Path tmp) throws Exception {
+    Path file = tmp.resolve("dup.json");
+    Files.writeString(file, "{\n  \"id\": \"foo\",\n  \"id\": \"bar\"\n}");
+    TemplateLoader.Result result = TemplateLoader.load(file);
+    assertThat(result.ok()).isFalse();
+    Finding finding = result.finding();
+    assertThat(finding.ruleId()).isEqualTo(TemplateLoader.DUPLICATE_KEYS_RULE);
+    assertThat(finding.jsonPointer()).isEqualTo("/");
+    assertThat(finding.message()).contains("Duplicate field").contains("id").contains("line");
+  }
+
+  @Test
+  void duplicateNestedKey_emitsDuplicateKeysFinding(@TempDir Path tmp) throws Exception {
+    Path file = tmp.resolve("dupnested.json");
+    Files.writeString(file, "{\n  \"properties\": [\n    { \"id\": \"a\", \"id\": \"b\" }\n  ]\n}");
+    TemplateLoader.Result result = TemplateLoader.load(file);
+    assertThat(result.ok()).isFalse();
+    assertThat(result.finding().ruleId()).isEqualTo(TemplateLoader.DUPLICATE_KEYS_RULE);
+  }
+
+  @Test
+  void malformedJson_emitsJsonParseFinding(@TempDir Path tmp) throws Exception {
+    Path file = tmp.resolve("bad.json");
+    Files.writeString(file, "{ \"id\": ");
+    TemplateLoader.Result result = TemplateLoader.load(file);
+    assertThat(result.ok()).isFalse();
+    assertThat(result.finding().ruleId()).isEqualTo(TemplateLoader.JSON_PARSE_RULE);
+  }
+
+  @Test
+  void missingFile_emitsJsonParseFinding(@TempDir Path tmp) {
+    Path missing = tmp.resolve("does-not-exist.json");
+    TemplateLoader.Result result = TemplateLoader.load(missing);
+    assertThat(result.ok()).isFalse();
+    assertThat(result.finding().ruleId()).isEqualTo(TemplateLoader.JSON_PARSE_RULE);
+  }
+}

--- a/element-template-generator/validator/src/test/java/io/camunda/connector/validator/rule/ConditionPropertyOrderRuleTest.java
+++ b/element-template-generator/validator/src/test/java/io/camunda/connector/validator/rule/ConditionPropertyOrderRuleTest.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.validator.rule;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.connector.validator.core.Finding;
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class ConditionPropertyOrderRuleTest {
+
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+  private static final Path FILE = Path.of("template.json");
+  private final ConditionPropertyOrderRule rule = new ConditionPropertyOrderRule();
+
+  @Test
+  void inOrder_noFindings() throws Exception {
+    JsonNode t =
+        read(
+            "{ \"properties\": ["
+                + "{ \"id\": \"op\" },"
+                + "{ \"id\": \"sub\", \"condition\": { \"property\": \"op\", \"equals\": \"v\" } } ] }");
+    assertThat(rule.apply(FILE, t)).isEmpty();
+  }
+
+  @Test
+  void outOfOrder_oneFinding() throws Exception {
+    JsonNode t =
+        read(
+            "{ \"properties\": ["
+                + "{ \"id\": \"sub\", \"condition\": { \"property\": \"op\", \"equals\": \"v\" } },"
+                + "{ \"id\": \"op\" } ] }");
+    List<Finding> findings = rule.apply(FILE, t);
+    assertThat(findings).hasSize(1);
+    assertThat(findings.get(0).jsonPointer()).isEqualTo("/properties/0/condition/property");
+    assertThat(findings.get(0).message()).contains("\"op\"").contains("after");
+  }
+
+  @Test
+  void selfReference_oneFinding() throws Exception {
+    JsonNode t =
+        read(
+            "{ \"properties\": ["
+                + "{ \"id\": \"x\", \"condition\": { \"property\": \"x\", \"equals\": \"v\" } } ] }");
+    List<Finding> findings = rule.apply(FILE, t);
+    assertThat(findings).hasSize(1);
+    assertThat(findings.get(0).message()).contains("the property itself");
+  }
+
+  @Test
+  void allMatchOneSubViolating_oneFindingForThatSub() throws Exception {
+    JsonNode t =
+        read(
+            "{ \"properties\": ["
+                + "{ \"id\": \"a\" },"
+                + "{ \"id\": \"b\", \"condition\": { \"allMatch\": ["
+                + "  { \"property\": \"a\", \"equals\": \"x\" },"
+                + "  { \"property\": \"c\", \"equals\": \"y\" } ] } },"
+                + "{ \"id\": \"c\" } ] }");
+    List<Finding> findings = rule.apply(FILE, t);
+    assertThat(findings).hasSize(1);
+    assertThat(findings.get(0).jsonPointer())
+        .isEqualTo("/properties/1/condition/allMatch/1/property");
+    assertThat(findings.get(0).message()).contains("\"c\"");
+  }
+
+  @Test
+  void choiceConditionForwardReference_oneFinding() throws Exception {
+    JsonNode t =
+        read(
+            "{ \"properties\": ["
+                + "{ \"id\": \"sub\", \"choices\": ["
+                + "  { \"value\": \"x\", \"condition\": { \"property\": \"op\", \"equals\": \"v\" } } ] },"
+                + "{ \"id\": \"op\" } ] }");
+    List<Finding> findings = rule.apply(FILE, t);
+    assertThat(findings).hasSize(1);
+    assertThat(findings.get(0).jsonPointer())
+        .isEqualTo("/properties/0/choices/0/condition/property");
+  }
+
+  @Test
+  void nonExistentReference_skipped() throws Exception {
+    JsonNode t =
+        read(
+            "{ \"properties\": ["
+                + "{ \"id\": \"a\", \"condition\": { \"property\": \"missing\", \"equals\": \"v\" } } ] }");
+    assertThat(rule.apply(FILE, t)).isEmpty();
+  }
+
+  @Test
+  void duplicateIdSwitchingPattern_firstOccurrenceUsed() throws Exception {
+    // First "op" is at index 0, "dependent" at index 1, second "op" at index 2.
+    // Dependent's condition referencing "op" is OK because firstIndex(op)=0 < 1.
+    JsonNode t =
+        read(
+            "{ \"properties\": ["
+                + "{ \"id\": \"op\", \"condition\": { \"property\": \"group\", \"equals\": \"a\" } },"
+                + "{ \"id\": \"dependent\", \"condition\": { \"property\": \"op\", \"equals\": \"x\" } },"
+                + "{ \"id\": \"op\", \"condition\": { \"property\": \"group\", \"equals\": \"b\" } } ] }");
+    // The two "op" properties are mutually exclusive (group=a vs group=b) so the rule's
+    // unique-property-id sibling tolerates them; this rule also accepts the dependent ordering.
+    // But "group" is referenced before it appears (or doesn't exist) — for this test we don't
+    // include "group" as a property, so condition-target-exists handles that case; the order
+    // rule must not fire here.
+    assertThat(rule.apply(FILE, t)).isEmpty();
+  }
+
+  @Test
+  void missingPropertiesArray_noFindings() throws Exception {
+    assertThat(rule.apply(FILE, read("{}"))).isEmpty();
+    assertThat(rule.apply(FILE, read("{ \"properties\": null }"))).isEmpty();
+  }
+
+  private static JsonNode read(String json) throws Exception {
+    return MAPPER.readTree(json);
+  }
+}

--- a/element-template-generator/validator/src/test/java/io/camunda/connector/validator/rule/ConditionTargetExistsRuleTest.java
+++ b/element-template-generator/validator/src/test/java/io/camunda/connector/validator/rule/ConditionTargetExistsRuleTest.java
@@ -71,7 +71,7 @@ class ConditionTargetExistsRuleTest {
     List<Finding> findings = rule.apply(FILE, template);
     assertThat(findings).hasSize(1);
     Finding f = findings.get(0);
-    assertThat(f.ruleId()).isEqualTo(ConditionTargetExistsRule.ID);
+    assertThat(f.ruleId()).isEqualTo("condition-target-exists");
     assertThat(f.jsonPointer()).isEqualTo("/properties/1/condition/property");
     assertThat(f.message()).contains("opGruop");
   }

--- a/element-template-generator/validator/src/test/java/io/camunda/connector/validator/rule/ConditionTargetExistsRuleTest.java
+++ b/element-template-generator/validator/src/test/java/io/camunda/connector/validator/rule/ConditionTargetExistsRuleTest.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.validator.rule;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.connector.validator.core.Finding;
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class ConditionTargetExistsRuleTest {
+
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+  private static final Path FILE = Path.of("test.json");
+  private final ConditionTargetExistsRule rule = new ConditionTargetExistsRule();
+
+  @Test
+  void noConditions_noFindings() throws Exception {
+    JsonNode template =
+        read(
+            """
+        { "properties": [ { "id": "a" }, { "id": "b" } ] }
+        """);
+    assertThat(rule.apply(FILE, template)).isEmpty();
+  }
+
+  @Test
+  void simpleEqualsCondition_referencesExisting_noFindings() throws Exception {
+    JsonNode template =
+        read(
+            """
+        {
+          "properties": [
+            { "id": "authType" },
+            { "id": "token", "condition": { "property": "authType", "equals": "pat" } }
+          ]
+        }
+        """);
+    assertThat(rule.apply(FILE, template)).isEmpty();
+  }
+
+  @Test
+  void simpleOneOfCondition_referencesMissing_oneFinding() throws Exception {
+    JsonNode template =
+        read(
+            """
+        {
+          "properties": [
+            { "id": "operationGroup" },
+            { "id": "x", "condition": { "property": "opGruop", "oneOf": ["issues"] } }
+          ]
+        }
+        """);
+    List<Finding> findings = rule.apply(FILE, template);
+    assertThat(findings).hasSize(1);
+    Finding f = findings.get(0);
+    assertThat(f.ruleId()).isEqualTo(ConditionTargetExistsRule.ID);
+    assertThat(f.jsonPointer()).isEqualTo("/properties/1/condition/property");
+    assertThat(f.message()).contains("opGruop");
+  }
+
+  @Test
+  void allMatchCompound_eachSubconditionChecked() throws Exception {
+    JsonNode template =
+        read(
+            """
+        {
+          "properties": [
+            { "id": "providerType" },
+            { "id": "x", "condition": { "allMatch": [
+              { "property": "providerType", "equals": "bedrock" },
+              { "property": "missingOne", "equals": "credentials" }
+            ]}}
+          ]
+        }
+        """);
+    List<Finding> findings = rule.apply(FILE, template);
+    assertThat(findings).hasSize(1);
+    assertThat(findings.get(0).jsonPointer())
+        .isEqualTo("/properties/1/condition/allMatch/1/property");
+    assertThat(findings.get(0).message()).contains("missingOne");
+  }
+
+  @Test
+  void allMatchCompound_allValid_noFindings() throws Exception {
+    JsonNode template =
+        read(
+            """
+        {
+          "properties": [
+            { "id": "a" }, { "id": "b" },
+            { "id": "x", "condition": { "allMatch": [
+              { "property": "a", "equals": 1 },
+              { "property": "b", "equals": 2 }
+            ]}}
+          ]
+        }
+        """);
+    assertThat(rule.apply(FILE, template)).isEmpty();
+  }
+
+  @Test
+  void dottedPropertyId_matchesLiterally() throws Exception {
+    JsonNode template =
+        read(
+            """
+        {
+          "properties": [
+            { "id": "authentication.authType" },
+            { "id": "x", "condition": { "property": "authentication.authType", "equals": "pat" } }
+          ]
+        }
+        """);
+    assertThat(rule.apply(FILE, template)).isEmpty();
+  }
+
+  @Test
+  void multipleMissingReferences_independentFindings() throws Exception {
+    JsonNode template =
+        read(
+            """
+        {
+          "properties": [
+            { "id": "a" },
+            { "id": "x", "condition": { "property": "missing1", "equals": "v" } },
+            { "id": "y", "condition": { "property": "missing2", "oneOf": ["v"] } }
+          ]
+        }
+        """);
+    List<Finding> findings = rule.apply(FILE, template);
+    assertThat(findings).hasSize(2);
+    assertThat(findings)
+        .extracting(Finding::jsonPointer)
+        .containsExactlyInAnyOrder(
+            "/properties/1/condition/property", "/properties/2/condition/property");
+  }
+
+  private static JsonNode read(String json) throws Exception {
+    return MAPPER.readTree(json);
+  }
+}

--- a/element-template-generator/validator/src/test/java/io/camunda/connector/validator/rule/ConditionValueInChoicesRuleTest.java
+++ b/element-template-generator/validator/src/test/java/io/camunda/connector/validator/rule/ConditionValueInChoicesRuleTest.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.validator.rule;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.connector.validator.core.Finding;
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class ConditionValueInChoicesRuleTest {
+
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+  private static final Path FILE = Path.of("test.json");
+  private final ConditionValueInChoicesRule rule = new ConditionValueInChoicesRule();
+
+  @Test
+  void equalsMatchesChoice_noFindings() throws Exception {
+    JsonNode template =
+        read(
+            """
+        {
+          "properties": [
+            { "id": "authType", "choices": [{"value":"pat"},{"value":"oauth"}] },
+            { "id": "x", "condition": { "property": "authType", "equals": "pat" } }
+          ]
+        }
+        """);
+    assertThat(rule.apply(FILE, template)).isEmpty();
+  }
+
+  @Test
+  void equalsNotInChoices_oneFinding() throws Exception {
+    JsonNode template =
+        read(
+            """
+        {
+          "properties": [
+            { "id": "authType", "choices": [{"value":"pat"},{"value":"oauth"}] },
+            { "id": "x", "condition": { "property": "authType", "equals": "patt" } }
+          ]
+        }
+        """);
+    List<Finding> findings = rule.apply(FILE, template);
+    assertThat(findings).hasSize(1);
+    assertThat(findings.get(0).jsonPointer()).isEqualTo("/properties/1/condition/equals");
+    assertThat(findings.get(0).message()).contains("patt");
+  }
+
+  @Test
+  void oneOfWithSomeInvalid_findsOnlyInvalid() throws Exception {
+    JsonNode template =
+        read(
+            """
+        {
+          "properties": [
+            { "id": "op", "choices": [{"value":"a"},{"value":"b"}] },
+            { "id": "x", "condition": { "property": "op", "oneOf": ["a", "c", "b", "d"] } }
+          ]
+        }
+        """);
+    List<Finding> findings = rule.apply(FILE, template);
+    assertThat(findings).hasSize(2);
+    assertThat(findings)
+        .extracting(Finding::jsonPointer)
+        .containsExactlyInAnyOrder(
+            "/properties/1/condition/oneOf/1", "/properties/1/condition/oneOf/3");
+  }
+
+  @Test
+  void allMatchSubconditionsChecked() throws Exception {
+    JsonNode template =
+        read(
+            """
+        {
+          "properties": [
+            { "id": "p", "choices": [{"value":"a"}] },
+            { "id": "q", "choices": [{"value":"x"}] },
+            { "id": "r", "condition": { "allMatch": [
+              { "property": "p", "equals": "a" },
+              { "property": "q", "equals": "y" }
+            ]}}
+          ]
+        }
+        """);
+    List<Finding> findings = rule.apply(FILE, template);
+    assertThat(findings).hasSize(1);
+    assertThat(findings.get(0).jsonPointer())
+        .isEqualTo("/properties/2/condition/allMatch/1/equals");
+  }
+
+  @Test
+  void targetPropertyHasNoChoices_noEnforcement() throws Exception {
+    JsonNode template =
+        read(
+            """
+        {
+          "properties": [
+            { "id": "freeText" },
+            { "id": "x", "condition": { "property": "freeText", "equals": "anything" } }
+          ]
+        }
+        """);
+    assertThat(rule.apply(FILE, template)).isEmpty();
+  }
+
+  @Test
+  void choicesUnionedAcrossDuplicateIds() throws Exception {
+    JsonNode template =
+        read(
+            """
+        {
+          "properties": [
+            { "id": "op", "choices": [{"value":"a"}], "condition": { "property": "g", "equals": "x" } },
+            { "id": "op", "choices": [{"value":"b"}], "condition": { "property": "g", "equals": "y" } },
+            { "id": "z", "condition": { "property": "op", "equals": "b" } }
+          ]
+        }
+        """);
+    assertThat(rule.apply(FILE, template)).extracting(Finding::ruleId).doesNotContain(rule.id());
+  }
+
+  private static JsonNode read(String json) throws Exception {
+    return MAPPER.readTree(json);
+  }
+}

--- a/element-template-generator/validator/src/test/java/io/camunda/connector/validator/rule/CurrentVersionBumpRuleTest.java
+++ b/element-template-generator/validator/src/test/java/io/camunda/connector/validator/rule/CurrentVersionBumpRuleTest.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.validator.rule;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.connector.validator.core.Finding;
+import java.nio.file.Path;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class CurrentVersionBumpRuleTest {
+
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+  private final CurrentVersionBumpRule rule = new CurrentVersionBumpRule();
+
+  @Test
+  void currentExactlyOneHigher_noFindings() throws Exception {
+    Map<Path, JsonNode> templates = new LinkedHashMap<>();
+    templates.put(
+        Path.of("connectors/foo/element-templates/foo.json"),
+        read("{ \"id\": \"io.foo\", \"version\": 5 }"));
+    templates.put(
+        Path.of("connectors/foo/element-templates/versioned/foo-4.json"),
+        read("{ \"id\": \"io.foo\", \"version\": 4 }"));
+    templates.put(
+        Path.of("connectors/foo/element-templates/versioned/foo-3.json"),
+        read("{ \"id\": \"io.foo\", \"version\": 3 }"));
+    assertThat(rule.apply(templates)).isEmpty();
+  }
+
+  @Test
+  void currentTwoHigher_oneFinding() throws Exception {
+    Map<Path, JsonNode> templates = new LinkedHashMap<>();
+    templates.put(
+        Path.of("connectors/foo/element-templates/foo.json"),
+        read("{ \"id\": \"io.foo\", \"version\": 6 }"));
+    templates.put(
+        Path.of("connectors/foo/element-templates/versioned/foo-4.json"),
+        read("{ \"id\": \"io.foo\", \"version\": 4 }"));
+    List<Finding> findings = rule.apply(templates);
+    assertThat(findings).hasSize(1);
+    assertThat(findings.get(0).jsonPointer()).isEqualTo("/version");
+    assertThat(findings.get(0).message()).contains("6").contains("4").contains("5");
+  }
+
+  @Test
+  void currentEqualsLatestSnapshot_oneFinding() throws Exception {
+    Map<Path, JsonNode> templates = new LinkedHashMap<>();
+    templates.put(
+        Path.of("connectors/foo/element-templates/foo.json"),
+        read("{ \"id\": \"io.foo\", \"version\": 4 }"));
+    templates.put(
+        Path.of("connectors/foo/element-templates/versioned/foo-4.json"),
+        read("{ \"id\": \"io.foo\", \"version\": 4 }"));
+    List<Finding> findings = rule.apply(templates);
+    assertThat(findings).hasSize(1);
+    assertThat(findings.get(0).message()).contains("4").contains("5");
+  }
+
+  @Test
+  void noVersionedSiblingWithSameId_silent() throws Exception {
+    // Intentional id rename: current is .v2 while every snapshot is .v1.
+    Map<Path, JsonNode> templates = new LinkedHashMap<>();
+    templates.put(
+        Path.of("connectors/foo/element-templates/foo.json"),
+        read("{ \"id\": \"io.foo.v2\", \"version\": 1 }"));
+    templates.put(
+        Path.of("connectors/foo/element-templates/versioned/foo-7.json"),
+        read("{ \"id\": \"io.foo.v1\", \"version\": 7 }"));
+    assertThat(rule.apply(templates)).isEmpty();
+  }
+
+  @Test
+  void currentVersionMissing_oneFinding() throws Exception {
+    Map<Path, JsonNode> templates = new LinkedHashMap<>();
+    templates.put(
+        Path.of("connectors/foo/element-templates/foo.json"), read("{ \"id\": \"io.foo\" }"));
+    templates.put(
+        Path.of("connectors/foo/element-templates/versioned/foo-4.json"),
+        read("{ \"id\": \"io.foo\", \"version\": 4 }"));
+    List<Finding> findings = rule.apply(templates);
+    assertThat(findings).hasSize(1);
+    assertThat(findings.get(0).message()).contains("missing").contains("5");
+  }
+
+  @Test
+  void scopedPerConnector_noCrossConnectorMatch() throws Exception {
+    // Same id under two different element-templates trees should not interfere.
+    Map<Path, JsonNode> templates = new LinkedHashMap<>();
+    templates.put(
+        Path.of("connectors/foo/element-templates/x.json"),
+        read("{ \"id\": \"shared.id\", \"version\": 2 }"));
+    templates.put(
+        Path.of("connectors/foo/element-templates/versioned/x-1.json"),
+        read("{ \"id\": \"shared.id\", \"version\": 1 }"));
+    templates.put(
+        Path.of("connectors/bar/element-templates/x.json"),
+        read("{ \"id\": \"shared.id\", \"version\": 9 }"));
+    templates.put(
+        Path.of("connectors/bar/element-templates/versioned/x-8.json"),
+        read("{ \"id\": \"shared.id\", \"version\": 8 }"));
+    assertThat(rule.apply(templates)).isEmpty();
+  }
+
+  @Test
+  void hybridLineageIndependent_noFindings() throws Exception {
+    // Hybrid has its own id, so it's compared only against versioned hybrid snapshots.
+    Map<Path, JsonNode> templates = new LinkedHashMap<>();
+    templates.put(
+        Path.of("connectors/foo/element-templates/foo.json"),
+        read("{ \"id\": \"io.foo\", \"version\": 5 }"));
+    templates.put(
+        Path.of("connectors/foo/element-templates/versioned/foo-4.json"),
+        read("{ \"id\": \"io.foo\", \"version\": 4 }"));
+    templates.put(
+        Path.of("connectors/foo/element-templates/hybrid/foo-hybrid.json"),
+        read("{ \"id\": \"io.foo.hybrid\", \"version\": 3 }"));
+    templates.put(
+        Path.of("connectors/foo/element-templates/versioned/foo-hybrid-2.json"),
+        read("{ \"id\": \"io.foo.hybrid\", \"version\": 2 }"));
+    assertThat(rule.apply(templates)).isEmpty();
+  }
+
+  @Test
+  void multipleSnapshots_usesMaximum() throws Exception {
+    Map<Path, JsonNode> templates = new LinkedHashMap<>();
+    templates.put(
+        Path.of("connectors/foo/element-templates/foo.json"),
+        read("{ \"id\": \"io.foo\", \"version\": 8 }"));
+    templates.put(
+        Path.of("connectors/foo/element-templates/versioned/foo-7.json"),
+        read("{ \"id\": \"io.foo\", \"version\": 7 }"));
+    templates.put(
+        Path.of("connectors/foo/element-templates/versioned/foo-3.json"),
+        read("{ \"id\": \"io.foo\", \"version\": 3 }"));
+    templates.put(
+        Path.of("connectors/foo/element-templates/versioned/foo-5.json"),
+        read("{ \"id\": \"io.foo\", \"version\": 5 }"));
+    assertThat(rule.apply(templates)).isEmpty();
+  }
+
+  private static JsonNode read(String json) throws Exception {
+    return MAPPER.readTree(json);
+  }
+}

--- a/element-template-generator/validator/src/test/java/io/camunda/connector/validator/rule/DefaultValueInChoicesRuleTest.java
+++ b/element-template-generator/validator/src/test/java/io/camunda/connector/validator/rule/DefaultValueInChoicesRuleTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.validator.rule;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.connector.validator.core.Finding;
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class DefaultValueInChoicesRuleTest {
+
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+  private static final Path FILE = Path.of("test.json");
+  private final DefaultValueInChoicesRule rule = new DefaultValueInChoicesRule();
+
+  @Test
+  void defaultValueInChoices_noFinding() throws Exception {
+    JsonNode template =
+        read(
+            """
+        {
+          "properties": [
+            { "id": "x", "type": "Dropdown", "value": "a",
+              "choices": [{"value":"a"},{"value":"b"}] }
+          ]
+        }
+        """);
+    assertThat(rule.apply(FILE, template)).isEmpty();
+  }
+
+  @Test
+  void defaultValueNotInChoices_oneFinding() throws Exception {
+    JsonNode template =
+        read(
+            """
+        {
+          "properties": [
+            { "id": "x", "type": "Dropdown", "value": "c",
+              "choices": [{"value":"a"},{"value":"b"}] }
+          ]
+        }
+        """);
+    List<Finding> findings = rule.apply(FILE, template);
+    assertThat(findings).hasSize(1);
+    Finding f = findings.get(0);
+    assertThat(f.ruleId()).isEqualTo(DefaultValueInChoicesRule.ID);
+    assertThat(f.jsonPointer()).isEqualTo("/properties/0/value");
+    assertThat(f.message()).contains("c").contains("x");
+  }
+
+  @Test
+  void nonDropdown_skipped() throws Exception {
+    JsonNode template =
+        read(
+            """
+        {
+          "properties": [
+            { "id": "x", "type": "String", "value": "literally anything" }
+          ]
+        }
+        """);
+    assertThat(rule.apply(FILE, template)).isEmpty();
+  }
+
+  @Test
+  void dropdownWithoutDefault_skipped() throws Exception {
+    JsonNode template =
+        read(
+            """
+        {
+          "properties": [
+            { "id": "x", "type": "Dropdown", "choices": [{"value":"a"}] }
+          ]
+        }
+        """);
+    assertThat(rule.apply(FILE, template)).isEmpty();
+  }
+
+  private static JsonNode read(String json) throws Exception {
+    return MAPPER.readTree(json);
+  }
+}

--- a/element-template-generator/validator/src/test/java/io/camunda/connector/validator/rule/DefaultValueInChoicesRuleTest.java
+++ b/element-template-generator/validator/src/test/java/io/camunda/connector/validator/rule/DefaultValueInChoicesRuleTest.java
@@ -61,7 +61,7 @@ class DefaultValueInChoicesRuleTest {
     List<Finding> findings = rule.apply(FILE, template);
     assertThat(findings).hasSize(1);
     Finding f = findings.get(0);
-    assertThat(f.ruleId()).isEqualTo(DefaultValueInChoicesRule.ID);
+    assertThat(f.ruleId()).isEqualTo("default-value-in-choices");
     assertThat(f.jsonPointer()).isEqualTo("/properties/0/value");
     assertThat(f.message()).contains("c").contains("x");
   }

--- a/element-template-generator/validator/src/test/java/io/camunda/connector/validator/rule/EmptyGroupRuleTest.java
+++ b/element-template-generator/validator/src/test/java/io/camunda/connector/validator/rule/EmptyGroupRuleTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.validator.rule;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.connector.validator.core.Finding;
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class EmptyGroupRuleTest {
+
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+  private static final Path FILE = Path.of("test.json");
+  private final EmptyGroupRule rule = new EmptyGroupRule();
+
+  @Test
+  void everyGroupReferenced_noFindings() throws Exception {
+    JsonNode template =
+        read(
+            """
+        {
+          "groups": [ {"id":"a"}, {"id":"b"} ],
+          "properties": [ { "group": "a" }, { "group": "b" } ]
+        }
+        """);
+    assertThat(rule.apply(FILE, template)).isEmpty();
+  }
+
+  @Test
+  void unreferencedGroup_oneFinding() throws Exception {
+    JsonNode template =
+        read(
+            """
+        {
+          "groups": [ {"id":"a"}, {"id":"orphan"} ],
+          "properties": [ { "group": "a" } ]
+        }
+        """);
+    List<Finding> findings = rule.apply(FILE, template);
+    assertThat(findings).hasSize(1);
+    assertThat(findings.get(0).jsonPointer()).isEqualTo("/groups/1/id");
+    assertThat(findings.get(0).message()).contains("orphan");
+  }
+
+  private static JsonNode read(String json) throws Exception {
+    return MAPPER.readTree(json);
+  }
+}

--- a/element-template-generator/validator/src/test/java/io/camunda/connector/validator/rule/GroupTargetExistsRuleTest.java
+++ b/element-template-generator/validator/src/test/java/io/camunda/connector/validator/rule/GroupTargetExistsRuleTest.java
@@ -57,7 +57,7 @@ class GroupTargetExistsRuleTest {
     List<Finding> findings = rule.apply(FILE, template);
     assertThat(findings).hasSize(1);
     Finding f = findings.get(0);
-    assertThat(f.ruleId()).isEqualTo(GroupTargetExistsRule.ID);
+    assertThat(f.ruleId()).isEqualTo("group-target-exists");
     assertThat(f.jsonPointer()).isEqualTo("/properties/0/group");
     assertThat(f.message()).contains("operatoin");
   }

--- a/element-template-generator/validator/src/test/java/io/camunda/connector/validator/rule/GroupTargetExistsRuleTest.java
+++ b/element-template-generator/validator/src/test/java/io/camunda/connector/validator/rule/GroupTargetExistsRuleTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.validator.rule;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.connector.validator.core.Finding;
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class GroupTargetExistsRuleTest {
+
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+  private static final Path FILE = Path.of("test.json");
+  private final GroupTargetExistsRule rule = new GroupTargetExistsRule();
+
+  @Test
+  void groupReferenceMatchesDeclaredGroup_noFindings() throws Exception {
+    JsonNode template =
+        read(
+            """
+        {
+          "groups": [ { "id": "auth" }, { "id": "operation" } ],
+          "properties": [ { "id": "x", "group": "auth" } ]
+        }
+        """);
+    assertThat(rule.apply(FILE, template)).isEmpty();
+  }
+
+  @Test
+  void propertyReferencesUndeclaredGroup_oneFinding() throws Exception {
+    JsonNode template =
+        read(
+            """
+        {
+          "groups": [ { "id": "auth" } ],
+          "properties": [ { "id": "x", "group": "operatoin" } ]
+        }
+        """);
+    List<Finding> findings = rule.apply(FILE, template);
+    assertThat(findings).hasSize(1);
+    Finding f = findings.get(0);
+    assertThat(f.ruleId()).isEqualTo(GroupTargetExistsRule.ID);
+    assertThat(f.jsonPointer()).isEqualTo("/properties/0/group");
+    assertThat(f.message()).contains("operatoin");
+  }
+
+  @Test
+  void propertyWithoutGroup_noFinding() throws Exception {
+    JsonNode template =
+        read(
+            """
+        { "groups": [], "properties": [ { "id": "x" } ] }
+        """);
+    assertThat(rule.apply(FILE, template)).isEmpty();
+  }
+
+  private static JsonNode read(String json) throws Exception {
+    return MAPPER.readTree(json);
+  }
+}

--- a/element-template-generator/validator/src/test/java/io/camunda/connector/validator/rule/HybridParityRuleTest.java
+++ b/element-template-generator/validator/src/test/java/io/camunda/connector/validator/rule/HybridParityRuleTest.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.validator.rule;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.connector.validator.core.Finding;
+import java.nio.file.Path;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class HybridParityRuleTest {
+
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+  private final HybridParityRule rule = new HybridParityRule();
+
+  @Test
+  void siblingsHaveIdenticalIdSets_noFindings() throws Exception {
+    Map<Path, JsonNode> templates = new LinkedHashMap<>();
+    templates.put(
+        Path.of("connectors/foo/element-templates/foo.json"),
+        read(
+            """
+        { "groups": [{"id":"g1"}], "properties": [{"id":"p1"},{"id":"p2"}] }
+        """));
+    templates.put(
+        Path.of("connectors/foo/element-templates/hybrid/foo-hybrid.json"),
+        read(
+            """
+        { "groups": [{"id":"g1"}], "properties": [{"id":"p2"},{"id":"p1"}] }
+        """));
+    assertThat(rule.apply(templates)).isEmpty();
+  }
+
+  @Test
+  void hybridGainsProperty_oneFinding() throws Exception {
+    Map<Path, JsonNode> templates = new LinkedHashMap<>();
+    templates.put(
+        Path.of("connectors/foo/element-templates/foo.json"),
+        read(
+            """
+        { "properties": [{"id":"p1"}] }
+        """));
+    templates.put(
+        Path.of("connectors/foo/element-templates/hybrid/foo-hybrid.json"),
+        read(
+            """
+        { "properties": [{"id":"p1"},{"id":"extra"}] }
+        """));
+    List<Finding> findings = rule.apply(templates);
+    assertThat(findings).hasSize(1);
+    assertThat(findings.get(0).message()).contains("extra");
+  }
+
+  @Test
+  void hybridMissesProperty_oneFinding() throws Exception {
+    Map<Path, JsonNode> templates = new LinkedHashMap<>();
+    templates.put(
+        Path.of("connectors/foo/element-templates/foo.json"),
+        read(
+            """
+        { "properties": [{"id":"p1"},{"id":"p2"}] }
+        """));
+    templates.put(
+        Path.of("connectors/foo/element-templates/hybrid/foo-hybrid.json"),
+        read(
+            """
+        { "properties": [{"id":"p1"}] }
+        """));
+    List<Finding> findings = rule.apply(templates);
+    assertThat(findings).hasSize(1);
+    assertThat(findings.get(0).message()).contains("p2");
+  }
+
+  @Test
+  void hybridWithoutSibling_oneFinding() throws Exception {
+    Map<Path, JsonNode> templates = new LinkedHashMap<>();
+    templates.put(
+        Path.of("connectors/foo/element-templates/hybrid/orphan-hybrid.json"),
+        read(
+            """
+        { "properties": [] }
+        """));
+    List<Finding> findings = rule.apply(templates);
+    assertThat(findings).hasSize(1);
+    assertThat(findings.get(0).message()).contains("no matching non-hybrid sibling");
+  }
+
+  @Test
+  void hybridPrefixedSibling_resolvedByStrippingBoth() throws Exception {
+    Map<Path, JsonNode> templates = new LinkedHashMap<>();
+    templates.put(
+        Path.of("connectors/foo/element-templates/foo.json"),
+        read(
+            """
+        { "properties": [{"id":"p1"}] }
+        """));
+    templates.put(
+        Path.of("connectors/foo/element-templates/hybrid/hybrid-foo-hybrid.json"),
+        read(
+            """
+        { "properties": [{"id":"p1"}] }
+        """));
+    assertThat(rule.apply(templates)).isEmpty();
+  }
+
+  @Test
+  void groupSetsAlsoCompared() throws Exception {
+    Map<Path, JsonNode> templates = new LinkedHashMap<>();
+    templates.put(
+        Path.of("connectors/foo/element-templates/foo.json"),
+        read(
+            """
+        { "groups": [{"id":"a"}], "properties": [] }
+        """));
+    templates.put(
+        Path.of("connectors/foo/element-templates/hybrid/foo-hybrid.json"),
+        read(
+            """
+        { "groups": [{"id":"b"}], "properties": [] }
+        """));
+    List<Finding> findings = rule.apply(templates);
+    assertThat(findings).hasSize(2);
+    assertThat(findings).extracting(Finding::jsonPointer).containsExactly("/groups", "/groups");
+  }
+
+  private static JsonNode read(String json) throws Exception {
+    return MAPPER.readTree(json);
+  }
+}

--- a/element-template-generator/validator/src/test/java/io/camunda/connector/validator/rule/PresetTargetExistsRuleTest.java
+++ b/element-template-generator/validator/src/test/java/io/camunda/connector/validator/rule/PresetTargetExistsRuleTest.java
@@ -159,6 +159,57 @@ class PresetTargetExistsRuleTest {
   }
 
   @Test
+  void duplicateIdsWithDifferentChoices_unionAccepted() throws Exception {
+    // Mutually-exclusive switching pattern: same id "eventOperationType" appears twice with
+    // disjoint choices, gated on different operationGroup values. A preset value valid under
+    // either variant must not be flagged.
+    JsonNode template =
+        read(
+            """
+        {
+          "properties": [
+            { "id": "operationGroup", "choices": [
+              { "value": "actions" }, { "value": "issues" }
+            ]},
+            { "id": "eventOperationType",
+              "choices": [{ "value": "createWorkflowDispatchEvent" }],
+              "condition": { "property": "operationGroup", "equals": "actions" } },
+            { "id": "eventOperationType",
+              "choices": [{ "value": "createIssue" }, { "value": "closeIssue" }],
+              "condition": { "property": "operationGroup", "equals": "issues" } }
+          ],
+          "steps": [
+            { "steps": [ { "presets": {
+              "operationGroup": "issues",
+              "eventOperationType": "createIssue"
+            }}]}
+          ]
+        }
+        """);
+    assertThat(rule.apply(FILE, template)).isEmpty();
+  }
+
+  @Test
+  void duplicateIdsWithDifferentChoices_valueOutsideUnion_flagged() throws Exception {
+    JsonNode template =
+        read(
+            """
+        {
+          "properties": [
+            { "id": "eventOperationType", "choices": [{ "value": "a" }] },
+            { "id": "eventOperationType", "choices": [{ "value": "b" }] }
+          ],
+          "steps": [
+            { "steps": [ { "presets": { "eventOperationType": "c" } } ] }
+          ]
+        }
+        """);
+    List<Finding> findings = rule.apply(FILE, template);
+    assertThat(findings).hasSize(1);
+    assertThat(findings.get(0).message()).contains("\"c\"");
+  }
+
+  @Test
   void presetsAtTopLevel_alsoValidated() throws Exception {
     JsonNode template =
         read(

--- a/element-template-generator/validator/src/test/java/io/camunda/connector/validator/rule/PresetTargetExistsRuleTest.java
+++ b/element-template-generator/validator/src/test/java/io/camunda/connector/validator/rule/PresetTargetExistsRuleTest.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.validator.rule;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.connector.validator.core.Finding;
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class PresetTargetExistsRuleTest {
+
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+  private static final Path FILE = Path.of("test.json");
+  private final PresetTargetExistsRule rule = new PresetTargetExistsRule();
+
+  @Test
+  void noPresets_noFindings() throws Exception {
+    JsonNode template =
+        read(
+            """
+        {
+          "properties": [
+            { "id": "operationGroup", "choices": [{"value": "issues"}] }
+          ]
+        }
+        """);
+    assertThat(rule.apply(FILE, template)).isEmpty();
+  }
+
+  @Test
+  void presetReferencesExistingPropertyAndValidChoice_noFindings() throws Exception {
+    JsonNode template =
+        read(
+            """
+        {
+          "properties": [
+            { "id": "operationGroup", "choices": [
+              { "value": "actions" }, { "value": "issues" }
+            ]}
+          ],
+          "steps": [
+            {
+              "name": "Actions",
+              "steps": [
+                { "name": "Create dispatch", "presets": { "operationGroup": "actions" } }
+              ]
+            }
+          ]
+        }
+        """);
+    assertThat(rule.apply(FILE, template)).isEmpty();
+  }
+
+  @Test
+  void presetReferencesMissingProperty_oneFinding() throws Exception {
+    JsonNode template =
+        read(
+            """
+        {
+          "properties": [
+            { "id": "operationGroup", "choices": [{"value": "actions"}] }
+          ],
+          "steps": [
+            { "steps": [ { "presets": { "operationGruop": "actions" } } ] }
+          ]
+        }
+        """);
+    List<Finding> findings = rule.apply(FILE, template);
+    assertThat(findings).hasSize(1);
+    Finding f = findings.get(0);
+    assertThat(f.ruleId()).isEqualTo(PresetTargetExistsRule.ID);
+    assertThat(f.jsonPointer()).isEqualTo("/steps/0/steps/0/presets/operationGruop");
+    assertThat(f.message()).contains("operationGruop");
+  }
+
+  @Test
+  void presetValueNotInChoices_oneFinding() throws Exception {
+    JsonNode template =
+        read(
+            """
+        {
+          "properties": [
+            { "id": "operationGroup", "choices": [
+              { "value": "actions" }, { "value": "issues" }
+            ]}
+          ],
+          "steps": [
+            { "steps": [ { "presets": { "operationGroup": "deployments" } } ] }
+          ]
+        }
+        """);
+    List<Finding> findings = rule.apply(FILE, template);
+    assertThat(findings).hasSize(1);
+    Finding f = findings.get(0);
+    assertThat(f.jsonPointer()).isEqualTo("/steps/0/steps/0/presets/operationGroup");
+    assertThat(f.message()).contains("deployments").contains("operationGroup");
+  }
+
+  @Test
+  void multipleEntriesInOnePresetsObject_independentFindings() throws Exception {
+    JsonNode template =
+        read(
+            """
+        {
+          "properties": [
+            { "id": "operationGroup", "choices": [{"value": "actions"}] },
+            { "id": "eventOperationType" }
+          ],
+          "steps": [
+            { "steps": [ { "presets": {
+              "operationGroup": "deployments",
+              "eventOperationType": "createWorkflowDispatchEvent",
+              "missing": "x"
+            }}]}
+          ]
+        }
+        """);
+    List<Finding> findings = rule.apply(FILE, template);
+    assertThat(findings).hasSize(2);
+    assertThat(findings)
+        .extracting(Finding::jsonPointer)
+        .containsExactlyInAnyOrder(
+            "/steps/0/steps/0/presets/operationGroup", "/steps/0/steps/0/presets/missing");
+  }
+
+  @Test
+  void propertyWithoutChoices_anyValueAccepted() throws Exception {
+    JsonNode template =
+        read(
+            """
+        {
+          "properties": [
+            { "id": "freeText" }
+          ],
+          "steps": [
+            { "steps": [ { "presets": { "freeText": "anything goes" } } ] }
+          ]
+        }
+        """);
+    assertThat(rule.apply(FILE, template)).isEmpty();
+  }
+
+  @Test
+  void presetsAtTopLevel_alsoValidated() throws Exception {
+    JsonNode template =
+        read(
+            """
+        {
+          "properties": [ { "id": "x" } ],
+          "presets": { "missing": "y" }
+        }
+        """);
+    List<Finding> findings = rule.apply(FILE, template);
+    assertThat(findings).hasSize(1);
+    assertThat(findings.get(0).jsonPointer()).isEqualTo("/presets/missing");
+  }
+
+  private static JsonNode read(String json) throws Exception {
+    return MAPPER.readTree(json);
+  }
+}

--- a/element-template-generator/validator/src/test/java/io/camunda/connector/validator/rule/PresetTargetExistsRuleTest.java
+++ b/element-template-generator/validator/src/test/java/io/camunda/connector/validator/rule/PresetTargetExistsRuleTest.java
@@ -86,7 +86,7 @@ class PresetTargetExistsRuleTest {
     List<Finding> findings = rule.apply(FILE, template);
     assertThat(findings).hasSize(1);
     Finding f = findings.get(0);
-    assertThat(f.ruleId()).isEqualTo(PresetTargetExistsRule.ID);
+    assertThat(f.ruleId()).isEqualTo("preset-target-exists");
     assertThat(f.jsonPointer()).isEqualTo("/steps/0/steps/0/presets/operationGruop");
     assertThat(f.message()).contains("operationGruop");
   }

--- a/element-template-generator/validator/src/test/java/io/camunda/connector/validator/rule/TaskDefinitionBindingFormRuleTest.java
+++ b/element-template-generator/validator/src/test/java/io/camunda/connector/validator/rule/TaskDefinitionBindingFormRuleTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.validator.rule;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.connector.validator.core.Finding;
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class TaskDefinitionBindingFormRuleTest {
+
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+  private static final Path FILE = Path.of("template.json");
+  private final TaskDefinitionBindingFormRule rule = new TaskDefinitionBindingFormRule();
+
+  @Test
+  void canonicalForm_noFindings() throws Exception {
+    JsonNode t =
+        read(
+            "{ \"properties\": [{ \"type\": \"Hidden\", \"value\": \"io.camunda:foo:1\","
+                + " \"binding\": { \"type\": \"zeebe:taskDefinition\", \"property\": \"type\" } }] }");
+    assertThat(rule.apply(FILE, t)).isEmpty();
+  }
+
+  @Test
+  void legacyForm_oneFinding() throws Exception {
+    JsonNode t =
+        read(
+            "{ \"properties\": [{ \"type\": \"Hidden\", \"value\": \"io.camunda:foo:1\","
+                + " \"binding\": { \"type\": \"zeebe:taskDefinition:type\" } }] }");
+    List<Finding> findings = rule.apply(FILE, t);
+    assertThat(findings).hasSize(1);
+    assertThat(findings.get(0).jsonPointer()).isEqualTo("/properties/0/binding/type");
+    assertThat(findings.get(0).message())
+        .contains("zeebe:taskDefinition:type")
+        .contains("zeebe:taskDefinition");
+  }
+
+  @Test
+  void multipleLegacyOccurrences_multipleFindings() throws Exception {
+    JsonNode t =
+        read(
+            "{ \"properties\": ["
+                + "{ \"binding\": { \"type\": \"zeebe:taskDefinition:type\" } },"
+                + "{ \"binding\": { \"type\": \"zeebe:input\", \"name\": \"x\" } },"
+                + "{ \"binding\": { \"type\": \"zeebe:taskDefinition:type\" } } ] }");
+    List<Finding> findings = rule.apply(FILE, t);
+    assertThat(findings).hasSize(2);
+    assertThat(findings.get(0).jsonPointer()).isEqualTo("/properties/0/binding/type");
+    assertThat(findings.get(1).jsonPointer()).isEqualTo("/properties/2/binding/type");
+  }
+
+  @Test
+  void otherBindingTypes_ignored() throws Exception {
+    JsonNode t =
+        read(
+            "{ \"properties\": ["
+                + "{ \"binding\": { \"type\": \"zeebe:input\", \"name\": \"x\" } },"
+                + "{ \"binding\": { \"type\": \"zeebe:property\", \"name\": \"y\" } },"
+                + "{ \"binding\": { \"type\": \"zeebe:taskHeader\", \"key\": \"k\" } } ] }");
+    assertThat(rule.apply(FILE, t)).isEmpty();
+  }
+
+  @Test
+  void missingPropertiesArray_noFindings() throws Exception {
+    assertThat(rule.apply(FILE, read("{}"))).isEmpty();
+    assertThat(rule.apply(FILE, read("{ \"properties\": null }"))).isEmpty();
+  }
+
+  private static JsonNode read(String json) throws Exception {
+    return MAPPER.readTree(json);
+  }
+}

--- a/element-template-generator/validator/src/test/java/io/camunda/connector/validator/rule/UniqueGroupIdRuleTest.java
+++ b/element-template-generator/validator/src/test/java/io/camunda/connector/validator/rule/UniqueGroupIdRuleTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.validator.rule;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.connector.validator.core.Finding;
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class UniqueGroupIdRuleTest {
+
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+  private static final Path FILE = Path.of("test.json");
+  private final UniqueGroupIdRule rule = new UniqueGroupIdRule();
+
+  @Test
+  void allUnique_noFindings() throws Exception {
+    JsonNode template =
+        read(
+            """
+        { "groups": [ {"id":"a"}, {"id":"b"}, {"id":"c"} ] }
+        """);
+    assertThat(rule.apply(FILE, template)).isEmpty();
+  }
+
+  @Test
+  void duplicate_findingPointsAtSecondOccurrence() throws Exception {
+    JsonNode template =
+        read(
+            """
+        { "groups": [ {"id":"a"}, {"id":"b"}, {"id":"a"} ] }
+        """);
+    List<Finding> findings = rule.apply(FILE, template);
+    assertThat(findings).hasSize(1);
+    Finding f = findings.get(0);
+    assertThat(f.jsonPointer()).isEqualTo("/groups/2/id");
+    assertThat(f.message()).contains("a").contains("/groups/0/id");
+  }
+
+  @Test
+  void noGroupsArray_noFindings() throws Exception {
+    JsonNode template = read("{}");
+    assertThat(rule.apply(FILE, template)).isEmpty();
+  }
+
+  private static JsonNode read(String json) throws Exception {
+    return MAPPER.readTree(json);
+  }
+}

--- a/element-template-generator/validator/src/test/java/io/camunda/connector/validator/rule/UniqueIdVersionRuleTest.java
+++ b/element-template-generator/validator/src/test/java/io/camunda/connector/validator/rule/UniqueIdVersionRuleTest.java
@@ -58,7 +58,7 @@ class UniqueIdVersionRuleTest {
         read("{ \"id\": \"io.foo\", \"version\": 5 }"));
     List<Finding> findings = rule.apply(templates);
     assertThat(findings).hasSize(2);
-    assertThat(findings).allMatch(f -> f.ruleId().equals(UniqueIdVersionRule.ID));
+    assertThat(findings).allMatch(f -> f.ruleId().equals("unique-id-version"));
     assertThat(findings.get(0).message()).contains("io.foo").contains("5");
     assertThat(findings.get(0).message()).contains(findings.get(1).file().toString());
   }

--- a/element-template-generator/validator/src/test/java/io/camunda/connector/validator/rule/UniqueIdVersionRuleTest.java
+++ b/element-template-generator/validator/src/test/java/io/camunda/connector/validator/rule/UniqueIdVersionRuleTest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.validator.rule;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.connector.validator.core.Finding;
+import java.nio.file.Path;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class UniqueIdVersionRuleTest {
+
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+  private final UniqueIdVersionRule rule = new UniqueIdVersionRule();
+
+  @Test
+  void allUnique_noFindings() throws Exception {
+    Map<Path, JsonNode> templates = new LinkedHashMap<>();
+    templates.put(
+        Path.of("connectors/foo/element-templates/foo.json"),
+        read("{ \"id\": \"io.foo\", \"version\": 5 }"));
+    templates.put(
+        Path.of("connectors/foo/element-templates/versioned/foo-4.json"),
+        read("{ \"id\": \"io.foo\", \"version\": 4 }"));
+    templates.put(
+        Path.of("connectors/bar/element-templates/bar.json"),
+        read("{ \"id\": \"io.bar\", \"version\": 5 }"));
+    assertThat(rule.apply(templates)).isEmpty();
+  }
+
+  @Test
+  void twoFilesSameIdSameVersion_twoFindings() throws Exception {
+    Map<Path, JsonNode> templates = new LinkedHashMap<>();
+    templates.put(
+        Path.of("connectors/foo/element-templates/foo.json"),
+        read("{ \"id\": \"io.foo\", \"version\": 5 }"));
+    templates.put(
+        Path.of("connectors/foo/element-templates/versioned/foo-5.json"),
+        read("{ \"id\": \"io.foo\", \"version\": 5 }"));
+    List<Finding> findings = rule.apply(templates);
+    assertThat(findings).hasSize(2);
+    assertThat(findings).allMatch(f -> f.ruleId().equals(UniqueIdVersionRule.ID));
+    assertThat(findings.get(0).message()).contains("io.foo").contains("5");
+    assertThat(findings.get(0).message()).contains(findings.get(1).file().toString());
+  }
+
+  @Test
+  void sameIdDifferentVersions_noFindings() throws Exception {
+    Map<Path, JsonNode> templates = new LinkedHashMap<>();
+    templates.put(
+        Path.of("connectors/foo/element-templates/foo.json"),
+        read("{ \"id\": \"io.foo\", \"version\": 5 }"));
+    templates.put(
+        Path.of("connectors/foo/element-templates/versioned/foo-4.json"),
+        read("{ \"id\": \"io.foo\", \"version\": 4 }"));
+    assertThat(rule.apply(templates)).isEmpty();
+  }
+
+  @Test
+  void sameVersionDifferentIds_noFindings() throws Exception {
+    Map<Path, JsonNode> templates = new LinkedHashMap<>();
+    templates.put(
+        Path.of("connectors/foo/element-templates/foo.json"),
+        read("{ \"id\": \"io.foo\", \"version\": 5 }"));
+    templates.put(
+        Path.of("connectors/bar/element-templates/bar.json"),
+        read("{ \"id\": \"io.bar\", \"version\": 5 }"));
+    assertThat(rule.apply(templates)).isEmpty();
+  }
+
+  @Test
+  void threeFilesSameKey_threeFindings() throws Exception {
+    Map<Path, JsonNode> templates = new LinkedHashMap<>();
+    templates.put(Path.of("a.json"), read("{ \"id\": \"x\", \"version\": 1 }"));
+    templates.put(Path.of("b.json"), read("{ \"id\": \"x\", \"version\": 1 }"));
+    templates.put(Path.of("c.json"), read("{ \"id\": \"x\", \"version\": 1 }"));
+    List<Finding> findings = rule.apply(templates);
+    assertThat(findings).hasSize(3);
+  }
+
+  @Test
+  void missingIdOrVersion_skipped() throws Exception {
+    Map<Path, JsonNode> templates = new LinkedHashMap<>();
+    templates.put(Path.of("a.json"), read("{ \"id\": \"x\" }"));
+    templates.put(Path.of("b.json"), read("{ \"version\": 1 }"));
+    templates.put(Path.of("c.json"), read("{}"));
+    assertThat(rule.apply(templates)).isEmpty();
+  }
+
+  @Test
+  void multipleDistinctClashes_allReported() throws Exception {
+    Map<Path, JsonNode> templates = new LinkedHashMap<>();
+    templates.put(Path.of("a.json"), read("{ \"id\": \"x\", \"version\": 1 }"));
+    templates.put(Path.of("b.json"), read("{ \"id\": \"x\", \"version\": 1 }"));
+    templates.put(Path.of("c.json"), read("{ \"id\": \"y\", \"version\": 2 }"));
+    templates.put(Path.of("d.json"), read("{ \"id\": \"y\", \"version\": 2 }"));
+    assertThat(rule.apply(templates)).hasSize(4);
+  }
+
+  private static JsonNode read(String json) throws Exception {
+    return MAPPER.readTree(json);
+  }
+}

--- a/element-template-generator/validator/src/test/java/io/camunda/connector/validator/rule/UniquePropertyIdRuleTest.java
+++ b/element-template-generator/validator/src/test/java/io/camunda/connector/validator/rule/UniquePropertyIdRuleTest.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.validator.rule;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.connector.validator.core.Finding;
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class UniquePropertyIdRuleTest {
+
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+  private static final Path FILE = Path.of("template.json");
+  private final UniquePropertyIdRule rule = new UniquePropertyIdRule();
+
+  @Test
+  void allUnique_noFindings() throws Exception {
+    JsonNode t =
+        read("{ \"properties\": [{ \"id\": \"a\" }, { \"id\": \"b\" }, { \"id\": \"c\" } ] }");
+    assertThat(rule.apply(FILE, t)).isEmpty();
+  }
+
+  @Test
+  void duplicateId_noConditions_oneFinding() throws Exception {
+    JsonNode t =
+        read("{ \"properties\": [{ \"id\": \"a\" }, { \"id\": \"b\" }, { \"id\": \"a\" } ] }");
+    List<Finding> findings = rule.apply(FILE, t);
+    assertThat(findings).hasSize(1);
+    assertThat(findings.get(0).jsonPointer()).isEqualTo("/properties/2/id");
+    assertThat(findings.get(0).message()).contains("\"a\"").contains("/properties/0/id");
+  }
+
+  @Test
+  void tripleDuplicate_noConditions_twoFindings() throws Exception {
+    JsonNode t =
+        read("{ \"properties\": [{ \"id\": \"x\" }, { \"id\": \"x\" }, { \"id\": \"x\" } ] }");
+    List<Finding> findings = rule.apply(FILE, t);
+    assertThat(findings).hasSize(2);
+    assertThat(findings.get(0).jsonPointer()).isEqualTo("/properties/1/id");
+    assertThat(findings.get(1).jsonPointer()).isEqualTo("/properties/2/id");
+  }
+
+  @Test
+  void mutuallyExclusiveDuplicates_equals_noFindings() throws Exception {
+    JsonNode t =
+        read(
+            "{ \"properties\": ["
+                + "{ \"id\": \"x\", \"condition\": { \"property\": \"op\", \"equals\": \"a\" } },"
+                + "{ \"id\": \"x\", \"condition\": { \"property\": \"op\", \"equals\": \"b\" } } ] }");
+    assertThat(rule.apply(FILE, t)).isEmpty();
+  }
+
+  @Test
+  void mutuallyExclusiveDuplicates_oneOf_noFindings() throws Exception {
+    JsonNode t =
+        read(
+            "{ \"properties\": ["
+                + "{ \"id\": \"x\", \"condition\": { \"property\": \"op\", \"oneOf\": [\"a\", \"b\"] } },"
+                + "{ \"id\": \"x\", \"condition\": { \"property\": \"op\", \"oneOf\": [\"c\"] } },"
+                + "{ \"id\": \"x\", \"condition\": { \"property\": \"op\", \"oneOf\": [\"d\", \"e\"] } } ] }");
+    assertThat(rule.apply(FILE, t)).isEmpty();
+  }
+
+  @Test
+  void overlappingValues_flagged() throws Exception {
+    JsonNode t =
+        read(
+            "{ \"properties\": ["
+                + "{ \"id\": \"x\", \"condition\": { \"property\": \"op\", \"oneOf\": [\"a\", \"b\"] } },"
+                + "{ \"id\": \"x\", \"condition\": { \"property\": \"op\", \"equals\": \"b\" } } ] }");
+    List<Finding> findings = rule.apply(FILE, t);
+    assertThat(findings).hasSize(1);
+    assertThat(findings.get(0).jsonPointer()).isEqualTo("/properties/1/id");
+  }
+
+  @Test
+  void differentGatingProperties_flagged() throws Exception {
+    JsonNode t =
+        read(
+            "{ \"properties\": ["
+                + "{ \"id\": \"x\", \"condition\": { \"property\": \"opA\", \"equals\": \"v\" } },"
+                + "{ \"id\": \"x\", \"condition\": { \"property\": \"opB\", \"equals\": \"v\" } } ] }");
+    List<Finding> findings = rule.apply(FILE, t);
+    assertThat(findings).hasSize(1);
+  }
+
+  @Test
+  void unconditionalDuplicateMixedWithConditional_flagged() throws Exception {
+    JsonNode t =
+        read(
+            "{ \"properties\": ["
+                + "{ \"id\": \"x\" },"
+                + "{ \"id\": \"x\", \"condition\": { \"property\": \"op\", \"equals\": \"v\" } } ] }");
+    List<Finding> findings = rule.apply(FILE, t);
+    assertThat(findings).hasSize(1);
+  }
+
+  @Test
+  void allMatchCompoundDisjoint_noFindings() throws Exception {
+    // allMatch contains a disjoint sub-condition pair → mutually exclusive
+    JsonNode t =
+        read(
+            "{ \"properties\": ["
+                + "{ \"id\": \"x\", \"condition\": { \"allMatch\": ["
+                + "  { \"property\": \"op\", \"equals\": \"a\" },"
+                + "  { \"property\": \"foo\", \"equals\": \"1\" } ] } },"
+                + "{ \"id\": \"x\", \"condition\": { \"allMatch\": ["
+                + "  { \"property\": \"op\", \"equals\": \"b\" },"
+                + "  { \"property\": \"foo\", \"equals\": \"1\" } ] } } ] }");
+    assertThat(rule.apply(FILE, t)).isEmpty();
+  }
+
+  @Test
+  void propertiesWithoutId_ignored() throws Exception {
+    JsonNode t =
+        read(
+            "{ \"properties\": ["
+                + "{ \"type\": \"Hidden\" }, { \"type\": \"Hidden\" }, { \"id\": \"a\" } ] }");
+    assertThat(rule.apply(FILE, t)).isEmpty();
+  }
+
+  @Test
+  void missingPropertiesArray_noFindings() throws Exception {
+    assertThat(rule.apply(FILE, read("{}"))).isEmpty();
+    assertThat(rule.apply(FILE, read("{ \"properties\": null }"))).isEmpty();
+  }
+
+  private static JsonNode read(String json) throws Exception {
+    return MAPPER.readTree(json);
+  }
+}

--- a/element-template-generator/validator/src/test/java/io/camunda/connector/validator/rule/VersionedTemplateConsistencyRuleTest.java
+++ b/element-template-generator/validator/src/test/java/io/camunda/connector/validator/rule/VersionedTemplateConsistencyRuleTest.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.validator.rule;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.connector.validator.core.Finding;
+import java.nio.file.Path;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class VersionedTemplateConsistencyRuleTest {
+
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+  private final VersionedTemplateConsistencyRule rule = new VersionedTemplateConsistencyRule();
+
+  @Test
+  void filenameVersionMatchesField_noFindings() throws Exception {
+    Map<Path, JsonNode> templates = new LinkedHashMap<>();
+    templates.put(
+        Path.of("connectors/foo/element-templates/versioned/foo-3.json"),
+        read("{ \"id\": \"io.foo\", \"version\": 3 }"));
+    assertThat(rule.apply(templates)).isEmpty();
+  }
+
+  @Test
+  void filenameVersionMismatch_oneFinding() throws Exception {
+    Map<Path, JsonNode> templates = new LinkedHashMap<>();
+    templates.put(
+        Path.of("connectors/foo/element-templates/versioned/foo-3.json"),
+        read("{ \"id\": \"io.foo\", \"version\": 4 }"));
+    List<Finding> findings = rule.apply(templates);
+    assertThat(findings).hasSize(1);
+    assertThat(findings.get(0).jsonPointer()).isEqualTo("/version");
+    assertThat(findings.get(0).message()).contains("3").contains("4");
+  }
+
+  @Test
+  void idDriftAcrossVersions_notFlagged() throws Exception {
+    Map<Path, JsonNode> templates = new LinkedHashMap<>();
+    templates.put(
+        Path.of("connectors/foo/element-templates/foo.json"),
+        read("{ \"id\": \"io.foo.v2\", \"version\": 5 }"));
+    templates.put(
+        Path.of("connectors/foo/element-templates/versioned/foo-3.json"),
+        read("{ \"id\": \"io.foo.legacy\", \"version\": 3 }"));
+    assertThat(rule.apply(templates)).isEmpty();
+  }
+
+  @Test
+  void filenameWithoutVersionSuffix_findingOnFormat() throws Exception {
+    Map<Path, JsonNode> templates = new LinkedHashMap<>();
+    templates.put(
+        Path.of("connectors/foo/element-templates/versioned/badname.json"),
+        read("{ \"id\": \"x\", \"version\": 1 }"));
+    List<Finding> findings = rule.apply(templates);
+    assertThat(findings).hasSize(1);
+    assertThat(findings.get(0).message()).contains("{base}-{version}.json");
+  }
+
+  @Test
+  void versionFieldMissing_oneFinding() throws Exception {
+    Map<Path, JsonNode> templates = new LinkedHashMap<>();
+    templates.put(
+        Path.of("connectors/foo/element-templates/versioned/foo-3.json"),
+        read("{ \"id\": \"x\" }"));
+    List<Finding> findings = rule.apply(templates);
+    assertThat(findings).hasSize(1);
+    assertThat(findings.get(0).jsonPointer()).isEqualTo("/version");
+  }
+
+  @Test
+  void nonVersionedFiles_ignored() throws Exception {
+    Map<Path, JsonNode> templates = new LinkedHashMap<>();
+    templates.put(Path.of("connectors/foo/element-templates/foo.json"), read("{ \"id\": \"x\" }"));
+    assertThat(rule.apply(templates)).isEmpty();
+  }
+
+  @Test
+  void leadingZeroSuffixWithMissingVersion_tolerated() throws Exception {
+    Map<Path, JsonNode> templates = new LinkedHashMap<>();
+    templates.put(
+        Path.of("connectors/foo/element-templates/versioned/foo-0.json"),
+        read("{ \"id\": \"io.foo\" }"));
+    templates.put(
+        Path.of("connectors/foo/element-templates/versioned/foo-01.json"),
+        read("{ \"id\": \"io.foo\" }"));
+    templates.put(
+        Path.of("connectors/foo/element-templates/versioned/foo-02.json"),
+        read("{ \"id\": \"io.foo\" }"));
+    assertThat(rule.apply(templates)).isEmpty();
+  }
+
+  @Test
+  void leadingZeroSuffixWithMatchingVersion_noFindings() throws Exception {
+    Map<Path, JsonNode> templates = new LinkedHashMap<>();
+    templates.put(
+        Path.of("connectors/foo/element-templates/versioned/foo-02.json"),
+        read("{ \"id\": \"io.foo\", \"version\": 2 }"));
+    assertThat(rule.apply(templates)).isEmpty();
+  }
+
+  @Test
+  void leadingZeroSuffixWithMismatchedVersion_oneFinding() throws Exception {
+    Map<Path, JsonNode> templates = new LinkedHashMap<>();
+    templates.put(
+        Path.of("connectors/foo/element-templates/versioned/foo-01.json"),
+        read("{ \"id\": \"io.foo\", \"version\": 5 }"));
+    List<Finding> findings = rule.apply(templates);
+    assertThat(findings).hasSize(1);
+    assertThat(findings.get(0).jsonPointer()).isEqualTo("/version");
+    assertThat(findings.get(0).message()).contains("1").contains("5");
+  }
+
+  private static JsonNode read(String json) throws Exception {
+    return MAPPER.readTree(json);
+  }
+}


### PR DESCRIPTION
## Description

Hackdays :fire: 

A validator for element templates.

## Checklist

- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest
  release, as this branch will be rebased onto main before the next release. Example backport labels:
    - `backport stable/8.8`: for changes that should be included in the next 8.8.x release.
    - **or** `backport release-8.8.7`: for changes that should be included in the specific release 8.8.7, and this
      *release has already been created*. The release branch will be merged back into stable/8.8 later, so the change
      will be included in future 8.8.x releases as well.
- [ ] Tests/Integration tests for the changes have been added if applicable.
- [ ] If the change requires a documentation update, it has been added to the appropriate section in the documentation.


