### PR TITLE
refactor(microsoft): tooltip-first element-template field hints

### DIFF
--- a/connectors/microsoft/azure-blobstorage/element-templates/azure-blobstorage-outbound-connector.json
+++ b/connectors/microsoft/azure-blobstorage/element-templates/azure-blobstorage-outbound-connector.json
@@ -337,7 +337,6 @@
   }, {
     "id" : "authentication.SASToken",
     "label" : "SAS token",
-    "description" : "Shared access signature (SAS) token of the container. Learn more in our <a href=\"https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/azure-blob-storage/#prerequisites\">documentation</a>.",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -353,11 +352,11 @@
       "equals" : "SAS",
       "type" : "simple"
     },
+    "tooltip" : "Shared access signature (SAS) token of the container. Learn more in our <a href=\"https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/azure-blob-storage/#prerequisites\">Azure Blob Storage SAS token documentation</a>.",
     "type" : "String"
   }, {
     "id" : "authentication.SASUrl",
     "label" : "SAS URL",
-    "description" : "Shared access signature (SAS) URL of the container. Learn more in our <a href=\"https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/azure-blob-storage/#prerequisites\">documentation</a>.",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -373,11 +372,11 @@
       "equals" : "SAS",
       "type" : "simple"
     },
+    "tooltip" : "Shared access signature (SAS) URL of the container. Learn more in our <a href=\"https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/azure-blob-storage/#prerequisites\">Azure Blob Storage SAS token documentation</a>.",
     "type" : "String"
   }, {
     "id" : "authentication.tenantId",
     "label" : "Tenant id",
-    "description" : "The tenant id. Learn more in our <a href=\"https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/azure-blob-storage/#oauth-20\">documentation</a>.",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -393,11 +392,11 @@
       "equals" : "oAuth-client-credentials-flow",
       "type" : "simple"
     },
+    "tooltip" : "ID of the Microsoft Entra ID tenant that owns the application. Learn more in our <a href=\"https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/azure-blob-storage/#oauth-20\">Azure Blob Storage OAuth 2.0 documentation</a>.",
     "type" : "String"
   }, {
     "id" : "authentication.clientId",
     "label" : "Client id",
-    "description" : "The client if of the application. Learn more in our <a href=\"https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/azure-blob-storage/#oauth-20\">documentation</a>.",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -413,11 +412,11 @@
       "equals" : "oAuth-client-credentials-flow",
       "type" : "simple"
     },
+    "tooltip" : "Application (client) ID of the registered Microsoft Entra ID application. Learn more in our <a href=\"https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/azure-blob-storage/#oauth-20\">Azure Blob Storage OAuth 2.0 documentation</a>.",
     "type" : "String"
   }, {
     "id" : "authentication.clientSecret",
     "label" : "Client secret",
-    "description" : "The client secret of the application. Learn more in our <a href=\"https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/azure-blob-storage/#oauth-20\">documentation</a>.",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -433,11 +432,11 @@
       "equals" : "oAuth-client-credentials-flow",
       "type" : "simple"
     },
+    "tooltip" : "Client secret generated for the registered Microsoft Entra ID application. Learn more in our <a href=\"https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/azure-blob-storage/#oauth-20\">Azure Blob Storage OAuth 2.0 documentation</a>.",
     "type" : "String"
   }, {
     "id" : "authentication.accountUrl",
     "label" : "Account url",
-    "description" : "The account url of the storage account. Learn more in our <a href=\"https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/azure-blob-storage/#oauth-20\">documentation</a>.",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -453,6 +452,7 @@
       "equals" : "oAuth-client-credentials-flow",
       "type" : "simple"
     },
+    "tooltip" : "URL of the Azure Blob Storage account to connect to. Learn more in our <a href=\"https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/azure-blob-storage/#oauth-20\">Azure Blob Storage OAuth 2.0 documentation</a>.",
     "type" : "String"
   }, {
     "id" : "uploadOperationFileName",

--- a/connectors/microsoft/azure-blobstorage/element-templates/hybrid/azure-blobstorage-outbound-connector-hybrid.json
+++ b/connectors/microsoft/azure-blobstorage/element-templates/hybrid/azure-blobstorage-outbound-connector-hybrid.json
@@ -342,7 +342,6 @@
   }, {
     "id" : "authentication.SASToken",
     "label" : "SAS token",
-    "description" : "Shared access signature (SAS) token of the container. Learn more in our <a href=\"https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/azure-blob-storage/#prerequisites\">documentation</a>.",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -358,11 +357,11 @@
       "equals" : "SAS",
       "type" : "simple"
     },
+    "tooltip" : "Shared access signature (SAS) token of the container. Learn more in our <a href=\"https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/azure-blob-storage/#prerequisites\">Azure Blob Storage SAS token documentation</a>.",
     "type" : "String"
   }, {
     "id" : "authentication.SASUrl",
     "label" : "SAS URL",
-    "description" : "Shared access signature (SAS) URL of the container. Learn more in our <a href=\"https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/azure-blob-storage/#prerequisites\">documentation</a>.",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -378,11 +377,11 @@
       "equals" : "SAS",
       "type" : "simple"
     },
+    "tooltip" : "Shared access signature (SAS) URL of the container. Learn more in our <a href=\"https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/azure-blob-storage/#prerequisites\">Azure Blob Storage SAS token documentation</a>.",
     "type" : "String"
   }, {
     "id" : "authentication.tenantId",
     "label" : "Tenant id",
-    "description" : "The tenant id. Learn more in our <a href=\"https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/azure-blob-storage/#oauth-20\">documentation</a>.",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -398,11 +397,11 @@
       "equals" : "oAuth-client-credentials-flow",
       "type" : "simple"
     },
+    "tooltip" : "ID of the Microsoft Entra ID tenant that owns the application. Learn more in our <a href=\"https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/azure-blob-storage/#oauth-20\">Azure Blob Storage OAuth 2.0 documentation</a>.",
     "type" : "String"
   }, {
     "id" : "authentication.clientId",
     "label" : "Client id",
-    "description" : "The client if of the application. Learn more in our <a href=\"https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/azure-blob-storage/#oauth-20\">documentation</a>.",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -418,11 +417,11 @@
       "equals" : "oAuth-client-credentials-flow",
       "type" : "simple"
     },
+    "tooltip" : "Application (client) ID of the registered Microsoft Entra ID application. Learn more in our <a href=\"https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/azure-blob-storage/#oauth-20\">Azure Blob Storage OAuth 2.0 documentation</a>.",
     "type" : "String"
   }, {
     "id" : "authentication.clientSecret",
     "label" : "Client secret",
-    "description" : "The client secret of the application. Learn more in our <a href=\"https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/azure-blob-storage/#oauth-20\">documentation</a>.",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -438,11 +437,11 @@
       "equals" : "oAuth-client-credentials-flow",
       "type" : "simple"
     },
+    "tooltip" : "Client secret generated for the registered Microsoft Entra ID application. Learn more in our <a href=\"https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/azure-blob-storage/#oauth-20\">Azure Blob Storage OAuth 2.0 documentation</a>.",
     "type" : "String"
   }, {
     "id" : "authentication.accountUrl",
     "label" : "Account url",
-    "description" : "The account url of the storage account. Learn more in our <a href=\"https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/azure-blob-storage/#oauth-20\">documentation</a>.",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -458,6 +457,7 @@
       "equals" : "oAuth-client-credentials-flow",
       "type" : "simple"
     },
