### PR TITLE
fix(agentic-ai): Ensure that AI agent chat resources are properly closed where possible

### DIFF
--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/langchain4j/jobworker/BaseL4JAiAgentJobWorkerTest.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/langchain4j/jobworker/BaseL4JAiAgentJobWorkerTest.java
@@ -30,7 +30,6 @@ import dev.langchain4j.data.message.ChatMessage;
 import dev.langchain4j.data.message.SystemMessage;
 import dev.langchain4j.data.message.ToolExecutionResultMessage;
 import dev.langchain4j.data.message.UserMessage;
-import dev.langchain4j.model.chat.ChatModel;
 import dev.langchain4j.model.chat.request.ChatRequest;
 import dev.langchain4j.model.chat.response.ChatResponse;
 import dev.langchain4j.model.chat.response.ChatResponseMetadata;
@@ -38,6 +37,7 @@ import dev.langchain4j.model.output.FinishReason;
 import dev.langchain4j.model.output.TokenUsage;
 import io.camunda.connector.agenticai.adhoctoolsschema.schema.AdHocToolsSchemaResolver;
 import io.camunda.connector.agenticai.aiagent.framework.langchain4j.ChatModelFactory;
+import io.camunda.connector.agenticai.aiagent.framework.langchain4j.CloseableChatModel;
 import io.camunda.connector.agenticai.aiagent.framework.langchain4j.document.DocumentToContentResponseModel;
 import io.camunda.connector.agenticai.aiagent.model.AgentMetrics;
 import io.camunda.connector.agenticai.aiagent.model.JobWorkerAgentResponse;
