### PR TITLE
fix(ci): remove issue from connectors project when label routes to specific project

### DIFF
--- a/.github/workflows/ADD_TO_PROJECT.yml
+++ b/.github/workflows/ADD_TO_PROJECT.yml
@@ -61,19 +61,8 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
-          ITEM_DATA=$(gh api graphql \
-            -f query='query($owner: String!, $repo: String!, $issueNumber: Int!) { repository(owner: $owner, name: $repo) { issue(number: $issueNumber) { projectItems(first: 20) { nodes { id project { ... on ProjectV2 { number id } } } } } } }' \
-            -F owner='${{ github.repository_owner }}' \
-            -F repo='${{ github.event.repository.name }}' \
-            -F issueNumber=${{ github.event.issue.number }})
-          PROJECT_ID=$(echo “$ITEM_DATA” | jq -r '.data.repository.issue.projectItems.nodes[] | select(.project.number == 23) | .project.id' | head -1)
-          ITEM_ID=$(echo “$ITEM_DATA” | jq -r '.data.repository.issue.projectItems.nodes[] | select(.project.number == 23) | .id' | head -1)
-          if [ -n “$ITEM_ID” ] && [ “$ITEM_ID” != “null” ]; then
-            gh api graphql \
-              -f query='mutation($projectId: ID!, $itemId: ID!) { deleteProjectV2Item(input: { projectId: $projectId, itemId: $itemId }) { deletedItemId } }' \
-              -F projectId=”$PROJECT_ID” \
-              -F itemId=”$ITEM_ID”
-          fi
+          PROJECT_TITLE=$(gh project view 23 --owner camunda --format json | jq -r '.title')
+          gh issue edit “${{ github.event.issue.number }}” --remove-project “$PROJECT_TITLE” --repo “${{ github.repository }}”
 
   add-default:
     name: Add issue to project if no label

--- a/.github/workflows/ADD_TO_PROJECT.yml
+++ b/.github/workflows/ADD_TO_PROJECT.yml
@@ -15,15 +15,6 @@ jobs:
   add-by-label:
     name: Add issue to project if label
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        mapping:
-          - label: idp
-            project-url: https://github.com/orgs/camunda/projects/133/views/1
-          - label: agentic-ai
-            project-url: https://github.com/orgs/camunda/projects/155/views/1
-
     steps:
       - name: Import Secrets
         id: vault-secrets
@@ -53,25 +44,32 @@ jobs:
         env:
           GITHUB_EVENT_PATH: ${{ github.event_path }}
 
-      - name: Add to project if “${{ matrix.mapping.label }}” present
-        if: contains(steps.get-labels.outputs.labels, matrix.mapping.label)
+      - name: Add to idp project
+        if: contains(steps.get-labels.outputs.labels, 'idp')
         uses: actions/add-to-project@v2.0.0
         with:
-          project-url: ${{ matrix.mapping.project-url }}
+          project-url: https://github.com/orgs/camunda/projects/133/views/1
+          github-token: ${{ steps.app-token.outputs.token }}
+
+      - name: Add to agentic-ai project
+        if: contains(steps.get-labels.outputs.labels, 'agentic-ai')
+        uses: actions/add-to-project@v2.0.0
+        with:
+          project-url: https://github.com/orgs/camunda/projects/155/views/1
           github-token: ${{ steps.app-token.outputs.token }}
 
       - name: Remove from connectors project
-        if: contains(steps.get-labels.outputs.labels, matrix.mapping.label)
+        if: contains(steps.get-labels.outputs.labels, 'idp') || contains(steps.get-labels.outputs.labels, 'agentic-ai')
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           GITHUB_EVENT_PATH: ${{ github.event_path }}
         run: |
           PROJECT_TITLE=$(gh project view 23 --owner camunda --format json | jq -r '.title')
