### PR TITLE
chore(et-validator): Small improvments for native operations metadata checks

### DIFF
--- a/element-template-generator/validator/src/main/java/io/camunda/connector/validator/rule/PresetCoverageRule.java
+++ b/element-template-generator/validator/src/main/java/io/camunda/connector/validator/rule/PresetCoverageRule.java
@@ -72,11 +72,9 @@ public class PresetCoverageRule implements Rule {
               file,
               "/presets",
               id(),
-              "Operation-metadata search space is too large to exhaustively check ("
-                  + searchSpace
-                  + " candidate assignments, cap is "
+              "Operation-metadata search space exceeds the cap ("
                   + MAX_CANDIDATES
-                  + "). Reduce the number of operation discriminators or choices, or split the template."));
+                  + " candidate assignments) and is too large to exhaustively check. Reduce the number of operation discriminators or choices, or split the template."));
     }
 
     Set<Map<String, String>> reachable = enumerateReachableLeaves(opKeys, declsByKey);

--- a/element-template-generator/validator/src/main/java/io/camunda/connector/validator/rule/PresetCoverageRule.java
+++ b/element-template-generator/validator/src/main/java/io/camunda/connector/validator/rule/PresetCoverageRule.java
@@ -48,6 +48,8 @@ import java.util.TreeMap;
  */
 public class PresetCoverageRule implements Rule {
 
+  static final int MAX_CANDIDATES = 100_000;
+
   @Override
   public List<Finding> apply(Path file, JsonNode template) {
     if (OperationMetadataIgnoreList.isIgnored(file)) {
@@ -63,6 +65,20 @@ public class PresetCoverageRule implements Rule {
     }
     Map<String, List<Declaration>> declsByKey = collectDeclarations(template, opKeys);
 
+    long searchSpace = candidateSearchSpace(opKeys, declsByKey);
+    if (searchSpace > MAX_CANDIDATES) {
+      return List.of(
+          Finding.error(
+              file,
+              "/presets",
+              id(),
+              "Operation-metadata search space is too large to exhaustively check ("
+                  + searchSpace
+                  + " candidate assignments, cap is "
+                  + MAX_CANDIDATES
+                  + "). Reduce the number of operation discriminators or choices, or split the template."));
+    }
+
     Set<Map<String, String>> reachable = enumerateReachableLeaves(opKeys, declsByKey);
     Set<Map<String, String>> presetAssignments = extractPresetAssignments(presetsNode);
     List<Map<String, String>> stepLeafAssignments =
@@ -73,6 +89,25 @@ public class PresetCoverageRule implements Rule {
     findings.addAll(reportOrphanAndDuplicatePresets(file, presetsNode, reachable));
     findings.addAll(reportStepLeafCoverage(file, reachable, stepLeafAssignments));
     return findings;
+  }
+
+  private long candidateSearchSpace(Set<String> opKeys, Map<String, List<Declaration>> declsByKey) {
+    long product = 1L;
+    for (String k : opKeys) {
+      Set<String> union = new LinkedHashSet<>();
+      for (Declaration d : declsByKey.get(k)) {
+        union.addAll(d.choices);
+      }
+      long factor = 1L + union.size();
+      if (factor > MAX_CANDIDATES) {
+        return Long.MAX_VALUE;
+      }
+      product = Math.multiplyExact(product, factor);
+      if (product > MAX_CANDIDATES) {
+        return product;
+      }
+    }
+    return product;
   }
 
   private Set<String> discoverOpKeys(JsonNode presets) {
@@ -197,16 +232,7 @@ public class PresetCoverageRule implements Rule {
       if (!properties.isObject()) {
         continue;
       }
-      Map<String, String> assignment = new LinkedHashMap<>();
-      properties
-          .properties()
-          .forEach(
-              e -> {
-                if (e.getValue().isTextual()) {
-                  assignment.put(e.getKey(), e.getValue().asText());
-                }
-              });
-      result.add(normalize(assignment));
+      result.add(normalize(extractTextAssignment(properties)));
     }
     return result;
   }
@@ -220,16 +246,7 @@ public class PresetCoverageRule implements Rule {
       if (!idNode.isTextual() || !properties.isObject()) {
         continue;
       }
-      Map<String, String> assignment = new LinkedHashMap<>();
-      properties
-          .properties()
-          .forEach(
-              e -> {
-                if (e.getValue().isTextual()) {
-                  assignment.put(e.getKey(), e.getValue().asText());
-                }
-              });
-      presetsById.put(idNode.asText(), normalize(assignment));
+      presetsById.put(idNode.asText(), normalize(extractTextAssignment(properties)));
     }
     List<Map<String, String>> result = new ArrayList<>();
     JsonNode steps = template.path(ElementTemplate.STEPS);
@@ -237,6 +254,19 @@ public class PresetCoverageRule implements Rule {
       collectLeaves(steps, presetsById, result);
     }
     return result;
+  }
+
+  private static Map<String, String> extractTextAssignment(JsonNode properties) {
+    Map<String, String> assignment = new LinkedHashMap<>();
+    properties
+        .properties()
+        .forEach(
+            e -> {
+              if (e.getValue().isTextual()) {
+                assignment.put(e.getKey(), e.getValue().asText());
+              }
+            });
+    return assignment;
   }
 
   private void collectLeaves(
@@ -284,16 +314,7 @@ public class PresetCoverageRule implements Rule {
       if (!idNode.isTextual() || !properties.isObject()) {
         continue;
       }
-      Map<String, String> assignment = new LinkedHashMap<>();
-      properties
-          .properties()
-          .forEach(
-              e -> {
-                if (e.getValue().isTextual()) {
-                  assignment.put(e.getKey(), e.getValue().asText());
-                }
-              });
-      Map<String, String> normalized = normalize(assignment);
+      Map<String, String> normalized = normalize(extractTextAssignment(properties));
       if (!reachable.contains(normalized)) {
         findings.add(
             Finding.error(

--- a/element-template-generator/validator/src/main/java/io/camunda/connector/validator/rule/PresetTargetExistsRule.java
+++ b/element-template-generator/validator/src/main/java/io/camunda/connector/validator/rule/PresetTargetExistsRule.java
@@ -72,6 +72,16 @@ public class PresetTargetExistsRule implements Rule {
           continue;
         }
         if (!value.isTextual()) {
+          findings.add(
+              Finding.error(
+                  file,
+                  entryPointer,
+                  id(),
+                  "Preset value for property \""
+                      + key
+                      + "\" must be a string (got "
+                      + value.getNodeType().toString().toLowerCase()
+                      + ")."));
           continue;
         }
         Set<String> choices = propertyChoices.get(key);

--- a/element-template-generator/validator/src/test/java/io/camunda/connector/validator/rule/PresetCoverageRuleTest.java
+++ b/element-template-generator/validator/src/test/java/io/camunda/connector/validator/rule/PresetCoverageRuleTest.java
@@ -201,6 +201,37 @@ class PresetCoverageRuleTest {
     assertThat(rule.apply(Path.of("connectors/aws/element-templates/x.json"), template)).isEmpty();
   }
 
+  @Test
+  void searchSpaceExceedsCap_singleFinding() throws Exception {
+    // Build 6 op-keys with 9 choices each → (1+9)^6 = 1,000,000 candidate assignments,
+    // well above the 100,000 cap.
+    StringBuilder properties = new StringBuilder();
+    StringBuilder presetProps = new StringBuilder();
+    for (int k = 0; k < 6; k++) {
+      if (k > 0) {
+        properties.append(",");
+        presetProps.append(",");
+      }
+      properties.append("{\"id\":\"k").append(k).append("\",\"choices\":[");
+      for (int c = 0; c < 9; c++) {
+        if (c > 0) properties.append(",");
+        properties.append("{\"value\":\"v").append(c).append("\"}");
+      }
+      properties.append("]}");
+      presetProps.append("\"k").append(k).append("\":\"v0\"");
+    }
+    String json =
+        "{\"properties\":["
+            + properties
+            + "],\"presets\":[{\"id\":\"p\",\"properties\":{"
+            + presetProps
+            + "}}],\"steps\":[]}";
+    List<Finding> findings = rule.apply(FILE, read(json));
+    assertThat(findings).hasSize(1);
+    assertThat(findings.get(0).jsonPointer()).isEqualTo("/presets");
+    assertThat(findings.get(0).message()).contains("search space").contains("too large");
+  }
+
   private static JsonNode read(String json) throws Exception {
     return MAPPER.readTree(json);
   }

--- a/element-template-generator/validator/src/test/java/io/camunda/connector/validator/rule/PresetTargetExistsRuleTest.java
+++ b/element-template-generator/validator/src/test/java/io/camunda/connector/validator/rule/PresetTargetExistsRuleTest.java
@@ -138,6 +138,23 @@ class PresetTargetExistsRuleTest {
   }
 
   @Test
+  void nonStringPresetValue_oneFinding() throws Exception {
+    JsonNode template =
+        read(
+            """
+        {
+          "properties": [ { "id": "freeText" } ],
+          "presets": [ { "id": "p", "properties": { "freeText": 42 } } ]
+        }
+        """);
+    List<Finding> findings = rule.apply(FILE, template);
+    assertThat(findings).hasSize(1);
+    Finding f = findings.get(0);
+    assertThat(f.jsonPointer()).isEqualTo("/presets/0/properties/freeText");
+    assertThat(f.message()).contains("must be a string");
+  }
+
+  @Test
   void duplicateIdsWithDifferentChoices_unionAccepted() throws Exception {
     JsonNode template =
         read(


### PR DESCRIPTION
## Description
Just few smaller improvements for the validator rules of native operations metadata

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #

## Checklist

- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest
  release, as this branch will be rebased onto main before the next release. Example backport labels:
    - `backport stable/8.8`: for changes that should be included in the next 8.8.x release.
    - **or** `backport release-8.8.7`: for changes that should be included in the specific release 8.8.7, and this
      *release has already been created*. The release branch will be merged back into stable/8.8 later, so the change
      will be included in future 8.8.x releases as well.
- [ ] Tests/Integration tests for the changes have been added if applicable.
- [ ] If the change requires a documentation update, it has been added to the appropriate section in the documentation.


