### PR TITLE
chore: separate IDP from AI collaborators in CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -19,15 +19,17 @@
 /connectors/webhook/ @camunda/connectors-core
 /connectors/soap/ @camunda/connectors-core
 
-# Custom rule for AI & IDP collaborators
+# Custom rule for AI collaborators
 /connectors/agentic-ai @camunda/connectors-agentic-ai
-/connectors/idp-extraction @camunda/connectors-idp @camunda/connectors
 /connectors/embeddings-vector-database @camunda/connectors-agentic-ai
 /connectors-e2e-test/connectors-e2e-test-agentic-ai @camunda/connectors-agentic-ai
 /connectors/aws/aws-bedrock-codeinterpreter @camunda/connectors-agentic-ai
 /connectors/aws/aws-bedrock-knowledgebase @camunda/connectors-agentic-ai
 /connectors/aws/aws-bedrock-agentcore-runtime @camunda/connectors-agentic-ai
 /connectors/aws/aws-bedrock-agentcore-long-term-memory @camunda/connectors-agentic-ai
+
+# Custom rule for IDP collaborators
+/connectors/idp-extraction @camunda/connectors-idp
 
 # These files are excluded so that Renovate can automatically merge dependency upgrades
 renovate.json


### PR DESCRIPTION
Splits `idp-extraction` into its own "IDP collaborators" rule owned by `@camunda/connectors-idp`, removing it from the combined "AI & IDP collaborators" rule.

This is the CODEOWNERS-only portion of #7549 (the `parent/pom.xml` jaxb-core pin is left out).

🤖 Generated with [Claude Code](https://claude.com/claude-code)