### PR TITLE
feat(agentic-ai): add model name to chat response metadata serialization

### DIFF
--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/ChatMessageConverterImpl.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/ChatMessageConverterImpl.java
@@ -162,6 +162,9 @@ public class ChatMessageConverterImpl implements ChatMessageConverter {
     Optional.ofNullable(chatResponseMetadata.id())
         .filter(StringUtils::isNotBlank)
         .ifPresent(id -> metadata.put("id", id));
+    Optional.ofNullable(chatResponseMetadata.modelName())
+        .filter(StringUtils::isNotBlank)
+        .ifPresent(model -> metadata.put("model", model));
     Optional.ofNullable(chatResponseMetadata.finishReason())
         .ifPresent(finishReason -> metadata.put("finishReason", finishReason.name()));
 

--- a/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/ChatMessageConverterTest.java
+++ b/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/ChatMessageConverterTest.java
@@ -204,6 +204,7 @@ class ChatMessageConverterTest {
     final var chatResponseMetadata =
         ChatResponseMetadata.builder()
             .id("chatcmpl-123")
+            .modelName("my-model")
             .finishReason(FinishReason.STOP)
             .tokenUsage(new TokenUsage(10, 20))
             .build();
@@ -234,6 +235,7 @@ class ChatMessageConverterTest {
         .asInstanceOf(InstanceOfAssertFactories.MAP)
         .containsExactly(
             entry("id", "chatcmpl-123"),
+            entry("model", "my-model"),
             entry("finishReason", "STOP"),
             entry(
                 "tokenUsage",
@@ -247,6 +249,7 @@ class ChatMessageConverterTest {
     final var chatResponseMetadata =
         OpenAiChatResponseMetadata.builder()
             .id("chatcmpl-123")
+            .modelName("gpt-4o")
             .finishReason(FinishReason.TOOL_EXECUTION)
             .tokenUsage(
                 OpenAiTokenUsage.builder()
@@ -281,9 +284,36 @@ class ChatMessageConverterTest {
         .asInstanceOf(InstanceOfAssertFactories.MAP)
         .containsExactly(
             entry("id", "chatcmpl-123"),
+            entry("model", "gpt-4o"),
             entry("finishReason", "TOOL_EXECUTION"),
             entry("tokenUsage", expectedTokenUsage))
         .doesNotContainKeys("serviceTier", "rawHttpResponse");
+  }
+
+  @Test
+  void toAssistantMessage_omitsModelFromFrameworkMetadata_whenNotSet() {
+    final var aiMessage = AiMessage.builder().text("AI response").build();
+
+    final var chatResponseMetadata =
+        ChatResponseMetadata.builder()
+            .id("chatcmpl-123")
+            .finishReason(FinishReason.STOP)
+            .tokenUsage(new TokenUsage(10, 20))
+            .build();
+
+    final var chatResponse =
+        new ChatResponse.Builder().aiMessage(aiMessage).metadata(chatResponseMetadata).build();
+
+    final var result = chatMessageConverter.toAssistantMessage(chatResponse);
+
+    assertThat(result.metadata().get("framework"))
+        .asInstanceOf(InstanceOfAssertFactories.MAP)
+        .containsExactly(
+            entry("id", "chatcmpl-123"),
+            entry("finishReason", "STOP"),
+            entry(
+                "tokenUsage",
+                Map.of("inputTokenCount", 10, "outputTokenCount", 20, "totalTokenCount", 30)));
   }
 
   @Test
@@ -293,6 +323,7 @@ class ChatMessageConverterTest {
     final var chatResponseMetadata =
         ChatResponseMetadata.builder()
             .id("chatcmpl-123")
+            .modelName("my-model")
             .finishReason(FinishReason.CONTENT_FILTER)
             .tokenUsage(new TokenUsage(10, 0))
             .build();
@@ -309,6 +340,7 @@ class ChatMessageConverterTest {
         .asInstanceOf(InstanceOfAssertFactories.MAP)
         .containsExactly(
             entry("id", "chatcmpl-123"),
+            entry("model", "my-model"),
             entry("finishReason", "CONTENT_FILTER"),
             entry(
                 "tokenUsage",


### PR DESCRIPTION
## Description

Extracts the model name from `ChatResponseMetadata` and stores it under the `"model"` key in the `AssistantMessage` framework metadata, alongside the existing `id`, `finishReason`, and `tokenUsage` fields. The field is silently omitted when the provider does not return a model name.

## Related issues

closes #7205

## Checklist

- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest
  release, as this branch will be rebased onto main before the next release. Example backport labels:
    - `backport stable/8.8`: for changes that should be included in the next 8.8.x release.
    - **or** `backport release-8.8.7`: for changes that should be included in the specific release 8.8.7, and this
      *release has already been created*. The release branch will be merged back into stable/8.8 later, so the change
      will be included in future 8.8.x releases as well.
- [x] Tests/Integration tests for the changes have been added if applicable.
- [ ] If the change requires a documentation update, it has been added to the appropriate section in the documentation.

https://claude.ai/code/session_016yH1AMzFPX4am3V62dKePr