### PR TITLE
feat(agentic-ai): apply @NullMarked to adhoctoolsschema package

### DIFF
--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/adhoctoolsschema/.gitignore
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/adhoctoolsschema/.gitignore
@@ -1,1 +1,0 @@
-package-info.java

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/adhoctoolsschema/model/AdHocToolElement.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/adhoctoolsschema/model/AdHocToolElement.java
@@ -14,8 +14,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import org.apache.commons.lang3.StringUtils;
-import org.springframework.lang.Nullable;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
+@NullMarked
 @AgenticAiRecord
 @JsonDeserialize(builder = AdHocToolElement.AdHocToolElementJacksonProxyBuilder.class)
 public record AdHocToolElement(
@@ -32,7 +34,7 @@ public record AdHocToolElement(
    *
    * @return the documentation if available and valid; otherwise, the elementName.
    */
-  public String documentationWithNameFallback() {
+  public @Nullable String documentationWithNameFallback() {
     return Optional.ofNullable(documentation)
         .map(String::trim)
         .filter(StringUtils::isNotBlank)

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/adhoctoolsschema/model/AdHocToolElement.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/adhoctoolsschema/model/AdHocToolElement.java
@@ -28,9 +28,10 @@ public record AdHocToolElement(
 
   /**
    * Returns the documentation if it is non-null, non-blank, and not only whitespace. Otherwise, it
-   * falls back to returning the elementName.
+   * falls back to returning the elementName, which may itself be null.
    *
-   * @return the documentation if available and valid; otherwise, the elementName.
+   * @return the documentation if available and valid; otherwise, the elementName, or {@code null}
+   *     if both are null.
    */
   public @Nullable String documentationWithNameFallback() {
     return Optional.ofNullable(documentation)

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/adhoctoolsschema/model/AdHocToolElement.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/adhoctoolsschema/model/AdHocToolElement.java
@@ -14,10 +14,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import org.apache.commons.lang3.StringUtils;
-import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
-@NullMarked
 @AgenticAiRecord
 @JsonDeserialize(builder = AdHocToolElement.AdHocToolElementJacksonProxyBuilder.class)
 public record AdHocToolElement(

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/adhoctoolsschema/model/AdHocToolElementParameter.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/adhoctoolsschema/model/AdHocToolElementParameter.java
@@ -11,8 +11,10 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import io.camunda.connector.agenticai.common.AgenticAiRecord;
 import java.util.Map;
-import org.springframework.lang.Nullable;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
+@NullMarked
 @AgenticAiRecord
 @JsonDeserialize(
     builder = AdHocToolElementParameter.AdHocToolElementParameterJacksonProxyBuilder.class)

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/adhoctoolsschema/model/AdHocToolElementParameter.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/adhoctoolsschema/model/AdHocToolElementParameter.java
@@ -11,10 +11,8 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import io.camunda.connector.agenticai.common.AgenticAiRecord;
 import java.util.Map;
-import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
-@NullMarked
 @AgenticAiRecord
 @JsonDeserialize(
     builder = AdHocToolElementParameter.AdHocToolElementParameterJacksonProxyBuilder.class)

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/adhoctoolsschema/model/AdHocToolsSchemaRequest.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/adhoctoolsschema/model/AdHocToolsSchemaRequest.java
@@ -11,7 +11,9 @@ import io.camunda.connector.generator.java.annotation.TemplateProperty.PropertyC
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import org.jspecify.annotations.NullMarked;
 
+@NullMarked
 public record AdHocToolsSchemaRequest(@Valid @NotNull AdHocToolsSchemaRequestData data) {
   public record AdHocToolsSchemaRequestData(
       @NotBlank

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/adhoctoolsschema/model/AdHocToolsSchemaRequest.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/adhoctoolsschema/model/AdHocToolsSchemaRequest.java
@@ -11,9 +11,7 @@ import io.camunda.connector.generator.java.annotation.TemplateProperty.PropertyC
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
-import org.jspecify.annotations.NullMarked;
 
-@NullMarked
 public record AdHocToolsSchemaRequest(@Valid @NotNull AdHocToolsSchemaRequestData data) {
   public record AdHocToolsSchemaRequestData(
       @NotBlank

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/adhoctoolsschema/model/package-info.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/adhoctoolsschema/model/package-info.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+@NullMarked
+package io.camunda.connector.agenticai.adhoctoolsschema.model;
+
+import org.jspecify.annotations.NullMarked;

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/adhoctoolsschema/package-info.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/adhoctoolsschema/package-info.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+@NullMarked
+package io.camunda.connector.agenticai.adhoctoolsschema;
+
+import org.jspecify.annotations.NullMarked;

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/adhoctoolsschema/processdefinition/feel/package-info.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/adhoctoolsschema/processdefinition/feel/package-info.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+@NullMarked
+package io.camunda.connector.agenticai.adhoctoolsschema.processdefinition.feel;
+
+import org.jspecify.annotations.NullMarked;

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/adhoctoolsschema/processdefinition/package-info.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/adhoctoolsschema/processdefinition/package-info.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+@NullMarked
+package io.camunda.connector.agenticai.adhoctoolsschema.processdefinition;
+
+import org.jspecify.annotations.NullMarked;

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/adhoctoolsschema/schema/package-info.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/adhoctoolsschema/schema/package-info.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+@NullMarked
+package io.camunda.connector.agenticai.adhoctoolsschema.schema;
+
+import org.jspecify.annotations.NullMarked;


### PR DESCRIPTION
## Summary

Applies JSpecify null-safety to the `adhoctoolsschema` package (9 files changed). Requires #7696 to be merged first.

- Adds `package-info.java` with `@NullMarked` to all `adhoctoolsschema` subpackages.
- Fixes NullAway violations: `@Nullable` on fields that may be absent in `AdHocToolElement`, `AdHocToolElementParameter`, and `AdHocToolsSchemaRequest`.
- Deletes `adhoctoolsschema/.gitignore` (the placeholder from #7696).

After this PR merges, NullAway enforces non-null-by-default for the entire `adhoctoolsschema` package at compile time.

## Merge order

Merge #7696 first. This PR and the other three feature PRs (#7697, #7698, #7699) can be merged in any order after that.