### PR TITLE
ci: fix DEPLOY SNAPSHOTS workflow

### DIFF
--- a/.github/workflows/DEPLOY_SNAPSHOTS.yaml
+++ b/.github/workflows/DEPLOY_SNAPSHOTS.yaml
@@ -76,9 +76,6 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '21.0.9'
-          server-id: camunda-nexus
-          server-username: MAVEN_USERNAME
-          server-password: MAVEN_PASSWORD
 
       # Use CI Nexus as co-located pull-through cache for Maven artifacts via ~/.m2/settings.xml
       - name: 'Create settings.xml'
@@ -90,6 +87,11 @@ jobs:
                "id": "camunda-nexus",
                "username": "${{ steps.secrets.outputs.CI_NEXUS_USR }}",
                "password": "${{ steps.secrets.outputs.CI_NEXUS_PSW }}"
+             },
+            {
+               "id": "camunda-artifactory",
+                "username": "${{ steps.secrets.outputs.ARTIFACTORY_USR }}",
+                "password": "${{ steps.secrets.outputs.ARTIFACTORY_PSW }}"
              }]
           mirrors: '[{"url": "https://repository.nexus.camunda.cloud/content/groups/internal/", "id": "camunda-nexus", "mirrorOf": "*,!confluent,!shibboleth", "name": "camunda Nexus"}]'
 
@@ -116,8 +118,8 @@ jobs:
       - name: Build Artifacts
         run: ./mvnw -B -U compile generate-sources source:jar javadoc:jar deploy -DskipTests
         env:
-          MAVEN_USERNAME: ${{ steps.secrets.outputs.ARTIFACTORY_USR }}
-          MAVEN_PASSWORD: ${{ steps.secrets.outputs.ARTIFACTORY_PSW }}
+          NEXUS_USR: ${{ steps.secrets.outputs.ARTIFACTORY_USR }}
+          NEXUS_PSW: ${{ steps.secrets.outputs.ARTIFACTORY_PSW }}
 
       - name: Lint Connector Bundle Dockerfile - SaaS
         uses: hadolint/hadolint-action@v3.3.0

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@
 # Log file
 *.log
 
+# Worktrees
+.worktree
+ 
 # BlueJ files
 *.ctxt
 


### PR DESCRIPTION
## Description

Due to this [change](https://github.com/camunda/infra-core/blob/stage/docs/artifact-storages/nexus.md), we have to update how we publish SNAPSHOTs.

This pull request updates the deployment workflow for publishing Maven snapshots, focusing on improving credential management and repository configuration for artifact deployment.

Repository and credential improvements:

* Added a new Maven server entry for `camunda-artifactory` in the `DEPLOY_SNAPSHOTS.yaml` workflow, allowing deployments to Artifactory with its own credentials.
* Changed the environment variable names for Maven credentials in the "Build Artifacts" step from `MAVEN_USERNAME`/`MAVEN_PASSWORD` to `NEXUS_USR`/`NEXUS_PSW` for consistency with the rest of the workflow.

## Checklist

- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest
  release, as this branch will be rebased onto main before the next release. Example backport labels:
    - `backport stable/8.8`: for changes that should be included in the next 8.8.x release.
    - **or** `backport release-8.8.7`: for changes that should be included in the specific release 8.8.7, and this
      *release has already been created*. The release branch will be merged back into stable/8.8 later, so the change
      will be included in future 8.8.x releases as well.
- [ ] Tests/Integration tests for the changes have been added if applicable.
- [ ] If the change requires a documentation update, it has been added to the appropriate section in the documentation.


