### PR TITLE
deps: Pin version of azure-cosmos to avoid using a stale transitive version leading to failures

### DIFF
--- a/connectors/embeddings-vector-database/pom.xml
+++ b/connectors/embeddings-vector-database/pom.xml
@@ -99,6 +99,11 @@
       <artifactId>tika-parsers-standard-package</artifactId>
       <version>${version.apache-tika}</version>
     </dependency>
+    <dependency>
+      <groupId>com.azure</groupId>
+      <artifactId>azure-cosmos</artifactId>
+      <version>${version.azure-cosmos}</version>
+    </dependency>
 
     <dependency>
         <groupId>org.springframework.boot</groupId>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -133,6 +133,7 @@ limitations under the License.</license.inlineheader>
 
     <version.microsoft-graph>6.65.0</version.microsoft-graph>
     <version.azure-identity>1.18.3</version.azure-identity>
+    <version.azure-cosmos>4.80.0</version.azure-cosmos>
 
     <version.bouncycastle>1.84</version.bouncycastle>
     <version.box-sdk>4.16.4</version.box-sdk>


### PR DESCRIPTION
## Description

In 0747d796d4b6e9684b0b34f1d7eb517ab14e3f23 we fixed a TLS/SSL handshake issue in our `embeddings-vector-database` connector by upgrading the `azure-cosmos` dependency version.

On `stable/8.8` the version was not pinned and a stale beta version of `langchain4j-azure-cosmos-nosql` dependency got used, resulting in having version `4.71.0-beta.1`

This PR pins the version to the latest available stable version, which works on `stable.8.9` and main.

## Checklist

- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest
  release, as this branch will be rebased onto main before the next release. Example backport labels:
    - `backport stable/8.8`: for changes that should be included in the next 8.8.x release.
    - **or** `backport release-8.8.7`: for changes that should be included in the specific release 8.8.7, and this
      *release has already been created*. The release branch will be merged back into stable/8.8 later, so the change
      will be included in future 8.8.x releases as well.
- [ ] Tests/Integration tests for the changes have been added if applicable.
- [ ] If the change requires a documentation update, it has been added to the appropriate section in the documentation.


