### PR TITLE
chore: updating okttp version for it to work with 5.3.2

### DIFF
--- a/connectors/microsoft/common/pom.xml
+++ b/connectors/microsoft/common/pom.xml
@@ -45,7 +45,7 @@
     </dependency>
     <dependency>
       <groupId>com.squareup.okhttp3</groupId>
-      <artifactId>okhttp</artifactId>
+      <artifactId>okhttp-jvm</artifactId>
       <version>${version.okhttp}</version>
     </dependency>
     <dependency>

--- a/connectors/microsoft/teams/pom.xml
+++ b/connectors/microsoft/teams/pom.xml
@@ -35,7 +35,7 @@
     </dependency>
     <dependency>
       <groupId>com.squareup.okhttp3</groupId>
-      <artifactId>okhttp</artifactId>
+      <artifactId>okhttp-jvm</artifactId>
       <version>${version.okhttp}</version>
       <scope>test</scope>
     </dependency>

--- a/connectors/slack/pom.xml
+++ b/connectors/slack/pom.xml
@@ -48,7 +48,7 @@
     </dependency>
     <dependency>
       <groupId>com.squareup.okhttp3</groupId>
-      <artifactId>okhttp</artifactId>
+      <artifactId>okhttp-jvm</artifactId>
       <version>${version.okhttp}</version>
     </dependency>
     <dependency>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -111,7 +111,7 @@ limitations under the License.</license.inlineheader>
 
     <version.localstack>2.0.5</version.localstack>
 
-    <version.okhttp>4.12.0</version.okhttp>
+    <version.okhttp>5.3.2</version.okhttp>
     <!-- Langchain4j requires a version >= 2.9.0 < 3.x. Do not bump to 3.x unless Langchain4j supports it! -->
     <version.opensearch-client>2.26.0</version.opensearch-client>
 
@@ -211,6 +211,18 @@ limitations under the License.</license.inlineheader>
         <groupId>com.fasterxml.jackson.datatype</groupId>
         <artifactId>jackson-datatype-jsr310</artifactId>
         <version>${version.jackson-datatype-jsr310}</version>
+      </dependency>
+
+      <!--
+        OkHttp 5 split into multi-platform modules: the `okhttp` artifact's pom is now
+        an empty shell (classes ship in `okhttp-jvm`). Maven cannot read Gradle module
+        metadata, so we pin the transitive `okhttp` to the matching version (still empty
+        but harmless) and let modules that actually need OkHttp depend on `okhttp-jvm`.
+      -->
+      <dependency>
+        <groupId>com.squareup.okhttp3</groupId>
+        <artifactId>okhttp</artifactId>
+        <version>${version.okhttp}</version>
       </dependency>
 
       <!-- CVE override for Tomcat - remove when version.tomcat property is removed -->


### PR DESCRIPTION
This pull request updates our usage of the OkHttp library to version 5.3.2 and adapts our Maven dependencies to OkHttp's new multi-platform module structure. The main change is replacing the old `okhttp` artifact with `okhttp-jvm` in modules that require it, while also ensuring compatibility by explicitly including the empty `okhttp` artifact at the root level.

Dependency and version updates:

* Upgraded OkHttp to version 5.3.2 in the parent `pom.xml`, ensuring all modules use the latest version.
* Added the empty `okhttp` artifact as a dependency in the parent `pom.xml` to address Maven/Gradle metadata compatibility issues introduced in OkHttp 5.x.

Module-specific dependency changes:

* Updated `connectors/microsoft/common/pom.xml`, `connectors/microsoft/teams/pom.xml`, and `connectors/slack/pom.xml` to depend on `okhttp-jvm` instead of `okhttp`, reflecting the new artifact structure in OkHttp 5.x. [[1]](diffhunk://#diff-dc8caa752d11d5d43e99338faf14f14b864073e7f8f02f3f9c7871f93c65cf74L48-R48) [[2]](diffhunk://#diff-1c5f782453d3b239e4712b452773830338beb18c2578c932569683ea87e358d1L38-R38) [[3]](diffhunk://#diff-2d042890605b5fc1a54e7dd6f736a27f47c47e6353778e5f104952742d2ccae6L51-R51)