### PR TITLE
test: add tests for intrisic function

### DIFF
--- a/connectors-e2e-test/connectors-e2e-test-intrinsic-functions/pom.xml
+++ b/connectors-e2e-test/connectors-e2e-test-intrinsic-functions/pom.xml
@@ -1,0 +1,50 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>io.camunda.connector</groupId>
+    <artifactId>connectors-e2e-test-parent</artifactId>
+    <relativePath>../pom.xml</relativePath>
+    <version>8.10.0-SNAPSHOT</version>
+  </parent>
+
+  <description>E2E tests for intrinsic functions (base64, getText, getJson, createLink)</description>
+  <name>Connectors E2E Test Intrinsic Functions</name>
+  <artifactId>connectors-e2e-test-intrinsic-functions</artifactId>
+  <packaging>jar</packaging>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-deploy-plugin</artifactId>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.camunda.connector</groupId>
+      <artifactId>connector-http-json</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>camunda-process-test-spring</artifactId>
+      <version>${version.camunda}</version>
+    </dependency>
+
+    <!-- Test -->
+    <dependency>
+      <groupId>io.camunda.connector</groupId>
+      <artifactId>connectors-e2e-test-base</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/connectors-e2e-test/connectors-e2e-test-intrinsic-functions/src/test/java/io/camunda/connector/e2e/intrinsic/IntrinsicFunctionsTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-intrinsic-functions/src/test/java/io/camunda/connector/e2e/intrinsic/IntrinsicFunctionsTests.java
@@ -39,6 +39,7 @@ import io.camunda.connector.e2e.ElementTemplate;
 import io.camunda.connector.e2e.ZeebeTest;
 import io.camunda.connector.e2e.app.TestConnectorRuntimeApplication;
 import io.camunda.connector.runtime.core.document.store.CamundaDocumentStore;
+import io.camunda.connector.test.utils.annotation.SlowTest;
 import io.camunda.process.test.api.CamundaSpringProcessTest;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import java.io.File;
@@ -63,6 +64,7 @@ import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
     },
     webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @CamundaSpringProcessTest
