### PR TITLE
chore: updating Box connector to the new SDK

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -149,7 +149,7 @@ limitations under the License.</license.inlineheader>
     <version.azure-cosmos>4.80.0</version.azure-cosmos>
 
     <version.bouncycastle>1.84</version.bouncycastle>
-    <version.box-sdk>4.16.4</version.box-sdk>
+    <version.box-sdk>5.12.0</version.box-sdk>
 
     <version.sendGrid>4.10.3</version.sendGrid>
     <version.sendGrid-http-client>4.5.1</version.sendGrid-http-client>

--- a/renovate.json
+++ b/renovate.json
@@ -136,6 +136,12 @@
         "org.elasticsearch.client:elasticsearch-rest-client"
       ],
       "enabled": false
+    },
+    {
+      "description": "Pin Box SDK to v5 line; v10 drops the legacy com.box.sdk package and the auto-paginating iterators.",
+      "matchUpdateTypes": ["major"],
+      "matchPackageNames": ["com.box:box-java-sdk"],
+      "enabled": false
     }
   ],
   "baseBranchPatterns": [


### PR DESCRIPTION
This pull request updates the Box SDK dependency to a newer version and modifies the Renovate configuration to prevent automatic major version upgrades for this package. The most important changes are:

Dependency updates:

* Updated the Box SDK version from `4.16.4` to `5.12.0` in `parent/pom.xml`. This brings in new features and fixes from the 5.x line, but avoids breaking changes introduced in later major versions.

Dependency management configuration:

* Added a rule to `renovate.json` to pin the Box SDK (`com.box:box-java-sdk`) to the v5 line and prevent major upgrades (such as to v10), since v10 drops the legacy `com.box.sdk` package and auto-paginating iterators. This ensures compatibility with existing code that relies on these features.