### PR TITLE
fix: prefer connector virtual thread executor

### DIFF
--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/main/java/io/camunda/connector/runtime/OutboundConnectorsAutoConfiguration.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/main/java/io/camunda/connector/runtime/OutboundConnectorsAutoConfiguration.java
@@ -18,6 +18,8 @@ package io.camunda.connector.runtime;
 
 import io.camunda.client.jobhandling.CamundaClientExecutorService;
 import io.camunda.client.metrics.MeteredCamundaClientExecutorService;
+import io.camunda.client.spring.configuration.CamundaAutoConfiguration;
+import io.camunda.client.spring.configuration.ExecutorServiceConfiguration;
 import io.camunda.connector.runtime.instances.InstanceForwardingConfiguration;
 import io.camunda.connector.runtime.outbound.OutboundConnectorRuntimeConfiguration;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -25,12 +27,14 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 
 @AutoConfiguration
+@AutoConfigureBefore({CamundaAutoConfiguration.class, ExecutorServiceConfiguration.class})
 @Import({OutboundConnectorRuntimeConfiguration.class, InstanceForwardingConfiguration.class})
 public class OutboundConnectorsAutoConfiguration {
 
@@ -40,7 +44,7 @@ public class OutboundConnectorsAutoConfiguration {
       name = "camunda.connector.virtual-threads.enabled",
       havingValue = "true",
       matchIfMissing = true)
-  public CamundaClientExecutorService camundaClientExecutorService(
+  public CamundaClientExecutorService connectorCamundaClientExecutorService(
       @Autowired(required = false) MeterRegistry meterRegistry) {
     ThreadFactory factory = Thread.ofVirtual().name("job-worker-virtual-", 0).factory();
     var vThreadExecutor = Executors.newThreadPerTaskExecutor(factory);

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/main/java/io/camunda/connector/runtime/OutboundConnectorsAutoConfiguration.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/main/java/io/camunda/connector/runtime/OutboundConnectorsAutoConfiguration.java
@@ -38,7 +38,7 @@ import org.springframework.context.annotation.Import;
 @Import({OutboundConnectorRuntimeConfiguration.class, InstanceForwardingConfiguration.class})
 public class OutboundConnectorsAutoConfiguration {
 
-  @Bean
+  @Bean(name = {"connectorCamundaClientExecutorService", "camundaClientExecutorService"})
   @ConditionalOnMissingBean
   @ConditionalOnProperty(
       name = "camunda.connector.virtual-threads.enabled",

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/OutboundConnectorsAutoConfigurationTest.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/OutboundConnectorsAutoConfigurationTest.java
@@ -45,7 +45,6 @@ class OutboundConnectorsAutoConfigurationTest {
 
   private static final String CONNECTOR_EXECUTOR_BEAN_NAME =
       "connectorCamundaClientExecutorService";
-  private static final String CAMUNDA_EXECUTOR_BEAN_NAME = "meteredCamundaClientThreadPool";
 
   private final ApplicationContextRunner contextRunner =
       new ApplicationContextRunner()
@@ -60,7 +59,6 @@ class OutboundConnectorsAutoConfigurationTest {
         context -> {
           assertThat(context).hasSingleBean(CamundaClientExecutorService.class);
           assertThat(context).hasBean(CONNECTOR_EXECUTOR_BEAN_NAME);
-          assertThat(context).doesNotHaveBean(CAMUNDA_EXECUTOR_BEAN_NAME);
           assertThat(context.getBean(CamundaClientExecutorService.class))
               .isSameAs(context.getBean(CONNECTOR_EXECUTOR_BEAN_NAME))
               .isInstanceOf(MeteredCamundaClientExecutorService.class);
@@ -84,7 +82,6 @@ class OutboundConnectorsAutoConfigurationTest {
         .run(
             context -> {
               assertThat(context).doesNotHaveBean(CONNECTOR_EXECUTOR_BEAN_NAME);
-              assertThat(context).hasBean(CAMUNDA_EXECUTOR_BEAN_NAME);
               assertThat(context).hasSingleBean(CamundaClientExecutorService.class);
             });
   }

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/OutboundConnectorsAutoConfigurationTest.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/OutboundConnectorsAutoConfigurationTest.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.runtime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.client.CamundaClient;
+import io.camunda.client.jobhandling.CamundaClientExecutorService;
+import io.camunda.client.jobhandling.JobCallbackCommandWrapperFactory;
+import io.camunda.client.jobhandling.JobWorkerManager;
+import io.camunda.client.metrics.MeteredCamundaClientExecutorService;
+import io.camunda.client.metrics.MetricsRecorder;
+import io.camunda.client.spring.configuration.CamundaAutoConfiguration;
+import io.camunda.client.spring.configuration.ExecutorServiceConfiguration;
+import io.camunda.client.spring.properties.CamundaClientProperties;
+import io.camunda.connector.jackson.ConnectorsObjectMapperSupplier;
+import io.camunda.connector.runtime.annotation.ConnectorsObjectMapper;
+import io.camunda.connector.runtime.annotation.OutboundConnectorObjectMapper;
+import io.camunda.connector.runtime.core.secret.SecretProviderAggregator;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.autoconfigure.AutoConfigureBefore;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.core.annotation.MergedAnnotations;
+
+class OutboundConnectorsAutoConfigurationTest {
+
+  private static final String CONNECTOR_EXECUTOR_BEAN_NAME =
+      "connectorCamundaClientExecutorService";
+  private static final String CAMUNDA_EXECUTOR_BEAN_NAME = "meteredCamundaClientThreadPool";
+
+  private final ApplicationContextRunner contextRunner =
+      new ApplicationContextRunner()
+          .withConfiguration(
+              AutoConfigurations.of(
+                  ExecutorServiceConfiguration.class, OutboundConnectorsAutoConfiguration.class))
+          .withUserConfiguration(RequiredOutboundRuntimeBeans.class);
+
+  @Test
+  void shouldCreateConnectorExecutorServiceByDefault() {
+    contextRunner.run(
+        context -> {
+          assertThat(context).hasSingleBean(CamundaClientExecutorService.class);
+          assertThat(context).hasBean(CONNECTOR_EXECUTOR_BEAN_NAME);
+          assertThat(context).doesNotHaveBean(CAMUNDA_EXECUTOR_BEAN_NAME);
+          assertThat(context.getBean(CamundaClientExecutorService.class))
+              .isSameAs(context.getBean(CONNECTOR_EXECUTOR_BEAN_NAME))
+              .isInstanceOf(MeteredCamundaClientExecutorService.class);
+        });
+  }
+
+  @Test
+  void shouldBeConfiguredBeforeCamundaClientAutoConfiguration() {
+    var autoConfigureBefore =
+        MergedAnnotations.from(OutboundConnectorsAutoConfiguration.class)
+            .get(AutoConfigureBefore.class);
+
+    assertThat(autoConfigureBefore.getClassArray("value"))
+        .contains(CamundaAutoConfiguration.class, ExecutorServiceConfiguration.class);
+  }
+
+  @Test
+  void shouldNotCreateConnectorExecutorServiceWhenVirtualThreadsAreDisabled() {
+    contextRunner
+        .withPropertyValues("camunda.connector.virtual-threads.enabled=false")
+        .run(
+            context -> {
+              assertThat(context).doesNotHaveBean(CONNECTOR_EXECUTOR_BEAN_NAME);
+              assertThat(context).hasBean(CAMUNDA_EXECUTOR_BEAN_NAME);
+              assertThat(context).hasSingleBean(CamundaClientExecutorService.class);
+            });
+  }
+
+  static class RequiredOutboundRuntimeBeans {
+
+    @Bean
+    CamundaClient camundaClient() {
+      return mock(CamundaClient.class);
+    }
+
+    @Bean
+    JobWorkerManager jobWorkerManager() {
+      return mock(JobWorkerManager.class);
+    }
+
+    @Bean
+    JobCallbackCommandWrapperFactory jobCallbackCommandWrapperFactory() {
+      return mock(JobCallbackCommandWrapperFactory.class);
+    }
+
+    @Bean
+    SecretProviderAggregator secretProviderAggregator() {
+      return new SecretProviderAggregator(List.of());
+    }
+
+    @Bean
+    MetricsRecorder metricsRecorder() {
+      return mock(MetricsRecorder.class);
+    }
+
+    @Bean
+    CamundaClientProperties camundaClientProperties() {
+      var properties = new CamundaClientProperties();
+      properties.setExecutionThreads(1);
+      return properties;
+    }
+
+    @Bean
+    @ConnectorsObjectMapper
+    ObjectMapper connectorObjectMapper() {
+      return ConnectorsObjectMapperSupplier.getCopy();
+    }
+
+    @Bean
+    @OutboundConnectorObjectMapper
+    ObjectMapper outboundConnectorObjectMapper() {
+      return ConnectorsObjectMapperSupplier.getCopy();
+    }
+  }
+}


### PR DESCRIPTION
## Description

Fixes the default virtual-thread executor setup for the connector runtime.

The connector runtime already defines a `CamundaClientExecutorService` backed by virtual threads when `camunda.connector.virtual-threads.enabled` is missing or set to `true`. However, Camunda client auto-configuration can create its own fallback `CamundaClientExecutorService` first. Because both beans are guarded by `@ConditionalOnMissingBean`, the connector-provided virtual-thread executor may never be created.

This PR makes the connector outbound auto-configuration run before the Camunda client executor auto-configuration, ensuring that the connector-specific virtual-thread executor wins by default.

Changes included:

- Configure `OutboundConnectorsAutoConfiguration` before:
  - `CamundaAutoConfiguration`
  - `ExecutorServiceConfiguration`
- Rename the connector executor bean factory method to `connectorCamundaClientExecutorService` so the bean name is explicit and distinguishable from Camunda’s fallback bean.
- Add regression tests that verify:
  - the connector executor bean is created by default
  - Camunda’s fallback executor bean is not created when connector virtual threads are enabled
  - disabling `camunda.connector.virtual-threads.enabled` allows Camunda’s fallback executor to be created
  - the auto-configuration ordering includes the Camunda client executor configuration


## Related issues

<!-- Which issues are closed by this PR or are related -->

closes https://github.com/camunda/connectors/issues/7186

## Checklist

- [x] Backport labels are added if these code changes should be backported. No backport label is added to the latest
  release, as this branch will be rebased onto main before the next release. Example backport labels:
    - `backport stable/8.8`: for changes that should be included in the next 8.8.x release.
    - **or** `backport release-8.8.7`: for changes that should be included in the specific release 8.8.7, and this
      *release has already been created*. The release branch will be merged back into stable/8.8 later, so the change
      will be included in future 8.8.x releases as well.
- [x] Tests/Integration tests for the changes have been added if applicable.
- [x] If the change requires a documentation update, it has been added to the appropriate section in the documentation.


