### PR TITLE
fix: pin postgresql to 42.7.11

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -217,6 +217,13 @@ limitations under the License.</license.inlineheader>
         <type>pom</type>
       </dependency>
 
+      <!-- Override Spring Boot BOM postgresql pin -->
+      <dependency>
+        <groupId>org.postgresql</groupId>
+        <artifactId>postgresql</artifactId>
+        <version>42.7.11</version>
+      </dependency>
+
       <!-- gRPC BOM - the version has to be equal or greater than the one from the Camunda client -->
       <dependency>
         <groupId>io.grpc</groupId>


### PR DESCRIPTION
## Summary

Pins `org.postgresql:postgresql` to `42.7.11` in `parent/pom.xml` `<dependencyManagement>`, overriding the Spring Boot BOM-managed version.

Security fix. Details in the internal tracking issue: camunda/team-connectors#1215