### PR TITLE
feat(refresh-token): Add refresh token option to the rest connector, add it to the MS email as well

### DIFF
--- a/connector-commons/http-client/src/main/java/io/camunda/connector/http/client/authentication/OAuthConstants.java
+++ b/connector-commons/http-client/src/main/java/io/camunda/connector/http/client/authentication/OAuthConstants.java
@@ -22,8 +22,13 @@ public class OAuthConstants {
   public static final String CLIENT_SECRET = "client_secret";
   public static final String AUDIENCE = "audience";
   public static final String SCOPE = "scope";
+  public static final String REFRESH_TOKEN = "refresh_token";
   public static final String ACCESS_TOKEN = "access_token";
   public static final String EXPIRES_IN = "expires_in";
   public static final String BASIC_AUTH_HEADER = "basicAuthHeader";
   public static final String CREDENTIALS_BODY = "credentialsBody";
+  public static final String ERROR = "error";
+  public static final String ERROR_DESCRIPTION = "error_description";
+  public static final String INVALID_GRANT = "invalid_grant";
+  public static final String INTERACTION_REQUIRED = "interaction_required";
 }

--- a/connector-commons/http-client/src/main/java/io/camunda/connector/http/client/authentication/OAuthService.java
+++ b/connector-commons/http-client/src/main/java/io/camunda/connector/http/client/authentication/OAuthService.java
@@ -25,6 +25,7 @@ import io.camunda.connector.http.client.mapper.StreamingHttpResponse;
 import io.camunda.connector.http.client.model.HttpClientRequest;
 import io.camunda.connector.http.client.model.HttpMethod;
 import io.camunda.connector.http.client.model.auth.OAuthAuthentication;
+import io.camunda.connector.http.client.model.auth.OAuthRefreshTokenAuthentication;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -69,6 +70,72 @@ public class OAuthService {
 
   public TokenResponse extractTokenFromResponse(StreamingHttpResponse body) {
     var jsonNode = ResponseMappers.asJsonNode(() -> OBJECT_MAPPER).apply(body);
+    return Optional.ofNullable(jsonNode)
+        .filter(JsonNode::isObject)
+        .map(node -> node.findValue(OAuthConstants.ACCESS_TOKEN))
+        .map(JsonNode::asText)
+        .map(accessToken -> toTokenResponse(accessToken, jsonNode))
+        .orElseThrow(
+            () ->
+                new ConnectorException(
+                    "OAUTH_TOKEN_ERROR",
+                    "OAuth token response does not contain an access_token field"));
+  }
+
+  /**
+   * Creates an OAuth token request for the refresh-token grant flow.
+   *
+   * @param authentication the refresh-token authentication configuration
+   * @return a request targeting the token endpoint with the refresh-token body
+   */
+  public HttpClientRequest createOAuthRefreshTokenRequestFrom(
+      OAuthRefreshTokenAuthentication authentication) {
+    HttpClientRequest oauthRequest = new HttpClientRequest();
+    Map<String, String> headers = new HashMap<>();
+    headers.put(HttpHeaders.CONTENT_TYPE, ContentType.APPLICATION_FORM_URLENCODED.getMimeType());
+
+    oauthRequest.setMethod(HttpMethod.POST);
+    oauthRequest.setUrl(authentication.oauthTokenEndpoint());
+    oauthRequest.setBody(authentication.getDataForAuthRequestBody());
+    oauthRequest.setHeaders(headers);
+    return oauthRequest;
+  }
+
+  /**
+   * Extracts an access token from a refresh-token grant response, with actionable error messages
+   * for common failure modes ({@code invalid_grant}, {@code interaction_required}).
+   *
+   * @param body the raw token endpoint response
+   * @return the access token
+   * @throws ConnectorException if the response contains an OAuth error or no access_token
+   */
+  public TokenResponse extractTokenFromRefreshTokenResponse(StreamingHttpResponse body) {
+    var jsonNode = ResponseMappers.asJsonNode(() -> OBJECT_MAPPER).apply(body);
+    if (jsonNode != null && jsonNode.isObject()) {
+      var errorNode = jsonNode.findValue(OAuthConstants.ERROR);
+      if (errorNode != null) {
+        String error = errorNode.asText();
+        String description =
+            Optional.ofNullable(jsonNode.findValue(OAuthConstants.ERROR_DESCRIPTION))
+                .map(JsonNode::asText)
+                .orElse("no description provided");
+        if (OAuthConstants.INVALID_GRANT.equals(error)) {
+          throw new ConnectorException(
+              "OAUTH_REFRESH_TOKEN_EXPIRED",
+              "Refresh token is invalid or expired; re-authorization is required. Details: "
+                  + description);
+        }
+        if (OAuthConstants.INTERACTION_REQUIRED.equals(error)) {
+          throw new ConnectorException(
+              "OAUTH_INTERACTION_REQUIRED",
+              "The identity provider requires user interaction before a token can be issued; "
+                  + "re-authorization is required. Details: "
+                  + description);
+        }
+        throw new ConnectorException(
+            "OAUTH_TOKEN_ERROR", "OAuth token exchange failed: " + error + ". " + description);
+      }
+    }
     return Optional.ofNullable(jsonNode)
         .filter(JsonNode::isObject)
         .map(node -> node.findValue(OAuthConstants.ACCESS_TOKEN))

--- a/connector-commons/http-client/src/main/java/io/camunda/connector/http/client/authentication/OAuthService.java
+++ b/connector-commons/http-client/src/main/java/io/camunda/connector/http/client/authentication/OAuthService.java
@@ -106,7 +106,7 @@ public class OAuthService {
    * for common failure modes ({@code invalid_grant}, {@code interaction_required}).
    *
    * @param body the raw token endpoint response
-   * @return the access token
+   * @return token response containing the access token (and expires_in if present)
    * @throws ConnectorException if the response contains an OAuth error or no access_token
    */
   public TokenResponse extractTokenFromRefreshTokenResponse(StreamingHttpResponse body) {

--- a/connector-commons/http-client/src/main/java/io/camunda/connector/http/client/authentication/OAuthTokenCache.java
+++ b/connector-commons/http-client/src/main/java/io/camunda/connector/http/client/authentication/OAuthTokenCache.java
@@ -17,6 +17,7 @@
 package io.camunda.connector.http.client.authentication;
 
 import io.camunda.connector.http.client.model.auth.OAuthAuthentication;
+import io.camunda.connector.http.client.model.auth.OAuthRefreshTokenAuthentication;
 import java.util.function.Supplier;
 
 /**
@@ -40,12 +41,30 @@ public interface OAuthTokenCache {
   String getOrFetch(OAuthAuthentication auth, Supplier<TokenResponse> tokenSupplier);
 
   /**
+   * Returns a cached token for the given refresh-token authentication configuration, or fetches a
+   * new one using the provided supplier and caches it according to the configured TTL strategy.
+   *
+   * @param auth the refresh-token authentication configuration used to derive the cache key
+   * @param tokenSupplier a supplier that fetches a new token from the token endpoint
+   * @return the access token string
+   */
+  String getOrFetch(OAuthRefreshTokenAuthentication auth, Supplier<TokenResponse> tokenSupplier);
+
+  /**
    * Invalidates the cached token for the given authentication configuration, e.g. after receiving a
    * 401 response from a downstream service.
    *
    * @param auth the OAuth authentication configuration whose cached token should be removed
    */
   void invalidate(OAuthAuthentication auth);
+
+  /**
+   * Invalidates the cached token for the given refresh-token authentication configuration, e.g.
+   * after receiving a 401 response from a downstream service.
+   *
+   * @param auth the refresh-token authentication configuration whose cached token should be removed
+   */
+  void invalidate(OAuthRefreshTokenAuthentication auth);
 
   /** Invalidates all cached tokens. */
   void invalidateAll();

--- a/connector-commons/http-client/src/main/java/io/camunda/connector/http/client/authentication/cacheimpl/CaffeineOAuthTokenCache.java
+++ b/connector-commons/http-client/src/main/java/io/camunda/connector/http/client/authentication/cacheimpl/CaffeineOAuthTokenCache.java
@@ -21,6 +21,7 @@ import com.github.benmanes.caffeine.cache.Caffeine;
 import io.camunda.connector.http.client.authentication.OAuthTokenCache;
 import io.camunda.connector.http.client.authentication.TokenResponse;
 import io.camunda.connector.http.client.model.auth.OAuthAuthentication;
+import io.camunda.connector.http.client.model.auth.OAuthRefreshTokenAuthentication;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -107,7 +108,26 @@ public class CaffeineOAuthTokenCache implements OAuthTokenCache {
             Objects.requireNonNullElse(auth.audience(), ""),
             Objects.requireNonNullElse(auth.scopes(), ""),
             Objects.requireNonNullElse(auth.clientAuthentication(), ""));
+    return sha256Hex(raw);
+  }
 
+  /**
+   * Computes a SHA-256 hash of the refresh-token configuration fields to use as the cache key. This
+   * ensures that sensitive credential material is never stored in plain text.
+   */
+  static String computeCacheKey(OAuthRefreshTokenAuthentication auth) {
+    String raw =
+        String.join(
+            "\0",
+            Objects.requireNonNullElse(auth.oauthTokenEndpoint(), ""),
+            Objects.requireNonNullElse(auth.clientId(), ""),
+            Objects.requireNonNullElse(auth.clientSecret(), ""),
+            Objects.requireNonNullElse(auth.refreshToken(), ""),
+            Objects.requireNonNullElse(auth.scopes(), ""));
+    return sha256Hex(raw);
+  }
+
+  private static String sha256Hex(String raw) {
     MessageDigest digest = SHA_256_DIGEST.get();
     digest.reset();
     byte[] hash = digest.digest(raw.getBytes(StandardCharsets.UTF_8));
@@ -125,8 +145,28 @@ public class CaffeineOAuthTokenCache implements OAuthTokenCache {
 
   @Override
   public String getOrFetch(OAuthAuthentication auth, Supplier<TokenResponse> tokenSupplier) {
-    String cacheKey = computeCacheKey(auth);
+    return getOrFetchByKey(computeCacheKey(auth), tokenSupplier);
+  }
 
+  @Override
+  public String getOrFetch(
+      OAuthRefreshTokenAuthentication auth, Supplier<TokenResponse> tokenSupplier) {
+    return getOrFetchByKey(computeCacheKey(auth), tokenSupplier);
+  }
+
+  @Override
+  public void invalidate(OAuthAuthentication auth) {
+    cache.invalidate(computeCacheKey(auth));
+    LOG.debug("OAuth token cache entry invalidated");
+  }
+
+  @Override
+  public void invalidate(OAuthRefreshTokenAuthentication auth) {
+    cache.invalidate(computeCacheKey(auth));
+    LOG.debug("OAuth token cache entry invalidated");
+  }
+
+  private String getOrFetchByKey(String cacheKey, Supplier<TokenResponse> tokenSupplier) {
     AtomicReference<String> uncachedToken = new AtomicReference<>();
 
     CaffeineCacheToken entry =
@@ -153,13 +193,6 @@ public class CaffeineOAuthTokenCache implements OAuthTokenCache {
 
     // Mapping returned null → token was fetched but not cached (no expires_in)
     return uncachedToken.get();
-  }
-
-  @Override
-  public void invalidate(OAuthAuthentication auth) {
-    String cacheKey = computeCacheKey(auth);
-    cache.invalidate(cacheKey);
-    LOG.debug("OAuth token cache entry invalidated");
   }
 
   @Override

--- a/connector-commons/http-client/src/main/java/io/camunda/connector/http/client/client/apache/builder/parts/ApacheRequestAuthenticationBuilder.java
+++ b/connector-commons/http-client/src/main/java/io/camunda/connector/http/client/client/apache/builder/parts/ApacheRequestAuthenticationBuilder.java
@@ -55,7 +55,7 @@ public class ApacheRequestAuthenticationBuilder implements ApacheRequestPartBuil
           builder.addHeader(AUTHORIZATION, String.format(BEARER, token));
         }
         case OAuthRefreshTokenAuthentication auth -> {
-          var token = fetchOAuthRefreshToken(auth);
+          var token = tokenCache.getOrFetch(auth, () -> fetchOAuthRefreshToken(auth));
           builder.addHeader(AUTHORIZATION, String.format(BEARER, token));
         }
         case BearerAuthentication auth ->
@@ -81,12 +81,11 @@ public class ApacheRequestAuthenticationBuilder implements ApacheRequestPartBuil
         .entity();
   }
 
-  String fetchOAuthRefreshToken(OAuthRefreshTokenAuthentication authentication) {
+  TokenResponse fetchOAuthRefreshToken(OAuthRefreshTokenAuthentication authentication) {
     HttpClientRequest oAuthRequest =
         oAuthService.createOAuthRefreshTokenRequestFrom(authentication);
     return new CustomApacheHttpClient()
         .execute(oAuthRequest, oAuthService::extractTokenFromRefreshTokenResponse)
-        .entity()
-        .accessToken();
+        .entity();
   }
 }

--- a/connector-commons/http-client/src/main/java/io/camunda/connector/http/client/client/apache/builder/parts/ApacheRequestAuthenticationBuilder.java
+++ b/connector-commons/http-client/src/main/java/io/camunda/connector/http/client/client/apache/builder/parts/ApacheRequestAuthenticationBuilder.java
@@ -54,6 +54,10 @@ public class ApacheRequestAuthenticationBuilder implements ApacheRequestPartBuil
           var token = tokenCache.getOrFetch(auth, () -> fetchOAuthToken(auth));
           builder.addHeader(AUTHORIZATION, String.format(BEARER, token));
         }
+        case OAuthRefreshTokenAuthentication auth -> {
+          var token = fetchOAuthRefreshToken(auth);
+          builder.addHeader(AUTHORIZATION, String.format(BEARER, token));
+        }
         case BearerAuthentication auth ->
             builder.addHeader(AUTHORIZATION, String.format(BEARER, auth.token()));
         case ApiKeyAuthentication auth -> {
@@ -75,5 +79,14 @@ public class ApacheRequestAuthenticationBuilder implements ApacheRequestPartBuil
     return new CustomApacheHttpClient()
         .execute(oAuthRequest, oAuthService::extractTokenFromResponse)
         .entity();
+  }
+
+  String fetchOAuthRefreshToken(OAuthRefreshTokenAuthentication authentication) {
+    HttpClientRequest oAuthRequest =
+        oAuthService.createOAuthRefreshTokenRequestFrom(authentication);
+    return new CustomApacheHttpClient()
+        .execute(oAuthRequest, oAuthService::extractTokenFromRefreshTokenResponse)
+        .entity()
+        .accessToken();
   }
 }

--- a/connector-commons/http-client/src/main/java/io/camunda/connector/http/client/model/auth/HttpAuthentication.java
+++ b/connector-commons/http-client/src/main/java/io/camunda/connector/http/client/model/auth/HttpAuthentication.java
@@ -24,6 +24,9 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
   @JsonSubTypes.Type(value = BasicAuthentication.class, name = BasicAuthentication.TYPE),
   @JsonSubTypes.Type(value = NoAuthentication.class, name = NoAuthentication.TYPE),
   @JsonSubTypes.Type(value = OAuthAuthentication.class, name = OAuthAuthentication.TYPE),
+  @JsonSubTypes.Type(
+      value = OAuthRefreshTokenAuthentication.class,
+      name = OAuthRefreshTokenAuthentication.TYPE),
   @JsonSubTypes.Type(value = BearerAuthentication.class, name = BearerAuthentication.TYPE),
   @JsonSubTypes.Type(value = ApiKeyAuthentication.class, name = ApiKeyAuthentication.TYPE)
 })

