### PR TITLE
refactor(aws): tooltip-first element-template field hints

### DIFF
--- a/connectors/aws/aws-base/src/main/java/io/camunda/connector/aws/model/impl/AwsAuthentication.java
+++ b/connectors/aws/aws-base/src/main/java/io/camunda/connector/aws/model/impl/AwsAuthentication.java
@@ -41,15 +41,15 @@ public sealed interface AwsAuthentication
       @TemplateProperty(
               group = "authentication",
               label = "Access key",
-              description =
-                  "Provide an IAM access key tailored to a user, equipped with the necessary permissions")
+              tooltip =
+                  "IAM access key of a user with the necessary permissions for this connector")
           @NotBlank
           String accessKey,
       @TemplateProperty(
               group = "authentication",
               label = "Secret key",
-              description =
-                  "Provide a secret key of a user with permissions to invoke specified AWS Lambda function")
+              tooltip =
+                  "IAM secret key of a user with the necessary permissions for this connector")
           @NotBlank
           String secretKey)
       implements AwsAuthentication {

--- a/connectors/aws/aws-base/src/main/java/io/camunda/connector/aws/model/impl/AwsBaseConfiguration.java
+++ b/connectors/aws/aws-base/src/main/java/io/camunda/connector/aws/model/impl/AwsBaseConfiguration.java
@@ -12,10 +12,7 @@ import io.camunda.connector.generator.java.annotation.TemplateProperty;
 import io.camunda.connector.generator.java.annotation.TemplateProperty.PropertyConstraints;
 
 public record AwsBaseConfiguration(
-    @TemplateProperty(
-            group = "configuration",
-            description = "Specify the AWS region",
-            constraints = @PropertyConstraints(notEmpty = true))
+    @TemplateProperty(group = "configuration", constraints = @PropertyConstraints(notEmpty = true))
         String region,
     @TemplateProperty(
             group = "configuration",

--- a/connectors/aws/aws-bedrock-agentcore-long-term-memory/element-templates/aws-bedrock-agentcore-long-term-memory-outbound-connector.json
+++ b/connectors/aws/aws-bedrock-agentcore-long-term-memory/element-templates/aws-bedrock-agentcore-long-term-memory-outbound-connector.json
@@ -88,7 +88,6 @@
   }, {
     "id" : "authentication.accessKey",
     "label" : "Access key",
-    "description" : "Provide an IAM access key tailored to a user, equipped with the necessary permissions",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -104,11 +103,11 @@
       "equals" : "credentials",
       "type" : "simple"
     },
+    "tooltip" : "IAM access key of a user with the necessary permissions for this connector",
     "type" : "String"
   }, {
     "id" : "authentication.secretKey",
     "label" : "Secret key",
-    "description" : "Provide a secret key of a user with permissions to invoke specified AWS Lambda function",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -124,6 +123,7 @@
       "equals" : "credentials",
       "type" : "simple"
     },
+    "tooltip" : "IAM secret key of a user with the necessary permissions for this connector",
     "type" : "String"
   }, {
     "id" : "memoryId",
@@ -158,7 +158,6 @@
   }, {
     "id" : "configuration.region",
     "label" : "Region",
-    "description" : "Specify the AWS region",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true

--- a/connectors/aws/aws-bedrock-agentcore-long-term-memory/element-templates/hybrid/aws-bedrock-agentcore-long-term-memory-outbound-connector-hybrid.json
+++ b/connectors/aws/aws-bedrock-agentcore-long-term-memory/element-templates/hybrid/aws-bedrock-agentcore-long-term-memory-outbound-connector-hybrid.json
@@ -93,7 +93,6 @@
   }, {
     "id" : "authentication.accessKey",
     "label" : "Access key",
-    "description" : "Provide an IAM access key tailored to a user, equipped with the necessary permissions",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -109,11 +108,11 @@
       "equals" : "credentials",
       "type" : "simple"
     },
+    "tooltip" : "IAM access key of a user with the necessary permissions for this connector",
     "type" : "String"
   }, {
     "id" : "authentication.secretKey",
     "label" : "Secret key",
-    "description" : "Provide a secret key of a user with permissions to invoke specified AWS Lambda function",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -129,6 +128,7 @@
       "equals" : "credentials",
       "type" : "simple"
     },
+    "tooltip" : "IAM secret key of a user with the necessary permissions for this connector",
     "type" : "String"
   }, {
     "id" : "memoryId",
@@ -163,7 +163,6 @@
   }, {
     "id" : "configuration.region",
     "label" : "Region",
-    "description" : "Specify the AWS region",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true

--- a/connectors/aws/aws-bedrock-agentcore-runtime/element-templates/aws-bedrock-agentcore-runtime-outbound-connector.json
+++ b/connectors/aws/aws-bedrock-agentcore-runtime/element-templates/aws-bedrock-agentcore-runtime-outbound-connector.json
@@ -66,7 +66,6 @@
   }, {
     "id" : "authentication.accessKey",
     "label" : "Access key",
-    "description" : "Provide an IAM access key tailored to a user, equipped with the necessary permissions",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -82,11 +81,11 @@
       "equals" : "credentials",
       "type" : "simple"
     },
+    "tooltip" : "IAM access key of a user with the necessary permissions for this connector",
     "type" : "String"
   }, {
     "id" : "authentication.secretKey",
     "label" : "Secret key",
-    "description" : "Provide a secret key of a user with permissions to invoke specified AWS Lambda function",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -102,11 +101,11 @@
       "equals" : "credentials",
       "type" : "simple"
     },
+    "tooltip" : "IAM secret key of a user with the necessary permissions for this connector",
     "type" : "String"
   }, {
     "id" : "configuration.region",
     "label" : "Region",
-    "description" : "Specify the AWS region",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true

--- a/connectors/aws/aws-bedrock-agentcore-runtime/element-templates/hybrid/aws-bedrock-agentcore-runtime-outbound-connector-hybrid.json
+++ b/connectors/aws/aws-bedrock-agentcore-runtime/element-templates/hybrid/aws-bedrock-agentcore-runtime-outbound-connector-hybrid.json
@@ -71,7 +71,6 @@
   }, {
     "id" : "authentication.accessKey",
     "label" : "Access key",
-    "description" : "Provide an IAM access key tailored to a user, equipped with the necessary permissions",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -87,11 +86,11 @@
       "equals" : "credentials",
       "type" : "simple"
     },
+    "tooltip" : "IAM access key of a user with the necessary permissions for this connector",
     "type" : "String"
   }, {
     "id" : "authentication.secretKey",
     "label" : "Secret key",
-    "description" : "Provide a secret key of a user with permissions to invoke specified AWS Lambda function",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -107,11 +106,11 @@
       "equals" : "credentials",
       "type" : "simple"
     },
+    "tooltip" : "IAM secret key of a user with the necessary permissions for this connector",
     "type" : "String"
   }, {
     "id" : "configuration.region",
     "label" : "Region",
-    "description" : "Specify the AWS region",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true

--- a/connectors/aws/aws-bedrock-codeinterpreter/element-templates/aws-bedrock-codeinterpreter-outbound-connector.json
+++ b/connectors/aws/aws-bedrock-codeinterpreter/element-templates/aws-bedrock-codeinterpreter-outbound-connector.json
@@ -68,7 +68,6 @@
   }, {
     "id" : "authentication.accessKey",
     "label" : "Access key",
-    "description" : "Provide an IAM access key tailored to a user, equipped with the necessary permissions",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -84,11 +83,11 @@
       "equals" : "credentials",
       "type" : "simple"
     },
+    "tooltip" : "IAM access key of a user with the necessary permissions for this connector",
     "type" : "String"
   }, {
     "id" : "authentication.secretKey",
     "label" : "Secret key",
-    "description" : "Provide a secret key of a user with permissions to invoke specified AWS Lambda function",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -104,11 +103,11 @@
       "equals" : "credentials",
       "type" : "simple"
     },
+    "tooltip" : "IAM secret key of a user with the necessary permissions for this connector",
     "type" : "String"
   }, {
     "id" : "configuration.region",
     "label" : "Region",
-    "description" : "Specify the AWS region",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true

--- a/connectors/aws/aws-bedrock-codeinterpreter/element-templates/hybrid/aws-bedrock-codeinterpreter-outbound-connector-hybrid.json
+++ b/connectors/aws/aws-bedrock-codeinterpreter/element-templates/hybrid/aws-bedrock-codeinterpreter-outbound-connector-hybrid.json
@@ -73,7 +73,6 @@
   }, {
     "id" : "authentication.accessKey",
     "label" : "Access key",
-    "description" : "Provide an IAM access key tailored to a user, equipped with the necessary permissions",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -89,11 +88,11 @@
       "equals" : "credentials",
       "type" : "simple"
     },
+    "tooltip" : "IAM access key of a user with the necessary permissions for this connector",
     "type" : "String"
   }, {
     "id" : "authentication.secretKey",
     "label" : "Secret key",
-    "description" : "Provide a secret key of a user with permissions to invoke specified AWS Lambda function",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -109,11 +108,11 @@
       "equals" : "credentials",
       "type" : "simple"
     },
+    "tooltip" : "IAM secret key of a user with the necessary permissions for this connector",
     "type" : "String"
   }, {
     "id" : "configuration.region",
     "label" : "Region",
-    "description" : "Specify the AWS region",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true

--- a/connectors/aws/aws-bedrock-knowledgebase/element-templates/aws-bedrock-knowledgebase-outbound-connector.json
+++ b/connectors/aws/aws-bedrock-knowledgebase/element-templates/aws-bedrock-knowledgebase-outbound-connector.json
@@ -68,7 +68,6 @@
   }, {
     "id" : "authentication.accessKey",
     "label" : "Access key",
-    "description" : "Provide an IAM access key tailored to a user, equipped with the necessary permissions",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -84,11 +83,11 @@
       "equals" : "credentials",
       "type" : "simple"
     },
+    "tooltip" : "IAM access key of a user with the necessary permissions for this connector",
     "type" : "String"
   }, {
     "id" : "authentication.secretKey",
     "label" : "Secret key",
-    "description" : "Provide a secret key of a user with permissions to invoke specified AWS Lambda function",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -104,6 +103,7 @@
       "equals" : "credentials",
       "type" : "simple"
     },
+    "tooltip" : "IAM secret key of a user with the necessary permissions for this connector",
     "type" : "String"
   }, {
     "id" : "knowledgeBaseId",
@@ -123,7 +123,6 @@
   }, {
     "id" : "configuration.region",
     "label" : "Region",
-    "description" : "Specify the AWS region",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true

--- a/connectors/aws/aws-bedrock-knowledgebase/element-templates/hybrid/aws-bedrock-knowledgebase-outbound-connector-hybrid.json
+++ b/connectors/aws/aws-bedrock-knowledgebase/element-templates/hybrid/aws-bedrock-knowledgebase-outbound-connector-hybrid.json
@@ -73,7 +73,6 @@
   }, {
     "id" : "authentication.accessKey",
     "label" : "Access key",
-    "description" : "Provide an IAM access key tailored to a user, equipped with the necessary permissions",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -89,11 +88,11 @@
       "equals" : "credentials",
       "type" : "simple"
     },
+    "tooltip" : "IAM access key of a user with the necessary permissions for this connector",
     "type" : "String"
   }, {
     "id" : "authentication.secretKey",
     "label" : "Secret key",
-    "description" : "Provide a secret key of a user with permissions to invoke specified AWS Lambda function",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -109,6 +108,7 @@
       "equals" : "credentials",
       "type" : "simple"
     },
+    "tooltip" : "IAM secret key of a user with the necessary permissions for this connector",
     "type" : "String"
   }, {
     "id" : "knowledgeBaseId",
@@ -128,7 +128,6 @@
   }, {
     "id" : "configuration.region",
     "label" : "Region",
-    "description" : "Specify the AWS region",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true

--- a/connectors/aws/aws-bedrock/element-templates/aws-bedrock-outbound-connector.json
+++ b/connectors/aws/aws-bedrock/element-templates/aws-bedrock-outbound-connector.json
@@ -90,7 +90,6 @@
   }, {
     "id" : "authentication.accessKey",
     "label" : "Access key",
-    "description" : "Provide an IAM access key tailored to a user, equipped with the necessary permissions",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -106,11 +105,11 @@
       "equals" : "credentials",
       "type" : "simple"
     },
+    "tooltip" : "IAM access key of a user with the necessary permissions for this connector",
     "type" : "String"
   }, {
     "id" : "authentication.secretKey",
     "label" : "Secret key",
-    "description" : "Provide a secret key of a user with permissions to invoke specified AWS Lambda function",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -126,11 +125,11 @@
       "equals" : "credentials",
       "type" : "simple"
     },
+    "tooltip" : "IAM secret key of a user with the necessary permissions for this connector",
     "type" : "String"
   }, {
     "id" : "configuration.region",
     "label" : "Region",
-    "description" : "Specify the AWS region",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -171,7 +170,8 @@
       "equals" : "invokeModel",
       "type" : "simple"
     },
-    "tooltip" : "<a href=\"https://docs.aws.amazon.com/bedrock/latest/userguide/model-ids.html\" target=\"_blank\">AWS Bedrock model IDs</a>",
+    "tooltip" : "ID of the model to invoke. See <a href=\"https://docs.aws.amazon.com/bedrock/latest/userguide/model-ids.html\" target=\"_blank\">AWS Bedrock model IDs</a>.",
+    "placeholder" : "amazon.titan-text-express-v1",
     "type" : "String"
   }, {
     "id" : "data.payload",
@@ -191,7 +191,7 @@
       "equals" : "invokeModel",
       "type" : "simple"
     },
-    "tooltip" : "<a href=\"https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters.html\" target=\"_blank\">AWS Bedrock model parameters</a>",
+    "tooltip" : "Request body sent to the model, whose structure depends on the model. See <a href=\"https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters.html\" target=\"_blank\">AWS Bedrock model parameters</a>.",
     "type" : "String"
   }, {
     "id" : "data.messagesHistory",
@@ -228,7 +228,8 @@
       "equals" : "converse",
       "type" : "simple"
     },
-    "tooltip" : "<a href=\"https://docs.aws.amazon.com/bedrock/latest/userguide/model-ids.html\" target=\"_blank\">AWS Bedrock model IDs</a>",
+    "tooltip" : "ID of the model to invoke. See <a href=\"https://docs.aws.amazon.com/bedrock/latest/userguide/model-ids.html\" target=\"_blank\">AWS Bedrock model IDs</a>.",
+    "placeholder" : "amazon.titan-text-express-v1",
     "type" : "String"
   }, {
     "id" : "data.newMessage",
@@ -248,7 +249,6 @@
       "equals" : "converse",
       "type" : "simple"
     },
-    "tooltip" : "The next message to send in the conversation.",
     "type" : "String"
   }, {
     "id" : "data.maxTokens",

--- a/connectors/aws/aws-bedrock/element-templates/aws-bedrock-outbound-connector.json
+++ b/connectors/aws/aws-bedrock/element-templates/aws-bedrock-outbound-connector.json
@@ -156,7 +156,6 @@
   }, {
     "id" : "data.modelId0",
     "label" : "Model ID",
-    "description" : "Specify the model ID. Details in the <a href=\"https://docs.aws.amazon.com/bedrock/latest/userguide/model-ids.html\" target=\"_blank\">documentation</a>",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -172,11 +171,11 @@
       "equals" : "invokeModel",
       "type" : "simple"
     },
+    "tooltip" : "<a href=\"https://docs.aws.amazon.com/bedrock/latest/userguide/model-ids.html\" target=\"_blank\">AWS Bedrock model IDs</a>",
     "type" : "String"
   }, {
     "id" : "data.payload",
     "label" : "Payload",
-    "description" : "Specify the payload. Details in the <a href=\"https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters.html\" target=\"_blank\">documentation</a>",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -192,11 +191,11 @@
       "equals" : "invokeModel",
       "type" : "simple"
     },
+    "tooltip" : "<a href=\"https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters.html\" target=\"_blank\">AWS Bedrock model parameters</a>",
     "type" : "String"
   }, {
     "id" : "data.messagesHistory",
     "label" : "Message History",
-    "description" : "Specify the message history, when previous context is needed",
     "optional" : true,
     "feel" : "required",
     "group" : "converse",
@@ -209,11 +208,11 @@
       "equals" : "converse",
       "type" : "simple"
     },
+    "tooltip" : "History of the conversation to continue. If not set, this starts a new conversation.",
     "type" : "String"
   }, {
     "id" : "data.modelId1",
     "label" : "Model ID",
-    "description" : "Specify the model ID. Details in the <a href=\"https://docs.aws.amazon.com/bedrock/latest/userguide/model-ids.html\" target=\"_blank\">documentation</a>",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -229,11 +228,11 @@
       "equals" : "converse",
       "type" : "simple"
     },
+    "tooltip" : "<a href=\"https://docs.aws.amazon.com/bedrock/latest/userguide/model-ids.html\" target=\"_blank\">AWS Bedrock model IDs</a>",
     "type" : "String"
   }, {
     "id" : "data.newMessage",
     "label" : "New Message",
-    "description" : "Specify the next message",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -249,6 +248,7 @@
       "equals" : "converse",
       "type" : "simple"
     },
+    "tooltip" : "The next message to send in the conversation.",
     "type" : "String"
   }, {
     "id" : "data.maxTokens",

--- a/connectors/aws/aws-bedrock/element-templates/hybrid/aws-bedrock-outbound-connector-hybrid.json
+++ b/connectors/aws/aws-bedrock/element-templates/hybrid/aws-bedrock-outbound-connector-hybrid.json
@@ -161,7 +161,6 @@
   }, {
     "id" : "data.modelId0",
     "label" : "Model ID",
-    "description" : "Specify the model ID. Details in the <a href=\"https://docs.aws.amazon.com/bedrock/latest/userguide/model-ids.html\" target=\"_blank\">documentation</a>",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -177,11 +176,11 @@
       "equals" : "invokeModel",
       "type" : "simple"
     },
+    "tooltip" : "<a href=\"https://docs.aws.amazon.com/bedrock/latest/userguide/model-ids.html\" target=\"_blank\">AWS Bedrock model IDs</a>",
     "type" : "String"
   }, {
     "id" : "data.payload",
     "label" : "Payload",
-    "description" : "Specify the payload. Details in the <a href=\"https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters.html\" target=\"_blank\">documentation</a>",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -197,11 +196,11 @@
       "equals" : "invokeModel",
       "type" : "simple"
     },
+    "tooltip" : "<a href=\"https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters.html\" target=\"_blank\">AWS Bedrock model parameters</a>",
     "type" : "String"
   }, {
     "id" : "data.messagesHistory",
     "label" : "Message History",
-    "description" : "Specify the message history, when previous context is needed",
     "optional" : true,
     "feel" : "required",
     "group" : "converse",
@@ -214,11 +213,11 @@
       "equals" : "converse",
       "type" : "simple"
     },
+    "tooltip" : "History of the conversation to continue. If not set, this starts a new conversation.",
     "type" : "String"
   }, {
     "id" : "data.modelId1",
     "label" : "Model ID",
-    "description" : "Specify the model ID. Details in the <a href=\"https://docs.aws.amazon.com/bedrock/latest/userguide/model-ids.html\" target=\"_blank\">documentation</a>",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -234,11 +233,11 @@
       "equals" : "converse",
       "type" : "simple"
     },
+    "tooltip" : "<a href=\"https://docs.aws.amazon.com/bedrock/latest/userguide/model-ids.html\" target=\"_blank\">AWS Bedrock model IDs</a>",
     "type" : "String"
   }, {
     "id" : "data.newMessage",
     "label" : "New Message",
-    "description" : "Specify the next message",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -254,6 +253,7 @@
       "equals" : "converse",
       "type" : "simple"
     },
+    "tooltip" : "The next message to send in the conversation.",
     "type" : "String"
   }, {
     "id" : "data.maxTokens",

--- a/connectors/aws/aws-bedrock/element-templates/hybrid/aws-bedrock-outbound-connector-hybrid.json
+++ b/connectors/aws/aws-bedrock/element-templates/hybrid/aws-bedrock-outbound-connector-hybrid.json
@@ -95,7 +95,6 @@
   }, {
     "id" : "authentication.accessKey",
     "label" : "Access key",
-    "description" : "Provide an IAM access key tailored to a user, equipped with the necessary permissions",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -111,11 +110,11 @@
       "equals" : "credentials",
       "type" : "simple"
     },
+    "tooltip" : "IAM access key of a user with the necessary permissions for this connector",
     "type" : "String"
   }, {
     "id" : "authentication.secretKey",
     "label" : "Secret key",
-    "description" : "Provide a secret key of a user with permissions to invoke specified AWS Lambda function",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -131,11 +130,11 @@
       "equals" : "credentials",
       "type" : "simple"
     },
+    "tooltip" : "IAM secret key of a user with the necessary permissions for this connector",
     "type" : "String"
   }, {
     "id" : "configuration.region",
     "label" : "Region",
-    "description" : "Specify the AWS region",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -176,7 +175,8 @@
       "equals" : "invokeModel",
       "type" : "simple"
     },
-    "tooltip" : "<a href=\"https://docs.aws.amazon.com/bedrock/latest/userguide/model-ids.html\" target=\"_blank\">AWS Bedrock model IDs</a>",
+    "tooltip" : "ID of the model to invoke. See <a href=\"https://docs.aws.amazon.com/bedrock/latest/userguide/model-ids.html\" target=\"_blank\">AWS Bedrock model IDs</a>.",
+    "placeholder" : "amazon.titan-text-express-v1",
     "type" : "String"
   }, {
     "id" : "data.payload",
@@ -196,7 +196,7 @@
       "equals" : "invokeModel",
       "type" : "simple"
     },
-    "tooltip" : "<a href=\"https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters.html\" target=\"_blank\">AWS Bedrock model parameters</a>",
+    "tooltip" : "Request body sent to the model, whose structure depends on the model. See <a href=\"https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters.html\" target=\"_blank\">AWS Bedrock model parameters</a>.",
     "type" : "String"
   }, {
     "id" : "data.messagesHistory",
@@ -233,7 +233,8 @@
       "equals" : "converse",
       "type" : "simple"
     },
-    "tooltip" : "<a href=\"https://docs.aws.amazon.com/bedrock/latest/userguide/model-ids.html\" target=\"_blank\">AWS Bedrock model IDs</a>",
+    "tooltip" : "ID of the model to invoke. See <a href=\"https://docs.aws.amazon.com/bedrock/latest/userguide/model-ids.html\" target=\"_blank\">AWS Bedrock model IDs</a>.",
+    "placeholder" : "amazon.titan-text-express-v1",
     "type" : "String"
   }, {
     "id" : "data.newMessage",
@@ -253,7 +254,6 @@
       "equals" : "converse",
       "type" : "simple"
     },
-    "tooltip" : "The next message to send in the conversation.",
     "type" : "String"
   }, {
     "id" : "data.maxTokens",

--- a/connectors/aws/aws-bedrock/src/main/java/io/camunda/connector/aws/bedrock/model/ConverseData.java
+++ b/connectors/aws/aws-bedrock/src/main/java/io/camunda/connector/aws/bedrock/model/ConverseData.java
@@ -44,7 +44,7 @@ public final class ConverseData implements RequestData {
       label = "Message History",
       group = "converse",
       id = "data.messagesHistory",
-      description = "Specify the message history, when previous context is needed",
+      tooltip = "History of the conversation to continue. If not set, this starts a new conversation.",
       feel = FeelMode.required,
       optional = true,
       binding = @TemplateProperty.PropertyBinding(name = "data.messagesHistory"))
@@ -55,8 +55,8 @@ public final class ConverseData implements RequestData {
   @TemplateProperty(
       label = "Model ID",
       group = "converse",
-      description =
-          "Specify the model ID. Details in the <a href=\"https://docs.aws.amazon.com/bedrock/latest/userguide/model-ids.html\" target=\"_blank\">documentation</a>",
+      tooltip =
+          "<a href=\"https://docs.aws.amazon.com/bedrock/latest/userguide/model-ids.html\" target=\"_blank\">AWS Bedrock model IDs</a>",
       id = "data.modelId1",
       feel = FeelMode.optional,
       binding = @TemplateProperty.PropertyBinding(name = "data.modelId"))
@@ -68,7 +68,7 @@ public final class ConverseData implements RequestData {
       label = "New Message",
       group = "converse",
       id = "data.newMessage",
-      description = "Specify the next message",
+      tooltip = "The next message to send in the conversation.",
       feel = FeelMode.optional,
       binding = @TemplateProperty.PropertyBinding(name = "data.newMessage"))
   @Valid

--- a/connectors/aws/aws-bedrock/src/main/java/io/camunda/connector/aws/bedrock/model/ConverseData.java
+++ b/connectors/aws/aws-bedrock/src/main/java/io/camunda/connector/aws/bedrock/model/ConverseData.java
@@ -44,7 +44,8 @@ public final class ConverseData implements RequestData {
       label = "Message History",
       group = "converse",
       id = "data.messagesHistory",
-      tooltip = "History of the conversation to continue. If not set, this starts a new conversation.",
+      tooltip =
+          "History of the conversation to continue. If not set, this starts a new conversation.",
       feel = FeelMode.required,
       optional = true,
       binding = @TemplateProperty.PropertyBinding(name = "data.messagesHistory"))
@@ -56,7 +57,8 @@ public final class ConverseData implements RequestData {
       label = "Model ID",
       group = "converse",
       tooltip =
-          "<a href=\"https://docs.aws.amazon.com/bedrock/latest/userguide/model-ids.html\" target=\"_blank\">AWS Bedrock model IDs</a>",
+          "ID of the model to invoke. See <a href=\"https://docs.aws.amazon.com/bedrock/latest/userguide/model-ids.html\" target=\"_blank\">AWS Bedrock model IDs</a>.",
+      placeholder = "amazon.titan-text-express-v1",
       id = "data.modelId1",
       feel = FeelMode.optional,
       binding = @TemplateProperty.PropertyBinding(name = "data.modelId"))
@@ -68,7 +70,6 @@ public final class ConverseData implements RequestData {
       label = "New Message",
       group = "converse",
       id = "data.newMessage",
-      tooltip = "The next message to send in the conversation.",
       feel = FeelMode.optional,
       binding = @TemplateProperty.PropertyBinding(name = "data.newMessage"))
   @Valid

--- a/connectors/aws/aws-bedrock/src/main/java/io/camunda/connector/aws/bedrock/model/InvokeModelData.java
+++ b/connectors/aws/aws-bedrock/src/main/java/io/camunda/connector/aws/bedrock/model/InvokeModelData.java
@@ -36,7 +36,8 @@ public final class InvokeModelData implements RequestData {
       group = "invokeModel",
       id = "data.modelId0",
       tooltip =
-          "<a href=\"https://docs.aws.amazon.com/bedrock/latest/userguide/model-ids.html\" target=\"_blank\">AWS Bedrock model IDs</a>",
+          "ID of the model to invoke. See <a href=\"https://docs.aws.amazon.com/bedrock/latest/userguide/model-ids.html\" target=\"_blank\">AWS Bedrock model IDs</a>.",
+      placeholder = "amazon.titan-text-express-v1",
       feel = FeelMode.optional,
       binding = @TemplateProperty.PropertyBinding(name = "data.modelId"))
   @Valid
@@ -47,7 +48,7 @@ public final class InvokeModelData implements RequestData {
       label = "Payload",
       group = "invokeModel",
       tooltip =
-          "<a href=\"https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters.html\" target=\"_blank\">AWS Bedrock model parameters</a>",
+          "Request body sent to the model, whose structure depends on the model. See <a href=\"https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters.html\" target=\"_blank\">AWS Bedrock model parameters</a>.",
       id = "data.payload",
       feel = FeelMode.required,
       binding = @TemplateProperty.PropertyBinding(name = "data.payload"))

--- a/connectors/aws/aws-bedrock/src/main/java/io/camunda/connector/aws/bedrock/model/InvokeModelData.java
+++ b/connectors/aws/aws-bedrock/src/main/java/io/camunda/connector/aws/bedrock/model/InvokeModelData.java
@@ -35,8 +35,8 @@ public final class InvokeModelData implements RequestData {
       label = "Model ID",
       group = "invokeModel",
       id = "data.modelId0",
-      description =
-          "Specify the model ID. Details in the <a href=\"https://docs.aws.amazon.com/bedrock/latest/userguide/model-ids.html\" target=\"_blank\">documentation</a>",
+      tooltip =
+          "<a href=\"https://docs.aws.amazon.com/bedrock/latest/userguide/model-ids.html\" target=\"_blank\">AWS Bedrock model IDs</a>",
       feel = FeelMode.optional,
       binding = @TemplateProperty.PropertyBinding(name = "data.modelId"))
   @Valid
@@ -46,8 +46,8 @@ public final class InvokeModelData implements RequestData {
   @TemplateProperty(
       label = "Payload",
       group = "invokeModel",
-      description =
-          "Specify the payload. Details in the <a href=\"https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters.html\" target=\"_blank\">documentation</a>",
+      tooltip =
+          "<a href=\"https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters.html\" target=\"_blank\">AWS Bedrock model parameters</a>",
       id = "data.payload",
       feel = FeelMode.required,
       binding = @TemplateProperty.PropertyBinding(name = "data.payload"))

--- a/connectors/aws/aws-comprehend/element-templates/aws-comprehend-outbound-connector.json
+++ b/connectors/aws/aws-comprehend/element-templates/aws-comprehend-outbound-connector.json
@@ -152,7 +152,6 @@
   }, {
     "id" : "input.text",
     "label" : "Text",
-    "description" : "<a href=\"https://docs.aws.amazon.com/comprehend/latest/APIReference/API_ClassifyDocument.html#comprehend-ClassifyDocument-request-Text\">Text</a> to be analyzed.",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -168,11 +167,11 @@
       "equals" : "sync",
       "type" : "simple"
     },
+    "tooltip" : "<a href=\"https://docs.aws.amazon.com/comprehend/latest/APIReference/API_ClassifyDocument.html#comprehend-ClassifyDocument-request-Text\">Text</a> to be analyzed.",
     "type" : "String"
   }, {
     "id" : "input.endpointArn",
     "label" : "Endpoint's ARN",
-    "description" : "<a href=\"https://docs.aws.amazon.com/comprehend/latest/APIReference/API_ClassifyDocument.html#comprehend-ClassifyDocument-request-EndpointArn\">ARN of Endpoint.</a>",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -188,11 +187,11 @@
       "equals" : "sync",
       "type" : "simple"
     },
+    "tooltip" : "<a href=\"https://docs.aws.amazon.com/comprehend/latest/APIReference/API_ClassifyDocument.html#comprehend-ClassifyDocument-request-EndpointArn\">ARN of Endpoint.</a>",
     "type" : "String"
   }, {
     "id" : "input.async.documentReadMode",
     "label" : "Document read mode",
-    "description" : "Determines <a href=\"https://docs.aws.amazon.com/comprehend/latest/dg/idp-set-textract-options.html\">text extraction actions</a> for PDF files.",
     "optional" : false,
     "value" : "SERVICE_DEFAULT",
     "constraints" : {
@@ -208,6 +207,7 @@
       "equals" : "async",
       "type" : "simple"
     },
+    "tooltip" : "Determines <a href=\"https://docs.aws.amazon.com/comprehend/latest/dg/idp-set-textract-options.html\">text extraction actions</a> for PDF files.",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "Service default",
@@ -222,7 +222,6 @@
   }, {
     "id" : "input.async.documentReadAction",
     "label" : "Document read action",
-    "description" : "Textract API operation that uses to extract text from PDF files and image files.",
     "optional" : false,
     "value" : "TEXTRACT_DETECT_DOCUMENT_TEXT",
     "constraints" : {
@@ -238,7 +237,7 @@
       "equals" : "async",
       "type" : "simple"
     },
-    "tooltip" : "<a href=\"https://docs.aws.amazon.com/comprehend/latest/dg/idp-set-textract-options.html\"target=\"_blank\">more info</a>",
+    "tooltip" : "The Amazon Textract API operation that Amazon Comprehend uses to extract text from PDF files and image files.",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "Detect document text",
@@ -299,7 +298,6 @@
   }, {
     "id" : "input.inputS3Uri",
     "label" : "Inputs' S3 URI",
-    "description" : "The <a href=\"https://docs.aws.amazon.com/comprehend/latest/APIReference/API_InputDataConfig.html#comprehend-Type-InputDataConfig-S3Uri\">S3Uri</a> for input data.",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -315,11 +313,11 @@
       "equals" : "async",
       "type" : "simple"
     },
+    "tooltip" : "The <a href=\"https://docs.aws.amazon.com/comprehend/latest/APIReference/API_InputDataConfig.html#comprehend-Type-InputDataConfig-S3Uri\">S3Uri</a> for input data.",
     "type" : "String"
   }, {
     "id" : "input.comprehendInputFormat",
     "label" : "Input file processing mode",
-    "description" : "Specifies how to <a href=\"https://docs.aws.amazon.com/comprehend/latest/APIReference/API_InputDataConfig.html#comprehend-Type-InputDataConfig-InputFormat\">process input data</a>.",
     "optional" : false,
     "value" : "ONE_DOC_PER_FILE",
     "group" : "input",
@@ -332,6 +330,7 @@
       "equals" : "async",
       "type" : "simple"
     },
+    "tooltip" : "Specifies how to <a href=\"https://docs.aws.amazon.com/comprehend/latest/APIReference/API_InputDataConfig.html#comprehend-Type-InputDataConfig-InputFormat\">process input data</a>.",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "Each file is considered a separate document",
@@ -346,7 +345,6 @@
   }, {
     "id" : "input.clientRequestToken",
     "label" : "Client request token",
-    "description" : "<a href=\"https://docs.aws.amazon.com/comprehend/latest/APIReference/API_StartDocumentClassificationJob.html#comprehend-StartDocumentClassificationJob-request-ClientRequestToken\">Unique identifier</a> for the processing.",
     "optional" : true,
     "feel" : "optional",
     "group" : "input",
@@ -359,11 +357,11 @@
       "equals" : "async",
       "type" : "simple"
     },
+    "tooltip" : "<a href=\"https://docs.aws.amazon.com/comprehend/latest/APIReference/API_StartDocumentClassificationJob.html#comprehend-StartDocumentClassificationJob-request-ClientRequestToken\">Unique identifier</a> for the processing.",
     "type" : "String"
   }, {
     "id" : "input.dataAccessRoleArn",
     "label" : "Data Access Role's ARN",
-    "description" : "ARN of IAM role that grants <a href=\"https://docs.aws.amazon.com/comprehend/latest/APIReference/API_StartDocumentClassificationJob.html#comprehend-StartDocumentClassificationJob-request-DataAccessRoleArn\">Amazon Comprehend read access</a> to input data.",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -379,11 +377,11 @@
       "equals" : "async",
       "type" : "simple"
     },