@@ -71,7 +71,7 @@ import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 @ExtendWith(MockitoExtension.class)
 abstract class BaseL4JAiAgentJobWorkerTest extends BaseAiAgentJobWorkerTest {
   @MockitoBean private ChatModelFactory chatModelFactory;
-  @Mock protected ChatModel chatModel;
+  @Mock protected CloseableChatModel chatModel;
   @Captor protected ArgumentCaptor<ChatRequest> chatRequestCaptor;
   @MockitoSpyBean protected AdHocToolsSchemaResolver toolsSchemaResolver;
 

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/langchain4j/outboundconnector/BaseL4JAiAgentConnectorTest.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/langchain4j/outboundconnector/BaseL4JAiAgentConnectorTest.java
@@ -29,7 +29,6 @@ import dev.langchain4j.data.message.ChatMessage;
 import dev.langchain4j.data.message.SystemMessage;
 import dev.langchain4j.data.message.ToolExecutionResultMessage;
 import dev.langchain4j.data.message.UserMessage;
-import dev.langchain4j.model.chat.ChatModel;
 import dev.langchain4j.model.chat.request.ChatRequest;
 import dev.langchain4j.model.chat.response.ChatResponse;
 import dev.langchain4j.model.chat.response.ChatResponseMetadata;
@@ -37,6 +36,7 @@ import dev.langchain4j.model.output.FinishReason;
 import dev.langchain4j.model.output.TokenUsage;
 import io.camunda.connector.agenticai.adhoctoolsschema.schema.AdHocToolsSchemaResolver;
 import io.camunda.connector.agenticai.aiagent.framework.langchain4j.ChatModelFactory;
+import io.camunda.connector.agenticai.aiagent.framework.langchain4j.CloseableChatModel;
 import io.camunda.connector.agenticai.aiagent.framework.langchain4j.document.DocumentToContentResponseModel;
 import io.camunda.connector.agenticai.aiagent.model.AgentMetrics;
 import io.camunda.connector.agenticai.aiagent.model.AgentResponse;
@@ -69,7 +69,7 @@ import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 @ExtendWith(MockitoExtension.class)
 abstract class BaseL4JAiAgentConnectorTest extends BaseAiAgentConnectorTest {
   @MockitoBean private ChatModelFactory chatModelFactory;
-  @Mock protected ChatModel chatModel;
+  @Mock protected CloseableChatModel chatModel;
   @Captor protected ArgumentCaptor<ChatRequest> chatRequestCaptor;
   @MockitoSpyBean protected AdHocToolsSchemaResolver toolsSchemaResolver;
 

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/ChatModelFactory.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/ChatModelFactory.java
@@ -6,9 +6,8 @@
  */
 package io.camunda.connector.agenticai.aiagent.framework.langchain4j;
 
-import dev.langchain4j.model.chat.ChatModel;
 import io.camunda.connector.agenticai.aiagent.model.request.provider.ProviderConfiguration;
 
 public interface ChatModelFactory {
-  ChatModel createChatModel(ProviderConfiguration providerConfiguration);
+  CloseableChatModel createChatModel(ProviderConfiguration providerConfiguration);
 }

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/ChatModelFactoryImpl.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/ChatModelFactoryImpl.java
@@ -6,7 +6,6 @@
  */
 package io.camunda.connector.agenticai.aiagent.framework.langchain4j;
 
-import dev.langchain4j.model.chat.ChatModel;
 import io.camunda.connector.agenticai.aiagent.framework.langchain4j.provider.ChatModelProviderRegistry;
 import io.camunda.connector.agenticai.aiagent.model.request.provider.ProviderConfiguration;
 
@@ -19,7 +18,7 @@ public class ChatModelFactoryImpl implements ChatModelFactory {
   }
 
   @Override
-  public ChatModel createChatModel(ProviderConfiguration providerConfiguration) {
+  public CloseableChatModel createChatModel(ProviderConfiguration providerConfiguration) {
     return chatModelProviderRegistry
         .getChatModelProvider(providerConfiguration)
         .createChatModel(providerConfiguration);

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/ChatModelHttpProxySupport.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/ChatModelHttpProxySupport.java
@@ -11,11 +11,18 @@ import dev.langchain4j.http.client.jdk.JdkHttpClientBuilder;
 import io.camunda.connector.http.client.client.jdk.proxy.JdkHttpClientProxyConfigurator;
 import io.camunda.connector.http.client.proxy.NonProxyHosts;
 import io.camunda.connector.http.client.proxy.ProxyConfiguration;
+import java.net.Authenticator;
+import java.net.CookieHandler;
 import java.net.InetSocketAddress;
+import java.net.ProxySelector;
 import java.net.URI;
 import java.net.http.HttpClient;
+import java.time.Duration;
 import java.util.Optional;
+import java.util.concurrent.Executor;
 import java.util.stream.Collectors;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLParameters;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.http.apache.ApacheHttpClient;
@@ -33,10 +40,94 @@ public class ChatModelHttpProxySupport {
     this.jdkHttpClientProxyConfigurator = jdkHttpClientProxyConfigurator;
   }
 
-  public JdkHttpClientBuilder createJdkHttpClientBuilder() {
-    final var httpClientBuilder = HttpClient.newBuilder();
+  /**
+   * Builds a JDK {@link HttpClient} and returns it together with a {@link JdkHttpClientBuilder}
+   * configured to reuse that exact instance. Callers can close the returned {@code httpClient}
+   * after the request to release the connection pool and selector thread.
+   *
+   * <p>The supplied {@code connectTimeout} is applied to the real client before construction so
+   * that the inner {@link JdkHttpClientBuilder} does not build a second client when {@code
+   * JdkHttpClient} is constructed from the builder.
+   */
+  public JdkHttpClientHandle createJdkHttpClient(Duration connectTimeout) {
+    final var httpClientBuilder = HttpClient.newBuilder().connectTimeout(connectTimeout);
     jdkHttpClientProxyConfigurator.configure(httpClientBuilder);
-    return new JdkHttpClientBuilder().httpClientBuilder(httpClientBuilder);
+    final var httpClient = httpClientBuilder.build();
+    final var jdkBuilder =
+        new JdkHttpClientBuilder().httpClientBuilder(new PrebuiltHttpClientBuilder(httpClient));
+    return new JdkHttpClientHandle(httpClient, jdkBuilder);
+  }
+
+  /** Pairs the pre-built {@link HttpClient} with a {@link JdkHttpClientBuilder} wrapping it. */
+  public record JdkHttpClientHandle(HttpClient httpClient, JdkHttpClientBuilder builder) {}
+
+  /**
+   * Wraps a pre-built {@link HttpClient} behind the {@link HttpClient.Builder} interface. All
+   * configuration calls are no-ops — settings were already applied before the client was built.
+   * {@link #build()} returns the pre-built instance so {@code JdkHttpClient} reuses it rather than
+   * creating a second one.
+   */
+  private static final class PrebuiltHttpClientBuilder implements HttpClient.Builder {
+    private final HttpClient httpClient;
+
+    PrebuiltHttpClientBuilder(HttpClient httpClient) {
+      this.httpClient = httpClient;
+    }
+
+    @Override
+    public HttpClient.Builder cookieHandler(CookieHandler cookieHandler) {
+      return this;
+    }
+
+    @Override
+    public HttpClient.Builder connectTimeout(Duration duration) {
+      return this;
+    }
+
+    @Override
+    public HttpClient.Builder sslContext(SSLContext sslContext) {
+      return this;
+    }
+
+    @Override
+    public HttpClient.Builder sslParameters(SSLParameters sslParameters) {
+      return this;
+    }
+
+    @Override
+    public HttpClient.Builder executor(Executor executor) {
+      return this;
+    }
+
+    @Override
+    public HttpClient.Builder followRedirects(HttpClient.Redirect policy) {
+      return this;
+    }
+
+    @Override
+    public HttpClient.Builder version(HttpClient.Version version) {
+      return this;
+    }
+
+    @Override
+    public HttpClient.Builder priority(int priority) {
+      return this;
+    }
+
+    @Override
+    public HttpClient.Builder proxy(ProxySelector proxySelector) {
+      return this;
+    }
+
+    @Override
+    public HttpClient.Builder authenticator(Authenticator authenticator) {
+      return this;
+    }
+
+    @Override
+    public HttpClient build() {
+      return httpClient;
+    }
   }
 
   public ApacheHttpClient.Builder createAwsHttpClientBuilder(URI endpointOverride) {

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/ChatModelHttpProxySupport.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/ChatModelHttpProxySupport.java
@@ -41,92 +41,117 @@ public class ChatModelHttpProxySupport {
   }
 
   /**
-   * Builds a JDK {@link HttpClient} and returns it together with a {@link JdkHttpClientBuilder}
-   * configured to reuse that exact instance. Callers can close the returned {@code httpClient}
-   * after the request to release the connection pool and selector thread.
-   *
-   * <p>The supplied {@code connectTimeout} is applied to the real client before construction so
-   * that the inner {@link JdkHttpClientBuilder} does not build a second client when {@code
-   * JdkHttpClient} is constructed from the builder.
+   * Configures an {@link HttpClient.Builder} with proxy settings, then wraps it in a {@link
+   * CloseableJdkHttpClientBuilder}. Callers set timeouts on the returned builder directly (e.g.
+   * {@code .connectTimeout(...).readTimeout(...)}), pass it to a langchain4j model builder as the
+   * {@code httpClientBuilder}, then pass it to {@link CloseableChatModelDelegate} as the resource
+   * to close.
    */
-  public JdkHttpClientHandle createJdkHttpClient(Duration connectTimeout) {
-    final var httpClientBuilder = HttpClient.newBuilder().connectTimeout(connectTimeout);
+  public CloseableJdkHttpClientBuilder createJdkHttpClientBuilder() {
+    final var httpClientBuilder = HttpClient.newBuilder();
     jdkHttpClientProxyConfigurator.configure(httpClientBuilder);
-    final var httpClient = httpClientBuilder.build();
-    final var jdkBuilder =
-        new JdkHttpClientBuilder().httpClientBuilder(new PrebuiltHttpClientBuilder(httpClient));
-    return new JdkHttpClientHandle(httpClient, jdkBuilder);
+    return new CloseableJdkHttpClientBuilder(httpClientBuilder);
   }
 
-  /** Pairs the pre-built {@link HttpClient} with a {@link JdkHttpClientBuilder} wrapping it. */
-  public record JdkHttpClientHandle(HttpClient httpClient, JdkHttpClientBuilder builder) {}
-
   /**
-   * Wraps a pre-built {@link HttpClient} behind the {@link HttpClient.Builder} interface. All
-   * configuration calls are no-ops — settings were already applied before the client was built.
-   * {@link #build()} returns the pre-built instance so {@code JdkHttpClient} reuses it rather than
-   * creating a second one.
+   * A {@link JdkHttpClientBuilder} that wraps a configured {@link HttpClient.Builder} and captures
+   * the {@link HttpClient} produced when langchain4j calls {@link HttpClient.Builder#build()}.
+   * Extends {@link JdkHttpClientBuilder} so it can be passed directly to langchain4j model
+   * builders. Implements {@link AutoCloseable} so it can be passed directly to {@link
+   * CloseableChatModelDelegate}.
+   *
+   * <p>All {@link HttpClient.Builder} method calls are forwarded to the real builder so any
+   * configuration langchain4j applies (SSL context, version, executor, etc.) takes effect on the
+   * actual client. {@link CapturingBridge#build()} captures the resulting instance for {@link
+   * #close()}.
    */
-  private static final class PrebuiltHttpClientBuilder implements HttpClient.Builder {
-    private final HttpClient httpClient;
+  public static final class CloseableJdkHttpClientBuilder extends JdkHttpClientBuilder
+      implements AutoCloseable {
 
-    PrebuiltHttpClientBuilder(HttpClient httpClient) {
-      this.httpClient = httpClient;
+    private HttpClient builtClient;
+
+    CloseableJdkHttpClientBuilder(HttpClient.Builder delegate) {
+      httpClientBuilder(new CapturingBridge(delegate));
     }
 
     @Override
-    public HttpClient.Builder cookieHandler(CookieHandler cookieHandler) {
-      return this;
+    public void close() {
+      if (builtClient != null) {
+        builtClient.close();
+      }
     }
 
-    @Override
-    public HttpClient.Builder connectTimeout(Duration duration) {
-      return this;
-    }
+    private final class CapturingBridge implements HttpClient.Builder {
+      private final HttpClient.Builder delegate;
 
-    @Override
-    public HttpClient.Builder sslContext(SSLContext sslContext) {
-      return this;
-    }
+      CapturingBridge(HttpClient.Builder delegate) {
+        this.delegate = delegate;
+      }
 
-    @Override
-    public HttpClient.Builder sslParameters(SSLParameters sslParameters) {
-      return this;
-    }
+      @Override
+      public HttpClient.Builder cookieHandler(CookieHandler cookieHandler) {
+        delegate.cookieHandler(cookieHandler);
+        return this;
+      }
 
-    @Override
-    public HttpClient.Builder executor(Executor executor) {
-      return this;
-    }
+      @Override
+      public HttpClient.Builder connectTimeout(Duration duration) {
+        delegate.connectTimeout(duration);
+        return this;
+      }
 
-    @Override
-    public HttpClient.Builder followRedirects(HttpClient.Redirect policy) {
-      return this;
-    }
+      @Override
+      public HttpClient.Builder sslContext(SSLContext sslContext) {
+        delegate.sslContext(sslContext);
+        return this;
+      }
 
-    @Override
-    public HttpClient.Builder version(HttpClient.Version version) {
-      return this;
-    }
+      @Override
+      public HttpClient.Builder sslParameters(SSLParameters sslParameters) {
+        delegate.sslParameters(sslParameters);
+        return this;
+      }
 
-    @Override
-    public HttpClient.Builder priority(int priority) {
-      return this;
-    }
+      @Override
+      public HttpClient.Builder executor(Executor executor) {
+        delegate.executor(executor);
+        return this;
+      }
 
-    @Override
-    public HttpClient.Builder proxy(ProxySelector proxySelector) {
-      return this;
-    }
+      @Override
+      public HttpClient.Builder followRedirects(HttpClient.Redirect policy) {
+        delegate.followRedirects(policy);
+        return this;
+      }
 
-    @Override
-    public HttpClient.Builder authenticator(Authenticator authenticator) {
-      return this;
-    }
+      @Override
+      public HttpClient.Builder version(HttpClient.Version version) {
+        delegate.version(version);
+        return this;
+      }
 
-    @Override
-    public HttpClient build() {
-      return httpClient;
+      @Override
+      public HttpClient.Builder priority(int priority) {
+        delegate.priority(priority);
+        return this;
+      }
+
+      @Override
+      public HttpClient.Builder proxy(ProxySelector proxySelector) {
+        delegate.proxy(proxySelector);
+        return this;
+      }
+
+      @Override
+      public HttpClient.Builder authenticator(Authenticator authenticator) {
+        delegate.authenticator(authenticator);
+        return this;
+      }
+
+      @Override
+      public HttpClient build() {
+        return builtClient = delegate.build();
+      }
     }
   }
 

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/ChatModelHttpProxySupport.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/ChatModelHttpProxySupport.java
@@ -150,6 +150,9 @@ public class ChatModelHttpProxySupport {
 
       @Override
       public HttpClient build() {
+        if (builtClient != null) {
+          throw new IllegalStateException("HttpClient has already been built");
+        }
         return builtClient = delegate.build();
       }
     }

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/CloseableChatModel.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/CloseableChatModel.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.agenticai.aiagent.framework.langchain4j;
+
+import dev.langchain4j.model.chat.ChatModel;
+
+/**
+ * A {@link ChatModel} that owns a closeable resource (e.g. an HTTP connection pool) and must be
+ * closed after use. Declares {@code close()} without a checked exception to align with AWS SDK's
+ * {@code SdkAutoCloseable}.
+ */
+public interface CloseableChatModel extends ChatModel, AutoCloseable {
+  @Override
+  void close();
+}

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/CloseableChatModelDelegate.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/CloseableChatModelDelegate.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.agenticai.aiagent.framework.langchain4j;
+
+import dev.langchain4j.model.ModelProvider;
+import dev.langchain4j.model.chat.Capability;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.listener.ChatModelListener;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.request.ChatRequestParameters;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import java.util.List;
+import java.util.Set;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Pairs a {@link ChatModel} with an {@link AutoCloseable} resource (e.g. a {@code
+ * BedrockRuntimeClient}) so both can be treated as a single {@link CloseableChatModel}. {@link
+ * #close()} releases the resource and swallows any exception to avoid masking LLM failures in the
+ * caller's {@code finally} block.
+ */
+public record CloseableChatModelDelegate(ChatModel delegate, AutoCloseable resource)
+    implements CloseableChatModel {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(CloseableChatModelDelegate.class);
+
+  @Override
+  public ChatResponse chat(ChatRequest request) {
+    return delegate.chat(request);
+  }
+
+  @Override
+  public ChatRequestParameters defaultRequestParameters() {
+    return delegate.defaultRequestParameters();
+  }
+
+  @Override
+  public List<ChatModelListener> listeners() {
+    return delegate.listeners();
+  }
+
+  @Override
+  public ModelProvider provider() {
+    return delegate.provider();
+  }
+
+  @Override
+  public Set<Capability> supportedCapabilities() {
+    return delegate.supportedCapabilities();
+  }
+
+  @Override
+  public void close() {
+    try {
+      resource.close();
+    } catch (Exception e) {
+      LOGGER.warn("Failed to close chat model resource", e);
+    }
+  }
+}

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/Langchain4JAiFrameworkAdapter.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/Langchain4JAiFrameworkAdapter.java
@@ -28,9 +28,13 @@ import io.camunda.connector.agenticai.model.message.AssistantMessage;
 import io.camunda.connector.api.error.ConnectorException;
 import java.util.Optional;
 import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class Langchain4JAiFrameworkAdapter
     implements AiFrameworkAdapter<Langchain4JAiFrameworkChatResponse> {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(Langchain4JAiFrameworkAdapter.class);
 
   private final ChatModelFactory chatModelFactory;
   private final ChatMessageConverter chatMessageConverter;
@@ -62,18 +66,29 @@ public class Langchain4JAiFrameworkAdapter
     configureResponseFormat(chatRequestBuilder, executionContext.response());
 
     final ChatModel chatModel = chatModelFactory.createChatModel(executionContext.provider());
-    final ChatResponse chatResponse = doChat(chatModel, chatRequestBuilder);
-    final AssistantMessage assistantMessage = chatMessageConverter.toAssistantMessage(chatResponse);
+    try {
+      final ChatResponse chatResponse = doChat(chatModel, chatRequestBuilder);
+      final AssistantMessage assistantMessage =
+          chatMessageConverter.toAssistantMessage(chatResponse);
 
-    final var updatedAgentContext =
-        agentContext.withMetrics(
-            agentContext
-                .metrics()
-                .incrementModelCalls(1)
-                .incrementTokenUsage(tokenUsage(chatResponse.tokenUsage())));
+      final var updatedAgentContext =
+          agentContext.withMetrics(
+              agentContext
+                  .metrics()
+                  .incrementModelCalls(1)
+                  .incrementTokenUsage(tokenUsage(chatResponse.tokenUsage())));
 
-    return new Langchain4JAiFrameworkChatResponse(
-        updatedAgentContext, assistantMessage, chatResponse);
+      return new Langchain4JAiFrameworkChatResponse(
+          updatedAgentContext, assistantMessage, chatResponse);
+    } finally {
+      if (chatModel instanceof AutoCloseable closeable) {
+        try {
+          closeable.close();
+        } catch (Exception e) {
+          LOGGER.warn("Failed to close chat model", e);
+        }
+      }
+    }
   }
 
   private void configureResponseFormat(

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/Langchain4JAiFrameworkAdapter.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/Langchain4JAiFrameworkAdapter.java
@@ -65,8 +65,7 @@ public class Langchain4JAiFrameworkAdapter
         ChatRequest.builder().messages(messages).toolSpecifications(toolSpecifications);
     configureResponseFormat(chatRequestBuilder, executionContext.response());
 
-    final ChatModel chatModel = chatModelFactory.createChatModel(executionContext.provider());
-    try {
+    try (final var chatModel = chatModelFactory.createChatModel(executionContext.provider())) {
       final ChatResponse chatResponse = doChat(chatModel, chatRequestBuilder);
       final AssistantMessage assistantMessage =
           chatMessageConverter.toAssistantMessage(chatResponse);
@@ -80,14 +79,6 @@ public class Langchain4JAiFrameworkAdapter
 
       return new Langchain4JAiFrameworkChatResponse(
           updatedAgentContext, assistantMessage, chatResponse);
-    } finally {
-      if (chatModel instanceof AutoCloseable closeable) {
-        try {
-          closeable.close();
-        } catch (Exception e) {
-          LOGGER.warn("Failed to close chat model", e);
-        }
-      }
     }
   }
 

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/provider/AnthropicChatModelProvider.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/provider/AnthropicChatModelProvider.java
@@ -44,13 +44,13 @@ public class AnthropicChatModelProvider
     final var apiTimeout =
         deriveTimeoutSetting("Anthropic model call", config, connection.timeouts(), LOGGER);
 
-    final var http = proxySupport.createJdkHttpClient(CONNECT_TIMEOUT);
+    final var http = proxySupport.createJdkHttpClientBuilder();
     final var builder =
         AnthropicChatModel.builder()
             .apiKey(connection.authentication().apiKey())
             .modelName(connection.model().model())
             .timeout(apiTimeout)
-            .httpClientBuilder(http.builder().readTimeout(apiTimeout));
+            .httpClientBuilder(http.connectTimeout(CONNECT_TIMEOUT).readTimeout(apiTimeout));
 
     Optional.ofNullable(connection.endpoint()).ifPresent(builder::baseUrl);
 
@@ -62,6 +62,6 @@ public class AnthropicChatModelProvider
       Optional.ofNullable(modelParameters.topK()).ifPresent(builder::topK);
     }
 
-    return new CloseableChatModelDelegate(builder.build(), http.httpClient());
+    return new CloseableChatModelDelegate(builder.build(), http);
   }
 }

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/provider/AnthropicChatModelProvider.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/provider/AnthropicChatModelProvider.java
@@ -12,6 +12,7 @@ import static io.camunda.connector.agenticai.aiagent.framework.langchain4j.provi
 import dev.langchain4j.model.anthropic.AnthropicChatModel;
 import dev.langchain4j.model.chat.ChatModel;
 import io.camunda.connector.agenticai.aiagent.framework.langchain4j.ChatModelHttpProxySupport;
+import io.camunda.connector.agenticai.aiagent.framework.langchain4j.CloseableChatModelDelegate;
 import io.camunda.connector.agenticai.aiagent.model.request.provider.AnthropicProviderConfiguration;
 import io.camunda.connector.agenticai.autoconfigure.AgenticAiConnectorsConfigurationProperties.ChatModelProperties;
 import java.util.Optional;
@@ -43,16 +44,13 @@ public class AnthropicChatModelProvider
     final var apiTimeout =
         deriveTimeoutSetting("Anthropic model call", config, connection.timeouts(), LOGGER);
 
+    final var http = proxySupport.createJdkHttpClient(CONNECT_TIMEOUT);
     final var builder =
         AnthropicChatModel.builder()
             .apiKey(connection.authentication().apiKey())
             .modelName(connection.model().model())
             .timeout(apiTimeout)
-            .httpClientBuilder(
-                proxySupport
-                    .createJdkHttpClientBuilder()
-                    .connectTimeout(CONNECT_TIMEOUT)
-                    .readTimeout(apiTimeout));
+            .httpClientBuilder(http.builder().readTimeout(apiTimeout));
 
     Optional.ofNullable(connection.endpoint()).ifPresent(builder::baseUrl);
 
@@ -64,6 +62,6 @@ public class AnthropicChatModelProvider
       Optional.ofNullable(modelParameters.topK()).ifPresent(builder::topK);
     }
 
-    return builder.build();
+    return new CloseableChatModelDelegate(builder.build(), http.httpClient());
   }
 }

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/provider/AnthropicChatModelProvider.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/provider/AnthropicChatModelProvider.java
@@ -10,8 +10,8 @@ import static io.camunda.connector.agenticai.aiagent.framework.langchain4j.provi
 import static io.camunda.connector.agenticai.aiagent.framework.langchain4j.provider.ChatModelProviderSupport.deriveTimeoutSetting;
 
 import dev.langchain4j.model.anthropic.AnthropicChatModel;
-import dev.langchain4j.model.chat.ChatModel;
 import io.camunda.connector.agenticai.aiagent.framework.langchain4j.ChatModelHttpProxySupport;
+import io.camunda.connector.agenticai.aiagent.framework.langchain4j.CloseableChatModel;
 import io.camunda.connector.agenticai.aiagent.framework.langchain4j.CloseableChatModelDelegate;
 import io.camunda.connector.agenticai.aiagent.model.request.provider.AnthropicProviderConfiguration;
 import io.camunda.connector.agenticai.autoconfigure.AgenticAiConnectorsConfigurationProperties.ChatModelProperties;
@@ -39,7 +39,7 @@ public class AnthropicChatModelProvider
   }
 
   @Override
-  public ChatModel createChatModel(AnthropicProviderConfiguration anthropic) {
+  public CloseableChatModel createChatModel(AnthropicProviderConfiguration anthropic) {
     final var connection = anthropic.anthropic();
     final var apiTimeout =
         deriveTimeoutSetting("Anthropic model call", config, connection.timeouts(), LOGGER);

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/provider/AzureOpenAiChatModelProvider.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/provider/AzureOpenAiChatModelProvider.java
@@ -76,6 +76,8 @@ public class AzureOpenAiChatModelProvider
       Optional.ofNullable(modelParameters.topP()).ifPresent(builder::topP);
     }
 
+    // AzureOpenAiChatModel / OpenAIClient / NettyAsyncHttpClient expose no close/dispose API,
+    // so we cannot wrap the result in CloseableChatModelDelegate here.
     return builder.build();
   }
 }

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/provider/AzureOpenAiChatModelProvider.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/provider/AzureOpenAiChatModelProvider.java
@@ -10,8 +10,9 @@ import static io.camunda.connector.agenticai.aiagent.framework.langchain4j.provi
 
 import com.azure.identity.ClientSecretCredentialBuilder;
 import dev.langchain4j.model.azure.AzureOpenAiChatModel;
-import dev.langchain4j.model.chat.ChatModel;
 import io.camunda.connector.agenticai.aiagent.framework.langchain4j.ChatModelHttpProxySupport;
+import io.camunda.connector.agenticai.aiagent.framework.langchain4j.CloseableChatModel;
+import io.camunda.connector.agenticai.aiagent.framework.langchain4j.CloseableChatModelDelegate;
 import io.camunda.connector.agenticai.aiagent.model.request.provider.AzureOpenAiProviderConfiguration;
 import io.camunda.connector.agenticai.aiagent.model.request.provider.AzureOpenAiProviderConfiguration.AzureAuthentication.AzureApiKeyAuthentication;
 import io.camunda.connector.agenticai.aiagent.model.request.provider.AzureOpenAiProviderConfiguration.AzureAuthentication.AzureClientCredentialsAuthentication;
@@ -41,7 +42,7 @@ public class AzureOpenAiChatModelProvider
   }
 
   @Override
-  public ChatModel createChatModel(AzureOpenAiProviderConfiguration azureOpenAi) {
+  public CloseableChatModel createChatModel(AzureOpenAiProviderConfiguration azureOpenAi) {
     final var connection = azureOpenAi.azureOpenAi();
     final var builder =
         AzureOpenAiChatModel.builder()
@@ -76,8 +77,7 @@ public class AzureOpenAiChatModelProvider
       Optional.ofNullable(modelParameters.topP()).ifPresent(builder::topP);
     }
 
-    // AzureOpenAiChatModel / OpenAIClient / NettyAsyncHttpClient expose no close/dispose API,
-    // so we cannot wrap the result in CloseableChatModelDelegate here.
-    return builder.build();
+    // AzureOpenAiChatModel / OpenAIClient / NettyAsyncHttpClient expose no close/dispose API.
+    return new CloseableChatModelDelegate(builder.build(), () -> {});
   }
 }

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/provider/BedrockChatModelProvider.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/provider/BedrockChatModelProvider.java
@@ -21,7 +21,6 @@ import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
-import software.amazon.awssdk.http.SdkHttpClient;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.bedrockruntime.BedrockRuntimeClient;
 
@@ -83,13 +82,11 @@ public class BedrockChatModelProvider implements ChatModelProvider<BedrockProvid
     // socket timeout of 30 seconds. The TCP connect timeout is kept at a small constant since it
     // covers infrastructure availability (DNS / firewall / proxy), not model latency. See issue
     // #7193.
-    SdkHttpClient httpClient =
+    bedrockClientBuilder.httpClientBuilder(
         proxySupport
             .createAwsHttpClientBuilder(endpointOverride)
             .connectionTimeout(CONNECT_TIMEOUT)
-            .socketTimeout(apiTimeout)
-            .build();
-    bedrockClientBuilder.httpClient(httpClient);
+            .socketTimeout(apiTimeout));
 
     bedrockClientBuilder.overrideConfiguration(overrideClientConfigurationBuilder.build());
 

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/provider/BedrockChatModelProvider.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/provider/BedrockChatModelProvider.java
@@ -11,8 +11,9 @@ import static io.camunda.connector.agenticai.aiagent.framework.langchain4j.provi
 
 import dev.langchain4j.model.bedrock.BedrockChatModel;
 import dev.langchain4j.model.bedrock.BedrockChatRequestParameters;
-import dev.langchain4j.model.chat.ChatModel;
 import io.camunda.connector.agenticai.aiagent.framework.langchain4j.ChatModelHttpProxySupport;
+import io.camunda.connector.agenticai.aiagent.framework.langchain4j.CloseableChatModel;
+import io.camunda.connector.agenticai.aiagent.framework.langchain4j.CloseableChatModelDelegate;
 import io.camunda.connector.agenticai.aiagent.model.request.provider.BedrockProviderConfiguration;
 import io.camunda.connector.agenticai.autoconfigure.AgenticAiConnectorsConfigurationProperties.ChatModelProperties;
 import java.net.URI;
@@ -43,20 +44,21 @@ public class BedrockChatModelProvider implements ChatModelProvider<BedrockProvid
   }
 
   @Override
-  public ChatModel createChatModel(BedrockProviderConfiguration bedrock) {
+  public CloseableChatModel createChatModel(BedrockProviderConfiguration bedrock) {
     final var connection = bedrock.bedrock();
     final var apiTimeout =
         deriveTimeoutSetting("Bedrock model call", config, connection.timeouts(), LOGGER);
 
+    final var bedrockRuntimeClient = createBedrockClient(connection, apiTimeout);
     final var builder =
         BedrockChatModel.builder()
-            .client(createBedrockClient(connection, apiTimeout))
+            .client(bedrockRuntimeClient)
             .modelId(connection.model().model())
             .timeout(apiTimeout);
 
     applyBedrockModelParametersIfPresent(connection, builder);
 
-    return builder.build();
+    return new CloseableChatModelDelegate(builder.build(), bedrockRuntimeClient);
   }
 
   private BedrockRuntimeClient createBedrockClient(

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/provider/ChatModelProvider.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/provider/ChatModelProvider.java
@@ -6,7 +6,7 @@
  */
 package io.camunda.connector.agenticai.aiagent.framework.langchain4j.provider;
 
-import dev.langchain4j.model.chat.ChatModel;
+import io.camunda.connector.agenticai.aiagent.framework.langchain4j.CloseableChatModel;
 import io.camunda.connector.agenticai.aiagent.model.request.provider.ProviderConfiguration;
 
 /**
@@ -21,6 +21,6 @@ public interface ChatModelProvider<T extends ProviderConfiguration> {
   /** Identifier of the provider this implementation is responsible for. */
   String type();
 
-  /** Creates a {@link ChatModel} instance from the given configuration. */
-  ChatModel createChatModel(T providerConfiguration);
+  /** Creates a {@link CloseableChatModel} instance from the given configuration. */
+  CloseableChatModel createChatModel(T providerConfiguration);
 }

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/provider/GoogleVertexAiChatModelProvider.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/provider/GoogleVertexAiChatModelProvider.java
@@ -7,8 +7,9 @@
 package io.camunda.connector.agenticai.aiagent.framework.langchain4j.provider;
 
 import com.google.auth.oauth2.ServiceAccountCredentials;
-import dev.langchain4j.model.chat.ChatModel;
 import dev.langchain4j.model.vertexai.gemini.VertexAiGeminiChatModel;
+import io.camunda.connector.agenticai.aiagent.framework.langchain4j.CloseableChatModel;
+import io.camunda.connector.agenticai.aiagent.framework.langchain4j.CloseableChatModelDelegate;
 import io.camunda.connector.agenticai.aiagent.model.request.provider.GoogleVertexAiProviderConfiguration;
 import io.camunda.connector.agenticai.aiagent.model.request.provider.GoogleVertexAiProviderConfiguration.GoogleVertexAiAuthentication.ServiceAccountCredentialsAuthentication;
 import io.camunda.connector.api.error.ConnectorInputException;
@@ -31,7 +32,7 @@ public class GoogleVertexAiChatModelProvider
   }
 
   @Override
-  public ChatModel createChatModel(GoogleVertexAiProviderConfiguration vertexAi) {
+  public CloseableChatModel createChatModel(GoogleVertexAiProviderConfiguration vertexAi) {
     final var connection = vertexAi.googleVertexAi();
     final var builder =
         VertexAiGeminiChatModel.builder()
@@ -51,7 +52,8 @@ public class GoogleVertexAiChatModelProvider
       Optional.ofNullable(modelParameters.topK()).ifPresent(builder::topK);
     }
 
-    return builder.build();
+    final var model = builder.build();
+    return new CloseableChatModelDelegate(model, model);
   }
 
   private ServiceAccountCredentials createGoogleServiceAccountCredentials(

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/provider/OpenAiChatModelProvider.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/provider/OpenAiChatModelProvider.java
@@ -13,6 +13,7 @@ import dev.langchain4j.model.chat.ChatModel;
 import dev.langchain4j.model.openai.OpenAiChatModel;
 import dev.langchain4j.model.openai.OpenAiChatRequestParameters;
 import io.camunda.connector.agenticai.aiagent.framework.langchain4j.ChatModelHttpProxySupport;
+import io.camunda.connector.agenticai.aiagent.framework.langchain4j.CloseableChatModelDelegate;
 import io.camunda.connector.agenticai.aiagent.model.request.provider.OpenAiProviderConfiguration;
 import io.camunda.connector.agenticai.autoconfigure.AgenticAiConnectorsConfigurationProperties.ChatModelProperties;
 import java.util.Optional;
@@ -43,16 +44,13 @@ public class OpenAiChatModelProvider implements ChatModelProvider<OpenAiProvider
     final var apiTimeout =
         deriveTimeoutSetting("OpenAI model call", config, connection.timeouts(), LOGGER);
 
+    final var http = proxySupport.createJdkHttpClient(CONNECT_TIMEOUT);
     final var builder =
         OpenAiChatModel.builder()
             .apiKey(connection.authentication().apiKey())
             .modelName(connection.model().model())
             .timeout(apiTimeout)
-            .httpClientBuilder(
-                proxySupport
-                    .createJdkHttpClientBuilder()
-                    .connectTimeout(CONNECT_TIMEOUT)
-                    .readTimeout(apiTimeout));
+            .httpClientBuilder(http.builder().readTimeout(apiTimeout));
 
     Optional.ofNullable(connection.authentication().organizationId())
         .ifPresent(builder::organizationId);
@@ -70,6 +68,6 @@ public class OpenAiChatModelProvider implements ChatModelProvider<OpenAiProvider
       builder.defaultRequestParameters(requestParametersBuilder.build());
     }
 
-    return builder.build();
+    return new CloseableChatModelDelegate(builder.build(), http.httpClient());
   }
 }

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/provider/OpenAiChatModelProvider.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/provider/OpenAiChatModelProvider.java
@@ -9,10 +9,10 @@ package io.camunda.connector.agenticai.aiagent.framework.langchain4j.provider;
 import static io.camunda.connector.agenticai.aiagent.framework.langchain4j.provider.ChatModelProviderSupport.CONNECT_TIMEOUT;
 import static io.camunda.connector.agenticai.aiagent.framework.langchain4j.provider.ChatModelProviderSupport.deriveTimeoutSetting;
 
