### PR TITLE
fix(logging): update logging configuration for stackdriver integration

### DIFF
--- a/connector-runtime/connector-runtime-application/src/main/resources/logback-spring.xml
+++ b/connector-runtime/connector-runtime-application/src/main/resources/logback-spring.xml
@@ -3,7 +3,11 @@
     <springProperty name="connectorsLogAppender" source="connectors.log.appender"
                     defaultValue="default"/>
     <springProfile name="!test">
-        <if condition='property("connectorsLogAppender").equalsIgnoreCase("stackdriver")'>
+        <condition class="ch.qos.logback.core.boolex.PropertyEqualityCondition">
+            <key>connectorsLogAppender</key>
+            <value>stackdriver</value>
+        </condition>
+        <if>
             <then>
                 <springProperty name="serviceName" source="log.stackdriver.serviceName"
                                 defaultValue="connectors"/>


### PR DESCRIPTION
This pull request updates the logging configuration for the Camunda SaaS bundle and connector runtime to improve profile-based log appender selection and streamline property usage. The main changes involve switching from a custom property-based log appender selection to using Spring profiles, and cleaning up related configuration files.

**Logging configuration improvements:**

* Replaced the `connectors.log.appender` property with the standard `spring.profiles.active=stackdriver` in `application.properties`, aligning the log configuration with Spring profile conventions.
* Updated `logback-spring.xml` to use Spring profiles (`stackdriver` and non-`stackdriver`) for log appender selection instead of a custom property check, simplifying the configuration and making profile activation more explicit. [[1]](diffhunk://#diff-97ffd3e2d8d38ec1d43dfc3a30fb62db2d437cdd656f82586e903a7f8e56b788L3-R3) [[2]](diffhunk://#diff-97ffd3e2d8d38ec1d43dfc3a30fb62db2d437cdd656f82586e903a7f8e56b788L25-R30)
