### PR TITLE
fix(runtime): address review comments on broker/gateway monitoring

### DIFF
--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/instances/service/OutboundConnectorsService.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/instances/service/OutboundConnectorsService.java
@@ -95,11 +95,11 @@ public class OutboundConnectorsService {
    * Resolves the broker-side remote streams to use for broker connectivity state computation.
    *
    * <ul>
-   *   <li>If broker monitoring addresses are configured, query brokers directly.
-   *   <li>Otherwise, fall back to the gateway's own {@code remote} data (non-empty only when the
-   *       gateway is embedded in a broker).
+   *   <li>If the broker monitoring client is configured, query brokers directly.
+   *   <li>If the broker query fails, or no broker client is configured, fall back to the gateway's
+   *       own {@code remote} data (non-empty only when the gateway is embedded in a broker).
    *   <li>Returns {@link Optional#empty()} when broker state cannot be determined (standalone
-   *       gateway with no broker addresses configured, or gateway unreachable).
+   *       gateway with broker monitoring unavailable or unreachable, or gateway unreachable).
    * </ul>
    */
   private Optional<List<RemoteJobStream>> resolveBrokerStreams(GatewayResult gateway) {
@@ -111,7 +111,7 @@ public class OutboundConnectorsService {
         return Optional.of(brokerJobStreamClient.fetchRemoteStreams());
       } catch (Exception e) {
         LOG.warn("Failed to fetch remote streams from brokers: {}", e.getMessage());
-        return Optional.empty();
+        // Fall through to gateway remote fallback below.
       }
     }
     // Fallback: use gateway's remote field (populated only for embedded gateways).

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/OutboundConnectorRuntimeConfiguration.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/OutboundConnectorRuntimeConfiguration.java
@@ -99,8 +99,8 @@ public class OutboundConnectorRuntimeConfiguration {
   }
 
   /**
-   * Creates a {@link BrokerJobStreamClient} when broker monitoring is explicitly enabled via {@code
-   * camunda.connector.broker.monitoring.enabled=true} (match if missing).
+   * Creates a {@link BrokerJobStreamClient} when broker monitoring is enabled (on by default; set
+   * {@code camunda.connector.broker.monitoring.enabled=false} to disable).
    *
    * <p>Two sub-modes, controlled by {@code camunda.connector.broker.monitoring.addresses}:
    *
@@ -108,9 +108,10 @@ public class OutboundConnectorRuntimeConfiguration {
    *   <li><b>Explicit addresses</b> (recommended for Docker/NAT'd envs): set {@code
    *       camunda.connector.broker.monitoring.addresses} to a comma-separated list of base URLs
    *       (e.g. {@code http://localhost:9600,http://localhost:9601}). No topology request is made.
-   *   <li><b>Topology discovery</b> (default fallback): when {@code addresses} is not set, broker
-   *       hosts are discovered via the Camunda topology API. The monitoring port defaults to {@code
-   *       9600} and can be overridden via {@code camunda.connector.broker.monitoring.port}.
+   *   <li><b>Topology discovery</b> (default fallback): when {@code addresses} is blank or resolves
+   *       to an empty list, broker hosts are discovered via the Camunda topology API. The
+   *       monitoring port defaults to {@code 9600} and can be overridden via {@code
+   *       camunda.connector.broker.monitoring.port}.
    * </ul>
    */
   @Bean
@@ -130,7 +131,9 @@ public class OutboundConnectorRuntimeConfiguration {
               .filter(s -> !s.isBlank())
               .map(URI::create)
               .toList();
-      return new BrokerJobStreamClient(uris, mapper);
+      if (!uris.isEmpty()) {
+        return new BrokerJobStreamClient(uris, mapper);
+      }
     }
     return new BrokerJobStreamClient(camundaClient, monitoringPort, mapper);
   }

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/jobstream/BrokerConnectivityState.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/jobstream/BrokerConnectivityState.java
@@ -20,10 +20,11 @@ package io.camunda.connector.runtime.outbound.jobstream;
  * Describes the connectivity state of an outbound connector worker to the Zeebe brokers.
  *
  * <ul>
