### PR TITLE
[Release 8.8] Release branch to base branch (conflict-free rebase)

### DIFF
--- a/.github/workflows/RELEASE.yaml
+++ b/.github/workflows/RELEASE.yaml
@@ -271,6 +271,9 @@ jobs:
         with:
           name: repository
 
+      - name: Ensure Maven wrapper is executable
+        run: chmod +x ./mvnw
+
       - name: Prepare Java and Maven settings
         uses: actions/setup-java@v5
         with:

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,4 +1,4 @@
 java temurin-21.0.11+10.0.LTS
 maven 3.9.15
 pre-commit 4.6.0
-nodejs 24.15.0
+nodejs 24.16.0

--- a/bundle/camunda-saas-bundle/pom.xml
+++ b/bundle/camunda-saas-bundle/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.camunda.connector</groupId>
     <artifactId>connector-runtime-bundle-parent</artifactId>
-    <version>8.8.11</version>
+    <version>8.8.12</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>connector-runtime-bundle-saas</artifactId>

--- a/bundle/camunda-saas-bundle/pom.xml
+++ b/bundle/camunda-saas-bundle/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.camunda.connector</groupId>
     <artifactId>connector-runtime-bundle-parent</artifactId>
-    <version>8.8.13-rc1</version>
+    <version>8.8.13</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>connector-runtime-bundle-saas</artifactId>

--- a/bundle/camunda-saas-bundle/pom.xml
+++ b/bundle/camunda-saas-bundle/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.camunda.connector</groupId>
     <artifactId>connector-runtime-bundle-parent</artifactId>
-    <version>8.8.12</version>
+    <version>8.8.13-rc1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>connector-runtime-bundle-saas</artifactId>

--- a/bundle/default-bundle/pom.xml
+++ b/bundle/default-bundle/pom.xml
@@ -4,7 +4,7 @@
   <parent>
         <groupId>io.camunda.connector</groupId>
         <artifactId>connector-runtime-bundle-parent</artifactId>
-        <version>8.8.12</version>
+        <version>8.8.13-rc1</version>
         <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>connector-runtime-bundle</artifactId>

--- a/bundle/default-bundle/pom.xml
+++ b/bundle/default-bundle/pom.xml
@@ -4,7 +4,7 @@
   <parent>
         <groupId>io.camunda.connector</groupId>
         <artifactId>connector-runtime-bundle-parent</artifactId>
-        <version>8.8.13-rc1</version>
+        <version>8.8.13</version>
         <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>connector-runtime-bundle</artifactId>

--- a/bundle/default-bundle/pom.xml
+++ b/bundle/default-bundle/pom.xml
@@ -4,7 +4,7 @@
   <parent>
         <groupId>io.camunda.connector</groupId>
         <artifactId>connector-runtime-bundle-parent</artifactId>
-        <version>8.8.11</version>
+        <version>8.8.12</version>
         <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>connector-runtime-bundle</artifactId>

--- a/bundle/pom.xml
+++ b/bundle/pom.xml
@@ -11,7 +11,7 @@
     <groupId>io.camunda.connector</groupId>
     <artifactId>connector-parent</artifactId>
     <relativePath>../parent/pom.xml</relativePath>
-    <version>8.8.12</version>
+    <version>8.8.13-rc1</version>
   </parent>
 
   <modules>

--- a/bundle/pom.xml
+++ b/bundle/pom.xml
@@ -11,7 +11,7 @@
     <groupId>io.camunda.connector</groupId>
     <artifactId>connector-parent</artifactId>
     <relativePath>../parent/pom.xml</relativePath>
-    <version>8.8.11</version>
+    <version>8.8.12</version>
   </parent>
 
   <modules>

--- a/bundle/pom.xml
+++ b/bundle/pom.xml
@@ -11,7 +11,7 @@
     <groupId>io.camunda.connector</groupId>
     <artifactId>connector-parent</artifactId>
     <relativePath>../parent/pom.xml</relativePath>
-    <version>8.8.13-rc1</version>
+    <version>8.8.13</version>
   </parent>
 
   <modules>

--- a/connector-commons/connector-object-mapper/pom.xml
+++ b/connector-commons/connector-object-mapper/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.camunda.connector</groupId>
     <artifactId>connector-commons</artifactId>
-    <version>8.8.11</version>
+    <version>8.8.12</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/connector-commons/connector-object-mapper/pom.xml
+++ b/connector-commons/connector-object-mapper/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.camunda.connector</groupId>
     <artifactId>connector-commons</artifactId>
-    <version>8.8.12</version>
+    <version>8.8.13-rc1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/connector-commons/connector-object-mapper/pom.xml
+++ b/connector-commons/connector-object-mapper/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.camunda.connector</groupId>
     <artifactId>connector-commons</artifactId>
-    <version>8.8.13-rc1</version>
+    <version>8.8.13</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/connector-commons/connector-test-utils/pom.xml
+++ b/connector-commons/connector-test-utils/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.camunda.connector</groupId>
         <artifactId>connector-commons</artifactId>
-        <version>8.8.12</version>
+        <version>8.8.13-rc1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/connector-commons/connector-test-utils/pom.xml
+++ b/connector-commons/connector-test-utils/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.camunda.connector</groupId>
         <artifactId>connector-commons</artifactId>
-        <version>8.8.13-rc1</version>
+        <version>8.8.13</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/connector-commons/connector-test-utils/pom.xml
+++ b/connector-commons/connector-test-utils/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.camunda.connector</groupId>
         <artifactId>connector-commons</artifactId>
-        <version>8.8.11</version>
+        <version>8.8.12</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/connector-commons/connector-utils/pom.xml
+++ b/connector-commons/connector-utils/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.camunda.connector</groupId>
     <artifactId>connector-commons</artifactId>
-    <version>8.8.11</version>
+    <version>8.8.12</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/connector-commons/connector-utils/pom.xml
+++ b/connector-commons/connector-utils/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.camunda.connector</groupId>
     <artifactId>connector-commons</artifactId>
-    <version>8.8.12</version>
+    <version>8.8.13-rc1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/connector-commons/connector-utils/pom.xml
+++ b/connector-commons/connector-utils/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.camunda.connector</groupId>
     <artifactId>connector-commons</artifactId>
-    <version>8.8.13-rc1</version>
+    <version>8.8.13</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/connector-commons/http-client/pom.xml
+++ b/connector-commons/http-client/pom.xml
@@ -7,7 +7,7 @@
     <groupId>io.camunda.connector</groupId>
     <artifactId>connector-commons</artifactId>
     <relativePath>../pom.xml</relativePath>
-    <version>8.8.12</version>
+    <version>8.8.13-rc1</version>
   </parent>
 
   <name>Connector HTTP Client</name>

--- a/connector-commons/http-client/pom.xml
+++ b/connector-commons/http-client/pom.xml
@@ -7,7 +7,7 @@
     <groupId>io.camunda.connector</groupId>
     <artifactId>connector-commons</artifactId>
     <relativePath>../pom.xml</relativePath>
-    <version>8.8.13-rc1</version>
+    <version>8.8.13</version>
   </parent>
 
   <name>Connector HTTP Client</name>

--- a/connector-commons/http-client/pom.xml
+++ b/connector-commons/http-client/pom.xml
@@ -7,7 +7,7 @@
     <groupId>io.camunda.connector</groupId>
     <artifactId>connector-commons</artifactId>
     <relativePath>../pom.xml</relativePath>
-    <version>8.8.11</version>
+    <version>8.8.12</version>
   </parent>
 
   <name>Connector HTTP Client</name>

--- a/connector-commons/pom.xml
+++ b/connector-commons/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.camunda.connector</groupId>
     <artifactId>connectors-bundle-parent</artifactId>
-    <version>8.8.11</version>
+    <version>8.8.12</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/connector-commons/pom.xml
+++ b/connector-commons/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.camunda.connector</groupId>
     <artifactId>connectors-bundle-parent</artifactId>
-    <version>8.8.12</version>
+    <version>8.8.13-rc1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/connector-commons/pom.xml
+++ b/connector-commons/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.camunda.connector</groupId>
     <artifactId>connectors-bundle-parent</artifactId>
-    <version>8.8.13-rc1</version>
+    <version>8.8.13</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/connector-runtime/connector-runtime-application/pom.xml
+++ b/connector-runtime/connector-runtime-application/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.camunda.connector</groupId>
     <artifactId>connector-runtime-parent</artifactId>
-    <version>8.8.13-rc1</version>
+    <version>8.8.13</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/connector-runtime/connector-runtime-application/pom.xml
+++ b/connector-runtime/connector-runtime-application/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.camunda.connector</groupId>
     <artifactId>connector-runtime-parent</artifactId>
-    <version>8.8.11</version>
+    <version>8.8.12</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/connector-runtime/connector-runtime-application/pom.xml
+++ b/connector-runtime/connector-runtime-application/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.camunda.connector</groupId>
     <artifactId>connector-runtime-parent</artifactId>
-    <version>8.8.12</version>
+    <version>8.8.13-rc1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/connector-runtime/connector-runtime-core/pom.xml
+++ b/connector-runtime/connector-runtime-core/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda.connector</groupId>
     <artifactId>connector-runtime-parent</artifactId>
-    <version>8.8.11</version>
+    <version>8.8.12</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/connector-runtime/connector-runtime-core/pom.xml
+++ b/connector-runtime/connector-runtime-core/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda.connector</groupId>
     <artifactId>connector-runtime-parent</artifactId>
-    <version>8.8.12</version>
+    <version>8.8.13-rc1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/connector-runtime/connector-runtime-core/pom.xml
+++ b/connector-runtime/connector-runtime-core/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda.connector</groupId>
     <artifactId>connector-runtime-parent</artifactId>
-    <version>8.8.13-rc1</version>
+    <version>8.8.13</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/connector-runtime/connector-runtime-spring/pom.xml
+++ b/connector-runtime/connector-runtime-spring/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.camunda.connector</groupId>
     <artifactId>connector-runtime-parent</artifactId>
-    <version>8.8.13-rc1</version>
+    <version>8.8.13</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/connector-runtime/connector-runtime-spring/pom.xml
+++ b/connector-runtime/connector-runtime-spring/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.camunda.connector</groupId>
     <artifactId>connector-runtime-parent</artifactId>
-    <version>8.8.11</version>
+    <version>8.8.12</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/connector-runtime/connector-runtime-spring/pom.xml
+++ b/connector-runtime/connector-runtime-spring/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.camunda.connector</groupId>
     <artifactId>connector-runtime-parent</artifactId>
-    <version>8.8.12</version>
+    <version>8.8.13-rc1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/connector-runtime/connector-runtime-test/pom.xml
+++ b/connector-runtime/connector-runtime-test/pom.xml
@@ -8,7 +8,7 @@
         <groupId>io.camunda.connector</groupId>
         <artifactId>connector-runtime-parent</artifactId>
         <relativePath>../pom.xml</relativePath>
-        <version>8.8.13-rc1</version>
+        <version>8.8.13</version>
     </parent>
 
     <name>Connector Runtime Test</name>

--- a/connector-runtime/connector-runtime-test/pom.xml
+++ b/connector-runtime/connector-runtime-test/pom.xml
@@ -8,7 +8,7 @@
         <groupId>io.camunda.connector</groupId>
         <artifactId>connector-runtime-parent</artifactId>
         <relativePath>../pom.xml</relativePath>
-        <version>8.8.12</version>
+        <version>8.8.13-rc1</version>
     </parent>
 
     <name>Connector Runtime Test</name>

--- a/connector-runtime/connector-runtime-test/pom.xml
+++ b/connector-runtime/connector-runtime-test/pom.xml
@@ -8,7 +8,7 @@
         <groupId>io.camunda.connector</groupId>
         <artifactId>connector-runtime-parent</artifactId>
         <relativePath>../pom.xml</relativePath>
-        <version>8.8.11</version>
+        <version>8.8.12</version>
     </parent>
 
     <name>Connector Runtime Test</name>

--- a/connector-runtime/feel-wrapper/pom.xml
+++ b/connector-runtime/feel-wrapper/pom.xml
@@ -6,7 +6,7 @@
     <groupId>io.camunda.connector</groupId>
     <artifactId>connector-runtime-parent</artifactId>
     <relativePath>../pom.xml</relativePath>
-    <version>8.8.12</version>
+    <version>8.8.13-rc1</version>
   </parent>
 
   <artifactId>connector-feel-wrapper</artifactId>

--- a/connector-runtime/feel-wrapper/pom.xml
+++ b/connector-runtime/feel-wrapper/pom.xml
@@ -6,7 +6,7 @@
     <groupId>io.camunda.connector</groupId>
     <artifactId>connector-runtime-parent</artifactId>
     <relativePath>../pom.xml</relativePath>
-    <version>8.8.11</version>
+    <version>8.8.12</version>
   </parent>
 
   <artifactId>connector-feel-wrapper</artifactId>

