### PR TITLE
fix(runtime): fix false NONE broker state in standalone gateway deployments

### DIFF
--- a/bundle/default-bundle/src/test/resources/application.properties
+++ b/bundle/default-bundle/src/test/resources/application.properties
@@ -13,6 +13,7 @@ camunda.client.worker.defaults.max-jobs-active=100
 camunda.client.worker.defaults.stream-enabled=true
 camunda.client.rest-address=http://localhost:8080
 camunda.client.mode=self-managed
+camunda.connector.broker.monitoring.addresses=http://localhost:9600
 # Config for use with docker-compose.yml
 #camunda.client.auth.client-id=connectors
 #camunda.client.auth.client-secret=XALaRPl5qwTEItdwCMiPS62nVpKs7dL7

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/instances/service/OutboundConnectorsService.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/instances/service/OutboundConnectorsService.java
@@ -21,10 +21,13 @@ import io.camunda.connector.runtime.core.config.OutboundConnectorConfiguration;
 import io.camunda.connector.runtime.core.outbound.OutboundConnectorFactory;
 import io.camunda.connector.runtime.inbound.controller.exception.DataNotFoundException;
 import io.camunda.connector.runtime.outbound.controller.OutboundConnectorResponse;
+import io.camunda.connector.runtime.outbound.jobstream.BrokerJobStreamClient;
 import io.camunda.connector.runtime.outbound.jobstream.GatewayJobStreamClient;
 import io.camunda.connector.runtime.outbound.jobstream.GatewayResult;
+import io.camunda.connector.runtime.outbound.jobstream.RemoteJobStream;
 import io.camunda.connector.runtime.outbound.jobstream.StreamConnectivity;
 import java.util.List;
+import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -34,30 +37,41 @@ public class OutboundConnectorsService {
 
   private final OutboundConnectorFactory connectorFactory;
   private final GatewayJobStreamClient gatewayJobStreamClient;
+  private final BrokerJobStreamClient brokerJobStreamClient;
 
   public OutboundConnectorsService(OutboundConnectorFactory connectorFactory) {
-    this(connectorFactory, null);
+    this(connectorFactory, null, null);
   }
 
   public OutboundConnectorsService(
       OutboundConnectorFactory connectorFactory, GatewayJobStreamClient gatewayJobStreamClient) {
+    this(connectorFactory, gatewayJobStreamClient, null);
+  }
+
+  public OutboundConnectorsService(
+      OutboundConnectorFactory connectorFactory,
+      GatewayJobStreamClient gatewayJobStreamClient,
+      BrokerJobStreamClient brokerJobStreamClient) {
     this.connectorFactory = connectorFactory;
     this.gatewayJobStreamClient = gatewayJobStreamClient;
+    this.brokerJobStreamClient = brokerJobStreamClient;
   }
 
   public List<OutboundConnectorResponse> findAll(String runtimeId) {
     GatewayResult gateway = queryGateway();
+    Optional<List<RemoteJobStream>> remoteStreams = resolveBrokerStreams(gateway);
     return connectorFactory.getRuntimeConfigurations().stream()
-        .map(config -> toResponse(config, runtimeId, gateway))
+        .map(config -> toResponse(config, runtimeId, gateway, remoteStreams))
         .toList();
   }
 
   public List<OutboundConnectorResponse> findByType(String type, String runtimeId) {
     GatewayResult gateway = queryGateway();
+    Optional<List<RemoteJobStream>> remoteStreams = resolveBrokerStreams(gateway);
     var results =
         connectorFactory.getRuntimeConfigurations().stream()
             .filter(config -> config.config().type().equals(type))
-            .map(config -> toResponse(config, runtimeId, gateway))
+            .map(config -> toResponse(config, runtimeId, gateway, remoteStreams))
             .toList();
     if (results.isEmpty()) {
       throw new DataNotFoundException(OutboundConnectorResponse.class, type);
@@ -77,15 +91,46 @@ public class OutboundConnectorsService {
     }
   }
 
+  /**
+   * Resolves the broker-side remote streams to use for broker connectivity state computation.
+   *
+   * <ul>
+   *   <li>If broker monitoring addresses are configured, query brokers directly.
+   *   <li>Otherwise, fall back to the gateway's own {@code remote} data (non-empty only when the
+   *       gateway is embedded in a broker).
+   *   <li>Returns {@link Optional#empty()} when broker state cannot be determined (standalone
+   *       gateway with no broker addresses configured, or gateway unreachable).
+   * </ul>
+   */
+  private Optional<List<RemoteJobStream>> resolveBrokerStreams(GatewayResult gateway) {
+    if (!(gateway instanceof GatewayResult.Success success)) {
+      return Optional.empty();
+    }
+    if (brokerJobStreamClient != null) {
+      try {
+        return Optional.of(brokerJobStreamClient.fetchRemoteStreams());
+      } catch (Exception e) {
+        LOG.warn("Failed to fetch remote streams from brokers: {}", e.getMessage());
+        return Optional.empty();
+      }
+    }
+    // Fallback: use gateway's remote field (populated only for embedded gateways).
+    // Empty remote in a standalone gateway means we cannot determine broker state.
+    List<RemoteJobStream> gatewayRemote = success.streams().remote();
+    return gatewayRemote.isEmpty() ? Optional.empty() : Optional.of(gatewayRemote);
+  }
+
   private OutboundConnectorResponse toResponse(
       AbstractConnectorFactory.ConnectorRuntimeConfiguration<OutboundConnectorConfiguration> config,
       String runtimeId,
-      GatewayResult gateway) {
+      GatewayResult gateway,
+      Optional<List<RemoteJobStream>> remoteStreams) {
     String jobType = config.config().type();
     StreamConnectivity connectivity =
         switch (gateway) {
           case GatewayResult.Failure f -> StreamConnectivity.unavailable(f.gatewayState());
-          case GatewayResult.Success s -> StreamConnectivity.compute(jobType, s.streams());
+          case GatewayResult.Success s ->
+              StreamConnectivity.compute(jobType, s.streams().client(), remoteStreams);
         };
     return buildResponse(config, runtimeId, connectivity);
   }

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/instances/service/OutboundConnectorsService.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/instances/service/OutboundConnectorsService.java
@@ -95,11 +95,11 @@ public class OutboundConnectorsService {
    * Resolves the broker-side remote streams to use for broker connectivity state computation.
    *
    * <ul>
-   *   <li>If broker monitoring addresses are configured, query brokers directly.
-   *   <li>Otherwise, fall back to the gateway's own {@code remote} data (non-empty only when the
-   *       gateway is embedded in a broker).
+   *   <li>If the broker monitoring client is configured, query brokers directly.
+   *   <li>If the broker query fails, or no broker client is configured, fall back to the gateway's
+   *       own {@code remote} data (non-empty only when the gateway is embedded in a broker).
    *   <li>Returns {@link Optional#empty()} when broker state cannot be determined (standalone
-   *       gateway with no broker addresses configured, or gateway unreachable).
+   *       gateway with broker monitoring unavailable or unreachable, or gateway unreachable).
    * </ul>
    */
   private Optional<List<RemoteJobStream>> resolveBrokerStreams(GatewayResult gateway) {
@@ -111,7 +111,7 @@ public class OutboundConnectorsService {
         return Optional.of(brokerJobStreamClient.fetchRemoteStreams());
       } catch (Exception e) {
         LOG.warn("Failed to fetch remote streams from brokers: {}", e.getMessage());
-        return Optional.empty();
+        // Fall through to gateway remote fallback below.
       }
     }
     // Fallback: use gateway's remote field (populated only for embedded gateways).

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/OutboundConnectorRuntimeConfiguration.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/OutboundConnectorRuntimeConfiguration.java
@@ -99,8 +99,8 @@ public class OutboundConnectorRuntimeConfiguration {
   }
 
   /**
-   * Creates a {@link BrokerJobStreamClient} when broker monitoring is explicitly enabled via {@code
-   * camunda.connector.broker.monitoring.enabled=true} (match if missing).
+   * Creates a {@link BrokerJobStreamClient} when broker monitoring is enabled (on by default; set
+   * {@code camunda.connector.broker.monitoring.enabled=false} to disable).
    *
    * <p>Two sub-modes, controlled by {@code camunda.connector.broker.monitoring.addresses}:
    *
@@ -108,9 +108,10 @@ public class OutboundConnectorRuntimeConfiguration {
    *   <li><b>Explicit addresses</b> (recommended for Docker/NAT'd envs): set {@code
    *       camunda.connector.broker.monitoring.addresses} to a comma-separated list of base URLs
    *       (e.g. {@code http://localhost:9600,http://localhost:9601}). No topology request is made.
-   *   <li><b>Topology discovery</b> (default fallback): when {@code addresses} is not set, broker
-   *       hosts are discovered via the Camunda topology API. The monitoring port defaults to {@code
-   *       9600} and can be overridden via {@code camunda.connector.broker.monitoring.port}.
+   *   <li><b>Topology discovery</b> (default fallback): when {@code addresses} is blank or resolves
+   *       to an empty list, broker hosts are discovered via the Camunda topology API. The
+   *       monitoring port defaults to {@code 9600} and can be overridden via {@code
+   *       camunda.connector.broker.monitoring.port}.
    * </ul>
    */
   @Bean
@@ -130,7 +131,9 @@ public class OutboundConnectorRuntimeConfiguration {
               .filter(s -> !s.isBlank())
               .map(URI::create)
               .toList();
-      return new BrokerJobStreamClient(uris, mapper);
+      if (!uris.isEmpty()) {
+        return new BrokerJobStreamClient(uris, mapper);
+      }
     }
     return new BrokerJobStreamClient(camundaClient, monitoringPort, mapper);
   }

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/OutboundConnectorRuntimeConfiguration.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/OutboundConnectorRuntimeConfiguration.java
@@ -37,9 +37,13 @@ import io.camunda.connector.runtime.core.validation.ValidationUtil;
 import io.camunda.connector.runtime.instances.InstanceForwardingConfiguration;
 import io.camunda.connector.runtime.instances.service.OutboundConnectorsService;
 import io.camunda.connector.runtime.outbound.controller.OutboundConnectorsRestController;