--- a/connector-commons/http-client/src/main/java/io/camunda/connector/http/client/model/auth/OAuthRefreshTokenAuthentication.java
+++ b/connector-commons/http-client/src/main/java/io/camunda/connector/http/client/model/auth/OAuthRefreshTokenAuthentication.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.http.client.model.auth;
+
+import io.camunda.connector.http.client.authentication.OAuthConstants;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.commons.lang3.StringUtils;
+
+public record OAuthRefreshTokenAuthentication(
+    String oauthTokenEndpoint,
+    String clientId,
+    String clientSecret,
+    String refreshToken,
+    String scopes)
+    implements HttpAuthentication {
+
+  public static final String TYPE = "oauth-refresh-token";
+  public static final String GRANT_TYPE = "refresh_token";
+
+  public Map<String, String> getDataForAuthRequestBody() {
+    Map<String, String> data = new HashMap<>();
+    data.put(OAuthConstants.GRANT_TYPE, GRANT_TYPE);
+    data.put(OAuthConstants.CLIENT_ID, clientId());
+    data.put(OAuthConstants.REFRESH_TOKEN, refreshToken());
+    if (StringUtils.isNotBlank(clientSecret())) {
+      data.put(OAuthConstants.CLIENT_SECRET, clientSecret());
+    }
+    if (StringUtils.isNotBlank(scopes())) {
+      data.put(OAuthConstants.SCOPE, scopes());
+    }
+    return data;
+  }
+
+  @Override
+  public String toString() {
+    return "OAuthRefreshTokenAuthentication{"
+        + "oauthTokenEndpoint='"
+        + oauthTokenEndpoint
+        + "'"
+        + ", clientId='"
+        + clientId
+        + "'"
+        + ", clientSecret=[REDACTED]"
+        + ", refreshToken=[REDACTED]"
+        + ", scopes='"
+        + scopes
+        + "'"
+        + "}";
+  }
+}

