### PR TITLE
fix(ci): install Node.js before element-templates-cli step in RELEASE

### DIFF
--- a/.github/workflows/RELEASE.yaml
+++ b/.github/workflows/RELEASE.yaml
@@ -105,6 +105,11 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-
 
+      - name: Install Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: '24'
+
       - name: Install element templates CLI
         run: npm install --global element-templates-cli@$(jq -r '.devDependencies["element-templates-cli"]' .github/workflows/package.json)
 


### PR DESCRIPTION
## Summary

The release workflow `setup` job runs `npm install --global element-templates-cli@...` but the runner image no longer ships Node/npm by default. Without an explicit `actions/setup-node` step, this fails with `npm: command not found` (exit 127).

This was the root cause of the failed `release-8.8.13` run: https://github.com/camunda/connectors/actions/runs/26224800164

`main` already has this step but it was never backported to `stable/8.8`. PR #7312 only adds `cache: 'npm'` to existing setup-node steps on `main` and does not address the missing step on stable branches.

This PR adds the missing `Install Node.js` step before `Install element templates CLI` in the `setup` job, matching the `setup-node@v5` version already used elsewhere on this branch.

Sibling PRs follow for `stable/8.7` and `stable/8.9`.

## Test plan
- [ ] Re-run the `release-8.8.13` workflow after merge and verify the `setup → Install element templates CLI` step succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)