### PR TITLE
chore: add vault secrets verification workflow

### DIFF
--- a/.github/workflows/VERIFY_VAULT_SECRETS.yml
+++ b/.github/workflows/VERIFY_VAULT_SECRETS.yml
@@ -1,0 +1,72 @@
+name: Verify Vault Secrets
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/VERIFY_VAULT_SECRETS.yml"
+
+jobs:
+  verify-vault-secrets:
+    name: Verify Vault access
+    runs-on: ubuntu-latest
+    steps:
+      - name: Import Secrets (common)
+        id: secrets-common
+        uses: hashicorp/vault-action@4c06c5ccf5c0761b6029f56cfb1dcf5565918a3b # v3.4.0
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          exportEnv: false
+          secrets: |
+            secret/data/products/connectors/ci/common GITHUB_APP_ID;
+            secret/data/products/connectors/ci/common GITHUB_APP_PRIVATE_KEY;
+
+      - name: Import Secrets (nexus)
+        id: secrets-nexus
+        uses: hashicorp/vault-action@4c06c5ccf5c0761b6029f56cfb1dcf5565918a3b # v3.4.0
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          exportEnv: false
+          secrets: |
+            secret/data/products/connectors/ci/nexus USER;
+            secret/data/products/connectors/ci/nexus PASSWORD;
+
+      - name: Import Secrets (artifactory)
+        id: secrets-artifactory
+        uses: hashicorp/vault-action@4c06c5ccf5c0761b6029f56cfb1dcf5565918a3b # v3.4.0
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          exportEnv: false
+          secrets: |
+            secret/data/products/connectors/ci/artifactory USER;
+            secret/data/products/connectors/ci/artifactory TOKEN;
+
+      - name: Import Secrets (org)
+        id: secrets-org
+        uses: hashicorp/vault-action@4c06c5ccf5c0761b6029f56cfb1dcf5565918a3b # v3.4.0
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          exportEnv: false
+          secrets: |
+            secret/data/github.com/organizations/camunda MAVEN_CENTRAL_DEPLOYMENT_USR;
+            secret/data/github.com/organizations/camunda MAVEN_CENTRAL_DEPLOYMENT_PSW;
+            secret/data/github.com/organizations/camunda MAVEN_CENTRAL_GPG_SIGNING_KEY_PASSPHRASE;
+
+      - name: Verify all secrets loaded
+        run: |
+          echo "✅ All Vault secrets imported successfully"
+          echo "  - common: GITHUB_APP_ID present=${{ steps.secrets-common.outputs.GITHUB_APP_ID != '' }}"
+          echo "  - nexus: USER present=${{ steps.secrets-nexus.outputs.USER != '' }}"
+          echo "  - artifactory: USER present=${{ steps.secrets-artifactory.outputs.USER != '' }}"
+          echo "  - org: MAVEN_CENTRAL_DEPLOYMENT_USR present=${{ steps.secrets-org.outputs.MAVEN_CENTRAL_DEPLOYMENT_USR != '' }}"


### PR DESCRIPTION
## Description

Temporary workflow to verify Vault access works after infra-core migrated this repo to a team-scoped AppRole.

Imports the same 4 secret paths used by the release workflow:
- `secret/data/products/connectors/ci/common`
- `secret/data/products/connectors/ci/nexus`
- `secret/data/products/connectors/ci/artifactory`
- `secret/data/github.com/organizations/camunda`

Triggers on PR when this workflow file changes. **To be removed after verification.**

## Prerequisite

camunda/infra-core PR must be merged and applied first (creates the secrets).