### PR TITLE
refactor(inbound): deprecate @InboundConnector deduplicationProperties

### DIFF
--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/ConnectorConfigurationUtil.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/ConnectorConfigurationUtil.java
@@ -62,6 +62,9 @@ public final class ConnectorConfigurationUtil {
         configurationOverrides.timeoutOverride().orElse(null));
   }
 
+  // Deprecation bridge: reads the deprecated @InboundConnector#deduplicationProperties to keep
+  // honoring it for backward compatibility. Removed together with the attribute in Phase 2 (#6684).
+  @SuppressWarnings("removal")
   public static InboundConnectorConfiguration getInboundConnectorConfiguration(
       Class<? extends InboundConnectorExecutable> cls) {
 

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/discovery/EnvVarsConnectorDiscovery.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/discovery/EnvVarsConnectorDiscovery.java
@@ -30,9 +30,13 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /** Static functionality for discovery via environment variables */
 public class EnvVarsConnectorDiscovery {
+
+  private static final Logger LOG = LoggerFactory.getLogger(EnvVarsConnectorDiscovery.class);
 
   /** Pattern describing the outbound connector env configuration pattern. */
   public static final Pattern OUTBOUND_CONNECTOR_FUNCTION_PATTERN =
@@ -126,24 +130,37 @@ public class EnvVarsConnectorDiscovery {
       }
       var annotationConfig = tmpAnnotationConfig;
 
+      // Deprecated (scheduled for removal): the deduplication-properties allow-list. See #6684.
+      var deduplicationPropertiesEnv =
+          getConnectorEnvironmentVariable(name, "DEDUPLICATION_PROPERTIES");
+      if (deduplicationPropertiesEnv.isPresent()) {
+        LOG.warn(
+            "Connector '{}' uses the deprecated CONNECTOR_{}_DEDUPLICATION_PROPERTIES environment "
+                + "variable. This deduplication-properties allow-list is scheduled for removal: it "
+                + "leaves every other bound property out of the deduplication scope, so the value "
+                + "retained by a deduplicated executable is arbitrary when elements diverge. Rely on "
+                + "the default deduplication scope and declare non-deduplicating properties as "
+                + "template-only instead. See https://github.com/camunda/connectors/issues/6684",
+            name,
+            name);
+      }
+
       return new InboundConnectorConfiguration(
           name,
           getConnectorEnvironmentVariable(name, "TYPE")
               .or(() -> annotationConfig.map(InboundConnectorConfiguration::type))
               .orElseThrow(() -> envMissing("Type not specified", name, "TYPE")),
           cls,
-          getConnectorEnvironmentVariable(name, "DEDUPLICATION_PROPERTIES")
+          deduplicationPropertiesEnv
               .map(properties -> properties.split(","))
               .map(Arrays::asList)
               .or(
                   () ->
                       annotationConfig.map(InboundConnectorConfiguration::deduplicationProperties))
-              .orElseThrow(
-                  () ->
-                      envMissing(
-                          "Deduplication properties not specified",
-                          name,
-                          "DEDUPLICATION_PROPERTIES")));
+              // The deduplication-properties allow-list is deprecated and therefore optional:
+              // default to the empty (deny-list) deduplication scope when neither the env var nor
+              // the annotation provides one.
+              .orElse(List.of()));
 
     } catch (ClassNotFoundException | ClassCastException e) {
       throw loadFailed("Failed to load " + executableFqdn, e);

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/ConnectorConfigurationUtilTest.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/ConnectorConfigurationUtilTest.java
@@ -205,7 +205,7 @@ public class ConnectorConfigurationUtilTest {
               config -> {
                 assertThat(config.name()).isEqualTo("ANNOTATED");
                 assertThat(config.type()).isEqualTo("io.camunda.Annotated");
-                assertThat(config.deduplicationProperties()).containsExactly("id");
+                assertThat(config.deduplicationProperties()).isEmpty();
               });
     }
 
