### PR TITLE
test: fix E2E tests that uses OIDC mock server

### DIFF
--- a/bundle/camunda-saas-bundle/pom.xml
+++ b/bundle/camunda-saas-bundle/pom.xml
@@ -142,11 +142,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>io.camunda</groupId>
-      <artifactId>camunda-process-test-spring</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-test</artifactId>
       <scope>test</scope>

--- a/bundle/camunda-saas-bundle/src/test/java/io/camunda/connector/runtime/saas/InboundInstancesSecurityConfigurationTest.java
+++ b/bundle/camunda-saas-bundle/src/test/java/io/camunda/connector/runtime/saas/InboundInstancesSecurityConfigurationTest.java
@@ -20,11 +20,9 @@ import static org.springframework.security.test.web.servlet.request.SecurityMock
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import io.camunda.connector.test.utils.annotation.SlowTest;
+import io.camunda.client.CamundaClient;
 import io.camunda.connector.test.utils.oidc.MockOidcServer;
-import io.camunda.process.test.api.CamundaSpringProcessTest;
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.mockito.Answers;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -52,13 +50,14 @@ import org.springframework.test.web.servlet.MockMvc;
       "camunda.connector.secretprovider.discovery.enabled=false",
       "management.endpoints.web.exposure.include=*",
       "camunda.client.auth.audience=connectors.dev.ultrawombat.com",
+      "camunda.client.auth.token-url=http://localhost:0/not-used",
+      "camunda.client.auth.client-id=test",
+      "camunda.client.auth.client-secret=test",
       "spring.cloud.gcp.parametermanager.enabled=false"
     })
 @DirtiesContext
 @ActiveProfiles("test")
 @AutoConfigureMockMvc
