### PR TITLE
feat(agentic-ai): apply @NullMarked to aiagent package

### DIFF
--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/.gitignore
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/.gitignore
@@ -1,1 +1,0 @@
-package-info.java

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/AiAgentSubProcessConnectorResponse.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/AiAgentSubProcessConnectorResponse.java
@@ -13,7 +13,7 @@ import io.camunda.connector.api.outbound.ConnectorResponse.AdHocSubProcessConnec
 import io.camunda.connector.api.outbound.JobCompletionFailure;
 import java.util.List;
 import java.util.Map;
-import org.springframework.lang.Nullable;
+import org.jspecify.annotations.Nullable;
 
 @AgenticAiRecord
 public record AiAgentSubProcessConnectorResponse(

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/AiAgentTaskConnectorResponse.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/AiAgentTaskConnectorResponse.java
@@ -10,7 +10,7 @@ import io.camunda.connector.agenticai.aiagent.agent.AgentJobCompletionListener;
 import io.camunda.connector.agenticai.aiagent.model.AgentResponse;
 import io.camunda.connector.api.outbound.ConnectorResponse.StandardConnectorResponse;
 import io.camunda.connector.api.outbound.JobCompletionFailure;
-import org.springframework.lang.Nullable;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Response type for the AI Agent task flavor (outbound connector on a service task). Carries an
@@ -22,7 +22,7 @@ public record AiAgentTaskConnectorResponse(
     implements StandardConnectorResponse, AgentJobCompletionListener {
 
   @Override
-  public Object responseValue() {
+  public @Nullable Object responseValue() {
     return agentResponse;
   }
 

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/agent/AgentConversationTurnInputComposerImpl.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/agent/AgentConversationTurnInputComposerImpl.java
@@ -36,6 +36,7 @@ import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -129,7 +130,7 @@ public class AgentConversationTurnInputComposerImpl implements AgentConversation
     return new CompositionResult.NextTurn(messages);
   }
 
-  private UserMessage createUserPromptMessage(AgentInput.UserPrompt userPrompt) {
+  private @Nullable UserMessage createUserPromptMessage(AgentInput.UserPrompt userPrompt) {
 
     final var content = new ArrayList<Content>();
 
@@ -196,7 +197,7 @@ public class AgentConversationTurnInputComposerImpl implements AgentConversation
             .build());
   }
 
-  private UserMessage createDocumentMessageForToolResults(List<ToolCallResult> results) {
+  private @Nullable UserMessage createDocumentMessageForToolResults(List<ToolCallResult> results) {
     final var toolCallDocuments = documentExtractor.extractDocuments(results);
     if (toolCallDocuments.isEmpty()) {
       return null;
@@ -217,7 +218,7 @@ public class AgentConversationTurnInputComposerImpl implements AgentConversation
     Object eventContent = eventResult.content();
 
     List<Content> userMessageContent = new ArrayList<>();
-    if (isEventContentEmpty(eventContent)) {
+    if (eventContent == null || isEventContentEmpty(eventContent)) {
       userMessageContent.add(
           textContent(
               interruptToolCallsOnEventResults
@@ -260,7 +261,7 @@ public class AgentConversationTurnInputComposerImpl implements AgentConversation
     return content;
   }
 
-  private boolean isEventContentEmpty(Object eventContent) {
+  private boolean isEventContentEmpty(@Nullable Object eventContent) {
     return switch (eventContent) {
       case null -> true;
       case String textContent -> StringUtils.isBlank(textContent);

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/agent/AgentJobCompletionListener.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/agent/AgentJobCompletionListener.java
@@ -30,7 +30,8 @@ public interface AgentJobCompletionListener {
    * Chains an arbitrary number of listeners, skipping nulls. Each listener is called regardless of
    * whether a previous one threw; exceptions are logged and swallowed.
    */
-  static @Nullable AgentJobCompletionListener compose(AgentJobCompletionListener... listeners) {
+  static @Nullable AgentJobCompletionListener compose(
+      @Nullable AgentJobCompletionListener... listeners) {
     final var nonNull = Arrays.stream(listeners).filter(Objects::nonNull).toList();
     return switch (nonNull.size()) {
       case 0 -> null;

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/agent/AgentResponseHandlerImpl.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/agent/AgentResponseHandlerImpl.java
@@ -25,6 +25,7 @@ import io.camunda.connector.agenticai.aiagent.model.tool.ToolCallProcessVariable
 import io.camunda.connector.agenticai.aiagent.tool.GatewayToolHandlerRegistry;
 import io.camunda.connector.api.error.ConnectorException;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
@@ -49,13 +50,15 @@ public class AgentResponseHandlerImpl implements AgentResponseHandler {
   public AgentResponse createResponse(AgentConversation conversation) {
     final var agentContext = conversation.toAgentContext();
     final var assistantMessage =
-        conversation
-            .lastTurn()
-            .orElseThrow(
-                () ->
-                    new IllegalStateException(
-                        "Cannot create an agent response: the conversation has no completed turn"))
-            .assistantMessage();
+        Objects.requireNonNull(
+            conversation
+                .lastTurn()
+                .orElseThrow(
+                    () ->
+                        new IllegalStateException(
+                            "Cannot create an agent response: the conversation has no completed turn"))
+                .assistantMessage(),
+            "Cannot create an agent response: the last turn has no assistant message");
     final var rawToolCalls = Optional.ofNullable(assistantMessage.toolCalls()).orElse(List.of());
     final var toolCalls =
         gatewayToolHandlers.transformToolCalls(agentContext, rawToolCalls).stream()

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/agent/AgentResponseHandlerImpl.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/agent/AgentResponseHandlerImpl.java
@@ -147,7 +147,7 @@ public class AgentResponseHandlerImpl implements AgentResponseHandler {
       throws JsonProcessingException {
     // Strip markdown code blocks before parsing to handle AI models (like Anthropic Claude)
     // that wrap JSON responses in ```json ... ``` code fences
-    String cleanedText = stripMarkdownCodeBlocks(responseText);
+    String cleanedText = Objects.requireNonNull(stripMarkdownCodeBlocks(responseText));
     Object responseJson = objectMapper.readValue(cleanedText, Object.class);
     responseBuilder.responseJson(responseJson);
   }

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/agent/BaseAgentRequestHandler.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/agent/BaseAgentRequestHandler.java
@@ -376,7 +376,7 @@ public abstract class BaseAgentRequestHandler<
   }
 
   private static <C extends AgentExecutionContext>
-      AgentJobCompletionListener createStoreCompletionListener(
+      @Nullable AgentJobCompletionListener createStoreCompletionListener(
           C executionContext, ConversationStore store, @Nullable AgentResponse agentResponse) {
     if (agentResponse == null) {
       return null;

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/agent/ContentTreeDocumentWalker.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/agent/ContentTreeDocumentWalker.java
@@ -11,6 +11,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Stateless utility that recursively walks an arbitrary content tree and collects {@link Document}
@@ -28,7 +29,7 @@ public final class ContentTreeDocumentWalker {
 
   private ContentTreeDocumentWalker() {}
 
-  public static List<Document> extractDocumentsFromContent(Object content) {
+  public static List<Document> extractDocumentsFromContent(@Nullable Object content) {
     if (content == null) {
       return List.of();
     }

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/agent/JobWorkerAgentRequestHandler.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/agent/JobWorkerAgentRequestHandler.java
@@ -21,6 +21,7 @@ import io.camunda.connector.api.outbound.ConnectorResponse.AdHocSubProcessConnec
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -69,9 +70,9 @@ public class JobWorkerAgentRequestHandler
   @Override
   public AiAgentSubProcessConnectorResponse buildConnectorResponse(
       JobWorkerAgentExecutionContext executionContext,
-      AgentConversation conversation,
-      AgentResponse agentResponse,
-      AgentJobCompletionListener completionListener) {
+      @Nullable AgentConversation conversation,
+      @Nullable AgentResponse agentResponse,
+      @Nullable AgentJobCompletionListener completionListener) {
     if (agentResponse == null) {
       LOGGER.debug(
           "No agent response provided, completing job {} without response",
@@ -97,9 +98,9 @@ public class JobWorkerAgentRequestHandler
 
   private AiAgentSubProcessConnectorResponse buildResponse(
       JobWorkerAgentExecutionContext executionContext,
-      AgentConversation conversation,
+      @Nullable AgentConversation conversation,
       AgentResponse agentResponse,
-      AgentJobCompletionListener completionListener) {
+      @Nullable AgentJobCompletionListener completionListener) {
     boolean completionConditionFulfilled = agentResponse.toolCalls().isEmpty();
     // cancel remaining instances if any tool call in this turn's input was interrupted
     boolean cancelRemainingInstances =

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/agent/OutboundConnectorAgentRequestHandler.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/agent/OutboundConnectorAgentRequestHandler.java
@@ -15,6 +15,7 @@ import io.camunda.connector.agenticai.aiagent.model.AgentResponse;
 import io.camunda.connector.agenticai.aiagent.model.OutboundConnectorAgentExecutionContext;
 import io.camunda.connector.agenticai.aiagent.systemprompt.SystemPromptComposer;
 import io.camunda.connector.api.error.ConnectorException;
+import org.jspecify.annotations.Nullable;
 
 public class OutboundConnectorAgentRequestHandler
     extends BaseAgentRequestHandler<
@@ -54,9 +55,9 @@ public class OutboundConnectorAgentRequestHandler
   @Override
   public AiAgentTaskConnectorResponse buildConnectorResponse(
       OutboundConnectorAgentExecutionContext executionContext,
-      AgentConversation conversation,
-      AgentResponse agentResponse,
-      AgentJobCompletionListener completionListener) {
+      @Nullable AgentConversation conversation,
+      @Nullable AgentResponse agentResponse,
+      @Nullable AgentJobCompletionListener completionListener) {
     return new AiAgentTaskConnectorResponse(agentResponse, completionListener);
   }
 }

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/agent/ToolCallResultDocumentExtractor.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/agent/ToolCallResultDocumentExtractor.java
@@ -14,6 +14,8 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -34,7 +36,7 @@ public class ToolCallResultDocumentExtractor {
 
   /** Documents extracted from a single tool call result, grouped with the tool call identity. */
   public record ToolCallDocuments(
-      String toolCallId, String toolCallName, List<Document> documents) {}
+      @Nullable String toolCallId, @Nullable String toolCallName, List<Document> documents) {}
 
   private final GatewayToolHandlerRegistry gatewayToolHandlers;
 
@@ -69,8 +71,8 @@ public class ToolCallResultDocumentExtractor {
 
   private List<Document> extractFromToolCallResult(ToolCallResult toolCallResult) {
     final var documents =
-        gatewayToolHandlers
-            .handlerForToolDefinition(toolCallResult.name())
+        Optional.ofNullable(toolCallResult.name())
+            .flatMap(gatewayToolHandlers::handlerForToolDefinition)
             .map(handler -> handler.extractDocuments(toolCallResult))
             .orElseGet(
                 () ->

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/agent/package-info.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/agent/package-info.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+@NullMarked
+package io.camunda.connector.agenticai.aiagent.agent;
+
+import org.jspecify.annotations.NullMarked;

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/agentinstance/package-info.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/agentinstance/package-info.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+@NullMarked
+package io.camunda.connector.agenticai.aiagent.agentinstance;
+
+import org.jspecify.annotations.NullMarked;

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/ChatModelHttpProxySupport.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/ChatModelHttpProxySupport.java
@@ -23,6 +23,8 @@ import java.util.concurrent.Executor;
 import java.util.stream.Collectors;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLParameters;
+import org.jspecify.annotations.NullUnmarked;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.http.apache.ApacheHttpClient;
@@ -65,6 +67,9 @@ public class ChatModelHttpProxySupport {
    * actual client. {@link CapturingBridge#build()} captures the resulting instance for {@link
    * #close()}.
    */
+  // @NullUnmarked: builtClient is set via the CapturingBridge callback during build(), not in the
+  // constructor.
+  @NullUnmarked
   public static final class CloseableJdkHttpClientBuilder extends JdkHttpClientBuilder
       implements AutoCloseable {
 
@@ -158,7 +163,7 @@ public class ChatModelHttpProxySupport {
     }
   }
 
-  public ApacheHttpClient.Builder createAwsHttpClientBuilder(URI endpointOverride) {
+  public ApacheHttpClient.Builder createAwsHttpClientBuilder(@Nullable URI endpointOverride) {
     String schemeName =
         endpointOverride != null ? endpointOverride.getScheme() : ProxyConfiguration.SCHEME_HTTPS;
     return ApacheHttpClient.builder().proxyConfiguration(createAwsProxyConfiguration(schemeName));

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/ContentConverter.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/ContentConverter.java
@@ -8,6 +8,7 @@ package io.camunda.connector.agenticai.aiagent.framework.langchain4j;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import io.camunda.connector.agenticai.aiagent.model.message.content.Content;
+import org.jspecify.annotations.Nullable;
 
 public interface ContentConverter {
   /** Converts a {@link Content} to a LangChain4j {@link dev.langchain4j.data.message.Content}. */
@@ -15,5 +16,5 @@ public interface ContentConverter {
       throws JsonProcessingException;
 
   /** Converts a result to a string representation. */
-  String convertToString(Object content) throws JsonProcessingException;
+  @Nullable String convertToString(@Nullable Object content) throws JsonProcessingException;
 }

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/ContentConverterImpl.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/ContentConverterImpl.java
@@ -13,6 +13,7 @@ import io.camunda.connector.agenticai.aiagent.model.message.content.Content;
 import io.camunda.connector.agenticai.aiagent.model.message.content.DocumentContent;
 import io.camunda.connector.agenticai.aiagent.model.message.content.ObjectContent;
 import io.camunda.connector.agenticai.aiagent.model.message.content.TextContent;
+import java.util.Objects;
 import org.jspecify.annotations.Nullable;
 
 public class ContentConverterImpl implements ContentConverter {
@@ -34,7 +35,8 @@ public class ContentConverterImpl implements ContentConverter {
       case DocumentContent documentContent ->
           documentToContentConverter.convert(documentContent.document());
       case ObjectContent objectContent ->
-          new dev.langchain4j.data.message.TextContent(convertToString(objectContent.content()));
+          new dev.langchain4j.data.message.TextContent(
+              Objects.requireNonNull(convertToString(objectContent.content())));
     };
   }
 

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/ContentConverterImpl.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/ContentConverterImpl.java
@@ -13,6 +13,7 @@ import io.camunda.connector.agenticai.aiagent.model.message.content.Content;
 import io.camunda.connector.agenticai.aiagent.model.message.content.DocumentContent;
 import io.camunda.connector.agenticai.aiagent.model.message.content.ObjectContent;
 import io.camunda.connector.agenticai.aiagent.model.message.content.TextContent;
+import org.jspecify.annotations.Nullable;
 
 public class ContentConverterImpl implements ContentConverter {
   private final DocumentToContentConverter documentToContentConverter;
@@ -38,7 +39,7 @@ public class ContentConverterImpl implements ContentConverter {
   }
 
   @Override
-  public String convertToString(Object content) throws JsonProcessingException {
+  public @Nullable String convertToString(@Nullable Object content) throws JsonProcessingException {
     if (content == null) {
       return null;
     }

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/Langchain4JAiFrameworkAdapter.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/Langchain4JAiFrameworkAdapter.java
@@ -27,6 +27,7 @@ import io.camunda.connector.agenticai.aiagent.model.request.ResponseFormatConfig
 import io.camunda.connector.api.error.ConnectorException;
 import java.util.Optional;
 import org.apache.commons.lang3.StringUtils;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -82,14 +83,16 @@ public class Langchain4JAiFrameworkAdapter
   }
 
   private void configureResponseFormat(
-      ChatRequest.Builder chatRequestBuilder, ResponseConfiguration responseConfiguration) {
+      ChatRequest.Builder chatRequestBuilder,
+      @Nullable ResponseConfiguration responseConfiguration) {
     final var responseFormat = createResponseFormat(responseConfiguration);
     if (responseFormat != null) {
       chatRequestBuilder.responseFormat(responseFormat);
     }
   }
 
-  private ResponseFormat createResponseFormat(ResponseConfiguration responseConfiguration) {
+  private @Nullable ResponseFormat createResponseFormat(
+      @Nullable ResponseConfiguration responseConfiguration) {
     // do not explicitely configure response format to TEXT as (depending on the model) this might
     // lead to exceptions
     if (responseConfiguration != null

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/configuration/package-info.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/configuration/package-info.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+@NullMarked
+package io.camunda.connector.agenticai.aiagent.framework.langchain4j.configuration;
+
+import org.jspecify.annotations.NullMarked;

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/document/package-info.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/document/package-info.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+@NullMarked
+package io.camunda.connector.agenticai.aiagent.framework.langchain4j.document;
+
+import org.jspecify.annotations.NullMarked;

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/jsonschema/package-info.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/jsonschema/package-info.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+@NullMarked
+package io.camunda.connector.agenticai.aiagent.framework.langchain4j.jsonschema;
+
+import org.jspecify.annotations.NullMarked;

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/package-info.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/package-info.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+@NullMarked
+package io.camunda.connector.agenticai.aiagent.framework.langchain4j;
+
+import org.jspecify.annotations.NullMarked;

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/provider/ChatModelProviderSupport.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/provider/ChatModelProviderSupport.java
@@ -10,6 +10,7 @@ import io.camunda.connector.agenticai.aiagent.model.request.provider.shared.Time
 import io.camunda.connector.agenticai.autoconfigure.AgenticAiConnectorsConfigurationProperties.ChatModelProperties;
 import java.time.Duration;
 import java.util.Optional;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 
 public final class ChatModelProviderSupport {
@@ -27,7 +28,7 @@ public final class ChatModelProviderSupport {
   public static Duration deriveTimeoutSetting(
       String timeoutType,
       ChatModelProperties chatModelConfig,
-      TimeoutConfiguration timeoutConfiguration,
+      @Nullable TimeoutConfiguration timeoutConfiguration,
       Logger logger) {
     var derivedTimeout =
         Optional.ofNullable(timeoutConfiguration)

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/provider/package-info.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/provider/package-info.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+@NullMarked
+package io.camunda.connector.agenticai.aiagent.framework.langchain4j.provider;
+
+import org.jspecify.annotations.NullMarked;

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/tool/ToolCallConverterImpl.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/tool/ToolCallConverterImpl.java
@@ -22,6 +22,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 import org.apache.commons.lang3.StringUtils;
+import org.jspecify.annotations.Nullable;
 
 public class ToolCallConverterImpl implements ToolCallConverter {
 
@@ -91,7 +92,7 @@ public class ToolCallConverterImpl implements ToolCallConverter {
     return toolExecutionResultMessage(id, name, content);
   }
 
-  private String contentAsString(String toolName, Object result) {
+  private @Nullable String contentAsString(String toolName, @Nullable Object result) {
     try {
       if (result == null) {
         return null;

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/tool/package-info.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/langchain4j/tool/package-info.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+@NullMarked
+package io.camunda.connector.agenticai.aiagent.framework.langchain4j.tool;
+
+import org.jspecify.annotations.NullMarked;

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/package-info.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/framework/package-info.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+@NullMarked
+package io.camunda.connector.agenticai.aiagent.framework;
+
+import org.jspecify.annotations.NullMarked;

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/memory/conversation/ConversationUtil.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/memory/conversation/ConversationUtil.java
@@ -8,10 +8,11 @@ package io.camunda.connector.agenticai.aiagent.memory.conversation;
 
 import io.camunda.connector.agenticai.aiagent.model.AgentContext;
 import java.util.Optional;
+import org.jspecify.annotations.Nullable;
 
 public class ConversationUtil {
 
-  public static <C extends ConversationContext> C loadConversationContext(
+  public static <C extends ConversationContext> @Nullable C loadConversationContext(
       AgentContext agentContext, Class<C> contextClass) {
     final var conversationContext =
         Optional.ofNullable(agentContext).map(AgentContext::conversation).orElse(null);

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/memory/conversation/awsagentcore/AwsAgentCoreConversationContext.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/memory/conversation/awsagentcore/AwsAgentCoreConversationContext.java
@@ -11,7 +11,7 @@ import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import io.camunda.connector.agenticai.aiagent.memory.conversation.ConversationContext;
 import io.camunda.connector.agenticai.aiagent.model.message.SystemMessage;
 import io.camunda.connector.agenticai.common.AgenticAiRecord;
-import jakarta.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Conversation context for AWS AgentCore Memory storage.

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/memory/conversation/awsagentcore/AwsAgentCoreConversationSession.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/memory/conversation/awsagentcore/AwsAgentCoreConversationSession.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.services.bedrockagentcore.BedrockAgentCoreClient;
@@ -59,10 +60,10 @@ public class AwsAgentCoreConversationSession implements ConversationSession {
   private final BedrockAgentCoreClient client;
   private final AwsAgentCoreConversationMapper conversationMapper;
 
-  private AwsAgentCoreConversationContext previousConversationContext;
-  private String sessionId;
-  private String branchName;
-  private String lastEventId;
+  @Nullable private AwsAgentCoreConversationContext previousConversationContext;
+  @Nullable private String sessionId;
+  @Nullable private String branchName;
+  @Nullable private String lastEventId;
   private int initialMessageCount = 0;
 
   public AwsAgentCoreConversationSession(
@@ -110,6 +111,10 @@ public class AwsAgentCoreConversationSession implements ConversationSession {
   @Override
   public ConversationContext storeMessages(
       AgentContext agentContext, ConversationStoreRequest request) {
+    final String currentSessionId = sessionId;
+    if (currentSessionId == null) {
+      throw new IllegalStateException("loadMessages() must be called before storeMessages()");
+    }
     final List<Message> allMessages = request.messages();
 
     // extract system message — needs to be preserved in context since AgentCore doesn't support it
@@ -140,7 +145,8 @@ public class AwsAgentCoreConversationSession implements ConversationSession {
       if (lastEventId != null) {
         branchName = UUID.randomUUID().toString();
       }
-      lastEventId = storeMessagesToAgentCore(sessionId, newMessages, branchName, lastEventId);
+      lastEventId =
+          storeMessagesToAgentCore(currentSessionId, newMessages, branchName, lastEventId);
       if (Objects.equals(lastEventId, previousLastEventId)) {
         // no events were actually written (all messages produced empty payloads) —
         // revert to the previous branch to avoid saving a phantom branch in context
@@ -149,14 +155,14 @@ public class AwsAgentCoreConversationSession implements ConversationSession {
       LOGGER.debug(
           "Stored {} new messages to AgentCore Memory for session '{}' on branch '{}'",
           newMessages.size(),
-          sessionId,
+          currentSessionId,
           branchName != null ? branchName : "<main>");
     }
 
     final var conversationContextBuilder =
         previousConversationContext != null
             ? previousConversationContext.with()
-            : AwsAgentCoreConversationContext.builder(sessionId)
+            : AwsAgentCoreConversationContext.builder(currentSessionId)
                 .memoryId(config.memoryId())
                 .actorId(config.actorId());
 
@@ -208,7 +214,7 @@ public class AwsAgentCoreConversationSession implements ConversationSession {
     }
   }
 
-  private List<Message> loadMessagesFromAgentCore(String sessionId, String branchName) {
+  private List<Message> loadMessagesFromAgentCore(String sessionId, @Nullable String branchName) {
     final var requestBuilder =
         ListEventsRequest.builder()
             .memoryId(config.memoryId())
@@ -275,8 +281,11 @@ public class AwsAgentCoreConversationSession implements ConversationSession {
    * @param rootEventId the event ID to fork from (null on first turn)
    * @return the event ID of the last written event
    */
-  private String storeMessagesToAgentCore(
-      String sessionId, List<Message> messages, String branchName, String rootEventId) {
+  private @Nullable String storeMessagesToAgentCore(
+      String sessionId,
+      List<Message> messages,
+      @Nullable String branchName,
+      @Nullable String rootEventId) {
     String lastEventId = rootEventId;
     final Branch branch =
         rootEventId != null
@@ -325,7 +334,7 @@ public class AwsAgentCoreConversationSession implements ConversationSession {
     return lastEventId;
   }
 
-  private static Integer extractSeq(Event event) {
+  private static @Nullable Integer extractSeq(Event event) {
     if (event.metadata() == null) {
       return null;
     }

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/memory/conversation/awsagentcore/mapping/AwsAgentCoreConversationMapper.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/memory/conversation/awsagentcore/mapping/AwsAgentCoreConversationMapper.java
@@ -26,6 +26,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
+import org.jspecify.annotations.Nullable;
 import software.amazon.awssdk.core.document.Document;
 import software.amazon.awssdk.services.bedrockagentcore.model.Conversational;
 import software.amazon.awssdk.services.bedrockagentcore.model.Event;
@@ -317,7 +318,7 @@ public class AwsAgentCoreConversationMapper {
   }
 
   private PayloadType createMetadataBlobPayload(
-      Map<String, Object> metadata, Map<String, Object> properties) {
+      Map<String, Object> metadata, @Nullable Map<String, Object> properties) {
     try {
       BlobEnvelope envelope = BlobEnvelope.forMetadata(metadata, properties, objectMapper);
       Document document = envelope.toDocument(objectMapper);
@@ -328,7 +329,7 @@ public class AwsAgentCoreConversationMapper {
     }
   }
 
-  private String extractTextFromConversational(Conversational conversational) {
+  private @Nullable String extractTextFromConversational(Conversational conversational) {
     if (conversational.content() == null) {
       return null;
     }
@@ -348,7 +349,8 @@ public class AwsAgentCoreConversationMapper {
     return envelope.parseData(TOOL_CALL_RESULTS_TYPE, objectMapper);
   }
 
-  private static Role resolveRoleFromProperties(Map<String, Object> properties) {
+  private static @Nullable Role resolveRoleFromProperties(
+      @Nullable Map<String, Object> properties) {
     if (properties == null) {
       return null;
     }
@@ -375,7 +377,7 @@ public class AwsAgentCoreConversationMapper {
    * properties section. The role is always included as the canonical source for message
    * reconstruction during deserialization.
    */
-  private Map<String, Object> extractProperties(Message message) {
+  private @Nullable Map<String, Object> extractProperties(Message message) {
     // role is the canonical source for deserialization — must always be present
     String role =
         switch (message) {
@@ -402,7 +404,7 @@ public class AwsAgentCoreConversationMapper {
    * non-recoverable errors that should be handled at the session level.
    */
   public static class AgentCoreMapperException extends RuntimeException {
-    public AgentCoreMapperException(String message, Throwable cause) {
+    public AgentCoreMapperException(String message, @Nullable Throwable cause) {
       super(message, cause);
     }
   }

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/memory/conversation/awsagentcore/mapping/BlobEnvelope.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/memory/conversation/awsagentcore/mapping/BlobEnvelope.java
@@ -17,6 +17,7 @@ import io.camunda.connector.agenticai.aiagent.model.tool.ToolCallResult;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
+import org.jspecify.annotations.Nullable;
 import software.amazon.awssdk.core.document.Document;
 
 /**
@@ -107,7 +108,9 @@ public record BlobEnvelope(String blobType, int version, JsonNode data) {
    * @return the envelope
    */
   public static BlobEnvelope forMetadata(
-      Map<String, Object> metadata, Map<String, Object> properties, ObjectMapper objectMapper) {
+      Map<String, Object> metadata,
+      @Nullable Map<String, Object> properties,
+      ObjectMapper objectMapper) {
     ObjectNode envelope = objectMapper.createObjectNode();
     envelope.put(FIELD_BLOB_TYPE, BlobEnvelopeType.MESSAGE_METADATA.getBlobType());
     envelope.put(FIELD_VERSION, CURRENT_VERSION);
@@ -191,7 +194,7 @@ public record BlobEnvelope(String blobType, int version, JsonNode data) {
    * @return the properties map, or null if not present
    * @throws IOException if deserialization fails
    */
-  public <T> T parseProperties(TypeReference<T> typeRef, ObjectMapper objectMapper)
+  public <T> @Nullable T parseProperties(TypeReference<T> typeRef, ObjectMapper objectMapper)
       throws IOException {
     if (!data.has(FIELD_PROPERTIES)) {
       return null;

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/memory/conversation/awsagentcore/mapping/package-info.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/memory/conversation/awsagentcore/mapping/package-info.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+@NullMarked
+package io.camunda.connector.agenticai.aiagent.memory.conversation.awsagentcore.mapping;
+
+import org.jspecify.annotations.NullMarked;

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/memory/conversation/awsagentcore/package-info.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/memory/conversation/awsagentcore/package-info.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+@NullMarked
+package io.camunda.connector.agenticai.aiagent.memory.conversation.awsagentcore;
+
+import org.jspecify.annotations.NullMarked;

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/memory/conversation/document/CamundaDocumentConversationSession.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/memory/conversation/document/CamundaDocumentConversationSession.java
@@ -30,6 +30,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -47,7 +48,7 @@ public class CamundaDocumentConversationSession implements ConversationSession {
   private final AgentExecutionContext executionContext;
   private final int previousDocumentsRetentionSize;
 
-  private CamundaDocumentConversationContext previousConversationContext;
+  private @Nullable CamundaDocumentConversationContext previousConversationContext;
 
   public CamundaDocumentConversationSession(
       CamundaDocumentMemoryStorageConfiguration config,

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/memory/conversation/document/package-info.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/memory/conversation/document/package-info.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+@NullMarked
+package io.camunda.connector.agenticai.aiagent.memory.conversation.document;
+
+import org.jspecify.annotations.NullMarked;

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/memory/conversation/inprocess/InProcessConversationSession.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/memory/conversation/inprocess/InProcessConversationSession.java
@@ -14,10 +14,11 @@ import io.camunda.connector.agenticai.aiagent.memory.conversation.ConversationSe
 import io.camunda.connector.agenticai.aiagent.memory.conversation.ConversationStoreRequest;
 import io.camunda.connector.agenticai.aiagent.model.AgentContext;
 import java.util.UUID;
+import org.jspecify.annotations.Nullable;
 
 public class InProcessConversationSession implements ConversationSession {
 
-  private InProcessConversationContext previousConversationContext;
+  private @Nullable InProcessConversationContext previousConversationContext;
 
   @Override
   public ConversationLoadResult loadMessages(AgentContext agentContext) {

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/memory/conversation/inprocess/package-info.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/memory/conversation/inprocess/package-info.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+@NullMarked
+package io.camunda.connector.agenticai.aiagent.memory.conversation.inprocess;
+
+import org.jspecify.annotations.NullMarked;

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/memory/conversation/package-info.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/memory/conversation/package-info.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+@NullMarked
+package io.camunda.connector.agenticai.aiagent.memory.conversation;
+
+import org.jspecify.annotations.NullMarked;

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/memory/package-info.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/memory/package-info.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+@NullMarked
+package io.camunda.connector.agenticai.aiagent.memory;
+
+import org.jspecify.annotations.NullMarked;

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/memory/runtime/package-info.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/memory/runtime/package-info.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+@NullMarked
+package io.camunda.connector.agenticai.aiagent.memory.runtime;
+
+import org.jspecify.annotations.NullMarked;

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/AgentContext.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/AgentContext.java
@@ -17,8 +17,10 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import org.springframework.lang.Nullable;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
+@NullMarked
 @AgenticAiRecord
 @JsonDeserialize(builder = AgentContext.AgentContextJacksonProxyBuilder.class)
 public record AgentContext(

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/AgentContext.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/AgentContext.java
@@ -17,10 +17,8 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
-@NullMarked
 @AgenticAiRecord
 @JsonDeserialize(builder = AgentContext.AgentContextJacksonProxyBuilder.class)
 public record AgentContext(

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/AgentInput.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/AgentInput.java
@@ -53,8 +53,8 @@ public final class AgentInput {
         new UserPrompt(
             userPrompt.prompt(),
             userPrompt.documents() == null ? List.of() : userPrompt.documents()),
-        partitioned.get(true),
-        partitioned.get(false));
+        partitioned.getOrDefault(true, List.of()),
+        partitioned.getOrDefault(false, List.of()));
   }
 
   public UserPrompt userPrompt() {

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/AgentResponse.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/AgentResponse.java
@@ -18,8 +18,10 @@ import io.camunda.connector.agenticai.common.AgenticAiRecord;
 import io.camunda.connector.generator.java.annotation.DataExample;
 import java.util.List;
 import java.util.Map;
-import org.springframework.lang.Nullable;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
+@NullMarked
 @AgenticAiRecord
 @JsonDeserialize(builder = AgentResponse.AgentResponseJacksonProxyBuilder.class)
 public record AgentResponse(

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/AgentResponse.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/AgentResponse.java
@@ -18,10 +18,8 @@ import io.camunda.connector.agenticai.common.AgenticAiRecord;
 import io.camunda.connector.generator.java.annotation.DataExample;
 import java.util.List;
 import java.util.Map;
-import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
-@NullMarked
 @AgenticAiRecord
 @JsonDeserialize(builder = AgentResponse.AgentResponseJacksonProxyBuilder.class)
 public record AgentResponse(

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/JobWorkerAgentResponse.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/JobWorkerAgentResponse.java
@@ -11,7 +11,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import io.camunda.connector.agenticai.aiagent.model.message.AssistantMessage;
 import io.camunda.connector.agenticai.common.AgenticAiRecord;
-import org.springframework.lang.Nullable;
+import org.jspecify.annotations.Nullable;
 
 @AgenticAiRecord
 @JsonInclude(JsonInclude.Include.NON_EMPTY)

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/message/AssistantMessage.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/message/AssistantMessage.java
@@ -14,13 +14,16 @@ import io.camunda.connector.agenticai.aiagent.model.tool.ToolCall;
 import io.camunda.connector.agenticai.common.AgenticAiRecord;
 import java.util.List;
 import java.util.Map;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
+@NullMarked
 @AgenticAiRecord
 @JsonDeserialize(builder = AssistantMessage.AssistantMessageJacksonProxyBuilder.class)
 public record AssistantMessage(
     @JsonInclude(JsonInclude.Include.NON_EMPTY) List<Content> content,
     @JsonInclude(JsonInclude.Include.NON_EMPTY) List<ToolCall> toolCalls,
-    @JsonInclude(JsonInclude.Include.NON_EMPTY) Map<String, Object> metadata)
+    @JsonInclude(JsonInclude.Include.NON_EMPTY) @Nullable Map<String, Object> metadata)
     implements AssistantMessageBuilder.With, Message, ContentMessage {
 
   public boolean hasToolCalls() {

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/message/AssistantMessage.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/message/AssistantMessage.java
@@ -14,10 +14,8 @@ import io.camunda.connector.agenticai.aiagent.model.tool.ToolCall;
 import io.camunda.connector.agenticai.common.AgenticAiRecord;
 import java.util.List;
 import java.util.Map;
-import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
-@NullMarked
 @AgenticAiRecord
 @JsonDeserialize(builder = AssistantMessage.AssistantMessageJacksonProxyBuilder.class)
 public record AssistantMessage(

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/message/DocumentReferenceXmlTag.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/message/DocumentReferenceXmlTag.java
@@ -14,7 +14,6 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.text.StringEscapeUtils;
-import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -34,7 +33,6 @@ import org.jspecify.annotations.Nullable;
  * learn their content type or filename — the tag deliberately omits the metadata block for those to
  * avoid a download just to render a label.
  */
-@NullMarked
 public sealed interface DocumentReferenceXmlTag {
 
   @Nullable String toolCallId();

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/message/DocumentReferenceXmlTag.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/message/DocumentReferenceXmlTag.java
@@ -14,7 +14,8 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.text.StringEscapeUtils;
-import org.springframework.lang.Nullable;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Represents a self-closing XML tag used to label a document in the synthetic user message, e.g.:
@@ -33,13 +34,12 @@ import org.springframework.lang.Nullable;
  * learn their content type or filename — the tag deliberately omits the metadata block for those to
  * avoid a download just to render a label.
  */
+@NullMarked
 public sealed interface DocumentReferenceXmlTag {
 
-  @Nullable
-  String toolCallId();
+  @Nullable String toolCallId();
 
-  @Nullable
-  String toolName();
+  @Nullable String toolName();
 
   String toXml();
 

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/message/UserMessage.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/message/UserMessage.java
@@ -13,8 +13,10 @@ import io.camunda.connector.agenticai.aiagent.model.message.content.Content;
 import io.camunda.connector.agenticai.common.AgenticAiRecord;
 import java.util.List;
 import java.util.Map;
-import org.springframework.lang.Nullable;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
+@NullMarked
 @AgenticAiRecord
 @JsonDeserialize(builder = UserMessage.UserMessageJacksonProxyBuilder.class)
 public record UserMessage(

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/message/UserMessage.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/message/UserMessage.java
@@ -13,10 +13,8 @@ import io.camunda.connector.agenticai.aiagent.model.message.content.Content;
 import io.camunda.connector.agenticai.common.AgenticAiRecord;
 import java.util.List;
 import java.util.Map;
-import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
-@NullMarked
 @AgenticAiRecord
 @JsonDeserialize(builder = UserMessage.UserMessageJacksonProxyBuilder.class)
 public record UserMessage(

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/message/content/DocumentContent.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/message/content/DocumentContent.java
@@ -10,10 +10,12 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import io.camunda.connector.api.document.Document;
 import java.util.Map;
+import org.jspecify.annotations.Nullable;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public record DocumentContent(
-    Document document, @JsonInclude(JsonInclude.Include.NON_EMPTY) Map<String, Object> metadata)
+    Document document,
+    @JsonInclude(JsonInclude.Include.NON_EMPTY) @Nullable Map<String, Object> metadata)
     implements Content {
   public DocumentContent {
     if (document == null) {

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/message/content/ObjectContent.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/message/content/ObjectContent.java
@@ -9,10 +9,12 @@ package io.camunda.connector.agenticai.aiagent.model.message.content;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import java.util.Map;
+import org.jspecify.annotations.Nullable;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public record ObjectContent(
-    Object content, @JsonInclude(JsonInclude.Include.NON_EMPTY) Map<String, Object> metadata)
+    Object content,
+    @JsonInclude(JsonInclude.Include.NON_EMPTY) @Nullable Map<String, Object> metadata)
     implements Content {
   public ObjectContent {
     if (content == null) {

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/message/content/TextContent.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/message/content/TextContent.java
@@ -9,10 +9,11 @@ package io.camunda.connector.agenticai.aiagent.model.message.content;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import java.util.Map;
+import org.jspecify.annotations.Nullable;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public record TextContent(
-    String text, @JsonInclude(JsonInclude.Include.NON_EMPTY) Map<String, Object> metadata)
+    String text, @JsonInclude(JsonInclude.Include.NON_EMPTY) @Nullable Map<String, Object> metadata)
     implements Content {
   public TextContent {
     if (text == null || text.isBlank()) {

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/message/content/package-info.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/message/content/package-info.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+@NullMarked
+package io.camunda.connector.agenticai.aiagent.model.message.content;
+
+import org.jspecify.annotations.NullMarked;

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/message/package-info.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/message/package-info.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+@NullMarked
+package io.camunda.connector.agenticai.aiagent.model.message;
+
+import org.jspecify.annotations.NullMarked;

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/package-info.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/package-info.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+@NullMarked
+package io.camunda.connector.agenticai.aiagent.model;
+
+import org.jspecify.annotations.NullMarked;

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/EventHandlingConfiguration.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/EventHandlingConfiguration.java
@@ -8,9 +8,7 @@ package io.camunda.connector.agenticai.aiagent.model.request;
 
 import io.camunda.connector.generator.java.annotation.TemplateProperty;
 import jakarta.validation.constraints.NotNull;
-import org.jspecify.annotations.NullMarked;
 
-@NullMarked
 public record EventHandlingConfiguration(
     @TemplateProperty(
             label = "Event handling behavior",

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/EventHandlingConfiguration.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/EventHandlingConfiguration.java
@@ -8,7 +8,9 @@ package io.camunda.connector.agenticai.aiagent.model.request;
 
 import io.camunda.connector.generator.java.annotation.TemplateProperty;
 import jakarta.validation.constraints.NotNull;
+import org.jspecify.annotations.NullMarked;
 
+@NullMarked
 public record EventHandlingConfiguration(
     @TemplateProperty(
             label = "Event handling behavior",

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/JobWorkerAgentRequest.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/JobWorkerAgentRequest.java
@@ -19,10 +19,8 @@ import io.camunda.connector.generator.java.annotation.TemplateProperty;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import java.util.List;
-import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
-@NullMarked
 public record JobWorkerAgentRequest(
     @JsonProperty("adHocSubProcessElements") List<AdHocToolElement> toolElements,
     @FEEL

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/JobWorkerAgentRequest.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/JobWorkerAgentRequest.java
@@ -19,7 +19,10 @@ import io.camunda.connector.generator.java.annotation.TemplateProperty;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import java.util.List;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
+@NullMarked
 public record JobWorkerAgentRequest(
     @JsonProperty("adHocSubProcessElements") List<AdHocToolElement> toolElements,
     @FEEL
@@ -46,8 +49,8 @@ public record JobWorkerAgentRequest(
   public record JobWorkerAgentRequestData(
       @Valid @NotNull SystemPromptConfiguration systemPrompt,
       @Valid @NotNull UserPromptConfiguration userPrompt,
-      @Valid MemoryConfiguration memory,
-      @Valid LimitsConfiguration limits,
-      @Valid EventHandlingConfiguration events,
+      @Valid @Nullable MemoryConfiguration memory,
+      @Valid @Nullable LimitsConfiguration limits,
+      @Valid @Nullable EventHandlingConfiguration events,
       @Valid JobWorkerResponseConfiguration response) {}
 }

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/JobWorkerResponseConfiguration.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/JobWorkerResponseConfiguration.java
@@ -10,10 +10,8 @@ import io.camunda.connector.agenticai.aiagent.model.request.ResponseFormatConfig
 import io.camunda.connector.generator.java.annotation.TemplateProperty;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
-import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
-@NullMarked
 public record JobWorkerResponseConfiguration(
     @Valid @NotNull ResponseFormatConfiguration format,
     @TemplateProperty(

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/JobWorkerResponseConfiguration.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/JobWorkerResponseConfiguration.java
@@ -10,7 +10,10 @@ import io.camunda.connector.agenticai.aiagent.model.request.ResponseFormatConfig
 import io.camunda.connector.generator.java.annotation.TemplateProperty;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
+@NullMarked
 public record JobWorkerResponseConfiguration(
     @Valid @NotNull ResponseFormatConfiguration format,
     @TemplateProperty(
@@ -22,7 +25,7 @@ public record JobWorkerResponseConfiguration(
                     + "and metadata (such as token usage). The message will be available as <code>response.responseMessage</code>.",
             type = TemplateProperty.PropertyType.Boolean,
             optional = true)
-        Boolean includeAssistantMessage,
+        @Nullable Boolean includeAssistantMessage,
     @TemplateProperty(
             group = "response",
             label = "Include agent context",
@@ -31,7 +34,7 @@ public record JobWorkerResponseConfiguration(
                 "Use this option if you need to re-inject the previous agent context into a future agent execution, for example when modeling a user feedback loop between an agent and a user task.",
             type = TemplateProperty.PropertyType.Boolean,
             optional = true)
-        Boolean includeAgentContext)
+        @Nullable Boolean includeAgentContext)
     implements ResponseConfiguration {
 
   public JobWorkerResponseConfiguration {

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/LimitsConfiguration.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/LimitsConfiguration.java
@@ -8,10 +8,8 @@ package io.camunda.connector.agenticai.aiagent.model.request;
 
 import io.camunda.connector.generator.java.annotation.TemplateProperty;
 import jakarta.validation.constraints.Min;
-import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
-@NullMarked
 public record LimitsConfiguration(
     // TODO think of other limits (max tool calls, max tokens, ...)
     @TemplateProperty(

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/LimitsConfiguration.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/LimitsConfiguration.java
@@ -8,7 +8,10 @@ package io.camunda.connector.agenticai.aiagent.model.request;
 
 import io.camunda.connector.generator.java.annotation.TemplateProperty;
 import jakarta.validation.constraints.Min;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
+@NullMarked
 public record LimitsConfiguration(
     // TODO think of other limits (max tool calls, max tokens, ...)
     @TemplateProperty(
@@ -20,4 +23,4 @@ public record LimitsConfiguration(
             defaultValue = "10",
             defaultValueType = TemplateProperty.DefaultValueType.Number)
         @Min(1)
-        Integer maxModelCalls) {}
+        @Nullable Integer maxModelCalls) {}

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/MemoryConfiguration.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/MemoryConfiguration.java
@@ -10,10 +10,8 @@ import io.camunda.connector.generator.java.annotation.NestedProperties;
 import io.camunda.connector.generator.java.annotation.TemplateProperty;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
-import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
-@NullMarked
 public record MemoryConfiguration(
     @Valid @NestedProperties(group = "memory") @Nullable MemoryStorageConfiguration storage,
     // TODO support more advanced eviction policies (token window)

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/MemoryConfiguration.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/MemoryConfiguration.java
@@ -10,9 +10,12 @@ import io.camunda.connector.generator.java.annotation.NestedProperties;
 import io.camunda.connector.generator.java.annotation.TemplateProperty;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
+@NullMarked
 public record MemoryConfiguration(
-    @Valid @NestedProperties(group = "memory") MemoryStorageConfiguration storage,
+    @Valid @NestedProperties(group = "memory") @Nullable MemoryStorageConfiguration storage,
     // TODO support more advanced eviction policies (token window)
     @TemplateProperty(
             group = "memory",
@@ -29,4 +32,4 @@ public record MemoryConfiguration(
             defaultValue = "20",
             defaultValueType = TemplateProperty.DefaultValueType.Number)
         @Min(3)
-        Integer contextWindowSize) {}
+        @Nullable Integer contextWindowSize) {}

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/OutboundConnectorResponseConfiguration.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/OutboundConnectorResponseConfiguration.java
@@ -10,10 +10,8 @@ import io.camunda.connector.agenticai.aiagent.model.request.ResponseFormatConfig
 import io.camunda.connector.generator.java.annotation.TemplateProperty;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
-import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
-@NullMarked
 public record OutboundConnectorResponseConfiguration(
     @Valid @NotNull ResponseFormatConfiguration format,
     @TemplateProperty(

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/OutboundConnectorResponseConfiguration.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/OutboundConnectorResponseConfiguration.java
@@ -10,7 +10,10 @@ import io.camunda.connector.agenticai.aiagent.model.request.ResponseFormatConfig
 import io.camunda.connector.generator.java.annotation.TemplateProperty;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
+@NullMarked
 public record OutboundConnectorResponseConfiguration(
     @Valid @NotNull ResponseFormatConfiguration format,
     @TemplateProperty(
@@ -22,7 +25,7 @@ public record OutboundConnectorResponseConfiguration(
                     + "and metadata (such as token usage). The message will be available as <code>response.responseMessage</code>.",
             type = TemplateProperty.PropertyType.Boolean,
             optional = true)
-        Boolean includeAssistantMessage)
+        @Nullable Boolean includeAssistantMessage)
     implements ResponseConfiguration {
 
   public OutboundConnectorResponseConfiguration {

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/ToolsConfiguration.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/ToolsConfiguration.java
@@ -11,7 +11,10 @@ import io.camunda.connector.api.annotation.FEEL;
 import io.camunda.connector.generator.java.annotation.FeelMode;
 import io.camunda.connector.generator.java.annotation.TemplateProperty;
 import java.util.List;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
+@NullMarked
 public record ToolsConfiguration(
     @TemplateProperty(
             group = "tools",
@@ -23,7 +26,7 @@ public record ToolsConfiguration(
                     + "<a href=\"https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/agentic-ai-aiagent-task/\" target=\"_blank\">See documentation</a> "
                     + "for details.",
             optional = true)
-        String containerElementId,
+        @Nullable String containerElementId,
     @FEEL
         @TemplateProperty(
             group = "tools",
@@ -37,4 +40,4 @@ public record ToolsConfiguration(
             type = TemplateProperty.PropertyType.Text,
             feel = FeelMode.required,
             optional = true)
-        List<ToolCallResult> toolCallResults) {}
+        @Nullable List<ToolCallResult> toolCallResults) {}

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/ToolsConfiguration.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/ToolsConfiguration.java
@@ -11,10 +11,8 @@ import io.camunda.connector.api.annotation.FEEL;
 import io.camunda.connector.generator.java.annotation.FeelMode;
 import io.camunda.connector.generator.java.annotation.TemplateProperty;
 import java.util.List;
-import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
-@NullMarked
 public record ToolsConfiguration(
     @TemplateProperty(
             group = "tools",

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/package-info.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/package-info.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+@NullMarked
+package io.camunda.connector.agenticai.aiagent.model.request;
+
+import org.jspecify.annotations.NullMarked;

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/provider/AnthropicProviderConfiguration.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/provider/AnthropicProviderConfiguration.java
@@ -17,10 +17,8 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
-import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
-@NullMarked
 @TemplateSubType(id = ANTHROPIC_ID, label = "Anthropic")
 public record AnthropicProviderConfiguration(@Valid @NotNull AnthropicConnection anthropic)
     implements ProviderConfiguration {

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/provider/AnthropicProviderConfiguration.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/provider/AnthropicProviderConfiguration.java
@@ -17,7 +17,10 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
+@NullMarked
 @TemplateSubType(id = ANTHROPIC_ID, label = "Anthropic")
 public record AnthropicProviderConfiguration(@Valid @NotNull AnthropicConnection anthropic)
     implements ProviderConfiguration {
@@ -43,9 +46,9 @@ public record AnthropicProviderConfiguration(@Valid @NotNull AnthropicConnection
               type = TemplateProperty.PropertyType.String,
               feel = FeelMode.optional,
               optional = true)
-          String endpoint,
+          @Nullable String endpoint,
       @Valid @NotNull AnthropicAuthentication authentication,
-      @Valid TimeoutConfiguration timeouts,
+      @Valid @Nullable TimeoutConfiguration timeouts,
       @Valid @NotNull AnthropicModel model) {}
 
   public record AnthropicAuthentication(
@@ -90,7 +93,7 @@ public record AnthropicProviderConfiguration(@Valid @NotNull AnthropicConnection
                 type = TemplateProperty.PropertyType.Number,
                 feel = FeelMode.required,
                 optional = true)
-            Integer maxTokens,
+            @Nullable Integer maxTokens,
         @Min(0)
             @TemplateProperty(
                 group = "model",
@@ -100,7 +103,7 @@ public record AnthropicProviderConfiguration(@Valid @NotNull AnthropicConnection
                 type = TemplateProperty.PropertyType.Number,
                 feel = FeelMode.required,
                 optional = true)
-            Double temperature,
+            @Nullable Double temperature,
         @Min(0)
             @TemplateProperty(
                 group = "model",
@@ -110,7 +113,7 @@ public record AnthropicProviderConfiguration(@Valid @NotNull AnthropicConnection
                 type = TemplateProperty.PropertyType.Number,
                 feel = FeelMode.required,
                 optional = true)
-            Double topP,
+            @Nullable Double topP,
         @Min(0)
             @TemplateProperty(
                 group = "model",
@@ -120,6 +123,6 @@ public record AnthropicProviderConfiguration(@Valid @NotNull AnthropicConnection
                 type = TemplateProperty.PropertyType.Number,
                 feel = FeelMode.required,
                 optional = true)
-            Integer topK) {}
+            @Nullable Integer topK) {}
   }
 }

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/provider/AzureOpenAiProviderConfiguration.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/provider/AzureOpenAiProviderConfiguration.java
@@ -21,10 +21,8 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
-import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
-@NullMarked
 @TemplateSubType(id = AZURE_OPENAI_ID, label = "Azure OpenAI")
 public record AzureOpenAiProviderConfiguration(@Valid @NotNull AzureOpenAiConnection azureOpenAi)
     implements ProviderConfiguration {

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/provider/AzureOpenAiProviderConfiguration.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/provider/AzureOpenAiProviderConfiguration.java
@@ -21,7 +21,10 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
+@NullMarked
 @TemplateSubType(id = AZURE_OPENAI_ID, label = "Azure OpenAI")
 public record AzureOpenAiProviderConfiguration(@Valid @NotNull AzureOpenAiConnection azureOpenAi)
     implements ProviderConfiguration {
@@ -50,7 +53,7 @@ public record AzureOpenAiProviderConfiguration(@Valid @NotNull AzureOpenAiConnec
               constraints = @TemplateProperty.PropertyConstraints(notEmpty = true))
           String endpoint,
       @Valid @NotNull AzureAuthentication authentication,
-      @Valid TimeoutConfiguration timeouts,
+      @Valid @Nullable TimeoutConfiguration timeouts,
       @Valid @NotNull AzureOpenAiModel model) {}
 
   @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
@@ -124,7 +127,7 @@ public record AzureOpenAiProviderConfiguration(@Valid @NotNull AzureOpenAiConnec
                 type = TemplateProperty.PropertyType.String,
                 feel = FeelMode.optional,
                 optional = true)
-            String authorityHost)
+            @Nullable String authorityHost)
         implements AzureAuthentication {
 
       @Override
@@ -158,7 +161,7 @@ public record AzureOpenAiProviderConfiguration(@Valid @NotNull AzureOpenAiConnec
                 type = TemplateProperty.PropertyType.Number,
                 feel = FeelMode.required,
                 optional = true)
-            Integer maxTokens,
+            @Nullable Integer maxTokens,
         @Min(0)
             @TemplateProperty(
                 group = "model",
@@ -168,7 +171,7 @@ public record AzureOpenAiProviderConfiguration(@Valid @NotNull AzureOpenAiConnec
                 type = TemplateProperty.PropertyType.Number,
                 feel = FeelMode.required,
                 optional = true)
-            Double temperature,
+            @Nullable Double temperature,
         @Min(0)
             @TemplateProperty(
                 group = "model",
@@ -178,6 +181,6 @@ public record AzureOpenAiProviderConfiguration(@Valid @NotNull AzureOpenAiConnec
                 type = TemplateProperty.PropertyType.Number,
                 feel = FeelMode.required,
                 optional = true)
-            Double topP) {}
+            @Nullable Double topP) {}
   }
 }

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/provider/BedrockProviderConfiguration.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/provider/BedrockProviderConfiguration.java
@@ -23,10 +23,8 @@ import jakarta.validation.constraints.AssertFalse;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
-import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
-@NullMarked
 @TemplateSubType(id = BEDROCK_ID, label = "AWS Bedrock")
 public record BedrockProviderConfiguration(@Valid @NotNull BedrockConnection bedrock)
     implements ProviderConfiguration {

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/provider/BedrockProviderConfiguration.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/provider/BedrockProviderConfiguration.java
@@ -23,7 +23,10 @@ import jakarta.validation.constraints.AssertFalse;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
+@NullMarked
 @TemplateSubType(id = BEDROCK_ID, label = "AWS Bedrock")
 public record BedrockProviderConfiguration(@Valid @NotNull BedrockConnection bedrock)
     implements ProviderConfiguration {
@@ -57,9 +60,9 @@ public record BedrockProviderConfiguration(@Valid @NotNull BedrockConnection bed
               type = TemplateProperty.PropertyType.String,
               feel = FeelMode.optional,
               optional = true)
-          String endpoint,
+          @Nullable String endpoint,
       @Valid @NotNull AwsAuthentication authentication,
-      @Valid TimeoutConfiguration timeouts,
+      @Valid @Nullable TimeoutConfiguration timeouts,
       @Valid @NotNull BedrockModel model) {
 
     @AssertFalse(message = "AWS default credentials chain is not supported on SaaS")
@@ -161,7 +164,7 @@ public record BedrockProviderConfiguration(@Valid @NotNull BedrockConnection bed
                 type = TemplateProperty.PropertyType.Number,
                 feel = FeelMode.required,
                 optional = true)
-            Integer maxTokens,
+            @Nullable Integer maxTokens,
         @Min(0)
             @TemplateProperty(
                 group = "model",
@@ -171,7 +174,7 @@ public record BedrockProviderConfiguration(@Valid @NotNull BedrockConnection bed
                 type = TemplateProperty.PropertyType.Number,
                 feel = FeelMode.required,
                 optional = true)
-            Double temperature,
+            @Nullable Double temperature,
         @Min(0)
             @TemplateProperty(
                 group = "model",
@@ -181,6 +184,6 @@ public record BedrockProviderConfiguration(@Valid @NotNull BedrockConnection bed
                 type = TemplateProperty.PropertyType.Number,
                 feel = FeelMode.required,
                 optional = true)
-            Double topP) {}
+            @Nullable Double topP) {}
   }
 }

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/provider/GoogleVertexAiProviderConfiguration.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/provider/GoogleVertexAiProviderConfiguration.java
@@ -20,7 +20,10 @@ import jakarta.validation.constraints.AssertFalse;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
+@NullMarked
 @TemplateSubType(id = GOOGLE_VERTEX_AI_ID, label = "Google Vertex AI")
 public record GoogleVertexAiProviderConfiguration(
     @Valid @NotNull GoogleVertexAiConnection googleVertexAi) implements ProviderConfiguration {
@@ -130,7 +133,7 @@ public record GoogleVertexAiProviderConfiguration(
                 type = TemplateProperty.PropertyType.Number,
                 feel = FeelMode.required,
                 optional = true)
-            Integer maxOutputTokens,
+            @Nullable Integer maxOutputTokens,
         @Min(0)
             @TemplateProperty(
                 group = "model",
@@ -140,7 +143,7 @@ public record GoogleVertexAiProviderConfiguration(
                 type = TemplateProperty.PropertyType.Number,
                 feel = FeelMode.required,
                 optional = true)
-            Float temperature,
+            @Nullable Float temperature,
         @Min(0)
             @TemplateProperty(
                 group = "model",
@@ -150,7 +153,7 @@ public record GoogleVertexAiProviderConfiguration(
                 type = TemplateProperty.PropertyType.Number,
                 feel = FeelMode.required,
                 optional = true)
-            Float topP,
+            @Nullable Float topP,
         @Min(0)
             @TemplateProperty(
                 group = "model",
@@ -160,6 +163,6 @@ public record GoogleVertexAiProviderConfiguration(
                 type = TemplateProperty.PropertyType.Number,
                 feel = FeelMode.required,
                 optional = true)
-            Integer topK) {}
+            @Nullable Integer topK) {}
   }
 }

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/provider/GoogleVertexAiProviderConfiguration.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/provider/GoogleVertexAiProviderConfiguration.java
@@ -20,10 +20,8 @@ import jakarta.validation.constraints.AssertFalse;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
-import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
-@NullMarked
 @TemplateSubType(id = GOOGLE_VERTEX_AI_ID, label = "Google Vertex AI")
 public record GoogleVertexAiProviderConfiguration(
     @Valid @NotNull GoogleVertexAiConnection googleVertexAi) implements ProviderConfiguration {

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/provider/package-info.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/provider/package-info.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+@NullMarked
+package io.camunda.connector.agenticai.aiagent.model.request.provider;
+
+import org.jspecify.annotations.NullMarked;

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/provider/shared/package-info.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/request/provider/shared/package-info.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+@NullMarked
+package io.camunda.connector.agenticai.aiagent.model.request.provider.shared;
+
+import org.jspecify.annotations.NullMarked;

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/tool/GatewayToolDefinition.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/tool/GatewayToolDefinition.java
@@ -11,7 +11,6 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import io.camunda.connector.agenticai.common.AgenticAiRecord;
 import java.util.Map;
-import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -21,7 +20,6 @@ import org.jspecify.annotations.Nullable;
  * <p>Example use case: MCP Client is a gateway to multiple tools exposed by the connected MCP
  * server
  */
-@NullMarked
 @AgenticAiRecord
 @JsonDeserialize(builder = GatewayToolDefinition.GatewayToolDefinitionJacksonProxyBuilder.class)
 public record GatewayToolDefinition(

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/tool/GatewayToolDefinition.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/tool/GatewayToolDefinition.java
@@ -11,7 +11,8 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import io.camunda.connector.agenticai.common.AgenticAiRecord;
 import java.util.Map;
-import org.springframework.lang.Nullable;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 /**
  * A gateway tool definition, being an entrypoint for multiple tools. Tool discovery needs to be
@@ -20,6 +21,7 @@ import org.springframework.lang.Nullable;
  * <p>Example use case: MCP Client is a gateway to multiple tools exposed by the connected MCP
  * server
  */
+@NullMarked
 @AgenticAiRecord
 @JsonDeserialize(builder = GatewayToolDefinition.GatewayToolDefinitionJacksonProxyBuilder.class)
 public record GatewayToolDefinition(

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/tool/ToolCall.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/tool/ToolCall.java
@@ -10,9 +10,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import io.camunda.connector.agenticai.common.AgenticAiRecord;
 import java.util.Map;
-import org.jspecify.annotations.NullMarked;
 
-@NullMarked
 @AgenticAiRecord
 @JsonDeserialize(builder = ToolCall.ToolCallJacksonProxyBuilder.class)
 public record ToolCall(String id, String name, Map<String, Object> arguments)

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/tool/ToolCall.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/tool/ToolCall.java
@@ -10,7 +10,9 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import io.camunda.connector.agenticai.common.AgenticAiRecord;
 import java.util.Map;
+import org.jspecify.annotations.NullMarked;
 
+@NullMarked
 @AgenticAiRecord
 @JsonDeserialize(builder = ToolCall.ToolCallJacksonProxyBuilder.class)
 public record ToolCall(String id, String name, Map<String, Object> arguments)

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/tool/ToolCallResult.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/tool/ToolCallResult.java
@@ -14,10 +14,8 @@ import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import io.camunda.connector.agenticai.common.AgenticAiRecord;
 import java.util.HashMap;
 import java.util.Map;
-import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
-@NullMarked
 @AgenticAiRecord
 @JsonDeserialize(builder = ToolCallResult.ToolCallResultJacksonProxyBuilder.class)
 public record ToolCallResult(

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/tool/ToolCallResult.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/tool/ToolCallResult.java
@@ -14,8 +14,10 @@ import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import io.camunda.connector.agenticai.common.AgenticAiRecord;
 import java.util.HashMap;
 import java.util.Map;
-import org.springframework.lang.Nullable;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
+@NullMarked
 @AgenticAiRecord
 @JsonDeserialize(builder = ToolCallResult.ToolCallResultJacksonProxyBuilder.class)
 public record ToolCallResult(

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/tool/ToolDefinition.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/tool/ToolDefinition.java
@@ -10,11 +10,9 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import io.camunda.connector.agenticai.common.AgenticAiRecord;
 import java.util.Map;
-import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
 /** A tool definition, being a single tool available within the ad-hoc sub-process. */
-@NullMarked
 @AgenticAiRecord
 @JsonDeserialize(builder = ToolDefinition.ToolDefinitionJacksonProxyBuilder.class)
 public record ToolDefinition(

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/tool/ToolDefinition.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/tool/ToolDefinition.java
@@ -9,10 +9,12 @@ package io.camunda.connector.agenticai.aiagent.model.tool;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import io.camunda.connector.agenticai.common.AgenticAiRecord;
-import jakarta.annotation.Nullable;
 import java.util.Map;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 /** A tool definition, being a single tool available within the ad-hoc sub-process. */
+@NullMarked
 @AgenticAiRecord
 @JsonDeserialize(builder = ToolDefinition.ToolDefinitionJacksonProxyBuilder.class)
 public record ToolDefinition(

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/tool/package-info.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/model/tool/package-info.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+@NullMarked
+package io.camunda.connector.agenticai.aiagent.model.tool;
+
+import org.jspecify.annotations.NullMarked;

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/package-info.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/package-info.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+@NullMarked
+package io.camunda.connector.agenticai.aiagent;
+
+import org.jspecify.annotations.NullMarked;

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/systemprompt/SystemPromptComposerImpl.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/systemprompt/SystemPromptComposerImpl.java
@@ -12,6 +12,7 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import org.apache.commons.lang3.StringUtils;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -52,7 +53,7 @@ public class SystemPromptComposerImpl implements SystemPromptComposer {
 
     contributors.forEach(
         contributor -> {
-          String contribution = contributor.contribute(executionContext, agentContext);
+          @Nullable String contribution = contributor.contribute(executionContext, agentContext);
           if (StringUtils.isNotBlank(contribution)) {
             composed.add(contribution);
             LOGGER.debug(

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/systemprompt/SystemPromptContributor.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/systemprompt/SystemPromptContributor.java
@@ -8,6 +8,7 @@ package io.camunda.connector.agenticai.aiagent.systemprompt;
 
 import io.camunda.connector.agenticai.aiagent.model.AgentContext;
 import io.camunda.connector.agenticai.aiagent.model.AgentExecutionContext;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Contributes additional instructions to the AI agent's system prompt. Implementations can provide
@@ -26,7 +27,7 @@ public interface SystemPromptContributor {
    * @param agentContext the current durable agent context
    * @return The system prompt contribution, or null/empty if no contribution needed
    */
-  String contribute(AgentExecutionContext executionContext, AgentContext agentContext);
+  @Nullable String contribute(AgentExecutionContext executionContext, AgentContext agentContext);
 
   /**
    * Determines the order in which this contributor's content is appended. Lower values are appended

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/systemprompt/package-info.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/systemprompt/package-info.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+@NullMarked
+package io.camunda.connector.agenticai.aiagent.systemprompt;
+
+import org.jspecify.annotations.NullMarked;

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/tool/GatewayToolHandlerRegistryImpl.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/tool/GatewayToolHandlerRegistryImpl.java
@@ -16,6 +16,7 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
@@ -110,7 +111,10 @@ public class GatewayToolHandlerRegistryImpl implements GatewayToolHandlerRegistr
         .filter(entry -> !entry.getKey().equals(DEFAULT_TYPE))
         .forEach(
             entry -> {
-              final var handler = handlers.get(entry.getKey());
+              final var handler =
+                  Objects.requireNonNull(
+                      handlers.get(entry.getKey()),
+                      "No handler registered for gateway type: " + entry.getKey());
               final var gatewayToolDefinitions =
                   handler.handleToolDiscoveryResults(agentContext, entry.getValue());
               mergedToolDefinitions.addAll(gatewayToolDefinitions);

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/tool/package-info.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/tool/package-info.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+@NullMarked
+package io.camunda.connector.agenticai.aiagent.tool;
+
+import org.jspecify.annotations.NullMarked;

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/util/ResponseTextUtil.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/util/ResponseTextUtil.java
@@ -6,6 +6,8 @@
  */
 package io.camunda.connector.agenticai.aiagent.util;
 
+import org.jspecify.annotations.Nullable;
+
 /**
  * Utility class for cleaning and preparing response text from AI models before JSON parsing.
  *
@@ -47,7 +49,7 @@ public final class ResponseTextUtil {
    * @return the response with markdown code blocks stripped, or the original response if no code
    *     blocks are found
    */
-  public static String stripMarkdownCodeBlocks(String response) {
+  public static @Nullable String stripMarkdownCodeBlocks(@Nullable String response) {
     if (response == null) {
       return null;
     }

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/util/package-info.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/util/package-info.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+@NullMarked
+package io.camunda.connector.agenticai.aiagent.util;
+
+import org.jspecify.annotations.NullMarked;

--- a/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/agent/ToolCallResultDocumentExtractorTest.java
+++ b/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/agent/ToolCallResultDocumentExtractorTest.java
@@ -8,6 +8,7 @@ package io.camunda.connector.agenticai.aiagent.agent;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -46,7 +47,8 @@ class ToolCallResultDocumentExtractorTest {
   void setUp() {
     documentStore.clear();
     when(handler.type()).thenReturn("typed");
-    when(handler.isGatewayManaged(any()))
+    lenient()
+        .when(handler.isGatewayManaged(any()))
         .thenAnswer(inv -> MANAGED_TOOL.equals(inv.getArgument(0)));
     extractor =
         new ToolCallResultDocumentExtractor(new GatewayToolHandlerRegistryImpl(List.of(handler)));


### PR DESCRIPTION
## Summary

Applies JSpecify null-safety to the `aiagent` package (79 files changed). Requires #7696 to be merged first.

- Adds `package-info.java` with `@NullMarked` to all `aiagent` subpackages.
- Fixes NullAway violations surfaced by enabling the check: explicit `@Nullable` annotations on fields and return types that may be absent, null-checks and `Objects.requireNonNull` guards where warranted, `@NullUnmarked` used sparingly as a named deferral with an explanatory comment.
- Deletes `aiagent/.gitignore` (the placeholder from #7696 that suppressed untracked `package-info.java` files in this package).
- Includes corresponding unit test and e2e test updates.

After this PR merges, NullAway enforces non-null-by-default for the entire `aiagent` package at compile time.

## Merge order

Merge #7696 first. This PR and the other three feature PRs (#7698, #7699, #7700) can be merged in any order after that.