### PR TITLE
fix(ci): correct nightly e2e notify jq syntax and spurious matrix jobs

### DIFF
--- a/.github/workflows/E2E_BRANCH_RUN.yml
+++ b/.github/workflows/E2E_BRANCH_RUN.yml
@@ -76,8 +76,9 @@ jobs:
 
       # Discover the e2e-test modules to run from this branch's checkout so the test matrix is
       # branch-accurate. Leaf poms with `jar` packaging are test modules; aggregators (`pom`
-      # packaging) and `*-base` shared libraries are excluded. Paths are emitted relative to
-      # connectors-e2e-test/pom.xml so they can be passed directly to `-pl`.
+      # packaging) and `*-base` shared libraries are excluded. Each entry is a
+      # {"module": "...", "runner": "..."} object; runner overrides come from
+      # e2e-runner-overrides.json (modules not listed there default to ubuntu-latest).
       - name: Discover e2e-test modules
         id: set-modules
         run: |
@@ -86,8 +87,11 @@ jobs:
             pkg=$(grep -m1 -oP '(?<=<packaging>)[^<]+' "$p" || echo jar)
             [ "$pkg" = "pom" ] && continue
             case "$base" in *-base) continue;; esac
-            echo "${d#connectors-e2e-test/}"
-          done | jq -R -s -c 'split("\n") | map(select(length>0))')
+            module="${d#connectors-e2e-test/}"
+            runner=$(jq -r --arg m "$module" '.[$m] // "ubuntu-latest"' \
+              .github/workflows/e2e-runner-overrides.json)
+            printf '{"module":"%s","runner":"%s"}\n' "$module" "$runner"
+          done | jq -sc '.')
           echo "modules=$modules" >> "$GITHUB_OUTPUT"
 
       - name: Sanitize branch name for artifact
@@ -106,20 +110,16 @@ jobs:
           include-hidden-files: true
           overwrite: true
 
-  # Test phase (matrix: module): each e2e-test module runs in its own job, in isolation.
-  # Defaults to ubuntu-latest; resource-heavy modules override the runner via matrix.include.
+  # Test phase (matrix: entry): each e2e-test module runs in its own job, in isolation.
+  # Runner is baked into each entry by the build job (sourced from e2e-runner-overrides.json).
   test:
-    name: ${{ matrix.module }}
+    name: ${{ matrix.entry.module }}
     needs: build
-    runs-on: ${{ matrix.runner || 'ubuntu-latest' }}
+    runs-on: ${{ matrix.entry.runner }}
     strategy:
       fail-fast: false
       matrix:
-        module: ${{ fromJson(needs.build.outputs.modules) }}
-        include:
-          # Override the runner for resource-heavy modules; all others use ubuntu-latest.
-          - module: connectors-e2e-test-agentic-ai
-            runner: gcp-core-8-default
+        entry: ${{ fromJson(needs.build.outputs.modules) }}
     steps:
       - uses: actions/checkout@v7
         with:
@@ -177,7 +177,7 @@ jobs:
           echo "module=${MODULE//\//-}" >> "$GITHUB_OUTPUT"
         env:
           BRANCH: ${{ inputs.branch }}
-          MODULE: ${{ matrix.module }}
+          MODULE: ${{ matrix.entry.module }}
 
       # Restore the first-party SNAPSHOTs built by the build job; the test run resolves
       # connectors + e2e base from here and does not rebuild them.
@@ -190,13 +190,13 @@ jobs:
       # Run only this module's tests. No -am: base/connector SNAPSHOTs come from the downloaded
       # artifact, so nothing upstream is rebuilt.
       - name: Test e2e module
-        run: ./mvnw --batch-mode test -pl "${{ matrix.module }}" -f connectors-e2e-test/pom.xml
+        run: ./mvnw --batch-mode test -pl "${{ matrix.entry.module }}" -f connectors-e2e-test/pom.xml
 
       - name: Publish Test Report
         if: always()
         uses: scacap/action-surefire-report@v1
         with:
-          check_name: Tests (${{ inputs.branch }} / ${{ matrix.module }})
+          check_name: Tests (${{ inputs.branch }} / ${{ matrix.entry.module }})
 
       - name: Upload detailed surefire reports
         if: always()
@@ -226,15 +226,18 @@ jobs:
           BRANCH: ${{ inputs.branch }}
         run: |
           prefix="(${BRANCH}) / "
