### PR TITLE
deps: update asdf maven version to 3.9.16 due to older version being unavailable

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,4 +1,4 @@
 java temurin-25.0.3+9.0.LTS
-maven 3.9.15
+maven 3.9.16
 pre-commit 4.6.0
 nodejs 24.15.0


### PR DESCRIPTION
## Description

Bump maven to `3.9.16` in asdf `.tool-version` file to ensure that the latest CDN available version is being used

## Checklist

- [x] Backport labels are added if these code changes should be backported. No backport label is added to the latest
  release, as this branch will be rebased onto main before the next release. Example backport labels:
    - `backport stable/8.8`: for changes that should be included in the next 8.8.x release.
    - **or** `backport release-8.8.7`: for changes that should be included in the specific release 8.8.7, and this
      *release has already been created*. The release branch will be merged back into stable/8.8 later, so the change
      will be included in future 8.8.x releases as well.
- [ ] Tests/Integration tests for the changes have been added if applicable.
- [ ] If the change requires a documentation update, it has been added to the appropriate section in the documentation.


