### PR TITLE
[Backport stable/8.9] deps: Update version.mcp-sdk to v2

### DIFF
--- a/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/mcp/McpSdkToolSpecifications.java
+++ b/connectors-e2e-test/connectors-e2e-test-agentic-ai/src/test/java/io/camunda/connector/e2e/agenticai/mcp/McpSdkToolSpecifications.java
@@ -27,54 +27,45 @@ public class McpSdkToolSpecifications {
   public static final McpSchema.ListToolsResult MCP_TOOL_SPECIFICATIONS =
       new McpSchema.ListToolsResult(
           List.of(
-              McpSchema.Tool.builder()
-                  .name("toolA")
-                  .description("The first tool")
-                  .title("Tool A")
-                  .inputSchema(
-                      new McpSchema.JsonSchema(
+              McpSchema.Tool.builder(
+                      "toolA",
+                      Map.of(
+                          "type",
                           "object",
+                          "properties",
                           Map.of(
                               "paramA1",
-                                  Map.of("type", "string", "description", "The first parameter"),
+                              Map.of("type", "string", "description", "The first parameter"),
                               "paramA2",
-                                  Map.of("type", "number", "description", "The second parameter")),
-                          null,
-                          null,
-                          null,
-                          null))
+                              Map.of("type", "number", "description", "The second parameter"))))
+                  .title("Tool A")
+                  .description("The first tool")
                   .build(),
-              McpSchema.Tool.builder()
-                  .name("toolB")
-                  .description("The second tool")
-                  .title("Tool B")
-                  .inputSchema(
-                      new McpSchema.JsonSchema(
+              McpSchema.Tool.builder(
+                      "toolB",
+                      Map.of(
+                          "type",
                           "object",
+                          "properties",
                           Map.of(
                               "paramB1",
                               Map.of("type", "string", "description", "The first parameter"),
                               "paramB2",
-                              Map.of("type", "string", "enum", List.of("A", "B", "C"))),
-                          null,
-                          null,
-                          null,
-                          null))
+                              Map.of("type", "string", "enum", List.of("A", "B", "C")))))
+                  .title("Tool B")
+                  .description("The second tool")
                   .build(),
-              McpSchema.Tool.builder()
-                  .name("toolC")
-                  .description("The third tool")
-                  .title("Tool C")
-                  .inputSchema(
-                      new McpSchema.JsonSchema(
+              McpSchema.Tool.builder(
+                      "toolC",
+                      Map.of(
+                          "type",
                           "object",
+                          "properties",
                           Map.of(
                               "paramC1",
-                              Map.of("type", "string", "description", "The first parameter")),
-                          null,
-                          null,
-                          null,
-                          null))
+                              Map.of("type", "string", "description", "The first parameter"))))
+                  .title("Tool C")
+                  .description("The third tool")
                   .build()),
           null);
 }

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/mcp/client/framework/mcpsdk/McpSdkClientFactory.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/mcp/client/framework/mcpsdk/McpSdkClientFactory.java
@@ -52,8 +52,9 @@ public class McpSdkClientFactory implements McpClientFactory {
                 McpSchema.Implementation.builder("Camunda 8 MCP Connector", "1.0.0").build())
             .capabilities(McpSchema.ClientCapabilities.builder().roots(false).build());
 
