### PR TITLE
fix(runtime): stable health.lastUpdatedAt for non-Activated inbound connector states

### DIFF
--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/executable/BatchExecutableProcessor.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/executable/BatchExecutableProcessor.java
@@ -91,7 +91,10 @@ public class BatchExecutableProcessor {
       final ValidInboundConnectorDetails data;
 
       if (maybeValidData instanceof InvalidInboundConnectorDetails invalid) {
-        var reason = invalid.error().getMessage();
+        var reason =
+            invalid.error().getMessage() != null
+                ? invalid.error().getMessage()
+                : invalid.error().getClass().getSimpleName();
         alreadyActivated.put(
             id,
             new RegisteredExecutable.InvalidDefinition(
@@ -142,7 +145,7 @@ public class BatchExecutableProcessor {
                   new FailedToActivate(
                       failedEntry.getValue(),
                       failureReasonForOthers,
-                      id,
+                      failedEntry.getKey(),
                       Health.down(new RuntimeException(failureReasonForOthers))));
             }
           }
@@ -159,7 +162,10 @@ public class BatchExecutableProcessor {
 
     final ExecutableId id = ExecutableId.fromDeduplicationId(data.deduplicationId());
     if (data instanceof InvalidInboundConnectorDetails invalid) {
-      var reason = invalid.error().getMessage();
+      var reason =
+          invalid.error().getMessage() != null
+              ? invalid.error().getMessage()
+              : invalid.error().getClass().getSimpleName();
       return new InvalidDefinition(
           invalid,
           reason,
@@ -202,8 +208,9 @@ public class BatchExecutableProcessor {
     } catch (Exception e) {
       LOG.error("Failed to activate connector", e);
       connectorsInboundMetrics.increaseActivationFailure(data.connectorElements().getFirst());
+      var reason = e.getMessage() != null ? e.getMessage() : e.getClass().getSimpleName();
       return new FailedToActivate(
-          data, e.getMessage(), id, Health.down(new RuntimeException(e.getMessage())));
+          data, reason, id, Health.down(new RuntimeException(reason)));
     }
     log(
         id,

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/executable/BatchExecutableProcessor.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/executable/BatchExecutableProcessor.java
@@ -209,8 +209,7 @@ public class BatchExecutableProcessor {
       LOG.error("Failed to activate connector", e);
       connectorsInboundMetrics.increaseActivationFailure(data.connectorElements().getFirst());
       var reason = e.getMessage() != null ? e.getMessage() : e.getClass().getSimpleName();
-      return new FailedToActivate(
-          data, reason, id, Health.down(new RuntimeException(reason)));
+      return new FailedToActivate(data, reason, id, Health.down(new RuntimeException(reason)));
     }
     log(
         id,

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/executable/BatchExecutableProcessor.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/executable/BatchExecutableProcessor.java
@@ -91,9 +91,14 @@ public class BatchExecutableProcessor {
       final ValidInboundConnectorDetails data;
 
       if (maybeValidData instanceof InvalidInboundConnectorDetails invalid) {
+        var reason = invalid.error().getMessage();
         alreadyActivated.put(
             id,
-            new RegisteredExecutable.InvalidDefinition(invalid, invalid.error().getMessage(), id));
+            new RegisteredExecutable.InvalidDefinition(
+                invalid,
+                reason,
+                id,
+                Health.down(new RuntimeException("Invalid connector definition: " + reason))));
         continue;
       } else {
         data = (ValidInboundConnectorDetails) maybeValidData;
@@ -134,7 +139,11 @@ public class BatchExecutableProcessor {
             if (!failedEntry.getKey().equals(id)) {
               notActivated.put(
                   failedEntry.getKey(),
-                  new FailedToActivate(failedEntry.getValue(), failureReasonForOthers, id));
+                  new FailedToActivate(
+                      failedEntry.getValue(),
+                      failureReasonForOthers,
+                      id,
+                      Health.down(new RuntimeException(failureReasonForOthers))));
             }
           }
           notActivated.put(id, failed);
@@ -150,7 +159,12 @@ public class BatchExecutableProcessor {
 
     final ExecutableId id = ExecutableId.fromDeduplicationId(data.deduplicationId());
     if (data instanceof InvalidInboundConnectorDetails invalid) {
-      return new InvalidDefinition(invalid, invalid.error().getMessage(), id);
+      var reason = invalid.error().getMessage();
+      return new InvalidDefinition(
+          invalid,
+          reason,
+          id,
+          Health.down(new RuntimeException("Invalid connector definition: " + reason)));
     }
     var validData = (ValidInboundConnectorDetails) data;
 
@@ -165,7 +179,10 @@ public class BatchExecutableProcessor {
                   validData, cancellationCallback, executable.getClass(), activityLogWriter);
     } catch (NoSuchElementException e) {
       LOG.warn("Failed to create executable", e);
-      return new ConnectorNotRegistered(validData, id);
+      return new ConnectorNotRegistered(
+          validData,
+          id,
+          Health.down(new RuntimeException("Connector " + validData.type() + " not registered")));
     }
 
     if (webhookConnectorRegistry == null && executable instanceof WebhookConnectorExecutable) {
@@ -174,7 +191,10 @@ public class BatchExecutableProcessor {
           Health.down(
               new UnsupportedOperationException(
                   "Webhook connectors are not supported in this environment")));
-      return new ConnectorNotRegistered(validData, id);
+      return new ConnectorNotRegistered(
+          validData,
+          id,
+          Health.down(new RuntimeException("Connector " + validData.type() + " not registered")));
     }
     final Activated activated;
     try {
@@ -182,7 +202,8 @@ public class BatchExecutableProcessor {
     } catch (Exception e) {
       LOG.error("Failed to activate connector", e);
       connectorsInboundMetrics.increaseActivationFailure(data.connectorElements().getFirst());
-      return new FailedToActivate(data, e.getMessage(), id);
+      return new FailedToActivate(
+          data, e.getMessage(), id, Health.down(new RuntimeException(e.getMessage())));
     }
     log(
         id,
@@ -341,6 +362,7 @@ public class BatchExecutableProcessor {
   public RegisteredExecutable.Cancelled cancelExecutable(Activated activated, Throwable throwable) {
     try {
       activated.executable().deactivate();
+      activated.context().reportHealth(throwable != null ? Health.down(throwable) : Health.down());
       return new RegisteredExecutable.Cancelled(
           activated.executable(), activated.context(), throwable, activated.id());
     } catch (Exception e) {

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/executable/InboundExecutableQueryService.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/executable/InboundExecutableQueryService.java
@@ -137,7 +137,7 @@ public class InboundExecutableQueryService {
         cancelled.id(),
         cancelled.executable().getClass(),
         context.connectorElements(),
-        Health.down(cancelled.exceptionThrown()),
+        context.getHealth(),
         activityLogRegistry.getLogs(cancelled.id()),
         context.getActivationTimestamp());
   }
@@ -149,7 +149,7 @@ public class InboundExecutableQueryService {
         notRegistered.id(),
         null,
         data.connectorElements(),
-        Health.down(new RuntimeException("Connector " + data.type() + " not registered")),
+        notRegistered.health(),
         activityLogRegistry.getLogs(notRegistered.id()),
         null);
   }
@@ -161,7 +161,7 @@ public class InboundExecutableQueryService {
         failed.id(),
         null,
         data.connectorElements(),
-        Health.down(new RuntimeException(failed.reason())),
+        failed.health(),
         activityLogRegistry.getLogs(failed.id()),
         null);
   }
@@ -173,7 +173,7 @@ public class InboundExecutableQueryService {
         invalid.id(),
         null,
         data.connectorElements(),
-        Health.down(new RuntimeException("Invalid connector definition: " + invalid.reason())),
+        invalid.health(),
         activityLogRegistry.getLogs(invalid.id()),
         null);
   }
@@ -208,10 +208,10 @@ public class InboundExecutableQueryService {
   private Health getHealthFromExecutable(RegisteredExecutable executable) {
     return switch (executable) {
       case Activated activated -> activated.context().getHealth();
-      case Cancelled cancelled -> Health.down(cancelled.exceptionThrown());
-      case ConnectorNotRegistered ignored -> Health.down(new RuntimeException("Not registered"));
-      case FailedToActivate failed -> Health.down(new RuntimeException(failed.reason()));
-      case InvalidDefinition invalid -> Health.down(new RuntimeException(invalid.reason()));
+      case Cancelled cancelled -> cancelled.context().getHealth();
+      case ConnectorNotRegistered notRegistered -> notRegistered.health();
+      case FailedToActivate failed -> failed.health();
+      case InvalidDefinition invalid -> invalid.health();
     };
   }
 }

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/executable/InboundExecutableRegistryImpl.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/executable/InboundExecutableRegistryImpl.java
@@ -209,9 +209,14 @@ public class InboundExecutableRegistryImpl implements InboundExecutableRegistry 
         batchExecutableProcessor.deactivateBatch(List.of(activated));
       }
       var invalid = target.invalid().get(id);
+      var reason = invalid.error().getMessage();
       stateStore.put(
           id,
-          new RegisteredExecutable.InvalidDefinition(invalid, invalid.error().getMessage(), id));
+          new RegisteredExecutable.InvalidDefinition(
+              invalid,
+              reason,
+              id,
+              Health.down(new RuntimeException("Invalid connector definition: " + reason))));
     }
   }
 

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/executable/InboundExecutableRegistryImpl.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/executable/InboundExecutableRegistryImpl.java
@@ -209,7 +209,10 @@ public class InboundExecutableRegistryImpl implements InboundExecutableRegistry 
         batchExecutableProcessor.deactivateBatch(List.of(activated));
       }
       var invalid = target.invalid().get(id);
-      var reason = invalid.error().getMessage();
+      var reason =
+          invalid.error().getMessage() != null
+              ? invalid.error().getMessage()
+              : invalid.error().getClass().getSimpleName();
       stateStore.put(
           id,
           new RegisteredExecutable.InvalidDefinition(

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/executable/RegisteredExecutable.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/executable/RegisteredExecutable.java
@@ -16,6 +16,7 @@
  */
 package io.camunda.connector.runtime.inbound.executable;
 
+import io.camunda.connector.api.inbound.Health;
 import io.camunda.connector.api.inbound.InboundConnectorContext;
 import io.camunda.connector.api.inbound.InboundConnectorExecutable;
 import io.camunda.connector.runtime.core.inbound.ExecutableId;
@@ -41,12 +42,14 @@ public sealed interface RegisteredExecutable {
       ExecutableId id)
       implements RegisteredExecutable {}
 
-  record ConnectorNotRegistered(ValidInboundConnectorDetails data, ExecutableId id)
+  record ConnectorNotRegistered(ValidInboundConnectorDetails data, ExecutableId id, Health health)
       implements RegisteredExecutable {}
 
-  record FailedToActivate(InboundConnectorDetails data, String reason, ExecutableId id)
+  record FailedToActivate(
+      InboundConnectorDetails data, String reason, ExecutableId id, Health health)
       implements RegisteredExecutable {}
 
-  record InvalidDefinition(InvalidInboundConnectorDetails data, String reason, ExecutableId id)
+  record InvalidDefinition(
+      InvalidInboundConnectorDetails data, String reason, ExecutableId id, Health health)
       implements RegisteredExecutable {}
 }

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/inbound/executable/InboundExecutableQueryServiceTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/inbound/executable/InboundExecutableQueryServiceTest.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.runtime.inbound.executable;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.when;
+
+import io.camunda.connector.api.inbound.Health;
+import io.camunda.connector.api.inbound.InboundConnectorExecutable;
+import io.camunda.connector.runtime.core.inbound.ExecutableId;
+import io.camunda.connector.runtime.core.inbound.InboundConnectorElement;
+import io.camunda.connector.runtime.core.inbound.InboundConnectorFactory;
+import io.camunda.connector.runtime.core.inbound.InboundConnectorManagementContext;
+import io.camunda.connector.runtime.core.inbound.ProcessElementWithRuntimeData;
+import io.camunda.connector.runtime.core.inbound.activitylog.ActivityLogRegistry;
+import io.camunda.connector.runtime.core.inbound.correlation.StartEventCorrelationPoint;
+import io.camunda.connector.runtime.core.inbound.details.InboundConnectorDetails.InvalidInboundConnectorDetails;
+import io.camunda.connector.runtime.core.inbound.details.InboundConnectorDetails.ValidInboundConnectorDetails;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * Tests that health timestamps are stable across multiple queries for non-Activated states.
+ *
+ * <p>Bug: {@link InboundExecutableQueryService} was creating new {@link Health} objects on every
+ * call to {@code query()}, causing {@code health.getLastUpdatedAt()} to always return the current
+ * time instead of the time the failure occurred.
+ */
+@ExtendWith(MockitoExtension.class)
+class InboundExecutableQueryServiceTest {
+
+  @Mock private InboundConnectorFactory connectorFactory;
+  @Mock private InboundConnectorExecutable<?> executable;
+  @Mock private InboundConnectorManagementContext context;
+
+  private InMemoryInboundExecutableStateStore stateStore;
+  private InboundExecutableQueryService queryService;
+
+  @BeforeEach
+  void setUp() {
+    // lenient: only used by getConnectorName(), not by the query tests below
+    lenient().when(connectorFactory.getActiveConfigurations()).thenReturn(List.of());
+    stateStore = new InMemoryInboundExecutableStateStore();
+    queryService =
+        new InboundExecutableQueryService(stateStore, connectorFactory, new ActivityLogRegistry());
+  }
+
+  private InboundConnectorElement testElement() {
+    return new InboundConnectorElement(
+        Map.of("inbound.type", "test-type"),
+        new StartEventCorrelationPoint("processId", 0, 0),
+        new ProcessElementWithRuntimeData("processId", 0, 0, "elementId", "tenant"));
+  }
+
+  private ValidInboundConnectorDetails testValidDetails(String dedupId) {
+    return new ValidInboundConnectorDetails(
+        "test-type", "tenant", dedupId, Map.of(), List.of(testElement()), "processId");
+  }
+
+  private InvalidInboundConnectorDetails testInvalidDetails(String dedupId) {
+    return new InvalidInboundConnectorDetails(
+        List.of(testElement()),
+        new RuntimeException("invalid config"),
+        "tenant",
+        dedupId,
+        "test-type",
+        "processId");
+  }
+
+  /**
+   * Demonstrates the bug: {@code FailedToActivate} health timestamp changes on every query because
+   * a new {@link Health} object is created each time in {@link InboundExecutableQueryService}.
+   *
+   * <p>After the fix, the {@link Health} is stored in the record at creation time and reused.
+   */
+  @Test
+  void failedToActivate_healthLastUpdatedAt_shouldBeStableAcrossQueries()
+      throws InterruptedException {
+    var id = ExecutableId.fromDeduplicationId("test-failed");
+    stateStore.put(
+        id,
+        new RegisteredExecutable.FailedToActivate(
+            testValidDetails("test-failed"),
+            "activation failed",
+            id,
+            Health.down(new RuntimeException("activation failed"))));
+
+    var health1 = queryService.query(null).get(0).health();
+    Thread.sleep(5); // ensure clock advances between the two calls
+    var health2 = queryService.query(null).get(0).health();
+
+    // Health.lastUpdatedAt must not change between queries — it should reflect
+    // when the failure was recorded, not when the API was called.
+    assertThat(health1.getLastUpdatedAt())
+        .as("lastUpdatedAt should be stable across queries for FailedToActivate")
+        .isEqualTo(health2.getLastUpdatedAt());
+  }
+
+  @Test
+  void invalidDefinition_healthLastUpdatedAt_shouldBeStableAcrossQueries()
+      throws InterruptedException {
+    var id = ExecutableId.fromDeduplicationId("test-invalid");
+    var invalid = testInvalidDetails("test-invalid");
+    stateStore.put(
+        id,
+        new RegisteredExecutable.InvalidDefinition(
+            invalid,
+            "Invalid connector definition: invalid config",
+            id,
+            Health.down(new RuntimeException("Invalid connector definition: invalid config"))));
+
+    var health1 = queryService.query(null).get(0).health();
+    Thread.sleep(5);
+    var health2 = queryService.query(null).get(0).health();
+
+    assertThat(health1.getLastUpdatedAt())
+        .as("lastUpdatedAt should be stable across queries for InvalidDefinition")
+        .isEqualTo(health2.getLastUpdatedAt());
+  }
+
+  @Test
+  void connectorNotRegistered_healthLastUpdatedAt_shouldBeStableAcrossQueries()
+      throws InterruptedException {
+    var id = ExecutableId.fromDeduplicationId("test-not-registered");
+    stateStore.put(
+        id,
+        new RegisteredExecutable.ConnectorNotRegistered(
+            testValidDetails("test-not-registered"),
+            id,
+            Health.down(new RuntimeException("Connector test-type not registered"))));
+
+    var health1 = queryService.query(null).get(0).health();
+    Thread.sleep(5);
+    var health2 = queryService.query(null).get(0).health();
+
+    assertThat(health1.getLastUpdatedAt())
+        .as("lastUpdatedAt should be stable across queries for ConnectorNotRegistered")
+        .isEqualTo(health2.getLastUpdatedAt());
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void cancelled_healthLastUpdatedAt_shouldBeStableAcrossQueries() throws InterruptedException {
+    var id = ExecutableId.fromDeduplicationId("test-cancelled");
+    var throwable = new RuntimeException("connector timed out");
+    // Simulate what cancelExecutable() does: report health on the context once, then read it back.
+    // The same Health object is returned on every call — timestamp is stable.
+    var stableHealth = Health.down(throwable);
+    when(context.connectorElements()).thenReturn(List.of(testElement()));
+    when(context.getActivationTimestamp()).thenReturn(0L);
+    when(context.getHealth()).thenReturn(stableHealth);
+    stateStore.put(
+        id,
+        new RegisteredExecutable.Cancelled(
+            (InboundConnectorExecutable<io.camunda.connector.api.inbound.InboundConnectorContext>)
+                executable,
+            context,
+            throwable,
+            id));
+
+    var health1 = queryService.query(null).get(0).health();
+    Thread.sleep(5); // ensure clock advances between the two calls
+    var health2 = queryService.query(null).get(0).health();
+
+    assertThat(health1.getLastUpdatedAt())
+        .as("lastUpdatedAt should be stable across queries for Cancelled")
+        .isEqualTo(health2.getLastUpdatedAt());
+  }
+}

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/inbound/executable/InboundExecutableRegistryTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/inbound/executable/InboundExecutableRegistryTest.java
@@ -385,7 +385,7 @@ public class InboundExecutableRegistryTest {
             null,
             t -> registry.handleEvent(new InboundExecutableEvent.Cancelled(RANDOM_ID, t)),
             new ObjectMapper(),
-            null);
+            activityLogRegistry);
 
     when(factory.getInstance(any())).thenReturn(executable);
     when(contextFactory.createContext(any(), any(), any(), any())).thenReturn(context);
@@ -416,16 +416,18 @@ public class InboundExecutableRegistryTest {
 
     var executable = mock(InboundConnectorExecutable.class);
     var definition = mock(InboundConnectorDefinition.class);
+    var connectorDetails2 = mock(InboundConnectorDetails.ValidInboundConnectorDetails.class);
+    when(connectorDetails2.deduplicationId()).thenReturn(RANDOM_STRING);
     var context =
         spy(
             new InboundConnectorContextImpl(
                 mock(SecretProvider.class),
                 mock(ValidationProvider.class),
-                mock(InboundConnectorDetails.ValidInboundConnectorDetails.class),
+                connectorDetails2,
                 null,
                 t -> registry.handleEvent(new InboundExecutableEvent.Cancelled(RANDOM_ID, t)),
                 new ObjectMapper(),
-                null));
+                activityLogRegistry));
 
     doNothing().doThrow(new Exception()).when(executable).activate(any());
     when(definition.deduplicationId()).thenReturn(RANDOM_STRING);


### PR DESCRIPTION
## Description

### The Bug

Every call to the inbound connector health/status API endpoints (`/inbound-instances`, `/executables/{id}/health`, etc.) was returning a **fresh `lastUpdatedAt` timestamp** for connectors in error states — meaning the timestamp always reflected the time of the API call, not when the failure actually occurred.

**Root cause:** `InboundExecutableQueryService.buildActiveExecutableResponse()` was called on every query. For non-`Activated` states (`FailedToActivate`, `InvalidDefinition`, `ConnectorNotRegistered`, and `Cancelled`), it constructed a new `Health` object via `Health.down(...)` on every invocation. Since every `Health` constructor sets `this.lastUpdatedAt = Instant.now()`, the timestamp was always "now".

```java
// Before — new Health created on every query call:
case FailedToActivate failed ->
    Health.down(new RuntimeException(failed.reason()))  // lastUpdatedAt = Instant.now() 🐛

// Also broken in aggregateHealth():
case Cancelled cancelled -> Health.down(cancelled.exceptionThrown())  // same problem
```

### The Fix

**For `FailedToActivate`, `InvalidDefinition`, and `ConnectorNotRegistered`:** a `Health health` field was added to each record and populated once at record creation time (in `BatchExecutableProcessor` and `InboundExecutableRegistryImpl`). The query service now reads this stored field instead of re-creating `Health` on every call.

**For `Cancelled`:** the approach mirrors `Activated` — the health is stored in the existing `context` (`InboundConnectorManagementContext`). `BatchExecutableProcessor.cancelExecutable()` now calls `context.reportHealth(Health.down(throwable))` at cancellation time, so `context.getHealth()` in the query service returns the stable, pre-computed health. This also produces an activity log entry for the health change, which is desirable behaviour.

```java
// After — health computed once at state-transition time, read on every query:
// FailedToActivate / InvalidDefinition / ConnectorNotRegistered:
record FailedToActivate(..., Health health) { }   // stored at creation

// Cancelled — consistent with Activated:
context.reportHealth(Health.down(throwable));       // set once at cancellation
context.getHealth()                                 // read on query (stable)
```

### Impact

All inbound connector API endpoints are fixed, since they all share the same `queryService.query()` code path.

## Related issues

closes #

## Checklist

- [x] Tests/Integration tests for the changes have been added if applicable.
  - New `InboundExecutableQueryServiceTest` with 4 tests (one per affected state) asserting `health.lastUpdatedAt` is stable across repeated queries.
  - Two existing `InboundExecutableRegistryTest` tests updated to pass a non-null `ActivityLogWriter` (required now that `cancelExecutable` calls `context.reportHealth()`).
- [ ] Backport labels are added if these code changes should be backported.
- [ ] If the change requires a documentation update, it has been added to the appropriate section in the documentation.
