### PR TITLE
feat(element-template-generator): add @TemplateLinkedResource annotation support

### DIFF
--- a/element-template-generator/annotations/src/main/java/io/camunda/connector/generator/java/annotation/TemplateLinkedResource.java
+++ b/element-template-generator/annotations/src/main/java/io/camunda/connector/generator/java/annotation/TemplateLinkedResource.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.generator.java.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Declares a {@code zeebe:linkedResource} block for the annotated request class. Placing this on a
+ * connector input record causes the element-template generator to emit three properties for the
+ * linked resource: a hidden {@code resourceType} marker, a {@code bindingType} dropdown, and a
+ * {@code resourceId} string field.
+ *
+ * <p>This annotation is repeatable via {@link TemplateLinkedResources}.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+@Repeatable(TemplateLinkedResources.class)
+public @interface TemplateLinkedResource {
+
+  /**
+   * Symbolic name that ties the three generated properties together, e.g. {@code formDefinition}.
+   */
+  String linkName();
+
+  /** Value written to the hidden {@code resourceType} property, e.g. {@code form}. */
+  String resourceType();
+
+  /** Property group for the visible fields (bindingType dropdown and resourceId input). */
+  String group() default "";
+
+  /** Label for the resource ID input. Defaults to {@code "Form ID"} if blank. */
+  String resourceIdLabel() default "";
+
+  /** Description for the resource ID input. Omitted if blank. */
+  String resourceIdDescription() default "";
+
+  /** Label for the binding-type dropdown. Defaults to {@code "Form binding"} if blank. */
+  String bindingTypeLabel() default "";
+}

--- a/element-template-generator/annotations/src/main/java/io/camunda/connector/generator/java/annotation/TemplateLinkedResource.java
+++ b/element-template-generator/annotations/src/main/java/io/camunda/connector/generator/java/annotation/TemplateLinkedResource.java
@@ -28,11 +28,10 @@ import java.lang.annotation.Target;
  * marker, a {@code bindingType} dropdown, a {@code resourceId} string field, and a conditional
  * {@code versionTag} string field shown only when {@code bindingType} is {@code "versionTag"}.
  *
- * <p>Supported on both operation-based connectors ({@link
- * io.camunda.connector.api.outbound.OutboundConnectorProvider} with {@link
- * io.camunda.connector.api.annotation.Operation}-annotated methods) and class-based connectors
- * ({@link io.camunda.connector.api.outbound.OutboundConnectorFunction} implementations). Not
- * supported on inbound connectors — {@code zeebe:linkedResource} is a service-task extension.
+ * <p>Supported on both operation-based connectors ({@code OutboundConnectorProvider} with
+ * {@code @Operation}-annotated methods) and class-based connectors ({@code
+ * OutboundConnectorFunction} implementations). Not supported on inbound connectors — {@code
+ * zeebe:linkedResource} is a service-task extension.
  *
  * <p>This annotation is repeatable via {@link TemplateLinkedResources}.
  */

--- a/element-template-generator/annotations/src/main/java/io/camunda/connector/generator/java/annotation/TemplateLinkedResource.java
+++ b/element-template-generator/annotations/src/main/java/io/camunda/connector/generator/java/annotation/TemplateLinkedResource.java
@@ -23,10 +23,16 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Declares a {@code zeebe:linkedResource} block for the annotated request class. Placing this on a
- * connector input record causes the element-template generator to emit three properties for the
- * linked resource: a hidden {@code resourceType} marker, a {@code bindingType} dropdown, and a
- * {@code resourceId} string field.
+ * Declares a {@code zeebe:linkedResource} block for the annotated request class. The
+ * element-template generator emits four properties per annotation: a hidden {@code resourceType}
+ * marker, a {@code bindingType} dropdown, a {@code resourceId} string field, and a conditional
+ * {@code versionTag} string field shown only when {@code bindingType} is {@code "versionTag"}.
+ *
+ * <p>Supported on both operation-based connectors ({@link
+ * io.camunda.connector.api.outbound.OutboundConnectorProvider} with {@link
+ * io.camunda.connector.api.annotation.Operation}-annotated methods) and class-based connectors
+ * ({@link io.camunda.connector.api.outbound.OutboundConnectorFunction} implementations). Not
+ * supported on inbound connectors — {@code zeebe:linkedResource} is a service-task extension.
  *
  * <p>This annotation is repeatable via {@link TemplateLinkedResources}.
  */
@@ -46,12 +52,12 @@ public @interface TemplateLinkedResource {
   /** Property group for the visible fields (bindingType dropdown and resourceId input). */
   String group() default "";
 
-  /** Label for the resource ID input. Defaults to {@code "Form ID"} if blank. */
+  /** Label for the resource ID input. Defaults to {@code "Resource ID"} if blank. */
   String resourceIdLabel() default "";
 
   /** Description for the resource ID input. Omitted if blank. */
   String resourceIdDescription() default "";
 
-  /** Label for the binding-type dropdown. Defaults to {@code "Form binding"} if blank. */
+  /** Label for the binding-type dropdown. Defaults to {@code "Resource binding"} if blank. */
   String bindingTypeLabel() default "";
 }

