### PR TITLE
fix(aws): restore STS dependency to re-enable IRSA authentication

### DIFF
--- a/connectors/aws/aws-base/pom.xml
+++ b/connectors/aws/aws-base/pom.xml
@@ -42,6 +42,10 @@
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
+      <artifactId>sts</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>software.amazon.awssdk</groupId>
       <artifactId>aws-core</artifactId>
       <version>${version.aws-sdk2}</version>
     </dependency>

--- a/connectors/aws/aws-base/src/test/java/io/camunda/connector/aws/CredentialsProviderSupportV2Test.java
+++ b/connectors/aws/aws-base/src/test/java/io/camunda/connector/aws/CredentialsProviderSupportV2Test.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.aws;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import io.camunda.connector.aws.model.impl.AwsAuthentication;
+import io.camunda.connector.aws.model.impl.AwsBaseConfiguration;
+import io.camunda.connector.aws.model.impl.AwsBaseRequest;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+
+class CredentialsProviderSupportV2Test {
+
+  @Test
+  void staticCredentials_shouldReturnStaticCredentialsProvider() {
+    var request =
+        requestWith(new AwsAuthentication.AwsStaticCredentialsAuthentication("key", "secret"));
+    var provider = CredentialsProviderSupportV2.credentialsProvider(request);
+    assertThat(provider.resolveCredentials().accessKeyId()).isEqualTo("key");
+  }
+
+  @Test
+  void defaultCredentials_shouldReturnDefaultCredentialsProvider() {
+    var request = requestWith(new AwsAuthentication.AwsDefaultCredentialsChainAuthentication());
+    var provider = CredentialsProviderSupportV2.credentialsProvider(request);
+    assertThat(provider).isInstanceOf(DefaultCredentialsProvider.class);
+  }
+
+  @Test
+  void stsShouldBeOnClasspathForIrsaSupport() {
+    // DefaultCredentialsProvider includes WebIdentityTokenFileCredentialsProvider (IRSA) only
+    // when software.amazon.awssdk:sts is on the classpath. Without it the provider is silently
+    // skipped. This test guards against accidental removal of that dependency.
+    assertThatCode(() -> Class.forName("software.amazon.awssdk.services.sts.StsClient"))
+        .as("software.amazon.awssdk:sts must be on the classpath for IRSA support")
+        .doesNotThrowAnyException();
+  }
+
+  private static AwsBaseRequest requestWith(AwsAuthentication auth) {
+    var request = new AwsBaseRequest();
+    request.setAuthentication(auth);
+    request.setConfiguration(new AwsBaseConfiguration("eu-central-1", null));
+    return request;
+  }
+}

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -584,6 +584,11 @@ limitations under the License.</license.inlineheader>
         <artifactId>http-auth</artifactId>
         <version>${version.aws-sdk2}</version>
       </dependency>
+      <dependency>
+        <groupId>software.amazon.awssdk</groupId>
+        <artifactId>sts</artifactId>
+        <version>${version.aws-sdk2}</version>
+      </dependency>
 
       <dependency>
         <groupId>com.google.code.findbugs</groupId>
@@ -1108,6 +1113,8 @@ Ref: https://cve-registry.infosec.camunda-it.rocks/team/3/finding/3575
                   <dependency>org.testcontainers:testcontainers</dependency>
                   <dependency>org.springframework.boot:spring-boot-starter-actuator</dependency>
                   <dependency>io.camunda.connector:connector-validation</dependency>
+                  <!-- runtime-only: loaded reflectively by DefaultCredentialsProvider for IRSA/WebIdentityTokenFileCredentialsProvider -->
+                  <dependency>software.amazon.awssdk:sts</dependency>
                 </ignoredUnusedDeclaredDependencies>
                 <ignoredUsedUndeclaredDependencies>
                   <!-- included in junit-jupiter, ignore for cleaner pom -->

