### PR TITLE
refactor(google): tooltip-first element-template field hints

### DIFF
--- a/connectors/google/google-base/src/main/java/io/camunda/google/model/Authentication.java
+++ b/connectors/google/google-base/src/main/java/io/camunda/google/model/Authentication.java
@@ -32,7 +32,6 @@ public record Authentication(
     @TemplateProperty(
             id = "bearerToken",
             label = "Bearer token",
-            tooltip = "Enter a valid Google API bearer token.",
             group = "authentication",
             feel = FeelMode.optional,
             constraints = @PropertyConstraints(notEmpty = true),
@@ -41,7 +40,6 @@ public record Authentication(
     @TemplateProperty(
             id = "oauthClientId",
             label = "Client ID",
-            tooltip = "Enter the Google API client ID.",
             group = "authentication",
             feel = FeelMode.optional,
             constraints = @PropertyConstraints(notEmpty = true),
@@ -51,7 +49,6 @@ public record Authentication(
     @TemplateProperty(
             id = "oauthClientSecret",
             label = "Client secret",
-            tooltip = "Enter the Google API client secret.",
             group = "authentication",
             feel = FeelMode.optional,
             constraints = @PropertyConstraints(notEmpty = true),
@@ -61,7 +58,6 @@ public record Authentication(
     @TemplateProperty(
             id = "oauthRefreshToken",
             label = "Refresh token",
-            tooltip = "Enter a valid Google API refresh token.",
             group = "authentication",
             feel = FeelMode.optional,
             constraints = @PropertyConstraints(notEmpty = true),

--- a/connectors/google/google-base/src/main/java/io/camunda/google/model/Authentication.java
+++ b/connectors/google/google-base/src/main/java/io/camunda/google/model/Authentication.java
@@ -32,7 +32,7 @@ public record Authentication(
     @TemplateProperty(
             id = "bearerToken",
             label = "Bearer token",
-            description = "Enter a valid Google API Bearer token",
+            tooltip = "Enter a valid Google API bearer token.",
             group = "authentication",
             feel = FeelMode.optional,
             constraints = @PropertyConstraints(notEmpty = true),
@@ -41,7 +41,7 @@ public record Authentication(
     @TemplateProperty(
             id = "oauthClientId",
             label = "Client ID",
-            description = "Enter Google API Client ID",
+            tooltip = "Enter the Google API client ID.",
             group = "authentication",
             feel = FeelMode.optional,
             constraints = @PropertyConstraints(notEmpty = true),
@@ -51,7 +51,7 @@ public record Authentication(
     @TemplateProperty(
             id = "oauthClientSecret",
             label = "Client secret",
-            description = "Enter Google API client Secret",
+            tooltip = "Enter the Google API client secret.",
             group = "authentication",
             feel = FeelMode.optional,
             constraints = @PropertyConstraints(notEmpty = true),
@@ -61,7 +61,7 @@ public record Authentication(
     @TemplateProperty(
             id = "oauthRefreshToken",
             label = "Refresh token",
-            description = "Enter a valid Google API refresh token",
+            tooltip = "Enter a valid Google API refresh token.",
             group = "authentication",
             feel = FeelMode.optional,
             constraints = @PropertyConstraints(notEmpty = true),

--- a/connectors/google/google-drive/element-templates/google-drive-outbound-connector.json
+++ b/connectors/google/google-drive/element-templates/google-drive-outbound-connector.json
@@ -70,7 +70,6 @@
   }, {
     "id" : "authentication.bearerToken",
     "label" : "Bearer token",
-    "description" : "Enter a valid Google API Bearer token",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -86,11 +85,11 @@
       "equals" : "bearer",
       "type" : "simple"
     },
+    "tooltip" : "Enter a valid Google API bearer token.",
     "type" : "String"
   }, {
     "id" : "authentication.oauthClientId",
     "label" : "Client ID",
-    "description" : "Enter Google API Client ID",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -106,11 +105,11 @@
       "equals" : "refresh",
       "type" : "simple"
     },
+    "tooltip" : "Enter the Google API client ID.",
     "type" : "String"
   }, {
     "id" : "authentication.oauthClientSecret",
     "label" : "Client secret",
-    "description" : "Enter Google API client Secret",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -126,11 +125,11 @@
       "equals" : "refresh",
       "type" : "simple"
     },
+    "tooltip" : "Enter the Google API client secret.",
     "type" : "String"
   }, {
     "id" : "authentication.oauthRefreshToken",
     "label" : "Refresh token",
-    "description" : "Enter a valid Google API refresh token",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -146,6 +145,7 @@
       "equals" : "refresh",
       "type" : "simple"
     },
+    "tooltip" : "Enter a valid Google API refresh token.",
     "type" : "String"
   }, {
     "id" : "resource.type",
@@ -196,7 +196,6 @@
   }, {
     "id" : "resource.parent",
     "label" : "Parent folder ID",
-    "description" : "Your resources will be created here. If left empty, a new resource will appear in the root folder",
     "optional" : true,
     "feel" : "optional",
     "group" : "operationDetails",
@@ -209,6 +208,7 @@
       "oneOf" : [ "folder", "file", "upload" ],
       "type" : "simple"
     },
+    "tooltip" : "Your resources will be created here. If left empty, a new resource will appear in the root folder.",
     "type" : "String"
   }, {
     "id" : "resource.additionalGoogleDriveProperties",
@@ -283,7 +283,6 @@
   }, {
     "id" : "resource.uploadData.document_documentSource",
     "label" : "Document source",
-    "description" : "Upload camunda document, <a href=\"https://docs.camunda.io/docs/apis-tools/camunda-api-rest/specifications/upload-document-alpha/\">see documentation</a>",
     "value" : "camunda",
     "group" : "operationDetails",
     "binding" : {
@@ -295,6 +294,7 @@
       "equals" : "upload",
       "type" : "simple"
     },
+    "tooltip" : "Upload a Camunda document. See the <a href=\"https://docs.camunda.io/docs/apis-tools/camunda-api-rest/specifications/upload-document-alpha/\">Camunda document upload API</a>.",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "Camunda Document",

--- a/connectors/google/google-drive/element-templates/google-drive-outbound-connector.json
+++ b/connectors/google/google-drive/element-templates/google-drive-outbound-connector.json
@@ -85,7 +85,6 @@
       "equals" : "bearer",
       "type" : "simple"
     },
-    "tooltip" : "Enter a valid Google API bearer token.",
     "type" : "String"
   }, {
     "id" : "authentication.oauthClientId",
@@ -105,7 +104,6 @@
       "equals" : "refresh",
       "type" : "simple"
     },
-    "tooltip" : "Enter the Google API client ID.",
     "type" : "String"
   }, {
     "id" : "authentication.oauthClientSecret",
@@ -125,7 +123,6 @@
       "equals" : "refresh",
       "type" : "simple"
     },
-    "tooltip" : "Enter the Google API client secret.",
     "type" : "String"
   }, {
     "id" : "authentication.oauthRefreshToken",
@@ -145,7 +142,6 @@
       "equals" : "refresh",
       "type" : "simple"
     },
-    "tooltip" : "Enter a valid Google API refresh token.",
     "type" : "String"
   }, {
     "id" : "resource.type",

--- a/connectors/google/google-drive/element-templates/hybrid/google-drive-outbound-connector-hybrid.json
+++ b/connectors/google/google-drive/element-templates/hybrid/google-drive-outbound-connector-hybrid.json
@@ -75,7 +75,6 @@
   }, {
     "id" : "authentication.bearerToken",
     "label" : "Bearer token",
-    "description" : "Enter a valid Google API Bearer token",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -91,11 +90,11 @@
       "equals" : "bearer",
       "type" : "simple"
     },
+    "tooltip" : "Enter a valid Google API bearer token.",
     "type" : "String"
   }, {
     "id" : "authentication.oauthClientId",
     "label" : "Client ID",
-    "description" : "Enter Google API Client ID",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -111,11 +110,11 @@
       "equals" : "refresh",
       "type" : "simple"
     },
+    "tooltip" : "Enter the Google API client ID.",
     "type" : "String"
   }, {
     "id" : "authentication.oauthClientSecret",
     "label" : "Client secret",
-    "description" : "Enter Google API client Secret",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -131,11 +130,11 @@
       "equals" : "refresh",
       "type" : "simple"
     },
+    "tooltip" : "Enter the Google API client secret.",
     "type" : "String"
   }, {
     "id" : "authentication.oauthRefreshToken",
     "label" : "Refresh token",
-    "description" : "Enter a valid Google API refresh token",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -151,6 +150,7 @@
       "equals" : "refresh",
       "type" : "simple"
     },
+    "tooltip" : "Enter a valid Google API refresh token.",
     "type" : "String"
   }, {
     "id" : "resource.type",
@@ -201,7 +201,6 @@
   }, {
     "id" : "resource.parent",
     "label" : "Parent folder ID",
-    "description" : "Your resources will be created here. If left empty, a new resource will appear in the root folder",
     "optional" : true,
     "feel" : "optional",
     "group" : "operationDetails",
@@ -214,6 +213,7 @@
       "oneOf" : [ "folder", "file", "upload" ],
       "type" : "simple"
     },
+    "tooltip" : "Your resources will be created here. If left empty, a new resource will appear in the root folder.",
     "type" : "String"
   }, {
     "id" : "resource.additionalGoogleDriveProperties",
@@ -288,7 +288,6 @@
   }, {
     "id" : "resource.uploadData.document_documentSource",
     "label" : "Document source",
-    "description" : "Upload camunda document, <a href=\"https://docs.camunda.io/docs/apis-tools/camunda-api-rest/specifications/upload-document-alpha/\">see documentation</a>",
     "value" : "camunda",
     "group" : "operationDetails",
     "binding" : {
@@ -300,6 +299,7 @@
       "equals" : "upload",
       "type" : "simple"
     },
+    "tooltip" : "Upload a Camunda document. See the <a href=\"https://docs.camunda.io/docs/apis-tools/camunda-api-rest/specifications/upload-document-alpha/\">Camunda document upload API</a>.",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "Camunda Document",

--- a/connectors/google/google-drive/element-templates/hybrid/google-drive-outbound-connector-hybrid.json
+++ b/connectors/google/google-drive/element-templates/hybrid/google-drive-outbound-connector-hybrid.json
@@ -90,7 +90,6 @@
       "equals" : "bearer",
       "type" : "simple"
     },
-    "tooltip" : "Enter a valid Google API bearer token.",
     "type" : "String"
   }, {
     "id" : "authentication.oauthClientId",
@@ -110,7 +109,6 @@
       "equals" : "refresh",
       "type" : "simple"
     },
-    "tooltip" : "Enter the Google API client ID.",
     "type" : "String"
   }, {
     "id" : "authentication.oauthClientSecret",
@@ -130,7 +128,6 @@
       "equals" : "refresh",
       "type" : "simple"
     },
-    "tooltip" : "Enter the Google API client secret.",
     "type" : "String"
   }, {
     "id" : "authentication.oauthRefreshToken",
@@ -150,7 +147,6 @@
       "equals" : "refresh",
       "type" : "simple"
     },
-    "tooltip" : "Enter a valid Google API refresh token.",
     "type" : "String"
   }, {
     "id" : "resource.type",

--- a/connectors/google/google-drive/src/main/java/io/camunda/connector/gdrive/model/request/Resource.java
+++ b/connectors/google/google-drive/src/main/java/io/camunda/connector/gdrive/model/request/Resource.java
@@ -47,9 +47,9 @@ public record Resource(
     @TemplateProperty(
             id = "parent",
             label = "Parent folder ID",
-            description =
+            tooltip =
                 "Your resources will be created here. "
-                    + "If left empty, a new resource will appear in the root folder",
+                    + "If left empty, a new resource will appear in the root folder.",
             group = "operationDetails",
             optional = true,
             feel = FeelMode.optional,

--- a/connectors/google/google-drive/src/main/java/io/camunda/connector/gdrive/model/request/UploadData.java
+++ b/connectors/google/google-drive/src/main/java/io/camunda/connector/gdrive/model/request/UploadData.java
@@ -15,6 +15,6 @@ public record UploadData(
             group = "operationDetails",
             condition =
                 @TemplateProperty.PropertyCondition(property = "resource.type", equals = "upload"),
-            description =
-                "Upload camunda document, <a href=\"https://docs.camunda.io/docs/apis-tools/camunda-api-rest/specifications/upload-document-alpha/\">see documentation</a>")
+            tooltip =
+                "Upload a Camunda document. See the <a href=\"https://docs.camunda.io/docs/apis-tools/camunda-api-rest/specifications/upload-document-alpha/\">Camunda document upload API</a>.")
         Document document) {}

--- a/connectors/google/google-gcs/element-templates/google-cloud-storage-outbound-connector.json
+++ b/connectors/google/google-gcs/element-templates/google-cloud-storage-outbound-connector.json
@@ -139,7 +139,7 @@
       "equals" : "downloadObject",
       "type" : "simple"
     },
-    "tooltip" : "If checked, a Camunda document is created and its reference is returned\nIf not checked, no document is created and the content is passed as is",
+    "tooltip" : "If checked, a Camunda document is created and its reference is returned.\nIf not checked, no document is created and the content is returned as is.",
     "type" : "Boolean"
   }, {
     "id" : "uploadOperationProject",
@@ -359,7 +359,6 @@
   }, {
     "id" : "authentication.jsonKey",
     "label" : "JSON key of the service account",
-    "description" : "This is the key of the service account in JSON format. See <a href=\"https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/google-cloud-storage/#authentication\" target=\"_blank\">documentation</a> for details.",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -370,6 +369,7 @@
       "name" : "authentication.jsonKey",
       "type" : "zeebe:input"
     },
+    "tooltip" : "Service account key in JSON format. See the <a href=\"https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/google-cloud-storage/#authentication\" target=\"_blank\">Google Cloud Storage authentication guide</a> for details.",
     "type" : "String"
   }, {
     "id" : "uploadOperationFileName",

--- a/connectors/google/google-gcs/element-templates/google-cloud-storage-outbound-connector.json
+++ b/connectors/google/google-gcs/element-templates/google-cloud-storage-outbound-connector.json
@@ -121,7 +121,7 @@
       "equals" : "downloadObject",
       "type" : "simple"
     },
-    "tooltip" : "Specify the name of the document to be downloaded.",
+    "tooltip" : "Name of the object in the bucket to download.",
     "type" : "String"
   }, {
     "id" : "downloadOperationAsFile",

--- a/connectors/google/google-gcs/element-templates/hybrid/hybrid-google-cloud-storage-outbound-connector-hybrid.json
+++ b/connectors/google/google-gcs/element-templates/hybrid/hybrid-google-cloud-storage-outbound-connector-hybrid.json
@@ -144,7 +144,7 @@
       "equals" : "downloadObject",
       "type" : "simple"
     },
