### PR TITLE
fix: prefer connector virtual thread executor

### DIFF
--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/main/java/io/camunda/connector/runtime/OutboundConnectorsAutoConfiguration.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/main/java/io/camunda/connector/runtime/OutboundConnectorsAutoConfiguration.java
@@ -18,12 +18,15 @@ package io.camunda.connector.runtime;
 
 import io.camunda.client.jobhandling.CamundaClientExecutorService;
 import io.camunda.client.metrics.MeteredCamundaClientExecutorService;
+import io.camunda.client.spring.configuration.CamundaAutoConfiguration;
+import io.camunda.client.spring.configuration.ExecutorServiceConfiguration;
 import io.camunda.connector.runtime.outbound.OutboundConnectorRuntimeConfiguration;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
@@ -31,15 +34,16 @@ import org.springframework.context.annotation.Import;
 
 @AutoConfiguration
 @Import(OutboundConnectorRuntimeConfiguration.class)
+@AutoConfigureBefore({CamundaAutoConfiguration.class, ExecutorServiceConfiguration.class})
 public class OutboundConnectorsAutoConfiguration {
 
-  @Bean
+  @Bean(name = {"connectorCamundaClientExecutorService", "camundaClientExecutorService"})
   @ConditionalOnMissingBean
   @ConditionalOnProperty(
       name = "camunda.connector.virtual-threads.enabled",
       havingValue = "true",
       matchIfMissing = true)
-  public CamundaClientExecutorService camundaClientExecutorService(
+  public CamundaClientExecutorService connectorCamundaClientExecutorService(
       @Autowired(required = false) MeterRegistry meterRegistry) {
     ThreadFactory factory = Thread.ofVirtual().name("job-worker-virtual-", 0).factory();
     var vThreadExecutor = Executors.newThreadPerTaskExecutor(factory);

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/OutboundConnectorsAutoConfigurationTest.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/OutboundConnectorsAutoConfigurationTest.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.runtime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.client.CamundaClient;
+import io.camunda.client.jobhandling.CamundaClientExecutorService;
+import io.camunda.client.jobhandling.CommandExceptionHandlingStrategy;
+import io.camunda.client.jobhandling.JobWorkerManager;
+import io.camunda.client.metrics.MeteredCamundaClientExecutorService;
+import io.camunda.client.metrics.MetricsRecorder;
+import io.camunda.client.spring.configuration.CamundaAutoConfiguration;
+import io.camunda.client.spring.configuration.ExecutorServiceConfiguration;
+import io.camunda.client.spring.properties.CamundaClientProperties;
+import io.camunda.connector.jackson.ConnectorsObjectMapperSupplier;
+import io.camunda.connector.runtime.annotation.ConnectorsObjectMapper;
+import io.camunda.connector.runtime.annotation.OutboundConnectorObjectMapper;
+import io.camunda.connector.runtime.core.secret.SecretProviderAggregator;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.autoconfigure.AutoConfigureBefore;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.core.annotation.MergedAnnotations;
+
+class OutboundConnectorsAutoConfigurationTest {
+
+  private static final String CONNECTOR_EXECUTOR_BEAN_NAME =
+      "connectorCamundaClientExecutorService";
+
+  private final ApplicationContextRunner contextRunner =
+      new ApplicationContextRunner()
+          .withConfiguration(
+              AutoConfigurations.of(
+                  ExecutorServiceConfiguration.class, OutboundConnectorsAutoConfiguration.class))
+          .withUserConfiguration(RequiredOutboundRuntimeBeans.class);
+
+  @Test
+  void shouldCreateConnectorExecutorServiceByDefault() {
+    contextRunner.run(
+        context -> {
+          assertThat(context).hasSingleBean(CamundaClientExecutorService.class);
+          assertThat(context).hasBean(CONNECTOR_EXECUTOR_BEAN_NAME);
+          assertThat(context.getBean(CamundaClientExecutorService.class))
+              .isSameAs(context.getBean(CONNECTOR_EXECUTOR_BEAN_NAME))
+              .isInstanceOf(MeteredCamundaClientExecutorService.class);
+        });
+  }
+
+  @Test
+  void shouldBeConfiguredBeforeCamundaClientAutoConfiguration() {
+    var autoConfigureBefore =
+        MergedAnnotations.from(OutboundConnectorsAutoConfiguration.class)
+            .get(AutoConfigureBefore.class);
+
+    assertThat(autoConfigureBefore.getClassArray("value"))
+        .contains(CamundaAutoConfiguration.class, ExecutorServiceConfiguration.class);
+  }
+
+  @Test
+  void shouldNotCreateConnectorExecutorServiceWhenVirtualThreadsAreDisabled() {
+    contextRunner
+        .withPropertyValues("camunda.connector.virtual-threads.enabled=false")
+        .run(
+            context -> {
+              assertThat(context).doesNotHaveBean(CONNECTOR_EXECUTOR_BEAN_NAME);
+              assertThat(context).hasSingleBean(CamundaClientExecutorService.class);
+            });
+  }
+
+  static class RequiredOutboundRuntimeBeans {
+
+    @Bean
+    CamundaClient camundaClient() {
+      return mock(CamundaClient.class);
+    }
+
+    @Bean
+    JobWorkerManager jobWorkerManager() {
+      return mock(JobWorkerManager.class);
+    }
+
+    @Bean
+    CommandExceptionHandlingStrategy commandExceptionHandlingStrategy() {
+      return mock(CommandExceptionHandlingStrategy.class);
+    }
+
+    @Bean
+    SecretProviderAggregator secretProviderAggregator() {
+      return new SecretProviderAggregator(List.of());
+    }
+
+    @Bean
+    MetricsRecorder metricsRecorder() {
+      return mock(MetricsRecorder.class);
+    }
+
+    @Bean
+    CamundaClientProperties camundaClientProperties() {
+      var properties = new CamundaClientProperties();
+      properties.setExecutionThreads(1);
+      return properties;
+    }
+
+    @Bean
+    @ConnectorsObjectMapper
+    ObjectMapper connectorObjectMapper() {
+      return ConnectorsObjectMapperSupplier.getCopy();
+    }
+
+    @Bean
+    @OutboundConnectorObjectMapper
+    ObjectMapper outboundConnectorObjectMapper() {
+      return ConnectorsObjectMapperSupplier.getCopy();
+    }
+  }
+}


### PR DESCRIPTION
Backport of https://github.com/camunda/connectors/pull/7233

This pull request makes improvements to the auto-configuration of outbound connectors in the Spring Boot starter, focusing on bean initialization order and test coverage. The main changes ensure that the connector executor service is correctly configured and available before related auto-configurations, and that this behavior is well-tested.

**Auto-configuration improvements:**

* Added the `@AutoConfigureBefore` annotation to `OutboundConnectorsAutoConfiguration` to ensure it is configured before `CamundaAutoConfiguration` and `ExecutorServiceConfiguration`, preventing bean initialization conflicts.
* Updated the bean definition for the connector executor service to use both `connectorCamundaClientExecutorService` and `camundaClientExecutorService` as names, clarifying its role and avoiding naming collisions.

**Testing enhancements:**

* Added a new test class `OutboundConnectorsAutoConfigurationTest` to verify the correct creation and configuration order of the connector executor service, including scenarios with virtual threads enabled or disabled.