### PR TITLE
ci: add ag cookbook & merge queue trigger

### DIFF
--- a/.github/workflows/FEATURE_BRANCH_HELM_TEST.yaml
+++ b/.github/workflows/FEATURE_BRANCH_HELM_TEST.yaml
@@ -1,12 +1,26 @@
 name: Feature branch Helm test
 
 on:
-  push:
-    branches:
-      - '**'
-      - '!main'
+  workflow_dispatch:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+      - converted_to_draft
 
 jobs:
+  fork-guard:
+    name: Skip if external fork
+    runs-on: ubuntu-latest
+    permissions: {}
+    if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
+    steps:
+      - name: Explain skip in logs
+        run: |
+          echo "🛑 External fork; skipping secrets-dependent feature branch Helm workflow."
+          echo "Push to a branch in the main repository to run this workflow."
   build-image:
     name: Build and Publish Connectors Docker Image
     runs-on: ubuntu-latest
@@ -93,13 +107,7 @@ jobs:
           MAVEN_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
           BASE_VERSION="${MAVEN_VERSION%-SNAPSHOT}"
 
-          PR_NUMBER="$(
-            curl -fsSL \
-              -H "Accept: application/vnd.github+json" \
-              -H "Authorization: Bearer ${GH_TOKEN}" \
-              "https://api.github.com/repos/${GITHUB_REPOSITORY}/commits/${GITHUB_SHA}/pulls" \
-            | jq -r '.[0].number // empty'
-          )" || PR_NUMBER=""
+           PR_NUMBER="${{ github.event.pull_request.number }}"
 
           if [[ -z "$PR_NUMBER" ]]; then
             echo "::notice::No PR found for ${GITHUB_SHA}. Will not push PR-tagged images."
@@ -122,6 +130,7 @@ jobs:
 
       # Publish Docker images for Preview environments
       - name: Build and Push Docker Image tag ${{ env.TAG }} - bundle-default
+        if: ${{ steps.connectors-version.outputs.should-push == 'true' }}
         env:
           TAG: ${{ steps.connectors-version.outputs.connectors-version }}
         uses: docker/build-push-action@v6
@@ -152,6 +161,24 @@ jobs:
       connectors-version: ${{ needs.build-image.outputs.connectors-version }}
       release-branch: main
       helm-dir: camunda-platform-8.7
+
+  sm-e2e-debug-summary:
+    name: Add SM E2E debugging guidance on failure
+    needs: trigger-sm-e2e
+    if: needs.trigger-sm-e2e.result == 'failure'
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    permissions: {}
+    steps:
+      - name: Add Helm debugging guidance on failure
+        run: |
+          COOKBOOK_URL="https://github.com/camunda/c8-cross-component-e2e-tests/blob/main/docs/ci-debugging-cookbook.md"
+          {
+            echo "## SM E2E / Helm Integration Tests Failed"
+            echo ""
+            echo "### Full debugging guide"
+            echo "[CI Debugging Cookbook — Helm Chart Setup/Integration failures](${COOKBOOK_URL}#failure-type-3--helm-chart-setup--integration-tests) · [Helm Chart E2E failures](${COOKBOOK_URL}#failure-type-4--helm-chart-e2e-tests)"
+          } >> "$GITHUB_STEP_SUMMARY"
 
   trigger-saas-e2e:
     name: Trigger SaaS E2E tests
@@ -316,3 +343,19 @@ jobs:
           else
             echo "No downstream workflow run URL found." >> "$GITHUB_STEP_SUMMARY"
           fi
