### PR TITLE
fix(cve): bump netty to 4.1.133.Final via netty-bom (CVE-2026-42579)

### DIFF
--- a/connectors/soap/pom.xml
+++ b/connectors/soap/pom.xml
@@ -34,6 +34,13 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-bom</artifactId>
+        <version>${version.netty}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-dependencies</artifactId>
         <version>${version.spring-boot}</version>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -141,6 +141,8 @@ limitations under the License.</license.inlineheader>
     <version.awaitility>4.3.0</version.awaitility>
     <version.json-path>2.10.0</version.json-path>
 
+    <version.netty>4.1.133.Final</version.netty>
+
     <version.snappy-java>1.1.10.8</version.snappy-java>
     <version.commons-codec>1.22.0</version.commons-codec>
     <version.guava>33.6.0-jre</version.guava>
@@ -181,6 +183,15 @@ limitations under the License.</license.inlineheader>
         <groupId>com.fasterxml.jackson.datatype</groupId>
         <artifactId>jackson-datatype-jsr310</artifactId>
         <version>${version.jackson-datatype-jsr310}</version>
+      </dependency>
+
+      <!-- Netty BOM imported before Spring Boot so its version takes precedence -->
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-bom</artifactId>
+        <version>${version.netty}</version>
+        <scope>import</scope>
+        <type>pom</type>
       </dependency>
 
       <!-- Spring Boot BOM -->
@@ -581,6 +592,7 @@ limitations under the License.</license.inlineheader>
         <artifactId>commons-lang3</artifactId>
         <version>3.20.0</version>
       </dependency>
+
 
       <!-- Fixes CWE-770 -->
       <dependency>


### PR DESCRIPTION
## Description

Bumps `io.netty:*` from the version shipped with Spring Boot 3.5.14 to `4.1.133.Final` by importing the `netty-bom` ahead of the Spring Boot BOM in `parent/pom.xml` (and in `connectors/soap/pom.xml`, which re-imports `spring-boot-dependencies`).

Security fix for CVE-2026-42579 / SNYK-JAVA-IONETTY-16438938 (Poison Null Byte in netty-codec-dns).
INC-5493