-          ITEM_NUMBER=$(jq -r '.issue.number // .pull_request.number' < “$GITHUB_EVENT_PATH”)
-          if [ “${{ github.event_name }}” = “pull_request” ]; then
-            gh pr edit “$ITEM_NUMBER” --remove-project “$PROJECT_TITLE” --repo “${{ github.repository }}”
+          ITEM_NUMBER=$(jq -r '.issue.number // .pull_request.number' < "$GITHUB_EVENT_PATH")
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            gh pr edit "$ITEM_NUMBER" --remove-project "$PROJECT_TITLE" --repo "${{ github.repository }}"
           else
-            gh issue edit “$ITEM_NUMBER” --remove-project “$PROJECT_TITLE” --repo “${{ github.repository }}”
+            gh issue edit "$ITEM_NUMBER" --remove-project "$PROJECT_TITLE" --repo "${{ github.repository }}"
           fi
 
   add-default:

--- a/.github/workflows/ADD_TO_PROJECT.yml
+++ b/.github/workflows/ADD_TO_PROJECT.yml
@@ -61,12 +61,12 @@ jobs:
           github-token: ${{ steps.app-token.outputs.token }}
 
       - name: Remove from connectors project
-        if: contains(steps.get-labels.outputs.labels, matrix.mapping.label) && github.event_name != 'pull_request'
+        if: contains(steps.get-labels.outputs.labels, matrix.mapping.label)
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           PROJECT_TITLE=$(gh project view 23 --owner camunda --format json | jq -r '.title')
-          gh issue edit “${{ github.event.issue.number }}” --remove-project “$PROJECT_TITLE” --repo “${{ github.repository }}”
+          gh issue edit “${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.event.issue.number }}” --remove-project “$PROJECT_TITLE” --repo “${{ github.repository }}”
 
   add-default:
     name: Add issue to project if no label

--- a/.github/workflows/ADD_TO_PROJECT.yml
+++ b/.github/workflows/ADD_TO_PROJECT.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Get labels
         id: get-labels
         run: |
-          echo "::set-output name=labels::$(jq -r '.issue? // .pull_request? | .labels[].name' <"$GITHUB_EVENT_PATH")"
+          echo "labels=$(jq -r '.issue? // .pull_request? | .labels[].name' <"$GITHUB_EVENT_PATH")" >> "$GITHUB_OUTPUT"
         env:
           GITHUB_EVENT_PATH: ${{ github.event_path }}
 
@@ -56,16 +56,36 @@ jobs:
           project-url: ${{ matrix.mapping.project-url }}
           github-token: ${{ steps.app-token.outputs.token }}
 
-      # Mark that at least one label matched
-      - name: Flag “matched”
-        if: contains(steps.get-labels.outputs.labels, matrix.mapping.label)
-        run: echo "::set-output name=matched::true"
-        id: flag
+      - name: Remove from connectors project
+        if: contains(steps.get-labels.outputs.labels, matrix.mapping.label) && github.event_name != 'pull_request'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          ITEM_DATA=$(gh api graphql \
+            -f query='query($owner: String!, $repo: String!, $issueNumber: Int!) { repository(owner: $owner, name: $repo) { issue(number: $issueNumber) { projectItems(first: 20) { nodes { id project { ... on ProjectV2 { number id } } } } } } }' \
+            -F owner='${{ github.repository_owner }}' \
+            -F repo='${{ github.event.repository.name }}' \
+            -F issueNumber=${{ github.event.issue.number }})
+          PROJECT_ID=$(echo “$ITEM_DATA” | jq -r '.data.repository.issue.projectItems.nodes[] | select(.project.number == 23) | .project.id' | head -1)
+          ITEM_ID=$(echo “$ITEM_DATA” | jq -r '.data.repository.issue.projectItems.nodes[] | select(.project.number == 23) | .id' | head -1)
+          if [ -n “$ITEM_ID” ] && [ “$ITEM_ID” != “null” ]; then
+            gh api graphql \
+              -f query='mutation($projectId: ID!, $itemId: ID!) { deleteProjectV2Item(input: { projectId: $projectId, itemId: $itemId }) { deletedItemId } }' \
+              -F projectId=”$PROJECT_ID” \
+              -F itemId=”$ITEM_ID”
+          fi
 
   add-default:
     name: Add issue to project if no label
     runs-on: ubuntu-latest