--- a/connector-runtime/feel-wrapper/pom.xml
+++ b/connector-runtime/feel-wrapper/pom.xml
@@ -6,7 +6,7 @@
     <groupId>io.camunda.connector</groupId>
     <artifactId>connector-runtime-parent</artifactId>
     <relativePath>../pom.xml</relativePath>
-    <version>8.8.13-rc1</version>
+    <version>8.8.13</version>
   </parent>
 
   <artifactId>connector-feel-wrapper</artifactId>

--- a/connector-runtime/jackson-datatype-document/pom.xml
+++ b/connector-runtime/jackson-datatype-document/pom.xml
@@ -5,7 +5,7 @@
     <groupId>io.camunda.connector</groupId>
     <artifactId>connector-runtime-parent</artifactId>
     <relativePath>../pom.xml</relativePath>
-    <version>8.8.12</version>
+    <version>8.8.13-rc1</version>
   </parent>
 
   <artifactId>jackson-datatype-document</artifactId>

--- a/connector-runtime/jackson-datatype-document/pom.xml
+++ b/connector-runtime/jackson-datatype-document/pom.xml
@@ -5,7 +5,7 @@
     <groupId>io.camunda.connector</groupId>
     <artifactId>connector-runtime-parent</artifactId>
     <relativePath>../pom.xml</relativePath>
-    <version>8.8.13-rc1</version>
+    <version>8.8.13</version>
   </parent>
 
   <artifactId>jackson-datatype-document</artifactId>

--- a/connector-runtime/jackson-datatype-document/pom.xml
+++ b/connector-runtime/jackson-datatype-document/pom.xml
@@ -5,7 +5,7 @@
     <groupId>io.camunda.connector</groupId>
     <artifactId>connector-runtime-parent</artifactId>
     <relativePath>../pom.xml</relativePath>
-    <version>8.8.11</version>
+    <version>8.8.12</version>
   </parent>
 
   <artifactId>jackson-datatype-document</artifactId>

--- a/connector-runtime/jackson-datatype-feel/pom.xml
+++ b/connector-runtime/jackson-datatype-feel/pom.xml
@@ -5,7 +5,7 @@
     <groupId>io.camunda.connector</groupId>
     <artifactId>connector-runtime-parent</artifactId>
     <relativePath>../pom.xml</relativePath>
-    <version>8.8.12</version>
+    <version>8.8.13-rc1</version>
   </parent>
 
   <artifactId>jackson-datatype-feel</artifactId>

--- a/connector-runtime/jackson-datatype-feel/pom.xml
+++ b/connector-runtime/jackson-datatype-feel/pom.xml
@@ -5,7 +5,7 @@
     <groupId>io.camunda.connector</groupId>
     <artifactId>connector-runtime-parent</artifactId>
     <relativePath>../pom.xml</relativePath>
-    <version>8.8.13-rc1</version>
+    <version>8.8.13</version>
   </parent>
 
   <artifactId>jackson-datatype-feel</artifactId>

--- a/connector-runtime/jackson-datatype-feel/pom.xml
+++ b/connector-runtime/jackson-datatype-feel/pom.xml
@@ -5,7 +5,7 @@
     <groupId>io.camunda.connector</groupId>
     <artifactId>connector-runtime-parent</artifactId>
     <relativePath>../pom.xml</relativePath>
-    <version>8.8.11</version>
+    <version>8.8.12</version>
   </parent>
 
   <artifactId>jackson-datatype-feel</artifactId>

--- a/connector-runtime/pom.xml
+++ b/connector-runtime/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.camunda.connector</groupId>
     <artifactId>connectors-bundle-parent</artifactId>
-    <version>8.8.11</version>
+    <version>8.8.12</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/connector-runtime/pom.xml
+++ b/connector-runtime/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.camunda.connector</groupId>
     <artifactId>connectors-bundle-parent</artifactId>
-    <version>8.8.12</version>
+    <version>8.8.13-rc1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/connector-runtime/pom.xml
+++ b/connector-runtime/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.camunda.connector</groupId>
     <artifactId>connectors-bundle-parent</artifactId>
-    <version>8.8.13-rc1</version>
+    <version>8.8.13</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/connector-runtime/spring-boot-starter-camunda-connectors/pom.xml
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.camunda.connector</groupId>
     <artifactId>connector-runtime-parent</artifactId>
-    <version>8.8.13-rc1</version>
+    <version>8.8.13</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/connector-runtime/spring-boot-starter-camunda-connectors/pom.xml
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.camunda.connector</groupId>
     <artifactId>connector-runtime-parent</artifactId>
-    <version>8.8.11</version>
+    <version>8.8.12</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/connector-runtime/spring-boot-starter-camunda-connectors/pom.xml
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.camunda.connector</groupId>
     <artifactId>connector-runtime-parent</artifactId>
-    <version>8.8.12</version>
+    <version>8.8.13-rc1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/connector-sdk/core/pom.xml
+++ b/connector-sdk/core/pom.xml
@@ -6,7 +6,7 @@
     <groupId>io.camunda.connector</groupId>
     <artifactId>connector-sdk-parent</artifactId>
     <relativePath>../pom.xml</relativePath>
-    <version>8.8.11</version>
+    <version>8.8.12</version>
   </parent>
 
   <name>Connector SDK Core</name>

--- a/connector-sdk/core/pom.xml
+++ b/connector-sdk/core/pom.xml
@@ -6,7 +6,7 @@
     <groupId>io.camunda.connector</groupId>
     <artifactId>connector-sdk-parent</artifactId>
     <relativePath>../pom.xml</relativePath>
-    <version>8.8.12</version>
+    <version>8.8.13-rc1</version>
   </parent>
 
   <name>Connector SDK Core</name>

--- a/connector-sdk/core/pom.xml
+++ b/connector-sdk/core/pom.xml
@@ -6,7 +6,7 @@
     <groupId>io.camunda.connector</groupId>
     <artifactId>connector-sdk-parent</artifactId>
     <relativePath>../pom.xml</relativePath>
-    <version>8.8.13-rc1</version>
+    <version>8.8.13</version>
   </parent>
 
   <name>Connector SDK Core</name>

--- a/connector-sdk/pom.xml
+++ b/connector-sdk/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.camunda.connector</groupId>
     <artifactId>connectors-bundle-parent</artifactId>
-    <version>8.8.11</version>
+    <version>8.8.12</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/connector-sdk/pom.xml
+++ b/connector-sdk/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.camunda.connector</groupId>
     <artifactId>connectors-bundle-parent</artifactId>
-    <version>8.8.12</version>
+    <version>8.8.13-rc1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/connector-sdk/pom.xml
+++ b/connector-sdk/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.camunda.connector</groupId>
     <artifactId>connectors-bundle-parent</artifactId>
-    <version>8.8.13-rc1</version>
+    <version>8.8.13</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/connector-sdk/test/pom.xml
+++ b/connector-sdk/test/pom.xml
@@ -6,7 +6,7 @@
     <groupId>io.camunda.connector</groupId>
     <artifactId>connector-sdk-parent</artifactId>
     <relativePath>../pom.xml</relativePath>
-    <version>8.8.11</version>
+    <version>8.8.12</version>
   </parent>
 
   <name>Connector SDK Test</name>

--- a/connector-sdk/test/pom.xml
+++ b/connector-sdk/test/pom.xml
@@ -6,7 +6,7 @@
     <groupId>io.camunda.connector</groupId>
     <artifactId>connector-sdk-parent</artifactId>
     <relativePath>../pom.xml</relativePath>
-    <version>8.8.13-rc1</version>
+    <version>8.8.13</version>
   </parent>
 
   <name>Connector SDK Test</name>

--- a/connector-sdk/test/pom.xml
+++ b/connector-sdk/test/pom.xml
@@ -6,7 +6,7 @@
     <groupId>io.camunda.connector</groupId>
     <artifactId>connector-sdk-parent</artifactId>
     <relativePath>../pom.xml</relativePath>
-    <version>8.8.12</version>
+    <version>8.8.13-rc1</version>
   </parent>
 
   <name>Connector SDK Test</name>

--- a/connector-sdk/validation/pom.xml
+++ b/connector-sdk/validation/pom.xml
@@ -8,7 +8,7 @@
     <groupId>io.camunda.connector</groupId>
     <artifactId>connector-sdk-parent</artifactId>
     <relativePath>../pom.xml</relativePath>
-    <version>8.8.12</version>
+    <version>8.8.13-rc1</version>
   </parent>
 
   <name>Connector SDK Validation</name>

--- a/connector-sdk/validation/pom.xml
+++ b/connector-sdk/validation/pom.xml
@@ -8,7 +8,7 @@
     <groupId>io.camunda.connector</groupId>
     <artifactId>connector-sdk-parent</artifactId>
     <relativePath>../pom.xml</relativePath>
-    <version>8.8.11</version>
+    <version>8.8.12</version>
   </parent>
 
   <name>Connector SDK Validation</name>

--- a/connector-sdk/validation/pom.xml
+++ b/connector-sdk/validation/pom.xml
@@ -8,7 +8,7 @@
     <groupId>io.camunda.connector</groupId>
     <artifactId>connector-sdk-parent</artifactId>
     <relativePath>../pom.xml</relativePath>
-    <version>8.8.13-rc1</version>
+    <version>8.8.13</version>
   </parent>
 
   <name>Connector SDK Validation</name>

--- a/connectors-e2e-test/connectors-e2e-email/pom.xml
+++ b/connectors-e2e-test/connectors-e2e-email/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.camunda.connector</groupId>
         <artifactId>connectors-e2e-test-parent</artifactId>
-        <version>8.8.11</version>
+        <version>8.8.12</version>
     </parent>
 
     <artifactId>connectors-e2e-email</artifactId>

--- a/connectors-e2e-test/connectors-e2e-email/pom.xml
+++ b/connectors-e2e-test/connectors-e2e-email/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.camunda.connector</groupId>
         <artifactId>connectors-e2e-test-parent</artifactId>
-        <version>8.8.12</version>
+        <version>8.8.13-rc1</version>
     </parent>
 
     <artifactId>connectors-e2e-email</artifactId>

--- a/connectors-e2e-test/connectors-e2e-email/pom.xml
+++ b/connectors-e2e-test/connectors-e2e-email/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.camunda.connector</groupId>
         <artifactId>connectors-e2e-test-parent</artifactId>
-        <version>8.8.13-rc1</version>
+        <version>8.8.13</version>
     </parent>
 
     <artifactId>connectors-e2e-email</artifactId>

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/pom.xml
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/pom.xml
@@ -6,7 +6,7 @@
     <groupId>io.camunda.connector</groupId>
     <artifactId>connectors-e2e-test-parent</artifactId>
     <relativePath>../pom.xml</relativePath>
-    <version>8.8.11</version>
+    <version>8.8.12</version>
   </parent>
 
   <description>Agentic AI E2E Tests</description>

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/pom.xml
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/pom.xml
@@ -6,7 +6,7 @@
     <groupId>io.camunda.connector</groupId>
     <artifactId>connectors-e2e-test-parent</artifactId>
     <relativePath>../pom.xml</relativePath>
-    <version>8.8.13-rc1</version>
+    <version>8.8.13</version>
   </parent>
 
   <description>Agentic AI E2E Tests</description>

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/pom.xml
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/pom.xml
@@ -6,7 +6,7 @@
     <groupId>io.camunda.connector</groupId>
     <artifactId>connectors-e2e-test-parent</artifactId>
     <relativePath>../pom.xml</relativePath>
-    <version>8.8.12</version>
+    <version>8.8.13-rc1</version>
   </parent>
 
   <description>Agentic AI E2E Tests</description>

--- a/connectors-e2e-test/connectors-e2e-test-automation-anywhere/pom.xml
+++ b/connectors-e2e-test/connectors-e2e-test-automation-anywhere/pom.xml
@@ -6,7 +6,7 @@
     <groupId>io.camunda.connector</groupId>
     <artifactId>connectors-e2e-test-parent</artifactId>
     <relativePath>../pom.xml</relativePath>
-    <version>8.8.12</version>
+    <version>8.8.13-rc1</version>
   </parent>
 
   <description>Tests</description>

--- a/connectors-e2e-test/connectors-e2e-test-automation-anywhere/pom.xml
+++ b/connectors-e2e-test/connectors-e2e-test-automation-anywhere/pom.xml
@@ -6,7 +6,7 @@
     <groupId>io.camunda.connector</groupId>
     <artifactId>connectors-e2e-test-parent</artifactId>
     <relativePath>../pom.xml</relativePath>
-    <version>8.8.13-rc1</version>
+    <version>8.8.13</version>
   </parent>
 
   <description>Tests</description>