-    Optional.ofNullable(config.initializationTimeout()).map(clientBuilder::initializationTimeout);
-    Optional.ofNullable(config.toolExecutionTimeout()).map(clientBuilder::requestTimeout);
+    Optional.ofNullable(config.initializationTimeout())
+        .ifPresent(clientBuilder::initializationTimeout);
+    Optional.ofNullable(config.toolExecutionTimeout()).ifPresent(clientBuilder::requestTimeout);
 
     return new McpSdkMcpClientDelegate(clientId, clientBuilder.build(), objectMapper);
   }

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/mcp/client/framework/mcpsdk/McpSdkClientFactory.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/mcp/client/framework/mcpsdk/McpSdkClientFactory.java
@@ -48,7 +48,8 @@ public class McpSdkClientFactory implements McpClientFactory {
       String clientId, McpClientConfigurationProperties.McpClientConfiguration config) {
     var clientBuilder =
         McpClient.sync(createTransport(config))
-            .clientInfo(new McpSchema.Implementation("Camunda 8 MCP Connector", "1.0.0"))
+            .clientInfo(
+                McpSchema.Implementation.builder("Camunda 8 MCP Connector", "1.0.0").build())
             .capabilities(McpSchema.ClientCapabilities.builder().roots(false).build());
 
     Optional.ofNullable(config.initializationTimeout()).map(clientBuilder::initializationTimeout);
@@ -97,9 +98,10 @@ public class McpSdkClientFactory implements McpClientFactory {
             List.of(
                 ProtocolVersions.MCP_2024_11_05,
                 ProtocolVersions.MCP_2025_03_26,
-                ProtocolVersions.MCP_2025_06_18))
-        .customizeRequest(
-            request -> {
+                ProtocolVersions.MCP_2025_06_18,
+                ProtocolVersions.MCP_2025_11_25))
+        .httpRequestCustomizer(
+            (request, method, uri, protocolVersion, context) -> {
               var headers = headerSupplier.get();
               headers.forEach(request::header);
             })
@@ -114,8 +116,8 @@ public class McpSdkClientFactory implements McpClientFactory {
         .sseEndpoint(sseConfig.url()) // see https://github.com/camunda/connectors/issues/6393
         .customizeClient(proxyConfigurator::configure)
         .connectTimeout(timeout(sseConfig.timeout()))
-        .customizeRequest(
-            request -> {
+        .httpRequestCustomizer(
+            (request, method, uri, protocolVersion, context) -> {
               var headers = headerSuppliers.get();
               headers.forEach(request::header);
             })

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/mcp/client/framework/mcpsdk/rpc/GetPromptRequest.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/mcp/client/framework/mcpsdk/rpc/GetPromptRequest.java
@@ -92,6 +92,9 @@ final class GetPromptRequest {
               throw new UnsupportedOperationException("Not yet implemented!");
           case McpSchema.TextContent textContent ->
               new McpClientGetPromptResult.TextMessage(textContent.text());
+          default ->
+              throw new UnsupportedOperationException(
+                  "Unsupported content type: " + content.getClass().getSimpleName());
         };
 
     return new McpClientGetPromptResult.PromptMessage(role, resultingContent);
@@ -111,6 +114,10 @@ final class GetPromptRequest {
                   textResourceContents.uri(),
                   textResourceContents.mimeType(),
                   textResourceContents.text());
+          default ->
+              throw new UnsupportedOperationException(
+                  "Unsupported resource type: "
+                      + embeddedResource.resource().getClass().getSimpleName());
         });
   }
 

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/mcp/client/framework/mcpsdk/rpc/ListPromptsRequest.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/mcp/client/framework/mcpsdk/rpc/ListPromptsRequest.java
@@ -12,6 +12,7 @@ import io.camunda.connector.agenticai.mcp.client.model.result.PromptDescription;
 import io.modelcontextprotocol.client.McpSyncClient;
 import io.modelcontextprotocol.spec.McpSchema;
 import java.util.Collections;
+import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.util.CollectionUtils;
@@ -53,7 +54,11 @@ final class ListPromptsRequest {
                             fr.name(),
                             fr.title(),
                             fr.description(),
-                            fr.arguments().stream().map(this::from).toList()))
+                            Optional.ofNullable(fr.arguments())
+                                .orElse(Collections.emptyList())
+                                .stream()
+                                .map(this::from)
+                                .toList()))
                 .toList());
 
     LOGGER.debug(

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/mcp/client/framework/mcpsdk/rpc/ListToolsRequest.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/mcp/client/framework/mcpsdk/rpc/ListToolsRequest.java
@@ -6,16 +6,12 @@
  */
 package io.camunda.connector.agenticai.mcp.client.framework.mcpsdk.rpc;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.connector.agenticai.mcp.client.filters.AllowDenyList;
 import io.camunda.connector.agenticai.mcp.client.model.McpToolDefinition;
 import io.camunda.connector.agenticai.mcp.client.model.McpToolDefinitionBuilder;
 import io.camunda.connector.agenticai.mcp.client.model.result.McpClientListToolsResult;
-import io.camunda.connector.agenticai.util.ObjectMapperConstants;
 import io.modelcontextprotocol.client.McpSyncClient;
-import io.modelcontextprotocol.spec.McpSchema;
 import java.util.Collections;
-import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -24,11 +20,9 @@ final class ListToolsRequest {
   private static final Logger LOGGER = LoggerFactory.getLogger(ListToolsRequest.class);
 
   private final String clientId;
-  private final ObjectMapper objectMapper;
 
-  ListToolsRequest(String clientId, ObjectMapper objectMapper) {
+  ListToolsRequest(String clientId) {
     this.clientId = clientId;
-    this.objectMapper = objectMapper;
   }
 
   public McpClientListToolsResult execute(McpSyncClient client, AllowDenyList toolNameFilter) {
@@ -52,7 +46,7 @@ final class ListToolsRequest {
                         .name(tool.name())
                         .title(tool.title())
                         .description(tool.description())
-                        .inputSchema(parseToolParameters(tool.inputSchema()))
+                        .inputSchema(tool.inputSchema())
                         .build())
             .toList();
 
@@ -68,10 +62,5 @@ final class ListToolsRequest {
         filteredToolDefinitions.stream().map(McpToolDefinition::name).toList());
 
     return new McpClientListToolsResult(filteredToolDefinitions);
-  }
-
-  private Map<String, Object> parseToolParameters(McpSchema.JsonSchema inputSchema) {
-    return objectMapper.convertValue(
-        inputSchema, ObjectMapperConstants.STRING_OBJECT_MAP_TYPE_REFERENCE);
   }
 }

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/mcp/client/framework/mcpsdk/rpc/McpSdkMcpClientDelegate.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/mcp/client/framework/mcpsdk/rpc/McpSdkMcpClientDelegate.java
@@ -41,7 +41,7 @@ public class McpSdkMcpClientDelegate implements McpClientDelegate {
 
   @Override
   public McpClientListToolsResult listTools(AllowDenyList filter) {
-    return new ListToolsRequest(clientId, objectMapper).execute(delegate, filter);
+    return new ListToolsRequest(clientId).execute(delegate, filter);
   }
 
   @Override

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/mcp/client/framework/mcpsdk/rpc/ReadResourceRequest.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/mcp/client/framework/mcpsdk/rpc/ReadResourceRequest.java
@@ -94,6 +94,9 @@ public class ReadResourceRequest {
               textResourceContents.uri(),
               textResourceContents.mimeType(),
               textResourceContents.text());
+      default ->
+          throw new UnsupportedOperationException(
+              "Unsupported resource type: " + content.getClass().getSimpleName());
     };
   }
 }

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/mcp/client/framework/mcpsdk/rpc/ToolCallRequest.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/mcp/client/framework/mcpsdk/rpc/ToolCallRequest.java
@@ -116,6 +116,9 @@ final class ToolCallRequest {
           fromBlob(imageContent.data(), imageContent.mimeType(), imageContent.meta());
       case McpSchema.ResourceLink resourceLink -> mapResourceLink(resourceLink);
       case McpSchema.TextContent textContent -> McpTextContent.textContent(textContent.text());
+      default ->
+          throw new UnsupportedOperationException(
+              "Unsupported content type: " + responseContent.getClass().getSimpleName());
     };
   }
 
