### PR TITLE
feat(agentic-ai): apply @NullMarked to mcp package

### DIFF
--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/mcp/.gitignore
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/mcp/.gitignore
@@ -1,1 +1,0 @@
-package-info.java

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/mcp/client/McpRemoteClientRegistry.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/mcp/client/McpRemoteClientRegistry.java
@@ -28,7 +28,6 @@ import io.camunda.connector.agenticai.mcp.client.model.auth.NoAuthentication;
 import io.camunda.connector.agenticai.mcp.client.model.auth.OAuthAuthentication;
 import io.camunda.connector.api.outbound.OutboundConnectorContext;
 import org.jspecify.annotations.NonNull;
-import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -55,7 +54,9 @@ public class McpRemoteClientRegistry implements AutoCloseable {
             (key, value, cause) -> {
               LOGGER.info(
                   "MCP({}): Removing cached remote HTTP client (removal cause: {})", key, cause);
-              this.closeClient(key, value);
+              if (key != null && value != null) {
+                this.closeClient(key, value);
+              }
             })
         .build();
   }
@@ -154,7 +155,7 @@ public class McpRemoteClientRegistry implements AutoCloseable {
     this.cache.asMap().forEach(this::closeClient);
   }
 
-  public void closeClient(@Nullable Object clientId, @Nullable Object client) {
+  public void closeClient(McpRemoteClientIdentifier clientId, McpClientDelegate client) {
     LOGGER.info("MCP({}): Closing remote HTTP client", clientId);
     if (client instanceof AutoCloseable autoCloseable) {
       try {

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/mcp/client/McpRemoteClientRegistry.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/mcp/client/McpRemoteClientRegistry.java
@@ -55,7 +55,7 @@ public class McpRemoteClientRegistry implements AutoCloseable {
               LOGGER.info(
                   "MCP({}): Removing cached remote HTTP client (removal cause: {})", key, cause);
               if (key != null && value != null) {
-                this.closeClient(key, value);
+                this.closeClient((McpRemoteClientIdentifier) key, (McpClientDelegate) value);
               }
             })
         .build();

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/mcp/client/McpRemoteClientRegistry.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/mcp/client/McpRemoteClientRegistry.java
@@ -28,6 +28,7 @@ import io.camunda.connector.agenticai.mcp.client.model.auth.NoAuthentication;
 import io.camunda.connector.agenticai.mcp.client.model.auth.OAuthAuthentication;
 import io.camunda.connector.api.outbound.OutboundConnectorContext;
 import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -153,7 +154,7 @@ public class McpRemoteClientRegistry implements AutoCloseable {
     this.cache.asMap().forEach(this::closeClient);
   }
 
-  public void closeClient(Object clientId, Object client) {
+  public void closeClient(@Nullable Object clientId, @Nullable Object client) {
     LOGGER.info("MCP({}): Closing remote HTTP client", clientId);
     if (client instanceof AutoCloseable autoCloseable) {
       try {

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/mcp/client/configuration/McpClientConfigurationProperties.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/mcp/client/configuration/McpClientConfigurationProperties.java
@@ -20,9 +20,9 @@ import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
+import org.jspecify.annotations.Nullable;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.bind.DefaultValue;
-import org.springframework.lang.Nullable;
 import org.springframework.validation.annotation.Validated;
 
 @Validated

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/mcp/client/configuration/annotation/package-info.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/mcp/client/configuration/annotation/package-info.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+@NullMarked
+package io.camunda.connector.agenticai.mcp.client.configuration.annotation;
+
+import org.jspecify.annotations.NullMarked;

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/mcp/client/configuration/mcpsdk/package-info.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/mcp/client/configuration/mcpsdk/package-info.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+@NullMarked
+package io.camunda.connector.agenticai.mcp.client.configuration.mcpsdk;
+
+import org.jspecify.annotations.NullMarked;

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/mcp/client/configuration/package-info.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/mcp/client/configuration/package-info.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+@NullMarked
+package io.camunda.connector.agenticai.mcp.client.configuration;
+
+import org.jspecify.annotations.NullMarked;

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/mcp/client/configuration/validation/package-info.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/mcp/client/configuration/validation/package-info.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+@NullMarked
+package io.camunda.connector.agenticai.mcp.client.configuration.validation;
+
+import org.jspecify.annotations.NullMarked;

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/mcp/client/execution/package-info.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/mcp/client/execution/package-info.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+@NullMarked
+package io.camunda.connector.agenticai.mcp.client.execution;
+
+import org.jspecify.annotations.NullMarked;

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/mcp/client/filters/package-info.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/mcp/client/filters/package-info.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+@NullMarked
+package io.camunda.connector.agenticai.mcp.client.filters;
+
+import org.jspecify.annotations.NullMarked;

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/mcp/client/framework/bootstrap/auth/OAuthHeadersSupplier.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/mcp/client/framework/bootstrap/auth/OAuthHeadersSupplier.java
@@ -65,17 +65,14 @@ public class OAuthHeadersSupplier implements Supplier<Map<String, String>> {
 
   @Override
   public synchronized Map<String, String> get() {
-    // local copy: NullAway cannot narrow @Nullable field nullability through a null check
-    var current = tokenResponse;
-    if (current == null || current.isExpired(clock)) {
+    if (tokenResponse == null || tokenResponse.isExpired(clock)) {
       LOGGER.debug(
           "Fetching MCP client OAuth token from token endpoint: {}", config.oauthTokenEndpoint());
-      current = fetchOAuthToken();
-      tokenResponse = current;
+      tokenResponse = fetchOAuthToken();
       LOGGER.debug("Successfully fetched MCP client OAuth token");
     }
 
-    return Map.of("Authorization", "Bearer " + current.accessToken());
+    return Map.of("Authorization", "Bearer " + tokenResponse.accessToken());
   }
 
   private TokenResponse fetchOAuthToken() {

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/mcp/client/framework/bootstrap/auth/OAuthHeadersSupplier.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/mcp/client/framework/bootstrap/auth/OAuthHeadersSupplier.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.function.Supplier;
 import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -39,7 +40,7 @@ public class OAuthHeadersSupplier implements Supplier<Map<String, String>> {
   private final OAuthAuthentication config;
   private final Clock clock;
 
-  private TokenResponse tokenResponse;
+  private @Nullable TokenResponse tokenResponse;
 
   public OAuthHeadersSupplier(
       OAuthService oAuthService,
@@ -64,14 +65,16 @@ public class OAuthHeadersSupplier implements Supplier<Map<String, String>> {
 
   @Override
   public synchronized Map<String, String> get() {
-    if (tokenResponse == null || tokenResponse.isExpired(clock)) {
+    var current = tokenResponse;
+    if (current == null || current.isExpired(clock)) {
       LOGGER.debug(
           "Fetching MCP client OAuth token from token endpoint: {}", config.oauthTokenEndpoint());
-      tokenResponse = fetchOAuthToken();
+      current = fetchOAuthToken();
+      tokenResponse = current;
       LOGGER.debug("Successfully fetched MCP client OAuth token");
     }
 
-    return Map.of("Authorization", "Bearer " + tokenResponse.accessToken());
+    return Map.of("Authorization", "Bearer " + current.accessToken());
   }
 
   private TokenResponse fetchOAuthToken() {
@@ -130,7 +133,7 @@ public class OAuthHeadersSupplier implements Supplier<Map<String, String>> {
     return new TokenResponse(accessToken, clock.instant().plus(expiresIn));
   }
 
-  private Object getErrorResponseBody(ConnectorException exception) {
+  private @Nullable Object getErrorResponseBody(ConnectorException exception) {
     final var errorVariables = exception.getErrorVariables();
     if (errorVariables == null) {
       return null;

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/mcp/client/framework/bootstrap/auth/OAuthHeadersSupplier.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/mcp/client/framework/bootstrap/auth/OAuthHeadersSupplier.java
@@ -65,6 +65,7 @@ public class OAuthHeadersSupplier implements Supplier<Map<String, String>> {
 
   @Override
   public synchronized Map<String, String> get() {
+    // local copy: NullAway cannot narrow @Nullable field nullability through a null check
     var current = tokenResponse;
     if (current == null || current.isExpired(clock)) {
       LOGGER.debug(

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/mcp/client/framework/bootstrap/auth/package-info.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/mcp/client/framework/bootstrap/auth/package-info.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+@NullMarked
+package io.camunda.connector.agenticai.mcp.client.framework.bootstrap.auth;
+
+import org.jspecify.annotations.NullMarked;

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/mcp/client/framework/bootstrap/package-info.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/mcp/client/framework/bootstrap/package-info.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+@NullMarked
+package io.camunda.connector.agenticai.mcp.client.framework.bootstrap;
+
+import org.jspecify.annotations.NullMarked;

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/mcp/client/framework/mcpsdk/package-info.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/mcp/client/framework/mcpsdk/package-info.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+@NullMarked
+package io.camunda.connector.agenticai.mcp.client.framework.mcpsdk;
+
+import org.jspecify.annotations.NullMarked;

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/mcp/client/framework/mcpsdk/rpc/package-info.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/mcp/client/framework/mcpsdk/rpc/package-info.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+@NullMarked
+package io.camunda.connector.agenticai.mcp.client.framework.mcpsdk.rpc;
+
+import org.jspecify.annotations.NullMarked;

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/mcp/client/handler/package-info.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/mcp/client/handler/package-info.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+@NullMarked
+package io.camunda.connector.agenticai.mcp.client.handler;
+
+import org.jspecify.annotations.NullMarked;

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/mcp/client/model/McpClientRequest.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/mcp/client/model/McpClientRequest.java
@@ -14,7 +14,7 @@ import io.camunda.connector.generator.java.annotation.TemplateProperty.PropertyC
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
-import org.springframework.lang.Nullable;
+import org.jspecify.annotations.Nullable;
 
 public record McpClientRequest(@Valid @NotNull McpClientRequestData data) {
   public record McpClientRequestData(

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/mcp/client/model/McpClientStandaloneFiltersConfiguration.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/mcp/client/model/McpClientStandaloneFiltersConfiguration.java
@@ -9,6 +9,7 @@ package io.camunda.connector.agenticai.mcp.client.model;
 import io.camunda.connector.generator.java.annotation.NestedProperties;
 import io.camunda.connector.generator.java.annotation.TemplateProperty;
 import jakarta.validation.Valid;
+import org.jspecify.annotations.Nullable;
 
 public record McpClientStandaloneFiltersConfiguration(
     @NestedProperties(
@@ -24,11 +25,11 @@ public record McpClientStandaloneFiltersConfiguration(
                     property = "data.connectorMode.operation.type",
                     oneOf = {"resources/read", "resources/list", "resources/templates/list"}))
         @Valid
-        McpClientResourcesFilterConfiguration resources,
+        @Nullable McpClientResourcesFilterConfiguration resources,
     @NestedProperties(
             condition =
                 @TemplateProperty.PropertyCondition(
                     property = "data.connectorMode.operation.type",
                     oneOf = {"prompts/get", "prompts/list"}))
         @Valid
-        McpClientPromptsFilterConfiguration prompts) {}
+        @Nullable McpClientPromptsFilterConfiguration prompts) {}

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/mcp/client/model/McpRemoteClientRequest.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/mcp/client/model/McpRemoteClientRequest.java
@@ -10,7 +10,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
-import org.springframework.lang.Nullable;
+import org.jspecify.annotations.Nullable;
 
 public record McpRemoteClientRequest(@Valid @NotNull McpRemoteClientRequestData data) {
   public record McpRemoteClientRequestData(

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/mcp/client/model/auth/package-info.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/mcp/client/model/auth/package-info.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+@NullMarked
+package io.camunda.connector.agenticai.mcp.client.model.auth;
+
+import org.jspecify.annotations.NullMarked;

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/mcp/client/model/content/McpObjectContent.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/mcp/client/model/content/McpObjectContent.java
@@ -9,10 +9,12 @@ package io.camunda.connector.agenticai.mcp.client.model.content;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import java.util.Map;
+import org.jspecify.annotations.Nullable;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public record McpObjectContent(
-    Object content, @JsonInclude(JsonInclude.Include.NON_EMPTY) Map<String, Object> metadata)
+    Object content,
+    @JsonInclude(JsonInclude.Include.NON_EMPTY) @Nullable Map<String, Object> metadata)
     implements McpContent {
   public McpObjectContent {
     if (content == null) {

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/mcp/client/model/content/McpTextContent.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/mcp/client/model/content/McpTextContent.java
@@ -9,10 +9,11 @@ package io.camunda.connector.agenticai.mcp.client.model.content;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import java.util.Map;
+import org.jspecify.annotations.Nullable;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public record McpTextContent(
-    String text, @JsonInclude(JsonInclude.Include.NON_EMPTY) Map<String, Object> metadata)
+    String text, @JsonInclude(JsonInclude.Include.NON_EMPTY) @Nullable Map<String, Object> metadata)
     implements McpContent {
   public McpTextContent {
     if (text == null || text.isBlank()) {

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/mcp/client/model/content/package-info.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/mcp/client/model/content/package-info.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+@NullMarked
+package io.camunda.connector.agenticai.mcp.client.model.content;
+
+import org.jspecify.annotations.NullMarked;

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/mcp/client/model/package-info.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/mcp/client/model/package-info.java
@@ -4,15 +4,7 @@
  * See the License.txt file for more information. You may not use this file
  * except in compliance with the proprietary license.
  */
+@NullMarked
 package io.camunda.connector.agenticai.mcp.client.model;
 
-import io.camunda.connector.agenticai.common.AgenticAiRecord;
-import java.util.Map;
-import org.jspecify.annotations.Nullable;
-
-@AgenticAiRecord
-public record McpToolDefinition(
-    String name,
-    @Nullable String title,
-    @Nullable String description,
-    Map<String, Object> inputSchema) {}
+import org.jspecify.annotations.NullMarked;

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/mcp/client/model/result/ResourceDescription.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/mcp/client/model/result/ResourceDescription.java
@@ -9,7 +9,7 @@ package io.camunda.connector.agenticai.mcp.client.model.result;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import io.camunda.connector.agenticai.common.AgenticAiRecord;
-import jakarta.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 
 @AgenticAiRecord
 @JsonDeserialize(builder = ResourceDescription.ResourceDescriptionBuilderJacksonProxyBuilder.class)

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/mcp/client/model/result/ResourceTemplate.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/mcp/client/model/result/ResourceTemplate.java
@@ -9,7 +9,7 @@ package io.camunda.connector.agenticai.mcp.client.model.result;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import io.camunda.connector.agenticai.common.AgenticAiRecord;
-import jakarta.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 
 @AgenticAiRecord
 @JsonDeserialize(builder = ResourceTemplate.ResourceTemplateBuilderJacksonProxyBuilder.class)

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/mcp/client/model/result/package-info.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/mcp/client/model/result/package-info.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+@NullMarked
+package io.camunda.connector.agenticai.mcp.client.model.result;
+
+import org.jspecify.annotations.NullMarked;

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/mcp/client/package-info.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/mcp/client/package-info.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+@NullMarked
+package io.camunda.connector.agenticai.mcp.client;
+
+import org.jspecify.annotations.NullMarked;

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/mcp/discovery/McpClientGatewayToolHandler.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/mcp/discovery/McpClientGatewayToolHandler.java
@@ -35,6 +35,7 @@ import io.camunda.connector.api.error.ConnectorException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
@@ -198,7 +199,10 @@ public class McpClientGatewayToolHandler implements GatewayToolHandler {
 
   private String fullyQualifiedToolName(
       ToolCallResult toolCallResult, McpToolDefinition toolDefinition) {
-    final var identifier = new McpToolCallIdentifier(toolCallResult.name(), toolDefinition.name());
+    final var identifier =
+        new McpToolCallIdentifier(
+            Objects.requireNonNull(toolCallResult.name(), "Tool call result name is required"),
+            toolDefinition.name());
     return identifier.fullyQualifiedName();
   }
 
@@ -260,7 +264,10 @@ public class McpClientGatewayToolHandler implements GatewayToolHandler {
   private ToolCallResult toolCallResultFromMcpToolCall(ToolCallResult toolCallResult) {
     final var callToolResult =
         objectMapper.convertValue(toolCallResult.content(), McpClientCallToolResult.class);
-    final var identifier = new McpToolCallIdentifier(toolCallResult.name(), callToolResult.name());
+    final var identifier =
+        new McpToolCallIdentifier(
+            Objects.requireNonNull(toolCallResult.name(), "Tool call result name is required"),
+            callToolResult.name());
 
     final var toolCallResultBuilder =
         ToolCallResult.builder().id(toolCallResult.id()).name(identifier.fullyQualifiedName());

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/mcp/discovery/McpClientGatewayToolHandler.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/mcp/discovery/McpClientGatewayToolHandler.java
@@ -35,7 +35,6 @@ import io.camunda.connector.api.error.ConnectorException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
@@ -199,11 +198,12 @@ public class McpClientGatewayToolHandler implements GatewayToolHandler {
 
   private String fullyQualifiedToolName(
       ToolCallResult toolCallResult, McpToolDefinition toolDefinition) {
-    final var identifier =
-        new McpToolCallIdentifier(
-            Objects.requireNonNull(toolCallResult.name(), "Tool call result name is required"),
-            toolDefinition.name());
-    return identifier.fullyQualifiedName();
+    final var name = toolCallResult.name();
+    if (name == null) {
+      throw new ConnectorException(
+          ERROR_CODE_MCP_GATEWAY_INVALID_TOOL_DEFINITIONS, "Tool call result is missing name");
+    }
+    return new McpToolCallIdentifier(name, toolDefinition.name()).fullyQualifiedName();
   }
 
   /**
@@ -262,12 +262,14 @@ public class McpClientGatewayToolHandler implements GatewayToolHandler {
   }
 
   private ToolCallResult toolCallResultFromMcpToolCall(ToolCallResult toolCallResult) {
+    final var name = toolCallResult.name();
+    if (name == null) {
+      throw new ConnectorException(
+          ERROR_CODE_MCP_GATEWAY_INVALID_TOOL_DEFINITIONS, "Tool call result is missing name");
+    }
     final var callToolResult =
         objectMapper.convertValue(toolCallResult.content(), McpClientCallToolResult.class);
-    final var identifier =
-        new McpToolCallIdentifier(
-            Objects.requireNonNull(toolCallResult.name(), "Tool call result name is required"),
-            callToolResult.name());
+    final var identifier = new McpToolCallIdentifier(name, callToolResult.name());
 
     final var toolCallResultBuilder =
         ToolCallResult.builder().id(toolCallResult.id()).name(identifier.fullyQualifiedName());

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/mcp/discovery/configuration/package-info.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/mcp/discovery/configuration/package-info.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+@NullMarked
+package io.camunda.connector.agenticai.mcp.discovery.configuration;
+
+import org.jspecify.annotations.NullMarked;

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/mcp/discovery/package-info.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/mcp/discovery/package-info.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+@NullMarked
+package io.camunda.connector.agenticai.mcp.discovery;
+
+import org.jspecify.annotations.NullMarked;

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/mcp/package-info.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/mcp/package-info.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+@NullMarked
+package io.camunda.connector.agenticai.mcp;
+
+import org.jspecify.annotations.NullMarked;


### PR DESCRIPTION
## Summary

Applies JSpecify null-safety to the `mcp` package. Requires #7696 to be merged first.

- Adds `package-info.java` with `@NullMarked` to all `mcp` subpackages.
- Fixes NullAway violations: `@Nullable` on fields/return types that may be absent, null guards at appropriate call sites.
- Deletes `mcp/.gitignore` (the placeholder from #7696).

After this PR merges, NullAway enforces non-null-by-default for the entire `mcp` package at compile time.

## Merge order

Merge #7696 first. This PR and the other three feature PRs (#7697, #7699, #7700) can be merged in any order after that.