+    "tooltip" : "ARN of IAM role that grants <a href=\"https://docs.aws.amazon.com/comprehend/latest/APIReference/API_StartDocumentClassificationJob.html#comprehend-StartDocumentClassificationJob-request-DataAccessRoleArn\">Amazon Comprehend read access</a> to input data.",
     "type" : "String"
   }, {
     "id" : "input.documentClassifierArn",
     "label" : "Document Classifier's ARN",
-    "description" : "The <a href=\"https://docs.aws.amazon.com/comprehend/latest/APIReference/API_StartDocumentClassificationJob.html#comprehend-StartDocumentClassificationJob-request-DocumentClassifierArn\">ARN of document classifier</a> to process input data.",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -399,11 +397,11 @@
       "equals" : "async",
       "type" : "simple"
     },
+    "tooltip" : "The <a href=\"https://docs.aws.amazon.com/comprehend/latest/APIReference/API_StartDocumentClassificationJob.html#comprehend-StartDocumentClassificationJob-request-DocumentClassifierArn\">ARN of document classifier</a> to process input data.",
     "type" : "String"
   }, {
     "id" : "input.flywheelArn",
     "label" : "Flywheel's ARN",
-    "description" : "ARN of <a href=\"https://docs.aws.amazon.com/comprehend/latest/APIReference/API_StartDocumentClassificationJob.html#comprehend-StartDocumentClassificationJob-request-FlywheelArn\">Flywheel</a> for processing model.",
     "optional" : true,
     "feel" : "optional",
     "group" : "input",
@@ -416,11 +414,11 @@
       "equals" : "async",
       "type" : "simple"
     },
+    "tooltip" : "ARN of <a href=\"https://docs.aws.amazon.com/comprehend/latest/APIReference/API_StartDocumentClassificationJob.html#comprehend-StartDocumentClassificationJob-request-FlywheelArn\">Flywheel</a> for processing model.",
     "type" : "String"
   }, {
     "id" : "input.jobName",
     "label" : "Job name",
-    "description" : "The identifier of the job. <a href=\"https://docs.aws.amazon.com/comprehend/latest/APIReference/API_StartDocumentClassificationJob.html#comprehend-StartDocumentClassificationJob-request-JobName\">More info.</a>",
     "optional" : true,
     "feel" : "optional",
     "group" : "input",
@@ -433,11 +431,11 @@
       "equals" : "async",
       "type" : "simple"
     },
+    "tooltip" : "The <a href=\"https://docs.aws.amazon.com/comprehend/latest/APIReference/API_StartDocumentClassificationJob.html#comprehend-StartDocumentClassificationJob-request-JobName\">identifier of the job</a>.",
     "type" : "String"
   }, {
     "id" : "input.outputS3Uri",
     "label" : "Output's S3 URI",
-    "description" : "The <a href=\"https://docs.aws.amazon.com/comprehend/latest/APIReference/API_InputDataConfig.html#comprehend-Type-OutputDataConfig-S3Uri\">S3Uri</a> for output data.",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -453,11 +451,11 @@
       "equals" : "async",
       "type" : "simple"
     },
+    "tooltip" : "The <a href=\"https://docs.aws.amazon.com/comprehend/latest/APIReference/API_InputDataConfig.html#comprehend-Type-OutputDataConfig-S3Uri\">S3Uri</a> for output data.",
     "type" : "String"
   }, {
     "id" : "input.outputKmsKeyId",
     "label" : "Outputs KMS Key Id",
-    "description" : "KMS' key Id used to <a href=\"https://docs.aws.amazon.com/comprehend/latest/APIReference/API_OutputDataConfig.html#comprehend-Type-OutputDataConfig-KmsKeyId\">encrypt output data</a>.",
     "optional" : true,
     "feel" : "optional",
     "group" : "input",
@@ -470,11 +468,11 @@
       "equals" : "async",
       "type" : "simple"
     },
+    "tooltip" : "KMS' key Id used to <a href=\"https://docs.aws.amazon.com/comprehend/latest/APIReference/API_OutputDataConfig.html#comprehend-Type-OutputDataConfig-KmsKeyId\">encrypt output data</a>.",
     "type" : "String"
   }, {
     "id" : "input.tags",
     "label" : "Tags",
-    "description" : "Tags to <a href=\"https://docs.aws.amazon.com/comprehend/latest/APIReference/API_StartDocumentClassificationJob.html#comprehend-StartDocumentClassificationJob-request-Tags\">associate progressing with a document classification</a>.",
     "optional" : true,
     "feel" : "required",
     "group" : "input",
@@ -487,11 +485,11 @@
       "equals" : "async",
       "type" : "simple"
     },
+    "tooltip" : "Tags to <a href=\"https://docs.aws.amazon.com/comprehend/latest/APIReference/API_StartDocumentClassificationJob.html#comprehend-StartDocumentClassificationJob-request-Tags\">associate with the document classification job</a>.",
     "type" : "String"
   }, {
     "id" : "input.volumeKmsKeyId",
     "label" : "VolumeKmsKeyId",
-    "description" : "<a href=\"https://docs.aws.amazon.com/comprehend/latest/APIReference/API_StartDocumentClassificationJob.html#comprehend-StartDocumentClassificationJob-request-VolumeKmsKeyId\">KMS to encrypt data on storage</a> attached to compute instance.",
     "optional" : true,
     "feel" : "optional",
     "group" : "input",
@@ -504,11 +502,11 @@
       "equals" : "async",
       "type" : "simple"
     },
+    "tooltip" : "<a href=\"https://docs.aws.amazon.com/comprehend/latest/APIReference/API_StartDocumentClassificationJob.html#comprehend-StartDocumentClassificationJob-request-VolumeKmsKeyId\">KMS to encrypt data on storage</a> attached to compute instance.",
     "type" : "String"
   }, {
     "id" : "input.securityGroupIds",
     "label" : "Security group Ids",
-    "description" : "<a href=\"https://docs.aws.amazon.com/comprehend/latest/APIReference/API_VpcConfig.html#comprehend-Type-VpcConfig-SecurityGroupIds\">ID for security group</a> on instance of private VPC.",
     "optional" : true,
     "feel" : "required",
     "group" : "input",
@@ -521,11 +519,11 @@
       "equals" : "async",
       "type" : "simple"
     },
+    "tooltip" : "<a href=\"https://docs.aws.amazon.com/comprehend/latest/APIReference/API_VpcConfig.html#comprehend-Type-VpcConfig-SecurityGroupIds\">ID for security group</a> on instance of private VPC.",
     "type" : "String"
   }, {
     "id" : "input.subnets",
     "label" : "Subnets",
-    "description" : "ID for each <a href=\"https://docs.aws.amazon.com/comprehend/latest/APIReference/API_VpcConfig.html#comprehend-Type-VpcConfig-Subnets\">subnet used in VPC</a>.",
     "optional" : true,
     "feel" : "required",
     "group" : "input",
@@ -538,6 +536,7 @@
       "equals" : "async",
       "type" : "simple"
     },
+    "tooltip" : "ID for each <a href=\"https://docs.aws.amazon.com/comprehend/latest/APIReference/API_VpcConfig.html#comprehend-Type-VpcConfig-Subnets\">subnet used in VPC</a>.",
     "type" : "String"
   }, {
     "id" : "version",

--- a/connectors/aws/aws-comprehend/element-templates/aws-comprehend-outbound-connector.json
+++ b/connectors/aws/aws-comprehend/element-templates/aws-comprehend-outbound-connector.json
@@ -86,7 +86,6 @@
   }, {
     "id" : "authentication.accessKey",
     "label" : "Access key",
-    "description" : "Provide an IAM access key tailored to a user, equipped with the necessary permissions",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -102,11 +101,11 @@
       "equals" : "credentials",
       "type" : "simple"
     },
+    "tooltip" : "IAM access key of a user with the necessary permissions for this connector",
     "type" : "String"
   }, {
     "id" : "authentication.secretKey",
     "label" : "Secret key",
-    "description" : "Provide a secret key of a user with permissions to invoke specified AWS Lambda function",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -122,11 +121,11 @@
       "equals" : "credentials",
       "type" : "simple"
     },
+    "tooltip" : "IAM secret key of a user with the necessary permissions for this connector",
     "type" : "String"
   }, {
     "id" : "configuration.region",
     "label" : "Region",
-    "description" : "Specify the AWS region",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -187,7 +186,7 @@
       "equals" : "sync",
       "type" : "simple"
     },
-    "tooltip" : "<a href=\"https://docs.aws.amazon.com/comprehend/latest/APIReference/API_ClassifyDocument.html#comprehend-ClassifyDocument-request-EndpointArn\">ARN of Endpoint.</a>",
+    "tooltip" : "ARN of the custom model <a href=\"https://docs.aws.amazon.com/comprehend/latest/APIReference/API_ClassifyDocument.html#comprehend-ClassifyDocument-request-EndpointArn\">endpoint</a> used to run the classification.",
     "type" : "String"
   }, {
     "id" : "input.async.documentReadMode",
@@ -414,7 +413,7 @@
       "equals" : "async",
       "type" : "simple"
     },
-    "tooltip" : "ARN of <a href=\"https://docs.aws.amazon.com/comprehend/latest/APIReference/API_StartDocumentClassificationJob.html#comprehend-StartDocumentClassificationJob-request-FlywheelArn\">Flywheel</a> for processing model.",
+    "tooltip" : "ARN of the <a href=\"https://docs.aws.amazon.com/comprehend/latest/APIReference/API_StartDocumentClassificationJob.html#comprehend-StartDocumentClassificationJob-request-FlywheelArn\">flywheel</a> that orchestrates training and versioning of the classification model.",
     "type" : "String"
   }, {
     "id" : "input.jobName",
@@ -431,7 +430,6 @@
       "equals" : "async",
       "type" : "simple"
     },
-    "tooltip" : "The <a href=\"https://docs.aws.amazon.com/comprehend/latest/APIReference/API_StartDocumentClassificationJob.html#comprehend-StartDocumentClassificationJob-request-JobName\">identifier of the job</a>.",
     "type" : "String"
   }, {
     "id" : "input.outputS3Uri",

--- a/connectors/aws/aws-comprehend/element-templates/hybrid/aws-comprehend-outbound-connector-hybrid.json
+++ b/connectors/aws/aws-comprehend/element-templates/hybrid/aws-comprehend-outbound-connector-hybrid.json
@@ -157,7 +157,6 @@
   }, {
     "id" : "input.text",
     "label" : "Text",
-    "description" : "<a href=\"https://docs.aws.amazon.com/comprehend/latest/APIReference/API_ClassifyDocument.html#comprehend-ClassifyDocument-request-Text\">Text</a> to be analyzed.",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -173,11 +172,11 @@
       "equals" : "sync",
       "type" : "simple"
     },
+    "tooltip" : "<a href=\"https://docs.aws.amazon.com/comprehend/latest/APIReference/API_ClassifyDocument.html#comprehend-ClassifyDocument-request-Text\">Text</a> to be analyzed.",
     "type" : "String"
   }, {
     "id" : "input.endpointArn",
     "label" : "Endpoint's ARN",
-    "description" : "<a href=\"https://docs.aws.amazon.com/comprehend/latest/APIReference/API_ClassifyDocument.html#comprehend-ClassifyDocument-request-EndpointArn\">ARN of Endpoint.</a>",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -193,11 +192,11 @@
       "equals" : "sync",
       "type" : "simple"
     },
+    "tooltip" : "<a href=\"https://docs.aws.amazon.com/comprehend/latest/APIReference/API_ClassifyDocument.html#comprehend-ClassifyDocument-request-EndpointArn\">ARN of Endpoint.</a>",
     "type" : "String"
   }, {
     "id" : "input.async.documentReadMode",
     "label" : "Document read mode",
-    "description" : "Determines <a href=\"https://docs.aws.amazon.com/comprehend/latest/dg/idp-set-textract-options.html\">text extraction actions</a> for PDF files.",
     "optional" : false,
     "value" : "SERVICE_DEFAULT",
     "constraints" : {
@@ -213,6 +212,7 @@
       "equals" : "async",
       "type" : "simple"
     },
+    "tooltip" : "Determines <a href=\"https://docs.aws.amazon.com/comprehend/latest/dg/idp-set-textract-options.html\">text extraction actions</a> for PDF files.",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "Service default",
@@ -227,7 +227,6 @@
   }, {
     "id" : "input.async.documentReadAction",
     "label" : "Document read action",
-    "description" : "Textract API operation that uses to extract text from PDF files and image files.",
     "optional" : false,
     "value" : "TEXTRACT_DETECT_DOCUMENT_TEXT",
     "constraints" : {
@@ -243,7 +242,7 @@
       "equals" : "async",
       "type" : "simple"
     },
-    "tooltip" : "<a href=\"https://docs.aws.amazon.com/comprehend/latest/dg/idp-set-textract-options.html\"target=\"_blank\">more info</a>",
+    "tooltip" : "The Amazon Textract API operation that Amazon Comprehend uses to extract text from PDF files and image files.",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "Detect document text",
@@ -304,7 +303,6 @@
   }, {
     "id" : "input.inputS3Uri",
     "label" : "Inputs' S3 URI",
-    "description" : "The <a href=\"https://docs.aws.amazon.com/comprehend/latest/APIReference/API_InputDataConfig.html#comprehend-Type-InputDataConfig-S3Uri\">S3Uri</a> for input data.",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -320,11 +318,11 @@
       "equals" : "async",
       "type" : "simple"
     },
+    "tooltip" : "The <a href=\"https://docs.aws.amazon.com/comprehend/latest/APIReference/API_InputDataConfig.html#comprehend-Type-InputDataConfig-S3Uri\">S3Uri</a> for input data.",
     "type" : "String"
   }, {
     "id" : "input.comprehendInputFormat",
     "label" : "Input file processing mode",
-    "description" : "Specifies how to <a href=\"https://docs.aws.amazon.com/comprehend/latest/APIReference/API_InputDataConfig.html#comprehend-Type-InputDataConfig-InputFormat\">process input data</a>.",
     "optional" : false,
     "value" : "ONE_DOC_PER_FILE",
     "group" : "input",
@@ -337,6 +335,7 @@
       "equals" : "async",
       "type" : "simple"
     },
+    "tooltip" : "Specifies how to <a href=\"https://docs.aws.amazon.com/comprehend/latest/APIReference/API_InputDataConfig.html#comprehend-Type-InputDataConfig-InputFormat\">process input data</a>.",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "Each file is considered a separate document",
@@ -351,7 +350,6 @@
   }, {
     "id" : "input.clientRequestToken",
     "label" : "Client request token",
-    "description" : "<a href=\"https://docs.aws.amazon.com/comprehend/latest/APIReference/API_StartDocumentClassificationJob.html#comprehend-StartDocumentClassificationJob-request-ClientRequestToken\">Unique identifier</a> for the processing.",
     "optional" : true,
     "feel" : "optional",
     "group" : "input",
@@ -364,11 +362,11 @@
       "equals" : "async",
       "type" : "simple"
     },
+    "tooltip" : "<a href=\"https://docs.aws.amazon.com/comprehend/latest/APIReference/API_StartDocumentClassificationJob.html#comprehend-StartDocumentClassificationJob-request-ClientRequestToken\">Unique identifier</a> for the processing.",
     "type" : "String"
   }, {
     "id" : "input.dataAccessRoleArn",
     "label" : "Data Access Role's ARN",
-    "description" : "ARN of IAM role that grants <a href=\"https://docs.aws.amazon.com/comprehend/latest/APIReference/API_StartDocumentClassificationJob.html#comprehend-StartDocumentClassificationJob-request-DataAccessRoleArn\">Amazon Comprehend read access</a> to input data.",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -384,11 +382,11 @@
       "equals" : "async",
       "type" : "simple"
     },
+    "tooltip" : "ARN of IAM role that grants <a href=\"https://docs.aws.amazon.com/comprehend/latest/APIReference/API_StartDocumentClassificationJob.html#comprehend-StartDocumentClassificationJob-request-DataAccessRoleArn\">Amazon Comprehend read access</a> to input data.",
     "type" : "String"
   }, {
     "id" : "input.documentClassifierArn",
     "label" : "Document Classifier's ARN",
-    "description" : "The <a href=\"https://docs.aws.amazon.com/comprehend/latest/APIReference/API_StartDocumentClassificationJob.html#comprehend-StartDocumentClassificationJob-request-DocumentClassifierArn\">ARN of document classifier</a> to process input data.",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -404,11 +402,11 @@
       "equals" : "async",
       "type" : "simple"
     },
+    "tooltip" : "The <a href=\"https://docs.aws.amazon.com/comprehend/latest/APIReference/API_StartDocumentClassificationJob.html#comprehend-StartDocumentClassificationJob-request-DocumentClassifierArn\">ARN of document classifier</a> to process input data.",
     "type" : "String"
   }, {
     "id" : "input.flywheelArn",
     "label" : "Flywheel's ARN",
-    "description" : "ARN of <a href=\"https://docs.aws.amazon.com/comprehend/latest/APIReference/API_StartDocumentClassificationJob.html#comprehend-StartDocumentClassificationJob-request-FlywheelArn\">Flywheel</a> for processing model.",
     "optional" : true,
     "feel" : "optional",
     "group" : "input",
@@ -421,11 +419,11 @@
       "equals" : "async",
       "type" : "simple"
     },
+    "tooltip" : "ARN of <a href=\"https://docs.aws.amazon.com/comprehend/latest/APIReference/API_StartDocumentClassificationJob.html#comprehend-StartDocumentClassificationJob-request-FlywheelArn\">Flywheel</a> for processing model.",
     "type" : "String"
   }, {
     "id" : "input.jobName",
     "label" : "Job name",
-    "description" : "The identifier of the job. <a href=\"https://docs.aws.amazon.com/comprehend/latest/APIReference/API_StartDocumentClassificationJob.html#comprehend-StartDocumentClassificationJob-request-JobName\">More info.</a>",
     "optional" : true,
     "feel" : "optional",
     "group" : "input",
@@ -438,11 +436,11 @@
       "equals" : "async",
       "type" : "simple"
     },
+    "tooltip" : "The <a href=\"https://docs.aws.amazon.com/comprehend/latest/APIReference/API_StartDocumentClassificationJob.html#comprehend-StartDocumentClassificationJob-request-JobName\">identifier of the job</a>.",
     "type" : "String"
   }, {
     "id" : "input.outputS3Uri",
     "label" : "Output's S3 URI",
-    "description" : "The <a href=\"https://docs.aws.amazon.com/comprehend/latest/APIReference/API_InputDataConfig.html#comprehend-Type-OutputDataConfig-S3Uri\">S3Uri</a> for output data.",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -458,11 +456,11 @@
       "equals" : "async",
       "type" : "simple"
     },
+    "tooltip" : "The <a href=\"https://docs.aws.amazon.com/comprehend/latest/APIReference/API_InputDataConfig.html#comprehend-Type-OutputDataConfig-S3Uri\">S3Uri</a> for output data.",
     "type" : "String"
   }, {
     "id" : "input.outputKmsKeyId",
     "label" : "Outputs KMS Key Id",
-    "description" : "KMS' key Id used to <a href=\"https://docs.aws.amazon.com/comprehend/latest/APIReference/API_OutputDataConfig.html#comprehend-Type-OutputDataConfig-KmsKeyId\">encrypt output data</a>.",
     "optional" : true,
     "feel" : "optional",
     "group" : "input",
@@ -475,11 +473,11 @@
       "equals" : "async",
       "type" : "simple"
     },
+    "tooltip" : "KMS' key Id used to <a href=\"https://docs.aws.amazon.com/comprehend/latest/APIReference/API_OutputDataConfig.html#comprehend-Type-OutputDataConfig-KmsKeyId\">encrypt output data</a>.",
     "type" : "String"
   }, {
     "id" : "input.tags",
     "label" : "Tags",
-    "description" : "Tags to <a href=\"https://docs.aws.amazon.com/comprehend/latest/APIReference/API_StartDocumentClassificationJob.html#comprehend-StartDocumentClassificationJob-request-Tags\">associate progressing with a document classification</a>.",
     "optional" : true,
     "feel" : "required",
     "group" : "input",
@@ -492,11 +490,11 @@
       "equals" : "async",
       "type" : "simple"
     },
+    "tooltip" : "Tags to <a href=\"https://docs.aws.amazon.com/comprehend/latest/APIReference/API_StartDocumentClassificationJob.html#comprehend-StartDocumentClassificationJob-request-Tags\">associate with the document classification job</a>.",
     "type" : "String"
   }, {
     "id" : "input.volumeKmsKeyId",
     "label" : "VolumeKmsKeyId",
-    "description" : "<a href=\"https://docs.aws.amazon.com/comprehend/latest/APIReference/API_StartDocumentClassificationJob.html#comprehend-StartDocumentClassificationJob-request-VolumeKmsKeyId\">KMS to encrypt data on storage</a> attached to compute instance.",
     "optional" : true,
     "feel" : "optional",
     "group" : "input",
@@ -509,11 +507,11 @@
       "equals" : "async",
       "type" : "simple"
     },
+    "tooltip" : "<a href=\"https://docs.aws.amazon.com/comprehend/latest/APIReference/API_StartDocumentClassificationJob.html#comprehend-StartDocumentClassificationJob-request-VolumeKmsKeyId\">KMS to encrypt data on storage</a> attached to compute instance.",
     "type" : "String"
   }, {
     "id" : "input.securityGroupIds",
     "label" : "Security group Ids",
-    "description" : "<a href=\"https://docs.aws.amazon.com/comprehend/latest/APIReference/API_VpcConfig.html#comprehend-Type-VpcConfig-SecurityGroupIds\">ID for security group</a> on instance of private VPC.",
     "optional" : true,
     "feel" : "required",
     "group" : "input",
@@ -526,11 +524,11 @@
       "equals" : "async",
       "type" : "simple"
     },
+    "tooltip" : "<a href=\"https://docs.aws.amazon.com/comprehend/latest/APIReference/API_VpcConfig.html#comprehend-Type-VpcConfig-SecurityGroupIds\">ID for security group</a> on instance of private VPC.",
     "type" : "String"
   }, {
     "id" : "input.subnets",
     "label" : "Subnets",
-    "description" : "ID for each <a href=\"https://docs.aws.amazon.com/comprehend/latest/APIReference/API_VpcConfig.html#comprehend-Type-VpcConfig-Subnets\">subnet used in VPC</a>.",
     "optional" : true,
     "feel" : "required",
     "group" : "input",
@@ -543,6 +541,7 @@
       "equals" : "async",
       "type" : "simple"
     },
+    "tooltip" : "ID for each <a href=\"https://docs.aws.amazon.com/comprehend/latest/APIReference/API_VpcConfig.html#comprehend-Type-VpcConfig-Subnets\">subnet used in VPC</a>.",
     "type" : "String"
   }, {
     "id" : "version",

--- a/connectors/aws/aws-comprehend/element-templates/hybrid/aws-comprehend-outbound-connector-hybrid.json
+++ b/connectors/aws/aws-comprehend/element-templates/hybrid/aws-comprehend-outbound-connector-hybrid.json
@@ -91,7 +91,6 @@
   }, {
     "id" : "authentication.accessKey",
     "label" : "Access key",
-    "description" : "Provide an IAM access key tailored to a user, equipped with the necessary permissions",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -107,11 +106,11 @@
       "equals" : "credentials",
       "type" : "simple"
     },
+    "tooltip" : "IAM access key of a user with the necessary permissions for this connector",
     "type" : "String"
   }, {
     "id" : "authentication.secretKey",
     "label" : "Secret key",
-    "description" : "Provide a secret key of a user with permissions to invoke specified AWS Lambda function",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -127,11 +126,11 @@
       "equals" : "credentials",
       "type" : "simple"
     },
+    "tooltip" : "IAM secret key of a user with the necessary permissions for this connector",
     "type" : "String"
   }, {
     "id" : "configuration.region",
     "label" : "Region",
-    "description" : "Specify the AWS region",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -192,7 +191,7 @@
       "equals" : "sync",
       "type" : "simple"
     },
-    "tooltip" : "<a href=\"https://docs.aws.amazon.com/comprehend/latest/APIReference/API_ClassifyDocument.html#comprehend-ClassifyDocument-request-EndpointArn\">ARN of Endpoint.</a>",
+    "tooltip" : "ARN of the custom model <a href=\"https://docs.aws.amazon.com/comprehend/latest/APIReference/API_ClassifyDocument.html#comprehend-ClassifyDocument-request-EndpointArn\">endpoint</a> used to run the classification.",
     "type" : "String"
   }, {
     "id" : "input.async.documentReadMode",
@@ -419,7 +418,7 @@
       "equals" : "async",
       "type" : "simple"
     },
-    "tooltip" : "ARN of <a href=\"https://docs.aws.amazon.com/comprehend/latest/APIReference/API_StartDocumentClassificationJob.html#comprehend-StartDocumentClassificationJob-request-FlywheelArn\">Flywheel</a> for processing model.",
+    "tooltip" : "ARN of the <a href=\"https://docs.aws.amazon.com/comprehend/latest/APIReference/API_StartDocumentClassificationJob.html#comprehend-StartDocumentClassificationJob-request-FlywheelArn\">flywheel</a> that orchestrates training and versioning of the classification model.",
     "type" : "String"
   }, {
     "id" : "input.jobName",
@@ -436,7 +435,6 @@
       "equals" : "async",
       "type" : "simple"
     },
-    "tooltip" : "The <a href=\"https://docs.aws.amazon.com/comprehend/latest/APIReference/API_StartDocumentClassificationJob.html#comprehend-StartDocumentClassificationJob-request-JobName\">identifier of the job</a>.",
     "type" : "String"
   }, {
     "id" : "input.outputS3Uri",

--- a/connectors/aws/aws-comprehend/src/main/java/io/camunda/connector/comprehend/model/ComprehendAsyncRequestData.java
+++ b/connectors/aws/aws-comprehend/src/main/java/io/camunda/connector/comprehend/model/ComprehendAsyncRequestData.java
@@ -145,16 +145,10 @@ public record ComprehendAsyncRequestData(
             group = "input",
             label = "Flywheel's ARN",
             tooltip =
-                "ARN of <a href=\"https://docs.aws.amazon.com/comprehend/latest/APIReference/API_StartDocumentClassificationJob.html#comprehend-StartDocumentClassificationJob-request-FlywheelArn\">Flywheel</a> for processing model.",
+                "ARN of the <a href=\"https://docs.aws.amazon.com/comprehend/latest/APIReference/API_StartDocumentClassificationJob.html#comprehend-StartDocumentClassificationJob-request-FlywheelArn\">flywheel</a> that orchestrates training and versioning of the classification model.",
             optional = true)
         String flywheelArn,
-    @TemplateProperty(
-            group = "input",
-            label = "Job name",
-            tooltip =
-                "The <a href=\"https://docs.aws.amazon.com/comprehend/latest/APIReference/API_StartDocumentClassificationJob.html#comprehend-StartDocumentClassificationJob-request-JobName\">identifier of the job</a>.",
-            optional = true)
-        String jobName,
+    @TemplateProperty(group = "input", label = "Job name", optional = true) String jobName,
     @TemplateProperty(
             group = "input",
             label = "Output's S3 URI",

--- a/connectors/aws/aws-comprehend/src/main/java/io/camunda/connector/comprehend/model/ComprehendAsyncRequestData.java
+++ b/connectors/aws/aws-comprehend/src/main/java/io/camunda/connector/comprehend/model/ComprehendAsyncRequestData.java
@@ -46,7 +46,7 @@ public record ComprehendAsyncRequestData(
                   label = "Force document read action"),
               @TemplateProperty.DropdownPropertyChoice(value = "NO_DATA", label = "None"),
             },
-            description =
+            tooltip =
                 "Determines <a href=\"https://docs.aws.amazon.com/comprehend/latest/dg/idp-set-textract-options.html\">text extraction actions</a> for PDF files.")
         @NotNull
         ComprehendDocumentReadMode documentReadMode,
@@ -67,10 +67,8 @@ public record ComprehendAsyncRequestData(
                   label = "Analyze document"),
               @TemplateProperty.DropdownPropertyChoice(value = "NO_DATA", label = "None")
             },
-            description =
-                "Textract API operation that uses to extract text from PDF files and image files.",
             tooltip =
-                "<a href=\"https://docs.aws.amazon.com/comprehend/latest/dg/idp-set-textract-options.html\"target=\"_blank\">more info</a>")
+                "The Amazon Textract API operation that Amazon Comprehend uses to extract text from PDF files and image files.")
         @NotNull
         ComprehendDocumentReadAction documentReadAction,
     @TemplateProperty(
@@ -100,7 +98,7 @@ public record ComprehendAsyncRequestData(
     @TemplateProperty(
             label = "Inputs' S3 URI",
             group = "input",
-            description =
+            tooltip =
                 "The <a href=\"https://docs.aws.amazon.com/comprehend/latest/APIReference/API_InputDataConfig.html#comprehend-Type-InputDataConfig-S3Uri\">S3Uri</a> for input data.")
         @NotNull
         String inputS3Uri,
@@ -119,56 +117,55 @@ public record ComprehendAsyncRequestData(
                   label = "Each line in a file is considered a separate document"),
               @TemplateProperty.DropdownPropertyChoice(value = "NO_DATA", label = "None")
             },
-            description =
+            tooltip =
                 "Specifies how to <a href=\"https://docs.aws.amazon.com/comprehend/latest/APIReference/API_InputDataConfig.html#comprehend-Type-InputDataConfig-InputFormat\">process input data</a>.")
         ComprehendInputFormat comprehendInputFormat,
     @TemplateProperty(
             group = "input",
             label = "Client request token",
-            description =
+            tooltip =
                 "<a href=\"https://docs.aws.amazon.com/comprehend/latest/APIReference/API_StartDocumentClassificationJob.html#comprehend-StartDocumentClassificationJob-request-ClientRequestToken\">Unique identifier</a> for the processing.",
             optional = true)
         String clientRequestToken,
     @TemplateProperty(
             group = "input",
             label = "Data Access Role's ARN",
-            description =
+            tooltip =
                 "ARN of IAM role that grants <a href=\"https://docs.aws.amazon.com/comprehend/latest/APIReference/API_StartDocumentClassificationJob.html#comprehend-StartDocumentClassificationJob-request-DataAccessRoleArn\">Amazon Comprehend read access</a> to input data.")
         @NotNull
         String dataAccessRoleArn,
     @TemplateProperty(
             group = "input",
             label = "Document Classifier's ARN",
-            description =
+            tooltip =
                 "The <a href=\"https://docs.aws.amazon.com/comprehend/latest/APIReference/API_StartDocumentClassificationJob.html#comprehend-StartDocumentClassificationJob-request-DocumentClassifierArn\">ARN of document classifier</a> to process input data.")
         @NotNull
         String documentClassifierArn,
     @TemplateProperty(
             group = "input",
             label = "Flywheel's ARN",
-            description =
+            tooltip =
                 "ARN of <a href=\"https://docs.aws.amazon.com/comprehend/latest/APIReference/API_StartDocumentClassificationJob.html#comprehend-StartDocumentClassificationJob-request-FlywheelArn\">Flywheel</a> for processing model.",
             optional = true)
         String flywheelArn,
     @TemplateProperty(
             group = "input",
             label = "Job name",
-            description =
-                "The identifier of the job. "
-                    + "<a href=\"https://docs.aws.amazon.com/comprehend/latest/APIReference/API_StartDocumentClassificationJob.html#comprehend-StartDocumentClassificationJob-request-JobName\">More info.</a>",
+            tooltip =
+                "The <a href=\"https://docs.aws.amazon.com/comprehend/latest/APIReference/API_StartDocumentClassificationJob.html#comprehend-StartDocumentClassificationJob-request-JobName\">identifier of the job</a>.",
             optional = true)
         String jobName,
     @TemplateProperty(
             group = "input",
             label = "Output's S3 URI",
-            description =
+            tooltip =
                 "The <a href=\"https://docs.aws.amazon.com/comprehend/latest/APIReference/API_InputDataConfig.html#comprehend-Type-OutputDataConfig-S3Uri\">S3Uri</a> for output data.")
         @NotNull
         String outputS3Uri,
     @TemplateProperty(
             group = "input",
             label = "Outputs KMS Key Id",
-            description =
+            tooltip =
                 "KMS' key Id used to <a href=\"https://docs.aws.amazon.com/comprehend/latest/APIReference/API_OutputDataConfig.html#comprehend-Type-OutputDataConfig-KmsKeyId\">encrypt output data</a>.",
             optional = true)
         String outputKmsKeyId,
