### PR TITLE
other: bump Camunda client to 8.10.0-alpha2

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -70,7 +70,7 @@ limitations under the License.</license.inlineheader>
     <nexus.release.repository>https://artifacts.camunda.com/artifactory/connectors/</nexus.release.repository>
 
     <!-- Camunda internal libraries -->
-    <version.camunda>8.10.0-alpha2-rc1</version.camunda>
+    <version.camunda>8.10.0-alpha2</version.camunda>
     <version.feel-engine>1.21.0</version.feel-engine>
     <version.camunda-xml-model>7.24.0</version.camunda-xml-model>
 


### PR DESCRIPTION
## Description

This pull request makes a minor update to the Camunda dependency version in the `parent/pom.xml` file, moving from a release candidate to the final alpha2 version.

- Updated the `version.camunda` property from `8.10.0-alpha2-rc1` to `8.10.0-alpha2` in `parent/pom.xml` to use the finalized alpha2 release.
