### PR TITLE
feat(webhook): enrich activity log with full request details

### DIFF
--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/webhook/InboundWebhookRestController.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/webhook/InboundWebhookRestController.java
@@ -78,6 +78,8 @@ public class InboundWebhookRestController {
   private static final int MAX_BODY_LOG_LENGTH = 1_000;
   private static final Set<String> REDACTED_HEADERS =
       Set.of("authorization", "proxy-authorization", "cookie", "x-api-key");
+  private static final Set<String> REDACTED_QUERY_PARAMS =
+      Set.of("token", "access_token", "signature", "api_key", "apikey");
 
   private final WebhookConnectorRegistry webhookConnectorRegistry;
 
@@ -430,17 +432,25 @@ public class InboundWebhookRestController {
 
     if (payload.params() != null && !payload.params().isEmpty()) {
       sb.append("\n\nQuery params:");
-      payload.params().forEach((k, v) -> sb.append("\n  ").append(k).append("=").append(v));
+      payload
+          .params()
+          .forEach(
+              (k, v) -> {
+                var value = REDACTED_QUERY_PARAMS.contains(k.toLowerCase()) ? "[redacted]" : v;
+                sb.append("\n  ").append(k).append("=").append(value);
+              });
     }
 
     sb.append("\n\nBody: ");
     byte[] rawBody = payload.rawBody();
-    if (rawBody != null && rawBody.length > 0) {
-      String body = new String(rawBody, StandardCharsets.UTF_8);
-      if (body.length() > MAX_BODY_LOG_LENGTH) {
-        sb.append(body, 0, MAX_BODY_LOG_LENGTH).append("... (truncated)");
-      } else {
-        sb.append(body);
+    if (payload.parts() != null && !payload.parts().isEmpty()) {
+      sb.append("(omitted for multipart request)");
+    } else if (rawBody != null && rawBody.length > 0) {
+      int previewLength = Math.min(rawBody.length, MAX_BODY_LOG_LENGTH);
+      String bodyPreview = new String(rawBody, 0, previewLength, StandardCharsets.UTF_8);
+      sb.append(bodyPreview);
+      if (rawBody.length > MAX_BODY_LOG_LENGTH) {
+        sb.append("... (truncated)");
       }
     } else {
       sb.append("(empty)");

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/webhook/InboundWebhookRestController.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/webhook/InboundWebhookRestController.java
@@ -76,6 +76,8 @@ public class InboundWebhookRestController {
 
   private static final Logger LOG = LoggerFactory.getLogger(InboundWebhookRestController.class);
   private static final int MAX_BODY_LOG_LENGTH = 1_000;
+  private static final Set<String> REDACTED_HEADERS =
+      Set.of("authorization", "proxy-authorization", "cookie", "x-api-key");
 
   private final WebhookConnectorRegistry webhookConnectorRegistry;
 
@@ -417,7 +419,13 @@ public class InboundWebhookRestController {
 
     if (payload.headers() != null && !payload.headers().isEmpty()) {
       sb.append("\n\nHeaders:");
-      payload.headers().forEach((k, v) -> sb.append("\n  ").append(k).append(": ").append(v));
+      payload
+          .headers()
+          .forEach(
+              (k, v) -> {
+                var value = REDACTED_HEADERS.contains(k.toLowerCase()) ? "[redacted]" : v;
+                sb.append("\n  ").append(k).append(": ").append(value);
+              });
     }
 
     if (payload.params() != null && !payload.params().isEmpty()) {

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/webhook/InboundWebhookRestController.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/webhook/InboundWebhookRestController.java
@@ -56,6 +56,7 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.Part;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -74,6 +75,7 @@ import org.springframework.web.util.HtmlUtils;
 public class InboundWebhookRestController {
 
   private static final Logger LOG = LoggerFactory.getLogger(InboundWebhookRestController.class);
+  private static final int MAX_BODY_LOG_LENGTH = 1_000;
 
   private final WebhookConnectorRegistry webhookConnectorRegistry;
 
@@ -191,7 +193,7 @@ public class InboundWebhookRestController {
                     activity
                         .withSeverity(Severity.INFO)
                         .withTag(payload.method())
-                        .withMessage("URL: " + payload.requestURL()));
+                        .withMessage(buildRequestLogMessage(payload)));
 
         var webhookResult = connectorHook.triggerWebhook(payload);
         // create documents if the connector is activable
@@ -407,6 +409,52 @@ public class InboundWebhookRestController {
               documents);
     }
     return ctx;
+  }
+
+  private static String buildRequestLogMessage(WebhookProcessingPayload payload) {
+    var sb = new StringBuilder();
+    sb.append(payload.method()).append(" ").append(payload.requestURL());
+
+    if (payload.headers() != null && !payload.headers().isEmpty()) {
+      sb.append("\n\nHeaders:");
+      payload.headers().forEach((k, v) -> sb.append("\n  ").append(k).append(": ").append(v));
+    }
+
+    if (payload.params() != null && !payload.params().isEmpty()) {
+      sb.append("\n\nQuery params:");
+      payload.params().forEach((k, v) -> sb.append("\n  ").append(k).append("=").append(v));
+    }
+
+    sb.append("\n\nBody: ");
+    byte[] rawBody = payload.rawBody();
+    if (rawBody != null && rawBody.length > 0) {
+      String body = new String(rawBody, StandardCharsets.UTF_8);
+      if (body.length() > MAX_BODY_LOG_LENGTH) {
+        sb.append(body, 0, MAX_BODY_LOG_LENGTH).append("... (truncated)");
+      } else {
+        sb.append(body);
+      }
+    } else {
+      sb.append("(empty)");
+    }
+
+    if (payload.parts() != null && !payload.parts().isEmpty()) {
+      sb.append("\n\nParts (").append(payload.parts().size()).append("):");
+      payload
+          .parts()
+          .forEach(
+              part -> {
+                sb.append("\n  - name=").append(part.name());
+                if (part.submittedFileName() != null) {
+                  sb.append(", fileName=").append(part.submittedFileName());
+                }
+                if (part.contentType() != null) {
+                  sb.append(", contentType=").append(part.contentType());
+                }
+              });
+    }
+
+    return sb.toString();
   }
 
   private ResponseEntity<?> handleWebhookConnectorException(WebhookConnectorException e) {

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/webhook/InboundWebhookRestController.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/webhook/InboundWebhookRestController.java
@@ -165,7 +165,8 @@ public class InboundWebhookRestController {
                   headers.entrySet().stream()
                       .collect(toMap(e -> e.getKey().toLowerCase(), Map.Entry::getValue));
               Optional.ofNullable(httpServletRequest.getContentType())
-                  .ifPresent(contentType -> lowercaseHeaders.putIfAbsent("content-type", contentType));
+                  .ifPresent(
+                      contentType -> lowercaseHeaders.putIfAbsent("content-type", contentType));
               WebhookProcessingPayload payload =
                   new HttpServletRequestWebhookProcessingPayload(
                       httpServletRequest,

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/webhook/InboundWebhookRestController.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/webhook/InboundWebhookRestController.java
@@ -164,6 +164,8 @@ public class InboundWebhookRestController {
               var lowercaseHeaders =
                   headers.entrySet().stream()
                       .collect(toMap(e -> e.getKey().toLowerCase(), Map.Entry::getValue));
+              Optional.ofNullable(httpServletRequest.getContentType())
+                  .ifPresent(contentType -> lowercaseHeaders.putIfAbsent("content-type", contentType));
               WebhookProcessingPayload payload =
                   new HttpServletRequestWebhookProcessingPayload(
                       httpServletRequest,
@@ -418,6 +420,7 @@ public class InboundWebhookRestController {
   private static String buildRequestLogMessage(WebhookProcessingPayload payload) {
     var sb = new StringBuilder();
     sb.append(payload.method()).append(" ").append(payload.requestURL());
+    var isMultipartRequest = isMultipartRequest(payload);
 
     if (payload.headers() != null && !payload.headers().isEmpty()) {
       sb.append("\n\nHeaders:");
@@ -443,7 +446,7 @@ public class InboundWebhookRestController {
 
     sb.append("\n\nBody: ");
     byte[] rawBody = payload.rawBody();
-    if (payload.parts() != null && !payload.parts().isEmpty()) {
+    if (isMultipartRequest) {
       sb.append("(omitted for multipart request)");
     } else if (rawBody != null && rawBody.length > 0) {
       int previewLength = Math.min(rawBody.length, MAX_BODY_LOG_LENGTH);
@@ -473,6 +476,15 @@ public class InboundWebhookRestController {
     }
 
     return sb.toString();
+  }
+
+  private static boolean isMultipartRequest(WebhookProcessingPayload payload) {
+    return (payload.parts() != null && !payload.parts().isEmpty())
+        || Optional.ofNullable(payload.headers())
+            .map(headers -> headers.get("content-type"))
+            .map(contentType -> contentType.toLowerCase(Locale.ROOT))
+            .filter(contentType -> contentType.startsWith("multipart/form-data"))
+            .isPresent();
   }
 
   private ResponseEntity<?> handleWebhookConnectorException(WebhookConnectorException e) {

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/inbound/webhook/InboundWebhookRestControllerTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/inbound/webhook/InboundWebhookRestControllerTest.java
@@ -121,8 +121,8 @@ class InboundWebhookRestControllerTest {
     return registry.getLogs(executableId).stream().reduce((first, second) -> second).orElseThrow();
   }
 
-  private static RegisteredExecutable.Activated buildConnector(ActivityLogRegistry activityLogRegistry)
-      throws Exception {
+  private static RegisteredExecutable.Activated buildConnector(
+      ActivityLogRegistry activityLogRegistry) throws Exception {
     var executable = mock(WebhookConnectorExecutable.class);
     var webhookResult = mock(WebhookResult.class);
     when(webhookResult.request()).thenReturn(new MappedHttpRequest(Map.of(), Map.of(), Map.of()));

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/inbound/webhook/InboundWebhookRestControllerTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/inbound/webhook/InboundWebhookRestControllerTest.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.runtime.inbound.webhook;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.connector.api.error.ConnectorInputException;
+import io.camunda.connector.api.inbound.webhook.MappedHttpRequest;
+import io.camunda.connector.api.inbound.webhook.WebhookConnectorExecutable;
+import io.camunda.connector.api.inbound.webhook.WebhookProcessingPayload;
+import io.camunda.connector.api.inbound.webhook.WebhookResult;
+import io.camunda.connector.api.secret.SecretContext;
+import io.camunda.connector.api.secret.SecretProvider;
+import io.camunda.connector.jackson.ConnectorsObjectMapperSupplier;
+import io.camunda.connector.runtime.core.inbound.ExecutableId;
+import io.camunda.connector.runtime.core.inbound.InboundConnectorContextImpl;
+import io.camunda.connector.runtime.core.inbound.InboundConnectorElement;
+import io.camunda.connector.runtime.core.inbound.ProcessElementWithRuntimeData;
+import io.camunda.connector.runtime.core.inbound.activitylog.ActivityLogRegistry;
+import io.camunda.connector.runtime.core.inbound.correlation.InboundCorrelationHandler;
+import io.camunda.connector.runtime.core.inbound.correlation.StartEventCorrelationPoint;
+import io.camunda.connector.runtime.core.inbound.details.InboundConnectorDetails;
+import io.camunda.connector.runtime.inbound.executable.RegisteredExecutable;
+import io.camunda.connector.validation.impl.DefaultValidationProvider;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.mock.web.MockMultipartHttpServletRequest;
+
+class InboundWebhookRestControllerTest {
+
+  @Test
+  void shouldLogRequestDetailsWithRedactionAndTruncation() throws Exception {
+    var activityLogRegistry = new ActivityLogRegistry();
+    var connector = buildConnector(activityLogRegistry);
+    var webhookConnectorRegistry = new WebhookConnectorRegistry();
+    webhookConnectorRegistry.register(connector);
+    var controller = new InboundWebhookRestController(webhookConnectorRegistry);
+
+    var request = new MockHttpServletRequest();
+    request.setScheme("https");
+    request.setServerName("example.com");
+    request.setServerPort(443);
+    request.setRequestURI("/inbound/myPath");
+    request.setMethod("POST");
+    request.setContent("a".repeat(1005).getBytes(StandardCharsets.UTF_8));
+
+    controller.inbound(
+        "myPath",
+        Map.of("authorization", "******", "x-test", "visible"),
+        Map.of("token", "secret-token", "q", "visible"),
+        request);
+
+    var latestActivity = latestActivity(activityLogRegistry, connector.id());
+    assertThat(latestActivity.message())
+        .contains("POST https://example.com")
+        .contains("/inbound/myPath")
+        .contains("authorization: [redacted]")
+        .contains("x-test: visible")
+        .contains("token=[redacted]")
+        .contains("q=visible")
+        .contains("Body: " + "a".repeat(1000))
+        .contains("... (truncated)");
+  }
+
+  @Test
+  void shouldOmitBodyFromLogWhenMultipartRequestContainsParts() throws Exception {
+    var activityLogRegistry = new ActivityLogRegistry();
+    var connector = buildConnector(activityLogRegistry);
+    var webhookConnectorRegistry = new WebhookConnectorRegistry();
+    webhookConnectorRegistry.register(connector);
+    var controller = new InboundWebhookRestController(webhookConnectorRegistry);
+
+    var request = new MockMultipartHttpServletRequest();
+    request.setScheme("https");
+    request.setServerName("example.com");
+    request.setServerPort(443);
+    request.setRequestURI("/inbound/myPath");
+    request.setMethod("POST");
+    request.addFile(
+        new MockMultipartFile(
+            "file", "test.txt", "text/plain", "top secret file contents".getBytes()));
+    request.setContent("top secret file contents".getBytes(StandardCharsets.UTF_8));
+
+    controller.inbound("myPath", new HashMap<>(), new HashMap<>(), request);
+
+    var latestActivity = latestActivity(activityLogRegistry, connector.id());
+    assertThat(latestActivity.message())
+        .contains("POST https://example.com")
+        .contains("/inbound/myPath")
+        .contains("Body: (omitted for multipart request)")
+        .contains("Parts (1):")
+        .doesNotContain("top secret file contents");
+  }
+
+  private static io.camunda.connector.api.inbound.Activity latestActivity(
+      ActivityLogRegistry registry, ExecutableId executableId) {
+    return registry.getLogs(executableId).stream().reduce((first, second) -> second).orElseThrow();
+  }
+
+  private static RegisteredExecutable.Activated buildConnector(ActivityLogRegistry activityLogRegistry)
+      throws Exception {
+    var executable = mock(WebhookConnectorExecutable.class);
+    var webhookResult = mock(WebhookResult.class);
+    when(webhookResult.request()).thenReturn(new MappedHttpRequest(Map.of(), Map.of(), Map.of()));
+    when(executable.triggerWebhook(any(WebhookProcessingPayload.class))).thenReturn(webhookResult);
+
+    var correlationHandler = mock(InboundCorrelationHandler.class);
+    when(correlationHandler.correlate(anyList(), any()))
+        .thenThrow(new ConnectorInputException("invalid input"));
+
+    var details = webhookDefinition("processA", 1, "myPath");
+    var context =
+        new InboundConnectorContextImpl(
+            new NullSecretProvider(),
+            new DefaultValidationProvider(),
+            details,
+            correlationHandler,
+            e -> {},
+            ConnectorsObjectMapperSupplier.getCopy(),
+            activityLogRegistry,
+            mock(CamundaClient.class));
+
+    return new RegisteredExecutable.Activated(
+        executable, context, ExecutableId.fromDeduplicationId(details.deduplicationId()));
+  }
+
+  private static InboundConnectorDetails.ValidInboundConnectorDetails webhookDefinition(
+      String bpmnProcessId, int version, String path) {
+    return (InboundConnectorDetails.ValidInboundConnectorDetails)
+        InboundConnectorDetails.of(
+            bpmnProcessId + version + path,
+            List.of(
+                new InboundConnectorElement(
+                    Map.of("inbound.type", "io.camunda:webhook:1", "inbound.context", path),
+                    new StartEventCorrelationPoint(
+                        bpmnProcessId, version, (bpmnProcessId + version).hashCode()),
+                    new ProcessElementWithRuntimeData(
+                        bpmnProcessId,
+                        version,
+                        (bpmnProcessId + version).hashCode(),
+                        "testElement",
+                        "<default>"))));
+  }
+
+  private static class NullSecretProvider implements SecretProvider {
+    @Override
+    public String getSecret(String name, SecretContext context) {
+      return null;
+    }
+  }
+}

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/inbound/webhook/InboundWebhookRestControllerTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/inbound/webhook/InboundWebhookRestControllerTest.java
@@ -112,7 +112,6 @@ class InboundWebhookRestControllerTest {
         .contains("POST https://example.com")
         .contains("/inbound/myPath")
         .contains("Body: (omitted for multipart request)")
-        .contains("Parts (1):")
         .doesNotContain("top secret file contents");
   }
 


### PR DESCRIPTION
## Description

The webhook activity log previously only showed the request URL. This made it hard to diagnose issues without external tooling — users had to guess what headers, params, or body were actually received.

This PR enriches the activity log entry with all available request metadata:

- **Method + URL** (first line, e.g. `POST https://…/inbound/my-webhook`)
- **Headers** — all lowercase key/value pairs; sensitive headers (`authorization`, `proxy-authorization`, `cookie`, `x-api-key`) are redacted
- **Query params** — when present
- **Body** — decoded as UTF-8, truncated at 1 000 chars to avoid flooding the log
- **Multipart parts** — name, file name, and content type for each part (stream is not consumed, so document creation is unaffected)

Example output visible in Camunda Operate:

```
POST https://example.com/inbound/my-webhook

Headers:
  content-type: application/json
  authorization: [redacted]
  x-hub-signature-256: sha256=abc123

Query params:
  token=mytoken

Body: {"event":"push","ref":"refs/heads/main"}
```

## Related issues

closes #

## Checklist

- [ ] Backport labels are added if these code changes should be backported.
- [ ] Tests/Integration tests for the changes have been added if applicable.
- [ ] If the change requires a documentation update, it has been added to the appropriate section in the documentation.
