### PR TITLE
feat(agentic-ai): apply @NullMarked to a2a package, replace jsr305 with JSpecify

### DIFF
--- a/connectors/agentic-ai/pom.xml
+++ b/connectors/agentic-ai/pom.xml
@@ -283,11 +283,6 @@
     </dependency>
 
     <dependency>
-      <groupId>com.google.code.findbugs</groupId>
-      <artifactId>jsr305</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>org.camunda.bpm.model</groupId>
       <artifactId>camunda-xml-model</artifactId>
     </dependency>

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/a2a/.gitignore
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/a2a/.gitignore
@@ -1,1 +1,0 @@
-package-info.java

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/a2a/client/agentic/tool/A2aGatewayToolHandler.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/a2a/client/agentic/tool/A2aGatewayToolHandler.java
@@ -34,6 +34,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
@@ -166,7 +167,10 @@ public class A2aGatewayToolHandler implements GatewayToolHandler {
           "Tool call result content for A2A client tool discovery is not a map.");
     }
 
-    String toolName = new A2aToolCallIdentifier(toolCallResult.name()).fullyQualifiedName();
+    String toolName =
+        new A2aToolCallIdentifier(
+                Objects.requireNonNull(toolCallResult.name(), "Tool call result name is required"))
+            .fullyQualifiedName();
     return ToolDefinition.builder()
         .name(toolName)
         .description(createToolDefinitionDescription(toolCallResult))
