### PR TITLE
ci: fix security tests

### DIFF
--- a/bundle/camunda-saas-bundle/src/test/java/io/camunda/connector/runtime/saas/SecurityConfigurationTest.java
+++ b/bundle/camunda-saas-bundle/src/test/java/io/camunda/connector/runtime/saas/SecurityConfigurationTest.java
@@ -17,6 +17,7 @@
 package io.camunda.connector.runtime.saas;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.head;
@@ -26,9 +27,8 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import io.camunda.connector.test.utils.annotation.SlowTest;
+import io.camunda.client.CamundaClient;
 import io.camunda.connector.test.utils.oidc.MockOidcServer;
-import io.camunda.process.test.api.CamundaSpringProcessTest;
 import java.time.Duration;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
@@ -39,11 +39,9 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.web.server.LocalManagementPort;
 import org.springframework.boot.web.client.RestTemplateBuilder;
-import org.springframework.http.HttpEntity;
-import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
@@ -60,12 +58,13 @@ import org.springframework.test.web.servlet.MockMvc;
       "camunda.connector.secretprovider.discovery.enabled=false",
       "management.endpoints.web.exposure.include=*",
       "camunda.client.auth.audience=connectors.dev.ultrawombat.com",
+      "camunda.client.auth.token-url=http://localhost:0/not-used",
+      "camunda.client.auth.client-id=test",
+      "camunda.client.auth.client-secret=test",
       "spring.cloud.gcp.parametermanager.enabled=false"
     })
 @ActiveProfiles("test")
 @AutoConfigureMockMvc
-@CamundaSpringProcessTest
-@SlowTest
 public class SecurityConfigurationTest {
 
   private static final MockOidcServer OIDC_SERVER = MockOidcServer.start();
@@ -73,7 +72,6 @@ public class SecurityConfigurationTest {
   @DynamicPropertySource
   static void registerOidcProperties(DynamicPropertyRegistry registry) {
     registry.add("camunda.connector.auth.issuer", OIDC_SERVER::issuer);
-    registry.add("camunda.client.auth.token-url", OIDC_SERVER::tokenUrl);
   }
 
   @AfterAll
@@ -84,8 +82,9 @@ public class SecurityConfigurationTest {
   @MockitoBean(answers = Answers.RETURNS_MOCKS)
   public SaaSSecretConfiguration saaSSecretConfiguration;
 
-  // needed to access /actuator endpoints
-  @Autowired RestTemplateBuilder restTemplateBuilder;
+  @MockitoBean(answers = Answers.RETURNS_DEEP_STUBS)
+  public CamundaClient camundaClient;
+
   @LocalManagementPort int managementPort;
   @Autowired private MockMvc mvc;
 
@@ -95,15 +94,17 @@ public class SecurityConfigurationTest {
   }
 
   @Test
-  @WithMockUser(authorities = "SCOPE_inbound:read")
   public void inboundEndpoint_auth_returns200() throws Exception {
-    mvc.perform(get("/inbound")).andExpect(status().isOk());
+    mvc.perform(
+            get("/inbound")
+                .with(jwt().authorities(new SimpleGrantedAuthority("SCOPE_inbound:read"))))
+        .andExpect(status().isOk());
   }
 
   @Test
-  @WithMockUser(authorities = "SCOPE_WRONG")
   public void inboundEndpoint_wrongAuth_returns403() throws Exception {
-    mvc.perform(get("/inbound")).andExpect(status().isForbidden());
+    mvc.perform(get("/inbound").with(jwt().authorities(new SimpleGrantedAuthority("SCOPE_WRONG"))))
+        .andExpect(status().isForbidden());
   }
 
   @Test
@@ -170,12 +171,12 @@ public class SecurityConfigurationTest {
   @Test
   public void actuatorEndpoint_isAccessible() {
     ResponseEntity<String> response =
-        restTemplateBuilder
+        new RestTemplateBuilder()
             .rootUri("http://localhost:" + managementPort + "/actuator")
-            .setConnectTimeout(Duration.ofSeconds(60))
-            .setReadTimeout(Duration.ofSeconds(60))
+            .connectTimeout(Duration.ofSeconds(60))
+            .readTimeout(Duration.ofSeconds(60))
             .build()
-            .exchange("/metrics", HttpMethod.GET, new HttpEntity<>(null), String.class);
+            .getForEntity("/metrics", String.class);
 
     assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
   }


### PR DESCRIPTION
This pull request updates the `SecurityConfigurationTest` class to modernize the security test setup, simplify dependencies, and improve test reliability. The main changes involve switching from annotation-based mock user authentication to JWT-based authentication, removing unused dependencies, and updating client configuration for test environments.

**Authentication and Security Test Improvements:**

* Replaced usage of `@WithMockUser` with JWT-based authentication in MockMvc tests, using `jwt().authorities(...)` to simulate security contexts more accurately. (`SecurityConfigurationTest.java`)

**Dependency and Annotation Cleanup:**

* Removed unused annotations and dependencies such as `@CamundaSpringProcessTest`, `@SlowTest`, and `RestTemplateBuilder` injection, and replaced them with more appropriate mocks (e.g., added a `@MockitoBean` for `CamundaClient`). (`SecurityConfigurationTest.java`) [[1]](diffhunk://#diff-df29f2fa4a5868c990896aa34ded07152ac2f0006caebe0ade89d7100f02dea3L29-L31) [[2]](diffhunk://#diff-df29f2fa4a5868c990896aa34ded07152ac2f0006caebe0ade89d7100f02dea3R61-L76) [[3]](diffhunk://#diff-df29f2fa4a5868c990896aa34ded07152ac2f0006caebe0ade89d7100f02dea3L87-R87)

**Test Configuration Updates:**

* Updated test properties to use static values for `camunda.client.auth.token-url`, `client-id`, and `client-secret`, and removed dynamic OIDC server property assignment for `token-url`. (`SecurityConfigurationTest.java`)

**Code Modernization:**

* Updated the actuator endpoint test to use `RestTemplateBuilder` directly (instead of an injected instance), and switched from the deprecated `setConnectTimeout`/`setReadTimeout` to `connectTimeout`/`readTimeout` methods. Also simplified the HTTP request from `.exchange` to `.getForEntity`. (`SecurityConfigurationTest.java`)

**Imports and Cleanup:**

* Cleaned up unused imports and replaced them with only the necessary security and test utility imports. (`SecurityConfigurationTest.java`) [[1]](diffhunk://#diff-df29f2fa4a5868c990896aa34ded07152ac2f0006caebe0ade89d7100f02dea3R20) [[2]](diffhunk://#diff-df29f2fa4a5868c990896aa34ded07152ac2f0006caebe0ade89d7100f02dea3L42-R44)