### PR TITLE
fix(webhook): exclude response expression from inbound deduplication

### DIFF
--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/Keywords.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/Keywords.java
@@ -16,6 +16,7 @@
  */
 package io.camunda.connector.runtime.core;
 
+import io.camunda.connector.api.inbound.webhook.WebhookPropertyNames;
 import java.util.Set;
 
 public class Keywords {
@@ -152,6 +153,23 @@ public class Keywords {
   public static final String SYNCHRONOUS_RESPONSE = "synchronousResponse";
 
   /**
+   * The webhook connector's `response expression` property. Unlike the other keywords, this is a
+   * connector(user)-space property: it is part of the webhook connector's request model and is
+   * passed to the connector. It is referenced here only to exclude it from deduplication — the HTTP
+   * response expression does not affect the inbound subscription itself, so changing it must not
+   * produce a new executable.
+   */
+  public static final String WEBHOOK_RESPONSE_EXPRESSION_KEYWORD =
+      "inbound." + WebhookPropertyNames.RESPONSE_EXPRESSION;
+
+  /**
+   * The legacy predecessor of {@link #WEBHOOK_RESPONSE_EXPRESSION_KEYWORD}. Hidden from element
+   * templates since 8.6.0, but still supported at runtime and equally excluded from deduplication.
+   */
+  public static final String WEBHOOK_RESPONSE_BODY_EXPRESSION_KEYWORD =
+      "inbound." + WebhookPropertyNames.RESPONSE_BODY_EXPRESSION;
+
+  /**
    * Properties that are handled by the connector runtime and should not be passed to the inbound
    * connector along with the properties defined by the connector.
    */
@@ -169,8 +187,9 @@ public class Keywords {
           SYNCHRONOUS_RESPONSE);
 
   /**
-   * Subset of {@link #INBOUND_RUNTIME_PROPERTIES} that should not be used for connector
-   * deduplication
+   * Properties that should not be used for connector deduplication. Mostly a subset of {@link
+   * #INBOUND_RUNTIME_PROPERTIES}, plus the webhook response expression properties, which are
+   * connector-level but must not split otherwise identical elements into separate executables.
    */
   public static final Set<String> PROPERTIES_EXCLUDED_FROM_DEDUPLICATION =
       Set.of(
@@ -187,5 +206,7 @@ public class Keywords {
           RESULT_EXPRESSION_KEYWORD,
           RESULT_VARIABLE_KEYWORD,
           CONSUME_UNMATCHED_EVENTS_KEYWORD,
-          SYNCHRONOUS_RESPONSE);
+          SYNCHRONOUS_RESPONSE,
+          WEBHOOK_RESPONSE_EXPRESSION_KEYWORD,
+          WEBHOOK_RESPONSE_BODY_EXPRESSION_KEYWORD);
 }

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImpl.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImpl.java
@@ -289,8 +289,24 @@ public class InboundConnectorContextImpl extends AbstractConnectorContext
 
   @Override
   public <T> T bindProperties(Class<T> cls) {
+    return bindPropertiesWithSecrets(cls, getPropertiesWithSecrets(properties));
+  }
+
+  @Override
+  public <T> T bindProperties(Class<T> cls, Map<String, String> rawProperties) {
+    var wrapped = InboundPropertyHandler.readWrappedProperties(rawProperties);
+    var withSecrets =
+        InboundPropertyHandler.getPropertiesWithSecrets(
+            getSecretHandler(),
+            objectMapper,
+            wrapped,
+            new SecretContext(connectorDetails.tenantId(), connectorDetails.processDefinitionId()));
+    return bindPropertiesWithSecrets(cls, withSecrets);
+  }
+
+  private <T> T bindPropertiesWithSecrets(Class<T> cls, Map<String, Object> propertiesWithSecrets) {
     try {
-      var propertiesJson = objectMapper.valueToTree(getPropertiesWithSecrets(properties));
+      var propertiesJson = objectMapper.valueToTree(propertiesWithSecrets);
       var result =
           FeelContextAwareObjectReader.of(objectMapper)
               .withEvaluator(evaluator)

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/InboundConnectorManagementContext.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/InboundConnectorManagementContext.java
@@ -20,6 +20,7 @@ import io.camunda.connector.api.inbound.Health;
 import io.camunda.connector.api.inbound.InboundConnectorContext;
 import io.camunda.connector.runtime.core.inbound.details.InboundConnectorDetails.ValidInboundConnectorDetails;
 import java.util.List;
+import java.util.Map;
 
 public interface InboundConnectorManagementContext extends InboundConnectorContext {
 
@@ -34,6 +35,27 @@ public interface InboundConnectorManagementContext extends InboundConnectorConte
   Health getHealth();
 
   List<InboundConnectorElement> connectorElements();
+
+  /**
+   * Binds the given raw element properties to an instance of {@code cls}, applying secret
+   * replacement, validation and FEEL evaluation/deserialization the same way as {@link
+   * #bindProperties(Class)}.
+   *
+   * <p>Unlike {@link #bindProperties(Class)}, which always binds the properties of the (first)
+   * element this context was created from, this overload binds arbitrary element properties. This
+   * is needed when several elements are deduplicated into a single executable but a request must be
+   * answered using the properties of the element that was actually activated (e.g. the webhook
+   * response expression).
+   *
+   * @param cls the target type to bind to
+   * @param rawProperties the unwrapped, raw properties of the element (FEEL not evaluated, secret
+   *     placeholders not resolved), e.g. {@link
+   *     io.camunda.connector.api.inbound.ProcessElement#properties()}
+   */
+  default <T> T bindProperties(Class<T> cls, Map<String, String> rawProperties) {
+    throw new UnsupportedOperationException(
+        "Binding arbitrary element properties is not supported by this context implementation");
+  }
 
   Long getActivationTimestamp();
 

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/correlation/ActivationConditionEvaluator.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/correlation/ActivationConditionEvaluator.java
@@ -20,6 +20,7 @@ import io.camunda.connector.api.error.ConnectorInputException;
 import io.camunda.connector.api.inbound.ActivationCheckResult;
 import io.camunda.connector.feel.FeelEngineWrapperException;
 import io.camunda.connector.feel.FeelExpressionEvaluator;
+import io.camunda.connector.runtime.core.Keywords;
 import io.camunda.connector.runtime.core.inbound.InboundConnectorElement;
 import java.util.List;
 import org.slf4j.Logger;
@@ -109,6 +110,8 @@ public class ActivationConditionEvaluator {
    *   <li>All have the same message name
    *   <li>All have the same resultExpression, resultVariable, correlationKeyExpression,
    *       messageIdExpression, and timeToLive
+   *   <li>All have the same webhook response expression (excluded from deduplication, so it must be
+   *       checked here to avoid ambiguity about which response to return)
    * </ul>
    *
    * <p>When compatible, we can pick any one (the first) since they're functionally identical and
@@ -186,6 +189,28 @@ public class ActivationConditionEvaluator {
             .toList();
     if (timeToLives.size() > 1) {
       mismatches.add("timeToLive: " + timeToLives);
+    }
+
+    // The webhook response expression is excluded from deduplication, so otherwise-identical
+    // elements may be grouped into a single executable while declaring different response
+    // expressions. When several such elements match the same request we cannot tell which response
+    // to return, so they must be treated as incompatible.
+    var responseExpressions =
+        matchingElements.stream()
+            .map(e -> e.rawProperties().get(Keywords.WEBHOOK_RESPONSE_EXPRESSION_KEYWORD))
+            .distinct()
+            .toList();
+    if (responseExpressions.size() > 1) {
+      mismatches.add("responseExpression: " + responseExpressions);
+    }
+
+    var responseBodyExpressions =
+        matchingElements.stream()
+            .map(e -> e.rawProperties().get(Keywords.WEBHOOK_RESPONSE_BODY_EXPRESSION_KEYWORD))
+            .distinct()
+            .toList();
+    if (responseBodyExpressions.size() > 1) {
+      mismatches.add("responseBodyExpression: " + responseBodyExpressions);
     }
 
     if (!mismatches.isEmpty()) {

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/details/InboundConnectorDetails.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/details/InboundConnectorDetails.java
@@ -67,11 +67,25 @@ public sealed interface InboundConnectorDetails {
       implements InboundConnectorDetails {
 
     /**
+     * Properties that are relevant for deduplication, i.e. excluding runtime-level properties and
+     * the webhook response expression (see {@link
+     * io.camunda.connector.runtime.core.Keywords#PROPERTIES_EXCLUDED_FROM_DEDUPLICATION}). All
+     * grouped elements are guaranteed to share these properties by construction, so the first
+     * element is representative.
+     */
+    @JsonIgnore
+    public Map<String, String> propertiesForDeduplication() {
+      return connectorElements.getFirst().propertiesForDeduplication();
+    }
+
+    /**
      * Whether this InboundConnectorDetails is compatible with another one. Two
      * InboundConnectorDetails are compatible if they have the same type, tenantId, deduplicationId,
-     * are related to the same process definition, AND have the same properties. They can have
-     * different connector elements. This is useful to know if we can update an existing inbound
-     * connector if it has not been changed when a new process version is deployed.
+     * are related to the same process definition, AND have the same deduplication-relevant
+     * properties. They can have different connector elements, and they may differ in properties
+     * excluded from deduplication (e.g. the webhook response expression). This is useful to know if
+     * we can update an existing inbound connector if it has not been changed when a new process
+     * version is deployed.
      */
     public Optional<List<String>> checkCompatibility(ValidInboundConnectorDetails other) {
       List<String> validationErrors = new ArrayList<>();
@@ -88,7 +102,7 @@ public sealed interface InboundConnectorDetails {
         validationErrors.add("processDefinitionId mismatch");
       }
       MapDifference<String, String> diff =
-          Maps.difference(this.rawPropertiesWithoutKeywords, other.rawPropertiesWithoutKeywords);
+          Maps.difference(this.propertiesForDeduplication(), other.propertiesForDeduplication());
       if (!diff.areEqual()) {
         validationErrors.add("properties mismatch: " + diff);
       }

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/inbound/InboundConnectorDetailsTest.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/inbound/InboundConnectorDetailsTest.java
@@ -105,6 +105,72 @@ public class InboundConnectorDetailsTest {
   }
 
   @Test
+  void notMatchingResponseExpressions_returnsValid() {
+    // given
+    List<InboundConnectorElement> elements = new ArrayList<>();
+    elements.add(
+        new InboundConnectorElement(
+            Map.of(
+                "inbound.type", "type1",
+                "deduplicationMode", "AUTO",
+                "property1", "value1",
+                "inbound.responseExpression", "={statusCode: 200}",
+                "inbound.responseBodyExpression", "={body: request.body}"),
+            null,
+            new ProcessElementWithRuntimeData("myProcess", 0, 0, "element1", "<default>")));
+    elements.add(
+        new InboundConnectorElement(
+            Map.of(
+                "inbound.type", "type1",
+                "deduplicationMode", "AUTO",
+                "property1", "value1",
+                "inbound.responseExpression", "={statusCode: 201}",
+                "inbound.responseBodyExpression", "={body: \"changed\"}"),
+            null,
+            new ProcessElementWithRuntimeData("myProcess", 0, 0, "element2", "<default>")));
+
+    // when & then
+    var result =
+        InboundConnectorDetails.of(elements.getFirst().deduplicationId(List.of()), elements);
+    assertThat(result).isInstanceOf(InboundConnectorDetails.ValidInboundConnectorDetails.class);
+  }
+
+  @Test
+  void checkCompatibility_ignoresResponseExpressions() {
+    // given two valid groups that only differ in their webhook response expressions
+    var elementsA =
+        List.of(
+            new InboundConnectorElement(
+                Map.of(
+                    "inbound.type", "type1",
+                    "deduplicationMode", "AUTO",
+                    "property1", "value1",
+                    "inbound.responseExpression", "={statusCode: 200}"),
+                null,
+                new ProcessElementWithRuntimeData("myProcess", 0, 0, "element1", "<default>")));
+    var elementsB =
+        List.of(
+            new InboundConnectorElement(
+                Map.of(
+                    "inbound.type", "type1",
+                    "deduplicationMode", "AUTO",
+                    "property1", "value1",
+                    "inbound.responseExpression", "={statusCode: 201}"),
+                null,
+                new ProcessElementWithRuntimeData("myProcess", 0, 1, "element1", "<default>")));
+
+    var detailsA =
+        (InboundConnectorDetails.ValidInboundConnectorDetails)
+            InboundConnectorDetails.of(elementsA.getFirst().deduplicationId(List.of()), elementsA);
+    var detailsB =
+        (InboundConnectorDetails.ValidInboundConnectorDetails)
+            InboundConnectorDetails.of(elementsB.getFirst().deduplicationId(List.of()), elementsB);
+
+    // when & then
+    assertThat(detailsA.checkCompatibility(detailsB)).isEmpty();
+  }
+
+  @Test
   void notMatchingProperties_returnsInvalid() {
     // given
     List<InboundConnectorElement> elements = new ArrayList<>();

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/inbound/InboundConnectorElementTest.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/inbound/InboundConnectorElementTest.java
@@ -128,6 +128,36 @@ public class InboundConnectorElementTest {
   }
 
   @Test
+  void deduplicationId_autoMode_ignoresWebhookResponseExpression() {
+    // given
+    var testObj =
+        new InboundConnectorElement(
+            Map.of(
+                "inbound.type", "test",
+                "deduplicationMode", "AUTO",
+                "property", "value",
+                "inbound.responseExpression", "={statusCode: 200}",
+                "inbound.responseBodyExpression", "={body: request.body}"),
+            new StandaloneMessageCorrelationPoint("", "", null, null),
+            new ProcessElementWithRuntimeData("myProcess", 0, 0, "element1", "<default>"));
+
+    var testObjWithDifferentResponseExpressions =
+        new InboundConnectorElement(
+            Map.of(
+                "inbound.type", "test",
+                "deduplicationMode", "AUTO",
+                "property", "value",
+                "inbound.responseExpression", "={statusCode: 201}",
+                "inbound.responseBodyExpression", "={body: \"changed\"}"),
+            new StandaloneMessageCorrelationPoint("", "", null, null),
+            new ProcessElementWithRuntimeData("myProcess", 0, 0, "element1", "<default>"));
+
+    // when && then
+    assertThat(testObj.deduplicationId(List.of()))
+        .isEqualTo(testObjWithDifferentResponseExpressions.deduplicationId(List.of()));
+  }
+
+  @Test
   void deduplicationId_autoMode_customPropertyScope() {
     // given
     var testObj =

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/inbound/ProcessElementWithRuntimeDataTest.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/inbound/ProcessElementWithRuntimeDataTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.runtime.core.inbound;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.connector.api.inbound.ElementTemplateDetails;
+import io.camunda.connector.api.inbound.ProcessElement;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class ProcessElementWithRuntimeDataTest {
+
+  @Test
+  void exposesRawPropertiesThroughProcessElementInterface() {
+    var properties =
+        Map.of("inbound.type", "io.camunda:webhook:1", "inbound.responseExpression", "={x: 1}");
+
+    ProcessElement element =
+        new ProcessElementWithRuntimeData(
+            "myProcess",
+            "My Process",
+            1,
+            123L,
+            "element1",
+            "Element 1",
+            "bpmn:ServiceTask",
+            "<default>",
+            new ElementTemplateDetails("Webhook", "1", "icon"),
+            properties);
+
+    assertThat(element.properties()).isEqualTo(properties);
+  }
+
+  @Test
+  void processElementDefaultPropertiesAreEmpty() {
+    // A minimal ProcessElement implementation that does not override properties() must default to
+    // an empty map rather than null.
+    ProcessElement element =
+        new ProcessElement() {
+          @Override
+          public String bpmnProcessId() {
+            return "p";
+          }
+
+          @Override
+          public int version() {
+            return 1;
+          }
+
+          @Override
+          public long processDefinitionKey() {
+            return 1L;
+          }
+
+          @Override
+          public String elementId() {
+            return "e";
+          }
+
+          @Override
+          public String elementName() {
+            return "e";
+          }
+
+          @Override
+          public String elementType() {
+            return "t";
+          }
+
+          @Override
+          public String tenantId() {
+            return "<default>";
+          }
+        };
+
+    assertThat(element.properties()).isEmpty();
+  }
+}

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/inbound/correlation/ActivationConditionEvaluatorTest.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/inbound/correlation/ActivationConditionEvaluatorTest.java
@@ -338,6 +338,56 @@ public class ActivationConditionEvaluatorTest {
   }
 
   @Nested
+  @DisplayName("Webhook response expression compatibility (excluded from deduplication)")
+  class WebhookResponseExpression {
+
+    @Test
+    @DisplayName("Same response expression should be compatible")
+    void sameResponseExpression_shouldBeCompatible() {
+      var element1 = createMessageElement("elem1", "shared-msg", "", "=result", "var", "=key");
+      var element2 = createMessageElement("elem2", "shared-msg", "", "=result", "var", "=key");
+      when(element1.rawProperties())
+          .thenReturn(Map.of("inbound.responseExpression", "={statusCode: 200}"));
+      when(element2.rawProperties())
+          .thenReturn(Map.of("inbound.responseExpression", "={statusCode: 200}"));
+
+      var result = evaluator.checkActivation(List.of(element1, element2), Map.of());
+
+      assertThat(result).isInstanceOf(ActivationCheckResult.Success.CanActivate.class);
+    }
+
+    @Test
+    @DisplayName("Different response expression should be incompatible")
+    void differentResponseExpression_shouldBeIncompatible() {
+      var element1 = createMessageElement("elem1", "shared-msg", "", "=result", "var", "=key");
+      var element2 = createMessageElement("elem2", "shared-msg", "", "=result", "var", "=key");
+      when(element1.rawProperties())
+          .thenReturn(Map.of("inbound.responseExpression", "={statusCode: 200}"));
+      when(element2.rawProperties())
+          .thenReturn(Map.of("inbound.responseExpression", "={statusCode: 201}"));
+
+      var result = evaluator.checkActivation(List.of(element1, element2), Map.of());
+
+      assertThat(result).isInstanceOf(ActivationCheckResult.Failure.TooManyMatchingElements.class);
+    }
+
+    @Test
+    @DisplayName("Different legacy responseBodyExpression should be incompatible")
+    void differentResponseBodyExpression_shouldBeIncompatible() {
+      var element1 = createMessageElement("elem1", "shared-msg", "", "=result", "var", "=key");
+      var element2 = createMessageElement("elem2", "shared-msg", "", "=result", "var", "=key");
+      when(element1.rawProperties())
+          .thenReturn(Map.of("inbound.responseBodyExpression", "={body: \"a\"}"));
+      when(element2.rawProperties())
+          .thenReturn(Map.of("inbound.responseBodyExpression", "={body: \"b\"}"));
+
+      var result = evaluator.checkActivation(List.of(element1, element2), Map.of());
+
+      assertThat(result).isInstanceOf(ActivationCheckResult.Failure.TooManyMatchingElements.class);
+    }
+  }
+
+  @Nested
   @DisplayName("Different message names (always incompatible when both match)")
   class DifferentMessageNames {
 

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/executable/InboundExecutableStateTransitionService.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/executable/InboundExecutableStateTransitionService.java
@@ -223,9 +223,7 @@ public class InboundExecutableStateTransitionService {
     if (!existing.deduplicationId().equals(newDetails.deduplicationId())) {
       return false;
     }
-    return existing
-        .rawPropertiesWithoutKeywords()
-        .equals(newDetails.rawPropertiesWithoutKeywords());
+    return existing.propertiesForDeduplication().equals(newDetails.propertiesForDeduplication());
   }
 
   private List<InboundConnectorDetails> groupElementsByDeduplicationId(

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/webhook/InboundWebhookRestController.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/webhook/InboundWebhookRestController.java
@@ -48,8 +48,10 @@ import io.camunda.connector.api.inbound.webhook.WebhookResult;
 import io.camunda.connector.api.inbound.webhook.WebhookResultContext;
 import io.camunda.connector.api.inbound.webhook.WebhookTriggerResultContext;
 import io.camunda.connector.feel.FeelEngineWrapperException;
+import io.camunda.connector.runtime.core.Keywords;
 import io.camunda.connector.runtime.core.inbound.InboundConnectorManagementContext;
 import io.camunda.connector.runtime.inbound.executable.RegisteredExecutable;
+import io.camunda.connector.runtime.inbound.webhook.WebhookResponseExpressionProperties.WebhookResponseExpressions;
 import io.camunda.connector.runtime.inbound.webhook.model.HttpServletRequestWebhookProcessingPayload;
 import io.grpc.Status;
 import jakarta.servlet.ServletException;
@@ -200,7 +202,7 @@ public class InboundWebhookRestController {
         // correlate
         var correlationResult =
             connector.context().correlate(CorrelationRequest.builder().variables(ctxData).build());
-        response = buildResponse(webhookResult, documents, correlationResult);
+        response = buildResponse(connector.context(), webhookResult, documents, correlationResult);
       }
     } catch (Exception e) {
       connector
@@ -254,15 +256,22 @@ public class InboundWebhookRestController {
   }
 
   private ResponseEntity<?> buildResponse(
-      WebhookResult webhookResult, List<Document> documents, CorrelationResult correlationResult) {
+      InboundConnectorManagementContext context,
+      WebhookResult webhookResult,
+      List<Document> documents,
+      CorrelationResult correlationResult) {
     ResponseEntity<?> response;
     if (correlationResult instanceof CorrelationResult.Success success) {
-      response = buildSuccessfulResponse(webhookResult, documents, success);
+      response = buildSuccessfulResponse(context, webhookResult, documents, success);
     } else {
       if (correlationResult instanceof CorrelationResult.Failure failure) {
-        switch (failure.handlingStrategy()) {
-          case ForwardErrorToUpstream ignored -> response = buildErrorResponse(failure);
-          case Ignore ignored -> response = buildSuccessfulResponse(webhookResult, documents, null);
+        var handlingStrategy = failure.handlingStrategy();
+        if (handlingStrategy instanceof ForwardErrorToUpstream) {
+          response = buildErrorResponse(failure);
+        } else if (handlingStrategy instanceof Ignore) {
+          response = buildSuccessfulResponse(context, webhookResult, documents, null);
+        } else {
+          throw new IllegalStateException("Unexpected handling strategy: " + handlingStrategy);
         }
       } else {
         throw new IllegalStateException("Illegal correlation result : " + correlationResult);
@@ -300,23 +309,74 @@ public class InboundWebhookRestController {
   }
 
   private ResponseEntity<?> buildSuccessfulResponse(
+      InboundConnectorManagementContext context,
       WebhookResult webhookResult,
       List<Document> documents,
       CorrelationResult.Success correlationResult) {
-    ResponseEntity<?> response;
-    if (webhookResult.response() != null) {
-      var processVariablesContext =
-          toWebhookResultContext(webhookResult, documents, correlationResult);
-      var httpResponseData = webhookResult.response().apply(processVariablesContext);
-      if (httpResponseData != null) {
-        response = toResponseEntity(httpResponseData);
-      } else {
-        response = ResponseEntity.ok().build();
-      }
-    } else {
-      response = ResponseEntity.ok().build();
+    var processVariablesContext =
+        toWebhookResultContext(webhookResult, documents, correlationResult);
+
+    // The response expression is excluded from deduplication, so the executable may have been
+    // activated from a different element than the one that matched this request. Resolve the
+    // response from the activated element's own properties; only fall back to the response provided
+    // by the executable (e.g. for custom WebhookConnectorExecutable implementations) when the
+    // activated element does not declare a response expression.
+    WebhookHttpResponse httpResponseData =
+        resolveActivatedElementResponse(context, correlationResult, processVariablesContext);
+    if (httpResponseData == null && webhookResult.response() != null) {
+      httpResponseData = webhookResult.response().apply(processVariablesContext);
     }
-    return response;
+
+    if (httpResponseData != null) {
+      return toResponseEntity(httpResponseData);
+    }
+    return ResponseEntity.ok().build();
+  }
+
+  /**
+   * Resolves the HTTP response from the response expression declared on the element that was
+   * actually activated, evaluating it against the given context. Returns {@code null} when there is
+   * no activated element (e.g. unmatched-but-consumed events) or the element declares no response
+   * expression, in which case the caller falls back to the executable-provided response.
+   */
+  private WebhookHttpResponse resolveActivatedElementResponse(
+      InboundConnectorManagementContext context,
+      CorrelationResult.Success correlationResult,
+      WebhookResultContext resultContext) {
+    if (correlationResult == null || correlationResult.activatedElement() == null) {
+      return null;
+    }
+    var properties = correlationResult.activatedElement().properties();
+    var responseExpression = properties.get(Keywords.WEBHOOK_RESPONSE_EXPRESSION_KEYWORD);
+    var responseBodyExpression = properties.get(Keywords.WEBHOOK_RESPONSE_BODY_EXPRESSION_KEYWORD);
+    if (responseExpression == null && responseBodyExpression == null) {
+      return null;
+    }
+
+    var rawResponseProperties = new HashMap<String, String>();
+    if (responseExpression != null) {
+      rawResponseProperties.put(Keywords.WEBHOOK_RESPONSE_EXPRESSION_KEYWORD, responseExpression);
+    }
+    if (responseBodyExpression != null) {
+      rawResponseProperties.put(
+          Keywords.WEBHOOK_RESPONSE_BODY_EXPRESSION_KEYWORD, responseBodyExpression);
+    }
+
+    WebhookResponseExpressions bound =
+        context
+            .bindProperties(WebhookResponseExpressionProperties.class, rawResponseProperties)
+            .inbound();
+    if (bound == null) {
+      return null;
+    }
+    if (bound.responseExpression() != null) {
+      return bound.responseExpression().apply(resultContext);
+    }
+    if (bound.responseBodyExpression() != null) {
+      // Legacy response body expression: only the body is configured, wrap it in a 200 response.
+      return WebhookHttpResponse.ok(bound.responseBodyExpression().apply(resultContext));
+    }
+    return null;
   }
 
   protected ResponseEntity<?> buildErrorResponse(Exception e) {

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/webhook/WebhookResponseExpressionProperties.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/webhook/WebhookResponseExpressionProperties.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.runtime.inbound.webhook;
+
+import io.camunda.connector.api.inbound.webhook.WebhookHttpResponse;
+import io.camunda.connector.api.inbound.webhook.WebhookResultContext;
+import java.util.function.Function;
+
+/**
+ * Minimal binding target for the webhook response expressions of a single process element.
+ *
+ * <p>The webhook response expression is excluded from deduplication, so several elements may share
+ * one executable while declaring different response expressions. After correlation, {@link
+ * InboundWebhookRestController} binds the activated element's response expression into this holder
+ * (reusing the same FEEL / secret machinery as regular property binding) and evaluates it, instead
+ * of relying on the expression bound at activation time from an arbitrary group member.
+ *
+ * <p>The {@code inbound} wrapper mirrors the {@code inbound.} prefix that webhook properties carry
+ * in the process model.
+ */
+public record WebhookResponseExpressionProperties(WebhookResponseExpressions inbound) {
+
+  public record WebhookResponseExpressions(
+      Function<WebhookResultContext, WebhookHttpResponse> responseExpression,
+      Function<WebhookResultContext, Object> responseBodyExpression) {}
+}

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/inbound/WebhookControllerTestZeebeTest.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/inbound/WebhookControllerTestZeebeTest.java
@@ -35,6 +35,7 @@ import io.camunda.connector.api.inbound.webhook.WebhookHttpResponse;
 import io.camunda.connector.api.inbound.webhook.WebhookProcessingPayload;
 import io.camunda.connector.api.inbound.webhook.WebhookResult;
 import io.camunda.connector.feel.FeelEngineWrapperException;
+import io.camunda.connector.runtime.annotation.ConnectorsObjectMapper;
 import io.camunda.connector.runtime.app.TestConnectorRuntimeApplication;
 import io.camunda.connector.runtime.core.inbound.ExecutableId;
 import io.camunda.connector.runtime.core.inbound.InboundConnectorContextImpl;
@@ -83,6 +84,10 @@ class WebhookControllerTestZeebeTest {
   @Autowired private SecretProviderAggregator secretProvider;
 
   @Autowired private ObjectMapper mapper;
+
+  // FEEL-enabled mapper used by inbound connector contexts in production; required for binding
+  // response expressions (Function fields) the same way the runtime does.
+  @Autowired @ConnectorsObjectMapper private ObjectMapper connectorObjectMapper;
 
   @Autowired private InboundCorrelationHandler correlationHandler;
 
@@ -592,6 +597,152 @@ class WebhookControllerTestZeebeTest {
 
     assertEquals(200, responseEntity.getStatusCode().value());
     assertNull(responseEntity.getBody());
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void testResponseExpressionResolvedFromActivatedElement() throws Exception {
+    var webhookConnectorExecutable = mock(WebhookConnectorExecutable.class);
+    var correlationHandlerMock = mock(InboundCorrelationHandler.class);
+
+    var activatedElement = mock(ProcessElement.class);
+    when(activatedElement.properties())
+        .thenReturn(
+            Map.of(
+                "inbound.responseExpression",
+                "={statusCode: 201, body: {greeting: \"hello world\"}}"));
+    when(correlationHandlerMock.correlate(any(), any()))
+        .thenReturn(
+            new CorrelationResult.Success.ProcessInstanceCreated(activatedElement, 1L, "test"));
+
+    WebhookResult webhookResult = mock(WebhookResult.class);
+    when(webhookResult.request()).thenReturn(new MappedHttpRequest(Map.of(), Map.of(), Map.of()));
+    // The executable provides no response; it must be resolved from the activated element.
+    when(webhookConnectorExecutable.triggerWebhook(any(WebhookProcessingPayload.class)))
+        .thenReturn(webhookResult);
+
+    var webhookDef = webhookDefinition("processA", 1, "myPath");
+    var webhookContext =
+        new InboundConnectorContextImpl(
+            secretProvider,
+            v -> {},
+            webhookDef,
+            correlationHandlerMock,
+            (e) -> {},
+            connectorObjectMapper,
+            activityLogRegistry,
+            camundaClient);
+
+    webhookConnectorRegistry.register(
+        new RegisteredExecutable.Activated(
+            webhookConnectorExecutable,
+            webhookContext,
+            ExecutableId.fromDeduplicationId("random")));
+
+    deployProcess("processA");
+
+    ResponseEntity<Map> responseEntity =
+        (ResponseEntity<Map>)
+            controller.inbound(
+                "myPath", new HashMap<>(), new HashMap<>(), new MockHttpServletRequest());
+
+    assertEquals(201, responseEntity.getStatusCode().value());
+    assertEquals("hello world", responseEntity.getBody().get("greeting"));
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void testLegacyResponseBodyExpressionResolvedFromActivatedElement() throws Exception {
+    var webhookConnectorExecutable = mock(WebhookConnectorExecutable.class);
+    var correlationHandlerMock = mock(InboundCorrelationHandler.class);
+
+    var activatedElement = mock(ProcessElement.class);
+    when(activatedElement.properties())
+        .thenReturn(Map.of("inbound.responseBodyExpression", "={msg: \"legacy\"}"));
+    when(correlationHandlerMock.correlate(any(), any()))
+        .thenReturn(
+            new CorrelationResult.Success.ProcessInstanceCreated(activatedElement, 1L, "test"));
+
+    WebhookResult webhookResult = mock(WebhookResult.class);
+    when(webhookResult.request()).thenReturn(new MappedHttpRequest(Map.of(), Map.of(), Map.of()));
+    when(webhookConnectorExecutable.triggerWebhook(any(WebhookProcessingPayload.class)))
+        .thenReturn(webhookResult);
+
+    var webhookDef = webhookDefinition("processA", 1, "myPath");
+    var webhookContext =
+        new InboundConnectorContextImpl(
+            secretProvider,
+            v -> {},
+            webhookDef,
+            correlationHandlerMock,
+            (e) -> {},
+            connectorObjectMapper,
+            activityLogRegistry,
+            camundaClient);
+
+    webhookConnectorRegistry.register(
+        new RegisteredExecutable.Activated(
+            webhookConnectorExecutable,
+            webhookContext,
+            ExecutableId.fromDeduplicationId("random")));
+
+    deployProcess("processA");
+
+    ResponseEntity<Map> responseEntity =
+        (ResponseEntity<Map>)
+            controller.inbound(
+                "myPath", new HashMap<>(), new HashMap<>(), new MockHttpServletRequest());
+
+    // Legacy responseBodyExpression only configures the body; the status defaults to 200.
+    assertEquals(200, responseEntity.getStatusCode().value());
+    assertEquals("legacy", responseEntity.getBody().get("msg"));
+  }
+
+  @Test
+  public void testActivatedElementResponseTakesPrecedenceOverExecutableResponse() throws Exception {
+    var webhookConnectorExecutable = mock(WebhookConnectorExecutable.class);
+    var correlationHandlerMock = mock(InboundCorrelationHandler.class);
+
+    var activatedElement = mock(ProcessElement.class);
+    when(activatedElement.properties())
+        .thenReturn(Map.of("inbound.responseExpression", "={statusCode: 202}"));
+    when(correlationHandlerMock.correlate(any(), any()))
+        .thenReturn(
+            new CorrelationResult.Success.ProcessInstanceCreated(activatedElement, 1L, "test"));
+
+    WebhookResult webhookResult = mock(WebhookResult.class);
+    when(webhookResult.request()).thenReturn(new MappedHttpRequest(Map.of(), Map.of(), Map.of()));
+    // Executable-provided response must be ignored when the activated element declares one.
+    when(webhookResult.response())
+        .thenReturn((c) -> new WebhookHttpResponse(Map.of("from", "fallback"), null, 500));
+    when(webhookConnectorExecutable.triggerWebhook(any(WebhookProcessingPayload.class)))
+        .thenReturn(webhookResult);
+
+    var webhookDef = webhookDefinition("processA", 1, "myPath");
+    var webhookContext =
+        new InboundConnectorContextImpl(
+            secretProvider,
+            v -> {},
+            webhookDef,
+            correlationHandlerMock,
+            (e) -> {},
+            connectorObjectMapper,
+            activityLogRegistry,
+            camundaClient);
+
+    webhookConnectorRegistry.register(
+        new RegisteredExecutable.Activated(
+            webhookConnectorExecutable,
+            webhookContext,
+            ExecutableId.fromDeduplicationId("random")));
+
+    deployProcess("processA");
+
+    ResponseEntity<?> responseEntity =
+        controller.inbound(
+            "myPath", new HashMap<>(), new HashMap<>(), new MockHttpServletRequest());
+
+    assertEquals(202, responseEntity.getStatusCode().value());
   }
 
   @Test

--- a/connector-sdk/core/src/main/java/io/camunda/connector/api/inbound/ProcessElement.java
+++ b/connector-sdk/core/src/main/java/io/camunda/connector/api/inbound/ProcessElement.java
@@ -16,6 +16,8 @@
  */
 package io.camunda.connector.api.inbound;
 
+import java.util.Map;
+
 public interface ProcessElement {
 
   String bpmnProcessId();
@@ -35,4 +37,16 @@ public interface ProcessElement {
   String elementType();
 
   String tenantId();
+
+  /**
+   * Raw properties of this element as defined in the process model. Values are returned exactly as
+   * modeled: FEEL expressions are not evaluated and secret placeholders are <b>never</b> resolved.
+   *
+   * <p>This lets the runtime resolve element-specific properties (such as the webhook response
+   * expression) for the element that was actually activated, even when several elements were
+   * deduplicated into a single executable.
+   */
+  default Map<String, String> properties() {
+    return Map.of();
+  }
 }

--- a/connector-sdk/core/src/main/java/io/camunda/connector/api/inbound/webhook/WebhookPropertyNames.java
+++ b/connector-sdk/core/src/main/java/io/camunda/connector/api/inbound/webhook/WebhookPropertyNames.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.api.inbound.webhook;
+
+/**
+ * Names of well-known webhook connector properties that the connector runtime needs to recognize,
+ * e.g. to exclude them from connector deduplication. Webhook connector implementations should
+ * reference these constants in their property definitions so that the property IDs and the runtime
+ * behavior cannot drift apart.
+ */
+public final class WebhookPropertyNames {
+
+  /**
+   * The property holding the FEEL expression used to generate the HTTP response of the webhook
+   * endpoint after a successful correlation.
+   */
+  public static final String RESPONSE_EXPRESSION = "responseExpression";
+
+  /**
+   * The legacy predecessor of {@link #RESPONSE_EXPRESSION} that only produced the response body.
+   * Hidden from element templates since 8.6.0, but still supported at runtime.
+   */
+  public static final String RESPONSE_BODY_EXPRESSION = "responseBodyExpression";
+
+  private WebhookPropertyNames() {}
+}

--- a/connectors/webhook/pom.xml
+++ b/connectors/webhook/pom.xml
@@ -45,10 +45,6 @@
       <version>${version.commons-codec}</version>
     </dependency>
     <dependency>
-      <groupId>jakarta.annotation</groupId>
-      <artifactId>jakarta.annotation-api</artifactId>
-    </dependency>
-    <dependency>
       <groupId>com.auth0</groupId>
       <artifactId>java-jwt</artifactId>
       <version>${version.auth0.jwt}</version>

--- a/connectors/webhook/src/main/java/io/camunda/connector/inbound/HttpWebhookExecutable.java
+++ b/connectors/webhook/src/main/java/io/camunda/connector/inbound/HttpWebhookExecutable.java
@@ -17,7 +17,6 @@ import io.camunda.connector.api.inbound.webhook.WebhookConnectorExecutable;
 import io.camunda.connector.api.inbound.webhook.WebhookHttpResponse;
 import io.camunda.connector.api.inbound.webhook.WebhookProcessingPayload;
 import io.camunda.connector.api.inbound.webhook.WebhookResult;
-import io.camunda.connector.api.inbound.webhook.WebhookResultContext;
 import io.camunda.connector.generator.java.annotation.BpmnType;
 import io.camunda.connector.generator.java.annotation.ElementTemplate;
 import io.camunda.connector.generator.java.annotation.ElementTemplate.ConnectorElementType;
@@ -30,9 +29,7 @@ import io.camunda.connector.inbound.model.WebhookProcessingResultImpl;
 import io.camunda.connector.inbound.signature.HMACVerifier;
 import io.camunda.connector.inbound.utils.HttpMethods;
 import io.camunda.connector.inbound.utils.HttpWebhookUtil;
-import jakarta.annotation.Nullable;
 import java.util.Map;
-import java.util.function.Function;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -101,7 +98,6 @@ public class HttpWebhookExecutable implements WebhookConnectorExecutable {
   private WebhookConnectorProperties props;
   private WebhookAuthorizationHandler<?> authChecker;
   private InboundConnectorContext context;
-  private Function<WebhookResultContext, WebhookHttpResponse> responseExpression;
   private HMACVerifier hmacVerifier;
 
   @Override
@@ -110,7 +106,6 @@ public class HttpWebhookExecutable implements WebhookConnectorExecutable {
     var wrappedProps = context.bindProperties(WebhookConnectorPropertiesWrapper.class);
     props = new WebhookConnectorProperties(wrappedProps);
     authChecker = WebhookAuthorizationHandler.getHandlerForAuth(props.auth());
-    responseExpression = mapResponseExpression();
     hmacVerifier =
         new HMACVerifier(
             props.hmacScopes(), props.hmacHeader(), props.hmacSecret(), props.hmacAlgorithm());
@@ -130,7 +125,9 @@ public class HttpWebhookExecutable implements WebhookConnectorExecutable {
     }
 
     var mappedRequest = mapRequest(payload);
-    return new WebhookProcessingResultImpl(mappedRequest, responseExpression, null);
+    // The response expression is resolved by the runtime from the activated element after
+    // correlation, so the executable does not provide a response function here.
+    return new WebhookProcessingResultImpl(mappedRequest, null, null);
   }
 
   private void validateHttpMethod(WebhookProcessingPayload payload) {
@@ -146,24 +143,6 @@ public class HttpWebhookExecutable implements WebhookConnectorExecutable {
             payload.rawBody(), HttpWebhookUtil.extractContentType(payload.headers())),
         payload.headers(),
         payload.params());
-  }
-
-  @Nullable
-  private Function<WebhookResultContext, WebhookHttpResponse> mapResponseExpression() {
-    Function<WebhookResultContext, WebhookHttpResponse> responseExpression = null;
-    if (props.responseExpression() != null) {
-      responseExpression = props.responseExpression();
-    } else if (props.responseBodyExpression() != null) {
-      // To be backwards compatible we need to wrap the responseBodyExpression into a
-      // responseExpression
-      // and only use the body in the final response
-      responseExpression =
-          (context) -> {
-            Object responseBody = props.responseBodyExpression().apply(context);
-            return WebhookHttpResponse.ok(responseBody);
-          };
-    }
-    return responseExpression;
   }
 
   private void verifyHmac(WebhookProcessingPayload payload) {

--- a/connectors/webhook/src/main/java/io/camunda/connector/inbound/model/WebhookConnectorProperties.java
+++ b/connectors/webhook/src/main/java/io/camunda/connector/inbound/model/WebhookConnectorProperties.java
@@ -6,10 +6,12 @@
  */
 package io.camunda.connector.inbound.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.connector.api.annotation.FEEL;
 import io.camunda.connector.api.inbound.webhook.WebhookHttpResponse;
-import io.camunda.connector.api.inbound.webhook.WebhookResultContext;
+import io.camunda.connector.api.inbound.webhook.WebhookPropertyNames;
 import io.camunda.connector.generator.java.annotation.FeelMode;
+import io.camunda.connector.generator.java.annotation.TemplateOnly;
 import io.camunda.connector.generator.java.annotation.TemplateProperty;
 import io.camunda.connector.generator.java.annotation.TemplateProperty.DropdownPropertyChoice;
 import io.camunda.connector.generator.java.annotation.TemplateProperty.PropertyCondition;
@@ -104,16 +106,22 @@ public record WebhookConnectorProperties(
         @FEEL
         HMACScope[] hmacScopes,
     WebhookAuthorization auth,
-    @TemplateProperty(
-            id = "responseExpression",
+    // Template-only property: appears in the element template but is never bound. The
+    // uninstantiable TemplateOnly type makes "no value" type-enforced (only null is assignable),
+    // and @JsonIgnore keeps Jackson from binding it during bindProperties(). The runtime resolves
+    // the response expression per request from the activated element (see
+    // InboundWebhookRestController),
+    // not from this model. Kept in its original position so the generated template is unchanged.
+    @JsonIgnore
+        @TemplateProperty(
+            id = WebhookPropertyNames.RESPONSE_EXPRESSION,
             label = "Response expression",
             type = PropertyType.Text,
             group = "webhookResponse",
             description = "Expression used to generate the HTTP response",
             feel = FeelMode.required,
             optional = true)
-        Function<WebhookResultContext, WebhookHttpResponse> responseExpression,
-    @TemplateProperty(ignore = true) Function<WebhookResultContext, Object> responseBodyExpression,
+        TemplateOnly responseExpression,
     @TemplateProperty(
             id = "verificationExpression",
             label = "One time verification response expression",
@@ -136,8 +144,8 @@ public record WebhookConnectorProperties(
         // default to BODY if no scopes are provided
         getOrDefault(wrapper.inbound.hmacScopes, new HMACScope[] {HMACScope.BODY}),
         getOrDefault(wrapper.inbound.auth, new WebhookAuthorization.None()),
-        wrapper.inbound.responseExpression,
-        wrapper.inbound.responseBodyExpression,
+        // responseExpression is template-only (never bound); always null on the model
+        null,
         wrapper.inbound.verificationExpression);
   }
 
@@ -170,10 +178,6 @@ public record WebhookConnectorProperties(
         + Arrays.toString(hmacScopes)
         + ", auth="
         + auth
-        + ", responseExpression="
-        + responseExpression
-        + ", responseBodyExpression="
-        + responseBodyExpression
         + ", verificationExpression="
         + verificationExpression
         + "}";

--- a/connectors/webhook/src/test/java/io/camunda/connector/inbound/HttpWebhookExecutableTest.java
+++ b/connectors/webhook/src/test/java/io/camunda/connector/inbound/HttpWebhookExecutableTest.java
@@ -12,8 +12,6 @@ import static io.camunda.connector.inbound.utils.HttpWebhookUtil.FORM_DATA_CONTE
 import static io.camunda.connector.inbound.utils.HttpWebhookUtil.HEADER_CONTENT_TYPE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchException;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -65,57 +63,16 @@ class HttpWebhookExecutableTest {
   }
 
   @Test
-  void triggerWebhook_ResponseExpression_HappyCase() {
+  void triggerWebhook_ArrayOfPrimitiveBody_HappyCase() {
     InboundConnectorContext ctx =
         InboundConnectorContextBuilder.create()
             .properties(
                 Map.of(
                     "inbound",
                     Map.of(
-                        "context",
-                        "webhookContext",
-                        "method",
-                        "any",
-                        "auth",
-                        Map.of("type", "NONE"),
-                        "responseExpression",
-                        "=if request.body.key != null then {body: request.body.key} else null")))
-            .build();
-
-    WebhookProcessingPayload payload = Mockito.mock(WebhookProcessingPayload.class);
-    Mockito.when(payload.method()).thenReturn(HttpMethods.any.name());
-    Mockito.when(payload.headers()).thenReturn(Map.of(HEADER_CONTENT_TYPE, "application/json"));
-    Mockito.when(payload.rawBody())
-        .thenReturn("{\"key\": \"value\"}".getBytes(StandardCharsets.UTF_8));
-
-    testObject.activate(ctx);
-    var result = testObject.triggerWebhook(payload);
-
-    assertNotNull(result.response());
-    assertThat((Map) result.request().body()).containsEntry("key", "value");
-
-    var request = new MappedHttpRequest(Map.of("key", "value"), null, null);
-    var context = new WebhookResultContext(request, null, null);
-    var response = result.response().apply(context);
-    assertEquals("value", response.body());
-  }
-
-  @Test
-  void triggerWebhook_ResponseIsArrayOfPrimitive_HappyCase() {
-    InboundConnectorContext ctx =
-        InboundConnectorContextBuilder.create()
-            .properties(
-                Map.of(
-                    "inbound",
-                    Map.of(
-                        "context",
-                        "webhookContext",
-                        "method",
-                        "any",
-                        "auth",
-                        Map.of("type", "NONE"),
-                        "responseExpression",
-                        "=if request.body.key != null then {body: request.body.key} else null")))
+                        "context", "webhookContext",
+                        "method", "any",
+                        "auth", Map.of("type", "NONE"))))
             .build();
 
     WebhookProcessingPayload payload = Mockito.mock(WebhookProcessingPayload.class);
@@ -127,31 +84,22 @@ class HttpWebhookExecutableTest {
     testObject.activate(ctx);
     var result = testObject.triggerWebhook(payload);
 
-    assertNotNull(result.response());
+    // The response is resolved by the runtime from the activated element, not the executable.
+    assertNull(result.response());
     assertThat((List<String>) result.request().body()).contains("test1", "test2");
-
-    var request = new MappedHttpRequest(Map.of("key", "value"), null, null);
-    var context = new WebhookResultContext(request, null, null);
-    var response = result.response().apply(context);
-    assertEquals("value", response.body());
   }
 
   @Test
-  void triggerWebhook_ResponseIsArrayOfObject_HappyCase() {
+  void triggerWebhook_ArrayOfObjectBody_HappyCase() {
     InboundConnectorContext ctx =
         InboundConnectorContextBuilder.create()
             .properties(
                 Map.of(
                     "inbound",
                     Map.of(
-                        "context",
-                        "webhookContext",
-                        "method",
-                        "any",
-                        "auth",
-                        Map.of("type", "NONE"),
-                        "responseExpression",
-                        "=if request.body.key != null then {body: request.body.key} else null")))
+                        "context", "webhookContext",
+                        "method", "any",
+                        "auth", Map.of("type", "NONE"))))
             .build();
 
     WebhookProcessingPayload payload = Mockito.mock(WebhookProcessingPayload.class);
@@ -164,14 +112,10 @@ class HttpWebhookExecutableTest {
     testObject.activate(ctx);
     var result = testObject.triggerWebhook(payload);
 
-    assertNotNull(result.response());
+    // The response is resolved by the runtime from the activated element, not the executable.
+    assertNull(result.response());
     assertThat((List<Map>) result.request().body())
         .contains(Map.of("key", "value"), Map.of("key", "value"));
-
-    var request = new MappedHttpRequest(Map.of("key", "value"), null, null);
-    var context = new WebhookResultContext(request, null, null);
-    var response = result.response().apply(context);
-    assertEquals("value", response.body());
   }
 
   @Test


### PR DESCRIPTION
> ⚠️ **Stacked on #7487** (branch `6684-etg-template-only-property`). This PR targets the ETG branch, not `main` — review/merge #7487 first. The diff shown here is only the webhook + runtime change on top of it.

## Description

The webhook `responseExpression` was being included in the inbound connector **deduplication** key. As a result, changing only the response expression across deployments produced a different dedup ID and broke webhook correlation for the affected element. The response expression is a pure output concern and should not influence deduplication.

This PR removes `responseExpression` from the bound webhook model and from the deduplication scope, and resolves it **per request from the activated element** instead of from a shared connector instance. Consequently, several elements that share one webhook executable may legitimately declare different response expressions.

### Key changes
- **Deduplication** — `responseExpression` is excluded from the dedup scope (`Keywords.PROPERTIES_EXCLUDED_FROM_DEDUPLICATION`); compatibility checks compare only dedup-scoped properties. Adds SDK `WebhookPropertyNames`.
- **Per-request resolution** — the controller resolves the response expression from the element that was actually activated at request time (`InboundConnectorManagementContext.bindProperties(Class, rawProperties)`, `WebhookResponseExpressionProperties`), falling back to `WebhookResult.response()` for custom executables. `ActivationConditionEvaluator` guards divergent multi-match cases.
- **Template-only property** — `responseExpression` is declared as a `@JsonIgnore`'d `TemplateOnly` record component (see #7487) kept in its original position. It is never bound: `@JsonIgnore` keeps Jackson from binding it during `bindProperties()`, and the runtime resolves the value per request. Because the property keeps its original declaration position, the generated element templates are **byte-identical to `main`** (no display-order churn).

### Scope notes
- `verificationExpression` is unchanged: it is consumed pre-correlation, so it stays bound and within the dedup scope.
- The legacy `responseBodyExpression` is removed from the bound model.

## Related issues

closes #6684

## Checklist

- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest
  release, as this branch will be rebased onto main before the next release. Example backport labels:
    - `backport stable/8.8`: for changes that should be included in the next 8.8.x release.
    - **or** `backport release-8.8.7`: for changes that should be included in the specific release 8.8.7, and this
      *release has already been created*. The release branch will be merged back into stable/8.8 later, so the change
      will be included in future 8.8.x releases as well.
- [ ] Tests/Integration tests for the changes have been added if applicable.
- [ ] If the change requires a documentation update, it has been added to the appropriate section in the documentation.