- *   <li>{@code UNKNOWN} – Broker state cannot be determined. This happens when no broker monitoring
- *       addresses are configured ({@code camunda.connector.broker.monitoring.addresses}) and the
- *       gateway's remote streams are empty (standalone gateway deployment). Configure broker
- *       addresses to get accurate broker connectivity state.
+ *   <li>{@code UNKNOWN} – Broker state cannot be determined. This can happen when: broker
+ *       monitoring is not configured; broker monitoring is configured but the query failed and the
+ *       gateway's remote streams are also empty; or the gateway is a standalone deployment with no
+ *       embedded broker. Enable and configure broker monitoring to get accurate broker connectivity
+ *       state.
  *   <li>{@code NONE} – Brokers were queried but no client stream appears as a consumer in any
  *       broker's remote stream. This indicates a genuine connectivity problem.
  *   <li>{@code PARTIALLY_CONNECTED} – Client streams exist on the gateway, but they do not appear

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/jobstream/StreamConnectivity.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/jobstream/StreamConnectivity.java
@@ -31,9 +31,9 @@ import java.util.Set;
  *   <li>Gateway state comes from the {@code client} streams of the gateway's {@code
  *       /actuator/jobstreams} endpoint.
  *   <li>Broker state comes from the {@code remote} streams queried directly from each broker (when
- *       broker addresses are configured), or falls back to the gateway's own {@code remote} data
- *       (only non-empty when the gateway is embedded in a broker). When neither source is
- *       available, broker state is {@link BrokerConnectivityState#UNKNOWN}.
+ *       broker monitoring is configured and reachable), or falls back to the gateway's own {@code
+ *       remote} data (only non-empty when the gateway is embedded in a broker). When neither source
+ *       is available, broker state is {@link BrokerConnectivityState#UNKNOWN}.
  * </ul>
  *
  * @param gatewayState whether the connector is registered as a client stream on the gateway
@@ -58,9 +58,9 @@ public record StreamConnectivity(
    * @param jobType the job type to compute state for
    * @param allClientStreams all client streams from the gateway's response
    * @param allRemoteStreams broker-side remote streams; {@link Optional#empty()} when broker state
-   *     cannot be determined (standalone gateway with no broker addresses configured), which yields
-   *     {@link BrokerConnectivityState#UNKNOWN}; a present {@link Optional} with an empty list
-   *     yields {@link BrokerConnectivityState#NONE}
+   *     cannot be determined (broker monitoring not configured or unavailable, and no embedded
+   *     gateway remote data), which yields {@link BrokerConnectivityState#UNKNOWN}; a present
+   *     {@link Optional} with an empty list yields {@link BrokerConnectivityState#NONE}
    */
   public static StreamConnectivity compute(
       String jobType,


### PR DESCRIPTION
## Summary

Follow-up to #7570 addressing Copilot review comments:

- **Empty broker addresses guard**: if `camunda.connector.broker.monitoring.addresses` is set but resolves to an empty list (e.g. `","` input), now falls back to topology discovery instead of creating a client with zero targets and reporting a false `NONE`
- **Broker failure fallback**: when the broker client is configured but `fetchRemoteStreams()` throws, the code now falls through to the gateway-remote fallback — embedded-gateway deployments remain functional when broker endpoints are temporarily unreachable
- **Javadoc accuracy**: updated `BrokerJobStreamClient` bean doc to reflect opt-out semantics (`matchIfMissing=true`); updated `UNKNOWN` state description in `BrokerConnectivityState` to cover all scenarios; aligned `StreamConnectivity` Javadocs to reference client availability rather than address configuration

## Test plan

- [ ] Existing test suite passes (105 tests in `spring-boot-starter-camunda-connectors`, `connector-runtime-spring`)
- [ ] Empty addresses string (e.g. `","`) falls back to topology discovery — no `NONE` false negative
- [ ] Broker fetch failure in an embedded-gateway setup still reports correct state via gateway remote fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)