--- a/connectors-e2e-test/connectors-e2e-test-automation-anywhere/pom.xml
+++ b/connectors-e2e-test/connectors-e2e-test-automation-anywhere/pom.xml
@@ -6,7 +6,7 @@
     <groupId>io.camunda.connector</groupId>
     <artifactId>connectors-e2e-test-parent</artifactId>
     <relativePath>../pom.xml</relativePath>
-    <version>8.8.11</version>
+    <version>8.8.12</version>
   </parent>
 
   <description>Tests</description>

--- a/connectors-e2e-test/connectors-e2e-test-aws/connectors-e2e-test-aws-base/pom.xml
+++ b/connectors-e2e-test/connectors-e2e-test-aws/connectors-e2e-test-aws-base/pom.xml
@@ -8,7 +8,7 @@
         <groupId>io.camunda.connector</groupId>
         <artifactId>connectors-e2e-test-aws-parent</artifactId>
         <relativePath>../pom.xml</relativePath>
-        <version>8.8.13-rc1</version>
+        <version>8.8.13</version>
     </parent>
 
     <name>connectors-e2e-test-aws-base</name>

--- a/connectors-e2e-test/connectors-e2e-test-aws/connectors-e2e-test-aws-base/pom.xml
+++ b/connectors-e2e-test/connectors-e2e-test-aws/connectors-e2e-test-aws-base/pom.xml
@@ -8,7 +8,7 @@
         <groupId>io.camunda.connector</groupId>
         <artifactId>connectors-e2e-test-aws-parent</artifactId>
         <relativePath>../pom.xml</relativePath>
-        <version>8.8.11</version>
+        <version>8.8.12</version>
     </parent>
 
     <name>connectors-e2e-test-aws-base</name>

--- a/connectors-e2e-test/connectors-e2e-test-aws/connectors-e2e-test-aws-base/pom.xml
+++ b/connectors-e2e-test/connectors-e2e-test-aws/connectors-e2e-test-aws-base/pom.xml
@@ -8,7 +8,7 @@
         <groupId>io.camunda.connector</groupId>
         <artifactId>connectors-e2e-test-aws-parent</artifactId>
         <relativePath>../pom.xml</relativePath>
-        <version>8.8.12</version>
+        <version>8.8.13-rc1</version>
     </parent>
 
     <name>connectors-e2e-test-aws-base</name>

--- a/connectors-e2e-test/connectors-e2e-test-aws/connectors-e2e-test-aws-event-bridge/pom.xml
+++ b/connectors-e2e-test/connectors-e2e-test-aws/connectors-e2e-test-aws-event-bridge/pom.xml
@@ -7,7 +7,7 @@
         <groupId>io.camunda.connector</groupId>
         <artifactId>connectors-e2e-test-aws-parent</artifactId>
         <relativePath>../pom.xml</relativePath>
-        <version>8.8.13-rc1</version>
+        <version>8.8.13</version>
     </parent>
 
     <artifactId>connectors-e2e-test-aws-event-bridge</artifactId>

--- a/connectors-e2e-test/connectors-e2e-test-aws/connectors-e2e-test-aws-event-bridge/pom.xml
+++ b/connectors-e2e-test/connectors-e2e-test-aws/connectors-e2e-test-aws-event-bridge/pom.xml
@@ -7,7 +7,7 @@
         <groupId>io.camunda.connector</groupId>
         <artifactId>connectors-e2e-test-aws-parent</artifactId>
         <relativePath>../pom.xml</relativePath>
-        <version>8.8.12</version>
+        <version>8.8.13-rc1</version>
     </parent>
 
     <artifactId>connectors-e2e-test-aws-event-bridge</artifactId>

--- a/connectors-e2e-test/connectors-e2e-test-aws/connectors-e2e-test-aws-event-bridge/pom.xml
+++ b/connectors-e2e-test/connectors-e2e-test-aws/connectors-e2e-test-aws-event-bridge/pom.xml
@@ -7,7 +7,7 @@
         <groupId>io.camunda.connector</groupId>
         <artifactId>connectors-e2e-test-aws-parent</artifactId>
         <relativePath>../pom.xml</relativePath>
-        <version>8.8.11</version>
+        <version>8.8.12</version>
     </parent>
 
     <artifactId>connectors-e2e-test-aws-event-bridge</artifactId>

--- a/connectors-e2e-test/connectors-e2e-test-aws/connectors-e2e-test-aws-lambda/pom.xml
+++ b/connectors-e2e-test/connectors-e2e-test-aws/connectors-e2e-test-aws-lambda/pom.xml
@@ -7,7 +7,7 @@
         <groupId>io.camunda.connector</groupId>
         <artifactId>connectors-e2e-test-aws-parent</artifactId>
         <relativePath>../pom.xml</relativePath>
-        <version>8.8.13-rc1</version>
+        <version>8.8.13</version>
     </parent>
 
     <name>connectors-e2e-test-aws-lambda</name>

--- a/connectors-e2e-test/connectors-e2e-test-aws/connectors-e2e-test-aws-lambda/pom.xml
+++ b/connectors-e2e-test/connectors-e2e-test-aws/connectors-e2e-test-aws-lambda/pom.xml
@@ -7,7 +7,7 @@
         <groupId>io.camunda.connector</groupId>
         <artifactId>connectors-e2e-test-aws-parent</artifactId>
         <relativePath>../pom.xml</relativePath>
-        <version>8.8.11</version>
+        <version>8.8.12</version>
     </parent>
 
     <name>connectors-e2e-test-aws-lambda</name>

--- a/connectors-e2e-test/connectors-e2e-test-aws/connectors-e2e-test-aws-lambda/pom.xml
+++ b/connectors-e2e-test/connectors-e2e-test-aws/connectors-e2e-test-aws-lambda/pom.xml
@@ -7,7 +7,7 @@
         <groupId>io.camunda.connector</groupId>
         <artifactId>connectors-e2e-test-aws-parent</artifactId>
         <relativePath>../pom.xml</relativePath>
-        <version>8.8.12</version>
+        <version>8.8.13-rc1</version>
     </parent>
 
     <name>connectors-e2e-test-aws-lambda</name>

--- a/connectors-e2e-test/connectors-e2e-test-aws/connectors-e2e-test-aws-sns/pom.xml
+++ b/connectors-e2e-test/connectors-e2e-test-aws/connectors-e2e-test-aws-sns/pom.xml
@@ -7,7 +7,7 @@
         <groupId>io.camunda.connector</groupId>
         <artifactId>connectors-e2e-test-aws-parent</artifactId>
         <relativePath>../pom.xml</relativePath>
-        <version>8.8.11</version>
+        <version>8.8.12</version>
     </parent>
 
     <name>connectors-e2e-test-aws-sns</name>

--- a/connectors-e2e-test/connectors-e2e-test-aws/connectors-e2e-test-aws-sns/pom.xml
+++ b/connectors-e2e-test/connectors-e2e-test-aws/connectors-e2e-test-aws-sns/pom.xml
@@ -7,7 +7,7 @@
         <groupId>io.camunda.connector</groupId>
         <artifactId>connectors-e2e-test-aws-parent</artifactId>
         <relativePath>../pom.xml</relativePath>
-        <version>8.8.13-rc1</version>
+        <version>8.8.13</version>
     </parent>
 
     <name>connectors-e2e-test-aws-sns</name>

--- a/connectors-e2e-test/connectors-e2e-test-aws/connectors-e2e-test-aws-sns/pom.xml
+++ b/connectors-e2e-test/connectors-e2e-test-aws/connectors-e2e-test-aws-sns/pom.xml
@@ -7,7 +7,7 @@
         <groupId>io.camunda.connector</groupId>
         <artifactId>connectors-e2e-test-aws-parent</artifactId>
         <relativePath>../pom.xml</relativePath>
-        <version>8.8.12</version>
+        <version>8.8.13-rc1</version>
     </parent>
 
     <name>connectors-e2e-test-aws-sns</name>

--- a/connectors-e2e-test/connectors-e2e-test-aws/connectors-e2e-test-aws-sqs/pom.xml
+++ b/connectors-e2e-test/connectors-e2e-test-aws/connectors-e2e-test-aws-sqs/pom.xml
@@ -7,7 +7,7 @@
         <groupId>io.camunda.connector</groupId>
         <artifactId>connectors-e2e-test-aws-parent</artifactId>
         <relativePath>../pom.xml</relativePath>
-        <version>8.8.11</version>
+        <version>8.8.12</version>
     </parent>
 
     <name>connectors-e2e-test-aws-sqs</name>

--- a/connectors-e2e-test/connectors-e2e-test-aws/connectors-e2e-test-aws-sqs/pom.xml
+++ b/connectors-e2e-test/connectors-e2e-test-aws/connectors-e2e-test-aws-sqs/pom.xml
@@ -7,7 +7,7 @@
         <groupId>io.camunda.connector</groupId>
         <artifactId>connectors-e2e-test-aws-parent</artifactId>
         <relativePath>../pom.xml</relativePath>
-        <version>8.8.12</version>
+        <version>8.8.13-rc1</version>
     </parent>
 
     <name>connectors-e2e-test-aws-sqs</name>

--- a/connectors-e2e-test/connectors-e2e-test-aws/connectors-e2e-test-aws-sqs/pom.xml
+++ b/connectors-e2e-test/connectors-e2e-test-aws/connectors-e2e-test-aws-sqs/pom.xml
@@ -7,7 +7,7 @@
         <groupId>io.camunda.connector</groupId>
         <artifactId>connectors-e2e-test-aws-parent</artifactId>
         <relativePath>../pom.xml</relativePath>
-        <version>8.8.13-rc1</version>
+        <version>8.8.13</version>
     </parent>
 
     <name>connectors-e2e-test-aws-sqs</name>

--- a/connectors-e2e-test/connectors-e2e-test-aws/pom.xml
+++ b/connectors-e2e-test/connectors-e2e-test-aws/pom.xml
@@ -6,13 +6,13 @@
     <groupId>io.camunda.connector</groupId>
     <artifactId>connectors-e2e-test-parent</artifactId>
     <relativePath>../pom.xml</relativePath>
-    <version>8.8.11</version>
+    <version>8.8.12</version>
   </parent>
 
   <artifactId>connectors-e2e-test-aws-parent</artifactId>
   <packaging>pom</packaging>
   <name>connectors-e2e-test-aws-parent</name>
-  <version>8.8.11</version>
+  <version>8.8.12</version>
 
   <modules>
     <module>connectors-e2e-test-aws-base</module>

--- a/connectors-e2e-test/connectors-e2e-test-aws/pom.xml
+++ b/connectors-e2e-test/connectors-e2e-test-aws/pom.xml
@@ -6,13 +6,13 @@
     <groupId>io.camunda.connector</groupId>
     <artifactId>connectors-e2e-test-parent</artifactId>
     <relativePath>../pom.xml</relativePath>
-    <version>8.8.12</version>
+    <version>8.8.13-rc1</version>
   </parent>
 
   <artifactId>connectors-e2e-test-aws-parent</artifactId>
   <packaging>pom</packaging>
   <name>connectors-e2e-test-aws-parent</name>
-  <version>8.8.12</version>
+  <version>8.8.13-rc1</version>
 
   <modules>
     <module>connectors-e2e-test-aws-base</module>

--- a/connectors-e2e-test/connectors-e2e-test-aws/pom.xml
+++ b/connectors-e2e-test/connectors-e2e-test-aws/pom.xml
@@ -6,13 +6,13 @@
     <groupId>io.camunda.connector</groupId>
     <artifactId>connectors-e2e-test-parent</artifactId>
     <relativePath>../pom.xml</relativePath>
-    <version>8.8.13-rc1</version>
+    <version>8.8.13</version>
   </parent>
 
   <artifactId>connectors-e2e-test-aws-parent</artifactId>
   <packaging>pom</packaging>
   <name>connectors-e2e-test-aws-parent</name>
-  <version>8.8.13-rc1</version>
+  <version>8.8.13</version>
 
   <modules>
     <module>connectors-e2e-test-aws-base</module>

--- a/connectors-e2e-test/connectors-e2e-test-base/pom.xml
+++ b/connectors-e2e-test/connectors-e2e-test-base/pom.xml
@@ -6,7 +6,7 @@
         <groupId>io.camunda.connector</groupId>
         <artifactId>connectors-e2e-test-parent</artifactId>
         <relativePath>../pom.xml</relativePath>
-        <version>8.8.11</version>
+        <version>8.8.12</version>
     </parent>
 
     <description>Connectors Test Base project</description>

--- a/connectors-e2e-test/connectors-e2e-test-base/pom.xml
+++ b/connectors-e2e-test/connectors-e2e-test-base/pom.xml
@@ -6,7 +6,7 @@
         <groupId>io.camunda.connector</groupId>
         <artifactId>connectors-e2e-test-parent</artifactId>
         <relativePath>../pom.xml</relativePath>
-        <version>8.8.12</version>
+        <version>8.8.13-rc1</version>
     </parent>
 
     <description>Connectors Test Base project</description>

