### PR TITLE
refactor: align nullability contracts in agent conversation metrics

### DIFF
--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/agent/BaseAgentRequestHandler.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/agent/BaseAgentRequestHandler.java
@@ -316,7 +316,7 @@ public abstract class BaseAgentRequestHandler<
       C executionContext,
       AgentContext context,
       AgentMetrics metricsDelta,
-      AgentInstanceUpdateStatus nextState,
+      @Nullable AgentInstanceUpdateStatus nextState,
       boolean rethrowOnFailure) {
     try {
 
@@ -327,10 +327,14 @@ public abstract class BaseAgentRequestHandler<
           metricsDelta.tokenUsage().inputTokenCount(),
           metricsDelta.tokenUsage().outputTokenCount(),
           metricsDelta.toolCalls());
+      var updateRequestBuilder = AgentInstanceUpdateRequest.builder().delta(metricsDelta);
+      if (nextState != null) {
+        updateRequestBuilder.status(nextState);
+      }
       agentInstanceClient.update(
           executionContext,
           AgentInstanceKey.from(context.metadata()),
-          AgentInstanceUpdateRequest.builder().status(nextState).delta(metricsDelta).build());
+          updateRequestBuilder.build());
     } catch (Exception e) {
       LOGGER.error("Failed to update agent instance metrics; metrics may be inaccurate", e);
       if (rethrowOnFailure) {

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/AgentConversation.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/AgentConversation.java
@@ -120,7 +120,7 @@ public final class AgentConversation {
   }
 
   /** Returns the agent instance key of that conversation, or null if it is not existing (yet). */
-  public AgentInstanceKey agentInstanceKey() {
+  public @Nullable AgentInstanceKey agentInstanceKey() {
     return AgentInstanceKey.from(currentContext.metadata());
   }
 


### PR DESCRIPTION
Mark AgentConversation#agentInstanceKey() as @Nullable to match the @Nullable contract of AgentInstanceKey.from(...) it delegates to.

Mark the notifyMetrics nextState parameter @Nullable and omit the status field from the update request when it is null, instead of passing null into the builder, to keep the superseded-job intent clear and avoid nullness warnings.


Claude-Session: https://claude.ai/code/session_01Bp7tP2X4vnDBcS4u9y4P4g