### PR TITLE
fix(uniquet): skip non-JSON files and surface errors

### DIFF
--- a/element-template-generator/uniquet/pom.xml
+++ b/element-template-generator/uniquet/pom.xml
@@ -54,7 +54,7 @@
 
     <dependency>
       <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-nop</artifactId>
+      <artifactId>slf4j-simple</artifactId>
     </dependency>
 
     <dependency>
@@ -112,7 +112,7 @@
             <id>analyze-dependencies</id>
             <configuration>
               <ignoredDependencies>
-                <ignoredDependency>org.slf4j:slf4j-nop</ignoredDependency>
+                <ignoredDependency>org.slf4j:slf4j-simple</ignoredDependency>
               </ignoredDependencies>
             </configuration>
           </execution>

--- a/element-template-generator/uniquet/src/main/java/io/camunda/connector/uniquet/core/ConnectorsFinder.java
+++ b/element-template-generator/uniquet/src/main/java/io/camunda/connector/uniquet/core/ConnectorsFinder.java
@@ -35,6 +35,7 @@ public class ConnectorsFinder {
 
   private static final String ELEMENT_TEMPLATES = "element-templates";
   private static final String VERSIONED = "versioned";
+  private static final String JSON_EXTENSION = ".json";
   private final List<Connector> connectors;
   private static final ObjectMapper objectMapper = new ObjectMapper();
   private List<String> IGNORED_TEMPLATE_IDS = new ArrayList<>();
@@ -83,11 +84,13 @@ public class ConnectorsFinder {
             versionedDirectory ->
                 Arrays.stream(files)
                     .filter(File::isFile)
+                    .filter(ConnectorsFinder::isJsonFile)
                     .filter(this::isIgnoredTemplate)
                     .map(currentFile -> this.mapToConnector(currentFile, versionedDirectory)))
         .orElse(
             Arrays.stream(files)
                 .filter(File::isFile)
+                .filter(ConnectorsFinder::isJsonFile)
                 .filter(this::isIgnoredTemplate)
                 .map(currentFile -> new Connector(currentFile, List.of())));
   }
@@ -96,8 +99,14 @@ public class ConnectorsFinder {
     return new Connector(
         current,
         Arrays.stream(Objects.requireNonNull(versionedDirectory.listFiles()))
+            .filter(File::isFile)
+            .filter(ConnectorsFinder::isJsonFile)
             .filter(file -> getBaseName(file).contains(getBaseName(current)))
             .toList());
+  }
+
+  private static boolean isJsonFile(File file) {
+    return file.getName().endsWith(JSON_EXTENSION);
   }
 
   private boolean containsElementTemplates(File directory) {

--- a/element-template-generator/uniquet/src/test/java/io/camunda/connector/uniquet/core/ConnectorsFinderTest.java
+++ b/element-template-generator/uniquet/src/test/java/io/camunda/connector/uniquet/core/ConnectorsFinderTest.java
@@ -43,6 +43,22 @@ class ConnectorsFinderTest {
   }
 
   @Test
+  void nonJsonFilesAreIgnored() {
+    // README.md files exist alongside the JSON templates in element-templates/ and
+    // element-templates/versioned/; ConnectorsFinder must skip them without throwing.
+    ConnectorsFinder connectorsFinder =
+        ConnectorsFinder.create(Path.of("src/test/resources"), null);
+    List<Connector> connectors = connectorsFinder.getAllConnectors();
+    assertEquals(1, connectors.size());
+    connectors.forEach(
+        c -> {
+          assertTrue(c.currentElementTemplate().getName().endsWith(".json"));
+          c.versionedElementTemplate()
+              .forEach(v -> assertTrue(v.getName().endsWith(".json")));
+        });
+  }
+
+  @Test
   void next() {
     ConnectorsFinder connectorsFinder =
         ConnectorsFinder.create(Path.of("src/test/resources"), null);

--- a/element-template-generator/uniquet/src/test/java/io/camunda/connector/uniquet/core/ConnectorsFinderTest.java
+++ b/element-template-generator/uniquet/src/test/java/io/camunda/connector/uniquet/core/ConnectorsFinderTest.java
@@ -53,8 +53,7 @@ class ConnectorsFinderTest {
     connectors.forEach(
         c -> {
           assertTrue(c.currentElementTemplate().getName().endsWith(".json"));
-          c.versionedElementTemplate()
-              .forEach(v -> assertTrue(v.getName().endsWith(".json")));
+          c.versionedElementTemplate().forEach(v -> assertTrue(v.getName().endsWith(".json")));
         });
   }
 

--- a/element-template-generator/uniquet/src/test/resources/connectors/element-templates/README.md
+++ b/element-template-generator/uniquet/src/test/resources/connectors/element-templates/README.md
@@ -1,0 +1,3 @@
+# Element Templates
+
+This directory contains element templates for the SOAP connector.

--- a/element-template-generator/uniquet/src/test/resources/connectors/element-templates/versioned/README.md
+++ b/element-template-generator/uniquet/src/test/resources/connectors/element-templates/versioned/README.md
@@ -1,0 +1,3 @@
+# Versioned Element Templates
+
+This directory contains versioned element templates for the SOAP connector.


### PR DESCRIPTION
## Summary

The `Run uniquet and push` workflow has been failing silently with `exit code 1` since [run 25724199472](https://github.com/camunda/connectors/actions/runs/25724199472) (May 12). Most recent failure: [run 26021480013](https://github.com/camunda/connectors/actions/runs/26021480013/job/76483899322).

Two issues:

1. **Root cause** — `ConnectorsFinder.findVersionedConnectors` streamed every file under `element-templates/` and passed it to Jackson via `isIgnoredTemplate`. The `README.md` added under `connectors/agentic-ai/element-templates/` in #7006 starts with `#`, so `ObjectMapper.readTree` threw `JsonParseException: Unexpected character ('#' (code 35))` and `ConnectorsFinder` wrapped it as a `RuntimeException`.
2. **Why the CI log was empty** — uniquet shipped `slf4j-nop`, so the `log.atError().log(...)` call in `UniquetCommand` discarded the error message entirely. That's why the job showed exit 1 with no diagnostic.

## Changes

- `ConnectorsFinder`: only consider `.json` files when collecting current and versioned templates (also applied in `mapToConnector`).
- `uniquet/pom.xml`: swap `slf4j-nop` for `slf4j-simple` so future errors actually reach stderr.

## Test plan
- [x] Local: `mvn test` in `element-template-generator/uniquet` — 4/4 pass.
- [x] Local: run the appassembler binary against the repo — produces a 141KB `connector-templates.json`, no exception.
- [ ] Re-trigger the `Run uniquet and push` workflow on `main` (or this branch) after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)