@@ -131,6 +134,10 @@ final class ToolCallRequest {
                   blobResource.uri(),
                   blobResource.mimeType(),
                   Base64.getDecoder().decode(blobResource.blob()));
+          default ->
+              throw new UnsupportedOperationException(
+                  "Unsupported resource type: "
+                      + embeddedResource.resource().getClass().getSimpleName());
         };
     return new McpEmbeddedResourceContent(resource, embeddedResource.meta());
   }
@@ -176,7 +183,7 @@ final class ToolCallRequest {
 
     final var arguments = Optional.ofNullable(params.arguments()).orElseGet(Collections::emptyMap);
 
-    return McpSchema.CallToolRequest.builder().name(params.name()).arguments(arguments).build();
+    return McpSchema.CallToolRequest.builder(params.name()).arguments(arguments).build();
   }
 
   record ToolExecutionParameters(String name, Map<String, Object> arguments) {}

--- a/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/mcp/client/framework/mcpsdk/rpc/ListPromptsRequestTest.java
+++ b/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/mcp/client/framework/mcpsdk/rpc/ListPromptsRequestTest.java
@@ -153,7 +153,11 @@ class ListPromptsRequestTest {
 
   private McpSchema.Prompt createMcpPrompt(
       String name, String title, String description, List<McpSchema.PromptArgument> arguments) {
-    return new McpSchema.Prompt(name, title, description, List.copyOf(arguments));
+    return McpSchema.Prompt.builder(name)
+        .title(title)
+        .description(description)
+        .arguments(List.copyOf(arguments))
+        .build();
   }
 
   private PromptDescription createPrompt(

--- a/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/mcp/client/framework/mcpsdk/rpc/ListResourceTemplatesRequestTest.java
+++ b/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/mcp/client/framework/mcpsdk/rpc/ListResourceTemplatesRequestTest.java
@@ -201,9 +201,7 @@ class ListResourceTemplatesRequestTest {
 
   private McpSchema.ResourceTemplate createMcpResourceTemplate(
       String uriTemplate, String name, String title, String description, String mimeType) {
-    return McpSchema.ResourceTemplate.builder()
-        .uriTemplate(uriTemplate)
-        .name(name)
+    return McpSchema.ResourceTemplate.builder(uriTemplate, name)
         .title(title)
         .description(description)
         .mimeType(mimeType)

--- a/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/mcp/client/framework/mcpsdk/rpc/ListResourcesRequestTest.java
+++ b/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/mcp/client/framework/mcpsdk/rpc/ListResourcesRequestTest.java
@@ -191,7 +191,11 @@ class ListResourcesRequestTest {
 
   private McpSchema.Resource createMcpResource(
       String uri, String name, String title, String description, String mimeType) {
-    return new McpSchema.Resource(uri, name, title, description, mimeType, null, null, null);
+    return McpSchema.Resource.builder(uri, name)
+        .title(title)
+        .description(description)
+        .mimeType(mimeType)
+        .build();
   }
 
   private ResourceDescription createResourceDescription(

--- a/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/mcp/client/framework/mcpsdk/rpc/ListToolsRequestTest.java
+++ b/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/mcp/client/framework/mcpsdk/rpc/ListToolsRequestTest.java
@@ -9,7 +9,6 @@ package io.camunda.connector.agenticai.mcp.client.framework.mcpsdk.rpc;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.connector.agenticai.mcp.client.filters.AllowDenyList;
 import io.camunda.connector.agenticai.mcp.client.filters.AllowDenyListBuilder;
 import io.camunda.connector.agenticai.mcp.client.model.McpToolDefinition;
@@ -31,7 +30,7 @@ class ListToolsRequestTest {
 
   @Mock private McpSyncClient mcpClient;
 
-  private final ListToolsRequest testee = new ListToolsRequest("testClient", new ObjectMapper());
+  private final ListToolsRequest testee = new ListToolsRequest("testClient");
 
   @Test
   void returnsEmptyList_whenNoToolsAvailable() {
@@ -111,19 +110,15 @@ class ListToolsRequestTest {
   }
 
   private McpSchema.Tool createTool(String name, String title, String description) {
-    return new McpSchema.Tool(
-        name,
-        title,
-        description,
-        new McpSchema.JsonSchema(
-            "object",
-            Map.of("toolArg", Map.of("type", "string", "description", "A tool argument")),
-            List.of("toolArg"),
-            null,
-            null,
-            null),
-        null,
-        null,
-        null);
+    return McpSchema.Tool.builder(
+            name,
+            Map.of(
+                "type", "object",
+                "properties",
+                    Map.of("toolArg", Map.of("type", "string", "description", "A tool argument")),
+                "required", List.of("toolArg")))
+        .title(title)
+        .description(description)
+        .build();
   }
 }

--- a/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/mcp/client/framework/mcpsdk/rpc/ToolCallRequestTest.java
+++ b/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/mcp/client/framework/mcpsdk/rpc/ToolCallRequestTest.java
@@ -346,7 +346,7 @@ class ToolCallRequestTest {
   }
 
   private static McpSchema.CallToolResult callToolResult(Object structuredContent) {
-    return new McpSchema.CallToolResult(null, false, structuredContent, null);
+    return new McpSchema.CallToolResult(List.of(), false, structuredContent, null);
   }
 
   private static McpSchema.CallToolResult callToolResultWithEmbeddedTextResource(

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -173,7 +173,7 @@ limitations under the License.</license.inlineheader>
     <version.auth0.jwks>0.24.1</version.auth0.jwks>
 
     <version.langchain4j>1.17.1</version.langchain4j>
-    <version.mcp-sdk>1.1.3</version.mcp-sdk>
+    <version.mcp-sdk>2.0.0</version.mcp-sdk>
     <version.elasticsearch-java>8.19.18</version.elasticsearch-java>
     <version.elasticsearch-rest-client>8.19.18</version.elasticsearch-rest-client>
 


### PR DESCRIPTION
Backport of #7476 to stable/8.9.

## Why this matters for 8.9

The primary goal is to **align the 8.9 MCP client code with the 8.10 codebase** so that future changes touching the MCP integration can be backported cleanly, rather than diverging on two different SDK major versions.

As a side effect, this also brings 8.9 in line with 8.10 with respect to the c8Run 8.9 Connectors runtime hang under Java 25 (camunda/camunda#55595) — though note that issue was ultimately addressed differently.

## Summary

- Bumps `version.mcp-sdk` 1.1.3 -> 2.0.0
- Adapts client code to the 2.0.0 API:
  - `new Implementation(...)` -> `Implementation.builder(...)`
  - `customizeRequest` -> `httpRequestCustomizer` (SSE + streamable HTTP)
  - advertises `MCP_2025_11_25`
  - `Tool.inputSchema()` is now `Map<String,Object>` (dropped `JsonSchema` parsing)
  - `CallToolRequest.builder(name)`
  - `default` arms for the now-unsealed `Content`/`ResourceContents`
  - null-safe `Prompt.arguments()`
- Updates affected unit tests and the e2e `McpSdkToolSpecifications` to the new builders

## Backport notes

- The original PR's only e2e integration-test change migrated a `mcpCallToolResultWithImage` helper that **does not exist on stable/8.9**; both 8.9 MCP e2e tests (job worker + outbound connector) compile unchanged.
- The 3-arg `ImageContent(annotations, data, mimeType)` constructor still exists in 2.0.0, so `ToolCallRequestTest`/`GetPromptRequestTest` are unchanged.

## Verification

- `connectors/agentic-ai` main + test sources compile against 2.0.0
- The separate `connectors-e2e-test-agentic-ai` module test-compiles against 2.0.0
- MCP unit tests pass: `McpSdkClientFactoryTest` 10/10, `ToolCallRequestTest` 17/17, `GetPromptRequestTest` 18/18, `ReadResourceRequestTest` 11/11, `McpRemoteClientRegistryTest` 18/18, all `List*RequestTest` green — 0 failures

🤖 Generated with [Claude Code](https://claude.ai/claude-code)