### PR TITLE
feat: add /outbound/** to CORS mappings

### DIFF
--- a/bundle/camunda-saas-bundle/src/main/resources/application.properties
+++ b/bundle/camunda-saas-bundle/src/main/resources/application.properties
@@ -30,7 +30,7 @@ camunda.connector.inbound.log.size=100
 # Default is 1h and can be overridden by the connector configuration
 #camunda.connector.inbound.message.ttl=PT1H
 camunda.connector.secretprovider.discovery.enabled=false
-camunda.endpoints.cors.mappings=/inbound-instances/**
+camunda.endpoints.cors.mappings=/inbound-instances/**,/outbound/**
 camunda.endpoints.cors.allow.credentials=true
 
 server.max-http-request-header-size=1MB

--- a/bundle/default-bundle/src/test/resources/application-local.properties
+++ b/bundle/default-bundle/src/test/resources/application-local.properties
@@ -8,7 +8,7 @@ camunda.client.auth.password=demo
 camunda.client.auth.token-url=null
 # Access from local c4-connectors storybook
 camunda.endpoints.cors.allowed.origins=http://localhost:6006
-camunda.endpoints.cors.mappings=/inbound-instances/**
+camunda.endpoints.cors.mappings=/inbound-instances/**,/outbound/**
 camunda.client.prefer-rest-over-grpc=false
 camunda.client.rest-address=http://localhost:8080
 camunda.connector.oauth.cache.skew-buffer=PT9S


### PR DESCRIPTION
## Description

Follow-up to #7558 — the security filter chain was updated to cover `/outbound/**`, but the `camunda.endpoints.cors.mappings` property was not updated in the properties files. This PR fixes the gap.

**Changes:**
- `bundle/camunda-saas-bundle/src/main/resources/application.properties`: add `/outbound/**` to `camunda.endpoints.cors.mappings`
- `bundle/default-bundle/src/test/resources/application-local.properties`: same change for the local dev config

Without this, CORS pre-flight requests to `/outbound/**` would be rejected even though the endpoint is now secured and exposed.

## Related issues

closes #

## Checklist

- [ ] Backport labels are added if these code changes should be backported.
- [ ] Tests/Integration tests for the changes have been added if applicable.
- [ ] If the change requires a documentation update, it has been added to the appropriate section in the documentation.