@@ -176,15 +173,15 @@ public record ComprehendAsyncRequestData(
         @TemplateProperty(
             group = "input",
             label = "Tags",
-            description =
-                "Tags to <a href=\"https://docs.aws.amazon.com/comprehend/latest/APIReference/API_StartDocumentClassificationJob.html#comprehend-StartDocumentClassificationJob-request-Tags\">associate progressing with a document classification</a>.",
+            tooltip =
+                "Tags to <a href=\"https://docs.aws.amazon.com/comprehend/latest/APIReference/API_StartDocumentClassificationJob.html#comprehend-StartDocumentClassificationJob-request-Tags\">associate with the document classification job</a>.",
             optional = true,
             feel = FeelMode.required)
         Map<String, String> tags,
     @TemplateProperty(
             group = "input",
             label = "VolumeKmsKeyId",
-            description =
+            tooltip =
                 "<a href=\"https://docs.aws.amazon.com/comprehend/latest/APIReference/API_StartDocumentClassificationJob.html#comprehend-StartDocumentClassificationJob-request-VolumeKmsKeyId\">KMS to encrypt data on storage</a> attached to compute instance.",
             optional = true)
         String volumeKmsKeyId,
@@ -192,7 +189,7 @@ public record ComprehendAsyncRequestData(
         @TemplateProperty(
             group = "input",
             label = "Security group Ids",
-            description =
+            tooltip =
                 "<a href=\"https://docs.aws.amazon.com/comprehend/latest/APIReference/API_VpcConfig.html#comprehend-Type-VpcConfig-SecurityGroupIds\">ID for security group</a> on instance of private VPC.",
             optional = true,
             feel = FeelMode.required)
@@ -201,7 +198,7 @@ public record ComprehendAsyncRequestData(
         @TemplateProperty(
             group = "input",
             label = "Subnets",
-            description =
+            tooltip =
                 "ID for each <a href=\"https://docs.aws.amazon.com/comprehend/latest/APIReference/API_VpcConfig.html#comprehend-Type-VpcConfig-Subnets\">subnet used in VPC</a>.",
             optional = true,
             feel = FeelMode.required)

--- a/connectors/aws/aws-comprehend/src/main/java/io/camunda/connector/comprehend/model/ComprehendSyncRequestData.java
+++ b/connectors/aws/aws-comprehend/src/main/java/io/camunda/connector/comprehend/model/ComprehendSyncRequestData.java
@@ -36,7 +36,7 @@ public record ComprehendSyncRequestData(
             group = "input",
             label = "Endpoint's ARN",
             tooltip =
-                "<a href=\"https://docs.aws.amazon.com/comprehend/latest/APIReference/API_ClassifyDocument.html#comprehend-ClassifyDocument-request-EndpointArn\">ARN of Endpoint.</a>")
+                "ARN of the custom model <a href=\"https://docs.aws.amazon.com/comprehend/latest/APIReference/API_ClassifyDocument.html#comprehend-ClassifyDocument-request-EndpointArn\">endpoint</a> used to run the classification.")
         @NotNull
         String endpointArn)
     implements ComprehendRequestData {

--- a/connectors/aws/aws-comprehend/src/main/java/io/camunda/connector/comprehend/model/ComprehendSyncRequestData.java
+++ b/connectors/aws/aws-comprehend/src/main/java/io/camunda/connector/comprehend/model/ComprehendSyncRequestData.java
@@ -28,14 +28,14 @@ public record ComprehendSyncRequestData(
     @TemplateProperty(
             group = "input",
             label = "Text",
-            description =
+            tooltip =
                 "<a href=\"https://docs.aws.amazon.com/comprehend/latest/APIReference/API_ClassifyDocument.html#comprehend-ClassifyDocument-request-Text\">Text</a> to be analyzed.")
         @NotNull
         String text,
     @TemplateProperty(
             group = "input",
             label = "Endpoint's ARN",
-            description =
+            tooltip =
                 "<a href=\"https://docs.aws.amazon.com/comprehend/latest/APIReference/API_ClassifyDocument.html#comprehend-ClassifyDocument-request-EndpointArn\">ARN of Endpoint.</a>")
         @NotNull
         String endpointArn)

--- a/connectors/aws/aws-dynamodb/element-templates/aws-dynamodb-outbound-connector.json
+++ b/connectors/aws/aws-dynamodb/element-templates/aws-dynamodb-outbound-connector.json
@@ -206,7 +206,6 @@
   }, {
     "id" : "input.createTable.tableName",
     "label" : "Table name",
-    "description" : "Name of DynamoDB table",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -228,11 +227,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Name of DynamoDB table",
     "type" : "String"
   }, {
     "id" : "input.partitionKey",
     "label" : "Partition key",
-    "description" : "Partition key role. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-dynamodb/\" target=\"_blank\">documentation</a>",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -254,11 +253,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Attribute name of the table's partition key. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-dynamodb/\" target=\"_blank\">Amazon DynamoDB connector documentation</a>",
     "type" : "String"
   }, {
     "id" : "input.partitionKeyRole",
     "label" : "Partition key role",
-    "description" : "The role that this key attribute will assume. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-dynamodb/\" target=\"_blank\">documentation</a>",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -279,6 +278,7 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "The role that this key attribute will assume. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-dynamodb/\" target=\"_blank\">Amazon DynamoDB connector documentation</a>",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "HASH",
@@ -290,7 +290,6 @@
   }, {
     "id" : "input.partitionKeyType",
     "label" : "Partition key attribute data type",
-    "description" : "Represents the data for an attribute",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -311,6 +310,7 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Represents the data for an attribute",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "Binary",
@@ -325,7 +325,6 @@
   }, {
     "id" : "input.sortKey",
     "label" : "Sort key",
-    "description" : "Sort key. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-dynamodb/\" target=\"_blank\">documentation</a>",
     "optional" : true,
     "feel" : "optional",
     "group" : "input",
@@ -344,11 +343,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-dynamodb/\" target=\"_blank\">Amazon DynamoDB connector documentation</a>",
     "type" : "String"
   }, {
     "id" : "input.sortKeyRole",
     "label" : "Sort key role",
-    "description" : "The role that this key attribute will assume",
     "optional" : true,
     "group" : "input",
     "binding" : {
@@ -366,6 +365,7 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "The role that this key attribute will assume",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "HASH",
@@ -377,7 +377,6 @@
   }, {
     "id" : "input.sortKeyType",
     "label" : "Sort key attribute data type",
-    "description" : "Represents the data for an attribute",
     "optional" : true,
     "group" : "input",
     "binding" : {
@@ -395,6 +394,7 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Represents the data for an attribute",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "Binary",
@@ -409,7 +409,6 @@
   }, {
     "id" : "input.readCapacityUnits",
     "label" : "Read capacity units",
-    "description" : "Total number of read capacity units. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-dynamodb/\" target=\"_blank\">documentation</a>",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -431,11 +430,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Total number of read capacity units. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-dynamodb/\" target=\"_blank\">Amazon DynamoDB connector documentation</a>",
     "type" : "Number"
   }, {
     "id" : "input.writeCapacityUnits",
     "label" : "Write capacity units",
-    "description" : "Total number of write capacity units. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-dynamodb/\" target=\"_blank\">documentation</a>",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -457,11 +456,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Total number of write capacity units. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-dynamodb/\" target=\"_blank\">Amazon DynamoDB connector documentation</a>",
     "type" : "Number"
   }, {
     "id" : "input.billingModeStr",
     "label" : "Billing mode",
-    "description" : "Controls how you are charged for read and write throughput. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-dynamodb/\" target=\"_blank\">documentation</a>",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -482,6 +481,7 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Controls how you are charged for read and write throughput. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-dynamodb/\" target=\"_blank\">Amazon DynamoDB connector documentation</a>",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "PROVISIONED",
@@ -493,7 +493,6 @@
   }, {
     "id" : "input.deletionProtection",
     "label" : "Deletion protection",
-    "description" : "Prevents accidental table deletion",
     "optional" : false,
     "value" : "false",
     "constraints" : {
@@ -515,6 +514,7 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Prevents accidental table deletion",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "True",
@@ -526,7 +526,6 @@
   }, {
     "id" : "input.deleteTable.tableName",
     "label" : "Table name",
-    "description" : "Name of DynamoDB table",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -548,11 +547,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Name of DynamoDB table",
     "type" : "String"
   }, {
     "id" : "input.describeTable.tableName",
     "label" : "Table name",
-    "description" : "Name of DynamoDB table",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -574,11 +573,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Name of DynamoDB table",
     "type" : "String"
   }, {
     "id" : "input.scanTable.tableName",
     "label" : "Table name",
-    "description" : "Name of DynamoDB table",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -600,11 +599,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Name of DynamoDB table",
     "type" : "String"
   }, {
     "id" : "input.filterExpression",
     "label" : "Filter expression",
-    "description" : "Filter expressions for scan. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-dynamodb/\" target=\"_blank\">documentation</a>",
     "optional" : true,
     "feel" : "optional",
     "group" : "input",
@@ -623,11 +622,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Filter expressions for scan. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-dynamodb/\" target=\"_blank\">Amazon DynamoDB connector documentation</a>",
     "type" : "String"
   }, {
     "id" : "input.projectionExpression",
     "label" : "Projection expression",
-    "description" : "Is a string that identifies the attributes that you want. For multiple attributes, the names must be comma-separated",
     "optional" : true,
     "feel" : "optional",
     "group" : "input",
@@ -646,11 +645,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "A string that identifies the attributes that you want. For multiple attributes, the names must be comma-separated.",
     "type" : "String"
   }, {
     "id" : "input.expressionAttributeNames",
     "label" : "Expression attribute names",
-    "description" : "Is a placeholder that you use as an alternative to an actual attribute name. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-dynamodb/\" target=\"_blank\">documentation</a>",
     "optional" : true,
     "feel" : "required",
     "group" : "input",
@@ -669,11 +668,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "A placeholder that you use as an alternative to an actual attribute name. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-dynamodb/\" target=\"_blank\">Amazon DynamoDB connector documentation</a>",
     "type" : "String"
   }, {
     "id" : "input.expressionAttributeValues",
     "label" : "Expression attribute values",
-    "description" : "Expression attribute values. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-dynamodb/\" target=\"_blank\">documentation</a>",
     "optional" : true,
     "feel" : "required",
     "group" : "input",
@@ -692,11 +691,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-dynamodb/\" target=\"_blank\">Amazon DynamoDB connector documentation</a>",
     "type" : "String"
   }, {
     "id" : "input.addItem.tableName",
     "label" : "Table name",
-    "description" : "Name of DynamoDB table",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -718,11 +717,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Name of DynamoDB table",
     "type" : "String"
   }, {
     "id" : "input.item",
     "label" : "Item",
-    "description" : "DynamoDB item (group of attributes)",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -744,11 +743,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "DynamoDB item (group of attributes)",
     "type" : "String"
   }, {
     "id" : "input.deleteItem.tableName",
     "label" : "Table name",
-    "description" : "Name of DynamoDB table",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -770,11 +769,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Name of DynamoDB table",
     "type" : "String"
   }, {
     "id" : "input.deleteItem.primaryKeyComponents",
     "label" : "Primary key components",
-    "description" : "Simple or composite primary key",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -796,11 +795,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Simple or composite primary key",
     "type" : "String"
   }, {
     "id" : "input.getItem.tableName",
     "label" : "Table name",
-    "description" : "Name of DynamoDB table",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -822,11 +821,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Name of DynamoDB table",
     "type" : "String"
   }, {
     "id" : "input.getItem.primaryKeyComponents",
     "label" : "Primary key components",
-    "description" : "Simple or composite primary key",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -848,11 +847,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Simple or composite primary key",
     "type" : "String"
   }, {
     "id" : "input.updateTable.tableName",
     "label" : "Table name",
-    "description" : "Name of DynamoDB table",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -874,11 +873,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Name of DynamoDB table",
     "type" : "String"
   }, {
     "id" : "input.updateItem.primaryKeyComponents",
     "label" : "Primary key components",
-    "description" : "Simple or composite primary key",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -900,11 +899,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Simple or composite primary key",
     "type" : "String"
   }, {
     "id" : "input.keyAttributes",
     "label" : "Key attributes",
-    "description" : "DynamoDB key attributes. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-dynamodb/\" target=\"_blank\">documentation</a>",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -926,11 +925,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "DynamoDB key attributes. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-dynamodb/\" target=\"_blank\">Amazon DynamoDB connector documentation</a>",
     "type" : "String"
   }, {
     "id" : "input.attributeAction",
     "label" : "Attribute action",
-    "description" : "Specifies how to perform the update",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -951,6 +950,7 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Specifies how to perform the update",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "PUT",

--- a/connectors/aws/aws-dynamodb/element-templates/aws-dynamodb-outbound-connector.json
+++ b/connectors/aws/aws-dynamodb/element-templates/aws-dynamodb-outbound-connector.json
@@ -140,7 +140,6 @@
   }, {
     "id" : "authentication.accessKey",
     "label" : "Access key",
-    "description" : "Provide an IAM access key tailored to a user, equipped with the necessary permissions",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -156,11 +155,11 @@
       "equals" : "credentials",
       "type" : "simple"
     },
+    "tooltip" : "IAM access key of a user with the necessary permissions for this connector",
     "type" : "String"
   }, {
     "id" : "authentication.secretKey",
     "label" : "Secret key",
-    "description" : "Provide a secret key of a user with permissions to invoke specified AWS Lambda function",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -176,11 +175,11 @@
       "equals" : "credentials",
       "type" : "simple"
     },
+    "tooltip" : "IAM secret key of a user with the necessary permissions for this connector",
     "type" : "String"
   }, {
     "id" : "configuration.region",
     "label" : "Region",
-    "description" : "Specify the AWS region",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -227,7 +226,6 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "Name of DynamoDB table",
     "type" : "String"
   }, {
     "id" : "input.partitionKey",
@@ -310,7 +308,7 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "Represents the data for an attribute",
+    "tooltip" : "S = String, N = Number, B = Binary",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "Binary",
@@ -343,7 +341,7 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-dynamodb/\" target=\"_blank\">Amazon DynamoDB connector documentation</a>",
+    "tooltip" : "Attribute name of the table's sort key. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-dynamodb/\" target=\"_blank\">Amazon DynamoDB connector documentation</a>",
     "type" : "String"
   }, {
     "id" : "input.sortKeyRole",
@@ -365,7 +363,7 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "The role that this key attribute will assume",
+    "tooltip" : "The role that this key attribute will assume. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-dynamodb/\" target=\"_blank\">Amazon DynamoDB connector documentation</a>",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "HASH",
@@ -394,7 +392,7 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "Represents the data for an attribute",
+    "tooltip" : "S = String, N = Number, B = Binary",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "Binary",
@@ -547,7 +545,6 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "Name of DynamoDB table",
     "type" : "String"
   }, {
     "id" : "input.describeTable.tableName",
@@ -573,7 +570,6 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "Name of DynamoDB table",
     "type" : "String"
   }, {
     "id" : "input.scanTable.tableName",
@@ -599,7 +595,6 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "Name of DynamoDB table",
     "type" : "String"
   }, {
     "id" : "input.filterExpression",
@@ -646,6 +641,7 @@
       } ]
     },
     "tooltip" : "A string that identifies the attributes that you want. For multiple attributes, the names must be comma-separated.",
+    "placeholder" : "Artist, SongTitle, Genre",
     "type" : "String"
   }, {
     "id" : "input.expressionAttributeNames",
@@ -691,7 +687,7 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-dynamodb/\" target=\"_blank\">Amazon DynamoDB connector documentation</a>",
+    "tooltip" : "Substitution values for placeholders used in the filter or projection expression. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-dynamodb/\" target=\"_blank\">Amazon DynamoDB connector documentation</a>",
     "type" : "String"
   }, {
     "id" : "input.addItem.tableName",
@@ -717,7 +713,6 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "Name of DynamoDB table",
     "type" : "String"
   }, {
     "id" : "input.item",
@@ -769,7 +764,6 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "Name of DynamoDB table",
     "type" : "String"
   }, {
     "id" : "input.deleteItem.primaryKeyComponents",
@@ -821,7 +815,6 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "Name of DynamoDB table",
     "type" : "String"
   }, {
     "id" : "input.getItem.primaryKeyComponents",
@@ -873,7 +866,6 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "Name of DynamoDB table",
     "type" : "String"
   }, {
     "id" : "input.updateItem.primaryKeyComponents",
@@ -925,7 +917,7 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "DynamoDB key attributes. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-dynamodb/\" target=\"_blank\">Amazon DynamoDB connector documentation</a>",
+    "tooltip" : "Attribute values to write to the item. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-dynamodb/\" target=\"_blank\">Amazon DynamoDB connector documentation</a>",
     "type" : "String"
   }, {
     "id" : "input.attributeAction",
@@ -950,7 +942,7 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "Specifies how to perform the update",
+    "tooltip" : "PUT = set the attribute value, DELETE = remove the attribute",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "PUT",

--- a/connectors/aws/aws-dynamodb/element-templates/hybrid/aws-dynamodb-outbound-connector-hybrid.json
+++ b/connectors/aws/aws-dynamodb/element-templates/hybrid/aws-dynamodb-outbound-connector-hybrid.json
@@ -211,7 +211,6 @@
   }, {
     "id" : "input.createTable.tableName",
     "label" : "Table name",
-    "description" : "Name of DynamoDB table",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -233,11 +232,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Name of DynamoDB table",
     "type" : "String"
   }, {
     "id" : "input.partitionKey",
     "label" : "Partition key",
-    "description" : "Partition key role. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-dynamodb/\" target=\"_blank\">documentation</a>",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -259,11 +258,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Attribute name of the table's partition key. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-dynamodb/\" target=\"_blank\">Amazon DynamoDB connector documentation</a>",
     "type" : "String"
   }, {
     "id" : "input.partitionKeyRole",
     "label" : "Partition key role",
-    "description" : "The role that this key attribute will assume. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-dynamodb/\" target=\"_blank\">documentation</a>",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -284,6 +283,7 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "The role that this key attribute will assume. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-dynamodb/\" target=\"_blank\">Amazon DynamoDB connector documentation</a>",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "HASH",
@@ -295,7 +295,6 @@
   }, {
     "id" : "input.partitionKeyType",
     "label" : "Partition key attribute data type",
-    "description" : "Represents the data for an attribute",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -316,6 +315,7 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Represents the data for an attribute",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "Binary",
@@ -330,7 +330,6 @@
   }, {
     "id" : "input.sortKey",
     "label" : "Sort key",
-    "description" : "Sort key. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-dynamodb/\" target=\"_blank\">documentation</a>",
     "optional" : true,
     "feel" : "optional",
     "group" : "input",
@@ -349,11 +348,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-dynamodb/\" target=\"_blank\">Amazon DynamoDB connector documentation</a>",
     "type" : "String"
   }, {
     "id" : "input.sortKeyRole",
     "label" : "Sort key role",
-    "description" : "The role that this key attribute will assume",
     "optional" : true,
     "group" : "input",
     "binding" : {
@@ -371,6 +370,7 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "The role that this key attribute will assume",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "HASH",
@@ -382,7 +382,6 @@
   }, {
     "id" : "input.sortKeyType",
     "label" : "Sort key attribute data type",
-    "description" : "Represents the data for an attribute",
     "optional" : true,
     "group" : "input",
     "binding" : {
@@ -400,6 +399,7 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Represents the data for an attribute",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "Binary",
@@ -414,7 +414,6 @@
   }, {
     "id" : "input.readCapacityUnits",
     "label" : "Read capacity units",
-    "description" : "Total number of read capacity units. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-dynamodb/\" target=\"_blank\">documentation</a>",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -436,11 +435,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Total number of read capacity units. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-dynamodb/\" target=\"_blank\">Amazon DynamoDB connector documentation</a>",
     "type" : "Number"
   }, {
     "id" : "input.writeCapacityUnits",
     "label" : "Write capacity units",
-    "description" : "Total number of write capacity units. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-dynamodb/\" target=\"_blank\">documentation</a>",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -462,11 +461,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Total number of write capacity units. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-dynamodb/\" target=\"_blank\">Amazon DynamoDB connector documentation</a>",
     "type" : "Number"
   }, {
     "id" : "input.billingModeStr",
     "label" : "Billing mode",
-    "description" : "Controls how you are charged for read and write throughput. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-dynamodb/\" target=\"_blank\">documentation</a>",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -487,6 +486,7 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Controls how you are charged for read and write throughput. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-dynamodb/\" target=\"_blank\">Amazon DynamoDB connector documentation</a>",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "PROVISIONED",
@@ -498,7 +498,6 @@
   }, {
     "id" : "input.deletionProtection",
     "label" : "Deletion protection",
-    "description" : "Prevents accidental table deletion",
     "optional" : false,
     "value" : "false",
     "constraints" : {
@@ -520,6 +519,7 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Prevents accidental table deletion",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "True",
@@ -531,7 +531,6 @@
   }, {
     "id" : "input.deleteTable.tableName",
     "label" : "Table name",
-    "description" : "Name of DynamoDB table",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -553,11 +552,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Name of DynamoDB table",
     "type" : "String"
   }, {
     "id" : "input.describeTable.tableName",
     "label" : "Table name",
-    "description" : "Name of DynamoDB table",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -579,11 +578,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Name of DynamoDB table",
     "type" : "String"
   }, {
     "id" : "input.scanTable.tableName",
     "label" : "Table name",
-    "description" : "Name of DynamoDB table",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -605,11 +604,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Name of DynamoDB table",
     "type" : "String"
   }, {
     "id" : "input.filterExpression",
     "label" : "Filter expression",
-    "description" : "Filter expressions for scan. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-dynamodb/\" target=\"_blank\">documentation</a>",
     "optional" : true,
     "feel" : "optional",
     "group" : "input",
@@ -628,11 +627,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Filter expressions for scan. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-dynamodb/\" target=\"_blank\">Amazon DynamoDB connector documentation</a>",
     "type" : "String"
   }, {
     "id" : "input.projectionExpression",
     "label" : "Projection expression",
-    "description" : "Is a string that identifies the attributes that you want. For multiple attributes, the names must be comma-separated",
     "optional" : true,
     "feel" : "optional",
     "group" : "input",
@@ -651,11 +650,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "A string that identifies the attributes that you want. For multiple attributes, the names must be comma-separated.",
     "type" : "String"
   }, {
     "id" : "input.expressionAttributeNames",
     "label" : "Expression attribute names",
-    "description" : "Is a placeholder that you use as an alternative to an actual attribute name. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-dynamodb/\" target=\"_blank\">documentation</a>",
     "optional" : true,
     "feel" : "required",
     "group" : "input",
@@ -674,11 +673,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "A placeholder that you use as an alternative to an actual attribute name. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-dynamodb/\" target=\"_blank\">Amazon DynamoDB connector documentation</a>",
     "type" : "String"
   }, {
     "id" : "input.expressionAttributeValues",
     "label" : "Expression attribute values",
-    "description" : "Expression attribute values. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-dynamodb/\" target=\"_blank\">documentation</a>",
     "optional" : true,
     "feel" : "required",
     "group" : "input",
@@ -697,11 +696,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-dynamodb/\" target=\"_blank\">Amazon DynamoDB connector documentation</a>",
     "type" : "String"
   }, {
     "id" : "input.addItem.tableName",
     "label" : "Table name",
-    "description" : "Name of DynamoDB table",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -723,11 +722,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Name of DynamoDB table",
     "type" : "String"
   }, {
     "id" : "input.item",
     "label" : "Item",
-    "description" : "DynamoDB item (group of attributes)",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -749,11 +748,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "DynamoDB item (group of attributes)",
     "type" : "String"
   }, {
     "id" : "input.deleteItem.tableName",
     "label" : "Table name",
-    "description" : "Name of DynamoDB table",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -775,11 +774,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Name of DynamoDB table",
     "type" : "String"
   }, {
     "id" : "input.deleteItem.primaryKeyComponents",
     "label" : "Primary key components",
-    "description" : "Simple or composite primary key",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -801,11 +800,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Simple or composite primary key",
     "type" : "String"
   }, {
     "id" : "input.getItem.tableName",
     "label" : "Table name",
-    "description" : "Name of DynamoDB table",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -827,11 +826,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Name of DynamoDB table",
     "type" : "String"
   }, {
     "id" : "input.getItem.primaryKeyComponents",
     "label" : "Primary key components",
-    "description" : "Simple or composite primary key",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -853,11 +852,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Simple or composite primary key",
     "type" : "String"
   }, {
     "id" : "input.updateTable.tableName",
     "label" : "Table name",
-    "description" : "Name of DynamoDB table",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -879,11 +878,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Name of DynamoDB table",
     "type" : "String"
   }, {
     "id" : "input.updateItem.primaryKeyComponents",
     "label" : "Primary key components",
-    "description" : "Simple or composite primary key",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -905,11 +904,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Simple or composite primary key",
     "type" : "String"
   }, {
     "id" : "input.keyAttributes",
     "label" : "Key attributes",
-    "description" : "DynamoDB key attributes. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-dynamodb/\" target=\"_blank\">documentation</a>",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -931,11 +930,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "DynamoDB key attributes. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-dynamodb/\" target=\"_blank\">Amazon DynamoDB connector documentation</a>",
     "type" : "String"
   }, {
     "id" : "input.attributeAction",
     "label" : "Attribute action",
-    "description" : "Specifies how to perform the update",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -956,6 +955,7 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Specifies how to perform the update",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "PUT",

--- a/connectors/aws/aws-dynamodb/element-templates/hybrid/aws-dynamodb-outbound-connector-hybrid.json
+++ b/connectors/aws/aws-dynamodb/element-templates/hybrid/aws-dynamodb-outbound-connector-hybrid.json
@@ -145,7 +145,6 @@
   }, {
     "id" : "authentication.accessKey",
     "label" : "Access key",
-    "description" : "Provide an IAM access key tailored to a user, equipped with the necessary permissions",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -161,11 +160,11 @@
       "equals" : "credentials",
       "type" : "simple"
     },
+    "tooltip" : "IAM access key of a user with the necessary permissions for this connector",
     "type" : "String"
   }, {
     "id" : "authentication.secretKey",
     "label" : "Secret key",
-    "description" : "Provide a secret key of a user with permissions to invoke specified AWS Lambda function",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -181,11 +180,11 @@
       "equals" : "credentials",
       "type" : "simple"
     },
+    "tooltip" : "IAM secret key of a user with the necessary permissions for this connector",
     "type" : "String"
   }, {
     "id" : "configuration.region",
     "label" : "Region",
-    "description" : "Specify the AWS region",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -232,7 +231,6 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "Name of DynamoDB table",
     "type" : "String"
   }, {
     "id" : "input.partitionKey",
@@ -315,7 +313,7 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "Represents the data for an attribute",
+    "tooltip" : "S = String, N = Number, B = Binary",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "Binary",
@@ -348,7 +346,7 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-dynamodb/\" target=\"_blank\">Amazon DynamoDB connector documentation</a>",
+    "tooltip" : "Attribute name of the table's sort key. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-dynamodb/\" target=\"_blank\">Amazon DynamoDB connector documentation</a>",
     "type" : "String"
   }, {
     "id" : "input.sortKeyRole",
@@ -370,7 +368,7 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "The role that this key attribute will assume",
+    "tooltip" : "The role that this key attribute will assume. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-dynamodb/\" target=\"_blank\">Amazon DynamoDB connector documentation</a>",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "HASH",
@@ -399,7 +397,7 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "Represents the data for an attribute",
+    "tooltip" : "S = String, N = Number, B = Binary",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "Binary",
@@ -552,7 +550,6 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "Name of DynamoDB table",
     "type" : "String"
   }, {
     "id" : "input.describeTable.tableName",
@@ -578,7 +575,6 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "Name of DynamoDB table",
     "type" : "String"
   }, {
     "id" : "input.scanTable.tableName",
@@ -604,7 +600,6 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "Name of DynamoDB table",
     "type" : "String"
   }, {
     "id" : "input.filterExpression",
@@ -651,6 +646,7 @@
       } ]
     },
     "tooltip" : "A string that identifies the attributes that you want. For multiple attributes, the names must be comma-separated.",
+    "placeholder" : "Artist, SongTitle, Genre",
     "type" : "String"
   }, {
     "id" : "input.expressionAttributeNames",
@@ -696,7 +692,7 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-dynamodb/\" target=\"_blank\">Amazon DynamoDB connector documentation</a>",
+    "tooltip" : "Substitution values for placeholders used in the filter or projection expression. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-dynamodb/\" target=\"_blank\">Amazon DynamoDB connector documentation</a>",
     "type" : "String"
   }, {
     "id" : "input.addItem.tableName",
@@ -722,7 +718,6 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "Name of DynamoDB table",
     "type" : "String"
   }, {
     "id" : "input.item",
@@ -774,7 +769,6 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "Name of DynamoDB table",
     "type" : "String"
   }, {
     "id" : "input.deleteItem.primaryKeyComponents",
@@ -826,7 +820,6 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "Name of DynamoDB table",
     "type" : "String"
   }, {
     "id" : "input.getItem.primaryKeyComponents",
@@ -878,7 +871,6 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "Name of DynamoDB table",
     "type" : "String"
   }, {
     "id" : "input.updateItem.primaryKeyComponents",
@@ -930,7 +922,7 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "DynamoDB key attributes. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-dynamodb/\" target=\"_blank\">Amazon DynamoDB connector documentation</a>",
+    "tooltip" : "Attribute values to write to the item. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-dynamodb/\" target=\"_blank\">Amazon DynamoDB connector documentation</a>",
     "type" : "String"
   }, {
     "id" : "input.attributeAction",
@@ -955,7 +947,7 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "Specifies how to perform the update",
+    "tooltip" : "PUT = set the attribute value, DELETE = remove the attribute",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "PUT",

--- a/connectors/aws/aws-dynamodb/src/main/java/io/camunda/connector/aws/dynamodb/model/AddItem.java
+++ b/connectors/aws/aws-dynamodb/src/main/java/io/camunda/connector/aws/dynamodb/model/AddItem.java
@@ -21,14 +21,14 @@ public record AddItem(
             label = "Table name",
             id = "addItem.tableName",
             group = "input",
-            description = "Name of DynamoDB table")
+            tooltip = "Name of DynamoDB table")
         @NotBlank
         String tableName,
     @TemplateProperty(
             label = "Item",
             group = "input",
             feel = FeelMode.required,
-            description = "DynamoDB item (group of attributes)")
+            tooltip = "DynamoDB item (group of attributes)")
         @NotNull
         Object item)
     implements ItemInput {}

--- a/connectors/aws/aws-dynamodb/src/main/java/io/camunda/connector/aws/dynamodb/model/AddItem.java
+++ b/connectors/aws/aws-dynamodb/src/main/java/io/camunda/connector/aws/dynamodb/model/AddItem.java
@@ -17,12 +17,7 @@ import jakarta.validation.constraints.NotNull;
     description = "Add a single item to a DynamoDB table",
     keywords = {"add item", "put item", "insert item"})
 public record AddItem(
-    @TemplateProperty(
-            label = "Table name",
-            id = "addItem.tableName",
-            group = "input",
-            tooltip = "Name of DynamoDB table")
-        @NotBlank
+    @TemplateProperty(label = "Table name", id = "addItem.tableName", group = "input") @NotBlank
         String tableName,
     @TemplateProperty(
             label = "Item",

--- a/connectors/aws/aws-dynamodb/src/main/java/io/camunda/connector/aws/dynamodb/model/CreateTable.java
+++ b/connectors/aws/aws-dynamodb/src/main/java/io/camunda/connector/aws/dynamodb/model/CreateTable.java
@@ -22,13 +22,13 @@ public record CreateTable(
             label = "Table name",
             id = "createTable.tableName",
             group = "input",
-            description = "Name of DynamoDB table")
+            tooltip = "Name of DynamoDB table")
         @NotBlank
         String tableName,
     @TemplateProperty(
             group = "input",
-            description =
-                "Partition key role. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-dynamodb/\" target=\"_blank\">documentation</a>")
+            tooltip =
+                "Attribute name of the table's partition key. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-dynamodb/\" target=\"_blank\">Amazon DynamoDB connector documentation</a>")
         @NotBlank
         String partitionKey,
     @TemplateProperty(
@@ -38,8 +38,8 @@ public record CreateTable(
               @TemplateProperty.DropdownPropertyChoice(value = "HASH", label = "HASH"),
               @TemplateProperty.DropdownPropertyChoice(value = "RANGE", label = "RANGE")
             },
-            description =
-                "The role that this key attribute will assume. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-dynamodb/\" target=\"_blank\">documentation</a>")
+            tooltip =
+                "The role that this key attribute will assume. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-dynamodb/\" target=\"_blank\">Amazon DynamoDB connector documentation</a>")
         @NotBlank
         String partitionKeyRole,
     @TemplateProperty(
@@ -51,15 +51,15 @@ public record CreateTable(
               @TemplateProperty.DropdownPropertyChoice(value = "N", label = "Number"),
               @TemplateProperty.DropdownPropertyChoice(value = "S", label = "String")
             },
-            description = "Represents the data for an attribute")
+            tooltip = "Represents the data for an attribute")
         @NotBlank
         String partitionKeyType,
     @TemplateProperty(
             label = "Sort key",
             group = "input",
             optional = true,
-            description =
-                "Sort key. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-dynamodb/\" target=\"_blank\">documentation</a>")
+            tooltip =
+                "Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-dynamodb/\" target=\"_blank\">Amazon DynamoDB connector documentation</a>")
         String sortKey,
     @TemplateProperty(
             label = "Sort key role",
@@ -70,7 +70,7 @@ public record CreateTable(
               @TemplateProperty.DropdownPropertyChoice(value = "HASH", label = "HASH"),
               @TemplateProperty.DropdownPropertyChoice(value = "RANGE", label = "RANGE")
             },
-            description = "The role that this key attribute will assume")
+            tooltip = "The role that this key attribute will assume")
         String sortKeyRole,
     @TemplateProperty(
             label = "Sort key attribute data type",
@@ -82,20 +82,20 @@ public record CreateTable(
               @TemplateProperty.DropdownPropertyChoice(value = "N", label = "Number"),
               @TemplateProperty.DropdownPropertyChoice(value = "S", label = "String")
             },
-            description = "Represents the data for an attribute")
+            tooltip = "Represents the data for an attribute")
         String sortKeyType,
     @TemplateProperty(
             label = "Read capacity units",
             group = "input",
-            description =
-                "Total number of read capacity units. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-dynamodb/\" target=\"_blank\">documentation</a>")
+            tooltip =
+                "Total number of read capacity units. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-dynamodb/\" target=\"_blank\">Amazon DynamoDB connector documentation</a>")
         @NotNull
         Long readCapacityUnits,
     @TemplateProperty(
             label = "Write capacity units",
             group = "input",
-            description =
-                "Total number of write capacity units. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-dynamodb/\" target=\"_blank\">documentation</a>")
+            tooltip =
+                "Total number of write capacity units. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-dynamodb/\" target=\"_blank\">Amazon DynamoDB connector documentation</a>")
         @NotNull
         Long writeCapacityUnits,
     @TemplateProperty(
@@ -110,8 +110,8 @@ public record CreateTable(
                   value = "PAY_PER_REQUEST",
                   label = "PAY_PER_REQUEST")
             },
-            description =
-                "Controls how you are charged for read and write throughput. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-dynamodb/\" target=\"_blank\">documentation</a>")
+            tooltip =
+                "Controls how you are charged for read and write throughput. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-dynamodb/\" target=\"_blank\">Amazon DynamoDB connector documentation</a>")
         @NotBlank
         String billingModeStr,
     @TemplateProperty(
@@ -123,7 +123,7 @@ public record CreateTable(
               @TemplateProperty.DropdownPropertyChoice(value = "false", label = "False")
             },
             defaultValue = "false",
-            description = "Prevents accidental table deletion")
+            tooltip = "Prevents accidental table deletion")
         @NotNull
         boolean deletionProtection)
     implements TableInput {}

