### PR TITLE
test(e2e): stabilize flaky agentic-ai e2e tests

### DIFF
--- a/.github/workflows/NIGHTLY_E2E.yml
+++ b/.github/workflows/NIGHTLY_E2E.yml
@@ -39,7 +39,7 @@ jobs:
   run-e2e-tests:
     name: (${{ matrix.branch }}) Nightly E2E test run
     needs: get-branches
-    runs-on: gcp-core-8-default
+    runs-on: gcp-core-4-default
     strategy:
       fail-fast: false
       matrix:
@@ -107,19 +107,19 @@ jobs:
         if: github.event_name != 'pull_request'
         run: |
           E2E_EXCLUDES=$(find connectors-e2e-test -name pom.xml -not -path '*/target/*' -printf '!%h\n' | paste -sd, -)
-          ./mvnw --batch-mode -U clean install -PcheckFormat -pl "$E2E_EXCLUDES"
+          ./mvnw -T1C --batch-mode -U clean install -PcheckFormat -pl "$E2E_EXCLUDES"
 
       # PR: build all connector modules without running tests (e2e is the only thing tested).
       - name: Build connectors without tests (PR)
         if: github.event_name == 'pull_request'
-        run: ./mvnw --batch-mode -U clean install -DskipTests
+        run: ./mvnw -T1C --batch-mode -U clean install -DskipTests
 
       # Phase 2 (both events): test the e2e-test modules against the just-built artifacts.
       # `-f connectors-e2e-test/pom.xml` makes that aggregator the reactor root so ALL its submodules
       # are tested. To narrow to just the flaky A2A tests, use
       # `-pl connectors-e2e-test/connectors-e2e-test-agentic-ai` from the repo root instead.
       - name: Test e2e-test modules
-        run: ./mvnw --batch-mode test -f connectors-e2e-test/pom.xml
+        run: ./mvnw -T1C --batch-mode test -f connectors-e2e-test/pom.xml
 
       - name: Publish Test Report
         if: always()

--- a/.github/workflows/NIGHTLY_E2E.yml
+++ b/.github/workflows/NIGHTLY_E2E.yml
@@ -168,11 +168,11 @@ jobs:
       matrix:
         branch: ${{ fromJson(needs.setup.outputs.branches) }}
         module: ${{ fromJson(needs.setup.outputs.modules) }}
-#        include:
+        include:
           # Override the runner for resource-heavy modules; all others use ubuntu-latest.
           # To add more, append entries here.
-#          - module: connectors-e2e-test-agentic-ai
-#            runner: gcp-core-8-default
+          - module: connectors-e2e-test-agentic-ai
+            runner: gcp-core-4-default
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/NIGHTLY_E2E.yml
+++ b/.github/workflows/NIGHTLY_E2E.yml
@@ -55,9 +55,6 @@ jobs:
           done | jq -R -s -c 'split("\n") | map(select(length>0))')
           echo "modules=$modules" >> $GITHUB_OUTPUT
 
-  # Build phase (per branch): build the connector modules + install the e2e-test base libraries, then
-  # hand the freshly built first-party SNAPSHOTs to the test matrix as a branch-scoped artifact. The
-  # test jobs resolve everything from this artifact and never rebuild it.
   build:
     name: (${{ matrix.branch }}) Build
     needs: setup
@@ -111,10 +108,8 @@ jobs:
              }]
           mirrors: '[{"url": "https://repository.nexus.camunda.cloud/content/groups/internal/", "id": "camunda-nexus", "mirrorOf": "*,!confluent,!shibboleth", "name": "camunda Nexus"}]'
 
-      # Non-PR (nightly/manual): build + unit-test + format-check all connector modules, EXCLUDING
-      # the connectors-e2e-test subtree (its tests run in the test matrix). The exclusion list is
-      # generated from the pom layout so new e2e modules are covered automatically — excluding only
-      # the aggregator (`-pl !connectors-e2e-test`) does NOT drop its submodules from the reactor.
+      # Non-PR (nightly/manual): build + unit-test + format-check all connector modules
+      # without the connectors-e2e-test subtree
       - name: Build connectors with tests (non-PR)
         if: github.event_name != 'pull_request'
         run: |
@@ -127,8 +122,6 @@ jobs:
         run: ./mvnw --batch-mode -U clean install -DskipTests
 
       # Install the e2e-test base libraries so the test matrix can resolve them from ~/.m2 without
-      # rebuilding: connectors-e2e-test-base (test dependency of every module) and the AWS test-jar
-      # base (connectors-e2e-test-aws-base). Idempotent for the PR path, which already installs them.
       - name: Build e2e-test base libraries
         run: |
           ./mvnw --batch-mode install -DskipTests -f connectors-e2e-test/pom.xml \
@@ -142,11 +135,7 @@ jobs:
         env:
           BRANCH: ${{ matrix.branch }}
 
-      # Hand the freshly built first-party SNAPSHOTs (connectors + e2e base) to the test matrix.
-      # Name is scoped to run_id only (NOT run_attempt): re-running a single failed test job bumps
-      # run_attempt but does NOT re-run build, so the test job must still find the artifact built on
-      # the first attempt. overwrite:true lets "re-run all jobs" (build re-runs under the same run_id)
-      # replace the artifact instead of failing on a duplicate name.
+      # Hand the built artifacts (connectors + e2e base) to the test matrix.
       - name: Upload first-party artifacts
         uses: actions/upload-artifact@v7
         with:
@@ -157,8 +146,7 @@ jobs:
           overwrite: true
 
   # Test phase (matrix: branch x module): each e2e-test module runs in its own job, in isolation, so
-  # one flaky/slow module no longer blocks the others. Defaults to ubuntu-latest; resource-heavy
-  # modules override the runner via matrix.include.
+  # Defaults to ubuntu-latest; resource-heavy modules override the runner via matrix.include.
   run-e2e-tests:
     name: ${{ matrix.module }} E2E tests
     needs: [ setup, build ]
@@ -220,8 +208,6 @@ jobs:
         with:
           node-version: '24'
 
-      # element-templates-cli is invoked at runtime by BpmnFile.java (in connectors-e2e-test-base)
-      # to apply element templates during the tests, so it must be installed on the test runner.
       - name: Install element templates CLI
         run: npm install --global element-templates-cli@$(jq -r '.devDependencies["element-templates-cli"]' .github/workflows/package.json)
 

--- a/.github/workflows/NIGHTLY_E2E.yml
+++ b/.github/workflows/NIGHTLY_E2E.yml
@@ -156,11 +156,11 @@ jobs:
       matrix:
         branch: ${{ fromJson(needs.setup.outputs.branches) }}
         module: ${{ fromJson(needs.setup.outputs.modules) }}
-#        include:
-#          # Override the runner for resource-heavy modules; all others use ubuntu-latest.
-#          # To add more, append entries here.
-#          - module: connectors-e2e-test-agentic-ai
-#            runner: gcp-core-8-default
+        include:
+          # Override the runner for resource-heavy modules; all others use ubuntu-latest.
+          # To add more, append entries here.
+          - module: connectors-e2e-test-agentic-ai
+            runner: gcp-core-8-default
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/NIGHTLY_E2E.yml
+++ b/.github/workflows/NIGHTLY_E2E.yml
@@ -96,8 +96,30 @@ jobs:
       - name: Install element templates CLI
         run: npm install --global element-templates-cli@$(jq -r '.devDependencies["element-templates-cli"]' .github/workflows/package.json)
 
-      - name: Build Connectors
-        run: ./mvnw --batch-mode -U clean test -PcheckFormat
+      # Build is split into two independent phases: (1) build the connector modules, (2) run the
+      # e2e-test modules against that build (sibling artifacts resolved from ~/.m2).
+      #
+      # Non-PR (nightly/manual): build + unit-test + format-check all connector modules, EXCLUDING
+      # the connectors-e2e-test subtree (its tests run in phase 2). The exclusion list is generated
+      # from the pom layout so new e2e modules are covered automatically — excluding only the
+      # aggregator (`-pl !connectors-e2e-test`) does NOT drop its submodules from the reactor.
+      - name: Build connectors with tests (non-PR)
+        if: github.event_name != 'pull_request'
+        run: |
+          E2E_EXCLUDES=$(find connectors-e2e-test -name pom.xml -not -path '*/target/*' -printf '!%h\n' | paste -sd, -)
+          ./mvnw --batch-mode -U clean install -PcheckFormat -pl "$E2E_EXCLUDES"
+
+      # PR: build all connector modules without running tests (e2e is the only thing tested).
+      - name: Build connectors without tests (PR)
+        if: github.event_name == 'pull_request'
+        run: ./mvnw --batch-mode -U clean install -DskipTests
+
+      # Phase 2 (both events): test the e2e-test modules against the just-built artifacts.
+      # `-f connectors-e2e-test/pom.xml` makes that aggregator the reactor root so ALL its submodules
+      # are tested. To narrow to just the flaky A2A tests, use
+      # `-pl connectors-e2e-test/connectors-e2e-test-agentic-ai` from the repo root instead.
+      - name: Test e2e-test modules
+        run: ./mvnw --batch-mode test -f connectors-e2e-test/pom.xml
 
       - name: Publish Test Report
         if: always()
