### PR TITLE
fix(runtime): defer GatewayJobStreamClient URI resolution to fix e2e test failures

### DIFF
--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/jobstream/GatewayJobStreamClient.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/jobstream/GatewayJobStreamClient.java
@@ -35,18 +35,17 @@ public class GatewayJobStreamClient {
 
   private static final String JOB_STREAMS_PATH = "/actuator/jobstreams";
 
-  private final URI monitoringBaseUri;
+  private final CamundaClient camundaClient;
+  private final int monitoringPort;
   private final ObjectMapper objectMapper;
   private final HttpClient httpClient;
 
   public GatewayJobStreamClient(
       CamundaClient camundaClient, int monitoringPort, ObjectMapper objectMapper) {
+    this.camundaClient = camundaClient;
+    this.monitoringPort = monitoringPort;
     this.objectMapper = objectMapper;
     this.httpClient = HttpClient.newHttpClient();
-
-    URI restAddress = camundaClient.getConfiguration().getRestAddress();
-    this.monitoringBaseUri =
-        URI.create(restAddress.getScheme() + "://" + restAddress.getHost() + ":" + monitoringPort);
   }
 
   /**
@@ -57,6 +56,9 @@ public class GatewayJobStreamClient {
    * @throws Exception if the request fails for any other reason (network error, parse error, etc.)
    */
   public JobStreamsResponse fetchJobStreams() throws Exception {
+    URI restAddress = camundaClient.getConfiguration().getRestAddress();
+    URI monitoringBaseUri =
+        URI.create(restAddress.getScheme() + "://" + restAddress.getHost() + ":" + monitoringPort);
     URI uri = monitoringBaseUri.resolve(JOB_STREAMS_PATH);
     HttpRequest request = HttpRequest.newBuilder(uri).GET().build();
     HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());


### PR DESCRIPTION
## Summary

- `GatewayJobStreamClient` called `camundaClient.getConfiguration()` eagerly in its constructor
- The `gatewayJobStreamClient` bean is opt-out (`matchIfMissing = true`), so it is created by default in every Spring context — including e2e tests using `@CamundaSpringProcessTest`
- That framework wires a proxy `CamundaClient` not initialized until the test method starts, causing context startup to fail with: *"CamundaClient is currently not initialized. Maybe you run outside of a testcase?"*
- This was the root cause of `HttpTests` and `WebhookActivatedDocumentTests` failing in CI

## Fix

Move `camundaClient.getConfiguration().getRestAddress()` from the constructor into `fetchJobStreams()`, so URI resolution happens at request time (when the proxy is live) instead of at bean-creation time.

This is the minimal root-cause fix. The prior workaround commits (#7579, #7580) added `camunda.connector.gateway.monitoring.enabled=false` to unit tests — those remain valid for tests that explicitly need gateway monitoring disabled. This fix covers the e2e tests without requiring per-test property overrides.

## Test plan

- [x] `GatewayJobStreamClientTest` — 3/3 pass
- [x] `StreamConnectivityTest` — 11/11 pass
- [x] `OutboundConnectorsAutoConfigurationTest` — 3/3 pass
- [x] `OutboundConnectorsRestControllerTest` — 4/4 pass
- `HttpTests` and `WebhookActivatedDocumentTests` require a running Zeebe cluster; context no longer fails at startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)