-import dev.langchain4j.model.chat.ChatModel;
 import dev.langchain4j.model.openai.OpenAiChatModel;
 import dev.langchain4j.model.openai.OpenAiChatRequestParameters;
 import io.camunda.connector.agenticai.aiagent.framework.langchain4j.ChatModelHttpProxySupport;
+import io.camunda.connector.agenticai.aiagent.framework.langchain4j.CloseableChatModel;
 import io.camunda.connector.agenticai.aiagent.framework.langchain4j.CloseableChatModelDelegate;
 import io.camunda.connector.agenticai.aiagent.model.request.provider.OpenAiProviderConfiguration;
 import io.camunda.connector.agenticai.autoconfigure.AgenticAiConnectorsConfigurationProperties.ChatModelProperties;
@@ -39,7 +39,7 @@ public class OpenAiChatModelProvider implements ChatModelProvider<OpenAiProvider
   }
 
   @Override
-  public ChatModel createChatModel(OpenAiProviderConfiguration openai) {
+  public CloseableChatModel createChatModel(OpenAiProviderConfiguration openai) {
     final var connection = openai.openai();
     final var apiTimeout =
         deriveTimeoutSetting("OpenAI model call", config, connection.timeouts(), LOGGER);

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/provider/OpenAiChatModelProvider.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/provider/OpenAiChatModelProvider.java
@@ -44,13 +44,13 @@ public class OpenAiChatModelProvider implements ChatModelProvider<OpenAiProvider
     final var apiTimeout =
         deriveTimeoutSetting("OpenAI model call", config, connection.timeouts(), LOGGER);
 
-    final var http = proxySupport.createJdkHttpClient(CONNECT_TIMEOUT);
+    final var http = proxySupport.createJdkHttpClientBuilder();
     final var builder =
         OpenAiChatModel.builder()
             .apiKey(connection.authentication().apiKey())
             .modelName(connection.model().model())
             .timeout(apiTimeout)
-            .httpClientBuilder(http.builder().readTimeout(apiTimeout));
+            .httpClientBuilder(http.connectTimeout(CONNECT_TIMEOUT).readTimeout(apiTimeout));
 
     Optional.ofNullable(connection.authentication().organizationId())
         .ifPresent(builder::organizationId);
@@ -68,6 +68,6 @@ public class OpenAiChatModelProvider implements ChatModelProvider<OpenAiProvider
       builder.defaultRequestParameters(requestParametersBuilder.build());
     }
 
-    return new CloseableChatModelDelegate(builder.build(), http.httpClient());
+    return new CloseableChatModelDelegate(builder.build(), http);
   }
 }

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/provider/OpenAiCompatibleChatModelProvider.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/provider/OpenAiCompatibleChatModelProvider.java
@@ -9,10 +9,10 @@ package io.camunda.connector.agenticai.aiagent.framework.langchain4j.provider;
 import static io.camunda.connector.agenticai.aiagent.framework.langchain4j.provider.ChatModelProviderSupport.CONNECT_TIMEOUT;
 import static io.camunda.connector.agenticai.aiagent.framework.langchain4j.provider.ChatModelProviderSupport.deriveTimeoutSetting;
 
