### PR TITLE
feat: Support IP based filtering for hostnames

### DIFF
--- a/bundle/camunda-saas-bundle/src/main/resources/application.properties
+++ b/bundle/camunda-saas-bundle/src/main/resources/application.properties
@@ -17,6 +17,7 @@ camunda.client.worker.defaults.max-jobs-active=100
 camunda.client.worker.defaults.stream-enabled=true
 camunda.client.mode=saas
 camunda.client.prefer-rest-over-grpc=false
+camunda.connector.validation.hosts.enabled=true
 # to be provided in the deployment:
 # camunda.client.grpc-address
 # camunda.client.rest-address

--- a/connector-commons/host-ip-validator-annotation/pom.xml
+++ b/connector-commons/host-ip-validator-annotation/pom.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>io.camunda.connector</groupId>
+    <artifactId>connector-commons</artifactId>
+    <version>8.10.0-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+
+  <artifactId>host-ip-validator-annotation</artifactId>
+  <name>Connector Host IP Validator Annotation</name>
+  <description>
+    Resolves hostnames and validates the resulting IP addresses against allow/deny
+    CIDR ranges. Inspired by Stripe's smokescreen, intended for defending outbound
+    HTTP calls against SSRF and access to private/loopback ranges.
+  </description>
+  <packaging>jar</packaging>
+
+  <dependencies>
+    <dependency>
+      <groupId>jakarta.validation</groupId>
+      <artifactId>jakarta.validation-api</artifactId>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/connector-commons/host-ip-validator-annotation/src/main/java/io/camunda/connector/hostvalidator/VerifiedHost.java
+++ b/connector-commons/host-ip-validator-annotation/src/main/java/io/camunda/connector/hostvalidator/VerifiedHost.java
@@ -82,7 +82,8 @@ public @interface VerifiedHost {
    * {@code example.com}) and validated directly without any URI parsing.
    *
    * <p>Set this to {@code true} when annotating properties that hold full request URLs (see {@code
-   * HttpCommonRequest} and {@code GraphQLRequest}); leave it {@code false} for plain host/IP fields.
+   * HttpCommonRequest} and {@code GraphQLRequest}); leave it {@code false} for plain host/IP
+   * fields.
    *
    * @return {@code true} if the value is a URI from which the host must be extracted before
    *     validation; {@code false} if the value is already a bare hostname

--- a/connector-commons/host-ip-validator-annotation/src/main/java/io/camunda/connector/hostvalidator/VerifiedHost.java
+++ b/connector-commons/host-ip-validator-annotation/src/main/java/io/camunda/connector/hostvalidator/VerifiedHost.java
@@ -69,5 +69,23 @@ public @interface VerifiedHost {
 
   Class<? extends Payload>[] payload() default {};
 
+  /**
+   * Indicates whether the annotated string is a full URI rather than a bare hostname.
+   *
+   * <p>The validator resolves and checks an IP address, so it needs a hostname — not a URI. When
+   * this flag is {@code true}, the {@code VerifiedHostValidator} first extracts the host component
+   * from the value (via {@link java.net.URI#getHost()}) before resolving and validating its IP
+   * address. For example, {@code https://example.com/path} is reduced to {@code example.com} prior
+   * to validation. If the value cannot be parsed as a URI with a host, it is validated as-is.
+   *
+   * <p>When {@code false} (the default), the annotated value is treated as a bare hostname (e.g.
+   * {@code example.com}) and validated directly without any URI parsing.
+   *
+   * <p>Set this to {@code true} when annotating properties that hold full request URLs (see {@code
+   * HttpCommonRequest} and {@code GraphQLRequest}); leave it {@code false} for plain host/IP fields.
+   *
+   * @return {@code true} if the value is a URI from which the host must be extracted before
+   *     validation; {@code false} if the value is already a bare hostname
+   */
   boolean isUri() default false;
 }

--- a/connector-commons/host-ip-validator-annotation/src/main/java/io/camunda/connector/hostvalidator/VerifiedHost.java
+++ b/connector-commons/host-ip-validator-annotation/src/main/java/io/camunda/connector/hostvalidator/VerifiedHost.java
@@ -38,6 +38,24 @@ import java.lang.annotation.Target;
  * options live on the stateful VerifiedHostValidator that the {@link
  * jakarta.validation.ConstraintValidatorFactory} returns. Register a Spring bean (or otherwise wire
  * up a constraint validator factory) holding the desired VerifiedHostValidator.Config.
+ *
+ * <h2>Security caveat — TOCTOU / DNS rebinding</h2>
+ *
+ * <p><strong>Validation is not a substitute for connection-time enforcement.</strong> This
+ * annotation runs at Bean Validation time — typically when a connector job is picked up — but the
+ * outbound HTTP/SMTP/IMAP/POP3 connection that uses the host happens later, after a separate DNS
+ * lookup. An attacker who controls the authoritative DNS for an allowed hostname can serve a
+ * short-TTL record that resolves to a <em>public</em> IP for the validation lookup and to a
+ * <em>private</em> IP (e.g. {@code 169.254.169.254}, RFC 1918) for the connection lookup. This is
+ * the classic DNS-rebinding / time-of-check-to-time-of-use (TOCTOU) gap and is inherent to any
+ * annotation-based host check.
+ *
+ * <p>True defense requires re-validating the resolved IP at <em>connection</em> time — for example,
+ * via a custom {@code DnsResolver} / {@code SocketFactory} (Apache HttpClient), a custom {@code
+ * Address} resolver (OkHttp), or by resolving the host once and dialing the literal IP (pinning) so
+ * the connection uses the same address that was checked. Consider this annotation a first line of
+ * defense against obvious mistakes (e.g. a user pasting an RFC 1918 URL), not a complete SSRF
+ * mitigation.
  */
 @Documented
 @Retention(RUNTIME)

--- a/connector-commons/host-ip-validator-annotation/src/main/java/io/camunda/connector/hostvalidator/VerifiedHost.java
+++ b/connector-commons/host-ip-validator-annotation/src/main/java/io/camunda/connector/hostvalidator/VerifiedHost.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.hostvalidator;
+
+import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.RECORD_COMPONENT;
+import static java.lang.annotation.ElementType.TYPE_USE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+/**
+ * Marker constraint annotation: the string value must be a hostname whose resolved IP address(es)
+ * pass the configuration of the VerifiedHostValidator instance applied by the validator factory.
+ *
+ * <p>This annotation intentionally carries no configuration — the allow/deny ranges and other
+ * options live on the stateful VerifiedHostValidator that the {@link
+ * jakarta.validation.ConstraintValidatorFactory} returns. Register a Spring bean (or otherwise wire
+ * up a constraint validator factory) holding the desired VerifiedHostValidator.Config.
+ */
+@Documented
+@Retention(RUNTIME)
+@Target({FIELD, METHOD, PARAMETER, ANNOTATION_TYPE, RECORD_COMPONENT, TYPE_USE})
+@Constraint(validatedBy = {}) // Configured via XML in the validator
+public @interface VerifiedHost {
+
+  String message() default "Host is not allowed";
+
+  Class<?>[] groups() default {};
+
+  Class<? extends Payload>[] payload() default {};
+
+  boolean isUrl() default false;
+}

--- a/connector-commons/host-ip-validator-annotation/src/main/java/io/camunda/connector/hostvalidator/VerifiedHost.java
+++ b/connector-commons/host-ip-validator-annotation/src/main/java/io/camunda/connector/hostvalidator/VerifiedHost.java
@@ -69,5 +69,5 @@ public @interface VerifiedHost {
 
   Class<? extends Payload>[] payload() default {};
 
-  boolean isUrl() default false;
+  boolean isUri() default false;
 }

--- a/connector-commons/host-ip-validator/pom.xml
+++ b/connector-commons/host-ip-validator/pom.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>io.camunda.connector</groupId>
+    <artifactId>connector-commons</artifactId>
+    <version>8.10.0-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+
+  <artifactId>host-ip-validator</artifactId>
+  <name>Connector Host IP Validator</name>
+  <description>
+    Resolves hostnames and validates the resulting IP addresses against allow/deny
+    CIDR ranges. Inspired by Stripe's smokescreen, intended for defending outbound
+    HTTP calls against SSRF and access to private/loopback ranges.
+  </description>
+  <packaging>jar</packaging>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.camunda.connector</groupId>
+      <artifactId>host-ip-validator-annotation</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>jakarta.validation</groupId>
+      <artifactId>jakarta.validation-api</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.hibernate.validator</groupId>
+      <artifactId>hibernate-validator</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/connector-commons/host-ip-validator/src/main/java/io/camunda/connector/hostvalidator/CidrRange.java
+++ b/connector-commons/host-ip-validator/src/main/java/io/camunda/connector/hostvalidator/CidrRange.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.hostvalidator;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.Objects;
+
+/**
+ * Immutable CIDR range (IPv4 or IPv6). Parsed from notation such as {@code 10.0.0.0/8} or {@code
+ * fc00::/7}. A bare address (no {@code /prefix}) is treated as a host route ({@code /32} for IPv4,
+ * {@code /128} for IPv6).
+ */
+public final class CidrRange {
+
+  private final byte[] networkBytes;
+  private final int prefixLength;
+  private final String original;
+
+  private CidrRange(byte[] networkBytes, int prefixLength, String original) {
+    this.networkBytes = networkBytes;
+    this.prefixLength = prefixLength;
+    this.original = original;
+  }
+
+  public static CidrRange parse(String cidr) {
+    Objects.requireNonNull(cidr, "cidr must not be null");
+    String address;
+    int prefix;
+    int slash = cidr.indexOf('/');
+    if (slash < 0) {
+      address = cidr;
+      prefix = -1;
+    } else {
+      address = cidr.substring(0, slash);
+      try {
+        prefix = Integer.parseInt(cidr.substring(slash + 1));
+      } catch (NumberFormatException e) {
+        throw new IllegalArgumentException("Invalid CIDR prefix in '" + cidr + "'", e);
+      }
+    }
+
+    InetAddress parsed;
+    try {
+      parsed = InetAddress.getByName(address);
+    } catch (UnknownHostException e) {
+      throw new IllegalArgumentException("Invalid CIDR address in '" + cidr + "'", e);
+    }
+
+    byte[] bytes = parsed.getAddress();
+    int maxPrefix = bytes.length * 8;
+    if (prefix < 0) {
+      prefix = maxPrefix;
+    }
+    if (prefix > maxPrefix) {
+      throw new IllegalArgumentException(
+          "CIDR prefix " + prefix + " exceeds maximum " + maxPrefix + " in '" + cidr + "'");
+    }
+
+    maskInPlace(bytes, prefix);
+    return new CidrRange(bytes, prefix, cidr);
+  }
+
+  public boolean contains(InetAddress address) {
+    byte[] target = address.getAddress();
+    if (target.length != networkBytes.length) {
+      return false;
+    }
+    int fullBytes = prefixLength / 8;
+    for (int i = 0; i < fullBytes; i++) {
+      if (target[i] != networkBytes[i]) {
+        return false;
+      }
+    }
+    int remainingBits = prefixLength % 8;
+    if (remainingBits == 0) {
+      return true;
+    }
+    int mask = 0xFF << (8 - remainingBits);
+    return (target[fullBytes] & mask) == (networkBytes[fullBytes] & mask);
+  }
+
+  public int prefixLength() {
+    return prefixLength;
+  }
+
+  @Override
+  public String toString() {
+    return original;
+  }
+
+  private static void maskInPlace(byte[] bytes, int prefix) {
+    int fullBytes = prefix / 8;
+    int remainingBits = prefix % 8;
+    if (remainingBits != 0 && fullBytes < bytes.length) {
+      int mask = 0xFF << (8 - remainingBits);
+      bytes[fullBytes] = (byte) (bytes[fullBytes] & mask);
+      fullBytes++;
+    }
+    for (int i = fullBytes; i < bytes.length; i++) {
+      bytes[i] = 0;
+    }
+  }
+}

