### PR TITLE
fix(runtime): restrict outbound connector secret resolution to declared secrets

### DIFF
--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/AbstractConnectorContext.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/AbstractConnectorContext.java
@@ -18,6 +18,7 @@ package io.camunda.connector.runtime.core;
 
 import io.camunda.connector.api.secret.SecretProvider;
 import io.camunda.connector.api.validation.ValidationProvider;
+import io.camunda.connector.runtime.core.secret.SecretFilter;
 import io.camunda.connector.runtime.core.secret.SecretHandler;
 import org.jspecify.annotations.Nullable;
 
@@ -25,11 +26,19 @@ public abstract class AbstractConnectorContext {
 
   protected @Nullable SecretHandler secretHandler;
   protected final SecretProvider secretProvider;
+  protected final SecretFilter secretFilter;
 
   protected final ValidationProvider validationProvider;
 
   protected AbstractConnectorContext(
-      final SecretProvider secretProvider, final ValidationProvider validationProvider) {
+      final SecretProvider secretProvider,
+      SecretFilter secretFilter,
+      final ValidationProvider validationProvider) {
+    if (secretFilter == null) {
+      throw new IllegalArgumentException(
+          "Secret filter required in Connector context but was null");
+    }
+    this.secretFilter = secretFilter;
     if (secretProvider == null) {
       throw new RuntimeException("Secret provider required in Connector context but was null");
     }
@@ -43,7 +52,7 @@ public abstract class AbstractConnectorContext {
 
   public SecretHandler getSecretHandler() {
     if (secretHandler == null) {
-      secretHandler = new SecretHandler(secretProvider);
+      secretHandler = new SecretHandler(secretProvider, secretFilter);
     }
     return secretHandler;
   }

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImpl.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/InboundConnectorContextImpl.java
@@ -50,6 +50,7 @@ import io.camunda.connector.runtime.core.inbound.activitylog.ActivityLogWriter;
 import io.camunda.connector.runtime.core.inbound.activitylog.ActivitySource;
 import io.camunda.connector.runtime.core.inbound.correlation.InboundCorrelationHandler;
 import io.camunda.connector.runtime.core.inbound.details.InboundConnectorDetails.ValidInboundConnectorDetails;
+import io.camunda.connector.runtime.core.secret.SecretFilter;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
@@ -87,7 +88,7 @@ public class InboundConnectorContextImpl extends AbstractConnectorContext
       ObjectMapper objectMapper,
       ActivityLogWriter activityLogWriter,
       CamundaClient camundaClient) {
-    super(secretProvider, validationProvider);
+    super(secretProvider, SecretFilter.allowAll(), validationProvider);
     this.documentFactory = documentFactory;
     this.correlationHandler = correlationHandler;
     this.connectorDetails = connectorDetails;

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/outbound/JobHandlerContext.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/outbound/JobHandlerContext.java
@@ -33,6 +33,7 @@ import io.camunda.connector.api.secret.SecretContext;
 import io.camunda.connector.api.secret.SecretProvider;
 import io.camunda.connector.api.validation.ValidationProvider;
 import io.camunda.connector.runtime.core.AbstractConnectorContext;
+import io.camunda.connector.runtime.core.secret.SecretFilter;
 import java.util.Objects;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
@@ -59,8 +60,9 @@ public class JobHandlerContext extends AbstractConnectorContext
       final SecretProvider secretProvider,
       final ValidationProvider validationProvider,
       final DocumentFactory documentFactory,
-      final ObjectMapper objectMapper) {
-    super(secretProvider, validationProvider);
+      final ObjectMapper objectMapper,
+      final SecretFilter secretFilter) {
+    super(secretProvider, secretFilter, validationProvider);
     this.documentFactory = documentFactory;
     this.job = job;
     this.objectMapper = objectMapper;

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretFilter.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretFilter.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.runtime.core.secret;
+
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Determines whether a named secret may be resolved within a connector's context.
+ *
+ * <p>Use {@link #allowAll()} when no restriction applies and {@link #allowOnly(List)} to restrict
+ * resolution to a declared set of names. An empty list passed to {@code allowOnly} denies all
+ * secrets.
+ */
+@FunctionalInterface
+public interface SecretFilter {
+
+  /**
+   * Returns {@code true} if the secret with the given name may be resolved.
+   *
+   * @param secretName the secret name to check
+   * @return {@code true} to allow resolution, {@code false} to leave the reference as-is
+   */
+  boolean isAllowed(String secretName);
+
+  /** Returns a filter that permits every secret name. */
+  static SecretFilter allowAll() {
+    return name -> true;
+  }
+
+  /**
+   * Returns a filter that permits only the secret names in {@code names}. An empty list denies all
+   * secrets.
+   *
+   * @param names the permitted secret names
+   * @return a filter restricted to the given names
+   */
+  static SecretFilter allowOnly(List<String> names) {
+    var allowed = Set.copyOf(names);
+    return allowed::contains;
+  }
+}

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretFilterFactory.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretFilterFactory.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.runtime.core.secret;
+
+public interface SecretFilterFactory {
+  SecretFilter create(SecretFilterContext context);
+
+  static SecretFilterFactory disabled() {
+    return context -> SecretFilter.allowAll();
+  }
+
+  record SecretFilterContext(long processDefinitionKey, String elementId) {}
+}

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretHandler.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/secret/SecretHandler.java
@@ -20,22 +20,31 @@ import io.camunda.connector.api.error.ConnectorInputException;
 import io.camunda.connector.api.secret.SecretContext;
 import io.camunda.connector.api.secret.SecretProvider;
 import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class SecretHandler {
+
+  private static final Logger LOG = LoggerFactory.getLogger(SecretHandler.class);
 
   protected final SecretProvider secretProvider;
 
   protected SecretReplacer secretReplacer;
 
-  public SecretHandler(final SecretProvider secretProvider) {
+  public SecretHandler(final SecretProvider secretProvider, SecretFilter secretFilter) {
     this.secretProvider = secretProvider;
     secretReplacer =
-        (name, context) ->
-            Optional.ofNullable(secretProvider.getSecret(name, context))
+        (name, context) -> {
+          if (secretFilter.isAllowed(name)) {
+            return Optional.ofNullable(secretProvider.getSecret(name, context))
                 .orElseThrow(
                     () ->
                         new ConnectorInputException(
                             String.format("Secret with name '%s' is not available", name)));
+          }
+          LOG.debug("Secret '{}' not in allow-list — placeholder left unreplaced", name);
+          return null;
+        };
   }
 
   public String replaceSecrets(String input, SecretContext context) {

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/SecretUtilTests.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/SecretUtilTests.java
@@ -22,9 +22,12 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 
+import io.camunda.connector.api.secret.SecretContext;
 import io.camunda.connector.runtime.core.secret.SecretReplacer;
 import io.camunda.connector.runtime.core.secret.SecretUtil;
+import java.util.List;
 import java.util.Map;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
@@ -81,5 +84,16 @@ public class SecretUtilTests {
     SecretReplacer secretReplacer = (name, context) -> secrets.get(name);
     var result = SecretUtil.replaceSecrets(input, null, secretReplacer);
     assertThat(result).isEqualTo(output);
+  }
+
+  @Test
+  void shouldOnlyReplaceAllowListedSecrets() {
+    List<String> allowList = List.of("KEY1", "KEY2");
+    SecretReplacer secretReplacer =
+        (name, context) -> allowList.contains(name) ? secrets.get(name) : null;
+    String content = "Hello {{secrets.KEY1}} and {{secrets.KEY2}} and {{secrets.KEY3}}";
+    SecretContext secretContext = new SecretContext("tenantId", "processId");
+    String replacedContent = SecretUtil.replaceSecrets(content, secretContext, secretReplacer);
+    assertThat(replacedContent).isEqualTo("Hello VALUE1 and VALUE2 and {{secrets.KEY3}}");
   }
 }

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/outbound/AnnotatedOperationTests.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/outbound/AnnotatedOperationTests.java
@@ -31,6 +31,7 @@ import io.camunda.connector.runtime.core.NoOpSecretProvider;
 import io.camunda.connector.runtime.core.TestObjectMapperSupplier;
 import io.camunda.connector.runtime.core.outbound.operation.ConnectorOperations;
 import io.camunda.connector.runtime.core.outbound.operation.OutboundConnectorOperationFunction;
+import io.camunda.connector.runtime.core.secret.SecretFilter;
 import io.camunda.connector.validation.impl.DefaultValidationProvider;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -153,7 +154,12 @@ public class AnnotatedOperationTests {
     when(activatedJob.getCustomHeaders()).thenReturn(customHeaders);
     when(activatedJob.getVariables()).thenReturn(json);
     return new JobHandlerContext(
-        activatedJob, new NoOpSecretProvider(), validationProvider, null, objectMapper);
+        activatedJob,
+        new NoOpSecretProvider(),
+        validationProvider,
+        null,
+        objectMapper,
+        SecretFilter.allowAll());
   }
 
   @Test

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/outbound/JobHandlerContextTest.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/outbound/JobHandlerContextTest.java
@@ -27,13 +27,13 @@ import io.camunda.client.api.response.ActivatedJob;
 import io.camunda.connector.api.error.ConnectorInputException;
 import io.camunda.connector.api.secret.SecretProvider;
 import io.camunda.connector.api.validation.ValidationProvider;
+import io.camunda.connector.runtime.core.secret.SecretFilter;
 import io.camunda.connector.runtime.core.testutil.classexample.TestClass;
 import io.camunda.connector.runtime.core.testutil.classexample.TestClassString;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
@@ -41,10 +41,22 @@ class JobHandlerContextTest {
 
   @Mock private ActivatedJob activatedJob;
   @Mock private SecretProvider secretProvider;
-  @Spy private ObjectMapper objectMapper = new ObjectMapper();
   @Mock private ValidationProvider validationProvider;
 
-  @InjectMocks private JobHandlerContext jobHandlerContext;
+  private final ObjectMapper objectMapper = new ObjectMapper();
+  private JobHandlerContext jobHandlerContext;
+
+  @BeforeEach
+  void setUp() {
+    jobHandlerContext =
+        new JobHandlerContext(
+            activatedJob,
+            secretProvider,
+            validationProvider,
+            null,
+            objectMapper,
+            SecretFilter.allowAll());
+  }
 
   @Test
   void getVariables() {

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/InboundConnectorRuntimeConfiguration.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/InboundConnectorRuntimeConfiguration.java
@@ -52,6 +52,7 @@ import io.micrometer.core.instrument.MeterRegistry;
 import java.time.Duration;
 import java.util.Objects;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.cache.Cache;
@@ -69,7 +70,7 @@ import org.springframework.core.env.Environment;
   ProcessInstanceClientConfiguration.class,
   InboundConnectorRestController.class,
   InboundInstancesRestController.class,
-  GlobalExceptionHandler.class,
+  GlobalExceptionHandler.class
 })
 public class InboundConnectorRuntimeConfiguration {
   @Value("${camunda.connector.inbound.message.ttl:PT1H}")
@@ -184,7 +185,8 @@ public class InboundConnectorRuntimeConfiguration {
 
   @Bean
   public ProcessDefinitionInspector processDefinitionInspector(
-      SearchQueryClient searchQueryClient, CacheManager cacheManager) {
+      SearchQueryClient searchQueryClient,
+      @Qualifier("processDefinitionCacheManager") CacheManager cacheManager) {
     Cache cache =
         Objects.requireNonNull(
             cacheManager.getCache(ProcessDefinitionInspector.PROCESS_DEFINITION_CACHE_NAME),

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/OutboundConnectorRuntimeConfiguration.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/OutboundConnectorRuntimeConfiguration.java
@@ -17,6 +17,7 @@
 package io.camunda.connector.runtime.outbound;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.benmanes.caffeine.cache.Caffeine;
 import io.camunda.client.CamundaClient;
 import io.camunda.client.jobhandling.JobCallbackCommandWrapperFactory;
 import io.camunda.client.jobhandling.JobWorkerManager;
@@ -32,21 +33,30 @@ import io.camunda.connector.runtime.core.document.store.CamundaDocumentStore;
 import io.camunda.connector.runtime.core.document.store.CamundaDocumentStoreImpl;
 import io.camunda.connector.runtime.core.outbound.DefaultOutboundConnectorFactory;
 import io.camunda.connector.runtime.core.outbound.OutboundConnectorFactory;
+import io.camunda.connector.runtime.core.secret.SecretFilterFactory;
 import io.camunda.connector.runtime.core.secret.SecretProviderAggregator;
 import io.camunda.connector.runtime.core.validation.ValidationUtil;
 import io.camunda.connector.runtime.instances.InstanceForwardingConfiguration;
 import io.camunda.connector.runtime.instances.service.OutboundConnectorsService;
 import io.camunda.connector.runtime.outbound.controller.OutboundConnectorsRestController;
+import io.camunda.connector.runtime.outbound.job.ConfigurableSecretFilterFactory;
+import io.camunda.connector.runtime.outbound.job.ConfigurableSecretFilterFactory.SecretFilterMode;
 import io.camunda.connector.runtime.outbound.jobstream.BrokerJobStreamClient;
 import io.camunda.connector.runtime.outbound.lifecycle.OutboundConnectorManager;
+import io.camunda.connector.runtime.outbound.secret.ProcessDefinitionSecretKeyCache;
+import io.camunda.connector.runtime.outbound.secret.SecretKeyCache;
 import java.net.URI;
 import java.util.Arrays;
 import java.util.List;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.caffeine.CaffeineCacheManager;
+import org.springframework.cache.support.NoOpCacheManager;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -134,6 +144,37 @@ public class OutboundConnectorRuntimeConfiguration {
   }
 
   @Bean
+  public CacheManager secretKeyCacheManager(
+      @Value("${camunda.connector.secret-resolver.secret-filter.cache.enabled:true}")
+          boolean cacheEnabled,
+      @Value("${camunda.connector.secret-resolver.secret-filter.cache.max-size:1000}")
+          int cacheMaxSize) {
+    if (!cacheEnabled) {
+      return new NoOpCacheManager();
+    }
+    int boundedMaxSize = cacheMaxSize > 0 ? cacheMaxSize : 1000;
+    CaffeineCacheManager cacheManager =
+        new CaffeineCacheManager(SecretKeyCache.SECRET_KEY_CACHE_NAME);
+    cacheManager.setCaffeine(Caffeine.newBuilder().maximumSize(boundedMaxSize));
+    return cacheManager;
+  }
+
+  @Bean
+  public SecretKeyCache secretKeyCache(
+      CamundaClient camundaClient, @Qualifier("secretKeyCacheManager") CacheManager cacheManager) {
+    return new ProcessDefinitionSecretKeyCache(
+        camundaClient, cacheManager.getCache(SecretKeyCache.SECRET_KEY_CACHE_NAME));
+  }
+
+  @Bean
+  public SecretFilterFactory secretFilterFactory(
+      @Value("${camunda.connector.secret-resolver.secret-filter.mode:DISABLED}")
+          SecretFilterMode secretFilterMode,
+      SecretKeyCache secretKeyCache) {
+    return new ConfigurableSecretFilterFactory(secretFilterMode, secretKeyCache);
+  }
+
+  @Bean
   public OutboundConnectorManager outboundConnectorManager(
       JobWorkerManager jobWorkerManager,
       OutboundConnectorFactory connectorFactory,
@@ -142,7 +183,8 @@ public class OutboundConnectorRuntimeConfiguration {
       ValidationProvider validationProvider,
       MetricsRecorder metricsRecorder,
       DocumentFactory documentFactory,
-      @OutboundConnectorObjectMapper ObjectMapper objectMapper) {
+      @OutboundConnectorObjectMapper ObjectMapper objectMapper,
+      SecretFilterFactory secretFilterFactory) {
     return new OutboundConnectorManager(
         jobWorkerManager,
         connectorFactory,
@@ -151,6 +193,7 @@ public class OutboundConnectorRuntimeConfiguration {
         validationProvider,
         documentFactory,
         objectMapper,
-        metricsRecorder);
+        metricsRecorder,
+        secretFilterFactory);
   }
 }

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/ConfigurableSecretFilterFactory.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/ConfigurableSecretFilterFactory.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.runtime.outbound.job;
+
+import io.camunda.connector.runtime.core.secret.SecretFilter;
+import io.camunda.connector.runtime.core.secret.SecretFilterFactory;
+import io.camunda.connector.runtime.core.secret.SecretFilterFactory.SecretFilterContext;
+import io.camunda.connector.runtime.outbound.secret.SecretKeyCache;
+import io.camunda.connector.runtime.outbound.secret.SecretKeyCache.SecretKeyContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ConfigurableSecretFilterFactory implements SecretFilterFactory {
+  private static final Logger LOG = LoggerFactory.getLogger(ConfigurableSecretFilterFactory.class);
+  private final SecretFilterMode secretFilterMode;
+  private final SecretKeyCache secretKeyCache;
+
+  public ConfigurableSecretFilterFactory(
+      SecretFilterMode secretFilterMode, SecretKeyCache secretKeyCache) {
+    this.secretFilterMode = secretFilterMode;
+    this.secretKeyCache = secretKeyCache;
+  }
+
+  @Override
+  public SecretFilter create(SecretFilterContext context) {
+    return switch (secretFilterMode) {
+      case DISABLED -> SecretFilter.allowAll();
+      case LAX -> enabled(context, false);
+      case STRICT -> enabled(context, true);
+    };
+  }
+
+  private SecretFilter enabled(SecretFilterContext context, boolean strict) {
+    return new LazyLoadingSecretFilter(
+        () -> {
+          try {
+            return secretKeyCache.getSecretKeys(
+                new SecretKeyContext(context.processDefinitionKey(), context.elementId()));
+          } catch (RuntimeException e) {
+            if (strict) {
+              throw new IllegalArgumentException("Error retrieving secret keys", e);
+            } else {
+              LOG.warn(
+                  "Error filtering secrets for element '{}' in process definition key {}), will allow all as secret-filter-mode is LAX",
+                  context.elementId(),
+                  context.processDefinitionKey(),
+                  e);
+              return null;
+            }
+          }
+        });
+  }
+
+  public enum SecretFilterMode {
+    DISABLED,
+    LAX,
+    STRICT
+  }
+}

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/LazyLoadingSecretFilter.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/LazyLoadingSecretFilter.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.runtime.outbound.job;
+
+import io.camunda.connector.runtime.core.secret.SecretFilter;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Supplier;
+
+/**
+ * A {@link SecretFilter} that resolves the allowed secret names on the first {@link
+ * #isAllowed(String)} call rather than at construction time. This defers the BPMN process
+ * definition lookup to the point where secrets are actually being replaced, so that any exception
+ * thrown by the supplier propagates through the normal connector error-handling path and results in
+ * a proper Zeebe {@code failJob} command.
+ *
+ * <p>The supplier is called exactly once per filter instance regardless of outcome. When the
+ * supplier returns {@code null} (LAX mode: lookup failed, fall back to allow-all), all subsequent
+ * calls to {@link #isAllowed(String)} return {@code true} without re-invoking the supplier.
+ */
+public class LazyLoadingSecretFilter implements SecretFilter {
+  private final Supplier<List<String>> secretNamesSupplier;
+
+  private volatile boolean initialized = false;
+  private Set<String> secretNames;
+
+  public LazyLoadingSecretFilter(Supplier<List<String>> secretNamesSupplier) {
+    this.secretNamesSupplier = secretNamesSupplier;
+  }
+
+  @Override
+  public boolean isAllowed(String secretName) {
+    if (!initialized) {
+      synchronized (this) {
+        if (!initialized) {
+          List<String> names = secretNamesSupplier.get();
+          secretNames = names != null ? Set.copyOf(names) : null;
+          initialized = true;
+        }
+      }
+    }
+    if (secretNames != null) {
+      return secretNames.contains(secretName);
+    } else {
+      return true;
+    }
+  }
+}

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/OutboundConnectorExceptionHandler.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/OutboundConnectorExceptionHandler.java
@@ -26,6 +26,7 @@ import io.camunda.connector.api.secret.SecretContext;
 import io.camunda.connector.api.secret.SecretProvider;
 import io.camunda.connector.runtime.core.error.InvalidBackOffDurationException;
 import io.camunda.connector.runtime.core.outbound.ConnectorResult;
+import io.camunda.connector.runtime.core.secret.SecretFilter;
 import io.camunda.connector.runtime.core.secret.SecretUtil;
 import java.time.Duration;
 import java.util.*;
@@ -67,13 +68,16 @@ public class OutboundConnectorExceptionHandler {
   }
 
   public ConnectorResult.ErrorResult manageConnectorJobHandlerException(
-      Exception e, ActivatedJob job, Duration retryBackoffDuration) {
+      Exception e, ActivatedJob job, Duration retryBackoffDuration, SecretFilter secretFilter) {
     List<String> secrets;
     try {
+      var allowedKeys =
+          SecretUtil.retrieveSecretKeysInInput(job.getVariables()).stream()
+              .filter(secretFilter::isAllowed)
+              .toList();
       secrets =
           this.secretProvider.fetchAll(
-              SecretUtil.retrieveSecretKeysInInput(job.getVariables()),
-              new SecretContext(job.getTenantId(), job.getBpmnProcessId()));
+              allowedKeys, new SecretContext(job.getTenantId(), job.getBpmnProcessId()));
     } catch (Exception ex) {
       LOGGER.error(
           "Initial error for job: {} for tenant: {} can't be displayed because fetching secrets failed: {}",
@@ -166,11 +170,15 @@ public class OutboundConnectorExceptionHandler {
     return handleSDKException(job, newException, retries, errorCode, retryBackoff);
   }
 
-  public ConnectorResult.ErrorResult handleFinalResultException(Exception ex, ActivatedJob job) {
+  public ConnectorResult.ErrorResult handleFinalResultException(
+      Exception ex, ActivatedJob job, SecretFilter secretFilter) {
+    var allowedKeys =
+        SecretUtil.retrieveSecretKeysInInput(job.getVariables()).stream()
+            .filter(secretFilter::isAllowed)
+            .toList();
     List<String> secrets =
         this.secretProvider.fetchAll(
-            SecretUtil.retrieveSecretKeysInInput(job.getVariables()),
-            new SecretContext(job.getTenantId(), job.getBpmnProcessId()));
+            allowedKeys, new SecretContext(job.getTenantId(), job.getBpmnProcessId()));
     Exception newException = new Exception(hideSecretsFromMessage(ex.getMessage(), secrets), ex);
     LOGGER.error(
         "Exception while processing job: {} for tenant: {}, message: {}",

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/SpringConnectorJobHandler.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/SpringConnectorJobHandler.java
@@ -58,6 +58,9 @@ import io.camunda.connector.runtime.core.error.JobError;
 import io.camunda.connector.runtime.core.outbound.ConnectorResult;
 import io.camunda.connector.runtime.core.outbound.ErrorExpressionJobContext;
 import io.camunda.connector.runtime.core.outbound.JobHandlerContext;
+import io.camunda.connector.runtime.core.secret.SecretFilter;
+import io.camunda.connector.runtime.core.secret.SecretFilterFactory;
+import io.camunda.connector.runtime.core.secret.SecretFilterFactory.SecretFilterContext;
 import io.camunda.connector.runtime.core.secret.SecretProviderAggregator;
 import io.camunda.connector.runtime.core.secret.SecretProviderDiscovery;
 import io.camunda.connector.runtime.metrics.ConnectorMetrics;
@@ -90,6 +93,7 @@ public class SpringConnectorJobHandler implements JobHandler {
   private final ValidationProvider validationProvider;
   private final DocumentFactory documentFactory;
   private final ObjectMapper objectMapper;
+  private final SecretFilterFactory secretFilterFactory;
 
   public SpringConnectorJobHandler(
       MetricsRecorder outboundMetrics,
@@ -98,12 +102,14 @@ public class SpringConnectorJobHandler implements JobHandler {
       ValidationProvider validationProvider,
       DocumentFactory documentFactory,
       ObjectMapper objectMapper,
-      OutboundConnectorFunction connectorFunction) {
+      OutboundConnectorFunction connectorFunction,
+      SecretFilterFactory secretFilterFactory) {
     this.call = connectorFunction;
     this.secretProvider = secretProviderAggregator;
     this.validationProvider = validationProvider;
     this.documentFactory = documentFactory;
     this.objectMapper = objectMapper;
+    this.secretFilterFactory = secretFilterFactory;
     this.outboundConnectorExceptionHandler =
         new OutboundConnectorExceptionHandler(getSecretProvider());
     this.connectorResultHandler = new ConnectorResultHandler(objectMapper);
@@ -152,14 +158,23 @@ public class SpringConnectorJobHandler implements JobHandler {
         job.getKey(),
         job.getType(),
         job.getTenantId());
+    var secretFilter =
+        secretFilterFactory.create(
+            new SecretFilterContext(job.getProcessDefinitionKey(), job.getElementId()));
     var context =
         new JobHandlerContext(
-            job, getSecretProvider(), validationProvider, documentFactory, objectMapper);
-    ConnectorResult result = getConnectorResult(job, context);
-    processFinalResult(client, job, context, result, counterMetricsContext);
+            job,
+            getSecretProvider(),
+            validationProvider,
+            documentFactory,
+            objectMapper,
+            secretFilter);
+    ConnectorResult result = getConnectorResult(job, context, secretFilter);
+    processFinalResult(client, job, context, result, counterMetricsContext, secretFilter);
   }
 
-  private ConnectorResult getConnectorResult(ActivatedJob job, OutboundConnectorContext context) {
+  private ConnectorResult getConnectorResult(
+      ActivatedJob job, OutboundConnectorContext context, SecretFilter secretFilter) {
     Duration retryBackoff = null;
     try {
       retryBackoff = getBackoffDuration(job);
@@ -183,7 +198,7 @@ public class SpringConnectorJobHandler implements JobHandler {
       return new ConnectorResult.SuccessResult(connectorResponse, responseVariables);
     } catch (Exception e) {
       return outboundConnectorExceptionHandler.manageConnectorJobHandlerException(
-          e, job, retryBackoff);
+          e, job, retryBackoff, secretFilter);
     }
   }
 
@@ -202,7 +217,8 @@ public class SpringConnectorJobHandler implements JobHandler {
       ActivatedJob job,
       OutboundConnectorContext context,
       ConnectorResult finalResult,
-      CounterMetricsContext counterMetricsContext) {
+      CounterMetricsContext counterMetricsContext,
+      SecretFilter secretFilter) {
     try {
       Optional<ConnectorError> optionalConnectorError =
           connectorResultHandler.examineErrorExpression(
@@ -219,7 +235,8 @@ public class SpringConnectorJobHandler implements JobHandler {
           failJob(
               client,
               job,
-              this.outboundConnectorExceptionHandler.handleFinalResultException(ex, job),
+              this.outboundConnectorExceptionHandler.handleFinalResultException(
+                  ex, job, secretFilter),
               counterMetricsContext);
       notifyFailureOnCommandOutcome(
           failJobRequest,

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/lifecycle/OutboundConnectorManager.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/lifecycle/OutboundConnectorManager.java
@@ -32,6 +32,7 @@ import io.camunda.connector.api.outbound.OutboundConnectorFunction;
 import io.camunda.connector.api.validation.ValidationProvider;
 import io.camunda.connector.runtime.core.config.OutboundConnectorConfiguration;
 import io.camunda.connector.runtime.core.outbound.OutboundConnectorFactory;
+import io.camunda.connector.runtime.core.secret.SecretFilterFactory;
 import io.camunda.connector.runtime.core.secret.SecretProviderAggregator;
 import io.camunda.connector.runtime.outbound.job.SpringConnectorJobHandler;
 import java.time.Duration;
@@ -52,6 +53,7 @@ public class OutboundConnectorManager implements CamundaClientLifecycleAware {
   private final ObjectMapper objectMapper;
   private final DocumentFactory documentFactory;
   private final MetricsRecorder metricsRecorder;
+  private final SecretFilterFactory secretFilterFactory;
 
   public OutboundConnectorManager(
       JobWorkerManager jobWorkerManager,
@@ -61,7 +63,8 @@ public class OutboundConnectorManager implements CamundaClientLifecycleAware {
       ValidationProvider validationProvider,
       DocumentFactory documentFactory,
       ObjectMapper objectMapper,
-      MetricsRecorder metricsRecorder) {
+      MetricsRecorder metricsRecorder,
+      SecretFilterFactory secretFilterFactory) {
     this.jobWorkerManager = jobWorkerManager;
     this.connectorFactory = connectorFactory;
     this.jobCallbackCommandWrapperFactory = jobCallbackCommandWrapperFactory;
@@ -70,6 +73,7 @@ public class OutboundConnectorManager implements CamundaClientLifecycleAware {
     this.documentFactory = documentFactory;
     this.objectMapper = objectMapper;
     this.metricsRecorder = metricsRecorder;
+    this.secretFilterFactory = secretFilterFactory;
   }
 
   @Override
@@ -115,7 +119,8 @@ public class OutboundConnectorManager implements CamundaClientLifecycleAware {
                 validationProvider,
                 documentFactory,
                 objectMapper,
-                connectorFunction);
+                connectorFunction,
+                secretFilterFactory);
     jobWorkerManager.createJobWorker(
         client, new ManagedJobWorker(jobWorkerValue, jobHandlerFactory), this);
   }

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/secret/ProcessDefinitionSecretKeyCache.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/secret/ProcessDefinitionSecretKeyCache.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.runtime.outbound.secret;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.connector.api.inbound.ElementTemplateDetails;
+import io.camunda.connector.runtime.core.secret.SecretUtil;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.model.bpmn.instance.BaseElement;
+import io.camunda.zeebe.model.bpmn.instance.BusinessRuleTask;
+import io.camunda.zeebe.model.bpmn.instance.FlowElement;
+import io.camunda.zeebe.model.bpmn.instance.Process;
+import io.camunda.zeebe.model.bpmn.instance.ScriptTask;
+import io.camunda.zeebe.model.bpmn.instance.SendTask;
+import io.camunda.zeebe.model.bpmn.instance.ServiceTask;
+import io.camunda.zeebe.model.bpmn.instance.SubProcess;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeInput;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeIoMapping;
+import java.io.ByteArrayInputStream;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.cache.Cache;
+
+public class ProcessDefinitionSecretKeyCache implements SecretKeyCache {
+  private static final Logger LOG = LoggerFactory.getLogger(ProcessDefinitionSecretKeyCache.class);
+  private static final List<Class<? extends BaseElement>> OUTBOUND_ELIGIBLE_TYPES =
+      new ArrayList<>();
+
+  static {
+    OUTBOUND_ELIGIBLE_TYPES.add(ServiceTask.class);
+    OUTBOUND_ELIGIBLE_TYPES.add(SendTask.class);
+    OUTBOUND_ELIGIBLE_TYPES.add(ScriptTask.class);
+    OUTBOUND_ELIGIBLE_TYPES.add(BusinessRuleTask.class);
+  }
+
+  private final CamundaClient camundaClient;
+  private final Cache cache;
+
+  public ProcessDefinitionSecretKeyCache(CamundaClient camundaClient, Cache cache) {
+    this.camundaClient = camundaClient;
+    this.cache = cache;
+  }
+
+  @Override
+  public List<String> getSecretKeys(SecretKeyContext secretKeyContext) {
+    return cache
+        .get(
+            secretKeyContext.processDefinitionKey(),
+            () -> fetchSecretKeysByElementIds(secretKeyContext.processDefinitionKey()))
+        .getOrDefault(secretKeyContext.elementId(), Collections.emptyList());
+  }
+
+  private Map<String, List<String>> fetchSecretKeysByElementIds(long processDefinitionKey) {
+    String bpmnXml =
+        camundaClient.newProcessDefinitionGetXmlRequest(processDefinitionKey).execute();
+
+    BpmnModelInstance modelInstance =
+        Bpmn.readModelFromStream(new ByteArrayInputStream(bpmnXml.getBytes()));
+    var processes =
+        modelInstance.getDefinitions().getChildElementsByType(Process.class).stream().toList();
+
+    return processes.stream()
+        .flatMap(process -> inspectBpmnProcess(process, processDefinitionKey).entrySet().stream())
+        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+  }
+
+  private Map<String, List<String>> inspectBpmnProcess(Process process, long processDefinitionKey) {
+    Collection<BaseElement> outboundEligibleElements =
+        retrieveOutboundEligibleElementsFromProcess(process);
+    if (outboundEligibleElements.isEmpty()) {
+      LOG.debug(
+          "No connector elements found in process definition with key {}", processDefinitionKey);
+      return Collections.emptyMap();
+    }
+
+    Map<String, List<String>> discoveredOutboundConnectors = new HashMap<>();
+    for (BaseElement element : outboundEligibleElements) {
+      var inputs = findElementInput(element);
+      var definedSecrets = extractSecrets(inputs);
+      discoveredOutboundConnectors.put(element.getId(), definedSecrets);
+    }
+    return discoveredOutboundConnectors;
+  }
+
+  private List<String> extractSecrets(List<ZeebeInput> inputs) {
+    return inputs.stream()
+        .flatMap(input -> SecretUtil.retrieveSecretKeysInInput(input.getSource()).stream())
+        .map(String::trim)
+        .distinct()
+        .toList();
+  }
+
+  private List<ZeebeInput> findElementInput(BaseElement element) {
+    ZeebeIoMapping singleExtensionElement = element.getSingleExtensionElement(ZeebeIoMapping.class);
+    if (singleExtensionElement == null) {
+      return Collections.emptyList();
+    }
+    return singleExtensionElement.getInputs().stream().toList();
+  }
+
+  private Collection<BaseElement> retrieveOutboundEligibleElementsFromProcess(
+      final Process process) {
+    // process is root element in graph
+    Collection<FlowElement> buffer = new HashSet<>();
+    Collection<FlowElement> allElements = collectFlowElements(process.getFlowElements(), buffer);
+    Collection<BaseElement> outboundEligibleElements = new HashSet<>();
+    for (FlowElement element : allElements) {
+      OUTBOUND_ELIGIBLE_TYPES.forEach(
+          iet -> {
+            if (iet.isInstance(element) && isElementTemplate(element)) {
+              outboundEligibleElements.add(element);
+            }
+          });
+    }
+    return outboundEligibleElements;
+  }
+
+  // pre-existing, move to util from ProcessDefinitionInspector
+  private Collection<FlowElement> collectFlowElements(
+      final Collection<FlowElement> processFlowElements, final Collection<FlowElement> buffer) {
+    for (FlowElement element : processFlowElements) {
+      // if we detect a subprocess, we have to expand it
+      // its building blocks to identify where are connectors
+      if (element instanceof SubProcess subprocess) {
+        buffer.addAll(retrieveEligibleElementsFromSubprocess(subprocess));
+        continue;
+      }
+      buffer.add(element);
+    }
+    return buffer;
+  }
+
+  // pre-existing, move to util from ProcessDefinitionInspector
+  private Collection<FlowElement> retrieveEligibleElementsFromSubprocess(
+      final SubProcess subprocess) {
+    // Subprocesses can contain other subprocesses
+    Collection<FlowElement> buffer = new HashSet<>();
+    Collection<FlowElement> processFlowElements = subprocess.getFlowElements();
+    return collectFlowElements(processFlowElements, buffer);
+  }
+
+  private boolean isElementTemplate(FlowElement element) {
+    ElementTemplateDetails elementTemplateDetails = getElementTemplateDetails(element);
+    return elementTemplateDetails.id() != null;
+  }
+
+  // pre-existing, move to util from ProcessDefinitionInspector
+  private static ElementTemplateDetails getElementTemplateDetails(BaseElement element) {
+    final String NAMESPACE = "http://camunda.org/schema/zeebe/1.0";
+
+    final String TEMPLATE_ID = "modelerTemplate";
+    final String TEMPLATE_VERSION = "modelerTemplateVersion";
+    final String TEMPLATE_ICON = "modelerTemplateIcon";
+
+    return new ElementTemplateDetails(
+        element.getAttributeValueNs(NAMESPACE, TEMPLATE_ID),
+        element.getAttributeValueNs(NAMESPACE, TEMPLATE_VERSION),
+        element.getAttributeValueNs(NAMESPACE, TEMPLATE_ICON));
+  }
+}

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/secret/SecretKeyCache.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/secret/SecretKeyCache.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.runtime.outbound.secret;
+
+import java.util.List;
+
+public interface SecretKeyCache {
+  String SECRET_KEY_CACHE_NAME = SecretKeyCache.class.getName();
+
+  List<String> getSecretKeys(SecretKeyContext secretKeyContext);
+
+  record SecretKeyContext(long processDefinitionKey, String elementId) {}
+}

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/OutboundConnectorRuntimeConfigurationTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/OutboundConnectorRuntimeConfigurationTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.runtime.outbound;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+import io.camunda.connector.runtime.outbound.secret.SecretKeyCache;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+import org.springframework.cache.Cache;
+import org.springframework.cache.caffeine.CaffeineCacheManager;
+import org.springframework.cache.support.NoOpCacheManager;
+
+class OutboundConnectorRuntimeConfigurationTest {
+
+  private final OutboundConnectorRuntimeConfiguration configuration =
+      new OutboundConnectorRuntimeConfiguration();
+
+  @Test
+  void secretKeyCacheManager_whenEnabled_returnsCaffeineCacheManager() {
+    var cacheManager = configuration.secretKeyCacheManager(true, 1000);
+
+    assertInstanceOf(CaffeineCacheManager.class, cacheManager);
+  }
+
+  @Test
+  void secretKeyCacheManager_whenDisabled_returnsNoOpCacheManager() {
+    var cacheManager = configuration.secretKeyCacheManager(false, 1000);
+
+    assertInstanceOf(NoOpCacheManager.class, cacheManager);
+  }
+
+  @Test
+  void secretKeyCacheManager_whenDisabled_cacheNeverStoresValues() throws Exception {
+    var cacheManager = configuration.secretKeyCacheManager(false, 1000);
+    Cache cache = cacheManager.getCache(SecretKeyCache.SECRET_KEY_CACHE_NAME);
+
+    var callCount = new AtomicInteger(0);
+    cache.get("key", callCount::incrementAndGet);
+    cache.get("key", callCount::incrementAndGet);
+
+    assertEquals(2, callCount.get(), "NoOp cache must call loader on every get");
+  }
+
+  @Test
+  void secretKeyCacheManager_whenMaxSizeIsZero_clampedToDefault() {
+    var cacheManager = configuration.secretKeyCacheManager(true, 0);
+
+    assertInstanceOf(CaffeineCacheManager.class, cacheManager);
+  }
+
+  @Test
+  void secretKeyCacheManager_whenMaxSizeIsNegative_clampedToDefault() {
+    var cacheManager = configuration.secretKeyCacheManager(true, -1);
+
+    assertInstanceOf(CaffeineCacheManager.class, cacheManager);
+  }
+}

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/job/ConfigurableSecretFilterFactoryTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/job/ConfigurableSecretFilterFactoryTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.runtime.outbound.job;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import io.camunda.connector.runtime.core.secret.SecretFilterFactory.SecretFilterContext;
+import io.camunda.connector.runtime.outbound.job.ConfigurableSecretFilterFactory.SecretFilterMode;
+import io.camunda.connector.runtime.outbound.secret.SecretKeyCache;
+import io.camunda.connector.runtime.outbound.secret.SecretKeyCache.SecretKeyContext;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ConfigurableSecretFilterFactoryTest {
+
+  private static final long PROCESS_DEF_KEY = 42L;
+  private static final String ELEMENT_ID = "service-task-1";
+  private static final SecretFilterContext CONTEXT =
+      new SecretFilterContext(PROCESS_DEF_KEY, ELEMENT_ID);
+  private static final SecretKeyContext SECRET_KEY_CONTEXT =
+      new SecretKeyContext(PROCESS_DEF_KEY, ELEMENT_ID);
+
+  @Mock private SecretKeyCache secretKeyCache;
+
+  @Test
+  void create_disabled_allowsAllSecrets_withoutCacheInteraction() {
+    var factory = new ConfigurableSecretFilterFactory(SecretFilterMode.DISABLED, secretKeyCache);
+
+    var filter = factory.create(CONTEXT);
+
+    assertThat(filter.isAllowed("ANY_SECRET")).isTrue();
+    assertThat(filter.isAllowed("ANOTHER_SECRET")).isTrue();
+    verifyNoInteractions(secretKeyCache);
+  }
+
+  @Test
+  void create_lax_withSecretKeys_restrictesFilterToList() {
+    when(secretKeyCache.getSecretKeys(SECRET_KEY_CONTEXT)).thenReturn(List.of("API_KEY", "TOKEN"));
+    var factory = new ConfigurableSecretFilterFactory(SecretFilterMode.LAX, secretKeyCache);
+
+    var filter = factory.create(CONTEXT);
+
+    assertThat(filter.isAllowed("API_KEY")).isTrue();
+    assertThat(filter.isAllowed("TOKEN")).isTrue();
+    assertThat(filter.isAllowed("UNLISTED_SECRET")).isFalse();
+  }
+
+  @Test
+  void create_lax_whenCacheThrows_allowsAll() {
+    when(secretKeyCache.getSecretKeys(any())).thenThrow(new RuntimeException("fetch failed"));
+    var factory = new ConfigurableSecretFilterFactory(SecretFilterMode.LAX, secretKeyCache);
+
+    var filter = factory.create(CONTEXT);
+
+    assertThat(filter.isAllowed("ANY_SECRET")).isTrue();
+  }
+
+  @Test
+  void create_strict_withSecretKeys_restrictesFilterToList() {
+    when(secretKeyCache.getSecretKeys(SECRET_KEY_CONTEXT)).thenReturn(List.of("API_KEY"));
+    var factory = new ConfigurableSecretFilterFactory(SecretFilterMode.STRICT, secretKeyCache);
+
+    var filter = factory.create(CONTEXT);
+
+    assertThat(filter.isAllowed("API_KEY")).isTrue();
+    assertThat(filter.isAllowed("UNLISTED_SECRET")).isFalse();
+  }
+
+  @Test
+  void create_strict_whenCacheThrows_throwsIllegalArgumentException() {
+    when(secretKeyCache.getSecretKeys(any())).thenThrow(new RuntimeException("fetch failed"));
+    var factory = new ConfigurableSecretFilterFactory(SecretFilterMode.STRICT, secretKeyCache);
+
+    var filter = factory.create(CONTEXT);
+
+    assertThatThrownBy(() -> filter.isAllowed("ANY_SECRET"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Error retrieving secret keys");
+  }
+}

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/job/LazyLoadingSecretFilterTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/job/LazyLoadingSecretFilterTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.runtime.outbound.job;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+
+class LazyLoadingSecretFilterTest {
+
+  @Test
+  void isAllowed_withAllowList_permitsListedSecret() {
+    var filter = new LazyLoadingSecretFilter(() -> List.of("MY_SECRET", "OTHER_SECRET"));
+
+    assertTrue(filter.isAllowed("MY_SECRET"));
+    assertTrue(filter.isAllowed("OTHER_SECRET"));
+  }
+
+  @Test
+  void isAllowed_withAllowList_deniesUnlistedSecret() {
+    var filter = new LazyLoadingSecretFilter(() -> List.of("MY_SECRET"));
+
+    assertFalse(filter.isAllowed("UNLISTED_SECRET"));
+  }
+
+  @Test
+  void isAllowed_withNullSupplierResult_allowsAll() {
+    var filter = new LazyLoadingSecretFilter(() -> null);
+
+    assertTrue(filter.isAllowed("ANY_SECRET"));
+    assertTrue(filter.isAllowed("ANOTHER_SECRET"));
+  }
+
+  @Test
+  void isAllowed_supplierCalledExactlyOnce() {
+    var callCount = new AtomicInteger(0);
+    var filter =
+        new LazyLoadingSecretFilter(
+            () -> {
+              callCount.incrementAndGet();
+              return List.of("SECRET");
+            });
+
+    filter.isAllowed("SECRET");
+    filter.isAllowed("SECRET");
+    filter.isAllowed("OTHER");
+
+    assertTrue(callCount.get() == 1, "Supplier must be called exactly once");
+  }
+
+  @Test
+  void isAllowed_nullSupplierResultCached_supplierNotReinvoked() {
+    var callCount = new AtomicInteger(0);
+    var filter =
+        new LazyLoadingSecretFilter(
+            () -> {
+              callCount.incrementAndGet();
+              return null;
+            });
+
+    filter.isAllowed("ANY");
+    filter.isAllowed("ANY");
+
+    assertTrue(callCount.get() == 1, "Supplier must be called exactly once even when null");
+  }
+}

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/job/SpringConnectorJobHandlerTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/job/SpringConnectorJobHandlerTest.java
@@ -60,6 +60,7 @@ import io.camunda.connector.runtime.JobBuilder;
 import io.camunda.connector.runtime.TestObjectMapperSupplier;
 import io.camunda.connector.runtime.TestValidation;
 import io.camunda.connector.runtime.core.Keywords;
+import io.camunda.connector.runtime.core.secret.SecretFilter;
 import io.camunda.connector.runtime.core.secret.SecretProviderAggregator;
 import io.camunda.connector.runtime.secret.FooBarSecretProvider;
 import io.camunda.connector.validation.impl.DefaultValidationProvider;
@@ -126,7 +127,8 @@ class SpringConnectorJobHandlerTest {
         new DefaultValidationProvider(),
         mock(DocumentFactory.class),
         TestObjectMapperSupplier.INSTANCE,
-        call);
+        call,
+        job -> SecretFilter.allowAll());
   }
 
   private SpringConnectorJobHandler newConnectorJobHandler(
@@ -140,7 +142,8 @@ class SpringConnectorJobHandlerTest {
         new DefaultValidationProvider(),
         mock(DocumentFactory.class),
         TestObjectMapperSupplier.INSTANCE,
-        call);
+        call,
+        job -> SecretFilter.allowAll());
   }
 
   @Nested

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/secret/ProcessDefinitionSecretKeyCacheTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/secret/ProcessDefinitionSecretKeyCacheTest.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.runtime.outbound.secret;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.when;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.fetch.ProcessDefinitionGetXmlRequest;
+import io.camunda.connector.runtime.outbound.secret.SecretKeyCache.SecretKeyContext;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.Callable;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.cache.Cache;
+
+@ExtendWith(MockitoExtension.class)
+class ProcessDefinitionSecretKeyCacheTest {
+
+  private static final long PROCESS_DEF_KEY = 1L;
+
+  @Mock private CamundaClient camundaClient;
+  @Mock private ProcessDefinitionGetXmlRequest xmlRequest;
+  @Mock private Cache cache;
+
+  private ProcessDefinitionSecretKeyCache secretKeyCache;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    secretKeyCache = new ProcessDefinitionSecretKeyCache(camundaClient, cache);
+    when(camundaClient.newProcessDefinitionGetXmlRequest(anyLong())).thenReturn(xmlRequest);
+    when(cache.get(anyLong(), any(Callable.class)))
+        .thenAnswer(
+            invocation -> {
+              Callable<?> loader = invocation.getArgument(1);
+              return loader.call();
+            });
+  }
+
+  @Test
+  void getSecretKeys_singleTaskWithSecrets_returnsExtractedKeys() throws IOException {
+    when(xmlRequest.execute()).thenReturn(loadBpmn("outbound-with-secrets.bpmn"));
+
+    var keys =
+        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "service-task-1"));
+
+    assertThat(keys).containsExactlyInAnyOrder("API_KEY", "MY_TOKEN");
+  }
+
+  @Test
+  void getSecretKeys_multipleTasksWithSecrets_returnsOnlyKeysForRequestedElement()
+      throws IOException {
+    when(xmlRequest.execute()).thenReturn(loadBpmn("outbound-multiple-tasks-with-secrets.bpmn"));
+
+    var alphaKeys =
+        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "task-alpha"));
+    var betaKeys = secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "task-beta"));
+
+    assertThat(alphaKeys).containsExactly("SECRET_ALPHA");
+    assertThat(betaKeys).containsExactlyInAnyOrder("SECRET_BETA", "SECRET_GAMMA");
+  }
+
+  @Test
+  void getSecretKeys_taskWithNoSecrets_returnsEmptyList() throws IOException {
+    when(xmlRequest.execute()).thenReturn(loadBpmn("outbound-no-secrets.bpmn"));
+
+    var keys =
+        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "no-secrets-task"));
+
+    assertThat(keys).isEmpty();
+  }
+
+  @Test
+  void getSecretKeys_taskWithoutTemplate_excluded_returnsEmptyList() throws IOException {
+    when(xmlRequest.execute()).thenReturn(loadBpmn("outbound-no-template.bpmn"));
+
+    var keys = secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "plain-task"));
+
+    assertThat(keys).isEmpty();
+  }
+
+  @Test
+  void getSecretKeys_unknownElementId_returnsEmptyList() throws IOException {
+    when(xmlRequest.execute()).thenReturn(loadBpmn("outbound-with-secrets.bpmn"));
+
+    var keys =
+        secretKeyCache.getSecretKeys(new SecretKeyContext(PROCESS_DEF_KEY, "nonexistent-task"));
+
+    assertThat(keys).isEmpty();
+  }
+
+  private String loadBpmn(String fileName) throws IOException {
+    try (var stream = getClass().getClassLoader().getResourceAsStream("bpmn/" + fileName)) {
+      if (stream == null) {
+        throw new IllegalArgumentException("BPMN resource not found: bpmn/" + fileName);
+      }
+      return new String(stream.readAllBytes(), StandardCharsets.UTF_8);
+    }
+  }
+}

--- a/connector-runtime/connector-runtime-spring/src/test/resources/bpmn/outbound-multiple-tasks-with-secrets.bpmn
+++ b/connector-runtime/connector-runtime-spring/src/test/resources/bpmn/outbound-multiple-tasks-with-secrets.bpmn
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                  xmlns:zeebe="http://camunda.org/schema/zeebe/1.0"
+                  id="Definitions_multi_outbound"
+                  targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="multi-outbound-with-secrets" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_1" sourceRef="StartEvent_1" targetRef="task-alpha"/>
+    <bpmn:serviceTask id="task-alpha" name="Task Alpha"
+                      zeebe:modelerTemplate="io.camunda.connectors.A">
+      <bpmn:extensionElements>
+        <zeebe:ioMapping>
+          <zeebe:input source="{{secrets.SECRET_ALPHA}}" target="alphaKey"/>
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1</bpmn:incoming>
+      <bpmn:outgoing>Flow_2</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="Flow_2" sourceRef="task-alpha" targetRef="task-beta"/>
+    <bpmn:serviceTask id="task-beta" name="Task Beta"
+                      zeebe:modelerTemplate="io.camunda.connectors.B">
+      <bpmn:extensionElements>
+        <zeebe:ioMapping>
+          <zeebe:input source="{{secrets.SECRET_BETA}}" target="betaKey"/>
+          <zeebe:input source="{{secrets.SECRET_GAMMA}}" target="gammaKey"/>
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_2</bpmn:incoming>
+      <bpmn:outgoing>Flow_3</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="Flow_3" sourceRef="task-beta" targetRef="EndEvent_1"/>
+    <bpmn:endEvent id="EndEvent_1">
+      <bpmn:incoming>Flow_3</bpmn:incoming>
+    </bpmn:endEvent>
+  </bpmn:process>
+</bpmn:definitions>

--- a/connector-runtime/connector-runtime-spring/src/test/resources/bpmn/outbound-no-secrets.bpmn
+++ b/connector-runtime/connector-runtime-spring/src/test/resources/bpmn/outbound-no-secrets.bpmn
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                  xmlns:zeebe="http://camunda.org/schema/zeebe/1.0"
+                  id="Definitions_no_secrets"
+                  targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="outbound-no-secrets" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_1" sourceRef="StartEvent_1" targetRef="no-secrets-task"/>
+    <bpmn:serviceTask id="no-secrets-task" name="No Secrets Task"
+                      zeebe:modelerTemplate="io.camunda.connectors.NoSecrets">
+      <bpmn:extensionElements>
+        <zeebe:ioMapping>
+          <zeebe:input source="https://example.com" target="url"/>
+          <zeebe:input source="POST" target="method"/>
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1</bpmn:incoming>
+      <bpmn:outgoing>Flow_2</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="Flow_2" sourceRef="no-secrets-task" targetRef="EndEvent_1"/>
+    <bpmn:endEvent id="EndEvent_1">
+      <bpmn:incoming>Flow_2</bpmn:incoming>
+    </bpmn:endEvent>
+  </bpmn:process>
+</bpmn:definitions>

--- a/connector-runtime/connector-runtime-spring/src/test/resources/bpmn/outbound-no-template.bpmn
+++ b/connector-runtime/connector-runtime-spring/src/test/resources/bpmn/outbound-no-template.bpmn
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                  xmlns:zeebe="http://camunda.org/schema/zeebe/1.0"
+                  id="Definitions_no_template"
+                  targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="outbound-no-template" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_1" sourceRef="StartEvent_1" targetRef="plain-task"/>
+    <bpmn:serviceTask id="plain-task" name="Plain Task">
+      <bpmn:extensionElements>
+        <zeebe:ioMapping>
+          <zeebe:input source="{{secrets.SECRET_X}}" target="x"/>
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1</bpmn:incoming>
+      <bpmn:outgoing>Flow_2</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="Flow_2" sourceRef="plain-task" targetRef="EndEvent_1"/>
+    <bpmn:endEvent id="EndEvent_1">
+      <bpmn:incoming>Flow_2</bpmn:incoming>
+    </bpmn:endEvent>
+  </bpmn:process>
+</bpmn:definitions>

--- a/connector-runtime/connector-runtime-spring/src/test/resources/bpmn/outbound-task-types.bpmn
+++ b/connector-runtime/connector-runtime-spring/src/test/resources/bpmn/outbound-task-types.bpmn
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                  xmlns:zeebe="http://camunda.org/schema/zeebe/1.0"
+                  id="Definitions_task_types"
+                  targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="outbound-task-types" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_1" sourceRef="StartEvent_1" targetRef="send-task"/>
+    <bpmn:sendTask id="send-task" name="Send Task"
+                   zeebe:modelerTemplate="io.camunda.connectors.SendTask">
+      <bpmn:extensionElements>
+        <zeebe:ioMapping>
+          <zeebe:input source="{{secrets.SEND_SECRET}}" target="key"/>
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1</bpmn:incoming>
+      <bpmn:outgoing>Flow_2</bpmn:outgoing>
+    </bpmn:sendTask>
+    <bpmn:sequenceFlow id="Flow_2" sourceRef="send-task" targetRef="script-task"/>
+    <bpmn:scriptTask id="script-task" name="Script Task"
+                     zeebe:modelerTemplate="io.camunda.connectors.ScriptTask">
+      <bpmn:extensionElements>
+        <zeebe:ioMapping>
+          <zeebe:input source="{{secrets.SCRIPT_SECRET}}" target="key"/>
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_2</bpmn:incoming>
+      <bpmn:outgoing>Flow_3</bpmn:outgoing>
+    </bpmn:scriptTask>
+    <bpmn:sequenceFlow id="Flow_3" sourceRef="script-task" targetRef="business-rule-task"/>
+    <bpmn:businessRuleTask id="business-rule-task" name="Business Rule Task"
+                           zeebe:modelerTemplate="io.camunda.connectors.BusinessRuleTask">
+      <bpmn:extensionElements>
+        <zeebe:ioMapping>
+          <zeebe:input source="{{secrets.BRT_SECRET}}" target="key"/>
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_3</bpmn:incoming>
+      <bpmn:outgoing>Flow_4</bpmn:outgoing>
+    </bpmn:businessRuleTask>
+    <bpmn:sequenceFlow id="Flow_4" sourceRef="business-rule-task" targetRef="EndEvent_1"/>
+    <bpmn:endEvent id="EndEvent_1">
+      <bpmn:incoming>Flow_4</bpmn:incoming>
+    </bpmn:endEvent>
+  </bpmn:process>
+</bpmn:definitions>

--- a/connector-runtime/connector-runtime-spring/src/test/resources/bpmn/outbound-with-secrets.bpmn
+++ b/connector-runtime/connector-runtime-spring/src/test/resources/bpmn/outbound-with-secrets.bpmn
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                  xmlns:zeebe="http://camunda.org/schema/zeebe/1.0"
+                  id="Definitions_outbound_secrets"
+                  targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="outbound-with-secrets" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_1" sourceRef="StartEvent_1" targetRef="service-task-1"/>
+    <bpmn:serviceTask id="service-task-1" name="HTTP Task"
+                      zeebe:modelerTemplate="io.camunda.connectors.HttpJson.v2">
+      <bpmn:extensionElements>
+        <zeebe:ioMapping>
+          <zeebe:input source="{{secrets.API_KEY}}" target="apiKey"/>
+          <zeebe:input source="secrets.MY_TOKEN" target="token"/>
+          <zeebe:input source="https://example.com" target="url"/>
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1</bpmn:incoming>
+      <bpmn:outgoing>Flow_2</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="Flow_2" sourceRef="service-task-1" targetRef="EndEvent_1"/>
+    <bpmn:endEvent id="EndEvent_1">
+      <bpmn:incoming>Flow_2</bpmn:incoming>
+    </bpmn:endEvent>
+  </bpmn:process>
+</bpmn:definitions>

--- a/connector-runtime/connector-runtime-test/src/main/java/io/camunda/connector/runtime/test/inbound/InboundConnectorContextBuilder.java
+++ b/connector-runtime/connector-runtime-test/src/main/java/io/camunda/connector/runtime/test/inbound/InboundConnectorContextBuilder.java
@@ -40,6 +40,7 @@ import io.camunda.connector.runtime.core.inbound.InboundConnectorManagementConte
 import io.camunda.connector.runtime.core.inbound.ProcessElementWithRuntimeData;
 import io.camunda.connector.runtime.core.inbound.details.InboundConnectorDetails.ValidInboundConnectorDetails;
 import io.camunda.connector.runtime.core.intrinsic.DefaultIntrinsicFunctionExecutor;
+import io.camunda.connector.runtime.core.secret.SecretFilter;
 import io.camunda.connector.runtime.core.validation.ValidationUtil;
 import io.camunda.connector.test.ConnectorContextTestUtil;
 import io.camunda.connector.test.MapSecretProvider;
@@ -253,7 +254,7 @@ public class InboundConnectorContextBuilder {
         SecretProvider secretProvider,
         ValidationProvider validationProvider,
         CorrelationResult result) {
-      super(secretProvider, validationProvider);
+      super(secretProvider, SecretFilter.allowAll(), validationProvider);
       this.result = result;
       this.activationTimestamp = System.currentTimeMillis();
       try {

--- a/connector-runtime/connector-runtime-test/src/main/java/io/camunda/connector/runtime/test/outbound/OutboundConnectorContextBuilder.java
+++ b/connector-runtime/connector-runtime-test/src/main/java/io/camunda/connector/runtime/test/outbound/OutboundConnectorContextBuilder.java
@@ -36,6 +36,7 @@ import io.camunda.connector.runtime.core.AbstractConnectorContext;
 import io.camunda.connector.runtime.core.document.DocumentFactoryImpl;
 import io.camunda.connector.runtime.core.document.store.InMemoryDocumentStore;
 import io.camunda.connector.runtime.core.intrinsic.DefaultIntrinsicFunctionExecutor;
+import io.camunda.connector.runtime.core.secret.SecretFilter;
 import io.camunda.connector.runtime.core.validation.ValidationUtil;
 import io.camunda.connector.test.ConnectorContextTestUtil;
 import io.camunda.connector.test.MapSecretProvider;
@@ -227,7 +228,7 @@ public class OutboundConnectorContextBuilder {
 
     protected TestConnectorContext(
         SecretProvider secretProvider, ValidationProvider validationProvider) {
-      super(secretProvider, validationProvider);
+      super(secretProvider, SecretFilter.allowAll(), validationProvider);
       try {
         var asString = objectMapper.writeValueAsString(variables);
         variablesWithSecrets = getSecretHandler().replaceSecrets(asString, null);


### PR DESCRIPTION
## Summary

Prevents outbound connectors from resolving secrets that are not declared in their BPMN input mappings.

### New abstractions (connector-runtime-core)

- **`SecretFilter`** — predicate that controls whether a named secret may be resolved. Two factory methods: `allowAll()` (existing behaviour) and `allowOnly(List<String>)` (restricts to a declared set; empty list denies all).
- **`SecretFilterFactory`** — per-job factory that creates a `SecretFilter` from a `SecretFilterContext` (process definition key + element id).
- **`AbstractConnectorContext`** — now accepts a `SecretFilter` at construction; the `SecretHandler` it builds passes filtered names through before resolving. Unallowed secret references are left as-is in the connector input (logged at DEBUG).
- **Inbound** connectors hardcode `SecretFilter.allowAll()` for now (extending filtering to inbound is tracked in #7730).

### Outbound implementation (connector-runtime-spring)

| Class | Role |
|---|---|
| `SecretKeyCache` | Interface: given a process definition key + element id, returns the list of declared secret names. |
| `ProcessDefinitionSecretKeyCache` | Implementation: fetches BPMN XML via `CamundaClient.newProcessDefinitionGetXmlRequest`, parses Zeebe input mappings for ServiceTask/SendTask/ScriptTask/BusinessRuleTask elements that carry an element template, and extracts secret names via `SecretUtil.retrieveSecretKeysInInput`. Results are cached by process definition key. |
| `ConfigurableSecretFilterFactory` | `SecretFilterFactory` implementation wired via `OutboundConnectorRuntimeConfiguration`. Delegates to `ProcessDefinitionSecretKeyCache` and wraps the result in a `LazyLoadingSecretFilter`. |
| `LazyLoadingSecretFilter` | Defers the BPMN lookup to the first `isAllowed()` call (which happens inside the job handler's try/catch), so lookup failures propagate as a proper Zeebe `failJob` rather than escaping error handling. The supplier is invoked exactly once per filter instance via double-checked locking; a `null` result (LAX fallback) is cached. |

### Configuration

Property: `camunda.connector.secret-resolver.secret-filter.mode` (default: `DISABLED`)

| Mode | Behaviour | Security guarantee |
|------|-----------|-------------------|
| `DISABLED` | All secrets resolved freely — existing behaviour. | None — feature is off. |
| `LAX` | Enforces allow-list when the process definition is available. Falls back to **allow-all** on any lookup failure (API unavailable, eventual-consistency delay, element not yet indexed). | Best-effort. Any lookup failure silently bypasses the restriction. Choose this when uninterrupted job processing matters more than strict secret isolation. |
| `STRICT` | Enforces allow-list unconditionally. Fails the Zeebe job (triggering retries) when the process definition cannot be retrieved. | Strong — no secret resolves outside the declared set. |

Secret-key results are cached separately from the inbound process-definition cache, controlled by:
- `camunda.connector.secret-resolver.secret-filter.cache.enabled` (default: `true`)
- `camunda.connector.secret-resolver.secret-filter.cache.max-size` (default: `1000`)

### Design note — lazy loading

`ConfigurableSecretFilterFactory.create()` is called before the `try/catch` block in `SpringConnectorJobHandler.getConnectorResult`. The actual BPMN lookup is deferred to the first `isAllowed()` invocation inside the guarded path, so exceptions are routed through the standard connector error handling. Jobs with no secret references never trigger a lookup at all.

## Test plan

- [x] `LazyLoadingSecretFilterTest` — single-invocation guarantee, null-fallback caching, allow/deny behaviour
- [x] `ConfigurableSecretFilterFactoryTest` — all three modes including LAX fallback and STRICT propagation
- [x] `ProcessDefinitionSecretKeyCacheTest` — BPMN fixture-based: bracket and bare notation, multi-task isolation, no-template exclusion, no-secrets, unknown element id
- [x] `OutboundConnectorRuntimeConfigurationTest` — `secretKeyCacheManager` enabled/disabled/size-clamping
- [x] `SecretUtilTests.shouldOnlyReplaceAllowListedSecrets` — unreferenced secrets left as-is
- [x] Existing `SpringConnectorJobHandlerTest`, `AnnotatedOperationTests`, `JobHandlerContextTest` — all pass with new API

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

Closes #7629