### PR TITLE
feat: add compatibility with scope key tenant evaluation

### DIFF
--- a/connector-runtime/connector-feel/src/main/java/io/camunda/connector/feel/CamundaClientFeelExpressionEvaluator.java
+++ b/connector-runtime/connector-feel/src/main/java/io/camunda/connector/feel/CamundaClientFeelExpressionEvaluator.java
@@ -32,6 +32,8 @@ public class CamundaClientFeelExpressionEvaluator implements FeelExpressionEvalu
 
   private final CamundaClient camundaClient;
   private final ObjectMapper objectMapper;
+  private final String tenantId;
+  private final Long scopeKey;
 
   /**
    * Creates a new evaluator with a custom ObjectMapper for result conversion.
@@ -41,7 +43,35 @@ public class CamundaClientFeelExpressionEvaluator implements FeelExpressionEvalu
    */
   public CamundaClientFeelExpressionEvaluator(
       CamundaClient camundaClient, ObjectMapper objectMapper) {
+    this(camundaClient, null, null, objectMapper);
+  }
+
+  /**
+   * Creates a new evaluator scoped to a specific tenant.
+   *
+   * @param camundaClient the CamundaClient instance to use for expression evaluation
+   * @param tenantId the tenant id to apply on the evaluation command (nullable)
+   * @param objectMapper the ObjectMapper to use for JSON conversion of the results
+   */
+  public CamundaClientFeelExpressionEvaluator(
+      CamundaClient camundaClient, String tenantId, ObjectMapper objectMapper) {
+    this(camundaClient, tenantId, null, objectMapper);
+  }
+
+  /**
+   * Creates a new evaluator scoped to a specific tenant and element instance.
+   *
+   * @param camundaClient the CamundaClient instance to use for expression evaluation
+   * @param tenantId the tenant id to apply on the evaluation command (nullable)
+   * @param scopeKey the scope key (e.g. element instance key) to apply on the evaluation command
+   *     (nullable)
+   * @param objectMapper the ObjectMapper to use for JSON conversion of the results
+   */
+  public CamundaClientFeelExpressionEvaluator(
+      CamundaClient camundaClient, String tenantId, Long scopeKey, ObjectMapper objectMapper) {
     this.camundaClient = camundaClient;
+    this.tenantId = tenantId;
+    this.scopeKey = scopeKey;
     this.objectMapper = objectMapper;
   }
 
@@ -89,6 +119,13 @@ public class CamundaClientFeelExpressionEvaluator implements FeelExpressionEvalu
     Map<String, Object> mergedVariables = FeelEngineWrapperUtil.mergeMapVariables(variables);
     if (!mergedVariables.isEmpty()) {
       request.variables(mergedVariables);
+    }
+
+    if (tenantId != null) {
+      request.tenantId(tenantId);
+    }
+    if (scopeKey != null) {
+      request.scopeKey(scopeKey);
     }
 
     var response = request.send().join();

--- a/connector-runtime/connector-feel/src/main/java/io/camunda/connector/feel/FeelExpressionEvaluatorBuilder.java
+++ b/connector-runtime/connector-feel/src/main/java/io/camunda/connector/feel/FeelExpressionEvaluatorBuilder.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.feel;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.client.CamundaClient;
+import io.camunda.connector.jackson.ConnectorsObjectMapperSupplier;
+
+/**
+ * Step builder for {@link FeelExpressionEvaluator} instances. The entry points return distinct
+ * sub-builders so that backend-specific options (e.g. {@code scopeKey}, {@code tenantId}) are only
+ * reachable for the backend that actually supports them.
+ *
+ * <p>Pick {@link #local()} for embedded FEEL evaluation, or {@link #camundaClient(CamundaClient)}
+ * for cluster-based evaluation (allowing access to cluster variables like {@code
+ * camunda.vars.env.*}).
+ *
+ * <pre>{@code
+ * FeelExpressionEvaluator local = FeelExpressionEvaluatorBuilder.local().build();
+ *
+ * FeelExpressionEvaluator cluster = FeelExpressionEvaluatorBuilder.camundaClient(client)
+ *     .tenantId("acme")
+ *     .scopeKey(elementInstanceKey)
+ *     .objectMapper(objectMapper)
+ *     .build();
+ * }</pre>
+ */
+public final class FeelExpressionEvaluatorBuilder {
+
+  private FeelExpressionEvaluatorBuilder() {}
+
+  /** Start building a {@link LocalFeelExpressionEvaluator}. */
+  public static LocalStep local() {
+    return new LocalStep();
+  }
+
+  /** Start building a {@link CamundaClientFeelExpressionEvaluator}. */
+  public static CamundaClientStep camundaClient(CamundaClient camundaClient) {
+    if (camundaClient == null) {
+      throw new IllegalArgumentException("camundaClient must not be null");
+    }
+    return new CamundaClientStep(camundaClient);
+  }
+
+  /** Step builder for the embedded FEEL engine evaluator. */
+  public static final class LocalStep {
+    private LocalStep() {}
+
+    public FeelExpressionEvaluator build() {
+      return new LocalFeelExpressionEvaluator();
+    }
+  }
+
+  /** Step builder for the cluster-based evaluator. */
+  public static final class CamundaClientStep {
+    private final CamundaClient camundaClient;
+    private String tenantId;
+    private Long scopeKey;
+    private ObjectMapper objectMapper;
+
+    private CamundaClientStep(CamundaClient camundaClient) {
+      this.camundaClient = camundaClient;
+    }
+
+    public CamundaClientStep tenantId(String tenantId) {
+      this.tenantId = tenantId;
+      return this;
+    }
+
+    public CamundaClientStep scopeKey(Long scopeKey) {
+      this.scopeKey = scopeKey;
+      return this;
+    }
+
+    public CamundaClientStep objectMapper(ObjectMapper objectMapper) {
+      this.objectMapper = objectMapper;
+      return this;
+    }
+
+    public FeelExpressionEvaluator build() {
+      ObjectMapper mapper =
+          objectMapper != null ? objectMapper : ConnectorsObjectMapperSupplier.getCopy();
+      return new CamundaClientFeelExpressionEvaluator(camundaClient, tenantId, scopeKey, mapper);
+    }
+  }
+}

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/DefaultInboundConnectorContextFactory.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/DefaultInboundConnectorContextFactory.java
@@ -17,6 +17,7 @@
 package io.camunda.connector.runtime.core.inbound;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.client.CamundaClient;
 import io.camunda.connector.api.document.DocumentFactory;
 import io.camunda.connector.api.inbound.InboundConnectorContext;
 import io.camunda.connector.api.inbound.InboundConnectorExecutable;
@@ -28,6 +29,7 @@ import io.camunda.connector.runtime.core.inbound.details.InboundConnectorDetails
 import io.camunda.connector.runtime.core.secret.SecretProviderAggregator;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
+import java.util.Objects;
 import java.util.function.Consumer;
 
 public class DefaultInboundConnectorContextFactory implements InboundConnectorContextFactory {
@@ -37,6 +39,7 @@ public class DefaultInboundConnectorContextFactory implements InboundConnectorCo
   private final ValidationProvider validationProvider;
   private final ProcessInstanceClient processInstanceClient;
   private final DocumentFactory documentFactory;
+  private final CamundaClient camundaClient;
 
   public DefaultInboundConnectorContextFactory(
       final ObjectMapper mapper,
@@ -44,13 +47,15 @@ public class DefaultInboundConnectorContextFactory implements InboundConnectorCo
       final SecretProviderAggregator secretProviderAggregator,
       final ValidationProvider validationProvider,
       final ProcessInstanceClient processInstanceClient,
-      final DocumentFactory documentFactory) {
+      final DocumentFactory documentFactory,
+      final CamundaClient camundaClient) {
     this.objectMapper = mapper;
     this.correlationHandler = correlationHandler;
     this.secretProviderAggregator = secretProviderAggregator;
     this.validationProvider = validationProvider;
     this.processInstanceClient = processInstanceClient;
     this.documentFactory = documentFactory;
+    this.camundaClient = Objects.requireNonNull(camundaClient, "camundaClient must not be null");
   }
 
   @Override
@@ -69,7 +74,8 @@ public class DefaultInboundConnectorContextFactory implements InboundConnectorCo
             correlationHandler,
             cancellationCallback,
             objectMapper,
-            logWriter);
+            logWriter,
+            camundaClient);
 
     if (isIntermediateContext(executableClass)) {
       inboundContext =
@@ -78,7 +84,8 @@ public class DefaultInboundConnectorContextFactory implements InboundConnectorCo
               processInstanceClient,
               validationProvider,
               objectMapper,
-              correlationHandler);
+              correlationHandler,
+              camundaClient);
     }
 
     return inboundContext;

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/DefaultProcessInstanceContext.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/DefaultProcessInstanceContext.java
@@ -23,10 +23,12 @@ import io.camunda.client.api.search.response.ElementInstance;
 import io.camunda.connector.api.inbound.CorrelationRequest;
 import io.camunda.connector.api.inbound.ProcessInstanceContext;
 import io.camunda.connector.api.validation.ValidationProvider;
+import io.camunda.connector.feel.FeelEngineWrapperException;
 import io.camunda.connector.feel.FeelExpressionEvaluatorBuilder;
 import io.camunda.connector.feel.jackson.FeelContextAwareObjectReader;
 import io.camunda.connector.runtime.core.inbound.correlation.InboundCorrelationHandler;
 import io.camunda.connector.runtime.core.validation.ValidationUtil;
