### PR TITLE
fix(document-handling): Fix missing file size check on large inline d…

### DIFF
--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/correlation/InboundCorrelationHandler.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/correlation/InboundCorrelationHandler.java
@@ -16,6 +16,7 @@
  */
 package io.camunda.connector.runtime.core.inbound.correlation;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.command.ClientStatusException;
@@ -23,6 +24,7 @@ import io.camunda.client.api.response.CorrelateMessageResponse;
 import io.camunda.client.api.response.ProcessInstanceEvent;
 import io.camunda.client.api.response.ProcessInstanceResult;
 import io.camunda.client.api.response.PublishMessageResponse;
+import io.camunda.connector.api.document.InlineSizeGuard;
 import io.camunda.connector.api.error.ConnectorInputException;
 import io.camunda.connector.api.inbound.ActivationCheckResult;
 import io.camunda.connector.api.inbound.CorrelationRequest;
@@ -57,10 +59,12 @@ public class InboundCorrelationHandler {
   private final Duration defaultMessageTtl;
 
   private final ConnectorResultHandler connectorResultHandler;
+  private final ObjectMapper objectMapper;
 
   public InboundCorrelationHandler(
       CamundaClient camundaClient, ObjectMapper objectMapper, Duration defaultMessageTtl) {
     this.camundaClient = camundaClient;
+    this.objectMapper = objectMapper;
     this.activationConditionEvaluator = new ActivationConditionEvaluator(feelExpressionEvaluator);
     this.defaultMessageTtl = defaultMessageTtl;
     this.connectorResultHandler = new ConnectorResultHandler(objectMapper);
@@ -123,6 +127,11 @@ public class InboundCorrelationHandler {
       StartEventCorrelationPoint correlationPoint,
       Object variables) {
     Object extractedVariables = extractVariables(variables, activatedElement);
+    try {
+      checkVariablesSize(extractedVariables);
+    } catch (ConnectorInputException e) {
+      return new CorrelationResult.Failure.InvalidInput(e.getMessage(), e);
+    }
     if (activatedElement.synchronousResponse()) {
       return triggerStartEventWithResult(activatedElement, correlationPoint, extractedVariables);
     } else {
@@ -254,6 +263,11 @@ public class InboundCorrelationHandler {
       String correlationKey) {
     Object extractedVariables = extractVariables(variables, activatedElement);
     try {
+      checkVariablesSize(extractedVariables);
+    } catch (ConnectorInputException e) {
+      return new CorrelationResult.Failure.InvalidInput(e.getMessage(), e);
+    }
+    try {
       var step2 = camundaClient.newCorrelateMessageCommand().messageName(messageName);
       var step3 =
           correlationKey.isBlank()
@@ -288,6 +302,11 @@ public class InboundCorrelationHandler {
       Duration timeToLive,
       String correlationKey) {
     Object extractedVariables = extractVariables(variables, activatedElement);
+    try {
+      checkVariablesSize(extractedVariables);
+    } catch (ConnectorInputException e) {
+      return new CorrelationResult.Failure.InvalidInput(e.getMessage(), e);
+    }
     CorrelationResult result;
     try {
       var command =
@@ -361,6 +380,15 @@ public class InboundCorrelationHandler {
   protected Object extractVariables(Object rawVariables, InboundConnectorElement definition) {
     return connectorResultHandler.createOutputVariables(
         rawVariables, definition.resultVariable(), definition.resultExpression());
+  }
+
+  private void checkVariablesSize(Object variables) {
+    if (variables == null) return;
+    try {
+      InlineSizeGuard.check(objectMapper.writeValueAsBytes(variables).length);
+    } catch (JsonProcessingException e) {
+      throw new RuntimeException("Failed to serialize variables for size check", e);
+    }
   }
 
   private String resolveMessageId(String messageIdExpression, String messageId, Object context) {

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/SpringConnectorJobHandler.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/SpringConnectorJobHandler.java
@@ -18,6 +18,7 @@ package io.camunda.connector.runtime.outbound.job;
 
 import static java.util.Objects.requireNonNullElse;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.client.api.command.JobCallbackFinalCommandStep;
 import io.camunda.client.api.response.ActivatedJob;
@@ -165,7 +166,8 @@ public class SpringConnectorJobHandler implements JobHandler {
 
       var connectorResponse = getConnectorResponse(context);
 
-      if (connectorResponse instanceof AdHocSubProcessConnectorResponse) {
+      if (connectorResponse instanceof AdHocSubProcessConnectorResponse ahsp) {
+        InlineSizeGuard.check(objectMapper.writeValueAsBytes(ahsp.variables()).length);
         // AHSP responses provide their own variables; skip result expression evaluation
         return new ConnectorResult.SuccessResult(connectorResponse, Map.of());
       }
@@ -268,6 +270,7 @@ public class SpringConnectorJobHandler implements JobHandler {
 
     switch (error) {
       case BpmnError bpmnError -> {
+        checkVariablesSize(bpmnError.variables());
         LOGGER.debug(
             "Throwing BPMN error for job {} with code {}", job.getKey(), bpmnError.errorCode());
         CompletableFuture<CommandOutcome> throwBpmnErrorRequest =
@@ -284,6 +287,7 @@ public class SpringConnectorJobHandler implements JobHandler {
                     completionFailure));
       }
       case JobError jobError -> {
+        checkVariablesSize(jobError.variablesWithErrorMessage());
         LOGGER.debug("Throwing incident for job {}", job.getKey());
         CompletableFuture<CommandOutcome> failJobRequest =
             failJob(
@@ -338,6 +342,7 @@ public class SpringConnectorJobHandler implements JobHandler {
           response,
           completionFailure -> new ExecutionFailed(cause, completionFailure));
     } else {
+      checkVariablesSize(ignoreError.variables());
       LOGGER.debug("Ignoring error for job {}", job.getKey());
       completeJob(
           client,
@@ -485,6 +490,15 @@ public class SpringConnectorJobHandler implements JobHandler {
 
               return adHocSubProcess;
             });
+  }
+
+  private void checkVariablesSize(Map<String, Object> variables) {
+    if (variables == null || variables.isEmpty()) return;
+    try {
+      InlineSizeGuard.check(objectMapper.writeValueAsBytes(variables).length);
+    } catch (JsonProcessingException e) {
+      throw new RuntimeException("Failed to serialize variables for size check", e);
+    }
   }
 
   private static String truncateErrorMessage(String message) {

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/SpringConnectorJobHandler.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/SpringConnectorJobHandler.java
@@ -32,6 +32,7 @@ import io.camunda.client.metrics.MetricsRecorder;
 import io.camunda.client.metrics.MetricsRecorder.CounterMetricsContext;
 import io.camunda.client.metrics.MetricsRecorder.TimerMetricsContext;
 import io.camunda.connector.api.document.DocumentFactory;
+import io.camunda.connector.api.document.InlineSizeGuard;
 import io.camunda.connector.api.outbound.ConnectorResponse;
 import io.camunda.connector.api.outbound.ConnectorResponse.AdHocSubProcessConnectorResponse;
 import io.camunda.connector.api.outbound.ConnectorResponse.AdHocSubProcessConnectorResponse.ElementActivation;
@@ -174,6 +175,9 @@ public class SpringConnectorJobHandler implements JobHandler {
               connectorResponse.responseValue(),
               job.getCustomHeaders().get(Keywords.RESULT_VARIABLE_KEYWORD),
               job.getCustomHeaders().get(Keywords.RESULT_EXPRESSION_KEYWORD));
+      if (!responseVariables.isEmpty()) {
+        InlineSizeGuard.check(objectMapper.writeValueAsBytes(responseVariables).length);
+      }
       return new ConnectorResult.SuccessResult(connectorResponse, responseVariables);
     } catch (Exception e) {
       return outboundConnectorExceptionHandler.manageConnectorJobHandlerException(

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/job/SpringConnectorJobHandlerTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/job/SpringConnectorJobHandlerTest.java
@@ -228,6 +228,42 @@ class SpringConnectorJobHandlerTest {
         // then
         assertThat(result.getVariables()).isEqualTo(Map.of("result", 1));
       }
+
+      @Test
+      void shouldFailJobWhenResultVariableExceedsZeebeLimit() throws Exception {
+        // given
+        String largeValue =
+            "x"
+                .repeat(
+                    (int) io.camunda.connector.api.document.InlineSizeGuard.MAX_INLINE_BYTES + 1);
+        var jobHandler = newConnectorJobHandler((ctx) -> largeValue);
+
+        // when
+        var result =
+            JobBuilder.create()
+                .withRetries(3)
+                .withResultVariableHeader("result")
+                .executeAndCaptureResult(jobHandler, false);
+
+        // then - oversized payload is a deterministic input error: immediate incident, no retries
+        assertThat(result.getRetries()).isEqualTo(0);
+        assertThat(result.getErrorMessage()).contains("Create document");
+      }
+
+      @Test
+      void shouldCompleteJobWhenResultVariableBelowZeebeLimit() throws Exception {
+        // given
+        var jobHandler = newConnectorJobHandler((ctx) -> "small value");
+
+        // when
+        var result =
+            JobBuilder.create()
+                .withResultVariableHeader("result")
+                .executeAndCaptureResult(jobHandler);
+
+        // then
+        assertThat(result.getVariables()).containsKey("result");
+      }
     }
 
     @Nested

--- a/connector-sdk/core/src/main/java/io/camunda/connector/api/document/InlineSizeGuard.java
+++ b/connector-sdk/core/src/main/java/io/camunda/connector/api/document/InlineSizeGuard.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.api.document;
+
+import io.camunda.connector.api.error.ConnectorInputException;
+
+public final class InlineSizeGuard {
+
+  // Zeebe safe limit for commands that include variables (e.g. complete-job):
+  // https://docs.camunda.io/docs/components/concepts/variables/#variable-size-limitation
+  public static final long MAX_INLINE_BYTES = 3L * 1024 * 1024 / 2; // 1.5 MB
+
+  private InlineSizeGuard() {}
+
+  public static void check(long sizeBytes) {
+    if (sizeBytes > MAX_INLINE_BYTES) {
+      throw new ConnectorInputException(
+          "Output variables payload (%d bytes) exceeds the 1.5 MB safe variable size limit for Zeebe job completion. To handle large payloads, enable the 'Create document' option where available."
+              .formatted(sizeBytes));
+    }
+  }
+}


### PR DESCRIPTION
…ocuments

## Description

Adding a guard to give users feedback and fail processes on file to big errors, instead of just a stuck process.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #7049 

## Checklist

- [x] Backport labels are added if these code changes should be backported. No backport label is added to the latest
  release, as this branch will be rebased onto main before the next release. Example backport labels:
    - `backport stable/8.8`: for changes that should be included in the next 8.8.x release.
    - **or** `backport release-8.8.7`: for changes that should be included in the specific release 8.8.7, and this
      *release has already been created*. The release branch will be merged back into stable/8.8 later, so the change
      will be included in future 8.8.x releases as well.
- [x] Tests/Integration tests for the changes have been added if applicable.
- [x] If the change requires a documentation update, it has been added to the appropriate section in the documentation.