-import dev.langchain4j.model.chat.ChatModel;
 import dev.langchain4j.model.openai.OpenAiChatModel;
 import dev.langchain4j.model.openai.OpenAiChatRequestParameters;
 import io.camunda.connector.agenticai.aiagent.framework.langchain4j.ChatModelHttpProxySupport;
+import io.camunda.connector.agenticai.aiagent.framework.langchain4j.CloseableChatModel;
 import io.camunda.connector.agenticai.aiagent.framework.langchain4j.CloseableChatModelDelegate;
 import io.camunda.connector.agenticai.aiagent.model.request.provider.OpenAiCompatibleProviderConfiguration;
 import io.camunda.connector.agenticai.aiagent.model.request.provider.OpenAiCompatibleProviderConfiguration.OpenAiCompatibleAuthentication;
@@ -43,7 +43,8 @@ public class OpenAiCompatibleChatModelProvider
   }
 
   @Override
-  public ChatModel createChatModel(OpenAiCompatibleProviderConfiguration openaiCompatible) {
+  public CloseableChatModel createChatModel(
+      OpenAiCompatibleProviderConfiguration openaiCompatible) {
     final var connection = openaiCompatible.openaiCompatible();
     final var apiTimeout =
         deriveTimeoutSetting("OpenAI compatible model call", config, connection.timeouts(), LOGGER);

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/provider/OpenAiCompatibleChatModelProvider.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/provider/OpenAiCompatibleChatModelProvider.java
@@ -13,6 +13,7 @@ import dev.langchain4j.model.chat.ChatModel;
 import dev.langchain4j.model.openai.OpenAiChatModel;
 import dev.langchain4j.model.openai.OpenAiChatRequestParameters;
 import io.camunda.connector.agenticai.aiagent.framework.langchain4j.ChatModelHttpProxySupport;
+import io.camunda.connector.agenticai.aiagent.framework.langchain4j.CloseableChatModelDelegate;
 import io.camunda.connector.agenticai.aiagent.model.request.provider.OpenAiCompatibleProviderConfiguration;
 import io.camunda.connector.agenticai.aiagent.model.request.provider.OpenAiCompatibleProviderConfiguration.OpenAiCompatibleAuthentication;
 import io.camunda.connector.agenticai.autoconfigure.AgenticAiConnectorsConfigurationProperties.ChatModelProperties;
@@ -47,16 +48,13 @@ public class OpenAiCompatibleChatModelProvider
     final var apiTimeout =
         deriveTimeoutSetting("OpenAI compatible model call", config, connection.timeouts(), LOGGER);
 
+    final var http = proxySupport.createJdkHttpClient(CONNECT_TIMEOUT);
     final var builder =
         OpenAiChatModel.builder()
             .modelName(connection.model().model())
             .baseUrl(connection.endpoint())
             .timeout(apiTimeout)
-            .httpClientBuilder(
-                proxySupport
-                    .createJdkHttpClientBuilder()
-                    .connectTimeout(CONNECT_TIMEOUT)
-                    .readTimeout(apiTimeout));
+            .httpClientBuilder(http.builder().readTimeout(apiTimeout));
 
     Optional.ofNullable(connection.authentication())
         .map(OpenAiCompatibleAuthentication::apiKey)
@@ -90,6 +88,6 @@ public class OpenAiCompatibleChatModelProvider
       builder.defaultRequestParameters(requestParametersBuilder.build());
     }
 
-    return builder.build();
+    return new CloseableChatModelDelegate(builder.build(), http.httpClient());
   }
 }

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/provider/OpenAiCompatibleChatModelProvider.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/provider/OpenAiCompatibleChatModelProvider.java
@@ -48,13 +48,13 @@ public class OpenAiCompatibleChatModelProvider
     final var apiTimeout =
         deriveTimeoutSetting("OpenAI compatible model call", config, connection.timeouts(), LOGGER);
 
-    final var http = proxySupport.createJdkHttpClient(CONNECT_TIMEOUT);
+    final var http = proxySupport.createJdkHttpClientBuilder();
     final var builder =
         OpenAiChatModel.builder()
             .modelName(connection.model().model())
             .baseUrl(connection.endpoint())
             .timeout(apiTimeout)
-            .httpClientBuilder(http.builder().readTimeout(apiTimeout));
+            .httpClientBuilder(http.connectTimeout(CONNECT_TIMEOUT).readTimeout(apiTimeout));
 
     Optional.ofNullable(connection.authentication())
         .map(OpenAiCompatibleAuthentication::apiKey)
@@ -88,6 +88,6 @@ public class OpenAiCompatibleChatModelProvider
       builder.defaultRequestParameters(requestParametersBuilder.build());
     }
 