-    if: needs.add-by-label.outputs['flag.matched'] != 'true'
+    needs: [add-by-label]
+    if: |
+      (github.event_name == 'issues' &&
+       !contains(github.event.issue.labels.*.name, 'idp') &&
+       !contains(github.event.issue.labels.*.name, 'agentic-ai')) ||
+      (github.event_name == 'pull_request' &&
+       !contains(github.event.pull_request.labels.*.name, 'idp') &&
+       !contains(github.event.pull_request.labels.*.name, 'agentic-ai'))
     steps:
       - name: Import Secrets
         id: vault-secrets

--- a/.github/workflows/ADD_TO_PROJECT.yml
+++ b/.github/workflows/ADD_TO_PROJECT.yml
@@ -45,7 +45,11 @@ jobs:
       - name: Get labels
         id: get-labels
         run: |
-          echo "labels=$(jq -r '.issue? // .pull_request? | .labels[].name' <"$GITHUB_EVENT_PATH")" >> "$GITHUB_OUTPUT"
+          {
+            echo "labels<<EOF"
+            jq -r '.issue? // .pull_request? | .labels[].name' <"$GITHUB_EVENT_PATH"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
         env:
           GITHUB_EVENT_PATH: ${{ github.event_path }}
 

--- a/.github/workflows/ADD_TO_PROJECT.yml
+++ b/.github/workflows/ADD_TO_PROJECT.yml
@@ -64,9 +64,15 @@ jobs:
         if: contains(steps.get-labels.outputs.labels, matrix.mapping.label)
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GITHUB_EVENT_PATH: ${{ github.event_path }}
         run: |
           PROJECT_TITLE=$(gh project view 23 --owner camunda --format json | jq -r '.title')
-          gh issue edit “${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.event.issue.number }}” --remove-project “$PROJECT_TITLE” --repo “${{ github.repository }}”
+          ITEM_NUMBER=$(jq -r '.issue.number // .pull_request.number' < “$GITHUB_EVENT_PATH”)
+          if [ “${{ github.event_name }}” = “pull_request” ]; then
+            gh pr edit “$ITEM_NUMBER” --remove-project “$PROJECT_TITLE” --repo “${{ github.repository }}”
+          else
+            gh issue edit “$ITEM_NUMBER” --remove-project “$PROJECT_TITLE” --repo “${{ github.repository }}”
+          fi
 
   add-default:
     name: Add issue to project if no label


### PR DESCRIPTION
## Summary

- **Root cause**: `add-default` had no `needs` dependency on `add-by-label`, so it always ran — every issue was added to the connectors project (project 23) regardless of labels. The broken `needs.add-by-label.outputs['flag.matched'] != 'true'` condition referenced a non-existent output and always evaluated to `true`.
- **Fix**: `add-default` now has `needs: [add-by-label]` and checks labels directly via `github.event.issue.labels.*.name` / `github.event.pull_request.labels.*.name` instead of relying on matrix job outputs.
- **Remove step**: Added a step in `add-by-label` that, after routing an issue to a specific project (`idp`, `agentic-ai`), queries the issue's project memberships via GraphQL and removes it from the connectors project (project 23) if present. This covers the case where an issue was already in project 23 before the label was applied.
- Also fixes deprecated `::set-output` → `$GITHUB_OUTPUT`.

## Test plan

- [ ] Open an issue with `idp` label → should appear in project 133, not project 23
- [ ] Open an issue with `agentic-ai` label → should appear in project 155, not project 23
- [ ] Add `idp` label to an existing issue already in project 23 → should be removed from project 23 and added to project 133
- [ ] Open an issue with no matching label → should appear in project 23

🤖 Generated with [Claude Code](https://claude.com/claude-code)