-@CamundaSpringProcessTest
-@SlowTest
 public class InboundInstancesSecurityConfigurationTest {
 
   private static final MockOidcServer OIDC_SERVER = MockOidcServer.start();
@@ -66,16 +65,6 @@ public class InboundInstancesSecurityConfigurationTest {
   @DynamicPropertySource
   static void registerOidcProperties(DynamicPropertyRegistry registry) {
     registry.add("camunda.connector.auth.issuer", OIDC_SERVER::issuer);
-    registry.add("camunda.client.auth.token-url", OIDC_SERVER::tokenUrl);
-  }
-
-  @BeforeAll
-  static void beforeAll() {
-    OIDC_SERVER.stubTokenResponse(
-        200,
-        """
-        {"access_token":"test-token","token_type":"Bearer","expires_in":3600}
-        """);
   }
 
   @AfterAll
@@ -85,6 +74,9 @@ public class InboundInstancesSecurityConfigurationTest {
 
   @MockitoBean(answers = Answers.RETURNS_MOCKS)
   public SaaSSecretConfiguration saaSSecretConfiguration;
+
+  @MockitoBean(answers = Answers.RETURNS_DEEP_STUBS)
+  public CamundaClient camundaClient;
 
   @Autowired private MockMvc mvc;
 

--- a/bundle/camunda-saas-bundle/src/test/java/io/camunda/connector/runtime/saas/SecurityConfigurationTest.java
+++ b/bundle/camunda-saas-bundle/src/test/java/io/camunda/connector/runtime/saas/SecurityConfigurationTest.java
@@ -27,12 +27,10 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import io.camunda.connector.test.utils.annotation.SlowTest;
+import io.camunda.client.CamundaClient;
 import io.camunda.connector.test.utils.oidc.MockOidcServer;
-import io.camunda.process.test.api.CamundaSpringProcessTest;
 import java.time.Duration;
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.mockito.Answers;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -60,12 +58,13 @@ import org.springframework.test.web.servlet.MockMvc;
       "camunda.connector.secretprovider.discovery.enabled=false",
       "management.endpoints.web.exposure.include=*",
       "camunda.client.auth.audience=connectors.dev.ultrawombat.com",
+      "camunda.client.auth.token-url=http://localhost:0/not-used",
+      "camunda.client.auth.client-id=test",
+      "camunda.client.auth.client-secret=test",
       "spring.cloud.gcp.parametermanager.enabled=false"
     })
 @ActiveProfiles("test")
 @AutoConfigureMockMvc
-@CamundaSpringProcessTest
-@SlowTest
 public class SecurityConfigurationTest {
 
   private static final MockOidcServer OIDC_SERVER = MockOidcServer.start();
@@ -73,16 +72,6 @@ public class SecurityConfigurationTest {
   @DynamicPropertySource
   static void registerOidcProperties(DynamicPropertyRegistry registry) {
     registry.add("camunda.connector.auth.issuer", OIDC_SERVER::issuer);
-    registry.add("camunda.client.auth.token-url", OIDC_SERVER::tokenUrl);
-  }
-
-  @BeforeAll
-  static void beforeAll() {
-    OIDC_SERVER.stubTokenResponse(
-        200,
-        """
-        {"access_token":"test-token","token_type":"Bearer","expires_in":3600}
-        """);
   }
 
   @AfterAll
@@ -92,6 +81,9 @@ public class SecurityConfigurationTest {
 
   @MockitoBean(answers = Answers.RETURNS_MOCKS)
   public SaaSSecretConfiguration saaSSecretConfiguration;
+
+  @MockitoBean(answers = Answers.RETURNS_DEEP_STUBS)
+  public CamundaClient camundaClient;
 
   @LocalManagementPort int managementPort;
   @Autowired private MockMvc mvc;


### PR DESCRIPTION
## Description

This pull request updates the test configuration for the Camunda SaaS bundle, primarily focusing on simplifying test dependencies and improving the mocking of external services. The main changes involve removing unused or unnecessary dependencies, updating property setups for authentication, and enhancing test isolation by mocking the `CamundaClient`.

**Dependency and Test Configuration Simplification:**

* Removed the `camunda-process-test-spring` test dependency from the project’s `pom.xml`, reducing unnecessary dependencies in the test scope.
* Removed the use of the `@CamundaSpringProcessTest` and `@SlowTest` annotations from test classes, streamlining the test setup and execution. [[1]](diffhunk://#diff-ed09231744f622a77172d54e96e2272f03ed31c3e8fcfad022e42a878da5b224L23-L27) [[2]](diffhunk://#diff-ed09231744f622a77172d54e96e2272f03ed31c3e8fcfad022e42a878da5b224R53-L78) [[3]](diffhunk://#diff-df29f2fa4a5868c990896aa34ded07152ac2f0006caebe0ade89d7100f02dea3L30-L35) [[4]](diffhunk://#diff-df29f2fa4a5868c990896aa34ded07152ac2f0006caebe0ade89d7100f02dea3R61-L85)

**Authentication and Mocking Improvements:**

* Added explicit dummy authentication properties (`token-url`, `client-id`, `client-secret`) to test configurations, ensuring tests are decoupled from real authentication endpoints. [[1]](diffhunk://#diff-ed09231744f622a77172d54e96e2272f03ed31c3e8fcfad022e42a878da5b224R53-L78) [[2]](diffhunk://#diff-df29f2fa4a5868c990896aa34ded07152ac2f0006caebe0ade89d7100f02dea3R61-L85)
* Removed OIDC server token response stubbing and dynamic property registration for `camunda.client.auth.token-url`, further isolating tests from external dependencies. [[1]](diffhunk://#diff-ed09231744f622a77172d54e96e2272f03ed31c3e8fcfad022e42a878da5b224R53-L78) [[2]](diffhunk://#diff-df29f2fa4a5868c990896aa34ded07152ac2f0006caebe0ade89d7100f02dea3R61-L85)

**Mocking External Services:**

* Introduced a deep-stubbed `CamundaClient` mock using `@MockitoBean` in both test classes, allowing for more robust and isolated unit tests. [[1]](diffhunk://#diff-ed09231744f622a77172d54e96e2272f03ed31c3e8fcfad022e42a878da5b224R78-R80) [[2]](diffhunk://#diff-df29f2fa4a5868c990896aa34ded07152ac2f0006caebe0ade89d7100f02dea3R85-R87)

**Related to:** 
https://camunda.slack.com/archives/C02JLRNQQ05/p1779094977156189

## Checklist

- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest
  release, as this branch will be rebased onto main before the next release. Example backport labels:
    - `backport stable/8.8`: for changes that should be included in the next 8.8.x release.
    - **or** `backport release-8.8.7`: for changes that should be included in the specific release 8.8.7, and this
      *release has already been created*. The release branch will be merged back into stable/8.8 later, so the change
      will be included in future 8.8.x releases as well.
- [ ] Tests/Integration tests for the changes have been added if applicable.
- [ ] If the change requires a documentation update, it has been added to the appropriate section in the documentation.


