### PR TITLE
ci: trigger Helm test workflow only on merge queue

### DIFF
--- a/.github/workflows/INTEGRATION_TEST.yml
+++ b/.github/workflows/INTEGRATION_TEST.yml
@@ -15,6 +15,16 @@ on:
         description: 'Connectors release branch containing code to test. Used to determine the Helm chart directory via helm-git-refs.json'
         required: true
         type: string
+      scenario:
+        description: 'Helm test scenario passed through to camunda-platform-helm test-integration-template (e.g. keycloak-original, alwaysgreen)'
+        required: false
+        type: string
+        default: 'keycloak-original'
+      shortname:
+        description: 'Short identifier used in the namespace prefix (paired with scenario)'
+        required: false
+        type: string
+        default: 'keyco'
   workflow_dispatch:
     inputs:
       image-source:
@@ -172,10 +182,12 @@ jobs:
       test-enabled: true
       # e2e-enabled is our way to disable E2E tests if needed.
       e2e-enabled: true
-      # This scenario installs a full Camunda 8 cluster with Keycloak and Elasticsearch being external. 
-      # This keycloak realm and elasticsearch prefixes are all randomly generated at installation time.
-      scenario: keycloak-original
-      shortname: keyco
+      # Scenario + shortname are caller-overridable. The default (keycloak-original / keyco) installs a
+      # full Camunda 8 cluster with external Keycloak and Elasticsearch, with randomly-generated realm
+      # and ES prefix per install. Merge-queue runs pass 'alwaysgreen' / 'agrn' to route deploys to the
+      # dedicated AlwaysGreen GKE namespace/node pool that finance tracks.
+      scenario: ${{ inputs.scenario }}
+      shortname: ${{ inputs.shortname }}
       # Github does not guarantee that the cleanup job will run. So we need to use flags. Within the helm CI the max ttl for a namespace is set.
       # That max ttl can be overridden by setting the deployment-ttl to a non-empty value.
       # When always-delete-namespace is true, and ttl is empty, the namespace is deleted after the test run.

--- a/.github/workflows/MERGE_QUEUE_HELM_TEST.yaml
+++ b/.github/workflows/MERGE_QUEUE_HELM_TEST.yaml
@@ -159,7 +159,6 @@ jobs:
     name: Trigger SM E2E tests
     needs: [ build-image ]
     if: needs.build-image.outputs.connectors-version != ''
-    continue-on-error: ${{ github.event_name == 'merge_group' }}
     uses: ./.github/workflows/INTEGRATION_TEST.yml
     secrets: inherit
     with:
@@ -176,7 +175,6 @@ jobs:
     if: always() && needs.trigger-sm-e2e.result == 'failure'
     runs-on: ubuntu-latest
     timeout-minutes: 3
-    continue-on-error: ${{ github.event_name == 'merge_group' }}
     permissions: {}
     steps:
       - name: Add Helm debugging guidance on failure
@@ -195,7 +193,6 @@ jobs:
     needs: [ build-image ]
     if: needs.build-image.outputs.connectors-version != ''
     timeout-minutes: 25
-    continue-on-error: ${{ github.event_name == 'merge_group' }}
     permissions: { }
     steps:
       - name: Checkout repository

--- a/.github/workflows/MERGE_QUEUE_HELM_TEST.yaml
+++ b/.github/workflows/MERGE_QUEUE_HELM_TEST.yaml
@@ -1,8 +1,17 @@
 name: Merge queue Helm test
 
 on:
+  push:
+    branches:
+      - main
   workflow_dispatch:
   merge_group:
