### PR TITLE
[Backport release-8.9.4] fix(ci): restoring `mvnw` execute permission in the release workflow

### DIFF
--- a/.github/workflows/RELEASE.yaml
+++ b/.github/workflows/RELEASE.yaml
@@ -266,6 +266,9 @@ jobs:
         with:
           name: repository
 
+      - name: Ensure Maven wrapper is executable
+        run: chmod +x ./mvnw
+
       - name: Prepare Java and Maven settings
         uses: actions/setup-java@v5
         with:


### PR DESCRIPTION
# Description
Backport of #7290 to `release-8.9.4`.

The original cherry-pick conflicted because `release-8.9.4` does not contain the `e2e-tests` job introduced on `main`. Only the `maven-release` portion of the original patch (adding `chmod +x ./mvnw` after `Download repository`) applies to this branch.