### PR TITLE
chore: fix renovate for json-schema-validator

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -142,7 +142,17 @@
       "matchUpdateTypes": ["major"],
       "matchPackageNames": ["com.box:box-java-sdk"],
       "enabled": false
-    }
+    },
+    {
+      "description": "Disable major version updates for json-schema-validator — v3 is a complete API rewrite requiring a dedicated migration.",
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "matchPackageNames": [
+        "com.networknt:json-schema-validator"
+      ],
+      "enabled": false,
+      }
   ],
   "baseBranchPatterns": [
     "main",


### PR DESCRIPTION
This pull request updates the `renovate.json` configuration to further restrict automated major version updates. The main change is the explicit disabling of major version updates for the `json-schema-validator` package, due to significant API changes in its latest release.

Dependency update restrictions:

* Disabled major version updates for `com.networknt:json-schema-validator` to prevent automated upgrades to v3, which is a complete API rewrite and requires a dedicated migration.