### PR TITLE
fix(openapi-parser): resolve $ref parameters from components

### DIFF
--- a/element-template-generator/openapi-parser/src/main/java/io/camunda/connector/generator/openapi/util/ParameterUtil.java
+++ b/element-template-generator/openapi-parser/src/main/java/io/camunda/connector/generator/openapi/util/ParameterUtil.java
@@ -38,39 +38,7 @@ public class ParameterUtil {
   public static HttpOperationProperty transformToProperty(
       Parameter parameter, Components components) {
     if (parameter.get$ref() != null) {
-      var ref = parameter.get$ref();
-      if (!ref.startsWith("#/")) {
-        throw new IllegalArgumentException(
-            "External $ref '"
-                + ref
-                + "' cannot be resolved: the spec contains a reference to an external file or URL "
-                + "that was not inlined during parsing. Either remove '--no-resolve-refs' so the "
-                + "parser can follow the reference, or replace the external $ref with an inline "
-                + "parameter definition.");
-      }
-      var prefix = "#/components/parameters/";
-      if (!ref.startsWith(prefix)) {
-        throw new IllegalArgumentException(
-            "Parameter $ref '"
-                + ref
-                + "' cannot be resolved: only '#/components/parameters/...' references are supported.");
-      }
-      var paramName = ref.substring(prefix.length());
-      if (components == null || components.getParameters() == null) {
-        throw new IllegalArgumentException(
-            "Parameter $ref '"
-                + ref
-                + "' cannot be resolved: the spec has no components.parameters section.");
-      }
-      if (!components.getParameters().containsKey(paramName)) {
-        throw new IllegalArgumentException(
-            "Parameter $ref '"
-                + ref
-                + "' cannot be resolved: '"
-                + paramName
-                + "' is not defined in components.parameters.");
-      }
-      parameter = components.getParameters().get(paramName);
+      parameter = resolveParameterRef(parameter.get$ref(), components);
     }
     if (parameter.getSchema() != null) {
       return fromSchema(parameter, components);
@@ -79,6 +47,42 @@ public class ParameterUtil {
     } else {
       throw new IllegalArgumentException("Parameter must have either a schema or a content");
     }
+  }
+
+  private static Parameter resolveParameterRef(String ref, Components components) {
+    if (!ref.startsWith("#/")) {
+      throw new IllegalArgumentException(
+          "External $ref '"
+              + ref
+              + "' cannot be resolved: the spec contains a reference to an external file or URL "
+              + "that was not inlined during parsing. Either remove '--no-resolve-refs' so the "
+              + "parser can follow the reference, or replace the external $ref with an inline "
+              + "parameter definition.");
+    }
+    var prefix = "#/components/parameters/";
+    if (!ref.startsWith(prefix)) {
+      throw new IllegalArgumentException(
+          "Parameter $ref '"
+              + ref
+              + "' cannot be resolved: only '#/components/parameters/...' references are supported.");
+    }
+    var paramName = ref.substring(prefix.length());
+    if (components == null || components.getParameters() == null) {
+      throw new IllegalArgumentException(
+          "Parameter $ref '"
+              + ref
+              + "' cannot be resolved: the spec has no components.parameters section.");
+    }
+    var resolved = components.getParameters().get(paramName);
+    if (resolved == null) {
+      throw new IllegalArgumentException(
+          "Parameter $ref '"
+              + ref
+              + "' cannot be resolved: '"
+              + paramName
+              + "' is not defined in components.parameters.");
+    }
+    return resolved;
   }
 
   private static HttpOperationProperty fromSchema(Parameter parameter, Components components) {

--- a/element-template-generator/openapi-parser/src/main/java/io/camunda/connector/generator/openapi/util/ParameterUtil.java
+++ b/element-template-generator/openapi-parser/src/main/java/io/camunda/connector/generator/openapi/util/ParameterUtil.java
@@ -48,7 +48,18 @@ public class ParameterUtil {
                 + "parser can follow the reference, or replace the external $ref with an inline "
                 + "parameter definition.");
       }
-      parameter = components.getParameters().get(ref.replace("#/components/parameters/", ""));
+      var paramName = ref.replace("#/components/parameters/", "");
+      if (components == null
+          || components.getParameters() == null
+          || !components.getParameters().containsKey(paramName)) {
+        throw new IllegalArgumentException(
+            "Parameter $ref '"
+                + ref
+                + "' cannot be resolved: '"
+                + paramName
+                + "' is not defined in components.parameters.");
+      }
+      parameter = components.getParameters().get(paramName);
     }
     if (parameter.getSchema() != null) {
       return fromSchema(parameter, components);

--- a/element-template-generator/openapi-parser/src/main/java/io/camunda/connector/generator/openapi/util/ParameterUtil.java
+++ b/element-template-generator/openapi-parser/src/main/java/io/camunda/connector/generator/openapi/util/ParameterUtil.java
@@ -48,10 +48,21 @@ public class ParameterUtil {
                 + "parser can follow the reference, or replace the external $ref with an inline "
                 + "parameter definition.");
       }
-      var paramName = ref.replace("#/components/parameters/", "");
-      if (components == null
-          || components.getParameters() == null
-          || !components.getParameters().containsKey(paramName)) {
+      var prefix = "#/components/parameters/";
+      if (!ref.startsWith(prefix)) {
+        throw new IllegalArgumentException(
+            "Parameter $ref '"
+                + ref
+                + "' cannot be resolved: only '#/components/parameters/...' references are supported.");
+      }
+      var paramName = ref.substring(prefix.length());
+      if (components == null || components.getParameters() == null) {
+        throw new IllegalArgumentException(
+            "Parameter $ref '"
+                + ref
+                + "' cannot be resolved: the spec has no components.parameters section.");
+      }
+      if (!components.getParameters().containsKey(paramName)) {
         throw new IllegalArgumentException(
             "Parameter $ref '"
                 + ref

--- a/element-template-generator/openapi-parser/src/main/java/io/camunda/connector/generator/openapi/util/ParameterUtil.java
+++ b/element-template-generator/openapi-parser/src/main/java/io/camunda/connector/generator/openapi/util/ParameterUtil.java
@@ -37,6 +37,19 @@ public class ParameterUtil {
 
   public static HttpOperationProperty transformToProperty(
       Parameter parameter, Components components) {
+    if (parameter.get$ref() != null) {
+      var ref = parameter.get$ref();
+      if (!ref.startsWith("#/")) {
+        throw new IllegalArgumentException(
+            "External $ref '"
+                + ref
+                + "' cannot be resolved: the spec contains a reference to an external file or URL "
+                + "that was not inlined during parsing. Either remove '--no-resolve-refs' so the "
+                + "parser can follow the reference, or replace the external $ref with an inline "
+                + "parameter definition.");
+      }
+      parameter = components.getParameters().get(ref.replace("#/components/parameters/", ""));
+    }
     if (parameter.getSchema() != null) {
       return fromSchema(parameter, components);
     } else if (parameter.getContent() != null) {

--- a/element-template-generator/openapi-parser/src/test/java/io/camunda/connector/generator/openapi/OperationUtilTest.java
+++ b/element-template-generator/openapi-parser/src/test/java/io/camunda/connector/generator/openapi/OperationUtilTest.java
@@ -148,4 +148,46 @@ public class OperationUtilTest {
         .as("healthCheck has no external $ref and must still be supported")
         .isTrue();
   }
+
+  @Test
+  void extractOperations_specWithInternalParamRef_noResolve_operationIsSupported() {
+    var spec =
+        """
+        openapi: 3.0.3
+        info:
+          title: Test API
+          version: 1.0.0
+        servers:
+          - url: https://api.example.com/v1
+        components:
+          parameters:
+            myParam:
+              name: myParam
+              in: query
+              schema:
+                type: string
+        paths:
+          /items:
+            get:
+              operationId: listItems
+              parameters:
+                - $ref: '#/components/parameters/myParam'
+              responses:
+                '200':
+                  description: OK
+        """;
+
+    var source = new OpenApiGenerationSource(List.of(spec, "--no-resolve-refs"));
+
+    var results =
+        OperationUtil.extractOperations(
+            source.openAPI(), source.includeOperations(), source.options());
+
+    assertThat(results).hasSize(1);
+    var listItems = results.getFirst();
+    assertThat(listItems.supported())
+        .as("listItems uses an internal $ref param and must be supported")
+        .isTrue();
+    assertThat(listItems.builder().getProperties()).anyMatch(p -> "myParam".equals(p.id()));
+  }
 }

--- a/element-template-generator/openapi-parser/src/test/java/io/camunda/connector/generator/openapi/ParameterUtilTest.java
+++ b/element-template-generator/openapi-parser/src/test/java/io/camunda/connector/generator/openapi/ParameterUtilTest.java
@@ -19,6 +19,7 @@ package io.camunda.connector.generator.openapi;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import io.camunda.connector.generator.dsl.http.HttpOperationProperty.Target;
 import io.camunda.connector.generator.openapi.util.ParameterUtil;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.media.Schema;
@@ -182,6 +183,44 @@ public class ParameterUtilTest {
 
       // then
       assertThat(resolved).isSameAs(schema);
+    }
+
+    @Test
+    void transformToProperty_internalParameterRef_resolvesAndTransforms() {
+      // given – parameter with only $ref set, pointing to components
+      var schema = new Schema<>().type("string");
+      var referencedParam = new Parameter();
+      referencedParam.setName("myParam");
+      referencedParam.setIn("query");
+      referencedParam.setSchema(schema);
+
+      var stub = new Parameter();
+      stub.set$ref("#/components/parameters/myParam");
+
+      var components = new Components();
+      components.setParameters(Map.of("myParam", referencedParam));
+
+      // when
+      var property = ParameterUtil.transformToProperty(stub, components);
+
+      // then
+      assertThat(property.id()).isEqualTo("myParam");
+      assertThat(property.target()).isEqualTo(Target.QUERY);
+    }
+
+    @Test
+    void transformToProperty_externalParameterRef_throwsWithMessage() {
+      // given – parameter with an unresolved external $ref
+      var stub = new Parameter();
+      stub.set$ref("./external.yaml#/components/parameters/myParam");
+
+      var components = new Components();
+
+      // when / then
+      assertThatThrownBy(() -> ParameterUtil.transformToProperty(stub, components))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("./external.yaml#/components/parameters/myParam")
+          .hasMessageContaining("External $ref");
     }
   }
 }

--- a/element-template-generator/openapi-parser/src/test/java/io/camunda/connector/generator/openapi/ParameterUtilTest.java
+++ b/element-template-generator/openapi-parser/src/test/java/io/camunda/connector/generator/openapi/ParameterUtilTest.java
@@ -209,6 +209,22 @@ public class ParameterUtilTest {
     }
 
     @Test
+    void transformToProperty_internalParameterRef_missingKey_throwsWithMessage() {
+      // given – $ref points to a key that does not exist in components
+      var stub = new Parameter();
+      stub.set$ref("#/components/parameters/missingParam");
+
+      var components = new Components();
+      components.setParameters(Map.of("otherParam", new Parameter()));
+
+      // when / then
+      assertThatThrownBy(() -> ParameterUtil.transformToProperty(stub, components))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("missingParam")
+          .hasMessageContaining("components.parameters");
+    }
+
+    @Test
     void transformToProperty_externalParameterRef_throwsWithMessage() {
       // given – parameter with an unresolved external $ref
       var stub = new Parameter();

--- a/element-template-generator/openapi-parser/src/test/java/io/camunda/connector/generator/openapi/ParameterUtilTest.java
+++ b/element-template-generator/openapi-parser/src/test/java/io/camunda/connector/generator/openapi/ParameterUtilTest.java
@@ -209,7 +209,7 @@ public class ParameterUtilTest {
     }
 
     @Test
-    void transformToProperty_internalParameterRef_missingKey_throwsWithMessage() {
+    void transformToProperty_internalParameterRef_missingKey_throwsDistinctMessage() {
       // given – $ref points to a key that does not exist in components
       var stub = new Parameter();
       stub.set$ref("#/components/parameters/missingParam");
@@ -221,7 +221,36 @@ public class ParameterUtilTest {
       assertThatThrownBy(() -> ParameterUtil.transformToProperty(stub, components))
           .isInstanceOf(IllegalArgumentException.class)
           .hasMessageContaining("missingParam")
-          .hasMessageContaining("components.parameters");
+          .hasMessageContaining("is not defined in components.parameters");
+    }
+
+    @Test
+    void transformToProperty_internalParameterRef_noParametersSection_throwsDistinctMessage() {
+      // given – components exists but has no parameters map
+      var stub = new Parameter();
+      stub.set$ref("#/components/parameters/myParam");
+
+      var components = new Components();
+
+      // when / then
+      assertThatThrownBy(() -> ParameterUtil.transformToProperty(stub, components))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("no components.parameters section");
+    }
+
+    @Test
+    void transformToProperty_internalRefOutsideParameters_throwsWithMessage() {
+      // given – internal ref that points to a schema, not a parameter
+      var stub = new Parameter();
+      stub.set$ref("#/components/schemas/MySchema");
+
+      var components = new Components();
+
+      // when / then
+      assertThatThrownBy(() -> ParameterUtil.transformToProperty(stub, components))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("#/components/schemas/MySchema")
+          .hasMessageContaining("only '#/components/parameters/...' references are supported");
     }
 
     @Test


### PR DESCRIPTION
Operations using `$ref` parameters (e.g., `- $ref: '#/components/parameters/myParam'`) would fail when `--no-resolve-refs` was active. `ParameterUtil.transformToProperty()` only handled parameters with an inline `schema` or `content`, so a stub parameter carrying only `$ref` fell through to the error "Parameter must have either a schema or a content", causing the entire operation to be marked unsupported.

The fix resolves internal `#/components/parameters/` refs from `components.getParameters()` before the schema/content check, following the same pattern already used for `RequestBody` in `BodyUtil` and `PathItem` in `OperationUtil`. External `$ref` parameters (pointing to files or URLs) throw with the standard "External $ref" message so the operation is reported as unsupported with a clear reason rather than a misleading one.

Closes #7729.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Sonnet_4.6](https://img.shields.io/badge/Sonnet_4.6-D97757?logo=claude&logoColor=white)