### PR TITLE
test(e2e): use shared cpt runtime for e2e tests and fix deprecrated property

### DIFF
--- a/connectors-e2e-test/connectors-e2e-test-base/src/main/resources/application.properties
+++ b/connectors-e2e-test/connectors-e2e-test-base/src/main/resources/application.properties
@@ -3,4 +3,6 @@ logging.level.io.camunda.process.test=info
 logging.level.org.testcontainers=warn
 logging.level.tc=warn
 logging.level.io.camunda.connector=debug
-io.camunda.process.test.camundaVersion=SNAPSHOT
+
+camunda.process-test.runtime-mode=shared
+camunda.process-test.camunda-docker-image-version=SNAPSHOT


### PR DESCRIPTION
## Description

- Use the `shared` CPT runtime where applicable to improve e2e test efficiency.
- Fix deprecated CPT property

## Checklist

- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest
  release, as this branch will be rebased onto main before the next release. Example backport labels:
    - `backport stable/8.8`: for changes that should be included in the next 8.8.x release.
    - **or** `backport release-8.8.7`: for changes that should be included in the specific release 8.8.7, and this
      *release has already been created*. The release branch will be merged back into stable/8.8 later, so the change
      will be included in future 8.8.x releases as well.
- [ ] Tests/Integration tests for the changes have been added if applicable.
- [ ] If the change requires a documentation update, it has been added to the appropriate section in the documentation.


