### PR TITLE
fix: convert Health.lastUpdatedAt Instant to OffsetDateTime in InstanceAwareHealth

### DIFF
--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/instances/InstanceAwareModel.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/instances/InstanceAwareModel.java
@@ -28,6 +28,10 @@ public sealed interface InstanceAwareModel
       implements InstanceAwareModel {}
 
   record InstanceAwareHealth(
-      Health.Status status, Health.Error error, Map<String, Object> details, String runtimeId)
+      Health.Status status,
+      Health.Error error,
+      Map<String, Object> details,
+      OffsetDateTime lastUpdatedAt,
+      String runtimeId)
       implements InstanceAwareModel {}
 }

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/instances/service/InboundInstancesService.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/instances/service/InboundInstancesService.java
@@ -47,9 +47,7 @@ public class InboundInstancesService {
             health.getStatus(),
             health.getError(),
             health.getDetails(),
-            health.getLastUpdatedAt() != null
-                ? health.getLastUpdatedAt().atOffset(ZoneOffset.UTC)
-                : null,
+            health.getLastUpdatedAt().atOffset(ZoneOffset.UTC),
             hostname));
   }
 

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/instances/service/InboundInstancesService.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/instances/service/InboundInstancesService.java
@@ -24,6 +24,7 @@ import io.camunda.connector.runtime.inbound.executable.ConnectorDataMapper;
 import io.camunda.connector.runtime.inbound.executable.ConnectorInstances;
 import io.camunda.connector.runtime.inbound.executable.InboundExecutableRegistry;
 import io.camunda.connector.runtime.instances.InstanceAwareModel;
+import java.time.ZoneOffset;
 import java.util.List;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
@@ -43,7 +44,13 @@ public class InboundInstancesService {
     Health health = executable.health();
     return List.of(
         new InstanceAwareModel.InstanceAwareHealth(
-            health.getStatus(), health.getError(), health.getDetails(), hostname));
+            health.getStatus(),
+            health.getError(),
+            health.getDetails(),
+            health.getLastUpdatedAt() != null
+                ? health.getLastUpdatedAt().atOffset(ZoneOffset.UTC)
+                : null,
+            hostname));
   }
 
   public List<InstanceAwareModel.InstanceAwareActivity> findInstanceAwareActivityLogs(

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/instances/reducer/InstanceAwareHealthListReducerTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/instances/reducer/InstanceAwareHealthListReducerTest.java
@@ -22,6 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.fasterxml.jackson.core.type.TypeReference;
 import io.camunda.connector.api.inbound.Health;
 import io.camunda.connector.runtime.instances.InstanceAwareModel;
+import java.time.ZoneOffset;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 
@@ -35,13 +36,21 @@ public class InstanceAwareHealthListReducerTest {
     List<InstanceAwareModel.InstanceAwareHealth> health1 =
         List.of(
             new InstanceAwareModel.InstanceAwareHealth(
-                up.getStatus(), up.getError(), up.getDetails(), "hostname"));
+                up.getStatus(),
+                up.getError(),
+                up.getDetails(),
+                up.getLastUpdatedAt().atOffset(ZoneOffset.UTC),
+                "hostname"));
 
     Health down = Health.down();
     List<InstanceAwareModel.InstanceAwareHealth> health2 =
         List.of(
             new InstanceAwareModel.InstanceAwareHealth(
-                down.getStatus(), down.getError(), down.getDetails(), "hostname2"));
+                down.getStatus(),
+                down.getError(),
+                down.getDetails(),
+                down.getLastUpdatedAt().atOffset(ZoneOffset.UTC),
+                "hostname2"));
 
     List<InstanceAwareModel.InstanceAwareHealth> result = reducer.reduce(health1, health2);
 
@@ -57,7 +66,11 @@ public class InstanceAwareHealthListReducerTest {
     List<InstanceAwareModel.InstanceAwareHealth> health2 =
         List.of(
             new InstanceAwareModel.InstanceAwareHealth(
-                down.getStatus(), down.getError(), down.getDetails(), "hostname2"));
+                down.getStatus(),
+                down.getError(),
+                down.getDetails(),
+                down.getLastUpdatedAt().atOffset(ZoneOffset.UTC),
+                "hostname2"));
 
     List<InstanceAwareModel.InstanceAwareHealth> result = reducer.reduce(health1, health2);
 

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/inbound/InboundInstancesRestControllerMultiInstancesTest.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/inbound/InboundInstancesRestControllerMultiInstancesTest.java
@@ -247,15 +247,18 @@ class InboundInstancesRestControllerMultiInstancesTest extends BaseMultiInstance
             new ParameterizedTypeReference<>() {});
     var logs = response.getBody();
     assertEquals(2, logs.size());
