### PR TITLE
refactor(agentic-ai): Refactor agent initialization around domain oriented concepts

### DIFF
--- a/connectors/agentic-ai/docs/adr/006-data-driven-agent-initialization.md
+++ b/connectors/agentic-ai/docs/adr/006-data-driven-agent-initialization.md
@@ -1,0 +1,106 @@
+# Data-Driven Agent Initialization Verdicts and the `AgentConversation` Aggregate
+
+* Deciders: Agentic AI Team
+* Date: Jun 5, 2026
+
+## Status
+
+**Proposed**
+
+## Context and Problem Statement
+
+The AI Agent connector's per-turn initialization was complex and procedural. `AgentInitializer`
+returned a sealed `AgentInitializationResult` whose three variants
+(`AgentContextInitializationResult`, `AgentResponseInitializationResult`,
+`AgentDiscoveryInProgressInitializationResult`) were named after their payload shape rather than any
+lifecycle meaning, and two of the three collapsed to the same handler action. More importantly, the
+result carried **technical objects** the initializer had no business building: an `AgentResponse`
+(connector-output shaping) and an `AgentJobCompletionListener` (engine status-update concern). So the
+initializer reached into response assembly (`AgentResponse.builder()`, `ToolCallProcessVariable`) and
+agent-instance status patching — concerns the handler already owns for the sibling transitions
+(`THINKING`, `TOOL_CALLING`, `IDLE`, metrics).
+
+Separately, the agent's working state for a turn was scattered across three layers with no domain
+object tying them together: `AgentContext` (durable, persisted state), the inbound
+`toolCallResults` (transient per-turn input from the engine), and `RuntimeMemory` (the message
+working-set). The orchestration threaded these as loose locals through `BaseAgentRequestHandler`.
+
+How should we express the beginning of the agent lifecycle in a domain-oriented way, without leaking
+technical response/engine concerns into the initializer, and without changing runtime behavior or the
+serialized `agentContext` contract?
+
+## Decision Drivers
+
+* **Domain-oriented expression**: the lifecycle should read as agent concepts — provision the agent
+  instance, resolve tools, discover gateway tools, then converse — not as a payload-shaped state
+  switch.
+* **No layer leak**: the initializer should return *what it determined* (domain data), and the
+  handler should own the *technical translation* (responses, listeners, the conversation phase).
+* **A cohesive turn aggregate**: one object should represent "the agent's conversation as it stands
+  this turn," restored from durable state + stored messages and primed with the engine's new results.
+* **Behavior + contract preservation**: identical engine calls, listeners, no-op semantics, and
+  migration handling; the serialized `AgentContext` / `AgentState` enum must not change.
+* **Incremental adoption**: land the structural/state changes first; migrate turn behavior into the
+  aggregate later to keep the change reviewable.
+
+## Considered Options
+
+1. **Keep** the three payload-shaped variants and the procedural orchestration.
+2. **Collapse to two variants** that still carry `AgentResponse` + listener (a `ReadyToConverse` /
+   `DeferConversation` pair). Simpler switch, but the technical-object leak remains.
+3. **Data-driven verdicts + an `AgentConversation` aggregate**: the initializer returns pure-data
+   verdicts; the handler builds responses/listeners; a transient `AgentConversation` aggregate carries
+   the turn's working state.
+
+A `JobData` wrapper bundling `agentContext` + `toolCallResults` was also considered and **rejected**:
+the two are at different layers (durable persisted state vs. transient per-turn engine input), so
+bundling them would unify them only superficially.
+
+## Decision Outcome
+
+Chosen option: **Option 3 — data-driven verdicts + an `AgentConversation` aggregate**, adopted in
+**stages** (state aggregate now, turn behavior later).
+
+### Core changes (Stage 1)
+
+- `AgentInitializationResult` becomes three pure-data verdicts:
+  - `ReadyToConverse(AgentContext agentContext, List<ToolCallResult> engineToolCallResults)`
+  - `DiscoverTools(AgentContext agentContext, List<ToolCall> toolDiscoveryToolCalls)`
+  - `DeferConversation()`  (no-op this turn while awaiting more results)
+- `AgentResponse` construction and the `TOOL_DISCOVERY` completion listener move from
+  `AgentInitializerImpl` into `BaseAgentRequestHandler`, co-located with the other agent-instance
+  status transitions. The initializer keeps `agentInstanceClient` only for provisioning.
+- `AgentInitializerImpl` reads as a lifecycle narrative — `provisionAgentInstance` → `beginToolDiscovery`
+  → `dispatchGatewayToolDiscovery` → `completeToolDiscovery` → `resumeReadyAgent` — keeping the
+  serialized `AgentState` enum (`INITIALIZING`/`TOOL_DISCOVERY`/`READY`) unchanged.
+- New transient, non-serialized aggregate `AgentConversation`, built by
+  `rehydrate(context, messageMemory, engineToolCallResults)`: `context` + `messageMemory` are
+  *restored* from persisted state, while `engineToolCallResults` is *this turn's new engine input*
+  primed to be folded into the conversation. `AgentContext` remains the sole serialized projection;
+  the aggregate reduces back to it.
+- `BaseAgentRequestHandler` switches over the three verdicts; the conversation phase rehydrates the
+  aggregate inside the `ConversationSession` try-with-resources (the handler continues to own the
+  session lifecycle).
+
+### Consequences
+
+**Positive:**
+- The initializer is pure domain logic; technical response/engine concerns live in one place (the
+  handler).
+- The verdicts are self-describing and exhaustively switchable (sealed, no `default`).
+- A single aggregate represents the turn's working state, replacing scattered locals and giving turn
+  behavior a future home.
+- No change to the serialized contract, migration detection, or the write-ahead/pointer memory
+  invariant.
+
+**Negative:**
+- Listener-behavior tests move from the initializer layer to the handler layer.
+- Two "conversation" vocabularies now coexist — `ConversationStore`/`Session`/`Context` (message
+  persistence) vs. `AgentConversation` (the live turn aggregate); the distinction must be kept clear.
+
+### Future improvements
+
+- **Stage 2**: migrate turn behavior onto `AgentConversation` (folding `engineToolCallResults` into
+  messages, the model call, persistence, response building), thinning `BaseAgentRequestHandler` to a
+  driver; reconsider whether the aggregate should then own the `ConversationSession`.
+- Update `docs/reference/ai-agent.md` and `connectors/agentic-ai/CLAUDE.md` to the new vocabulary.

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/agent/AgentInitializationResult.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/agent/AgentInitializationResult.java
@@ -14,7 +14,7 @@ import java.util.List;
 public sealed interface AgentInitializationResult {
 
   /** Agent provisioned and tools resolved: proceed to the conversation phase. */
-  record ReadyToConverse(AgentContext agentContext, List<ToolCallResult> engineToolCallResults)
+  record ReadyToConverse(AgentContext agentContext, List<ToolCallResult> toolCallResults)
       implements AgentInitializationResult {}
 
   /** Gateway tools require discovery: dispatch these discovery tool calls, then await results. */

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/agent/AgentInitializationResult.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/agent/AgentInitializationResult.java
@@ -7,28 +7,23 @@
 package io.camunda.connector.agenticai.aiagent.agent;
 
 import io.camunda.connector.agenticai.aiagent.model.AgentContext;
-import io.camunda.connector.agenticai.aiagent.model.AgentResponse;
+import io.camunda.connector.agenticai.model.tool.ToolCall;
 import io.camunda.connector.agenticai.model.tool.ToolCallResult;
 import java.util.List;
-import org.jspecify.annotations.Nullable;
 
 public sealed interface AgentInitializationResult
-    permits AgentInitializationResult.AgentContextInitializationResult,
-        AgentInitializationResult.AgentDiscoveryInProgressInitializationResult,
-        AgentInitializationResult.AgentResponseInitializationResult {
+    permits AgentInitializationResult.ReadyToConverse,
+        AgentInitializationResult.DiscoverTools,
+        AgentInitializationResult.DeferConversation {
 
-  record AgentContextInitializationResult(
-      AgentContext agentContext, List<ToolCallResult> toolCallResults)
+  /** Agent provisioned and tools resolved: proceed to the conversation phase. */
+  record ReadyToConverse(AgentContext agentContext, List<ToolCallResult> engineToolCallResults)
       implements AgentInitializationResult {}
 
-  record AgentDiscoveryInProgressInitializationResult() implements AgentInitializationResult {}
+  /** Gateway tools require discovery: dispatch these discovery tool calls, then await results. */
+  record DiscoverTools(AgentContext agentContext, List<ToolCall> toolDiscoveryToolCalls)
+      implements AgentInitializationResult {}
 
-  record AgentResponseInitializationResult(
-      AgentResponse agentResponse, @Nullable AgentJobCompletionListener completionListener)
-      implements AgentInitializationResult {
-
-    AgentResponseInitializationResult(AgentResponse agentResponse) {
-      this(agentResponse, null);
-    }
-  }
+  /** Discovery already dispatched; results not all present yet — no-op this turn. */
+  record DeferConversation() implements AgentInitializationResult {}
 }

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/agent/AgentInitializationResult.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/agent/AgentInitializationResult.java
@@ -11,10 +11,7 @@ import io.camunda.connector.agenticai.model.tool.ToolCall;
 import io.camunda.connector.agenticai.model.tool.ToolCallResult;
 import java.util.List;
 
-public sealed interface AgentInitializationResult
-    permits AgentInitializationResult.ReadyToConverse,
-        AgentInitializationResult.DiscoverTools,
-        AgentInitializationResult.DeferConversation {
+public sealed interface AgentInitializationResult {
 
   /** Agent provisioned and tools resolved: proceed to the conversation phase. */
   record ReadyToConverse(AgentContext agentContext, List<ToolCallResult> engineToolCallResults)

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/agent/AgentInitializerImpl.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/agent/AgentInitializerImpl.java
@@ -6,23 +6,19 @@
  */
 package io.camunda.connector.agenticai.aiagent.agent;
 
-import io.camunda.client.api.command.AgentInstanceUpdateStatus;
-import io.camunda.connector.agenticai.aiagent.agent.AgentInitializationResult.AgentContextInitializationResult;
-import io.camunda.connector.agenticai.aiagent.agent.AgentInitializationResult.AgentDiscoveryInProgressInitializationResult;
-import io.camunda.connector.agenticai.aiagent.agent.AgentInitializationResult.AgentResponseInitializationResult;
+import io.camunda.connector.agenticai.aiagent.agent.AgentInitializationResult.DeferConversation;
+import io.camunda.connector.agenticai.aiagent.agent.AgentInitializationResult.DiscoverTools;
+import io.camunda.connector.agenticai.aiagent.agent.AgentInitializationResult.ReadyToConverse;
 import io.camunda.connector.agenticai.aiagent.agentinstance.AgentInstanceClient;
-import io.camunda.connector.agenticai.aiagent.agentinstance.AgentInstanceUpdateRequest;
 import io.camunda.connector.agenticai.aiagent.model.AgentContext;
 import io.camunda.connector.agenticai.aiagent.model.AgentExecutionContext;
 import io.camunda.connector.agenticai.aiagent.model.AgentMetadata;
-import io.camunda.connector.agenticai.aiagent.model.AgentResponse;
 import io.camunda.connector.agenticai.aiagent.model.AgentState;
 import io.camunda.connector.agenticai.aiagent.tool.GatewayToolDiscoveryInitiationResult;
 import io.camunda.connector.agenticai.aiagent.tool.GatewayToolHandlerRegistry;
 import io.camunda.connector.agenticai.model.tool.GatewayToolDefinition;
-import io.camunda.connector.agenticai.model.tool.ToolCallProcessVariable;
+import io.camunda.connector.agenticai.model.tool.ToolCall;
 import io.camunda.connector.agenticai.model.tool.ToolCallResult;
-import io.camunda.connector.api.outbound.JobCompletionFailure;
 import java.util.List;
 import java.util.Optional;
 import org.slf4j.Logger;
@@ -50,15 +46,16 @@ public class AgentInitializerImpl implements AgentInitializer {
   public AgentInitializationResult initializeAgent(AgentExecutionContext executionContext) {
     AgentContext agentContext =
         Optional.ofNullable(executionContext.initialAgentContext())
-            .orElseGet(() -> createAgentContext(executionContext));
+            .orElseGet(() -> provisionAgentInstance(executionContext));
 
-    List<ToolCallResult> toolCallResults =
+    List<ToolCallResult> engineToolCallResults =
         Optional.ofNullable(executionContext.initialToolCallResults()).orElseGet(List::of);
 
     return switch (agentContext.state()) {
-      case INITIALIZING -> initiateToolDiscovery(executionContext, agentContext, toolCallResults);
-      case TOOL_DISCOVERY -> handleToolDiscoveryResults(agentContext, toolCallResults);
-      default -> handleReadyState(executionContext, agentContext, toolCallResults);
+      case INITIALIZING ->
+          beginToolDiscovery(executionContext, agentContext, engineToolCallResults);
+      case TOOL_DISCOVERY -> completeToolDiscovery(agentContext, engineToolCallResults);
+      default -> resumeReadyAgent(executionContext, agentContext, engineToolCallResults);
     };
   }
 
@@ -69,7 +66,7 @@ public class AgentInitializerImpl implements AgentInitializer {
    * @throws io.camunda.connector.api.error.ConnectorException with code {@code
    *     AGENT_INSTANCE_CREATION_FAILED} when retries are exhausted or a non-retryable error occurs
    */
-  private AgentContext createAgentContext(AgentExecutionContext executionContext) {
+  private AgentContext provisionAgentInstance(AgentExecutionContext executionContext) {
     final var agentInstanceKey = agentInstanceClient.create(executionContext);
     return AgentContext.empty()
         .withMetadata(
@@ -77,10 +74,10 @@ public class AgentInitializerImpl implements AgentInitializer {
                 .withAgentInstanceKey(agentInstanceKey.value()));
   }
 
-  private AgentInitializationResult handleReadyState(
+  private AgentInitializationResult resumeReadyAgent(
       AgentExecutionContext executionContext,
       AgentContext agentContext,
-      List<ToolCallResult> toolCallResults) {
+      List<ToolCallResult> engineToolCallResults) {
 
     final var agentMetadata = agentContext.metadata();
     final var executionMetadata = AgentMetadata.of(executionContext.jobContext());
@@ -92,31 +89,29 @@ public class AgentInitializerImpl implements AgentInitializer {
               .withMetadata(executionMetadata);
     }
 
-    return new AgentContextInitializationResult(agentContext, toolCallResults);
+    return new ReadyToConverse(agentContext, engineToolCallResults);
   }
 
-  private AgentInitializationResult initiateToolDiscovery(
+  private AgentInitializationResult beginToolDiscovery(
       AgentExecutionContext executionContext,
       AgentContext agentContext,
-      List<ToolCallResult> toolCallResults) {
+      List<ToolCallResult> engineToolCallResults) {
     // add ad-hoc tool definitions to agent context
     final var adHocToolsSchema = toolsResolver.loadAdHocToolsSchema(executionContext, agentContext);
     agentContext = agentContext.withToolDefinitions(adHocToolsSchema.toolDefinitions());
 
     if (CollectionUtils.isEmpty(adHocToolsSchema.gatewayToolDefinitions())) {
-      return new AgentContextInitializationResult(
-          agentContext.withState(AgentState.READY), toolCallResults);
+      return new ReadyToConverse(agentContext.withState(AgentState.READY), engineToolCallResults);
     }
 
     // handle gateway tool definitions (e.g. MCP)
-    return initiateGatewayToolDiscovery(
-        executionContext, agentContext, toolCallResults, adHocToolsSchema.gatewayToolDefinitions());
+    return dispatchGatewayToolDiscovery(
+        agentContext, engineToolCallResults, adHocToolsSchema.gatewayToolDefinitions());
   }
 
-  private AgentInitializationResult initiateGatewayToolDiscovery(
-      AgentExecutionContext executionContext,
+  private AgentInitializationResult dispatchGatewayToolDiscovery(
       AgentContext agentContext,
-      List<ToolCallResult> toolCallResults,
+      List<ToolCallResult> engineToolCallResults,
       List<GatewayToolDefinition> gatewayToolDefinitions) {
     GatewayToolDiscoveryInitiationResult initiationResult =
         gatewayToolHandlers.initiateToolDiscovery(agentContext, gatewayToolDefinitions);
@@ -124,58 +119,25 @@ public class AgentInitializerImpl implements AgentInitializer {
 
     if (!CollectionUtils.isEmpty(initiationResult.toolDiscoveryToolCalls())) {
       // execute tool discovery tool calls before agent is ready for requests
-      final var discoveryAgentContext = agentContext.withState(AgentState.TOOL_DISCOVERY);
-      return new AgentResponseInitializationResult(
-          AgentResponse.builder()
-              .context(discoveryAgentContext)
-              .toolCalls(
-                  initiationResult.toolDiscoveryToolCalls().stream()
-                      .map(ToolCallProcessVariable::from)
-                      .toList())
-              .build(),
-          createToolDiscoveryCompletionListener(executionContext, discoveryAgentContext));
+      final List<ToolCall> discoveryToolCalls = initiationResult.toolDiscoveryToolCalls();
+      return new DiscoverTools(
+          agentContext.withState(AgentState.TOOL_DISCOVERY), discoveryToolCalls);
     } else {
       // no tool discovery needed -> agent is ready for requests
-      return new AgentContextInitializationResult(
-          agentContext.withState(AgentState.READY), toolCallResults);
+      return new ReadyToConverse(agentContext.withState(AgentState.READY), engineToolCallResults);
     }
   }
 
-  private AgentJobCompletionListener createToolDiscoveryCompletionListener(
-      AgentExecutionContext executionContext, AgentContext agentContext) {
-    return new AgentJobCompletionListener() {
-      @Override
-      public void onJobCompleted() {
-        try {
-          agentInstanceClient.update(
-              executionContext,
-              agentContext,
-              AgentInstanceUpdateRequest.statusOnly(AgentInstanceUpdateStatus.TOOL_DISCOVERY));
-        } catch (Exception e) {
-          LOGGER.error(
-              "Failed to update agent instance status to TOOL_DISCOVERY after job completion", e);
-        }
-      }
-
-      @Override
-      public void onJobCompletionFailed(JobCompletionFailure failure) {
-        LOGGER.debug(
-            "Job completion failed ({}), skipping TOOL_DISCOVERY status update",
-            failure.getClass().getSimpleName());
-      }
-    };
-  }
-
-  private AgentInitializationResult handleToolDiscoveryResults(
-      AgentContext agentContext, List<ToolCallResult> toolCallResults) {
-    if (!gatewayToolHandlers.allToolDiscoveryResultsPresent(agentContext, toolCallResults)) {
-      return new AgentDiscoveryInProgressInitializationResult();
+  private AgentInitializationResult completeToolDiscovery(
+      AgentContext agentContext, List<ToolCallResult> engineToolCallResults) {
+    if (!gatewayToolHandlers.allToolDiscoveryResultsPresent(agentContext, engineToolCallResults)) {
+      return new DeferConversation();
     }
 
     final var gatewayToolDiscoveryResult =
-        gatewayToolHandlers.handleToolDiscoveryResults(agentContext, toolCallResults);
+        gatewayToolHandlers.handleToolDiscoveryResults(agentContext, engineToolCallResults);
 
-    return new AgentContextInitializationResult(
+    return new ReadyToConverse(
         gatewayToolDiscoveryResult.agentContext().withState(AgentState.READY),
         gatewayToolDiscoveryResult.remainingToolCallResults());
   }

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/agent/AgentInitializerImpl.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/agent/AgentInitializerImpl.java
@@ -48,14 +48,14 @@ public class AgentInitializerImpl implements AgentInitializer {
         Optional.ofNullable(executionContext.initialAgentContext())
             .orElseGet(() -> provisionAgentInstance(executionContext));
 
-    List<ToolCallResult> engineToolCallResults =
+    List<ToolCallResult> initialToolCallResults =
         Optional.ofNullable(executionContext.initialToolCallResults()).orElseGet(List::of);
 
     return switch (agentContext.state()) {
       case INITIALIZING ->
-          beginToolDiscovery(executionContext, agentContext, engineToolCallResults);
-      case TOOL_DISCOVERY -> completeToolDiscovery(agentContext, engineToolCallResults);
-      default -> resumeReadyAgent(executionContext, agentContext, engineToolCallResults);
+          beginToolDiscovery(executionContext, agentContext, initialToolCallResults);
+      case TOOL_DISCOVERY -> completeToolDiscovery(agentContext, initialToolCallResults);
+      default -> resumeReadyAgent(executionContext, agentContext, initialToolCallResults);
     };
   }
 
@@ -77,7 +77,7 @@ public class AgentInitializerImpl implements AgentInitializer {
   private AgentInitializationResult resumeReadyAgent(
       AgentExecutionContext executionContext,
       AgentContext agentContext,
-      List<ToolCallResult> engineToolCallResults) {
+      List<ToolCallResult> initialToolCallResults) {
 
     final var agentMetadata = agentContext.metadata();
     final var executionMetadata = AgentMetadata.of(executionContext.jobContext());
@@ -89,29 +89,29 @@ public class AgentInitializerImpl implements AgentInitializer {
               .withMetadata(executionMetadata);
     }
 
-    return new ReadyToConverse(agentContext, engineToolCallResults);
+    return new ReadyToConverse(agentContext, initialToolCallResults);
   }
 
   private AgentInitializationResult beginToolDiscovery(
       AgentExecutionContext executionContext,
       AgentContext agentContext,
-      List<ToolCallResult> engineToolCallResults) {
+      List<ToolCallResult> initialToolCallResults) {
     // add ad-hoc tool definitions to agent context
     final var adHocToolsSchema = toolsResolver.loadAdHocToolsSchema(executionContext, agentContext);
     agentContext = agentContext.withToolDefinitions(adHocToolsSchema.toolDefinitions());
 
     if (CollectionUtils.isEmpty(adHocToolsSchema.gatewayToolDefinitions())) {
-      return new ReadyToConverse(agentContext.withState(AgentState.READY), engineToolCallResults);
+      return new ReadyToConverse(agentContext.withState(AgentState.READY), initialToolCallResults);
     }
 
     // handle gateway tool definitions (e.g. MCP)
     return dispatchGatewayToolDiscovery(
-        agentContext, engineToolCallResults, adHocToolsSchema.gatewayToolDefinitions());
+        agentContext, initialToolCallResults, adHocToolsSchema.gatewayToolDefinitions());
   }
 
   private AgentInitializationResult dispatchGatewayToolDiscovery(
       AgentContext agentContext,
-      List<ToolCallResult> engineToolCallResults,
+      List<ToolCallResult> initialToolCallResults,
       List<GatewayToolDefinition> gatewayToolDefinitions) {
     GatewayToolDiscoveryInitiationResult initiationResult =
         gatewayToolHandlers.initiateToolDiscovery(agentContext, gatewayToolDefinitions);
@@ -124,18 +124,18 @@ public class AgentInitializerImpl implements AgentInitializer {
           agentContext.withState(AgentState.TOOL_DISCOVERY), discoveryToolCalls);
     } else {
       // no tool discovery needed -> agent is ready for requests
-      return new ReadyToConverse(agentContext.withState(AgentState.READY), engineToolCallResults);
+      return new ReadyToConverse(agentContext.withState(AgentState.READY), initialToolCallResults);
     }
   }
 
   private AgentInitializationResult completeToolDiscovery(
-      AgentContext agentContext, List<ToolCallResult> engineToolCallResults) {
-    if (!gatewayToolHandlers.allToolDiscoveryResultsPresent(agentContext, engineToolCallResults)) {
+      AgentContext agentContext, List<ToolCallResult> initialToolCallResults) {
+    if (!gatewayToolHandlers.allToolDiscoveryResultsPresent(agentContext, initialToolCallResults)) {
       return new DeferConversation();
     }
 
     final var gatewayToolDiscoveryResult =
-        gatewayToolHandlers.handleToolDiscoveryResults(agentContext, engineToolCallResults);
+        gatewayToolHandlers.handleToolDiscoveryResults(agentContext, initialToolCallResults);
 
     return new ReadyToConverse(
         gatewayToolDiscoveryResult.agentContext().withState(AgentState.READY),

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/agent/BaseAgentRequestHandler.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/agent/BaseAgentRequestHandler.java
@@ -78,12 +78,6 @@ public abstract class BaseAgentRequestHandler<
   @Override
   public R handleRequest(final C executionContext) {
     return switch (agentInitializer.initializeAgent(executionContext)) {
-      case ReadyToConverse(var agentContext, var engineToolCallResults) -> {
-        LOGGER.debug(
-            "Handling agent request with {} tool call results",
-            engineToolCallResults != null ? engineToolCallResults.size() : 0);
-        yield converse(executionContext, agentContext, engineToolCallResults);
-      }
       case DiscoverTools(var agentContext, var toolDiscoveryToolCalls) -> {
         LOGGER.debug(
             "AI Agent initialization dispatching {} gateway tool discovery calls. Completing job without further processing.",
@@ -94,6 +88,11 @@ public abstract class BaseAgentRequestHandler<
         LOGGER.debug(
             "AI Agent initialization tool discovery is still in progress. Completing job without further processing.");
         yield buildConnectorResponse(executionContext, null, null);
+      }
+      case ReadyToConverse(var agentContext, var engineToolCallResults) -> {
+        LOGGER.debug(
+            "Handling agent request with {} tool call results", engineToolCallResults.size());
+        yield converse(executionContext, agentContext, engineToolCallResults);
       }
     };
   }
@@ -157,7 +156,7 @@ public abstract class BaseAgentRequestHandler<
     LOGGER.debug("Executing chat request with AI framework");
     final var chatResponse =
         framework.executeChatRequest(
-            executionContext, conversation.context(), conversation.messageMemory());
+            executionContext, conversation.context(), conversation.runtimeMemory());
 
     conversation.updateContext(updateContextMetrics(chatResponse.agentContext(), chatResponse));
 
@@ -181,13 +180,13 @@ public abstract class BaseAgentRequestHandler<
     messagesHandler.addSystemMessage(
         executionContext,
         conversation.context(),
-        conversation.messageMemory(),
+        conversation.runtimeMemory(),
         executionContext.systemPrompt());
 
     return messagesHandler.addUserMessages(
         executionContext,
         conversation.context(),
-        conversation.messageMemory(),
+        conversation.runtimeMemory(),
         executionContext.userPrompt(),
         conversation.engineToolCallResults());
   }
@@ -227,7 +226,7 @@ public abstract class BaseAgentRequestHandler<
     LOGGER.debug(
         "Received assistant message containing {} tool call requests",
         assistantMessage.toolCalls() != null ? assistantMessage.toolCalls().size() : 0);
-    conversation.messageMemory().addMessage(assistantMessage);
+    conversation.runtimeMemory().addMessage(assistantMessage);
 
     final var toolCalls =
         gatewayToolHandlers.transformToolCalls(
@@ -239,7 +238,7 @@ public abstract class BaseAgentRequestHandler<
     final var updatedConversation =
         session.storeMessages(
             conversation.context(),
-            ConversationStoreRequest.of(conversation.messageMemory().allMessages()));
+            ConversationStoreRequest.of(conversation.runtimeMemory().allMessages()));
     conversation.updateContext(conversation.context().withConversation(updatedConversation));
 
     return responseHandler.createResponse(

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/agent/BaseAgentRequestHandler.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/agent/BaseAgentRequestHandler.java
@@ -89,10 +89,9 @@ public abstract class BaseAgentRequestHandler<
             "AI Agent initialization tool discovery is still in progress. Completing job without further processing.");
         yield buildConnectorResponse(executionContext, null, null);
       }
-      case ReadyToConverse(var agentContext, var engineToolCallResults) -> {
-        LOGGER.debug(
-            "Handling agent request with {} tool call results", engineToolCallResults.size());
-        yield converse(executionContext, agentContext, engineToolCallResults);
+      case ReadyToConverse(var agentContext, var toolCallResults) -> {
+        LOGGER.debug("Handling agent request with {} tool call results", toolCallResults.size());
+        yield converse(executionContext, agentContext, toolCallResults);
       }
     };
   }
@@ -100,15 +99,14 @@ public abstract class BaseAgentRequestHandler<
   private R converse(
       final C executionContext,
       AgentContext agentContext,
-      final List<ToolCallResult> engineToolCallResults) {
+      final List<ToolCallResult> toolCallResults) {
     final var store =
         conversationStoreRegistry.getConversationStore(executionContext, agentContext);
     final var initialMetrics = agentContext.metrics();
 
     try (var session = store.createSession(executionContext, agentContext)) {
       final var runtimeMemory = initializeRuntimeMemory(executionContext, agentContext, session);
-      var conversation =
-          AgentConversation.rehydrate(agentContext, runtimeMemory, engineToolCallResults);
+      var conversation = AgentConversation.rehydrate(agentContext, runtimeMemory, toolCallResults);
 
       var agentResponse = processConversation(executionContext, conversation, session);
 
@@ -188,7 +186,7 @@ public abstract class BaseAgentRequestHandler<
         conversation.context(),
         conversation.runtimeMemory(),
         executionContext.userPrompt(),
-        conversation.engineToolCallResults());
+        conversation.toolCallResults());
   }
 
   private AgentContext updateContextMetrics(

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/agent/BaseAgentRequestHandler.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/agent/BaseAgentRequestHandler.java
@@ -7,9 +7,9 @@
 package io.camunda.connector.agenticai.aiagent.agent;
 
 import io.camunda.client.api.command.AgentInstanceUpdateStatus;
-import io.camunda.connector.agenticai.aiagent.agent.AgentInitializationResult.AgentContextInitializationResult;
-import io.camunda.connector.agenticai.aiagent.agent.AgentInitializationResult.AgentDiscoveryInProgressInitializationResult;
-import io.camunda.connector.agenticai.aiagent.agent.AgentInitializationResult.AgentResponseInitializationResult;
+import io.camunda.connector.agenticai.aiagent.agent.AgentInitializationResult.DeferConversation;
+import io.camunda.connector.agenticai.aiagent.agent.AgentInitializationResult.DiscoverTools;
+import io.camunda.connector.agenticai.aiagent.agent.AgentInitializationResult.ReadyToConverse;
 import io.camunda.connector.agenticai.aiagent.agentinstance.AgentInstanceClient;
 import io.camunda.connector.agenticai.aiagent.agentinstance.AgentInstanceUpdateRequest;
 import io.camunda.connector.agenticai.aiagent.framework.AiFrameworkAdapter;
@@ -21,12 +21,14 @@ import io.camunda.connector.agenticai.aiagent.memory.conversation.ConversationSt
 import io.camunda.connector.agenticai.aiagent.memory.runtime.MessageWindowRuntimeMemory;
 import io.camunda.connector.agenticai.aiagent.memory.runtime.RuntimeMemory;
 import io.camunda.connector.agenticai.aiagent.model.AgentContext;
+import io.camunda.connector.agenticai.aiagent.model.AgentConversation;
 import io.camunda.connector.agenticai.aiagent.model.AgentExecutionContext;
 import io.camunda.connector.agenticai.aiagent.model.AgentMetrics;
 import io.camunda.connector.agenticai.aiagent.model.AgentResponse;
 import io.camunda.connector.agenticai.aiagent.model.request.MemoryConfiguration;
 import io.camunda.connector.agenticai.aiagent.tool.GatewayToolHandlerRegistry;
 import io.camunda.connector.agenticai.model.message.Message;
+import io.camunda.connector.agenticai.model.tool.ToolCall;
 import io.camunda.connector.agenticai.model.tool.ToolCallProcessVariable;
 import io.camunda.connector.agenticai.model.tool.ToolCallResult;
 import io.camunda.connector.api.outbound.ConnectorResponse;
@@ -75,48 +77,41 @@ public abstract class BaseAgentRequestHandler<
 
   @Override
   public R handleRequest(final C executionContext) {
-    final var agentInitializationResult = agentInitializer.initializeAgent(executionContext);
-    return switch (agentInitializationResult) {
-      // directly return agent response if needed (e.g. tool discovery tool calls before calling the
-      // LLM)
-      case AgentResponseInitializationResult(
-              AgentResponse agentResponse,
-              AgentJobCompletionListener initCompletionListener) -> {
+    return switch (agentInitializer.initializeAgent(executionContext)) {
+      case ReadyToConverse(var agentContext, var engineToolCallResults) -> {
         LOGGER.debug(
-            "AI Agent initialization returned direct response including {} tool calls. Completing job without further processing.",
-            agentResponse.toolCalls().size());
-        yield buildConnectorResponse(executionContext, agentResponse, initCompletionListener);
+            "Handling agent request with {} tool call results",
+            engineToolCallResults != null ? engineToolCallResults.size() : 0);
+        yield converse(executionContext, agentContext, engineToolCallResults);
       }
-
-      // discovery still in progress (not all tool call results present)
-      case AgentDiscoveryInProgressInitializationResult ignored -> {
+      case DiscoverTools(var agentContext, var toolDiscoveryToolCalls) -> {
+        LOGGER.debug(
+            "AI Agent initialization dispatching {} gateway tool discovery calls. Completing job without further processing.",
+            toolDiscoveryToolCalls.size());
+        yield dispatchToolDiscovery(executionContext, agentContext, toolDiscoveryToolCalls);
+      }
+      case DeferConversation() -> {
         LOGGER.debug(
             "AI Agent initialization tool discovery is still in progress. Completing job without further processing.");
         yield buildConnectorResponse(executionContext, null, null);
       }
-
-      case AgentContextInitializationResult(
-              AgentContext agentContext,
-              List<ToolCallResult> toolCallResults) -> {
-        LOGGER.debug(
-            "Handling agent request with {} tool call results",
-            toolCallResults != null ? toolCallResults.size() : 0);
-        yield handleRequest(executionContext, agentContext, toolCallResults);
-      }
     };
   }
 
-  private R handleRequest(
+  private R converse(
       final C executionContext,
       AgentContext agentContext,
-      final List<ToolCallResult> toolCallResults) {
+      final List<ToolCallResult> engineToolCallResults) {
     final var store =
         conversationStoreRegistry.getConversationStore(executionContext, agentContext);
     final var initialMetrics = agentContext.metrics();
 
     try (var session = store.createSession(executionContext, agentContext)) {
-      var agentResponse =
-          processConversation(executionContext, agentContext, toolCallResults, session);
+      final var runtimeMemory = initializeRuntimeMemory(executionContext, agentContext, session);
+      var conversation =
+          AgentConversation.rehydrate(agentContext, runtimeMemory, engineToolCallResults);
+
+      var agentResponse = processConversation(executionContext, conversation, session);
 
       LOGGER.debug(
           "Request processing completed {} agent response, completing job",
@@ -145,32 +140,28 @@ public abstract class BaseAgentRequestHandler<
   }
 
   private AgentResponse processConversation(
-      final C executionContext,
-      AgentContext agentContext,
-      final List<ToolCallResult> toolCallResults,
-      final ConversationSession session) {
-    final var runtimeMemory = initializeRuntimeMemory(executionContext, agentContext, session);
-
+      final C executionContext, AgentConversation conversation, final ConversationSession session) {
     LOGGER.trace("Validating configured limits for agent execution");
-    limitsValidator.validateConfiguredLimits(executionContext, agentContext);
+    limitsValidator.validateConfiguredLimits(executionContext, conversation.context());
 
-    final var addedUserMessages =
-        prepareMessages(executionContext, agentContext, runtimeMemory, toolCallResults);
+    final var addedUserMessages = prepareMessages(executionContext, conversation);
 
-    if (!modelCallPrerequisitesFulfilled(executionContext, agentContext, addedUserMessages)) {
+    if (!modelCallPrerequisitesFulfilled(
+        executionContext, conversation.context(), addedUserMessages)) {
       LOGGER.debug("Model call prerequisites not fulfilled, returning without agent response");
       return null;
     }
-    handleAddedUserMessages(executionContext, agentContext, addedUserMessages);
+    handleAddedUserMessages(executionContext, conversation.context(), addedUserMessages);
 
-    notifyThinking(executionContext, agentContext);
+    notifyThinking(executionContext, conversation);
     LOGGER.debug("Executing chat request with AI framework");
     final var chatResponse =
-        framework.executeChatRequest(executionContext, agentContext, runtimeMemory);
+        framework.executeChatRequest(
+            executionContext, conversation.context(), conversation.messageMemory());
 
-    agentContext = updateContextMetrics(chatResponse.agentContext(), chatResponse);
+    conversation.updateContext(updateContextMetrics(chatResponse.agentContext(), chatResponse));
 
-    return buildResponse(executionContext, agentContext, chatResponse, session, runtimeMemory);
+    return buildResponse(executionContext, conversation, chatResponse, session);
   }
 
   private RuntimeMemory initializeRuntimeMemory(
@@ -185,21 +176,20 @@ public abstract class BaseAgentRequestHandler<
     return runtimeMemory;
   }
 
-  private List<Message> prepareMessages(
-      C executionContext,
-      AgentContext agentContext,
-      RuntimeMemory runtimeMemory,
-      List<ToolCallResult> toolCallResults) {
+  private List<Message> prepareMessages(C executionContext, AgentConversation conversation) {
     LOGGER.trace("Adding system message (if necessary)");
     messagesHandler.addSystemMessage(
-        executionContext, agentContext, runtimeMemory, executionContext.systemPrompt());
+        executionContext,
+        conversation.context(),
+        conversation.messageMemory(),
+        executionContext.systemPrompt());
 
     return messagesHandler.addUserMessages(
         executionContext,
-        agentContext,
-        runtimeMemory,
+        conversation.context(),
+        conversation.messageMemory(),
         executionContext.userPrompt(),
-        toolCallResults);
+        conversation.engineToolCallResults());
   }
 
   private AgentContext updateContextMetrics(
@@ -214,11 +204,11 @@ public abstract class BaseAgentRequestHandler<
     return agentContext.withMetrics(agentContext.metrics().incrementToolCalls(toolCallsDelta));
   }
 
-  private void notifyThinking(C executionContext, AgentContext agentContext) {
+  private void notifyThinking(C executionContext, AgentConversation conversation) {
     LOGGER.debug("Notifying agent instance: status=THINKING before LLM call");
     agentInstanceClient.update(
         executionContext,
-        agentContext,
+        conversation.context(),
         AgentInstanceUpdateRequest.statusOnly(AgentInstanceUpdateStatus.THINKING));
   }
 
@@ -230,29 +220,66 @@ public abstract class BaseAgentRequestHandler<
 
   private AgentResponse buildResponse(
       C executionContext,
-      AgentContext agentContext,
+      AgentConversation conversation,
       AiFrameworkChatResponse<?> chatResponse,
-      ConversationSession session,
-      RuntimeMemory runtimeMemory) {
+      ConversationSession session) {
     final var assistantMessage = chatResponse.assistantMessage();
     LOGGER.debug(
         "Received assistant message containing {} tool call requests",
         assistantMessage.toolCalls() != null ? assistantMessage.toolCalls().size() : 0);
-    runtimeMemory.addMessage(assistantMessage);
+    conversation.messageMemory().addMessage(assistantMessage);
 
     final var toolCalls =
-        gatewayToolHandlers.transformToolCalls(agentContext, assistantMessage.toolCalls());
+        gatewayToolHandlers.transformToolCalls(
+            conversation.context(), assistantMessage.toolCalls());
     final var processVariableToolCalls =
         toolCalls.stream().map(ToolCallProcessVariable::from).toList();
 
     LOGGER.debug("Storing runtime memory to conversation session");
     final var updatedConversation =
         session.storeMessages(
-            agentContext, ConversationStoreRequest.of(runtimeMemory.allMessages()));
-    agentContext = agentContext.withConversation(updatedConversation);
+            conversation.context(),
+            ConversationStoreRequest.of(conversation.messageMemory().allMessages()));
+    conversation.updateContext(conversation.context().withConversation(updatedConversation));
 
     return responseHandler.createResponse(
-        executionContext, agentContext, assistantMessage, processVariableToolCalls);
+        executionContext, conversation.context(), assistantMessage, processVariableToolCalls);
+  }
+
+  private R dispatchToolDiscovery(
+      C executionContext, AgentContext agentContext, List<ToolCall> discoveryToolCalls) {
+    var response =
+        AgentResponse.builder()
+            .context(agentContext)
+            .toolCalls(discoveryToolCalls.stream().map(ToolCallProcessVariable::from).toList())
+            .build();
+    var listener = createToolDiscoveryCompletionListener(executionContext, agentContext);
+    return buildConnectorResponse(executionContext, response, listener);
+  }
+
+  private AgentJobCompletionListener createToolDiscoveryCompletionListener(
+      C executionContext, AgentContext agentContext) {
+    return new AgentJobCompletionListener() {
+      @Override
+      public void onJobCompleted() {
+        try {
+          agentInstanceClient.update(
+              executionContext,
+              agentContext,
+              AgentInstanceUpdateRequest.statusOnly(AgentInstanceUpdateStatus.TOOL_DISCOVERY));
+        } catch (Exception e) {
+          LOGGER.error(
+              "Failed to update agent instance status to TOOL_DISCOVERY after job completion", e);
+        }
+      }
+
+      @Override
+      public void onJobCompletionFailed(JobCompletionFailure failure) {
+        LOGGER.debug(
+            "Job completion failed ({}), skipping TOOL_DISCOVERY status update",
+            failure.getClass().getSimpleName());
+      }
+    };
   }
 
   protected abstract boolean modelCallPrerequisitesFulfilled(

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/AgentConversation.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/AgentConversation.java
@@ -14,7 +14,7 @@ import java.util.List;
 /**
  * Transient domain aggregate representing the agent's conversation state for one turn.
  *
- * <p>{@code context} and {@code messageMemory} are <em>restored</em> from persisted state at the
+ * <p>{@code context} and {@code runtimeMemory} are <em>restored</em> from persisted state at the
  * start of each turn. {@code engineToolCallResults} is <em>this turn's new engine input</em>,
  * primed to be folded into the conversation by the message handler.
  */
@@ -37,7 +37,7 @@ public final class AgentConversation {
    * Builds the aggregate from persisted state and this turn's engine input.
    *
    * @param context the durable agent context restored from the process variable
-   * @param messageMemory transient messages restored from the conversation store
+   * @param messageMemory runtime memory restored from the conversation store
    * @param engineToolCallResults this turn's new tool-call results from the engine, to be folded in
    * @return a rehydrated {@code AgentConversation}
    */
@@ -64,7 +64,7 @@ public final class AgentConversation {
     return context.toolDefinitions();
   }
 
-  public RuntimeMemory messageMemory() {
+  public RuntimeMemory runtimeMemory() {
     return messageMemory;
   }
 

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/AgentConversation.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/AgentConversation.java
@@ -21,13 +21,13 @@ import java.util.List;
 public final class AgentConversation {
 
   private AgentContext context;
-  private final RuntimeMemory messageMemory;
+  private final RuntimeMemory runtimeMemory;
   private final List<ToolCallResult> toolCallResults;
 
   private AgentConversation(
-      AgentContext context, RuntimeMemory messageMemory, List<ToolCallResult> toolCallResults) {
+      AgentContext context, RuntimeMemory runtimeMemory, List<ToolCallResult> toolCallResults) {
     this.context = context;
-    this.messageMemory = messageMemory;
+    this.runtimeMemory = runtimeMemory;
     this.toolCallResults = toolCallResults;
   }
 
@@ -61,7 +61,7 @@ public final class AgentConversation {
   }
 
   public RuntimeMemory runtimeMemory() {
-    return messageMemory;
+    return runtimeMemory;
   }
 
   public List<ToolCallResult> toolCallResults() {

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/AgentConversation.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/AgentConversation.java
@@ -15,22 +15,20 @@ import java.util.List;
  * Transient domain aggregate representing the agent's conversation state for one turn.
  *
  * <p>{@code context} and {@code runtimeMemory} are <em>restored</em> from persisted state at the
- * start of each turn. {@code engineToolCallResults} is <em>this turn's new engine input</em>,
- * primed to be folded into the conversation by the message handler.
+ * start of each turn. {@code toolCallResults} is <em>this turn's new engine input</em>, primed to
+ * be folded into the conversation by the message handler.
  */
 public final class AgentConversation {
 
   private AgentContext context;
   private final RuntimeMemory messageMemory;
-  private final List<ToolCallResult> engineToolCallResults;
+  private final List<ToolCallResult> toolCallResults;
 
   private AgentConversation(
-      AgentContext context,
-      RuntimeMemory messageMemory,
-      List<ToolCallResult> engineToolCallResults) {
+      AgentContext context, RuntimeMemory messageMemory, List<ToolCallResult> toolCallResults) {
     this.context = context;
     this.messageMemory = messageMemory;
-    this.engineToolCallResults = engineToolCallResults;
+    this.toolCallResults = toolCallResults;
   }
 
   /**
@@ -38,14 +36,12 @@ public final class AgentConversation {
    *
    * @param context the durable agent context restored from the process variable
    * @param messageMemory runtime memory restored from the conversation store
-   * @param engineToolCallResults this turn's new tool-call results from the engine, to be folded in
+   * @param toolCallResults this turn's new tool-call results from the engine, to be folded in
    * @return a rehydrated {@code AgentConversation}
    */
   public static AgentConversation rehydrate(
-      AgentContext context,
-      RuntimeMemory messageMemory,
-      List<ToolCallResult> engineToolCallResults) {
-    return new AgentConversation(context, messageMemory, engineToolCallResults);
+      AgentContext context, RuntimeMemory messageMemory, List<ToolCallResult> toolCallResults) {
+    return new AgentConversation(context, messageMemory, toolCallResults);
   }
 
   public AgentContext context() {
@@ -68,7 +64,7 @@ public final class AgentConversation {
     return messageMemory;
   }
 
-  public List<ToolCallResult> engineToolCallResults() {
-    return engineToolCallResults;
+  public List<ToolCallResult> toolCallResults() {
+    return toolCallResults;
   }
 }

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/AgentConversation.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/AgentConversation.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.agenticai.aiagent.model;
+
+import io.camunda.connector.agenticai.aiagent.memory.runtime.RuntimeMemory;
+import io.camunda.connector.agenticai.model.tool.ToolCallResult;
+import io.camunda.connector.agenticai.model.tool.ToolDefinition;
+import java.util.List;
+
+/**
+ * Transient domain aggregate representing the agent's conversation state for one turn.
+ *
+ * <p>{@code context} and {@code messageMemory} are <em>restored</em> from persisted state at the
+ * start of each turn. {@code engineToolCallResults} is <em>this turn's new engine input</em>,
+ * primed to be folded into the conversation by the message handler.
+ */
+public final class AgentConversation {
+
+  private AgentContext context;
+  private final RuntimeMemory messageMemory;
+  private final List<ToolCallResult> engineToolCallResults;
+
+  private AgentConversation(
+      AgentContext context,
+      RuntimeMemory messageMemory,
+      List<ToolCallResult> engineToolCallResults) {
+    this.context = context;
+    this.messageMemory = messageMemory;
+    this.engineToolCallResults = engineToolCallResults;
+  }
+
+  /**
+   * Builds the aggregate from persisted state and this turn's engine input.
+   *
+   * @param context the durable agent context restored from the process variable
+   * @param messageMemory transient messages restored from the conversation store
+   * @param engineToolCallResults this turn's new tool-call results from the engine, to be folded in
+   * @return a rehydrated {@code AgentConversation}
+   */
+  public static AgentConversation rehydrate(
+      AgentContext context,
+      RuntimeMemory messageMemory,
+      List<ToolCallResult> engineToolCallResults) {
+    return new AgentConversation(context, messageMemory, engineToolCallResults);
+  }
+
+  public AgentContext context() {
+    return context;
+  }
+
+  public void updateContext(AgentContext newContext) {
+    this.context = newContext;
+  }
+
+  public AgentState state() {
+    return context.state();
+  }
+
+  public List<ToolDefinition> toolDefinitions() {
+    return context.toolDefinitions();
+  }
+
+  public RuntimeMemory messageMemory() {
+    return messageMemory;
+  }
+
+  public List<ToolCallResult> engineToolCallResults() {
+    return engineToolCallResults;
+  }
+}

--- a/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/agent/AgentInitializerTest.java
+++ b/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/agent/AgentInitializerTest.java
@@ -112,7 +112,7 @@ class AgentInitializerTest {
               ReadyToConverse.class,
               res -> {
                 assertThat(res.agentContext()).usingRecursiveComparison().isEqualTo(agentContext);
-                assertThat(res.engineToolCallResults()).isEqualTo(TOOL_CALL_RESULTS);
+                assertThat(res.toolCallResults()).isEqualTo(TOOL_CALL_RESULTS);
               });
 
       verifyNoInteractions(toolsResolver, gatewayToolHandlers);
@@ -142,7 +142,7 @@ class AgentInitializerTest {
                         AgentContext.empty()
                             .withState(AgentState.READY)
                             .withMetadata(expectedMetadata));
-                assertThat(res.engineToolCallResults()).isEmpty();
+                assertThat(res.toolCallResults()).isEmpty();
               });
 
       verifyNoInteractions(gatewayToolHandlers);
@@ -161,7 +161,7 @@ class AgentInitializerTest {
               ReadyToConverse.class,
               res -> {
                 assertThat(res.agentContext()).isEqualTo(agentContext);
-                assertThat(res.engineToolCallResults()).isEmpty();
+                assertThat(res.toolCallResults()).isEmpty();
               });
 
       verifyNoInteractions(toolsResolver, gatewayToolHandlers);
@@ -196,7 +196,7 @@ class AgentInitializerTest {
                 assertThat(res.agentContext())
                     .usingRecursiveComparison()
                     .isEqualTo(AGENT_CONTEXT.withState(AgentState.READY));
-                assertThat(res.engineToolCallResults()).isEmpty();
+                assertThat(res.toolCallResults()).isEmpty();
               });
 
       verifyNoInteractions(gatewayToolHandlers);
@@ -222,7 +222,7 @@ class AgentInitializerTest {
                         AGENT_CONTEXT
                             .withState(AgentState.READY)
                             .withToolDefinitions(TOOL_DEFINITIONS));
-                assertThat(res.engineToolCallResults()).isEmpty();
+                assertThat(res.toolCallResults()).isEmpty();
               });
 
       verifyNoInteractions(gatewayToolHandlers);
@@ -258,7 +258,7 @@ class AgentInitializerTest {
                             .withState(AgentState.READY)
                             .withToolDefinitions(TOOL_DEFINITIONS)
                             .withProperty("mcpClients", List.of("AnMcpClient")));
-                assertThat(res.engineToolCallResults()).isEmpty();
+                assertThat(res.toolCallResults()).isEmpty();
               });
     }
 
@@ -373,7 +373,7 @@ class AgentInitializerTest {
                             .withProperty("discovered", true));
 
                 // filtered out by the gateway tool handler
-                assertThat(res.engineToolCallResults()).isEmpty();
+                assertThat(res.toolCallResults()).isEmpty();
               });
     }
 
@@ -416,8 +416,7 @@ class AgentInitializerTest {
                             .withProperty("mcpClients", List.of("AnMcpClient"))
                             .withProperty("discovered", true));
 
-                assertThat(res.engineToolCallResults())
-                    .containsExactlyElementsOf(TOOL_CALL_RESULTS);
+                assertThat(res.toolCallResults()).containsExactlyElementsOf(TOOL_CALL_RESULTS);
               });
     }
 
@@ -542,7 +541,7 @@ class AgentInitializerTest {
               ReadyToConverse.class,
               res -> {
                 assertThat(res.agentContext()).isEqualTo(agentContext);
-                assertThat(res.engineToolCallResults()).isEqualTo(TOOL_CALL_RESULTS);
+                assertThat(res.toolCallResults()).isEqualTo(TOOL_CALL_RESULTS);
               });
 
       verifyNoInteractions(toolsResolver, gatewayToolHandlers);

--- a/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/agent/AgentInitializerTest.java
+++ b/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/agent/AgentInitializerTest.java
@@ -20,14 +20,12 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
-import io.camunda.client.api.command.AgentInstanceUpdateStatus;
 import io.camunda.connector.agenticai.adhoctoolsschema.model.AdHocToolsSchemaResponse;
-import io.camunda.connector.agenticai.aiagent.agent.AgentInitializationResult.AgentContextInitializationResult;
-import io.camunda.connector.agenticai.aiagent.agent.AgentInitializationResult.AgentDiscoveryInProgressInitializationResult;
-import io.camunda.connector.agenticai.aiagent.agent.AgentInitializationResult.AgentResponseInitializationResult;
+import io.camunda.connector.agenticai.aiagent.agent.AgentInitializationResult.DeferConversation;
+import io.camunda.connector.agenticai.aiagent.agent.AgentInitializationResult.DiscoverTools;
+import io.camunda.connector.agenticai.aiagent.agent.AgentInitializationResult.ReadyToConverse;
 import io.camunda.connector.agenticai.aiagent.agentinstance.AgentInstanceClient;
 import io.camunda.connector.agenticai.aiagent.agentinstance.AgentInstanceKey;
-import io.camunda.connector.agenticai.aiagent.agentinstance.AgentInstanceUpdateRequest;
 import io.camunda.connector.agenticai.aiagent.model.AgentContext;
 import io.camunda.connector.agenticai.aiagent.model.AgentExecutionContext;
 import io.camunda.connector.agenticai.aiagent.model.AgentMetadata;
@@ -37,11 +35,9 @@ import io.camunda.connector.agenticai.aiagent.tool.GatewayToolDiscoveryResult;
 import io.camunda.connector.agenticai.aiagent.tool.GatewayToolHandlerRegistry;
 import io.camunda.connector.agenticai.model.tool.GatewayToolDefinition;
 import io.camunda.connector.agenticai.model.tool.ToolCall;
-import io.camunda.connector.agenticai.model.tool.ToolCallProcessVariable;
 import io.camunda.connector.agenticai.model.tool.ToolCallResult;
 import io.camunda.connector.agenticai.model.tool.ToolDefinition;
 import io.camunda.connector.api.error.ConnectorException;
-import io.camunda.connector.api.outbound.JobCompletionFailure;
 import io.camunda.connector.api.outbound.JobContext;
 import java.util.ArrayList;
 import java.util.List;
@@ -113,10 +109,10 @@ class AgentInitializerTest {
 
       assertThat(result)
           .isInstanceOfSatisfying(
-              AgentContextInitializationResult.class,
+              ReadyToConverse.class,
               res -> {
                 assertThat(res.agentContext()).usingRecursiveComparison().isEqualTo(agentContext);
-                assertThat(res.toolCallResults()).isEqualTo(TOOL_CALL_RESULTS);
+                assertThat(res.engineToolCallResults()).isEqualTo(TOOL_CALL_RESULTS);
               });
 
       verifyNoInteractions(toolsResolver, gatewayToolHandlers);
@@ -138,7 +134,7 @@ class AgentInitializerTest {
           new AgentMetadata(PROCESS_DEFINITION_KEY, PROCESS_INSTANCE_KEY, 12345L);
       assertThat(result)
           .isInstanceOfSatisfying(
-              AgentContextInitializationResult.class,
+              ReadyToConverse.class,
               res -> {
                 assertThat(res.agentContext())
                     .usingRecursiveComparison()
@@ -146,7 +142,7 @@ class AgentInitializerTest {
                         AgentContext.empty()
                             .withState(AgentState.READY)
                             .withMetadata(expectedMetadata));
-                assertThat(res.toolCallResults()).isEmpty();
+                assertThat(res.engineToolCallResults()).isEmpty();
               });
 
       verifyNoInteractions(gatewayToolHandlers);
@@ -162,10 +158,10 @@ class AgentInitializerTest {
 
       assertThat(result)
           .isInstanceOfSatisfying(
-              AgentContextInitializationResult.class,
+              ReadyToConverse.class,
               res -> {
                 assertThat(res.agentContext()).isEqualTo(agentContext);
-                assertThat(res.toolCallResults()).isEmpty();
+                assertThat(res.engineToolCallResults()).isEmpty();
               });
 
       verifyNoInteractions(toolsResolver, gatewayToolHandlers);
@@ -195,12 +191,12 @@ class AgentInitializerTest {
 
       assertThat(result)
           .isInstanceOfSatisfying(
-              AgentContextInitializationResult.class,
+              ReadyToConverse.class,
               res -> {
                 assertThat(res.agentContext())
                     .usingRecursiveComparison()
                     .isEqualTo(AGENT_CONTEXT.withState(AgentState.READY));
-                assertThat(res.toolCallResults()).isEmpty();
+                assertThat(res.engineToolCallResults()).isEmpty();
               });
 
       verifyNoInteractions(gatewayToolHandlers);
@@ -218,7 +214,7 @@ class AgentInitializerTest {
 
       assertThat(result)
           .isInstanceOfSatisfying(
-              AgentContextInitializationResult.class,
+              ReadyToConverse.class,
               res -> {
                 assertThat(res.agentContext())
                     .usingRecursiveComparison()
@@ -226,7 +222,7 @@ class AgentInitializerTest {
                         AGENT_CONTEXT
                             .withState(AgentState.READY)
                             .withToolDefinitions(TOOL_DEFINITIONS));
-                assertThat(res.toolCallResults()).isEmpty();
+                assertThat(res.engineToolCallResults()).isEmpty();
               });
 
       verifyNoInteractions(gatewayToolHandlers);
@@ -253,7 +249,7 @@ class AgentInitializerTest {
 
       assertThat(result)
           .isInstanceOfSatisfying(
-              AgentContextInitializationResult.class,
+              ReadyToConverse.class,
               res -> {
                 assertThat(res.agentContext())
                     .usingRecursiveComparison()
@@ -262,12 +258,12 @@ class AgentInitializerTest {
                             .withState(AgentState.READY)
                             .withToolDefinitions(TOOL_DEFINITIONS)
                             .withProperty("mcpClients", List.of("AnMcpClient")));
-                assertThat(res.toolCallResults()).isEmpty();
+                assertThat(res.engineToolCallResults()).isEmpty();
               });
     }
 
     @Test
-    void shouldReturnAgentResponseWithDiscoveryToolCallsWhenToolDiscoveryCallsAreReturned() {
+    void shouldReturnDiscoverToolsWithDiscoveryToolCallsWhenToolDiscoveryCallsAreReturned() {
       final var toolDiscoveryToolCalls =
           List.of(
               ToolCall.builder()
@@ -293,107 +289,18 @@ class AgentInitializerTest {
 
       assertThat(result)
           .isInstanceOfSatisfying(
-              AgentResponseInitializationResult.class,
+              DiscoverTools.class,
               res -> {
-                assertThat(res.agentResponse()).isNotNull();
-                assertThat(res.agentResponse().context())
+                assertThat(res.agentContext())
                     .usingRecursiveComparison()
                     .isEqualTo(
                         AGENT_CONTEXT
                             .withState(AgentState.TOOL_DISCOVERY)
                             .withToolDefinitions(TOOL_DEFINITIONS)
                             .withProperty("mcpClients", List.of("AnMcpClient")));
-                assertThat(res.agentResponse().toolCalls())
-                    .containsExactlyElementsOf(
-                        toolDiscoveryToolCalls.stream()
-                            .map(ToolCallProcessVariable::from)
-                            .toList());
+                assertThat(res.toolDiscoveryToolCalls())
+                    .containsExactlyElementsOf(toolDiscoveryToolCalls);
               });
-    }
-
-    @Test
-    void shouldDeferToolDiscoveryPatchToJobCompletionWhenGatewayDiscoveryCallsAreDispatched() {
-      // given
-      final var toolDiscoveryToolCalls =
-          List.of(ToolCall.builder().id("tool1").name("AnMcpClient").build());
-
-      when(toolsResolver.loadAdHocToolsSchema(
-              any(AgentExecutionContext.class), any(AgentContext.class)))
-          .thenReturn(new AdHocToolsSchemaResponse(TOOL_DEFINITIONS, GATEWAY_TOOL_DEFINITIONS));
-      when(gatewayToolHandlers.initiateToolDiscovery(
-              any(AgentContext.class), eq(GATEWAY_TOOL_DEFINITIONS)))
-          .thenAnswer(
-              args ->
-                  new GatewayToolDiscoveryInitiationResult(
-                      args.getArgument(0, AgentContext.class), toolDiscoveryToolCalls));
-
-      // when
-      final var result =
-          (AgentResponseInitializationResult) agentInitializer.initializeAgent(executionContext);
-
-      // then: no eager update during initialization
-      verify(agentInstanceClient, never()).update(any(), any(), any());
-      assertThat(result.completionListener()).isNotNull();
-
-      // when: job completes
-      result.completionListener().onJobCompleted();
-
-      // then: TOOL_DISCOVERY status reported on completion
-      verify(agentInstanceClient)
-          .update(
-              eq(executionContext),
-              any(AgentContext.class),
-              eq(AgentInstanceUpdateRequest.statusOnly(AgentInstanceUpdateStatus.TOOL_DISCOVERY)));
-    }
-
-    @Test
-    void shouldSkipToolDiscoveryPatchWhenJobCompletionFails() {
-      // given
-      final var toolDiscoveryToolCalls =
-          List.of(ToolCall.builder().id("tool1").name("AnMcpClient").build());
-
-      when(toolsResolver.loadAdHocToolsSchema(
-              any(AgentExecutionContext.class), any(AgentContext.class)))
-          .thenReturn(new AdHocToolsSchemaResponse(TOOL_DEFINITIONS, GATEWAY_TOOL_DEFINITIONS));
-      when(gatewayToolHandlers.initiateToolDiscovery(
-              any(AgentContext.class), eq(GATEWAY_TOOL_DEFINITIONS)))
-          .thenAnswer(
-              args ->
-                  new GatewayToolDiscoveryInitiationResult(
-                      args.getArgument(0, AgentContext.class), toolDiscoveryToolCalls));
-
-      // when
-      final var result =
-          (AgentResponseInitializationResult) agentInitializer.initializeAgent(executionContext);
-      result
-          .completionListener()
-          .onJobCompletionFailed(
-              new JobCompletionFailure.CommandFailure.CommandIgnored(new RuntimeException()));
-
-      // then: no update on failure
-      verify(agentInstanceClient, never()).update(any(), any(), any());
-    }
-
-    @ParameterizedTest
-    @NullAndEmptySource
-    void shouldNotCreateCompletionListenerWhenNoDiscoveryCallsAreDispatched(
-        List<ToolCall> toolDiscoveryToolCalls) {
-      // given
-      when(toolsResolver.loadAdHocToolsSchema(
-              any(AgentExecutionContext.class), any(AgentContext.class)))
-          .thenReturn(new AdHocToolsSchemaResponse(TOOL_DEFINITIONS, GATEWAY_TOOL_DEFINITIONS));
-      when(gatewayToolHandlers.initiateToolDiscovery(
-              any(AgentContext.class), eq(GATEWAY_TOOL_DEFINITIONS)))
-          .thenAnswer(
-              args ->
-                  new GatewayToolDiscoveryInitiationResult(
-                      args.getArgument(0, AgentContext.class), toolDiscoveryToolCalls));
-
-      // when
-      agentInitializer.initializeAgent(executionContext);
-
-      // then
-      verify(agentInstanceClient, never()).update(any(), any(), any());
     }
   }
 
@@ -454,7 +361,7 @@ class AgentInitializerTest {
 
       assertThat(result)
           .isInstanceOfSatisfying(
-              AgentContextInitializationResult.class,
+              ReadyToConverse.class,
               res -> {
                 assertThat(res.agentContext())
                     .usingRecursiveComparison()
@@ -466,7 +373,7 @@ class AgentInitializerTest {
                             .withProperty("discovered", true));
 
                 // filtered out by the gateway tool handler
-                assertThat(res.toolCallResults()).isEmpty();
+                assertThat(res.engineToolCallResults()).isEmpty();
               });
     }
 
@@ -498,7 +405,7 @@ class AgentInitializerTest {
 
       assertThat(result)
           .isInstanceOfSatisfying(
-              AgentContextInitializationResult.class,
+              ReadyToConverse.class,
               res -> {
                 assertThat(res.agentContext())
                     .usingRecursiveComparison()
@@ -509,7 +416,8 @@ class AgentInitializerTest {
                             .withProperty("mcpClients", List.of("AnMcpClient"))
                             .withProperty("discovered", true));
 
-                assertThat(res.toolCallResults()).containsExactlyElementsOf(TOOL_CALL_RESULTS);
+                assertThat(res.engineToolCallResults())
+                    .containsExactlyElementsOf(TOOL_CALL_RESULTS);
               });
     }
 
@@ -524,7 +432,7 @@ class AgentInitializerTest {
 
       final var result = agentInitializer.initializeAgent(executionContext);
 
-      assertThat(result).isInstanceOf(AgentDiscoveryInProgressInitializationResult.class);
+      assertThat(result).isInstanceOf(DeferConversation.class);
     }
 
     @Test
@@ -545,7 +453,7 @@ class AgentInitializerTest {
 
       final var result = agentInitializer.initializeAgent(executionContext);
 
-      assertThat(result).isInstanceOf(AgentDiscoveryInProgressInitializationResult.class);
+      assertThat(result).isInstanceOf(DeferConversation.class);
     }
   }
 
@@ -575,7 +483,7 @@ class AgentInitializerTest {
           new AgentMetadata(MIGRATED_PROCESS_DEFINITION_KEY, PROCESS_INSTANCE_KEY, null);
       assertThat(result)
           .isInstanceOfSatisfying(
-              AgentContextInitializationResult.class,
+              ReadyToConverse.class,
               res -> {
                 assertThat(res.agentContext().metadata()).isEqualTo(expectedMetadata);
                 assertThat(res.agentContext().properties()).containsEntry("updated", true);
@@ -606,7 +514,7 @@ class AgentInitializerTest {
           new AgentMetadata(MIGRATED_PROCESS_DEFINITION_KEY, PROCESS_INSTANCE_KEY, null);
       assertThat(result)
           .isInstanceOfSatisfying(
-              AgentContextInitializationResult.class,
+              ReadyToConverse.class,
               res -> {
                 assertThat(res.agentContext().metadata()).isEqualTo(expectedMetadata);
                 assertThat(res.agentContext().properties()).containsEntry("migrated", true);
@@ -631,10 +539,10 @@ class AgentInitializerTest {
 
       assertThat(result)
           .isInstanceOfSatisfying(
-              AgentContextInitializationResult.class,
+              ReadyToConverse.class,
               res -> {
                 assertThat(res.agentContext()).isEqualTo(agentContext);
-                assertThat(res.toolCallResults()).isEqualTo(TOOL_CALL_RESULTS);
+                assertThat(res.engineToolCallResults()).isEqualTo(TOOL_CALL_RESULTS);
               });
 
       verifyNoInteractions(toolsResolver, gatewayToolHandlers);
@@ -663,8 +571,7 @@ class AgentInitializerTest {
               any(AgentExecutionContext.class), any(AgentContext.class)))
           .thenReturn(new AdHocToolsSchemaResponse(List.of(), null));
 
-      final var result =
-          (AgentContextInitializationResult) agentInitializer.initializeAgent(executionContext);
+      final var result = (ReadyToConverse) agentInitializer.initializeAgent(executionContext);
 
       verify(agentInstanceClient, times(1)).create(any(AgentExecutionContext.class));
       assertThat(result.agentContext().metadata().agentInstanceKey()).isEqualTo(12345L);

--- a/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/agent/JobWorkerAgentRequestHandlerTest.java
+++ b/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/agent/JobWorkerAgentRequestHandlerTest.java
@@ -31,8 +31,9 @@ import static org.mockito.Mockito.when;
 
 import io.camunda.client.api.command.AgentInstanceUpdateStatus;
 import io.camunda.connector.agenticai.aiagent.AiAgentJobWorker;
-import io.camunda.connector.agenticai.aiagent.agent.AgentInitializationResult.AgentContextInitializationResult;
-import io.camunda.connector.agenticai.aiagent.agent.AgentInitializationResult.AgentResponseInitializationResult;
+import io.camunda.connector.agenticai.aiagent.agent.AgentInitializationResult.DeferConversation;
+import io.camunda.connector.agenticai.aiagent.agent.AgentInitializationResult.DiscoverTools;
+import io.camunda.connector.agenticai.aiagent.agent.AgentInitializationResult.ReadyToConverse;
 import io.camunda.connector.agenticai.aiagent.agentinstance.AgentInstanceClient;
 import io.camunda.connector.agenticai.aiagent.agentinstance.AgentInstanceUpdateRequest;
 import io.camunda.connector.agenticai.aiagent.framework.AiFrameworkAdapter;
@@ -122,26 +123,89 @@ class JobWorkerAgentRequestHandlerTest {
   }
 
   @Test
-  void directlyReturnsAgentResponseWhenInitializationReturnsResponse() {
+  void dispatchesToolDiscoveryWhenInitializationReturnsDiscoverTools() {
     reset(conversationStoreRegistry);
 
-    final var agentResponse =
-        AgentResponse.builder()
-            .context(AgentContext.builder().state(AgentState.TOOL_DISCOVERY).build())
-            .toolCalls(
-                List.of(
-                    ToolCallProcessVariable.from(
-                        ToolCall.builder().id("tool_discovery").name("AGatewayTool").build())))
-            .build();
+    final var toolDiscoveryToolCalls =
+        List.of(ToolCall.builder().id("tool_discovery").name("AGatewayTool").build());
+    final var discoveryAgentContext =
+        AgentContext.builder().state(AgentState.TOOL_DISCOVERY).build();
 
     when(agentInitializer.initializeAgent(agentExecutionContext))
-        .thenReturn(new AgentResponseInitializationResult(agentResponse));
+        .thenReturn(new DiscoverTools(discoveryAgentContext, toolDiscoveryToolCalls));
 
     final var response = requestHandler.handleRequest(agentExecutionContext);
     assertThat(response.variables()).containsOnlyKeys("agentContext", "toolCallResults");
     assertThat(response.completionConditionFulfilled()).isFalse();
     assertThat(response.cancelRemainingInstances()).isFalse();
-    assertThat(response.responseValue()).isNotNull().isEqualTo(agentResponse);
+    assertThat(response.responseValue()).isNotNull();
+    assertThat(response.responseValue().context()).isEqualTo(discoveryAgentContext);
+    assertThat(response.responseValue().toolCalls())
+        .containsExactly(ToolCallProcessVariable.from(toolDiscoveryToolCalls.get(0)));
+
+    verifyNoInteractions(
+        limitsValidator, messagesHandler, gatewayToolHandlers, framework, responseHandler);
+  }
+
+  @Test
+  void toolDiscoveryListenerPatchesStatusOnJobCompletion() {
+    reset(conversationStoreRegistry);
+
+    final var toolDiscoveryToolCalls =
+        List.of(ToolCall.builder().id("tool_discovery").name("AGatewayTool").build());
+    final var discoveryAgentContext =
+        AgentContext.builder().state(AgentState.TOOL_DISCOVERY).build();
+
+    when(agentInitializer.initializeAgent(agentExecutionContext))
+        .thenReturn(new DiscoverTools(discoveryAgentContext, toolDiscoveryToolCalls));
+
+    final var response = requestHandler.handleRequest(agentExecutionContext);
+
+    // no agentInstanceClient calls during handleRequest itself
+    verifyNoInteractions(agentInstanceClient);
+
+    // when: job completes — TOOL_DISCOVERY status patch fires
+    response.onJobCompleted();
+    verify(agentInstanceClient)
+        .update(
+            eq(agentExecutionContext),
+            eq(discoveryAgentContext),
+            eq(AgentInstanceUpdateRequest.statusOnly(AgentInstanceUpdateStatus.TOOL_DISCOVERY)));
+    verifyNoMoreInteractions(agentInstanceClient);
+  }
+
+  @Test
+  void toolDiscoveryListenerSkipsStatusPatchOnJobCompletionFailure() {
+    reset(conversationStoreRegistry);
+
+    final var toolDiscoveryToolCalls =
+        List.of(ToolCall.builder().id("tool_discovery").name("AGatewayTool").build());
+    final var discoveryAgentContext =
+        AgentContext.builder().state(AgentState.TOOL_DISCOVERY).build();
+
+    when(agentInitializer.initializeAgent(agentExecutionContext))
+        .thenReturn(new DiscoverTools(discoveryAgentContext, toolDiscoveryToolCalls));
+
+    final var response = requestHandler.handleRequest(agentExecutionContext);
+
+    verifyNoInteractions(agentInstanceClient);
+
+    // when: job completion fails — listener logs and does nothing
+    response.onJobCompletionFailed(
+        new JobCompletionFailure.ExecutionFailed(new RuntimeException(), null));
+    verifyNoInteractions(agentInstanceClient);
+  }
+
+  @Test
+  void returnsNoOpResponseWhenInitializationReturnsDeferConversation() {
+    reset(conversationStoreRegistry);
+
+    when(agentInitializer.initializeAgent(agentExecutionContext))
+        .thenReturn(new DeferConversation());
+
+    final var response = requestHandler.handleRequest(agentExecutionContext);
+    assertThat(response.responseValue()).isNull();
+    assertThat(response.completionConditionFulfilled()).isFalse();
 
     verifyNoInteractions(
         limitsValidator, messagesHandler, gatewayToolHandlers, framework, responseHandler);
@@ -153,7 +217,7 @@ class JobWorkerAgentRequestHandlerTest {
     mockUserPrompt(USER_PROMPT_CONFIGURATION_WITHOUT_TOOLS, List.of());
 
     when(agentInitializer.initializeAgent(agentExecutionContext))
-        .thenReturn(new AgentContextInitializationResult(INITIAL_AGENT_CONTEXT, List.of()));
+        .thenReturn(new ReadyToConverse(INITIAL_AGENT_CONTEXT, List.of()));
 
     final var assistantMessageText =
         "Endless waves whisper | moonlight dances on the tide | secrets drift below.";
@@ -215,7 +279,7 @@ class JobWorkerAgentRequestHandlerTest {
     mockUserPrompt(USER_PROMPT_CONFIGURATION_WITH_TOOLS, List.of());
 
     when(agentInitializer.initializeAgent(agentExecutionContext))
-        .thenReturn(new AgentContextInitializationResult(INITIAL_AGENT_CONTEXT, List.of()));
+        .thenReturn(new ReadyToConverse(INITIAL_AGENT_CONTEXT, List.of()));
 
     final var assistantMessage = AssistantMessage.builder().toolCalls(TOOL_CALLS).build();
 
@@ -306,7 +370,7 @@ class JobWorkerAgentRequestHandlerTest {
     mockInterruptedToolCall(toolCallResults);
 
     when(agentInitializer.initializeAgent(agentExecutionContext))
-        .thenReturn(new AgentContextInitializationResult(INITIAL_AGENT_CONTEXT, List.of()));
+        .thenReturn(new ReadyToConverse(INITIAL_AGENT_CONTEXT, List.of()));
 
     when(agentExecutionContext.cancelRemainingInstances()).thenReturn(true);
 
@@ -424,7 +488,7 @@ class JobWorkerAgentRequestHandlerTest {
     mockSystemPrompt();
 
     when(agentInitializer.initializeAgent(agentExecutionContext))
-        .thenReturn(new AgentContextInitializationResult(INITIAL_AGENT_CONTEXT, List.of()));
+        .thenReturn(new ReadyToConverse(INITIAL_AGENT_CONTEXT, List.of()));
 
     final var response = requestHandler.handleRequest(agentExecutionContext);
     assertThat(response.variables()).isEmpty();
@@ -442,7 +506,7 @@ class JobWorkerAgentRequestHandlerTest {
     mockSystemPrompt();
     mockUserPrompt(USER_PROMPT_CONFIGURATION_WITH_TOOLS, List.of());
     when(agentInitializer.initializeAgent(agentExecutionContext))
-        .thenReturn(new AgentContextInitializationResult(INITIAL_AGENT_CONTEXT, List.of()));
+        .thenReturn(new ReadyToConverse(INITIAL_AGENT_CONTEXT, List.of()));
     final var assistantMessage = AssistantMessage.builder().toolCalls(TOOL_CALLS).build();
     mockFrameworkExecution(assistantMessage);
     when(gatewayToolHandlers.transformToolCalls(any(AgentContext.class), anyList()))
@@ -494,7 +558,7 @@ class JobWorkerAgentRequestHandlerTest {
     mockSystemPrompt();
     mockUserPrompt(USER_PROMPT_CONFIGURATION_WITHOUT_TOOLS, List.of());
     when(agentInitializer.initializeAgent(agentExecutionContext))
-        .thenReturn(new AgentContextInitializationResult(INITIAL_AGENT_CONTEXT, List.of()));
+        .thenReturn(new ReadyToConverse(INITIAL_AGENT_CONTEXT, List.of()));
     final var assistantMessage = AssistantMessage.builder().build();
     mockFrameworkExecution(assistantMessage);
     when(gatewayToolHandlers.transformToolCalls(any(AgentContext.class), anyList()))
@@ -544,7 +608,7 @@ class JobWorkerAgentRequestHandlerTest {
     mockSystemPrompt();
     mockUserPrompt(USER_PROMPT_CONFIGURATION_WITH_TOOLS, List.of());
     when(agentInitializer.initializeAgent(agentExecutionContext))
-        .thenReturn(new AgentContextInitializationResult(INITIAL_AGENT_CONTEXT, List.of()));
+        .thenReturn(new ReadyToConverse(INITIAL_AGENT_CONTEXT, List.of()));
     final var assistantMessage = AssistantMessage.builder().toolCalls(TOOL_CALLS).build();
     mockFrameworkExecution(assistantMessage);
     when(gatewayToolHandlers.transformToolCalls(any(AgentContext.class), anyList()))
@@ -597,7 +661,7 @@ class JobWorkerAgentRequestHandlerTest {
     mockSystemPrompt();
     mockUserPrompt(USER_PROMPT_CONFIGURATION_WITH_TOOLS, List.of());
     when(agentInitializer.initializeAgent(agentExecutionContext))
-        .thenReturn(new AgentContextInitializationResult(INITIAL_AGENT_CONTEXT, List.of()));
+        .thenReturn(new ReadyToConverse(INITIAL_AGENT_CONTEXT, List.of()));
     final var assistantMessage = AssistantMessage.builder().toolCalls(TOOL_CALLS).build();
     mockFrameworkExecution(assistantMessage);
     when(gatewayToolHandlers.transformToolCalls(any(AgentContext.class), anyList()))
@@ -658,7 +722,7 @@ class JobWorkerAgentRequestHandlerTest {
             InProcessConversationContext.builder("in-process").messages(previousMessages).build());
 
     when(agentInitializer.initializeAgent(agentExecutionContext))
-        .thenReturn(new AgentContextInitializationResult(initialAgentContext, List.of()));
+        .thenReturn(new ReadyToConverse(initialAgentContext, List.of()));
 
     final var assistantMessageText = "This is the assistant message";
     final var assistantMessage = assistantMessage(assistantMessageText);

--- a/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/agent/OutboundConnectorAgentRequestHandlerTest.java
+++ b/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/agent/OutboundConnectorAgentRequestHandlerTest.java
@@ -26,8 +26,9 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import io.camunda.client.api.command.AgentInstanceUpdateStatus;
-import io.camunda.connector.agenticai.aiagent.agent.AgentInitializationResult.AgentContextInitializationResult;
-import io.camunda.connector.agenticai.aiagent.agent.AgentInitializationResult.AgentResponseInitializationResult;
+import io.camunda.connector.agenticai.aiagent.agent.AgentInitializationResult.DeferConversation;
+import io.camunda.connector.agenticai.aiagent.agent.AgentInitializationResult.DiscoverTools;
+import io.camunda.connector.agenticai.aiagent.agent.AgentInitializationResult.ReadyToConverse;
 import io.camunda.connector.agenticai.aiagent.agentinstance.AgentInstanceClient;
 import io.camunda.connector.agenticai.aiagent.agentinstance.AgentInstanceUpdateRequest;
 import io.camunda.connector.agenticai.aiagent.framework.AiFrameworkAdapter;
@@ -53,6 +54,7 @@ import io.camunda.connector.agenticai.model.tool.ToolCall;
 import io.camunda.connector.agenticai.model.tool.ToolCallProcessVariable;
 import io.camunda.connector.agenticai.model.tool.ToolCallResult;
 import io.camunda.connector.api.error.ConnectorException;
+import io.camunda.connector.api.outbound.JobCompletionFailure;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
@@ -109,23 +111,84 @@ class OutboundConnectorAgentRequestHandlerTest {
   }
 
   @Test
-  void directlyReturnsAgentResponseWhenInitializationReturnsResponse() {
+  void dispatchesToolDiscoveryWhenInitializationReturnsDiscoverTools() {
     reset(conversationStoreRegistry);
 
-    final var agentResponse =
-        AgentResponse.builder()
-            .context(AgentContext.builder().state(AgentState.TOOL_DISCOVERY).build())
-            .toolCalls(
-                List.of(
-                    ToolCallProcessVariable.from(
-                        ToolCall.builder().id("tool_discovery").name("AGatewayTool").build())))
-            .build();
+    final var toolDiscoveryToolCalls =
+        List.of(ToolCall.builder().id("tool_discovery").name("AGatewayTool").build());
+    final var discoveryAgentContext =
+        AgentContext.builder().state(AgentState.TOOL_DISCOVERY).build();
 
     when(agentInitializer.initializeAgent(agentExecutionContext))
-        .thenReturn(new AgentResponseInitializationResult(agentResponse));
+        .thenReturn(new DiscoverTools(discoveryAgentContext, toolDiscoveryToolCalls));
 
     final var response = requestHandler.handleRequest(agentExecutionContext);
-    assertThat(response.agentResponse()).isEqualTo(agentResponse);
+    assertThat(response.agentResponse().context()).isEqualTo(discoveryAgentContext);
+    assertThat(response.agentResponse().toolCalls())
+        .containsExactly(ToolCallProcessVariable.from(toolDiscoveryToolCalls.get(0)));
+
+    verifyNoInteractions(
+        limitsValidator, messagesHandler, gatewayToolHandlers, framework, responseHandler);
+  }
+
+  @Test
+  void toolDiscoveryListenerPatchesStatusOnJobCompletion() {
+    reset(conversationStoreRegistry);
+
+    final var toolDiscoveryToolCalls =
+        List.of(ToolCall.builder().id("tool_discovery").name("AGatewayTool").build());
+    final var discoveryAgentContext =
+        AgentContext.builder().state(AgentState.TOOL_DISCOVERY).build();
+
+    when(agentInitializer.initializeAgent(agentExecutionContext))
+        .thenReturn(new DiscoverTools(discoveryAgentContext, toolDiscoveryToolCalls));
+
+    final var response = requestHandler.handleRequest(agentExecutionContext);
+
+    // no agentInstanceClient calls during handleRequest itself
+    verifyNoInteractions(agentInstanceClient);
+
+    // when: job completes — TOOL_DISCOVERY status patch fires
+    response.onJobCompleted();
+    verify(agentInstanceClient)
+        .update(
+            eq(agentExecutionContext),
+            eq(discoveryAgentContext),
+            eq(AgentInstanceUpdateRequest.statusOnly(AgentInstanceUpdateStatus.TOOL_DISCOVERY)));
+    verifyNoMoreInteractions(agentInstanceClient);
+  }
+
+  @Test
+  void toolDiscoveryListenerSkipsStatusPatchOnJobCompletionFailure() {
+    reset(conversationStoreRegistry);
+
+    final var toolDiscoveryToolCalls =
+        List.of(ToolCall.builder().id("tool_discovery").name("AGatewayTool").build());
+    final var discoveryAgentContext =
+        AgentContext.builder().state(AgentState.TOOL_DISCOVERY).build();
+
+    when(agentInitializer.initializeAgent(agentExecutionContext))
+        .thenReturn(new DiscoverTools(discoveryAgentContext, toolDiscoveryToolCalls));
+
+    final var response = requestHandler.handleRequest(agentExecutionContext);
+
+    verifyNoInteractions(agentInstanceClient);
+
+    // when: job completion fails — listener logs and does nothing
+    response.onJobCompletionFailed(
+        new JobCompletionFailure.ExecutionFailed(new RuntimeException(), null));
+    verifyNoInteractions(agentInstanceClient);
+  }
+
+  @Test
+  void returnsNoOpResponseWhenInitializationReturnsDeferConversation() {
+    reset(conversationStoreRegistry);
+
+    when(agentInitializer.initializeAgent(agentExecutionContext))
+        .thenReturn(new DeferConversation());
+
+    final var response = requestHandler.handleRequest(agentExecutionContext);
+    assertThat(response.agentResponse()).isNull();
 
     verifyNoInteractions(
         limitsValidator, messagesHandler, gatewayToolHandlers, framework, responseHandler);
@@ -137,7 +200,7 @@ class OutboundConnectorAgentRequestHandlerTest {
     mockUserPrompt(USER_PROMPT_CONFIGURATION_WITHOUT_TOOLS, List.of());
 
     when(agentInitializer.initializeAgent(agentExecutionContext))
-        .thenReturn(new AgentContextInitializationResult(INITIAL_AGENT_CONTEXT, List.of()));
+        .thenReturn(new ReadyToConverse(INITIAL_AGENT_CONTEXT, List.of()));
 
     final var assistantMessageText =
         "Endless waves whisper | moonlight dances on the tide | secrets drift below.";
@@ -193,7 +256,7 @@ class OutboundConnectorAgentRequestHandlerTest {
     mockUserPrompt(USER_PROMPT_CONFIGURATION_WITH_TOOLS, List.of());
 
     when(agentInitializer.initializeAgent(agentExecutionContext))
-        .thenReturn(new AgentContextInitializationResult(INITIAL_AGENT_CONTEXT, List.of()));
+        .thenReturn(new ReadyToConverse(INITIAL_AGENT_CONTEXT, List.of()));
 
     final var assistantMessage = AssistantMessage.builder().toolCalls(TOOL_CALLS).build();
 
@@ -307,7 +370,7 @@ class OutboundConnectorAgentRequestHandlerTest {
     mockSystemPrompt();
 
     when(agentInitializer.initializeAgent(agentExecutionContext))
-        .thenReturn(new AgentContextInitializationResult(INITIAL_AGENT_CONTEXT, List.of()));
+        .thenReturn(new ReadyToConverse(INITIAL_AGENT_CONTEXT, List.of()));
 
     assertThatThrownBy(() -> requestHandler.handleRequest(agentExecutionContext))
         .isInstanceOfSatisfying(
@@ -326,7 +389,7 @@ class OutboundConnectorAgentRequestHandlerTest {
     mockSystemPrompt();
     mockUserPrompt(USER_PROMPT_CONFIGURATION_WITHOUT_TOOLS, List.of());
     when(agentInitializer.initializeAgent(agentExecutionContext))
-        .thenReturn(new AgentContextInitializationResult(INITIAL_AGENT_CONTEXT, List.of()));
+        .thenReturn(new ReadyToConverse(INITIAL_AGENT_CONTEXT, List.of()));
     final var assistantMessage = assistantMessage("No tool calls here.");
     mockFrameworkExecution(assistantMessage);
     when(gatewayToolHandlers.transformToolCalls(any(AgentContext.class), anyList()))
@@ -376,7 +439,7 @@ class OutboundConnectorAgentRequestHandlerTest {
     mockSystemPrompt();
     mockUserPrompt(USER_PROMPT_CONFIGURATION_WITH_TOOLS, List.of());
     when(agentInitializer.initializeAgent(agentExecutionContext))
-        .thenReturn(new AgentContextInitializationResult(INITIAL_AGENT_CONTEXT, List.of()));
+        .thenReturn(new ReadyToConverse(INITIAL_AGENT_CONTEXT, List.of()));
     final var assistantMessage = AssistantMessage.builder().toolCalls(TOOL_CALLS).build();
     mockFrameworkExecution(assistantMessage);
     when(gatewayToolHandlers.transformToolCalls(any(AgentContext.class), anyList()))
@@ -441,7 +504,7 @@ class OutboundConnectorAgentRequestHandlerTest {
             eq(USER_PROMPT_CONFIGURATION_WITHOUT_TOOLS),
             anyList());
     when(agentInitializer.initializeAgent(agentExecutionContext))
-        .thenReturn(new AgentContextInitializationResult(INITIAL_AGENT_CONTEXT, List.of()));
+        .thenReturn(new ReadyToConverse(INITIAL_AGENT_CONTEXT, List.of()));
     final var assistantMessage = assistantMessage("Done.");
     mockFrameworkExecution(assistantMessage);
     when(gatewayToolHandlers.transformToolCalls(any(AgentContext.class), anyList()))
@@ -476,7 +539,7 @@ class OutboundConnectorAgentRequestHandlerTest {
     // given: addUserMessages returns empty list → throws NO_USER_MESSAGE_CONTENT
     mockSystemPrompt();
     when(agentInitializer.initializeAgent(agentExecutionContext))
-        .thenReturn(new AgentContextInitializationResult(INITIAL_AGENT_CONTEXT, List.of()));
+        .thenReturn(new ReadyToConverse(INITIAL_AGENT_CONTEXT, List.of()));
 
     // when / then: exception is thrown before any PATCH
     assertThatThrownBy(() -> requestHandler.handleRequest(agentExecutionContext))
@@ -500,7 +563,7 @@ class OutboundConnectorAgentRequestHandlerTest {
             InProcessConversationContext.builder("in-process").messages(previousMessages).build());
 
     when(agentInitializer.initializeAgent(agentExecutionContext))
-        .thenReturn(new AgentContextInitializationResult(initialAgentContext, List.of()));
+        .thenReturn(new ReadyToConverse(initialAgentContext, List.of()));
 
     final var assistantMessageText = "This is the assistant message";
     final var assistantMessage = assistantMessage(assistantMessageText);


### PR DESCRIPTION
## Description

Improve code organization around the agent initialization to reflect actual logic around domain oriented concepts.

Key improvements:
* AgentInitializer result typing reflects the actual intent for the conversation, either
   * Defer the conversation
   * Proceed with the conversation
   * Dispatch a tool discovery
* Introduce `AgentConversation` domain model as the center model around the agent lifecycle
  * In this PR it begins to wrap several other objects to ensure that the data flow is clearer 

## Checklist

- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest
  release, as this branch will be rebased onto main before the next release. Example backport labels:
    - `backport stable/8.8`: for changes that should be included in the next 8.8.x release.
    - **or** `backport release-8.8.7`: for changes that should be included in the specific release 8.8.7, and this
      *release has already been created*. The release branch will be merged back into stable/8.8 later, so the change
      will be included in future 8.8.x releases as well.
- [x] Tests/Integration tests for the changes have been added if applicable.
- [ ] If the change requires a documentation update, it has been added to the appropriate section in the documentation.


