### PR TITLE
chore: split CODEOWNERS between connectors-core and connectors-experience teams

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -14,6 +14,7 @@
 /connectors/ @camunda/connectors-experience
 /connectors/http/ @camunda/connectors-core
 /connectors/webhook/ @camunda/connectors-core
+/connectors/soap/ @camunda/connectors-core
 
 # Custom rule for AI & IDP collaborators
 /connectors/agentic-ai @camunda/connectors-agentic-ai @camunda/connectors

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -9,6 +9,8 @@
 /parent/ @camunda/connectors-core
 /secret-providers/ @camunda/connectors-core
 /element-template-generator/ @camunda/connectors-core
+/connector-templates.json @camunda/connectors-core
+/ignore-templates.json @camunda/connectors-core
 
 # Connectors: experience team owns all by default; core overrides for http/graphql/webhook
 /connectors/ @camunda/connectors-experience

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -12,6 +12,7 @@
 
 # Connectors: experience team owns all by default; core overrides for http/graphql/webhook
 /connectors/ @camunda/connectors-experience
+/connectors/pom.xml @camunda/connectors-core @camunda/connectors-experience
 /connectors/http/ @camunda/connectors-core
 /connectors/webhook/ @camunda/connectors-core
 /connectors/soap/ @camunda/connectors-core

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -20,14 +20,14 @@
 /connectors/soap/ @camunda/connectors-core
 
 # Custom rule for AI & IDP collaborators
-/connectors/agentic-ai @camunda/connectors-agentic-ai @camunda/connectors
+/connectors/agentic-ai @camunda/connectors-agentic-ai
 /connectors/idp-extraction @camunda/connectors-idp @camunda/connectors
-/connectors/embeddings-vector-database @camunda/connectors-agentic-ai @camunda/connectors
-/connectors-e2e-test/connectors-e2e-test-agentic-ai @camunda/connectors-agentic-ai @camunda/connectors
-/connectors/aws/aws-bedrock-codeinterpreter @camunda/connectors-agentic-ai @camunda/connectors
-/connectors/aws/aws-bedrock-knowledgebase @camunda/connectors-agentic-ai @camunda/connectors
-/connectors/aws/aws-bedrock-agentcore-runtime @camunda/connectors-agentic-ai @camunda/connectors
-/connectors/aws/aws-bedrock-agentcore-long-term-memory @camunda/connectors-agentic-ai @camunda/connectors
+/connectors/embeddings-vector-database @camunda/connectors-agentic-ai
+/connectors-e2e-test/connectors-e2e-test-agentic-ai @camunda/connectors-agentic-ai
+/connectors/aws/aws-bedrock-codeinterpreter @camunda/connectors-agentic-ai
+/connectors/aws/aws-bedrock-knowledgebase @camunda/connectors-agentic-ai
+/connectors/aws/aws-bedrock-agentcore-runtime @camunda/connectors-agentic-ai
+/connectors/aws/aws-bedrock-agentcore-long-term-memory @camunda/connectors-agentic-ai
 
 # These files are excluded so that Renovate can automatically merge dependency upgrades
 renovate.json

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,6 +1,20 @@
 # These owners will be the default owners for everything in the repo.
 * @camunda/connectors
 
+# Core platform infrastructure (SDK, runtime, bundle, shared libs)
+/connector-sdk/ @camunda/connectors-core
+/connector-runtime/ @camunda/connectors-core
+/bundle/ @camunda/connectors-core
+/connector-commons/ @camunda/connectors-core
+/parent/ @camunda/connectors-core
+/secret-providers/ @camunda/connectors-core
+/element-template-generator/ @camunda/connectors-core
+
+# Connectors: experience team owns all by default; core overrides for http/graphql/webhook
+/connectors/ @camunda/connectors-experience
+/connectors/http/ @camunda/connectors-core
+/connectors/webhook/ @camunda/connectors-core
+
 # Custom rule for AI & IDP collaborators
 /connectors/agentic-ai @camunda/connectors-agentic-ai @camunda/connectors
 /connectors/idp-extraction @camunda/connectors-idp @camunda/connectors


### PR DESCRIPTION
## Summary

- Introduces `@camunda/connectors-core` as owner of the platform infrastructure (SDK, runtime, bundle, connector-commons, parent, secret-providers, element-template-generator), including `/connector-templates.json` and `/ignore-templates.json`, and the http/webhook/soap connectors
- Introduces `@camunda/connectors-experience` as owner of all other integration connectors
- Sets `/connectors/pom.xml` to shared ownership between `@camunda/connectors-core` and `@camunda/connectors-experience`
- `@camunda/connectors` umbrella team remains as the catch-all for anything not explicitly assigned
- Adjusts AI ownership paths to be owned by `@camunda/connectors-agentic-ai` (without additionally tagging `@camunda/connectors`), while keeping IDP-specific ownership unchanged

🤖 Generated with <a href="https://claude.com/claude-code">Claude Code</a>