### PR TITLE
fix: let test dummies implement new businessId methods

### DIFF
--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/testutil/command/CorrelateMessageCommandDummy.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/testutil/command/CorrelateMessageCommandDummy.java
@@ -79,6 +79,11 @@ public class CorrelateMessageCommandDummy
   }
 
   @Override
+  public CorrelateMessageCommandStep3 businessId(String businessId) {
+    return this;
+  }
+
+  @Override
   public FinalCommandStep<CorrelateMessageResponse> requestTimeout(Duration requestTimeout) {
     return this;
   }

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/testutil/command/PublishMessageCommandDummy.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/testutil/command/PublishMessageCommandDummy.java
@@ -87,6 +87,11 @@ public class PublishMessageCommandDummy
   }
 
   @Override
+  public PublishMessageCommandStep3 businessId(String businessId) {
+    return this;
+  }
+
+  @Override
   public FinalCommandStep<PublishMessageResponse> requestTimeout(Duration requestTimeout) {
     return this;
   }


### PR DESCRIPTION
## Description

Builds failed due to two dummy classes not implementing new `busnessId` method.

## Checklist

- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest
  release, as this branch will be rebased onto main before the next release. Example backport labels:
    - `backport stable/8.8`: for changes that should be included in the next 8.8.x release.
    - **or** `backport release-8.8.7`: for changes that should be included in the specific release 8.8.7, and this
      *release has already been created*. The release branch will be merged back into stable/8.8 later, so the change
      will be included in future 8.8.x releases as well.
- [ ] Tests/Integration tests for the changes have been added if applicable.
- [ ] If the change requires a documentation update, it has been added to the appropriate section in the documentation.