-    "tooltip" : "If checked, a Camunda document is created and its reference is returned\nIf not checked, no document is created and the content is passed as is",
+    "tooltip" : "If checked, a Camunda document is created and its reference is returned.\nIf not checked, no document is created and the content is returned as is.",
     "type" : "Boolean"
   }, {
     "id" : "uploadOperationProject",
@@ -364,7 +364,6 @@
   }, {
     "id" : "authentication.jsonKey",
     "label" : "JSON key of the service account",
-    "description" : "This is the key of the service account in JSON format. See <a href=\"https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/google-cloud-storage/#authentication\" target=\"_blank\">documentation</a> for details.",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -375,6 +374,7 @@
       "name" : "authentication.jsonKey",
       "type" : "zeebe:input"
     },
+    "tooltip" : "Service account key in JSON format. See the <a href=\"https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/google-cloud-storage/#authentication\" target=\"_blank\">Google Cloud Storage authentication guide</a> for details.",
     "type" : "String"
   }, {
     "id" : "uploadOperationFileName",

--- a/connectors/google/google-gcs/element-templates/hybrid/hybrid-google-cloud-storage-outbound-connector-hybrid.json
+++ b/connectors/google/google-gcs/element-templates/hybrid/hybrid-google-cloud-storage-outbound-connector-hybrid.json
@@ -126,7 +126,7 @@
       "equals" : "downloadObject",
       "type" : "simple"
     },
-    "tooltip" : "Specify the name of the document to be downloaded.",
+    "tooltip" : "Name of the object in the bucket to download.",
     "type" : "String"
   }, {
     "id" : "downloadOperationAsFile",

--- a/connectors/google/google-gcs/src/main/java/io/camunda/connector/google/gcs/model/request/Authentication.java
+++ b/connectors/google/google-gcs/src/main/java/io/camunda/connector/google/gcs/model/request/Authentication.java
@@ -16,8 +16,8 @@ public class Authentication {
   @TemplateProperty(
       group = "authentication",
       label = "JSON key of the service account",
-      description =
-          "This is the key of the service account in JSON format. See <a href=\"https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/google-cloud-storage/#authentication\" target=\"_blank\">documentation</a> for details.",
+      tooltip =
+          "Service account key in JSON format. See the <a href=\"https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/google-cloud-storage/#authentication\" target=\"_blank\">Google Cloud Storage authentication guide</a> for details.",
       feel = FeelMode.optional)
   @NotBlank
   private String jsonKey;

--- a/connectors/google/google-gcs/src/main/java/io/camunda/connector/google/gcs/model/request/DownloadObject.java
+++ b/connectors/google/google-gcs/src/main/java/io/camunda/connector/google/gcs/model/request/DownloadObject.java
@@ -39,7 +39,7 @@ public record DownloadObject(
             label = "File name",
             id = "downloadOperationFileName",
             group = "operation",
-            tooltip = "Specify the name of the document to be downloaded.",
+            tooltip = "Name of the object in the bucket to download.",
             feel = FeelMode.optional,
             binding = @TemplateProperty.PropertyBinding(name = "operation.fileName"))
         @NotBlank

--- a/connectors/google/google-gcs/src/main/java/io/camunda/connector/google/gcs/model/request/DownloadObject.java
+++ b/connectors/google/google-gcs/src/main/java/io/camunda/connector/google/gcs/model/request/DownloadObject.java
@@ -49,8 +49,8 @@ public record DownloadObject(
             id = "downloadOperationAsFile",
             group = "operation",
             tooltip =
-                "If checked, a Camunda document is created and its reference is returned\n"
-                    + "If not checked, no document is created and the content is passed as is",
+                "If checked, a Camunda document is created and its reference is returned.\n"
+                    + "If not checked, no document is created and the content is returned as is.",
             type = TemplateProperty.PropertyType.Boolean,
             defaultValueType = TemplateProperty.DefaultValueType.Boolean,
             defaultValue = "true",

--- a/connectors/google/google-gemini/element-templates/google-gemini-outbound-connector.json
+++ b/connectors/google/google-gemini/element-templates/google-gemini-outbound-connector.json
@@ -82,7 +82,6 @@
       "equals" : "bearer",
       "type" : "simple"
     },
-    "tooltip" : "Enter a valid Google API bearer token.",
     "type" : "String"
   }, {
     "id" : "authentication.oauthClientId",
@@ -102,7 +101,6 @@
       "equals" : "refresh",
       "type" : "simple"
     },
-    "tooltip" : "Enter the Google API client ID.",
     "type" : "String"
   }, {
     "id" : "authentication.oauthClientSecret",
@@ -122,7 +120,6 @@
       "equals" : "refresh",
       "type" : "simple"
     },
-    "tooltip" : "Enter the Google API client secret.",
     "type" : "String"
   }, {
     "id" : "authentication.oauthRefreshToken",
@@ -142,7 +139,6 @@
       "equals" : "refresh",
       "type" : "simple"
     },
-    "tooltip" : "Enter a valid Google API refresh token.",
     "type" : "String"
   }, {
     "id" : "input.projectId",
@@ -223,7 +219,6 @@
       "equals" : "CUSTOM",
       "type" : "simple"
     },
-    "tooltip" : "Custom model name or identifier.",
     "type" : "String"
   }, {
     "id" : "input.prompts",
@@ -313,7 +308,7 @@
       "equals" : true,
       "type" : "simple"
     },
-    "tooltip" : "You can adjust the likelihood of receiving a model response that could contain harmful content. Content is blocked based on the probability that it's harmful. <a href=\"https://cloud.google.com/vertex-ai/docs/generative-ai/learn/responsible-ai?hl=en#safety_filters_and_attributes\" target=\"_blank\">Learn more about safety filters</a>",
+    "tooltip" : "Adjust how much potentially harmful content is blocked, based on the probability that it's harmful: OFF blocks nothing, Block few blocks only high-probability content, Block some blocks medium-and-above, and Block most blocks low-and-above. <a href=\"https://cloud.google.com/vertex-ai/docs/generative-ai/learn/responsible-ai?hl=en#safety_filters_and_attributes\" target=\"_blank\">Learn more about safety filters</a>",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "OFF",
@@ -343,7 +338,7 @@
       "equals" : true,
       "type" : "simple"
     },
-    "tooltip" : "You can adjust the likelihood of receiving a model response that could contain harmful content. Content is blocked based on the probability that it's harmful. <a href=\"https://cloud.google.com/vertex-ai/docs/generative-ai/learn/responsible-ai?hl=en#safety_filters_and_attributes\" target=\"_blank\">Learn more about safety filters</a>",
+    "tooltip" : "Adjust how much potentially harmful content is blocked, based on the probability that it's harmful: OFF blocks nothing, Block few blocks only high-probability content, Block some blocks medium-and-above, and Block most blocks low-and-above. <a href=\"https://cloud.google.com/vertex-ai/docs/generative-ai/learn/responsible-ai?hl=en#safety_filters_and_attributes\" target=\"_blank\">Learn more about safety filters</a>",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "OFF",
@@ -373,7 +368,7 @@
       "equals" : true,
       "type" : "simple"
     },
-    "tooltip" : "You can adjust the likelihood of receiving a model response that could contain harmful content. Content is blocked based on the probability that it's harmful. <a href=\"https://cloud.google.com/vertex-ai/docs/generative-ai/learn/responsible-ai?hl=en#safety_filters_and_attributes\" target=\"_blank\">Learn more about safety filters</a>",
+    "tooltip" : "Adjust how much potentially harmful content is blocked, based on the probability that it's harmful: OFF blocks nothing, Block few blocks only high-probability content, Block some blocks medium-and-above, and Block most blocks low-and-above. <a href=\"https://cloud.google.com/vertex-ai/docs/generative-ai/learn/responsible-ai?hl=en#safety_filters_and_attributes\" target=\"_blank\">Learn more about safety filters</a>",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "OFF",
@@ -403,7 +398,7 @@
       "equals" : true,
       "type" : "simple"
     },
-    "tooltip" : "You can adjust the likelihood of receiving a model response that could contain harmful content. Content is blocked based on the probability that it's harmful. <a href=\"https://cloud.google.com/vertex-ai/docs/generative-ai/learn/responsible-ai?hl=en#safety_filters_and_attributes\" target=\"_blank\">Learn more about safety filters</a>",
+    "tooltip" : "Adjust how much potentially harmful content is blocked, based on the probability that it's harmful: OFF blocks nothing, Block few blocks only high-probability content, Block some blocks medium-and-above, and Block most blocks low-and-above. <a href=\"https://cloud.google.com/vertex-ai/docs/generative-ai/learn/responsible-ai?hl=en#safety_filters_and_attributes\" target=\"_blank\">Learn more about safety filters</a>",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "OFF",

--- a/connectors/google/google-gemini/element-templates/google-gemini-outbound-connector.json
+++ b/connectors/google/google-gemini/element-templates/google-gemini-outbound-connector.json
@@ -67,7 +67,6 @@
   }, {
     "id" : "authentication.bearerToken",
     "label" : "Bearer token",
-    "description" : "Enter a valid Google API Bearer token",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -83,11 +82,11 @@
       "equals" : "bearer",
       "type" : "simple"
     },
+    "tooltip" : "Enter a valid Google API bearer token.",
     "type" : "String"
   }, {
     "id" : "authentication.oauthClientId",
     "label" : "Client ID",
-    "description" : "Enter Google API Client ID",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -103,11 +102,11 @@
       "equals" : "refresh",
       "type" : "simple"
     },
+    "tooltip" : "Enter the Google API client ID.",
     "type" : "String"
   }, {
     "id" : "authentication.oauthClientSecret",
     "label" : "Client secret",
-    "description" : "Enter Google API client Secret",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -123,11 +122,11 @@
       "equals" : "refresh",
       "type" : "simple"
     },
+    "tooltip" : "Enter the Google API client secret.",
     "type" : "String"
   }, {
     "id" : "authentication.oauthRefreshToken",
     "label" : "Refresh token",
-    "description" : "Enter a valid Google API refresh token",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -143,11 +142,11 @@
       "equals" : "refresh",
       "type" : "simple"
     },
+    "tooltip" : "Enter a valid Google API refresh token.",
     "type" : "String"
   }, {
     "id" : "input.projectId",
     "label" : "Project ID",
-    "description" : "Project identifier.",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -161,7 +160,6 @@
   }, {
     "id" : "input.region",
     "label" : "Region",
-    "description" : "Input region.",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -175,7 +173,6 @@
   }, {
     "id" : "input.model",
     "label" : "Model",
-    "description" : "Select gemini model.",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -211,7 +208,6 @@
   }, {
     "id" : "input.customModelName",
     "label" : "Custom model name",
-    "description" : "Custom model name or identifier",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -227,11 +223,11 @@
       "equals" : "CUSTOM",
       "type" : "simple"
     },
+    "tooltip" : "Custom model name or identifier.",
     "type" : "String"
   }, {
     "id" : "input.prompts",
     "label" : "Prompts",
-    "description" : "Provide a list of prompts",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -246,19 +242,17 @@
   }, {
     "id" : "input.systemInstrText",
     "label" : "System instructions",
-    "description" : "System instructions inform how the model should respond.",
     "optional" : true,
     "group" : "input",
     "binding" : {
       "name" : "input.systemInstrText",
       "type" : "zeebe:input"
     },
-    "tooltip" : "System instructions inform how the model should respond. Use them to give the model context to understand the task, provide more custom responses and adhere to specific guidelines. Instructions apply each time you send a request to the model.<a href=\"https://cloud.google.com/vertex-ai/generative-ai/docs/learn/prompts/system-instructions?hl=en\" Learn more about system instructions </a>",
+    "tooltip" : "System instructions inform how the model should respond. Use them to give the model context to understand the task, provide more custom responses and adhere to specific guidelines. Instructions apply each time you send a request to the model. <a href=\"https://cloud.google.com/vertex-ai/generative-ai/docs/learn/prompts/system-instructions?hl=en\" target=\"_blank\">Learn more about system instructions</a>",
     "type" : "String"
   }, {
     "id" : "input.grounding",
     "label" : "Grounding",
-    "description" : "Customize grounding by Vertex AI Search.",
     "optional" : false,
     "value" : false,
     "feel" : "static",
@@ -267,12 +261,11 @@
       "name" : "input.grounding",
       "type" : "zeebe:input"
     },
-    "tooltip" : "Grounding connects model output to verifiable sources of information. This is useful in situations where accuracy and reliability are important.<a href=\"https://cloud.google.com/vertex-ai/generative-ai/docs/grounding/overview?hl=en\" Learn more about grounding </a>",
+    "tooltip" : "Grounding connects model output to verifiable sources of information. This is useful in situations where accuracy and reliability are important. <a href=\"https://cloud.google.com/vertex-ai/generative-ai/docs/grounding/overview?hl=en\" target=\"_blank\">Learn more about grounding</a>",
     "type" : "Boolean"
   }, {
     "id" : "input.dataStorePath",
     "label" : "Vertex AI data store path",
-    "description" : "Vertex AI datastore path",
     "optional" : true,
     "constraints" : {
       "notEmpty" : false,
@@ -295,7 +288,6 @@
   }, {
     "id" : "input.safetySettings",
     "label" : "Safety Filter Settings",
-    "description" : "You can adjust the likelihood of receiving a model response that could contain harmful content. Content is blocked based on the probability that it's harmful.<a href=\"https://cloud.google.com/vertex-ai/generative-ai/docs/learn/responsible-ai?hl=en#safety_filters_and_attributes\" Learn more.</a>",
     "optional" : false,
     "value" : false,
     "feel" : "static",
@@ -304,6 +296,7 @@
       "name" : "input.safetySettings",
       "type" : "zeebe:input"
     },
+    "tooltip" : "You can adjust the likelihood of receiving a model response that could contain harmful content. Content is blocked based on the probability that it's harmful. See the <a href=\"https://cloud.google.com/vertex-ai/generative-ai/docs/learn/responsible-ai?hl=en#safety_filters_and_attributes\">safety filters and attributes</a>.",
     "type" : "Boolean"
   }, {
     "id" : "input.hateSpeech",
@@ -320,7 +313,7 @@
       "equals" : true,
       "type" : "simple"
     },