+import io.camunda.connector.runtime.outbound.jobstream.BrokerJobStreamClient;
 import io.camunda.connector.runtime.outbound.jobstream.GatewayJobStreamClient;
 import io.camunda.connector.runtime.outbound.lifecycle.OutboundConnectorManager;
+import java.net.URI;
+import java.util.Arrays;
 import java.util.List;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -85,7 +89,8 @@ public class OutboundConnectorRuntimeConfiguration {
   @Bean
   @ConditionalOnProperty(
       name = "camunda.connector.gateway.monitoring.enabled",
-      havingValue = "true")
+      havingValue = "true",
+      matchIfMissing = true)
   public GatewayJobStreamClient gatewayJobStreamClient(
       CamundaClient camundaClient,
       @ConnectorsObjectMapper ObjectMapper mapper,
@@ -93,12 +98,50 @@ public class OutboundConnectorRuntimeConfiguration {
     return new GatewayJobStreamClient(camundaClient, monitoringPort, mapper);
   }
 
+  /**
+   * Creates a {@link BrokerJobStreamClient} when broker monitoring is explicitly enabled via {@code
+   * camunda.connector.broker.monitoring.enabled=true} (match if missing).
+   *
+   * <p>Two sub-modes, controlled by {@code camunda.connector.broker.monitoring.addresses}:
+   *
+   * <ul>
+   *   <li><b>Explicit addresses</b> (recommended for Docker/NAT'd envs): set {@code
+   *       camunda.connector.broker.monitoring.addresses} to a comma-separated list of base URLs
+   *       (e.g. {@code http://localhost:9600,http://localhost:9601}). No topology request is made.
+   *   <li><b>Topology discovery</b> (default fallback): when {@code addresses} is not set, broker
+   *       hosts are discovered via the Camunda topology API. The monitoring port defaults to {@code
+   *       9600} and can be overridden via {@code camunda.connector.broker.monitoring.port}.
+   * </ul>
+   */
+  @Bean
+  @ConditionalOnProperty(
+      name = "camunda.connector.broker.monitoring.enabled",
+      havingValue = "true",
+      matchIfMissing = true)
+  public BrokerJobStreamClient brokerJobStreamClient(
+      CamundaClient camundaClient,
+      @ConnectorsObjectMapper ObjectMapper mapper,
+      @Value("${camunda.connector.broker.monitoring.port:9600}") int monitoringPort,
+      @Value("${camunda.connector.broker.monitoring.addresses:#{null}}") String addresses) {
+    if (StringUtils.isNotBlank(addresses)) {
+      List<URI> uris =
+          Arrays.stream(addresses.split(","))
+              .map(String::trim)
+              .filter(s -> !s.isBlank())
+              .map(URI::create)
+              .toList();
+      return new BrokerJobStreamClient(uris, mapper);
+    }
+    return new BrokerJobStreamClient(camundaClient, monitoringPort, mapper);
+  }
+
   @Bean
   public OutboundConnectorsService outboundConnectorsService(
       OutboundConnectorFactory outboundConnectorConfigurationRegistry,
-      @Autowired(required = false) GatewayJobStreamClient gatewayJobStreamClient) {
+      @Autowired(required = false) GatewayJobStreamClient gatewayJobStreamClient,
+      @Autowired(required = false) BrokerJobStreamClient brokerJobStreamClient) {
     return new OutboundConnectorsService(
-        outboundConnectorConfigurationRegistry, gatewayJobStreamClient);
+        outboundConnectorConfigurationRegistry, gatewayJobStreamClient, brokerJobStreamClient);
   }
 
   @Bean

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/jobstream/BrokerConnectivityState.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/jobstream/BrokerConnectivityState.java
@@ -20,10 +20,11 @@ package io.camunda.connector.runtime.outbound.jobstream;
  * Describes the connectivity state of an outbound connector worker to the Zeebe brokers.
  *
  * <ul>
