### PR TITLE
fix(agentic-ai): Fix socket and connection timeout config on LLM clients being too short on default settings

### DIFF
--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/langchain4j/outboundconnector/L4JAiAgentConnectorHttpTimeoutTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/langchain4j/outboundconnector/L4JAiAgentConnectorHttpTimeoutTests.java
@@ -36,6 +36,7 @@ import io.camunda.process.test.api.CamundaAssert;
 import java.time.Duration;
 import java.util.Map;
 import java.util.function.Function;
+import java.util.regex.Pattern;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -180,7 +181,9 @@ public class L4JAiAgentConnectorHttpTimeoutTests extends BaseAiAgentConnectorTes
           zeebeTest,
           incident -> {
             assertThat(incident.getElementId()).isEqualTo(AI_AGENT_TASK_ID);
-            assertThat(incident.getErrorMessage()).isNotBlank();
+            assertThat(incident.getErrorMessage())
+                .containsPattern(Pattern.compile("timed out|timeout"));
+            assertThat(incident.getErrorMessage()).contains("FAILED_MODEL_CALL");
           });
       assertThat(userFeedbackJobWorkerCounter.get())
           .as("user feedback must not be reached on a timeout failure")

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/langchain4j/outboundconnector/L4JAiAgentConnectorHttpTimeoutTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/langchain4j/outboundconnector/L4JAiAgentConnectorHttpTimeoutTests.java
@@ -1,0 +1,315 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.e2e.agenticai.aiagent.langchain4j.outboundconnector;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static io.camunda.connector.e2e.agenticai.aiagent.AiAgentTestFixtures.AI_AGENT_TASK_ID;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import io.camunda.connector.e2e.ElementTemplate;
+import io.camunda.connector.e2e.ZeebeTest;
+import io.camunda.connector.e2e.agenticai.aiagent.BaseAiAgentConnectorTest;
+import io.camunda.connector.e2e.agenticai.assertj.AgentResponseAssert;
+import io.camunda.connector.test.utils.annotation.SlowTest;
+import io.camunda.process.test.api.CamundaAssert;
+import java.time.Duration;
+import java.util.Map;
+import java.util.function.Function;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * E2E coverage for HTTP transport timeouts on all chat model providers that we configure HTTP
+ * clients for. For each provider we run two scenarios:
+ *
+ * <ul>
+ *   <li><b>Positive</b>: WireMock responds within the configured socket timeout — the process
+ *       completes and the agent variable contains the simulated assistant message.
+ *   <li><b>Negative</b>: WireMock delays beyond the configured socket timeout — the connector fails
+ *       fast and Zeebe raises an incident on the AI agent task.
+ * </ul>
+ *
+ * <p>Providers tested:
+ *
+ * <ul>
+ *   <li>Anthropic: exercises the JDK HTTP client path (read timeout).
+ *   <li>OpenAI-compatible: same JDK HTTP client path with a different endpoint shape.
+ *   <li>Bedrock: exercises the Apache HTTP client path (socket timeout) used by the AWS SDK.
+ * </ul>
+ *
+ * <p>Providers that are currently untested:
+ *
+ * <ul>
+ *   <li>OpenAI: There is currently no option to override the OpenAI default API URL
+ *   <li>Azure OpenAI: Due to current implementation we are unable to call HTTP urls using native
+ *       Azure SDK during Authorization Header generation.
+ * </ul>
+ *
+ * <p>Regression test for <a href="https://github.com/camunda/connectors/issues/7193">issue
+ * #7193</a>: before the fix, transport-level defaults (Apache 30s socket timeout) would fire
+ * regardless of the connector-level timeout configuration.
+ */
+@SlowTest
+@WireMockTest
+public class L4JAiAgentConnectorHttpTimeoutTests extends BaseAiAgentConnectorTest {
+
+  private static final String AGENT_RESPONSE_TEXT = "Endless waves whisper.";
+
+  /**
+   * WireMock response delay used in positive cases: must be shorter than {@link #MODEL_TIMEOUT}.
+   */
+  private static final Duration RESPONSE_DELAY_BELOW_TIMEOUT = Duration.ofSeconds(3);
+
+  /** WireMock response delay used in negative cases: must be longer than {@link #MODEL_TIMEOUT}. */
+  private static final Duration RESPONSE_DELAY_ABOVE_TIMEOUT = Duration.ofSeconds(8);
+
+  /** Connector-level model call timeout: short enough to keep negative cases under ~10s. */
+  private static final Duration MODEL_TIMEOUT = Duration.ofSeconds(6);
+
+  private WireMockRuntimeInfo wm;
+
+  @BeforeEach
+  void setupCamundaAssertTimeout() {
+    CamundaAssert.setAssertionTimeout(Duration.ofSeconds(30));
+  }
+
+  @BeforeEach
+  void captureWireMockInfo(WireMockRuntimeInfo wm) {
+    this.wm = wm;
+  }
+
+  @Nested
+  class AnthropicTests {
+
+    @Test
+    void processCompletesWhenResponseArrivesWithinSocketTimeout() {
+      stubAnthropic(RESPONSE_DELAY_BELOW_TIMEOUT);
+      runPositiveCase(anthropicProvider());
+    }
+
+    @Test
+    void raisesIncidentWhenResponseExceedsSocketTimeout() {
+      stubAnthropic(RESPONSE_DELAY_ABOVE_TIMEOUT);
+      runNegativeCase(anthropicProvider());
+    }
+  }
+
+  @Nested
+  class OpenAiCompatibleTests {
+
+    @Test
+    void processCompletesWhenResponseArrivesWithinSocketTimeout() {
+      stubOpenAiCompatible(RESPONSE_DELAY_BELOW_TIMEOUT);
+      runPositiveCase(openAiCompatibleProvider());
+    }
+
+    @Test
+    void raisesIncidentWhenResponseExceedsSocketTimeout() {
+      stubOpenAiCompatible(RESPONSE_DELAY_ABOVE_TIMEOUT);
+      runNegativeCase(openAiCompatibleProvider());
+    }
+  }
+
+  @Nested
+  class BedrockTest {
+
+    @Test
+    void processCompletesWhenResponseArrivesWithinSocketTimeout() {
+      stubBedrock(RESPONSE_DELAY_BELOW_TIMEOUT);
+      runPositiveCase(bedrockProvider());
+    }
+
+    @Test
+    void raisesIncidentWhenResponseExceedsSocketTimeout() {
+      stubBedrock(RESPONSE_DELAY_ABOVE_TIMEOUT);
+      runNegativeCase(bedrockProvider());
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Test runners
+  // ---------------------------------------------------------------------------
+
+  private void runPositiveCase(Function<ElementTemplate, ElementTemplate> providerConfig) {
+    try {
+      userFeedbackVariables.set(userSatisfiedFeedback());
+
+      final ZeebeTest zeebeTest =
+          createProcessInstance(providerConfig, Map.of("userPrompt", "Write a haiku about the sea"))
+              .waitForProcessCompletion();
+
+      assertAgentResponse(
+          zeebeTest,
+          agentResponse ->
+              AgentResponseAssert.assertThat(agentResponse).hasResponseText(AGENT_RESPONSE_TEXT));
+      assertThat(userFeedbackJobWorkerCounter.get()).isEqualTo(1);
+    } catch (Exception exception) {
+      fail(exception);
+    }
+  }
+
+  private void runNegativeCase(Function<ElementTemplate, ElementTemplate> providerConfig) {
+    try {
+      final ZeebeTest zeebeTest =
+          createProcessInstance(providerConfig, Map.of("userPrompt", "Write a haiku about the sea"))
+              .waitForActiveIncidents();
+
+      assertIncident(
+          zeebeTest,
+          incident -> {
+            assertThat(incident.getElementId()).isEqualTo(AI_AGENT_TASK_ID);
+            assertThat(incident.getErrorMessage()).isNotBlank();
+          });
+      assertThat(userFeedbackJobWorkerCounter.get())
+          .as("user feedback must not be reached on a timeout failure")
+          .isZero();
+    } catch (Exception exception) {
+      fail(exception);
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Provider element template configurations
+  // ---------------------------------------------------------------------------
+
+  private Function<ElementTemplate, ElementTemplate> anthropicProvider() {
+    return template ->
+        template
+            .property("retryCount", "1")
+            .property("provider.type", "anthropic")
+            .property("provider.anthropic.endpoint", wm.getHttpBaseUrl() + "/v1")
+            .property("provider.anthropic.authentication.apiKey", "dummy")
+            .property("provider.anthropic.model.model", "claude-3-5-sonnet")
+            .property("provider.anthropic.timeouts.timeout", MODEL_TIMEOUT.toString());
+  }
+
+  private Function<ElementTemplate, ElementTemplate> openAiCompatibleProvider() {
+    return template ->
+        template
+            .property("retryCount", "1")
+            .property("provider.type", "openaiCompatible")
+            .property("provider.openaiCompatible.endpoint", wm.getHttpBaseUrl() + "/v1")
+            .property("provider.openaiCompatible.authentication.apiKey", "dummy")
+            .property("provider.openaiCompatible.model.model", "test-model")
+            .property("provider.openaiCompatible.timeouts.timeout", MODEL_TIMEOUT.toString());
+  }
+
+  private Function<ElementTemplate, ElementTemplate> bedrockProvider() {
+    return template ->
+        template
+            .property("retryCount", "1")
+            .property("provider.type", "bedrock")
+            .property("provider.bedrock.region", "us-east-1")
+            .property("provider.bedrock.endpoint", wm.getHttpBaseUrl())
+            .property("provider.bedrock.authentication.type", "credentials")
+            .property("provider.bedrock.authentication.accessKey", "dummy")
+            .property("provider.bedrock.authentication.secretKey", "dummy")
+            .property("provider.bedrock.model.model", "anthropic.claude-3-haiku-20240307-v1:0")
+            .property("provider.bedrock.timeouts.timeout", MODEL_TIMEOUT.toString());
+  }
+
+  // ---------------------------------------------------------------------------
+  // WireMock stubs: return provider-shaped responses with the requested delay
+  // ---------------------------------------------------------------------------
+
+  private void stubAnthropic(Duration delay) {
+    stubFor(
+        post(urlPathEqualTo("/v1/messages"))
+            .willReturn(
+                aResponse()
+                    .withStatus(200)
+                    .withHeader("Content-Type", "application/json")
+                    .withFixedDelay((int) delay.toMillis())
+                    .withBody(
+                        """
+                        {
+                          "id": "msg_test",
+                          "type": "message",
+                          "role": "assistant",
+                          "content": [{"type": "text", "text": "%s"}],
+                          "model": "claude-3-5-sonnet",
+                          "stop_reason": "end_turn",
+                          "stop_sequence": null,
+                          "usage": {"input_tokens": 10, "output_tokens": 20}
+                        }
+                        """
+                            .formatted(AGENT_RESPONSE_TEXT))));
+  }
+
+  private void stubOpenAiCompatible(Duration delay) {
+    stubFor(
+        post(urlPathEqualTo("/v1/chat/completions"))
+            .willReturn(
+                aResponse()
+                    .withStatus(200)
+                    .withHeader("Content-Type", "application/json")
+                    .withFixedDelay((int) delay.toMillis())
+                    .withBody(
+                        """
+                        {
+                          "id": "chatcmpl-test",
+                          "object": "chat.completion",
+                          "created": 1700000000,
+                          "model": "test-model",
+                          "choices": [
+                            {
+                              "index": 0,
+                              "message": {"role": "assistant", "content": "%s"},
+                              "finish_reason": "stop"
+                            }
+                          ],
+                          "usage": {"prompt_tokens": 10, "completion_tokens": 20, "total_tokens": 30}
+                        }
+                        """
+                            .formatted(AGENT_RESPONSE_TEXT))));
+  }
+
+  private void stubBedrock(Duration delay) {
+    // Bedrock Converse: POST /model/{modelId}/converse - the SDK URL-encodes the model id, so we
+    // match any model path here for simplicity
+    stubFor(
+        post(urlMatching("/model/.+/converse"))
+            .willReturn(
+                aResponse()
+                    .withStatus(200)
+                    .withHeader("Content-Type", "application/json")
+                    .withFixedDelay((int) delay.toMillis())
+                    .withBody(
+                        """
+                        {
+                          "metrics": {"latencyMs": 100},
+                          "output": {
+                            "message": {
+                              "role": "assistant",
+                              "content": [{"text": "%s"}]
+                            }
+                          },
+                          "stopReason": "end_turn",
+                          "usage": {"inputTokens": 10, "outputTokens": 20, "totalTokens": 30}
+                        }
+                        """
+                            .formatted(AGENT_RESPONSE_TEXT))));
+  }
+}

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/ChatModelHttpProxySupport.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/ChatModelHttpProxySupport.java
@@ -18,7 +18,6 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import software.amazon.awssdk.http.SdkHttpClient;
 import software.amazon.awssdk.http.apache.ApacheHttpClient;
 
 public class ChatModelHttpProxySupport {
@@ -40,12 +39,10 @@ public class ChatModelHttpProxySupport {
     return new JdkHttpClientBuilder().httpClientBuilder(httpClientBuilder);
   }
 
-  public SdkHttpClient createAwsHttpClient(URI endpointOverride) {
+  public ApacheHttpClient.Builder createAwsHttpClientBuilder(URI endpointOverride) {
     String schemeName =
         endpointOverride != null ? endpointOverride.getScheme() : ProxyConfiguration.SCHEME_HTTPS;
-    return ApacheHttpClient.builder()
-        .proxyConfiguration(createAwsProxyConfiguration(schemeName))
-        .build();
+    return ApacheHttpClient.builder().proxyConfiguration(createAwsProxyConfiguration(schemeName));
   }
 
   software.amazon.awssdk.http.apache.ProxyConfiguration createAwsProxyConfiguration(

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/provider/AnthropicChatModelProvider.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/provider/AnthropicChatModelProvider.java
@@ -6,6 +6,7 @@
  */
 package io.camunda.connector.agenticai.aiagent.framework.langchain4j.provider;
 
+import static io.camunda.connector.agenticai.aiagent.framework.langchain4j.provider.ChatModelProviderSupport.CONNECT_TIMEOUT;
 import static io.camunda.connector.agenticai.aiagent.framework.langchain4j.provider.ChatModelProviderSupport.deriveTimeoutSetting;
 
 import dev.langchain4j.model.anthropic.AnthropicChatModel;
@@ -39,14 +40,19 @@ public class AnthropicChatModelProvider
   @Override
   public ChatModel createChatModel(AnthropicProviderConfiguration anthropic) {
     final var connection = anthropic.anthropic();
+    final var apiTimeout =
+        deriveTimeoutSetting("Anthropic model call", config, connection.timeouts(), LOGGER);
 
     final var builder =
         AnthropicChatModel.builder()
             .apiKey(connection.authentication().apiKey())
             .modelName(connection.model().model())
-            .timeout(
-                deriveTimeoutSetting("Anthropic model call", config, connection.timeouts(), LOGGER))
-            .httpClientBuilder(proxySupport.createJdkHttpClientBuilder());
+            .timeout(apiTimeout)
+            .httpClientBuilder(
+                proxySupport
+                    .createJdkHttpClientBuilder()
+                    .connectTimeout(CONNECT_TIMEOUT)
+                    .readTimeout(apiTimeout));
 
     Optional.ofNullable(connection.endpoint()).ifPresent(builder::baseUrl);
 

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/provider/BedrockChatModelProvider.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/provider/BedrockChatModelProvider.java
@@ -6,6 +6,7 @@
  */
 package io.camunda.connector.agenticai.aiagent.framework.langchain4j.provider;
 
+import static io.camunda.connector.agenticai.aiagent.framework.langchain4j.provider.ChatModelProviderSupport.CONNECT_TIMEOUT;
 import static io.camunda.connector.agenticai.aiagent.framework.langchain4j.provider.ChatModelProviderSupport.deriveTimeoutSetting;
 
 import dev.langchain4j.model.bedrock.BedrockChatModel;
@@ -15,6 +16,7 @@ import io.camunda.connector.agenticai.aiagent.framework.langchain4j.ChatModelHtt
 import io.camunda.connector.agenticai.aiagent.model.request.provider.BedrockProviderConfiguration;
 import io.camunda.connector.agenticai.autoconfigure.AgenticAiConnectorsConfigurationProperties.ChatModelProperties;
 import java.net.URI;
+import java.time.Duration;
 import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -44,13 +46,14 @@ public class BedrockChatModelProvider implements ChatModelProvider<BedrockProvid
   @Override
   public ChatModel createChatModel(BedrockProviderConfiguration bedrock) {
     final var connection = bedrock.bedrock();
+    final var apiTimeout =
+        deriveTimeoutSetting("Bedrock model call", config, connection.timeouts(), LOGGER);
 
     final var builder =
         BedrockChatModel.builder()
-            .client(createBedrockClient(connection))
+            .client(createBedrockClient(connection, apiTimeout))
             .modelId(connection.model().model())
-            .timeout(
-                deriveTimeoutSetting("Bedrock model call", config, connection.timeouts(), LOGGER));
+            .timeout(apiTimeout);
 
     applyBedrockModelParametersIfPresent(connection, builder);
 
@@ -58,7 +61,7 @@ public class BedrockChatModelProvider implements ChatModelProvider<BedrockProvid
   }
 
   private BedrockRuntimeClient createBedrockClient(
-      BedrockProviderConfiguration.BedrockConnection connection) {
+      BedrockProviderConfiguration.BedrockConnection connection, Duration apiTimeout) {
     var bedrockClientBuilder =
         BedrockRuntimeClient.builder().region(Region.of(connection.region()));
     var overrideClientConfigurationBuilder = ClientOverrideConfiguration.builder();
@@ -73,10 +76,19 @@ public class BedrockChatModelProvider implements ChatModelProvider<BedrockProvid
       bedrockClientBuilder.endpointOverride(endpointOverride);
     }
 
-    overrideClientConfigurationBuilder.apiCallTimeout(
-        deriveTimeoutSetting("Bedrock API call", config, connection.timeouts(), LOGGER));
+    overrideClientConfigurationBuilder.apiCallTimeout(apiTimeout);
 
-    SdkHttpClient httpClient = proxySupport.createAwsHttpClient(endpointOverride);
+    // Align the underlying Apache HTTP socket timeout with the high-level API call timeout so
+    // long-running LLM responses (e.g. Claude Sonnet > 30s) are not killed by the Apache default
+    // socket timeout of 30 seconds. The TCP connect timeout is kept at a small constant since it
+    // covers infrastructure availability (DNS / firewall / proxy), not model latency. See issue
+    // #7193.
+    SdkHttpClient httpClient =
+        proxySupport
+            .createAwsHttpClientBuilder(endpointOverride)
+            .connectionTimeout(CONNECT_TIMEOUT)
+            .socketTimeout(apiTimeout)
+            .build();
     bedrockClientBuilder.httpClient(httpClient);
 
     bedrockClientBuilder.overrideConfiguration(overrideClientConfigurationBuilder.build());

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/provider/ChatModelProviderSupport.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/provider/ChatModelProviderSupport.java
@@ -14,6 +14,14 @@ import org.slf4j.Logger;
 
 public final class ChatModelProviderSupport {
 
+  /**
+   * TCP connect timeout applied to every chat model HTTP client. Kept short and constant — a
+   * healthy public LLM endpoint accepts connections in well under a second, and anything in the
+   * "seconds" range indicates DNS/firewall/proxy misconfiguration rather than model latency.
+   * Matches the LangChain4j JDK client default so behavior stays consistent across providers.
+   */
+  public static final Duration CONNECT_TIMEOUT = Duration.ofSeconds(15);
+
   private ChatModelProviderSupport() {}
 
   public static Duration deriveTimeoutSetting(

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/provider/OpenAiChatModelProvider.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/provider/OpenAiChatModelProvider.java
@@ -6,6 +6,7 @@
  */
 package io.camunda.connector.agenticai.aiagent.framework.langchain4j.provider;
 
+import static io.camunda.connector.agenticai.aiagent.framework.langchain4j.provider.ChatModelProviderSupport.CONNECT_TIMEOUT;
 import static io.camunda.connector.agenticai.aiagent.framework.langchain4j.provider.ChatModelProviderSupport.deriveTimeoutSetting;
 
 import dev.langchain4j.model.chat.ChatModel;
@@ -39,14 +40,19 @@ public class OpenAiChatModelProvider implements ChatModelProvider<OpenAiProvider
   @Override
   public ChatModel createChatModel(OpenAiProviderConfiguration openai) {
     final var connection = openai.openai();
+    final var apiTimeout =
+        deriveTimeoutSetting("OpenAI model call", config, connection.timeouts(), LOGGER);
 
     final var builder =
         OpenAiChatModel.builder()
             .apiKey(connection.authentication().apiKey())
             .modelName(connection.model().model())
-            .timeout(
-                deriveTimeoutSetting("OpenAI model call", config, connection.timeouts(), LOGGER))
-            .httpClientBuilder(proxySupport.createJdkHttpClientBuilder());
+            .timeout(apiTimeout)
+            .httpClientBuilder(
+                proxySupport
+                    .createJdkHttpClientBuilder()
+                    .connectTimeout(CONNECT_TIMEOUT)
+                    .readTimeout(apiTimeout));
 
     Optional.ofNullable(connection.authentication().organizationId())
         .ifPresent(builder::organizationId);

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/provider/OpenAiCompatibleChatModelProvider.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/provider/OpenAiCompatibleChatModelProvider.java
@@ -6,6 +6,7 @@
  */
 package io.camunda.connector.agenticai.aiagent.framework.langchain4j.provider;
 
+import static io.camunda.connector.agenticai.aiagent.framework.langchain4j.provider.ChatModelProviderSupport.CONNECT_TIMEOUT;
 import static io.camunda.connector.agenticai.aiagent.framework.langchain4j.provider.ChatModelProviderSupport.deriveTimeoutSetting;
 
 import dev.langchain4j.model.chat.ChatModel;
@@ -43,15 +44,19 @@ public class OpenAiCompatibleChatModelProvider
   @Override
   public ChatModel createChatModel(OpenAiCompatibleProviderConfiguration openaiCompatible) {
     final var connection = openaiCompatible.openaiCompatible();
+    final var apiTimeout =
+        deriveTimeoutSetting("OpenAI compatible model call", config, connection.timeouts(), LOGGER);
 
     final var builder =
         OpenAiChatModel.builder()
             .modelName(connection.model().model())
             .baseUrl(connection.endpoint())
-            .timeout(
-                deriveTimeoutSetting(
-                    "OpenAI compatible model call", config, connection.timeouts(), LOGGER))
-            .httpClientBuilder(proxySupport.createJdkHttpClientBuilder());
+            .timeout(apiTimeout)
+            .httpClientBuilder(
+                proxySupport
+                    .createJdkHttpClientBuilder()
+                    .connectTimeout(CONNECT_TIMEOUT)
+                    .readTimeout(apiTimeout));
 
     Optional.ofNullable(connection.authentication())
         .map(OpenAiCompatibleAuthentication::apiKey)

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/memory/conversation/awsagentcore/DefaultBedrockAgentCoreClientFactory.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/memory/conversation/awsagentcore/DefaultBedrockAgentCoreClientFactory.java
@@ -49,7 +49,7 @@ public class DefaultBedrockAgentCoreClientFactory implements BedrockAgentCoreCli
     }
 
     // apply HTTP proxy configuration (same as Bedrock LLM client)
-    builder.httpClient(proxySupport.createAwsHttpClient(endpointOverride));
+    builder.httpClient(proxySupport.createAwsHttpClientBuilder(endpointOverride).build());
 
     return builder.build();
   }

--- a/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/ChatModelHttpProxySupportTest.java
+++ b/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/ChatModelHttpProxySupportTest.java
@@ -13,6 +13,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.notNull;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -24,6 +25,7 @@ import io.camunda.connector.http.client.proxy.ProxyConfiguration;
 import io.camunda.connector.http.client.proxy.ProxyConfiguration.ProxyDetails;
 import java.net.URI;
 import java.net.http.HttpClient;
+import java.time.Duration;
 import java.util.Optional;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
@@ -35,7 +37,6 @@ import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
-import software.amazon.awssdk.http.SdkHttpClient;
 import software.amazon.awssdk.http.apache.ApacheHttpClient;
 
 @ExtendWith(MockitoExtension.class)
@@ -53,6 +54,9 @@ class ChatModelHttpProxySupportTest {
   private static final String NON_PROXY_HOST_LOCALHOST_REGEX = "localhost.*";
   private static final String NON_PROXY_HOST_127 = "127\\.0\\.0\\.1";
   private static final String NON_PROXY_HOST_INTERNAL = "*.internal.com";
+
+  private static final Duration CONNECT_TIMEOUT = Duration.ofSeconds(20);
+  private static final Duration READ_TIMEOUT = Duration.ofMinutes(3);
 
   @Mock private ProxyConfiguration proxyConfiguration;
   @Mock private JdkHttpClientProxyConfigurator jdkProxyConfigurator;
@@ -76,29 +80,52 @@ class ChatModelHttpProxySupportTest {
       assertThat(result).isNotNull();
       verify(jdkProxyConfigurator).configure(any(HttpClient.Builder.class));
     }
+
+    @Test
+    void shouldNotApplyTimeoutsByDefault() {
+      // when
+      JdkHttpClientBuilder result = proxySupport.createJdkHttpClientBuilder();
+
+      // then — timeouts are the caller's (chat model provider) responsibility
+      assertThat(result.connectTimeout()).isNull();
+      assertThat(result.readTimeout()).isNull();
+    }
+
+    @Test
+    void shouldAcceptTimeoutsConfiguredByCaller() {
+      // when — caller (e.g. a chat model provider) applies timeouts to the returned builder
+      JdkHttpClientBuilder result =
+          proxySupport
+              .createJdkHttpClientBuilder()
+              .connectTimeout(CONNECT_TIMEOUT)
+              .readTimeout(READ_TIMEOUT);
+
+      // then
+      assertThat(result.connectTimeout()).isEqualTo(CONNECT_TIMEOUT);
+      assertThat(result.readTimeout()).isEqualTo(READ_TIMEOUT);
+    }
   }
 
   @Nested
-  class CreateAwsHttpClient {
+  class CreateAwsHttpClientBuilder {
 
     @Test
-    void shouldCreateAwsHttpClientWithHttpsEndpoint() {
+    void shouldConfigureProxyForHttpsEndpoint() {
       // given
       when(proxyConfiguration.getProxyDetails(SCHEME_HTTPS)).thenReturn(Optional.empty());
 
       ApacheHttpClient.Builder httpClientBuilder =
           Mockito.mock(ApacheHttpClient.Builder.class, Answers.RETURNS_SELF);
-      when(httpClientBuilder.build()).thenReturn(Mockito.mock(SdkHttpClient.class));
 
       try (MockedStatic<ApacheHttpClient> apacheMock = mockStatic(ApacheHttpClient.class)) {
         apacheMock.when(ApacheHttpClient::builder).thenReturn(httpClientBuilder);
 
         // when
-        SdkHttpClient result =
-            proxySupport.createAwsHttpClient(URI.create("https://bedrock.amazonaws.com"));
+        ApacheHttpClient.Builder result =
+            proxySupport.createAwsHttpClientBuilder(URI.create("https://bedrock.amazonaws.com"));
 
         // then
-        assertThat(result).isNotNull();
+        assertThat(result).isSameAs(httpClientBuilder);
         verify(proxyConfiguration).getProxyDetails(SCHEME_HTTPS);
         verify(httpClientBuilder)
             .proxyConfiguration(
@@ -107,44 +134,59 @@ class ChatModelHttpProxySupportTest {
     }
 
     @Test
-    void shouldCreateAwsHttpClientWithHttpEndpoint() {
+    void shouldConfigureProxyForHttpEndpoint() {
       // given
       when(proxyConfiguration.getProxyDetails(SCHEME_HTTP)).thenReturn(Optional.empty());
 
       ApacheHttpClient.Builder httpClientBuilder =
           Mockito.mock(ApacheHttpClient.Builder.class, Answers.RETURNS_SELF);
-      when(httpClientBuilder.build()).thenReturn(Mockito.mock(SdkHttpClient.class));
 
       try (MockedStatic<ApacheHttpClient> apacheMock = mockStatic(ApacheHttpClient.class)) {
         apacheMock.when(ApacheHttpClient::builder).thenReturn(httpClientBuilder);
 
         // when
-        SdkHttpClient result =
-            proxySupport.createAwsHttpClient(URI.create("http://localhost:8080"));
+        proxySupport.createAwsHttpClientBuilder(URI.create("http://localhost:8080"));
 
         // then
-        assertThat(result).isNotNull();
         verify(proxyConfiguration).getProxyDetails(SCHEME_HTTP);
       }
     }
 
     @Test
-    void shouldCreateAwsHttpClientWithNullEndpointDefaultingToHttps() {
+    void shouldNotApplyTimeoutsToTheBuilder() {
       // given
       when(proxyConfiguration.getProxyDetails(SCHEME_HTTPS)).thenReturn(Optional.empty());
 
       ApacheHttpClient.Builder httpClientBuilder =
           Mockito.mock(ApacheHttpClient.Builder.class, Answers.RETURNS_SELF);
-      when(httpClientBuilder.build()).thenReturn(Mockito.mock(SdkHttpClient.class));
 
       try (MockedStatic<ApacheHttpClient> apacheMock = mockStatic(ApacheHttpClient.class)) {
         apacheMock.when(ApacheHttpClient::builder).thenReturn(httpClientBuilder);
 
         // when
-        SdkHttpClient result = proxySupport.createAwsHttpClient(null);
+        proxySupport.createAwsHttpClientBuilder(URI.create("https://bedrock.amazonaws.com"));
+
+        // then — timeouts are the caller's (chat model provider) responsibility
+        verify(httpClientBuilder, never()).connectionTimeout(any());
+        verify(httpClientBuilder, never()).socketTimeout(any());
+      }
+    }
+
+    @Test
+    void shouldDefaultToHttpsSchemeWhenEndpointIsNull() {
+      // given
+      when(proxyConfiguration.getProxyDetails(SCHEME_HTTPS)).thenReturn(Optional.empty());
+
+      ApacheHttpClient.Builder httpClientBuilder =
+          Mockito.mock(ApacheHttpClient.Builder.class, Answers.RETURNS_SELF);
+
+      try (MockedStatic<ApacheHttpClient> apacheMock = mockStatic(ApacheHttpClient.class)) {
+        apacheMock.when(ApacheHttpClient::builder).thenReturn(httpClientBuilder);
+
+        // when
+        proxySupport.createAwsHttpClientBuilder(null);
 
         // then
-        assertThat(result).isNotNull();
         verify(proxyConfiguration).getProxyDetails(SCHEME_HTTPS);
       }
     }

--- a/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/ChatModelHttpProxySupportTest.java
+++ b/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/ChatModelHttpProxySupportTest.java
@@ -13,7 +13,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.notNull;
 import static org.mockito.Mockito.mockStatic;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -25,7 +24,6 @@ import io.camunda.connector.http.client.proxy.ProxyConfiguration;
 import io.camunda.connector.http.client.proxy.ProxyConfiguration.ProxyDetails;
 import java.net.URI;
 import java.net.http.HttpClient;
-import java.time.Duration;
 import java.util.Optional;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
@@ -55,9 +53,6 @@ class ChatModelHttpProxySupportTest {
   private static final String NON_PROXY_HOST_127 = "127\\.0\\.0\\.1";
   private static final String NON_PROXY_HOST_INTERNAL = "*.internal.com";
 
-  private static final Duration CONNECT_TIMEOUT = Duration.ofSeconds(20);
-  private static final Duration READ_TIMEOUT = Duration.ofMinutes(3);
-
   @Mock private ProxyConfiguration proxyConfiguration;
   @Mock private JdkHttpClientProxyConfigurator jdkProxyConfigurator;
 
@@ -79,30 +74,6 @@ class ChatModelHttpProxySupportTest {
       // then
       assertThat(result).isNotNull();
       verify(jdkProxyConfigurator).configure(any(HttpClient.Builder.class));
-    }
-
-    @Test
-    void shouldNotApplyTimeoutsByDefault() {
-      // when
-      JdkHttpClientBuilder result = proxySupport.createJdkHttpClientBuilder();
-
-      // then — timeouts are the caller's (chat model provider) responsibility
-      assertThat(result.connectTimeout()).isNull();
-      assertThat(result.readTimeout()).isNull();
-    }
-
-    @Test
-    void shouldAcceptTimeoutsConfiguredByCaller() {
-      // when — caller (e.g. a chat model provider) applies timeouts to the returned builder
-      JdkHttpClientBuilder result =
-          proxySupport
-              .createJdkHttpClientBuilder()
-              .connectTimeout(CONNECT_TIMEOUT)
-              .readTimeout(READ_TIMEOUT);
-
-      // then
-      assertThat(result.connectTimeout()).isEqualTo(CONNECT_TIMEOUT);
-      assertThat(result.readTimeout()).isEqualTo(READ_TIMEOUT);
     }
   }
 
@@ -149,26 +120,6 @@ class ChatModelHttpProxySupportTest {
 
         // then
         verify(proxyConfiguration).getProxyDetails(SCHEME_HTTP);
-      }
-    }
-
-    @Test
-    void shouldNotApplyTimeoutsToTheBuilder() {
-      // given
-      when(proxyConfiguration.getProxyDetails(SCHEME_HTTPS)).thenReturn(Optional.empty());
-
-      ApacheHttpClient.Builder httpClientBuilder =
-          Mockito.mock(ApacheHttpClient.Builder.class, Answers.RETURNS_SELF);
-
-      try (MockedStatic<ApacheHttpClient> apacheMock = mockStatic(ApacheHttpClient.class)) {
-        apacheMock.when(ApacheHttpClient::builder).thenReturn(httpClientBuilder);
-
-        // when
-        proxySupport.createAwsHttpClientBuilder(URI.create("https://bedrock.amazonaws.com"));
-
-        // then — timeouts are the caller's (chat model provider) responsibility
-        verify(httpClientBuilder, never()).connectionTimeout(any());
-        verify(httpClientBuilder, never()).socketTimeout(any());
       }
     }
 

--- a/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/provider/BedrockChatModelProviderTest.java
+++ b/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/provider/BedrockChatModelProviderTest.java
@@ -300,7 +300,7 @@ class BedrockChatModelProviderTest {
       assertThat(chatModel).isNotNull().isInstanceOf(BedrockChatModel.class);
       assertThat(chatModel).isSameAs(chatModelResultCaptor.getResult());
 
-      verify(proxySupport).createAwsHttpClient(expectedEndpointOverride);
+      verify(proxySupport).createAwsHttpClientBuilder(expectedEndpointOverride);
       builderAssertions.accept(builders);
     }
   }


### PR DESCRIPTION
## Description

* Added explicit connection and socket timeout configuration to LLM clients:
  * Anthropic
  * OpenAI
  * OpenAI compatible
  * Amazon Bedrock

#### Settings 
* Connection Timeout: 15 seconds
* Socket (Read) Timeout: Configured LLM timeout on connector or default timeout (3 minutes)

#### Reasoning
Due to the nature of the synchronous LLM APIs that are currently used in our implementations, bigger context windows might delay a response from the LLM provider, especially during high load or longer thinking scenarios.

In synchronous LLM APIs the entire response is generated before it is transmitted, thus the socket (read) timeout must be large enough to wait in such cases.

## Related issues

closes #7193 

## Checklist

- [x] Backport labels are added if these code changes should be backported. No backport label is added to the latest
  release, as this branch will be rebased onto main before the next release. Example backport labels:
    - `backport stable/8.8`: for changes that should be included in the next 8.8.x release.
    - **or** `backport release-8.8.7`: for changes that should be included in the specific release 8.8.7, and this
      *release has already been created*. The release branch will be merged back into stable/8.8 later, so the change
      will be included in future 8.8.x releases as well.
- [x] Tests/Integration tests for the changes have been added if applicable.
- [ ] If the change requires a documentation update, it has been added to the appropriate section in the documentation.