+import java.io.IOException;
 
 public final class DefaultProcessInstanceContext implements ProcessInstanceContext {
 
@@ -65,11 +67,13 @@ public final class DefaultProcessInstanceContext implements ProcessInstanceConte
 
   @Override
   public <T> T bind(final Class<T> cls) {
+    String tenantId = context.getDefinition().tenantId();
+    Long scopeKey = elementInstance.getElementInstanceKey();
     try {
       var evaluator =
           FeelExpressionEvaluatorBuilder.camundaClient(camundaClient)
-              .tenantId(context.getDefinition().tenantId())
-              .scopeKey(elementInstance.getElementInstanceKey())
+              .tenantId(tenantId)
+              .scopeKey(scopeKey)
               .objectMapper(objectMapper)
               .build();
       T mappedObject =
@@ -78,8 +82,17 @@ public final class DefaultProcessInstanceContext implements ProcessInstanceConte
               .readValue(processDefinitionProperties, cls);
       validationProvider.validate(mappedObject);
       return mappedObject;
-    } catch (Exception e) {
-      throw new RuntimeException(e);
+    } catch (IOException | FeelEngineWrapperException e) {
+      throw new RuntimeException(
+          "Failed to bind process instance properties to "
+              + cls.getName()
+              + " using FEEL evaluation/deserialization"
+              + " (tenantId="
+              + tenantId
+              + ", scopeKey="
+              + scopeKey
+              + ")",
+          e);
     }
   }
 

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/DefaultProcessInstanceContext.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/DefaultProcessInstanceContext.java
@@ -18,15 +18,15 @@ package io.camunda.connector.runtime.core.inbound;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.client.CamundaClient;
 import io.camunda.client.api.search.response.ElementInstance;
 import io.camunda.connector.api.inbound.CorrelationRequest;
 import io.camunda.connector.api.inbound.ProcessInstanceContext;
 import io.camunda.connector.api.validation.ValidationProvider;
+import io.camunda.connector.feel.FeelExpressionEvaluatorBuilder;
 import io.camunda.connector.feel.jackson.FeelContextAwareObjectReader;
 import io.camunda.connector.runtime.core.inbound.correlation.InboundCorrelationHandler;
 import io.camunda.connector.runtime.core.validation.ValidationUtil;
-import java.util.Map;
-import java.util.function.Supplier;
 
 public final class DefaultProcessInstanceContext implements ProcessInstanceContext {
 
@@ -34,8 +34,8 @@ public final class DefaultProcessInstanceContext implements ProcessInstanceConte
   private final ElementInstance elementInstance;
   private final ValidationProvider validationProvider;
   private final ObjectMapper objectMapper;
-  private final Supplier<Map<String, Object>> operatePropertiesSupplier;
   private final InboundCorrelationHandler correlationHandler;
+  private final CamundaClient camundaClient;
 
   private final JsonNode processDefinitionProperties;
 
@@ -45,7 +45,7 @@ public final class DefaultProcessInstanceContext implements ProcessInstanceConte
       final ValidationProvider validationProvider,
       final InboundCorrelationHandler correlationHandler,
       final ObjectMapper objectMapper,
-      final Supplier<Map<String, Object>> operateVariables) {
+      final CamundaClient camundaClient) {
     this.context = context;
     this.elementInstance = elementInstance;
     this.validationProvider =
@@ -54,9 +54,8 @@ public final class DefaultProcessInstanceContext implements ProcessInstanceConte
             : validationProvider;
     this.correlationHandler = correlationHandler;
     this.objectMapper = objectMapper;
-    this.operatePropertiesSupplier = operateVariables;
-
-    processDefinitionProperties = objectMapper.valueToTree(context.getProperties());
+    this.camundaClient = camundaClient;
+    this.processDefinitionProperties = objectMapper.valueToTree(context.getProperties());
   }
 
   @Override
@@ -67,9 +66,15 @@ public final class DefaultProcessInstanceContext implements ProcessInstanceConte
   @Override
   public <T> T bind(final Class<T> cls) {
     try {
+      var evaluator =
+          FeelExpressionEvaluatorBuilder.camundaClient(camundaClient)
+              .tenantId(context.getDefinition().tenantId())
+              .scopeKey(elementInstance.getElementInstanceKey())
+              .objectMapper(objectMapper)
+              .build();
       T mappedObject =
           FeelContextAwareObjectReader.of(objectMapper)
-              .withContextSupplier(operatePropertiesSupplier)
+              .withEvaluator(evaluator)
               .readValue(processDefinitionProperties, cls);
       validationProvider.validate(mappedObject);
       return mappedObject;

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/DefaultProcessInstanceContext.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/DefaultProcessInstanceContext.java
@@ -72,6 +72,11 @@ public final class DefaultProcessInstanceContext implements ProcessInstanceConte
   }
 
   @Override
+  public Long getElementInstanceKey() {
+    return elementInstance.getElementInstanceKey();
+  }
+
+  @Override
   public <T> T bind(final Class<T> cls) {
     try {
       T mappedObject =

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/DefaultProcessInstanceContext.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/DefaultProcessInstanceContext.java
@@ -24,6 +24,7 @@ import io.camunda.connector.api.inbound.CorrelationRequest;
 import io.camunda.connector.api.inbound.ProcessInstanceContext;
 import io.camunda.connector.api.validation.ValidationProvider;
 import io.camunda.connector.feel.FeelEngineWrapperException;
+import io.camunda.connector.feel.FeelExpressionEvaluator;
 import io.camunda.connector.feel.FeelExpressionEvaluatorBuilder;
 import io.camunda.connector.feel.jackson.FeelContextAwareObjectReader;
 import io.camunda.connector.runtime.core.inbound.correlation.InboundCorrelationHandler;
@@ -37,7 +38,7 @@ public final class DefaultProcessInstanceContext implements ProcessInstanceConte
   private final ValidationProvider validationProvider;
   private final ObjectMapper objectMapper;
   private final InboundCorrelationHandler correlationHandler;
-  private final CamundaClient camundaClient;
+  private final FeelExpressionEvaluator evaluator;
 
   private final JsonNode processDefinitionProperties;
 
@@ -56,7 +57,12 @@ public final class DefaultProcessInstanceContext implements ProcessInstanceConte
             : validationProvider;
     this.correlationHandler = correlationHandler;
     this.objectMapper = objectMapper;
-    this.camundaClient = camundaClient;
+    this.evaluator =
+        FeelExpressionEvaluatorBuilder.camundaClient(camundaClient)
+            .tenantId(context.getDefinition().tenantId())
+            .scopeKey(elementInstance.getElementInstanceKey())
+            .objectMapper(objectMapper)
+            .build();
     this.processDefinitionProperties = objectMapper.valueToTree(context.getProperties());
   }
 
@@ -67,15 +73,7 @@ public final class DefaultProcessInstanceContext implements ProcessInstanceConte
 
   @Override
   public <T> T bind(final Class<T> cls) {
-    String tenantId = context.getDefinition().tenantId();
-    Long scopeKey = elementInstance.getElementInstanceKey();
     try {
-      var evaluator =
-          FeelExpressionEvaluatorBuilder.camundaClient(camundaClient)
-              .tenantId(tenantId)
-              .scopeKey(scopeKey)
-              .objectMapper(objectMapper)
-              .build();
       T mappedObject =
           FeelContextAwareObjectReader.of(objectMapper)
               .withEvaluator(evaluator)
@@ -88,9 +86,9 @@ public final class DefaultProcessInstanceContext implements ProcessInstanceConte
               + cls.getName()
               + " using FEEL evaluation/deserialization"
               + " (tenantId="
-              + tenantId
+              + context.getDefinition().tenantId()
               + ", scopeKey="
-              + scopeKey
+              + elementInstance.getElementInstanceKey()
               + ")",
           e);
     }

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImpl.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImpl.java
@@ -283,22 +283,18 @@ public class InboundConnectorContextImpl extends AbstractConnectorContext
 
   @Override
   public <T> T bindProperties(Class<T> cls) {
-    try {
-      var evaluator =
-          FeelExpressionEvaluatorBuilder.camundaClient(camundaClient)
-              .tenantId(connectorDetails.tenantId())
-              .objectMapper(objectMapper)
-              .build();
-      var json = objectMapper.writeValueAsString(getPropertiesWithSecrets(properties));
-      var result =
-          FeelContextAwareObjectReader.of(objectMapper)
-              .withEvaluator(evaluator)
-              .readValue(json, cls);
-      getValidationProvider().validate(result);
-      return result;
-    } catch (java.io.IOException e) {
-      throw new RuntimeException("Failed to bind properties", e);
-    }
+    var evaluator =
+        FeelExpressionEvaluatorBuilder.camundaClient(camundaClient)
+            .tenantId(connectorDetails.tenantId())
+            .objectMapper(objectMapper)
+            .build();
+    var propertiesNode = objectMapper.valueToTree(getPropertiesWithSecrets(properties));
+    var result =
+        FeelContextAwareObjectReader.of(objectMapper)
+            .withEvaluator(evaluator)
+            .readValue(propertiesNode, cls);
+    getValidationProvider().validate(result);
+    return result;
   }
 
   @Override

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImpl.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImpl.java
@@ -37,6 +37,7 @@ import io.camunda.connector.api.secret.SecretContext;
 import io.camunda.connector.api.secret.SecretProvider;
 import io.camunda.connector.api.validation.ValidationProvider;
 import io.camunda.connector.feel.FeelEngineWrapperException;
+import io.camunda.connector.feel.FeelExpressionEvaluator;
 import io.camunda.connector.feel.FeelExpressionEvaluatorBuilder;
 import io.camunda.connector.feel.jackson.FeelContextAwareObjectReader;
 import io.camunda.connector.runtime.core.AbstractConnectorContext;
@@ -47,6 +48,7 @@ import io.camunda.connector.runtime.core.inbound.activitylog.ActivityLogWriter;
 import io.camunda.connector.runtime.core.inbound.activitylog.ActivitySource;
 import io.camunda.connector.runtime.core.inbound.correlation.InboundCorrelationHandler;
 import io.camunda.connector.runtime.core.inbound.details.InboundConnectorDetails.ValidInboundConnectorDetails;
+import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -59,17 +61,16 @@ public class InboundConnectorContextImpl extends AbstractConnectorContext
     implements InboundConnectorContext, InboundConnectorManagementContext {
 
   private final Logger LOG = LoggerFactory.getLogger(InboundConnectorContextImpl.class);
-  private ValidInboundConnectorDetails connectorDetails;
+  private final FeelExpressionEvaluator evaluator;
   private final Map<String, Object> properties;
-
   private final InboundCorrelationHandler correlationHandler;
   private final ObjectMapper objectMapper;
-
   private final Consumer<Throwable> cancellationCallback;
   private final ActivityLogWriter activityLogWriter;
   private final DocumentFactory documentFactory;
   private final Long activationTimestamp;
   private final CamundaClient camundaClient;
+  private ValidInboundConnectorDetails connectorDetails;
   private Health health = Health.unknown();
   private Map<String, Object> propertiesWithSecrets;
 
@@ -95,6 +96,11 @@ public class InboundConnectorContextImpl extends AbstractConnectorContext
     this.activityLogWriter = activityLogWriter;
     this.activationTimestamp = System.currentTimeMillis();
     this.camundaClient = Objects.requireNonNull(camundaClient, "camundaClient must not be null");
+    this.evaluator =
+        FeelExpressionEvaluatorBuilder.camundaClient(camundaClient)
+            .tenantId(connectorDetails.tenantId())
+            .objectMapper(objectMapper)
+            .build();
   }
 
   public InboundConnectorContextImpl(
@@ -284,11 +290,6 @@ public class InboundConnectorContextImpl extends AbstractConnectorContext
   @Override
   public <T> T bindProperties(Class<T> cls) {
     try {
-      var evaluator =
-          FeelExpressionEvaluatorBuilder.camundaClient(camundaClient)
-              .tenantId(connectorDetails.tenantId())
-              .objectMapper(objectMapper)
-              .build();
       var propertiesJson = objectMapper.valueToTree(getPropertiesWithSecrets(properties));
       var result =
           FeelContextAwareObjectReader.of(objectMapper)
@@ -296,8 +297,15 @@ public class InboundConnectorContextImpl extends AbstractConnectorContext
               .readValue(propertiesJson, cls);
       getValidationProvider().validate(result);
       return result;
-    } catch (java.io.IOException e) {
-      throw new RuntimeException("Failed to bind properties", e);
+    } catch (IOException | FeelEngineWrapperException e) {
+      throw new RuntimeException(
+          "Failed to bind process instance properties to "
+              + cls.getName()
+              + " using FEEL evaluation/deserialization"
+              + " (tenantId="
+              + connectorDetails.tenantId()
+              + ")",
+          e);
     }
   }
 

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImpl.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImpl.java
@@ -283,18 +283,22 @@ public class InboundConnectorContextImpl extends AbstractConnectorContext
 
   @Override
   public <T> T bindProperties(Class<T> cls) {
-    var evaluator =
-        FeelExpressionEvaluatorBuilder.camundaClient(camundaClient)
-            .tenantId(connectorDetails.tenantId())
-            .objectMapper(objectMapper)
-            .build();
-    var propertiesNode = objectMapper.valueToTree(getPropertiesWithSecrets(properties));
-    var result =
-        FeelContextAwareObjectReader.of(objectMapper)
-            .withEvaluator(evaluator)
-            .readValue(propertiesNode, cls);
-    getValidationProvider().validate(result);
-    return result;
+    try {
+      var evaluator =
+          FeelExpressionEvaluatorBuilder.camundaClient(camundaClient)
+              .tenantId(connectorDetails.tenantId())
+              .objectMapper(objectMapper)
+              .build();
+      var propertiesJson = objectMapper.valueToTree(getPropertiesWithSecrets(properties));
+      var result =
+          FeelContextAwareObjectReader.of(objectMapper)
+              .withEvaluator(evaluator)
+              .readValue(propertiesJson, cls);
+      getValidationProvider().validate(result);
+      return result;
+    } catch (java.io.IOException e) {
+      throw new RuntimeException("Failed to bind properties", e);
+    }
   }
 
   @Override

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImpl.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImpl.java
@@ -17,6 +17,7 @@
 package io.camunda.connector.runtime.core.inbound;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.client.CamundaClient;
 import io.camunda.connector.api.document.Document;
 import io.camunda.connector.api.document.DocumentCreationRequest;
 import io.camunda.connector.api.document.DocumentFactory;
@@ -36,6 +37,8 @@ import io.camunda.connector.api.secret.SecretContext;
 import io.camunda.connector.api.secret.SecretProvider;
 import io.camunda.connector.api.validation.ValidationProvider;
 import io.camunda.connector.feel.FeelEngineWrapperException;
+import io.camunda.connector.feel.FeelExpressionEvaluatorBuilder;
+import io.camunda.connector.feel.jackson.FeelContextAwareObjectReader;
 import io.camunda.connector.runtime.core.AbstractConnectorContext;
 import io.camunda.connector.runtime.core.document.DocumentFactoryImpl;
 import io.camunda.connector.runtime.core.document.store.InMemoryDocumentStore;
@@ -66,6 +69,7 @@ public class InboundConnectorContextImpl extends AbstractConnectorContext
   private final ActivityLogWriter activityLogWriter;
   private final DocumentFactory documentFactory;
   private final Long activationTimestamp;
+  private final CamundaClient camundaClient;
   private Health health = Health.unknown();
   private Map<String, Object> propertiesWithSecrets;
 
@@ -77,7 +81,8 @@ public class InboundConnectorContextImpl extends AbstractConnectorContext
       InboundCorrelationHandler correlationHandler,
       Consumer<Throwable> cancellationCallback,
       ObjectMapper objectMapper,
-      ActivityLogWriter activityLogWriter) {
+      ActivityLogWriter activityLogWriter,
+      CamundaClient camundaClient) {
     super(secretProvider, validationProvider);
     this.documentFactory = documentFactory;
     this.correlationHandler = correlationHandler;
@@ -89,6 +94,7 @@ public class InboundConnectorContextImpl extends AbstractConnectorContext
     this.cancellationCallback = cancellationCallback;
     this.activityLogWriter = activityLogWriter;
     this.activationTimestamp = System.currentTimeMillis();
+    this.camundaClient = Objects.requireNonNull(camundaClient, "camundaClient must not be null");
   }
 
   public InboundConnectorContextImpl(
@@ -98,7 +104,8 @@ public class InboundConnectorContextImpl extends AbstractConnectorContext
       InboundCorrelationHandler correlationHandler,
       Consumer<Throwable> cancellationCallback,
       ObjectMapper objectMapper,
-      ActivityLogWriter logs) {
+      ActivityLogWriter logs,
+      CamundaClient camundaClient) {
     this(
         secretProvider,
         validationProvider,
@@ -107,7 +114,8 @@ public class InboundConnectorContextImpl extends AbstractConnectorContext
         correlationHandler,
         cancellationCallback,
         objectMapper,
-        logs);
+        logs,
+        camundaClient);
   }
 
   @Override
@@ -275,9 +283,22 @@ public class InboundConnectorContextImpl extends AbstractConnectorContext
 
   @Override
   public <T> T bindProperties(Class<T> cls) {
-    var mappedObject = objectMapper.convertValue(getPropertiesWithSecrets(properties), cls);
-    getValidationProvider().validate(mappedObject);
-    return mappedObject;
+    try {
+      var evaluator =
+          FeelExpressionEvaluatorBuilder.camundaClient(camundaClient)
+              .tenantId(connectorDetails.tenantId())
+              .objectMapper(objectMapper)
+              .build();
+      var json = objectMapper.writeValueAsString(getPropertiesWithSecrets(properties));
+      var result =
+          FeelContextAwareObjectReader.of(objectMapper)
+              .withEvaluator(evaluator)
+              .readValue(json, cls);
+      getValidationProvider().validate(result);
+      return result;
+    } catch (java.io.IOException e) {
+      throw new RuntimeException("Failed to bind properties", e);
+    }
   }
 
   @Override

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/InboundIntermediateConnectorContextImpl.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/InboundIntermediateConnectorContextImpl.java
@@ -17,6 +17,7 @@
 package io.camunda.connector.runtime.core.inbound;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.client.CamundaClient;
 import io.camunda.client.api.search.response.ElementInstance;
 import io.camunda.connector.api.document.Document;
 import io.camunda.connector.api.document.DocumentCreationRequest;
@@ -29,7 +30,6 @@ import io.camunda.connector.runtime.core.inbound.details.InboundConnectorDetails
 import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
-import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 /**
@@ -44,19 +44,22 @@ public class InboundIntermediateConnectorContextImpl
   private final ObjectMapper objectMapper;
   private final InboundCorrelationHandler correlationHandler;
   private final Long activationTimestamp;
+  private final CamundaClient camundaClient;
 
   public InboundIntermediateConnectorContextImpl(
       final InboundConnectorManagementContext inboundContext,
       final ProcessInstanceClient processInstanceClient,
       final ValidationProvider validationProvider,
       final ObjectMapper objectMapper,
-      final InboundCorrelationHandler correlationHandler) {
+      final InboundCorrelationHandler correlationHandler,
+      final CamundaClient camundaClient) {
     this.inboundContext = inboundContext;
     this.processInstanceClient = processInstanceClient;
     this.validationProvider = validationProvider;
     this.objectMapper = objectMapper;
     this.correlationHandler = correlationHandler;
     this.activationTimestamp = System.currentTimeMillis();
+    this.camundaClient = camundaClient;
   }
 
   @Override
@@ -79,18 +82,8 @@ public class InboundIntermediateConnectorContextImpl
   }
 
   private ProcessInstanceContext createProcessInstanceContext(ElementInstance elementInstance) {
-    Supplier<Map<String, Object>> variableSupplier =
-        () ->
-            processInstanceClient.fetchVariablesByProcessInstanceKey(
-                elementInstance.getProcessInstanceKey(), elementInstance.getElementInstanceKey());
-
     return new DefaultProcessInstanceContext(
-        this,
-        elementInstance,
-        validationProvider,
-        correlationHandler,
-        objectMapper,
-        variableSupplier);
+        this, elementInstance, validationProvider, correlationHandler, objectMapper, camundaClient);
   }
 
   @Override

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/ProcessInstanceClient.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/ProcessInstanceClient.java
@@ -18,15 +18,13 @@ package io.camunda.connector.runtime.core.inbound;
 
 import io.camunda.client.api.search.response.ElementInstance;
 import java.util.List;
-import java.util.Map;
 
 /**
- * Provides a proxy interface to interact with Camunda Operate's APIs for retrieving information
- * related to active process instances and their variables.
+ * Provides a proxy interface for retrieving information related to active process instances.
  *
- * <p>This interface defines methods to fetch information about active process instances and their
- * associated variables. These methods facilitate communication with Camunda Operate's APIs and help
- * in obtaining relevant data for inbound connectors.
+ * <p>This interface defines methods to fetch information about active process instances. These
+ * methods facilitate communication with Camunda's APIs and help in obtaining relevant data for
+ * inbound connectors.
  */
 public interface ProcessInstanceClient {
 
@@ -43,14 +41,4 @@ public interface ProcessInstanceClient {
    */
   List<ElementInstance> fetchActiveProcessInstanceKeyByDefinitionKeyAndElementId(
       final Long processDefinitionKey, final String elementId);
-
-  /**
-   * Fetches the variables associated with a given active process instance identified by its key.
-   *
-   * @param processInstanceKey The unique identifier for the active process instance.
-   * @param elementInstanceKey The unique identifier for the active element instance.
-   * @return A {@link Map} containing the variables associated with the active process instance.
-   */
-  Map<String, Object> fetchVariablesByProcessInstanceKey(
-      final Long processInstanceKey, final Long elementInstanceKey);
 }

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/inbound/DefaultInboundConnectorContextFactoryTest.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/inbound/DefaultInboundConnectorContextFactoryTest.java
@@ -19,6 +19,7 @@ package io.camunda.connector.runtime.core.inbound;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.client.CamundaClient;
 import io.camunda.connector.api.document.DocumentFactory;
 import io.camunda.connector.api.inbound.InboundConnectorContext;
 import io.camunda.connector.api.inbound.InboundConnectorExecutable;
@@ -46,6 +47,7 @@ class DefaultInboundConnectorContextFactoryTest {
   @Mock private Consumer<Throwable> cancellationCallback;
   @Mock private ValidInboundConnectorDetails newConnector;
   @Mock private DocumentFactory documentFactory;
+  @Mock private CamundaClient camundaClient;
   private DefaultInboundConnectorContextFactory factory;
   private final ActivityLogRegistry activityLogRegistry = new ActivityLogRegistry();
 
@@ -58,7 +60,8 @@ class DefaultInboundConnectorContextFactoryTest {
             secretProviderAggregator,
             validationProvider,
             processInstanceClient,
-            documentFactory);
+            documentFactory,
+            camundaClient);
   }
 
   @Test

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/inbound/DefaultProcessInstanceContextTest.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/inbound/DefaultProcessInstanceContextTest.java
@@ -17,6 +17,7 @@
 package io.camunda.connector.runtime.core.inbound;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
@@ -73,6 +74,39 @@ class DefaultProcessInstanceContextTest {
     assertThat(result.getStr()).isEqualTo("scoped-result");
     verify(step2).tenantId(eq("tenant-A"));
     verify(step2).scopeKey(eq(987654321L));
+  }
+
+  @Test
+  void bind_shouldIncludeTenantAndScopeKeyWhenFeelBindingFails() {
+    // given
+    var intermediateContext = mock(InboundIntermediateConnectorContextImpl.class);
+    when(intermediateContext.getProperties()).thenReturn(Map.of("str", "= failing"));
+    when(intermediateContext.getDefinition())
+        .thenReturn(
+            new InboundConnectorDefinition("type", "tenant-A", "dedup", java.util.List.of()));
+
+    var elementInstance = mock(ElementInstance.class);
+    when(elementInstance.getElementInstanceKey()).thenReturn(987654321L);
+
+    var camundaClient = mock(CamundaClient.class, RETURNS_DEEP_STUBS);
+    var step2 = mock(EvaluateExpressionCommandStep2.class, RETURNS_DEEP_STUBS);
+    when(camundaClient.newEvaluateExpressionCommand().expression(any())).thenReturn(step2);
+    when(step2.send().join()).thenThrow(new RuntimeException("remote FEEL failed"));
+
+    ValidationProvider validationProvider = obj -> {};
+
+    var context =
+        new DefaultProcessInstanceContext(
+            intermediateContext, elementInstance, validationProvider, null, mapper, camundaClient);
+
+    // when/then
+    assertThatThrownBy(() -> context.bind(SimpleProps.class))
+        .isInstanceOf(RuntimeException.class)
+        .hasMessageContaining("Failed to bind process instance properties")
+        .hasMessageContaining(SimpleProps.class.getName())
+        .hasMessageContaining("tenantId=tenant-A")
+        .hasMessageContaining("scopeKey=987654321")
+        .hasRootCauseMessage("remote FEEL failed");
   }
 
   public static class SimpleProps {

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/inbound/DefaultProcessInstanceContextTest.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/inbound/DefaultProcessInstanceContextTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.runtime.core.inbound;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.command.EvaluateExpressionCommandStep1.EvaluateExpressionCommandStep2;
+import io.camunda.client.api.response.EvaluateExpressionResponse;
+import io.camunda.client.api.search.response.ElementInstance;
+import io.camunda.connector.api.annotation.FEEL;
+import io.camunda.connector.api.inbound.InboundConnectorDefinition;
+import io.camunda.connector.api.validation.ValidationProvider;
+import io.camunda.connector.runtime.core.TestObjectMapperSupplier;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class DefaultProcessInstanceContextTest {
+
+  private final ObjectMapper mapper = TestObjectMapperSupplier.INSTANCE;
+
+  @Test
+  void bind_shouldUseCamundaClientEvaluatorWithElementInstanceKeyAsScopeKey() {
+    // given
+    var intermediateContext = mock(InboundIntermediateConnectorContextImpl.class);
+    when(intermediateContext.getProperties()).thenReturn(Map.of("str", "= anything"));
+    when(intermediateContext.getDefinition())
+        .thenReturn(
+            new InboundConnectorDefinition("type", "tenant-A", "dedup", java.util.List.of()));
+
+    var elementInstance = mock(ElementInstance.class);
+    when(elementInstance.getElementInstanceKey()).thenReturn(987654321L);
+    when(elementInstance.getProcessInstanceKey()).thenReturn(111L);
+
+    var camundaClient = mock(CamundaClient.class, RETURNS_DEEP_STUBS);
+    var step2 = mock(EvaluateExpressionCommandStep2.class, RETURNS_DEEP_STUBS);
+    var response = mock(EvaluateExpressionResponse.class);
+    when(camundaClient.newEvaluateExpressionCommand().expression(any())).thenReturn(step2);
+    when(step2.send().join()).thenReturn(response);
+    when(response.getResult()).thenReturn("scoped-result");
+
+    ValidationProvider validationProvider = obj -> {};
+
+    var context =
+        new DefaultProcessInstanceContext(
+            intermediateContext, elementInstance, validationProvider, null, mapper, camundaClient);
+
+    // when
+    SimpleProps result = context.bind(SimpleProps.class);
+
+    // then
+    assertThat(result.getStr()).isEqualTo("scoped-result");
+    verify(step2).tenantId(eq("tenant-A"));
+    verify(step2).scopeKey(eq(987654321L));
+  }
+
+  public static class SimpleProps {
+    @FEEL private String str;
+
+    public String getStr() {
+      return str;
+    }
+
+    public void setStr(String str) {
+      this.str = str;
+    }
+  }
+}

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImplTest.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImplTest.java
@@ -281,9 +281,179 @@ class InboundConnectorContextImplTest {
             });
   }
 
+  /**
+   * Returns a {@link CamundaClient} mock whose {@code newEvaluateExpressionCommand().expression(x)}
+   * resolves to the value mapped from {@code x} in {@code expressionToResult}. Useful for verifying
+   * that {@link InboundConnectorContextImpl#bindProperties(Class)} forwards each {@code @FEEL}
+   * field as its own evaluation through the cluster.
+   */
+  private static CamundaClient mockClusterEvaluations(Map<String, Object> expressionToResult) {
+    var camundaClient = mock(CamundaClient.class, RETURNS_DEEP_STUBS);
+    var step2 = mock(EvaluateExpressionCommandStep2.class, RETURNS_DEEP_STUBS);
+    when(camundaClient.newEvaluateExpressionCommand().expression(any()))
+        .thenAnswer(
+            invocation -> {
+              String expression = invocation.getArgument(0, String.class);
+              var response = mock(EvaluateExpressionResponse.class);
+              when(response.getResult()).thenReturn(expressionToResult.get(expression));
+              when(step2.send().join()).thenReturn(response);
+              return step2;
+            });
+    return camundaClient;
+  }
+
+  @Test
+  void bindProperties_shouldBindListFromClusterResult() {
+    // given the cluster returns a List for a @FEEL List<String> field
+    var definition =
+        getInboundConnectorDefinition(Map.of("stringList", "=camunda.vars.env.RECIPIENTS"));
+    var camundaClient =
+        mockClusterEvaluations(
+            Map.of("=camunda.vars.env.RECIPIENTS", List.of("alice", "bob", "carol")));
+
+    var inboundConnectorContext =
+        new InboundConnectorContextImpl(
+            secretProvider,
+            (e) -> {},
+            null,
+            definition,
+            null,
+            (e) -> {},
+            mapper,
+            activityLogRegistry,
+            camundaClient);
+
+    // when
+    TestPropertiesClass result = inboundConnectorContext.bindProperties(TestPropertiesClass.class);
+
+    // then
+    assertThat(result.stringList).containsExactly("alice", "bob", "carol");
+  }
+
+  @Test
+  void bindProperties_shouldBindMapFromClusterResult() {
+    // given the cluster returns a Map for a @FEEL Map<String, String> field
+    var definition =
+        getInboundConnectorDefinition(Map.of("stringMap", "=camunda.vars.env.HEADERS"));
+    var camundaClient =
+        mockClusterEvaluations(
+            Map.of(
+                "=camunda.vars.env.HEADERS",
+                Map.of("Authorization", "Bearer 123", "X-Tenant", "acme")));
+
+    var inboundConnectorContext =
+        new InboundConnectorContextImpl(
+            secretProvider,
+            (e) -> {},
+            null,
+            definition,
+            null,
+            (e) -> {},
+            mapper,
+            activityLogRegistry,
+            camundaClient);
+
+    // when
+    TestPropertiesClass result = inboundConnectorContext.bindProperties(TestPropertiesClass.class);
+
+    // then
+    assertThat(result.stringMap)
+        .containsEntry("Authorization", "Bearer 123")
+        .containsEntry("X-Tenant", "acme");
+  }
+
+  @Test
+  void bindProperties_shouldBindNullFromClusterResult() {
+    // given the cluster returns null (e.g. optional cluster variable not set)
+    var definition =
+        getInboundConnectorDefinition(Map.of("str", "=camunda.vars.env.OPTIONAL_VALUE"));
+    var expressionToResult = new HashMap<String, Object>();
+    expressionToResult.put("=camunda.vars.env.OPTIONAL_VALUE", null);
+    var camundaClient = mockClusterEvaluations(expressionToResult);
+
+    var inboundConnectorContext =
+        new InboundConnectorContextImpl(
+            secretProvider,
+            (e) -> {},
+            null,
+            definition,
+            null,
+            (e) -> {},
+            mapper,
+            activityLogRegistry,
+            camundaClient);
+
+    // when
+    TestPropertiesClass result = inboundConnectorContext.bindProperties(TestPropertiesClass.class);
+
+    // then
+    assertThat(result.str).isNull();
+  }
+
+  @Test
+  void bindProperties_shouldConvertIntegerResultToLongField() {
+    // given the cluster returns an Integer but the target field is a Long
+    var definition =
+        getInboundConnectorDefinition(Map.of("longValue", "=camunda.vars.env.RETRY_LIMIT"));
+    var camundaClient =
+        mockClusterEvaluations(Map.of("=camunda.vars.env.RETRY_LIMIT", Integer.valueOf(42)));
+
+    var inboundConnectorContext =
+        new InboundConnectorContextImpl(
+            secretProvider,
+            (e) -> {},
+            null,
+            definition,
+            null,
+            (e) -> {},
+            mapper,
+            activityLogRegistry,
+            camundaClient);
+
+    // when
+    TestPropertiesClass result = inboundConnectorContext.bindProperties(TestPropertiesClass.class);
+
+    // then Jackson widens the Integer to Long during binding
+    assertThat(result.longValue).isEqualTo(42L);
+  }
+
+  @Test
+  void bindProperties_shouldBindNestedObjectFromClusterResult() {
+    // given the cluster returns a nested Map that should bind to a structured record
+    var definition =
+        getInboundConnectorDefinition(Map.of("inner", "=camunda.vars.env.NESTED_CONFIG"));
+    var camundaClient =
+        mockClusterEvaluations(
+            Map.of(
+                "=camunda.vars.env.NESTED_CONFIG",
+                Map.of("name", "primary", "values", List.of("x", "y"))));
+
+    var inboundConnectorContext =
+        new InboundConnectorContextImpl(
+            secretProvider,
+            (e) -> {},
+            null,
+            definition,
+            null,
+            (e) -> {},
+            mapper,
+            activityLogRegistry,
+            camundaClient);
+
+    // when
+    TestPropertiesClass result = inboundConnectorContext.bindProperties(TestPropertiesClass.class);
+
+    // then the nested JSON-like structure is bound to the record
+    assertThat(result.inner).isEqualTo(new InnerObject("primary", List.of("x", "y")));
+  }
+
   public static class TestPropertiesClass {
     @FEEL private String str;
     @FEEL private String second;
+    @FEEL private List<String> stringList;
+    @FEEL private Map<String, String> stringMap;
+    @FEEL private Long longValue;
+    @FEEL private InnerObject inner;
 
     public void setStr(final String str) {
       this.str = str;
@@ -292,5 +462,23 @@ class InboundConnectorContextImplTest {
     public void setSecond(final String second) {
       this.second = second;
     }
+
+    public void setStringList(final List<String> stringList) {
+      this.stringList = stringList;
+    }
+
+    public void setStringMap(final Map<String, String> stringMap) {
+      this.stringMap = stringMap;
+    }
+
+    public void setLongValue(final Long longValue) {
+      this.longValue = longValue;
+    }
+
+    public void setInner(final InnerObject inner) {
+      this.inner = inner;
+    }
   }
+
+  public record InnerObject(String name, List<String> values) {}
 }

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImplTest.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImplTest.java
@@ -17,13 +17,10 @@
 package io.camunda.connector.runtime.core.inbound;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.client.CamundaClient;
@@ -34,8 +31,11 @@ import io.camunda.connector.api.inbound.ActivityLogTag;
 import io.camunda.connector.api.inbound.Health;
 import io.camunda.connector.api.inbound.Severity;
 import io.camunda.connector.api.secret.SecretProvider;
+import io.camunda.connector.feel.FeelEngineWrapperException;
+import io.camunda.connector.feel.LocalFeelExpressionEvaluator;
 import io.camunda.connector.runtime.core.FooBarSecretProvider;
 import io.camunda.connector.runtime.core.TestObjectMapperSupplier;
+import io.camunda.connector.runtime.core.inbound.InboundConnectorContextImplTest.TestPropertiesClass.InnerObject;
 import io.camunda.connector.runtime.core.inbound.activitylog.ActivityLogRegistry;
 import io.camunda.connector.runtime.core.inbound.correlation.MessageCorrelationPoint.StandaloneMessageCorrelationPoint;
 import io.camunda.connector.runtime.core.inbound.details.InboundConnectorDetails;
@@ -43,6 +43,7 @@ import io.camunda.connector.runtime.core.inbound.details.InboundConnectorDetails
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
@@ -50,7 +51,13 @@ class InboundConnectorContextImplTest {
   private final SecretProvider secretProvider = new FooBarSecretProvider();
   private final ObjectMapper mapper = TestObjectMapperSupplier.INSTANCE;
   private final ActivityLogRegistry activityLogRegistry = new ActivityLogRegistry();
-  private final CamundaClient camundaClient = mock(CamundaClient.class, RETURNS_DEEP_STUBS);
+
+  /**
+   * Default {@link CamundaClient} stub for tests that don't care about cluster-specific behavior:
+   * it forwards each FEEL expression to a {@link LocalFeelExpressionEvaluator} so binding tests can
+   * exercise the cluster code path without mocking each expression individually.
+   */
+  private final CamundaClient camundaClient = camundaClientBackedByLocalFeel();
 
   private static ValidInboundConnectorDetails getInboundConnectorDefinition(
       Map<String, String> properties) {
@@ -69,6 +76,165 @@ class InboundConnectorContextImplTest {
     var details = InboundConnectorDetails.of(element.deduplicationId(List.of()), List.of(element));
     assertThat(details).isInstanceOf(ValidInboundConnectorDetails.class);
     return (ValidInboundConnectorDetails) details;
+  }
+
+  /**
+   * Builds a {@link CamundaClient} mock whose {@code newEvaluateExpressionCommand} chain resolves
+   * each expression via a real {@link LocalFeelExpressionEvaluator}. Useful for tests that want to
+   * verify end-to-end FEEL binding behavior through {@link
+   * InboundConnectorContextImpl#bindProperties(Class)} without re-stubbing per expression.
+   */
+  private static CamundaClient camundaClientBackedByLocalFeel() {
+    var local = new LocalFeelExpressionEvaluator();
+    var client = mock(CamundaClient.class, RETURNS_DEEP_STUBS);
+    var step2 = mock(EvaluateExpressionCommandStep2.class, RETURNS_DEEP_STUBS);
+    when(client.newEvaluateExpressionCommand().expression(any()))
+        .thenAnswer(
+            invocation -> {
+              String expression = invocation.getArgument(0, String.class);
+              var response = mock(EvaluateExpressionResponse.class);
+              when(response.getResult()).thenAnswer(unused -> local.evaluate(expression));
+              when(step2.send().join()).thenReturn(response);
+              return step2;
+            });
+    return client;
+  }
+
+  /**
+   * Builds a {@link CamundaClient} mock whose {@code newEvaluateExpressionCommand().expression(x)}
+   * resolves to the value mapped from {@code x} in {@code expressionToResult}. Useful for verifying
+   * that {@link InboundConnectorContextImpl#bindProperties(Class)} forwards each {@code @FEEL}
+   * field as its own evaluation through the cluster.
+   */
+  private static CamundaClient mockClusterEvaluations(Map<String, Object> expressionToResult) {
+    var camundaClient = mock(CamundaClient.class, RETURNS_DEEP_STUBS);
+    var step2 = mock(EvaluateExpressionCommandStep2.class, RETURNS_DEEP_STUBS);
+    when(camundaClient.newEvaluateExpressionCommand().expression(any()))
+        .thenAnswer(
+            invocation -> {
+              String expression = invocation.getArgument(0, String.class);
+              var response = mock(EvaluateExpressionResponse.class);
+              when(response.getResult()).thenReturn(expressionToResult.get(expression));
+              when(step2.send().join()).thenReturn(response);
+              return step2;
+            });
+    return camundaClient;
+  }
+
+  @Test
+  void bindProperties_shouldThrowExceptionWhenWrongFormat() {
+    // given
+    var definition = getInboundConnectorDefinition(Map.of("stringMap", "={{\"key\":\"value\"}"));
+    InboundConnectorContextImpl inboundConnectorContext =
+        new InboundConnectorContextImpl(
+            secretProvider,
+            (e) -> {},
+            definition,
+            null,
+            (e) -> {},
+            mapper,
+            activityLogRegistry,
+            camundaClient);
+    // when and then
+    RuntimeException exception =
+        assertThrows(
+            RuntimeException.class,
+            () -> inboundConnectorContext.bindProperties(TestPropertiesClass.class));
+    // Outer wrapper from bindProperties; the FEEL failure surfaces in the cause chain.
+    assertThat(exception).hasMessageContaining("Failed to bind process instance properties");
+    assertThat(exception).hasStackTraceContaining(FeelEngineWrapperException.class.getName());
+    assertThat(exception).hasStackTraceContaining("Failed to evaluate expression");
+  }
+
+  @Test
+  void bindProperties_shouldParseNullValue() {
+    // given
+    var definition = getInboundConnectorDefinition(Map.of("stringMap", "={\"keyString\":null}"));
+    InboundConnectorContextImpl inboundConnectorContext =
+        new InboundConnectorContextImpl(
+            secretProvider,
+            (e) -> {},
+            definition,
+            null,
+            (e) -> {},
+            mapper,
+            activityLogRegistry,
+            camundaClient);
+    // when
+    TestPropertiesClass propertiesAsType =
+        inboundConnectorContext.bindProperties(TestPropertiesClass.class);
+    // then
+    assertThat(propertiesAsType.getStringMap().containsKey("keyString")).isTrue();
+    assertThat(propertiesAsType.getStringMap().get("keyString")).isNull();
+  }
+
+  @Test
+  void bindProperties_shouldParseStringAsString() {
+    // given
+    var definition =
+        getInboundConnectorDefinition(
+            Map.of(
+                "mapWithStringListWithNumbers",
+                "={key:[\"34\", \"45\", \"890\",\"0\",\"16785\"]}"));
+    InboundConnectorContextImpl inboundConnectorContext =
+        new InboundConnectorContextImpl(
+            secretProvider,
+            (e) -> {},
+            definition,
+            null,
+            (e) -> {},
+            mapper,
+            activityLogRegistry,
+            camundaClient);
+    // when
+    TestPropertiesClass propertiesAsType =
+        inboundConnectorContext.bindProperties(TestPropertiesClass.class);
+    // then
+    assertThat(propertiesAsType.getMapWithStringListWithNumbers().get("key").getFirst())
+        .isInstanceOf(String.class);
+  }
+
+  @Test
+  void bindProperties_shouldParseAllObject() {
+    // Given
+    var definition =
+        getInboundConnectorDefinition(
+            Map.of(
+                "stringMap",
+                "={\"keyString\":\"valueString\"}",
+                "stringMapMap",
+                "={\"keyString\":{\"innerKeyString\":\"innerValueString\"}}",
+                "stringList",
+                "=[\"value1\", \"value2\", \"value3\"]",
+                "numberList",
+                "=[34, -45, 890, 0, -16785]",
+                "str",
+                "foo",
+                "bool",
+                "=true",
+                "mapWithNumberList",
+                "={\"key\":[43, 0, -123]}",
+                "mapWithStringListWithNumbers",
+                "={\"key\":[\"34\", \"45\", \"890\",\"0\",\"16785\"]}",
+                "stringNumberList",
+                "=[\"34\", \"-45\", \"890\", \"0\", \"-16785\"]",
+                "stringObjectMap",
+                "={\"innerObject\":{\"stringList\":[\"innerList\"], \"bool\":true}}"));
+    InboundConnectorContextImpl inboundConnectorContext =
+        new InboundConnectorContextImpl(
+            secretProvider,
+            (e) -> {},
+            definition,
+            null,
+            (e) -> {},
+            mapper,
+            activityLogRegistry,
+            camundaClient);
+    // when
+    TestPropertiesClass propertiesAsType =
+        inboundConnectorContext.bindProperties(TestPropertiesClass.class);
+    // then
+    assertThat(propertiesAsType).isEqualTo(createTestClass());
   }
 
   @Test
@@ -164,59 +330,6 @@ class InboundConnectorContextImplTest {
   }
 
   @Test
-  void bindProperties_shouldEvaluateMultipleFeelFieldsViaCluster() {
-    // given several @FEEL fields, each referencing distinct cluster/tenant variables
-    var definition =
-        getInboundConnectorDefinitionWithTenant(
-            Map.of(
-                "str", "=camunda.vars.env.API_KEY",
-                "second", "=camunda.vars.tenant.greeting"),
-            "tenant-acme");
-    var camundaClient = mock(CamundaClient.class, RETURNS_DEEP_STUBS);
-    var step2 = mock(EvaluateExpressionCommandStep2.class, RETURNS_DEEP_STUBS);
-    var expressionCaptor = ArgumentCaptor.forClass(String.class);
-    when(camundaClient.newEvaluateExpressionCommand().expression(expressionCaptor.capture()))
-        .thenReturn(step2);
-    when(step2.send().join())
-        .thenAnswer(
-            invocation -> {
-              var lastExpression =
-                  expressionCaptor.getAllValues().get(expressionCaptor.getAllValues().size() - 1);
-              var response = mock(EvaluateExpressionResponse.class);
-              if (lastExpression.contains("API_KEY")) {
-                when(response.getResult()).thenReturn("resolved-api-key");
-              } else if (lastExpression.contains("greeting")) {
-                when(response.getResult()).thenReturn("hello-acme");
-              }
-              return response;
-            });
-
-    InboundConnectorContextImpl inboundConnectorContext =
-        new InboundConnectorContextImpl(
-            secretProvider,
-            (e) -> {},
-            null,
-            definition,
-            null,
-            (e) -> {},
-            mapper,
-            activityLogRegistry,
-            camundaClient);
-
-    // when
-    TestPropertiesClass result = inboundConnectorContext.bindProperties(TestPropertiesClass.class);
-
-    // then both expressions were forwarded verbatim to the cluster
-    assertThat(expressionCaptor.getAllValues())
-        .containsExactlyInAnyOrder("=camunda.vars.env.API_KEY", "=camunda.vars.tenant.greeting");
-    // both results are bound to their respective fields
-    assertThat(result.str).isEqualTo("resolved-api-key");
-    assertThat(result.second).isEqualTo("hello-acme");
-    // tenant is propagated to every evaluation so tenant-scoped variables resolve correctly
-    verify(step2, org.mockito.Mockito.times(2)).tenantId(eq("tenant-acme"));
-  }
-
-  @Test
   void bindProperties_shouldUseCamundaClientEvaluatorWithTenantId() {
     // given
     var definition =
@@ -279,27 +392,6 @@ class InboundConnectorContextImplTest {
               assertThat(log.healthChange()).isEqualTo(health);
               assertThat(log.severity()).isEqualTo(Severity.ERROR);
             });
-  }
-
-  /**
-   * Returns a {@link CamundaClient} mock whose {@code newEvaluateExpressionCommand().expression(x)}
-   * resolves to the value mapped from {@code x} in {@code expressionToResult}. Useful for verifying
-   * that {@link InboundConnectorContextImpl#bindProperties(Class)} forwards each {@code @FEEL}
-   * field as its own evaluation through the cluster.
-   */
-  private static CamundaClient mockClusterEvaluations(Map<String, Object> expressionToResult) {
-    var camundaClient = mock(CamundaClient.class, RETURNS_DEEP_STUBS);
-    var step2 = mock(EvaluateExpressionCommandStep2.class, RETURNS_DEEP_STUBS);
-    when(camundaClient.newEvaluateExpressionCommand().expression(any()))
-        .thenAnswer(
-            invocation -> {
-              String expression = invocation.getArgument(0, String.class);
-              var response = mock(EvaluateExpressionResponse.class);
-              when(response.getResult()).thenReturn(expressionToResult.get(expression));
-              when(step2.send().join()).thenReturn(response);
-              return step2;
-            });
-    return camundaClient;
   }
 
   @Test
@@ -391,12 +483,14 @@ class InboundConnectorContextImplTest {
   }
 
   @Test
-  void bindProperties_shouldConvertIntegerResultToLongField() {
-    // given the cluster returns an Integer but the target field is a Long
+  void bindProperties_shouldConvertIntegerResultsToLongList() {
+    // given the cluster returns Integers but the target field is Map<String, List<Long>>
     var definition =
-        getInboundConnectorDefinition(Map.of("longValue", "=camunda.vars.env.RETRY_LIMIT"));
+        getInboundConnectorDefinition(
+            Map.of("mapWithNumberList", "=camunda.vars.env.RETRY_LIMITS"));
     var camundaClient =
-        mockClusterEvaluations(Map.of("=camunda.vars.env.RETRY_LIMIT", Integer.valueOf(42)));
+        mockClusterEvaluations(
+            Map.of("=camunda.vars.env.RETRY_LIMITS", Map.of("key", List.of(1, 2, 3))));
 
     var inboundConnectorContext =
         new InboundConnectorContextImpl(
@@ -413,20 +507,20 @@ class InboundConnectorContextImplTest {
     // when
     TestPropertiesClass result = inboundConnectorContext.bindProperties(TestPropertiesClass.class);
 
-    // then Jackson widens the Integer to Long during binding
-    assertThat(result.longValue).isEqualTo(42L);
+    // then Jackson widens the Integer elements to Long during binding
+    assertThat(result.mapWithNumberList).containsEntry("key", List.of(1L, 2L, 3L));
   }
 
   @Test
   void bindProperties_shouldBindNestedObjectFromClusterResult() {
-    // given the cluster returns a nested Map that should bind to a structured record
+    // given the cluster returns a nested Map that should bind to a Map<String, InnerObject>
     var definition =
-        getInboundConnectorDefinition(Map.of("inner", "=camunda.vars.env.NESTED_CONFIG"));
+        getInboundConnectorDefinition(Map.of("stringObjectMap", "=camunda.vars.env.NESTED_CONFIG"));
     var camundaClient =
         mockClusterEvaluations(
             Map.of(
                 "=camunda.vars.env.NESTED_CONFIG",
-                Map.of("name", "primary", "values", List.of("x", "y"))));
+                Map.of("inner", Map.of("stringList", List.of("x", "y"), "bool", true))));
 
     var inboundConnectorContext =
         new InboundConnectorContextImpl(
@@ -443,42 +537,148 @@ class InboundConnectorContextImplTest {
     // when
     TestPropertiesClass result = inboundConnectorContext.bindProperties(TestPropertiesClass.class);
 
-    // then the nested JSON-like structure is bound to the record
-    assertThat(result.inner).isEqualTo(new InnerObject("primary", List.of("x", "y")));
+    // then the nested JSON-like structure is bound to the record-valued map entry
+    assertThat(result.stringObjectMap)
+        .containsEntry("inner", new InnerObject(List.of("x", "y"), true));
+  }
+
+  private TestPropertiesClass createTestClass() {
+    TestPropertiesClass testClass = new TestPropertiesClass();
+    testClass.setStringMap(Map.of("keyString", "valueString"));
+    testClass.setStringMapMap(Map.of("keyString", Map.of("innerKeyString", "innerValueString")));
+    testClass.setStringList(List.of("value1", "value2", "value3"));
+    testClass.setNumberList(List.of(34, -45, 890, 0, -16785));
+    testClass.setStringNumberList(List.of("34", "-45", "890", "0", "-16785"));
+    testClass.setStr("foo");
+    testClass.setBool(true);
+    testClass.setMapWithNumberList(Map.of("key", List.of(43L, 0L, -123L)));
+    var innerObject = new InnerObject(List.of("innerList"), true);
+    testClass.setStringObjectMap(Map.of("innerObject", innerObject));
+    testClass.setMapWithStringListWithNumbers(
+        Map.of("key", List.of("34", "45", "890", "0", "16785")));
+    return testClass;
   }
 
   public static class TestPropertiesClass {
-    @FEEL private String str;
-    @FEEL private String second;
-    @FEEL private List<String> stringList;
     @FEEL private Map<String, String> stringMap;
-    @FEEL private Long longValue;
-    @FEEL private InnerObject inner;
+    @FEEL private Map<String, Map<String, String>> stringMapMap;
+    @FEEL private Map<String, InnerObject> stringObjectMap;
+    @FEEL private List<String> stringList;
+    @FEEL private List<Integer> numberList;
+    @FEEL private List<String> stringNumberList;
+    @FEEL private Map<String, List<Long>> mapWithNumberList;
+    @FEEL private Map<String, List<String>> mapWithStringListWithNumbers;
+    @FEEL private String str;
+    @FEEL private boolean bool;
 
-    public void setStr(final String str) {
-      this.str = str;
-    }
-
-    public void setSecond(final String second) {
-      this.second = second;
-    }
-
-    public void setStringList(final List<String> stringList) {
-      this.stringList = stringList;
+    public Map<String, String> getStringMap() {
+      return stringMap;
     }
 
     public void setStringMap(final Map<String, String> stringMap) {
       this.stringMap = stringMap;
     }
 
-    public void setLongValue(final Long longValue) {
-      this.longValue = longValue;
+    public void setStringMapMap(final Map<String, Map<String, String>> stringMapMap) {
+      this.stringMapMap = stringMapMap;
     }
 
-    public void setInner(final InnerObject inner) {
-      this.inner = inner;
+    public void setStringObjectMap(final Map<String, InnerObject> stringObjectMap) {
+      this.stringObjectMap = stringObjectMap;
+    }
+
+    public void setStringList(final List<String> stringList) {
+      this.stringList = stringList;
+    }
+
+    public void setNumberList(final List<Integer> numberList) {
+      this.numberList = numberList;
+    }
+
+    public void setStringNumberList(final List<String> stringNumberList) {
+      this.stringNumberList = stringNumberList;
+    }
+
+    public void setMapWithNumberList(final Map<String, List<Long>> mapWithNumberList) {
+      this.mapWithNumberList = mapWithNumberList;
+    }
+
+    public Map<String, List<String>> getMapWithStringListWithNumbers() {
+      return mapWithStringListWithNumbers;
+    }
+
+    public void setMapWithStringListWithNumbers(
+        final Map<String, List<String>> mapWithStringListWithNumbers) {
+      this.mapWithStringListWithNumbers = mapWithStringListWithNumbers;
+    }
+
+    public void setStr(final String str) {
+      this.str = str;
+    }
+
+    public void setBool(final boolean bool) {
+      this.bool = bool;
+    }
+
+    public record InnerObject(List<String> stringList, boolean bool) {}
+
+    @Override
+    public boolean equals(final Object o) {
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
+      final TestPropertiesClass that = (TestPropertiesClass) o;
+      return bool == that.bool
+          && Objects.equals(stringMap, that.stringMap)
+          && Objects.equals(stringMapMap, that.stringMapMap)
+          && Objects.equals(stringObjectMap, that.stringObjectMap)
+          && Objects.equals(stringList, that.stringList)
+          && Objects.equals(numberList, that.numberList)
+          && Objects.equals(stringNumberList, that.stringNumberList)
+          && Objects.equals(mapWithNumberList, that.mapWithNumberList)
+          && Objects.equals(mapWithStringListWithNumbers, that.mapWithStringListWithNumbers)
+          && Objects.equals(str, that.str);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(
+          stringMap,
+          stringMapMap,
+          stringObjectMap,
+          stringList,
+          numberList,
+          stringNumberList,
+          mapWithNumberList,
+          mapWithStringListWithNumbers,
+          str,
+          bool);
+    }
+
+    @Override
+    public String toString() {
+      return "TestPropertiesClass{"
+          + "stringMap="
+          + stringMap
+          + ", stringMapMap="
+          + stringMapMap
+          + ", stringObjectMap="
+          + stringObjectMap
+          + ", stringList="
+          + stringList
+          + ", numberList="
+          + numberList
+          + ", stringNumberList="
+          + stringNumberList
+          + ", mapWithNumberList="
+          + mapWithNumberList
+          + ", mapWithStringListWithNumbers="
+          + mapWithStringListWithNumbers
+          + ", str='"
+          + str
+          + "'"
+          + ", bool="
+          + bool
+          + "}";
     }
   }
-
-  public record InnerObject(String name, List<String> values) {}
 }

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImplTest.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImplTest.java
@@ -17,9 +17,18 @@
 package io.camunda.connector.runtime.core.inbound;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.command.EvaluateExpressionCommandStep1.EvaluateExpressionCommandStep2;
+import io.camunda.client.api.response.EvaluateExpressionResponse;
 import io.camunda.connector.api.annotation.FEEL;
 import io.camunda.connector.api.inbound.ActivityLogTag;
 import io.camunda.connector.api.inbound.Health;
@@ -27,7 +36,6 @@ import io.camunda.connector.api.inbound.Severity;
 import io.camunda.connector.api.secret.SecretProvider;
 import io.camunda.connector.runtime.core.FooBarSecretProvider;
 import io.camunda.connector.runtime.core.TestObjectMapperSupplier;
-import io.camunda.connector.runtime.core.inbound.InboundConnectorContextImplTest.TestPropertiesClass.InnerObject;
 import io.camunda.connector.runtime.core.inbound.activitylog.ActivityLogRegistry;
 import io.camunda.connector.runtime.core.inbound.correlation.MessageCorrelationPoint.StandaloneMessageCorrelationPoint;
 import io.camunda.connector.runtime.core.inbound.details.InboundConnectorDetails;
@@ -35,111 +43,31 @@ import io.camunda.connector.runtime.core.inbound.details.InboundConnectorDetails
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import org.junit.jupiter.api.Test;
 
 class InboundConnectorContextImplTest {
   private final SecretProvider secretProvider = new FooBarSecretProvider();
   private final ObjectMapper mapper = TestObjectMapperSupplier.INSTANCE;
   private final ActivityLogRegistry activityLogRegistry = new ActivityLogRegistry();
-
-  @Test
-  void bindProperties_shouldThrowExceptionWhenWrongFormat() {
-    // given
-    var definition = getInboundConnectorDefinition(Map.of("stringMap", "={{\"key\":\"value\"}"));
-    InboundConnectorContextImpl inboundConnectorContext =
-        new InboundConnectorContextImpl(
-            secretProvider, (e) -> {}, definition, null, (e) -> {}, mapper, activityLogRegistry);
-    // when and then
-    RuntimeException exception =
-        assertThrows(
-            RuntimeException.class,
-            () -> inboundConnectorContext.bindProperties(TestPropertiesClass.class));
-    assertThat(exception.getMessage()).contains("Failed to evaluate expression");
-  }
-
-  @Test
-  void bindProperties_shouldParseNullValue() {
-    // given
-    var definition = getInboundConnectorDefinition(Map.of("stringMap", "={\"keyString\":null}"));
-    InboundConnectorContextImpl inboundConnectorContext =
-        new InboundConnectorContextImpl(
-            secretProvider, (e) -> {}, definition, null, (e) -> {}, mapper, activityLogRegistry);
-    // when
-    TestPropertiesClass propertiesAsType =
-        inboundConnectorContext.bindProperties(TestPropertiesClass.class);
-    // then
-    assertThat(propertiesAsType.getStringMap().containsKey("keyString")).isTrue();
-    assertThat(propertiesAsType.getStringMap().get("keyString")).isNull();
-  }
-
-  @Test
-  void bindProperties_shouldParseStringAsString() {
-    // given
-    var definition =
-        getInboundConnectorDefinition(
-            Map.of(
-                "mapWithStringListWithNumbers",
-                "={key:[\"34\", \"45\", \"890\",\"0\",\"16785\"]}"));
-    InboundConnectorContextImpl inboundConnectorContext =
-        new InboundConnectorContextImpl(
-            secretProvider, (e) -> {}, definition, null, (e) -> {}, mapper, activityLogRegistry);
-    // when
-    TestPropertiesClass propertiesAsType =
-        inboundConnectorContext.bindProperties(TestPropertiesClass.class);
-    // then
-    assertThat(propertiesAsType.getMapWithStringListWithNumbers().get("key").getFirst())
-        .isInstanceOf(String.class);
-  }
+  private final CamundaClient camundaClient = mock(CamundaClient.class, RETURNS_DEEP_STUBS);
 
   private static ValidInboundConnectorDetails getInboundConnectorDefinition(
       Map<String, String> properties) {
+    return getInboundConnectorDefinitionWithTenant(properties, "<default>");
+  }
+
+  private static ValidInboundConnectorDetails getInboundConnectorDefinitionWithTenant(
+      Map<String, String> properties, String tenantId) {
     properties = new HashMap<>(properties);
     properties.put("inbound.type", "io.camunda:connector:1");
     InboundConnectorElement element =
         new InboundConnectorElement(
             properties,
             new StandaloneMessageCorrelationPoint("", "", null, null),
-            new ProcessElementWithRuntimeData("bool", 0, 0, "id", "<default>"));
+            new ProcessElementWithRuntimeData("bool", 0, 0, "id", tenantId));
     var details = InboundConnectorDetails.of(element.deduplicationId(List.of()), List.of(element));
     assertThat(details).isInstanceOf(ValidInboundConnectorDetails.class);
     return (ValidInboundConnectorDetails) details;
-  }
-
-  @Test
-  void bindProperties_shouldParseAllObject() {
-    // Given
-    var definition =
-        getInboundConnectorDefinition(
-            Map.of(
-                "stringMap",
-                "={\"keyString\":\"valueString\"}",
-                "stringMapMap",
-                "={\"keyString\":{\"innerKeyString\":\"innerValueString\"}}",
-                "stringList",
-                "=[\"value1\", \"value2\", \"value3\"]",
-                "numberList",
-                "=[34, -45, 890, 0, -16785]",
-                "str",
-                "foo",
-                "bool",
-                "=true",
-                "mapWithNumberList",
-                "={\"key\":[43, 0, -123]}",
-                "mapWithStringListWithNumbers",
-                "={\"key\":[\"34\", \"45\", \"890\",\"0\",\"16785\"]}",
-                "stringNumberList",
-                "=[\"34\", \"-45\", \"890\", \"0\", \"-16785\"]",
-                "stringObjectMap",
-                "={\"innerObject\":{\"stringList\":[\"innerList\"], \"bool\":true}}"));
-    InboundConnectorContextImpl inboundConnectorContext =
-        new InboundConnectorContextImpl(
-            secretProvider, (e) -> {}, definition, null, (e) -> {}, mapper, activityLogRegistry);
-    // when
-    TestPropertiesClass propertiesAsType =
-        inboundConnectorContext.bindProperties(TestPropertiesClass.class);
-    // then
-    assertThat(propertiesAsType).isEqualTo(createTestClass());
   }
 
   @Test
@@ -149,7 +77,14 @@ class InboundConnectorContextImplTest {
 
     InboundConnectorContextImpl inboundConnectorContext =
         new InboundConnectorContextImpl(
-            secretProvider, (e) -> {}, definition, null, (e) -> {}, mapper, activityLogRegistry);
+            secretProvider,
+            (e) -> {},
+            definition,
+            null,
+            (e) -> {},
+            mapper,
+            activityLogRegistry,
+            camundaClient);
 
     // when
     Map<String, Object> properties = inboundConnectorContext.getProperties();
@@ -165,7 +100,14 @@ class InboundConnectorContextImplTest {
     var health = Health.up();
     InboundConnectorContextImpl inboundConnectorContext =
         new InboundConnectorContextImpl(
-            secretProvider, (e) -> {}, definition, null, (e) -> {}, mapper, activityLogRegistry);
+            secretProvider,
+            (e) -> {},
+            definition,
+            null,
+            (e) -> {},
+            mapper,
+            activityLogRegistry,
+            camundaClient);
 
     // when
     inboundConnectorContext.reportHealth(health);
@@ -184,13 +126,53 @@ class InboundConnectorContextImplTest {
   }
 
   @Test
+  void bindProperties_shouldUseCamundaClientEvaluatorWithTenantId() {
+    // given
+    var definition =
+        getInboundConnectorDefinitionWithTenant(Map.of("str", "= anything"), "tenant-1");
+    var camundaClient = mock(CamundaClient.class, RETURNS_DEEP_STUBS);
+    var step2 = mock(EvaluateExpressionCommandStep2.class, RETURNS_DEEP_STUBS);
+    var response = mock(EvaluateExpressionResponse.class);
+    when(camundaClient.newEvaluateExpressionCommand().expression(any())).thenReturn(step2);
+    when(step2.send().join()).thenReturn(response);
+    when(response.getResult()).thenReturn("evaluated-by-cluster");
+
+    InboundConnectorContextImpl inboundConnectorContext =
+        new InboundConnectorContextImpl(
+            secretProvider,
+            (e) -> {},
+            null,
+            definition,
+            null,
+            (e) -> {},
+            mapper,
+            activityLogRegistry,
+            camundaClient);
+
+    // when
+    TestPropertiesClass result = inboundConnectorContext.bindProperties(TestPropertiesClass.class);
+
+    // then
+    assertThat(result.str).isEqualTo("evaluated-by-cluster");
+    verify(step2).tenantId(eq("tenant-1"));
+    verify(step2, never()).scopeKey(org.mockito.ArgumentMatchers.anyLong());
+  }
+
+  @Test
   void reportHealth_shouldLogErrorSeverityWhenStatusIsDown() {
     // given
     var definition = getInboundConnectorDefinition(Map.of());
     var health = Health.down();
     InboundConnectorContextImpl inboundConnectorContext =
         new InboundConnectorContextImpl(
-            secretProvider, (e) -> {}, definition, null, (e) -> {}, mapper, activityLogRegistry);
+            secretProvider,
+            (e) -> {},
+            definition,
+            null,
+            (e) -> {},
+            mapper,
+            activityLogRegistry,
+            camundaClient);
 
     // when
     inboundConnectorContext.reportHealth(health);
@@ -208,143 +190,11 @@ class InboundConnectorContextImplTest {
             });
   }
 
-  private TestPropertiesClass createTestClass() {
-    TestPropertiesClass testClass = new TestPropertiesClass();
-    testClass.setStringMap(Map.of("keyString", "valueString"));
-    testClass.setStringMapMap(Map.of("keyString", Map.of("innerKeyString", "innerValueString")));
-    testClass.setStringList(List.of("value1", "value2", "value3"));
-    testClass.setNumberList(List.of(34, -45, 890, 0, -16785));
-    testClass.setStringNumberList(List.of("34", "-45", "890", "0", "-16785"));
-    testClass.setStr("foo");
-    testClass.setBool(true);
-    testClass.setMapWithNumberList(Map.of("key", List.of(43L, 0L, -123L)));
-    var innerObject = new InnerObject(List.of("innerList"), true);
-    testClass.setStringObjectMap(Map.of("innerObject", innerObject));
-    testClass.setMapWithStringListWithNumbers(
-        Map.of("key", List.of("34", "45", "890", "0", "16785")));
-    return testClass;
-  }
-
   public static class TestPropertiesClass {
-    @FEEL private Map<String, String> stringMap;
-    @FEEL private Map<String, Map<String, String>> stringMapMap;
-    @FEEL private Map<String, InnerObject> stringObjectMap;
-    @FEEL private List<String> stringList;
-    @FEEL private List<Integer> numberList;
-    @FEEL private List<String> stringNumberList;
-    @FEEL private Map<String, List<Long>> mapWithNumberList;
-    @FEEL private Map<String, List<String>> mapWithStringListWithNumbers;
     @FEEL private String str;
-    @FEEL private boolean bool;
-
-    public Map<String, String> getStringMap() {
-      return stringMap;
-    }
-
-    public void setStringMap(final Map<String, String> stringMap) {
-      this.stringMap = stringMap;
-    }
-
-    public void setStringMapMap(final Map<String, Map<String, String>> stringMapMap) {
-      this.stringMapMap = stringMapMap;
-    }
-
-    public void setStringObjectMap(final Map<String, InnerObject> stringObjectMap) {
-      this.stringObjectMap = stringObjectMap;
-    }
-
-    public void setStringList(final List<String> stringList) {
-      this.stringList = stringList;
-    }
-
-    public void setNumberList(final List<Integer> numberList) {
-      this.numberList = numberList;
-    }
-
-    public void setStringNumberList(final List<String> stringNumberList) {
-      this.stringNumberList = stringNumberList;
-    }
-
-    public void setMapWithNumberList(final Map<String, List<Long>> mapWithNumberList) {
-      this.mapWithNumberList = mapWithNumberList;
-    }
-
-    public Map<String, List<String>> getMapWithStringListWithNumbers() {
-      return mapWithStringListWithNumbers;
-    }
-
-    public void setMapWithStringListWithNumbers(
-        final Map<String, List<String>> mapWithStringListWithNumbers) {
-      this.mapWithStringListWithNumbers = mapWithStringListWithNumbers;
-    }
 
     public void setStr(final String str) {
       this.str = str;
-    }
-
-    public void setBool(final boolean bool) {
-      this.bool = bool;
-    }
-
-    public record InnerObject(List<String> stringList, boolean bool) {}
-
-    @Override
-    public boolean equals(final Object o) {
-      if (this == o) return true;
-      if (o == null || getClass() != o.getClass()) return false;
-      final TestPropertiesClass that = (TestPropertiesClass) o;
-      return bool == that.bool
-          && Objects.equals(stringMap, that.stringMap)
-          && Objects.equals(stringMapMap, that.stringMapMap)
-          && Objects.equals(stringObjectMap, that.stringObjectMap)
-          && Objects.equals(stringList, that.stringList)
-          && Objects.equals(numberList, that.numberList)
-          && Objects.equals(stringNumberList, that.stringNumberList)
-          && Objects.equals(mapWithNumberList, that.mapWithNumberList)
-          && Objects.equals(mapWithStringListWithNumbers, that.mapWithStringListWithNumbers)
-          && Objects.equals(str, that.str);
-    }
-
-    @Override
-    public int hashCode() {
-      return Objects.hash(
-          stringMap,
-          stringMapMap,
-          stringObjectMap,
-          stringList,
-          numberList,
-          stringNumberList,
-          mapWithNumberList,
-          mapWithStringListWithNumbers,
-          str,
-          bool);
-    }
-
-    @Override
-    public String toString() {
-      return "TestPropertiesClass{"
-          + "stringMap="
-          + stringMap
-          + ", stringMapMap="
-          + stringMapMap
-          + ", stringObjectMap="
-          + stringObjectMap
-          + ", stringList="
-          + stringList
-          + ", numberList="
-          + numberList
-          + ", stringNumberList="
-          + stringNumberList
-          + ", mapWithNumberList="
-          + mapWithNumberList
-          + ", mapWithStringListWithNumbers="
-          + mapWithStringListWithNumbers
-          + ", str='"
-          + str
-          + "'"
-          + ", bool="
-          + bool
-          + "}";
     }
   }
 }

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImplTest.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImplTest.java
@@ -44,6 +44,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 
 class InboundConnectorContextImplTest {
   private final SecretProvider secretProvider = new FooBarSecretProvider();
@@ -126,6 +127,96 @@ class InboundConnectorContextImplTest {
   }
 
   @Test
+  void bindProperties_shouldForwardClusterVariableExpressionToCluster() {
+    // given a property referencing a cluster-scoped variable (e.g. camunda.vars.env.*)
+    var definition =
+        getInboundConnectorDefinitionWithTenant(
+            Map.of("str", "=camunda.vars.env.MY_API_KEY"), "tenant-1");
+    var camundaClient = mock(CamundaClient.class, RETURNS_DEEP_STUBS);
+    var step2 = mock(EvaluateExpressionCommandStep2.class, RETURNS_DEEP_STUBS);
+    var response = mock(EvaluateExpressionResponse.class);
+    var expressionCaptor = ArgumentCaptor.forClass(String.class);
+    when(camundaClient.newEvaluateExpressionCommand().expression(expressionCaptor.capture()))
+        .thenReturn(step2);
+    when(step2.send().join()).thenReturn(response);
+    when(response.getResult()).thenReturn("resolved-api-key");
+
+    InboundConnectorContextImpl inboundConnectorContext =
+        new InboundConnectorContextImpl(
+            secretProvider,
+            (e) -> {},
+            null,
+            definition,
+            null,
+            (e) -> {},
+            mapper,
+            activityLogRegistry,
+            camundaClient);
+
+    // when
+    TestPropertiesClass result = inboundConnectorContext.bindProperties(TestPropertiesClass.class);
+
+    // then the cluster receives the expression verbatim and the result is bound
+    assertThat(expressionCaptor.getValue()).contains("camunda.vars.env.MY_API_KEY");
+    assertThat(result.str).isEqualTo("resolved-api-key");
+    // tenant must be propagated so cluster variables can be resolved against the right scope
+    verify(step2).tenantId(eq("tenant-1"));
+  }
+
+  @Test
+  void bindProperties_shouldEvaluateMultipleFeelFieldsViaCluster() {
+    // given several @FEEL fields, each referencing distinct cluster/tenant variables
+    var definition =
+        getInboundConnectorDefinitionWithTenant(
+            Map.of(
+                "str", "=camunda.vars.env.API_KEY",
+                "second", "=camunda.vars.tenant.greeting"),
+            "tenant-acme");
+    var camundaClient = mock(CamundaClient.class, RETURNS_DEEP_STUBS);
+    var step2 = mock(EvaluateExpressionCommandStep2.class, RETURNS_DEEP_STUBS);
+    var expressionCaptor = ArgumentCaptor.forClass(String.class);
+    when(camundaClient.newEvaluateExpressionCommand().expression(expressionCaptor.capture()))
+        .thenReturn(step2);
+    when(step2.send().join())
+        .thenAnswer(
+            invocation -> {
+              var lastExpression =
+                  expressionCaptor.getAllValues().get(expressionCaptor.getAllValues().size() - 1);
+              var response = mock(EvaluateExpressionResponse.class);
+              if (lastExpression.contains("API_KEY")) {
+                when(response.getResult()).thenReturn("resolved-api-key");
+              } else if (lastExpression.contains("greeting")) {
+                when(response.getResult()).thenReturn("hello-acme");
+              }
+              return response;
+            });
+
+    InboundConnectorContextImpl inboundConnectorContext =
+        new InboundConnectorContextImpl(
+            secretProvider,
+            (e) -> {},
+            null,
+            definition,
+            null,
+            (e) -> {},
+            mapper,
+            activityLogRegistry,
+            camundaClient);
+
+    // when
+    TestPropertiesClass result = inboundConnectorContext.bindProperties(TestPropertiesClass.class);
+
+    // then both expressions were forwarded verbatim to the cluster
+    assertThat(expressionCaptor.getAllValues())
+        .containsExactlyInAnyOrder("=camunda.vars.env.API_KEY", "=camunda.vars.tenant.greeting");
+    // both results are bound to their respective fields
+    assertThat(result.str).isEqualTo("resolved-api-key");
+    assertThat(result.second).isEqualTo("hello-acme");
+    // tenant is propagated to every evaluation so tenant-scoped variables resolve correctly
+    verify(step2, org.mockito.Mockito.times(2)).tenantId(eq("tenant-acme"));
+  }
+
+  @Test
   void bindProperties_shouldUseCamundaClientEvaluatorWithTenantId() {
     // given
     var definition =
@@ -192,9 +283,14 @@ class InboundConnectorContextImplTest {
 
   public static class TestPropertiesClass {
     @FEEL private String str;
+    @FEEL private String second;
 
     public void setStr(final String str) {
       this.str = str;
+    }
+
+    public void setSecond(final String second) {
+      this.second = second;
     }
   }
 }

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/InboundConnectorRuntimeConfiguration.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/InboundConnectorRuntimeConfiguration.java
@@ -100,14 +100,16 @@ public class InboundConnectorRuntimeConfiguration {
       SecretProviderAggregator secretProviderAggregator,
       @Autowired(required = false) ValidationProvider validationProvider,
       ProcessInstanceClient processInstanceClient,
-      DocumentFactory documentFactory) {
+      DocumentFactory documentFactory,
+      CamundaClient camundaClient) {
     return new DefaultInboundConnectorContextFactory(
         mapper,
         correlationHandler,
         secretProviderAggregator,
         validationProvider,
         processInstanceClient,
-        documentFactory);
+        documentFactory,
+        camundaClient);
   }
 
   @Bean

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/search/ProcessInstanceClientConfiguration.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/search/ProcessInstanceClientConfiguration.java
@@ -16,8 +16,6 @@
  */
 package io.camunda.connector.runtime.inbound.search;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import io.camunda.connector.runtime.annotation.ConnectorsObjectMapper;
 import io.camunda.connector.runtime.core.inbound.ProcessInstanceClient;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -25,8 +23,7 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 public class ProcessInstanceClientConfiguration {
   @Bean
-  public ProcessInstanceClient springProcessInstanceClient(
-      SearchQueryClient searchQueryClient, @ConnectorsObjectMapper ObjectMapper mapper) {
-    return new ProcessInstanceClientImpl(searchQueryClient, mapper);
+  public ProcessInstanceClient springProcessInstanceClient(SearchQueryClient searchQueryClient) {
+    return new ProcessInstanceClientImpl(searchQueryClient);
   }
 }

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/search/ProcessInstanceClientImpl.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/search/ProcessInstanceClientImpl.java
@@ -16,36 +16,23 @@
  */
 package io.camunda.connector.runtime.inbound.search;
 
-import static org.apache.commons.lang3.StringUtils.isNotBlank;
-
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.client.api.search.response.ElementInstance;
 import io.camunda.client.api.search.response.SearchResponse;
-import io.camunda.client.api.search.response.Variable;
 import io.camunda.connector.runtime.core.inbound.ProcessInstanceClient;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
-import java.util.stream.Collectors;
 import org.springframework.util.CollectionUtils;
 
 public class ProcessInstanceClientImpl implements ProcessInstanceClient {
 
   private final SearchQueryClient searchQueryClient;
-  private final ObjectMapper mapper;
   private final Lock fetchActiveProcessLock;
-  private final Lock fetchVariablesLock;
 
-  public ProcessInstanceClientImpl(
-      final SearchQueryClient searchQueryClient, final ObjectMapper mapper) {
+  public ProcessInstanceClientImpl(final SearchQueryClient searchQueryClient) {
     this.searchQueryClient = searchQueryClient;
-    this.mapper = mapper;
     this.fetchActiveProcessLock = new ReentrantLock();
-    this.fetchVariablesLock = new ReentrantLock();
   }
 
   /**
@@ -81,84 +68,5 @@ public class ProcessInstanceClientImpl implements ProcessInstanceClient {
     } finally {
       fetchActiveProcessLock.unlock();
     }
-  }
-
-  /**
-   * Fetches the variables associated with a given active process instance identified by its key.
-   * The variables are dynamic and may change over the lifetime of the process instance.
-   *
-   * @param processInstanceKey The unique identifier for the active process instance to retrieve
-   *     variables of.
-   * @param elementInstanceKey The unique identifier for the active element instance to retrieve
-   *     variables of.
-   * @return A map containing the variables associated with the active process and element instance.
-   * @throws RuntimeException If an error occurs during the fetch operation.
-   */
-  @Override
-  public Map<String, Object> fetchVariablesByProcessInstanceKey(
-      final Long processInstanceKey, final Long elementInstanceKey) {
-    fetchVariablesLock.lock();
-    try {
-      String variablePaginationIndex = null;
-      SearchResponse<Variable> searchResult;
-      Map<String, Object> processVariables = new HashMap<>();
-      do {
-        searchResult =
-            searchQueryClient.queryVariables(
-                processInstanceKey, elementInstanceKey, variablePaginationIndex);
-        String newPaginationIdx = searchResult.page().endCursor();
-        if (searchResult.items() != null) {
-          processVariables.putAll(
-              searchResult.items().stream()
-                  .collect(
-                      Collectors.toMap(
-                          Variable::getName, variable -> unwrapValue(variable.getValue()))));
-        }
-        if (isNotBlank(newPaginationIdx)) {
-          variablePaginationIndex = newPaginationIdx;
-        }
-
-      } while (!CollectionUtils.isEmpty(searchResult.items()));
-      return processVariables;
-    } finally {
-      fetchVariablesLock.unlock();
-    }
-  }
-
-  /**
-   * Unwraps a value that could either be a regular string or a serialized object.
-   *
-   * <p>This method takes a string and tries to deserialize it into its original object form if it's
-   * serialized. It covers basic types like String, Number, Boolean, List, and Map. If the input is
-   * a regular string, it returns the string as is.
-   *
-   * @param wrappedValue The string that might wrap a serialized object.
-   * @return The unwrapped native object, or the original string if it's not serialized.
-   */
-  private Object unwrapValue(String wrappedValue) {
-    try {
-      // First, attempt to parse as JSON
-      JsonNode node = mapper.readTree(wrappedValue);
-
-      // If parsing was successful, unwrap based on the detected type
-      if (node.isTextual()) {
-        return node.textValue();
-      } else if (node.isNumber()) {
-        return node.numberValue();
-      } else if (node.isArray()) {
-        return mapper.readValue(wrappedValue, List.class);
-      } else if (node.isObject()) {
-        return mapper.readValue(wrappedValue, Map.class);
-      } else if (node.isNull()) {
-        return wrappedValue;
-      } else if (node.isBoolean()) {
-        return node.booleanValue();
-      }
-    } catch (Exception e) {
-      // If parsing fails, it's a regular string; return as is
-      return wrappedValue;
-    }
-    // Default fallback: return the original string
-    return wrappedValue;
   }
 }

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/search/SearchQueryClient.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/search/SearchQueryClient.java
@@ -19,7 +19,6 @@ package io.camunda.connector.runtime.inbound.search;
 import io.camunda.client.api.search.response.ElementInstance;
 import io.camunda.client.api.search.response.ProcessDefinition;
 import io.camunda.client.api.search.response.SearchResponse;
-import io.camunda.client.api.search.response.Variable;
 import io.camunda.client.api.statistics.response.ProcessDefinitionMessageSubscriptionStatistics;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 
@@ -33,9 +32,6 @@ public interface SearchQueryClient {
 
   SearchResponse<ElementInstance> queryActiveFlowNodes(
       long processDefinitionKey, String elementId, String paginationIndex);
-
-  SearchResponse<Variable> queryVariables(
-      long processInstanceKey, long elementInstanceKey, String variablePaginationIndex);
 
   BpmnModelInstance getProcessModel(long processDefinitionKey);
 

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/search/SearchQueryClientImpl.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/search/SearchQueryClientImpl.java
@@ -88,24 +88,6 @@ public class SearchQueryClientImpl implements SearchQueryClient {
   }
 
   @Override
-  public SearchResponse<Variable> queryVariables(
-      long processInstanceKey, long elementInstanceKey, String variablePaginationIndex) {
-    final var query =
-        camundaClient
-            .newVariableSearchRequest()
-            .filter(
-                v ->
-                    v.processInstanceKey(processInstanceKey)
-                        .scopeKey(s -> s.in(processInstanceKey, elementInstanceKey)));
-    if (variablePaginationIndex != null) {
-      query.page(p -> p.limit(limit).after(variablePaginationIndex));
-    } else {
-      query.page(p -> p.limit(limit));
-    }
-    return query.send().join();
-  }
-
-  @Override
   public BpmnModelInstance getProcessModel(long processDefinitionKey) {
     final String xml =
         camundaClient.newProcessDefinitionGetXmlRequest(processDefinitionKey).send().join();

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/inbound/executable/InboundExecutableRegistryTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/inbound/executable/InboundExecutableRegistryTest.java
@@ -387,7 +387,7 @@ public class InboundExecutableRegistryTest {
             null,
             t -> registry.handleEvent(new InboundExecutableEvent.Cancelled(RANDOM_ID, t)),
             new ObjectMapper(),
-            null,
+            activityLogRegistry,
             mock(CamundaClient.class));
 
     when(factory.getInstance(any())).thenReturn(executable);
@@ -430,7 +430,7 @@ public class InboundExecutableRegistryTest {
                 null,
                 t -> registry.handleEvent(new InboundExecutableEvent.Cancelled(RANDOM_ID, t)),
                 new ObjectMapper(),
-                null,
+                activityLogRegistry,
                 mock(CamundaClient.class)));
 
     doNothing().doThrow(new Exception()).when(executable).activate(any());

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/inbound/executable/InboundExecutableRegistryTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/inbound/executable/InboundExecutableRegistryTest.java
@@ -21,6 +21,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.client.CamundaClient;
 import io.camunda.connector.api.error.ConnectorRetryException;
 import io.camunda.connector.api.inbound.*;
 import io.camunda.connector.api.inbound.Health.Status;
@@ -339,7 +340,8 @@ public class InboundExecutableRegistryTest {
             null,
             t -> registry.handleEvent(new InboundExecutableEvent.Cancelled(RANDOM_ID, t)),
             new ObjectMapper(),
-            null);
+            null,
+            mock(CamundaClient.class));
 
     when(factory.getInstance(any())).thenReturn(executable);
     when(contextFactory.createContext(any(), any(), any(), any())).thenReturn(context);
@@ -385,7 +387,8 @@ public class InboundExecutableRegistryTest {
             null,
             t -> registry.handleEvent(new InboundExecutableEvent.Cancelled(RANDOM_ID, t)),
             new ObjectMapper(),
-            activityLogRegistry);
+            null,
+            mock(CamundaClient.class));
 
     when(factory.getInstance(any())).thenReturn(executable);
     when(contextFactory.createContext(any(), any(), any(), any())).thenReturn(context);
@@ -427,7 +430,8 @@ public class InboundExecutableRegistryTest {
                 null,
                 t -> registry.handleEvent(new InboundExecutableEvent.Cancelled(RANDOM_ID, t)),
                 new ObjectMapper(),
-                activityLogRegistry));
+                null,
+                mock(CamundaClient.class)));
 
     doNothing().doThrow(new Exception()).when(executable).activate(any());
     when(definition.deduplicationId()).thenReturn(RANDOM_STRING);
@@ -689,7 +693,8 @@ public class InboundExecutableRegistryTest {
             null,
             t -> {},
             new ObjectMapper(),
-            activityLogRegistry);
+            activityLogRegistry,
+            mock(CamundaClient.class));
 
     when(contextFactory.createContext(any(), any(), any(), any())).thenReturn(realContext);
     when(factory.getInstance(any())).thenReturn(executable);

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/inbound/search/ProcessInstanceClientImplTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/inbound/search/ProcessInstanceClientImplTest.java
@@ -18,27 +18,19 @@ package io.camunda.connector.runtime.inbound.search;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.when;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.client.api.search.response.ElementInstance;
 import io.camunda.client.api.search.response.SearchResponse;
-import io.camunda.client.api.search.response.Variable;
-import io.camunda.client.impl.CamundaObjectMapper;
 import io.camunda.client.impl.search.response.ElementInstanceImpl;
 import io.camunda.client.impl.search.response.SearchResponseImpl;
 import io.camunda.client.impl.search.response.SearchResponsePageImpl;
-import io.camunda.client.impl.search.response.VariableImpl;
 import io.camunda.client.protocol.rest.ElementInstanceResult;
-import io.camunda.client.protocol.rest.VariableResult;
 import io.camunda.connector.runtime.core.inbound.ProcessInstanceClient;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -48,17 +40,10 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class ProcessInstanceClientImplTest {
 
   @Mock private SearchQueryClient searchQueryClient;
-  private ObjectMapper objectMapper;
-
-  @BeforeEach
-  public void setUp() {
-    objectMapper = new ObjectMapper();
-  }
 
   @Test
   public void testFetchFlowNodeInstanceByDefinitionKeyAndElementId() {
-    ProcessInstanceClient processInstanceClient =
-        new ProcessInstanceClientImpl(searchQueryClient, objectMapper);
+    ProcessInstanceClient processInstanceClient = new ProcessInstanceClientImpl(searchQueryClient);
 
     // Given
     Long processDefinitionKey = 123L;
@@ -107,46 +92,6 @@ class ProcessInstanceClientImplTest {
     item.setElementId(flowNodeId);
     item.setTenantId(tenantId);
     return new ElementInstanceImpl(item);
-  }
-
-  @Test
-  public void testFetchVariablesByProcessInstanceKey() {
-    ProcessInstanceClient processInstanceClient =
-        new ProcessInstanceClientImpl(searchQueryClient, objectMapper);
-
-    // Given
-    Long processInstanceKey = 456L;
-    Long elementInstanceKey = 789L;
-
-    Variable variable1 = createVariable("12345", "var1", "value1");
-    Variable variable2 = createVariable("67890", "var2", "value2");
-
-    SearchResponse<Variable> variableSearchResult = createSearchResult(variable1, variable2);
-    SearchResponse<Variable> variableEmptySearchResult = createEmptySearchResult();
-
-    when(searchQueryClient.queryVariables(eq(processInstanceKey), eq(elementInstanceKey), any()))
-        .thenReturn(variableSearchResult)
-        .thenReturn(variableEmptySearchResult);
-
-    // When
-    Map<String, Object> result =
-        processInstanceClient.fetchVariablesByProcessInstanceKey(
-            processInstanceKey, elementInstanceKey);
-
-    // Then
-    assertThat(result.size()).isEqualTo(2);
-
-    assertThat(result.get("var1")).isEqualTo("value1");
-    assertThat(result.get("var2")).isEqualTo("value2");
-  }
-
-  private Variable createVariable(String key, String name, String value) {
-    final var item = new VariableResult();
-    item.setVariableKey(key);
-    item.setScopeKey(key);
-    item.setName(name);
-    item.setValue(value);
-    return new VariableImpl(item, new CamundaObjectMapper());
   }
 
   @SafeVarargs

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/inbound/search/SearchQueryClientTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/inbound/search/SearchQueryClientTest.java
@@ -19,7 +19,6 @@ package io.camunda.connector.runtime.inbound.search;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.client.CamundaClient;
-import io.camunda.client.api.search.response.Variable;
 import io.camunda.connector.runtime.inbound.EmptyConfiguration;
 import io.camunda.connector.test.utils.annotation.SlowTest;
 import io.camunda.process.test.api.CamundaSpringProcessTest;
@@ -283,113 +282,6 @@ public class SearchQueryClientTest {
   }
 
   @Test
-  public void shouldFetchVariables() {
-    // Given
-    BpmnModelInstance modelInstance =
-        Bpmn.createExecutableProcess("variableProcess")
-            .startEvent()
-            .serviceTask("task")
-            .zeebeJobType("testJob")
-            .endEvent()
-            .done();
-
-    var deployment =
-        camundaClient
-            .newDeployResourceCommand()
-            .addProcessModel(modelInstance, "variableProcess.bpmn")
-            .send()
-            .join();
-
-    long processDefinitionKey = deployment.getProcesses().getFirst().getProcessDefinitionKey();
-
-    var instance =
-        camundaClient
-            .newCreateInstanceCommand()
-            .bpmnProcessId("variableProcess")
-            .latestVersion()
-            .variables("{\"var1\": \"value1\", \"var2\": 123}")
-            .send()
-            .join();
-
-    long processInstanceKey = instance.getProcessInstanceKey();
-
-    waitForActiveElement(processDefinitionKey, "task");
-
-    // Get the element instance key
-    SearchQueryClientImpl searchClient = new SearchQueryClientImpl(camundaClient, 200);
-    var activeNodes = searchClient.queryActiveFlowNodes(processDefinitionKey, "task", null);
-    long elementInstanceKey = activeNodes.items().getFirst().getElementInstanceKey();
-
-    waitForVariables(processInstanceKey);
-
-    // When
-    var result = searchClient.queryVariables(processInstanceKey, elementInstanceKey, null);
-
-    // Then
-    assertThat(result.items()).hasSizeGreaterThanOrEqualTo(2);
-    var varNames = result.items().stream().map(Variable::getName).toList();
-    assertThat(varNames).contains("var1", "var2");
-  }
-
-  @Test
-  public void shouldFetchVariables_whenPaginated() {
-    // Given - create process with multiple variables
-    BpmnModelInstance modelInstance =
-        Bpmn.createExecutableProcess("multiVarProcess")
-            .startEvent()
-            .serviceTask("task")
-            .zeebeJobType("testJob")
-            .endEvent()
-            .done();
-
-    var deployment =
-        camundaClient
-            .newDeployResourceCommand()
-            .addProcessModel(modelInstance, "multiVarProcess.bpmn")
-            .send()
-            .join();
-
-    long processDefinitionKey = deployment.getProcesses().getFirst().getProcessDefinitionKey();
-
-    var instance =
-        camundaClient
-            .newCreateInstanceCommand()
-            .bpmnProcessId("multiVarProcess")
-            .latestVersion()
-            .variables("{\"a\": 1, \"b\": 2, \"c\": 3, \"d\": 4}")
-            .send()
-            .join();
-
-    long processInstanceKey = instance.getProcessInstanceKey();
-
-    waitForActiveElement(processDefinitionKey, "task");
-
-    SearchQueryClientImpl searchClient = new SearchQueryClientImpl(camundaClient, 200);
-    var activeNodes = searchClient.queryActiveFlowNodes(processDefinitionKey, "task", null);
-    long elementInstanceKey = activeNodes.items().getFirst().getElementInstanceKey();
-
-    waitForVariables(processInstanceKey);
-
-    // When - fetch with pagination
-    SearchQueryClientImpl searchClientPaginated = new SearchQueryClientImpl(camundaClient, 2);
-    var resultPage1 =
-        searchClientPaginated.queryVariables(processInstanceKey, elementInstanceKey, null);
-
-    // Then
-    assertThat(resultPage1.items()).hasSizeLessThanOrEqualTo(2);
-    var allItems = new ArrayList<>(resultPage1.items());
-
-    if (resultPage1.page().endCursor() != null) {
-      var resultPage2 =
-          searchClientPaginated.queryVariables(
-              processInstanceKey, elementInstanceKey, resultPage1.page().endCursor());
-      allItems.addAll(resultPage2.items());
-    }
-
-    assertThat(allItems.size()).isGreaterThanOrEqualTo(2);
-  }
-
-  @Test
   public void shouldGetProcessModel() {
     // Given
     BpmnModelInstance modelInstance =
@@ -498,22 +390,6 @@ public class SearchQueryClientTest {
                       .newElementInstanceSearchRequest()
                       .filter(
                           f -> f.processDefinitionKey(processDefinitionKey).elementId(elementId))
-                      .send()
-                      .join();
-              assertThat(result.items()).isNotEmpty();
-            });
-  }
-
-  private void waitForVariables(long processInstanceKey) {
-    Awaitility.await("should have variables indexed")
-        .atMost(Duration.ofSeconds(15))
-        .ignoreExceptions()
-        .untilAsserted(
-            () -> {
-              final var result =
-                  camundaClient
-                      .newVariableSearchRequest()
-                      .filter(f -> f.processInstanceKey(processInstanceKey))
                       .send()
                       .join();
               assertThat(result.items()).isNotEmpty();

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/inbound/webhook/WebhookTestsBase.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/inbound/webhook/WebhookTestsBase.java
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.client.CamundaClient;
 import io.camunda.connector.api.inbound.Health;
 import io.camunda.connector.api.inbound.webhook.WebhookConnectorExecutable;
 import io.camunda.connector.api.inbound.webhook.WebhookProcessingPayload;
@@ -80,7 +81,8 @@ public abstract class WebhookTestsBase {
             mock(InboundCorrelationHandler.class),
             e -> {},
             mapper,
-            new ActivityLogRegistry());
+            new ActivityLogRegistry(),
+            mock(CamundaClient.class));
 
     context.reportHealth(Health.up());
     return spy(context);

--- a/connector-runtime/jackson-datatype-feel/src/main/java/io/camunda/connector/feel/jackson/AbstractFeelDeserializer.java
+++ b/connector-runtime/jackson-datatype-feel/src/main/java/io/camunda/connector/feel/jackson/AbstractFeelDeserializer.java
@@ -29,6 +29,14 @@ import io.camunda.connector.jackson.ConnectorsObjectMapperSupplier;
 import java.io.IOException;
 import java.util.function.Supplier;
 
+/**
+ * Base Jackson deserializer for connector FEEL-backed values.
+ *
+ * <p>Subclasses decide whether values are evaluated immediately during property binding or turned
+ * into deferred runtime callbacks such as {@link java.util.function.Function} and {@link Supplier}.
+ *
+ * @param <T> the deserialized target type
+ */
 public abstract class AbstractFeelDeserializer<T> extends StdDeserializer<T>
     implements ContextualDeserializer {
 
@@ -44,20 +52,21 @@ public abstract class AbstractFeelDeserializer<T> extends StdDeserializer<T>
   protected static final ObjectMapper BLANK_OBJECT_MAPPER =
       ConnectorsObjectMapperSupplier.getCopy();
 
+  /** Evaluator configured for this deserializer instance. */
   protected final FeelExpressionEvaluator evaluator;
 
   /**
    * Controls both accepted input shape and evaluator override behavior.
    *
-   * <p>Strict mode ({@code false}) is used for deferred runtime callbacks such as {@link *
-   * java.util.function.Function} and {@link java.util.function.Supplier}. These callbacks are *
-   * deserialized from explicit FEEL expressions and evaluated later against in-memory runtime data,
-   * * which may include objects such as Documents. They must keep the evaluator configured by their
-   * * Jackson module, usually local FEEL, because a remote evaluator cannot serialize or interpret
-   * * those runtime objects reliably. * *
+   * <p>Strict mode ({@code false}) is used for deferred runtime callbacks such as {@link
+   * java.util.function.Function} and {@link Supplier}. These callbacks are deserialized from
+   * explicit FEEL expressions and evaluated later against in-memory runtime data, which may include
+   * objects such as Documents. They must keep the evaluator configured by their Jackson module,
+   * usually local FEEL, because a remote evaluator cannot serialize or interpret those runtime
+   * objects reliably.
    *
-   * <p>Relaxed mode ({@code true}) is used for regular connector properties, for example fields *
-   * annotated with {@code @FEEL}. In this mode, the deserializer also accepts plain strings and *
+   * <p>Relaxed mode ({@code true}) is used for regular connector properties, for example fields
+   * annotated with {@code @FEEL}. In this mode, the deserializer also accepts plain strings and
    * JSON-like values, and a per-reader evaluator override may be applied.
    */
   protected final boolean relaxed;
@@ -105,6 +114,12 @@ public abstract class AbstractFeelDeserializer<T> extends StdDeserializer<T>
             + parser.getParsingContext().getCurrentName());
   }
 
+  /**
+   * Checks whether the given value is an explicit FEEL expression.
+   *
+   * @param value the textual value to inspect
+   * @return {@code true} if the value starts with {@code =}
+   */
   protected boolean isFeelExpression(String value) {
     return value != null && value.startsWith("=");
   }
@@ -118,6 +133,7 @@ public abstract class AbstractFeelDeserializer<T> extends StdDeserializer<T>
    * @param expression the FEEL expression to evaluate
    * @param targetType the target type to convert the result to
    * @param variables the variables to use in evaluation
+   * @param <R> the converted FEEL expression result type
    * @return the evaluation result converted to the target type
    */
   @SuppressWarnings("unchecked")
@@ -147,6 +163,15 @@ public abstract class AbstractFeelDeserializer<T> extends StdDeserializer<T>
     }
   }
 
+  /**
+   * Performs subclass-specific deserialization after the FEEL context has been resolved.
+   *
+   * @param node the source JSON node
+   * @param feelContext the FEEL context available during evaluation
+   * @param deserializationContext the Jackson deserialization context
+   * @return the deserialized value
+   * @throws IOException when deserialization fails
+   */
   protected abstract T doDeserialize(
       JsonNode node, JsonNode feelContext, DeserializationContext deserializationContext)
       throws IOException;

--- a/connector-runtime/jackson-datatype-feel/src/main/java/io/camunda/connector/feel/jackson/AbstractFeelDeserializer.java
+++ b/connector-runtime/jackson-datatype-feel/src/main/java/io/camunda/connector/feel/jackson/AbstractFeelDeserializer.java
@@ -185,9 +185,16 @@ public abstract class AbstractFeelDeserializer<T> extends StdDeserializer<T>
       return evaluator;
     }
     var override = ctx.getAttribute(FeelContextAwareObjectReader.FEEL_EVALUATOR_ATTRIBUTE);
+    if (override == null) {
+      return evaluator;
+    }
     if (override instanceof FeelExpressionEvaluator feelEvaluator) {
       return feelEvaluator;
     }
-    return evaluator;
+    throw new IllegalArgumentException(
+        "Attribute "
+            + FeelContextAwareObjectReader.FEEL_EVALUATOR_ATTRIBUTE
+            + " must be a FeelExpressionEvaluator, but was: "
+            + override.getClass());
   }
 }

