### PR TITLE
fix: allow reset of inbound connectors in FailedToActivate/ConnectorNotRegistered state

### DIFF
--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/executable/InboundExecutableRegistry.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/executable/InboundExecutableRegistry.java
@@ -17,7 +17,6 @@
 package io.camunda.connector.runtime.inbound.executable;
 
 import io.camunda.connector.runtime.core.inbound.ExecutableId;
-import io.camunda.connector.runtime.inbound.executable.RegisteredExecutable.Activated;
 import java.util.List;
 import java.util.function.Consumer;
 
@@ -38,12 +37,14 @@ public interface InboundExecutableRegistry {
   String getConnectorName(String type);
 
   /**
-   * Resets the executable with the given ID by deactivating it and re-activating it with a fresh
-   * instance. Only executables in {@code Activated} or {@code Cancelled} state can be reset. Blocks
-   * until the restart completes and returns the new {@link Activated} executable.
+   * Resets the executable with the given ID by deactivating it (if applicable) and re-activating it
+   * with a fresh instance. Executables in {@code Activated}, {@code Cancelled}, or {@code
+   * FailedToActivate} state can be reset — this allows operators to retry activation after fixing
+   * the root cause (e.g. adding a missing secret). Blocks until the restart completes and returns
+   * the new state.
    *
    * @param id the ID of the executable to reset
-   * @return the new {@link Activated} executable after the reset
+   * @return the resulting {@link RegisteredExecutable} after the reset attempt
    * @throws IllegalArgumentException if no executable with the given ID is found
    * @throws IllegalStateException if the executable is not in a resettable state
    * @throws RuntimeException if the restart fails

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/executable/InboundExecutableRegistryImpl.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/executable/InboundExecutableRegistryImpl.java
@@ -339,7 +339,7 @@ public class InboundExecutableRegistryImpl implements InboundExecutableRegistry 
       throw new IllegalStateException(
           "Cannot reset executable '"
               + id
-              + "': not in a resettable state, but was: "
+              + "': not in a resettable state, was: "
               + current.getClass().getSimpleName());
     }
     return current;

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/executable/InboundExecutableRegistryImpl.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/executable/InboundExecutableRegistryImpl.java
@@ -30,6 +30,7 @@ import io.camunda.connector.runtime.inbound.executable.InboundExecutableStateTra
 import io.camunda.connector.runtime.inbound.executable.InboundExecutableStateTransitionService.TargetState;
 import io.camunda.connector.runtime.inbound.executable.RegisteredExecutable.Activated;
 import io.camunda.connector.runtime.inbound.executable.RegisteredExecutable.Cancelled;
+import io.camunda.connector.runtime.inbound.executable.RegisteredExecutable.FailedToActivate;
 import java.util.*;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -314,7 +315,7 @@ public class InboundExecutableRegistryImpl implements InboundExecutableRegistry 
       // elements and issue a RESTART plan. On activation failure, activateBatch stores a
       // FailedToActivate entry so the executable remains visible and retryable by operators.
       var targetState =
-          stateTransitionService.computeTargetState(extractContext(current).connectorElements());
+          stateTransitionService.computeTargetState(extractConnectorElements(current));
       executeStateTransition(
           new StateTransitionPlan(List.of(new PlannedAction(id, ActionType.RESTART))), targetState);
 
@@ -332,14 +333,27 @@ public class InboundExecutableRegistryImpl implements InboundExecutableRegistry 
     if (current == null) {
       throw new IllegalArgumentException("No executable found with ID: " + id);
     }
-    if (!(current instanceof Activated) && !(current instanceof Cancelled)) {
+    if (!(current instanceof Activated)
+        && !(current instanceof Cancelled)
+        && !(current instanceof FailedToActivate)) {
       throw new IllegalStateException(
           "Cannot reset executable '"
               + id
-              + "': must be in Activated or Cancelled state, but was: "
+              + "': not in a resettable state, but was: "
               + current.getClass().getSimpleName());
     }
     return current;
+  }
+
+  private List<InboundConnectorElement> extractConnectorElements(RegisteredExecutable executable) {
+    return switch (executable) {
+      case Activated a -> a.context().connectorElements();
+      case Cancelled c -> c.context().connectorElements();
+      case FailedToActivate f -> f.data().connectorElements();
+      default ->
+          throw new IllegalArgumentException(
+              "Cannot extract connector elements from: " + executable.getClass().getSimpleName());
+    };
   }
 
   /**
@@ -347,22 +361,12 @@ public class InboundExecutableRegistryImpl implements InboundExecutableRegistry 
    * {@link #handleProcessStateChanged} to synchronize state transitions.
    */
   private String extractProcessLockKey(RegisteredExecutable executable) {
-    var element = extractContext(executable).connectorElements().getFirst();
+    var element = extractConnectorElements(executable).getFirst();
     return processLockKey(element.tenantId(), element.element().bpmnProcessId());
   }
 
   private String processLockKey(String tenantId, String bpmnProcessId) {
     return tenantId + bpmnProcessId;
-  }
-
-  private InboundConnectorManagementContext extractContext(RegisteredExecutable executable) {
-    return switch (executable) {
-      case Activated a -> a.context();
-      case Cancelled c -> c.context();
-      default ->
-          throw new IllegalArgumentException(
-              "Cannot extract context from: " + executable.getClass().getSimpleName());
-    };
   }
 
   @Scheduled(fixedDelay = 30000)

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/inbound/executable/InboundExecutableRegistryTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/inbound/executable/InboundExecutableRegistryTest.java
@@ -526,6 +526,46 @@ public class InboundExecutableRegistryTest {
   }
 
   // -------------------------------------------------------------------------
+  // reset() tests
+  // -------------------------------------------------------------------------
+
+  @Test
+  public void reset_failedToActivate_shouldRetryAndSucceed() throws Exception {
+    // given - a connector that fails to activate on the first attempt
+    var elementId = "elementId";
+    var element =
+        spy(
+            new InboundConnectorElement(
+                Map.of(Keywords.INBOUND_TYPE_KEYWORD, "type1"),
+                new StartEventCorrelationPoint("processId", 0, 0),
+                new ProcessElementWithRuntimeData("id", 0, 0, elementId, "tenant")));
+    when(element.deduplicationId(any())).thenReturn(RANDOM_STRING);
+
+    var executable = mock(InboundConnectorExecutable.class);
+    var context = mock(InboundConnectorManagementContext.class);
+    when(contextFactory.createContext(any(), any(), any(), any())).thenReturn(context);
+    when(context.getDefinition())
+        .thenReturn(new InboundConnectorDefinition("type1", "tenant", "id", null));
+    when(context.connectorElements()).thenReturn(List.of(element));
+    when(factory.getInstance(any())).thenReturn(executable);
+
+    // First activate() throws → FailedToActivate; second call succeeds
+    doThrow(new RuntimeException("Missing secret")).doNothing().when(executable).activate(any());
+
+    registry.handleEvent(new ProcessStateChanged("id", "tenant", Map.of(0L, List.of(element))));
+
+    var beforeReset = registry.query(f -> f.executableId(RANDOM_ID)).getFirst();
+    assertThat(beforeReset.health().getStatus()).isEqualTo(Status.DOWN);
+
+    // when
+    var result = registry.reset(RANDOM_ID);
+
+    // then
+    assertThat(result).isInstanceOf(RegisteredExecutable.Activated.class);
+    verify(executable, times(2)).activate(any());
+  }
+
+  // -------------------------------------------------------------------------
   // Activity log tests
   // -------------------------------------------------------------------------
 

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/inbound/InboundInstancesRestControllerMultiInstancesTest.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/inbound/InboundInstancesRestControllerMultiInstancesTest.java
@@ -296,4 +296,64 @@ class InboundInstancesRestControllerMultiInstancesTest extends BaseMultiInstance
     List<ConnectorInstances> instance = response.getBody();
     assertEquals(0, instance.size());
   }