-    return new CloseableChatModelDelegate(builder.build(), http.httpClient());
+    return new CloseableChatModelDelegate(builder.build(), http);
   }
 }

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/memory/conversation/awsagentcore/DefaultBedrockAgentCoreClientFactory.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/memory/conversation/awsagentcore/DefaultBedrockAgentCoreClientFactory.java
@@ -49,7 +49,7 @@ public class DefaultBedrockAgentCoreClientFactory implements BedrockAgentCoreCli
     }
 
     // apply HTTP proxy configuration (same as Bedrock LLM client)
-    builder.httpClient(proxySupport.createAwsHttpClientBuilder(endpointOverride).build());
+    builder.httpClientBuilder(proxySupport.createAwsHttpClientBuilder(endpointOverride));
 
     return builder.build();
   }

--- a/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/ChatModelFactoryTest.java
+++ b/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/ChatModelFactoryTest.java
@@ -11,7 +11,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import dev.langchain4j.model.chat.ChatModel;
 import io.camunda.connector.agenticai.aiagent.framework.langchain4j.provider.ChatModelProvider;
 import io.camunda.connector.agenticai.aiagent.framework.langchain4j.provider.ChatModelProviderRegistry;
 import io.camunda.connector.agenticai.aiagent.model.request.provider.AnthropicProviderConfiguration;
@@ -39,7 +38,7 @@ class ChatModelFactoryTest {
                 new AnthropicAuthentication("api-key"),
                 null,
                 new AnthropicModel("claude", null)));
-    final var expectedChatModel = mock(ChatModel.class);
+    final var expectedChatModel = mock(CloseableChatModel.class);
     final ChatModelProvider<ProviderConfiguration> provider = mock(ChatModelProvider.class);
     when(registry.getChatModelProvider(providerConfig)).thenReturn(provider);
     when(provider.createChatModel(providerConfig)).thenReturn(expectedChatModel);

--- a/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/ChatModelHttpProxySupportTest.java
+++ b/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/ChatModelHttpProxySupportTest.java
@@ -63,10 +63,10 @@ class ChatModelHttpProxySupportTest {
   }
 
   @Nested