--- a/connector-runtime/jackson-datatype-feel/src/main/java/io/camunda/connector/feel/jackson/AbstractFeelDeserializer.java
+++ b/connector-runtime/jackson-datatype-feel/src/main/java/io/camunda/connector/feel/jackson/AbstractFeelDeserializer.java
@@ -32,9 +32,6 @@ import java.util.function.Supplier;
 public abstract class AbstractFeelDeserializer<T> extends StdDeserializer<T>
     implements ContextualDeserializer {
 
-  protected final FeelExpressionEvaluator evaluator;
-  protected final boolean relaxed;
-
   /**
    * A blank object mapper object for use in inheriting classes.
    *
@@ -46,6 +43,24 @@ public abstract class AbstractFeelDeserializer<T> extends StdDeserializer<T>
    */
   protected static final ObjectMapper BLANK_OBJECT_MAPPER =
       ConnectorsObjectMapperSupplier.getCopy();
+
+  protected final FeelExpressionEvaluator evaluator;
+
+  /**
+   * Controls both accepted input shape and evaluator override behavior.
+   *
+   * <p>Strict mode ({@code false}) is used for deferred runtime callbacks such as {@link *
+   * java.util.function.Function} and {@link java.util.function.Supplier}. These callbacks are *
+   * deserialized from explicit FEEL expressions and evaluated later against in-memory runtime data,
+   * * which may include objects such as Documents. They must keep the evaluator configured by their
+   * * Jackson module, usually local FEEL, because a remote evaluator cannot serialize or interpret
+   * * those runtime objects reliably. * *
+   *
+   * <p>Relaxed mode ({@code true}) is used for regular connector properties, for example fields *
+   * annotated with {@code @FEEL}. In this mode, the deserializer also accepts plain strings and *
+   * JSON-like values, and a per-reader evaluator override may be applied.
+   */
+  protected final boolean relaxed;
 
   /**
    * Creates a new deserializer with the given FEEL expression evaluator.
@@ -111,8 +126,10 @@ public abstract class AbstractFeelDeserializer<T> extends StdDeserializer<T>
       final String expression,
       final JavaType targetType,
       final Object... variables) {
-    // Evaluate the expression - get raw result
-    Object result = evaluator.evaluate(expression, variables);
+    // Evaluate the expression - get raw result, allowing a per-call evaluator override via
+    // FEEL_EVALUATOR_ATTRIBUTE on the DeserializationContext.
+    FeelExpressionEvaluator effectiveEvaluator = resolveEvaluator(ctx);
+    Object result = effectiveEvaluator.evaluate(expression, variables);
 
     // Convert result using the deserialization context to preserve registered modules
     try {
@@ -133,4 +150,19 @@ public abstract class AbstractFeelDeserializer<T> extends StdDeserializer<T>
   protected abstract T doDeserialize(
       JsonNode node, JsonNode feelContext, DeserializationContext deserializationContext)
       throws IOException;
+
+  private FeelExpressionEvaluator resolveEvaluator(DeserializationContext ctx) {
+    // Strict deserializers are used for deferred runtime callbacks like Function/Supplier.
+    // They must keep their module-configured evaluator, usually local FEEL, because their
+    // inputs can contain in-memory runtime objects that a remote evaluator cannot serialize
+    // or interpret correctly.
+    if (!relaxed) {
+      return evaluator;
+    }
+    var override = ctx.getAttribute(FeelContextAwareObjectReader.FEEL_EVALUATOR_ATTRIBUTE);
+    if (override instanceof FeelExpressionEvaluator feelEvaluator) {
+      return feelEvaluator;
+    }
+    return evaluator;
+  }
 }

--- a/connector-runtime/jackson-datatype-feel/src/main/java/io/camunda/connector/feel/jackson/FeelContextAwareObjectReader.java
+++ b/connector-runtime/jackson-datatype-feel/src/main/java/io/camunda/connector/feel/jackson/FeelContextAwareObjectReader.java
@@ -18,6 +18,7 @@ package io.camunda.connector.feel.jackson;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
+import io.camunda.connector.feel.FeelExpressionEvaluator;
 import java.util.function.Supplier;
 
 /**
@@ -29,6 +30,12 @@ public class FeelContextAwareObjectReader {
 
   /** Attribute name that is used to pass the FEEL context supplier object to the deserializer */
   public static final String FEEL_CONTEXT_ATTRIBUTE = "FEEL_CONTEXT";
+
+  /**
+   * Attribute name used to inject a {@link FeelExpressionEvaluator} that overrides the evaluator
+   * baked into the deserializer for the scope of a single {@link ObjectReader} call.
+   */
+  public static final String FEEL_EVALUATOR_ATTRIBUTE = "FEEL_EVALUATOR";
 
   private final ObjectMapper mapper;
 
@@ -55,5 +62,16 @@ public class FeelContextAwareObjectReader {
   public ObjectReader withStaticContext(Object context) {
     Supplier<?> supplier = () -> context;
     return withContextSupplier(supplier);
+  }
+
+  /**
+   * Returns a new {@link ObjectReader} carrying the given FEEL expression evaluator as an
+   * attribute. The {@code AbstractFeelDeserializer} picks it up and uses it instead of the
+   * evaluator baked in at module-registration time. Jackson's {@link ObjectReader#withAttribute}
+   * returns a new reader with the attribute added, so callers can chain with other {@code
+   * withAttribute}/{@code withContextSupplier} calls.
+   */
+  public ObjectReader withEvaluator(FeelExpressionEvaluator evaluator) {
+    return mapper.reader().withAttribute(FEEL_EVALUATOR_ATTRIBUTE, evaluator);
   }
 }

--- a/connector-runtime/jackson-datatype-feel/src/test/java/io/camunda/connector/feel/jackson/FeelDeserializerTest.java
+++ b/connector-runtime/jackson-datatype-feel/src/test/java/io/camunda/connector/feel/jackson/FeelDeserializerTest.java
@@ -251,6 +251,25 @@ public class FeelDeserializerTest {
   }
 
   @Test
+  void feelDeserializer_evaluatorOverride_invalidObjectProvided() {
+    // given
+    String json =
+        """
+        { "props": "= \"foobar\"" }
+        """;
+    var objectReader =
+        mapper
+            .readerFor(TargetTypeString.class)
+            .withAttribute(
+                FeelContextAwareObjectReader.FEEL_EVALUATOR_ATTRIBUTE, "not an evaluator");
+
+    // when && then
+    var e = assertThrows(JsonMappingException.class, () -> objectReader.readValue(json));
+    assertThat(e.getMessage())
+        .contains("Attribute FEEL_EVALUATOR must be a FeelExpressionEvaluator");
+  }
+
+  @Test
   void feelDeserializer_notFeel_java8Time_parsed() {
     // this test is to ensure that deserialization takes active jackson modules into account
 

--- a/connector-runtime/jackson-datatype-feel/src/test/java/io/camunda/connector/feel/jackson/FeelFunctionDeserializerTest.java
+++ b/connector-runtime/jackson-datatype-feel/src/test/java/io/camunda/connector/feel/jackson/FeelFunctionDeserializerTest.java
@@ -19,8 +19,10 @@ package io.camunda.connector.feel.jackson;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import io.camunda.connector.feel.FeelExpressionEvaluator;
 import java.io.IOException;
 import java.time.LocalDate;
 import java.util.List;
@@ -210,6 +212,28 @@ public class FeelFunctionDeserializerTest {
   }
 
   @Test
+  void feelFunctionDeserialization_withEvaluatorOverride_usesFunctionEvaluator()
+      throws IOException {
+    // given
+    var json =
+        """
+        { "function": "= { result: a + b }" }
+        """;
+    var contextualReader =
+        FeelContextAwareObjectReader.of(mapper)
+            .withEvaluator(new ThrowingFeelExpressionEvaluator());
+
+    // when
+    TargetTypeObject targetType = contextualReader.readValue(json, TargetTypeObject.class);
+
+    // then
+    InputContextString inputContext = new InputContextString("foo", "bar");
+    OutputContext result = targetType.function().apply(inputContext);
+    assertThat(result).isInstanceOf(OutputContext.class);
+    assertThat(result.result).isEqualTo("foobar");
+  }
+
+  @Test
   void feelFunctionDeserialization_contextAware_knowsJava8Time() throws IOException {
     // given
     var json =
@@ -249,4 +273,27 @@ public class FeelFunctionDeserializerTest {
   private record TargetTypeFoldedMap(Function<InputContextInteger, Map<String, Object>> function) {}
 
   private record TargetTypeJava8Time(Function<InputContextInteger, LocalDate> function) {}
+
+  private static class ThrowingFeelExpressionEvaluator implements FeelExpressionEvaluator {
+
+    @Override
+    public <T> T evaluate(String expression, Object... variables) {
+      throw new AssertionError("Function deserialization must use the module's function evaluator");
+    }
+
+    @Override
+    public <T> T evaluate(String expression, Class<T> targetType, Object... variables) {
+      throw new AssertionError("Function deserialization must use the module's function evaluator");
+    }
+
+    @Override
+    public <T> T evaluate(String expression, JavaType targetType, Object... variables) {
+      throw new AssertionError("Function deserialization must use the module's function evaluator");
+    }
+
+    @Override
+    public String evaluateToJson(String expression, Object... variables) {
+      throw new AssertionError("Function deserialization must use the module's function evaluator");
+    }
+  }
 }

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/main/java/io/camunda/connector/runtime/ConnectorsAutoConfiguration.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/main/java/io/camunda/connector/runtime/ConnectorsAutoConfiguration.java
@@ -25,9 +25,8 @@ import io.camunda.connector.api.document.DocumentFactory;
 import io.camunda.connector.api.secret.SecretProvider;
 import io.camunda.connector.document.jackson.JacksonModuleDocumentDeserializer;
 import io.camunda.connector.document.jackson.JacksonModuleDocumentSerializer;
-import io.camunda.connector.feel.CamundaClientFeelExpressionEvaluator;
 import io.camunda.connector.feel.FeelExpressionEvaluator;
-import io.camunda.connector.feel.LocalFeelExpressionEvaluator;
+import io.camunda.connector.feel.FeelExpressionEvaluatorBuilder;
 import io.camunda.connector.feel.jackson.JacksonModuleFeelFunction;
 import io.camunda.connector.http.client.authentication.OAuthTokenCache;
 import io.camunda.connector.http.client.authentication.OAuthTokenCacheHolder;
@@ -106,8 +105,7 @@ public class ConnectorsAutoConfiguration {
   @Primary
   @ConditionalOnMissingBean(FeelExpressionEvaluator.class)
   public FeelExpressionEvaluator camundaClientFeelExpressionEvaluator(CamundaClient camundaClient) {
-    return new CamundaClientFeelExpressionEvaluator(
-        camundaClient, ConnectorsObjectMapperSupplier.getCopy());
+    return FeelExpressionEvaluatorBuilder.camundaClient(camundaClient).build();
   }
 
   /**
@@ -228,7 +226,7 @@ public class ConnectorsAutoConfiguration {
     return copy.registerModules(
         jacksonModuleDocumentDeserializer,
         new JacksonModuleFeelFunction(
-            true, feelExpressionEvaluator, new LocalFeelExpressionEvaluator()),
+            true, feelExpressionEvaluator, FeelExpressionEvaluatorBuilder.local().build()),
         new JacksonModuleDocumentSerializer());
   }
 
@@ -255,7 +253,8 @@ public class ConnectorsAutoConfiguration {
     return copy.registerModules(
         jacksonModuleDocumentDeserializer,
         new JacksonModuleFeelFunction(
-            false, new LocalFeelExpressionEvaluator()), // FEEL annotation processing disabled
+            false,
+            FeelExpressionEvaluatorBuilder.local().build()), // FEEL annotation processing disabled
         new JacksonModuleDocumentSerializer());
   }
 

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/inbound/WebhookControllerTestExceptionZeebeTest.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/inbound/WebhookControllerTestExceptionZeebeTest.java
@@ -245,7 +245,8 @@ class WebhookControllerTestExceptionZeebeTest {
             correlationHandler,
             (e) -> {},
             mapper,
-            new ActivityLogRegistry());
+            new ActivityLogRegistry(),
+            camundaClient);
 
     webhookConnectorRegistry.register(
         new RegisteredExecutable.Activated(

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/inbound/WebhookControllerTestZeebeTest.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/inbound/WebhookControllerTestZeebeTest.java
@@ -113,7 +113,8 @@ class WebhookControllerTestZeebeTest {
             correlationHandler,
             (e) -> {},
             mapper,
-            activityLogRegistry);
+            activityLogRegistry,
+            camundaClient);
 
     // Register webhook function 'implementation'
     webhookConnectorRegistry.register(
@@ -153,7 +154,8 @@ class WebhookControllerTestZeebeTest {
             correlationHandler,
             (e) -> {},
             mapper,
-            activityLogRegistry);
+            activityLogRegistry,
+            camundaClient);
 
     // Register webhook function 'implementation'
     webhookConnectorRegistry.register(
@@ -199,7 +201,8 @@ class WebhookControllerTestZeebeTest {
             correlationHandlerMock,
             (e) -> {},
             mapper,
-            activityLogRegistry);
+            activityLogRegistry,
+            camundaClient);
 
     // Register webhook function 'implementation'
     webhookConnectorRegistry.register(
@@ -239,7 +242,8 @@ class WebhookControllerTestZeebeTest {
             correlationHandlerMock,
             (e) -> {},
             mapper,
-            activityLogRegistry);
+            activityLogRegistry,
+            camundaClient);
 
     // Register webhook function 'implementation'
     webhookConnectorRegistry.register(
@@ -281,7 +285,8 @@ class WebhookControllerTestZeebeTest {
             correlationHandlerMock,
             (e) -> {},
             mapper,
-            activityLogRegistry);
+            activityLogRegistry,
+            camundaClient);
 
     // Register webhook function 'implementation'
     webhookConnectorRegistry.register(
@@ -318,7 +323,8 @@ class WebhookControllerTestZeebeTest {
             correlationHandler,
             (e) -> {},
             mapper,
-            activityLogRegistry);
+            activityLogRegistry,
+            camundaClient);
 
     // Register webhook function 'implementation'
     webhookConnectorRegistry.register(
@@ -355,7 +361,8 @@ class WebhookControllerTestZeebeTest {
             correlationHandler,
             (e) -> {},
             mapper,
-            activityLogRegistry);
+            activityLogRegistry,
+            camundaClient);
 
     // Register webhook function 'implementation'
     webhookConnectorRegistry.register(
@@ -387,7 +394,8 @@ class WebhookControllerTestZeebeTest {
             correlationHandler,
             (e) -> {},
             mapper,
-            activityLogRegistry);
+            activityLogRegistry,
+            camundaClient);
 
     // Register webhook function 'implementation'
     webhookConnectorRegistry.register(
@@ -421,7 +429,8 @@ class WebhookControllerTestZeebeTest {
             correlationHandler,
             (e) -> {},
             mapper,
-            activityLogRegistry);
+            activityLogRegistry,
+            camundaClient);
 
     // Register webhook function 'implementation'
     webhookConnectorRegistry.register(
@@ -467,7 +476,8 @@ class WebhookControllerTestZeebeTest {
             correlationHandler,
             (e) -> {},
             mapper,
-            activityLogRegistry);
+            activityLogRegistry,
+            camundaClient);
 
     // Register webhook function 'implementation'
     webhookConnectorRegistry.register(
@@ -517,7 +527,8 @@ class WebhookControllerTestZeebeTest {
             correlationHandlerMock,
             (e) -> {},
             mapper,
-            activityLogRegistry);
+            activityLogRegistry,
+            camundaClient);
 
     // Register webhook function 'implementation'
     webhookConnectorRegistry.register(
@@ -563,7 +574,8 @@ class WebhookControllerTestZeebeTest {
             correlationHandlerMock,
             (e) -> {},
             mapper,
-            activityLogRegistry);
+            activityLogRegistry,
+            camundaClient);
 
     // Register webhook function 'implementation'
     webhookConnectorRegistry.register(
@@ -599,7 +611,8 @@ class WebhookControllerTestZeebeTest {
             correlationHandler,
             (e) -> {},
             mapper,
-            activityLogRegistry);
+            activityLogRegistry,
+            camundaClient);
 
     // Register webhook function 'implementation'
     webhookConnectorRegistry.register(
@@ -636,7 +649,8 @@ class WebhookControllerTestZeebeTest {
             correlationHandler,
             (e) -> {},
             mapper,
-            activityLogRegistry);
+            activityLogRegistry,
+            camundaClient);
 
     webhookConnectorRegistry.register(
         new RegisteredExecutable.Activated(
@@ -674,7 +688,8 @@ class WebhookControllerTestZeebeTest {
             correlationHandler,
             (e) -> {},
             mapper,
-            activityLogRegistry);
+            activityLogRegistry,
+            camundaClient);
 
     webhookConnectorRegistry.register(
         new RegisteredExecutable.Activated(
@@ -718,7 +733,8 @@ class WebhookControllerTestZeebeTest {
             correlationHandler,
             (e) -> {},
             mapper,
-            activityLogRegistry);
+            activityLogRegistry,
+            camundaClient);
 
     webhookConnectorRegistry.register(
         new RegisteredExecutable.Activated(
@@ -756,7 +772,8 @@ class WebhookControllerTestZeebeTest {
             correlationHandler,
             (e) -> {},
             mapper,
-            activityLogRegistry);
+            activityLogRegistry,
+            camundaClient);
 
     webhookConnectorRegistry.register(
         new RegisteredExecutable.Activated(
@@ -794,7 +811,8 @@ class WebhookControllerTestZeebeTest {
             correlationHandler,
             (e) -> {},
             mapper,
-            activityLogRegistry);
+            activityLogRegistry,
+            camundaClient);
 
     webhookConnectorRegistry.register(
         new RegisteredExecutable.Activated(
@@ -832,7 +850,8 @@ class WebhookControllerTestZeebeTest {
             correlationHandler,
             (e) -> {},
             mapper,
-            activityLogRegistry);
+            activityLogRegistry,
+            camundaClient);
 
     webhookConnectorRegistry.register(
         new RegisteredExecutable.Activated(

--- a/connector-sdk/core/src/main/java/io/camunda/connector/api/inbound/ProcessInstanceContext.java
+++ b/connector-sdk/core/src/main/java/io/camunda/connector/api/inbound/ProcessInstanceContext.java
@@ -40,6 +40,19 @@ public interface ProcessInstanceContext {
   Long getElementInstanceKey();
 
   /**
+   * Builds a stable key that uniquely identifies this element instance, composed of the provided
+   * prefix and this context's process instance key and element instance key. Useful for
+   * deduplicating per-token work (e.g. scheduled polling tasks) when multiple element instances of
+   * the same connector element may coexist.
+   *
+   * @param prefix A caller-provided prefix (typically the inbound connector's deduplication id).
+   * @return A key of the form {@code prefix + processInstanceKey + ":" + elementInstanceKey}.
+   */
+  default String taskKey(final String prefix) {
+    return prefix + getKey() + ":" + getElementInstanceKey();
+  }
+
+  /**
    * Binds the stored properties to a specified class type. It facilitates the deserialization and
    * conversion of these properties into a desired data structure or object. In cases where binding
    * the properties to the specified class isn't possible, this method will throw a runtime

--- a/connector-sdk/core/src/main/java/io/camunda/connector/api/inbound/ProcessInstanceContext.java
+++ b/connector-sdk/core/src/main/java/io/camunda/connector/api/inbound/ProcessInstanceContext.java
@@ -30,6 +30,16 @@ public interface ProcessInstanceContext {
   Long getKey();
 
   /**
+   * Retrieves the key of the specific element instance this context represents. A single process
+   * instance may have multiple concurrent element instances at the same connector element (e.g. a
+   * multi-instance subprocess containing an intermediate catch event), so this key — not {@link
+   * #getKey()} — is what uniquely identifies a token at the connector element.
+   *
+   * @return The unique identifier for the element instance.
+   */
+  Long getElementInstanceKey();
+
+  /**
    * Binds the stored properties to a specified class type. It facilitates the deserialization and
    * conversion of these properties into a desired data structure or object. In cases where binding
    * the properties to the specified class isn't possible, this method will throw a runtime

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/a2a/client/inbound/polling/task/A2aPollingProcessInstancesFetcherTask.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/a2a/client/inbound/polling/task/A2aPollingProcessInstancesFetcherTask.java
@@ -112,7 +112,10 @@ public class A2aPollingProcessInstancesFetcherTask implements Runnable {
   }
 
   private String getRequestTaskKey(final ProcessInstanceContext processInstanceContext) {
-    return context.getDefinition().deduplicationId() + processInstanceContext.getKey();
+    return context.getDefinition().deduplicationId()
+        + processInstanceContext.getKey()
+        + ":"
+        + processInstanceContext.getElementInstanceKey();
   }
 
   public void start() {

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/a2a/client/inbound/polling/task/A2aPollingProcessInstancesFetcherTask.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/a2a/client/inbound/polling/task/A2aPollingProcessInstancesFetcherTask.java
@@ -74,8 +74,9 @@ public class A2aPollingProcessInstancesFetcherTask implements Runnable {
   }
 
   private void removeInactiveTasks(final List<ProcessInstanceContext> processInstanceContexts) {
+    String prefix = context.getDefinition().deduplicationId();
     List<String> activeTasks =
-        processInstanceContexts.stream().map(this::getRequestTaskKey).toList();
+        processInstanceContexts.stream().map(p -> p.taskKey(prefix)).toList();
 
     List<Map.Entry<String, ScheduledPoll>> inactiveTasks =
         runningPollTasks.entrySet().stream()
@@ -90,7 +91,7 @@ public class A2aPollingProcessInstancesFetcherTask implements Runnable {
   }
 
   private void scheduleRequest(ProcessInstanceContext processInstanceContext) {
-    String taskKey = getRequestTaskKey(processInstanceContext);
+    String taskKey = processInstanceContext.taskKey(context.getDefinition().deduplicationId());
     runningPollTasks.computeIfAbsent(
         taskKey,
         (key) -> {
@@ -109,13 +110,6 @@ public class A2aPollingProcessInstancesFetcherTask implements Runnable {
 
           return new ScheduledPoll(task, future);
         });
-  }
-
-  private String getRequestTaskKey(final ProcessInstanceContext processInstanceContext) {
-    return context.getDefinition().deduplicationId()
-        + processInstanceContext.getKey()
-        + ":"
-        + processInstanceContext.getElementInstanceKey();
   }
 
   public void start() {

--- a/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/a2a/client/inbound/polling/task/A2aPollingProcessInstancesFetcherTaskTest.java
+++ b/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/a2a/client/inbound/polling/task/A2aPollingProcessInstancesFetcherTaskTest.java
@@ -18,6 +18,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.connector.agenticai.a2a.client.common.A2aAgentCardFetcher;
@@ -39,6 +40,7 @@ import java.util.concurrent.ScheduledFuture;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
@@ -90,6 +92,8 @@ class A2aPollingProcessInstancesFetcherTaskTest {
   @Test
   void schedulesNoTasksWhenNoProcessInstances() {
     when(context.getProcessInstanceContexts()).thenReturn(List.of());
+    when(context.getDefinition()).thenReturn(inboundConnectorDefinition);
+    when(inboundConnectorDefinition.deduplicationId()).thenReturn(DEDUPLICATION_ID);
 
     fetcherTask.run();
 
@@ -455,7 +459,9 @@ class A2aPollingProcessInstancesFetcherTaskTest {
   }
 
   private ProcessInstanceContext mockProcessInstanceContext(Long key, Long elementInstanceKey) {
-    ProcessInstanceContext processInstanceContext = mock(ProcessInstanceContext.class);
+    ProcessInstanceContext processInstanceContext =
+        mock(
+            ProcessInstanceContext.class, withSettings().defaultAnswer(Answers.CALLS_REAL_METHODS));
     when(processInstanceContext.getKey()).thenReturn(key);
     when(processInstanceContext.getElementInstanceKey()).thenReturn(elementInstanceKey);
     return processInstanceContext;

--- a/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/a2a/client/inbound/polling/task/A2aPollingProcessInstancesFetcherTaskTest.java
+++ b/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/a2a/client/inbound/polling/task/A2aPollingProcessInstancesFetcherTaskTest.java
@@ -451,8 +451,69 @@ class A2aPollingProcessInstancesFetcherTaskTest {
   }
 
   private ProcessInstanceContext mockProcessInstanceContext(Long key) {
+    return mockProcessInstanceContext(key, key * 10);
+  }
+
+  private ProcessInstanceContext mockProcessInstanceContext(Long key, Long elementInstanceKey) {
     ProcessInstanceContext processInstanceContext = mock(ProcessInstanceContext.class);
     when(processInstanceContext.getKey()).thenReturn(key);
+    when(processInstanceContext.getElementInstanceKey()).thenReturn(elementInstanceKey);
     return processInstanceContext;
+  }
+
+  @Test
+  void schedulesSeparateTasksForMultipleTokensOfSameProcessInstance() {
+    // given: two element instances belonging to the same process instance (e.g. two tokens
+    // of a multi-instance subprocess reaching the same intermediate catch event)
+    ProcessInstanceContext token1 = mockProcessInstanceContext(1L, 10L);
+    ProcessInstanceContext token2 = mockProcessInstanceContext(1L, 20L);
+
+    when(context.getProcessInstanceContexts()).thenReturn(List.of(token1, token2));
+    when(context.getDefinition()).thenReturn(inboundConnectorDefinition);
+    when(inboundConnectorDefinition.deduplicationId()).thenReturn(DEDUPLICATION_ID);
+
+    ScheduledFuture<?> future1 = mock(ScheduledFuture.class);
+    ScheduledFuture<?> future2 = mock(ScheduledFuture.class);
+    doReturn(future1)
+        .doReturn(future2)
+        .when(executorService)
+        .scheduleWithFixedDelay(any(A2aPollingTask.class), eq(TASK_POLLING_INTERVAL));
+
+    fetcherTask.run();
+
+    verify(executorService, times(2))
+        .scheduleWithFixedDelay(any(A2aPollingTask.class), eq(TASK_POLLING_INTERVAL));
+  }
+
+  @Test
+  void cancelsTaskOfCompletedTokenWhenSiblingTokenSurvives() {
+    // given: two tokens at the same intermediate catch event in one process instance
+    ProcessInstanceContext token1 = mockProcessInstanceContext(1L, 10L);
+    ProcessInstanceContext token2 = mockProcessInstanceContext(1L, 20L);
+
+    when(context.getDefinition()).thenReturn(inboundConnectorDefinition);
+    when(inboundConnectorDefinition.deduplicationId()).thenReturn(DEDUPLICATION_ID);
+
+    ScheduledFuture<?> future1 = mock(ScheduledFuture.class);
+    ScheduledFuture<?> future2 = mock(ScheduledFuture.class);
+    doReturn(future1)
+        .doReturn(future2)
+        .when(executorService)
+        .scheduleWithFixedDelay(pollingTaskCaptor.capture(), eq(TASK_POLLING_INTERVAL));
+
+    try (MockedConstruction<A2aPollingTask> mockedConstruction =
+        mockConstruction(A2aPollingTask.class)) {
+      when(context.getProcessInstanceContexts()).thenReturn(List.of(token1, token2));
+      fetcherTask.run();
+
+      // token1 completes; only token2 remains
+      when(context.getProcessInstanceContexts()).thenReturn(List.of(token2));
+      fetcherTask.run();
+
+      final var pollingTasks = pollingTaskCaptor.getAllValues();
+      verify(pollingTasks.get(0)).close();
+      verify(future1).cancel(true);
+      verify(future2, never()).cancel(true);
+    }
   }
 }

--- a/connectors/http/polling/pom.xml
+++ b/connectors/http/polling/pom.xml
@@ -44,6 +44,12 @@
       <artifactId>connector-runtime-core</artifactId>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>camunda-client-java</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <profiles>

--- a/connectors/http/polling/src/main/java/io/camunda/connector/http/polling/task/ProcessInstancesFetcherTask.java
+++ b/connectors/http/polling/src/main/java/io/camunda/connector/http/polling/task/ProcessInstancesFetcherTask.java
@@ -88,7 +88,10 @@ public class ProcessInstancesFetcherTask implements Runnable {
   }
 
   private String getRequestTaskKey(final ProcessInstanceContext processInstanceContext) {
-    return context.getDefinition().deduplicationId() + processInstanceContext.getKey();
+    return context.getDefinition().deduplicationId()
+        + processInstanceContext.getKey()
+        + ":"
+        + processInstanceContext.getElementInstanceKey();
   }
 
   public void start() {

--- a/connectors/http/polling/src/main/java/io/camunda/connector/http/polling/task/ProcessInstancesFetcherTask.java
+++ b/connectors/http/polling/src/main/java/io/camunda/connector/http/polling/task/ProcessInstancesFetcherTask.java
@@ -59,8 +59,9 @@ public class ProcessInstancesFetcherTask implements Runnable {
   }
 
   private void removeInactiveTasks(final List<ProcessInstanceContext> processInstanceContexts) {
+    String prefix = context.getDefinition().deduplicationId();
     List<String> activeTasks =
-        processInstanceContexts.stream().map(this::getRequestTaskKey).toList();
+        processInstanceContexts.stream().map(p -> p.taskKey(prefix)).toList();
 
     List<Map.Entry<String, ScheduledFuture<?>>> inactiveTasks =
         runningHttpRequestTaskIds.entrySet().stream()
@@ -75,7 +76,7 @@ public class ProcessInstancesFetcherTask implements Runnable {
   }
 
   private void scheduleRequest(ProcessInstanceContext processInstanceContext) {
-    String taskKey = getRequestTaskKey(processInstanceContext);
+    String taskKey = processInstanceContext.taskKey(context.getDefinition().deduplicationId());
     runningHttpRequestTaskIds.computeIfAbsent(
         taskKey,
         (key) -> {
@@ -85,13 +86,6 @@ public class ProcessInstancesFetcherTask implements Runnable {
               .scheduleWithFixedDelay(
                   task, 0, config.getHttpRequestInterval().toMillis(), TimeUnit.MILLISECONDS);
         });
-  }
-
-  private String getRequestTaskKey(final ProcessInstanceContext processInstanceContext) {
-    return context.getDefinition().deduplicationId()
-        + processInstanceContext.getKey()
-        + ":"
-        + processInstanceContext.getElementInstanceKey();
   }
 
   public void start() {

--- a/connectors/http/polling/src/test/java/io/camunda/connector/http/polling/model/PollingIntervalConfigurationTest.java
+++ b/connectors/http/polling/src/test/java/io/camunda/connector/http/polling/model/PollingIntervalConfigurationTest.java
@@ -7,8 +7,10 @@
 package io.camunda.connector.http.polling.model;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import io.camunda.client.CamundaClient;
 import io.camunda.connector.api.secret.SecretContext;
 import io.camunda.connector.api.secret.SecretProvider;
 import io.camunda.connector.jackson.ConnectorsObjectMapperSupplier;
@@ -66,7 +68,8 @@ public class PollingIntervalConfigurationTest {
             null,
             (e) -> {},
             ConnectorsObjectMapperSupplier.getCopy(),
-            new ActivityLogRegistry());
+            new ActivityLogRegistry(),
+            mock(CamundaClient.class));
   }
 
   @ParameterizedTest

--- a/connectors/http/polling/src/test/java/io/camunda/connector/http/polling/task/ProcessInstancesFetcherTaskTest.java
+++ b/connectors/http/polling/src/test/java/io/camunda/connector/http/polling/task/ProcessInstancesFetcherTaskTest.java
@@ -30,6 +30,7 @@ import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
@@ -42,8 +43,13 @@ public class ProcessInstancesFetcherTaskTest {
   @Mock private HttpService mockHttpService;
   @Mock private SharedExecutorService mockExecutorService;
   @Mock private ScheduledExecutorService mockScheduledExecutorService;
-  @Mock private ProcessInstanceContext mockProcessInstanceContext1;
-  @Mock private ProcessInstanceContext mockProcessInstanceContext2;
+
+  @Mock(answer = Answers.CALLS_REAL_METHODS)
+  private ProcessInstanceContext mockProcessInstanceContext1;
+
+  @Mock(answer = Answers.CALLS_REAL_METHODS)
+  private ProcessInstanceContext mockProcessInstanceContext2;
+
   @Mock private ScheduledFuture<?> mockScheduledFuture;
   @Mock private InboundConnectorDefinition mockInboundConnectorDefinition;
 

--- a/connectors/http/polling/src/test/java/io/camunda/connector/http/polling/task/ProcessInstancesFetcherTaskTest.java
+++ b/connectors/http/polling/src/test/java/io/camunda/connector/http/polling/task/ProcessInstancesFetcherTaskTest.java
@@ -97,6 +97,55 @@ public class ProcessInstancesFetcherTaskTest {
   }
 
   @Test
+  public void shouldScheduleSeparateTasksForMultipleTokensOfSameProcessInstance() {
+    // given: two element instances belonging to the same process instance (e.g. two tokens
+    // of a multi-instance subprocess reaching the same intermediate catch event)
+    when(mockProcessInstanceContext1.getKey()).thenReturn(1L);
+    when(mockProcessInstanceContext1.getElementInstanceKey()).thenReturn(10L);
+    when(mockProcessInstanceContext2.getKey()).thenReturn(1L);
+    when(mockProcessInstanceContext2.getElementInstanceKey()).thenReturn(20L);
+
+    doReturn((ScheduledFuture<?>) mockScheduledFuture)
+        .when(mockScheduledExecutorService)
+        .scheduleWithFixedDelay(any(), anyLong(), anyLong(), any());
+
+    when(mockContext.getProcessInstanceContexts())
+        .thenReturn(List.of(mockProcessInstanceContext1, mockProcessInstanceContext2));
+
+    // when
+    task.run();
+
+    // then: a distinct HTTP request task is scheduled per element instance
+    verify(mockScheduledExecutorService, times(2))
+        .scheduleWithFixedDelay(any(Runnable.class), eq(0L), eq(1000L), eq(TimeUnit.MILLISECONDS));
+  }
+
+  @Test
+  public void shouldCancelTaskWhenOneTokenCompletesEvenIfSiblingTokenSurvives() {
+    // given: two tokens at the same intermediate catch event in one process instance
+    when(mockProcessInstanceContext1.getKey()).thenReturn(1L);
+    when(mockProcessInstanceContext1.getElementInstanceKey()).thenReturn(10L);
+    when(mockProcessInstanceContext2.getKey()).thenReturn(1L);
+    when(mockProcessInstanceContext2.getElementInstanceKey()).thenReturn(20L);
+
+    doReturn((ScheduledFuture<?>) mockScheduledFuture)
+        .when(mockScheduledExecutorService)
+        .scheduleWithFixedDelay(any(), anyLong(), anyLong(), any());
+
+    // First tick has both tokens; second tick has only the surviving one
+    when(mockContext.getProcessInstanceContexts())
+        .thenReturn(List.of(mockProcessInstanceContext1, mockProcessInstanceContext2))
+        .thenReturn(List.of(mockProcessInstanceContext2));
+
+    // when
+    task.run();
+    task.run();
+
+    // then: the completed token's task is cancelled exactly once
+    verify(mockScheduledFuture, times(1)).cancel(true);
+  }
+
+  @Test
   public void shouldRemoveInactiveTasks() {
     // Given two active tasks initially
     when(mockProcessInstanceContext1.getKey()).thenReturn(1L);


### PR DESCRIPTION
This pull request introduces significant improvements to FEEL expression evaluation in inbound connector contexts by integrating a new builder pattern for configuring evaluators, supporting tenant and scope scoping, and updating how properties are bound and evaluated. The changes enhance flexibility, allow for more precise context-aware evaluation (including tenant and element instance scoping), and improve the maintainability of the codebase by removing legacy mechanisms.

Key changes include:

### FEEL Expression Evaluator Enhancements

* Introduced the `FeelExpressionEvaluatorBuilder` class, providing a step-builder pattern to configure FEEL evaluators for both local and Camunda client-based evaluation, with support for tenant ID, scope key, and custom `ObjectMapper` instances. This enables more flexible and explicit evaluator creation.
* Updated `CamundaClientFeelExpressionEvaluator` to support tenant and scope key scoping, with new constructors and logic to apply these options during evaluation. [[1]](diffhunk://#diff-69560fad66ffd01fc9d723c7815a37a7c0e6fcee33bca69cea6723f578c68000R35-R36) [[2]](diffhunk://#diff-69560fad66ffd01fc9d723c7815a37a7c0e6fcee33bca69cea6723f578c68000R46-R74) [[3]](diffhunk://#diff-69560fad66ffd01fc9d723c7815a37a7c0e6fcee33bca69cea6723f578c68000R124-R130)

### Inbound Connector Context Refactoring

* Refactored `InboundConnectorContextImpl` and `DefaultProcessInstanceContext` to use the new FEEL evaluator builder for property binding, replacing the previous supplier-based approach. This allows for FEEL evaluation with tenant and scope context, and ensures properties are bound using the correct evaluation context. [[1]](diffhunk://#diff-3b621a7444b3de88ba434fa0251b7bda0c4b6d3e1d25f44a737011c4b9661d37L278-R301) [[2]](diffhunk://#diff-a60cbba070109d310c3ee61d96356885ed63326d5ccefa5c6cefc7e67c590d8bR69-R77)
* Updated constructors and fields in `DefaultProcessInstanceContext`, `InboundConnectorContextImpl`, and `DefaultInboundConnectorContextFactory` to require and propagate the `CamundaClient` dependency, ensuring all relevant contexts have access to the client for FEEL evaluation. [[1]](diffhunk://#diff-3b621a7444b3de88ba434fa0251b7bda0c4b6d3e1d25f44a737011c4b9661d37R72) [[2]](diffhunk://#diff-3b621a7444b3de88ba434fa0251b7bda0c4b6d3e1d25f44a737011c4b9661d37L80-R85) [[3]](diffhunk://#diff-3b621a7444b3de88ba434fa0251b7bda0c4b6d3e1d25f44a737011c4b9661d37R97) [[4]](diffhunk://#diff-3b621a7444b3de88ba434fa0251b7bda0c4b6d3e1d25f44a737011c4b9661d37L101-R108) [[5]](diffhunk://#diff-3b621a7444b3de88ba434fa0251b7bda0c4b6d3e1d25f44a737011c4b9661d37L110-R118) [[6]](diffhunk://#diff-a60cbba070109d310c3ee61d96356885ed63326d5ccefa5c6cefc7e67c590d8bR21-R38) [[7]](diffhunk://#diff-a60cbba070109d310c3ee61d96356885ed63326d5ccefa5c6cefc7e67c590d8bL48-R48) [[8]](diffhunk://#diff-a60cbba070109d310c3ee61d96356885ed63326d5ccefa5c6cefc7e67c590d8bL57-R58) [[9]](diffhunk://#diff-9c4d88efc4bbd18a4051500d16ea7ccb8edf7d5e74d4d6230793ac72b1707905R20) [[10]](diffhunk://#diff-9c4d88efc4bbd18a4051500d16ea7ccb8edf7d5e74d4d6230793ac72b1707905R32) [[11]](diffhunk://#diff-9c4d88efc4bbd18a4051500d16ea7ccb8edf7d5e74d4d6230793ac72b1707905R42-R58) [[12]](diffhunk://#diff-9c4d88efc4bbd18a4051500d16ea7ccb8edf7d5e74d4d6230793ac72b1707905L72-R78) [[13]](diffhunk://#diff-9c4d88efc4bbd18a4051500d16ea7ccb8edf7d5e74d4d6230793ac72b1707905L81-R88)

### Dependency and Import Cleanups

* Removed unused imports and legacy supplier-based mechanisms for property retrieval, streamlining the code and reducing technical debt. [[1]](diffhunk://#diff-a60cbba070109d310c3ee61d96356885ed63326d5ccefa5c6cefc7e67c590d8bR21-R38) [[2]](diffhunk://#diff-66e26916f09f5c8e664bba2363ccbe96fa857eb6763101fef7fc037b4dd2790cL32)

These changes collectively improve the expressiveness, correctness, and maintainability of FEEL expression evaluation in connector contexts.

# TESTS

What specifically needs testing
The review comments already call out the most important functional scenarios to verify:

Global / tenant cluster variables in inbound connectors should now resolve correctly during FEEL evaluation.  
Global / tenant cluster variables in intermediate connectors should also resolve correctly.  
Global / tenant cluster variables in intermediate polling connectors should work as well.  
Process-scoped variables in intermediate polling connectors should be available, except for httpRequestInterval and processPollingInterval, which are explicitly excluded.  