@@ -301,10 +301,7 @@ class UnannotatedFunction implements OutboundConnectorFunction {
   }
 }
 
-@InboundConnector(
-    name = "ANNOTATED",
-    type = "io.camunda.Annotated",
-    deduplicationProperties = {"id"})
+@InboundConnector(name = "ANNOTATED", type = "io.camunda.Annotated")
 class AnnotatedExecutable implements InboundConnectorExecutable {
 
   @Override

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/inbound/AnnotatedExecutable.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/inbound/AnnotatedExecutable.java
@@ -20,10 +20,7 @@ import io.camunda.connector.api.annotation.InboundConnector;
 import io.camunda.connector.api.inbound.InboundConnectorContext;
 import io.camunda.connector.api.inbound.InboundConnectorExecutable;
 
-@InboundConnector(
-    name = "ANNOTATED",
-    type = "io.camunda:annotated",
-    deduplicationProperties = {"id"})
+@InboundConnector(name = "ANNOTATED", type = "io.camunda:annotated")
 public class AnnotatedExecutable implements InboundConnectorExecutable {
 
   @Override

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/inbound/InboundConnectorDiscoveryTest.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/inbound/InboundConnectorDiscoveryTest.java
@@ -41,8 +41,6 @@ public class InboundConnectorDiscoveryTest {
           "io.camunda.connector.runtime.core.inbound.AnnotatedExecutable",
           "CONNECTOR_ANNOTATED_OVERRIDE_TYPE",
           "io.camunda:annotated-override",
-          "CONNECTOR_ANNOTATED_OVERRIDE_DEDUPLICATION_PROPERTIES",
-          "prop1,prop2,prop3",
 
           // shall be picked up with meta-data
           "CONNECTOR_ANNOTATED_EXECUTABLE",
@@ -52,9 +50,7 @@ public class InboundConnectorDiscoveryTest {
           "CONNECTOR_NOT_ANNOTATED_EXECUTABLE",
           "io.camunda.connector.runtime.core.inbound.NotAnnotatedExecutable",
           "CONNECTOR_NOT_ANNOTATED_TYPE",
-          "io.camunda:not-annotated",
-          "CONNECTOR_NOT_ANNOTATED_DEDUPLICATION_PROPERTIES",
-          "prop1,prop2"
+          "io.camunda:not-annotated"
         };
 
     // when
@@ -68,22 +64,16 @@ public class InboundConnectorDiscoveryTest {
         registrations,
         "ANNOTATED_OVERRIDE",
         "io.camunda:annotated-override",
-        AnnotatedExecutable.class.getName(),
-        List.of("prop1", "prop2", "prop3"));
+        AnnotatedExecutable.class.getName());
 
     assertRegistration(
-        registrations,
-        "ANNOTATED",
-        "io.camunda:annotated",
-        AnnotatedExecutable.class.getName(),
-        List.of("id"));
+        registrations, "ANNOTATED", "io.camunda:annotated", AnnotatedExecutable.class.getName());
 
     assertRegistration(
         registrations,
         "NOT_ANNOTATED",
         "io.camunda:not-annotated",
-        NotAnnotatedExecutable.class.getName(),
-        List.of("prop1", "prop2"));
+        NotAnnotatedExecutable.class.getName());
   }
 
   @Test
@@ -172,25 +162,11 @@ public class InboundConnectorDiscoveryTest {
       String type,
       String functionCls) {
 
-    assertRegistration(registrations, name, type, functionCls, null);
-  }
-
-  private static void assertRegistration(
-      Collection<InboundConnectorConfiguration> registrations,
-      String name,
-      String type,
-      String functionCls,
-      List<String> deduplicationProperties) {
-
     Assertions.assertThatCollection(registrations)
         .anyMatch(
             registration ->
-                (registration.name().equals(name)
+                registration.name().equals(name)
                     && registration.type().equals(type)
-                    && registration.connectorClass().getName().equals(functionCls)
-                    && (deduplicationProperties == null
-                        || registration
-                            .deduplicationProperties()
-                            .equals(deduplicationProperties))));
+                    && registration.connectorClass().getName().equals(functionCls));
   }
 }

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/InboundConnectorBeanDefinitionProcessor.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/InboundConnectorBeanDefinitionProcessor.java
@@ -88,6 +88,9 @@ public class InboundConnectorBeanDefinitionProcessor
     }
   }
 
