### PR TITLE
feat(element-template-generator): support custom category via annotation

### DIFF
--- a/element-template-generator/annotations/README.md
+++ b/element-template-generator/annotations/README.md
@@ -296,9 +296,8 @@ constructor injection.
 
 ## Category
 
-By default, the generated element template is assigned to the `connectors`/`Connectors` category in
-Camunda Modeler. You can override this by defining a custom category in the `@ElementTemplate`
-annotation:
+By default, the generated element template is assigned to the `connectors`/`Connectors` category.
+You can override this by defining a custom category in the `@ElementTemplate` annotation:
 
 ```java
 @ElementTemplate(

--- a/element-template-generator/annotations/README.md
+++ b/element-template-generator/annotations/README.md
@@ -304,7 +304,7 @@ You can override this by defining a custom category in the `@ElementTemplate` an
     id = "myConnector",
     name = "My Connector",
     version = 1,
-    category = @ElementTemplate.Category(id = "agentic-ai", name = "Agentic AI"))
+    category = @ElementTemplate.Category(id = "custom-category", name = "Custom Category"))
 public class MyConnectorFunction { }
 ```
 

--- a/element-template-generator/annotations/README.md
+++ b/element-template-generator/annotations/README.md
@@ -294,6 +294,24 @@ adds the individual connector resources to the custom class loader that can be c
 Template Generator either via `Thread.currentThread().getContextClassLoader()` or directly via
 constructor injection.
 
+## Category
+
+By default, the generated element template is assigned to the `connectors`/`Connectors` category in
+Camunda Modeler. You can override this by defining a custom category in the `@ElementTemplate`
+annotation:
+
+```java
+@ElementTemplate(
+    id = "myConnector",
+    name = "My Connector",
+    version = 1,
+    category = @ElementTemplate.Category(id = "agentic-ai", name = "Agentic AI"))
+public class MyConnectorFunction { }
+```
+
+Both `id` and `name` must be set when overriding the category. If the category is not specified,
+the default `connectors`/`Connectors` category is used.
+
 ## Element Template DSL
 
 This module defines a DSL for building element templates programmatically. The starting point is the