- *   <li>{@code UNKNOWN} – Broker state cannot be determined. This happens when no broker monitoring
- *       addresses are configured ({@code camunda.connector.broker.monitoring.addresses}) and the
- *       gateway's remote streams are empty (standalone gateway deployment). Configure broker
- *       addresses to get accurate broker connectivity state.
+ *   <li>{@code UNKNOWN} – Broker state cannot be determined. This can happen when: broker
+ *       monitoring is not configured; broker monitoring is configured but the query failed and the
+ *       gateway's remote streams are also empty; or the gateway is a standalone deployment with no
+ *       embedded broker. Enable and configure broker monitoring to get accurate broker connectivity
+ *       state.
  *   <li>{@code NONE} – Brokers were queried but no client stream appears as a consumer in any
  *       broker's remote stream. This indicates a genuine connectivity problem.
  *   <li>{@code PARTIALLY_CONNECTED} – Client streams exist on the gateway, but they do not appear

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/jobstream/BrokerConnectivityState.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/jobstream/BrokerConnectivityState.java
@@ -20,7 +20,12 @@ package io.camunda.connector.runtime.outbound.jobstream;
  * Describes the connectivity state of an outbound connector worker to the Zeebe brokers.
  *
  * <ul>
- *   <li>{@code NONE} – No client stream is registered as a consumer in any broker's remote stream.
+ *   <li>{@code UNKNOWN} – Broker state cannot be determined. This happens when no broker monitoring
+ *       addresses are configured ({@code camunda.connector.broker.monitoring.addresses}) and the
+ *       gateway's remote streams are empty (standalone gateway deployment). Configure broker
+ *       addresses to get accurate broker connectivity state.
+ *   <li>{@code NONE} – Brokers were queried but no client stream appears as a consumer in any
+ *       broker's remote stream. This indicates a genuine connectivity problem.
  *   <li>{@code PARTIALLY_CONNECTED} – Client streams exist on the gateway, but they do not appear
  *       as consumers in <b>every</b> broker's remote stream. This may indicate a transient issue;
  *       restart the gateway if it persists.
