### PR TITLE
fix: remove activity log entries on permanent connector deactivation

### DIFF
--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/activitylog/ActivityLogRegistry.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/activitylog/ActivityLogRegistry.java
@@ -48,6 +48,12 @@ public class ActivityLogRegistry implements ActivityLogWriter {
     }
   }
 
+  public void remove(ExecutableId executableId) {
+    synchronized (activityLogs) {
+      activityLogs.remove(executableId);
+    }
+  }
+
   @Override
   public void log(ActivityLogEntry logEntry) {
     String message = logEntry.activity().toString();

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/inbound/activitylog/ActivityLogRegistryTest.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/inbound/activitylog/ActivityLogRegistryTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.runtime.core.inbound.activitylog;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import io.camunda.connector.api.inbound.Activity;
+import io.camunda.connector.api.inbound.ActivityLogTag;
+import io.camunda.connector.api.inbound.Severity;
+import io.camunda.connector.runtime.core.inbound.ExecutableId;
+import org.junit.jupiter.api.Test;
+
+class ActivityLogRegistryTest {
+
+  private final ActivityLogRegistry registry = new ActivityLogRegistry();
+
+  private static ActivityLogEntry entry(ExecutableId id, String message) {
+    return new ActivityLogEntry(
+        id,
+        ActivitySource.RUNTIME,
+        Activity.newBuilder()
+            .withSeverity(Severity.INFO)
+            .withTag(ActivityLogTag.LIFECYCLE)
+            .withMessage(message)
+            .build());
+  }
+
+  @Test
+  void remove_removesAllLogsForExecutable() {
+    var id = ExecutableId.fromDeduplicationId("someConnector");
+    registry.log(entry(id, "activated"));
+    registry.log(entry(id, "something happened"));
+
+    registry.remove(id);
+
+    assertThat(registry.getLogs(id)).isEmpty();
+  }
+
+  @Test
+  void remove_doesNotAffectOtherExecutables() {
+    var id1 = ExecutableId.fromDeduplicationId("connector-1");
+    var id2 = ExecutableId.fromDeduplicationId("connector-2");
+    registry.log(entry(id1, "activated"));
+    registry.log(entry(id2, "activated"));
+
+    registry.remove(id1);
+
+    assertThat(registry.getLogs(id1)).isEmpty();
+    assertThat(registry.getLogs(id2)).hasSize(1);
+  }
+
+  @Test
+  void remove_unknownId_isNoOp() {
+    var id = ExecutableId.fromDeduplicationId("nonexistent");
+    assertThatCode(() -> registry.remove(id)).doesNotThrowAnyException();
+    assertThat(registry.getLogs(id)).isEmpty();
+  }
+}

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/executable/InboundExecutableRegistryImpl.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/executable/InboundExecutableRegistryImpl.java
@@ -50,6 +50,7 @@ public class InboundExecutableRegistryImpl implements InboundExecutableRegistry 
   private final InboundExecutableStateTransitionService stateTransitionService;
   private final InboundExecutableQueryService queryService;
   private final BatchExecutableProcessor batchExecutableProcessor;
+  private final ActivityLogRegistry activityLogRegistry;
 
   private final BlockingQueue<InboundExecutableEvent> eventQueue = new LinkedBlockingQueue<>();
 
@@ -71,6 +72,7 @@ public class InboundExecutableRegistryImpl implements InboundExecutableRegistry 
     this.queryService =
         new InboundExecutableQueryService(stateStore, connectorFactory, activityLogRegistry);
     this.batchExecutableProcessor = batchExecutableProcessor;
+    this.activityLogRegistry = activityLogRegistry;
   }
 
   // Constructor for testing with injected dependencies
@@ -83,6 +85,7 @@ public class InboundExecutableRegistryImpl implements InboundExecutableRegistry 
     this.stateTransitionService = stateTransitionService;
     this.queryService = queryService;
     this.batchExecutableProcessor = batchExecutableProcessor;
+    this.activityLogRegistry = new ActivityLogRegistry();
   }
 
   @Override
@@ -143,8 +146,10 @@ public class InboundExecutableRegistryImpl implements InboundExecutableRegistry 
     // Process actions in order: deactivate first, then updates, then activate
     // This ensures we free resources before allocating new ones
 
