### PR TITLE
ci(qa): build & publish QA docker images to Harbor on qa:required

### DIFF
--- a/.github/workflows/QA_REQUIRED.yml
+++ b/.github/workflows/QA_REQUIRED.yml
@@ -201,7 +201,6 @@ jobs:
     runs-on: gcp-core-2-default
     permissions:
       contents: read
-      pull-requests: write
     if: |
       github.event.pull_request.state != 'closed' &&
       github.event.label.name == 'qa:required'
@@ -226,6 +225,15 @@ jobs:
             secret/data/products/connectors/ci/common ARTIFACTORY_USR | CI_HARBOR_USR;
             secret/data/products/connectors/ci/common ARTIFACTORY_PSW | CI_HARBOR_PSW;
             secret/data/products/connectors/ci/common REGISTRY_MINIMUS_PSW;
+            secret/data/products/connectors/ci/common GITHUB_APP_ID;
+            secret/data/products/connectors/ci/common GITHUB_APP_PRIVATE_KEY;
+
+      - name: Generate a GitHub token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ steps.secrets.outputs.GITHUB_APP_ID }}
+          private-key: ${{ steps.secrets.outputs.GITHUB_APP_PRIVATE_KEY }}
 
       - name: Restore cache
         uses: actions/cache@v5
@@ -330,7 +338,7 @@ jobs:
 
       - name: Comment image tags on PR
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           TAG: ${{ steps.tag.outputs.tag }}
         run: |

--- a/.github/workflows/QA_REQUIRED.yml
+++ b/.github/workflows/QA_REQUIRED.yml
@@ -336,16 +336,23 @@ jobs:
           platforms: linux/amd64,linux/arm64
           provenance: false
 