@@ -29,6 +34,7 @@ package io.camunda.connector.runtime.outbound.jobstream;
  * </ul>
  */
 public enum BrokerConnectivityState {
+  UNKNOWN,
   NONE,
   PARTIALLY_CONNECTED,
   ALL_CONNECTED

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/jobstream/BrokerJobStreamClient.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/jobstream/BrokerJobStreamClient.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.runtime.outbound.jobstream;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.client.CamundaClient;
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Fetches remote (broker-side) job-stream data from each Zeebe broker's monitoring endpoint ({@code
+ * /actuator/jobstreams}). Operates in two modes:
+ *
+ * <ul>
+ *   <li><b>Explicit addresses</b> (preferred for Docker/NAT'd environments): provide base URLs via
+ *       {@code camunda.connector.broker.monitoring.addresses} (comma-separated, e.g. {@code
+ *       http://localhost:9600,http://localhost:9601}). No topology request is made.
+ *   <li><b>Topology discovery</b> (fallback): when no addresses are configured, broker hosts are
+ *       resolved at query time via {@link CamundaClient#newTopologyRequest()}. The monitoring port
+ *       defaults to {@code 9600} and can be overridden via {@code
+ *       camunda.connector.broker.monitoring.port}.
+ * </ul>
+ *
+ * <p>This client is used in standalone gateway deployments where the gateway's {@code
+ * /actuator/jobstreams} endpoint cannot report broker-side streams (its {@code remote} field is
+ * always empty). Enable with {@code camunda.connector.broker.monitoring.enabled=true}.
+ */
+public class BrokerJobStreamClient {
+
+  private static final String JOB_STREAMS_PATH = "/actuator/jobstreams";
+
+  // Explicit mode — null means use topology discovery instead
+  private final List<URI> explicitBaseUris;
+  // Topology mode — only used when explicitBaseUris is null
+  private final CamundaClient camundaClient;
+  private final int monitoringPort;
+
+  private final ObjectMapper objectMapper;
+  private final HttpClient httpClient;
+
+  /** Topology-discovery mode: broker hosts are resolved at query time via the topology API. */
+  public BrokerJobStreamClient(
+      CamundaClient camundaClient, int monitoringPort, ObjectMapper objectMapper) {
+    this.explicitBaseUris = null;
+    this.camundaClient = camundaClient;
+    this.monitoringPort = monitoringPort;
+    this.objectMapper = objectMapper;
+    this.httpClient = HttpClient.newHttpClient();
+  }
+
+  /**
+   * Explicit-addresses mode: skip topology, query each of the given base URLs directly. Useful in
+   * Docker or other NAT'd environments where topology-reported IPs are not reachable.
+   */
+  public BrokerJobStreamClient(List<URI> explicitBaseUris, ObjectMapper objectMapper) {
+    this.explicitBaseUris = explicitBaseUris;
+    this.camundaClient = null;
+    this.monitoringPort = 0;
+    this.objectMapper = objectMapper;
+    this.httpClient = HttpClient.newHttpClient();
+  }
+
+  /**
+   * Fetches and aggregates the {@code remote} job streams from all brokers. URIs are either taken
+   * from the explicit address list or resolved from the Camunda topology.
+   *
+   * @return combined list of remote streams from all brokers
+   * @throws IOException if any broker endpoint returns a non-200 status
+   * @throws Exception if the topology request or any broker HTTP request fails
+   */
+  public List<RemoteJobStream> fetchRemoteStreams() throws Exception {
+    List<URI> uris = resolveUris();
+    List<RemoteJobStream> result = new ArrayList<>();
+    for (URI uri : uris) {
+      HttpRequest request = HttpRequest.newBuilder(uri).GET().build();
+      HttpResponse<String> response =
+          httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+      if (response.statusCode() != 200) {
+        throw new IOException(
+            "Broker job-streams endpoint returned status " + response.statusCode() + ": " + uri);
+      }
+      result.addAll(objectMapper.readValue(response.body(), JobStreamsResponse.class).remote());
+    }
+    return result;
+  }
+
+  private List<URI> resolveUris() {
+    if (explicitBaseUris != null) {
+      return explicitBaseUris.stream().map(base -> base.resolve(JOB_STREAMS_PATH)).toList();
+    }
+    return camundaClient.newTopologyRequest().send().join().getBrokers().stream()
+        .map(b -> URI.create("http://" + b.getHost() + ":" + monitoringPort + JOB_STREAMS_PATH))
+        .toList();
+  }
+}

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/jobstream/GatewayJobStreamClient.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/jobstream/GatewayJobStreamClient.java
@@ -35,18 +35,17 @@ public class GatewayJobStreamClient {
 
   private static final String JOB_STREAMS_PATH = "/actuator/jobstreams";
 
-  private final URI monitoringBaseUri;
+  private final CamundaClient camundaClient;
+  private final int monitoringPort;
   private final ObjectMapper objectMapper;
   private final HttpClient httpClient;
 
   public GatewayJobStreamClient(
       CamundaClient camundaClient, int monitoringPort, ObjectMapper objectMapper) {
+    this.camundaClient = camundaClient;
+    this.monitoringPort = monitoringPort;
     this.objectMapper = objectMapper;
     this.httpClient = HttpClient.newHttpClient();
-
-    URI restAddress = camundaClient.getConfiguration().getRestAddress();
-    this.monitoringBaseUri =
-        URI.create(restAddress.getScheme() + "://" + restAddress.getHost() + ":" + monitoringPort);
   }
 
   /**
@@ -57,6 +56,9 @@ public class GatewayJobStreamClient {
    * @throws Exception if the request fails for any other reason (network error, parse error, etc.)
    */
   public JobStreamsResponse fetchJobStreams() throws Exception {
+    URI restAddress = camundaClient.getConfiguration().getRestAddress();
+    URI monitoringBaseUri =
+        URI.create(restAddress.getScheme() + "://" + restAddress.getHost() + ":" + monitoringPort);
     URI uri = monitoringBaseUri.resolve(JOB_STREAMS_PATH);
     HttpRequest request = HttpRequest.newBuilder(uri).GET().build();
     HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/jobstream/StreamConnectivity.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/jobstream/StreamConnectivity.java
@@ -31,9 +31,9 @@ import java.util.Set;
  *   <li>Gateway state comes from the {@code client} streams of the gateway's {@code
  *       /actuator/jobstreams} endpoint.
  *   <li>Broker state comes from the {@code remote} streams queried directly from each broker (when
- *       broker addresses are configured), or falls back to the gateway's own {@code remote} data
- *       (only non-empty when the gateway is embedded in a broker). When neither source is
- *       available, broker state is {@link BrokerConnectivityState#UNKNOWN}.
+ *       broker monitoring is configured and reachable), or falls back to the gateway's own {@code
+ *       remote} data (only non-empty when the gateway is embedded in a broker). When neither source
+ *       is available, broker state is {@link BrokerConnectivityState#UNKNOWN}.
  * </ul>
  *
  * @param gatewayState whether the connector is registered as a client stream on the gateway
@@ -58,9 +58,9 @@ public record StreamConnectivity(
    * @param jobType the job type to compute state for
    * @param allClientStreams all client streams from the gateway's response
    * @param allRemoteStreams broker-side remote streams; {@link Optional#empty()} when broker state
-   *     cannot be determined (standalone gateway with no broker addresses configured), which yields
-   *     {@link BrokerConnectivityState#UNKNOWN}; a present {@link Optional} with an empty list
-   *     yields {@link BrokerConnectivityState#NONE}
+   *     cannot be determined (broker monitoring not configured or unavailable, and no embedded
+   *     gateway remote data), which yields {@link BrokerConnectivityState#UNKNOWN}; a present
+   *     {@link Optional} with an empty list yields {@link BrokerConnectivityState#NONE}
    */
   public static StreamConnectivity compute(
       String jobType,

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/jobstream/StreamConnectivity.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/jobstream/StreamConnectivity.java
@@ -18,11 +18,23 @@ package io.camunda.connector.runtime.outbound.jobstream;
 
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 
 /**
  * Captures the connectivity state of a single connector job type as observed from both the gateway
  * (client streams) and the brokers (remote streams).
+ *
+ * <p>Gateway state and broker state are derived from separate sources:
+ *
+ * <ul>
+ *   <li>Gateway state comes from the {@code client} streams of the gateway's {@code
+ *       /actuator/jobstreams} endpoint.
+ *   <li>Broker state comes from the {@code remote} streams queried directly from each broker (when
+ *       broker addresses are configured), or falls back to the gateway's own {@code remote} data
+ *       (only non-empty when the gateway is embedded in a broker). When neither source is
+ *       available, broker state is {@link BrokerConnectivityState#UNKNOWN}.
+ * </ul>
  *
  * @param gatewayState whether the connector is registered as a client stream on the gateway
  * @param brokerState whether the gateway stream is propagated to all brokers; {@code null} when
@@ -41,11 +53,22 @@ public record StreamConnectivity(
   }
 
   /**
-   * Computes the connectivity state for a given job type from a live gateway job streams snapshot.
+   * Computes the connectivity state for a given job type from separate gateway and broker data.
+   *
+   * @param jobType the job type to compute state for
+   * @param allClientStreams all client streams from the gateway's response
+   * @param allRemoteStreams broker-side remote streams; {@link Optional#empty()} when broker state
+   *     cannot be determined (standalone gateway with no broker addresses configured), which yields
+   *     {@link BrokerConnectivityState#UNKNOWN}; a present {@link Optional} with an empty list
+   *     yields {@link BrokerConnectivityState#NONE}
    */
-  public static StreamConnectivity compute(String jobType, JobStreamsResponse jobStreams) {
+  public static StreamConnectivity compute(
+      String jobType,
+      List<ClientJobStream> allClientStreams,
+      Optional<List<RemoteJobStream>> allRemoteStreams) {
+
     List<ClientJobStream> clientStreams =
-        jobStreams.client().stream().filter(s -> jobType.equals(s.jobType())).toList();
+        allClientStreams.stream().filter(s -> jobType.equals(s.jobType())).toList();
 
     if (clientStreams.isEmpty()) {
       return unavailable(GatewayConnectivityState.NOT_CONNECTED);
@@ -58,8 +81,9 @@ public record StreamConnectivity(
             .distinct()
             .toList();
 
-    List<RemoteJobStream> remoteStreams =
-        jobStreams.remote().stream().filter(s -> jobType.equals(s.jobType())).toList();
+    Optional<List<RemoteJobStream>> remoteStreams =
+        allRemoteStreams.map(
+            streams -> streams.stream().filter(s -> jobType.equals(s.jobType())).toList());
 
     BrokerConnectivityState brokerState = computeBrokerState(Set.copyOf(streamIds), remoteStreams);
 
@@ -68,19 +92,26 @@ public record StreamConnectivity(
   }
 
   private static BrokerConnectivityState computeBrokerState(
-      Set<String> clientStreamIds, List<RemoteJobStream> remoteStreams) {
-    if (remoteStreams.isEmpty()) {
-      return BrokerConnectivityState.NONE;
-    }
-    boolean allConnected =
-        remoteStreams.stream()
-            .allMatch(
-                remote ->
-                    remote.consumers() != null
-                        && remote.consumers().stream()
-                            .anyMatch(consumer -> clientStreamIds.contains(consumer.get("id"))));
-    return allConnected
-        ? BrokerConnectivityState.ALL_CONNECTED
-        : BrokerConnectivityState.PARTIALLY_CONNECTED;
+      Set<String> clientStreamIds, Optional<List<RemoteJobStream>> remoteStreams) {
+    return remoteStreams
+        .map(
+            streams -> {
+              if (streams.isEmpty()) {
+                return BrokerConnectivityState.NONE;
+              }
+              boolean allConnected =
+                  streams.stream()
+                      .allMatch(
+                          remote ->
+                              remote.consumers() != null
+                                  && remote.consumers().stream()
+                                      .anyMatch(
+                                          consumer ->
+                                              clientStreamIds.contains(consumer.get("id"))));
+              return allConnected
+                  ? BrokerConnectivityState.ALL_CONNECTED
+                  : BrokerConnectivityState.PARTIALLY_CONNECTED;
+            })
+        .orElse(BrokerConnectivityState.UNKNOWN);
   }
 }

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/instances/service/OutboundConnectorsServiceTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/instances/service/OutboundConnectorsServiceTest.java
@@ -27,6 +27,7 @@ import io.camunda.connector.runtime.core.config.OutboundConnectorConfiguration;
 import io.camunda.connector.runtime.core.outbound.OutboundConnectorFactory;
 import io.camunda.connector.runtime.inbound.controller.exception.DataNotFoundException;
 import io.camunda.connector.runtime.outbound.jobstream.BrokerConnectivityState;
+import io.camunda.connector.runtime.outbound.jobstream.BrokerJobStreamClient;
 import io.camunda.connector.runtime.outbound.jobstream.ClientJobStream;
 import io.camunda.connector.runtime.outbound.jobstream.ClientStreamId;
 import io.camunda.connector.runtime.outbound.jobstream.GatewayConnectivityState;
@@ -47,6 +48,7 @@ class OutboundConnectorsServiceTest {
 
   private final OutboundConnectorFactory factory = mock(OutboundConnectorFactory.class);
   private final GatewayJobStreamClient gatewayClient = mock(GatewayJobStreamClient.class);
+  private final BrokerJobStreamClient brokerClient = mock(BrokerJobStreamClient.class);
 
   @BeforeEach
   void setupFactory() {
@@ -108,11 +110,11 @@ class OutboundConnectorsServiceTest {
   }
 
   // ---------------------------------------------------------------------------
-  // Gateway reachable — client stream present
+  // Gateway reachable — client stream present, embedded gateway (remote in gateway response)
   // ---------------------------------------------------------------------------
 
   @Test
-  void shouldReturnConnectedAndAllBrokers_whenFullyConnected() throws Exception {
+  void shouldReturnConnectedAndAllBrokers_whenFullyConnected_embeddedGateway() throws Exception {
     var clientStream = new ClientJobStream(TYPE, new ClientStreamId(STREAM_ID, 0), List.of(0));
     var brokerStream = new RemoteJobStream(TYPE, List.of(Map.of("id", STREAM_ID)));
     when(gatewayClient.fetchJobStreams())
@@ -129,7 +131,8 @@ class OutboundConnectorsServiceTest {
   }
 
   @Test
-  void shouldReturnPartiallyConnected_whenOnlyOneBrokerHasConsumer() throws Exception {
+  void shouldReturnPartiallyConnected_whenOnlyOneBrokerHasConsumer_embeddedGateway()
+      throws Exception {
     var clientStream = new ClientJobStream(TYPE, new ClientStreamId(STREAM_ID, 0), List.of(0));
     var connectedBroker = new RemoteJobStream(TYPE, List.of(Map.of("id", STREAM_ID)));
     var disconnectedBroker = new RemoteJobStream(TYPE, List.of());
@@ -145,8 +148,13 @@ class OutboundConnectorsServiceTest {
         .isEqualTo(BrokerConnectivityState.PARTIALLY_CONNECTED);
   }
 
+  // ---------------------------------------------------------------------------
+  // Standalone gateway: empty remote in gateway response → UNKNOWN without broker client
+  // ---------------------------------------------------------------------------
+
   @Test
-  void shouldReturnNoneBrokerState_whenNoRemoteStreamsForJobType() throws Exception {
+  void shouldReturnUnknownBrokerState_whenGatewayRemoteEmpty_andNoBrokerClientConfigured()
+      throws Exception {
     var clientStream = new ClientJobStream(TYPE, new ClientStreamId(STREAM_ID, 0), List.of(0));
     when(gatewayClient.fetchJobStreams())
         .thenReturn(new JobStreamsResponse(List.of(), List.of(clientStream)));
@@ -155,7 +163,55 @@ class OutboundConnectorsServiceTest {
     var results = service.findAll(RUNTIME_ID);
 
     assertThat(results.getFirst().brokerConnectivityState())
+        .isEqualTo(BrokerConnectivityState.UNKNOWN);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Standalone gateway with broker client configured
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void shouldReturnAllConnected_whenBrokerClientReturnsFullRemoteStreams() throws Exception {
+    var clientStream = new ClientJobStream(TYPE, new ClientStreamId(STREAM_ID, 0), List.of(0));
+    var brokerStream = new RemoteJobStream(TYPE, List.of(Map.of("id", STREAM_ID)));
+    // Gateway has no remote (standalone)
+    when(gatewayClient.fetchJobStreams())
+        .thenReturn(new JobStreamsResponse(List.of(), List.of(clientStream)));
+    when(brokerClient.fetchRemoteStreams()).thenReturn(List.of(brokerStream));
+
+    var service = new OutboundConnectorsService(factory, gatewayClient, brokerClient);
+    var results = service.findAll(RUNTIME_ID);
+
+    assertThat(results.getFirst().brokerConnectivityState())
+        .isEqualTo(BrokerConnectivityState.ALL_CONNECTED);
+  }
+
+  @Test
+  void shouldReturnNone_whenBrokerClientReturnsEmptyList() throws Exception {
+    var clientStream = new ClientJobStream(TYPE, new ClientStreamId(STREAM_ID, 0), List.of(0));
+    when(gatewayClient.fetchJobStreams())
+        .thenReturn(new JobStreamsResponse(List.of(), List.of(clientStream)));
+    when(brokerClient.fetchRemoteStreams()).thenReturn(List.of());
+
+    var service = new OutboundConnectorsService(factory, gatewayClient, brokerClient);
+    var results = service.findAll(RUNTIME_ID);
+
+    assertThat(results.getFirst().brokerConnectivityState())
         .isEqualTo(BrokerConnectivityState.NONE);
+  }
+
+  @Test
+  void shouldReturnUnknownBrokerState_whenBrokerClientThrows() throws Exception {
+    var clientStream = new ClientJobStream(TYPE, new ClientStreamId(STREAM_ID, 0), List.of(0));
+    when(gatewayClient.fetchJobStreams())
+        .thenReturn(new JobStreamsResponse(List.of(), List.of(clientStream)));
+    when(brokerClient.fetchRemoteStreams()).thenThrow(new RuntimeException("broker unreachable"));
+
+    var service = new OutboundConnectorsService(factory, gatewayClient, brokerClient);
+    var results = service.findAll(RUNTIME_ID);
+
+    assertThat(results.getFirst().brokerConnectivityState())
+        .isEqualTo(BrokerConnectivityState.UNKNOWN);
   }
 
   // ---------------------------------------------------------------------------

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/jobstream/BrokerJobStreamClientTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/jobstream/BrokerJobStreamClientTest.java
@@ -1,0 +1,187 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.runtime.outbound.jobstream;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.okJson;
+import static com.github.tomakehurst.wiremock.client.WireMock.serverError;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.verify;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.response.BrokerInfo;
+import io.camunda.client.api.response.Topology;
+import io.camunda.connector.jackson.ConnectorsObjectMapperSupplier;
+import java.io.IOException;
+import java.net.URI;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+@WireMockTest
+class BrokerJobStreamClientTest {
+
+  private static final String JOB_STREAMS_PATH = "/actuator/jobstreams";
+  private static final String JOB_TYPE = "io.camunda:http-json:1";
+  private static final String STREAM_ID = "stream-abc-123";
+
+  // ---------------------------------------------------------------------------
+  // Explicit-addresses mode
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void fetchRemoteStreams_shouldReturnRemoteStreams_withExplicitAddress(
+      WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
+    stubFor(
+        get(JOB_STREAMS_PATH)
+            .willReturn(
+                okJson(
+                    """
+                    {
+                      "remote": [
+                        {"jobType": "io.camunda:http-json:1", "consumers": [{"id": "stream-abc-123"}]}
+                      ],
+                      "client": []
+                    }
+                    """)));
+    var client = clientWithAddresses(wmRuntimeInfo.getHttpPort(), "localhost");
+
+    var result = client.fetchRemoteStreams();
+
+    assertThat(result).hasSize(1);
+    assertThat(result.getFirst().jobType()).isEqualTo(JOB_TYPE);
+    assertThat(result.getFirst().consumers().getFirst()).containsEntry("id", STREAM_ID);
+    verify(getRequestedFor(urlEqualTo(JOB_STREAMS_PATH)));
+  }
+
+  @Test
+  void fetchRemoteStreams_shouldAggregateStreams_fromMultipleExplicitAddresses(
+      WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
+    stubFor(
+        get(JOB_STREAMS_PATH)
+            .willReturn(
+                okJson(
+                    """
+                    {
+                      "remote": [
+                        {"jobType": "io.camunda:http-json:1", "consumers": [{"id": "stream-abc-123"}]}
+                      ],
+                      "client": []
+                    }
+                    """)));
+    int port = wmRuntimeInfo.getHttpPort();
+    // Two explicit addresses pointing at the same mock (simulates 2 brokers)
+    var client = clientWithAddresses(port, "localhost", "localhost");
+
+    var result = client.fetchRemoteStreams();
+
+    assertThat(result).hasSize(2);
+    assertThat(result).allMatch(s -> JOB_TYPE.equals(s.jobType()));
+    verify(2, getRequestedFor(urlEqualTo(JOB_STREAMS_PATH)));
+  }
+
+  @Test
+  void fetchRemoteStreams_shouldReturnEmptyList_whenBrokerHasNoRemoteStreams(
+      WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
+    stubFor(
+        get(JOB_STREAMS_PATH)
+            .willReturn(
+                okJson(
+                    """
+            {"remote": [], "client": []}
+            """)));
+    var client = clientWithAddresses(wmRuntimeInfo.getHttpPort(), "localhost");
+
+    assertThat(client.fetchRemoteStreams()).isEmpty();
+  }
+
+  @Test
+  void fetchRemoteStreams_shouldThrowIOException_whenBrokerReturnsNon200(
+      WireMockRuntimeInfo wmRuntimeInfo) {
+    stubFor(get(JOB_STREAMS_PATH).willReturn(serverError().withBody("boom")));
+    var client = clientWithAddresses(wmRuntimeInfo.getHttpPort(), "localhost");
+
+    assertThatThrownBy(client::fetchRemoteStreams)
+        .isInstanceOf(IOException.class)
+        .hasMessageContaining("Broker job-streams endpoint returned status 500")
+        .hasMessageContaining(JOB_STREAMS_PATH);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Topology-discovery mode (fallback)
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void fetchRemoteStreams_shouldDiscoverBrokersFromTopology_whenNoAddressesConfigured(
+      WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
+    stubFor(
+        get(JOB_STREAMS_PATH)
+            .willReturn(
+                okJson(
+                    """
+                    {
+                      "remote": [
+                        {"jobType": "io.camunda:http-json:1", "consumers": [{"id": "stream-abc-123"}]}
+                      ],
+                      "client": []
+                    }
+                    """)));
+    var client = clientFromTopology(wmRuntimeInfo.getHttpPort(), "localhost");
+
+    var result = client.fetchRemoteStreams();
+
+    assertThat(result).hasSize(1);
+    assertThat(result.getFirst().jobType()).isEqualTo(JOB_TYPE);
+    verify(getRequestedFor(urlEqualTo(JOB_STREAMS_PATH)));
+  }
+
+  // ---------------------------------------------------------------------------
+  // Helpers
+  // ---------------------------------------------------------------------------
+
+  private BrokerJobStreamClient clientWithAddresses(int port, String... hosts) {
+    List<URI> uris = Arrays.stream(hosts).map(h -> URI.create("http://" + h + ":" + port)).toList();
+    return new BrokerJobStreamClient(uris, ConnectorsObjectMapperSupplier.getCopy());
+  }
+
+  private BrokerJobStreamClient clientFromTopology(int port, String... hosts) {
+    CamundaClient camundaClient = mock(CamundaClient.class, RETURNS_DEEP_STUBS);
+    Topology topology = mock(Topology.class);
+    List<BrokerInfo> brokers =
+        Arrays.stream(hosts)
+            .map(
+                host -> {
+                  BrokerInfo broker = mock(BrokerInfo.class);
+                  when(broker.getHost()).thenReturn(host);
+                  return broker;
+                })
+            .toList();
+    when(topology.getBrokers()).thenReturn(brokers);
+    when(camundaClient.newTopologyRequest().send().join()).thenReturn(topology);
+
+    return new BrokerJobStreamClient(camundaClient, port, ConnectorsObjectMapperSupplier.getCopy());
+  }
+}

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/jobstream/StreamConnectivityTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/jobstream/StreamConnectivityTest.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
 
 class StreamConnectivityTest {
@@ -47,12 +48,7 @@ class StreamConnectivityTest {
 
   @Test
   void compute_shouldReturnNotConnected_whenNoClientStreamForJobType() {
-    var jobStreams =
-        new JobStreamsResponse(
-            List.of(new RemoteJobStream(JOB_TYPE, List.of())), List.of() // no client streams
-            );
-
-    var result = StreamConnectivity.compute(JOB_TYPE, jobStreams);
+    var result = StreamConnectivity.compute(JOB_TYPE, List.of(), Optional.empty());
 
     assertThat(result.gatewayState()).isEqualTo(GatewayConnectivityState.NOT_CONNECTED);
     assertThat(result.brokerState()).isNull();
@@ -63,9 +59,8 @@ class StreamConnectivityTest {
   void compute_shouldReturnNotConnected_whenClientStreamExistsForOtherTypeOnly() {
     var clientStream =
         new ClientJobStream(OTHER_TYPE, new ClientStreamId(STREAM_ID, 0), List.of(0));
-    var jobStreams = new JobStreamsResponse(List.of(), List.of(clientStream));
 
-    var result = StreamConnectivity.compute(JOB_TYPE, jobStreams);
+    var result = StreamConnectivity.compute(JOB_TYPE, List.of(clientStream), Optional.empty());
 
     assertThat(result.gatewayState()).isEqualTo(GatewayConnectivityState.NOT_CONNECTED);
   }
@@ -75,11 +70,22 @@ class StreamConnectivityTest {
   // ---------------------------------------------------------------------------
 
   @Test
-  void compute_shouldReturnNonBrokerState_whenNoRemoteStreams() {
+  void compute_shouldReturnUnknown_whenRemoteStreamsAbsent() {
     var clientStream = new ClientJobStream(JOB_TYPE, new ClientStreamId(STREAM_ID, 0), List.of(0));
-    var jobStreams = new JobStreamsResponse(List.of(), List.of(clientStream));
 
-    var result = StreamConnectivity.compute(JOB_TYPE, jobStreams);
+    var result = StreamConnectivity.compute(JOB_TYPE, List.of(clientStream), Optional.empty());
+
+    assertThat(result.gatewayState()).isEqualTo(GatewayConnectivityState.CONNECTED);
+    assertThat(result.brokerState()).isEqualTo(BrokerConnectivityState.UNKNOWN);
+    assertThat(result.streamIds()).containsExactly(STREAM_ID);
+  }
+
+  @Test
+  void compute_shouldReturnNone_whenBrokerStreamsExplicitlyEmpty() {
+    var clientStream = new ClientJobStream(JOB_TYPE, new ClientStreamId(STREAM_ID, 0), List.of(0));
+
+    var result =
+        StreamConnectivity.compute(JOB_TYPE, List.of(clientStream), Optional.of(List.of()));
 
     assertThat(result.gatewayState()).isEqualTo(GatewayConnectivityState.CONNECTED);
     assertThat(result.brokerState()).isEqualTo(BrokerConnectivityState.NONE);
@@ -91,9 +97,10 @@ class StreamConnectivityTest {
     var clientStream = new ClientJobStream(JOB_TYPE, new ClientStreamId(STREAM_ID, 0), List.of(0));
     var broker1 = new RemoteJobStream(JOB_TYPE, List.of(Map.of("id", STREAM_ID)));
     var broker2 = new RemoteJobStream(JOB_TYPE, List.of(Map.of("id", STREAM_ID)));
-    var jobStreams = new JobStreamsResponse(List.of(broker1, broker2), List.of(clientStream));
 
-    var result = StreamConnectivity.compute(JOB_TYPE, jobStreams);
+    var result =
+        StreamConnectivity.compute(
+            JOB_TYPE, List.of(clientStream), Optional.of(List.of(broker1, broker2)));
 
     assertThat(result.gatewayState()).isEqualTo(GatewayConnectivityState.CONNECTED);
     assertThat(result.brokerState()).isEqualTo(BrokerConnectivityState.ALL_CONNECTED);
@@ -105,10 +112,12 @@ class StreamConnectivityTest {
     var clientStream = new ClientJobStream(JOB_TYPE, new ClientStreamId(STREAM_ID, 0), List.of(0));
     var connectedBroker = new RemoteJobStream(JOB_TYPE, List.of(Map.of("id", STREAM_ID)));
     var disconnectedBroker = new RemoteJobStream(JOB_TYPE, List.of()); // no consumers
-    var jobStreams =
-        new JobStreamsResponse(List.of(connectedBroker, disconnectedBroker), List.of(clientStream));
 
-    var result = StreamConnectivity.compute(JOB_TYPE, jobStreams);
+    var result =
+        StreamConnectivity.compute(
+            JOB_TYPE,
+            List.of(clientStream),
+            Optional.of(List.of(connectedBroker, disconnectedBroker)));
 
     assertThat(result.gatewayState()).isEqualTo(GatewayConnectivityState.CONNECTED);
     assertThat(result.brokerState()).isEqualTo(BrokerConnectivityState.PARTIALLY_CONNECTED);
@@ -119,10 +128,10 @@ class StreamConnectivityTest {
     var clientStream = new ClientJobStream(JOB_TYPE, new ClientStreamId(STREAM_ID, 0), List.of(0));
     var brokerWithWrongConsumer =
         new RemoteJobStream(JOB_TYPE, List.of(Map.of("id", "other-stream-id")));
-    var jobStreams =
-        new JobStreamsResponse(List.of(brokerWithWrongConsumer), List.of(clientStream));
 
-    var result = StreamConnectivity.compute(JOB_TYPE, jobStreams);
+    var result =
+        StreamConnectivity.compute(
+            JOB_TYPE, List.of(clientStream), Optional.of(List.of(brokerWithWrongConsumer)));
 
     assertThat(result.brokerState()).isEqualTo(BrokerConnectivityState.PARTIALLY_CONNECTED);
   }
@@ -134,9 +143,9 @@ class StreamConnectivityTest {
   @Test
   void compute_shouldFilterOutNullStreamIds() {
     var clientStreamWithNullId = new ClientJobStream(JOB_TYPE, null, List.of(0));
-    var jobStreams = new JobStreamsResponse(List.of(), List.of(clientStreamWithNullId));
 
-    var result = StreamConnectivity.compute(JOB_TYPE, jobStreams);
+    var result =
+        StreamConnectivity.compute(JOB_TYPE, List.of(clientStreamWithNullId), Optional.empty());
 
     // Gateway connected (client stream exists) but streamIds null (all ids were null)
     assertThat(result.gatewayState()).isEqualTo(GatewayConnectivityState.CONNECTED);
@@ -147,9 +156,8 @@ class StreamConnectivityTest {
   void compute_shouldDeduplicateStreamIds_whenMultipleClientStreamsShareSameId() {
     var stream1 = new ClientJobStream(JOB_TYPE, new ClientStreamId(STREAM_ID, 0), List.of(0));
     var stream2 = new ClientJobStream(JOB_TYPE, new ClientStreamId(STREAM_ID, 1), List.of(1));
-    var jobStreams = new JobStreamsResponse(List.of(), List.of(stream1, stream2));
 
-    var result = StreamConnectivity.compute(JOB_TYPE, jobStreams);
+    var result = StreamConnectivity.compute(JOB_TYPE, List.of(stream1, stream2), Optional.empty());
 
     assertThat(result.streamIds()).containsExactly(STREAM_ID);
   }
@@ -157,13 +165,14 @@ class StreamConnectivityTest {
   @Test
   void compute_shouldOnlyConsiderRemoteStreamsMatchingJobType() {
     var clientStream = new ClientJobStream(JOB_TYPE, new ClientStreamId(STREAM_ID, 0), List.of(0));
-    // remote stream is for a different type — should be ignored
+    // remote stream is for a different type — should be filtered out
     var otherRemote = new RemoteJobStream(OTHER_TYPE, List.of(Map.of("id", STREAM_ID)));
-    var jobStreams = new JobStreamsResponse(List.of(otherRemote), List.of(clientStream));
 
-    var result = StreamConnectivity.compute(JOB_TYPE, jobStreams);
+    var result =
+        StreamConnectivity.compute(
+            JOB_TYPE, List.of(clientStream), Optional.of(List.of(otherRemote)));
 
-    // No remote streams for JOB_TYPE → NONE
+    // No remote streams for JOB_TYPE → NONE (we queried but found nothing for this type)
     assertThat(result.brokerState()).isEqualTo(BrokerConnectivityState.NONE);
   }
 }

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/OutboundConnectorsAutoConfigurationTest.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/OutboundConnectorsAutoConfigurationTest.java
@@ -17,7 +17,9 @@
 package io.camunda.connector.runtime;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.client.CamundaClient;
@@ -33,6 +35,7 @@ import io.camunda.connector.jackson.ConnectorsObjectMapperSupplier;
 import io.camunda.connector.runtime.annotation.ConnectorsObjectMapper;
 import io.camunda.connector.runtime.annotation.OutboundConnectorObjectMapper;
 import io.camunda.connector.runtime.core.secret.SecretProviderAggregator;
+import java.net.URI;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
@@ -90,7 +93,10 @@ class OutboundConnectorsAutoConfigurationTest {
 
     @Bean
     CamundaClient camundaClient() {
-      return mock(CamundaClient.class);
+      CamundaClient client = mock(CamundaClient.class, RETURNS_DEEP_STUBS);
+      when(client.getConfiguration().getRestAddress())
+          .thenReturn(URI.create("http://localhost:26500"));
+      return client;
     }
 
     @Bean

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/inbound/WebhookControllerTestExceptionZeebeTest.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/inbound/WebhookControllerTestExceptionZeebeTest.java
@@ -60,6 +60,7 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
     properties = {
       "spring.main.allow-bean-definition-overriding=true",
       "camunda.connector.webhook.enabled=true",
+      "camunda.connector.gateway.monitoring.enabled=false",
     })
 @CamundaSpringProcessTest
 @ExtendWith(MockitoExtension.class)

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/outbound/OutboundConnectorsRestControllerTest.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/outbound/OutboundConnectorsRestControllerTest.java
@@ -44,7 +44,10 @@ import org.springframework.test.web.servlet.MockMvc;
 
 @SpringBootTest(
     classes = TestConnectorRuntimeApplication.class,
-    properties = "camunda.connector.hostname=localhost")
+    properties = {
+      "camunda.connector.hostname=localhost",
+      "camunda.connector.gateway.monitoring.enabled=false"
+    })
 @AutoConfigureMockMvc
 class OutboundConnectorsRestControllerTest {
 


### PR DESCRIPTION
## Description

### Problem

The `/actuator/jobstreams` endpoint on the Zeebe gateway only populates its `remote` field when the gateway is **embedded** in a broker process. In **standalone gateway** deployments (gateway as a separate container/process), `remote` is always empty because the gateway has no visibility into broker-side streams.

The existing `StreamConnectivity.compute()` method derived both `gatewayState` and `brokerState` from a single call to the gateway's endpoint. As a result, in any standalone gateway deployment:

- `gatewayState` was correct (derived from `client` streams ✅)
- `brokerState` was always `NONE` — even when the brokers were perfectly healthy ❌

This is a **false negative** that makes the `/outbound` monitoring endpoint misleading.

### Fix

Separate the two concerns:

1. **Gateway state** — unchanged, still derived from `client` streams of the gateway's `/actuator/jobstreams` endpoint.
2. **Broker state** — now derived from a dedicated query to each broker's own `/actuator/jobstreams` endpoint, via the new `BrokerJobStreamClient`.

**Topology by topology:**

| Topology | Config | `brokerState` before | `brokerState` after |
|---|---|---|---|
| Embedded gateway | No broker config | `ALL_CONNECTED` / `PARTIAL` / `NONE` ✅ | Unchanged ✅ |
| Standalone gateway | No broker config | `NONE` ❌ (false negative) | **`UNKNOWN`** ✅ (honest) |
| Standalone gateway | Broker addresses set | n/a | `ALL_CONNECTED` / `PARTIAL` / `NONE` ✅ |

### New `BrokerConnectivityState.UNKNOWN`

Added `UNKNOWN` to distinguish "broker state cannot be determined (no broker monitoring configured)" from `NONE` which means "we queried brokers but found no consumer registrations".

### New `BrokerJobStreamClient`

Queries each broker's `/actuator/jobstreams` endpoint and aggregates their `remote` streams. Two sub-modes:

- **Explicit addresses** (preferred for Docker/NAT environments): set `camunda.connector.broker.monitoring.addresses` to a comma-separated list of base URLs (e.g. `http://localhost:9600`). No topology request is made. This avoids the problem where `newTopologyRequest()` returns internal Docker IPs (`172.x.x.x`) that are unreachable from the host.
- **Topology discovery** (fallback): when no addresses are configured, broker hosts are discovered via `CamundaClient.newTopologyRequest()` at query time.

### Configuration

```properties
# Enable broker-side connectivity monitoring (required for standalone gateway)
camunda.connector.broker.monitoring.enabled=true

# Optional: explicit broker monitoring addresses (recommended for Docker)
# Falls back to topology discovery when absent
camunda.connector.broker.monitoring.addresses=http://localhost:9600,http://localhost:9601

# Optional: monitoring port used in topology-discovery mode (default: 9600)
camunda.connector.broker.monitoring.port=9600
```

## Related issues

closes #

## Checklist

- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest
  release, as this branch will be rebased onto main before the next release. Example backport labels:
    - `backport stable/8.8`: for changes that should be included in the next 8.8.x release.
    - **or** `backport release-8.8.7`: for changes that should be included in the specific release 8.8.7, and this
      *release has already been created*. The release branch will be merged back into stable/8.8 later, so the change
      will be included in future 8.8.x releases as well.
- [x] Tests/Integration tests for the changes have been added if applicable.
- [ ] If the change requires a documentation update, it has been added to the appropriate section in the documentation.
