### PR TITLE
chore(deps): integrate HeroDevs NES Maven repository (stable/8.8)

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -797,6 +797,19 @@ limitations under the License.</license.inlineheader>
       <url>https://artifacts.camunda.com/artifactory/zeebe-io-snapshots/</url>
     </repository>
 
+    <!-- HeroDevs Never-Ending Support (NES) -->
+    <repository>
+      <id>herodevs-nes</id>
+      <name>HeroDevs NES Repository</name>
+      <url>https://artifacts.camunda.com/artifactory/herodevs-nes</url>
+      <releases>
+        <enabled>true</enabled>
+      </releases>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+    </repository>
+
     <!-- opensaml dependencies for soap connector -->
     <repository>
       <id>shibboleth</id>
@@ -811,6 +824,21 @@ limitations under the License.</license.inlineheader>
       </snapshots>
     </repository>
   </repositories>
+
+  <pluginRepositories>
+    <!-- HeroDevs Never-Ending Support (NES) -->
+    <pluginRepository>
+      <id>herodevs-nes</id>
+      <name>HeroDevs NES Repository</name>
+      <url>https://artifacts.camunda.com/artifactory/herodevs-nes</url>
+      <releases>
+        <enabled>true</enabled>
+      </releases>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+    </pluginRepository>
+  </pluginRepositories>
 
   <build>
     <pluginManagement>


### PR DESCRIPTION
## Description

Related to https://github.com/camunda/team-infrastructure/issues/1036. Companion to #7313 (Renovate config on `main`).

Adds the HeroDevs Never-Ending Support (NES) Maven repository to `parent/pom.xml` on `stable/8.8`, incl. a `<pluginRepositories>` entry for `spring-boot-maven-plugin` (which is pinned to `${version.spring-boot}` and follows the BOM into NES versioning), so Spring Boot 3.5.x patches can be pulled from HeroDevs via Camunda Artifactory after the OSS EOL on 2026-06-30.

The matching Renovate config lives on `main` only (#7313); on stable branches Renovate uses `main`'s `renovate.json` via `baseBranchPatterns` with `useBaseBranchConfig: none`, so no `renovate.json` change is needed here.

## Related issues

Refs camunda/team-infrastructure#1036

## Checklist

- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest
  release, as this branch will be rebased onto main before the next release. Example backport labels:
    - `backport stable/8.8`: for changes that should be included in the next 8.8.x release.
    - **or** `backport release-8.8.7`: for changes that should be included in the specific release 8.8.7, and this
      *release has already been created*. The release branch will be merged back into stable/8.8 later, so the change
      will be included in future 8.8.x releases as well.
- [ ] Tests/Integration tests for the changes have been added if applicable.
- [ ] If the change requires a documentation update, it has been added to the appropriate section in the documentation.