-    "tooltip" : "You can adjust the likelihood of receiving a model response that could contain harmful content. Content is blocked based on the probability that it's harmful.<a href=\"https://cloud.google.com/vertex-ai/docs/generative-ai/learn/responsible-ai?hl=en#safety_filters_and_attributes\" Learn more </a>",
+    "tooltip" : "You can adjust the likelihood of receiving a model response that could contain harmful content. Content is blocked based on the probability that it's harmful. <a href=\"https://cloud.google.com/vertex-ai/docs/generative-ai/learn/responsible-ai?hl=en#safety_filters_and_attributes\" target=\"_blank\">Learn more about safety filters</a>",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "OFF",
@@ -350,7 +343,7 @@
       "equals" : true,
       "type" : "simple"
     },
-    "tooltip" : "You can adjust the likelihood of receiving a model response that could contain harmful content. Content is blocked based on the probability that it's harmful.<a href=\"https://cloud.google.com/vertex-ai/docs/generative-ai/learn/responsible-ai?hl=en#safety_filters_and_attributes\" Learn more </a>",
+    "tooltip" : "You can adjust the likelihood of receiving a model response that could contain harmful content. Content is blocked based on the probability that it's harmful. <a href=\"https://cloud.google.com/vertex-ai/docs/generative-ai/learn/responsible-ai?hl=en#safety_filters_and_attributes\" target=\"_blank\">Learn more about safety filters</a>",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "OFF",
@@ -380,7 +373,7 @@
       "equals" : true,
       "type" : "simple"
     },
-    "tooltip" : "You can adjust the likelihood of receiving a model response that could contain harmful content. Content is blocked based on the probability that it's harmful.<a href=\"https://cloud.google.com/vertex-ai/docs/generative-ai/learn/responsible-ai?hl=en#safety_filters_and_attributes\" Learn more </a>",
+    "tooltip" : "You can adjust the likelihood of receiving a model response that could contain harmful content. Content is blocked based on the probability that it's harmful. <a href=\"https://cloud.google.com/vertex-ai/docs/generative-ai/learn/responsible-ai?hl=en#safety_filters_and_attributes\" target=\"_blank\">Learn more about safety filters</a>",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "OFF",
@@ -410,7 +403,7 @@
       "equals" : true,
       "type" : "simple"
     },
-    "tooltip" : "You can adjust the likelihood of receiving a model response that could contain harmful content. Content is blocked based on the probability that it's harmful.<a href=\"https://cloud.google.com/vertex-ai/docs/generative-ai/learn/responsible-ai?hl=en#safety_filters_and_attributes\" Learn more </a>",
+    "tooltip" : "You can adjust the likelihood of receiving a model response that could contain harmful content. Content is blocked based on the probability that it's harmful. <a href=\"https://cloud.google.com/vertex-ai/docs/generative-ai/learn/responsible-ai?hl=en#safety_filters_and_attributes\" target=\"_blank\">Learn more about safety filters</a>",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "OFF",
@@ -428,7 +421,6 @@
   }, {
     "id" : "input.stopSequences",
     "label" : "Add stop sequence",
-    "description" : "Vertex AI datastore path",
     "optional" : true,
     "feel" : "required",
     "group" : "input",
@@ -536,7 +528,6 @@
   }, {
     "id" : "input.functionCalls",
     "label" : "Function call description",
-    "description" : "Describe function calls.",
     "optional" : true,
     "feel" : "required",
     "group" : "input",

--- a/connectors/google/google-gemini/element-templates/hybrid/google-gemini-outbound-connector-hybrid.json
+++ b/connectors/google/google-gemini/element-templates/hybrid/google-gemini-outbound-connector-hybrid.json
@@ -72,7 +72,6 @@
   }, {
     "id" : "authentication.bearerToken",
     "label" : "Bearer token",
-    "description" : "Enter a valid Google API Bearer token",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -88,11 +87,11 @@
       "equals" : "bearer",
       "type" : "simple"
     },
+    "tooltip" : "Enter a valid Google API bearer token.",
     "type" : "String"
   }, {
     "id" : "authentication.oauthClientId",
     "label" : "Client ID",
-    "description" : "Enter Google API Client ID",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -108,11 +107,11 @@
       "equals" : "refresh",
       "type" : "simple"
     },
+    "tooltip" : "Enter the Google API client ID.",
     "type" : "String"
   }, {
     "id" : "authentication.oauthClientSecret",
     "label" : "Client secret",
-    "description" : "Enter Google API client Secret",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -128,11 +127,11 @@
       "equals" : "refresh",
       "type" : "simple"
     },
+    "tooltip" : "Enter the Google API client secret.",
     "type" : "String"
   }, {
     "id" : "authentication.oauthRefreshToken",
     "label" : "Refresh token",
-    "description" : "Enter a valid Google API refresh token",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -148,11 +147,11 @@
       "equals" : "refresh",
       "type" : "simple"
     },
+    "tooltip" : "Enter a valid Google API refresh token.",
     "type" : "String"
   }, {
     "id" : "input.projectId",
     "label" : "Project ID",
-    "description" : "Project identifier.",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -166,7 +165,6 @@
   }, {
     "id" : "input.region",
     "label" : "Region",
-    "description" : "Input region.",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -180,7 +178,6 @@
   }, {
     "id" : "input.model",
     "label" : "Model",
-    "description" : "Select gemini model.",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -216,7 +213,6 @@
   }, {
     "id" : "input.customModelName",
     "label" : "Custom model name",
-    "description" : "Custom model name or identifier",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -232,11 +228,11 @@
       "equals" : "CUSTOM",
       "type" : "simple"
     },
+    "tooltip" : "Custom model name or identifier.",
     "type" : "String"
   }, {
     "id" : "input.prompts",
     "label" : "Prompts",
-    "description" : "Provide a list of prompts",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -251,19 +247,17 @@
   }, {
     "id" : "input.systemInstrText",
     "label" : "System instructions",
-    "description" : "System instructions inform how the model should respond.",
     "optional" : true,
     "group" : "input",
     "binding" : {
       "name" : "input.systemInstrText",
       "type" : "zeebe:input"
     },
-    "tooltip" : "System instructions inform how the model should respond. Use them to give the model context to understand the task, provide more custom responses and adhere to specific guidelines. Instructions apply each time you send a request to the model.<a href=\"https://cloud.google.com/vertex-ai/generative-ai/docs/learn/prompts/system-instructions?hl=en\" Learn more about system instructions </a>",
+    "tooltip" : "System instructions inform how the model should respond. Use them to give the model context to understand the task, provide more custom responses and adhere to specific guidelines. Instructions apply each time you send a request to the model. <a href=\"https://cloud.google.com/vertex-ai/generative-ai/docs/learn/prompts/system-instructions?hl=en\" target=\"_blank\">Learn more about system instructions</a>",
     "type" : "String"
   }, {
     "id" : "input.grounding",
     "label" : "Grounding",
-    "description" : "Customize grounding by Vertex AI Search.",
     "optional" : false,
     "value" : false,
     "feel" : "static",
@@ -272,12 +266,11 @@
       "name" : "input.grounding",
       "type" : "zeebe:input"
     },
-    "tooltip" : "Grounding connects model output to verifiable sources of information. This is useful in situations where accuracy and reliability are important.<a href=\"https://cloud.google.com/vertex-ai/generative-ai/docs/grounding/overview?hl=en\" Learn more about grounding </a>",
+    "tooltip" : "Grounding connects model output to verifiable sources of information. This is useful in situations where accuracy and reliability are important. <a href=\"https://cloud.google.com/vertex-ai/generative-ai/docs/grounding/overview?hl=en\" target=\"_blank\">Learn more about grounding</a>",
     "type" : "Boolean"
   }, {
     "id" : "input.dataStorePath",
     "label" : "Vertex AI data store path",
-    "description" : "Vertex AI datastore path",
     "optional" : true,
     "constraints" : {
       "notEmpty" : false,
@@ -300,7 +293,6 @@
   }, {
     "id" : "input.safetySettings",
     "label" : "Safety Filter Settings",
-    "description" : "You can adjust the likelihood of receiving a model response that could contain harmful content. Content is blocked based on the probability that it's harmful.<a href=\"https://cloud.google.com/vertex-ai/generative-ai/docs/learn/responsible-ai?hl=en#safety_filters_and_attributes\" Learn more.</a>",
     "optional" : false,
     "value" : false,
     "feel" : "static",
@@ -309,6 +301,7 @@
       "name" : "input.safetySettings",
       "type" : "zeebe:input"
     },
+    "tooltip" : "You can adjust the likelihood of receiving a model response that could contain harmful content. Content is blocked based on the probability that it's harmful. See the <a href=\"https://cloud.google.com/vertex-ai/generative-ai/docs/learn/responsible-ai?hl=en#safety_filters_and_attributes\">safety filters and attributes</a>.",
     "type" : "Boolean"
   }, {
     "id" : "input.hateSpeech",
@@ -325,7 +318,7 @@
       "equals" : true,
       "type" : "simple"
     },
-    "tooltip" : "You can adjust the likelihood of receiving a model response that could contain harmful content. Content is blocked based on the probability that it's harmful.<a href=\"https://cloud.google.com/vertex-ai/docs/generative-ai/learn/responsible-ai?hl=en#safety_filters_and_attributes\" Learn more </a>",
+    "tooltip" : "You can adjust the likelihood of receiving a model response that could contain harmful content. Content is blocked based on the probability that it's harmful. <a href=\"https://cloud.google.com/vertex-ai/docs/generative-ai/learn/responsible-ai?hl=en#safety_filters_and_attributes\" target=\"_blank\">Learn more about safety filters</a>",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "OFF",
@@ -355,7 +348,7 @@
       "equals" : true,
       "type" : "simple"
     },
-    "tooltip" : "You can adjust the likelihood of receiving a model response that could contain harmful content. Content is blocked based on the probability that it's harmful.<a href=\"https://cloud.google.com/vertex-ai/docs/generative-ai/learn/responsible-ai?hl=en#safety_filters_and_attributes\" Learn more </a>",
+    "tooltip" : "You can adjust the likelihood of receiving a model response that could contain harmful content. Content is blocked based on the probability that it's harmful. <a href=\"https://cloud.google.com/vertex-ai/docs/generative-ai/learn/responsible-ai?hl=en#safety_filters_and_attributes\" target=\"_blank\">Learn more about safety filters</a>",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "OFF",
@@ -385,7 +378,7 @@
       "equals" : true,
       "type" : "simple"
     },
-    "tooltip" : "You can adjust the likelihood of receiving a model response that could contain harmful content. Content is blocked based on the probability that it's harmful.<a href=\"https://cloud.google.com/vertex-ai/docs/generative-ai/learn/responsible-ai?hl=en#safety_filters_and_attributes\" Learn more </a>",
+    "tooltip" : "You can adjust the likelihood of receiving a model response that could contain harmful content. Content is blocked based on the probability that it's harmful. <a href=\"https://cloud.google.com/vertex-ai/docs/generative-ai/learn/responsible-ai?hl=en#safety_filters_and_attributes\" target=\"_blank\">Learn more about safety filters</a>",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "OFF",
@@ -415,7 +408,7 @@
       "equals" : true,
       "type" : "simple"
     },
-    "tooltip" : "You can adjust the likelihood of receiving a model response that could contain harmful content. Content is blocked based on the probability that it's harmful.<a href=\"https://cloud.google.com/vertex-ai/docs/generative-ai/learn/responsible-ai?hl=en#safety_filters_and_attributes\" Learn more </a>",
+    "tooltip" : "You can adjust the likelihood of receiving a model response that could contain harmful content. Content is blocked based on the probability that it's harmful. <a href=\"https://cloud.google.com/vertex-ai/docs/generative-ai/learn/responsible-ai?hl=en#safety_filters_and_attributes\" target=\"_blank\">Learn more about safety filters</a>",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "OFF",
@@ -433,7 +426,6 @@
   }, {
     "id" : "input.stopSequences",
     "label" : "Add stop sequence",
-    "description" : "Vertex AI datastore path",
     "optional" : true,
     "feel" : "required",
     "group" : "input",
@@ -541,7 +533,6 @@
   }, {
     "id" : "input.functionCalls",
     "label" : "Function call description",
-    "description" : "Describe function calls.",
     "optional" : true,
     "feel" : "required",
     "group" : "input",

--- a/connectors/google/google-gemini/element-templates/hybrid/google-gemini-outbound-connector-hybrid.json
+++ b/connectors/google/google-gemini/element-templates/hybrid/google-gemini-outbound-connector-hybrid.json
@@ -87,7 +87,6 @@
       "equals" : "bearer",
       "type" : "simple"
     },
-    "tooltip" : "Enter a valid Google API bearer token.",
     "type" : "String"
   }, {
     "id" : "authentication.oauthClientId",
@@ -107,7 +106,6 @@
       "equals" : "refresh",
       "type" : "simple"
     },
-    "tooltip" : "Enter the Google API client ID.",
     "type" : "String"
   }, {
     "id" : "authentication.oauthClientSecret",
@@ -127,7 +125,6 @@
       "equals" : "refresh",
       "type" : "simple"
     },
-    "tooltip" : "Enter the Google API client secret.",
     "type" : "String"
   }, {
     "id" : "authentication.oauthRefreshToken",
@@ -147,7 +144,6 @@
       "equals" : "refresh",
       "type" : "simple"
     },
-    "tooltip" : "Enter a valid Google API refresh token.",
     "type" : "String"
   }, {
     "id" : "input.projectId",
@@ -228,7 +224,6 @@
       "equals" : "CUSTOM",
       "type" : "simple"
     },
-    "tooltip" : "Custom model name or identifier.",
     "type" : "String"
   }, {
     "id" : "input.prompts",
@@ -318,7 +313,7 @@
       "equals" : true,
       "type" : "simple"
     },
-    "tooltip" : "You can adjust the likelihood of receiving a model response that could contain harmful content. Content is blocked based on the probability that it's harmful. <a href=\"https://cloud.google.com/vertex-ai/docs/generative-ai/learn/responsible-ai?hl=en#safety_filters_and_attributes\" target=\"_blank\">Learn more about safety filters</a>",
+    "tooltip" : "Adjust how much potentially harmful content is blocked, based on the probability that it's harmful: OFF blocks nothing, Block few blocks only high-probability content, Block some blocks medium-and-above, and Block most blocks low-and-above. <a href=\"https://cloud.google.com/vertex-ai/docs/generative-ai/learn/responsible-ai?hl=en#safety_filters_and_attributes\" target=\"_blank\">Learn more about safety filters</a>",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "OFF",
@@ -348,7 +343,7 @@
       "equals" : true,
       "type" : "simple"
     },
