### PR TITLE
ci: ping connectors medic when E2E tests fail

### DIFF
--- a/.github/workflows/NIGHTLY_E2E.yml
+++ b/.github/workflows/NIGHTLY_E2E.yml
@@ -128,5 +128,5 @@ jobs:
           payload: |
             {
               "channel": ${{ secrets.CONNECTORS_SUPPORT_SLACK_CHANNEL_ID }},
-              "text": ":alarm: E2E test run failed on branch `${{ matrix.branch}}`.\nCheck details: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+              "text": ":alarm: ${{ secrets.CONNECTORS_MEDIC_SLACK_GROUP_ID }} E2E test run failed on branch `${{ matrix.branch}}`.\nCheck details: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
             }


### PR DESCRIPTION
## Description
This pull request makes a minor update to the Slack notification message in the nightly E2E workflow. The change adds the `CONNECTORS_MEDIC_SLACK_GROUP_ID` to the alert message, ensuring the correct Slack group is mentioned when E2E tests fail.