### PR TITLE
backport-7528-to-alpha/8.8

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -123,6 +123,13 @@
       "matchPackageNames": [
         "dev.langchain4j:{/,}**"
       ]
+    },
+    {
+      "description": "kafka-clients: stay on the Apache versioning track. The Confluent Platform builds (-ce/-ccs/-cp suffixes, e.g. 8.2.1-ce) are republished under the same org.apache.kafka coordinates via artifacts.camunda.com and must not be treated as upgrades to the Apache releases (x.y.z).",
+      "matchPackageNames": [
+        "org.apache.kafka:kafka-clients"
+      ],
+      "allowedVersions": "!/-(ce|ccs|cp\\d*)$/"
     }
   ],
   "baseBranchPatterns": [


### PR DESCRIPTION
## Summary

Backport of #7528 to stable/8.8.

- Adds a `packageRules` entry to `renovate.json` that restricts `org.apache.kafka:kafka-clients` to Apache-versioned releases only, blocking Confluent Platform builds (`-ce`/`-ccs`/`-cp*` suffixes) which are republished under the same Maven coordinates via artifacts.camunda.com.

## Test plan

- [ ] Verify `renovate.json` is valid JSON
- [ ] Confirm Renovate does not propose Confluent-suffixed kafka-clients upgrades on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)