@@ -234,7 +238,9 @@ public class A2aGatewayToolHandler implements GatewayToolHandler {
   private ToolCallResult toolCallResultFromA2aSendMessage(ToolCallResult toolCallResult) {
     final var sendMessageResult =
         objectMapper.convertValue(toolCallResult.content(), A2aSendMessageResult.class);
-    final var identifier = new A2aToolCallIdentifier(toolCallResult.name());
+    final var identifier =
+        new A2aToolCallIdentifier(
+            Objects.requireNonNull(toolCallResult.name(), "Tool call result name is required"));
 
     final var toolCallResultBuilder =
         ToolCallResult.builder().id(toolCallResult.id()).name(identifier.fullyQualifiedName());

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/a2a/client/agentic/tool/configuration/package-info.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/a2a/client/agentic/tool/configuration/package-info.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+@NullMarked
+package io.camunda.connector.agenticai.a2a.client.agentic.tool.configuration;
+
+import org.jspecify.annotations.NullMarked;

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/a2a/client/agentic/tool/package-info.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/a2a/client/agentic/tool/package-info.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+@NullMarked
+package io.camunda.connector.agenticai.a2a.client.agentic.tool;
+
+import org.jspecify.annotations.NullMarked;

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/a2a/client/agentic/tool/systemprompt/A2aSystemPromptContributor.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/a2a/client/agentic/tool/systemprompt/A2aSystemPromptContributor.java
@@ -14,6 +14,7 @@ import io.camunda.connector.agenticai.aiagent.systemprompt.SystemPromptContribut
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.core.io.Resource;
@@ -38,7 +39,8 @@ public class A2aSystemPromptContributor implements SystemPromptContributor {
   }
 
   @Override
-  public String contribute(AgentExecutionContext executionContext, AgentContext agentContext) {
+  public @Nullable String contribute(
+      AgentExecutionContext executionContext, AgentContext agentContext) {
 
     // Only contribute if A2A tools are present in the agent context
     boolean hasA2aTools =

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/a2a/client/agentic/tool/systemprompt/package-info.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/a2a/client/agentic/tool/systemprompt/package-info.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+@NullMarked
+package io.camunda.connector.agenticai.a2a.client.agentic.tool.systemprompt;
+
+import org.jspecify.annotations.NullMarked;

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/a2a/client/common/configuration/package-info.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/a2a/client/common/configuration/package-info.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+@NullMarked
+package io.camunda.connector.agenticai.a2a.client.common.configuration;
+
+import org.jspecify.annotations.NullMarked;

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/a2a/client/common/convert/package-info.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/a2a/client/common/convert/package-info.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+@NullMarked
+package io.camunda.connector.agenticai.a2a.client.common.convert;
+
+import org.jspecify.annotations.NullMarked;

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/a2a/client/common/model/package-info.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/a2a/client/common/model/package-info.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+@NullMarked
+package io.camunda.connector.agenticai.a2a.client.common.model;
+
+import org.jspecify.annotations.NullMarked;

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/a2a/client/common/model/result/A2aArtifact.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/a2a/client/common/model/result/A2aArtifact.java
@@ -13,7 +13,7 @@ import io.camunda.connector.agenticai.aiagent.model.message.content.Content;
 import io.camunda.connector.agenticai.common.AgenticAiRecord;
 import java.util.List;
 import java.util.Map;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 
 @AgenticAiRecord
 @JsonDeserialize(builder = A2aArtifact.A2aArtifactJacksonProxyBuilder.class)

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/a2a/client/common/model/result/A2aClientResponse.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/a2a/client/common/model/result/A2aClientResponse.java
@@ -7,7 +7,7 @@
 package io.camunda.connector.agenticai.a2a.client.common.model.result;
 
 import io.camunda.connector.agenticai.common.AgenticAiRecord;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 
 @AgenticAiRecord
 public record A2aClientResponse(

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/a2a/client/common/model/result/A2aMessage.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/a2a/client/common/model/result/A2aMessage.java
@@ -15,7 +15,7 @@ import io.camunda.connector.agenticai.aiagent.model.message.content.Content;
 import io.camunda.connector.agenticai.common.AgenticAiRecord;
 import java.util.List;
 import java.util.Map;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 
 @AgenticAiRecord
 @JsonDeserialize(builder = A2aMessage.A2aMessageJacksonProxyBuilder.class)

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/a2a/client/common/model/result/A2aTaskStatus.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/a2a/client/common/model/result/A2aTaskStatus.java
@@ -12,7 +12,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import io.camunda.connector.agenticai.common.AgenticAiRecord;
 import java.time.OffsetDateTime;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 
 @AgenticAiRecord
 @JsonDeserialize(builder = A2aTaskStatus.A2aTaskStatusJacksonProxyBuilder.class)

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/a2a/client/common/model/result/package-info.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/a2a/client/common/model/result/package-info.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+@NullMarked
+package io.camunda.connector.agenticai.a2a.client.common.model.result;
+
+import org.jspecify.annotations.NullMarked;

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/a2a/client/common/package-info.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/a2a/client/common/package-info.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+@NullMarked
+package io.camunda.connector.agenticai.a2a.client.common;
+
+import org.jspecify.annotations.NullMarked;

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/a2a/client/common/sdk/A2aSdkClientConfig.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/a2a/client/common/sdk/A2aSdkClientConfig.java
@@ -8,7 +8,7 @@ package io.camunda.connector.agenticai.a2a.client.common.sdk;
 
 import io.camunda.connector.agenticai.common.AgenticAiRecord;
 import java.util.List;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 
 @AgenticAiRecord
 public record A2aSdkClientConfig(

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/a2a/client/common/sdk/grpc/package-info.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/a2a/client/common/sdk/grpc/package-info.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+@NullMarked
+package io.camunda.connector.agenticai.a2a.client.common.sdk.grpc;
+
+import org.jspecify.annotations.NullMarked;

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/a2a/client/common/sdk/http/package-info.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/a2a/client/common/sdk/http/package-info.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+@NullMarked
+package io.camunda.connector.agenticai.a2a.client.common.sdk.http;
+
+import org.jspecify.annotations.NullMarked;

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/a2a/client/common/sdk/package-info.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/a2a/client/common/sdk/package-info.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+@NullMarked
+package io.camunda.connector.agenticai.a2a.client.common.sdk;
+
+import org.jspecify.annotations.NullMarked;

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/a2a/client/inbound/polling/A2aClientPollingExecutable.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/a2a/client/inbound/polling/A2aClientPollingExecutable.java
@@ -18,6 +18,7 @@ import io.camunda.connector.api.inbound.InboundConnectorExecutable;
 import io.camunda.connector.api.inbound.InboundIntermediateConnectorContext;
 import io.camunda.connector.generator.java.annotation.BpmnType;
 import io.camunda.connector.generator.java.annotation.ElementTemplate;
+import org.jspecify.annotations.Nullable;
 
 @ElementTemplate(
     id = "io.camunda.connectors.agenticai.a2a.client.polling.v0",
@@ -61,7 +62,7 @@ public class A2aClientPollingExecutable
   private final A2aSdkObjectConverter objectConverter;
   private final ObjectMapper objectMapper;
 
-  private A2aPollingProcessInstancesFetcherTask processInstancesFetcherTask;
+  private @Nullable A2aPollingProcessInstancesFetcherTask processInstancesFetcherTask;
 
   public A2aClientPollingExecutable(
       final A2aPollingExecutorService executorService,
@@ -91,6 +92,8 @@ public class A2aClientPollingExecutable
 
   @Override
   public void deactivate() {
-    processInstancesFetcherTask.stop();
+    if (processInstancesFetcherTask != null) {
+      processInstancesFetcherTask.stop();
+    }
   }
 }

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/a2a/client/inbound/polling/configuration/package-info.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/a2a/client/inbound/polling/configuration/package-info.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+@NullMarked
+package io.camunda.connector.agenticai.a2a.client.inbound.polling.configuration;
+
+import org.jspecify.annotations.NullMarked;

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/a2a/client/inbound/polling/model/package-info.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/a2a/client/inbound/polling/model/package-info.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+@NullMarked
+package io.camunda.connector.agenticai.a2a.client.inbound.polling.model;
+
+import org.jspecify.annotations.NullMarked;

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/a2a/client/inbound/polling/package-info.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/a2a/client/inbound/polling/package-info.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+@NullMarked
+package io.camunda.connector.agenticai.a2a.client.inbound.polling;
+
+import org.jspecify.annotations.NullMarked;

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/a2a/client/inbound/polling/service/package-info.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/a2a/client/inbound/polling/service/package-info.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+@NullMarked
+package io.camunda.connector.agenticai.a2a.client.inbound.polling.service;
+
+import org.jspecify.annotations.NullMarked;

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/a2a/client/inbound/polling/task/A2aPollingProcessInstancesFetcherTask.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/a2a/client/inbound/polling/task/A2aPollingProcessInstancesFetcherTask.java
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ScheduledFuture;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -41,7 +42,7 @@ public class A2aPollingProcessInstancesFetcherTask implements Runnable {
 
   private final ConcurrentHashMap<String, ScheduledPoll> runningPollTasks =
       new ConcurrentHashMap<>();
-  private ScheduledFuture<?> mainTaskFuture;
+  @Nullable private ScheduledFuture<?> mainTaskFuture;
 
   public A2aPollingProcessInstancesFetcherTask(
       final InboundIntermediateConnectorContext context,

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/a2a/client/inbound/polling/task/A2aPollingTask.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/a2a/client/inbound/polling/task/A2aPollingTask.java
@@ -27,6 +27,7 @@ import io.camunda.connector.api.inbound.ProcessInstanceContext;
 import io.camunda.connector.api.inbound.Severity;
 import java.util.Objects;
 import java.util.Optional;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -48,7 +49,7 @@ public class A2aPollingTask implements Runnable, AutoCloseable {
   private final A2aSdkObjectConverter objectConverter;
   private final ObjectMapper objectMapper;
 
-  private A2aSdkClient client;
+  private @Nullable A2aSdkClient client;
 
   public A2aPollingTask(
       final InboundIntermediateConnectorContext context,
@@ -152,7 +153,7 @@ public class A2aPollingTask implements Runnable, AutoCloseable {
     }
   }
 
-  private A2aPollingRuntimeProperties bindRuntimeProperties() {
+  private @Nullable A2aPollingRuntimeProperties bindRuntimeProperties() {
     try {
       return processInstanceContext.bind(A2aPollingRuntimeProperties.class);
     } catch (Exception e) {
@@ -168,7 +169,8 @@ public class A2aPollingTask implements Runnable, AutoCloseable {
     return null;
   }
 
-  private A2aClientResponse getClientResponse(final A2aPollingRuntimeProperties runtimeProperties) {
+  private @Nullable A2aClientResponse getClientResponse(
+      final A2aPollingRuntimeProperties runtimeProperties) {
     try {
       final var clientResponseJson = runtimeProperties.data().clientResponse();
       return objectMapper.readValue(clientResponseJson, A2aClientResponse.class);
@@ -185,7 +187,8 @@ public class A2aPollingTask implements Runnable, AutoCloseable {
     return null;
   }
 
-  private synchronized A2aSdkClient getClient(final A2aPollingRuntimeProperties runtimeProperties) {
+  private synchronized @Nullable A2aSdkClient getClient(
+      final A2aPollingRuntimeProperties runtimeProperties) {
     if (this.client == null) {
       try {
         final var agentCard =

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/a2a/client/inbound/polling/task/package-info.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/a2a/client/inbound/polling/task/package-info.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+@NullMarked
+package io.camunda.connector.agenticai.a2a.client.inbound.polling.task;
+
+import org.jspecify.annotations.NullMarked;

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/a2a/client/inbound/webhook/A2aClientWebhookExecutable.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/a2a/client/inbound/webhook/A2aClientWebhookExecutable.java
@@ -32,7 +32,6 @@ import io.camunda.connector.inbound.authorization.WebhookAuthorizationHandler;
 import io.camunda.connector.inbound.signature.HMACVerifier;
 import java.io.IOException;
 import java.util.Objects;
-import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -70,7 +69,6 @@ import org.slf4j.LoggerFactory;
           templateNameOverride = "A2A Client Webhook Receive Task Connector (early access)"),
     })
 @InboundConnector(name = "A2A Webhook Connector", type = "io.camunda.agenticai:a2aclient:webhook:0")
-@NullMarked
 public class A2aClientWebhookExecutable implements WebhookConnectorExecutable {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(A2aClientWebhookExecutable.class);

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/a2a/client/inbound/webhook/A2aClientWebhookExecutable.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/a2a/client/inbound/webhook/A2aClientWebhookExecutable.java
@@ -31,6 +31,9 @@ import io.camunda.connector.inbound.authorization.AuthorizationResult.Failure;
 import io.camunda.connector.inbound.authorization.WebhookAuthorizationHandler;
 import io.camunda.connector.inbound.signature.HMACVerifier;
 import java.io.IOException;
+import java.util.Objects;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -67,6 +70,7 @@ import org.slf4j.LoggerFactory;
           templateNameOverride = "A2A Client Webhook Receive Task Connector (early access)"),
     })
 @InboundConnector(name = "A2A Webhook Connector", type = "io.camunda.agenticai:a2aclient:webhook:0")
+@NullMarked
 public class A2aClientWebhookExecutable implements WebhookConnectorExecutable {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(A2aClientWebhookExecutable.class);
@@ -74,10 +78,10 @@ public class A2aClientWebhookExecutable implements WebhookConnectorExecutable {
   private final A2aSdkObjectConverter a2aSdkObjectConverter;
   private final ObjectMapper objectMapper;
 
-  private A2aWebhookProperties props;
-  private WebhookAuthorizationHandler<?> authChecker;
-  private InboundConnectorContext context;
-  private HMACVerifier hmacVerifier;
+  @Nullable private A2aWebhookProperties props;
+  @Nullable private WebhookAuthorizationHandler<?> authChecker;
+  @Nullable private InboundConnectorContext context;
+  @Nullable private HMACVerifier hmacVerifier;
 
   public A2aClientWebhookExecutable(
       A2aSdkObjectConverter a2aSdkObjectConverter, ObjectMapper objectMapper) {
@@ -99,26 +103,32 @@ public class A2aClientWebhookExecutable implements WebhookConnectorExecutable {
 
   @Override
   public WebhookResult triggerWebhook(WebhookProcessingPayload payload) {
-    LOGGER.debug("Triggered A2A webhook with context {}", props.context());
+    final var activeProps = Objects.requireNonNull(props);
+    final var activeAuthChecker = Objects.requireNonNull(authChecker);
+    final var activeContext = Objects.requireNonNull(context);
+    final var activeHmacVerifier = Objects.requireNonNull(hmacVerifier);
 
-    verifyHmac(payload);
+    LOGGER.debug("Triggered A2A webhook with context {}", activeProps.context());
 
-    final var authResult = authChecker.checkAuthorization(payload);
+    verifyHmac(payload, activeProps, activeHmacVerifier);
+
+    final var authResult = activeAuthChecker.checkAuthorization(payload);
     if (authResult instanceof Failure failureResult) {
       throw failureResult.toException();
     }
 
-    final var mappedRequest = mapRequest(payload);
+    final var mappedRequest = mapRequest(payload, activeContext);
     return new A2aWebhookResult(mappedRequest);
   }
 
-  private MappedHttpRequest mapRequest(WebhookProcessingPayload payload) {
+  private MappedHttpRequest mapRequest(
+      WebhookProcessingPayload payload, InboundConnectorContext ctx) {
     try {
       Task task = objectMapper.readValue(payload.rawBody(), Task.TYPE_REFERENCE);
       A2aTask a2aTask = a2aSdkObjectConverter.convert(task);
       return new MappedHttpRequest(a2aTask, payload.headers(), payload.params());
     } catch (IOException e) {
-      this.context.log(
+      ctx.log(
           activity ->
               activity
                   .withSeverity(Severity.ERROR)
@@ -128,15 +138,20 @@ public class A2aClientWebhookExecutable implements WebhookConnectorExecutable {
     }
   }
 
-  private void verifyHmac(WebhookProcessingPayload payload) {
-    if (enabled.equals(props.shouldValidateHmac())) {
-      hmacVerifier.verifySignature(payload);
+  private void verifyHmac(
+      WebhookProcessingPayload payload,
+      A2aWebhookProperties activeProps,
+      HMACVerifier activeHmacVerifier) {
+    if (enabled.equals(activeProps.shouldValidateHmac())) {
+      activeHmacVerifier.verifySignature(payload);
     }
   }
 
   @Override
   public void deactivate() {
     LOGGER.debug("Deactivating A2A Webhook Connector");
-    context.reportHealth(Health.down());
+    if (context != null) {
+      context.reportHealth(Health.down());
+    }
   }
 }

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/a2a/client/inbound/webhook/configuration/package-info.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/a2a/client/inbound/webhook/configuration/package-info.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+@NullMarked
+package io.camunda.connector.agenticai.a2a.client.inbound.webhook.configuration;
+
+import org.jspecify.annotations.NullMarked;

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/a2a/client/inbound/webhook/model/package-info.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/a2a/client/inbound/webhook/model/package-info.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+@NullMarked
+package io.camunda.connector.agenticai.a2a.client.inbound.webhook.model;
+
+import org.jspecify.annotations.NullMarked;

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/a2a/client/inbound/webhook/package-info.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/a2a/client/inbound/webhook/package-info.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+@NullMarked
+package io.camunda.connector.agenticai.a2a.client.inbound.webhook;
+
+import org.jspecify.annotations.NullMarked;

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/a2a/client/outbound/configuration/package-info.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/a2a/client/outbound/configuration/package-info.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+@NullMarked
+package io.camunda.connector.agenticai.a2a.client.outbound.configuration;
+
+import org.jspecify.annotations.NullMarked;

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/a2a/client/outbound/convert/package-info.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/a2a/client/outbound/convert/package-info.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+@NullMarked
+package io.camunda.connector.agenticai.a2a.client.outbound.convert;
+
+import org.jspecify.annotations.NullMarked;

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/a2a/client/outbound/model/A2aSendMessageOperationParameters.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/a2a/client/outbound/model/A2aSendMessageOperationParameters.java
@@ -15,7 +15,7 @@ import io.camunda.connector.generator.java.annotation.FeelMode;
 import io.camunda.connector.generator.java.annotation.TemplateProperty;
 import jakarta.validation.constraints.NotBlank;
 import java.util.List;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 
 @AgenticAiRecord
 @JsonDeserialize(

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/a2a/client/outbound/model/package-info.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/a2a/client/outbound/model/package-info.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+@NullMarked
+package io.camunda.connector.agenticai.a2a.client.outbound.model;
+
+import org.jspecify.annotations.NullMarked;

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/a2a/client/outbound/package-info.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/a2a/client/outbound/package-info.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+@NullMarked
+package io.camunda.connector.agenticai.a2a.client.outbound;
+
+import org.jspecify.annotations.NullMarked;


### PR DESCRIPTION
## Summary

Applies JSpecify null-safety to the `a2a` package (36 files changed). Requires #7696 to be merged first.

- Adds `package-info.java` with `@NullMarked` to all `a2a` subpackages.
- Replaces `javax.annotation.Nullable` (jsr305) with `org.jspecify.annotations.Nullable` across the a2a package (`A2aSdkClientConfig`, `A2aMessage`, `A2aArtifact`, `A2aClientResponse`, `A2aTaskStatus`, `A2aSendMessageOperationParameters`).
- Fixes NullAway violations surfaced by the check.
- Removes the `com.google.code.findbugs:jsr305` Maven dependency from pom.xml — the a2a package was the last consumer; all other packages already use JSpecify.
- Deletes `a2a/.gitignore` (the placeholder from #7696).

After this PR merges, NullAway enforces non-null-by-default for the entire `a2a` package at compile time, and jsr305 is no longer a dependency.

## Merge order

Merge #7696 first. This PR and the other three feature PRs (#7697, #7698, #7700) can be merged in any order after that.