--- a/connectors-e2e-test/connectors-e2e-test-base/pom.xml
+++ b/connectors-e2e-test/connectors-e2e-test-base/pom.xml
@@ -6,7 +6,7 @@
         <groupId>io.camunda.connector</groupId>
         <artifactId>connectors-e2e-test-parent</artifactId>
         <relativePath>../pom.xml</relativePath>
-        <version>8.8.13-rc1</version>
+        <version>8.8.13</version>
     </parent>
 
     <description>Connectors Test Base project</description>

--- a/connectors-e2e-test/connectors-e2e-test-csv/pom.xml
+++ b/connectors-e2e-test/connectors-e2e-test-csv/pom.xml
@@ -6,7 +6,7 @@
     <groupId>io.camunda.connector</groupId>
     <artifactId>connectors-e2e-test-parent</artifactId>
     <relativePath>../pom.xml</relativePath>
-    <version>8.8.11</version>
+    <version>8.8.12</version>
   </parent>
 
   <description>CSV Connector tests</description>

--- a/connectors-e2e-test/connectors-e2e-test-csv/pom.xml
+++ b/connectors-e2e-test/connectors-e2e-test-csv/pom.xml
@@ -6,7 +6,7 @@
     <groupId>io.camunda.connector</groupId>
     <artifactId>connectors-e2e-test-parent</artifactId>
     <relativePath>../pom.xml</relativePath>
-    <version>8.8.12</version>
+    <version>8.8.13-rc1</version>
   </parent>
 
   <description>CSV Connector tests</description>

--- a/connectors-e2e-test/connectors-e2e-test-csv/pom.xml
+++ b/connectors-e2e-test/connectors-e2e-test-csv/pom.xml
@@ -6,7 +6,7 @@
     <groupId>io.camunda.connector</groupId>
     <artifactId>connectors-e2e-test-parent</artifactId>
     <relativePath>../pom.xml</relativePath>
-    <version>8.8.13-rc1</version>
+    <version>8.8.13</version>
   </parent>
 
   <description>CSV Connector tests</description>

--- a/connectors-e2e-test/connectors-e2e-test-easy-post/pom.xml
+++ b/connectors-e2e-test/connectors-e2e-test-easy-post/pom.xml
@@ -6,7 +6,7 @@
     <groupId>io.camunda.connector</groupId>
     <artifactId>connectors-e2e-test-parent</artifactId>
     <relativePath>../pom.xml</relativePath>
-    <version>8.8.12</version>
+    <version>8.8.13-rc1</version>
   </parent>
 
   <description>Tests</description>

--- a/connectors-e2e-test/connectors-e2e-test-easy-post/pom.xml
+++ b/connectors-e2e-test/connectors-e2e-test-easy-post/pom.xml
@@ -6,7 +6,7 @@
     <groupId>io.camunda.connector</groupId>
     <artifactId>connectors-e2e-test-parent</artifactId>
     <relativePath>../pom.xml</relativePath>
-    <version>8.8.13-rc1</version>
+    <version>8.8.13</version>
   </parent>
 
   <description>Tests</description>

--- a/connectors-e2e-test/connectors-e2e-test-easy-post/pom.xml
+++ b/connectors-e2e-test/connectors-e2e-test-easy-post/pom.xml
@@ -6,7 +6,7 @@
     <groupId>io.camunda.connector</groupId>
     <artifactId>connectors-e2e-test-parent</artifactId>
     <relativePath>../pom.xml</relativePath>
-    <version>8.8.11</version>
+    <version>8.8.12</version>
   </parent>
 
   <description>Tests</description>

--- a/connectors-e2e-test/connectors-e2e-test-http/pom.xml
+++ b/connectors-e2e-test/connectors-e2e-test-http/pom.xml
@@ -6,7 +6,7 @@
     <groupId>io.camunda.connector</groupId>
     <artifactId>connectors-e2e-test-parent</artifactId>
     <relativePath>../pom.xml</relativePath>
-    <version>8.8.12</version>
+    <version>8.8.13-rc1</version>
   </parent>
 
   <description>Tests</description>

--- a/connectors-e2e-test/connectors-e2e-test-http/pom.xml
+++ b/connectors-e2e-test/connectors-e2e-test-http/pom.xml
@@ -6,7 +6,7 @@
     <groupId>io.camunda.connector</groupId>
     <artifactId>connectors-e2e-test-parent</artifactId>
     <relativePath>../pom.xml</relativePath>
-    <version>8.8.13-rc1</version>
+    <version>8.8.13</version>
   </parent>
 
   <description>Tests</description>

--- a/connectors-e2e-test/connectors-e2e-test-http/pom.xml
+++ b/connectors-e2e-test/connectors-e2e-test-http/pom.xml
@@ -6,7 +6,7 @@
     <groupId>io.camunda.connector</groupId>
     <artifactId>connectors-e2e-test-parent</artifactId>
     <relativePath>../pom.xml</relativePath>
-    <version>8.8.11</version>
+    <version>8.8.12</version>
   </parent>
 
   <description>Tests</description>

--- a/connectors-e2e-test/connectors-e2e-test-kafka/pom.xml
+++ b/connectors-e2e-test/connectors-e2e-test-kafka/pom.xml
@@ -6,7 +6,7 @@
     <groupId>io.camunda.connector</groupId>
     <artifactId>connectors-e2e-test-parent</artifactId>
     <relativePath>../pom.xml</relativePath>
-    <version>8.8.12</version>
+    <version>8.8.13-rc1</version>
   </parent>
 
   <description>Tests</description>

--- a/connectors-e2e-test/connectors-e2e-test-kafka/pom.xml
+++ b/connectors-e2e-test/connectors-e2e-test-kafka/pom.xml
@@ -6,7 +6,7 @@
     <groupId>io.camunda.connector</groupId>
     <artifactId>connectors-e2e-test-parent</artifactId>
     <relativePath>../pom.xml</relativePath>
-    <version>8.8.13-rc1</version>
+    <version>8.8.13</version>
   </parent>
 
   <description>Tests</description>

--- a/connectors-e2e-test/connectors-e2e-test-kafka/pom.xml
+++ b/connectors-e2e-test/connectors-e2e-test-kafka/pom.xml
@@ -6,7 +6,7 @@
     <groupId>io.camunda.connector</groupId>
     <artifactId>connectors-e2e-test-parent</artifactId>
     <relativePath>../pom.xml</relativePath>
-    <version>8.8.11</version>
+    <version>8.8.12</version>
   </parent>
 
   <description>Tests</description>

--- a/connectors-e2e-test/connectors-e2e-test-message/pom.xml
+++ b/connectors-e2e-test/connectors-e2e-test-message/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>io.camunda.connector</groupId>
     <artifactId>connectors-e2e-test-parent</artifactId>
-    <version>8.8.11</version>
+    <version>8.8.12</version>
   </parent>
   
   <description>Tests</description>

--- a/connectors-e2e-test/connectors-e2e-test-message/pom.xml
+++ b/connectors-e2e-test/connectors-e2e-test-message/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>io.camunda.connector</groupId>
     <artifactId>connectors-e2e-test-parent</artifactId>
-    <version>8.8.12</version>
+    <version>8.8.13-rc1</version>
   </parent>
   
   <description>Tests</description>

--- a/connectors-e2e-test/connectors-e2e-test-message/pom.xml
+++ b/connectors-e2e-test/connectors-e2e-test-message/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>io.camunda.connector</groupId>
     <artifactId>connectors-e2e-test-parent</artifactId>
-    <version>8.8.13-rc1</version>
+    <version>8.8.13</version>
   </parent>
   
   <description>Tests</description>

--- a/connectors-e2e-test/connectors-e2e-test-rabbitmq/pom.xml
+++ b/connectors-e2e-test/connectors-e2e-test-rabbitmq/pom.xml
@@ -6,7 +6,7 @@
     <groupId>io.camunda.connector</groupId>
     <artifactId>connectors-e2e-test-parent</artifactId>
     <relativePath>../pom.xml</relativePath>
-    <version>8.8.12</version>
+    <version>8.8.13-rc1</version>
   </parent>
 
   <description>Tests</description>

--- a/connectors-e2e-test/connectors-e2e-test-rabbitmq/pom.xml
+++ b/connectors-e2e-test/connectors-e2e-test-rabbitmq/pom.xml
@@ -6,7 +6,7 @@
     <groupId>io.camunda.connector</groupId>
     <artifactId>connectors-e2e-test-parent</artifactId>
     <relativePath>../pom.xml</relativePath>
-    <version>8.8.13-rc1</version>
+    <version>8.8.13</version>
   </parent>
 
   <description>Tests</description>

--- a/connectors-e2e-test/connectors-e2e-test-rabbitmq/pom.xml
+++ b/connectors-e2e-test/connectors-e2e-test-rabbitmq/pom.xml
@@ -6,7 +6,7 @@
     <groupId>io.camunda.connector</groupId>
     <artifactId>connectors-e2e-test-parent</artifactId>
     <relativePath>../pom.xml</relativePath>
-    <version>8.8.11</version>
+    <version>8.8.12</version>
   </parent>
 
   <description>Tests</description>

--- a/connectors-e2e-test/connectors-e2e-test-servicenow/pom.xml
+++ b/connectors-e2e-test/connectors-e2e-test-servicenow/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.camunda.connector</groupId>
     <artifactId>connectors-e2e-test-parent</artifactId>
-    <version>8.8.11</version>
+    <version>8.8.12</version>
   </parent>
   <artifactId>connectors-e2e-test-servicenow</artifactId>
   <name>Archetype - connectors-e2e-test-servicenow</name>

--- a/connectors-e2e-test/connectors-e2e-test-servicenow/pom.xml
+++ b/connectors-e2e-test/connectors-e2e-test-servicenow/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.camunda.connector</groupId>
     <artifactId>connectors-e2e-test-parent</artifactId>
-    <version>8.8.12</version>
+    <version>8.8.13-rc1</version>
   </parent>
   <artifactId>connectors-e2e-test-servicenow</artifactId>
   <name>Archetype - connectors-e2e-test-servicenow</name>

--- a/connectors-e2e-test/connectors-e2e-test-servicenow/pom.xml
+++ b/connectors-e2e-test/connectors-e2e-test-servicenow/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.camunda.connector</groupId>
     <artifactId>connectors-e2e-test-parent</artifactId>
-    <version>8.8.13-rc1</version>
+    <version>8.8.13</version>
   </parent>
   <artifactId>connectors-e2e-test-servicenow</artifactId>
   <name>Archetype - connectors-e2e-test-servicenow</name>

--- a/connectors-e2e-test/connectors-e2e-test-soap/pom.xml
+++ b/connectors-e2e-test/connectors-e2e-test-soap/pom.xml
@@ -6,7 +6,7 @@
     <groupId>io.camunda.connector</groupId>
     <artifactId>connector-parent</artifactId>
     <relativePath>../../parent/pom.xml</relativePath>
-    <version>8.8.11</version>
+    <version>8.8.12</version>
   </parent>
 
   <description>SOAP Connector tests</description>

--- a/connectors-e2e-test/connectors-e2e-test-soap/pom.xml
+++ b/connectors-e2e-test/connectors-e2e-test-soap/pom.xml
@@ -6,7 +6,7 @@
     <groupId>io.camunda.connector</groupId>
     <artifactId>connector-parent</artifactId>
     <relativePath>../../parent/pom.xml</relativePath>
-    <version>8.8.13-rc1</version>
+    <version>8.8.13</version>
   </parent>
 
   <description>SOAP Connector tests</description>

--- a/connectors-e2e-test/connectors-e2e-test-soap/pom.xml
+++ b/connectors-e2e-test/connectors-e2e-test-soap/pom.xml
@@ -6,7 +6,7 @@
     <groupId>io.camunda.connector</groupId>
     <artifactId>connector-parent</artifactId>
     <relativePath>../../parent/pom.xml</relativePath>
-    <version>8.8.12</version>
+    <version>8.8.13-rc1</version>
   </parent>
 
   <description>SOAP Connector tests</description>

--- a/connectors-e2e-test/pom.xml
+++ b/connectors-e2e-test/pom.xml
@@ -6,7 +6,7 @@
         <groupId>io.camunda.connector</groupId>
         <artifactId>connector-parent</artifactId>
         <relativePath>../parent/pom.xml</relativePath>
-        <version>8.8.11</version>
+        <version>8.8.12</version>
     </parent>
 
     <description>Parent POM for Connectors e2e tests</description>

--- a/connectors-e2e-test/pom.xml
+++ b/connectors-e2e-test/pom.xml
@@ -6,7 +6,7 @@
         <groupId>io.camunda.connector</groupId>
         <artifactId>connector-parent</artifactId>
         <relativePath>../parent/pom.xml</relativePath>
-        <version>8.8.13-rc1</version>
+        <version>8.8.13</version>
     </parent>
 
     <description>Parent POM for Connectors e2e tests</description>

