### PR TITLE
other(native-operations): Add validator for new native operations fields

### DIFF
--- a/element-template-generator/validator/README.md
+++ b/element-template-generator/validator/README.md
@@ -87,11 +87,31 @@ diverge from the conventions enforced here.
 | `task-definition-binding-form`| The legacy binding type `zeebe:taskDefinition:type` is not allowed; use the canonical form `{ "type": "zeebe:taskDefinition", "property": "type" }`. The schema accepts both spellings, but generator output and all current templates use the canonical form. |
 | `empty-group`                 | Every declared `groups[].id` must be referenced by at least one property.                                                                                                                                     |
 
+### Operations-metadata rules
+
+These rules enforce the `steps` / `presets` contract used by the Modeler search/discovery UI.
+Connectors listed in `core/OperationMetadataIgnoreList` are exempt — other rules still run on those
+connectors, only the ops-metadata rules below skip them. Remove an entry from the ignore list once
+the connector's `@Searchable` annotations (or hand-authored JSON, for ET-only connectors) are in
+place.
+
+| Rule id                          | What it checks                                                                                                                                                                                                |
+|----------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `steps-presets-present`          | Both `steps` and `presets` are present at the template root and are non-empty arrays.                                                                                                                         |
+| `step-group-shape`               | Intermediate (group) step nodes have a non-empty `steps[]`; `description` is optional; **`keywords` is disallowed** (search aliases are leaf-only); no `presetId`.                                            |
+| `step-leaf-shape`                | Leaf step nodes have a non-blank `presetId` and a non-empty `keywords` array; `description` is optional.                                                                                                      |
+| `preset-id-unique`               | No two entries in `presets[]` share an `id`.                                                                                                                                                                  |
+| `preset-id-resolves`             | Every leaf step's `presetId` resolves to some `presets[].id`.                                                                                                                                                 |
+| `preset-target-exists`           | Each key inside `presets[].properties` references a template `properties[].id`; values match declared `choices` (union across duplicate-id declarations).                                                     |
+| `preset-operation-group-consistency`    | Every property key referenced from `presets[].properties` is declared with `group == "operation"`. The `operation` group is the first entry in `groups[]`.                                                    |
+| `preset-conditions-satisfied`    | For each preset, every pinned property's `condition` must hold under the preset's own assignment. Catches mutually-exclusive value pairings (e.g. setting `operationGroup=A` alongside a property gated on `operationGroup=B`). |
+| `preset-coverage`                | The set of `presets[]` and the set of leaf `steps[]` each enumerate **exactly** the reachable leaves of the discriminator tree (counts add across conditional branches, not multiply). Missing leaves, orphans, and duplicates are errors. |
+
 ### Multi-file rules (run once over the full set, including `versioned/`)
 
 | Rule id                          | What it checks                                                                                                                                                                                |
 |----------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `hybrid-parity`                  | For every `hybrid/<base>-hybrid.json`, the non-hybrid sibling must exist and declare the same `properties[].id` and `groups[].id`. Known-intentional differences (`taskDefinitionType`, `connectorType` on the hybrid side; `deduplication*`, `consumeUnmatchedEvents`, `messageTtl` on the non-hybrid side) are allowlisted. |
+| `hybrid-parity`                  | For every `hybrid/<base>-hybrid.json`, the non-hybrid sibling must exist and declare the same `properties[].id` and `groups[].id`. Known-intentional differences (`taskDefinitionType`, `connectorType` on the hybrid side; `deduplication*`, `consumeUnmatchedEvents`, `messageTtl` on the non-hybrid side) are allowlisted. Additionally, `steps` and `presets` must be deep-equal between hybrid and non-hybrid (skipped for connectors on the ops-metadata ignore list). |
 | `versioned-template-consistency` | For each `versioned/<base>-<N>.json`, the file's `version` field must equal `N`. Files whose filename suffix starts with `0` (e.g. `-0`, `-01`, `-02`) are pre-versioning snapshots — a missing `version` field is tolerated, but a present one must still match. |
 | `current-version-bump`           | For each non-versioned template, the `version` field must be exactly one higher than the highest-versioned snapshot under the same `element-templates/` subtree that shares the same `id`. If no snapshot shares the id (e.g. an intentional `.vN` → `.v(N+1)` rename starts a new lineage), the rule is silent. |
 | `unique-id-version`              | No two templates (current or versioned) may share both the same `id` and the same `version`. The Modeler dedupes by id+version on import, so duplicates collide silently. Catches snapshots that weren't promoted to a new version and content changes that forgot to bump the version. |

--- a/element-template-generator/validator/src/main/java/io/camunda/connector/validator/command/ValidatorCommand.java
+++ b/element-template-generator/validator/src/main/java/io/camunda/connector/validator/command/ValidatorCommand.java
@@ -32,8 +32,16 @@ import io.camunda.connector.validator.rule.DefaultValueInChoicesRule;
 import io.camunda.connector.validator.rule.EmptyGroupRule;
 import io.camunda.connector.validator.rule.GroupTargetExistsRule;
 import io.camunda.connector.validator.rule.HybridParityRule;
+import io.camunda.connector.validator.rule.PresetConditionsSatisfiedRule;
+import io.camunda.connector.validator.rule.PresetCoverageRule;
+import io.camunda.connector.validator.rule.PresetIdResolvesRule;
+import io.camunda.connector.validator.rule.PresetIdUniqueRule;
+import io.camunda.connector.validator.rule.PresetOperationGroupConsistencyRule;
 import io.camunda.connector.validator.rule.PresetTargetExistsRule;
 import io.camunda.connector.validator.rule.SchemaRule;
+import io.camunda.connector.validator.rule.StepGroupShapeRule;
+import io.camunda.connector.validator.rule.StepLeafShapeRule;
+import io.camunda.connector.validator.rule.StepsPresetsPresentRule;
 import io.camunda.connector.validator.rule.TaskDefinitionBindingFormRule;
 import io.camunda.connector.validator.rule.UniqueGroupIdRule;
 import io.camunda.connector.validator.rule.UniqueIdVersionRule;