+    "tooltip" : "URL of the Azure Blob Storage account to connect to. Learn more in our <a href=\"https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/azure-blob-storage/#oauth-20\">Azure Blob Storage OAuth 2.0 documentation</a>.",
     "type" : "String"
   }, {
     "id" : "uploadOperationFileName",

--- a/connectors/microsoft/azure-blobstorage/src/main/java/io/camunda/connector/azure/blobstorage/model/request/auth/OAuthAuthentication.java
+++ b/connectors/microsoft/azure-blobstorage/src/main/java/io/camunda/connector/azure/blobstorage/model/request/auth/OAuthAuthentication.java
@@ -19,32 +19,32 @@ public record OAuthAuthentication(
     @FEEL
         @TemplateProperty(
             group = "authentication",
-            description =
-                "The tenant id. Learn more in our <a href=\"https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/azure-blob-storage/#oauth-20\">documentation</a>.",
+            tooltip =
+                "Learn more in our <a href=\"https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/azure-blob-storage/#oauth-20\">Azure Blob Storage OAuth 2.0 documentation</a>.",
             feel = FeelMode.optional)
         @NotBlank
         String tenantId,
     @FEEL
         @TemplateProperty(
             group = "authentication",
-            description =
-                "The client if of the application. Learn more in our <a href=\"https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/azure-blob-storage/#oauth-20\">documentation</a>.",
+            tooltip =
+                "Learn more in our <a href=\"https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/azure-blob-storage/#oauth-20\">Azure Blob Storage OAuth 2.0 documentation</a>.",
             feel = FeelMode.optional)
         @NotBlank
         String clientId,
     @FEEL
         @TemplateProperty(
             group = "authentication",
-            description =
-                "The client secret of the application. Learn more in our <a href=\"https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/azure-blob-storage/#oauth-20\">documentation</a>.",
+            tooltip =
+                "Learn more in our <a href=\"https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/azure-blob-storage/#oauth-20\">Azure Blob Storage OAuth 2.0 documentation</a>.",
             feel = FeelMode.optional)
         @NotBlank
         String clientSecret,
     @FEEL
         @TemplateProperty(
             group = "authentication",
-            description =
-                "The account url of the storage account. Learn more in our <a href=\"https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/azure-blob-storage/#oauth-20\">documentation</a>.",
+            tooltip =
+                "Learn more in our <a href=\"https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/azure-blob-storage/#oauth-20\">Azure Blob Storage OAuth 2.0 documentation</a>.",
             feel = FeelMode.optional)
         @NotBlank
         String accountUrl)

--- a/connectors/microsoft/azure-blobstorage/src/main/java/io/camunda/connector/azure/blobstorage/model/request/auth/OAuthAuthentication.java
+++ b/connectors/microsoft/azure-blobstorage/src/main/java/io/camunda/connector/azure/blobstorage/model/request/auth/OAuthAuthentication.java
@@ -20,7 +20,7 @@ public record OAuthAuthentication(
         @TemplateProperty(
             group = "authentication",
             tooltip =
-                "Learn more in our <a href=\"https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/azure-blob-storage/#oauth-20\">Azure Blob Storage OAuth 2.0 documentation</a>.",
+                "ID of the Microsoft Entra ID tenant that owns the application. Learn more in our <a href=\"https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/azure-blob-storage/#oauth-20\">Azure Blob Storage OAuth 2.0 documentation</a>.",
             feel = FeelMode.optional)
         @NotBlank
         String tenantId,
@@ -28,7 +28,7 @@ public record OAuthAuthentication(
         @TemplateProperty(
             group = "authentication",
             tooltip =
-                "Learn more in our <a href=\"https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/azure-blob-storage/#oauth-20\">Azure Blob Storage OAuth 2.0 documentation</a>.",
+                "Application (client) ID of the registered Microsoft Entra ID application. Learn more in our <a href=\"https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/azure-blob-storage/#oauth-20\">Azure Blob Storage OAuth 2.0 documentation</a>.",
             feel = FeelMode.optional)
         @NotBlank
         String clientId,
@@ -36,7 +36,7 @@ public record OAuthAuthentication(
         @TemplateProperty(
             group = "authentication",
             tooltip =
-                "Learn more in our <a href=\"https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/azure-blob-storage/#oauth-20\">Azure Blob Storage OAuth 2.0 documentation</a>.",
+                "Client secret generated for the registered Microsoft Entra ID application. Learn more in our <a href=\"https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/azure-blob-storage/#oauth-20\">Azure Blob Storage OAuth 2.0 documentation</a>.",
             feel = FeelMode.optional)
         @NotBlank
         String clientSecret,
@@ -44,7 +44,7 @@ public record OAuthAuthentication(
         @TemplateProperty(
             group = "authentication",
             tooltip =
-                "Learn more in our <a href=\"https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/azure-blob-storage/#oauth-20\">Azure Blob Storage OAuth 2.0 documentation</a>.",
+                "URL of the Azure Blob Storage account to connect to. Learn more in our <a href=\"https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/azure-blob-storage/#oauth-20\">Azure Blob Storage OAuth 2.0 documentation</a>.",
             feel = FeelMode.optional)
         @NotBlank
         String accountUrl)

--- a/connectors/microsoft/azure-blobstorage/src/main/java/io/camunda/connector/azure/blobstorage/model/request/auth/SASAuthentication.java
+++ b/connectors/microsoft/azure-blobstorage/src/main/java/io/camunda/connector/azure/blobstorage/model/request/auth/SASAuthentication.java
@@ -20,8 +20,8 @@ public record SASAuthentication(
         @TemplateProperty(
             group = "authentication",
             label = "SAS token",
-            description =
-                "Shared access signature (SAS) token of the container. Learn more in our <a href=\"https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/azure-blob-storage/#prerequisites\">documentation</a>.",
+            tooltip =
+                "Shared access signature (SAS) token of the container. Learn more in our <a href=\"https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/azure-blob-storage/#prerequisites\">Azure Blob Storage SAS token documentation</a>.",
             feel = FeelMode.optional)
         @NotBlank
         String SASToken,
@@ -29,8 +29,8 @@ public record SASAuthentication(
         @TemplateProperty(
             group = "authentication",
             label = "SAS URL",
-            description =
-                "Shared access signature (SAS) URL of the container. Learn more in our <a href=\"https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/azure-blob-storage/#prerequisites\">documentation</a>.",
+            tooltip =
+                "Shared access signature (SAS) URL of the container. Learn more in our <a href=\"https://docs.camunda.io/docs/8.9/components/connectors/out-of-the-box-connectors/azure-blob-storage/#prerequisites\">Azure Blob Storage SAS token documentation</a>.",
             feel = FeelMode.optional)
         @NotBlank
         String SASUrl)

--- a/connectors/microsoft/azure-open-ai/element-templates/azure-open-ai-connector.json
+++ b/connectors/microsoft/azure-open-ai/element-templates/azure-open-ai-connector.json
@@ -154,7 +154,7 @@
     },
     {
       "label": "Resource name",
-      "description": "The name of your Azure OpenAI Resource. <a href=\"https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#completions\" target=\"_blank\">See documentation</a>",
+      "tooltip": "The name of your Azure OpenAI Resource. <a href=\"https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#completions\" target=\"_blank\">Azure OpenAI completions documentation</a>",
       "group": "operation",
       "type": "String",
       "feel": "optional",
@@ -172,7 +172,7 @@
     },
     {
       "label": "Deployment ID",
-      "description": "The deployment name you chose when you deployed the model. <a href=\"https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#completions\" target=\"_blank\">See documentation</a>",
+      "tooltip": "The deployment name you chose when you deployed the model. <a href=\"https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#completions\" target=\"_blank\">Azure OpenAI completions documentation</a>",
       "group": "operation",
       "type": "String",
       "feel": "optional",
@@ -190,7 +190,7 @@
     },
     {
       "label": "API version",
-      "description": "The API version to use for this operation. <a href=\"https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#completions\" target=\"_blank\">See documentation</a>",
+      "tooltip": "The API version to use for this operation. <a href=\"https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#completions\" target=\"_blank\">Azure OpenAI completions documentation</a>",
       "group": "operation",
       "type": "String",
       "value": "2024-02-01",
@@ -209,7 +209,7 @@
     },
     {
       "label": "Prompt",
-      "description": "The prompt or prompts to generate completions for, encoded as a string, or array of strings. <a href=\"https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#completions\" target=\"_blank\">See documentation</a>",
+      "description": "The prompt or prompts to generate completions for, encoded as a string, or array of strings. <a href=\"https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#completions\" target=\"_blank\">Azure OpenAI completions documentation</a>",
       "group": "parameters",
       "type": "Text",
       "feel": "optional",
@@ -227,7 +227,7 @@
     },
     {
       "label": "Max tokens",
-      "description": "The maximum number of tokens to generate in the completion. <a href=\"https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#completions\" target=\"_blank\">See documentation</a>",
+      "tooltip": "The maximum number of tokens to generate in the completion. <a href=\"https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#completions\" target=\"_blank\">Azure OpenAI completions documentation</a>",
       "group": "parameters",
       "type": "String",
       "value": "16",
@@ -244,7 +244,7 @@
     },
     {
       "label": "Temperature",
-      "description": "What sampling temperature to use, between 0 and 2. <a href=\"https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#completions\" target=\"_blank\">See documentation</a>",
+      "description": "What sampling temperature to use, between 0 and 2. <a href=\"https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#completions\" target=\"_blank\">Azure OpenAI completions documentation</a>",
       "group": "parameters",
       "type": "String",
       "value": "1",
@@ -261,7 +261,7 @@
     },
     {
       "label": "Top P",
-      "description": "An alternative to sampling with temperature, AKA nucleus sampling. <a href=\"https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#completions\" target=\"_blank\">See documentation</a>",
+      "tooltip": "An alternative to sampling with temperature, AKA nucleus sampling. <a href=\"https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#completions\" target=\"_blank\">Azure OpenAI completions documentation</a>",
       "group": "parameters",
       "type": "String",
       "value": "1",
@@ -278,7 +278,7 @@
     },
     {
       "label": "Logit bias",
-      "description": "Modify the likelihood of specified tokens appearing in the completion. <a href=\"https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#completions\" target=\"_blank\">See documentation</a>",
+      "tooltip": "Modify the likelihood of specified tokens appearing in the completion. <a href=\"https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#completions\" target=\"_blank\">Azure OpenAI completions documentation</a>",
       "group": "parameters",
       "type": "Text",
       "feel": "required",
@@ -294,7 +294,7 @@
     },
     {
       "label": "User",
-      "description": "A unique identifier representing your end-user. <a href=\"https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#completions\" target=\"_blank\">See documentation</a>",
+      "tooltip": "A unique identifier representing your end-user. <a href=\"https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#completions\" target=\"_blank\">Azure OpenAI completions documentation</a>",
       "group": "parameters",
       "type": "String",
       "optional": true,
@@ -309,7 +309,7 @@
     },
     {
       "label": "Number of completions",
-      "description": "How many completions to generate for each prompt. <a href=\"https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#completions\" target=\"_blank\">See documentation</a>",
+      "tooltip": "How many completions to generate for each prompt. <a href=\"https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#completions\" target=\"_blank\">Azure OpenAI completions documentation</a>",
       "group": "parameters",
       "value": "1",
       "type": "String",
@@ -325,7 +325,7 @@
     },
     {
       "label": "Stream",
-      "description": "Whether to stream back partial progress. <a href=\"https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#completions\" target=\"_blank\">See documentation</a>",
+      "tooltip": "Whether to stream back partial progress. <a href=\"https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#completions\" target=\"_blank\">Azure OpenAI completions documentation</a>",
       "group": "parameters",
       "value": "False",
       "type": "Dropdown",
@@ -350,7 +350,7 @@
     },
     {
       "label": "Log probabilities",
-      "description": "Include the log probabilities on the logprobs most likely tokens, as well the chosen tokens. <a href=\"https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#completions\" target=\"_blank\">See documentation</a>",
+      "tooltip": "Include the log probabilities on the logprobs most likely tokens, as well as the chosen tokens. <a href=\"https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#completions\" target=\"_blank\">Azure OpenAI completions documentation</a>",
       "group": "parameters",
       "type": "String",
       "optional": true,
@@ -365,7 +365,7 @@
     },
     {
       "label": "Suffix",
-      "description": "The suffix that comes after a completion of inserted text. <a href=\"https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#completions\" target=\"_blank\">See documentation</a>",
+      "tooltip": "The suffix that comes after a completion of inserted text. <a href=\"https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#completions\" target=\"_blank\">Azure OpenAI completions documentation</a>",
       "group": "parameters",
       "type": "String",
       "optional": true,
@@ -380,7 +380,7 @@
     },
     {
       "label": "Echo",
-      "description": "Echo back the prompt in addition to the completion. <a href=\"https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#completions\" target=\"_blank\">See documentation</a>",
+      "tooltip": "Echo back the prompt in addition to the completion. <a href=\"https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#completions\" target=\"_blank\">Azure OpenAI completions documentation</a>",
       "group": "parameters",
       "value": "False",
       "type": "Dropdown",
@@ -406,7 +406,7 @@
     },
     {
       "label": "Stop",
-      "description": "Up to four sequences where the API will stop generating further tokens. <a href=\"https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#completions\" target=\"_blank\">See documentation</a>",
+      "description": "Up to four sequences where the API will stop generating further tokens. <a href=\"https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#completions\" target=\"_blank\">Azure OpenAI completions documentation</a>",
       "group": "parameters",
       "type": "String",
       "optional": true,
@@ -421,7 +421,7 @@
     },
     {
       "label": "Presence penalty",
-      "description": "Positive values penalize new tokens based on whether they appear in the text so far. <a href=\"https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#completions\" target=\"_blank\">See documentation</a>",
+      "tooltip": "Positive values penalize new tokens based on whether they appear in the text so far. <a href=\"https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#completions\" target=\"_blank\">Azure OpenAI completions documentation</a>",
       "group": "parameters",
       "type": "String",
       "value": "0",
@@ -437,7 +437,7 @@
     },
     {
       "label": "Frequency penalty",
-      "description": "Positive values penalize new tokens based on their existing frequency in the text so far. <a href=\"https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#completions\" target=\"_blank\">See documentation</a>",
+      "tooltip": "Positive values penalize new tokens based on their existing frequency in the text so far. <a href=\"https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#completions\" target=\"_blank\">Azure OpenAI completions documentation</a>",
       "group": "parameters",
       "type": "String",
       "value": "0",
@@ -453,7 +453,7 @@
     },
     {
       "label": "Best of",
-      "description": "Generates 'best of' completions server-side and returns the \"best\". <a href=\"https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#completions\" target=\"_blank\">See documentation</a>",
+      "tooltip": "Generates 'best of' completions server-side and returns the \"best\". <a href=\"https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#completions\" target=\"_blank\">Azure OpenAI completions documentation</a>",
       "group": "parameters",
       "type": "String",
       "value": "1",
@@ -508,7 +508,7 @@
     },
     {
       "label": "Resource name",
-      "description": "The name of your Azure OpenAI Resource. <a href=\"https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#chat-completions\" target=\"_blank\">See documentation</a>",
+      "tooltip": "The name of your Azure OpenAI Resource. <a href=\"https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#chat-completions\" target=\"_blank\">Azure OpenAI chat completions documentation</a>",
       "group": "operation",
       "type": "String",
       "feel": "optional",
@@ -526,7 +526,7 @@
     },
     {
       "label": "Deployment ID",
-      "description": "The deployment name you chose when you deployed the model. <a href=\"https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#chat-completions\" target=\"_blank\">See documentation</a>",
+      "tooltip": "The deployment name you chose when you deployed the model. <a href=\"https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#chat-completions\" target=\"_blank\">Azure OpenAI chat completions documentation</a>",
       "group": "operation",
       "type": "String",
       "feel": "optional",
@@ -544,7 +544,7 @@
     },
     {
       "label": "API version",
-      "description": "The API version to use for this operation. <a href=\"https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#chat-completions\" target=\"_blank\">See documentation</a>",
+      "tooltip": "The API version to use for this operation. <a href=\"https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#chat-completions\" target=\"_blank\">Azure OpenAI chat completions documentation</a>",
       "group": "operation",
       "type": "String",
       "value": "2024-02-01",
@@ -563,7 +563,7 @@
     },
     {
       "label": "Message role",
-      "description": "Indicates who is giving the current message",
+      "tooltip": "Indicates who is giving the current message",
       "group": "parameters",
       "type": "Dropdown",
       "value": "user",
@@ -600,7 +600,7 @@
     },
     {
       "label": "Message content",
-      "description": "The content of the message. <a href=\"https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#chat-completions\" target=\"_blank\">See documentation</a>",
+      "tooltip": "The content of the message. <a href=\"https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#chat-completions\" target=\"_blank\">Azure OpenAI chat completions documentation</a>",
       "group": "parameters",
       "type": "Text",
       "feel": "optional",
@@ -619,7 +619,7 @@
     },
     {
       "label": "Messages context",
-      "description": "The array of messages associated with this chat completion request. <a href=\"https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#chat-completions\" target=\"_blank\">See documentation</a>",
+      "tooltip": "The array of messages associated with this chat completion request. <a href=\"https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#chat-completions\" target=\"_blank\">Azure OpenAI chat completions documentation</a>",
       "group": "parameters",
       "type": "Text",
       "feel": "required",
@@ -635,7 +635,7 @@
     },
     {
       "label": "Content part",
-      "description": "Part of a user's multi-modal message. <a href=\"https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#chat-completions\" target=\"_blank\">See documentation</a>",
+      "tooltip": "Part of a user's multi-modal message. <a href=\"https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#chat-completions\" target=\"_blank\">Azure OpenAI chat completions documentation</a>",
       "group": "parameters",
       "type": "String",
       "feel": "required",
@@ -651,7 +651,7 @@
     },
     {
       "label": "Enhancements",
-      "description": "Represents the Vision enhancement features requested for the chat. <a href=\"https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#chat-completions\" target=\"_blank\">See documentation</a>",
+      "tooltip": "Represents the Vision enhancement features requested for the chat. <a href=\"https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#chat-completions\" target=\"_blank\">Azure OpenAI chat completions documentation</a>",
       "group": "parameters",
       "type": "String",
       "feel": "required",
@@ -667,7 +667,7 @@
     },
     {
       "label": "Temperature",
-      "description": "What sampling temperature to use, between 0 and 2. <a href=\"https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#chat-completions\" target=\"_blank\">See documentation</a>",
+      "description": "What sampling temperature to use, between 0 and 2. <a href=\"https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#chat-completions\" target=\"_blank\">Azure OpenAI chat completions documentation</a>",
       "value": "1",
       "group": "parameters",
       "type": "String",
@@ -684,7 +684,7 @@
     },
     {
       "label": "Number of completions",
-      "description": "How many completions to generate for each prompt. <a href=\"https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#chat-completions\" target=\"_blank\">See documentation</a>",
+      "tooltip": "How many completions to generate for each prompt. <a href=\"https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#chat-completions\" target=\"_blank\">Azure OpenAI chat completions documentation</a>",
       "value": "1",
       "group": "parameters",
       "type": "String",
@@ -701,7 +701,7 @@
     },
     {
       "label": "Stream",
-      "description": "Whether to stream back partial progress. <a href=\"https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#chat-completions\" target=\"_blank\">See documentation</a>",
+      "tooltip": "Whether to stream back partial progress. <a href=\"https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#chat-completions\" target=\"_blank\">Azure OpenAI chat completions documentation</a>",
       "value": "False",
       "group": "parameters",
       "type": "Dropdown",
@@ -726,7 +726,7 @@
     },
     {
       "label": "Stop",
-      "description": "Up to four sequences where the API will stop generating further tokens. <a href=\"https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#chat-completions\" target=\"_blank\">See documentation</a>",
+      "description": "Up to four sequences where the API will stop generating further tokens. <a href=\"https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#chat-completions\" target=\"_blank\">Azure OpenAI chat completions documentation</a>",
       "group": "parameters",
       "type": "String",
       "feel": "required",
@@ -742,7 +742,7 @@
     },
     {
       "label": "Max tokens",
-      "description": "The maximum number of tokens to generate in the completion. <a href=\"https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#chat-completions\" target=\"_blank\">See documentation</a>",
+      "tooltip": "The maximum number of tokens to generate in the completion. <a href=\"https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#chat-completions\" target=\"_blank\">Azure OpenAI chat completions documentation</a>",
       "group": "parameters",
       "type": "String",
       "feel": "optional",
@@ -758,7 +758,7 @@
     },
     {
       "label": "Presence penalty",
-      "description": "Positive values penalize new tokens based on whether they appear in the text so far. <a href=\"https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#chat-completions\" target=\"_blank\">See documentation</a>",
+      "tooltip": "Positive values penalize new tokens based on whether they appear in the text so far. <a href=\"https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#chat-completions\" target=\"_blank\">Azure OpenAI chat completions documentation</a>",
       "group": "parameters",
       "type": "String",
       "feel": "optional",
@@ -774,7 +774,7 @@
     },
     {
       "label": "Frequency penalty",
-      "description": "Positive values penalize new tokens based on their existing frequency in the text so far. <a href=\"https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#chat-completions\" target=\"_blank\">See documentation</a>",
+      "tooltip": "Positive values penalize new tokens based on their existing frequency in the text so far. <a href=\"https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#chat-completions\" target=\"_blank\">Azure OpenAI chat completions documentation</a>",
       "group": "parameters",
       "type": "String",
       "feel": "optional",
@@ -790,7 +790,7 @@
     },
     {
       "label": "Logit bias",
-      "description": "Modify the likelihood of specified tokens appearing in the completion. <a href=\"https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#chat-completions\" target=\"_blank\">See documentation</a>",
+      "tooltip": "Modify the likelihood of specified tokens appearing in the completion. <a href=\"https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#chat-completions\" target=\"_blank\">Azure OpenAI chat completions documentation</a>",
       "group": "parameters",
       "type": "String",
       "feel": "required",
@@ -806,7 +806,7 @@
     },
     {
       "label": "User",
-      "description": "A unique identifier representing your end-user. <a href=\"https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#chat-completions\" target=\"_blank\">See documentation</a>",
+      "tooltip": "A unique identifier representing your end-user. <a href=\"https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#chat-completions\" target=\"_blank\">Azure OpenAI chat completions documentation</a>",
       "group": "parameters",
       "type": "String",
       "feel": "optional",
@@ -822,7 +822,7 @@
     },
     {
       "label": "Tools",
-      "description": "A list of tools the model can call. <a href=\"https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#chat-completions\" target=\"_blank\">See documentation</a>",
+      "tooltip": "A list of tools the model can call. <a href=\"https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#chat-completions\" target=\"_blank\">Azure OpenAI chat completions documentation</a>",
       "group": "parameters",
       "type": "String",
       "feel": "optional",
@@ -838,7 +838,7 @@
     },
     {
       "label": "Data sources",
-      "description": "Represents additional resource data. <a href=\"https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#chat-completions\" target=\"_blank\">See documentation</a>",
+      "tooltip": "Represents additional resource data. <a href=\"https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#chat-completions\" target=\"_blank\">Azure OpenAI chat completions documentation</a>",
       "group": "parameters",
       "type": "String",
       "feel": "required",
@@ -893,7 +893,7 @@
     },
     {
       "label": "Resource name",
-      "description": "The name of your Azure OpenAI Resource. <a href=\"https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#completions-extensions\" target=\"_blank\">See documentation</a>",
+      "tooltip": "The name of your Azure OpenAI Resource. <a href=\"https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#completions-extensions\" target=\"_blank\">Azure OpenAI completions extensions documentation</a>",
       "group": "operation",
       "type": "String",
       "feel": "optional",
@@ -911,7 +911,7 @@
     },
     {
       "label": "Deployment ID",
-      "description": "The deployment name you chose when you deployed the model. <a href=\"https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#completions-extensions\" target=\"_blank\">See documentation</a>",
+      "tooltip": "The deployment name you chose when you deployed the model. <a href=\"https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#completions-extensions\" target=\"_blank\">Azure OpenAI completions extensions documentation</a>",
       "group": "operation",
       "type": "String",
       "feel": "optional",
@@ -929,7 +929,7 @@
     },
     {
       "label": "API version",
-      "description": "The API version to use for this operation. <a href=\"https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#completions-extensions\" target=\"_blank\">See documentation</a>",
+      "tooltip": "The API version to use for this operation. <a href=\"https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#completions-extensions\" target=\"_blank\">Azure OpenAI completions extensions documentation</a>",
       "group": "operation",
       "type": "String",
       "value": "2023-12-01-preview",
@@ -948,7 +948,7 @@
     },
     {
       "label": "Messages",
-      "description": "The array of messages associated with this chat completion request. <a href=\"https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#completions-extensions\" target=\"_blank\">See documentation</a>",
+      "tooltip": "The array of messages associated with this chat completion request. <a href=\"https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#completions-extensions\" target=\"_blank\">Azure OpenAI completions extensions documentation</a>",
       "group": "parameters",
       "type": "String",
       "feel": "required",
@@ -967,7 +967,7 @@
     },
     {
       "label": "Content part",
-      "description": "Part of a user's multi-modal message. <a href=\"https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#completions-extensions\" target=\"_blank\">See documentation</a>",
+      "tooltip": "Part of a user's multi-modal message. <a href=\"https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#completions-extensions\" target=\"_blank\">Azure OpenAI completions extensions documentation</a>",
       "group": "parameters",
       "type": "String",
       "feel": "required",
@@ -983,7 +983,7 @@
     },
     {
       "label": "Enhancements",
-      "description": "Represents the Vision enhancement features requested for the chat. <a href=\"https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#completions-extensions\" target=\"_blank\">See documentation</a>",
+      "tooltip": "Represents the Vision enhancement features requested for the chat. <a href=\"https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#completions-extensions\" target=\"_blank\">Azure OpenAI completions extensions documentation</a>",
       "group": "parameters",
       "type": "String",
       "feel": "required",
@@ -999,7 +999,7 @@
     },
     {
       "label": "Temperature",
-      "description": "What sampling temperature to use, between 0 and 2. <a href=\"https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#completions-extensions\" target=\"_blank\">See documentation</a>",
+      "description": "What sampling temperature to use, between 0 and 2. <a href=\"https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#completions-extensions\" target=\"_blank\">Azure OpenAI completions extensions documentation</a>",
       "value": "1",
       "group": "parameters",
       "type": "String",
@@ -1016,7 +1016,7 @@
     },
     {
       "label": "Number of completions",
-      "description": "How many completions to generate for each prompt. <a href=\"https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#completions-extensions\" target=\"_blank\">See documentation</a>",
+      "tooltip": "How many completions to generate for each prompt. <a href=\"https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#completions-extensions\" target=\"_blank\">Azure OpenAI completions extensions documentation</a>",
       "value": "1",
       "group": "parameters",
       "type": "String",
@@ -1033,7 +1033,7 @@
     },
     {
       "label": "Stream",
-      "description": "Whether to stream back partial progress. <a href=\"https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#completions-extensions\" target=\"_blank\">See documentation</a>",
+      "tooltip": "Whether to stream back partial progress. <a href=\"https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#completions-extensions\" target=\"_blank\">Azure OpenAI completions extensions documentation</a>",
       "value": "False",
       "group": "parameters",
       "type": "Dropdown",
@@ -1058,7 +1058,7 @@
     },
     {
       "label": "Stop",
-      "description": "Up to four sequences where the API will stop generating further tokens. <a href=\"https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#completions-extensions\" target=\"_blank\">See documentation</a>",
+      "description": "Up to four sequences where the API will stop generating further tokens. <a href=\"https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#completions-extensions\" target=\"_blank\">Azure OpenAI completions extensions documentation</a>",
       "group": "parameters",
       "type": "String",
       "feel": "required",
@@ -1074,7 +1074,7 @@
     },
     {
       "label": "Max tokens",
-      "description": "The maximum number of tokens to generate in the completion. <a href=\"https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#completions-extensions\" target=\"_blank\">See documentation</a>",
+      "tooltip": "The maximum number of tokens to generate in the completion. <a href=\"https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#completions-extensions\" target=\"_blank\">Azure OpenAI completions extensions documentation</a>",
       "group": "parameters",
       "type": "String",
       "feel": "optional",
@@ -1090,7 +1090,7 @@
     },
     {
       "label": "Presence penalty",
-      "description": "Positive values penalize new tokens based on whether they appear in the text so far. <a href=\"https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#completions-extensions\" target=\"_blank\">See documentation</a>",
+      "tooltip": "Positive values penalize new tokens based on whether they appear in the text so far. <a href=\"https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#completions-extensions\" target=\"_blank\">Azure OpenAI completions extensions documentation</a>",
       "group": "parameters",
       "type": "String",
       "feel": "optional",
@@ -1106,7 +1106,7 @@
     },
     {
       "label": "Frequency penalty",
-      "description": "Positive values penalize new tokens based on their existing frequency in the text so far. <a href=\"https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#completions-extensions\" target=\"_blank\">See documentation</a>",
+      "tooltip": "Positive values penalize new tokens based on their existing frequency in the text so far. <a href=\"https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#completions-extensions\" target=\"_blank\">Azure OpenAI completions extensions documentation</a>",
       "group": "parameters",
       "type": "String",
       "feel": "optional",
@@ -1122,7 +1122,7 @@
     },
     {
       "label": "Logit bias",
-      "description": "Modify the likelihood of specified tokens appearing in the completion. <a href=\"https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#completions-extensions\" target=\"_blank\">See documentation</a>",
+      "tooltip": "Modify the likelihood of specified tokens appearing in the completion. <a href=\"https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#completions-extensions\" target=\"_blank\">Azure OpenAI completions extensions documentation</a>",
       "group": "parameters",
       "type": "String",
       "feel": "required",
@@ -1138,7 +1138,7 @@
     },
     {
       "label": "User",
-      "description": "A unique identifier representing your end-user. <a href=\"https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#completions-extensions\" target=\"_blank\">See documentation</a>",
+      "tooltip": "A unique identifier representing your end-user. <a href=\"https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#completions-extensions\" target=\"_blank\">Azure OpenAI completions extensions documentation</a>",
       "group": "parameters",
       "type": "String",
       "feel": "optional",
@@ -1154,7 +1154,7 @@
     },
     {
       "label": "Tools",
-      "description": "A list of tools the model can call. <a href=\"https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#completions-extensions\" target=\"_blank\">See documentation</a>",
+      "tooltip": "A list of tools the model can call. <a href=\"https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#completions-extensions\" target=\"_blank\">Azure OpenAI completions extensions documentation</a>",
       "group": "parameters",
       "type": "String",
       "feel": "optional",
@@ -1170,7 +1170,7 @@
     },
     {
       "label": "Data sources",
-      "description": "Represents additional resource data. <a href=\"https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#completions-extensions\" target=\"_blank\">See documentation</a>",
+      "tooltip": "Represents additional resource data. <a href=\"https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#completions-extensions\" target=\"_blank\">Azure OpenAI completions extensions documentation</a>",
       "group": "parameters",
       "type": "String",
       "feel": "required",
@@ -1226,7 +1226,7 @@
     {
       "id": "resultVariable",
       "label": "Result variable",
-      "description": "Name of variable to store the response in",
+      "tooltip": "Name of variable to store the response in",
       "group": "output",
       "binding": {
         "key": "resultVariable",
@@ -1237,7 +1237,7 @@
     {
       "id": "resultExpression",
       "label": "Result expression",
-      "description": "Expression to map the response into process variables",
+      "tooltip": "Expression to map the response into process variables",
       "feel": "required",
       "group": "output",
       "binding": {
@@ -1249,7 +1249,7 @@
     {
       "id": "errorExpression",
       "label": "Error expression",
-      "description": "Expression to handle errors. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/\" target=\"_blank\">documentation</a>.",
+      "tooltip": "Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/\" target=\"_blank\">connector error handling documentation</a>.",
       "feel": "required",
       "group": "error",
       "binding": {
@@ -1261,7 +1261,6 @@
     {
       "id": "retryCount",
       "label": "Retries",
-      "description": "Number of retries",
       "value": "3",
       "feel": "optional",
       "group": "retries",

--- a/connectors/microsoft/common/src/main/java/io/camunda/connector/microsoft/common/auth/ClientCredentialsAuthentication.java
+++ b/connectors/microsoft/common/src/main/java/io/camunda/connector/microsoft/common/auth/ClientCredentialsAuthentication.java
@@ -20,7 +20,6 @@ public record ClientCredentialsAuthentication(
             group = "authentication",
             id = "credentials.clientId",
             label = "Client ID",
-            description = "The client ID of the application",
             feel = FeelMode.optional)
         String clientId,
     @FEEL
@@ -29,7 +28,6 @@ public record ClientCredentialsAuthentication(
             group = "authentication",
             id = "credentials.tenantId",
             label = "Tenant ID",
-            description = "The tenant ID of the application",
             feel = FeelMode.optional)
         String tenantId,
     @FEEL
@@ -38,7 +36,7 @@ public record ClientCredentialsAuthentication(
             group = "authentication",
             id = "credentials.clientSecret",
             label = "Client secret",
-            description = "The secret value of the Azure AD application",
+            tooltip = "The secret value of the Microsoft Entra ID (formerly Azure AD) application",
             feel = FeelMode.optional)
         String clientSecret)
     implements MicrosoftAuthentication {

--- a/connectors/microsoft/common/src/main/java/io/camunda/connector/microsoft/common/auth/RefreshTokenAuthentication.java
+++ b/connectors/microsoft/common/src/main/java/io/camunda/connector/microsoft/common/auth/RefreshTokenAuthentication.java
@@ -28,7 +28,6 @@ public record RefreshTokenAuthentication(
             group = "authentication",
             id = "refresh.clientId",
             label = "Client ID",
-            description = "The client ID of the application",
             feel = FeelMode.optional)
         String clientId,
     @FEEL
@@ -37,7 +36,6 @@ public record RefreshTokenAuthentication(
             group = "authentication",
             id = "refresh.tenantId",
             label = "Tenant ID",
-            description = "The tenant ID of the application",
             feel = FeelMode.optional)
         String tenantId,
     @FEEL
@@ -46,8 +44,8 @@ public record RefreshTokenAuthentication(
             id = "refresh.clientSecret",
             label = "Client secret",
             optional = true,
-            description =
-                "The secret value of the Azure AD application; optional, depends on whether the client is public or private",
+            tooltip =
+                "The secret value of the Microsoft Entra ID (formerly Azure AD) application; optional, depends on whether the client is public or private",
             feel = FeelMode.optional)
         String clientSecret)
     implements MicrosoftAuthentication {

--- a/connectors/microsoft/email-inbound/element-templates/hybrid/hybrid-microsoft-o365-email-boundary-event-connector-hybrid.json
+++ b/connectors/microsoft/email-inbound/element-templates/hybrid/hybrid-microsoft-o365-email-boundary-event-connector-hybrid.json
@@ -234,7 +234,8 @@
       "name" : "pollingConfig.userId",
       "type" : "zeebe:property"
     },
-    "tooltip" : "The email address or user ID of the mailbox to monitor (e.g., user@example.com). <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/microsoft-o365-mail-inbound/#configuration\" target=\"_blank\">Learn more</a>",
+    "tooltip" : "The email address or user ID of the mailbox to monitor. <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/microsoft-o365-mail-inbound/#configuration\" target=\"_blank\">Microsoft O365 Mail connector configuration</a>",
+    "placeholder" : "user@example.com",
     "type" : "String"
   }, {
     "id" : "pollingConfig.folder.folderSpecification",

--- a/connectors/microsoft/email-inbound/element-templates/hybrid/hybrid-microsoft-o365-email-boundary-event-connector-hybrid.json
+++ b/connectors/microsoft/email-inbound/element-templates/hybrid/hybrid-microsoft-o365-email-boundary-event-connector-hybrid.json
@@ -92,7 +92,6 @@
   }, {
     "id" : "authentication.credentials.clientId",
     "label" : "Client ID",
-    "description" : "The client ID of the application",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -112,7 +111,6 @@
   }, {
     "id" : "authentication.credentials.tenantId",
     "label" : "Tenant ID",
-    "description" : "The tenant ID of the application",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -132,7 +130,6 @@
   }, {
     "id" : "authentication.credentials.clientSecret",
     "label" : "Client secret",
-    "description" : "The secret value of the Azure AD application",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -148,6 +145,7 @@
       "equals" : "clientCredentials",
       "type" : "simple"
     },
+    "tooltip" : "The secret value of the Microsoft Entra ID (formerly Azure AD) application",
     "type" : "String"
   }, {
     "id" : "authentication.refresh.token",
@@ -171,7 +169,6 @@
   }, {
     "id" : "authentication.refresh.clientId",
     "label" : "Client ID",
-    "description" : "The client ID of the application",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -191,7 +188,6 @@
   }, {
     "id" : "authentication.refresh.tenantId",
     "label" : "Tenant ID",
-    "description" : "The tenant ID of the application",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -211,7 +207,6 @@
   }, {
     "id" : "authentication.refresh.clientSecret",
     "label" : "Client secret",
-    "description" : "The secret value of the Azure AD application; optional, depends on whether the client is public or private",
     "optional" : true,
     "feel" : "optional",
     "group" : "authentication",
@@ -224,6 +219,7 @@
       "equals" : "refresh",
       "type" : "simple"
     },
+    "tooltip" : "The secret value of the Microsoft Entra ID (formerly Azure AD) application; optional, depends on whether the client is public or private",
     "type" : "String"
   }, {
     "id" : "pollingConfig.userId",
@@ -243,7 +239,7 @@
   }, {
     "id" : "pollingConfig.folder.folderSpecification",
     "label" : "Folder Identifier Type",
-    "description" : "Prefer using a folder ID if you are using a well known folder otherwise use the folder name",
+    "description" : "Prefer using a folder ID if you are using a well-known folder; otherwise, use the folder name.",
     "value" : "byId",
     "group" : "pollingConfig",
     "binding" : {
@@ -310,7 +306,7 @@
       "name" : "pollingConfig.pollingInterval",
       "type" : "zeebe:property"
     },
-    "tooltip" : "The interval between email polling requests, defined as ISO 8601 duration format. <a href='https://docs.camunda.io/docs/components/modeler/bpmn/timer-events/#time-duration' target='_blank'>How to configure a time duration</a>",
+    "tooltip" : "The interval between email polling requests, in ISO 8601 duration format. <a href='https://docs.camunda.io/docs/components/modeler/bpmn/timer-events/#time-duration' target='_blank'>How to configure a time duration</a>",
     "type" : "String"
   }, {
     "id" : "pollingConfig.filterCriteria.filterSpecification",
@@ -441,7 +437,7 @@
   }, {
     "id" : "operation.targetFolder.folderSpecification",
     "label" : "Folder Identifier Type",
-    "description" : "Prefer using a folder ID if you are using a well known folder otherwise use the folder name",
+    "description" : "Prefer using a folder ID if you are using a well-known folder; otherwise, use the folder name.",
     "value" : "byId",
     "group" : "postprocessing",
     "binding" : {

--- a/connectors/microsoft/email-inbound/element-templates/hybrid/hybrid-microsoft-o365-email-intermediate-catch-event-connector-hybrid.json
+++ b/connectors/microsoft/email-inbound/element-templates/hybrid/hybrid-microsoft-o365-email-intermediate-catch-event-connector-hybrid.json
@@ -234,7 +234,8 @@
       "name" : "pollingConfig.userId",
       "type" : "zeebe:property"
     },
-    "tooltip" : "The email address or user ID of the mailbox to monitor (e.g., user@example.com). <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/microsoft-o365-mail-inbound/#configuration\" target=\"_blank\">Learn more</a>",
+    "tooltip" : "The email address or user ID of the mailbox to monitor. <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/microsoft-o365-mail-inbound/#configuration\" target=\"_blank\">Microsoft O365 Mail connector configuration</a>",
+    "placeholder" : "user@example.com",
     "type" : "String"
   }, {
     "id" : "pollingConfig.folder.folderSpecification",

--- a/connectors/microsoft/email-inbound/element-templates/hybrid/hybrid-microsoft-o365-email-intermediate-catch-event-connector-hybrid.json
+++ b/connectors/microsoft/email-inbound/element-templates/hybrid/hybrid-microsoft-o365-email-intermediate-catch-event-connector-hybrid.json
@@ -92,7 +92,6 @@
   }, {
     "id" : "authentication.credentials.clientId",
     "label" : "Client ID",
-    "description" : "The client ID of the application",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -112,7 +111,6 @@
   }, {
     "id" : "authentication.credentials.tenantId",
     "label" : "Tenant ID",
-    "description" : "The tenant ID of the application",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -132,7 +130,6 @@
   }, {
     "id" : "authentication.credentials.clientSecret",
     "label" : "Client secret",
-    "description" : "The secret value of the Azure AD application",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -148,6 +145,7 @@
       "equals" : "clientCredentials",
       "type" : "simple"
     },
+    "tooltip" : "The secret value of the Microsoft Entra ID (formerly Azure AD) application",
     "type" : "String"
   }, {
     "id" : "authentication.refresh.token",
@@ -171,7 +169,6 @@
   }, {
     "id" : "authentication.refresh.clientId",
     "label" : "Client ID",
-    "description" : "The client ID of the application",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -191,7 +188,6 @@
   }, {
     "id" : "authentication.refresh.tenantId",
     "label" : "Tenant ID",
-    "description" : "The tenant ID of the application",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -211,7 +207,6 @@
   }, {
     "id" : "authentication.refresh.clientSecret",
     "label" : "Client secret",
-    "description" : "The secret value of the Azure AD application; optional, depends on whether the client is public or private",
     "optional" : true,
     "feel" : "optional",
     "group" : "authentication",
@@ -224,6 +219,7 @@
       "equals" : "refresh",
       "type" : "simple"
     },
+    "tooltip" : "The secret value of the Microsoft Entra ID (formerly Azure AD) application; optional, depends on whether the client is public or private",
     "type" : "String"
   }, {
     "id" : "pollingConfig.userId",
@@ -243,7 +239,7 @@
   }, {
     "id" : "pollingConfig.folder.folderSpecification",
     "label" : "Folder Identifier Type",
-    "description" : "Prefer using a folder ID if you are using a well known folder otherwise use the folder name",
+    "description" : "Prefer using a folder ID if you are using a well-known folder; otherwise, use the folder name.",
     "value" : "byId",
     "group" : "pollingConfig",
     "binding" : {
@@ -310,7 +306,7 @@
       "name" : "pollingConfig.pollingInterval",
       "type" : "zeebe:property"
     },
-    "tooltip" : "The interval between email polling requests, defined as ISO 8601 duration format. <a href='https://docs.camunda.io/docs/components/modeler/bpmn/timer-events/#time-duration' target='_blank'>How to configure a time duration</a>",
+    "tooltip" : "The interval between email polling requests, in ISO 8601 duration format. <a href='https://docs.camunda.io/docs/components/modeler/bpmn/timer-events/#time-duration' target='_blank'>How to configure a time duration</a>",
     "type" : "String"
   }, {
     "id" : "pollingConfig.filterCriteria.filterSpecification",
@@ -441,7 +437,7 @@
   }, {
     "id" : "operation.targetFolder.folderSpecification",
     "label" : "Folder Identifier Type",
-    "description" : "Prefer using a folder ID if you are using a well known folder otherwise use the folder name",
+    "description" : "Prefer using a folder ID if you are using a well-known folder; otherwise, use the folder name.",
     "value" : "byId",
     "group" : "postprocessing",
     "binding" : {

--- a/connectors/microsoft/email-inbound/element-templates/hybrid/hybrid-microsoft-o365-email-message-start-event-connector-hybrid.json
+++ b/connectors/microsoft/email-inbound/element-templates/hybrid/hybrid-microsoft-o365-email-message-start-event-connector-hybrid.json
@@ -234,7 +234,8 @@
       "name" : "pollingConfig.userId",
       "type" : "zeebe:property"
     },
-    "tooltip" : "The email address or user ID of the mailbox to monitor (e.g., user@example.com). <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/microsoft-o365-mail-inbound/#configuration\" target=\"_blank\">Learn more</a>",
+    "tooltip" : "The email address or user ID of the mailbox to monitor. <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/microsoft-o365-mail-inbound/#configuration\" target=\"_blank\">Microsoft O365 Mail connector configuration</a>",
+    "placeholder" : "user@example.com",
     "type" : "String"
   }, {
     "id" : "pollingConfig.folder.folderSpecification",

--- a/connectors/microsoft/email-inbound/element-templates/hybrid/hybrid-microsoft-o365-email-message-start-event-connector-hybrid.json
+++ b/connectors/microsoft/email-inbound/element-templates/hybrid/hybrid-microsoft-o365-email-message-start-event-connector-hybrid.json
@@ -92,7 +92,6 @@
   }, {
     "id" : "authentication.credentials.clientId",
     "label" : "Client ID",
-    "description" : "The client ID of the application",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -112,7 +111,6 @@
   }, {
     "id" : "authentication.credentials.tenantId",
     "label" : "Tenant ID",
-    "description" : "The tenant ID of the application",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -132,7 +130,6 @@
   }, {
     "id" : "authentication.credentials.clientSecret",
     "label" : "Client secret",
-    "description" : "The secret value of the Azure AD application",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -148,6 +145,7 @@
       "equals" : "clientCredentials",
       "type" : "simple"
     },
+    "tooltip" : "The secret value of the Microsoft Entra ID (formerly Azure AD) application",
     "type" : "String"
   }, {
     "id" : "authentication.refresh.token",
@@ -171,7 +169,6 @@
   }, {
     "id" : "authentication.refresh.clientId",
     "label" : "Client ID",
-    "description" : "The client ID of the application",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -191,7 +188,6 @@
   }, {
     "id" : "authentication.refresh.tenantId",
     "label" : "Tenant ID",
-    "description" : "The tenant ID of the application",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -211,7 +207,6 @@
   }, {
     "id" : "authentication.refresh.clientSecret",
     "label" : "Client secret",
-    "description" : "The secret value of the Azure AD application; optional, depends on whether the client is public or private",
     "optional" : true,
     "feel" : "optional",
     "group" : "authentication",
@@ -224,6 +219,7 @@
       "equals" : "refresh",
       "type" : "simple"
     },
+    "tooltip" : "The secret value of the Microsoft Entra ID (formerly Azure AD) application; optional, depends on whether the client is public or private",
     "type" : "String"
   }, {
     "id" : "pollingConfig.userId",
@@ -243,7 +239,7 @@
   }, {
     "id" : "pollingConfig.folder.folderSpecification",
     "label" : "Folder Identifier Type",
-    "description" : "Prefer using a folder ID if you are using a well known folder otherwise use the folder name",
+    "description" : "Prefer using a folder ID if you are using a well-known folder; otherwise, use the folder name.",
     "value" : "byId",
     "group" : "pollingConfig",
     "binding" : {
@@ -310,7 +306,7 @@
       "name" : "pollingConfig.pollingInterval",
       "type" : "zeebe:property"
     },
-    "tooltip" : "The interval between email polling requests, defined as ISO 8601 duration format. <a href='https://docs.camunda.io/docs/components/modeler/bpmn/timer-events/#time-duration' target='_blank'>How to configure a time duration</a>",
+    "tooltip" : "The interval between email polling requests, in ISO 8601 duration format. <a href='https://docs.camunda.io/docs/components/modeler/bpmn/timer-events/#time-duration' target='_blank'>How to configure a time duration</a>",
     "type" : "String"
   }, {
     "id" : "pollingConfig.filterCriteria.filterSpecification",
@@ -441,7 +437,7 @@
   }, {
     "id" : "operation.targetFolder.folderSpecification",
     "label" : "Folder Identifier Type",
-    "description" : "Prefer using a folder ID if you are using a well known folder otherwise use the folder name",
+    "description" : "Prefer using a folder ID if you are using a well-known folder; otherwise, use the folder name.",
     "value" : "byId",
     "group" : "postprocessing",
     "binding" : {

--- a/connectors/microsoft/email-inbound/element-templates/microsoft-o365-email-boundary-event-connector.json
+++ b/connectors/microsoft/email-inbound/element-templates/microsoft-o365-email-boundary-event-connector.json
@@ -229,7 +229,8 @@
       "name" : "pollingConfig.userId",
       "type" : "zeebe:property"
     },
-    "tooltip" : "The email address or user ID of the mailbox to monitor (e.g., user@example.com). <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/microsoft-o365-mail-inbound/#configuration\" target=\"_blank\">Learn more</a>",
+    "tooltip" : "The email address or user ID of the mailbox to monitor. <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/microsoft-o365-mail-inbound/#configuration\" target=\"_blank\">Microsoft O365 Mail connector configuration</a>",
+    "placeholder" : "user@example.com",
     "type" : "String"
   }, {
     "id" : "pollingConfig.folder.folderSpecification",

--- a/connectors/microsoft/email-inbound/element-templates/microsoft-o365-email-boundary-event-connector.json
+++ b/connectors/microsoft/email-inbound/element-templates/microsoft-o365-email-boundary-event-connector.json
@@ -87,7 +87,6 @@
   }, {
     "id" : "authentication.credentials.clientId",
     "label" : "Client ID",
-    "description" : "The client ID of the application",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -107,7 +106,6 @@
   }, {
     "id" : "authentication.credentials.tenantId",
     "label" : "Tenant ID",
-    "description" : "The tenant ID of the application",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -127,7 +125,6 @@
   }, {
     "id" : "authentication.credentials.clientSecret",
     "label" : "Client secret",
-    "description" : "The secret value of the Azure AD application",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -143,6 +140,7 @@
       "equals" : "clientCredentials",
       "type" : "simple"
     },
+    "tooltip" : "The secret value of the Microsoft Entra ID (formerly Azure AD) application",
     "type" : "String"
   }, {
     "id" : "authentication.refresh.token",
@@ -166,7 +164,6 @@
   }, {
     "id" : "authentication.refresh.clientId",
     "label" : "Client ID",
-    "description" : "The client ID of the application",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -186,7 +183,6 @@
   }, {
     "id" : "authentication.refresh.tenantId",
     "label" : "Tenant ID",
-    "description" : "The tenant ID of the application",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -206,7 +202,6 @@
   }, {
     "id" : "authentication.refresh.clientSecret",
     "label" : "Client secret",
-    "description" : "The secret value of the Azure AD application; optional, depends on whether the client is public or private",
     "optional" : true,
     "feel" : "optional",
     "group" : "authentication",
@@ -219,6 +214,7 @@
       "equals" : "refresh",
       "type" : "simple"
     },
+    "tooltip" : "The secret value of the Microsoft Entra ID (formerly Azure AD) application; optional, depends on whether the client is public or private",
     "type" : "String"
   }, {
     "id" : "pollingConfig.userId",
@@ -238,7 +234,7 @@
   }, {
     "id" : "pollingConfig.folder.folderSpecification",
     "label" : "Folder Identifier Type",
-    "description" : "Prefer using a folder ID if you are using a well known folder otherwise use the folder name",
+    "description" : "Prefer using a folder ID if you are using a well-known folder; otherwise, use the folder name.",
     "value" : "byId",
     "group" : "pollingConfig",
     "binding" : {
@@ -305,7 +301,7 @@
       "name" : "pollingConfig.pollingInterval",
       "type" : "zeebe:property"
     },
-    "tooltip" : "The interval between email polling requests, defined as ISO 8601 duration format. <a href='https://docs.camunda.io/docs/components/modeler/bpmn/timer-events/#time-duration' target='_blank'>How to configure a time duration</a>",
+    "tooltip" : "The interval between email polling requests, in ISO 8601 duration format. <a href='https://docs.camunda.io/docs/components/modeler/bpmn/timer-events/#time-duration' target='_blank'>How to configure a time duration</a>",
     "type" : "String"
   }, {
     "id" : "pollingConfig.filterCriteria.filterSpecification",
@@ -436,7 +432,7 @@
   }, {
     "id" : "operation.targetFolder.folderSpecification",
     "label" : "Folder Identifier Type",
-    "description" : "Prefer using a folder ID if you are using a well known folder otherwise use the folder name",
+    "description" : "Prefer using a folder ID if you are using a well-known folder; otherwise, use the folder name.",
     "value" : "byId",
     "group" : "postprocessing",
     "binding" : {

--- a/connectors/microsoft/email-inbound/element-templates/microsoft-o365-email-intermediate-catch-event-connector.json
+++ b/connectors/microsoft/email-inbound/element-templates/microsoft-o365-email-intermediate-catch-event-connector.json
@@ -229,7 +229,8 @@
       "name" : "pollingConfig.userId",
       "type" : "zeebe:property"
     },
-    "tooltip" : "The email address or user ID of the mailbox to monitor (e.g., user@example.com). <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/microsoft-o365-mail-inbound/#configuration\" target=\"_blank\">Learn more</a>",
+    "tooltip" : "The email address or user ID of the mailbox to monitor. <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/microsoft-o365-mail-inbound/#configuration\" target=\"_blank\">Microsoft O365 Mail connector configuration</a>",
+    "placeholder" : "user@example.com",
     "type" : "String"
   }, {
     "id" : "pollingConfig.folder.folderSpecification",

--- a/connectors/microsoft/email-inbound/element-templates/microsoft-o365-email-intermediate-catch-event-connector.json
+++ b/connectors/microsoft/email-inbound/element-templates/microsoft-o365-email-intermediate-catch-event-connector.json
@@ -87,7 +87,6 @@
   }, {
     "id" : "authentication.credentials.clientId",
     "label" : "Client ID",
-    "description" : "The client ID of the application",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -107,7 +106,6 @@
   }, {
     "id" : "authentication.credentials.tenantId",
     "label" : "Tenant ID",
-    "description" : "The tenant ID of the application",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -127,7 +125,6 @@
   }, {
     "id" : "authentication.credentials.clientSecret",
     "label" : "Client secret",
-    "description" : "The secret value of the Azure AD application",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -143,6 +140,7 @@
       "equals" : "clientCredentials",
       "type" : "simple"
     },
+    "tooltip" : "The secret value of the Microsoft Entra ID (formerly Azure AD) application",
     "type" : "String"
   }, {
     "id" : "authentication.refresh.token",
@@ -166,7 +164,6 @@
   }, {
     "id" : "authentication.refresh.clientId",
     "label" : "Client ID",
-    "description" : "The client ID of the application",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -186,7 +183,6 @@
   }, {
     "id" : "authentication.refresh.tenantId",
     "label" : "Tenant ID",
-    "description" : "The tenant ID of the application",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -206,7 +202,6 @@
   }, {
     "id" : "authentication.refresh.clientSecret",
     "label" : "Client secret",
-    "description" : "The secret value of the Azure AD application; optional, depends on whether the client is public or private",
     "optional" : true,
     "feel" : "optional",
     "group" : "authentication",
@@ -219,6 +214,7 @@
       "equals" : "refresh",
       "type" : "simple"
     },
+    "tooltip" : "The secret value of the Microsoft Entra ID (formerly Azure AD) application; optional, depends on whether the client is public or private",
     "type" : "String"
   }, {
     "id" : "pollingConfig.userId",
@@ -238,7 +234,7 @@
   }, {
     "id" : "pollingConfig.folder.folderSpecification",
     "label" : "Folder Identifier Type",
-    "description" : "Prefer using a folder ID if you are using a well known folder otherwise use the folder name",
+    "description" : "Prefer using a folder ID if you are using a well-known folder; otherwise, use the folder name.",
     "value" : "byId",
     "group" : "pollingConfig",
     "binding" : {
@@ -305,7 +301,7 @@
       "name" : "pollingConfig.pollingInterval",
       "type" : "zeebe:property"
     },
-    "tooltip" : "The interval between email polling requests, defined as ISO 8601 duration format. <a href='https://docs.camunda.io/docs/components/modeler/bpmn/timer-events/#time-duration' target='_blank'>How to configure a time duration</a>",
+    "tooltip" : "The interval between email polling requests, in ISO 8601 duration format. <a href='https://docs.camunda.io/docs/components/modeler/bpmn/timer-events/#time-duration' target='_blank'>How to configure a time duration</a>",
     "type" : "String"
   }, {
     "id" : "pollingConfig.filterCriteria.filterSpecification",
@@ -436,7 +432,7 @@
   }, {
     "id" : "operation.targetFolder.folderSpecification",
     "label" : "Folder Identifier Type",
-    "description" : "Prefer using a folder ID if you are using a well known folder otherwise use the folder name",
+    "description" : "Prefer using a folder ID if you are using a well-known folder; otherwise, use the folder name.",
     "value" : "byId",
     "group" : "postprocessing",
     "binding" : {

--- a/connectors/microsoft/email-inbound/element-templates/microsoft-o365-email-message-start-event-connector.json
+++ b/connectors/microsoft/email-inbound/element-templates/microsoft-o365-email-message-start-event-connector.json
@@ -229,7 +229,8 @@
       "name" : "pollingConfig.userId",
       "type" : "zeebe:property"
     },
-    "tooltip" : "The email address or user ID of the mailbox to monitor (e.g., user@example.com). <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/microsoft-o365-mail-inbound/#configuration\" target=\"_blank\">Learn more</a>",
+    "tooltip" : "The email address or user ID of the mailbox to monitor. <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/microsoft-o365-mail-inbound/#configuration\" target=\"_blank\">Microsoft O365 Mail connector configuration</a>",
+    "placeholder" : "user@example.com",
     "type" : "String"
   }, {
     "id" : "pollingConfig.folder.folderSpecification",

--- a/connectors/microsoft/email-inbound/element-templates/microsoft-o365-email-message-start-event-connector.json
+++ b/connectors/microsoft/email-inbound/element-templates/microsoft-o365-email-message-start-event-connector.json
@@ -87,7 +87,6 @@
   }, {
     "id" : "authentication.credentials.clientId",
     "label" : "Client ID",
-    "description" : "The client ID of the application",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -107,7 +106,6 @@
   }, {
     "id" : "authentication.credentials.tenantId",
     "label" : "Tenant ID",
-    "description" : "The tenant ID of the application",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -127,7 +125,6 @@
   }, {
     "id" : "authentication.credentials.clientSecret",
     "label" : "Client secret",
-    "description" : "The secret value of the Azure AD application",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -143,6 +140,7 @@
       "equals" : "clientCredentials",
       "type" : "simple"
     },
