### PR TITLE
fix(ci): install Node.js before element-templates-cli step in RELEASE

### DIFF
--- a/.github/workflows/RELEASE.yaml
+++ b/.github/workflows/RELEASE.yaml
@@ -105,6 +105,11 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-
 
+      - name: Install Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+
       - name: Install element templates CLI
         run: npm install --global element-templates-cli@$(jq -r '.devDependencies["element-templates-cli"]' .github/workflows/package.json)
 


### PR DESCRIPTION
## Summary

The release workflow `setup` job runs `npm install --global element-templates-cli@...` but the runner image no longer ships Node/npm by default, causing `npm: command not found` (exit 127). See sibling PR for stable/8.8 and the failing run https://github.com/camunda/connectors/actions/runs/26224800164.

`main` already has this step but it was never backported to `stable/8.7`. This PR adds the missing `Install Node.js` step before `Install element templates CLI` in the `setup` job, matching `setup-node@v4` used elsewhere on this branch.

## Test plan
- [ ] Trigger a release of the next 8.7.x patch and verify `setup → Install element templates CLI` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)