--- a/connectors-e2e-test/pom.xml
+++ b/connectors-e2e-test/pom.xml
@@ -6,7 +6,7 @@
         <groupId>io.camunda.connector</groupId>
         <artifactId>connector-parent</artifactId>
         <relativePath>../parent/pom.xml</relativePath>
-        <version>8.8.12</version>
+        <version>8.8.13-rc1</version>
     </parent>
 
     <description>Parent POM for Connectors e2e tests</description>

--- a/connectors/agentic-ai/pom.xml
+++ b/connectors/agentic-ai/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>io.camunda.connector</groupId>
     <artifactId>connectors-parent</artifactId>
-    <version>8.8.11</version>
+    <version>8.8.12</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/connectors/agentic-ai/pom.xml
+++ b/connectors/agentic-ai/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>io.camunda.connector</groupId>
     <artifactId>connectors-parent</artifactId>
-    <version>8.8.13-rc1</version>
+    <version>8.8.13</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/connectors/agentic-ai/pom.xml
+++ b/connectors/agentic-ai/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>io.camunda.connector</groupId>
     <artifactId>connectors-parent</artifactId>
-    <version>8.8.12</version>
+    <version>8.8.13-rc1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/connectors/automation-anywhere/pom.xml
+++ b/connectors/automation-anywhere/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda.connector</groupId>
     <artifactId>connectors-parent</artifactId>
-    <version>8.8.13-rc1</version>
+    <version>8.8.13</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/connectors/automation-anywhere/pom.xml
+++ b/connectors/automation-anywhere/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda.connector</groupId>
     <artifactId>connectors-parent</artifactId>
-    <version>8.8.12</version>
+    <version>8.8.13-rc1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/connectors/automation-anywhere/pom.xml
+++ b/connectors/automation-anywhere/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda.connector</groupId>
     <artifactId>connectors-parent</artifactId>
-    <version>8.8.11</version>
+    <version>8.8.12</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/connectors/aws/aws-base/pom.xml
+++ b/connectors/aws/aws-base/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.camunda.connector</groupId>
         <artifactId>connector-aws-parent</artifactId>
-        <version>8.8.11</version>
+        <version>8.8.12</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/connectors/aws/aws-base/pom.xml
+++ b/connectors/aws/aws-base/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.camunda.connector</groupId>
         <artifactId>connector-aws-parent</artifactId>
-        <version>8.8.13-rc1</version>
+        <version>8.8.13</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/connectors/aws/aws-base/pom.xml
+++ b/connectors/aws/aws-base/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.camunda.connector</groupId>
         <artifactId>connector-aws-parent</artifactId>
-        <version>8.8.12</version>
+        <version>8.8.13-rc1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/connectors/aws/aws-bedrock/pom.xml
+++ b/connectors/aws/aws-bedrock/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.camunda.connector</groupId>
         <artifactId>connector-aws-parent</artifactId>
-        <version>8.8.11</version>
+        <version>8.8.12</version>
     </parent>
 
 

--- a/connectors/aws/aws-bedrock/pom.xml
+++ b/connectors/aws/aws-bedrock/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.camunda.connector</groupId>
         <artifactId>connector-aws-parent</artifactId>
-        <version>8.8.13-rc1</version>
+        <version>8.8.13</version>
     </parent>
 
 

--- a/connectors/aws/aws-bedrock/pom.xml
+++ b/connectors/aws/aws-bedrock/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.camunda.connector</groupId>
         <artifactId>connector-aws-parent</artifactId>
-        <version>8.8.12</version>
+        <version>8.8.13-rc1</version>
     </parent>
 
 

--- a/connectors/aws/aws-comprehend/pom.xml
+++ b/connectors/aws/aws-comprehend/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda.connector</groupId>
     <artifactId>connector-aws-parent</artifactId>
-    <version>8.8.11</version>
+    <version>8.8.12</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/connectors/aws/aws-comprehend/pom.xml
+++ b/connectors/aws/aws-comprehend/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda.connector</groupId>
     <artifactId>connector-aws-parent</artifactId>
-    <version>8.8.12</version>
+    <version>8.8.13-rc1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/connectors/aws/aws-comprehend/pom.xml
+++ b/connectors/aws/aws-comprehend/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda.connector</groupId>
     <artifactId>connector-aws-parent</artifactId>
-    <version>8.8.13-rc1</version>
+    <version>8.8.13</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/connectors/aws/aws-dynamodb/pom.xml
+++ b/connectors/aws/aws-dynamodb/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.camunda.connector</groupId>
         <artifactId>connector-aws-parent</artifactId>
-        <version>8.8.11</version>
+        <version>8.8.12</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/connectors/aws/aws-dynamodb/pom.xml
+++ b/connectors/aws/aws-dynamodb/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.camunda.connector</groupId>
         <artifactId>connector-aws-parent</artifactId>
-        <version>8.8.13-rc1</version>
+        <version>8.8.13</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/connectors/aws/aws-dynamodb/pom.xml
+++ b/connectors/aws/aws-dynamodb/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.camunda.connector</groupId>
         <artifactId>connector-aws-parent</artifactId>
-        <version>8.8.12</version>
+        <version>8.8.13-rc1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/connectors/aws/aws-eventbridge/pom.xml
+++ b/connectors/aws/aws-eventbridge/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.camunda.connector</groupId>
     <artifactId>connector-aws-parent</artifactId>
-    <version>8.8.13-rc1</version>
+    <version>8.8.13</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/connectors/aws/aws-eventbridge/pom.xml
+++ b/connectors/aws/aws-eventbridge/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.camunda.connector</groupId>
     <artifactId>connector-aws-parent</artifactId>
-    <version>8.8.12</version>
+    <version>8.8.13-rc1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/connectors/aws/aws-eventbridge/pom.xml
+++ b/connectors/aws/aws-eventbridge/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.camunda.connector</groupId>
     <artifactId>connector-aws-parent</artifactId>
-    <version>8.8.11</version>
+    <version>8.8.12</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/connectors/aws/aws-lambda/pom.xml
+++ b/connectors/aws/aws-lambda/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.camunda.connector</groupId>
     <artifactId>connector-aws-parent</artifactId>
-    <version>8.8.13-rc1</version>
+    <version>8.8.13</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/connectors/aws/aws-lambda/pom.xml
+++ b/connectors/aws/aws-lambda/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.camunda.connector</groupId>
     <artifactId>connector-aws-parent</artifactId>
-    <version>8.8.12</version>
+    <version>8.8.13-rc1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/connectors/aws/aws-lambda/pom.xml
+++ b/connectors/aws/aws-lambda/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.camunda.connector</groupId>
     <artifactId>connector-aws-parent</artifactId>
-    <version>8.8.11</version>
+    <version>8.8.12</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/connectors/aws/aws-s3/pom.xml
+++ b/connectors/aws/aws-s3/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.camunda.connector</groupId>
         <artifactId>connectors-parent</artifactId>
-        <version>8.8.12</version>
+        <version>8.8.13-rc1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/connectors/aws/aws-s3/pom.xml
+++ b/connectors/aws/aws-s3/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.camunda.connector</groupId>
         <artifactId>connectors-parent</artifactId>
-        <version>8.8.11</version>
+        <version>8.8.12</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/connectors/aws/aws-s3/pom.xml
+++ b/connectors/aws/aws-s3/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.camunda.connector</groupId>
         <artifactId>connectors-parent</artifactId>
-        <version>8.8.13-rc1</version>
+        <version>8.8.13</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/connectors/aws/aws-sagemaker/pom.xml
+++ b/connectors/aws/aws-sagemaker/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda.connector</groupId>
     <artifactId>connector-aws-parent</artifactId>
-    <version>8.8.11</version>
+    <version>8.8.12</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/connectors/aws/aws-sagemaker/pom.xml
+++ b/connectors/aws/aws-sagemaker/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda.connector</groupId>
     <artifactId>connector-aws-parent</artifactId>
-    <version>8.8.12</version>
+    <version>8.8.13-rc1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/connectors/aws/aws-sagemaker/pom.xml
+++ b/connectors/aws/aws-sagemaker/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda.connector</groupId>
     <artifactId>connector-aws-parent</artifactId>
-    <version>8.8.13-rc1</version>
+    <version>8.8.13</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/connectors/aws/aws-sns/pom.xml
+++ b/connectors/aws/aws-sns/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda.connector</groupId>
     <artifactId>connector-aws-parent</artifactId>
-    <version>8.8.11</version>
+    <version>8.8.12</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/connectors/aws/aws-sns/pom.xml
+++ b/connectors/aws/aws-sns/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda.connector</groupId>
     <artifactId>connector-aws-parent</artifactId>
-    <version>8.8.12</version>
+    <version>8.8.13-rc1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/connectors/aws/aws-sns/pom.xml
+++ b/connectors/aws/aws-sns/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda.connector</groupId>
     <artifactId>connector-aws-parent</artifactId>
-    <version>8.8.13-rc1</version>
+    <version>8.8.13</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/connectors/aws/aws-sqs/pom.xml
+++ b/connectors/aws/aws-sqs/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda.connector</groupId>
     <artifactId>connector-aws-parent</artifactId>
-    <version>8.8.11</version>
+    <version>8.8.12</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/connectors/aws/aws-sqs/pom.xml
+++ b/connectors/aws/aws-sqs/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda.connector</groupId>
     <artifactId>connector-aws-parent</artifactId>
-    <version>8.8.12</version>
+    <version>8.8.13-rc1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/connectors/aws/aws-sqs/pom.xml
+++ b/connectors/aws/aws-sqs/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda.connector</groupId>
     <artifactId>connector-aws-parent</artifactId>
-    <version>8.8.13-rc1</version>
+    <version>8.8.13</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/connectors/aws/aws-textract/pom.xml
+++ b/connectors/aws/aws-textract/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda.connector</groupId>
     <artifactId>connector-aws-parent</artifactId>
-    <version>8.8.11</version>
+    <version>8.8.12</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/connectors/aws/aws-textract/pom.xml
+++ b/connectors/aws/aws-textract/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda.connector</groupId>
     <artifactId>connector-aws-parent</artifactId>
-    <version>8.8.12</version>
+    <version>8.8.13-rc1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/connectors/aws/aws-textract/pom.xml
+++ b/connectors/aws/aws-textract/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda.connector</groupId>
     <artifactId>connector-aws-parent</artifactId>
-    <version>8.8.13-rc1</version>
+    <version>8.8.13</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/connectors/aws/pom.xml
+++ b/connectors/aws/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.camunda.connector</groupId>
     <artifactId>connectors-parent</artifactId>
-    <version>8.8.12</version>
+    <version>8.8.13-rc1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/connectors/aws/pom.xml
+++ b/connectors/aws/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.camunda.connector</groupId>
     <artifactId>connectors-parent</artifactId>
-    <version>8.8.13-rc1</version>
+    <version>8.8.13</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/connectors/aws/pom.xml
+++ b/connectors/aws/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.camunda.connector</groupId>
     <artifactId>connectors-parent</artifactId>
-    <version>8.8.11</version>
+    <version>8.8.12</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/connectors/box/pom.xml
+++ b/connectors/box/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.camunda.connector</groupId>
     <artifactId>connectors-parent</artifactId>
-    <version>8.8.12</version>
+    <version>8.8.13-rc1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/connectors/box/pom.xml
+++ b/connectors/box/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.camunda.connector</groupId>
     <artifactId>connectors-parent</artifactId>
-    <version>8.8.11</version>
+    <version>8.8.12</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/connectors/box/pom.xml
+++ b/connectors/box/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.camunda.connector</groupId>
     <artifactId>connectors-parent</artifactId>
-    <version>8.8.13-rc1</version>
+    <version>8.8.13</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/connectors/camunda-message/pom.xml
+++ b/connectors/camunda-message/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda.connector</groupId>
     <artifactId>connectors-parent</artifactId>
-    <version>8.8.11</version>
+    <version>8.8.12</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>connector-message</artifactId>

--- a/connectors/camunda-message/pom.xml
+++ b/connectors/camunda-message/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda.connector</groupId>
     <artifactId>connectors-parent</artifactId>
-    <version>8.8.12</version>
+    <version>8.8.13-rc1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>connector-message</artifactId>

--- a/connectors/camunda-message/pom.xml
+++ b/connectors/camunda-message/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda.connector</groupId>
     <artifactId>connectors-parent</artifactId>
-    <version>8.8.13-rc1</version>
+    <version>8.8.13</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>connector-message</artifactId>

--- a/connectors/csv/pom.xml
+++ b/connectors/csv/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.camunda.connector</groupId>
     <artifactId>connectors-parent</artifactId>
-    <version>8.8.12</version>
+    <version>8.8.13-rc1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/connectors/csv/pom.xml
+++ b/connectors/csv/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.camunda.connector</groupId>
     <artifactId>connectors-parent</artifactId>
