### PR TITLE
fix(agentic-ai): Fix breaking camunda client interface changes

### DIFF
--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/agentinstance/AgentInstanceHistoryMapper.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/agentinstance/AgentInstanceHistoryMapper.java
@@ -43,9 +43,9 @@ import org.jspecify.annotations.Nullable;
 
 /**
  * Maps agentic-ai conversation messages ({@link Message}/{@link AssistantMessage}) into the Camunda
- * client agent-instance history item components ({@code AgentHistory*}). Pure transformation logic:
- * no API calls, retries or logging — those remain the responsibility of {@link
- * CamundaAgentInstanceClient}.
+ * client agent-instance history item components ({@code AgentInstanceHistory*}). Pure
+ * transformation logic: no API calls, retries or logging — those remain the responsibility of
+ * {@link CamundaAgentInstanceClient}.
  */
 public class AgentInstanceHistoryMapper {
 

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/agentinstance/AgentInstanceHistoryMapper.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/agentinstance/AgentInstanceHistoryMapper.java
@@ -10,10 +10,10 @@ import static io.camunda.connector.agenticai.aiagent.agent.AgentErrorCodes.ERROR
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.camunda.client.api.command.CreateAgentHistoryItemCommandStep1.AgentHistoryContent;
-import io.camunda.client.api.command.CreateAgentHistoryItemCommandStep1.AgentHistoryMetrics;
-import io.camunda.client.api.command.CreateAgentHistoryItemCommandStep1.AgentHistoryRole;
-import io.camunda.client.api.command.CreateAgentHistoryItemCommandStep1.AgentHistoryToolCall;
+import io.camunda.client.api.command.AgentInstanceHistoryContent;
+import io.camunda.client.api.command.AgentInstanceHistoryMetrics;
+import io.camunda.client.api.command.AgentInstanceHistoryToolCall;
+import io.camunda.client.api.search.enums.AgentInstanceHistoryRole;
 import io.camunda.client.impl.response.DocumentReferenceResponseImpl;
 import io.camunda.client.protocol.rest.DocumentMetadataResponse;
 import io.camunda.client.protocol.rest.DocumentReference;
@@ -64,16 +64,16 @@ public class AgentInstanceHistoryMapper {
    * carrying a single-entry {@code toolCalls} list correlating it to the originating tool call.
    */
   public record InputHistoryItem(
-      AgentHistoryRole role,
-      List<AgentHistoryContent> content,
-      @Nullable List<AgentHistoryToolCall> toolCalls) {}
+      AgentInstanceHistoryRole role,
+      List<AgentInstanceHistoryContent> content,
+      @Nullable List<AgentInstanceHistoryToolCall> toolCalls) {}
 
   public List<InputHistoryItem> inputHistoryItems(Message message) {
     return switch (message) {
       case UserMessage userMessage ->
           List.of(
               new InputHistoryItem(
-                  AgentHistoryRole.USER, contentBlocks(userMessage.content()), null));
+                  AgentInstanceHistoryRole.USER, contentBlocks(userMessage.content()), null));
       case ToolCallResultMessage toolCallResultMessage ->
           toolCallResultMessage.results().stream().map(this::toolResultHistoryItem).toList();
       default ->
@@ -87,21 +87,21 @@ public class AgentInstanceHistoryMapper {
     // tool-call result id/name are nullable on the model (and partial/malformed results may omit
     // them); default to empty strings, which the client model accepts
     return new InputHistoryItem(
-        AgentHistoryRole.TOOL_RESULT,
+        AgentInstanceHistoryRole.TOOL_RESULT,
         toolResultContent(result.content()),
         List.of(
-            new AgentHistoryToolCall()
+            new AgentInstanceHistoryToolCall()
                 .toolCallId(StringUtils.defaultString(result.id()))
                 .toolName(StringUtils.defaultString(result.name()))
                 .elementId(elementIdFor(result.elementId(), result.name()))
                 .arguments(Map.of())));
   }
 
-  public List<AgentHistoryContent> assistantContent(AssistantMessage assistantMessage) {
+  public List<AgentInstanceHistoryContent> assistantContent(AssistantMessage assistantMessage) {
     return contentBlocks(assistantMessage.content());
   }
 
-  public @Nullable List<AgentHistoryToolCall> assistantToolCalls(
+  public @Nullable List<AgentInstanceHistoryToolCall> assistantToolCalls(
       AssistantMessage assistantMessage) {
     final List<ToolCall> toolCalls = assistantMessage.toolCalls();
     if (toolCalls == null || toolCalls.isEmpty()) {
@@ -110,7 +110,7 @@ public class AgentInstanceHistoryMapper {
     return toolCalls.stream()
         .map(
             toolCall ->
-                new AgentHistoryToolCall()
+                new AgentInstanceHistoryToolCall()
                     .toolCallId(toolCall.id())
                     .toolName(toolCall.name())
                     .elementId(elementIdFor(null, toolCall.name()))
@@ -134,46 +134,46 @@ public class AgentInstanceHistoryMapper {
     return gatewayToolHandlers.resolveElementId(toolName).orElse(toolName);
   }
 
-  public AgentHistoryMetrics historyMetrics(AgentMetrics metrics) {
+  public AgentInstanceHistoryMetrics historyMetrics(AgentMetrics metrics) {
     final long durationMs =
         metrics.executionTime() != null ? metrics.executionTime().toMillis() : 0;
-    return new AgentHistoryMetrics()
+    return new AgentInstanceHistoryMetrics()
         .inputTokens(metrics.tokenUsage().inputTokenCount())
         .outputTokens(metrics.tokenUsage().outputTokenCount())
         .durationMs(durationMs);
   }
 
-  private List<AgentHistoryContent> contentBlocks(List<Content> contents) {
+  private List<AgentInstanceHistoryContent> contentBlocks(List<Content> contents) {
     return contents.stream().map(this::toHistoryContent).toList();
   }
 
-  private AgentHistoryContent toHistoryContent(Content content) {
+  private AgentInstanceHistoryContent toHistoryContent(Content content) {
     return switch (content) {
-      case TextContent textContent -> AgentHistoryContent.text(textContent.text());
+      case TextContent textContent -> AgentInstanceHistoryContent.text(textContent.text());
       case ObjectContent objectContent -> objectOrText(objectContent.content());
       case DocumentContent documentContent -> documentHistoryContent(documentContent);
     };
   }
 
-  private List<AgentHistoryContent> toolResultContent(@Nullable Object resultContent) {
+  private List<AgentInstanceHistoryContent> toolResultContent(@Nullable Object resultContent) {
     if (resultContent == null) {
       return List.of();
     }
     if (resultContent instanceof String s) {
-      return StringUtils.isBlank(s) ? List.of() : List.of(AgentHistoryContent.text(s));
+      return StringUtils.isBlank(s) ? List.of() : List.of(AgentInstanceHistoryContent.text(s));
     }
     return List.of(objectOrText(resultContent));
   }
 
   @SuppressWarnings("unchecked")
-  private AgentHistoryContent objectOrText(Object value) {
+  private AgentInstanceHistoryContent objectOrText(Object value) {
     if (value instanceof Map<?, ?> map) {
-      return AgentHistoryContent.object((Map<String, Object>) map);
+      return AgentInstanceHistoryContent.object((Map<String, Object>) map);
     }
     try {
-      return AgentHistoryContent.object(objectMapper.convertValue(value, Map.class));
+      return AgentInstanceHistoryContent.object(objectMapper.convertValue(value, Map.class));
     } catch (IllegalArgumentException e) {
-      return AgentHistoryContent.text(toJson(value));
+      return AgentInstanceHistoryContent.text(toJson(value));
     }
   }
 
@@ -191,11 +191,12 @@ public class AgentInstanceHistoryMapper {
     }
   }
 
-  private AgentHistoryContent documentHistoryContent(DocumentContent documentContent) {
+  private AgentInstanceHistoryContent documentHistoryContent(DocumentContent documentContent) {
     final Document document = documentContent.document();
     return switch (document.reference()) {
       case CamundaDocumentReference ref ->
-          AgentHistoryContent.document(toDocumentReferenceResponse(ref, document.metadata()));
+          AgentInstanceHistoryContent.document(
+              toDocumentReferenceResponse(ref, document.metadata()));
       // External document references are not yet representable as a document content block on the
       // engine; fall back to an object reference block (follow-up: team decision).
       case ExternalDocumentReference ref -> externalDocumentReferenceContent(ref);
@@ -208,7 +209,8 @@ public class AgentInstanceHistoryMapper {
     };
   }
 
-  private AgentHistoryContent externalDocumentReferenceContent(ExternalDocumentReference ref) {
+  private AgentInstanceHistoryContent externalDocumentReferenceContent(
+      ExternalDocumentReference ref) {
     if (ref.url() == null || ref.name() == null) {
       throw new IllegalArgumentException(
           "External document reference requires both url and name for a history item");

--- a/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/agentinstance/CamundaAgentInstanceClient.java
+++ b/connectors/agentic-ai/src/main/java/io/camunda/connector/agenticai/aiagent/agentinstance/CamundaAgentInstanceClient.java
@@ -11,12 +11,12 @@ import static io.camunda.connector.agenticai.aiagent.agent.AgentErrorCodes.ERROR
 import static io.camunda.connector.agenticai.aiagent.agent.AgentErrorCodes.ERROR_CODE_AGENT_INSTANCE_UPDATE_FAILED;
 
 import io.camunda.client.CamundaClient;
-import io.camunda.client.api.command.CreateAgentHistoryItemCommandStep1.AgentHistoryContent;
-import io.camunda.client.api.command.CreateAgentHistoryItemCommandStep1.AgentHistoryMetrics;
-import io.camunda.client.api.command.CreateAgentHistoryItemCommandStep1.AgentHistoryRole;
-import io.camunda.client.api.command.CreateAgentHistoryItemCommandStep1.AgentHistoryToolCall;
+import io.camunda.client.api.command.AgentInstanceHistoryContent;
+import io.camunda.client.api.command.AgentInstanceHistoryMetrics;
+import io.camunda.client.api.command.AgentInstanceHistoryToolCall;
 import io.camunda.client.api.command.CreateAgentHistoryItemCommandStep1.CreateAgentHistoryItemFinalCommandStep;
 import io.camunda.client.api.command.UpdateAgentInstanceCommandStep1.UpdateAgentInstanceCommandStep2;
+import io.camunda.client.api.search.enums.AgentInstanceHistoryRole;
 import io.camunda.connector.agenticai.aiagent.model.AgentConversationTurn;
 import io.camunda.connector.agenticai.aiagent.model.AgentExecutionContext;
 import io.camunda.connector.agenticai.aiagent.model.message.AssistantMessage;
@@ -203,7 +203,7 @@ public class CamundaAgentInstanceClient implements AgentInstanceClient {
     createHistoryItem(
         executionContext,
         agentInstanceKey.value(),
-        AgentHistoryRole.ASSISTANT,
+        AgentInstanceHistoryRole.ASSISTANT,
         content,
         turn.iterationKey(),
         toolCalls,
@@ -213,11 +213,11 @@ public class CamundaAgentInstanceClient implements AgentInstanceClient {
   private void createHistoryItem(
       AgentExecutionContext executionContext,
       long agentInstanceKey,
-      AgentHistoryRole role,
-      List<AgentHistoryContent> content,
+      AgentInstanceHistoryRole role,
+      List<AgentInstanceHistoryContent> content,
       int iteration,
-      @Nullable List<AgentHistoryToolCall> toolCalls,
-      @Nullable AgentHistoryMetrics metrics) {
+      @Nullable List<AgentInstanceHistoryToolCall> toolCalls,
+      @Nullable AgentInstanceHistoryMetrics metrics) {
     CamundaApiRetry.execute(
         () -> {
           executeCreateHistoryItem(
@@ -234,11 +234,11 @@ public class CamundaAgentInstanceClient implements AgentInstanceClient {
   private void executeCreateHistoryItem(
       AgentExecutionContext executionContext,
       long agentInstanceKey,
-      AgentHistoryRole role,
-      List<AgentHistoryContent> content,
+      AgentInstanceHistoryRole role,
+      List<AgentInstanceHistoryContent> content,
       int iteration,
-      @Nullable List<AgentHistoryToolCall> toolCalls,
-      @Nullable AgentHistoryMetrics metrics) {
+      @Nullable List<AgentInstanceHistoryToolCall> toolCalls,
+      @Nullable AgentInstanceHistoryMetrics metrics) {
     LOGGER.debug(
         "Creating agent instance {} history item: role={}, iteration={}, contentBlocks={}",
         agentInstanceKey,

--- a/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/agentinstance/CamundaAgentInstanceClientTest.java
+++ b/connectors/agentic-ai/src/test/java/io/camunda/connector/agenticai/aiagent/agentinstance/CamundaAgentInstanceClientTest.java
@@ -23,18 +23,18 @@ import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.client.CamundaClient;
+import io.camunda.client.api.command.AgentInstanceHistoryContent;
+import io.camunda.client.api.command.AgentInstanceHistoryMetrics;
+import io.camunda.client.api.command.AgentInstanceHistoryToolCall;
 import io.camunda.client.api.command.AgentInstanceUpdateStatus;
 import io.camunda.client.api.command.ClientHttpException;
-import io.camunda.client.api.command.CreateAgentHistoryItemCommandStep1.AgentHistoryContent;
-import io.camunda.client.api.command.CreateAgentHistoryItemCommandStep1.AgentHistoryMetrics;
-import io.camunda.client.api.command.CreateAgentHistoryItemCommandStep1.AgentHistoryRole;
-import io.camunda.client.api.command.CreateAgentHistoryItemCommandStep1.AgentHistoryToolCall;
 import io.camunda.client.api.command.CreateAgentInstanceCommandStep1;
 import io.camunda.client.api.command.CreateAgentInstanceCommandStep1.CreateAgentInstanceCommandStep5;
 import io.camunda.client.api.command.UpdateAgentInstanceCommandStep1;
 import io.camunda.client.api.command.UpdateAgentInstanceCommandStep1.AgentTool;
 import io.camunda.client.api.command.UpdateAgentInstanceCommandStep1.UpdateAgentInstanceCommandStep2;
 import io.camunda.client.api.response.CreateAgentInstanceResponse;
+import io.camunda.client.api.search.enums.AgentInstanceHistoryRole;
 import io.camunda.client.impl.command.CreateAgentHistoryItemCommandImpl;
 import io.camunda.connector.agenticai.adhoctoolsschema.model.AdHocToolElement;
 import io.camunda.connector.agenticai.aiagent.model.AgentConfiguration;
@@ -500,7 +500,7 @@ class CamundaAgentInstanceClientTest {
   @Nested
   class HistoryItems {
 
-    @Captor private ArgumentCaptor<List<AgentHistoryContent>> contentCaptor;
+    @Captor private ArgumentCaptor<List<AgentInstanceHistoryContent>> contentCaptor;
 
     @Test
     void shouldCreateUserHistoryItemBeforeChat() {
@@ -524,7 +524,7 @@ class CamundaAgentInstanceClientTest {
       // then
       verify(historyCommand).elementInstanceKey(ELEMENT_INSTANCE_KEY);
       verify(historyCommand).jobKey(JOB_KEY);
-      verify(historyCommand).role(AgentHistoryRole.USER);
+      verify(historyCommand).role(AgentInstanceHistoryRole.USER);
       verify(historyCommand).iteration(3);
       verify(historyCommand).producedAt(any());
       verify(historyCommand).content(contentCaptor.capture());
@@ -535,7 +535,7 @@ class CamundaAgentInstanceClientTest {
       assertThat(contentCaptor.getValue())
           .singleElement()
           .isInstanceOfSatisfying(
-              AgentHistoryContent.TextContent.class,
+              AgentInstanceHistoryContent.TextContent.class,
               text -> assertThat(text.getText()).isEqualTo("Hello there"));
     }
 
@@ -574,7 +574,7 @@ class CamundaAgentInstanceClientTest {
       // then: one TOOL_RESULT item per result, each with a single-entry toolCalls array correlating
       // it to the originating tool call. The first result carries its content block; the second has
       // no content, yielding an empty (now valid) content list rather than a placeholder block.
-      verify(historyCommand, times(2)).role(AgentHistoryRole.TOOL_RESULT);
+      verify(historyCommand, times(2)).role(AgentInstanceHistoryRole.TOOL_RESULT);
       verify(historyCommand, times(2)).iteration(1);
       verify(historyCommand, times(2)).execute();
 
@@ -582,11 +582,11 @@ class CamundaAgentInstanceClientTest {
       final var contents = contentCaptor.getAllValues();
       assertThat(contents).hasSize(2);
       assertThat(contents.get(0)).singleElement();
-      assertThat(((AgentHistoryContent.TextContent) contents.get(0).get(0)).getText())
+      assertThat(((AgentInstanceHistoryContent.TextContent) contents.get(0).get(0)).getText())
           .isEqualTo("sunny");
       assertThat(contents.get(1)).isEmpty();
 
-      final ArgumentCaptor<List<AgentHistoryToolCall>> toolCallsCaptor =
+      final ArgumentCaptor<List<AgentInstanceHistoryToolCall>> toolCallsCaptor =
           ArgumentCaptor.forClass(List.class);
       verify(historyCommand, times(2)).toolCalls(toolCallsCaptor.capture());
       final var toolCalls = toolCallsCaptor.getAllValues();
@@ -635,7 +635,7 @@ class CamundaAgentInstanceClientTest {
       client.createHistoryForInputMessages(
           TestAgentExecutionContext.withLimits(), AgentInstanceKey.of(AGENT_INSTANCE_KEY), turn);
 
-      final ArgumentCaptor<List<AgentHistoryToolCall>> toolCallsCaptor =
+      final ArgumentCaptor<List<AgentInstanceHistoryToolCall>> toolCallsCaptor =
           ArgumentCaptor.forClass(List.class);
       verify(historyCommand).toolCalls(toolCallsCaptor.capture());
       assertThat(toolCallsCaptor.getValue())
@@ -697,7 +697,7 @@ class CamundaAgentInstanceClientTest {
       assertThat(contentCaptor.getValue())
           .singleElement()
           .isInstanceOfSatisfying(
-              AgentHistoryContent.ObjectContent.class,
+              AgentInstanceHistoryContent.ObjectContent.class,
               object -> assertThat(object.getObject()).containsEntry("key", "value"));
     }
 
@@ -725,10 +725,10 @@ class CamundaAgentInstanceClientTest {
           TestAgentExecutionContext.withLimits(), AgentInstanceKey.of(AGENT_INSTANCE_KEY), turn);
 
       // then
-      verify(historyCommand).role(AgentHistoryRole.ASSISTANT);
+      verify(historyCommand).role(AgentInstanceHistoryRole.ASSISTANT);
       verify(historyCommand).iteration(2);
 
-      final ArgumentCaptor<List<AgentHistoryToolCall>> toolCallsCaptor =
+      final ArgumentCaptor<List<AgentInstanceHistoryToolCall>> toolCallsCaptor =
           ArgumentCaptor.forClass(List.class);
       verify(historyCommand).toolCalls(toolCallsCaptor.capture());
       assertThat(toolCallsCaptor.getValue())
@@ -741,8 +741,8 @@ class CamundaAgentInstanceClientTest {
                 assertThat(tc.getElementId()).isEqualTo("getWeather");
               });
 
-      final ArgumentCaptor<AgentHistoryMetrics> metricsCaptor =
-          ArgumentCaptor.forClass(AgentHistoryMetrics.class);
+      final ArgumentCaptor<AgentInstanceHistoryMetrics> metricsCaptor =
+          ArgumentCaptor.forClass(AgentInstanceHistoryMetrics.class);
       verify(historyCommand).metrics(metricsCaptor.capture());
       assertThat(metricsCaptor.getValue().getInputTokens()).isEqualTo(11L);
       assertThat(metricsCaptor.getValue().getOutputTokens()).isEqualTo(22L);
@@ -780,7 +780,7 @@ class CamundaAgentInstanceClientTest {
           TestAgentExecutionContext.withLimits(), AgentInstanceKey.of(AGENT_INSTANCE_KEY), turn);
 
       // then
-      final ArgumentCaptor<List<AgentHistoryToolCall>> toolCallsCaptor =
+      final ArgumentCaptor<List<AgentInstanceHistoryToolCall>> toolCallsCaptor =
           ArgumentCaptor.forClass(List.class);
       verify(historyCommand).toolCalls(toolCallsCaptor.capture());
       assertThat(toolCallsCaptor.getValue())
@@ -849,7 +849,7 @@ class CamundaAgentInstanceClientTest {
       assertThat(contentCaptor.getValue())
           .singleElement()
           .isInstanceOfSatisfying(
-              AgentHistoryContent.DocumentContent.class,
+              AgentInstanceHistoryContent.DocumentContent.class,
               doc -> assertThat(doc.getDocumentReference().getDocumentId()).isEqualTo("doc-1"));
     }
 


### PR DESCRIPTION
## Description

https://github.com/camunda/camunda/pull/55544 broke the interface of the agent instance history camunda client.

This PR adapts those changes across the code base.

## Checklist

- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest
  release, as this branch will be rebased onto main before the next release. Example backport labels:
    - `backport stable/8.8`: for changes that should be included in the next 8.8.x release.
    - **or** `backport release-8.8.7`: for changes that should be included in the specific release 8.8.7, and this
      *release has already been created*. The release branch will be merged back into stable/8.8 later, so the change
      will be included in future 8.8.x releases as well.
- [ ] Tests/Integration tests for the changes have been added if applicable.
- [ ] If the change requires a documentation update, it has been added to the appropriate section in the documentation.