@@ -117,7 +139,11 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: surefire-reports-${{ steps.sanitize.outputs.branch }}-${{ github.run_id }}-${{ github.run_attempt }}
-          path: '**/target/surefire-reports/*.xml'
+          # *-output.txt holds the redirected test stdout (parent pom sets redirectTestOutputToFile=true);
+          # the XML <system-out> is empty, so upload the txt files to retain test logs from CI runs.
+          path: |
+            **/target/surefire-reports/*.xml
+            **/target/surefire-reports/*-output.txt
 
       - name: Send Slack notification on failure
         if: failure() && (matrix.branch == 'main' || startsWith(matrix.branch, 'stable/'))

--- a/.github/workflows/NIGHTLY_E2E.yml
+++ b/.github/workflows/NIGHTLY_E2E.yml
@@ -61,7 +61,7 @@ jobs:
   build:
     name: (${{ matrix.branch }}) Build
     needs: setup
-    runs-on: gcp-core-8-default
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
@@ -163,11 +163,11 @@ jobs:
       matrix:
         branch: ${{ fromJson(needs.setup.outputs.branches) }}
         module: ${{ fromJson(needs.setup.outputs.modules) }}
-        include:
+#        include:
           # Override the runner for resource-heavy modules; all others use ubuntu-latest.
           # To add more, append entries here.
-          - module: connectors-e2e-test-agentic-ai
-            runner: gcp-core-8-default
+#          - module: connectors-e2e-test-agentic-ai
+#            runner: gcp-core-8-default
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/NIGHTLY_E2E.yml
+++ b/.github/workflows/NIGHTLY_E2E.yml
@@ -39,7 +39,7 @@ jobs:
   run-e2e-tests:
     name: (${{ matrix.branch }}) Nightly E2E test run
     needs: get-branches
-    runs-on: ubuntu-latest
+    runs-on: gcp-core-8-default
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/NIGHTLY_E2E.yml
+++ b/.github/workflows/NIGHTLY_E2E.yml
@@ -172,7 +172,7 @@ jobs:
           # Override the runner for resource-heavy modules; all others use ubuntu-latest.
           # To add more, append entries here.
           - module: connectors-e2e-test-agentic-ai
-            runner: gcp-core-4-default
+            runner: gcp-core-8-default
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/NIGHTLY_E2E.yml
+++ b/.github/workflows/NIGHTLY_E2E.yml
@@ -155,7 +155,7 @@ jobs:
   # one flaky/slow module no longer blocks the others. Defaults to ubuntu-latest; resource-heavy
   # modules override the runner via matrix.include.
   run-e2e-tests:
-    name: (${{ matrix.branch }}) ${{ matrix.module }}
+    name: ${{ matrix.module }} E2E tests
     needs: [ setup, build ]
     runs-on: ${{ matrix.runner || 'ubuntu-latest' }}
     strategy:

--- a/.github/workflows/NIGHTLY_E2E.yml
+++ b/.github/workflows/NIGHTLY_E2E.yml
@@ -250,6 +250,8 @@ jobs:
       - name: Publish Test Report
         if: always()
         uses: scacap/action-surefire-report@v1
+        with:
+          check_name: Tests (${{ matrix.branch }} / ${{ matrix.module }})
 
       - name: Upload detailed surefire reports
         if: always()

--- a/.github/workflows/NIGHTLY_E2E.yml
+++ b/.github/workflows/NIGHTLY_E2E.yml
@@ -143,13 +143,18 @@ jobs:
           BRANCH: ${{ matrix.branch }}
 
       # Hand the freshly built first-party SNAPSHOTs (connectors + e2e base) to the test matrix.
+      # Name is scoped to run_id only (NOT run_attempt): re-running a single failed test job bumps
+      # run_attempt but does NOT re-run build, so the test job must still find the artifact built on
+      # the first attempt. overwrite:true lets "re-run all jobs" (build re-runs under the same run_id)
+      # replace the artifact instead of failing on a duplicate name.
       - name: Upload first-party artifacts
         uses: actions/upload-artifact@v7
         with:
-          name: m2-firstparty-${{ steps.sanitize.outputs.branch }}-${{ github.run_id }}-${{ github.run_attempt }}
+          name: m2-firstparty-${{ steps.sanitize.outputs.branch }}-${{ github.run_id }}
           path: ~/.m2/repository/io/camunda/connector
           retention-days: 1
           include-hidden-files: true
+          overwrite: true
 
   # Test phase (matrix: branch x module): each e2e-test module runs in its own job, in isolation, so
   # one flaky/slow module no longer blocks the others. Defaults to ubuntu-latest; resource-heavy
@@ -234,7 +239,7 @@ jobs:
       - name: Download first-party artifacts
         uses: actions/download-artifact@v7
         with:
-          name: m2-firstparty-${{ steps.sanitize.outputs.branch }}-${{ github.run_id }}-${{ github.run_attempt }}
+          name: m2-firstparty-${{ steps.sanitize.outputs.branch }}-${{ github.run_id }}
           path: ~/.m2/repository/io/camunda/connector
 
       # Run only this module's tests. No -am: base/connector SNAPSHOTs come from the downloaded

--- a/.github/workflows/NIGHTLY_E2E.yml
+++ b/.github/workflows/NIGHTLY_E2E.yml
@@ -156,11 +156,11 @@ jobs:
       matrix:
         branch: ${{ fromJson(needs.setup.outputs.branches) }}
         module: ${{ fromJson(needs.setup.outputs.modules) }}
-        include:
-          # Override the runner for resource-heavy modules; all others use ubuntu-latest.
-          # To add more, append entries here.
-          - module: connectors-e2e-test-agentic-ai
-            runner: gcp-core-8-default
+#        include:
+#          # Override the runner for resource-heavy modules; all others use ubuntu-latest.
+#          # To add more, append entries here.
+#          - module: connectors-e2e-test-agentic-ai
+#            runner: gcp-core-8-default
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/NIGHTLY_E2E.yml
+++ b/.github/workflows/NIGHTLY_E2E.yml
@@ -107,7 +107,7 @@ jobs:
         if: github.event_name != 'pull_request'
         run: |
           E2E_EXCLUDES=$(find connectors-e2e-test -name pom.xml -not -path '*/target/*' -printf '!%h\n' | paste -sd, -)
-          ./mvnw -T1C --batch-mode -U clean install -PcheckFormat -pl "$E2E_EXCLUDES"
+          ./mvnw --batch-mode -U clean install -PcheckFormat -pl "$E2E_EXCLUDES"
 
       # PR: build all connector modules without running tests (e2e is the only thing tested).
       - name: Build connectors without tests (PR)
@@ -119,7 +119,7 @@ jobs:
       # are tested. To narrow to just the flaky A2A tests, use
       # `-pl connectors-e2e-test/connectors-e2e-test-agentic-ai` from the repo root instead.
       - name: Test e2e-test modules
-        run: ./mvnw -T1C --batch-mode test -f connectors-e2e-test/pom.xml
+        run: ./mvnw --batch-mode test -f connectors-e2e-test/pom.xml
 
       - name: Publish Test Report
         if: always()

--- a/.github/workflows/NIGHTLY_E2E.yml
+++ b/.github/workflows/NIGHTLY_E2E.yml
@@ -39,7 +39,7 @@ jobs:
   run-e2e-tests:
     name: (${{ matrix.branch }}) Nightly E2E test run
     needs: get-branches
-    runs-on: gcp-core-4-default
+    runs-on: gcp-core-8-default
     strategy:
       fail-fast: false
       matrix:
@@ -112,7 +112,7 @@ jobs:
       # PR: build all connector modules without running tests (e2e is the only thing tested).
       - name: Build connectors without tests (PR)
         if: github.event_name == 'pull_request'
-        run: ./mvnw -T1C --batch-mode -U clean install -DskipTests
+        run: ./mvnw --batch-mode -U clean install -DskipTests
 
       # Phase 2 (both events): test the e2e-test modules against the just-built artifacts.
       # `-f connectors-e2e-test/pom.xml` makes that aggregator the reactor root so ALL its submodules

--- a/.github/workflows/NIGHTLY_E2E.yml
+++ b/.github/workflows/NIGHTLY_E2E.yml
@@ -9,19 +9,22 @@ on:
 
 jobs:
 
-  get-branches:
+  setup:
     runs-on: ubuntu-latest
     # Only run if scheduled/manual OR if the 'e2e-tests' label exists on a non-fork PR
     if: |
-      github.event_name != 'pull_request' || 
-      (github.event.pull_request.head.repo.fork == false && 
+      github.event_name != 'pull_request' ||
+      (github.event.pull_request.head.repo.fork == false &&
        (github.event.action == 'labeled' && github.event.label.name == 'e2e-tests') ||
        (github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'e2e-tests')))
     outputs:
-      branches: ${{ steps.set-matrix.outputs.branches }}
+      branches: ${{ steps.set-branches.outputs.branches }}
+      modules: ${{ steps.set-modules.outputs.modules }}
     steps:
+      - uses: actions/checkout@v6
+
       - name: Fetch stable branches
-        id: set-matrix
+        id: set-branches
         run: |
           if [ "${{ github.event_name }}" == "pull_request" ]; then
             # For PR, only test the PR's head ref
@@ -36,14 +39,33 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  run-e2e-tests:
-    name: (${{ matrix.branch }}) Nightly E2E test run
-    needs: get-branches
+      # Discover the e2e-test modules to run, one matrix entry per module. Leaf poms with `jar`
+      # packaging are test modules; aggregators (`pom` packaging) and `*-base` shared libraries are
+      # excluded. Paths are emitted relative to connectors-e2e-test/pom.xml so they can be passed
+      # directly to `-pl ... -f connectors-e2e-test/pom.xml`. New modules are picked up automatically.
+      - name: Discover e2e-test modules
+        id: set-modules
+        run: |
+          modules=$(find connectors-e2e-test -name pom.xml -not -path '*/target/*' | while read -r p; do
+            d=$(dirname "$p"); base=$(basename "$d")
+            pkg=$(grep -m1 -oP '(?<=<packaging>)[^<]+' "$p" || echo jar)
+            [ "$pkg" = "pom" ] && continue
+            case "$base" in *-base) continue;; esac
+            echo "${d#connectors-e2e-test/}"
+          done | jq -R -s -c 'split("\n") | map(select(length>0))')
+          echo "modules=$modules" >> $GITHUB_OUTPUT
+
+  # Build phase (per branch): build the connector modules + install the e2e-test base libraries, then
+  # hand the freshly built first-party SNAPSHOTs to the test matrix as a branch-scoped artifact. The
+  # test jobs resolve everything from this artifact and never rebuild it.
+  build:
+    name: (${{ matrix.branch }}) Build
+    needs: setup
     runs-on: gcp-core-8-default
     strategy:
       fail-fast: false
       matrix:
-        branch: ${{ fromJson(needs.get-branches.outputs.branches) }}
+        branch: ${{ fromJson(needs.setup.outputs.branches) }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -89,20 +111,10 @@ jobs:
              }]
           mirrors: '[{"url": "https://repository.nexus.camunda.cloud/content/groups/internal/", "id": "camunda-nexus", "mirrorOf": "*,!confluent,!shibboleth", "name": "camunda Nexus"}]'
 
-      - uses: actions/setup-node@v6
-        with:
-          node-version: '24'
-
-      - name: Install element templates CLI
-        run: npm install --global element-templates-cli@$(jq -r '.devDependencies["element-templates-cli"]' .github/workflows/package.json)
-
-      # Build is split into two independent phases: (1) build the connector modules, (2) run the
-      # e2e-test modules against that build (sibling artifacts resolved from ~/.m2).
-      #
       # Non-PR (nightly/manual): build + unit-test + format-check all connector modules, EXCLUDING
-      # the connectors-e2e-test subtree (its tests run in phase 2). The exclusion list is generated
-      # from the pom layout so new e2e modules are covered automatically — excluding only the
-      # aggregator (`-pl !connectors-e2e-test`) does NOT drop its submodules from the reactor.
+      # the connectors-e2e-test subtree (its tests run in the test matrix). The exclusion list is
+      # generated from the pom layout so new e2e modules are covered automatically — excluding only
+      # the aggregator (`-pl !connectors-e2e-test`) does NOT drop its submodules from the reactor.
       - name: Build connectors with tests (non-PR)
         if: github.event_name != 'pull_request'
         run: |
@@ -114,19 +126,15 @@ jobs:
         if: github.event_name == 'pull_request'
         run: ./mvnw --batch-mode -U clean install -DskipTests
 
-      # Phase 2 (both events): test the e2e-test modules against the just-built artifacts.
-      # `-f connectors-e2e-test/pom.xml` makes that aggregator the reactor root so ALL its submodules
-      # are tested. To narrow to just the flaky A2A tests, use
-      # `-pl connectors-e2e-test/connectors-e2e-test-agentic-ai` from the repo root instead.
-      - name: Test e2e-test modules
-        run: ./mvnw --batch-mode test -f connectors-e2e-test/pom.xml
-
-      - name: Publish Test Report
-        if: always()
-        uses: scacap/action-surefire-report@v1
+      # Install the e2e-test base libraries so the test matrix can resolve them from ~/.m2 without
+      # rebuilding: connectors-e2e-test-base (test dependency of every module) and the AWS test-jar
+      # base (connectors-e2e-test-aws-base). Idempotent for the PR path, which already installs them.
+      - name: Build e2e-test base libraries
+        run: |
+          ./mvnw --batch-mode install -DskipTests -f connectors-e2e-test/pom.xml \
+            -pl connectors-e2e-test-base,connectors-e2e-test-aws/connectors-e2e-test-aws-base
 
       - name: Sanitize branch name for artifact
-        if: always()
         id: sanitize
         run: |
           SANITIZED="${BRANCH//\//-}"
@@ -134,11 +142,115 @@ jobs:
         env:
           BRANCH: ${{ matrix.branch }}
 
+      # Hand the freshly built first-party SNAPSHOTs (connectors + e2e base) to the test matrix.
+      - name: Upload first-party artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: m2-firstparty-${{ steps.sanitize.outputs.branch }}-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ~/.m2/repository/io/camunda/connector
+          retention-days: 1
+          include-hidden-files: true
+
+  # Test phase (matrix: branch x module): each e2e-test module runs in its own job, in isolation, so
+  # one flaky/slow module no longer blocks the others. Defaults to ubuntu-latest; resource-heavy
+  # modules override the runner via matrix.include.
+  run-e2e-tests:
+    name: (${{ matrix.branch }}) ${{ matrix.module }}
+    needs: [ setup, build ]
+    runs-on: ${{ matrix.runner || 'ubuntu-latest' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        branch: ${{ fromJson(needs.setup.outputs.branches) }}
+        module: ${{ fromJson(needs.setup.outputs.modules) }}
+        include:
+          # Override the runner for resource-heavy modules; all others use ubuntu-latest.
+          # To add more, append entries here.
+          - module: connectors-e2e-test-agentic-ai
+            runner: gcp-core-8-default
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ matrix.branch }}
+
+      - name: Import Secrets
+        id: secrets
+        uses: hashicorp/vault-action@v4.0.0
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          exportEnv: false # we rely on step outputs, no need for environment variables
+          secrets: |
+            secret/data/products/connectors/ci/nexus USER | CI_NEXUS_USR;
+            secret/data/products/connectors/ci/nexus PASSWORD | CI_NEXUS_PSW;
+
+      - name: Restore cache
+        uses: actions/cache@v5
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+
+      - uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: '21.0.9'
+
+      - name: 'Create settings.xml'
+        uses: s4u/maven-settings-action@v4.0.0
+        with:
+          githubServer: false
+          servers: |
+            [{
+               "id": "camunda-nexus",
+               "username": "${{ steps.secrets.outputs.CI_NEXUS_USR }}",
+               "password": "${{ steps.secrets.outputs.CI_NEXUS_PSW }}"
+             }]
+          mirrors: '[{"url": "https://repository.nexus.camunda.cloud/content/groups/internal/", "id": "camunda-nexus", "mirrorOf": "*,!confluent,!shibboleth", "name": "camunda Nexus"}]'
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+
+      # element-templates-cli is invoked at runtime by BpmnFile.java (in connectors-e2e-test-base)
+      # to apply element templates during the tests, so it must be installed on the test runner.
+      - name: Install element templates CLI
+        run: npm install --global element-templates-cli@$(jq -r '.devDependencies["element-templates-cli"]' .github/workflows/package.json)
+
+      - name: Sanitize branch name for artifact
+        id: sanitize
+        run: |
+          echo "branch=${BRANCH//\//-}" >> $GITHUB_OUTPUT
+          echo "module=${MODULE//\//-}" >> $GITHUB_OUTPUT
+        env:
+          BRANCH: ${{ matrix.branch }}
+          MODULE: ${{ matrix.module }}
+
+      # Restore the first-party SNAPSHOTs built by the matching build job; the test run resolves
+      # connectors + e2e base from here and does not rebuild them.
+      - name: Download first-party artifacts
+        uses: actions/download-artifact@v7
+        with:
+          name: m2-firstparty-${{ steps.sanitize.outputs.branch }}-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ~/.m2/repository/io/camunda/connector
+
+      # Run only this module's tests. No -am: base/connector SNAPSHOTs come from the downloaded
+      # artifact, so nothing upstream is rebuilt.
+      - name: Test e2e module
+        run: ./mvnw --batch-mode test -pl "${{ matrix.module }}" -f connectors-e2e-test/pom.xml
+
+      - name: Publish Test Report
+        if: always()
+        uses: scacap/action-surefire-report@v1
+
       - name: Upload detailed surefire reports
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: surefire-reports-${{ steps.sanitize.outputs.branch }}-${{ github.run_id }}-${{ github.run_attempt }}
+          name: surefire-reports-${{ steps.sanitize.outputs.branch }}-${{ steps.sanitize.outputs.module }}-${{ github.run_id }}-${{ github.run_attempt }}
           # *-output.txt holds the redirected test stdout (parent pom sets redirectTestOutputToFile=true);
           # the XML <system-out> is empty, so upload the txt files to retain test logs from CI runs.
           path: |
@@ -154,5 +266,5 @@ jobs:
           payload: |
             {
               "channel": ${{ secrets.CONNECTORS_SUPPORT_SLACK_CHANNEL_ID }},
-              "text": ":alarm: ${{ secrets.CONNECTORS_MEDIC_SLACK_GROUP_ID }} E2E test run failed on branch `${{ matrix.branch}}`.\nCheck details: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+              "text": ":alarm: ${{ secrets.CONNECTORS_MEDIC_SLACK_GROUP_ID }} E2E test run failed on branch `${{ matrix.branch }}` for module `${{ matrix.module }}`.\nCheck details: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
             }

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/BaseAgenticAiTest.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/BaseAgenticAiTest.java
@@ -98,6 +98,22 @@ public abstract class BaseAgenticAiTest {
     return zeebeTest;
   }
 
+  protected ZeebeTest awaitActiveIncidents(ZeebeTest zeebeTest) {
+    return awaitActiveIncidents(zeebeTest, Duration.ofSeconds(30));
+  }
+
+  protected ZeebeTest awaitActiveIncidents(ZeebeTest zeebeTest, Duration timeout) {
+    return zeebeTest.waitForActiveIncidents(timeout);
+  }
+
+  protected ZeebeTest awaitProcessCompletion(ZeebeTest zeebeTest) {
+    return awaitProcessCompletion(zeebeTest, Duration.ofSeconds(30));
+  }
+
+  protected ZeebeTest awaitProcessCompletion(ZeebeTest zeebeTest, Duration timeout) {
+    return zeebeTest.waitForProcessCompletion(timeout);
+  }
+
   protected void assertIncident(ZeebeTest zeebeTest, ThrowingConsumer<Incident> assertion) {
     final var incidents =
         camundaClient

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/BaseAgenticAiTest.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/BaseAgenticAiTest.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.response.ProcessInstanceEvent;
 import io.camunda.client.api.search.response.Incident;
+import io.camunda.connector.e2e.ClusterStateDumpExtension;
 import io.camunda.connector.e2e.ZeebeTest;
 import io.camunda.connector.e2e.app.TestConnectorRuntimeApplication;
 import io.camunda.connector.runtime.annotation.ConnectorsObjectMapper;
@@ -35,6 +36,7 @@ import java.time.Duration;
 import java.util.Map;
 import java.util.function.Supplier;
 import org.assertj.core.api.ThrowingConsumer;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -51,6 +53,7 @@ import org.springframework.core.io.ResourceLoader;
     },
     webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @CamundaSpringProcessTest
+@ExtendWith(ClusterStateDumpExtension.class)
 public abstract class BaseAgenticAiTest {
   @Autowired protected CamundaClient camundaClient;
   @Autowired @ConnectorsObjectMapper protected ObjectMapper objectMapper;

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/TestUtil.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/TestUtil.java
@@ -31,6 +31,7 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import org.apache.commons.collections4.MapUtils;
+import org.awaitility.Awaitility;
 
 public final class TestUtil {
 
@@ -63,7 +64,14 @@ public final class TestUtil {
   }
 
   public static void waitForElementActivation(ZeebeTest zeebeTest, String elementId) {
-    CamundaAssert.assertThat(zeebeTest.getProcessInstanceEvent()).hasActiveElement(elementId, 1);
+    Awaitility.with()
+        .pollInSameThread()
+        .await()
+        .atMost(20, TimeUnit.SECONDS)
+        .untilAsserted(
+            () ->
+                CamundaAssert.assertThat(zeebeTest.getProcessInstanceEvent())
+                    .hasActiveElement(elementId, 1));
   }
 
   /**

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/TestUtil.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/TestUtil.java
@@ -20,6 +20,9 @@ import io.camunda.connector.e2e.ZeebeTest;
 import io.camunda.connector.e2e.inbound.InboundConnectorTestConfiguration.InboundConnectorTestHelper;
 import io.camunda.connector.runtime.inbound.importer.ImportSchedulers;
 import io.camunda.process.test.api.CamundaAssert;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.model.bpmn.instance.IntermediateCatchEvent;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeProperties;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
@@ -28,7 +31,6 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import org.apache.commons.collections4.MapUtils;
-import org.awaitility.Awaitility;
 
 public final class TestUtil {
 
@@ -61,14 +63,7 @@ public final class TestUtil {
   }
 
   public static void waitForElementActivation(ZeebeTest zeebeTest, String elementId) {
-    Awaitility.with()
-        .pollInSameThread()
-        .await()
-        .atMost(20, TimeUnit.SECONDS)
-        .untilAsserted(
-            () ->
-                CamundaAssert.assertThat(zeebeTest.getProcessInstanceEvent())
-                    .hasActiveElement(elementId, 1));
+    CamundaAssert.assertThat(zeebeTest.getProcessInstanceEvent()).hasActiveElement(elementId, 1);
   }
 
   /**
@@ -88,5 +83,23 @@ public final class TestUtil {
     waitForElementActivation(zeebeTest, elementId);
     importSchedulers.scheduleLatestVersionImport();
     testHelper.awaitActiveInboundExecutable(elementId);
+  }
+
+  /**
+   * Sets the {@code inbound.context} (webhook path) of the given intermediate catch event so each
+   * test can register a distinct webhook context. Without unique contexts, consecutive A2A tests
+   * sharing {@code test-webhook-id} collide in the connector runtime's webhook registry ("Context:
+   * ... already in use"), leaving the executable DOWN. No-op if the element or property is absent.
+   */
+  public static void setWebhookContext(BpmnModelInstance model, String elementId, String context) {
+    IntermediateCatchEvent catchEvent = model.getModelElementById(elementId);
+    if (catchEvent == null) {
+      return;
+    }
+    ZeebeProperties properties = catchEvent.getSingleExtensionElement(ZeebeProperties.class);
+    properties.getProperties().stream()
+        .filter(property -> "inbound.context".equals(property.getName()))
+        .findFirst()
+        .ifPresent(property -> property.setValue(context));
   }
 }

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/a2a/A2aStandaloneTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/a2a/A2aStandaloneTests.java
@@ -57,6 +57,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.context.annotation.Import;
 import org.springframework.core.io.Resource;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.TestPropertySource;
 
 @SlowTest