--- a/connector-commons/http-client/src/test/java/io/camunda/connector/http/client/authentication/OAuthRefreshTokenServiceTest.java
+++ b/connector-commons/http-client/src/test/java/io/camunda/connector/http/client/authentication/OAuthRefreshTokenServiceTest.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.http.client.authentication;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.connector.api.error.ConnectorException;
+import io.camunda.connector.http.client.HttpClientObjectMapperSupplier;
+import io.camunda.connector.http.client.mapper.StreamingHttpResponse;
+import io.camunda.connector.http.client.model.HttpMethod;
+import io.camunda.connector.http.client.model.auth.OAuthRefreshTokenAuthentication;
+import java.io.ByteArrayInputStream;
+import java.util.Map;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+public class OAuthRefreshTokenServiceTest {
+
+  private final OAuthService oAuthService = new OAuthService();
+  private final ObjectMapper objectMapper = HttpClientObjectMapperSupplier.getCopy();
+
+  @Nested
+  class CreateOAuthRefreshTokenRequestTests {
+
+    @Test
+    void shouldCreateRequestWithRefreshTokenGrantType() {
+      var auth =
+          new OAuthRefreshTokenAuthentication(
+              "https://login.microsoftonline.com/tenant/oauth2/v2.0/token",
+              "clientId",
+              "clientSecret",
+              "theRefreshToken",
+              "https://graph.microsoft.com/.default");
+
+      var request = oAuthService.createOAuthRefreshTokenRequestFrom(auth);
+
+      assertThat(request.getUrl())
+          .isEqualTo("https://login.microsoftonline.com/tenant/oauth2/v2.0/token");
+      assertThat(request.getMethod()).isEqualTo(HttpMethod.POST);
+      assertThat(request.getHeaders().orElse(Map.of()))
+          .containsEntry("Content-Type", "application/x-www-form-urlencoded");
+      assertThat((Map) request.getBody()).containsEntry("grant_type", "refresh_token");
+      assertThat((Map) request.getBody()).containsEntry("client_id", "clientId");
+      assertThat((Map) request.getBody()).containsEntry("client_secret", "clientSecret");
+      assertThat((Map) request.getBody()).containsEntry("refresh_token", "theRefreshToken");
+      assertThat((Map) request.getBody())
+          .containsEntry("scope", "https://graph.microsoft.com/.default");
+    }
+
+    @Test
+    void shouldOmitClientSecretWhenBlank() {
+      var auth =
+          new OAuthRefreshTokenAuthentication(
+              "https://login.microsoftonline.com/tenant/oauth2/v2.0/token",
+              "clientId",
+              null,
+              "theRefreshToken",
+              null);
+
+      var request = oAuthService.createOAuthRefreshTokenRequestFrom(auth);
+
+      assertThat((Map) request.getBody()).doesNotContainKey("client_secret");
+      assertThat((Map) request.getBody()).doesNotContainKey("scope");
+      assertThat((Map) request.getBody()).containsEntry("grant_type", "refresh_token");
+      assertThat((Map) request.getBody()).containsEntry("client_id", "clientId");
+      assertThat((Map) request.getBody()).containsEntry("refresh_token", "theRefreshToken");
+    }
+  }
+
+  @Nested
+  class ExtractTokenFromRefreshTokenResponseTests {
+
+    @Test
+    void shouldReturnToken_whenResponseContainsAccessToken() throws JsonProcessingException {
+      var body =
+          Map.of(
+              "access_token", "myAccessToken",
+              "token_type", "Bearer",
+              "expires_in", 3600);
+      String json = objectMapper.writeValueAsString(body);
+      var response =
+          new StreamingHttpResponse(200, null, null, new ByteArrayInputStream(json.getBytes()));
+
+      var tokenResponse = oAuthService.extractTokenFromRefreshTokenResponse(response);
+
+      assertThat(tokenResponse.accessToken()).isEqualTo("myAccessToken");
+      assertThat(tokenResponse.expiresInSeconds()).hasValue(3600);
+    }
+
+    @Test
+    void shouldThrowInvalidGrantException_whenResponseContainsInvalidGrant() {
+      String body =
+          "{\"error\":\"invalid_grant\",\"error_description\":\"AADSTS70008: Refresh token expired.\"}";
+      var response =
+          new StreamingHttpResponse(400, null, null, new ByteArrayInputStream(body.getBytes()));
+
+      assertThatThrownBy(() -> oAuthService.extractTokenFromRefreshTokenResponse(response))
+          .isInstanceOf(ConnectorException.class)
+          .hasMessageContaining("re-authorization is required")
+          .hasMessageContaining("AADSTS70008");
+    }
+
+    @Test
+    void shouldThrowInteractionRequiredException_whenResponseContainsInteractionRequired() {
+      String body =
+          "{\"error\":\"interaction_required\",\"error_description\":\"User must re-authenticate.\"}";
+      var response =
+          new StreamingHttpResponse(400, null, null, new ByteArrayInputStream(body.getBytes()));
+
+      assertThatThrownBy(() -> oAuthService.extractTokenFromRefreshTokenResponse(response))
+          .isInstanceOf(ConnectorException.class)
+          .hasMessageContaining("re-authorization is required")
+          .hasMessageContaining("User must re-authenticate");
+    }
+
+    @Test
+    void shouldThrowGenericOAuthError_whenResponseContainsUnknownError() {
+      String body =
+          "{\"error\":\"unauthorized_client\",\"error_description\":\"Client not allowed.\"}";
+      var response =
+          new StreamingHttpResponse(400, null, null, new ByteArrayInputStream(body.getBytes()));
+
+      assertThatThrownBy(() -> oAuthService.extractTokenFromRefreshTokenResponse(response))
+          .isInstanceOf(ConnectorException.class)
+          .hasMessageContaining("unauthorized_client");
+    }
+
+    @Test
+    void shouldThrowOAuthTokenError_whenResponseHasNoAccessToken() {
+      String body = "{\"scope\":\"read\",\"token_type\":\"Bearer\"}";
+      var response =
+          new StreamingHttpResponse(200, null, null, new ByteArrayInputStream(body.getBytes()));
+
+      assertThatThrownBy(() -> oAuthService.extractTokenFromRefreshTokenResponse(response))
+          .isInstanceOf(ConnectorException.class)
+          .hasMessageContaining("access_token");
+    }
+  }
+}

--- a/connector-commons/http-client/src/test/java/io/camunda/connector/http/client/authentication/cacheimpl/CaffeineOAuthTokenCacheTest.java
+++ b/connector-commons/http-client/src/test/java/io/camunda/connector/http/client/authentication/cacheimpl/CaffeineOAuthTokenCacheTest.java
@@ -21,6 +21,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.camunda.connector.http.client.authentication.OAuthConstants;
 import io.camunda.connector.http.client.authentication.TokenResponse;
 import io.camunda.connector.http.client.model.auth.OAuthAuthentication;
+import io.camunda.connector.http.client.model.auth.OAuthRefreshTokenAuthentication;
 import java.time.Duration;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.Nested;
@@ -245,6 +246,110 @@ public class CaffeineOAuthTokenCacheTest {
 
       assertThat(result2).isEqualTo("token-2");
       assertThat(fetchCount.get()).isEqualTo(0);
+    }
+  }
+
+  @Nested
+  class RefreshTokenCacheTests {
+
+    private static OAuthRefreshTokenAuthentication createRefreshAuth(
+        String endpoint, String clientId, String refreshToken) {
+      return new OAuthRefreshTokenAuthentication(endpoint, clientId, null, refreshToken, null);
+    }
+
+    @Test
+    void shouldProduceSameKey_forSameRefreshTokenAuthentication() {
+      var auth1 = createRefreshAuth("https://token.example.com", "id1", "rt1");
+      var auth2 = createRefreshAuth("https://token.example.com", "id1", "rt1");
+
+      assertThat(CaffeineOAuthTokenCache.computeCacheKey(auth1))
+          .isEqualTo(CaffeineOAuthTokenCache.computeCacheKey(auth2));
+    }
+
+    @Test
+    void shouldProduceDifferentKey_forDifferentRefreshToken() {
+      var auth1 = createRefreshAuth("https://token.example.com", "id1", "rt1");
+      var auth2 = createRefreshAuth("https://token.example.com", "id1", "rt2");
+
+      assertThat(CaffeineOAuthTokenCache.computeCacheKey(auth1))
+          .isNotEqualTo(CaffeineOAuthTokenCache.computeCacheKey(auth2));
+    }
+
+    @Test
+    void shouldReturnCachedToken_onSecondCall() {
+      var cache = new CaffeineOAuthTokenCache();
+      var auth = createRefreshAuth("https://token.example.com", "id1", "rt1");
+      var fetchCount = new AtomicInteger(0);
+
+      var result1 =
+          cache.getOrFetch(
+              auth,
+              () -> {
+                fetchCount.incrementAndGet();
+                return new TokenResponse("access-token-1", 300);
+              });
+      var result2 =
+          cache.getOrFetch(
+              auth,
+              () -> {
+                fetchCount.incrementAndGet();
+                return new TokenResponse("access-token-2", 300);
+              });
+
+      assertThat(result1).isEqualTo("access-token-1");
+      assertThat(result2).isEqualTo("access-token-1");
+      assertThat(fetchCount.get()).isEqualTo(1);
+    }
+
+    @Test
+    void shouldFetchNewToken_afterInvalidation() {
+      var cache = new CaffeineOAuthTokenCache();
+      var auth = createRefreshAuth("https://token.example.com", "id1", "rt1");
+      var fetchCount = new AtomicInteger(0);
+
+      cache.getOrFetch(
+          auth,
+          () -> {
+            fetchCount.incrementAndGet();
+            return new TokenResponse("access-token-1", 300);
+          });
+      cache.invalidate(auth);
+      var result =
+          cache.getOrFetch(
+              auth,
+              () -> {
+                fetchCount.incrementAndGet();
+                return new TokenResponse("access-token-2", 300);
+              });
+
+      assertThat(result).isEqualTo("access-token-2");
+      assertThat(fetchCount.get()).isEqualTo(2);
+    }
+
+    @Test
+    void shouldNotCacheToken_whenExpiresInIsAbsent() {
+      var cache = new CaffeineOAuthTokenCache();
+      var auth = createRefreshAuth("https://token.example.com", "id1", "rt1");
+      var fetchCount = new AtomicInteger(0);
+
+      var result1 =
+          cache.getOrFetch(
+              auth,
+              () -> {
+                fetchCount.incrementAndGet();
+                return new TokenResponse("token-no-expiry-1");
+              });
+      var result2 =
+          cache.getOrFetch(
+              auth,
+              () -> {
+                fetchCount.incrementAndGet();
+                return new TokenResponse("token-no-expiry-2");
+              });
+
+      assertThat(result1).isEqualTo("token-no-expiry-1");
+      assertThat(result2).isEqualTo("token-no-expiry-2");
+      assertThat(fetchCount.get()).isEqualTo(2);
     }
   }
 

--- a/connector-commons/http-client/src/test/java/io/camunda/connector/http/client/client/apache/ApacheRequestFactoryTest.java
+++ b/connector-commons/http-client/src/test/java/io/camunda/connector/http/client/client/apache/ApacheRequestFactoryTest.java
@@ -35,6 +35,7 @@ import io.camunda.connector.http.client.model.auth.ApiKeyLocation;
 import io.camunda.connector.http.client.model.auth.BasicAuthentication;
 import io.camunda.connector.http.client.model.auth.BearerAuthentication;
 import io.camunda.connector.http.client.model.auth.OAuthAuthentication;
+import io.camunda.connector.http.client.model.auth.OAuthRefreshTokenAuthentication;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -129,6 +130,29 @@ public class ApacheRequestFactoryTest {
         // then
         assertThat(httpRequest.getHeader(HttpHeaders.AUTHORIZATION).getValue())
             .isEqualTo("Bearer token");
+      }
+    }
+
+    @Test
+    public void shouldSetOAuthRefreshTokenAuthentication_whenProvided() throws Exception {
+      var tokenResponse = new TokenResponse("refreshed-token", 300);
+      var response = new HttpResponse<>(200, null, Map.of(), tokenResponse);
+      HttpClientRequest request = new HttpClientRequest();
+      request.setMethod(HttpMethod.GET);
+      request.setUrl("theurl");
+      request.setAuthentication(
+          new OAuthRefreshTokenAuthentication(
+              "https://idp/token", "clientId", "secret", "the-refresh-token", "scopes"));
+      try (MockedConstruction<CustomApacheHttpClient> mocked =
+          mockConstruction(
+              CustomApacheHttpClient.class,
+              (mock, context) ->
+                  when(mock.execute(any(HttpClientRequest.class), any(ResponseMapper.class)))
+                      .thenReturn(response))) {
+        ClassicHttpRequest httpRequest = ApacheRequestFactory.get().createHttpRequest(request);
+
+        assertThat(httpRequest.getHeader(HttpHeaders.AUTHORIZATION).getValue())
+            .isEqualTo("Bearer refreshed-token");
       }
     }
 

