### PR TITLE
test: fix test so that it works on any machine (github runners)

### DIFF
--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/outbound/OutboundConnectorsRestControllerTest.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/outbound/OutboundConnectorsRestControllerTest.java
@@ -42,7 +42,9 @@ import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
-@SpringBootTest(classes = TestConnectorRuntimeApplication.class)
+@SpringBootTest(
+    classes = TestConnectorRuntimeApplication.class,
+    properties = "camunda.connector.hostname=localhost")
 @AutoConfigureMockMvc
 class OutboundConnectorsRestControllerTest {
 


### PR DESCRIPTION
## Description

This pull request makes a small configuration change to the `OutboundConnectorsRestControllerTest` class. The test is now explicitly configured to use `localhost` as the value for the `camunda.connector.hostname` property during test execution.

- Test configuration: Set the `camunda.connector.hostname` property to `localhost` in the `@SpringBootTest` annotation of `OutboundConnectorsRestControllerTest` to ensure consistent test behavior.

## Checklist

- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest
  release, as this branch will be rebased onto main before the next release. Example backport labels:
    - `backport stable/8.8`: for changes that should be included in the next 8.8.x release.
    - **or** `backport release-8.8.7`: for changes that should be included in the specific release 8.8.7, and this
      *release has already been created*. The release branch will be merged back into stable/8.8 later, so the change
      will be included in future 8.8.x releases as well.
- [ ] Tests/Integration tests for the changes have been added if applicable.
- [ ] If the change requires a documentation update, it has been added to the appropriate section in the documentation.