--- a/element-template-generator/annotations/src/main/java/io/camunda/connector/generator/java/annotation/ElementTemplate.java
+++ b/element-template-generator/annotations/src/main/java/io/camunda/connector/generator/java/annotation/ElementTemplate.java
@@ -95,6 +95,14 @@ public @interface ElementTemplate {
   PropertyGroup[] propertyGroups() default {};
 
   /**
+   * Element template category. Will be displayed as a group label in the Camunda Modeler element
+   * template selection.
+   *
+   * <p>If not specified, defaults to the {@code connectors} / {@code Connectors} category.
+   */
+  Category category() default @Category(id = "", name = "");
+
+  /**
    * Icon for the connector. Will be displayed in Camunda Modeler along with the connector name.
    * Should be a classpath resource path. The classpath resource should either be an SVG or PNG
    * image.
@@ -119,6 +127,18 @@ public @interface ElementTemplate {
    * <p>If not specified, no default expression value will be set.
    */
   String defaultResultExpression() default "";
+
+  @interface Category {
+
+    /** Element template category ID, e.g. {@code connectors}. */
+    String id();
+
+    /**
+     * Human-readable element template category name displayed in Camunda Modeler, e.g. {@code
+     * Connectors}.
+     */
+    String name();
+  }
 
   @interface PropertyGroup {
 

--- a/element-template-generator/annotations/src/main/java/io/camunda/connector/generator/java/annotation/ElementTemplate.java
+++ b/element-template-generator/annotations/src/main/java/io/camunda/connector/generator/java/annotation/ElementTemplate.java
@@ -57,6 +57,14 @@ public @interface ElementTemplate {
   long version() default 0;
 
   /**
+   * Element template category. Will be displayed as a group label in the Camunda Modeler element
+   * template selection.
+   *
+   * <p>If not specified, defaults to the {@code connectors} / {@code Connectors} category.
+   */
+  Category category() default @Category(id = "connectors", name = "Connectors");
+
+  /**
    * Link to the documentation page for the connector. Will be used by the Camunda Modeler to
    * redirect users to the documentation page when they click on the corresponding button.
    *
@@ -93,14 +101,6 @@ public @interface ElementTemplate {
    * in Camunda Modeler.
    */
   PropertyGroup[] propertyGroups() default {};
-
-  /**
-   * Element template category. Will be displayed as a group label in the Camunda Modeler element
-   * template selection.
-   *
-   * <p>If not specified, defaults to the {@code connectors} / {@code Connectors} category.
-   */
-  Category category() default @Category(id = "connectors", name = "Connectors");
 
   /**
    * Icon for the connector. Will be displayed in Camunda Modeler along with the connector name.

--- a/element-template-generator/annotations/src/main/java/io/camunda/connector/generator/java/annotation/ElementTemplate.java
+++ b/element-template-generator/annotations/src/main/java/io/camunda/connector/generator/java/annotation/ElementTemplate.java
@@ -100,7 +100,7 @@ public @interface ElementTemplate {
    *
    * <p>If not specified, defaults to the {@code connectors} / {@code Connectors} category.
    */
-  Category category() default @Category(id = "", name = "");
+  Category category() default @Category(id = "connectors", name = "Connectors");
 
   /**
    * Icon for the connector. Will be displayed in Camunda Modeler along with the connector name.

--- a/element-template-generator/core/src/main/java/io/camunda/connector/generator/dsl/ElementTemplate.java
+++ b/element-template-generator/core/src/main/java/io/camunda/connector/generator/dsl/ElementTemplate.java
@@ -47,6 +47,7 @@ public record ElementTemplate(
     String id,
     String name,
     long version,
+    ElementTemplateCategory category,
     String documentationRef,
     Engines engines,
     String description,
@@ -55,17 +56,13 @@ public record ElementTemplate(
     ElementTypeWrapper elementType,
     List<PropertyGroup> groups,
     List<Property> properties,
-    ElementTemplateIcon icon,
-    ElementTemplateCategory category) {
+    ElementTemplateIcon icon) {
 
   static final String SCHEMA_FIELD_NAME = "$schema";
   static final String SCHEMA_URL =
       "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json";
 
   public ElementTemplate {
-    if (category == null) {
-      category = ElementTemplateCategory.CONNECTORS;
-    }
     List<String> errors = new ArrayList<>();
     if (id == null) {
       errors.add("id is required");
@@ -76,7 +73,8 @@ public record ElementTemplate(
     if (version < 0) {
       errors.add("version cannot be negative");
     }
-    if (category.id() == null
+    if (category == null
+        || category.id() == null
         || category.id().isBlank()
         || category.name() == null
         || category.name().isBlank()) {

--- a/element-template-generator/core/src/main/java/io/camunda/connector/generator/dsl/ElementTemplate.java
+++ b/element-template-generator/core/src/main/java/io/camunda/connector/generator/dsl/ElementTemplate.java
@@ -76,6 +76,12 @@ public record ElementTemplate(
     if (version < 0) {
       errors.add("version cannot be negative");
     }
+    if (category.id() == null
+        || category.id().isBlank()
+        || category.name() == null
+        || category.name().isBlank()) {
+      errors.add("category id and name must be non-blank");
+    }
     if (appliesTo == null || appliesTo.isEmpty() || appliesTo.stream().allMatch(String::isBlank)) {
       errors.add("appliesTo must be defined");
     }

--- a/element-template-generator/core/src/main/java/io/camunda/connector/generator/dsl/ElementTemplate.java
+++ b/element-template-generator/core/src/main/java/io/camunda/connector/generator/dsl/ElementTemplate.java
@@ -55,13 +55,17 @@ public record ElementTemplate(
     ElementTypeWrapper elementType,
     List<PropertyGroup> groups,
     List<Property> properties,
-    ElementTemplateIcon icon) {
+    ElementTemplateIcon icon,
+    ElementTemplateCategory category) {
 
   static final String SCHEMA_FIELD_NAME = "$schema";
   static final String SCHEMA_URL =
       "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json";
 
   public ElementTemplate {
+    if (category == null) {
+      category = ElementTemplateCategory.CONNECTORS;
+    }
     List<String> errors = new ArrayList<>();
     if (id == null) {
       errors.add("id is required");
@@ -110,11 +114,6 @@ public record ElementTemplate(
 
   public static ElementTemplateBuilder builderForInbound() {
     return ElementTemplateBuilder.createInbound();
-  }
-
-  @JsonProperty
-  public ElementTemplateCategory category() {
-    return ElementTemplateCategory.CONNECTORS;
   }
 
   @JsonProperty(SCHEMA_FIELD_NAME)

--- a/element-template-generator/core/src/main/java/io/camunda/connector/generator/dsl/ElementTemplateBuilder.java
+++ b/element-template-generator/core/src/main/java/io/camunda/connector/generator/dsl/ElementTemplateBuilder.java
@@ -37,8 +37,7 @@ public class ElementTemplateBuilder {
   protected String id;
   protected String name;
   protected long version;
-  protected ElementTemplateCategory category =
-      new ElementTemplateCategory("connectors", "Connectors");
+  protected ElementTemplateCategory category = ElementTemplateCategory.CONNECTORS;
   protected ElementTemplateIcon icon;
   protected String documentationRef;
   protected String description;

--- a/element-template-generator/core/src/main/java/io/camunda/connector/generator/dsl/ElementTemplateBuilder.java
+++ b/element-template-generator/core/src/main/java/io/camunda/connector/generator/dsl/ElementTemplateBuilder.java
@@ -44,6 +44,7 @@ public class ElementTemplateBuilder {
   protected String[] keywords;
   protected Set<String> appliesTo;
   protected BpmnType elementType;
+  protected ElementTemplateCategory category;
 
   private ElementTemplateBuilder(Mode mode) {
     this.mode = mode;
@@ -171,6 +172,11 @@ public class ElementTemplateBuilder {
     return this;
   }
 
+  public ElementTemplateBuilder category(ElementTemplateCategory category) {
+    this.category = category;
+    return this;
+  }
+
   public ElementTemplateBuilder propertyGroups(PropertyGroup... groups) {
     this.groups.addAll(Arrays.asList(groups));
     this.properties.addAll(
@@ -210,7 +216,8 @@ public class ElementTemplateBuilder {
         ElementTypeWrapper.from(elementType),
         groups,
         properties,
-        icon);
+        icon,
+        category);
   }
 
   private enum Mode {

--- a/element-template-generator/core/src/main/java/io/camunda/connector/generator/dsl/ElementTemplateBuilder.java
+++ b/element-template-generator/core/src/main/java/io/camunda/connector/generator/dsl/ElementTemplateBuilder.java
@@ -37,7 +37,8 @@ public class ElementTemplateBuilder {
   protected String id;
   protected String name;
   protected long version;
-  protected ElementTemplateCategory category = ElementTemplateCategory.CONNECTORS;
+  protected ElementTemplateCategory category =
+      new ElementTemplateCategory("connectors", "Connectors");
   protected ElementTemplateIcon icon;
   protected String documentationRef;
   protected String description;

--- a/element-template-generator/core/src/main/java/io/camunda/connector/generator/dsl/ElementTemplateBuilder.java
+++ b/element-template-generator/core/src/main/java/io/camunda/connector/generator/dsl/ElementTemplateBuilder.java
@@ -37,6 +37,7 @@ public class ElementTemplateBuilder {
   protected String id;
   protected String name;
   protected long version;
+  protected ElementTemplateCategory category = ElementTemplateCategory.CONNECTORS;
   protected ElementTemplateIcon icon;
   protected String documentationRef;
   protected String description;
@@ -44,7 +45,6 @@ public class ElementTemplateBuilder {
   protected String[] keywords;
   protected Set<String> appliesTo;
   protected BpmnType elementType;
-  protected ElementTemplateCategory category;
 
   private ElementTemplateBuilder(Mode mode) {
     this.mode = mode;
@@ -132,6 +132,11 @@ public class ElementTemplateBuilder {
     return this;
   }
 
+  public ElementTemplateBuilder category(ElementTemplateCategory category) {
+    this.category = category;
+    return this;
+  }
+
   public ElementTemplateBuilder engines(Engines engines) {
     this.engines = engines;
     return this;
@@ -172,11 +177,6 @@ public class ElementTemplateBuilder {
     return this;
   }
 
-  public ElementTemplateBuilder category(ElementTemplateCategory category) {
-    this.category = category;
-    return this;
-  }
-
   public ElementTemplateBuilder propertyGroups(PropertyGroup... groups) {
     this.groups.addAll(Arrays.asList(groups));
     this.properties.addAll(
@@ -208,6 +208,7 @@ public class ElementTemplateBuilder {
         id,
         name,
         version,
+        category,
         documentationRef,
         engines,
         description,
@@ -216,8 +217,7 @@ public class ElementTemplateBuilder {
         ElementTypeWrapper.from(elementType),
         groups,
         properties,
-        icon,
-        category);
+        icon);
   }
 
   private enum Mode {

--- a/element-template-generator/core/src/main/java/io/camunda/connector/generator/dsl/ElementTemplateCategory.java
+++ b/element-template-generator/core/src/main/java/io/camunda/connector/generator/dsl/ElementTemplateCategory.java
@@ -16,8 +16,4 @@
  */
 package io.camunda.connector.generator.dsl;
 
-public record ElementTemplateCategory(String id, String name) {
-
-  public static final ElementTemplateCategory CONNECTORS =
-      new ElementTemplateCategory("connectors", "Connectors");
-}
+public record ElementTemplateCategory(String id, String name) {}

--- a/element-template-generator/core/src/main/java/io/camunda/connector/generator/dsl/ElementTemplateCategory.java
+++ b/element-template-generator/core/src/main/java/io/camunda/connector/generator/dsl/ElementTemplateCategory.java
@@ -16,4 +16,8 @@
  */
 package io.camunda.connector.generator.dsl;
 
-public record ElementTemplateCategory(String id, String name) {}
+public record ElementTemplateCategory(String id, String name) {
+
+  public static final ElementTemplateCategory CONNECTORS =
+      new ElementTemplateCategory("connectors", "Connectors");
+}

--- a/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/ClassBasedTemplateGenerator.java
+++ b/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/ClassBasedTemplateGenerator.java
@@ -278,12 +278,7 @@ public class ClassBasedTemplateGenerator implements ElementTemplateGenerator<Cla
 
   private static ElementTemplateCategory resolveCategory(ElementTemplate template) {
     var category = template.category();
-    boolean idBlank = category.id().isBlank();
-    boolean nameBlank = category.name().isBlank();
-    if (idBlank && nameBlank) {
-      return null;
-    }
-    if (idBlank || nameBlank) {
+    if (category.id().isBlank() || category.name().isBlank()) {
       throw new IllegalArgumentException(
           "Element template category requires both id and name to be set");
     }

--- a/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/ClassBasedTemplateGenerator.java
+++ b/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/ClassBasedTemplateGenerator.java
@@ -190,8 +190,6 @@ public class ClassBasedTemplateGenerator implements ElementTemplateGenerator<Cla
           template.engineVersion() + " is not a valid semantic version");
     }
 
-    var category = resolveCategory(template);
-
     return context.elementTypes().stream()
         .map(
             elementType -> {
@@ -205,6 +203,9 @@ public class ClassBasedTemplateGenerator implements ElementTemplateGenerator<Cla
                   .type(context.connectorType(), isHybridMode)
                   .name(createName(context, template.name(), elementType, isHybridMode))
                   .version(template.version())
+                  .category(
+                      new ElementTemplateCategory(
+                          template.category().id(), template.category().name()))
                   .appliesTo(elementType.appliesTo())
                   .engines(
                       !template.engineVersion().isBlank()
@@ -216,7 +217,6 @@ public class ClassBasedTemplateGenerator implements ElementTemplateGenerator<Cla
                   .documentationRef(
                       template.documentationRef().isEmpty() ? null : template.documentationRef())
                   .description(template.description().isEmpty() ? null : template.description())
-                  .category(category)
                   .properties(nonGroupedProperties.stream().map(PropertyBuilder::build).toList())
                   .propertyGroups(
                       addServiceProperties(
@@ -274,15 +274,6 @@ public class ClassBasedTemplateGenerator implements ElementTemplateGenerator<Cla
               template.defaultResultVariable(), template.defaultResultExpression()));
     }
     return newGroups;
-  }
-
-  private static ElementTemplateCategory resolveCategory(ElementTemplate template) {
-    var category = template.category();
-    if (category.id().isBlank() || category.name().isBlank()) {
-      throw new IllegalArgumentException(
-          "Element template category requires both id and name to be set");
-    }
-    return new ElementTemplateCategory(category.id(), category.name());
   }
 
   private List<PropertyBuilder> generateExtensionProperties(ElementTemplate template) {

--- a/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/ClassBasedTemplateGenerator.java
+++ b/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/ClassBasedTemplateGenerator.java
@@ -190,6 +190,8 @@ public class ClassBasedTemplateGenerator implements ElementTemplateGenerator<Cla
           template.engineVersion() + " is not a valid semantic version");
     }
 
+    var category = resolveCategory(template);
+
     return context.elementTypes().stream()
         .map(
             elementType -> {
@@ -214,6 +216,7 @@ public class ClassBasedTemplateGenerator implements ElementTemplateGenerator<Cla
                   .documentationRef(
                       template.documentationRef().isEmpty() ? null : template.documentationRef())
                   .description(template.description().isEmpty() ? null : template.description())
+                  .category(category)
                   .properties(nonGroupedProperties.stream().map(PropertyBuilder::build).toList())
                   .propertyGroups(
                       addServiceProperties(
@@ -271,6 +274,20 @@ public class ClassBasedTemplateGenerator implements ElementTemplateGenerator<Cla
               template.defaultResultVariable(), template.defaultResultExpression()));
     }
     return newGroups;
+  }
+
+  private static ElementTemplateCategory resolveCategory(ElementTemplate template) {
+    var category = template.category();
+    boolean idBlank = category.id().isBlank();
+    boolean nameBlank = category.name().isBlank();
+    if (idBlank && nameBlank) {
+      return null;
+    }
+    if (idBlank || nameBlank) {
+      throw new IllegalArgumentException(
+          "Element template category requires both id and name to be set");
+    }
+    return new ElementTemplateCategory(category.id(), category.name());
   }
 
   private List<PropertyBuilder> generateExtensionProperties(ElementTemplate template) {

--- a/element-template-generator/core/src/test/java/io/camunda/connector/generator/dsl/ElementTemplateSerializationTest.java
+++ b/element-template-generator/core/src/test/java/io/camunda/connector/generator/dsl/ElementTemplateSerializationTest.java
@@ -39,6 +39,63 @@ public class ElementTemplateSerializationTest {
       new ObjectMapper().registerModule(new ElementTemplateModule());
 
   @Test
+  void customCategorySerializationTest() throws Exception {
+    // given
+    var elementTemplate =
+        ElementTemplate.builderForOutbound()
+            .id("io.camunda.connector.Template.v1")
+            .type("io.camunda:template:1")
+            .name("Template: Some Function")
+            .appliesTo(Set.of(TASK))
+            .elementType(SERVICE_TASK)
+            .version(1)
+            .category(new ElementTemplateCategory("agentic-ai", "Agentic AI"))
+            .propertyGroups(
+                PropertyGroup.builder()
+                    .id("default")
+                    .label("Properties")
+                    .properties(
+                        StringProperty.builder().label("Foo").binding(new ZeebeInput("foo")))
+                    .build())
+            .build();
+
+    // when
+    var json = objectMapper.writeValueAsString(elementTemplate);
+
+    // then
+    JSONAssert.assertEquals(
+        "{\"category\":{\"id\":\"agentic-ai\",\"name\":\"Agentic AI\"}}", json, false);
+  }
+
+  @Test
+  void defaultCategorySerializationTest() throws Exception {
+    // given
+    var elementTemplate =
+        ElementTemplate.builderForOutbound()
+            .id("io.camunda.connector.Template.v1")
+            .type("io.camunda:template:1")
+            .name("Template: Some Function")
+            .appliesTo(Set.of(TASK))
+            .elementType(SERVICE_TASK)
+            .version(1)
+            .propertyGroups(
+                PropertyGroup.builder()
+                    .id("default")
+                    .label("Properties")
+                    .properties(
+                        StringProperty.builder().label("Foo").binding(new ZeebeInput("foo")))
+                    .build())
+            .build();
+
+    // when
+    var json = objectMapper.writeValueAsString(elementTemplate);
+
+    // then
+    JSONAssert.assertEquals(
+        "{\"category\":{\"id\":\"connectors\",\"name\":\"Connectors\"}}", json, false);
+  }
+
+  @Test
   void serializationTest() throws Exception {
     // given
     var elementTemplate =

--- a/element-template-generator/core/src/test/java/io/camunda/connector/generator/dsl/ElementTemplateSerializationTest.java
+++ b/element-template-generator/core/src/test/java/io/camunda/connector/generator/dsl/ElementTemplateSerializationTest.java
@@ -17,6 +17,7 @@
 package io.camunda.connector.generator.dsl;
 
 import static io.camunda.connector.generator.java.annotation.BpmnType.*;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.connector.generator.dsl.DropdownProperty.DropdownChoice;
@@ -65,6 +66,29 @@ public class ElementTemplateSerializationTest {
     // then
     JSONAssert.assertEquals(
         "{\"category\":{\"id\":\"agentic-ai\",\"name\":\"Agentic AI\"}}", json, false);
+  }
+
+  @Test
+  void blankCategoryIsRejected() {
+    var builder =
+        ElementTemplate.builderForOutbound()
+            .id("io.camunda.connector.Template.v1")
+            .type("io.camunda:template:1")
+            .name("Template: Some Function")
+            .appliesTo(Set.of(TASK))
+            .elementType(SERVICE_TASK)
+            .category(new ElementTemplateCategory("", ""))
+            .propertyGroups(
+                PropertyGroup.builder()
+                    .id("default")
+                    .label("Properties")
+                    .properties(
+                        StringProperty.builder().label("Foo").binding(new ZeebeInput("foo")))
+                    .build());
+
+    assertThatThrownBy(builder::build)
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("category");
   }
 
   @Test

--- a/element-template-generator/core/src/test/java/io/camunda/connector/generator/dsl/ElementTemplateSerializationTest.java
+++ b/element-template-generator/core/src/test/java/io/camunda/connector/generator/dsl/ElementTemplateSerializationTest.java
@@ -31,6 +31,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Set;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
 
@@ -38,86 +39,6 @@ public class ElementTemplateSerializationTest {
 
   private final ObjectMapper objectMapper =
       new ObjectMapper().registerModule(new ElementTemplateModule());
-
-  @Test
-  void customCategorySerializationTest() throws Exception {
-    // given
-    var elementTemplate =
-        ElementTemplate.builderForOutbound()
-            .id("io.camunda.connector.Template.v1")
-            .type("io.camunda:template:1")
-            .name("Template: Some Function")
-            .appliesTo(Set.of(TASK))
-            .elementType(SERVICE_TASK)
-            .version(1)
-            .category(new ElementTemplateCategory("agentic-ai", "Agentic AI"))
-            .propertyGroups(
-                PropertyGroup.builder()
-                    .id("default")
-                    .label("Properties")
-                    .properties(
-                        StringProperty.builder().label("Foo").binding(new ZeebeInput("foo")))
-                    .build())
-            .build();
-
-    // when
-    var json = objectMapper.writeValueAsString(elementTemplate);
-
-    // then
-    JSONAssert.assertEquals(
-        "{\"category\":{\"id\":\"agentic-ai\",\"name\":\"Agentic AI\"}}", json, false);
-  }
-
-  @Test
-  void blankCategoryIsRejected() {
-    var builder =
-        ElementTemplate.builderForOutbound()
-            .id("io.camunda.connector.Template.v1")
-            .type("io.camunda:template:1")
-            .name("Template: Some Function")
-            .appliesTo(Set.of(TASK))
-            .elementType(SERVICE_TASK)
-            .category(new ElementTemplateCategory("", ""))
-            .propertyGroups(
-                PropertyGroup.builder()
-                    .id("default")
-                    .label("Properties")
-                    .properties(
-                        StringProperty.builder().label("Foo").binding(new ZeebeInput("foo")))
-                    .build());
-
-    assertThatThrownBy(builder::build)
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("category");
-  }
-
-  @Test
-  void defaultCategorySerializationTest() throws Exception {
-    // given
-    var elementTemplate =
-        ElementTemplate.builderForOutbound()
-            .id("io.camunda.connector.Template.v1")
-            .type("io.camunda:template:1")
-            .name("Template: Some Function")
-            .appliesTo(Set.of(TASK))
-            .elementType(SERVICE_TASK)
-            .version(1)
-            .propertyGroups(
-                PropertyGroup.builder()
-                    .id("default")
-                    .label("Properties")
-                    .properties(
-                        StringProperty.builder().label("Foo").binding(new ZeebeInput("foo")))
-                    .build())
-            .build();
-
-    // when
-    var json = objectMapper.writeValueAsString(elementTemplate);
-
-    // then
-    JSONAssert.assertEquals(
-        "{\"category\":{\"id\":\"connectors\",\"name\":\"Connectors\"}}", json, false);
-  }
 
   @Test
   void serializationTest() throws Exception {
@@ -220,5 +141,63 @@ public class ElementTemplateSerializationTest {
     var path = Path.of(ClassLoader.getSystemResource("test-element-template.json").toURI());
     var referenceJsonString = Files.readString(path);
     JSONAssert.assertEquals(referenceJsonString, jsonString, true);
+  }
+
+  @Nested
+  class Category {
+
+    private ElementTemplateBuilder builder() {
+      return ElementTemplate.builderForOutbound()
+          .id("io.camunda.connector.Template.v1")
+          .type("io.camunda:template:1")
+          .name("Template: Some Function")
+          .appliesTo(Set.of(TASK))
+          .elementType(SERVICE_TASK)
+          .version(1)
+          .propertyGroups(
+              PropertyGroup.builder()
+                  .id("default")
+                  .label("Properties")
+                  .properties(StringProperty.builder().label("Foo").binding(new ZeebeInput("foo")))
+                  .build());
+    }
+
+    @Test
+    void defaultCategorySerialization() throws Exception {
+      var json = objectMapper.writeValueAsString(builder().build());
+
+      JSONAssert.assertEquals(
+          "{\"category\":{\"id\":\"connectors\",\"name\":\"Connectors\"}}", json, false);
+    }
+
+    @Test
+    void customCategorySerialization() throws Exception {
+      var json =
+          objectMapper.writeValueAsString(
+              builder()
+                  .category(new ElementTemplateCategory("test-category", "Test Category"))
+                  .build());
+
+      JSONAssert.assertEquals(
+          "{\"category\":{\"id\":\"test-category\",\"name\":\"Test Category\"}}", json, false);
+    }
+
+    @Test
+    void blankCategoryIsRejected() {
+      var builder = builder().category(new ElementTemplateCategory("", ""));
+
+      assertThatThrownBy(builder::build)
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessage("category id and name must be non-blank");
+    }
+
+    @Test
+    void nullCategoryIsRejected() {
+      var builder = builder().category(null);
+
+      assertThatThrownBy(builder::build)
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessage("category id and name must be non-blank");
+    }
   }
 }

--- a/element-template-generator/core/src/test/java/io/camunda/connector/generator/java/OutboundClassBasedTemplateGeneratorTest.java
+++ b/element-template-generator/core/src/test/java/io/camunda/connector/generator/java/OutboundClassBasedTemplateGeneratorTest.java
@@ -35,6 +35,7 @@ import io.camunda.connector.generator.api.GeneratorConfiguration.ConnectorMode;
 import io.camunda.connector.generator.dsl.DropdownProperty;
 import io.camunda.connector.generator.dsl.DropdownProperty.DropdownChoice;
 import io.camunda.connector.generator.dsl.ElementTemplate.ElementTypeWrapper;
+import io.camunda.connector.generator.dsl.ElementTemplateCategory;
 import io.camunda.connector.generator.dsl.HiddenProperty;
 import io.camunda.connector.generator.dsl.NumberProperty;
 import io.camunda.connector.generator.dsl.Property;
@@ -136,6 +137,32 @@ public class OutboundClassBasedTemplateGeneratorTest extends BaseTest {
       assertThat(template.version()).isEqualTo(0);
       assertThat(template.documentationRef()).isNull();
       assertThat(template.description()).isNull();
+    }
+
+    @Test
+    void elementTemplateAnnotation_categoryDefaultsToConnectors() {
+      var template = generator.generate(MyConnectorFunction.MinimallyAnnotated.class).getFirst();
+      assertThat(template.category()).isEqualTo(ElementTemplateCategory.CONNECTORS);
+    }
+
+    @Test
+    void elementTemplateAnnotation_canDefineCustomCategory() {
+      var template =
+          generator
+              .generate(MyConnectorFunction.MinimallyAnnotatedWithCustomCategory.class)
+              .getFirst();
+      assertThat(template.category())
+          .isEqualTo(new ElementTemplateCategory("agentic-ai", "Agentic AI"));
+    }
+
+    @Test
+    void elementTemplateAnnotation_partialCategoryFails() {
+      assertThatThrownBy(
+              () ->
+                  generator.generate(
+                      MyConnectorFunction.MinimallyAnnotatedWithPartialCategory.class))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("category");
     }
 
     @Test

--- a/element-template-generator/core/src/test/java/io/camunda/connector/generator/java/OutboundClassBasedTemplateGeneratorTest.java
+++ b/element-template-generator/core/src/test/java/io/camunda/connector/generator/java/OutboundClassBasedTemplateGeneratorTest.java
@@ -142,7 +142,8 @@ public class OutboundClassBasedTemplateGeneratorTest extends BaseTest {
     @Test
     void elementTemplateAnnotation_categoryDefaultsToConnectors() {
       var template = generator.generate(MyConnectorFunction.MinimallyAnnotated.class).getFirst();
-      assertThat(template.category()).isEqualTo(ElementTemplateCategory.CONNECTORS);
+      assertThat(template.category())
+          .isEqualTo(new ElementTemplateCategory("connectors", "Connectors"));
     }
 
     @Test

--- a/element-template-generator/core/src/test/java/io/camunda/connector/generator/java/OutboundClassBasedTemplateGeneratorTest.java
+++ b/element-template-generator/core/src/test/java/io/camunda/connector/generator/java/OutboundClassBasedTemplateGeneratorTest.java
@@ -142,8 +142,7 @@ public class OutboundClassBasedTemplateGeneratorTest extends BaseTest {
     @Test
     void elementTemplateAnnotation_categoryDefaultsToConnectors() {
       var template = generator.generate(MyConnectorFunction.MinimallyAnnotated.class).getFirst();
-      assertThat(template.category())
-          .isEqualTo(new ElementTemplateCategory("connectors", "Connectors"));
+      assertThat(template.category()).isEqualTo(ElementTemplateCategory.CONNECTORS);
     }
 
     @Test

--- a/element-template-generator/core/src/test/java/io/camunda/connector/generator/java/OutboundClassBasedTemplateGeneratorTest.java
+++ b/element-template-generator/core/src/test/java/io/camunda/connector/generator/java/OutboundClassBasedTemplateGeneratorTest.java
@@ -152,7 +152,7 @@ public class OutboundClassBasedTemplateGeneratorTest extends BaseTest {
               .generate(MyConnectorFunction.MinimallyAnnotatedWithCustomCategory.class)
               .getFirst();
       assertThat(template.category())
-          .isEqualTo(new ElementTemplateCategory("agentic-ai", "Agentic AI"));
+          .isEqualTo(new ElementTemplateCategory("test-category", "Test Category"));
     }
 
     @Test
@@ -162,7 +162,7 @@ public class OutboundClassBasedTemplateGeneratorTest extends BaseTest {
                   generator.generate(
                       MyConnectorFunction.MinimallyAnnotatedWithPartialCategory.class))
           .isInstanceOf(IllegalArgumentException.class)
-          .hasMessageContaining("category");
+          .hasMessage("category id and name must be non-blank");
     }
 
     @Test

--- a/element-template-generator/core/src/test/java/io/camunda/connector/generator/java/example/outbound/MyConnectorFunction.java
+++ b/element-template-generator/core/src/test/java/io/camunda/connector/generator/java/example/outbound/MyConnectorFunction.java
@@ -183,6 +183,24 @@ public abstract class MyConnectorFunction implements OutboundConnectorFunction {
       id = MyConnectorFunction.ID,
       name = MyConnectorFunction.NAME,
       inputDataClass = MyConnectorInput.class,
+      category = @ElementTemplate.Category(id = "agentic-ai", name = "Agentic AI"))
+  public static class MinimallyAnnotatedWithCustomCategory extends MyConnectorFunction {}
+
+  @OutboundConnector(name = "my-connector", type = "my-connector-type")
+  @ElementTemplate(
+      engineVersion = "^8.7",
+      id = MyConnectorFunction.ID,
+      name = MyConnectorFunction.NAME,
+      inputDataClass = MyConnectorInput.class,
+      category = @ElementTemplate.Category(id = "agentic-ai", name = ""))
+  public static class MinimallyAnnotatedWithPartialCategory extends MyConnectorFunction {}
+
+  @OutboundConnector(name = "my-connector", type = "my-connector-type")
+  @ElementTemplate(
+      engineVersion = "^8.7",
+      id = MyConnectorFunction.ID,
+      name = MyConnectorFunction.NAME,
+      inputDataClass = MyConnectorInput.class,
       elementTypes = {
         @ConnectorElementType(appliesTo = BpmnType.TASK, elementType = BpmnType.SERVICE_TASK),
         @ConnectorElementType(appliesTo = BpmnType.TASK, elementType = BpmnType.SCRIPT_TASK),

--- a/element-template-generator/core/src/test/java/io/camunda/connector/generator/java/example/outbound/MyConnectorFunction.java
+++ b/element-template-generator/core/src/test/java/io/camunda/connector/generator/java/example/outbound/MyConnectorFunction.java
@@ -183,7 +183,7 @@ public abstract class MyConnectorFunction implements OutboundConnectorFunction {
       id = MyConnectorFunction.ID,
       name = MyConnectorFunction.NAME,
       inputDataClass = MyConnectorInput.class,
-      category = @ElementTemplate.Category(id = "agentic-ai", name = "Agentic AI"))
+      category = @ElementTemplate.Category(id = "test-category", name = "Test Category"))
   public static class MinimallyAnnotatedWithCustomCategory extends MyConnectorFunction {}
 
   @OutboundConnector(name = "my-connector", type = "my-connector-type")
@@ -192,7 +192,7 @@ public abstract class MyConnectorFunction implements OutboundConnectorFunction {
       id = MyConnectorFunction.ID,
       name = MyConnectorFunction.NAME,
       inputDataClass = MyConnectorInput.class,
-      category = @ElementTemplate.Category(id = "agentic-ai", name = ""))
+      category = @ElementTemplate.Category(id = "test-category", name = ""))
   public static class MinimallyAnnotatedWithPartialCategory extends MyConnectorFunction {}
 
   @OutboundConnector(name = "my-connector", type = "my-connector-type")


### PR DESCRIPTION
Closes #7395.

Allow connectors to override the default `connectors`/`Connectors` element template category through `@ElementTemplate(category = ...)`.

### Usage

```java
@ElementTemplate(
    id = "myConnector",
    name = "My Connector",
    version = 1,
    category = @ElementTemplate.Category(id = "custom-category", name = "Custom Category"))
public class MyConnectorFunction { ... }
```

The annotation defaults to `connectors`/`Connectors`, so existing element template JSON is unchanged.

## Test plan

- [x] New annotation-based tests (default category, custom category, blank category rejected).
- [x] New DSL `@Nested Category` serialization tests (default/custom/blank/null).
- [x] Existing element-template-generator submodule tests pass.
- [x] Rebuilt several connectors (`sendgrid`, `webhook`, `jdbc`); generated JSON is byte-identical to the committed files.

https://claude.ai/code/session_01MgKBHcoRw2WjeVkrWkAbN3