### PR TITLE
chore(cve): Update netty codec dns

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -141,6 +141,8 @@ limitations under the License.</license.inlineheader>
     <version.awaitility>4.3.0</version.awaitility>
     <version.json-path>2.10.0</version.json-path>
 
+    <version.netty-codec-dns>4.1.133.Final</version.netty-codec-dns>
+
     <version.snappy-java>1.1.10.8</version.snappy-java>
     <version.commons-codec>1.22.0</version.commons-codec>
     <version.guava>33.6.0-jre</version.guava>
@@ -580,6 +582,13 @@ limitations under the License.</license.inlineheader>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-lang3</artifactId>
         <version>3.20.0</version>
+      </dependency>
+
+      <!-- CVE-2026-42579 fix: pin netty-codec-dns to 4.1.133.Final -->
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-codec-dns</artifactId>
+        <version>${version.netty-codec-dns}</version>
       </dependency>
 
       <!-- Fixes CWE-770 -->


### PR DESCRIPTION
## Description

cve-2026-42579
INC-5493

## Checklist

- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest
  release, as this branch will be rebased onto main before the next release. Example backport labels:
    - `backport stable/8.8`: for changes that should be included in the next 8.8.x release.
    - **or** `backport release-8.8.7`: for changes that should be included in the specific release 8.8.7, and this
      *release has already been created*. The release branch will be merged back into stable/8.8 later, so the change
      will be included in future 8.8.x releases as well.
- [ ] Tests/Integration tests for the changes have been added if applicable.
- [ ] If the change requires a documentation update, it has been added to the appropriate section in the documentation.