--- a/connector-commons/host-ip-validator/src/main/java/io/camunda/connector/hostvalidator/CidrRange.java
+++ b/connector-commons/host-ip-validator/src/main/java/io/camunda/connector/hostvalidator/CidrRange.java
@@ -76,7 +76,7 @@ public final class CidrRange {
   }
 
   public boolean contains(InetAddress address) {
-    byte[] target = address.getAddress();
+    byte[] target = unmapIPv4(address.getAddress());
     if (target.length != networkBytes.length) {
       return false;
     }
@@ -101,6 +101,28 @@ public final class CidrRange {
   @Override
   public String toString() {
     return original;
+  }
+
+  /**
+   * Unmaps IPv4-mapped IPv6 addresses ({@code ::ffff:a.b.c.d}) to their 4-byte IPv4 form so a
+   * 16-byte representation of an IPv4 address still matches IPv4 CIDR ranges. Without this, an
+   * attacker could bypass an IPv4 private-range check by supplying e.g. {@code [::ffff:10.0.0.1]}.
+   */
+  private static byte[] unmapIPv4(byte[] bytes) {
+    if (bytes.length != 16) {
+      return bytes;
+    }
+    for (int i = 0; i < 10; i++) {
+      if (bytes[i] != 0) {
+        return bytes;
+      }
+    }
+    if (bytes[10] != (byte) 0xff || bytes[11] != (byte) 0xff) {
+      return bytes;
+    }
+    byte[] ipv4 = new byte[4];
+    System.arraycopy(bytes, 12, ipv4, 0, 4);
+    return ipv4;
   }
 
   private static void maskInPlace(byte[] bytes, int prefix) {

--- a/connector-commons/host-ip-validator/src/main/java/io/camunda/connector/hostvalidator/HostDeniedException.java
+++ b/connector-commons/host-ip-validator/src/main/java/io/camunda/connector/hostvalidator/HostDeniedException.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.hostvalidator;
+
+import java.net.InetAddress;
+
+/** Thrown when a hostname resolves to an IP address that is disallowed. */
+public class HostDeniedException extends RuntimeException {
+
+  private final String host;
+  private final InetAddress resolvedAddress;
+  private final HostIpValidator.Classification classification;
+
+  public HostDeniedException(
+      String host, InetAddress resolvedAddress, HostIpValidator.Classification classification) {
+    super(
+        "Host '"
+            + host
+            + "' resolved to '"
+            + (resolvedAddress != null ? resolvedAddress.getHostAddress() : "<none>")
+            + "' was denied: "
+            + classification);
+    this.host = host;
+    this.resolvedAddress = resolvedAddress;
+    this.classification = classification;
+  }
+
+  public String host() {
+    return host;
+  }
+
+  public InetAddress resolvedAddress() {
+    return resolvedAddress;
+  }
+
+  public HostIpValidator.Classification classification() {
+    return classification;
+  }
+}

--- a/connector-commons/host-ip-validator/src/main/java/io/camunda/connector/hostvalidator/HostIpValidator.java
+++ b/connector-commons/host-ip-validator/src/main/java/io/camunda/connector/hostvalidator/HostIpValidator.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.hostvalidator;
+
+import java.net.Inet4Address;
+import java.net.Inet6Address;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Resolves a hostname and classifies each resolved IP against allow/deny CIDR ranges. Models the
+ * classification used by Stripe's smokescreen ({@code classifyAddr} / {@code safeResolve}) and is
+ * intended for SSRF defence in outbound HTTP calls.
+ *
+ * <p>Unlike smokescreen — which only checks the first resolved IP — this validator inspects every
+ * address returned by the resolver, to defend against DNS rebinding / multi-record SSRF.
+ */
+public final class HostIpValidator {
+
+  /** Standard RFC 1918 (IPv4) and RFC 4193 (IPv6 ULA) private ranges. */
+  private static final List<CidrRange> RFC_PRIVATE_RANGES =
+      List.of(
+          CidrRange.parse("10.0.0.0/8"),
+          CidrRange.parse("172.16.0.0/12"),
+          CidrRange.parse("192.168.0.0/16"),
+          CidrRange.parse("fc00::/7"));
+
+  private HostIpValidator() {}
+
+  public enum Classification {
+    ALLOW_DEFAULT(true),
+    ALLOW_USER_CONFIGURED(true),
+    DENY_NOT_GLOBAL_UNICAST(false),
+    DENY_PRIVATE_RANGE(false),
+    DENY_USER_CONFIGURED(false);
+
+    private final boolean allowed;
+
+    Classification(boolean allowed) {
+      this.allowed = allowed;
+    }
+
+    public boolean isAllowed() {
+      return allowed;
+    }
+  }
+
+  /**
+   * Resolves {@code host} and throws {@link HostDeniedException} if any resolved address is denied.
+   *
+   * @throws UnknownHostException when the hostname cannot be resolved
+   * @throws HostDeniedException when any resolved IP is disallowed
+   */
+  public static void validate(
+      String host,
+      List<CidrRange> allowRanges,
+      List<CidrRange> denyRanges,
+      boolean unsafeAllowPrivateRanges,
+      boolean unsafeAllowLoopback)
+      throws UnknownHostException {
+    if (host == null || host.isBlank()) {
+      throw new IllegalArgumentException("host must not be null or blank");
+    }
+    InetAddress[] resolved = InetAddress.getAllByName(host);
+    if (resolved == null || resolved.length == 0) {
+      throw new UnknownHostException("No IPs resolved for '" + host + "'");
+    }
+    List<CidrRange> allow = allowRanges != null ? allowRanges : Collections.emptyList();
+    List<CidrRange> deny = denyRanges != null ? denyRanges : Collections.emptyList();
+    for (InetAddress addr : resolved) {
+      Classification c = classify(addr, allow, deny, unsafeAllowPrivateRanges, unsafeAllowLoopback);
+      if (!c.isAllowed()) {
+        throw new HostDeniedException(host, addr, c);
+      }
+    }
+  }
+
+  /**
+   * Classifies a single resolved {@link InetAddress}. Mirrors smokescreen's {@code classifyAddr}.
+   */
+  public static Classification classify(
+      InetAddress address,
+      List<CidrRange> allowRanges,
+      List<CidrRange> denyRanges,
+      boolean unsafeAllowPrivateRanges,
+      boolean unsafeAllowLoopback) {
+    boolean inAllow = anyContains(allowRanges, address);
+    if (!isGlobalUnicast(address) || (!unsafeAllowLoopback && address.isLoopbackAddress())) {
+      return inAllow
+          ? Classification.ALLOW_USER_CONFIGURED
+          : Classification.DENY_NOT_GLOBAL_UNICAST;
+    }
+    if (inAllow) {
+      return Classification.ALLOW_USER_CONFIGURED;
+    }
+    if (anyContains(denyRanges, address)) {
+      return Classification.DENY_USER_CONFIGURED;
+    }
+    if (isPrivate(address) && !unsafeAllowPrivateRanges) {
+      return Classification.DENY_PRIVATE_RANGE;
+    }
+    return Classification.ALLOW_DEFAULT;
+  }
+
+  private static boolean anyContains(List<CidrRange> ranges, InetAddress address) {
+    if (ranges == null || ranges.isEmpty()) {
+      return false;
+    }
+    for (CidrRange range : ranges) {
+      if (range.contains(address)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Approximates Go's {@code net.IP.IsGlobalUnicast}: excludes the unspecified address, multicast,
+   * and link-local addresses. Loopback is intentionally <em>not</em> excluded here — callers handle
+   * loopback separately, matching smokescreen.
+   */
+  private static boolean isGlobalUnicast(InetAddress address) {
+    return !address.isAnyLocalAddress()
+        && !address.isMulticastAddress()
+        && !address.isLinkLocalAddress();
+  }
+
+  /** RFC 1918 for IPv4 and RFC 4193 ULA for IPv6. */
+  private static boolean isPrivate(InetAddress address) {
+    if (address instanceof Inet4Address || address instanceof Inet6Address) {
+      return anyContains(RFC_PRIVATE_RANGES, address);
+    }
+    return false;
+  }
+}

--- a/connector-commons/host-ip-validator/src/main/java/io/camunda/connector/hostvalidator/HostIpValidator.java
+++ b/connector-commons/host-ip-validator/src/main/java/io/camunda/connector/hostvalidator/HostIpValidator.java
@@ -41,6 +41,42 @@ public final class HostIpValidator {
           CidrRange.parse("192.168.0.0/16"),
           CidrRange.parse("fc00::/7"));
 
+  /**
+   * Reserved / special-use ranges that are never a legitimate outbound HTTP target. Includes IPv4
+   * gaps not covered by Java's {@code InetAddress.is*} methods (the {@code 0.0.0.0/8} "this
+   * network" range — Java only flags the single {@code 0.0.0.0}, while {@code 0.0.0.1} routes to
+   * loopback on Linux — and the {@code 240.0.0.0/4} reserved block which contains the {@code
+   * 255.255.255.255} limited broadcast). Also includes IPv6 transition mechanisms ({@code
+   * 64:ff9b::/96} NAT64, {@code 2002::/16} 6to4, {@code 2001::/32} Teredo) that can encode
+   * arbitrary IPv4 addresses — including RFC 1918 — and would otherwise bypass the IPv4 private
+   * check entirely. Unlike {@link #RFC_PRIVATE_RANGES} these are <em>not</em> unlocked by the
+   * {@code unsafeAllowPrivateRanges} escape hatch; an operator who legitimately needs one of these
+   * (e.g. a test harness against TEST-NET) must add it to {@code allowRanges}.
+   */
+  private static final List<CidrRange> DEFAULT_RESERVED_RANGES =
+      List.of(
+          // IPv4 — gaps in Java's InetAddress.is* methods
+          CidrRange.parse("0.0.0.0/8"), // RFC 1122 "this network" — 0.0.0.1 routes to loopback
+          CidrRange.parse("100.64.0.0/10"), // RFC 6598 CGN / shared address space
+          CidrRange.parse("192.0.0.0/24"), // RFC 6890 IETF protocol assignments
+          CidrRange.parse("192.0.2.0/24"), // RFC 5737 TEST-NET-1
+          CidrRange.parse("192.88.99.0/24"), // RFC 7526 deprecated 6to4 relay anycast
+          CidrRange.parse("198.18.0.0/15"), // RFC 2544 benchmark
+          CidrRange.parse("198.51.100.0/24"), // RFC 5737 TEST-NET-2
+          CidrRange.parse("203.0.113.0/24"), // RFC 5737 TEST-NET-3
+          CidrRange.parse("240.0.0.0/4"), // RFC 1112 reserved (includes 255.255.255.255 broadcast)
+          // IPv6 — transition / discard / documentation prefixes
+          CidrRange.parse("64:ff9b::/96"), // RFC 6052 NAT64 (embeds arbitrary IPv4)
+          CidrRange.parse("64:ff9b:1::/48"), // RFC 8215 local-use NAT64
+          CidrRange.parse("100::/64"), // RFC 6666 discard prefix
+          CidrRange.parse("2001::/32"), // RFC 4380 Teredo (embeds IPv4)
+          CidrRange.parse("2001:10::/28"), // RFC 4843 ORCHID (deprecated, still reserved)
+          CidrRange.parse("2001:20::/28"), // RFC 7343 ORCHIDv2
+          CidrRange.parse("2001:db8::/32"), // RFC 3849 documentation
+          CidrRange.parse("2002::/16"), // RFC 3056 6to4 (embeds IPv4)
+          CidrRange.parse("3fff::/20"), // RFC 9637 documentation
+          CidrRange.parse("5f00::/16")); // RFC 9602 segment routing (SRv6)
+
   private HostIpValidator() {}
 
   public enum Classification {
@@ -48,6 +84,7 @@ public final class HostIpValidator {
     ALLOW_USER_CONFIGURED(true),
     DENY_NOT_GLOBAL_UNICAST(false),
     DENY_PRIVATE_RANGE(false),
+    DENY_RESERVED_RANGE(false),
     DENY_USER_CONFIGURED(false);
 
     private final boolean allowed;
@@ -112,6 +149,9 @@ public final class HostIpValidator {
     if (anyContains(denyRanges, address)) {
       return Classification.DENY_USER_CONFIGURED;
     }
+    if (isReserved(address)) {
+      return Classification.DENY_RESERVED_RANGE;
+    }
     if (isPrivate(address) && !unsafeAllowPrivateRanges) {
       return Classification.DENY_PRIVATE_RANGE;
     }
@@ -145,6 +185,17 @@ public final class HostIpValidator {
   private static boolean isPrivate(InetAddress address) {
     if (address instanceof Inet4Address || address instanceof Inet6Address) {
       return anyContains(RFC_PRIVATE_RANGES, address);
+    }
+    return false;
+  }
+
+  /**
+   * Reserved / special-use ranges that should never be a legitimate outbound target. See {@link
+   * #DEFAULT_RESERVED_RANGES} for the full list and rationale.
+   */
+  private static boolean isReserved(InetAddress address) {
+    if (address instanceof Inet4Address || address instanceof Inet6Address) {
+      return anyContains(DEFAULT_RESERVED_RANGES, address);
     }
     return false;
   }

--- a/connector-commons/host-ip-validator/src/main/java/io/camunda/connector/hostvalidator/VerifiedHostValidator.java
+++ b/connector-commons/host-ip-validator/src/main/java/io/camunda/connector/hostvalidator/VerifiedHostValidator.java
@@ -86,18 +86,11 @@ public class VerifiedHostValidator implements ConstraintValidator<VerifiedHost, 
     if (!config.enabled) {
       return true;
     }
-    ConstraintValidatorContextImpl unwrappedContext =
-        (ConstraintValidatorContextImpl) context.unwrap(HibernateConstraintValidatorContext.class);
-    ConstraintDescriptorImpl unwrappedConstraintDescriptor =
-        (ConstraintDescriptorImpl) unwrappedContext.getConstraintDescriptor();
-    VerifiedHost verifiedHost = (VerifiedHost) unwrappedConstraintDescriptor.getAnnotation();
-    if (verifiedHost.isUrl()) {
-      try {
-        var uri = URI.create(host);
-        if (uri.getHost() != null) {
-          host = uri.getHost();
-        }
-      } catch (Exception ignored) {
+
+    if (host != null && !host.isBlank()) {
+      VerifiedHost verifiedHost = getAnnotation(context);
+      if (verifiedHost.isUrl()) {
+        host = getHostFromUrl(host);
       }
     }
 
@@ -121,10 +114,27 @@ public class VerifiedHostValidator implements ConstraintValidator<VerifiedHost, 
     }
   }
 
-  private static void replaceViolationMessage(ConstraintValidatorContext context, String message) {
-    if (context != null) {
-      context.disableDefaultConstraintViolation();
-      context.buildConstraintViolationWithTemplate(message).addConstraintViolation();
+  private static VerifiedHost getAnnotation(ConstraintValidatorContext context) {
+    ConstraintValidatorContextImpl unwrappedContext =
+        (ConstraintValidatorContextImpl) context.unwrap(HibernateConstraintValidatorContext.class);
+    ConstraintDescriptorImpl unwrappedConstraintDescriptor =
+        (ConstraintDescriptorImpl) unwrappedContext.getConstraintDescriptor();
+    return (VerifiedHost) unwrappedConstraintDescriptor.getAnnotation();
+  }
+
+  private static String getHostFromUrl(String url) {
+    try {
+      var uri = URI.create(url);
+      if (uri.getHost() != null) {
+        return uri.getHost();
+      } else return url;
+    } catch (Exception ignored) {
+      return url;
     }
+  }
+
+  private static void replaceViolationMessage(ConstraintValidatorContext context, String message) {
+    context.disableDefaultConstraintViolation();
+    context.buildConstraintViolationWithTemplate(message).addConstraintViolation();
   }
 }

--- a/connector-commons/host-ip-validator/src/main/java/io/camunda/connector/hostvalidator/VerifiedHostValidator.java
+++ b/connector-commons/host-ip-validator/src/main/java/io/camunda/connector/hostvalidator/VerifiedHostValidator.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.hostvalidator;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import java.net.URI;
+import java.net.UnknownHostException;
+import java.util.List;
+import java.util.Objects;
+import org.hibernate.validator.constraintvalidation.HibernateConstraintValidatorContext;
+import org.hibernate.validator.internal.engine.constraintvalidation.ConstraintValidatorContextImpl;
+import org.hibernate.validator.internal.metadata.descriptor.ConstraintDescriptorImpl;
+
+/**
+ * Stateful Jakarta Bean Validation validator backing {@link VerifiedHost}. Holds its own
+ * configuration (allow/deny CIDR ranges, private-range policy) and delegates the actual hostname
+ * resolution and classification to {@link HostIpValidator}.
+ *
+ * <p>Because this validator carries state, the default constraint validator factory's no-arg
+ * instantiation is not suitable when non-default configuration is required. To inject configuration
+ * — e.g. via Spring — register this class as a bean and configure a stateful {@link
+ * jakarta.validation.ConstraintValidatorFactory} (for example {@code
+ * SpringConstraintValidatorFactory}) on the {@link jakarta.validation.ValidatorFactory}. See <a
+ * href="https://www.baeldung.com/spring-custom-stateful-bean-validation">the Baeldung guide on
+ * stateful bean validation</a> for the wiring pattern.
+ *
+ * <p>A {@code null} or blank value is treated as valid — combine with {@code @NotBlank} when the
+ * host is required.
+ */
+public class VerifiedHostValidator implements ConstraintValidator<VerifiedHost, String> {
+
+  /**
+   * Configuration container. Defaults are conservative: no allow/deny ranges configured and private
+   * ranges are denied. Pass an instance to the {@link
+   * VerifiedHostValidator#VerifiedHostValidator(Config)} constructor.
+   */
+  public record Config(
+      boolean enabled,
+      List<CidrRange> allowRanges,
+      List<CidrRange> denyRanges,
+      boolean unsafeAllowPrivateRanges,
+      boolean allowLoopback) {
+
+    public Config {
+      allowRanges = allowRanges == null ? List.of() : List.copyOf(allowRanges);
+      denyRanges = denyRanges == null ? List.of() : List.copyOf(denyRanges);
+    }
+
+    public static Config defaults() {
+      return new Config(true, List.of(), List.of(), false, false);
+    }
+  }
+
+  private final Config config;
+
+  /** Convenience constructor that applies the default configuration. */
+  public VerifiedHostValidator() {
+    this(Config.defaults());
+  }
+
+  public VerifiedHostValidator(Config config) {
+    this.config = Objects.requireNonNull(config, "config must not be null");
+  }
+
+  public Config config() {
+    return config;
+  }
+
+  @Override
+  public boolean isValid(String host, ConstraintValidatorContext context) {
+    if (!config.enabled) {
+      return true;
+    }
+    ConstraintValidatorContextImpl unwrappedContext =
+        (ConstraintValidatorContextImpl) context.unwrap(HibernateConstraintValidatorContext.class);
+    ConstraintDescriptorImpl unwrappedConstraintDescriptor =
+        (ConstraintDescriptorImpl) unwrappedContext.getConstraintDescriptor();
+    VerifiedHost verifiedHost = (VerifiedHost) unwrappedConstraintDescriptor.getAnnotation();
+    if (verifiedHost.isUrl()) {
+      try {
+        var uri = URI.create(host);
+        if (uri.getHost() != null) {
+          host = uri.getHost();
+        }
+      } catch (Exception ignored) {
+      }
+    }
+
+    if (host == null || host.isBlank()) {
+      return true;
+    }
+    try {
+      HostIpValidator.validate(
+          host,
+          config.allowRanges(),
+          config.denyRanges(),
+          config.unsafeAllowPrivateRanges(),
+          config.allowLoopback());
+      return true;
+    } catch (HostDeniedException e) {
+      replaceViolationMessage(context, e.getMessage());
+      return false;
+    } catch (UnknownHostException e) {
+      replaceViolationMessage(context, "Could not resolve host '" + host + "'");
+      return false;
+    }
+  }
+
+  private static void replaceViolationMessage(ConstraintValidatorContext context, String message) {
+    if (context != null) {
+      context.disableDefaultConstraintViolation();
+      context.buildConstraintViolationWithTemplate(message).addConstraintViolation();
+    }
+  }
+}

--- a/connector-commons/host-ip-validator/src/main/java/io/camunda/connector/hostvalidator/VerifiedHostValidator.java
+++ b/connector-commons/host-ip-validator/src/main/java/io/camunda/connector/hostvalidator/VerifiedHostValidator.java
@@ -89,8 +89,8 @@ public class VerifiedHostValidator implements ConstraintValidator<VerifiedHost, 
 
     if (host != null && !host.isBlank()) {
       VerifiedHost verifiedHost = getAnnotation(context);
-      if (verifiedHost.isUrl()) {
-        host = getHostFromUrl(host);
+      if (verifiedHost.isUri()) {
+        host = getHostFromUri(host);
       }
     }
 
@@ -122,14 +122,14 @@ public class VerifiedHostValidator implements ConstraintValidator<VerifiedHost, 
     return (VerifiedHost) unwrappedConstraintDescriptor.getAnnotation();
   }
 
-  private static String getHostFromUrl(String url) {
+  private static String getHostFromUri(String uri) {
     try {
-      var uri = URI.create(url);
-      if (uri.getHost() != null) {
-        return uri.getHost();
-      } else return url;
+      var parsedUri = URI.create(uri);
+      if (parsedUri.getHost() != null) {
+        return parsedUri.getHost();
+      } else return uri;
     } catch (Exception ignored) {
-      return url;
+      return uri;
     }
   }
 

--- a/connector-commons/host-ip-validator/src/main/resources/META-INF/constraints.xml
+++ b/connector-commons/host-ip-validator/src/main/resources/META-INF/constraints.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<constraint-mappings
+        xmlns="https://jakarta.ee/xml/ns/validation/mapping"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/mapping
+        https://jakarta.ee/xml/ns/validation/validation-mapping-3.0.xsd"
+        version="3.0">
+
+    <constraint-definition annotation="io.camunda.connector.hostvalidator.VerifiedHost">
+        <validated-by include-existing-validators="false">
+            <value>io.camunda.connector.hostvalidator.VerifiedHostValidator</value>
+        </validated-by>
+    </constraint-definition>
+</constraint-mappings>

--- a/connector-commons/host-ip-validator/src/main/resources/META-INF/validation.xml
+++ b/connector-commons/host-ip-validator/src/main/resources/META-INF/validation.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<validation-config
+        xmlns="https://jakarta.ee/xml/ns/validation/configuration"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/configuration
+        https://jakarta.ee/xml/ns/validation/validation-configuration-3.0.xsd"
+        version="3.0">
+    <constraint-mapping>META-INF/constraints.xml</constraint-mapping>
+</validation-config>

--- a/connector-commons/host-ip-validator/src/test/java/io/camunda/connector/hostvalidator/CidrRangeTest.java
+++ b/connector-commons/host-ip-validator/src/test/java/io/camunda/connector/hostvalidator/CidrRangeTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.hostvalidator;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.net.InetAddress;
+import org.junit.jupiter.api.Test;
+
+class CidrRangeTest {
+
+  @Test
+  void ipv4SlashEightContainsExpected() throws Exception {
+    CidrRange range = CidrRange.parse("10.0.0.0/8");
+    assertThat(range.contains(InetAddress.getByName("10.0.0.1"))).isTrue();
+    assertThat(range.contains(InetAddress.getByName("10.255.255.255"))).isTrue();
+    assertThat(range.contains(InetAddress.getByName("11.0.0.0"))).isFalse();
+    assertThat(range.contains(InetAddress.getByName("9.255.255.255"))).isFalse();
+  }
+
+  @Test
+  void ipv4SlashTwelveBoundary() throws Exception {
+    CidrRange range = CidrRange.parse("172.16.0.0/12");
+    assertThat(range.contains(InetAddress.getByName("172.16.0.0"))).isTrue();
+    assertThat(range.contains(InetAddress.getByName("172.31.255.255"))).isTrue();
+    assertThat(range.contains(InetAddress.getByName("172.32.0.0"))).isFalse();
+    assertThat(range.contains(InetAddress.getByName("172.15.255.255"))).isFalse();
+  }
+
+  @Test
+  void ipv6UlaRange() throws Exception {
+    CidrRange range = CidrRange.parse("fc00::/7");
+    assertThat(range.contains(InetAddress.getByName("fc00::1"))).isTrue();
+    assertThat(range.contains(InetAddress.getByName("fd00::1"))).isTrue();
+    assertThat(range.contains(InetAddress.getByName("fe00::1"))).isFalse();
+  }
+
+  @Test
+  void ipv4NotContainedInIpv6Range() throws Exception {
+    CidrRange range = CidrRange.parse("fc00::/7");
+    assertThat(range.contains(InetAddress.getByName("10.0.0.1"))).isFalse();
+  }
+
+  @Test
+  void bareAddressTreatedAsHostRoute() throws Exception {
+    CidrRange range = CidrRange.parse("1.2.3.4");
+    assertThat(range.contains(InetAddress.getByName("1.2.3.4"))).isTrue();
+    assertThat(range.contains(InetAddress.getByName("1.2.3.5"))).isFalse();
+    assertThat(range.prefixLength()).isEqualTo(32);
+  }
+
+  @Test
+  void invalidCidrRejected() {
+    assertThatThrownBy(() -> CidrRange.parse("10.0.0.0/abc"))
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> CidrRange.parse("10.0.0.0/40"))
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> CidrRange.parse("not.an.ip/8"))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+}

--- a/connector-commons/host-ip-validator/src/test/java/io/camunda/connector/hostvalidator/CidrRangeTest.java
+++ b/connector-commons/host-ip-validator/src/test/java/io/camunda/connector/hostvalidator/CidrRangeTest.java
@@ -19,6 +19,7 @@ package io.camunda.connector.hostvalidator;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.net.Inet6Address;
 import java.net.InetAddress;
 import org.junit.jupiter.api.Test;
 
@@ -62,6 +63,30 @@ class CidrRangeTest {
     assertThat(range.contains(InetAddress.getByName("1.2.3.4"))).isTrue();
     assertThat(range.contains(InetAddress.getByName("1.2.3.5"))).isFalse();
     assertThat(range.prefixLength()).isEqualTo(32);
+  }
+
+  @Test
+  void ipv4MappedIpv6AddressMatchesIpv4Cidr() throws Exception {
+    CidrRange range = CidrRange.parse("10.0.0.0/8");
+    byte[] mapped = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, (byte) 0xff, (byte) 0xff, 10, 0, 0, 1};
+    InetAddress ipv4Mapped = Inet6Address.getByAddress(null, mapped, 0);
+    assertThat(ipv4Mapped).isInstanceOf(Inet6Address.class);
+    assertThat(range.contains(ipv4Mapped)).isTrue();
+  }
+
+  @Test
+  void ipv4MappedIpv6AddressOutsideIpv4CidrStillExcluded() throws Exception {
+    CidrRange range = CidrRange.parse("10.0.0.0/8");
+    byte[] mapped = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, (byte) 0xff, (byte) 0xff, 11, 0, 0, 1};
+    InetAddress ipv4Mapped = Inet6Address.getByAddress(null, mapped, 0);
+    assertThat(range.contains(ipv4Mapped)).isFalse();
+  }
+
+  @Test
+  void nonMappedIpv6AddressDoesNotMatchIpv4Cidr() throws Exception {
+    CidrRange range = CidrRange.parse("10.0.0.0/8");
+    assertThat(range.contains(InetAddress.getByName("::1"))).isFalse();
+    assertThat(range.contains(InetAddress.getByName("2001:db8::a00:1"))).isFalse();
   }
 
   @Test

--- a/connector-commons/host-ip-validator/src/test/java/io/camunda/connector/hostvalidator/HostIpValidatorTest.java
+++ b/connector-commons/host-ip-validator/src/test/java/io/camunda/connector/hostvalidator/HostIpValidatorTest.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.hostvalidator;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.connector.hostvalidator.HostIpValidator.Classification;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class HostIpValidatorTest {
+
+  @Test
+  void publicAddressIsAllowedByDefault() throws Exception {
+    InetAddress addr = InetAddress.getByName("8.8.8.8");
+    assertThat(HostIpValidator.classify(addr, List.of(), List.of(), false, false))
+        .isEqualTo(Classification.ALLOW_DEFAULT);
+  }
+
+  @Test
+  void loopbackIsDeniedAsNotGlobalUnicast() throws Exception {
+    InetAddress addr = InetAddress.getByName("127.0.0.1");
+    assertThat(HostIpValidator.classify(addr, List.of(), List.of(), false, false))
+        .isEqualTo(Classification.DENY_NOT_GLOBAL_UNICAST);
+  }
+
+  @Test
+  void ipv6LoopbackIsDeniedAsNotGlobalUnicast() throws Exception {
+    InetAddress addr = InetAddress.getByName("::1");
+    assertThat(HostIpValidator.classify(addr, List.of(), List.of(), false, false))
+        .isEqualTo(Classification.DENY_NOT_GLOBAL_UNICAST);
+  }
+
+  @Test
+  void linkLocalIsDeniedAsNotGlobalUnicast() throws Exception {
+    // 169.254.0.0/16 — IMDS lives here on AWS/GCP/Azure.
+    InetAddress addr = InetAddress.getByName("169.254.169.254");
+    assertThat(HostIpValidator.classify(addr, List.of(), List.of(), false, false))
+        .isEqualTo(Classification.DENY_NOT_GLOBAL_UNICAST);
+  }
+
+  @Test
+  void multicastIsDeniedAsNotGlobalUnicast() throws Exception {
+    InetAddress addr = InetAddress.getByName("224.0.0.1");
+    assertThat(HostIpValidator.classify(addr, List.of(), List.of(), false, false))
+        .isEqualTo(Classification.DENY_NOT_GLOBAL_UNICAST);
+  }
+
+  @Test
+  void rfc1918IsDeniedAsPrivateRange() throws Exception {
+    assertThat(
+            HostIpValidator.classify(
+                InetAddress.getByName("10.0.0.5"), List.of(), List.of(), false, false))
+        .isEqualTo(Classification.DENY_PRIVATE_RANGE);
+    assertThat(
+            HostIpValidator.classify(
+                InetAddress.getByName("172.16.5.5"), List.of(), List.of(), false, false))
+        .isEqualTo(Classification.DENY_PRIVATE_RANGE);
+    assertThat(
+            HostIpValidator.classify(
+                InetAddress.getByName("192.168.1.1"), List.of(), List.of(), false, false))
+        .isEqualTo(Classification.DENY_PRIVATE_RANGE);
+  }
+
+  @Test
+  void ipv6UlaIsDeniedAsPrivateRange() throws Exception {
+    InetAddress addr = InetAddress.getByName("fc00::1");
+    assertThat(HostIpValidator.classify(addr, List.of(), List.of(), false, false))
+        .isEqualTo(Classification.DENY_PRIVATE_RANGE);
+  }
+
+  @Test
+  void privateRangeIsAllowedWhenUnsafeFlagSet() throws Exception {
+    InetAddress addr = InetAddress.getByName("10.0.0.5");
+    assertThat(HostIpValidator.classify(addr, List.of(), List.of(), true, false))
+        .isEqualTo(Classification.ALLOW_DEFAULT);
+  }
+
+  @Test
+  void userConfiguredDenyOverridesAllowDefault() throws Exception {
+    InetAddress addr = InetAddress.getByName("8.8.8.8");
+    List<CidrRange> deny = List.of(CidrRange.parse("8.8.8.0/24"));
+    assertThat(HostIpValidator.classify(addr, List.of(), deny, false, false))
+        .isEqualTo(Classification.DENY_USER_CONFIGURED);
+  }
+
+  @Test
+  void allowRangeOverridesPrivateAndDeny() throws Exception {
+    InetAddress privateAddr = InetAddress.getByName("10.0.0.5");
+    List<CidrRange> allow = List.of(CidrRange.parse("10.0.0.0/8"));
+    List<CidrRange> deny = List.of(CidrRange.parse("10.0.0.0/16"));
+    assertThat(HostIpValidator.classify(privateAddr, allow, deny, false, false))
+        .isEqualTo(Classification.ALLOW_USER_CONFIGURED);
+  }
+
+  @Test
+  void allowRangeOverridesLoopback() throws Exception {
+    InetAddress addr = InetAddress.getByName("127.0.0.1");
+    List<CidrRange> allow = List.of(CidrRange.parse("127.0.0.0/8"));
+    assertThat(HostIpValidator.classify(addr, allow, List.of(), false, false))
+        .isEqualTo(Classification.ALLOW_USER_CONFIGURED);
+  }
+
+  @Test
+  void allowRangeOverridesLoopbackValidatio() throws Exception {
+    List<CidrRange> allow = List.of(CidrRange.parse("127.0.0.0/8"));
+    HostIpValidator.validate("127.0.0.1", allow, List.of(), false, false);
+  }
+
+  @Test
+  void hostnameValidationRejectsLoopback() {
+    assertThatExceptionOfType(HostDeniedException.class)
+        .isThrownBy(() -> HostIpValidator.validate("localhost", List.of(), List.of(), false, false))
+        .satisfies(
+            ex ->
+                assertThat(ex.classification()).isEqualTo(Classification.DENY_NOT_GLOBAL_UNICAST));
+  }
+
+  @Test
+  void hostnameValidationRejectsLiteralPrivateIp() {
+    assertThatThrownBy(
+            () -> HostIpValidator.validate("10.0.0.1", List.of(), List.of(), false, false))
+        .isInstanceOf(HostDeniedException.class);
+  }
+
+  @Test
+  void hostnameValidationRejectsUnknownHost() {
+    assertThatThrownBy(
+            () ->
+                HostIpValidator.validate(
+                    "no-such-host.invalid.camunda.test", List.of(), List.of(), false, false))
+        .isInstanceOf(UnknownHostException.class);
+  }
+
+  @Test
+  void blankHostnameRejected() {
+    assertThatThrownBy(() -> HostIpValidator.validate("", List.of(), List.of(), false, false))
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> HostIpValidator.validate(null, List.of(), List.of(), false, false))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+}

--- a/connector-commons/host-ip-validator/src/test/java/io/camunda/connector/hostvalidator/HostIpValidatorTest.java
+++ b/connector-commons/host-ip-validator/src/test/java/io/camunda/connector/hostvalidator/HostIpValidatorTest.java
@@ -106,6 +106,91 @@ class HostIpValidatorTest {
   }
 
   @Test
+  void ipv4ThisNetworkRangeIsDeniedAsReserved() throws Exception {
+    // Java's isAnyLocalAddress() only matches 0.0.0.0 exactly, but 0.0.0.1 routes to loopback on
+    // Linux — must be blocked by the reserved-range check.
+    InetAddress addr = InetAddress.getByName("0.0.0.1");
+    assertThat(HostIpValidator.classify(addr, List.of(), List.of(), false, false))
+        .isEqualTo(Classification.DENY_RESERVED_RANGE);
+  }
+
+  @Test
+  void ipv4LimitedBroadcastIsDeniedAsReserved() throws Exception {
+    // 255.255.255.255 isn't flagged by any Java is* method.
+    InetAddress addr = InetAddress.getByName("255.255.255.255");
+    assertThat(HostIpValidator.classify(addr, List.of(), List.of(), false, false))
+        .isEqualTo(Classification.DENY_RESERVED_RANGE);
+  }
+
+  @Test
+  void ipv4CgnSharedAddressIsDeniedAsReserved() throws Exception {
+    InetAddress addr = InetAddress.getByName("100.64.0.1");
+    assertThat(HostIpValidator.classify(addr, List.of(), List.of(), false, false))
+        .isEqualTo(Classification.DENY_RESERVED_RANGE);
+  }
+
+  @Test
+  void ipv4TestNetIsDeniedAsReserved() throws Exception {
+    assertThat(
+            HostIpValidator.classify(
+                InetAddress.getByName("192.0.2.1"), List.of(), List.of(), false, false))
+        .isEqualTo(Classification.DENY_RESERVED_RANGE);
+    assertThat(
+            HostIpValidator.classify(
+                InetAddress.getByName("198.51.100.1"), List.of(), List.of(), false, false))
+        .isEqualTo(Classification.DENY_RESERVED_RANGE);
+    assertThat(
+            HostIpValidator.classify(
+                InetAddress.getByName("203.0.113.1"), List.of(), List.of(), false, false))
+        .isEqualTo(Classification.DENY_RESERVED_RANGE);
+  }
+
+  @Test
+  void ipv6TransitionPrefixesAreDeniedAsReserved() throws Exception {
+    // 2002::/16 (6to4) — 2002:0a00:0001:: would decode to embedded IPv4 10.0.0.1.
+    assertThat(
+            HostIpValidator.classify(
+                InetAddress.getByName("2002:0a00:0001::"), List.of(), List.of(), false, false))
+        .isEqualTo(Classification.DENY_RESERVED_RANGE);
+    // 64:ff9b::/96 (NAT64) — 64:ff9b::10.0.0.1 embeds IPv4 10.0.0.1.
+    assertThat(
+            HostIpValidator.classify(
+                InetAddress.getByName("64:ff9b::10.0.0.1"), List.of(), List.of(), false, false))
+        .isEqualTo(Classification.DENY_RESERVED_RANGE);
+    // 2001::/32 (Teredo).
+    assertThat(
+            HostIpValidator.classify(
+                InetAddress.getByName("2001::1"), List.of(), List.of(), false, false))
+        .isEqualTo(Classification.DENY_RESERVED_RANGE);
+  }
+
+  @Test
+  void ipv6DocumentationRangeIsDeniedAsReserved() throws Exception {
+    InetAddress addr = InetAddress.getByName("2001:db8::1");
+    assertThat(HostIpValidator.classify(addr, List.of(), List.of(), false, false))
+        .isEqualTo(Classification.DENY_RESERVED_RANGE);
+  }
+
+  @Test
+  void reservedRangeIsNotUnlockedByUnsafeAllowPrivateRanges() throws Exception {
+    // The unsafeAllowPrivateRanges escape hatch is for RFC 1918, not for reserved/special-use
+    // ranges — those must stay blocked.
+    InetAddress addr = InetAddress.getByName("192.0.2.1");
+    assertThat(HostIpValidator.classify(addr, List.of(), List.of(), true, false))
+        .isEqualTo(Classification.DENY_RESERVED_RANGE);
+  }
+
+  @Test
+  void reservedRangeIsOverriddenByExplicitAllow() throws Exception {
+    // An operator can still allow a reserved range if they have a legitimate need (e.g. a test
+    // harness pointing at TEST-NET).
+    InetAddress addr = InetAddress.getByName("198.18.0.1");
+    List<CidrRange> allow = List.of(CidrRange.parse("198.18.0.0/15"));
+    assertThat(HostIpValidator.classify(addr, allow, List.of(), false, false))
+        .isEqualTo(Classification.ALLOW_USER_CONFIGURED);
+  }
+
+  @Test
   void userConfiguredDenyOverridesAllowDefault() throws Exception {
     InetAddress addr = InetAddress.getByName("8.8.8.8");
     List<CidrRange> deny = List.of(CidrRange.parse("8.8.8.0/24"));

--- a/connector-commons/host-ip-validator/src/test/java/io/camunda/connector/hostvalidator/HostIpValidatorTest.java
+++ b/connector-commons/host-ip-validator/src/test/java/io/camunda/connector/hostvalidator/HostIpValidatorTest.java
@@ -216,7 +216,7 @@ class HostIpValidatorTest {
   }
 
   @Test
-  void allowRangeOverridesLoopbackValidatio() throws Exception {
+  void allowRangeOverridesLoopbackValidation() throws Exception {
     List<CidrRange> allow = List.of(CidrRange.parse("127.0.0.0/8"));
     HostIpValidator.validate("127.0.0.1", allow, List.of(), false, false);
   }

--- a/connector-commons/host-ip-validator/src/test/java/io/camunda/connector/hostvalidator/HostIpValidatorTest.java
+++ b/connector-commons/host-ip-validator/src/test/java/io/camunda/connector/hostvalidator/HostIpValidatorTest.java
@@ -21,6 +21,7 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.camunda.connector.hostvalidator.HostIpValidator.Classification;
+import java.net.Inet6Address;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.List;
@@ -83,6 +84,16 @@ class HostIpValidatorTest {
   @Test
   void ipv6UlaIsDeniedAsPrivateRange() throws Exception {
     InetAddress addr = InetAddress.getByName("fc00::1");
+    assertThat(HostIpValidator.classify(addr, List.of(), List.of(), false, false))
+        .isEqualTo(Classification.DENY_PRIVATE_RANGE);
+  }
+
+  @Test
+  void ipv4MappedPrivateAddressIsDeniedAsPrivateRange() throws Exception {
+    // ::ffff:10.0.0.1 — IPv4-mapped form of 10.0.0.1. Must not bypass the RFC 1918 check.
+    byte[] mapped = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, (byte) 0xff, (byte) 0xff, 10, 0, 0, 1};
+    InetAddress addr = Inet6Address.getByAddress(null, mapped, 0);
+    assertThat(addr).isInstanceOf(Inet6Address.class);
     assertThat(HostIpValidator.classify(addr, List.of(), List.of(), false, false))
         .isEqualTo(Classification.DENY_PRIVATE_RANGE);
   }

--- a/connector-commons/host-ip-validator/src/test/java/io/camunda/connector/hostvalidator/VerifiedHostValidatorTest.java
+++ b/connector-commons/host-ip-validator/src/test/java/io/camunda/connector/hostvalidator/VerifiedHostValidatorTest.java
@@ -146,7 +146,6 @@ class VerifiedHostValidatorTest {
   }
 
   @Test
-  @Test
   void testWithUrl() {
     VerifiedHostValidator.Config config =
         new VerifiedHostValidator.Config(true, List.of(), List.of(), false, false);

--- a/connector-commons/host-ip-validator/src/test/java/io/camunda/connector/hostvalidator/VerifiedHostValidatorTest.java
+++ b/connector-commons/host-ip-validator/src/test/java/io/camunda/connector/hostvalidator/VerifiedHostValidatorTest.java
@@ -152,13 +152,5 @@ class VerifiedHostValidatorTest {
     Validator v = validatorWith(new VerifiedHostValidator(config));
     assertThat(v.validate(new TargetWithURL("http://example.com"))).isEmpty();
   }
-
-  @Test
-  void testWithUri() {
-    VerifiedHostValidator.Config config =
-        new VerifiedHostValidator.Config(true, List.of(), List.of(), false, false);
-    Validator v = validatorWith(new VerifiedHostValidator(config));
-    assertThat(v.validate(new TargetWithURL("jdbc:mysql://root:mypass@myhost1:3306/db_name")))
-        .isEmpty();
-  }
+  
 }

--- a/connector-commons/host-ip-validator/src/test/java/io/camunda/connector/hostvalidator/VerifiedHostValidatorTest.java
+++ b/connector-commons/host-ip-validator/src/test/java/io/camunda/connector/hostvalidator/VerifiedHostValidatorTest.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.hostvalidator;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorFactory;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import java.util.List;
+import java.util.Set;
+import org.hibernate.validator.messageinterpolation.ParameterMessageInterpolator;
+import org.junit.jupiter.api.Test;
+
+class VerifiedHostValidatorTest {
+
+  /** Bean validation target with a marker-annotated host string. */
+  private record Target(@VerifiedHost String host) {}
+
+  /** Bean validation target with a marker-annotated url string */
+  private record TargetWithURL(@VerifiedHost(isUrl = true) String url) {}
+
+  /**
+   * Builds a {@link Validator} whose {@link ConstraintValidatorFactory} hands out the provided
+   * stateful {@link VerifiedHostValidator}. This is the wiring described in the Baeldung guide on
+   * stateful bean validation, scaled down to a test fixture.
+   */
+  private static Validator validatorWith(VerifiedHostValidator stateful) {
+    ConstraintValidatorFactory factory =
+        new ConstraintValidatorFactory() {
+          @Override
+          public <T extends ConstraintValidator<?, ?>> T getInstance(Class<T> key) {
+            if (key.equals(VerifiedHostValidator.class)) {
+              return key.cast(stateful);
+            }
+            try {
+              return key.getDeclaredConstructor().newInstance();
+            } catch (ReflectiveOperationException e) {
+              throw new IllegalStateException(e);
+            }
+          }
+
+          @Override
+          public void releaseInstance(ConstraintValidator<?, ?> instance) {}
+        };
+    return Validation.byDefaultProvider()
+        .configure()
+        .messageInterpolator(new ParameterMessageInterpolator())
+        .constraintValidatorFactory(factory)
+        .buildValidatorFactory()
+        .getValidator();
+  }
+
+  @Test
+  void publicHostnamePasses() {
+    Validator v = validatorWith(new VerifiedHostValidator());
+    Set<ConstraintViolation<Target>> violations = v.validate(new Target("8.8.8.8"));
+    assertThat(violations).isEmpty();
+  }
+
+  @Test
+  void loopbackIsRejected() {
+    Validator v = validatorWith(new VerifiedHostValidator());
+    Set<ConstraintViolation<Target>> violations = v.validate(new Target("127.0.0.1"));
+    assertThat(violations).hasSize(1);
+    assertThat(violations.iterator().next().getMessage()).contains("DENY_NOT_GLOBAL_UNICAST");
+  }
+
+  @Test
+  void privateRangeIsRejectedByDefault() {
+    Validator v = validatorWith(new VerifiedHostValidator());
+    assertThat(v.validate(new Target("10.0.0.1"))).hasSize(1);
+  }
+
+  @Test
+  void configCanAllowPrivateRanges() {
+    VerifiedHostValidator.Config config =
+        new VerifiedHostValidator.Config(true, List.of(), List.of(), true, false);
+    Validator v = validatorWith(new VerifiedHostValidator(config));
+    assertThat(v.validate(new Target("10.0.0.1"))).isEmpty();
+  }
+
+  @Test
+  void configCanAllowLoopbackViaAllowRange() {
+    VerifiedHostValidator.Config config =
+        new VerifiedHostValidator.Config(
+            true, List.of(CidrRange.parse("127.0.0.0/8")), List.of(), false, false);
+    Validator v = validatorWith(new VerifiedHostValidator(config));
+    assertThat(v.validate(new Target("127.0.0.1"))).isEmpty();
+  }
+
+  @Test
+  void configDenyRangeRejectsOtherwiseAllowedHost() {
+    VerifiedHostValidator.Config config =
+        new VerifiedHostValidator.Config(
+            true, List.of(), List.of(CidrRange.parse("8.8.8.0/24")), false, false);
+    Validator v = validatorWith(new VerifiedHostValidator(config));
+    Set<ConstraintViolation<Target>> violations = v.validate(new Target("8.8.8.8"));
+    assertThat(violations).hasSize(1);
+    assertThat(violations.iterator().next().getMessage()).contains("DENY_USER_CONFIGURED");
+  }
+
+  @Test
+  void unresolvableHostnameProducesViolation() {
+    Validator v = validatorWith(new VerifiedHostValidator());
+    Set<ConstraintViolation<Target>> violations =
+        v.validate(new Target("no-such-host.invalid.camunda.test"));
+    assertThat(violations).hasSize(1);
+    assertThat(violations.iterator().next().getMessage()).contains("Could not resolve");
+  }
+
+  @Test
+  void nullAndBlankAreTreatedAsValid() {
+    Validator v = validatorWith(new VerifiedHostValidator());
+    assertThat(v.validate(new Target(null))).isEmpty();
+    assertThat(v.validate(new Target(""))).isEmpty();
+    assertThat(v.validate(new Target("   "))).isEmpty();
+  }
+
+  @Test
+  void defaultConstructorAppliesDefaultConfig() {
+    VerifiedHostValidator validator = new VerifiedHostValidator();
+    assertThat(validator.config()).isEqualTo(VerifiedHostValidator.Config.defaults());
+  }
+
+  @Test
+  void configRejectsNull() {
+    org.assertj.core.api.Assertions.assertThatThrownBy(() -> new VerifiedHostValidator(null))
+        .isInstanceOf(NullPointerException.class);
+  }
+
+  @Test
+  void testWithUrl() {
+    VerifiedHostValidator.Config config =
+        new VerifiedHostValidator.Config(true, List.of(), List.of(), false, false);
+    Validator v = validatorWith(new VerifiedHostValidator(config));
+    assertThat(v.validate(new TargetWithURL("http://example.com"))).isEmpty();
+  }
+}

--- a/connector-commons/host-ip-validator/src/test/java/io/camunda/connector/hostvalidator/VerifiedHostValidatorTest.java
+++ b/connector-commons/host-ip-validator/src/test/java/io/camunda/connector/hostvalidator/VerifiedHostValidatorTest.java
@@ -146,10 +146,11 @@ class VerifiedHostValidatorTest {
   }
 
   @Test
+  @Test
   void testWithUrl() {
     VerifiedHostValidator.Config config =
         new VerifiedHostValidator.Config(true, List.of(), List.of(), false, false);
     Validator v = validatorWith(new VerifiedHostValidator(config));
-    assertThat(v.validate(new TargetWithURL("http://example.com"))).isEmpty();
+    assertThat(v.validate(new TargetWithURL("http://8.8.8.8"))).isEmpty();
   }
 }

--- a/connector-commons/host-ip-validator/src/test/java/io/camunda/connector/hostvalidator/VerifiedHostValidatorTest.java
+++ b/connector-commons/host-ip-validator/src/test/java/io/camunda/connector/hostvalidator/VerifiedHostValidatorTest.java
@@ -34,7 +34,7 @@ class VerifiedHostValidatorTest {
   private record Target(@VerifiedHost String host) {}
 
   /** Bean validation target with a marker-annotated url string */
-  private record TargetWithURL(@VerifiedHost(isUrl = true) String url) {}
+  private record TargetWithURL(@VerifiedHost(isUri = true) String url) {}
 
   /**
    * Builds a {@link Validator} whose {@link ConstraintValidatorFactory} hands out the provided
@@ -151,5 +151,14 @@ class VerifiedHostValidatorTest {
         new VerifiedHostValidator.Config(true, List.of(), List.of(), false, false);
     Validator v = validatorWith(new VerifiedHostValidator(config));
     assertThat(v.validate(new TargetWithURL("http://example.com"))).isEmpty();
+  }
+
+  @Test
+  void testWithUri() {
+    VerifiedHostValidator.Config config =
+        new VerifiedHostValidator.Config(true, List.of(), List.of(), false, false);
+    Validator v = validatorWith(new VerifiedHostValidator(config));
+    assertThat(v.validate(new TargetWithURL("jdbc:mysql://root:mypass@myhost1:3306/db_name")))
+        .isEmpty();
   }
 }

--- a/connector-commons/host-ip-validator/src/test/java/io/camunda/connector/hostvalidator/VerifiedHostValidatorTest.java
+++ b/connector-commons/host-ip-validator/src/test/java/io/camunda/connector/hostvalidator/VerifiedHostValidatorTest.java
@@ -152,5 +152,4 @@ class VerifiedHostValidatorTest {
     Validator v = validatorWith(new VerifiedHostValidator(config));
     assertThat(v.validate(new TargetWithURL("http://example.com"))).isEmpty();
   }
-  
 }

--- a/connector-commons/pom.xml
+++ b/connector-commons/pom.xml
@@ -21,6 +21,8 @@
     <module>http-client</module>
     <module>connector-utils</module>
     <module>connector-test-utils</module>
+    <module>host-ip-validator</module>
+    <module>host-ip-validator-annotation</module>
   </modules>
 
 </project>

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/OutboundConnectorRuntimeConfiguration.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/OutboundConnectorRuntimeConfiguration.java
@@ -77,6 +77,7 @@ public class OutboundConnectorRuntimeConfiguration {
   }
 
   @Bean
+  @ConditionalOnMissingBean(ValidationProvider.class)
   ValidationProvider validationProvider() {
     return ValidationUtil.discoverDefaultValidationProviderImplementation();
   }

--- a/connector-runtime/connector-runtime-test/pom.xml
+++ b/connector-runtime/connector-runtime-test/pom.xml
@@ -20,17 +20,35 @@
       <groupId>io.camunda.connector</groupId>
       <artifactId>connector-core</artifactId>
     </dependency>
+
     <dependency>
       <groupId>io.camunda.connector</groupId>
       <artifactId>connector-test</artifactId>
     </dependency>
+
     <dependency>
       <groupId>io.camunda.connector</groupId>
       <artifactId>connector-runtime-core</artifactId>
     </dependency>
+
     <dependency>
       <groupId>io.camunda.connector</groupId>
       <artifactId>connector-object-mapper</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda.connector</groupId>
+      <artifactId>host-ip-validator</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>jakarta.validation</groupId>
+      <artifactId>jakarta.validation-api</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.hibernate.validator</groupId>
+      <artifactId>hibernate-validator</artifactId>
     </dependency>
 
     <dependency>

--- a/connector-runtime/connector-runtime-test/src/main/java/io/camunda/connector/runtime/test/outbound/OutboundConnectorContextBuilder.java
+++ b/connector-runtime/connector-runtime-test/src/main/java/io/camunda/connector/runtime/test/outbound/OutboundConnectorContextBuilder.java
@@ -31,7 +31,6 @@ import io.camunda.connector.document.jackson.JacksonModuleDocumentDeserializer;
 import io.camunda.connector.document.jackson.JacksonModuleDocumentDeserializer.DocumentModuleSettings;
 import io.camunda.connector.document.jackson.JacksonModuleDocumentSerializer;
 import io.camunda.connector.feel.jackson.JacksonModuleFeelFunction;
-import io.camunda.connector.hostvalidator.VerifiedHostValidator;
 import io.camunda.connector.jackson.ConnectorsObjectMapperSupplier;
 import io.camunda.connector.runtime.core.AbstractConnectorContext;
 import io.camunda.connector.runtime.core.document.DocumentFactoryImpl;
@@ -40,15 +39,8 @@ import io.camunda.connector.runtime.core.intrinsic.DefaultIntrinsicFunctionExecu
 import io.camunda.connector.runtime.core.validation.ValidationUtil;
 import io.camunda.connector.test.ConnectorContextTestUtil;
 import io.camunda.connector.test.MapSecretProvider;
-import io.camunda.connector.validation.impl.DefaultValidationProvider;
-import jakarta.validation.ConstraintValidator;
-import jakarta.validation.ConstraintValidatorFactory;
-import jakarta.validation.Validation;
-import jakarta.validation.ValidatorFactory;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
-import org.hibernate.validator.messageinterpolation.ParameterMessageInterpolator;
 
 /** Test helper class for creating a {@link OutboundConnectorContext} with a fluent API. */
 public class OutboundConnectorContextBuilder {
@@ -198,41 +190,7 @@ public class OutboundConnectorContextBuilder {
   }
 
   public OutboundConnectorContextBuilder includeAllValidators() {
-    // TODO extract into test utils
-    VerifiedHostValidator verifiedHostValidator =
-        new VerifiedHostValidator(
-            new VerifiedHostValidator.Config(true, List.of(), List.of(), true, true));
-
-    // TODO extract into test utils
-    ConstraintValidatorFactory factory =
-        new ConstraintValidatorFactory() {
-          @Override
-          public <T extends ConstraintValidator<?, ?>> T getInstance(Class<T> key) {
-            if (key.equals(VerifiedHostValidator.class)) {
-              return key.cast(verifiedHostValidator);
-            }
-            try {
-              return key.getDeclaredConstructor().newInstance();
-            } catch (ReflectiveOperationException e) {
-              throw new IllegalStateException(e);
-            }
-          }
-
-          @Override
-          public void releaseInstance(ConstraintValidator<?, ?> instance) {}
-        };
-
-    // TODO extract into test utils
-    ValidatorFactory validatorFactory =
-        Validation.byDefaultProvider()
-            .configure()
-            .constraintValidatorFactory(factory)
-            .messageInterpolator(new ParameterMessageInterpolator())
-            .buildValidatorFactory();
-
-    ValidationProvider validationProvider = new DefaultValidationProvider(validatorFactory);
-
-    this.validationProvider = validationProvider;
+    this.validationProvider = new TestValidationProvider();
     return this;
   }
 

--- a/connector-runtime/connector-runtime-test/src/main/java/io/camunda/connector/runtime/test/outbound/OutboundConnectorContextBuilder.java
+++ b/connector-runtime/connector-runtime-test/src/main/java/io/camunda/connector/runtime/test/outbound/OutboundConnectorContextBuilder.java
@@ -31,6 +31,7 @@ import io.camunda.connector.document.jackson.JacksonModuleDocumentDeserializer;
 import io.camunda.connector.document.jackson.JacksonModuleDocumentDeserializer.DocumentModuleSettings;
 import io.camunda.connector.document.jackson.JacksonModuleDocumentSerializer;
 import io.camunda.connector.feel.jackson.JacksonModuleFeelFunction;
+import io.camunda.connector.hostvalidator.VerifiedHostValidator;
 import io.camunda.connector.jackson.ConnectorsObjectMapperSupplier;
 import io.camunda.connector.runtime.core.AbstractConnectorContext;
 import io.camunda.connector.runtime.core.document.DocumentFactoryImpl;
@@ -39,8 +40,15 @@ import io.camunda.connector.runtime.core.intrinsic.DefaultIntrinsicFunctionExecu
 import io.camunda.connector.runtime.core.validation.ValidationUtil;
 import io.camunda.connector.test.ConnectorContextTestUtil;
 import io.camunda.connector.test.MapSecretProvider;
+import io.camunda.connector.validation.impl.DefaultValidationProvider;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorFactory;
+import jakarta.validation.Validation;
+import jakarta.validation.ValidatorFactory;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import org.hibernate.validator.messageinterpolation.ParameterMessageInterpolator;
 
 /** Test helper class for creating a {@link OutboundConnectorContext} with a fluent API. */
 public class OutboundConnectorContextBuilder {
@@ -185,6 +193,45 @@ public class OutboundConnectorContextBuilder {
   }
 
   public OutboundConnectorContextBuilder validation(ValidationProvider validationProvider) {
+    this.validationProvider = validationProvider;
+    return this;
+  }
+
+  public OutboundConnectorContextBuilder includeAllValidators() {
+    // TODO extract into test utils
+    VerifiedHostValidator verifiedHostValidator =
+        new VerifiedHostValidator(
+            new VerifiedHostValidator.Config(true, List.of(), List.of(), true, true));
+
+    // TODO extract into test utils
+    ConstraintValidatorFactory factory =
+        new ConstraintValidatorFactory() {
+          @Override
+          public <T extends ConstraintValidator<?, ?>> T getInstance(Class<T> key) {
+            if (key.equals(VerifiedHostValidator.class)) {
+              return key.cast(verifiedHostValidator);
+            }
+            try {
+              return key.getDeclaredConstructor().newInstance();
+            } catch (ReflectiveOperationException e) {
+              throw new IllegalStateException(e);
+            }
+          }
+
+          @Override
+          public void releaseInstance(ConstraintValidator<?, ?> instance) {}
+        };
+
+    // TODO extract into test utils
+    ValidatorFactory validatorFactory =
+        Validation.byDefaultProvider()
+            .configure()
+            .constraintValidatorFactory(factory)
+            .messageInterpolator(new ParameterMessageInterpolator())
+            .buildValidatorFactory();
+
+    ValidationProvider validationProvider = new DefaultValidationProvider(validatorFactory);
+
     this.validationProvider = validationProvider;
     return this;
   }

--- a/connector-runtime/connector-runtime-test/src/main/java/io/camunda/connector/runtime/test/outbound/TestValidationProvider.java
+++ b/connector-runtime/connector-runtime-test/src/main/java/io/camunda/connector/runtime/test/outbound/TestValidationProvider.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.runtime.test.outbound;
+
+import io.camunda.connector.api.validation.ValidationProvider;
+import io.camunda.connector.hostvalidator.VerifiedHostValidator;
+import io.camunda.connector.validation.impl.DefaultValidationProvider;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorFactory;
+import jakarta.validation.Validation;
+import jakarta.validation.ValidatorFactory;
+import java.util.List;
+import org.hibernate.validator.messageinterpolation.ParameterMessageInterpolator;
+
+public class TestValidationProvider implements ValidationProvider {
+
+  private final ValidationProvider delegate;
+
+  public TestValidationProvider(VerifiedHostValidator verifiedHostValidator) {
+    /*
+     Basic implementation that is able to discover the {@link VerifiedHostValidator}
+    */
+    ConstraintValidatorFactory factory =
+        new ConstraintValidatorFactory() {
+          @Override
+          public <T extends ConstraintValidator<?, ?>> T getInstance(Class<T> key) {
+            if (key.equals(VerifiedHostValidator.class)) {
+              return key.cast(verifiedHostValidator);
+            }
+            try {
+              return key.getDeclaredConstructor().newInstance();
+            } catch (ReflectiveOperationException e) {
+              throw new IllegalStateException(e);
+            }
+          }
+
+          @Override
+          public void releaseInstance(ConstraintValidator<?, ?> instance) {}
+        };
+
+    ValidatorFactory validatorFactory =
+        Validation.byDefaultProvider()
+            .configure()
+            .constraintValidatorFactory(factory)
+            .messageInterpolator(new ParameterMessageInterpolator())
+            .buildValidatorFactory();
+
+    this.delegate = new DefaultValidationProvider(validatorFactory);
+  }
+
+  public TestValidationProvider() {
+    this(
+        new VerifiedHostValidator(
+            new VerifiedHostValidator.Config(true, List.of(), List.of(), true, true)));
+  }
+
+  @Override
+  public void validate(Object objectToValidate) {
+    delegate.validate(objectToValidate);
+  }
+}

--- a/connector-runtime/spring-boot-starter-camunda-connectors/pom.xml
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/pom.xml
@@ -28,6 +28,10 @@
     </dependency>
     <dependency>
       <groupId>io.camunda.connector</groupId>
+      <artifactId>host-ip-validator</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.camunda.connector</groupId>
       <artifactId>connector-core</artifactId>
     </dependency>
     <dependency>

--- a/connector-runtime/spring-boot-starter-camunda-connectors/pom.xml
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/pom.xml
@@ -121,6 +121,14 @@
       <artifactId>jakarta.annotation-api</artifactId>
     </dependency>
     <dependency>
+      <groupId>jakarta.validation</groupId>
+      <artifactId>jakarta.validation-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.hibernate.validator</groupId>
+      <artifactId>hibernate-validator</artifactId>
+    </dependency>
+    <dependency>
       <groupId>io.micrometer</groupId>
       <artifactId>micrometer-core</artifactId>
     </dependency>

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/main/java/io/camunda/connector/runtime/ConnectorProperties.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/main/java/io/camunda/connector/runtime/ConnectorProperties.java
@@ -17,6 +17,7 @@
 package io.camunda.connector.runtime;
 
 import java.time.Duration;
+import java.util.List;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 /** Configuration properties for Camunda Connectors. */
@@ -27,7 +28,8 @@ public record ConnectorProperties(
     SecretProvider secretProvider,
     VirtualThreads virtualThreads,
     Inbound inbound,
-    OAuth oauth) {
+    OAuth oauth,
+    Validation validation) {
   // NOTE: this class is not used in directly in the code, but is used by Spring Boot
   // configuration annotation processor to generate the configuration properties metadata
 
@@ -85,4 +87,29 @@ public record ConnectorProperties(
    *     Default is 10 seconds.
    */
   public record OAuthCache(Duration skewBuffer) {}
+
+  /**
+   * Configuration for custom validations that are managed by the runtime.
+   *
+   * @param hosts
+   */
+  public record Validation(Hosts hosts) {
+
+    /**
+     * Used by the {@link io.camunda.connector.hostvalidator.VerifiedHostValidator} to verify hosts
+     * used by Connectors as an input configuration.
+     *
+     * @param enabled
+     * @param allowRanges
+     * @param denyRanges
+     * @param unsafeAllowPrivateRanges
+     * @param unsafeAllowLoopback
+     */
+    public record Hosts(
+        boolean enabled,
+        List<String> allowRanges,
+        List<String> denyRanges,
+        boolean unsafeAllowPrivateRanges,
+        boolean unsafeAllowLoopback) {}
+  }
 }

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/main/java/io/camunda/connector/runtime/ConnectorsAutoConfiguration.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/main/java/io/camunda/connector/runtime/ConnectorsAutoConfiguration.java
@@ -23,11 +23,14 @@ import io.camunda.client.spring.configuration.CamundaAutoConfiguration;
 import io.camunda.client.spring.properties.CamundaClientProperties;
 import io.camunda.connector.api.document.DocumentFactory;
 import io.camunda.connector.api.secret.SecretProvider;
+import io.camunda.connector.api.validation.ValidationProvider;
 import io.camunda.connector.document.jackson.JacksonModuleDocumentDeserializer;
 import io.camunda.connector.document.jackson.JacksonModuleDocumentSerializer;
 import io.camunda.connector.feel.FeelExpressionEvaluator;
 import io.camunda.connector.feel.FeelExpressionEvaluatorBuilder;
 import io.camunda.connector.feel.jackson.JacksonModuleFeelFunction;
+import io.camunda.connector.hostvalidator.CidrRange;
+import io.camunda.connector.hostvalidator.VerifiedHostValidator;
 import io.camunda.connector.http.client.authentication.OAuthTokenCache;
 import io.camunda.connector.http.client.authentication.OAuthTokenCacheHolder;
 import io.camunda.connector.http.client.authentication.cacheimpl.CaffeineOAuthTokenCache;
@@ -41,15 +44,20 @@ import io.camunda.connector.runtime.secret.ConsoleSecretProvider;
 import io.camunda.connector.runtime.secret.EnvironmentSecretProvider;
 import io.camunda.connector.runtime.secret.console.ConsoleSecretApiClient;
 import io.camunda.connector.runtime.secret.console.JwtCredential;
+import io.camunda.connector.validation.impl.DefaultValidationProvider;
+import jakarta.validation.ConstraintValidatorFactory;
+import jakarta.validation.Validation;
 import java.net.URL;
 import java.time.Duration;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
+import org.hibernate.validator.messageinterpolation.ParameterMessageInterpolator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.beans.factory.config.AutowireCapableBeanFactory;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -266,5 +274,51 @@ public class ConnectorsAutoConfiguration {
 
     OAuthTokenCache cache = oAuthTokenCacheProvider.getIfAvailable(OAuthTokenCacheHolder::get);
     LOG.debug("OAuth token cache stats: {}", cache.getStats());
+  }
+
+  @Bean
+  @ConditionalOnMissingBean(ValidationProvider.class)
+  VerifiedHostValidator verifiedHostValidator(ConnectorProperties connectorProperties) {
+    var validation =
+        Optional.ofNullable(connectorProperties.validation())
+            .orElseGet(
+                () ->
+                    new ConnectorProperties.Validation(
+                        new ConnectorProperties.Validation.Hosts(false, null, null, false, false)));
+    var allowRanges =
+        Optional.ofNullable(validation.hosts().allowRanges()).orElseGet(List::of).stream()
+            .map(CidrRange::parse)
+            .toList();
+    List<CidrRange> denyRanges =
+        Optional.ofNullable(validation.hosts().denyRanges()).orElseGet(List::of).stream()
+            .map(CidrRange::parse)
+            .toList();
+    var config =
+        new VerifiedHostValidator.Config(
+            validation.hosts().enabled(),
+            allowRanges,
+            denyRanges,
+            validation.hosts().unsafeAllowPrivateRanges(),
+            validation.hosts().unsafeAllowLoopback());
+    return new VerifiedHostValidator(config);
+  }
+
+  @Bean
+  @ConditionalOnMissingBean(ValidationProvider.class)
+  SpringBeanConstraintValidatorFactory springConstraintValidatorFactory(
+      AutowireCapableBeanFactory autowireCapableBeanFactory) {
+    return new SpringBeanConstraintValidatorFactory(autowireCapableBeanFactory);
+  }
+
+  @Bean
+  @ConditionalOnMissingBean(ValidationProvider.class)
+  ValidationProvider validationProvider(ConstraintValidatorFactory constraintValidatorFactory) {
+    var validationFactory =
+        Validation.byDefaultProvider()
+            .configure()
+            .messageInterpolator(new ParameterMessageInterpolator())
+            .constraintValidatorFactory(constraintValidatorFactory)
+            .buildValidatorFactory();
+    return new DefaultValidationProvider(validationFactory);
   }
 }

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/main/java/io/camunda/connector/runtime/SpringBeanConstraintValidatorFactory.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/main/java/io/camunda/connector/runtime/SpringBeanConstraintValidatorFactory.java
@@ -1,0 +1,28 @@
+package io.camunda.connector.runtime;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorFactory;
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
+import org.springframework.beans.factory.config.AutowireCapableBeanFactory;
+
+public class SpringBeanConstraintValidatorFactory implements ConstraintValidatorFactory {
+  private final AutowireCapableBeanFactory beanFactory;
+
+  public SpringBeanConstraintValidatorFactory(AutowireCapableBeanFactory beanFactory) {
+    this.beanFactory = beanFactory;
+  }
+
+  @Override
+  public <T extends ConstraintValidator<?, ?>> T getInstance(Class<T> key) {
+    // Try to find an existing bean of this type first
+    try {
+      return beanFactory.getBean(key);
+    } catch (NoSuchBeanDefinitionException e) {
+      // Fall back to creating a new autowired instance
+      return beanFactory.createBean(key);
+    }
+  }
+
+  @Override
+  public void releaseInstance(ConstraintValidator<?, ?> instance) {}
+}

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/main/java/io/camunda/connector/runtime/SpringBeanConstraintValidatorFactory.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/main/java/io/camunda/connector/runtime/SpringBeanConstraintValidatorFactory.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.camunda.connector.runtime;
 
 import jakarta.validation.ConstraintValidator;

--- a/connector-sdk/validation/src/main/java/io/camunda/connector/validation/impl/DefaultValidationProvider.java
+++ b/connector-sdk/validation/src/main/java/io/camunda/connector/validation/impl/DefaultValidationProvider.java
@@ -38,6 +38,10 @@ public class DefaultValidationProvider implements ValidationProvider {
     this.validatorFactory = configuration.buildValidatorFactory();
   }
 
+  public DefaultValidationProvider(ValidatorFactory validatorFactory) {
+    this.validatorFactory = validatorFactory;
+  }
+
   @Override
   public void validate(Object objectToValidate) {
     Set<ConstraintViolation<Object>> violations =

--- a/connectors-e2e-test/connectors-e2e-email/src/test/java/io/camunda/connector/e2e/InboundEmailTests.java
+++ b/connectors-e2e-test/connectors-e2e-email/src/test/java/io/camunda/connector/e2e/InboundEmailTests.java
@@ -49,7 +49,9 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
     properties = {
       "spring.main.allow-bean-definition-overriding=true",
       "camunda.connector.webhook.enabled=false",
-      "camunda.connector.polling.enabled=true"
+      "camunda.connector.polling.enabled=true",
+      "camunda.connector.validation.hosts.enabled=true",
+      "camunda.connector.validation.hosts.unsafe-allow-loopback=true"
     },
     webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @CamundaSpringProcessTest

--- a/connectors-e2e-test/connectors-e2e-test-http/src/test/java/io/camunda/connector/e2e/HttpTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-http/src/test/java/io/camunda/connector/e2e/HttpTests.java
@@ -70,7 +70,9 @@ import wiremock.com.fasterxml.jackson.databind.node.JsonNodeFactory;
     properties = {
       "spring.main.allow-bean-definition-overriding=true",
       "camunda.connector.webhook.enabled=true",
-      "camunda.connector.polling.enabled=false"
+      "camunda.connector.polling.enabled=false",
+      "camunda.connector.validation.hosts.enabled=true",
+      "camunda.connector.validation.hosts.unsafe-allow-loopback=true"
     },
     webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @CamundaSpringProcessTest

--- a/connectors-e2e-test/connectors-e2e-test-http/src/test/java/io/camunda/connector/e2e/HttpTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-http/src/test/java/io/camunda/connector/e2e/HttpTests.java
@@ -139,6 +139,37 @@ public class HttpTests {
   }
 
   @Test
+  void testHostValidationUsingBlockedIp() {
+    var model =
+        Bpmn.createProcess().executable().startEvent().serviceTask("restTask").endEvent().done();
+
+    var elementTemplate =
+        ElementTemplate.from(
+                "../../connectors/http/rest/element-templates/http-json-connector.json")
+            .property("url", "http:/192.0.0.0")
+            .property("method", "post")
+            .property("headers", "={testHeader: \"testHeaderValue\"}")
+            .property("queryParameters", "={testQueryParam: \"testQueryParamValue\"}")
+            .property("authentication.type", BasicAuthentication.TYPE)
+            .property("authentication.username", "username")
+            .property("authentication.password", "password")
+            .property("body", "={\"order\": {\"status\": \"processing\", \"id\": string(42+3)}}")
+            .property("resultExpression", "={orderStatus: response.body.order.status}")
+            .writeTo(new File(tempDir, "template.json"));
+
+    var updatedModel =
+        new BpmnFile(model)
+            .writeToFile(new File(tempDir, "test.bpmn"))
+            .apply(elementTemplate, "restTask", new File(tempDir, "result.bpmn"));
+
+    var bpmnTest =
+        ZeebeTest.with(camundaClient)
+            .deploy(updatedModel)
+            .createInstance()
+            .waitForActiveIncidents();
+  }
+
+  @Test
   void bearerAuth() {
     // Prepare an HTTP mock server
     wm.stubFor(

--- a/connectors/email/pom.xml
+++ b/connectors/email/pom.xml
@@ -65,6 +65,10 @@
       <artifactId>connector-runtime-core</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>io.camunda.connector</groupId>
+      <artifactId>host-ip-validator-annotation</artifactId>
+    </dependency>
   </dependencies>
 
   <build>

--- a/connectors/email/pom.xml
+++ b/connectors/email/pom.xml
@@ -69,16 +69,6 @@
       <groupId>io.camunda.connector</groupId>
       <artifactId>host-ip-validator-annotation</artifactId>
     </dependency>
-    <dependency>
-      <groupId>io.camunda.connector</groupId>
-      <artifactId>host-ip-validator</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.hibernate.validator</groupId>
-      <artifactId>hibernate-validator</artifactId>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 
   <build>

--- a/connectors/email/pom.xml
+++ b/connectors/email/pom.xml
@@ -69,6 +69,16 @@
       <groupId>io.camunda.connector</groupId>
       <artifactId>host-ip-validator-annotation</artifactId>
     </dependency>
+    <dependency>
+      <groupId>io.camunda.connector</groupId>
+      <artifactId>host-ip-validator</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.hibernate.validator</groupId>
+      <artifactId>hibernate-validator</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/connectors/email/src/main/java/io/camunda/connector/email/config/ImapConfig.java
+++ b/connectors/email/src/main/java/io/camunda/connector/email/config/ImapConfig.java
@@ -9,6 +9,7 @@ package io.camunda.connector.email.config;
 import io.camunda.connector.api.annotation.FEEL;
 import io.camunda.connector.generator.java.annotation.FeelMode;
 import io.camunda.connector.generator.java.annotation.TemplateProperty;
+import io.camunda.connector.hostvalidator.VerifiedHost;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 
@@ -23,6 +24,7 @@ public record ImapConfig(
             binding = @TemplateProperty.PropertyBinding(name = "data.imapConfig.imapHost"))
         @Valid
         @NotNull
+        @VerifiedHost
         String imapHost,
     @TemplateProperty(
             label = "IMAP Port",

--- a/connectors/email/src/main/java/io/camunda/connector/email/config/Pop3Config.java
+++ b/connectors/email/src/main/java/io/camunda/connector/email/config/Pop3Config.java
@@ -8,6 +8,7 @@ package io.camunda.connector.email.config;
 
 import io.camunda.connector.generator.java.annotation.FeelMode;
 import io.camunda.connector.generator.java.annotation.TemplateProperty;
+import io.camunda.connector.hostvalidator.VerifiedHost;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 
@@ -22,6 +23,7 @@ public record Pop3Config(
             binding = @TemplateProperty.PropertyBinding(name = "data.pop3Config.pop3Host"))
         @Valid
         @NotNull
+        @VerifiedHost
         String pop3Host,
     @TemplateProperty(
             label = "POP3 Port",

--- a/connectors/email/src/main/java/io/camunda/connector/email/config/SmtpConfig.java
+++ b/connectors/email/src/main/java/io/camunda/connector/email/config/SmtpConfig.java
@@ -8,6 +8,7 @@ package io.camunda.connector.email.config;
 
 import io.camunda.connector.generator.java.annotation.FeelMode;
 import io.camunda.connector.generator.java.annotation.TemplateProperty;
+import io.camunda.connector.hostvalidator.VerifiedHost;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 
@@ -22,6 +23,7 @@ public record SmtpConfig(
             binding = @TemplateProperty.PropertyBinding(name = "data.smtpConfig.smtpHost"))
         @Valid
         @NotNull
+        @VerifiedHost
         String smtpHost,
     @TemplateProperty(
             label = "SMTP Port",

--- a/connectors/email/src/test/java/io/camunda/connector/email/integration/OutboundEmailTest.java
+++ b/connectors/email/src/test/java/io/camunda/connector/email/integration/OutboundEmailTest.java
@@ -13,31 +13,23 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.connector.api.document.DocumentCreationRequest;
 import io.camunda.connector.api.document.DocumentFactory;
 import io.camunda.connector.api.outbound.OutboundConnectorContext;
-import io.camunda.connector.api.validation.ValidationProvider;
 import io.camunda.connector.email.client.jakarta.outbound.JakartaEmailActionExecutor;
 import io.camunda.connector.email.client.jakarta.utils.JakartaUtils;
 import io.camunda.connector.email.response.DeleteEmailResponse;
 import io.camunda.connector.email.response.ListEmailsResponse;
 import io.camunda.connector.email.response.ReadEmailResponse;
 import io.camunda.connector.email.response.SearchEmailsResponse;
-import io.camunda.connector.hostvalidator.VerifiedHostValidator;
 import io.camunda.connector.jackson.ConnectorsObjectMapperSupplier;
 import io.camunda.connector.runtime.core.document.DocumentFactoryImpl;
 import io.camunda.connector.runtime.core.document.store.InMemoryDocumentStore;
 import io.camunda.connector.runtime.test.outbound.OutboundConnectorContextBuilder;
-import io.camunda.connector.validation.impl.DefaultValidationProvider;
 import jakarta.mail.Message;
-import jakarta.validation.ConstraintValidator;
-import jakarta.validation.ConstraintValidatorFactory;
-import jakarta.validation.Validation;
-import jakarta.validation.ValidatorFactory;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Stream;
-import org.hibernate.validator.messageinterpolation.ParameterMessageInterpolator;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -48,46 +40,12 @@ public class OutboundEmailTest extends BaseEmailTest {
   DocumentFactory documentFactory = new DocumentFactoryImpl(InMemoryDocumentStore.INSTANCE);
   ObjectMapper objectMapper = new ObjectMapper();
 
-  // TODO extract into test utils
-  VerifiedHostValidator verifiedHostValidator =
-      new VerifiedHostValidator(
-          new VerifiedHostValidator.Config(true, List.of(), List.of(), true, true));
-
-  // TODO extract into test utils
-  ConstraintValidatorFactory factory =
-      new ConstraintValidatorFactory() {
-        @Override
-        public <T extends ConstraintValidator<?, ?>> T getInstance(Class<T> key) {
-          if (key.equals(VerifiedHostValidator.class)) {
-            return key.cast(verifiedHostValidator);
-          }
-          try {
-            return key.getDeclaredConstructor().newInstance();
-          } catch (ReflectiveOperationException e) {
-            throw new IllegalStateException(e);
-          }
-        }
-
-        @Override
-        public void releaseInstance(ConstraintValidator<?, ?> instance) {}
-      };
-
-  // TODO extract into test utils
-  ValidatorFactory validatorFactory =
-      Validation.byDefaultProvider()
-          .configure()
-          .constraintValidatorFactory(factory)
-          .messageInterpolator(new ParameterMessageInterpolator())
-          .buildValidatorFactory();
-
-  ValidationProvider validationProvider = new DefaultValidationProvider(validatorFactory);
-
   JakartaEmailActionExecutor jakartaEmailActionExecutor =
       JakartaEmailActionExecutor.create(
           new JakartaUtils(), ConnectorsObjectMapperSupplier.getCopy());
 
   private OutboundConnectorContextBuilder contextBuilder =
-      OutboundConnectorContextBuilder.create().validation(validationProvider);
+      OutboundConnectorContextBuilder.create().includeAllValidators();
 
   private static Stream<String> getStreamFromPath(String path) {
     ObjectMapper objectMapper = new ObjectMapper().findAndRegisterModules();

--- a/connectors/email/src/test/java/io/camunda/connector/email/integration/OutboundEmailTest.java
+++ b/connectors/email/src/test/java/io/camunda/connector/email/integration/OutboundEmailTest.java
@@ -13,23 +13,31 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.connector.api.document.DocumentCreationRequest;
 import io.camunda.connector.api.document.DocumentFactory;
 import io.camunda.connector.api.outbound.OutboundConnectorContext;
+import io.camunda.connector.api.validation.ValidationProvider;
 import io.camunda.connector.email.client.jakarta.outbound.JakartaEmailActionExecutor;
 import io.camunda.connector.email.client.jakarta.utils.JakartaUtils;
 import io.camunda.connector.email.response.DeleteEmailResponse;
 import io.camunda.connector.email.response.ListEmailsResponse;
 import io.camunda.connector.email.response.ReadEmailResponse;
 import io.camunda.connector.email.response.SearchEmailsResponse;
+import io.camunda.connector.hostvalidator.VerifiedHostValidator;
 import io.camunda.connector.jackson.ConnectorsObjectMapperSupplier;
 import io.camunda.connector.runtime.core.document.DocumentFactoryImpl;
 import io.camunda.connector.runtime.core.document.store.InMemoryDocumentStore;
 import io.camunda.connector.runtime.test.outbound.OutboundConnectorContextBuilder;
+import io.camunda.connector.validation.impl.DefaultValidationProvider;
 import jakarta.mail.Message;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorFactory;
+import jakarta.validation.Validation;
+import jakarta.validation.ValidatorFactory;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Stream;
+import org.hibernate.validator.messageinterpolation.ParameterMessageInterpolator;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -40,10 +48,46 @@ public class OutboundEmailTest extends BaseEmailTest {
   DocumentFactory documentFactory = new DocumentFactoryImpl(InMemoryDocumentStore.INSTANCE);
   ObjectMapper objectMapper = new ObjectMapper();
 
+  // TODO extract into test utils
+  VerifiedHostValidator verifiedHostValidator =
+      new VerifiedHostValidator(
+          new VerifiedHostValidator.Config(true, List.of(), List.of(), true, true));
+
+  // TODO extract into test utils
+  ConstraintValidatorFactory factory =
+      new ConstraintValidatorFactory() {
+        @Override
+        public <T extends ConstraintValidator<?, ?>> T getInstance(Class<T> key) {
+          if (key.equals(VerifiedHostValidator.class)) {
+            return key.cast(verifiedHostValidator);
+          }
+          try {
+            return key.getDeclaredConstructor().newInstance();
+          } catch (ReflectiveOperationException e) {
+            throw new IllegalStateException(e);
+          }
+        }
+
+        @Override
+        public void releaseInstance(ConstraintValidator<?, ?> instance) {}
+      };
+
+  // TODO extract into test utils
+  ValidatorFactory validatorFactory =
+      Validation.byDefaultProvider()
+          .configure()
+          .constraintValidatorFactory(factory)
+          .messageInterpolator(new ParameterMessageInterpolator())
+          .buildValidatorFactory();
+
+  ValidationProvider validationProvider = new DefaultValidationProvider(validatorFactory);
+
   JakartaEmailActionExecutor jakartaEmailActionExecutor =
       JakartaEmailActionExecutor.create(
           new JakartaUtils(), ConnectorsObjectMapperSupplier.getCopy());
-  private OutboundConnectorContextBuilder contextBuilder = OutboundConnectorContextBuilder.create();
+
+  private OutboundConnectorContextBuilder contextBuilder =
+      OutboundConnectorContextBuilder.create().validation(validationProvider);
 
   private static Stream<String> getStreamFromPath(String path) {
     ObjectMapper objectMapper = new ObjectMapper().findAndRegisterModules();

--- a/connectors/http/graphql/pom.xml
+++ b/connectors/http/graphql/pom.xml
@@ -38,6 +38,11 @@
     </dependency>
 
     <dependency>
+      <groupId>io.camunda.connector</groupId>
+      <artifactId>host-ip-validator-annotation</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.wiremock</groupId>
       <artifactId>wiremock-standalone</artifactId>
       <version>${version.wiremock}</version>

--- a/connectors/http/graphql/src/main/java/io/camunda/connector/http/graphql/model/GraphQLRequest.java
+++ b/connectors/http/graphql/src/main/java/io/camunda/connector/http/graphql/model/GraphQLRequest.java
@@ -9,6 +9,7 @@ package io.camunda.connector.http.graphql.model;
 import io.camunda.connector.api.annotation.FEEL;
 import io.camunda.connector.generator.java.annotation.FeelMode;
 import io.camunda.connector.generator.java.annotation.TemplateProperty;
+import io.camunda.connector.hostvalidator.VerifiedHost;
 import io.camunda.connector.http.base.model.HttpMethod;
 import io.camunda.connector.http.base.model.auth.Authentication;
 import jakarta.validation.Valid;
@@ -64,6 +65,7 @@ public record GraphQLRequest(@Valid GraphQL graphql, @Valid Authentication authe
               regexp = "^(=|(http://|https://|secrets|\\{\\{).*$)",
               message = "Must be a http(s) URL")
           @TemplateProperty(id = "url", group = "endpoint", label = "URL")
+          @VerifiedHost(isUri = true)
           String url,
       @FEEL
           @TemplateProperty(

--- a/connectors/http/graphql/src/test/java/io/camunda/connector/http/graphql/GraphQLFunctionTest.java
+++ b/connectors/http/graphql/src/test/java/io/camunda/connector/http/graphql/GraphQLFunctionTest.java
@@ -27,7 +27,6 @@ import io.camunda.connector.http.graphql.model.GraphQLRequest;
 import io.camunda.connector.http.graphql.utils.GraphQLRequestMapper;
 import io.camunda.connector.jackson.ConnectorsObjectMapperSupplier;
 import io.camunda.connector.runtime.test.outbound.OutboundConnectorContextBuilder;
-import io.camunda.connector.validation.impl.DefaultValidationProvider;
 import java.io.IOException;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
@@ -86,7 +85,7 @@ public class GraphQLFunctionTest extends BaseTest {
     final var context =
         OutboundConnectorContextBuilder.create()
             .variables(input)
-            .validation(new DefaultValidationProvider())
+            .includeAllValidators()
             .secrets(new StaticSecretProvider("foo"))
             .build();
 
@@ -106,6 +105,7 @@ public class GraphQLFunctionTest extends BaseTest {
     final var context =
         OutboundConnectorContextBuilder.create()
             .variables(input)
+            .includeAllValidators()
             .secrets(new StaticSecretProvider("foo"))
             .build();
     final var expectedTimeInSeconds =
@@ -138,6 +138,7 @@ public class GraphQLFunctionTest extends BaseTest {
     final var context =
         OutboundConnectorContextBuilder.create()
             .variables(input)
+            .includeAllValidators()
             .secrets(new StaticSecretProvider("foo"))
             .build();
 
@@ -170,6 +171,7 @@ public class GraphQLFunctionTest extends BaseTest {
     final var context =
         OutboundConnectorContextBuilder.create()
             .variables(input)
+            .includeAllValidators()
             .secrets(new StaticSecretProvider("foo"))
             .build();
 
@@ -181,6 +183,7 @@ public class GraphQLFunctionTest extends BaseTest {
     final var context =
         OutboundConnectorContextBuilder.create()
             .variables(input)
+            .includeAllValidators()
             .secrets(new StaticSecretProvider("foo"))
             .build();
     return (HttpCommonResult) functionUnderTest.execute(context);

--- a/connectors/http/http-base/pom.xml
+++ b/connectors/http/http-base/pom.xml
@@ -52,6 +52,10 @@
       <artifactId>connector-runtime-core</artifactId>
       <scope>test</scope>
     </dependency>
+      <dependency>
+          <groupId>io.camunda.connector</groupId>
+          <artifactId>host-ip-validator-annotation</artifactId>
+      </dependency>
   </dependencies>
 
 </project>

--- a/connectors/http/http-base/pom.xml
+++ b/connectors/http/http-base/pom.xml
@@ -38,6 +38,10 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>io.camunda.connector</groupId>
+      <artifactId>host-ip-validator-annotation</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.wiremock</groupId>
       <artifactId>wiremock-standalone</artifactId>
       <scope>test</scope>
@@ -52,10 +56,6 @@
       <artifactId>connector-runtime-core</artifactId>
       <scope>test</scope>
     </dependency>
-      <dependency>
-          <groupId>io.camunda.connector</groupId>
-          <artifactId>host-ip-validator-annotation</artifactId>
-      </dependency>
   </dependencies>
 
 </project>

--- a/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/model/HttpCommonRequest.java
+++ b/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/model/HttpCommonRequest.java
@@ -11,6 +11,7 @@ import io.camunda.connector.generator.java.annotation.FeelMode;
 import io.camunda.connector.generator.java.annotation.TemplateProperty;
 import io.camunda.connector.generator.java.annotation.TemplateProperty.PropertyCondition;
 import io.camunda.connector.generator.java.annotation.TemplateProperty.PropertyType;
+import io.camunda.connector.hostvalidator.VerifiedHost;
 import io.camunda.connector.http.base.model.auth.Authentication;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
@@ -33,6 +34,7 @@ public class HttpCommonRequest {
   @FEEL
   @NotBlank
   @Pattern(regexp = "^(=|(http://|https://|secrets|\\{\\{).*$)", message = "Must be a http(s) URL")
+  @VerifiedHost(isUrl = true)
   @TemplateProperty(group = "endpoint", label = "URL", feel = FeelMode.optional)
   private String url;
 

--- a/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/model/HttpCommonRequest.java
+++ b/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/model/HttpCommonRequest.java
@@ -34,7 +34,7 @@ public class HttpCommonRequest {
   @FEEL
   @NotBlank
   @Pattern(regexp = "^(=|(http://|https://|secrets|\\{\\{).*$)", message = "Must be a http(s) URL")
-  @VerifiedHost(isUrl = true)
+  @VerifiedHost(isUri = true)
   @TemplateProperty(group = "endpoint", label = "URL", feel = FeelMode.optional)
   private String url;
 

--- a/connectors/http/rest/src/test/java/io/camunda/connector/http/rest/BaseTest.java
+++ b/connectors/http/rest/src/test/java/io/camunda/connector/http/rest/BaseTest.java
@@ -129,6 +129,7 @@ public class BaseTest {
 
   protected OutboundConnectorContextBuilder getContextBuilderWithSecrets() {
     return OutboundConnectorContextBuilder.create()
+        .includeAllValidators()
         .secret(SecretsConstant.URL, ActualValue.URL)
         .secret(SecretsConstant.METHOD, ActualValue.METHOD)
         .secret(SecretsConstant.CONNECT_TIMEOUT, String.valueOf(ActualValue.CONNECT_TIMEOUT))

--- a/connectors/http/rest/src/test/java/io/camunda/connector/http/rest/HttpJsonFunctionInputValidationTest.java
+++ b/connectors/http/rest/src/test/java/io/camunda/connector/http/rest/HttpJsonFunctionInputValidationTest.java
@@ -136,10 +136,7 @@ public class HttpJsonFunctionInputValidationTest extends BaseTest {
   void validate_shouldValidateWithoutException(String input) {
     // Given request without one required field
     OutboundConnectorContext context =
-        getContextBuilderWithSecrets()
-            .variables(input)
-            .validation(new DefaultValidationProvider())
-            .build();
+        getContextBuilderWithSecrets().variables(input).includeAllValidators().build();
     // When context.validate(request);
     // Then expect normal validate without exception
     context.bindVariables(HttpJsonRequest.class);

--- a/connectors/http/rest/src/test/java/io/camunda/connector/http/rest/HttpJsonFunctionTest.java
+++ b/connectors/http/rest/src/test/java/io/camunda/connector/http/rest/HttpJsonFunctionTest.java
@@ -110,7 +110,8 @@ public class HttpJsonFunctionTest extends BaseTest {
         "{ \"createdAt\": \"2022-10-10T05:03:14.723Z\", \"name\": \"Marvin Cremin\",\"unknown\": null, \"id\": \"1\" }";
     stubFor(any(urlPathEqualTo("/http-endpoint")).willReturn(aResponse().withBody(response)));
 
-    final var context = OutboundConnectorContextBuilder.create().variables(request).build();
+    final var context =
+        OutboundConnectorContextBuilder.create().includeAllValidators().variables(request).build();
     // when connector execute
     var functionCallResponseAsObject = functionUnderTest.execute(context);
     // then null field 'unknown' exists in response body and has a null value
@@ -131,7 +132,8 @@ public class HttpJsonFunctionTest extends BaseTest {
     stubFor(
         put(urlPathEqualTo("/http-endpoint")).willReturn(aResponse().withStatus(200)).withId(uuid));
 
-    final var context = OutboundConnectorContextBuilder.create().variables(request).build();
+    final var context =
+        OutboundConnectorContextBuilder.create().includeAllValidators().variables(request).build();
     functionUnderTest.execute(context);
 
     List<ServeEvent> allServeEvents = getAllServeEvents(ServeEventQuery.forStubMapping(uuid));
@@ -152,7 +154,8 @@ public class HttpJsonFunctionTest extends BaseTest {
     stubFor(
         put(urlPathEqualTo("/http-endpoint")).willReturn(aResponse().withStatus(200)).withId(uuid));
 
-    final var context = OutboundConnectorContextBuilder.create().variables(request).build();
+    final var context =
+        OutboundConnectorContextBuilder.create().includeAllValidators().variables(request).build();
     functionUnderTest.execute(context);
 
     List<ServeEvent> allServeEvents = getAllServeEvents(ServeEventQuery.forStubMapping(uuid));
@@ -168,6 +171,7 @@ public class HttpJsonFunctionTest extends BaseTest {
         OutboundConnectorContextBuilder.create()
             .variables(input)
             .secrets(new StaticSecretProvider("foo"))
+            .includeAllValidators()
             .build();
     return (HttpCommonResult) functionUnderTest.execute(context);
   }

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -433,6 +433,18 @@ limitations under the License.</license.inlineheader>
       </dependency>
 
       <dependency>
+        <groupId>io.camunda.connector</groupId>
+        <artifactId>host-ip-validator</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>io.camunda.connector</groupId>
+        <artifactId>host-ip-validator-annotation</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+
+      <dependency>
         <groupId>io.camunda</groupId>
         <artifactId>camunda-spring-boot-starter</artifactId>
         <version>${version.camunda}</version>


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

This pull request introduces a new host/IP validation module for connectors, designed to defend against SSRF and unauthorized outbound HTTP calls by validating hostnames and their resolved IP addresses against configurable CIDR allow/deny lists. The implementation is split into two Maven modules: one for the Jakarta Bean Validation annotation and another for the core validator logic. The validator is configurable and intended for integration with dependency injection frameworks like Spring.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes camunda/security-testing-findings/issues/2

## Checklist

- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest
  release, as this branch will be rebased onto main before the next release. Example backport labels:
    - `backport stable/8.8`: for changes that should be included in the next 8.8.x release.
    - **or** `backport release-8.8.7`: for changes that should be included in the specific release 8.8.7, and this
      *release has already been created*. The release branch will be merged back into stable/8.8 later, so the change
      will be included in future 8.8.x releases as well.
- [x] Tests/Integration tests for the changes have been added if applicable.
- [ ] If the change requires a documentation update, it has been added to the appropriate section in the documentation.


