### PR TITLE
feat(secret-util): add env var to disable legacy unbraced secrets. pattern

### DIFF
--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/AbstractConnectorContext.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/AbstractConnectorContext.java
@@ -20,6 +20,7 @@ import io.camunda.connector.api.secret.SecretProvider;
 import io.camunda.connector.api.validation.ValidationProvider;
 import io.camunda.connector.runtime.core.secret.SecretFilter;
 import io.camunda.connector.runtime.core.secret.SecretHandler;
+import io.camunda.connector.runtime.core.secret.SecretResolverMode;
 import org.jspecify.annotations.Nullable;
 
 public abstract class AbstractConnectorContext {
@@ -30,10 +31,20 @@ public abstract class AbstractConnectorContext {
 
   protected final ValidationProvider validationProvider;
 
+  private final SecretResolverMode secretResolverMode;
+
   protected AbstractConnectorContext(
       final SecretProvider secretProvider,
-      SecretFilter secretFilter,
+      final SecretFilter secretFilter,
       final ValidationProvider validationProvider) {
+    this(secretProvider, secretFilter, validationProvider, SecretResolverMode.ALL);
+  }
+
+  protected AbstractConnectorContext(
+      final SecretProvider secretProvider,
+      final SecretFilter secretFilter,
+      final ValidationProvider validationProvider,
+      final SecretResolverMode secretResolverMode) {
     if (secretFilter == null) {
       throw new IllegalArgumentException(
           "Secret filter required in Connector context but was null");
@@ -48,11 +59,13 @@ public abstract class AbstractConnectorContext {
       throw new RuntimeException("Validation provider required in Connector context but was null");
     }
     this.validationProvider = validationProvider;
+    this.secretResolverMode =
+        secretResolverMode != null ? secretResolverMode : SecretResolverMode.ALL;
   }
 
   public SecretHandler getSecretHandler() {
     if (secretHandler == null) {
-      secretHandler = new SecretHandler(secretProvider, secretFilter);
+      secretHandler = new SecretHandler(secretProvider, secretFilter, secretResolverMode);
     }
     return secretHandler;
   }

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/outbound/JobHandlerContext.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/outbound/JobHandlerContext.java
@@ -34,6 +34,7 @@ import io.camunda.connector.api.secret.SecretProvider;
 import io.camunda.connector.api.validation.ValidationProvider;
 import io.camunda.connector.runtime.core.AbstractConnectorContext;
 import io.camunda.connector.runtime.core.secret.SecretFilter;
+import io.camunda.connector.runtime.core.secret.SecretResolverMode;
 import java.util.Objects;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
@@ -62,7 +63,25 @@ public class JobHandlerContext extends AbstractConnectorContext
       final DocumentFactory documentFactory,
       final ObjectMapper objectMapper,
       final SecretFilter secretFilter) {
-    super(secretProvider, secretFilter, validationProvider);
+    this(
+        job,
+        secretProvider,
+        validationProvider,
+        documentFactory,
+        objectMapper,
+        secretFilter,
+        SecretResolverMode.ALL);
+  }
+
+  public JobHandlerContext(
+      final ActivatedJob job,
+      final SecretProvider secretProvider,
+      final ValidationProvider validationProvider,
+      final DocumentFactory documentFactory,
+      final ObjectMapper objectMapper,
+      final SecretFilter secretFilter,
+      final SecretResolverMode secretResolverMode) {
+    super(secretProvider, secretFilter, validationProvider, secretResolverMode);
     this.documentFactory = documentFactory;
     this.job = job;
     this.objectMapper = objectMapper;

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretHandler.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretHandler.java
@@ -31,8 +31,14 @@ public class SecretHandler {
 
   protected SecretReplacer secretReplacer;
 
-  public SecretHandler(final SecretProvider secretProvider, SecretFilter secretFilter) {
+  protected final SecretResolverMode mode;
+
+  public SecretHandler(
+      final SecretProvider secretProvider,
+      final SecretFilter secretFilter,
+      final SecretResolverMode mode) {
     this.secretProvider = secretProvider;
+    this.mode = mode;
     secretReplacer =
         (name, context) -> {
           if (secretFilter.isAllowed(name)) {
@@ -48,6 +54,6 @@ public class SecretHandler {
   }
 
   public String replaceSecrets(String input, SecretContext context) {
-    return SecretUtil.replaceSecrets(input, context, secretReplacer);
+    return SecretUtil.replaceSecrets(input, context, secretReplacer, mode);
   }
 }

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretResolverMode.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretResolverMode.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.runtime.core.secret;
+
+public enum SecretResolverMode {
+  /** Resolve both {@code {{secrets.KEY}}} and the legacy unbraced {@code secrets.KEY} pattern. */
+  ALL,
+  /**
+   * Resolve only {@code {{secrets.KEY}}}. The legacy unbraced {@code secrets.KEY} pattern is
+   * ignored, preventing accidental matches in arbitrary text such as third-party documentation.
+   */
+  BRACES_ONLY
+}

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretUtil.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretUtil.java
@@ -37,13 +37,17 @@ public class SecretUtil {
   private static final Pattern SECRET_PATTERN_PARENTHESES =
       Pattern.compile("\\{\\{\\s*secrets\\.(?<secret>\\S+?\\s*)}}");
 
+  private SecretUtil() {}
+
   public static String replaceSecrets(
-      String input, SecretContext context, SecretReplacer secretReplacer) {
+      String input, SecretContext context, SecretReplacer secretReplacer, SecretResolverMode mode) {
     if (input == null) {
       throw new IllegalStateException("input cant be null.");
     }
     input = replaceSecretsWithParentheses(input, context, secretReplacer);
-    input = replaceSecretsWithoutParentheses(input, context, secretReplacer);
+    if (mode == SecretResolverMode.ALL) {
+      input = replaceSecretsWithoutParentheses(input, context, secretReplacer);
+    }
     return input;
   }
 
@@ -103,14 +107,19 @@ public class SecretUtil {
     return output.toString();
   }
 
-  public static List<String> retrieveSecretKeysInInput(String input) {
-    return Objects.isNull(input)
-        ? List.of()
-        : Stream.of(SECRET_PATTERN_PARENTHESES, SECRET_PATTERN_SECRETS)
-            .map(pattern -> pattern.matcher(input))
-            .flatMap(Matcher::results)
-            .map(matchResult -> matchResult.group("secret"))
-            .distinct()
-            .toList();
+  public static List<String> retrieveSecretKeysInInput(String input, SecretResolverMode mode) {
+    if (Objects.isNull(input)) {
+      return List.of();
+    }
+    var patterns =
+        mode == SecretResolverMode.ALL
+            ? Stream.of(SECRET_PATTERN_PARENTHESES, SECRET_PATTERN_SECRETS)
+            : Stream.of(SECRET_PATTERN_PARENTHESES);
+    return patterns
+        .map(pattern -> pattern.matcher(input))
+        .flatMap(Matcher::results)
+        .map(matchResult -> matchResult.group("secret"))
+        .distinct()
+        .toList();
   }
 }

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/SecretUtilTests.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/SecretUtilTests.java
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.verifyNoInteractions;
 
 import io.camunda.connector.api.secret.SecretContext;
 import io.camunda.connector.runtime.core.secret.SecretReplacer;
+import io.camunda.connector.runtime.core.secret.SecretResolverMode;
 import io.camunda.connector.runtime.core.secret.SecretUtil;
 import java.util.List;
 import java.util.Map;
@@ -57,12 +58,36 @@ public class SecretUtilTests {
   })
   void testSecretPattern(String input, String secret, Boolean shouldDetect) {
     var secretReplacer = mock(SecretReplacer.class);
-    SecretUtil.replaceSecrets(input, null, secretReplacer);
+    SecretUtil.replaceSecrets(input, null, secretReplacer, SecretResolverMode.ALL);
     if (shouldDetect) {
       verify(secretReplacer).replaceSecrets(eq(secret), any());
     } else {
       verifyNoInteractions(secretReplacer);
     }
+  }
+
+  @Test
+  void bracesOnly_secretsDotKeyNotReplaced() {
+    var secretReplacer = mock(SecretReplacer.class);
+    SecretUtil.replaceSecrets(
+        "secrets.MY_SECRET", null, secretReplacer, SecretResolverMode.BRACES_ONLY);
+    verifyNoInteractions(secretReplacer);
+  }
+
+  @Test
+  void bracesOnly_bracesPatternStillReplaced() {
+    var secretReplacer = mock(SecretReplacer.class);
+    SecretUtil.replaceSecrets(
+        "{{secrets.MY_SECRET}}", null, secretReplacer, SecretResolverMode.BRACES_ONLY);
+    verify(secretReplacer).replaceSecrets(eq("MY_SECRET"), any());
+  }
+
+  @Test
+  void bracesOnly_retrieveSecretKeysExcludesUnbracedKeys() {
+    var keys =
+        SecretUtil.retrieveSecretKeysInInput(
+            "secrets.A and {{secrets.B}}", SecretResolverMode.BRACES_ONLY);
+    assertThat(keys).containsExactly("B");
   }
 
   Map<String, String> secrets =
@@ -82,7 +107,7 @@ public class SecretUtilTests {
       delimiter = '|') // delimiter is needed to escape the comma in the json
   void testSecretReplacementWithJsonInput(String input, String output) {
     SecretReplacer secretReplacer = (name, context) -> secrets.get(name);
-    var result = SecretUtil.replaceSecrets(input, null, secretReplacer);
+    var result = SecretUtil.replaceSecrets(input, null, secretReplacer, SecretResolverMode.ALL);
     assertThat(result).isEqualTo(output);
   }
 
@@ -93,7 +118,8 @@ public class SecretUtilTests {
         (name, context) -> allowList.contains(name) ? secrets.get(name) : null;
     String content = "Hello {{secrets.KEY1}} and {{secrets.KEY2}} and {{secrets.KEY3}}";
     SecretContext secretContext = new SecretContext("tenantId", "processId");
-    String replacedContent = SecretUtil.replaceSecrets(content, secretContext, secretReplacer);
+    String replacedContent =
+        SecretUtil.replaceSecrets(content, secretContext, secretReplacer, SecretResolverMode.ALL);
     assertThat(replacedContent).isEqualTo("Hello VALUE1 and VALUE2 and {{secrets.KEY3}}");
   }
 }

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/OutboundConnectorRuntimeConfiguration.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/OutboundConnectorRuntimeConfiguration.java
@@ -35,6 +35,7 @@ import io.camunda.connector.runtime.core.outbound.DefaultOutboundConnectorFactor
 import io.camunda.connector.runtime.core.outbound.OutboundConnectorFactory;
 import io.camunda.connector.runtime.core.secret.SecretFilterFactory;
 import io.camunda.connector.runtime.core.secret.SecretProviderAggregator;
+import io.camunda.connector.runtime.core.secret.SecretResolverMode;
 import io.camunda.connector.runtime.core.validation.ValidationUtil;
 import io.camunda.connector.runtime.instances.InstanceForwardingConfiguration;
 import io.camunda.connector.runtime.instances.service.OutboundConnectorsService;
@@ -187,7 +188,8 @@ public class OutboundConnectorRuntimeConfiguration {
       DocumentFactory documentFactory,
       @OutboundConnectorObjectMapper ObjectMapper objectMapper,
       SecretFilterFactory secretFilterFactory,
-      Optional<MeterRegistry> meterRegistry) {
+      Optional<MeterRegistry> meterRegistry,
+      SecretResolverMode secretResolverMode) {
     return new OutboundConnectorManager(
         jobWorkerManager,
         connectorFactory,
@@ -198,6 +200,7 @@ public class OutboundConnectorRuntimeConfiguration {
         objectMapper,
         metricsRecorder,
         secretFilterFactory,
-        meterRegistry.orElse(null));
+        meterRegistry.orElse(null),
+        secretResolverMode);
   }
 }

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/OutboundConnectorExceptionHandler.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/OutboundConnectorExceptionHandler.java
@@ -27,6 +27,7 @@ import io.camunda.connector.api.secret.SecretProvider;
 import io.camunda.connector.runtime.core.error.InvalidBackOffDurationException;
 import io.camunda.connector.runtime.core.outbound.ConnectorResult;
 import io.camunda.connector.runtime.core.secret.SecretFilter;
+import io.camunda.connector.runtime.core.secret.SecretResolverMode;
 import io.camunda.connector.runtime.core.secret.SecretUtil;
 import java.time.Duration;
 import java.util.*;
@@ -38,9 +39,11 @@ public class OutboundConnectorExceptionHandler {
   private static final Logger LOGGER =
       LoggerFactory.getLogger(OutboundConnectorExceptionHandler.class);
   private final SecretProvider secretProvider;
+  private final SecretResolverMode mode;
 
-  public OutboundConnectorExceptionHandler(SecretProvider secretProvider) {
+  public OutboundConnectorExceptionHandler(SecretProvider secretProvider, SecretResolverMode mode) {
     this.secretProvider = secretProvider;
+    this.mode = mode;
   }
 
   private static Map<String, Object> exceptionToMap(Exception wrappedException) {
@@ -72,7 +75,7 @@ public class OutboundConnectorExceptionHandler {
     List<String> secrets;
     try {
       var allowedKeys =
-          SecretUtil.retrieveSecretKeysInInput(job.getVariables()).stream()
+          SecretUtil.retrieveSecretKeysInInput(job.getVariables(), mode).stream()
               .filter(secretFilter::isAllowed)
               .toList();
       secrets =
@@ -173,7 +176,7 @@ public class OutboundConnectorExceptionHandler {
   public ConnectorResult.ErrorResult handleFinalResultException(
       Exception ex, ActivatedJob job, SecretFilter secretFilter) {
     var allowedKeys =
-        SecretUtil.retrieveSecretKeysInInput(job.getVariables()).stream()
+        SecretUtil.retrieveSecretKeysInInput(job.getVariables(), mode).stream()
             .filter(secretFilter::isAllowed)
             .toList();
     List<String> secrets =

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/SpringConnectorJobHandler.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/SpringConnectorJobHandler.java
@@ -63,6 +63,7 @@ import io.camunda.connector.runtime.core.secret.SecretFilterFactory;
 import io.camunda.connector.runtime.core.secret.SecretFilterFactory.SecretFilterContext;
 import io.camunda.connector.runtime.core.secret.SecretProviderAggregator;
 import io.camunda.connector.runtime.core.secret.SecretProviderDiscovery;
+import io.camunda.connector.runtime.core.secret.SecretResolverMode;
 import io.camunda.connector.runtime.metrics.ConnectorMetrics;
 import io.camunda.connector.runtime.metrics.ConnectorOutboundMetrics;
 import java.time.Duration;
@@ -95,6 +96,7 @@ public class SpringConnectorJobHandler implements JobHandler {
   private final DocumentFactory documentFactory;
   private final ObjectMapper objectMapper;
   private final SecretFilterFactory secretFilterFactory;
+  private final SecretResolverMode secretResolverMode;
 
   public SpringConnectorJobHandler(
       MetricsRecorder outboundMetrics,
@@ -104,7 +106,8 @@ public class SpringConnectorJobHandler implements JobHandler {
       DocumentFactory documentFactory,
       ObjectMapper objectMapper,
       OutboundConnectorFunction connectorFunction,
-      SecretFilterFactory secretFilterFactory) {
+      SecretFilterFactory secretFilterFactory,
+      SecretResolverMode secretResolverMode) {
     this(
         new ConnectorOutboundMetrics(outboundMetrics, null),
         jobCallbackCommandWrapperFactory,
@@ -113,7 +116,8 @@ public class SpringConnectorJobHandler implements JobHandler {
         documentFactory,
         objectMapper,
         connectorFunction,
-        secretFilterFactory);
+        secretFilterFactory,
+        secretResolverMode);
   }
 
   public SpringConnectorJobHandler(
@@ -124,15 +128,17 @@ public class SpringConnectorJobHandler implements JobHandler {
       DocumentFactory documentFactory,
       ObjectMapper objectMapper,
       OutboundConnectorFunction connectorFunction,
-      SecretFilterFactory secretFilterFactory) {
+      SecretFilterFactory secretFilterFactory,
+      SecretResolverMode secretResolverMode) {
     this.call = connectorFunction;
     this.secretProvider = secretProviderAggregator;
     this.validationProvider = validationProvider;
     this.documentFactory = documentFactory;
     this.objectMapper = objectMapper;
     this.secretFilterFactory = secretFilterFactory;
+    this.secretResolverMode = secretResolverMode;
     this.outboundConnectorExceptionHandler =
-        new OutboundConnectorExceptionHandler(getSecretProvider());
+        new OutboundConnectorExceptionHandler(getSecretProvider(), secretResolverMode);
     this.connectorResultHandler = new ConnectorResultHandler(objectMapper);
     this.jobCallbackCommandWrapperFactory = jobCallbackCommandWrapperFactory;
     this.connectorsOutboundMetrics = outboundMetrics;
@@ -190,7 +196,8 @@ public class SpringConnectorJobHandler implements JobHandler {
             validationProvider,
             documentFactory,
             objectMapper,
-            secretFilter);
+            secretFilter,
+            secretResolverMode);
     ConnectorResult result = getConnectorResult(job, context, secretFilter);
     processFinalResult(client, job, context, result, counterMetricsContext, secretFilter);
   }

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/lifecycle/OutboundConnectorManager.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/lifecycle/OutboundConnectorManager.java
@@ -34,6 +34,7 @@ import io.camunda.connector.runtime.core.config.OutboundConnectorConfiguration;
 import io.camunda.connector.runtime.core.outbound.OutboundConnectorFactory;
 import io.camunda.connector.runtime.core.secret.SecretFilterFactory;
 import io.camunda.connector.runtime.core.secret.SecretProviderAggregator;
+import io.camunda.connector.runtime.core.secret.SecretResolverMode;
 import io.camunda.connector.runtime.metrics.ConnectorOutboundMetrics;
 import io.camunda.connector.runtime.outbound.job.SpringConnectorJobHandler;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -57,6 +58,7 @@ public class OutboundConnectorManager implements CamundaClientLifecycleAware {
   private final MetricsRecorder metricsRecorder;
   private final SecretFilterFactory secretFilterFactory;
   private final MeterRegistry meterRegistry;
+  private final SecretResolverMode secretResolverMode;
 
   public OutboundConnectorManager(
       JobWorkerManager jobWorkerManager,
@@ -68,7 +70,8 @@ public class OutboundConnectorManager implements CamundaClientLifecycleAware {
       ObjectMapper objectMapper,
       MetricsRecorder metricsRecorder,
       SecretFilterFactory secretFilterFactory,
-      MeterRegistry meterRegistry) {
+      MeterRegistry meterRegistry,
+      SecretResolverMode secretResolverMode) {
     this.jobWorkerManager = jobWorkerManager;
     this.connectorFactory = connectorFactory;
     this.jobCallbackCommandWrapperFactory = jobCallbackCommandWrapperFactory;
@@ -79,6 +82,7 @@ public class OutboundConnectorManager implements CamundaClientLifecycleAware {
     this.metricsRecorder = metricsRecorder;
     this.secretFilterFactory = secretFilterFactory;
     this.meterRegistry = meterRegistry;
+    this.secretResolverMode = secretResolverMode;
   }
 
   @Override
@@ -125,7 +129,8 @@ public class OutboundConnectorManager implements CamundaClientLifecycleAware {
                 documentFactory,
                 objectMapper,
                 connectorFunction,
-                secretFilterFactory);
+                secretFilterFactory,
+                secretResolverMode);
     jobWorkerManager.createJobWorker(
         client, new ManagedJobWorker(jobWorkerValue, jobHandlerFactory), this);
   }

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/secret/ProcessDefinitionSecretKeyCache.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/secret/ProcessDefinitionSecretKeyCache.java
@@ -18,6 +18,7 @@ package io.camunda.connector.runtime.outbound.secret;
 
 import io.camunda.client.CamundaClient;
 import io.camunda.connector.api.inbound.ElementTemplateDetails;
+import io.camunda.connector.runtime.core.secret.SecretResolverMode;
 import io.camunda.connector.runtime.core.secret.SecretUtil;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
@@ -107,7 +108,10 @@ public class ProcessDefinitionSecretKeyCache implements SecretKeyCache {
 
   private List<String> extractSecrets(List<ZeebeInput> inputs) {
     return inputs.stream()
-        .flatMap(input -> SecretUtil.retrieveSecretKeysInInput(input.getSource()).stream())
+        .flatMap(
+            input ->
+                SecretUtil.retrieveSecretKeysInInput(input.getSource(), SecretResolverMode.ALL)
+                    .stream())
         .map(String::trim)
         .distinct()
         .toList();

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/job/SpringConnectorJobHandlerTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/job/SpringConnectorJobHandlerTest.java
@@ -62,6 +62,7 @@ import io.camunda.connector.runtime.TestValidation;
 import io.camunda.connector.runtime.core.Keywords;
 import io.camunda.connector.runtime.core.secret.SecretFilter;
 import io.camunda.connector.runtime.core.secret.SecretProviderAggregator;
+import io.camunda.connector.runtime.core.secret.SecretResolverMode;
 import io.camunda.connector.runtime.secret.FooBarSecretProvider;
 import io.camunda.connector.validation.impl.DefaultValidationProvider;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
@@ -128,7 +129,8 @@ class SpringConnectorJobHandlerTest {
         mock(DocumentFactory.class),
         TestObjectMapperSupplier.INSTANCE,
         call,
-        job -> SecretFilter.allowAll());
+        job -> SecretFilter.allowAll(),
+        SecretResolverMode.ALL);
   }
 
   private SpringConnectorJobHandler newConnectorJobHandler(
@@ -143,7 +145,8 @@ class SpringConnectorJobHandlerTest {
         mock(DocumentFactory.class),
         TestObjectMapperSupplier.INSTANCE,
         call,
-        job -> SecretFilter.allowAll());
+        job -> SecretFilter.allowAll(),
+        SecretResolverMode.ALL);
   }
 
   @Nested

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/main/java/io/camunda/connector/runtime/ConnectorProperties.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/main/java/io/camunda/connector/runtime/ConnectorProperties.java
@@ -16,6 +16,7 @@
  */
 package io.camunda.connector.runtime;
 
+import io.camunda.connector.runtime.core.secret.SecretResolverMode;
 import java.time.Duration;
 import java.util.List;
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -26,6 +27,7 @@ public record ConnectorProperties(
     Polling polling,
     Webhook webhook,
     SecretProvider secretProvider,
+    Secrets secrets,
     VirtualThreads virtualThreads,
     Inbound inbound,
     OAuth oauth,
@@ -55,6 +57,13 @@ public record ConnectorProperties(
       boolean enabled, String prefix, boolean tenantAware, boolean processDefinitionAware) {}
 
   public record ConsoleSecretProvider(boolean enabled, String endpoint, String audience) {}
+
+  /** Configuration for secret resolution behaviour. */
+  public record Secrets(SecretResolverMode resolverMode) {
+    public Secrets() {
+      this(SecretResolverMode.ALL);
+    }
+  }
 
   /** Configuration for inbound connector processing. */
   public record Inbound(ProcessDefinitionCache processDefinitionCache) {}

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/main/java/io/camunda/connector/runtime/OutboundConnectorsAutoConfiguration.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/main/java/io/camunda/connector/runtime/OutboundConnectorsAutoConfiguration.java
@@ -20,11 +20,13 @@ import io.camunda.client.jobhandling.CamundaClientExecutorService;
 import io.camunda.client.metrics.MeteredCamundaClientExecutorService;
 import io.camunda.client.spring.configuration.CamundaAutoConfiguration;
 import io.camunda.client.spring.configuration.ExecutorServiceConfiguration;
+import io.camunda.connector.runtime.core.secret.SecretResolverMode;
 import io.camunda.connector.runtime.instances.InstanceForwardingConfiguration;
 import io.camunda.connector.runtime.outbound.OutboundConnectorRuntimeConfiguration;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
@@ -37,6 +39,15 @@ import org.springframework.context.annotation.Import;
 @AutoConfigureBefore({CamundaAutoConfiguration.class, ExecutorServiceConfiguration.class})
 @Import({OutboundConnectorRuntimeConfiguration.class, InstanceForwardingConfiguration.class})
 public class OutboundConnectorsAutoConfiguration {
+
+  @Bean
+  @ConditionalOnMissingBean(SecretResolverMode.class)
+  public SecretResolverMode secretResolverMode(
+      ObjectProvider<ConnectorProperties> connectorProperties) {
+    var props = connectorProperties.getIfAvailable();
+    var secrets = props != null ? props.secrets() : null;
+    return secrets != null ? secrets.resolverMode() : SecretResolverMode.ALL;
+  }
 
   @Bean(name = {"connectorCamundaClientExecutorService", "camundaClientExecutorService"})
   @ConditionalOnMissingBean


### PR DESCRIPTION
## Summary

- Adds `CAMUNDA_CONNECTOR_SECRETS_LEGACY_PATTERN_ENABLED=false` env var to disable the unbraced `secrets.KEY` secret pattern in `SecretUtil`
- When disabled, only `{{secrets.KEY}}` is accepted; the bare `secrets.KEY` form is silently ignored
- Both `replaceSecrets` and `retrieveSecretKeysInInput` respect the flag; the check is per-call so the env var is always fresh
- Tests use `system-stubs-jupiter` (`@SystemStub EnvironmentVariables`) to pin the env var to a known value for the whole class, ensuring the suite is deterministic regardless of the JVM environment

## Motivation

The unbraced `secrets.KEY` pattern matches any text that contains the substring `secrets.` — including third-party documentation, Helm chart READMEs, and other untrusted content that agents routinely process. For example, a connector that fetches a Helm chart README (such as the one for [external-secrets](https://github.com/camunda/helm-charts-mirror/blob/main/charts/charts.external-secrets.io/external-secrets/2.6.0/external-secrets/README.md)) will have `secrets.` references in that content silently resolved (or silently left as-is, masking failures), making connectors brittle in the face of untrusted input data.

The `{{secrets.KEY}}` form is unambiguous and intentional; the bare form is a historical convenience that now does more harm than good in environments that process arbitrary text.

## Test plan

- [ ] `SecretUtilTests` passes (26 tests: two new for `replaceSecrets` with legacy disabled, one new for `retrieveSecretKeysInInput` with legacy disabled)
- [ ] Verify default behaviour is unchanged (env var absent → legacy pattern still active)
- [ ] Set `CAMUNDA_CONNECTOR_SECRETS_LEGACY_PATTERN_ENABLED=false` and confirm `secrets.KEY` in a connector input is no longer resolved