--- a/connector-commons/http-client/src/test/java/io/camunda/connector/http/client/client/apache/CustomApacheHttpClientTest.java
+++ b/connector-commons/http-client/src/test/java/io/camunda/connector/http/client/client/apache/CustomApacheHttpClientTest.java
@@ -43,6 +43,7 @@ import io.camunda.connector.http.client.model.auth.ApiKeyLocation;
 import io.camunda.connector.http.client.model.auth.BasicAuthentication;
 import io.camunda.connector.http.client.model.auth.BearerAuthentication;
 import io.camunda.connector.http.client.model.auth.OAuthAuthentication;
+import io.camunda.connector.http.client.model.auth.OAuthRefreshTokenAuthentication;
 import io.camunda.connector.test.utils.DockerImages;
 import java.io.IOException;
 import java.util.HashMap;
@@ -1232,6 +1233,215 @@ public class CustomApacheHttpClientTest {
       // Second request — should fetch a new token after invalidation
       httpClient.execute(request, ResponseMappers.asJsonNode(() -> objectMapper));
       verify(2, postRequestedFor(urlEqualTo("/oauth")));
+    }
+
+    @Test
+    public void shouldReturn200WithBody_whenGetWithOAuthRefreshToken(
+        WireMockRuntimeInfo wmRuntimeInfo) {
+      createRefreshTokenAuthServer();
+      stubFor(
+          get("/path")
+              .withHeader("Authorization", equalTo("Bearer refreshed-token"))
+              .willReturn(
+                  ok().withJsonBody(JsonNodeFactory.instance.objectNode().put("result", "ok"))));
+
+      HttpClientRequest request = new HttpClientRequest();
+      request.setUrl(wmRuntimeInfo.getHttpBaseUrl() + "/path");
+      request.setMethod(HttpMethod.GET);
+      request.setAuthentication(
+          new OAuthRefreshTokenAuthentication(
+              wmRuntimeInfo.getHttpBaseUrl() + "/oauth",
+              "clientId",
+              "clientSecret",
+              "theRefreshToken",
+              "read:resource"));
+
+      var result =
+          httpClient.execute(request, ResponseMappers.asJsonNode(() -> objectMapper)).entity();
+      assertThat(result.get("result").asText()).isEqualTo("ok");
+      verify(1, postRequestedFor(urlEqualTo("/oauth")));
+    }
+
+    @Test
+    public void shouldThrowRefreshTokenExpired_whenAuthServerReturnsInvalidGrantBody(
+        WireMockRuntimeInfo wmRuntimeInfo) {
+      // Non-RFC-compliant but observed: IdP returns 200 with an OAuth error body.
+      // RFC-compliant 4xx responses are already covered by the generic HTTP-error path.
+      stubFor(
+          post("/oauth")
+              .willReturn(
+                  ok().withHeader(HttpHeaders.CONTENT_TYPE, "application/json")
+                      .withBody(
+                          "{\"error\":\"invalid_grant\",\"error_description\":\"AADSTS70008: Refresh token expired.\"}")));
+
+      HttpClientRequest request = new HttpClientRequest();
+      request.setUrl(wmRuntimeInfo.getHttpBaseUrl() + "/path");
+      request.setMethod(HttpMethod.GET);
+      request.setAuthentication(
+          new OAuthRefreshTokenAuthentication(
+              wmRuntimeInfo.getHttpBaseUrl() + "/oauth",
+              "clientId",
+              "clientSecret",
+              "theRefreshToken",
+              null));
+
+      var e =
+          assertThrows(
+              ConnectorException.class,
+              () -> httpClient.execute(request, ResponseMappers.asVoid()));
+      assertThat(e.getErrorCode()).isEqualTo("OAUTH_REFRESH_TOKEN_EXPIRED");
+      assertThat(e.getMessage()).contains("re-authorization is required");
+      assertThat(e.getMessage()).contains("AADSTS70008");
+    }
+
+    @Test
+    public void shouldThrowInteractionRequired_whenAuthServerReturnsInteractionRequiredBody(
+        WireMockRuntimeInfo wmRuntimeInfo) {
+      stubFor(
+          post("/oauth")
+              .willReturn(
+                  ok().withHeader(HttpHeaders.CONTENT_TYPE, "application/json")
+                      .withBody(
+                          "{\"error\":\"interaction_required\",\"error_description\":\"User must re-authenticate.\"}")));
+
+      HttpClientRequest request = new HttpClientRequest();
+      request.setUrl(wmRuntimeInfo.getHttpBaseUrl() + "/path");
+      request.setMethod(HttpMethod.GET);
+      request.setAuthentication(
+          new OAuthRefreshTokenAuthentication(
+              wmRuntimeInfo.getHttpBaseUrl() + "/oauth",
+              "clientId",
+              "clientSecret",
+              "theRefreshToken",
+              null));
+
+      var e =
+          assertThrows(
+              ConnectorException.class,
+              () -> httpClient.execute(request, ResponseMappers.asVoid()));
+      assertThat(e.getErrorCode()).isEqualTo("OAUTH_INTERACTION_REQUIRED");
+      assertThat(e.getMessage()).contains("User must re-authenticate");
+    }
+
+    @Test
+    public void shouldCacheOAuthRefreshToken_andReuseOnSecondRequest(
+        WireMockRuntimeInfo wmRuntimeInfo) {
+      createRefreshTokenAuthServer();
+      stubFor(
+          get("/path")
+              .withHeader("Authorization", equalTo("Bearer refreshed-token"))
+              .willReturn(
+                  ok().withJsonBody(JsonNodeFactory.instance.objectNode().put("result", "ok"))));
+
+      HttpClientRequest request = new HttpClientRequest();
+      request.setUrl(wmRuntimeInfo.getHttpBaseUrl() + "/path");
+      request.setMethod(HttpMethod.GET);
+      request.setAuthentication(
+          new OAuthRefreshTokenAuthentication(
+              wmRuntimeInfo.getHttpBaseUrl() + "/oauth",
+              "clientId",
+              "clientSecret",
+              "theRefreshToken",
+              "read:resource"));
+
+      httpClient.execute(request, ResponseMappers.asJsonNode(() -> objectMapper));
+      httpClient.execute(request, ResponseMappers.asJsonNode(() -> objectMapper));
+
+      verify(1, postRequestedFor(urlEqualTo("/oauth")));
+    }
+
+    @Test
+    public void shouldFetchNewToken_afterRefreshTokenCacheInvalidation(
+        WireMockRuntimeInfo wmRuntimeInfo) {
+      createRefreshTokenAuthServer();
+      stubFor(
+          get("/path")
+              .withHeader("Authorization", equalTo("Bearer refreshed-token"))
+              .willReturn(
+                  ok().withJsonBody(JsonNodeFactory.instance.objectNode().put("result", "ok"))));
+
+      var refreshAuth =
+          new OAuthRefreshTokenAuthentication(
+              wmRuntimeInfo.getHttpBaseUrl() + "/oauth",
+              "clientId",
+              "clientSecret",
+              "theRefreshToken",
+              "read:resource");
+
+      HttpClientRequest request = new HttpClientRequest();
+      request.setUrl(wmRuntimeInfo.getHttpBaseUrl() + "/path");
+      request.setMethod(HttpMethod.GET);
+      request.setAuthentication(refreshAuth);
+
+      httpClient.execute(request, ResponseMappers.asJsonNode(() -> objectMapper));
+      verify(1, postRequestedFor(urlEqualTo("/oauth")));
+
+      OAuthTokenCacheHolder.get().invalidate(refreshAuth);
+
+      httpClient.execute(request, ResponseMappers.asJsonNode(() -> objectMapper));
+      verify(2, postRequestedFor(urlEqualTo("/oauth")));
+    }
+
+    @Test
+    public void shouldOmitClientSecretAndScopes_whenBlank(WireMockRuntimeInfo wmRuntimeInfo) {
+      stubFor(
+          post("/oauth")
+              .withHeader(
+                  HttpHeaders.CONTENT_TYPE,
+                  equalTo(ContentType.APPLICATION_FORM_URLENCODED.getMimeType()))
+              .withFormParam("grant_type", equalTo("refresh_token"))
+              .withFormParam("client_id", equalTo("clientId"))
+              .withFormParam("refresh_token", equalTo("theRefreshToken"))
+              .willReturn(
+                  ok().withJsonBody(
+                          JsonNodeFactory.instance
+                              .objectNode()
+                              .put("access_token", "refreshed-token")
+                              .put("token_type", "Bearer")
+                              .put("expires_in", 3600))));
+      stubFor(
+          get("/path")
+              .withHeader("Authorization", equalTo("Bearer refreshed-token"))
+              .willReturn(ok().withBody("ok")));
+
+      HttpClientRequest request = new HttpClientRequest();
+      request.setUrl(wmRuntimeInfo.getHttpBaseUrl() + "/path");
+      request.setMethod(HttpMethod.GET);
+      request.setAuthentication(
+          new OAuthRefreshTokenAuthentication(
+              wmRuntimeInfo.getHttpBaseUrl() + "/oauth",
+              "clientId",
+              null,
+              "theRefreshToken",
+              null));
+
+      httpClient.execute(request, ResponseMappers.asString());
+
+      verify(
+          1,
+          postRequestedFor(urlEqualTo("/oauth"))
+              .withRequestBody(notMatching(".*client_secret.*"))
+              .withRequestBody(notMatching(".*scope.*")));
+    }
+
+    private void createRefreshTokenAuthServer() {
+      stubFor(
+          post("/oauth")
+              .withHeader(
+                  HttpHeaders.CONTENT_TYPE,
+                  equalTo(ContentType.APPLICATION_FORM_URLENCODED.getMimeType()))
+              .withFormParam("grant_type", equalTo("refresh_token"))
+              .withFormParam("client_id", equalTo("clientId"))
+              .withFormParam("client_secret", equalTo("clientSecret"))
+              .withFormParam("refresh_token", equalTo("theRefreshToken"))
+              .withFormParam("scope", equalTo("read:resource"))
+              .willReturn(
+                  ok().withJsonBody(
+                          JsonNodeFactory.instance
+                              .objectNode()
+                              .put("access_token", "refreshed-token")
+                              .put("token_type", "Bearer")
+                              .put("expires_in", 3600))));
     }
 
     private void createAuthServer(String credentialsLocation) {

--- a/connectors/http/graphql/element-templates/graphql-outbound-connector.json
+++ b/connectors/http/graphql/element-templates/graphql-outbound-connector.json
@@ -75,6 +75,9 @@
     }, {
       "name" : "OAuth 2.0",
       "value" : "oauth-client-credentials-flow"
+    }, {
+      "name" : "OAuth 2.0 Refresh Token",
+      "value" : "oauth-refresh-token"
     } ]
   }, {
     "id" : "authentication.apiKeyLocation",
@@ -319,6 +322,104 @@
     "condition" : {
       "property" : "authentication.type",
       "equals" : "oauth-client-credentials-flow",
+      "type" : "simple"
+    },
+    "type" : "String"
+  }, {
+    "id" : "authentication.oauthRefreshToken.oauthTokenEndpoint",
+    "label" : "OAuth 2.0 token endpoint",
+    "description" : "The OAuth token endpoint",
+    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true,
+      "pattern" : {
+        "value" : "^(=|(http://|https://|secrets|\\{\\{).*$)",
+        "message" : "Must be a http(s) URL"
+      }
+    },
+    "feel" : "optional",
+    "group" : "authentication",
+    "binding" : {
+      "name" : "authentication.oauthTokenEndpoint",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "authentication.type",
+      "equals" : "oauth-refresh-token",
+      "type" : "simple"
+    },
+    "type" : "String"
+  }, {
+    "id" : "authentication.oauthRefreshToken.clientId",
+    "label" : "Client ID",
+    "description" : "Your application's client ID from the OAuth client",
+    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "authentication",
+    "binding" : {
+      "name" : "authentication.clientId",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "authentication.type",
+      "equals" : "oauth-refresh-token",
+      "type" : "simple"
+    },
+    "type" : "String"
+  }, {
+    "id" : "authentication.oauthRefreshToken.clientSecret",
+    "label" : "Client secret",
+    "description" : "Your application's client secret from the OAuth client",
+    "optional" : true,
+    "feel" : "optional",
+    "group" : "authentication",
+    "binding" : {
+      "name" : "authentication.clientSecret",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "authentication.type",
+      "equals" : "oauth-refresh-token",
+      "type" : "simple"
+    },
+    "type" : "String"
+  }, {
+    "id" : "authentication.oauthRefreshToken.refreshToken",
+    "label" : "Refresh token",
+    "description" : "The refresh token used to obtain a new access token",
+    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "authentication",
+    "binding" : {
+      "name" : "authentication.refreshToken",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "authentication.type",
+      "equals" : "oauth-refresh-token",
+      "type" : "simple"
+    },
+    "type" : "String"
+  }, {
+    "id" : "authentication.oauthRefreshToken.scopes",
+    "label" : "Oauth refresh token.scopes",
+    "description" : "The scopes to request authorization for (space-separated)",
+    "optional" : true,
+    "feel" : "optional",
+    "group" : "authentication",
+    "binding" : {
+      "name" : "authentication.scopes",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "authentication.type",
+      "equals" : "oauth-refresh-token",
       "type" : "simple"
     },
     "type" : "String"

--- a/connectors/http/graphql/element-templates/graphql-outbound-connector.json
+++ b/connectors/http/graphql/element-templates/graphql-outbound-connector.json
@@ -408,7 +408,7 @@
     "type" : "String"
   }, {
     "id" : "authentication.oauthRefreshToken.scopes",
-    "label" : "Oauth refresh token.scopes",
+    "label" : "Scopes",
     "description" : "The scopes to request authorization for (space-separated)",
     "optional" : true,
     "feel" : "optional",

--- a/connectors/http/graphql/element-templates/hybrid/graphql-outbound-connector-hybrid.json
+++ b/connectors/http/graphql/element-templates/hybrid/graphql-outbound-connector-hybrid.json
@@ -413,7 +413,7 @@
     "type" : "String"
   }, {
     "id" : "authentication.oauthRefreshToken.scopes",
-    "label" : "Oauth refresh token.scopes",
+    "label" : "Scopes",
     "description" : "The scopes to request authorization for (space-separated)",
     "optional" : true,
     "feel" : "optional",

--- a/connectors/http/graphql/element-templates/hybrid/graphql-outbound-connector-hybrid.json
+++ b/connectors/http/graphql/element-templates/hybrid/graphql-outbound-connector-hybrid.json
@@ -80,6 +80,9 @@
     }, {
       "name" : "OAuth 2.0",
       "value" : "oauth-client-credentials-flow"
+    }, {
+      "name" : "OAuth 2.0 Refresh Token",
+      "value" : "oauth-refresh-token"
     } ]
   }, {
     "id" : "authentication.apiKeyLocation",
@@ -324,6 +327,104 @@
     "condition" : {
       "property" : "authentication.type",
       "equals" : "oauth-client-credentials-flow",
+      "type" : "simple"
+    },
+    "type" : "String"
+  }, {
+    "id" : "authentication.oauthRefreshToken.oauthTokenEndpoint",
+    "label" : "OAuth 2.0 token endpoint",
+    "description" : "The OAuth token endpoint",
+    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true,
+      "pattern" : {
+        "value" : "^(=|(http://|https://|secrets|\\{\\{).*$)",
+        "message" : "Must be a http(s) URL"
+      }
+    },
+    "feel" : "optional",
+    "group" : "authentication",
+    "binding" : {
+      "name" : "authentication.oauthTokenEndpoint",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "authentication.type",
+      "equals" : "oauth-refresh-token",
+      "type" : "simple"
+    },
+    "type" : "String"
+  }, {
+    "id" : "authentication.oauthRefreshToken.clientId",
+    "label" : "Client ID",
+    "description" : "Your application's client ID from the OAuth client",
+    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "authentication",
+    "binding" : {
+      "name" : "authentication.clientId",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "authentication.type",
+      "equals" : "oauth-refresh-token",
+      "type" : "simple"
+    },
+    "type" : "String"
+  }, {
+    "id" : "authentication.oauthRefreshToken.clientSecret",
+    "label" : "Client secret",
+    "description" : "Your application's client secret from the OAuth client",
+    "optional" : true,
+    "feel" : "optional",
+    "group" : "authentication",
+    "binding" : {
+      "name" : "authentication.clientSecret",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "authentication.type",
+      "equals" : "oauth-refresh-token",
+      "type" : "simple"
+    },
+    "type" : "String"
+  }, {
+    "id" : "authentication.oauthRefreshToken.refreshToken",
+    "label" : "Refresh token",
+    "description" : "The refresh token used to obtain a new access token",
+    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "authentication",
+    "binding" : {
+      "name" : "authentication.refreshToken",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "authentication.type",
+      "equals" : "oauth-refresh-token",
+      "type" : "simple"
+    },
+    "type" : "String"
+  }, {
+    "id" : "authentication.oauthRefreshToken.scopes",
+    "label" : "Oauth refresh token.scopes",
+    "description" : "The scopes to request authorization for (space-separated)",
+    "optional" : true,
+    "feel" : "optional",
+    "group" : "authentication",
+    "binding" : {
+      "name" : "authentication.scopes",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "authentication.type",
+      "equals" : "oauth-refresh-token",
       "type" : "simple"
     },
     "type" : "String"

--- a/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/model/auth/Authentication.java
+++ b/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/model/auth/Authentication.java
@@ -15,6 +15,9 @@ import io.camunda.connector.generator.java.annotation.TemplateDiscriminatorPrope
   @JsonSubTypes.Type(value = BasicAuthentication.class, name = BasicAuthentication.TYPE),
   @JsonSubTypes.Type(value = NoAuthentication.class, name = NoAuthentication.TYPE),
   @JsonSubTypes.Type(value = OAuthAuthentication.class, name = OAuthAuthentication.TYPE),
+  @JsonSubTypes.Type(
+      value = OAuthRefreshTokenAuthentication.class,
+      name = OAuthRefreshTokenAuthentication.TYPE),
   @JsonSubTypes.Type(value = BearerAuthentication.class, name = BearerAuthentication.TYPE),
   @JsonSubTypes.Type(value = ApiKeyAuthentication.class, name = ApiKeyAuthentication.TYPE)
 })