@@ -68,6 +69,7 @@ import org.springframework.test.context.TestPropertySource;
     })
 @Import(InboundConnectorTestConfiguration.class)
 @WireMockTest
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 public class A2aStandaloneTests extends BaseAgenticAiTest {
 
   private static final String WEBHOOK_ELEMENT_ID = "Wait_For_Completion_Webhook";

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/a2a/A2aStandaloneTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/a2a/A2aStandaloneTests.java
@@ -63,7 +63,8 @@ import org.springframework.test.context.TestPropertySource;
 @TestPropertySource(
     properties = {
       "camunda.connector.polling.enabled=true",
-      "camunda.connector.webhook.enabled=true"
+      "camunda.connector.webhook.enabled=true",
+      "camunda.connector.polling.interval=2000"
     })
 @Import(InboundConnectorTestConfiguration.class)
 @WireMockTest
@@ -104,7 +105,7 @@ public class A2aStandaloneTests extends BaseAgenticAiTest {
 
     awaitInboundConnectorReady(zeebeTest, POLLING_ELEMENT_ID);
 
-    zeebeTest.waitForProcessCompletion();
+    awaitProcessCompletion(zeebeTest);
 
     CamundaAssert.assertThat(zeebeTest.getProcessInstanceEvent())
         .hasVariableSatisfies(
@@ -143,7 +144,7 @@ public class A2aStandaloneTests extends BaseAgenticAiTest {
         extractTaskFromJsonRpc(testFileContent("travel-agent-response-completed.json").get()),
         300);
 
-    zeebeTest.waitForProcessCompletion();
+    awaitProcessCompletion(zeebeTest);
 
     assertVariablesWithWebhook(zeebeTest);
   }
@@ -192,7 +193,7 @@ public class A2aStandaloneTests extends BaseAgenticAiTest {
         Map.of("X-A2A-Notification-Token", token),
         500);
 
-    zeebeTest.waitForProcessCompletion();
+    awaitProcessCompletion(zeebeTest);
 
     assertVariablesWithWebhook(zeebeTest);
 
@@ -246,7 +247,7 @@ public class A2aStandaloneTests extends BaseAgenticAiTest {
         authHeaders,
         500);
 
-    zeebeTest.waitForProcessCompletion();
+    awaitProcessCompletion(zeebeTest);
 
     assertVariablesWithWebhook(zeebeTest);
   }
@@ -296,7 +297,7 @@ public class A2aStandaloneTests extends BaseAgenticAiTest {
             "X-HMAC-Signature", "1fe75a1c849df2aacb18952f187938b64edff510f341c9ab55df03783aee85a0"),
         500);
 
-    zeebeTest.waitForProcessCompletion();
+    awaitProcessCompletion(zeebeTest);
 
     assertVariablesWithWebhook(zeebeTest);
   }

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/a2a/A2aStandaloneTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/a2a/A2aStandaloneTests.java
@@ -57,7 +57,6 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.context.annotation.Import;
 import org.springframework.core.io.Resource;
-import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.TestPropertySource;
 
 @SlowTest
@@ -69,7 +68,6 @@ import org.springframework.test.context.TestPropertySource;
     })
 @Import(InboundConnectorTestConfiguration.class)
 @WireMockTest
