### PR TITLE
test(congen-cli): smoke test for CLI bootstrap (proves issue, fix to follow)

### DIFF
--- a/element-template-generator/congen-cli/pom.xml
+++ b/element-template-generator/congen-cli/pom.xml
@@ -61,6 +61,17 @@
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-nop</artifactId>
     </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/element-template-generator/congen-cli/src/main/java/io/camunda/connector/generator/cli/command/Generate.java
+++ b/element-template-generator/congen-cli/src/main/java/io/camunda/connector/generator/cli/command/Generate.java
@@ -39,8 +39,7 @@ public class Generate implements Callable<Integer> {
 
   static final Schema jsonSchema =
       SchemaRegistry.withDialect(
-              Dialects.getDraft202012(),
-              builder -> builder.schemaLoader(Builder::fetchRemoteResources))
+              Dialects.getDraft7(), builder -> builder.schemaLoader(Builder::fetchRemoteResources))
           .getSchema(
               SchemaLocation.of(
                   "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json"));

--- a/element-template-generator/congen-cli/src/test/java/io/camunda/connector/generator/cli/CliBootstrapTest.java
+++ b/element-template-generator/congen-cli/src/test/java/io/camunda/connector/generator/cli/CliBootstrapTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.generator.cli;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import io.camunda.connector.generator.cli.command.ConGen;
+import org.junit.jupiter.api.Test;
+import picocli.CommandLine;
+
+/**
+ * Smoke tests guarding against startup-time crashes in the CLI. picocli reflects over every
+ * subcommand class when the root {@link CommandLine} is constructed, so any failing {@code static}
+ * initializer in a subcommand wedges every entry point — including {@code -h}, {@code list}, and
+ * {@code scan} that don't touch the failing class otherwise.
+ */
+class CliBootstrapTest {
+
+  @Test
+  void commandLineCanBeConstructed() {
+    assertThatCode(() -> new CommandLine(new ConGen())).doesNotThrowAnyException();
+  }
+
+  @Test
+  void helpFlagReturnsZeroExitCode() {
+    int exitCode =
+        new CommandLine(new ConGen()).setUnmatchedOptionsArePositionalParams(true).execute("-h");
+    assertThatCode(() -> {}).doesNotThrowAnyException();
+    if (exitCode != 0) {
+      throw new AssertionError("expected -h to exit 0, got " + exitCode);
+    }
+  }
+}


### PR DESCRIPTION
## Description

Two commits, separable by intent:

1. **`test(congen-cli)`** — the first tests for `congen-cli`. Demonstrates the failure by constructing `new CommandLine(new ConGen())` and asserting `congen -h` returns exit 0. Both crashed at startup before the fix.
2. **`fix(congen-cli)`** — one-line dialect swap (`Dialects.getDraft202012()` → `Dialects.getDraft7()`) to match the Camunda template schema's declared `$schema`.

## Root cause

PR #5923 (`json-schema-validator` 2.x → 3.x) removed the implicit registration of older JSON Schema draft dialects. `Generate.java` then loads a draft-07 schema against a registry initialized with only draft-2020-12, throwing `InvalidSchemaException` in a `static final` initializer. Picocli reflects over every subcommand class at startup, so every entry point (including `-h`, `list`, `scan`) crashed.

See #7355 for a full root-cause writeup. The failing CI on the test-only commit (https://github.com/camunda/connectors/actions/runs/26450331753/job/77868959986) is the evidence.

Fixes #7355.

## Checklist

- [ ] Backport labels — main only; the regression has been on main since 2025-12-15 in #5923 but no release shipped a broken CLI binary that wasn't already broken
- [x] Tests added — first tests for `congen-cli`
- [ ] Documentation — no user-visible behavior change
