### PR TITLE
deps: bump Zeebe client version

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -70,8 +70,8 @@ limitations under the License.</license.inlineheader>
     <nexus.release.repository>https://artifacts.camunda.com/artifactory/connectors/</nexus.release.repository>
 
     <!-- Camunda internal libraries -->
-    <version.zeebe>8.7.18</version.zeebe>
-    <version.camunda-process-test>8.7.18</version.camunda-process-test>
+    <version.zeebe>8.7.34</version.zeebe>
+    <version.camunda-process-test>8.7.34</version.camunda-process-test>
     <version.operate-client>8.7.1</version.operate-client>
     <version.feel-engine>1.21.0</version.feel-engine>
     <!-- Third party dependencies -->


### PR DESCRIPTION
This pull request updates internal dependency versions in the `parent/pom.xml` file to keep the project up to date with the latest releases.

Dependency version updates:

* Bumped `zeebe` and `camunda-process-test` versions from `8.7.18` to `8.7.34` to use newer releases of these Camunda internal libraries.