### PR TITLE
fix: bump tomcat-embed-* to 10.1.55

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -160,6 +160,7 @@ limitations under the License.</license.inlineheader>
     <plugin.version.license.codehaus>2.7.1</plugin.version.license.codehaus>
     <plugin.version.maven-resources-plugin>3.2.0</plugin.version.maven-resources-plugin>
     <plugin.version.maven-shade-plugin>3.6.2</plugin.version.maven-shade-plugin>
+    <plugin.version.maven-site-plugin>3.21.0</plugin.version.maven-site-plugin>
     <plugin.version.maven-surefire-plugin>3.5.5</plugin.version.maven-surefire-plugin>
     <plugin.version.spotless-maven-plugin>3.5.1</plugin.version.spotless-maven-plugin>
     <plugin.version.maven-jar-plugin>3.5.0</plugin.version.maven-jar-plugin>
@@ -851,6 +852,11 @@ Ref: https://cve-registry.infosec.camunda-it.rocks/team/3/finding/3575
               </goals>
             </execution>
           </executions>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-site-plugin</artifactId>
+          <version>${plugin.version.maven-site-plugin}</version>
         </plugin>
         <plugin>
           <groupId>com.diffplug.spotless</groupId>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -88,6 +88,10 @@ limitations under the License.</license.inlineheader>
     <version.hamcrest>3.0</version.hamcrest>
 
     <version.spring-boot>3.5.14</version.spring-boot>
+    <!-- CVE override: Spring Boot 3.5.14 ships Tomcat 10.1.54 which has a known vulnerability.
+         Remove once Spring Boot upgrades to Tomcat >= 10.1.55 (likely in 3.5.15+).
+         Ref: https://cve-registry.infosec.camunda-it.rocks/team/3/finding/3575 -->
+    <version.tomcat>10.1.55</version.tomcat>
     <version.spring-cloud-gcp-starter-logging>5.13.11</version.spring-cloud-gcp-starter-logging>
     <version.logback>1.5.32</version.logback>
 
@@ -193,6 +197,23 @@ limitations under the License.</license.inlineheader>
         <version>${version.spring-boot}</version>
         <scope>import</scope>
         <type>pom</type>
+      </dependency>
+
+      <!-- CVE override for Tomcat - remove when version.tomcat property is removed -->
+      <dependency>
+        <groupId>org.apache.tomcat.embed</groupId>
+        <artifactId>tomcat-embed-core</artifactId>
+        <version>${version.tomcat}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.tomcat.embed</groupId>
+        <artifactId>tomcat-embed-el</artifactId>
+        <version>${version.tomcat}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.tomcat.embed</groupId>
+        <artifactId>tomcat-embed-websocket</artifactId>
+        <version>${version.tomcat}</version>
       </dependency>
 
       <!-- Override Spring Boot BOM postgresql pin -->
@@ -805,7 +826,23 @@ limitations under the License.</license.inlineheader>
           <artifactId>maven-enforcer-plugin</artifactId>
           <version>${plugin.version.maven-enforcer-plugin}</version>
           <configuration>
-            <skip>true</skip>
+            <rules>
+              <requirePluginVersions>
+                <banSnapshots>false</banSnapshots>
+              </requirePluginVersions>
+              <!-- CVE override reminder: fail build when Spring Boot is bumped past 3.5.14
+                   so we remember to check if the Tomcat override (version.tomcat) can be removed.
+                   Ref: https://cve-registry.infosec.camunda-it.rocks/team/3/finding/3575 -->
+              <requireProperty>
+                <property>version.spring-boot</property>
+                <regex>3\.5\.14</regex>
+                <regexMessage>
+Spring Boot version was bumped! Check if the Tomcat CVE override (version.tomcat in parent/pom.xml) can be removed.
+If the new Spring Boot version ships Tomcat >= 10.1.55, remove version.tomcat property and the tomcat-embed-* dependencyManagement entries.
+Ref: https://cve-registry.infosec.camunda-it.rocks/team/3/finding/3575
+                </regexMessage>
+              </requireProperty>
+            </rules>
           </configuration>
           <executions>
             <execution>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -158,7 +158,7 @@ limitations under the License.</license.inlineheader>
     <plugin.version.maven-install-plugin>3.1.4</plugin.version.maven-install-plugin>
     <plugin.version.license>4.6</plugin.version.license>
     <plugin.version.license.codehaus>2.7.1</plugin.version.license.codehaus>
-    <plugin.version.maven-resources-plugin>3.2.0</plugin.version.maven-resources-plugin>
+    <plugin.version.maven-resources-plugin>3.4.0</plugin.version.maven-resources-plugin>
     <plugin.version.maven-shade-plugin>3.6.2</plugin.version.maven-shade-plugin>
     <plugin.version.maven-site-plugin>3.21.0</plugin.version.maven-site-plugin>
     <plugin.version.maven-surefire-plugin>3.5.5</plugin.version.maven-surefire-plugin>
@@ -852,6 +852,11 @@ Ref: https://cve-registry.infosec.camunda-it.rocks/team/3/finding/3575
               </goals>
             </execution>
           </executions>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-resources-plugin</artifactId>
+          <version>${plugin.version.maven-resources-plugin}</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
## Summary

Bumps `org.apache.tomcat.embed:tomcat-embed-*` from `10.1.52` to `10.1.55`.

Security fix. Details in the internal tracking issue: camunda/team-connectors#1218