-    <version>8.8.11</version>
+    <version>8.8.12</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/connectors/csv/pom.xml
+++ b/connectors/csv/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.camunda.connector</groupId>
     <artifactId>connectors-parent</artifactId>
-    <version>8.8.13-rc1</version>
+    <version>8.8.13</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/connectors/email/pom.xml
+++ b/connectors/email/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.camunda.connector</groupId>
         <artifactId>connectors-parent</artifactId>
-        <version>8.8.11</version>
+        <version>8.8.12</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/connectors/email/pom.xml
+++ b/connectors/email/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.camunda.connector</groupId>
         <artifactId>connectors-parent</artifactId>
-        <version>8.8.13-rc1</version>
+        <version>8.8.13</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/connectors/email/pom.xml
+++ b/connectors/email/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.camunda.connector</groupId>
         <artifactId>connectors-parent</artifactId>
-        <version>8.8.12</version>
+        <version>8.8.13-rc1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/connectors/embeddings-vector-database/pom.xml
+++ b/connectors/embeddings-vector-database/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.camunda.connector</groupId>
     <artifactId>connectors-parent</artifactId>
-    <version>8.8.12</version>
+    <version>8.8.13-rc1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/connectors/embeddings-vector-database/pom.xml
+++ b/connectors/embeddings-vector-database/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.camunda.connector</groupId>
     <artifactId>connectors-parent</artifactId>
-    <version>8.8.11</version>
+    <version>8.8.12</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/connectors/embeddings-vector-database/pom.xml
+++ b/connectors/embeddings-vector-database/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.camunda.connector</groupId>
     <artifactId>connectors-parent</artifactId>
-    <version>8.8.13-rc1</version>
+    <version>8.8.13</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/connectors/google/google-base/pom.xml
+++ b/connectors/google/google-base/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.camunda.connector</groupId>
         <artifactId>connector-google-parent</artifactId>
-        <version>8.8.13-rc1</version>
+        <version>8.8.13</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/connectors/google/google-base/pom.xml
+++ b/connectors/google/google-base/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.camunda.connector</groupId>
         <artifactId>connector-google-parent</artifactId>
-        <version>8.8.12</version>
+        <version>8.8.13-rc1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/connectors/google/google-base/pom.xml
+++ b/connectors/google/google-base/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.camunda.connector</groupId>
         <artifactId>connector-google-parent</artifactId>
-        <version>8.8.11</version>
+        <version>8.8.12</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/connectors/google/google-drive/pom.xml
+++ b/connectors/google/google-drive/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.camunda.connector</groupId>
     <artifactId>connector-google-parent</artifactId>
-    <version>8.8.12</version>
+    <version>8.8.13-rc1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/connectors/google/google-drive/pom.xml
+++ b/connectors/google/google-drive/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.camunda.connector</groupId>
     <artifactId>connector-google-parent</artifactId>
-    <version>8.8.11</version>
+    <version>8.8.12</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/connectors/google/google-drive/pom.xml
+++ b/connectors/google/google-drive/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.camunda.connector</groupId>
     <artifactId>connector-google-parent</artifactId>
-    <version>8.8.13-rc1</version>
+    <version>8.8.13</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/connectors/google/google-gcs/pom.xml
+++ b/connectors/google/google-gcs/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>io.camunda.connector</groupId>
     <artifactId>connectors-parent</artifactId>
-    <version>8.8.12</version>
+    <version>8.8.13-rc1</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/connectors/google/google-gcs/pom.xml
+++ b/connectors/google/google-gcs/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>io.camunda.connector</groupId>
     <artifactId>connectors-parent</artifactId>
-    <version>8.8.11</version>
+    <version>8.8.12</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/connectors/google/google-gcs/pom.xml
+++ b/connectors/google/google-gcs/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>io.camunda.connector</groupId>
     <artifactId>connectors-parent</artifactId>
-    <version>8.8.13-rc1</version>
+    <version>8.8.13</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/connectors/google/google-gemini/pom.xml
+++ b/connectors/google/google-gemini/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.camunda.connector</groupId>
         <artifactId>connector-google-parent</artifactId>
-        <version>8.8.12</version>
+        <version>8.8.13-rc1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/connectors/google/google-gemini/pom.xml
+++ b/connectors/google/google-gemini/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.camunda.connector</groupId>
         <artifactId>connector-google-parent</artifactId>
-        <version>8.8.11</version>
+        <version>8.8.12</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/connectors/google/google-gemini/pom.xml
+++ b/connectors/google/google-gemini/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.camunda.connector</groupId>
         <artifactId>connector-google-parent</artifactId>
-        <version>8.8.13-rc1</version>
+        <version>8.8.13</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/connectors/google/google-sheets/pom.xml
+++ b/connectors/google/google-sheets/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.camunda.connector</groupId>
         <artifactId>connector-google-parent</artifactId>
-        <version>8.8.13-rc1</version>
+        <version>8.8.13</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/connectors/google/google-sheets/pom.xml
+++ b/connectors/google/google-sheets/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.camunda.connector</groupId>
         <artifactId>connector-google-parent</artifactId>
-        <version>8.8.12</version>
+        <version>8.8.13-rc1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/connectors/google/google-sheets/pom.xml
+++ b/connectors/google/google-sheets/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.camunda.connector</groupId>
         <artifactId>connector-google-parent</artifactId>
-        <version>8.8.11</version>
+        <version>8.8.12</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/connectors/google/pom.xml
+++ b/connectors/google/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.camunda.connector</groupId>
         <artifactId>connectors-parent</artifactId>
-        <version>8.8.11</version>
+        <version>8.8.12</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/connectors/google/pom.xml
+++ b/connectors/google/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.camunda.connector</groupId>
         <artifactId>connectors-parent</artifactId>
-        <version>8.8.13-rc1</version>
+        <version>8.8.13</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/connectors/google/pom.xml
+++ b/connectors/google/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.camunda.connector</groupId>
         <artifactId>connectors-parent</artifactId>
-        <version>8.8.12</version>
+        <version>8.8.13-rc1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/connectors/http/graphql/pom.xml
+++ b/connectors/http/graphql/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.camunda.connector</groupId>
     <artifactId>connector-http-parent</artifactId>
-    <version>8.8.12</version>
+    <version>8.8.13-rc1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/connectors/http/graphql/pom.xml
+++ b/connectors/http/graphql/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.camunda.connector</groupId>
     <artifactId>connector-http-parent</artifactId>
-    <version>8.8.11</version>
+    <version>8.8.12</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/connectors/http/graphql/pom.xml
+++ b/connectors/http/graphql/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.camunda.connector</groupId>
     <artifactId>connector-http-parent</artifactId>
-    <version>8.8.13-rc1</version>
+    <version>8.8.13</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/connectors/http/http-base/pom.xml
+++ b/connectors/http/http-base/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.camunda.connector</groupId>
     <artifactId>connector-http-parent</artifactId>
-    <version>8.8.12</version>
+    <version>8.8.13-rc1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/connectors/http/http-base/pom.xml
+++ b/connectors/http/http-base/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.camunda.connector</groupId>
     <artifactId>connector-http-parent</artifactId>
-    <version>8.8.11</version>
+    <version>8.8.12</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/connectors/http/http-base/pom.xml
+++ b/connectors/http/http-base/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.camunda.connector</groupId>
     <artifactId>connector-http-parent</artifactId>
-    <version>8.8.13-rc1</version>
+    <version>8.8.13</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/connectors/http/polling/pom.xml
+++ b/connectors/http/polling/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.camunda.connector</groupId>
         <artifactId>connector-http-parent</artifactId>
-        <version>8.8.13-rc1</version>
+        <version>8.8.13</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/connectors/http/polling/pom.xml
+++ b/connectors/http/polling/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.camunda.connector</groupId>
         <artifactId>connector-http-parent</artifactId>
-        <version>8.8.11</version>
+        <version>8.8.12</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/connectors/http/polling/pom.xml
+++ b/connectors/http/polling/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.camunda.connector</groupId>
         <artifactId>connector-http-parent</artifactId>
-        <version>8.8.12</version>
+        <version>8.8.13-rc1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/connectors/http/pom.xml
+++ b/connectors/http/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.camunda.connector</groupId>
         <artifactId>connectors-parent</artifactId>
-        <version>8.8.11</version>
+        <version>8.8.12</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/connectors/http/pom.xml
+++ b/connectors/http/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.camunda.connector</groupId>
         <artifactId>connectors-parent</artifactId>
-        <version>8.8.13-rc1</version>
+        <version>8.8.13</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/connectors/http/pom.xml
+++ b/connectors/http/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.camunda.connector</groupId>
         <artifactId>connectors-parent</artifactId>
-        <version>8.8.12</version>
+        <version>8.8.13-rc1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/connectors/http/rest/pom.xml
+++ b/connectors/http/rest/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.camunda.connector</groupId>
     <artifactId>connector-http-parent</artifactId>
-    <version>8.8.12</version>
+    <version>8.8.13-rc1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/connectors/http/rest/pom.xml
+++ b/connectors/http/rest/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.camunda.connector</groupId>
     <artifactId>connector-http-parent</artifactId>
-    <version>8.8.11</version>
+    <version>8.8.12</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/connectors/http/rest/pom.xml
+++ b/connectors/http/rest/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.camunda.connector</groupId>
     <artifactId>connector-http-parent</artifactId>
-    <version>8.8.13-rc1</version>
+    <version>8.8.13</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/connectors/idp-extraction/pom.xml
+++ b/connectors/idp-extraction/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.camunda.connector</groupId>
     <artifactId>connectors-parent</artifactId>
-    <version>8.8.12</version>
+    <version>8.8.13-rc1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/connectors/idp-extraction/pom.xml
+++ b/connectors/idp-extraction/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.camunda.connector</groupId>
     <artifactId>connectors-parent</artifactId>
-    <version>8.8.13-rc1</version>
+    <version>8.8.13</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/connectors/idp-extraction/pom.xml
+++ b/connectors/idp-extraction/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.camunda.connector</groupId>
     <artifactId>connectors-parent</artifactId>
-    <version>8.8.11</version>
+    <version>8.8.12</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/connectors/jdbc/pom.xml
+++ b/connectors/jdbc/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.camunda.connector</groupId>
     <artifactId>connectors-parent</artifactId>
-    <version>8.8.12</version>
+    <version>8.8.13-rc1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/connectors/jdbc/pom.xml
+++ b/connectors/jdbc/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.camunda.connector</groupId>
     <artifactId>connectors-parent</artifactId>
-    <version>8.8.11</version>
+    <version>8.8.12</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/connectors/jdbc/pom.xml
+++ b/connectors/jdbc/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.camunda.connector</groupId>
     <artifactId>connectors-parent</artifactId>
-    <version>8.8.13-rc1</version>
+    <version>8.8.13</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/connectors/kafka/pom.xml
+++ b/connectors/kafka/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.camunda.connector</groupId>
     <artifactId>connectors-parent</artifactId>
-    <version>8.8.12</version>
+    <version>8.8.13-rc1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/connectors/kafka/pom.xml
+++ b/connectors/kafka/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.camunda.connector</groupId>
     <artifactId>connectors-parent</artifactId>
-    <version>8.8.11</version>
+    <version>8.8.12</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/connectors/kafka/pom.xml
+++ b/connectors/kafka/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.camunda.connector</groupId>
     <artifactId>connectors-parent</artifactId>
-    <version>8.8.13-rc1</version>
+    <version>8.8.13</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/connectors/microsoft-teams/pom.xml
+++ b/connectors/microsoft-teams/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.camunda.connector</groupId>
     <artifactId>connectors-parent</artifactId>
-    <version>8.8.12</version>
+    <version>8.8.13-rc1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/connectors/microsoft-teams/pom.xml
+++ b/connectors/microsoft-teams/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.camunda.connector</groupId>
     <artifactId>connectors-parent</artifactId>
-    <version>8.8.11</version>
+    <version>8.8.12</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/connectors/microsoft-teams/pom.xml
+++ b/connectors/microsoft-teams/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.camunda.connector</groupId>
     <artifactId>connectors-parent</artifactId>
-    <version>8.8.13-rc1</version>
+    <version>8.8.13</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/connectors/microsoft/azure-blobstorage/pom.xml
+++ b/connectors/microsoft/azure-blobstorage/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>io.camunda.connector</groupId>
     <artifactId>connectors-parent</artifactId>
-    <version>8.8.12</version>
+    <version>8.8.13-rc1</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/connectors/microsoft/azure-blobstorage/pom.xml
+++ b/connectors/microsoft/azure-blobstorage/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>io.camunda.connector</groupId>
     <artifactId>connectors-parent</artifactId>
-    <version>8.8.11</version>
+    <version>8.8.12</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/connectors/microsoft/azure-blobstorage/pom.xml
+++ b/connectors/microsoft/azure-blobstorage/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>io.camunda.connector</groupId>
     <artifactId>connectors-parent</artifactId>