+          
+      - name: Add debugging guidance on failure
+        if: steps.wait-downstream.outcome == 'failure'
+        run: |
+          DOWNSTREAM_URL="${{ steps.wait-downstream.outputs.downstream_run_url }}"
+          COOKBOOK_URL="https://github.com/camunda/c8-cross-component-e2e-tests/blob/main/docs/ci-debugging-cookbook.md"
+          {
+            echo ""
+            echo "### Debugging the SaaS E2E Failure"
+            echo ""
+            if [ -n "$DOWNSTREAM_URL" ]; then
+              echo "**Downstream run:** [$DOWNSTREAM_URL]($DOWNSTREAM_URL)"
+              echo ""
+            fi
+            echo "**Full guide:** [CI Debugging Cookbook — SaaS E2E section](${COOKBOOK_URL}#failure-type-5--saas-e2e-tests)"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/INTEGRATION_TEST.yml
+++ b/.github/workflows/INTEGRATION_TEST.yml
@@ -15,6 +15,16 @@ on:
         description: 'Connectors release branch containing code to test. Used to determine the Helm chart directory via helm-git-refs.json'
         required: true
         type: string
+      scenario:
+        description: 'Helm test scenario passed through to camunda-platform-helm test-integration-template (e.g. keycloak-original, alwaysgreen)'
+        required: false
+        type: string
+        default: 'keycloak-original'
+      shortname:
+        description: 'Short identifier used in the namespace prefix (paired with scenario)'
+        required: false
+        type: string
+        default: 'keyco'
       helm-dir:
         description: 'The camunda-platform-helm/charts directory of the Helm chart to test against. If not provided, the directory is determined based on the ref this workflow was triggered on (see helm-git-refs.json)'
         required: false
@@ -176,10 +186,12 @@ jobs:
       test-enabled: true
       # e2e-enabled is our way to disable E2E tests if needed.
       e2e-enabled: true
-      # This scenario installs a full Camunda 8 cluster with Keycloak and Elasticsearch being external. 
-      # This keycloak realm and elasticsearch prefixes are all randomly generated at installation time.
-      scenario: keycloak-original
-      shortname: keyco
+      # Scenario + shortname are caller-overridable. The default (keycloak-original / keyco) installs a
+      # full Camunda 8 cluster with external Keycloak and Elasticsearch, with randomly-generated realm
+      # and ES prefix per install. Merge-queue runs pass 'alwaysgreen' / 'agrn' to route deploys to the
+      # dedicated AlwaysGreen GKE namespace/node pool that finance tracks.
+      scenario: ${{ inputs.scenario }}
+      shortname: ${{ inputs.shortname }}
       # Github does not guarantee that the cleanup job will run. So we need to use flags. Within the helm CI the max ttl for a namespace is set.
       # That max ttl can be overridden by setting the deployment-ttl to a non-empty value.
       # When always-delete-namespace is true, and ttl is empty, the namespace is deleted after the test run.

--- a/.github/workflows/MERGE_QUEUE_HELM_TEST.yaml
+++ b/.github/workflows/MERGE_QUEUE_HELM_TEST.yaml
@@ -1,13 +1,23 @@
 name: Merge queue Helm test
 
 on:
+  push:
+    branches:
+      - stable/8.7
   workflow_dispatch:
   merge_group:
+
+# Limit workflow to 1 concurrent run per ref (branch) and trigger event: new commit -> old runs are canceled to save costs.
+# Exception for main + stable/* branches: complete builds for every commit needed for confidence.
+concurrency:
+  group: ${{ format('{0}-{1}-{2}', github.workflow, github.event_name, (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/stable/')) && github.sha || github.ref) }}
+  cancel-in-progress: true
 
 jobs:
   build-image:
     name: Build and Publish Connectors Docker Image
     runs-on: ubuntu-latest
+    continue-on-error: ${{ github.event_name == 'merge_group' }}
     outputs:
       connectors-version: ${{ steps.connectors-version.outputs.connectors-version }}
     steps:
@@ -81,7 +91,7 @@ jobs:
           username: ${{ steps.secrets.outputs.CI_LDAP_USER }}
           password: ${{ steps.secrets.outputs.CI_LDAP_PASSWORD }}
 
-      - name: Set connectors version (PR tag only)
+      - name: Set connectors version
         id: connectors-version
         env:
           GH_TOKEN: ${{ github.token }}
@@ -92,18 +102,24 @@ jobs:
           MAVEN_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
           BASE_VERSION="${MAVEN_VERSION%-SNAPSHOT}"
 
-          # merge_group.head_ref looks like refs/heads/gh-readonly-queue/<base>/pr-<N>-<sha>
-          PR_NUMBER=$(printf '%s' "$HEAD_REF" | sed -nE 's|.*/pr-([0-9]+)-.*|\1|p')
-
-          if [[ -z "$PR_NUMBER" ]]; then
-            echo "::notice::No PR number could be extracted from merge_group head_ref: $HEAD_REF"
-            echo "should-push=false" >> "$GITHUB_OUTPUT"
-            exit 0
+          if [[ "${{ github.event_name }}" == "merge_group" ]]; then
+            # merge_group.head_ref looks like refs/heads/gh-readonly-queue/<base>/pr-<N>-<sha>
+            PR_NUMBER=$(printf '%s' "$HEAD_REF" | sed -nE 's|.*/pr-([0-9]+)-.*|\1|p')
+            if [[ -z "$PR_NUMBER" ]]; then
+              echo "::notice::No PR number could be extracted from merge_group head_ref: $HEAD_REF"
+              echo "should-push=false" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            TAG="${BASE_VERSION}-pr${PR_NUMBER}-run${GITHUB_RUN_ID}-a${GITHUB_RUN_ATTEMPT}"
+          elif [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            # For manual dispatch: <base>-dispatch-run<run_id>-a<run_attempt>
+            TAG="${BASE_VERSION}-dispatch-run${GITHUB_RUN_ID}-a${GITHUB_RUN_ATTEMPT}"
+          else
+            # For push to stable/8.7: <base>-stable-8.7-run<run_id>-a<run_attempt>
+            TAG="${BASE_VERSION}-stable-8.7-run${GITHUB_RUN_ID}-a${GITHUB_RUN_ATTEMPT}"
           fi
 
-          TAG="${BASE_VERSION}-pr${PR_NUMBER}-run${GITHUB_RUN_ID}-a${GITHUB_RUN_ATTEMPT}"
-          echo "::notice::PR tag: ${TAG}"
-
+          echo "::notice::Tag: ${TAG}"
           echo "connectors-version=${TAG}" >> "$GITHUB_OUTPUT"
           echo "should-push=true" >> "$GITHUB_OUTPUT"
 
@@ -140,6 +156,7 @@ jobs:
   trigger-sm-e2e:
     name: Trigger SM E2E tests
     needs: [ build-image ]
+    if: needs.build-image.outputs.connectors-version != ''
     uses: ./.github/workflows/INTEGRATION_TEST.yml
     secrets: inherit
     with:
@@ -147,13 +164,17 @@ jobs:
       connectors-version: ${{ needs.build-image.outputs.connectors-version }}
       release-branch: main
       helm-dir: camunda-platform-8.7
+      # Route to the dedicated AlwaysGreen GKE namespace/node pool that finance tracks for cost.
+      scenario: alwaysgreen
+      shortname: agrn
 
   sm-e2e-debug-summary:
     name: Add SM E2E debugging guidance on failure
     needs: trigger-sm-e2e
-    if: needs.trigger-sm-e2e.result == 'failure'
+    if: always() && needs.trigger-sm-e2e.result == 'failure'
     runs-on: ubuntu-latest
     timeout-minutes: 3
+    continue-on-error: ${{ github.event_name == 'merge_group' }}
     permissions: {}
     steps:
       - name: Add Helm debugging guidance on failure
@@ -170,7 +191,9 @@ jobs:
     name: Trigger SaaS E2E tests
     runs-on: ubuntu-latest
     needs: [ build-image ]
+    if: needs.build-image.outputs.connectors-version != ''
     timeout-minutes: 25
+    continue-on-error: ${{ github.event_name == 'merge_group' }}
     permissions: { }
     steps:
       - name: Checkout repository
@@ -194,7 +217,12 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ steps.github-token.outputs.token }}
           CORRELATION_ID: ${{ github.repository }}:${{ github.run_id }}:${{ github.run_attempt }}:${{ github.sha }}
+          IMAGE_TAG: ${{ needs.build-image.outputs.connectors-version }}
         run: |
+          # Use the image tag as the generation name to match filter patterns
+          # e.g., "8.7.0-stable-8.7-run12345678-a1" matches "**-stable-8.7-run**-a**"
+          GEN_NAME="${IMAGE_TAG}"
+
           curl -X POST \
             -H "Accept: application/vnd.github+json" \
             -H "Authorization: Bearer $GITHUB_TOKEN" \
@@ -205,6 +233,7 @@ jobs:
                       "correlation_id": "'"$CORRELATION_ID"'",
                       "source_repo": "${{ github.repository }}",
                       "source_sha": "${{ github.sha }}",
+                      "gen_name": "'"${GEN_NAME}"'",
                       "c8Version": "8.7",
                       "zeebeVersion": "8.7-SNAPSHOT",
                       "operateVersion": "8.7-SNAPSHOT",

--- a/.github/workflows/MERGE_QUEUE_HELM_TEST.yaml
+++ b/.github/workflows/MERGE_QUEUE_HELM_TEST.yaml
@@ -1,26 +1,10 @@
-name: Feature branch Helm test
+name: Merge queue Helm test
 
 on:
   workflow_dispatch:
-  pull_request:
-    types:
-      - opened
-      - synchronize
-      - reopened
-      - ready_for_review
-      - converted_to_draft
+  merge_group:
 
 jobs:
-  fork-guard:
-    name: Skip if external fork
-    runs-on: ubuntu-latest
-    permissions: {}
-    if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
-    steps:
-      - name: Explain skip in logs
-        run: |
-          echo "🛑 External fork; skipping secrets-dependent feature branch Helm workflow."
-          echo "Push to a branch in the main repository to run this workflow."
   build-image:
     name: Build and Publish Connectors Docker Image
     runs-on: ubuntu-latest
@@ -101,16 +85,18 @@ jobs:
         id: connectors-version
         env:
           GH_TOKEN: ${{ github.token }}
+          HEAD_REF: ${{ github.event.merge_group.head_ref }}
         run: |
           set -euo pipefail
 
           MAVEN_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
           BASE_VERSION="${MAVEN_VERSION%-SNAPSHOT}"
 
-           PR_NUMBER="${{ github.event.pull_request.number }}"
+          # merge_group.head_ref looks like refs/heads/gh-readonly-queue/<base>/pr-<N>-<sha>
+          PR_NUMBER=$(printf '%s' "$HEAD_REF" | sed -nE 's|.*/pr-([0-9]+)-.*|\1|p')
 
           if [[ -z "$PR_NUMBER" ]]; then
-            echo "::notice::No PR found for ${GITHUB_SHA}. Will not push PR-tagged images."
+            echo "::notice::No PR number could be extracted from merge_group head_ref: $HEAD_REF"
             echo "should-push=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

This PR updates the AlwaysGreen trigger to just be on open PRs and as well improves DevEx by adding a link to the Cookbook.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #

## Checklist

- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest
  release, as this branch will be rebased onto main before the next release. Example backport labels:
    - `backport stable/8.8`: for changes that should be included in the next 8.8.x release.
    - **or** `backport release-8.8.7`: for changes that should be included in the specific release 8.8.7, and this
      *release has already been created*. The release branch will be merged back into stable/8.8 later, so the change
      will be included in future 8.8.x releases as well.
- [ ] Tests/Integration tests for the changes have been added if applicable.
- [ ] If the change requires a documentation update, it has been added to the appropriate section in the documentation.