--- a/connectors/aws/aws-dynamodb/src/main/java/io/camunda/connector/aws/dynamodb/model/CreateTable.java
+++ b/connectors/aws/aws-dynamodb/src/main/java/io/camunda/connector/aws/dynamodb/model/CreateTable.java
@@ -18,12 +18,7 @@ import jakarta.validation.constraints.NotNull;
     description = "Create a new DynamoDB table",
     keywords = {"create table", "new table", "provision table"})
 public record CreateTable(
-    @TemplateProperty(
-            label = "Table name",
-            id = "createTable.tableName",
-            group = "input",
-            tooltip = "Name of DynamoDB table")
-        @NotBlank
+    @TemplateProperty(label = "Table name", id = "createTable.tableName", group = "input") @NotBlank
         String tableName,
     @TemplateProperty(
             group = "input",
@@ -51,7 +46,7 @@ public record CreateTable(
               @TemplateProperty.DropdownPropertyChoice(value = "N", label = "Number"),
               @TemplateProperty.DropdownPropertyChoice(value = "S", label = "String")
             },
-            tooltip = "Represents the data for an attribute")
+            tooltip = "S = String, N = Number, B = Binary")
         @NotBlank
         String partitionKeyType,
     @TemplateProperty(
@@ -59,7 +54,7 @@ public record CreateTable(
             group = "input",
             optional = true,
             tooltip =
-                "Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-dynamodb/\" target=\"_blank\">Amazon DynamoDB connector documentation</a>")
+                "Attribute name of the table's sort key. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-dynamodb/\" target=\"_blank\">Amazon DynamoDB connector documentation</a>")
         String sortKey,
     @TemplateProperty(
             label = "Sort key role",
@@ -70,7 +65,8 @@ public record CreateTable(
               @TemplateProperty.DropdownPropertyChoice(value = "HASH", label = "HASH"),
               @TemplateProperty.DropdownPropertyChoice(value = "RANGE", label = "RANGE")
             },
-            tooltip = "The role that this key attribute will assume")
+            tooltip =
+                "The role that this key attribute will assume. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-dynamodb/\" target=\"_blank\">Amazon DynamoDB connector documentation</a>")
         String sortKeyRole,
     @TemplateProperty(
             label = "Sort key attribute data type",
@@ -82,7 +78,7 @@ public record CreateTable(
               @TemplateProperty.DropdownPropertyChoice(value = "N", label = "Number"),
               @TemplateProperty.DropdownPropertyChoice(value = "S", label = "String")
             },
-            tooltip = "Represents the data for an attribute")
+            tooltip = "S = String, N = Number, B = Binary")
         String sortKeyType,
     @TemplateProperty(
             label = "Read capacity units",

--- a/connectors/aws/aws-dynamodb/src/main/java/io/camunda/connector/aws/dynamodb/model/DeleteItem.java
+++ b/connectors/aws/aws-dynamodb/src/main/java/io/camunda/connector/aws/dynamodb/model/DeleteItem.java
@@ -21,7 +21,7 @@ public record DeleteItem(
             label = "Table name",
             id = "deleteItem.tableName",
             group = "input",
-            description = "Name of DynamoDB table")
+            tooltip = "Name of DynamoDB table")
         @NotBlank
         String tableName,
     @TemplateProperty(
@@ -29,7 +29,7 @@ public record DeleteItem(
             id = "deleteItem.primaryKeyComponents",
             group = "input",
             feel = FeelMode.required,
-            description = "Simple or composite primary key")
+            tooltip = "Simple or composite primary key")
         @NotNull
         Object primaryKeyComponents)
     implements ItemInput {}

--- a/connectors/aws/aws-dynamodb/src/main/java/io/camunda/connector/aws/dynamodb/model/DeleteItem.java
+++ b/connectors/aws/aws-dynamodb/src/main/java/io/camunda/connector/aws/dynamodb/model/DeleteItem.java
@@ -17,12 +17,7 @@ import jakarta.validation.constraints.NotNull;
     description = "Delete a single item from a DynamoDB table by primary key",
     keywords = {"delete item", "remove item", "drop item"})
 public record DeleteItem(
-    @TemplateProperty(
-            label = "Table name",
-            id = "deleteItem.tableName",
-            group = "input",
-            tooltip = "Name of DynamoDB table")
-        @NotBlank
+    @TemplateProperty(label = "Table name", id = "deleteItem.tableName", group = "input") @NotBlank
         String tableName,
     @TemplateProperty(
             label = "Primary key components",

--- a/connectors/aws/aws-dynamodb/src/main/java/io/camunda/connector/aws/dynamodb/model/DeleteTable.java
+++ b/connectors/aws/aws-dynamodb/src/main/java/io/camunda/connector/aws/dynamodb/model/DeleteTable.java
@@ -15,11 +15,6 @@ import jakarta.validation.constraints.NotBlank;
     description = "Delete a DynamoDB table",
     keywords = {"delete table", "drop table", "remove table"})
 public record DeleteTable(
-    @TemplateProperty(
-            label = "Table name",
-            id = "deleteTable.tableName",
-            group = "input",
-            tooltip = "Name of DynamoDB table")
-        @NotBlank
+    @TemplateProperty(label = "Table name", id = "deleteTable.tableName", group = "input") @NotBlank
         String tableName)
     implements TableInput {}

--- a/connectors/aws/aws-dynamodb/src/main/java/io/camunda/connector/aws/dynamodb/model/DeleteTable.java
+++ b/connectors/aws/aws-dynamodb/src/main/java/io/camunda/connector/aws/dynamodb/model/DeleteTable.java
@@ -19,7 +19,7 @@ public record DeleteTable(
             label = "Table name",
             id = "deleteTable.tableName",
             group = "input",
-            description = "Name of DynamoDB table")
+            tooltip = "Name of DynamoDB table")
         @NotBlank
         String tableName)
     implements TableInput {}

--- a/connectors/aws/aws-dynamodb/src/main/java/io/camunda/connector/aws/dynamodb/model/DescribeTable.java
+++ b/connectors/aws/aws-dynamodb/src/main/java/io/camunda/connector/aws/dynamodb/model/DescribeTable.java
@@ -19,7 +19,7 @@ public record DescribeTable(
             label = "Table name",
             id = "describeTable.tableName",
             group = "input",
-            description = "Name of DynamoDB table")
+            tooltip = "Name of DynamoDB table")
         @NotBlank
         String tableName)
     implements TableInput {}

--- a/connectors/aws/aws-dynamodb/src/main/java/io/camunda/connector/aws/dynamodb/model/DescribeTable.java
+++ b/connectors/aws/aws-dynamodb/src/main/java/io/camunda/connector/aws/dynamodb/model/DescribeTable.java
@@ -15,11 +15,7 @@ import jakarta.validation.constraints.NotBlank;
     description = "Return the metadata of a DynamoDB table",
     keywords = {"describe table", "table schema", "table metadata"})
 public record DescribeTable(
-    @TemplateProperty(
-            label = "Table name",
-            id = "describeTable.tableName",
-            group = "input",
-            tooltip = "Name of DynamoDB table")
+    @TemplateProperty(label = "Table name", id = "describeTable.tableName", group = "input")
         @NotBlank
         String tableName)
     implements TableInput {}

--- a/connectors/aws/aws-dynamodb/src/main/java/io/camunda/connector/aws/dynamodb/model/GetItem.java
+++ b/connectors/aws/aws-dynamodb/src/main/java/io/camunda/connector/aws/dynamodb/model/GetItem.java
@@ -21,7 +21,7 @@ public record GetItem(
             label = "Table name",
             id = "getItem.tableName",
             group = "input",
-            description = "Name of DynamoDB table")
+            tooltip = "Name of DynamoDB table")
         @NotBlank
         String tableName,
     @TemplateProperty(
@@ -29,7 +29,7 @@ public record GetItem(
             id = "getItem.primaryKeyComponents",
             group = "input",
             feel = FeelMode.required,
-            description = "Simple or composite primary key")
+            tooltip = "Simple or composite primary key")
         @NotNull
         Object primaryKeyComponents)
     implements ItemInput {}

--- a/connectors/aws/aws-dynamodb/src/main/java/io/camunda/connector/aws/dynamodb/model/GetItem.java
+++ b/connectors/aws/aws-dynamodb/src/main/java/io/camunda/connector/aws/dynamodb/model/GetItem.java
@@ -17,12 +17,7 @@ import jakarta.validation.constraints.NotNull;
     description = "Fetch a single item from a DynamoDB table by primary key",
     keywords = {"get item", "fetch item", "lookup item"})
 public record GetItem(
-    @TemplateProperty(
-            label = "Table name",
-            id = "getItem.tableName",
-            group = "input",
-            tooltip = "Name of DynamoDB table")
-        @NotBlank
+    @TemplateProperty(label = "Table name", id = "getItem.tableName", group = "input") @NotBlank
         String tableName,
     @TemplateProperty(
             label = "Primary key components",

--- a/connectors/aws/aws-dynamodb/src/main/java/io/camunda/connector/aws/dynamodb/model/ScanTable.java
+++ b/connectors/aws/aws-dynamodb/src/main/java/io/camunda/connector/aws/dynamodb/model/ScanTable.java
@@ -21,37 +21,37 @@ public record ScanTable(
             label = "Table name",
             id = "scanTable.tableName",
             group = "input",
-            description = "Name of DynamoDB table")
+            tooltip = "Name of DynamoDB table")
         @NotBlank
         String tableName,
     @TemplateProperty(
             label = "Filter expression",
             group = "input",
             optional = true,
-            description =
-                "Filter expressions for scan. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-dynamodb/\" target=\"_blank\">documentation</a>")
+            tooltip =
+                "Filter expressions for scan. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-dynamodb/\" target=\"_blank\">Amazon DynamoDB connector documentation</a>")
         String filterExpression,
     @TemplateProperty(
             label = "Projection expression",
             group = "input",
             optional = true,
-            description =
-                "Is a string that identifies the attributes that you want. For multiple attributes, the names must be comma-separated")
+            tooltip =
+                "A string that identifies the attributes that you want. For multiple attributes, the names must be comma-separated.")
         String projectionExpression,
     @TemplateProperty(
             label = "Expression attribute names",
             group = "input",
             feel = FeelMode.required,
             optional = true,
-            description =
-                "Is a placeholder that you use as an alternative to an actual attribute name. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-dynamodb/\" target=\"_blank\">documentation</a>")
+            tooltip =
+                "A placeholder that you use as an alternative to an actual attribute name. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-dynamodb/\" target=\"_blank\">Amazon DynamoDB connector documentation</a>")
         Map<String, String> expressionAttributeNames,
     @TemplateProperty(
             label = "Expression attribute values",
             group = "input",
             feel = FeelMode.required,
             optional = true,
-            description =
-                "Expression attribute values. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-dynamodb/\" target=\"_blank\">documentation</a>")
+            tooltip =
+                "Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-dynamodb/\" target=\"_blank\">Amazon DynamoDB connector documentation</a>")
         Map<String, Object> expressionAttributeValues)
     implements TableInput {}

--- a/connectors/aws/aws-dynamodb/src/main/java/io/camunda/connector/aws/dynamodb/model/ScanTable.java
+++ b/connectors/aws/aws-dynamodb/src/main/java/io/camunda/connector/aws/dynamodb/model/ScanTable.java
@@ -17,12 +17,7 @@ import java.util.Map;
     description = "Read every item in a DynamoDB table",
     keywords = {"scan table", "list items", "read all items"})
 public record ScanTable(
-    @TemplateProperty(
-            label = "Table name",
-            id = "scanTable.tableName",
-            group = "input",
-            tooltip = "Name of DynamoDB table")
-        @NotBlank
+    @TemplateProperty(label = "Table name", id = "scanTable.tableName", group = "input") @NotBlank
         String tableName,
     @TemplateProperty(
             label = "Filter expression",
@@ -35,6 +30,7 @@ public record ScanTable(
             label = "Projection expression",
             group = "input",
             optional = true,
+            placeholder = "Artist, SongTitle, Genre",
             tooltip =
                 "A string that identifies the attributes that you want. For multiple attributes, the names must be comma-separated.")
         String projectionExpression,
@@ -52,6 +48,6 @@ public record ScanTable(
             feel = FeelMode.required,
             optional = true,
             tooltip =
-                "Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-dynamodb/\" target=\"_blank\">Amazon DynamoDB connector documentation</a>")
+                "Substitution values for placeholders used in the filter or projection expression. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-dynamodb/\" target=\"_blank\">Amazon DynamoDB connector documentation</a>")
         Map<String, Object> expressionAttributeValues)
     implements TableInput {}

--- a/connectors/aws/aws-dynamodb/src/main/java/io/camunda/connector/aws/dynamodb/model/UpdateItem.java
+++ b/connectors/aws/aws-dynamodb/src/main/java/io/camunda/connector/aws/dynamodb/model/UpdateItem.java
@@ -22,7 +22,7 @@ public record UpdateItem(
             label = "Table name",
             id = "updateTable.tableName",
             group = "input",
-            description = "Name of DynamoDB table")
+            tooltip = "Name of DynamoDB table")
         @NotBlank
         String tableName,
     @TemplateProperty(
@@ -30,15 +30,15 @@ public record UpdateItem(
             id = "updateItem.primaryKeyComponents",
             group = "input",
             feel = FeelMode.required,
-            description = "Simple or composite primary key")
+            tooltip = "Simple or composite primary key")
         @NotNull
         Map<String, Object> primaryKeyComponents,
     @TemplateProperty(
             label = "Key attributes",
             group = "input",
             feel = FeelMode.required,
-            description =
-                "DynamoDB key attributes. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-dynamodb/\" target=\"_blank\">documentation</a>")
+            tooltip =
+                "DynamoDB key attributes. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-dynamodb/\" target=\"_blank\">Amazon DynamoDB connector documentation</a>")
         @NotNull
         Map<String, Object> keyAttributes,
     @TemplateProperty(
@@ -49,7 +49,7 @@ public record UpdateItem(
               @TemplateProperty.DropdownPropertyChoice(value = "put", label = "PUT"),
               @TemplateProperty.DropdownPropertyChoice(value = "delete", label = "DELETE")
             },
-            description = "Specifies how to perform the update")
+            tooltip = "Specifies how to perform the update")
         @NotBlank
         String attributeAction)
     implements ItemInput {}

--- a/connectors/aws/aws-dynamodb/src/main/java/io/camunda/connector/aws/dynamodb/model/UpdateItem.java
+++ b/connectors/aws/aws-dynamodb/src/main/java/io/camunda/connector/aws/dynamodb/model/UpdateItem.java
@@ -18,12 +18,7 @@ import java.util.Map;
     description = "Update a single item in a DynamoDB table",
     keywords = {"update item", "modify item", "patch item"})
 public record UpdateItem(
-    @TemplateProperty(
-            label = "Table name",
-            id = "updateTable.tableName",
-            group = "input",
-            tooltip = "Name of DynamoDB table")
-        @NotBlank
+    @TemplateProperty(label = "Table name", id = "updateTable.tableName", group = "input") @NotBlank
         String tableName,
     @TemplateProperty(
             label = "Primary key components",
@@ -38,7 +33,7 @@ public record UpdateItem(
             group = "input",
             feel = FeelMode.required,
             tooltip =
-                "DynamoDB key attributes. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-dynamodb/\" target=\"_blank\">Amazon DynamoDB connector documentation</a>")
+                "Attribute values to write to the item. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-dynamodb/\" target=\"_blank\">Amazon DynamoDB connector documentation</a>")
         @NotNull
         Map<String, Object> keyAttributes,
     @TemplateProperty(
@@ -49,7 +44,7 @@ public record UpdateItem(
               @TemplateProperty.DropdownPropertyChoice(value = "put", label = "PUT"),
               @TemplateProperty.DropdownPropertyChoice(value = "delete", label = "DELETE")
             },
-            tooltip = "Specifies how to perform the update")
+            tooltip = "PUT = set the attribute value, DELETE = remove the attribute")
         @NotBlank
         String attributeAction)
     implements ItemInput {}

--- a/connectors/aws/aws-eventbridge/element-templates/aws-eventbridge-outbound-connector.json
+++ b/connectors/aws/aws-eventbridge/element-templates/aws-eventbridge-outbound-connector.json
@@ -136,7 +136,6 @@
   }, {
     "id" : "input.source",
     "label" : "Source",
-    "description" : "Enter the event source value. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-eventbridge/?awseventbridge=outbound\" target=\"_blank\">documentation</a>",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -147,11 +146,11 @@
       "name" : "input.source",
       "type" : "zeebe:input"
     },
+    "tooltip" : "Value that identifies the service that generated the event. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-eventbridge/?awseventbridge=outbound\" target=\"_blank\">Amazon EventBridge documentation</a>.",
     "type" : "String"
   }, {
     "id" : "input.detailType",
     "label" : "Detail type",
-    "description" : "Enter the event detail type. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-eventbridge/?awseventbridge=outbound\" target=\"_blank\">documentation</a>",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -162,11 +161,11 @@
       "name" : "input.detailType",
       "type" : "zeebe:input"
     },
+    "tooltip" : "Type of event being sent. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-eventbridge/?awseventbridge=outbound\" target=\"_blank\">Amazon EventBridge documentation</a>.",
     "type" : "String"
   }, {
     "id" : "input.eventBusName",
     "label" : "Event bus name",
-    "description" : "Enter the event bus name. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-eventbridge/?awseventbridge=outbound\" target=\"_blank\">documentation</a>",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -177,11 +176,11 @@
       "name" : "input.eventBusName",
       "type" : "zeebe:input"
     },
+    "tooltip" : "Name of the destination event bus. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-eventbridge/?awseventbridge=outbound\" target=\"_blank\">Amazon EventBridge documentation</a>.",
     "type" : "Text"
   }, {
     "id" : "input.detail",
     "label" : "Event payload",
-    "description" : "Provide the payload for the event as JSON. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-eventbridge/?awseventbridge=outbound\" target=\"_blank\">documentation</a>",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -192,6 +191,7 @@
       "name" : "input.detail",
       "type" : "zeebe:input"
     },
+    "tooltip" : "Payload must be provided as JSON. <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-eventbridge/?awseventbridge=outbound\" target=\"_blank\">Amazon EventBridge event payload</a>",
     "type" : "String"
   }, {
     "id" : "version",

--- a/connectors/aws/aws-eventbridge/element-templates/aws-eventbridge-outbound-connector.json
+++ b/connectors/aws/aws-eventbridge/element-templates/aws-eventbridge-outbound-connector.json
@@ -70,7 +70,6 @@
   }, {
     "id" : "authentication.accessKey",
     "label" : "Access key",
-    "description" : "Provide an IAM access key tailored to a user, equipped with the necessary permissions",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -86,11 +85,11 @@
       "equals" : "credentials",
       "type" : "simple"
     },
+    "tooltip" : "IAM access key of a user with the necessary permissions for this connector",
     "type" : "String"
   }, {
     "id" : "authentication.secretKey",
     "label" : "Secret key",
-    "description" : "Provide a secret key of a user with permissions to invoke specified AWS Lambda function",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -106,11 +105,11 @@
       "equals" : "credentials",
       "type" : "simple"
     },
+    "tooltip" : "IAM secret key of a user with the necessary permissions for this connector",
     "type" : "String"
   }, {
     "id" : "configuration.region",
     "label" : "Region",
-    "description" : "Specify the AWS region",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -191,7 +190,8 @@
       "name" : "input.detail",
       "type" : "zeebe:input"
     },
-    "tooltip" : "Payload must be provided as JSON. <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-eventbridge/?awseventbridge=outbound\" target=\"_blank\">Amazon EventBridge event payload</a>",
+    "tooltip" : "Payload must be provided as JSON. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-eventbridge/?awseventbridge=outbound\" target=\"_blank\">Amazon EventBridge event payload</a> documentation.",
+    "placeholder" : "{\"key\": \"value\"}",
     "type" : "String"
   }, {
     "id" : "version",

--- a/connectors/aws/aws-eventbridge/element-templates/hybrid/aws-eventbridge-outbound-connector-hybrid.json
+++ b/connectors/aws/aws-eventbridge/element-templates/hybrid/aws-eventbridge-outbound-connector-hybrid.json
@@ -141,7 +141,6 @@
   }, {
     "id" : "input.source",
     "label" : "Source",
-    "description" : "Enter the event source value. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-eventbridge/?awseventbridge=outbound\" target=\"_blank\">documentation</a>",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -152,11 +151,11 @@
       "name" : "input.source",
       "type" : "zeebe:input"
     },
+    "tooltip" : "Value that identifies the service that generated the event. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-eventbridge/?awseventbridge=outbound\" target=\"_blank\">Amazon EventBridge documentation</a>.",
     "type" : "String"
   }, {
     "id" : "input.detailType",
     "label" : "Detail type",
-    "description" : "Enter the event detail type. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-eventbridge/?awseventbridge=outbound\" target=\"_blank\">documentation</a>",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -167,11 +166,11 @@
       "name" : "input.detailType",
       "type" : "zeebe:input"
     },
+    "tooltip" : "Type of event being sent. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-eventbridge/?awseventbridge=outbound\" target=\"_blank\">Amazon EventBridge documentation</a>.",
     "type" : "String"
   }, {
     "id" : "input.eventBusName",
     "label" : "Event bus name",
-    "description" : "Enter the event bus name. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-eventbridge/?awseventbridge=outbound\" target=\"_blank\">documentation</a>",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -182,11 +181,11 @@
       "name" : "input.eventBusName",
       "type" : "zeebe:input"
     },
+    "tooltip" : "Name of the destination event bus. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-eventbridge/?awseventbridge=outbound\" target=\"_blank\">Amazon EventBridge documentation</a>.",
     "type" : "Text"
   }, {
     "id" : "input.detail",
     "label" : "Event payload",
-    "description" : "Provide the payload for the event as JSON. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-eventbridge/?awseventbridge=outbound\" target=\"_blank\">documentation</a>",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -197,6 +196,7 @@
       "name" : "input.detail",
       "type" : "zeebe:input"
     },
+    "tooltip" : "Payload must be provided as JSON. <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-eventbridge/?awseventbridge=outbound\" target=\"_blank\">Amazon EventBridge event payload</a>",
     "type" : "String"
   }, {
     "id" : "version",

--- a/connectors/aws/aws-eventbridge/element-templates/hybrid/aws-eventbridge-outbound-connector-hybrid.json
+++ b/connectors/aws/aws-eventbridge/element-templates/hybrid/aws-eventbridge-outbound-connector-hybrid.json
@@ -75,7 +75,6 @@
   }, {
     "id" : "authentication.accessKey",
     "label" : "Access key",
-    "description" : "Provide an IAM access key tailored to a user, equipped with the necessary permissions",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -91,11 +90,11 @@
       "equals" : "credentials",
       "type" : "simple"
     },
+    "tooltip" : "IAM access key of a user with the necessary permissions for this connector",
     "type" : "String"
   }, {
     "id" : "authentication.secretKey",
     "label" : "Secret key",
-    "description" : "Provide a secret key of a user with permissions to invoke specified AWS Lambda function",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -111,11 +110,11 @@
       "equals" : "credentials",
       "type" : "simple"
     },
+    "tooltip" : "IAM secret key of a user with the necessary permissions for this connector",
     "type" : "String"
   }, {
     "id" : "configuration.region",
     "label" : "Region",
-    "description" : "Specify the AWS region",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -196,7 +195,8 @@
       "name" : "input.detail",
       "type" : "zeebe:input"
     },
-    "tooltip" : "Payload must be provided as JSON. <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-eventbridge/?awseventbridge=outbound\" target=\"_blank\">Amazon EventBridge event payload</a>",
+    "tooltip" : "Payload must be provided as JSON. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-eventbridge/?awseventbridge=outbound\" target=\"_blank\">Amazon EventBridge event payload</a> documentation.",
+    "placeholder" : "{\"key\": \"value\"}",
     "type" : "String"
   }, {
     "id" : "version",

--- a/connectors/aws/aws-eventbridge/src/main/java/io/camunda/connector/aws/eventbridge/AwsEventBridgeInput.java
+++ b/connectors/aws/aws-eventbridge/src/main/java/io/camunda/connector/aws/eventbridge/AwsEventBridgeInput.java
@@ -16,16 +16,16 @@ public class AwsEventBridgeInput {
   @TemplateProperty(
       group = "eventDetails",
       label = "Source",
-      description =
-          "Enter the event source value. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-eventbridge/?awseventbridge=outbound\" target=\"_blank\">documentation</a>")
+      tooltip =
+          "Value that identifies the service that generated the event. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-eventbridge/?awseventbridge=outbound\" target=\"_blank\">Amazon EventBridge documentation</a>.")
   @NotBlank
   private String source;
 
   @TemplateProperty(
       group = "eventDetails",
       label = "Detail type",
-      description =
-          "Enter the event detail type. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-eventbridge/?awseventbridge=outbound\" target=\"_blank\">documentation</a>")
+      tooltip =
+          "Type of event being sent. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-eventbridge/?awseventbridge=outbound\" target=\"_blank\">Amazon EventBridge documentation</a>.")
   @NotBlank
   private String detailType;
 
@@ -34,16 +34,16 @@ public class AwsEventBridgeInput {
       label = "Event bus name",
       type = TemplateProperty.PropertyType.Text,
       feel = FeelMode.required,
-      description =
-          "Enter the event bus name. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-eventbridge/?awseventbridge=outbound\" target=\"_blank\">documentation</a>")
+      tooltip =
+          "Name of the destination event bus. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-eventbridge/?awseventbridge=outbound\" target=\"_blank\">Amazon EventBridge documentation</a>.")
   @NotBlank
   private String eventBusName;
 
   @TemplateProperty(
       group = "eventPayload",
       label = "Event payload",
-      description =
-          "Provide the payload for the event as JSON. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-eventbridge/?awseventbridge=outbound\" target=\"_blank\">documentation</a>")
+      tooltip =
+          "Payload must be provided as JSON. <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-eventbridge/?awseventbridge=outbound\" target=\"_blank\">Amazon EventBridge event payload</a>")
   @NotNull
   private Object detail;
 

--- a/connectors/aws/aws-eventbridge/src/main/java/io/camunda/connector/aws/eventbridge/AwsEventBridgeInput.java
+++ b/connectors/aws/aws-eventbridge/src/main/java/io/camunda/connector/aws/eventbridge/AwsEventBridgeInput.java
@@ -42,8 +42,9 @@ public class AwsEventBridgeInput {
   @TemplateProperty(
       group = "eventPayload",
       label = "Event payload",
+      placeholder = "{\"key\": \"value\"}",
       tooltip =
-          "Payload must be provided as JSON. <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-eventbridge/?awseventbridge=outbound\" target=\"_blank\">Amazon EventBridge event payload</a>")
+          "Payload must be provided as JSON. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-eventbridge/?awseventbridge=outbound\" target=\"_blank\">Amazon EventBridge event payload</a> documentation.")
   @NotNull
   private Object detail;
 

--- a/connectors/aws/aws-lambda/element-templates/aws-lambda-outbound-connector.json
+++ b/connectors/aws/aws-lambda/element-templates/aws-lambda-outbound-connector.json
@@ -70,7 +70,6 @@
   }, {
     "id" : "authentication.accessKey",
     "label" : "Access key",
-    "description" : "Provide an IAM access key tailored to a user, equipped with the necessary permissions",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -86,11 +85,11 @@
       "equals" : "credentials",
       "type" : "simple"
     },
+    "tooltip" : "IAM access key of a user with the necessary permissions for this connector",
     "type" : "String"
   }, {
     "id" : "authentication.secretKey",
     "label" : "Secret key",
-    "description" : "Provide a secret key of a user with permissions to invoke specified AWS Lambda function",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -106,11 +105,11 @@
       "equals" : "credentials",
       "type" : "simple"
     },
+    "tooltip" : "IAM secret key of a user with the necessary permissions for this connector",
     "type" : "String"
   }, {
     "id" : "configuration.region",
     "label" : "Region",
-    "description" : "Specify the AWS region",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -176,7 +175,8 @@
       "name" : "awsFunction.payload",
       "type" : "zeebe:input"
     },
-    "tooltip" : "Payload for your function as JSON",
+    "tooltip" : "JSON input passed to the Lambda function when it is invoked.",
+    "placeholder" : "{\"key\": \"value\"}",
     "type" : "Text"
   }, {
     "id" : "version",

--- a/connectors/aws/aws-lambda/element-templates/aws-lambda-outbound-connector.json
+++ b/connectors/aws/aws-lambda/element-templates/aws-lambda-outbound-connector.json
@@ -151,7 +151,6 @@
   }, {
     "id" : "awsFunction.functionName",
     "label" : "Function name",
-    "description" : "Enter a name, ARN or alias of your function",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -162,11 +161,11 @@
       "name" : "awsFunction.functionName",
       "type" : "zeebe:input"
     },
+    "tooltip" : "Name, ARN or alias of your function",
     "type" : "String"
   }, {
     "id" : "awsFunction.payload",
     "label" : "Payload",
-    "description" : "Provide payload for your function as JSON",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -177,6 +176,7 @@
       "name" : "awsFunction.payload",
       "type" : "zeebe:input"
     },
+    "tooltip" : "Payload for your function as JSON",
     "type" : "Text"
   }, {
     "id" : "version",

--- a/connectors/aws/aws-lambda/element-templates/hybrid/aws-lambda-outbound-connector-hybrid.json
+++ b/connectors/aws/aws-lambda/element-templates/hybrid/aws-lambda-outbound-connector-hybrid.json
@@ -75,7 +75,6 @@
   }, {
     "id" : "authentication.accessKey",
     "label" : "Access key",
-    "description" : "Provide an IAM access key tailored to a user, equipped with the necessary permissions",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -91,11 +90,11 @@
       "equals" : "credentials",
       "type" : "simple"
     },
+    "tooltip" : "IAM access key of a user with the necessary permissions for this connector",
     "type" : "String"
   }, {
     "id" : "authentication.secretKey",
     "label" : "Secret key",
-    "description" : "Provide a secret key of a user with permissions to invoke specified AWS Lambda function",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -111,11 +110,11 @@
       "equals" : "credentials",
       "type" : "simple"
     },
+    "tooltip" : "IAM secret key of a user with the necessary permissions for this connector",
     "type" : "String"
   }, {
     "id" : "configuration.region",
     "label" : "Region",
-    "description" : "Specify the AWS region",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -181,7 +180,8 @@
       "name" : "awsFunction.payload",
       "type" : "zeebe:input"
     },
-    "tooltip" : "Payload for your function as JSON",
+    "tooltip" : "JSON input passed to the Lambda function when it is invoked.",
+    "placeholder" : "{\"key\": \"value\"}",
     "type" : "Text"
   }, {
     "id" : "version",

--- a/connectors/aws/aws-lambda/element-templates/hybrid/aws-lambda-outbound-connector-hybrid.json
+++ b/connectors/aws/aws-lambda/element-templates/hybrid/aws-lambda-outbound-connector-hybrid.json
@@ -156,7 +156,6 @@
   }, {
     "id" : "awsFunction.functionName",
     "label" : "Function name",
-    "description" : "Enter a name, ARN or alias of your function",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -167,11 +166,11 @@
       "name" : "awsFunction.functionName",
       "type" : "zeebe:input"
     },
+    "tooltip" : "Name, ARN or alias of your function",
     "type" : "String"
   }, {
     "id" : "awsFunction.payload",
     "label" : "Payload",
-    "description" : "Provide payload for your function as JSON",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -182,6 +181,7 @@
       "name" : "awsFunction.payload",
       "type" : "zeebe:input"
     },
+    "tooltip" : "Payload for your function as JSON",
     "type" : "Text"
   }, {
     "id" : "version",

--- a/connectors/aws/aws-lambda/src/main/java/io/camunda/connector/awslambda/model/FunctionRequestData.java
+++ b/connectors/aws/aws-lambda/src/main/java/io/camunda/connector/awslambda/model/FunctionRequestData.java
@@ -27,7 +27,7 @@ public class FunctionRequestData {
   @TemplateProperty(
       group = "operationDetails",
       label = "Function name",
-      description = "Enter a name, ARN or alias of your function")
+      tooltip = "Name, ARN or alias of your function")
   private String functionName;
 
   @NotNull
@@ -36,7 +36,7 @@ public class FunctionRequestData {
       group = "operationDetails",
       label = "Payload",
       type = TemplateProperty.PropertyType.Text,
-      description = "Provide payload for your function as JSON")
+      tooltip = "Payload for your function as JSON")
   private Object payload;
 
   @TemplateProperty(ignore = true)

--- a/connectors/aws/aws-lambda/src/main/java/io/camunda/connector/awslambda/model/FunctionRequestData.java
+++ b/connectors/aws/aws-lambda/src/main/java/io/camunda/connector/awslambda/model/FunctionRequestData.java
@@ -36,7 +36,8 @@ public class FunctionRequestData {
       group = "operationDetails",
       label = "Payload",
       type = TemplateProperty.PropertyType.Text,
-      tooltip = "Payload for your function as JSON")
+      placeholder = "{\"key\": \"value\"}",
+      tooltip = "JSON input passed to the Lambda function when it is invoked.")
   private Object payload;
 
   @TemplateProperty(ignore = true)

--- a/connectors/aws/aws-s3/element-templates/aws-s3-outbound-connector.json
+++ b/connectors/aws/aws-s3/element-templates/aws-s3-outbound-connector.json
@@ -96,7 +96,6 @@
   }, {
     "id" : "authentication.accessKey",
     "label" : "Access key",
-    "description" : "Provide an IAM access key tailored to a user, equipped with the necessary permissions",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -112,11 +111,11 @@
       "equals" : "credentials",
       "type" : "simple"
     },
+    "tooltip" : "IAM access key of a user with the necessary permissions for this connector",
     "type" : "String"
   }, {
     "id" : "authentication.secretKey",
     "label" : "Secret key",
-    "description" : "Provide a secret key of a user with permissions to invoke specified AWS Lambda function",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -132,11 +131,11 @@
       "equals" : "credentials",
       "type" : "simple"
     },
+    "tooltip" : "IAM secret key of a user with the necessary permissions for this connector",
     "type" : "String"
   }, {
     "id" : "configuration.region",
     "label" : "Region",
-    "description" : "Specify the AWS region",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -449,7 +448,7 @@
       "equals" : "downloadObject",
       "type" : "simple"
     },
-    "tooltip" : "Key of the object which should be download",
+    "tooltip" : "Key of the object which should be downloaded",
     "type" : "String"
   }, {
     "id" : "downloadActionAsFile",

--- a/connectors/aws/aws-s3/element-templates/hybrid/aws-s3-outbound-connector-hybrid.json
+++ b/connectors/aws/aws-s3/element-templates/hybrid/aws-s3-outbound-connector-hybrid.json
@@ -101,7 +101,6 @@
   }, {
     "id" : "authentication.accessKey",
     "label" : "Access key",
-    "description" : "Provide an IAM access key tailored to a user, equipped with the necessary permissions",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -117,11 +116,11 @@
       "equals" : "credentials",
       "type" : "simple"
     },
+    "tooltip" : "IAM access key of a user with the necessary permissions for this connector",
     "type" : "String"
   }, {
     "id" : "authentication.secretKey",
     "label" : "Secret key",
-    "description" : "Provide a secret key of a user with permissions to invoke specified AWS Lambda function",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -137,11 +136,11 @@
       "equals" : "credentials",
       "type" : "simple"
     },
