### PR TITLE
deps: bump Zeebe client version

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -70,7 +70,7 @@ limitations under the License.</license.inlineheader>
     <nexus.release.repository>https://artifacts.camunda.com/artifactory/connectors/</nexus.release.repository>
 
     <!-- Camunda internal libraries -->
-    <version.camunda>8.8.18</version.camunda>
+    <version.camunda>8.8.29</version.camunda>
     <version.feel-engine>1.21.0</version.feel-engine>
 
     <!-- Third party dependencies -->


### PR DESCRIPTION
This pull request updates the Camunda platform version used in the project. The only change is a version bump.

* Upgraded the Camunda platform dependency from version `8.8.18` to `8.8.29` in `parent/pom.xml` to use the latest features and fixes.