@@ -159,7 +167,15 @@ public class ValidatorCommand implements Callable<Integer> {
             new UniqueGroupIdRule(),
             new UniquePropertyIdRule(),
             new EmptyGroupRule(),
-            new TaskDefinitionBindingFormRule());
+            new TaskDefinitionBindingFormRule(),
+            new StepsPresetsPresentRule(),
+            new StepGroupShapeRule(),
+            new StepLeafShapeRule(),
+            new PresetIdUniqueRule(),
+            new PresetIdResolvesRule(),
+            new PresetOperationGroupConsistencyRule(),
+            new PresetConditionsSatisfiedRule(),
+            new PresetCoverageRule());
     List<Finding> findings = new ArrayList<>();
     for (Map.Entry<Path, JsonNode> entry : templates.entrySet()) {
       Path path = entry.getKey();

--- a/element-template-generator/validator/src/main/java/io/camunda/connector/validator/core/ConditionEvaluator.java
+++ b/element-template-generator/validator/src/main/java/io/camunda/connector/validator/core/ConditionEvaluator.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.validator.core;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.util.Map;
+
+/**
+ * Evaluates an element-template property {@code condition} against an assignment of property
+ * values.
+ */
+public final class ConditionEvaluator {
+
+  private ConditionEvaluator() {}
+
+  public static boolean evaluate(JsonNode condition, Map<String, String> assignment) {
+    if (condition == null || condition.isMissingNode() || condition.isNull()) {
+      return true;
+    }
+    JsonNode allMatch = condition.path(ElementTemplate.ALL_MATCH);
+    if (allMatch.isArray()) {
+      for (JsonNode sub : allMatch) {
+        if (!evaluate(sub, assignment)) {
+          return false;
+        }
+      }
+      return true;
+    }
+    JsonNode propertyRef = condition.path(ElementTemplate.PROPERTY);
+    if (!propertyRef.isTextual()) {
+      return false;
+    }
+    String value = assignment.get(propertyRef.asText());
+    if (value == null) {
+      return false;
+    }
+    JsonNode equals = condition.path(ElementTemplate.EQUALS);
+    if (equals.isTextual()) {
+      return value.equals(equals.asText());
+    }
+    JsonNode oneOf = condition.path(ElementTemplate.ONE_OF);
+    if (oneOf.isArray()) {
+      for (JsonNode v : oneOf) {
+        if (v.isTextual() && value.equals(v.asText())) {
+          return true;
+        }
+      }
+      return false;
+    }
+    return false;
+  }
+}

--- a/element-template-generator/validator/src/main/java/io/camunda/connector/validator/core/ElementTemplate.java
+++ b/element-template-generator/validator/src/main/java/io/camunda/connector/validator/core/ElementTemplate.java
@@ -39,4 +39,8 @@ public final class ElementTemplate {
 
   public static final String PRESETS = "presets";
   public static final String BINDING = "binding";
+
+  public static final String STEPS = "steps";
+  public static final String PRESET_ID = "presetId";
+  public static final String KEYWORDS = "keywords";
 }

--- a/element-template-generator/validator/src/main/java/io/camunda/connector/validator/core/OperationMetadataIgnoreList.java
+++ b/element-template-generator/validator/src/main/java/io/camunda/connector/validator/core/OperationMetadataIgnoreList.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.validator.core;
+
+import java.nio.file.Path;
+import java.util.Set;
+
+/**
+ * Connectors that are exempt from the operations-metadata rules (the {@code steps} / {@code
+ * presets} contract). Other rules still run on these connectors.
+ */
+public final class OperationMetadataIgnoreList {
+
+  private OperationMetadataIgnoreList() {}
+
+  public static final Set<String> ENTRIES =
+      Set.of(
+          "agentic-ai",
+          "asana",
+          "automation-anywhere",
+          "aws",
+          "blue-prism",
+          "box",
+          "camunda-message",
+          "csv",
+          "easy-post",
+          "email",
+          "embeddings-vector-database",
+          "github",
+          "gitlab",
+          "google",
+          "google-maps-platform",
+          "http",
+          "hubspot",
+          "hugging-face",
+          "idp-extraction",
+          "jdbc",
+          "kafka",
+          "microsoft",
+          "openai",
+          "operate",
+          "power-automate",
+          "rabbitmq",
+          "rpa",
+          "salesforce",
+          "sendgrid",
+          "servicenow",
+          "slack",
+          "soap",
+          "twilio",
+          "uipath",
+          "webhook",
+          "whatsapp");
+
+  /**
+   * Returns true if the given template file lives under any connector directory on the ignore list.
+   * Matching is by directory name only (any path segment), the same convention as the existing
+   * {@code --skip-connector} flag.
+   */
+  public static boolean isIgnored(Path templateFile) {
+    if (templateFile == null) {
+      return false;
+    }
+    for (Path segment : templateFile) {
+      if (ENTRIES.contains(segment.toString())) {
+        return true;
+      }
+    }
+    return false;
+  }
+}

--- a/element-template-generator/validator/src/main/java/io/camunda/connector/validator/rule/HybridParityRule.java
+++ b/element-template-generator/validator/src/main/java/io/camunda/connector/validator/rule/HybridParityRule.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import io.camunda.connector.validator.core.ElementTemplate;
 import io.camunda.connector.validator.core.Finding;
 import io.camunda.connector.validator.core.MultiFileRule;
+import io.camunda.connector.validator.core.OperationMetadataIgnoreList;
 import io.camunda.connector.validator.core.TemplateFinder;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -76,8 +77,46 @@ public class HybridParityRule implements MultiFileRule {
       JsonNode mainTemplate = templates.get(sibling);
       compareIdSet(hybrid, hybridTemplate, mainTemplate, sibling, "properties", findings);
       compareIdSet(hybrid, hybridTemplate, mainTemplate, sibling, "groups", findings);
+      compareNativeOperationMetadata(hybrid, hybridTemplate, mainTemplate, sibling, findings);
     }
     return findings;
+  }
+
+  private void compareNativeOperationMetadata(
+      Path hybrid,
+      JsonNode hybridTemplate,
+      JsonNode mainTemplate,
+      Path mainPath,
+      List<Finding> findings) {
+    if (OperationMetadataIgnoreList.isIgnored(hybrid)
+        || OperationMetadataIgnoreList.isIgnored(mainPath)) {
+      return;
+    }
+    compareField(hybrid, hybridTemplate, mainTemplate, mainPath, ElementTemplate.STEPS, findings);
+    compareField(hybrid, hybridTemplate, mainTemplate, mainPath, ElementTemplate.PRESETS, findings);
+  }
+
+  private void compareField(
+      Path hybrid,
+      JsonNode hybridTemplate,
+      JsonNode mainTemplate,
+      Path mainPath,
+      String field,
+      List<Finding> findings) {
+    JsonNode hybridNode = hybridTemplate.path(field);
+    JsonNode mainNode = mainTemplate.path(field);
+    if (!hybridNode.equals(mainNode)) {
+      findings.add(
+          Finding.error(
+              hybrid,
+              "/" + field,
+              id(),
+              "Hybrid \""
+                  + field
+                  + "\" does not match the non-hybrid sibling ("
+                  + mainPath.getFileName()
+                  + ")."));
+    }
   }
 
   private void compareIdSet(

--- a/element-template-generator/validator/src/main/java/io/camunda/connector/validator/rule/PresetConditionsSatisfiedRule.java
+++ b/element-template-generator/validator/src/main/java/io/camunda/connector/validator/rule/PresetConditionsSatisfiedRule.java
@@ -17,6 +17,7 @@
 package io.camunda.connector.validator.rule;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import io.camunda.connector.validator.core.ConditionEvaluator;
 import io.camunda.connector.validator.core.ElementTemplate;
 import io.camunda.connector.validator.core.Finding;
 import io.camunda.connector.validator.core.JsonPointers;
@@ -25,17 +26,17 @@ import io.camunda.connector.validator.core.Rule;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 /**
- * For every entry of the top-level {@code presets[]} array, each key inside {@code properties} must
- * reference a property declared in the template's top-level {@code properties[]}, and the value
- * must be one of the property's declared {@code choices} (when choices are declared).
+ * For each preset, every pinned property's {@code condition} must evaluate to true under the
+ * preset's own assignment. Catches presets whose pinned values are mutually exclusive under the
+ * template's conditions (e.g. setting {@code operationGroup=A} alongside a property gated on {@code
+ * operationGroup=B}).
  */
-public class PresetTargetExistsRule implements Rule {
+public class PresetConditionsSatisfiedRule implements Rule {
 
   @Override
   public List<Finding> apply(Path file, JsonNode template) {
@@ -46,7 +47,7 @@ public class PresetTargetExistsRule implements Rule {
     if (!presets.isArray()) {
       return List.of();
     }
-    Map<String, Set<String>> propertyChoices = collectPropertyChoices(template);
+    Map<String, List<JsonNode>> conditionsByPropertyId = collectConditions(template);
     List<Finding> findings = new ArrayList<>();
     for (int i = 0; i < presets.size(); i++) {
       JsonNode preset = presets.get(i);
@@ -54,46 +55,46 @@ public class PresetTargetExistsRule implements Rule {
       if (!properties.isObject()) {
         continue;
       }
-      String pointer = "/presets/" + i + "/properties";
-      for (Map.Entry<String, JsonNode> entry : properties.properties()) {
+      Map<String, String> assignment = new LinkedHashMap<>();
+      properties
+          .properties()
+          .forEach(
+              e -> {
+                if (e.getValue().isTextual()) {
+                  assignment.put(e.getKey(), e.getValue().asText());
+                }
+              });
+      for (Map.Entry<String, String> entry : assignment.entrySet()) {
         String key = entry.getKey();
-        JsonNode value = entry.getValue();
-        String entryPointer = pointer + "/" + JsonPointers.escape(key);
-
-        if (!propertyChoices.containsKey(key)) {
+        List<JsonNode> conditions = conditionsByPropertyId.get(key);
+        if (conditions == null || conditions.isEmpty()) {
+          continue;
+        }
+        boolean anyHolds = false;
+        for (JsonNode cond : conditions) {
+          if (ConditionEvaluator.evaluate(cond, assignment)) {
+            anyHolds = true;
+            break;
+          }
+        }
+        if (!anyHolds) {
           findings.add(
               Finding.error(
                   file,
-                  entryPointer,
+                  "/presets/" + i + "/properties/" + JsonPointers.escape(key),
                   id(),
-                  "Preset references property \""
+                  "Preset pins property \""
                       + key
-                      + "\" which does not exist in this template."));
-          continue;
-        }
-        if (!value.isTextual()) {
-          continue;
-        }
-        Set<String> choices = propertyChoices.get(key);
-        if (!choices.isEmpty() && !choices.contains(value.asText())) {
-          findings.add(
-              Finding.error(
-                  file,
-                  entryPointer,
-                  id(),
-                  "Preset value \""
-                      + value.asText()
-                      + "\" is not one of the declared choices for property \""
-                      + key
-                      + "\"."));
+                      + "\" but no declaration of that property has a condition that holds under "
+                      + "the preset's assignment."));
         }
       }
     }
     return findings;
   }
 
-  private Map<String, Set<String>> collectPropertyChoices(JsonNode template) {
-    Map<String, Set<String>> result = new HashMap<>();
+  private Map<String, List<JsonNode>> collectConditions(JsonNode template) {
+    Map<String, List<JsonNode>> result = new HashMap<>();
     JsonNode props = template.path(ElementTemplate.PROPERTIES);
     if (!props.isArray()) {
       return result;
@@ -103,16 +104,8 @@ public class PresetTargetExistsRule implements Rule {
       if (!idNode.isTextual()) {
         continue;
       }
-      Set<String> choices = result.computeIfAbsent(idNode.asText(), k -> new HashSet<>());
-      JsonNode choicesNode = prop.path(ElementTemplate.CHOICES);
-      if (choicesNode.isArray()) {
-        for (JsonNode choice : choicesNode) {
-          JsonNode value = choice.path(ElementTemplate.VALUE);
-          if (value.isTextual()) {
-            choices.add(value.asText());
-          }
-        }
-      }
+      JsonNode condition = prop.path(ElementTemplate.CONDITION);
+      result.computeIfAbsent(idNode.asText(), k -> new ArrayList<>()).add(condition);
     }
     return result;
   }

--- a/element-template-generator/validator/src/main/java/io/camunda/connector/validator/rule/PresetCoverageRule.java
+++ b/element-template-generator/validator/src/main/java/io/camunda/connector/validator/rule/PresetCoverageRule.java
@@ -1,0 +1,384 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.validator.rule;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.camunda.connector.validator.core.ConditionEvaluator;
+import io.camunda.connector.validator.core.ElementTemplate;
+import io.camunda.connector.validator.core.Finding;
+import io.camunda.connector.validator.core.OperationMetadataIgnoreList;
+import io.camunda.connector.validator.core.Rule;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+
+/**
+ * Verifies that the set of {@code presets[]} and the set of leaf {@code steps} both enumerate
+ * exactly the reachable leaves of the discriminator tree.
+ *
+ * <p>A "reachable leaf" is a stable assignment to the discovered operation-group dropdowns: every
+ * key in the assignment must have a property declaration whose {@code condition} is satisfied under
+ * the assignment (and whose value is among declared choices), and every op-dropdown key NOT in the
+ * assignment must have no satisfied declaration under that assignment.
+ *
+ * <p>For a two-level connector with group "Table" (3 ops) and group "Item" (4 ops), this produces 7
+ * reachable leaves — counts add across conditional branches, not multiply.
+ */
+public class PresetCoverageRule implements Rule {
+
+  @Override
+  public List<Finding> apply(Path file, JsonNode template) {
+    if (OperationMetadataIgnoreList.isIgnored(file)) {
+      return List.of();
+    }
+    JsonNode presetsNode = template.path(ElementTemplate.PRESETS);
+    if (!presetsNode.isArray() || presetsNode.isEmpty()) {
+      return List.of();
+    }
+    Set<String> opKeys = discoverOpKeys(presetsNode);
+    if (opKeys.isEmpty()) {
+      return List.of();
+    }
+    Map<String, List<Declaration>> declsByKey = collectDeclarations(template, opKeys);
+
+    Set<Map<String, String>> reachable = enumerateReachableLeaves(opKeys, declsByKey);
+    Set<Map<String, String>> presetAssignments = extractPresetAssignments(presetsNode);
+    List<Map<String, String>> stepLeafAssignments =
+        extractStepLeafAssignments(template, presetsNode);
+
+    List<Finding> findings = new ArrayList<>();
+    findings.addAll(reportMissingFromPresets(file, reachable, presetAssignments));
+    findings.addAll(reportOrphanAndDuplicatePresets(file, presetsNode, reachable));
+    findings.addAll(reportStepLeafCoverage(file, reachable, stepLeafAssignments));
+    return findings;
+  }
+
+  private Set<String> discoverOpKeys(JsonNode presets) {
+    Set<String> keys = new LinkedHashSet<>();
+    for (JsonNode preset : presets) {
+      JsonNode properties = preset.path(ElementTemplate.PROPERTIES);
+      if (properties.isObject()) {
+        properties.fieldNames().forEachRemaining(keys::add);
+      }
+    }
+    return keys;
+  }
+
+  private Map<String, List<Declaration>> collectDeclarations(
+      JsonNode template, Set<String> opKeys) {
+    Map<String, List<Declaration>> result = new HashMap<>();
+    for (String k : opKeys) {
+      result.put(k, new ArrayList<>());
+    }
+    JsonNode props = template.path(ElementTemplate.PROPERTIES);
+    if (!props.isArray()) {
+      return result;
+    }
+    for (JsonNode prop : props) {
+      JsonNode idNode = prop.path(ElementTemplate.ID);
+      if (!idNode.isTextual()) {
+        continue;
+      }
+      String id = idNode.asText();
+      if (!opKeys.contains(id)) {
+        continue;
+      }
+      Set<String> choices = new LinkedHashSet<>();
+      JsonNode choicesNode = prop.path(ElementTemplate.CHOICES);
+      if (choicesNode.isArray()) {
+        for (JsonNode c : choicesNode) {
+          JsonNode v = c.path(ElementTemplate.VALUE);
+          if (v.isTextual()) {
+            choices.add(v.asText());
+          }
+        }
+      }
+      JsonNode condition = prop.path(ElementTemplate.CONDITION);
+      result.get(id).add(new Declaration(condition, choices));
+    }
+    return result;
+  }
+
+  private Set<Map<String, String>> enumerateReachableLeaves(
+      Set<String> opKeys, Map<String, List<Declaration>> declsByKey) {
+    List<String> orderedKeys = new ArrayList<>(opKeys);
+    Map<String, Set<String>> choicesUnion = new HashMap<>();
+    for (String k : orderedKeys) {
+      Set<String> union = new LinkedHashSet<>();
+      for (Declaration d : declsByKey.get(k)) {
+        union.addAll(d.choices);
+      }
+      choicesUnion.put(k, union);
+    }
+    List<Map<String, String>> candidates = new ArrayList<>();
+    enumerate(orderedKeys, 0, new LinkedHashMap<>(), choicesUnion, candidates);
+    Set<Map<String, String>> reachable = new LinkedHashSet<>();
+    for (Map<String, String> candidate : candidates) {
+      if (isStable(candidate, opKeys, declsByKey)) {
+        reachable.add(normalize(candidate));
+      }
+    }
+    return reachable;
+  }
+
+  private void enumerate(
+      List<String> keys,
+      int idx,
+      Map<String, String> current,
+      Map<String, Set<String>> choices,
+      List<Map<String, String>> output) {
+    if (idx == keys.size()) {
+      output.add(new LinkedHashMap<>(current));
+      return;
+    }
+    String key = keys.get(idx);
+    enumerate(keys, idx + 1, current, choices, output);
+    for (String c : choices.get(key)) {
+      current.put(key, c);
+      enumerate(keys, idx + 1, current, choices, output);
+      current.remove(key);
+    }
+  }
+
+  private boolean isStable(
+      Map<String, String> assignment,
+      Set<String> opKeys,
+      Map<String, List<Declaration>> declsByKey) {
+    for (String key : opKeys) {
+      List<Declaration> decls = declsByKey.get(key);
+      boolean anyVisible = false;
+      boolean anyValid = false;
+      for (Declaration d : decls) {
+        if (ConditionEvaluator.evaluate(d.condition, assignment)) {
+          anyVisible = true;
+          if (assignment.containsKey(key)
+              && (d.choices.isEmpty() || d.choices.contains(assignment.get(key)))) {
+            anyValid = true;
+          }
+        }
+      }
+      boolean assigned = assignment.containsKey(key);
+      if (assigned != anyVisible) {
+        return false;
+      }
+      if (assigned && !anyValid) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  private Set<Map<String, String>> extractPresetAssignments(JsonNode presets) {
+    Set<Map<String, String>> result = new LinkedHashSet<>();
+    for (JsonNode preset : presets) {
+      JsonNode properties = preset.path(ElementTemplate.PROPERTIES);
+      if (!properties.isObject()) {
+        continue;
+      }
+      Map<String, String> assignment = new LinkedHashMap<>();
+      properties
+          .properties()
+          .forEach(
+              e -> {
+                if (e.getValue().isTextual()) {
+                  assignment.put(e.getKey(), e.getValue().asText());
+                }
+              });
+      result.add(normalize(assignment));
+    }
+    return result;
+  }
+
+  private List<Map<String, String>> extractStepLeafAssignments(
+      JsonNode template, JsonNode presetsNode) {
+    Map<String, Map<String, String>> presetsById = new HashMap<>();
+    for (JsonNode preset : presetsNode) {
+      JsonNode idNode = preset.path(ElementTemplate.ID);
+      JsonNode properties = preset.path(ElementTemplate.PROPERTIES);
+      if (!idNode.isTextual() || !properties.isObject()) {
+        continue;
+      }
+      Map<String, String> assignment = new LinkedHashMap<>();
+      properties
+          .properties()
+          .forEach(
+              e -> {
+                if (e.getValue().isTextual()) {
+                  assignment.put(e.getKey(), e.getValue().asText());
+                }
+              });
+      presetsById.put(idNode.asText(), normalize(assignment));
+    }
+    List<Map<String, String>> result = new ArrayList<>();
+    JsonNode steps = template.path(ElementTemplate.STEPS);
+    if (steps.isArray()) {
+      collectLeaves(steps, presetsById, result);
+    }
+    return result;
+  }
+
+  private void collectLeaves(
+      JsonNode steps, Map<String, Map<String, String>> presetsById, List<Map<String, String>> out) {
+    for (JsonNode step : steps) {
+      JsonNode children = step.path(ElementTemplate.STEPS);
+      if (children.isArray()) {
+        collectLeaves(children, presetsById, out);
+        continue;
+      }
+      JsonNode presetIdNode = step.path(ElementTemplate.PRESET_ID);
+      if (presetIdNode.isTextual()) {
+        Map<String, String> assignment = presetsById.get(presetIdNode.asText());
+        if (assignment != null) {
+          out.add(assignment);
+        }
+      }
+    }
+  }
+
+  private List<Finding> reportMissingFromPresets(
+      Path file, Set<Map<String, String>> reachable, Set<Map<String, String>> presetAssignments) {
+    List<Finding> findings = new ArrayList<>();
+    Set<Map<String, String>> missing = new LinkedHashSet<>(reachable);
+    missing.removeAll(presetAssignments);
+    for (Map<String, String> assignment : missing) {
+      findings.add(
+          Finding.error(
+              file,
+              "/presets",
+              id(),
+              "Reachable operation \"" + format(assignment) + "\" has no matching preset."));
+    }
+    return findings;
+  }
+
+  private List<Finding> reportOrphanAndDuplicatePresets(
+      Path file, JsonNode presetsNode, Set<Map<String, String>> reachable) {
+    List<Finding> findings = new ArrayList<>();
+    Set<Map<String, String>> seen = new HashSet<>();
+    for (int i = 0; i < presetsNode.size(); i++) {
+      JsonNode preset = presetsNode.get(i);
+      JsonNode idNode = preset.path(ElementTemplate.ID);
+      JsonNode properties = preset.path(ElementTemplate.PROPERTIES);
+      if (!idNode.isTextual() || !properties.isObject()) {
+        continue;
+      }
+      Map<String, String> assignment = new LinkedHashMap<>();
+      properties
+          .properties()
+          .forEach(
+              e -> {
+                if (e.getValue().isTextual()) {
+                  assignment.put(e.getKey(), e.getValue().asText());
+                }
+              });
+      Map<String, String> normalized = normalize(assignment);
+      if (!reachable.contains(normalized)) {
+        findings.add(
+            Finding.error(
+                file,
+                "/presets/" + i,
+                id(),
+                "Preset \""
+                    + idNode.asText()
+                    + "\" does not correspond to any reachable operation."));
+      }
+      if (!seen.add(normalized)) {
+        findings.add(
+            Finding.error(
+                file,
+                "/presets/" + i,
+                id(),
+                "Preset \""
+                    + idNode.asText()
+                    + "\" duplicates an earlier preset's operation assignment."));
+      }
+    }
+    return findings;
+  }
+
+  private List<Finding> reportStepLeafCoverage(
+      Path file, Set<Map<String, String>> reachable, List<Map<String, String>> stepLeaves) {
+    List<Finding> findings = new ArrayList<>();
+    Map<Map<String, String>, Integer> stepCounts = new HashMap<>();
+    for (Map<String, String> leaf : stepLeaves) {
+      stepCounts.merge(leaf, 1, Integer::sum);
+    }
+    Set<Map<String, String>> missing = new LinkedHashSet<>(reachable);
+    missing.removeAll(stepCounts.keySet());
+    for (Map<String, String> assignment : missing) {
+      findings.add(
+          Finding.error(
+              file,
+              "/steps",
+              id(),
+              "Reachable operation \"" + format(assignment) + "\" has no matching leaf step."));
+    }
+    Set<Map<String, String>> orphan = new LinkedHashSet<>(stepCounts.keySet());
+    orphan.removeAll(reachable);
+    for (Map<String, String> assignment : orphan) {
+      findings.add(
+          Finding.error(
+              file,
+              "/steps",
+              id(),
+              "Step leaf \""
+                  + format(assignment)
+                  + "\" does not correspond to any reachable operation."));
+    }
+    for (Map.Entry<Map<String, String>, Integer> entry : stepCounts.entrySet()) {
+      if (entry.getValue() > 1 && reachable.contains(entry.getKey())) {
+        findings.add(
+            Finding.error(
+                file,
+                "/steps",
+                id(),
+                "Operation \""
+                    + format(entry.getKey())
+                    + "\" appears "
+                    + entry.getValue()
+                    + " times in the step tree — expected exactly once."));
+      }
+    }
+    return findings;
+  }
+
+  private Map<String, String> normalize(Map<String, String> assignment) {
+    return Collections.unmodifiableMap(new TreeMap<>(assignment));
+  }
+
+  private String format(Map<String, String> assignment) {
+    StringBuilder sb = new StringBuilder("{");
+    boolean first = true;
+    for (Map.Entry<String, String> e : assignment.entrySet()) {
+      if (!first) sb.append(", ");
+      sb.append(e.getKey()).append("=").append(e.getValue());
+      first = false;
+    }
+    sb.append("}");
+    return sb.toString();
+  }
+
+  private record Declaration(JsonNode condition, Set<String> choices) {}
+}

--- a/element-template-generator/validator/src/main/java/io/camunda/connector/validator/rule/PresetIdResolvesRule.java
+++ b/element-template-generator/validator/src/main/java/io/camunda/connector/validator/rule/PresetIdResolvesRule.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.validator.rule;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.camunda.connector.validator.core.ElementTemplate;
+import io.camunda.connector.validator.core.Finding;
+import io.camunda.connector.validator.core.OperationMetadataIgnoreList;
+import io.camunda.connector.validator.core.Rule;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Every leaf step's {@code presetId} must resolve to some {@code presets[].id} declared at the
+ * template root.
+ */
+public class PresetIdResolvesRule implements Rule {
+
+  @Override
+  public List<Finding> apply(Path file, JsonNode template) {
+    if (OperationMetadataIgnoreList.isIgnored(file)) {
+      return List.of();
+    }
+    JsonNode steps = template.path(ElementTemplate.STEPS);
+    if (!steps.isArray()) {
+      return List.of();
+    }
+    Set<String> declaredIds = collectPresetIds(template);
+    List<Finding> findings = new ArrayList<>();
+    for (int i = 0; i < steps.size(); i++) {
+      walk(steps.get(i), "/steps/" + i, file, declaredIds, findings);
+    }
+    return findings;
+  }
+
+  private Set<String> collectPresetIds(JsonNode template) {
+    Set<String> ids = new HashSet<>();
+    JsonNode presets = template.path(ElementTemplate.PRESETS);
+    if (!presets.isArray()) {
+      return ids;
+    }
+    for (JsonNode entry : presets) {
+      JsonNode idNode = entry.path(ElementTemplate.ID);
+      if (idNode.isTextual()) {
+        ids.add(idNode.asText());
+      }
+    }
+    return ids;
+  }
+
+  private void walk(
+      JsonNode node, String pointer, Path file, Set<String> declaredIds, List<Finding> findings) {
+    if (!node.isObject()) {
+      return;
+    }
+    JsonNode children = node.path(ElementTemplate.STEPS);
+    if (children.isArray()) {
+      for (int i = 0; i < children.size(); i++) {
+        walk(children.get(i), pointer + "/steps/" + i, file, declaredIds, findings);
+      }
+      return;
+    }
+    JsonNode presetId = node.path(ElementTemplate.PRESET_ID);
+    if (!presetId.isTextual()) {
+      return;
+    }
+    String value = presetId.asText();
+    if (!declaredIds.contains(value)) {
+      findings.add(
+          Finding.error(
+              file,
+              pointer + "/presetId",
+              id(),
+              "Leaf step references presetId \""
+                  + value
+                  + "\" which is not declared in presets[]."));
+    }
+  }
+}

--- a/element-template-generator/validator/src/main/java/io/camunda/connector/validator/rule/PresetIdUniqueRule.java
+++ b/element-template-generator/validator/src/main/java/io/camunda/connector/validator/rule/PresetIdUniqueRule.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.validator.rule;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.camunda.connector.validator.core.ElementTemplate;
+import io.camunda.connector.validator.core.Finding;
+import io.camunda.connector.validator.core.OperationMetadataIgnoreList;
+import io.camunda.connector.validator.core.Rule;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/** No two entries in {@code presets[]} may share an {@code id}. */
+public class PresetIdUniqueRule implements Rule {
+
+  @Override
+  public List<Finding> apply(Path file, JsonNode template) {
+    if (OperationMetadataIgnoreList.isIgnored(file)) {
+      return List.of();
+    }
+    JsonNode presets = template.path(ElementTemplate.PRESETS);
+    if (!presets.isArray()) {
+      return List.of();
+    }
+    List<Finding> findings = new ArrayList<>();
+    Set<String> seen = new HashSet<>();
+    for (int i = 0; i < presets.size(); i++) {
+      JsonNode entry = presets.get(i);
+      JsonNode idNode = entry.path(ElementTemplate.ID);
+      if (!idNode.isTextual()) {
+        continue;
+      }
+      String idValue = idNode.asText();
+      if (!seen.add(idValue)) {
+        findings.add(
+            Finding.error(
+                file, "/presets/" + i + "/id", id(), "Duplicate preset id \"" + idValue + "\"."));
+      }
+    }
+    return findings;
+  }
+}

--- a/element-template-generator/validator/src/main/java/io/camunda/connector/validator/rule/PresetOperationGroupConsistencyRule.java
+++ b/element-template-generator/validator/src/main/java/io/camunda/connector/validator/rule/PresetOperationGroupConsistencyRule.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.validator.rule;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.camunda.connector.validator.core.ElementTemplate;
+import io.camunda.connector.validator.core.Finding;
+import io.camunda.connector.validator.core.OperationMetadataIgnoreList;
+import io.camunda.connector.validator.core.Rule;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * The set of "operation-group dropdowns" is discovered as the union of keys across {@code
+ * presets[].properties}. For each such key, this rule enforces:
+ *
+ * <ul>
+ *   <li>The matching entry in {@code properties[]} has {@code group == "operation"}.
+ *   <li>An {@code "operation"} group is declared in {@code groups[]} and is the first entry.
+ * </ul>
+ */
+public class PresetOperationGroupConsistencyRule implements Rule {
+
+  public static final String OPERATION_GROUP_ID = "operation";
+
+  @Override
+  public List<Finding> apply(Path file, JsonNode template) {
+    if (OperationMetadataIgnoreList.isIgnored(file)) {
+      return List.of();
+    }
+    Set<String> opKeys = discoverOperationKeys(template);
+    List<Finding> findings = new ArrayList<>();
+    if (!opKeys.isEmpty()) {
+      checkPropertyGroups(file, template, opKeys, findings);
+      checkOperationGroupFirst(file, template, findings);
+    }
+    return findings;
+  }
+
+  private Set<String> discoverOperationKeys(JsonNode template) {
+    Set<String> keys = new LinkedHashSet<>();
+    JsonNode presets = template.path(ElementTemplate.PRESETS);
+    if (!presets.isArray()) {
+      return keys;
+    }
+    for (JsonNode preset : presets) {
+      JsonNode properties = preset.path(ElementTemplate.PROPERTIES);
+      if (!properties.isObject()) {
+        continue;
+      }
+      properties.fieldNames().forEachRemaining(keys::add);
+    }
+    return keys;
+  }
+
+  private void checkPropertyGroups(
+      Path file, JsonNode template, Set<String> opKeys, List<Finding> findings) {
+    JsonNode props = template.path(ElementTemplate.PROPERTIES);
+    if (!props.isArray()) {
+      return;
+    }
+    Set<String> flagged = new HashSet<>();
+    for (int i = 0; i < props.size(); i++) {
+      JsonNode prop = props.get(i);
+      JsonNode idNode = prop.path(ElementTemplate.ID);
+      if (!idNode.isTextual()) {
+        continue;
+      }
+      String propId = idNode.asText();
+      if (!opKeys.contains(propId) || flagged.contains(propId)) {
+        continue;
+      }
+      JsonNode groupNode = prop.path(ElementTemplate.GROUP);
+      if (!groupNode.isTextual() || !OPERATION_GROUP_ID.equals(groupNode.asText())) {
+        findings.add(
+            Finding.error(
+                file,
+                "/properties/" + i + "/group",
+                id(),
+                "Property \""
+                    + propId
+                    + "\" is referenced by a preset but its group is "
+                    + (groupNode.isTextual() ? "\"" + groupNode.asText() + "\"" : "missing")
+                    + " — expected \"operation\"."));
+        flagged.add(propId);
+      }
+    }
+  }
+
+  private void checkOperationGroupFirst(Path file, JsonNode template, List<Finding> findings) {
+    JsonNode groups = template.path(ElementTemplate.GROUPS);
+    if (!groups.isArray() || groups.isEmpty()) {
+      findings.add(
+          Finding.error(
+              file,
+              "/groups",
+              id(),
+              "Template uses operation presets but declares no \"operation\" group."));
+      return;
+    }
+    JsonNode first = groups.get(0);
+    JsonNode firstId = first.path(ElementTemplate.ID);
+    if (!firstId.isTextual() || !OPERATION_GROUP_ID.equals(firstId.asText())) {
+      // Look up the index of the operation group, if any, for a more useful message.
+      int opIndex = -1;
+      for (int i = 0; i < groups.size(); i++) {
+        JsonNode gid = groups.get(i).path(ElementTemplate.ID);
+        if (gid.isTextual() && OPERATION_GROUP_ID.equals(gid.asText())) {
+          opIndex = i;
+          break;
+        }
+      }
+      String pointer = opIndex >= 0 ? "/groups/" + opIndex : "/groups";
+      String message =
+          opIndex >= 0
+              ? "Operation group must be the first entry in groups[] (currently at index "
+                  + opIndex
+                  + ")."
+              : "Template uses operation presets but declares no \"operation\" group.";
+      findings.add(Finding.error(file, pointer, id(), message));
+    }
+  }
+}

--- a/element-template-generator/validator/src/main/java/io/camunda/connector/validator/rule/StepGroupShapeRule.java
+++ b/element-template-generator/validator/src/main/java/io/camunda/connector/validator/rule/StepGroupShapeRule.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.validator.rule;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.camunda.connector.validator.core.ElementTemplate;
+import io.camunda.connector.validator.core.Finding;
+import io.camunda.connector.validator.core.OperationMetadataIgnoreList;
+import io.camunda.connector.validator.core.Rule;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Validates group step nodes (intermediate nodes that carry a {@code steps} child array). A group
+ * must have a non-empty {@code steps[]}; {@code description} is optional; {@code keywords} are
+ * disallowed (keywords are conceptually leaf-only — search aliases apply to operations, not to
+ * categories); {@code presetId} is disallowed (only leaves point at presets).
+ */
+public class StepGroupShapeRule implements Rule {
+
+  @Override
+  public List<Finding> apply(Path file, JsonNode template) {
+    if (OperationMetadataIgnoreList.isIgnored(file)) {
+      return List.of();
+    }
+    JsonNode steps = template.path(ElementTemplate.STEPS);
+    if (!steps.isArray()) {
+      return List.of();
+    }
+    List<Finding> findings = new ArrayList<>();
+    for (int i = 0; i < steps.size(); i++) {
+      walk(steps.get(i), "/steps/" + i, file, findings);
+    }
+    return findings;
+  }
+
+  private void walk(JsonNode node, String pointer, Path file, List<Finding> findings) {
+    if (!node.isObject()) {
+      return;
+    }
+    JsonNode children = node.path(ElementTemplate.STEPS);
+    boolean isGroup = children.isArray();
+    if (!isGroup) {
+      return;
+    }
+    if (children.isEmpty()) {
+      findings.add(
+          Finding.error(
+              file, pointer + "/steps", id(), "Group step must have a non-empty \"steps\" array."));
+    }
+    if (node.has(ElementTemplate.KEYWORDS)) {
+      findings.add(
+          Finding.error(
+              file,
+              pointer + "/keywords",
+              id(),
+              "Group step must not declare \"keywords\" — keywords are leaf-only."));
+    }
+    if (node.has(ElementTemplate.PRESET_ID)) {
+      findings.add(
+          Finding.error(
+              file,
+              pointer + "/presetId",
+              id(),
+              "Group step must not declare \"presetId\" — only leaf steps reference presets."));
+    }
+    for (int i = 0; i < children.size(); i++) {
+      walk(children.get(i), pointer + "/steps/" + i, file, findings);
+    }
+  }
+}

--- a/element-template-generator/validator/src/main/java/io/camunda/connector/validator/rule/StepLeafShapeRule.java
+++ b/element-template-generator/validator/src/main/java/io/camunda/connector/validator/rule/StepLeafShapeRule.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.validator.rule;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.camunda.connector.validator.core.ElementTemplate;
+import io.camunda.connector.validator.core.Finding;
+import io.camunda.connector.validator.core.OperationMetadataIgnoreList;
+import io.camunda.connector.validator.core.Rule;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Validates leaf step nodes (no child {@code steps} array). A leaf must declare {@code presetId}
+ * (non-blank string) and a non-empty {@code keywords} array. {@code description} is optional.
+ */
+public class StepLeafShapeRule implements Rule {
+
+  @Override
+  public List<Finding> apply(Path file, JsonNode template) {
+    if (OperationMetadataIgnoreList.isIgnored(file)) {
+      return List.of();
+    }
+    JsonNode steps = template.path(ElementTemplate.STEPS);
+    if (!steps.isArray()) {
+      return List.of();
+    }
+    List<Finding> findings = new ArrayList<>();
+    for (int i = 0; i < steps.size(); i++) {
+      walk(steps.get(i), "/steps/" + i, file, findings);
+    }
+    return findings;
+  }
+
+  private void walk(JsonNode node, String pointer, Path file, List<Finding> findings) {
+    if (!node.isObject()) {
+      return;
+    }
+    JsonNode children = node.path(ElementTemplate.STEPS);
+    if (children.isArray()) {
+      for (int i = 0; i < children.size(); i++) {
+        walk(children.get(i), pointer + "/steps/" + i, file, findings);
+      }
+      return;
+    }
+    JsonNode presetId = node.path(ElementTemplate.PRESET_ID);
+    if (!presetId.isTextual() || presetId.asText().isBlank()) {
+      findings.add(
+          Finding.error(
+              file, pointer + "/presetId", id(), "Leaf step is missing a non-blank \"presetId\"."));
+    }
+    JsonNode keywords = node.path(ElementTemplate.KEYWORDS);
+    if (keywords.isMissingNode()) {
+      findings.add(
+          Finding.error(
+              file, pointer + "/keywords", id(), "Leaf step is missing a \"keywords\" array."));
+    } else if (!keywords.isArray()) {
+      findings.add(
+          Finding.error(
+              file, pointer + "/keywords", id(), "Leaf step \"keywords\" must be an array."));
+    } else if (keywords.isEmpty()) {
+      findings.add(
+          Finding.error(
+              file,
+              pointer + "/keywords",
+              id(),
+              "Leaf step \"keywords\" array must be non-empty."));
+    }
+  }
+}

--- a/element-template-generator/validator/src/main/java/io/camunda/connector/validator/rule/StepsPresetsPresentRule.java
+++ b/element-template-generator/validator/src/main/java/io/camunda/connector/validator/rule/StepsPresetsPresentRule.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.validator.rule;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.camunda.connector.validator.core.ElementTemplate;
+import io.camunda.connector.validator.core.Finding;
+import io.camunda.connector.validator.core.OperationMetadataIgnoreList;
+import io.camunda.connector.validator.core.Rule;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * The operations-metadata contract requires every connector template to declare both {@code steps}
+ * and {@code presets} at the root, and both must be non-empty arrays. Connectors listed in {@link
+ * OperationMetadataIgnoreList} are exempt until their {@code @Searchable} annotations or
+ * hand-authored JSON sections land.
+ */
+public class StepsPresetsPresentRule implements Rule {
+
+  @Override
+  public List<Finding> apply(Path file, JsonNode template) {
+    if (OperationMetadataIgnoreList.isIgnored(file)) {
+      return List.of();
+    }
+    List<Finding> findings = new ArrayList<>();
+    checkArray(file, template, ElementTemplate.STEPS, findings);
+    checkArray(file, template, ElementTemplate.PRESETS, findings);
+    return findings;
+  }
+
+  private void checkArray(Path file, JsonNode template, String field, List<Finding> findings) {
+    JsonNode node = template.path(field);
+    if (node.isMissingNode() || node.isNull()) {
+      findings.add(
+          Finding.error(file, "/" + field, id(), "Required field \"" + field + "\" is missing."));
+      return;
+    }
+    if (!node.isArray()) {
+      findings.add(
+          Finding.error(file, "/" + field, id(), "Field \"" + field + "\" must be an array."));
+      return;
+    }
+    if (node.isEmpty()) {
+      findings.add(
+          Finding.error(file, "/" + field, id(), "Field \"" + field + "\" must be non-empty."));
+    }
+  }
+}

--- a/element-template-generator/validator/src/test/java/io/camunda/connector/validator/rule/HybridParityRuleTest.java
+++ b/element-template-generator/validator/src/test/java/io/camunda/connector/validator/rule/HybridParityRuleTest.java
@@ -142,6 +142,58 @@ class HybridParityRuleTest {
     assertThat(findings).extracting(Finding::jsonPointer).containsExactly("/groups", "/groups");
   }
 
+  @Test
+  void opsMetadataIdentical_noFindings() throws Exception {
+    Map<Path, JsonNode> templates = new LinkedHashMap<>();
+    String body =
+        """
+        { "groups": [], "properties": [],
+          "steps":  [ { "presetId": "p" } ],
+          "presets": [ { "id": "p", "properties": { "x": "y" } } ] }
+        """;
+    templates.put(Path.of("connectors/foo/element-templates/foo.json"), read(body));
+    templates.put(Path.of("connectors/foo/element-templates/hybrid/foo-hybrid.json"), read(body));
+    assertThat(rule.apply(templates)).isEmpty();
+  }
+
+  @Test
+  void opsMetadataStepsDiffer_flagged() throws Exception {
+    Map<Path, JsonNode> templates = new LinkedHashMap<>();
+    templates.put(
+        Path.of("connectors/foo/element-templates/foo.json"),
+        read(
+            """
+        { "groups": [], "properties": [],
+          "steps":  [ { "presetId": "p" } ],
+          "presets": [ { "id": "p", "properties": {} } ] }
+        """));
+    templates.put(
+        Path.of("connectors/foo/element-templates/hybrid/foo-hybrid.json"),
+        read(
+            """
+        { "groups": [], "properties": [],
+          "steps":  [ { "presetId": "other" } ],
+          "presets": [ { "id": "p", "properties": {} } ] }
+        """));
+    List<Finding> findings = rule.apply(templates);
+    assertThat(findings).extracting(Finding::jsonPointer).contains("/steps");
+  }
+
+  @Test
+  void opsMetadataIgnoredConnector_notCompared() throws Exception {
+    Map<Path, JsonNode> templates = new LinkedHashMap<>();
+    templates.put(
+        Path.of("connectors/aws/element-templates/aws.json"),
+        read("{ \"properties\": [], \"groups\": [], \"steps\": [ { \"presetId\": \"a\" } ] }"));
+    templates.put(
+        Path.of("connectors/aws/element-templates/hybrid/aws-hybrid.json"),
+        read("{ \"properties\": [], \"groups\": [], \"steps\": [ { \"presetId\": \"b\" } ] }"));
+    // Steps differ, but aws is on the ignore list — no /steps finding.
+    assertThat(rule.apply(templates))
+        .extracting(Finding::jsonPointer)
+        .doesNotContain("/steps", "/presets");
+  }
+
   private static JsonNode read(String json) throws Exception {
     return MAPPER.readTree(json);
   }

--- a/element-template-generator/validator/src/test/java/io/camunda/connector/validator/rule/PresetConditionsSatisfiedRuleTest.java
+++ b/element-template-generator/validator/src/test/java/io/camunda/connector/validator/rule/PresetConditionsSatisfiedRuleTest.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.validator.rule;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.connector.validator.core.Finding;
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class PresetConditionsSatisfiedRuleTest {
+
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+  private static final Path FILE = Path.of("my-connector/element-templates/foo.json");
+  private final PresetConditionsSatisfiedRule rule = new PresetConditionsSatisfiedRule();
+
+  @Test
+  void consistentPreset_noFindings() throws Exception {
+    JsonNode template =
+        read(
+            """
+        {
+          "properties": [
+            { "id": "operationGroup" },
+            { "id": "tableOp",
+              "condition": { "property": "operationGroup", "equals": "table" } }
+          ],
+          "presets": [
+            { "id": "p", "properties": { "operationGroup": "table", "tableOp": "create" } }
+          ]
+        }
+        """);
+    assertThat(rule.apply(FILE, template)).isEmpty();
+  }
+
+  @Test
+  void inconsistentPreset_flagged() throws Exception {
+    JsonNode template =
+        read(
+            """
+        {
+          "properties": [
+            { "id": "operationGroup" },
+            { "id": "tableOp",
+              "condition": { "property": "operationGroup", "equals": "table" } }
+          ],
+          "presets": [
+            { "id": "bad", "properties": { "operationGroup": "item", "tableOp": "create" } }
+          ]
+        }
+        """);
+    List<Finding> findings = rule.apply(FILE, template);
+    assertThat(findings).hasSize(1);
+    assertThat(findings.get(0).jsonPointer()).isEqualTo("/presets/0/properties/tableOp");
+    assertThat(findings.get(0).message()).contains("tableOp");
+  }
+
+  @Test
+  void switchingPattern_eitherDeclarationHolds_noFindings() throws Exception {
+    JsonNode template =
+        read(
+            """
+        {
+          "properties": [
+            { "id": "operationGroup" },
+            { "id": "innerOp",
+              "condition": { "property": "operationGroup", "equals": "table" } },
+            { "id": "innerOp",
+              "condition": { "property": "operationGroup", "equals": "item" } }
+          ],
+          "presets": [
+            { "id": "p", "properties": { "operationGroup": "item", "innerOp": "getItem" } }
+          ]
+        }
+        """);
+    assertThat(rule.apply(FILE, template)).isEmpty();
+  }
+
+  @Test
+  void unconditionalProperty_alwaysHolds() throws Exception {
+    JsonNode template =
+        read(
+            """
+        {
+          "properties": [ { "id": "foo" } ],
+          "presets": [ { "id": "p", "properties": { "foo": "anything" } } ]
+        }
+        """);
+    assertThat(rule.apply(FILE, template)).isEmpty();
+  }
+
+  @Test
+  void allMatchCondition_evaluated() throws Exception {
+    JsonNode template =
+        read(
+            """
+        {
+          "properties": [
+            { "id": "a" }, { "id": "b" },
+            { "id": "c",
+              "condition": { "allMatch": [
+                { "property": "a", "equals": "1" },
+                { "property": "b", "equals": "2" }
+              ]}}
+          ],
+          "presets": [
+            { "id": "ok",  "properties": { "a": "1", "b": "2", "c": "x" } },
+            { "id": "bad", "properties": { "a": "1", "b": "3", "c": "x" } }
+          ]
+        }
+        """);
+    List<Finding> findings = rule.apply(FILE, template);
+    assertThat(findings).hasSize(1);
+    assertThat(findings.get(0).jsonPointer()).isEqualTo("/presets/1/properties/c");
+  }
+
+  @Test
+  void ignoredConnector_noFindings() throws Exception {
+    JsonNode template =
+        read(
+            """
+        {
+          "properties": [
+            { "id": "x",
+              "condition": { "property": "y", "equals": "z" } }
+          ],
+          "presets": [ { "id": "p", "properties": { "x": "v" } } ]
+        }
+        """);
+    assertThat(rule.apply(Path.of("connectors/aws/element-templates/x.json"), template)).isEmpty();
+  }
+
+  private static JsonNode read(String json) throws Exception {
+    return MAPPER.readTree(json);
+  }
+}

--- a/element-template-generator/validator/src/test/java/io/camunda/connector/validator/rule/PresetCoverageRuleTest.java
+++ b/element-template-generator/validator/src/test/java/io/camunda/connector/validator/rule/PresetCoverageRuleTest.java
@@ -1,0 +1,207 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.validator.rule;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.connector.validator.core.Finding;
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class PresetCoverageRuleTest {
+
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+  private static final Path FILE = Path.of("my-connector/element-templates/foo.json");
+  private final PresetCoverageRule rule = new PresetCoverageRule();
+
+  @Test
+  void oneLevelComplete_noFindings() throws Exception {
+    // S3-like: one dropdown with three choices, three presets, three step leaves.
+    JsonNode template =
+        read(
+            """
+        {
+          "properties": [
+            { "id": "action", "choices": [
+              { "value": "upload" }, { "value": "download" }, { "value": "delete" }
+            ]}
+          ],
+          "steps": [
+            { "presetId": "upload" }, { "presetId": "download" }, { "presetId": "delete" }
+          ],
+          "presets": [
+            { "id": "upload",   "properties": { "action": "upload" } },
+            { "id": "download", "properties": { "action": "download" } },
+            { "id": "delete",   "properties": { "action": "delete" } }
+          ]
+        }
+        """);
+    assertThat(rule.apply(FILE, template)).isEmpty();
+  }
+
+  @Test
+  void oneLevelMissingPreset_flagged() throws Exception {
+    JsonNode template =
+        read(
+            """
+        {
+          "properties": [
+            { "id": "action", "choices": [
+              { "value": "upload" }, { "value": "download" }, { "value": "delete" }
+            ]}
+          ],
+          "steps": [ { "presetId": "upload" }, { "presetId": "download" } ],
+          "presets": [
+            { "id": "upload",   "properties": { "action": "upload" } },
+            { "id": "download", "properties": { "action": "download" } }
+          ]
+        }
+        """);
+    List<Finding> findings = rule.apply(FILE, template);
+    assertThat(findings).extracting(Finding::message).anyMatch(m -> m.contains("delete"));
+  }
+
+  @Test
+  void twoLevelConditionalSwitching_sumNotProduct() throws Exception {
+    // DynamoDB-like: operationGroup gates two distinct inner dropdowns.
+    // 3 + 4 = 7 reachable leaves (NOT 12).
+    JsonNode template =
+        read(
+            """
+        {
+          "properties": [
+            { "id": "operationGroup", "choices": [
+              { "value": "table" }, { "value": "item" }
+            ]},
+            { "id": "tableOp",
+              "condition": { "property": "operationGroup", "equals": "table" },
+              "choices": [
+                { "value": "createTable" }, { "value": "deleteTable" }, { "value": "scanTable" }
+              ]},
+            { "id": "itemOp",
+              "condition": { "property": "operationGroup", "equals": "item" },
+              "choices": [
+                { "value": "getItem" }, { "value": "putItem" },
+                { "value": "delItem" }, { "value": "updItem" }
+              ]}
+          ],
+          "steps": [
+            { "presetId": "createTable" },
+            { "presetId": "deleteTable" },
+            { "presetId": "scanTable" },
+            { "presetId": "getItem" },
+            { "presetId": "putItem" },
+            { "presetId": "delItem" },
+            { "presetId": "updItem" }
+          ],
+          "presets": [
+            { "id": "createTable", "properties": { "operationGroup": "table", "tableOp": "createTable" } },
+            { "id": "deleteTable", "properties": { "operationGroup": "table", "tableOp": "deleteTable" } },
+            { "id": "scanTable",   "properties": { "operationGroup": "table", "tableOp": "scanTable" } },
+            { "id": "getItem",     "properties": { "operationGroup": "item",  "itemOp":  "getItem" } },
+            { "id": "putItem",     "properties": { "operationGroup": "item",  "itemOp":  "putItem" } },
+            { "id": "delItem",     "properties": { "operationGroup": "item",  "itemOp":  "delItem" } },
+            { "id": "updItem",     "properties": { "operationGroup": "item",  "itemOp":  "updItem" } }
+          ]
+        }
+        """);
+    assertThat(rule.apply(FILE, template)).isEmpty();
+  }
+
+  @Test
+  void orphanPreset_flagged() throws Exception {
+    JsonNode template =
+        read(
+            """
+        {
+          "properties": [
+            { "id": "action", "choices": [ { "value": "upload" } ] }
+          ],
+          "steps": [ { "presetId": "upload" } ],
+          "presets": [
+            { "id": "upload", "properties": { "action": "upload" } },
+            { "id": "bogus",  "properties": { "action": "wrong" } }
+          ]
+        }
+        """);
+    List<Finding> findings = rule.apply(FILE, template);
+    assertThat(findings).extracting(Finding::message).anyMatch(m -> m.contains("bogus"));
+  }
+
+  @Test
+  void duplicateAssignmentPresets_flagged() throws Exception {
+    JsonNode template =
+        read(
+            """
+        {
+          "properties": [
+            { "id": "action", "choices": [ { "value": "upload" } ] }
+          ],
+          "steps": [ { "presetId": "upload" } ],
+          "presets": [
+            { "id": "upload",  "properties": { "action": "upload" } },
+            { "id": "upload2", "properties": { "action": "upload" } }
+          ]
+        }
+        """);
+    List<Finding> findings = rule.apply(FILE, template);
+    assertThat(findings).extracting(Finding::message).anyMatch(m -> m.contains("duplicates"));
+  }
+
+  @Test
+  void missingStepLeaf_flagged() throws Exception {
+    JsonNode template =
+        read(
+            """
+        {
+          "properties": [
+            { "id": "action", "choices": [ { "value": "a" }, { "value": "b" } ] }
+          ],
+          "steps": [ { "presetId": "pa" } ],
+          "presets": [
+            { "id": "pa", "properties": { "action": "a" } },
+            { "id": "pb", "properties": { "action": "b" } }
+          ]
+        }
+        """);
+    List<Finding> findings = rule.apply(FILE, template);
+    // Reachable {action=b} has a preset but no step leaf — flag.
+    assertThat(findings)
+        .extracting(Finding::message)
+        .anyMatch(m -> m.contains("no matching leaf step"));
+  }
+
+  @Test
+  void ignoredConnector_noFindings() throws Exception {
+    JsonNode template =
+        read(
+            """
+        {
+          "properties": [],
+          "presets": [ { "id": "p", "properties": { "x": "y" } } ]
+        }
+        """);
+    assertThat(rule.apply(Path.of("connectors/aws/element-templates/x.json"), template)).isEmpty();
+  }
+
+  private static JsonNode read(String json) throws Exception {
+    return MAPPER.readTree(json);
+  }
+}

--- a/element-template-generator/validator/src/test/java/io/camunda/connector/validator/rule/PresetIdResolvesRuleTest.java
+++ b/element-template-generator/validator/src/test/java/io/camunda/connector/validator/rule/PresetIdResolvesRuleTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.validator.rule;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.connector.validator.core.Finding;
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class PresetIdResolvesRuleTest {
+
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+  private static final Path FILE = Path.of("my-connector/element-templates/foo.json");
+  private final PresetIdResolvesRule rule = new PresetIdResolvesRule();
+
+  @Test
+  void allResolved_noFindings() throws Exception {
+    JsonNode template =
+        read(
+            """
+        {
+          "steps": [ { "presetId": "a" }, { "presetId": "b" } ],
+          "presets": [ { "id": "a" }, { "id": "b" } ]
+        }
+        """);
+    assertThat(rule.apply(FILE, template)).isEmpty();
+  }
+
+  @Test
+  void unresolvedPresetId_flagged() throws Exception {
+    JsonNode template =
+        read(
+            """
+        {
+          "steps": [ { "presetId": "missing" } ],
+          "presets": [ { "id": "a" } ]
+        }
+        """);
+    List<Finding> findings = rule.apply(FILE, template);
+    assertThat(findings).hasSize(1);
+    assertThat(findings.get(0).jsonPointer()).isEqualTo("/steps/0/presetId");
+    assertThat(findings.get(0).message()).contains("missing");
+  }
+
+  @Test
+  void nestedLeavesChecked() throws Exception {
+    JsonNode template =
+        read(
+            """
+        {
+          "steps": [
+            { "name": "g", "steps": [ { "presetId": "x" }, { "presetId": "y" } ] }
+          ],
+          "presets": [ { "id": "x" } ]
+        }
+        """);
+    List<Finding> findings = rule.apply(FILE, template);
+    assertThat(findings).hasSize(1);
+    assertThat(findings.get(0).jsonPointer()).isEqualTo("/steps/0/steps/1/presetId");
+  }
+
+  @Test
+  void ignoredConnector_noFindings() throws Exception {
+    JsonNode template = read("{ \"steps\": [ { \"presetId\": \"x\" } ], \"presets\": [] }");
+    assertThat(rule.apply(Path.of("connectors/aws/element-templates/x.json"), template)).isEmpty();
+  }
+
+  private static JsonNode read(String json) throws Exception {
+    return MAPPER.readTree(json);
+  }
+}

--- a/element-template-generator/validator/src/test/java/io/camunda/connector/validator/rule/PresetIdUniqueRuleTest.java
+++ b/element-template-generator/validator/src/test/java/io/camunda/connector/validator/rule/PresetIdUniqueRuleTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.validator.rule;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.connector.validator.core.Finding;
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class PresetIdUniqueRuleTest {
+
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+  private static final Path FILE = Path.of("my-connector/element-templates/foo.json");
+  private final PresetIdUniqueRule rule = new PresetIdUniqueRule();
+
+  @Test
+  void uniqueIds_noFindings() throws Exception {
+    JsonNode template = read("{ \"presets\": [ { \"id\": \"a\" }, { \"id\": \"b\" } ] }");
+    assertThat(rule.apply(FILE, template)).isEmpty();
+  }
+
+  @Test
+  void duplicateId_flagged() throws Exception {
+    JsonNode template =
+        read("{ \"presets\": [ { \"id\": \"a\" }, { \"id\": \"b\" }, { \"id\": \"a\" } ] }");
+    List<Finding> findings = rule.apply(FILE, template);
+    assertThat(findings).hasSize(1);
+    assertThat(findings.get(0).jsonPointer()).isEqualTo("/presets/2/id");
+    assertThat(findings.get(0).message()).contains("\"a\"");
+  }
+
+  @Test
+  void ignoredConnector_noFindings() throws Exception {
+    JsonNode template = read("{ \"presets\": [ { \"id\": \"a\" }, { \"id\": \"a\" } ] }");
+    assertThat(rule.apply(Path.of("connectors/aws/element-templates/x.json"), template)).isEmpty();
+  }
+
+  private static JsonNode read(String json) throws Exception {
+    return MAPPER.readTree(json);
+  }
+}

--- a/element-template-generator/validator/src/test/java/io/camunda/connector/validator/rule/PresetOperationGroupConsistencyRuleTest.java
+++ b/element-template-generator/validator/src/test/java/io/camunda/connector/validator/rule/PresetOperationGroupConsistencyRuleTest.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.validator.rule;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.connector.validator.core.Finding;
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class PresetOperationGroupConsistencyRuleTest {
+
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+  private static final Path FILE = Path.of("my-connector/element-templates/foo.json");
+  private final PresetOperationGroupConsistencyRule rule =
+      new PresetOperationGroupConsistencyRule();
+
+  @Test
+  void wellFormed_noFindings() throws Exception {
+    JsonNode template =
+        read(
+            """
+        {
+          "groups": [ { "id": "operation" }, { "id": "auth" } ],
+          "properties": [
+            { "id": "operationGroup", "group": "operation" },
+            { "id": "creds", "group": "auth" }
+          ],
+          "presets": [
+            { "id": "p", "properties": { "operationGroup": "x" } }
+          ]
+        }
+        """);
+    assertThat(rule.apply(FILE, template)).isEmpty();
+  }
+
+  @Test
+  void noPresets_noFindings() throws Exception {
+    JsonNode template = read("{ \"groups\": [ { \"id\": \"auth\" } ] }");
+    assertThat(rule.apply(FILE, template)).isEmpty();
+  }
+
+  @Test
+  void presetReferencesNonOperationProperty_flagged() throws Exception {
+    JsonNode template =
+        read(
+            """
+        {
+          "groups": [ { "id": "operation" } ],
+          "properties": [
+            { "id": "operationGroup", "group": "operation" },
+            { "id": "creds", "group": "auth" }
+          ],
+          "presets": [
+            { "id": "p", "properties": { "operationGroup": "x", "creds": "y" } }
+          ]
+        }
+        """);
+    List<Finding> findings = rule.apply(FILE, template);
+    assertThat(findings).hasSize(1);
+    assertThat(findings.get(0).message()).contains("creds").contains("operation");
+  }
+
+  @Test
+  void operationGroupNotFirst_flagged() throws Exception {
+    JsonNode template =
+        read(
+            """
+        {
+          "groups": [ { "id": "auth" }, { "id": "operation" } ],
+          "properties": [ { "id": "operationGroup", "group": "operation" } ],
+          "presets": [ { "id": "p", "properties": { "operationGroup": "x" } } ]
+        }
+        """);
+    List<Finding> findings = rule.apply(FILE, template);
+    assertThat(findings).hasSize(1);
+    assertThat(findings.get(0).jsonPointer()).isEqualTo("/groups/1");
+    assertThat(findings.get(0).message()).contains("first");
+  }
+
+  @Test
+  void operationGroupMissing_flagged() throws Exception {
+    JsonNode template =
+        read(
+            """
+        {
+          "groups": [ { "id": "auth" } ],
+          "properties": [ { "id": "operationGroup", "group": "auth" } ],
+          "presets": [ { "id": "p", "properties": { "operationGroup": "x" } } ]
+        }
+        """);
+    List<Finding> findings = rule.apply(FILE, template);
+    assertThat(findings).hasSize(2);
+    assertThat(findings).extracting(Finding::jsonPointer).contains("/groups");
+  }
+
+  @Test
+  void ignoredConnector_noFindings() throws Exception {
+    JsonNode template =
+        read(
+            """
+        {
+          "groups": [],
+          "properties": [ { "id": "x", "group": "wrong" } ],
+          "presets": [ { "id": "p", "properties": { "x": "v" } } ]
+        }
+        """);
+    assertThat(rule.apply(Path.of("connectors/aws/element-templates/x.json"), template)).isEmpty();
+  }
+
+  private static JsonNode read(String json) throws Exception {
+    return MAPPER.readTree(json);
+  }
+}

--- a/element-template-generator/validator/src/test/java/io/camunda/connector/validator/rule/PresetTargetExistsRuleTest.java
+++ b/element-template-generator/validator/src/test/java/io/camunda/connector/validator/rule/PresetTargetExistsRuleTest.java
@@ -28,7 +28,7 @@ import org.junit.jupiter.api.Test;
 class PresetTargetExistsRuleTest {
 
   private static final ObjectMapper MAPPER = new ObjectMapper();
-  private static final Path FILE = Path.of("test.json");
+  private static final Path FILE = Path.of("my-connector/element-templates/foo.json");
   private final PresetTargetExistsRule rule = new PresetTargetExistsRule();
 
   @Test
@@ -36,11 +36,7 @@ class PresetTargetExistsRuleTest {
     JsonNode template =
         read(
             """
-        {
-          "properties": [
-            { "id": "operationGroup", "choices": [{"value": "issues"}] }
-          ]
-        }
+        { "properties": [ { "id": "operationGroup", "choices": [{"value": "issues"}] } ] }
         """);
     assertThat(rule.apply(FILE, template)).isEmpty();
   }
@@ -56,13 +52,8 @@ class PresetTargetExistsRuleTest {
               { "value": "actions" }, { "value": "issues" }
             ]}
           ],
-          "steps": [
-            {
-              "name": "Actions",
-              "steps": [
-                { "name": "Create dispatch", "presets": { "operationGroup": "actions" } }
-              ]
-            }
+          "presets": [
+            { "id": "p1", "properties": { "operationGroup": "actions" } }
           ]
         }
         """);
@@ -75,19 +66,15 @@ class PresetTargetExistsRuleTest {
         read(
             """
         {
-          "properties": [
-            { "id": "operationGroup", "choices": [{"value": "actions"}] }
-          ],
-          "steps": [
-            { "steps": [ { "presets": { "operationGruop": "actions" } } ] }
-          ]
+          "properties": [ { "id": "operationGroup", "choices": [{"value": "actions"}] } ],
+          "presets": [ { "id": "p", "properties": { "operationGruop": "actions" } } ]
         }
         """);
     List<Finding> findings = rule.apply(FILE, template);
     assertThat(findings).hasSize(1);
     Finding f = findings.get(0);
     assertThat(f.ruleId()).isEqualTo("preset-target-exists");
-    assertThat(f.jsonPointer()).isEqualTo("/steps/0/steps/0/presets/operationGruop");
+    assertThat(f.jsonPointer()).isEqualTo("/presets/0/properties/operationGruop");
     assertThat(f.message()).contains("operationGruop");
   }
 
@@ -102,20 +89,18 @@ class PresetTargetExistsRuleTest {
               { "value": "actions" }, { "value": "issues" }
             ]}
           ],
-          "steps": [
-            { "steps": [ { "presets": { "operationGroup": "deployments" } } ] }
-          ]
+          "presets": [ { "id": "p", "properties": { "operationGroup": "deployments" } } ]
         }
         """);
     List<Finding> findings = rule.apply(FILE, template);
     assertThat(findings).hasSize(1);
     Finding f = findings.get(0);
-    assertThat(f.jsonPointer()).isEqualTo("/steps/0/steps/0/presets/operationGroup");
+    assertThat(f.jsonPointer()).isEqualTo("/presets/0/properties/operationGroup");
     assertThat(f.message()).contains("deployments").contains("operationGroup");
   }
 
   @Test
-  void multipleEntriesInOnePresetsObject_independentFindings() throws Exception {
+  void multipleEntriesInOnePreset_independentFindings() throws Exception {
     JsonNode template =
         read(
             """
@@ -124,13 +109,11 @@ class PresetTargetExistsRuleTest {
             { "id": "operationGroup", "choices": [{"value": "actions"}] },
             { "id": "eventOperationType" }
           ],
-          "steps": [
-            { "steps": [ { "presets": {
-              "operationGroup": "deployments",
-              "eventOperationType": "createWorkflowDispatchEvent",
-              "missing": "x"
-            }}]}
-          ]
+          "presets": [ { "id": "p", "properties": {
+            "operationGroup": "deployments",
+            "eventOperationType": "createWorkflowDispatchEvent",
+            "missing": "x"
+          }}]
         }
         """);
     List<Finding> findings = rule.apply(FILE, template);
@@ -138,7 +121,7 @@ class PresetTargetExistsRuleTest {
     assertThat(findings)
         .extracting(Finding::jsonPointer)
         .containsExactlyInAnyOrder(
-            "/steps/0/steps/0/presets/operationGroup", "/steps/0/steps/0/presets/missing");
+            "/presets/0/properties/operationGroup", "/presets/0/properties/missing");
   }
 
   @Test
@@ -147,12 +130,8 @@ class PresetTargetExistsRuleTest {
         read(
             """
         {
-          "properties": [
-            { "id": "freeText" }
-          ],
-          "steps": [
-            { "steps": [ { "presets": { "freeText": "anything goes" } } ] }
-          ]
+          "properties": [ { "id": "freeText" } ],
+          "presets": [ { "id": "p", "properties": { "freeText": "anything goes" } } ]
         }
         """);
     assertThat(rule.apply(FILE, template)).isEmpty();
@@ -160,9 +139,6 @@ class PresetTargetExistsRuleTest {
 
   @Test
   void duplicateIdsWithDifferentChoices_unionAccepted() throws Exception {
-    // Mutually-exclusive switching pattern: same id "eventOperationType" appears twice with
-    // disjoint choices, gated on different operationGroup values. A preset value valid under
-    // either variant must not be flagged.
     JsonNode template =
         read(
             """
@@ -178,50 +154,57 @@ class PresetTargetExistsRuleTest {
               "choices": [{ "value": "createIssue" }, { "value": "closeIssue" }],
               "condition": { "property": "operationGroup", "equals": "issues" } }
           ],
-          "steps": [
-            { "steps": [ { "presets": {
-              "operationGroup": "issues",
-              "eventOperationType": "createIssue"
-            }}]}
-          ]
+          "presets": [ { "id": "p", "properties": {
+            "operationGroup": "issues",
+            "eventOperationType": "createIssue"
+          }}]
         }
         """);
     assertThat(rule.apply(FILE, template)).isEmpty();
   }
 
   @Test
-  void duplicateIdsWithDifferentChoices_valueOutsideUnion_flagged() throws Exception {
+  void duplicateIdsWithDifferentChoices_valueOutsideUnion_oneFinding() throws Exception {
     JsonNode template =
         read(
             """
         {
           "properties": [
-            { "id": "eventOperationType", "choices": [{ "value": "a" }] },
-            { "id": "eventOperationType", "choices": [{ "value": "b" }] }
+            { "id": "operationGroup", "choices": [
+              { "value": "actions" }, { "value": "issues" }
+            ]},
+            { "id": "eventOperationType",
+              "choices": [{ "value": "createWorkflowDispatchEvent" }],
+              "condition": { "property": "operationGroup", "equals": "actions" } },
+            { "id": "eventOperationType",
+              "choices": [{ "value": "createIssue" }, { "value": "closeIssue" }],
+              "condition": { "property": "operationGroup", "equals": "issues" } }
           ],
-          "steps": [
-            { "steps": [ { "presets": { "eventOperationType": "c" } } ] }
-          ]
+          "presets": [ { "id": "p", "properties": {
+            "operationGroup": "issues",
+            "eventOperationType": "notInEither"
+          }}]
         }
         """);
     List<Finding> findings = rule.apply(FILE, template);
     assertThat(findings).hasSize(1);
-    assertThat(findings.get(0).message()).contains("\"c\"");
+    Finding f = findings.get(0);
+    assertThat(f.jsonPointer()).isEqualTo("/presets/0/properties/eventOperationType");
+    assertThat(f.message()).contains("notInEither").contains("eventOperationType");
   }
 
   @Test
-  void presetsAtTopLevel_alsoValidated() throws Exception {
+  void ignoredConnector_noFindings() throws Exception {
     JsonNode template =
         read(
             """
         {
           "properties": [ { "id": "x" } ],
-          "presets": { "missing": "y" }
+          "presets": [ { "id": "p", "properties": { "missing": "y" } } ]
         }
         """);
-    List<Finding> findings = rule.apply(FILE, template);
-    assertThat(findings).hasSize(1);
-    assertThat(findings.get(0).jsonPointer()).isEqualTo("/presets/missing");
+    assertThat(rule.apply(Path.of("connectors/aws/element-templates/aws.json"), template))
+        .isEmpty();
   }
 
   private static JsonNode read(String json) throws Exception {

--- a/element-template-generator/validator/src/test/java/io/camunda/connector/validator/rule/StepGroupShapeRuleTest.java
+++ b/element-template-generator/validator/src/test/java/io/camunda/connector/validator/rule/StepGroupShapeRuleTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.validator.rule;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.connector.validator.core.Finding;
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class StepGroupShapeRuleTest {
+
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+  private static final Path FILE = Path.of("my-connector/element-templates/foo.json");
+  private final StepGroupShapeRule rule = new StepGroupShapeRule();
+
+  @Test
+  void wellFormedGroup_noFindings() throws Exception {
+    JsonNode template =
+        read(
+            """
+        { "steps": [
+          { "name": "Table",
+            "description": "Table ops",
+            "steps": [ { "name": "Create", "presetId": "p", "keywords": ["x"] } ]
+          }
+        ] }
+        """);
+    assertThat(rule.apply(FILE, template)).isEmpty();
+  }
+
+  @Test
+  void groupWithKeywords_flagged() throws Exception {
+    JsonNode template =
+        read(
+            """
+        { "steps": [
+          { "name": "g", "keywords": ["x"],
+            "steps": [ { "name": "leaf", "presetId": "p" } ] }
+        ] }
+        """);
+    List<Finding> findings = rule.apply(FILE, template);
+    assertThat(findings).hasSize(1);
+    assertThat(findings.get(0).jsonPointer()).isEqualTo("/steps/0/keywords");
+    assertThat(findings.get(0).message()).contains("keywords");
+  }
+
+  @Test
+  void groupWithPresetId_flagged() throws Exception {
+    JsonNode template =
+        read(
+            """
+        { "steps": [
+          { "name": "g", "presetId": "p",
+            "steps": [ { "name": "leaf", "presetId": "p" } ] }
+        ] }
+        """);
+    List<Finding> findings = rule.apply(FILE, template);
+    assertThat(findings).hasSize(1);
+    assertThat(findings.get(0).jsonPointer()).isEqualTo("/steps/0/presetId");
+  }
+
+  @Test
+  void emptyGroupStepsArray_flagged() throws Exception {
+    JsonNode template =
+        read(
+            """
+        { "steps": [ { "name": "g", "steps": [] } ] }
+        """);
+    List<Finding> findings = rule.apply(FILE, template);
+    assertThat(findings).hasSize(1);
+    assertThat(findings.get(0).jsonPointer()).isEqualTo("/steps/0/steps");
+    assertThat(findings.get(0).message()).contains("non-empty");
+  }
+
+  @Test
+  void leafNodes_notFlagged() throws Exception {
+    JsonNode template =
+        read(
+            """
+        { "steps": [ { "name": "leaf", "presetId": "p", "keywords": ["x"] } ] }
+        """);
+    assertThat(rule.apply(FILE, template)).isEmpty();
+  }
+
+  @Test
+  void ignoredConnector_noFindings() throws Exception {
+    JsonNode template = read("{ \"steps\": [ { \"steps\": [], \"keywords\": [\"x\"] } ] }");
+    assertThat(rule.apply(Path.of("connectors/aws/element-templates/aws.json"), template))
+        .isEmpty();
+  }
+
+  private static JsonNode read(String json) throws Exception {
+    return MAPPER.readTree(json);
+  }
+}

--- a/element-template-generator/validator/src/test/java/io/camunda/connector/validator/rule/StepLeafShapeRuleTest.java
+++ b/element-template-generator/validator/src/test/java/io/camunda/connector/validator/rule/StepLeafShapeRuleTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.validator.rule;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.connector.validator.core.Finding;
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class StepLeafShapeRuleTest {
+
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+  private static final Path FILE = Path.of("my-connector/element-templates/foo.json");
+  private final StepLeafShapeRule rule = new StepLeafShapeRule();
+
+  @Test
+  void wellFormedLeaf_noFindings() throws Exception {
+    JsonNode template =
+        read(
+            """
+        { "steps": [ { "name": "x", "presetId": "p", "keywords": ["x"] } ] }
+        """);
+    assertThat(rule.apply(FILE, template)).isEmpty();
+  }
+
+  @Test
+  void leafMissingPresetId_flagged() throws Exception {
+    JsonNode template =
+        read(
+            """
+        { "steps": [ { "name": "x", "keywords": ["x"] } ] }
+        """);
+    List<Finding> findings = rule.apply(FILE, template);
+    assertThat(findings).hasSize(1);
+    assertThat(findings.get(0).jsonPointer()).isEqualTo("/steps/0/presetId");
+  }
+
+  @Test
+  void leafBlankPresetId_flagged() throws Exception {
+    JsonNode template =
+        read(
+            """
+        { "steps": [ { "presetId": "  ", "keywords": ["x"] } ] }
+        """);
+    assertThat(rule.apply(FILE, template)).hasSize(1);
+  }
+
+  @Test
+  void leafMissingKeywords_flagged() throws Exception {
+    JsonNode template = read("{ \"steps\": [ { \"presetId\": \"p\" } ] }");
+    List<Finding> findings = rule.apply(FILE, template);
+    assertThat(findings).hasSize(1);
+    assertThat(findings.get(0).jsonPointer()).isEqualTo("/steps/0/keywords");
+  }
+
+  @Test
+  void leafEmptyKeywords_flagged() throws Exception {
+    JsonNode template = read("{ \"steps\": [ { \"presetId\": \"p\", \"keywords\": [] } ] }");
+    List<Finding> findings = rule.apply(FILE, template);
+    assertThat(findings).hasSize(1);
+    assertThat(findings.get(0).message()).contains("non-empty");
+  }
+
+  @Test
+  void leafKeywordsNotArray_flagged() throws Exception {
+    JsonNode template = read("{ \"steps\": [ { \"presetId\": \"p\", \"keywords\": \"x\" } ] }");
+    List<Finding> findings = rule.apply(FILE, template);
+    assertThat(findings).hasSize(1);
+    assertThat(findings.get(0).jsonPointer()).isEqualTo("/steps/0/keywords");
+    assertThat(findings.get(0).message()).contains("must be an array");
+  }
+
+  @Test
+  void nestedLeafChecked() throws Exception {
+    JsonNode template =
+        read(
+            """
+        { "steps": [
+          { "name": "g", "steps": [ { "name": "leaf", "presetId": "p" } ] }
+        ] }
+        """);
+    List<Finding> findings = rule.apply(FILE, template);
+    assertThat(findings).hasSize(1);
+    assertThat(findings.get(0).jsonPointer()).isEqualTo("/steps/0/steps/0/keywords");
+  }
+
+  @Test
+  void groupNodes_notFlagged() throws Exception {
+    JsonNode template =
+        read(
+            """
+        { "steps": [
+          { "name": "g",
+            "steps": [ { "presetId": "p", "keywords": ["x"] } ] }
+        ] }
+        """);
+    assertThat(rule.apply(FILE, template)).isEmpty();
+  }
+
+  @Test
+  void ignoredConnector_noFindings() throws Exception {
+    JsonNode template = read("{ \"steps\": [ { } ] }");
+    assertThat(rule.apply(Path.of("connectors/aws/element-templates/aws.json"), template))
+        .isEmpty();
+  }
+
+  private static JsonNode read(String json) throws Exception {
+    return MAPPER.readTree(json);
+  }
+}

--- a/element-template-generator/validator/src/test/java/io/camunda/connector/validator/rule/StepsPresetsPresentRuleTest.java
+++ b/element-template-generator/validator/src/test/java/io/camunda/connector/validator/rule/StepsPresetsPresentRuleTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.validator.rule;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.connector.validator.core.Finding;
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class StepsPresetsPresentRuleTest {
+
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+  // A path that does NOT match any connector on the ignore list.
+  private static final Path FILE = Path.of("my-connector/element-templates/foo.json");
+  private final StepsPresetsPresentRule rule = new StepsPresetsPresentRule();
+
+  @Test
+  void bothPresentAndNonEmpty_noFindings() throws Exception {
+    JsonNode template =
+        read(
+            """
+        {
+          "steps":  [ { "name": "x", "presetId": "p" } ],
+          "presets": [ { "id": "p", "properties": {} } ]
+        }
+        """);
+    assertThat(rule.apply(FILE, template)).isEmpty();
+  }
+
+  @Test
+  void missingSteps_oneFinding() throws Exception {
+    JsonNode template = read("{ \"presets\": [ { \"id\": \"p\" } ] }");
+    List<Finding> findings = rule.apply(FILE, template);
+    assertThat(findings).hasSize(1);
+    assertThat(findings.get(0).jsonPointer()).isEqualTo("/steps");
+    assertThat(findings.get(0).message()).contains("missing");
+  }
+
+  @Test
+  void emptyPresets_oneFinding() throws Exception {
+    JsonNode template =
+        read(
+            """
+        { "steps": [ { "name": "x" } ], "presets": [] }
+        """);
+    List<Finding> findings = rule.apply(FILE, template);
+    assertThat(findings).hasSize(1);
+    assertThat(findings.get(0).jsonPointer()).isEqualTo("/presets");
+    assertThat(findings.get(0).message()).contains("non-empty");
+  }
+
+  @Test
+  void stepsNotAnArray_oneFinding() throws Exception {
+    JsonNode template =
+        read(
+            """
+        { "steps": "nope", "presets": [{}] }
+        """);
+    List<Finding> findings = rule.apply(FILE, template);
+    assertThat(findings).hasSize(1);
+    assertThat(findings.get(0).jsonPointer()).isEqualTo("/steps");
+    assertThat(findings.get(0).message()).contains("must be an array");
+  }
+
+  @Test
+  void ignoredConnector_noFindings() throws Exception {
+    JsonNode template = read("{}");
+    // "aws" is on the ignore list.
+    Path ignored = Path.of("connectors/aws/element-templates/aws-s3.json");
+    assertThat(rule.apply(ignored, template)).isEmpty();
+  }
+
+  private static JsonNode read(String json) throws Exception {
+    return MAPPER.readTree(json);
+  }
+}


### PR DESCRIPTION
## Description
- Added new rules to verify all native operations metadata of all connectors are valid.
- Currently all connectors are in the ignore list, as there is also a check that connectors must have this metadata, so in the future when creating new connectors you get an error, if missing the metadata. 

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes https://github.com/camunda/connectors/issues/7338

## Checklist

- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest
  release, as this branch will be rebased onto main before the next release. Example backport labels:
    - `backport stable/8.8`: for changes that should be included in the next 8.8.x release.
    - **or** `backport release-8.8.7`: for changes that should be included in the specific release 8.8.7, and this
      *release has already been created*. The release branch will be merged back into stable/8.8 later, so the change
      will be included in future 8.8.x releases as well.
- [ ] Tests/Integration tests for the changes have been added if applicable.
- [ ] If the change requires a documentation update, it has been added to the appropriate section in the documentation.


