### PR TITLE
docs: introduce ADR process and first example record

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -573,6 +573,17 @@ For examples, see existing connectors in `connectors/` directory:
 - **Kafka connector** (`connectors/kafka/`): Example of both inbound and outbound patterns
 - **Azure Blob Storage** (`connectors/microsoft/azure-blobstorage/`): Document handling example
 
+## Architecture Decision Records (ADRs)
+
+Significant architectural decisions are recorded in [`docs/adr/`](docs/adr/). Read [`docs/adr/README.md`](docs/adr/README.md) for the full process, template, and agent instructions before creating or updating an ADR.
+
+**When to write one:** a decision that affects multiple modules, involves a meaningful trade-off, or changes an established pattern in the SDK, runtime, or out-of-box connectors.
+
+**Quick start:**
+1. Find the next sequence number from the index in `docs/adr/README.md`.
+2. Create `docs/adr/ADR-NNNN-<kebab-title>.md` using the template in that README.
+3. Add a one-line entry to the index table in `docs/adr/README.md`.
+
 ## Documentation
 
 For detailed documentation, see

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -575,7 +575,7 @@ For examples, see existing connectors in `connectors/` directory:
 
 ## Architecture Decision Records (ADRs)
 
-Significant architectural decisions are recorded in [`docs/adr/`](docs/adr/). Read [`docs/adr/README.md`](docs/adr/README.md) for the full process, template, and agent instructions before creating or updating an ADR.
+Significant architectural decisions are recorded in [`docs/adr/`](../docs/adr/). Read [`docs/adr/README.md`](../docs/adr/README.md) for the full process, template, and agent instructions before creating or updating an ADR.
 
 **When to write one:** a decision that affects multiple modules, involves a meaningful trade-off, or changes an established pattern in the SDK, runtime, or out-of-box connectors.
 

