### PR TITLE
[Backport stable/8.9] fix(ci): restoring `mvnw` execute permission in the release workflow

### DIFF
--- a/.github/workflows/RELEASE.yaml
+++ b/.github/workflows/RELEASE.yaml
@@ -264,6 +264,9 @@ jobs:
         with:
           name: repository
 
+      - name: Ensure Maven wrapper is executable
+        run: chmod +x ./mvnw
+
       - name: Prepare Java and Maven settings
         uses: actions/setup-java@v5
         with:


### PR DESCRIPTION
# Description
Backport of #7290 to `stable/8.9`.

The original cherry-pick conflicted because `stable/8.9` does not contain the `e2e-tests` job introduced on `main`. Only the `maven-release` portion of the original patch (adding `chmod +x ./mvnw` after `Download repository`) applies to this branch.