+
+  @Test
+  public void shouldResetExecutable_whenExistsOnlyOnInstance1() {
+    ResponseEntity<ActiveInboundConnectorResponse> response =
+        restTemplate.exchange(
+            "http://localhost:"
+                + port1
+                + "/inbound-instances/executables/"
+                + ONLY_IN_RUNTIME_1_ID.getId()
+                + "/reset",
+            HttpMethod.POST,
+            null,
+            new ParameterizedTypeReference<>() {});
+
+    assertEquals(200, response.getStatusCode().value());
+    var body = response.getBody();
+    assertNotNull(body);
+    assertEquals(ONLY_IN_RUNTIME_1_ID, body.executableId());
+    // reset() called on the instance that owns the executable, never on the other
+    verify(executableRegistry1).reset(ONLY_IN_RUNTIME_1_ID);
+    verify(executableRegistry2, never()).reset(any());
+  }
+
+  @Test
+  public void shouldResetExecutable_whenExistsOnBothInstances() {
+    ResponseEntity<ActiveInboundConnectorResponse> response =
+        restTemplate.exchange(
+            "http://localhost:"
+                + port1
+                + "/inbound-instances/executables/"
+                + RANDOM_ID_1.getId()
+                + "/reset",
+            HttpMethod.POST,
+            null,
+            new ParameterizedTypeReference<>() {});
+
+    assertEquals(200, response.getStatusCode().value());
+    var body = response.getBody();
+    assertNotNull(body);
+    assertEquals(RANDOM_ID_1, body.executableId());
+    // reset() called on both instances since both own the executable
+    verify(executableRegistry1).reset(RANDOM_ID_1);
+    verify(executableRegistry2).reset(RANDOM_ID_1);
+  }
+
+  @Test
+  public void shouldReturn404_whenResettingUnknownExecutable() {
+    var response =
+        restTemplate.exchange(
+            "http://localhost:"
+                + port1
+                + "/inbound-instances/executables/"
+                + UNKNOWN_ID.getId()
+                + "/reset",
+            HttpMethod.POST,
+            null,
+            String.class);
+
+    assertThat(404, equalTo(response.getStatusCode().value()));
+  }
 }


