### PR TITLE
fix(idp-extraction): remove default topP from converseData to avoid model conflicts

### DIFF
--- a/connectors/idp-extraction/element-templates/hybrid/hybrid-idp-classification-outbound-connector-hybrid.json
+++ b/connectors/idp-extraction/element-templates/hybrid/hybrid-idp-classification-outbound-connector-hybrid.json
@@ -55,7 +55,7 @@
     "label" : "AWS Bedrock Converse Parameters",
     "description" : "Specify the parameters for AWS Bedrock",
     "optional" : false,
-    "value" : "={\n  modelId: \"\",\n  temperature: 0.5,\n  topP: 0.9\n}",
+    "value" : "={\n  modelId: \"\",\n  temperature: 0.5\n}",
     "feel" : "optional",
     "group" : "input",
     "binding" : {

--- a/connectors/idp-extraction/element-templates/hybrid/hybrid-idp-unstructured-extraction-outbound-connector-hybrid.json
+++ b/connectors/idp-extraction/element-templates/hybrid/hybrid-idp-unstructured-extraction-outbound-connector-hybrid.json
@@ -68,7 +68,7 @@
     "label" : "Ai converse parameters",
     "description" : "Specify the parameters for the ai conversation",
     "optional" : false,
-    "value" : "={\n  modelId: \"\",\n  temperature: 0.5,\n  topP: 0.9\n}",
+    "value" : "={\n  modelId: \"\",\n  temperature: 0.5\n}",
     "feel" : "optional",
     "group" : "input",
     "binding" : {

--- a/connectors/idp-extraction/element-templates/idp-classification-outbound-connector.json
+++ b/connectors/idp-extraction/element-templates/idp-classification-outbound-connector.json
@@ -50,7 +50,7 @@
     "label" : "AWS Bedrock Converse Parameters",
     "description" : "Specify the parameters for AWS Bedrock",
     "optional" : false,
-    "value" : "={\n  modelId: \"\",\n  temperature: 0.5,\n  topP: 0.9\n}",
+    "value" : "={\n  modelId: \"\",\n  temperature: 0.5\n}",
     "feel" : "optional",
     "group" : "input",
     "binding" : {

--- a/connectors/idp-extraction/element-templates/idp-unstructured-extraction-outbound-connector.json
+++ b/connectors/idp-extraction/element-templates/idp-unstructured-extraction-outbound-connector.json
@@ -63,7 +63,7 @@
     "label" : "Ai converse parameters",
     "description" : "Specify the parameters for the ai conversation",
     "optional" : false,
-    "value" : "={\n  modelId: \"\",\n  temperature: 0.5,\n  topP: 0.9\n}",
+    "value" : "={\n  modelId: \"\",\n  temperature: 0.5\n}",
     "feel" : "optional",
     "group" : "input",
     "binding" : {

--- a/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/request/classification/ClassificationRequestData.java
+++ b/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/request/classification/ClassificationRequestData.java
@@ -23,7 +23,7 @@ public class ClassificationRequestData extends DocumentRequestData {
       group = "input",
       type = TemplateProperty.PropertyType.Text,
       description = "Specify the parameters for AWS Bedrock",
-      defaultValue = "={\n  modelId: \"\",\n  temperature: 0.5,\n  topP: 0.9\n}",
+      defaultValue = "={\n  modelId: \"\",\n  temperature: 0.5\n}",
       binding = @TemplateProperty.PropertyBinding(name = "converseData"),
       feel = FeelMode.optional)
   ConverseData converseData;

--- a/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/request/unstructured/UnstructuredExtractionRequestData.java
+++ b/connectors/idp-extraction/src/main/java/io/camunda/connector/idp/extraction/request/unstructured/UnstructuredExtractionRequestData.java
@@ -31,7 +31,7 @@ public class UnstructuredExtractionRequestData extends DocumentRequestData {
       group = "input",
       type = TemplateProperty.PropertyType.Text,
       description = "Specify the parameters for the ai conversation",
-      defaultValue = "={\n  modelId: \"\",\n  temperature: 0.5,\n  topP: 0.9\n}",
+      defaultValue = "={\n  modelId: \"\",\n  temperature: 0.5\n}",
       binding = @TemplateProperty.PropertyBinding(name = "converseData"),
       feel = FeelMode.optional)
   ConverseData converseData;


### PR DESCRIPTION
## Description

Some models do not support specifying both temperature and top_p simultaneously, resulting in an error. Remove topP from the default converseData value so users only send temperature by default.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes https://github.com/camunda/connectors/issues/7326

## Checklist

- [x] Backport labels are added if these code changes should be backported. No backport label is added to the latest
  release, as this branch will be rebased onto main before the next release. Example backport labels:
    - `backport stable/8.8`: for changes that should be included in the next 8.8.x release.
    - **or** `backport release-8.8.7`: for changes that should be included in the specific release 8.8.7, and this
      *release has already been created*. The release branch will be merged back into stable/8.8 later, so the change
      will be included in future 8.8.x releases as well.
- [x] Tests/Integration tests for the changes have been added if applicable.
- [x] If the change requires a documentation update, it has been added to the appropriate section in the documentation.


