### PR TITLE
fix: bump netty to 4.2.13.Final

### DIFF
--- a/connectors/soap/pom.xml
+++ b/connectors/soap/pom.xml
@@ -31,6 +31,13 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-bom</artifactId>
+        <version>${version.netty}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-dependencies</artifactId>
         <version>${version.spring-boot}</version>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -95,6 +95,7 @@ limitations under the License.</license.inlineheader>
     <version.hamcrest>3.0</version.hamcrest>
 
     <version.spring-boot>4.0.6</version.spring-boot>
+    <version.netty>4.2.13.Final</version.netty>
     <version.spring-cloud-gcp-starter-logging>8.0.2</version.spring-cloud-gcp-starter-logging>
     <version.logback>1.5.32</version.logback>
 
@@ -206,6 +207,15 @@ limitations under the License.</license.inlineheader>
         <groupId>com.fasterxml.jackson.datatype</groupId>
         <artifactId>jackson-datatype-jsr310</artifactId>
         <version>${version.jackson-datatype-jsr310}</version>
+      </dependency>
+
+      <!-- Netty BOM imported before Spring Boot so its version takes precedence -->
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-bom</artifactId>
+        <version>${version.netty}</version>
+        <scope>import</scope>
+        <type>pom</type>
       </dependency>
 
       <!-- Spring Boot BOM -->


### PR DESCRIPTION
## Summary

Bumps `io.netty:*` from `4.2.12.Final` to `4.2.13.Final` by importing the `netty-bom` ahead of the Spring Boot BOM in `parent/pom.xml` (and in `connectors/soap/pom.xml`, which re-imports `spring-boot-dependencies`).

Security fix. Details in the internal tracking issue: camunda/team-connectors#1213