### PR TITLE
fix(agentic-ai): Fix socket and connection timeout config on LLM clients being too short on default settings (#7240)

### DIFF
--- a/connectors/agentic-ai/pom.xml
+++ b/connectors/agentic-ai/pom.xml
@@ -136,6 +136,11 @@
     </dependency>
 
     <dependency>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>apache-client</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/ChatModelFactoryImpl.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/ChatModelFactoryImpl.java
@@ -151,11 +151,10 @@ public class ChatModelFactoryImpl implements ChatModelFactory {
                 ClientOverrideConfiguration.builder()
                     .apiCallTimeout(DEFAULT_MODEL_CALL_TIMEOUT)
                     .build())
-            .httpClient(
+            .httpClientBuilder(
                 ApacheHttpClient.builder()
                     .connectionTimeout(Duration.ofSeconds(15))
-                    .socketTimeout(DEFAULT_MODEL_CALL_TIMEOUT)
-                    .build())
+                    .socketTimeout(DEFAULT_MODEL_CALL_TIMEOUT))
             .region(Region.of(connection.region()));
 
     if (connection.endpoint() != null) {

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/ChatModelFactoryImpl.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/ChatModelFactoryImpl.java
@@ -43,6 +43,7 @@ import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
+import software.amazon.awssdk.http.apache.ApacheHttpClient;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.bedrockruntime.BedrockRuntimeClient;
 
@@ -149,6 +150,11 @@ public class ChatModelFactoryImpl implements ChatModelFactory {
             .overrideConfiguration(
                 ClientOverrideConfiguration.builder()
                     .apiCallTimeout(DEFAULT_MODEL_CALL_TIMEOUT)
+                    .build())
+            .httpClient(
+                ApacheHttpClient.builder()
+                    .connectionTimeout(Duration.ofSeconds(15))
+                    .socketTimeout(DEFAULT_MODEL_CALL_TIMEOUT)
                     .build())
             .region(Region.of(connection.region()));
 

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -468,6 +468,11 @@ limitations under the License.</license.inlineheader>
         <artifactId>regions</artifactId>
         <version>${version.software-aws-java-sdk}</version>
       </dependency>
+      <dependency>
+        <groupId>software.amazon.awssdk</groupId>
+        <artifactId>apache-client</artifactId>
+        <version>${version.software-aws-java-sdk}</version>
+      </dependency>
 
       <dependency>
         <groupId>com.google.api-client</groupId>


### PR DESCRIPTION
## Description

Backport of #7240 to `stable/8.8`

Deviations:
* Only applying socket and connection timeouts to Amazon Bedrock chat models
* Other providers in the original PR respect the timeout settings that are already configured, as L4J implementation applies it, when no custom client is being configured.


