### PR TITLE
feat: add processName to ProcessElement and lastUpdatedAt to Health

### DIFF
--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/ProcessElementWithRuntimeData.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/ProcessElementWithRuntimeData.java
@@ -23,6 +23,7 @@ import java.util.Map;
 /** Represents a BPMN process element that contains an inbound connector definition. */
 public record ProcessElementWithRuntimeData(
     String bpmnProcessId,
+    String processName,
     int version,
     long processDefinitionKey,
     String elementId,
@@ -41,6 +42,7 @@ public record ProcessElementWithRuntimeData(
       String tenantId) {
     this(
         bpmnProcessId,
+        null,
         version,
         processDefinitionKey,
         elementId,

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/state/ProcessDefinitionInspector.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/state/ProcessDefinitionInspector.java
@@ -161,6 +161,7 @@ public class ProcessDefinitionInspector {
       var processElement =
           new ProcessElementWithRuntimeData(
               process.getId(),
+              process.getName(),
               version.version(),
               version.processDefinitionKey(),
               element.getId(),

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/inbound/importer/ProcessDefinitionInspectorUtilTests.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/inbound/importer/ProcessDefinitionInspectorUtilTests.java
@@ -41,6 +41,7 @@ public class ProcessDefinitionInspectorUtilTests {
     var inboundConnectors = fromModel("single-webhook-collaboration.bpmn", "process");
     assertEquals(1, inboundConnectors.size());
     assertEquals("start_event", inboundConnectors.getFirst().element().elementId());
+    assertEquals("My Webhook Process", inboundConnectors.getFirst().element().processName());
   }
 
   @Test

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/instances/helpers/ConnectorInstancesListResponseHelper.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/instances/helpers/ConnectorInstancesListResponseHelper.java
@@ -25,6 +25,7 @@ import io.camunda.connector.runtime.inbound.executable.ConnectorInstances;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
+import org.assertj.core.api.recursive.comparison.RecursiveComparisonConfiguration;
 import org.junit.jupiter.params.provider.Arguments;
 
 public class ConnectorInstancesListResponseHelper {
@@ -171,7 +172,10 @@ public class ConnectorInstancesListResponseHelper {
       assertThat(actualInstance.connectorName()).isEqualTo(expectedInstance.connectorName());
       assertThat(actualInstance.instances()).hasSameSizeAs(expectedInstance.instances());
       assertThat(actualInstance.instances())
-          .usingRecursiveFieldByFieldElementComparator()
+          .usingRecursiveFieldByFieldElementComparator(
+              RecursiveComparisonConfiguration.builder()
+                  .withIgnoredFields("health.lastUpdatedAt")
+                  .build())
           .containsExactlyInAnyOrderElementsOf(expectedInstance.instances());
     }
   }

--- a/connector-runtime/connector-runtime-spring/src/test/resources/bpmn/single-webhook-collaboration.bpmn
+++ b/connector-runtime/connector-runtime-spring/src/test/resources/bpmn/single-webhook-collaboration.bpmn
@@ -6,7 +6,7 @@
     <bpmn:messageFlow id="Flow_0v8mcd7" sourceRef="Activity_0bbhjnc" targetRef="Activity_0wgjxnj" />
     <bpmn:messageFlow id="Flow_1w42yir" sourceRef="Activity_1svog89" targetRef="Activity_1up34yp" />
   </bpmn:collaboration>
-  <bpmn:process id="process" isExecutable="true">
+  <bpmn:process id="process" name="My Webhook Process" isExecutable="true">
     <bpmn:task id="Activity_0wgjxnj" name="yo">
       <bpmn:outgoing>Flow_1c6ej6l</bpmn:outgoing>
     </bpmn:task>

--- a/connector-sdk/core/src/main/java/io/camunda/connector/api/inbound/Health.java
+++ b/connector-sdk/core/src/main/java/io/camunda/connector/api/inbound/Health.java
@@ -63,13 +63,12 @@ public class Health {
     Health health = (Health) o;
     return status == health.status
         && Objects.equals(error, health.error)
-        && Objects.equals(details, health.details)
-        && Objects.equals(lastUpdatedAt, health.lastUpdatedAt);
+        && Objects.equals(details, health.details);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(status, error, details, lastUpdatedAt);
+    return Objects.hash(status, error, details);
   }
 
   @Override

--- a/connector-sdk/core/src/main/java/io/camunda/connector/api/inbound/Health.java
+++ b/connector-sdk/core/src/main/java/io/camunda/connector/api/inbound/Health.java
@@ -16,6 +16,7 @@
  */
 package io.camunda.connector.api.inbound;
 
+import java.time.Instant;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
@@ -31,6 +32,7 @@ public class Health {
   private final Status status;
   private final Error error;
   private final Map<String, Object> details;
+  private final Instant lastUpdatedAt;
 
   public enum Status {
     UP,
@@ -50,6 +52,10 @@ public class Health {
     return error;
   }
 
+  public Instant getLastUpdatedAt() {
+    return lastUpdatedAt;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
@@ -57,17 +63,27 @@ public class Health {
     Health health = (Health) o;
     return status == health.status
         && Objects.equals(error, health.error)
-        && Objects.equals(details, health.details);
+        && Objects.equals(details, health.details)
+        && Objects.equals(lastUpdatedAt, health.lastUpdatedAt);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(status, error, details);
+    return Objects.hash(status, error, details, lastUpdatedAt);
   }
 
   @Override
   public String toString() {
-    return "Health{" + "status=" + status + ", error=" + error + ", details=" + details + '}';
+    return "Health{"
+        + "status="
+        + status
+        + ", error="
+        + error
+        + ", details="
+        + details
+        + ", lastUpdatedAt="
+        + lastUpdatedAt
+        + '}';
   }
 
   static DetailsStep status(Status status) {
@@ -147,12 +163,14 @@ public class Health {
     this.status = builder.status;
     this.error = builder.error;
     this.details = builder.details;
+    this.lastUpdatedAt = Instant.now();
   }
 
   private Health(Status status, Error error, Map<String, Object> details) {
     this.status = status;
     this.error = error;
     this.details = details;
+    this.lastUpdatedAt = Instant.now();
   }
 
   private Health() {

--- a/connector-sdk/core/src/main/java/io/camunda/connector/api/inbound/ProcessElement.java
+++ b/connector-sdk/core/src/main/java/io/camunda/connector/api/inbound/ProcessElement.java
@@ -20,6 +20,8 @@ public interface ProcessElement {
 
   String bpmnProcessId();
 
+  String processName();
+
   int version();
 
   long processDefinitionKey();

--- a/connector-sdk/core/src/main/java/io/camunda/connector/api/inbound/ProcessElement.java
+++ b/connector-sdk/core/src/main/java/io/camunda/connector/api/inbound/ProcessElement.java
@@ -20,7 +20,9 @@ public interface ProcessElement {
 
   String bpmnProcessId();
 
-  String processName();
+  default String processName() {
+    return null;
+  }
 
   int version();
 


### PR DESCRIPTION
## Description

This PR introduces two small but useful additions to the connector SDK's inbound API:

### `processName` in `ProcessElement`

A new `processName()` method has been added to the `ProcessElement` interface, exposing the human-readable name of the process definition alongside the existing `bpmnProcessId()`. This name is populated by `ProcessDefinitionInspector` from the process definition data and carried through `ProcessElementWithRuntimeData`.

This makes it easier for connector implementations and observability tooling to display a friendly process name without having to look it up separately.

### `lastUpdatedAt` in `Health`

A new `lastUpdatedAt` field (of type `java.time.Instant`) has been added to the `Health` class. It is automatically set to `Instant.now()` at construction time, so no API changes are required from callers.

This allows consumers of the Health API (e.g., monitoring endpoints) to know **when** a connector's health status was last updated, enabling staleness detection and better observability.

Both changes are backwards-compatible additions to existing APIs.


## Checklist

- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest
  release, as this branch will be rebased onto main before the next release. Example backport labels:
    - `backport stable/8.8`: for changes that should be included in the next 8.8.x release.
    - **or** `backport release-8.8.7`: for changes that should be included in the specific release 8.8.7, and this
      *release has already been created*. The release branch will be merged back into stable/8.8 later, so the change
      will be included in future 8.8.x releases as well.
- [x] Tests/Integration tests for the changes have been added if applicable.
- [ ] If the change requires a documentation update, it has been added to the appropriate section in the documentation.