+
+# Limit workflow to 1 concurrent run per ref (branch) and trigger event: new commit -> old runs are canceled to save costs.
+# Exception for main + stable/* branches: complete builds for every commit needed for confidence.
+concurrency:
+  group: ${{ format('{0}-{1}-{2}', github.workflow, github.event_name, (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/stable/')) && github.sha || github.ref) }}
+  cancel-in-progress: true
 
 jobs:
   build-image:
@@ -84,7 +93,7 @@ jobs:
           username: ${{ steps.secrets.outputs.CI_HARBOR_USR }}
           password: ${{ steps.secrets.outputs.CI_HARBOR_PSW }}
 
-      - name: Set connectors version (PR tag only)
+      - name: Set connectors version
         id: connectors-version
         env:
           GH_TOKEN: ${{ github.token }}
@@ -95,18 +104,24 @@ jobs:
           MAVEN_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
           BASE_VERSION="${MAVEN_VERSION%-SNAPSHOT}"
 
-          # merge_group.head_ref looks like refs/heads/gh-readonly-queue/<base>/pr-<N>-<sha>
-          PR_NUMBER=$(printf '%s' "$HEAD_REF" | sed -nE 's|.*/pr-([0-9]+)-.*|\1|p')
-
-          if [[ -z "$PR_NUMBER" ]]; then
-            echo "::notice::No PR number could be extracted from merge_group head_ref: $HEAD_REF"
-            echo "should-push=false" >> "$GITHUB_OUTPUT"
-            exit 0
+          if [[ "${{ github.event_name }}" == "merge_group" ]]; then
+            # merge_group.head_ref looks like refs/heads/gh-readonly-queue/<base>/pr-<N>-<sha>
+            PR_NUMBER=$(printf '%s' "$HEAD_REF" | sed -nE 's|.*/pr-([0-9]+)-.*|\1|p')
+            if [[ -z "$PR_NUMBER" ]]; then
+              echo "::notice::No PR number could be extracted from merge_group head_ref: $HEAD_REF"
+              echo "should-push=false" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            TAG="${BASE_VERSION}-pr${PR_NUMBER}-run${GITHUB_RUN_ID}-a${GITHUB_RUN_ATTEMPT}"
+          elif [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            # For manual dispatch: <base>-dispatch-run<run_id>-a<run_attempt>
+            TAG="${BASE_VERSION}-dispatch-run${GITHUB_RUN_ID}-a${GITHUB_RUN_ATTEMPT}"
+          else
+            # For push to main: <base>-main-run<run_id>-a<run_attempt>
+            TAG="${BASE_VERSION}-main-run${GITHUB_RUN_ID}-a${GITHUB_RUN_ATTEMPT}"
           fi
 
-          TAG="${BASE_VERSION}-pr${PR_NUMBER}-run${GITHUB_RUN_ID}-a${GITHUB_RUN_ATTEMPT}"
-          echo "::notice::PR tag: ${TAG}"
-
+          echo "::notice::Tag: ${TAG}"
           echo "connectors-version=${TAG}" >> "$GITHUB_OUTPUT"
           echo "should-push=true" >> "$GITHUB_OUTPUT"
 
@@ -202,7 +217,12 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ steps.github-token.outputs.token }}
           CORRELATION_ID: ${{ github.repository }}:${{ github.run_id }}:${{ github.run_attempt }}:${{ github.sha }}
+          IMAGE_TAG: ${{ needs.build-image.outputs.connectors-version }}
         run: |
+          # Use the image tag as the generation name to match filter patterns
+          # e.g., "8.10.0-main-run12345678-a1" matches "**-main-run**-a**"
+          GEN_NAME="${IMAGE_TAG}"
+
           curl -X POST \
             -H "Accept: application/vnd.github+json" \
             -H "Authorization: Bearer $GITHUB_TOKEN" \
@@ -213,6 +233,7 @@ jobs:
                       "correlation_id": "'"$CORRELATION_ID"'",
                       "source_repo": "${{ github.repository }}",
                       "source_sha": "${{ github.sha }}",
+                      "gen_name": "'"${GEN_NAME}"'",
                       "c8Version": "8.10",
                       "zeebeVersion": "SNAPSHOT",
                       "operateVersion": "SNAPSHOT",

--- a/.github/workflows/MERGE_QUEUE_HELM_TEST.yaml
+++ b/.github/workflows/MERGE_QUEUE_HELM_TEST.yaml
@@ -166,6 +166,9 @@ jobs:
       image-source: artifactory
       connectors-version: ${{ needs.build-image.outputs.connectors-version }}
       release-branch: main
+      # Route to the dedicated AlwaysGreen GKE namespace/node pool that finance tracks for cost.
+      scenario: alwaysgreen
+      shortname: agrn
 
   sm-e2e-debug-summary:
     name: Add SM E2E debugging guidance on failure

--- a/.github/workflows/MERGE_QUEUE_HELM_TEST.yaml
+++ b/.github/workflows/MERGE_QUEUE_HELM_TEST.yaml
@@ -8,6 +8,7 @@ jobs:
   build-image:
     name: Build and Publish Connectors Docker Image
     runs-on: ubuntu-latest
+    continue-on-error: ${{ github.event_name == 'merge_group' }}
     outputs:
       connectors-version: ${{ steps.connectors-version.outputs.connectors-version }}
     steps:
@@ -142,6 +143,8 @@ jobs:
   trigger-sm-e2e:
     name: Trigger SM E2E tests
     needs: [ build-image ]
+    if: needs.build-image.outputs.connectors-version != ''
+    continue-on-error: ${{ github.event_name == 'merge_group' }}
     uses: ./.github/workflows/INTEGRATION_TEST.yml
     secrets: inherit
     with:
@@ -152,9 +155,10 @@ jobs:
   sm-e2e-debug-summary:
     name: Add SM E2E debugging guidance on failure
     needs: trigger-sm-e2e
-    if: needs.trigger-sm-e2e.result == 'failure'
+    if: always() && needs.trigger-sm-e2e.result == 'failure'
     runs-on: ubuntu-latest
     timeout-minutes: 3
+    continue-on-error: ${{ github.event_name == 'merge_group' }}
     permissions: {}
     steps:
       - name: Add Helm debugging guidance on failure
@@ -171,7 +175,9 @@ jobs:
     name: Trigger SaaS E2E tests
     runs-on: ubuntu-latest
     needs: [ build-image ]
+    if: needs.build-image.outputs.connectors-version != ''
     timeout-minutes: 25
+    continue-on-error: ${{ github.event_name == 'merge_group' }}
     permissions: { }
     steps:
       - name: Checkout repository
@@ -355,6 +361,7 @@ jobs:
     needs: [ build-image ]
     if: needs.build-image.outputs.connectors-version != ''
     timeout-minutes: 20
+    continue-on-error: ${{ github.event_name == 'merge_group' }}
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/MERGE_QUEUE_HELM_TEST.yaml
+++ b/.github/workflows/MERGE_QUEUE_HELM_TEST.yaml
@@ -175,6 +175,7 @@ jobs:
     if: always() && needs.trigger-sm-e2e.result == 'failure'
     runs-on: ubuntu-latest
     timeout-minutes: 3
+    continue-on-error: ${{ github.event_name == 'merge_group' }}
     permissions: {}
     steps:
       - name: Add Helm debugging guidance on failure
@@ -193,6 +194,7 @@ jobs:
     needs: [ build-image ]
     if: needs.build-image.outputs.connectors-version != ''
     timeout-minutes: 25
+    continue-on-error: ${{ github.event_name == 'merge_group' }}
     permissions: { }
     steps:
       - name: Checkout repository

--- a/.github/workflows/MERGE_QUEUE_HELM_TEST.yaml
+++ b/.github/workflows/MERGE_QUEUE_HELM_TEST.yaml
@@ -1,31 +1,13 @@
-name: Feature branch Helm test
+name: Merge queue Helm test
 
 on:
   workflow_dispatch:
-  pull_request:
-    types:
-      - opened
-      - synchronize
-      - reopened
-      - ready_for_review
-      - converted_to_draft
+  merge_group:
 
 jobs:
-  fork-guard:
-    name: Skip if external fork
-    runs-on: ubuntu-latest
-    permissions: {}
-    if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
-    steps:
-      - name: Explain skip in logs
-        run: |
-          echo "🛑 External fork; skipping secrets-dependent feature branch Helm workflow."
-          echo "Push to a branch in the main repository to run this workflow."
-
   build-image:
     name: Build and Publish Connectors Docker Image
     runs-on: ubuntu-latest
-    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
     outputs:
       connectors-version: ${{ steps.connectors-version.outputs.connectors-version }}
     steps:
@@ -105,16 +87,18 @@ jobs:
         id: connectors-version
         env:
           GH_TOKEN: ${{ github.token }}
+          HEAD_REF: ${{ github.event.merge_group.head_ref }}
         run: |
           set -euo pipefail
 
           MAVEN_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
           BASE_VERSION="${MAVEN_VERSION%-SNAPSHOT}"
 
-          PR_NUMBER="${{ github.event.pull_request.number }}"
+          # merge_group.head_ref looks like refs/heads/gh-readonly-queue/<base>/pr-<N>-<sha>
+          PR_NUMBER=$(printf '%s' "$HEAD_REF" | sed -nE 's|.*/pr-([0-9]+)-.*|\1|p')
 
           if [[ -z "$PR_NUMBER" ]]; then
-            echo "::notice::No PR number available. Will not push PR-tagged images."
+            echo "::notice::No PR number could be extracted from merge_group head_ref: $HEAD_REF"
             echo "should-push=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi


### PR DESCRIPTION
## Summary
- Renames `FEATURE_BRANCH_HELM_TEST.yaml` → `MERGE_QUEUE_HELM_TEST.yaml`
- Changes trigger from `pull_request` to `merge_group` so the workflow only runs once a PR is added to the merge queue
- Removes the `fork-guard` job (forks can't be added to the merge queue, the guard is unreachable)
- Removes the `if: event_name` conditions on `build-image` (no longer needed)
- Extracts the PR number from `github.event.merge_group.head_ref` so produced images keep their `-pr<N>-` tag
- Adds `continue-on-error: ${{ github.event_name == 'merge_group' }}` to all jobs so failures do not block the merge queue (matching the pattern in `camunda/camunda`'s `docker-build-helm-integration.yml`)
- Adds `connectors-version != ''` guard to `trigger-sm-e2e` and `trigger-saas-e2e` so they skip cleanly when no Docker image was pushed (e.g. `workflow_dispatch` with no PR context)
- Fixes `sm-e2e-debug-summary` to use `always() &&` so it can still evaluate when `trigger-sm-e2e` is skipped by the version guard

## Non-blocking rationale
The `continue-on-error` pattern ensures that merge queue entries are not blocked by transient infrastructure failures (flaky deploys, test environment issues). Failures are still visible in the UI and step summary — they just don't prevent merging. This matches the approach already used in `camunda/camunda`.

## Branch-protection coordination
For this workflow to gate merges, branch protection on `main` must:
1. Have merge queue enabled
2. Reference the new check name `Merge queue Helm test / Build and Publish Connectors Docker Image` (renamed from `Feature branch Helm test / Build and Publish Connectors Docker Image`)

## Test plan
- [x] Confirm merge queue is enabled on `main`
- [ ] Update required-check names in branch protection if needed
- [ ] Add a small no-op PR to the merge queue and verify the workflow runs + the Docker image tag remains `<version>-pr<N>-run<id>-a<attempt>`