-  class CreateJdkHttpClient {
+  class CreateJdkHttpClientBuilder {
 
     @Test
-    void shouldCreateJdkHttpClientWithProxyConfiguration() {
+    void shouldCreateJdkHttpClientBuilderWithProxyConfiguration() {
       // when
       ChatModelHttpProxySupport.CloseableJdkHttpClientBuilder result =
           proxySupport.createJdkHttpClientBuilder();

--- a/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/ChatModelHttpProxySupportTest.java
+++ b/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/ChatModelHttpProxySupportTest.java
@@ -17,7 +17,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.azure.core.http.ProxyOptions;
-import dev.langchain4j.http.client.jdk.JdkHttpClientBuilder;
 import io.camunda.connector.http.client.client.jdk.proxy.JdkHttpClientProxyConfigurator;
 import io.camunda.connector.http.client.proxy.NonProxyHosts;
 import io.camunda.connector.http.client.proxy.ProxyConfiguration;
@@ -64,15 +63,18 @@ class ChatModelHttpProxySupportTest {
   }
 
   @Nested
-  class CreateJdkHttpClientBuilder {
+  class CreateJdkHttpClient {
 
     @Test
-    void shouldCreateJdkHttpClientBuilderWithProxyConfiguration() {
+    void shouldCreateJdkHttpClientWithProxyConfiguration() {
       // when
-      JdkHttpClientBuilder result = proxySupport.createJdkHttpClientBuilder();
+      ChatModelHttpProxySupport.JdkHttpClientHandle result =
+          proxySupport.createJdkHttpClient(java.time.Duration.ofSeconds(15));
 
       // then
       assertThat(result).isNotNull();
+      assertThat(result.httpClient()).isNotNull();
+      assertThat(result.builder()).isNotNull();
       verify(jdkProxyConfigurator).configure(any(HttpClient.Builder.class));
     }
   }

--- a/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/ChatModelHttpProxySupportTest.java
+++ b/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/ChatModelHttpProxySupportTest.java
@@ -68,13 +68,11 @@ class ChatModelHttpProxySupportTest {
     @Test
     void shouldCreateJdkHttpClientWithProxyConfiguration() {
       // when
-      ChatModelHttpProxySupport.JdkHttpClientHandle result =
-          proxySupport.createJdkHttpClient(java.time.Duration.ofSeconds(15));
+      ChatModelHttpProxySupport.CloseableJdkHttpClientBuilder result =
+          proxySupport.createJdkHttpClientBuilder();
 
       // then
       assertThat(result).isNotNull();
-      assertThat(result.httpClient()).isNotNull();
-      assertThat(result.builder()).isNotNull();
       verify(jdkProxyConfigurator).configure(any(HttpClient.Builder.class));
     }
   }

--- a/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/CloseableChatModelDelegateTest.java
+++ b/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/CloseableChatModelDelegateTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.agenticai.aiagent.framework.langchain4j;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import dev.langchain4j.model.ModelProvider;
+import dev.langchain4j.model.chat.Capability;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.listener.ChatModelListener;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.request.ChatRequestParameters;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class CloseableChatModelDelegateTest {
+
+  @Mock private ChatModel delegate;
+  @Mock private AutoCloseable resource;
+
+  private CloseableChatModelDelegate subject;
+
+  @BeforeEach
+  void setUp() {
+    subject = new CloseableChatModelDelegate(delegate, resource);
+  }
+
+  @Test
+  void delegatesChatCallToDelegate() {
+    final var request = mock(ChatRequest.class);
+    final var response = mock(ChatResponse.class);
+    when(delegate.chat(request)).thenReturn(response);
+
+    assertThat(subject.chat(request)).isSameAs(response);
+    verify(delegate).chat(request);
+  }
+
+  @Test
+  void delegatesDefaultRequestParameters() {
+    final var params = mock(ChatRequestParameters.class);
+    when(delegate.defaultRequestParameters()).thenReturn(params);
+
+    assertThat(subject.defaultRequestParameters()).isSameAs(params);
+  }
+
+  @Test
+  void delegatesListeners() {
+    final var listener = mock(ChatModelListener.class);
+    when(delegate.listeners()).thenReturn(List.of(listener));
+
+    assertThat(subject.listeners()).containsExactly(listener);
+  }
+
+  @Test
+  void delegatesProvider() {
+    when(delegate.provider()).thenReturn(ModelProvider.AMAZON_BEDROCK);
+
+    assertThat(subject.provider()).isEqualTo(ModelProvider.AMAZON_BEDROCK);
+  }
+
+  @Test
+  void delegatesSupportedCapabilities() {
+    when(delegate.supportedCapabilities())
+        .thenReturn(Set.of(Capability.RESPONSE_FORMAT_JSON_SCHEMA));
+
+    assertThat(subject.supportedCapabilities())
+        .containsExactly(Capability.RESPONSE_FORMAT_JSON_SCHEMA);
+  }
+
+  @Test
+  void closesResource() throws Exception {
+    subject.close();
+
+    verify(resource).close();
+  }
+
+  @Test
+  void swallowsExceptionFromResourceClose() throws Exception {
+    doThrow(new RuntimeException("close failed")).when(resource).close();
+
+    assertThatNoException().isThrownBy(() -> subject.close());
+    verify(resource).close();
+  }
+}

--- a/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/Langchain4JAiFrameworkAdapterTest.java
+++ b/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/Langchain4JAiFrameworkAdapterTest.java
@@ -15,6 +15,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import dev.langchain4j.agent.tool.ToolSpecification;
@@ -297,6 +298,47 @@ class Langchain4JAiFrameworkAdapterTest {
     assertThat(adapterResponse.agentContext())
         .usingRecursiveComparison()
         .isEqualTo(AGENT_CONTEXT.withMetrics(AGENT_CONTEXT.metrics().withModelCalls(6)));
+  }
+
+  @Test
+  void closesChatModelAfterSuccessfulCall() throws Exception {
+    // chatModel.chat stub from @BeforeEach is unused — this test uses closeableChatModel
+    reset(chatModel);
+
+    final var closeableChatModel = mock(CloseableChatModel.class);
+    when(chatModelFactory.createChatModel(any())).thenReturn(closeableChatModel);
+    when(closeableChatModel.chat(any(ChatRequest.class))).thenReturn(chatResponse);
+
+    adapter.executeChatRequest(createExecutionContext(), AGENT_CONTEXT, runtimeMemory);
+
+    verify(closeableChatModel).close();
+  }
+
+  @Test
+  void closesChatModelEvenWhenChatCallThrows() throws Exception {
+    // chatModel.chat, chatResponse and toAssistantMessage stubs from @BeforeEach are unused here
+    reset(chatModel, chatResponse, chatMessageConverter);
+    when(chatMessageConverter.map(runtimeMemory.filteredMessages())).thenReturn(L4J_MESSAGES);
+
+    final var closeableChatModel = mock(CloseableChatModel.class);
+    when(chatModelFactory.createChatModel(any())).thenReturn(closeableChatModel);
+    doThrow(new RuntimeException("model unavailable"))
+        .when(closeableChatModel)
+        .chat(any(ChatRequest.class));
+
+    assertThatThrownBy(
+            () ->
+                adapter.executeChatRequest(createExecutionContext(), AGENT_CONTEXT, runtimeMemory))
+        .isInstanceOf(ConnectorException.class);
+
+    verify(closeableChatModel).close();
+  }
+
+  @Test
+  void doesNotAttemptToCloseNonCloseableChatModel() {
+    // chatModel from @BeforeEach is a plain ChatModel mock (not AutoCloseable)
+    adapter.executeChatRequest(createExecutionContext(), AGENT_CONTEXT, runtimeMemory);
+    // no exception expected — verifies the instanceof guard works
   }
 
   private AgentExecutionContext createExecutionContext() {

--- a/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/Langchain4JAiFrameworkAdapterTest.java
+++ b/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/Langchain4JAiFrameworkAdapterTest.java
@@ -22,7 +22,6 @@ import dev.langchain4j.agent.tool.ToolSpecification;
 import dev.langchain4j.data.message.ChatMessage;
 import dev.langchain4j.exception.ModelNotFoundException;
 import dev.langchain4j.exception.UnresolvedModelServerException;
-import dev.langchain4j.model.chat.ChatModel;
 import dev.langchain4j.model.chat.request.ChatRequest;
 import dev.langchain4j.model.chat.request.ResponseFormatType;
 import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
@@ -103,7 +102,7 @@ class Langchain4JAiFrameworkAdapterTest {
   @Mock private ToolSpecificationConverter toolSpecificationConverter;
   @Mock private JsonSchemaConverter jsonSchemaConverter;
 
-  @Mock private ChatModel chatModel;
+  @Mock private CloseableChatModel chatModel;
   @Mock private ChatResponse chatResponse;
 
   @Captor private ArgumentCaptor<ChatRequest> chatRequestCaptor;
@@ -302,43 +301,22 @@ class Langchain4JAiFrameworkAdapterTest {
 
   @Test
   void closesChatModelAfterSuccessfulCall() throws Exception {
-    // chatModel.chat stub from @BeforeEach is unused — this test uses closeableChatModel
-    reset(chatModel);
-
-    final var closeableChatModel = mock(CloseableChatModel.class);
-    when(chatModelFactory.createChatModel(any())).thenReturn(closeableChatModel);
-    when(closeableChatModel.chat(any(ChatRequest.class))).thenReturn(chatResponse);
-
     adapter.executeChatRequest(createExecutionContext(), AGENT_CONTEXT, runtimeMemory);
-
-    verify(closeableChatModel).close();
+    verify(chatModel).close();
   }
 
   @Test
   void closesChatModelEvenWhenChatCallThrows() throws Exception {
-    // chatModel.chat, chatResponse and toAssistantMessage stubs from @BeforeEach are unused here
     reset(chatModel, chatResponse, chatMessageConverter);
     when(chatMessageConverter.map(runtimeMemory.filteredMessages())).thenReturn(L4J_MESSAGES);
-
-    final var closeableChatModel = mock(CloseableChatModel.class);
-    when(chatModelFactory.createChatModel(any())).thenReturn(closeableChatModel);
-    doThrow(new RuntimeException("model unavailable"))
-        .when(closeableChatModel)
-        .chat(any(ChatRequest.class));
+    doThrow(new RuntimeException("model unavailable")).when(chatModel).chat(any(ChatRequest.class));
 
     assertThatThrownBy(
             () ->
                 adapter.executeChatRequest(createExecutionContext(), AGENT_CONTEXT, runtimeMemory))
         .isInstanceOf(ConnectorException.class);
 
-    verify(closeableChatModel).close();
-  }
-
-  @Test
-  void doesNotAttemptToCloseNonCloseableChatModel() {
-    // chatModel from @BeforeEach is a plain ChatModel mock (not AutoCloseable)
-    adapter.executeChatRequest(createExecutionContext(), AGENT_CONTEXT, runtimeMemory);
-    // no exception expected — verifies the instanceof guard works
+    verify(chatModel).close();
   }
 
   private AgentExecutionContext createExecutionContext() {

--- a/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/provider/AnthropicChatModelProviderTest.java
+++ b/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/provider/AnthropicChatModelProviderTest.java
@@ -6,7 +6,6 @@
  */
 package io.camunda.connector.agenticai.aiagent.framework.langchain4j.provider;
 
-import static io.camunda.connector.agenticai.aiagent.framework.langchain4j.provider.ChatModelProviderSupport.CONNECT_TIMEOUT;
 import static io.camunda.connector.agenticai.aiagent.framework.langchain4j.provider.ChatModelProviderTestSupport.MODEL_TIMEOUT;
 import static io.camunda.connector.agenticai.aiagent.framework.langchain4j.provider.ChatModelProviderTestSupport.createDefaultChatModelProperties;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -191,7 +190,7 @@ class AnthropicChatModelProviderTest {
       assertThat(((CloseableChatModelDelegate) chatModel).delegate())
           .isSameAs(chatModelResultCaptor.getResult());
 
-      verify(proxySupport).createJdkHttpClient(CONNECT_TIMEOUT);
+      verify(proxySupport).createJdkHttpClientBuilder();
       builderAssertions.accept(chatModelBuilder);
     }
   }

--- a/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/provider/AnthropicChatModelProviderTest.java
+++ b/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/provider/AnthropicChatModelProviderTest.java
@@ -6,6 +6,7 @@
  */
 package io.camunda.connector.agenticai.aiagent.framework.langchain4j.provider;
 
+import static io.camunda.connector.agenticai.aiagent.framework.langchain4j.provider.ChatModelProviderSupport.CONNECT_TIMEOUT;
 import static io.camunda.connector.agenticai.aiagent.framework.langchain4j.provider.ChatModelProviderTestSupport.MODEL_TIMEOUT;
 import static io.camunda.connector.agenticai.aiagent.framework.langchain4j.provider.ChatModelProviderTestSupport.createDefaultChatModelProperties;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -13,14 +14,18 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyDouble;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import dev.langchain4j.model.anthropic.AnthropicChatModel;
 import dev.langchain4j.model.anthropic.AnthropicChatModel.AnthropicChatModelBuilder;
 import io.camunda.connector.agenticai.aiagent.framework.langchain4j.ChatModelHttpProxySupport;
+import io.camunda.connector.agenticai.aiagent.framework.langchain4j.CloseableChatModel;
+import io.camunda.connector.agenticai.aiagent.framework.langchain4j.CloseableChatModelDelegate;
 import io.camunda.connector.agenticai.aiagent.framework.langchain4j.provider.ChatModelProviderTestSupport.ResultCaptor;
 import io.camunda.connector.agenticai.aiagent.model.request.provider.AnthropicProviderConfiguration;
 import io.camunda.connector.agenticai.aiagent.model.request.provider.AnthropicProviderConfiguration.AnthropicAuthentication;
@@ -30,6 +35,7 @@ import io.camunda.connector.agenticai.aiagent.model.request.provider.AnthropicPr
 import io.camunda.connector.agenticai.aiagent.model.request.provider.shared.TimeoutConfiguration;
 import io.camunda.connector.http.client.client.jdk.proxy.JdkHttpClientProxyConfigurator;
 import io.camunda.connector.http.client.proxy.ProxyConfiguration;
+import java.net.http.HttpClient;
 import java.time.Duration;
 import java.util.stream.Stream;
 import org.assertj.core.api.ThrowingConsumer;
@@ -140,6 +146,35 @@ class AnthropicChatModelProviderTest {
         providerConfig, (builder) -> verify(builder).timeout(Duration.ofMinutes(3)));
   }
 
+  @Test
+  void closingChatModelClosesHttpClient() throws Exception {
+    final var providerConfig =
+        new AnthropicProviderConfiguration(
+            new AnthropicConnection(
+                null,
+                new AnthropicAuthentication(ANTHROPIC_API_KEY),
+                MODEL_TIMEOUT,
+                new AnthropicModel(ANTHROPIC_MODEL, null)));
+
+    final var mockHttpClient = mock(HttpClient.class);
+    final var mockBuilder = mock(HttpClient.Builder.class, Answers.RETURNS_SELF);
+    when(mockBuilder.build()).thenReturn(mockHttpClient);
+
+    try (MockedStatic<HttpClient> httpClientMock =
+            mockStatic(HttpClient.class, Answers.CALLS_REAL_METHODS);
+        MockedStatic<AnthropicChatModel> chatModelMock =
+            mockStatic(AnthropicChatModel.class, Answers.CALLS_REAL_METHODS)) {
+      httpClientMock.when(HttpClient::newBuilder).thenReturn(mockBuilder);
+
+      final var chatModel = (CloseableChatModel) provider.createChatModel(providerConfig);
+      assertThat(chatModel).isInstanceOf(CloseableChatModel.class);
+
+      chatModel.close();
+
+      verify(mockHttpClient).close();
+    }
+  }
+
   private void testAnthropicChatModelBuilder(
       AnthropicProviderConfiguration providerConfig,
       ThrowingConsumer<AnthropicChatModelBuilder> builderAssertions) {
@@ -152,10 +187,11 @@ class AnthropicChatModelProviderTest {
       chatModelMock.when(AnthropicChatModel::builder).thenReturn(chatModelBuilder);
 
       final var chatModel = provider.createChatModel(providerConfig);
-      assertThat(chatModel).isNotNull().isInstanceOf(AnthropicChatModel.class);
-      assertThat(chatModel).isSameAs(chatModelResultCaptor.getResult());
+      assertThat(chatModel).isNotNull().isInstanceOf(CloseableChatModelDelegate.class);
+      assertThat(((CloseableChatModelDelegate) chatModel).delegate())
+          .isSameAs(chatModelResultCaptor.getResult());
 
-      verify(proxySupport).createJdkHttpClientBuilder();
+      verify(proxySupport).createJdkHttpClient(CONNECT_TIMEOUT);
       builderAssertions.accept(chatModelBuilder);
     }
   }

--- a/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/provider/AzureOpenAiChatModelProviderTest.java
+++ b/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/provider/AzureOpenAiChatModelProviderTest.java
@@ -22,6 +22,7 @@ import com.azure.core.credential.TokenCredential;
 import com.azure.identity.ClientSecretCredential;
 import dev.langchain4j.model.azure.AzureOpenAiChatModel;
 import io.camunda.connector.agenticai.aiagent.framework.langchain4j.ChatModelHttpProxySupport;
+import io.camunda.connector.agenticai.aiagent.framework.langchain4j.CloseableChatModelDelegate;
 import io.camunda.connector.agenticai.aiagent.framework.langchain4j.provider.ChatModelProviderTestSupport.ResultCaptor;
 import io.camunda.connector.agenticai.aiagent.model.request.provider.AzureOpenAiProviderConfiguration;
 import io.camunda.connector.agenticai.aiagent.model.request.provider.AzureOpenAiProviderConfiguration.AzureAuthentication.AzureApiKeyAuthentication;
@@ -173,8 +174,10 @@ class AzureOpenAiChatModelProviderTest {
       chatModelMock.when(AzureOpenAiChatModel::builder).thenReturn(chatModelBuilder);
 
       final var chatModel = provider.createChatModel(providerConfig);
-      assertThat(chatModel).isNotNull().isInstanceOf(AzureOpenAiChatModel.class);
-      assertThat(chatModel).isSameAs(chatModelResultCaptor.getResult());
+      assertThat(chatModel).isNotNull().isInstanceOf(CloseableChatModelDelegate.class);
+      final var delegate = ((CloseableChatModelDelegate) chatModel).delegate();
+      assertThat(delegate).isInstanceOf(AzureOpenAiChatModel.class);
+      assertThat(delegate).isSameAs(chatModelResultCaptor.getResult());
 
       verify(proxySupport).createAzureProxyOptions(AZURE_OPENAI_ENDPOINT);
       verify(chatModelBuilder).endpoint(AZURE_OPENAI_ENDPOINT);

--- a/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/provider/BedrockChatModelProviderTest.java
+++ b/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/provider/BedrockChatModelProviderTest.java
@@ -12,6 +12,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
@@ -21,6 +22,8 @@ import dev.langchain4j.model.bedrock.BedrockChatModel;
 import dev.langchain4j.model.bedrock.BedrockChatRequestParameters;
 import dev.langchain4j.model.chat.request.ChatRequestParameters;
 import io.camunda.connector.agenticai.aiagent.framework.langchain4j.ChatModelHttpProxySupport;
+import io.camunda.connector.agenticai.aiagent.framework.langchain4j.CloseableChatModel;
+import io.camunda.connector.agenticai.aiagent.framework.langchain4j.CloseableChatModelDelegate;
 import io.camunda.connector.agenticai.aiagent.framework.langchain4j.provider.ChatModelProviderTestSupport.ResultCaptor;
 import io.camunda.connector.agenticai.aiagent.model.request.provider.BedrockProviderConfiguration;
 import io.camunda.connector.agenticai.aiagent.model.request.provider.BedrockProviderConfiguration.AwsAuthentication;
@@ -241,6 +244,36 @@ class BedrockChatModelProviderTest {
         (builder) -> verify(builder.chatModelBuilder).timeout(Duration.ofMinutes(3)));
   }
 
+  @Test
+  void closingChatModelClosesBedrockRuntimeClient() {
+    final var providerConfig =
+        new BedrockProviderConfiguration(
+            new BedrockConnection(
+                BEDROCK_REGION,
+                null,
+                new AwsAuthentication.AwsDefaultCredentialsChainAuthentication(),
+                MODEL_TIMEOUT,
+                new BedrockModel(BEDROCK_MODEL, null)));
+
+    final var mockClient = mock(BedrockRuntimeClient.class);
+    final var clientBuilder = spy(BedrockRuntimeClient.builder());
+    doAnswer(inv -> mockClient).when(clientBuilder).build();
+
+    try (MockedStatic<BedrockRuntimeClient> clientMock =
+            mockStatic(BedrockRuntimeClient.class, Answers.CALLS_REAL_METHODS);
+        MockedStatic<BedrockChatModel> chatModelMock =
+            mockStatic(BedrockChatModel.class, Answers.CALLS_REAL_METHODS)) {
+      clientMock.when(BedrockRuntimeClient::builder).thenReturn(clientBuilder);
+
+      final var chatModel = provider.createChatModel(providerConfig);
+      assertThat(chatModel).isInstanceOf(CloseableChatModel.class);
+
+      chatModel.close();
+
+      verify(mockClient).close();
+    }
+  }
+
   private void testCreateBedrockChatModelWithCredentials(
       BedrockProviderConfiguration providerConfig,
       ThrowingConsumer<AwsCredentialsProvider> credentialsProviderAssertions) {
@@ -297,8 +330,11 @@ class BedrockChatModelProviderTest {
           new BedrockBuilderContext(clientBuilder, clientResultCaptor, chatModelBuilder);
 
       final var chatModel = provider.createChatModel(providerConfig);
-      assertThat(chatModel).isNotNull().isInstanceOf(BedrockChatModel.class);
-      assertThat(chatModel).isSameAs(chatModelResultCaptor.getResult());
+      assertThat(chatModel).isNotNull().isInstanceOf(CloseableChatModel.class);
+      assertThat(((CloseableChatModelDelegate) chatModel).delegate())
+          .isSameAs(chatModelResultCaptor.getResult());
+      assertThat(((CloseableChatModelDelegate) chatModel).resource())
+          .isSameAs(clientResultCaptor.getResult());
 
       verify(proxySupport).createAwsHttpClientBuilder(expectedEndpointOverride);
       builderAssertions.accept(builders);

--- a/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/provider/GoogleVertexAiChatModelProviderTest.java
+++ b/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/provider/GoogleVertexAiChatModelProviderTest.java
@@ -130,6 +130,13 @@ class GoogleVertexAiChatModelProviderTest {
     }
   }
 
+  @Test
+  void vertexAiGeminiChatModelImplementsAutoCloseable() {
+    // VertexAiGeminiChatModel implements Closeable; the adapter closes it via instanceof check.
+    // This test guards against a future langchain4j upgrade silently removing that interface.
+    assertThat(AutoCloseable.class.isAssignableFrom(VertexAiGeminiChatModel.class)).isTrue();
+  }
+
   private void testGoogleVertexAiChatModelBuilder(
       GoogleVertexAiProviderConfiguration providerConfig,
       ThrowingConsumer<VertexAiGeminiChatModelBuilder> builderAssertions) {

--- a/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/provider/GoogleVertexAiChatModelProviderTest.java
+++ b/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/provider/GoogleVertexAiChatModelProviderTest.java
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.when;
 import com.google.auth.oauth2.ServiceAccountCredentials;
 import dev.langchain4j.model.vertexai.gemini.VertexAiGeminiChatModel;
 import dev.langchain4j.model.vertexai.gemini.VertexAiGeminiChatModel.VertexAiGeminiChatModelBuilder;
+import io.camunda.connector.agenticai.aiagent.framework.langchain4j.CloseableChatModelDelegate;
 import io.camunda.connector.agenticai.aiagent.framework.langchain4j.provider.ChatModelProviderTestSupport.ResultCaptor;
 import io.camunda.connector.agenticai.aiagent.model.request.provider.GoogleVertexAiProviderConfiguration;
 import io.camunda.connector.agenticai.aiagent.model.request.provider.GoogleVertexAiProviderConfiguration.GoogleVertexAiAuthentication.ApplicationDefaultCredentialsAuthentication;
@@ -132,9 +133,10 @@ class GoogleVertexAiChatModelProviderTest {
 
   @Test
   void vertexAiGeminiChatModelImplementsAutoCloseable() {
-    // VertexAiGeminiChatModel implements Closeable; the adapter closes it via instanceof check.
-    // This test guards against a future langchain4j upgrade silently removing that interface.
-    assertThat(AutoCloseable.class.isAssignableFrom(VertexAiGeminiChatModel.class)).isTrue();
+    // VertexAiGeminiChatModel implements Closeable; the provider passes it as the resource to
+    // CloseableChatModelDelegate. This test guards against a future langchain4j upgrade silently
+    // removing that interface, which would make the close() call a no-op.
+    assertThat(VertexAiGeminiChatModel.class).isAssignableTo(AutoCloseable.class);
   }
 
   private void testGoogleVertexAiChatModelBuilder(
@@ -149,8 +151,10 @@ class GoogleVertexAiChatModelProviderTest {
       chatModelMock.when(VertexAiGeminiChatModel::builder).thenReturn(chatModelBuilder);
 
       final var chatModel = provider.createChatModel(providerConfig);
-      assertThat(chatModel).isNotNull().isInstanceOf(VertexAiGeminiChatModel.class);
-      assertThat(chatModel).isSameAs(chatModelResultCaptor.getResult());
+      assertThat(chatModel).isNotNull().isInstanceOf(CloseableChatModelDelegate.class);
+      final var delegate = ((CloseableChatModelDelegate) chatModel).delegate();
+      assertThat(delegate).isInstanceOf(VertexAiGeminiChatModel.class);
+      assertThat(delegate).isSameAs(chatModelResultCaptor.getResult());
 
       builderAssertions.accept(chatModelBuilder);
     }

--- a/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/provider/OpenAiChatModelProviderTest.java
+++ b/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/provider/OpenAiChatModelProviderTest.java
@@ -6,7 +6,6 @@
  */
 package io.camunda.connector.agenticai.aiagent.framework.langchain4j.provider;
 
-import static io.camunda.connector.agenticai.aiagent.framework.langchain4j.provider.ChatModelProviderSupport.CONNECT_TIMEOUT;
 import static io.camunda.connector.agenticai.aiagent.framework.langchain4j.provider.ChatModelProviderTestSupport.MODEL_TIMEOUT;
 import static io.camunda.connector.agenticai.aiagent.framework.langchain4j.provider.ChatModelProviderTestSupport.createDefaultChatModelProperties;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -206,7 +205,7 @@ class OpenAiChatModelProviderTest {
       assertThat(((CloseableChatModelDelegate) chatModel).delegate())
           .isSameAs(chatModelResultCaptor.getResult());
 
-      verify(proxySupport).createJdkHttpClient(CONNECT_TIMEOUT);
+      verify(proxySupport).createJdkHttpClientBuilder();
       builderAssertions.accept(chatModelBuilder);
     }
   }

--- a/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/provider/OpenAiChatModelProviderTest.java
+++ b/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/provider/OpenAiChatModelProviderTest.java
@@ -6,20 +6,25 @@
  */
 package io.camunda.connector.agenticai.aiagent.framework.langchain4j.provider;
 
+import static io.camunda.connector.agenticai.aiagent.framework.langchain4j.provider.ChatModelProviderSupport.CONNECT_TIMEOUT;
 import static io.camunda.connector.agenticai.aiagent.framework.langchain4j.provider.ChatModelProviderTestSupport.MODEL_TIMEOUT;
 import static io.camunda.connector.agenticai.aiagent.framework.langchain4j.provider.ChatModelProviderTestSupport.createDefaultChatModelProperties;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import dev.langchain4j.model.openai.OpenAiChatModel;
 import dev.langchain4j.model.openai.OpenAiChatModel.OpenAiChatModelBuilder;
 import dev.langchain4j.model.openai.OpenAiChatRequestParameters;
 import io.camunda.connector.agenticai.aiagent.framework.langchain4j.ChatModelHttpProxySupport;
+import io.camunda.connector.agenticai.aiagent.framework.langchain4j.CloseableChatModel;
+import io.camunda.connector.agenticai.aiagent.framework.langchain4j.CloseableChatModelDelegate;
 import io.camunda.connector.agenticai.aiagent.framework.langchain4j.provider.ChatModelProviderTestSupport.ResultCaptor;
 import io.camunda.connector.agenticai.aiagent.model.request.provider.OpenAiProviderConfiguration;
 import io.camunda.connector.agenticai.aiagent.model.request.provider.OpenAiProviderConfiguration.OpenAiConnection;
@@ -27,6 +32,7 @@ import io.camunda.connector.agenticai.aiagent.model.request.provider.OpenAiProvi
 import io.camunda.connector.agenticai.aiagent.model.request.provider.shared.TimeoutConfiguration;
 import io.camunda.connector.http.client.client.jdk.proxy.JdkHttpClientProxyConfigurator;
 import io.camunda.connector.http.client.proxy.ProxyConfiguration;
+import java.net.http.HttpClient;
 import java.time.Duration;
 import java.util.stream.Stream;
 import org.assertj.core.api.ThrowingConsumer;
@@ -156,6 +162,34 @@ class OpenAiChatModelProviderTest {
         providerConfig, (builder) -> verify(builder).timeout(Duration.ofMinutes(3)));
   }
 
+  @Test
+  void closingChatModelClosesHttpClient() throws Exception {
+    final var providerConfig =
+        new OpenAiProviderConfiguration(
+            new OpenAiConnection(
+                new OpenAiProviderConfiguration.OpenAiAuthentication(OPEN_AI_API_KEY, null, null),
+                MODEL_TIMEOUT,
+                new OpenAiProviderConfiguration.OpenAiModel(OPEN_AI_MODEL, null)));
+
+    final var mockHttpClient = mock(HttpClient.class);
+    final var mockBuilder = mock(HttpClient.Builder.class, Answers.RETURNS_SELF);
+    when(mockBuilder.build()).thenReturn(mockHttpClient);
+
+    try (MockedStatic<HttpClient> httpClientMock =
+            mockStatic(HttpClient.class, Answers.CALLS_REAL_METHODS);
+        MockedStatic<OpenAiChatModel> chatModelMock =
+            mockStatic(OpenAiChatModel.class, Answers.CALLS_REAL_METHODS)) {
+      httpClientMock.when(HttpClient::newBuilder).thenReturn(mockBuilder);
+
+      final var chatModel = (CloseableChatModel) provider.createChatModel(providerConfig);
+      assertThat(chatModel).isInstanceOf(CloseableChatModel.class);
+
+      chatModel.close();
+
+      verify(mockHttpClient).close();
+    }
+  }
+
   private void testOpenAiChatModelBuilder(
       OpenAiProviderConfiguration providerConfig,
       ThrowingConsumer<OpenAiChatModelBuilder> builderAssertions) {
@@ -168,10 +202,11 @@ class OpenAiChatModelProviderTest {
       chatModelMock.when(OpenAiChatModel::builder).thenReturn(chatModelBuilder);
 
       final var chatModel = provider.createChatModel(providerConfig);
-      assertThat(chatModel).isNotNull().isInstanceOf(OpenAiChatModel.class);
-      assertThat(chatModel).isSameAs(chatModelResultCaptor.getResult());
+      assertThat(chatModel).isNotNull().isInstanceOf(CloseableChatModelDelegate.class);
+      assertThat(((CloseableChatModelDelegate) chatModel).delegate())
+          .isSameAs(chatModelResultCaptor.getResult());
 
-      verify(proxySupport).createJdkHttpClientBuilder();
+      verify(proxySupport).createJdkHttpClient(CONNECT_TIMEOUT);
       builderAssertions.accept(chatModelBuilder);
     }
   }

--- a/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/provider/OpenAiCompatibleChatModelProviderTest.java
+++ b/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/provider/OpenAiCompatibleChatModelProviderTest.java
@@ -6,7 +6,6 @@
  */
 package io.camunda.connector.agenticai.aiagent.framework.langchain4j.provider;
 
-import static io.camunda.connector.agenticai.aiagent.framework.langchain4j.provider.ChatModelProviderSupport.CONNECT_TIMEOUT;
 import static io.camunda.connector.agenticai.aiagent.framework.langchain4j.provider.ChatModelProviderTestSupport.MODEL_TIMEOUT;
 import static io.camunda.connector.agenticai.aiagent.framework.langchain4j.provider.ChatModelProviderTestSupport.createDefaultChatModelProperties;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -300,7 +299,7 @@ class OpenAiCompatibleChatModelProviderTest {
       assertThat(((CloseableChatModelDelegate) chatModel).delegate())
           .isSameAs(chatModelResultCaptor.getResult());
 
-      verify(proxySupport).createJdkHttpClient(CONNECT_TIMEOUT);
+      verify(proxySupport).createJdkHttpClientBuilder();
       builderAssertions.accept(chatModelBuilder);
     }
   }

--- a/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/provider/OpenAiCompatibleChatModelProviderTest.java
+++ b/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/provider/OpenAiCompatibleChatModelProviderTest.java
@@ -6,6 +6,7 @@
  */
 package io.camunda.connector.agenticai.aiagent.framework.langchain4j.provider;
 
+import static io.camunda.connector.agenticai.aiagent.framework.langchain4j.provider.ChatModelProviderSupport.CONNECT_TIMEOUT;
 import static io.camunda.connector.agenticai.aiagent.framework.langchain4j.provider.ChatModelProviderTestSupport.MODEL_TIMEOUT;
 import static io.camunda.connector.agenticai.aiagent.framework.langchain4j.provider.ChatModelProviderTestSupport.createDefaultChatModelProperties;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -13,15 +14,19 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import dev.langchain4j.model.openai.OpenAiChatModel;
 import dev.langchain4j.model.openai.OpenAiChatModel.OpenAiChatModelBuilder;
 import dev.langchain4j.model.openai.OpenAiChatRequestParameters;
 import io.camunda.connector.agenticai.aiagent.framework.langchain4j.ChatModelHttpProxySupport;
+import io.camunda.connector.agenticai.aiagent.framework.langchain4j.CloseableChatModel;
+import io.camunda.connector.agenticai.aiagent.framework.langchain4j.CloseableChatModelDelegate;
 import io.camunda.connector.agenticai.aiagent.framework.langchain4j.provider.ChatModelProviderTestSupport.ResultCaptor;
 import io.camunda.connector.agenticai.aiagent.model.request.provider.OpenAiCompatibleProviderConfiguration;
 import io.camunda.connector.agenticai.aiagent.model.request.provider.OpenAiCompatibleProviderConfiguration.OpenAiCompatibleConnection;
@@ -29,6 +34,7 @@ import io.camunda.connector.agenticai.aiagent.model.request.provider.OpenAiCompa
 import io.camunda.connector.agenticai.aiagent.model.request.provider.shared.TimeoutConfiguration;
 import io.camunda.connector.http.client.client.jdk.proxy.JdkHttpClientProxyConfigurator;
 import io.camunda.connector.http.client.proxy.ProxyConfiguration;
+import java.net.http.HttpClient;
 import java.time.Duration;
 import java.util.Collections;
 import java.util.Map;
@@ -247,6 +253,37 @@ class OpenAiCompatibleChatModelProviderTest {
         });
   }
 
+  @Test
+  void closingChatModelClosesHttpClient() throws Exception {
+    final var providerConfig =
+        new OpenAiCompatibleProviderConfiguration(
+            new OpenAiCompatibleConnection(
+                ENDPOINT,
+                null,
+                null,
+                null,
+                MODEL_TIMEOUT,
+                new OpenAiCompatibleProviderConfiguration.OpenAiCompatibleModel(MODEL, null)));
+
+    final var mockHttpClient = mock(HttpClient.class);
+    final var mockBuilder = mock(HttpClient.Builder.class, Answers.RETURNS_SELF);
+    when(mockBuilder.build()).thenReturn(mockHttpClient);
+
+    try (MockedStatic<HttpClient> httpClientMock =
+            mockStatic(HttpClient.class, Answers.CALLS_REAL_METHODS);
+        MockedStatic<OpenAiChatModel> chatModelMock =
+            mockStatic(OpenAiChatModel.class, Answers.CALLS_REAL_METHODS)) {
+      httpClientMock.when(HttpClient::newBuilder).thenReturn(mockBuilder);
+
+      final var chatModel = (CloseableChatModel) provider.createChatModel(providerConfig);
+      assertThat(chatModel).isInstanceOf(CloseableChatModel.class);
+
+      chatModel.close();
+
+      verify(mockHttpClient).close();
+    }
+  }
+
   private void testOpenAiCompatibleChatModelBuilder(
       OpenAiCompatibleProviderConfiguration providerConfig,
       ThrowingConsumer<OpenAiChatModelBuilder> builderAssertions) {
@@ -259,10 +296,11 @@ class OpenAiCompatibleChatModelProviderTest {
       chatModelMock.when(OpenAiChatModel::builder).thenReturn(chatModelBuilder);
 
       final var chatModel = provider.createChatModel(providerConfig);
-      assertThat(chatModel).isNotNull().isInstanceOf(OpenAiChatModel.class);
-      assertThat(chatModel).isSameAs(chatModelResultCaptor.getResult());
+      assertThat(chatModel).isNotNull().isInstanceOf(CloseableChatModelDelegate.class);
+      assertThat(((CloseableChatModelDelegate) chatModel).delegate())
+          .isSameAs(chatModelResultCaptor.getResult());
 
-      verify(proxySupport).createJdkHttpClientBuilder();
+      verify(proxySupport).createJdkHttpClient(CONNECT_TIMEOUT);
       builderAssertions.accept(chatModelBuilder);
     }
   }

--- a/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/autoconfigure/AgenticAiConnectorsAutoConfigurationTest.java
+++ b/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/autoconfigure/AgenticAiConnectorsAutoConfigurationTest.java
@@ -11,7 +11,6 @@ import static io.camunda.connector.agenticai.autoconfigure.ApplicationContextAss
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
-import dev.langchain4j.model.chat.ChatModel;
 import io.camunda.connector.agenticai.adhoctoolsschema.AdHocToolsSchemaFunction;
 import io.camunda.connector.agenticai.adhoctoolsschema.processdefinition.CachingProcessDefinitionAdHocToolElementsResolver;
 import io.camunda.connector.agenticai.adhoctoolsschema.processdefinition.CamundaClientProcessDefinitionAdHocToolElementsResolver;
@@ -31,6 +30,7 @@ import io.camunda.connector.agenticai.aiagent.agent.OutboundConnectorAgentReques
 import io.camunda.connector.agenticai.aiagent.framework.langchain4j.ChatMessageConverter;
 import io.camunda.connector.agenticai.aiagent.framework.langchain4j.ChatModelFactory;
 import io.camunda.connector.agenticai.aiagent.framework.langchain4j.ChatModelHttpProxySupport;
+import io.camunda.connector.agenticai.aiagent.framework.langchain4j.CloseableChatModel;
 import io.camunda.connector.agenticai.aiagent.framework.langchain4j.ContentConverter;
 import io.camunda.connector.agenticai.aiagent.framework.langchain4j.Langchain4JAiFrameworkAdapter;
 import io.camunda.connector.agenticai.aiagent.framework.langchain4j.document.DocumentToContentConverter;
@@ -367,8 +367,9 @@ class AgenticAiConnectorsAutoConfigurationTest {
         }
 
         @Override
-        public ChatModel createChatModel(AnthropicProviderConfiguration providerConfiguration) {
-          return mock(ChatModel.class);
+        public CloseableChatModel createChatModel(
+            AnthropicProviderConfiguration providerConfiguration) {
+          return mock(CloseableChatModel.class);
         }
       }
     }
@@ -388,8 +389,9 @@ class AgenticAiConnectorsAutoConfigurationTest {
         }
 
         @Override
-        public ChatModel createChatModel(AzureOpenAiProviderConfiguration providerConfiguration) {
-          return mock(ChatModel.class);
+        public CloseableChatModel createChatModel(
+            AzureOpenAiProviderConfiguration providerConfiguration) {
+          return mock(CloseableChatModel.class);
         }
       }
     }
@@ -409,8 +411,9 @@ class AgenticAiConnectorsAutoConfigurationTest {
         }
 
         @Override
-        public ChatModel createChatModel(BedrockProviderConfiguration providerConfiguration) {
-          return mock(ChatModel.class);
+        public CloseableChatModel createChatModel(
+            BedrockProviderConfiguration providerConfiguration) {
+          return mock(CloseableChatModel.class);
         }
       }
     }
@@ -431,9 +434,9 @@ class AgenticAiConnectorsAutoConfigurationTest {
         }
 
         @Override
-        public ChatModel createChatModel(
+        public CloseableChatModel createChatModel(
             GoogleVertexAiProviderConfiguration providerConfiguration) {
-          return mock(ChatModel.class);
+          return mock(CloseableChatModel.class);
         }
       }
     }
@@ -453,8 +456,9 @@ class AgenticAiConnectorsAutoConfigurationTest {
         }
 
         @Override
-        public ChatModel createChatModel(OpenAiProviderConfiguration providerConfiguration) {
-          return mock(ChatModel.class);
+        public CloseableChatModel createChatModel(
+            OpenAiProviderConfiguration providerConfiguration) {
+          return mock(CloseableChatModel.class);
         }
       }
     }
@@ -475,9 +479,9 @@ class AgenticAiConnectorsAutoConfigurationTest {
         }
 
         @Override
-        public ChatModel createChatModel(
+        public CloseableChatModel createChatModel(
             OpenAiCompatibleProviderConfiguration providerConfiguration) {
-          return mock(ChatModel.class);
+          return mock(CloseableChatModel.class);
         }
       }
     }


### PR DESCRIPTION
## Description

AI Agent connectors were potentially leaking HTTP client resources because ChatModel instances created per-request and their delegates were never closed. This fix makes all provider-created chat models closeable and ensures cleanup after each connector invocation.

Changes:
* Introduce `CloseableChatModel` / `CloseableChatModelDelegate` to pair a ChatModel with its underlying HTTP client resource
* Bedrock: switch from httpClient() to httpClientBuilder() so the AWS SDK owns the client lifecycle and closes it when the BedrockRuntimeClient closes
* OpenAI / Anthropic / OpenAI-compatible: introduce CloseableJdkHttpClientBuilder — extends JdkHttpClientBuilder and implements AutoCloseable; captures the JDK HttpClient produced during model construction and closes it on cleanup. All HttpClient.Builder calls are forwarded to the real builder so any configuration langchain4j applies takes effect
* Azure OpenAI is out-of-scope due to its internal implementation
* Vertex AI already implements `CloseableChatModel` and will be closed by our adapter
* `Langchain4JAiFrameworkAdapter` closes the chat model after each invocation

See also (for example) https://docs.aws.amazon.com/java/api/latest/software/amazon/awssdk/core/client/builder/SdkSyncClientBuilder.html#httpClient(software.amazon.awssdk.http.SdkHttpClient)

## Checklist

- [x] Backport labels are added if these code changes should be backported. No backport label is added to the latest
  release, as this branch will be rebased onto main before the next release. Example backport labels:
    - `backport stable/8.8`: for changes that should be included in the next 8.8.x release.
    - **or** `backport release-8.8.7`: for changes that should be included in the specific release 8.8.7, and this
      *release has already been created*. The release branch will be merged back into stable/8.8 later, so the change
      will be included in future 8.8.x releases as well.
- [ ] Tests/Integration tests for the changes have been added if applicable.
- [ ] If the change requires a documentation update, it has been added to the appropriate section in the documentation.