-    // 1. Deactivate executables no longer needed
-    deactivateExecutables(plan.getExecutableIds(ActionType.DEACTIVATE));
+    // 1. Deactivate executables no longer needed and purge their logs
+    var toDeactivatePermanently = plan.getExecutableIds(ActionType.DEACTIVATE);
+    deactivateExecutables(toDeactivatePermanently);
+    toDeactivatePermanently.forEach(activityLogRegistry::remove);
 
     // 2. Restart executables (deactivate + activate)
     var toRestart = plan.getExecutableIds(ActionType.RESTART);

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/executable/InboundExecutableRegistryImpl.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/executable/InboundExecutableRegistryImpl.java
@@ -80,12 +80,13 @@ public class InboundExecutableRegistryImpl implements InboundExecutableRegistry 
       InboundExecutableStateStore stateStore,
       InboundExecutableStateTransitionService stateTransitionService,
       InboundExecutableQueryService queryService,
-      BatchExecutableProcessor batchExecutableProcessor) {
+      BatchExecutableProcessor batchExecutableProcessor,
+      ActivityLogRegistry activityLogRegistry) {
     this.stateStore = stateStore;
     this.stateTransitionService = stateTransitionService;
     this.queryService = queryService;
     this.batchExecutableProcessor = batchExecutableProcessor;
-    this.activityLogRegistry = new ActivityLogRegistry();
+    this.activityLogRegistry = activityLogRegistry;
   }
 
   @Override

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/inbound/executable/InboundExecutableRegistryTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/inbound/executable/InboundExecutableRegistryTest.java
@@ -720,11 +720,16 @@ public class InboundExecutableRegistryTest {
     var executableId = registry.query(f -> f.elementId(elementId)).getFirst().executableId();
     assertThat(activityLogRegistry.getLogs(executableId)).hasSize(1); // initial activation log
 
+    // capture logs before reset to verify they survive the restart
+    var logsBeforeReset = List.copyOf(activityLogRegistry.getLogs(executableId));
+
     // when - restart (RESTART action, not permanent DEACTIVATE)
     registry.reset(executableId);
 
-    // then - logs from before the restart are still present alongside new activation log
-    assertThat(activityLogRegistry.getLogs(executableId)).hasSizeGreaterThanOrEqualTo(2);
+    // then - all logs from before the restart are still present alongside the new activation log
+    var logsAfterReset = activityLogRegistry.getLogs(executableId);
+    assertThat(logsAfterReset).containsAll(logsBeforeReset);
+    assertThat(logsAfterReset).hasSizeGreaterThan(logsBeforeReset.size());
   }
 
   @Test

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/inbound/executable/InboundExecutableRegistryTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/inbound/executable/InboundExecutableRegistryTest.java
@@ -17,7 +17,7 @@
 package io.camunda.connector.runtime.inbound.executable;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -634,8 +634,7 @@ public class InboundExecutableRegistryTest {
   }
 
   @Test
