### PR TITLE
test: introduce MockOidcServer to replace hardcoded OIDC URLs in tests (backport #7081 to stable/8.8)

### DIFF
--- a/bundle/camunda-saas-bundle/src/test/java/io/camunda/connector/runtime/saas/InboundInstancesSecurityConfigurationTest.java
+++ b/bundle/camunda-saas-bundle/src/test/java/io/camunda/connector/runtime/saas/InboundInstancesSecurityConfigurationTest.java
@@ -20,7 +20,9 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import io.camunda.connector.test.utils.annotation.SlowTest;
+import io.camunda.connector.test.utils.oidc.MockOidcServer;
 import io.camunda.process.test.api.CamundaSpringProcessTest;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 import org.mockito.Answers;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -30,6 +32,8 @@ import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -44,10 +48,8 @@ import org.springframework.test.web.servlet.MockMvc;
       "camunda.connector.auth.audience=connectors.dev.ultrawombat.com",
       "camunda.connector.cloud.organizationId=orgId",
       "camunda.connector.auth.console.audience=cloud.dev.ultrawombat.com",
-      "camunda.connector.auth.issuer=https://weblogin.cloud.dev.ultrawombat.com/",
       "camunda.connector.secretprovider.discovery.enabled=false",
       "management.endpoints.web.exposure.include=*",
-      "camunda.client.auth.token-url=https://weblogin.cloud.dev.ultrawombat.com/token",
       "camunda.client.auth.audience=connectors.dev.ultrawombat.com",
       "spring.cloud.gcp.parametermanager.enabled=false"
     })
@@ -57,6 +59,19 @@ import org.springframework.test.web.servlet.MockMvc;
 @CamundaSpringProcessTest
 @SlowTest
 public class InboundInstancesSecurityConfigurationTest {
+
+  private static final MockOidcServer OIDC_SERVER = MockOidcServer.start();
+
+  @DynamicPropertySource
+  static void registerOidcProperties(DynamicPropertyRegistry registry) {
+    registry.add("camunda.connector.auth.issuer", OIDC_SERVER::issuer);
+    registry.add("camunda.client.auth.token-url", OIDC_SERVER::tokenUrl);
+  }
+
+  @AfterAll
+  static void stopOidcServer() {
+    OIDC_SERVER.close();
+  }
 
   @MockitoBean(answers = Answers.RETURNS_MOCKS)
   public SaaSSecretConfiguration saaSSecretConfiguration;

--- a/bundle/camunda-saas-bundle/src/test/java/io/camunda/connector/runtime/saas/SecurityConfigurationTest.java
+++ b/bundle/camunda-saas-bundle/src/test/java/io/camunda/connector/runtime/saas/SecurityConfigurationTest.java
@@ -27,8 +27,10 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import io.camunda.connector.test.utils.annotation.SlowTest;
+import io.camunda.connector.test.utils.oidc.MockOidcServer;
 import io.camunda.process.test.api.CamundaSpringProcessTest;
 import java.time.Duration;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 import org.mockito.Answers;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -42,8 +44,9 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.test.context.support.WithMockUser;
-import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -52,21 +55,31 @@ import org.springframework.test.web.servlet.MockMvc;
     classes = {SaaSConnectorRuntimeApplication.class},
     properties = {
       "camunda.saas.secrets.projectId=42",
-      "camunda.client.enabled=true",
+      "camunda.connector.polling.enabled=false",
       "camunda.connector.auth.audience=connectors.dev.ultrawombat.com",
-      "camunda.connector.auth.issuer=https://weblogin.cloud.dev.ultrawombat.com/",
       "camunda.connector.secretprovider.discovery.enabled=false",
       "management.endpoints.web.exposure.include=*",
-      "camunda.client.auth.token-url=https://weblogin.cloud.dev.ultrawombat.com/token",
       "camunda.client.auth.audience=connectors.dev.ultrawombat.com",
       "spring.cloud.gcp.parametermanager.enabled=false"
     })