+  // Deprecation bridge: reads the deprecated @InboundConnector#deduplicationProperties to keep
+  // honoring it for backward compatibility. Removed together with the attribute in Phase 2 (#6684).
+  @SuppressWarnings("removal")
   private InboundConnectorConfiguration getInboundConnectorConfiguration(
       InboundConnector inboundConnector, String beanName, BeanFactory beanFactory) {
     final var configurationOverrides =

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/executable/InboundExecutableRegistryImpl.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/executable/InboundExecutableRegistryImpl.java
@@ -66,6 +66,7 @@ public class InboundExecutableRegistryImpl implements InboundExecutableRegistry 
                     config -> config.type(),
                     config -> config.deduplicationProperties(),
                     (a, b) -> a));
+    warnAboutDeprecatedDeduplicationProperties(deduplicationScopesByType);
     this.stateTransitionService =
         new InboundExecutableStateTransitionService(deduplicationScopesByType, stateStore);
     this.queryService =
@@ -83,6 +84,25 @@ public class InboundExecutableRegistryImpl implements InboundExecutableRegistry 
     this.stateTransitionService = stateTransitionService;
     this.queryService = queryService;
     this.batchExecutableProcessor = batchExecutableProcessor;
+  }
+
+  private static void warnAboutDeprecatedDeduplicationProperties(
+      Map<String, List<String>> deduplicationScopesByType) {
+    deduplicationScopesByType.forEach(
+        (type, deduplicationProperties) -> {
+          if (deduplicationProperties != null && !deduplicationProperties.isEmpty()) {
+            LOG.warn(
+                "Connector type '{}' declares a deduplication-properties allow-list {}. "
+                    + "This feature is deprecated and scheduled for removal: it keeps the listed "
+                    + "properties as the only deduplication scope while leaving every other bound "
+                    + "property out of it, so the value retained by a deduplicated executable is "
+                    + "arbitrary when elements diverge. Migrate to the default deduplication scope "
+                    + "and declare non-deduplicating properties as template-only (resolved per "
+                    + "request at runtime). See https://github.com/camunda/connectors/issues/6684",
+                type,
+                deduplicationProperties);
+          }
+        });
   }
 
   @Override

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/inbound/InboundConnectorBeanDefinitionProcessorTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/inbound/InboundConnectorBeanDefinitionProcessorTest.java
@@ -67,7 +67,7 @@ class InboundConnectorBeanDefinitionProcessorTest {
                   config -> {
                     assertThat(config.name()).isEqualTo("My Executable");
                     assertThat(config.type()).isEqualTo("io.camunda:annotated");
-                    assertThat(config.deduplicationProperties()).containsExactly("id");
+                    assertThat(config.deduplicationProperties()).isEmpty();
                     assertThat(config.customInstanceSupplier().get())
                         .isInstanceOf(AnnotatedExecutable.class);
                   });
@@ -88,7 +88,7 @@ class InboundConnectorBeanDefinitionProcessorTest {
                       config -> {
                         assertThat(config.name()).isEqualTo("My Executable");
                         assertThat(config.type()).isEqualTo("io.camunda:overridden");
-                        assertThat(config.deduplicationProperties()).containsExactly("id");
+                        assertThat(config.deduplicationProperties()).isEmpty();
                         assertThat(config.customInstanceSupplier().get())
                             .isInstanceOf(AnnotatedExecutable.class);
                       });
@@ -96,10 +96,7 @@ class InboundConnectorBeanDefinitionProcessorTest {
   }
 }
 
