### PR TITLE
chore(agentic-ai): drop local NullAway/ErrorProne javac exports workaround

### DIFF
--- a/connectors/agentic-ai/connector-agentic-ai/pom.xml
+++ b/connectors/agentic-ai/connector-agentic-ai/pom.xml
@@ -360,7 +360,6 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <fork>true</fork>
           <annotationProcessorPaths>
             <path>
               <groupId>org.springframework.boot</groupId>
@@ -390,18 +389,6 @@
             <id>default-compile</id>
             <configuration>
               <compilerArgs>
-                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED</arg>
-                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED</arg>
-                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED</arg>
-                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED</arg>
-                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED</arg>
-                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED</arg>
-                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED</arg>
-                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED</arg>
-                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED</arg>
-                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED</arg>
-                <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED</arg>
-                <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED</arg>
                 <arg>-XDcompilePolicy=simple</arg>
                 <arg>-XDshould-stop.ifError=FLOW</arg>
                 <arg>-XDaddTypeAnnotationsToSymbol=true</arg>


### PR DESCRIPTION
## Description

The agentic-ai module's NullAway/ErrorProne wiring (#7696) forked the compiler and passed the required `jdk.compiler` `--add-exports`/`--add-opens` flags via module-local `-J` compiler args, specifically to avoid touching `.mvn/jvm.config` globally.

connector-runtime's own NullAway rollout (#7702) has since added those same exports/opens to `.mvn/jvm.config` globally. The module-local workaround in `connectors/agentic-ai/connector-agentic-ai/pom.xml` is now redundant, so this removes the `fork` flag and the `-J--add-exports`/`-J--add-opens` compiler args, relying on the global `.mvn/jvm.config` instead. The ErrorProne/NullAway plugin wiring itself (annotation processor paths, `-Xplugin:ErrorProne` args) is unchanged.

Verified by building the module and temporarily introducing a `return null;` NullAway violation, confirming it is still caught by the compiler with only the global `jvm.config` exports in place, then reverting the test violation.

## Checklist

- [ ] Backport labels are added if these code changes should be backported. No backport label is added to the latest
  release, as this branch will be rebased onto main before the next release. Example backport labels:
    - `backport stable/8.8`: for changes that should be included in the next 8.8.x release.
    - **or** `backport release-8.8.7`: for changes that should be included in the specific release 8.8.7, and this
      *release has already been created*. The release branch will be merged back into stable/8.8 later, so the change
      will be included in future 8.8.x releases as well.
- [x] Tests/Integration tests for the changes have been added if applicable. (No functional change; verified manually with a smoke test as described above.)
- [ ] If the change requires a documentation update, it has been added to the appropriate section in the documentation.


---
_Generated by [Claude Code](https://claude.ai/code/session_01SH1KNpfjq4ZZ3fbpJwsVyH)_