+    "tooltip" : "IAM secret key of a user with the necessary permissions for this connector",
     "type" : "String"
   }, {
     "id" : "configuration.region",
     "label" : "Region",
-    "description" : "Specify the AWS region",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -454,7 +453,7 @@
       "equals" : "downloadObject",
       "type" : "simple"
     },
-    "tooltip" : "Key of the object which should be download",
+    "tooltip" : "Key of the object which should be downloaded",
     "type" : "String"
   }, {
     "id" : "downloadActionAsFile",

--- a/connectors/aws/aws-s3/src/main/java/io/camunda/connector/aws/s3/model/request/DownloadObject.java
+++ b/connectors/aws/aws-s3/src/main/java/io/camunda/connector/aws/s3/model/request/DownloadObject.java
@@ -30,7 +30,7 @@ public record DownloadObject(
             label = "AWS key",
             id = "downloadActionKey",
             group = "downloadObject",
-            tooltip = "Key of the object which should be download",
+            tooltip = "Key of the object which should be downloaded",
             feel = FeelMode.optional,
             binding = @TemplateProperty.PropertyBinding(name = "action.key"))
         @NotBlank

--- a/connectors/aws/aws-sagemaker/element-templates/aws-sagemaker-outbound-connector.json
+++ b/connectors/aws/aws-sagemaker/element-templates/aws-sagemaker-outbound-connector.json
@@ -133,7 +133,6 @@
   }, {
     "id" : "input.invocationType",
     "label" : "Inference type",
-    "description" : "Endpoint inference type",
     "optional" : false,
     "value" : "SYNC",
     "constraints" : {
@@ -155,7 +154,6 @@
   }, {
     "id" : "input.endpointName",
     "label" : "Endpoint name",
-    "description" : "The name of the endpoint. <a href=\"https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_Operations_Amazon_SageMaker_Runtime.html\">Learn more</a>",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -166,11 +164,11 @@
       "name" : "input.endpointName",
       "type" : "zeebe:input"
     },
+    "tooltip" : "<a href=\"https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_Operations_Amazon_SageMaker_Runtime.html\">Amazon SageMaker Runtime API</a>",
     "type" : "String"
   }, {
     "id" : "input.body",
     "label" : "Payload",
-    "description" : "Input data. <a href=\"https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_Operations_Amazon_SageMaker_Runtime.html\">Learn more</a>",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -186,11 +184,11 @@
       "equals" : "SYNC",
       "type" : "simple"
     },
+    "tooltip" : "Input data. <a href=\"https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_Operations_Amazon_SageMaker_Runtime.html\">Amazon SageMaker Runtime API</a>",
     "type" : "Text"
   }, {
     "id" : "input.contentType",
     "label" : "Content type",
-    "description" : "The MIME type of the input data in the request body. <a href=\"https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_Operations_Amazon_SageMaker_Runtime.html\">Learn more</a>",
     "optional" : false,
     "value" : "application/json",
     "constraints" : {
@@ -202,11 +200,11 @@
       "name" : "input.contentType",
       "type" : "zeebe:input"
     },
+    "tooltip" : "The MIME type of the input data in the request body. <a href=\"https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_Operations_Amazon_SageMaker_Runtime.html\">Amazon SageMaker Runtime API</a>",
     "type" : "String"
   }, {
     "id" : "input.accept",
     "label" : "Accept",
-    "description" : "The desired MIME type of the inference response from the model container. <a href=\"https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_Operations_Amazon_SageMaker_Runtime.html\">Learn more</a>",
     "optional" : false,
     "value" : "application/json",
     "constraints" : {
@@ -218,11 +216,11 @@
       "name" : "input.accept",
       "type" : "zeebe:input"
     },
+    "tooltip" : "The desired MIME type of the inference response from the model container. <a href=\"https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_Operations_Amazon_SageMaker_Runtime.html\">Amazon SageMaker Runtime API</a>",
     "type" : "String"
   }, {
     "id" : "input.customAttributes",
     "label" : "Custom attributes",
-    "description" : "Provides additional information about a request for an inference submitted to a model hosted at an Amazon SageMaker endpoint. <a href=\"https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_Operations_Amazon_SageMaker_Runtime.html\">Learn more</a>",
     "optional" : true,
     "feel" : "optional",
     "group" : "input",
@@ -230,11 +228,11 @@
       "name" : "input.customAttributes",
       "type" : "zeebe:input"
     },
+    "tooltip" : "Provides additional information about a request for an inference submitted to a model hosted at an Amazon SageMaker endpoint. <a href=\"https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_Operations_Amazon_SageMaker_Runtime.html\">Amazon SageMaker Runtime API</a>",
     "type" : "String"
   }, {
     "id" : "input.targetModel",
     "label" : "Target model",
-    "description" : "The model to request for inference when invoking a multi-model endpoint. <a href=\"https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_Operations_Amazon_SageMaker_Runtime.html\">Learn more</a>",
     "optional" : true,
     "feel" : "optional",
     "group" : "input",
@@ -247,11 +245,11 @@
       "equals" : "SYNC",
       "type" : "simple"
     },
+    "tooltip" : "The model to request for inference when invoking a multi-model endpoint. <a href=\"https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_Operations_Amazon_SageMaker_Runtime.html\">Amazon SageMaker Runtime API</a>",
     "type" : "String"
   }, {
     "id" : "input.targetVariant",
     "label" : "Target variant",
-    "description" : "Specify the production variant to send the inference request to. <a href=\"https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_Operations_Amazon_SageMaker_Runtime.html\">Learn more</a>",
     "optional" : true,
     "feel" : "optional",
     "group" : "input",
@@ -264,11 +262,11 @@
       "equals" : "SYNC",
       "type" : "simple"
     },
+    "tooltip" : "The production variant to send the inference request to. <a href=\"https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_Operations_Amazon_SageMaker_Runtime.html\">Amazon SageMaker Runtime API</a>",
     "type" : "String"
   }, {
     "id" : "input.targetContainerHostname",
     "label" : "Target invocation host name",
-    "description" : "If the endpoint hosts multiple containers and is configured to use direct invocation, this parameter specifies the host name of the container to invoke. <a href=\"https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_Operations_Amazon_SageMaker_Runtime.html\">Learn more</a>",
     "optional" : true,
     "feel" : "optional",
     "group" : "input",
@@ -281,11 +279,11 @@
       "equals" : "SYNC",
       "type" : "simple"
     },
+    "tooltip" : "If the endpoint hosts multiple containers and is configured to use direct invocation, this parameter specifies the host name of the container to invoke. <a href=\"https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_Operations_Amazon_SageMaker_Runtime.html\">Amazon SageMaker Runtime API</a>",
     "type" : "String"
   }, {
     "id" : "input.inferenceId",
     "label" : "Inference ID",
-    "description" : "If you provide a value, it is added to the captured data when you enable data capture on the endpoint. <a href=\"https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_Operations_Amazon_SageMaker_Runtime.html\">Learn more</a>",
     "optional" : true,
     "feel" : "optional",
     "group" : "input",
@@ -293,11 +291,11 @@
       "name" : "input.inferenceId",
       "type" : "zeebe:input"
     },
+    "tooltip" : "If you provide a value, it is added to the captured data when you enable data capture on the endpoint. <a href=\"https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_Operations_Amazon_SageMaker_Runtime.html\">Amazon SageMaker Runtime API</a>",
     "type" : "String"
   }, {
     "id" : "input.enableExplanations",
     "label" : "Enable explanations",
-    "description" : "Whether request needs to be explained. <a href=\"https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_Operations_Amazon_SageMaker_Runtime.html\">Learn more</a>",
     "optional" : false,
     "value" : "NOT_SET",
     "group" : "input",
@@ -310,6 +308,7 @@
       "equals" : "SYNC",
       "type" : "simple"
     },
+    "tooltip" : "Whether request needs to be explained. <a href=\"https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_Operations_Amazon_SageMaker_Runtime.html\">Amazon SageMaker Runtime API</a>",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "Not set",
@@ -324,7 +323,6 @@
   }, {
     "id" : "input.inferenceComponentName",
     "label" : "Inference component name",
-    "description" : "If the endpoint hosts one or more inference components, this parameter specifies the name of inference component to invoke. <a href=\"https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_Operations_Amazon_SageMaker_Runtime.html\">Learn more</a>",
     "optional" : true,
     "feel" : "optional",
     "group" : "input",
@@ -337,11 +335,11 @@
       "equals" : "SYNC",
       "type" : "simple"
     },
+    "tooltip" : "If the endpoint hosts one or more inference components, this parameter specifies the name of inference component to invoke. <a href=\"https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_Operations_Amazon_SageMaker_Runtime.html\">Amazon SageMaker Runtime API</a>",
     "type" : "String"
   }, {
     "id" : "input.inputLocation",
     "label" : "Input location",
-    "description" : "The Amazon S3 URI where the inference request payload is stored. <a href=\"https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_Operations_Amazon_SageMaker_Runtime.html\">Learn more</a>",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -357,11 +355,11 @@
       "equals" : "ASYNC",
       "type" : "simple"
     },
+    "tooltip" : "The Amazon S3 URI where the inference request payload is stored. <a href=\"https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_Operations_Amazon_SageMaker_Runtime.html\">Amazon SageMaker Runtime API</a>",
     "type" : "String"
   }, {
     "id" : "input.requestTTLSeconds",
     "label" : "Request time-to-leave in seconds",
-    "description" : "Maximum age in seconds a request can be in the queue before it is marked as expired. The default is 21,600 seconds. <a href=\"https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_Operations_Amazon_SageMaker_Runtime.html\">Learn more</a>",
     "optional" : true,
     "feel" : "optional",
     "group" : "input",
@@ -374,11 +372,11 @@
       "equals" : "ASYNC",
       "type" : "simple"
     },
+    "tooltip" : "Maximum age in seconds a request can be in the queue before it is marked as expired. The default is 21,600 seconds. <a href=\"https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_Operations_Amazon_SageMaker_Runtime.html\">Amazon SageMaker Runtime API</a>",
     "type" : "String"
   }, {
     "id" : "input.invocationTimeoutSeconds",
     "label" : "Invocation timeout in seconds",
-    "description" : "Maximum amount of time in seconds a request can be processed before it is marked as expired. The default is 900 seconds. <a href=\"https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_Operations_Amazon_SageMaker_Runtime.html\">Learn more</a>",
     "optional" : true,
     "feel" : "optional",
     "group" : "input",
@@ -391,6 +389,7 @@
       "equals" : "ASYNC",
       "type" : "simple"
     },
+    "tooltip" : "Maximum amount of time in seconds a request can be processed before it is marked as expired. The default is 900 seconds. <a href=\"https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_Operations_Amazon_SageMaker_Runtime.html\">Amazon SageMaker Runtime API</a>",
     "type" : "String"
   }, {
     "id" : "version",

--- a/connectors/aws/aws-sagemaker/element-templates/aws-sagemaker-outbound-connector.json
+++ b/connectors/aws/aws-sagemaker/element-templates/aws-sagemaker-outbound-connector.json
@@ -67,7 +67,6 @@
   }, {
     "id" : "authentication.accessKey",
     "label" : "Access key",
-    "description" : "Provide an IAM access key tailored to a user, equipped with the necessary permissions",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -83,11 +82,11 @@
       "equals" : "credentials",
       "type" : "simple"
     },
+    "tooltip" : "IAM access key of a user with the necessary permissions for this connector",
     "type" : "String"
   }, {
     "id" : "authentication.secretKey",
     "label" : "Secret key",
-    "description" : "Provide a secret key of a user with permissions to invoke specified AWS Lambda function",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -103,11 +102,11 @@
       "equals" : "credentials",
       "type" : "simple"
     },
+    "tooltip" : "IAM secret key of a user with the necessary permissions for this connector",
     "type" : "String"
   }, {
     "id" : "configuration.region",
     "label" : "Region",
-    "description" : "Specify the AWS region",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -164,7 +163,7 @@
       "name" : "input.endpointName",
       "type" : "zeebe:input"
     },
-    "tooltip" : "<a href=\"https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_Operations_Amazon_SageMaker_Runtime.html\">Amazon SageMaker Runtime API</a>",
+    "tooltip" : "The name of the endpoint to invoke. <a href=\"https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_Operations_Amazon_SageMaker_Runtime.html\">Amazon SageMaker Runtime API</a>",
     "type" : "String"
   }, {
     "id" : "input.body",

--- a/connectors/aws/aws-sagemaker/element-templates/hybrid/aws-sagemaker-outbound-connector-hybrid.json
+++ b/connectors/aws/aws-sagemaker/element-templates/hybrid/aws-sagemaker-outbound-connector-hybrid.json
@@ -72,7 +72,6 @@
   }, {
     "id" : "authentication.accessKey",
     "label" : "Access key",
-    "description" : "Provide an IAM access key tailored to a user, equipped with the necessary permissions",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -88,11 +87,11 @@
       "equals" : "credentials",
       "type" : "simple"
     },
+    "tooltip" : "IAM access key of a user with the necessary permissions for this connector",
     "type" : "String"
   }, {
     "id" : "authentication.secretKey",
     "label" : "Secret key",
-    "description" : "Provide a secret key of a user with permissions to invoke specified AWS Lambda function",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -108,11 +107,11 @@
       "equals" : "credentials",
       "type" : "simple"
     },
+    "tooltip" : "IAM secret key of a user with the necessary permissions for this connector",
     "type" : "String"
   }, {
     "id" : "configuration.region",
     "label" : "Region",
-    "description" : "Specify the AWS region",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -169,7 +168,7 @@
       "name" : "input.endpointName",
       "type" : "zeebe:input"
     },
-    "tooltip" : "<a href=\"https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_Operations_Amazon_SageMaker_Runtime.html\">Amazon SageMaker Runtime API</a>",
+    "tooltip" : "The name of the endpoint to invoke. <a href=\"https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_Operations_Amazon_SageMaker_Runtime.html\">Amazon SageMaker Runtime API</a>",
     "type" : "String"
   }, {
     "id" : "input.body",

--- a/connectors/aws/aws-sagemaker/element-templates/hybrid/aws-sagemaker-outbound-connector-hybrid.json
+++ b/connectors/aws/aws-sagemaker/element-templates/hybrid/aws-sagemaker-outbound-connector-hybrid.json
@@ -138,7 +138,6 @@
   }, {
     "id" : "input.invocationType",
     "label" : "Inference type",
-    "description" : "Endpoint inference type",
     "optional" : false,
     "value" : "SYNC",
     "constraints" : {
@@ -160,7 +159,6 @@
   }, {
     "id" : "input.endpointName",
     "label" : "Endpoint name",
-    "description" : "The name of the endpoint. <a href=\"https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_Operations_Amazon_SageMaker_Runtime.html\">Learn more</a>",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -171,11 +169,11 @@
       "name" : "input.endpointName",
       "type" : "zeebe:input"
     },
+    "tooltip" : "<a href=\"https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_Operations_Amazon_SageMaker_Runtime.html\">Amazon SageMaker Runtime API</a>",
     "type" : "String"
   }, {
     "id" : "input.body",
     "label" : "Payload",
-    "description" : "Input data. <a href=\"https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_Operations_Amazon_SageMaker_Runtime.html\">Learn more</a>",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -191,11 +189,11 @@
       "equals" : "SYNC",
       "type" : "simple"
     },
+    "tooltip" : "Input data. <a href=\"https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_Operations_Amazon_SageMaker_Runtime.html\">Amazon SageMaker Runtime API</a>",
     "type" : "Text"
   }, {
     "id" : "input.contentType",
     "label" : "Content type",
-    "description" : "The MIME type of the input data in the request body. <a href=\"https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_Operations_Amazon_SageMaker_Runtime.html\">Learn more</a>",
     "optional" : false,
     "value" : "application/json",
     "constraints" : {
@@ -207,11 +205,11 @@
       "name" : "input.contentType",
       "type" : "zeebe:input"
     },
+    "tooltip" : "The MIME type of the input data in the request body. <a href=\"https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_Operations_Amazon_SageMaker_Runtime.html\">Amazon SageMaker Runtime API</a>",
     "type" : "String"
   }, {
     "id" : "input.accept",
     "label" : "Accept",
-    "description" : "The desired MIME type of the inference response from the model container. <a href=\"https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_Operations_Amazon_SageMaker_Runtime.html\">Learn more</a>",
     "optional" : false,
     "value" : "application/json",
     "constraints" : {
@@ -223,11 +221,11 @@
       "name" : "input.accept",
       "type" : "zeebe:input"
     },
+    "tooltip" : "The desired MIME type of the inference response from the model container. <a href=\"https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_Operations_Amazon_SageMaker_Runtime.html\">Amazon SageMaker Runtime API</a>",
     "type" : "String"
   }, {
     "id" : "input.customAttributes",
     "label" : "Custom attributes",
-    "description" : "Provides additional information about a request for an inference submitted to a model hosted at an Amazon SageMaker endpoint. <a href=\"https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_Operations_Amazon_SageMaker_Runtime.html\">Learn more</a>",
     "optional" : true,
     "feel" : "optional",
     "group" : "input",
@@ -235,11 +233,11 @@
       "name" : "input.customAttributes",
       "type" : "zeebe:input"
     },
+    "tooltip" : "Provides additional information about a request for an inference submitted to a model hosted at an Amazon SageMaker endpoint. <a href=\"https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_Operations_Amazon_SageMaker_Runtime.html\">Amazon SageMaker Runtime API</a>",
     "type" : "String"
   }, {
     "id" : "input.targetModel",
     "label" : "Target model",
-    "description" : "The model to request for inference when invoking a multi-model endpoint. <a href=\"https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_Operations_Amazon_SageMaker_Runtime.html\">Learn more</a>",
     "optional" : true,
     "feel" : "optional",
     "group" : "input",
@@ -252,11 +250,11 @@
       "equals" : "SYNC",
       "type" : "simple"
     },
+    "tooltip" : "The model to request for inference when invoking a multi-model endpoint. <a href=\"https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_Operations_Amazon_SageMaker_Runtime.html\">Amazon SageMaker Runtime API</a>",
     "type" : "String"
   }, {
     "id" : "input.targetVariant",
     "label" : "Target variant",
-    "description" : "Specify the production variant to send the inference request to. <a href=\"https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_Operations_Amazon_SageMaker_Runtime.html\">Learn more</a>",
     "optional" : true,
     "feel" : "optional",
     "group" : "input",
@@ -269,11 +267,11 @@
       "equals" : "SYNC",
       "type" : "simple"
     },
+    "tooltip" : "The production variant to send the inference request to. <a href=\"https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_Operations_Amazon_SageMaker_Runtime.html\">Amazon SageMaker Runtime API</a>",
     "type" : "String"
   }, {
     "id" : "input.targetContainerHostname",
     "label" : "Target invocation host name",
-    "description" : "If the endpoint hosts multiple containers and is configured to use direct invocation, this parameter specifies the host name of the container to invoke. <a href=\"https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_Operations_Amazon_SageMaker_Runtime.html\">Learn more</a>",
     "optional" : true,
     "feel" : "optional",
     "group" : "input",
@@ -286,11 +284,11 @@
       "equals" : "SYNC",
       "type" : "simple"
     },
+    "tooltip" : "If the endpoint hosts multiple containers and is configured to use direct invocation, this parameter specifies the host name of the container to invoke. <a href=\"https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_Operations_Amazon_SageMaker_Runtime.html\">Amazon SageMaker Runtime API</a>",
     "type" : "String"
   }, {
     "id" : "input.inferenceId",
     "label" : "Inference ID",
-    "description" : "If you provide a value, it is added to the captured data when you enable data capture on the endpoint. <a href=\"https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_Operations_Amazon_SageMaker_Runtime.html\">Learn more</a>",
     "optional" : true,
     "feel" : "optional",
     "group" : "input",
@@ -298,11 +296,11 @@
       "name" : "input.inferenceId",
       "type" : "zeebe:input"
     },
+    "tooltip" : "If you provide a value, it is added to the captured data when you enable data capture on the endpoint. <a href=\"https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_Operations_Amazon_SageMaker_Runtime.html\">Amazon SageMaker Runtime API</a>",
     "type" : "String"
   }, {
     "id" : "input.enableExplanations",
     "label" : "Enable explanations",
-    "description" : "Whether request needs to be explained. <a href=\"https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_Operations_Amazon_SageMaker_Runtime.html\">Learn more</a>",
     "optional" : false,
     "value" : "NOT_SET",
     "group" : "input",
@@ -315,6 +313,7 @@
       "equals" : "SYNC",
       "type" : "simple"
     },
+    "tooltip" : "Whether request needs to be explained. <a href=\"https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_Operations_Amazon_SageMaker_Runtime.html\">Amazon SageMaker Runtime API</a>",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "Not set",
@@ -329,7 +328,6 @@
   }, {
     "id" : "input.inferenceComponentName",
     "label" : "Inference component name",
-    "description" : "If the endpoint hosts one or more inference components, this parameter specifies the name of inference component to invoke. <a href=\"https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_Operations_Amazon_SageMaker_Runtime.html\">Learn more</a>",
     "optional" : true,
     "feel" : "optional",
     "group" : "input",
@@ -342,11 +340,11 @@
       "equals" : "SYNC",
       "type" : "simple"
     },
+    "tooltip" : "If the endpoint hosts one or more inference components, this parameter specifies the name of inference component to invoke. <a href=\"https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_Operations_Amazon_SageMaker_Runtime.html\">Amazon SageMaker Runtime API</a>",
     "type" : "String"
   }, {
     "id" : "input.inputLocation",
     "label" : "Input location",
-    "description" : "The Amazon S3 URI where the inference request payload is stored. <a href=\"https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_Operations_Amazon_SageMaker_Runtime.html\">Learn more</a>",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -362,11 +360,11 @@
       "equals" : "ASYNC",
       "type" : "simple"
     },
+    "tooltip" : "The Amazon S3 URI where the inference request payload is stored. <a href=\"https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_Operations_Amazon_SageMaker_Runtime.html\">Amazon SageMaker Runtime API</a>",
     "type" : "String"
   }, {
     "id" : "input.requestTTLSeconds",
     "label" : "Request time-to-leave in seconds",
-    "description" : "Maximum age in seconds a request can be in the queue before it is marked as expired. The default is 21,600 seconds. <a href=\"https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_Operations_Amazon_SageMaker_Runtime.html\">Learn more</a>",
     "optional" : true,
     "feel" : "optional",
     "group" : "input",
@@ -379,11 +377,11 @@
       "equals" : "ASYNC",
       "type" : "simple"
     },
+    "tooltip" : "Maximum age in seconds a request can be in the queue before it is marked as expired. The default is 21,600 seconds. <a href=\"https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_Operations_Amazon_SageMaker_Runtime.html\">Amazon SageMaker Runtime API</a>",
     "type" : "String"
   }, {
     "id" : "input.invocationTimeoutSeconds",
     "label" : "Invocation timeout in seconds",
-    "description" : "Maximum amount of time in seconds a request can be processed before it is marked as expired. The default is 900 seconds. <a href=\"https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_Operations_Amazon_SageMaker_Runtime.html\">Learn more</a>",
     "optional" : true,
     "feel" : "optional",
     "group" : "input",
@@ -396,6 +394,7 @@
       "equals" : "ASYNC",
       "type" : "simple"
     },
+    "tooltip" : "Maximum amount of time in seconds a request can be processed before it is marked as expired. The default is 900 seconds. <a href=\"https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_Operations_Amazon_SageMaker_Runtime.html\">Amazon SageMaker Runtime API</a>",
     "type" : "String"
   }, {
     "id" : "version",

--- a/connectors/aws/aws-sagemaker/src/main/java/io/camunda/connector/sagemaker/model/SageMakerRequestData.java
+++ b/connectors/aws/aws-sagemaker/src/main/java/io/camunda/connector/sagemaker/model/SageMakerRequestData.java
@@ -30,7 +30,7 @@ public record SageMakerRequestData(
             group = "input",
             label = "Endpoint name",
             tooltip =
-                "<a href=\"https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_Operations_Amazon_SageMaker_Runtime.html\">Amazon SageMaker Runtime API</a>")
+                "The name of the endpoint to invoke. <a href=\"https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_Operations_Amazon_SageMaker_Runtime.html\">Amazon SageMaker Runtime API</a>")
         String endpointName,
     @TemplateProperty(
             label = "Payload",

--- a/connectors/aws/aws-sagemaker/src/main/java/io/camunda/connector/sagemaker/model/SageMakerRequestData.java
+++ b/connectors/aws/aws-sagemaker/src/main/java/io/camunda/connector/sagemaker/model/SageMakerRequestData.java
@@ -22,22 +22,21 @@ public record SageMakerRequestData(
             choices = {
               @TemplateProperty.DropdownPropertyChoice(value = "SYNC", label = "Real-time"),
               @TemplateProperty.DropdownPropertyChoice(value = "ASYNC", label = "Asynchronous")
-            },
-            description = "Endpoint inference type")
+            })
         @NotNull
         SageMakerInvocationType invocationType,
     @NotBlank
         @TemplateProperty(
             group = "input",
             label = "Endpoint name",
-            description =
-                "The name of the endpoint. <a href=\"https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_Operations_Amazon_SageMaker_Runtime.html\">Learn more</a>")
+            tooltip =
+                "<a href=\"https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_Operations_Amazon_SageMaker_Runtime.html\">Amazon SageMaker Runtime API</a>")
         String endpointName,
     @TemplateProperty(
             label = "Payload",
             group = "input",
-            description =
-                "Input data. <a href=\"https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_Operations_Amazon_SageMaker_Runtime.html\">Learn more</a>",
+            tooltip =
+                "Input data. <a href=\"https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_Operations_Amazon_SageMaker_Runtime.html\">Amazon SageMaker Runtime API</a>",
             type = TemplateProperty.PropertyType.Text,
             constraints = @PropertyConstraints(notEmpty = true),
             condition =
@@ -49,8 +48,8 @@ public record SageMakerRequestData(
         @TemplateProperty(
             group = "input",
             label = "Content type",
-            description =
-                "The MIME type of the input data in the request body. <a href=\"https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_Operations_Amazon_SageMaker_Runtime.html\">Learn more</a>",
+            tooltip =
+                "The MIME type of the input data in the request body. <a href=\"https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_Operations_Amazon_SageMaker_Runtime.html\">Amazon SageMaker Runtime API</a>",
             constraints = @PropertyConstraints(notEmpty = true),
             defaultValue = "application/json")
         String contentType,
@@ -58,23 +57,23 @@ public record SageMakerRequestData(
         @TemplateProperty(
             group = "input",
             label = "Accept",
-            description =
-                "The desired MIME type of the inference response from the model container. <a href=\"https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_Operations_Amazon_SageMaker_Runtime.html\">Learn more</a>",
+            tooltip =
+                "The desired MIME type of the inference response from the model container. <a href=\"https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_Operations_Amazon_SageMaker_Runtime.html\">Amazon SageMaker Runtime API</a>",
             constraints = @PropertyConstraints(notEmpty = true),
             defaultValue = "application/json")
         String accept,
     @TemplateProperty(
             group = "input",
             label = "Custom attributes",
-            description =
-                "Provides additional information about a request for an inference submitted to a model hosted at an Amazon SageMaker endpoint. <a href=\"https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_Operations_Amazon_SageMaker_Runtime.html\">Learn more</a>",
+            tooltip =
+                "Provides additional information about a request for an inference submitted to a model hosted at an Amazon SageMaker endpoint. <a href=\"https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_Operations_Amazon_SageMaker_Runtime.html\">Amazon SageMaker Runtime API</a>",
             optional = true)
         String customAttributes,
     @TemplateProperty(
             group = "input",
             label = "Target model",
-            description =
-                "The model to request for inference when invoking a multi-model endpoint. <a href=\"https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_Operations_Amazon_SageMaker_Runtime.html\">Learn more</a>",
+            tooltip =
+                "The model to request for inference when invoking a multi-model endpoint. <a href=\"https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_Operations_Amazon_SageMaker_Runtime.html\">Amazon SageMaker Runtime API</a>",
             optional = true,
             condition =
                 @TemplateProperty.PropertyCondition(
@@ -84,8 +83,8 @@ public record SageMakerRequestData(
     @TemplateProperty(
             group = "input",
             label = "Target variant",
-            description =
-                "Specify the production variant to send the inference request to. <a href=\"https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_Operations_Amazon_SageMaker_Runtime.html\">Learn more</a>",
+            tooltip =
+                "The production variant to send the inference request to. <a href=\"https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_Operations_Amazon_SageMaker_Runtime.html\">Amazon SageMaker Runtime API</a>",
             optional = true,
             condition =
                 @TemplateProperty.PropertyCondition(
@@ -95,8 +94,8 @@ public record SageMakerRequestData(
     @TemplateProperty(
             group = "input",
             label = "Target invocation host name",
-            description =
-                "If the endpoint hosts multiple containers and is configured to use direct invocation, this parameter specifies the host name of the container to invoke. <a href=\"https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_Operations_Amazon_SageMaker_Runtime.html\">Learn more</a>",
+            tooltip =
+                "If the endpoint hosts multiple containers and is configured to use direct invocation, this parameter specifies the host name of the container to invoke. <a href=\"https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_Operations_Amazon_SageMaker_Runtime.html\">Amazon SageMaker Runtime API</a>",
             optional = true,
             condition =
                 @TemplateProperty.PropertyCondition(
@@ -106,8 +105,8 @@ public record SageMakerRequestData(
     @TemplateProperty(
             group = "input",
             label = "Inference ID",
-            description =
-                "If you provide a value, it is added to the captured data when you enable data capture on the endpoint. <a href=\"https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_Operations_Amazon_SageMaker_Runtime.html\">Learn more</a>",
+            tooltip =
+                "If you provide a value, it is added to the captured data when you enable data capture on the endpoint. <a href=\"https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_Operations_Amazon_SageMaker_Runtime.html\">Amazon SageMaker Runtime API</a>",
             optional = true)
         String inferenceId,
     @TemplateProperty(
@@ -124,14 +123,14 @@ public record SageMakerRequestData(
               @TemplateProperty.DropdownPropertyChoice(value = "YES", label = "True"),
               @TemplateProperty.DropdownPropertyChoice(value = "NO", label = "False")
             },
-            description =
-                "Whether request needs to be explained. <a href=\"https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_Operations_Amazon_SageMaker_Runtime.html\">Learn more</a>")
+            tooltip =
+                "Whether request needs to be explained. <a href=\"https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_Operations_Amazon_SageMaker_Runtime.html\">Amazon SageMaker Runtime API</a>")
         SageMakerEnableExplanations enableExplanations,
     @TemplateProperty(
             group = "input",
             label = "Inference component name",
-            description =
-                "If the endpoint hosts one or more inference components, this parameter specifies the name of inference component to invoke. <a href=\"https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_Operations_Amazon_SageMaker_Runtime.html\">Learn more</a>",
+            tooltip =
+                "If the endpoint hosts one or more inference components, this parameter specifies the name of inference component to invoke. <a href=\"https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_Operations_Amazon_SageMaker_Runtime.html\">Amazon SageMaker Runtime API</a>",
             optional = true,
             condition =
                 @TemplateProperty.PropertyCondition(
@@ -141,8 +140,8 @@ public record SageMakerRequestData(
     @TemplateProperty(
             group = "input",
             label = "Input location",
-            description =
-                "The Amazon S3 URI where the inference request payload is stored. <a href=\"https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_Operations_Amazon_SageMaker_Runtime.html\">Learn more</a>",
+            tooltip =
+                "The Amazon S3 URI where the inference request payload is stored. <a href=\"https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_Operations_Amazon_SageMaker_Runtime.html\">Amazon SageMaker Runtime API</a>",
             constraints = @PropertyConstraints(notEmpty = true),
             condition =
                 @TemplateProperty.PropertyCondition(
@@ -152,8 +151,8 @@ public record SageMakerRequestData(
     @TemplateProperty(
             group = "input",
             label = "Request time-to-leave in seconds",
-            description =
-                "Maximum age in seconds a request can be in the queue before it is marked as expired. The default is 21,600 seconds. <a href=\"https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_Operations_Amazon_SageMaker_Runtime.html\">Learn more</a>",
+            tooltip =
+                "Maximum age in seconds a request can be in the queue before it is marked as expired. The default is 21,600 seconds. <a href=\"https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_Operations_Amazon_SageMaker_Runtime.html\">Amazon SageMaker Runtime API</a>",
             optional = true,
             condition =
                 @TemplateProperty.PropertyCondition(
@@ -163,8 +162,8 @@ public record SageMakerRequestData(
     @TemplateProperty(
             group = "input",
             label = "Invocation timeout in seconds",
-            description =
-                "Maximum amount of time in seconds a request can be processed before it is marked as expired. The default is 900 seconds. <a href=\"https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_Operations_Amazon_SageMaker_Runtime.html\">Learn more</a>",
+            tooltip =
+                "Maximum amount of time in seconds a request can be processed before it is marked as expired. The default is 900 seconds. <a href=\"https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_Operations_Amazon_SageMaker_Runtime.html\">Amazon SageMaker Runtime API</a>",
             optional = true,
             condition =
                 @TemplateProperty.PropertyCondition(

--- a/connectors/aws/aws-sns/element-templates/aws-sns-inbound-boundary.json
+++ b/connectors/aws/aws-sns/element-templates/aws-sns-inbound-boundary.json
@@ -91,7 +91,8 @@
       "equals" : "specific",
       "type" : "simple"
     },
-    "tooltip" : "Comma-separated topic ARNs that are allowed to trigger the process",
+    "tooltip" : "Topic ARNs that are allowed to trigger the process, comma-separated",
+    "placeholder" : "arn:aws:sns:us-east-1:123456789012:Topic1,arn:aws:sns:us-east-1:123456789012:Topic2",
     "type" : "String"
   }, {
     "id" : "activationCondition",

--- a/connectors/aws/aws-sns/element-templates/aws-sns-inbound-boundary.json
+++ b/connectors/aws/aws-sns/element-templates/aws-sns-inbound-boundary.json
@@ -46,7 +46,6 @@
   }, {
     "id" : "inbound.context",
     "label" : "Subscription ID",
-    "description" : "The subscription ID is a part of the URL endpoint",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -56,11 +55,11 @@
       "name" : "inbound.context",
       "type" : "zeebe:property"
     },
+    "tooltip" : "The subscription ID is a part of the URL endpoint",
     "type" : "String"
   }, {
     "id" : "inbound.securitySubscriptionAllowedFor",
     "label" : "Allow to receive messages from topic(s)",
-    "description" : "Control which topic(s) is allowed to start a process",
     "optional" : false,
     "value" : "any",
     "group" : "subscription",
@@ -68,6 +67,7 @@
       "name" : "inbound.securitySubscriptionAllowedFor",
       "type" : "zeebe:property"
     },
+    "tooltip" : "Control which topic(s) are allowed to start a process",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "Any",
@@ -79,7 +79,6 @@
   }, {
     "id" : "inbound.topicsAllowList",
     "label" : "Topic ARN(s)",
-    "description" : "Topics that allow to publish messages",
     "optional" : true,
     "feel" : "optional",
     "group" : "subscription",
@@ -92,6 +91,7 @@
       "equals" : "specific",
       "type" : "simple"
     },
+    "tooltip" : "Comma-separated topic ARNs that are allowed to trigger the process",
     "type" : "String"
   }, {
     "id" : "activationCondition",

--- a/connectors/aws/aws-sns/element-templates/aws-sns-inbound-intermediate.json
+++ b/connectors/aws/aws-sns/element-templates/aws-sns-inbound-intermediate.json
@@ -91,7 +91,8 @@
       "equals" : "specific",
       "type" : "simple"
     },
-    "tooltip" : "Comma-separated topic ARNs that are allowed to trigger the process",
+    "tooltip" : "Topic ARNs that are allowed to trigger the process, comma-separated",
+    "placeholder" : "arn:aws:sns:us-east-1:123456789012:Topic1,arn:aws:sns:us-east-1:123456789012:Topic2",
     "type" : "String"
   }, {
     "id" : "activationCondition",

--- a/connectors/aws/aws-sns/element-templates/aws-sns-inbound-intermediate.json
+++ b/connectors/aws/aws-sns/element-templates/aws-sns-inbound-intermediate.json
@@ -46,7 +46,6 @@
   }, {
     "id" : "inbound.context",
     "label" : "Subscription ID",
-    "description" : "The subscription ID is a part of the URL endpoint",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -56,11 +55,11 @@
       "name" : "inbound.context",
       "type" : "zeebe:property"
     },
+    "tooltip" : "The subscription ID is a part of the URL endpoint",
     "type" : "String"
   }, {
     "id" : "inbound.securitySubscriptionAllowedFor",
     "label" : "Allow to receive messages from topic(s)",
-    "description" : "Control which topic(s) is allowed to start a process",
     "optional" : false,
     "value" : "any",
     "group" : "subscription",
@@ -68,6 +67,7 @@
       "name" : "inbound.securitySubscriptionAllowedFor",
       "type" : "zeebe:property"
     },
+    "tooltip" : "Control which topic(s) are allowed to start a process",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "Any",
@@ -79,7 +79,6 @@
   }, {
     "id" : "inbound.topicsAllowList",
     "label" : "Topic ARN(s)",
-    "description" : "Topics that allow to publish messages",
     "optional" : true,
     "feel" : "optional",
     "group" : "subscription",
@@ -92,6 +91,7 @@
       "equals" : "specific",
       "type" : "simple"
     },
+    "tooltip" : "Comma-separated topic ARNs that are allowed to trigger the process",
     "type" : "String"
   }, {
     "id" : "activationCondition",

--- a/connectors/aws/aws-sns/element-templates/aws-sns-inbound-message-start.json
+++ b/connectors/aws/aws-sns/element-templates/aws-sns-inbound-message-start.json
@@ -91,7 +91,8 @@
       "equals" : "specific",
       "type" : "simple"
     },
-    "tooltip" : "Comma-separated topic ARNs that are allowed to trigger the process",
+    "tooltip" : "Topic ARNs that are allowed to trigger the process, comma-separated",
+    "placeholder" : "arn:aws:sns:us-east-1:123456789012:Topic1,arn:aws:sns:us-east-1:123456789012:Topic2",
     "type" : "String"
   }, {
     "id" : "activationCondition",

--- a/connectors/aws/aws-sns/element-templates/aws-sns-inbound-message-start.json
+++ b/connectors/aws/aws-sns/element-templates/aws-sns-inbound-message-start.json
@@ -46,7 +46,6 @@
   }, {
     "id" : "inbound.context",
     "label" : "Subscription ID",
-    "description" : "The subscription ID is a part of the URL endpoint",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -56,11 +55,11 @@
       "name" : "inbound.context",
       "type" : "zeebe:property"
     },
+    "tooltip" : "The subscription ID is a part of the URL endpoint",
     "type" : "String"
   }, {
     "id" : "inbound.securitySubscriptionAllowedFor",
     "label" : "Allow to receive messages from topic(s)",
-    "description" : "Control which topic(s) is allowed to start a process",
     "optional" : false,
     "value" : "any",
     "group" : "subscription",
@@ -68,6 +67,7 @@
       "name" : "inbound.securitySubscriptionAllowedFor",
       "type" : "zeebe:property"
     },
+    "tooltip" : "Control which topic(s) are allowed to start a process",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "Any",
@@ -79,7 +79,6 @@
   }, {
     "id" : "inbound.topicsAllowList",
     "label" : "Topic ARN(s)",
-    "description" : "Topics that allow to publish messages",
     "optional" : true,
     "feel" : "optional",
     "group" : "subscription",
@@ -92,6 +91,7 @@
       "equals" : "specific",
       "type" : "simple"
     },
+    "tooltip" : "Comma-separated topic ARNs that are allowed to trigger the process",
     "type" : "String"
   }, {
     "id" : "activationCondition",

--- a/connectors/aws/aws-sns/element-templates/aws-sns-inbound-receive.json
+++ b/connectors/aws/aws-sns/element-templates/aws-sns-inbound-receive.json
@@ -90,7 +90,8 @@
       "equals" : "specific",
       "type" : "simple"
     },
-    "tooltip" : "Comma-separated topic ARNs that are allowed to trigger the process",
+    "tooltip" : "Topic ARNs that are allowed to trigger the process, comma-separated",
+    "placeholder" : "arn:aws:sns:us-east-1:123456789012:Topic1,arn:aws:sns:us-east-1:123456789012:Topic2",
     "type" : "String"
   }, {
     "id" : "activationCondition",

--- a/connectors/aws/aws-sns/element-templates/aws-sns-inbound-receive.json
+++ b/connectors/aws/aws-sns/element-templates/aws-sns-inbound-receive.json
@@ -45,7 +45,6 @@
   }, {
     "id" : "inbound.context",
     "label" : "Subscription ID",
-    "description" : "The subscription ID is a part of the URL endpoint",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -55,11 +54,11 @@
       "name" : "inbound.context",
       "type" : "zeebe:property"
     },
+    "tooltip" : "The subscription ID is a part of the URL endpoint",
     "type" : "String"
   }, {
     "id" : "inbound.securitySubscriptionAllowedFor",
     "label" : "Allow to receive messages from topic(s)",
-    "description" : "Control which topic(s) is allowed to start a process",
     "optional" : false,
     "value" : "any",
     "group" : "subscription",
@@ -67,6 +66,7 @@
       "name" : "inbound.securitySubscriptionAllowedFor",
       "type" : "zeebe:property"
     },
+    "tooltip" : "Control which topic(s) are allowed to start a process",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "Any",
@@ -78,7 +78,6 @@
   }, {
     "id" : "inbound.topicsAllowList",
     "label" : "Topic ARN(s)",
-    "description" : "Topics that allow to publish messages",
     "optional" : true,
     "feel" : "optional",
     "group" : "subscription",
@@ -91,6 +90,7 @@
       "equals" : "specific",
       "type" : "simple"
     },
+    "tooltip" : "Comma-separated topic ARNs that are allowed to trigger the process",
     "type" : "String"
   }, {
     "id" : "activationCondition",

--- a/connectors/aws/aws-sns/element-templates/aws-sns-outbound-connector.json
+++ b/connectors/aws/aws-sns/element-templates/aws-sns-outbound-connector.json
@@ -67,7 +67,6 @@
   }, {
     "id" : "authentication.accessKey",
     "label" : "Access key",
-    "description" : "Provide an IAM access key tailored to a user, equipped with the necessary permissions",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -83,11 +82,11 @@
       "equals" : "credentials",
       "type" : "simple"
     },
+    "tooltip" : "IAM access key of a user with the necessary permissions for this connector",
     "type" : "String"
   }, {
     "id" : "authentication.secretKey",
     "label" : "Secret key",
-    "description" : "Provide a secret key of a user with permissions to invoke specified AWS Lambda function",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -103,6 +102,7 @@
       "equals" : "credentials",
       "type" : "simple"
     },
+    "tooltip" : "IAM secret key of a user with the necessary permissions for this connector",
     "type" : "String"
   }, {
     "id" : "topic.topicArn",
@@ -117,7 +117,7 @@
       "name" : "topic.topicArn",
       "type" : "zeebe:input"
     },
-    "tooltip" : "ARN of the SNS topic to publish to.",
+    "placeholder" : "arn:aws:sns:us-east-1:123456789012:MyTopic",
     "type" : "String"
   }, {
     "id" : "topic.type",
@@ -132,7 +132,7 @@
       "name" : "topic.type",
       "type" : "zeebe:input"
     },
-    "tooltip" : "Details at <a href=\"https://aws.amazon.com/sns/features/\">AWS SNS features</a>",
+    "tooltip" : "Standard topics maximize throughput; FIFO topics preserve ordering and deduplication. See <a href=\"https://aws.amazon.com/sns/features/\" target=\"_blank\">AWS SNS features</a>",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "Standard",
@@ -144,7 +144,6 @@
   }, {
     "id" : "configuration.region",
     "label" : "Region",
-    "description" : "Specify the AWS region",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -182,7 +181,7 @@
       "equals" : "fifo",
       "type" : "simple"
     },
-    "tooltip" : "Required for FIFO topics. See <a href=\"https://docs.aws.amazon.com/sns/latest/dg/fifo-message-grouping.html\">message grouping for FIFO topics</a> in the Amazon SNS developer guide",
+    "tooltip" : "Required for FIFO topics. See <a href=\"https://docs.aws.amazon.com/sns/latest/dg/fifo-message-grouping.html\" target=\"_blank\">message grouping for FIFO topics</a> in the Amazon SNS developer guide",
     "type" : "String"
   }, {
     "id" : "topic.messageDeduplicationId",
@@ -199,7 +198,7 @@
       "equals" : "fifo",
       "type" : "simple"
     },