-          # $p is a jq variable passed via --arg, not a shell variable
-          # shellcheck disable=SC2016
+          # --paginate emits one JSON doc per page; --slurp collects them so .[].jobs[] spans all pages.
           failed_modules=$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID/jobs" \
-            --paginate \
-            --jq --arg p "$prefix" \
-            '[.jobs[] | select(.conclusion == "failure") | select(.name | startswith($p)) | .name | ltrimstr($p) | select(test("^connectors-"))] | map("• " + .) | join("\\n")' \
+            --paginate | \
+            jq -rs --arg p "$prefix" \
+            '[.[].jobs[] | select(.conclusion == "failure") | select(.name | startswith($p)) | .name | ltrimstr($p) | select(test("^connectors-"))] | map("• " + .) | join("\n")' \
           )
           [ -z "$failed_modules" ] && failed_modules="(see run for details)"
-          echo "failed_modules=$failed_modules" >> "$GITHUB_OUTPUT"
+          {
+            echo "failed_modules<<EOF_MODULES"
+            echo "$failed_modules"
+            echo "EOF_MODULES"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Post failure summary to Slack
         uses: slackapi/slack-github-action@v3.0.3

--- a/.github/workflows/E2E_BRANCH_RUN.yml
+++ b/.github/workflows/E2E_BRANCH_RUN.yml
@@ -88,8 +88,11 @@ jobs:
             [ "$pkg" = "pom" ] && continue
             case "$base" in *-base) continue;; esac
             module="${d#connectors-e2e-test/}"
-            runner=$(jq -r --arg m "$module" '.[$m] // "ubuntu-latest"' \
-              .github/workflows/e2e-runner-overrides.json)
+            runner="ubuntu-latest"
+            if [ -f .github/workflows/e2e-runner-overrides.json ]; then
+              runner=$(jq -r --arg m "$module" '.[$m] // "ubuntu-latest"' .github/workflows/e2e-runner-overrides.json)
+            fi
+            case "$runner" in ubuntu-latest|gcp-core-8-default) ;; *) runner="ubuntu-latest";; esac
             printf '{"module":"%s","runner":"%s"}\n' "$module" "$runner"
           done | jq -sc '.')
           echo "modules=$modules" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/NIGHTLY_E2E.yml
+++ b/.github/workflows/NIGHTLY_E2E.yml
@@ -23,16 +23,10 @@ jobs:
       - name: Fetch stable branches
         id: set-branches
         run: |
-          if [ "${{ github.event_name }}" == "pull_request" ]; then
-            # For PR, only test the PR's head ref
-            echo "branches=[\"${{ github.head_ref }}\"]" >> $GITHUB_OUTPUT
-          else
-            # For scheduled/manual runs, test main and all stable branches
-            git ls-remote --heads https://github.com/${{ github.repository }}.git | \
-            awk '{print $2}' | sed 's|refs/heads/||' | grep '^stable/' > stables.txt || true
-            all_branches=$( (echo "main"; cat stables.txt) | grep -v '^$' | jq -R -s -c 'split("\n")[:-1]' )
-            echo "branches=$all_branches" >> $GITHUB_OUTPUT
-          fi
+          git ls-remote --heads https://github.com/${{ github.repository }}.git | \
+          awk '{print $2}' | sed 's|refs/heads/||' | grep '^stable/' > stables.txt || true
+          all_branches=$( (echo "main"; cat stables.txt) | grep -v '^$' | jq -R -s -c 'split("\n")[:-1]' )
+          echo "branches=$all_branches" >> $GITHUB_OUTPUT
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/e2e-runner-overrides.json
+++ b/.github/workflows/e2e-runner-overrides.json
@@ -1,0 +1,3 @@
+{
+  "connectors-e2e-test-agentic-ai": "gcp-core-8-default"
+}


### PR DESCRIPTION
## Description

Bug 1 — gh api --jq does not forward --arg to jq; passing both caused "accepts 1 arg(s), received 4". Fix: pipe --paginate output through `jq -rs --arg` so the filter receives the prefix variable correctly. Also switch GITHUB_OUTPUT write to the multiline heredoc form since the value may now contain real newlines.

Bug 2 — matrix.include with a module name not present in the dynamic discovery list unconditionally adds a new job (GitHub Actions footgun). This caused connectors-e2e-test-agentic-ai to run on stable/8.7 where the module doesn't exist. Fix: embed runner into the discovery output as {"module": "...", "runner": "..."} objects resolved from the new e2e-runner-overrides.json config file, eliminating matrix.include entirely. To assign a custom runner to a new module, add one line to the JSON file — no YAML changes required.

## Checklist

- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest
  release, as this branch will be rebased onto main before the next release. Example backport labels:
    - `backport stable/8.8`: for changes that should be included in the next 8.8.x release.
    - **or** `backport release-8.8.7`: for changes that should be included in the specific release 8.8.7, and this
      *release has already been created*. The release branch will be merged back into stable/8.8 later, so the change
      will be included in future 8.8.x releases as well.
- [ ] Tests/Integration tests for the changes have been added if applicable.
- [ ] If the change requires a documentation update, it has been added to the appropriate section in the documentation.