-@DirtiesContext
 @ActiveProfiles("test")
 @AutoConfigureMockMvc
 @CamundaSpringProcessTest
 @SlowTest
 public class SecurityConfigurationTest {
+
+  private static final MockOidcServer OIDC_SERVER = MockOidcServer.start();
+
+  @DynamicPropertySource
+  static void registerOidcProperties(DynamicPropertyRegistry registry) {
+    registry.add("camunda.connector.auth.issuer", OIDC_SERVER::issuer);
+    registry.add("camunda.client.auth.token-url", OIDC_SERVER::tokenUrl);
+  }
+
+  @AfterAll
+  static void stopOidcServer() {
+    OIDC_SERVER.close();
+  }
 
   @MockitoBean(answers = Answers.RETURNS_MOCKS)
   public SaaSSecretConfiguration saaSSecretConfiguration;

--- a/bundle/camunda-saas-bundle/src/test/java/io/camunda/connector/runtime/saas/TestSpringContextStartup.java
+++ b/bundle/camunda-saas-bundle/src/test/java/io/camunda/connector/runtime/saas/TestSpringContextStartup.java
@@ -16,11 +16,15 @@
  */
 package io.camunda.connector.runtime.saas;
 
+import io.camunda.connector.test.utils.oidc.MockOidcServer;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Answers;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @SpringBootTest(
@@ -28,9 +32,7 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
     properties = {
       "camunda.saas.secrets.projectId=42",
       "camunda.connector.auth.audience=connectors.dev.ultrawombat.com",
-      "camunda.connector.auth.issuer=https://weblogin.cloud.dev.ultrawombat.com/",
       "camunda.connector.secretprovider.discovery.enabled=false",
-      "camunda.client.auth.token-url=https://weblogin.cloud.dev.ultrawombat.com/token",
       "camunda.client.auth.audience=connectors.dev.ultrawombat.com",
       "spring.cloud.gcp.parametermanager.enabled=false"
     })
@@ -39,6 +41,19 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 // we keep it disabled to test the setup e2e with stackdriver logging configuration as in prod
 @ExtendWith(MockitoExtension.class)
 public class TestSpringContextStartup {
+
+  private static final MockOidcServer OIDC_SERVER = MockOidcServer.start();
+
+  @DynamicPropertySource
+  static void registerOidcProperties(DynamicPropertyRegistry registry) {
+    registry.add("camunda.connector.auth.issuer", OIDC_SERVER::issuer);
+    registry.add("camunda.client.auth.token-url", OIDC_SERVER::tokenUrl);
+  }
+
+  @AfterAll
+  static void stopOidcServer() {
+    OIDC_SERVER.close();
+  }
 
   @MockitoBean(answers = Answers.RETURNS_MOCKS)
   public SaaSSecretConfiguration saaSSecretConfiguration;

--- a/bundle/camunda-saas-bundle/src/test/java/io/camunda/connector/runtime/saas/auth/CustomCredentialsProviderNotUsedTest.java
+++ b/bundle/camunda-saas-bundle/src/test/java/io/camunda/connector/runtime/saas/auth/CustomCredentialsProviderNotUsedTest.java
@@ -21,12 +21,16 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.camunda.client.CredentialsProvider;
 import io.camunda.connector.runtime.saas.SaaSConnectorRuntimeApplication;
 import io.camunda.connector.runtime.saas.SaaSSecretConfiguration;
+import io.camunda.connector.test.utils.oidc.MockOidcServer;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 import org.mockito.Answers;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.ApplicationContext;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @SpringBootTest(
@@ -34,9 +38,7 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
     properties = {
       "camunda.saas.secrets.projectId=42",
       "camunda.connector.auth.audience=connectors.dev.ultrawombat.com",
-      "camunda.connector.auth.issuer=https://weblogin.cloud.dev.ultrawombat.com/",
       "camunda.connector.secretprovider.discovery.enabled=false",
-      "camunda.client.auth.token-url=https://weblogin.cloud.dev.ultrawombat.com/token",
       "camunda.client.auth.audience=connectors.dev.ultrawombat.com",
       "camunda.client.auth.client-id=client-id",
       "camunda.client.auth.client-secret=client-secret",
@@ -44,6 +46,19 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
     })
 @ActiveProfiles("test")
 public class CustomCredentialsProviderNotUsedTest {
+
+  private static final MockOidcServer OIDC_SERVER = MockOidcServer.start();
+
+  @DynamicPropertySource
+  static void registerOidcProperties(DynamicPropertyRegistry registry) {
+    registry.add("camunda.connector.auth.issuer", OIDC_SERVER::issuer);
+    registry.add("camunda.client.auth.token-url", OIDC_SERVER::tokenUrl);
+  }
+
+  @AfterAll
+  static void stopOidcServer() {
+    OIDC_SERVER.close();
+  }
 
   @MockitoBean(answers = Answers.RETURNS_MOCKS)
   public SaaSSecretConfiguration saaSSecretConfiguration;

--- a/bundle/camunda-saas-bundle/src/test/java/io/camunda/connector/runtime/saas/auth/CustomCredentialsProviderUsedTest.java
+++ b/bundle/camunda-saas-bundle/src/test/java/io/camunda/connector/runtime/saas/auth/CustomCredentialsProviderUsedTest.java
@@ -21,12 +21,16 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.camunda.client.CredentialsProvider;
 import io.camunda.connector.runtime.saas.SaaSConnectorRuntimeApplication;
 import io.camunda.connector.runtime.saas.SaaSSecretConfiguration;
+import io.camunda.connector.test.utils.oidc.MockOidcServer;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 import org.mockito.Answers;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.ApplicationContext;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @SpringBootTest(
@@ -34,15 +38,26 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
     properties = {
       "camunda.saas.secrets.projectId=42",
       "camunda.connector.auth.audience=connectors.dev.ultrawombat.com",
-      "camunda.connector.auth.issuer=https://weblogin.cloud.dev.ultrawombat.com/",
       "camunda.connector.secretprovider.discovery.enabled=false",
-      "camunda.client.auth.token-url=https://weblogin.cloud.dev.ultrawombat.com/token",
       "camunda.client.auth.audience=connectors.dev.ultrawombat.com",
       // NOTE: client-id and client-secret are NOT provided
       "spring.cloud.gcp.parametermanager.enabled=false"
     })
 @ActiveProfiles("test")
 public class CustomCredentialsProviderUsedTest {
+
+  private static final MockOidcServer OIDC_SERVER = MockOidcServer.start();
+
+  @DynamicPropertySource
+  static void registerOidcProperties(DynamicPropertyRegistry registry) {
+    registry.add("camunda.connector.auth.issuer", OIDC_SERVER::issuer);
+    registry.add("camunda.client.auth.token-url", OIDC_SERVER::tokenUrl);
+  }
+
+  @AfterAll
+  static void stopOidcServer() {
+    OIDC_SERVER.close();
+  }
 
   @MockitoBean(answers = Answers.RETURNS_MOCKS)
   public SaaSSecretConfiguration saaSSecretConfiguration;

--- a/connector-commons/connector-test-utils/pom.xml
+++ b/connector-commons/connector-test-utils/pom.xml
@@ -15,12 +15,21 @@
     <packaging>jar</packaging>
     <dependencies>
         <dependency>
+            <groupId>org.wiremock</groupId>
+            <artifactId>wiremock-standalone</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 </project>

--- a/connector-commons/connector-test-utils/src/main/java/io/camunda/connector/test/utils/oidc/MockOidcServer.java
+++ b/connector-commons/connector-test-utils/src/main/java/io/camunda/connector/test/utils/oidc/MockOidcServer.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.test.utils.oidc;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import java.security.KeyPairGenerator;
+import java.security.interfaces.RSAPublicKey;
+import java.util.Arrays;
+import java.util.Base64;
+
+/**
+ * Local OIDC issuer for tests that need provider discovery/JWKS endpoints without depending on an
+ * external identity provider.
+ */
+public final class MockOidcServer implements AutoCloseable {
+
+  private static final String OPEN_ID_CONFIGURATION_PATH = "/.well-known/openid-configuration";
+  private static final String JWKS_PATH = "/oauth2/jwks";
+  private static final String TOKEN_PATH = "/token";
+  private static final int DEFAULT_STUB_PRIORITY = 10;
+  private static final int CUSTOM_STUB_PRIORITY = 1;
+
+  private final WireMockServer server;
+
+  private MockOidcServer(WireMockServer server) {
+    this.server = server;
+  }
+
+  public static MockOidcServer start() {
+    var server = new WireMockServer(options().dynamicPort());
+    server.start();
+    var mockOidcServer = new MockOidcServer(server);
+    mockOidcServer.stubOidcEndpoints();
+    return mockOidcServer;
+  }
+
+  public String issuer() {
+    return server.baseUrl();
+  }
+
+  public String tokenUrl() {
+    return server.baseUrl() + TOKEN_PATH;
+  }
+
+  public MockOidcServer stubOpenIdConfigurationResponse(String body) {
+    return stubOpenIdConfigurationResponse(200, body);
+  }
+
+  public MockOidcServer stubOpenIdConfigurationResponse(int status, String body) {
+    server.stubFor(
+        WireMock.get(urlEqualTo(OPEN_ID_CONFIGURATION_PATH))
+            .atPriority(CUSTOM_STUB_PRIORITY)
+            .willReturn(jsonResponse(status, body)));
+    return this;
+  }
+
+  public MockOidcServer stubJwksResponse(String body) {
+    return stubJwksResponse(200, body);
+  }
+
+  public MockOidcServer stubJwksResponse(int status, String body) {
+    server.stubFor(
+        WireMock.get(urlEqualTo(JWKS_PATH))
+            .atPriority(CUSTOM_STUB_PRIORITY)
+            .willReturn(jsonResponse(status, body)));
+    return this;
+  }
+
+  public MockOidcServer stubTokenResponse(String body) {
+    return stubTokenResponse(200, body);
+  }
+
+  public MockOidcServer stubTokenResponse(int status, String body) {
+    server.stubFor(
+        WireMock.post(urlEqualTo(TOKEN_PATH))
+            .atPriority(CUSTOM_STUB_PRIORITY)
+            .willReturn(jsonResponse(status, body)));
+    return this;
+  }
+
+  @Override
+  public void close() {
+    server.stop();
+  }
+
+  private void stubOidcEndpoints() {
+    server.stubFor(
+        WireMock.get(urlEqualTo(OPEN_ID_CONFIGURATION_PATH))
+            .atPriority(DEFAULT_STUB_PRIORITY)
+            .willReturn(
+                jsonResponse(
+                    200,
+                    """
+                    {
+                      "issuer": "%s",
+                      "jwks_uri": "%s%s",
+                      "id_token_signing_alg_values_supported": ["RS256"]
+                    }
+                    """
+                        .formatted(issuer(), issuer(), JWKS_PATH))));
+    server.stubFor(
+        WireMock.get(urlEqualTo(JWKS_PATH))
+            .atPriority(DEFAULT_STUB_PRIORITY)
+            .willReturn(
+                jsonResponse(
+                    200,
+                    """
+                    {"keys": [%s]}
+                    """
+                        .formatted(jwk()))));
+    server.stubFor(
+        WireMock.post(urlEqualTo(TOKEN_PATH))
+            .atPriority(DEFAULT_STUB_PRIORITY)
+            .willReturn(jsonResponse(401, "")));
+  }
+
+  private static ResponseDefinitionBuilder jsonResponse(int status, String body) {
+    return aResponse()
+        .withStatus(status)
+        .withHeader("Content-Type", "application/json")
+        .withBody(body);
+  }
+
+  private static String jwk() {
+    try {
+      var keyPairGenerator = KeyPairGenerator.getInstance("RSA");
+      keyPairGenerator.initialize(2048);
+      var keyPair = keyPairGenerator.generateKeyPair();
+      var publicKey = (RSAPublicKey) keyPair.getPublic();
+      return """
+          {
+            "kty": "RSA",
+            "kid": "test-key",
+            "use": "sig",
+            "alg": "RS256",
+            "n": "%s",
+            "e": "%s"
+          }
+          """
+          .formatted(
+              base64Url(publicKey.getModulus().toByteArray()),
+              base64Url(publicKey.getPublicExponent().toByteArray()));
+    } catch (Exception e) {
+      throw new IllegalStateException("Failed to create test JWK", e);
+    }
+  }
+
+  private static String base64Url(byte[] bytes) {
+    if (bytes.length > 1 && bytes[0] == 0) {
+      bytes = Arrays.copyOfRange(bytes, 1, bytes.length);
+    }
+    return Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
+  }
+}

--- a/connector-commons/connector-test-utils/src/test/java/io/camunda/connector/test/utils/oidc/MockOidcServerTest.java
+++ b/connector-commons/connector-test-utils/src/test/java/io/camunda/connector/test/utils/oidc/MockOidcServerTest.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.test.utils.oidc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse.BodyHandlers;
+import org.junit.jupiter.api.Test;
+
+class MockOidcServerTest {
+
+  private final HttpClient httpClient = HttpClient.newHttpClient();
+
+  @Test
+  void shouldServeOpenIdConfiguration() throws Exception {
+    try (var server = MockOidcServer.start()) {
+      var response =
+          httpClient.send(
+              HttpRequest.newBuilder(
+                      URI.create(server.issuer() + "/.well-known/openid-configuration"))
+                  .GET()
+                  .build(),
+              BodyHandlers.ofString());
+
+      assertThat(response.statusCode()).isEqualTo(200);
+      assertThat(response.body())
+          .contains("\"issuer\": \"" + server.issuer() + "\"")
+          .contains("\"jwks_uri\": \"" + server.issuer() + "/oauth2/jwks\"");
+    }
+  }
+
+  @Test
+  void shouldServeJwks() throws Exception {
+    try (var server = MockOidcServer.start()) {
+      var response =
+          httpClient.send(
+              HttpRequest.newBuilder(URI.create(server.issuer() + "/oauth2/jwks")).GET().build(),
+              BodyHandlers.ofString());
+
+      assertThat(response.statusCode()).isEqualTo(200);
+      assertThat(response.body())
+          .contains("\"keys\"")
+          .contains("\"kty\": \"RSA\"")
+          .contains("\"alg\": \"RS256\"");
+    }
+  }
+
+  @Test
+  void shouldRejectTokenRequests() throws Exception {
+    try (var server = MockOidcServer.start()) {
+      var response =
+          httpClient.send(
+              HttpRequest.newBuilder(URI.create(server.tokenUrl()))
+                  .POST(HttpRequest.BodyPublishers.noBody())
+                  .build(),
+              BodyHandlers.ofString());
+
+      assertThat(response.statusCode()).isEqualTo(401);
+    }
+  }
+
+  @Test
+  void shouldAllowCustomOpenIdConfigurationResponse() throws Exception {
+    try (var server = MockOidcServer.start()) {
+      server.stubOpenIdConfigurationResponse(503, "{\"error\":\"unavailable\"}");
+
+      var response =
+          httpClient.send(
+              HttpRequest.newBuilder(
+                      URI.create(server.issuer() + "/.well-known/openid-configuration"))
+                  .GET()
+                  .build(),
+              BodyHandlers.ofString());
+
+      assertThat(response.statusCode()).isEqualTo(503);
+      assertThat(response.body()).isEqualTo("{\"error\":\"unavailable\"}");
+    }
+  }
+
+  @Test
+  void shouldAllowCustomJwksResponse() throws Exception {
+    try (var server = MockOidcServer.start()) {
+      server.stubJwksResponse(500, "{\"keys\":[]}");
+
+      var response =
+          httpClient.send(
+              HttpRequest.newBuilder(URI.create(server.issuer() + "/oauth2/jwks")).GET().build(),
+              BodyHandlers.ofString());
+
+      assertThat(response.statusCode()).isEqualTo(500);
+      assertThat(response.body()).isEqualTo("{\"keys\":[]}");
+    }
+  }
+
+  @Test
+  void shouldAllowCustomTokenResponse() throws Exception {
+    try (var server = MockOidcServer.start()) {
+      server.stubTokenResponse(
+          """
+          {
+            "access_token": "test-access-token",
+            "token_type": "Bearer",
+            "expires_in": 3600
+          }
+          """);
+
+      var response =
+          httpClient.send(
+              HttpRequest.newBuilder(URI.create(server.tokenUrl()))
+                  .POST(HttpRequest.BodyPublishers.noBody())
+                  .build(),
+              BodyHandlers.ofString());
+
+      assertThat(response.statusCode()).isEqualTo(200);
+      assertThat(response.body()).contains("\"access_token\": \"test-access-token\"");
+    }
+  }
+}

--- a/connectors-e2e-test/connectors-e2e-test-message/src/test/java/io/camunda/connector/e2e/MessageTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-message/src/test/java/io/camunda/connector/e2e/MessageTests.java
@@ -22,6 +22,7 @@ import io.camunda.client.CamundaClient;
 import io.camunda.client.api.response.ProcessInstanceEvent;
 import io.camunda.connector.e2e.app.TestConnectorRuntimeApplication;
 import io.camunda.connector.test.utils.annotation.SlowTest;
+import io.camunda.connector.test.utils.oidc.MockOidcServer;
 import io.camunda.process.test.api.CamundaAssert;
 import io.camunda.process.test.api.CamundaSpringProcessTest;
 import io.camunda.zeebe.model.bpmn.Bpmn;
@@ -29,6 +30,7 @@ import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import java.io.File;
 import java.util.concurrent.TimeUnit;
 import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -38,6 +40,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.ComponentScan;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
 
 @SpringBootTest(
     classes = {TestConnectorRuntimeApplication.class},
@@ -50,7 +54,6 @@ import org.springframework.context.annotation.ComponentScan;
       "camunda.connector.auth.audience=connectors.dev.ultrawombat.com",
       "camunda.connector.cloud.organizationId=orgId",
       "camunda.connector.auth.console.audience=cloud.dev.ultrawombat.com",
-      "camunda.connector.auth.issuer=https://weblogin.cloud.dev.ultrawombat.com/",
       "camunda.connector.secretprovider.discovery.enabled=false",
       "management.endpoints.web.exposure.include=*"
     },
@@ -64,6 +67,17 @@ public class MessageTests {
   private static final String MESSAGE_NAME = "first-message";
   private static final String CORRELATION_KEY_EXPRESSION = "valOneCorrelation";
   private static final String CORRELATION_VALUE = "123";
+  private static final MockOidcServer OIDC_SERVER = MockOidcServer.start();
+
+  @DynamicPropertySource
+  static void registerOidcProperties(DynamicPropertyRegistry registry) {
+    registry.add("camunda.connector.auth.issuer", OIDC_SERVER::issuer);
+  }
+
+  @AfterAll
+  static void stopOidcServer() {
+    OIDC_SERVER.close();
+  }
 
   @TempDir File tempDir;
 


### PR DESCRIPTION
Backport of #7081 to `stable/8.8`.

## Summary
- Introduces `MockOidcServer` to replace hardcoded OIDC URLs in tests
- Removes `@DirtiesContext` annotation (no longer needed with dynamic property injection)
- Adds `@DynamicPropertySource` to wire `MockOidcServer` issuer and token URL into test context

## Conflict resolution
`SecurityConfigurationTest.java` had a minor import conflict: `stable/8.8` had `WithMockUser` + `DirtiesContext`; cherry-pick side had `SimpleGrantedAuthority`. Kept `WithMockUser` (still used by test methods), dropped both `DirtiesContext` (removed by this commit) and `SimpleGrantedAuthority` (not used in this file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)