### PR TITLE
[Backport stable/8.7] fix(document-handling): Fix missing file size check on large inline documents

### DIFF
--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/correlation/InboundCorrelationHandler.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/correlation/InboundCorrelationHandler.java
@@ -20,7 +20,6 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.connector.api.document.InlineSizeGuard;
 import io.camunda.connector.api.error.ConnectorInputException;
-import io.camunda.connector.api.json.ConnectorsObjectMapperSupplier;
 import io.camunda.connector.api.inbound.ActivationCheckResult;
 import io.camunda.connector.api.inbound.CorrelationRequest;
 import io.camunda.connector.api.inbound.CorrelationResult;
@@ -29,6 +28,7 @@ import io.camunda.connector.api.inbound.CorrelationResult.Failure.ActivationCond
 import io.camunda.connector.api.inbound.CorrelationResult.Failure.Other;
 import io.camunda.connector.api.inbound.CorrelationResult.Success.MessageAlreadyCorrelated;
 import io.camunda.connector.api.inbound.ProcessElementContext;
+import io.camunda.connector.api.json.ConnectorsObjectMapperSupplier;
 import io.camunda.connector.feel.FeelEngineWrapper;
 import io.camunda.connector.feel.FeelEngineWrapperException;
 import io.camunda.connector.runtime.core.ConnectorHelper;

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/correlation/InboundCorrelationHandler.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/correlation/InboundCorrelationHandler.java
@@ -16,7 +16,11 @@
  */
 package io.camunda.connector.runtime.core.inbound.correlation;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.connector.api.document.InlineSizeGuard;
 import io.camunda.connector.api.error.ConnectorInputException;
+import io.camunda.connector.api.json.ConnectorsObjectMapperSupplier;
 import io.camunda.connector.api.inbound.ActivationCheckResult;
 import io.camunda.connector.api.inbound.CorrelationRequest;
 import io.camunda.connector.api.inbound.CorrelationResult;