--- a/docs/adr/ADR-0001-annotation-driven-element-template-generation.md
+++ b/docs/adr/ADR-0001-annotation-driven-element-template-generation.md
@@ -1,0 +1,29 @@
+# ADR-0001: Annotation-Driven Element Template Generation
+
+## Status
+Accepted
+
+## Context
+Camunda Modeler requires element templates — JSON descriptor files — for each connector so users can configure connector properties in the modeling UI. These descriptors must stay in sync with the connector's Java input model: property names, types, validation constraints, groups, and FEEL-mode flags.
+
+Maintaining these JSON files by hand alongside Java code introduced drift: properties were added to Java models but the template was not updated, or vice versa. Reviewing JSON diffs in PRs was error-prone and required deep knowledge of the template schema.
+
+## Decision
+Generate element templates automatically from the Java connector class and its input model at build time using a dedicated `element-template-generator` module. Connector authors annotate their input model with `@ElementTemplate`, `@TemplateProperty`, `@PropertyGroup`, and validation annotations (`@NotEmpty`, `@Pattern`, etc.). A `GenerateElementTemplate` test class (and a corresponding Maven plugin) reads these annotations via reflection and produces the JSON descriptor.
+
+The generated JSON is committed to the repository under `element-templates/` inside each connector module and symlinked into Camunda Modeler's resources directory for local development.
+
+## Consequences
+
+### Positive
+- Element templates are always in sync with the Java model; drift is structurally prevented.
+- Connector authors work only in Java; no manual JSON authoring or schema knowledge required.
+- Validation constraints (Jakarta Bean Validation) double as template constraints with no extra work.
+- Template changes are surfaced as Java annotation diffs, which are easier to review than raw JSON diffs.
+- The generator is versioned with the SDK, so improvements to the template format propagate automatically.
+
+### Negative
+- Connector authors must learn a set of generator-specific annotations (`@TemplateProperty`, `@FEEL`, `@TemplateDiscriminatorProperty`, etc.) in addition to standard Java/Jakarta annotations.
+- Advanced template features not yet modeled by annotations require workarounds or manual post-processing.
+- Generated JSON is committed to the repo, creating noise in diffs when the generator format changes across SDK versions.
+- The generator is a build-time dependency; issues in it can block all connector builds simultaneously.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,83 @@
+# Architecture Decision Records
+
+This directory records significant architectural decisions made for the Camunda Connectors project.
+
+## What is an ADR?
+
+An Architecture Decision Record (ADR) captures a single significant decision: the context that drove it, what was decided, and the consequences. ADRs are lightweight — a few hundred words — and live in the repo so they evolve alongside the code.
+
+## When to write one
+
+Write an ADR when a decision:
+- Affects multiple modules or teams
+- Involves a meaningful trade-off between alternatives
+- Would be re-litigated without a recorded rationale
+- Changes an established pattern in the connector SDK, runtime, or out-of-box connectors
+
+You do **not** need an ADR for implementation details, bug fixes, or decisions that follow an existing pattern without deviation.
+
+## File naming
+
+```
+ADR-NNNN-short-kebab-title.md
+```
+
+- `NNNN` is a zero-padded sequence number (find the highest existing number and increment).
+- The title slug is lowercase, hyphen-separated, descriptive but concise.
+
+Examples: `ADR-0002-connector-discovery-via-serviceloader.md`, `ADR-0003-feel-annotation-for-dynamic-properties.md`
+
+## Statuses
+
+| Status | Meaning |
+|--------|---------|
+| `Proposed` | Open for discussion; not yet merged to `main` |
+| `Accepted` | Merged; the decision is in effect |
+| `Deprecated` | No longer recommended but not yet replaced |
+| `Superseded by ADR-XXXX` | Replaced by a later decision |
+
+## Template
+
+```markdown
+# ADR-NNNN: Title
+
+## Status
+Proposed
+
+## Context
+<!-- What situation, constraint, or problem prompted this decision? -->
+
+## Decision
+<!-- What was decided? Be specific. -->
+
+## Consequences
+
+### Positive
+<!-- Benefits that result from this decision -->
+
+### Negative
+<!-- Costs, risks, or limitations introduced -->
+```
+
+## Process
+
+1. Copy the template, fill out all sections, open a PR targeting `main`.
+2. Discuss in the PR; update the ADR status to `Accepted` before merging.
+3. If a later decision supersedes this one, update the original ADR's status to `Superseded by ADR-XXXX` and open a new ADR.
+
+## Agent instructions
+
+When asked to create an ADR:
+
+1. Check existing files in this directory to find the next sequence number.
+2. Copy the template above into a new file named `ADR-NNNN-<kebab-title>.md`.
+3. Fill out all four sections (Status, Context, Decision, Consequences) based on the information provided.
+4. Set Status to `Proposed` unless told otherwise.
+5. Add a one-line entry to the index below.
+6. Do not invent consequences or context that wasn't given — ask if anything is unclear.
+
+## Index
+
+| ADR | Title | Status |
+|-----|-------|--------|
+| [ADR-0001](ADR-0001-annotation-driven-element-template-generation.md) | Annotation-Driven Element Template Generation | Accepted |


### PR DESCRIPTION
## Summary

- Adds `docs/adr/` with a `README.md` covering the full ADR lifecycle: naming convention (`ADR-NNNN-kebab-title.md`), status values, blank template, process (PR → discuss → merge), and explicit agent instructions for creating new records
- Adds `ADR-0001` documenting the annotation-driven element template generation decision as a worked example
- Updates `AGENTS.md` (`copilot-instructions.md`) with an ADR quick-start section so agents (and humans) can find and follow the process without hunting

## Test plan

- [ ] Review `docs/adr/README.md` — process, template, and agent instructions look correct
- [ ] Review `docs/adr/ADR-0001-annotation-driven-element-template-generation.md` — format matches the template and reflects an accurate description of the decision
- [ ] Review `AGENTS.md` ADR section — quick-start steps point to the right files

🤖 Generated with [Claude Code](https://claude.com/claude-code)