-@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 public class A2aStandaloneTests extends BaseAgenticAiTest {
 
   private static final String WEBHOOK_ELEMENT_ID = "Wait_For_Completion_Webhook";

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/adhoctoolsschema/BaseAdHocToolsSchemaTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/adhoctoolsschema/BaseAdHocToolsSchemaTests.java
@@ -49,8 +49,8 @@ abstract class BaseAdHocToolsSchemaTests extends BaseAgenticAiTest {
             .apply(elementTemplate, SCHEMA_RESOLVER_ELEMENT_ID, new File(tempDir, "updated.bpmn"));
 
     final var zeebeTest =
-        createProcessInstance(updatedModel, Map.of("action", "resolveSchema"))
-            .waitForProcessCompletion();
+        awaitProcessCompletion(
+            createProcessInstance(updatedModel, Map.of("action", "resolveSchema")));
 
     CamundaAssert.assertThat(zeebeTest.getProcessInstanceEvent())
         .hasVariableNames(RESOLVED_SCHEMA_VARIABLE);

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/BaseAiAgentTest.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/BaseAiAgentTest.java
@@ -20,13 +20,15 @@ import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
 import static io.camunda.connector.e2e.agenticai.aiagent.AiAgentTestFixtures.AI_AGENT_TASK_ID;
 import static io.camunda.connector.e2e.agenticai.aiagent.AiAgentToolSpecifications.EXPECTED_TOOL_SPECIFICATIONS;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.common.ConsoleNotifier;
+import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
 import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
-import com.github.tomakehurst.wiremock.junit5.WireMockTest;
 import io.camunda.connector.agenticai.model.tool.ToolDefinition;
 import io.camunda.connector.e2e.BpmnFile;
 import io.camunda.connector.e2e.ElementTemplate;
@@ -49,13 +51,23 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Import;
 import org.springframework.core.io.Resource;
 
-@WireMockTest
 @Import(CamundaDocumentTestConfiguration.class)
 public abstract class BaseAiAgentTest extends BaseAgenticAiTest {
+
+  // Programmatic registration (not @WireMockTest) so we can set a verbose notifier that logs the
+  // request journal. We use ConsoleNotifier (stdout) because wiremock-standalone's Slf4jNotifier
+  // is bound to its shaded SLF4J and never reaches our logback.
+  @RegisterExtension
+  static WireMockExtension wireMockExtension =
+      WireMockExtension.newInstance()
+          .options(options().dynamicPort().notifier(new ConsoleNotifier(true)))
+          .configureStaticDsl(true)
+          .build();
 
   @Autowired private CamundaProcessTestContext processTestContext;
 
@@ -89,8 +101,8 @@ public abstract class BaseAiAgentTest extends BaseAgenticAiTest {
   }
 
   @BeforeEach
-  void setupWireMock(WireMockRuntimeInfo wm) {
-    wireMock = wm;
+  void setupWireMock() {
+    wireMock = wireMockExtension.getRuntimeInfo();
     // WireMock returns the content type for the YAML file as application/json, so
     // we need to override the stub manually
     WireMock.resetAllScenarios();

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/BaseAiAgentTest.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/BaseAiAgentTest.java
@@ -24,9 +24,9 @@ import static io.camunda.connector.e2e.agenticai.aiagent.AiAgentTestFixtures.AI_
 import static io.camunda.connector.e2e.agenticai.aiagent.AiAgentToolSpecifications.EXPECTED_TOOL_SPECIFICATIONS;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
 import com.github.tomakehurst.wiremock.junit5.WireMockTest;
-import io.camunda.client.api.response.ProcessInstanceEvent;
 import io.camunda.connector.agenticai.model.tool.ToolDefinition;
 import io.camunda.connector.e2e.BpmnFile;
 import io.camunda.connector.e2e.ElementTemplate;
@@ -37,11 +37,12 @@ import io.camunda.connector.e2e.agenticai.aiagent.wiremock.openai.OpenAiCompleti
 import io.camunda.connector.runtime.core.document.store.InMemoryDocumentStore;
 import io.camunda.process.test.api.CamundaAssert;
 import io.camunda.process.test.api.CamundaProcessTestContext;
-import io.camunda.process.test.api.assertions.JobSelectors;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import java.io.File;
 import java.io.IOException;
 import java.time.Duration;
+import java.util.Collections;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -58,6 +59,8 @@ public abstract class BaseAiAgentTest extends BaseAgenticAiTest {
 
   @Autowired private CamundaProcessTestContext processTestContext;
 
+  protected final LinkedList<Map<String, Object>> userFeedback = new LinkedList<>();
+
   protected final AtomicInteger userFeedbackJobWorkerCounter = new AtomicInteger(0);
 
   protected WireMockRuntimeInfo wireMock;
@@ -65,6 +68,19 @@ public abstract class BaseAiAgentTest extends BaseAgenticAiTest {
   @BeforeAll
   static void setCamundaAssertDefaultTimeout() {
     CamundaAssert.setAssertionTimeout(Duration.ofSeconds(30));
+  }
+
+  @BeforeEach
+  void mockUserFeedbackJobWorker() {
+    processTestContext
+        .mockJobWorker("user_feedback")
+        .withHandler(
+            (client, job) -> {
+              var nextFeedback =
+                  userFeedback.isEmpty() ? Collections.emptyMap() : userFeedback.poll();
+              userFeedbackJobWorkerCounter.incrementAndGet();
+              client.newCompleteCommand(job.getKey()).variables(nextFeedback).execute();
+            });
   }
 
   @BeforeEach
@@ -77,6 +93,8 @@ public abstract class BaseAiAgentTest extends BaseAgenticAiTest {
     wireMock = wm;
     // WireMock returns the content type for the YAML file as application/json, so
     // we need to override the stub manually
+    WireMock.resetAllScenarios();
+    WireMock.reset();
     stubFor(
         get(urlPathEqualTo("/test.yaml"))
             .atPriority(1)
@@ -125,7 +143,16 @@ public abstract class BaseAiAgentTest extends BaseAgenticAiTest {
         updatedElementTemplate.writeTo(new File(tempDir, "template.json"));
     final var updatedModel = modelWithModifications(process.getFile(), updatedElementTemplateFile);
 
-    return createProcessInstance(updatedModel, variables);
+    return createProcessInstance(customizeModel(updatedModel), variables);
+  }
+
+  /**
+   * Hook to mutate the built process model just before deployment. Default is a no-op; overridden
+   * by tests that need a per-test model tweak (e.g. a unique inbound webhook context to avoid
+   * cross-test "context already in use" collisions in the shared per-class runtime).
+   */
+  protected BpmnModelInstance customizeModel(BpmnModelInstance model) {
+    return model;
   }
 
   protected ElementTemplate elementTemplateWithModifications(
@@ -151,22 +178,7 @@ public abstract class BaseAiAgentTest extends BaseAgenticAiTest {
     if (feedback.length == 0) {
       return;
     }
-    final var builder =
-        processTestContext
-            .when(
-                () -> {
-                  final ProcessInstanceEvent pi = currentProcess;
-                  if (pi == null) throw new AssertionError("process not yet created");
-                  CamundaAssert.assertThat(pi).hasActiveElements("User_Feedback");
-                })
-            .as("user-feedback");
-    for (final Map<String, Object> f : feedback) {
-      builder.then(
-          () -> {
-            userFeedbackJobWorkerCounter.incrementAndGet();
-            processTestContext.completeJob(JobSelectors.byElementId("User_Feedback"), f);
-          });
-    }
+    userFeedback.addAll(List.of(feedback));
   }
 
   protected Map<String, Object> userSatisfiedFeedback() {

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/jobworker/AiAgentJobWorkerA2aIntegrationTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/jobworker/AiAgentJobWorkerA2aIntegrationTests.java
@@ -47,6 +47,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.context.annotation.Import;
 import org.springframework.core.io.Resource;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.TestPropertySource;
 
 @SlowTest
@@ -57,6 +58,7 @@ import org.springframework.test.context.TestPropertySource;
       "camunda.connector.polling.interval=2000"
     })
 @Import(InboundConnectorTestConfiguration.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 public class AiAgentJobWorkerA2aIntegrationTests extends BaseAiAgentJobWorkerTest {
 
   public static final String WEBHOOK_ELEMENT_ID = "Wait_For_Completion_Webhook";

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/jobworker/AiAgentJobWorkerA2aIntegrationTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/jobworker/AiAgentJobWorkerA2aIntegrationTests.java
@@ -35,9 +35,11 @@ import io.camunda.connector.e2e.inbound.InboundConnectorTestConfiguration;
 import io.camunda.connector.e2e.inbound.InboundConnectorTestConfiguration.InboundConnectorTestHelper;
 import io.camunda.connector.runtime.inbound.importer.ImportSchedulers;
 import io.camunda.connector.test.utils.annotation.SlowTest;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -51,7 +53,8 @@ import org.springframework.test.context.TestPropertySource;
 @TestPropertySource(
     properties = {
       "camunda.connector.polling.enabled=true",
-      "camunda.connector.webhook.enabled=true"
+      "camunda.connector.webhook.enabled=true",
+      "camunda.connector.polling.interval=2000"
     })
 @Import(InboundConnectorTestConfiguration.class)
 public class AiAgentJobWorkerA2aIntegrationTests extends BaseAiAgentJobWorkerTest {
@@ -71,15 +74,25 @@ public class AiAgentJobWorkerA2aIntegrationTests extends BaseAiAgentJobWorkerTes
 
   private AiAgentA2aIntegrationTestSupport testSupport;
   private String webhookUrl;
+  private String webhookContext;
 
   @BeforeEach
   void setUp() {
     testSupport = new AiAgentA2aIntegrationTestSupport(a2aSystemPromptResource, objectMapper);
     testSupport.setUpWireMockStubs(wireMock, (testFile) -> testFileContent(testFile).get());
-    webhookUrl = "http://localhost:%s/inbound/test-webhook-id".formatted(port);
+    // Unique webhook context per test so consecutive A2A tests/reruns don't collide on the same
+    // inbound context in the shared per-class runtime. webhookUrl must match the registered path.
+    webhookContext = "test-webhook-id-" + UUID.randomUUID();
+    webhookUrl = "http://localhost:%s/inbound/%s".formatted(port, webhookContext);
 
     // clear process definition caches & reset executables from previous tests
     inboundConnectorTestHelper.setUpTest();
+  }
+
+  @Override
+  protected BpmnModelInstance customizeModel(BpmnModelInstance model) {
+    TestUtil.setWebhookContext(model, WEBHOOK_ELEMENT_ID, webhookContext);
+    return model;
   }
 
   @Override
@@ -149,7 +162,7 @@ public class AiAgentJobWorkerA2aIntegrationTests extends BaseAiAgentJobWorkerTes
     postWithDelay(
         webhookUrl, testFileContent("exchange-rate-agent-webhook-payload.json").get(), 100);
 
-    zeebeTest.waitForProcessCompletion();
+    awaitProcessCompletion(zeebeTest);
 
     final var recorded = OpenAiCompletionsRecordedConversation.recorded();
     assertThat(recorded.modelCallCount()).isEqualTo(3);

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/jobworker/AiAgentJobWorkerA2aIntegrationTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/jobworker/AiAgentJobWorkerA2aIntegrationTests.java
@@ -47,7 +47,6 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.context.annotation.Import;
 import org.springframework.core.io.Resource;
-import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.TestPropertySource;
 
 @SlowTest
@@ -58,7 +57,6 @@ import org.springframework.test.context.TestPropertySource;
       "camunda.connector.polling.interval=2000"
     })
 @Import(InboundConnectorTestConfiguration.class)
-@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 public class AiAgentJobWorkerA2aIntegrationTests extends BaseAiAgentJobWorkerTest {
 
   public static final String WEBHOOK_ELEMENT_ID = "Wait_For_Completion_Webhook";

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/jobworker/AiAgentJobWorkerAgentInstanceTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/jobworker/AiAgentJobWorkerAgentInstanceTests.java
@@ -88,8 +88,9 @@ class AiAgentJobWorkerAgentInstanceTests extends BaseAiAgentJobWorkerTest {
     enqueueUserFeedback(userSatisfiedFeedback());
 
     final var zeebeTest =
-        createProcessInstance(Map.of("userPrompt", "Calculate the superflux product of 5 and 3"))
-            .waitForProcessCompletion();
+        awaitProcessCompletion(
+            createProcessInstance(
+                Map.of("userPrompt", "Calculate the superflux product of 5 and 3")));
 
     assertAgentResponse(
         zeebeTest,
@@ -198,9 +199,9 @@ class AiAgentJobWorkerAgentInstanceTests extends BaseAiAgentJobWorkerTest {
     enqueueUserFeedback(userSatisfiedFeedback());
 
     final var zeebeTest =
-        createProcessInstance(
-                Map.of("userPrompt", "Calculate the superflux product of 5 and 3, twice"))
-            .waitForProcessCompletion();
+        awaitProcessCompletion(
+            createProcessInstance(
+                Map.of("userPrompt", "Calculate the superflux product of 5 and 3, twice")));
 
     // modelCalls=3, inputTokens=10+10+15=35, outputTokens=20+20+25=65, toolCalls=2
     assertAgentResponse(

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/jobworker/AiAgentJobWorkerElementTemplateRegressionTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/jobworker/AiAgentJobWorkerElementTemplateRegressionTests.java
@@ -61,14 +61,14 @@ public class AiAgentJobWorkerElementTemplateRegressionTests extends BaseAiAgentJ
 
     final var processResource = resourceLoader.getResource("classpath:regression/" + processFile);
     final var zeebeTest =
-        createProcessInstance(
+        awaitProcessCompletion(
+            createProcessInstance(
                 processResource,
                 Map.of(
                     "userPrompt",
                     initialUserPrompt,
                     "providerEndpoint",
-                    wireMock.getHttpBaseUrl() + "/v1"))
-            .waitForProcessCompletion();
+                    wireMock.getHttpBaseUrl() + "/v1")));
 
     final var recorded = OpenAiCompletionsRecordedConversation.recorded();
     assertThat(recorded.modelCallCount()).isEqualTo(3);

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/jobworker/AiAgentJobWorkerEventsTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/jobworker/AiAgentJobWorkerEventsTests.java
@@ -132,7 +132,7 @@ public class AiAgentJobWorkerEventsTests extends BaseAiAgentJobWorkerTest {
     publishEventMessage(EVENT_PAYLOAD);
     final var zeebeTest = startProcessInstance(e -> e);
 
-    zeebeTest.waitForProcessCompletion();
+    awaitProcessCompletion(zeebeTest);
 
     assertCompleted(
         zeebeTest,
@@ -214,7 +214,7 @@ public class AiAgentJobWorkerEventsTests extends BaseAiAgentJobWorkerTest {
 
     completePendingToolJob(PENDING_TOOL_RESULT);
 
-    zeebeTest.waitForProcessCompletion();
+    awaitProcessCompletion(zeebeTest);
 
     assertCompleted(
         zeebeTest,
@@ -251,7 +251,7 @@ public class AiAgentJobWorkerEventsTests extends BaseAiAgentJobWorkerTest {
     awaitEventSubprocessCompletions(zeebeTest, 1);
     completePendingToolJob(pendingToolResultValue);
 
-    zeebeTest.waitForProcessCompletion();
+    awaitProcessCompletion(zeebeTest);
 
     assertCompleted(
         zeebeTest,
@@ -283,7 +283,7 @@ public class AiAgentJobWorkerEventsTests extends BaseAiAgentJobWorkerTest {
     awaitPendingToolJobCreated(zeebeTest);
     publishEventMessage(publishedPayload);
 
-    zeebeTest.waitForProcessCompletion();
+    awaitProcessCompletion(zeebeTest);
 
     assertCompleted(
         zeebeTest,

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/jobworker/AiAgentJobWorkerFeedbackLoopTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/jobworker/AiAgentJobWorkerFeedbackLoopTests.java
@@ -83,7 +83,7 @@ public class AiAgentJobWorkerFeedbackLoopTests extends BaseAiAgentJobWorkerTest 
     enqueueUserFeedback(userFollowUpFeedback("Add emojis!"), userSatisfiedFeedback());
 
     final var zeebeTest =
-        createProcessInstance(Map.of("userPrompt", initialUserPrompt)).waitForProcessCompletion();
+        awaitProcessCompletion(createProcessInstance(Map.of("userPrompt", initialUserPrompt)));
 
     assertConversationMessages(
         OpenAiCompletionsRecordedConversation.recorded().lastRequest(),
@@ -106,7 +106,7 @@ public class AiAgentJobWorkerFeedbackLoopTests extends BaseAiAgentJobWorkerTest 
 
   @Test
   void raisesIncidentWhenUserPromptIsEmpty() throws Exception {
-    final var zeebeTest = createProcessInstance(Map.of("userPrompt", "")).waitForActiveIncidents();
+    final var zeebeTest = awaitActiveIncidents(createProcessInstance(Map.of("userPrompt", "")));
 
     assertIncident(
         zeebeTest,
@@ -123,12 +123,12 @@ public class AiAgentJobWorkerFeedbackLoopTests extends BaseAiAgentJobWorkerTest 
   @Test
   void mapsIncidentToJobError() throws Exception {
     final var zeebeTest =
-        createProcessInstance(
+        awaitActiveIncidents(
+            createProcessInstance(
                 elementTemplate ->
                     elementTemplate.property(
                         "errorExpression", "=jobError(\"Job error: \" + error.message)"),
-                Map.of("userPrompt", ""))
-            .waitForActiveIncidents();
+                Map.of("userPrompt", "")));
 
     assertIncident(
         zeebeTest,

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/jobworker/AiAgentJobWorkerLimitsTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/jobworker/AiAgentJobWorkerLimitsTests.java
@@ -69,10 +69,10 @@ public class AiAgentJobWorkerLimitsTests extends BaseAiAgentJobWorkerTest {
         """;
 
     final var zeebeTest =
-        createProcessInstance(
+        awaitProcessCompletion(
+            createProcessInstance(
                 elementTemplate -> elementTemplate.property("errorExpression", errorExpression),
-                Map.of("userPrompt", "Write a haiku about the sea"))
-            .waitForProcessCompletion();
+                Map.of("userPrompt", "Write a haiku about the sea")));
 
     assertThat(zeebeTest.getProcessInstanceEvent())
         .hasNoActiveIncidents()
@@ -86,9 +86,9 @@ public class AiAgentJobWorkerLimitsTests extends BaseAiAgentJobWorkerTest {
     mockInfiniteLoop(expectedMaxModelCalls);
 
     final var zeebeTest =
-        createProcessInstance(
-                elementTemplateModifier, Map.of("userPrompt", "Write a haiku about the sea"))
-            .waitForActiveIncidents();
+        awaitActiveIncidents(
+            createProcessInstance(
+                elementTemplateModifier, Map.of("userPrompt", "Write a haiku about the sea")));
 
     assertIncident(
         zeebeTest,

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/jobworker/AiAgentJobWorkerMcpIntegrationTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/jobworker/AiAgentJobWorkerMcpIntegrationTests.java
@@ -57,14 +57,18 @@ import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
-import org.springframework.beans.factory.annotation.Qualifier;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.Resource;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @SlowTest
+@ExtendWith(MockitoExtension.class)
 @TestPropertySource(properties = {"camunda.connector.agenticai.mcp.client.enabled=true"})
 public class AiAgentJobWorkerMcpIntegrationTests extends BaseAiAgentJobWorkerTest {
 
@@ -76,32 +80,18 @@ public class AiAgentJobWorkerMcpIntegrationTests extends BaseAiAgentJobWorkerTes
   @MockitoBean private McpClientRegistry mcpClientRegistry;
   @MockitoBean private McpRemoteClientRegistry remoteMcpClientRegistry;
 
-  @MockitoBean
-  @Qualifier("aMcpClient")
-  private McpSyncClient aMcpClient;
+  @Mock private McpSyncClient aMcpClient;
+  @Mock private McpSyncClient aHttpRemoteMcpClient;
+  @Mock private McpSyncClient aSseRemoteMcpClient;
+  @Mock private McpSyncClient filesystemMcpClient;
 
-  @MockitoBean
-  @Qualifier("aHttpRemoteMcpClient")
-  private McpSyncClient aHttpRemoteMcpClient;
+  @Captor private ArgumentCaptor<McpSchema.CallToolRequest> aMcpClientToolExecutionRequestCaptor;
 
-  @MockitoBean
-  @Qualifier("aSseRemoteMcpClient")
-  private McpSyncClient aSseRemoteMcpClient;
+  @Captor
+  private ArgumentCaptor<McpSchema.CallToolRequest> aHttpRemoteMcpClientToolExecutionRequestCaptor;
 
-  @MockitoBean
-  @Qualifier("filesystemMcpClient")
-  private McpSyncClient filesystemMcpClient;
-
-  private final ArgumentCaptor<McpSchema.CallToolRequest> aMcpClientToolExecutionRequestCaptor =
-      ArgumentCaptor.forClass(McpSchema.CallToolRequest.class);
-
-  private final ArgumentCaptor<McpSchema.CallToolRequest>
-      aHttpRemoteMcpClientToolExecutionRequestCaptor =
-          ArgumentCaptor.forClass(McpSchema.CallToolRequest.class);
-
-  private final ArgumentCaptor<McpSchema.CallToolRequest>
-      aSseRemoteMcpClientToolExecutionRequestCaptor =
-          ArgumentCaptor.forClass(McpSchema.CallToolRequest.class);
+  @Captor
+  private ArgumentCaptor<McpSchema.CallToolRequest> aSseRemoteMcpClientToolExecutionRequestCaptor;
 
   private final Map<String, McpRemoteClientTransportConfiguration> requestedRemoteMcpClients =
       new LinkedHashMap<>();

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/jobworker/AiAgentJobWorkerMcpIntegrationTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/jobworker/AiAgentJobWorkerMcpIntegrationTests.java
@@ -57,18 +57,14 @@ import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
-import org.mockito.Captor;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.Resource;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @SlowTest
-@ExtendWith(MockitoExtension.class)
 @TestPropertySource(properties = {"camunda.connector.agenticai.mcp.client.enabled=true"})
 public class AiAgentJobWorkerMcpIntegrationTests extends BaseAiAgentJobWorkerTest {
 
@@ -80,18 +76,32 @@ public class AiAgentJobWorkerMcpIntegrationTests extends BaseAiAgentJobWorkerTes
   @MockitoBean private McpClientRegistry mcpClientRegistry;
   @MockitoBean private McpRemoteClientRegistry remoteMcpClientRegistry;
 
-  @Mock private McpSyncClient aMcpClient;
-  @Mock private McpSyncClient aHttpRemoteMcpClient;
-  @Mock private McpSyncClient aSseRemoteMcpClient;
-  @Mock private McpSyncClient filesystemMcpClient;
+  @MockitoBean
+  @Qualifier("aMcpClient")
+  private McpSyncClient aMcpClient;
 
-  @Captor private ArgumentCaptor<McpSchema.CallToolRequest> aMcpClientToolExecutionRequestCaptor;
+  @MockitoBean
+  @Qualifier("aHttpRemoteMcpClient")
+  private McpSyncClient aHttpRemoteMcpClient;
 
-  @Captor
-  private ArgumentCaptor<McpSchema.CallToolRequest> aHttpRemoteMcpClientToolExecutionRequestCaptor;
+  @MockitoBean
+  @Qualifier("aSseRemoteMcpClient")
+  private McpSyncClient aSseRemoteMcpClient;
 
-  @Captor
-  private ArgumentCaptor<McpSchema.CallToolRequest> aSseRemoteMcpClientToolExecutionRequestCaptor;
+  @MockitoBean
+  @Qualifier("filesystemMcpClient")
+  private McpSyncClient filesystemMcpClient;
+
+  private final ArgumentCaptor<McpSchema.CallToolRequest> aMcpClientToolExecutionRequestCaptor =
+      ArgumentCaptor.forClass(McpSchema.CallToolRequest.class);
+
+  private final ArgumentCaptor<McpSchema.CallToolRequest>
+      aHttpRemoteMcpClientToolExecutionRequestCaptor =
+          ArgumentCaptor.forClass(McpSchema.CallToolRequest.class);
+
+  private final ArgumentCaptor<McpSchema.CallToolRequest>
+      aSseRemoteMcpClientToolExecutionRequestCaptor =
+          ArgumentCaptor.forClass(McpSchema.CallToolRequest.class);
 
   private final Map<String, McpRemoteClientTransportConfiguration> requestedRemoteMcpClients =
       new LinkedHashMap<>();

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/jobworker/AiAgentJobWorkerMcpIntegrationTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/jobworker/AiAgentJobWorkerMcpIntegrationTests.java
@@ -247,8 +247,9 @@ public class AiAgentJobWorkerMcpIntegrationTests extends BaseAiAgentJobWorkerTes
     enqueueUserFeedback(userFollowUpFeedback("Ok thanks, anything else?"), userSatisfiedFeedback());
 
     final var zeebeTest =
-        createProcessInstance(testProcessWithMcp, e -> e, Map.of("userPrompt", initialUserPrompt))
-            .waitForProcessCompletion();
+        awaitProcessCompletion(
+            createProcessInstance(
+                testProcessWithMcp, e -> e, Map.of("userPrompt", initialUserPrompt)));
 
     final var recorded = OpenAiCompletionsRecordedConversation.recorded();
     assertThat(recorded.modelCallCount()).isEqualTo(3);
@@ -335,8 +336,9 @@ public class AiAgentJobWorkerMcpIntegrationTests extends BaseAiAgentJobWorkerTes
     enqueueUserFeedback(userSatisfiedFeedback());
 
     final var zeebeTest =
-        createProcessInstance(testProcessWithMcp, e -> e, Map.of("userPrompt", initialUserPrompt))
-            .waitForProcessCompletion();
+        awaitProcessCompletion(
+            createProcessInstance(
+                testProcessWithMcp, e -> e, Map.of("userPrompt", initialUserPrompt)));
 
     final var recorded = OpenAiCompletionsRecordedConversation.recorded();
     assertThat(recorded.modelCallCount()).isEqualTo(2);

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/jobworker/AiAgentJobWorkerResponseHandlingTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/jobworker/AiAgentJobWorkerResponseHandlingTests.java
@@ -235,7 +235,7 @@ public class AiAgentJobWorkerResponseHandlingTests extends BaseAiAgentJobWorkerT
               elementTemplate -> elementTemplate.property("data.response.format.type", "json"),
               Map.of(),
               HAIKU_TEXT);
-      zeebeTest.waitForActiveIncidents();
+      awaitActiveIncidents(zeebeTest);
 
       assertIncident(
           zeebeTest,

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/jobworker/AiAgentJobWorkerToolCallingTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/jobworker/AiAgentJobWorkerToolCallingTests.java
@@ -95,11 +95,11 @@ public class AiAgentJobWorkerToolCallingTests extends BaseAiAgentJobWorkerTest {
     enqueueUserFeedback(userFollowUpFeedback("What is the content type?"), userSatisfiedFeedback());
 
     final var zeebeTest =
-        createProcessInstance(
+        awaitProcessCompletion(
+            createProcessInstance(
                 elementTemplate ->
                     elementTemplate.property("retryCount", "3").property("retryBackoff", "PT2S"),
-                Map.of("userPrompt", initialUserPrompt))
-            .waitForProcessCompletion();
+                Map.of("userPrompt", initialUserPrompt)));
 
     final var recorded = OpenAiCompletionsRecordedConversation.recorded();
     assertThat(recorded.modelCallCount()).isEqualTo(3);
@@ -164,11 +164,11 @@ public class AiAgentJobWorkerToolCallingTests extends BaseAiAgentJobWorkerTest {
     enqueueUserFeedback(userSatisfiedFeedback());
 
     final var zeebeTest =
-        createProcessInstance(
+        awaitProcessCompletion(
+            createProcessInstance(
                 elementTemplate ->
                     elementTemplate.property("retryCount", "3").property("retryBackoff", "PT2S"),
-                Map.of("userPrompt", initialUserPrompt))
-            .waitForProcessCompletion();
+                Map.of("userPrompt", initialUserPrompt)));
 
     final var recorded = OpenAiCompletionsRecordedConversation.recorded();
     assertThat(recorded.modelCallCount()).isEqualTo(2);

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/jobworker/AiAgentJobWorkerUserPromptDocumentsTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/jobworker/AiAgentJobWorkerUserPromptDocumentsTests.java
@@ -57,15 +57,15 @@ public class AiAgentJobWorkerUserPromptDocumentsTests extends BaseAiAgentJobWork
     enqueueUserFeedback(userSatisfiedFeedback());
 
     final var zeebeTest =
-        createProcessInstance(
+        awaitProcessCompletion(
+            createProcessInstance(
                 elementTemplate ->
                     elementTemplate.property("retryCount", "3").property("retryBackoff", "PT2S"),
                 Map.of(
                     "userPrompt",
                     initialUserPrompt,
                     "downloadUrls",
-                    List.of(wireMock.getHttpBaseUrl() + "/" + filename)))
-            .waitForProcessCompletion();
+                    List.of(wireMock.getHttpBaseUrl() + "/" + filename))));
 
     final var recorded = OpenAiCompletionsRecordedConversation.recorded();
     assertThat(recorded.modelCallCount()).isEqualTo(1);
@@ -109,7 +109,8 @@ public class AiAgentJobWorkerUserPromptDocumentsTests extends BaseAiAgentJobWork
     enqueueUserFeedback(userSatisfiedFeedback());
 
     final var zeebeTest =
-        createProcessInstance(
+        awaitProcessCompletion(
+            createProcessInstance(
                 elementTemplate ->
                     elementTemplate.property("retryCount", "3").property("retryBackoff", "PT2S"),
                 Map.of(
@@ -118,8 +119,7 @@ public class AiAgentJobWorkerUserPromptDocumentsTests extends BaseAiAgentJobWork
                     "downloadUrls",
                     List.of(
                         wireMock.getHttpBaseUrl() + "/test.txt",
-                        wireMock.getHttpBaseUrl() + "/test.jpg")))
-            .waitForProcessCompletion();
+                        wireMock.getHttpBaseUrl() + "/test.jpg"))));
 
     final var recorded = OpenAiCompletionsRecordedConversation.recorded();
     assertThat(recorded.modelCallCount()).isEqualTo(1);
@@ -155,13 +155,13 @@ public class AiAgentJobWorkerUserPromptDocumentsTests extends BaseAiAgentJobWork
   @Test
   void raisesIncidentWhenDocumentTypeIsNotSupported() throws Exception {
     final var zeebeTest =
-        createProcessInstance(
+        awaitActiveIncidents(
+            createProcessInstance(
                 Map.of(
                     "userPrompt",
                     "Summarize the following document",
                     "downloadUrls",
-                    List.of(wireMock.getHttpBaseUrl() + "/unsupported.zip")))
-            .waitForActiveIncidents();
+                    List.of(wireMock.getHttpBaseUrl() + "/unsupported.zip"))));
 
     assertIncident(
         zeebeTest,

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/jobworker/AiAgentJobWorkerVariableScopeTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/jobworker/AiAgentJobWorkerVariableScopeTests.java
@@ -98,7 +98,7 @@ public class AiAgentJobWorkerVariableScopeTests extends BaseAiAgentJobWorkerTest
     final var updatedModel =
         modelWithModifications(testProcess.getFile(), updatedElementTemplateFile);
 
-    return createProcessInstance(updatedModel, processVariables).waitForProcessCompletion();
+    return awaitProcessCompletion(createProcessInstance(updatedModel, processVariables));
   }
 
   private void assertCustomResultVariable(ZeebeTest zeebeTest, String expectedText) {

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/jobworker/BaseAiAgentJobWorkerTest.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/jobworker/BaseAiAgentJobWorkerTest.java
@@ -137,7 +137,7 @@ public abstract class BaseAiAgentJobWorkerTest extends BaseAiAgentTest {
     final var zeebeTest =
         setupBasicTestWithoutFeedbackLoop(
             process, elementTemplateModifier, extraProcessVariables, responseText);
-    zeebeTest.waitForProcessCompletion();
+    awaitProcessCompletion(zeebeTest);
 
     final var recorded = OpenAiCompletionsRecordedConversation.recorded();
     assertThat(recorded.modelCallCount()).isEqualTo(1);
@@ -218,9 +218,9 @@ public abstract class BaseAiAgentJobWorkerTest extends BaseAiAgentTest {
     enqueueUserFeedback(userFollowUpFeedback(followUpPrompt), userSatisfiedFeedback());
 
     final var zeebeTest =
-        createProcessInstance(
-                testProcess, elementTemplateModifier, Map.of("userPrompt", initialUserPrompt))
-            .waitForProcessCompletion();
+        awaitProcessCompletion(
+            createProcessInstance(
+                testProcess, elementTemplateModifier, Map.of("userPrompt", initialUserPrompt)));
 
     final var recorded = OpenAiCompletionsRecordedConversation.recorded();
     assertThat(recorded.modelCallCount()).isEqualTo(3);

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/outboundconnector/AiAgentConnectorA2aIntegrationTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/outboundconnector/AiAgentConnectorA2aIntegrationTests.java
@@ -47,6 +47,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.context.annotation.Import;
 import org.springframework.core.io.Resource;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.TestPropertySource;
 
 @SlowTest
@@ -57,6 +58,7 @@ import org.springframework.test.context.TestPropertySource;
       "camunda.connector.polling.interval=2000"
     })
 @Import(InboundConnectorTestConfiguration.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 public class AiAgentConnectorA2aIntegrationTests extends BaseAiAgentConnectorTest {
 
   public static final String WEBHOOK_ELEMENT_ID = "Wait_For_Completion_Webhook";

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/outboundconnector/AiAgentConnectorA2aIntegrationTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/outboundconnector/AiAgentConnectorA2aIntegrationTests.java
@@ -47,7 +47,6 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.context.annotation.Import;
 import org.springframework.core.io.Resource;
-import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.TestPropertySource;
 
 @SlowTest
@@ -58,7 +57,6 @@ import org.springframework.test.context.TestPropertySource;
       "camunda.connector.polling.interval=2000"
     })
 @Import(InboundConnectorTestConfiguration.class)
-@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 public class AiAgentConnectorA2aIntegrationTests extends BaseAiAgentConnectorTest {
 
   public static final String WEBHOOK_ELEMENT_ID = "Wait_For_Completion_Webhook";

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/outboundconnector/AiAgentConnectorA2aIntegrationTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/outboundconnector/AiAgentConnectorA2aIntegrationTests.java
@@ -35,9 +35,11 @@ import io.camunda.connector.e2e.inbound.InboundConnectorTestConfiguration;
 import io.camunda.connector.e2e.inbound.InboundConnectorTestConfiguration.InboundConnectorTestHelper;
 import io.camunda.connector.runtime.inbound.importer.ImportSchedulers;
 import io.camunda.connector.test.utils.annotation.SlowTest;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -51,7 +53,8 @@ import org.springframework.test.context.TestPropertySource;
 @TestPropertySource(
     properties = {
       "camunda.connector.polling.enabled=true",
-      "camunda.connector.webhook.enabled=true"
+      "camunda.connector.webhook.enabled=true",
+      "camunda.connector.polling.interval=2000"
     })
 @Import(InboundConnectorTestConfiguration.class)
 public class AiAgentConnectorA2aIntegrationTests extends BaseAiAgentConnectorTest {
@@ -71,15 +74,25 @@ public class AiAgentConnectorA2aIntegrationTests extends BaseAiAgentConnectorTes
 
   private AiAgentA2aIntegrationTestSupport testSupport;
   private String webhookUrl;
+  private String webhookContext;
 
   @BeforeEach
   void setUp() {
     testSupport = new AiAgentA2aIntegrationTestSupport(a2aSystemPromptResource, objectMapper);
     testSupport.setUpWireMockStubs(wireMock, (testFile) -> testFileContent(testFile).get());
-    webhookUrl = "http://localhost:%s/inbound/test-webhook-id".formatted(port);
+    // Unique webhook context per test so consecutive A2A tests/reruns don't collide on the same
+    // inbound context in the shared per-class runtime. webhookUrl must match the registered path.
+    webhookContext = "test-webhook-id-" + UUID.randomUUID();
+    webhookUrl = "http://localhost:%s/inbound/%s".formatted(port, webhookContext);
 
     // clear process definition caches & reset executables from previous tests
     inboundConnectorTestHelper.setUpTest();
+  }
+
+  @Override
+  protected BpmnModelInstance customizeModel(BpmnModelInstance model) {
+    TestUtil.setWebhookContext(model, WEBHOOK_ELEMENT_ID, webhookContext);
+    return model;
   }
 
   @Override
@@ -150,7 +163,7 @@ public class AiAgentConnectorA2aIntegrationTests extends BaseAiAgentConnectorTes
     postWithDelay(
         webhookUrl, testFileContent("exchange-rate-agent-webhook-payload.json").get(), 100);
 
-    zeebeTest.waitForProcessCompletion();
+    awaitProcessCompletion(zeebeTest);
 
     final var recorded = OpenAiCompletionsRecordedConversation.recorded();
     assertThat(recorded.modelCallCount()).isEqualTo(3);

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/outboundconnector/AiAgentConnectorAgentInstanceTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/outboundconnector/AiAgentConnectorAgentInstanceTests.java
@@ -90,14 +90,14 @@ class AiAgentConnectorAgentInstanceTests extends BaseAiAgentConnectorTest {
     enqueueUserFeedback(userSatisfiedFeedback());
 
     final var zeebeTest =
-        createProcessInstance(
+        awaitProcessCompletion(
+            createProcessInstance(
                 e ->
                     e.property("provider.type", "openaiCompatible")
                         .property(
                             "provider.openaiCompatible.endpoint", wireMock.getHttpBaseUrl() + "/v1")
                         .property("provider.openaiCompatible.model.model", "gpt-4o"),
-                Map.of("userPrompt", "Calculate the superflux product of 5 and 3"))
-            .waitForProcessCompletion();
+                Map.of("userPrompt", "Calculate the superflux product of 5 and 3")));
 
     assertAgentResponse(
         zeebeTest,
@@ -203,14 +203,14 @@ class AiAgentConnectorAgentInstanceTests extends BaseAiAgentConnectorTest {
     enqueueUserFeedback(userSatisfiedFeedback());
 
     final var zeebeTest =
-        createProcessInstance(
+        awaitProcessCompletion(
+            createProcessInstance(
                 e ->
                     e.property("provider.type", "openaiCompatible")
                         .property(
                             "provider.openaiCompatible.endpoint", wireMock.getHttpBaseUrl() + "/v1")
                         .property("provider.openaiCompatible.model.model", "gpt-4o"),
-                Map.of("userPrompt", "Calculate the superflux product of 5 and 3, twice"))
-            .waitForProcessCompletion();
+                Map.of("userPrompt", "Calculate the superflux product of 5 and 3, twice")));
 
     // modelCalls=3, inputTokens=10+10+15=35, outputTokens=20+20+25=65, toolCalls=2
     assertAgentResponse(

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/outboundconnector/AiAgentConnectorElementTemplateRegressionTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/outboundconnector/AiAgentConnectorElementTemplateRegressionTests.java
@@ -61,14 +61,14 @@ public class AiAgentConnectorElementTemplateRegressionTests extends BaseAiAgentC
 
     final var processResource = resourceLoader.getResource("classpath:regression/" + processFile);
     final var zeebeTest =
-        createProcessInstance(
+        awaitProcessCompletion(
+            createProcessInstance(
                 processResource,
                 Map.of(
                     "userPrompt",
                     initialUserPrompt,
                     "providerEndpoint",
-                    wireMock.getHttpBaseUrl() + "/v1"))
-            .waitForProcessCompletion();
+                    wireMock.getHttpBaseUrl() + "/v1")));
 
     final var recorded = OpenAiCompletionsRecordedConversation.recorded();
     assertThat(recorded.modelCallCount()).isEqualTo(3);

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/outboundconnector/AiAgentConnectorFeedbackLoopTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/outboundconnector/AiAgentConnectorFeedbackLoopTests.java
@@ -82,7 +82,7 @@ public class AiAgentConnectorFeedbackLoopTests extends BaseAiAgentConnectorTest 
     enqueueUserFeedback(userFollowUpFeedback("Add emojis!"), userSatisfiedFeedback());
 
     final var zeebeTest =
-        createProcessInstance(Map.of("userPrompt", initialUserPrompt)).waitForProcessCompletion();
+        awaitProcessCompletion(createProcessInstance(Map.of("userPrompt", initialUserPrompt)));
 
     final var recorded = OpenAiCompletionsRecordedConversation.recorded();
     assertThat(recorded.modelCallCount()).isEqualTo(2);

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/outboundconnector/AiAgentConnectorHttpTimeoutTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/outboundconnector/AiAgentConnectorHttpTimeoutTests.java
@@ -81,13 +81,13 @@ public class AiAgentConnectorHttpTimeoutTests extends BaseAiAgentConnectorTest {
   /**
    * WireMock response delay used in positive cases: must be shorter than {@link #MODEL_TIMEOUT}.
    */
-  private static final Duration RESPONSE_DELAY_BELOW_TIMEOUT = Duration.ofSeconds(3);
+  private static final Duration RESPONSE_DELAY_BELOW_TIMEOUT = Duration.ofSeconds(1);
 
   /** WireMock response delay used in negative cases: must be longer than {@link #MODEL_TIMEOUT}. */
-  private static final Duration RESPONSE_DELAY_ABOVE_TIMEOUT = Duration.ofSeconds(8);
+  private static final Duration RESPONSE_DELAY_ABOVE_TIMEOUT = Duration.ofSeconds(5);
 
   /** Connector-level model call timeout: short enough to keep negative cases under ~10s. */
-  private static final Duration MODEL_TIMEOUT = Duration.ofSeconds(6);
+  private static final Duration MODEL_TIMEOUT = Duration.ofSeconds(3);
 
   /** This test configures its own providers — skip the base's openaiCompatible redirect. */
   @Override
@@ -159,8 +159,9 @@ public class AiAgentConnectorHttpTimeoutTests extends BaseAiAgentConnectorTest {
       enqueueUserFeedback(userSatisfiedFeedback());
 
       final ZeebeTest zeebeTest =
-          createProcessInstance(providerConfig, Map.of("userPrompt", "Write a haiku about the sea"))
-              .waitForProcessCompletion();
+          awaitProcessCompletion(
+              createProcessInstance(
+                  providerConfig, Map.of("userPrompt", "Write a haiku about the sea")));
 
       assertAgentResponse(
           zeebeTest,
@@ -175,8 +176,9 @@ public class AiAgentConnectorHttpTimeoutTests extends BaseAiAgentConnectorTest {
   private void runNegativeCase(Function<ElementTemplate, ElementTemplate> providerConfig) {
     try {
       final ZeebeTest zeebeTest =
-          createProcessInstance(providerConfig, Map.of("userPrompt", "Write a haiku about the sea"))
-              .waitForActiveIncidents();
+          awaitActiveIncidents(
+              createProcessInstance(
+                  providerConfig, Map.of("userPrompt", "Write a haiku about the sea")));
 
       assertIncident(
           zeebeTest,
@@ -257,34 +259,6 @@ public class AiAgentConnectorHttpTimeoutTests extends BaseAiAgentConnectorTest {
                           "stop_reason": "end_turn",
                           "stop_sequence": null,
                           "usage": {"input_tokens": 10, "output_tokens": 20}
-                        }
-                        """
-                            .formatted(AGENT_RESPONSE_TEXT))));
-  }
-
-  private void stubOpenAiCompatible(Duration delay) {
-    stubFor(
-        post(urlPathEqualTo("/v1/chat/completions"))
-            .willReturn(
-                aResponse()
-                    .withStatus(200)
-                    .withHeader("Content-Type", "application/json")
-                    .withFixedDelay((int) delay.toMillis())
-                    .withBody(
-                        """
-                        {
-                          "id": "chatcmpl-test",
-                          "object": "chat.completion",
-                          "created": 1700000000,
-                          "model": "test-model",
-                          "choices": [
-                            {
-                              "index": 0,
-                              "message": {"role": "assistant", "content": "%s"},
-                              "finish_reason": "stop"
-                            }
-                          ],
-                          "usage": {"prompt_tokens": 10, "completion_tokens": 20, "total_tokens": 30}
                         }
                         """
                             .formatted(AGENT_RESPONSE_TEXT))));

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/outboundconnector/AiAgentConnectorLimitsTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/outboundconnector/AiAgentConnectorLimitsTests.java
@@ -63,9 +63,9 @@ public class AiAgentConnectorLimitsTests extends BaseAiAgentConnectorTest {
     }
 
     final var zeebeTest =
-        createProcessInstance(
-                elementTemplateModifier, Map.of("userPrompt", "Write a haiku about the sea"))
-            .waitForActiveIncidents();
+        awaitActiveIncidents(
+            createProcessInstance(
+                elementTemplateModifier, Map.of("userPrompt", "Write a haiku about the sea")));
 
     assertIncident(
         zeebeTest,

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/outboundconnector/AiAgentConnectorMcpIntegrationTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/outboundconnector/AiAgentConnectorMcpIntegrationTests.java
@@ -245,8 +245,9 @@ class AiAgentConnectorMcpIntegrationTests extends BaseAiAgentConnectorTest {
     enqueueUserFeedback(userFollowUpFeedback("Ok thanks, anything else?"), userSatisfiedFeedback());
 
     final var zeebeTest =
-        createProcessInstance(testProcessWithMcp, e -> e, Map.of("userPrompt", initialUserPrompt))
-            .waitForProcessCompletion();
+        awaitProcessCompletion(
+            createProcessInstance(
+                testProcessWithMcp, e -> e, Map.of("userPrompt", initialUserPrompt)));
 
     final var recorded = OpenAiCompletionsRecordedConversation.recorded();
     assertThat(recorded.modelCallCount()).isEqualTo(3);
@@ -334,8 +335,9 @@ class AiAgentConnectorMcpIntegrationTests extends BaseAiAgentConnectorTest {
     enqueueUserFeedback(userSatisfiedFeedback());
 
     final var zeebeTest =
-        createProcessInstance(testProcessWithMcp, e -> e, Map.of("userPrompt", initialUserPrompt))
-            .waitForProcessCompletion();
+        awaitProcessCompletion(
+            createProcessInstance(
+                testProcessWithMcp, e -> e, Map.of("userPrompt", initialUserPrompt)));
 
     final var recorded = OpenAiCompletionsRecordedConversation.recorded();
     assertThat(recorded.modelCallCount()).isEqualTo(2);

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/outboundconnector/AiAgentConnectorMcpIntegrationTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/outboundconnector/AiAgentConnectorMcpIntegrationTests.java
@@ -57,14 +57,18 @@ import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
-import org.springframework.beans.factory.annotation.Qualifier;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.Resource;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @SlowTest
+@ExtendWith(MockitoExtension.class)
 @TestPropertySource(properties = {"camunda.connector.agenticai.mcp.client.enabled=true"})
 class AiAgentConnectorMcpIntegrationTests extends BaseAiAgentConnectorTest {
 
@@ -76,32 +80,18 @@ class AiAgentConnectorMcpIntegrationTests extends BaseAiAgentConnectorTest {
   @MockitoBean private McpClientRegistry mcpClientRegistry;
   @MockitoBean private McpRemoteClientRegistry remoteMcpClientRegistry;
 
-  @MockitoBean
-  @Qualifier("aMcpClient")
-  private McpSyncClient aMcpClient;
+  @Mock private McpSyncClient aMcpClient;
+  @Mock private McpSyncClient aHttpRemoteMcpClient;
+  @Mock private McpSyncClient aSseRemoteMcpClient;
+  @Mock private McpSyncClient filesystemMcpClient;
 
-  @MockitoBean
-  @Qualifier("aHttpRemoteMcpClient")
-  private McpSyncClient aHttpRemoteMcpClient;
+  @Captor private ArgumentCaptor<McpSchema.CallToolRequest> aMcpClientToolExecutionRequestCaptor;
 
-  @MockitoBean
-  @Qualifier("aSseRemoteMcpClient")
-  private McpSyncClient aSseRemoteMcpClient;
+  @Captor
+  private ArgumentCaptor<McpSchema.CallToolRequest> aHttpRemoteMcpClientToolExecutionRequestCaptor;
 
-  @MockitoBean
-  @Qualifier("filesystemMcpClient")
-  private McpSyncClient filesystemMcpClient;
-
-  private final ArgumentCaptor<McpSchema.CallToolRequest> aMcpClientToolExecutionRequestCaptor =
-      ArgumentCaptor.forClass(McpSchema.CallToolRequest.class);
-
-  private final ArgumentCaptor<McpSchema.CallToolRequest>
-      aHttpRemoteMcpClientToolExecutionRequestCaptor =
-          ArgumentCaptor.forClass(McpSchema.CallToolRequest.class);
-
-  private final ArgumentCaptor<McpSchema.CallToolRequest>
-      aSseRemoteMcpClientToolExecutionRequestCaptor =
-          ArgumentCaptor.forClass(McpSchema.CallToolRequest.class);
+  @Captor
+  private ArgumentCaptor<McpSchema.CallToolRequest> aSseRemoteMcpClientToolExecutionRequestCaptor;
 
   private final Map<String, McpRemoteClientTransportConfiguration> requestedRemoteMcpClients =
       new LinkedHashMap<>();

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/outboundconnector/AiAgentConnectorMcpIntegrationTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/outboundconnector/AiAgentConnectorMcpIntegrationTests.java
@@ -57,18 +57,14 @@ import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
-import org.mockito.Captor;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.Resource;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @SlowTest
-@ExtendWith(MockitoExtension.class)
 @TestPropertySource(properties = {"camunda.connector.agenticai.mcp.client.enabled=true"})
 class AiAgentConnectorMcpIntegrationTests extends BaseAiAgentConnectorTest {
 
@@ -80,18 +76,32 @@ class AiAgentConnectorMcpIntegrationTests extends BaseAiAgentConnectorTest {
   @MockitoBean private McpClientRegistry mcpClientRegistry;
   @MockitoBean private McpRemoteClientRegistry remoteMcpClientRegistry;
 
-  @Mock private McpSyncClient aMcpClient;
-  @Mock private McpSyncClient aHttpRemoteMcpClient;
-  @Mock private McpSyncClient aSseRemoteMcpClient;
-  @Mock private McpSyncClient filesystemMcpClient;
+  @MockitoBean
+  @Qualifier("aMcpClient")
+  private McpSyncClient aMcpClient;
 
-  @Captor private ArgumentCaptor<McpSchema.CallToolRequest> aMcpClientToolExecutionRequestCaptor;
+  @MockitoBean
+  @Qualifier("aHttpRemoteMcpClient")
+  private McpSyncClient aHttpRemoteMcpClient;
 
-  @Captor
-  private ArgumentCaptor<McpSchema.CallToolRequest> aHttpRemoteMcpClientToolExecutionRequestCaptor;
+  @MockitoBean
+  @Qualifier("aSseRemoteMcpClient")
+  private McpSyncClient aSseRemoteMcpClient;
 
-  @Captor
-  private ArgumentCaptor<McpSchema.CallToolRequest> aSseRemoteMcpClientToolExecutionRequestCaptor;
+  @MockitoBean
+  @Qualifier("filesystemMcpClient")
+  private McpSyncClient filesystemMcpClient;
+
+  private final ArgumentCaptor<McpSchema.CallToolRequest> aMcpClientToolExecutionRequestCaptor =
+      ArgumentCaptor.forClass(McpSchema.CallToolRequest.class);
+
+  private final ArgumentCaptor<McpSchema.CallToolRequest>
+      aHttpRemoteMcpClientToolExecutionRequestCaptor =
+          ArgumentCaptor.forClass(McpSchema.CallToolRequest.class);
+
+  private final ArgumentCaptor<McpSchema.CallToolRequest>
+      aSseRemoteMcpClientToolExecutionRequestCaptor =
+          ArgumentCaptor.forClass(McpSchema.CallToolRequest.class);
 
   private final Map<String, McpRemoteClientTransportConfiguration> requestedRemoteMcpClients =
       new LinkedHashMap<>();

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/outboundconnector/AiAgentConnectorResponseHandlingTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/outboundconnector/AiAgentConnectorResponseHandlingTests.java
@@ -232,7 +232,7 @@ public class AiAgentConnectorResponseHandlingTests extends BaseAiAgentConnectorT
               elementTemplate -> elementTemplate.property("data.response.format.type", "json"),
               Map.of(),
               HAIKU_TEXT);
-      zeebeTest.waitForActiveIncidents();
+      awaitActiveIncidents(zeebeTest);
 
       assertIncident(
           zeebeTest,

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/outboundconnector/AiAgentConnectorToolCallingTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/outboundconnector/AiAgentConnectorToolCallingTests.java
@@ -89,8 +89,8 @@ public class AiAgentConnectorToolCallingTests extends BaseAiAgentConnectorTest {
     enqueueUserFeedback(userFollowUpFeedback("What is the content type?"), userSatisfiedFeedback());
 
     final var zeebeTest =
-        createProcessInstance(e -> e, Map.of("userPrompt", initialUserPrompt))
-            .waitForProcessCompletion();
+        awaitProcessCompletion(
+            createProcessInstance(e -> e, Map.of("userPrompt", initialUserPrompt)));
 
     final var recorded = OpenAiCompletionsRecordedConversation.recorded();
     assertThat(recorded.modelCallCount()).isEqualTo(3);
@@ -158,8 +158,8 @@ public class AiAgentConnectorToolCallingTests extends BaseAiAgentConnectorTest {
     enqueueUserFeedback(userSatisfiedFeedback());
 
     final var zeebeTest =
-        createProcessInstance(e -> e, Map.of("userPrompt", initialUserPrompt))
-            .waitForProcessCompletion();
+        awaitProcessCompletion(
+            createProcessInstance(e -> e, Map.of("userPrompt", initialUserPrompt)));
 
     final var recorded = OpenAiCompletionsRecordedConversation.recorded();
     assertThat(recorded.modelCallCount()).isEqualTo(2);

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/outboundconnector/AiAgentConnectorUserPromptDocumentsTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/outboundconnector/AiAgentConnectorUserPromptDocumentsTests.java
@@ -57,15 +57,15 @@ public class AiAgentConnectorUserPromptDocumentsTests extends BaseAiAgentConnect
     enqueueUserFeedback(userSatisfiedFeedback());
 
     final var zeebeTest =
-        createProcessInstance(
+        awaitProcessCompletion(
+            createProcessInstance(
                 elementTemplate ->
                     elementTemplate.property("retryCount", "3").property("retryBackoff", "PT2S"),
                 Map.of(
                     "userPrompt",
                     initialUserPrompt,
                     "downloadUrls",
-                    List.of(wireMock.getHttpBaseUrl() + "/" + filename)))
-            .waitForProcessCompletion();
+                    List.of(wireMock.getHttpBaseUrl() + "/" + filename))));
 
     final var recorded = OpenAiCompletionsRecordedConversation.recorded();
     assertThat(recorded.modelCallCount()).isEqualTo(1);
@@ -111,7 +111,8 @@ public class AiAgentConnectorUserPromptDocumentsTests extends BaseAiAgentConnect
     enqueueUserFeedback(userSatisfiedFeedback());
 
     final var zeebeTest =
-        createProcessInstance(
+        awaitProcessCompletion(
+            createProcessInstance(
                 elementTemplate ->
                     elementTemplate.property("retryCount", "3").property("retryBackoff", "PT2S"),
                 Map.of(
@@ -120,8 +121,7 @@ public class AiAgentConnectorUserPromptDocumentsTests extends BaseAiAgentConnect
                     "downloadUrls",
                     List.of(
                         wireMock.getHttpBaseUrl() + "/test.txt",
-                        wireMock.getHttpBaseUrl() + "/test.jpg")))
-            .waitForProcessCompletion();
+                        wireMock.getHttpBaseUrl() + "/test.jpg"))));
 
     final var recorded = OpenAiCompletionsRecordedConversation.recorded();
     assertThat(recorded.modelCallCount()).isEqualTo(1);
@@ -159,13 +159,13 @@ public class AiAgentConnectorUserPromptDocumentsTests extends BaseAiAgentConnect
   @Test
   void raisesIncidentWhenDocumentTypeIsNotSupported() throws Exception {
     final var zeebeTest =
-        createProcessInstance(
+        awaitActiveIncidents(
+            createProcessInstance(
                 Map.of(
                     "userPrompt",
                     "Summarize the following document",
                     "downloadUrls",
-                    List.of(wireMock.getHttpBaseUrl() + "/unsupported.zip")))
-            .waitForActiveIncidents();
+                    List.of(wireMock.getHttpBaseUrl() + "/unsupported.zip"))));
 
     assertIncident(
         zeebeTest,

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/outboundconnector/BaseAiAgentConnectorTest.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/aiagent/outboundconnector/BaseAiAgentConnectorTest.java
@@ -133,7 +133,7 @@ public abstract class BaseAiAgentConnectorTest extends BaseAiAgentTest {
     final var zeebeTest =
         setupBasicTestWithoutFeedbackLoop(
             process, elementTemplateModifier, extraProcessVariables, responseText);
-    zeebeTest.waitForProcessCompletion();
+    awaitProcessCompletion(zeebeTest);
 
     final var recorded = OpenAiCompletionsRecordedConversation.recorded();
     assertThat(recorded.modelCallCount()).isEqualTo(1);
@@ -215,9 +215,9 @@ public abstract class BaseAiAgentConnectorTest extends BaseAiAgentTest {
     enqueueUserFeedback(userFollowUpFeedback(followUpPrompt), userSatisfiedFeedback());
 
     final var zeebeTest =
-        createProcessInstance(
-                testProcess, elementTemplateModifier, Map.of("userPrompt", initialUserPrompt))
-            .waitForProcessCompletion();
+        awaitProcessCompletion(
+            createProcessInstance(
+                testProcess, elementTemplateModifier, Map.of("userPrompt", initialUserPrompt)));
 
     final var recorded = OpenAiCompletionsRecordedConversation.recorded();
     assertThat(recorded.modelCallCount()).isEqualTo(3);

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/mcp/McpStandaloneTests.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/mcp/McpStandaloneTests.java
@@ -373,7 +373,7 @@ public class McpStandaloneTests extends BaseAgenticAiTest {
       BpmnModelInstance model,
       Map<String, Object> variables,
       Consumer<ProcessInstanceEvent> assertion) {
-    ZeebeTest zeebeTest = createProcessInstance(model, variables).waitForProcessCompletion();
+    ZeebeTest zeebeTest = awaitProcessCompletion(createProcessInstance(model, variables));
 
     assertion.accept(zeebeTest.getProcessInstanceEvent());
   }

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/mcp/authentication/BaseMcpAuthenticationTest.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/mcp/authentication/BaseMcpAuthenticationTest.java
@@ -156,7 +156,7 @@ abstract class BaseMcpAuthenticationTest extends BaseAgenticAiTest {
             Map.entry("data.connectorMode.operation.toolArguments", "={ a: 5, b: 3 }")));
 
     ZeebeTest zeebeTest =
-        createProcessInstance(bpmnModel, Map.of("path", "tools")).waitForProcessCompletion();
+        awaitProcessCompletion(createProcessInstance(bpmnModel, Map.of("path", "tools")));
 
     CamundaAssert.assertThat(zeebeTest.getProcessInstanceEvent())
         .hasVariableSatisfies(

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/resources/a2a-connectors-standalone.bpmn
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/resources/a2a-connectors-standalone.bpmn
@@ -33,7 +33,7 @@
           <zeebe:property name="data.connection.url" value="=a2aServerUrl" />
           <zeebe:property name="data.clientResponse" value="=internal_clientResponse" />
           <zeebe:property name="data.historyLength" value="3" />
-          <zeebe:property name="data.processPollingInterval" value="PT5S" />
+          <zeebe:property name="data.processPollingInterval" value="PT2S" />
           <zeebe:property name="data.taskPollingInterval" value="PT1S" />
           <zeebe:property name="activationCondition" value="=if result.kind = &#34;task&#34; then&#10;  is defined(result.status.state) and not(list contains([&#34;submitted&#34;, &#34;working&#34;], result.status.state))&#10;else&#10;  true" />
           <zeebe:property name="correlationKeyExpression" value="=pollingData.id" />

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/resources/agentic-ai-ahsp-connectors-a2a.bpmn
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/resources/agentic-ai-ahsp-connectors-a2a.bpmn
@@ -160,8 +160,8 @@
             <zeebe:property name="data.connection.agentCardLocation" value="/agents/agent-card.json" />
             <zeebe:property name="data.clientResponse" value="=internal_clientResponse" />
             <zeebe:property name="data.historyLength" value="3" />
-            <zeebe:property name="data.processPollingInterval" value="PT5S" />
-            <zeebe:property name="data.taskPollingInterval" value="PT5S" />
+            <zeebe:property name="data.processPollingInterval" value="PT2S" />
+            <zeebe:property name="data.taskPollingInterval" value="PT2S" />
             <zeebe:property name="activationCondition" value="=if result.kind = &#34;task&#34; then&#10;  is defined(result.status.state) and not(list contains([&#34;submitted&#34;, &#34;working&#34;], result.status.state))&#10;else&#10;  true" />
             <zeebe:property name="correlationKeyExpression" value="=pollingData.id" />
             <zeebe:property name="deduplicationModeManualFlag" value="false" />
@@ -183,8 +183,8 @@
             <zeebe:property name="data.connection.url" value="=a2aServerUrl" />
             <zeebe:property name="data.clientResponse" value="=internal_clientResponse" />
             <zeebe:property name="data.historyLength" value="3" />
-            <zeebe:property name="data.processPollingInterval" value="PT5S" />
-            <zeebe:property name="data.taskPollingInterval" value="PT5S" />
+            <zeebe:property name="data.processPollingInterval" value="PT2S" />
+            <zeebe:property name="data.taskPollingInterval" value="PT2S" />
             <zeebe:property name="activationCondition" value="=if result.kind = &#34;task&#34; then&#10;  is defined(result.status.state) and not(list contains([&#34;submitted&#34;, &#34;working&#34;], result.status.state))&#10;else&#10;  true" />
             <zeebe:property name="correlationKeyExpression" value="=pollingData.id" />
             <zeebe:property name="deduplicationModeManualFlag" value="false" />

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/resources/agentic-ai-connectors-a2a.bpmn
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/resources/agentic-ai-connectors-a2a.bpmn
@@ -142,8 +142,8 @@
             <zeebe:property name="data.connection.agentCardLocation" value="/agents/agent-card.json" />
             <zeebe:property name="data.clientResponse" value="=internal_clientResponse" />
             <zeebe:property name="data.historyLength" value="3" />
-            <zeebe:property name="data.processPollingInterval" value="PT5S" />
-            <zeebe:property name="data.taskPollingInterval" value="PT30S" />
+            <zeebe:property name="data.processPollingInterval" value="PT2S" />
+            <zeebe:property name="data.taskPollingInterval" value="PT2S" />
             <zeebe:property name="activationCondition" value="=if result.kind = &#34;task&#34; then&#10;  is defined(result.status.state) and not(list contains([&#34;submitted&#34;, &#34;working&#34;], result.status.state))&#10;else&#10;  true" />
             <zeebe:property name="correlationKeyExpression" value="=pollingData.id" />
             <zeebe:property name="deduplicationModeManualFlag" value="false" />
@@ -250,8 +250,8 @@
             <zeebe:property name="data.connection.url" value="=a2aServerUrl" />
             <zeebe:property name="data.clientResponse" value="=internal_clientResponse" />
             <zeebe:property name="data.historyLength" value="3" />
-            <zeebe:property name="data.processPollingInterval" value="PT5S" />
-            <zeebe:property name="data.taskPollingInterval" value="PT30S" />
+            <zeebe:property name="data.processPollingInterval" value="PT2S" />
+            <zeebe:property name="data.taskPollingInterval" value="PT2S" />
             <zeebe:property name="activationCondition" value="=if result.kind = &#34;task&#34; then&#10;  is defined(result.status.state) and not(list contains([&#34;submitted&#34;, &#34;working&#34;], result.status.state))&#10;else&#10;  true" />
             <zeebe:property name="correlationKeyExpression" value="=pollingData.id" />
             <zeebe:property name="deduplicationModeManualFlag" value="false" />

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/resources/application.yml
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/resources/application.yml
@@ -1,3 +1,0 @@
-camunda:
-  process-test:
-    runtime-mode: shared

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/resources/application.yml
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/resources/application.yml
@@ -1,0 +1,3 @@
+camunda:
+  process-test:
+    runtime-mode: shared

--- a/connectors-e2e-test/connectors-e2e-test-base/src/main/java/io/camunda/connector/e2e/ClusterStateDumpExtension.java
+++ b/connectors-e2e-test/connectors-e2e-test-base/src/main/java/io/camunda/connector/e2e/ClusterStateDumpExtension.java
@@ -84,8 +84,8 @@ public class ClusterStateDumpExtension implements AfterTestExecutionCallback {
           .forEach(
               broker -> {
                 System.err.printf(
-                    "[cluster-dump]   broker %d (%s:%d) version=%s%n",
-                    broker.getNodeId(), broker.getHost(), broker.getPort(), broker.getVersion());
+                    "[cluster-dump]   broker %s (%s:%d) version=%s%n",
+                    broker.getMemberId(), broker.getHost(), broker.getPort(), broker.getVersion());
                 broker
                     .getPartitions()
                     .forEach(

--- a/connectors-e2e-test/connectors-e2e-test-base/src/main/java/io/camunda/connector/e2e/ClusterStateDumpExtension.java
+++ b/connectors-e2e-test/connectors-e2e-test-base/src/main/java/io/camunda/connector/e2e/ClusterStateDumpExtension.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.e2e;
+
+import io.camunda.client.CamundaClient;
+import org.junit.jupiter.api.extension.AfterTestExecutionCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+/**
+ * On any test failure, dumps the Camunda cluster topology + per-partition health (and active
+ * incidents) to {@code System.err}. Surefire captures this into the {@code *-output.txt} artifact,
+ * so every flaky CI failure self-documents the broker state at failure time — making it possible to
+ * tell a transient partition-health flap (e.g. "Services not installed" / "Snapshot not taken yet")
+ * apart from a genuine test bug without re-running.
+ *
+ * <p>Implemented as an {@link AfterTestExecutionCallback} rather than a {@code TestWatcher} on
+ * purpose: camunda-process-test unbinds the proxied {@link CamundaClient} in Spring's {@code
+ * afterTestMethod} (an {@code AfterEachCallback}), which runs <em>after</em> {@code
+ * TestWatcher#testFailed}. {@code afterTestExecution} runs before any {@code AfterEachCallback}, so
+ * the client is still usable here.
+ *
+ * <p>Read-only and strictly best-effort: it swallows its own errors and never masks the original
+ * test failure. Apply with {@code @ExtendWith(ClusterStateDumpExtension.class)} on a base test
+ * class.
+ */
+public class ClusterStateDumpExtension implements AfterTestExecutionCallback {
+
+  @Override
+  public void afterTestExecution(final ExtensionContext context) {
+    if (context.getExecutionException().isEmpty()) {
+      return; // test passed — nothing to dump
+    }
+    System.err.println(
+        "===== CLUSTER STATE DUMP (test failed: " + context.getDisplayName() + ") =====");
+    try {
+      final CamundaClient client = resolveClient(context);
+      if (client == null) {
+        System.err.println("[cluster-dump] no CamundaClient in application context; skipping");
+        return;
+      }
+      dumpTopology(client);
+      dumpIncidents(client);
+    } catch (final Throwable t) {
+      System.err.println("[cluster-dump] failed to collect cluster state: " + t);
+    } finally {
+      System.err.println("===== END CLUSTER STATE DUMP =====");
+    }
+  }
+
+  private CamundaClient resolveClient(final ExtensionContext context) {
+    try {
+      return SpringExtension.getApplicationContext(context).getBean(CamundaClient.class);
+    } catch (final Throwable t) {
+      return null;
+    }
+  }
+
+  private void dumpTopology(final CamundaClient client) {
+    try {
+      final var topology = client.newTopologyRequest().send().join();
+      System.err.printf(
+          "[cluster-dump] topology: clusterSize=%d partitions=%d replicationFactor=%d brokers=%d%n",
+          topology.getClusterSize(),
+          topology.getPartitionsCount(),
+          topology.getReplicationFactor(),
+          topology.getBrokers().size());
+      topology
+          .getBrokers()
+          .forEach(
+              broker -> {
+                System.err.printf(
+                    "[cluster-dump]   broker %d (%s:%d) version=%s%n",
+                    broker.getNodeId(), broker.getHost(), broker.getPort(), broker.getVersion());
+                broker
+                    .getPartitions()
+                    .forEach(
+                        p ->
+                            System.err.printf(
+                                "[cluster-dump]     partition %d role=%s health=%s%n",
+                                p.getPartitionId(), p.getRole(), p.getHealth()));
+              });
+    } catch (final Throwable t) {
+      System.err.println(
+          "[cluster-dump] TOPOLOGY REQUEST FAILED (broker unreachable/unhealthy?): " + t);
+    }
+  }
+
+  private void dumpIncidents(final CamundaClient client) {
+    try {
+      final var incidents = client.newIncidentSearchRequest().send().join();
+      final var items = incidents.items();
+      System.err.printf("[cluster-dump] active incidents: %d%n", items.size());
+      items.stream().limit(20).forEach(i -> System.err.println("[cluster-dump]   " + i));
+    } catch (final Throwable t) {
+      System.err.println("[cluster-dump] incident search failed: " + t);
+    }
+  }
+}

--- a/connectors-e2e-test/connectors-e2e-test-base/src/main/java/io/camunda/connector/e2e/ZeebeTest.java
+++ b/connectors-e2e-test/connectors-e2e-test-base/src/main/java/io/camunda/connector/e2e/ZeebeTest.java
@@ -105,7 +105,11 @@ public class ZeebeTest {
   }
 
   public ZeebeTest waitForProcessCompletion(Duration timeout) {
-    CamundaAssert.assertThat(processInstanceEvent).withAssertionTimeout(timeout).isCompleted();
+    Awaitility.with()
+        .pollInSameThread()
+        .await()
+        .atMost(timeout)
+        .untilAsserted(() -> CamundaAssert.assertThat(processInstanceEvent).isCompleted());
     return this;
   }
 
@@ -114,9 +118,11 @@ public class ZeebeTest {
   }
 
   public ZeebeTest waitForActiveIncidents(Duration timeout) {
-    CamundaAssert.assertThat(processInstanceEvent)
-        .withAssertionTimeout(timeout)
-        .hasActiveIncidents();
+    Awaitility.with()
+        .pollInSameThread()
+        .await()
+        .atMost(timeout)
+        .untilAsserted(() -> CamundaAssert.assertThat(processInstanceEvent).hasActiveIncidents());
     return this;
   }
 

--- a/connectors-e2e-test/connectors-e2e-test-base/src/main/java/io/camunda/connector/e2e/ZeebeTest.java
+++ b/connectors-e2e-test/connectors-e2e-test-base/src/main/java/io/camunda/connector/e2e/ZeebeTest.java
@@ -89,7 +89,7 @@ public class ZeebeTest {
                                   .map(
                                       p ->
                                           "broker "
-                                              + broker.getNodeId()
+                                              + broker.getMemberId()
                                               + " partition "
                                               + p.getPartitionId()
                                               + " = "

--- a/connectors-e2e-test/connectors-e2e-test-base/src/main/java/io/camunda/connector/e2e/ZeebeTest.java
+++ b/connectors-e2e-test/connectors-e2e-test-base/src/main/java/io/camunda/connector/e2e/ZeebeTest.java
@@ -27,7 +27,6 @@ import io.camunda.zeebe.model.bpmn.instance.Process;
 import java.time.Duration;
 import java.util.Collections;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Assertions;
 import org.springframework.util.CollectionUtils;
@@ -102,20 +101,22 @@ public class ZeebeTest {
   }
 
   public ZeebeTest waitForProcessCompletion() {
-    Awaitility.with()
-        .pollInSameThread()
-        .await()
-        .atMost(20, TimeUnit.SECONDS)
-        .untilAsserted(() -> CamundaAssert.assertThat(processInstanceEvent).isCompleted());
+    return waitForProcessCompletion(Duration.ofSeconds(20));
+  }
+
+  public ZeebeTest waitForProcessCompletion(Duration timeout) {
+    CamundaAssert.assertThat(processInstanceEvent).withAssertionTimeout(timeout).isCompleted();
     return this;
   }
 
   public ZeebeTest waitForActiveIncidents() {
-    Awaitility.with()
-        .pollInSameThread()
-        .await()
-        .atMost(20, TimeUnit.SECONDS)
-        .untilAsserted(() -> CamundaAssert.assertThat(processInstanceEvent).hasActiveIncidents());
+    return waitForActiveIncidents(Duration.ofSeconds(20));
+  }
+
+  public ZeebeTest waitForActiveIncidents(Duration timeout) {
+    CamundaAssert.assertThat(processInstanceEvent)
+        .withAssertionTimeout(timeout)
+        .hasActiveIncidents();
     return this;
   }
 

--- a/connectors-e2e-test/connectors-e2e-test-base/src/main/java/io/camunda/connector/e2e/ZeebeTest.java
+++ b/connectors-e2e-test/connectors-e2e-test-base/src/main/java/io/camunda/connector/e2e/ZeebeTest.java
@@ -17,16 +17,21 @@
 package io.camunda.connector.e2e;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.response.DeploymentEvent;
+import io.camunda.client.api.response.PartitionBrokerHealth;
+import io.camunda.client.api.response.PartitionInfo;
 import io.camunda.client.api.response.ProcessInstanceEvent;
 import io.camunda.process.test.api.CamundaAssert;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.model.bpmn.instance.Process;
 import java.time.Duration;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Assertions;
 import org.springframework.util.CollectionUtils;
@@ -46,9 +51,17 @@ public class ZeebeTest {
   }
 
   public ZeebeTest awaitCompleteTopology() {
-    return awaitCompleteTopology(1, 1, 1, Duration.ofSeconds(10));
+    return awaitCompleteTopology(1, 1, 1, Duration.ofSeconds(30));
   }
 
+  /**
+   * Waits until the topology is complete <em>and healthy</em>: the expected number of brokers and
+   * partitions are present, and every reported partition is {@link PartitionBrokerHealth#HEALTHY}
+   * with a healthy leader. The plain count check is not enough — under CPU contention the broker
+   * reports the right topology counts while a partition is still installing services (health {@code
+   * UNHEALTHY}, e.g. "Services not installed" / "Snapshot not taken yet"), so deploying against it
+   * races a partition that cannot yet serve and leads to flaky assertion timeouts.
+   */
   public ZeebeTest awaitCompleteTopology(
       final int clusterSize,
       final int partitionCount,
@@ -65,6 +78,36 @@ public class ZeebeTest {
               assertEquals(clusterSize, topology.getBrokers().size());
               assertEquals(partitionCount, topology.getPartitionsCount());
               assertEquals(replicationFactor, topology.getReplicationFactor());
+
+              // Every partition reported by any broker must be healthy.
+              final List<String> unhealthy =
+                  topology.getBrokers().stream()
+                      .flatMap(
+                          broker ->
+                              broker.getPartitions().stream()
+                                  .filter(p -> p.getHealth() != PartitionBrokerHealth.HEALTHY)
+                                  .map(
+                                      p ->
+                                          "broker "
+                                              + broker.getNodeId()
+                                              + " partition "
+                                              + p.getPartitionId()
+                                              + " = "
+                                              + p.getHealth()))
+                      .collect(Collectors.toList());
+              assertTrue(unhealthy.isEmpty(), () -> "partitions not healthy yet: " + unhealthy);
+
+              // Each partition must have a healthy leader so the broker can serve requests.
+              for (int partitionId = 1; partitionId <= partitionCount; partitionId++) {
+                final int pid = partitionId;
+                final boolean hasHealthyLeader =
+                    topology.getBrokers().stream()
+                        .flatMap(broker -> broker.getPartitions().stream())
+                        .filter(p -> p.getPartitionId() == pid)
+                        .filter(PartitionInfo::isLeader)
+                        .anyMatch(p -> p.getHealth() == PartitionBrokerHealth.HEALTHY);
+                assertTrue(hasHealthyLeader, "no healthy leader for partition " + pid + " yet");
+              }
             });
     return this;
   }

--- a/connectors-e2e-test/connectors-e2e-test-base/src/main/resources/application.properties
+++ b/connectors-e2e-test/connectors-e2e-test-base/src/main/resources/application.properties
@@ -3,4 +3,3 @@ logging.level.io.camunda.process.test=info
 logging.level.org.testcontainers=warn
 logging.level.tc=warn
 logging.level.io.camunda.connector=debug
-io.camunda.process.test.camundaVersion=SNAPSHOT

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -982,7 +982,7 @@ limitations under the License.</license.inlineheader>
           <artifactId>maven-surefire-plugin</artifactId>
           <version>${plugin.version.maven-surefire-plugin}</version>
           <configuration>
-<!--            <redirectTestOutputToFile>true</redirectTestOutputToFile>-->
+            <redirectTestOutputToFile>true</redirectTestOutputToFile>
             <runOrder>hourly</runOrder>
             <argLine>-Duser.language=en -Duser.region=US</argLine>
           </configuration>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -982,7 +982,7 @@ limitations under the License.</license.inlineheader>
           <artifactId>maven-surefire-plugin</artifactId>
           <version>${plugin.version.maven-surefire-plugin}</version>
           <configuration>
-            <redirectTestOutputToFile>true</redirectTestOutputToFile>
+<!--            <redirectTestOutputToFile>true</redirectTestOutputToFile>-->
             <runOrder>hourly</runOrder>
             <argLine>-Duser.language=en -Duser.region=US</argLine>
           </configuration>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -984,7 +984,7 @@ limitations under the License.</license.inlineheader>
           <configuration>
             <redirectTestOutputToFile>true</redirectTestOutputToFile>
             <runOrder>hourly</runOrder>
-            <argLine>-XX:InitialRAMPercentage=75.0 -XX:MaxRAMPercentage=75.0 -Duser.language=en -Duser.region=US</argLine>
+            <argLine>-XX:InitialRAMPercentage=65.0 -XX:MaxRAMPercentage=65.0 -Duser.language=en -Duser.region=US</argLine>
           </configuration>
         </plugin>
         <plugin>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -984,7 +984,7 @@ limitations under the License.</license.inlineheader>
           <configuration>
             <redirectTestOutputToFile>true</redirectTestOutputToFile>
             <runOrder>hourly</runOrder>
-            <argLine>-Duser.language=en -Duser.region=US</argLine>
+            <argLine>-XX:InitialRAMPercentage=75.0 -XX:MaxRAMPercentage=75.0 -Duser.language=en -Duser.region=US</argLine>
           </configuration>
         </plugin>
         <plugin>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -950,18 +950,18 @@ limitations under the License.</license.inlineheader>
     </repository>
 
     <!-- opensaml dependencies for soap connector -->
-<!--    <repository>-->
-<!--      <id>shibboleth</id>-->
-<!--      <name>Shibboleth Releases Repository</name>-->
-<!--      <url>https://build.shibboleth.net/maven/releases/</url>-->
-<!--      <releases>-->
-<!--        <enabled>true</enabled>-->
-<!--        <checksumPolicy>warn</checksumPolicy>-->
-<!--      </releases>-->
-<!--      <snapshots>-->
-<!--        <enabled>false</enabled>-->
-<!--      </snapshots>-->
-<!--    </repository>-->
+    <repository>
+      <id>shibboleth</id>
+      <name>Shibboleth Releases Repository</name>
+      <url>https://build.shibboleth.net/maven/releases/</url>
+      <releases>
+        <enabled>true</enabled>
+        <checksumPolicy>warn</checksumPolicy>
+      </releases>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+    </repository>
   </repositories>
 
   <build>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -984,7 +984,7 @@ limitations under the License.</license.inlineheader>
           <configuration>
             <redirectTestOutputToFile>true</redirectTestOutputToFile>
             <runOrder>hourly</runOrder>
-            <argLine>-XX:InitialRAMPercentage=65.0 -XX:MaxRAMPercentage=65.0 -Duser.language=en -Duser.region=US</argLine>
+            <argLine>-Duser.language=en -Duser.region=US</argLine>
           </configuration>
         </plugin>
         <plugin>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -950,18 +950,18 @@ limitations under the License.</license.inlineheader>
     </repository>
 
     <!-- opensaml dependencies for soap connector -->
-    <repository>
-      <id>shibboleth</id>
-      <name>Shibboleth Releases Repository</name>
-      <url>https://build.shibboleth.net/maven/releases/</url>
-      <releases>
-        <enabled>true</enabled>
-        <checksumPolicy>warn</checksumPolicy>
-      </releases>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-    </repository>
+<!--    <repository>-->
+<!--      <id>shibboleth</id>-->
+<!--      <name>Shibboleth Releases Repository</name>-->
+<!--      <url>https://build.shibboleth.net/maven/releases/</url>-->
+<!--      <releases>-->
+<!--        <enabled>true</enabled>-->
+<!--        <checksumPolicy>warn</checksumPolicy>-->
+<!--      </releases>-->
+<!--      <snapshots>-->
+<!--        <enabled>false</enabled>-->
+<!--      </snapshots>-->
+<!--    </repository>-->
   </repositories>
 
   <build>


### PR DESCRIPTION
## Description

  The agentic-ai e2e suite (mainly the A2A integration tests) flaked intermittently: webhook context collisions, non-deterministic feedback handling, cross-test state bleed, and ad-hoc timeouts. This PR addresses each:

  - Unique webhook context per A2A test fixes the Context: test-webhook-id already in use collision that parked the webhook executable DOWN across consecutive tests/reruns (new customizeModel hook plus TestUtil.setWebhookContext).
  - Per-class CPT runtime: drop runtime-mode: shared, whose cross-class carryover reintroduced the same collision.
  - Per-test WireMock reset: clear scenarios/stubs in `@BeforeEach` to stop stub bleed.
  - Deterministic user-feedback: replace the timing-sensitive when/then conditional (gated behind a costly condition-await timeout) with a queued mock job worker.
  - Centralized timeouts: Duration-based waitForProcessCompletion/waitForActiveIncidents (default 30s) instead of per-test timeout setup.
  - PT2S A2A polling: tighten task/process polling in the A2A BPMNs so polled completions surface promptly.
  - Split E2E test execution into matrix based workflow
     - Each branch (on PR it's only main) builds connectors and e2e test base modules first
     - For each e2e test module a separate matrix branch is created
     - Each matrix branch pulls the pre-built artifacts from cache
  - Retain CI logs: upload surefire *-output.txt (redirected stdout) alongside the XML reports.

## Checklist

- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest
  release, as this branch will be rebased onto main before the next release. Example backport labels:
    - `backport stable/8.8`: for changes that should be included in the next 8.8.x release.
    - **or** `backport release-8.8.7`: for changes that should be included in the specific release 8.8.7, and this
      *release has already been created*. The release branch will be merged back into stable/8.8 later, so the change
      will be included in future 8.8.x releases as well.
- [ ] Tests/Integration tests for the changes have been added if applicable.
- [ ] If the change requires a documentation update, it has been added to the appropriate section in the documentation.