-    "tooltip" : "You can adjust the likelihood of receiving a model response that could contain harmful content. Content is blocked based on the probability that it's harmful. <a href=\"https://cloud.google.com/vertex-ai/docs/generative-ai/learn/responsible-ai?hl=en#safety_filters_and_attributes\" target=\"_blank\">Learn more about safety filters</a>",
+    "tooltip" : "Adjust how much potentially harmful content is blocked, based on the probability that it's harmful: OFF blocks nothing, Block few blocks only high-probability content, Block some blocks medium-and-above, and Block most blocks low-and-above. <a href=\"https://cloud.google.com/vertex-ai/docs/generative-ai/learn/responsible-ai?hl=en#safety_filters_and_attributes\" target=\"_blank\">Learn more about safety filters</a>",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "OFF",
@@ -378,7 +373,7 @@
       "equals" : true,
       "type" : "simple"
     },
-    "tooltip" : "You can adjust the likelihood of receiving a model response that could contain harmful content. Content is blocked based on the probability that it's harmful. <a href=\"https://cloud.google.com/vertex-ai/docs/generative-ai/learn/responsible-ai?hl=en#safety_filters_and_attributes\" target=\"_blank\">Learn more about safety filters</a>",
+    "tooltip" : "Adjust how much potentially harmful content is blocked, based on the probability that it's harmful: OFF blocks nothing, Block few blocks only high-probability content, Block some blocks medium-and-above, and Block most blocks low-and-above. <a href=\"https://cloud.google.com/vertex-ai/docs/generative-ai/learn/responsible-ai?hl=en#safety_filters_and_attributes\" target=\"_blank\">Learn more about safety filters</a>",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "OFF",
@@ -408,7 +403,7 @@
       "equals" : true,
       "type" : "simple"
     },
-    "tooltip" : "You can adjust the likelihood of receiving a model response that could contain harmful content. Content is blocked based on the probability that it's harmful. <a href=\"https://cloud.google.com/vertex-ai/docs/generative-ai/learn/responsible-ai?hl=en#safety_filters_and_attributes\" target=\"_blank\">Learn more about safety filters</a>",
+    "tooltip" : "Adjust how much potentially harmful content is blocked, based on the probability that it's harmful: OFF blocks nothing, Block few blocks only high-probability content, Block some blocks medium-and-above, and Block most blocks low-and-above. <a href=\"https://cloud.google.com/vertex-ai/docs/generative-ai/learn/responsible-ai?hl=en#safety_filters_and_attributes\" target=\"_blank\">Learn more about safety filters</a>",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "OFF",

--- a/connectors/google/google-gemini/src/main/java/io/camunda/connector/gemini/model/GeminiRequestData.java
+++ b/connectors/google/google-gemini/src/main/java/io/camunda/connector/gemini/model/GeminiRequestData.java
@@ -13,24 +13,13 @@ import jakarta.validation.constraints.NotNull;
 import java.util.List;
 
 public record GeminiRequestData(
-    @TemplateProperty(
-            label = "Project ID",
-            group = "input",
-            description = "Project identifier.",
-            feel = FeelMode.disabled)
-        @NotNull
+    @TemplateProperty(label = "Project ID", group = "input", feel = FeelMode.disabled) @NotNull
         String projectId,
-    @TemplateProperty(
-            label = "Region",
-            group = "input",
-            description = "Input region.",
-            feel = FeelMode.disabled)
-        @NotNull
+    @TemplateProperty(label = "Region", group = "input", feel = FeelMode.disabled) @NotNull
         String region,
     @TemplateProperty(
             label = "Model",
             group = "input",
-            description = "Select gemini model.",
             feel = FeelMode.disabled,
             choices = {
               @TemplateProperty.DropdownPropertyChoice(
@@ -58,49 +47,40 @@ public record GeminiRequestData(
     @TemplateProperty(
             label = "Custom model name",
             group = "input",
-            description = "Custom model name or identifier",
+            tooltip = "Custom model name or identifier.",
             feel = FeelMode.optional,
             condition =
                 @TemplateProperty.PropertyCondition(property = "input.model", equals = "CUSTOM"),
             constraints = @TemplateProperty.PropertyConstraints(notEmpty = true))
         String customModelName,
-    @FEEL
-        @TemplateProperty(
-            label = "Prompts",
-            group = "input",
-            description = "Provide a list of prompts",
-            feel = FeelMode.required)
-        @NotNull
+    @FEEL @TemplateProperty(label = "Prompts", group = "input", feel = FeelMode.required) @NotNull
         List<Object> prompts,
     @TemplateProperty(
             label = "System instructions",
             group = "input",
-            description = "System instructions inform how the model should respond.",
             feel = FeelMode.disabled,
             tooltip =
                 "System instructions inform how the model should respond."
                     + " Use them to give the model context to understand the task, "
                     + "provide more custom responses and adhere to specific guidelines. "
                     + "Instructions apply each time you send a request to the model."
-                    + "<a href=\"https://cloud.google.com/vertex-ai/generative-ai/docs/learn/prompts/system-instructions?hl=en\" Learn more about system instructions </a>",
+                    + " <a href=\"https://cloud.google.com/vertex-ai/generative-ai/docs/learn/prompts/system-instructions?hl=en\" target=\"_blank\">Learn more about system instructions</a>",
             optional = true)
         String systemInstrText,
     @TemplateProperty(
             label = "Grounding",
             group = "input",
-            description = "Customize grounding by Vertex AI Search.",
             type = TemplateProperty.PropertyType.Boolean,
             defaultValueType = TemplateProperty.DefaultValueType.Boolean,
             tooltip =
                 "Grounding connects model output to verifiable sources of information. "
                     + "This is useful in situations where accuracy and reliability are important."
-                    + "<a href=\"https://cloud.google.com/vertex-ai/generative-ai/docs/grounding/overview?hl=en\" Learn more about grounding </a>",
+                    + " <a href=\"https://cloud.google.com/vertex-ai/generative-ai/docs/grounding/overview?hl=en\" target=\"_blank\">Learn more about grounding</a>",
             defaultValue = "false")
         boolean grounding,
     @TemplateProperty(
             label = "Vertex AI data store path",
             group = "input",
-            description = "Vertex AI datastore path",
             feel = FeelMode.disabled,
             condition =
                 @TemplateProperty.PropertyCondition(
@@ -121,10 +101,10 @@ public record GeminiRequestData(
             group = "input",
             type = TemplateProperty.PropertyType.Boolean,
             defaultValueType = TemplateProperty.DefaultValueType.Boolean,
-            description =
+            tooltip =
                 "You can adjust the likelihood of receiving a model response that could contain harmful content."
                     + " Content is blocked based on the probability that it's harmful."
-                    + "<a href=\"https://cloud.google.com/vertex-ai/generative-ai/docs/learn/responsible-ai?hl=en#safety_filters_and_attributes\" Learn more.</a>",
+                    + " See the <a href=\"https://cloud.google.com/vertex-ai/generative-ai/docs/learn/responsible-ai?hl=en#safety_filters_and_attributes\">safety filters and attributes</a>.",
             defaultValue = "false")
         boolean safetySettings,
     @TemplateProperty(
@@ -151,7 +131,7 @@ public record GeminiRequestData(
             tooltip =
                 "You can adjust the likelihood of receiving a model response that could contain harmful content. "
                     + "Content is blocked based on the probability that it's harmful."
-                    + "<a href=\"https://cloud.google.com/vertex-ai/docs/generative-ai/learn/responsible-ai?hl=en#safety_filters_and_attributes\" Learn more </a>",
+                    + " <a href=\"https://cloud.google.com/vertex-ai/docs/generative-ai/learn/responsible-ai?hl=en#safety_filters_and_attributes\" target=\"_blank\">Learn more about safety filters</a>",
             optional = true)
         BlockingDegree hateSpeech,
     @TemplateProperty(
@@ -178,7 +158,7 @@ public record GeminiRequestData(
             tooltip =
                 "You can adjust the likelihood of receiving a model response that could contain harmful content. "
                     + "Content is blocked based on the probability that it's harmful."
-                    + "<a href=\"https://cloud.google.com/vertex-ai/docs/generative-ai/learn/responsible-ai?hl=en#safety_filters_and_attributes\" Learn more </a>",
+                    + " <a href=\"https://cloud.google.com/vertex-ai/docs/generative-ai/learn/responsible-ai?hl=en#safety_filters_and_attributes\" target=\"_blank\">Learn more about safety filters</a>",
             optional = true)
         BlockingDegree dangerousContent,
     @TemplateProperty(
@@ -205,7 +185,7 @@ public record GeminiRequestData(
             tooltip =
                 "You can adjust the likelihood of receiving a model response that could contain harmful content. "
                     + "Content is blocked based on the probability that it's harmful."
-                    + "<a href=\"https://cloud.google.com/vertex-ai/docs/generative-ai/learn/responsible-ai?hl=en#safety_filters_and_attributes\" Learn more </a>",
+                    + " <a href=\"https://cloud.google.com/vertex-ai/docs/generative-ai/learn/responsible-ai?hl=en#safety_filters_and_attributes\" target=\"_blank\">Learn more about safety filters</a>",
             optional = true)
         BlockingDegree sexuallyExplicit,
     @TemplateProperty(
@@ -232,14 +212,13 @@ public record GeminiRequestData(
             tooltip =
                 "You can adjust the likelihood of receiving a model response that could contain harmful content. "
                     + "Content is blocked based on the probability that it's harmful."
-                    + "<a href=\"https://cloud.google.com/vertex-ai/docs/generative-ai/learn/responsible-ai?hl=en#safety_filters_and_attributes\" Learn more </a>",
+                    + " <a href=\"https://cloud.google.com/vertex-ai/docs/generative-ai/learn/responsible-ai?hl=en#safety_filters_and_attributes\" target=\"_blank\">Learn more about safety filters</a>",
             optional = true)
         BlockingDegree harassment,
     @FEEL
         @TemplateProperty(
             label = "Add stop sequence",
             group = "input",
-            description = "Vertex AI datastore path",
             feel = FeelMode.required,
             optional = true,
             tooltip =
@@ -329,7 +308,6 @@ public record GeminiRequestData(
     @FEEL
         @TemplateProperty(
             label = "Function call description",
-            description = "Describe function calls.",
             group = "input",
             feel = FeelMode.required,
             optional = true)

--- a/connectors/google/google-gemini/src/main/java/io/camunda/connector/gemini/model/GeminiRequestData.java
+++ b/connectors/google/google-gemini/src/main/java/io/camunda/connector/gemini/model/GeminiRequestData.java
@@ -47,7 +47,6 @@ public record GeminiRequestData(
     @TemplateProperty(
             label = "Custom model name",
             group = "input",
-            tooltip = "Custom model name or identifier.",
             feel = FeelMode.optional,
             condition =
                 @TemplateProperty.PropertyCondition(property = "input.model", equals = "CUSTOM"),
@@ -129,8 +128,9 @@ public record GeminiRequestData(
                     property = "input.safetySettings",
                     equalsBoolean = TemplateProperty.EqualsBoolean.TRUE),
             tooltip =
-                "You can adjust the likelihood of receiving a model response that could contain harmful content. "
-                    + "Content is blocked based on the probability that it's harmful."
+                "Adjust how much potentially harmful content is blocked, based on the probability that it's harmful: "
+                    + "OFF blocks nothing, Block few blocks only high-probability content, "
+                    + "Block some blocks medium-and-above, and Block most blocks low-and-above."
                     + " <a href=\"https://cloud.google.com/vertex-ai/docs/generative-ai/learn/responsible-ai?hl=en#safety_filters_and_attributes\" target=\"_blank\">Learn more about safety filters</a>",
             optional = true)
         BlockingDegree hateSpeech,
@@ -156,8 +156,9 @@ public record GeminiRequestData(
                     property = "input.safetySettings",
                     equalsBoolean = TemplateProperty.EqualsBoolean.TRUE),
             tooltip =
-                "You can adjust the likelihood of receiving a model response that could contain harmful content. "
-                    + "Content is blocked based on the probability that it's harmful."
+                "Adjust how much potentially harmful content is blocked, based on the probability that it's harmful: "
+                    + "OFF blocks nothing, Block few blocks only high-probability content, "
+                    + "Block some blocks medium-and-above, and Block most blocks low-and-above."
                     + " <a href=\"https://cloud.google.com/vertex-ai/docs/generative-ai/learn/responsible-ai?hl=en#safety_filters_and_attributes\" target=\"_blank\">Learn more about safety filters</a>",
             optional = true)
         BlockingDegree dangerousContent,
@@ -183,8 +184,9 @@ public record GeminiRequestData(
                     property = "input.safetySettings",
                     equalsBoolean = TemplateProperty.EqualsBoolean.TRUE),
             tooltip =
-                "You can adjust the likelihood of receiving a model response that could contain harmful content. "
-                    + "Content is blocked based on the probability that it's harmful."
+                "Adjust how much potentially harmful content is blocked, based on the probability that it's harmful: "
+                    + "OFF blocks nothing, Block few blocks only high-probability content, "
+                    + "Block some blocks medium-and-above, and Block most blocks low-and-above."
                     + " <a href=\"https://cloud.google.com/vertex-ai/docs/generative-ai/learn/responsible-ai?hl=en#safety_filters_and_attributes\" target=\"_blank\">Learn more about safety filters</a>",
             optional = true)
         BlockingDegree sexuallyExplicit,
@@ -210,8 +212,9 @@ public record GeminiRequestData(
                     property = "input.safetySettings",
                     equalsBoolean = TemplateProperty.EqualsBoolean.TRUE),
             tooltip =
-                "You can adjust the likelihood of receiving a model response that could contain harmful content. "
-                    + "Content is blocked based on the probability that it's harmful."
+                "Adjust how much potentially harmful content is blocked, based on the probability that it's harmful: "
+                    + "OFF blocks nothing, Block few blocks only high-probability content, "
+                    + "Block some blocks medium-and-above, and Block most blocks low-and-above."
                     + " <a href=\"https://cloud.google.com/vertex-ai/docs/generative-ai/learn/responsible-ai?hl=en#safety_filters_and_attributes\" target=\"_blank\">Learn more about safety filters</a>",
             optional = true)
         BlockingDegree harassment,

--- a/connectors/google/google-sheets/element-templates/google-sheets-outbound-connector.json
+++ b/connectors/google/google-sheets/element-templates/google-sheets-outbound-connector.json
@@ -126,7 +126,6 @@
       "equals" : "bearer",
       "type" : "simple"
     },
-    "tooltip" : "Enter a valid Google API bearer token.",
     "type" : "String"
   }, {
     "id" : "authentication.oauthClientId",
@@ -146,7 +145,6 @@
       "equals" : "refresh",
       "type" : "simple"
     },
-    "tooltip" : "Enter the Google API client ID.",
     "type" : "String"
   }, {
     "id" : "authentication.oauthClientSecret",
@@ -166,7 +164,6 @@
       "equals" : "refresh",
       "type" : "simple"
     },
-    "tooltip" : "Enter the Google API client secret.",
     "type" : "String"
   }, {
     "id" : "authentication.oauthRefreshToken",
@@ -186,7 +183,6 @@
       "equals" : "refresh",
       "type" : "simple"
     },
-    "tooltip" : "Enter a valid Google API refresh token.",
     "type" : "String"
   }, {
     "id" : "createSpreadsheet.spreadsheetName",
@@ -222,7 +218,7 @@
       "equals" : "createSpreadsheet",
       "type" : "simple"
     },
-    "tooltip" : "Enter the ID of the parent folder where the new spreadsheet will be created",
+    "tooltip" : "Folder in which the new spreadsheet is created. If left empty, it is created in the Google Drive root folder of the OAuth token owner.",
     "type" : "String"
   }, {
     "id" : "addValues.spreadsheetId",
@@ -280,7 +276,8 @@
       "equals" : "addValues",
       "type" : "simple"
     },
-    "tooltip" : "Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#add-values-to-spreadsheet\" target=\"_blank\">Cell ID documentation</a>",
+    "tooltip" : "Target cell in ColumnRow format. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#add-values-to-spreadsheet\" target=\"_blank\">add values to spreadsheet</a> operation.",
+    "placeholder" : "A1",
     "type" : "String"
   }, {
     "id" : "value",
@@ -380,7 +377,7 @@
       "equals" : "createEmptyColumnOrRow",
       "type" : "simple"
     },
-    "tooltip" : "Leave empty to add to the end of the sheet. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#create-empty-column-or-row\" target=\"_blank\">create empty column or row documentation</a>",
+    "tooltip" : "Leave empty to add to the end of the sheet. Count starts from 0. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#create-empty-column-or-row\" target=\"_blank\">create empty column or row</a> operation.",
     "type" : "Number"
   }, {
     "id" : "endIndex",
@@ -397,7 +394,7 @@
       "equals" : "createEmptyColumnOrRow",
       "type" : "simple"
     },
-    "tooltip" : "Leave empty to add to the end of the sheet. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#create-empty-column-or-row\" target=\"_blank\">create empty column or row documentation</a>",
+    "tooltip" : "Leave empty to add to the end of the sheet. Count starts from 0. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#create-empty-column-or-row\" target=\"_blank\">create empty column or row</a> operation.",
     "type" : "Number"
   }, {
     "id" : "createRow.spreadsheetId",
@@ -459,7 +456,7 @@
       "equals" : "createRow",
       "type" : "simple"
     },
-    "tooltip" : "Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#what-is-a-row-index\" target=\"_blank\">row index documentation</a>",
+    "tooltip" : "Position of the row, shown to the left of each row. If left empty, a new row is appended to the end. See <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#what-is-a-row-index\" target=\"_blank\">what is a row index</a>.",
     "type" : "Number"
   }, {
     "id" : "values",
@@ -479,7 +476,7 @@
       "equals" : "createRow",
       "type" : "simple"
     },
-    "tooltip" : "See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#create-row\" target=\"_blank\">create row value format</a>",
+    "tooltip" : "List of cell values to add as a new row. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#create-row\" target=\"_blank\">create row</a> operation.",
     "type" : "String"
   }, {
     "id" : "createWorksheet.spreadsheetId",
@@ -534,7 +531,7 @@
       "equals" : "createWorksheet",
       "type" : "simple"
     },
