### PR TITLE
fix: add package.json and package-lock.json to CODEOWNERS Renovate exclusions (stable/8.9)

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -18,3 +18,5 @@ renovate.json
 **/docker-images.properties
 .tool-versions
 **/pom.xml
+**/package.json
+**/package-lock.json


### PR DESCRIPTION
Adds `**/package.json` and `**/package-lock.json` to the Renovate auto-merge exclusion list in CODEOWNERS so that npm dependency updates can be auto-approved on this branch.

These entries are already present on `main` but were missing from the stable branches.