### PR TITLE
ci: enable SM Helm integration tests on push to main

### DIFF
--- a/.github/workflows/INTEGRATION_TEST.yml
+++ b/.github/workflows/INTEGRATION_TEST.yml
@@ -169,7 +169,7 @@ jobs:
           echo "=========================================="
 
   helm-deploy:
-    if: github.ref != 'refs/heads/main' && !contains(github.event.pull_request.labels.*.name, 'skip-helm-deploy')
+    if: "!contains(github.event.pull_request.labels.*.name, 'skip-helm-deploy')"
     needs: prepare-inputs
     name: Helm chart Integration Tests
     uses: camunda/camunda-platform-helm/.github/workflows/test-integration-template.yaml@main
@@ -200,3 +200,4 @@ jobs:
             registry: ${{ needs.prepare-inputs.outputs.connectors-registry }}
             repository: ${{ needs.prepare-inputs.outputs.connectors-repository }}
             tag: ${{ needs.prepare-inputs.outputs.connectors-version }}
+


### PR DESCRIPTION
## Summary

- Removes the `github.ref != 'refs/heads/main'` guard from the `Helm chart Integration Tests` job condition in `INTEGRATION_TEST.yml`
- SM E2E tests (`trigger-sm-e2e`) were already wired up in `MERGE_QUEUE_HELM_TEST.yaml` for push to main, but the `Helm chart Integration Tests` job inside `INTEGRATION_TEST.yml` was explicitly skipping when `github.ref == refs/heads/main`
- After this change, SM Helm integration tests will run on both **merge queue** and **push to main**

## Before / After

| Event | Before | After |
|---|---|---|
| `merge_group` | ✅ runs | ✅ runs |
| `push` to `main` | ⏭️ skipped | ✅ runs |

> Note: stable branches are unaffected — their ref is never `refs/heads/main` so they already ran.

🤖 Generated with [Claude Code](https://claude.com/claude-code)