-    "tooltip" : "Leave empty to add to the end of the sheet list. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#what-is-a-worksheet-index\" target=\"_blank\">worksheet index documentation</a>",
+    "tooltip" : "Position of the new worksheet; count starts from 0. Leave empty to add it to the end of the sheet list. See <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#what-is-a-worksheet-index\" target=\"_blank\">what is a worksheet index</a>.",
     "type" : "Number"
   }, {
     "id" : "deleteColumn.spreadsheetId",
@@ -592,7 +589,7 @@
       "equals" : "deleteColumn",
       "type" : "simple"
     },
-    "tooltip" : "Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#how-can-i-define-which-column-will-be-deleted\" target=\"_blank\">column index format documentation</a>",
+    "tooltip" : "How the column to delete is identified: Numbers (numeric index at the top of the column, starting from 0) or Letters (the column letter). See <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#how-can-i-define-which-column-will-be-deleted\" target=\"_blank\">defining which column will be deleted</a>.",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "Numbers",
@@ -622,7 +619,7 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#how-can-i-define-which-column-will-be-deleted\" target=\"_blank\">column index documentation</a>",
+    "tooltip" : "Numeric position of the column to delete; count starts from 0 (column A is 0, B is 1). See <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#how-can-i-define-which-column-will-be-deleted\" target=\"_blank\">defining which column will be deleted</a>.",
     "type" : "Number"
   }, {
     "id" : "columnLetterIndex",
@@ -645,7 +642,8 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#how-can-i-define-which-column-will-be-deleted\" target=\"_blank\">column index documentation</a>",
+    "tooltip" : "Letter of the column to delete, as shown at the top of the column. See <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#how-can-i-define-which-column-will-be-deleted\" target=\"_blank\">defining which column will be deleted</a>.",
+    "placeholder" : "A",
     "type" : "String"
   }, {
     "id" : "deleteWorksheet.spreadsheetId",
@@ -738,7 +736,7 @@
       "equals" : "getRowByIndex",
       "type" : "simple"
     },
-    "tooltip" : "Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#what-is-a-row-index\" target=\"_blank\">row index documentation</a>",
+    "tooltip" : "Position of the row to retrieve, shown to the left of each row. See <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#what-is-a-row-index\" target=\"_blank\">what is a row index</a>.",
     "type" : "Number"
   }, {
     "id" : "spreadsheetsDetails.spreadsheetId",

--- a/connectors/google/google-sheets/element-templates/google-sheets-outbound-connector.json
+++ b/connectors/google/google-sheets/element-templates/google-sheets-outbound-connector.json
@@ -111,7 +111,6 @@
   }, {
     "id" : "authentication.bearerToken",
     "label" : "Bearer token",
-    "description" : "Enter a valid Google API Bearer token",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -127,11 +126,11 @@
       "equals" : "bearer",
       "type" : "simple"
     },
+    "tooltip" : "Enter a valid Google API bearer token.",
     "type" : "String"
   }, {
     "id" : "authentication.oauthClientId",
     "label" : "Client ID",
-    "description" : "Enter Google API Client ID",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -147,11 +146,11 @@
       "equals" : "refresh",
       "type" : "simple"
     },
+    "tooltip" : "Enter the Google API client ID.",
     "type" : "String"
   }, {
     "id" : "authentication.oauthClientSecret",
     "label" : "Client secret",
-    "description" : "Enter Google API client Secret",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -167,11 +166,11 @@
       "equals" : "refresh",
       "type" : "simple"
     },
+    "tooltip" : "Enter the Google API client secret.",
     "type" : "String"
   }, {
     "id" : "authentication.oauthRefreshToken",
     "label" : "Refresh token",
-    "description" : "Enter a valid Google API refresh token",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -187,11 +186,11 @@
       "equals" : "refresh",
       "type" : "simple"
     },
+    "tooltip" : "Enter a valid Google API refresh token.",
     "type" : "String"
   }, {
     "id" : "createSpreadsheet.spreadsheetName",
     "label" : "Spreadsheet name",
-    "description" : "Enter name for the new spreadsheet",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -211,7 +210,6 @@
   }, {
     "id" : "parent",
     "label" : "Parent folder ID",
-    "description" : "Enter ID of the parent folder where new spreadsheet will be created",
     "optional" : true,
     "feel" : "optional",
     "group" : "operationDetails",
@@ -224,11 +222,11 @@
       "equals" : "createSpreadsheet",
       "type" : "simple"
     },
+    "tooltip" : "Enter the ID of the parent folder where the new spreadsheet will be created",
     "type" : "String"
   }, {
     "id" : "addValues.spreadsheetId",
     "label" : "Spreadsheet ID",
-    "description" : "Enter the ID of the spreadsheet",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -248,7 +246,6 @@
   }, {
     "id" : "addValues.worksheetName",
     "label" : "Worksheet name",
-    "description" : "Enter name for the worksheet",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -268,7 +265,6 @@
   }, {
     "id" : "cellId",
     "label" : "Cell ID",
-    "description" : "Enter the ID of the cell. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#add-values-to-spreadsheet\" target=\"_blank\">documentation</a>",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -284,11 +280,11 @@
       "equals" : "addValues",
       "type" : "simple"
     },
+    "tooltip" : "Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#add-values-to-spreadsheet\" target=\"_blank\">Cell ID documentation</a>",
     "type" : "String"
   }, {
     "id" : "value",
     "label" : "Value",
-    "description" : "Enter the value",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -308,7 +304,6 @@
   }, {
     "id" : "createEmptyColumnOrRow.spreadsheetId",
     "label" : "Spreadsheet ID",
-    "description" : "Enter the ID of the spreadsheet",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -328,7 +323,6 @@
   }, {
     "id" : "createEmptyColumnOrRow.worksheetId",
     "label" : "Worksheet ID",
-    "description" : "Enter the ID of the worksheet",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -348,7 +342,6 @@
   }, {
     "id" : "dimension",
     "label" : "Dimension",
-    "description" : "Choose what to add: column or row",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -363,6 +356,7 @@
       "equals" : "createEmptyColumnOrRow",
       "type" : "simple"
     },
+    "tooltip" : "What to add: column or row",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "ROWS",
@@ -374,7 +368,6 @@
   }, {
     "id" : "startIndex",
     "label" : "Start index",
-    "description" : "Enter start index (leave empty if add to the end of the sheet). Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#create-empty-column-or-row\" target=\"_blank\">documentation</a>",
     "optional" : false,
     "feel" : "optional",
     "group" : "operationDetails",
@@ -387,11 +380,11 @@
       "equals" : "createEmptyColumnOrRow",
       "type" : "simple"
     },
+    "tooltip" : "Leave empty to add to the end of the sheet. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#create-empty-column-or-row\" target=\"_blank\">create empty column or row documentation</a>",
     "type" : "Number"
   }, {
     "id" : "endIndex",
     "label" : "End index",
-    "description" : "Enter end index (leave empty if add to the end of the sheet). Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#create-empty-column-or-row\" target=\"_blank\">documentation</a>",
     "optional" : false,
     "feel" : "optional",
     "group" : "operationDetails",
@@ -404,11 +397,11 @@
       "equals" : "createEmptyColumnOrRow",
       "type" : "simple"
     },
+    "tooltip" : "Leave empty to add to the end of the sheet. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#create-empty-column-or-row\" target=\"_blank\">create empty column or row documentation</a>",
     "type" : "Number"
   }, {
     "id" : "createRow.spreadsheetId",
     "label" : "Spreadsheet ID",
-    "description" : "Enter the ID of the spreadsheet",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -428,7 +421,6 @@
   }, {
     "id" : "createRow.worksheetName",
     "label" : "Worksheet name",
-    "description" : "Enter name for the worksheet",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -448,7 +440,6 @@
   }, {
     "id" : "createRow.rowIndex",
     "label" : "Row index",
-    "description" : "Enter row index. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#what-is-a-row-index\" target=\"_blank\">documentation</a>",
     "optional" : true,
     "constraints" : {
       "notEmpty" : false,
@@ -468,11 +459,11 @@
       "equals" : "createRow",
       "type" : "simple"
     },
+    "tooltip" : "Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#what-is-a-row-index\" target=\"_blank\">row index documentation</a>",
     "type" : "Number"
   }, {
     "id" : "values",
     "label" : "Enter values",
-    "description" : "Enter the array of values. <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#create-row\" target=\"_blank\">Learn more about the required format</a>",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -488,11 +479,11 @@
       "equals" : "createRow",
       "type" : "simple"
     },
+    "tooltip" : "See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#create-row\" target=\"_blank\">create row value format</a>",
     "type" : "String"
   }, {
     "id" : "createWorksheet.spreadsheetId",
     "label" : "Spreadsheet ID",
-    "description" : "Enter the ID of the spreadsheet",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -512,7 +503,6 @@
   }, {
     "id" : "createWorksheet.worksheetName",
     "label" : "Worksheet name",
-    "description" : "Enter name for the worksheet",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -532,7 +522,6 @@
   }, {
     "id" : "worksheetIndex",
     "label" : "Worksheet index",
-    "description" : "Enter index of the place where to add worksheet (leave empty if add to the end of sheet list) Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#what-is-a-worksheet-index\" target=\"_blank\">documentation</a>",
     "optional" : false,
     "feel" : "optional",
     "group" : "operationDetails",
@@ -545,11 +534,11 @@
       "equals" : "createWorksheet",
       "type" : "simple"
     },
