### PR TITLE
fix(runtime): generic variable deserialization in operation bindings

### DIFF
--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/outbound/operation/ConnectorOperations.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/outbound/operation/ConnectorOperations.java
@@ -69,7 +69,9 @@ public record ConnectorOperations(Object connector, Map<String, OperationInvoker
     if (parameter.isAnnotationPresent(Variable.class)) {
       Variable variableAnnotation = parameter.getAnnotation(Variable.class);
       return new ParameterDescriptor.Variable<>(
-          getVariableName(variableAnnotation), parameter.getType(), variableAnnotation.required());
+          getVariableName(variableAnnotation),
+          parameter.getParameterizedType(),
+          variableAnnotation.required());
     } else if (parameter.getType().equals(OutboundConnectorContext.class)) {
       return new Context();
     } else if (parameter.isAnnotationPresent(Header.class)) {

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/outbound/operation/OperationInvoker.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/outbound/operation/OperationInvoker.java
@@ -19,6 +19,7 @@ package io.camunda.connector.runtime.core.outbound.operation;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonPointer;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.connector.api.error.ConnectorInputException;
@@ -26,6 +27,7 @@ import io.camunda.connector.api.outbound.OutboundConnectorContext;
 import io.camunda.connector.api.validation.ValidationProvider;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Type;
 import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -101,10 +103,13 @@ public class OperationInvoker {
     return value;
   }
 
-  private Object readValueAs(JsonNode jsonNode, JsonPointer jsonPointer, Class<?> type) {
+  private Object readValueAs(JsonNode jsonNode, JsonPointer jsonPointer, Type type) {
     JsonNode node = jsonNode.at(jsonPointer);
+
+    JavaType javaType = objectMapper.getTypeFactory().constructType(type);
+
     try (JsonParser parser = node.traverse(objectMapper)) {
-      return parser.readValueAs(type);
+      return objectMapper.readValue(parser, javaType);
     } catch (IOException ex) {
       throw new RuntimeException(ex);
     }

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/outbound/operation/ParameterDescriptor.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/outbound/operation/ParameterDescriptor.java
@@ -17,6 +17,7 @@
 package io.camunda.connector.runtime.core.outbound.operation;
 
 import com.fasterxml.jackson.core.JsonPointer;
+import java.lang.reflect.Type;
 
 public sealed interface ParameterDescriptor {
 
@@ -26,10 +27,10 @@ public sealed interface ParameterDescriptor {
 
     private final JsonPointer jsonPointer;
     private final String name;
-    private final Class<T> type;
+    private final Type type;
     private final boolean required;
 
-    public Variable(String name, Class<T> type, boolean required) {
+    public Variable(String name, Type type, boolean required) {
       this.name = name;
       this.type = type;
       this.required = required;
@@ -48,7 +49,7 @@ public sealed interface ParameterDescriptor {
       return name;
     }
 
-    public Class<T> getType() {
+    public Type getType() {
       return type;
     }
 

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/outbound/AnnotatedOperationConnector.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/outbound/AnnotatedOperationConnector.java
@@ -24,6 +24,7 @@ import io.camunda.connector.api.error.ConnectorRetryExceptionBuilder;
 import io.camunda.connector.api.outbound.OutboundConnectorContext;
 import io.camunda.connector.api.outbound.OutboundConnectorProvider;
 import jakarta.validation.constraints.NotNull;
+import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 
@@ -31,6 +32,8 @@ import java.util.function.Function;
 public class AnnotatedOperationConnector implements OutboundConnectorProvider {
 
   record MyObjectParam(String name, int value) {}
+
+  record Span(int start, int end) {}
 
   @Operation(id = "myOperation")
   public String myOperation(
@@ -78,5 +81,10 @@ public class AnnotatedOperationConnector implements OutboundConnectorProvider {
         .errorCode("RETRY_ERROR")
         .message("Please retry")
         .build();
+  }
+
+  @Operation(id = "myOperation7")
+  public Object handleGenericListVariable(@Variable("spans") List<Span> spans) {
+    return spans.stream().mapToInt(Span::start).sum();
   }
 }

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/outbound/AnnotatedOperationTests.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/outbound/AnnotatedOperationTests.java
@@ -118,7 +118,13 @@ public class AnnotatedOperationTests {
             .toList();
     Assertions.assertThatCollection(variables)
         .containsExactlyInAnyOrder(
-            "myStringParam", "myObjectParam", "nullObjectParam", "name", "value", "validatingName");
+            "myStringParam",
+            "myObjectParam",
+            "nullObjectParam",
+            "name",
+            "value",
+            "validatingName",
+            "spans");
   }
 
   @Test
@@ -148,5 +154,22 @@ public class AnnotatedOperationTests {
     when(activatedJob.getVariables()).thenReturn(json);
     return new JobHandlerContext(
         activatedJob, new NoOpSecretProvider(), validationProvider, null, objectMapper);
+  }
+
+  @Test
+  public void shouldDeserializeGenericListVariable() {
+    var json =
+        """
+          {
+            "spans": [
+              {"start": 1, "end": 3},
+              {"start": 5, "end": 7}
+            ]
+          }
+        """;
+
+    var result = invoker.execute(createMockContext(json, "myOperation7"));
+
+    assertEquals(6, result);
   }
 }


### PR DESCRIPTION
## Description

Fix generic deserialization for `@Variable` bindings in operation-based connectors.

Previously, parameterized types such as `List<T>` were deserialized using the raw type, which results in values being mapped as `LinkedHashMap` instead of the expected type.

Parameterized types such as List<T> now preserve their type information during variable binding and are deserialized correctly.

Added a regression test for generic collection variables

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #7377

## Checklist

- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest
  release, as this branch will be rebased onto main before the next release. Example backport labels:
    - `backport stable/8.8`: for changes that should be included in the next 8.8.x release.
    - **or** `backport release-8.8.7`: for changes that should be included in the specific release 8.8.7, and this
      *release has already been created*. The release branch will be merged back into stable/8.8 later, so the change
      will be included in future 8.8.x releases as well.
- [x] Tests/Integration tests for the changes have been added if applicable.
- [ ] If the change requires a documentation update, it has been added to the appropriate section in the documentation.