-    assertThat(
-        logs,
-        containsInAnyOrder(
-            new InstanceAwareModel.InstanceAwareHealth(
-                Health.Status.UNKNOWN,
-                null,
-                Map.of("Test unknown key", "Test unknown value"),
-                "instance1"),
-            new InstanceAwareModel.InstanceAwareHealth(Health.Status.UP, null, null, "instance2")));
+    var instance1Health =
+        logs.stream().filter(h -> "instance1".equals(h.runtimeId())).findFirst().orElseThrow();
+    assertEquals(Health.Status.UNKNOWN, instance1Health.status());
+    assertNull(instance1Health.error());
+    assertEquals(Map.of("Test unknown key", "Test unknown value"), instance1Health.details());
+    assertNotNull(instance1Health.lastUpdatedAt());
+    var instance2Health =
+        logs.stream().filter(h -> "instance2".equals(h.runtimeId())).findFirst().orElseThrow();
+    assertEquals(Health.Status.UP, instance2Health.status());
+    assertNull(instance2Health.error());
+    assertNull(instance2Health.details());
+    assertNotNull(instance2Health.lastUpdatedAt());
   }
 
   @Test
@@ -274,10 +277,12 @@ class InboundInstancesRestControllerMultiInstancesTest extends BaseMultiInstance
             new ParameterizedTypeReference<>() {});
     var logs = response.getBody();
     assertEquals(1, logs.size());
-    assertThat(
-        logs.getFirst(),
-        equalTo(
-            new InstanceAwareModel.InstanceAwareHealth(Health.Status.UP, null, null, "instance1")));
+    var healthEntry = logs.getFirst();
+    assertEquals(Health.Status.UP, healthEntry.status());
+    assertNull(healthEntry.error());
+    assertNull(healthEntry.details());
+    assertNotNull(healthEntry.lastUpdatedAt());
+    assertEquals("instance1", healthEntry.runtimeId());
   }
 
   @Test

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/inbound/InboundInstancesRestControllerTest.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/inbound/InboundInstancesRestControllerTest.java
@@ -43,6 +43,8 @@ import io.camunda.connector.runtime.inbound.executable.ActiveExecutableQuery;
 import io.camunda.connector.runtime.inbound.executable.ActiveExecutableResponse;
 import io.camunda.connector.runtime.inbound.executable.ConnectorInstances;
 import io.camunda.connector.runtime.inbound.executable.InboundExecutableRegistry;
+import io.camunda.connector.runtime.instances.InstanceAwareModel;
+import java.time.ZoneOffset;
 import java.util.*;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
@@ -67,6 +69,8 @@ class InboundInstancesRestControllerTest {
   private static final ExecutableId RANDOM_ID_2 = ExecutableId.fromDeduplicationId("theid2");
   private static final ExecutableId RANDOM_ID_3 = ExecutableId.fromDeduplicationId("theid3");
   private static final String TYPE_2 = "anotherType";
+
+  private final Health health1 = Health.up();
 
   static class AnotherExecutable implements InboundConnectorExecutable<InboundConnectorContext> {
 
@@ -106,7 +110,7 @@ class InboundInstancesRestControllerTest {
                                   new StandaloneMessageCorrelationPoint(
                                       "myPath", "=expression", "=myPath", null),
                                   new ProcessElementWithRuntimeData("ProcessA", 1, 1, "", ""))),
-                          Health.up(),
+                          health1,
                           Collections.emptyList(),
                           System.currentTimeMillis()),
                       new ActiveExecutableResponse(
@@ -382,6 +386,30 @@ class InboundInstancesRestControllerTest {
                 .string(
                     containsString(
                         "Data of type 'ActiveInboundConnectorResponse' with id 'UNKNOWN-ID' not found")));
+  }
+
+  @Test
+  public void shouldReturnHealth() throws Exception {
+    var response =
+        mockMvc
+            .perform(
+                get(
+                    "/inbound-instances/"
+                        + TYPE_1
+                        + "/executables/"
+                        + RANDOM_ID_1.getId()
+                        + "/health"))
+            .andExpect(status().isOk())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+
+    List<InstanceAwareModel.InstanceAwareHealth> health =
+        ConnectorsObjectMapperSupplier.getCopy().readValue(response, new TypeReference<>() {});
+    assertEquals(1, health.size());
+    assertEquals(Health.Status.UP, health.getFirst().status());
+    assertEquals(
+        health1.getLastUpdatedAt().atOffset(ZoneOffset.UTC), health.getFirst().lastUpdatedAt());
   }
 
   private boolean matchesQuery(ActiveExecutableResponse response, ActiveExecutableQuery query) {


### PR DESCRIPTION
This pull request enhances the health status reporting for connector instances by adding a `lastUpdatedAt` timestamp to the `InstanceAwareHealth` model. The changes ensure that health status responses now include the last time the health information was updated, and all relevant code and tests have been updated to support and validate this new field.

**Health status model and logic updates:**

* Added a new `lastUpdatedAt` field of type `OffsetDateTime` to the `InstanceAwareHealth` record in `InstanceAwareModel`, and updated all usages to populate this field with the health's last updated timestamp in UTC. [[1]](diffhunk://#diff-44196568fd16b0b486b7e551ccb90cfa8c1fc8d45de09fafc48318729ebbff39L31-R35) [[2]](diffhunk://#diff-51c70770e13963767ce65f8aebfa59ea4aac214e8b35dbb0eb02018a7f01f92fL46-R53)

