### PR TITLE
feat(google-drive): support key-value template replacements

### DIFF
--- a/connectors/google/google-drive/element-templates/google-drive-outbound-connector.json
+++ b/connectors/google/google-drive/element-templates/google-drive-outbound-connector.json
@@ -5,7 +5,7 @@
   "description" : "Manage Google Drive files and folders",
   "keywords" : [ "create file", "create file from template", "create folder", "upload file", "download file", "file storage", "document management" ],
   "documentationRef" : "https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/googledrive/",
-  "version" : 5,
+  "version" : 6,
   "category" : {
     "id" : "connectors",
     "name" : "Connectors"
@@ -246,18 +246,59 @@
     },
     "type" : "String"
   }, {
-    "id" : "resource.template.variables",
-    "label" : "Template variables",
+    "id" : "resource.template.variables.mode",
+    "label" : "Template variable mode",
     "optional" : false,
-    "feel" : "required",
+    "value" : "simple",
     "group" : "operationDetails",
     "binding" : {
-      "name" : "resource.template.variables",
+      "name" : "resource.template.variables.mode",
       "type" : "zeebe:input"
     },
     "condition" : {
       "property" : "resource.type",
       "equals" : "file",
+      "type" : "simple"
+    },
+    "type" : "Dropdown",
+    "choices" : [ {
+      "name" : "Key-value template replacements",
+      "value" : "simple"
+    }, {
+      "name" : "Advanced Google Docs API requests",
+      "value" : "advanced"
+    } ]
+  }, {
+    "id" : "resource.template.variables.replacements",
+    "label" : "Template replacements",
+    "description" : "Provide key-value pairs. For example, {\"customerName\": \"Acme Corp\"} replaces {{customerName}}.",
+    "optional" : false,
+    "feel" : "required",
+    "group" : "operationDetails",
+    "binding" : {
+      "name" : "resource.template.variables.replacements",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "resource.template.variables.mode",
+      "equals" : "simple",
+      "type" : "simple"
+    },
+    "type" : "String"
+  }, {
+    "id" : "resource.template.variables.requests",
+    "label" : "Template variables",
+    "description" : "Advanced mode: provide a FEEL JSON object compatible with the Google Docs Requests API, for example {\"requests\": [...]}.",
+    "optional" : false,
+    "feel" : "required",
+    "group" : "operationDetails",
+    "binding" : {
+      "name" : "resource.template.variables.requests",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "resource.template.variables.mode",
+      "equals" : "advanced",
       "type" : "simple"
     },
     "type" : "String"
@@ -304,7 +345,7 @@
     "id" : "version",
     "label" : "Version",
     "description" : "Version of the element template",
-    "value" : "5",
+    "value" : "6",
     "group" : "connector",
     "binding" : {
       "key" : "elementTemplateVersion",
@@ -379,6 +420,6 @@
     "type" : "String"
   } ],
   "icon" : {
-    "contents" : "data:image/svg+xml;base64,PHN2ZyB2aWV3Qm94PSIwIDAgODcuMyA3OCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KCTxwYXRoIGQ9Im02LjYgNjYuODUgMy44NSA2LjY1Yy44IDEuNCAxLjk1IDIuNSAzLjMgMy4zbDEzLjc1LTIzLjhoLTI3LjVjMCAxLjU1LjQgMy4xIDEuMiA0LjV6IiBmaWxsPSIjMDA2NmRhIi8+Cgk8cGF0aCBkPSJtNDMuNjUgMjUtMTMuNzUtMjMuOGMtMS4zNS44LTIuNSAxLjktMy4zIDMuM2wtMjUuNCA0NGE5LjA2IDkuMDYgMCAwIDAgLTEuMiA0LjVoMjcuNXoiIGZpbGw9IiMwMGFjNDciLz4KCTxwYXRoIGQ9Im03My41NSA3Ni44YzEuMzUtLjggMi41LTEuOSAzLjMtMy4zbDEuNi0yLjc1IDcuNjUtMTMuMjVjLjgtMS40IDEuMi0yLjk1IDEuMi00LjVoLTI3LjUwMmw1Ljg1MiAxMS41eiIgZmlsbD0iI2VhNDMzNSIvPgoJPHBhdGggZD0ibTQzLjY1IDI1IDEzLjc1LTIzLjhjLTEuMzUtLjgtMi45LTEuMi00LjUtMS4yaC0xOC41Yy0xLjYgMC0zLjE1LjQ1LTQuNSAxLjJ6IiBmaWxsPSIjMDA4MzJkIi8+Cgk8cGF0aCBkPSJtNTkuOCA1M2gtMzIuM2wtMTMuNzUgMjMuOGMxLjM1LjggMi45IDEuMiA0LjUgMS4yaDUwLjhjMS42IDAgMy4xNS0uNDUgNC41LTEuMnoiIGZpbGw9IiMyNjg0ZmMiLz4KCTxwYXRoIGQ9Im03My40IDI2LjUtMTIuNy0yMmMtLjgtMS40LTEuOTUtMi41LTMuMy0zLjNsLTEzLjc1IDIzLjggMTYuMTUgMjhoMjcuNDVjMC0xLjU1LS40LTMuMS0xLjItNC41eiIgZmlsbD0iI2ZmYmEwMCIvPgo8L3N2Zz4="
+    "contents" : "data:image/svg+xml;base64,PHN2ZyB2aWV3Qm94PSIwIDAgODcuMyA3OCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4NCgk8cGF0aCBkPSJtNi42IDY2Ljg1IDMuODUgNi42NWMuOCAxLjQgMS45NSAyLjUgMy4zIDMuM2wxMy43NS0yMy44aC0yNy41YzAgMS41NS40IDMuMSAxLjIgNC41eiIgZmlsbD0iIzAwNjZkYSIvPg0KCTxwYXRoIGQ9Im00My42NSAyNS0xMy43NS0yMy44Yy0xLjM1LjgtMi41IDEuOS0zLjMgMy4zbC0yNS40IDQ0YTkuMDYgOS4wNiAwIDAgMCAtMS4yIDQuNWgyNy41eiIgZmlsbD0iIzAwYWM0NyIvPg0KCTxwYXRoIGQ9Im03My41NSA3Ni44YzEuMzUtLjggMi41LTEuOSAzLjMtMy4zbDEuNi0yLjc1IDcuNjUtMTMuMjVjLjgtMS40IDEuMi0yLjk1IDEuMi00LjVoLTI3LjUwMmw1Ljg1MiAxMS41eiIgZmlsbD0iI2VhNDMzNSIvPg0KCTxwYXRoIGQ9Im00My42NSAyNSAxMy43NS0yMy44Yy0xLjM1LS44LTIuOS0xLjItNC41LTEuMmgtMTguNWMtMS42IDAtMy4xNS40NS00LjUgMS4yeiIgZmlsbD0iIzAwODMyZCIvPg0KCTxwYXRoIGQ9Im01OS44IDUzaC0zMi4zbC0xMy43NSAyMy44YzEuMzUuOCAyLjkgMS4yIDQuNSAxLjJoNTAuOGMxLjYgMCAzLjE1LS40NSA0LjUtMS4yeiIgZmlsbD0iIzI2ODRmYyIvPg0KCTxwYXRoIGQ9Im03My40IDI2LjUtMTIuNy0yMmMtLjgtMS40LTEuOTUtMi41LTMuMy0zLjNsLTEzLjc1IDIzLjggMTYuMTUgMjhoMjcuNDVjMC0xLjU1LS40LTMuMS0xLjItNC41eiIgZmlsbD0iI2ZmYmEwMCIvPg0KPC9zdmc+"
   }
 }