+    "tooltip" : "The secret value of the Microsoft Entra ID (formerly Azure AD) application",
     "type" : "String"
   }, {
     "id" : "authentication.refresh.token",
@@ -166,7 +164,6 @@
   }, {
     "id" : "authentication.refresh.clientId",
     "label" : "Client ID",
-    "description" : "The client ID of the application",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -186,7 +183,6 @@
   }, {
     "id" : "authentication.refresh.tenantId",
     "label" : "Tenant ID",
-    "description" : "The tenant ID of the application",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -206,7 +202,6 @@
   }, {
     "id" : "authentication.refresh.clientSecret",
     "label" : "Client secret",
-    "description" : "The secret value of the Azure AD application; optional, depends on whether the client is public or private",
     "optional" : true,
     "feel" : "optional",
     "group" : "authentication",
@@ -219,6 +214,7 @@
       "equals" : "refresh",
       "type" : "simple"
     },
+    "tooltip" : "The secret value of the Microsoft Entra ID (formerly Azure AD) application; optional, depends on whether the client is public or private",
     "type" : "String"
   }, {
     "id" : "pollingConfig.userId",
@@ -238,7 +234,7 @@
   }, {
     "id" : "pollingConfig.folder.folderSpecification",
     "label" : "Folder Identifier Type",
-    "description" : "Prefer using a folder ID if you are using a well known folder otherwise use the folder name",
+    "description" : "Prefer using a folder ID if you are using a well-known folder; otherwise, use the folder name.",
     "value" : "byId",
     "group" : "pollingConfig",
     "binding" : {
@@ -305,7 +301,7 @@
       "name" : "pollingConfig.pollingInterval",
       "type" : "zeebe:property"
     },
-    "tooltip" : "The interval between email polling requests, defined as ISO 8601 duration format. <a href='https://docs.camunda.io/docs/components/modeler/bpmn/timer-events/#time-duration' target='_blank'>How to configure a time duration</a>",
+    "tooltip" : "The interval between email polling requests, in ISO 8601 duration format. <a href='https://docs.camunda.io/docs/components/modeler/bpmn/timer-events/#time-duration' target='_blank'>How to configure a time duration</a>",
     "type" : "String"
   }, {
     "id" : "pollingConfig.filterCriteria.filterSpecification",
@@ -436,7 +432,7 @@
   }, {
     "id" : "operation.targetFolder.folderSpecification",
     "label" : "Folder Identifier Type",
-    "description" : "Prefer using a folder ID if you are using a well known folder otherwise use the folder name",
+    "description" : "Prefer using a folder ID if you are using a well-known folder; otherwise, use the folder name.",
     "value" : "byId",
     "group" : "postprocessing",
     "binding" : {

--- a/connectors/microsoft/email-inbound/src/main/java/io/camunda/connector/microsoft/email/model/config/EmailPollingConfig.java
+++ b/connectors/microsoft/email-inbound/src/main/java/io/camunda/connector/microsoft/email/model/config/EmailPollingConfig.java
@@ -30,7 +30,7 @@ public record EmailPollingConfig(
             group = "pollingConfig",
             defaultValue = "PT30S",
             tooltip =
-                "The interval between email polling requests, defined as ISO 8601 duration format. <a href='https://docs.camunda.io/docs/components/modeler/bpmn/timer-events/#time-duration' target='_blank'>How to configure a time duration</a>",
+                "The interval between email polling requests, in ISO 8601 duration format. <a href='https://docs.camunda.io/docs/components/modeler/bpmn/timer-events/#time-duration' target='_blank'>How to configure a time duration</a>",
             feel = FeelMode.optional)
         @FEEL
         Duration pollingInterval,

--- a/connectors/microsoft/email-inbound/src/main/java/io/camunda/connector/microsoft/email/model/config/EmailPollingConfig.java
+++ b/connectors/microsoft/email-inbound/src/main/java/io/camunda/connector/microsoft/email/model/config/EmailPollingConfig.java
@@ -18,8 +18,9 @@ public record EmailPollingConfig(
     @TemplateProperty(
             label = "Mailbox Owner",
             feel = FeelMode.optional,
+            placeholder = "user@example.com",
             tooltip =
-                "The email address or user ID of the mailbox to monitor (e.g., user@example.com). <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/microsoft-o365-mail-inbound/#configuration\" target=\"_blank\">Learn more</a>")
+                "The email address or user ID of the mailbox to monitor. <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/microsoft-o365-mail-inbound/#configuration\" target=\"_blank\">Microsoft O365 Mail connector configuration</a>")
         @NotBlank
         @FEEL
         String userId,

--- a/connectors/microsoft/email-inbound/src/main/java/io/camunda/connector/microsoft/email/model/config/Folder.java
+++ b/connectors/microsoft/email-inbound/src/main/java/io/camunda/connector/microsoft/email/model/config/Folder.java
@@ -18,7 +18,7 @@ import jakarta.validation.constraints.NotBlank;
 @TemplateDiscriminatorProperty(
     label = "Folder Identifier Type",
     description =
-        "Prefer using a folder ID if you are using a well known folder otherwise use the folder name",
+        "Prefer using a folder ID if you are using a well-known folder; otherwise, use the folder name.",
     group = "pollingConfig",
     name = "folderSpecification",
     defaultValue = Folder.FolderById.TYPE)

--- a/connectors/microsoft/mail/element-templates/microsoft-office365-mail-connector.json
+++ b/connectors/microsoft/mail/element-templates/microsoft-office365-mail-connector.json
@@ -122,7 +122,7 @@
     {
       "id": "authentication.type",
       "label": "Type",
-      "description": "Authentication type",
+      "tooltip": "Authentication type",
       "value": "oauth-client-credentials-flow",
       "group": "authentication",
       "binding": {
@@ -168,7 +168,6 @@
     {
       "id": "authentication.oauthTokenEndpoint",
       "label": "OAuth token endpoint",
-      "description": "The OAuth token endpoint",
       "optional": false,
       "constraints": {
         "notEmpty": true
@@ -189,7 +188,7 @@
     {
       "id": "authentication.clientId",
       "label": "Client ID",
-      "description": "Your application's client ID from the OAuth client",
+      "tooltip": "Your application's client ID from the OAuth client",
       "optional": false,
       "constraints": {
         "notEmpty": true
@@ -210,7 +209,7 @@
     {
       "id": "authentication.clientSecret",
       "label": "Client secret",
-      "description": "Your application's client secret from the OAuth client",
+      "tooltip": "Your application's client secret from the OAuth client",
       "optional": false,
       "constraints": {
         "notEmpty": true
@@ -262,7 +261,7 @@
     {
       "id": "authentication.refreshToken.tenantId",
       "label": "Tenant ID",
-      "description": "The tenant ID of the Microsoft Entra (Azure AD) application",
+      "tooltip": "The tenant ID of the Microsoft Entra (Azure AD) application",
       "optional": false,
       "constraints": {
         "notEmpty": true
@@ -283,7 +282,6 @@
     {
       "id": "authentication.refreshToken.clientId",
       "label": "Client ID",
-      "description": "The client ID of the application",
       "optional": false,
       "constraints": {
         "notEmpty": true
@@ -322,7 +320,7 @@
     {
       "id": "authentication.refreshToken.token",
       "label": "Refresh token",
-      "description": "The OAuth 2.0 refresh token used to obtain a new access token",
+      "tooltip": "The OAuth 2.0 refresh token used to obtain a new access token",
       "optional": false,
       "constraints": {
         "notEmpty": true
@@ -373,7 +371,7 @@
     {
       "id": "users.ListMailFolders_user_id",
       "label": "User ID",
-      "description": "The unique identifier of user. Can be UUID or email",
+      "description": "The unique identifier of the user. Can be a UUID or an email address",
       "optional": false,
       "value": "myuser@mycompany.com",
       "constraints": {
@@ -425,7 +423,7 @@
     {
       "id": "users.ListMailFolders_odata_queryParameters",
       "label": "Query parameters",
-      "description": "Query parameters. Supporting <a href='https://learn.microsoft.com/en-us/graph/query-parameters?tabs=http' target='_blank'>OData query parameters</a>",
+      "tooltip": "Supports <a href='https://learn.microsoft.com/en-us/graph/query-parameters?tabs=http' target='_blank'>OData query parameters</a>",
       "group": "parameters",
       "optional": true,
       "feel": "required",
@@ -458,7 +456,7 @@
     {
       "id": "users.CreateMailFolders_user_id",
       "label": "User ID",
-      "description": "The unique identifier of user. Can be UUID or email",
+      "description": "The unique identifier of the user. Can be a UUID or an email address",
       "optional": false,
       "value": "myuser@mycompany.com",
       "constraints": {
@@ -480,7 +478,6 @@
     {
       "id": "users.CreateMailFolders_folder_name",
       "label": "Folder display name",
-      "description": "A folder name to be created",
       "optional": false,
       "value": "",
       "constraints": {
@@ -562,7 +559,7 @@
     {
       "id": "users.ListMessages_user_id",
       "label": "User ID",
-      "description": "The unique identifier of user. Can be UUID or email",
+      "description": "The unique identifier of the user. Can be a UUID or an email address",
       "optional": false,
       "value": "myuser@mycompany.com",
       "constraints": {
@@ -614,7 +611,7 @@
     {
       "id": "users.ListMessages_odata_queryParameters",
       "label": "Query parameters",
-      "description": "Query parameters. Supporting <a href='https://learn.microsoft.com/en-us/graph/query-parameters?tabs=http' target='_blank'>OData query parameters</a>",
+      "tooltip": "Supports <a href='https://learn.microsoft.com/en-us/graph/query-parameters?tabs=http' target='_blank'>OData query parameters</a>",
       "group": "parameters",
       "optional": true,
       "feel": "required",
@@ -647,7 +644,7 @@
     {
       "id": "users.user.sendMail_user_id",
       "label": "User ID",
-      "description": "The unique identifier of user. Can be UUID or email",
+      "description": "The unique identifier of the user. Can be a UUID or an email address",
       "optional": false,
       "value": "myuser@mycompany.com",
       "constraints": {
@@ -669,7 +666,6 @@
     {
       "id": "users.user.sendMail_subject",
       "label": "Subject",
-      "description": "Mail subject",
       "optional": false,
       "constraints": {
         "notEmpty": true
@@ -716,7 +712,6 @@
     {
       "id": "users.user.sendMail_body_content",
       "label": "Body content",
-      "description": "Mail body content",
       "optional": false,
       "constraints": {
         "notEmpty": true
@@ -899,7 +894,7 @@
     {
       "id": "resultVariable",
       "label": "Result variable",
-      "description": "Name of variable to store the response in",
+      "tooltip": "Name of variable to store the response in",
       "group": "output",
       "binding": {
         "key": "resultVariable",
@@ -910,7 +905,7 @@
     {
       "id": "resultExpression",
       "label": "Result expression",
-      "description": "Expression to map the response into process variables",
+      "tooltip": "Expression to map the response into process variables",
       "feel": "required",
       "group": "output",
       "binding": {
@@ -922,7 +917,7 @@
     {
       "id": "errorExpression",
       "label": "Error expression",
-      "description": "Expression to handle errors. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/\" target=\"_blank\">documentation</a>.",
+      "tooltip": "<a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/\" target=\"_blank\">BPMN error handling documentation</a>",
       "feel": "required",
       "group": "error",
       "binding": {
@@ -934,7 +929,6 @@
     {
       "id": "retryCount",
       "label": "Retries",
-      "description": "Number of retries",
       "value": "3",
       "feel": "optional",
       "group": "retries",
@@ -947,7 +941,7 @@
     {
       "id": "retryBackoff",
       "label": "Retry backoff",
-      "description": "ISO-8601 duration to wait between retries",
+      "tooltip": "ISO-8601 duration to wait between retries",
       "value" : "PT30S",
       "feel": "optional",
       "group": "retries",

--- a/connectors/microsoft/teams/element-templates/hybrid/microsoft-teams-outbound-connector-hybrid.json
+++ b/connectors/microsoft/teams/element-templates/hybrid/microsoft-teams-outbound-connector-hybrid.json
@@ -344,7 +344,7 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "The type of a new chat",
+    "tooltip" : "One on one for a private conversation between two people; group for a conversation among three or more people.",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "One on one",
@@ -540,7 +540,7 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "The type of the content. Possible values are text and html",
+    "tooltip" : "Text sends the message body as plain text; HTML renders it as HTML markup.",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "Text",
@@ -782,7 +782,6 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "The Microsoft Teams group ID.",
     "type" : "String"
   }, {
     "id" : "data.createChannel.name",
@@ -894,7 +893,7 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "Enter ID or principal name of a user",
+    "tooltip" : "ID or principal name of the user",
     "type" : "String"
   }, {
     "id" : "data.getChannel.groupId",
@@ -920,7 +919,6 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "The Microsoft Teams group ID.",
     "type" : "String"
   }, {
     "id" : "data.getChannel.channelId",
@@ -971,7 +969,6 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "The Microsoft Teams group ID.",
     "type" : "String"
   }, {
     "id" : "data.listChannels.filter",
@@ -1020,7 +1017,6 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "The Microsoft Teams group ID.",
     "type" : "String"
   }, {
     "id" : "data.sendMessageToChannel.channelId",
@@ -1071,7 +1067,7 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "The type of the content. Possible values are text and html",
+    "tooltip" : "Text sends the message body as plain text; HTML renders it as HTML markup.",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "Text",
@@ -1453,7 +1449,6 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "The Microsoft Teams group ID.",
     "type" : "String"
   }, {
     "id" : "data.getChannelMessage.channelId",
@@ -1529,7 +1524,6 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "The Microsoft Teams group ID.",
     "type" : "String"
   }, {
     "id" : "data.listChannelMessage.channelId",
@@ -1636,7 +1630,6 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "The Microsoft Teams group ID.",
     "type" : "String"
   }, {
     "id" : "data.listMessageRepliesInChannel.channelId",
@@ -1712,7 +1705,6 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "The Microsoft Teams group ID.",
     "type" : "String"
   }, {
     "id" : "data.listChannelMembers.channelId",

--- a/connectors/microsoft/teams/element-templates/hybrid/microsoft-teams-outbound-connector-hybrid.json
+++ b/connectors/microsoft/teams/element-templates/hybrid/microsoft-teams-outbound-connector-hybrid.json
@@ -191,7 +191,6 @@
   }, {
     "id" : "authentication.credentials.clientId",
     "label" : "Client ID",
-    "description" : "The client ID of the application",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -211,7 +210,6 @@
   }, {
     "id" : "authentication.credentials.tenantId",
     "label" : "Tenant ID",
-    "description" : "The tenant ID of the application",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -231,7 +229,6 @@
   }, {
     "id" : "authentication.credentials.clientSecret",
     "label" : "Client secret",
-    "description" : "The secret value of the Azure AD application",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -247,6 +244,7 @@
       "equals" : "clientCredentials",
       "type" : "simple"
     },
+    "tooltip" : "The secret value of the Microsoft Entra ID (formerly Azure AD) application",
     "type" : "String"
   }, {
     "id" : "authentication.refresh.token",
@@ -270,7 +268,6 @@
   }, {
     "id" : "authentication.refresh.clientId",
     "label" : "Client ID",
-    "description" : "The client ID of the application",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -290,7 +287,6 @@
   }, {
     "id" : "authentication.refresh.tenantId",
     "label" : "Tenant ID",
-    "description" : "The tenant ID of the application",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -310,7 +306,6 @@
   }, {
     "id" : "authentication.refresh.clientSecret",
     "label" : "Client secret",
-    "description" : "The secret value of the Azure AD application; optional, depends on whether the client is public or private",
     "optional" : true,
     "feel" : "optional",
     "group" : "authentication",
@@ -323,11 +318,11 @@
       "equals" : "refresh",
       "type" : "simple"
     },
+    "tooltip" : "The secret value of the Microsoft Entra ID (formerly Azure AD) application; optional, depends on whether the client is public or private",
     "type" : "String"
   }, {
     "id" : "data.createChat.chatType",
     "label" : "Chat type",
-    "description" : "The type of a new chat",
     "optional" : false,
     "value" : "one_on_one",
     "constraints" : {
@@ -349,6 +344,7 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "The type of a new chat",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "One on one",
@@ -360,7 +356,6 @@
   }, {
     "id" : "data.createChat.topic",
     "label" : "Topic",
-    "description" : "Set topic of chat (optional)",
     "optional" : true,
     "feel" : "optional",
     "group" : "data",
@@ -387,7 +382,6 @@
   }, {
     "id" : "data.createChat.members",
     "label" : "Members",
-    "description" : "Set array members of chat. <a href='https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/microsoft-teams/#members-property'>Learn more about the required format</a>",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -409,11 +403,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/microsoft-teams/#members-property\">Members property</a> reference.",
     "type" : "String"
   }, {
     "id" : "data.getChat.chatId",
     "label" : "Chat ID",
-    "description" : "The chat ID",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -439,7 +433,6 @@
   }, {
     "id" : "data.getChat.expand",
     "label" : "Expand response",
-    "description" : "Choose expand type. <a href='https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/microsoft-teams/#expand-response'>Learn more about expanding chat response</a>",
     "optional" : false,
     "value" : "withoutExpand",
     "constraints" : {
@@ -461,6 +454,7 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/microsoft-teams/#expand-response\">expand response</a> reference.",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "Without expand",
@@ -475,7 +469,6 @@
   }, {
     "id" : "data.listChatMembers.chatId",
     "label" : "Chat ID",
-    "description" : "The chat ID",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -501,7 +494,6 @@
   }, {
     "id" : "data.sendMessageInChat.chatId",
     "label" : "Chat ID",
-    "description" : "The chat ID",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -527,7 +519,6 @@
   }, {
     "id" : "data.sendMessageInChat.bodyType",
     "label" : "Content type",
-    "description" : "The type of the content. Possible values are text and html",
     "optional" : false,
     "value" : "TEXT",
     "constraints" : {
@@ -549,6 +540,7 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "The type of the content. Possible values are text and html",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "Text",
@@ -560,7 +552,6 @@
   }, {
     "id" : "data.sendMessageInChat.content",
     "label" : "Content",
-    "description" : "Enter content",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -586,7 +577,6 @@
   }, {
     "id" : "data.sendMessageInChat.attachments",
     "label" : "Attachments",
-    "description" : "Optional list of attachments. Each item must have an 'id', 'contentType' (e.g. 'application/vnd.microsoft.card.adaptive') and 'content' (e.g. an Adaptive Card JSON payload). Attachment IDs must match <attachment id=\"...\"></attachment> tags in the message body (auto-appended if missing).",
     "optional" : true,
     "feel" : "required",
     "group" : "data",
@@ -609,11 +599,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Optional list of attachments. Each item must have an 'id', 'contentType' (e.g. 'application/vnd.microsoft.card.adaptive') and 'content' (e.g. an Adaptive Card JSON payload). Attachment IDs must match <attachment id=\"...\"></attachment> tags in the message body (auto-appended if missing).",
     "type" : "String"
   }, {
     "id" : "data.listMessagesInChat.chatId",
     "label" : "Chat ID",
-    "description" : "The chat ID",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -639,7 +629,7 @@
   }, {
     "id" : "data.listMessagesInChat.top",
     "label" : "Top",
-    "description" : "Controls the number of items per response. Maximum allowed $top value is 50",
+    "description" : "Maximum allowed $top value is 50.",
     "optional" : true,
     "feel" : "optional",
     "group" : "data",
@@ -658,6 +648,7 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Controls the number of items per response.",
     "type" : "String"
   }, {
     "id" : "data.listMessagesInChat.orderBy",
@@ -697,7 +688,6 @@
   }, {
     "id" : "data.listMessagesInChat.filter",
     "label" : "Filter",
-    "description" : "Sets the date range filter for the lastModifiedDateTime and createdDateTime properties. <a href='https://learn.microsoft.com/en-us/graph/filter-query-parameter'>Learn more about filtering</a>",
     "optional" : false,
     "feel" : "optional",
     "group" : "data",
@@ -716,11 +706,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Sets the date range filter for the lastModifiedDateTime and createdDateTime properties. See the <a href=\"https://learn.microsoft.com/en-us/graph/filter-query-parameter\">filter query parameter</a> reference.",
     "type" : "String"
   }, {
     "id" : "data.getMessageInChat.chatId",
     "label" : "Chat ID",
-    "description" : "The chat ID",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -746,7 +736,6 @@
   }, {
     "id" : "data.getMessageInChat.messageId",
     "label" : "Message ID",
-    "description" : "The message ID",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -772,7 +761,6 @@
   }, {
     "id" : "data.createChannel.groupId",
     "label" : "Group ID",
-    "description" : "The group ID for teams",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -794,11 +782,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "The Microsoft Teams group ID.",
     "type" : "String"
   }, {
     "id" : "data.createChannel.name",
     "label" : "Display name",
-    "description" : "Enter name of a channel",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -824,7 +812,6 @@
   }, {
     "id" : "data.createChannel.description",
     "label" : "Description",
-    "description" : "Enter description",
     "optional" : true,
     "feel" : "optional",
     "group" : "data",
@@ -847,7 +834,6 @@
   }, {
     "id" : "data.createChannel.channelType",
     "label" : "Channel membership type",
-    "description" : "Choose type",
     "optional" : false,
     "value" : "standard",
     "constraints" : {
@@ -883,7 +869,6 @@
   }, {
     "id" : "data.createChannel.owner",
     "label" : "Owner",
-    "description" : "Enter ID or principal name of a user",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -909,11 +894,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Enter ID or principal name of a user",
     "type" : "String"
   }, {
     "id" : "data.getChannel.groupId",
     "label" : "Group ID",
-    "description" : "The group ID for teams",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -935,11 +920,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "The Microsoft Teams group ID.",
     "type" : "String"
   }, {
     "id" : "data.getChannel.channelId",
     "label" : "Channel ID",
-    "description" : "The Channel ID",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -965,7 +950,6 @@
   }, {
     "id" : "data.listChannels.groupId",
     "label" : "Group ID",
-    "description" : "The group ID for teams",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -987,11 +971,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "The Microsoft Teams group ID.",
     "type" : "String"
   }, {
     "id" : "data.listChannels.filter",
     "label" : "Filter",
-    "description" : "Sets the search filter. <a href='https://learn.microsoft.com/en-us/graph/filter-query-parameter'>Learn more about filtering</a>",
     "optional" : true,
     "feel" : "optional",
     "group" : "data",
@@ -1010,11 +994,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Sets the search filter. See the <a href=\"https://learn.microsoft.com/en-us/graph/filter-query-parameter\">filter query parameter</a> reference.",
     "type" : "String"
   }, {
     "id" : "data.sendMessageToChannel.groupId",
     "label" : "Group ID",
-    "description" : "The group ID for teams",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -1036,11 +1020,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "The Microsoft Teams group ID.",
     "type" : "String"
   }, {
     "id" : "data.sendMessageToChannel.channelId",
     "label" : "Channel ID",
-    "description" : "The channel ID",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -1066,7 +1050,6 @@
   }, {
     "id" : "data.sendMessageToChannel.bodyType",
     "label" : "Content type",
-    "description" : "The type of the content. Possible values are text and html",
     "optional" : false,
     "value" : "TEXT",
     "constraints" : {
@@ -1088,6 +1071,7 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "The type of the content. Possible values are text and html",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "Text",
@@ -1099,7 +1083,6 @@
   }, {
     "id" : "data.sendMessageToChannel.content",
     "label" : "Content",
-    "description" : "Enter content",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -1422,7 +1405,6 @@
   }, {
     "id" : "data.sendMessageToChannel.attachments",
     "label" : "Attachments",
-    "description" : "Optional list of attachments. Each item must have an 'id', 'contentType' (e.g. 'application/vnd.microsoft.card.adaptive') and 'content' (e.g. an Adaptive Card JSON payload). Attachment IDs must match <attachment id=\"...\"></attachment> tags in the message body (auto-appended if missing).",
     "optional" : true,
     "feel" : "required",
     "group" : "data",
@@ -1445,11 +1427,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Optional list of attachments. Each item must have an 'id', 'contentType' (e.g. 'application/vnd.microsoft.card.adaptive') and 'content' (e.g. an Adaptive Card JSON payload). Attachment IDs must match <attachment id=\"...\"></attachment> tags in the message body (auto-appended if missing).",
     "type" : "String"
   }, {
     "id" : "data.getChannelMessage.groupId",
     "label" : "Group ID",
-    "description" : "The group ID for teams",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -1471,11 +1453,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "The Microsoft Teams group ID.",
     "type" : "String"
   }, {
     "id" : "data.getChannelMessage.channelId",
     "label" : "Channel ID",
-    "description" : "The channel ID",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -1501,7 +1483,6 @@
   }, {
     "id" : "data.getChannelMessage.messageId",
     "label" : "Message ID",
-    "description" : "The message ID",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -1527,7 +1508,6 @@
   }, {
     "id" : "data.listChannelMessage.groupId",
     "label" : "Group ID",
-    "description" : "The group ID for teams",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -1549,11 +1529,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "The Microsoft Teams group ID.",
     "type" : "String"
   }, {
     "id" : "data.listChannelMessage.channelId",
     "label" : "Channel ID",
-    "description" : "The channel ID",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -1579,7 +1559,6 @@
   }, {
     "id" : "data.listChannelMessage.top",
     "label" : "Top",
-    "description" : "Controls the number of items per response",
     "optional" : true,
     "feel" : "optional",
     "group" : "data",
@@ -1598,11 +1577,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Controls the number of items per response",
     "type" : "String"
   }, {
     "id" : "data.listChannelMessage.isExpand",
     "label" : "With replies",
-    "description" : "Return message replies",
     "optional" : false,
     "value" : "false",
     "constraints" : {
@@ -1624,6 +1603,7 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Return message replies",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "False",
@@ -1635,7 +1615,6 @@
   }, {
     "id" : "data.listMessageRepliesInChannel.groupId",
     "label" : "Group ID",
-    "description" : "The group ID for teams",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -1657,11 +1636,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "The Microsoft Teams group ID.",
     "type" : "String"
   }, {
     "id" : "data.listMessageRepliesInChannel.channelId",
     "label" : "Channel ID",
-    "description" : "The channel ID",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -1687,7 +1666,6 @@
   }, {
     "id" : "data.listMessageRepliesInChannel.messageId",
     "label" : "Message ID",
-    "description" : "The message ID",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -1713,7 +1691,6 @@
   }, {
     "id" : "data.listChannelMembers.groupId",
     "label" : "Group ID",
-    "description" : "The group ID for teams",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -1735,11 +1712,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "The Microsoft Teams group ID.",
     "type" : "String"
   }, {
     "id" : "data.listChannelMembers.channelId",
     "label" : "Channel ID",
-    "description" : "The channel ID",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true

--- a/connectors/microsoft/teams/element-templates/microsoft-teams-outbound-connector.json
+++ b/connectors/microsoft/teams/element-templates/microsoft-teams-outbound-connector.json
@@ -339,7 +339,7 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "The type of a new chat",
+    "tooltip" : "One on one for a private conversation between two people; group for a conversation among three or more people.",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "One on one",
@@ -535,7 +535,7 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "The type of the content. Possible values are text and html",
+    "tooltip" : "Text sends the message body as plain text; HTML renders it as HTML markup.",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "Text",
@@ -777,7 +777,6 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "The Microsoft Teams group ID.",
     "type" : "String"
   }, {
     "id" : "data.createChannel.name",
@@ -889,7 +888,7 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "Enter ID or principal name of a user",
+    "tooltip" : "ID or principal name of the user",
     "type" : "String"
   }, {
     "id" : "data.getChannel.groupId",
@@ -915,7 +914,6 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "The Microsoft Teams group ID.",
     "type" : "String"
   }, {
     "id" : "data.getChannel.channelId",
@@ -966,7 +964,6 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "The Microsoft Teams group ID.",
     "type" : "String"
   }, {
     "id" : "data.listChannels.filter",
@@ -1015,7 +1012,6 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "The Microsoft Teams group ID.",
     "type" : "String"
   }, {
     "id" : "data.sendMessageToChannel.channelId",
@@ -1066,7 +1062,7 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "The type of the content. Possible values are text and html",
+    "tooltip" : "Text sends the message body as plain text; HTML renders it as HTML markup.",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "Text",
@@ -1448,7 +1444,6 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "The Microsoft Teams group ID.",
     "type" : "String"
   }, {
     "id" : "data.getChannelMessage.channelId",
@@ -1524,7 +1519,6 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "The Microsoft Teams group ID.",
     "type" : "String"
   }, {
     "id" : "data.listChannelMessage.channelId",
@@ -1631,7 +1625,6 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "The Microsoft Teams group ID.",
     "type" : "String"
   }, {
     "id" : "data.listMessageRepliesInChannel.channelId",
@@ -1707,7 +1700,6 @@
         "type" : "simple"
       } ]
     },
-    "tooltip" : "The Microsoft Teams group ID.",
     "type" : "String"
   }, {
     "id" : "data.listChannelMembers.channelId",

--- a/connectors/microsoft/teams/element-templates/microsoft-teams-outbound-connector.json
+++ b/connectors/microsoft/teams/element-templates/microsoft-teams-outbound-connector.json
@@ -186,7 +186,6 @@
   }, {
     "id" : "authentication.credentials.clientId",
     "label" : "Client ID",
-    "description" : "The client ID of the application",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -206,7 +205,6 @@
   }, {
     "id" : "authentication.credentials.tenantId",
     "label" : "Tenant ID",
-    "description" : "The tenant ID of the application",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -226,7 +224,6 @@
   }, {
     "id" : "authentication.credentials.clientSecret",
     "label" : "Client secret",
-    "description" : "The secret value of the Azure AD application",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -242,6 +239,7 @@
       "equals" : "clientCredentials",
       "type" : "simple"
     },
+    "tooltip" : "The secret value of the Microsoft Entra ID (formerly Azure AD) application",
     "type" : "String"
   }, {
     "id" : "authentication.refresh.token",
@@ -265,7 +263,6 @@
   }, {
     "id" : "authentication.refresh.clientId",
     "label" : "Client ID",
-    "description" : "The client ID of the application",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -285,7 +282,6 @@
   }, {
     "id" : "authentication.refresh.tenantId",
     "label" : "Tenant ID",
-    "description" : "The tenant ID of the application",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -305,7 +301,6 @@
   }, {
     "id" : "authentication.refresh.clientSecret",
     "label" : "Client secret",
-    "description" : "The secret value of the Azure AD application; optional, depends on whether the client is public or private",
     "optional" : true,
     "feel" : "optional",
     "group" : "authentication",
@@ -318,11 +313,11 @@
       "equals" : "refresh",
       "type" : "simple"
     },
+    "tooltip" : "The secret value of the Microsoft Entra ID (formerly Azure AD) application; optional, depends on whether the client is public or private",
     "type" : "String"
   }, {
     "id" : "data.createChat.chatType",
     "label" : "Chat type",
-    "description" : "The type of a new chat",
     "optional" : false,
     "value" : "one_on_one",
     "constraints" : {
@@ -344,6 +339,7 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "The type of a new chat",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "One on one",
@@ -355,7 +351,6 @@
   }, {
     "id" : "data.createChat.topic",
     "label" : "Topic",
-    "description" : "Set topic of chat (optional)",
     "optional" : true,
     "feel" : "optional",
     "group" : "data",
@@ -382,7 +377,6 @@
   }, {
     "id" : "data.createChat.members",
     "label" : "Members",
-    "description" : "Set array members of chat. <a href='https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/microsoft-teams/#members-property'>Learn more about the required format</a>",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -404,11 +398,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/microsoft-teams/#members-property\">Members property</a> reference.",
     "type" : "String"
   }, {
     "id" : "data.getChat.chatId",
     "label" : "Chat ID",
-    "description" : "The chat ID",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -434,7 +428,6 @@
   }, {
     "id" : "data.getChat.expand",
     "label" : "Expand response",
-    "description" : "Choose expand type. <a href='https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/microsoft-teams/#expand-response'>Learn more about expanding chat response</a>",
     "optional" : false,
     "value" : "withoutExpand",
     "constraints" : {
@@ -456,6 +449,7 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/microsoft-teams/#expand-response\">expand response</a> reference.",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "Without expand",
@@ -470,7 +464,6 @@
   }, {
     "id" : "data.listChatMembers.chatId",
     "label" : "Chat ID",
-    "description" : "The chat ID",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -496,7 +489,6 @@
   }, {
     "id" : "data.sendMessageInChat.chatId",
     "label" : "Chat ID",
-    "description" : "The chat ID",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -522,7 +514,6 @@
   }, {
     "id" : "data.sendMessageInChat.bodyType",
     "label" : "Content type",
-    "description" : "The type of the content. Possible values are text and html",
     "optional" : false,
     "value" : "TEXT",
     "constraints" : {
@@ -544,6 +535,7 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "The type of the content. Possible values are text and html",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "Text",
@@ -555,7 +547,6 @@
   }, {
     "id" : "data.sendMessageInChat.content",
     "label" : "Content",
-    "description" : "Enter content",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -581,7 +572,6 @@
   }, {
     "id" : "data.sendMessageInChat.attachments",
     "label" : "Attachments",
-    "description" : "Optional list of attachments. Each item must have an 'id', 'contentType' (e.g. 'application/vnd.microsoft.card.adaptive') and 'content' (e.g. an Adaptive Card JSON payload). Attachment IDs must match <attachment id=\"...\"></attachment> tags in the message body (auto-appended if missing).",
     "optional" : true,
     "feel" : "required",
     "group" : "data",
@@ -604,11 +594,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Optional list of attachments. Each item must have an 'id', 'contentType' (e.g. 'application/vnd.microsoft.card.adaptive') and 'content' (e.g. an Adaptive Card JSON payload). Attachment IDs must match <attachment id=\"...\"></attachment> tags in the message body (auto-appended if missing).",
     "type" : "String"
   }, {
     "id" : "data.listMessagesInChat.chatId",
     "label" : "Chat ID",
-    "description" : "The chat ID",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -634,7 +624,7 @@
   }, {
     "id" : "data.listMessagesInChat.top",
     "label" : "Top",
-    "description" : "Controls the number of items per response. Maximum allowed $top value is 50",
+    "description" : "Maximum allowed $top value is 50.",
     "optional" : true,
     "feel" : "optional",
     "group" : "data",
@@ -653,6 +643,7 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Controls the number of items per response.",
     "type" : "String"
   }, {
     "id" : "data.listMessagesInChat.orderBy",
@@ -692,7 +683,6 @@
   }, {
     "id" : "data.listMessagesInChat.filter",
     "label" : "Filter",
-    "description" : "Sets the date range filter for the lastModifiedDateTime and createdDateTime properties. <a href='https://learn.microsoft.com/en-us/graph/filter-query-parameter'>Learn more about filtering</a>",
     "optional" : false,
     "feel" : "optional",
     "group" : "data",
@@ -711,11 +701,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Sets the date range filter for the lastModifiedDateTime and createdDateTime properties. See the <a href=\"https://learn.microsoft.com/en-us/graph/filter-query-parameter\">filter query parameter</a> reference.",
     "type" : "String"
   }, {
     "id" : "data.getMessageInChat.chatId",
     "label" : "Chat ID",
-    "description" : "The chat ID",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -741,7 +731,6 @@
   }, {
     "id" : "data.getMessageInChat.messageId",
     "label" : "Message ID",
-    "description" : "The message ID",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -767,7 +756,6 @@
   }, {
     "id" : "data.createChannel.groupId",
     "label" : "Group ID",
-    "description" : "The group ID for teams",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -789,11 +777,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "The Microsoft Teams group ID.",
     "type" : "String"
   }, {
     "id" : "data.createChannel.name",
     "label" : "Display name",
-    "description" : "Enter name of a channel",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -819,7 +807,6 @@
   }, {
     "id" : "data.createChannel.description",
     "label" : "Description",
-    "description" : "Enter description",
     "optional" : true,
     "feel" : "optional",
     "group" : "data",
@@ -842,7 +829,6 @@
   }, {
     "id" : "data.createChannel.channelType",
     "label" : "Channel membership type",
-    "description" : "Choose type",
     "optional" : false,
     "value" : "standard",
     "constraints" : {
@@ -878,7 +864,6 @@
   }, {
     "id" : "data.createChannel.owner",
     "label" : "Owner",
-    "description" : "Enter ID or principal name of a user",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -904,11 +889,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Enter ID or principal name of a user",
     "type" : "String"
   }, {
     "id" : "data.getChannel.groupId",
     "label" : "Group ID",
-    "description" : "The group ID for teams",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -930,11 +915,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "The Microsoft Teams group ID.",
     "type" : "String"
   }, {
     "id" : "data.getChannel.channelId",
     "label" : "Channel ID",
-    "description" : "The Channel ID",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -960,7 +945,6 @@
   }, {
     "id" : "data.listChannels.groupId",
     "label" : "Group ID",
-    "description" : "The group ID for teams",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -982,11 +966,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "The Microsoft Teams group ID.",
     "type" : "String"
   }, {
     "id" : "data.listChannels.filter",
     "label" : "Filter",
-    "description" : "Sets the search filter. <a href='https://learn.microsoft.com/en-us/graph/filter-query-parameter'>Learn more about filtering</a>",
     "optional" : true,
     "feel" : "optional",
     "group" : "data",
@@ -1005,11 +989,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Sets the search filter. See the <a href=\"https://learn.microsoft.com/en-us/graph/filter-query-parameter\">filter query parameter</a> reference.",
     "type" : "String"
   }, {
     "id" : "data.sendMessageToChannel.groupId",
     "label" : "Group ID",
-    "description" : "The group ID for teams",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -1031,11 +1015,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "The Microsoft Teams group ID.",
     "type" : "String"
   }, {
     "id" : "data.sendMessageToChannel.channelId",
     "label" : "Channel ID",
-    "description" : "The channel ID",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -1061,7 +1045,6 @@
   }, {
     "id" : "data.sendMessageToChannel.bodyType",
     "label" : "Content type",
-    "description" : "The type of the content. Possible values are text and html",
     "optional" : false,
     "value" : "TEXT",
     "constraints" : {
@@ -1083,6 +1066,7 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "The type of the content. Possible values are text and html",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "Text",
@@ -1094,7 +1078,6 @@
   }, {
     "id" : "data.sendMessageToChannel.content",
     "label" : "Content",
-    "description" : "Enter content",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -1417,7 +1400,6 @@
   }, {
     "id" : "data.sendMessageToChannel.attachments",
     "label" : "Attachments",
-    "description" : "Optional list of attachments. Each item must have an 'id', 'contentType' (e.g. 'application/vnd.microsoft.card.adaptive') and 'content' (e.g. an Adaptive Card JSON payload). Attachment IDs must match <attachment id=\"...\"></attachment> tags in the message body (auto-appended if missing).",
     "optional" : true,
     "feel" : "required",
     "group" : "data",
@@ -1440,11 +1422,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Optional list of attachments. Each item must have an 'id', 'contentType' (e.g. 'application/vnd.microsoft.card.adaptive') and 'content' (e.g. an Adaptive Card JSON payload). Attachment IDs must match <attachment id=\"...\"></attachment> tags in the message body (auto-appended if missing).",
     "type" : "String"
   }, {
     "id" : "data.getChannelMessage.groupId",
     "label" : "Group ID",
-    "description" : "The group ID for teams",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -1466,11 +1448,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "The Microsoft Teams group ID.",
     "type" : "String"
   }, {
     "id" : "data.getChannelMessage.channelId",
     "label" : "Channel ID",
-    "description" : "The channel ID",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -1496,7 +1478,6 @@
   }, {
     "id" : "data.getChannelMessage.messageId",
     "label" : "Message ID",
-    "description" : "The message ID",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -1522,7 +1503,6 @@
   }, {
     "id" : "data.listChannelMessage.groupId",
     "label" : "Group ID",
-    "description" : "The group ID for teams",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -1544,11 +1524,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "The Microsoft Teams group ID.",
     "type" : "String"
   }, {
     "id" : "data.listChannelMessage.channelId",
     "label" : "Channel ID",
-    "description" : "The channel ID",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -1574,7 +1554,6 @@
   }, {
     "id" : "data.listChannelMessage.top",
     "label" : "Top",
-    "description" : "Controls the number of items per response",
     "optional" : true,
     "feel" : "optional",
     "group" : "data",
@@ -1593,11 +1572,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Controls the number of items per response",
     "type" : "String"
   }, {
     "id" : "data.listChannelMessage.isExpand",
     "label" : "With replies",
-    "description" : "Return message replies",
     "optional" : false,
     "value" : "false",
     "constraints" : {
@@ -1619,6 +1598,7 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "Return message replies",
     "type" : "Dropdown",
     "choices" : [ {
       "name" : "False",
@@ -1630,7 +1610,6 @@
   }, {
     "id" : "data.listMessageRepliesInChannel.groupId",
     "label" : "Group ID",
-    "description" : "The group ID for teams",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -1652,11 +1631,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "The Microsoft Teams group ID.",
     "type" : "String"
   }, {
     "id" : "data.listMessageRepliesInChannel.channelId",
     "label" : "Channel ID",
-    "description" : "The channel ID",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -1682,7 +1661,6 @@
   }, {
     "id" : "data.listMessageRepliesInChannel.messageId",
     "label" : "Message ID",
-    "description" : "The message ID",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -1708,7 +1686,6 @@
   }, {
     "id" : "data.listChannelMembers.groupId",
     "label" : "Group ID",
-    "description" : "The group ID for teams",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true
@@ -1730,11 +1707,11 @@
         "type" : "simple"
       } ]
     },
+    "tooltip" : "The Microsoft Teams group ID.",
     "type" : "String"
   }, {
     "id" : "data.listChannelMembers.channelId",
     "label" : "Channel ID",
-    "description" : "The channel ID",
     "optional" : false,
     "constraints" : {
       "notEmpty" : true

--- a/connectors/microsoft/teams/src/main/java/io/camunda/connector/model/Attachment.java
+++ b/connectors/microsoft/teams/src/main/java/io/camunda/connector/model/Attachment.java
@@ -10,17 +10,15 @@ import io.camunda.connector.generator.java.annotation.TemplateProperty;
 import jakarta.validation.constraints.NotBlank;
 
 public record Attachment(
-    @NotBlank
-        @TemplateProperty(label = "Attachment ID", description = "Unique ID for the attachment")
+    @NotBlank @TemplateProperty(label = "Attachment ID", tooltip = "Unique ID for the attachment")
         String id,
     @NotBlank
         @TemplateProperty(
             label = "Content type",
-            description =
-                "The media type of the content attachment"
-                    + " (e.g. 'application/vnd.microsoft.card.adaptive')")
+            placeholder = "application/vnd.microsoft.card.adaptive",
+            tooltip = "The media type of the content attachment")
         String contentType,
     @TemplateProperty(
             label = "Content",
-            description = "The content of the attachment (e.g. an Adaptive Card JSON payload)")
+            tooltip = "The content of the attachment, e.g. an Adaptive Card JSON payload")
         String content) {}

--- a/connectors/microsoft/teams/src/main/java/io/camunda/connector/model/request/data/CreateChannel.java
+++ b/connectors/microsoft/teams/src/main/java/io/camunda/connector/model/request/data/CreateChannel.java
@@ -22,22 +22,16 @@ public record CreateChannel(
             group = "data",
             id = "createChannel.groupId",
             label = "Group ID",
-            description = "The group ID for teams")
+            tooltip = "The Microsoft Teams group ID.")
         String groupId,
-    @NotBlank
-        @TemplateProperty(
-            group = "data",
-            id = "createChannel.name",
-            label = "Display name",
-            description = "Enter name of a channel")
+    @NotBlank @TemplateProperty(group = "data", id = "createChannel.name", label = "Display name")
         String name,
     @TemplateProperty(
             group = "data",
             id = "createChannel.description",
             label = "Description",
             optional = true,
-            type = TemplateProperty.PropertyType.Text,
-            description = "Enter description")
+            type = TemplateProperty.PropertyType.Text)
         String description,
     @NotBlank
         @TemplateProperty(
@@ -51,8 +45,7 @@ public record CreateChannel(
               @TemplateProperty.DropdownPropertyChoice(value = "private", label = "Private"),
               @TemplateProperty.DropdownPropertyChoice(value = "shared", label = "Shared")
             },
-            constraints = @TemplateProperty.PropertyConstraints(notEmpty = true),
-            description = "Choose type")
+            constraints = @TemplateProperty.PropertyConstraints(notEmpty = true))
         String channelType,
     @TemplateProperty(
             group = "data",
@@ -63,6 +56,6 @@ public record CreateChannel(
                 @TemplateProperty.PropertyCondition(
                     property = "data.createChannel.channelType",
                     oneOf = {"private", "shared"}),
-            description = "Enter ID or principal name of a user")
+            tooltip = "Enter ID or principal name of a user")
         String owner)
     implements ChannelData {}

--- a/connectors/microsoft/teams/src/main/java/io/camunda/connector/model/request/data/CreateChannel.java
+++ b/connectors/microsoft/teams/src/main/java/io/camunda/connector/model/request/data/CreateChannel.java
@@ -17,12 +17,7 @@ import jakarta.validation.constraints.NotBlank;
     description = "Create a new channel in a Microsoft Teams team",
     keywords = {"create channel", "new channel", "add channel", "setup channel", "open channel"})
 public record CreateChannel(
-    @NotBlank
-        @TemplateProperty(
-            group = "data",
-            id = "createChannel.groupId",
-            label = "Group ID",
-            tooltip = "The Microsoft Teams group ID.")
+    @NotBlank @TemplateProperty(group = "data", id = "createChannel.groupId", label = "Group ID")
         String groupId,
     @NotBlank @TemplateProperty(group = "data", id = "createChannel.name", label = "Display name")
         String name,
@@ -56,6 +51,6 @@ public record CreateChannel(
                 @TemplateProperty.PropertyCondition(
                     property = "data.createChannel.channelType",
                     oneOf = {"private", "shared"}),
-            tooltip = "Enter ID or principal name of a user")
+            tooltip = "ID or principal name of the user")
         String owner)
     implements ChannelData {}

--- a/connectors/microsoft/teams/src/main/java/io/camunda/connector/model/request/data/CreateChat.java
+++ b/connectors/microsoft/teams/src/main/java/io/camunda/connector/model/request/data/CreateChat.java
@@ -33,7 +33,7 @@ public record CreateChat(
               @TemplateProperty.DropdownPropertyChoice(value = "group", label = "Group")
             },
             constraints = @TemplateProperty.PropertyConstraints(notEmpty = true),
-            description = "The type of a new chat")
+            tooltip = "The type of a new chat")
         String chatType,
     @TemplateProperty(
             group = "data",
@@ -43,8 +43,7 @@ public record CreateChat(
             condition =
                 @TemplateProperty.PropertyCondition(
                     property = "data.createChat.chatType",
-                    equals = "group"),
-            description = "Set topic of chat (optional)")
+                    equals = "group"))
         String topic,
     @NotNull
         @TemplateProperty(
@@ -52,7 +51,7 @@ public record CreateChat(
             id = "createChat.members",
             label = "Members",
             feel = FeelMode.required,
-            description =
-                "Set array members of chat. <a href='https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/microsoft-teams/#members-property'>Learn more about the required format</a>")
+            tooltip =
+                "See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/microsoft-teams/#members-property\">Members property</a> reference.")
         List<Member> members)
     implements ChatData {}

--- a/connectors/microsoft/teams/src/main/java/io/camunda/connector/model/request/data/CreateChat.java
+++ b/connectors/microsoft/teams/src/main/java/io/camunda/connector/model/request/data/CreateChat.java
@@ -33,7 +33,9 @@ public record CreateChat(
               @TemplateProperty.DropdownPropertyChoice(value = "group", label = "Group")
             },
             constraints = @TemplateProperty.PropertyConstraints(notEmpty = true),
-            tooltip = "The type of a new chat")
+            tooltip =
+                "One on one for a private conversation between two people; group for a"
+                    + " conversation among three or more people.")
         String chatType,
     @TemplateProperty(
             group = "data",

--- a/connectors/microsoft/teams/src/main/java/io/camunda/connector/model/request/data/GetChannel.java
+++ b/connectors/microsoft/teams/src/main/java/io/camunda/connector/model/request/data/GetChannel.java
@@ -28,13 +28,8 @@ public record GetChannel(
             group = "data",
             id = "getChannel.groupId",
             label = "Group ID",
-            description = "The group ID for teams")
+            tooltip = "The Microsoft Teams group ID.")
         String groupId,
-    @NotBlank
-        @TemplateProperty(
-            group = "data",
-            id = "getChannel.channelId",
-            label = "Channel ID",
-            description = "The Channel ID")
+    @NotBlank @TemplateProperty(group = "data", id = "getChannel.channelId", label = "Channel ID")
         String channelId)
     implements ChannelData {}

--- a/connectors/microsoft/teams/src/main/java/io/camunda/connector/model/request/data/GetChannel.java
+++ b/connectors/microsoft/teams/src/main/java/io/camunda/connector/model/request/data/GetChannel.java
@@ -23,12 +23,7 @@ import jakarta.validation.constraints.NotBlank;
       "channel details"
     })
 public record GetChannel(
-    @NotBlank
-        @TemplateProperty(
-            group = "data",
-            id = "getChannel.groupId",
-            label = "Group ID",
-            tooltip = "The Microsoft Teams group ID.")
+    @NotBlank @TemplateProperty(group = "data", id = "getChannel.groupId", label = "Group ID")
         String groupId,
     @NotBlank @TemplateProperty(group = "data", id = "getChannel.channelId", label = "Channel ID")
         String channelId)

--- a/connectors/microsoft/teams/src/main/java/io/camunda/connector/model/request/data/GetChannelMessage.java
+++ b/connectors/microsoft/teams/src/main/java/io/camunda/connector/model/request/data/GetChannelMessage.java
@@ -24,11 +24,7 @@ import jakarta.validation.constraints.NotBlank;
     })
 public record GetChannelMessage(
     @NotBlank
-        @TemplateProperty(
-            group = "data",
-            id = "getChannelMessage.groupId",
-            label = "Group ID",
-            tooltip = "The Microsoft Teams group ID.")
+        @TemplateProperty(group = "data", id = "getChannelMessage.groupId", label = "Group ID")
         String groupId,
     @NotBlank
         @TemplateProperty(group = "data", id = "getChannelMessage.channelId", label = "Channel ID")

--- a/connectors/microsoft/teams/src/main/java/io/camunda/connector/model/request/data/GetChannelMessage.java
+++ b/connectors/microsoft/teams/src/main/java/io/camunda/connector/model/request/data/GetChannelMessage.java
@@ -28,20 +28,12 @@ public record GetChannelMessage(
             group = "data",
             id = "getChannelMessage.groupId",
             label = "Group ID",
-            description = "The group ID for teams")
+            tooltip = "The Microsoft Teams group ID.")
         String groupId,
     @NotBlank
-        @TemplateProperty(
-            group = "data",
-            id = "getChannelMessage.channelId",
-            label = "Channel ID",
-            description = "The channel ID")
+        @TemplateProperty(group = "data", id = "getChannelMessage.channelId", label = "Channel ID")
         String channelId,
     @NotBlank
-        @TemplateProperty(
-            group = "data",
-            id = "getChannelMessage.messageId",
-            label = "Message ID",
-            description = "The message ID")
+        @TemplateProperty(group = "data", id = "getChannelMessage.messageId", label = "Message ID")
         String messageId)
     implements ChannelData {}

--- a/connectors/microsoft/teams/src/main/java/io/camunda/connector/model/request/data/GetChat.java
+++ b/connectors/microsoft/teams/src/main/java/io/camunda/connector/model/request/data/GetChat.java
@@ -17,12 +17,7 @@ import jakarta.validation.constraints.NotBlank;
     description = "Retrieve details of a specific Microsoft Teams chat",
     keywords = {"get chat", "chat info", "fetch chat", "retrieve chat", "chat details"})
 public record GetChat(
-    @NotBlank
-        @TemplateProperty(
-            group = "data",
-            id = "getChat.chatId",
-            label = "Chat ID",
-            description = "The chat ID")
+    @NotBlank @TemplateProperty(group = "data", id = "getChat.chatId", label = "Chat ID")
         String chatId,
     @TemplateProperty(
             group = "data",
@@ -42,7 +37,7 @@ public record GetChat(
                   label = "With chat members")
             },
             constraints = @TemplateProperty.PropertyConstraints(notEmpty = true),
-            description =
-                "Choose expand type. <a href='https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/microsoft-teams/#expand-response'>Learn more about expanding chat response</a>")
+            tooltip =
+                "See the <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/microsoft-teams/#expand-response\">expand response</a> reference.")
         String expand)
     implements ChatData {}

--- a/connectors/microsoft/teams/src/main/java/io/camunda/connector/model/request/data/GetMessageInChat.java
+++ b/connectors/microsoft/teams/src/main/java/io/camunda/connector/model/request/data/GetMessageInChat.java
@@ -23,18 +23,9 @@ import jakarta.validation.constraints.NotBlank;
       "direct message"
     })
 public record GetMessageInChat(
-    @NotBlank
-        @TemplateProperty(
-            group = "data",
-            id = "getMessageInChat.chatId",
-            label = "Chat ID",
-            description = "The chat ID")
+    @NotBlank @TemplateProperty(group = "data", id = "getMessageInChat.chatId", label = "Chat ID")
         String chatId,
     @NotBlank
-        @TemplateProperty(
-            group = "data",
-            id = "getMessageInChat.messageId",
-            label = "Message ID",
-            description = "The message ID")
+        @TemplateProperty(group = "data", id = "getMessageInChat.messageId", label = "Message ID")
         String messageId)
     implements ChatData {}

--- a/connectors/microsoft/teams/src/main/java/io/camunda/connector/model/request/data/ListChannelMembers.java
+++ b/connectors/microsoft/teams/src/main/java/io/camunda/connector/model/request/data/ListChannelMembers.java
@@ -24,11 +24,7 @@ import jakarta.validation.constraints.NotBlank;
     })
 public record ListChannelMembers(
     @NotBlank
-        @TemplateProperty(
-            group = "data",
-            id = "listChannelMembers.groupId",
-            label = "Group ID",
-            tooltip = "The Microsoft Teams group ID.")
+        @TemplateProperty(group = "data", id = "listChannelMembers.groupId", label = "Group ID")
         String groupId,
     @NotBlank
         @TemplateProperty(group = "data", id = "listChannelMembers.channelId", label = "Channel ID")

--- a/connectors/microsoft/teams/src/main/java/io/camunda/connector/model/request/data/ListChannelMembers.java
+++ b/connectors/microsoft/teams/src/main/java/io/camunda/connector/model/request/data/ListChannelMembers.java
@@ -28,13 +28,9 @@ public record ListChannelMembers(
             group = "data",
             id = "listChannelMembers.groupId",
             label = "Group ID",
-            description = "The group ID for teams")
+            tooltip = "The Microsoft Teams group ID.")
         String groupId,
     @NotBlank
-        @TemplateProperty(
-            group = "data",
-            id = "listChannelMembers.channelId",
-            label = "Channel ID",
-            description = "The channel ID")
+        @TemplateProperty(group = "data", id = "listChannelMembers.channelId", label = "Channel ID")
         String channelId)
     implements ChannelData {}

--- a/connectors/microsoft/teams/src/main/java/io/camunda/connector/model/request/data/ListChannelMessages.java
+++ b/connectors/microsoft/teams/src/main/java/io/camunda/connector/model/request/data/ListChannelMessages.java
@@ -28,21 +28,17 @@ public record ListChannelMessages(
             group = "data",
             id = "listChannelMessage.groupId",
             label = "Group ID",
-            description = "The group ID for teams")
+            tooltip = "The Microsoft Teams group ID.")
         String groupId,
     @NotBlank
-        @TemplateProperty(
-            group = "data",
-            id = "listChannelMessage.channelId",
-            label = "Channel ID",
-            description = "The channel ID")
+        @TemplateProperty(group = "data", id = "listChannelMessage.channelId", label = "Channel ID")
         String channelId,
     @TemplateProperty(
             group = "data",
             id = "listChannelMessage.top",
             label = "Top",
             optional = true,
-            description = "Controls the number of items per response")
+            tooltip = "Controls the number of items per response")
         String top,
     @TemplateProperty(
             group = "data",
@@ -55,7 +51,7 @@ public record ListChannelMessages(
               @TemplateProperty.DropdownPropertyChoice(value = "true", label = "True")
             },
             constraints = @TemplateProperty.PropertyConstraints(notEmpty = true),
-            description = "Return message replies")
+            tooltip = "Return message replies")
         String isExpand)
     implements ChannelData {
   public static final String EXPAND_VALUE = "replies";

--- a/connectors/microsoft/teams/src/main/java/io/camunda/connector/model/request/data/ListChannelMessages.java
+++ b/connectors/microsoft/teams/src/main/java/io/camunda/connector/model/request/data/ListChannelMessages.java
@@ -24,11 +24,7 @@ import jakarta.validation.constraints.NotBlank;
     })
 public record ListChannelMessages(
     @NotBlank
-        @TemplateProperty(
-            group = "data",
-            id = "listChannelMessage.groupId",
-            label = "Group ID",
-            tooltip = "The Microsoft Teams group ID.")
+        @TemplateProperty(group = "data", id = "listChannelMessage.groupId", label = "Group ID")
         String groupId,
     @NotBlank
         @TemplateProperty(group = "data", id = "listChannelMessage.channelId", label = "Channel ID")

--- a/connectors/microsoft/teams/src/main/java/io/camunda/connector/model/request/data/ListChannels.java
+++ b/connectors/microsoft/teams/src/main/java/io/camunda/connector/model/request/data/ListChannels.java
@@ -28,14 +28,14 @@ public record ListChannels(
             group = "data",
             id = "listChannels.groupId",
             label = "Group ID",
-            description = "The group ID for teams")
+            tooltip = "The Microsoft Teams group ID.")
         String groupId,
     @TemplateProperty(
             group = "data",
             id = "listChannels.filter",
             label = "Filter",
             optional = true,
-            description =
-                "Sets the search filter. <a href='https://learn.microsoft.com/en-us/graph/filter-query-parameter'>Learn more about filtering</a>")
+            tooltip =
+                "Sets the search filter. See the <a href=\"https://learn.microsoft.com/en-us/graph/filter-query-parameter\">filter query parameter</a> reference.")
         String filter)
     implements ChannelData {}

--- a/connectors/microsoft/teams/src/main/java/io/camunda/connector/model/request/data/ListChannels.java
+++ b/connectors/microsoft/teams/src/main/java/io/camunda/connector/model/request/data/ListChannels.java
@@ -23,12 +23,7 @@ import jakarta.validation.constraints.NotBlank;
       "browse channels"
     })
 public record ListChannels(
-    @NotBlank
-        @TemplateProperty(
-            group = "data",
-            id = "listChannels.groupId",
-            label = "Group ID",
-            tooltip = "The Microsoft Teams group ID.")
+    @NotBlank @TemplateProperty(group = "data", id = "listChannels.groupId", label = "Group ID")
         String groupId,
     @TemplateProperty(
             group = "data",

--- a/connectors/microsoft/teams/src/main/java/io/camunda/connector/model/request/data/ListChatMembers.java
+++ b/connectors/microsoft/teams/src/main/java/io/camunda/connector/model/request/data/ListChatMembers.java
@@ -23,11 +23,6 @@ import jakarta.validation.constraints.NotBlank;
       "conversation members"
     })
 public record ListChatMembers(
-    @NotBlank
-        @TemplateProperty(
-            group = "data",
-            id = "listChatMembers.chatId",
-            label = "Chat ID",
-            description = "The chat ID")
+    @NotBlank @TemplateProperty(group = "data", id = "listChatMembers.chatId", label = "Chat ID")
         String chatId)
     implements ChatData {}

--- a/connectors/microsoft/teams/src/main/java/io/camunda/connector/model/request/data/ListMessageRepliesInChannel.java
+++ b/connectors/microsoft/teams/src/main/java/io/camunda/connector/model/request/data/ListMessageRepliesInChannel.java
@@ -27,8 +27,7 @@ public record ListMessageRepliesInChannel(
         @TemplateProperty(
             group = "data",
             id = "listMessageRepliesInChannel.groupId",
-            label = "Group ID",
-            tooltip = "The Microsoft Teams group ID.")
+            label = "Group ID")
         String groupId,
     @NotBlank
         @TemplateProperty(

--- a/connectors/microsoft/teams/src/main/java/io/camunda/connector/model/request/data/ListMessageRepliesInChannel.java
+++ b/connectors/microsoft/teams/src/main/java/io/camunda/connector/model/request/data/ListMessageRepliesInChannel.java
@@ -28,20 +28,18 @@ public record ListMessageRepliesInChannel(
             group = "data",
             id = "listMessageRepliesInChannel.groupId",
             label = "Group ID",
-            description = "The group ID for teams")
+            tooltip = "The Microsoft Teams group ID.")
         String groupId,
     @NotBlank
         @TemplateProperty(
             group = "data",
             id = "listMessageRepliesInChannel.channelId",
-            label = "Channel ID",
-            description = "The channel ID")
+            label = "Channel ID")
         String channelId,
     @NotBlank
         @TemplateProperty(
             group = "data",
             id = "listMessageRepliesInChannel.messageId",
-            label = "Message ID",
-            description = "The message ID")
+            label = "Message ID")
         String messageId)
     implements ChannelData {}

--- a/connectors/microsoft/teams/src/main/java/io/camunda/connector/model/request/data/ListMessagesInChat.java
+++ b/connectors/microsoft/teams/src/main/java/io/camunda/connector/model/request/data/ListMessagesInChat.java
@@ -25,20 +25,15 @@ import jakarta.validation.constraints.NotNull;
       "read chat history"
     })
 public record ListMessagesInChat(
-    @NotBlank
-        @TemplateProperty(
-            group = "data",
-            id = "listMessagesInChat.chatId",
-            label = "Chat ID",
-            description = "The chat ID")
+    @NotBlank @TemplateProperty(group = "data", id = "listMessagesInChat.chatId", label = "Chat ID")
         String chatId,
     @TemplateProperty(
             group = "data",
             id = "listMessagesInChat.top",
             label = "Top",
             optional = true,
-            description =
-                "Controls the number of items per response. Maximum allowed $top value is 50")
+            tooltip = "Controls the number of items per response.",
+            description = "Maximum allowed $top value is 50.")
         String top,
     @NotNull
         @TemplateProperty(
@@ -64,7 +59,7 @@ public record ListMessagesInChat(
             group = "data",
             id = "listMessagesInChat.filter",
             label = "Filter",
-            description =
-                "Sets the date range filter for the lastModifiedDateTime and createdDateTime properties. <a href='https://learn.microsoft.com/en-us/graph/filter-query-parameter'>Learn more about filtering</a>")
+            tooltip =
+                "Sets the date range filter for the lastModifiedDateTime and createdDateTime properties. See the <a href=\"https://learn.microsoft.com/en-us/graph/filter-query-parameter\">filter query parameter</a> reference.")
         String filter)
     implements ChatData {}

--- a/connectors/microsoft/teams/src/main/java/io/camunda/connector/model/request/data/SendMessageInChat.java
+++ b/connectors/microsoft/teams/src/main/java/io/camunda/connector/model/request/data/SendMessageInChat.java
@@ -39,7 +39,7 @@ public record SendMessageInChat(
               @TemplateProperty.DropdownPropertyChoice(value = "HTML", label = "HTML")
             },
             constraints = @TemplateProperty.PropertyConstraints(notEmpty = true),
-            tooltip = "The type of the content. Possible values are text and html")
+            tooltip = "Text sends the message body as plain text; HTML renders it as HTML markup.")
         String bodyType,
     @NotBlank
         @TemplateProperty(

--- a/connectors/microsoft/teams/src/main/java/io/camunda/connector/model/request/data/SendMessageInChat.java
+++ b/connectors/microsoft/teams/src/main/java/io/camunda/connector/model/request/data/SendMessageInChat.java
@@ -26,12 +26,7 @@ import java.util.List;
       "notify via chat"
     })
 public record SendMessageInChat(
-    @NotBlank
-        @TemplateProperty(
-            group = "data",
-            id = "sendMessageInChat.chatId",
-            label = "Chat ID",
-            description = "The chat ID")
+    @NotBlank @TemplateProperty(group = "data", id = "sendMessageInChat.chatId", label = "Chat ID")
         String chatId,
     @TemplateProperty(
             group = "data",
@@ -44,15 +39,14 @@ public record SendMessageInChat(
               @TemplateProperty.DropdownPropertyChoice(value = "HTML", label = "HTML")
             },
             constraints = @TemplateProperty.PropertyConstraints(notEmpty = true),
-            description = "The type of the content. Possible values are text and html")
+            tooltip = "The type of the content. Possible values are text and html")
         String bodyType,
     @NotBlank
         @TemplateProperty(
             group = "data",
             id = "sendMessageInChat.content",
             type = TemplateProperty.PropertyType.Text,
-            label = "Content",
-            description = "Enter content")
+            label = "Content")
         String content,
     @TemplateProperty(
             label = "Attachments",
@@ -64,7 +58,7 @@ public record SendMessageInChat(
                 @TemplateProperty.PropertyCondition(
                     property = "data.sendMessageInChat.bodyType",
                     equals = "HTML"),
-            description =
+            tooltip =
                 "Optional list of attachments. Each item must have an 'id', 'contentType'"
                     + " (e.g. 'application/vnd.microsoft.card.adaptive') and 'content'"
                     + " (e.g. an Adaptive Card JSON payload). Attachment IDs must match"

--- a/connectors/microsoft/teams/src/main/java/io/camunda/connector/model/request/data/SendMessageToChannel.java
+++ b/connectors/microsoft/teams/src/main/java/io/camunda/connector/model/request/data/SendMessageToChannel.java
@@ -33,14 +33,13 @@ public record SendMessageToChannel(
             group = "data",
             id = "sendMessageToChannel.groupId",
             label = "Group ID",
-            description = "The group ID for teams")
+            tooltip = "The Microsoft Teams group ID.")
         String groupId,
     @NotBlank
         @TemplateProperty(
             group = "data",
             id = "sendMessageToChannel.channelId",
-            label = "Channel ID",
-            description = "The channel ID")
+            label = "Channel ID")
         String channelId,
     @TemplateProperty(
             group = "data",
@@ -53,15 +52,14 @@ public record SendMessageToChannel(
               @TemplateProperty.DropdownPropertyChoice(value = "HTML", label = "HTML")
             },
             constraints = @TemplateProperty.PropertyConstraints(notEmpty = true),
-            description = "The type of the content. Possible values are text and html")
+            tooltip = "The type of the content. Possible values are text and html")
         String bodyType,
     @NotBlank
         @TemplateProperty(
             group = "data",
             id = "sendMessageToChannel.content",
             label = "Content",
-            type = TemplateProperty.PropertyType.Text,
-            description = "Enter content")
+            type = TemplateProperty.PropertyType.Text)
         String content,
     @TemplateDocumentProperty(
             group = "data",
@@ -78,7 +76,7 @@ public record SendMessageToChannel(
                 @TemplateProperty.PropertyCondition(
                     property = "data.sendMessageToChannel.bodyType",
                     equals = "HTML"),
-            description =
+            tooltip =
                 "Optional list of attachments. Each item must have an 'id', 'contentType'"
                     + " (e.g. 'application/vnd.microsoft.card.adaptive') and 'content'"
                     + " (e.g. an Adaptive Card JSON payload). Attachment IDs must match"

--- a/connectors/microsoft/teams/src/main/java/io/camunda/connector/model/request/data/SendMessageToChannel.java
+++ b/connectors/microsoft/teams/src/main/java/io/camunda/connector/model/request/data/SendMessageToChannel.java
@@ -29,11 +29,7 @@ import java.util.List;
     })
 public record SendMessageToChannel(
     @NotBlank
-        @TemplateProperty(
-            group = "data",
-            id = "sendMessageToChannel.groupId",
-            label = "Group ID",
-            tooltip = "The Microsoft Teams group ID.")
+        @TemplateProperty(group = "data", id = "sendMessageToChannel.groupId", label = "Group ID")
         String groupId,
     @NotBlank
         @TemplateProperty(
@@ -52,7 +48,7 @@ public record SendMessageToChannel(
               @TemplateProperty.DropdownPropertyChoice(value = "HTML", label = "HTML")
             },
             constraints = @TemplateProperty.PropertyConstraints(notEmpty = true),
-            tooltip = "The type of the content. Possible values are text and html")
+            tooltip = "Text sends the message body as plain text; HTML renders it as HTML markup.")
         String bodyType,
     @NotBlank
         @TemplateProperty(


### PR DESCRIPTION
Part of #7470. One of 8 review-sized slices of the `description` → `tooltip` migration (originally the umbrella PR #7651, split per review feedback for reviewability).

**Priority:** `tooltip` > `placeholder` > `description`. Field hints move to `tooltip=`; always-visible `description=` is kept only for value-constraints, `Note:`/`Warning:` markers, and genuinely critical guidance.

**Connectors in this slice:** microsoft-teams, microsoft o365 email-inbound, azure-blobstorage, microsoft mail, azure-open-ai (+ shared `microsoft/common`).

Generated templates are regenerated from the migrated Java `@TemplateProperty` sources; hand-authored ones (mail, azure-open-ai) edited directly. Shared auth/base classes that feed agentic-ai-owned templates (aws-base, webhook) are excluded and handled in the `element-template-generator` follow-up.