@@ -29,4 +32,5 @@ public sealed interface Authentication
         BasicAuthentication,
         BearerAuthentication,
         NoAuthentication,
-        OAuthAuthentication {}
+        OAuthAuthentication,
+        OAuthRefreshTokenAuthentication {}

--- a/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/model/auth/AuthenticationMapper.java
+++ b/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/model/auth/AuthenticationMapper.java
@@ -37,6 +37,14 @@ public class AuthenticationMapper {
               String scopes) ->
           new io.camunda.connector.http.client.model.auth.OAuthAuthentication(
               oauthTokenEndpoint, clientId, clientSecret, audience, clientAuthentication, scopes);
+      case OAuthRefreshTokenAuthentication(
+              String oauthTokenEndpoint,
+              String clientId,
+              String clientSecret,
+              String refreshToken,
+              String scopes) ->
+          new io.camunda.connector.http.client.model.auth.OAuthRefreshTokenAuthentication(
+              oauthTokenEndpoint, clientId, clientSecret, refreshToken, scopes);
       default -> throw new IllegalArgumentException("Unsupported Authentication type");
     };
   }

--- a/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/model/auth/OAuthRefreshTokenAuthentication.java
+++ b/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/model/auth/OAuthRefreshTokenAuthentication.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.http.base.model.auth;
+
+import io.camunda.connector.api.annotation.FEEL;
+import io.camunda.connector.generator.java.annotation.TemplateProperty;
+import io.camunda.connector.generator.java.annotation.TemplateSubType;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Pattern;
+
+@TemplateSubType(
+    id = io.camunda.connector.http.client.model.auth.OAuthRefreshTokenAuthentication.TYPE,
+    label = "OAuth 2.0 Refresh Token")
+public record OAuthRefreshTokenAuthentication(
+    @FEEL
+        @NotEmpty
+        @Pattern(
+            regexp = "^(=|(http://|https://|secrets|\\{\\{).*$)",
+            message = "Must be a http(s) URL")
+        @TemplateProperty(
+            id = "oauthRefreshToken.oauthTokenEndpoint",
+            group = "authentication",
+            description = "The OAuth token endpoint",
+            label = "OAuth 2.0 token endpoint")
+        String oauthTokenEndpoint,
+    @FEEL
+        @NotEmpty
+        @TemplateProperty(
+            id = "oauthRefreshToken.clientId",
+            group = "authentication",
+            description = "Your application's client ID from the OAuth client",
+            label = "Client ID")
+        String clientId,
+    @FEEL
+        @TemplateProperty(
+            id = "oauthRefreshToken.clientSecret",
+            group = "authentication",
+            description = "Your application's client secret from the OAuth client",
+            label = "Client secret",
+            optional = true)
+        String clientSecret,
+    @FEEL
+        @NotEmpty
+        @TemplateProperty(
+            id = "oauthRefreshToken.refreshToken",
+            group = "authentication",
+            description = "The refresh token used to obtain a new access token",
+            label = "Refresh token")
+        String refreshToken,
+    @TemplateProperty(
+            id = "oauthRefreshToken.scopes",
+            group = "authentication",
+            description = "The scopes to request authorization for (space-separated)",
+            optional = true)
+        String scopes)
+    implements Authentication {
+
+  @TemplateProperty(ignore = true)
+  public static final String TYPE =
+      io.camunda.connector.http.client.model.auth.OAuthRefreshTokenAuthentication.TYPE;
+}

