### PR TITLE
fix(runtime): enrich aggregated health with per-connector context details

### DIFF
--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/executable/InboundExecutableQueryService.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/executable/InboundExecutableQueryService.java
@@ -228,27 +228,19 @@ public class InboundExecutableQueryService {
     Map<String, Object> details = new LinkedHashMap<>();
     if (health.getDetails() != null) details.putAll(health.getDetails());
     if (!def.elements().isEmpty()) {
-      details.put("processId", def.elements().getFirst().bpmnProcessId());
+      details.putIfAbsent("processId", def.elements().getFirst().bpmnProcessId());
     }
-    details.put("tenantId", def.tenantId());
-    details.put("type", def.type());
-    return withDetails(health, details);
+    details.putIfAbsent("tenantId", def.tenantId());
+    details.putIfAbsent("type", def.type());
+    return health.withDetails(details);
   }
 
   private Health enrich(Health health, InboundConnectorDetails data) {
     Map<String, Object> details = new LinkedHashMap<>();
     if (health.getDetails() != null) details.putAll(health.getDetails());
-    details.put("processId", data.processDefinitionId());
-    details.put("tenantId", data.tenantId());
-    details.put("type", data.type());
-    return withDetails(health, details);
-  }
-
-  private static Health withDetails(Health health, Map<String, Object> details) {
-    return switch (health.getStatus()) {
-      case UP -> Health.up(details);
-      case DOWN -> Health.down(health.getError(), details);
-      case UNKNOWN -> Health.unknown(details);
-    };
+    details.putIfAbsent("processId", data.processDefinitionId());
+    details.putIfAbsent("tenantId", data.tenantId());
+    details.putIfAbsent("type", data.type());
+    return health.withDetails(details);
   }
 }

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/executable/InboundExecutableQueryService.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/executable/InboundExecutableQueryService.java
@@ -19,14 +19,17 @@ package io.camunda.connector.runtime.inbound.executable;
 import io.camunda.connector.api.inbound.Health;
 import io.camunda.connector.api.inbound.Health.Status;
 import io.camunda.connector.runtime.core.inbound.InboundConnectorFactory;
+import io.camunda.connector.runtime.core.inbound.InboundConnectorManagementContext;
 import io.camunda.connector.runtime.core.inbound.activitylog.ActivityLogRegistry;
+import io.camunda.connector.runtime.core.inbound.details.InboundConnectorDetails;
 import io.camunda.connector.runtime.inbound.executable.RegisteredExecutable.Activated;
 import io.camunda.connector.runtime.inbound.executable.RegisteredExecutable.Cancelled;
 import io.camunda.connector.runtime.inbound.executable.RegisteredExecutable.ConnectorNotRegistered;
 import io.camunda.connector.runtime.inbound.executable.RegisteredExecutable.FailedToActivate;
 import io.camunda.connector.runtime.inbound.executable.RegisteredExecutable.InvalidDefinition;
-import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 /** Service responsible for handling queries against the executable state and building responses. */
@@ -190,16 +193,20 @@ public class InboundExecutableQueryService {
       return Health.up();
     }
 
-    List<Health> healths = new ArrayList<>();
+    Map<String, Object> downHealthsById = new LinkedHashMap<>();
     for (RegisteredExecutable executable : executables) {
-      healths.add(getHealthFromExecutable(executable));
+      var health = getHealthFromExecutable(executable);
+      if (health.getStatus() == Status.DOWN) {
+        downHealthsById.put(executable.id().getId(), health);
+      }
     }
 
-    boolean anyDown = healths.stream().anyMatch(h -> h.getStatus() == Status.DOWN);
-    if (anyDown) {
-      long downCount = healths.stream().filter(h -> h.getStatus() == Status.DOWN).count();
+    if (!downHealthsById.isEmpty()) {
       return Health.down(
-          new RuntimeException(downCount + " of " + healths.size() + " connectors are down"));
+          new Health.Error(
+              "CONNECTORS_DOWN",
+              downHealthsById.size() + " of " + executables.size() + " connectors are down"),
+          downHealthsById);
     }
 
     return Health.up();
