### PR TITLE
ci: remove asdf step from RELEASE workflow

### DIFF
--- a/.github/workflows/RELEASE.yaml
+++ b/.github/workflows/RELEASE.yaml
@@ -73,8 +73,6 @@ jobs:
           ref: ${{ github.ref }}
           fetch-depth: 0
           persist-credentials: false # we will use a GitHub App token for pushing commits and tags, so we need to disable the default token
-      - name: Install asdf & tools
-        uses: asdf-vm/actions/install@v4
       - name: Install bc calculator
         run: sudo apt-get update && sudo apt-get install -y bc
       - name: Identify previous release version


### PR DESCRIPTION
## Summary

Follow-up to #7261 which removed `asdf` from `DEPLOY_SNAPSHOTS.yaml`.

The `RELEASE.yaml` workflow had the same `Install asdf & tools` step, originally added in #6002 because Maven is not pre-installed on the self-hosted `gcp-core-2-release` runner. Now that all `mvn` calls in this workflow use `./mvnw` (which downloads Maven 3.9.16 from Maven Central on first run), the asdf step is redundant and can be removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)