### PR TITLE
deps(agentic-ai): update Langchain4J to 1.14.1

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -170,7 +170,7 @@ limitations under the License.</license.inlineheader>
     <version.auth0.jwt>4.5.2</version.auth0.jwt>
     <version.auth0.jwks>0.23.1</version.auth0.jwks>
 
-    <version.langchain4j>1.14.0</version.langchain4j>
+    <version.langchain4j>1.14.1</version.langchain4j>
     <version.mcp-sdk>1.1.2</version.mcp-sdk>
     <version.elasticsearch-java-client>8.19.15</version.elasticsearch-java-client>
 


### PR DESCRIPTION
## Description

Update to 1.14.1 including a fix for CVE-2026-40682.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #

## Checklist

- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest
  release, as this branch will be rebased onto main before the next release. Example backport labels:
    - `backport stable/8.8`: for changes that should be included in the next 8.8.x release.
    - **or** `backport release-8.8.7`: for changes that should be included in the specific release 8.8.7, and this
      *release has already been created*. The release branch will be merged back into stable/8.8 later, so the change
      will be included in future 8.8.x releases as well.
- [ ] Tests/Integration tests for the changes have been added if applicable.
- [ ] If the change requires a documentation update, it has been added to the appropriate section in the documentation.