+    "tooltip" : "Leave empty to add to the end of the sheet list. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#what-is-a-worksheet-index\" target=\"_blank\">worksheet index documentation</a>",
     "type" : "Number"
   }, {
     "id" : "deleteColumn.spreadsheetId",
     "label" : "Spreadsheet ID",
-    "description" : "Enter the ID of the spreadsheet",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -569,7 +558,6 @@
   }, {
     "id" : "deleteColumn.worksheetId",
     "label" : "Worksheet ID",
-    "description" : "Enter the ID of the worksheet",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -589,7 +577,6 @@
   }, {
     "id" : "columnIndexType",
     "label" : "Index format",
-    "description" : "Choose the type of the index. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#how-can-i-define-which-column-will-be-deleted\" target=\"_blank\">documentation</a>",
     "optional" : false,
     "value" : "NUMBERS",
     "constraints" : {
@@ -605,6 +592,7 @@
       "equals" : "deleteColumn",
       "type" : "simple"
     },
+    "tooltip" : "Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#how-can-i-define-which-column-will-be-deleted\" target=\"_blank\">column index format documentation</a>",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "Numbers",
@@ -616,7 +604,6 @@
   }, {
     "id" : "columnNumberIndex",
     "label" : "Column numeric index",
-    "description" : "Enter the index of the column. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#how-can-i-define-which-column-will-be-deleted\" target=\"_blank\">documentation</a>",
     "optional" : false,
     "feel" : "optional",
     "group" : "operationDetails",
@@ -635,11 +622,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#how-can-i-define-which-column-will-be-deleted\" target=\"_blank\">column index documentation</a>",
     "type" : "Number"
   }, {
     "id" : "columnLetterIndex",
     "label" : "Column letter index",
-    "description" : "Enter the index of the column. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#how-can-i-define-which-column-will-be-deleted\" target=\"_blank\">documentation</a>",
     "optional" : false,
     "feel" : "optional",
     "group" : "operationDetails",
@@ -658,11 +645,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#how-can-i-define-which-column-will-be-deleted\" target=\"_blank\">column index documentation</a>",
     "type" : "String"
   }, {
     "id" : "deleteWorksheet.spreadsheetId",
     "label" : "Spreadsheet ID",
-    "description" : "Enter the ID of the spreadsheet",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -682,7 +669,6 @@
   }, {
     "id" : "deleteWorksheet.worksheetId",
     "label" : "Worksheet ID",
-    "description" : "Enter the ID of the worksheet",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -702,7 +688,6 @@
   }, {
     "id" : "getRowByIndex.spreadsheetId",
     "label" : "Spreadsheet ID",
-    "description" : "Enter the ID of the spreadsheet",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -722,7 +707,6 @@
   }, {
     "id" : "getRowByIndex.worksheetName",
     "label" : "Worksheet name",
-    "description" : "Enter name for the worksheet",
     "optional" : false,
     "feel" : "optional",
     "group" : "operationDetails",
@@ -739,7 +723,6 @@
   }, {
     "id" : "getRowByIndex.rowIndex",
     "label" : "Row index",
-    "description" : "Enter row index. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#what-is-a-row-index\" target=\"_blank\">documentation</a>",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -755,11 +738,11 @@
       "equals" : "getRowByIndex",
       "type" : "simple"
     },
+    "tooltip" : "Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#what-is-a-row-index\" target=\"_blank\">row index documentation</a>",
     "type" : "Number"
   }, {
     "id" : "spreadsheetsDetails.spreadsheetId",
     "label" : "Spreadsheet ID",
-    "description" : "Enter the ID of the spreadsheet",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -779,7 +762,6 @@
   }, {
     "id" : "getWorksheetData.spreadsheetId",
     "label" : "Spreadsheet ID",
-    "description" : "Enter the ID of the spreadsheet",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -799,7 +781,6 @@
   }, {
     "id" : "getWorksheetData.worksheetName",
     "label" : "Worksheet name",
-    "description" : "Enter name for the worksheet",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true

--- a/connectors/google/google-sheets/element-templates/hybrid/google-sheets-outbound-connector-hybrid.json
+++ b/connectors/google/google-sheets/element-templates/hybrid/google-sheets-outbound-connector-hybrid.json
@@ -131,7 +131,6 @@
       "equals" : "bearer",
       "type" : "simple"
     },
-    "tooltip" : "Enter a valid Google API bearer token.",
     "type" : "String"
   }, {
     "id" : "authentication.oauthClientId",
@@ -151,7 +150,6 @@
       "equals" : "refresh",
       "type" : "simple"
     },
-    "tooltip" : "Enter the Google API client ID.",
     "type" : "String"
   }, {
     "id" : "authentication.oauthClientSecret",
@@ -171,7 +169,6 @@
       "equals" : "refresh",
       "type" : "simple"
     },
-    "tooltip" : "Enter the Google API client secret.",
     "type" : "String"
   }, {
     "id" : "authentication.oauthRefreshToken",
@@ -191,7 +188,6 @@
       "equals" : "refresh",
       "type" : "simple"
     },
-    "tooltip" : "Enter a valid Google API refresh token.",
     "type" : "String"
   }, {
     "id" : "createSpreadsheet.spreadsheetName",
@@ -227,7 +223,7 @@
       "equals" : "createSpreadsheet",
       "type" : "simple"
     },
-    "tooltip" : "Enter the ID of the parent folder where the new spreadsheet will be created",
+    "tooltip" : "Folder in which the new spreadsheet is created. If left empty, it is created in the Google Drive root folder of the OAuth token owner.",
     "type" : "String"
   }, {
     "id" : "addValues.spreadsheetId",
@@ -285,7 +281,8 @@
       "equals" : "addValues",
       "type" : "simple"
     },
-    "tooltip" : "Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#add-values-to-spreadsheet\" target=\"_blank\">Cell ID documentation</a>",
+    "tooltip" : "Target cell in ColumnRow format. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#add-values-to-spreadsheet\" target=\"_blank\">add values to spreadsheet</a> operation.",
+    "placeholder" : "A1",
     "type" : "String"
   }, {
     "id" : "value",
@@ -385,7 +382,7 @@
       "equals" : "createEmptyColumnOrRow",
       "type" : "simple"
     },
-    "tooltip" : "Leave empty to add to the end of the sheet. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#create-empty-column-or-row\" target=\"_blank\">create empty column or row documentation</a>",
+    "tooltip" : "Leave empty to add to the end of the sheet. Count starts from 0. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#create-empty-column-or-row\" target=\"_blank\">create empty column or row</a> operation.",
     "type" : "Number"
   }, {
     "id" : "endIndex",
@@ -402,7 +399,7 @@
       "equals" : "createEmptyColumnOrRow",
       "type" : "simple"
     },
-    "tooltip" : "Leave empty to add to the end of the sheet. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#create-empty-column-or-row\" target=\"_blank\">create empty column or row documentation</a>",
+    "tooltip" : "Leave empty to add to the end of the sheet. Count starts from 0. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#create-empty-column-or-row\" target=\"_blank\">create empty column or row</a> operation.",
     "type" : "Number"
   }, {
     "id" : "createRow.spreadsheetId",
@@ -464,7 +461,7 @@
       "equals" : "createRow",
       "type" : "simple"
     },
-    "tooltip" : "Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#what-is-a-row-index\" target=\"_blank\">row index documentation</a>",
+    "tooltip" : "Position of the row, shown to the left of each row. If left empty, a new row is appended to the end. See <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#what-is-a-row-index\" target=\"_blank\">what is a row index</a>.",
     "type" : "Number"
   }, {
     "id" : "values",
@@ -484,7 +481,7 @@
       "equals" : "createRow",
       "type" : "simple"
     },
-    "tooltip" : "See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#create-row\" target=\"_blank\">create row value format</a>",
+    "tooltip" : "List of cell values to add as a new row. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#create-row\" target=\"_blank\">create row</a> operation.",
     "type" : "String"
   }, {
     "id" : "createWorksheet.spreadsheetId",
@@ -539,7 +536,7 @@
       "equals" : "createWorksheet",
       "type" : "simple"
     },
-    "tooltip" : "Leave empty to add to the end of the sheet list. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#what-is-a-worksheet-index\" target=\"_blank\">worksheet index documentation</a>",
+    "tooltip" : "Position of the new worksheet; count starts from 0. Leave empty to add it to the end of the sheet list. See <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#what-is-a-worksheet-index\" target=\"_blank\">what is a worksheet index</a>.",
     "type" : "Number"
   }, {
     "id" : "deleteColumn.spreadsheetId",
@@ -597,7 +594,7 @@
       "equals" : "deleteColumn",
       "type" : "simple"
     },
-    "tooltip" : "Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#how-can-i-define-which-column-will-be-deleted\" target=\"_blank\">column index format documentation</a>",
+    "tooltip" : "How the column to delete is identified: Numbers (numeric index at the top of the column, starting from 0) or Letters (the column letter). See <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#how-can-i-define-which-column-will-be-deleted\" target=\"_blank\">defining which column will be deleted</a>.",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "Numbers",
@@ -627,7 +624,7 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#how-can-i-define-which-column-will-be-deleted\" target=\"_blank\">column index documentation</a>",
+    "tooltip" : "Numeric position of the column to delete; count starts from 0 (column A is 0, B is 1). See <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#how-can-i-define-which-column-will-be-deleted\" target=\"_blank\">defining which column will be deleted</a>.",
     "type" : "Number"
   }, {
     "id" : "columnLetterIndex",
@@ -650,7 +647,8 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#how-can-i-define-which-column-will-be-deleted\" target=\"_blank\">column index documentation</a>",
+    "tooltip" : "Letter of the column to delete, as shown at the top of the column. See <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#how-can-i-define-which-column-will-be-deleted\" target=\"_blank\">defining which column will be deleted</a>.",
+    "placeholder" : "A",
     "type" : "String"
   }, {
     "id" : "deleteWorksheet.spreadsheetId",
@@ -743,7 +741,7 @@
       "equals" : "getRowByIndex",
       "type" : "simple"
     },
-    "tooltip" : "Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#what-is-a-row-index\" target=\"_blank\">row index documentation</a>",
+    "tooltip" : "Position of the row to retrieve, shown to the left of each row. See <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#what-is-a-row-index\" target=\"_blank\">what is a row index</a>.",
     "type" : "Number"
   }, {
     "id" : "spreadsheetsDetails.spreadsheetId",

--- a/connectors/google/google-sheets/element-templates/hybrid/google-sheets-outbound-connector-hybrid.json
+++ b/connectors/google/google-sheets/element-templates/hybrid/google-sheets-outbound-connector-hybrid.json
@@ -116,7 +116,6 @@
   }, {
     "id" : "authentication.bearerToken",
     "label" : "Bearer token",
-    "description" : "Enter a valid Google API Bearer token",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -132,11 +131,11 @@
       "equals" : "bearer",
       "type" : "simple"
     },
+    "tooltip" : "Enter a valid Google API bearer token.",
     "type" : "String"
   }, {
     "id" : "authentication.oauthClientId",
     "label" : "Client ID",
-    "description" : "Enter Google API Client ID",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -152,11 +151,11 @@
       "equals" : "refresh",
       "type" : "simple"
     },
+    "tooltip" : "Enter the Google API client ID.",
     "type" : "String"
   }, {
     "id" : "authentication.oauthClientSecret",
     "label" : "Client secret",
-    "description" : "Enter Google API client Secret",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -172,11 +171,11 @@
       "equals" : "refresh",
       "type" : "simple"
     },
+    "tooltip" : "Enter the Google API client secret.",
     "type" : "String"
   }, {
     "id" : "authentication.oauthRefreshToken",
     "label" : "Refresh token",
-    "description" : "Enter a valid Google API refresh token",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -192,11 +191,11 @@
       "equals" : "refresh",
       "type" : "simple"
     },
+    "tooltip" : "Enter a valid Google API refresh token.",
     "type" : "String"
   }, {
     "id" : "createSpreadsheet.spreadsheetName",
     "label" : "Spreadsheet name",
-    "description" : "Enter name for the new spreadsheet",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -216,7 +215,6 @@
   }, {
     "id" : "parent",
     "label" : "Parent folder ID",
-    "description" : "Enter ID of the parent folder where new spreadsheet will be created",
     "optional" : true,
     "feel" : "optional",
     "group" : "operationDetails",
@@ -229,11 +227,11 @@
       "equals" : "createSpreadsheet",
       "type" : "simple"
     },
+    "tooltip" : "Enter the ID of the parent folder where the new spreadsheet will be created",
     "type" : "String"
   }, {
     "id" : "addValues.spreadsheetId",
     "label" : "Spreadsheet ID",
-    "description" : "Enter the ID of the spreadsheet",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -253,7 +251,6 @@
   }, {
     "id" : "addValues.worksheetName",
     "label" : "Worksheet name",
-    "description" : "Enter name for the worksheet",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -273,7 +270,6 @@
   }, {
     "id" : "cellId",
     "label" : "Cell ID",
-    "description" : "Enter the ID of the cell. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#add-values-to-spreadsheet\" target=\"_blank\">documentation</a>",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -289,11 +285,11 @@
       "equals" : "addValues",
       "type" : "simple"
     },
+    "tooltip" : "Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#add-values-to-spreadsheet\" target=\"_blank\">Cell ID documentation</a>",
     "type" : "String"
   }, {
     "id" : "value",
     "label" : "Value",
-    "description" : "Enter the value",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -313,7 +309,6 @@
   }, {
     "id" : "createEmptyColumnOrRow.spreadsheetId",
     "label" : "Spreadsheet ID",
-    "description" : "Enter the ID of the spreadsheet",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -333,7 +328,6 @@
   }, {
     "id" : "createEmptyColumnOrRow.worksheetId",
     "label" : "Worksheet ID",
-    "description" : "Enter the ID of the worksheet",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -353,7 +347,6 @@
   }, {
     "id" : "dimension",
     "label" : "Dimension",
-    "description" : "Choose what to add: column or row",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -368,6 +361,7 @@
       "equals" : "createEmptyColumnOrRow",
       "type" : "simple"
     },
+    "tooltip" : "What to add: column or row",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "ROWS",
@@ -379,7 +373,6 @@
   }, {
     "id" : "startIndex",
     "label" : "Start index",
-    "description" : "Enter start index (leave empty if add to the end of the sheet). Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#create-empty-column-or-row\" target=\"_blank\">documentation</a>",
     "optional" : false,
     "feel" : "optional",
     "group" : "operationDetails",
@@ -392,11 +385,11 @@
       "equals" : "createEmptyColumnOrRow",
       "type" : "simple"
     },
+    "tooltip" : "Leave empty to add to the end of the sheet. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#create-empty-column-or-row\" target=\"_blank\">create empty column or row documentation</a>",
     "type" : "Number"
   }, {
     "id" : "endIndex",
     "label" : "End index",
-    "description" : "Enter end index (leave empty if add to the end of the sheet). Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#create-empty-column-or-row\" target=\"_blank\">documentation</a>",
     "optional" : false,
     "feel" : "optional",
     "group" : "operationDetails",
@@ -409,11 +402,11 @@
       "equals" : "createEmptyColumnOrRow",
       "type" : "simple"
     },
+    "tooltip" : "Leave empty to add to the end of the sheet. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#create-empty-column-or-row\" target=\"_blank\">create empty column or row documentation</a>",
     "type" : "Number"
   }, {
     "id" : "createRow.spreadsheetId",
     "label" : "Spreadsheet ID",
-    "description" : "Enter the ID of the spreadsheet",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -433,7 +426,6 @@
   }, {
     "id" : "createRow.worksheetName",
     "label" : "Worksheet name",
-    "description" : "Enter name for the worksheet",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -453,7 +445,6 @@
   }, {
     "id" : "createRow.rowIndex",
     "label" : "Row index",
-    "description" : "Enter row index. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#what-is-a-row-index\" target=\"_blank\">documentation</a>",
     "optional" : true,
     "constraints" : {
       "notEmpty" : false,
@@ -473,11 +464,11 @@
       "equals" : "createRow",
       "type" : "simple"
     },
+    "tooltip" : "Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#what-is-a-row-index\" target=\"_blank\">row index documentation</a>",
     "type" : "Number"
   }, {
     "id" : "values",
     "label" : "Enter values",
-    "description" : "Enter the array of values. <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#create-row\" target=\"_blank\">Learn more about the required format</a>",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -493,11 +484,11 @@
       "equals" : "createRow",
       "type" : "simple"
     },