@@ -49,6 +53,7 @@ public class InboundCorrelationHandler {
 
   private final ZeebeClient zeebeClient;
   private final FeelEngineWrapper feelEngine;
+  private final ObjectMapper objectMapper;
 
   private final ProcessElementContextFactory processElementContextFactory;
 
@@ -61,6 +66,7 @@ public class InboundCorrelationHandler {
       Duration defaultMessageTtl) {
     this.zeebeClient = zeebeClient;
     this.feelEngine = feelEngine;
+    this.objectMapper = ConnectorsObjectMapperSupplier.getCopy();
     this.processElementContextFactory = processElementContextFactory;
     this.defaultMessageTtl = defaultMessageTtl;
   }
@@ -122,6 +128,11 @@ public class InboundCorrelationHandler {
       Object variables) {
 
     Object extractedVariables = extractVariables(variables, activatedElement);
+    try {
+      checkVariablesSize(extractedVariables);
+    } catch (ConnectorInputException e) {
+      return new CorrelationResult.Failure.InvalidInput(e.getMessage(), e);
+    }
 
     try {
       ProcessInstanceEvent result =
@@ -196,6 +207,11 @@ public class InboundCorrelationHandler {
       Duration timeToLive,
       String correlationKey) {
     Object extractedVariables = extractVariables(variables, activatedElement);
+    try {
+      checkVariablesSize(extractedVariables);
+    } catch (ConnectorInputException e) {
+      return new CorrelationResult.Failure.InvalidInput(e.getMessage(), e);
+    }
     CorrelationResult result;
     try {
       var command =
@@ -302,6 +318,15 @@ public class InboundCorrelationHandler {
   protected Object extractVariables(Object rawVariables, InboundConnectorElement definition) {
     return ConnectorHelper.createOutputVariables(
         rawVariables, definition.resultVariable(), definition.resultExpression());
+  }
+
+  private void checkVariablesSize(Object variables) {
+    if (variables == null) return;
+    try {
+      InlineSizeGuard.check(objectMapper.writeValueAsBytes(variables).length);
+    } catch (JsonProcessingException e) {
+      throw new RuntimeException("Failed to serialize variables for size check", e);
+    }
   }
 
   private String resolveMessageId(String messageIdExpression, String messageId, Object context) {

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/outbound/ConnectorJobHandler.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/outbound/ConnectorJobHandler.java
@@ -17,7 +17,9 @@
 
 package io.camunda.connector.runtime.core.outbound;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.connector.api.document.InlineSizeGuard;
 import io.camunda.connector.api.outbound.OutboundConnectorFunction;
 import io.camunda.connector.api.secret.SecretProvider;
 import io.camunda.connector.api.validation.ValidationProvider;
@@ -139,6 +141,9 @@ public class ConnectorJobHandler implements JobHandler {
               response,
               job.getCustomHeaders().get(Keywords.RESULT_VARIABLE_KEYWORD),
               job.getCustomHeaders().get(Keywords.RESULT_EXPRESSION_KEYWORD));
+      if (!responseVariables.isEmpty()) {
+        InlineSizeGuard.check(objectMapper.writeValueAsBytes(responseVariables).length);
+      }
       return new SuccessResult(response, responseVariables);
     } catch (Exception e) {
       return outboundConnectorExceptionHandler.manageConnectorJobHandlerException(
@@ -197,6 +202,7 @@ public class ConnectorJobHandler implements JobHandler {
 
   private void handleBPMNError(JobClient client, ActivatedJob job, ConnectorError error) {
     if (error instanceof BpmnError bpmnError) {
+      checkVariablesSize(bpmnError.variables());
       LOGGER.debug("Throwing BPMN error for job {} with code {}", job.getKey(), bpmnError.code());
       throwBpmnError(client, job, bpmnError);
     } else if (error instanceof JobError jobError) {
@@ -209,6 +215,15 @@ public class ConnectorJobHandler implements JobHandler {
               new RuntimeException(jobError.message()),
               jobError.retries(),
               jobError.retryBackoff()));
+    }
+  }
+
+  private void checkVariablesSize(Map<String, Object> variables) {
+    if (variables == null || variables.isEmpty()) return;
+    try {
+      InlineSizeGuard.check(objectMapper.writeValueAsBytes(variables).length);
+    } catch (JsonProcessingException e) {
+      throw new RuntimeException("Failed to serialize variables for size check", e);
     }
   }
 

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/outbound/ConnectorJobHandler.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/outbound/ConnectorJobHandler.java
@@ -20,6 +20,7 @@ package io.camunda.connector.runtime.core.outbound;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.connector.api.document.InlineSizeGuard;
+import io.camunda.connector.api.json.ConnectorsObjectMapperSupplier;
 import io.camunda.connector.api.outbound.OutboundConnectorFunction;
 import io.camunda.connector.api.secret.SecretProvider;
 import io.camunda.connector.api.validation.ValidationProvider;
@@ -142,7 +143,7 @@ public class ConnectorJobHandler implements JobHandler {
               job.getCustomHeaders().get(Keywords.RESULT_VARIABLE_KEYWORD),
               job.getCustomHeaders().get(Keywords.RESULT_EXPRESSION_KEYWORD));
       if (!responseVariables.isEmpty()) {
-        InlineSizeGuard.check(objectMapper.writeValueAsBytes(responseVariables).length);
+        InlineSizeGuard.check(sizeCheckMapper().writeValueAsBytes(responseVariables).length);
       }
       return new SuccessResult(response, responseVariables);
     } catch (Exception e) {
@@ -221,10 +222,14 @@ public class ConnectorJobHandler implements JobHandler {
   private void checkVariablesSize(Map<String, Object> variables) {
     if (variables == null || variables.isEmpty()) return;
     try {
-      InlineSizeGuard.check(objectMapper.writeValueAsBytes(variables).length);
+      InlineSizeGuard.check(sizeCheckMapper().writeValueAsBytes(variables).length);
     } catch (JsonProcessingException e) {
       throw new RuntimeException("Failed to serialize variables for size check", e);
     }
+  }
+
+  private ObjectMapper sizeCheckMapper() {
+    return objectMapper != null ? objectMapper : ConnectorsObjectMapperSupplier.getCopy();
   }
 
   protected SecretProvider getSecretProvider() {

--- a/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/outbound/ConnectorJobHandlerTest.java
+++ b/connector-runtime/connector-runtime-core/src/test/java/io/camunda/connector/runtime/core/outbound/ConnectorJobHandlerTest.java
@@ -33,6 +33,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import io.camunda.connector.api.document.InlineSizeGuard;
 import io.camunda.connector.api.error.ConnectorException;
 import io.camunda.connector.api.error.ConnectorExceptionBuilder;
 import io.camunda.connector.api.error.ConnectorInputException;
@@ -153,6 +154,39 @@ class ConnectorJobHandlerTest {
 
         // then
         assertThat(result.getVariables()).isEqualTo(Map.of("result", 1));
+      }
+
+      @Test
+      void shouldFailJobWhenResultVariableExceedsZeebeLimit() {
+        // given
+        String largeValue = "x".repeat((int) InlineSizeGuard.MAX_INLINE_BYTES + 1);
+        var jobHandler = newConnectorJobHandler((ctx) -> largeValue);
+
+        // when
+        var result =
+            JobBuilder.create()
+                .withRetries(3)
+                .withResultVariableHeader("result")
+                .executeAndCaptureResult(jobHandler, false);
+
+        // then
+        assertThat(result.getRetries()).isEqualTo(0);
+        assertThat(result.getErrorMessage()).contains("Create document");
+      }
+
+      @Test
+      void shouldCompleteJobWhenResultVariableBelowZeebeLimit() {
+        // given
+        var jobHandler = newConnectorJobHandler((ctx) -> "small value");
+
+        // when
+        var result =
+            JobBuilder.create()
+                .withResultVariableHeader("result")
+                .executeAndCaptureResult(jobHandler);
+
+        // then
+        assertThat(result.getVariables()).containsKey("result");
       }
     }
 

--- a/connector-sdk/core/src/main/java/io/camunda/connector/api/document/InlineSizeGuard.java
+++ b/connector-sdk/core/src/main/java/io/camunda/connector/api/document/InlineSizeGuard.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.api.document;
+
+import io.camunda.connector.api.error.ConnectorInputException;
+
+public final class InlineSizeGuard {
+
+  // Zeebe safe limit for commands that include variables (e.g. complete-job):
+  // https://docs.camunda.io/docs/components/concepts/variables/#variable-size-limitation
+  public static final long MAX_INLINE_BYTES = 3L * 1024 * 1024 / 2; // 1.5 MB
+
+  private InlineSizeGuard() {}
+
+  public static void check(long sizeBytes) {
+    if (sizeBytes > MAX_INLINE_BYTES) {
+      throw new ConnectorInputException(
+          "Output variables payload (%d bytes) exceeds the 1.5 MB safe variable size limit for Zeebe job completion. To handle large payloads, enable the 'Create document' option where available."
+              .formatted(sizeBytes));
+    }
+  }
+}


### PR DESCRIPTION
Backport of #7608 to stable/8.7.

## Summary

- Adds `InlineSizeGuard` to `connector-sdk/core` (package `io.camunda.connector.api.document`)
- Guards outbound job completion against oversized variables in `ConnectorJobHandler` (the base class used in 8.7's architecture)
- Guards inbound correlation message variables in `InboundCorrelationHandler`

## Conflict resolution

- **stable/8.7 uses `ZeebeClient`** (not yet migrated to `CamundaClient`) — `InboundCorrelationHandler` was adapted to keep the ZeebeClient-based implementation while adding the size guard
- **`SpringConnectorJobHandler` moved to `jobhandling` package** in 8.7 — the outbound guard was applied to `ConnectorJobHandler` (parent class) instead
- **`InlineSizeGuard.java` file location** — git suggested the wrong directory; placed in `connector-sdk/core` to match `package io.camunda.connector.api.document`
- **`ObjectMapper`** — initialized via `ConnectorsObjectMapperSupplier.getCopy()` to avoid changing the existing constructor

🤖 Generated with [Claude Code](https://claude.ai/claude-code)