### PR TITLE
fix: replace String.intern() locks with ConcurrentHashMap in InboundExecutableRegistryImpl

### DIFF
--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/executable/InboundExecutableRegistryImpl.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/executable/InboundExecutableRegistryImpl.java
@@ -53,7 +53,8 @@ public class InboundExecutableRegistryImpl implements InboundExecutableRegistry 
   private final BatchExecutableProcessor batchExecutableProcessor;
 
   private final BlockingQueue<InboundExecutableEvent> eventQueue = new LinkedBlockingQueue<>();
-  // Per-(tenantId,bpmnProcessId) lock objects to serialize state transitions within this registry instance.
+  // Per-(tenantId,bpmnProcessId) lock objects to serialize state transitions within this registry
+  // instance.
   // Intentionally never evicted to avoid handing out different locks for the same key under race;
   // size grows with distinct (tenantId,bpmnProcessId) pairs observed during runtime.
   private final ConcurrentHashMap<String, Object> processLocks = new ConcurrentHashMap<>();

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/executable/InboundExecutableRegistryImpl.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/executable/InboundExecutableRegistryImpl.java
@@ -33,6 +33,7 @@ import io.camunda.connector.runtime.inbound.executable.RegisteredExecutable.Canc
 import io.camunda.connector.runtime.inbound.executable.RegisteredExecutable.FailedToActivate;
 import java.util.*;
 import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.function.Consumer;
 import org.slf4j.Logger;
@@ -52,6 +53,7 @@ public class InboundExecutableRegistryImpl implements InboundExecutableRegistry 
   private final BatchExecutableProcessor batchExecutableProcessor;
 
   private final BlockingQueue<InboundExecutableEvent> eventQueue = new LinkedBlockingQueue<>();
+  private final ConcurrentHashMap<String, Object> processLocks = new ConcurrentHashMap<>();
 
   public InboundExecutableRegistryImpl(
       InboundConnectorFactory connectorFactory,
@@ -119,7 +121,7 @@ public class InboundExecutableRegistryImpl implements InboundExecutableRegistry 
 
     var processLockKey = processLockKey(event.tenantId(), event.bpmnProcessId());
 
-    synchronized (processLockKey.intern()) {
+    synchronized (processLocks.computeIfAbsent(processLockKey, k -> new Object())) {
       try {
         List<InboundConnectorElement> allElements =
             event.elementsByProcessDefinitionKey().values().stream().flatMap(List::stream).toList();
@@ -315,7 +317,7 @@ public class InboundExecutableRegistryImpl implements InboundExecutableRegistry 
     // could run during restart, leaving the newly-activated executable invisible to the state
     // machine (zombie connector).
     var processLockKey = extractProcessLockKey(validateResettable(id));
-    synchronized (processLockKey.intern()) {
+    synchronized (processLocks.computeIfAbsent(processLockKey, k -> new Object())) {
       // Re-validate inside the lock; state may have changed since the peek
       var current = validateResettable(id);
 

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/executable/InboundExecutableRegistryImpl.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/executable/InboundExecutableRegistryImpl.java
@@ -53,6 +53,9 @@ public class InboundExecutableRegistryImpl implements InboundExecutableRegistry 
   private final BatchExecutableProcessor batchExecutableProcessor;
 
   private final BlockingQueue<InboundExecutableEvent> eventQueue = new LinkedBlockingQueue<>();
+  // Per-(tenantId,bpmnProcessId) lock objects to serialize state transitions within this registry instance.
+  // Intentionally never evicted to avoid handing out different locks for the same key under race;
+  // size grows with distinct (tenantId,bpmnProcessId) pairs observed during runtime.
   private final ConcurrentHashMap<String, Object> processLocks = new ConcurrentHashMap<>();
 
   public InboundExecutableRegistryImpl(


### PR DESCRIPTION
## Problem

`InboundExecutableRegistryImpl` used `synchronized (processLockKey.intern())` in two places — `handleProcessStateChanged` and `reset` — to serialize concurrent state transitions for the same process.

`String.intern()` is an anti-pattern for lock objects. It returns the canonical instance from the **JVM-wide string pool**, so the monitor lives on a globally shared object. Any code anywhere in the JVM — a library, a framework, or another Spring bean — that interns a string with the same value as `tenantId + bpmnProcessId` would share that monitor. This creates invisible, unauditable coupling that can cause unexpected contention or liveness issues.

## Fix

Replaced both usages with a `ConcurrentHashMap<String, Object> processLocks` field on the registry instance:

```java
synchronized (processLocks.computeIfAbsent(processLockKey, k -> new Object()))
```

Lock objects are now:
- **Private** to this registry instance — no accidental sharing with external code
- **Per process key** — `(tenantId, bpmnProcessId)` pairs still get distinct locks, so unrelated processes don't block each other
- **Stable** — `computeIfAbsent` is atomic; two threads racing on the same key will always get the same object

The map is intentionally never evicted. Removing an entry while another thread is about to `computeIfAbsent` the same key would silently hand two concurrent callers *different* lock objects, breaking mutual exclusion. Growth is bounded by the number of distinct deployed processes, which is fine for this domain.

## Out of scope (flagged for follow-up)

`processLockKey` is currently computed as `tenantId + bpmnProcessId` with no separator, so `("foo", "bar")` and `("foob", "ar")` collide on the same key (false lock sharing). This is a pre-existing issue not introduced here — tracked separately.