### PR TITLE
feat: secure /outbound endpoint and consolidate connector instances security config

### DIFF
--- a/bundle/camunda-saas-bundle/src/main/java/io/camunda/connector/runtime/saas/security/ConnectorInstancesSecurityConfiguration.java
+++ b/bundle/camunda-saas-bundle/src/main/java/io/camunda/connector/runtime/saas/security/ConnectorInstancesSecurityConfiguration.java
@@ -37,7 +37,7 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @EnableWebSecurity
 @Configuration
-public class InboundInstancesSecurityConfiguration {
+public class ConnectorInstancesSecurityConfiguration {
 
   @Value("${camunda.connector.auth.console.audience:}")
   private String consoleAudience;
@@ -79,21 +79,21 @@ public class InboundInstancesSecurityConfiguration {
 
   @Bean
   @Order(2)
-  public SecurityFilterChain inboundInstancesFilterChain(HttpSecurity http) throws Exception {
+  public SecurityFilterChain connectorInstancesFilterChain(HttpSecurity http) throws Exception {
     http.cors(Customizer.withDefaults())
-        .csrf(csrf -> csrf.ignoringRequestMatchers("/inbound-instances/**"))
+        .csrf(csrf -> csrf.ignoringRequestMatchers("/inbound-instances/**", "/outbound/**"))
         .securityMatchers(
             requestMatcherConfigurer ->
-                requestMatcherConfigurer.requestMatchers("/inbound-instances/**"))
+                requestMatcherConfigurer.requestMatchers("/inbound-instances/**", "/outbound/**"))
         .authorizeHttpRequests(
-            auth -> auth.requestMatchers("/inbound-instances/**").authenticated())
+            auth -> auth.requestMatchers("/inbound-instances/**", "/outbound/**").authenticated())
         .oauth2ResourceServer(
-            oauth2 -> oauth2.jwt(jwt -> jwt.decoder(inboundInstancesJwtDecoder())));
+            oauth2 -> oauth2.jwt(jwt -> jwt.decoder(connectorInstancesJwtDecoder())));
     return http.build();
   }
 
   @Bean
-  JwtDecoder inboundInstancesJwtDecoder() {
+  JwtDecoder connectorInstancesJwtDecoder() {
     NimbusJwtDecoder jwtDecoder = JwtDecoders.fromOidcIssuerLocation(issuer);
 
     OAuth2TokenValidator<Jwt> audienceValidator = new AudienceValidator(consoleAudience);

--- a/bundle/camunda-saas-bundle/src/test/java/io/camunda/connector/runtime/saas/ConnectorInstancesSecurityConfigurationTest.java
+++ b/bundle/camunda-saas-bundle/src/test/java/io/camunda/connector/runtime/saas/ConnectorInstancesSecurityConfigurationTest.java
@@ -58,7 +58,7 @@ import org.springframework.test.web.servlet.MockMvc;
 @DirtiesContext
 @ActiveProfiles("test")
 @AutoConfigureMockMvc
-public class InboundInstancesSecurityConfigurationTest {
+public class ConnectorInstancesSecurityConfigurationTest {
 
   private static final MockOidcServer OIDC_SERVER = MockOidcServer.start();
 
@@ -88,5 +88,15 @@ public class InboundInstancesSecurityConfigurationTest {
   @Test
   public void inboundInstancesEndpoint_withAuth_returns200() throws Exception {
     mvc.perform(get("/inbound-instances").with(jwt())).andExpect(status().isOk());
+  }
+
+  @Test
+  public void outboundEndpoint_noAuth_returns401() throws Exception {
+    mvc.perform(get("/outbound")).andExpect(status().isUnauthorized());
+  }
+
+  @Test
+  public void outboundEndpoint_withAuth_returns200() throws Exception {
+    mvc.perform(get("/outbound").with(jwt())).andExpect(status().isOk());
   }
 }


### PR DESCRIPTION
## Description

The new `OutboundConnectorsRestController` (`/outbound/**`) was left unprotected. This PR adds it to the existing connector instances security filter chain and takes the opportunity to rename the configuration class now that it is no longer inbound-only.

**Changes:**

- **Security**: `/outbound/**` is now secured with the same JWT validation as `/inbound-instances/**` (audience validator + organisation/roles validator). Both paths are handled by a single `connectorInstancesFilterChain` at `@Order(2)`.
- **Rename**: `InboundInstancesSecurityConfiguration` → `ConnectorInstancesSecurityConfiguration` to reflect its broader scope.
- **Tests**: `InboundInstancesSecurityConfigurationTest` renamed accordingly; two new test cases added for the `/outbound` endpoint (`noAuth` → 401, `withAuth` → 200).

## Related issues

closes #

## Checklist

- [ ] Backport labels are added if these code changes should be backported.
- [x] Tests/Integration tests for the changes have been added if applicable.
- [ ] If the change requires a documentation update, it has been added to the appropriate section in the documentation.