+@SlowTest
 public class IntrinsicFunctionsTests {
 
   static final String TEST_LINK_PREFIX = "https://test.example.com/documents/";

--- a/connectors-e2e-test/connectors-e2e-test-intrinsic-functions/src/test/java/io/camunda/connector/e2e/intrinsic/IntrinsicFunctionsTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-intrinsic-functions/src/test/java/io/camunda/connector/e2e/intrinsic/IntrinsicFunctionsTests.java
@@ -134,7 +134,7 @@ public class IntrinsicFunctionsTests {
     String text = "Some text content for getText";
     Document doc =
         documentFactory.create(
-            DocumentCreationRequest.from(text.getBytes(StandardCharsets.UTF_8))
+            DocumentCreationRequest.from(text.getBytes(java.nio.charset.Charset.defaultCharset()))
                 .contentType("text/plain")
                 .build());
 

--- a/connectors-e2e-test/connectors-e2e-test-intrinsic-functions/src/test/java/io/camunda/connector/e2e/intrinsic/IntrinsicFunctionsTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-intrinsic-functions/src/test/java/io/camunda/connector/e2e/intrinsic/IntrinsicFunctionsTests.java
@@ -1,0 +1,278 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.e2e.intrinsic;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalToJson;
+import static com.github.tomakehurst.wiremock.client.WireMock.matchingJsonPath;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathMatching;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static io.camunda.process.test.api.CamundaAssert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+
+import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder;
+import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
+import io.camunda.client.CamundaClient;
+import io.camunda.connector.api.document.Document;
+import io.camunda.connector.api.document.DocumentCreationRequest;
+import io.camunda.connector.api.document.DocumentFactory;
+import io.camunda.connector.api.document.DocumentReference.CamundaDocumentReference;
+import io.camunda.connector.e2e.BpmnFile;
+import io.camunda.connector.e2e.ElementTemplate;
+import io.camunda.connector.e2e.ZeebeTest;
+import io.camunda.connector.e2e.app.TestConnectorRuntimeApplication;
+import io.camunda.connector.runtime.core.document.store.CamundaDocumentStore;
+import io.camunda.process.test.api.CamundaSpringProcessTest;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
+
+@SpringBootTest(
+    classes = {TestConnectorRuntimeApplication.class},
+    properties = {
+      "spring.main.allow-bean-definition-overriding=true",
+      "camunda.connector.webhook.enabled=false",
+      "camunda.connector.polling.enabled=false"
+    },
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@CamundaSpringProcessTest
+public class IntrinsicFunctionsTests {
+
+  static final String TEST_LINK_PREFIX = "https://test.example.com/documents/";
+
+  @RegisterExtension
+  static WireMockExtension wm =
+      WireMockExtension.newInstance().options(wireMockConfig().dynamicPort()).build();
+
+  @TempDir File tempDir;
+  @Autowired CamundaClient camundaClient;
+  @Autowired DocumentFactory documentFactory;
+
+  // Spy on the runtime's document store so that `generateLink` can return a deterministic value —
+  // the test cluster's fallback in-memory document store rejects link generation with HTTP 403,
+  // which would otherwise make the `createLink` intrinsic untestable end-to-end.
+  @MockitoSpyBean CamundaDocumentStore documentStore;
+
+  @BeforeEach
+  void stubGenerateLink() {
+    doAnswer(
+            inv ->
+                TEST_LINK_PREFIX + ((CamundaDocumentReference) inv.getArgument(0)).getDocumentId())
+        .when(documentStore)
+        .generateLink(any(), any());
+  }
+
+  @Test
+  void base64Intrinsic_withStringInput() {
+    String originalText = "Hello World";
+    String expectedBase64 =
+        Base64.getEncoder().encodeToString(originalText.getBytes(StandardCharsets.UTF_8));
+
+    wm.stubFor(
+        post(urlPathMatching("/mock"))
+            .withRequestBody(matchingJsonPath("$.result", equalTo(expectedBase64)))
+            .willReturn(ResponseDefinitionBuilder.okForJson(Map.of("status", "ok"))));
+
+    runProcess(
+        Map.of(),
+        "={result: {\"camunda.function.type\": \"base64\", \"params\": [\""
+            + originalText
+            + "\"]}}");
+
+    wm.verify(postRequestedFor(urlPathMatching("/mock")));
+  }
+
+  @Test
+  void base64Intrinsic_withDocumentInput() {
+    byte[] content = "Hello Document".getBytes(StandardCharsets.UTF_8);
+    Document doc =
+        documentFactory.create(
+            DocumentCreationRequest.from(content).contentType("text/plain").build());
+    String expectedBase64 = Base64.getEncoder().encodeToString(content);
+
+    wm.stubFor(
+        post(urlPathMatching("/mock"))
+            .withRequestBody(matchingJsonPath("$.result", equalTo(expectedBase64)))
+            .willReturn(ResponseDefinitionBuilder.okForJson(Map.of("status", "ok"))));
+
+    runProcess(
+        Map.of("inputDoc", referenceAsMap(doc)),
+        "={result: {\"camunda.function.type\": \"base64\", \"params\": [inputDoc]}}");
+
+    wm.verify(postRequestedFor(urlPathMatching("/mock")));
+  }
+
+  @Test
+  void getTextIntrinsic_defaultCharset() {
+    String text = "Some text content for getText";
+    Document doc =
+        documentFactory.create(
+            DocumentCreationRequest.from(text.getBytes(StandardCharsets.UTF_8))
+                .contentType("text/plain")
+                .build());
+
+    wm.stubFor(
+        post(urlPathMatching("/mock"))
+            .withRequestBody(matchingJsonPath("$.result", equalTo(text)))
+            .willReturn(ResponseDefinitionBuilder.okForJson(Map.of("status", "ok"))));
+
+    runProcess(
+        Map.of("inputDoc", referenceAsMap(doc)),
+        "={result: {\"camunda.function.type\": \"getText\", \"params\": [inputDoc]}}");
+
+    wm.verify(postRequestedFor(urlPathMatching("/mock")));
+  }
+
+  @Test
+  void getTextIntrinsic_withExplicitCharset() {
+    String text = "Charset test";
+    Document doc =
+        documentFactory.create(
+            DocumentCreationRequest.from(text.getBytes(StandardCharsets.UTF_16))
+                .contentType("text/plain; charset=UTF-16")
+                .build());
+
+    wm.stubFor(
+        post(urlPathMatching("/mock"))
+            .withRequestBody(matchingJsonPath("$.result", equalTo(text)))
+            .willReturn(ResponseDefinitionBuilder.okForJson(Map.of("status", "ok"))));
+
+    runProcess(
+        Map.of("inputDoc", referenceAsMap(doc)),
+        "={result: {\"camunda.function.type\": \"getText\", \"params\": [inputDoc, \"UTF-16\"]}}");
+
+    wm.verify(postRequestedFor(urlPathMatching("/mock")));
+  }
+
+  @Test
+  void getJsonIntrinsic_returnsFullObject() {
+    String json = "{\"name\":\"Alice\",\"age\":30}";
+    Document doc =
+        documentFactory.create(
+            DocumentCreationRequest.from(json.getBytes(StandardCharsets.UTF_8))
+                .contentType("application/json")
+                .build());
+
+    wm.stubFor(
+        post(urlPathMatching("/mock"))
+            .withRequestBody(
+                equalToJson("{\"result\":{\"name\":\"Alice\",\"age\":30}}", true, true))
+            .willReturn(ResponseDefinitionBuilder.okForJson(Map.of("status", "ok"))));
+
+    runProcess(
+        Map.of("inputDoc", referenceAsMap(doc)),
+        "={result: {\"camunda.function.type\": \"getJson\", \"params\": [inputDoc]}}");
+
+    wm.verify(postRequestedFor(urlPathMatching("/mock")));
+  }
+
+  @Test
+  void getJsonIntrinsic_withFeelFilter() {
+    String json = "{\"name\":\"Alice\",\"age\":30}";
+    Document doc =
+        documentFactory.create(
+            DocumentCreationRequest.from(json.getBytes(StandardCharsets.UTF_8))
+                .contentType("application/json")
+                .build());
+
+    wm.stubFor(
+        post(urlPathMatching("/mock"))
+            .withRequestBody(matchingJsonPath("$.result", equalTo("Alice")))
+            .willReturn(ResponseDefinitionBuilder.okForJson(Map.of("status", "ok"))));
+
+    runProcess(
+        Map.of("inputDoc", referenceAsMap(doc)),
+        "={result: {\"camunda.function.type\": \"getJson\", \"params\": [inputDoc, \"name\"]}}");
+
+    wm.verify(postRequestedFor(urlPathMatching("/mock")));
+  }
+
+  @Test
+  void createLinkIntrinsic_returnsLink() {
+    Document doc =
+        documentFactory.create(
+            DocumentCreationRequest.from("link me".getBytes(StandardCharsets.UTF_8))
+                .contentType("text/plain")
+                .build());
+    String expectedLink =
+        TEST_LINK_PREFIX + ((CamundaDocumentReference) doc.reference()).getDocumentId();
+
+    wm.stubFor(
+        post(urlPathMatching("/mock"))
+            .withRequestBody(matchingJsonPath("$.result", equalTo(expectedLink)))
+            .willReturn(ResponseDefinitionBuilder.okForJson(Map.of("status", "ok"))));
+
+    runProcess(
+        Map.of("inputDoc", referenceAsMap(doc)),
+        "={result: {\"camunda.function.type\": \"createLink\", \"params\": [inputDoc]}}");
+
+    wm.verify(postRequestedFor(urlPathMatching("/mock")));
+  }
+
+  /** Runs an HTTP POST connector against the WireMock mock URL with the given body FEEL. */
+  private void runProcess(Map<String, Object> variables, String bodyFeelExpression) {
+    var mockUrl = "http://localhost:" + wm.getPort() + "/mock";
+    var model =
+        Bpmn.createProcess().executable().startEvent().serviceTask("restTask").endEvent().done();
+
+    var elementTemplate =
+        ElementTemplate.from(
+                "../../connectors/http/rest/element-templates/http-json-connector.json")
+            .property("url", mockUrl)
+            .property("method", "POST")
+            .property("body", bodyFeelExpression)
+            .property("resultExpression", "={httpStatus: response.body.status}")
+            .writeTo(new File(tempDir, "template.json"));
+
+    var updatedModel =
+        new BpmnFile(model)
+            .writeToFile(new File(tempDir, "test.bpmn"))
+            .apply(elementTemplate, "restTask", new File(tempDir, "result.bpmn"));
+
+    var bpmnTest =
+        ZeebeTest.with(camundaClient)
+            .deploy(updatedModel)
+            .createInstance(variables)
+            .waitForProcessCompletion();
+
+    assertThat(bpmnTest.getProcessInstanceEvent()).hasVariable("httpStatus", "ok");
+  }
+
+  private static Map<String, Object> referenceAsMap(Document document) {
+    var ref = (CamundaDocumentReference) document.reference();
+    Map<String, Object> map = new HashMap<>();
+    map.put("camunda.document.type", "camunda");
+    map.put("storeId", ref.getStoreId());
+    map.put("documentId", ref.getDocumentId());
+    map.put("contentHash", ref.getContentHash());
+    map.put("metadata", Map.of());
+    return map;
+  }
+}

--- a/connectors-e2e-test/pom.xml
+++ b/connectors-e2e-test/pom.xml
@@ -36,6 +36,7 @@
     <module>connectors-e2e-test-inbound-runtime</module>
     <module>connectors-e2e-test-csv</module>
     <module>connectors-e2e-test-feel</module>
+    <module>connectors-e2e-test-intrinsic-functions</module>
   </modules>
 
   <dependencies>


### PR DESCRIPTION
This pull request adds a new end-to-end (E2E) test module for intrinsic functions to the connectors test suite. The new module provides comprehensive tests for intrinsic functions such as `base64`, `getText`, `getJson`, and `createLink`, ensuring their correct behavior with various input types and scenarios.

**New Intrinsic Functions E2E Test Module:**

* Added a new Maven module, `connectors-e2e-test-intrinsic-functions`, to the connectors E2E test suite, including its own `pom.xml` and dependencies. [[1]](diffhunk://#diff-6ecd164f0cb8f3a5b701b355466c736d78912b3c539926fbc260ff34c1bd1c94R1-R50) [[2]](diffhunk://#diff-7ba884696a5c23674202eff784ddab1368e1db3f32275d5d0cdb58c2455d1effR39)

**Intrinsic Functions Test Coverage:**

* Implemented `IntrinsicFunctionsTests.java` to verify the following intrinsic functions:
  - `base64`: Tests both string and document inputs for correct base64 encoding.
  - `getText`: Tests extraction of text from documents, with and without explicit charset.
  - `getJson`: Tests JSON extraction from documents, including filtering with FEEL expressions.
  - [`createLink`](diffhunk://#diff-fb9944a3ebeb209e634242495637c7b8d44f1e3d7477d25b140877aa0c51fe8dR1-R278): Tests link generation for documents with deterministic output.
* Utilized WireMock to mock HTTP endpoints and verify request/response handling in all test cases.
* Added helper methods for process execution and document reference mapping to facilitate reusable and deterministic test logic.