### PR TITLE
fix(github-connector): qualify FEEL variable references in authentication.token expression

### DIFF
--- a/connectors/github/element-templates/github-connector.json
+++ b/connectors/github/element-templates/github-connector.json
@@ -589,7 +589,7 @@
     {
       "group": "authentication",
       "type": "Hidden",
-      "value": "= if authType = \"github_app\" then {\"camunda.function.type\":\"createGithubAppInstallationToken\",\"params\":[githubAppPrivateKey,githubAppAppId,githubAppInstallationId]} else pat",
+      "value": "= if authentication.authType = \"github_app\" then {\"camunda.function.type\":\"createGithubAppInstallationToken\",\"params\":[authentication.githubAppPrivateKey,authentication.githubAppAppId,authentication.githubAppInstallationId]} else authentication.pat",
       "binding": {
         "type": "zeebe:input",
         "name": "authentication.token"


### PR DESCRIPTION
## Description

The GitHub connector element template has a Hidden field that computes the `authentication.token` input for the underlying HTTP REST connector. Its FEEL expression referenced bare variable names (`authType`, `pat`, `githubAppPrivateKey`, `githubAppAppId`, `githubAppInstallationId`), but every sibling form field binds to a dotted `zeebe:input` name under the `authentication.*` prefix.

Per the [Camunda variables docs](https://docs.camunda.io/docs/components/concepts/variables/#inputoutput-variable-mappings), Zeebe evaluates input mappings in source order and materialises dotted names into a nested object. This means the FEEL scope at evaluation time contained `authentication.authType` (nested), not a top-level `authType`. All bare references resolved to `null`, the `if/else` expression evaluated to `null`, and `authentication.token` was set to empty — triggering:

```
jakarta.validation.ValidationException: Found constraints violated while validating input:
 - Property: authentication.token: Validation failed. Original message: must not be empty
```

This affected both the Personal Access Token path (token always null) and the GitHub App path (function call descriptor never constructed).

**Fix:** qualify every variable reference with the `authentication.` prefix in the single Hidden field's `value`:

```diff
- "= if authType = \"github_app\" then {\"camunda.function.type\":\"createGithubAppInstallationToken\",\"params\":[githubAppPrivateKey,githubAppAppId,githubAppInstallationId]} else pat"
+ "= if authentication.authType = \"github_app\" then {\"camunda.function.type\":\"createGithubAppInstallationToken\",\"params\":[authentication.githubAppPrivateKey,authentication.githubAppAppId,authentication.githubAppInstallationId]} else authentication.pat"
```

**Note for users:** existing BPMN diagrams that already embedded the old expression must be re-saved in Camunda Modeler (open the task, click save) to regenerate the `zeebe:input` source with the corrected expression. Diagrams saved after this template is deployed will work automatically.

**Scope:** only `connectors/github/element-templates/github-connector.json` (the unversioned/latest template). The frozen versioned copies (`versioned/github-connector-9.json`, `versioned/github-connector-10.json`) are left untouched per the versioning convention — users on those older template versions should upgrade to the latest.

## Related issues

closes #

## Checklist

- [ ] Backport labels are added if these code changes should be backported.
- [x] Tests/Integration tests for the changes have been added if applicable. *(The GitHub connector has no Java module — it is element-template only. The fix was verified locally using `LocalFeelExpressionEvaluator` against both the PAT and GitHub App branches, plus a negative-control test confirming the old broken expression returned `null`.)*
- [ ] If the change requires a documentation update, it has been added to the appropriate section in the documentation.