-    <version>8.8.13-rc1</version>
+    <version>8.8.13</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/connectors/pom.xml
+++ b/connectors/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.camunda.connector</groupId>
     <artifactId>connectors-bundle-parent</artifactId>
-    <version>8.8.11</version>
+    <version>8.8.12</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/connectors/pom.xml
+++ b/connectors/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.camunda.connector</groupId>
     <artifactId>connectors-bundle-parent</artifactId>
-    <version>8.8.12</version>
+    <version>8.8.13-rc1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/connectors/pom.xml
+++ b/connectors/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.camunda.connector</groupId>
     <artifactId>connectors-bundle-parent</artifactId>
-    <version>8.8.13-rc1</version>
+    <version>8.8.13</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/connectors/rabbitmq/pom.xml
+++ b/connectors/rabbitmq/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.camunda.connector</groupId>
     <artifactId>connectors-parent</artifactId>
-    <version>8.8.12</version>
+    <version>8.8.13-rc1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/connectors/rabbitmq/pom.xml
+++ b/connectors/rabbitmq/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.camunda.connector</groupId>
     <artifactId>connectors-parent</artifactId>
-    <version>8.8.11</version>
+    <version>8.8.12</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/connectors/rabbitmq/pom.xml
+++ b/connectors/rabbitmq/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.camunda.connector</groupId>
     <artifactId>connectors-parent</artifactId>
-    <version>8.8.13-rc1</version>
+    <version>8.8.13</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/connectors/sendgrid/pom.xml
+++ b/connectors/sendgrid/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.camunda.connector</groupId>
     <artifactId>connectors-parent</artifactId>
-    <version>8.8.12</version>
+    <version>8.8.13-rc1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/connectors/sendgrid/pom.xml
+++ b/connectors/sendgrid/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.camunda.connector</groupId>
     <artifactId>connectors-parent</artifactId>
-    <version>8.8.11</version>
+    <version>8.8.12</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/connectors/sendgrid/pom.xml
+++ b/connectors/sendgrid/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.camunda.connector</groupId>
     <artifactId>connectors-parent</artifactId>
-    <version>8.8.13-rc1</version>
+    <version>8.8.13</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/connectors/slack/pom.xml
+++ b/connectors/slack/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.camunda.connector</groupId>
     <artifactId>connectors-parent</artifactId>
-    <version>8.8.12</version>
+    <version>8.8.13-rc1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/connectors/slack/pom.xml
+++ b/connectors/slack/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.camunda.connector</groupId>
     <artifactId>connectors-parent</artifactId>
-    <version>8.8.11</version>
+    <version>8.8.12</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/connectors/slack/pom.xml
+++ b/connectors/slack/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.camunda.connector</groupId>
     <artifactId>connectors-parent</artifactId>
-    <version>8.8.13-rc1</version>
+    <version>8.8.13</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/connectors/soap/pom.xml
+++ b/connectors/soap/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.camunda.connector</groupId>
     <artifactId>connectors-parent</artifactId>
-    <version>8.8.12</version>
+    <version>8.8.13-rc1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/connectors/soap/pom.xml
+++ b/connectors/soap/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.camunda.connector</groupId>
     <artifactId>connectors-parent</artifactId>
-    <version>8.8.11</version>
+    <version>8.8.12</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/connectors/soap/pom.xml
+++ b/connectors/soap/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.camunda.connector</groupId>
     <artifactId>connectors-parent</artifactId>
-    <version>8.8.13-rc1</version>
+    <version>8.8.13</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/connectors/webhook/pom.xml
+++ b/connectors/webhook/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda.connector</groupId>
       <artifactId>connectors-parent</artifactId>
-      <version>8.8.11</version>
+      <version>8.8.12</version>
       <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/connectors/webhook/pom.xml
+++ b/connectors/webhook/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda.connector</groupId>
       <artifactId>connectors-parent</artifactId>
-      <version>8.8.13-rc1</version>
+      <version>8.8.13</version>
       <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/connectors/webhook/pom.xml
+++ b/connectors/webhook/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda.connector</groupId>
       <artifactId>connectors-parent</artifactId>
-      <version>8.8.12</version>
+      <version>8.8.13-rc1</version>
       <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/element-template-generator/congen-cli/pom.xml
+++ b/element-template-generator/congen-cli/pom.xml
@@ -7,7 +7,7 @@
     <groupId>io.camunda.connector</groupId>
     <artifactId>element-template-generator-parent</artifactId>
     <relativePath>../pom.xml</relativePath>
-    <version>8.8.11</version>
+    <version>8.8.12</version>
   </parent>
 
   <name>congen-cli</name>

--- a/element-template-generator/congen-cli/pom.xml
+++ b/element-template-generator/congen-cli/pom.xml
@@ -7,7 +7,7 @@
     <groupId>io.camunda.connector</groupId>
     <artifactId>element-template-generator-parent</artifactId>
     <relativePath>../pom.xml</relativePath>
-    <version>8.8.12</version>
+    <version>8.8.13-rc1</version>
   </parent>
 
   <name>congen-cli</name>

--- a/element-template-generator/congen-cli/pom.xml
+++ b/element-template-generator/congen-cli/pom.xml
@@ -7,7 +7,7 @@
     <groupId>io.camunda.connector</groupId>
     <artifactId>element-template-generator-parent</artifactId>
     <relativePath>../pom.xml</relativePath>
-    <version>8.8.13-rc1</version>
+    <version>8.8.13</version>
   </parent>
 
   <name>congen-cli</name>

--- a/element-template-generator/core/pom.xml
+++ b/element-template-generator/core/pom.xml
@@ -6,7 +6,7 @@
     <groupId>io.camunda.connector</groupId>
     <artifactId>element-template-generator-parent</artifactId>
     <relativePath>../pom.xml</relativePath>
-    <version>8.8.11</version>
+    <version>8.8.12</version>
   </parent>
 
   <name>element-template-generator-core</name>

--- a/element-template-generator/core/pom.xml
+++ b/element-template-generator/core/pom.xml
@@ -6,7 +6,7 @@
     <groupId>io.camunda.connector</groupId>
     <artifactId>element-template-generator-parent</artifactId>
     <relativePath>../pom.xml</relativePath>
-    <version>8.8.13-rc1</version>
+    <version>8.8.13</version>
   </parent>
 
   <name>element-template-generator-core</name>

--- a/element-template-generator/core/pom.xml
+++ b/element-template-generator/core/pom.xml
@@ -6,7 +6,7 @@
     <groupId>io.camunda.connector</groupId>
     <artifactId>element-template-generator-parent</artifactId>
     <relativePath>../pom.xml</relativePath>
-    <version>8.8.12</version>
+    <version>8.8.13-rc1</version>
   </parent>
 
   <name>element-template-generator-core</name>

--- a/element-template-generator/http-dsl/pom.xml
+++ b/element-template-generator/http-dsl/pom.xml
@@ -6,7 +6,7 @@
     <groupId>io.camunda.connector</groupId>
     <artifactId>element-template-generator-parent</artifactId>
     <relativePath>../pom.xml</relativePath>
-    <version>8.8.11</version>
+    <version>8.8.12</version>
   </parent>
 
   <name>element-template-generator-http</name>

--- a/element-template-generator/http-dsl/pom.xml
+++ b/element-template-generator/http-dsl/pom.xml
@@ -6,7 +6,7 @@
     <groupId>io.camunda.connector</groupId>
     <artifactId>element-template-generator-parent</artifactId>
     <relativePath>../pom.xml</relativePath>
-    <version>8.8.13-rc1</version>
+    <version>8.8.13</version>
   </parent>
 
   <name>element-template-generator-http</name>

--- a/element-template-generator/http-dsl/pom.xml
+++ b/element-template-generator/http-dsl/pom.xml
@@ -6,7 +6,7 @@
     <groupId>io.camunda.connector</groupId>
     <artifactId>element-template-generator-parent</artifactId>
     <relativePath>../pom.xml</relativePath>
-    <version>8.8.12</version>
+    <version>8.8.13-rc1</version>
   </parent>
 
   <name>element-template-generator-http</name>

--- a/element-template-generator/maven-plugin/pom.xml
+++ b/element-template-generator/maven-plugin/pom.xml
@@ -6,7 +6,7 @@
     <groupId>io.camunda.connector</groupId>
     <artifactId>element-template-generator-parent</artifactId>
     <relativePath>../pom.xml</relativePath>
-    <version>8.8.12</version>
+    <version>8.8.13-rc1</version>
   </parent>
 
   <name>element-template-generator-maven-plugin</name>

--- a/element-template-generator/maven-plugin/pom.xml
+++ b/element-template-generator/maven-plugin/pom.xml
@@ -6,7 +6,7 @@
     <groupId>io.camunda.connector</groupId>
     <artifactId>element-template-generator-parent</artifactId>
     <relativePath>../pom.xml</relativePath>
-    <version>8.8.13-rc1</version>
+    <version>8.8.13</version>
   </parent>
 
   <name>element-template-generator-maven-plugin</name>

--- a/element-template-generator/maven-plugin/pom.xml
+++ b/element-template-generator/maven-plugin/pom.xml
@@ -6,7 +6,7 @@
     <groupId>io.camunda.connector</groupId>
     <artifactId>element-template-generator-parent</artifactId>
     <relativePath>../pom.xml</relativePath>
-    <version>8.8.11</version>
+    <version>8.8.12</version>
   </parent>
 
   <name>element-template-generator-maven-plugin</name>

