### PR TITLE
feat(document-handling): Unifed response dropdown for rest connector

### DIFF
--- a/connector-commons/http-client/src/main/java/io/camunda/connector/http/client/client/HttpClient.java
+++ b/connector-commons/http-client/src/main/java/io/camunda/connector/http/client/client/HttpClient.java
@@ -19,6 +19,7 @@ package io.camunda.connector.http.client.client;
 import io.camunda.connector.http.client.mapper.HttpResponse;
 import io.camunda.connector.http.client.mapper.ResponseMapper;
 import io.camunda.connector.http.client.mapper.ResponseMappers;
+import io.camunda.connector.http.client.mapper.StreamingHttpResponse;
 import io.camunda.connector.http.client.model.HttpClientRequest;
 
 public interface HttpClient {
@@ -35,4 +36,10 @@ public interface HttpClient {
    * @see ResponseMappers for common body mappers
    */
   <T> HttpResponse<T> execute(HttpClientRequest request, ResponseMapper<T> responseMapper);
+
+  /**
+   * Executes the request with the body stream left open. The caller MUST close {@link
+   * StreamingHttpResponse#body()} to release the connection and dispose the client.
+   */
+  StreamingHttpResponse executeStreaming(HttpClientRequest request);
 }

--- a/connector-commons/http-client/src/main/java/io/camunda/connector/http/client/client/apache/CustomApacheHttpClient.java
+++ b/connector-commons/http-client/src/main/java/io/camunda/connector/http/client/client/apache/CustomApacheHttpClient.java
@@ -26,10 +26,19 @@ import io.camunda.connector.http.client.mapper.HttpResponse;
 import io.camunda.connector.http.client.mapper.ResponseMapper;
 import io.camunda.connector.http.client.mapper.StreamingHttpResponse;
 import io.camunda.connector.http.client.model.HttpClientRequest;
+import java.io.FilterInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.SocketTimeoutException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 import javax.net.ssl.SSLException;
 import org.apache.hc.client5.http.ClientProtocolException;
+import org.apache.hc.core5.http.ClassicHttpRequest;
+import org.apache.hc.core5.http.ClassicHttpResponse;
+import org.apache.hc.core5.http.Header;
 import org.apache.hc.core5.http.HttpStatus;
 
 public class CustomApacheHttpClient implements HttpClient {
@@ -45,39 +54,9 @@ public class CustomApacheHttpClient implements HttpClient {
    */
   @Override
   public <T> HttpResponse<T> execute(HttpClientRequest request, ResponseMapper<T> responseMapper) {
-    // Will throw ConnectorInputException if URL is blocked
-    httpBlocklistManager.validateUrlAgainstBlocklist(request.getUrl());
-    var apacheRequest = ApacheRequestFactory.get().createHttpRequest(request);
+    var apacheRequest = prepareApacheRequest(request);
 
-    var authority = apacheRequest.getAuthority();
-    if (authority == null) {
-      throw new ConnectorInputException(
-          "Invalid URL: The URL '"
-              + request.getUrl()
-              + "' cannot be parsed as a valid HTTP request. "
-              + "Please ensure the URL includes a valid hostname.");
-    }
-    var host = authority.getHostName();
-    var scheme = apacheRequest.getScheme();
-    if (scheme == null) {
-      throw new ConnectorInputException(
-          "Invalid URL: The URL '"
-              + request.getUrl()
-              + "' cannot be parsed as a valid HTTP request. "
-              + "Please ensure the URL includes a valid scheme.");
-    }
-
-    var sslContext =
-        request.hasClientTls() ? ClientTlsFactory.create(request.getClientTls()) : null;
-
-    try (var client =
-        new ProxyAwareHttpClient(
-            new ProxyAwareHttpClient.TimeoutConfiguration(
-                request.getConnectionTimeoutInSeconds(), request.getReadTimeoutInSeconds()),
-            new ProxyAwareHttpClient.ProxyContext(scheme, host),
-            request.isFollowRedirects(),
-            sslContext)) {
-
+    try (var client = newClient(apacheRequest, request)) {
       var apacheResponseHandler =
           new CustomResponseHandler<>(responseMapper, request.isFollowRedirects());
       return client.execute(apacheRequest, apacheResponseHandler);
@@ -115,5 +94,143 @@ public class CustomApacheHttpClient implements HttpClient {
       cause = cause.getCause();
     }
     return cause.getMessage();
+  }
+
+  @Override
+  public StreamingHttpResponse executeStreaming(HttpClientRequest request) {
+    var apacheRequest = prepareApacheRequest(request);
+    ProxyAwareHttpClient client = newClient(apacheRequest, request);
+    try {
+      ClassicHttpResponse response = client.executeOpen(apacheRequest);
+      int status = response.getCode();
+      String reason = response.getReasonPhrase();
+      Map<String, List<String>> headers = formatHeaders(response.getHeaders());
+      InputStream entityStream =
+          response.getEntity() != null ? response.getEntity().getContent() : null;
+      InputStream body = new ResponseClosingStream(entityStream, response, client);
+      return new StreamingHttpResponse(status, reason, headers, body);
+    } catch (ClientProtocolException e) {
+      closeQuietly(client);
+      throw new ConnectorException(
+          String.valueOf(HttpStatus.SC_SERVER_ERROR),
+          "An error with the HTTP protocol occurred",
+          e);
+    } catch (SocketTimeoutException e) {
+      closeQuietly(client);
+      throw new ConnectorException(
+          String.valueOf(HttpStatus.SC_REQUEST_TIMEOUT),
+          "The request timed out. Please try increasing the read and connection timeouts.",
+          e);
+    } catch (SSLException e) {
+      closeQuietly(client);
+      throw new ConnectorException(
+          "SSL_HANDSHAKE_FAILED",
+          "TLS handshake failed: "
+              + rootMessage(e)
+              + ". The server certificate may not be trusted — provide the server's CA "
+              + "certificate via 'clientTls.trustedCertificate', or check the client certificate "
+              + "configuration.",
+          e);
+    } catch (IOException e) {
+      closeQuietly(client);
+      throw new ConnectorException(
+          String.valueOf(HttpStatus.SC_REQUEST_TIMEOUT),
+          "An error occurred while executing the request, or the connection was aborted",
+          e);
+    } catch (RuntimeException e) {
+      closeQuietly(client);
+      throw e;
+    }
+  }
+
+  private ClassicHttpRequest prepareApacheRequest(HttpClientRequest request) {
+    httpBlocklistManager.validateUrlAgainstBlocklist(request.getUrl());
+    var apacheRequest = ApacheRequestFactory.get().createHttpRequest(request);
+
+    var authority = apacheRequest.getAuthority();
+    if (authority == null) {
+      throw new ConnectorInputException(
+          "Invalid URL: The URL '"
+              + request.getUrl()
+              + "' cannot be parsed as a valid HTTP request. "
+              + "Please ensure the URL includes a valid hostname.");
+    }
+    if (apacheRequest.getScheme() == null) {
+      throw new ConnectorInputException(
+          "Invalid URL: The URL '"
+              + request.getUrl()
+              + "' cannot be parsed as a valid HTTP request. "
+              + "Please ensure the URL includes a valid scheme.");
+    }
+    return apacheRequest;
+  }
+
+  private ProxyAwareHttpClient newClient(
+      ClassicHttpRequest apacheRequest, HttpClientRequest request) {
+    var host = apacheRequest.getAuthority().getHostName();
+    var scheme = apacheRequest.getScheme();
+    var sslContext =
+        request.hasClientTls() ? ClientTlsFactory.create(request.getClientTls()) : null;
+    return new ProxyAwareHttpClient(
+        new ProxyAwareHttpClient.TimeoutConfiguration(
+            request.getConnectionTimeoutInSeconds(), request.getReadTimeoutInSeconds()),
+        new ProxyAwareHttpClient.ProxyContext(scheme, host),
+        request.isFollowRedirects(),
+        sslContext);
+  }
+
+  private static Map<String, List<String>> formatHeaders(Header[] headersArray) {
+    return Arrays.stream(headersArray)
+        .collect(
+            Collectors.groupingBy(
+                Header::getName, Collectors.mapping(Header::getValue, Collectors.toList())));
+  }
+
+  private static void closeQuietly(AutoCloseable closeable) {
+    if (closeable == null) return;
+    try {
+      closeable.close();
+    } catch (Exception ignored) {
+    }
+  }
+
+  /** Closing this stream cascades close to the response and client, releasing the connection. */
+  private static final class ResponseClosingStream extends FilterInputStream {
+
+    private final ClassicHttpResponse response;
+    private final ProxyAwareHttpClient client;
+    private boolean closed;
+
+    ResponseClosingStream(
+        InputStream delegate, ClassicHttpResponse response, ProxyAwareHttpClient client) {
+      super(delegate != null ? delegate : InputStream.nullInputStream());
+      this.response = response;
+      this.client = client;
+    }
+
+    @Override
+    public void close() throws IOException {
+      if (closed) {
+        return;
+      }
+      closed = true;
+      IOException firstError = null;
+      try {
+        super.close();
+      } catch (IOException e) {
+        firstError = e;
+      }
+      try {
+        response.close();
+      } catch (IOException e) {
+        if (firstError == null) firstError = e;
+      }
+      try {
+        client.close();
+      } catch (IOException e) {
+        if (firstError == null) firstError = e;
+      }
+      if (firstError != null) throw firstError;
+    }
   }
 }

--- a/connector-commons/http-client/src/main/java/io/camunda/connector/http/client/client/apache/proxy/ProxyAwareHttpClient.java
+++ b/connector-commons/http-client/src/main/java/io/camunda/connector/http/client/client/apache/proxy/ProxyAwareHttpClient.java
@@ -28,6 +28,7 @@ import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManager;
 import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManagerBuilder;
 import org.apache.hc.client5.http.ssl.DefaultClientTlsStrategy;
 import org.apache.hc.core5.http.ClassicHttpRequest;
+import org.apache.hc.core5.http.ClassicHttpResponse;
 import org.apache.hc.core5.http.HttpHost;
 import org.apache.hc.core5.http.io.HttpClientResponseHandler;
 import org.apache.hc.core5.http.io.SocketConfig;
@@ -81,6 +82,14 @@ public class ProxyAwareHttpClient implements Closeable {
   public <T> T execute(ClassicHttpRequest request, HttpClientResponseHandler<T> responseHandler)
       throws IOException {
     return client.execute(request, responseHandler);
+  }
+
+  /**
+   * Executes the request without closing the response. The caller MUST close the returned response
+   * and this client to release the connection.
+   */
+  public ClassicHttpResponse executeOpen(ClassicHttpRequest request) throws IOException {
+    return client.executeOpen(null, request, null);
   }
 
   private CloseableHttpClient createClient() {

--- a/connector-commons/http-client/src/main/java/io/camunda/connector/http/client/mapper/StreamingHttpResponse.java
+++ b/connector-commons/http-client/src/main/java/io/camunda/connector/http/client/mapper/StreamingHttpResponse.java
@@ -20,6 +20,10 @@ import java.io.InputStream;
 import java.util.List;
 import java.util.Map;
 
-/** An HTTP response where the body is represented as a stream. */
+/**
+ * An HTTP response where the body is represented as a stream. When produced by {@link
+ * io.camunda.connector.http.client.client.HttpClient#executeStreaming}, the caller MUST close the
+ * body to release the underlying response, connection, and client.
+ */
 public record StreamingHttpResponse(
     int status, String reason, Map<String, List<String>> headers, InputStream body) {}

--- a/connector-commons/http-client/src/test/java/io/camunda/connector/http/client/client/apache/CustomApacheHttpClientStreamingTest.java
+++ b/connector-commons/http-client/src/test/java/io/camunda/connector/http/client/client/apache/CustomApacheHttpClientStreamingTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.http.client.client.apache;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.ok;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import io.camunda.connector.http.client.mapper.StreamingHttpResponse;
+import io.camunda.connector.http.client.model.HttpClientRequest;
+import io.camunda.connector.http.client.model.HttpMethod;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.Test;
+
+@WireMockTest
+class CustomApacheHttpClientStreamingTest {
+
+  private final CustomApacheHttpClient client = new CustomApacheHttpClient();
+
+  private HttpClientRequest request(WireMockRuntimeInfo wm) {
+    HttpClientRequest request = new HttpClientRequest();
+    request.setMethod(HttpMethod.GET);
+    request.setUrl(wm.getHttpBaseUrl() + "/stream");
+    return request;
+  }
+
+  @Test
+  void executeStreaming_exposesStatusReasonHeadersAndBody(WireMockRuntimeInfo wm) throws Exception {
+    stubFor(
+        get("/stream")
+            .willReturn(
+                ok("streamed-body").withHeader("Content-Type", "text/plain").withStatus(200)));
+
+    StreamingHttpResponse response = client.executeStreaming(request(wm));
+
+    assertThat(response.status()).isEqualTo(200);
+    assertThat(response.headers().get("Content-Type")).contains("text/plain");
+    try (InputStream body = response.body()) {
+      assertThat(new String(body.readAllBytes(), StandardCharsets.UTF_8))
+          .isEqualTo("streamed-body");
+    }
+  }
+
+  @Test
+  void executeStreaming_closingBodyIsIdempotent(WireMockRuntimeInfo wm) throws Exception {
+    stubFor(get("/stream").willReturn(ok("body")));
+
+    StreamingHttpResponse response = client.executeStreaming(request(wm));
+    InputStream body = response.body();
+    body.readAllBytes();
+
+    // A second close must be a no-op.
+    assertThatCode(
+            () -> {
+              body.close();
+              body.close();
+            })
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  void executeStreaming_emptyBodyDoesNotThrow(WireMockRuntimeInfo wm) throws Exception {
+    stubFor(get("/stream").willReturn(aResponse().withStatus(204)));
+
+    StreamingHttpResponse response = client.executeStreaming(request(wm));
+
+    assertThat(response.status()).isEqualTo(204);
+    try (InputStream body = response.body()) {
+      assertThat(body.readAllBytes()).isEmpty();
+    }
+  }
+}

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/document/DocumentReturnProcessor.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/document/DocumentReturnProcessor.java
@@ -27,6 +27,7 @@ import io.camunda.connector.api.document.DocumentReturnFormat;
 import io.camunda.connector.api.document.InlineSizeGuard;
 import io.camunda.connector.api.document.RawPayload;
 import io.camunda.connector.api.error.ConnectorException;
+import io.camunda.connector.api.error.ConnectorInputException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.Charset;
@@ -136,8 +137,8 @@ public class DocumentReturnProcessor {
     try {
       return Charset.forName(encoding);
     } catch (IllegalArgumentException e) {
-      throw new ConnectorException(
-          null,
+      // An unknown charset never resolves on retry, so fail fast as an input error.
+      throw new ConnectorInputException(
           "Unsupported charset '"
               + encoding
               + "' configured on documentReturnFormat.encoding. Use a valid IANA charset name (e.g."

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/document/DocumentReturnProcessorTest.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/document/DocumentReturnProcessorTest.java
@@ -27,6 +27,7 @@ import io.camunda.connector.api.document.DocumentReturnFormat;
 import io.camunda.connector.api.document.InlineSizeGuard;
 import io.camunda.connector.api.document.RawPayload;
 import io.camunda.connector.api.error.ConnectorException;
+import io.camunda.connector.api.error.ConnectorInputException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
@@ -219,7 +220,7 @@ class DocumentReturnProcessorTest {
             () ->
                 processor.process(
                     ret, format(DocumentReturnChoice.TEXT, "definitely-not-a-charset")))
-        .isInstanceOf(ConnectorException.class)
+        .isInstanceOf(ConnectorInputException.class)
         .hasMessageContaining("Unsupported charset");
   }
 

--- a/connectors/http/graphql/element-templates/hybrid/graphql-outbound-connector-hybrid.json
+++ b/connectors/http/graphql/element-templates/hybrid/graphql-outbound-connector-hybrid.json
@@ -5,7 +5,7 @@
   "description" : "Execute GraphQL query",
   "keywords" : [ "API", "query", "mutation", "HTTP", "web request", "GraphQL", "fetch data", "data query", "execute query", "API call" ],
   "documentationRef" : "https://docs.camunda.io/docs/components/connectors/protocol/graphql/",
-  "version" : 10,
+  "version" : 11,
   "category" : {
     "id" : "connectors",
     "name" : "Connectors"
@@ -15,7 +15,7 @@
     "value" : "bpmn:ServiceTask"
   },
   "engines" : {
-    "camunda" : "^8.9"
+    "camunda" : "^8.10"
   },
   "groups" : [ {
     "id" : "taskDefinitionType",
@@ -485,18 +485,43 @@
     "tooltip" : "Map of HTTP headers to add to the request",
     "type" : "String"
   }, {
-    "id" : "graphql.storeResponse",
-    "label" : "Store response",
-    "optional" : false,
-    "value" : false,
-    "feel" : "static",
+    "id" : "documentReturnFormat",
+    "label" : "Response format",
+    "value" : "JSON",
     "group" : "endpoint",
     "binding" : {
-      "name" : "graphql.storeResponse",
+      "name" : "documentReturnFormat.choice",
       "type" : "zeebe:input"
     },
-    "tooltip" : "Store the response as a document in the document store",
-    "type" : "Boolean"
+    "tooltip" : "How the response body should be returned. Document reference uploads the body to the document store; as text decodes it as a String; as JSON parses it into a structure you can access via dot notation.",
+    "type" : "Dropdown",
+    "choices" : [ {
+      "name" : "Document reference",
+      "value" : "DOCUMENT"
+    }, {
+      "name" : "as text",
+      "value" : "TEXT"
+    }, {
+      "name" : "as JSON",
+      "value" : "JSON"
+    } ]
+  }, {
+    "id" : "documentReturnFormatEncoding",
+    "label" : "Encoding",
+    "description" : "Character set used to decode the response. Default UTF-8.",
+    "value" : "UTF-8",
+    "feel" : "optional",
+    "group" : "endpoint",
+    "binding" : {
+      "name" : "documentReturnFormat.encoding",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "documentReturnFormat",
+      "equals" : "TEXT",
+      "type" : "simple"
+    },
+    "type" : "String"
   }, {
     "id" : "graphql.query",
     "label" : "Query/Mutation",
@@ -553,7 +578,7 @@
     "id" : "version",
     "label" : "Version",
     "description" : "Version of the element template",
-    "value" : "10",
+    "value" : "11",
     "group" : "connector",
     "binding" : {
       "key" : "elementTemplateVersion",

--- a/connectors/http/graphql/element-templates/versioned/graphql-outbound-connector-10.json
+++ b/connectors/http/graphql/element-templates/versioned/graphql-outbound-connector-10.json
@@ -5,7 +5,7 @@
   "description" : "Execute GraphQL query",
   "keywords" : [ "API", "query", "mutation", "HTTP", "web request", "GraphQL", "fetch data", "data query", "execute query", "API call" ],
   "documentationRef" : "https://docs.camunda.io/docs/components/connectors/protocol/graphql/",
-  "version" : 11,
+  "version" : 10,
   "category" : {
     "id" : "connectors",
     "name" : "Connectors"
@@ -15,7 +15,7 @@
     "value" : "bpmn:ServiceTask"
   },
   "engines" : {
-    "camunda" : "^8.10"
+    "camunda" : "^8.9"
   },
   "groups" : [ {
     "id" : "authentication",
@@ -480,43 +480,18 @@
     "tooltip" : "Map of HTTP headers to add to the request",
     "type" : "String"
   }, {
-    "id" : "documentReturnFormat",
-    "label" : "Response format",
-    "value" : "JSON",
+    "id" : "graphql.storeResponse",
+    "label" : "Store response",
+    "optional" : false,
+    "value" : false,
+    "feel" : "static",
     "group" : "endpoint",
     "binding" : {
-      "name" : "documentReturnFormat.choice",
+      "name" : "graphql.storeResponse",
       "type" : "zeebe:input"
     },
-    "tooltip" : "How the response body should be returned. Document reference uploads the body to the document store; as text decodes it as a String; as JSON parses it into a structure you can access via dot notation.",
-    "type" : "Dropdown",
-    "choices" : [ {
-      "name" : "Document reference",
-      "value" : "DOCUMENT"
-    }, {
-      "name" : "as text",
-      "value" : "TEXT"
-    }, {
-      "name" : "as JSON",
-      "value" : "JSON"
-    } ]
-  }, {
-    "id" : "documentReturnFormatEncoding",
-    "label" : "Encoding",
-    "description" : "Character set used to decode the response. Default UTF-8.",
-    "value" : "UTF-8",
-    "feel" : "optional",
-    "group" : "endpoint",
-    "binding" : {
-      "name" : "documentReturnFormat.encoding",
-      "type" : "zeebe:input"
-    },
-    "condition" : {
-      "property" : "documentReturnFormat",
-      "equals" : "TEXT",
-      "type" : "simple"
-    },
-    "type" : "String"
+    "tooltip" : "Store the response as a document in the document store",
+    "type" : "Boolean"
   }, {
     "id" : "graphql.query",
     "label" : "Query/Mutation",
@@ -573,7 +548,7 @@
     "id" : "version",
     "label" : "Version",
     "description" : "Version of the element template",
-    "value" : "11",
+    "value" : "10",
     "group" : "connector",
     "binding" : {
       "key" : "elementTemplateVersion",

--- a/connectors/http/graphql/src/main/java/io/camunda/connector/http/graphql/GraphQLFunction.java
+++ b/connectors/http/graphql/src/main/java/io/camunda/connector/http/graphql/GraphQLFunction.java
@@ -8,6 +8,7 @@ package io.camunda.connector.http.graphql;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.connector.api.annotation.OutboundConnector;
+import io.camunda.connector.api.document.DocumentReturn;
 import io.camunda.connector.api.error.ConnectorExceptionBuilder;
 import io.camunda.connector.api.outbound.OutboundConnectorContext;
 import io.camunda.connector.api.outbound.OutboundConnectorFunction;
@@ -26,10 +27,10 @@ import org.slf4j.LoggerFactory;
 
 @OutboundConnector(
     name = "GraphQL",
-    inputVariables = {"graphql", "authentication"},
+    inputVariables = {"graphql", "authentication", "documentReturnFormat"},
     type = "io.camunda:connector-graphql:1")
 @ElementTemplate(
-    engineVersion = "^8.9",
+    engineVersion = "^8.10",
     id = "io.camunda.connectors.GraphQL.v1",
     name = "Send GraphQL Request",
     description = "Execute GraphQL query",
@@ -46,7 +47,7 @@ import org.slf4j.LoggerFactory;
       "API call"
     },
     inputDataClass = GraphQLRequest.class,
-    version = 10,
+    version = 11,
     propertyGroups = {
       @ElementTemplate.PropertyGroup(id = "authentication", label = "Authentication"),
       @ElementTemplate.PropertyGroup(id = "endpoint", label = "HTTP Endpoint"),
@@ -63,6 +64,8 @@ public class GraphQLFunction implements OutboundConnectorFunction {
 
   private final GraphQLRequestMapper graphQLRequestMapper;
 
+  private final ObjectMapper objectMapper;
+
   public GraphQLFunction() {
     this(ConnectorsObjectMapperSupplier.getCopy());
   }
@@ -70,6 +73,7 @@ public class GraphQLFunction implements OutboundConnectorFunction {
   public GraphQLFunction(final ObjectMapper objectMapper) {
     this.httpService = new HttpService();
     this.graphQLRequestMapper = new GraphQLRequestMapper(objectMapper);
+    this.objectMapper = objectMapper;
   }
 
   static final String GRAPHQL_ERROR_CODE = "GRAPHQL_ERROR";
@@ -79,20 +83,35 @@ public class GraphQLFunction implements OutboundConnectorFunction {
     var graphQLRequest = context.bindVariables(GraphQLRequest.class);
     HttpCommonRequest commonRequest = graphQLRequestMapper.toHttpCommonRequest(graphQLRequest);
     LOGGER.debug("Executing graphql connector with request {}", commonRequest);
-    var rawResult = httpService.executeConnectorRequest(commonRequest, context);
+    var responseChoice = context.readDocumentReturnFormat().map(f -> f.choice()).orElse(null);
+    var rawResult = httpService.executeConnectorRequest(commonRequest, context, responseChoice);
+    if (rawResult instanceof DocumentReturn<?> documentReturn) {
+      // The body is only materialized inside the wrap lambda, so run the error check there too.
+      return new DocumentReturn<>(
+          documentReturn.payload(),
+          (converted, choice) ->
+              failOnGraphQLErrors(documentReturn.wrap().apply(converted, choice)));
+    }
+    return failOnGraphQLErrors(rawResult);
+  }
+
+  /** Raises a {@code GRAPHQL_ERROR} when the body is a GraphQL error envelope, else returns it. */
+  private Object failOnGraphQLErrors(Object rawResult) {
     if (!(rawResult instanceof HttpCommonResult result)) {
       return rawResult;
     }
-    if (result.body() instanceof Map<?, ?> body
-        && body.get("errors") instanceof List<?> errors
-        && !errors.isEmpty()) {
+    // JSON gives a Map directly; TEXT gives a String we parse so error detection still fires. A
+    // DOCUMENT body is a reference we cannot inspect inline (as with the legacy storeResponse
+    // path).
+    Map<?, ?> body = asErrorEnvelope(result.body());
+    if (body != null && body.get("errors") instanceof List<?> errors && !errors.isEmpty()) {
       var firstMessage =
           errors.get(0) instanceof Map<?, ?> firstError
                   && firstError.get("message") instanceof String msg
               ? msg
               : "GraphQL response contains errors";
       var responseVariables = new HashMap<String, Object>();
-      responseVariables.put("body", result.body());
+      responseVariables.put("body", body);
       responseVariables.put("headers", result.headers());
       throw new ConnectorExceptionBuilder()
           .errorCode(GRAPHQL_ERROR_CODE)
@@ -101,5 +120,22 @@ public class GraphQLFunction implements OutboundConnectorFunction {
           .build();
     }
     return result;
+  }
+
+  /**
+   * Returns the body as a Map if it is one or parses to one (TEXT choice); {@code null} otherwise.
+   */
+  private Map<?, ?> asErrorEnvelope(Object body) {
+    if (body instanceof Map<?, ?> map) {
+      return map;
+    }
+    if (body instanceof String text) {
+      try {
+        return objectMapper.readValue(text, Map.class);
+      } catch (Exception e) {
+        return null; // not JSON, so not a GraphQL error envelope
+      }
+    }
+    return null;
   }
 }

--- a/connectors/http/graphql/src/main/java/io/camunda/connector/http/graphql/model/GraphQLRequest.java
+++ b/connectors/http/graphql/src/main/java/io/camunda/connector/http/graphql/model/GraphQLRequest.java
@@ -7,6 +7,8 @@
 package io.camunda.connector.http.graphql.model;
 
 import io.camunda.connector.api.annotation.FEEL;
+import io.camunda.connector.api.document.DocumentReturnChoice;
+import io.camunda.connector.generator.java.annotation.DocumentReturnFormat;
 import io.camunda.connector.generator.java.annotation.FeelMode;
 import io.camunda.connector.generator.java.annotation.TemplateProperty;
 import io.camunda.connector.hostvalidator.VerifiedHost;
@@ -29,6 +31,13 @@ import java.util.Map;
  */
 public record GraphQLRequest(@Valid GraphQL graphql, @Valid Authentication authentication) {
 
+  @DocumentReturnFormat(
+      group = "endpoint",
+      defaultFormat = DocumentReturnChoice.JSON,
+      tooltip =
+          "How the response body should be returned. Document reference uploads the body to the"
+              + " document store; as text decodes it as a String; as JSON parses it into a"
+              + " structure you can access via dot notation.")
   public record GraphQL(
       @TemplateProperty(
               id = "query",
@@ -74,13 +83,7 @@ public record GraphQLRequest(@Valid GraphQL graphql, @Valid Authentication authe
               optional = true,
               tooltip = "Map of HTTP headers to add to the request")
           Map<String, String> headers,
-      @TemplateProperty(
-              group = "endpoint",
-              type = TemplateProperty.PropertyType.Boolean,
-              defaultValueType = TemplateProperty.DefaultValueType.Boolean,
-              defaultValue = "false",
-              tooltip = "Store the response as a document in the document store")
-          boolean storeResponse,
+      @TemplateProperty(ignore = true) @Deprecated boolean storeResponse,
       @TemplateProperty(
               group = "timeout",
               defaultValue = "20",

--- a/connectors/http/graphql/src/test/java/io/camunda/connector/http/graphql/GraphQLFunctionDocumentReturnTest.java
+++ b/connectors/http/graphql/src/test/java/io/camunda/connector/http/graphql/GraphQLFunctionDocumentReturnTest.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.http.graphql;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.any;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static io.camunda.connector.http.graphql.GraphQLFunction.GRAPHQL_ERROR_CODE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import io.camunda.connector.api.document.DocumentReturn;
+import io.camunda.connector.api.document.DocumentReturnChoice;
+import io.camunda.connector.api.document.DocumentReturnFormat;
+import io.camunda.connector.api.error.ConnectorException;
+import io.camunda.connector.api.outbound.OutboundConnectorContext;
+import io.camunda.connector.http.base.model.HttpCommonResult;
+import io.camunda.connector.http.base.model.HttpMethod;
+import io.camunda.connector.http.graphql.model.GraphQLRequest;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Covers GraphQL error detection on the response-format path, where it runs inside the wrap lambda.
+ */
+@WireMockTest
+class GraphQLFunctionDocumentReturnTest {
+
+  private final GraphQLFunction function = new GraphQLFunction();
+
+  private OutboundConnectorContext contextWithChoice(
+      WireMockRuntimeInfo wm, DocumentReturnChoice choice) {
+    var graphql =
+        new GraphQLRequest.GraphQL(
+            "{ hero { name } }",
+            null,
+            HttpMethod.POST,
+            wm.getHttpBaseUrl() + "/graphql",
+            null,
+            false,
+            20,
+            20);
+    OutboundConnectorContext context = mock(OutboundConnectorContext.class);
+    when(context.bindVariables(GraphQLRequest.class)).thenReturn(new GraphQLRequest(graphql, null));
+    when(context.readDocumentReturnFormat())
+        .thenReturn(Optional.of(new DocumentReturnFormat(choice, null)));
+    return context;
+  }
+
+  @Test
+  void newPath_returnsDocumentReturn(WireMockRuntimeInfo wm) {
+    stubFor(any(urlPathEqualTo("/graphql")).willReturn(aResponse().withStatus(200)));
+
+    Object result = function.execute(contextWithChoice(wm, DocumentReturnChoice.JSON));
+
+    assertThat(result).isInstanceOf(DocumentReturn.class);
+  }
+
+  @Test
+  void newPath_wrapDetectsGraphQLErrors_andThrows(WireMockRuntimeInfo wm) {
+    stubFor(any(urlPathEqualTo("/graphql")).willReturn(aResponse().withStatus(200)));
+
+    var documentReturn =
+        (DocumentReturn<?>) function.execute(contextWithChoice(wm, DocumentReturnChoice.JSON));
+
+    Map<String, Object> errorBody = Map.of("errors", List.of(Map.of("message", "boom")));
+
+    assertThatThrownBy(() -> documentReturn.wrap().apply(errorBody, DocumentReturnChoice.JSON))
+        .isInstanceOf(ConnectorException.class)
+        .satisfies(
+            ex -> {
+              var ce = (ConnectorException) ex;
+              assertThat(ce.getErrorCode()).isEqualTo(GRAPHQL_ERROR_CODE);
+              assertThat(ce.getMessage()).isEqualTo("boom");
+            });
+  }
+
+  @Test
+  void newPath_wrapReturnsResult_whenNoErrors(WireMockRuntimeInfo wm) {
+    stubFor(any(urlPathEqualTo("/graphql")).willReturn(aResponse().withStatus(200)));
+
+    var documentReturn =
+        (DocumentReturn<?>) function.execute(contextWithChoice(wm, DocumentReturnChoice.JSON));
+
+    Map<String, Object> dataBody = Map.of("data", Map.of("hero", Map.of("name", "R2-D2")));
+    Object wrapped = documentReturn.wrap().apply(dataBody, DocumentReturnChoice.JSON);
+
+    assertThat(wrapped).isInstanceOf(HttpCommonResult.class);
+    assertThat(((HttpCommonResult) wrapped).body()).isEqualTo(dataBody);
+  }
+
+  @Test
+  void newPath_text_wrapDetectsGraphQLErrorsInDecodedText_andThrows(WireMockRuntimeInfo wm) {
+    stubFor(any(urlPathEqualTo("/graphql")).willReturn(aResponse().withStatus(200)));
+
+    var documentReturn =
+        (DocumentReturn<?>) function.execute(contextWithChoice(wm, DocumentReturnChoice.TEXT));
+
+    // With TEXT the runtime hands the wrap lambda the decoded body as a String.
+    String errorText = "{\"errors\":[{\"message\":\"boom\"}]}";
+
+    assertThatThrownBy(() -> documentReturn.wrap().apply(errorText, DocumentReturnChoice.TEXT))
+        .isInstanceOf(ConnectorException.class)
+        .satisfies(
+            ex -> {
+              var ce = (ConnectorException) ex;
+              assertThat(ce.getErrorCode()).isEqualTo(GRAPHQL_ERROR_CODE);
+              assertThat(ce.getMessage()).isEqualTo("boom");
+            });
+  }
+
+  @Test
+  void newPath_text_nonJsonBodyReturnedUnchanged(WireMockRuntimeInfo wm) {
+    stubFor(any(urlPathEqualTo("/graphql")).willReturn(aResponse().withStatus(200)));
+
+    var documentReturn =
+        (DocumentReturn<?>) function.execute(contextWithChoice(wm, DocumentReturnChoice.TEXT));
+
+    Object wrapped = documentReturn.wrap().apply("just plain text", DocumentReturnChoice.TEXT);
+
+    assertThat(wrapped).isInstanceOf(HttpCommonResult.class);
+    assertThat(((HttpCommonResult) wrapped).body()).isEqualTo("just plain text");
+  }
+}

--- a/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/HttpService.java
+++ b/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/HttpService.java
@@ -7,15 +7,23 @@
 package io.camunda.connector.http.base;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.connector.api.document.Document;
 import io.camunda.connector.api.document.DocumentFactory;
+import io.camunda.connector.api.document.DocumentReturn;
+import io.camunda.connector.api.document.DocumentReturnChoice;
 import io.camunda.connector.http.base.model.HttpCommonRequest;
 import io.camunda.connector.http.base.model.HttpCommonResult;
 import io.camunda.connector.http.base.model.auth.AuthenticationMapper;
 import io.camunda.connector.http.client.client.HttpClient;
 import io.camunda.connector.http.client.client.apache.CustomApacheHttpClient;
+import io.camunda.connector.http.client.exception.ConnectorExceptionMapper;
+import io.camunda.connector.http.client.mapper.StreamingHttpResponse;
 import io.camunda.connector.http.client.model.HttpClientRequest;
+import io.camunda.connector.http.client.utils.HeadersHelper;
+import io.camunda.connector.http.client.utils.HttpStatusHelper;
 import io.camunda.connector.jackson.ConnectorsObjectMapperSupplier;
 import java.util.Optional;
+import org.apache.hc.core5.http.HttpHeaders;
 
 public class HttpService {
 
@@ -23,12 +31,49 @@ public class HttpService {
   private static final ObjectMapper OBJECT_MAPPER = ConnectorsObjectMapperSupplier.getCopy();
 
   public HttpCommonResult executeConnectorRequest(HttpCommonRequest request) {
-    return executeConnectorRequest(request, null);
+    return (HttpCommonResult) executeConnectorRequest(request, null, null);
   }
 
   public HttpCommonResult executeConnectorRequest(
       final HttpCommonRequest request, final DocumentFactory documentFactory) {
+    return (HttpCommonResult) executeConnectorRequest(request, documentFactory, null);
+  }
+
+  /**
+   * Executes the HTTP request. A non-null {@code choice} takes the {@link DocumentReturn} flow: the
+   * body stream is handed to the runtime for conversion, and the runtime owns closing it. A null
+   * {@code choice} takes the legacy {@code storeResponse} path.
+   */
+  public Object executeConnectorRequest(
+      final HttpCommonRequest request,
+      final DocumentFactory documentFactory,
+      final DocumentReturnChoice choice) {
     HttpClientRequest httpClientRequest = mapToHttpClientRequest(request);
+
+    if (choice != null) {
+      StreamingHttpResponse live = HTTP_CLIENT.executeStreaming(httpClientRequest);
+      int status = live.status();
+      // Match the legacy path: an error status fails the job with the response in error variables,
+      // rather than streaming the error body to the document store. Reads and closes the stream.
+      if (HttpStatusHelper.isError(status)) {
+        throw ConnectorExceptionMapper.from(live);
+      }
+      String reason = live.reason();
+      var flatHeaders = HeadersHelper.flattenHeaders(live.headers());
+      String contentType =
+          HeadersHelper.getHeaderIgnoreCase(live.headers(), HttpHeaders.CONTENT_TYPE);
+      return DocumentReturn.of(
+          live.body(),
+          contentType,
+          null,
+          (converted, c) -> {
+            if (c == DocumentReturnChoice.DOCUMENT) {
+              return new HttpCommonResult(status, flatHeaders, null, reason, (Document) converted);
+            }
+            return new HttpCommonResult(status, flatHeaders, converted, reason, null);
+          });
+    }
+
     HttpCommonResultMapper responseMapper =
         new HttpCommonResultMapper(documentFactory, request.isStoreResponse(), OBJECT_MAPPER);
     return HTTP_CLIENT.execute(httpClientRequest, responseMapper).entity();

--- a/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/model/HttpCommonRequest.java
+++ b/connectors/http/http-base/src/main/java/io/camunda/connector/http/base/model/HttpCommonRequest.java
@@ -7,6 +7,8 @@
 package io.camunda.connector.http.base.model;
 
 import io.camunda.connector.api.annotation.FEEL;
+import io.camunda.connector.api.document.DocumentReturnChoice;
+import io.camunda.connector.generator.java.annotation.DocumentReturnFormat;
 import io.camunda.connector.generator.java.annotation.FeelMode;
 import io.camunda.connector.generator.java.annotation.TemplateProperty;
 import io.camunda.connector.generator.java.annotation.TemplateProperty.PropertyCondition;
@@ -21,6 +23,13 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 
+@DocumentReturnFormat(
+    group = "endpoint",
+    defaultFormat = DocumentReturnChoice.JSON,
+    tooltip =
+        "How the response body should be returned. Document reference uploads the body to the"
+            + " document store; as text decodes it as a String; as JSON parses it into a structure"
+            + " you can access via dot notation.")
 public class HttpCommonRequest {
 
   @TemplateProperty(ignore = true)
@@ -96,12 +105,8 @@ public class HttpCommonRequest {
       tooltip = "Map of query parameters to add to the request URL")
   private Map<String, String> queryParameters;
 
-  @TemplateProperty(
-      group = "endpoint",
-      type = PropertyType.Boolean,
-      defaultValueType = TemplateProperty.DefaultValueType.Boolean,
-      defaultValue = "false",
-      tooltip = "Store the response as a document in the document store")
+  @TemplateProperty(ignore = true)
+  @Deprecated
   private boolean storeResponse;
 
   @TemplateProperty(

--- a/connectors/http/http-base/src/test/java/io/camunda/connector/http/base/HttpServiceDocumentReturnTest.java
+++ b/connectors/http/http-base/src/test/java/io/camunda/connector/http/base/HttpServiceDocumentReturnTest.java
@@ -1,0 +1,191 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.http.base;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import io.camunda.connector.api.document.Document;
+import io.camunda.connector.api.document.DocumentReturn;
+import io.camunda.connector.api.document.DocumentReturnChoice;
+import io.camunda.connector.api.document.RawPayload;
+import io.camunda.connector.api.error.ConnectorException;
+import io.camunda.connector.http.base.model.HttpCommonRequest;
+import io.camunda.connector.http.base.model.HttpCommonResult;
+import io.camunda.connector.http.base.model.HttpMethod;
+import io.camunda.connector.runtime.core.document.DocumentFactoryImpl;
+import io.camunda.connector.runtime.core.document.store.InMemoryDocumentStore;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Covers the {@code executeConnectorRequest(request, documentFactory, choice)} overload: a non-null
+ * choice returns a {@link DocumentReturn}, a null choice takes the legacy {@code storeResponse}
+ * path.
+ */
+@WireMockTest
+public class HttpServiceDocumentReturnTest {
+
+  private final HttpService httpService = new HttpService();
+  private final InMemoryDocumentStore store = InMemoryDocumentStore.INSTANCE;
+  private final DocumentFactoryImpl documentFactory = new DocumentFactoryImpl(store);
+
+  @BeforeEach
+  public void setUp() {
+    store.clear();
+  }
+
+  private HttpCommonRequest getRequest(WireMockRuntimeInfo wm) {
+    HttpCommonRequest request = new HttpCommonRequest();
+    request.setMethod(HttpMethod.GET);
+    request.setUrl(wm.getHttpBaseUrl() + "/endpoint");
+    return request;
+  }
+
+  @Test
+  void newPath_returnsDocumentReturn_withBodyStreamAndContentType(WireMockRuntimeInfo wm) {
+    WireMock.stubFor(
+        WireMock.get("/endpoint")
+            .willReturn(
+                WireMock.ok("{\"hello\":\"world\"}")
+                    .withHeader("Content-Type", "application/json")));
+
+    Object raw =
+        httpService.executeConnectorRequest(
+            getRequest(wm), documentFactory, DocumentReturnChoice.JSON);
+
+    assertThat(raw).isInstanceOf(DocumentReturn.class);
+    var documentReturn = (DocumentReturn<?>) raw;
+    RawPayload payload = documentReturn.payload();
+    assertThat(payload.contentType()).isEqualTo("application/json");
+    try (InputStream stream = payload.stream()) {
+      assertThat(new String(stream.readAllBytes(), StandardCharsets.UTF_8))
+          .isEqualTo("{\"hello\":\"world\"}");
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Test
+  void newPath_json_wrapPutsConvertedValueInBodyField(WireMockRuntimeInfo wm) {
+    WireMock.stubFor(WireMock.get("/endpoint").willReturn(WireMock.ok("{}")));
+
+    var documentReturn =
+        (DocumentReturn<?>)
+            httpService.executeConnectorRequest(
+                getRequest(wm), documentFactory, DocumentReturnChoice.JSON);
+
+    Map<String, Object> converted = Map.of("hello", "world");
+    Object wrapped = documentReturn.wrap().apply(converted, DocumentReturnChoice.JSON);
+
+    assertThat(wrapped).isInstanceOf(HttpCommonResult.class);
+    HttpCommonResult result = (HttpCommonResult) wrapped;
+    assertThat(result.body()).isEqualTo(converted);
+    assertThat(result.document()).isNull();
+    assertThat(result.status()).isEqualTo(200);
+  }
+
+  @Test
+  void newPath_text_wrapPutsStringInBodyField(WireMockRuntimeInfo wm) {
+    WireMock.stubFor(WireMock.get("/endpoint").willReturn(WireMock.ok("plain")));
+
+    var documentReturn =
+        (DocumentReturn<?>)
+            httpService.executeConnectorRequest(
+                getRequest(wm), documentFactory, DocumentReturnChoice.TEXT);
+
+    Object wrapped = documentReturn.wrap().apply("plain text body", DocumentReturnChoice.TEXT);
+
+    HttpCommonResult result = (HttpCommonResult) wrapped;
+    assertThat(result.body()).isEqualTo("plain text body");
+    assertThat(result.document()).isNull();
+  }
+
+  @Test
+  void newPath_document_wrapPutsDocumentInDocumentField(WireMockRuntimeInfo wm) {
+    WireMock.stubFor(WireMock.get("/endpoint").willReturn(WireMock.ok("binary")));
+
+    var documentReturn =
+        (DocumentReturn<?>)
+            httpService.executeConnectorRequest(
+                getRequest(wm), documentFactory, DocumentReturnChoice.DOCUMENT);
+
+    Document document =
+        documentFactory.create(
+            io.camunda.connector.api.document.DocumentCreationRequest.from(
+                    "binary".getBytes(StandardCharsets.UTF_8))
+                .build());
+    Object wrapped = documentReturn.wrap().apply(document, DocumentReturnChoice.DOCUMENT);
+
+    HttpCommonResult result = (HttpCommonResult) wrapped;
+    assertThat(result.document()).isSameAs(document);
+    assertThat(result.body()).isNull();
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void newPath_errorStatus_throwsWithResponseInErrorVariables(WireMockRuntimeInfo wm) {
+    WireMock.stubFor(
+        WireMock.get("/endpoint")
+            .willReturn(
+                WireMock.badRequest()
+                    .withHeader("Content-Type", "application/json")
+                    .withBody("{\"message\":\"custom message\",\"temp\":36}")));
+
+    assertThatThrownBy(
+            () ->
+                httpService.executeConnectorRequest(
+                    getRequest(wm), documentFactory, DocumentReturnChoice.JSON))
+        .isInstanceOf(ConnectorException.class)
+        .satisfies(
+            ex -> {
+              var ce = (ConnectorException) ex;
+              assertThat(ce.getErrorCode()).isEqualTo("400");
+              var response = (Map<String, Object>) ce.getErrorVariables().get("response");
+              var body = (Map<String, Object>) response.get("body");
+              assertThat(body).containsEntry("temp", 36).containsEntry("message", "custom message");
+            });
+  }
+
+  @Test
+  void legacyPath_choiceNull_storeResponseFalse_returnsBody(WireMockRuntimeInfo wm) {
+    WireMock.stubFor(
+        WireMock.get("/endpoint")
+            .willReturn(
+                WireMock.ok("{\"k\":\"v\"}").withHeader("Content-Type", "application/json")));
+    HttpCommonRequest request = getRequest(wm);
+    request.setStoreResponse(false);
+
+    Object raw = httpService.executeConnectorRequest(request, documentFactory, null);
+
+    assertThat(raw).isInstanceOf(HttpCommonResult.class);
+    HttpCommonResult result = (HttpCommonResult) raw;
+    assertThat(result.body()).isEqualTo(Map.of("k", "v"));
+    assertThat(result.document()).isNull();
+  }
+
+  @Test
+  void legacyPath_choiceNull_storeResponseTrue_returnsDocument(WireMockRuntimeInfo wm) {
+    WireMock.stubFor(WireMock.get("/endpoint").willReturn(WireMock.ok("file-content")));
+    HttpCommonRequest request = getRequest(wm);
+    request.setStoreResponse(true);
+
+    Object raw = httpService.executeConnectorRequest(request, documentFactory, null);
+
+    assertThat(raw).isInstanceOf(HttpCommonResult.class);
+    HttpCommonResult result = (HttpCommonResult) raw;
+    assertThat(result.document()).isNotNull();
+    assertThat(result.body()).isNull();
+    assertThat(store.getDocuments()).isNotEmpty();
+  }
+}

--- a/connectors/http/http-base/src/test/java/io/camunda/connector/http/base/HttpServiceDocumentTest.java
+++ b/connectors/http/http-base/src/test/java/io/camunda/connector/http/base/HttpServiceDocumentTest.java
@@ -4,7 +4,6 @@
  * See the License.txt file for more information. You may not use this file
  * except in compliance with the proprietary license.
  */
-
 package io.camunda.connector.http.base;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -95,7 +94,8 @@ public class HttpServiceDocumentTest {
       request.setStoreResponse(true);
       request.setUrl(wmRuntimeInfo.getHttpBaseUrl() + "/download");
       HttpCommonResult result =
-          customApacheHttpClient.executeConnectorRequest(request, documentFactory);
+          (HttpCommonResult)
+              customApacheHttpClient.executeConnectorRequest(request, documentFactory);
       assertThat(result).isNotNull();
       assertThat(result.status()).isEqualTo(200);
       assertThat(result.headers().get(HttpHeaders.CONTENT_TYPE))
@@ -138,7 +138,8 @@ public class HttpServiceDocumentTest {
       request.setUrl(wmRuntimeInfo.getHttpBaseUrl() + "/path");
       request.setBody(bodyMap);
       HttpCommonResult result =
-          customApacheHttpClient.executeConnectorRequest(request, documentFactory);
+          (HttpCommonResult)
+              customApacheHttpClient.executeConnectorRequest(request, documentFactory);
       assertThat(result).isNotNull();
       assertThat(result.status()).isEqualTo(201);
 
@@ -193,7 +194,8 @@ public class HttpServiceDocumentTest {
       request.setUrl(wmRuntimeInfo.getHttpBaseUrl() + "/path");
       request.setBody(bodyMap);
       HttpCommonResult result =
-          customApacheHttpClient.executeConnectorRequest(request, documentFactory);
+          (HttpCommonResult)
+              customApacheHttpClient.executeConnectorRequest(request, documentFactory);
       assertThat(result).isNotNull();
       assertThat(result.status()).isEqualTo(201);
 

--- a/connectors/http/http-base/src/test/java/io/camunda/connector/http/base/HttpServiceTest.java
+++ b/connectors/http/http-base/src/test/java/io/camunda/connector/http/base/HttpServiceTest.java
@@ -97,7 +97,8 @@ public class HttpServiceTest {
     request.setUrl(getHostAndPort(wmRuntimeInfo) + "/upload");
 
     // when
-    HttpCommonResult result = httpService.executeConnectorRequest(request, documentFactory);
+    HttpCommonResult result =
+        (HttpCommonResult) httpService.executeConnectorRequest(request, documentFactory);
 
     // then
     Assertions.assertThat(result).isNotNull();
@@ -155,7 +156,8 @@ public class HttpServiceTest {
     request.setUrl(getHostAndPort(wmRuntimeInfo) + "/upload");
 
     // when
-    HttpCommonResult result = httpService.executeConnectorRequest(request, documentFactory);
+    HttpCommonResult result =
+        (HttpCommonResult) httpService.executeConnectorRequest(request, documentFactory);
 
     // then
     Assertions.assertThat(result).isNotNull();
@@ -187,7 +189,8 @@ public class HttpServiceTest {
     request.setUrl(getHostAndPort(wmRuntimeInfo) + "/download");
 
     // when
-    HttpCommonResult result = httpService.executeConnectorRequest(request, documentFactory);
+    HttpCommonResult result =
+        (HttpCommonResult) httpService.executeConnectorRequest(request, documentFactory);
 
     // then
     Assertions.assertThat(result).isNotNull();
@@ -404,7 +407,8 @@ public class HttpServiceTest {
     request.setUrl(getHostAndPort(wmRuntimeInfo) + "/path");
 
     // when
-    HttpCommonResult result = httpService.executeConnectorRequest(request, documentFactory);
+    HttpCommonResult result =
+        (HttpCommonResult) httpService.executeConnectorRequest(request, documentFactory);
 
     // then
     Assertions.assertThat(result).isNotNull();

--- a/connectors/http/rest/README.md
+++ b/connectors/http/rest/README.md
@@ -235,6 +235,6 @@ leading to the following result
 | Connector Info            |                                                                       |
 | ---                       | ---                                                                   |
 | Type                      | io.camunda:http-json:1                                                            |
-| Version                   | 15                                                         |
+| Version                   | 17                                                         |
 | Supported element types   |     |
 

--- a/connectors/http/rest/element-templates/http-json-connector.json
+++ b/connectors/http/rest/element-templates/http-json-connector.json
@@ -5,7 +5,7 @@
   "description" : "Invoke REST API",
   "keywords" : [ "HTTP", "REST", "API call", "web request", "GET", "POST", "PUT", "PATCH", "DELETE", "fetch data", "send request", "invoke API" ],
   "documentationRef" : "https://docs.camunda.io/docs/components/connectors/protocol/rest/",
-  "version" : 16,
+  "version" : 17,
   "category" : {
     "id" : "connectors",
     "name" : "Connectors"
@@ -564,19 +564,6 @@
     "tooltip" : "Map of query parameters to add to the request URL",
     "type" : "String"
   }, {
-    "id" : "storeResponse",
-    "label" : "Store response",
-    "optional" : false,
-    "value" : false,
-    "feel" : "static",
-    "group" : "endpoint",
-    "binding" : {
-      "name" : "storeResponse",
-      "type" : "zeebe:input"
-    },
-    "tooltip" : "Store the response as a document in the document store",
-    "type" : "Boolean"
-  }, {
     "id" : "skipEncoding",
     "label" : "Skip URL encoding",
     "optional" : true,
@@ -599,6 +586,44 @@
     },
     "tooltip" : "If enabled, HTTP 3xx redirects will be followed automatically. Disabled by default.",
     "type" : "Boolean"
+  }, {
+    "id" : "documentReturnFormat",
+    "label" : "Response format",
+    "value" : "JSON",
+    "group" : "endpoint",
+    "binding" : {
+      "name" : "documentReturnFormat.choice",
+      "type" : "zeebe:input"
+    },
+    "tooltip" : "How the response body should be returned. Document reference uploads the body to the document store; as text decodes it as a String; as JSON parses it into a structure you can access via dot notation.",
+    "type" : "Dropdown",
+    "choices" : [ {
+      "name" : "Document reference",
+      "value" : "DOCUMENT"
+    }, {
+      "name" : "as text",
+      "value" : "TEXT"
+    }, {
+      "name" : "as JSON",
+      "value" : "JSON"
+    } ]
+  }, {
+    "id" : "documentReturnFormatEncoding",
+    "label" : "Encoding",
+    "description" : "Character set used to decode the response. Default UTF-8.",
+    "value" : "UTF-8",
+    "feel" : "optional",
+    "group" : "endpoint",
+    "binding" : {
+      "name" : "documentReturnFormat.encoding",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "property" : "documentReturnFormat",
+      "equals" : "TEXT",
+      "type" : "simple"
+    },
+    "type" : "String"
   }, {
     "id" : "connectionTimeoutInSeconds",
     "label" : "Connection timeout in seconds",
@@ -678,7 +703,7 @@
     "id" : "version",
     "label" : "Version",
     "description" : "Version of the element template",
-    "value" : "16",
+    "value" : "17",
     "group" : "connector",
     "binding" : {
       "key" : "elementTemplateVersion",

--- a/connectors/http/rest/element-templates/versioned/http-json-connector-16.json
+++ b/connectors/http/rest/element-templates/versioned/http-json-connector-16.json
@@ -1,11 +1,11 @@
 {
   "$schema" : "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
-  "name" : "Hybrid Send REST Request",
-  "id" : "io.camunda.connectors.HttpJson.v2-hybrid",
+  "name" : "Send REST Request",
+  "id" : "io.camunda.connectors.HttpJson.v2",
   "description" : "Invoke REST API",
   "keywords" : [ "HTTP", "REST", "API call", "web request", "GET", "POST", "PUT", "PATCH", "DELETE", "fetch data", "send request", "invoke API" ],
   "documentationRef" : "https://docs.camunda.io/docs/components/connectors/protocol/rest/",
-  "version" : 17,
+  "version" : 16,
   "category" : {
     "id" : "connectors",
     "name" : "Connectors"
@@ -18,9 +18,6 @@
     "camunda" : "^8.10"
   },
   "groups" : [ {
-    "id" : "taskDefinitionType",
-    "label" : "Task definition type"
-  }, {
     "id" : "authentication",
     "label" : "Authentication"
   }, {
@@ -49,14 +46,12 @@
     "label" : "Retries"
   } ],
   "properties" : [ {
-    "id" : "taskDefinitionType",
     "value" : "io.camunda:http-json:1",
-    "group" : "taskDefinitionType",
     "binding" : {
       "property" : "type",
       "type" : "zeebe:taskDefinition"
     },
-    "type" : "String"
+    "type" : "Hidden"
   }, {
     "id" : "authenticationConfiguration",
     "label" : "Authentication credential",
@@ -569,6 +564,19 @@
     "tooltip" : "Map of query parameters to add to the request URL",
     "type" : "String"
   }, {
+    "id" : "storeResponse",
+    "label" : "Store response",
+    "optional" : false,
+    "value" : false,
+    "feel" : "static",
+    "group" : "endpoint",
+    "binding" : {
+      "name" : "storeResponse",
+      "type" : "zeebe:input"
+    },
+    "tooltip" : "Store the response as a document in the document store",
+    "type" : "Boolean"
+  }, {
     "id" : "skipEncoding",
     "label" : "Skip URL encoding",
     "optional" : true,
@@ -591,44 +599,6 @@
     },
     "tooltip" : "If enabled, HTTP 3xx redirects will be followed automatically. Disabled by default.",
     "type" : "Boolean"
-  }, {
-    "id" : "documentReturnFormat",
-    "label" : "Response format",
-    "value" : "JSON",
-    "group" : "endpoint",
-    "binding" : {
-      "name" : "documentReturnFormat.choice",
-      "type" : "zeebe:input"
-    },
-    "tooltip" : "How the response body should be returned. Document reference uploads the body to the document store; as text decodes it as a String; as JSON parses it into a structure you can access via dot notation.",
-    "type" : "Dropdown",
-    "choices" : [ {
-      "name" : "Document reference",
-      "value" : "DOCUMENT"
-    }, {
-      "name" : "as text",
-      "value" : "TEXT"
-    }, {
-      "name" : "as JSON",
-      "value" : "JSON"
-    } ]
-  }, {
-    "id" : "documentReturnFormatEncoding",
-    "label" : "Encoding",
-    "description" : "Character set used to decode the response. Default UTF-8.",
-    "value" : "UTF-8",
-    "feel" : "optional",
-    "group" : "endpoint",
-    "binding" : {
-      "name" : "documentReturnFormat.encoding",
-      "type" : "zeebe:input"
-    },
-    "condition" : {
-      "property" : "documentReturnFormat",
-      "equals" : "TEXT",
-      "type" : "simple"
-    },
-    "type" : "String"
   }, {
     "id" : "connectionTimeoutInSeconds",
     "label" : "Connection timeout in seconds",
@@ -708,7 +678,7 @@
     "id" : "version",
     "label" : "Version",
     "description" : "Version of the element template",
-    "value" : "17",
+    "value" : "16",
     "group" : "connector",
     "binding" : {
       "key" : "elementTemplateVersion",

--- a/connectors/http/rest/src/main/java/io/camunda/connector/http/rest/HttpJsonFunction.java
+++ b/connectors/http/rest/src/main/java/io/camunda/connector/http/rest/HttpJsonFunction.java
@@ -40,6 +40,7 @@ import io.camunda.connector.http.rest.model.RestAuthenticationConfiguration;
       "readTimeoutInSeconds",
       "body",
       "storeResponse",
+      "documentReturnFormat",
       "groupSetCookieHeaders",
       "ignoreNullValues",
       "followRedirects",
@@ -68,7 +69,7 @@ import io.camunda.connector.http.rest.model.RestAuthenticationConfiguration;
     inputDataClass = HttpJsonRequest.class,
     configurations = {RestAuthenticationConfiguration.class},
     outputDataClass = HttpCommonResult.class,
-    version = 16,
+    version = 17,
     defaultResultExpression =
         "{\n"
             + "  myResponseBody: response.body\n"
@@ -101,6 +102,7 @@ public class HttpJsonFunction implements OutboundConnectorFunction {
   @Override
   public Object execute(final OutboundConnectorContext context) {
     final var request = context.bindVariables(HttpJsonRequest.class);
-    return httpService.executeConnectorRequest(request, context);
+    var responseChoice = context.readDocumentReturnFormat().map(f -> f.choice()).orElse(null);
+    return httpService.executeConnectorRequest(request, context, responseChoice);
   }
 }

--- a/connectors/http/rest/src/test/java/io/camunda/connector/http/rest/HttpJsonFunctionDocumentReturnTest.java
+++ b/connectors/http/rest/src/test/java/io/camunda/connector/http/rest/HttpJsonFunctionDocumentReturnTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.http.rest;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.ok;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import io.camunda.connector.api.document.DocumentReturn;
+import io.camunda.connector.api.document.DocumentReturnChoice;
+import io.camunda.connector.api.document.DocumentReturnFormat;
+import io.camunda.connector.api.outbound.OutboundConnectorContext;
+import io.camunda.connector.http.base.model.HttpCommonResult;
+import io.camunda.connector.http.base.model.HttpMethod;
+import io.camunda.connector.http.rest.model.HttpJsonRequest;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies {@link HttpJsonFunction} takes the {@link DocumentReturn} flow when a {@code
+ * documentReturnFormat} choice is present, and the legacy path when absent.
+ */
+@WireMockTest
+class HttpJsonFunctionDocumentReturnTest {
+
+  private final HttpJsonFunction function = new HttpJsonFunction();
+
+  private HttpJsonRequest request(WireMockRuntimeInfo wm) {
+    HttpJsonRequest request = new HttpJsonRequest();
+    request.setMethod(HttpMethod.GET);
+    request.setUrl(wm.getHttpBaseUrl() + "/endpoint");
+    return request;
+  }
+
+  @Test
+  void choicePresent_takesNewPath_returnsDocumentReturn(WireMockRuntimeInfo wm) {
+    stubFor(get("/endpoint").willReturn(ok("{}")));
+    OutboundConnectorContext context = mock(OutboundConnectorContext.class);
+    when(context.bindVariables(HttpJsonRequest.class)).thenReturn(request(wm));
+    when(context.readDocumentReturnFormat())
+        .thenReturn(Optional.of(new DocumentReturnFormat(DocumentReturnChoice.JSON, null)));
+
+    Object result = function.execute(context);
+
+    assertThat(result).isInstanceOf(DocumentReturn.class);
+  }
+
+  @Test
+  void choiceAbsent_takesLegacyPath_returnsHttpCommonResult(WireMockRuntimeInfo wm) {
+    stubFor(
+        get("/endpoint")
+            .willReturn(ok("{\"k\":\"v\"}").withHeader("Content-Type", "application/json")));
+    OutboundConnectorContext context = mock(OutboundConnectorContext.class);
+    HttpJsonRequest request = request(wm);
+    request.setStoreResponse(false);
+    when(context.bindVariables(HttpJsonRequest.class)).thenReturn(request);
+    when(context.readDocumentReturnFormat()).thenReturn(Optional.empty());
+
+    Object result = function.execute(context);
+
+    assertThat(result).isInstanceOf(HttpCommonResult.class);
+    assertThat(((HttpCommonResult) result).body()).isEqualTo(Map.of("k", "v"));
+  }
+}


### PR DESCRIPTION
## Description

Extends the unified `Response format` dropdown from #7553 to the **HTTP REST** and **GraphQL** connectors,
replacing the old `storeResponse` boolean with `Document reference` / `as text` / `as JSON` (default `as JSON`).

- Streams the response body to the document store / decoder instead of buffering it fully in heap
  (`CustomApacheHttpClient.executeStreaming`).
- Back-compat: `storeResponse` stays but is `@Deprecated` and hidden; old templates keep the legacy path unchanged.
- Templates regenerated — REST **v17**, GraphQL **v11**, with `versioned/` snapshots.

**Behavior note:** on new templates, the `as JSON` default fails the job on non-JSON bodies (was previously
lenient, returning them as text). Intentional — matches the 5 connectors from #7553 and follows least-surprise;
use `as text` for non-JSON. Existing deployments are unaffected.

## Related issues

Part of #7058 · Stacks on #7553

## Checklist

- [ ] Backport labels are added if these code changes should be backported.
- [x] Tests/Integration tests for the changes have been added if applicable.
- [ ] If the change requires a documentation update, it has been added to the appropriate section in the documentation.
