### PR TITLE
feat(element-template-generator): support template-only properties via TemplateOnly marker

### DIFF
--- a/docs/adr/ADR-0002-template-only-properties.md
+++ b/docs/adr/ADR-0002-template-only-properties.md
@@ -1,0 +1,45 @@
+# ADR-0002: Template-Only Properties via the TemplateOnly Marker
+
+## Status
+Accepted
+
+## Context
+Element templates expose properties for the Camunda Modeler UI. Historically every
+`@TemplateProperty` was also bound to the connector's Java input model and read at runtime.
+But some properties are pure output or runtime concerns whose value must be resolved per
+request from the *activated* process element — not from a shared connector instance. Because
+inbound connectors deduplicate elements into a single executable, binding such a property to
+the model means the executable holds whichever element's value won the grouping (the webhook
+`responseExpression` bug, [#6684](https://github.com/camunda/connectors/issues/6684)). The
+generator had no first-class way to express "appears in the template, never bound."
+
+## Decision
+Introduce an uninstantiable `TemplateOnly` marker type in the element-template-generator. A
+`@TemplateProperty`-annotated field of type `TemplateOnly` is *template-only*: emitted into the
+generated template but never bound to the model. The generator enforces at build time that such
+a field
+
+- is excluded from binding — declared `static` or annotated `@JsonIgnore`; and
+- declares an explicit `@TemplateProperty(type = ...)`, since the marker carries no inferable
+  property type.
+
+The template type is owned by the annotation, never derived from the Java field type. The
+runtime is responsible for resolving the corresponding value per request from the activated
+element.
+
+## Consequences
+
+### Positive
+- "No runtime value" is enforced by the type system — `null` is the only assignable value, so
+  there is nothing meaningful to read even reflectively.
+- Build-time checks reject a template-only field that is bound or lacks an explicit type, so the
+  guarantee cannot be dropped by accident; usages are greppable.
+- Declaring the field as a `@JsonIgnore`'d record component keeps it in its original position, so
+  generated templates remain byte-identical (no display-order churn) when migrating a property.
+- Gives connector authors a correct, explicit tool for per-request and output-only properties.
+
+### Negative
+- Adds a generator-specific concept that connector authors must learn.
+- A `@JsonIgnore`'d record component leaves a vestigial accessor that always returns `null`.
+- Correctness relies on two coupled requirements (the marker type plus exclusion from binding)
+  enforced by the generator rather than by the language.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -81,3 +81,4 @@ When asked to create an ADR:
 | ADR | Title | Status |
 |-----|-------|--------|
 | [ADR-0001](ADR-0001-annotation-driven-element-template-generation.md) | Annotation-Driven Element Template Generation | Accepted |
+| [ADR-0002](ADR-0002-template-only-properties.md) | Template-Only Properties via the TemplateOnly Marker | Accepted |

--- a/element-template-generator/annotations/src/main/java/io/camunda/connector/generator/java/annotation/TemplateOnly.java
+++ b/element-template-generator/annotations/src/main/java/io/camunda/connector/generator/java/annotation/TemplateOnly.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.generator.java.annotation;
+
+/**
+ * Marker type for a <em>template-only</em> property.
+ *
+ * <p>A {@code static} field of this type, annotated with {@link TemplateProperty}, declares a
+ * property that appears in the generated element template but is never part of the bound connector
+ * model: the runtime is responsible for resolving the corresponding value (for example, per request
+ * from the activated element). The {@code static} modifier is what keeps the field out of the model
+ * — it is ignored by Jackson during binding and a record exposes no accessor for it.
+ *
+ * <p>This type exists to make that intent explicit and type-safe at the declaration site:
+ *
+ * <ul>
+ *   <li>It is uninstantiable, so the <em>only</em> assignable value is {@code null}. "No runtime
+ *       value" is therefore enforced by the type system rather than by convention — there is no
+ *       meaningful value to read even reflectively.
+ *   <li>It carries no inferable property type, so the element-template-generator requires the field
+ *       to declare an explicit {@link TemplateProperty#type()}. The template type is owned by the
+ *       annotation, never derived from the Java field type.
+ *   <li>Usages are greppable: searching for references of this type lists every template-only
+ *       property in the codebase.
+ * </ul>
+ */
+public final class TemplateOnly {
+
+  private TemplateOnly() {
+    throw new UnsupportedOperationException(
+        "TemplateOnly is a marker type that holds no value and cannot be instantiated");
+  }
+}

--- a/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/util/TemplatePropertiesUtil.java
+++ b/element-template-generator/core/src/main/java/io/camunda/connector/generator/java/util/TemplatePropertiesUtil.java
@@ -16,8 +16,7 @@
  */
 package io.camunda.connector.generator.java.util;
 
-import static io.camunda.connector.util.reflection.ReflectionUtil.getAllFields;
-
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.JsonNode;
 import io.camunda.connector.api.annotation.Header;
 import io.camunda.connector.api.annotation.Variable;
@@ -41,6 +40,7 @@ import io.camunda.connector.generator.java.util.TemplateGenerationContext.Outbou
 import java.lang.annotation.Annotation;
 import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
 import java.lang.reflect.Parameter;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
@@ -122,7 +122,7 @@ public class TemplatePropertiesUtil {
       return handleSealedType(type, context);
     }
 
-    var fields = getAllFields(type);
+    var fields = getAllTemplateFields(type);
     var properties = new ArrayList<PropertyBuilder>();
 
     for (Field field : fields) {
@@ -131,6 +131,33 @@ public class TemplatePropertiesUtil {
         throw new IllegalStateException(
             "@TemplateProperty and @TemplateDocumentProperty are mutually exclusive on: "
                 + field.getName());
+      }
+      if (field.getType() == TemplateOnly.class) {
+        // A TemplateOnly field declares a template-only property: it must be excluded from binding
+        // (either declared static, or annotated @JsonIgnore if kept as a record component/field)
+        // and carries no inferable property type (hence an explicit type is required).
+        var templateOnlyAnnotation = field.getAnnotation(TemplateProperty.class);
+        boolean excludedFromBinding =
+            Modifier.isStatic(field.getModifiers()) || field.isAnnotationPresent(JsonIgnore.class);
+        if (!excludedFromBinding) {
+          throw new IllegalStateException(
+              "TemplateOnly field '"
+                  + field.getName()
+                  + "' in "
+                  + type.getName()
+                  + " must be excluded from binding (declare it static or annotate it @JsonIgnore):"
+                  + " a template-only property is never bound to the model.");
+        }
+        if (templateOnlyAnnotation == null
+            || templateOnlyAnnotation.type() == PropertyType.Unknown) {
+          throw new IllegalStateException(
+              "TemplateOnly field '"
+                  + field.getName()
+                  + "' in "
+                  + type.getName()
+                  + " must declare an explicit @TemplateProperty(type=...): the marker type"
+                  + " carries no property type to infer.");
+        }
       }
       if (documentAnnotation != null) {
         properties.addAll(
@@ -184,6 +211,35 @@ public class TemplatePropertiesUtil {
       }
     }
     return properties.stream().filter(Objects::nonNull).toList();
+  }
+
+  /**
+   * Collects the fields of {@code type} (and its supertypes) that contribute template properties.
+   *
+   * <p>Behaves like {@link io.camunda.connector.util.reflection.ReflectionUtil#getAllFields} for
+   * instance fields, preserving their declaration order. In addition, {@code static} fields are
+   * included when (and only when) they carry a {@link TemplateProperty} or {@link
+   * TemplateDocumentProperty} annotation. Such fields let a connector declare a property that
+   * appears in the element template but is never part of the bound data model: a {@code static}
+   * field is ignored by Jackson during binding and has no record component accessor, so it cannot
+   * be read as element data. The runtime is responsible for handling the corresponding binding.
+   *
+   * <p>Non-annotated {@code static} fields (e.g. plain constants) are skipped, so they never leak
+   * into templates.
+   */
+  private static List<Field> getAllTemplateFields(Class<?> type) {
+    var fields = new ArrayList<Field>();
+    for (Class<?> current = type; current != null; current = current.getSuperclass()) {
+      for (Field field : current.getDeclaredFields()) {
+        if (!Modifier.isStatic(field.getModifiers())) {
+          fields.add(field);
+        } else if (field.isAnnotationPresent(TemplateProperty.class)
+            || field.isAnnotationPresent(TemplateDocumentProperty.class)) {
+          fields.add(field);
+        }
+      }
+    }
+    return fields;
   }
 
   /**

--- a/element-template-generator/core/src/test/java/io/camunda/connector/generator/java/util/TemplatePropertiesUtilTest.java
+++ b/element-template-generator/core/src/test/java/io/camunda/connector/generator/java/util/TemplatePropertiesUtilTest.java
@@ -17,11 +17,22 @@
 package io.camunda.connector.generator.java.util;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import io.camunda.connector.generator.dsl.PropertyBinding.ZeebeProperty;
+import io.camunda.connector.generator.java.annotation.TemplateOnly;
+import io.camunda.connector.generator.java.annotation.TemplateProperty;
+import io.camunda.connector.generator.java.annotation.TemplateProperty.PropertyType;
+import io.camunda.connector.generator.java.util.TemplateGenerationContext.Inbound;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
 public class TemplatePropertiesUtilTest {
+
+  private static final Inbound INBOUND_CONTEXT = new Inbound("my-type", Set.of());
 
   @ParameterizedTest
   @CsvSource({
@@ -36,5 +47,134 @@ public class TemplatePropertiesUtilTest {
 
     // then
     assertThat(actual).isEqualTo(expected);
+  }
+
+  /** A model with a bound instance field, a template-only static field, and a plain constant. */
+  record ModelWithStaticTemplateProperty(
+      @TemplateProperty(id = "instanceProp") String instanceProp) {
+
+    @TemplateProperty(
+        id = "staticProp",
+        label = "Static prop",
+        type = PropertyType.Text,
+        group = "responses")
+    private static final String staticProp = null;
+
+    private static final String NOT_A_TEMPLATE_PROPERTY = "constant";
+  }
+
+  @Test
+  void staticTemplateProperty_isEmitted() {
+    var properties =
+        TemplatePropertiesUtil.extractTemplatePropertiesFromType(
+            ModelWithStaticTemplateProperty.class, INBOUND_CONTEXT);
+
+    var staticProp =
+        properties.stream()
+            .map(builder -> builder.build())
+            .filter(p -> "staticProp".equals(p.getId()))
+            .findFirst()
+            .orElseThrow();
+
+    assertThat(staticProp.getType()).isEqualTo("Text");
+    assertThat(staticProp.getGroup()).isEqualTo("responses");
+    assertThat(staticProp.getBinding()).isEqualTo(new ZeebeProperty("staticProp"));
+  }
+
+  @Test
+  void nonAnnotatedStaticField_isNotEmitted() {
+    var ids =
+        TemplatePropertiesUtil.extractTemplatePropertiesFromType(
+                ModelWithStaticTemplateProperty.class, INBOUND_CONTEXT)
+            .stream()
+            .map(p -> p.build().getId())
+            .toList();
+
+    assertThat(ids)
+        .contains("instanceProp", "staticProp")
+        .doesNotContain("NOT_A_TEMPLATE_PROPERTY");
+  }
+
+  /** A model whose template-only property is declared via the {@link TemplateOnly} marker type. */
+  record ModelWithTemplateOnlyMarker(@TemplateProperty(id = "instanceProp") String instanceProp) {
+
+    @TemplateProperty(
+        id = "templateOnlyProp",
+        label = "Template-only prop",
+        type = PropertyType.Text,
+        group = "responses")
+    private static final TemplateOnly templateOnlyProp = null;
+  }
+
+  @Test
+  void templateOnlyMarkerProperty_isEmittedWithAnnotationType() {
+    var templateOnlyProp =
+        TemplatePropertiesUtil.extractTemplatePropertiesFromType(
+                ModelWithTemplateOnlyMarker.class, INBOUND_CONTEXT)
+            .stream()
+            .map(builder -> builder.build())
+            .filter(p -> "templateOnlyProp".equals(p.getId()))
+            .findFirst()
+            .orElseThrow();
+
+    assertThat(templateOnlyProp.getType()).isEqualTo("Text");
+    assertThat(templateOnlyProp.getGroup()).isEqualTo("responses");
+    assertThat(templateOnlyProp.getBinding()).isEqualTo(new ZeebeProperty("templateOnlyProp"));
+  }
+
+  /** A {@link TemplateOnly} component that is neither static nor @JsonIgnore'd would be bound. */
+  record ModelWithBoundTemplateOnly(
+      @TemplateProperty(id = "bad", type = PropertyType.Text) TemplateOnly bad) {}
+
+  @Test
+  void templateOnlyMarker_mustBeExcludedFromBinding() {
+    assertThatThrownBy(
+            () ->
+                TemplatePropertiesUtil.extractTemplatePropertiesFromType(
+                    ModelWithBoundTemplateOnly.class, INBOUND_CONTEXT))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("must be excluded from binding");
+  }
+
+  /**
+   * A {@link TemplateOnly} property may be kept as a record component (preserving its position in
+   * the template) as long as it is @JsonIgnore'd so it is never bound.
+   */
+  record ModelWithJsonIgnoredTemplateOnly(
+      @TemplateProperty(id = "instanceProp") String instanceProp,
+      @JsonIgnore
+          @TemplateProperty(id = "ignoredProp", type = PropertyType.Text, group = "responses")
+          TemplateOnly ignoredProp) {}
+
+  @Test
+  void templateOnlyMarker_asJsonIgnoredComponent_isEmitted() {
+    var ignoredProp =
+        TemplatePropertiesUtil.extractTemplatePropertiesFromType(
+                ModelWithJsonIgnoredTemplateOnly.class, INBOUND_CONTEXT)
+            .stream()
+            .map(builder -> builder.build())
+            .filter(p -> "ignoredProp".equals(p.getId()))
+            .findFirst()
+            .orElseThrow();
+
+    assertThat(ignoredProp.getType()).isEqualTo("Text");
+    assertThat(ignoredProp.getBinding()).isEqualTo(new ZeebeProperty("ignoredProp"));
+  }
+
+  /** The marker type carries no inferable property type, so an explicit type is required. */
+  record ModelWithUntypedTemplateOnly(@TemplateProperty(id = "instanceProp") String instanceProp) {
+
+    @TemplateProperty(id = "untyped", group = "responses")
+    private static final TemplateOnly untyped = null;
+  }
+
+  @Test
+  void templateOnlyMarker_requiresExplicitType() {
+    assertThatThrownBy(
+            () ->
+                TemplatePropertiesUtil.extractTemplatePropertiesFromType(
+                    ModelWithUntypedTemplateOnly.class, INBOUND_CONTEXT))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("explicit @TemplateProperty(type=...)");
   }
 }


### PR DESCRIPTION
## Description

Introduces support for **template-only properties** in the element-template-generator: properties that appear in the generated element template but are never part of the bound connector model. The runtime owns resolving the corresponding value.

A property is declared template-only by giving its `@TemplateProperty` field the new uninstantiable **`TemplateOnly`** marker type. Such a field:

- must be **excluded from binding** — either declared `static`, or annotated `@JsonIgnore` so it can be kept as a record component in its original declaration position;
- must declare an explicit `@TemplateProperty(type = ...)`, since the marker type carries no inferable property type.

The generator **fails the build** if either rule is violated, so the binding exclusion can't be dropped by accident. The marker type also makes the "no runtime value" guarantee type-enforced — `null` is the only assignable value, so there is nothing meaningful to read even reflectively.

This is the foundation for #6684. The webhook change that consumes it is stacked on top (see the follow-up PR).

## Related issues

Part of #6684

## Checklist

- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest
  release, as this branch will be rebased onto main before the next release. Example backport labels:
    - `backport stable/8.8`: for changes that should be included in the next 8.8.x release.
    - **or** `backport release-8.8.7`: for changes that should be included in the specific release 8.8.7, and this
      *release has already been created*. The release branch will be merged back into stable/8.8 later, so the change
      will be included in future 8.8.x releases as well.
- [ ] Tests/Integration tests for the changes have been added if applicable.
- [ ] If the change requires a documentation update, it has been added to the appropriate section in the documentation.