--- a/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/model/auth/OAuthRefreshTokenAuthentication.java
+++ b/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/model/auth/OAuthRefreshTokenAuthentication.java
@@ -55,6 +55,7 @@ public record OAuthRefreshTokenAuthentication(
             id = "oauthRefreshToken.scopes",
             group = "authentication",
             description = "The scopes to request authorization for (space-separated)",
+            label = "Scopes",
             optional = true)
         String scopes)
     implements Authentication {

--- a/connectors/http/polling/element-templates/http-polling-boundary-catch-event-connector.json
+++ b/connectors/http/polling/element-templates/http-polling-boundary-catch-event-connector.json
@@ -396,7 +396,7 @@
     "type" : "String"
   }, {
     "id" : "authentication.oauthRefreshToken.scopes",
-    "label" : "Oauth refresh token.scopes",
+    "label" : "Scopes",
     "description" : "The scopes to request authorization for (space-separated)",
     "optional" : true,
     "group" : "authentication",

--- a/connectors/http/polling/element-templates/http-polling-boundary-catch-event-connector.json
+++ b/connectors/http/polling/element-templates/http-polling-boundary-catch-event-connector.json
@@ -77,6 +77,9 @@
     }, {
       "name" : "OAuth 2.0",
       "value" : "oauth-client-credentials-flow"
+    }, {
+      "name" : "OAuth 2.0 Refresh Token",
+      "value" : "oauth-refresh-token"
     } ]
   }, {
     "id" : "authentication.apiKeyLocation",
@@ -311,6 +314,99 @@
     "condition" : {
       "property" : "authentication.type",
       "equals" : "oauth-client-credentials-flow",
+      "type" : "simple"
+    },
+    "type" : "String"
+  }, {
+    "id" : "authentication.oauthRefreshToken.oauthTokenEndpoint",
+    "label" : "OAuth 2.0 token endpoint",
+    "description" : "The OAuth token endpoint",
+    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true,
+      "pattern" : {
+        "value" : "^(=|(http://|https://|secrets|\\{\\{).*$)",
+        "message" : "Must be a http(s) URL"
+      }
+    },
+    "group" : "authentication",
+    "binding" : {
+      "name" : "authentication.oauthTokenEndpoint",
+      "type" : "zeebe:property"
+    },
+    "condition" : {
+      "property" : "authentication.type",
+      "equals" : "oauth-refresh-token",
+      "type" : "simple"
+    },
+    "type" : "String"
+  }, {
+    "id" : "authentication.oauthRefreshToken.clientId",
+    "label" : "Client ID",
+    "description" : "Your application's client ID from the OAuth client",
+    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "group" : "authentication",
+    "binding" : {
+      "name" : "authentication.clientId",
+      "type" : "zeebe:property"
+    },
+    "condition" : {
+      "property" : "authentication.type",
+      "equals" : "oauth-refresh-token",
+      "type" : "simple"
+    },
+    "type" : "String"
+  }, {
+    "id" : "authentication.oauthRefreshToken.clientSecret",
+    "label" : "Client secret",
+    "description" : "Your application's client secret from the OAuth client",
+    "optional" : true,
+    "group" : "authentication",
+    "binding" : {
+      "name" : "authentication.clientSecret",
+      "type" : "zeebe:property"
+    },
+    "condition" : {
+      "property" : "authentication.type",
+      "equals" : "oauth-refresh-token",
+      "type" : "simple"
+    },
+    "type" : "String"
+  }, {
+    "id" : "authentication.oauthRefreshToken.refreshToken",
+    "label" : "Refresh token",
+    "description" : "The refresh token used to obtain a new access token",
+    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "group" : "authentication",
+    "binding" : {
+      "name" : "authentication.refreshToken",
+      "type" : "zeebe:property"
+    },
+    "condition" : {
+      "property" : "authentication.type",
+      "equals" : "oauth-refresh-token",
+      "type" : "simple"
+    },
+    "type" : "String"
+  }, {
+    "id" : "authentication.oauthRefreshToken.scopes",
+    "label" : "Oauth refresh token.scopes",
+    "description" : "The scopes to request authorization for (space-separated)",
+    "optional" : true,
+    "group" : "authentication",
+    "binding" : {
+      "name" : "authentication.scopes",
+      "type" : "zeebe:property"
+    },
+    "condition" : {
+      "property" : "authentication.type",
+      "equals" : "oauth-refresh-token",
       "type" : "simple"
     },
     "type" : "String"

--- a/connectors/http/polling/element-templates/http-polling-connector.json
+++ b/connectors/http/polling/element-templates/http-polling-connector.json
@@ -396,7 +396,7 @@
     "type" : "String"
   }, {
     "id" : "authentication.oauthRefreshToken.scopes",
-    "label" : "Oauth refresh token.scopes",
+    "label" : "Scopes",
     "description" : "The scopes to request authorization for (space-separated)",
     "optional" : true,
     "group" : "authentication",

--- a/connectors/http/polling/element-templates/http-polling-connector.json
+++ b/connectors/http/polling/element-templates/http-polling-connector.json
@@ -77,6 +77,9 @@
     }, {
       "name" : "OAuth 2.0",
       "value" : "oauth-client-credentials-flow"
+    }, {
+      "name" : "OAuth 2.0 Refresh Token",
+      "value" : "oauth-refresh-token"
     } ]
   }, {
     "id" : "authentication.apiKeyLocation",
@@ -311,6 +314,99 @@
     "condition" : {
       "property" : "authentication.type",
       "equals" : "oauth-client-credentials-flow",
+      "type" : "simple"
+    },
+    "type" : "String"
+  }, {
+    "id" : "authentication.oauthRefreshToken.oauthTokenEndpoint",
+    "label" : "OAuth 2.0 token endpoint",
+    "description" : "The OAuth token endpoint",
+    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true,
+      "pattern" : {
+        "value" : "^(=|(http://|https://|secrets|\\{\\{).*$)",
+        "message" : "Must be a http(s) URL"
+      }
+    },
+    "group" : "authentication",
+    "binding" : {
+      "name" : "authentication.oauthTokenEndpoint",
+      "type" : "zeebe:property"
+    },
+    "condition" : {
+      "property" : "authentication.type",
+      "equals" : "oauth-refresh-token",
+      "type" : "simple"
+    },
+    "type" : "String"
+  }, {
+    "id" : "authentication.oauthRefreshToken.clientId",
+    "label" : "Client ID",
+    "description" : "Your application's client ID from the OAuth client",
+    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "group" : "authentication",
+    "binding" : {
+      "name" : "authentication.clientId",
+      "type" : "zeebe:property"
+    },
+    "condition" : {
+      "property" : "authentication.type",
+      "equals" : "oauth-refresh-token",
+      "type" : "simple"
+    },
+    "type" : "String"
+  }, {
+    "id" : "authentication.oauthRefreshToken.clientSecret",
+    "label" : "Client secret",
+    "description" : "Your application's client secret from the OAuth client",
+    "optional" : true,
+    "group" : "authentication",
+    "binding" : {
+      "name" : "authentication.clientSecret",
+      "type" : "zeebe:property"
+    },
+    "condition" : {
+      "property" : "authentication.type",
+      "equals" : "oauth-refresh-token",
+      "type" : "simple"
+    },
+    "type" : "String"
+  }, {
+    "id" : "authentication.oauthRefreshToken.refreshToken",
+    "label" : "Refresh token",
+    "description" : "The refresh token used to obtain a new access token",
+    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "group" : "authentication",
+    "binding" : {
+      "name" : "authentication.refreshToken",
+      "type" : "zeebe:property"
+    },
+    "condition" : {
+      "property" : "authentication.type",
+      "equals" : "oauth-refresh-token",
+      "type" : "simple"
+    },
+    "type" : "String"
+  }, {
+    "id" : "authentication.oauthRefreshToken.scopes",
+    "label" : "Oauth refresh token.scopes",
+    "description" : "The scopes to request authorization for (space-separated)",
+    "optional" : true,
+    "group" : "authentication",
+    "binding" : {
+      "name" : "authentication.scopes",
+      "type" : "zeebe:property"
+    },
+    "condition" : {
+      "property" : "authentication.type",
+      "equals" : "oauth-refresh-token",
       "type" : "simple"
     },
     "type" : "String"

--- a/connectors/http/rest/README.md
+++ b/connectors/http/rest/README.md
@@ -235,6 +235,6 @@ leading to the following result
 | Connector Info            |                                                                       |
 | ---                       | ---                                                                   |
 | Type                      | io.camunda:http-json:1                                                            |
-| Version                   | 13                                                         |
+| Version                   | 14                                                         |
 | Supported element types   |     |
 

--- a/connectors/http/rest/element-templates/http-json-connector.json
+++ b/connectors/http/rest/element-templates/http-json-connector.json
@@ -5,7 +5,7 @@
   "description" : "Invoke REST API",
   "keywords" : [ "HTTP", "REST", "API call", "web request", "GET", "POST", "PUT", "PATCH", "DELETE", "fetch data", "send request", "invoke API" ],
   "documentationRef" : "https://docs.camunda.io/docs/components/connectors/protocol/rest/",
-  "version" : 13,
+  "version" : 14,
   "category" : {
     "id" : "connectors",
     "name" : "Connectors"
@@ -15,7 +15,7 @@
     "value" : "bpmn:ServiceTask"
   },
   "engines" : {
-    "camunda" : "^8.9"
+    "camunda" : "^8.10"
   },
   "groups" : [ {
     "id" : "authentication",
@@ -75,6 +75,9 @@
     }, {
       "name" : "OAuth 2.0",
       "value" : "oauth-client-credentials-flow"
+    }, {
+      "name" : "OAuth 2.0 Refresh Token",
+      "value" : "oauth-refresh-token"
     } ]
   }, {
     "id" : "authentication.apiKeyLocation",
@@ -323,6 +326,104 @@
     },
     "type" : "String"
   }, {
+    "id" : "authentication.oauthRefreshToken.oauthTokenEndpoint",
+    "label" : "OAuth 2.0 token endpoint",
+    "description" : "The OAuth token endpoint",
+    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true,
+      "pattern" : {
+        "value" : "^(=|(http://|https://|secrets|\\{\\{).*$)",
+        "message" : "Must be a http(s) URL"
+      }
+    },
+    "feel" : "optional",
+    "group" : "authentication",
+    "binding" : {
+      "name" : "authentication.oauthTokenEndpoint",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "authentication.type",
+      "equals" : "oauth-refresh-token",
+      "type" : "simple"
+    },
+    "type" : "String"
+  }, {
+    "id" : "authentication.oauthRefreshToken.clientId",
+    "label" : "Client ID",
+    "description" : "Your application's client ID from the OAuth client",
+    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "authentication",
+    "binding" : {
+      "name" : "authentication.clientId",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "authentication.type",
+      "equals" : "oauth-refresh-token",
+      "type" : "simple"
+    },
+    "type" : "String"
+  }, {
+    "id" : "authentication.oauthRefreshToken.clientSecret",
+    "label" : "Client secret",
+    "description" : "Your application's client secret from the OAuth client",
+    "optional" : true,
+    "feel" : "optional",
+    "group" : "authentication",
+    "binding" : {
+      "name" : "authentication.clientSecret",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "authentication.type",
+      "equals" : "oauth-refresh-token",
+      "type" : "simple"
+    },
+    "type" : "String"
+  }, {
+    "id" : "authentication.oauthRefreshToken.refreshToken",
+    "label" : "Refresh token",
+    "description" : "The refresh token used to obtain a new access token",
+    "optional" : false,
+    "constraints" : {
+      "notEmpty" : true
+    },
+    "feel" : "optional",
+    "group" : "authentication",
+    "binding" : {
+      "name" : "authentication.refreshToken",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "authentication.type",
+      "equals" : "oauth-refresh-token",
+      "type" : "simple"
+    },
+    "type" : "String"
+  }, {
+    "id" : "authentication.oauthRefreshToken.scopes",
+    "label" : "Oauth refresh token.scopes",
+    "description" : "The scopes to request authorization for (space-separated)",
+    "optional" : true,
+    "feel" : "optional",
+    "group" : "authentication",
+    "binding" : {
+      "name" : "authentication.scopes",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "authentication.type",
+      "equals" : "oauth-refresh-token",
+      "type" : "simple"
+    },
+    "type" : "String"
+  }, {
     "id" : "method",
     "label" : "Method",
     "optional" : false,
@@ -510,7 +611,7 @@
     "id" : "version",
     "label" : "Version",
     "description" : "Version of the element template",
-    "value" : "13",
+    "value" : "14",
     "group" : "connector",
     "binding" : {
       "key" : "elementTemplateVersion",

--- a/connectors/http/rest/element-templates/http-json-connector.json
+++ b/connectors/http/rest/element-templates/http-json-connector.json
@@ -408,7 +408,7 @@
     "type" : "String"
   }, {
     "id" : "authentication.oauthRefreshToken.scopes",
-    "label" : "Oauth refresh token.scopes",
+    "label" : "Scopes",
     "description" : "The scopes to request authorization for (space-separated)",
     "optional" : true,
     "feel" : "optional",

--- a/connectors/http/rest/element-templates/hybrid/http-json-connector-hybrid.json
+++ b/connectors/http/rest/element-templates/hybrid/http-json-connector-hybrid.json
@@ -413,7 +413,7 @@
     "type" : "String"
   }, {
     "id" : "authentication.oauthRefreshToken.scopes",
-    "label" : "Oauth refresh token.scopes",
+    "label" : "Scopes",
     "description" : "The scopes to request authorization for (space-separated)",
     "optional" : true,
     "feel" : "optional",

--- a/connectors/http/rest/element-templates/versioned/http-json-connector-13.json
+++ b/connectors/http/rest/element-templates/versioned/http-json-connector-13.json
@@ -1,11 +1,11 @@
 {
   "$schema" : "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
-  "name" : "Hybrid REST Outbound Connector",
-  "id" : "io.camunda.connectors.HttpJson.v2-hybrid",
+  "name" : "REST Outbound Connector",
+  "id" : "io.camunda.connectors.HttpJson.v2",
   "description" : "Invoke REST API",
   "keywords" : [ "HTTP", "REST", "API call", "web request", "GET", "POST", "PUT", "PATCH", "DELETE", "fetch data", "send request", "invoke API" ],
   "documentationRef" : "https://docs.camunda.io/docs/components/connectors/protocol/rest/",
-  "version" : 14,
+  "version" : 13,
   "category" : {
     "id" : "connectors",
     "name" : "Connectors"
@@ -15,12 +15,9 @@
     "value" : "bpmn:ServiceTask"
   },
   "engines" : {
-    "camunda" : "^8.10"
+    "camunda" : "^8.9"
   },
   "groups" : [ {
-    "id" : "taskDefinitionType",
-    "label" : "Task definition type"
-  }, {
     "id" : "authentication",
     "label" : "Authentication"
   }, {
@@ -46,14 +43,12 @@
     "label" : "Retries"
   } ],
   "properties" : [ {
-    "id" : "taskDefinitionType",
     "value" : "io.camunda:http-json:1",
-    "group" : "taskDefinitionType",
     "binding" : {
       "property" : "type",
       "type" : "zeebe:taskDefinition"
     },
-    "type" : "String"
+    "type" : "Hidden"
   }, {
     "id" : "authentication.type",
     "label" : "Type",
@@ -80,9 +75,6 @@
     }, {
       "name" : "OAuth 2.0",
       "value" : "oauth-client-credentials-flow"
-    }, {
-      "name" : "OAuth 2.0 Refresh Token",
-      "value" : "oauth-refresh-token"
     } ]
   }, {
     "id" : "authentication.apiKeyLocation",
@@ -331,104 +323,6 @@
     },
     "type" : "String"
   }, {
-    "id" : "authentication.oauthRefreshToken.oauthTokenEndpoint",
-    "label" : "OAuth 2.0 token endpoint",
-    "description" : "The OAuth token endpoint",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true,
-      "pattern" : {
-        "value" : "^(=|(http://|https://|secrets|\\{\\{).*$)",
-        "message" : "Must be a http(s) URL"
-      }
-    },
-    "feel" : "optional",
-    "group" : "authentication",
-    "binding" : {
-      "name" : "authentication.oauthTokenEndpoint",
-      "type" : "zeebe:input"
-    },
-    "condition" : {
-      "property" : "authentication.type",
-      "equals" : "oauth-refresh-token",
-      "type" : "simple"
-    },
-    "type" : "String"
-  }, {
-    "id" : "authentication.oauthRefreshToken.clientId",
-    "label" : "Client ID",
-    "description" : "Your application's client ID from the OAuth client",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "feel" : "optional",
-    "group" : "authentication",
-    "binding" : {
-      "name" : "authentication.clientId",
-      "type" : "zeebe:input"
-    },
-    "condition" : {
-      "property" : "authentication.type",
-      "equals" : "oauth-refresh-token",
-      "type" : "simple"
-    },
-    "type" : "String"
-  }, {
-    "id" : "authentication.oauthRefreshToken.clientSecret",
-    "label" : "Client secret",
-    "description" : "Your application's client secret from the OAuth client",
-    "optional" : true,
-    "feel" : "optional",
-    "group" : "authentication",
-    "binding" : {
-      "name" : "authentication.clientSecret",
-      "type" : "zeebe:input"
-    },
-    "condition" : {
-      "property" : "authentication.type",
-      "equals" : "oauth-refresh-token",
-      "type" : "simple"
-    },
-    "type" : "String"
-  }, {
-    "id" : "authentication.oauthRefreshToken.refreshToken",
-    "label" : "Refresh token",
-    "description" : "The refresh token used to obtain a new access token",
-    "optional" : false,
-    "constraints" : {
-      "notEmpty" : true
-    },
-    "feel" : "optional",
-    "group" : "authentication",
-    "binding" : {
-      "name" : "authentication.refreshToken",
-      "type" : "zeebe:input"
-    },
-    "condition" : {
-      "property" : "authentication.type",
-      "equals" : "oauth-refresh-token",
-      "type" : "simple"
-    },
-    "type" : "String"
-  }, {
-    "id" : "authentication.oauthRefreshToken.scopes",
-    "label" : "Oauth refresh token.scopes",
-    "description" : "The scopes to request authorization for (space-separated)",
-    "optional" : true,
-    "feel" : "optional",
-    "group" : "authentication",
-    "binding" : {
-      "name" : "authentication.scopes",
-      "type" : "zeebe:input"
-    },
-    "condition" : {
-      "property" : "authentication.type",
-      "equals" : "oauth-refresh-token",
-      "type" : "simple"
-    },
-    "type" : "String"
-  }, {
     "id" : "method",
     "label" : "Method",
     "optional" : false,
@@ -616,7 +510,7 @@
     "id" : "version",
     "label" : "Version",
     "description" : "Version of the element template",
-    "value" : "14",
+    "value" : "13",
     "group" : "connector",
     "binding" : {
       "key" : "elementTemplateVersion",

--- a/connectors/http/rest/src/main/java/io/camunda/connector/http/rest/HttpJsonFunction.java
+++ b/connectors/http/rest/src/main/java/io/camunda/connector/http/rest/HttpJsonFunction.java
@@ -44,7 +44,7 @@ import io.camunda.connector.http.rest.model.HttpJsonRequest;
     },
     type = HttpJsonFunction.TYPE)
 @ElementTemplate(
-    engineVersion = "^8.9",
+    engineVersion = "^8.10",
     id = "io.camunda.connectors.HttpJson.v2",
     name = "REST Outbound Connector",
     description = "Invoke REST API",
@@ -64,7 +64,7 @@ import io.camunda.connector.http.rest.model.HttpJsonRequest;
     },
     inputDataClass = HttpJsonRequest.class,
     outputDataClass = HttpCommonResult.class,
