### PR TITLE
ci(e2e): notify Slack on build failures and route pings to the owning team via CODEOWNERS

### DIFF
--- a/.github/actions/codeowners-slack-mentions/README.md
+++ b/.github/actions/codeowners-slack-mentions/README.md
@@ -5,7 +5,8 @@ mentions**, with optional always-include mentions, deduped.
 
 Pure derivation — it makes **no GitHub API calls** and **does not post to Slack**.
 You give it paths + a team→mention map; it gives you back the mentions to ping.
-Dependency-free (Node builtins only), so it runs without a build step.
+Its only dependency is [`minimatch`](https://www.npmjs.com/package/minimatch)
+(see "Why minimatch" below); the action installs it via `npm ci` before running.
 
 ## Inputs
 
@@ -32,6 +33,19 @@ Dependency-free (Node builtins only), so it runs without a build step.
 - An owner that isn't present in `team-slack-map`, or whose value is empty, contributes
   no mention (never a broken reference) — use `always-include` (e.g. a medic group)
   as the catch-all so nothing is silent.
+
+## Why minimatch
+
+Pattern matching used to be a hand-rolled glob-to-regex compiler. It's now
+delegated to [`minimatch`](https://www.npmjs.com/package/minimatch) (npm's own
+glob matcher; one transitive dependency, `brace-expansion`, itself dependency-free)
+instead of a generic gitignore library, because plain gitignore engines (e.g.
+`ignore`) recurse into matched directories even for bare wildcard patterns like
+`docs/*` — GitHub's CODEOWNERS docs explicitly say that pattern must *not* match
+nested files. Anchoring and "does this pattern also own its descendants" stay as
+our own small CODEOWNERS-specific rules; `[...]` ranges and leading `!` are
+escaped before matching, since CODEOWNERS treats both literally, unlike
+`.gitignore`/minimatch defaults.
 
 ## Example
 

--- a/.github/actions/codeowners-slack-mentions/README.md
+++ b/.github/actions/codeowners-slack-mentions/README.md
@@ -1,0 +1,62 @@
+# codeowners-slack-mentions
+
+Resolve the **CODEOWNERS owners** of a set of repo paths and map them to **Slack
+mentions**, with optional always-include mentions, deduped.
+
+Pure derivation — it makes **no GitHub API calls** and **does not post to Slack**.
+You give it paths + a team→mention map; it gives you back the mentions to ping.
+Dependency-free (Node builtins only), so it runs without a build step.
+
+## Inputs
+
+| Input | Required | Default | Description |
+|---|---|---|---|
+| `paths` | no | `""` | Newline- or space-separated repo-relative paths to resolve owners for. Empty → only `always-include` is returned. |
+| `codeowners-file` | no | `CODEOWNERS` | Path to the CODEOWNERS file. |
+| `team-slack-map` | yes | — | JSON mapping `"@org/team"` → Slack mention (`<!subteam^…>` or `<@…>`), inserted verbatim. Either **inline JSON** or a **path** to a `.json` file — inline lets a caller assemble it from secrets without writing them to disk. |
+| `always-include` | no | `""` | Already-formatted mention(s) always included regardless of owners (e.g. a medic group `<!subteam^…>`). Space-separated, passed through verbatim. |
+
+## Outputs
+
+| Output | Description |
+|---|---|
+| `mentions` | Space-joined, deduped Slack mentions — `always-include` first, then mapped owners. |
+| `owners` | Space-joined, deduped CODEOWNERS owner handles resolved from the paths (useful for logging). |
+
+## Behaviour
+
+- Matching follows GitHub's CODEOWNERS (gitignore-style) semantics: full glob
+  support (`*`, `**`, `?`), anchoring, directory matching, **last match wins**.
+- `team-slack-map` values are used verbatim, so they must be fully-formatted mentions
+  (`<!subteam^…>` or `<@…>`), the same form as `always-include`.
+- An owner that isn't present in `team-slack-map`, or whose value is empty, contributes
+  no mention (never a broken reference) — use `always-include` (e.g. a medic group)
+  as the catch-all so nothing is silent.
+
+## Example
+
+```yaml
+- uses: ./.github/actions/codeowners-slack-mentions
+  id: mentions
+  with:
+    paths: |
+      connectors-e2e-test/connectors-e2e-test-agentic-ai
+      connectors-e2e-test/connectors-e2e-test-soap
+    # Inline JSON assembled from secrets (values are full mentions):
+    team-slack-map: |
+      {
+        "@camunda/connectors-agentic-ai": "${{ secrets.AGENTIC_ORCHESTRATION_MEDIC_SLACK_GROUP_ID }}"
+      }
+    always-include: ${{ secrets.CONNECTORS_MEDIC_SLACK_GROUP_ID }}
+
+- run: echo "Ping ${{ steps.mentions.outputs.mentions }}"
+```
+
+`team-slack-map` also accepts a path to a committed `.json` file if you prefer to keep the
+mapping in the repo instead of secrets.
+
+## Tests
+
+```bash
+node --test .github/actions/codeowners-slack-mentions/index.test.mjs
+```

--- a/.github/actions/codeowners-slack-mentions/action.yml
+++ b/.github/actions/codeowners-slack-mentions/action.yml
@@ -32,6 +32,10 @@ outputs:
 runs:
   using: composite
   steps:
+    - name: Set up Node
+      uses: actions/setup-node@v6
+      with:
+        node-version: '24'
     - name: Install dependencies
       shell: bash
       working-directory: ${{ github.action_path }}

--- a/.github/actions/codeowners-slack-mentions/action.yml
+++ b/.github/actions/codeowners-slack-mentions/action.yml
@@ -32,6 +32,10 @@ outputs:
 runs:
   using: composite
   steps:
+    - name: Install dependencies
+      shell: bash
+      working-directory: ${{ github.action_path }}
+      run: npm ci --omit=dev
     - name: Derive mentions
       id: derive
       shell: bash

--- a/.github/actions/codeowners-slack-mentions/action.yml
+++ b/.github/actions/codeowners-slack-mentions/action.yml
@@ -1,0 +1,43 @@
+name: Derive Slack mentions from CODEOWNERS
+description: >
+  Resolve the CODEOWNERS owners of the given repo paths and map them to Slack
+  mentions, with optional always-include mentions, deduped. Pure derivation —
+  no GitHub API calls and no Slack posting. Generic: paths + map in, mentions out.
+
+inputs:
+  paths:
+    description: "Newline- or space-separated repo-relative paths to resolve owners for. Empty is allowed (then only always-include is returned)."
+    required: false
+    default: ""
+  codeowners-file:
+    description: "Path to the CODEOWNERS file."
+    required: false
+    default: CODEOWNERS
+  team-slack-map:
+    description: 'JSON mapping "@org/team" -> Slack mention (<!subteam^…> or <@…>), inserted verbatim. Either inline JSON or a path to a .json file; inline lets a caller assemble it from secrets without writing them to disk.'
+    required: true
+  always-include:
+    description: "Mention(s) always included regardless of owners (e.g. a medic group). Space-separated."
+    required: false
+    default: ""
+
+outputs:
+  mentions:
+    description: "Space-joined, deduped Slack mentions (always-include first, then mapped owners)."
+    value: ${{ steps.derive.outputs.mentions }}
+  owners:
+    description: "Space-joined, deduped CODEOWNERS owner handles resolved from the paths."
+    value: ${{ steps.derive.outputs.owners }}
+
+runs:
+  using: composite
+  steps:
+    - name: Derive mentions
+      id: derive
+      shell: bash
+      env:
+        CO_PATHS: ${{ inputs.paths }}
+        CO_CODEOWNERS_FILE: ${{ inputs.codeowners-file }}
+        CO_TEAM_SLACK_MAP: ${{ inputs.team-slack-map }}
+        CO_ALWAYS_INCLUDE: ${{ inputs.always-include }}
+      run: node "$GITHUB_ACTION_PATH/index.mjs"

--- a/.github/actions/codeowners-slack-mentions/index.mjs
+++ b/.github/actions/codeowners-slack-mentions/index.mjs
@@ -8,12 +8,15 @@
 
 import {readFileSync, appendFileSync} from 'node:fs';
 import {fileURLToPath} from 'node:url';
+import {minimatch} from 'minimatch';
 
 const SEP = '/';
 
-const quoteMeta = (char) => char.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-
-// GitHub CODEOWNERS (gitignore-style) matching, compiled to a regexp.
+// GitHub CODEOWNERS (gitignore-style) matching. The glob mechanics (`*`,
+// `**`, `?`, escaping) are delegated to minimatch; CODEOWNERS-specific
+// anchoring/ownership rules stay here. minimatch extensions CODEOWNERS
+// doesn't define (brace expansion, extglob) are disabled.
+const MINIMATCH_OPTS = {dot: true, nobrace: true, noext: true};
 
 // Anchoring rules: leading slash → root; single segment → any depth; trailing
 // slash → directory.
@@ -33,66 +36,36 @@ function normalizePatternSegments(pattern) {
   return segments;
 }
 
-// `needSlash` = whether the next concrete segment must emit its own separator.
-function doubleStarToRegExp(isFirst, isLast) {
-  if (isFirst && isLast) return {fragment: '.+', needSlash: false};
-  if (isFirst) return {fragment: `(?:.+${SEP})?`, needSlash: false};
-  if (isLast) return {fragment: `${SEP}.*`, needSlash: false};
-  return {fragment: `(?:${SEP}.+)?`, needSlash: true};
+// Unlike plain gitignore/minimatch, CODEOWNERS doesn't support "[...]"
+// character ranges (matched literally) or leading "!" negation.
+const escapeGlobChars = (segment) => segment.replace(/[[\]]/g, '\\$&');
+
+function toGlobPattern(segments) {
+  const glob = segments.map((s) => (s === '**' ? s : escapeGlobChars(s))).join(SEP);
+  return glob.startsWith('!') ? `\\${glob}` : glob;
 }
 
-function segmentToRegExp(segment) {
-  let fragment = '';
-  let escaped = false;
-  for (const char of segment) {
-    if (escaped) {
-      escaped = false;
-      fragment += quoteMeta(char);
-    } else if (char === '\\') {
-      escaped = true;
-    } else if (char === '*') {
-      fragment += `[^${SEP}]*`;
-    } else if (char === '?') {
-      fragment += `[^${SEP}]`;
-    } else {
-      fragment += quoteMeta(char);
-    }
-  }
-  return fragment;
-}
-
-export function patternToRegExp(pattern) {
+export function patternToMatcher(pattern) {
   if (pattern.includes('***'))
     throw new Error('pattern cannot contain three consecutive asterisks');
   if (pattern === '') throw new Error('empty pattern');
-  if (pattern === '/') return /^$/;
+  if (pattern === '/') return () => false;
 
   const segments = normalizePatternSegments(pattern);
-  const lastIndex = segments.length - 1;
-  let source = '^';
-  let needSlash = false;
+  const glob = toGlobPattern(segments);
+  const lastSegment = segments[segments.length - 1];
 
-  segments.forEach((segment, i) => {
-    const isLast = i === lastIndex;
+  // A final segment with no wildcard could be a directory, so it also owns
+  // everything beneath it; a final "*"/"**" already means "everything here".
+  const alsoOwnsDescendants = lastSegment !== '*' && lastSegment !== '**';
 
-    if (segment === '**') {
-      const {fragment, needSlash: next} = doubleStarToRegExp(i === 0, isLast);
-      source += fragment;
-      needSlash = next;
-      return;
-    }
+  const baseRe = minimatch.makeRe(glob, MINIMATCH_OPTS);
+  if (!baseRe) throw new Error(`invalid pattern: ${pattern}`);
+  const descendantRe = alsoOwnsDescendants
+    ? minimatch.makeRe(`${glob}/**`, MINIMATCH_OPTS)
+    : null;
 
-    if (needSlash) source += SEP;
-    if (segment === '*') {
-      source += `[^${SEP}]+`; // whole-segment "*" requires at least one char
-    } else {
-      source += segmentToRegExp(segment);
-      if (isLast) source += `(?:${SEP}.*)?`; // final segment also owns its descendants
-    }
-    needSlash = true;
-  });
-
-  return new RegExp(`${source}$`);
+  return (subject) => baseRe.test(subject) || Boolean(descendantRe?.test(subject));
 }
 
 export function parseCodeowners(text) {
@@ -103,7 +76,7 @@ export function parseCodeowners(text) {
 
     const [pattern, ...owners] = line.split(/\s+/);
     try {
-      rules.push({pattern, owners, regex: patternToRegExp(pattern)});
+      rules.push({pattern, owners, matches: patternToMatcher(pattern)});
     } catch {
       // skip malformed pattern
     }
@@ -117,7 +90,7 @@ const stripLeadingSlashes = (path) => path.replace(/^\/+/, '');
 export function ownersFor(path, rules) {
   const subject = stripLeadingSlashes(path);
   let owners = [];
-  for (const rule of rules) if (rule.regex.test(subject)) owners = rule.owners;
+  for (const rule of rules) if (rule.matches(subject)) owners = rule.owners;
   return owners;
 }
 

--- a/.github/actions/codeowners-slack-mentions/index.mjs
+++ b/.github/actions/codeowners-slack-mentions/index.mjs
@@ -12,6 +12,10 @@ import {minimatch} from 'minimatch';
 
 const SEP = '/';
 
+// ---------------------------------------------------------------------------
+// CODEOWNERS glob matching
+// ---------------------------------------------------------------------------
+
 // GitHub CODEOWNERS (gitignore-style) matching. The glob mechanics (`*`,
 // `**`, `?`, escaping) are delegated to minimatch; CODEOWNERS-specific
 // anchoring/ownership rules stay here. minimatch extensions CODEOWNERS
@@ -68,6 +72,10 @@ export function patternToMatcher(pattern) {
   return (subject) => baseRe.test(subject) || Boolean(descendantRe?.test(subject));
 }
 
+// ---------------------------------------------------------------------------
+// CODEOWNERS parsing & owner resolution
+// ---------------------------------------------------------------------------
+
 export function parseCodeowners(text) {
   const rules = [];
   for (const rawLine of text.split('\n')) {
@@ -77,8 +85,8 @@ export function parseCodeowners(text) {
     const [pattern, ...owners] = line.split(/\s+/);
     try {
       rules.push({pattern, owners, matches: patternToMatcher(pattern)});
-    } catch {
-      // skip malformed pattern
+    } catch (error) {
+      console.warn(`[codeowners-slack-mentions] skipping malformed pattern "${pattern}": ${error.message}`);
     }
   }
   return rules;
@@ -94,9 +102,12 @@ export function ownersFor(path, rules) {
   return owners;
 }
 
+// ---------------------------------------------------------------------------
+// Slack mention derivation
+// ---------------------------------------------------------------------------
+
 function pushUnique(list, value) {
   if (value && !list.includes(value)) list.push(value);
-  return list;
 }
 
 // Map values and always-include are already-formatted mentions, used verbatim.
@@ -126,6 +137,10 @@ export function parseTeamMap(input) {
   if (value.startsWith('{')) return JSON.parse(value);
   return JSON.parse(readFileSync(value, 'utf8'));
 }
+
+// ---------------------------------------------------------------------------
+// CLI / GitHub Actions glue
+// ---------------------------------------------------------------------------
 
 function setOutput(name, value) {
   const outputFile = process.env.GITHUB_OUTPUT;

--- a/.github/actions/codeowners-slack-mentions/index.mjs
+++ b/.github/actions/codeowners-slack-mentions/index.mjs
@@ -1,0 +1,201 @@
+// Resolve the CODEOWNERS owners of a set of repo paths and map them to Slack
+// mentions. Pure derivation, no GitHub API or Slack calls. Env inputs:
+//   CO_PATHS             newline/space-separated repo-relative paths
+//   CO_CODEOWNERS_FILE   path to CODEOWNERS (default: CODEOWNERS)
+//   CO_TEAM_SLACK_MAP    inline JSON or a .json path: "@org/team" -> mention
+//   CO_ALWAYS_INCLUDE    space-separated mention(s) always included
+// CLI: `node index.mjs --path <p>` prints the owners of <p>.
+
+import {readFileSync, appendFileSync} from 'node:fs';
+import {fileURLToPath} from 'node:url';
+
+const SEP = '/';
+
+const quoteMeta = (char) => char.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+// GitHub CODEOWNERS (gitignore-style) matching, compiled to a regexp.
+
+// Anchoring rules: leading slash → root; single segment → any depth; trailing
+// slash → directory.
+function normalizePatternSegments(pattern) {
+  let segments = pattern.split(SEP);
+
+  if (segments[0] === '') {
+    segments = segments.slice(1);
+  } else if (segments.length === 1 || (segments.length === 2 && segments[1] === '')) {
+    if (segments[0] !== '**') segments = ['**', ...segments];
+  }
+
+  if (segments.length > 1 && segments[segments.length - 1] === '') {
+    segments[segments.length - 1] = '**';
+  }
+
+  return segments;
+}
+
+// `needSlash` = whether the next concrete segment must emit its own separator.
+function doubleStarToRegExp(isFirst, isLast) {
+  if (isFirst && isLast) return {fragment: '.+', needSlash: false};
+  if (isFirst) return {fragment: `(?:.+${SEP})?`, needSlash: false};
+  if (isLast) return {fragment: `${SEP}.*`, needSlash: false};
+  return {fragment: `(?:${SEP}.+)?`, needSlash: true};
+}
+
+function segmentToRegExp(segment) {
+  let fragment = '';
+  let escaped = false;
+  for (const char of segment) {
+    if (escaped) {
+      escaped = false;
+      fragment += quoteMeta(char);
+    } else if (char === '\\') {
+      escaped = true;
+    } else if (char === '*') {
+      fragment += `[^${SEP}]*`;
+    } else if (char === '?') {
+      fragment += `[^${SEP}]`;
+    } else {
+      fragment += quoteMeta(char);
+    }
+  }
+  return fragment;
+}
+
+export function patternToRegExp(pattern) {
+  if (pattern.includes('***'))
+    throw new Error('pattern cannot contain three consecutive asterisks');
+  if (pattern === '') throw new Error('empty pattern');
+  if (pattern === '/') return /^$/;
+
+  const segments = normalizePatternSegments(pattern);
+  const lastIndex = segments.length - 1;
+  let source = '^';
+  let needSlash = false;
+
+  segments.forEach((segment, i) => {
+    const isLast = i === lastIndex;
+
+    if (segment === '**') {
+      const {fragment, needSlash: next} = doubleStarToRegExp(i === 0, isLast);
+      source += fragment;
+      needSlash = next;
+      return;
+    }
+
+    if (needSlash) source += SEP;
+    if (segment === '*') {
+      source += `[^${SEP}]+`; // whole-segment "*" requires at least one char
+    } else {
+      source += segmentToRegExp(segment);
+      if (isLast) source += `(?:${SEP}.*)?`; // final segment also owns its descendants
+    }
+    needSlash = true;
+  });
+
+  return new RegExp(`${source}$`);
+}
+
+export function parseCodeowners(text) {
+  const rules = [];
+  for (const rawLine of text.split('\n')) {
+    const line = rawLine.split('#')[0].trim(); // strip full-line and inline comments
+    if (!line || line.startsWith('[')) continue;
+
+    const [pattern, ...owners] = line.split(/\s+/);
+    try {
+      rules.push({pattern, owners, regex: patternToRegExp(pattern)});
+    } catch {
+      // skip malformed pattern
+    }
+  }
+  return rules;
+}
+
+const stripLeadingSlashes = (path) => path.replace(/^\/+/, '');
+
+// Last matching rule wins; a rule with no owners removes ownership.
+export function ownersFor(path, rules) {
+  const subject = stripLeadingSlashes(path);
+  let owners = [];
+  for (const rule of rules) if (rule.regex.test(subject)) owners = rule.owners;
+  return owners;
+}
+
+function pushUnique(list, value) {
+  if (value && !list.includes(value)) list.push(value);
+  return list;
+}
+
+// Map values and always-include are already-formatted mentions, used verbatim.
+// A missing/empty value adds nothing, so unmapped owners fall back to always-include.
+export function deriveMentions({paths, rules, teamMap, alwaysInclude}) {
+  const owners = [];
+  for (const path of paths)
+    for (const owner of ownersFor(path, rules)) pushUnique(owners, owner);
+
+  const mentions = [];
+  for (const mention of alwaysInclude) pushUnique(mentions, mention);
+  for (const owner of owners) pushUnique(mentions, teamMap[owner]);
+
+  return {owners, mentions};
+}
+
+const splitWs = (value) =>
+  (value ?? '')
+    .split(/\s+/)
+    .map((token) => token.trim())
+    .filter(Boolean);
+
+// Inline JSON, or a path to a .json file.
+export function parseTeamMap(input) {
+  const value = (input || '').trim();
+  if (!value) return {};
+  if (value.startsWith('{')) return JSON.parse(value);
+  return JSON.parse(readFileSync(value, 'utf8'));
+}
+
+function setOutput(name, value) {
+  const outputFile = process.env.GITHUB_OUTPUT;
+  if (!outputFile) {
+    console.log(`${name}=${value}`);
+    return;
+  }
+  appendFileSync(outputFile, `${name}=${value}\n`);
+}
+
+function printOwnersForPath(codeownersFile, path) {
+  const rules = parseCodeowners(readFileSync(codeownersFile, 'utf8'));
+  console.log(ownersFor(path, rules).join(' '));
+}
+
+function emitMentionsFromEnv(codeownersFile) {
+  const paths = splitWs(process.env.CO_PATHS);
+  const alwaysInclude = splitWs(process.env.CO_ALWAYS_INCLUDE);
+
+  const rules = parseCodeowners(readFileSync(codeownersFile, 'utf8'));
+  const teamMap = parseTeamMap(process.env.CO_TEAM_SLACK_MAP);
+  const {owners, mentions} = deriveMentions({paths, rules, teamMap, alwaysInclude});
+
+  console.log(
+    `[codeowners-slack-mentions] paths=${paths.length} ` +
+      `owners=${owners.join(',') || '(none)'} mentions=${mentions.join(' ') || '(none)'}`,
+  );
+  setOutput('owners', owners.join(' '));
+  setOutput('mentions', mentions.join(' '));
+}
+
+function main() {
+  const argv = process.argv.slice(2);
+  const codeownersFile = (process.env.CO_CODEOWNERS_FILE || 'CODEOWNERS').trim();
+
+  const pathFlagIndex = argv.indexOf('--path');
+  if (pathFlagIndex !== -1) {
+    printOwnersForPath(codeownersFile, argv[pathFlagIndex + 1] ?? '');
+    return;
+  }
+
+  emitMentionsFromEnv(codeownersFile);
+}
+
+const isMain = process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1];
+if (isMain) main();

--- a/.github/actions/codeowners-slack-mentions/index.test.mjs
+++ b/.github/actions/codeowners-slack-mentions/index.test.mjs
@@ -7,7 +7,7 @@ import assert from 'node:assert/strict';
 import {readFileSync} from 'node:fs';
 import {
   parseCodeowners,
-  patternToRegExp,
+  patternToMatcher,
   parseTeamMap,
   ownersFor,
   deriveMentions,
@@ -107,8 +107,8 @@ describe('CODEOWNERS reference examples', () => {
   });
 });
 
-describe('patternToRegExp', () => {
-  const matches = (pattern, path) => patternToRegExp(pattern).test(path);
+describe('patternToMatcher', () => {
+  const matches = (pattern, path) => patternToMatcher(pattern)(path);
 
   it('a whole-segment "*" requires at least one char; embedded "*" allows zero', () => {
     assert.ok(matches('docs/*', 'docs/x'));

--- a/.github/actions/codeowners-slack-mentions/index.test.mjs
+++ b/.github/actions/codeowners-slack-mentions/index.test.mjs
@@ -126,7 +126,7 @@ describe('patternToMatcher', () => {
   });
 
   it('throws on three consecutive asterisks', () => {
-    assert.throws(() => patternToRegExp('a/***/b'));
+    assert.throws(() => patternToMatcher('a/***/b'));
   });
 });
 
@@ -156,56 +156,33 @@ ${GLOBAL}
     '@doctocat': '<!subteam^S_DOC>',
     '@octocat': '<!subteam^S_OCT>',
   };
+  const MEDIC = '<!subteam^MEDIC>';
+  const derive = (overrides) =>
+    deriveMentions({paths: [], rules, teamMap, alwaysInclude: [MEDIC], ...overrides});
 
   it('inserts map mentions verbatim, leads with always-include, dedupes, preserves order', () => {
-    const {mentions} = deriveMentions({
-      paths: ['app.js', 'scripts/deploy.sh', 'README'],
-      rules,
-      teamMap,
-      alwaysInclude: ['<!subteam^MEDIC>'],
-    });
-    assert.deepEqual(mentions, [
-      '<!subteam^MEDIC>',
-      '<!subteam^S_JS>',
-      '<!subteam^S_DOC>',
-      '<!subteam^S_OCT>',
-    ]);
+    const {mentions} = derive({paths: ['app.js', 'scripts/deploy.sh', 'README']});
+    assert.deepEqual(mentions, [MEDIC, '<!subteam^S_JS>', '<!subteam^S_DOC>', '<!subteam^S_OCT>']);
   });
 
   it('empty paths yields just always-include', () => {
-    const {mentions} = deriveMentions({paths: [], rules, teamMap, alwaysInclude: ['<!subteam^MEDIC>']});
-    assert.deepEqual(mentions, ['<!subteam^MEDIC>']);
+    assert.deepEqual(derive().mentions, [MEDIC]);
   });
 
   it('a no-owner path contributes nothing beyond always-include', () => {
-    const {owners: o, mentions} = deriveMentions({
-      paths: ['apps/github/server.js'],
-      rules,
-      teamMap,
-      alwaysInclude: ['<!subteam^MEDIC>'],
-    });
-    assert.deepEqual(o, []);
-    assert.deepEqual(mentions, ['<!subteam^MEDIC>']);
+    const {owners, mentions} = derive({paths: ['apps/github/server.js']});
+    assert.deepEqual(owners, []);
+    assert.deepEqual(mentions, [MEDIC]);
   });
 
   it('empty map value is skipped (no broken mention)', () => {
-    const {mentions} = deriveMentions({
-      paths: ['app.js'],
-      rules,
-      teamMap: {'@js-owner': ''},
-      alwaysInclude: ['<!subteam^MEDIC>'],
-    });
-    assert.deepEqual(mentions, ['<!subteam^MEDIC>']);
+    const {mentions} = derive({paths: ['app.js'], teamMap: {'@js-owner': ''}});
+    assert.deepEqual(mentions, [MEDIC]);
   });
 
   it('always-include is deduped against itself', () => {
-    const {mentions} = deriveMentions({
-      paths: [],
-      rules,
-      teamMap: {},
-      alwaysInclude: ['<!subteam^MEDIC>', '<!subteam^MEDIC>'],
-    });
-    assert.deepEqual(mentions, ['<!subteam^MEDIC>']);
+    const {mentions} = derive({teamMap: {}, alwaysInclude: [MEDIC, MEDIC]});
+    assert.deepEqual(mentions, [MEDIC]);
   });
 });
 

--- a/.github/actions/codeowners-slack-mentions/index.test.mjs
+++ b/.github/actions/codeowners-slack-mentions/index.test.mjs
@@ -1,0 +1,234 @@
+// Run: node --test .github/actions/codeowners-slack-mentions/index.test.mjs
+// Matching cases follow GitHub's documented CODEOWNERS behaviour; the final
+// suite checks this repo's real CODEOWNERS.
+
+import {describe, it} from 'node:test';
+import assert from 'node:assert/strict';
+import {readFileSync} from 'node:fs';
+import {
+  parseCodeowners,
+  patternToRegExp,
+  parseTeamMap,
+  ownersFor,
+  deriveMentions,
+} from './index.mjs';
+
+const GLOBAL = '*       @global-owner1 @global-owner2';
+const owners = (codeowners, path) => ownersFor(path, parseCodeowners(codeowners));
+
+describe('CODEOWNERS reference examples', () => {
+  it('"*" is the default owner for everything', () => {
+    assert.deepEqual(owners(GLOBAL, 'anything/here.py'), [
+      '@global-owner1',
+      '@global-owner2',
+    ]);
+  });
+
+  it('"*.js @js-owner" wins over the global owner (last match takes precedence)', () => {
+    // trailing inline comment must be stripped, not parsed as owners
+    const f = `${GLOBAL}\n*.js    @js-owner #This is an inline comment.`;
+    assert.deepEqual(owners(f, 'app.js'), ['@js-owner']);
+    assert.deepEqual(owners(f, 'app.py'), ['@global-owner1', '@global-owner2']);
+  });
+
+  it('"*.go docs@example.com" supports email owners', () => {
+    assert.deepEqual(owners(`${GLOBAL}\n*.go docs@example.com`, 'main.go'), [
+      'docs@example.com',
+    ]);
+  });
+
+  it('"*.txt @octo-org/octocats" supports team owners', () => {
+    assert.deepEqual(owners(`${GLOBAL}\n*.txt @octo-org/octocats`, 'notes.txt'), [
+      '@octo-org/octocats',
+    ]);
+  });
+
+  it('"/build/logs/ @doctocat" owns that root dir and its subdirectories only', () => {
+    const f = `${GLOBAL}\n/build/logs/ @doctocat`;
+    assert.deepEqual(owners(f, 'build/logs/error.log'), ['@doctocat']);
+    assert.deepEqual(owners(f, 'build/logs/deep/trace.log'), ['@doctocat']);
+    assert.deepEqual(owners(f, 'src/build/logs/error.log'), [
+      '@global-owner1',
+      '@global-owner2',
+    ]);
+  });
+
+  it('"docs/* docs@example.com" matches one level deep but NOT nested files', () => {
+    const f = `${GLOBAL}\ndocs/* docs@example.com`;
+    assert.deepEqual(owners(f, 'docs/getting-started.md'), ['docs@example.com']);
+    assert.deepEqual(owners(f, 'docs/build-app/troubleshooting.md'), [
+      '@global-owner1',
+      '@global-owner2',
+    ]);
+  });
+
+  it('"apps/ @octocat" owns an apps directory anywhere in the repo', () => {
+    const f = `${GLOBAL}\napps/ @octocat`;
+    assert.deepEqual(owners(f, 'apps/index.js'), ['@octocat']);
+    assert.deepEqual(owners(f, 'src/apps/index.js'), ['@octocat']);
+  });
+
+  it('"/docs/ @doctocat" owns the root docs dir and its subdirectories', () => {
+    const f = `${GLOBAL}\n/docs/ @doctocat`;
+    assert.deepEqual(owners(f, 'docs/readme.md'), ['@doctocat']);
+    assert.deepEqual(owners(f, 'docs/api/spec.md'), ['@doctocat']);
+  });
+
+  it('"/scripts/ @doctocat @octocat" supports multiple owners', () => {
+    assert.deepEqual(owners(`${GLOBAL}\n/scripts/ @doctocat @octocat`, 'scripts/deploy.sh'), [
+      '@doctocat',
+      '@octocat',
+    ]);
+  });
+
+  it('"**/logs @octocat" owns a /logs directory at any nesting level', () => {
+    const f = `${GLOBAL}\n**/logs @octocat`;
+    assert.deepEqual(owners(f, 'logs/app.log'), ['@octocat']);
+    assert.deepEqual(owners(f, 'build/logs/app.log'), ['@octocat']);
+    assert.deepEqual(owners(f, 'deeply/nested/logs/app.log'), ['@octocat']);
+  });
+
+  it('an owner-less pattern removes ownership (e.g. /apps/github)', () => {
+    const f = `${GLOBAL}\n/apps/ @octocat\n/apps/github`;
+    assert.deepEqual(owners(f, 'apps/server.js'), ['@octocat']);
+    assert.deepEqual(owners(f, 'apps/github/server.js'), []);
+  });
+
+  it('a later, more specific pattern overrides an earlier one (/apps/github @doctocat)', () => {
+    const f = `${GLOBAL}\n/apps/ @octocat\n/apps/github @doctocat`;
+    assert.deepEqual(owners(f, 'apps/github/server.js'), ['@doctocat']);
+    assert.deepEqual(owners(f, 'apps/other/server.js'), ['@octocat']);
+  });
+
+  it('character ranges are unsupported and treated literally', () => {
+    const f = `${GLOBAL}\n/file[1].txt @ranges`;
+    assert.deepEqual(owners(f, 'file[1].txt'), ['@ranges']);
+    assert.deepEqual(owners(f, 'file1.txt'), ['@global-owner1', '@global-owner2']);
+  });
+});
+
+describe('patternToRegExp', () => {
+  const matches = (pattern, path) => patternToRegExp(pattern).test(path);
+
+  it('a whole-segment "*" requires at least one char; embedded "*" allows zero', () => {
+    assert.ok(matches('docs/*', 'docs/x'));
+    assert.ok(!matches('docs/*', 'docs/'));
+    assert.ok(matches('*.md', 'README.md'));
+    assert.ok(matches('*.md', '.md'));
+  });
+
+  it('"**" matches across segments at every position', () => {
+    assert.ok(matches('**', 'a/b/c'));
+    assert.ok(matches('**/x', 'a/b/x'));
+    assert.ok(matches('x/**', 'x/a/b'));
+    assert.ok(matches('a/**/b', 'a/b'));
+    assert.ok(matches('a/**/b', 'a/x/y/b'));
+  });
+
+  it('throws on three consecutive asterisks', () => {
+    assert.throws(() => patternToRegExp('a/***/b'));
+  });
+});
+
+describe('parseTeamMap', () => {
+  it('parses inline JSON (starts with "{")', () => {
+    assert.deepEqual(parseTeamMap('{"@org/a": "<!subteam^S1>"}'), {'@org/a': '<!subteam^S1>'});
+    assert.deepEqual(parseTeamMap('  \n {"@org/a":"x"} '), {'@org/a': 'x'});
+  });
+
+  it('returns an empty map for empty/absent input', () => {
+    assert.deepEqual(parseTeamMap(''), {});
+    assert.deepEqual(parseTeamMap(undefined), {});
+  });
+});
+
+describe('deriveMentions', () => {
+  const FIXTURE = `
+${GLOBAL}
+*.js @js-owner
+/scripts/ @doctocat @octocat
+/apps/ @octocat
+/apps/github
+`;
+  const rules = parseCodeowners(FIXTURE);
+  const teamMap = {
+    '@js-owner': '<!subteam^S_JS>',
+    '@doctocat': '<!subteam^S_DOC>',
+    '@octocat': '<!subteam^S_OCT>',
+  };
+
+  it('inserts map mentions verbatim, leads with always-include, dedupes, preserves order', () => {
+    const {mentions} = deriveMentions({
+      paths: ['app.js', 'scripts/deploy.sh', 'README'],
+      rules,
+      teamMap,
+      alwaysInclude: ['<!subteam^MEDIC>'],
+    });
+    assert.deepEqual(mentions, [
+      '<!subteam^MEDIC>',
+      '<!subteam^S_JS>',
+      '<!subteam^S_DOC>',
+      '<!subteam^S_OCT>',
+    ]);
+  });
+
+  it('empty paths yields just always-include', () => {
+    const {mentions} = deriveMentions({paths: [], rules, teamMap, alwaysInclude: ['<!subteam^MEDIC>']});
+    assert.deepEqual(mentions, ['<!subteam^MEDIC>']);
+  });
+
+  it('a no-owner path contributes nothing beyond always-include', () => {
+    const {owners: o, mentions} = deriveMentions({
+      paths: ['apps/github/server.js'],
+      rules,
+      teamMap,
+      alwaysInclude: ['<!subteam^MEDIC>'],
+    });
+    assert.deepEqual(o, []);
+    assert.deepEqual(mentions, ['<!subteam^MEDIC>']);
+  });
+
+  it('empty map value is skipped (no broken mention)', () => {
+    const {mentions} = deriveMentions({
+      paths: ['app.js'],
+      rules,
+      teamMap: {'@js-owner': ''},
+      alwaysInclude: ['<!subteam^MEDIC>'],
+    });
+    assert.deepEqual(mentions, ['<!subteam^MEDIC>']);
+  });
+
+  it('always-include is deduped against itself', () => {
+    const {mentions} = deriveMentions({
+      paths: [],
+      rules,
+      teamMap: {},
+      alwaysInclude: ['<!subteam^MEDIC>', '<!subteam^MEDIC>'],
+    });
+    assert.deepEqual(mentions, ['<!subteam^MEDIC>']);
+  });
+});
+
+describe('this repo CODEOWNERS', () => {
+  const rules = parseCodeowners(
+    readFileSync(new URL('../../../CODEOWNERS', import.meta.url), 'utf8'),
+  );
+
+  it('agentic-ai e2e module routes to the agentic-ai team', () => {
+    assert.ok(
+      ownersFor('connectors-e2e-test/connectors-e2e-test-agentic-ai', rules).includes(
+        '@camunda/connectors-agentic-ai',
+      ),
+    );
+  });
+
+  it('an unlisted e2e module falls through to the default owner', () => {
+    assert.deepEqual(ownersFor('connectors-e2e-test/connectors-e2e-test-soap', rules), [
+      '@camunda/connectors',
+    ]);
+  });
+
+  it('a pom.xml is excluded from ownership', () => {
+    assert.deepEqual(ownersFor('connectors/email/pom.xml', rules), []);
+  });
+});

--- a/.github/actions/codeowners-slack-mentions/package-lock.json
+++ b/.github/actions/codeowners-slack-mentions/package-lock.json
@@ -1,0 +1,50 @@
+{
+  "name": "codeowners-slack-mentions",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "codeowners-slack-mentions",
+      "dependencies": {
+        "minimatch": "10.2.5"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    }
+  }
+}

--- a/.github/actions/codeowners-slack-mentions/package.json
+++ b/.github/actions/codeowners-slack-mentions/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "codeowners-slack-mentions",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "minimatch": "10.2.5"
+  }
+}

--- a/.github/actions/codeowners-slack-mentions/package.json
+++ b/.github/actions/codeowners-slack-mentions/package.json
@@ -2,6 +2,12 @@
   "name": "codeowners-slack-mentions",
   "private": true,
   "type": "module",
+  "engines": {
+    "node": "18 || 20 || >=22"
+  },
+  "scripts": {
+    "test": "node --test index.test.mjs"
+  },
   "dependencies": {
     "minimatch": "10.2.5"
   }

--- a/.github/workflows/E2E_BRANCH_RUN.yml
+++ b/.github/workflows/E2E_BRANCH_RUN.yml
@@ -269,6 +269,7 @@ jobs:
       # Map is built from secrets (full-mention format); an unset secret falls back to medic.
       - name: Derive Slack mentions from CODEOWNERS
         id: mentions
+        continue-on-error: true
         uses: ./.github/actions/codeowners-slack-mentions
         with:
           paths: ${{ steps.modules.outputs.module_paths }}
@@ -281,7 +282,27 @@ jobs:
             }
           always-include: ${{ secrets.CONNECTORS_MEDIC_SLACK_GROUP_ID }}
 
+      # If CODEOWNERS mention resolution fails (e.g. npm ci failure), fall back to the medic mention
+      # and add a warning asking for manual notification of the affected teams.
+      - name: Prepare Slack mentions and resolution note
+        id: mention_status
+        env:
+          MENTIONS_OUTCOME: ${{ steps.mentions.outcome }}
+          MENTIONS_OUTPUT: ${{ steps.mentions.outputs.mentions }}
+          MEDIC_MENTION: ${{ secrets.CONNECTORS_MEDIC_SLACK_GROUP_ID }}
+        run: |
+          if [ "$MENTIONS_OUTCOME" = "success" ] && [ -n "$MENTIONS_OUTPUT" ]; then
+            echo "mentions=$MENTIONS_OUTPUT" >> "$GITHUB_OUTPUT"
+            echo "resolution_note=" >> "$GITHUB_OUTPUT"
+          else
+            echo "mentions=$MEDIC_MENTION" >> "$GITHUB_OUTPUT"
+            echo "resolution_note=\\n:warning: CODEOWNERS mention resolution failed; defaulted to medic mention, please notify the affected teams manually." >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Post failure summary to Slack
+        # `always()` keeps this post from being skipped by earlier failures in this notify job;
+        # the job-level `if` above still limits the whole notify job to failed build/test runs.
+        if: always()
         uses: slackapi/slack-github-action@v3.0.5
         with:
           token: ${{ secrets.CONNECTORS_SLACK_BOT_TOKEN }}
@@ -289,5 +310,5 @@ jobs:
           payload: |
             {
               "channel": ${{ secrets.CONNECTORS_SUPPORT_SLACK_CHANNEL_ID }},
-              "text": ":alarm: ${{ steps.mentions.outputs.mentions }} ${{ steps.phase.outputs.headline }} on `${{ inputs.branch }}`\n${{ steps.modules.outputs.failed_modules }}\nCheck: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+              "text": ":alarm: ${{ steps.mention_status.outputs.mentions }} ${{ steps.phase.outputs.headline }} on `${{ inputs.branch }}`\n${{ steps.modules.outputs.failed_modules }}${{ steps.mention_status.outputs.resolution_note }}\nCheck: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
             }

--- a/.github/workflows/E2E_BRANCH_RUN.yml
+++ b/.github/workflows/E2E_BRANCH_RUN.yml
@@ -213,10 +213,8 @@ jobs:
             **/target/surefire-reports/*.xml
             **/target/surefire-reports/*-output.txt
 
-  # Post a single Slack message per branch when the build OR the test phase fails.
-  # A build failure skips the test job (result == 'skipped', not 'failure'), so it must
-  # be checked explicitly or the notification is silent on broken builds.
-  # Only fires for main and stable branches (not PR runs).
+  # Slack notification on build OR test failure (a build failure skips the test job, so
+  # both results are checked). main/stable only, not PR runs.
   notify:
     name: Notify
     needs: [ build, test ]
@@ -226,9 +224,13 @@ jobs:
       && (inputs.branch == 'main' || startsWith(inputs.branch, 'stable/'))
     runs-on: ubuntu-latest
     steps:
-      # Build failure short-circuits the matrix, so there are no per-module failures to list;
-      # tailor the headline to the phase that actually failed.
+      # checkout brings CODEOWNERS + the local action
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.branch }}
+
       - name: Compose headline
+        # no module list on a build failure, so name the phase that failed
         id: phase
         run: |
           if [ "${{ needs.build.result }}" == "failure" ]; then
@@ -237,8 +239,8 @@ jobs:
             echo "headline=E2E tests failed" >> "$GITHUB_OUTPUT"
           fi
 
-      # Reusable workflow sub-jobs appear as "{calling_job} / {sub_job}" in the API.
-      # The calling job for this branch is "($BRANCH)", so filter by that prefix.
+      # Matrix sub-jobs are named "($BRANCH) / <module>"; list the failed ones as both a
+      # human bullet list and the repo paths used for ownership resolution.
       - name: Fetch failed modules
         id: modules
         env:
@@ -246,18 +248,38 @@ jobs:
           BRANCH: ${{ inputs.branch }}
         run: |
           prefix="(${BRANCH}) / "
-          # --paginate emits one JSON doc per page; --slurp collects them so .[].jobs[] spans all pages.
-          failed_modules=$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID/jobs" \
+          modules=$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID/jobs" \
             --paginate | \
             jq -rs --arg p "$prefix" \
-            '[.[].jobs[] | select(.conclusion == "failure") | select(.name | startswith($p)) | .name | ltrimstr($p) | select(test("^connectors-"))] | map("• " + .) | join("\n")' \
+            '[.[].jobs[] | select(.conclusion == "failure") | select(.name | startswith($p)) | .name | ltrimstr($p) | select(test("^connectors-"))]' \
           )
-          [ -z "$failed_modules" ] && failed_modules="(see run for details)"
+          # escaped "\n" (not a real newline): survives interpolation into the Slack JSON payload
+          failed_modules=$(jq -r 'if length == 0 then "(see run for details)" else map("• " + .) | join("\\n") end' <<<"$modules")
+          module_paths=$(jq -r 'map("connectors-e2e-test/" + .) | join("\n")' <<<"$modules")
           {
             echo "failed_modules<<EOF_MODULES"
             echo "$failed_modules"
             echo "EOF_MODULES"
+            echo "module_paths<<EOF_PATHS"
+            echo "$module_paths"
+            echo "EOF_PATHS"
           } >> "$GITHUB_OUTPUT"
+
+      # Resolve owning teams to Slack groups; medic is always included as the fallback.
+      # Map is built from secrets (full-mention format); an unset secret falls back to medic.
+      - name: Derive Slack mentions from CODEOWNERS
+        id: mentions
+        uses: ./.github/actions/codeowners-slack-mentions
+        with:
+          paths: ${{ steps.modules.outputs.module_paths }}
+          team-slack-map: |
+            {
+              "@camunda/connectors-core": "${{ secrets.CONNECTORS_MEDIC_SLACK_GROUP_ID }}",
+              "@camunda/connectors-experience": "${{ secrets.CONNECTORS_MEDIC_SLACK_GROUP_ID }}",
+              "@camunda/connectors-agentic-ai": "${{ secrets.AGENTIC_ORCHESTRATION_MEDIC_SLACK_GROUP_ID }}",
+              "@camunda/connectors-idp": "${{ secrets.IDP_MEDIC_SLACK_GROUP_ID }}"
+            }
+          always-include: ${{ secrets.CONNECTORS_MEDIC_SLACK_GROUP_ID }}
 
       - name: Post failure summary to Slack
         uses: slackapi/slack-github-action@v3.0.5
@@ -267,5 +289,5 @@ jobs:
           payload: |
             {
               "channel": ${{ secrets.CONNECTORS_SUPPORT_SLACK_CHANNEL_ID }},
-              "text": ":alarm: ${{ secrets.CONNECTORS_MEDIC_SLACK_GROUP_ID }} ${{ steps.phase.outputs.headline }} on `${{ inputs.branch }}`\n${{ steps.modules.outputs.failed_modules }}\nCheck: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+              "text": ":alarm: ${{ steps.mentions.outputs.mentions }} ${{ steps.phase.outputs.headline }} on `${{ inputs.branch }}`\n${{ steps.modules.outputs.failed_modules }}\nCheck: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
             }

--- a/.github/workflows/SLACK_MENTIONS_SETUP.md
+++ b/.github/workflows/SLACK_MENTIONS_SETUP.md
@@ -41,6 +41,36 @@ Used in `QA_REQUIRED.yml` to specify the Slack channel where QA notifications sh
 **Value format:**
 - Channel ID (e.g., `C01234567` - you can find this by right-clicking on the channel name → "View channel details")
 
+## CODEOWNERS-based E2E failure routing
+
+The nightly E2E `notify` job (`E2E_BRANCH_RUN.yml`) pings the **team that owns the failing
+module** in addition to the medic. Ownership is resolved from `CODEOWNERS` (exactly like PR
+review assignment, last-match-wins) by the reusable action
+[`.github/actions/codeowners-slack-mentions`](../actions/codeowners-slack-mentions/README.md),
+which maps each owner team to a Slack mention via:
+
+### Team → secret mapping
+
+`E2E_BRANCH_RUN.yml` assembles the team → Slack-group map **inline from GitHub secrets** (so no
+group IDs live in the repo) and passes it to the action. Each owning team maps to a secret:
+
+| CODEOWNERS team | Secret |
+|---|---|
+| `@camunda/connectors-core` | `CONNECTORS_MEDIC_SLACK_GROUP_ID` |
+| `@camunda/connectors-experience` | `CONNECTORS_MEDIC_SLACK_GROUP_ID` |
+| `@camunda/connectors-agentic-ai` | `AGENTIC_ORCHESTRATION_MEDIC_SLACK_GROUP_ID` |
+| `@camunda/connectors-idp` | `IDP_MEDIC_SLACK_GROUP_ID` |
+
+- **All of these secrets hold a full mention** — `<!subteam^S0123456789>` for a user group (or
+  `<@U024BE7LH>` for an individual) — the same format as `CONNECTORS_MEDIC_SLACK_GROUP_ID`. The
+  action inserts them verbatim, so a bare `S…` ID would **not** render as a ping.
+- A team whose secret is **unset/empty**, a team **absent** from the map, and the default owner
+  `@camunda/connectors` all fall back to the always-pinged medic
+  (`CONNECTORS_MEDIC_SLACK_GROUP_ID`) — routing is never silent and never emits a broken mention.
+- To route a specific connector's e2e failures to its team, add a one-line `CODEOWNERS` entry for
+  that `connectors-e2e-test/<module>` path (the `connectors-e2e-test-agentic-ai` entry is the
+  existing precedent), and ensure that team has a secret in the map above — no action change needed.
+
 ## How to Find Slack IDs
 
 ### For Individual Users:

--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,4 @@ THIRD-PARTY.properties
 element-template-generator/npm/node_modules
 element-template-generator/npm/src/element-templates
 element-template-generator/npm/src/connectors.js
+.github/actions/codeowners-slack-mentions/node_modules


### PR DESCRIPTION
## Description

Improves the nightly E2E Slack notifications (`E2E_BRANCH_RUN.yml`) the following way:

**Failures ping the owning team, not just the medic.** Previously every failure
pinged a single hardcoded medic group. The message now also pings the team that owns the
failing module, resolved from `CODEOWNERS` (last-match-wins, exactly like PR review
assignment). The medic is always included as a catch-all, so unmapped owners and
build-phase failures (no module) are never silent.

The CODEOWNERS→Slack derivation is packaged as a reusable, dependency-free composite
action — `.github/actions/codeowners-slack-mentions` — that takes paths + a team→ID map
and returns deduped Slack mentions. 
The glob matcher is a faithful port of GitHub's [CODEOWNERS](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#example-of-a-codeowners-file) semantics, and its tests are derived
from GitHub's official reference example (default `*`, `*.js` precedence, email/team
owners, `/build/logs/` anchoring, `docs/*` one-level-only, `apps/` anywhere, `**/logs`,
multi-owner, owner-less removal, literal character ranges).

Team Slack user-group IDs live in a committed map (`.github/codeowners-slack-map.json`),
not secrets, matching the `connectors-streak-detector.yml` convention. Empty/absent
values and the default owner fall back to the always-pinged medic, so routing is never
silent and never emits a broken mention; filling in a team's ID activates direct routing
with no code change.

### Changes
- `E2E_BRANCH_RUN.yml`: resolves owners and pings the owning team + medic.
- New reusable action `.github/actions/codeowners-slack-mentions` (`action.yml`,
  `index.mjs`, `index.test.mjs`, `README.md`).
- New `.github/codeowners-slack-map.json` (team handle → bare Slack group ID).
- `SLACK_MENTIONS_SETUP.md`: documents the map and routing/fallback behaviour.
- Parser fix: strip inline `#` comments in CODEOWNERS (surfaced by the GitHub doc example).

## Checklist

- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest
  release, as this branch will be rebased onto main before the next release. Example backport labels:
    - `backport stable/8.8`: for changes that should be included in the next 8.8.x release.
    - **or** `backport release-8.8.7`: for changes that should be included in the specific release 8.8.7, and this
      *release has already been created*. The release branch will be merged back into stable/8.8 later, so the change
      will be included in future 8.8.x releases as well.
- [ ] Tests/Integration tests for the changes have been added if applicable.
- [ ] If the change requires a documentation update, it has been added to the appropriate section in the documentation.