@@ -207,11 +214,41 @@ public class InboundExecutableQueryService {
 
   private Health getHealthFromExecutable(RegisteredExecutable executable) {
     return switch (executable) {
-      case Activated activated -> activated.context().getHealth();
-      case Cancelled cancelled -> cancelled.context().getHealth();
-      case ConnectorNotRegistered notRegistered -> notRegistered.health();
-      case FailedToActivate failed -> failed.health();
-      case InvalidDefinition invalid -> invalid.health();
+      case Activated activated -> enrich(activated.context().getHealth(), activated.context());
+      case Cancelled cancelled -> enrich(cancelled.context().getHealth(), cancelled.context());
+      case ConnectorNotRegistered notRegistered ->
+          enrich(notRegistered.health(), notRegistered.data());
+      case FailedToActivate failed -> enrich(failed.health(), failed.data());
+      case InvalidDefinition invalid -> enrich(invalid.health(), invalid.data());
+    };
+  }
+
+  private Health enrich(Health health, InboundConnectorManagementContext context) {
+    var def = context.getDefinition();
+    Map<String, Object> details = new LinkedHashMap<>();
+    if (health.getDetails() != null) details.putAll(health.getDetails());
+    if (!def.elements().isEmpty()) {
+      details.put("processId", def.elements().getFirst().bpmnProcessId());
+    }
+    details.put("tenantId", def.tenantId());
+    details.put("type", def.type());
+    return withDetails(health, details);
+  }
+
+  private Health enrich(Health health, InboundConnectorDetails data) {
+    Map<String, Object> details = new LinkedHashMap<>();
+    if (health.getDetails() != null) details.putAll(health.getDetails());
+    details.put("processId", data.processDefinitionId());
+    details.put("tenantId", data.tenantId());
+    details.put("type", data.type());
+    return withDetails(health, details);
+  }
+
+  private static Health withDetails(Health health, Map<String, Object> details) {
+    return switch (health.getStatus()) {
+      case UP -> Health.up(details);
+      case DOWN -> Health.down(health.getError(), details);
+      case UNKNOWN -> Health.unknown(details);
     };
   }
 }

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/inbound/executable/InboundExecutableQueryServiceTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/inbound/executable/InboundExecutableQueryServiceTest.java
@@ -186,4 +186,82 @@ class InboundExecutableQueryServiceTest {
         .as("lastUpdatedAt should be stable across queries for Cancelled")
         .isEqualTo(health2.getLastUpdatedAt());
   }