-    version = 13,
+    version = 14,
     defaultResultExpression =
         "{\n"
             + "  myResponseBody: response.body\n"

--- a/connectors/microsoft/mail/element-templates/versioned/microsoft-office365-mail-connector-4.json
+++ b/connectors/microsoft/mail/element-templates/versioned/microsoft-office365-mail-connector-4.json
@@ -16,7 +16,7 @@
     "email notification"
   ],
   "documentationRef": "https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/microsoft-o365-mail/",
-  "version": 5,
+  "version": 4,
   "engines": {
     "camunda": "^8.4"
   },
@@ -138,10 +138,6 @@
         {
           "name": "OAuth 2.0",
           "value": "oauth-client-credentials-flow"
-        },
-        {
-          "name": "Refresh token",
-          "value": "oauth-refresh-token"
         }
       ]
     },
@@ -255,117 +251,6 @@
       "condition": {
         "property": "authentication.type",
         "equals": "oauth-client-credentials-flow",
-        "type": "simple"
-      },
-      "type": "Hidden"
-    },
-    {
-      "id": "authentication.refreshToken.tenantId",
-      "label": "Tenant ID",
-      "description": "The tenant ID of the Microsoft Entra (Azure AD) application",
-      "optional": false,
-      "constraints": {
-        "notEmpty": true
-      },
-      "feel": "optional",
-      "group": "authentication",
-      "binding": {
-        "name": "refreshToken_tenantId",
-        "type": "zeebe:input"
-      },
-      "condition": {
-        "property": "authentication.type",
-        "equals": "oauth-refresh-token",
-        "type": "simple"
-      },
-      "type": "String"
-    },
-    {
-      "id": "authentication.refreshToken.clientId",
-      "label": "Client ID",
-      "description": "The client ID of the application",
-      "optional": false,
-      "constraints": {
-        "notEmpty": true
-      },
-      "feel": "optional",
-      "group": "authentication",
-      "binding": {
-        "name": "authentication.clientId",
-        "type": "zeebe:input"
-      },
-      "condition": {
-        "property": "authentication.type",
-        "equals": "oauth-refresh-token",
-        "type": "simple"
-      },
-      "type": "String"
-    },
-    {
-      "id": "authentication.refreshToken.clientSecret",
-      "label": "Client secret",
-      "description": "The secret value of the Azure AD application; optional for public clients",
-      "optional": true,
-      "feel": "optional",
-      "group": "authentication",
-      "binding": {
-        "name": "authentication.clientSecret",
-        "type": "zeebe:input"
-      },
-      "condition": {
-        "property": "authentication.type",
-        "equals": "oauth-refresh-token",
-        "type": "simple"
-      },
-      "type": "String"
-    },
-    {
-      "id": "authentication.refreshToken.token",
-      "label": "Refresh token",
-      "description": "The OAuth 2.0 refresh token used to obtain a new access token",
-      "optional": false,
-      "constraints": {
-        "notEmpty": true
-      },
-      "feel": "optional",
-      "group": "authentication",
-      "binding": {
-        "name": "authentication.refreshToken",
-        "type": "zeebe:input"
-      },
-      "condition": {
-        "property": "authentication.type",
-        "equals": "oauth-refresh-token",
-        "type": "simple"
-      },
-      "type": "String"
-    },
-    {
-      "id": "authentication.refreshToken.oauthTokenEndpoint",
-      "value": "=\"https://login.microsoftonline.com/\"+refreshToken_tenantId+\"/oauth2/v2.0/token\"",
-      "group": "authentication",
-      "binding": {
-        "name": "authentication.oauthTokenEndpoint",
-        "type": "zeebe:input"
-      },
-      "condition": {
-        "property": "authentication.type",
-        "equals": "oauth-refresh-token",
-        "type": "simple"
-      },
-      "type": "Hidden"
-    },
-    {
-      "id": "authentication.refreshToken.scopes",
-      "value": "https://graph.microsoft.com/.default",
-      "group": "authentication",
-      "binding": {
-        "name": "authentication.scopes",
-        "type": "zeebe:input"
-      },
-      "condition": {
-        "property": "authentication.type",
-        "equals": "oauth-refresh-token",
         "type": "simple"
       },
       "type": "Hidden"

--- a/element-template-generator/maven-plugin/src/main/java/io/camunda/connector/generator/ElementTemplateGeneratorMojo.java
+++ b/element-template-generator/maven-plugin/src/main/java/io/camunda/connector/generator/ElementTemplateGeneratorMojo.java
@@ -340,7 +340,7 @@ public class ElementTemplateGeneratorMojo extends AbstractMojo {
           Path.of(
               this.versionedDirectory
                   + File.separator
-                  + fileName.replaceFirst(".json", "")
+                  + fileName.replaceFirst("\\.json$", "")
                   + "-"
                   + latestVersionedElementTemplate.version()
                   + ".json"));


### PR DESCRIPTION
This pull request adds support for OAuth 2.0 Refresh Token authentication to the HTTP client library and updates the GraphQL connector templates to allow users to configure this new authentication method. The implementation includes a new authentication type, request/response handling logic, error handling for common OAuth failure modes, and comprehensive tests to ensure correct behavior.

**OAuth 2.0 Refresh Token Authentication Support**

* Introduced the new `OAuthRefreshTokenAuthentication` type, including its data model and logic for building the refresh token grant request body. (`OAuthRefreshTokenAuthentication.java`)
* Registered the new authentication type in the polymorphic `HttpAuthentication` hierarchy. (`HttpAuthentication.java`)

**Request and Token Handling**

* Implemented methods in `OAuthService` to create OAuth refresh token requests and extract tokens from responses, with detailed error handling for `invalid_grant`, `interaction_required`, and other OAuth errors. (`OAuthService.java`) [[1]](diffhunk://#diff-866507a5194cea5c19755c78048f6643aba0e5a9ec7cdda28fad0e0eb5431a6eR85-R150) [[2]](diffhunk://#diff-866507a5194cea5c19755c78048f6643aba0e5a9ec7cdda28fad0e0eb5431a6eR28)
* Updated the request builder to support the new authentication type, including fetching and applying access tokens obtained via the refresh token flow. (`ApacheRequestAuthenticationBuilder.java`) [[1]](diffhunk://#diff-0ab80d4506626ac2453209d6d4d8a25f1d40e5ffda45a20c3d23b43206c2789eR57-R60) [[2]](diffhunk://#diff-0ab80d4506626ac2453209d6d4d8a25f1d40e5ffda45a20c3d23b43206c2789eR83-R91)
* Added new constants for OAuth error fields and refresh token parameters. (`OAuthConstants.java`)

**Connector Template Updates**

* Extended both the standard and hybrid GraphQL connector element templates to allow configuration of OAuth 2.0 Refresh Token authentication, including all required fields (token endpoint, client ID, client secret, refresh token, and scopes). (`graphql-outbound-connector.json`, `graphql-outbound-connector-hybrid.json`) [[1]](diffhunk://#diff-bcb6d1e0f8c0285d249e3db0783b89292a2c3dce54a6ce8d8dbc466b781f9b8fR78-R80) [[2]](diffhunk://#diff-bcb6d1e0f8c0285d249e3db0783b89292a2c3dce54a6ce8d8dbc466b781f9b8fR328-R425) [[3]](diffhunk://#diff-6ac4bf8280fdc84a5f06d2503ce1f58be62e6a533698cb1e8bf60a3d932041feR83-R85) [[4]](diffhunk://#diff-6ac4bf8280fdc84a5f06d2503ce1f58be62e6a533698cb1e8bf60a3d932041feR333-R430)

**Testing**

* Added a comprehensive test suite for the OAuth refresh token flow, covering request construction, successful token extraction, and error handling for common OAuth error responses. (`OAuthRefreshTokenServiceTest.java`)