### PR DESCRIPTION
## Description

### Problem

Calling `POST /inbound-instances/executables/{id}/reset` on a connector that was **not healthy** (e.g. missing secret causing `FailedToActivate`) returned a confusing **404** instead of attempting to reset the connector.

### Root cause

The chain of failures that produced the 404:

1. `InboundInstancesService.resetExecutable()` first calls `findExecutable()` — this succeeds because `query()` returns all states including `FailedToActivate`.
2. It then calls `executableRegistry.reset(id)` which internally calls `validateResettable()`.
3. `validateResettable()` only accepted `Activated` or `Cancelled` states and threw `IllegalStateException` for anything else → **Spring returned 500**.
4. In the multi-instance setup, `InstanceForwardingHttpClient` filters out all responses with status ≥ 400. When every instance returns 4xx/5xx (500 from the owning instance, 404 from others), no successful response remains.
5. The controller's `Optional.ofNullable(...).orElseThrow(DataNotFoundException)` then fires → **404**.

### Fix

- **`validateResettable()`** now also allows `FailedToActivate`. `ConnectorNotRegistered` and `InvalidDefinition` remain non-resettable: `ConnectorNotRegistered` means the connector type isn't available in this runtime — resetting would immediately produce another `ConnectorNotRegistered`, so the right action is a runtime restart with the correct JARs. `InvalidDefinition` requires fixing the process model itself.
- **New `extractConnectorElements()` helper** replaces `extractContext()` and covers all three resettable states: for `Activated`/`Cancelled` it reads from the context; for `FailedToActivate` it reads from `data.connectorElements()`.
- The existing `RESTART` state-transition pipeline already handles `FailedToActivate` correctly: `deactivateSingle()` is a no-op for non-`Activated` entries, and `activateBatch()` retries activation from scratch — so if the root cause is fixed (e.g. secret added), the reset succeeds.

### State machine after this fix

| State | Resettable? | Notes |
|---|---|---|
| `Activated` | ✅ | Was already supported |
| `Cancelled` | ✅ | Was already supported |
| `FailedToActivate` | ✅ | **New** — retries activation (e.g. after adding a missing secret) |
| `ConnectorNotRegistered` | ❌ | Runtime doesn't have the connector type; needs runtime restart |
| `InvalidDefinition` | ❌ | Broken process model config; needs redeployment |

## Related issues

closes #

## Checklist

- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest
  release, as this branch will be rebased onto main before the next release. Example backport labels:
    - `backport stable/8.8`: for changes that should be included in the next 8.8.x release.
    - **or** `backport release-8.8.7`: for changes that should be included in the specific release 8.8.7, and this
      *release has already been created*. The release branch will be merged back into stable/8.8 later, so the change
      will be included in future 8.8.x releases as well.
- [x] Tests/Integration tests for the changes have been added if applicable.
- [ ] If the change requires a documentation update, it has been added to the appropriate section in the documentation.