+
+  @Test
+  void aggregateHealth_withDownExecutable_returnsDownWithPerExecutableDetails() {
+    var id = ExecutableId.fromDeduplicationId("test-down");
+    var error = new Health.Error("SOME_ERROR", "something failed");
+    stateStore.put(
+        id,
+        new RegisteredExecutable.FailedToActivate(
+            testValidDetails("test-down"), "activation failed", id, Health.down(error)));
+
+    var result = queryService.aggregateHealth();
+
+    assertThat(result.getStatus()).isEqualTo(Health.Status.DOWN);
+    assertThat(result.getError().code()).isEqualTo("CONNECTORS_DOWN");
+    assertThat(result.getDetails()).containsKey("test-down");
+    var executableHealth = (Health) result.getDetails().get("test-down");
+    assertThat(executableHealth.getStatus()).isEqualTo(Health.Status.DOWN);
+    assertThat(executableHealth.getError()).isEqualTo(error);
+  }
+
+  @Test
+  void aggregateHealth_downExecutableDetails_containEnrichmentKeys() {
+    var id = ExecutableId.fromDeduplicationId("test-down");
+    stateStore.put(
+        id,
+        new RegisteredExecutable.FailedToActivate(
+            testValidDetails("test-down"),
+            "activation failed",
+            id,
+            Health.down(new Health.Error("ERROR", "failed"))));
+
+    var result = queryService.aggregateHealth();
+
+    var executableHealth = (Health) result.getDetails().get("test-down");
+    assertThat(executableHealth.getDetails())
+        .containsEntry("processId", "processId")
+        .containsEntry("tenantId", "tenant")
+        .containsEntry("type", "test-type");
+  }
+
+  @Test
+  void aggregateHealth_connectorProvidedDetailsNotOverwrittenByEnrichment() {
+    var id = ExecutableId.fromDeduplicationId("test-down");
+    var connectorHealth =
+        Health.down(
+            new Health.Error("ERROR", "failed"),
+            Map.of("type", "connector-provided-type", "customKey", "customValue"));
+    stateStore.put(
+        id,
+        new RegisteredExecutable.FailedToActivate(
+            testValidDetails("test-down"), "activation failed", id, connectorHealth));
+
+    var result = queryService.aggregateHealth();
+
+    var executableHealth = (Health) result.getDetails().get("test-down");
+    assertThat(executableHealth.getDetails())
+        .containsEntry("type", "connector-provided-type")
+        .containsEntry("customKey", "customValue");
+  }
+
+  @Test
+  void aggregateHealth_enrichedHealth_preservesLastUpdatedAt() throws InterruptedException {
+    var id = ExecutableId.fromDeduplicationId("test-down");
+    var originalHealth = Health.down(new Health.Error("ERROR", "failed"));
+    var originalTimestamp = originalHealth.getLastUpdatedAt();
+    stateStore.put(
+        id,
+        new RegisteredExecutable.FailedToActivate(
+            testValidDetails("test-down"), "activation failed", id, originalHealth));
+
+    Thread.sleep(5);
+    var result = queryService.aggregateHealth();
+
+    var executableHealth = (Health) result.getDetails().get("test-down");
+    assertThat(executableHealth.getLastUpdatedAt())
+        .as("lastUpdatedAt should be preserved after enrichment, not reset to query time")
+        .isEqualTo(originalTimestamp);
+  }
 }

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/inbound/executable/InboundExecutableQueryServiceTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/inbound/executable/InboundExecutableQueryServiceTest.java
@@ -200,8 +200,8 @@ class InboundExecutableQueryServiceTest {
 
     assertThat(result.getStatus()).isEqualTo(Health.Status.DOWN);
     assertThat(result.getError().code()).isEqualTo("CONNECTORS_DOWN");
-    assertThat(result.getDetails()).containsKey("test-down");
-    var executableHealth = (Health) result.getDetails().get("test-down");
+    assertThat(result.getDetails()).containsKey(id.getId());
+    var executableHealth = (Health) result.getDetails().get(id.getId());
     assertThat(executableHealth.getStatus()).isEqualTo(Health.Status.DOWN);
     assertThat(executableHealth.getError()).isEqualTo(error);
   }
