### PR TITLE
feat(runtime): support CONNECTOR_{DIRECTION}_ENABLED allowlist

### DIFF
--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/discovery/DisabledConnectorEnvVarsConfig.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/discovery/DisabledConnectorEnvVarsConfig.java
@@ -30,33 +30,53 @@ import org.slf4j.LoggerFactory;
 public class DisabledConnectorEnvVarsConfig {
   private static final Logger LOG = LoggerFactory.getLogger(DisabledConnectorEnvVarsConfig.class);
 
-  private final HashMap<ConnectorDirection, Set<String>> envVarCache = new HashMap<>();
+  private final HashMap<String, Set<String>> envVarCache = new HashMap<>();
 
   public static boolean isDiscoveryDisabled(ConnectorDirection direction) {
     return getConnectorEnvironmentVariable(direction.name(), "DISCOVERY_DISABLED").isPresent();
   }
 
   public boolean isConnectorDisabled(ConnectorConfiguration config) {
+    var direction = config.direction();
+    var type = config.type().toLowerCase();
+    var enabledTypes = getConnectorTypes(direction, "ENABLED");
 
-    var isDisabled = isConnectorDisabled(config.direction(), config.type().toLowerCase());
-    if (isDisabled) {
-      LOG.info(
-          "Connector {} has been disabled by the CONNECTOR_{}_DISABLED environment variable",
-          config.type(),
-          config.direction().name());
+    // ENABLED (allowlist) and DISABLED (blocklist) are mutually exclusive per direction
+    if (!enabledTypes.isEmpty() && !getConnectorTypes(direction, "DISABLED").isEmpty()) {
+      throw new IllegalStateException(
+          "CONNECTOR_"
+              + direction.name()
+              + "_ENABLED and CONNECTOR_"
+              + direction.name()
+              + "_DISABLED are mutually exclusive, please use only one of them");
+    }
+
+    boolean isDisabled;
+    if (!enabledTypes.isEmpty()) {
+      isDisabled = !enabledTypes.contains(type);
+      if (isDisabled) {
+        LOG.info(
+            "Connector {} is not in the CONNECTOR_{}_ENABLED allowlist and has been disabled",
+            config.type(),
+            direction.name());
+      }
+    } else {
+      isDisabled = getConnectorTypes(direction, "DISABLED").contains(type);
+      if (isDisabled) {
+        LOG.info(
+            "Connector {} has been disabled by the CONNECTOR_{}_DISABLED environment variable",
+            config.type(),
+            direction.name());
+      }
     }
     return isDisabled;
   }
 
-  private boolean isConnectorDisabled(ConnectorDirection connectorDirection, String type) {
-    return getDisabledConnectorTypes(connectorDirection).contains(type);
-  }
-
-  private Set<String> getDisabledConnectorTypes(ConnectorDirection direction) {
+  private Set<String> getConnectorTypes(ConnectorDirection direction, String detail) {
     return envVarCache.computeIfAbsent(
-        direction,
+        direction.name() + "_" + detail,
         key ->
-            getConnectorEnvironmentVariable(key.name(), "DISABLED")
+            getConnectorEnvironmentVariable(direction.name(), detail)
                 .map(
                     value ->
                         Arrays.stream(value.split(","))

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/discovery/DisabledConnectorEnvVarsConfig.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/discovery/DisabledConnectorEnvVarsConfig.java
@@ -30,6 +30,9 @@ import org.slf4j.LoggerFactory;
 public class DisabledConnectorEnvVarsConfig {
   private static final Logger LOG = LoggerFactory.getLogger(DisabledConnectorEnvVarsConfig.class);
 
+  private static final String ENABLED = "ENABLED";
+  private static final String DISABLED = "DISABLED";
+
   private final HashMap<String, Set<String>> envVarCache = new HashMap<>();
 
   public static boolean isDiscoveryDisabled(ConnectorDirection direction) {
@@ -41,8 +44,8 @@ public class DisabledConnectorEnvVarsConfig {
     var type = config.type().toLowerCase();
     // Presence (not parsed content) decides the mode: an env var set to an empty/whitespace value
     // still counts as "set".
-    var enabledSet = getConnectorEnvironmentVariable(direction.name(), "ENABLED").isPresent();
-    var disabledSet = getConnectorEnvironmentVariable(direction.name(), "DISABLED").isPresent();
+    var enabledSet = getConnectorEnvironmentVariable(direction.name(), ENABLED).isPresent();
+    var disabledSet = getConnectorEnvironmentVariable(direction.name(), DISABLED).isPresent();
 
     // ENABLED (allowlist) and DISABLED (blocklist) are mutually exclusive per direction
     if (enabledSet && disabledSet) {
@@ -76,7 +79,7 @@ public class DisabledConnectorEnvVarsConfig {
   }
 
   private Set<String> getConnectorTypes(ConnectorDirection direction, boolean enabled) {
-    var state = enabled ? "ENABLED" : "DISABLED";
+    var state = enabled ? ENABLED : DISABLED;
     return envVarCache.computeIfAbsent(
         direction.name() + "_" + state,
         key ->

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/discovery/DisabledConnectorEnvVarsConfig.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/discovery/DisabledConnectorEnvVarsConfig.java
@@ -39,10 +39,13 @@ public class DisabledConnectorEnvVarsConfig {
   public boolean isConnectorDisabled(ConnectorConfiguration config) {
     var direction = config.direction();
     var type = config.type().toLowerCase();
-    var enabledTypes = getConnectorTypes(direction, "ENABLED");
+    // Presence (not parsed content) decides the mode: an env var set to an empty/whitespace value
+    // still counts as "set".
+    var enabledSet = getConnectorEnvironmentVariable(direction.name(), "ENABLED").isPresent();
+    var disabledSet = getConnectorEnvironmentVariable(direction.name(), "DISABLED").isPresent();
 
     // ENABLED (allowlist) and DISABLED (blocklist) are mutually exclusive per direction
-    if (!enabledTypes.isEmpty() && !getConnectorTypes(direction, "DISABLED").isEmpty()) {
+    if (enabledSet && disabledSet) {
       throw new IllegalStateException(
           "CONNECTOR_"
               + direction.name()
@@ -52,8 +55,8 @@ public class DisabledConnectorEnvVarsConfig {
     }
 
     boolean isDisabled;
-    if (!enabledTypes.isEmpty()) {
-      isDisabled = !enabledTypes.contains(type);
+    if (enabledSet) {
+      isDisabled = !getConnectorTypes(direction, "ENABLED").contains(type);
       if (isDisabled) {
         LOG.info(
             "Connector {} is not in the CONNECTOR_{}_ENABLED allowlist and has been disabled",

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/discovery/DisabledConnectorEnvVarsConfig.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/discovery/DisabledConnectorEnvVarsConfig.java
@@ -56,7 +56,7 @@ public class DisabledConnectorEnvVarsConfig {
 
     boolean isDisabled;
     if (enabledSet) {
-      isDisabled = !getConnectorTypes(direction, "ENABLED").contains(type);
+      isDisabled = !getConnectorTypes(direction, true).contains(type);
       if (isDisabled) {
         LOG.info(
             "Connector {} is not in the CONNECTOR_{}_ENABLED allowlist and has been disabled",
@@ -64,7 +64,7 @@ public class DisabledConnectorEnvVarsConfig {
             direction.name());
       }
     } else {
-      isDisabled = getConnectorTypes(direction, "DISABLED").contains(type);
+      isDisabled = getConnectorTypes(direction, false).contains(type);
       if (isDisabled) {
         LOG.info(
             "Connector {} has been disabled by the CONNECTOR_{}_DISABLED environment variable",
@@ -75,11 +75,12 @@ public class DisabledConnectorEnvVarsConfig {
     return isDisabled;
   }
 
-  private Set<String> getConnectorTypes(ConnectorDirection direction, String detail) {
+  private Set<String> getConnectorTypes(ConnectorDirection direction, boolean enabled) {
+    var state = enabled ? "ENABLED" : "DISABLED";
     return envVarCache.computeIfAbsent(
-        direction.name() + "_" + detail,
+        direction.name() + "_" + state,
         key ->
-            getConnectorEnvironmentVariable(direction.name(), detail)
+            getConnectorEnvironmentVariable(direction.name(), state)
                 .map(
                     value ->
                         Arrays.stream(value.split(","))

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/inbound/InboundDiscoveryDisablingTest.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/inbound/InboundDiscoveryDisablingTest.java
@@ -78,4 +78,45 @@ public class InboundDiscoveryDisablingTest {
                   });
         });
   }
+
+  @Test
+  public void enabledAllowlistDisablesEverythingElse() throws Exception {
+    restoreSystemProperties(
+        () -> {
+          withEnvironmentVariables("CONNECTOR_INBOUND_ENABLED", "io.camunda:test-inbound:1")
+              .execute(
+                  () -> {
+                    InboundConnectorFactory registry = new DefaultInboundConnectorFactory();
+                    registry.registerConfiguration(
+                        new InboundConnectorConfiguration(
+                            "Test Inbound Connector",
+                            "io.camunda:test-inbound:1",
+                            NotAnnotatedExecutable.class,
+                            List.of()));
+                    Assertions.assertInstanceOf(
+                        NotAnnotatedExecutable.class,
+                        registry.getInstance("io.camunda:test-inbound:1"),
+                        "Connector in the allowlist should be available");
+                    Assertions.assertThrows(
+                        RuntimeException.class,
+                        () -> registry.getInstance("io.camunda:annotated"),
+                        "Connector not in the allowlist should be disabled");
+                  });
+        });
+  }
+
+  @Test
+  public void enabledAndDisabledTogetherThrows() throws Exception {
+    restoreSystemProperties(
+        () -> {
+          withEnvironmentVariables("CONNECTOR_INBOUND_ENABLED", "io.camunda:test-inbound:1")
+              .and("CONNECTOR_INBOUND_DISABLED", "io.camunda:annotated")
+              .execute(
+                  () ->
+                      Assertions.assertThrows(
+                          IllegalStateException.class,
+                          DefaultInboundConnectorFactory::new,
+                          "ENABLED and DISABLED are mutually exclusive"));
+        });
+  }
 }

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/inbound/InboundDiscoveryDisablingTest.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/inbound/InboundDiscoveryDisablingTest.java
@@ -119,4 +119,19 @@ public class InboundDiscoveryDisablingTest {
                           "ENABLED and DISABLED are mutually exclusive"));
         });
   }
+
+  @Test
+  public void emptyEnabledWithDisabledThrows() throws Exception {
+    restoreSystemProperties(
+        () -> {
+          withEnvironmentVariables("CONNECTOR_INBOUND_ENABLED", "")
+              .and("CONNECTOR_INBOUND_DISABLED", "io.camunda:annotated")
+              .execute(
+                  () ->
+                      Assertions.assertThrows(
+                          IllegalStateException.class,
+                          DefaultInboundConnectorFactory::new,
+                          "Mutual exclusion is enforced even when ENABLED is empty"));
+        });
+  }
 }

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/outbound/OutboundDisablingTest.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/outbound/OutboundDisablingTest.java
@@ -83,6 +83,43 @@ public class OutboundDisablingTest {
   }
 
   @Test
+  public void enabledAllowlistDisablesEverythingElse() throws Exception {
+    restoreSystemProperties(
+        () -> {
+          withEnvironmentVariables("CONNECTOR_OUTBOUND_ENABLED", "io.camunda:local")
+              .execute(
+                  () -> {
+                    OutboundConnectorFactory factory =
+                        DiscoveryUtils.getFactory(new AnnotatedLocalFunction());
+                    Assertions.assertInstanceOf(
+                        AnnotatedLocalFunction.class,
+                        factory.getInstance("io.camunda:local"),
+                        "Connector in the allowlist should be available");
+
+                    Assertions.assertThrows(
+                        RuntimeException.class,
+                        () -> factory.getInstance("io.camunda:annotated"),
+                        "Connector not in the allowlist should be disabled");
+                  });
+        });
+  }
+
+  @Test
+  public void enabledAndDisabledTogetherThrows() throws Exception {
+    restoreSystemProperties(
+        () -> {
+          withEnvironmentVariables("CONNECTOR_OUTBOUND_ENABLED", "io.camunda:local")
+              .and("CONNECTOR_OUTBOUND_DISABLED", "io.camunda:annotated")
+              .execute(
+                  () ->
+                      Assertions.assertThrows(
+                          IllegalStateException.class,
+                          () -> DiscoveryUtils.getFactory(new AnnotatedLocalFunction()),
+                          "ENABLED and DISABLED are mutually exclusive"));
+        });
+  }
+
+  @Test
   public void namedDisablingForManuallyRegisteredConnectors() throws Exception {
     restoreSystemProperties(
         () -> {

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/outbound/OutboundDisablingTest.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/outbound/OutboundDisablingTest.java
@@ -105,6 +105,38 @@ public class OutboundDisablingTest {
   }
 
   @Test
+  public void emptyEnabledAllowlistDisablesEverything() throws Exception {
+    restoreSystemProperties(
+        () -> {
+          withEnvironmentVariables("CONNECTOR_OUTBOUND_ENABLED", "")
+              .execute(
+                  () -> {
+                    OutboundConnectorFactory factory =
+                        DiscoveryUtils.getFactory(new AnnotatedLocalFunction());
+                    Assertions.assertThrows(
+                        RuntimeException.class,
+                        () -> factory.getInstance("io.camunda:local"),
+                        "An empty allowlist should disable every connector");
+                  });
+        });
+  }
+
+  @Test
+  public void emptyEnabledWithDisabledThrows() throws Exception {
+    restoreSystemProperties(
+        () -> {
+          withEnvironmentVariables("CONNECTOR_OUTBOUND_ENABLED", "")
+              .and("CONNECTOR_OUTBOUND_DISABLED", "io.camunda:annotated")
+              .execute(
+                  () ->
+                      Assertions.assertThrows(
+                          IllegalStateException.class,
+                          () -> DiscoveryUtils.getFactory(new AnnotatedLocalFunction()),
+                          "Mutual exclusion is enforced even when ENABLED is empty"));
+        });
+  }
+
+  @Test
   public void enabledAndDisabledTogetherThrows() throws Exception {
     restoreSystemProperties(
         () -> {


### PR DESCRIPTION
## Description

Closes #5177

Adds an opt-in allowlist `CONNECTOR_{DIRECTION}_ENABLED` that is the inverse of the existing `CONNECTOR_{DIRECTION}_DISABLED` blocklist:

- When `CONNECTOR_{DIRECTION}_ENABLED` is set, only the listed connector types stay active and all others are disabled. `DISABLED` is not considered.
- `ENABLED` and `DISABLED` are mutually exclusive per direction — setting both throws an `IllegalStateException`.
- When neither (or only `DISABLED`) is set, behavior is unchanged.

Reuses the existing env-var read + cache in `DisabledConnectorEnvVarsConfig` (re-keyed by direction + detail) rather than introducing a new class.

## Tests

- `OutboundDisablingTest`: allowlist activation + mutual-exclusion error
- `InboundDiscoveryDisablingTest`: allowlist activation + mutual-exclusion error

🤖 Generated with [Claude Code](https://claude.com/claude-code)