### PR TITLE
fix: add stable/** push trigger so streak detector tracks stable branch failures

### DIFF
--- a/.github/workflows/MERGE_QUEUE_HELM_TEST.yaml
+++ b/.github/workflows/MERGE_QUEUE_HELM_TEST.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - stable/**
   workflow_dispatch:
   merge_group:
 


### PR DESCRIPTION
## Problem

The streak detector ([connectors-streak-detector.yml](https://github.com/camunda/connectors/blob/main/.github/workflows/connectors-streak-detector.yml)) only tracks `push` events, but `MERGE_QUEUE_HELM_TEST` had no `push` trigger for `stable/**` branches — only `main`. On stable branches the workflow exclusively ran via `merge_group`, which the streak detector ignores entirely.

Three compounding reasons nothing was detected:
1. No `push` trigger on `stable/**` → no push runs produced on stable branches
2. Streak detector job `if` condition requires `event == 'push'` → `merge_group` runs are skipped
3. Streak count jq also filters `select(.event == "push")` → even if the trigger fired, the count would be 0

## Fix

Add `stable/**` to the `push` trigger, mirroring exactly how `main` is handled today. Each commit merged into a stable branch will now produce a push run that the streak detector can track.

## What changes

- `MERGE_QUEUE_HELM_TEST` now runs on `push` to `stable/**` in addition to `main`
- No changes to the streak detector itself — it already handles `startsWith(head_branch, 'stable/')` correctly
- Behaviour on `main` and `merge_group` is unchanged