+    "tooltip" : "See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#create-row\" target=\"_blank\">create row value format</a>",
     "type" : "String"
   }, {
     "id" : "createWorksheet.spreadsheetId",
     "label" : "Spreadsheet ID",
-    "description" : "Enter the ID of the spreadsheet",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -517,7 +508,6 @@
   }, {
     "id" : "createWorksheet.worksheetName",
     "label" : "Worksheet name",
-    "description" : "Enter name for the worksheet",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -537,7 +527,6 @@
   }, {
     "id" : "worksheetIndex",
     "label" : "Worksheet index",
-    "description" : "Enter index of the place where to add worksheet (leave empty if add to the end of sheet list) Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#what-is-a-worksheet-index\" target=\"_blank\">documentation</a>",
     "optional" : false,
     "feel" : "optional",
     "group" : "operationDetails",
@@ -550,11 +539,11 @@
       "equals" : "createWorksheet",
       "type" : "simple"
     },
+    "tooltip" : "Leave empty to add to the end of the sheet list. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#what-is-a-worksheet-index\" target=\"_blank\">worksheet index documentation</a>",
     "type" : "Number"
   }, {
     "id" : "deleteColumn.spreadsheetId",
     "label" : "Spreadsheet ID",
-    "description" : "Enter the ID of the spreadsheet",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -574,7 +563,6 @@
   }, {
     "id" : "deleteColumn.worksheetId",
     "label" : "Worksheet ID",
-    "description" : "Enter the ID of the worksheet",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -594,7 +582,6 @@
   }, {
     "id" : "columnIndexType",
     "label" : "Index format",
-    "description" : "Choose the type of the index. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#how-can-i-define-which-column-will-be-deleted\" target=\"_blank\">documentation</a>",
     "optional" : false,
     "value" : "NUMBERS",
     "constraints" : {
@@ -610,6 +597,7 @@
       "equals" : "deleteColumn",
       "type" : "simple"
     },
+    "tooltip" : "Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#how-can-i-define-which-column-will-be-deleted\" target=\"_blank\">column index format documentation</a>",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "Numbers",
@@ -621,7 +609,6 @@
   }, {
     "id" : "columnNumberIndex",
     "label" : "Column numeric index",
-    "description" : "Enter the index of the column. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#how-can-i-define-which-column-will-be-deleted\" target=\"_blank\">documentation</a>",
     "optional" : false,
     "feel" : "optional",
     "group" : "operationDetails",
@@ -640,11 +627,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#how-can-i-define-which-column-will-be-deleted\" target=\"_blank\">column index documentation</a>",
     "type" : "Number"
   }, {
     "id" : "columnLetterIndex",
     "label" : "Column letter index",
-    "description" : "Enter the index of the column. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#how-can-i-define-which-column-will-be-deleted\" target=\"_blank\">documentation</a>",
     "optional" : false,
     "feel" : "optional",
     "group" : "operationDetails",
@@ -663,11 +650,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#how-can-i-define-which-column-will-be-deleted\" target=\"_blank\">column index documentation</a>",
     "type" : "String"
   }, {
     "id" : "deleteWorksheet.spreadsheetId",
     "label" : "Spreadsheet ID",
-    "description" : "Enter the ID of the spreadsheet",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -687,7 +674,6 @@
   }, {
     "id" : "deleteWorksheet.worksheetId",
     "label" : "Worksheet ID",
-    "description" : "Enter the ID of the worksheet",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -707,7 +693,6 @@
   }, {
     "id" : "getRowByIndex.spreadsheetId",
     "label" : "Spreadsheet ID",
-    "description" : "Enter the ID of the spreadsheet",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -727,7 +712,6 @@
   }, {
     "id" : "getRowByIndex.worksheetName",
     "label" : "Worksheet name",
-    "description" : "Enter name for the worksheet",
     "optional" : false,
     "feel" : "optional",
     "group" : "operationDetails",
@@ -744,7 +728,6 @@
   }, {
     "id" : "getRowByIndex.rowIndex",
     "label" : "Row index",
-    "description" : "Enter row index. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#what-is-a-row-index\" target=\"_blank\">documentation</a>",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -760,11 +743,11 @@
       "equals" : "getRowByIndex",
       "type" : "simple"
     },