-    "tooltip" : "See also <a href=\"https://docs.aws.amazon.com/sns/latest/dg/fifo-message-dedup.html\">Message deduplication for FIFO topics</a> in the Amazon SNS developer guide",
+    "tooltip" : "Suppresses duplicate messages within a five-minute window. See <a href=\"https://docs.aws.amazon.com/sns/latest/dg/fifo-message-dedup.html\" target=\"_blank\">message deduplication for FIFO topics</a> in the Amazon SNS developer guide",
     "type" : "String"
   }, {
     "id" : "topic.subject",
@@ -211,7 +210,6 @@
       "name" : "topic.subject",
       "type" : "zeebe:input"
     },
-    "tooltip" : "Subject of the message to publish in the SNS topic.",
     "type" : "String"
   }, {
     "id" : "topic.message",
@@ -226,7 +224,6 @@
       "name" : "topic.message",
       "type" : "zeebe:input"
     },
-    "tooltip" : "Data to publish in the SNS topic",
     "type" : "Text"
   }, {
     "id" : "topic.messageAttributes",

--- a/connectors/aws/aws-sns/element-templates/aws-sns-outbound-connector.json
+++ b/connectors/aws/aws-sns/element-templates/aws-sns-outbound-connector.json
@@ -107,7 +107,6 @@
   }, {
     "id" : "topic.topicArn",
     "label" : "Topic ARN",
-    "description" : "Specify the topic you want to publish to",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -118,11 +117,11 @@
       "name" : "topic.topicArn",
       "type" : "zeebe:input"
     },
+    "tooltip" : "ARN of the SNS topic to publish to.",
     "type" : "String"
   }, {
     "id" : "topic.type",
     "label" : "Topic type",
-    "description" : "Select SNS topic type. Details at <a href=\"https://aws.amazon.com/sns/features/\">AWS SNS Features</a>",
     "optional" : false,
     "value" : "standard",
     "constraints" : {
@@ -133,6 +132,7 @@
       "name" : "topic.type",
       "type" : "zeebe:input"
     },
+    "tooltip" : "Details at <a href=\"https://aws.amazon.com/sns/features/\">AWS SNS features</a>",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "Standard",
@@ -170,7 +170,6 @@
   }, {
     "id" : "topic.messageGroupId",
     "label" : "Message group ID",
-    "description" : "Message group ID (FIFO only). See also <a href=\"https://docs.aws.amazon.com/sns/latest/dg/fifo-message-grouping.html\">message grouping for FIFO topics</a> in the Amazon SNS developer guide",
     "optional" : false,
     "feel" : "optional",
     "group" : "input",
@@ -183,11 +182,11 @@
       "equals" : "fifo",
       "type" : "simple"
     },
+    "tooltip" : "Required for FIFO topics. See <a href=\"https://docs.aws.amazon.com/sns/latest/dg/fifo-message-grouping.html\">message grouping for FIFO topics</a> in the Amazon SNS developer guide",
     "type" : "String"
   }, {
     "id" : "topic.messageDeduplicationId",
     "label" : "Message deduplication ID",
-    "description" : "Message deduplication ID. See also <a href=\"https://docs.aws.amazon.com/sns/latest/dg/fifo-message-dedup.html\">Message deduplication for FIFO topics</a> in the Amazon SNS developer guide",
     "optional" : true,
     "feel" : "optional",
     "group" : "input",
@@ -200,11 +199,11 @@
       "equals" : "fifo",
       "type" : "simple"
     },
+    "tooltip" : "See also <a href=\"https://docs.aws.amazon.com/sns/latest/dg/fifo-message-dedup.html\">Message deduplication for FIFO topics</a> in the Amazon SNS developer guide",
     "type" : "String"
   }, {
     "id" : "topic.subject",
     "label" : "Subject",
-    "description" : "Specify the subject of the message you want to publish in the SNS topic",
     "optional" : true,
     "feel" : "optional",
     "group" : "input",
@@ -212,11 +211,11 @@
       "name" : "topic.subject",
       "type" : "zeebe:input"
     },
+    "tooltip" : "Subject of the message to publish in the SNS topic.",
     "type" : "String"
   }, {
     "id" : "topic.message",
     "label" : "Message",
-    "description" : "Data to publish in the SNS topic",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -227,11 +226,11 @@
       "name" : "topic.message",
       "type" : "zeebe:input"
     },
+    "tooltip" : "Data to publish in the SNS topic",
     "type" : "Text"
   }, {
     "id" : "topic.messageAttributes",
     "label" : "messageAttributes",
-    "description" : "Message attributes metadata",
     "optional" : true,
     "feel" : "required",
     "group" : "input",

--- a/connectors/aws/aws-sns/element-templates/hybrid/aws-sns-inbound-boundary-hybrid.json
+++ b/connectors/aws/aws-sns/element-templates/hybrid/aws-sns-inbound-boundary-hybrid.json
@@ -96,7 +96,8 @@
       "equals" : "specific",
       "type" : "simple"
     },
-    "tooltip" : "Comma-separated topic ARNs that are allowed to trigger the process",
+    "tooltip" : "Topic ARNs that are allowed to trigger the process, comma-separated",
+    "placeholder" : "arn:aws:sns:us-east-1:123456789012:Topic1,arn:aws:sns:us-east-1:123456789012:Topic2",
     "type" : "String"
   }, {
     "id" : "activationCondition",

--- a/connectors/aws/aws-sns/element-templates/hybrid/aws-sns-inbound-boundary-hybrid.json
+++ b/connectors/aws/aws-sns/element-templates/hybrid/aws-sns-inbound-boundary-hybrid.json
@@ -51,7 +51,6 @@
   }, {
     "id" : "inbound.context",
     "label" : "Subscription ID",
-    "description" : "The subscription ID is a part of the URL endpoint",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -61,11 +60,11 @@
       "name" : "inbound.context",
       "type" : "zeebe:property"
     },
+    "tooltip" : "The subscription ID is a part of the URL endpoint",
     "type" : "String"
   }, {
     "id" : "inbound.securitySubscriptionAllowedFor",
     "label" : "Allow to receive messages from topic(s)",
-    "description" : "Control which topic(s) is allowed to start a process",
     "optional" : false,
     "value" : "any",
     "group" : "subscription",
@@ -73,6 +72,7 @@
       "name" : "inbound.securitySubscriptionAllowedFor",
       "type" : "zeebe:property"
     },
+    "tooltip" : "Control which topic(s) are allowed to start a process",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "Any",
@@ -84,7 +84,6 @@
   }, {
     "id" : "inbound.topicsAllowList",
     "label" : "Topic ARN(s)",
-    "description" : "Topics that allow to publish messages",
     "optional" : true,
     "feel" : "optional",
     "group" : "subscription",
@@ -97,6 +96,7 @@
       "equals" : "specific",
       "type" : "simple"
     },
+    "tooltip" : "Comma-separated topic ARNs that are allowed to trigger the process",
     "type" : "String"
   }, {
     "id" : "activationCondition",

--- a/connectors/aws/aws-sns/element-templates/hybrid/aws-sns-inbound-intermediate-hybrid.json
+++ b/connectors/aws/aws-sns/element-templates/hybrid/aws-sns-inbound-intermediate-hybrid.json
@@ -96,7 +96,8 @@
       "equals" : "specific",
       "type" : "simple"
     },
-    "tooltip" : "Comma-separated topic ARNs that are allowed to trigger the process",
+    "tooltip" : "Topic ARNs that are allowed to trigger the process, comma-separated",
+    "placeholder" : "arn:aws:sns:us-east-1:123456789012:Topic1,arn:aws:sns:us-east-1:123456789012:Topic2",
     "type" : "String"
   }, {
     "id" : "activationCondition",

--- a/connectors/aws/aws-sns/element-templates/hybrid/aws-sns-inbound-intermediate-hybrid.json
+++ b/connectors/aws/aws-sns/element-templates/hybrid/aws-sns-inbound-intermediate-hybrid.json
@@ -51,7 +51,6 @@
   }, {
     "id" : "inbound.context",
     "label" : "Subscription ID",
-    "description" : "The subscription ID is a part of the URL endpoint",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -61,11 +60,11 @@
       "name" : "inbound.context",
       "type" : "zeebe:property"
     },
+    "tooltip" : "The subscription ID is a part of the URL endpoint",
     "type" : "String"
   }, {
     "id" : "inbound.securitySubscriptionAllowedFor",
     "label" : "Allow to receive messages from topic(s)",
-    "description" : "Control which topic(s) is allowed to start a process",
     "optional" : false,
     "value" : "any",
     "group" : "subscription",
@@ -73,6 +72,7 @@
       "name" : "inbound.securitySubscriptionAllowedFor",
       "type" : "zeebe:property"
     },
+    "tooltip" : "Control which topic(s) are allowed to start a process",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "Any",
@@ -84,7 +84,6 @@
   }, {
     "id" : "inbound.topicsAllowList",
     "label" : "Topic ARN(s)",
-    "description" : "Topics that allow to publish messages",
     "optional" : true,
     "feel" : "optional",
     "group" : "subscription",
@@ -97,6 +96,7 @@
       "equals" : "specific",
       "type" : "simple"
     },
+    "tooltip" : "Comma-separated topic ARNs that are allowed to trigger the process",
     "type" : "String"
   }, {
     "id" : "activationCondition",

--- a/connectors/aws/aws-sns/element-templates/hybrid/aws-sns-inbound-message-start-hybrid.json
+++ b/connectors/aws/aws-sns/element-templates/hybrid/aws-sns-inbound-message-start-hybrid.json
@@ -96,7 +96,8 @@
       "equals" : "specific",
       "type" : "simple"
     },
-    "tooltip" : "Comma-separated topic ARNs that are allowed to trigger the process",
+    "tooltip" : "Topic ARNs that are allowed to trigger the process, comma-separated",
+    "placeholder" : "arn:aws:sns:us-east-1:123456789012:Topic1,arn:aws:sns:us-east-1:123456789012:Topic2",
     "type" : "String"
   }, {
     "id" : "activationCondition",

--- a/connectors/aws/aws-sns/element-templates/hybrid/aws-sns-inbound-message-start-hybrid.json
+++ b/connectors/aws/aws-sns/element-templates/hybrid/aws-sns-inbound-message-start-hybrid.json
@@ -51,7 +51,6 @@
   }, {
     "id" : "inbound.context",
     "label" : "Subscription ID",
-    "description" : "The subscription ID is a part of the URL endpoint",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -61,11 +60,11 @@
       "name" : "inbound.context",
       "type" : "zeebe:property"
     },
+    "tooltip" : "The subscription ID is a part of the URL endpoint",
     "type" : "String"
   }, {
     "id" : "inbound.securitySubscriptionAllowedFor",
     "label" : "Allow to receive messages from topic(s)",
-    "description" : "Control which topic(s) is allowed to start a process",
     "optional" : false,
     "value" : "any",
     "group" : "subscription",
@@ -73,6 +72,7 @@
       "name" : "inbound.securitySubscriptionAllowedFor",
       "type" : "zeebe:property"
     },
+    "tooltip" : "Control which topic(s) are allowed to start a process",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "Any",
@@ -84,7 +84,6 @@
   }, {
     "id" : "inbound.topicsAllowList",
     "label" : "Topic ARN(s)",
-    "description" : "Topics that allow to publish messages",
     "optional" : true,
     "feel" : "optional",
     "group" : "subscription",
@@ -97,6 +96,7 @@
       "equals" : "specific",
       "type" : "simple"
     },
+    "tooltip" : "Comma-separated topic ARNs that are allowed to trigger the process",
     "type" : "String"
   }, {
     "id" : "activationCondition",

--- a/connectors/aws/aws-sns/element-templates/hybrid/aws-sns-inbound-receive-hybrid.json
+++ b/connectors/aws/aws-sns/element-templates/hybrid/aws-sns-inbound-receive-hybrid.json
@@ -95,7 +95,8 @@
       "equals" : "specific",
       "type" : "simple"
     },
-    "tooltip" : "Comma-separated topic ARNs that are allowed to trigger the process",
+    "tooltip" : "Topic ARNs that are allowed to trigger the process, comma-separated",
+    "placeholder" : "arn:aws:sns:us-east-1:123456789012:Topic1,arn:aws:sns:us-east-1:123456789012:Topic2",
     "type" : "String"
   }, {
     "id" : "activationCondition",

--- a/connectors/aws/aws-sns/element-templates/hybrid/aws-sns-inbound-receive-hybrid.json
+++ b/connectors/aws/aws-sns/element-templates/hybrid/aws-sns-inbound-receive-hybrid.json
@@ -50,7 +50,6 @@
   }, {
     "id" : "inbound.context",
     "label" : "Subscription ID",
-    "description" : "The subscription ID is a part of the URL endpoint",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -60,11 +59,11 @@
       "name" : "inbound.context",
       "type" : "zeebe:property"
     },
+    "tooltip" : "The subscription ID is a part of the URL endpoint",
     "type" : "String"
   }, {
     "id" : "inbound.securitySubscriptionAllowedFor",
     "label" : "Allow to receive messages from topic(s)",
-    "description" : "Control which topic(s) is allowed to start a process",
     "optional" : false,
     "value" : "any",
     "group" : "subscription",
@@ -72,6 +71,7 @@
       "name" : "inbound.securitySubscriptionAllowedFor",
       "type" : "zeebe:property"
     },
+    "tooltip" : "Control which topic(s) are allowed to start a process",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "Any",
@@ -83,7 +83,6 @@
   }, {
     "id" : "inbound.topicsAllowList",
     "label" : "Topic ARN(s)",
-    "description" : "Topics that allow to publish messages",
     "optional" : true,
     "feel" : "optional",
     "group" : "subscription",
@@ -96,6 +95,7 @@
       "equals" : "specific",
       "type" : "simple"
     },
+    "tooltip" : "Comma-separated topic ARNs that are allowed to trigger the process",
     "type" : "String"
   }, {
     "id" : "activationCondition",

--- a/connectors/aws/aws-sns/element-templates/hybrid/aws-sns-outbound-connector-hybrid.json
+++ b/connectors/aws/aws-sns/element-templates/hybrid/aws-sns-outbound-connector-hybrid.json
@@ -112,7 +112,6 @@
   }, {
     "id" : "topic.topicArn",
     "label" : "Topic ARN",
-    "description" : "Specify the topic you want to publish to",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -123,11 +122,11 @@
       "name" : "topic.topicArn",
       "type" : "zeebe:input"
     },
+    "tooltip" : "ARN of the SNS topic to publish to.",
     "type" : "String"
   }, {
     "id" : "topic.type",
     "label" : "Topic type",
-    "description" : "Select SNS topic type. Details at <a href=\"https://aws.amazon.com/sns/features/\">AWS SNS Features</a>",
     "optional" : false,
     "value" : "standard",
     "constraints" : {
@@ -138,6 +137,7 @@
       "name" : "topic.type",
       "type" : "zeebe:input"
     },
+    "tooltip" : "Details at <a href=\"https://aws.amazon.com/sns/features/\">AWS SNS features</a>",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "Standard",
@@ -175,7 +175,6 @@
   }, {
     "id" : "topic.messageGroupId",
     "label" : "Message group ID",
-    "description" : "Message group ID (FIFO only). See also <a href=\"https://docs.aws.amazon.com/sns/latest/dg/fifo-message-grouping.html\">message grouping for FIFO topics</a> in the Amazon SNS developer guide",
     "optional" : false,
     "feel" : "optional",
     "group" : "input",
@@ -188,11 +187,11 @@
       "equals" : "fifo",
       "type" : "simple"
     },
+    "tooltip" : "Required for FIFO topics. See <a href=\"https://docs.aws.amazon.com/sns/latest/dg/fifo-message-grouping.html\">message grouping for FIFO topics</a> in the Amazon SNS developer guide",
     "type" : "String"
   }, {
     "id" : "topic.messageDeduplicationId",
     "label" : "Message deduplication ID",
-    "description" : "Message deduplication ID. See also <a href=\"https://docs.aws.amazon.com/sns/latest/dg/fifo-message-dedup.html\">Message deduplication for FIFO topics</a> in the Amazon SNS developer guide",
     "optional" : true,
     "feel" : "optional",
     "group" : "input",
@@ -205,11 +204,11 @@
       "equals" : "fifo",
       "type" : "simple"
     },
+    "tooltip" : "See also <a href=\"https://docs.aws.amazon.com/sns/latest/dg/fifo-message-dedup.html\">Message deduplication for FIFO topics</a> in the Amazon SNS developer guide",
     "type" : "String"
   }, {
     "id" : "topic.subject",
     "label" : "Subject",
-    "description" : "Specify the subject of the message you want to publish in the SNS topic",
     "optional" : true,
     "feel" : "optional",
     "group" : "input",
@@ -217,11 +216,11 @@
       "name" : "topic.subject",
       "type" : "zeebe:input"
     },
+    "tooltip" : "Subject of the message to publish in the SNS topic.",
     "type" : "String"
   }, {
     "id" : "topic.message",
     "label" : "Message",
-    "description" : "Data to publish in the SNS topic",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -232,11 +231,11 @@
       "name" : "topic.message",
       "type" : "zeebe:input"
     },
+    "tooltip" : "Data to publish in the SNS topic",
     "type" : "Text"
   }, {
     "id" : "topic.messageAttributes",
     "label" : "messageAttributes",
-    "description" : "Message attributes metadata",
     "optional" : true,
     "feel" : "required",
     "group" : "input",

--- a/connectors/aws/aws-sns/element-templates/hybrid/aws-sns-outbound-connector-hybrid.json
+++ b/connectors/aws/aws-sns/element-templates/hybrid/aws-sns-outbound-connector-hybrid.json
@@ -72,7 +72,6 @@
   }, {
     "id" : "authentication.accessKey",
     "label" : "Access key",
-    "description" : "Provide an IAM access key tailored to a user, equipped with the necessary permissions",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -88,11 +87,11 @@
       "equals" : "credentials",
       "type" : "simple"
     },
+    "tooltip" : "IAM access key of a user with the necessary permissions for this connector",
     "type" : "String"
   }, {
     "id" : "authentication.secretKey",
     "label" : "Secret key",
-    "description" : "Provide a secret key of a user with permissions to invoke specified AWS Lambda function",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -108,6 +107,7 @@
       "equals" : "credentials",
       "type" : "simple"
     },
+    "tooltip" : "IAM secret key of a user with the necessary permissions for this connector",
     "type" : "String"
   }, {
     "id" : "topic.topicArn",
@@ -122,7 +122,7 @@
       "name" : "topic.topicArn",
       "type" : "zeebe:input"
     },
-    "tooltip" : "ARN of the SNS topic to publish to.",
+    "placeholder" : "arn:aws:sns:us-east-1:123456789012:MyTopic",
     "type" : "String"
   }, {
     "id" : "topic.type",
@@ -137,7 +137,7 @@
       "name" : "topic.type",
       "type" : "zeebe:input"
     },
-    "tooltip" : "Details at <a href=\"https://aws.amazon.com/sns/features/\">AWS SNS features</a>",
+    "tooltip" : "Standard topics maximize throughput; FIFO topics preserve ordering and deduplication. See <a href=\"https://aws.amazon.com/sns/features/\" target=\"_blank\">AWS SNS features</a>",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "Standard",
@@ -149,7 +149,6 @@
   }, {
     "id" : "configuration.region",
     "label" : "Region",
-    "description" : "Specify the AWS region",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -187,7 +186,7 @@
       "equals" : "fifo",
       "type" : "simple"
     },
-    "tooltip" : "Required for FIFO topics. See <a href=\"https://docs.aws.amazon.com/sns/latest/dg/fifo-message-grouping.html\">message grouping for FIFO topics</a> in the Amazon SNS developer guide",
+    "tooltip" : "Required for FIFO topics. See <a href=\"https://docs.aws.amazon.com/sns/latest/dg/fifo-message-grouping.html\" target=\"_blank\">message grouping for FIFO topics</a> in the Amazon SNS developer guide",
     "type" : "String"
   }, {
     "id" : "topic.messageDeduplicationId",
@@ -204,7 +203,7 @@
       "equals" : "fifo",
       "type" : "simple"
     },
-    "tooltip" : "See also <a href=\"https://docs.aws.amazon.com/sns/latest/dg/fifo-message-dedup.html\">Message deduplication for FIFO topics</a> in the Amazon SNS developer guide",
+    "tooltip" : "Suppresses duplicate messages within a five-minute window. See <a href=\"https://docs.aws.amazon.com/sns/latest/dg/fifo-message-dedup.html\" target=\"_blank\">message deduplication for FIFO topics</a> in the Amazon SNS developer guide",
     "type" : "String"
   }, {
     "id" : "topic.subject",
@@ -216,7 +215,6 @@
       "name" : "topic.subject",
       "type" : "zeebe:input"
     },
-    "tooltip" : "Subject of the message to publish in the SNS topic.",
     "type" : "String"
   }, {
     "id" : "topic.message",
@@ -231,7 +229,6 @@
       "name" : "topic.message",
       "type" : "zeebe:input"
     },