-  public void activityLog_deactivation_shouldContainBothActivationAndDeactivationEntries()
-      throws Exception {
+  public void activityLog_permanentDeactivation_logsShouldBePurged() throws Exception {
     // given
     var elementId = "elementId";
     var element =
@@ -654,17 +653,78 @@ public class InboundExecutableRegistryTest {
     registry.handleEvent(new ProcessStateChanged("id", "tenant", Map.of(0L, List.of(element))));
     var executableId = registry.query(f -> f.elementId(elementId)).getFirst().executableId();
 
-    // when - send empty process state to trigger deactivation of all connectors in this process
+    // when - send empty process state to trigger permanent deactivation
     registry.handleEvent(new ProcessStateChanged("id", "tenant", Map.of()));
 
-    // then
-    var logs = activityLogRegistry.getLogs(executableId);
-    assertThat(logs).hasSize(2);
-    assertThat(logs)
-        .extracting(Activity::message)
-        .anySatisfy(msg -> assertThat(msg).contains("Activated"))
-        .anySatisfy(msg -> assertThat(msg).contains("Deactivated"));
-    assertThat(logs).extracting(Activity::tag).containsOnly(ActivityLogTag.LIFECYCLE);
+    // then - logs are removed to prevent memory leak
+    assertThat(activityLogRegistry.getLogs(executableId)).isEmpty();
+  }
+
+  @Test
+  public void activityLog_deactivation_deactivationLifecycleEntryIsEmitted() throws Exception {
+    // given - use a spy so we can verify log() is called even though the entry is removed afterward
+    var spyRegistry = spy(activityLogRegistry);
+    var localBatchProcessor =
+        new BatchExecutableProcessor(
+            factory, contextFactory, mock(ConnectorsInboundMetrics.class), null, spyRegistry);
+    var localRegistry =
+        new InboundExecutableRegistryImpl(factory, localBatchProcessor, spyRegistry);
+
+    var elementId = "elementId";
+    var element =
+        new InboundConnectorElement(
+            Map.of(Keywords.INBOUND_TYPE_KEYWORD, "type1"),
+            new StartEventCorrelationPoint("processId", 0, 0),
+            new ProcessElementWithRuntimeData("id", 0, 0, elementId, "tenant"));
+    var executable = mock(InboundConnectorExecutable.class);
+    var context = mock(InboundConnectorManagementContext.class);
+    when(context.getDefinition())
+        .thenReturn(new InboundConnectorDefinition("type1", "tenant", "id", null));
+    when(context.connectorElements()).thenReturn(List.of(element));
+    when(contextFactory.createContext(any(), any(), any(), any())).thenReturn(context);
+    when(factory.getInstance(any())).thenReturn(executable);
+
+    localRegistry.handleEvent(
+        new ProcessStateChanged("id", "tenant", Map.of(0L, List.of(element))));
+
+    // when
+    localRegistry.handleEvent(new ProcessStateChanged("id", "tenant", Map.of()));
+
+    // then - the deactivation lifecycle entry was logged before being removed
+    verify(spyRegistry)
+        .log(
+            argThat(
+                entry ->
+                    ActivityLogTag.LIFECYCLE.equals(entry.activity().tag())
+                        && entry.activity().message().contains("Deactivated")));
+  }
+
+  @Test
+  public void activityLog_afterRestart_priorLogsShouldSurvive() throws Exception {
+    // given
+    var elementId = "elementId";
+    var element =
+        new InboundConnectorElement(
+            Map.of(Keywords.INBOUND_TYPE_KEYWORD, "type1"),
+            new StartEventCorrelationPoint("processId", 0, 0),
+            new ProcessElementWithRuntimeData("id", 0, 0, elementId, "tenant"));
+    var executable = mock(InboundConnectorExecutable.class);
+    var context = mock(InboundConnectorManagementContext.class);
+    when(context.getDefinition())
+        .thenReturn(new InboundConnectorDefinition("type1", "tenant", "id", null));
+    when(context.connectorElements()).thenReturn(List.of(element));
+    when(contextFactory.createContext(any(), any(), any(), any())).thenReturn(context);
+    when(factory.getInstance(any())).thenReturn(executable);
+
+    registry.handleEvent(new ProcessStateChanged("id", "tenant", Map.of(0L, List.of(element))));
+    var executableId = registry.query(f -> f.elementId(elementId)).getFirst().executableId();
+    assertThat(activityLogRegistry.getLogs(executableId)).hasSize(1); // initial activation log
+
+    // when - restart (RESTART action, not permanent DEACTIVATE)
+    registry.reset(executableId);
+
+    // then - logs from before the restart are still present alongside new activation log
+    assertThat(activityLogRegistry.getLogs(executableId)).hasSizeGreaterThanOrEqualTo(2);
   }
 
   @Test


### PR DESCRIPTION
## Problem

`ActivityLogRegistry` stores activity logs per `ExecutableId` in an internal `Map` but never removes entries. Each time a connector is deployed then undeployed, the map grows by one entry and those entries are never reclaimed. Over time this causes unbounded memory growth in long-running runtimes with frequent redeployments.

## Solution

Added `ActivityLogRegistry.remove(ExecutableId)` — a synchronized map removal, consistent with the existing `getLogs` and `log` methods.

The call site is `InboundExecutableRegistryImpl.executeStateTransition`, immediately after the permanent **DEACTIVATE** batch completes. This is the only action that permanently discards an executable:

- **DEACTIVATE** → remove logs ✅ (connector is gone for good)
- **RESTART** → keep logs (same `ExecutableId` re-activated moments later)
- **REPLACE_WITH_INVALID** → keep logs (executable stays visible via the query API as `InvalidDefinition`)

## Tests

- **`ActivityLogRegistryTest`** (new unit test): verifies `remove` clears all logs for the target id, leaves other ids untouched, and is a no-op on an unknown id.
- **`activityLog_permanentDeactivation_logsShouldBePurged`**: integration test — confirms the registry is empty after a permanent deactivation event.
- **`activityLog_deactivation_deactivationLifecycleEntryIsEmitted`**: regression test using a spy — confirms the deactivation lifecycle entry is still written to the log before being removed.
- **`activityLog_afterRestart_priorLogsShouldSurvive`**: regression test — confirms that a `reset()` (RESTART path) does not remove logs for the reactivated connector.

## Checklist

- [x] Memory leak fixed
- [x] RESTART and REPLACE_WITH_INVALID paths unaffected
- [x] All existing tests pass
- [x] New tests cover the fix and guard against regressions