@@ -219,7 +219,7 @@ class InboundExecutableQueryServiceTest {
 
     var result = queryService.aggregateHealth();
 
-    var executableHealth = (Health) result.getDetails().get("test-down");
+    var executableHealth = (Health) result.getDetails().get(id.getId());
     assertThat(executableHealth.getDetails())
         .containsEntry("processId", "processId")
         .containsEntry("tenantId", "tenant")
@@ -240,7 +240,7 @@ class InboundExecutableQueryServiceTest {
 
     var result = queryService.aggregateHealth();
 
-    var executableHealth = (Health) result.getDetails().get("test-down");
+    var executableHealth = (Health) result.getDetails().get(id.getId());
     assertThat(executableHealth.getDetails())
         .containsEntry("type", "connector-provided-type")
         .containsEntry("customKey", "customValue");
@@ -259,7 +259,7 @@ class InboundExecutableQueryServiceTest {
     Thread.sleep(5);
     var result = queryService.aggregateHealth();
 
-    var executableHealth = (Health) result.getDetails().get("test-down");
+    var executableHealth = (Health) result.getDetails().get(id.getId());
     assertThat(executableHealth.getLastUpdatedAt())
         .as("lastUpdatedAt should be preserved after enrichment, not reset to query time")
         .isEqualTo(originalTimestamp);

--- a/connector-sdk/core/src/main/java/io/camunda/connector/api/inbound/Health.java
+++ b/connector-sdk/core/src/main/java/io/camunda/connector/api/inbound/Health.java
@@ -172,6 +172,24 @@ public class Health {
     this.lastUpdatedAt = Instant.now();
   }
 
+  private Health(Status status, Error error, Map<String, Object> details, Instant lastUpdatedAt) {
+    this.status = status;
+    this.error = error;
+    this.details = details;
+    this.lastUpdatedAt = lastUpdatedAt;
+  }
+
+  /**
+   * Returns a new {@link Health} with the given details, preserving the original {@link
+   * #getLastUpdatedAt() lastUpdatedAt} timestamp.
+   *
+   * @param details the details map for the new instance
+   * @return a new Health with the same status, error, and timestamp but the supplied details
+   */
+  public Health withDetails(Map<String, Object> details) {
+    return new Health(this.status, this.error, details, this.lastUpdatedAt);
+  }
+
   private Health() {
     this(Status.UNKNOWN, null, null);
   }


### PR DESCRIPTION
## Description

When multiple inbound connectors are in a `DOWN` state, the aggregated health endpoint (`/health`) previously returned only a count-level message like _"2 of 5 connectors are down"_ with no structured information about **which** connectors were affected or **why**. This made it difficult to debug failing connectors in production without cross-referencing multiple API calls.

### Changes in `InboundExecutableQueryService`

**`aggregateHealth()`**
- Replaced the flat `List<Health>` + two-pass stream approach with a single pass that builds a `Map<String, Object>` collecting enriched `Health` entries for **DOWN connectors only**, keyed by `executableId`.
- The final result now uses `Health.down(Error, Map<String,Object>)` instead of `Health.down(Throwable)`, so the aggregated health object carries structured per-connector debug info directly in its `details` field — no extra API calls needed.

**`getHealthFromExecutable()`**
- Now delegates to `enrich()` so that every individual health object (regardless of its state — UP, DOWN, or UNKNOWN) carries `processId`, `tenantId`, and `type` from the connector's context before it is evaluated and potentially included in the aggregated result.

**Two `enrich()` overloads**
- `enrich(Health, InboundConnectorManagementContext)` — for `Activated` and `Cancelled` executables; pulls metadata from `context.getDefinition()`.
- `enrich(Health, InboundConnectorDetails)` — for `ConnectorNotRegistered`, `FailedToActivate`, and `InvalidDefinition`; pulls metadata directly from the data record.
- Both overloads **preserve any existing details** already set on the `Health` object by the connector itself.

**`withDetails()` helper**
- Reconstructs a `Health` of any status with a merged details map, preserving the original error — necessary because `Health`'s constructors are package-private.

**Imports**
- Removed unused `ArrayList`.
- Added `LinkedHashMap`, `Map`, `InboundConnectorManagementContext`, and `InboundConnectorDetails`.

### Before / After

**Before** — aggregated health for 2 failing connectors:
```json
{
  "status": "DOWN",
  "error": { "code": null, "message": "2 of 5 connectors are down" }
}
```

**After** — same scenario with enriched details:
```json
{
  "status": "DOWN",
  "error": { "code": "CONNECTORS_DOWN", "message": "2 of 5 connectors are down" },
  "details": {
    "a3f1...": {
      "status": "DOWN",
      "error": { "code": "CONNECT_TIMEOUT", "message": "Broker unreachable" },
      "details": { "processId": "my-process", "tenantId": "<default>", "type": "io.camunda:connector-kafka:1" }
    },
    "b9c2...": {
      "status": "DOWN",
      "error": { "code": "INVALID_CONFIG", "message": "Missing required property" },
      "details": { "processId": "other-process", "tenantId": "<default>", "type": "io.camunda:connector-rabbitmq-inbound:1" }
    }
  }
}
```

## Related issues

closes #

## Checklist

- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest release, as this branch will be rebased onto main before the next release.
- [ ] Tests/Integration tests for the changes have been added if applicable.
- [ ] If the change requires a documentation update, it has been added to the appropriate section in the documentation.