-    "tooltip" : "Data to publish in the SNS topic",
     "type" : "Text"
   }, {
     "id" : "topic.messageAttributes",

--- a/connectors/aws/aws-sns/src/main/java/io/camunda/connector/sns/inbound/model/SnsWebhookConnectorProperties.java
+++ b/connectors/aws/aws-sns/src/main/java/io/camunda/connector/sns/inbound/model/SnsWebhookConnectorProperties.java
@@ -22,7 +22,7 @@ public record SnsWebhookConnectorProperties(
             id = "context",
             label = "Subscription ID",
             group = "subscription",
-            description = "The subscription ID is a part of the URL endpoint",
+            tooltip = "The subscription ID is a part of the URL endpoint",
             feel = FeelMode.disabled)
         @NotBlank
         String context,
@@ -30,7 +30,7 @@ public record SnsWebhookConnectorProperties(
             id = "securitySubscriptionAllowedFor",
             label = "Allow to receive messages from topic(s)",
             group = "subscription",
-            description = "Control which topic(s) is allowed to start a process",
+            tooltip = "Control which topic(s) are allowed to start a process",
             defaultValue = "any",
             type = PropertyType.Dropdown,
             choices = {
@@ -42,7 +42,7 @@ public record SnsWebhookConnectorProperties(
             id = "topicsAllowList",
             label = "Topic ARN(s)",
             group = "subscription",
-            description = "Topics that allow to publish messages",
+            tooltip = "Comma-separated topic ARNs that are allowed to trigger the process",
             optional = true,
             condition =
                 @PropertyCondition(

--- a/connectors/aws/aws-sns/src/main/java/io/camunda/connector/sns/inbound/model/SnsWebhookConnectorProperties.java
+++ b/connectors/aws/aws-sns/src/main/java/io/camunda/connector/sns/inbound/model/SnsWebhookConnectorProperties.java
@@ -42,7 +42,9 @@ public record SnsWebhookConnectorProperties(
             id = "topicsAllowList",
             label = "Topic ARN(s)",
             group = "subscription",
-            tooltip = "Comma-separated topic ARNs that are allowed to trigger the process",
+            tooltip = "Topic ARNs that are allowed to trigger the process, comma-separated",
+            placeholder =
+                "arn:aws:sns:us-east-1:123456789012:Topic1,arn:aws:sns:us-east-1:123456789012:Topic2",
             optional = true,
             condition =
                 @PropertyCondition(

--- a/connectors/aws/aws-sns/src/main/java/io/camunda/connector/sns/outbound/model/TopicRequestData.java
+++ b/connectors/aws/aws-sns/src/main/java/io/camunda/connector/sns/outbound/model/TopicRequestData.java
@@ -24,7 +24,7 @@ public class TopicRequestData {
   @TemplateProperty(
       group = "configuration",
       label = "Topic ARN",
-      tooltip = "ARN of the SNS topic to publish to.")
+      placeholder = "arn:aws:sns:us-east-1:123456789012:MyTopic")
   @NotBlank
   private String topicArn;
 
@@ -41,7 +41,8 @@ public class TopicRequestData {
         @TemplateProperty.DropdownPropertyChoice(value = "standard", label = "Standard"),
         @TemplateProperty.DropdownPropertyChoice(value = "fifo", label = "FIFO")
       },
-      tooltip = "Details at <a href=\"https://aws.amazon.com/sns/features/\">AWS SNS features</a>")
+      tooltip =
+          "Standard topics maximize throughput; FIFO topics preserve ordering and deduplication. See <a href=\"https://aws.amazon.com/sns/features/\" target=\"_blank\">AWS SNS features</a>")
   @NotNull
   private TopicType type = TopicType.standard;
 
@@ -50,7 +51,7 @@ public class TopicRequestData {
       label = "Message group ID",
       condition = @TemplateProperty.PropertyCondition(property = "topic.type", equals = "fifo"),
       tooltip =
-          "Required for FIFO topics. See <a href=\"https://docs.aws.amazon.com/sns/latest/dg/fifo-message-grouping.html\">message grouping for FIFO topics</a> in the Amazon SNS developer guide")
+          "Required for FIFO topics. See <a href=\"https://docs.aws.amazon.com/sns/latest/dg/fifo-message-grouping.html\" target=\"_blank\">message grouping for FIFO topics</a> in the Amazon SNS developer guide")
   private String messageGroupId;
 
   @TemplateProperty(
@@ -59,22 +60,14 @@ public class TopicRequestData {
       condition = @TemplateProperty.PropertyCondition(property = "topic.type", equals = "fifo"),
       optional = true,
       tooltip =
-          "See also <a href=\"https://docs.aws.amazon.com/sns/latest/dg/fifo-message-dedup.html\">Message deduplication for FIFO topics</a> in the Amazon SNS developer guide")
+          "Suppresses duplicate messages within a five-minute window. See <a href=\"https://docs.aws.amazon.com/sns/latest/dg/fifo-message-dedup.html\" target=\"_blank\">message deduplication for FIFO topics</a> in the Amazon SNS developer guide")
   private String messageDeduplicationId;
 
-  @TemplateProperty(
-      group = "input",
-      label = "Subject",
-      optional = true,
-      tooltip = "Subject of the message to publish in the SNS topic.")
+  @TemplateProperty(group = "input", label = "Subject", optional = true)
   private String subject;
 
   // we don't need to know the customer message as we will pass it as-is
-  @TemplateProperty(
-      group = "input",
-      label = "Message",
-      type = TemplateProperty.PropertyType.Text,
-      tooltip = "Data to publish in the SNS topic")
+  @TemplateProperty(group = "input", label = "Message", type = TemplateProperty.PropertyType.Text)
   @NotNull
   private Object message;
 

--- a/connectors/aws/aws-sns/src/main/java/io/camunda/connector/sns/outbound/model/TopicRequestData.java
+++ b/connectors/aws/aws-sns/src/main/java/io/camunda/connector/sns/outbound/model/TopicRequestData.java
@@ -24,7 +24,7 @@ public class TopicRequestData {
   @TemplateProperty(
       group = "configuration",
       label = "Topic ARN",
-      description = "Specify the topic you want to publish to")
+      tooltip = "ARN of the SNS topic to publish to.")
   @NotBlank
   private String topicArn;
 
@@ -41,8 +41,7 @@ public class TopicRequestData {
         @TemplateProperty.DropdownPropertyChoice(value = "standard", label = "Standard"),
         @TemplateProperty.DropdownPropertyChoice(value = "fifo", label = "FIFO")
       },
-      description =
-          "Select SNS topic type. Details at <a href=\"https://aws.amazon.com/sns/features/\">AWS SNS Features</a>")
+      tooltip = "Details at <a href=\"https://aws.amazon.com/sns/features/\">AWS SNS features</a>")
   @NotNull
   private TopicType type = TopicType.standard;
 
@@ -50,8 +49,8 @@ public class TopicRequestData {
       group = "input",
       label = "Message group ID",
       condition = @TemplateProperty.PropertyCondition(property = "topic.type", equals = "fifo"),
-      description =
-          "Message group ID (FIFO only). See also <a href=\"https://docs.aws.amazon.com/sns/latest/dg/fifo-message-grouping.html\">message grouping for FIFO topics</a> in the Amazon SNS developer guide")
+      tooltip =
+          "Required for FIFO topics. See <a href=\"https://docs.aws.amazon.com/sns/latest/dg/fifo-message-grouping.html\">message grouping for FIFO topics</a> in the Amazon SNS developer guide")
   private String messageGroupId;
 
   @TemplateProperty(
@@ -59,15 +58,15 @@ public class TopicRequestData {
       label = "Message deduplication ID",
       condition = @TemplateProperty.PropertyCondition(property = "topic.type", equals = "fifo"),
       optional = true,
-      description =
-          "Message deduplication ID. See also <a href=\"https://docs.aws.amazon.com/sns/latest/dg/fifo-message-dedup.html\">Message deduplication for FIFO topics</a> in the Amazon SNS developer guide")
+      tooltip =
+          "See also <a href=\"https://docs.aws.amazon.com/sns/latest/dg/fifo-message-dedup.html\">Message deduplication for FIFO topics</a> in the Amazon SNS developer guide")
   private String messageDeduplicationId;
 
   @TemplateProperty(
       group = "input",
       label = "Subject",
       optional = true,
-      description = "Specify the subject of the message you want to publish in the SNS topic")
+      tooltip = "Subject of the message to publish in the SNS topic.")
   private String subject;
 
   // we don't need to know the customer message as we will pass it as-is
@@ -75,7 +74,7 @@ public class TopicRequestData {
       group = "input",
       label = "Message",
       type = TemplateProperty.PropertyType.Text,
-      description = "Data to publish in the SNS topic")
+      tooltip = "Data to publish in the SNS topic")
   @NotNull
   private Object message;
 
@@ -84,8 +83,7 @@ public class TopicRequestData {
       group = "input",
       feel = FeelMode.required,
       label = "messageAttributes",
-      optional = true,
-      description = "Message attributes metadata")
+      optional = true)
   private Map<String, SnsMessageAttribute> messageAttributes;
 
   @AssertTrue

--- a/connectors/aws/aws-sqs/element-templates/aws-sqs-boundary-connector.json
+++ b/connectors/aws/aws-sqs/element-templates/aws-sqs-boundary-connector.json
@@ -139,7 +139,6 @@
   }, {
     "id" : "queue.queue.url",
     "label" : "Queue URL",
-    "description" : "Specify the URL of the SQS queue where you would like to subscribe to",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -149,11 +148,11 @@
       "name" : "queue.url",
       "type" : "zeebe:property"
     },
+    "tooltip" : "URL of the SQS queue to subscribe to.",
     "type" : "String"
   }, {
     "id" : "queue.queue.pollingWaitTime",
     "label" : "Polling wait time",
-    "description" : "The duration (in seconds) for which the call waits for a message to arrive in the queue before returning. See <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-sqs/?amazonsqs=inbound\" target=\"_blank\">documentation</a> for details. A value of 0 will automatically be overridden to 1",
     "optional" : false,
     "value" : "20",
     "constraints" : {
@@ -167,11 +166,11 @@
       "name" : "queue.pollingWaitTime",
       "type" : "zeebe:property"
     },
+    "tooltip" : "The duration (in seconds) for which the call waits for a message to arrive in the queue before returning. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-sqs/?amazonsqs=inbound\" target=\"_blank\">Amazon SQS connector guide</a>. A value of 0 will automatically be overridden to 1.",
     "type" : "String"
   }, {
     "id" : "queue.queue.attributeNames",
     "label" : "Attribute names",
-    "description" : "Array of queue attribute names. See <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-sqs/?amazonsqs=inbound\" target=\"_blank\">documentation</a> for details",
     "optional" : false,
     "feel" : "optional",
     "group" : "input",
@@ -179,11 +178,11 @@
       "name" : "queue.attributeNames",
       "type" : "zeebe:property"
     },
+    "tooltip" : "Array of queue attribute names. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-sqs/?amazonsqs=inbound\" target=\"_blank\">Amazon SQS connector guide</a>.",
     "type" : "String"
   }, {
     "id" : "queue.queue.messageAttributeNames",
     "label" : "Message attribute names",
-    "description" : "Array of message attribute names. See <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-sqs/?amazonsqs=inbound\" target=\"_blank\">documentation</a> for details",
     "optional" : false,
     "feel" : "optional",
     "group" : "input",
@@ -191,6 +190,7 @@
       "name" : "queue.messageAttributeNames",
       "type" : "zeebe:property"
     },
+    "tooltip" : "Array of message attribute names. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-sqs/?amazonsqs=inbound\" target=\"_blank\">Amazon SQS connector guide</a>.",
     "type" : "String"
   }, {
     "id" : "activationCondition",

--- a/connectors/aws/aws-sqs/element-templates/aws-sqs-boundary-connector.json
+++ b/connectors/aws/aws-sqs/element-templates/aws-sqs-boundary-connector.json
@@ -76,7 +76,6 @@
   }, {
     "id" : "authentication.accessKey",
     "label" : "Access key",
-    "description" : "Provide an IAM access key tailored to a user, equipped with the necessary permissions",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -91,11 +90,11 @@
       "equals" : "credentials",
       "type" : "simple"
     },
+    "tooltip" : "IAM access key of a user with the necessary permissions for this connector",
     "type" : "String"
   }, {
     "id" : "authentication.secretKey",
     "label" : "Secret key",
-    "description" : "Provide a secret key of a user with permissions to invoke specified AWS Lambda function",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -110,11 +109,11 @@
       "equals" : "credentials",
       "type" : "simple"
     },
+    "tooltip" : "IAM secret key of a user with the necessary permissions for this connector",
     "type" : "String"
   }, {
     "id" : "configuration.region",
     "label" : "Region",
-    "description" : "Specify the AWS region",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -166,7 +165,7 @@
       "name" : "queue.pollingWaitTime",
       "type" : "zeebe:property"
     },
-    "tooltip" : "The duration (in seconds) for which the call waits for a message to arrive in the queue before returning. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-sqs/?amazonsqs=inbound\" target=\"_blank\">Amazon SQS connector guide</a>. A value of 0 will automatically be overridden to 1.",
+    "tooltip" : "The duration (in seconds) for which the call waits for a message to arrive in the queue before returning. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-sqs/?amazonsqs=inbound\" target=\"_blank\">Amazon SQS connector guide</a>. A value of 0 is automatically overridden to 1.",
     "type" : "String"
   }, {
     "id" : "queue.queue.attributeNames",

--- a/connectors/aws/aws-sqs/element-templates/aws-sqs-inbound-intermediate-connector.json
+++ b/connectors/aws/aws-sqs/element-templates/aws-sqs-inbound-intermediate-connector.json
@@ -139,7 +139,6 @@
   }, {
     "id" : "queue.queue.url",
     "label" : "Queue URL",
-    "description" : "Specify the URL of the SQS queue where you would like to subscribe to",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -149,11 +148,11 @@
       "name" : "queue.url",
       "type" : "zeebe:property"
     },
+    "tooltip" : "URL of the SQS queue to subscribe to.",
     "type" : "String"
   }, {
     "id" : "queue.queue.pollingWaitTime",
     "label" : "Polling wait time",
-    "description" : "The duration (in seconds) for which the call waits for a message to arrive in the queue before returning. See <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-sqs/?amazonsqs=inbound\" target=\"_blank\">documentation</a> for details. A value of 0 will automatically be overridden to 1",
     "optional" : false,
     "value" : "20",
     "constraints" : {
@@ -167,11 +166,11 @@
       "name" : "queue.pollingWaitTime",
       "type" : "zeebe:property"
     },
+    "tooltip" : "The duration (in seconds) for which the call waits for a message to arrive in the queue before returning. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-sqs/?amazonsqs=inbound\" target=\"_blank\">Amazon SQS connector guide</a>. A value of 0 will automatically be overridden to 1.",
     "type" : "String"
   }, {
     "id" : "queue.queue.attributeNames",
     "label" : "Attribute names",
-    "description" : "Array of queue attribute names. See <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-sqs/?amazonsqs=inbound\" target=\"_blank\">documentation</a> for details",
     "optional" : false,
     "feel" : "optional",
     "group" : "input",
@@ -179,11 +178,11 @@
       "name" : "queue.attributeNames",
       "type" : "zeebe:property"
     },
+    "tooltip" : "Array of queue attribute names. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-sqs/?amazonsqs=inbound\" target=\"_blank\">Amazon SQS connector guide</a>.",
     "type" : "String"
   }, {
     "id" : "queue.queue.messageAttributeNames",
     "label" : "Message attribute names",
-    "description" : "Array of message attribute names. See <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-sqs/?amazonsqs=inbound\" target=\"_blank\">documentation</a> for details",
     "optional" : false,
     "feel" : "optional",
     "group" : "input",
@@ -191,6 +190,7 @@
       "name" : "queue.messageAttributeNames",
       "type" : "zeebe:property"
     },
+    "tooltip" : "Array of message attribute names. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-sqs/?amazonsqs=inbound\" target=\"_blank\">Amazon SQS connector guide</a>.",
     "type" : "String"
   }, {
     "id" : "activationCondition",

--- a/connectors/aws/aws-sqs/element-templates/aws-sqs-inbound-intermediate-connector.json
+++ b/connectors/aws/aws-sqs/element-templates/aws-sqs-inbound-intermediate-connector.json
@@ -76,7 +76,6 @@
   }, {
     "id" : "authentication.accessKey",
     "label" : "Access key",
-    "description" : "Provide an IAM access key tailored to a user, equipped with the necessary permissions",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -91,11 +90,11 @@
       "equals" : "credentials",
       "type" : "simple"
     },
+    "tooltip" : "IAM access key of a user with the necessary permissions for this connector",
     "type" : "String"
   }, {
     "id" : "authentication.secretKey",
     "label" : "Secret key",
-    "description" : "Provide a secret key of a user with permissions to invoke specified AWS Lambda function",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -110,11 +109,11 @@
       "equals" : "credentials",
       "type" : "simple"
     },
+    "tooltip" : "IAM secret key of a user with the necessary permissions for this connector",
     "type" : "String"
   }, {
     "id" : "configuration.region",
     "label" : "Region",
-    "description" : "Specify the AWS region",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -166,7 +165,7 @@
       "name" : "queue.pollingWaitTime",
       "type" : "zeebe:property"
     },
-    "tooltip" : "The duration (in seconds) for which the call waits for a message to arrive in the queue before returning. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-sqs/?amazonsqs=inbound\" target=\"_blank\">Amazon SQS connector guide</a>. A value of 0 will automatically be overridden to 1.",
+    "tooltip" : "The duration (in seconds) for which the call waits for a message to arrive in the queue before returning. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-sqs/?amazonsqs=inbound\" target=\"_blank\">Amazon SQS connector guide</a>. A value of 0 is automatically overridden to 1.",
     "type" : "String"
   }, {
     "id" : "queue.queue.attributeNames",

--- a/connectors/aws/aws-sqs/element-templates/aws-sqs-outbound-connector.json
+++ b/connectors/aws/aws-sqs/element-templates/aws-sqs-outbound-connector.json
@@ -67,7 +67,6 @@
   }, {
     "id" : "authentication.accessKey",
     "label" : "Access key",
-    "description" : "Provide an IAM access key tailored to a user, equipped with the necessary permissions",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -83,11 +82,11 @@
       "equals" : "credentials",
       "type" : "simple"
     },
+    "tooltip" : "IAM access key of a user with the necessary permissions for this connector",
     "type" : "String"
   }, {
     "id" : "authentication.secretKey",
     "label" : "Secret key",
-    "description" : "Provide a secret key of a user with permissions to invoke specified AWS Lambda function",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -103,6 +102,7 @@
       "equals" : "credentials",
       "type" : "simple"
     },
+    "tooltip" : "IAM secret key of a user with the necessary permissions for this connector",
     "type" : "String"
   }, {
     "id" : "queue.url",
@@ -144,7 +144,6 @@
   }, {
     "id" : "configuration.region",
     "label" : "Region",
-    "description" : "Specify the AWS region",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -192,6 +191,7 @@
       "name" : "queue.messageAttributes",
       "type" : "zeebe:input"
     },
+    "tooltip" : "Optional message metadata as a map keyed by attribute name, each value having a StringValue and DataType, following the <a href=\"https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-message-metadata.html#sqs-message-attributes\" target=\"_blank\">SQS message attribute format</a>.",
     "type" : "Text"
   }, {
     "id" : "queue.messageGroupId",

--- a/connectors/aws/aws-sqs/element-templates/aws-sqs-outbound-connector.json
+++ b/connectors/aws/aws-sqs/element-templates/aws-sqs-outbound-connector.json
@@ -107,7 +107,6 @@
   }, {
     "id" : "queue.url",
     "label" : "URL",
-    "description" : "Specify the URL of the SQS queue where you would like to send message to",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -118,11 +117,11 @@
       "name" : "queue.url",
       "type" : "zeebe:input"
     },
+    "tooltip" : "URL of the SQS queue to send the message to.",
     "type" : "String"
   }, {
     "id" : "queue.type",
     "label" : "Queue type",
-    "description" : "Specify whether the queue is a <a href=\"https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/standard-queues.html\">standard</a> or <a href=\"https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/FIFO-queues.html\">FIFO</a> queue",
     "optional" : false,
     "value" : "standard",
     "constraints" : {
@@ -133,6 +132,7 @@
       "name" : "queue.type",
       "type" : "zeebe:input"
     },
+    "tooltip" : "Whether the queue is a <a href=\"https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/standard-queues.html\">standard</a> or <a href=\"https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/FIFO-queues.html\">FIFO</a> queue.",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "Standard",
@@ -170,7 +170,6 @@
   }, {
     "id" : "queue.messageBody",
     "label" : "Message body",
-    "description" : "Data to send to the SQS queue",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -181,11 +180,11 @@
       "name" : "queue.messageBody",
       "type" : "zeebe:input"
     },
+    "tooltip" : "Data to send to the SQS queue",
     "type" : "Text"
   }, {
     "id" : "queue.messageAttributes",
     "label" : "Message attributes",
-    "description" : "Message attributes metadata",
     "optional" : true,
     "feel" : "required",
     "group" : "input",
@@ -197,7 +196,6 @@
   }, {
     "id" : "queue.messageGroupId",
     "label" : "Message group ID",
-    "description" : "Message group ID (FIFO only). See also <a href=\"https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/using-messagegroupid-property.html\">using the MessageGroupId Property</a> in the Amazon SQS developer guide",
     "optional" : false,
     "feel" : "optional",
     "group" : "input",
@@ -210,11 +208,11 @@
       "equals" : "fifo",
       "type" : "simple"
     },
+    "tooltip" : "FIFO only. See <a href=\"https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/using-messagegroupid-property.html\">MessageGroupId property</a> in the Amazon SQS developer guide.",
     "type" : "String"
   }, {
     "id" : "queue.messageDeduplicationId",
     "label" : "Message deduplication ID",
-    "description" : "Message deduplication ID (FIFO only). See also <a href=\"https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/using-messagededuplicationid-property.html\">using the MessageDeduplicationId Property</a> in the Amazon SQS developer guide",
     "optional" : true,
     "feel" : "optional",
     "group" : "input",
@@ -227,6 +225,7 @@
       "equals" : "fifo",
       "type" : "simple"
     },
+    "tooltip" : "FIFO only. See <a href=\"https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/using-messagededuplicationid-property.html\">MessageDeduplicationId property</a> in the Amazon SQS developer guide.",
     "type" : "String"
   }, {
     "id" : "version",

--- a/connectors/aws/aws-sqs/element-templates/aws-sqs-receive-connector.json
+++ b/connectors/aws/aws-sqs/element-templates/aws-sqs-receive-connector.json
@@ -138,7 +138,6 @@
   }, {
     "id" : "queue.queue.url",
     "label" : "Queue URL",
-    "description" : "Specify the URL of the SQS queue where you would like to subscribe to",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -148,11 +147,11 @@
       "name" : "queue.url",
       "type" : "zeebe:property"
     },
+    "tooltip" : "URL of the SQS queue to subscribe to.",
     "type" : "String"
   }, {
     "id" : "queue.queue.pollingWaitTime",
     "label" : "Polling wait time",
-    "description" : "The duration (in seconds) for which the call waits for a message to arrive in the queue before returning. See <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-sqs/?amazonsqs=inbound\" target=\"_blank\">documentation</a> for details. A value of 0 will automatically be overridden to 1",
     "optional" : false,
     "value" : "20",
     "constraints" : {
@@ -166,11 +165,11 @@
       "name" : "queue.pollingWaitTime",
       "type" : "zeebe:property"
     },
+    "tooltip" : "The duration (in seconds) for which the call waits for a message to arrive in the queue before returning. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-sqs/?amazonsqs=inbound\" target=\"_blank\">Amazon SQS connector guide</a>. A value of 0 will automatically be overridden to 1.",
     "type" : "String"
   }, {
     "id" : "queue.queue.attributeNames",
     "label" : "Attribute names",
-    "description" : "Array of queue attribute names. See <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-sqs/?amazonsqs=inbound\" target=\"_blank\">documentation</a> for details",
     "optional" : false,
     "feel" : "optional",
     "group" : "input",
@@ -178,11 +177,11 @@
       "name" : "queue.attributeNames",
       "type" : "zeebe:property"
     },
+    "tooltip" : "Array of queue attribute names. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-sqs/?amazonsqs=inbound\" target=\"_blank\">Amazon SQS connector guide</a>.",
     "type" : "String"
   }, {
     "id" : "queue.queue.messageAttributeNames",
     "label" : "Message attribute names",
-    "description" : "Array of message attribute names. See <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-sqs/?amazonsqs=inbound\" target=\"_blank\">documentation</a> for details",
     "optional" : false,
     "feel" : "optional",
     "group" : "input",
@@ -190,6 +189,7 @@
       "name" : "queue.messageAttributeNames",
       "type" : "zeebe:property"
     },
+    "tooltip" : "Array of message attribute names. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-sqs/?amazonsqs=inbound\" target=\"_blank\">Amazon SQS connector guide</a>.",
     "type" : "String"
   }, {
     "id" : "activationCondition",

--- a/connectors/aws/aws-sqs/element-templates/aws-sqs-receive-connector.json
+++ b/connectors/aws/aws-sqs/element-templates/aws-sqs-receive-connector.json
@@ -75,7 +75,6 @@
   }, {
     "id" : "authentication.accessKey",
     "label" : "Access key",
-    "description" : "Provide an IAM access key tailored to a user, equipped with the necessary permissions",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -90,11 +89,11 @@
       "equals" : "credentials",
       "type" : "simple"
     },
+    "tooltip" : "IAM access key of a user with the necessary permissions for this connector",
     "type" : "String"
   }, {
     "id" : "authentication.secretKey",
     "label" : "Secret key",
-    "description" : "Provide a secret key of a user with permissions to invoke specified AWS Lambda function",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -109,11 +108,11 @@
       "equals" : "credentials",
       "type" : "simple"
     },
+    "tooltip" : "IAM secret key of a user with the necessary permissions for this connector",
     "type" : "String"
   }, {
     "id" : "configuration.region",
     "label" : "Region",
-    "description" : "Specify the AWS region",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -165,7 +164,7 @@
       "name" : "queue.pollingWaitTime",
       "type" : "zeebe:property"
     },
-    "tooltip" : "The duration (in seconds) for which the call waits for a message to arrive in the queue before returning. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-sqs/?amazonsqs=inbound\" target=\"_blank\">Amazon SQS connector guide</a>. A value of 0 will automatically be overridden to 1.",
+    "tooltip" : "The duration (in seconds) for which the call waits for a message to arrive in the queue before returning. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-sqs/?amazonsqs=inbound\" target=\"_blank\">Amazon SQS connector guide</a>. A value of 0 is automatically overridden to 1.",
     "type" : "String"
   }, {
     "id" : "queue.queue.attributeNames",

--- a/connectors/aws/aws-sqs/element-templates/aws-sqs-start-message.json
+++ b/connectors/aws/aws-sqs/element-templates/aws-sqs-start-message.json
@@ -139,7 +139,6 @@
   }, {
     "id" : "queue.queue.url",
     "label" : "Queue URL",
-    "description" : "Specify the URL of the SQS queue where you would like to subscribe to",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -149,11 +148,11 @@
       "name" : "queue.url",
       "type" : "zeebe:property"
     },
+    "tooltip" : "URL of the SQS queue to subscribe to.",
     "type" : "String"
   }, {
     "id" : "queue.queue.pollingWaitTime",
     "label" : "Polling wait time",
-    "description" : "The duration (in seconds) for which the call waits for a message to arrive in the queue before returning. See <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-sqs/?amazonsqs=inbound\" target=\"_blank\">documentation</a> for details. A value of 0 will automatically be overridden to 1",
     "optional" : false,
     "value" : "20",
     "constraints" : {
@@ -167,11 +166,11 @@
       "name" : "queue.pollingWaitTime",
       "type" : "zeebe:property"
     },
+    "tooltip" : "The duration (in seconds) for which the call waits for a message to arrive in the queue before returning. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-sqs/?amazonsqs=inbound\" target=\"_blank\">Amazon SQS connector guide</a>. A value of 0 will automatically be overridden to 1.",
     "type" : "String"
   }, {
     "id" : "queue.queue.attributeNames",
     "label" : "Attribute names",
-    "description" : "Array of queue attribute names. See <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-sqs/?amazonsqs=inbound\" target=\"_blank\">documentation</a> for details",
     "optional" : false,
     "feel" : "optional",
     "group" : "input",
@@ -179,11 +178,11 @@
       "name" : "queue.attributeNames",
       "type" : "zeebe:property"
     },
+    "tooltip" : "Array of queue attribute names. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-sqs/?amazonsqs=inbound\" target=\"_blank\">Amazon SQS connector guide</a>.",
     "type" : "String"
   }, {
     "id" : "queue.queue.messageAttributeNames",
     "label" : "Message attribute names",
-    "description" : "Array of message attribute names. See <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-sqs/?amazonsqs=inbound\" target=\"_blank\">documentation</a> for details",
     "optional" : false,
     "feel" : "optional",
     "group" : "input",
@@ -191,6 +190,7 @@
       "name" : "queue.messageAttributeNames",
       "type" : "zeebe:property"
     },
+    "tooltip" : "Array of message attribute names. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-sqs/?amazonsqs=inbound\" target=\"_blank\">Amazon SQS connector guide</a>.",
     "type" : "String"
   }, {
     "id" : "activationCondition",

--- a/connectors/aws/aws-sqs/element-templates/aws-sqs-start-message.json
+++ b/connectors/aws/aws-sqs/element-templates/aws-sqs-start-message.json
@@ -76,7 +76,6 @@
   }, {
     "id" : "authentication.accessKey",
     "label" : "Access key",
-    "description" : "Provide an IAM access key tailored to a user, equipped with the necessary permissions",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -91,11 +90,11 @@
       "equals" : "credentials",
       "type" : "simple"
     },
+    "tooltip" : "IAM access key of a user with the necessary permissions for this connector",
     "type" : "String"
   }, {
     "id" : "authentication.secretKey",
     "label" : "Secret key",
-    "description" : "Provide a secret key of a user with permissions to invoke specified AWS Lambda function",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -110,11 +109,11 @@
       "equals" : "credentials",
       "type" : "simple"
     },
+    "tooltip" : "IAM secret key of a user with the necessary permissions for this connector",
     "type" : "String"
   }, {
     "id" : "configuration.region",
     "label" : "Region",
-    "description" : "Specify the AWS region",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -166,7 +165,7 @@
       "name" : "queue.pollingWaitTime",
       "type" : "zeebe:property"
     },
-    "tooltip" : "The duration (in seconds) for which the call waits for a message to arrive in the queue before returning. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-sqs/?amazonsqs=inbound\" target=\"_blank\">Amazon SQS connector guide</a>. A value of 0 will automatically be overridden to 1.",
+    "tooltip" : "The duration (in seconds) for which the call waits for a message to arrive in the queue before returning. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-sqs/?amazonsqs=inbound\" target=\"_blank\">Amazon SQS connector guide</a>. A value of 0 is automatically overridden to 1.",
     "type" : "String"
   }, {
     "id" : "queue.queue.attributeNames",

--- a/connectors/aws/aws-sqs/element-templates/hybrid/aws-sqs-outbound-connector-hybrid.json
+++ b/connectors/aws/aws-sqs/element-templates/hybrid/aws-sqs-outbound-connector-hybrid.json
@@ -72,7 +72,6 @@
   }, {
     "id" : "authentication.accessKey",
     "label" : "Access key",
-    "description" : "Provide an IAM access key tailored to a user, equipped with the necessary permissions",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -88,11 +87,11 @@
       "equals" : "credentials",
       "type" : "simple"
     },
+    "tooltip" : "IAM access key of a user with the necessary permissions for this connector",
     "type" : "String"
   }, {
     "id" : "authentication.secretKey",
     "label" : "Secret key",
-    "description" : "Provide a secret key of a user with permissions to invoke specified AWS Lambda function",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -108,6 +107,7 @@
       "equals" : "credentials",
       "type" : "simple"
     },
+    "tooltip" : "IAM secret key of a user with the necessary permissions for this connector",
     "type" : "String"
   }, {
     "id" : "queue.url",
@@ -149,7 +149,6 @@
   }, {
     "id" : "configuration.region",
     "label" : "Region",
-    "description" : "Specify the AWS region",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -197,6 +196,7 @@
       "name" : "queue.messageAttributes",
       "type" : "zeebe:input"
     },
+    "tooltip" : "Optional message metadata as a map keyed by attribute name, each value having a StringValue and DataType, following the <a href=\"https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-message-metadata.html#sqs-message-attributes\" target=\"_blank\">SQS message attribute format</a>.",
     "type" : "Text"
   }, {
     "id" : "queue.messageGroupId",

--- a/connectors/aws/aws-sqs/element-templates/hybrid/aws-sqs-outbound-connector-hybrid.json
+++ b/connectors/aws/aws-sqs/element-templates/hybrid/aws-sqs-outbound-connector-hybrid.json
@@ -112,7 +112,6 @@
   }, {
     "id" : "queue.url",
     "label" : "URL",
-    "description" : "Specify the URL of the SQS queue where you would like to send message to",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -123,11 +122,11 @@
       "name" : "queue.url",
       "type" : "zeebe:input"
     },
+    "tooltip" : "URL of the SQS queue to send the message to.",
     "type" : "String"
   }, {
     "id" : "queue.type",
     "label" : "Queue type",
-    "description" : "Specify whether the queue is a <a href=\"https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/standard-queues.html\">standard</a> or <a href=\"https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/FIFO-queues.html\">FIFO</a> queue",
     "optional" : false,
     "value" : "standard",
     "constraints" : {
@@ -138,6 +137,7 @@
       "name" : "queue.type",
       "type" : "zeebe:input"
     },
+    "tooltip" : "Whether the queue is a <a href=\"https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/standard-queues.html\">standard</a> or <a href=\"https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/FIFO-queues.html\">FIFO</a> queue.",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "Standard",
@@ -175,7 +175,6 @@
   }, {
     "id" : "queue.messageBody",
     "label" : "Message body",
-    "description" : "Data to send to the SQS queue",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -186,11 +185,11 @@
       "name" : "queue.messageBody",
       "type" : "zeebe:input"
     },
+    "tooltip" : "Data to send to the SQS queue",
     "type" : "Text"
   }, {
     "id" : "queue.messageAttributes",
     "label" : "Message attributes",
-    "description" : "Message attributes metadata",
     "optional" : true,
     "feel" : "required",
     "group" : "input",
@@ -202,7 +201,6 @@
   }, {
     "id" : "queue.messageGroupId",
     "label" : "Message group ID",
-    "description" : "Message group ID (FIFO only). See also <a href=\"https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/using-messagegroupid-property.html\">using the MessageGroupId Property</a> in the Amazon SQS developer guide",
     "optional" : false,
     "feel" : "optional",
     "group" : "input",
@@ -215,11 +213,11 @@
       "equals" : "fifo",
       "type" : "simple"
     },
+    "tooltip" : "FIFO only. See <a href=\"https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/using-messagegroupid-property.html\">MessageGroupId property</a> in the Amazon SQS developer guide.",
     "type" : "String"
   }, {
     "id" : "queue.messageDeduplicationId",
     "label" : "Message deduplication ID",
-    "description" : "Message deduplication ID (FIFO only). See also <a href=\"https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/using-messagededuplicationid-property.html\">using the MessageDeduplicationId Property</a> in the Amazon SQS developer guide",
     "optional" : true,
     "feel" : "optional",
     "group" : "input",
@@ -232,6 +230,7 @@
       "equals" : "fifo",
       "type" : "simple"
     },