+      # github-script (Node) instead of gh CLI: the gcp runner has no gh binary
       - name: Comment image tags on PR
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          TAG: ${{ steps.tag.outputs.tag }}
-        run: |
-          gh pr comment "$PR_NUMBER" --repo ${{ github.repository }} --body "$(cat <<EOF
-          :whale: QA Docker images published to Harbor:
-          - \`registry.camunda.cloud/team-connectors/connectors:${TAG}\`
-          - \`registry.camunda.cloud/team-connectors/connectors-bundle:${TAG}\`
-          - \`registry.camunda.cloud/team-connectors/connectors-bundle-saas:${TAG}\`
-          EOF
-          )"
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+          script: |
+            const tag = '${{ steps.tag.outputs.tag }}';
+            const reg = 'registry.camunda.cloud/team-connectors';
+            const body = [
+              ':whale: QA Docker images published to Harbor:',
+              '- `' + reg + '/connectors:' + tag + '`',
+              '- `' + reg + '/connectors-bundle:' + tag + '`',
+              '- `' + reg + '/connectors-bundle-saas:' + tag + '`',
+            ].join('\n');
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: ${{ github.event.pull_request.number }},
+              body,
+            });

--- a/.github/workflows/QA_REQUIRED.yml
+++ b/.github/workflows/QA_REQUIRED.yml
@@ -194,3 +194,150 @@ jobs:
                 }
               ]
             }
+
+  build-qa-images:
+    name: Build & publish QA Docker images
+    # gcp runner to match the heavier Maven + multi-arch Docker build in DEPLOY_SNAPSHOTS
+    runs-on: gcp-core-2-default
+    permissions:
+      contents: read
+      pull-requests: write
+    if: |
+      github.event.pull_request.state != 'closed' &&
+      github.event.label.name == 'qa:required'
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          # build the PR's actual code, not the synthetic merge ref
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Import Secrets
+        id: secrets
+        uses: hashicorp/vault-action@v4.0.0
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          exportEnv: false # we rely on step outputs, no need for environment variables
+          secrets: |
+            secret/data/products/connectors/ci/nexus USER | CI_NEXUS_USR;
+            secret/data/products/connectors/ci/nexus PASSWORD | CI_NEXUS_PSW;
+            secret/data/products/connectors/ci/common ARTIFACTORY_USR | CI_HARBOR_USR;
+            secret/data/products/connectors/ci/common ARTIFACTORY_PSW | CI_HARBOR_PSW;
+            secret/data/products/connectors/ci/common REGISTRY_MINIMUS_PSW;
+
+      - name: Restore cache
+        uses: actions/cache@v5
+        continue-on-error: true # cache failures should not fail the build
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+
+      - uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: '21.0.9'
+
+      # Use CI Nexus as co-located pull-through cache for Maven artifacts via ~/.m2/settings.xml
+      - name: 'Create settings.xml'
+        uses: s4u/maven-settings-action@v4.0.0
+        with:
+          githubServer: false
+          servers: |
+            [{
+               "id": "camunda-nexus",
+               "username": "${{ steps.secrets.outputs.CI_NEXUS_USR }}",
+               "password": "${{ steps.secrets.outputs.CI_NEXUS_PSW }}"
+             }]
+          mirrors: '[{"url": "https://repository.nexus.camunda.cloud/content/groups/internal/", "id": "camunda-nexus", "mirrorOf": "*,!shibboleth,!confluent", "name": "camunda Nexus"}]'
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+
+      - name: Install element templates CLI
+        run: npm install --global element-templates-cli
+
+      # Skip tests AND checks: QA just needs runnable images, not verification
+      - name: Package Connectors (skip tests & checks)
+        env:
+          PROJECTS: connector-runtime/connector-runtime-application,bundle/default-bundle,bundle/camunda-saas-bundle
+        run: ./mvnw -B compile generate-sources package -DskipTests -DskipChecks --projects "${PROJECTS}" --also-make
+
+      - name: Compute image tag
+        id: tag
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          BASE_VERSION=$(./mvnw help:evaluate -Dexpression=project.version -q -DforceStdout)
+          BASE_VERSION="${BASE_VERSION%-SNAPSHOT}"
+          TAG="${BASE_VERSION}-pr${PR_NUMBER}-run${GITHUB_RUN_ID}-a${GITHUB_RUN_ATTEMPT}"
+          echo "::notice::QA image tag: ${TAG}"
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v4
+        with:
+          platforms: 'arm64,arm'
+
+      - name: Set up Docker Build
+        uses: docker/setup-buildx-action@v4
+
+      - name: Login to Harbor
+        uses: docker/login-action@v4
+        with:
+          registry: registry.camunda.cloud
+          username: ${{ steps.secrets.outputs.CI_HARBOR_USR }}
+          password: ${{ steps.secrets.outputs.CI_HARBOR_PSW }}
+
+      - name: Login to Minimus
+        uses: docker/login-action@v4
+        with:
+          registry: reg.mini.dev
+          username: minimus
+          password: ${{ steps.secrets.outputs.REGISTRY_MINIMUS_PSW }}
+
+      - name: Build and Push Docker Image - connector-runtime
+        uses: docker/build-push-action@v7
+        with:
+          context: connector-runtime/connector-runtime-application/
+          push: true
+          tags: registry.camunda.cloud/team-connectors/connectors:${{ steps.tag.outputs.tag }}
+          platforms: linux/amd64,linux/arm64
+          provenance: false
+
+      - name: Build and Push Docker Image - bundle-default
+        uses: docker/build-push-action@v7
+        with:
+          context: bundle/default-bundle/
+          push: true
+          tags: registry.camunda.cloud/team-connectors/connectors-bundle:${{ steps.tag.outputs.tag }}
+          platforms: linux/amd64,linux/arm64
+          provenance: false
+
+      - name: Build and Push Docker Image - bundle-saas
+        uses: docker/build-push-action@v7
+        with:
+          context: bundle/camunda-saas-bundle/
+          push: true
+          tags: registry.camunda.cloud/team-connectors/connectors-bundle-saas:${{ steps.tag.outputs.tag }}
+          platforms: linux/amd64,linux/arm64
+          provenance: false
+
+      - name: Comment image tags on PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          TAG: ${{ steps.tag.outputs.tag }}
+        run: |
+          gh pr comment "$PR_NUMBER" --repo ${{ github.repository }} --body "$(cat <<EOF
+          :whale: QA Docker images published to Harbor:
+          - \`registry.camunda.cloud/team-connectors/connectors:${TAG}\`
+          - \`registry.camunda.cloud/team-connectors/connectors-bundle:${TAG}\`
+          - \`registry.camunda.cloud/team-connectors/connectors-bundle-saas:${TAG}\`
+          EOF
+          )"

--- a/.github/workflows/QA_REQUIRED.yml
+++ b/.github/workflows/QA_REQUIRED.yml
@@ -2,11 +2,11 @@
 name: QA Required
 on:
   pull_request:
-    types: [ labeled ]
+    types: [ labeled, synchronize ]
 
-# Only cancel if the same PR gets qa:required label added again
+# One run per PR; a new push (or re-label) cancels the in-flight build
 concurrency:
-  group: qa-required-${{ github.event.pull_request.number }}-${{ github.event.label.name }}
+  group: qa-required-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 jobs:
@@ -201,9 +201,12 @@ jobs:
     runs-on: gcp-core-2-default
     permissions:
       contents: read
+    # Run when the qa:required label is added, or on any push to a PR that already has it
     if: |
-      github.event.pull_request.state != 'closed' &&
-      github.event.label.name == 'qa:required'
+      github.event.pull_request.state != 'closed' && (
+        github.event.label.name == 'qa:required' ||
+        (github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'qa:required'))
+      )
     steps:
       - uses: actions/checkout@v6
         with:


### PR DESCRIPTION
## What

Adds a `build-qa-images` job to the **QA Required** workflow. When a PR is labeled `qa:required`, it now (in parallel with the existing label/Slack/project-board job):

1. Checks out the PR head and packages the `connector-runtime` application + both bundles with `-DskipTests -DskipChecks` (no verify, no SBOM, no hadolint).
2. Builds **multi-arch** (amd64+arm64) images and pushes them to the **internal Harbor registry**:
   - `registry.camunda.cloud/team-connectors/connectors:<tag>`
   - `registry.camunda.cloud/team-connectors/connectors-bundle:<tag>`
   - `registry.camunda.cloud/team-connectors/connectors-bundle-saas:<tag>`
   - tag: `<base-version>-pr<N>-run<run_id>-a<attempt>`
3. Comments the three pullable tags back on the PR.

## Why

Gives QA ready-to-pull images for any PR, without waiting on the full test/verify pipeline.

## Reuse

~90% copied from `MERGE_QUEUE_HELM_TEST.yaml`'s `build-image` job (Harbor login via Artifactory creds, skip-tests package, PR→tag logic), plus the runtime image context from `DEPLOY_SNAPSHOTS.yaml`.

## Notes / to verify before merge

- Couldn't run `actionlint`/`act` locally — YAML validated only. First run on a test PR should confirm:
  - runner label `gcp-core-2-default` is available for this workflow,
  - the Harbor repo path `team-connectors/connectors` exists / is writable (only the two bundle repos had prior precedent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