--- a/element-template-generator/annotations/src/main/java/io/camunda/connector/generator/java/annotation/TemplateLinkedResource.java
+++ b/element-template-generator/annotations/src/main/java/io/camunda/connector/generator/java/annotation/TemplateLinkedResource.java
@@ -23,10 +23,17 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Declares a {@code zeebe:linkedResource} block for the annotated request class. The
- * element-template generator emits four properties per annotation: a hidden {@code resourceType}
- * marker, a {@code bindingType} dropdown, a {@code resourceId} string field, and a conditional
- * {@code versionTag} string field shown only when {@code bindingType} is {@code "versionTag"}.
+ * Declares a {@code zeebe:linkedResource} block for the annotated request class.
+ *
+ * <p>When {@link #optional} is {@code false} (the default), the generator emits four properties: a
+ * hidden {@code resourceType} marker, a {@code bindingType} dropdown, a {@code resourceId} string
+ * field, and a conditional {@code versionTag} string field shown only when {@code bindingType} is
+ * {@code "versionTag"}.
+ *
+ * <p>When {@link #optional} is {@code true}, a fifth property is prepended: a Yes/No toggle (bound
+ * as a {@code zeebe:taskHeader}). All four linked-resource properties are conditioned on the toggle
+ * being {@code "true"}, so when the user leaves it at the default {@code "false"} no {@code
+ * zeebe:linkedResource} block is written to the BPMN and Zeebe accepts the process without a form.
  *
  * <p>Supported on both operation-based connectors ({@code OutboundConnectorProvider} with
  * {@code @Operation}-annotated methods) and class-based connectors ({@code
@@ -59,4 +66,17 @@ public @interface TemplateLinkedResource {
 
   /** Label for the binding-type dropdown. Defaults to {@code "Resource binding"} if blank. */
   String bindingTypeLabel() default "";
+
+  /**
+   * When {@code true}, emits a Yes/No toggle before the other linked-resource properties. All four
+   * linked-resource properties are shown and written only when the toggle is set to {@code "Yes"},
+   * making the entire linked resource optional at deploy time.
+   */
+  boolean optional() default false;
+
+  /**
+   * Label for the optional toggle. Only used when {@link #optional} is {@code true}. Defaults to
+   * {@code "Include <linkName>?"} if blank.
+   */
+  String toggleLabel() default "";
 }

--- a/element-template-generator/annotations/src/main/java/io/camunda/connector/generator/java/annotation/TemplateLinkedResources.java
+++ b/element-template-generator/annotations/src/main/java/io/camunda/connector/generator/java/annotation/TemplateLinkedResources.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.generator.java.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/** Container annotation for repeatable {@link TemplateLinkedResource}. */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface TemplateLinkedResources {
+  TemplateLinkedResource[] value();
+}

--- a/element-template-generator/core/README.md
+++ b/element-template-generator/core/README.md
@@ -268,6 +268,88 @@ like message start events or message catch events.
 Every generated property is bound to a Zeebe input (`zeebe:input` mapping). The binding name is derived from the
 field name. Other bindings, like task headers, are currently not supported by the `@TemplateProperty` annotation.
 
+## Linked resources
+
+A [`zeebe:linkedResource`](https://docs.camunda.io/docs/apis-tools/modeler/element-templates/element-templates-json-schema/#linked-resources)
+block declares that a service task depends on a Camunda resource — such as a form —
+that Zeebe resolves and attaches at deployment time. Use `@TemplateLinkedResource` on the request
+class to generate this block automatically instead of writing the JSON by hand.
+
+> **Note:** `zeebe:linkedResource` is a service-task extension. It is supported on outbound
+> connectors (`OutboundConnectorFunction` and `OutboundConnectorProvider`) only. The annotation is
+> silently ignored on inbound connectors.
+
+### Basic usage
+
+Annotate the connector's request class (or an `@Operation` parameter type) with
+`@TemplateLinkedResource`:
+
+```java
+@TemplateLinkedResource(
+    linkName = "formDefinition",
+    resourceType = "form",
+    group = "form",
+    resourceIdLabel = "Form ID",
+    resourceIdDescription = "ID of the form to attach.",
+    bindingTypeLabel = "Form binding")
+public record MyRequest(String message) {}
+```
+
+The generator produces four properties:
+
+| Property | Type | Description |
+|---|---|---|
+| Hidden `resourceType` marker | `Hidden` | Carries the `resourceType` value to Zeebe. |
+| Binding type | `Dropdown` | Lets the user choose `Latest`, `Deployment`, or `Version tag`. |
+| Resource ID | `String` | The ID of the resource to link. FEEL is enabled so secrets and variables can be used. |
+| Version tag | `String` | Shown only when the binding type is `Version tag`. FEEL is disabled. |
+
+### Optional linked resources
+
+When the linked resource should be optional — i.e. the process is valid even without it — set
+`optional = true`. This prepends a Yes/No toggle (bound as a `zeebe:taskHeader`). All four
+linked-resource properties are conditioned on the toggle, so when it is left at the default `No` no
+`zeebe:linkedResource` block is written to the BPMN and Zeebe accepts the deployment without a
+linked resource.
+
+```java
+@TemplateLinkedResource(
+    linkName = "formDefinition",
+    resourceType = "form",
+    group = "form",
+    optional = true,
+    toggleLabel = "Include form?",
+    resourceIdLabel = "Form ID")
+public record MyRequest(String message) {}
+```
+
+The `toggleLabel` attribute controls the label of the toggle. If left blank it defaults to
+`"Include <linkName>?"`.
+
+### Multiple linked resources
+
+The annotation is repeatable. Each `@TemplateLinkedResource` on the same class must have a unique
+`linkName`:
+
+```java
+@TemplateLinkedResource(linkName = "preRunScript", resourceType = "RPA", group = "scripts")
+@TemplateLinkedResource(linkName = "postRunScript", resourceType = "RPA", group = "scripts")
+public record MyRequest(String input) {}
+```
+
+### Attribute reference
+
+| Attribute | Required | Default | Description |
+|---|---|---|---|
+| `linkName` | Yes | — | Symbolic name that groups the generated properties together. Must be unique per class. |
+| `resourceType` | Yes | — | Value written to the hidden `resourceType` property (e.g. `"form"`, `"RPA"`). |
+| `group` | No | `""` | Property group for the generated fields. |
+| `resourceIdLabel` | No | `"Resource ID"` | Label for the resource ID input. |
+| `resourceIdDescription` | No | `""` | Description for the resource ID input. Omitted if blank. |
+| `bindingTypeLabel` | No | `"Resource binding"` | Label for the binding type dropdown. |
+| `optional` | No | `false` | When `true`, adds a Yes/No toggle that gates the linked-resource block. |
+| `toggleLabel` | No | `"Include <linkName>?"` | Label for the optional toggle. Only used when `optional = true`. |
+
 ## Icons
 
 A custom element template icon can be defined by using the `@ElementTemplate` annotation:

--- a/element-template-generator/core/src/main/java/io/camunda/connector/generator/dsl/PropertyBinding.java
+++ b/element-template-generator/core/src/main/java/io/camunda/connector/generator/dsl/PropertyBinding.java
@@ -94,4 +94,12 @@ public sealed interface PropertyBinding {
       return "bpmn:Message#property";
     }
   }
+
+  record ZeebeLinkedResource(String linkName, String property) implements PropertyBinding {
+
+    @Override
+    public String type() {
+      return "zeebe:linkedResource";
+    }
+  }
 }

--- a/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/ClassBasedTemplateGenerator.java
+++ b/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/ClassBasedTemplateGenerator.java
@@ -33,6 +33,7 @@ import io.camunda.connector.generator.java.annotation.BpmnType;
 import io.camunda.connector.generator.java.annotation.ElementTemplate;
 import io.camunda.connector.generator.java.processor.TemplatePropertyAnnotationProcessor;
 import io.camunda.connector.generator.java.util.*;
+import io.camunda.connector.generator.java.util.LinkedResourcePropertiesUtil;
 import io.camunda.connector.generator.java.util.TemplateGenerationContext.Outbound;
 import io.camunda.connector.util.reflection.ReflectionUtil;
 import io.camunda.connector.util.reflection.ReflectionUtil.MethodWithAnnotation;
@@ -110,7 +111,7 @@ public class ClassBasedTemplateGenerator implements ElementTemplateGenerator<Cla
       // zeebe:linkedResource is a service-task extension; skip it for inbound connectors
       if (OutboundConnectorFunction.class.isAssignableFrom(connectorDefinition)) {
         properties.addAll(
-            OperationBasedConnectorUtil.buildClassBasedLinkedResourceProperties(connectorInput));
+            LinkedResourcePropertiesUtil.buildClassBasedLinkedResourceProperties(connectorInput));
       }
     } else if (OutboundConnectorProvider.class.isAssignableFrom(connectorDefinition)) {
       List<MethodWithAnnotation<Operation>> methods =

--- a/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/ClassBasedTemplateGenerator.java
+++ b/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/ClassBasedTemplateGenerator.java
@@ -33,7 +33,6 @@ import io.camunda.connector.generator.java.annotation.BpmnType;
 import io.camunda.connector.generator.java.annotation.ElementTemplate;
 import io.camunda.connector.generator.java.processor.TemplatePropertyAnnotationProcessor;
 import io.camunda.connector.generator.java.util.*;
-import io.camunda.connector.generator.java.util.LinkedResourcePropertiesUtil;
 import io.camunda.connector.generator.java.util.TemplateGenerationContext.Outbound;
 import io.camunda.connector.util.reflection.ReflectionUtil;
 import io.camunda.connector.util.reflection.ReflectionUtil.MethodWithAnnotation;

--- a/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/ClassBasedTemplateGenerator.java
+++ b/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/ClassBasedTemplateGenerator.java
@@ -107,6 +107,11 @@ public class ClassBasedTemplateGenerator implements ElementTemplateGenerator<Cla
       properties =
           new ArrayList<>(
               TemplatePropertiesUtil.extractTemplatePropertiesFromType(connectorInput, context));
+      // zeebe:linkedResource is a service-task extension; skip it for inbound connectors
+      if (OutboundConnectorFunction.class.isAssignableFrom(connectorDefinition)) {
+        properties.addAll(
+            OperationBasedConnectorUtil.buildClassBasedLinkedResourceProperties(connectorInput));
+      }
     } else if (OutboundConnectorProvider.class.isAssignableFrom(connectorDefinition)) {
       List<MethodWithAnnotation<Operation>> methods =
           ReflectionUtil.getMethodsAnnotatedWith(connectorDefinition, Operation.class);

--- a/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/util/LinkedResourcePropertiesUtil.java
+++ b/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/util/LinkedResourcePropertiesUtil.java
@@ -1,0 +1,199 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.generator.java.util;
+
+import io.camunda.connector.generator.dsl.DropdownProperty;
+import io.camunda.connector.generator.dsl.HiddenProperty;
+import io.camunda.connector.generator.dsl.PropertyBinding;
+import io.camunda.connector.generator.dsl.PropertyBuilder;
+import io.camunda.connector.generator.dsl.PropertyCondition;
+import io.camunda.connector.generator.dsl.StringProperty;
+import io.camunda.connector.generator.java.annotation.FeelMode;
+import io.camunda.connector.generator.java.annotation.TemplateLinkedResource;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+public class LinkedResourcePropertiesUtil {
+
+  static final String SUFFIX_INCLUDE = ".include";
+  static final String SUFFIX_BINDING_TYPE = ".bindingType";
+  static final String SUFFIX_RESOURCE_ID = ".resourceId";
+  static final String SUFFIX_VERSION_TAG = ".versionTag";
+
+  static final String PROPERTY_RESOURCE_TYPE = "resourceType";
+  static final String PROPERTY_BINDING_TYPE = "bindingType";
+  static final String PROPERTY_RESOURCE_ID = "resourceId";
+  static final String PROPERTY_VERSION_TAG = "versionTag";
+
+  private static final List<DropdownProperty.DropdownChoice> BINDING_TYPE_CHOICES =
+      List.of(
+          new DropdownProperty.DropdownChoice("Latest", "latest"),
+          new DropdownProperty.DropdownChoice("Deployment", "deployment"),
+          new DropdownProperty.DropdownChoice("Version tag", "versionTag"));
+
+  /** Entry point for class-based ({@code OutboundConnectorFunction}) connectors. */
+  public static List<PropertyBuilder> buildClassBasedLinkedResourceProperties(Class<?> type) {
+    TemplateLinkedResource[] annotations = type.getAnnotationsByType(TemplateLinkedResource.class);
+    if (annotations.length == 0) {
+      return List.of();
+    }
+    // defaultGroup is null: class-based connectors have no shared operation group to fall back to,
+    // unlike the operation-based path which defaults blank groups to OPERATION_GROUP_ID.
+    return buildLinkedResourcePropertiesCore(annotations, "", null, null);
+  }
+
+  static List<PropertyBuilder> buildLinkedResourcePropertiesCore(
+      TemplateLinkedResource[] annotations,
+      String idPrefix,
+      PropertyCondition.Equals baseCondition,
+      String defaultGroup) {
+
+    Set<String> seenLinkNames = new HashSet<>();
+    for (TemplateLinkedResource linkedResource : annotations) {
+      if (linkedResource.linkName().isBlank()) {
+        throw new IllegalArgumentException(
+            "@TemplateLinkedResource has a blank linkName. Please provide a non-blank linkName.");
+      }
+      if (linkedResource.resourceType().isBlank()) {
+        throw new IllegalArgumentException(
+            "@TemplateLinkedResource(linkName='"
+                + linkedResource.linkName()
+                + "') has a blank resourceType. Please provide a non-blank resourceType.");
+      }
+      if (!seenLinkNames.add(linkedResource.linkName())) {
+        throw new IllegalArgumentException(
+            "Duplicate @TemplateLinkedResource linkName '"
+                + linkedResource.linkName()
+                + "'. Each linked resource on the same class must have a unique linkName.");
+      }
+    }
+
+    List<PropertyBuilder> result = new ArrayList<>();
+    for (TemplateLinkedResource linkedResource : annotations) {
+      String group = linkedResource.group().isBlank() ? defaultGroup : linkedResource.group();
+      String bindingTypeId = idPrefix + linkedResource.linkName() + SUFFIX_BINDING_TYPE;
+
+      // When optional=true, prepend a Yes/No toggle (zeebe:taskHeader). All linked-resource
+      // properties are then conditioned on the toggle so no linkedResource block is written when
+      // the user leaves it at the default "No", avoiding a Zeebe deploy-time validation error.
+      PropertyCondition propertyCondition;
+      if (linkedResource.optional()) {
+        String toggleId = idPrefix + linkedResource.linkName() + SUFFIX_INCLUDE;
+        String toggleLabel =
+            linkedResource.toggleLabel().isBlank()
+                ? "Include " + linkedResource.linkName() + "?"
+                : linkedResource.toggleLabel();
+        result.add(
+            DropdownProperty.builder()
+                .choices(
+                    List.of(
+                        new DropdownProperty.DropdownChoice("No", "false"),
+                        new DropdownProperty.DropdownChoice("Yes", "true")))
+                .id(toggleId)
+                .label(toggleLabel)
+                .value("false")
+                .group(group)
+                .binding(
+                    new PropertyBinding.ZeebeTaskHeader(linkedResource.linkName() + SUFFIX_INCLUDE))
+                .condition(
+                    baseCondition == null
+                        ? null
+                        : new PropertyCondition.AllMatch(List.of(baseCondition))));
+
+        PropertyCondition.Equals toggleEquals = new PropertyCondition.Equals(toggleId, "true");
+        propertyCondition =
+            baseCondition == null
+                ? new PropertyCondition.AllMatch(List.of(toggleEquals))
+                : new PropertyCondition.AllMatch(List.of(baseCondition, toggleEquals));
+      } else {
+        // baseCondition == null for class-based (no operation scope); non-null for operation-based.
+        propertyCondition =
+            baseCondition == null ? null : new PropertyCondition.AllMatch(List.of(baseCondition));
+      }
+
+      result.add(
+          HiddenProperty.builder()
+              .value(linkedResource.resourceType())
+              .binding(
+                  new PropertyBinding.ZeebeLinkedResource(
+                      linkedResource.linkName(), PROPERTY_RESOURCE_TYPE))
+              .group(group)
+              .condition(propertyCondition));
+
+      result.add(
+          DropdownProperty.builder()
+              .choices(BINDING_TYPE_CHOICES)
+              .id(bindingTypeId)
+              .label(
+                  linkedResource.bindingTypeLabel().isBlank()
+                      ? "Resource binding"
+                      : linkedResource.bindingTypeLabel())
+              .value("latest")
+              .group(group)
+              .binding(
+                  new PropertyBinding.ZeebeLinkedResource(
+                      linkedResource.linkName(), PROPERTY_BINDING_TYPE))
+              .condition(propertyCondition));
+
+      result.add(
+          StringProperty.builder()
+              .id(idPrefix + linkedResource.linkName() + SUFFIX_RESOURCE_ID)
+              .label(
+                  linkedResource.resourceIdLabel().isBlank()
+                      ? "Resource ID"
+                      : linkedResource.resourceIdLabel())
+              .description(
+                  linkedResource.resourceIdDescription().isBlank()
+                      ? null
+                      : linkedResource.resourceIdDescription())
+              .group(group)
+              .binding(
+                  new PropertyBinding.ZeebeLinkedResource(
+                      linkedResource.linkName(), PROPERTY_RESOURCE_ID))
+              .condition(propertyCondition));
+
+      PropertyCondition.Equals versionTagEquals =
+          new PropertyCondition.Equals(bindingTypeId, "versionTag");
+      // versionTag condition = propertyCondition + versionTagEquals.
+      // When propertyCondition is null (non-optional class-based), just use versionTagEquals alone.
+      // Otherwise extend the existing AllMatch with versionTagEquals.
+      PropertyCondition versionTagCondition;
+      if (propertyCondition == null) {
+        versionTagCondition = versionTagEquals;
+      } else {
+        List<PropertyCondition> versionTagConditions =
+            new ArrayList<>(((PropertyCondition.AllMatch) propertyCondition).allMatch());
+        versionTagConditions.add(versionTagEquals);
+        versionTagCondition = new PropertyCondition.AllMatch(versionTagConditions);
+      }
+
+      result.add(
+          StringProperty.builder()
+              .id(idPrefix + linkedResource.linkName() + SUFFIX_VERSION_TAG)
+              .label("Version tag")
+              .feel(FeelMode.disabled)
+              .group(group)
+              .binding(
+                  new PropertyBinding.ZeebeLinkedResource(
+                      linkedResource.linkName(), PROPERTY_VERSION_TAG))
+              .condition(versionTagCondition));
+    }
+    return result;
+  }
+}

--- a/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/util/LinkedResourcePropertiesUtil.java
+++ b/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/util/LinkedResourcePropertiesUtil.java
@@ -178,8 +178,10 @@ public class LinkedResourcePropertiesUtil {
       if (propertyCondition == null) {
         versionTagCondition = versionTagEquals;
       } else {
-        List<PropertyCondition> versionTagConditions =
-            new ArrayList<>(((PropertyCondition.AllMatch) propertyCondition).allMatch());
+        if (!(propertyCondition instanceof PropertyCondition.AllMatch am)) {
+          throw new IllegalStateException("Expected AllMatch condition, got: " + propertyCondition);
+        }
+        List<PropertyCondition> versionTagConditions = new ArrayList<>(am.allMatch());
         versionTagConditions.add(versionTagEquals);
         versionTagCondition = new PropertyCondition.AllMatch(versionTagConditions);
       }

--- a/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/util/LinkedResourcePropertiesUtil.java
+++ b/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/util/LinkedResourcePropertiesUtil.java
@@ -110,7 +110,8 @@ public class LinkedResourcePropertiesUtil {
                 .value("false")
                 .group(group)
                 .binding(
-                    new PropertyBinding.ZeebeTaskHeader(linkedResource.linkName() + SUFFIX_INCLUDE))
+                    new PropertyBinding.ZeebeTaskHeader(
+                        idPrefix + linkedResource.linkName() + SUFFIX_INCLUDE))
                 .condition(
                     baseCondition == null
                         ? null

--- a/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/util/OperationBasedConnectorUtil.java
+++ b/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/util/OperationBasedConnectorUtil.java
@@ -27,11 +27,14 @@ import io.camunda.connector.generator.dsl.*;
 import io.camunda.connector.generator.dsl.PropertyBinding;
 import io.camunda.connector.generator.dsl.PropertyCondition;
 import io.camunda.connector.generator.java.annotation.FeelMode;
+import io.camunda.connector.generator.java.annotation.TemplateLinkedResource;
 import io.camunda.connector.generator.java.annotation.TemplateProperty;
 import io.camunda.connector.util.reflection.ReflectionUtil.MethodWithAnnotation;
 import java.lang.reflect.Parameter;
+import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.stream.Stream;
 
 public class OperationBasedConnectorUtil {
 
@@ -102,10 +105,13 @@ public class OperationBasedConnectorUtil {
                 List<PropertyBuilder> properties =
                     TemplatePropertiesUtil.extractTemplatePropertiesFromParameter(
                         parameter, context);
-                return properties.stream()
-                    .map(
-                        property ->
-                            mapProperty(property, operation, variable, shouldMapParameterBindings))
+                return Stream.concat(
+                        properties.stream()
+                            .map(
+                                property ->
+                                    mapProperty(
+                                        property, operation, variable, shouldMapParameterBindings)),
+                        buildLinkedResourceProperties(parameter.getType(), operation).stream())
                     .toList();
               } else {
                 return List.of(buildHeaderProperty(operation, parameter));
@@ -113,6 +119,54 @@ public class OperationBasedConnectorUtil {
             })
         .flatMap(List::stream)
         .toList();
+  }
+
+  private static List<PropertyBuilder> buildLinkedResourceProperties(
+      Class<?> type, Operation operation) {
+    TemplateLinkedResource[] annotations = type.getAnnotationsByType(TemplateLinkedResource.class);
+    if (annotations.length == 0) {
+      return List.of();
+    }
+
+    String operationId = getOperationId(operation);
+    PropertyCondition operationCondition =
+        new PropertyCondition.AllMatch(
+            List.of(new PropertyCondition.Equals(OPERATION_PROPERTY_ID, operationId)));
+
+    List<PropertyBuilder> result = new ArrayList<>();
+    for (TemplateLinkedResource lr : annotations) {
+      String group = lr.group().isBlank() ? OPERATION_GROUP_ID : lr.group();
+
+      result.add(
+          HiddenProperty.builder()
+              .value(lr.resourceType())
+              .binding(new PropertyBinding.ZeebeLinkedResource(lr.linkName(), "resourceType"))
+              .condition(operationCondition));
+
+      result.add(
+          DropdownProperty.builder()
+              .choices(
+                  List.of(
+                      new DropdownProperty.DropdownChoice("Latest", "latest"),
+                      new DropdownProperty.DropdownChoice("Deployment", "deployment"),
+                      new DropdownProperty.DropdownChoice("Version tag", "versionTag")))
+              .id(concatenateOperationIdAndPropertyId(operationId, lr.linkName() + ".bindingType"))
+              .label(lr.bindingTypeLabel().isBlank() ? "Resource binding" : lr.bindingTypeLabel())
+              .value("latest")
+              .group(group)
+              .binding(new PropertyBinding.ZeebeLinkedResource(lr.linkName(), "bindingType"))
+              .condition(operationCondition));
+
+      result.add(
+          StringProperty.builder()
+              .id(concatenateOperationIdAndPropertyId(operationId, lr.linkName() + ".resourceId"))
+              .label(lr.resourceIdLabel().isBlank() ? "Resource ID" : lr.resourceIdLabel())
+              .description(lr.resourceIdDescription().isBlank() ? null : lr.resourceIdDescription())
+              .group(group)
+              .binding(new PropertyBinding.ZeebeLinkedResource(lr.linkName(), "resourceId"))
+              .condition(operationCondition));
+    }
+    return result;
   }
 
   private static PropertyBuilder buildHeaderProperty(Operation operation, Parameter parameter) {

--- a/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/util/OperationBasedConnectorUtil.java
+++ b/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/util/OperationBasedConnectorUtil.java
@@ -44,6 +44,12 @@ public class OperationBasedConnectorUtil {
   public static String OPERATION_PROPERTY_SEPARATOR = ":";
   public static String VARIABLE_PATH_SEPARATOR = ".";
 
+  private static final List<DropdownProperty.DropdownChoice> BINDING_TYPE_CHOICES =
+      List.of(
+          new DropdownProperty.DropdownChoice("Latest", "latest"),
+          new DropdownProperty.DropdownChoice("Deployment", "deployment"),
+          new DropdownProperty.DropdownChoice("Version tag", "versionTag"));
+
   public static PropertyBuilder createOperationsProperty(
       List<MethodWithAnnotation<Operation>> methods) {
     if (methods.isEmpty()) {
@@ -127,44 +133,80 @@ public class OperationBasedConnectorUtil {
     if (annotations.length == 0) {
       return List.of();
     }
-
     String operationId = getOperationId(operation);
-    PropertyCondition operationCondition =
-        new PropertyCondition.AllMatch(
-            List.of(new PropertyCondition.Equals(OPERATION_PROPERTY_ID, operationId)));
+    String idPrefix = operationId + OPERATION_PROPERTY_SEPARATOR;
+    PropertyCondition.Equals baseCondition =
+        new PropertyCondition.Equals(OPERATION_PROPERTY_ID, operationId);
+    return buildLinkedResourcePropertiesCore(
+        annotations, idPrefix, baseCondition, OPERATION_GROUP_ID);
+  }
+
+  public static List<PropertyBuilder> buildClassBasedLinkedResourceProperties(Class<?> type) {
+    TemplateLinkedResource[] annotations = type.getAnnotationsByType(TemplateLinkedResource.class);
+    if (annotations.length == 0) {
+      return List.of();
+    }
+    // defaultGroup is null: class-based connectors have no shared operation group to fall back to,
+    // unlike the operation-based path which defaults blank groups to OPERATION_GROUP_ID.
+    return buildLinkedResourcePropertiesCore(annotations, "", null, null);
+  }
+
+  private static List<PropertyBuilder> buildLinkedResourcePropertiesCore(
+      TemplateLinkedResource[] annotations,
+      String idPrefix,
+      PropertyCondition.Equals baseCondition,
+      String defaultGroup) {
+
+    // baseCondition == null for class-based (no operation scope); non-null for operation-based.
+    // Regular properties are wrapped in AllMatch([baseCondition]) when present, null otherwise.
+    // versionTag adds its own Equals on top, forming AllMatch([baseCondition, versionTagEquals]).
+    PropertyCondition propertyCondition =
+        baseCondition == null ? null : new PropertyCondition.AllMatch(List.of(baseCondition));
 
     List<PropertyBuilder> result = new ArrayList<>();
     for (TemplateLinkedResource lr : annotations) {
-      String group = lr.group().isBlank() ? OPERATION_GROUP_ID : lr.group();
+      String group = lr.group().isBlank() ? defaultGroup : lr.group();
+      String bindingTypeId = idPrefix + lr.linkName() + ".bindingType";
 
       result.add(
           HiddenProperty.builder()
               .value(lr.resourceType())
               .binding(new PropertyBinding.ZeebeLinkedResource(lr.linkName(), "resourceType"))
-              .condition(operationCondition));
+              .condition(propertyCondition));
 
       result.add(
           DropdownProperty.builder()
-              .choices(
-                  List.of(
-                      new DropdownProperty.DropdownChoice("Latest", "latest"),
-                      new DropdownProperty.DropdownChoice("Deployment", "deployment"),
-                      new DropdownProperty.DropdownChoice("Version tag", "versionTag")))
-              .id(concatenateOperationIdAndPropertyId(operationId, lr.linkName() + ".bindingType"))
+              .choices(BINDING_TYPE_CHOICES)
+              .id(bindingTypeId)
               .label(lr.bindingTypeLabel().isBlank() ? "Resource binding" : lr.bindingTypeLabel())
               .value("latest")
               .group(group)
               .binding(new PropertyBinding.ZeebeLinkedResource(lr.linkName(), "bindingType"))
-              .condition(operationCondition));
+              .condition(propertyCondition));
 
       result.add(
           StringProperty.builder()
-              .id(concatenateOperationIdAndPropertyId(operationId, lr.linkName() + ".resourceId"))
+              .id(idPrefix + lr.linkName() + ".resourceId")
               .label(lr.resourceIdLabel().isBlank() ? "Resource ID" : lr.resourceIdLabel())
               .description(lr.resourceIdDescription().isBlank() ? null : lr.resourceIdDescription())
               .group(group)
               .binding(new PropertyBinding.ZeebeLinkedResource(lr.linkName(), "resourceId"))
-              .condition(operationCondition));
+              .condition(propertyCondition));
+
+      PropertyCondition.Equals versionTagEquals =
+          new PropertyCondition.Equals(bindingTypeId, "versionTag");
+      PropertyCondition versionTagCondition =
+          baseCondition == null
+              ? versionTagEquals
+              : new PropertyCondition.AllMatch(List.of(baseCondition, versionTagEquals));
+
+      result.add(
+          StringProperty.builder()
+              .id(idPrefix + lr.linkName() + ".versionTag")
+              .label("Version tag")
+              .group(group)
+              .binding(new PropertyBinding.ZeebeLinkedResource(lr.linkName(), "versionTag"))
+              .condition(versionTagCondition));
     }
     return result;
   }

--- a/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/util/OperationBasedConnectorUtil.java
+++ b/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/util/OperationBasedConnectorUtil.java
@@ -241,6 +241,7 @@ public class OperationBasedConnectorUtil {
           StringProperty.builder()
               .id(idPrefix + lr.linkName() + ".versionTag")
               .label("Version tag")
+              .feel(FeelMode.disabled)
               .group(group)
               .binding(new PropertyBinding.ZeebeLinkedResource(lr.linkName(), "versionTag"))
               .condition(versionTagCondition));

--- a/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/util/OperationBasedConnectorUtil.java
+++ b/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/util/OperationBasedConnectorUtil.java
@@ -157,16 +157,45 @@ public class OperationBasedConnectorUtil {
       PropertyCondition.Equals baseCondition,
       String defaultGroup) {
 
-    // baseCondition == null for class-based (no operation scope); non-null for operation-based.
-    // Regular properties are wrapped in AllMatch([baseCondition]) when present, null otherwise.
-    // versionTag adds its own Equals on top, forming AllMatch([baseCondition, versionTagEquals]).
-    PropertyCondition propertyCondition =
-        baseCondition == null ? null : new PropertyCondition.AllMatch(List.of(baseCondition));
-
     List<PropertyBuilder> result = new ArrayList<>();
     for (TemplateLinkedResource lr : annotations) {
       String group = lr.group().isBlank() ? defaultGroup : lr.group();
       String bindingTypeId = idPrefix + lr.linkName() + ".bindingType";
+
+      // When optional=true, prepend a Yes/No toggle (zeebe:taskHeader). All linked-resource
+      // properties are then conditioned on the toggle so no linkedResource block is written when
+      // the user leaves it at the default "No", avoiding a Zeebe deploy-time validation error.
+      PropertyCondition propertyCondition;
+      if (lr.optional()) {
+        String toggleId = idPrefix + lr.linkName() + ".include";
+        String toggleLabel =
+            lr.toggleLabel().isBlank() ? "Include " + lr.linkName() + "?" : lr.toggleLabel();
+        result.add(
+            DropdownProperty.builder()
+                .choices(
+                    List.of(
+                        new DropdownProperty.DropdownChoice("No", "false"),
+                        new DropdownProperty.DropdownChoice("Yes", "true")))
+                .id(toggleId)
+                .label(toggleLabel)
+                .value("false")
+                .group(group)
+                .binding(new PropertyBinding.ZeebeTaskHeader(lr.linkName() + ".include"))
+                .condition(
+                    baseCondition == null
+                        ? null
+                        : new PropertyCondition.AllMatch(List.of(baseCondition))));
+
+        PropertyCondition.Equals toggleEquals = new PropertyCondition.Equals(toggleId, "true");
+        propertyCondition =
+            baseCondition == null
+                ? new PropertyCondition.AllMatch(List.of(toggleEquals))
+                : new PropertyCondition.AllMatch(List.of(baseCondition, toggleEquals));
+      } else {
+        // baseCondition == null for class-based (no operation scope); non-null for operation-based.
+        propertyCondition =
+            baseCondition == null ? null : new PropertyCondition.AllMatch(List.of(baseCondition));
+      }
 
       result.add(
           HiddenProperty.builder()
@@ -195,10 +224,18 @@ public class OperationBasedConnectorUtil {
 
       PropertyCondition.Equals versionTagEquals =
           new PropertyCondition.Equals(bindingTypeId, "versionTag");
-      PropertyCondition versionTagCondition =
-          baseCondition == null
-              ? versionTagEquals
-              : new PropertyCondition.AllMatch(List.of(baseCondition, versionTagEquals));
+      // versionTag condition = propertyCondition + versionTagEquals.
+      // When propertyCondition is null (non-optional class-based), just use versionTagEquals alone.
+      // Otherwise extend the existing AllMatch with versionTagEquals.
+      PropertyCondition versionTagCondition;
+      if (propertyCondition == null) {
+        versionTagCondition = versionTagEquals;
+      } else {
+        List<PropertyCondition> versionTagConditions =
+            new ArrayList<>(((PropertyCondition.AllMatch) propertyCondition).allMatch());
+        versionTagConditions.add(versionTagEquals);
+        versionTagCondition = new PropertyCondition.AllMatch(versionTagConditions);
+      }
 
       result.add(
           StringProperty.builder()

--- a/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/util/OperationBasedConnectorUtil.java
+++ b/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/util/OperationBasedConnectorUtil.java
@@ -31,11 +31,8 @@ import io.camunda.connector.generator.java.annotation.TemplateLinkedResource;
 import io.camunda.connector.generator.java.annotation.TemplateProperty;
 import io.camunda.connector.util.reflection.ReflectionUtil.MethodWithAnnotation;
 import java.lang.reflect.Parameter;
-import java.util.ArrayList;
 import java.util.Comparator;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 import java.util.stream.Stream;
 
 public class OperationBasedConnectorUtil {
@@ -45,17 +42,6 @@ public class OperationBasedConnectorUtil {
   public static String OPERATION_TASK_HEADER_KEY = OPERATION_PROPERTY_ID;
   public static String OPERATION_PROPERTY_SEPARATOR = ":";
   public static String VARIABLE_PATH_SEPARATOR = ".";
-
-  private static final String SUFFIX_INCLUDE = ".include";
-  private static final String SUFFIX_BINDING_TYPE = ".bindingType";
-  private static final String SUFFIX_RESOURCE_ID = ".resourceId";
-  private static final String SUFFIX_VERSION_TAG = ".versionTag";
-
-  private static final List<DropdownProperty.DropdownChoice> BINDING_TYPE_CHOICES =
-      List.of(
-          new DropdownProperty.DropdownChoice("Latest", "latest"),
-          new DropdownProperty.DropdownChoice("Deployment", "deployment"),
-          new DropdownProperty.DropdownChoice("Version tag", "versionTag"));
 
   public static PropertyBuilder createOperationsProperty(
       List<MethodWithAnnotation<Operation>> methods) {
@@ -144,154 +130,8 @@ public class OperationBasedConnectorUtil {
     String idPrefix = operationId + OPERATION_PROPERTY_SEPARATOR;
     PropertyCondition.Equals baseCondition =
         new PropertyCondition.Equals(OPERATION_PROPERTY_ID, operationId);
-    return buildLinkedResourcePropertiesCore(
+    return LinkedResourcePropertiesUtil.buildLinkedResourcePropertiesCore(
         annotations, idPrefix, baseCondition, OPERATION_GROUP_ID);
-  }
-
-  /** Entry point for class-based ({@code OutboundConnectorFunction}) connectors. */
-  public static List<PropertyBuilder> buildClassBasedLinkedResourceProperties(Class<?> type) {
-    TemplateLinkedResource[] annotations = type.getAnnotationsByType(TemplateLinkedResource.class);
-    if (annotations.length == 0) {
-      return List.of();
-    }
-    // defaultGroup is null: class-based connectors have no shared operation group to fall back to,
-    // unlike the operation-based path which defaults blank groups to OPERATION_GROUP_ID.
-    return buildLinkedResourcePropertiesCore(annotations, "", null, null);
-  }
-
-  private static List<PropertyBuilder> buildLinkedResourcePropertiesCore(
-      TemplateLinkedResource[] annotations,
-      String idPrefix,
-      PropertyCondition.Equals baseCondition,
-      String defaultGroup) {
-
-    Set<String> seenLinkNames = new HashSet<>();
-    for (TemplateLinkedResource linkedResource : annotations) {
-      if (linkedResource.linkName().isBlank()) {
-        throw new IllegalArgumentException(
-            "@TemplateLinkedResource has a blank linkName. Please provide a non-blank linkName.");
-      }
-      if (linkedResource.resourceType().isBlank()) {
-        throw new IllegalArgumentException(
-            "@TemplateLinkedResource(linkName='"
-                + linkedResource.linkName()
-                + "') has a blank resourceType. Please provide a non-blank resourceType.");
-      }
-      if (!seenLinkNames.add(linkedResource.linkName())) {
-        throw new IllegalArgumentException(
-            "Duplicate @TemplateLinkedResource linkName '"
-                + linkedResource.linkName()
-                + "'. Each linked resource on the same class must have a unique linkName.");
-      }
-    }
-
-    List<PropertyBuilder> result = new ArrayList<>();
-    for (TemplateLinkedResource linkedResource : annotations) {
-      String group = linkedResource.group().isBlank() ? defaultGroup : linkedResource.group();
-      String bindingTypeId = idPrefix + linkedResource.linkName() + SUFFIX_BINDING_TYPE;
-
-      // When optional=true, prepend a Yes/No toggle (zeebe:taskHeader). All linked-resource
-      // properties are then conditioned on the toggle so no linkedResource block is written when
-      // the user leaves it at the default "No", avoiding a Zeebe deploy-time validation error.
-      PropertyCondition propertyCondition;
-      if (linkedResource.optional()) {
-        String toggleId = idPrefix + linkedResource.linkName() + SUFFIX_INCLUDE;
-        String toggleLabel =
-            linkedResource.toggleLabel().isBlank()
-                ? "Include " + linkedResource.linkName() + "?"
-                : linkedResource.toggleLabel();
-        result.add(
-            DropdownProperty.builder()
-                .choices(
-                    List.of(
-                        new DropdownProperty.DropdownChoice("No", "false"),
-                        new DropdownProperty.DropdownChoice("Yes", "true")))
-                .id(toggleId)
-                .label(toggleLabel)
-                .value("false")
-                .group(group)
-                .binding(
-                    new PropertyBinding.ZeebeTaskHeader(linkedResource.linkName() + SUFFIX_INCLUDE))
-                .condition(
-                    baseCondition == null
-                        ? null
-                        : new PropertyCondition.AllMatch(List.of(baseCondition))));
-
-        PropertyCondition.Equals toggleEquals = new PropertyCondition.Equals(toggleId, "true");
-        propertyCondition =
-            baseCondition == null
-                ? new PropertyCondition.AllMatch(List.of(toggleEquals))
-                : new PropertyCondition.AllMatch(List.of(baseCondition, toggleEquals));
-      } else {
-        // baseCondition == null for class-based (no operation scope); non-null for operation-based.
-        propertyCondition =
-            baseCondition == null ? null : new PropertyCondition.AllMatch(List.of(baseCondition));
-      }
-
-      result.add(
-          HiddenProperty.builder()
-              .value(linkedResource.resourceType())
-              .binding(
-                  new PropertyBinding.ZeebeLinkedResource(
-                      linkedResource.linkName(), "resourceType"))
-              .condition(propertyCondition));
-
-      result.add(
-          DropdownProperty.builder()
-              .choices(BINDING_TYPE_CHOICES)
-              .id(bindingTypeId)
-              .label(
-                  linkedResource.bindingTypeLabel().isBlank()
-                      ? "Resource binding"
-                      : linkedResource.bindingTypeLabel())
-              .value("latest")
-              .group(group)
-              .binding(
-                  new PropertyBinding.ZeebeLinkedResource(linkedResource.linkName(), "bindingType"))
-              .condition(propertyCondition));
-
-      result.add(
-          StringProperty.builder()
-              .id(idPrefix + linkedResource.linkName() + SUFFIX_RESOURCE_ID)
-              .label(
-                  linkedResource.resourceIdLabel().isBlank()
-                      ? "Resource ID"
-                      : linkedResource.resourceIdLabel())
-              .description(
-                  linkedResource.resourceIdDescription().isBlank()
-                      ? null
-                      : linkedResource.resourceIdDescription())
-              .group(group)
-              .binding(
-                  new PropertyBinding.ZeebeLinkedResource(linkedResource.linkName(), "resourceId"))
-              .condition(propertyCondition));
-
-      PropertyCondition.Equals versionTagEquals =
-          new PropertyCondition.Equals(bindingTypeId, "versionTag");
-      // versionTag condition = propertyCondition + versionTagEquals.
-      // When propertyCondition is null (non-optional class-based), just use versionTagEquals alone.
-      // Otherwise extend the existing AllMatch with versionTagEquals.
-      PropertyCondition versionTagCondition;
-      if (propertyCondition == null) {
-        versionTagCondition = versionTagEquals;
-      } else {
-        List<PropertyCondition> versionTagConditions =
-            new ArrayList<>(((PropertyCondition.AllMatch) propertyCondition).allMatch());
-        versionTagConditions.add(versionTagEquals);
-        versionTagCondition = new PropertyCondition.AllMatch(versionTagConditions);
-      }
-
-      result.add(
-          StringProperty.builder()
-              .id(idPrefix + linkedResource.linkName() + SUFFIX_VERSION_TAG)
-              .label("Version tag")
-              .feel(FeelMode.disabled)
-              .group(group)
-              .binding(
-                  new PropertyBinding.ZeebeLinkedResource(linkedResource.linkName(), "versionTag"))
-              .condition(versionTagCondition));
-    }
-    return result;
   }
 
   private static PropertyBuilder buildHeaderProperty(Operation operation, Parameter parameter) {

--- a/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/util/OperationBasedConnectorUtil.java
+++ b/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/util/OperationBasedConnectorUtil.java
@@ -33,7 +33,9 @@ import io.camunda.connector.util.reflection.ReflectionUtil.MethodWithAnnotation;
 import java.lang.reflect.Parameter;
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Stream;
 
 public class OperationBasedConnectorUtil {
@@ -43,6 +45,11 @@ public class OperationBasedConnectorUtil {
   public static String OPERATION_TASK_HEADER_KEY = OPERATION_PROPERTY_ID;
   public static String OPERATION_PROPERTY_SEPARATOR = ":";
   public static String VARIABLE_PATH_SEPARATOR = ".";
+
+  private static final String SUFFIX_INCLUDE = ".include";
+  private static final String SUFFIX_BINDING_TYPE = ".bindingType";
+  private static final String SUFFIX_RESOURCE_ID = ".resourceId";
+  private static final String SUFFIX_VERSION_TAG = ".versionTag";
 
   private static final List<DropdownProperty.DropdownChoice> BINDING_TYPE_CHOICES =
       List.of(
@@ -141,6 +148,7 @@ public class OperationBasedConnectorUtil {
         annotations, idPrefix, baseCondition, OPERATION_GROUP_ID);
   }
 
+  /** Entry point for class-based ({@code OutboundConnectorFunction}) connectors. */
   public static List<PropertyBuilder> buildClassBasedLinkedResourceProperties(Class<?> type) {
     TemplateLinkedResource[] annotations = type.getAnnotationsByType(TemplateLinkedResource.class);
     if (annotations.length == 0) {
@@ -157,19 +165,41 @@ public class OperationBasedConnectorUtil {
       PropertyCondition.Equals baseCondition,
       String defaultGroup) {
 
+    Set<String> seenLinkNames = new HashSet<>();
+    for (TemplateLinkedResource linkedResource : annotations) {
+      if (linkedResource.linkName().isBlank()) {
+        throw new IllegalArgumentException(
+            "@TemplateLinkedResource has a blank linkName. Please provide a non-blank linkName.");
+      }
+      if (linkedResource.resourceType().isBlank()) {
+        throw new IllegalArgumentException(
+            "@TemplateLinkedResource(linkName='"
+                + linkedResource.linkName()
+                + "') has a blank resourceType. Please provide a non-blank resourceType.");
+      }
+      if (!seenLinkNames.add(linkedResource.linkName())) {
+        throw new IllegalArgumentException(
+            "Duplicate @TemplateLinkedResource linkName '"
+                + linkedResource.linkName()
+                + "'. Each linked resource on the same class must have a unique linkName.");
+      }
+    }
+
     List<PropertyBuilder> result = new ArrayList<>();
-    for (TemplateLinkedResource lr : annotations) {
-      String group = lr.group().isBlank() ? defaultGroup : lr.group();
-      String bindingTypeId = idPrefix + lr.linkName() + ".bindingType";
+    for (TemplateLinkedResource linkedResource : annotations) {
+      String group = linkedResource.group().isBlank() ? defaultGroup : linkedResource.group();
+      String bindingTypeId = idPrefix + linkedResource.linkName() + SUFFIX_BINDING_TYPE;
 
       // When optional=true, prepend a Yes/No toggle (zeebe:taskHeader). All linked-resource
       // properties are then conditioned on the toggle so no linkedResource block is written when
       // the user leaves it at the default "No", avoiding a Zeebe deploy-time validation error.
       PropertyCondition propertyCondition;
-      if (lr.optional()) {
-        String toggleId = idPrefix + lr.linkName() + ".include";
+      if (linkedResource.optional()) {
+        String toggleId = idPrefix + linkedResource.linkName() + SUFFIX_INCLUDE;
         String toggleLabel =
-            lr.toggleLabel().isBlank() ? "Include " + lr.linkName() + "?" : lr.toggleLabel();
+            linkedResource.toggleLabel().isBlank()
+                ? "Include " + linkedResource.linkName() + "?"
+                : linkedResource.toggleLabel();
         result.add(
             DropdownProperty.builder()
                 .choices(
@@ -180,7 +210,8 @@ public class OperationBasedConnectorUtil {
                 .label(toggleLabel)
                 .value("false")
                 .group(group)
-                .binding(new PropertyBinding.ZeebeTaskHeader(lr.linkName() + ".include"))
+                .binding(
+                    new PropertyBinding.ZeebeTaskHeader(linkedResource.linkName() + SUFFIX_INCLUDE))
                 .condition(
                     baseCondition == null
                         ? null
@@ -199,27 +230,40 @@ public class OperationBasedConnectorUtil {
 
       result.add(
           HiddenProperty.builder()
-              .value(lr.resourceType())
-              .binding(new PropertyBinding.ZeebeLinkedResource(lr.linkName(), "resourceType"))
+              .value(linkedResource.resourceType())
+              .binding(
+                  new PropertyBinding.ZeebeLinkedResource(
+                      linkedResource.linkName(), "resourceType"))
               .condition(propertyCondition));
 
       result.add(
           DropdownProperty.builder()
               .choices(BINDING_TYPE_CHOICES)
               .id(bindingTypeId)
-              .label(lr.bindingTypeLabel().isBlank() ? "Resource binding" : lr.bindingTypeLabel())
+              .label(
+                  linkedResource.bindingTypeLabel().isBlank()
+                      ? "Resource binding"
+                      : linkedResource.bindingTypeLabel())
               .value("latest")
               .group(group)
-              .binding(new PropertyBinding.ZeebeLinkedResource(lr.linkName(), "bindingType"))
+              .binding(
+                  new PropertyBinding.ZeebeLinkedResource(linkedResource.linkName(), "bindingType"))
               .condition(propertyCondition));
 
       result.add(
           StringProperty.builder()
-              .id(idPrefix + lr.linkName() + ".resourceId")
-              .label(lr.resourceIdLabel().isBlank() ? "Resource ID" : lr.resourceIdLabel())
-              .description(lr.resourceIdDescription().isBlank() ? null : lr.resourceIdDescription())
+              .id(idPrefix + linkedResource.linkName() + SUFFIX_RESOURCE_ID)
+              .label(
+                  linkedResource.resourceIdLabel().isBlank()
+                      ? "Resource ID"
+                      : linkedResource.resourceIdLabel())
+              .description(
+                  linkedResource.resourceIdDescription().isBlank()
+                      ? null
+                      : linkedResource.resourceIdDescription())
               .group(group)
-              .binding(new PropertyBinding.ZeebeLinkedResource(lr.linkName(), "resourceId"))
+              .binding(
+                  new PropertyBinding.ZeebeLinkedResource(linkedResource.linkName(), "resourceId"))
               .condition(propertyCondition));
 
       PropertyCondition.Equals versionTagEquals =
@@ -239,11 +283,12 @@ public class OperationBasedConnectorUtil {
 
       result.add(
           StringProperty.builder()
-              .id(idPrefix + lr.linkName() + ".versionTag")
+              .id(idPrefix + linkedResource.linkName() + SUFFIX_VERSION_TAG)
               .label("Version tag")
               .feel(FeelMode.disabled)
               .group(group)
-              .binding(new PropertyBinding.ZeebeLinkedResource(lr.linkName(), "versionTag"))
+              .binding(
+                  new PropertyBinding.ZeebeLinkedResource(linkedResource.linkName(), "versionTag"))
               .condition(versionTagCondition));
     }
     return result;

--- a/element-template-generator/core/src/test/java/io/camunda/connector/generator/java/OutboundClassBasedTemplateGeneratorTest.java
+++ b/element-template-generator/core/src/test/java/io/camunda/connector/generator/java/OutboundClassBasedTemplateGeneratorTest.java
@@ -1185,16 +1185,6 @@ public class OutboundClassBasedTemplateGeneratorTest extends BaseTest {
     void optionalLinkedResource_emitsFiveProperties_firstIsToggle() {
       var template =
           generator.generate(OperationAnnotatedConnectorWithLinkedResource.class).getFirst();
-      var op4Props =
-          template.properties().stream()
-              .filter(
-                  p ->
-                      p.getCondition() instanceof PropertyCondition.AllMatch am
-                          && am.allMatch()
-                              .contains(new PropertyCondition.Equals("operation", "op4")))
-              .toList();
-      // 1 regular Variable property (message) + 1 toggle + 4 linked resource = 6 total,
-      // but only the 5 (toggle + linked resource) have zeebe:taskHeader or zeebe:linkedResource
       var toggle = getPropertyById("op4:formDefinition.include", template);
       assertThat(toggle).isInstanceOf(DropdownProperty.class);
       assertThat(toggle.getLabel()).isEqualTo("Include form?");

--- a/element-template-generator/core/src/test/java/io/camunda/connector/generator/java/OutboundClassBasedTemplateGeneratorTest.java
+++ b/element-template-generator/core/src/test/java/io/camunda/connector/generator/java/OutboundClassBasedTemplateGeneratorTest.java
@@ -1080,7 +1080,7 @@ public class OutboundClassBasedTemplateGeneratorTest extends BaseTest {
               .orElseThrow();
 
       assertThat(hidden.getValue()).isEqualTo("form");
-      assertThat(hidden.getGroup()).isNull();
+      assertThat(hidden.getGroup()).isEqualTo("form");
       assertThat(((ZeebeLinkedResource) hidden.getBinding()).linkName())
           .isEqualTo("formDefinition");
       assertThat(((ZeebeLinkedResource) hidden.getBinding()).property()).isEqualTo("resourceType");
@@ -1204,6 +1204,27 @@ public class OutboundClassBasedTemplateGeneratorTest extends BaseTest {
           .containsExactly(
               new DropdownProperty.DropdownChoice("No", "false"),
               new DropdownProperty.DropdownChoice("Yes", "true"));
+
+      // Property.equals() excludes condition, so indexOf is unreliable for properties that share
+      // the same binding/value across operations. Use index-based stream instead.
+      var allProps = template.properties();
+      int toggleIndex = -1;
+      int firstLinkedResourceIndex = Integer.MAX_VALUE;
+      for (int i = 0; i < allProps.size(); i++) {
+        var p = allProps.get(i);
+        if (toggleIndex == -1 && "op4:formDefinition.include".equals(p.getId())) {
+          toggleIndex = i;
+        }
+        if ("zeebe:linkedResource".equals(p.getBinding().type())
+            && p.getCondition() instanceof PropertyCondition.AllMatch am
+            && am.allMatch().contains(new PropertyCondition.Equals("operation", "op4"))
+            && i < firstLinkedResourceIndex) {
+          firstLinkedResourceIndex = i;
+        }
+      }
+      assertThat(toggleIndex).isGreaterThan(-1);
+      assertThat(firstLinkedResourceIndex).isLessThan(Integer.MAX_VALUE);
+      assertThat(toggleIndex).isLessThan(firstLinkedResourceIndex);
     }
 
     @Test
@@ -1380,6 +1401,16 @@ public class OutboundClassBasedTemplateGeneratorTest extends BaseTest {
           .hasMessageContaining("Duplicate")
           .hasMessageContaining("form");
     }
+
+    @Test
+    void inboundConnector_linkedResourceAnnotationOnRequest_producesNoLinkedResourceProperties() {
+      var template = generator.generate(InboundConnectorWithLinkedResourceRequest.class).getFirst();
+      var linkedResourceProps =
+          template.properties().stream()
+              .filter(p -> "zeebe:linkedResource".equals(p.getBinding().type()))
+              .toList();
+      assertThat(linkedResourceProps).isEmpty();
+    }
   }
 
   @Nested
@@ -1544,5 +1575,29 @@ public class OutboundClassBasedTemplateGeneratorTest extends BaseTest {
     public Object execute(OutboundConnectorContext context) {
       return null;
     }
+  }
+
+  // Fixture for inbound connector linked-resource test
+
+  @TemplateLinkedResource(linkName = "form", resourceType = "form")
+  private record InboundLinkedResourceRequest() {}
+
+  @io.camunda.connector.api.annotation.InboundConnector(
+      name = "Test Inbound",
+      type = "test:inbound-linked-resource")
+  @ElementTemplate(
+      id = "test-inbound-linked-resource",
+      name = "Test Inbound",
+      version = 1,
+      inputDataClass = InboundLinkedResourceRequest.class)
+  private static class InboundConnectorWithLinkedResourceRequest
+      implements io.camunda.connector.api.inbound.InboundConnectorExecutable<
+          io.camunda.connector.api.inbound.InboundConnectorContext> {
+    @Override
+    public void activate(io.camunda.connector.api.inbound.InboundConnectorContext context)
+        throws Exception {}
+
+    @Override
+    public void deactivate() {}
   }
 }

--- a/element-template-generator/core/src/test/java/io/camunda/connector/generator/java/OutboundClassBasedTemplateGeneratorTest.java
+++ b/element-template-generator/core/src/test/java/io/camunda/connector/generator/java/OutboundClassBasedTemplateGeneratorTest.java
@@ -36,6 +36,7 @@ import io.camunda.connector.generator.dsl.NumberProperty;
 import io.camunda.connector.generator.dsl.Property;
 import io.camunda.connector.generator.dsl.PropertyBinding;
 import io.camunda.connector.generator.dsl.PropertyBinding.ZeebeInput;
+import io.camunda.connector.generator.dsl.PropertyBinding.ZeebeLinkedResource;
 import io.camunda.connector.generator.dsl.PropertyBinding.ZeebeTaskDefinition;
 import io.camunda.connector.generator.dsl.PropertyBinding.ZeebeTaskHeader;
 import io.camunda.connector.generator.dsl.PropertyCondition;
@@ -48,6 +49,7 @@ import io.camunda.connector.generator.java.annotation.BpmnType;
 import io.camunda.connector.generator.java.annotation.FeelMode;
 import io.camunda.connector.generator.java.example.outbound.MyConnectorFunction;
 import io.camunda.connector.generator.java.example.outbound.OperationAnnotatedConnector;
+import io.camunda.connector.generator.java.example.outbound.OperationAnnotatedConnectorWithLinkedResource;
 import io.camunda.connector.generator.java.example.outbound.OperationAnnotatedConnectorWithPrimitiveTypes;
 import io.camunda.connector.generator.java.example.outbound.SingleOperationAnnotatedConnector;
 import java.io.File;
@@ -1035,6 +1037,151 @@ public class OutboundClassBasedTemplateGeneratorTest extends BaseTest {
       var icon = template.icon();
 
       assertThat(icon.contents()).isEqualTo(expectedIconString);
+    }
+  }
+
+  @Nested
+  class LinkedResource {
+
+    @Test
+    void singleLinkedResource_emitsThreeProperties() {
+      var template =
+          generator.generate(OperationAnnotatedConnectorWithLinkedResource.class).getFirst();
+      var linkedResourceProps =
+          template.properties().stream()
+              .filter(
+                  p ->
+                      "zeebe:linkedResource".equals(p.getBinding().type())
+                          && p.getCondition() instanceof PropertyCondition.AllMatch am
+                          && am.allMatch()
+                              .contains(new PropertyCondition.Equals("operation", "op1")))
+              .toList();
+      assertThat(linkedResourceProps).hasSize(3);
+    }
+
+    @Test
+    void linkedResource_hiddenResourceTypeProperty() {
+      var template =
+          generator.generate(OperationAnnotatedConnectorWithLinkedResource.class).getFirst();
+      var hidden =
+          template.properties().stream()
+              .filter(
+                  p ->
+                      "zeebe:linkedResource".equals(p.getBinding().type())
+                          && p instanceof HiddenProperty)
+              .findFirst()
+              .orElseThrow();
+
+      assertThat(hidden.getValue()).isEqualTo("form");
+      assertThat(hidden.getGroup()).isNull();
+      assertThat(((ZeebeLinkedResource) hidden.getBinding()).linkName())
+          .isEqualTo("formDefinition");
+      assertThat(((ZeebeLinkedResource) hidden.getBinding()).property()).isEqualTo("resourceType");
+      assertThat(hidden.getCondition()).isInstanceOf(PropertyCondition.AllMatch.class);
+      assertThat(((PropertyCondition.AllMatch) hidden.getCondition()).allMatch())
+          .contains(new PropertyCondition.Equals("operation", "op1"));
+    }
+
+    @Test
+    void linkedResource_bindingTypeDropdown() {
+      var template =
+          generator.generate(OperationAnnotatedConnectorWithLinkedResource.class).getFirst();
+      var bindingType =
+          (DropdownProperty) getPropertyById("op1:formDefinition.bindingType", template);
+
+      assertThat(bindingType.getLabel()).isEqualTo("Form binding");
+      assertThat(bindingType.getGroup()).isEqualTo("form");
+      assertThat(bindingType.getValue()).isEqualTo("latest");
+      assertThat(((ZeebeLinkedResource) bindingType.getBinding()).linkName())
+          .isEqualTo("formDefinition");
+      assertThat(((ZeebeLinkedResource) bindingType.getBinding()).property())
+          .isEqualTo("bindingType");
+      assertThat(bindingType.getChoices())
+          .containsExactly(
+              new DropdownProperty.DropdownChoice("Latest", "latest"),
+              new DropdownProperty.DropdownChoice("Deployment", "deployment"),
+              new DropdownProperty.DropdownChoice("Version tag", "versionTag"));
+      assertThat(bindingType.getCondition()).isInstanceOf(PropertyCondition.AllMatch.class);
+      assertThat(((PropertyCondition.AllMatch) bindingType.getCondition()).allMatch())
+          .contains(new PropertyCondition.Equals("operation", "op1"));
+    }
+
+    @Test
+    void linkedResource_resourceIdString() {
+      var template =
+          generator.generate(OperationAnnotatedConnectorWithLinkedResource.class).getFirst();
+      var resourceId = getPropertyById("op1:formDefinition.resourceId", template);
+
+      assertThat(resourceId).isInstanceOf(StringProperty.class);
+      assertThat(resourceId.getLabel()).isEqualTo("Form ID");
+      assertThat(resourceId.getDescription())
+          .isEqualTo("Select a form to render as an adaptive card");
+      assertThat(resourceId.getGroup()).isEqualTo("form");
+      assertThat(((ZeebeLinkedResource) resourceId.getBinding()).linkName())
+          .isEqualTo("formDefinition");
+      assertThat(((ZeebeLinkedResource) resourceId.getBinding()).property())
+          .isEqualTo("resourceId");
+      assertThat(resourceId.getCondition()).isInstanceOf(PropertyCondition.AllMatch.class);
+      assertThat(((PropertyCondition.AllMatch) resourceId.getCondition()).allMatch())
+          .contains(new PropertyCondition.Equals("operation", "op1"));
+    }
+
+    @Test
+    void multipleLinkedResources_emitsSixProperties() {
+      var template =
+          generator.generate(OperationAnnotatedConnectorWithLinkedResource.class).getFirst();
+      var op2LinkedResourceProps =
+          template.properties().stream()
+              .filter(
+                  p ->
+                      "zeebe:linkedResource".equals(p.getBinding().type())
+                          && p.getCondition() instanceof PropertyCondition.AllMatch am
+                          && am.allMatch()
+                              .contains(new PropertyCondition.Equals("operation", "op2")))
+              .toList();
+      assertThat(op2LinkedResourceProps).hasSize(6);
+    }
+
+    @Test
+    void linkedResource_blankLabels_fallBackToNeutralDefaults() {
+      var template =
+          generator.generate(OperationAnnotatedConnectorWithLinkedResource.class).getFirst();
+      var bindingType = (DropdownProperty) getPropertyById("op3:resource.bindingType", template);
+      var resourceId = getPropertyById("op3:resource.resourceId", template);
+
+      assertThat(bindingType.getLabel()).isEqualTo("Resource binding");
+      assertThat(resourceId.getLabel()).isEqualTo("Resource ID");
+      assertThat(resourceId.getDescription()).isNull();
+    }
+
+    @Test
+    void multipleLinkedResources_correctLinkNamesAndResourceTypes() {
+      var template =
+          generator.generate(OperationAnnotatedConnectorWithLinkedResource.class).getFirst();
+
+      var attachmentAHidden =
+          template.properties().stream()
+              .filter(
+                  p ->
+                      p instanceof HiddenProperty
+                          && "zeebe:linkedResource".equals(p.getBinding().type())
+                          && "attachmentA"
+                              .equals(((ZeebeLinkedResource) p.getBinding()).linkName()))
+              .findFirst()
+              .orElseThrow();
+      assertThat(attachmentAHidden.getValue()).isEqualTo("form");
+
+      var attachmentBHidden =
+          template.properties().stream()
+              .filter(
+                  p ->
+                      p instanceof HiddenProperty
+                          && "zeebe:linkedResource".equals(p.getBinding().type())
+                          && "attachmentB"
+                              .equals(((ZeebeLinkedResource) p.getBinding()).linkName()))
+              .findFirst()
+              .orElseThrow();
+      assertThat(attachmentBHidden.getValue()).isEqualTo("file");
     }
   }
 

--- a/element-template-generator/core/src/test/java/io/camunda/connector/generator/java/OutboundClassBasedTemplateGeneratorTest.java
+++ b/element-template-generator/core/src/test/java/io/camunda/connector/generator/java/OutboundClassBasedTemplateGeneratorTest.java
@@ -47,6 +47,7 @@ import io.camunda.connector.generator.dsl.StringProperty;
 import io.camunda.connector.generator.dsl.TextProperty;
 import io.camunda.connector.generator.java.annotation.BpmnType;
 import io.camunda.connector.generator.java.annotation.FeelMode;
+import io.camunda.connector.generator.java.example.outbound.ClassBasedConnectorWithLinkedResource;
 import io.camunda.connector.generator.java.example.outbound.MyConnectorFunction;
 import io.camunda.connector.generator.java.example.outbound.OperationAnnotatedConnector;
 import io.camunda.connector.generator.java.example.outbound.OperationAnnotatedConnectorWithLinkedResource;
@@ -1044,7 +1045,7 @@ public class OutboundClassBasedTemplateGeneratorTest extends BaseTest {
   class LinkedResource {
 
     @Test
-    void singleLinkedResource_emitsThreeProperties() {
+    void singleLinkedResource_emitsFourProperties() {
       var template =
           generator.generate(OperationAnnotatedConnectorWithLinkedResource.class).getFirst();
       var linkedResourceProps =
@@ -1056,7 +1057,7 @@ public class OutboundClassBasedTemplateGeneratorTest extends BaseTest {
                           && am.allMatch()
                               .contains(new PropertyCondition.Equals("operation", "op1")))
               .toList();
-      assertThat(linkedResourceProps).hasSize(3);
+      assertThat(linkedResourceProps).hasSize(4);
     }
 
     @Test
@@ -1127,7 +1128,27 @@ public class OutboundClassBasedTemplateGeneratorTest extends BaseTest {
     }
 
     @Test
-    void multipleLinkedResources_emitsSixProperties() {
+    void linkedResource_versionTagProperty_shownOnlyWhenBindingTypeIsVersionTag() {
+      var template =
+          generator.generate(OperationAnnotatedConnectorWithLinkedResource.class).getFirst();
+      var versionTag = getPropertyById("op1:formDefinition.versionTag", template);
+
+      assertThat(versionTag).isInstanceOf(StringProperty.class);
+      assertThat(versionTag.getLabel()).isEqualTo("Version tag");
+      assertThat(versionTag.getGroup()).isEqualTo("form");
+      assertThat(((ZeebeLinkedResource) versionTag.getBinding()).linkName())
+          .isEqualTo("formDefinition");
+      assertThat(((ZeebeLinkedResource) versionTag.getBinding()).property())
+          .isEqualTo("versionTag");
+      assertThat(versionTag.getCondition()).isInstanceOf(PropertyCondition.AllMatch.class);
+      var allMatch = ((PropertyCondition.AllMatch) versionTag.getCondition()).allMatch();
+      assertThat(allMatch).contains(new PropertyCondition.Equals("operation", "op1"));
+      assertThat(allMatch)
+          .contains(new PropertyCondition.Equals("op1:formDefinition.bindingType", "versionTag"));
+    }
+
+    @Test
+    void multipleLinkedResources_emitsEightProperties() {
       var template =
           generator.generate(OperationAnnotatedConnectorWithLinkedResource.class).getFirst();
       var op2LinkedResourceProps =
@@ -1139,7 +1160,7 @@ public class OutboundClassBasedTemplateGeneratorTest extends BaseTest {
                           && am.allMatch()
                               .contains(new PropertyCondition.Equals("operation", "op2")))
               .toList();
-      assertThat(op2LinkedResourceProps).hasSize(6);
+      assertThat(op2LinkedResourceProps).hasSize(8);
     }
 
     @Test
@@ -1182,6 +1203,86 @@ public class OutboundClassBasedTemplateGeneratorTest extends BaseTest {
               .findFirst()
               .orElseThrow();
       assertThat(attachmentBHidden.getValue()).isEqualTo("file");
+    }
+  }
+
+  @Nested
+  class ClassBasedLinkedResource {
+
+    @Test
+    void classBased_emitsFourLinkedResourceProperties() {
+      var template = generator.generate(ClassBasedConnectorWithLinkedResource.class).getFirst();
+      var linkedResourceProps =
+          template.properties().stream()
+              .filter(p -> "zeebe:linkedResource".equals(p.getBinding().type()))
+              .toList();
+      assertThat(linkedResourceProps).hasSize(4);
+    }
+
+    @Test
+    void classBased_hiddenResourceType_hasNoCondition() {
+      var template = generator.generate(ClassBasedConnectorWithLinkedResource.class).getFirst();
+      var hidden =
+          template.properties().stream()
+              .filter(
+                  p ->
+                      "zeebe:linkedResource".equals(p.getBinding().type())
+                          && p instanceof HiddenProperty)
+              .findFirst()
+              .orElseThrow();
+
+      assertThat(hidden.getValue()).isEqualTo("form");
+      assertThat(hidden.getCondition()).isNull();
+      assertThat(((ZeebeLinkedResource) hidden.getBinding()).linkName())
+          .isEqualTo("formDefinition");
+      assertThat(((ZeebeLinkedResource) hidden.getBinding()).property()).isEqualTo("resourceType");
+    }
+
+    @Test
+    void classBased_bindingTypeDropdown_hasNoCondition() {
+      var template = generator.generate(ClassBasedConnectorWithLinkedResource.class).getFirst();
+      var bindingType = (DropdownProperty) getPropertyById("formDefinition.bindingType", template);
+
+      assertThat(bindingType.getLabel()).isEqualTo("Form binding");
+      assertThat(bindingType.getGroup()).isEqualTo("form");
+      assertThat(bindingType.getValue()).isEqualTo("latest");
+      assertThat(bindingType.getCondition()).isNull();
+      assertThat(((ZeebeLinkedResource) bindingType.getBinding()).property())
+          .isEqualTo("bindingType");
+      assertThat(bindingType.getChoices())
+          .containsExactly(
+              new DropdownProperty.DropdownChoice("Latest", "latest"),
+              new DropdownProperty.DropdownChoice("Deployment", "deployment"),
+              new DropdownProperty.DropdownChoice("Version tag", "versionTag"));
+    }
+
+    @Test
+    void classBased_resourceIdString_hasNoCondition() {
+      var template = generator.generate(ClassBasedConnectorWithLinkedResource.class).getFirst();
+      var resourceId = getPropertyById("formDefinition.resourceId", template);
+
+      assertThat(resourceId).isInstanceOf(StringProperty.class);
+      assertThat(resourceId.getLabel()).isEqualTo("Form ID");
+      assertThat(resourceId.getDescription())
+          .isEqualTo("Select a form to render as an adaptive card");
+      assertThat(resourceId.getGroup()).isEqualTo("form");
+      assertThat(resourceId.getCondition()).isNull();
+      assertThat(((ZeebeLinkedResource) resourceId.getBinding()).property())
+          .isEqualTo("resourceId");
+    }
+
+    @Test
+    void classBased_versionTagProperty_shownOnlyWhenBindingTypeIsVersionTag() {
+      var template = generator.generate(ClassBasedConnectorWithLinkedResource.class).getFirst();
+      var versionTag = getPropertyById("formDefinition.versionTag", template);
+
+      assertThat(versionTag).isInstanceOf(StringProperty.class);
+      assertThat(versionTag.getLabel()).isEqualTo("Version tag");
+      assertThat(versionTag.getGroup()).isEqualTo("form");
+      assertThat(versionTag.getCondition())
+          .isEqualTo(new PropertyCondition.Equals("formDefinition.bindingType", "versionTag"));
+      assertThat(((ZeebeLinkedResource) versionTag.getBinding()).property())
+          .isEqualTo("versionTag");
     }
   }
 

--- a/element-template-generator/core/src/test/java/io/camunda/connector/generator/java/OutboundClassBasedTemplateGeneratorTest.java
+++ b/element-template-generator/core/src/test/java/io/camunda/connector/generator/java/OutboundClassBasedTemplateGeneratorTest.java
@@ -19,11 +19,15 @@ package io.camunda.connector.generator.java;
 import static io.camunda.connector.generator.java.util.TemplateGenerationStringUtil.camelCaseToSpaces;
 import static java.nio.file.Files.readAllBytes;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import io.camunda.connector.api.annotation.OutboundConnector;
+import io.camunda.connector.api.outbound.OutboundConnectorContext;
+import io.camunda.connector.api.outbound.OutboundConnectorFunction;
 import io.camunda.connector.generator.BaseTest;
 import io.camunda.connector.generator.api.GeneratorConfiguration;
 import io.camunda.connector.generator.api.GeneratorConfiguration.ConnectorElementType;
@@ -46,7 +50,9 @@ import io.camunda.connector.generator.dsl.PropertyConstraints.Pattern;
 import io.camunda.connector.generator.dsl.StringProperty;
 import io.camunda.connector.generator.dsl.TextProperty;
 import io.camunda.connector.generator.java.annotation.BpmnType;
+import io.camunda.connector.generator.java.annotation.ElementTemplate;
 import io.camunda.connector.generator.java.annotation.FeelMode;
+import io.camunda.connector.generator.java.annotation.TemplateLinkedResource;
 import io.camunda.connector.generator.java.example.outbound.ClassBasedConnectorWithLinkedResource;
 import io.camunda.connector.generator.java.example.outbound.MyConnectorFunction;
 import io.camunda.connector.generator.java.example.outbound.OperationAnnotatedConnector;
@@ -1352,6 +1358,28 @@ public class OutboundClassBasedTemplateGeneratorTest extends BaseTest {
       assertThat(((ZeebeLinkedResource) versionTag.getBinding()).property())
           .isEqualTo("versionTag");
     }
+
+    @Test
+    void blankLinkName_throwsIllegalArgumentException() {
+      assertThatThrownBy(() -> generator.generate(BlankLinkNameConnector.class))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("blank linkName");
+    }
+
+    @Test
+    void blankResourceType_throwsIllegalArgumentException() {
+      assertThatThrownBy(() -> generator.generate(BlankResourceTypeConnector.class))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("blank resourceType");
+    }
+
+    @Test
+    void duplicateLinkName_throwsIllegalArgumentException() {
+      assertThatThrownBy(() -> generator.generate(DuplicateLinkNameConnector.class))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("Duplicate")
+          .hasMessageContaining("form");
+    }
   }
 
   @Nested
@@ -1464,6 +1492,57 @@ public class OutboundClassBasedTemplateGeneratorTest extends BaseTest {
           .isEqualTo(new PropertyBinding.ZeebeTaskHeader("b"));
       assertThat(propertyAWithHeaderAndTemplateProperty.getLabel()).isEqualTo("a prop");
       assertThat(propertyBWithHeaderAndTemplateProperty.getLabel()).isEqualTo("b prop");
+    }
+  }
+
+  // Fixtures for linked-resource validation tests
+
+  @TemplateLinkedResource(linkName = "", resourceType = "form")
+  private record BlankLinkNameRequest() {}
+
+  @OutboundConnector(name = "Test", type = "test:blank-link")
+  @ElementTemplate(
+      id = "test-blank-link",
+      name = "Test",
+      version = 1,
+      inputDataClass = BlankLinkNameRequest.class)
+  private static class BlankLinkNameConnector implements OutboundConnectorFunction {
+    @Override
+    public Object execute(OutboundConnectorContext context) {
+      return null;
+    }
+  }
+
+  @TemplateLinkedResource(linkName = "myResource", resourceType = "")
+  private record BlankResourceTypeRequest() {}
+
+  @OutboundConnector(name = "Test", type = "test:blank-resource-type")
+  @ElementTemplate(
+      id = "test-blank-resource-type",
+      name = "Test",
+      version = 1,
+      inputDataClass = BlankResourceTypeRequest.class)
+  private static class BlankResourceTypeConnector implements OutboundConnectorFunction {
+    @Override
+    public Object execute(OutboundConnectorContext context) {
+      return null;
+    }
+  }
+
+  @TemplateLinkedResource(linkName = "form", resourceType = "form")
+  @TemplateLinkedResource(linkName = "form", resourceType = "form")
+  private record DuplicateLinkNameRequest() {}
+
+  @OutboundConnector(name = "Test", type = "test:duplicate-link")
+  @ElementTemplate(
+      id = "test-duplicate-link",
+      name = "Test",
+      version = 1,
+      inputDataClass = DuplicateLinkNameRequest.class)
+  private static class DuplicateLinkNameConnector implements OutboundConnectorFunction {
+    @Override
+    public Object execute(OutboundConnectorContext context) {
+      return null;
     }
   }
 }

--- a/element-template-generator/core/src/test/java/io/camunda/connector/generator/java/OutboundClassBasedTemplateGeneratorTest.java
+++ b/element-template-generator/core/src/test/java/io/camunda/connector/generator/java/OutboundClassBasedTemplateGeneratorTest.java
@@ -1176,6 +1176,74 @@ public class OutboundClassBasedTemplateGeneratorTest extends BaseTest {
     }
 
     @Test
+    void optionalLinkedResource_emitsFiveProperties_firstIsToggle() {
+      var template =
+          generator.generate(OperationAnnotatedConnectorWithLinkedResource.class).getFirst();
+      var op4Props =
+          template.properties().stream()
+              .filter(
+                  p ->
+                      p.getCondition() instanceof PropertyCondition.AllMatch am
+                          && am.allMatch()
+                              .contains(new PropertyCondition.Equals("operation", "op4")))
+              .toList();
+      // 1 regular Variable property (message) + 1 toggle + 4 linked resource = 6 total,
+      // but only the 5 (toggle + linked resource) have zeebe:taskHeader or zeebe:linkedResource
+      var toggle = getPropertyById("op4:formDefinition.include", template);
+      assertThat(toggle).isInstanceOf(DropdownProperty.class);
+      assertThat(toggle.getLabel()).isEqualTo("Include form?");
+      assertThat(toggle.getValue()).isEqualTo("false");
+      assertThat(toggle.getBinding().type()).isEqualTo("zeebe:taskHeader");
+      assertThat(((DropdownProperty) toggle).getChoices())
+          .containsExactly(
+              new DropdownProperty.DropdownChoice("No", "false"),
+              new DropdownProperty.DropdownChoice("Yes", "true"));
+    }
+
+    @Test
+    void optionalLinkedResource_linkedResourcePropertiesConditionedOnToggle() {
+      var template =
+          generator.generate(OperationAnnotatedConnectorWithLinkedResource.class).getFirst();
+      var toggleCondition = new PropertyCondition.Equals("op4:formDefinition.include", "true");
+
+      var resourceType =
+          template.properties().stream()
+              .filter(
+                  p ->
+                      p instanceof HiddenProperty
+                          && "zeebe:linkedResource".equals(p.getBinding().type())
+                          && "formDefinition"
+                              .equals(((ZeebeLinkedResource) p.getBinding()).linkName())
+                          && p.getCondition() instanceof PropertyCondition.AllMatch am
+                          && am.allMatch()
+                              .contains(new PropertyCondition.Equals("operation", "op4")))
+              .findFirst()
+              .orElseThrow();
+      assertThat(((PropertyCondition.AllMatch) resourceType.getCondition()).allMatch())
+          .contains(new PropertyCondition.Equals("operation", "op4"))
+          .contains(toggleCondition);
+
+      var resourceId = getPropertyById("op4:formDefinition.resourceId", template);
+      assertThat(((PropertyCondition.AllMatch) resourceId.getCondition()).allMatch())
+          .contains(new PropertyCondition.Equals("operation", "op4"))
+          .contains(toggleCondition);
+
+      var versionTag = getPropertyById("op4:formDefinition.versionTag", template);
+      assertThat(((PropertyCondition.AllMatch) versionTag.getCondition()).allMatch())
+          .contains(new PropertyCondition.Equals("operation", "op4"))
+          .contains(toggleCondition)
+          .contains(new PropertyCondition.Equals("op4:formDefinition.bindingType", "versionTag"));
+    }
+
+    @Test
+    void optionalLinkedResource_blankToggleLabel_defaultsToIncludeLinkName() {
+      var template =
+          generator.generate(OperationAnnotatedConnectorWithLinkedResource.class).getFirst();
+      var toggle = getPropertyById("op5:attachment.include", template);
+      assertThat(toggle.getLabel()).isEqualTo("Include attachment?");
+    }
+
+    @Test
     void multipleLinkedResources_correctLinkNamesAndResourceTypes() {
       var template =
           generator.generate(OperationAnnotatedConnectorWithLinkedResource.class).getFirst();

--- a/element-template-generator/core/src/test/java/io/camunda/connector/generator/java/example/outbound/ClassBasedConnectorWithLinkedResource.java
+++ b/element-template-generator/core/src/test/java/io/camunda/connector/generator/java/example/outbound/ClassBasedConnectorWithLinkedResource.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.generator.java.example.outbound;
+
+import io.camunda.connector.api.annotation.OutboundConnector;
+import io.camunda.connector.api.outbound.OutboundConnectorContext;
+import io.camunda.connector.api.outbound.OutboundConnectorFunction;
+import io.camunda.connector.generator.java.annotation.ElementTemplate;
+import io.camunda.connector.generator.java.annotation.TemplateLinkedResource;
+import io.camunda.connector.generator.java.annotation.TemplateProperty;
+
+@OutboundConnector(name = ClassBasedConnectorWithLinkedResource.NAME, type = "class-based-lr-type")
+@ElementTemplate(
+    id = ClassBasedConnectorWithLinkedResource.ID,
+    name = ClassBasedConnectorWithLinkedResource.NAME,
+    engineVersion = "^8.8",
+    inputDataClass = ClassBasedConnectorWithLinkedResource.Request.class,
+    propertyGroups = {@ElementTemplate.PropertyGroup(id = "form", label = "Form")})
+public class ClassBasedConnectorWithLinkedResource implements OutboundConnectorFunction {
+
+  public static final String ID = "class-based-lr-id";
+  public static final String NAME = "Class Based Connector With Linked Resource";
+
+  @TemplateLinkedResource(
+      linkName = "formDefinition",
+      resourceType = "form",
+      group = "form",
+      resourceIdLabel = "Form ID",
+      resourceIdDescription = "Select a form to render as an adaptive card",
+      bindingTypeLabel = "Form binding")
+  public record Request(@TemplateProperty(group = "form", label = "Message") String message) {}
+
+  @Override
+  public Object execute(OutboundConnectorContext context) {
+    return null;
+  }
+}

--- a/element-template-generator/core/src/test/java/io/camunda/connector/generator/java/example/outbound/OperationAnnotatedConnectorWithLinkedResource.java
+++ b/element-template-generator/core/src/test/java/io/camunda/connector/generator/java/example/outbound/OperationAnnotatedConnectorWithLinkedResource.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.generator.java.example.outbound;
+
+import io.camunda.connector.api.annotation.Operation;
+import io.camunda.connector.api.annotation.OutboundConnector;
+import io.camunda.connector.api.annotation.Variable;
+import io.camunda.connector.api.outbound.OutboundConnectorProvider;
+import io.camunda.connector.generator.java.annotation.ElementTemplate;
+import io.camunda.connector.generator.java.annotation.TemplateLinkedResource;
+import io.camunda.connector.generator.java.annotation.TemplateProperty;
+
+@OutboundConnector(
+    name = OperationAnnotatedConnectorWithLinkedResource.NAME,
+    type = OperationAnnotatedConnectorWithLinkedResource.TYPE)
+@ElementTemplate(
+    id = OperationAnnotatedConnectorWithLinkedResource.ID,
+    name = OperationAnnotatedConnectorWithLinkedResource.NAME,
+    engineVersion = "^8.8",
+    propertyGroups = {@ElementTemplate.PropertyGroup(id = "form", label = "Form")})
+public class OperationAnnotatedConnectorWithLinkedResource implements OutboundConnectorProvider {
+
+  public static final String ID = "op-annotated-with-linked-resource-id";
+  public static final String TYPE = "op-annotated-with-linked-resource-type";
+  public static final String NAME = "Operation Annotated Connector With Linked Resource";
+
+  @TemplateLinkedResource(
+      linkName = "formDefinition",
+      resourceType = "form",
+      group = "form",
+      resourceIdLabel = "Form ID",
+      resourceIdDescription = "Select a form to render as an adaptive card",
+      bindingTypeLabel = "Form binding")
+  record RequestWithLinkedResource(
+      @TemplateProperty(group = "form", label = "Message") String message) {}
+
+  @TemplateLinkedResource(
+      linkName = "attachmentA",
+      resourceType = "form",
+      group = "form",
+      resourceIdLabel = "Attachment A ID",
+      bindingTypeLabel = "Attachment A binding")
+  @TemplateLinkedResource(
+      linkName = "attachmentB",
+      resourceType = "file",
+      group = "form",
+      resourceIdLabel = "Attachment B ID",
+      bindingTypeLabel = "Attachment B binding")
+  record RequestWithMultipleLinkedResources(
+      @TemplateProperty(group = "form", label = "Subject") String subject) {}
+
+  @TemplateLinkedResource(linkName = "resource", resourceType = "form", group = "form")
+  record RequestWithDefaultLabels(
+      @TemplateProperty(group = "form", label = "Field") String field) {}
+
+  @Operation(id = "op1", name = "Operation 1")
+  public String op1(@Variable RequestWithLinkedResource request) {
+    return null;
+  }
+
+  @Operation(id = "op2", name = "Operation 2")
+  public String op2(@Variable RequestWithMultipleLinkedResources request) {
+    return null;
+  }
+
+  @Operation(id = "op3", name = "Operation 3")
+  public String op3(@Variable RequestWithDefaultLabels request) {
+    return null;
+  }
+}

--- a/element-template-generator/core/src/test/java/io/camunda/connector/generator/java/example/outbound/OperationAnnotatedConnectorWithLinkedResource.java
+++ b/element-template-generator/core/src/test/java/io/camunda/connector/generator/java/example/outbound/OperationAnnotatedConnectorWithLinkedResource.java
@@ -67,6 +67,25 @@ public class OperationAnnotatedConnectorWithLinkedResource implements OutboundCo
   record RequestWithDefaultLabels(
       @TemplateProperty(group = "form", label = "Field") String field) {}
 
+  @TemplateLinkedResource(
+      linkName = "formDefinition",
+      resourceType = "form",
+      group = "form",
+      optional = true,
+      toggleLabel = "Include form?",
+      resourceIdLabel = "Form ID",
+      bindingTypeLabel = "Form binding")
+  record RequestWithOptionalLinkedResource(
+      @TemplateProperty(group = "form", label = "Message") String message) {}
+
+  @TemplateLinkedResource(
+      linkName = "attachment",
+      resourceType = "form",
+      group = "form",
+      optional = true)
+  record RequestWithOptionalDefaultLabels(
+      @TemplateProperty(group = "form", label = "Field") String field) {}
+
   @Operation(id = "op1", name = "Operation 1")
   public String op1(@Variable RequestWithLinkedResource request) {
     return null;
@@ -79,6 +98,16 @@ public class OperationAnnotatedConnectorWithLinkedResource implements OutboundCo
 
   @Operation(id = "op3", name = "Operation 3")
   public String op3(@Variable RequestWithDefaultLabels request) {
+    return null;
+  }
+
+  @Operation(id = "op4", name = "Operation 4")
+  public String op4(@Variable RequestWithOptionalLinkedResource request) {
+    return null;
+  }
+
+  @Operation(id = "op5", name = "Operation 5")
+  public String op5(@Variable RequestWithOptionalDefaultLabels request) {
     return null;
   }
 }

--- a/element-template-generator/core/src/test/java/io/camunda/connector/generator/java/example/outbound/OperationAnnotatedConnectorWithLinkedResource.java
+++ b/element-template-generator/core/src/test/java/io/camunda/connector/generator/java/example/outbound/OperationAnnotatedConnectorWithLinkedResource.java
@@ -87,26 +87,31 @@ public class OperationAnnotatedConnectorWithLinkedResource implements OutboundCo
       @TemplateProperty(group = "form", label = "Field") String field) {}
 
   @Operation(id = "op1", name = "Operation 1")
+  @SuppressWarnings("unused")
   public String op1(@Variable RequestWithLinkedResource request) {
     return null;
   }
 
   @Operation(id = "op2", name = "Operation 2")
+  @SuppressWarnings("unused")
   public String op2(@Variable RequestWithMultipleLinkedResources request) {
     return null;
   }
 
   @Operation(id = "op3", name = "Operation 3")
+  @SuppressWarnings("unused")
   public String op3(@Variable RequestWithDefaultLabels request) {
     return null;
   }
 
   @Operation(id = "op4", name = "Operation 4")
+  @SuppressWarnings("unused")
   public String op4(@Variable RequestWithOptionalLinkedResource request) {
     return null;
   }
 
   @Operation(id = "op5", name = "Operation 5")
+  @SuppressWarnings("unused")
   public String op5(@Variable RequestWithOptionalDefaultLabels request) {
     return null;
   }


### PR DESCRIPTION
## Description

  Adds @TemplateLinkedResource annotation support to the element template generator, enabling connectors to declare zeebe:linkedResource blocks declaratively.
  
   - New @TemplateLinkedResource annotation (repeatable via @TemplateLinkedResources) placed on a connector request class. The generator emits four properties per linked resource: a hidden resourceType marker, 
  a bindingType dropdown (Latest / Deployment / Version tag), a resourceId string field, and a conditional versionTag field shown only when bindingType is "versionTag".
  - optional = true mode: prepends a Yes/No toggle (zeebe:taskHeader). All linked-resource properties are conditioned on the toggle, so when left at the default "No" no zeebe:linkedResource block is written to
   the BPMN — avoiding Zeebe's deploy-time validation error when no resource is linked.                                                                                                                          
  - Support for both operation-based connectors (OutboundConnectorProvider with @Operation-annotated methods) and class-based connectors (OutboundConnectorFunction). Inbound connectors are explicitly excluded
  (zeebe:linkedResource is a service-task extension).                                                                                                                                                            
  - ZeebeLinkedResource binding added to PropertyBinding.
  - feel is disabled on versionTag 

## Related issues

closes #7048 

## Checklist

- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest
  release, as this branch will be rebased onto main before the next release. Example backport labels:
    - `backport stable/8.8`: for changes that should be included in the next 8.8.x release.
    - **or** `backport release-8.8.7`: for changes that should be included in the specific release 8.8.7, and this
      *release has already been created*. The release branch will be merged back into stable/8.8 later, so the change
      will be included in future 8.8.x releases as well.
- [ ] Tests/Integration tests for the changes have been added if applicable.
- [ ] If the change requires a documentation update, it has been added to the appropriate section in the documentation.