+    "tooltip" : "FIFO only. See <a href=\"https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/using-messagededuplicationid-property.html\">MessageDeduplicationId property</a> in the Amazon SQS developer guide.",
     "type" : "String"
   }, {
     "id" : "version",

--- a/connectors/aws/aws-sqs/src/main/java/io/camunda/connector/inbound/model/SqsInboundQueueProperties.java
+++ b/connectors/aws/aws-sqs/src/main/java/io/camunda/connector/inbound/model/SqsInboundQueueProperties.java
@@ -44,7 +44,7 @@ public record SqsInboundQueueProperties(
             group = "messagePollingProperties",
             defaultValue = "20",
             tooltip =
-                "The duration (in seconds) for which the call waits for a message to arrive in the queue before returning. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-sqs/?amazonsqs=inbound\" target=\"_blank\">Amazon SQS connector guide</a>. A value of 0 will automatically be overridden to 1.",
+                "The duration (in seconds) for which the call waits for a message to arrive in the queue before returning. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-sqs/?amazonsqs=inbound\" target=\"_blank\">Amazon SQS connector guide</a>. A value of 0 is automatically overridden to 1.",
             feel = FeelMode.disabled)
         @Pattern(regexp = "^([0-9]?|1[0-9]|20|secrets\\..+)$")
         @NotBlank

--- a/connectors/aws/aws-sqs/src/main/java/io/camunda/connector/inbound/model/SqsInboundQueueProperties.java
+++ b/connectors/aws/aws-sqs/src/main/java/io/camunda/connector/inbound/model/SqsInboundQueueProperties.java
@@ -18,7 +18,7 @@ public record SqsInboundQueueProperties(
             id = "queue.url",
             label = "Queue URL",
             group = "queueProperties",
-            description = "Specify the URL of the SQS queue where you would like to subscribe to",
+            tooltip = "URL of the SQS queue to subscribe to.",
             feel = FeelMode.disabled)
         @NotBlank
         String url,
@@ -26,16 +26,16 @@ public record SqsInboundQueueProperties(
             id = "queue.attributeNames",
             label = "Attribute names",
             group = "input",
-            description =
-                "Array of queue attribute names. See <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-sqs/?amazonsqs=inbound\" target=\"_blank\">documentation</a> for details",
+            tooltip =
+                "Array of queue attribute names. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-sqs/?amazonsqs=inbound\" target=\"_blank\">Amazon SQS connector guide</a>.",
             feel = FeelMode.optional)
         List<String> attributeNames,
     @TemplateProperty(
             id = "queue.messageAttributeNames",
             label = "Message attribute names",
             group = "input",
-            description =
-                "Array of message attribute names. See <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-sqs/?amazonsqs=inbound\" target=\"_blank\">documentation</a> for details",
+            tooltip =
+                "Array of message attribute names. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-sqs/?amazonsqs=inbound\" target=\"_blank\">Amazon SQS connector guide</a>.",
             feel = FeelMode.optional)
         List<String> messageAttributeNames,
     @TemplateProperty(
@@ -43,8 +43,8 @@ public record SqsInboundQueueProperties(
             label = "Polling wait time",
             group = "messagePollingProperties",
             defaultValue = "20",
-            description =
-                "The duration (in seconds) for which the call waits for a message to arrive in the queue before returning. See <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-sqs/?amazonsqs=inbound\" target=\"_blank\">documentation</a> for details. A value of 0 will automatically be overridden to 1",
+            tooltip =
+                "The duration (in seconds) for which the call waits for a message to arrive in the queue before returning. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-sqs/?amazonsqs=inbound\" target=\"_blank\">Amazon SQS connector guide</a>. A value of 0 will automatically be overridden to 1.",
             feel = FeelMode.disabled)
         @Pattern(regexp = "^([0-9]?|1[0-9]|20|secrets\\..+)$")
         @NotBlank

--- a/connectors/aws/aws-sqs/src/main/java/io/camunda/connector/outbound/model/QueueRequestData.java
+++ b/connectors/aws/aws-sqs/src/main/java/io/camunda/connector/outbound/model/QueueRequestData.java
@@ -59,7 +59,9 @@ public class QueueRequestData {
       group = "input",
       type = TemplateProperty.PropertyType.Text,
       optional = true,
-      feel = FeelMode.required)
+      feel = FeelMode.required,
+      tooltip =
+          "Optional message metadata as a map keyed by attribute name, each value having a StringValue and DataType, following the <a href=\"https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-message-metadata.html#sqs-message-attributes\" target=\"_blank\">SQS message attribute format</a>.")
   private Map<String, SqsMessageAttribute> messageAttributes;
 
   @TemplateProperty(

--- a/connectors/aws/aws-sqs/src/main/java/io/camunda/connector/outbound/model/QueueRequestData.java
+++ b/connectors/aws/aws-sqs/src/main/java/io/camunda/connector/outbound/model/QueueRequestData.java
@@ -23,7 +23,7 @@ public class QueueRequestData {
   @TemplateProperty(
       group = "configuration",
       label = "URL",
-      description = "Specify the URL of the SQS queue where you would like to send message to")
+      tooltip = "URL of the SQS queue to send the message to.")
   @NotEmpty
   private String url;
 
@@ -36,7 +36,7 @@ public class QueueRequestData {
       group = "input",
       feel = FeelMode.required,
       type = TemplateProperty.PropertyType.Text,
-      description = "Data to send to the SQS queue")
+      tooltip = "Data to send to the SQS queue")
   @NotNull
   private Object messageBody;
 
@@ -49,8 +49,8 @@ public class QueueRequestData {
         @TemplateProperty.DropdownPropertyChoice(value = "standard", label = "Standard"),
         @TemplateProperty.DropdownPropertyChoice(value = "fifo", label = "FIFO")
       },
-      description =
-          "Specify whether the queue is a <a href=\"https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/standard-queues.html\">standard</a> or <a href=\"https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/FIFO-queues.html\">FIFO</a> queue")
+      tooltip =
+          "Whether the queue is a <a href=\"https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/standard-queues.html\">standard</a> or <a href=\"https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/FIFO-queues.html\">FIFO</a> queue.")
   @NotNull
   private QueueType type = QueueType.standard;
 
@@ -59,16 +59,15 @@ public class QueueRequestData {
       group = "input",
       type = TemplateProperty.PropertyType.Text,
       optional = true,
-      feel = FeelMode.required,
-      description = "Message attributes metadata")
+      feel = FeelMode.required)
   private Map<String, SqsMessageAttribute> messageAttributes;
 
   @TemplateProperty(
       group = "input",
       label = "Message group ID",
       condition = @TemplateProperty.PropertyCondition(property = "queue.type", equals = "fifo"),
-      description =
-          "Message group ID (FIFO only). See also <a href=\"https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/using-messagegroupid-property.html\">using the MessageGroupId Property</a> in the Amazon SQS developer guide")
+      tooltip =
+          "FIFO only. See <a href=\"https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/using-messagegroupid-property.html\">MessageGroupId property</a> in the Amazon SQS developer guide.")
   private String messageGroupId;
 
   @TemplateProperty(
@@ -76,8 +75,8 @@ public class QueueRequestData {
       label = "Message deduplication ID",
       condition = @TemplateProperty.PropertyCondition(property = "queue.type", equals = "fifo"),
       optional = true,
-      description =
-          "Message deduplication ID (FIFO only). See also <a href=\"https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/using-messagededuplicationid-property.html\">using the MessageDeduplicationId Property</a> in the Amazon SQS developer guide")
+      tooltip =
+          "FIFO only. See <a href=\"https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/using-messagededuplicationid-property.html\">MessageDeduplicationId property</a> in the Amazon SQS developer guide.")
   private String messageDeduplicationId;
 
   public String getUrl() {

--- a/connectors/aws/aws-textract/element-templates/aws-textract-outbound-connector.json
+++ b/connectors/aws/aws-textract/element-templates/aws-textract-outbound-connector.json
@@ -139,7 +139,6 @@
   }, {
     "id" : "input.documentLocationType",
     "label" : "Document source",
-    "description" : "Document source of the input document that should be analyzed.",
     "optional" : false,
     "value" : "S3",
     "group" : "document",
@@ -147,6 +146,7 @@
       "name" : "input.documentLocationType",
       "type" : "zeebe:input"
     },
+    "tooltip" : "Source of the input document to be analyzed.",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "Camunda Document",
@@ -158,7 +158,6 @@
   }, {
     "id" : "input.documentS3Bucket",
     "label" : "Document bucket",
-    "description" : "S3 bucket that contains document that should be analyzed.",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -174,11 +173,11 @@
       "equals" : "S3",
       "type" : "simple"
     },
+    "tooltip" : "S3 bucket that contains the document to be analyzed.",
     "type" : "String"
   }, {
     "id" : "input.documentName",
     "label" : "Document name",
-    "description" : "S3 document name of the document that should be analyzed.",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -194,11 +193,11 @@
       "equals" : "S3",
       "type" : "simple"
     },
+    "tooltip" : "Name of the document to be analyzed in the S3 bucket.",
     "type" : "String"
   }, {
     "id" : "input.documentVersion",
     "label" : "Document version",
-    "description" : "S3 document version of the document that should be analyzed.",
     "optional" : true,
     "feel" : "optional",
     "group" : "document",
@@ -211,11 +210,11 @@
       "equals" : "S3",
       "type" : "simple"
     },
+    "tooltip" : "Version of the document to be analyzed in the S3 bucket.",
     "type" : "String"
   }, {
     "id" : "input.document",
     "label" : "Camunda Document",
-    "description" : "The Camunda document of the process that should be analyzed.",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -231,11 +230,11 @@
       "equals" : "UPLOADED",
       "type" : "simple"
     },
+    "tooltip" : "The Camunda document to be analyzed.",
     "type" : "String"
   }, {
     "id" : "input.executionType",
     "label" : "Execution type",
-    "description" : "How the document should be processes. See more info in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-textract/#execution-types\" target=\"_blank\">documentation</a>.",
     "optional" : false,
     "value" : "POLLING",
     "constraints" : {
@@ -251,6 +250,7 @@
       "equals" : "S3",
       "type" : "simple"
     },
+    "tooltip" : "How the document should be processed. See more info in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-textract/#execution-types\" target=\"_blank\">Amazon Textract execution types documentation</a>.",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "Asynchronous",
@@ -265,7 +265,6 @@
   }, {
     "id" : "input.analyzeTables",
     "label" : "Analyze tables",
-    "description" : "Select this to return information about the tables that are detected in the input document.",
     "optional" : false,
     "value" : true,
     "constraints" : {
@@ -277,11 +276,11 @@
       "name" : "input.analyzeTables",
       "type" : "zeebe:input"
     },
+    "tooltip" : "Select this to return information about the tables that are detected in the input document.",
     "type" : "Boolean"
   }, {
     "id" : "input.analyzeForms",
     "label" : "Analyze form",
-    "description" : "Select this to return information detected form data.",
     "optional" : false,
     "value" : true,
     "constraints" : {
@@ -293,11 +292,11 @@
       "name" : "input.analyzeForms",
       "type" : "zeebe:input"
     },
+    "tooltip" : "Select this to return information about detected form data.",
     "type" : "Boolean"
   }, {
     "id" : "input.analyzeSignatures",
     "label" : "Analyze signatures",
-    "description" : "Select this to return the locations of detected signatures.",
     "optional" : false,
     "value" : true,
     "constraints" : {
@@ -309,11 +308,11 @@
       "name" : "input.analyzeSignatures",
       "type" : "zeebe:input"
     },
+    "tooltip" : "Select this to return the locations of detected signatures.",
     "type" : "Boolean"
   }, {
     "id" : "input.analyzeLayout",
     "label" : "Analyze layout",
-    "description" : "Select this to return information about the layout of the document.",
     "optional" : false,
     "value" : false,
     "constraints" : {
@@ -325,6 +324,7 @@
       "name" : "input.analyzeLayout",
       "type" : "zeebe:input"
     },
+    "tooltip" : "Select this to return information about the layout of the document.",
     "type" : "Boolean"
   }, {
     "id" : "input.analyzeQueries",
@@ -360,7 +360,6 @@
   }, {
     "id" : "input.outputConfigS3Bucket",
     "label" : "Output S3 bucket",
-    "description" : "The name of the bucket your output will go to.",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -376,11 +375,11 @@
       "equals" : "ASYNC",
       "type" : "simple"
     },
+    "tooltip" : "The name of the bucket your output will go to.",
     "type" : "String"
   }, {
     "id" : "input.outputConfigS3Prefix",
     "label" : "Output S3 prefix",
-    "description" : "The prefix of the object key that the output will be saved to.",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -396,11 +395,11 @@
       "equals" : "ASYNC",
       "type" : "simple"
     },
+    "tooltip" : "The prefix of the object key that the output will be saved to.",
     "type" : "String"
   }, {
     "id" : "input.clientRequestToken",
     "label" : "Client request token",
-    "description" : "The idempotent token that you use to identify the start request.",
     "optional" : true,
     "feel" : "optional",
     "group" : "advanced",
@@ -413,11 +412,11 @@
       "equals" : "ASYNC",
       "type" : "simple"
     },
+    "tooltip" : "The idempotent token that you use to identify the start request.",
     "type" : "String"
   }, {
     "id" : "input.jobTag",
     "label" : "Job tag",
-    "description" : "An identifier that you specify that's included in the completion notification published to the Amazon SNS topic.",
     "optional" : true,
     "feel" : "optional",
     "group" : "advanced",
@@ -430,11 +429,11 @@
       "equals" : "ASYNC",
       "type" : "simple"
     },
+    "tooltip" : "An identifier that you specify that's included in the completion notification published to the Amazon SNS topic.",
     "type" : "String"
   }, {
     "id" : "input.kmsKeyId",
     "label" : "KMS key ID",
-    "description" : "The KMS key used to encrypt the inference results.",
     "optional" : true,
     "feel" : "optional",
     "group" : "advanced",
@@ -447,11 +446,11 @@
       "equals" : "ASYNC",
       "type" : "simple"
     },
+    "tooltip" : "The KMS key used to encrypt the inference results.",
     "type" : "String"
   }, {
     "id" : "input.notificationChannelRoleArn",
     "label" : "Notification channel role ARN",
-    "description" : "The Amazon SNS topic role ARN that you want Amazon Textract to publish the completion status of the operation to.",
     "optional" : true,
     "feel" : "optional",
     "group" : "advanced",
@@ -464,11 +463,11 @@
       "equals" : "ASYNC",
       "type" : "simple"
     },
+    "tooltip" : "The Amazon SNS topic role ARN that you want Amazon Textract to publish the completion status of the operation to.",
     "type" : "String"
   }, {
     "id" : "input.notificationChannelSnsTopicArn",
     "label" : "Notification channel SNS topic ARN",
-    "description" : "The Amazon SNS topic ARN that you want Amazon Textract to publish the completion status of the operation to.",
     "optional" : true,
     "feel" : "optional",
     "group" : "advanced",
@@ -481,6 +480,7 @@
       "equals" : "ASYNC",
       "type" : "simple"
     },
+    "tooltip" : "The Amazon SNS topic ARN that you want Amazon Textract to publish the completion status of the operation to.",
     "type" : "String"
   }, {
     "id" : "version",

--- a/connectors/aws/aws-textract/element-templates/aws-textract-outbound-connector.json
+++ b/connectors/aws/aws-textract/element-templates/aws-textract-outbound-connector.json
@@ -73,7 +73,6 @@
   }, {
     "id" : "authentication.accessKey",
     "label" : "Access key",
-    "description" : "Provide an IAM access key tailored to a user, equipped with the necessary permissions",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -89,11 +88,11 @@
       "equals" : "credentials",
       "type" : "simple"
     },
+    "tooltip" : "IAM access key of a user with the necessary permissions for this connector",
     "type" : "String"
   }, {
     "id" : "authentication.secretKey",
     "label" : "Secret key",
-    "description" : "Provide a secret key of a user with permissions to invoke specified AWS Lambda function",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -109,11 +108,11 @@
       "equals" : "credentials",
       "type" : "simple"
     },
+    "tooltip" : "IAM secret key of a user with the necessary permissions for this connector",
     "type" : "String"
   }, {
     "id" : "configuration.region",
     "label" : "Region",
-    "description" : "Specify the AWS region",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -340,6 +339,7 @@
       "name" : "input.analyzeQueries",
       "type" : "zeebe:input"
     },
+    "tooltip" : "Select this to return an answer to a query run against the document.",
     "type" : "Boolean"
   }, {
     "id" : "input.query",
@@ -356,6 +356,8 @@
       "equals" : true,
       "type" : "simple"
     },
+    "tooltip" : "A natural-language question applied to the document; Textract returns the extracted answer.",
+    "placeholder" : "What is the IBAN in the invoice?",
     "type" : "String"
   }, {
     "id" : "input.outputConfigS3Bucket",

--- a/connectors/aws/aws-textract/element-templates/hybrid/aws-textract-outbound-connector-hybrid.json
+++ b/connectors/aws/aws-textract/element-templates/hybrid/aws-textract-outbound-connector-hybrid.json
@@ -144,7 +144,6 @@
   }, {
     "id" : "input.documentLocationType",
     "label" : "Document source",
-    "description" : "Document source of the input document that should be analyzed.",
     "optional" : false,
     "value" : "S3",
     "group" : "document",
@@ -152,6 +151,7 @@
       "name" : "input.documentLocationType",
       "type" : "zeebe:input"
     },
+    "tooltip" : "Source of the input document to be analyzed.",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "Camunda Document",
@@ -163,7 +163,6 @@
   }, {
     "id" : "input.documentS3Bucket",
     "label" : "Document bucket",
-    "description" : "S3 bucket that contains document that should be analyzed.",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -179,11 +178,11 @@
       "equals" : "S3",
       "type" : "simple"
     },
+    "tooltip" : "S3 bucket that contains the document to be analyzed.",
     "type" : "String"
   }, {
     "id" : "input.documentName",
     "label" : "Document name",
-    "description" : "S3 document name of the document that should be analyzed.",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -199,11 +198,11 @@
       "equals" : "S3",
       "type" : "simple"
     },
+    "tooltip" : "Name of the document to be analyzed in the S3 bucket.",
     "type" : "String"
   }, {
     "id" : "input.documentVersion",
     "label" : "Document version",
-    "description" : "S3 document version of the document that should be analyzed.",
     "optional" : true,
     "feel" : "optional",
     "group" : "document",
@@ -216,11 +215,11 @@
       "equals" : "S3",
       "type" : "simple"
     },
+    "tooltip" : "Version of the document to be analyzed in the S3 bucket.",
     "type" : "String"
   }, {
     "id" : "input.document",
     "label" : "Camunda Document",
-    "description" : "The Camunda document of the process that should be analyzed.",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -236,11 +235,11 @@
       "equals" : "UPLOADED",
       "type" : "simple"
     },
+    "tooltip" : "The Camunda document to be analyzed.",
     "type" : "String"
   }, {
     "id" : "input.executionType",
     "label" : "Execution type",
-    "description" : "How the document should be processes. See more info in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-textract/#execution-types\" target=\"_blank\">documentation</a>.",
     "optional" : false,
     "value" : "POLLING",
     "constraints" : {
@@ -256,6 +255,7 @@
       "equals" : "S3",
       "type" : "simple"
     },
+    "tooltip" : "How the document should be processed. See more info in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-textract/#execution-types\" target=\"_blank\">Amazon Textract execution types documentation</a>.",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "Asynchronous",
@@ -270,7 +270,6 @@
   }, {
     "id" : "input.analyzeTables",
     "label" : "Analyze tables",
-    "description" : "Select this to return information about the tables that are detected in the input document.",
     "optional" : false,
     "value" : true,
     "constraints" : {
@@ -282,11 +281,11 @@
       "name" : "input.analyzeTables",
       "type" : "zeebe:input"
     },
+    "tooltip" : "Select this to return information about the tables that are detected in the input document.",
     "type" : "Boolean"
   }, {
     "id" : "input.analyzeForms",
     "label" : "Analyze form",
-    "description" : "Select this to return information detected form data.",
     "optional" : false,
     "value" : true,
     "constraints" : {
@@ -298,11 +297,11 @@
       "name" : "input.analyzeForms",
       "type" : "zeebe:input"
     },
+    "tooltip" : "Select this to return information about detected form data.",
     "type" : "Boolean"
   }, {
     "id" : "input.analyzeSignatures",
     "label" : "Analyze signatures",
-    "description" : "Select this to return the locations of detected signatures.",
     "optional" : false,
     "value" : true,
     "constraints" : {
@@ -314,11 +313,11 @@
       "name" : "input.analyzeSignatures",
       "type" : "zeebe:input"
     },
+    "tooltip" : "Select this to return the locations of detected signatures.",
     "type" : "Boolean"
   }, {
     "id" : "input.analyzeLayout",
     "label" : "Analyze layout",
-    "description" : "Select this to return information about the layout of the document.",
     "optional" : false,
     "value" : false,
     "constraints" : {
@@ -330,6 +329,7 @@
       "name" : "input.analyzeLayout",
       "type" : "zeebe:input"
     },
+    "tooltip" : "Select this to return information about the layout of the document.",
     "type" : "Boolean"
   }, {
     "id" : "input.analyzeQueries",
@@ -365,7 +365,6 @@
   }, {
     "id" : "input.outputConfigS3Bucket",
     "label" : "Output S3 bucket",
-    "description" : "The name of the bucket your output will go to.",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -381,11 +380,11 @@
       "equals" : "ASYNC",
       "type" : "simple"
     },
+    "tooltip" : "The name of the bucket your output will go to.",
     "type" : "String"
   }, {
     "id" : "input.outputConfigS3Prefix",
     "label" : "Output S3 prefix",
-    "description" : "The prefix of the object key that the output will be saved to.",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -401,11 +400,11 @@
       "equals" : "ASYNC",
       "type" : "simple"
     },
+    "tooltip" : "The prefix of the object key that the output will be saved to.",
     "type" : "String"
   }, {
     "id" : "input.clientRequestToken",
     "label" : "Client request token",
-    "description" : "The idempotent token that you use to identify the start request.",
     "optional" : true,
     "feel" : "optional",
     "group" : "advanced",
@@ -418,11 +417,11 @@
       "equals" : "ASYNC",
       "type" : "simple"
     },
+    "tooltip" : "The idempotent token that you use to identify the start request.",
     "type" : "String"
   }, {
     "id" : "input.jobTag",
     "label" : "Job tag",
-    "description" : "An identifier that you specify that's included in the completion notification published to the Amazon SNS topic.",
     "optional" : true,
     "feel" : "optional",
     "group" : "advanced",
@@ -435,11 +434,11 @@
       "equals" : "ASYNC",
       "type" : "simple"
     },
+    "tooltip" : "An identifier that you specify that's included in the completion notification published to the Amazon SNS topic.",
     "type" : "String"
   }, {
     "id" : "input.kmsKeyId",
     "label" : "KMS key ID",
-    "description" : "The KMS key used to encrypt the inference results.",
     "optional" : true,
     "feel" : "optional",
     "group" : "advanced",
@@ -452,11 +451,11 @@
       "equals" : "ASYNC",
       "type" : "simple"
     },
+    "tooltip" : "The KMS key used to encrypt the inference results.",
     "type" : "String"
   }, {
     "id" : "input.notificationChannelRoleArn",
     "label" : "Notification channel role ARN",
-    "description" : "The Amazon SNS topic role ARN that you want Amazon Textract to publish the completion status of the operation to.",
     "optional" : true,
     "feel" : "optional",
     "group" : "advanced",
@@ -469,11 +468,11 @@
       "equals" : "ASYNC",
       "type" : "simple"
     },
+    "tooltip" : "The Amazon SNS topic role ARN that you want Amazon Textract to publish the completion status of the operation to.",
     "type" : "String"
   }, {
     "id" : "input.notificationChannelSnsTopicArn",
     "label" : "Notification channel SNS topic ARN",
-    "description" : "The Amazon SNS topic ARN that you want Amazon Textract to publish the completion status of the operation to.",
     "optional" : true,
     "feel" : "optional",
     "group" : "advanced",
@@ -486,6 +485,7 @@
       "equals" : "ASYNC",
       "type" : "simple"
     },
+    "tooltip" : "The Amazon SNS topic ARN that you want Amazon Textract to publish the completion status of the operation to.",
     "type" : "String"
   }, {
     "id" : "version",

--- a/connectors/aws/aws-textract/element-templates/hybrid/aws-textract-outbound-connector-hybrid.json
+++ b/connectors/aws/aws-textract/element-templates/hybrid/aws-textract-outbound-connector-hybrid.json
@@ -78,7 +78,6 @@
   }, {
     "id" : "authentication.accessKey",
     "label" : "Access key",
-    "description" : "Provide an IAM access key tailored to a user, equipped with the necessary permissions",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -94,11 +93,11 @@
       "equals" : "credentials",
       "type" : "simple"
     },
+    "tooltip" : "IAM access key of a user with the necessary permissions for this connector",
     "type" : "String"
   }, {
     "id" : "authentication.secretKey",
     "label" : "Secret key",
-    "description" : "Provide a secret key of a user with permissions to invoke specified AWS Lambda function",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -114,11 +113,11 @@
       "equals" : "credentials",
       "type" : "simple"
     },
+    "tooltip" : "IAM secret key of a user with the necessary permissions for this connector",
     "type" : "String"
   }, {
     "id" : "configuration.region",
     "label" : "Region",
-    "description" : "Specify the AWS region",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -345,6 +344,7 @@
       "name" : "input.analyzeQueries",
       "type" : "zeebe:input"
     },
+    "tooltip" : "Select this to return an answer to a query run against the document.",
     "type" : "Boolean"
   }, {
     "id" : "input.query",
@@ -361,6 +361,8 @@
       "equals" : true,
       "type" : "simple"
     },
+    "tooltip" : "A natural-language question applied to the document; Textract returns the extracted answer.",
+    "placeholder" : "What is the IBAN in the invoice?",
     "type" : "String"
   }, {
     "id" : "input.outputConfigS3Bucket",

--- a/connectors/aws/aws-textract/src/main/java/io/camunda/connector/textract/model/TextractRequestData.java
+++ b/connectors/aws/aws-textract/src/main/java/io/camunda/connector/textract/model/TextractRequestData.java
@@ -17,7 +17,7 @@ public record TextractRequestData(
     @TemplateProperty(
             group = "document",
             label = "Document source",
-            description = "Document source of the input document that should be analyzed.",
+            tooltip = "Source of the input document to be analyzed.",
             feel = FeelMode.disabled,
             type = TemplateProperty.PropertyType.Dropdown,
             defaultValue = "S3")
@@ -25,7 +25,7 @@ public record TextractRequestData(
     @TemplateProperty(
             group = "document",
             label = "Document bucket",
-            description = "S3 bucket that contains document that should be analyzed.",
+            tooltip = "S3 bucket that contains the document to be analyzed.",
             condition =
                 @TemplateProperty.PropertyCondition(
                     property = "input.documentLocationType",
@@ -35,7 +35,7 @@ public record TextractRequestData(
     @TemplateProperty(
             group = "document",
             label = "Document name",
-            description = "S3 document name of the document that should be analyzed.",
+            tooltip = "Name of the document to be analyzed in the S3 bucket.",
             condition =
                 @TemplateProperty.PropertyCondition(
                     property = "input.documentLocationType",
@@ -45,7 +45,7 @@ public record TextractRequestData(
     @TemplateProperty(
             group = "document",
             label = "Document version",
-            description = "S3 document version of the document that should be analyzed.",
+            tooltip = "Version of the document to be analyzed in the S3 bucket.",
             optional = true,
             condition =
                 @TemplateProperty.PropertyCondition(
@@ -55,7 +55,7 @@ public record TextractRequestData(
     @TemplateProperty(
             group = "document",
             label = "Camunda Document",
-            description = "The Camunda document of the process that should be analyzed.",
+            tooltip = "The Camunda document to be analyzed.",
             feel = FeelMode.required,
             type = TemplateProperty.PropertyType.String,
             condition =
@@ -70,8 +70,8 @@ public record TextractRequestData(
             type = TemplateProperty.PropertyType.Dropdown,
             defaultValue = "POLLING",
             feel = FeelMode.disabled,
-            description =
-                "How the document should be processes. See more info in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-textract/#execution-types\" target=\"_blank\">documentation</a>.",
+            tooltip =
+                "How the document should be processed. See more info in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/amazon-textract/#execution-types\" target=\"_blank\">Amazon Textract execution types documentation</a>.",
             condition =
                 @TemplateProperty.PropertyCondition(
                     property = "input.documentLocationType",
@@ -80,7 +80,7 @@ public record TextractRequestData(
         TextractExecutionType executionType,
     @TemplateProperty(
             label = "Analyze tables",
-            description =
+            tooltip =
                 "Select this to return information about the tables that are detected in the input document.",
             group = "input",
             type = TemplateProperty.PropertyType.Boolean,
@@ -90,7 +90,7 @@ public record TextractRequestData(
         boolean analyzeTables,
     @TemplateProperty(
             label = "Analyze form",
-            description = "Select this to return information detected form data.",
+            tooltip = "Select this to return information about detected form data.",
             group = "input",
             type = TemplateProperty.PropertyType.Boolean,
             defaultValueType = TemplateProperty.DefaultValueType.Boolean,
@@ -99,7 +99,7 @@ public record TextractRequestData(
         boolean analyzeForms,
     @TemplateProperty(
             label = "Analyze signatures",
-            description = "Select this to return the locations of detected signatures.",
+            tooltip = "Select this to return the locations of detected signatures.",
             group = "input",
             type = TemplateProperty.PropertyType.Boolean,
             defaultValueType = TemplateProperty.DefaultValueType.Boolean,
@@ -108,7 +108,7 @@ public record TextractRequestData(
         boolean analyzeSignatures,
     @TemplateProperty(
             label = "Analyze layout",
-            description = "Select this to return information about the layout of the document.",
+            tooltip = "Select this to return information about the layout of the document.",
             group = "input",
             type = TemplateProperty.PropertyType.Boolean,
             defaultValueType = TemplateProperty.DefaultValueType.Boolean,
@@ -135,7 +135,7 @@ public record TextractRequestData(
     @TemplateProperty(
             group = "advanced",
             label = "Client request token",
-            description = "The idempotent token that you use to identify the start request.",
+            tooltip = "The idempotent token that you use to identify the start request.",
             optional = true,
             condition =
                 @TemplateProperty.PropertyCondition(
@@ -145,7 +145,7 @@ public record TextractRequestData(
     @TemplateProperty(
             group = "advanced",
             label = "Job tag",
-            description =
+            tooltip =
                 "An identifier that you specify that's included in the completion notification published to the Amazon SNS topic.",
             optional = true,
             condition =
@@ -156,7 +156,7 @@ public record TextractRequestData(
     @TemplateProperty(
             group = "advanced",
             label = "KMS key ID",
-            description = "The KMS key used to encrypt the inference results.",
+            tooltip = "The KMS key used to encrypt the inference results.",
             optional = true,
             condition =
                 @TemplateProperty.PropertyCondition(
@@ -166,7 +166,7 @@ public record TextractRequestData(
     @TemplateProperty(
             group = "advanced",
             label = "Notification channel role ARN",
-            description =
+            tooltip =
                 "The Amazon SNS topic role ARN that you want Amazon Textract to publish the completion status of the operation to.",
             optional = true,
             condition =
@@ -177,7 +177,7 @@ public record TextractRequestData(
     @TemplateProperty(
             group = "advanced",
             label = "Notification channel SNS topic ARN",
-            description =
+            tooltip =
                 "The Amazon SNS topic ARN that you want Amazon Textract to publish the completion status of the operation to.",
             optional = true,
             condition =
@@ -188,7 +188,7 @@ public record TextractRequestData(
     @TemplateProperty(
             group = "input",
             label = "Output S3 bucket",
-            description = "The name of the bucket your output will go to.",
+            tooltip = "The name of the bucket your output will go to.",
             condition =
                 @TemplateProperty.PropertyCondition(
                     property = "input.executionType",
@@ -198,7 +198,7 @@ public record TextractRequestData(
     @TemplateProperty(
             group = "input",
             label = "Output S3 prefix",
-            description = "The prefix of the object key that the output will be saved to.",
+            tooltip = "The prefix of the object key that the output will be saved to.",
             condition =
                 @TemplateProperty.PropertyCondition(
                     property = "input.executionType",

--- a/connectors/aws/aws-textract/src/main/java/io/camunda/connector/textract/model/TextractRequestData.java
+++ b/connectors/aws/aws-textract/src/main/java/io/camunda/connector/textract/model/TextractRequestData.java
@@ -117,6 +117,7 @@ public record TextractRequestData(
         boolean analyzeLayout,
     @TemplateProperty(
             label = "Analyze queries",
+            tooltip = "Select this to return an answer to a query run against the document.",
             group = "input",
             type = TemplateProperty.PropertyType.Boolean,
             defaultValueType = TemplateProperty.DefaultValueType.Boolean,
@@ -125,6 +126,9 @@ public record TextractRequestData(
         boolean analyzeQueries,
     @TemplateProperty(
             label = "Query",
+            tooltip =
+                "A natural-language question applied to the document; Textract returns the extracted answer.",
+            placeholder = "What is the IBAN in the invoice?",
             group = "input",
             type = TemplateProperty.PropertyType.String,
             condition =

--- a/connectors/idp-extraction/element-templates/hybrid/hybrid-idp-extraction-outbound-connector-hybrid.json
+++ b/connectors/idp-extraction/element-templates/hybrid/hybrid-idp-extraction-outbound-connector-hybrid.json
@@ -191,7 +191,6 @@
   }, {
     "id" : "baseRequest.authentication.accessKey",
     "label" : "Access key",
-    "description" : "Provide an IAM access key tailored to a user, equipped with the necessary permissions",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -213,11 +212,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "IAM access key of a user with the necessary permissions for this connector",
     "type" : "String"
   }, {
     "id" : "baseRequest.authentication.secretKey",
     "label" : "Secret key",
-    "description" : "Provide a secret key of a user with permissions to invoke specified AWS Lambda function",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -239,6 +238,7 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "IAM secret key of a user with the necessary permissions for this connector",
     "type" : "String"
   }, {
     "id" : "baseRequest.authentication.authType",
@@ -449,7 +449,6 @@
   }, {
     "id" : "baseRequest.configuration.region",
     "label" : "Region",
-    "description" : "Specify the AWS region",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true

--- a/connectors/idp-extraction/element-templates/idp-extraction-outbound-connector.json
+++ b/connectors/idp-extraction/element-templates/idp-extraction-outbound-connector.json
@@ -186,7 +186,6 @@
   }, {
     "id" : "baseRequest.authentication.accessKey",
     "label" : "Access key",
-    "description" : "Provide an IAM access key tailored to a user, equipped with the necessary permissions",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -208,11 +207,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "IAM access key of a user with the necessary permissions for this connector",
     "type" : "String"
   }, {
     "id" : "baseRequest.authentication.secretKey",
     "label" : "Secret key",
-    "description" : "Provide a secret key of a user with permissions to invoke specified AWS Lambda function",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -234,6 +233,7 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "IAM secret key of a user with the necessary permissions for this connector",
     "type" : "String"
   }, {
     "id" : "baseRequest.authentication.authType",
@@ -444,7 +444,6 @@
   }, {
     "id" : "baseRequest.configuration.region",
     "label" : "Region",
-    "description" : "Specify the AWS region",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true


### PR DESCRIPTION
Part of #7470. **This PR is now the AWS slice** of the `description` → `tooltip` migration. The original umbrella PR was split into 8 review-sized, vendor-family PRs per review feedback (browser-freezing / not Copilot-reviewable at full size).

**Priority:** `tooltip` > `placeholder` > `description`. Field hints move to `tooltip=`; always-visible `description=` is kept only for value-constraints, `Note:`/`Warning:` markers, and genuinely critical guidance (see the REST example that motivated keeping *some* descriptions).

**Connectors in this slice:** aws-sns, aws-dynamodb, aws-sqs, aws-comprehend, aws-bedrock, aws-textract, aws-sagemaker, aws-lambda, aws-eventbridge. Templates regenerated from the migrated Java sources.

`aws-base` (shared auth) and `aws-s3` stay on `main` here — the shared auth block feeds agentic-ai-owned bedrock templates, so it's deferred to the generator follow-up (see below).

### The 8 slices (all `Part of #7470`)
| Slice | PR |
|-------|----|
| AWS | this PR (#7651) |
| Google | #7742 |
| Microsoft | #7743 |
| HTTP (REST/GraphQL/polling) | #7744 |
| Messaging (Kafka/RabbitMQ/Slack) | #7745 |
| IDP extraction | #7746 |
| Misc generated | #7747 |
| Hand-authored | #7748 |

### Review responses (thanks @ztefanie)
1. **Skill not committed** — removed `field_hint_guide` skill + the `copilot-instructions.md` change from all branches.
2. **JSON overwritten by generator** — root cause was hand-migrated *shared* classes (aws-base, webhook) feeding agentic-ai-owned templates we must not touch. Reverted those 6 shared classes and regenerated, so committed JSON now equals generator output (no `mvn install` drift). Shared/auth-block migration moves to the generator PR.
3. **Too big to review** — split into the 8 PRs above.
4. **Version bumps** — not bumped for now (kept as-is); flagged to revisit before merge to avoid clobbering concurrent PRs.
5. **Inconsistencies** — fixed in #7748: github redundant hints removed; google-maps `Units` hint restored.
6. **Generator first** — agreed the generator is the right place for the mechanical/shared conversion; it's the follow-up PR and will own the shared auth/base blocks + generic `tooltip` emission. These 8 PRs carry the per-connector, hand-curated hint wording that isn't purely mechanical.