--- a/connectors/google/google-drive/element-templates/versioned/google-drive-outbound-connector-5.json
+++ b/connectors/google/google-drive/element-templates/versioned/google-drive-outbound-connector-5.json
@@ -1,11 +1,11 @@
 {
   "$schema" : "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
-  "name" : "Hybrid Google Drive Outbound Connector",
-  "id" : "io.camunda.connectors.GoogleDrive.v1-hybrid",
+  "name" : "Google Drive Outbound Connector",
+  "id" : "io.camunda.connectors.GoogleDrive.v1",
   "description" : "Manage Google Drive files and folders",
   "keywords" : [ "create file", "create file from template", "create folder", "upload file", "download file", "file storage", "document management" ],
   "documentationRef" : "https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/googledrive/",
-  "version" : 6,
+  "version" : 5,
   "category" : {
     "id" : "connectors",
     "name" : "Connectors"
@@ -18,9 +18,6 @@
     "camunda" : "^8.3"
   },
   "groups" : [ {
-    "id" : "taskDefinitionType",
-    "label" : "Task definition type"
-  }, {
     "id" : "authentication",
     "label" : "Authentication"
   }, {
@@ -43,14 +40,12 @@
     "label" : "Retries"
   } ],
   "properties" : [ {
-    "id" : "taskDefinitionType",
     "value" : "io.camunda:google-drive:1",
-    "group" : "taskDefinitionType",
     "binding" : {
       "property" : "type",
       "type" : "zeebe:taskDefinition"
     },
-    "type" : "String"
+    "type" : "Hidden"
   }, {
     "id" : "authentication.authType",
     "label" : "Type",
@@ -267,7 +262,7 @@
     },
     "type" : "Dropdown",
     "choices" : [ {
-      "name" : "Key-value template replacements",
+      "name" : "Simple key-value replacements",
       "value" : "simple"
     }, {
       "name" : "Advanced Google Docs API requests",
@@ -350,7 +345,7 @@
     "id" : "version",
     "label" : "Version",
     "description" : "Version of the element template",
-    "value" : "6",
+    "value" : "5",
     "group" : "connector",
     "binding" : {
       "key" : "elementTemplateVersion",

--- a/connectors/google/google-drive/src/main/java/io/camunda/connector/gdrive/GoogleDriveFunction.java
+++ b/connectors/google/google-drive/src/main/java/io/camunda/connector/gdrive/GoogleDriveFunction.java
@@ -32,7 +32,7 @@ import org.slf4j.LoggerFactory;
       "document management"
     },
     inputDataClass = GoogleDriveRequest.class,
-    version = 5,
+    version = 6,
     propertyGroups = {
       @ElementTemplate.PropertyGroup(id = "authentication", label = "Authentication"),
       @ElementTemplate.PropertyGroup(id = "operation", label = "Select operation"),

--- a/connectors/google/google-drive/src/main/java/io/camunda/connector/gdrive/GoogleDriveService.java
+++ b/connectors/google/google-drive/src/main/java/io/camunda/connector/gdrive/GoogleDriveService.java
@@ -6,11 +6,14 @@
  */
 package io.camunda.connector.gdrive;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.google.api.client.http.ByteArrayContent;
 import com.google.api.client.json.JsonParser;
 import com.google.api.client.json.gson.GsonFactory;
 import com.google.api.services.docs.v1.model.BatchUpdateDocumentResponse;
+import com.google.api.services.docs.v1.model.ReplaceAllTextRequest;
 import com.google.api.services.docs.v1.model.Request;
+import com.google.api.services.docs.v1.model.SubstringMatchCriteria;
 import com.google.api.services.drive.Drive;
 import com.google.api.services.drive.model.File;
 import com.google.common.reflect.TypeToken;
@@ -21,12 +24,15 @@ import io.camunda.connector.gdrive.model.MimeTypeUrl;
 import io.camunda.connector.gdrive.model.request.Resource;
 import io.camunda.connector.gdrive.model.request.Template;
 import io.camunda.connector.gdrive.model.request.Type;
+import io.camunda.connector.gdrive.model.request.VariableMode;
 import io.camunda.connector.gdrive.model.request.Variables;
 import io.camunda.google.supplier.GsonComponentSupplier;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
@@ -82,15 +88,68 @@ public class GoogleDriveService {
       Optional.of(resource)
           .map(Resource::template)
           .map(Template::variables)
-          .map(Variables::requests)
-          .map(Object::toString)
-          .map(this::mapJsonToRequests)
+          .map(this::mapVariablesToRequests)
+          .filter(requests -> !requests.isEmpty())
           .ifPresent(requests -> updateWithRequests(client, requests, result));
     } else {
       result = client.createWithMetadata(metaData);
     }
     return new GoogleDriveResult(
         result.getId(), MimeTypeUrl.getResourceUrl(result.getMimeType(), result.getId()));
+  }
+
+  private List<Request> mapVariablesToRequests(final Variables variables) {
+    if (variables == null) {
+      return List.of();
+    }
+
+    if (variables.requests() != null || variables.mode() == VariableMode.ADVANCED) {
+      return mapAdvancedVariablesToRequests(variables.requests());
+    }
+
+    return mapSimpleVariablesToRequests(variables.replacements());
+  }
+
+  private List<Request> mapAdvancedVariablesToRequests(final JsonNode requests) {
+    return Optional.ofNullable(unwrapRequestsNode(requests))
+        .map(Object::toString)
+        .map(this::mapJsonToRequests)
+        .orElse(List.of());
+  }
+
+  private JsonNode unwrapRequestsNode(final JsonNode requests) {
+    if (requests != null && requests.isObject() && requests.has("requests")) {
+      return requests.get("requests");
+    }
+
+    return requests;
+  }
+
+  private List<Request> mapSimpleVariablesToRequests(final JsonNode replacements) {
+    if (replacements == null || !replacements.isObject()) {
+      return List.of();
+    }
+
+    List<Request> requests = new ArrayList<>();
+    Iterator<Map.Entry<String, JsonNode>> fields = replacements.fields();
+
+    while (fields.hasNext()) {
+      Map.Entry<String, JsonNode> entry = fields.next();
+
+      String placeholder = "{{" + entry.getKey() + "}}";
+      String replacementValue =
+          entry.getValue() == null || entry.getValue().isNull() ? "" : entry.getValue().asText();
+
+      requests.add(
+          new Request()
+              .setReplaceAllText(
+                  new ReplaceAllTextRequest()
+                      .setContainsText(
+                          new SubstringMatchCriteria().setText(placeholder).setMatchCase(true))
+                      .setReplaceText(replacementValue)));
+    }
+
+    return requests;
   }
 
   private List<Request> mapJsonToRequests(String requestsAsJson) {

--- a/connectors/google/google-drive/src/main/java/io/camunda/connector/gdrive/model/request/VariableMode.java
+++ b/connectors/google/google-drive/src/main/java/io/camunda/connector/gdrive/model/request/VariableMode.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.gdrive.model.request;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public enum VariableMode {
+  @JsonProperty("simple")
+  SIMPLE,
+
+  @JsonProperty("advanced")
+  ADVANCED
+}

--- a/connectors/google/google-drive/src/main/java/io/camunda/connector/gdrive/model/request/Variables.java
+++ b/connectors/google/google-drive/src/main/java/io/camunda/connector/gdrive/model/request/Variables.java
@@ -6,18 +6,56 @@
  */
 package io.camunda.connector.gdrive.model.request;
 
+import static io.camunda.connector.generator.java.annotation.TemplateProperty.PropertyType.Dropdown;
+
 import com.fasterxml.jackson.databind.JsonNode;
 import io.camunda.connector.generator.java.annotation.FeelMode;
 import io.camunda.connector.generator.java.annotation.TemplateProperty;
+import io.camunda.connector.generator.java.annotation.TemplateProperty.DropdownPropertyChoice;
 import io.camunda.connector.generator.java.annotation.TemplateProperty.PropertyBinding;
 import io.camunda.connector.generator.java.annotation.TemplateProperty.PropertyCondition;
 
 public record Variables(
     @TemplateProperty(
-            id = "variables",
-            label = "Template variables",
+            id = "variables.mode",
+            label = "Template variable mode",
+            group = "operationDetails",
+            type = Dropdown,
+            defaultValue = "simple",
+            binding = @PropertyBinding(name = "variables.mode"),
+            choices = {
+              @DropdownPropertyChoice(label = "Key-value template replacements", value = "simple"),
+              @DropdownPropertyChoice(
+                  label = "Advanced Google Docs API requests",
+                  value = "advanced")
+            },
+            condition = @PropertyCondition(property = "resource.type", equals = "file"))
+        VariableMode mode,
+    @TemplateProperty(
+            id = "variables.replacements",
+            label = "Template replacements",
+            description =
+                "Provide key-value pairs. For example, "
+                    + "{\"customerName\": \"Acme Corp\"} replaces {{customerName}}.",
             group = "operationDetails",
             feel = FeelMode.required,
-            binding = @PropertyBinding(name = "variables"),
-            condition = @PropertyCondition(property = "resource.type", equals = "file"))
+            binding = @PropertyBinding(name = "variables.replacements"),
+            condition =
+                @PropertyCondition(
+                    property = "resource.template.variables.mode",
+                    equals = "simple"))
+        JsonNode replacements,
+    @TemplateProperty(
+            id = "variables.requests",
+            label = "Template variables",
+            description =
+                "Advanced mode: provide a FEEL JSON object compatible with the Google Docs Requests API, "
+                    + "for example {\"requests\": [...]}.",
+            group = "operationDetails",
+            feel = FeelMode.required,
+            binding = @PropertyBinding(name = "variables.requests"),
+            condition =
+                @PropertyCondition(
+                    property = "resource.template.variables.mode",
+                    equals = "advanced"))
         JsonNode requests) {}

--- a/connectors/google/google-drive/src/test/java/io/camunda/connector/gdrive/GoogleDriveServiceTest.java
+++ b/connectors/google/google-drive/src/test/java/io/camunda/connector/gdrive/GoogleDriveServiceTest.java
@@ -10,11 +10,15 @@ import static io.camunda.connector.gdrive.GoogleDriveService.IO_EXCEPTION_MESSAG
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.api.client.http.ByteArrayContent;
 import com.google.api.services.docs.v1.model.BatchUpdateDocumentResponse;
+import com.google.api.services.docs.v1.model.ReplaceAllTextRequest;
 import com.google.api.services.docs.v1.model.Request;
 import com.google.api.services.drive.Drive;
 import com.google.api.services.drive.model.File;
@@ -43,6 +47,8 @@ class GoogleDriveServiceTest extends BaseTest {
 
   private static final String SUCCESS_FILE_CASES_RESOURCE_PATH =
       "src/test/resources/requests/file-success-test-cases.json";
+
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
   private DocumentMapper documentMapper;
   private GoogleDriveService service;
@@ -146,10 +152,234 @@ class GoogleDriveServiceTest extends BaseTest {
     // Then
     verify(googleDriveClient).updateDocument(eq(FILE_ID), captor.capture());
 
-    assertThat(captor.getValue().size()).isEqualTo(1);
+    assertThat(captor.getValue()).isNotNull();
+    assertThat(captor.getValue().isEmpty()).isFalse();
     assertThat(captor.getValue().get(0).getReplaceAllText()).isNotNull();
 
     assertThat(execute.getGoogleDriveResourceId()).isEqualTo(FILE_ID);
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  void execute_shouldCreateFileAndUpdateDocumentWithSimpleTemplateReplacements() {
+    // Given
+    String templateId = "templateId";
+
+    ObjectNode replacements = OBJECT_MAPPER.createObjectNode();
+    replacements.put("customerName", "Acme Corp");
+    replacements.put("amount", "$1,200");
+    replacements.putNull("optionalNote");
+
+    Resource resource =
+        new Resource(
+            Type.FILE,
+            FILE_NAME,
+            PARENT_ID,
+            null,
+            new Template(templateId, new Variables(VariableMode.SIMPLE, replacements, null)),
+            null,
+            null);
+
+    file.setMimeType(MimeTypeUrl.DOCUMENT.getMimeType());
+
+    BatchUpdateDocumentResponse response = new BatchUpdateDocumentResponse();
+    when(googleDriveClient.createWithTemplate(any(), eq(templateId))).thenReturn(file);
+    when(googleDriveClient.updateDocument(any(), any())).thenReturn(response);
+
+    ArgumentCaptor<List<Request>> captor = ArgumentCaptor.forClass(List.class);
+
+    // When
+    var execute = (GoogleDriveResult) service.execute(googleDriveClient, resource);
+
+    // Then
+    verify(googleDriveClient).updateDocument(eq(FILE_ID), captor.capture());
+
+    List<Request> requests = captor.getValue();
+
+    assertThat(requests.size()).isEqualTo(3);
+
+    ReplaceAllTextRequest customerNameRequest = requests.get(0).getReplaceAllText();
+    assertThat(customerNameRequest.getContainsText().getText()).isEqualTo("{{customerName}}");
+    assertThat(customerNameRequest.getContainsText().getMatchCase()).isTrue();
+    assertThat(customerNameRequest.getReplaceText()).isEqualTo("Acme Corp");
+
+    ReplaceAllTextRequest amountRequest = requests.get(1).getReplaceAllText();
+    assertThat(amountRequest.getContainsText().getText()).isEqualTo("{{amount}}");
+    assertThat(amountRequest.getContainsText().getMatchCase()).isTrue();
+    assertThat(amountRequest.getReplaceText()).isEqualTo("$1,200");
+
+    ReplaceAllTextRequest optionalNoteRequest = requests.get(2).getReplaceAllText();
+    assertThat(optionalNoteRequest.getContainsText().getText()).isEqualTo("{{optionalNote}}");
+    assertThat(optionalNoteRequest.getContainsText().getMatchCase()).isTrue();
+    assertThat(optionalNoteRequest.getReplaceText()).isEqualTo("");
+
+    assertThat(execute.getGoogleDriveResourceId()).isEqualTo(FILE_ID);
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  void execute_shouldKeepSupportingAdvancedTemplateVariableRequests() throws Exception {
+    // Given
+    String templateId = "templateId";
+
+    var advancedRequests =
+        OBJECT_MAPPER.readTree(
+            """
+            [
+              {
+                "replaceAllText": {
+                  "containsText": {
+                    "text": "{{customerName}}",
+                    "matchCase": true
+                  },
+                  "replaceText": "Acme Corp"
+                }
+              }
+            ]
+            """);
+
+    Resource resource =
+        new Resource(
+            Type.FILE,
+            FILE_NAME,
+            PARENT_ID,
+            null,
+            new Template(templateId, new Variables(VariableMode.ADVANCED, null, advancedRequests)),
+            null,
+            null);
+
+    file.setMimeType(MimeTypeUrl.DOCUMENT.getMimeType());
+
+    BatchUpdateDocumentResponse response = new BatchUpdateDocumentResponse();
+    when(googleDriveClient.createWithTemplate(any(), eq(templateId))).thenReturn(file);
+    when(googleDriveClient.updateDocument(any(), any())).thenReturn(response);
+
+    ArgumentCaptor<List<Request>> captor = ArgumentCaptor.forClass(List.class);
+
+    // When
+    service.execute(googleDriveClient, resource);
+
+    // Then
+    verify(googleDriveClient).updateDocument(eq(FILE_ID), captor.capture());
+
+    List<Request> requests = captor.getValue();
+
+    assertThat(requests.size()).isEqualTo(1);
+    assertThat(requests.get(0).getReplaceAllText().getContainsText().getText())
+        .isEqualTo("{{customerName}}");
+    assertThat(requests.get(0).getReplaceAllText().getContainsText().getMatchCase()).isTrue();
+    assertThat(requests.get(0).getReplaceAllText().getReplaceText()).isEqualTo("Acme Corp");
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  void execute_shouldKeepSupportingLegacyTemplateVariableRequestsWithoutMode() throws Exception {
+    // Given
+    String templateId = "templateId";
+
+    var legacyRequests =
+        OBJECT_MAPPER.readTree(
+            """
+            [
+              {
+                "replaceAllText": {
+                  "containsText": {
+                    "text": "{{customerName}}",
+                    "matchCase": true
+                  },
+                  "replaceText": "Acme Corp"
+                }
+              }
+            ]
+            """);
+
+    Resource resource =
+        new Resource(
+            Type.FILE,
+            FILE_NAME,
+            PARENT_ID,
+            null,
+            new Template(templateId, new Variables(null, null, legacyRequests)),
+            null,
+            null);
+
+    file.setMimeType(MimeTypeUrl.DOCUMENT.getMimeType());
+
+    BatchUpdateDocumentResponse response = new BatchUpdateDocumentResponse();
+    when(googleDriveClient.createWithTemplate(any(), eq(templateId))).thenReturn(file);
+    when(googleDriveClient.updateDocument(any(), any())).thenReturn(response);
+
+    ArgumentCaptor<List<Request>> captor = ArgumentCaptor.forClass(List.class);
+
+    // When
+    service.execute(googleDriveClient, resource);
+
+    // Then
+    verify(googleDriveClient).updateDocument(eq(FILE_ID), captor.capture());
+
+    List<Request> requests = captor.getValue();
+
+    assertThat(requests.size()).isEqualTo(1);
+    assertThat(requests.get(0).getReplaceAllText().getContainsText().getText())
+        .isEqualTo("{{customerName}}");
+    assertThat(requests.get(0).getReplaceAllText().getReplaceText()).isEqualTo("Acme Corp");
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  void execute_shouldSupportWrappedAdvancedTemplateVariableRequests() throws Exception {
+    // Given
+    String templateId = "templateId";
+
+    var wrappedRequests =
+        OBJECT_MAPPER.readTree(
+            """
+          {
+            "requests": [
+              {
+                "replaceAllText": {
+                  "containsText": {
+                    "text": "{{customerName}}",
+                    "matchCase": true
+                  },
+                  "replaceText": "Acme Corp"
+                }
+              }
+            ]
+          }
+          """);
+
+    Resource resource =
+        new Resource(
+            Type.FILE,
+            FILE_NAME,
+            PARENT_ID,
+            null,
+            new Template(templateId, new Variables(VariableMode.ADVANCED, null, wrappedRequests)),
+            null,
+            null);
+
+    file.setMimeType(MimeTypeUrl.DOCUMENT.getMimeType());
+
+    BatchUpdateDocumentResponse response = new BatchUpdateDocumentResponse();
+    when(googleDriveClient.createWithTemplate(any(), eq(templateId))).thenReturn(file);
+    when(googleDriveClient.updateDocument(any(), any())).thenReturn(response);
+
+    ArgumentCaptor<List<Request>> captor = ArgumentCaptor.forClass(List.class);
+
+    // When
+    service.execute(googleDriveClient, resource);
+
+    // Then
+    verify(googleDriveClient).updateDocument(eq(FILE_ID), captor.capture());
+
+    List<Request> requests = captor.getValue();
+
+    assertThat(requests.size()).isEqualTo(1);
+    assertThat(requests.get(0).getReplaceAllText().getContainsText().getText())
+        .isEqualTo("{{customerName}}");
+    assertThat(requests.get(0).getReplaceAllText().getContainsText().getMatchCase()).isTrue();
+    assertThat(requests.get(0).getReplaceAllText().getReplaceText()).isEqualTo("Acme Corp");
   }
 
   @DisplayName("Should do not update document if type is not document")

--- a/connectors/google/google-drive/src/test/resources/requests/file-success-test-cases.json
+++ b/connectors/google/google-drive/src/test/resources/requests/file-success-test-cases.json
@@ -5,22 +5,22 @@
       "bearerToken": "{{secrets.MyToken}}"
     },
     "resource": {
-      "type":"file",
-      "parent":"optional my idFolderParent",
-      "name":"MyNewFile",
-      "additionalGoogleDriveProperties":{
-        "description":"xxx"
+      "type": "file",
+      "parent": "optional my idFolderParent",
+      "name": "MyNewFile",
+      "additionalGoogleDriveProperties": {
+        "description": "xxx"
       },
-      "template":{
-        "id":"121J6hMy-4ffHhXl5egwIhCsznS3mXWm",
-        "variables":{
-          "requests":[
+      "template": {
+        "id": "121J6hMy-4ffHhXl5egwIhCsznS3mXWm",
+        "variables": {
+          "requests": [
             {
-              "replaceAllText":{
-                "replaceText":"2022-08-03",
-                "containsText":{
-                  "matchCase":"true",
-                  "text":"{{recordDate}}"
+              "replaceAllText": {
+                "replaceText": "2022-08-03",
+                "containsText": {
+                  "matchCase": "true",
+                  "text": "{{recordDate}}"
                 }
               }
             }
@@ -37,22 +37,22 @@
       "oauthRefreshToken": "{{secrets.MyOauthRefresh}}"
     },
     "resource": {
-      "type":"file",
-      "parent":"optional my idFolderParent",
-      "name":"MyNewFile",
-      "additionalGoogleDriveProperties":{
-        "description":"xxx"
+      "type": "file",
+      "parent": "optional my idFolderParent",
+      "name": "MyNewFile",
+      "additionalGoogleDriveProperties": {
+        "description": "xxx"
       },
-      "template":{
-        "id":"121J6hMy-4ffHhXl5egwIhCsznS3mXWm",
-        "variables":{
-          "requests":[
+      "template": {
+        "id": "121J6hMy-4ffHhXl5egwIhCsznS3mXWm",
+        "variables": {
+          "requests": [
             {
-              "replaceAllText":{
-                "replaceText":"2022-08-03",
-                "containsText":{
-                  "matchCase":"true",
-                  "text":"{{recordDate}}"
+              "replaceAllText": {
+                "replaceText": "2022-08-03",
+                "containsText": {
+                  "matchCase": "true",
+                  "text": "{{recordDate}}"
                 }
               }
             }
@@ -69,23 +69,44 @@
       "oauthRefreshToken": "{{secrets.MyOauthRefresh}}"
     },
     "resource": {
-      "type":"file",
-      "parent":"optional my idFolderParent",
-      "name":"MyNewFile",
-      "template":{
-        "id":"121J6hMy-4ffHhXl5egwIhCsznS3mXWm",
-        "variables":{
-          "requests":[
+      "type": "file",
+      "parent": "optional my idFolderParent",
+      "name": "MyNewFile",
+      "template": {
+        "id": "121J6hMy-4ffHhXl5egwIhCsznS3mXWm",
+        "variables": {
+          "requests": [
             {
-              "replaceAllText":{
-                "replaceText":"2022-08-03",
-                "containsText":{
-                  "matchCase":"true",
-                  "text":"{{recordDate}}"
+              "replaceAllText": {
+                "replaceText": "2022-08-03",
+                "containsText": {
+                  "matchCase": "true",
+                  "text": "{{recordDate}}"
                 }
               }
             }
           ]
+        }
+      }
+    }
+  },
+  {
+    "authentication": {
+      "authType": "bearer",
+      "bearerToken": "{{secrets.MyToken}}"
+    },
+    "resource": {
+      "type": "file",
+      "parent": "optional my idFolderParent",
+      "name": "MyNewFile",
+      "template": {
+        "id": "121J6hMy-4ffHhXl5egwIhCsznS3mXWm",
+        "variables": {
+          "mode": "simple",
+          "replacements": {
+            "recordDate": "2022-08-03",
+            "customerName": "Acme Corp"
+          }
         }
       }
     }

--- a/connectors/google/google-drive/src/test/resources/requests/request-success-test-cases.json
+++ b/connectors/google/google-drive/src/test/resources/requests/request-success-test-cases.json
@@ -6,22 +6,22 @@
       "bearerToken": "MyRealToken"
     },
     "resource": {
-      "type":"file",
-      "parent":"1wF4ME7XcM_6ZIaNCMADMXawz",
-      "name":"demoFile",
-      "additionalGoogleDriveProperties":{
-        "description":"xxx"
+      "type": "file",
+      "parent": "1wF4ME7XcM_6ZIaNCMADMXawz",
+      "name": "demoFile",
+      "additionalGoogleDriveProperties": {
+        "description": "xxx"
       },
-      "template":{
-        "id":"121J6hMy-4ffHhXl5egwIhCsznS3mXWm",
-        "variables":{
-          "requests":[
+      "template": {
+        "id": "121J6hMy-4ffHhXl5egwIhCsznS3mXWm",
+        "variables": {
+          "requests": [
             {
-              "replaceAllText":{
-                "replaceText":"2022-08-03",
-                "containsText":{
-                  "matchCase":"true",
-                  "text":"{{recordDate}}"
+              "replaceAllText": {
+                "replaceText": "2022-08-03",
+                "containsText": {
+                  "matchCase": "true",
+                  "text": "{{recordDate}}"
                 }
               }
             }
@@ -39,22 +39,22 @@
       "oauthRefreshToken": "MyRealRefreshTokenValue"
     },
     "resource": {
-      "type":"file",
-      "parent":"1wF4ME7XcM_6ZIaNCMADMXawz",
-      "name":"demoFile",
-      "additionalGoogleDriveProperties":{
-        "description":"xxx"
+      "type": "file",
+      "parent": "1wF4ME7XcM_6ZIaNCMADMXawz",
+      "name": "demoFile",
+      "additionalGoogleDriveProperties": {
+        "description": "xxx"
       },
-      "template":{
-        "id":"121J6hMy-4ffHhXl5egwIhCsznS3mXWm",
-        "variables":{
-          "requests":[
+      "template": {
+        "id": "121J6hMy-4ffHhXl5egwIhCsznS3mXWm",
+        "variables": {
+          "requests": [
             {
-              "replaceAllText":{
-                "replaceText":"2022-08-03",
-                "containsText":{
-                  "matchCase":"true",
-                  "text":"{{recordDate}}"
+              "replaceAllText": {
+                "replaceText": "2022-08-03",
+                "containsText": {
+                  "matchCase": "true",
+                  "text": "{{recordDate}}"
                 }
               }
             }
@@ -70,22 +70,22 @@
       "bearerToken": "{{secrets.MyToken}}"
     },
     "resource": {
-      "type":"file",
-      "parent":"1wF4ME7XcM_6ZIaNCMADMXawz",
-      "name":"demoFile",
-      "additionalGoogleDriveProperties":{
-        "description":"xxx"
+      "type": "file",
+      "parent": "1wF4ME7XcM_6ZIaNCMADMXawz",
+      "name": "demoFile",
+      "additionalGoogleDriveProperties": {
+        "description": "xxx"
       },
-      "template":{
-        "id":"121J6hMy-4ffHhXl5egwIhCsznS3mXWm",
-        "variables":{
-          "requests":[
+      "template": {
+        "id": "121J6hMy-4ffHhXl5egwIhCsznS3mXWm",
+        "variables": {
+          "requests": [
             {
-              "replaceAllText":{
-                "replaceText":"2022-08-03",
-                "containsText":{
-                  "matchCase":"true",
-                  "text":"{{recordDate}}"
+              "replaceAllText": {
+                "replaceText": "2022-08-03",
+                "containsText": {
+                  "matchCase": "true",
+                  "text": "{{recordDate}}"
                 }
               }
             }
@@ -103,26 +103,48 @@
       "oauthRefreshToken": "{{secrets.MyOauthRefresh}}"
     },
     "resource": {
-      "type":"file",
-      "parent":"1wF4ME7XcM_6ZIaNCMADMXawz",
-      "name":"demoFile",
-      "additionalGoogleDriveProperties":{
-        "description":"xxx"
+      "type": "file",
+      "parent": "1wF4ME7XcM_6ZIaNCMADMXawz",
+      "name": "demoFile",
+      "additionalGoogleDriveProperties": {
+        "description": "xxx"
       },
-      "template":{
-        "id":"121J6hMy-4ffHhXl5egwIhCsznS3mXWm",
-        "variables":{
-          "requests":[
+      "template": {
+        "id": "121J6hMy-4ffHhXl5egwIhCsznS3mXWm",
+        "variables": {
+          "requests": [
             {
-              "replaceAllText":{
-                "replaceText":"2022-08-03",
-                "containsText":{
-                  "matchCase":"true",
-                  "text":"{{recordDate}}"
+              "replaceAllText": {
+                "replaceText": "2022-08-03",
+                "containsText": {
+                  "matchCase": "true",
+                  "text": "{{recordDate}}"
                 }
               }
             }
           ]
+        }
+      }
+    }
+  },
+  {
+    "testDescription": "Simple template replacements",
+    "authentication": {
+      "authType": "bearer",
+      "bearerToken": "{{secrets.MyToken}}"
+    },
+    "resource": {
+      "type": "file",
+      "parent": "1wF4ME7XcM_6ZIaNCMADMXawz",
+      "name": "demoFile",
+      "template": {
+        "id": "121J6hMy-4ffHhXl5egwIhCsznS3mXWm",
+        "variables": {
+          "mode": "simple",
+          "replacements": {
+            "recordDate": "2022-08-03",
+            "customerName": "Acme Corp"
+          }
         }
       }
     }
@@ -133,12 +155,12 @@
       "bearerToken": "MyRealToken"
     },
     "resource": {
-      "type":"folder",
-      "additionalGoogleDriveProperties":{
-        "description":"description111"
+      "type": "folder",
+      "additionalGoogleDriveProperties": {
+        "description": "description111"
       },
-      "name":"demo",
-      "parent":"1wF4ME7XcM_6ZIaNCMADMXawzV"
+      "name": "demo",
+      "parent": "1wF4ME7XcM_6ZIaNCMADMXawzV"
     }
   }
 ]


### PR DESCRIPTION
## Description

Added a new key-value template replacement mode for the Google Drive connector.

Previously, users had to provide full Google Docs API request syntax even for basic placeholder replacements.

Example:

```json
{
  "requests": [
    {
      "replaceAllText": {
        "containsText": {
          "text": "{{candidateName}}",
          "matchCase": true
        },
        "replaceText": candidateName
      }
    },
    {
      "replaceAllText": {
        "containsText": {
          "text": "{{jobTitle}}",
          "matchCase": true
        },
        "replaceText": jobTitle
      }
    }
  ]
}
```

With this change, users can now use a simpler key-value format for common template replacement workflows:

```json
{
  "candidateName": "Azan Baloch",
  "jobTitle": "Junior Developer",
  "salary": "$2000"
}
```

The connector internally converts these key-value pairs into Google Docs replace requests.

This PR also keeps backward compatibility with the existing advanced Google Docs request format.

## Demo
The video below shows the new key-value template replacement mode working in a local Docker setup.

[![Watch the demo](https://img.youtube.com/vi/ynjF_MmmEvM/maxresdefault.jpg)](https://youtu.be/ynjF_MmmEvM?si=O86n9q6WSGV_mjYI)

## Related issues

closes #7335

## Checklist

- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest
  release, as this branch will be rebased onto main before the next release. Example backport labels:
    - `backport stable/8.8`: for changes that should be included in the next 8.8.x release.
    - **or** `backport release-8.8.7`: for changes that should be included in the specific release 8.8.7, and this
      *release has already been created*. The release branch will be merged back into stable/8.8 later, so the change
      will be included in future 8.8.x releases as well.
- [x] Tests/Integration tests for the changes have been added if applicable.
- [ ] If the change requires a documentation update, it has been added to the appropriate section in the documentation.