### PR TITLE
feat(connector-runtime): add process-definition-cache toggle

### DIFF
--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/InboundConnectorRuntimeConfiguration.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/InboundConnectorRuntimeConfiguration.java
@@ -57,6 +57,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.cache.Cache;
 import org.springframework.cache.CacheManager;
 import org.springframework.cache.caffeine.CaffeineCacheManager;
+import org.springframework.cache.support.NoOpCacheManager;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -165,8 +166,13 @@ public class InboundConnectorRuntimeConfiguration {
 
   @Bean
   public CacheManager processDefinitionCacheManager(
+      @Value("${camunda.connector.inbound.process-definition-cache.enabled:true}")
+          boolean cacheEnabled,
       @Value("${camunda.connector.inbound.process-definition-cache.max-size:1000}")
           int cacheMaxSize) {
+    if (!cacheEnabled) {
+      return new NoOpCacheManager();
+    }
     int boundedMaxSize = cacheMaxSize > 0 ? cacheMaxSize : 1000;
     CaffeineCacheManager cacheManager =
         new CaffeineCacheManager(ProcessDefinitionInspector.PROCESS_DEFINITION_CACHE_NAME);

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/inbound/InboundConnectorRuntimeConfigurationTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/inbound/InboundConnectorRuntimeConfigurationTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.runtime.inbound;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+import io.camunda.connector.runtime.inbound.state.ProcessDefinitionInspector;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+import org.springframework.cache.Cache;
+import org.springframework.cache.caffeine.CaffeineCacheManager;
+import org.springframework.cache.support.NoOpCacheManager;
+
+class InboundConnectorRuntimeConfigurationTest {
+
+  private final InboundConnectorRuntimeConfiguration configuration =
+      new InboundConnectorRuntimeConfiguration();
+
+  @Test
+  void processDefinitionCacheManager_whenEnabled_returnsCaffeineCacheManager() {
+    var cacheManager = configuration.processDefinitionCacheManager(true, 1000);
+
+    assertInstanceOf(CaffeineCacheManager.class, cacheManager);
+  }
+
+  @Test
+  void processDefinitionCacheManager_whenDisabled_returnsNoOpCacheManager() {
+    var cacheManager = configuration.processDefinitionCacheManager(false, 1000);
+
+    assertInstanceOf(NoOpCacheManager.class, cacheManager);
+  }
+
+  @Test
+  void processDefinitionCacheManager_whenDisabled_cacheNeverStoresValues() throws Exception {
+    var cacheManager = configuration.processDefinitionCacheManager(false, 1000);
+    Cache cache = cacheManager.getCache(ProcessDefinitionInspector.PROCESS_DEFINITION_CACHE_NAME);
+
+    var callCount = new AtomicInteger(0);
+    cache.get("key", callCount::incrementAndGet);
+    cache.get("key", callCount::incrementAndGet);
+
+    assertEquals(2, callCount.get(), "NoOp cache must call loader on every get");
+  }
+}


### PR DESCRIPTION
Previously, the inbound connector process-definition cache could not be disabled — only its size was configurable via `camunda.connector.inbound.process-definition-cache.max-size`. Setting `camunda.connector.inbound.process-definition-cache.enabled=false` now returns Spring's `NoOpCacheManager`, causing every lookup to call through to the loader without caching. The property defaults to `true`, so existing deployments are unaffected.

`InboundConnectorRuntimeConfigurationTest` covers three cases: enabled path returns `CaffeineCacheManager`, disabled path returns `NoOpCacheManager`, and the no-op cache calls the loader on every `get` rather than storing values.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Sonnet_4.6_(200K)](https://img.shields.io/badge/Sonnet_4.6_(200K)-D97757?logo=claude&logoColor=white)