-@InboundConnector(
-    name = "My Executable",
-    type = "io.camunda:annotated",
-    deduplicationProperties = {"id"})
+@InboundConnector(name = "My Executable", type = "io.camunda:annotated")
 @Component
 @Scope("prototype")
 class AnnotatedExecutable implements InboundConnectorExecutable {

--- a/connector-sdk/core/src/main/java/io/camunda/connector/api/annotation/InboundConnector.java
+++ b/connector-sdk/core/src/main/java/io/camunda/connector/api/annotation/InboundConnector.java
@@ -33,6 +33,18 @@ public @interface InboundConnector {
   /**
    * Names of the properties that are taken into account for connector deduplication. If empty, all
    * properties are taken into account.
+   *
+   * @deprecated since 8.10.0, scheduled for removal. This inclusion allow-list names the only
+   *     properties that contribute to the deduplication ID, which silently leaves every other
+   *     <em>bound</em> property out of the deduplication scope while it remains bound to the shared
+   *     executable model. When several elements share a deduplication ID but differ in such a
+   *     property, the value retained by the deduplicated executable is arbitrary (whichever element
+   *     won the grouping). Instead, rely on the default deduplication scope — all bound properties
+   *     except the runtime-managed ones — and declare any property that must not influence
+   *     deduplication as a <em>template-only</em> property (see {@code TemplateOnly}), resolving
+   *     its value per request at runtime rather than binding it to the model. See issue <a
+   *     href="https://github.com/camunda/connectors/issues/6684">#6684</a>.
    */
+  @Deprecated(since = "8.10.0", forRemoval = true)
   String[] deduplicationProperties() default {};
 }

--- a/docs/adr/ADR-0003-deduplication-scope-deprecate-deduplication-properties.md
+++ b/docs/adr/ADR-0003-deduplication-scope-deprecate-deduplication-properties.md
@@ -1,0 +1,51 @@
+# ADR-0003: Deduplication Scope and Deprecation of deduplicationProperties
+
+## Status
+Accepted
+
+## Context
+Inbound deduplication collapses process elements that share a deduplication ID into a single
+executable. Two mechanisms decide which properties form that ID:
+
+- `@InboundConnector.deduplicationProperties` — an inclusion *allow-list*: when set, only the
+  named properties contribute to the ID;
+- `PROPERTIES_EXCLUDED_FROM_DEDUPLICATION` — a *deny-list* used by the default path: all
+  properties except the runtime-managed ones.
+
+The allow-list silently leaves every *other bound* property out of the deduplication scope while
+it stays bound to the shared executable model. When elements collapse to one executable but
+differ in such a property, the executable retains an arbitrary value (whichever element won the
+grouping) — the general form of the webhook bug fixed in
+[#6684](https://github.com/camunda/connectors/issues/6684). No connector in this repository sets
+the allow-list, and it is half-wired: the update-compatibility check always compares the
+deny-list scope even when the ID was computed from the allow-list.
+
+## Decision
+Adopt the invariant **a property excluded from deduplication must not be bound to the shared
+model** — declare it template-only ([ADR-0002](ADR-0002-template-only-properties.md)) and resolve
+it per request. Standardize on the deny-list as the single deduplication scope and deprecate the
+allow-list:
+
+- **Phase 1 (non-breaking, now):** annotate `@InboundConnector.deduplicationProperties` with
+  `@Deprecated(forRemoval = true)`, deprecate the `CONNECTOR_<name>_DEDUPLICATION_PROPERTIES`
+  environment variable, and log a runtime warning when either is used. Behavior is unchanged.
+- **Phase 2 (a future major):** remove the annotation element and the allow-list code path so the
+  deny-list is the only deduplication model.
+- **Phase 3 (optional):** add a build-time guard that flags a bound property excluded from
+  deduplication, turning the invariant into a compile-time guarantee.
+
+## Consequences
+
+### Positive
+- Removes a foot-gun that silently produces an arbitrary value in a deduplicated executable.
+- Leaves a single deduplication model (the deny-list) instead of two divergent ones; removal also
+  resolves the latent update-compatibility inconsistency.
+- Pairs with `TemplateOnly` to give an explicit, correct way to keep a property out of dedup.
+
+### Negative
+- Deprecating public API and an environment variable requires a multi-release migration window
+  for out-of-repo consumers.
+- Eventual removal broadens the deduplication scope for anyone who set a narrow subset, producing
+  more executables (though it fixes the correctness problem).
+- Connector authors must now reason explicitly about the bound / deduplicated / template-only
+  distinction.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -82,3 +82,4 @@ When asked to create an ADR:
 |-----|-------|--------|
 | [ADR-0001](ADR-0001-annotation-driven-element-template-generation.md) | Annotation-Driven Element Template Generation | Accepted |
 | [ADR-0002](ADR-0002-template-only-properties.md) | Template-Only Properties via the TemplateOnly Marker | Accepted |
+| [ADR-0003](ADR-0003-deduplication-scope-deprecate-deduplication-properties.md) | Deduplication Scope and Deprecation of deduplicationProperties | Accepted |


### PR DESCRIPTION
> ⚠️ **Stacked on #7487** (branch `6684-etg-template-only-property`). This PR targets the ETG branch, not `main` — review/merge #7487 first. The diff shown here is only the deprecation change on top of it. GitHub will auto-retarget to `main` once #7487 merges.

## Description

Deprecates the `deduplicationProperties` allow-list on `@InboundConnector` (**Phase 1 — non-breaking**).

### Why it's a problematic pattern
`deduplicationProperties` is an **inclusion allow-list**: when set, it names the *only* properties that contribute to the deduplication ID. That silently leaves every **other bound property** out of the deduplication scope while it stays bound to the shared executable model. When several elements share a deduplication ID but differ in such a property, the value retained by the deduplicated executable is **arbitrary** (whichever element won the grouping) — exactly the class of bug fixed for the webhook response expression in #6684.

The cleaner invariant is: *a property that must not influence deduplication should not be bound to the shared model* — declare it **template-only** (see `TemplateOnly`, #7487) and resolve its value per request at runtime. Combined with the default deduplication scope (all bound properties minus the runtime-managed ones, via `PROPERTIES_EXCLUDED_FROM_DEDUPLICATION`), the inclusion allow-list becomes unnecessary.

**No connector in this repository sets `deduplicationProperties`** — the only in-repo users are test fixtures. The mechanism is effectively unused internally.

### Changes
- `@InboundConnector.deduplicationProperties()` is annotated `@Deprecated(since = "8.10.0", forRemoval = true)` with migration guidance in the Javadoc.
- The runtime logs a `WARN` when a non-empty allow-list is discovered:
  - once per connector type at startup (`InboundExecutableRegistryImpl`), covering annotated connectors;
  - when the `CONNECTOR_<name>_DEDUPLICATION_PROPERTIES` environment variable is set (`EnvVarsConnectorDiscovery`).
- Test fixtures that intentionally exercise the deprecated element are marked `@SuppressWarnings("removal")`.

**Behavior is unchanged.** The allow-list is still honored when present. Removal is deferred to a future major (Phase 2) because out-of-repo consumers may still rely on the public annotation element or the environment variable.

### Phase 2 (future major, not in this PR)
Drop the annotation element, collapse `computeDeduplicationId` to always use the default (deny-list) scope, and remove the supporting plumbing (`InboundConnectorConfiguration.deduplicationProperties`, `deduplicationScopesByType`, the env-var branch). This also resolves an existing inconsistency where `areDetailsCompatibleForUpdate` compares the deny-list scope even when the ID was computed from the allow-list.

> 📝 The `CONNECTOR_<name>_DEDUPLICATION_PROPERTIES` env var should also be marked deprecated in the external Camunda docs (separate repo).

## Related issues

Part of #6684

## Checklist

- [ ] Backport labels are added if these code changes should be backported.
- [ ] Tests/Integration tests for the changes have been added if applicable.
- [ ] If the change requires a documentation update, it has been added to the appropriate section in the documentation.
