### PR TITLE
[Backport stable/8.8] fix(document-handling): Fix missing file size check on large inline documents

### DIFF
--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/correlation/InboundCorrelationHandler.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/correlation/InboundCorrelationHandler.java
@@ -16,11 +16,13 @@
  */
 package io.camunda.connector.runtime.core.inbound.correlation;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.command.ClientStatusException;
 import io.camunda.client.api.response.ProcessInstanceEvent;
 import io.camunda.client.api.response.PublishMessageResponse;
+import io.camunda.connector.api.document.InlineSizeGuard;
 import io.camunda.connector.api.error.ConnectorInputException;
 import io.camunda.connector.api.inbound.ActivationCheckResult;
 import io.camunda.connector.api.inbound.CorrelationRequest;
@@ -49,6 +51,7 @@ public class InboundCorrelationHandler {
 
   private final CamundaClient camundaClient;
   private final FeelEngineWrapper feelEngine;
+  private final ObjectMapper objectMapper;
 
   private final Duration defaultMessageTtl;
 
@@ -61,6 +64,7 @@ public class InboundCorrelationHandler {
       Duration defaultMessageTtl) {
     this.camundaClient = camundaClient;
     this.feelEngine = feelEngine;
+    this.objectMapper = objectMapper;
     this.defaultMessageTtl = defaultMessageTtl;
     this.connectorResultHandler = new ConnectorResultHandler(objectMapper);
   }
@@ -122,6 +126,11 @@ public class InboundCorrelationHandler {
       Object variables) {
 
     Object extractedVariables = extractVariables(variables, activatedElement);
+    try {
+      checkVariablesSize(extractedVariables);
+    } catch (ConnectorInputException e) {
+      return new CorrelationResult.Failure.InvalidInput(e.getMessage(), e);
+    }
 
     try {
       ProcessInstanceEvent result =
@@ -194,6 +203,11 @@ public class InboundCorrelationHandler {
       Duration timeToLive,
       String correlationKey) {
     Object extractedVariables = extractVariables(variables, activatedElement);
+    try {
+      checkVariablesSize(extractedVariables);
+    } catch (ConnectorInputException e) {
+      return new CorrelationResult.Failure.InvalidInput(e.getMessage(), e);
+    }
     CorrelationResult result;
     try {
       var command =
@@ -296,6 +310,15 @@ public class InboundCorrelationHandler {
   protected Object extractVariables(Object rawVariables, InboundConnectorElement definition) {
     return connectorResultHandler.createOutputVariables(
         rawVariables, definition.resultVariable(), definition.resultExpression());
+  }
+
+  private void checkVariablesSize(Object variables) {
+    if (variables == null) return;
+    try {
+      InlineSizeGuard.check(objectMapper.writeValueAsBytes(variables).length);
+    } catch (JsonProcessingException e) {
+      throw new RuntimeException("Failed to serialize variables for size check", e);
+    }
   }
 
   private String resolveMessageId(String messageIdExpression, String messageId, Object context) {

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/SpringConnectorJobHandler.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/SpringConnectorJobHandler.java
@@ -16,6 +16,7 @@
  */
 package io.camunda.connector.runtime.outbound.job;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.client.api.command.FinalCommandStep;
 import io.camunda.client.api.command.ThrowErrorCommandStep1;
@@ -28,6 +29,7 @@ import io.camunda.client.jobhandling.CommandExceptionHandlingStrategy;
 import io.camunda.client.jobhandling.CommandWrapper;
 import io.camunda.client.metrics.DefaultNoopMetricsRecorder;
 import io.camunda.connector.api.document.DocumentFactory;
+import io.camunda.connector.api.document.InlineSizeGuard;
 import io.camunda.connector.api.outbound.OutboundConnectorFunction;
 import io.camunda.connector.api.secret.SecretProvider;
 import io.camunda.connector.api.validation.ValidationProvider;
@@ -144,6 +146,9 @@ public class SpringConnectorJobHandler implements JobHandler {
               response,
               job.getCustomHeaders().get(Keywords.RESULT_VARIABLE_KEYWORD),
               job.getCustomHeaders().get(Keywords.RESULT_EXPRESSION_KEYWORD));
+      if (!responseVariables.isEmpty()) {
+        InlineSizeGuard.check(objectMapper.writeValueAsBytes(responseVariables).length);
+      }
       return new ConnectorResult.SuccessResult(response, responseVariables);
     } catch (Exception e) {
       return outboundConnectorExceptionHandler.manageConnectorJobHandlerException(
@@ -187,10 +192,12 @@ public class SpringConnectorJobHandler implements JobHandler {
 
   private void handleBPMNError(JobClient client, ActivatedJob job, ConnectorError error) {
     if (error instanceof BpmnError bpmnError) {
+      checkVariablesSize(bpmnError.variables());
       LOGGER.debug(
           "Throwing BPMN error for job {} with code {}", job.getKey(), bpmnError.errorCode());
       throwBpmnError(client, job, bpmnError);
     } else if (error instanceof JobError jobError) {
+      checkVariablesSize(jobError.variablesWithErrorMessage());
       LOGGER.debug("Throwing incident for job {}", job.getKey());
       failJob(
           client,
@@ -302,6 +309,15 @@ public class SpringConnectorJobHandler implements JobHandler {
         .errorCode(error.errorCode())
         .variables(error.variables())
         .errorMessage(truncateErrorMessage(error.errorMessage()));
+  }
+
+  private void checkVariablesSize(Map<String, Object> variables) {
+    if (variables == null || variables.isEmpty()) return;
+    try {
+      InlineSizeGuard.check(objectMapper.writeValueAsBytes(variables).length);
+    } catch (JsonProcessingException e) {
+      throw new RuntimeException("Failed to serialize variables for size check", e);
+    }
   }
 
   private static String truncateErrorMessage(String message) {

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/SpringConnectorJobHandler.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/job/SpringConnectorJobHandler.java
@@ -197,7 +197,7 @@ public class SpringConnectorJobHandler implements JobHandler {
           "Throwing BPMN error for job {} with code {}", job.getKey(), bpmnError.errorCode());
       throwBpmnError(client, job, bpmnError);
     } else if (error instanceof JobError jobError) {
-      checkVariablesSize(jobError.variablesWithErrorMessage());
+      checkVariablesSize(jobError.variables());
       LOGGER.debug("Throwing incident for job {}", job.getKey());
       failJob(
           client,

--- a/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/job/SpringConnectorJobHandlerTest.java
+++ b/connector-runtime/connector-runtime-spring/src/test/java/io/camunda/connector/runtime/outbound/job/SpringConnectorJobHandlerTest.java
@@ -183,6 +183,42 @@ class SpringConnectorJobHandlerTest {
         // then
         assertThat(result.getVariables()).isEqualTo(Map.of("result", 1));
       }
+
+      @Test
+      void shouldFailJobWhenResultVariableExceedsZeebeLimit() throws Exception {
+        // given
+        String largeValue =
+            "x"
+                .repeat(
+                    (int) io.camunda.connector.api.document.InlineSizeGuard.MAX_INLINE_BYTES + 1);
+        var jobHandler = newConnectorJobHandler((ctx) -> largeValue);
+
+        // when
+        var result =
+            JobBuilder.create()
+                .withRetries(3)
+                .withResultVariableHeader("result")
+                .executeAndCaptureResult(jobHandler, false);
+
+        // then - oversized payload is a deterministic input error: immediate incident, no retries
+        assertThat(result.getRetries()).isEqualTo(0);
+        assertThat(result.getErrorMessage()).contains("Create document");
+      }
+
+      @Test
+      void shouldCompleteJobWhenResultVariableBelowZeebeLimit() throws Exception {
+        // given
+        var jobHandler = newConnectorJobHandler((ctx) -> "small value");
+
+        // when
+        var result =
+            JobBuilder.create()
+                .withResultVariableHeader("result")
+                .executeAndCaptureResult(jobHandler);
+
+        // then
+        assertThat(result.getVariables()).containsKey("result");
+      }
     }
 
     @Nested

--- a/connector-sdk/core/src/main/java/io/camunda/connector/api/document/InlineSizeGuard.java
+++ b/connector-sdk/core/src/main/java/io/camunda/connector/api/document/InlineSizeGuard.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.api.document;
+
+import io.camunda.connector.api.error.ConnectorInputException;
+
+public final class InlineSizeGuard {
+
+  // Zeebe safe limit for commands that include variables (e.g. complete-job):
+  // https://docs.camunda.io/docs/components/concepts/variables/#variable-size-limitation
+  public static final long MAX_INLINE_BYTES = 3L * 1024 * 1024 / 2; // 1.5 MB
+
+  private InlineSizeGuard() {}
+
+  public static void check(long sizeBytes) {
+    if (sizeBytes > MAX_INLINE_BYTES) {
+      throw new ConnectorInputException(
+          "Output variables payload (%d bytes) exceeds the 1.5 MB safe variable size limit for Zeebe job completion. To handle large payloads, enable the 'Create document' option where available."
+              .formatted(sizeBytes));
+    }
+  }
+}


### PR DESCRIPTION
Backport of #7608 to stable/8.8.

## Summary

- Adds `InlineSizeGuard` to `connector-sdk/core` (already at correct path — auto-staged)
- Guards outbound job completion against oversized variables in `SpringConnectorJobHandler`
- Guards inbound correlation message variables in `InboundCorrelationHandler`

## Conflict resolution

- **`SpringConnectorJobHandler`** — 8.8 uses `ConnectorsOutboundMetrics`/`DefaultNoopMetricsRecorder` (different metrics API than main); kept 8.8 structure, added `InlineSizeGuard` checks for response variables and BPMN/job error variables
- **`InboundCorrelationHandler`** — 8.8 uses `CamundaClient` + `FeelEngineWrapper` (different constructor than main); kept 8.8 structure, added `objectMapper` field and size check in `triggerStartEvent` and `publishMessage`
- `SpringConnectorJobHandlerTest` auto-merged correctly

🤖 Generated with [Claude Code](https://claude.ai/claude-code)