### PR TITLE
fix: bump opennlp-tools to 2.5.9

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -701,6 +701,12 @@ limitations under the License.</license.inlineheader>
         <version>${version.system-stubs-jupiter}</version>
         <scope>test</scope>
       </dependency>
+
+      <dependency>
+        <groupId>org.apache.opennlp</groupId>
+        <artifactId>opennlp-tools</artifactId>
+        <version>2.5.9</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 


### PR DESCRIPTION
## Summary

Bumps `org.apache.opennlp:opennlp-tools` from `2.5.4` to `2.5.9` via an explicit `dependencyManagement` override in `parent/pom.xml`. The artifact is pulled in transitively through Apache Tika in the embeddings-vector-database connector.

Security fix. Details in the internal tracking issue: camunda/team-connectors#1214