### PR TITLE
ci: replace 8-SNAPSHOT Optimize docker tag with SNAPSHOT

### DIFF
--- a/.github/workflows/MERGE_QUEUE_HELM_TEST.yaml
+++ b/.github/workflows/MERGE_QUEUE_HELM_TEST.yaml
@@ -241,7 +241,7 @@ jobs:
                       "operateVersion": "SNAPSHOT",
                       "tasklistVersion": "SNAPSHOT",
                       "connectorsVersion": "${{ needs.build-image.outputs.connectors-version }}",
-                      "optimizeVersion": "8-SNAPSHOT"
+                      "optimizeVersion": "SNAPSHOT"
                   }
                 }'
 


### PR DESCRIPTION
## Summary

Replaces `"optimizeVersion": "8-SNAPSHOT"` with `"optimizeVersion": "SNAPSHOT"` in `MERGE_QUEUE_HELM_TEST.yaml`.

Now that Optimize is built in the unified monorepo CI, the `8-SNAPSHOT` tag is no longer updated. `SNAPSHOT` always tracks the latest main build, consistent with how `zeebeVersion`, `operateVersion`, and `tasklistVersion` are already tagged in the same payload.

relates to camunda/camunda#40846

---
_Generated by [Claude Code](https://claude.ai/code/session_01W7vzpeKyfqFe5jNCebH4c6)_