### PR TITLE
fix: bump netty to 4.2.15.Final

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -141,6 +141,8 @@ limitations under the License.</license.inlineheader>
     <version.awaitility>4.3.0</version.awaitility>
     <version.json-path>2.10.0</version.json-path>
 
+    <version.netty-codec-dns>4.1.133.Final</version.netty-codec-dns>
+
     <version.snappy-java>1.1.10.8</version.snappy-java>
     <version.commons-codec>1.22.0</version.commons-codec>
     <version.guava>33.6.0-jre</version.guava>
@@ -580,6 +582,13 @@ limitations under the License.</license.inlineheader>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-lang3</artifactId>
         <version>3.20.0</version>
+      </dependency>
+
+      <!-- CVE-2026-42579 fix: pin netty-codec-dns to 4.1.133.Final -->
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-codec-dns</artifactId>
+        <version>${version.netty-codec-dns}</version>
       </dependency>
 
       <!-- Fixes CWE-770 -->

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -141,7 +141,7 @@ limitations under the License.</license.inlineheader>
     <version.awaitility>4.3.0</version.awaitility>
     <version.json-path>2.10.0</version.json-path>
 
-    <version.netty-codec-dns>4.1.133.Final</version.netty-codec-dns>
+    <version.netty>4.2.15.Final</version.netty>
 
     <version.snappy-java>1.1.10.8</version.snappy-java>
     <version.commons-codec>1.22.0</version.commons-codec>
@@ -183,6 +183,15 @@ limitations under the License.</license.inlineheader>
         <groupId>com.fasterxml.jackson.datatype</groupId>
         <artifactId>jackson-datatype-jsr310</artifactId>
         <version>${version.jackson-datatype-jsr310}</version>
+      </dependency>
+
+      <!-- Netty BOM — imported before Spring Boot BOM to take precedence -->
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-bom</artifactId>
+        <version>${version.netty}</version>
+        <type>pom</type>
+        <scope>import</scope>
       </dependency>
 
       <!-- Spring Boot BOM -->
@@ -584,12 +593,6 @@ limitations under the License.</license.inlineheader>
         <version>3.20.0</version>
       </dependency>
 
-      <!-- CVE-2026-42579 fix: pin netty-codec-dns to 4.1.133.Final -->
-      <dependency>
-        <groupId>io.netty</groupId>
-        <artifactId>netty-codec-dns</artifactId>
-        <version>${version.netty-codec-dns}</version>
-      </dependency>
 
       <!-- Fixes CWE-770 -->
       <dependency>


### PR DESCRIPTION
## Summary

Pins `io.netty:netty-bom` to `4.2.15.Final` explicitly (Spring Boot 3.5.14 BOM shipped 4.1.132.Final). Also removes the now-redundant individual `netty-codec-dns` pin introduced for a prior CVE — it is covered by the netty BOM at 4.2.15.Final.

Security fix. Details in the internal tracking issue: camunda/team-connectors#1233