### PR TITLE
deps: bump camunda client to 8.10.0-alpha2-rc1

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -70,7 +70,7 @@ limitations under the License.</license.inlineheader>
     <nexus.release.repository>https://artifacts.camunda.com/artifactory/connectors/</nexus.release.repository>
 
     <!-- Camunda internal libraries -->
-    <version.camunda>8.10.0-SNAPSHOT</version.camunda>
+    <version.camunda>8.10.0-alpha2-rc1</version.camunda>
     <version.feel-engine>1.21.0</version.feel-engine>
     <version.camunda-xml-model>7.24.0</version.camunda-xml-model>
 


### PR DESCRIPTION
## Description

This pull request updates the Camunda dependency version in the `parent/pom.xml` file. The main change is:

Dependency version update:

* Updated the `version.camunda` property from `8.10.0-SNAPSHOT` to `8.10.0-alpha2-rc1` to use a newer pre-release version of Camunda.


## Checklist

- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest
  release, as this branch will be rebased onto main before the next release. Example backport labels:
    - `backport stable/8.8`: for changes that should be included in the next 8.8.x release.
    - **or** `backport release-8.8.7`: for changes that should be included in the specific release 8.8.7, and this
      *release has already been created*. The release branch will be merged back into stable/8.8 later, so the change
      will be included in future 8.8.x releases as well.
- [ ] Tests/Integration tests for the changes have been added if applicable.
- [ ] If the change requires a documentation update, it has been added to the appropriate section in the documentation.


