### PR TITLE
chore(deps): teach Renovate about HeroDevs NES Spring artifacts

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,8 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended"
+    "config:recommended",
+    "github>camunda/infra-renovate-config:herodevs.json5"
   ],
   "commitMessagePrefix": "deps:",
   "dependencyDashboard": true,
@@ -35,6 +36,12 @@
       "matchHost": "https://reg.mini.dev",
       "username": "minimus",
       "password": "{{ secrets.INFRA_MINIMUS_REGISTRY_TOKEN }}"
+    },
+    {
+      "hostType": "maven",
+      "matchHost": "https://artifacts.camunda.com",
+      "username": "{{ secrets.ARTIFACTORY_USERNAME }}",
+      "password": "{{ secrets.ARTIFACTORY_PASSWORD }}"
     }
   ],
   "packageRules": [


### PR DESCRIPTION
## Description

Related to https://github.com/camunda/team-infrastructure/issues/1036.

Configures Renovate so that HeroDevs Never-Ending Support (NES) Spring artifacts are discovered and upgraded transparently on `stable/8.7` and `stable/8.8` after Spring Boot 3.5 OSS EOL on 2026-06-30.

Two changes:

- `extends` the shared [`herodevs.json5`](https://github.com/camunda/infra-renovate-config/blob/main/herodevs.json5) preset, which provides the regex versioning that maps OSS and NES versions (e.g. `3.5.14-spring-boot-3.5.15`) to the same major/minor/patch space so Renovate proposes upgrades transparently.
- Adds an `artifacts.camunda.com` `hostRule` so Renovate can authenticate against the gated HeroDevs remote.

The corresponding `<repositories>` / `<pluginRepositories>` entries in `parent/pom.xml` are added separately on `stable/8.7` (#7318) and `stable/8.8` (#7317), since `main` (Spring Boot 4.0.6) does not need HeroDevs NES today.

Renovate uses `main`'s `renovate.json` for all base branches via `baseBranchPatterns` with `useBaseBranchConfig: none`, so this single change on `main` covers both stable branches.

## Related issues

Refs camunda/team-infrastructure#1036

## Checklist

- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest
  release, as this branch will be rebased onto main before the next release. Example backport labels:
    - `backport stable/8.8`: for changes that should be included in the next 8.8.x release.
    - **or** `backport release-8.8.7`: for changes that should be included in the specific release 8.8.7, and this
      *release has already been created*. The release branch will be merged back into stable/8.8 later, so the change
      will be included in future 8.8.x releases as well.
- [ ] Tests/Integration tests for the changes have been added if applicable.
- [ ] If the change requires a documentation update, it has been added to the appropriate section in the documentation.