--- a/element-template-generator/npm/package-lock.json
+++ b/element-template-generator/npm/package-lock.json
@@ -560,9 +560,9 @@
       }
     },
     "node_modules/mocha": {
-      "version": "11.7.5",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-11.7.5.tgz",
-      "integrity": "sha512-mTT6RgopEYABzXWFx+GcJ+ZQ32kp4fMf0xvpZIIfSq9Z8lC/++MtcCnQ9t5FP2veYEP95FIYSvW+U9fV4xrlig==",
+      "version": "11.7.6",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-11.7.6.tgz",
+      "integrity": "sha512-nS9xOGbw2I3cjCpxwZAEJ9xK9lmJ08vEkQvLtz4du9ZrF9UrjRpeJGiIgl2Z+Qs++pmB4ecDe48Fwsh+j+j7xA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/element-template-generator/openapi-parser/pom.xml
+++ b/element-template-generator/openapi-parser/pom.xml
@@ -6,7 +6,7 @@
     <groupId>io.camunda.connector</groupId>
     <artifactId>element-template-generator-parent</artifactId>
     <relativePath>../pom.xml</relativePath>
-    <version>8.8.12</version>
+    <version>8.8.13-rc1</version>
   </parent>
 
   <name>openapi-parser</name>

--- a/element-template-generator/openapi-parser/pom.xml
+++ b/element-template-generator/openapi-parser/pom.xml
@@ -6,7 +6,7 @@
     <groupId>io.camunda.connector</groupId>
     <artifactId>element-template-generator-parent</artifactId>
     <relativePath>../pom.xml</relativePath>
-    <version>8.8.13-rc1</version>
+    <version>8.8.13</version>
   </parent>
 
   <name>openapi-parser</name>

--- a/element-template-generator/openapi-parser/pom.xml
+++ b/element-template-generator/openapi-parser/pom.xml
@@ -6,7 +6,7 @@
     <groupId>io.camunda.connector</groupId>
     <artifactId>element-template-generator-parent</artifactId>
     <relativePath>../pom.xml</relativePath>
-    <version>8.8.11</version>
+    <version>8.8.12</version>
   </parent>
 
   <name>openapi-parser</name>

--- a/element-template-generator/pom.xml
+++ b/element-template-generator/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.camunda.connector</groupId>
     <artifactId>connectors-bundle-parent</artifactId>
-    <version>8.8.11</version>
+    <version>8.8.12</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/element-template-generator/pom.xml
+++ b/element-template-generator/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.camunda.connector</groupId>
     <artifactId>connectors-bundle-parent</artifactId>
-    <version>8.8.12</version>
+    <version>8.8.13-rc1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/element-template-generator/pom.xml
+++ b/element-template-generator/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.camunda.connector</groupId>
     <artifactId>connectors-bundle-parent</artifactId>
-    <version>8.8.13-rc1</version>
+    <version>8.8.13</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/element-template-generator/postman-collections-parser/pom.xml
+++ b/element-template-generator/postman-collections-parser/pom.xml
@@ -6,7 +6,7 @@
     <groupId>io.camunda.connector</groupId>
     <artifactId>element-template-generator-parent</artifactId>
     <relativePath>../pom.xml</relativePath>
-    <version>8.8.13-rc1</version>
+    <version>8.8.13</version>
   </parent>
 
   <name>postman-collections-parser</name>

--- a/element-template-generator/postman-collections-parser/pom.xml
+++ b/element-template-generator/postman-collections-parser/pom.xml
@@ -6,7 +6,7 @@
     <groupId>io.camunda.connector</groupId>
     <artifactId>element-template-generator-parent</artifactId>
     <relativePath>../pom.xml</relativePath>
-    <version>8.8.11</version>
+    <version>8.8.12</version>
   </parent>
 
   <name>postman-collections-parser</name>

--- a/element-template-generator/postman-collections-parser/pom.xml
+++ b/element-template-generator/postman-collections-parser/pom.xml
@@ -6,7 +6,7 @@
     <groupId>io.camunda.connector</groupId>
     <artifactId>element-template-generator-parent</artifactId>
     <relativePath>../pom.xml</relativePath>
-    <version>8.8.12</version>
+    <version>8.8.13-rc1</version>
   </parent>
 
   <name>postman-collections-parser</name>

--- a/element-template-generator/uniquet/pom.xml
+++ b/element-template-generator/uniquet/pom.xml
@@ -8,7 +8,7 @@
         <groupId>io.camunda.connector</groupId>
         <artifactId>element-template-generator-parent</artifactId>
         <relativePath>../pom.xml</relativePath>
-        <version>8.8.12</version>
+        <version>8.8.13-rc1</version>
     </parent>
 
     <name>Uniquet</name>

--- a/element-template-generator/uniquet/pom.xml
+++ b/element-template-generator/uniquet/pom.xml
@@ -8,7 +8,7 @@
         <groupId>io.camunda.connector</groupId>
         <artifactId>element-template-generator-parent</artifactId>
         <relativePath>../pom.xml</relativePath>
-        <version>8.8.11</version>
+        <version>8.8.12</version>
     </parent>
 
     <name>Uniquet</name>

--- a/element-template-generator/uniquet/pom.xml
+++ b/element-template-generator/uniquet/pom.xml
@@ -8,7 +8,7 @@
         <groupId>io.camunda.connector</groupId>
         <artifactId>element-template-generator-parent</artifactId>
         <relativePath>../pom.xml</relativePath>
-        <version>8.8.13-rc1</version>
+        <version>8.8.13</version>
     </parent>
 
     <name>Uniquet</name>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -960,7 +960,7 @@ Ref: https://cve-registry.infosec.camunda-it.rocks/team/3/finding/3575
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-site-plugin</artifactId>
-          <version>3.21.0</version>
+          <version>3.22.0</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>io.camunda.connector</groupId>
   <artifactId>connector-parent</artifactId>
-  <version>8.8.12</version>
+  <version>8.8.13-rc1</version>
   <packaging>pom</packaging>
 
   <name>Connectors Parent</name>
@@ -98,12 +98,12 @@ limitations under the License.</license.inlineheader>
     <version.logback>1.5.32</version.logback>
 
     <version.aws-java-sdk>1.12.797</version.aws-java-sdk>
-    <version.software-aws-java-sdk>2.44.12</version.software-aws-java-sdk>
+    <version.software-aws-java-sdk>2.44.10</version.software-aws-java-sdk>
     <version.aws-java-sdk-sts>1.12.797</version.aws-java-sdk-sts>
-    <version.software-aws-java-sdk-sts>2.44.12</version.software-aws-java-sdk-sts>
+    <version.software-aws-java-sdk-sts>2.44.10</version.software-aws-java-sdk-sts>
     <version.aws-lambda-java-events>3.16.1</version.aws-lambda-java-events>
     <version.aws-lambda-java-core>1.4.0</version.aws-lambda-java-core>
-    <version.aws-sdk-secretsmanager>2.44.12</version.aws-sdk-secretsmanager>
+    <version.aws-sdk-secretsmanager>2.44.10</version.aws-sdk-secretsmanager>
 
     <version.localstack>1.21.4</version.localstack>
 
@@ -960,7 +960,7 @@ Ref: https://cve-registry.infosec.camunda-it.rocks/team/3/finding/3575
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-site-plugin</artifactId>
-          <version>3.22.0</version>
+          <version>3.21.0</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -98,12 +98,12 @@ limitations under the License.</license.inlineheader>
     <version.logback>1.5.32</version.logback>
 
     <version.aws-java-sdk>1.12.797</version.aws-java-sdk>
-    <version.software-aws-java-sdk>2.44.10</version.software-aws-java-sdk>
+    <version.software-aws-java-sdk>2.44.11</version.software-aws-java-sdk>
     <version.aws-java-sdk-sts>1.12.797</version.aws-java-sdk-sts>
-    <version.software-aws-java-sdk-sts>2.44.10</version.software-aws-java-sdk-sts>
+    <version.software-aws-java-sdk-sts>2.44.11</version.software-aws-java-sdk-sts>
     <version.aws-lambda-java-events>3.16.1</version.aws-lambda-java-events>
     <version.aws-lambda-java-core>1.4.0</version.aws-lambda-java-core>
-    <version.aws-sdk-secretsmanager>2.44.10</version.aws-sdk-secretsmanager>
+    <version.aws-sdk-secretsmanager>2.44.11</version.aws-sdk-secretsmanager>
 
     <version.localstack>1.21.4</version.localstack>
 

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>io.camunda.connector</groupId>
   <artifactId>connector-parent</artifactId>
-  <version>8.8.11</version>
+  <version>8.8.12</version>
   <packaging>pom</packaging>
 
   <name>Connectors Parent</name>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -98,12 +98,12 @@ limitations under the License.</license.inlineheader>
     <version.logback>1.5.32</version.logback>
 
     <version.aws-java-sdk>1.12.797</version.aws-java-sdk>
-    <version.software-aws-java-sdk>2.44.11</version.software-aws-java-sdk>
+    <version.software-aws-java-sdk>2.44.12</version.software-aws-java-sdk>
     <version.aws-java-sdk-sts>1.12.797</version.aws-java-sdk-sts>
-    <version.software-aws-java-sdk-sts>2.44.11</version.software-aws-java-sdk-sts>
+    <version.software-aws-java-sdk-sts>2.44.12</version.software-aws-java-sdk-sts>
     <version.aws-lambda-java-events>3.16.1</version.aws-lambda-java-events>
     <version.aws-lambda-java-core>1.4.0</version.aws-lambda-java-core>
-    <version.aws-sdk-secretsmanager>2.44.11</version.aws-sdk-secretsmanager>
+    <version.aws-sdk-secretsmanager>2.44.12</version.aws-sdk-secretsmanager>
 
     <version.localstack>1.21.4</version.localstack>
 

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>io.camunda.connector</groupId>
   <artifactId>connector-parent</artifactId>
-  <version>8.8.13-rc1</version>
+  <version>8.8.13</version>
   <packaging>pom</packaging>
 
   <name>Connectors Parent</name>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.camunda.connector</groupId>
     <artifactId>connector-parent</artifactId>
-    <version>8.8.12</version>
+    <version>8.8.13-rc1</version>
     <relativePath>parent/pom.xml</relativePath>
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.camunda.connector</groupId>
     <artifactId>connector-parent</artifactId>
-    <version>8.8.13-rc1</version>
+    <version>8.8.13</version>
     <relativePath>parent/pom.xml</relativePath>
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.camunda.connector</groupId>
     <artifactId>connector-parent</artifactId>
-    <version>8.8.11</version>
+    <version>8.8.12</version>
     <relativePath>parent/pom.xml</relativePath>
   </parent>
 

--- a/secret-providers/aws/pom.xml
+++ b/secret-providers/aws/pom.xml
@@ -7,7 +7,7 @@
     <groupId>io.camunda.connector</groupId>
     <artifactId>secret-providers</artifactId>
     <relativePath>../pom.xml</relativePath>
-    <version>8.8.13-rc1</version>
+    <version>8.8.13</version>
   </parent>
 
   <artifactId>aws-secret-provider</artifactId>

--- a/secret-providers/aws/pom.xml
+++ b/secret-providers/aws/pom.xml
@@ -7,7 +7,7 @@
     <groupId>io.camunda.connector</groupId>
     <artifactId>secret-providers</artifactId>
     <relativePath>../pom.xml</relativePath>
-    <version>8.8.12</version>
+    <version>8.8.13-rc1</version>
   </parent>
 
   <artifactId>aws-secret-provider</artifactId>

--- a/secret-providers/aws/pom.xml
+++ b/secret-providers/aws/pom.xml
@@ -7,7 +7,7 @@
     <groupId>io.camunda.connector</groupId>
     <artifactId>secret-providers</artifactId>
     <relativePath>../pom.xml</relativePath>
-    <version>8.8.11</version>
+    <version>8.8.12</version>
   </parent>
 
   <artifactId>aws-secret-provider</artifactId>

--- a/secret-providers/gcp/pom.xml
+++ b/secret-providers/gcp/pom.xml
@@ -7,7 +7,7 @@
     <groupId>io.camunda.connector</groupId>
     <artifactId>secret-providers</artifactId>
     <relativePath>../pom.xml</relativePath>
-    <version>8.8.12</version>
+    <version>8.8.13-rc1</version>
   </parent>
 
   <artifactId>gcp-secret-provider</artifactId>

--- a/secret-providers/gcp/pom.xml
+++ b/secret-providers/gcp/pom.xml
@@ -7,7 +7,7 @@
     <groupId>io.camunda.connector</groupId>
     <artifactId>secret-providers</artifactId>
     <relativePath>../pom.xml</relativePath>
-    <version>8.8.11</version>
+    <version>8.8.12</version>
   </parent>
 
   <artifactId>gcp-secret-provider</artifactId>

--- a/secret-providers/gcp/pom.xml
+++ b/secret-providers/gcp/pom.xml
@@ -7,7 +7,7 @@
     <groupId>io.camunda.connector</groupId>
     <artifactId>secret-providers</artifactId>
     <relativePath>../pom.xml</relativePath>
-    <version>8.8.13-rc1</version>
+    <version>8.8.13</version>
   </parent>
 
   <artifactId>gcp-secret-provider</artifactId>

--- a/secret-providers/pom.xml
+++ b/secret-providers/pom.xml
@@ -5,7 +5,7 @@
     <groupId>io.camunda.connector</groupId>
     <artifactId>connector-parent</artifactId>
     <relativePath>../parent/pom.xml</relativePath>
-    <version>8.8.12</version>
+    <version>8.8.13-rc1</version>
   </parent>
 
   <artifactId>secret-providers</artifactId>

--- a/secret-providers/pom.xml
+++ b/secret-providers/pom.xml
@@ -5,7 +5,7 @@
     <groupId>io.camunda.connector</groupId>
     <artifactId>connector-parent</artifactId>
     <relativePath>../parent/pom.xml</relativePath>
-    <version>8.8.13-rc1</version>
+    <version>8.8.13</version>
   </parent>
 
   <artifactId>secret-providers</artifactId>

--- a/secret-providers/pom.xml
+++ b/secret-providers/pom.xml
@@ -5,7 +5,7 @@
     <groupId>io.camunda.connector</groupId>
     <artifactId>connector-parent</artifactId>
     <relativePath>../parent/pom.xml</relativePath>
-    <version>8.8.11</version>
+    <version>8.8.12</version>
   </parent>
 
   <artifactId>secret-providers</artifactId>

--- a/secret-providers/secret-providers-base/pom.xml
+++ b/secret-providers/secret-providers-base/pom.xml
@@ -7,7 +7,7 @@
     <groupId>io.camunda.connector</groupId>
     <artifactId>secret-providers</artifactId>
     <relativePath>../pom.xml</relativePath>
-    <version>8.8.13-rc1</version>
+    <version>8.8.13</version>
   </parent>
 
   <artifactId>secret-providers-base</artifactId>

--- a/secret-providers/secret-providers-base/pom.xml
+++ b/secret-providers/secret-providers-base/pom.xml
@@ -7,7 +7,7 @@
     <groupId>io.camunda.connector</groupId>
     <artifactId>secret-providers</artifactId>
     <relativePath>../pom.xml</relativePath>
-    <version>8.8.12</version>
+    <version>8.8.13-rc1</version>
   </parent>
 
   <artifactId>secret-providers-base</artifactId>

--- a/secret-providers/secret-providers-base/pom.xml
+++ b/secret-providers/secret-providers-base/pom.xml
@@ -7,7 +7,7 @@
     <groupId>io.camunda.connector</groupId>
     <artifactId>secret-providers</artifactId>
     <relativePath>../pom.xml</relativePath>
-    <version>8.8.11</version>
+    <version>8.8.12</version>
   </parent>
 
   <artifactId>secret-providers-base</artifactId>


### PR DESCRIPTION
## Summary

Replaces #7347 which had merge conflicts.

- Rebased `release-8.8.13` onto `stable/8.8`
- Resolved all version-bump conflicts in pom.xml files by taking the release branch versions (`8.8.12` → `8.8.13-rc1` → `8.8.13`)
- Final version: `8.8.13`

Closes #7347