+    "tooltip" : "Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#what-is-a-row-index\" target=\"_blank\">row index documentation</a>",
     "type" : "Number"
   }, {
     "id" : "spreadsheetsDetails.spreadsheetId",
     "label" : "Spreadsheet ID",
-    "description" : "Enter the ID of the spreadsheet",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -784,7 +767,6 @@
   }, {
     "id" : "getWorksheetData.spreadsheetId",
     "label" : "Spreadsheet ID",
-    "description" : "Enter the ID of the spreadsheet",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -804,7 +786,6 @@
   }, {
     "id" : "getWorksheetData.worksheetName",
     "label" : "Worksheet name",
-    "description" : "Enter name for the worksheet",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true

--- a/connectors/google/google-sheets/src/main/java/io/camunda/connector/gsheets/model/request/input/AddValues.java
+++ b/connectors/google/google-sheets/src/main/java/io/camunda/connector/gsheets/model/request/input/AddValues.java
@@ -46,7 +46,8 @@ public record AddValues(
     @TemplateProperty(
             label = "Cell ID",
             tooltip =
-                "Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#add-values-to-spreadsheet\" target=\"_blank\">Cell ID documentation</a>",
+                "Target cell in ColumnRow format. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#add-values-to-spreadsheet\" target=\"_blank\">add values to spreadsheet</a> operation.",
+            placeholder = "A1",
             group = "operationDetails",
             feel = FeelMode.optional,
             binding = @PropertyBinding(name = "operation.cellId"))

--- a/connectors/google/google-sheets/src/main/java/io/camunda/connector/gsheets/model/request/input/AddValues.java
+++ b/connectors/google/google-sheets/src/main/java/io/camunda/connector/gsheets/model/request/input/AddValues.java
@@ -30,7 +30,6 @@ public record AddValues(
     @TemplateProperty(
             id = "addValues.spreadsheetId",
             label = "Spreadsheet ID",
-            description = "Enter the ID of the spreadsheet",
             group = "operationDetails",
             feel = FeelMode.optional,
             binding = @PropertyBinding(name = "operation.spreadsheetId"))
@@ -39,7 +38,6 @@ public record AddValues(
     @TemplateProperty(
             id = "addValues.worksheetName",
             label = "Worksheet name",
-            description = "Enter name for the worksheet",
             group = "operationDetails",
             feel = FeelMode.optional,
             binding = @PropertyBinding(name = "operation.worksheetName"))
@@ -47,8 +45,8 @@ public record AddValues(
         String worksheetName,
     @TemplateProperty(
             label = "Cell ID",
-            description =
-                "Enter the ID of the cell. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#add-values-to-spreadsheet\" target=\"_blank\">documentation</a>",
+            tooltip =
+                "Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#add-values-to-spreadsheet\" target=\"_blank\">Cell ID documentation</a>",
             group = "operationDetails",
             feel = FeelMode.optional,
             binding = @PropertyBinding(name = "operation.cellId"))
@@ -56,7 +54,6 @@ public record AddValues(
         String cellId,
     @TemplateProperty(
             label = "Value",
-            description = "Enter the value",
             group = "operationDetails",
             feel = FeelMode.optional,
             constraints = @PropertyConstraints(notEmpty = true),

--- a/connectors/google/google-sheets/src/main/java/io/camunda/connector/gsheets/model/request/input/CreateEmptyColumnOrRow.java
+++ b/connectors/google/google-sheets/src/main/java/io/camunda/connector/gsheets/model/request/input/CreateEmptyColumnOrRow.java
@@ -57,7 +57,7 @@ public record CreateEmptyColumnOrRow(
     @TemplateProperty(
             label = "Start index",
             tooltip =
-                "Leave empty to add to the end of the sheet. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#create-empty-column-or-row\" target=\"_blank\">create empty column or row documentation</a>",
+                "Leave empty to add to the end of the sheet. Count starts from 0. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#create-empty-column-or-row\" target=\"_blank\">create empty column or row</a> operation.",
             group = "operationDetails",
             feel = FeelMode.optional,
             binding = @PropertyBinding(name = "operation.startIndex"))
@@ -65,7 +65,7 @@ public record CreateEmptyColumnOrRow(
     @TemplateProperty(
             label = "End index",
             tooltip =
-                "Leave empty to add to the end of the sheet. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#create-empty-column-or-row\" target=\"_blank\">create empty column or row documentation</a>",
+                "Leave empty to add to the end of the sheet. Count starts from 0. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#create-empty-column-or-row\" target=\"_blank\">create empty column or row</a> operation.",
             group = "operationDetails",
             feel = FeelMode.optional,
             binding = @PropertyBinding(name = "operation.endIndex"))

--- a/connectors/google/google-sheets/src/main/java/io/camunda/connector/gsheets/model/request/input/CreateEmptyColumnOrRow.java
+++ b/connectors/google/google-sheets/src/main/java/io/camunda/connector/gsheets/model/request/input/CreateEmptyColumnOrRow.java
@@ -31,7 +31,6 @@ public record CreateEmptyColumnOrRow(
     @TemplateProperty(
             id = "createEmptyColumnOrRow.spreadsheetId",
             label = "Spreadsheet ID",
-            description = "Enter the ID of the spreadsheet",
             group = "operationDetails",
             feel = FeelMode.optional,
             binding = @PropertyBinding(name = "operation.spreadsheetId"))
@@ -40,7 +39,6 @@ public record CreateEmptyColumnOrRow(
     @TemplateProperty(
             id = "createEmptyColumnOrRow.worksheetId",
             label = "Worksheet ID",
-            description = "Enter the ID of the worksheet",
             group = "operationDetails",
             feel = FeelMode.optional,
             constraints = @PropertyConstraints(notEmpty = true),
@@ -49,7 +47,7 @@ public record CreateEmptyColumnOrRow(
         Integer worksheetId,
     @TemplateProperty(
             label = "Dimension",
-            description = "Choose what to add: column or row",
+            tooltip = "What to add: column or row",
             group = "operationDetails",
             feel = FeelMode.optional,
             constraints = @PropertyConstraints(notEmpty = true),
@@ -58,16 +56,16 @@ public record CreateEmptyColumnOrRow(
         Dimension dimension,
     @TemplateProperty(
             label = "Start index",
-            description =
-                "Enter start index (leave empty if add to the end of the sheet). Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#create-empty-column-or-row\" target=\"_blank\">documentation</a>",
+            tooltip =
+                "Leave empty to add to the end of the sheet. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#create-empty-column-or-row\" target=\"_blank\">create empty column or row documentation</a>",
             group = "operationDetails",
             feel = FeelMode.optional,
             binding = @PropertyBinding(name = "operation.startIndex"))
         Integer startIndex,
     @TemplateProperty(
             label = "End index",
-            description =
-                "Enter end index (leave empty if add to the end of the sheet). Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#create-empty-column-or-row\" target=\"_blank\">documentation</a>",
+            tooltip =
+                "Leave empty to add to the end of the sheet. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#create-empty-column-or-row\" target=\"_blank\">create empty column or row documentation</a>",
             group = "operationDetails",
             feel = FeelMode.optional,
             binding = @PropertyBinding(name = "operation.endIndex"))

--- a/connectors/google/google-sheets/src/main/java/io/camunda/connector/gsheets/model/request/input/CreateRow.java
+++ b/connectors/google/google-sheets/src/main/java/io/camunda/connector/gsheets/model/request/input/CreateRow.java
@@ -41,7 +41,7 @@ public record CreateRow(
             id = "createRow.rowIndex",
             label = "Row index",
             tooltip =
-                "Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#what-is-a-row-index\" target=\"_blank\">row index documentation</a>",
+                "Position of the row, shown to the left of each row. If left empty, a new row is appended to the end. See <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#what-is-a-row-index\" target=\"_blank\">what is a row index</a>.",
             group = "operationDetails",
             feel = FeelMode.optional,
             constraints =
@@ -56,7 +56,7 @@ public record CreateRow(
     @TemplateProperty(
             label = "Enter values",
             tooltip =
-                "See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#create-row\" target=\"_blank\">create row value format</a>",
+                "List of cell values to add as a new row. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#create-row\" target=\"_blank\">create row</a> operation.",
             group = "operationDetails",
             feel = FeelMode.required,
             constraints = @PropertyConstraints(notEmpty = true),

--- a/connectors/google/google-sheets/src/main/java/io/camunda/connector/gsheets/model/request/input/CreateRow.java
+++ b/connectors/google/google-sheets/src/main/java/io/camunda/connector/gsheets/model/request/input/CreateRow.java
@@ -24,7 +24,6 @@ public record CreateRow(
     @TemplateProperty(
             id = "createRow.spreadsheetId",
             label = "Spreadsheet ID",
-            description = "Enter the ID of the spreadsheet",
             group = "operationDetails",
             feel = FeelMode.optional,
             binding = @PropertyBinding(name = "operation.spreadsheetId"))
@@ -33,7 +32,6 @@ public record CreateRow(
     @TemplateProperty(
             id = "createRow.worksheetName",
             label = "Worksheet name",
-            description = "Enter name for the worksheet",
             group = "operationDetails",
             feel = FeelMode.optional,
             binding = @PropertyBinding(name = "operation.worksheetName"))
@@ -42,8 +40,8 @@ public record CreateRow(
     @TemplateProperty(
             id = "createRow.rowIndex",
             label = "Row index",
-            description =
-                "Enter row index. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#what-is-a-row-index\" target=\"_blank\">documentation</a>",
+            tooltip =
+                "Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#what-is-a-row-index\" target=\"_blank\">row index documentation</a>",
             group = "operationDetails",
             feel = FeelMode.optional,
             constraints =
@@ -57,8 +55,8 @@ public record CreateRow(
         Integer rowIndex,
     @TemplateProperty(
             label = "Enter values",
-            description =
-                "Enter the array of values. <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#create-row\" target=\"_blank\">Learn more about the required format</a>",
+            tooltip =
+                "See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#create-row\" target=\"_blank\">create row value format</a>",
             group = "operationDetails",
             feel = FeelMode.required,
             constraints = @PropertyConstraints(notEmpty = true),

--- a/connectors/google/google-sheets/src/main/java/io/camunda/connector/gsheets/model/request/input/CreateSpreadsheet.java
+++ b/connectors/google/google-sheets/src/main/java/io/camunda/connector/gsheets/model/request/input/CreateSpreadsheet.java
@@ -34,7 +34,8 @@ public record CreateSpreadsheet(
         String spreadsheetName,
     @TemplateProperty(
             label = "Parent folder ID",
-            tooltip = "Enter the ID of the parent folder where the new spreadsheet will be created",
+            tooltip =
+                "Folder in which the new spreadsheet is created. If left empty, it is created in the Google Drive root folder of the OAuth token owner.",
             group = "operationDetails",
             optional = true,
             feel = FeelMode.optional,

--- a/connectors/google/google-sheets/src/main/java/io/camunda/connector/gsheets/model/request/input/CreateSpreadsheet.java
+++ b/connectors/google/google-sheets/src/main/java/io/camunda/connector/gsheets/model/request/input/CreateSpreadsheet.java
@@ -27,7 +27,6 @@ public record CreateSpreadsheet(
     @TemplateProperty(
             id = "createSpreadsheet.spreadsheetName",
             label = "Spreadsheet name",
-            description = "Enter name for the new spreadsheet",
             group = "operationDetails",
             feel = FeelMode.optional,
             binding = @PropertyBinding(name = "operation.spreadsheetName"))
@@ -35,7 +34,7 @@ public record CreateSpreadsheet(
         String spreadsheetName,
     @TemplateProperty(
             label = "Parent folder ID",
-            description = "Enter ID of the parent folder where new spreadsheet will be created",
+            tooltip = "Enter the ID of the parent folder where the new spreadsheet will be created",
             group = "operationDetails",
             optional = true,
             feel = FeelMode.optional,

--- a/connectors/google/google-sheets/src/main/java/io/camunda/connector/gsheets/model/request/input/CreateWorksheet.java
+++ b/connectors/google/google-sheets/src/main/java/io/camunda/connector/gsheets/model/request/input/CreateWorksheet.java
@@ -37,7 +37,7 @@ public record CreateWorksheet(
     @TemplateProperty(
             label = "Worksheet index",
             tooltip =
-                "Leave empty to add to the end of the sheet list. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#what-is-a-worksheet-index\" target=\"_blank\">worksheet index documentation</a>",
+                "Position of the new worksheet; count starts from 0. Leave empty to add it to the end of the sheet list. See <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#what-is-a-worksheet-index\" target=\"_blank\">what is a worksheet index</a>.",
             group = "operationDetails",
             feel = FeelMode.optional,
             binding = @PropertyBinding(name = "operation.worksheetIndex"))

--- a/connectors/google/google-sheets/src/main/java/io/camunda/connector/gsheets/model/request/input/CreateWorksheet.java
+++ b/connectors/google/google-sheets/src/main/java/io/camunda/connector/gsheets/model/request/input/CreateWorksheet.java
@@ -21,7 +21,6 @@ public record CreateWorksheet(
     @TemplateProperty(
             id = "createWorksheet.spreadsheetId",
             label = "Spreadsheet ID",
-            description = "Enter the ID of the spreadsheet",
             group = "operationDetails",
             feel = FeelMode.optional,
             binding = @PropertyBinding(name = "operation.spreadsheetId"))
@@ -30,7 +29,6 @@ public record CreateWorksheet(
     @TemplateProperty(
             id = "createWorksheet.worksheetName",
             label = "Worksheet name",
-            description = "Enter name for the worksheet",
             group = "operationDetails",
             feel = FeelMode.optional,
             binding = @PropertyBinding(name = "operation.worksheetName"))
@@ -38,8 +36,8 @@ public record CreateWorksheet(
         String worksheetName,
     @TemplateProperty(
             label = "Worksheet index",
-            description =
-                "Enter index of the place where to add worksheet (leave empty if add to the end of sheet list) Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#what-is-a-worksheet-index\" target=\"_blank\">documentation</a>",
+            tooltip =
+                "Leave empty to add to the end of the sheet list. See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#what-is-a-worksheet-index\" target=\"_blank\">worksheet index documentation</a>",
             group = "operationDetails",
             feel = FeelMode.optional,
             binding = @PropertyBinding(name = "operation.worksheetIndex"))

--- a/connectors/google/google-sheets/src/main/java/io/camunda/connector/gsheets/model/request/input/DeleteColumn.java
+++ b/connectors/google/google-sheets/src/main/java/io/camunda/connector/gsheets/model/request/input/DeleteColumn.java
@@ -44,7 +44,7 @@ public record DeleteColumn(
     @TemplateProperty(
             label = "Index format",
             tooltip =
-                "Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#how-can-i-define-which-column-will-be-deleted\" target=\"_blank\">column index format documentation</a>",
+                "How the column to delete is identified: Numbers (numeric index at the top of the column, starting from 0) or Letters (the column letter). See <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#how-can-i-define-which-column-will-be-deleted\" target=\"_blank\">defining which column will be deleted</a>.",
             group = "operationDetails",
             feel = FeelMode.optional,
             constraints = @PropertyConstraints(notEmpty = true),
@@ -59,7 +59,7 @@ public record DeleteColumn(
     @TemplateProperty(
             label = "Column numeric index",
             tooltip =
-                "Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#how-can-i-define-which-column-will-be-deleted\" target=\"_blank\">column index documentation</a>",
+                "Numeric position of the column to delete; count starts from 0 (column A is 0, B is 1). See <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#how-can-i-define-which-column-will-be-deleted\" target=\"_blank\">defining which column will be deleted</a>.",
             group = "operationDetails",
             feel = FeelMode.optional,
             binding = @PropertyBinding(name = "operation.columnNumberIndex"),
@@ -68,7 +68,8 @@ public record DeleteColumn(
     @TemplateProperty(
             label = "Column letter index",
             tooltip =
-                "Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#how-can-i-define-which-column-will-be-deleted\" target=\"_blank\">column index documentation</a>",
+                "Letter of the column to delete, as shown at the top of the column. See <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#how-can-i-define-which-column-will-be-deleted\" target=\"_blank\">defining which column will be deleted</a>.",
+            placeholder = "A",
             group = "operationDetails",
             feel = FeelMode.optional,
             binding = @PropertyBinding(name = "operation.columnLetterIndex"),

--- a/connectors/google/google-sheets/src/main/java/io/camunda/connector/gsheets/model/request/input/DeleteColumn.java
+++ b/connectors/google/google-sheets/src/main/java/io/camunda/connector/gsheets/model/request/input/DeleteColumn.java
@@ -27,7 +27,6 @@ public record DeleteColumn(
     @TemplateProperty(
             id = "deleteColumn.spreadsheetId",
             label = "Spreadsheet ID",
-            description = "Enter the ID of the spreadsheet",
             group = "operationDetails",
             feel = FeelMode.optional,
             binding = @PropertyBinding(name = "operation.spreadsheetId"))
@@ -36,7 +35,6 @@ public record DeleteColumn(
     @TemplateProperty(
             id = "deleteColumn.worksheetId",
             label = "Worksheet ID",
-            description = "Enter the ID of the worksheet",
             group = "operationDetails",
             feel = FeelMode.optional,
             constraints = @PropertyConstraints(notEmpty = true),
@@ -45,8 +43,8 @@ public record DeleteColumn(
         Integer worksheetId,
     @TemplateProperty(
             label = "Index format",
-            description =
-                "Choose the type of the index. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#how-can-i-define-which-column-will-be-deleted\" target=\"_blank\">documentation</a>",
+            tooltip =
+                "Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#how-can-i-define-which-column-will-be-deleted\" target=\"_blank\">column index format documentation</a>",
             group = "operationDetails",
             feel = FeelMode.optional,
             constraints = @PropertyConstraints(notEmpty = true),
@@ -60,8 +58,8 @@ public record DeleteColumn(
         ColumnIndexType columnIndexType,
     @TemplateProperty(
             label = "Column numeric index",
-            description =
-                "Enter the index of the column. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#how-can-i-define-which-column-will-be-deleted\" target=\"_blank\">documentation</a>",
+            tooltip =
+                "Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#how-can-i-define-which-column-will-be-deleted\" target=\"_blank\">column index documentation</a>",
             group = "operationDetails",
             feel = FeelMode.optional,
             binding = @PropertyBinding(name = "operation.columnNumberIndex"),
@@ -69,8 +67,8 @@ public record DeleteColumn(
         Integer columnNumberIndex,
     @TemplateProperty(
             label = "Column letter index",
-            description =
-                "Enter the index of the column. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#how-can-i-define-which-column-will-be-deleted\" target=\"_blank\">documentation</a>",
+            tooltip =
+                "Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#how-can-i-define-which-column-will-be-deleted\" target=\"_blank\">column index documentation</a>",
             group = "operationDetails",
             feel = FeelMode.optional,
             binding = @PropertyBinding(name = "operation.columnLetterIndex"),

--- a/connectors/google/google-sheets/src/main/java/io/camunda/connector/gsheets/model/request/input/DeleteWorksheet.java
+++ b/connectors/google/google-sheets/src/main/java/io/camunda/connector/gsheets/model/request/input/DeleteWorksheet.java
@@ -23,7 +23,6 @@ public record DeleteWorksheet(
     @TemplateProperty(
             id = "deleteWorksheet.spreadsheetId",
             label = "Spreadsheet ID",
-            description = "Enter the ID of the spreadsheet",
             group = "operationDetails",
             feel = FeelMode.optional,
             binding = @PropertyBinding(name = "operation.spreadsheetId"))
@@ -32,7 +31,6 @@ public record DeleteWorksheet(
     @TemplateProperty(
             id = "deleteWorksheet.worksheetId",
             label = "Worksheet ID",
-            description = "Enter the ID of the worksheet",
             group = "operationDetails",
             feel = FeelMode.optional,
             constraints = @PropertyConstraints(notEmpty = true),

--- a/connectors/google/google-sheets/src/main/java/io/camunda/connector/gsheets/model/request/input/GetRowByIndex.java
+++ b/connectors/google/google-sheets/src/main/java/io/camunda/connector/gsheets/model/request/input/GetRowByIndex.java
@@ -23,7 +23,6 @@ public record GetRowByIndex(
     @TemplateProperty(
             id = "getRowByIndex.spreadsheetId",
             label = "Spreadsheet ID",
-            description = "Enter the ID of the spreadsheet",
             group = "operationDetails",
             feel = FeelMode.optional,
             binding = @PropertyBinding(name = "operation.spreadsheetId"))
@@ -32,7 +31,6 @@ public record GetRowByIndex(
     @TemplateProperty(
             id = "getRowByIndex.worksheetName",
             label = "Worksheet name",
-            description = "Enter name for the worksheet",
             group = "operationDetails",
             feel = FeelMode.optional,
             binding = @PropertyBinding(name = "operation.worksheetName"))
@@ -40,8 +38,8 @@ public record GetRowByIndex(
     @TemplateProperty(
             id = "getRowByIndex.rowIndex",
             label = "Row index",
-            description =
-                "Enter row index. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#what-is-a-row-index\" target=\"_blank\">documentation</a>",
+            tooltip =
+                "Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#what-is-a-row-index\" target=\"_blank\">row index documentation</a>",
             group = "operationDetails",
             feel = FeelMode.optional,
             constraints = @PropertyConstraints(notEmpty = true),

--- a/connectors/google/google-sheets/src/main/java/io/camunda/connector/gsheets/model/request/input/GetRowByIndex.java
+++ b/connectors/google/google-sheets/src/main/java/io/camunda/connector/gsheets/model/request/input/GetRowByIndex.java
@@ -39,7 +39,7 @@ public record GetRowByIndex(
             id = "getRowByIndex.rowIndex",
             label = "Row index",
             tooltip =
-                "Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#what-is-a-row-index\" target=\"_blank\">row index documentation</a>",
+                "Position of the row to retrieve, shown to the left of each row. See <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/google-sheets/#what-is-a-row-index\" target=\"_blank\">what is a row index</a>.",
             group = "operationDetails",
             feel = FeelMode.optional,
             constraints = @PropertyConstraints(notEmpty = true),

--- a/connectors/google/google-sheets/src/main/java/io/camunda/connector/gsheets/model/request/input/GetSpreadsheetDetails.java
+++ b/connectors/google/google-sheets/src/main/java/io/camunda/connector/gsheets/model/request/input/GetSpreadsheetDetails.java
@@ -27,7 +27,6 @@ public record GetSpreadsheetDetails(
     @TemplateProperty(
             id = "spreadsheetsDetails.spreadsheetId",
             label = "Spreadsheet ID",
-            description = "Enter the ID of the spreadsheet",
             group = "operationDetails",
             feel = FeelMode.optional,
             binding = @PropertyBinding(name = "operation.spreadsheetId"))

--- a/connectors/google/google-sheets/src/main/java/io/camunda/connector/gsheets/model/request/input/GetWorksheetData.java
+++ b/connectors/google/google-sheets/src/main/java/io/camunda/connector/gsheets/model/request/input/GetWorksheetData.java
@@ -27,7 +27,6 @@ public record GetWorksheetData(
     @TemplateProperty(
             id = "getWorksheetData.spreadsheetId",
             label = "Spreadsheet ID",
-            description = "Enter the ID of the spreadsheet",
             group = "operationDetails",
             feel = FeelMode.optional,
             binding = @PropertyBinding(name = "operation.spreadsheetId"))
@@ -36,7 +35,6 @@ public record GetWorksheetData(
     @TemplateProperty(
             id = "getWorksheetData.worksheetName",
             label = "Worksheet name",
-            description = "Enter name for the worksheet",
             group = "operationDetails",
             feel = FeelMode.optional,
             binding = @PropertyBinding(name = "operation.worksheetName"))


### PR DESCRIPTION
Part of #7470. One of 8 review-sized slices of the `description` → `tooltip` migration (originally the umbrella PR #7651, split per review feedback for reviewability).

**Priority:** `tooltip` > `placeholder` > `description`. Field hints move to `tooltip=`; always-visible `description=` is kept only for value-constraints, `Note:`/`Warning:` markers, and genuinely critical guidance.

**Connectors in this slice:** google-sheets, google-drive, google-gemini, google-gcs (+ shared `google-base`).

Templates are regenerated from the migrated Java `@TemplateProperty` sources. Shared auth/base classes that feed agentic-ai-owned templates (aws-base, webhook) are excluded and handled in the `element-template-generator` follow-up.