### PR TITLE
fix: quick fix, pages are now streamed one by one

### DIFF
--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/importer/Importers.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/importer/Importers.java
@@ -41,7 +41,7 @@ public class Importers {
     LOGGER.debug("Starting import of LATEST versions");
 
     Map<ProcessDefinitionRef, Set<Long>> result =
-        PaginatedSearchUtil.queryAllPages(searchQueryClient::queryProcessDefinitions).stream()
+        PaginatedSearchUtil.queryAllPages(searchQueryClient::queryProcessDefinitions)
             .collect(
                 Collectors.toMap(
                     definition ->
@@ -71,7 +71,6 @@ public class Importers {
 
     Map<ProcessDefinitionRef, Set<Long>> result =
         PaginatedSearchUtil.queryAllPages(searchQueryClient::queryMessageSubscriptionStatistics)
-            .stream()
             .collect(
                 Collectors.groupingBy(
                     stats ->

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/importer/PaginatedSearchUtil.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/importer/PaginatedSearchUtil.java
@@ -19,9 +19,8 @@ package io.camunda.connector.runtime.inbound.importer;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 import io.camunda.client.api.search.response.SearchResponse;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.function.Function;
+import java.util.stream.Stream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -35,30 +34,25 @@ final class PaginatedSearchUtil {
   private PaginatedSearchUtil() {}
 
   /**
-   * Executes a paginated query until an empty page is returned.
+   * Executes a paginated query lazily, fetching the next page only when the current page's items
+   * have been consumed. Iteration stops when a page is empty or its {@code endCursor} is blank.
    *
-   * @param pageFetcher function fetching a single page (input = pagination index, output = page)
+   * @param pageFetcher function fetching a single page (input = pagination cursor, output = page)
    * @param <T> item type
-   * @return all items from all pages
+   * @return a lazy stream of all items across all pages
    */
-  static <T> List<T> queryAllPages(Function<String, SearchResponse<T>> pageFetcher) {
-    List<T> items = new ArrayList<>();
-    SearchResponse<T> page;
-
-    String paginationIndex = null;
-    do {
-      page = pageFetcher.apply(paginationIndex);
-      String newPaginationIdx = page.page().endCursor();
-
-      LOG.trace("A page of size {} has been fetched, continuing...", page.items().size());
-
-      if (isNotBlank(newPaginationIdx)) {
-        paginationIndex = newPaginationIdx;
-      }
-
-      items.addAll(page.items());
-    } while (page.items() != null && !page.items().isEmpty());
-
-    return items;
+  static <T> Stream<T> queryAllPages(Function<String, SearchResponse<T>> pageFetcher) {
+    SearchResponse<T> firstPage = pageFetcher.apply(null);
+    return Stream.iterate(
+            firstPage,
+            page -> page != null && page.items() != null && !page.items().isEmpty(),
+            page -> {
+              String cursor = page.page().endCursor();
+              return isNotBlank(cursor) ? pageFetcher.apply(cursor) : null;
+            })
+        .peek(
+            page ->
+                LOG.trace("A page of size {} has been fetched, continuing...", page.items().size()))
+        .flatMap(page -> page.items().stream());
   }
 }

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/inbound/importer/PaginatedSearchUtilTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/inbound/importer/PaginatedSearchUtilTest.java
@@ -28,6 +28,7 @@ import io.camunda.client.impl.search.response.SearchResponseImpl;
 import io.camunda.client.impl.search.response.SearchResponsePageImpl;
 import java.util.List;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 
 public class PaginatedSearchUtilTest {
@@ -43,7 +44,8 @@ public class PaginatedSearchUtilTest {
     when(pageFetcher.apply("cursor1")).thenReturn(emptyPage);
 
     // When
-    List<String> result = PaginatedSearchUtil.queryAllPages(pageFetcher);
+    List<String> result =
+        PaginatedSearchUtil.queryAllPages(pageFetcher).collect(Collectors.toList());
 
     // Then
     assertEquals(3, result.size());
@@ -68,7 +70,8 @@ public class PaginatedSearchUtilTest {
     when(pageFetcher.apply("cursor3")).thenReturn(emptyPage);
 
     // When
-    List<String> result = PaginatedSearchUtil.queryAllPages(pageFetcher);
+    List<String> result =
+        PaginatedSearchUtil.queryAllPages(pageFetcher).collect(Collectors.toList());
 
     // Then
     assertEquals(5, result.size());
@@ -88,7 +91,8 @@ public class PaginatedSearchUtilTest {
     when(pageFetcher.apply(null)).thenReturn(emptyPage);
 
     // When
-    List<String> result = PaginatedSearchUtil.queryAllPages(pageFetcher);
+    List<String> result =
+        PaginatedSearchUtil.queryAllPages(pageFetcher).collect(Collectors.toList());
 
     // Then
     assertTrue(result.isEmpty());
@@ -107,13 +111,54 @@ public class PaginatedSearchUtilTest {
     when(pageFetcher.apply("cursor1")).thenReturn(emptyPage);
 
     // When
-    List<String> result = PaginatedSearchUtil.queryAllPages(pageFetcher);
+    List<String> result =
+        PaginatedSearchUtil.queryAllPages(pageFetcher).collect(Collectors.toList());
 
     // Then
     assertEquals(1, result.size());
     assertEquals(List.of("item1"), result);
     verify(pageFetcher, times(1)).apply(null);
     verify(pageFetcher, times(1)).apply("cursor1");
+  }
+
+  @Test
+  public void shouldStopWhenEndCursorIsBlankOnNonEmptyPage() {
+    // Given: non-empty final page with no cursor — must terminate, not re-fetch the same page.
+    SearchResponse<String> page1 = createPage(List.of("item1", "item2"), "cursor1");
+    SearchResponse<String> finalPage = createPage(List.of("item3"), null);
+
+    @SuppressWarnings("unchecked")
+    Function<String, SearchResponse<String>> pageFetcher = mock(Function.class);
+    when(pageFetcher.apply(null)).thenReturn(page1);
+    when(pageFetcher.apply("cursor1")).thenReturn(finalPage);
+
+    // When
+    List<String> result =
+        PaginatedSearchUtil.queryAllPages(pageFetcher).collect(Collectors.toList());
+
+    // Then
+    assertEquals(List.of("item1", "item2", "item3"), result);
+    verify(pageFetcher, times(1)).apply(null);
+    verify(pageFetcher, times(1)).apply("cursor1");
+  }
+
+  @Test
+  public void shouldFetchPagesLazily() {
+    // Given: page2 fetch would explode if invoked — proves it is never requested.
+    SearchResponse<String> page1 = createPage(List.of("item1", "item2"), "cursor1");
+
+    @SuppressWarnings("unchecked")
+    Function<String, SearchResponse<String>> pageFetcher = mock(Function.class);
+    when(pageFetcher.apply(null)).thenReturn(page1);
+    when(pageFetcher.apply("cursor1"))
+        .thenThrow(new AssertionError("second page must not be fetched"));
+
+    // When: consume only the first item, then stop.
+    String first = PaginatedSearchUtil.queryAllPages(pageFetcher).findFirst().orElseThrow();
+
+    // Then
+    assertEquals("item1", first);
+    verify(pageFetcher, times(1)).apply(null);
   }
 
   private <T> SearchResponse<T> createPage(List<T> items, String endCursor) {


### PR DESCRIPTION
This pull request refactors the `PaginatedSearchUtil.queryAllPages` utility to provide a lazy, stream-based approach to paginated queries, improving performance and resource usage. It also updates all usages and tests to align with the new streaming API, and adds new test cases to ensure correct lazy evaluation and proper termination conditions.

**Paginated query utility improvements:**

* Refactored `PaginatedSearchUtil.queryAllPages` to return a `Stream<T>` instead of a `List<T>`, enabling lazy fetching of paginated results and fetching the next page only when needed. The iteration now terminates when a page is empty or its `endCursor` is blank.
* Updated all usages of `queryAllPages` in `Importers.java` to consume the returned stream, collecting results as needed. [[1]](diffhunk://#diff-3e7d57b068e54a8fdc2c08e0e34c3b32594ffd31fb35ec24389afbc8084a1143L44-R44) [[2]](diffhunk://#diff-3e7d57b068e54a8fdc2c08e0e34c3b32594ffd31fb35ec24389afbc8084a1143L74)

**Test updates and enhancements:**

* Updated all tests in `PaginatedSearchUtilTest` to work with the new stream-based API by collecting results from the stream. [[1]](diffhunk://#diff-850aae8b03088cd7577c137ce2f48860051dfa43f1a98270fee76c8513feac85L46-R48) [[2]](diffhunk://#diff-850aae8b03088cd7577c137ce2f48860051dfa43f1a98270fee76c8513feac85L71-R74) [[3]](diffhunk://#diff-850aae8b03088cd7577c137ce2f48860051dfa43f1a98270fee76c8513feac85L91-R95) [[4]](diffhunk://#diff-850aae8b03088cd7577c137ce2f48860051dfa43f1a98270fee76c8513feac85L110-R115)
* Added new tests to verify that iteration stops when the `endCursor` is blank on a non-empty page, and to ensure pages are fetched lazily (i.e., only as needed).

**Dependency and import cleanup:**

* Removed unused imports and added necessary ones for stream handling in `PaginatedSearchUtil.java` and its test. [[1]](diffhunk://#diff-b2346d297fbee52678eb865f8e621ec15eaffb935e57450103653c9e3fa8a4a9L22-R23) [[2]](diffhunk://#diff-850aae8b03088cd7577c137ce2f48860051dfa43f1a98270fee76c8513feac85R31)