--- a/secret-providers/aws/pom.xml
+++ b/secret-providers/aws/pom.xml
@@ -25,6 +25,10 @@
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
+      <artifactId>sts</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>software.amazon.awssdk</groupId>
       <artifactId>aws-core</artifactId>
     </dependency>
     <dependency>
@@ -47,6 +51,11 @@
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/secret-providers/aws/src/test/java/AwsSecretProviderTest.java
+++ b/secret-providers/aws/src/test/java/AwsSecretProviderTest.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import io.camunda.connector.api.secret.SecretProvider;
@@ -26,5 +27,15 @@ public class AwsSecretProviderTest {
   public void shouldFindSecretProviderImpl() {
     var a = ServiceLoader.load(SecretProvider.class);
     assertEquals(1, a.stream().count());
+  }
+
+  @Test
+  public void stsShouldBeOnClasspathForIrsaSupport() {
+    // AwsSecretProvider uses DefaultCredentialsProvider which includes
+    // WebIdentityTokenFileCredentialsProvider (IRSA) only when software.amazon.awssdk:sts
+    // is on the classpath. Without it IRSA is silently skipped.
+    assertThatCode(() -> Class.forName("software.amazon.awssdk.services.sts.StsClient"))
+        .as("software.amazon.awssdk:sts must be on the classpath for IRSA support")
+        .doesNotThrowAnyException();
   }
 }


### PR DESCRIPTION
## Summary

AWS IRSA (IAM Roles for Service Accounts) stopped working in 8.8+ because `software.amazon.awssdk:sts` was accidentally removed during the AWS SDK v1→v2 migration.

### Root cause

IRSA relies on `WebIdentityTokenFileCredentialsProvider`, which AWS SDK v2's `DefaultCredentialsProvider` includes in its credential chain **only if `software.amazon.awssdk:sts` is on the classpath** — it is loaded reflectively. When `sts` is absent the provider is silently skipped, causing all IRSA-based authentication to fall through without any obvious error.

**The regression was introduced by [`1c7d6bdfb`](https://github.com/camunda/connectors/commit/1c7d6bdfb8d66091afb7a8887723ae4921af5463)** (`chore: migrate AWS connectors to AWS SDK v2`), which correctly removed the v1 `com.amazonaws:aws-java-sdk-sts` but inadvertently also dropped the v2 `software.amazon.awssdk:sts` that had been added by [`3dee3ebb2`](https://github.com/camunda/connectors/commit/3dee3ebb261db7f3cab782ffc3ac873dc590ca16) (`feat(aws): Role can now be assumed within an AWS EKS cluster using IRSA`).

Confirmed absent via `mvn dependency:tree -Dincludes=software.amazon.awssdk:sts` against the SaaS bundle (produced no output before this fix).

### Changes

- **`connectors/aws/aws-base/pom.xml`** — restore `software.amazon.awssdk:sts`; fixes IRSA for all AWS connectors using `CredentialsProviderSupportV2` with default credentials (Lambda, SQS, SNS, EventBridge, Bedrock, etc.)
- **`secret-providers/aws/pom.xml`** — add `software.amazon.awssdk:sts`; fixes IRSA for `AwsSecretProvider` (which does not depend on `aws-base`)
- **`parent/pom.xml`** — add `sts` to `dependencyManagement` and `ignoredUnusedDeclaredDependencies` (it is a runtime-only classpath dep, not directly referenced in source)
- **`CredentialsProviderSupportV2Test`** (new) — classpath guard + baseline behaviour tests for the credentials provider
- **`AwsSecretProviderTest`** — same classpath guard for the secret provider path

### Test plan

- [x] `mvn -pl connectors/aws/aws-base,secret-providers/aws verify` — all 9 tests pass, `BUILD SUCCESS`
- [x] `mvn dependency:tree -Dincludes=software.amazon.awssdk:sts` against `camunda-saas-bundle` now shows `software.amazon.awssdk:sts:jar:2.44.8:compile`
- [ ] Deploy to a cluster with IRSA configured and verify AWS Secrets Manager access works without static credentials

Closes #7271

🤖 Generated with [Claude Code](https://claude.com/claude-code)