### PR TITLE
test(e2e): accept empty tools list on agent-instance metrics update

### DIFF
--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/assertj/AgentInstanceClientVerifier.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/assertj/AgentInstanceClientVerifier.java
@@ -119,9 +119,6 @@ public class AgentInstanceClientVerifier {
                     request != null
                         && request.status() == endStatus
                         && Objects.equals(request.delta(), delta)
-                        // No tools on the metrics update (only THINKING carries them).
-                        // AgentInstanceUpdateRequest uses immutable collections, so an unset tools
-                        // list is normalized to an empty list rather than null.
                         && (request.tools() == null || request.tools().isEmpty())));
 
     final var expectedIterationKey = ++turnCount;

--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/assertj/AgentInstanceClientVerifier.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/assertj/AgentInstanceClientVerifier.java
@@ -119,7 +119,10 @@ public class AgentInstanceClientVerifier {
                     request != null
                         && request.status() == endStatus
                         && Objects.equals(request.delta(), delta)
-                        && request.tools() == null));
+                        // No tools on the metrics update (only THINKING carries them).
+                        // AgentInstanceUpdateRequest uses immutable collections, so an unset tools
+                        // list is normalized to an empty list rather than null.
+                        && (request.tools() == null || request.tools().isEmpty())));
 
     final var expectedIterationKey = ++turnCount;
     final var before = lastValue(beforeChatTurns);


### PR DESCRIPTION
## Description

#7662 changed the metrics-update matcher in `AgentInstanceClientVerifier`
to require `request.tools() == null`. However `AgentInstanceUpdateRequest` is
an `@AgenticAiRecord` built with `useImmutableCollections = true`, so an unset
tools list is normalized to a non-null empty list rather than null. The
metrics update therefore carries an empty collection, and the matcher could
never match, failing every toolCallTurn/finalAnswerTurn verification.

## Related issues

relates to #7640 

## Checklist

- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest
  release, as this branch will be rebased onto main before the next release. Example backport labels:
    - `backport stable/8.8`: for changes that should be included in the next 8.8.x release.
    - **or** `backport release-8.8.7`: for changes that should be included in the specific release 8.8.7, and this
      *release has already been created*. The release branch will be merged back into stable/8.8 later, so the change
      will be included in future 8.8.x releases as well.
- [ ] Tests/Integration tests for the changes have been added if applicable.
- [ ] If the change requires a documentation update, it has been added to the appropriate section in the documentation.