### PR TITLE
[Backport stable/8.8] deps(agentic-ai): update Langchain4J to 1.14.1

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -151,8 +151,8 @@ limitations under the License.</license.inlineheader>
 
     <version.auth0.jwt>4.5.2</version.auth0.jwt>
     <version.auth0.jwks>0.23.1</version.auth0.jwks>
-    
-    <version.langchain4j>1.14.0</version.langchain4j>
+
+    <version.langchain4j>1.14.1</version.langchain4j>
 
     <!-- maven plugins (not managed by parent) -->
     <plugin.version.maven-enforcer-plugin>3.6.2</plugin.version.maven-enforcer-plugin>


### PR DESCRIPTION
# Description
Backport of #7157 to `stable/8.8`.