### PR TITLE
fix: bump tomcat-embed-* to 10.1.55

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -90,6 +90,10 @@ limitations under the License.</license.inlineheader>
     <version.hamcrest>3.0</version.hamcrest>
 
     <version.spring-boot>3.5.14</version.spring-boot>
+    <!-- CVE override: Spring Boot 3.5.14 ships Tomcat 10.1.54 which has a known vulnerability.
+         Remove once Spring Boot upgrades to Tomcat >= 10.1.55 (likely in 3.5.15+).
+         Ref: https://cve-registry.infosec.camunda-it.rocks/team/3/finding/3575 -->
+    <version.tomcat>10.1.55</version.tomcat>
     <version.spring-cloud-gcp-starter-logging>7.4.7</version.spring-cloud-gcp-starter-logging>
     <version.logback>1.5.32</version.logback>
 
@@ -201,6 +205,23 @@ limitations under the License.</license.inlineheader>
         <version>${version.spring-boot}</version>
         <scope>import</scope>
         <type>pom</type>
+      </dependency>
+
+      <!-- CVE override for Tomcat - remove when version.tomcat property is removed -->
+      <dependency>
+        <groupId>org.apache.tomcat.embed</groupId>
+        <artifactId>tomcat-embed-core</artifactId>
+        <version>${version.tomcat}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.tomcat.embed</groupId>
+        <artifactId>tomcat-embed-el</artifactId>
+        <version>${version.tomcat}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.tomcat.embed</groupId>
+        <artifactId>tomcat-embed-websocket</artifactId>
+        <version>${version.tomcat}</version>
       </dependency>
 
       <!-- Override Spring Boot BOM postgresql pin -->
@@ -822,6 +843,18 @@ limitations under the License.</license.inlineheader>
               <requirePluginVersions>
                 <banSnapshots>false</banSnapshots>
               </requirePluginVersions>
+              <!-- CVE override reminder: fail build when Spring Boot is bumped past 3.5.14
+                   so we remember to check if the Tomcat override (version.tomcat) can be removed.
+                   Ref: https://cve-registry.infosec.camunda-it.rocks/team/3/finding/3575 -->
+              <requireProperty>
+                <property>version.spring-boot</property>
+                <regex>3\.5\.14</regex>
+                <regexMessage>
+Spring Boot version was bumped! Check if the Tomcat CVE override (version.tomcat in parent/pom.xml) can be removed.
+If the new Spring Boot version ships Tomcat >= 10.1.55, remove version.tomcat property and the tomcat-embed-* dependencyManagement entries.
+Ref: https://cve-registry.infosec.camunda-it.rocks/team/3/finding/3575
+                </regexMessage>
+              </requireProperty>
             </rules>
           </configuration>
           <executions>


### PR DESCRIPTION
## Summary

Bumps `org.apache.tomcat.embed:tomcat-embed-*` from `10.1.50` to `10.1.55`.

Security fix. Details in the internal tracking issue: camunda/team-connectors#1218